### PR TITLE
feat: auto-start the panel orchestrator on load (v0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/) and the format follows
 [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.4.0] - 2026-06-17
+
+The panel now drives itself: it auto-starts an autonomous background agent on
+your Claude subscription, so you just open ComfyUI and type.
+
+### Added
+
+- **Auto-start the panel orchestrator on load.** The pack launches
+  `npx -y comfyui-mcp --panel-orchestrator` when ComfyUI loads it — idempotent
+  (skips if the bridge port is already owned), auto-detects this ComfyUI's
+  `COMFYUI_URL`, and runs on your Claude **subscription** (no API key). The agent
+  is a background Claude Agent SDK session per tab that loads comfyui-mcp's
+  bundled skills (model expertise), so the only prerequisite is being signed in
+  to Claude (`claude` once). Opt out with `COMFYUI_MCP_NO_AUTOSPAWN=1`; override
+  the port with `COMFYUI_MCP_BRIDGE_PORT`. Requires comfyui-mcp ≥ 0.14.
+- **Lifecycle beacon.** The pack passes its PID so the orchestrator shuts down
+  when ComfyUI exits — including crashes/hard-kills — with an `atexit` teardown
+  on clean shutdown too. No orphan left holding the bridge port.
+
+### Changed
+
+- **Connection UI reflects the orchestrator model.** The settings help text and
+  header no longer tell you to wire the MCP into your interactive session with
+  `--channels` (which would steal the bridge port from the orchestrator); they
+  now describe the autonomous background agent and the one-time
+  `npx -y comfyui-mcp --panel-orchestrator` fallback.
+
 ## [0.3.0] - 2026-06-16
 
 The polished public release — now live on the [Comfy Registry](https://registry.comfy.org/nodes/comfyui-mcp-panel) and installable from ComfyUI-Manager.

--- a/__init__.py
+++ b/__init__.py
@@ -1,10 +1,33 @@
-"""ComfyUI MCP Panel — UI-only custom node pack.
+"""ComfyUI MCP Panel — sidebar driven by an autonomous background agent.
 
-Ships no Python nodes. Its sole job is to serve the sidebar panel JS
-(``web/js/comfyui-mcp-panel.js``) to the ComfyUI frontend via
-``WEB_DIRECTORY``. The panel talks to the agent backend that ships in the
-``comfyui-mcp`` npm package (run with ``COMFYUI_MCP_AGENT_POC=1``).
+Two jobs:
+
+1. Serve the sidebar panel JS (``web/js/comfyui-mcp-panel.js``) to the ComfyUI
+   frontend via ``WEB_DIRECTORY`` (this pack ships no Python nodes).
+
+2. Best-effort **auto-start the panel orchestrator** so the panel "just works":
+   open ComfyUI, type in the Agent sidebar. The orchestrator
+   (``npx -y comfyui-mcp --panel-orchestrator``) owns the loopback bridge the
+   panel connects to and drives it with a background Claude Agent SDK session
+   running on the user's Claude SUBSCRIPTION — no LLM API keys, and the user's
+   interactive Claude session stays free.
+
+Prerequisites for the agent to work: Node.js/``npx`` on PATH, and a Claude login
+(run ``claude`` once, or ``claude setup-token``). If either is missing the panel
+still loads and shows how to finish setup.
+
+Env knobs:
+- ``COMFYUI_MCP_NO_AUTOSPAWN=1`` — don't auto-start (e.g. you run the
+  orchestrator yourself).
+- ``COMFYUI_MCP_BRIDGE_PORT`` — bridge port to check/own (default 9101).
+- ``COMFYUI_URL`` — ComfyUI the agent generates against (auto-detected otherwise).
 """
+
+import atexit
+import os
+import shutil
+import socket
+import subprocess
 
 NODE_CLASS_MAPPINGS = {}
 NODE_DISPLAY_NAME_MAPPINGS = {}
@@ -13,3 +36,107 @@ NODE_DISPLAY_NAME_MAPPINGS = {}
 WEB_DIRECTORY = "./web"
 
 __all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS", "WEB_DIRECTORY"]
+
+_BRIDGE_HOST = "127.0.0.1"
+_BRIDGE_PORT = int(os.environ.get("COMFYUI_MCP_BRIDGE_PORT", "9101"))
+_orchestrator_proc = None
+
+
+def _log(msg):
+    print("[comfyui-mcp-panel] " + msg)
+
+
+def _port_in_use(host, port):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.3)
+        return sock.connect_ex((host, port)) == 0
+
+
+def _detect_comfyui_url():
+    """Best-effort: generate against THIS ComfyUI instance."""
+    if os.environ.get("COMFYUI_URL"):
+        return os.environ["COMFYUI_URL"]
+    host, port = "127.0.0.1", 8188
+    try:
+        from comfy.cli_args import args  # type: ignore
+
+        if getattr(args, "port", None):
+            port = int(args.port)
+        listen = getattr(args, "listen", None)
+        if listen and listen not in ("0.0.0.0", "::"):
+            host = listen
+    except Exception:
+        pass
+    return "http://{}:{}".format(host, port)
+
+
+def _maybe_start_orchestrator():
+    global _orchestrator_proc
+
+    if os.environ.get("COMFYUI_MCP_NO_AUTOSPAWN", "").lower() in ("1", "true", "yes"):
+        return
+
+    # Someone already owns the bridge port (a manual orchestrator, or another
+    # ComfyUI instance) — don't spawn a second one; it could never bind anyway.
+    if _port_in_use(_BRIDGE_HOST, _BRIDGE_PORT):
+        _log(
+            "bridge port {} already in use — assuming the panel orchestrator is "
+            "running.".format(_BRIDGE_PORT)
+        )
+        return
+
+    npx = shutil.which("npx") or shutil.which("npx.cmd")
+    if not npx:
+        _log(
+            "Node.js/npx not found on PATH — can't auto-start the panel agent. "
+            "Install Node, then run: npx -y comfyui-mcp --panel-orchestrator"
+        )
+        return
+
+    env = dict(os.environ)
+    env["COMFYUI_URL"] = _detect_comfyui_url()
+    # Beacon: the orchestrator watches this PID (ComfyUI) and shuts itself down
+    # when ComfyUI exits — including crashes/hard-kills where atexit never fires.
+    env["COMFYUI_MCP_PARENT_PID"] = str(os.getpid())
+    # Subscription lane: the background agent authenticates via the on-disk Claude
+    # login, never an API key.
+    env.pop("ANTHROPIC_API_KEY", None)
+
+    cmd = [npx, "-y", "comfyui-mcp", "--panel-orchestrator"]
+    kwargs = {"env": env, "stdin": subprocess.DEVNULL}
+    # Detach so a transient signal to ComfyUI doesn't kill the agent mid-turn;
+    # atexit still tears it down on a clean ComfyUI shutdown.
+    if os.name == "nt":
+        kwargs["creationflags"] = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    else:
+        kwargs["start_new_session"] = True
+
+    try:
+        _orchestrator_proc = subprocess.Popen(cmd, **kwargs)
+    except Exception as exc:  # noqa: BLE001 - surface any spawn failure to the user
+        _log(
+            "could not auto-start the panel orchestrator: {}\n"
+            "  Start it manually: npx -y comfyui-mcp --panel-orchestrator".format(exc)
+        )
+        return
+
+    _log(
+        "started the panel orchestrator (pid {}) on ws://{}:{} — the agent runs "
+        "on your Claude subscription. Sign in with `claude` if prompts fail.".format(
+            _orchestrator_proc.pid, _BRIDGE_HOST, _BRIDGE_PORT
+        )
+    )
+    atexit.register(_stop_orchestrator)
+
+
+def _stop_orchestrator():
+    global _orchestrator_proc
+    if _orchestrator_proc and _orchestrator_proc.poll() is None:
+        try:
+            _orchestrator_proc.terminate()
+        except Exception:
+            pass
+    _orchestrator_proc = None
+
+
+_maybe_start_orchestrator()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-mcp-panel"
-description = "AI agent sidebar for ComfyUI — drive your graph from a Claude Code (or any MCP client) session over the Model Context Protocol. Add, wire, move and tweak nodes live with full Ctrl+Z undo. No API keys, no extra LLM cost. Part of the comfyui-mcp project (channels mode)."
-version = "0.3.0"
+description = "AI agent sidebar for ComfyUI — an autonomous background agent drives your graph, running on your Claude subscription with no API keys. Add, wire, move and tweak nodes live with full Ctrl+Z undo, generate images, video and audio, and run your workflow. Auto-starts on load; just open ComfyUI and type. Part of the comfyui-mcp project."
+version = "0.4.0"
 license = "MIT"
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1,18 +1,19 @@
 // =============================================================================
-// ComfyUI MCP Panel — sidebar window into your own Claude Code session.
+// ComfyUI MCP Panel — sidebar driven by an autonomous background agent.
 //
 // Shipped as a UI-only custom node pack (served via WEB_DIRECTORY). The panel
-// connects to the loopback WebSocket bridge hosted by the `comfyui-mcp` MCP
-// server when it runs in channels mode:
+// connects to the loopback WebSocket bridge owned by the comfyui-mcp panel
+// orchestrator, started with:
 //
-//     npx -y comfyui-mcp --channels
+//     npx -y comfyui-mcp --panel-orchestrator
 //
-// The AGENT is the user's own Claude Code (or any MCP client) session — there
-// are NO LLM API keys anywhere in this path. Claude drives the graph through
-// the server's panel_* MCP tools; the bridge forwards each rid-correlated
-// command here, where a fixed allowlist of executors mutates the open
-// LiteGraph graph. Messages the user types below travel the other way:
-// panel → bridge → agent session (channel event / panel_inbox tool).
+// The AGENT is a background Claude Agent SDK session the orchestrator spawns
+// per tab, running on the user's Claude SUBSCRIPTION — there are NO LLM API
+// keys anywhere in this path, and the user's interactive Claude session stays
+// free. The agent drives the graph through the bridge; the bridge forwards each
+// rid-correlated command here, where a fixed allowlist of executors mutates the
+// open LiteGraph graph. Messages the user types below travel the other way:
+// panel → bridge → background agent.
 //
 // Wire protocol (mirrors node-lab's mcp/protocol.ts):
 //   inbound  { rid, cmd, ...args }  → execute → reply { rid, ok, result }
@@ -1036,10 +1037,10 @@ function buildPanel() {
   const helpDiv = document.createElement("div");
   helpDiv.className = "cmcp-help";
   helpDiv.textContent =
-    "This panel is a window into your own Claude Code session — no API keys. Add comfyui-mcp with channels mode:";
+    "This panel is driven by an autonomous background agent on your Claude subscription — no API keys. Sign in to Claude once (run `claude`), then start the panel agent:";
   const helpCmd = document.createElement("code");
   helpCmd.className = "cmcp-cmd";
-  helpCmd.textContent = "claude mcp add comfyui -- npx -y comfyui-mcp --channels";
+  helpCmd.textContent = "npx -y comfyui-mcp --panel-orchestrator";
   helpCmd.title = "Click to copy";
   helpCmd.addEventListener("click", () => {
     navigator.clipboard?.writeText(helpCmd.textContent).then(


### PR DESCRIPTION
## What

The ComfyUI MCP Panel now **drives itself**. On load, the pack auto-starts the comfyui-mcp panel orchestrator (`npx -y comfyui-mcp --panel-orchestrator`), which runs an autonomous background agent on your Claude **subscription** (no API key) and drives the sidebar. Open ComfyUI, type in the Agent panel — the only prerequisite is being signed in to Claude (`claude` once).

## Changes

- **Auto-start on load** (`__init__.py`): idempotent (skips if the bridge port is already owned), auto-detects this ComfyUI's `COMFYUI_URL`, strips `ANTHROPIC_API_KEY` (subscription lane), detaches the process, and passes its PID so the orchestrator beacon shuts it down when ComfyUI exits (crash/kill included); `atexit` teardown on clean shutdown. Opt out with `COMFYUI_MCP_NO_AUTOSPAWN=1`; override the port with `COMFYUI_MCP_BRIDGE_PORT`.
- **Connection UI fixed**: the help text/header no longer instruct `claude mcp add comfyui -- npx -y comfyui-mcp --channels` (that wires the bridge into your interactive session and steals the port the orchestrator needs). They now describe the background agent and the one-time `npx -y comfyui-mcp --panel-orchestrator` fallback.
- Registry description refreshed. **v0.4.0.** Requires comfyui-mcp >= 0.14.

Pairs with artokun/comfyui-mcp#39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)