### PR TITLE
fix(registry): MIT license table form + DisplayName 'ComfyUI Agent Panel' (v0.1.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ComfyUI MCP Panel
+# ComfyUI Agent Panel
 
 > ### 📦 On ComfyUI-Manager & the [Comfy Registry](https://registry.comfy.org/nodes/comfyui-agent-panel) as `comfyui-agent-panel`
 > The polished public release — native ComfyUI design system, live activity cards for every

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "comfyui-agent-panel"
 description = "AI agent sidebar for ComfyUI — an autonomous background agent drives your graph, running on your Claude subscription with no API keys. Add, wire, move and tweak nodes live with full Ctrl+Z undo, generate images, video and audio, and run your workflow. Click Connect to start the agent. Part of the comfyui-mcp project."
-version = "0.1.0"
-license = "MIT"
+version = "0.1.1"
+license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees
 # app.extensionManager.registerSidebarTab exists.
@@ -16,6 +16,6 @@ Documentation = "https://comfyui-mcp.artokun.io/docs"
 
 [tool.comfy]
 PublisherId = "artokun"
-DisplayName = "ComfyUI MCP Panel"
+DisplayName = "ComfyUI Agent Panel"
 Icon = "https://raw.githubusercontent.com/artokun/comfyui-mcp-panel/main/assets/icon.png"
 Banner = "https://raw.githubusercontent.com/artokun/comfyui-mcp-panel/main/assets/banner.png"


### PR DESCRIPTION
Fixes the two registry-metadata issues:
- **License** — `license = "MIT"` (bare string) is invalid for the Comfy Registry and renders as `{"license":"MIT"}`. Switched to the canonical table form `license = { file = "LICENSE" }` (the repo has an MIT LICENSE file).
- **Name** — `DisplayName` → **ComfyUI Agent Panel** (matches the `comfyui-agent-panel` slug); README H1 too.
- **Version** → 0.1.1 so the corrected metadata re-publishes.

Merging triggers the auto-publish (v0.1.1). Branched off main via worktree so it doesn't pull in rd2's in-progress work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)