### PR TITLE
rd3: SDK slash commands, one-click recovery, delivery status (v0.1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,41 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-06-19
+
+### Added
+
+- **Live-streaming chat** — extended-thinking in a collapsible "see thinking"
+  accordion + character-by-character reply, with a live thinking-token counter.
+- **SDK slash commands** in the composer `/` menu — `/compact`, `/context`,
+  `/usage`, `/loop`, `/goal`, `/clear` (the SDK's useful built-ins).
+- **`/restart` — one-click recovery for a wedged agent.** Kills the orchestrator
+  **and its whole child tree** (clearing a dead Agent-SDK shell an in-place reload
+  can't) and starts a **fresh** session — resuming would just restore the wedge.
+  Pure-Python route, so it works even when the agent isn't answering.
+- **Per-message delivery status** (queued → seen) with edit/cancel on a queued
+  message, and a **live model-download progress** tray.
+- **Subgraph authoring** — promote/retract inner widgets, node-title rename,
+  workflow-tab tools, built-in Manager install→restart→resume.
+
+### Changed
+
+- **Rebranded to "ComfyUI Agent Panel"** (registry slug `comfyui-agent-panel`);
+  license declared as the Comfy-correct `{ file = "LICENSE" }` table form.
+- **Removed all `--channels` plumbing.** The panel runs only on the autonomous
+  orchestrator (dedicated bridge `9180`); reload/restart live as slash commands
+  (`/reload`, `/reload-ui`, `/restart`), not header buttons.
+
 ### Fixed
 
+- **Pid-reuse-safe orchestrator kill** — identity (cmdline + creation time) is
+  re-verified immediately before every terminate/kill, for the orchestrator and
+  each child, so a recycled pid is never mistaken for ours and a user's unrelated
+  process is never signalled.
+- **Connect honors the Bridge URL field** (previously only Reconnect did).
+- **Deferred extension registration** so a Vite/Rolldown early module eval can't
+  throw and deadlock the loader (adapted from a community PR, thanks
+  @FreesoSaiFared).
 - **Truthful "connected".** The panel now turns green only after the orchestrator
   handshake (its `models` frame) arrives — a non-orchestrator squatting the
   bridge port (e.g. a stray `comfyui-mcp --channels` server from another

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ The bridge is loopback-only (`ws://127.0.0.1:9180`, set via
 `COMFYUI_MCP_BRIDGE_PORT`). To run the orchestrator yourself, set
 `COMFYUI_MCP_NO_AUTOSPAWN=1` and launch it manually, then click Connect.
 
+Type `/` in the composer for commands — including `/compact`, `/loop` and other
+Claude built-ins, plus panel ones: **`/reload`** (pick up new code, keep the
+chat), **`/reload-ui`** (reload just the panel), and **`/restart`** (recover an
+unresponsive agent — kills the orchestrator and its child tree, starts fresh).
+
 ## What the agent can do
 
 The agent drives the workflow you're viewing through a **fixed allowlist** of

--- a/__init__.py
+++ b/__init__.py
@@ -273,6 +273,65 @@ def _is_orchestrator_process(pid):
         return False  # can't verify → never kill
 
 
+def _kill_orchestrator_tree(pid, started_at_ms=None):
+    """Kill a VERIFIED orchestrator AND its child process tree, then reap them.
+
+    A soft reload terminates only the orchestrator's own pid — but the Claude
+    Agent SDK spawns child processes (its shell, helper binaries). If one of those
+    wedges (e.g. a dead shell after a re-auth) and is orphaned rather than killed,
+    the wedge survives the respawn and the user is stuck (Task Manager / reboot).
+    Hard restart kills the whole tree so the fresh orchestrator starts truly clean.
+
+    Safe by construction: we only ever snapshot/kill the tree of a pid that
+    verifies as our orchestrator (cmdline + recorded creation time), so every
+    descendant is by definition our agent's own subprocess — never a user's. If
+    the root doesn't verify, nothing is touched."""
+    try:
+        import psutil  # type: ignore
+    except Exception:
+        return False
+
+    children = []
+    try:
+        if _is_orchestrator_process(pid) and (
+            started_at_ms is None or _same_process(pid, started_at_ms)
+        ):
+            children = psutil.Process(int(pid)).children(recursive=True)
+    except Exception:
+        children = []
+
+    # Kill the root via the identity-re-verifying helper. Only if it confirms the
+    # root was ours do we reap the snapshotted descendants.
+    killed_root = _kill_pid(pid, started_at_ms)
+    if not killed_root:
+        return False
+
+    for ch in children:
+        try:
+            ch.terminate()
+        except Exception:
+            pass
+    try:
+        _gone, alive = psutil.wait_procs(children, timeout=3)
+    except Exception:
+        alive = children
+    for ch in alive:
+        try:
+            ch.kill()
+        except Exception:
+            pass
+    return True
+
+
+def _delete_lock():
+    """Remove the orchestrator lockfile (best-effort) so a fresh orchestrator
+    self-registers cleanly after a hard restart."""
+    try:
+        os.remove(_lock_path())
+    except Exception:
+        pass
+
+
 def _start_orchestrator():
     """Start the panel orchestrator on demand. Returns (ok: bool, message: str).
 
@@ -436,6 +495,46 @@ def _reload_orchestrator():
     return _start_orchestrator()
 
 
+def _hard_restart_orchestrator():
+    """Force a truly fresh orchestrator: kill the verified orchestrator AND its
+    whole child tree (clears a wedged Agent-SDK shell an in-place soft reload
+    can't), delete the lockfile, then respawn. Pure Python over the local route,
+    so it works even when the agent itself is unresponsive — the user's one-click
+    escape from "the agent stopped answering" without Task Manager or a reboot.
+    Returns (ok, message)."""
+    if _no_autospawn():
+        return False, (
+            "auto-start is disabled (COMFYUI_MCP_NO_AUTOSPAWN) — restart your "
+            "orchestrator process yourself."
+        )
+
+    _stop_orchestrator()
+    lock = _read_lock()
+    parent = lock.get("parent") if lock else None
+    opid = lock.get("pid") if lock else None
+    lock_is_ours = _lock_parent_is_current(lock)
+    lock_is_orphan = _lock_parent_is_gone(lock)
+    if opid and (lock_is_ours or lock_is_orphan) and _is_orchestrator_process(opid):
+        _kill_orchestrator_tree(opid, lock.get("pidStartedAt"))
+    elif lock and parent and parent != os.getpid() and not lock_is_orphan:
+        return False, (
+            "the panel bridge port {} is owned by another live ComfyUI "
+            "(pid {}). Not restarting it.".format(_BRIDGE_PORT, parent)
+        )
+
+    _delete_lock()
+    for _ in range(30):
+        if not _port_in_use(_BRIDGE_HOST, _BRIDGE_PORT):
+            break
+        time.sleep(0.1)
+    if _port_in_use(_BRIDGE_HOST, _BRIDGE_PORT):
+        return False, (
+            "the panel bridge port {} is still held after the restart — fully "
+            "restart ComfyUI.".format(_BRIDGE_PORT)
+        )
+    return _start_orchestrator()
+
+
 # ---------------------------------------------------------------------------
 # Local API the panel's Connect button calls. Registering aiohttp routes at
 # import is standard for custom nodes (no subprocess is spawned here); the
@@ -482,6 +581,17 @@ def _register_routes():
         # Soft reload: respawn the orchestrator (new code) without restarting
         # ComfyUI. The panel reconnects and resumes the session afterward.
         ok, message = _reload_orchestrator()
+        return web.json_response(
+            {"ok": ok, "running": _orchestrator_running(), "port": _BRIDGE_PORT, "message": message},
+            status=200 if ok else 503,
+        )
+
+    @routes.post("/comfyui_mcp_panel/hard_restart")
+    async def _hard_restart(_request):
+        # Recovery: kill the orchestrator + its whole child tree and respawn — the
+        # fix for a wedged/unresponsive agent backend that a soft reload can't
+        # clear. Pure Python, so it works even when the agent isn't answering.
+        ok, message = _hard_restart_orchestrator()
         return web.json_response(
             {"ok": ok, "running": _orchestrator_running(), "port": _BRIDGE_PORT, "message": message},
             status=200 if ok else 503,

--- a/__init__.py
+++ b/__init__.py
@@ -206,21 +206,56 @@ def _lock_parent_is_gone(lock):
     return not _same_process(parent, lock.get("parentStartedAt"))
 
 
-def _kill_pid(pid):
-    """Terminate a (verified-orchestrator) pid via psutil — no shell/taskkill, so
-    the only subprocess the pack ever runs is the explicit, Connect-gated
-    orchestrator spawn. If psutil is unavailable we don't kill (return False);
-    the caller then surfaces a "fully restart ComfyUI" message."""
+def _kill_pid(pid, started_at_ms=None):
+    """Terminate a pid via psutil, but ONLY while it still verifies as OUR panel
+    orchestrator — re-checking identity (cmdline + creation time) immediately
+    before every terminate()/kill() call.
+
+    This closes a TOCTOU pid-reuse race: the caller checks identity, but the
+    orchestrator can exit and the OS can recycle its pid before the signal lands.
+    Without the re-check we could terminate whatever now holds that pid — a user's
+    shell, node, editor, anything. So we never signal a pid that doesn't, at the
+    instant of signalling, still look like our orchestrator. psutil-only (no
+    shell/taskkill); if psutil is unavailable we don't kill (return False) and the
+    caller surfaces a "fully restart ComfyUI" message."""
     try:
         import psutil  # type: ignore
+    except Exception:
+        return False
 
+    def _still_ours():
+        # Must look like our orchestrator AND (when we recorded its start time) be
+        # the SAME process instance — not a pid-reuse impostor.
+        if not _is_orchestrator_process(pid):
+            return False
+        if started_at_ms is not None and not _same_process(pid, started_at_ms):
+            return False
+        return True
+
+    try:
+        if not _still_ours():
+            _log(
+                "refusing to kill pid {} — not (or no longer) a verified panel "
+                "orchestrator; possible pid reuse. Left untouched.".format(pid)
+            )
+            return False
         proc = psutil.Process(int(pid))
         proc.terminate()
         try:
             proc.wait(timeout=3)
+            return True
         except Exception:
+            # Still alive after terminate → escalate to kill, but ONLY if it's
+            # STILL our orchestrator (it may have exited + had its pid reused
+            # during the wait window).
+            if not _still_ours():
+                _log(
+                    "not escalating to kill pid {} — identity changed during "
+                    "wait (pid reuse?). Left untouched.".format(pid)
+                )
+                return False
             proc.kill()
-        return True
+            return True
     except Exception:
         return False
 
@@ -278,8 +313,10 @@ def _start_orchestrator():
             "replacing orphaned orchestrator pid {} (its ComfyUI {} is gone)".format(opid, parent)
         )
         # Kill ONLY if it's verifiably our orchestrator — never a reused pid.
+        # _kill_pid re-verifies (cmdline + the recorded creation time) right
+        # before it signals, so a pid recycled to an unrelated process is spared.
         if opid and _is_orchestrator_process(opid):
-            _kill_pid(opid)
+            _kill_pid(opid, lock.get("pidStartedAt"))
         for _ in range(20):
             if not _port_in_use(_BRIDGE_HOST, _BRIDGE_PORT):
                 break
@@ -375,8 +412,10 @@ def _reload_orchestrator():
     lock_is_ours = _lock_parent_is_current(lock)
     lock_is_orphan = _lock_parent_is_gone(lock)
     # Kill only a verified orchestrator pid — never a reused pid (pid-reuse safe).
+    # _kill_pid re-verifies identity (cmdline + recorded creation time) right
+    # before it signals, so a recycled pid can't be mistaken for ours and killed.
     if opid and (lock_is_ours or lock_is_orphan) and _is_orchestrator_process(opid):
-        _kill_pid(opid)
+        _kill_pid(opid, lock.get("pidStartedAt"))
     elif lock and parent and parent != os.getpid() and not lock_is_orphan:
         return False, (
             "the panel bridge port {} is owned by another live ComfyUI "

--- a/__init__.py
+++ b/__init__.py
@@ -291,14 +291,19 @@ def _kill_orchestrator_tree(pid, started_at_ms=None):
     except Exception:
         return False
 
-    children = []
+    # Snapshot descendants WITH their creation times, under a verified parent.
+    snapshot = []  # list of (psutil.Process, create_time)
     try:
         if _is_orchestrator_process(pid) and (
             started_at_ms is None or _same_process(pid, started_at_ms)
         ):
-            children = psutil.Process(int(pid)).children(recursive=True)
+            for ch in psutil.Process(int(pid)).children(recursive=True):
+                try:
+                    snapshot.append((ch, ch.create_time()))
+                except Exception:
+                    pass
     except Exception:
-        children = []
+        snapshot = []
 
     # Kill the root via the identity-re-verifying helper. Only if it confirms the
     # root was ours do we reap the snapshotted descendants.
@@ -306,20 +311,32 @@ def _kill_orchestrator_tree(pid, started_at_ms=None):
     if not killed_root:
         return False
 
-    for ch in children:
+    # A snapshotted child can exit and have its pid reused before we signal it, so
+    # NEVER signal a child whose pid no longer maps to the same process. Read the
+    # creation time FRESH (a cached psutil.Process would return the stale value) and
+    # only signal on an exact match — same guard rigor as _kill_pid uses for the root.
+    def _same_child(proc, ct):
         try:
-            ch.terminate()
+            return abs(psutil.Process(proc.pid).create_time() - ct) <= 0.02
         except Exception:
-            pass
+            return False  # gone or unreadable → don't signal
+
+    for proc, ct in snapshot:
+        if _same_child(proc, ct):
+            try:
+                proc.terminate()
+            except Exception:
+                pass
     try:
-        _gone, alive = psutil.wait_procs(children, timeout=3)
+        psutil.wait_procs([p for p, _ in snapshot], timeout=3)
     except Exception:
-        alive = children
-    for ch in alive:
-        try:
-            ch.kill()
-        except Exception:
-            pass
+        pass
+    for proc, ct in snapshot:
+        if _same_child(proc, ct):
+            try:
+                proc.kill()
+            except Exception:
+                pass
     return True
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "AI agent sidebar for ComfyUI — an autonomous background agent drives your graph, running on your Claude subscription with no API keys. Add, wire, move and tweak nodes live with full Ctrl+Z undo, generate images, video and audio, and run your workflow. Click Connect to start the agent. Part of the comfyui-mcp project."
-version = "0.1.2"
+version = "0.1.3"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3709,6 +3709,11 @@ function buildPanel() {
     connecting = true;
     connectBtn.disabled = true;
     connectBtn.textContent = "Starting…";
+    // Honor whatever is typed in the Bridge URL field — Connect previously
+    // ignored it (only Reconnect applied it), so editing the port (e.g. 9181)
+    // then clicking Connect still hit the old URL. setUrl persists + reconnects.
+    const wanted = urlInput.value.trim();
+    if (wanted && wanted !== client.currentUrl()) client.setUrl(wanted);
     try {
       const res = await api.fetchApi("/comfyui_mcp_panel/connect", { method: "POST" });
       const data = await res.json().catch(() => ({}));

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1572,14 +1572,20 @@ const PANEL_CSS = `
    needs pre-wrap to honor its newlines; the commit drops the .streaming class
    and it reverts to normal markdown flow. */
 .cmcp-bubble.agent.streaming .cmcp-reply { white-space: pre-wrap; }
-/* Per-message delivery status under a sent user bubble (sending → seen → failed). */
+/* Per-message delivery status: invisible on success (a normal bubble = received
+   and not dropped); only a FAILED send shows up — the bubble tints red and the
+   status row exposes ✎ edit / ✕ delete. */
 .cmcp-msg-status {
   align-self: flex-end; max-width: 92%;
   margin: 0.0625rem 0.125rem 0.125rem;
   font-size: 0.6875rem; color: var(--p-text-muted-color, #71717a);
-  display: flex; gap: 0.5rem; align-items: center;
+  display: flex; gap: 0.375rem; align-items: center;
 }
-.cmcp-msg-status.failed { color: var(--p-red-400, #f87171); font-weight: 500; }
+.cmcp-msg-status:empty { display: none; }
+.cmcp-bubble.user.failed {
+  border-color: color-mix(in srgb, var(--p-red-400, #f87171), transparent 35%);
+  background: color-mix(in srgb, var(--p-red-400, #f87171), transparent 86%);
+}
 .cmcp-msg-action {
   background: none; border: none; padding: 0.0625rem; cursor: pointer;
   display: inline-flex; align-items: center; line-height: 1;
@@ -2938,27 +2944,29 @@ function buildPanel() {
 
   function setMsgStatus(mid, state) {
     const statusEl = statusElFor(mid);
-    if (!statusEl) return;
-    statusEl.className = "cmcp-msg-status " + state;
-    statusEl.replaceChildren();
-    if (state === "sending" || state === "failed") {
-      // Pre-seen (or undelivered): a muted label plus ✎ edit (pull back into the
-      // composer) and ✕ delete. The agent hasn't replied yet, so editing is just
-      // a retract — no rollback needed.
-      const label = document.createElement("span");
-      label.textContent = state === "failed" ? "Not delivered" : "Sending…";
-      statusEl.append(
-        label,
-        iconAction("pi-pencil", "Edit (bring back to composer)", () => editMsg(mid)),
+    const bubble = log.querySelector(`.cmcp-bubble.user[data-mid="${mid}"]`);
+    // Successful delivery needs no chrome — a normal bubble IS the "delivered"
+    // signal. We only surface a PROBLEM: a failed send tints the bubble (color)
+    // and exposes ✎ edit (pull text back to the composer) + ✕ delete, so a
+    // dropped message never silently vanishes.
+    if (state === "sending") {
+      bubble?.classList.remove("failed");
+      statusEl?.replaceChildren(); // empty → hidden via :empty
+      return;
+    }
+    if (state === "seen") {
+      bubble?.classList.remove("failed");
+      statusEl?.remove();
+      return;
+    }
+    if (state === "failed") {
+      bubble?.classList.add("failed");
+      if (!statusEl) return;
+      statusEl.className = "cmcp-msg-status failed";
+      statusEl.replaceChildren(
+        iconAction("pi-pencil", "Edit — bring back to the composer", () => editMsg(mid)),
         iconAction("pi-times", "Delete this message", () => deleteMsg(mid)),
       );
-    } else if (state === "seen") {
-      // Delivered → the agent is on it. Drop the actions; show a brief "✓ Seen"
-      // that fades so confirmations don't pile up.
-      statusEl.textContent = "✓ Seen";
-      setTimeout(() => {
-        if (statusEl.classList.contains("seen")) statusEl.remove();
-      }, 2500);
     }
   }
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1365,7 +1365,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
       closed = false;
       connect();
     },
-    sendUserMessage(text, context, images) {
+    sendUserMessage(text, context, images, mid) {
       if (!sock || sock.readyState !== WebSocket.OPEN) return false;
       try {
         sock.send(
@@ -1374,6 +1374,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
             text,
             ...(context ? { context } : {}),
             ...(images?.length ? { images } : {}),
+            // Client message id — the orchestrator echoes it in the "working"
+            // ack so the panel can mark this exact bubble delivered ("Seen").
+            ...(mid ? { mid } : {}),
           }),
         );
         return true;
@@ -1569,6 +1572,24 @@ const PANEL_CSS = `
    needs pre-wrap to honor its newlines; the commit drops the .streaming class
    and it reverts to normal markdown flow. */
 .cmcp-bubble.agent.streaming .cmcp-reply { white-space: pre-wrap; }
+/* Per-message delivery status under a sent user bubble (sending → seen → failed). */
+.cmcp-msg-status {
+  align-self: flex-end; max-width: 92%;
+  margin: 0.0625rem 0.125rem 0.125rem;
+  font-size: 0.6875rem; color: var(--p-text-muted-color, #71717a);
+  display: flex; gap: 0.5rem; align-items: center;
+}
+.cmcp-msg-status.failed { color: var(--p-red-400, #f87171); font-weight: 500; }
+.cmcp-msg-action {
+  background: none; border: none; padding: 0.0625rem; cursor: pointer;
+  display: inline-flex; align-items: center; line-height: 1;
+  color: var(--p-text-muted-color, #71717a);
+  border-radius: var(--p-border-radius-sm, 4px);
+  transition: color 0.12s, background 0.12s;
+}
+.cmcp-msg-action .pi { font-size: 0.75rem; }
+.cmcp-msg-action:hover { color: var(--p-text-color, #fff); background: var(--p-surface-700, #3f3f46); }
+.cmcp-msg-status.failed .cmcp-msg-action:hover { color: var(--p-red-300, #fca5a5); }
 .cmcp-bubble.agent code, .cmcp-bubble.user code {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.75rem;
   background: var(--p-form-field-background, #09090b);
@@ -2581,13 +2602,24 @@ function buildPanel() {
     });
   }
 
-  function paintUser(text) {
+  function paintUser(text, opts = {}) {
     clearEmpty();
     const b = document.createElement("div");
     b.className = "cmcp-bubble user";
     b.textContent = text;
+    if (opts.mid) b.dataset.mid = opts.mid;
     log.appendChild(b);
+    // Live sends get a delivery-status line below the bubble (sending → seen, or
+    // failed with resend/delete). Replayed history has no mid → no status.
+    let statusEl = null;
+    if (opts.mid) {
+      statusEl = document.createElement("div");
+      statusEl.className = "cmcp-msg-status";
+      statusEl.dataset.mid = opts.mid;
+      log.appendChild(statusEl);
+    }
     scrollLog();
+    return { bubble: b, statusEl };
   }
 
   function paintAgent(text) {
@@ -2862,11 +2894,124 @@ function buildPanel() {
     return promise;
   }
 
-  function appendUser(text) {
+  function appendUser(text, opts = {}) {
     stickToBottom = true; // your own message → always jump to the latest
     newMsgBtn.hidden = true;
-    paintUser(text);
+    const painted = paintUser(text, opts);
     record({ role: "user", text });
+    return painted;
+  }
+
+  // ---- delivery status ("Seen") ----
+  // Every live send carries a client message id (mid). The orchestrator echoes it
+  // in the "working" ack the moment it RECEIVES the message, so we can flip the
+  // bubble from "Sending…" to "✓ Seen". If no ack lands in time (or the socket
+  // was down at send), the bubble shows "Not delivered" with Resend/Delete — so a
+  // dropped message (e.g. an image lost on a WS blip) never silently vanishes.
+  let midCounter = 0;
+  const pendingMsgs = new Map(); // mid -> { statusEl, payload, timer }
+  const DELIVERY_TIMEOUT_MS = 7000;
+
+  function newMid() {
+    midCounter += 1;
+    return `m${Date.now().toString(36)}_${midCounter.toString(36)}`;
+  }
+
+  function statusElFor(mid) {
+    return (
+      pendingMsgs.get(mid)?.statusEl ||
+      log.querySelector(`.cmcp-msg-status[data-mid="${mid}"]`)
+    );
+  }
+
+  function iconAction(icon, title, onClick) {
+    const b = document.createElement("button");
+    b.type = "button";
+    b.className = "cmcp-msg-action";
+    b.title = title;
+    const i = document.createElement("i");
+    i.className = `pi ${icon}`;
+    b.appendChild(i);
+    b.addEventListener("click", onClick);
+    return b;
+  }
+
+  function setMsgStatus(mid, state) {
+    const statusEl = statusElFor(mid);
+    if (!statusEl) return;
+    statusEl.className = "cmcp-msg-status " + state;
+    statusEl.replaceChildren();
+    if (state === "sending" || state === "failed") {
+      // Pre-seen (or undelivered): a muted label plus ✎ edit (pull back into the
+      // composer) and ✕ delete. The agent hasn't replied yet, so editing is just
+      // a retract — no rollback needed.
+      const label = document.createElement("span");
+      label.textContent = state === "failed" ? "Not delivered" : "Sending…";
+      statusEl.append(
+        label,
+        iconAction("pi-pencil", "Edit (bring back to composer)", () => editMsg(mid)),
+        iconAction("pi-times", "Delete this message", () => deleteMsg(mid)),
+      );
+    } else if (state === "seen") {
+      // Delivered → the agent is on it. Drop the actions; show a brief "✓ Seen"
+      // that fades so confirmations don't pile up.
+      statusEl.textContent = "✓ Seen";
+      setTimeout(() => {
+        if (statusEl.classList.contains("seen")) statusEl.remove();
+      }, 2500);
+    }
+  }
+
+  /** ✎ on a not-yet-answered message: retract it and drop the text back into the
+   *  composer to edit & resend (interrupting the turn if it already started). */
+  function editMsg(mid) {
+    const entry = pendingMsgs.get(mid);
+    const bubble = log.querySelector(`.cmcp-bubble.user[data-mid="${mid}"]`);
+    const raw = entry?.raw ?? bubble?.textContent ?? "";
+    if (thinkingEl) {
+      client?.sendFrame?.({ type: "interrupt" });
+      hideThinking();
+    }
+    deleteMsg(mid); // removes bubble + status + trailing record
+    setComposerValue(raw);
+    input.focus();
+  }
+
+  function armDeliveryTimeout(mid) {
+    const entry = pendingMsgs.get(mid);
+    if (!entry) return;
+    if (entry.timer) clearTimeout(entry.timer);
+    entry.timer = setTimeout(() => {
+      if (pendingMsgs.has(mid)) setMsgStatus(mid, "failed");
+    }, DELIVERY_TIMEOUT_MS);
+  }
+
+  function trackSend(mid, statusEl, payload, raw) {
+    pendingMsgs.set(mid, { statusEl, payload, raw, timer: null });
+    const ok = client.sendUserMessage(payload.text, payload.context, payload.images, mid);
+    if (!ok) setMsgStatus(mid, "failed"); // socket wasn't open — instant fail
+    else armDeliveryTimeout(mid);
+  }
+
+  function markSeen(mid) {
+    const entry = pendingMsgs.get(mid);
+    if (!entry) return;
+    if (entry.timer) clearTimeout(entry.timer);
+    pendingMsgs.delete(mid);
+    setMsgStatus(mid, "seen");
+  }
+
+  function deleteMsg(mid) {
+    const entry = pendingMsgs.get(mid);
+    if (entry?.timer) clearTimeout(entry.timer);
+    pendingMsgs.delete(mid);
+    for (const el of log.querySelectorAll(`[data-mid="${mid}"]`)) el.remove();
+    // An undelivered message was never answered, so it's the trailing record.
+    const msgs = thread?.msgs;
+    if (msgs && msgs.length && msgs[msgs.length - 1].role === "user") {
+      msgs.pop();
+      persistThreads();
+    }
   }
 
   function appendAgent(text) {
@@ -3379,6 +3524,12 @@ function buildPanel() {
       applyModelCatalog(list);
     },
     onAck(ack) {
+      // Delivery confirmation: the orchestrator received this message → mark its
+      // bubble "✓ Seen". (No mid = an internal nudge send; nothing to mark.)
+      if (ack?.kind === "working" && typeof ack.mid === "string") {
+        markSeen(ack.mid);
+        return;
+      }
       // Effort change while the agent was mid-turn: it can't change a running
       // turn's effort, so it applies once the current turn finishes (no more
       // killing the in-flight reply). Let the user know so the picker selection
@@ -4072,7 +4223,14 @@ function buildPanel() {
     animating.clear();
     const userBubbles = log.querySelectorAll(".cmcp-bubble.user");
     const last = userBubbles[userBubbles.length - 1];
+    const mid = last?.dataset?.mid;
     if (last) last.remove();
+    if (mid) {
+      const entry = pendingMsgs.get(mid);
+      if (entry?.timer) clearTimeout(entry.timer);
+      pendingMsgs.delete(mid);
+      log.querySelector(`.cmcp-msg-status[data-mid="${mid}"]`)?.remove();
+    }
     if (thinkingEl) {
       client?.sendFrame?.({ type: "interrupt" });
       hideThinking();
@@ -4125,7 +4283,9 @@ function buildPanel() {
       return;
     }
     const freshChat = !thread;
-    appendUser(text);
+    const mid = newMid();
+    const painted = appendUser(text, { mid });
+    setMsgStatus(mid, "sending");
     showThinking();
     input.value = "";
     input.style.height = "auto";
@@ -4163,14 +4323,14 @@ function buildPanel() {
     } catch {
       // graph unavailable — send without subgraph context
     }
-    client.sendUserMessage(
-      sendText,
-      {
-        workflow: getWorkflowTitle(),
-        ...(viewing.scope === "subgraph" ? { subgraph: viewing.title } : {}),
-      },
-      imageRefs,
-    );
+    const context = {
+      workflow: getWorkflowTitle(),
+      ...(viewing.scope === "subgraph" ? { subgraph: viewing.title } : {}),
+    };
+    // Track delivery: trackSend marks "Sending…", then the working ack flips it
+    // to "✓ Seen" (or a timeout / closed socket flips it to "Not delivered").
+    // `text` (the raw composer text) is kept so ✎ can restore it for editing.
+    trackSend(mid, painted.statusEl, { text: sendText, context, images: imageRefs }, text);
   });
 
   input.addEventListener("keydown", (ev) => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2913,7 +2913,9 @@ function buildPanel() {
     stickToBottom = true; // your own message → always jump to the latest
     newMsgBtn.hidden = true;
     const painted = paintUser(text, opts);
-    record({ role: "user", text });
+    // Tag the record with its mid so deleteMsg can remove the EXACT message even
+    // when several are queued (popping the trailing one would hit the wrong one).
+    record({ role: "user", text, ...(opts.mid ? { mid: opts.mid } : {}) });
     return painted;
   }
 
@@ -3032,11 +3034,15 @@ function buildPanel() {
     pendingMsgs.delete(mid);
     cancelOnServer(mid); // drop it from the agent's queue if still there
     for (const el of log.querySelectorAll(`[data-mid="${mid}"]`)) el.remove();
-    // A queued/undelivered message was never answered → it's the trailing record.
+    // Remove the EXACT record for this mid (not the trailing one — several may be
+    // queued at once).
     const msgs = thread?.msgs;
-    if (msgs && msgs.length && msgs[msgs.length - 1].role === "user") {
-      msgs.pop();
-      persistThreads();
+    if (msgs) {
+      const i = msgs.findIndex((m) => m.role === "user" && m.mid === mid);
+      if (i >= 0) {
+        msgs.splice(i, 1);
+        persistThreads();
+      }
     }
   }
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1120,7 +1120,7 @@ const GRAPH_TOOL_EXECUTORS = {
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 15000;
 
-function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk, onSecret, onReload, onTodo, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onAck, onTurn, onActivity, getResume }) {
+function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk, onSecret, onReload, onTodo, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onAck, onTurn, getResume }) {
   let sock = null;
   let url = loadBridgeUrl();
   let closed = false;
@@ -1189,9 +1189,6 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
       } catch {
         return;
       }
-      // Feed the health watchdog (it decides what counts as the agent actually
-      // responding vs. a bare receipt ack).
-      if (msg) onActivity?.(msg);
       if (msg && typeof msg.rid === "string" && typeof msg.cmd === "string") {
         // Agent command — execute against the graph, reply with the rid.
         // Executors may be async (run, save) — await uniformly.
@@ -2066,11 +2063,9 @@ function buildPanel() {
   actions.style.cssText = "margin-left:auto;display:flex;gap:0.125rem;align-items:center;";
   const newChatBtn = iconBtn("pi-plus", "New chat");
   const historyBtn = iconBtn("pi-history", "Chat history");
-  const reloadBtn = iconBtn("pi-sync", "Soft reload the agent — picks up new code, keeps ComfyUI and this conversation");
-  reloadBtn.addEventListener("click", () => softReload("user", "orchestrator"));
-  const restartBtn = iconBtn("pi-refresh", "Restart the agent backend — recover an unresponsive agent (kills + respawns the orchestrator, keeps this chat)");
-  restartBtn.addEventListener("click", () => hardRestart("user"));
-  actions.append(reloadBtn, restartBtn, newChatBtn, historyBtn);
+  // Reload / restart live as slash commands (/reload, /reload-ui, /restart) — no
+  // header buttons for them.
+  actions.append(newChatBtn, historyBtn);
 
   header.style.position = "relative";
   const histPop = document.createElement("div");
@@ -3456,75 +3451,6 @@ function buildPanel() {
   // skills), pushed by the orchestrator — surfaced in the completion menu below.
   let sdkCommands = [];
 
-  // ---- agent-health watchdog -------------------------------------------------
-  // Detect a wedged/unresponsive agent backend (e.g. the Agent-SDK shell dying
-  // after a re-auth) and offer one-click recovery, so a user is never stuck
-  // reaching for Task Manager.
-  //
-  // We only watch the window between "user sent a message" (startAwaiting) and
-  // "the agent produced its FIRST real output" — a stream delta, a reply, a tool
-  // call, or a question (stopAwaiting, called from those callbacks). That first
-  // output proves the backend is alive, so we stop watching and idle time can't
-  // trigger a false alarm. A bare "message received" ack does NOT count (that's
-  // exactly the wedge case: orchestrator alive, agent dead). If no real output
-  // arrives within the threshold, the recovery banner appears.
-  const HEALTH_THRESHOLD_MS = 75000; // silence-while-awaiting before we flag it
-  const HEALTH_TICK_MS = 10000;
-  let lastAgentActivityAt = Date.now();
-  let awaitingReply = false;
-
-  const unresponsiveBanner = document.createElement("div");
-  unresponsiveBanner.hidden = true;
-  unresponsiveBanner.style.cssText =
-    "display:flex;align-items:center;gap:0.5rem;margin:0.4rem 0.5rem;padding:0.45rem 0.6rem;" +
-    "border-radius:8px;border:1px solid var(--p-yellow-400,#facc15);" +
-    "background:color-mix(in srgb, var(--p-yellow-400,#facc15) 12%, transparent);font-size:0.75rem;";
-  const bannerText = document.createElement("span");
-  bannerText.style.cssText = "flex:1;min-width:0;";
-  bannerText.textContent = "The agent backend isn't responding.";
-  const bannerRestart = document.createElement("button");
-  bannerRestart.type = "button";
-  bannerRestart.className = "cmcp-btn";
-  bannerRestart.textContent = "Restart agent";
-  bannerRestart.style.cssText = "padding:0.2rem 0.55rem;font-size:0.72rem;white-space:nowrap;";
-  bannerRestart.addEventListener("click", () => hardRestart("watchdog"));
-  const bannerDismiss = iconBtn("pi-times", "Dismiss");
-  // Dismiss must STICK: also stop awaiting so the 10s timer can't re-show it.
-  // (The next message you send re-arms the watchdog via startAwaiting.)
-  bannerDismiss.addEventListener("click", () => {
-    stopAwaiting();
-    hideUnresponsive();
-  });
-  unresponsiveBanner.append(bannerText, bannerRestart, bannerDismiss);
-  header.insertAdjacentElement("afterend", unresponsiveBanner);
-
-  function showUnresponsive() {
-    unresponsiveBanner.hidden = false;
-  }
-  function hideUnresponsive() {
-    unresponsiveBanner.hidden = true;
-  }
-  function noteAgentActivity() {
-    lastAgentActivityAt = Date.now();
-    if (!unresponsiveBanner.hidden) hideUnresponsive();
-  }
-  function startAwaiting() {
-    awaitingReply = true;
-    lastAgentActivityAt = Date.now();
-  }
-  function stopAwaiting() {
-    awaitingReply = false;
-  }
-  const healthTimer = setInterval(() => {
-    if (
-      awaitingReply &&
-      client.isConnected() &&
-      Date.now() - lastAgentActivityAt > HEALTH_THRESHOLD_MS
-    ) {
-      showUnresponsive();
-    }
-  }, HEALTH_TICK_MS);
-
   // ---- bridge wiring ----
   const client = createBridgeClient({
     onStatus(state) {
@@ -3536,11 +3462,7 @@ function buildPanel() {
       disconnectBtn.hidden = !connected;
       connectBtn.disabled = state === "connecting";
       connectBtn.textContent = state === "connecting" ? "Connecting…" : "Connect";
-      if (!connected) {
-        hideThinking();
-        stopAwaiting(); // not connected → nothing to wait on; clear the watchdog
-        hideUnresponsive();
-      }
+      if (!connected) hideThinking();
       // NB: do NOT push set_options here. The saved model id is only known-valid
       // once the live catalog arrives, so the push happens in applyModelCatalog
       // — sending an unvalidated fallback id can wedge the agent on a model the
@@ -3597,19 +3519,6 @@ function buildPanel() {
       } else if (state === "done") {
         hideThinking();
         ssSet(MID_TASK_KEY, null); // turn finished cleanly — nothing to resume
-        stopAwaiting(); // reply landed — stand the watchdog down
-      }
-    },
-    onActivity(msg) {
-      noteAgentActivity(); // any frame: reset the clock + hide the banner
-      // A SUBSTANTIVE response proves the agent is alive AND answering, so stop
-      // watching this send — idle time afterward must not raise a false alarm. A
-      // bare receipt ack ({type:"ack"}) is NOT substantive: that's exactly the
-      // wedge case (orchestrator alive, agent dead), so it must keep us watching.
-      const t = msg && msg.type;
-      const isToolCall = msg && typeof msg.rid === "string" && typeof msg.cmd === "string";
-      if (isToolCall || t === "say" || t === "stream" || t === "turn" || t === "thinking") {
-        stopAwaiting();
       }
     },
     onLog(text) {
@@ -3850,7 +3759,6 @@ function buildPanel() {
       return;
     }
     reloading = true;
-    reloadBtn.classList.add("cmcp-spin");
     ssSet(SOFT_RELOAD_KEY, origin === "agent" ? "agent" : "user");
     appendSystem("Soft-reloading the agent (new code, no ComfyUI restart)…");
     try {
@@ -3868,7 +3776,6 @@ function buildPanel() {
       return;
     } finally {
       reloading = false;
-      reloadBtn.classList.remove("cmcp-spin");
     }
     // Reconnect with backoff until the fresh orchestrator binds; onAck resumes.
     client.start();
@@ -3887,14 +3794,7 @@ function buildPanel() {
   async function hardRestart(origin = "user") {
     if (reloading) return;
     reloading = true;
-    restartBtn.classList.add("cmcp-spin");
-    hideUnresponsive();
-    stopAwaiting();
-    appendSystem(
-      origin === "watchdog"
-        ? "Restarting the agent backend (it stopped responding)…"
-        : "Restarting the agent backend…",
-    );
+    appendSystem("Restarting the agent backend…");
     let ok = false;
     try {
       client.stop(); // drop the bridge so the old orchestrator can release the port
@@ -3912,7 +3812,6 @@ function buildPanel() {
       appendSystem(`Couldn't reach ComfyUI to restart the agent: ${err?.message ?? err}`);
     } finally {
       reloading = false;
-      restartBtn.classList.remove("cmcp-spin");
     }
     if (ok) {
       // Start FRESH on reconnect: clear the saved session id so hello sends no
@@ -4503,7 +4402,6 @@ function buildPanel() {
     const painted = appendUser(text, { mid });
     setMsgStatus(mid, "queued"); // muted + ✎/✕ until the agent actually reads it
     showThinking();
-    startAwaiting(); // arm the health watchdog — a reply (or activity) is expected
     input.value = "";
     input.style.height = "auto";
 
@@ -4700,7 +4598,6 @@ function buildPanel() {
         // recognition already stopped
       }
       document.removeEventListener("mousedown", onDocPointerDown);
-      clearInterval(healthTimer);
       try {
         api.removeEventListener("executed", onExecuted);
         api.removeEventListener("execution_error", onExecError);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1271,6 +1271,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
         markConnected();
         onModels?.(msg.models, typeof msg.current === "string" ? msg.current : undefined);
       }
+      // SDK slash commands (built-ins like /compact, plus any loaded skills) —
+      // surfaced in the composer's completion menu.
+      if (msg && msg.type === "commands" && Array.isArray(msg.commands)) {
+        onCommands?.(msg.commands);
+      }
       // Structured acks (ready / working / options / …). The "ready" ack is sent
       // after the orchestrator has processed hello (resume armed), so it's the
       // reliable signal to send a post-restart resume nudge.
@@ -2819,7 +2824,8 @@ function buildPanel() {
     clearEmpty();
     const card = document.createElement("div");
     card.className = "cmcp-card cmcp-secret";
-    card.style.cssText = "border-left:3px solid var(--p-yellow-400,#facc15);";
+    card.style.cssText =
+      "border-left:3px solid var(--p-yellow-400,#facc15);width:100%;box-sizing:border-box;";
 
     const head = document.createElement("div");
     head.className = "cmcp-card-head";
@@ -2849,7 +2855,7 @@ function buildPanel() {
     input.spellcheck = false;
     input.placeholder = "Paste token…";
     input.style.cssText =
-      "flex:1;padding:0.35rem 0.5rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
+      "flex:1;min-width:7rem;padding:0.35rem 0.5rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
       "background:var(--p-surface-900,#1e1e1e);color:inherit;font-size:0.8rem;";
 
     // Show/record only a masked preview (first 4 … last 4) so the user can
@@ -3435,6 +3441,10 @@ function buildPanel() {
     }, 700);
   }
 
+  // SDK-provided slash commands (built-ins like /compact, plus any loaded
+  // skills), pushed by the orchestrator — surfaced in the completion menu below.
+  let sdkCommands = [];
+
   // ---- bridge wiring ----
   const client = createBridgeClient({
     onStatus(state) {
@@ -3542,6 +3552,10 @@ function buildPanel() {
     },
     onModels(list) {
       applyModelCatalog(list);
+    },
+    onCommands(list) {
+      // SDK-provided slash commands → surface in the composer completion menu.
+      sdkCommands = Array.isArray(list) ? list : [];
     },
     onAck(ack) {
       // Receipt: orchestrator got it (not dropped) → cancel the failure timer.
@@ -3845,7 +3859,7 @@ function buildPanel() {
       const el = document.createElement("button");
       el.type = "button";
       el.className =
-        "cmcp-popover-item" + (idx === 0 ? " sel" : "") + (item.kind === "slash" ? " cmcp-slash" : "");
+        "cmcp-popover-item" + (idx === 0 ? " sel" : "") + (item.kind === "slash" || item.kind === "agent" ? " cmcp-slash" : "");
       const i = document.createElement("i");
       i.className = `pi ${item.icon}`;
       const lbl = document.createElement("span");
@@ -3951,15 +3965,30 @@ function buildPanel() {
     if (/^\/[\w-]*$/.test(upto) && upto === input.value) {
       const q = upto.toLowerCase();
       menuToken = { start: 0, end: input.value.length };
-      showMenu(
-        SLASH_COMMANDS.filter((c) => c.cmd.startsWith(q)).map((c) => ({
-          kind: "slash",
-          icon: c.icon,
-          label: c.cmd,
-          small: c.hint,
-          ref: c,
-        })),
-      );
+      const localItems = SLASH_COMMANDS.filter((c) => c.cmd.startsWith(q)).map((c) => ({
+        kind: "slash",
+        icon: c.icon,
+        label: c.cmd,
+        small: c.hint,
+        ref: c,
+      }));
+      // SDK commands (sent to the agent — the SDK processes them). Skip any whose
+      // name collides with a local command. Picking inserts "/name " so the user
+      // can add args, then send routes it to the agent.
+      const localNames = new Set(SLASH_COMMANDS.map((c) => c.cmd));
+      const sdkItems = sdkCommands
+        .filter((c) => {
+          const names = ["/" + c.name, ...(c.aliases || []).map((a) => "/" + a)];
+          return !localNames.has("/" + c.name) && names.some((n) => n.startsWith(q));
+        })
+        .map((c) => ({
+          kind: "agent",
+          icon: "pi-sparkles",
+          label: "/" + c.name,
+          small: c.description || c.argumentHint || "agent command",
+          insert: "/" + c.name + " ",
+        }));
+      showMenu([...localItems, ...sdkItems]);
       return;
     }
     const atM = upto.match(/(^|\s)@([\w./:-]*)$/);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1120,7 +1120,7 @@ const GRAPH_TOOL_EXECUTORS = {
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 15000;
 
-function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk, onSecret, onReload, onTodo, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onAck, onTurn, getResume }) {
+function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk, onSecret, onReload, onTodo, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onAck, onTurn, onActivity, getResume }) {
   let sock = null;
   let url = loadBridgeUrl();
   let closed = false;
@@ -1189,6 +1189,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
       } catch {
         return;
       }
+      // Any inbound frame proves the backend is alive and talking — feed the
+      // health watchdog so it only ever fires on TRUE silence.
+      if (msg) onActivity?.();
       if (msg && typeof msg.rid === "string" && typeof msg.cmd === "string") {
         // Agent command — execute against the graph, reply with the rid.
         // Executors may be async (run, save) — await uniformly.
@@ -2065,7 +2068,9 @@ function buildPanel() {
   const historyBtn = iconBtn("pi-history", "Chat history");
   const reloadBtn = iconBtn("pi-sync", "Soft reload the agent — picks up new code, keeps ComfyUI and this conversation");
   reloadBtn.addEventListener("click", () => softReload("user", "orchestrator"));
-  actions.append(reloadBtn, newChatBtn, historyBtn);
+  const restartBtn = iconBtn("pi-refresh", "Restart the agent backend — recover an unresponsive agent (kills + respawns the orchestrator, keeps this chat)");
+  restartBtn.addEventListener("click", () => hardRestart("user"));
+  actions.append(reloadBtn, restartBtn, newChatBtn, historyBtn);
 
   header.style.position = "relative";
   const histPop = document.createElement("div");
@@ -3451,6 +3456,65 @@ function buildPanel() {
   // skills), pushed by the orchestrator — surfaced in the completion menu below.
   let sdkCommands = [];
 
+  // ---- agent-health watchdog -------------------------------------------------
+  // Detect a wedged/unresponsive agent backend (e.g. the Agent-SDK shell dying
+  // after a re-auth) and offer one-click recovery, so a user is never stuck
+  // reaching for Task Manager. Purely passive: ANY inbound frame counts as
+  // "alive" (noteAgentActivity), so the banner only appears on TRUE silence
+  // after a message was actually sent — a busy agent streams thinking/text and
+  // keeps resetting the clock.
+  const HEALTH_THRESHOLD_MS = 75000; // silence-while-awaiting before we flag it
+  const HEALTH_TICK_MS = 10000;
+  let lastAgentActivityAt = Date.now();
+  let awaitingReply = false;
+
+  const unresponsiveBanner = document.createElement("div");
+  unresponsiveBanner.hidden = true;
+  unresponsiveBanner.style.cssText =
+    "display:flex;align-items:center;gap:0.5rem;margin:0.4rem 0.5rem;padding:0.45rem 0.6rem;" +
+    "border-radius:8px;border:1px solid var(--p-yellow-400,#facc15);" +
+    "background:color-mix(in srgb, var(--p-yellow-400,#facc15) 12%, transparent);font-size:0.75rem;";
+  const bannerText = document.createElement("span");
+  bannerText.style.cssText = "flex:1;min-width:0;";
+  bannerText.textContent = "The agent backend isn't responding.";
+  const bannerRestart = document.createElement("button");
+  bannerRestart.type = "button";
+  bannerRestart.className = "cmcp-btn";
+  bannerRestart.textContent = "Restart agent";
+  bannerRestart.style.cssText = "padding:0.2rem 0.55rem;font-size:0.72rem;white-space:nowrap;";
+  bannerRestart.addEventListener("click", () => hardRestart("watchdog"));
+  const bannerDismiss = iconBtn("pi-times", "Dismiss");
+  bannerDismiss.addEventListener("click", () => hideUnresponsive());
+  unresponsiveBanner.append(bannerText, bannerRestart, bannerDismiss);
+  header.insertAdjacentElement("afterend", unresponsiveBanner);
+
+  function showUnresponsive() {
+    unresponsiveBanner.hidden = false;
+  }
+  function hideUnresponsive() {
+    unresponsiveBanner.hidden = true;
+  }
+  function noteAgentActivity() {
+    lastAgentActivityAt = Date.now();
+    if (!unresponsiveBanner.hidden) hideUnresponsive();
+  }
+  function startAwaiting() {
+    awaitingReply = true;
+    lastAgentActivityAt = Date.now();
+  }
+  function stopAwaiting() {
+    awaitingReply = false;
+  }
+  const healthTimer = setInterval(() => {
+    if (
+      awaitingReply &&
+      client.isConnected() &&
+      Date.now() - lastAgentActivityAt > HEALTH_THRESHOLD_MS
+    ) {
+      showUnresponsive();
+    }
+  }, HEALTH_TICK_MS);
+
   // ---- bridge wiring ----
   const client = createBridgeClient({
     onStatus(state) {
@@ -3462,7 +3526,11 @@ function buildPanel() {
       disconnectBtn.hidden = !connected;
       connectBtn.disabled = state === "connecting";
       connectBtn.textContent = state === "connecting" ? "Connecting…" : "Connect";
-      if (!connected) hideThinking();
+      if (!connected) {
+        hideThinking();
+        stopAwaiting(); // not connected → nothing to wait on; clear the watchdog
+        hideUnresponsive();
+      }
       // NB: do NOT push set_options here. The saved model id is only known-valid
       // once the live catalog arrives, so the push happens in applyModelCatalog
       // — sending an unvalidated fallback id can wedge the agent on a model the
@@ -3519,7 +3587,11 @@ function buildPanel() {
       } else if (state === "done") {
         hideThinking();
         ssSet(MID_TASK_KEY, null); // turn finished cleanly — nothing to resume
+        stopAwaiting(); // reply landed — stand the watchdog down
       }
+    },
+    onActivity() {
+      noteAgentActivity();
     },
     onLog(text) {
       appendSystem(text);
@@ -3783,6 +3855,47 @@ function buildPanel() {
     client.start();
   }
 
+  // Hard restart: recover a wedged/unresponsive agent. Unlike soft reload (which
+  // bounces the orchestrator in place to pick up new code), this kills the
+  // orchestrator AND its whole child tree — clearing a dead Agent-SDK shell that
+  // an in-place reload can't — then respawns a clean one. Runs entirely over the
+  // Python /hard_restart route, so it works even when the agent isn't answering.
+  // The conversation resumes afterward via the persisted session id.
+  async function hardRestart(origin = "user") {
+    if (reloading) return;
+    reloading = true;
+    restartBtn.classList.add("cmcp-spin");
+    hideUnresponsive();
+    stopAwaiting();
+    appendSystem(
+      origin === "watchdog"
+        ? "Restarting the agent backend (it stopped responding)…"
+        : "Restarting the agent backend…",
+    );
+    try {
+      client.stop(); // drop the bridge so the old orchestrator can release the port
+      const res = await api.fetchApi("/comfyui_mcp_panel/hard_restart", { method: "POST" });
+      const data = await res.json().catch(() => ({}));
+      if (!data?.ok) {
+        appendSystem(
+          data?.message ||
+            "Restart failed — try Disconnect then Connect, or fully restart ComfyUI.",
+        );
+        return;
+      }
+    } catch (err) {
+      appendSystem(`Couldn't reach ComfyUI to restart the agent: ${err?.message ?? err}`);
+      return;
+    } finally {
+      reloading = false;
+      restartBtn.classList.remove("cmcp-spin");
+    }
+    // Resume the conversation on the fresh orchestrator (same path soft reload
+    // uses — the session id persists, so onAck resumes the thread).
+    ssSet(SOFT_RELOAD_KEY, "user");
+    client.start();
+  }
+
   disconnectBtn.addEventListener("click", async () => {
     // Explicit Disconnect = opt out of sticky auto-reconnect.
     lsSet(AUTOCONNECT_KEY, null);
@@ -3832,6 +3945,12 @@ function buildPanel() {
       icon: "pi-refresh",
       hint: "reload just the panel UI (new frontend code, keeps the session)",
       run: () => softReload("user", "frontend"),
+    },
+    {
+      cmd: "/restart",
+      icon: "pi-refresh",
+      hint: "restart the agent backend — recover an unresponsive agent",
+      run: () => hardRestart("user"),
     },
     {
       cmd: "/errors",
@@ -4352,6 +4471,7 @@ function buildPanel() {
     const painted = appendUser(text, { mid });
     setMsgStatus(mid, "queued"); // muted + ✎/✕ until the agent actually reads it
     showThinking();
+    startAwaiting(); // arm the health watchdog — a reply (or activity) is expected
     input.value = "";
     input.style.height = "auto";
 
@@ -4548,6 +4668,7 @@ function buildPanel() {
         // recognition already stopped
       }
       document.removeEventListener("mousedown", onDocPointerDown);
+      clearInterval(healthTimer);
       try {
         api.removeEventListener("executed", onExecuted);
         api.removeEventListener("execution_error", onExecError);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3872,27 +3872,32 @@ function buildPanel() {
         ? "Restarting the agent backend (it stopped responding)…"
         : "Restarting the agent backend…",
     );
+    let ok = false;
     try {
       client.stop(); // drop the bridge so the old orchestrator can release the port
       const res = await api.fetchApi("/comfyui_mcp_panel/hard_restart", { method: "POST" });
       const data = await res.json().catch(() => ({}));
-      if (!data?.ok) {
+      if (data?.ok) {
+        ok = true;
+      } else {
         appendSystem(
           data?.message ||
             "Restart failed — try Disconnect then Connect, or fully restart ComfyUI.",
         );
-        return;
       }
     } catch (err) {
       appendSystem(`Couldn't reach ComfyUI to restart the agent: ${err?.message ?? err}`);
-      return;
     } finally {
       reloading = false;
       restartBtn.classList.remove("cmcp-spin");
     }
-    // Resume the conversation on the fresh orchestrator (same path soft reload
-    // uses — the session id persists, so onAck resumes the thread).
-    ssSet(SOFT_RELOAD_KEY, "user");
+    // On success, arm the resume so the fresh orchestrator continues the thread —
+    // origin-aware like softReload: a watchdog/mid-task restart wants the agent
+    // continuation nudge ("agent"), a manual click just resumes ("user").
+    if (ok) ssSet(SOFT_RELOAD_KEY, origin === "user" ? "user" : "agent");
+    // Reconnect EITHER WAY: on success to the fresh orchestrator, on failure to
+    // restore the bridge we dropped (the old backend may still be intact, and the
+    // session resumes via the normal hello.resume path).
     client.start();
   }
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1120,7 +1120,7 @@ const GRAPH_TOOL_EXECUTORS = {
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 15000;
 
-function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk, onSecret, onReload, onTodo, onDownloads, onThinking, onAgentStatus, onSession, onModels, onAck, onTurn, getResume }) {
+function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk, onSecret, onReload, onTodo, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onAck, onTurn, getResume }) {
   let sock = null;
   let url = loadBridgeUrl();
   let closed = false;
@@ -1582,7 +1582,10 @@ const PANEL_CSS = `
   display: flex; gap: 0.375rem; align-items: center;
 }
 .cmcp-msg-status:empty { display: none; }
+/* Queued: received but NOT yet read by the agent — muted/dimmed until it's read. */
+.cmcp-bubble.user.queued { opacity: 0.5; }
 .cmcp-bubble.user.failed {
+  opacity: 1;
   border-color: color-mix(in srgb, var(--p-red-400, #f87171), transparent 35%);
   background: color-mix(in srgb, var(--p-red-400, #f87171), transparent 86%);
 }
@@ -2908,14 +2911,17 @@ function buildPanel() {
     return painted;
   }
 
-  // ---- delivery status ("Seen") ----
-  // Every live send carries a client message id (mid). The orchestrator echoes it
-  // in the "working" ack the moment it RECEIVES the message, so we can flip the
-  // bubble from "Sending…" to "✓ Seen". If no ack lands in time (or the socket
-  // was down at send), the bubble shows "Not delivered" with Resend/Delete — so a
-  // dropped message (e.g. an image lost on a WS blip) never silently vanishes.
+  // ---- message delivery / read state ----
+  // Every live send carries a client message id (mid). A message is QUEUED (muted
+  // + ✎/✕) from the moment it's sent until the agent actually DEQUEUES it (the
+  // orchestrator's "seen" ack) — i.e. read state is the true read moment, not mere
+  // receipt. The brief "working" ack (receipt) only cancels the failure timer.
+  // While queued, ✎ pulls it back to the composer and ✕ cancels it — both yank it
+  // out of the agent's queue so it's never processed. If the socket was closed at
+  // send or nothing acks in time, it goes FAILED (red) — a dropped message never
+  // silently vanishes.
   let midCounter = 0;
-  const pendingMsgs = new Map(); // mid -> { statusEl, payload, timer }
+  const pendingMsgs = new Map(); // mid -> { statusEl, payload, raw, timer }
   const DELIVERY_TIMEOUT_MS = 7000;
 
   function newMid() {
@@ -2945,42 +2951,37 @@ function buildPanel() {
   function setMsgStatus(mid, state) {
     const statusEl = statusElFor(mid);
     const bubble = log.querySelector(`.cmcp-bubble.user[data-mid="${mid}"]`);
-    // Successful delivery needs no chrome — a normal bubble IS the "delivered"
-    // signal. We only surface a PROBLEM: a failed send tints the bubble (color)
-    // and exposes ✎ edit (pull text back to the composer) + ✕ delete, so a
-    // dropped message never silently vanishes.
-    if (state === "sending") {
-      bubble?.classList.remove("failed");
-      statusEl?.replaceChildren(); // empty → hidden via :empty
-      return;
-    }
-    if (state === "seen") {
-      bubble?.classList.remove("failed");
+    if (state === "read") {
+      // The agent dequeued it → normal bubble, no chrome.
+      bubble?.classList.remove("queued", "failed");
       statusEl?.remove();
       return;
     }
-    if (state === "failed") {
-      bubble?.classList.add("failed");
-      if (!statusEl) return;
-      statusEl.className = "cmcp-msg-status failed";
-      statusEl.replaceChildren(
-        iconAction("pi-pencil", "Edit — bring back to the composer", () => editMsg(mid)),
-        iconAction("pi-times", "Delete this message", () => deleteMsg(mid)),
-      );
-    }
+    // queued (muted) or failed (red): tint the bubble + expose ✎/✕. The agent
+    // hasn't read it yet, so editing/deleting just yanks it from the queue.
+    bubble?.classList.toggle("queued", state === "queued");
+    bubble?.classList.toggle("failed", state === "failed");
+    if (!statusEl) return;
+    statusEl.className = "cmcp-msg-status " + state;
+    statusEl.replaceChildren(
+      iconAction("pi-pencil", "Edit — pull back to the composer", () => editMsg(mid)),
+      iconAction("pi-times", "Cancel this message", () => deleteMsg(mid)),
+    );
   }
 
-  /** ✎ on a not-yet-answered message: retract it and drop the text back into the
-   *  composer to edit & resend (interrupting the turn if it already started). */
+  /** Tell the orchestrator to drop a still-queued message from the agent's queue
+   *  (no-op server-side if it was already read or never received). */
+  function cancelOnServer(mid) {
+    client?.sendFrame?.({ type: "cancel_message", mid });
+  }
+
+  /** ✎ a queued/failed message: yank it from the queue and drop its text back in
+   *  the composer to edit & resend. */
   function editMsg(mid) {
     const entry = pendingMsgs.get(mid);
     const bubble = log.querySelector(`.cmcp-bubble.user[data-mid="${mid}"]`);
     const raw = entry?.raw ?? bubble?.textContent ?? "";
-    if (thinkingEl) {
-      client?.sendFrame?.({ type: "interrupt" });
-      hideThinking();
-    }
-    deleteMsg(mid); // removes bubble + status + trailing record
+    deleteMsg(mid); // cancels on server + removes bubble + trailing record
     setComposerValue(raw);
     input.focus();
   }
@@ -3001,20 +3002,31 @@ function buildPanel() {
     else armDeliveryTimeout(mid);
   }
 
-  function markSeen(mid) {
+  /** Receipt ack (orchestrator got it): not dropped → cancel the failure timer.
+   *  Still QUEUED until the agent reads it (the "seen" ack). */
+  function markReceived(mid) {
     const entry = pendingMsgs.get(mid);
-    if (!entry) return;
-    if (entry.timer) clearTimeout(entry.timer);
+    if (entry?.timer) {
+      clearTimeout(entry.timer);
+      entry.timer = null;
+    }
+  }
+
+  /** Read ack (agent dequeued it): flip to read state. */
+  function markRead(mid) {
+    const entry = pendingMsgs.get(mid);
+    if (entry?.timer) clearTimeout(entry.timer);
     pendingMsgs.delete(mid);
-    setMsgStatus(mid, "seen");
+    setMsgStatus(mid, "read");
   }
 
   function deleteMsg(mid) {
     const entry = pendingMsgs.get(mid);
     if (entry?.timer) clearTimeout(entry.timer);
     pendingMsgs.delete(mid);
+    cancelOnServer(mid); // drop it from the agent's queue if still there
     for (const el of log.querySelectorAll(`[data-mid="${mid}"]`)) el.remove();
-    // An undelivered message was never answered, so it's the trailing record.
+    // A queued/undelivered message was never answered → it's the trailing record.
     const msgs = thread?.msgs;
     if (msgs && msgs.length && msgs[msgs.length - 1].role === "user") {
       msgs.pop();
@@ -3532,10 +3544,15 @@ function buildPanel() {
       applyModelCatalog(list);
     },
     onAck(ack) {
-      // Delivery confirmation: the orchestrator received this message → mark its
-      // bubble "✓ Seen". (No mid = an internal nudge send; nothing to mark.)
+      // Receipt: orchestrator got it (not dropped) → cancel the failure timer.
+      // The bubble stays QUEUED (muted) until the agent actually reads it.
       if (ack?.kind === "working" && typeof ack.mid === "string") {
-        markSeen(ack.mid);
+        markReceived(ack.mid);
+        return;
+      }
+      // Read: the agent dequeued this message → flip its bubble to read (normal).
+      if (ack?.kind === "seen" && typeof ack.mid === "string") {
+        markRead(ack.mid);
         return;
       }
       // Effort change while the agent was mid-turn: it can't change a running
@@ -4293,7 +4310,7 @@ function buildPanel() {
     const freshChat = !thread;
     const mid = newMid();
     const painted = appendUser(text, { mid });
-    setMsgStatus(mid, "sending");
+    setMsgStatus(mid, "queued"); // muted + ✎/✕ until the agent actually reads it
     showThinking();
     input.value = "";
     input.style.height = "auto";

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1189,9 +1189,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
       } catch {
         return;
       }
-      // Any inbound frame proves the backend is alive and talking — feed the
-      // health watchdog so it only ever fires on TRUE silence.
-      if (msg) onActivity?.();
+      // Feed the health watchdog (it decides what counts as the agent actually
+      // responding vs. a bare receipt ack).
+      if (msg) onActivity?.(msg);
       if (msg && typeof msg.rid === "string" && typeof msg.cmd === "string") {
         // Agent command — execute against the graph, reply with the rid.
         // Executors may be async (run, save) — await uniformly.
@@ -3459,10 +3459,15 @@ function buildPanel() {
   // ---- agent-health watchdog -------------------------------------------------
   // Detect a wedged/unresponsive agent backend (e.g. the Agent-SDK shell dying
   // after a re-auth) and offer one-click recovery, so a user is never stuck
-  // reaching for Task Manager. Purely passive: ANY inbound frame counts as
-  // "alive" (noteAgentActivity), so the banner only appears on TRUE silence
-  // after a message was actually sent — a busy agent streams thinking/text and
-  // keeps resetting the clock.
+  // reaching for Task Manager.
+  //
+  // We only watch the window between "user sent a message" (startAwaiting) and
+  // "the agent produced its FIRST real output" — a stream delta, a reply, a tool
+  // call, or a question (stopAwaiting, called from those callbacks). That first
+  // output proves the backend is alive, so we stop watching and idle time can't
+  // trigger a false alarm. A bare "message received" ack does NOT count (that's
+  // exactly the wedge case: orchestrator alive, agent dead). If no real output
+  // arrives within the threshold, the recovery banner appears.
   const HEALTH_THRESHOLD_MS = 75000; // silence-while-awaiting before we flag it
   const HEALTH_TICK_MS = 10000;
   let lastAgentActivityAt = Date.now();
@@ -3484,7 +3489,12 @@ function buildPanel() {
   bannerRestart.style.cssText = "padding:0.2rem 0.55rem;font-size:0.72rem;white-space:nowrap;";
   bannerRestart.addEventListener("click", () => hardRestart("watchdog"));
   const bannerDismiss = iconBtn("pi-times", "Dismiss");
-  bannerDismiss.addEventListener("click", () => hideUnresponsive());
+  // Dismiss must STICK: also stop awaiting so the 10s timer can't re-show it.
+  // (The next message you send re-arms the watchdog via startAwaiting.)
+  bannerDismiss.addEventListener("click", () => {
+    stopAwaiting();
+    hideUnresponsive();
+  });
   unresponsiveBanner.append(bannerText, bannerRestart, bannerDismiss);
   header.insertAdjacentElement("afterend", unresponsiveBanner);
 
@@ -3590,8 +3600,17 @@ function buildPanel() {
         stopAwaiting(); // reply landed — stand the watchdog down
       }
     },
-    onActivity() {
-      noteAgentActivity();
+    onActivity(msg) {
+      noteAgentActivity(); // any frame: reset the clock + hide the banner
+      // A SUBSTANTIVE response proves the agent is alive AND answering, so stop
+      // watching this send — idle time afterward must not raise a false alarm. A
+      // bare receipt ack ({type:"ack"}) is NOT substantive: that's exactly the
+      // wedge case (orchestrator alive, agent dead), so it must keep us watching.
+      const t = msg && msg.type;
+      const isToolCall = msg && typeof msg.rid === "string" && typeof msg.cmd === "string";
+      if (isToolCall || t === "say" || t === "stream" || t === "turn" || t === "thinking") {
+        stopAwaiting();
+      }
     },
     onLog(text) {
       appendSystem(text);
@@ -3856,11 +3875,15 @@ function buildPanel() {
   }
 
   // Hard restart: recover a wedged/unresponsive agent. Unlike soft reload (which
-  // bounces the orchestrator in place to pick up new code), this kills the
-  // orchestrator AND its whole child tree — clearing a dead Agent-SDK shell that
-  // an in-place reload can't — then respawns a clean one. Runs entirely over the
-  // Python /hard_restart route, so it works even when the agent isn't answering.
-  // The conversation resumes afterward via the persisted session id.
+  // bounces the orchestrator in place and RESUMES, to pick up new code), this
+  // kills the orchestrator AND its whole child tree — clearing a dead Agent-SDK
+  // shell that an in-place reload can't — then respawns and starts a FRESH
+  // session. Resuming would defeat the purpose: a dead tool-subprocess handle is
+  // checkpointed into the session, so resume faithfully restores the corpse and
+  // re-wedges. Fresh = a brand-new shell that works. The chat history stays
+  // visible; the agent's memory resets (an acceptable trade to get it working).
+  // Runs entirely over the Python /hard_restart route, so it works even when the
+  // agent isn't answering.
   async function hardRestart(origin = "user") {
     if (reloading) return;
     reloading = true;
@@ -3891,13 +3914,17 @@ function buildPanel() {
       reloading = false;
       restartBtn.classList.remove("cmcp-spin");
     }
-    // On success, arm the resume so the fresh orchestrator continues the thread —
-    // origin-aware like softReload: a watchdog/mid-task restart wants the agent
-    // continuation nudge ("agent"), a manual click just resumes ("user").
-    if (ok) ssSet(SOFT_RELOAD_KEY, origin === "user" ? "user" : "agent");
+    if (ok) {
+      // Start FRESH on reconnect: clear the saved session id so hello sends no
+      // resume (resuming would restore the wedged shell). Don't arm the resume
+      // nudge. The reconnect spins up a brand-new agent.
+      ssSet(SESSION_KEY, null);
+      ssSet(SOFT_RELOAD_KEY, null);
+      ssSet(MID_TASK_KEY, null);
+      appendSystem("Agent restarted with a fresh session — your message history is still here.");
+    }
     // Reconnect EITHER WAY: on success to the fresh orchestrator, on failure to
-    // restore the bridge we dropped (the old backend may still be intact, and the
-    // session resumes via the normal hello.resume path).
+    // restore the bridge we dropped (the old backend may still be intact).
     client.start();
   }
 


### PR DESCRIPTION
# rd3: SDK slash commands, one-click recovery, delivery status (v0.1.3)

Round 3 panel work on `feat/3-agent-barley-smash-rd3`.

## Highlights
- **SDK slash commands** in the composer `/` menu (`/compact`, `/loop`, …) + panel commands (`/reload`, `/reload-ui`, `/restart`).
- **`/restart` — one-click recovery** for a wedged agent: kills the orchestrator + its child tree (clears a dead Agent-SDK shell), starts a **fresh** session. Pure-Python route, works even when the agent isn't answering.
- **Pid-reuse-safe kill** — identity re-verified before every signal (orchestrator + each child).
- **Per-message delivery status** (queued → seen) with edit/cancel; **live download-progress** tray.
- **Subgraph authoring** (promote/retract inner widgets, node-title rename, workflow tabs, Manager install→restart→resume).
- **Deferred extension registration** (Vite/Rolldown deadlock) — adapted from a community PR, thanks **@FreesoSaiFared**.
- Header trimmed: reload/restart are slash commands now (no buttons, no auto-banner).

## Release
- Comfy Registry `comfyui-agent-panel` **0.1.3** (auto-publishes on the pyproject bump after merge). License in the correct `{ file = "LICENSE" }` form.

## Verification
- `node --check web/js/comfyui-mcp-panel.js` ✓ · `py_compile __init__.py` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
