### PR TITLE
feat(panel): subgraph rail I/O wiring + unpack executors

### DIFF
--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1190,6 +1190,30 @@ function uniqueSubgraphInputName(subgraph, baseName) {
   return `${baseName}_${i}`;
 }
 
+function uniqueSubgraphOutputName(subgraph, baseName) {
+  const names = new Set((subgraph?.outputs ?? []).map((output) => output?.name).filter(Boolean));
+  if (!names.has(baseName)) return baseName;
+  let i = 1;
+  while (names.has(`${baseName}_${i}`)) i++;
+  return `${baseName}_${i}`;
+}
+
+/** Find the parent SubgraphNode that hosts a given Subgraph instance (searching
+ *  from root through nested subgraphs), so its promoted views can be refreshed
+ *  after a boundary I/O change. Returns null if it can't be located. */
+function findSubgraphHostNode(subgraph) {
+  const root = app?.graph;
+  if (!root || !subgraph) return null;
+  const stack = [...(root._nodes ?? [])];
+  while (stack.length) {
+    const node = stack.pop();
+    if (!node) continue;
+    if (node.subgraph === subgraph) return node;
+    if (node.subgraph?._nodes?.length) stack.push(...node.subgraph._nodes);
+  }
+  return null;
+}
+
 function getWidgetSlot(node, widget) {
   if (typeof node.getSlotFromWidget === "function") return node.getSlotFromWidget(widget);
   return (node.inputs ?? []).find((input) => input?.widget?.name === widget.name);
@@ -1432,6 +1456,57 @@ function resolveNode(graph, nodeId) {
   return node;
 }
 
+// ---- Subgraph boundary rails (input/output proxy nodes) -------------------
+// LiteGraph: subgraph.inputNode.id === SUBGRAPH_INPUT_ID (-10),
+//            subgraph.outputNode.id === SUBGRAPH_OUTPUT_ID (-20).
+// These rail nodes are NOT in graph._nodes_by_id, so resolveNode/getNodeById
+// cannot find them — rail-aware executors use resolveRail instead.
+const SUBGRAPH_INPUT_RAIL_ID = -10;
+const SUBGRAPH_OUTPUT_RAIL_ID = -20;
+const RAIL_INPUT_ALIASES = new Set(["input", "input_rail", "inputs", "in"]);
+const RAIL_OUTPUT_ALIASES = new Set(["output", "output_rail", "outputs", "out"]);
+
+/** Resolve a node-id reference to a subgraph boundary rail, by the rail node's
+ *  real id (-10 / -20) or by an alias ("input"/"output"/..). Returns
+ *  { rail: "input"|"output", node } or null when it isn't a rail reference. */
+function resolveRail(graph, ref) {
+  const inNode = graph?.inputNode ?? null;
+  const outNode = graph?.outputNode ?? null;
+  if (typeof ref === "string") {
+    const key = ref.trim().toLowerCase();
+    if (RAIL_INPUT_ALIASES.has(key)) return inNode ? { rail: "input", node: inNode } : null;
+    if (RAIL_OUTPUT_ALIASES.has(key)) return outNode ? { rail: "output", node: outNode } : null;
+  }
+  const num = Number(ref);
+  if (Number.isFinite(num)) {
+    if (inNode && (Number(inNode.id) === num || num === SUBGRAPH_INPUT_RAIL_ID))
+      return { rail: "input", node: inNode };
+    if (outNode && (Number(outNode.id) === num || num === SUBGRAPH_OUTPUT_RAIL_ID))
+      return { rail: "output", node: outNode };
+  }
+  return null;
+}
+
+/** True when a rail slot reference means "make a NEW exposed slot" rather than
+ *  reusing an existing one (empty string / "new" / "empty" / "+" / null). */
+function isEmptyRailSlotRef(ref) {
+  if (ref == null) return true;
+  if (typeof ref !== "string") return false;
+  const k = ref.trim().toLowerCase();
+  return k === "" || k === "new" || k === "empty" || k === "+";
+}
+
+/** Find an EXISTING rail slot (SubgraphInput/SubgraphOutput) by name or index,
+ *  or null if none matches. */
+function findExistingRailSlot(slots, ref) {
+  if (ref == null) return null;
+  if (typeof ref === "number" && Number.isInteger(ref)) {
+    return ref >= 0 && ref < (slots?.length ?? 0) ? slots[ref] : null;
+  }
+  const name = String(ref).toLowerCase();
+  return (slots ?? []).find((s) => s?.name?.toLowerCase() === name) ?? null;
+}
+
 // ---- Group boxes (LiteGraph LGraphGroup) helpers --------------------------
 
 /** Resolve a group box by id (with an index fallback for graphs whose groups
@@ -1496,16 +1571,43 @@ function summarizeGroup(graph, g) {
 }
 
 /** Describe a subgraph's input/output "rail" nodes (the boundary I/O proxies)
- *  so layouts can sit nodes next to them instead of floating away. The exact
- *  property name varies across ComfyUI versions, so probe the likely ones. */
+ *  so layouts can sit nodes next to them instead of floating away, AND so the
+ *  agent can wire internal nodes to/from the rails. Reports each rail node's id
+ *  + its connectable slots:
+ *   - the INPUT rail (`subgraph.inputNode`, id -10) hands OUTPUT slots to internal
+ *     node inputs — listed under `provides_outputs`.
+ *   - the OUTPUT rail (`subgraph.outputNode`, id -20) accepts INPUT slots from
+ *     internal node outputs — listed under `accepts_inputs`.
+ *  `has_empty_slot` reflects the trailing "+" slot that adds a NEW exposed I/O.
+ *  The exact rail property name varies across ComfyUI versions, so probe likely ones. */
 function describeRails(sub) {
   const xy = (n) => (n?.pos ? [Math.round(n.pos[0]), Math.round(n.pos[1])] : null);
   const wh = (n) => (n?.size ? [Math.round(n.size[0]), Math.round(n.size[1])] : null);
   const inNode = sub.inputNode ?? sub._inputNode ?? null;
   const outNode = sub.outputNode ?? sub._outputNode ?? null;
+  const slotList = (slots) =>
+    (slots ?? []).map((s, i) => ({ index: i, name: s?.name ?? null, type: s?.type ?? null }));
   return {
-    input: inNode ? { pos: xy(inNode), size: wh(inNode) } : null,
-    output: outNode ? { pos: xy(outNode), size: wh(outNode) } : null,
+    input: inNode
+      ? {
+          rail_node_id: inNode.id,
+          pos: xy(inNode),
+          size: wh(inNode),
+          provides_outputs: slotList(sub.inputs),
+          has_empty_slot: !!inNode.emptySlot,
+          aliases: ["input", "input_rail"],
+        }
+      : null,
+    output: outNode
+      ? {
+          rail_node_id: outNode.id,
+          pos: xy(outNode),
+          size: wh(outNode),
+          accepts_inputs: slotList(sub.outputs),
+          has_empty_slot: !!outNode.emptySlot,
+          aliases: ["output", "output_rail"],
+        }
+      : null,
   };
 }
 
@@ -1696,6 +1798,102 @@ const GRAPH_TOOL_EXECUTORS = {
 
   graph_connect({ from_node_id, from_output, to_node_id, to_input }) {
     const { graph } = getGraphCtx();
+
+    // Rail tolerance: when an endpoint is a subgraph boundary rail (by real id
+    // -10/-20 or alias "input"/"output"/..), route to the boundary I/O logic
+    // instead of throwing "No node with id". Normal node-to-node connect below
+    // is unchanged.
+    const fromRail = resolveRail(graph, from_node_id);
+    const toRail = resolveRail(graph, to_node_id);
+
+    if (toRail?.rail === "output") {
+      // internal node OUTPUT -> subgraph OUTPUT rail.
+      const node = resolveNode(graph, from_node_id);
+      const outIdx = resolveSlot(node.outputs, from_output ?? 0, "output");
+      const outputSlot = node.outputs[outIdx];
+      const existing = isEmptyRailSlotRef(to_input)
+        ? null
+        : findExistingRailSlot(graph.outputs, to_input);
+      if (existing && typeof existing.connect === "function") {
+        graph.beforeChange?.();
+        let link;
+        try {
+          link = existing.connect(outputSlot, node);
+        } finally {
+          graph.afterChange?.();
+        }
+        if (!link) {
+          throw new Error(
+            `connect refused — node ${node.id} output "${outputSlot?.name ?? outIdx}" ` +
+              `(${outputSlot?.type}) is not compatible with subgraph output "${existing.name}" (${existing.type})`,
+          );
+        }
+        graph.setDirtyCanvas?.(true, true);
+        findSubgraphHostNode(graph)?.invalidatePromotedViews?.();
+        return {
+          connected: {
+            from: { node_id: node.id, output: outputSlot?.name ?? outIdx },
+            to: { subgraph_output: existing.name },
+          },
+        };
+      }
+      return GRAPH_TOOL_EXECUTORS.graph_expose_subgraph_output({
+        from_node_id,
+        from_output,
+        name: typeof to_input === "string" && !isEmptyRailSlotRef(to_input) ? to_input : undefined,
+      });
+    }
+
+    if (fromRail?.rail === "input") {
+      // subgraph INPUT rail -> internal node INPUT.
+      const node = resolveNode(graph, to_node_id);
+      const inIdx = resolveSlot(node.inputs, to_input ?? 0, "input");
+      const inputSlot = node.inputs[inIdx];
+      const existing = isEmptyRailSlotRef(from_output)
+        ? null
+        : findExistingRailSlot(graph.inputs, from_output);
+      if (existing && typeof existing.connect === "function") {
+        graph.beforeChange?.();
+        let link;
+        try {
+          link = existing.connect(inputSlot, node);
+        } finally {
+          graph.afterChange?.();
+        }
+        if (!link) {
+          throw new Error(
+            `connect refused — subgraph input "${existing.name}" (${existing.type}) is not ` +
+              `compatible with node ${node.id} input "${inputSlot?.name ?? inIdx}" (${inputSlot?.type})`,
+          );
+        }
+        graph.setDirtyCanvas?.(true, true);
+        findSubgraphHostNode(graph)?.invalidatePromotedViews?.();
+        return {
+          connected: {
+            from: { subgraph_input: existing.name },
+            to: { node_id: node.id, input: inputSlot?.name ?? inIdx },
+          },
+        };
+      }
+      return GRAPH_TOOL_EXECUTORS.graph_expose_subgraph_input({
+        to_node_id,
+        to_input,
+        name:
+          typeof from_output === "string" && !isEmptyRailSlotRef(from_output) ? from_output : undefined,
+      });
+    }
+
+    if (fromRail?.rail === "output") {
+      throw new Error(
+        'cannot connect FROM the output rail — set from_node_id to an internal node and to_node_id to "output"',
+      );
+    }
+    if (toRail?.rail === "input") {
+      throw new Error(
+        'cannot connect TO the input rail — set from_node_id to "input" and to_node_id to an internal node',
+      );
+    }
+
     const origin = resolveNode(graph, from_node_id);
     const target = resolveNode(graph, to_node_id);
     const outIdx = resolveSlot(origin.outputs, from_output ?? 0, "output");
@@ -2069,6 +2267,178 @@ const GRAPH_TOOL_EXECUTORS = {
         node_id: res?.node?.id ?? null,
         name: res?.subgraph?.name ?? null,
         from_nodes: ns.map((n) => n.id),
+      },
+    };
+  },
+
+  // --- Subgraph boundary I/O: wire internal nodes to the input/output rails --
+  // Run while INSIDE a subgraph (the active graph IS the Subgraph). Mirrors
+  // promoteWidgetByLink (subgraph.addInput + SubgraphInput.connect) for the
+  // OUTPUT side via subgraph.addOutput + SubgraphOutput.connect.
+  // Ref: ComfyUI_frontend LGraph.ts addOutput ~2970 / addInput ~2948;
+  //      SubgraphOutput.connect(slot, node) ~line 34; SubgraphInput.connect(slot, node) ~line 48.
+
+  // Take an internal node's OUTPUT and expose it as a subgraph OUTPUT.
+  graph_expose_subgraph_output({ from_node_id, from_output, name }) {
+    const { graph, canvas } = getGraphCtx();
+    const subgraph = graph;
+    if (typeof subgraph.addOutput !== "function" || !subgraph.outputNode) {
+      throw new Error(
+        "graph_expose_subgraph_output must be run INSIDE a subgraph (no subgraph.addOutput on the active graph)",
+      );
+    }
+    const node = resolveNode(subgraph, from_node_id);
+    const outIdx = resolveSlot(node.outputs, from_output ?? 0, "output");
+    const outputSlot = node.outputs[outIdx];
+
+    // Idempotent-ish: reuse an existing subgraph output already fed by this slot.
+    const existing = (subgraph.outputs ?? []).find((o) =>
+      (o?.linkIds ?? []).some((linkId) => {
+        const link = subgraph.getLink?.(linkId);
+        return (
+          link && Number(link.origin_id) === Number(node.id) && Number(link.origin_slot) === outIdx
+        );
+      }),
+    );
+    if (existing) {
+      return {
+        exposed: {
+          name: existing.name,
+          type: existing.type,
+          slot: subgraph.outputs.indexOf(existing),
+          reused: true,
+          from: { node_id: node.id, output: outputSlot?.name ?? outIdx },
+        },
+      };
+    }
+
+    const outputName = uniqueSubgraphOutputName(subgraph, name || outputSlot?.name || "output");
+    const outputType = String(outputSlot?.type ?? "*");
+    subgraph.beforeChange?.();
+    let subgraphOutput;
+    let link;
+    try {
+      subgraphOutput = subgraph.addOutput(outputName, outputType);
+      subgraphOutput.label = outputSlot?.label;
+      link =
+        typeof subgraphOutput.connect === "function"
+          ? subgraphOutput.connect(outputSlot, node)
+          : null;
+      if (!link) {
+        subgraph.removeOutput?.(subgraphOutput);
+        throw new Error(
+          `Could not link node ${node.id} output "${outputSlot?.name ?? outIdx}" (${outputType}) to a new subgraph output`,
+        );
+      }
+    } finally {
+      subgraph.afterChange?.();
+    }
+    findSubgraphHostNode(subgraph)?.invalidatePromotedViews?.();
+    subgraph.setDirtyCanvas?.(true, true);
+    canvas?.setDirty?.(true, true);
+    return {
+      exposed: {
+        name: outputName,
+        type: outputType,
+        slot: subgraph.outputs.indexOf(subgraphOutput),
+        on_host_subgraph_node: true,
+        from: { node_id: node.id, output: outputSlot?.name ?? outIdx },
+      },
+    };
+  },
+
+  // Expose the input rail as a subgraph INPUT feeding an internal node's INPUT.
+  graph_expose_subgraph_input({ to_node_id, to_input, name }) {
+    const { graph, canvas } = getGraphCtx();
+    const subgraph = graph;
+    if (typeof subgraph.addInput !== "function" || !subgraph.inputNode) {
+      throw new Error(
+        "graph_expose_subgraph_input must be run INSIDE a subgraph (no subgraph.addInput on the active graph)",
+      );
+    }
+    const node = resolveNode(subgraph, to_node_id);
+    const inIdx = resolveSlot(node.inputs, to_input ?? 0, "input");
+    const inputSlot = node.inputs[inIdx];
+
+    // Idempotent-ish: reuse an existing subgraph input already feeding this slot.
+    const existing = (subgraph.inputs ?? []).find((s) =>
+      (s?.linkIds ?? []).some((linkId) => {
+        const link = subgraph.getLink?.(linkId);
+        return (
+          link && Number(link.target_id) === Number(node.id) && Number(link.target_slot) === inIdx
+        );
+      }),
+    );
+    if (existing) {
+      return {
+        exposed: {
+          name: existing.name,
+          type: existing.type,
+          slot: subgraph.inputs.indexOf(existing),
+          reused: true,
+          to: { node_id: node.id, input: inputSlot?.name ?? inIdx },
+        },
+      };
+    }
+
+    const inputName = uniqueSubgraphInputName(subgraph, name || inputSlot?.name || "input");
+    const inputType = String(inputSlot?.type ?? "*");
+    subgraph.beforeChange?.();
+    let subgraphInput;
+    let link;
+    try {
+      subgraphInput = subgraph.addInput(inputName, inputType);
+      subgraphInput.label = inputSlot?.label;
+      link =
+        typeof subgraphInput.connect === "function" ? subgraphInput.connect(inputSlot, node) : null;
+      if (!link) {
+        subgraph.removeInput?.(subgraphInput);
+        throw new Error(
+          `Could not link a new subgraph input to node ${node.id} input "${inputSlot?.name ?? inIdx}" (${inputType})`,
+        );
+      }
+    } finally {
+      subgraph.afterChange?.();
+    }
+    findSubgraphHostNode(subgraph)?.invalidatePromotedViews?.();
+    subgraph.setDirtyCanvas?.(true, true);
+    canvas?.setDirty?.(true, true);
+    return {
+      exposed: {
+        name: inputName,
+        type: inputType,
+        slot: subgraph.inputs.indexOf(subgraphInput),
+        on_host_subgraph_node: true,
+        to: { node_id: node.id, input: inputSlot?.name ?? inIdx },
+      },
+    };
+  },
+
+  // Dissolve a subgraph: inline its interior nodes into the parent + rewire
+  // external links. node_id is the SubgraphNode in the CURRENT (parent) graph.
+  // Ref: ComfyUI_frontend LGraph.ts unpackSubgraph ~1932 (wraps its own
+  // beforeChange/afterChange) and _unpackSubgraphImpl ~1950.
+  graph_unpack_subgraph({ node_id }) {
+    const { graph, canvas } = getGraphCtx();
+    const node = resolveNode(graph, node_id);
+    if (!node.subgraph) {
+      throw new Error(`Node ${node.id} (${node.type}) is not a subgraph`);
+    }
+    if (typeof graph.unpackSubgraph !== "function") {
+      throw new Error("unpackSubgraph is unavailable on this ComfyUI frontend");
+    }
+    const before = new Set((graph._nodes ?? []).map((n) => n.id));
+    // unpackSubgraph wraps its own beforeChange/afterChange for undo, so don't
+    // nest another pair here.
+    graph.unpackSubgraph(node, { skipMissingNodes: true });
+    const newNodeIds = (graph._nodes ?? []).filter((n) => !before.has(n.id)).map((n) => n.id);
+    graph.setDirtyCanvas?.(true, true);
+    canvas?.setDirty?.(true, true);
+    return {
+      unpacked: {
+        node_id,
+        new_node_ids: newNodeIds,
+        node_count: newNodeIds.length,
       },
     };
   },

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1487,6 +1487,24 @@ function resolveRail(graph, ref) {
   return null;
 }
 
+/** Detect rail INTENT independent of whether rails actually exist on the active
+ *  graph — i.e. the reference is clearly meant to be a boundary rail (an alias,
+ *  or the reserved rail ids -10/-20). Returns "input"|"output"|null. Used to give
+ *  a clear error when a rail endpoint is used at the ROOT graph (no rails). */
+function railIntent(ref) {
+  if (typeof ref === "string") {
+    const key = ref.trim().toLowerCase();
+    if (RAIL_INPUT_ALIASES.has(key)) return "input";
+    if (RAIL_OUTPUT_ALIASES.has(key)) return "output";
+  }
+  const num = Number(ref);
+  if (Number.isFinite(num)) {
+    if (num === SUBGRAPH_INPUT_RAIL_ID) return "input";
+    if (num === SUBGRAPH_OUTPUT_RAIL_ID) return "output";
+  }
+  return null;
+}
+
 /** True when a rail slot reference means "make a NEW exposed slot" rather than
  *  reusing an existing one (empty string / "new" / "empty" / "+" / null). */
 function isEmptyRailSlotRef(ref) {
@@ -1891,6 +1909,20 @@ const GRAPH_TOOL_EXECUTORS = {
     if (toRail?.rail === "input") {
       throw new Error(
         'cannot connect TO the input rail — set from_node_id to "input" and to_node_id to an internal node',
+      );
+    }
+
+    // Rail INTENT without resolvable rails: the endpoint is clearly a rail
+    // reference (alias or id -10/-20) but the active graph has none — i.e. we're
+    // at the root graph. Fail clearly instead of falling through to the normal
+    // node path (which would throw the confusing "No node with id output").
+    const fromIntent = railIntent(from_node_id);
+    const toIntent = railIntent(to_node_id);
+    if ((fromIntent && !fromRail) || (toIntent && !toRail)) {
+      const ref = toIntent && !toRail ? to_node_id : from_node_id;
+      throw new Error(
+        `Rail endpoint "${ref}" is only valid inside a subgraph — enter the subgraph first ` +
+          `(graph_enter_subgraph), then expose I/O with graph_expose_subgraph_output / graph_expose_subgraph_input.`,
       );
     }
 


### PR DESCRIPTION
## What

Gives the Agent panel the ability to wire internal nodes to a subgraph's input/output **rails** from inside a subgraph, and to dissolve a subgraph back into its parent. All in `web/js/comfyui-mcp-panel.js`.

### Rails exposed in `graph_get_state`
`describeRails` (now in `graph_get_state.rails`, only while inside a subgraph) reports, for each rail node:
- `rail_node_id` — the real LiteGraph rail id (`-10` input / `-20` output)
- the connectable slots: input rail = `provides_outputs` (it hands OUTPUT slots to internal node inputs); output rail = `accepts_inputs` (it accepts INPUT slots from internal node outputs) — each `{index,name,type}`
- `has_empty_slot` (the trailing "+" new-I/O slot) and `aliases`

Previously rails only reported pos/size, and `resolveNode`/`getNodeById` could not resolve them (they're not in `_nodes_by_id`), so wiring to the output rail failed with "No node with id N".

### New executors
- `graph_expose_subgraph_output({ from_node_id, from_output, name? })` — run INSIDE the subgraph. `subgraph.addOutput(name||slotName, type)` then `SubgraphOutput.connect(internalOutputSlot, internalNode)`. Reuses an equivalent existing output if the slot is already exposed. Returns `{ exposed: { name, type, slot, from:{node_id,output}, on_host_subgraph_node|reused } }`.
- `graph_expose_subgraph_input({ to_node_id, to_input, name? })` — mirror for the input side: `subgraph.addInput` + `SubgraphInput.connect(internalInputSlot, internalNode)`. Returns `{ exposed: { name, type, slot, to:{node_id,input}, ... } }`.
- `graph_unpack_subgraph({ node_id })` — resolves the SubgraphNode in the CURRENT (parent) graph and calls `graph.unpackSubgraph(node, { skipMissingNodes: true })` (which wraps its own before/afterChange). Returns `{ unpacked: { node_id, new_node_ids, node_count } }`. Errors if the node isn't a subgraph or `unpackSubgraph` is unavailable.

### `graph_connect` rail tolerance
If an endpoint resolves to a rail — by real id (`-10`/`-20`) or alias (`input`/`output`/`input_rail`/`output_rail`) — it routes to the expose logic, or links to a **named existing** rail slot when `to_input`/`from_output` names one. Reversed rail usage errors clearly. Normal node-to-node connect is unchanged.

## Reference API used (ComfyUI_frontend)
- `src/lib/litegraph/src/LGraph.ts`: `addInput` ~2948, `addOutput` ~2970 (both `(name,type)` returning the slot), `unpackSubgraph` ~1932 / `_unpackSubgraphImpl` ~1950, `Subgraph` class fields `inputNode`/`outputNode`/`inputs`/`outputs` ~2802-2808.
- `src/lib/litegraph/src/subgraph/SubgraphOutput.ts`: `connect(slot: INodeOutputSlot, node, afterRerouteId?)` ~line 34.
- `src/lib/litegraph/src/subgraph/SubgraphInput.ts`: `connect(slot: INodeInputSlot, node, afterRerouteId?)` ~line 48.
- `src/lib/litegraph/src/subgraph/SubgraphInputNode.ts`: `id`/`slots`/`emptySlot` ~29-39.
- `src/lib/litegraph/src/constants.ts`: `SUBGRAPH_INPUT_ID = -10`, `SUBGRAPH_OUTPUT_ID = -20`.

## Verify
`node --check web/js/comfyui-mcp-panel.js` exits 0.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — P2 fix (Codex review)

`graph_connect` now detects rail **intent** independent of rail resolution: when an endpoint is clearly a rail reference (alias `input`/`output`/`input_rail`/`output_rail`, or id `-10`/`-20`) but the active graph has no rails (you're at the root graph), it throws a clear error — *"Rail endpoint \"output\" is only valid inside a subgraph — enter the subgraph first (graph_enter_subgraph), then expose I/O with graph_expose_subgraph_output / graph_expose_subgraph_input."* — instead of falling through to normal node resolution and throwing the confusing "No node with id output". Normal non-rail node ids are unaffected. New `railIntent()` helper. The dedicated `graph_expose_subgraph_output`/`_input` executors already throw clear "must be run INSIDE a subgraph" errors at root (guarded on `!subgraph.outputNode`/`!subgraph.inputNode`). `node --check` exits 0.
