### PR TITLE
fix(panel): auto-escalate a stuck soft-reload to a clean reconnect

### DIFF
--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -5644,8 +5644,21 @@ function buildPanel() {
   // > RECONNECT_MAX_MS (15s) so the soft-reload's own backoff gets a full shot
   // before auto-respawn is re-armed.
   const SOFT_RELOAD_GUARD_MS = 28000;
+  // SHORT one-shot escalation window for a STUCK soft-reload. The guard above stops
+  // a competing-respawn storm, but it leaves a gap: when the fresh orchestrator binds
+  // the port yet its AGENT handshake (the `models` frame → "connected") never lands,
+  // the WS is OPEN — so there's no close event to drive scheduleReconnect, and
+  // tryAutoRespawn is standing down for the guard window. The panel then sits in the
+  // "Connected … waiting for the panel agent" stuck state until the user manually
+  // clicks Reconnect. So: if the handshake hasn't landed within this short window
+  // (comfortably under the 28s guard and the 20s HANDSHAKE_MS, but generous enough
+  // for a normal cold start), AUTO-ESCALATE once to exactly what Reconnect does — a
+  // single clean connectAgent(). One-shot (never a loop) so it can't reintroduce the
+  // storm the interlock prevents.
+  const SOFT_RELOAD_ESCALATE_MS = 11000;
   let softReloadInFlight = false;
   let softReloadGuardTimer = null;
+  let softReloadEscalateTimer = null;
   function setSoftReloadGuard() {
     softReloadInFlight = true;
     if (softReloadGuardTimer) clearTimeout(softReloadGuardTimer);
@@ -5653,6 +5666,14 @@ function buildPanel() {
       softReloadGuardTimer = null;
       softReloadInFlight = false; // safety: a failed soft-reload re-enables auto-respawn
     }, SOFT_RELOAD_GUARD_MS);
+    // Arm the stuck-handshake escalation. A FAST soft-reload handshakes well before
+    // this fires and clearSoftReloadGuard() (on "connected") cancels it → no
+    // escalation. Only a genuinely stuck reload reaches the timer.
+    if (softReloadEscalateTimer) clearTimeout(softReloadEscalateTimer);
+    softReloadEscalateTimer = setTimeout(() => {
+      softReloadEscalateTimer = null;
+      escalateSoftReload();
+    }, SOFT_RELOAD_ESCALATE_MS);
   }
   function clearSoftReloadGuard() {
     softReloadInFlight = false;
@@ -5660,6 +5681,27 @@ function buildPanel() {
       clearTimeout(softReloadGuardTimer);
       softReloadGuardTimer = null;
     }
+    if (softReloadEscalateTimer) {
+      clearTimeout(softReloadEscalateTimer);
+      softReloadEscalateTimer = null;
+    }
+  }
+  // The soft-reload's WS is open (or reconnecting) but the agent handshake hasn't
+  // landed within the short window — the "connected … waiting for the panel agent"
+  // stuck state. Escalate ONCE to exactly what the user's manual Reconnect does:
+  // drop the stale (open-but-unhandshook) socket — necessary because connect()
+  // early-returns on an already-OPEN socket, so a bare connectAgent()/client.start()
+  // alone would NOT replace it — then run a single clean connectAgent(). connectAgent
+  // bumps connectGen (superseding the soft-reload's own pending reconnect so the two
+  // never both drive the client), resets the reclaim/respawn budgets and clears this
+  // guard, so its own connectGen/budget logic owns recovery from here. One-shot
+  // timer: it can't loop, so no competing-respawn storm.
+  function escalateSoftReload() {
+    if (!softReloadInFlight) return; // handshake already landed / guard cleared → nothing to do
+    appendSystem("The agent reload is taking too long to hand off — reconnecting cleanly…");
+    client.stop(); // drop the stuck socket so connect() won't early-return on an OPEN sock
+    connecting = false; // don't let a stale in-flight guard block the escalation connect
+    void connectAgent();
   }
   // The bridge died and WS reconnects keep failing → the port is dead (the
   // orchestrator exited). If sticky autoconnect is on, spend the bounded respawn


