### PR TITLE
Release 0.2.0 — rewind/rollback, pending tray + reorder, spatial layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,25 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-19
+
 ### Added
 
+- **Rewind & rollback (#44).** A hover ✎ on any past message opens a rollback modal
+  to undo **code**, **conversation**, or **both** and resend an edited message —
+  graph reverts via per-turn snapshots, conversation rewinds via `forkSession`.
+  **`/revert`** undoes the last turn's graph edits, and a quick **double-Esc** in
+  the composer rewinds your last turn (revert graph + recall the message to edit).
+- **Pending-message tray.** Messages sent while the agent is busy now wait in a
+  fixed **Pending** tray above downloads (out of the chat flow), each with
+  **edit / send-now / delete**. **Send-now** interrupts the current turn (steer);
+  **drag the ≡ handle** to reorder how the agent flushes them. When the agent
+  dequeues a message it **materializes at the bottom of the chat** — so the chat
+  reads in the exact order Claude processes them.
+- **Spatial layout control.** The agent can now see and arrange the canvas: reads
+  include node positions/sizes and subgraph I/O rails; it can move rails, create
+  and edit groups, collapse/recolor nodes, and **screenshot** the canvas to verify
+  its own layout (with the "expose inputs/outputs" rule baked into a skill).
 - **Attach more than images.** The composer's attach button, drag-drop, and paste
   now accept **video**, **workflows (`.json`)**, and **text files** alongside
   images. Images and video upload into ComfyUI's `input/` folder (video is
@@ -16,6 +33,17 @@ All notable changes to this project are documented here. This project adheres to
   to the agent (a recognized ComfyUI graph is flagged so it can load/analyze/merge
   it). Each file drops a typed chip — `[Image #N]` / `[Video #N]` / `[Workflow #N]`
   / `[File #N]` — and the picker accepts multiple files at once.
+
+### Fixed
+
+- **Reconnect durability.** Connect now reclaims a lockfile-less orchestrator
+  "zombie" (alive but no longer serving the bridge) that would otherwise survive
+  reloads and a full ComfyUI restart and block reconnection — it finds the port
+  owner, and if it's our orchestrator, kills its tree and respawns a clean one.
+- **Rollback anchor stability** — the rewind anchor is stored as the turn's UUID in
+  the message's own handler (not an array index), so a bounded-history eviction
+  can't point a rollback at the wrong turn.
+- **Save-card** rendering fix.
 
 ## [0.1.3] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- **Attach more than images.** The composer's attach button, drag-drop, and paste
+  now accept **video**, **workflows (`.json`)**, and **text files** alongside
+  images. Images and video upload into ComfyUI's `input/` folder (video is
+  delivered as an `input/` path the agent can wire into a Load Video node, since
+  it can't be viewed inline); workflow `.json` and text files are read and inlined
+  to the agent (a recognized ComfyUI graph is flagged so it can load/analyze/merge
+  it). Each file drops a typed chip — `[Image #N]` / `[Video #N]` / `[Workflow #N]`
+  / `[File #N]` — and the picker accepts multiple files at once.
+
 ## [0.1.3] - 2026-06-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ edit exactly like your own.
 | `panel_enter_subgraph` | Drill into a subgraph to read/edit its inner nodes |
 | `panel_exit_subgraph` | Return to the parent / root graph |
 
+**Spatial layout** — the agent sees node positions/sizes + subgraph rails and arranges the canvas
+
+| Tool | Effect |
+|---|---|
+| `panel_move_rail` | Move a subgraph's input / output rail so boundary wires stay short |
+| `panel_create_group` / `panel_move_group` / `panel_edit_group` / `panel_remove_group` | Create, move, retitle/recolor, or delete a labeled group box |
+| `panel_set_node_color` | Color-code a node (named LiteGraph preset or hex) |
+| `panel_set_node_collapsed` | Collapse / expand a node to a title chip |
+| `panel_screenshot` | Render the canvas to a PNG so the agent can verify its own layout |
+
 **Workflow tabs**
 
 | Tool | Effect |
@@ -144,6 +154,27 @@ edit exactly like your own.
 
 …plus the full comfyui-mcp tool surface (88 tools: queue, models, custom
 nodes, workflows) — the agent is the MCP client, so it has everything.
+
+## Working in the panel
+
+- **Rewind & rollback.** Hover any past message for a **✎ edit** button that
+  opens a modal to roll back **code** (the graph), **conversation**
+  (fork the session), or **both**, then resend an edited message. Plus
+  **`/revert`** (undo the last turn's graph edits) and **double-Esc** (quick
+  last-turn rewind — revert the graph and recall the message to edit). Graph
+  reverts use per-turn snapshots.
+- **Pending-message tray.** Messages sent while the agent is busy wait in a
+  fixed **Pending** tray above the downloads tray — each with edit / send-now /
+  delete buttons. **Send-now** interrupts the current turn to steer it; a drag
+  handle (≡) reorders how the agent flushes them. On dequeue a message
+  materializes at the **bottom** of the chat, so it flows in the exact order
+  Claude processes it.
+- **Destructive-op confirmation.** `panel_clear` and `panel_restart_comfyui`
+  pop a yes / no card and only act on **yes**.
+- **Reconnect durability.** A wedged orchestrator no longer strands the panel —
+  **Connect** reclaims a zombie that still holds the bridge port.
+- **Richer composer attachments.** Attach, drag, or paste **images, video,
+  workflow `.json`, and text** files into the composer.
 
 ## Security notes
 

--- a/__init__.py
+++ b/__init__.py
@@ -349,6 +349,28 @@ def _delete_lock():
         pass
 
 
+def _port_owner_pid(host, port):
+    """Pid LISTENING on (host, port), or None. psutil-only. Lets us identify a
+    lockfile-less zombie squatting the bridge port so Connect can reclaim it."""
+    try:
+        import psutil  # type: ignore
+
+        for c in psutil.net_connections(kind="inet"):
+            try:
+                if (
+                    c.status == psutil.CONN_LISTEN
+                    and c.laddr
+                    and int(c.laddr.port) == int(port)
+                    and c.pid
+                ):
+                    return c.pid
+            except Exception:
+                continue
+    except Exception:
+        return None
+    return None
+
+
 def _start_orchestrator():
     """Start the panel orchestrator on demand. Returns (ok: bool, message: str).
 
@@ -361,48 +383,58 @@ def _start_orchestrator():
         lock = _read_lock()
         parent = lock.get("parent") if lock else None
         opid = lock.get("pid") if lock else None
-        ours = _lock_parent_is_current(lock) and _pid_alive(opid)
-        if ours:
+        # Healthy + ours (our ComfyUI launched it and its pid is alive) → reuse.
+        if lock and _lock_parent_is_current(lock) and _pid_alive(opid):
             return True, "already running"
-        # Replace ONLY a clear orphan: an orchestrator whose launching ComfyUI
-        # (a DIFFERENT pid) is now dead but which still squats the bridge port.
-        # Anything else (user-run orchestrator, another live ComfyUI, or a
-        # pre-lockfile build with no lockfile) is left alone — reuse it.
-        orphan = _lock_parent_is_gone(lock)
-        if not (orphan and not _no_autospawn()):
-            if not lock:
-                # Port held but NO orchestrator lockfile — a foreign process is
-                # squatting it. Do NOT claim "already running": the panel would
-                # attach to a non-agent ("connected but dead"). Surface it instead.
-                return False, (
-                    "the panel bridge port {} is held by another process that isn't a panel "
-                    "orchestrator. Close it, or set COMFYUI_MCP_BRIDGE_PORT to a free port.".format(_BRIDGE_PORT)
-                )
-            if parent and parent != os.getpid() and not orphan:
+
+        # Otherwise the port is held by something that isn't a healthy orchestrator
+        # of ours. Decide whether to RECLAIM it (kill + respawn) or bail. Reclaim
+        # only a process we can VERIFY is a panel orchestrator (cmdline check), so
+        # a genuinely foreign squatter is never killed.
+        reclaim_pid = None
+        reclaim_started = None
+        if lock and _pid_alive(opid) and _is_orchestrator_process(opid):
+            if parent and parent != os.getpid() and not _lock_parent_is_gone(lock):
+                # A different, still-live ComfyUI owns it — leave it alone.
                 return False, (
                     "the panel bridge port {} is owned by another live ComfyUI "
                     "(pid {}). Close it or set COMFYUI_MCP_BRIDGE_PORT to a "
                     "different port for this instance.".format(_BRIDGE_PORT, parent)
                 )
-            return True, "already running"
-        _log(
-            "replacing orphaned orchestrator pid {} (its ComfyUI {} is gone)".format(opid, parent)
-        )
-        # Kill ONLY if it's verifiably our orchestrator — never a reused pid.
-        # _kill_pid re-verifies (cmdline + the recorded creation time) right
-        # before it signals, so a pid recycled to an unrelated process is spared.
-        if opid and _is_orchestrator_process(opid):
-            _kill_pid(opid, lock.get("pidStartedAt"))
-        for _ in range(20):
-            if not _port_in_use(_BRIDGE_HOST, _BRIDGE_PORT):
-                break
-            time.sleep(0.1)
-        if _port_in_use(_BRIDGE_HOST, _BRIDGE_PORT):
-            return False, (
-                "the panel bridge port {} is still held by the previous session and "
-                "couldn't be freed — fully restart ComfyUI.".format(_BRIDGE_PORT)
-            )
-        # Port freed — fall through and spawn a fresh orchestrator.
+            # Our orchestrator but not healthy (orphaned ComfyUI, or wedged) → reclaim.
+            reclaim_pid, reclaim_started = opid, lock.get("pidStartedAt")
+        else:
+            # No (valid) lockfile, or its pid is dead, but the port is held. Find
+            # the actual port owner: a lockfile-less panel-orchestrator ZOMBIE (the
+            # "won't reconnect" bug) gets reclaimed; a truly foreign process is left.
+            owner = _port_owner_pid(_BRIDGE_HOST, _BRIDGE_PORT)
+            if owner and _is_orchestrator_process(owner):
+                reclaim_pid = owner
+            elif owner:
+                return False, (
+                    "the panel bridge port {} is held by another process that isn't a "
+                    "panel orchestrator. Close it, or set COMFYUI_MCP_BRIDGE_PORT to a "
+                    "free port.".format(_BRIDGE_PORT)
+                )
+            # owner unknown (couldn't read) → fall through; the bind will fail loudly
+            # if the port really is still held.
+
+        if reclaim_pid is not None:
+            if _no_autospawn():
+                return True, "reconnecting to your orchestrator"  # user-managed; don't kill
+            _log("reclaiming panel bridge port {} from orchestrator pid {}".format(_BRIDGE_PORT, reclaim_pid))
+            _kill_orchestrator_tree(reclaim_pid, reclaim_started)
+            _delete_lock()
+            for _ in range(20):
+                if not _port_in_use(_BRIDGE_HOST, _BRIDGE_PORT):
+                    break
+                time.sleep(0.1)
+            if _port_in_use(_BRIDGE_HOST, _BRIDGE_PORT):
+                return False, (
+                    "the panel bridge port {} is still held and couldn't be freed — "
+                    "fully restart ComfyUI.".format(_BRIDGE_PORT)
+                )
+        # Port freed (or never really held) — fall through and spawn a fresh one.
 
     if _no_autospawn():
         return False, (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "AI agent sidebar for ComfyUI — an autonomous background agent drives your graph, running on your Claude subscription with no API keys. Add, wire, move and tweak nodes live with full Ctrl+Z undo, generate images, video and audio, and run your workflow. Click Connect to start the agent. Part of the comfyui-mcp project."
-version = "0.1.3"
+version = "0.2.0"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -461,10 +461,8 @@ function captureGraphSnapshot(mid, label) {
   }
 }
 
-// Restore the canvas to the most recent pre-turn snapshot (undo the last turn's
-// edits). Returns the restored snapshot, or null if none / restore failed.
-function revertGraphToLastSnapshot() {
-  const snap = graphSnapshots[graphSnapshots.length - 1];
+// Restore the canvas to a given snapshot. Returns the snapshot, or null on fail.
+function restoreSnapshot(snap) {
   if (!snap) return null;
   try {
     // Deep-clone so the stored snapshot isn't mutated by the live graph after load.
@@ -473,6 +471,20 @@ function revertGraphToLastSnapshot() {
   } catch {
     return null;
   }
+}
+
+// Restore the canvas to the most recent pre-turn snapshot (undo the last turn's edits).
+function revertGraphToLastSnapshot() {
+  return restoreSnapshot(graphSnapshots[graphSnapshots.length - 1]);
+}
+
+// Restore the canvas to the snapshot captured before the message with this mid
+// (the per-message rollback). Returns the snapshot or null.
+function revertGraphSnapshotByMid(mid) {
+  for (let i = graphSnapshots.length - 1; i >= 0; i--) {
+    if (graphSnapshots[i].mid === mid) return restoreSnapshot(graphSnapshots[i]);
+  }
+  return null;
 }
 
 /** Summarize one LiteGraph node for the agent — id, type, title, widget
@@ -1152,7 +1164,7 @@ const GRAPH_TOOL_EXECUTORS = {
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 15000;
 
-function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk, onSecret, onReload, onTodo, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onAck, onTurn, getResume }) {
+function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk, onSecret, onReload, onTodo, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onAck, onTurn, onTurnAnchor, getResume }) {
   let sock = null;
   let url = loadBridgeUrl();
   let closed = false;
@@ -1295,6 +1307,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
       // on a reset) so the panel can persist it and resume across reloads.
       if (msg && msg.type === "session") {
         onSession?.(typeof msg.session_id === "string" ? msg.session_id : null);
+      }
+      // Per-turn rewind anchor (assistant UUID) → the panel stores it so a
+      // later "rewind conversation to here" can fork the session at that point.
+      if (msg && msg.type === "turn_anchor" && typeof msg.uuid === "string") {
+        onTurnAnchor?.(msg.uuid);
       }
       // Live model catalog from the orchestrator (SDK-probed). This is also the
       // orchestrator HANDSHAKE — receiving it proves a real panel agent is behind
@@ -1489,6 +1506,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
 const PANEL_CSS = `
 .cmcp-root {
   display: flex; flex-direction: column; height: 100%; min-height: 0;
+  position: relative; /* positioning context for the rollback modal overlay */
   font-family: var(--font-inter, "Inter", ui-sans-serif, system-ui, sans-serif);
   font-size: 0.8125rem; line-height: 1.5;
   color: var(--p-text-color, #fff);
@@ -1592,9 +1610,43 @@ const PANEL_CSS = `
 @keyframes cmcp-in { from { opacity: 0; transform: translateY(4px); } }
 .cmcp-bubble.user {
   align-self: flex-end;
+  position: relative; /* anchor for the absolute hover edit button (no reflow) */
   background: var(--p-highlight-background, rgba(96,165,250,0.16));
   border: 1px solid color-mix(in srgb, var(--p-primary-color, #60a5fa), transparent 70%);
 }
+/* Hover edit/rollback button — absolute to the LEFT so it never reflows text. */
+.cmcp-edit-btn {
+  position: absolute; left: -1.75rem; top: 0.1rem;
+  width: 1.4rem; height: 1.4rem; padding: 0; border-radius: 5px;
+  display: flex; align-items: center; justify-content: center;
+  border: 1px solid var(--p-content-border-color, #3f3f46);
+  background: var(--p-surface-800, #27272a); color: var(--p-text-muted-color, #a1a1aa);
+  cursor: pointer; opacity: 0; transition: opacity 0.12s, color 0.12s; font-size: 0.7rem;
+}
+.cmcp-bubble.user:hover .cmcp-edit-btn { opacity: 1; }
+.cmcp-edit-btn:hover { color: var(--p-primary-color, #60a5fa); border-color: var(--p-primary-color, #60a5fa); }
+/* Rollback modal */
+.cmcp-modal-overlay {
+  position: absolute; inset: 0; z-index: 50; display: flex; align-items: center;
+  justify-content: center; padding: 1rem; background: rgba(0,0,0,0.45);
+}
+.cmcp-modal {
+  width: 100%; max-width: 22rem; display: flex; flex-direction: column; gap: 0.6rem;
+  padding: 0.85rem; border-radius: 10px; background: var(--p-surface-900, #18181b);
+  border: 1px solid var(--p-content-border-color, #3f3f46); box-shadow: 0 8px 30px rgba(0,0,0,0.5);
+}
+.cmcp-modal-title { font-weight: 600; font-size: 0.85rem; }
+.cmcp-modal-text {
+  width: 100%; box-sizing: border-box; resize: vertical; min-height: 3.5rem;
+  padding: 0.4rem 0.5rem; border-radius: 6px; font: inherit; font-size: 0.8rem;
+  background: var(--p-surface-950, #111113); color: inherit;
+  border: 1px solid var(--p-surface-500, #555);
+}
+.cmcp-modal-scopes { display: flex; flex-direction: column; gap: 0.3rem; }
+.cmcp-modal-scope { display: flex; gap: 0.4rem; align-items: flex-start; font-size: 0.72rem; cursor: pointer; }
+.cmcp-modal-scope input { margin-top: 0.15rem; }
+.cmcp-modal-btns { display: flex; justify-content: flex-end; gap: 0.4rem; }
+.cmcp-btn-primary { background: var(--p-primary-color, #3a7bd5); color: #fff; border: none; }
 /* Agent text flows freely — no card/bubble. Only user messages are boxed. */
 .cmcp-bubble.agent {
   align-self: stretch; max-width: 100%;
@@ -2658,6 +2710,18 @@ function buildPanel() {
     b.className = "cmcp-bubble user";
     b.textContent = text;
     if (opts.mid) b.dataset.mid = opts.mid;
+    // Hover edit/rollback button — only on live messages (those with a mid).
+    // Absolute-positioned to the LEFT of the bubble so it never causes reflow.
+    if (opts.mid) {
+      const edit = document.createElement("button");
+      edit.type = "button";
+      edit.className = "cmcp-edit-btn";
+      edit.title = "Edit & roll back from this message";
+      edit.innerHTML = '<i class="pi pi-pencil"></i>';
+      const anchorIdx = typeof opts.anchorIdx === "number" ? opts.anchorIdx : 0;
+      edit.addEventListener("click", () => openRollbackModal({ mid: opts.mid, text, anchorIdx }));
+      b.appendChild(edit);
+    }
     log.appendChild(b);
     // Live sends get a delivery-status line below the bubble (sending → seen, or
     // failed with resend/delete). Replayed history has no mid → no status.
@@ -2968,7 +3032,9 @@ function buildPanel() {
   function appendUser(text, opts = {}) {
     stickToBottom = true; // your own message → always jump to the latest
     newMsgBtn.hidden = true;
-    const painted = paintUser(text, opts);
+    // Record how many turn anchors exist now, so a rewind to this message forks
+    // the conversation at turnAnchors[anchorIdx - 1].
+    const painted = paintUser(text, { ...opts, anchorIdx: turnAnchors.length });
     // Tag the record with its mid so deleteMsg can remove the EXACT message even
     // when several are queued (popping the trailing one would hit the wrong one).
     record({ role: "user", text, ...(opts.mid ? { mid: opts.mid } : {}) });
@@ -3279,6 +3345,7 @@ function buildPanel() {
 
   function newChat() {
     thread = null;
+    turnAnchors = []; // fresh conversation → no rewind anchors
     ssSet(CURRENT_THREAD_KEY, null);
     ssSet(SESSION_KEY, null);
     ssSet(CTX_KEY, null);
@@ -3507,6 +3574,11 @@ function buildPanel() {
   // skills), pushed by the orchestrator — surfaced in the completion menu below.
   let sdkCommands = [];
 
+  // Per-turn conversation rewind anchors (assistant UUIDs), in order. A user
+  // message records how many anchors existed when it was sent, so a rewind to
+  // that message forks the session at turnAnchors[recorded-1]. Reset on new chat.
+  let turnAnchors = [];
+
   // ---- bridge wiring ----
   const client = createBridgeClient({
     onStatus(state) {
@@ -3611,6 +3683,10 @@ function buildPanel() {
     },
     onSession(sessionId) {
       bindSession(sessionId);
+    },
+    onTurnAnchor(uuid) {
+      turnAnchors.push(uuid);
+      if (turnAnchors.length > 200) turnAnchors.shift();
     },
     onModels(list) {
       applyModelCatalog(list);
@@ -4576,6 +4652,96 @@ function buildPanel() {
     } else {
       appendSystem("Nothing to rewind yet — no message/graph snapshot from this session.");
     }
+  }
+
+  // Per-message rollback modal (edit button on a user bubble). Edit the message
+  // and choose what to roll back — code (revert the canvas to before it),
+  // conversation (fork the agent's memory at that point), or both — then resend.
+  function openRollbackModal({ mid, text, anchorIdx }) {
+    const anchor = anchorIdx > 0 ? turnAnchors[anchorIdx - 1] ?? null : null;
+    const overlay = document.createElement("div");
+    overlay.className = "cmcp-modal-overlay";
+    const modal = document.createElement("div");
+    modal.className = "cmcp-modal";
+    const title = document.createElement("div");
+    title.className = "cmcp-modal-title";
+    title.textContent = "Roll back & edit";
+    const ta = document.createElement("textarea");
+    ta.className = "cmcp-modal-text";
+    ta.rows = 3;
+    ta.value = text;
+    const scopeWrap = document.createElement("div");
+    scopeWrap.className = "cmcp-modal-scopes";
+    let chosen = "both";
+    const scopes = [
+      { v: "both", label: "Code + conversation", hint: "revert the canvas AND rewind the agent's memory" },
+      { v: "code", label: "Code only", hint: "revert the canvas; keep the conversation" },
+      { v: "conversation", label: "Conversation only", hint: "rewind the agent's memory; keep the canvas" },
+    ];
+    for (const s of scopes) {
+      const lbl = document.createElement("label");
+      lbl.className = "cmcp-modal-scope";
+      const r = document.createElement("input");
+      r.type = "radio";
+      r.name = "cmcp-rollback-scope";
+      r.value = s.v;
+      if (s.v === chosen) r.checked = true;
+      r.addEventListener("change", () => {
+        chosen = s.v;
+      });
+      const span = document.createElement("span");
+      const strong = document.createElement("strong");
+      strong.textContent = s.label;
+      span.append(strong, document.createTextNode(` — ${s.hint}`));
+      lbl.append(r, span);
+      scopeWrap.appendChild(lbl);
+    }
+    const btnRow = document.createElement("div");
+    btnRow.className = "cmcp-modal-btns";
+    const cancel = document.createElement("button");
+    cancel.type = "button";
+    cancel.className = "cmcp-btn";
+    cancel.textContent = "Cancel";
+    const go = document.createElement("button");
+    go.type = "button";
+    go.className = "cmcp-btn cmcp-btn-primary";
+    go.textContent = "Roll back & resend";
+    const close = () => overlay.remove();
+    cancel.addEventListener("click", close);
+    overlay.addEventListener("mousedown", (e) => {
+      if (e.target === overlay) close();
+    });
+    go.addEventListener("click", () => {
+      const edited = ta.value.trim();
+      const wantCode = chosen === "code" || chosen === "both";
+      const wantConvo = chosen === "conversation" || chosen === "both";
+      if (wantCode) {
+        const snap = revertGraphSnapshotByMid(mid);
+        appendSystem(
+          snap
+            ? "↩ Canvas reverted to before this message."
+            : "No graph snapshot for this message — canvas left as-is.",
+        );
+      }
+      if (wantConvo) {
+        client.sendFrame?.({ type: "rewind", anchor });
+        appendSystem(
+          anchor
+            ? "↩ Rewound the conversation to before this message."
+            : "↩ Started a fresh conversation from this point.",
+        );
+      }
+      close();
+      if (edited) {
+        setComposerValue(edited);
+        form.requestSubmit();
+      }
+    });
+    btnRow.append(cancel, go);
+    modal.append(title, ta, scopeWrap, btnRow);
+    overlay.appendChild(modal);
+    root.appendChild(overlay);
+    setTimeout(() => ta.focus(), 0);
   }
 
   // ---- submit ----

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -513,6 +513,11 @@ function summarizeNode(node) {
     id: node.id,
     type: node.type,
     title: node.title,
+    pos: node.pos ? [Math.round(node.pos[0]), Math.round(node.pos[1])] : null,
+    size: node.size ? [Math.round(node.size[0]), Math.round(node.size[1])] : null,
+    ...(node.flags && node.flags.collapsed ? { collapsed: true } : {}),
+    ...(node.color ? { color: node.color } : {}),
+    ...(node.bgcolor ? { bgcolor: node.bgcolor } : {}),
     widgets,
     inputs,
     outputs,
@@ -596,6 +601,20 @@ function summarizeGroup(graph, g) {
   };
 }
 
+/** Describe a subgraph's input/output "rail" nodes (the boundary I/O proxies)
+ *  so layouts can sit nodes next to them instead of floating away. The exact
+ *  property name varies across ComfyUI versions, so probe the likely ones. */
+function describeRails(sub) {
+  const xy = (n) => (n?.pos ? [Math.round(n.pos[0]), Math.round(n.pos[1])] : null);
+  const wh = (n) => (n?.size ? [Math.round(n.size[0]), Math.round(n.size[1])] : null);
+  const inNode = sub.inputNode ?? sub._inputNode ?? null;
+  const outNode = sub.outputNode ?? sub._outputNode ?? null;
+  return {
+    input: inNode ? { pos: xy(inNode), size: wh(inNode) } : null,
+    output: outNode ? { pos: xy(outNode), size: wh(outNode) } : null,
+  };
+}
+
 /** Resolve a slot reference (name string or numeric index) to an index in
  *  the given slot array. Names are matched case-insensitively. */
 function resolveSlot(slots, ref, kind) {
@@ -630,15 +649,17 @@ let activePanelRoot = null;
 
 const GRAPH_TOOL_EXECUTORS = {
   graph_get_state() {
-    const { graph } = getGraphCtx();
+    const { graph, rootGraph } = getGraphCtx();
     const nodes = (graph._nodes ?? []).slice(0, MAX_STATE_NODES).map(summarizeNode);
     const groups = (graph._groups ?? []).map((g) => summarizeGroup(graph, g));
+    const inSubgraph = graph !== rootGraph;
     return {
       viewing: describeActiveGraph(graph),
       node_count: graph._nodes?.length ?? 0,
       truncated: (graph._nodes?.length ?? 0) > MAX_STATE_NODES,
       nodes,
       ...(groups.length ? { groups } : {}),
+      ...(inSubgraph ? { rails: describeRails(graph) } : {}),
     };
   },
 
@@ -1172,6 +1193,151 @@ const GRAPH_TOOL_EXECUTORS = {
     return { node_id: node.id, previous, title: node.title };
   },
 
+  // Collapse (minimize) or expand a node. `collapsed` defaults to true.
+  graph_set_node_collapsed({ node_id, collapsed }) {
+    const { graph } = getGraphCtx();
+    const node = resolveNode(graph, node_id);
+    const want = collapsed !== false;
+    graph.beforeChange?.();
+    try {
+      const isCollapsed = !!(node.flags && node.flags.collapsed);
+      if (isCollapsed !== want) {
+        if (typeof node.collapse === "function") node.collapse();
+        else {
+          node.flags = node.flags || {};
+          node.flags.collapsed = want;
+        }
+      }
+    } finally {
+      graph.afterChange?.();
+    }
+    graph.setDirtyCanvas?.(true, true);
+    return { node_id: node.id, collapsed: !!(node.flags && node.flags.collapsed) };
+  },
+
+  // Set a node's title-bar color and/or body color. Pass a `preset` name from
+  // LiteGraph's palette (red, brown, green, blue, pale_blue, cyan, purple,
+  // yellow, black) for matched title+body colors, or explicit `color` (title)
+  // and/or `bgcolor` (body) hex strings. Pass null for a field to clear it.
+  graph_set_node_color({ node_id, color, bgcolor, preset }) {
+    const { graph, LG } = getGraphCtx();
+    const node = resolveNode(graph, node_id);
+    graph.beforeChange?.();
+    try {
+      if (preset != null) {
+        const LGC = LG?.LGraphCanvas ?? window.LGraphCanvas ?? globalThis.LGraphCanvas;
+        const presets = LGC?.node_colors;
+        const p = presets && presets[preset];
+        if (!p) {
+          throw new Error(
+            `unknown color preset "${preset}" (available: ${presets ? Object.keys(presets).join(", ") : "none"})`,
+          );
+        }
+        node.color = p.color;
+        node.bgcolor = p.bgcolor;
+      } else {
+        if (color === null) delete node.color;
+        else if (color != null) node.color = String(color);
+        if (bgcolor === null) delete node.bgcolor;
+        else if (bgcolor != null) node.bgcolor = String(bgcolor);
+      }
+    } finally {
+      graph.afterChange?.();
+    }
+    graph.setDirtyCanvas?.(true, true);
+    return { node_id: node.id, color: node.color ?? null, bgcolor: node.bgcolor ?? null };
+  },
+
+  // Render the CURRENT graph view (root graph or the open subgraph) to a PNG and
+  // return it as base64 so the agent can SEE the layout. Temporarily fits the
+  // whole graph (nodes + groups) into the canvas, draws synchronously, captures,
+  // then restores the user's view. Output is capped to ~1600px wide.
+  graph_screenshot({ padding } = {}) {
+    const { graph, canvas } = getGraphCtx();
+    const cv = canvas?.canvas;
+    const ds = canvas?.ds;
+    if (!cv || typeof cv.toDataURL !== "function" || !ds) {
+      throw new Error("canvas not available for screenshot");
+    }
+    const nodes = graph._nodes ?? [];
+    const groups = graph._groups ?? [];
+    if (!nodes.length && !groups.length) throw new Error("nothing to screenshot (empty graph)");
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    for (const n of nodes) {
+      const br = n.boundingRect;
+      let x;
+      let y;
+      let w0;
+      let h0;
+      if (Array.isArray(br) && br.length === 4 && (br[2] || br[3])) {
+        [x, y, w0, h0] = br;
+      } else {
+        x = n.pos?.[0] ?? 0;
+        y = (n.pos?.[1] ?? 0) - 30; // title bar renders above pos
+        w0 = n.size?.[0] ?? 200;
+        h0 = (n.size?.[1] ?? 100) + 30;
+      }
+      minX = Math.min(minX, x);
+      minY = Math.min(minY, y);
+      maxX = Math.max(maxX, x + w0);
+      maxY = Math.max(maxY, y + h0);
+    }
+    for (const g of groups) {
+      const b = g._bounding;
+      if (b && b.length >= 4) {
+        minX = Math.min(minX, b[0]);
+        minY = Math.min(minY, b[1]);
+        maxX = Math.max(maxX, b[0] + b[2]);
+        maxY = Math.max(maxY, b[1] + b[3]);
+      }
+    }
+    const bounds = [minX, minY, maxX - minX, maxY - minY];
+    const pad = Number.isFinite(padding) ? Number(padding) : 60;
+    const saved = { scale: ds.scale, ox: ds.offset[0], oy: ds.offset[1] };
+    let dataUrl;
+    let outW = cv.width;
+    let outH = cv.height;
+    try {
+      const w = bounds[2] + pad * 2;
+      const h = bounds[3] + pad * 2;
+      const next = Math.min(cv.width / w, cv.height / h, 1.5);
+      ds.scale = next;
+      ds.offset[0] = -bounds[0] + pad + (cv.width / next - w) / 2;
+      ds.offset[1] = -bounds[1] + pad + (cv.height / next - h) / 2;
+      canvas.draw(true, true); // synchronous redraw at the fitted transform
+      const MAXW = 1600;
+      if (cv.width > MAXW) {
+        const s = MAXW / cv.width;
+        const off = document.createElement("canvas");
+        off.width = Math.round(cv.width * s);
+        off.height = Math.round(cv.height * s);
+        off.getContext("2d").drawImage(cv, 0, 0, off.width, off.height);
+        dataUrl = off.toDataURL("image/png");
+        outW = off.width;
+        outH = off.height;
+      } else {
+        dataUrl = cv.toDataURL("image/png");
+      }
+    } finally {
+      ds.scale = saved.scale;
+      ds.offset[0] = saved.ox;
+      ds.offset[1] = saved.oy;
+      canvas.setDirty?.(true, true);
+      canvas.draw?.(true, true);
+    }
+    const comma = dataUrl.indexOf(",");
+    return {
+      image: comma >= 0 ? dataUrl.slice(comma + 1) : dataUrl,
+      mimeType: "image/png",
+      width: outW,
+      height: outH,
+      viewing: describeActiveGraph(graph),
+    };
+  },
+
   // Navigate INTO a subgraph node so the canvas (and therefore every graph_*
   // editor) targets its inner graph — the way to read/edit nodes inside a
   // subgraph. Pair with graph_exit_subgraph to return to the root.
@@ -1198,6 +1364,32 @@ const GRAPH_TOOL_EXECUTORS = {
     canvas.setGraph(graph.rootGraph ?? rootGraph);
     canvas.setDirty?.(true, true);
     return { viewing: describeActiveGraph(getGraphCtx().graph) };
+  },
+
+  // Reposition a subgraph's input/output RAIL (the boundary I/O node). Must run
+  // INSIDE the subgraph (graph_enter_subgraph first). Lets a layout place the
+  // input rail just left of the first column and the output rail just right of
+  // the last one, so boundary wires stay short — read current rail positions
+  // from graph_get_state's `rails` field.
+  graph_move_rail({ rail, pos }) {
+    const { graph, rootGraph } = getGraphCtx();
+    if (graph === rootGraph) {
+      throw new Error("graph_move_rail must run INSIDE a subgraph — call graph_enter_subgraph first");
+    }
+    const node =
+      rail === "input" ? (graph.inputNode ?? graph._inputNode) :
+      rail === "output" ? (graph.outputNode ?? graph._outputNode) :
+      null;
+    if (!node) throw new Error(`subgraph has no "${rail}" rail — use rail "input" or "output"`);
+    if (!Array.isArray(pos) || pos.length !== 2) throw new Error("pos must be [x, y]");
+    graph.beforeChange?.();
+    try {
+      node.pos = [Number(pos[0]), Number(pos[1])];
+    } finally {
+      graph.afterChange?.();
+    }
+    graph.setDirtyCanvas?.(true, true);
+    return { rail, pos: [Math.round(node.pos[0]), Math.round(node.pos[1])] };
   },
 
   // Promote (or demote) an INNER subgraph widget so it appears on the PARENT
@@ -2209,6 +2401,17 @@ function describeCommand(cmd, msg, reply) {
       return { icon: "pi-pencil", text: `Edited group ${r.group?.id} (“${r.group?.title}”)` };
     case "graph_remove_group":
       return { icon: "pi-minus-circle", text: `Removed group “${r.removed?.title}”` };
+    case "graph_move_rail":
+      return { icon: "pi-arrows-h", text: `Moved ${r.rail} rail to [${r.pos?.map(Math.round)}]` };
+    case "graph_set_node_collapsed":
+      return {
+        icon: r.collapsed ? "pi-chevron-right" : "pi-chevron-down",
+        text: `${r.collapsed ? "Collapsed" : "Expanded"} node ${r.node_id}`,
+      };
+    case "graph_set_node_color":
+      return { icon: "pi-palette", text: `Recolored node ${r.node_id}` };
+    case "graph_screenshot":
+      return { icon: "pi-camera", text: `Captured workflow image (${r.width}×${r.height})` };
     case "graph_canvas":
       return { icon: "pi-window-maximize", text: `Canvas: ${r.canvas?.action?.replace(/_/g, " ")}` };
     case "graph_run":
@@ -2227,7 +2430,7 @@ function describeCommand(cmd, msg, reply) {
     case "workflow_save":
       return { icon: "pi-save", text: `Saved “${r.workflow}”` };
     case "workflow_save_as":
-      return { icon: "pi-save", text: `Saved as ${r.saved_as}` };
+      return { icon: "pi-save", text: `Saved as “${r.workflow}”` };
     default:
       return { icon: "pi-bolt", text: cmd, detail: JSON.stringify(r).slice(0, 300) };
   }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -533,6 +533,69 @@ function resolveNode(graph, nodeId) {
   return node;
 }
 
+// ---- Group boxes (LiteGraph LGraphGroup) helpers --------------------------
+
+/** Resolve a group box by id (with an index fallback for graphs whose groups
+ *  don't carry ids). */
+function resolveGroup(graph, groupId) {
+  const groups = graph._groups ?? [];
+  let g = groups.find((gr) => gr && gr.id === groupId);
+  if (!g && typeof groupId === "number" && groupId >= 0 && groupId < groups.length) g = groups[groupId];
+  if (!g) throw new Error(`No group with id ${groupId} in the current graph`);
+  return g;
+}
+
+/** Next free group id — groups aren't always assigned one by the frontend. */
+function nextGroupId(graph) {
+  const ids = (graph._groups ?? []).map((g) => g.id).filter((n) => typeof n === "number");
+  return (ids.length ? Math.max(...ids) : 0) + 1;
+}
+
+/** Set a group's box, preferring its _bounding array (most portable). */
+function setGroupBounds(group, [x, y, w, h]) {
+  if (group._bounding && group._bounding.length >= 4) {
+    group._bounding[0] = x;
+    group._bounding[1] = y;
+    group._bounding[2] = w;
+    group._bounding[3] = h;
+  } else {
+    group.pos = [x, y];
+    group.size = [w, h];
+  }
+}
+
+/** [x, y, w, h] that wraps the given nodes, padded for the group + node titles. */
+function boundsAroundNodes(nodes, pad = 30, titlePad = 70) {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const n of nodes) {
+    const x = n.pos?.[0] ?? 0;
+    const y = n.pos?.[1] ?? 0;
+    const w = n.size?.[0] ?? 200;
+    const h = n.size?.[1] ?? 100;
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    maxX = Math.max(maxX, x + w);
+    maxY = Math.max(maxY, y + h);
+  }
+  if (!Number.isFinite(minX)) return [100, 100, 400, 300];
+  return [minX - pad, minY - titlePad, maxX - minX + pad * 2, maxY - minY + titlePad + pad];
+}
+
+/** Compact JSON-friendly view of a group box. */
+function summarizeGroup(graph, g) {
+  const b = g._bounding ?? [g.pos?.[0] ?? 0, g.pos?.[1] ?? 0, g.size?.[0] ?? 0, g.size?.[1] ?? 0];
+  return {
+    id: g.id != null ? g.id : (graph._groups ?? []).indexOf(g),
+    title: g.title ?? "",
+    color: g.color ?? null,
+    bounding: [Math.round(b[0]), Math.round(b[1]), Math.round(b[2]), Math.round(b[3])],
+    node_count: (g._nodes ?? []).length,
+  };
+}
+
 /** Resolve a slot reference (name string or numeric index) to an index in
  *  the given slot array. Names are matched case-insensitively. */
 function resolveSlot(slots, ref, kind) {
@@ -569,11 +632,13 @@ const GRAPH_TOOL_EXECUTORS = {
   graph_get_state() {
     const { graph } = getGraphCtx();
     const nodes = (graph._nodes ?? []).slice(0, MAX_STATE_NODES).map(summarizeNode);
+    const groups = (graph._groups ?? []).map((g) => summarizeGroup(graph, g));
     return {
       viewing: describeActiveGraph(graph),
       node_count: graph._nodes?.length ?? 0,
       truncated: (graph._nodes?.length ?? 0) > MAX_STATE_NODES,
       nodes,
+      ...(groups.length ? { groups } : {}),
     };
   },
 
@@ -993,6 +1058,103 @@ const GRAPH_TOOL_EXECUTORS = {
         from_nodes: ns.map((n) => n.id),
       },
     };
+  },
+
+  // ---- Group boxes (LiteGraph LGraphGroup) ----------------------------------
+  // The labeled, colored rectangles. Visual organizers ONLY — distinct from
+  // subgraphs (which nest nodes). All undoable via beforeChange/afterChange.
+
+  // Create a group. Pass node_ids to auto-wrap them, else bounds [x,y,w,h],
+  // else a default box near the last node.
+  graph_create_group({ title, node_ids, bounds, color, font_size }) {
+    const { graph, LG } = getGraphCtx();
+    const GroupCls = LG.LGraphGroup;
+    if (typeof GroupCls !== "function") throw new Error("LGraphGroup unavailable on this frontend");
+    const group = new GroupCls(typeof title === "string" && title ? title : "Group");
+    let bbox;
+    if (Array.isArray(node_ids) && node_ids.length) {
+      const ns = node_ids.map((id) => graph.getNodeById(Number(id))).filter(Boolean);
+      if (!ns.length) throw new Error("none of the given node_ids exist in the current graph");
+      bbox = boundsAroundNodes(ns);
+    } else if (Array.isArray(bounds) && bounds.length === 4) {
+      bbox = bounds.map(Number);
+    } else {
+      bbox = [...placementFor(graph), 400, 300];
+    }
+    if (color != null) group.color = String(color);
+    if (Number.isFinite(font_size)) group.font_size = Number(font_size);
+    graph.beforeChange();
+    try {
+      setGroupBounds(group, bbox);
+      graph.add(group);
+      if (group.id == null) group.id = nextGroupId(graph);
+      group.recomputeInsideNodes?.();
+    } finally {
+      graph.afterChange();
+    }
+    graph.setDirtyCanvas(true, true);
+    return { group: summarizeGroup(graph, group) };
+  },
+
+  // Move a group's box to [x,y]; by default the contained nodes move with it
+  // (move_nodes:false moves only the box).
+  graph_move_group({ group_id, pos, move_nodes }) {
+    const { graph } = getGraphCtx();
+    const g = resolveGroup(graph, group_id);
+    const b = g._bounding ?? [g.pos?.[0] ?? 0, g.pos?.[1] ?? 0, 0, 0];
+    const dx = Number(pos[0]) - b[0];
+    const dy = Number(pos[1]) - b[1];
+    graph.beforeChange();
+    try {
+      if (move_nodes !== false && typeof g.move === "function") {
+        g.recomputeInsideNodes?.();
+        g.move(dx, dy, false); // moves the box AND the nodes inside it
+      } else {
+        setGroupBounds(g, [Number(pos[0]), Number(pos[1]), b[2], b[3]]);
+      }
+    } finally {
+      graph.afterChange();
+    }
+    graph.setDirtyCanvas(true, true);
+    return { group: summarizeGroup(graph, g) };
+  },
+
+  // Edit a group's title / color / font_size / bounds — only the fields passed.
+  graph_edit_group({ group_id, title, color, font_size, bounds }) {
+    const { graph } = getGraphCtx();
+    const g = resolveGroup(graph, group_id);
+    graph.beforeChange();
+    try {
+      if (typeof title === "string") g.title = title;
+      if (color != null) g.color = String(color);
+      if (Number.isFinite(font_size)) g.font_size = Number(font_size);
+      if (Array.isArray(bounds) && bounds.length === 4) setGroupBounds(g, bounds.map(Number));
+      g.recomputeInsideNodes?.();
+    } finally {
+      graph.afterChange();
+    }
+    graph.setDirtyCanvas(true, true);
+    return { group: summarizeGroup(graph, g) };
+  },
+
+  // Remove a group box (the nodes inside are NOT deleted).
+  graph_remove_group({ group_id }) {
+    const { graph } = getGraphCtx();
+    const g = resolveGroup(graph, group_id);
+    const summary = summarizeGroup(graph, g);
+    graph.beforeChange();
+    try {
+      if (typeof graph.removeGroup === "function") graph.removeGroup(g);
+      else if (typeof graph.remove === "function") graph.remove(g);
+      else {
+        const i = (graph._groups ?? []).indexOf(g);
+        if (i >= 0) graph._groups.splice(i, 1);
+      }
+    } finally {
+      graph.afterChange();
+    }
+    graph.setDirtyCanvas(true, true);
+    return { removed: summary };
   },
 
   // Rename a node's TITLE (the label on its header) — distinct from widget values.
@@ -1778,6 +1940,12 @@ const PANEL_CSS = `
   color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; border-radius: 4px; font-size: 0.7rem; }
 .cmcp-pending-act:hover { color: var(--p-primary-color, #60a5fa); background: var(--p-surface-700, #3f3f46); }
 .cmcp-pending-act.danger:hover { color: var(--p-red-300, #fca5a5); }
+.cmcp-pending-handle { flex: none; width: 1rem; height: 1.2rem; display: flex; align-items: center; justify-content: center;
+  color: var(--p-text-muted-color, #71717a); cursor: grab; font-size: 0.65rem; opacity: 0.6; }
+.cmcp-pending-handle:hover { opacity: 1; color: var(--p-primary-color, #60a5fa); }
+.cmcp-pending-handle:active { cursor: grabbing; }
+.cmcp-pending-item.dragging { opacity: 0.4; }
+.cmcp-pending-item.drop-target { box-shadow: inset 0 2px 0 0 var(--p-primary-color, #60a5fa); }
 .cmcp-todo-item.pending .pi { opacity: 0.5; }
 .cmcp-dl { margin-bottom: 0.4rem; }
 .cmcp-dl-item { padding: 0.18rem 0; }
@@ -2033,6 +2201,14 @@ function describeCommand(cmd, msg, reply) {
         : { icon: "pi-arrow-up", text: `Promoted “${r.promoted}” to the subgraph node` };
     case "graph_move_node":
       return { icon: "pi-arrows-alt", text: `Moved node ${r.moved?.node_id} to [${r.moved?.to?.map(Math.round)}]` };
+    case "graph_create_group":
+      return { icon: "pi-clone", text: `Created group “${r.group?.title}” (id ${r.group?.id})` };
+    case "graph_move_group":
+      return { icon: "pi-arrows-alt", text: `Moved group ${r.group?.id} (“${r.group?.title}”)` };
+    case "graph_edit_group":
+      return { icon: "pi-pencil", text: `Edited group ${r.group?.id} (“${r.group?.title}”)` };
+    case "graph_remove_group":
+      return { icon: "pi-minus-circle", text: `Removed group “${r.removed?.title}”` };
     case "graph_canvas":
       return { icon: "pi-window-maximize", text: `Canvas: ${r.canvas?.action?.replace(/_/g, " ")}` };
     case "graph_run":
@@ -2363,11 +2539,36 @@ function buildPanel() {
       for (const [mid, entry] of pendingList) {
         const row = document.createElement("div");
         row.className = "cmcp-pending-item" + (entry.state === "failed" ? " failed" : "");
+        // Drag handle (LEFT) — reorder how the agent flushes the queue.
+        const handle = document.createElement("span");
+        handle.className = "cmcp-pending-handle";
+        handle.draggable = true;
+        handle.title = "Drag to reorder";
+        handle.innerHTML = '<i class="pi pi-bars"></i>';
+        handle.addEventListener("dragstart", (e) => {
+          e.dataTransfer.setData("text/plain", mid);
+          e.dataTransfer.effectAllowed = "move";
+          row.classList.add("dragging");
+        });
+        handle.addEventListener("dragend", () => row.classList.remove("dragging"));
+        row.addEventListener("dragover", (e) => {
+          e.preventDefault();
+          e.dataTransfer.dropEffect = "move";
+          row.classList.add("drop-target");
+        });
+        row.addEventListener("dragleave", () => row.classList.remove("drop-target"));
+        row.addEventListener("drop", (e) => {
+          e.preventDefault();
+          row.classList.remove("drop-target");
+          const dragMid = e.dataTransfer.getData("text/plain");
+          if (dragMid) reorderPending(dragMid, mid);
+        });
         const txt = document.createElement("span");
         txt.className = "cmcp-pending-text";
         txt.textContent = entry.raw || "";
         txt.title = entry.raw || "";
         row.append(
+          handle,
           txt,
           mkPendingAct("pi-pencil", "Edit — pull back to the composer", () => editMsg(mid)),
           mkPendingAct(
@@ -3216,6 +3417,25 @@ function buildPanel() {
     renderTray();
   }
 
+  /** Drag-reorder the pending tray: move `dragMid` to where `targetMid` sits, then
+   *  tell the orchestrator the new flush order so it drains the queue that way. */
+  function reorderPending(dragMid, targetMid) {
+    if (!dragMid || dragMid === targetMid) return;
+    const isTray = (e) => e.state === "queued" || e.state === "failed";
+    const queued = [...pendingMsgs].filter(([, e]) => isTray(e));
+    const others = [...pendingMsgs].filter(([, e]) => !isTray(e));
+    const from = queued.findIndex(([m]) => m === dragMid);
+    const to = queued.findIndex(([m]) => m === targetMid);
+    if (from < 0 || to < 0) return;
+    const [moved] = queued.splice(from, 1);
+    queued.splice(to, 0, moved);
+    // Rebuild the Map in the new order (queued reordered; transient sends trail).
+    pendingMsgs.clear();
+    for (const [m, e] of [...queued, ...others]) pendingMsgs.set(m, e);
+    renderTray();
+    client?.sendFrame?.({ type: "reorder", order: queued.map(([m]) => m) });
+  }
+
   /** Receipt ack (orchestrator got it): not dropped → cancel the failure timer.
    *  Still QUEUED until the agent reads it (the "seen" ack). */
   function markReceived(mid) {
@@ -3641,6 +3861,9 @@ function buildPanel() {
     "graph_create_subgraph",
     "graph_enter_subgraph",
     "graph_exit_subgraph",
+    "graph_create_group",
+    "graph_move_group",
+    "graph_remove_group",
   ]);
   let autoFitTimer = null;
   function scheduleAutoFit() {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2718,8 +2718,8 @@ function buildPanel() {
       edit.className = "cmcp-edit-btn";
       edit.title = "Edit & roll back from this message";
       edit.innerHTML = '<i class="pi pi-pencil"></i>';
-      const anchorIdx = typeof opts.anchorIdx === "number" ? opts.anchorIdx : 0;
-      edit.addEventListener("click", () => openRollbackModal({ mid: opts.mid, text, anchorIdx }));
+      const rewindAnchor = opts.rewindAnchor ?? null;
+      edit.addEventListener("click", () => openRollbackModal({ mid: opts.mid, text, anchor: rewindAnchor }));
       b.appendChild(edit);
     }
     log.appendChild(b);
@@ -3032,9 +3032,11 @@ function buildPanel() {
   function appendUser(text, opts = {}) {
     stickToBottom = true; // your own message → always jump to the latest
     newMsgBtn.hidden = true;
-    // Record how many turn anchors exist now, so a rewind to this message forks
-    // the conversation at turnAnchors[anchorIdx - 1].
-    const painted = paintUser(text, { ...opts, anchorIdx: turnAnchors.length });
+    // Capture the rewind anchor NOW (the latest turn's UUID) so a later rewind to
+    // this message forks the conversation right before it — stored directly (not as
+    // an index, which a bounded-ring shift() would invalidate).
+    const rewindAnchor = turnAnchors.length > 0 ? turnAnchors[turnAnchors.length - 1] : null;
+    const painted = paintUser(text, { ...opts, rewindAnchor });
     // Tag the record with its mid so deleteMsg can remove the EXACT message even
     // when several are queued (popping the trailing one would hit the wrong one).
     record({ role: "user", text, ...(opts.mid ? { mid: opts.mid } : {}) });
@@ -4657,8 +4659,7 @@ function buildPanel() {
   // Per-message rollback modal (edit button on a user bubble). Edit the message
   // and choose what to roll back — code (revert the canvas to before it),
   // conversation (fork the agent's memory at that point), or both — then resend.
-  function openRollbackModal({ mid, text, anchorIdx }) {
-    const anchor = anchorIdx > 0 ? turnAnchors[anchorIdx - 1] ?? null : null;
+  function openRollbackModal({ mid, text, anchor }) {
     const overlay = document.createElement("div");
     overlay.className = "cmcp-modal-overlay";
     const modal = document.createElement("div");

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3594,10 +3594,19 @@ function buildPanel() {
     }, DELIVERY_TIMEOUT_MS);
   }
 
-  function trackSend(mid, statusEl, payload, raw) {
-    // "queued" (agent busy → waiting in the pending tray) vs "sending" (idle send,
-    // processes immediately → stays inline, not in the tray).
-    pendingMsgs.set(mid, { statusEl, payload, raw, timer: null, state: agentWorking ? "queued" : "sending" });
+  function trackSend(mid, statusEl, payload, raw, materialize) {
+    // A `materialize` fn means this is a QUEUED send: nothing is painted inline yet;
+    // it waits in the pending tray and `materialize()` paints it at the END of the
+    // chat when the agent dequeues it (so the chat flows in dequeue order). An idle
+    // send ("sending") is already painted inline and processes immediately.
+    pendingMsgs.set(mid, {
+      statusEl,
+      payload,
+      raw,
+      timer: null,
+      state: materialize ? "queued" : "sending",
+      materialize: materialize || null,
+    });
     const ok = client.sendUserMessage(payload.text, payload.context, payload.images, mid);
     if (!ok) setMsgStatus(mid, "failed"); // socket wasn't open — instant fail
     else armDeliveryTimeout(mid);
@@ -3649,12 +3658,18 @@ function buildPanel() {
     }
   }
 
-  /** Read ack (agent dequeued it): flip to read state. */
+  /** Read ack (agent dequeued it): a queued message materializes at the END of the
+   *  chat (dequeue order, before the reply); an idle send just sheds its status. */
   function markRead(mid) {
     const entry = pendingMsgs.get(mid);
     if (entry?.timer) clearTimeout(entry.timer);
     pendingMsgs.delete(mid);
-    setMsgStatus(mid, "read");
+    if (entry?.materialize) {
+      entry.materialize(); // paint bubble + images at the bottom now
+      renderTray(); // it left the pending tray
+    } else {
+      setMsgStatus(mid, "read");
+    }
   }
 
   function deleteMsg(mid) {
@@ -5285,10 +5300,12 @@ function buildPanel() {
     }
     const freshChat = !thread;
     const mid = newMid();
-    const painted = appendUser(text, { mid });
-    // Only mark queued (→ hidden bubble + pending tray) if a turn is already in
-    // flight; an idle send processes immediately, so leave it inline (no flash).
-    if (agentWorking) setMsgStatus(mid, "queued");
+    // Decide tray-vs-inline at SEND time: if a turn is already in flight the message
+    // QUEUES — paint nothing inline now; it lives in the pending tray and materializes
+    // at the END of the chat when the agent dequeues it (so the chat flows in dequeue
+    // order, matching any reordering). An idle send paints immediately.
+    const isQueued = agentWorking;
+    const painted = isQueued ? null : appendUser(text, { mid });
     // Capture the pre-turn graph so /revert can undo this turn's edits in one step.
     captureGraphSnapshot(mid, text);
     showThinking();
@@ -5306,8 +5323,13 @@ function buildPanel() {
     resetAttachments();
     const pending = [...refImgs, ...refVideos, ...refFiles, ...refUploads];
     if (pending.length) await Promise.all(pending.map((a) => a.ready));
-    for (const a of refImgs) if (a.dataUrl) paintImage(a.dataUrl, a.name);
-    for (const a of refVideos) if (a.ref) paintVideo(imageViewUrl(a.ref), a.name);
+    // Paint the message's media. For a queued send this runs later, inside
+    // materialize() (at dequeue), so the bubble + its images land together at the end.
+    const paintMedia = () => {
+      for (const a of refImgs) if (a.dataUrl) paintImage(a.dataUrl, a.name);
+      for (const a of refVideos) if (a.ref) paintVideo(imageViewUrl(a.ref), a.name);
+    };
+    if (!isQueued) paintMedia();
 
     // Compose the text the AGENT receives. Pasted text and text/workflow files
     // expand inline (in a labeled fence). Images (chips + @input:/@node: mentions)
@@ -5360,7 +5382,17 @@ function buildPanel() {
     // Track delivery: trackSend marks "Sending…", then the working ack flips it
     // to "✓ Seen" (or a timeout / closed socket flips it to "Not delivered").
     // `text` (the raw composer text) is kept so ✎ can restore it for editing.
-    trackSend(mid, painted.statusEl, { text: sendText, context, images: imageRefs }, text);
+    if (isQueued) {
+      // Queued: hand trackSend a materializer that paints this message (bubble +
+      // media) at the END of the chat when the agent finally dequeues it.
+      const materialize = () => {
+        appendUser(text, { mid });
+        paintMedia();
+      };
+      trackSend(mid, null, { text: sendText, context, images: imageRefs }, text, materialize);
+    } else {
+      trackSend(mid, painted.statusEl, { text: sendText, context, images: imageRefs }, text);
+    }
   });
 
   input.addEventListener("keydown", (ev) => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -4559,6 +4559,25 @@ function buildPanel() {
     return true;
   }
 
+  // ---- double-Esc rewind (#44) ----
+  // Two Escapes in quick succession rewind your last turn: revert the canvas to
+  // before your last message AND bring that message back into the composer to
+  // edit & resend. (Graph + edit scope; conversation-fork is a follow-up.)
+  let lastEscAt = 0;
+  function rewindLastTurn() {
+    const snap = revertGraphToLastSnapshot();
+    const recalled = recallPrev(); // pulls your last message into the composer to edit
+    if (snap || recalled) {
+      appendSystem(
+        `↩ Rewound your last turn${snap ? " — canvas reverted" : ""}` +
+          `${recalled ? "; your message is back in the composer to edit & resend" : ""}.`,
+      );
+      input.focus();
+    } else {
+      appendSystem("Nothing to rewind yet — no message/graph snapshot from this session.");
+    }
+  }
+
   // ---- submit ----
   form.addEventListener("submit", async (ev) => {
     ev.preventDefault();
@@ -4681,6 +4700,18 @@ function buildPanel() {
         hideMenu();
         return;
       }
+    }
+    // Double-Esc (two within 600ms, menu closed, not mid-history-nav) rewinds the
+    // last turn. A single Esc falls through to its normal behavior below.
+    if (ev.key === "Escape" && menuPop.hidden && histIdx === -1) {
+      const now = performance.now();
+      if (now - lastEscAt < 600) {
+        lastEscAt = 0;
+        ev.preventDefault();
+        rewindLastTurn();
+        return;
+      }
+      lastEscAt = now;
     }
     // ↑ recalls your previous sent message (when already navigating, or from the
     // very start of the composer so it never hijacks normal line-up movement);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1766,6 +1766,18 @@ const PANEL_CSS = `
 .cmcp-todo-item.done .pi { color: var(--p-green-400, #4ade80); }
 .cmcp-todo-item.active { font-weight: 600; }
 .cmcp-todo-item.active .pi { color: var(--p-primary-color, #60a5fa); }
+/* Pending messages live in the tray (not the chat flow). The inline bubble + its
+   status line stay hidden while queued/failed; on "read" the classes drop and the
+   bubble materializes in place — right before the agent's reply. */
+.cmcp-bubble.user.queued, .cmcp-bubble.user.failed { display: none; }
+.cmcp-msg-status.queued, .cmcp-msg-status.failed { display: none; }
+.cmcp-pending-item { display: flex; align-items: center; gap: 0.3rem; padding: 0.15rem 0; line-height: 1.3; }
+.cmcp-pending-text { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cmcp-pending-item.failed .cmcp-pending-text { color: var(--p-red-300, #fca5a5); }
+.cmcp-pending-act { flex: none; width: 1.2rem; height: 1.2rem; padding: 0; border: none; background: transparent;
+  color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; border-radius: 4px; font-size: 0.7rem; }
+.cmcp-pending-act:hover { color: var(--p-primary-color, #60a5fa); background: var(--p-surface-700, #3f3f46); }
+.cmcp-pending-act.danger:hover { color: var(--p-red-300, #fca5a5); }
 .cmcp-todo-item.pending .pi { opacity: 0.5; }
 .cmcp-dl { margin-bottom: 0.4rem; }
 .cmcp-dl-item { padding: 0.18rem 0; }
@@ -2317,12 +2329,58 @@ function buildPanel() {
     return `${v.toFixed(1)} ${u[i]}`;
   }
 
+  function mkPendingAct(icon, title, onClick, danger) {
+    const b = document.createElement("button");
+    b.type = "button";
+    b.className = "cmcp-pending-act" + (danger ? " danger" : "");
+    b.title = title;
+    b.innerHTML = `<i class="pi ${icon}"></i>`;
+    b.addEventListener("click", onClick);
+    return b;
+  }
+
   function renderTray() {
     tray.replaceChildren();
+    // Only messages actually waiting (queued behind a turn) or failed belong in
+    // the tray — not idle sends that process immediately.
+    const pendingList = [...pendingMsgs].filter(
+      ([, e]) => e.state === "queued" || e.state === "failed",
+    );
+    const hasPending = pendingList.length > 0;
     const hasDl = downloadItems.length > 0;
     const hasTodo = todoItems.length > 0;
-    tray.hidden = !hasDl && !hasTodo;
+    tray.hidden = !hasPending && !hasDl && !hasTodo;
     if (tray.hidden) return;
+
+    // Pending messages (queued/failed) live here, not in the chat flow. Each has
+    // edit / send-now / delete. On dequeue they materialize as a chat bubble.
+    if (hasPending) {
+      const pend = document.createElement("div");
+      const head = document.createElement("div");
+      head.className = "cmcp-tray-head";
+      head.textContent = `Pending · ${pendingList.length}`;
+      pend.appendChild(head);
+      for (const [mid, entry] of pendingList) {
+        const row = document.createElement("div");
+        row.className = "cmcp-pending-item" + (entry.state === "failed" ? " failed" : "");
+        const txt = document.createElement("span");
+        txt.className = "cmcp-pending-text";
+        txt.textContent = entry.raw || "";
+        txt.title = entry.raw || "";
+        row.append(
+          txt,
+          mkPendingAct("pi-pencil", "Edit — pull back to the composer", () => editMsg(mid)),
+          mkPendingAct(
+            "pi-send",
+            entry.state === "failed" ? "Resend now" : "Send now (interrupt the current turn)",
+            () => sendNowMsg(mid),
+          ),
+          mkPendingAct("pi-times", "Delete this message", () => deleteMsg(mid), true),
+        );
+        pend.appendChild(row);
+      }
+      tray.appendChild(pend);
+    }
 
     if (hasDl) {
       const dl = document.createElement("div");
@@ -3083,16 +3141,21 @@ function buildPanel() {
   function setMsgStatus(mid, state) {
     const statusEl = statusElFor(mid);
     const bubble = log.querySelector(`.cmcp-bubble.user[data-mid="${mid}"]`);
+    const entry = pendingMsgs.get(mid);
+    if (entry) entry.state = state;
     if (state === "read") {
-      // The agent dequeued it → normal bubble, no chrome.
+      // The agent dequeued it → the bubble materializes in place (CSS un-hides it),
+      // and it leaves the pending tray.
       bubble?.classList.remove("queued", "failed");
       statusEl?.remove();
+      renderTray();
       return;
     }
     // queued (muted) or failed (red): tint the bubble + expose ✎/✕. The agent
     // hasn't read it yet, so editing/deleting just yanks it from the queue.
     bubble?.classList.toggle("queued", state === "queued");
     bubble?.classList.toggle("failed", state === "failed");
+    renderTray(); // reflect queued/failed state in the pending tray
     if (!statusEl) return;
     statusEl.className = "cmcp-msg-status " + state;
     statusEl.replaceChildren(
@@ -3128,10 +3191,29 @@ function buildPanel() {
   }
 
   function trackSend(mid, statusEl, payload, raw) {
-    pendingMsgs.set(mid, { statusEl, payload, raw, timer: null });
+    // "queued" (agent busy → waiting in the pending tray) vs "sending" (idle send,
+    // processes immediately → stays inline, not in the tray).
+    pendingMsgs.set(mid, { statusEl, payload, raw, timer: null, state: agentWorking ? "queued" : "sending" });
     const ok = client.sendUserMessage(payload.text, payload.context, payload.images, mid);
     if (!ok) setMsgStatus(mid, "failed"); // socket wasn't open — instant fail
     else armDeliveryTimeout(mid);
+    renderTray(); // surface it in the pending tray (not inline)
+  }
+
+  /** "Send now" from the pending tray: a queued message → interrupt the current
+   *  turn so the agent gets to the queue immediately; a failed one → resend it. */
+  function sendNowMsg(mid) {
+    const entry = pendingMsgs.get(mid);
+    if (!entry) return;
+    if (entry.state === "failed") {
+      setMsgStatus(mid, "queued");
+      const ok = client.sendUserMessage(entry.payload.text, entry.payload.context, entry.payload.images, mid);
+      if (!ok) setMsgStatus(mid, "failed");
+      else armDeliveryTimeout(mid);
+    } else {
+      client?.sendFrame?.({ type: "interrupt" });
+    }
+    renderTray();
   }
 
   /** Receipt ack (orchestrator got it): not dropped → cancel the failure timer.
@@ -3157,6 +3239,7 @@ function buildPanel() {
     if (entry?.timer) clearTimeout(entry.timer);
     pendingMsgs.delete(mid);
     cancelOnServer(mid); // drop it from the agent's queue if still there
+    renderTray(); // remove it from the pending tray
     for (const el of log.querySelectorAll(`[data-mid="${mid}"]`)) el.remove();
     // Remove the EXACT record for this mid (not the trailing one — several may be
     // queued at once).
@@ -3581,6 +3664,11 @@ function buildPanel() {
   // that message forks the session at turnAnchors[recorded-1]. Reset on new chat.
   let turnAnchors = [];
 
+  // True while a turn is in flight — a message sent now will QUEUE (→ pending
+  // tray) rather than start immediately. Drives the tray-vs-inline decision so
+  // an idle send doesn't briefly flash through the tray.
+  let agentWorking = false;
+
   // ---- bridge wiring ----
   const client = createBridgeClient({
     onStatus(state) {
@@ -3644,9 +3732,11 @@ function buildPanel() {
     },
     onTurn(state) {
       if (state === "working") {
+        agentWorking = true;
         showThinking();
         ssSet(MID_TASK_KEY, "1"); // a turn is in flight — arm the resume nudge
       } else if (state === "done") {
+        agentWorking = false;
         hideThinking();
         ssSet(MID_TASK_KEY, null); // turn finished cleanly — nothing to resume
       }
@@ -4770,7 +4860,9 @@ function buildPanel() {
     const freshChat = !thread;
     const mid = newMid();
     const painted = appendUser(text, { mid });
-    setMsgStatus(mid, "queued"); // muted + ✎/✕ until the agent actually reads it
+    // Only mark queued (→ hidden bubble + pending tray) if a turn is already in
+    // flight; an idle send processes immediately, so leave it inline (no flash).
+    if (agentWorking) setMsgStatus(mid, "queued");
     // Capture the pre-turn graph so /revert can undo this turn's edits in one step.
     captureGraphSnapshot(mid, text);
     showThinking();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -443,6 +443,38 @@ function describeActiveGraph(graph) {
   };
 }
 
+// ---- per-turn graph snapshots (rollback foundation, #44) -------------------
+// Before each turn that may edit the graph, capture the ROOT workflow JSON so a
+// whole turn's worth of agent edits can be reverted to a known-good point in one
+// step (ComfyUI's Ctrl+Z is per-operation; this is per-turn). Bounded ring,
+// correlated to the message id that started the turn. In-memory for this session.
+const GRAPH_SNAPSHOTS_MAX = 25;
+const graphSnapshots = []; // [{ mid, ts, label, data }], oldest → newest
+
+function captureGraphSnapshot(mid, label) {
+  try {
+    const data = getGraphCtx().rootGraph.serialize();
+    graphSnapshots.push({ mid, ts: Date.now(), label: (label || "").slice(0, 80), data });
+    while (graphSnapshots.length > GRAPH_SNAPSHOTS_MAX) graphSnapshots.shift();
+  } catch {
+    // graph unavailable — this turn just won't have a restore point.
+  }
+}
+
+// Restore the canvas to the most recent pre-turn snapshot (undo the last turn's
+// edits). Returns the restored snapshot, or null if none / restore failed.
+function revertGraphToLastSnapshot() {
+  const snap = graphSnapshots[graphSnapshots.length - 1];
+  if (!snap) return null;
+  try {
+    // Deep-clone so the stored snapshot isn't mutated by the live graph after load.
+    getGraphCtx().app.loadGraphData(JSON.parse(JSON.stringify(snap.data)));
+    return snap;
+  } catch {
+    return null;
+  }
+}
+
 /** Summarize one LiteGraph node for the agent — id, type, title, widget
  *  values, and input link sources. Deliberately NOT the full serialization
  *  (positions, colors, internal state) to keep token cost low. */
@@ -2538,14 +2570,18 @@ function buildPanel() {
   const spacer = document.createElement("span");
   spacer.className = "cmcp-spacer";
 
-  const attachBtn = iconBtn("pi-paperclip", "Attach an image (uploads to ComfyUI's input/ folder)");
+  const attachBtn = iconBtn("pi-paperclip", "Attach an image, video, workflow (.json), or text file");
   const micBtn = iconBtn("pi-microphone", "Dictate (browser speech recognition)");
   const sendBtn = iconBtn("pi-send", "Send (Enter)");
   sendBtn.type = "submit";
 
   const fileInput = document.createElement("input");
   fileInput.type = "file";
-  fileInput.accept = "image/*";
+  // Images + video upload into ComfyUI input/; workflows (.json) and text files
+  // are read and delivered inline to the agent. See handleFile() below.
+  fileInput.accept =
+    "image/*,video/*,.json,.txt,.md,.markdown,.csv,.tsv,.yaml,.yml,.xml,.toml,.ini,.cfg,.log,.py,.js,.ts,.sh,text/*,application/json";
+  fileInput.multiple = true;
   fileInput.hidden = true;
 
   row.append(ring, ctxLabel, modelChip, spacer, attachBtn, micBtn, sendBtn);
@@ -2680,6 +2716,26 @@ function buildPanel() {
     img.style.cssText = "max-width:100%;border-radius:6px;display:block;cursor:zoom-in;";
     img.addEventListener("click", () => window.open(url, "_blank"));
     card.appendChild(img);
+    if (name) {
+      const cap = document.createElement("div");
+      cap.style.cssText = "font-size:0.625rem;color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
+      cap.textContent = name;
+      card.appendChild(cap);
+    }
+    log.appendChild(card);
+    scrollLog();
+  }
+
+  function paintVideo(url, name) {
+    clearEmpty();
+    const card = document.createElement("div");
+    card.className = "cmcp-bubble agent cmcp-imgcard";
+    const vid = document.createElement("video");
+    vid.src = url;
+    vid.controls = true;
+    vid.preload = "metadata";
+    vid.style.cssText = "max-width:100%;border-radius:6px;display:block;";
+    card.appendChild(vid);
     if (name) {
       const cap = document.createElement("div");
       cap.style.cssText = "font-size:0.625rem;color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
@@ -3884,6 +3940,21 @@ function buildPanel() {
       run: () => hardRestart("user"),
     },
     {
+      cmd: "/revert",
+      icon: "pi-undo",
+      hint: "undo the last turn's graph edits — revert the canvas to before your last message",
+      run: () => {
+        const snap = revertGraphToLastSnapshot();
+        if (snap) {
+          appendSystem(
+            `↩ Reverted the canvas to before${snap.label ? ` “${snap.label}”` : " your last message"}.`,
+          );
+        } else {
+          appendSystem("Nothing to revert — no graph snapshot captured in this session yet.");
+        }
+      },
+    },
+    {
       cmd: "/errors",
       icon: "pi-info-circle",
       hint: "show the last execution errors",
@@ -4074,24 +4145,54 @@ function buildPanel() {
   }
 
   attachBtn.addEventListener("click", () => fileInput.click());
-  // The attach button now uses the same chip pipeline as drag/paste — a [Image #N]
-  // chip + structured ref, delivered inline to the agent on send.
+  // The attach button uses the same chip pipeline as drag/paste — each file drops
+  // a typed chip ([Image #N] / [Video #N] / [Workflow #N] / [File #N]) and a
+  // structured ref, delivered inline to the agent on send.
   fileInput.addEventListener("change", () => {
-    for (const f of Array.from(fileInput.files || [])) handleImageFile(f);
+    for (const f of Array.from(fileInput.files || [])) handleFile(f);
     fileInput.value = "";
   });
 
-  // ---- attachments: drag-drop / paste images + paste large text ----------
-  // Claude-Code style: a dropped/pasted image uploads into ComfyUI input/ and
-  // drops a [Image #N] chip in the composer; a big text paste collapses to a
-  // [Pasted text #N] chip. On send, pasted text expands inline and images are
-  // referenced (the agent can view_image them or wire a LoadImage node).
+  // ---- attachments: drag-drop / paste files + paste large text ------------
+  // Claude-Code style. A dropped/pasted/attached file becomes a typed chip in the
+  // composer; on send it's delivered to the agent inline:
+  //   • image    → uploads into ComfyUI input/, shown + delivered as a viewable ref
+  //   • video    → uploads into ComfyUI input/, delivered as an input/ path the
+  //                agent can wire into a video-load node or pass to video tools
+  //   • workflow → the .json is read and inlined so the agent can load/analyze it
+  //   • text     → the file's text is read and inlined (like a big paste)
+  // A big text paste also collapses to a [Pasted text #N] chip.
   const PASTE_TEXT_THRESHOLD = 800; // chars; longer pastes collapse to a chip
-  let attachments = []; // { id, kind:"image"|"text", ... }
+  const MAX_INLINE_TEXT = 600_000; // chars; cap inlined file text (workflows/docs)
+  // Text-ish files we read & inline rather than upload. (.json is handled as a
+  // workflow first; if it doesn't parse as one it falls back to a text file.)
+  const TEXT_FILE_RE =
+    /\.(txt|md|markdown|csv|tsv|ya?ml|xml|html?|toml|ini|cfg|conf|env|log|py|js|mjs|cjs|ts|tsx|jsx|sh|bat|ps1|rb|go|rs|c|h|cpp|hpp|java|kt|css|scss|sql|json5)$/i;
+  let attachments = []; // { id, kind:"image"|"video"|"text"|"textfile"|"workflow", ... }
   let attachSeq = 0;
   function resetAttachments() {
     attachments = [];
     attachSeq = 0;
+  }
+  function classifyFile(file) {
+    const type = file?.type || "";
+    const name = (file?.name || "").toLowerCase();
+    if (type.startsWith("image/")) return "image";
+    if (type.startsWith("video/")) return "video";
+    if (name.endsWith(".json") || type === "application/json") return "workflow";
+    if (type.startsWith("text/") || TEXT_FILE_RE.test(name)) return "text";
+    return "other"; // unknown binary — upload into input/ and reference by path
+  }
+  // Route any attached/dropped/pasted file to the right handler by kind.
+  function handleFile(file) {
+    if (!file) return;
+    switch (classifyFile(file)) {
+      case "image": return handleImageFile(file);
+      case "video": return handleMediaUpload(file, "video");
+      case "workflow": return handleWorkflowFile(file);
+      case "text": return handleTextFile(file);
+      default: return handleMediaUpload(file, "file");
+    }
   }
   function readAsDataURL(file) {
     return new Promise((resolve, reject) => {
@@ -4099,6 +4200,14 @@ function buildPanel() {
       fr.onload = () => resolve(fr.result);
       fr.onerror = reject;
       fr.readAsDataURL(file);
+    });
+  }
+  function readAsText(file) {
+    return new Promise((resolve, reject) => {
+      const fr = new FileReader();
+      fr.onload = () => resolve(String(fr.result ?? ""));
+      fr.onerror = reject;
+      fr.readAsText(file);
     });
   }
   function handleImageFile(file) {
@@ -4134,6 +4243,83 @@ function buildPanel() {
     const id = ++attachSeq;
     attachments.push({ id, kind: "text", content: text });
     insertAtCaret(`[Pasted text #${id}] `);
+  }
+  // Upload a non-inlineable file (video, or an unknown binary) into ComfyUI's
+  // input/ folder and drop a path-reference chip. Claude can't view video inline,
+  // so on send the agent gets the input/ path — ready to wire into a video-load
+  // node or hand to the comfyui video tools.
+  function handleMediaUpload(file, kind /* "video" | "file" */) {
+    if (!file) return;
+    const id = ++attachSeq;
+    const label = kind === "video" ? "Video" : "File";
+    const name = file.name || `pasted-${id}`;
+    const att = { id, kind, name, mediaType: file.type || "", inputRef: null, ref: null, token: `[${label} #${id}]` };
+    attachments.push(att);
+    insertAtCaret(`${att.token} `);
+    att.ready = (async () => {
+      try {
+        const fd = new FormData();
+        // ComfyUI's /upload/image writes ANY uploaded file verbatim into input/.
+        fd.append("image", file, name);
+        const res = await api.fetchApi("/upload/image", { method: "POST", body: fd });
+        if (res.status === 200) {
+          const info = await res.json();
+          att.inputRef = (info.subfolder ? `${info.subfolder}/` : "") + info.name;
+          att.ref = { filename: info.name, subfolder: info.subfolder || undefined, type: info.type || "input" };
+        }
+      } catch {
+        /* upload failed — the chip still names the file as a fallback */
+      }
+    })();
+  }
+  // Read a text file (docs, code, data) and inline its contents to the agent.
+  function handleTextFile(file) {
+    if (!file) return;
+    const id = ++attachSeq;
+    const name = file.name || `file-${id}.txt`;
+    const att = { id, kind: "textfile", name, content: "", token: `[File #${id}]` };
+    attachments.push(att);
+    insertAtCaret(`${att.token} `);
+    att.ready = (async () => {
+      try {
+        let t = await readAsText(file);
+        if (t.length > MAX_INLINE_TEXT) t = t.slice(0, MAX_INLINE_TEXT) + `\n…[truncated — original ${t.length} chars]`;
+        att.content = t;
+      } catch {
+        att.content = "";
+      }
+    })();
+  }
+  // Read a ComfyUI workflow .json and inline it so the agent can load / analyze /
+  // merge it. If it doesn't parse as JSON, fall back to delivering it as raw text.
+  function handleWorkflowFile(file) {
+    if (!file) return;
+    const id = ++attachSeq;
+    const name = file.name || `workflow-${id}.json`;
+    const att = { id, kind: "workflow", name, content: "", isWorkflow: true, token: `[Workflow #${id}]` };
+    attachments.push(att);
+    insertAtCaret(`${att.token} `);
+    att.ready = (async () => {
+      try {
+        let t = await readAsText(file);
+        try {
+          const obj = JSON.parse(t);
+          // Confirm it looks like a ComfyUI graph (UI format with nodes[], or API
+          // format keyed by node id with class_type). Pretty-print either way.
+          att.isWorkflow =
+            !!obj && typeof obj === "object" &&
+            (Array.isArray(obj.nodes) || "last_node_id" in obj ||
+              Object.values(obj).some((v) => v && typeof v === "object" && "class_type" in v));
+          t = JSON.stringify(obj, null, 2);
+        } catch {
+          att.isWorkflow = false; // not valid JSON — deliver as raw text
+        }
+        if (t.length > MAX_INLINE_TEXT) t = t.slice(0, MAX_INLINE_TEXT) + `\n…[truncated — original ${t.length} chars]`;
+        att.content = t;
+      } catch {
+        att.content = "";
+      }
+    })();
   }
 
   // Resolve image references from an @node:<id> mention to ComfyUI /view refs:
@@ -4210,7 +4396,7 @@ function buildPanel() {
   form.style.position = form.style.position || "relative";
   const dropzone = document.createElement("div");
   dropzone.className = "cmcp-dropzone";
-  dropzone.innerHTML = '<span><i class="pi pi-image"></i> Drop image to attach</span>';
+  dropzone.innerHTML = '<span><i class="pi pi-paperclip"></i> Drop a file to attach</span>';
   form.appendChild(dropzone);
   let dragDepth = 0;
   const showDrop = (on) => dropzone.classList.toggle("cmcp-show", on);
@@ -4239,22 +4425,20 @@ function buildPanel() {
     ev.preventDefault();
     dragDepth = 0;
     showDrop(false);
-    for (const f of Array.from(ev.dataTransfer.files || [])) {
-      if (f.type?.startsWith("image/")) handleImageFile(f);
-    }
+    for (const f of Array.from(ev.dataTransfer.files || [])) handleFile(f);
     input.focus();
   });
   input.addEventListener("paste", (ev) => {
     const dt = ev.clipboardData;
     if (!dt) return;
-    const imgItem = Array.from(dt.items || []).find(
-      (it) => it.kind === "file" && it.type?.startsWith("image/"),
-    );
-    if (imgItem) {
-      const file = imgItem.getAsFile();
+    // Any pasted file (a screenshot, or a file copied from the OS) routes through
+    // the same dispatcher as the attach button and drag-drop.
+    const fileItem = Array.from(dt.items || []).find((it) => it.kind === "file");
+    if (fileItem) {
+      const file = fileItem.getAsFile();
       if (file) {
         ev.preventDefault();
-        handleImageFile(file);
+        handleFile(file);
         return;
       }
     }
@@ -4401,27 +4585,54 @@ function buildPanel() {
     const mid = newMid();
     const painted = appendUser(text, { mid });
     setMsgStatus(mid, "queued"); // muted + ✎/✕ until the agent actually reads it
+    // Capture the pre-turn graph so /revert can undo this turn's edits in one step.
+    captureGraphSnapshot(mid, text);
     showThinking();
     input.value = "";
     input.style.height = "auto";
 
     // Resolve attachment chips referenced in this message (the user may have
     // deleted some), then clear the registry for the next message.
+    const referenced = (a) => text.includes(a.token || `[Image #${a.id}]`);
     const refImgs = attachments.filter((a) => a.kind === "image" && text.includes(`[Image #${a.id}]`));
     const refTexts = attachments.filter((a) => a.kind === "text" && text.includes(`[Pasted text #${a.id}]`));
+    const refVideos = attachments.filter((a) => a.kind === "video" && referenced(a));
+    const refFiles = attachments.filter((a) => (a.kind === "textfile" || a.kind === "workflow") && referenced(a));
+    const refUploads = attachments.filter((a) => a.kind === "file" && referenced(a));
     resetAttachments();
-    if (refImgs.length) await Promise.all(refImgs.map((a) => a.ready));
+    const pending = [...refImgs, ...refVideos, ...refFiles, ...refUploads];
+    if (pending.length) await Promise.all(pending.map((a) => a.ready));
     for (const a of refImgs) if (a.dataUrl) paintImage(a.dataUrl, a.name);
+    for (const a of refVideos) if (a.ref) paintVideo(imageViewUrl(a.ref), a.name);
 
-    // Compose the text the AGENT receives: pasted text expands inline. Images
-    // (chips + @input:/@node: mentions) are delivered as inline image blocks; a
-    // short note lists chip paths as a fallback if a fetch fails.
+    // Compose the text the AGENT receives. Pasted text and text/workflow files
+    // expand inline (in a labeled fence). Images (chips + @input:/@node: mentions)
+    // are delivered as inline image blocks; video/binary uploads are delivered as
+    // input/ paths the agent can wire or process. A short note lists chip paths.
     let sendText = text;
     for (const a of refTexts) sendText = sendText.split(`[Pasted text #${a.id}]`).join(a.content);
+    for (const a of refFiles) {
+      const lang = a.kind === "workflow" ? "json" : "";
+      const head =
+        a.kind === "workflow" && a.isWorkflow
+          ? `ComfyUI workflow “${a.name}” (you can load, analyze, or merge it into the canvas):`
+          : `File “${a.name}”:`;
+      const block = `\n\n${head}\n\`\`\`${lang}\n${a.content}\n\`\`\``;
+      sendText = sendText.split(a.token).join(block);
+    }
     const imageRefs = await collectImageRefs(text, refImgs);
     if (refImgs.length) {
       const lines = refImgs.map((a) => `#${a.id}${a.inputRef ? ` (input/${a.inputRef})` : ""}`).join(", ");
       sendText += `\n\n[Attached image(s) ${lines} — shown inline below.]`;
+    }
+    const mediaUploads = [...refVideos, ...refUploads];
+    if (mediaUploads.length) {
+      const lines = mediaUploads
+        .map((a) => `${a.token} ${a.inputRef ? `→ input/${a.inputRef}` : `(${a.name} — upload failed)`}`)
+        .join("\n");
+      sendText +=
+        `\n\n[Attached media in ComfyUI's input/ folder (not viewable inline — load via a ` +
+        `Load Video/file node or pass the path to the comfyui tools):\n${lines}]`;
     }
 
     // Ground a brand-new chat: if the open workflow was never saved, save it


### PR DESCRIPTION
## comfyui-agent-panel 0.2.0

The panel (custom-node) side of the rd4 work.

### Added
- **Rewind & rollback (#44)** — hover ✎ on any message → roll back code / conversation / both and resend; `/revert` (undo last turn's graph edits) + double-Esc quick rewind. Graph reverts via per-turn snapshots.
- **Pending-message tray** — messages sent while busy wait above downloads (out of the chat flow) with edit / send-now / delete; **drag ≡ to reorder** the flush order; **send-now** steers (interrupts). Dequeued messages **materialize at the bottom of the chat**, in the order Claude processes them.
- **Spatial layout control** — the agent sees node pos/size + subgraph rails and arranges the canvas (move rails, groups, collapse/recolor, screenshot to self-verify); `workflow-layout` skill with the "expose inputs/outputs" rule.
- **Attach more than images** — composer accepts video, workflow `.json`, and text files.

### Fixed
- **Reconnect durability** — Connect reclaims a lockfile-less orchestrator zombie that survived reloads + a full ComfyUI restart and blocked reconnection.
- **Rollback anchor stability** — rewind anchor stored as the turn UUID (not an array index).
- **Save-card** rendering fix.

Full detail in `CHANGELOG.md`. Panel JS verified with `node --check`.

> ⚠️ Merging the `pyproject.toml` bump to `main` triggers the Comfy Registry publish (auto-on-pyproject). The npm package publishes via the `v0.16.0` tag on the mcp repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)