### PR TITLE
fix(panel): default Bridge URL overriding the per-backend port (Codex → 9180)

### DIFF
--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -6410,7 +6410,13 @@ function buildPanel() {
     // manual override → keep it, and don't let /connect's bridge_url clobber it.
     // (A chip pick is never a manual override — it always uses the backend's port.)
     const wanted = urlInput.value.trim();
-    const manualOverride = !opts.fromChip && !!wanted && wanted !== lastAutoUrl;
+    // Only a GENUINELY custom URL counts as a manual override. The DEFAULT bridge URL
+    // must NOT — the Settings "Bridge URL" field seeds the default (9180), and on a
+    // sticky/load connect lastAutoUrl is still empty, so the old check wrongly flagged
+    // the default as an override and SKIPPED the per-backend bridge_url from /connect.
+    // That connected the Codex backend to Claude's port (9180) instead of 9181.
+    const manualOverride =
+      !opts.fromChip && !!wanted && wanted !== DEFAULT_BRIDGE_URL && wanted !== lastAutoUrl;
     if (manualOverride && wanted !== client.currentUrl()) client.setUrl(wanted);
     try {
       // Send the selected backend so the pack starts (and points us at) the right


### PR DESCRIPTION
Codex backend was connecting to Claude's port 9180 because the Settings Bridge URL seeds the default and the manualOverride check treated it as a custom override, skipping /connect's per-backend bridge_url (9181). Exclude DEFAULT_BRIDGE_URL from the override check. node --check OK; needs live re-test (Codex connects to 9181).

🤖 Generated with [Claude Code](https://claude.com/claude-code)