### PR TITLE
chore(registry): rename pack id to comfyui-agent-panel, reset version to 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ComfyUI MCP Panel
 
-> ### ✅ v0.3 is live on ComfyUI-Manager & the [Comfy Registry](https://registry.comfy.org/nodes/comfyui-mcp-panel)
+> ### 📦 On ComfyUI-Manager & the [Comfy Registry](https://registry.comfy.org/nodes/comfyui-agent-panel) as `comfyui-agent-panel`
 > The polished public release — native ComfyUI design system, live activity cards for every
-> agent edit, and multi-tab support. Search **`comfyui-mcp-panel`** in ComfyUI-Manager to install,
+> agent edit, and multi-tab support. Search **`comfyui-agent-panel`** in ComfyUI-Manager to install,
 > or see the [docs](https://comfyui-mcp.artokun.io/docs/panel).
 
 **Your Claude Code session, inside ComfyUI's sidebar — it sees your graph and edits it live.**
@@ -31,7 +31,7 @@ this panel ⇄ ws://127.0.0.1:9180 ⇄ comfyui-mcp orchestrator (background, you
 
 ## Install
 
-**Via ComfyUI-Manager** (recommended): search for `comfyui-mcp-panel` and install.
+**Via ComfyUI-Manager** (recommended): search for `comfyui-agent-panel` and install.
 
 **Via git:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "comfyui-mcp-panel"
+name = "comfyui-agent-panel"
 description = "AI agent sidebar for ComfyUI — an autonomous background agent drives your graph, running on your Claude subscription with no API keys. Add, wire, move and tweak nodes live with full Ctrl+Z undo, generate images, video and audio, and run your workflow. Click Connect to start the agent. Part of the comfyui-mcp project."
-version = "0.4.1"
+version = "0.1.0"
 license = "MIT"
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees


### PR DESCRIPTION
Re-publish prep: the `comfyui-mcp-panel` slug was unlisted and is reserved, so the registry id moves to `comfyui-agent-panel` and the version resets to `0.1.0`. DisplayName and the GitHub repo are unchanged. README registry references updated. **No registry publish / GitHub release performed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)