### PR TITLE
feat(panel): graph_set_node_mode (active/bypass/mute) + surface node mode in graph read

### DIFF
--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1386,6 +1386,9 @@ function summarizeNode(node) {
     size: node.size ? [Math.round(node.size[0]), Math.round(node.size[1])] : null,
     ...(fullHeight != null ? { full_height: fullHeight } : {}),
     ...(node.flags && node.flags.collapsed ? { collapsed: true } : {}),
+    // Execution mode — only emitted when NOT active so bypassed/muted nodes are
+    // clearly visible to the agent (LiteGraph: 2 = mute, 4 = bypass, 0 = active).
+    ...(node.mode ? { mode: { 2: "mute", 4: "bypass" }[node.mode] ?? `mode_${node.mode}` } : {}),
     ...(node.color ? { color: node.color } : {}),
     ...(node.bgcolor ? { bgcolor: node.bgcolor } : {}),
     widgets,
@@ -2391,6 +2394,42 @@ const GRAPH_TOOL_EXECUTORS = {
     }
     graph.setDirtyCanvas?.(true, true);
     return { node_id: node.id, color: node.color ?? null, bgcolor: node.bgcolor ?? null };
+  },
+
+  // Set a node's execution MODE: "active" (runs normally), "bypass" (the node is
+  // skipped but its inputs pass through to its outputs — LiteGraph mode 4), or
+  // "mute" (the node and everything downstream of it is skipped — mode 2). Also
+  // accepts the raw numeric LiteGraph modes 0/2/4 defensively. Undo-able like the
+  // other graph_set_node_* edits.
+  graph_set_node_mode({ node_id, mode }) {
+    const { graph } = getGraphCtx();
+    const node = resolveNode(graph, node_id);
+    const MODE_TO_NUM = { active: 0, bypass: 4, mute: 2 };
+    const NUM_TO_MODE = { 0: "active", 2: "mute", 4: "bypass" };
+    let target;
+    if (typeof mode === "number" || (typeof mode === "string" && /^\d+$/.test(mode.trim()))) {
+      const n = Number(mode);
+      if (!(n in NUM_TO_MODE)) {
+        throw new Error(`invalid mode ${mode} (valid: "active", "bypass", "mute" or 0/2/4)`);
+      }
+      target = n;
+    } else {
+      const key = String(mode ?? "").toLowerCase();
+      if (!(key in MODE_TO_NUM)) {
+        throw new Error(`invalid mode "${mode}" (valid: "active", "bypass", "mute")`);
+      }
+      target = MODE_TO_NUM[key];
+    }
+    const prevNum = typeof node.mode === "number" ? node.mode : 0;
+    const previous_mode = NUM_TO_MODE[prevNum] ?? prevNum;
+    graph.beforeChange?.();
+    try {
+      node.mode = target;
+    } finally {
+      graph.afterChange?.();
+    }
+    graph.setDirtyCanvas?.(true, true);
+    return { node_id: node.id, mode: NUM_TO_MODE[target], previous_mode };
   },
 
   // Render the CURRENT graph view (root graph or the open subgraph) to a PNG and
@@ -3819,6 +3858,11 @@ function describeCommand(cmd, msg, reply) {
       };
     case "graph_set_node_color":
       return { icon: "pi-palette", text: `Recolored node ${r.node_id}` };
+    case "graph_set_node_mode":
+      return {
+        icon: r.mode === "active" ? "pi-play-circle" : r.mode === "mute" ? "pi-volume-off" : "pi-ban",
+        text: `Set node ${r.node_id} to ${r.mode}${r.previous_mode && r.previous_mode !== r.mode ? ` (was ${r.previous_mode})` : ""}`,
+      };
     case "graph_screenshot":
       return { icon: "pi-camera", text: `Captured workflow image (${r.width}×${r.height})` };
     case "graph_canvas":


### PR DESCRIPTION
## Why
The live-canvas agent had **no way to bypass / un-bypass / mute** a node on the graph. This caused a real failure: an agent set the JSON-builder fields in a KREA pack but couldn't un-bypass that path, so the render used a stale prompt and produced the wrong image.

## What

### New executor: `graph_set_node_mode`
A sibling to `graph_set_node_collapsed` / `graph_set_node_color`, following the same structure (resolve node by id incl. active subgraph, mutate, `beforeChange`/`afterChange` + `setDirtyCanvas`, return a clear result).

**Contract** (the MCP tool def is written to match this):
- **cmd:** `graph_set_node_mode`
- **args:** `{ node_id, mode }` where `mode` is one of the strings `"active"` | `"bypass"` | `"mute"`. Raw LiteGraph numbers `0`/`2`/`4` are accepted defensively.
- **mapping:** `active→0`, `bypass→4`, `mute→2`
- **returns:** `{ node_id, mode, previous_mode }` (previous numeric mode mapped back to a string)
- **errors:** unknown `node_id` → clear error (via `resolveNode`); invalid `mode` → error listing the valid values

**Undo:** wrapped in `graph.beforeChange?.()` / `graph.afterChange?.()` and `graph.setDirtyCanvas?.(true, true)` — identical to the sibling executors — so **Ctrl+Z reverts it** like every other graph edit.

### Graph read now surfaces node mode
`summarizeNode` (used by `graph_get_state` and `graph_get_subgraph`) now emits a readable `mode: "mute" | "bypass"` field for any node that is **not active** (matching the codebase style for optional fields like `collapsed`). Bypassed/muted nodes are now clearly visible to the agent instead of silently dropped. No link/serialization semantics changed.

### UI
Added a `describeCommand` case so the command renders a friendly line in the chat log.

## Verify
- `node --check web/js/comfyui-mcp-panel.js` exits 0.