### PR TITLE
Backend-driven interdependent Defaults settings + 4 P2 fixes

### DIFF
--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -264,6 +264,30 @@ let suppressSettingOnChange = false;
 // decision; only genuine post-load user edits in the Settings dialog take effect.
 let settingsArmed = false;
 
+// Backend display names available at module scope (the panel also has its own copy
+// in buildPanel's closure for the chips; this one is for the Settings dialog).
+const BACKEND_TEXT = { claude: "Claude", codex: "ChatGPT" };
+
+// Live panel state PUBLISHED for the Settings dialog's backend-driven Default-model
+// / Default-effort / Bridge-URL controls. Those render at MODULE scope (outside
+// buildPanel's closure via the settings `type:()=>HTMLElement` render-fns), so the
+// open panel keeps this current and it persists (last value) after the panel
+// unmounts — the dialog can still render sensible options. `modelsByBackend` is the
+// per-backend FETCHED catalog (cached as each backend is connected at least once);
+// `ports` is the per-backend bridge port discovered from /backends (claude 9180,
+// codex 9181 by default — see the pack's _BACKEND_PORTS map).
+const settingsBackendState = {
+  connectedBackend: null, // backend whose live catalog we currently hold, or null
+  modelsByBackend: {}, // backend id -> presentable model rows (last fetched)
+  ports: { claude: 9180, codex: 9181 }, // per-backend bridge port (from /backends)
+};
+// References to the dialog's live dependent controls, (re)set by their render-fns
+// each time the dialog opens, so the Agent-backend onChange can RESET + repopulate
+// them in place (a render-fn setting has no static options to re-key).
+let settingsModelSelectEl = null;
+let settingsEffortSelectEl = null;
+let settingsBridgeInputEl = null;
+
 function getSetting(id) {
   try {
     return app?.ui?.settings?.getSettingValue?.(id);
@@ -301,7 +325,23 @@ function triggerSecret(envKey, friendly) {
   if (go()) return;
   let tries = 0;
   const t = setInterval(() => {
-    if (go() || ++tries > 25) clearInterval(t);
+    if (go()) {
+      clearInterval(t);
+      return;
+    }
+    // Retry exhausted: the panel never mounted / its hook never appeared (e.g. the
+    // Agent tab was never opened, or it failed to mount). Don't silently no-op —
+    // tell the user how to recover instead of leaving the button dead (fix b).
+    if (++tries > 25) {
+      clearInterval(t);
+      try {
+        window.alert(
+          `Open the Agent panel, connect, then set the ${friendly} token again.`,
+        );
+      } catch {
+        /* alert unavailable (headless/embedded) — nothing else to do */
+      }
+    }
   }, 150);
 }
 
@@ -387,6 +427,9 @@ function panelSettingsList() {
       tooltip:
         "Which background agent the panel connects to by default. Claude runs on your Claude subscription; " +
         "ChatGPT runs on your Codex (ChatGPT) account. Seeds the panel's backend; you can still switch live in the model picker.",
+      // Backend is the PARENT control: changing it RESETS the dependent Default-model
+      // (to Auto), maps Default-effort to the new backend's scale, and resets the
+      // Bridge URL to the new backend's default port — then drives the live panel.
       type: "combo",
       options: [
         { value: "claude", text: "Claude" },
@@ -395,57 +438,86 @@ function panelSettingsList() {
       defaultValue: "claude",
       onChange: (v) => {
         if (suppressSettingOnChange || !settingsArmed) return;
+        applyBackendDefaults(v); // reset model/effort/bridge + repopulate the controls
         panelHooks.applyBackend?.(v);
       },
     },
     {
+      // Default model — a real DROPDOWN of the FETCHED models for the selected
+      // backend (the same catalog the composer's picker shows). Rendered via the
+      // custom render-fn so it can be repopulated dynamically when the backend
+      // changes (a static `combo`'s options are fixed at registration). "Auto"
+      // clears the forced model (fix a). render-fn settings get no startup onChange
+      // volley, but we still gate the live applier on settingsArmed for consistency.
       id: SETTING_MODEL,
       name: "Default model",
       category: cat("Defaults", "Default model"),
       tooltip:
-        "Default model id for the background agent, e.g. claude-opus-4-8 or claude-sonnet-4-5 (Claude) / a Codex model id. " +
-        "Leave blank to auto-pick. Changing the model in the panel updates this too.",
-      type: "text",
-      defaultValue: "",
-      onChange: (v) => {
-        if (suppressSettingOnChange || !settingsArmed) return;
-        panelHooks.applyModel?.(v);
+        "Default model for the background agent, chosen from the models fetched for the selected backend (the same " +
+        "list the panel's model picker shows). 'Auto' lets the agent pick. Changing the model in the panel updates this too. " +
+        "A backend you haven't connected to yet may show only 'Auto' + your saved choice until you connect.",
+      type: () => {
+        const sel = makeSettingSelect();
+        populateModelSelect(sel, currentSettingsBackend());
+        sel.addEventListener("change", () => {
+          const v = sel.value === SETTINGS_PLACEHOLDER ? "" : sel.value;
+          setSetting(SETTING_MODEL, v);
+          if (settingsArmed) panelHooks.applyModel?.(v);
+        });
+        settingsModelSelectEl = sel;
+        return sel;
       },
     },
     {
+      // Default reasoning effort — render-fn dropdown whose options are the SELECTED
+      // backend's scale (Claude: low–max; Codex/ChatGPT: none–xhigh). When the backend
+      // changes, the current value is mapped to the nearest valid level. "Model
+      // default" clears the effort pref (fix a).
       id: SETTING_EFFORT,
       name: "Default reasoning effort",
       category: cat("Defaults", "Default reasoning effort"),
       tooltip:
-        "Default reasoning effort. The panel snaps this to the nearest level the connected backend/model supports " +
-        "(Claude: low–max; ChatGPT/Codex: none–xhigh). 'Model default' leaves it unset.",
-      type: "combo",
-      options: [
-        { value: "", text: "Model default" },
-        { value: "low", text: "Low" },
-        { value: "medium", text: "Medium" },
-        { value: "high", text: "High" },
-        { value: "xhigh", text: "Extra high" },
-        { value: "max", text: "Max" },
-      ],
-      defaultValue: "",
-      onChange: (v) => {
-        if (suppressSettingOnChange || !settingsArmed) return;
-        panelHooks.applyEffort?.(v);
+        "Default reasoning effort, from the selected backend's scale (Claude: low–max; ChatGPT/Codex: none–xhigh). " +
+        "Switching backend maps this to the nearest valid level. 'Model default' leaves it unset.",
+      type: () => {
+        const sel = makeSettingSelect();
+        populateEffortSelect(sel, currentSettingsBackend());
+        sel.addEventListener("change", () => {
+          setSetting(SETTING_EFFORT, sel.value);
+          if (settingsArmed) panelHooks.applyEffort?.(sel.value);
+        });
+        settingsEffortSelectEl = sel;
+        return sel;
       },
     },
     {
+      // Bridge URL — render-fn input so the value can be RESET in place when the
+      // backend changes (Claude bridge :9180 vs ChatGPT/Codex bridge :9181, per the
+      // pack's _BACKEND_PORTS map / GET /backends). Still freely editable.
       id: SETTING_BRIDGE_URL,
       name: "Bridge URL",
       category: cat("Defaults", "Bridge URL"),
       tooltip:
-        "WebSocket URL of the panel orchestrator bridge. Default ws://127.0.0.1:9180. Only change this if you run the " +
-        "orchestrator on a non-default port.",
-      type: "text",
-      defaultValue: DEFAULT_BRIDGE_URL,
-      onChange: (v) => {
-        if (suppressSettingOnChange || !settingsArmed) return;
-        panelHooks.applyBridgeUrl?.(v);
+        "WebSocket URL of the panel orchestrator bridge. Defaults to the selected backend's port (Claude ws://127.0.0.1:9180, " +
+        "ChatGPT/Codex ws://127.0.0.1:9181). Only change this if you run the orchestrator on a non-default port.",
+      type: () => {
+        const inp = document.createElement("input");
+        inp.type = "text";
+        inp.className = "p-inputtext p-component";
+        inp.style.cssText =
+          "padding:0.3rem 0.5rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
+          "background:var(--p-surface-900,#18181b);color:var(--p-text-color,#e4e4e7);font-size:0.8rem;min-width:14rem;";
+        const backend = currentSettingsBackend();
+        const cur = getSetting(SETTING_BRIDGE_URL);
+        inp.value = typeof cur === "string" && cur ? cur : backendBridgeUrl(backend);
+        inp.placeholder = backendBridgeUrl(backend);
+        inp.addEventListener("change", () => {
+          const v = inp.value.trim();
+          setSetting(SETTING_BRIDGE_URL, v);
+          if (settingsArmed) panelHooks.applyBridgeUrl?.(v);
+        });
+        settingsBridgeInputEl = inp;
+        return inp;
       },
     },
     {
@@ -465,6 +537,120 @@ function panelSettingsList() {
     tokenSetting(SETTING_TOKEN_CIVITAI, "CIVITAI_API_TOKEN", "CivitAI"),
     tokenSetting(SETTING_TOKEN_HF, "HUGGINGFACE_TOKEN", "HuggingFace"),
   ];
+}
+
+// Disabled placeholder <option> value (e.g. "Connect to load models") — mapped to
+// "" (Auto) if it ever gets selected so it never persists as a bogus model id.
+const SETTINGS_PLACEHOLDER = "__cmcp_placeholder__";
+
+/** Which backend the Settings dialog's dependent controls should reflect — the
+ *  persisted Default-backend (claude/codex), defaulting to claude. */
+function currentSettingsBackend() {
+  return getSetting(SETTING_BACKEND) === "codex" ? "codex" : "claude";
+}
+/** The default bridge ws:// URL for `backend` (port from /backends discovery, or
+ *  the static fallback: claude 9180, codex 9181). */
+function backendBridgeUrl(backend) {
+  const port =
+    settingsBackendState.ports[backend] ?? (backend === "codex" ? 9181 : 9180);
+  return `ws://127.0.0.1:${port}`;
+}
+/** Fetched model rows for `backend` (the same presentable catalog the composer
+ *  picker uses), or null when none is cached (backend never connected this session). */
+function settingsModelsFor(backend) {
+  const rows = settingsBackendState.modelsByBackend[backend];
+  return Array.isArray(rows) && rows.length ? rows : null;
+}
+/** A styled <select> matching the settings dialog's inputs. */
+function makeSettingSelect() {
+  const sel = document.createElement("select");
+  sel.className = "p-inputtext p-component";
+  sel.style.cssText =
+    "padding:0.3rem 0.5rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
+    "background:var(--p-surface-900,#18181b);color:var(--p-text-color,#e4e4e7);font-size:0.8rem;min-width:14rem;";
+  return sel;
+}
+/** (Re)populate the Default-model <select> for `backend`: an "Auto" option, then
+ *  the fetched models; a saved-but-absent model id is kept as a selectable entry so
+ *  a backend switch / not-yet-connected backend never loses the user's choice. */
+function populateModelSelect(sel, backend) {
+  if (!sel) return;
+  const rows = settingsModelsFor(backend);
+  const saved = getSetting(SETTING_MODEL) || "";
+  sel.replaceChildren();
+  const auto = document.createElement("option");
+  auto.value = "";
+  auto.textContent = "Auto (let the agent pick)";
+  sel.appendChild(auto);
+  const seen = new Set([""]);
+  if (rows) {
+    for (const m of rows) {
+      const o = document.createElement("option");
+      o.value = m.id;
+      o.textContent = m.small ? `${m.label} — ${m.small}` : m.label;
+      sel.appendChild(o);
+      seen.add(m.id);
+    }
+  } else {
+    const hint = document.createElement("option");
+    hint.value = SETTINGS_PLACEHOLDER;
+    hint.disabled = true;
+    hint.textContent = `Connect to ${BACKEND_TEXT[backend] || backend} to load its models`;
+    sel.appendChild(hint);
+  }
+  // Preserve a saved model id that isn't in this catalog (cross-backend / offline).
+  if (saved && !seen.has(saved)) {
+    const o = document.createElement("option");
+    o.value = saved;
+    o.textContent = `${saved} (saved)`;
+    sel.appendChild(o);
+    seen.add(saved);
+  }
+  sel.value = seen.has(saved) ? saved : "";
+}
+/** (Re)populate the Default-effort <select> with `backend`'s effort scale. */
+function populateEffortSelect(sel, backend) {
+  if (!sel) return;
+  const scale = BACKEND_EFFORTS[backend] || ALL_EFFORTS;
+  const saved = getSetting(SETTING_EFFORT);
+  sel.replaceChildren();
+  const def = document.createElement("option");
+  def.value = "";
+  def.textContent = "Model default";
+  sel.appendChild(def);
+  for (const id of scale) {
+    const o = document.createElement("option");
+    o.value = id;
+    o.textContent = effortMeta(id).label;
+    sel.appendChild(o);
+  }
+  sel.value = typeof saved === "string" && scale.includes(saved) ? saved : "";
+}
+/** Repaint the dialog's dependent controls in place for `backend` (no-op for any
+ *  control whose element is no longer mounted). */
+function rebuildDependentSettings(backend) {
+  if (settingsModelSelectEl?.isConnected) populateModelSelect(settingsModelSelectEl, backend);
+  if (settingsEffortSelectEl?.isConnected) populateEffortSelect(settingsEffortSelectEl, backend);
+  if (settingsBridgeInputEl?.isConnected) {
+    settingsBridgeInputEl.value = backendBridgeUrl(backend);
+    settingsBridgeInputEl.placeholder = backendBridgeUrl(backend);
+  }
+}
+/** Backend changed in the Settings dialog: RESET the dependent prefs to the new
+ *  backend's valid options/defaults (model→Auto, effort→nearest level in the new
+ *  scale, bridge URL→new backend's port), persist them, and repaint the controls.
+ *  The live panel is driven separately by panelHooks.applyBackend. */
+function applyBackendDefaults(backend) {
+  const scale = BACKEND_EFFORTS[backend] || ALL_EFFORTS;
+  const curEffort = getSetting(SETTING_EFFORT);
+  const mappedEffort =
+    typeof curEffort === "string" && curEffort ? nearestInList(curEffort, scale) || "" : "";
+  setSetting(SETTING_EFFORT, mappedEffort);
+  // The new backend's catalog differs — reset the model to Auto so the user
+  // re-picks from the new backend's fetched models (no stale cross-backend id).
+  setSetting(SETTING_MODEL, "");
+  setSetting(SETTING_BRIDGE_URL, backendBridgeUrl(backend));
+  rebuildDependentSettings(backend);
 }
 
 // ---------------------------------------------------------------------------
@@ -3617,10 +3803,20 @@ function buildPanel() {
   logo.className = "cmcp-logo";
   logo.alt = "";
   logo.setAttribute("aria-hidden", "true");
+  const LOGO_SERVED_PATH = "/extensions/comfyui-mcp-panel/img/comfyui-mcp-logo.png";
+  // A 404 on the module-resolved URL must also recover — not just a URL()
+  // construction failure. Fall back to the served path once (a flag prevents an
+  // error loop if the served path itself 404s) (fix c).
+  logo.addEventListener("error", () => {
+    if (logo.dataset.fellBack === "1") return;
+    logo.dataset.fellBack = "1";
+    logo.src = LOGO_SERVED_PATH;
+  });
   try {
     logo.src = new URL("../img/comfyui-mcp-logo.png", import.meta.url).href;
   } catch {
-    logo.src = "/extensions/comfyui-mcp-panel/img/comfyui-mcp-logo.png";
+    logo.dataset.fellBack = "1";
+    logo.src = LOGO_SERVED_PATH;
   }
   const title = document.createElement("span");
   title.className = "cmcp-title";
@@ -3716,6 +3912,12 @@ function buildPanel() {
         ? backends
         : [{ backend: "claude", running: false }];
     knownBackends = list;
+    // Publish discovered ports for the Settings dialog's backend-driven Bridge URL.
+    for (const b of list) {
+      if (b && b.backend && Number.isFinite(b.port)) {
+        settingsBackendState.ports[b.backend] = b.port;
+      }
+    }
     for (const b of list) {
       const id = b.backend;
       const chip = document.createElement("button");
@@ -4210,7 +4412,7 @@ function buildPanel() {
   modelChip.append(modelChipLabel, modelChipEffort, modelChipCaret);
 
   function refreshModelChip() {
-    modelChipLabel.textContent = modelLabel(modelCatalog, prefs.model);
+    modelChipLabel.textContent = prefs.modelAuto ? "Auto" : modelLabel(modelCatalog, prefs.model);
     modelChipEffort.textContent = prefs.effort ? ` · ${prefs.effort}` : "";
   }
 
@@ -4226,7 +4428,7 @@ function buildPanel() {
       setSetting(SETTING_BACKEND, selectedBackend || "claude");
       // Only persist model/effort the user actually chose — never a synthetic
       // fallback-catalog default (which may be an alias id, not a real model).
-      if (prefs.userSet && prefs.model) setSetting(SETTING_MODEL, prefs.model);
+      if (prefs.userSet && prefs.model && !prefs.modelAuto) setSetting(SETTING_MODEL, prefs.model);
       if (prefs.userSet && prefs.effort) setSetting(SETTING_EFFORT, prefs.effort);
       setSetting(SETTING_BRIDGE_URL, urlInput.value || DEFAULT_BRIDGE_URL);
       setSetting(SETTING_AUTOCONNECT, !!lsGet(AUTOCONNECT_KEY));
@@ -4240,17 +4442,39 @@ function buildPanel() {
         window.localStorage.setItem(STORAGE_KEY_BACKEND, sb);
       } catch {}
     }
+    // Default model. A blank ("Auto") selection now CLEARS the forced model rather
+    // than being ignored (fix a) — keep a valid display id but drop the user-pin via
+    // prefs.modelAuto. A concrete id sets it and clears Auto. An UNSET setting
+    // (undefined, never chosen) is left alone so a brand-new user keeps the default.
     const sm = getSetting(SETTING_MODEL);
-    if (sm && sm !== prefs.model) {
-      prefs.model = sm;
-      prefs.userSet = true;
-      savePrefs(prefs);
+    if (typeof sm === "string") {
+      if (sm === "") {
+        if (!prefs.modelAuto) {
+          prefs.modelAuto = true;
+          if (!prefs.model) prefs.model = pickDefaultModel(modelCatalog);
+          savePrefs(prefs);
+        }
+      } else if (sm !== prefs.model || prefs.modelAuto) {
+        prefs.model = sm;
+        prefs.modelAuto = false;
+        prefs.userSet = true;
+        savePrefs(prefs);
+      }
     }
+    // Default effort. A blank ("Model default") selection CLEARS the effort pref
+    // (fix a); a concrete level sets it. An unset setting is left alone.
     const se = getSetting(SETTING_EFFORT);
-    if (typeof se === "string" && se !== "" && se !== prefs.effort) {
-      prefs.effort = se;
-      prefs.userSet = true;
-      savePrefs(prefs);
+    if (typeof se === "string") {
+      if (se === "") {
+        if (prefs.effort) {
+          prefs.effort = undefined;
+          savePrefs(prefs);
+        }
+      } else if (se !== prefs.effort) {
+        prefs.effort = se;
+        prefs.userSet = true;
+        savePrefs(prefs);
+      }
     }
     const su = getSetting(SETTING_BRIDGE_URL);
     if (su && su !== urlInput.value) {
@@ -4325,8 +4549,9 @@ function buildPanel() {
 
     section("Model");
     for (const m of modelCatalog) {
-      item({ label: m.label, small: m.small }, m.id === prefs.model, () => {
+      item({ label: m.label, small: m.small }, m.id === prefs.model && !prefs.modelAuto, () => {
         prefs.model = m.id;
+        prefs.modelAuto = false; // an explicit pick clears the Auto state
         prefs.userSet = true;
         // SNAP the effort to the nearest level the new model supports (don't wipe
         // it silently); only clear if the model has no effort control at all.
@@ -4374,6 +4599,14 @@ function buildPanel() {
     const next = presentableModels(normalizeModels(list));
     if (!next.length) return;
     modelCatalog = next;
+    // Cache this FETCHED catalog per backend so the Settings dialog's Default-model
+    // dropdown can offer the right list for the connected backend (and still show a
+    // previously-connected backend's models after a switch).
+    const bk = connectedBackend || selectedBackend;
+    if (bk) {
+      settingsBackendState.modelsByBackend[bk] = modelCatalog;
+      settingsBackendState.connectedBackend = connectedBackend;
+    }
     // Keep the user's saved pick if still valid; else pre-select Opus.
     if (!modelCatalog.some((m) => m.id === prefs.model)) {
       prefs.model = pickDefaultModel(modelCatalog);
@@ -4412,7 +4645,8 @@ function buildPanel() {
     if (prefs.userSet) {
       client?.sendFrame?.({
         type: "set_options",
-        model: prefs.model,
+        // Auto (modelAuto) un-pins the model so the agent uses its own default.
+        model: prefs.modelAuto ? null : prefs.model,
         effort: prefs.effort ?? null,
       });
     }
@@ -7544,8 +7778,22 @@ function buildPanel() {
   };
   panelHooks.applyModel = (id) => {
     const next = (id || "").trim();
-    if (!next || next === prefs.model) return;
+    // Blank = "Auto (let the agent pick)" → CLEAR the forced model live (fix a):
+    // un-pin so a fresh/continued session uses the agent's own default. Keep a valid
+    // display id; the chip shows "Auto".
+    if (!next) {
+      if (prefs.modelAuto) return;
+      prefs.modelAuto = true;
+      if (!prefs.model) prefs.model = pickDefaultModel(modelCatalog);
+      savePrefs(prefs);
+      refreshModelChip();
+      client?.sendFrame?.({ type: "set_options", model: null, effort: prefs.effort ?? null });
+      appendSystem("Model → Auto (the agent picks).");
+      return;
+    }
+    if (next === prefs.model && !prefs.modelAuto) return;
     prefs.model = next;
+    prefs.modelAuto = false;
     prefs.userSet = true;
     savePrefs(prefs);
     refreshModelChip();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -460,7 +460,17 @@ function panelSettingsList() {
         const sel = makeSettingSelect();
         populateModelSelect(sel, currentSettingsBackend());
         sel.addEventListener("change", () => {
-          const v = sel.value === SETTINGS_PLACEHOLDER ? "" : sel.value;
+          let v = sel.value === SETTINGS_PLACEHOLDER ? "" : sel.value;
+          // Guard: never persist/send a model that isn't in the known fetched catalog
+          // for the current backend (a stale cross-backend id) — snap to Auto instead
+          // (P2). Disabled options already can't be picked; this covers any other path.
+          if (v) {
+            const rows = settingsModelsFor(currentSettingsBackend());
+            if (rows && !rows.some((m) => m.id === v)) {
+              v = "";
+              sel.value = "";
+            }
+          }
           setSetting(SETTING_MODEL, v);
           if (settingsArmed) panelHooks.applyModel?.(v);
         });
@@ -598,13 +608,22 @@ function populateModelSelect(sel, backend) {
     hint.textContent = `Connect to ${BACKEND_TEXT[backend] || backend} to load its models`;
     sel.appendChild(hint);
   }
-  // Preserve a saved model id that isn't in this catalog (cross-backend / offline).
+  // A saved model id that isn't in this list. When there's NO live catalog (backend
+  // not connected this session), keep it SELECTABLE so the user's choice isn't lost.
+  // But when `rows` IS the fetched catalog for this backend and the id isn't in it,
+  // it's invalid for this backend — render it DISABLED ("not available") and snap the
+  // selection to Auto, so it can never be re-sent as a cross-backend model (P2 fix).
   if (saved && !seen.has(saved)) {
     const o = document.createElement("option");
     o.value = saved;
-    o.textContent = `${saved} (saved)`;
+    if (rows) {
+      o.disabled = true;
+      o.textContent = `${saved} (not available for this backend)`;
+    } else {
+      o.textContent = `${saved} (saved)`;
+      seen.add(saved);
+    }
     sel.appendChild(o);
-    seen.add(saved);
   }
   sel.value = seen.has(saved) ? saved : "";
 }
@@ -7774,6 +7793,21 @@ function buildPanel() {
   panelHooks.applyBackend = (id) => {
     if (!id || id === selectedBackend) return;
     appendSystem(`Default backend → ${BACKEND_LABELS[id] || id}.`);
+    // A Settings backend change RESETS the dependent controls (the Settings UI does
+    // this for SETTING_MODEL/EFFORT, but those writes are under suppressSettingOnChange
+    // and the model/effort are render-fns with no onChange, so they never reach the
+    // live prefs). Mirror the reset in the LIVE prefs BEFORE connecting so the agent
+    // and the Settings UI agree on Auto: set modelAuto so the next catalog push sends
+    // model:null (P1 desync fix — otherwise applyModelCatalog would snap prefs.model
+    // to a concrete backend default and send THAT while the UI shows "Auto"), and map
+    // the effort to the nearest valid level in the new backend's scale.
+    prefs.modelAuto = true;
+    if (prefs.effort) {
+      const scale = BACKEND_EFFORTS[id] || ALL_EFFORTS;
+      prefs.effort = nearestInList(prefs.effort, scale) || undefined;
+    }
+    savePrefs(prefs);
+    refreshModelChip();
     connectBackend(id);
   };
   panelHooks.applyModel = (id) => {


### PR DESCRIPTION
## Summary

Reworks the **Defaults** in the panel's Application Settings so they are **backend-driven and interdependent**. **Agent backend is the parent control**; the dependent Default-model, Default-effort, and Bridge URL reset/adapt to it.

## Backend-driven, interdependent design

- **Order:** Agent backend first, then Default model, Default reasoning effort, Bridge URL (array order preserved; backend is the parent).
- **Changing Agent backend** (`applyBackendDefaults`): resets Default-model to **Auto**, **maps** Default-effort to the new backend's scale (`nearestInList`), and resets **Bridge URL** to the new backend's default port — then drives the live panel via `panelHooks.applyBackend`.

## Dynamic dropdowns via render-fn (`type: () => HTMLElement`)

ComfyUI combos have **static** options at registration, so Default-model and Default-effort are now custom render-fn `<select>`s (the same trick the token buttons + ⭐ star use). Bridge URL is a render-fn `<input>` so its value can be reset in place on a backend change.

When the backend combo changes, `rebuildDependentSettings(backend)` repopulates the live `<select>`/`<input>` elements in place (references captured by each render-fn: `settingsModelSelectEl` / `settingsEffortSelectEl` / `settingsBridgeInputEl`, guarded by `isConnected`).

## Model-catalog reuse + cross-backend fetch

Reuses the composer's machinery — `modelCatalog`, `presentableModels`/`normalizeModels`, `effortsForModel`, `BACKEND_EFFORTS`, `nearestInList`, `effortMeta`, `pickDefaultModel` (no duplication).

The fetched catalog is the connected backend's live list. The panel now **publishes** its per-backend catalog to module scope (`settingsBackendState.modelsByBackend[backend]`) inside `applyModelCatalog`, so the settings dropdown shows the right models for the connected backend (and a previously-connected backend after a switch).

**Cross-backend limitation (graceful fallback):** for a backend that has **not been connected this session**, no live list is available (the SDK probe only enumerates the *connected* backend), so the dropdown shows a disabled **"Connect to <backend> to load its models"** placeholder + keeps any previously-saved model id as a selectable `(saved)` entry — the user's choice is never lost. The dialog never blocks/hangs fetching. Per-backend bridge **ports** come from `GET /comfyui_mcp_panel/backends` (`settingsBackendState.ports`), with a static fallback (Claude 9180 / Codex 9181).

## Effort mapping

Per-backend scales (`BACKEND_EFFORTS`): Claude `low/medium/high/xhigh/max`; Codex/ChatGPT `none/minimal/low/medium/high/xhigh`. The effort dropdown shows the selected backend's scale; switching backend snaps the current value to the nearest valid level via `nearestInList`/`EFFORT_ORDER`.

## settingsArmed preserved

The new render-fn change handlers gate the **live appliers** (`panelHooks.apply*`) on `settingsArmed`; persistence via `setSetting` always runs. Render-fn settings don't receive ComfyUI's startup onChange volley, so this is belt-and-suspenders, but kept for consistency. The backend combo's `onChange` still respects `suppressSettingOnChange`/`settingsArmed`.

## 4 Codex P2 fixes

- **(a) Blank/Auto clears prefs.** New explicit **"Auto (let the agent pick)"** model option (`prefs.modelAuto`; sends `set_options model:null`) and effort **"Model default"** now CLEAR the prefs both live (`panelHooks.applyModel("")` / `applyEffort("")`) and on reopen (`seedFromSettings` honors `""` instead of ignoring it). Composer model-pick clears Auto; chip shows "Auto".
- **(b) Token button retry exhaustion** now shows an alert ("Open the Agent panel, connect, then set the <friendly> token again.") instead of silently no-op'ing.
- **(c) Logo onerror fallback** to the served path so a 404 recovers (not just a `URL()`-construction failure); a one-shot `dataset.fellBack` flag prevents an error loop.

## Verification

- `node --check web/js/comfyui-mcp-panel.js` → exit 0.
- **Needs live frontend re-test** (DOM/ComfyUI-settings behavior not exercisable headlessly):
  - Backend change resets/re-renders model + effort + bridge URL.
  - Model dropdown shows fetched models for the connected backend; non-connected backend shows the placeholder + saved entry.
  - Effort scale matches the selected backend; switching maps to the nearest level.
  - Blank/Auto model and "Model default" effort clear prefs live + on reopen.
  - No reconnect storm (settingsArmed intact).
  - Settings ordering within the "Defaults" group renders backend-first (ComfyUI may sort within a category; confirm visually).
  - Minor: after a settings backend switch, the settings model shows Auto while the composer snaps its saved model via its own reconnect path — confirm this is acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up review fixes (Codex P1 + P2)

**P1 — backend switch desynced Auto from the live agent.** `applyBackendDefaults()` reset `SETTING_MODEL` to `""` under `suppressSettingOnChange`, and the model is a render-fn with no `onChange`, so the live `prefs` never learned about Auto. `prefs.modelAuto` could stay `false` while the UI showed "Auto", and the next `applyModelCatalog()` would snap `prefs.model` to a concrete backend default and send THAT via `set_options`. Fixed: `panelHooks.applyBackend` now sets `prefs.modelAuto = true`, maps `prefs.effort` to the new backend's scale (`nearestInList`), saves, and refreshes the chip **before** connecting — so the catalog push sends `model: null` and the agent + Settings UI agree on Auto.

**P2 — saved-but-absent model could send an invalid cross-backend model.** `populateModelSelect()` appended a saved-but-absent id as an **enabled** option even when a fetched catalog for the backend existed. Fixed: the saved fallback is selectable only when there is **no** live catalog (backend not connected); when the fetched catalog exists and lacks the id, it renders **disabled** ("not available for this backend") and the selection snaps to Auto. The model render `onChange` also guards — a value not in the current backend's known catalog snaps to Auto instead of being sent.