### PR DESCRIPTION
## Problem

The soft-reload bug is very disruptive: after `/reload` the panel often ends up **stuck** in "Connected … waiting for the panel agent" (bridge open, no agent handshake). The user has to click **Reconnect** to recover.

### Root cause

A prior fix added a soft-reload ↔ auto-respawn **interlock**: `softReload("orchestrator")` does `client.stop()` → POST `/reload` → `client.start()`, and sets `softReloadInFlight` (28s `SOFT_RELOAD_GUARD_MS`) so `tryAutoRespawn()` stands down and doesn't fire a competing `/connect` while the fresh orchestrator cold-starts. That stopped the competing-respawn storm.

But it left a **gap with no auto-recovery**: when the fresh orchestrator binds the port yet its **agent handshake** (the `models` frame → `"connected"`) never lands —

- the WS is **OPEN**, so there's no `close` event to drive `scheduleReconnect`/`tryAutoRespawn`;
- `tryAutoRespawn` is suppressed by the guard anyway;
- the only remaining escape is the 20s `handshakeTimer` → `tryAutoReclaim` — a long wait on top of cold-start.

So the panel sits stuck. The user clicks **Reconnect** (`saveBtn` → `client.setUrl`, which **closes** the socket and reconnects fresh) and it recovers. Note: clicking **Connect** alone often wouldn't help, because `connect()` early-returns on an already-OPEN socket — only a path that drops the stale socket forces a fresh handshake. That asymmetry is exactly why "pressing reconnect usually fixes it."

## Fix

Arm a **short one-shot escalation** (`SOFT_RELOAD_ESCALATE_MS = 11000`) alongside the guard in `setSoftReloadGuard()`:

- It's comfortably under the 28s guard and the 20s `HANDSHAKE_MS`, but generous enough for a normal cold start.
- If the handshake hasn't landed by then, `escalateSoftReload()` does exactly what manual Reconnect does: `client.stop()` (drop the stale open-but-unhandshook socket — required, since `connect()` early-returns on an OPEN sock so `connectAgent` alone can't replace it), then **one** clean `connectAgent()`.
- `connectAgent` bumps `connectGen` (superseding the soft-reload's own pending reconnect so the two never both drive the client), calls `resetAutoReclaim()` + `clearSoftReloadGuard()`, then drives a fresh `/connect` + reconnect. From there its own `connectGen`/budget logic owns recovery.
- `clearSoftReloadGuard()` also cancels the escalation timer, so a successful handshake (`onStatus("connected")`), a fresh user/sticky Connect, or any soft-reload failure path all cancel it.

This mirrors the existing `connectBackend()` clean-teardown pattern (`client.stop(); connecting = false; connectAgent()`).

## Cases

1. **Fast soft-reload** → handshake lands first → `onStatus("connected")` → `clearSoftReloadGuard()` cancels the escalation timer. Resumes via its own reconnect, **no escalation**.
2. **Orchestrator binds but agent handshake stalls** (the stuck state) → at ~11s the escalation fires → `client.stop()` + one `connectAgent()` → fresh socket, fresh handshake → recovers **with no manual Reconnect**.
3. **No competing-respawn storm** → the escalation is a **one-shot** timer (not a loop). It supersedes the soft-reload's pending reconnect (stop + `connectGen` bump) so only one path drives the client; after it, `connectAgent`'s bounded reclaim/respawn budgets take over. The interlock's storm-prevention guarantee is preserved.
4. **Real orchestrator death** → still recovers: `connectAgent` POSTs `/connect` (a respawn), now via a single clean bounded path, and once `softReloadInFlight` is cleared, subsequent drops go through the normal bounded `tryAutoRespawn` as before.

## Verification

- `node --check web/js/comfyui-mcp-panel.js` → exit 0.
- This is live-frontend behavior; it needs a **live soft-reload re-test** to confirm the stuck handshake escalates and recovers in-browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)