### PR TITLE
fix(panel): make comfy_reboot robust against Desktop Manager exit-before-response

### DIFF
--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2177,8 +2177,56 @@ const GRAPH_TOOL_EXECUTORS = {
         // reboot; don't block a needed restart on a flaky probe.
       }
     }
-    await managerV2("manager/reboot", { method: "POST" });
-    return { rebooting: true };
+    // Fire the reboot. IMPORTANT: a "successful" reboot usually looks like a
+    // FAILED fetch. The bundled Desktop Manager handler calls exit(0) the instant
+    // it accepts POST /v2/manager/reboot — the process dies before sending any HTTP
+    // response, so fetch rejects with "Failed to fetch". Because this panel runs
+    // INSIDE the live ComfyUI frontend, the server was demonstrably up a moment
+    // ago, so a dropped connection here means the reboot fired (not that the
+    // endpoint is unreachable). Treat that as success and let the auto-reconnect/
+    // resume flow take over. Try the canonical v2 route first, then the legacy
+    // GET route for older Manager builds; a real Response that is 404/non-OK means
+    // "wrong route on this build" → try the next; 403 means Manager security
+    // blocked it (a real, actionable failure). On total failure we RETURN a
+    // structured error (rebooting:false) rather than throw, so the agent is told
+    // accurately AND the auto-resume flag is not armed.
+    const candidates = [
+      { route: "/v2/manager/reboot", method: "POST" },
+      { route: "/manager/reboot", method: "GET" },
+    ];
+    const errors = [];
+    for (const { route, method } of candidates) {
+      try {
+        const res = await api.fetchApi(route, { method });
+        if (res && res.ok) return { rebooting: true, endpoint: route, method };
+        if (res && res.status === 403) {
+          return {
+            rebooting: false,
+            error:
+              "ComfyUI-Manager refused the reboot (HTTP 403): rebooting requires the Manager " +
+              "security level to be 'middle' or below. Ask the user to lower it in ComfyUI-Manager " +
+              "settings, then retry. ComfyUI was NOT restarted.",
+          };
+        }
+        // 404 / other non-OK: this route isn't the one on this build — try next.
+        errors.push(`${method} ${route} → HTTP ${res ? res.status : "no response"}`);
+      } catch {
+        // Connection dropped mid-request = server going down = reboot initiated.
+        return {
+          rebooting: true,
+          endpoint: route,
+          method,
+          note: "connection dropped (server going down) — reboot initiated",
+        };
+      }
+    }
+    return {
+      rebooting: false,
+      error:
+        "Could not reach any ComfyUI-Manager reboot endpoint — ComfyUI was NOT restarted " +
+        "(is the built-in Manager enabled?). Tried: " +
+        errors.join("; "),
+    };
   },
   async free_vram() {
     // Unload all resident models + free cached VRAM via ComfyUI's standard /free
@@ -5199,7 +5247,11 @@ function buildPanel() {
       if (reply.ok && AUTOFIT_CMDS.has(cmd)) scheduleAutoFit();
       // The agent restarted ComfyUI — arm the auto-resume so we reconnect and
       // nudge it to continue once ComfyUI is back (install→restart→continue).
-      if (cmd === "comfy_reboot" && reply.ok) {
+      // Gate on the handler actually reporting rebooting:true — a busy-guard
+      // refusal or a failed reboot also returns ok:true but rebooting:false, and
+      // arming resume in those cases would leave the panel waiting for a restart
+      // that never happens.
+      if (cmd === "comfy_reboot" && reply.ok && reply.result?.rebooting === true) {
         ssSet(REBOOT_KEY, "1");
         appendSystem("Restarting ComfyUI to load new nodes — I'll reconnect and pick up automatically when it's back.");
       }


### PR DESCRIPTION
## Problem

Live test: the panel agent's `restart_comfyui` -> bridge `comfy_reboot` -> panel JS POSTs the ComfyUI Manager reboot endpoint, and it **failed with \"Failed to fetch\"**. This broke the install -> restart -> continue linchpin: the queued `cg-use-everywhere` / `rgthree` install never loaded because the restart was reported as failed and the auto-resume never armed.

## Root cause

The endpoint was **correct** — both the reference frontend (`useComfyManagerService.rebootComfyUI`) and the installed ComfyUI Manager 4.2.2 use `POST /v2/manager/reboot` exclusively.

The real problem is the server-side handler. On ComfyUI Desktop (`__COMFY_CLI_SESSION__` is set), `glob/manager_server.py::restart()` calls `exit(0)` the instant it accepts the POST — the process dies **before sending any HTTP response**. So `fetch` rejects with `TypeError: "Failed to fetch"` even though the reboot fired.

The old code did `await managerV2("manager/reboot", { method: "POST" })` and let that rejection propagate. Result: `comfy_reboot` threw, the agent was told the reboot failed, and `REBOOT_KEY` (auto-resume) was never armed — so the freshly installed nodes were never picked up.

As a secondary issue, the auto-resume was gated on `reply.ok` alone, so even the busy-guard refusal (which returns `ok:true, rebooting:false`) would have armed a resume for a restart that never happens.

## Fix

In `web/js/comfyui-mcp-panel.js`:

- `comfy_reboot` now treats a **dropped connection mid-request as a successful reboot trigger**. The panel runs inside the live ComfyUI frontend, so the server was demonstrably up a moment ago; a network drop means it is going down. Returns `{ rebooting: true }`.
- Endpoint **fallback chain**: canonical `POST /v2/manager/reboot` first, then legacy `GET /manager/reboot` for older Manager builds. A real `404`/non-OK Response means \"wrong route on this build\" -> try the next instead of throwing.
- `403` is surfaced as an actionable error (Manager security level must be `middle` or below).
- On total failure it **returns** a structured `{ rebooting: false, error }` so the agent is told accurately, instead of throwing an opaque \"Failed to fetch\".
- Auto-resume is armed only when `reply.result?.rebooting === true`, so busy-guard refusals and failed reboots no longer leave the panel waiting for a restart that never happens. The busy-guard (refuse while a render is queued) is otherwise unchanged.

## Verification

- `node --check web/js/comfyui-mcp-panel.js` -> exit 0.
- `__init__.py` untouched (no Python check needed).
- Endpoint/route confirmed against the reference frontend and installed Manager 4.2.2 source.

**Not verified without a live Manager:** the end-to-end reboot -> reconnect -> resume against a running Desktop ComfyUI (the connection-drop-as-success heuristic and the legacy-route fallback are reasoned from source, not exercised live).

🤖 Generated with [Claude Code](https://claude.com/claude-code)