### PR TITLE
Round 2: panel agent UX, orchestrator, --channels removal (v0.1.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  panel:
+    runs-on: ubuntu-latest
+    name: Lint pack (JS syntax + Python + pyproject)
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      # web/js is served LIVE via the custom_nodes junction — a single broken
+      # save throws in ComfyUI's extension loader and takes down the WHOLE
+      # frontend (no sidebar). node --check is the cheapest guard against that.
+      - name: JS syntax check (web/js)
+        shell: bash
+        run: |
+          set -e
+          shopt -s globstar nullglob
+          found=0
+          for f in web/js/**/*.js; do
+            found=1
+            echo "node --check $f"
+            node --check "$f"
+          done
+          [ "$found" = "1" ] || { echo "::error::no web/js/*.js files found"; exit 1; }
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # __init__.py must compile and (by design) only register routes at import
+      # time — no import-time subprocess. py_compile catches syntax breakage.
+      - name: Python compile check (__init__.py)
+        run: python -m py_compile __init__.py
+
+      - name: pyproject.toml is valid + has registry fields
+        run: |
+          python - <<'PY'
+          import tomllib
+          d = tomllib.load(open("pyproject.toml", "rb"))
+          proj = d.get("project", {})
+          comfy = d.get("tool", {}).get("comfy", {})
+          missing = [k for k in ("name", "version", "description", "license") if not proj.get(k)]
+          if not comfy.get("PublisherId"):
+              missing.append("tool.comfy.PublisherId")
+          assert not missing, f"pyproject missing required fields: {missing}"
+          print(f"pyproject OK: {proj['name']} {proj['version']}")
+          PY

--- a/.github/workflows/publish_action.yml
+++ b/.github/workflows/publish_action.yml
@@ -13,6 +13,50 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      # ---- Gate: never publish a broken pack to the Registry. -------------
+      # web/js is served live and a broken save crashes the whole ComfyUI
+      # frontend; these checks mirror ci.yml and run BEFORE publish. A failed
+      # step aborts the job, so the publish step below only runs if all pass.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: JS syntax check (web/js)
+        shell: bash
+        run: |
+          set -e
+          shopt -s globstar nullglob
+          found=0
+          for f in web/js/**/*.js; do
+            found=1
+            echo "node --check $f"
+            node --check "$f"
+          done
+          [ "$found" = "1" ] || { echo "::error::no web/js/*.js files found"; exit 1; }
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Python compile check (__init__.py)
+        run: python -m py_compile __init__.py
+
+      - name: pyproject.toml is valid + has registry fields
+        run: |
+          python - <<'PY'
+          import tomllib
+          d = tomllib.load(open("pyproject.toml", "rb"))
+          proj = d.get("project", {})
+          comfy = d.get("tool", {}).get("comfy", {})
+          missing = [k for k in ("name", "version", "description", "license") if not proj.get(k)]
+          if not comfy.get("PublisherId"):
+              missing.append("tool.comfy.PublisherId")
+          assert not missing, f"pyproject missing required fields: {missing}"
+          print(f"publishing {proj['name']} {proj['version']}")
+          PY
+      # --------------------------------------------------------------------
+
       - name: Publish custom node
         uses: Comfy-Org/publish-node-action@main
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ venv/
 node_modules/
 *.log
 .DS_Store
+.panel-guard/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ your Claude subscription, so you just open ComfyUI and type.
 
 ## [0.3.0] - 2026-06-16
 
-The polished public release — now live on the [Comfy Registry](https://registry.comfy.org/nodes/comfyui-mcp-panel) and installable from ComfyUI-Manager.
+The polished public release — now live on the [Comfy Registry](https://registry.comfy.org/nodes/comfyui-agent-panel) and installable from ComfyUI-Manager.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -73,33 +73,95 @@ claude mcp add comfyui -- npx -y comfyui-mcp --channels
 - **talk in your Claude terminal**: "check panel_status, then add a CheckpointLoaderSimple to my graph" — Claude uses the `panel_*` tools and the edits appear live;
 - **or type in the panel**: messages are pushed straight into your Claude Code session as channel events — Claude replies into the panel with `panel_say`. (Hosts without channel support can pull via `panel_inbox`.)
 
-## What the agent can do to your graph
+## What the agent can do
 
-| MCP tool | Effect |
+The agent drives the workflow you're viewing through a **fixed allowlist** of
+`panel_*` commands (no arbitrary JavaScript). Every graph mutation goes through
+LiteGraph's change tracking, so ComfyUI's native **Ctrl+Z** reverts an agent
+edit exactly like your own.
+
+**Read**
+
+| Tool | Effect |
 |---|---|
-| `panel_status` | Is the panel connected? |
 | `panel_get_graph` | Read the graph you're viewing — subgraphs summarized shallowly |
-| `panel_get_subgraph` | Drill into a subgraph node's inner graph |
+| `panel_get_subgraph` | Read inside a subgraph node's inner graph |
+| `panel_get_errors` | Read the last execution error + per-node validation errors |
+| `panel_list_workflows` | List open workflow tabs and which is active |
+| `panel_list_nodes` | List installed custom-node packs |
+| `panel_list_mcp` | List connected MCP servers |
+| `panel_get_content_mode` | Read the adult-content (NSFW) consent state |
+
+**Edit the graph** (all undoable with Ctrl+Z)
+
+| Tool | Effect |
+|---|---|
 | `panel_add_node` | Add a node by class_type |
 | `panel_remove_node` | Remove a node |
-| `panel_move_node` | Move a node to a new canvas position |
-| `panel_clear` | Remove every node — the whole wipe is one Ctrl+Z |
 | `panel_connect` / `panel_disconnect` | Wire / unwire slots (by name or index) |
 | `panel_set_widget` | Change a widget value (steps, cfg, prompts, …) |
-| `panel_canvas` | Fit, center on a node, pan, zoom your view |
+| `panel_move_node` | Move a node on the canvas |
+| `panel_set_node_title` | Rename a node's header title |
+| `panel_clear` | Remove every node — the whole wipe is one Ctrl+Z |
+
+**Subgraphs**
+
+| Tool | Effect |
+|---|---|
+| `panel_select_nodes` | Select nodes on the canvas (multi-selection) |
+| `panel_create_subgraph` | Group selected nodes into a subgraph ("Convert to Subgraph") |
+| `panel_enter_subgraph` | Drill into a subgraph to read/edit its inner nodes |
+| `panel_exit_subgraph` | Return to the parent / root graph |
+
+**Workflow tabs**
+
+| Tool | Effect |
+|---|---|
+| `panel_new_workflow` | Open a fresh blank workflow in a NEW tab (never wipes the current one) |
+| `panel_open_workflow` | Switch to a workflow by path / filename |
+| `panel_rename_workflow` | Rename a workflow |
+| `panel_close_workflow` | Close a tab (refuses unsaved changes unless forced) |
+| `panel_save_workflow` | Save / save-as programmatically (no dialog pops) |
+
+**Run & view**
+
+| Tool | Effect |
+|---|---|
 | `panel_run` | Queue the open workflow (same as pressing Queue Prompt) |
-| `panel_get_errors` | Read the last execution error + node validation errors |
-| `panel_save_workflow` | Save (Ctrl+S) or save-as/duplicate the open workflow |
-| `panel_say` | Post a message into this panel's chat feed |
-| `panel_inbox` | Drain messages you typed into the panel |
+| `panel_canvas` | Fit, center on a node, pan, or zoom your view |
+
+**Custom nodes — via your built-in ComfyUI Manager**
+
+| Tool | Effect |
+|---|---|
+| `panel_search_nodes` | Search installable node packs (the Manager's own source) |
+| `panel_install_node` | Queue a pack install (registry id or git URL) |
+| `panel_node_queue_status` | Check the Manager's install / update queue |
+| `panel_restart_comfyui` | Restart ComfyUI to load new nodes — panel auto-reconnects and the agent resumes |
+
+**MCP & session**
+
+| Tool | Effect |
+|---|---|
+| `panel_add_mcp` / `panel_remove_mcp` | Connect / remove an MCP server in your Claude config |
+| `panel_request_secret` | Securely collect an API token — the agent never sees the value |
+| `panel_reload` | Soft-reload the orchestrator (new code/tools) or the panel UI, then resume |
+
+**Working with you**
+
+| Tool | Effect |
+|---|---|
+| `panel_ask` | Ask you to choose between options (renders a question card, waits for your pick) |
+| `panel_set_todo` | Show a live TODO checklist in the footer tray |
+| `panel_request_adult_consent` / `panel_disable_adult_mode` | Toggle the 18+ NSFW consent gate |
 
 …plus the full comfyui-mcp tool surface (88 tools: queue, models, custom
 nodes, workflows) — the agent is the MCP client, so it has everything.
 
-The graph-mutation surface is a **fixed allowlist** — the agent cannot run
-arbitrary JavaScript in your browser. Every mutation goes through LiteGraph's
-standard change tracking, so ComfyUI's native undo reverts agent edits exactly
-like your own.
+> **Interactive (`--channels`) path:** when *your own* Claude Code session drives
+> the graph (see *Advanced* above), it uses the graph subset of these tools plus
+> `panel_status` (is the panel connected?), `panel_say` (post into the chat feed),
+> and `panel_inbox` (drain what you typed into the panel).
 
 ## Security notes
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@ Part of the **[comfyui-mcp](https://github.com/artokun/comfyui-mcp)** project �
 plugin + MCP server for ComfyUI (88 tools, 15 AI skills). Full documentation at
 **[comfyui-mcp.artokun.io/docs](https://comfyui-mcp.artokun.io/docs)**.
 
-Type "add a KSampler and wire it to my checkpoint" in the panel (or in your
-Claude terminal) and watch nodes appear on the canvas. Every edit is undoable
-with **Ctrl+Z**.
+Type "add a KSampler and wire it to my checkpoint" in the panel and watch nodes
+appear on the canvas. Every edit is undoable with **Ctrl+Z**.
 
 **No API keys. No extra LLM costs.** The agent runs on your Claude
 subscription — a background [comfyui-mcp](https://github.com/artokun/comfyui-mcp)
@@ -23,11 +22,6 @@ is just its window into your graph.
 ```
 this panel ⇄ ws://127.0.0.1:9180 ⇄ comfyui-mcp orchestrator (background, your Claude subscription) ⇄ your graph
 ```
-
-> Your normal `comfyui-mcp` MCP server (in Claude Code / Cursor / etc.) should
-> **not** use `--channels` — the orchestrator owns the bridge port. A stray
-> `--channels` session steals port 9101 and the panel will connect to it with no
-> agent ("connected" but unresponsive). See *Advanced* below.
 
 ## Install
 
@@ -60,18 +54,6 @@ your click.
 The bridge is loopback-only (`ws://127.0.0.1:9180`, set via
 `COMFYUI_MCP_BRIDGE_PORT`). To run the orchestrator yourself, set
 `COMFYUI_MCP_NO_AUTOSPAWN=1` and launch it manually, then click Connect.
-
-### Advanced: drive the graph from your own Claude Code session
-
-Prefer to use *your own* interactive session as the agent? Run the bridge in
-channels mode instead, then click Connect:
-
-```bash
-claude mcp add comfyui -- npx -y comfyui-mcp --channels
-```
-
-- **talk in your Claude terminal**: "check panel_status, then add a CheckpointLoaderSimple to my graph" — Claude uses the `panel_*` tools and the edits appear live;
-- **or type in the panel**: messages are pushed straight into your Claude Code session as channel events — Claude replies into the panel with `panel_say`. (Hosts without channel support can pull via `panel_inbox`.)
 
 ## What the agent can do
 
@@ -157,11 +139,6 @@ edit exactly like your own.
 
 …plus the full comfyui-mcp tool surface (88 tools: queue, models, custom
 nodes, workflows) — the agent is the MCP client, so it has everything.
-
-> **Interactive (`--channels`) path:** when *your own* Claude Code session drives
-> the graph (see *Advanced* above), it uses the graph subset of these tools plus
-> `panel_status` (is the panel connected?), `panel_say` (post into the chat feed),
-> and `panel_inbox` (drain what you typed into the panel).
 
 ## Security notes
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ComfyUI MCP Panel
+# ComfyUI Agent Panel
 
 > ### 📦 On ComfyUI-Manager & the [Comfy Registry](https://registry.comfy.org/nodes/comfyui-agent-panel) as `comfyui-agent-panel`
 > The polished public release — native ComfyUI design system, live activity cards for every

--- a/__init__.py
+++ b/__init__.py
@@ -18,8 +18,7 @@ time. Prerequisites for the agent to work: Node.js/``npx`` on PATH, and a Claude
 login (run ``claude`` once, or ``claude setup-token``).
 
 Env knobs:
-- ``COMFYUI_MCP_BRIDGE_PORT`` — panel bridge port to check/own (default 9180;
-  distinct from the legacy ``comfyui-mcp --channels`` bridge on 9101).
+- ``COMFYUI_MCP_BRIDGE_PORT`` — panel bridge port to check/own (default 9180).
 - ``COMFYUI_URL`` — ComfyUI the agent generates against (auto-detected otherwise).
 - ``COMFYUI_MCP_NO_AUTOSPAWN=1`` — the Connect route won't spawn; it only reports
   status (use when you run the orchestrator yourself).
@@ -261,14 +260,12 @@ def _start_orchestrator():
         orphan = _lock_parent_is_gone(lock)
         if not (orphan and not _no_autospawn()):
             if not lock:
-                # Port held but NO orchestrator lockfile — a foreign process
-                # (often a `comfyui-mcp --channels` server from a Claude/Cursor
-                # session). Do NOT claim "already running": the panel would attach
-                # to a non-agent ("connected but dead"). Surface it instead.
+                # Port held but NO orchestrator lockfile — a foreign process is
+                # squatting it. Do NOT claim "already running": the panel would
+                # attach to a non-agent ("connected but dead"). Surface it instead.
                 return False, (
                     "the panel bridge port {} is held by another process that isn't a panel "
-                    "orchestrator (often a 'comfyui-mcp --channels' server in a Claude/Cursor "
-                    "session). Close it, or set COMFYUI_MCP_BRIDGE_PORT to a free port.".format(_BRIDGE_PORT)
+                    "orchestrator. Close it, or set COMFYUI_MCP_BRIDGE_PORT to a free port.".format(_BRIDGE_PORT)
                 )
             if parent and parent != os.getpid() and not orphan:
                 return False, (
@@ -319,9 +316,7 @@ def _start_orchestrator():
     _parent_started_at = _current_process_started_at_ms()
     if _parent_started_at is not None:
         env["COMFYUI_MCP_PARENT_STARTED_AT_MS"] = str(_parent_started_at)
-    # Pin the orchestrator to the PANEL bridge port (9180 by default) — distinct
-    # from the legacy `comfyui-mcp --channels` bridge (9101), so a stray
-    # --channels server in any Claude/Cursor session can't squat the panel port.
+    # Pin the orchestrator to the PANEL bridge port (9180 by default).
     env["COMFYUI_MCP_BRIDGE_PORT"] = str(_BRIDGE_PORT)
     # Subscription lane: the background agent authenticates via the on-disk Claude
     # login, never an API key.

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
-"""ComfyUI MCP Panel — sidebar driven by an autonomous background agent.
+"""ComfyUI Agent Panel — sidebar driven by an autonomous background agent.
 
 Two jobs:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "AI agent sidebar for ComfyUI — an autonomous background agent drives your graph, running on your Claude subscription with no API keys. Add, wire, move and tweak nodes live with full Ctrl+Z undo, generate images, video and audio, and run your workflow. Click Connect to start the agent. Part of the comfyui-mcp project."
-version = "0.1.1"
+version = "0.1.2"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [project]
 name = "comfyui-agent-panel"
 description = "AI agent sidebar for ComfyUI — an autonomous background agent drives your graph, running on your Claude subscription with no API keys. Add, wire, move and tweak nodes live with full Ctrl+Z undo, generate images, video and audio, and run your workflow. Click Connect to start the agent. Part of the comfyui-mcp project."
-version = "0.1.0"
-license = "MIT"
+version = "0.1.1"
+license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees
 # app.extensionManager.registerSidebarTab exists.
@@ -16,6 +16,6 @@ Documentation = "https://comfyui-mcp.artokun.io/docs"
 
 [tool.comfy]
 PublisherId = "artokun"
-DisplayName = "ComfyUI MCP Panel"
+DisplayName = "ComfyUI Agent Panel"
 Icon = "https://raw.githubusercontent.com/artokun/comfyui-mcp-panel/main/assets/icon.png"
 Banner = "https://raw.githubusercontent.com/artokun/comfyui-mcp-panel/main/assets/banner.png"

--- a/scripts/panel-guard.mjs
+++ b/scripts/panel-guard.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+// panel-guard.mjs — dev-time guardian for the live-served panel bundle.
+//
+// web/js/*.js is served LIVE to ComfyUI through the custom_nodes junction, so a
+// single syntactically-broken save (a stray ``` fence, a bad optional-chaining
+// assignment, a half-finished edit) doesn't just break this panel — it throws
+// in ComfyUI's extension loader and blacks out the ENTIRE frontend (no sidebar).
+//
+// This watcher keeps a ring of the last-known-good version of every web/js file
+// and INSTANTLY restores it whenever a save fails `node --check`, so a fumbled
+// edit can never take down ComfyUI. Run it in a spare terminal while editing:
+//
+//     node scripts/panel-guard.mjs
+//
+// It only ever writes a file back to a version that previously parsed — it never
+// invents content. Snapshots live in .panel-guard/ (gitignored).
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import crypto from "node:crypto";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// Defaults to the repo root; PANEL_GUARD_ROOT overrides it (used by the test).
+const ROOT = process.env.PANEL_GUARD_ROOT
+  ? path.resolve(process.env.PANEL_GUARD_ROOT)
+  : path.resolve(__dirname, "..");
+const WATCH_DIR = path.join(ROOT, "web", "js");
+const SNAP_DIR = path.join(ROOT, ".panel-guard");
+const KEEP = 10; // history depth per file
+const DEBOUNCE_MS = 300;
+
+const lastGood = new Map(); // absFile -> { content, hash }
+const timers = new Map(); // absFile -> timeout
+
+fs.mkdirSync(SNAP_DIR, { recursive: true });
+
+const rel = (abs) => path.relative(WATCH_DIR, abs).split(path.sep).join("/");
+const snapKey = (abs) => rel(abs).replace(/[\\/]/g, "__");
+const sha = (s) => crypto.createHash("sha1").update(s).digest("hex").slice(0, 12);
+const stamp = () => new Date().toISOString().replace(/[:.]/g, "-");
+const log = (...a) => console.log(`[panel-guard ${new Date().toLocaleTimeString()}]`, ...a);
+
+function isValidJs(abs) {
+  const r = spawnSync(process.execPath, ["--check", abs], { encoding: "utf8" });
+  return { ok: r.status === 0, err: (r.stderr || "").trim() };
+}
+
+function listJs(dir) {
+  const out = [];
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...listJs(p));
+    else if (e.isFile() && e.name.endsWith(".js")) out.push(p);
+  }
+  return out;
+}
+
+function snapshotsFor(abs) {
+  const prefix = `${snapKey(abs)}.`;
+  return fs
+    .readdirSync(SNAP_DIR)
+    .filter((f) => f.startsWith(prefix))
+    .sort(); // ISO timestamps sort chronologically
+}
+
+function saveSnapshot(abs, content) {
+  const h = sha(content);
+  const prev = lastGood.get(abs);
+  if (prev && prev.hash === h) return; // unchanged — skip (also breaks restore loop)
+  lastGood.set(abs, { content, hash: h });
+  try {
+    fs.writeFileSync(path.join(SNAP_DIR, `${snapKey(abs)}.${stamp()}.${h}.js`), content);
+    const mine = snapshotsFor(abs);
+    for (const f of mine.slice(0, Math.max(0, mine.length - KEEP))) {
+      try {
+        fs.unlinkSync(path.join(SNAP_DIR, f));
+      } catch {}
+    }
+    log(`✓ snapshot ${rel(abs)} (${h})`);
+  } catch (e) {
+    log("snapshot write failed:", e.message);
+  }
+}
+
+function loadLatestSnapshot(abs) {
+  const mine = snapshotsFor(abs);
+  if (!mine.length) return null;
+  try {
+    return fs.readFileSync(path.join(SNAP_DIR, mine[mine.length - 1]), "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function check(abs) {
+  if (!fs.existsSync(abs)) return;
+  const { ok, err } = isValidJs(abs);
+  if (ok) {
+    saveSnapshot(abs, fs.readFileSync(abs, "utf8"));
+    return;
+  }
+  const good = lastGood.get(abs)?.content ?? loadLatestSnapshot(abs);
+  log(`✗ BROKEN save: ${rel(abs)}`);
+  if (err) log("   " + err.split("\n").find((l) => l.trim()) || err);
+  if (good == null) {
+    log("   ⚠ no known-good snapshot yet — cannot auto-restore. FIX THIS FILE manually.");
+    return;
+  }
+  try {
+    fs.writeFileSync(abs, good);
+    log(`   ↩ restored last-good ${rel(abs)} — ComfyUI frontend protected. Re-apply your edit cleanly.`);
+  } catch (e) {
+    log("   restore failed:", e.message);
+  }
+}
+
+function schedule(abs) {
+  clearTimeout(timers.get(abs));
+  timers.set(abs, setTimeout(() => check(abs), DEBOUNCE_MS));
+}
+
+if (!fs.existsSync(WATCH_DIR)) {
+  console.error(`panel-guard: ${WATCH_DIR} not found — run from the repo root.`);
+  process.exit(1);
+}
+
+log(`watching web/js (snapshots → .panel-guard/, keep ${KEEP} per file)`);
+for (const abs of listJs(WATCH_DIR)) {
+  const { ok } = isValidJs(abs);
+  if (ok) {
+    saveSnapshot(abs, fs.readFileSync(abs, "utf8"));
+  } else {
+    const good = loadLatestSnapshot(abs);
+    if (good != null) {
+      fs.writeFileSync(abs, good);
+      log(`↩ ${rel(abs)} was broken at startup — restored from snapshot`);
+    } else {
+      log(`⚠ ${rel(abs)} is broken and has no snapshot — fix it manually`);
+    }
+  }
+}
+
+fs.watch(WATCH_DIR, { recursive: true }, (_evt, name) => {
+  if (!name || !String(name).endsWith(".js")) return;
+  schedule(path.join(WATCH_DIR, String(name)));
+});
+
+log("ready — edit away; broken saves auto-revert.");

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1039,7 +1039,7 @@ const GRAPH_TOOL_EXECUTORS = {
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 15000;
 
-function createBridgeClient({ onStatus, onSay, onLog, onCommand, onAsk, onSecret, onReload, onTodo, onDownloads, onAgentStatus, onSession, onModels, onAck, onTurn, getResume }) {
+function createBridgeClient({ onStatus, onSay, onLog, onCommand, onAsk, onSecret, onReload, onTodo, onDownloads, onThinking, onAgentStatus, onSession, onModels, onAck, onTurn, getResume }) {
   let sock = null;
   let url = loadBridgeUrl();
   let closed = false;
@@ -1200,6 +1200,10 @@ function createBridgeClient({ onStatus, onSay, onLog, onCommand, onAsk, onSecret
       // from the download tool's temp progress file and/or the Manager queue).
       if (msg && msg.type === "download_progress" && Array.isArray(msg.downloads)) {
         onDownloads?.(msg.downloads);
+      }
+      // Live extended-thinking token count → "thinking… (N)" indicator.
+      if (msg && msg.type === "thinking" && typeof msg.tokens === "number") {
+        onThinking?.(msg.tokens);
       }
       // "echo" frames are ignored — we render the user bubble locally on send.
     });
@@ -2822,6 +2826,7 @@ function buildPanel() {
   let workWordTimer = null;
   let workWordIdx = 0;
   let thinkingSafety = null;
+  let thinkingTokens = 0;
   // Backstop: if no activity (say/command/turn signal) for this long, auto-hide
   // — covers a missed turn:done (e.g. an older orchestrator, or an errored turn)
   // so the indicator never sticks forever.
@@ -2832,10 +2837,24 @@ function buildPanel() {
     thinkingSafety = setTimeout(hideThinking, THINKING_SAFETY_MS);
   }
 
+  function fmtThinkTokens(n) {
+    return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : `${n}`;
+  }
   function cycleWord() {
     if (!thinkingLabel) return;
-    thinkingLabel.textContent = `${WORK_WORDS[workWordIdx % WORK_WORDS.length]}… (Ctrl+C to stop)`;
+    const base =
+      thinkingTokens > 0
+        ? `Thinking… (${fmtThinkTokens(thinkingTokens)} tokens)`
+        : `${WORK_WORDS[workWordIdx % WORK_WORDS.length]}…`;
+    thinkingLabel.textContent = `${base} (Ctrl+C to stop)`;
     workWordIdx += 1;
+  }
+  // Live extended-thinking token meter (from the orchestrator's thinking frame).
+  function setThinkingTokens(n) {
+    thinkingTokens = Number(n) || 0;
+    if (!thinkingEl) showThinking();
+    cycleWord();
+    armSafety();
   }
 
   function hideThinking() {
@@ -2852,6 +2871,7 @@ function buildPanel() {
       thinkingEl = null;
       thinkingLabel = null;
     }
+    thinkingTokens = 0; // reset so the next turn doesn't show a stale count
   }
 
   function showThinking() {
@@ -2948,6 +2968,10 @@ function buildPanel() {
     // Orchestrator pushed live download progress → render rows in the tray.
     onDownloads(list) {
       renderDownloads(list);
+    },
+    // Live extended-thinking token count → update the working indicator.
+    onThinking(tokens) {
+      setThinkingTokens(tokens);
     },
     // The agent called panel_request_secret — collect a token securely.
     onSecret(msg) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3106,16 +3106,25 @@ function buildPanel() {
   // After a reboot we triggered, respawn the orchestrator (it died with ComfyUI)
   // so the bridge can reconnect; onStatus(connected) then resumes the agent.
   function onComfyReconnecting() {
-    if (ssGet(REBOOT_KEY) || lsGet(AUTOCONNECT_KEY)) appendSystem("ComfyUI is restarting…");
+    // Only flag a restart if our bridge actually went down — a benign ComfyUI WS
+    // blip (asset view / image check) shouldn't print a false "restarting" alarm.
+    if ((ssGet(REBOOT_KEY) || lsGet(AUTOCONNECT_KEY)) && !client.isConnected()) {
+      appendSystem("ComfyUI is restarting…");
+    }
   }
   function onComfyReconnected() {
     // After ComfyUI comes back (backend-only reboot — the page didn't reload),
     // the orchestrator died with it. Respawn + reconnect if the agent was in use:
     // either a restart WE triggered (REBOOT_KEY) or sticky auto-connect.
     if (!ssGet(REBOOT_KEY) && !lsGet(AUTOCONNECT_KEY)) return;
+    // ComfyUI fires "reconnected" for BENIGN WS blips too — viewing assets,
+    // checking an image's status, a tab refocus — and those do NOT kill the
+    // orchestrator. If OUR bridge is still up, the agent is alive and well, so
+    // do NOT bounce a live session (that was the spurious "you reconnected"). A
+    // real ComfyUI restart drops the bridge (the orchestrator dies with it, and
+    // the bridge's own retry can't respawn it) — only then do we respawn here.
+    if (client.isConnected()) return;
     appendSystem("ComfyUI is back — reconnecting the agent…");
-    // Respawn the orchestrator on demand and reopen the bridge (same path as the
-    // Connect button). When it connects, onStatus sends the resume nudge.
     connectAgent();
   }
   try {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1,5 +1,5 @@
 // =============================================================================
-// ComfyUI MCP Panel — sidebar driven by an autonomous background agent.
+// ComfyUI Agent Panel — sidebar driven by an autonomous background agent.
 //
 // Shipped as a UI-only custom node pack (served via WEB_DIRECTORY). The panel
 // connects to the loopback WebSocket bridge owned by the comfyui-mcp panel
@@ -125,6 +125,11 @@ const SOFT_RELOAD_KEY = "comfyui-mcp.panel.softReloadResume";
 // resumed session to continue where it left off. The REBOOT/SOFT_RELOAD cases
 // (deliberate, agent-known) are handled first and clear this so we don't double-nudge.
 const MID_TASK_KEY = "comfyui-mcp.panel.midTaskResume";
+// Wall-clock (ms) of the last bridge drop — module-scoped so it survives panel
+// remounts. A FAST reconnect (panel swap / WS blip; orchestrator alive) vs a
+// SLOW one (real ComfyUI restart; orchestrator died + respawned) is how we tell
+// a spurious bounce from a real one — only the slow case fires the resume nudge.
+let lastBridgeDownAt = 0;
 // One-shot flag set right before a frontend (page) reload WE trigger, so that
 // after the reload we re-activate our own sidebar tab. ComfyUI restores the
 // last active tab BEFORE our extension re-registers it, so it can't reopen ours
@@ -1212,6 +1217,7 @@ function createBridgeClient({ onStatus, onSay, onLog, onCommand, onAsk, onSecret
       sock = null;
       handshakeDone = false;
       clearHandshake();
+      lastBridgeDownAt = Date.now(); // for the fast-vs-slow reconnect heuristic
       if (!closed) {
         onStatus("disconnected");
         scheduleReconnect();
@@ -3900,7 +3906,7 @@ if (!app || typeof app.registerExtension !== "function") {
         title: "Agent",
         // ComfyUI ships PrimeIcons; `pi-comments` is the closest "chat" glyph.
         icon: "pi pi-comments",
-        tooltip: "ComfyUI MCP Panel — your Claude session's window into this graph",
+        tooltip: "ComfyUI Agent Panel — your Claude session's window into this graph",
         type: "custom",
         render: (container) => {
           if (mounted) mounted.destroy();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1839,8 +1839,55 @@ function describeCommand(cmd, msg, reply) {
 // GitHub-flavored markdown, single-newline line breaks.
 marked.setOptions({ gfm: true, breaks: true });
 
+// CRITICAL: force every rendered link to open OUT of the panel frame. In the
+// ComfyUI desktop (Electron) app a plain in-frame navigation hijacks the WHOLE
+// window — no back button, hard-reload to escape. Tagging anchors target=_blank
+// + rel makes them open in a new context (the desktop routes that to the default
+// browser); a delegated click handler (wireExternalLinks) is the belt-and-braces
+// that intercepts the click and opens externally even if _blank is ignored.
+DOMPurify.addHook("afterSanitizeAttributes", (node) => {
+  if (node.tagName === "A") {
+    node.setAttribute("target", "_blank");
+    node.setAttribute("rel", "noopener noreferrer nofollow");
+  }
+});
+
+/** Open a URL outside the panel frame — never navigate the app/webview itself.
+ *  Prefers a desktop external-open bridge if present, else a new browser tab. */
+function openExternalUrl(href) {
+  if (!href) return;
+  try {
+    const ext =
+      window.electronAPI?.openExternal ||
+      window.comfyAPI?.electron?.openExternal ||
+      window.api?.openExternal;
+    if (typeof ext === "function") {
+      ext(href);
+      return;
+    }
+  } catch {
+    // fall through to window.open
+  }
+  window.open(href, "_blank", "noopener,noreferrer");
+}
+
+/** Delegate link clicks on a container so http(s)/mailto links open externally
+ *  instead of navigating the panel frame (which hijacks the desktop app). */
+function wireExternalLinks(container) {
+  container.addEventListener("click", (ev) => {
+    const a = ev.target?.closest?.("a[href]");
+    if (!a || !container.contains(a)) return;
+    const href = a.getAttribute("href") || "";
+    if (!href || href.startsWith("#")) return; // in-document anchors: leave alone
+    ev.preventDefault();
+    ev.stopPropagation();
+    openExternalUrl(a.href || href); // a.href resolves relative URLs
+  });
+}
+
 /** Render agent markdown (full GFM) via marked, sanitized with DOMPurify so
- *  agent output can never inject script/handlers into the panel. */
+ *  agent output can never inject script/handlers into the panel. Links are
+ *  forced external via the DOMPurify hook above + wireExternalLinks on the feed. */
 function renderRichText(el, text) {
   el.innerHTML = DOMPurify.sanitize(marked.parse(String(text)));
 }
@@ -1853,6 +1900,9 @@ function buildPanel() {
   // Expose this panel's root so canvas "fit" can measure how much of the canvas
   // the open panel occludes and frame the graph in the visible area.
   activePanelRoot = root;
+  // Any link clicked anywhere in the panel opens externally — never let it
+  // navigate (and hijack) the ComfyUI desktop webview.
+  wireExternalLinks(root);
 
   // ---- Header: title + status dot ----
   const header = document.createElement("div");
@@ -2135,6 +2185,12 @@ function buildPanel() {
   function renderTodo(items) {
     todoItems = Array.isArray(items) ? items : [];
     renderTray();
+    // Persist the plan ON the active thread so it survives a reload / panel
+    // remount (the tray is otherwise rebuilt empty) and follows thread switches.
+    if (thread) {
+      thread.todos = todoItems;
+      persistThreads();
+    }
   }
   function renderDownloads(downloads) {
     downloadItems = (Array.isArray(downloads) ? downloads : []).filter(Boolean);
@@ -2905,6 +2961,7 @@ function buildPanel() {
     ssSet(CTX_KEY, null);
     if (typeof resetAttachments === "function") resetAttachments();
     resetFeed();
+    renderTodo([]); // fresh chat → empty plan tray
     setContextPct(0);
     ctxLabel.textContent = "—";
     // Tell the orchestrator to forget this tab's session so the NEXT message
@@ -2921,6 +2978,7 @@ function buildPanel() {
       else if (m.role === "agent") paintAgent(m.text);
       else if (m.role === "card") paintCard(m);
     }
+    renderTodo(t.todos || []); // restore this thread's plan into the tray
     // Resume this conversation's agent session (or start fresh if it has none),
     // so typing continues THIS chat rather than whatever was last active.
     ssSet(SESSION_KEY, t.sessionId || null);
@@ -4133,6 +4191,7 @@ function buildPanel() {
         else if (m.role === "agent") paintAgent(m.text);
         else if (m.role === "card") paintCard(m);
       }
+      renderTodo(t.todos || []); // restore this thread's plan into the tray
     } catch {
       // Corrupt/absent state — start clean.
     }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1044,7 +1044,7 @@ const GRAPH_TOOL_EXECUTORS = {
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 15000;
 
-function createBridgeClient({ onStatus, onSay, onLog, onCommand, onAsk, onSecret, onReload, onTodo, onDownloads, onThinking, onAgentStatus, onSession, onModels, onAck, onTurn, getResume }) {
+function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk, onSecret, onReload, onTodo, onDownloads, onThinking, onAgentStatus, onSession, onModels, onAck, onTurn, getResume }) {
   let sock = null;
   let url = loadBridgeUrl();
   let closed = false;
@@ -1172,7 +1172,13 @@ function createBridgeClient({ onStatus, onSay, onLog, onCommand, onAsk, onSecret
         return;
       }
       if (msg && msg.type === "say" && typeof msg.text === "string") {
-        onSay(msg.text);
+        // `id` reconciles this committed reply with its live streaming preview.
+        onSay(msg.text, { id: msg.id, streamed: !!msg.streamed });
+      }
+      // Live streaming deltas: incremental thinking / reply text before the final
+      // `say` commits. phase: "think" | "text" | "end".
+      if (msg && msg.type === "stream" && typeof msg.id === "string") {
+        onStream?.(msg);
       }
       // Optional agent-side status (context window fill, model name).
       if (msg && msg.type === "agent_status") {
@@ -1631,6 +1637,42 @@ const PANEL_CSS = `
   0%, 60%, 100% { opacity: 0.25; transform: translateY(0); }
   30% { opacity: 1; transform: translateY(-3px); }
 }
+
+/* ---- live streaming: thinking accordion + reply preview ---- */
+/* The "see thinking" disclosure above a streaming reply. Open + scrollable while
+   the model reasons; collapses to a discreet one-line summary once text starts. */
+.cmcp-think {
+  margin: 0 0 0.5rem; border: 1px solid var(--p-content-border-color, #3f3f46);
+  border-radius: var(--p-border-radius-md, 6px);
+  background: var(--p-surface-900, #18181b);
+}
+.cmcp-think > summary {
+  list-style: none; cursor: pointer; user-select: none;
+  padding: 0.3125rem 0.5rem; font-size: 0.6875rem; font-weight: 600;
+  color: var(--p-text-muted-color, #a1a1aa);
+  display: flex; align-items: center; gap: 0.375rem;
+}
+.cmcp-think > summary::-webkit-details-marker { display: none; }
+.cmcp-think > summary::before {
+  content: "\\25b8"; font-size: 0.625rem; transition: transform 0.15s;
+}
+.cmcp-think[open] > summary::before { transform: rotate(90deg); }
+.cmcp-think-body {
+  max-height: 11rem; overflow-y: auto;
+  padding: 0 0.5rem 0.4375rem 0.875rem;
+  font-size: 0.6875rem; line-height: 1.45;
+  color: var(--p-text-muted-color, #8a8a93);
+  white-space: pre-wrap; word-break: break-word;
+  font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+}
+/* While open & streaming, a soft pulse on the summary so it reads as "live". */
+.cmcp-think[open] > summary { color: var(--p-primary-color, #60a5fa); }
+/* Blinking caret on the reply preview while it streams in. */
+.cmcp-reply.streaming-cursor::after {
+  content: "\\258b"; margin-left: 1px; color: var(--p-primary-color, #60a5fa);
+  animation: cmcp-caret 1s step-end infinite;
+}
+@keyframes cmcp-caret { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }
 
 .cmcp-composer {
   position: relative; margin: 0.625rem 0.75rem 0.75rem; flex: none;
@@ -2688,6 +2730,94 @@ function buildPanel() {
     record({ role: "agent", text });
   }
 
+  // ---- live streaming (thinking + reply) ----
+  // A streaming bubble is keyed by the SDK message id so deltas stay coherent and
+  // the final committed `say` (same id) REPLACES the preview rather than adding a
+  // duplicate. Thinking text streams into a "see thinking" accordion that's open
+  // (and scrollable) while the model reasons, then collapses the instant reply
+  // text begins. Reply text streams as plain text with a caret; on commit it's
+  // re-rendered as full markdown.
+  const streamBubbles = new Map(); // id -> { el, thinkWrap, thinkBody, thinkSummary, replyEl, thinkText, replyText }
+
+  function ensureStreamBubble(id) {
+    let s = streamBubbles.get(id);
+    if (s) return s;
+    clearEmpty();
+    const el = document.createElement("div");
+    el.className = "cmcp-bubble agent streaming";
+    const replyEl = document.createElement("div");
+    replyEl.className = "cmcp-reply";
+    el.appendChild(replyEl);
+    log.appendChild(el);
+    s = { el, thinkWrap: null, thinkBody: null, thinkSummary: null, replyEl, thinkText: "", replyText: "" };
+    streamBubbles.set(id, s);
+    bumpThinking(); // keep the working indicator pinned below the new bubble
+    return s;
+  }
+
+  function ensureThinkArea(s) {
+    if (s.thinkWrap) return s;
+    const det = document.createElement("details");
+    det.className = "cmcp-think";
+    det.open = true;
+    const sum = document.createElement("summary");
+    sum.textContent = "Thinking…";
+    const body = document.createElement("div");
+    body.className = "cmcp-think-body";
+    det.append(sum, body);
+    s.el.insertBefore(det, s.replyEl); // thinking sits above the reply
+    s.thinkWrap = det;
+    s.thinkBody = body;
+    s.thinkSummary = sum;
+    return s;
+  }
+
+  function collapseThinking(s, label) {
+    if (s.thinkWrap) {
+      s.thinkWrap.open = false;
+      if (s.thinkSummary) s.thinkSummary.textContent = label;
+    }
+  }
+
+  function onStreamDelta(msg) {
+    const { phase, id } = msg;
+    const delta = typeof msg.delta === "string" ? msg.delta : "";
+    if (phase === "think") {
+      const s = ensureStreamBubble(id);
+      ensureThinkArea(s);
+      s.thinkText += delta;
+      s.thinkBody.textContent = s.thinkText;
+      s.thinkBody.scrollTop = s.thinkBody.scrollHeight; // follow the newest reasoning
+      scrollLog();
+    } else if (phase === "text") {
+      const s = ensureStreamBubble(id);
+      collapseThinking(s, "See thinking"); // reply began → tuck the reasoning away
+      s.replyText += delta;
+      s.replyEl.textContent = s.replyText; // plain while streaming; markdown on commit
+      s.replyEl.classList.add("streaming-cursor");
+      scrollLog();
+    } else if (phase === "end") {
+      const s = streamBubbles.get(id);
+      if (s) s.replyEl.classList.remove("streaming-cursor");
+    }
+  }
+
+  /** Reconcile a committed `say` with its live preview: replace the streamed text
+   *  with final markdown, collapse thinking, record to history. Returns false if
+   *  there's no matching stream bubble (caller falls back to a normal bubble). */
+  function commitStream(id, text) {
+    const s = streamBubbles.get(id);
+    if (!s) return false;
+    s.replyEl.classList.remove("streaming-cursor");
+    collapseThinking(s, "See thinking");
+    renderRichText(s.replyEl, text);
+    s.el.classList.remove("streaming");
+    streamBubbles.delete(id);
+    record({ role: "agent", text }); // thinking is ephemeral — only the reply persists
+    scrollLog();
+    return true;
+  }
+
   function appendSystem(text) {
     // System notices are transient — painted, never recorded.
     const b = document.createElement("div");
@@ -2706,6 +2836,7 @@ function buildPanel() {
 
   function resetFeed() {
     for (const el of [...log.children]) el.remove();
+    streamBubbles.clear(); // drop any in-flight streaming previews (DOM is gone)
     log.appendChild(empty);
   }
 
@@ -2953,12 +3084,17 @@ function buildPanel() {
       // orchestrator sends only AFTER it has armed hello.resume — so the nudge
       // can't out-race the session resume.)
     },
-    onSay(text) {
-      // Append the agent's words but KEEP the working indicator — the turn isn't
-      // over until turn:done. (A turn often emits progress text, then keeps
-      // working silently.) bumpThinking pins the indicator below the new message.
-      appendAgent(text);
+    onSay(text, meta) {
+      // If this reply was streamed, commit it into its live preview bubble (same
+      // message id) instead of painting a duplicate. Otherwise paint normally.
+      // Either way KEEP the working indicator — the turn isn't over until
+      // turn:done (a turn often emits progress text, then works on silently).
+      if (!(meta && meta.id && commitStream(meta.id, text))) appendAgent(text);
       bumpThinking();
+    },
+    // Live streaming deltas (thinking + reply text) before the committed say.
+    onStream(msg) {
+      onStreamDelta(msg);
     },
     // The agent called panel_ask — render a question card and resolve with the
     // user's pick. Keep the working indicator pinned below it while we wait.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1559,7 +1559,16 @@ const PANEL_CSS = `
 .cmcp-bubble.agent {
   align-self: stretch; max-width: 100%;
   padding: 0; background: none; border: none; border-radius: 0;
+  /* Rendered markdown is real block elements — collapse the source newlines
+     marked emits between tags (the base .cmcp-bubble pre-wrap would otherwise
+     render every one as a blank line, ballooning the vertical spacing). Block
+     margins below handle the rhythm. */
+  white-space: normal;
 }
+/* While a reply is still STREAMING it's plain text (not yet markdown), so it
+   needs pre-wrap to honor its newlines; the commit drops the .streaming class
+   and it reverts to normal markdown flow. */
+.cmcp-bubble.agent.streaming .cmcp-reply { white-space: pre-wrap; }
 .cmcp-bubble.agent code, .cmcp-bubble.user code {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.75rem;
   background: var(--p-form-field-background, #09090b);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -405,6 +405,26 @@ function getGraphCtx() {
   return { app, graph, rootGraph: app.graph, canvas: app.canvas, LG };
 }
 
+/** Reach ComfyUI's subgraph widget-promotion store. The state that exposes an
+ *  inner subgraph widget on the parent SubgraphNode lives in a Pinia store with
+ *  id "promotion" (methods: promote/demote/isPromoted). Pinia attaches itself as
+ *  `$pinia` on the Vue app's globalProperties; the Vue app instance hangs off its
+ *  mount element (#vue-app) as `__vue_app__`; `_s` is pinia's id→store map. */
+function getPromotionStore() {
+  let pinia = null;
+  try {
+    const el = document.getElementById("vue-app") || document.querySelector("[id*='vue']");
+    pinia = el?.__vue_app__?.config?.globalProperties?.$pinia;
+  } catch {
+    // fall through
+  }
+  const store = pinia?._s?.get?.("promotion");
+  if (!store || typeof store.promote !== "function") {
+    throw new Error("widget-promotion unavailable on this ComfyUI frontend (no 'promotion' store)");
+  }
+  return store;
+}
+
 /** Where is the user looking right now — root graph or inside a subgraph? */
 function describeActiveGraph(graph) {
   if (!app?.graph || graph === app.graph) return { scope: "root" };
@@ -965,6 +985,56 @@ const GRAPH_TOOL_EXECUTORS = {
     canvas.setGraph(graph.rootGraph ?? rootGraph);
     canvas.setDirty?.(true, true);
     return { viewing: describeActiveGraph(getGraphCtx().graph) };
+  },
+
+  // Promote (or demote) an INNER subgraph widget so it appears on the PARENT
+  // SubgraphNode — the thing you couldn't do before. Must be called while INSIDE
+  // the subgraph (graph_enter_subgraph first): node_id is an inner node, widget
+  // is one of its widget names. Mirrors the "Promote Widget" context-menu action
+  // via the frontend's promotion store. Pass demote:true to un-promote.
+  graph_promote_widget({ node_id, widget, demote }) {
+    const { graph, canvas, rootGraph } = getGraphCtx();
+    if (graph === rootGraph) {
+      throw new Error(
+        "Enter the subgraph first (graph_enter_subgraph) — promotion exposes an INNER widget on the parent node.",
+      );
+    }
+    const node = resolveNode(graph, node_id);
+    const widgets = node.widgets ?? [];
+    const w = widgets.find((x) => x && x.name === widget);
+    if (!w) {
+      const names = widgets.map((x) => x?.name).filter(Boolean);
+      throw new Error(
+        `Node ${node.id} (${node.type}) has no widget "${widget}". Available: ${names.join(", ") || "(none)"}`,
+      );
+    }
+    // The parent SubgraphNode instance(s) embedding this subgraph (root-level
+    // search, same as describeActiveGraph). The widget is exposed on these.
+    const parents = (rootGraph._nodes ?? []).filter((n) => n.subgraph === graph);
+    if (!parents.length) {
+      throw new Error("Could not locate the parent subgraph node for the open subgraph.");
+    }
+    const store = getPromotionStore();
+    const source = { sourceNodeId: String(node.id), sourceWidgetName: w.name };
+    const action = demote ? "demote" : "promote";
+    graph.beforeChange?.();
+    try {
+      for (const p of parents) {
+        const rootGraphId = p.rootGraph?.id ?? rootGraph?.id;
+        store[action](rootGraphId, p.id, source);
+        // Recompute the parent node so the (un)promoted widget shows immediately.
+        p.computeSize?.(p.size);
+        p.setDirtyCanvas?.(true, true);
+      }
+    } finally {
+      graph.afterChange?.();
+    }
+    canvas?.setDirty?.(true, true);
+    return {
+      [demote ? "demoted" : "promoted"]: w.name,
+      from_node: node.id,
+      on_subgraph_nodes: parents.map((p) => p.id),
+    };
   },
 
   // --- Custom-node management via the BUILT-IN ComfyUI Manager (/v2 API) ----
@@ -1810,6 +1880,10 @@ function describeCommand(cmd, msg, reply) {
         icon: "pi-sitemap",
         text: `Read subgraph “${r.subgraph_of?.title}” — ${r.node_count} node${r.node_count === 1 ? "" : "s"}`,
       };
+    case "graph_promote_widget":
+      return r.demoted
+        ? { icon: "pi-arrow-down", text: `Un-promoted “${r.demoted}” from the subgraph node` }
+        : { icon: "pi-arrow-up", text: `Promoted “${r.promoted}” to the subgraph node` };
     case "graph_move_node":
       return { icon: "pi-arrows-alt", text: `Moved node ${r.moved?.node_id} to [${r.moved?.to?.map(Math.round)}]` };
     case "graph_canvas":

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -119,6 +119,12 @@ const REBOOT_KEY = "comfyui-mcp.panel.rebootResume";
 // agent-triggered reload mid-task — nudge it to continue. Survives the bridge
 // drop via sessionStorage.
 const SOFT_RELOAD_KEY = "comfyui-mcp.panel.softReloadResume";
+// Set while the agent is mid-turn (working), cleared when the turn finishes. If
+// the connection drops while it's set — an UNEXPECTED bounce (another agent
+// rebooting ComfyUI, a crash, an SDK self-heal) — the reconnect nudges the
+// resumed session to continue where it left off. The REBOOT/SOFT_RELOAD cases
+// (deliberate, agent-known) are handled first and clear this so we don't double-nudge.
+const MID_TASK_KEY = "comfyui-mcp.panel.midTaskResume";
 // One-shot flag set right before a frontend (page) reload WE trigger, so that
 // after the reload we re-activate our own sidebar tab. ComfyUI restores the
 // last active tab BEFORE our extension re-registers it, so it can't reopen ours
@@ -2809,8 +2815,13 @@ function buildPanel() {
       softReload("agent", scope);
     },
     onTurn(state) {
-      if (state === "working") showThinking();
-      else if (state === "done") hideThinking();
+      if (state === "working") {
+        showThinking();
+        ssSet(MID_TASK_KEY, "1"); // a turn is in flight — arm the resume nudge
+      } else if (state === "done") {
+        hideThinking();
+        ssSet(MID_TASK_KEY, null); // turn finished cleanly — nothing to resume
+      }
     },
     onLog(text) {
       appendSystem(text);
@@ -2870,6 +2881,7 @@ function buildPanel() {
       if (ack?.kind === "ready" && ssGet(SOFT_RELOAD_KEY)) {
         const origin = ssGet(SOFT_RELOAD_KEY);
         ssSet(SOFT_RELOAD_KEY, null);
+        ssSet(MID_TASK_KEY, null); // deliberate reload — don't also fire the drop nudge
         appendSystem("Agent reloaded — session resumed.");
         if (origin === "agent") {
           showThinking();
@@ -2877,6 +2889,18 @@ function buildPanel() {
             "✅ You were just soft-reloaded to pick up code changes (no ComfyUI restart) — your tools and system prompt are now the latest build. Continue exactly what you were doing before the reload.",
           );
         }
+        return;
+      }
+      // Unexpected bounce while mid-task — a DIFFERENT agent restarting ComfyUI
+      // (to load nodes), a crash, or an SDK self-heal. The session resumed with
+      // full context but has no pending turn, so it would sit idle. Nudge it.
+      if (ack?.kind === "ready" && ssGet(MID_TASK_KEY)) {
+        ssSet(MID_TASK_KEY, null);
+        appendSystem("Reconnected — picking up where we left off.");
+        showThinking();
+        client.sendUserMessage(
+          "✅ Your connection dropped mid-task (e.g. ComfyUI was restarted, possibly by another agent installing nodes). The session resumed with full context — continue exactly what you were doing before the drop; if you were mid-build or mid-edit, pick it right back up.",
+        );
       }
     },
     getResume: () => ssGet(SESSION_KEY),

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1039,7 +1039,7 @@ const GRAPH_TOOL_EXECUTORS = {
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 15000;
 
-function createBridgeClient({ onStatus, onSay, onLog, onCommand, onAsk, onSecret, onReload, onAgentStatus, onSession, onModels, onAck, onTurn, getResume }) {
+function createBridgeClient({ onStatus, onSay, onLog, onCommand, onAsk, onSecret, onReload, onTodo, onAgentStatus, onSession, onModels, onAck, onTurn, getResume }) {
   let sock = null;
   let url = loadBridgeUrl();
   let closed = false;
@@ -1135,6 +1135,11 @@ function createBridgeClient({ onStatus, onSay, onLog, onCommand, onAsk, onSecret
             const scope = msg.scope === "frontend" ? "frontend" : "orchestrator";
             result = `soft reload (${scope}) scheduled`;
             setTimeout(() => onReload(scope), 60);
+          } else if (msg.cmd === "set_todo") {
+            // Render/update the agent's live TODO checklist in the footer tray.
+            const items = Array.isArray(msg.items) ? msg.items : [];
+            onTodo?.(items);
+            result = { ok: true, count: items.length };
           } else {
             const executor = GRAPH_TOOL_EXECUTORS[msg.cmd];
             if (!executor) throw new Error(`Unknown command "${msg.cmd}"`);
@@ -1156,7 +1161,7 @@ function createBridgeClient({ onStatus, onSay, onLog, onCommand, onAsk, onSecret
         // ask_user / request_secret paint their OWN cards and their replies carry
         // user input (a choice, or a SECRET) — never echo them as an activity card
         // (and never record them). Other commands get the normal activity card.
-        if (msg.cmd !== "ask_user" && msg.cmd !== "request_secret") {
+        if (msg.cmd !== "ask_user" && msg.cmd !== "request_secret" && msg.cmd !== "set_todo") {
           onCommand?.(msg.cmd, msg, reply);
         }
         return;
@@ -1523,6 +1528,21 @@ const PANEL_CSS = `
 /* The base rule sets display, which beats the UA [hidden] rule — so re-assert
    it or "newMsgBtn.hidden = true" won't actually hide the pill. */
 .cmcp-newmsg[hidden] { display: none; }
+.cmcp-tray {
+  flex: none; margin: 0 0.5rem 0.25rem; padding: 0.4rem 0.55rem;
+  background: var(--p-surface-800, #27272a); border: 1px solid var(--p-content-border-color, #3f3f46);
+  border-radius: 8px; max-height: 9rem; overflow-y: auto; font-size: 0.7rem;
+}
+.cmcp-tray[hidden] { display: none; }
+.cmcp-tray-head { font-size: 0.6rem; text-transform: uppercase; letter-spacing: 0.05em; opacity: 0.55; margin-bottom: 0.3rem; }
+.cmcp-todo-item { display: flex; align-items: flex-start; gap: 0.4rem; padding: 0.12rem 0; line-height: 1.3; }
+.cmcp-todo-item .pi { font-size: 0.7rem; margin-top: 0.1rem; flex: none; }
+.cmcp-todo-item.done { opacity: 0.55; }
+.cmcp-todo-item.done span { text-decoration: line-through; }
+.cmcp-todo-item.done .pi { color: var(--p-green-400, #4ade80); }
+.cmcp-todo-item.active { font-weight: 600; }
+.cmcp-todo-item.active .pi { color: var(--p-primary-color, #60a5fa); }
+.cmcp-todo-item.pending .pi { opacity: 0.5; }
 .cmcp-sys {
   align-self: center; font-size: 0.6875rem; font-style: italic;
   color: var(--p-text-muted-color, #a1a1aa);
@@ -1953,6 +1973,46 @@ function buildPanel() {
   });
   body.appendChild(newMsgBtn);
   root.appendChild(body);
+
+  // Footer status tray — docked above the composer. Hosts the agent's live TODO
+  // checklist (download progress rows slot in here later). Hidden until non-empty.
+  let todoItems = [];
+  const tray = document.createElement("div");
+  tray.className = "cmcp-tray";
+  tray.hidden = true;
+  root.appendChild(tray);
+
+  function renderTray() {
+    tray.replaceChildren();
+    const has = todoItems.length > 0;
+    tray.hidden = !has;
+    if (!has) return;
+    const list = document.createElement("div");
+    list.className = "cmcp-todo";
+    const doneN = todoItems.filter((it) => it && it.status === "done").length;
+    const head = document.createElement("div");
+    head.className = "cmcp-tray-head";
+    head.textContent = `Plan · ${doneN}/${todoItems.length}`;
+    list.appendChild(head);
+    for (const it of todoItems) {
+      const status = it && it.status === "active" ? "active" : it && it.status === "done" ? "done" : "pending";
+      const row = document.createElement("div");
+      row.className = "cmcp-todo-item " + status;
+      const icon = document.createElement("i");
+      icon.className =
+        "pi " + (status === "done" ? "pi-check-circle" : status === "active" ? "pi-spin pi-spinner" : "pi-circle");
+      const txt = document.createElement("span");
+      txt.textContent = (it && it.text) || "";
+      row.append(icon, txt);
+      list.appendChild(row);
+    }
+    tray.appendChild(list);
+    scrollLog();
+  }
+  function renderTodo(items) {
+    todoItems = Array.isArray(items) ? items : [];
+    renderTray();
+  }
 
   function clearEmpty() {
     if (empty.parentElement) empty.remove();
@@ -2803,6 +2863,10 @@ function buildPanel() {
       const p = paintQuestion(msg);
       bumpThinking();
       return p;
+    },
+    // The agent called panel_set_todo — render/update the live plan tray.
+    onTodo(items) {
+      renderTodo(items);
     },
     // The agent called panel_request_secret — collect a token securely.
     onSecret(msg) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -60,9 +60,8 @@ try {
 // localStorage-backed settings.
 // ---------------------------------------------------------------------------
 const STORAGE_KEY_BRIDGE = "comfyui-mcp.panel.bridgeUrl";
-// The panel orchestrator owns a DEDICATED bridge port (9180), separate from the
-// legacy `comfyui-mcp --channels` bridge (9101) — so a stray --channels server
-// in any Claude/Cursor session can never sit on the panel's port and produce a
+// The panel orchestrator owns a DEDICATED bridge port (9180) — so a stray
+// process in another session can never sit on the panel's port and produce a
 // "connected but no agent" lie.
 const DEFAULT_BRIDGE_URL = "ws://127.0.0.1:9180";
 const LEGACY_BRIDGE_URL = "ws://127.0.0.1:9101"; // old shared default — migrate off it
@@ -1052,7 +1051,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
   let reconnectTimer = null;
   // Truthful "connected": a WS open is NOT enough — we only flip to "connected"
   // once the orchestrator handshake (its `models` frame) arrives. A non-orchestrator
-  // squatter on the port (e.g. a stray `comfyui-mcp --channels`) never sends it,
+  // squatter on the port (some other process) never sends it,
   // so the panel won't lie "connected" when there's no agent behind the socket.
   let handshakeTimer = null;
   let handshakeDone = false;
@@ -1100,9 +1099,8 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
       handshakeTimer = setTimeout(() => {
         if (handshakeDone) return;
         onLog(
-          `⚠ Bridge open on ${url} but no panel agent responded. Something else may be holding the port ` +
-            `(e.g. a 'comfyui-mcp --channels' server from another Claude/Cursor session). Close it, or fully ` +
-            `restart ComfyUI, then reconnect.`,
+          `⚠ Bridge open on ${url} but no panel agent responded. Something else may be holding the port. ` +
+            `Close it, or fully restart ComfyUI, then reconnect.`,
         );
       }, HANDSHAKE_MS);
     });
@@ -2731,13 +2729,57 @@ function buildPanel() {
   }
 
   // ---- live streaming (thinking + reply) ----
-  // A streaming bubble is keyed by the SDK message id so deltas stay coherent and
-  // the final committed `say` (same id) REPLACES the preview rather than adding a
-  // duplicate. Thinking text streams into a "see thinking" accordion that's open
-  // (and scrollable) while the model reasons, then collapses the instant reply
-  // text begins. Reply text streams as plain text with a caret; on commit it's
-  // re-rendered as full markdown.
-  const streamBubbles = new Map(); // id -> { el, thinkWrap, thinkBody, thinkSummary, replyEl, thinkText, replyText }
+  // Deltas arrive in uneven, network-sized chunks. To match the official app's
+  // smooth character-by-character feel we DON'T paint each chunk directly —
+  // instead each bubble holds a target string and a "shown" cursor, and ONE rAF
+  // loop advances every active bubble a few chars per frame: fast enough to catch
+  // up on a big burst, slow enough to read as typing. The committed `say` renders
+  // markdown only once the typewriter has caught up, so it never snaps mid-reveal.
+  // Keyed by SDK message id so deltas stay coherent and the final say replaces the
+  // preview instead of duplicating. Zero deps (no GSAP) — streaming text wants a
+  // render loop, not a DOM-splitting animation.
+  const streamBubbles = new Map(); // id -> bubble state
+  const animating = new Set(); // bubbles with characters still to reveal
+  let streamRaf = null;
+
+  function kickStreams(s) {
+    animating.add(s);
+    if (streamRaf == null) streamRaf = requestAnimationFrame(pumpStreams);
+  }
+
+  function pumpStreams() {
+    streamRaf = null;
+    let active = false;
+    for (const s of animating) {
+      let busy = false;
+      // Reveal thinking text (proportional catch-up, a few chars/frame minimum).
+      if (s.thinkBody && s.thinkShown < s.thinkTarget.length) {
+        const rem = s.thinkTarget.length - s.thinkShown;
+        s.thinkShown = Math.min(s.thinkTarget.length, s.thinkShown + Math.max(3, Math.ceil(rem / 6)));
+        s.thinkBody.textContent = s.thinkTarget.slice(0, s.thinkShown);
+        s.thinkBody.scrollTop = s.thinkBody.scrollHeight;
+        busy = true;
+      }
+      // Reveal reply text a touch slower so it reads as deliberate typing.
+      if (s.replyShown < s.replyTarget.length) {
+        const rem = s.replyTarget.length - s.replyShown;
+        s.replyShown = Math.min(s.replyTarget.length, s.replyShown + Math.max(2, Math.ceil(rem / 9)));
+        s.replyEl.textContent = s.replyTarget.slice(0, s.replyShown);
+        busy = true;
+      }
+      if (busy) {
+        active = true;
+      } else if (s.commitText != null) {
+        finalizeStream(s); // caught up and the final text is waiting → commit it
+      } else {
+        animating.delete(s); // idle until the next delta arrives
+      }
+    }
+    if (active) {
+      scrollLog();
+      streamRaf = requestAnimationFrame(pumpStreams);
+    }
+  }
 
   function ensureStreamBubble(id) {
     let s = streamBubbles.get(id);
@@ -2749,7 +2791,19 @@ function buildPanel() {
     replyEl.className = "cmcp-reply";
     el.appendChild(replyEl);
     log.appendChild(el);
-    s = { el, thinkWrap: null, thinkBody: null, thinkSummary: null, replyEl, thinkText: "", replyText: "" };
+    s = {
+      id,
+      el,
+      replyEl,
+      thinkWrap: null,
+      thinkBody: null,
+      thinkSummary: null,
+      thinkTarget: "",
+      thinkShown: 0,
+      replyTarget: "",
+      replyShown: 0,
+      commitText: null,
+    };
     streamBubbles.set(id, s);
     bumpThinking(); // keep the working indicator pinned below the new bubble
     return s;
@@ -2773,10 +2827,11 @@ function buildPanel() {
   }
 
   function collapseThinking(s, label) {
-    if (s.thinkWrap) {
-      s.thinkWrap.open = false;
-      if (s.thinkSummary) s.thinkSummary.textContent = label;
-    }
+    if (!s.thinkWrap) return;
+    s.thinkShown = s.thinkTarget.length; // snap the (now hidden) reasoning to full
+    if (s.thinkBody) s.thinkBody.textContent = s.thinkTarget;
+    s.thinkWrap.open = false;
+    if (s.thinkSummary) s.thinkSummary.textContent = label;
   }
 
   function onStreamDelta(msg) {
@@ -2785,36 +2840,39 @@ function buildPanel() {
     if (phase === "think") {
       const s = ensureStreamBubble(id);
       ensureThinkArea(s);
-      s.thinkText += delta;
-      s.thinkBody.textContent = s.thinkText;
-      s.thinkBody.scrollTop = s.thinkBody.scrollHeight; // follow the newest reasoning
-      scrollLog();
+      s.thinkTarget += delta;
+      kickStreams(s);
     } else if (phase === "text") {
       const s = ensureStreamBubble(id);
       collapseThinking(s, "See thinking"); // reply began → tuck the reasoning away
-      s.replyText += delta;
-      s.replyEl.textContent = s.replyText; // plain while streaming; markdown on commit
+      s.replyTarget += delta;
       s.replyEl.classList.add("streaming-cursor");
-      scrollLog();
-    } else if (phase === "end") {
-      const s = streamBubbles.get(id);
-      if (s) s.replyEl.classList.remove("streaming-cursor");
+      kickStreams(s);
     }
+    // phase "end" (message_stop): nothing — the commit (or typewriter catch-up)
+    // finalizes the bubble; the caret keeps blinking until the real text lands.
   }
 
-  /** Reconcile a committed `say` with its live preview: replace the streamed text
-   *  with final markdown, collapse thinking, record to history. Returns false if
-   *  there's no matching stream bubble (caller falls back to a normal bubble). */
+  function finalizeStream(s) {
+    animating.delete(s);
+    streamBubbles.delete(s.id);
+    s.replyEl.classList.remove("streaming-cursor");
+    collapseThinking(s, "See thinking");
+    renderRichText(s.replyEl, s.commitText); // streamed plain text → final markdown
+    s.el.classList.remove("streaming");
+    record({ role: "agent", text: s.commitText }); // thinking is ephemeral
+    scrollLog();
+  }
+
+  /** Reconcile a committed `say` with its live preview: let the typewriter finish,
+   *  then render final markdown (done in pumpStreams → finalizeStream). Returns
+   *  false if there's no matching stream bubble (caller paints a normal bubble). */
   function commitStream(id, text) {
     const s = streamBubbles.get(id);
     if (!s) return false;
-    s.replyEl.classList.remove("streaming-cursor");
-    collapseThinking(s, "See thinking");
-    renderRichText(s.replyEl, text);
-    s.el.classList.remove("streaming");
-    streamBubbles.delete(id);
-    record({ role: "agent", text }); // thinking is ephemeral — only the reply persists
-    scrollLog();
+    s.commitText = text;
+    s.replyTarget = text; // authoritative — guarantees the typewriter reaches the end
+    kickStreams(s); // run to completion; finalizeStream renders markdown when caught up
     return true;
   }
 
@@ -3843,11 +3901,34 @@ function buildPanel() {
       // detached/unsupported — value is set, caret position is cosmetic
     }
   }
+  /** "Edit last message": when you start navigating, if the agent hasn't answered
+   *  yet (the last recorded message is still yours), RETRACT it — pull the bubble
+   *  out of the feed, drop any in-flight reply preview, and interrupt the turn —
+   *  so editing and resending REPLACES it instead of leaving a duplicate. If the
+   *  agent already replied, we leave the conversation intact and just browse. */
+  function retractLastUserMessage() {
+    const msgs = thread?.msgs;
+    if (!msgs || !msgs.length || msgs[msgs.length - 1].role !== "user") return;
+    msgs.pop();
+    persistThreads();
+    for (const s of streamBubbles.values()) s.el.remove(); // interrupting → drop previews
+    streamBubbles.clear();
+    animating.clear();
+    const userBubbles = log.querySelectorAll(".cmcp-bubble.user");
+    const last = userBubbles[userBubbles.length - 1];
+    if (last) last.remove();
+    if (thinkingEl) {
+      client?.sendFrame?.({ type: "interrupt" });
+      hideThinking();
+    }
+  }
+
   function recallPrev() {
     if (!sentHistory.length) return false;
     if (histIdx === -1) {
       histDraft = input.value;
       histIdx = sentHistory.length;
+      retractLastUserMessage(); // pull an unanswered message back so resend ≠ duplicate
     }
     histIdx = Math.max(0, histIdx - 1);
     setComposerValue(sentHistory[histIdx]);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -373,7 +373,7 @@ function imageViewUrl(img) {
   }
 }
 
-/** Current workflow title for this tab (shown in panel_status). */
+/** Current workflow title for this tab. */
 function getWorkflowTitle() {
   // document.title is "<name> - ComfyUI" with a leading "*" when unsaved.
   const t = document.title.replace(/ - ComfyUI$/, "").replace(/^\*/, "").trim();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3817,12 +3817,61 @@ function buildPanel() {
     recognition.start();
   });
 
+  // ---- composer history (press ↑ to recall your last message for editing) ----
+  // Shell-style: ↑ from an empty composer (or with the caret at the very start)
+  // walks back through messages you've sent and drops them back in the composer;
+  // ↓ walks forward and finally restores the draft you were typing. Any keystroke
+  // that edits the text exits history mode. Born from the muscle-memory urge to
+  // press ↑ and fix a typo in the message you just fired off.
+  const sentHistory = [];
+  let histIdx = -1; // -1 = not navigating; otherwise an index into sentHistory
+  let histDraft = ""; // the unsent draft stashed when navigation began
+
+  function recordSent(text) {
+    if (sentHistory[sentHistory.length - 1] !== text) sentHistory.push(text);
+    if (sentHistory.length > 50) sentHistory.shift();
+    histIdx = -1;
+  }
+  function setComposerValue(val) {
+    input.value = val;
+    input.style.height = "auto";
+    input.style.height = `${Math.min(input.scrollHeight, 120)}px`;
+    const n = val.length;
+    try {
+      input.setSelectionRange(n, n);
+    } catch {
+      // detached/unsupported — value is set, caret position is cosmetic
+    }
+  }
+  function recallPrev() {
+    if (!sentHistory.length) return false;
+    if (histIdx === -1) {
+      histDraft = input.value;
+      histIdx = sentHistory.length;
+    }
+    histIdx = Math.max(0, histIdx - 1);
+    setComposerValue(sentHistory[histIdx]);
+    return true;
+  }
+  function recallNext() {
+    if (histIdx === -1) return false;
+    histIdx += 1;
+    if (histIdx >= sentHistory.length) {
+      histIdx = -1;
+      setComposerValue(histDraft); // back to the draft you were typing
+    } else {
+      setComposerValue(sentHistory[histIdx]);
+    }
+    return true;
+  }
+
   // ---- submit ----
   form.addEventListener("submit", async (ev) => {
     ev.preventDefault();
     hideMenu();
     const text = input.value.trim();
     if (!text) return;
+    recordSent(text); // remember it so ↑ can recall it later
     if (text.startsWith("/")) {
       const c = SLASH_COMMANDS.find((sc) => sc.cmd === text.split(/\s+/)[0]);
       if (c) {
@@ -3910,6 +3959,27 @@ function buildPanel() {
         return;
       }
     }
+    // ↑ recalls your previous sent message (when already navigating, or from the
+    // very start of the composer so it never hijacks normal line-up movement);
+    // ↓ walks forward / restores your draft. Esc bails out to the draft.
+    if (ev.key === "ArrowUp" && (histIdx !== -1 || (input.selectionStart === 0 && input.selectionEnd === 0))) {
+      if (recallPrev()) {
+        ev.preventDefault();
+        return;
+      }
+    }
+    if (ev.key === "ArrowDown" && histIdx !== -1) {
+      if (recallNext()) {
+        ev.preventDefault();
+        return;
+      }
+    }
+    if (ev.key === "Escape" && histIdx !== -1) {
+      ev.preventDefault();
+      histIdx = -1;
+      setComposerValue(histDraft);
+      return;
+    }
     if (ev.key === "Enter" && !ev.shiftKey) {
       ev.preventDefault();
       form.requestSubmit();
@@ -3934,6 +4004,7 @@ function buildPanel() {
   input.addEventListener("blur", () => setTimeout(hideMenu, 150));
   // Auto-grow the textarea up to its CSS max-height.
   input.addEventListener("input", () => {
+    histIdx = -1; // a real edit exits message-history navigation
     input.style.height = "auto";
     input.style.height = `${Math.min(input.scrollHeight, 120)}px`;
     refreshMenu();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -32,28 +32,35 @@
 // `NodeHandle`/`WidgetHandle`. v1 call sites are tagged `// TODO(v2):`.
 // =============================================================================
 
-// ComfyUI loads extension files as ES modules; on modern frontends (1.4x+)
-// `window.app` is no longer assigned before extension eval, so the module
-// import is the canonical access path. The absolute specifier works from any
-// nesting depth under /extensions/<pack>/.
-import { app } from "/scripts/app.js";
-import { api } from "/scripts/api.js";
+// `app` / `api` are resolved LAZILY (not via a static `import "/scripts/app.js"`).
+// On Vite/Rolldown frontends, extension modules are evaluated alphabetically-early
+// — before `window.comfyAPI.app` is populated — so a static import of the app.js
+// shim can throw synchronously and deadlock the module loader. We grab them from
+// window.comfyAPI once it's ready instead (see registerExtensionWhenReady at the
+// bottom). Deferral approach contributed by @FreesoSaiFared.
 import { marked } from "./vendor/marked.esm.js";
 import DOMPurify from "./vendor/purify.es.js";
 
-// Execution-error capture: listen from module load so graph_get_errors can
-// report the most recent failure even if it predates the agent's question.
-// execution_start clears state for the new run.
+let app = null;
+let api = null;
+
+// Execution-error capture so graph_get_errors can report the most recent failure
+// even if it predates the agent's question. Wired once `api` is ready (via
+// setupListeners, called from registerExtensionWhenReady). execution_start clears
+// state for the new run.
 let lastExecutionError = null;
-try {
-  api.addEventListener("execution_error", (ev) => {
-    lastExecutionError = { ...(ev.detail ?? {}), ts: new Date().toISOString() };
-  });
-  api.addEventListener("execution_start", () => {
-    lastExecutionError = null;
-  });
-} catch {
-  // api unavailable — graph_get_errors reports null.
+function setupListeners() {
+  if (!api) return;
+  try {
+    api.addEventListener("execution_error", (ev) => {
+      lastExecutionError = { ...(ev.detail ?? {}), ts: new Date().toISOString() };
+    });
+    api.addEventListener("execution_start", () => {
+      lastExecutionError = null;
+    });
+  } catch {
+    // api unavailable — graph_get_errors reports null.
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -4322,13 +4329,27 @@ function buildPanel() {
 }
 
 // ---------------------------------------------------------------------------
-// v1 registration via the imported app module.
+// Registration. Resolve `app`/`api` from window.comfyAPI and register the
+// extension only once they're ready — deferring past Vite/Rolldown's early
+// module eval so a not-yet-populated shim can't throw and deadlock the loader.
+// Defensive deferral contributed by @FreesoSaiFared (PR #2).
 // ---------------------------------------------------------------------------
-if (!app || typeof app.registerExtension !== "function") {
-  console.error(
-    "[comfyui-mcp-panel] app.registerExtension is unavailable — incompatible ComfyUI frontend version.",
-  );
-} else {
+function registerExtensionWhenReady(tries = 0) {
+  const comfyApp = window.comfyAPI?.app?.app || window.app;
+  if (!comfyApp || typeof comfyApp.registerExtension !== "function") {
+    if (tries >= 1000) {
+      console.error(
+        "[comfyui-mcp-panel] app.registerExtension never became available — incompatible ComfyUI frontend version.",
+      );
+      return;
+    }
+    setTimeout(() => registerExtensionWhenReady(tries + 1), 10);
+    return;
+  }
+  app = comfyApp;
+  api = window.comfyAPI?.api?.api || window.api || null;
+  setupListeners();
+
   // TODO(v2): replace with `defineExtension({ name, setup() {...} })`.
   app.registerExtension({
     name: "comfyui-mcp.agent-panel",
@@ -4389,3 +4410,5 @@ if (!app || typeof app.registerExtension !== "function") {
     },
   });
 }
+
+registerExtensionWhenReady();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3231,6 +3231,14 @@ function buildPanel() {
       applyModelCatalog(list);
     },
     onAck(ack) {
+      // Effort change while the agent was mid-turn: it can't change a running
+      // turn's effort, so it applies once the current turn finishes (no more
+      // killing the in-flight reply). Let the user know so the picker selection
+      // not taking effect *this* turn isn't a mystery.
+      if (ack?.kind === "options" && ack.deferred) {
+        appendSystem(`Effort → ${ack.effort ?? "default"} — applies after the current turn finishes.`);
+        return;
+      }
       // Post-restart auto-resume (#3): the "ready" ack is sent after the
       // orchestrator armed hello.resume, so resuming the agent is safe now.
       // Clear REBOOT_KEY only here (on actual send) so a drop mid-reconnect

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1039,7 +1039,7 @@ const GRAPH_TOOL_EXECUTORS = {
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 15000;
 
-function createBridgeClient({ onStatus, onSay, onLog, onCommand, onAsk, onSecret, onReload, onTodo, onAgentStatus, onSession, onModels, onAck, onTurn, getResume }) {
+function createBridgeClient({ onStatus, onSay, onLog, onCommand, onAsk, onSecret, onReload, onTodo, onDownloads, onAgentStatus, onSession, onModels, onAck, onTurn, getResume }) {
   let sock = null;
   let url = loadBridgeUrl();
   let closed = false;
@@ -1195,6 +1195,11 @@ function createBridgeClient({ onStatus, onSay, onLog, onCommand, onAsk, onSecret
       // turn incl. silent tool work; done clears it).
       if (msg && msg.type === "turn" && typeof msg.state === "string") {
         onTurn?.(msg.state);
+      }
+      // Live download progress for the status tray (sourced orchestrator-side
+      // from the download tool's temp progress file and/or the Manager queue).
+      if (msg && msg.type === "download_progress" && Array.isArray(msg.downloads)) {
+        onDownloads?.(msg.downloads);
       }
       // "echo" frames are ignored — we render the user bubble locally on send.
     });
@@ -1543,6 +1548,17 @@ const PANEL_CSS = `
 .cmcp-todo-item.active { font-weight: 600; }
 .cmcp-todo-item.active .pi { color: var(--p-primary-color, #60a5fa); }
 .cmcp-todo-item.pending .pi { opacity: 0.5; }
+.cmcp-dl { margin-bottom: 0.4rem; }
+.cmcp-dl-item { padding: 0.18rem 0; }
+.cmcp-dl-top { display: flex; justify-content: space-between; gap: 0.5rem; align-items: baseline; }
+.cmcp-dl-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cmcp-dl-meta { flex: none; opacity: 0.7; font-size: 0.62rem; }
+.cmcp-dl-bar { height: 4px; border-radius: 999px; background: var(--p-surface-700, #3f3f46); overflow: hidden; margin-top: 0.2rem; }
+.cmcp-dl-fill { height: 100%; background: var(--p-primary-color, #3a7bd5); transition: width 0.3s ease; }
+.cmcp-dl-item.done .cmcp-dl-fill { background: var(--p-green-400, #4ade80); }
+.cmcp-dl-item.error .cmcp-dl-fill { background: var(--p-red-400, #f87171); }
+.cmcp-dl-bar.indet .cmcp-dl-fill { width: 30%; animation: cmcp-indet 1.1s ease-in-out infinite; }
+@keyframes cmcp-indet { 0% { margin-left: -30%; } 100% { margin-left: 100%; } }
 .cmcp-sys {
   align-self: center; font-size: 0.6875rem; font-style: italic;
   color: var(--p-text-muted-color, #a1a1aa);
@@ -1977,40 +1993,101 @@ function buildPanel() {
   // Footer status tray — docked above the composer. Hosts the agent's live TODO
   // checklist (download progress rows slot in here later). Hidden until non-empty.
   let todoItems = [];
+  let downloadItems = [];
   const tray = document.createElement("div");
   tray.className = "cmcp-tray";
   tray.hidden = true;
   root.appendChild(tray);
 
+  function fmtBytes(n) {
+    if (!n || n < 1024) return `${n || 0} B`;
+    const u = ["KB", "MB", "GB", "TB"];
+    let i = -1;
+    let v = n;
+    do { v /= 1024; i++; } while (v >= 1024 && i < u.length - 1);
+    return `${v.toFixed(1)} ${u[i]}`;
+  }
+
   function renderTray() {
     tray.replaceChildren();
-    const has = todoItems.length > 0;
-    tray.hidden = !has;
-    if (!has) return;
-    const list = document.createElement("div");
-    list.className = "cmcp-todo";
-    const doneN = todoItems.filter((it) => it && it.status === "done").length;
-    const head = document.createElement("div");
-    head.className = "cmcp-tray-head";
-    head.textContent = `Plan · ${doneN}/${todoItems.length}`;
-    list.appendChild(head);
-    for (const it of todoItems) {
-      const status = it && it.status === "active" ? "active" : it && it.status === "done" ? "done" : "pending";
-      const row = document.createElement("div");
-      row.className = "cmcp-todo-item " + status;
-      const icon = document.createElement("i");
-      icon.className =
-        "pi " + (status === "done" ? "pi-check-circle" : status === "active" ? "pi-spin pi-spinner" : "pi-circle");
-      const txt = document.createElement("span");
-      txt.textContent = (it && it.text) || "";
-      row.append(icon, txt);
-      list.appendChild(row);
+    const hasDl = downloadItems.length > 0;
+    const hasTodo = todoItems.length > 0;
+    tray.hidden = !hasDl && !hasTodo;
+    if (tray.hidden) return;
+
+    if (hasDl) {
+      const dl = document.createElement("div");
+      dl.className = "cmcp-dl";
+      const head = document.createElement("div");
+      head.className = "cmcp-tray-head";
+      head.textContent = "Downloads";
+      dl.appendChild(head);
+      for (const d of downloadItems) {
+        const total = d && Number(d.total) > 0 ? Number(d.total) : 0;
+        const got = d && Number(d.downloaded) > 0 ? Number(d.downloaded) : 0;
+        const pct = total ? Math.min(100, Math.round((100 * got) / total)) : null;
+        const failed = d && (d.status === "error" || d.status === "failed");
+        const done = d && d.status === "done";
+        const row = document.createElement("div");
+        row.className = "cmcp-dl-item" + (failed ? " error" : done ? " done" : "");
+        const top = document.createElement("div");
+        top.className = "cmcp-dl-top";
+        const name = document.createElement("span");
+        name.className = "cmcp-dl-name";
+        name.textContent = (d && d.name) || "download";
+        name.title = name.textContent;
+        const meta = document.createElement("span");
+        meta.className = "cmcp-dl-meta";
+        const speed = d && Number(d.bytes_per_sec) > 0 ? `${fmtBytes(Number(d.bytes_per_sec))}/s` : "";
+        meta.textContent = failed
+          ? "failed"
+          : done
+            ? "done"
+            : [pct != null ? `${pct}%` : "…", speed].filter(Boolean).join(" · ");
+        top.append(name, meta);
+        row.appendChild(top);
+        const barWrap = document.createElement("div");
+        barWrap.className = "cmcp-dl-bar" + (pct == null && !done && !failed ? " indet" : "");
+        const fill = document.createElement("div");
+        fill.className = "cmcp-dl-fill";
+        fill.style.width = `${done ? 100 : (pct ?? (failed ? 100 : 30))}%`;
+        barWrap.appendChild(fill);
+        row.appendChild(barWrap);
+        dl.appendChild(row);
+      }
+      tray.appendChild(dl);
     }
-    tray.appendChild(list);
+
+    if (hasTodo) {
+      const list = document.createElement("div");
+      list.className = "cmcp-todo";
+      const doneN = todoItems.filter((it) => it && it.status === "done").length;
+      const head = document.createElement("div");
+      head.className = "cmcp-tray-head";
+      head.textContent = `Plan · ${doneN}/${todoItems.length}`;
+      list.appendChild(head);
+      for (const it of todoItems) {
+        const status = it && it.status === "active" ? "active" : it && it.status === "done" ? "done" : "pending";
+        const row = document.createElement("div");
+        row.className = "cmcp-todo-item " + status;
+        const icon = document.createElement("i");
+        icon.className =
+          "pi " + (status === "done" ? "pi-check-circle" : status === "active" ? "pi-spin pi-spinner" : "pi-circle");
+        const txt = document.createElement("span");
+        txt.textContent = (it && it.text) || "";
+        row.append(icon, txt);
+        list.appendChild(row);
+      }
+      tray.appendChild(list);
+    }
     scrollLog();
   }
   function renderTodo(items) {
     todoItems = Array.isArray(items) ? items : [];
+    renderTray();
+  }
+  function renderDownloads(downloads) {
+    downloadItems = (Array.isArray(downloads) ? downloads : []).filter(Boolean);
     renderTray();
   }
 
@@ -2867,6 +2944,10 @@ function buildPanel() {
     // The agent called panel_set_todo — render/update the live plan tray.
     onTodo(items) {
       renderTodo(items);
+    },
+    // Orchestrator pushed live download progress → render rows in the tray.
+    onDownloads(list) {
+      renderDownloads(list);
     },
     // The agent called panel_request_secret — collect a token securely.
     onSecret(msg) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3071,6 +3071,12 @@ function buildPanel() {
       // full context but has no pending turn, so it would sit idle. Nudge it.
       if (ack?.kind === "ready" && ssGet(MID_TASK_KEY)) {
         ssSet(MID_TASK_KEY, null);
+        // Only nudge for a REAL restart. A fast reconnect (a panel remount from a
+        // sidebar swap, or a brief WS blip) means the orchestrator never died —
+        // the agent's turn kept running — so a "you dropped" nudge is false AND
+        // would inject a spurious turn into a live session. A real ComfyUI restart
+        // takes many seconds to come back, so a long gap since the drop = real.
+        if (Date.now() - lastBridgeDownAt < 6000) return;
         appendSystem("Reconnected — picking up where we left off.");
         showThinking();
         client.sendUserMessage(


### PR DESCRIPTION
# ComfyUI Agent Panel — round 2 (v0.1.2)

The autonomous ComfyUI sidebar agent — streaming chat, subgraph authoring, and a hardened load path. Runs on your Claude subscription (no API keys). Combined work of three agents on `feat/3-agent-barley-smash-rd2`.

## Added
- **Live streaming chat** — extended-thinking streams into a collapsible "see thinking" accordion; the reply streams in character-by-character (rAF typewriter, no GSAP); press **↑** to recall/retract your last message.
- **Subgraph authoring** — `panel_promote_widget`: expose/retract an inner subgraph widget on the parent node (verified end-to-end on a 50-node LTX subgraph, with full restore). Plus the rd2 toolset: enter/exit/create subgraph, node-title rename, workflow tabs, built-in Manager install→restart→resume.
- **Footer status tray** — live TODO checklist + download-progress rows.
- **Live thinking-token counter** in the working indicator.
- **`.githooks/pre-commit` + CI** — `node --check web/js` + `py_compile` + pyproject validation, so a broken bundle can't be committed *or* merged; plus a dev **live-save guardian** (`scripts/panel-guard.mjs`) that auto-restores a syntactically-broken save (the live-served file can otherwise black out the whole ComfyUI frontend).

## Changed
- **Rebranded to "ComfyUI Agent Panel"** (registry slug `comfyui-agent-panel`, DisplayName, README, in-UI tooltip). License declared as the Comfy-correct `{ file = "LICENSE" }` table form. Version **0.1.2**.
- **Removed the legacy `--channels` mode entirely** — the panel runs only on the autonomous orchestrator; docs/README/comments scrubbed.
- Registry auto-publish is now **gated** on the syntax/pyproject checks before it fires.
- README now documents the full `panel_*` toolset by category.

## Fixed
- **Deferred extension registration** — resolve `app`/`api` from `window.comfyAPI` and register only once ready, so on Vite/Rolldown frontends an early module eval can't throw and deadlock the loader. *Adapted from #2 — thank you **@FreesoSaiFared**.*
- No reconnect "storm" — silent on panel-swap / WS-blip (no false "you dropped", no re-greet on resume).
- Changing reasoning effort mid-turn no longer drops the in-flight reply (deferred to idle; queued messages preserved).
- Links open externally (fixes the desktop-webview hijack); TODO plan persists across reloads; auto-resume after an unexpected mid-task disconnect.

## Verification
- `node --check web/js/comfyui-mcp-panel.js` ✓ · deferred-registration confirmed live (panel mounts, agent connects on `claude-opus-4-8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
