### PR TITLE
fix(panel): render streamed replies in a hidden/background tab (RAF-paused)

### DIFF
--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -6398,7 +6398,14 @@ function buildPanel() {
     if (!s) return false;
     s.commitText = text;
     s.replyTarget = text; // authoritative — guarantees the typewriter reaches the end
-    kickStreams(s); // run to completion; finalizeStream renders markdown when caught up
+    // CRITICAL: the typewriter (pumpStreams) runs on requestAnimationFrame, which
+    // the browser PAUSES in a hidden/background tab. If the user switched away
+    // during the turn (common on long pipeline runs), the reply would never paint
+    // and the bubble would sit empty with a stuck cursor — looking like "stuck
+    // thinking / never drains." When hidden, render the final text SYNCHRONOUSLY
+    // instead of waiting for an RAF tick that won't come.
+    if (document.hidden) finalizeStream(s);
+    else kickStreams(s); // run to completion; finalizeStream renders markdown when caught up
     return true;
   }
 
@@ -8976,6 +8983,20 @@ function buildPanel() {
     }
   }
   document.addEventListener("mousedown", onDocPointerDown, true);
+  // Background-tab safety for streamed replies: requestAnimationFrame (which drives
+  // the typewriter + finalize) is paused while the tab is hidden. When the tab goes
+  // hidden, synchronously finalize any reply whose commit already arrived so it never
+  // gets stranded as an empty cursor bubble; when it returns, resume the typewriters.
+  function onVisibilityChange() {
+    if (document.hidden) {
+      for (const s of [...streamBubbles.values()]) {
+        if (s.commitText != null) finalizeStream(s);
+      }
+    } else {
+      for (const s of streamBubbles.values()) kickStreams(s);
+    }
+  }
+  document.addEventListener("visibilitychange", onVisibilityChange);
 
   // Reload restore: repaint the chat this tab was last showing. The agent's
   // memory continues automatically — either the orchestrator's agent for this
@@ -9128,6 +9149,7 @@ function buildPanel() {
         // recognition already stopped
       }
       document.removeEventListener("mousedown", onDocPointerDown, true);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
       try {
         api.removeEventListener("executed", onExecuted);
         api.removeEventListener("execution_success", onExecutionSuccess);


### PR DESCRIPTION
## Root cause (confirmed live)
The streamed-reply typewriter + commit finalize run on `requestAnimationFrame`, which browsers **pause in a hidden/background tab**. Background the ComfyUI tab during a turn (long pipeline runs) → the reply never paints, the bubble sits empty with a stuck streaming cursor, and it looks like **'stuck thinking / never drains'** — even though the orchestrator finished and sent the `say`/`stream` frames (verified via live WS frame capture: `document.hidden=true`, frames received, bubble empty).

## Fix
- `commitStream()` finalizes the reply **synchronously** (`renderRichText`) when `document.hidden`, instead of waiting for an RAF tick that won't fire.
- `visibilitychange` handler: on hide, finalize any already-committed stream bubble; on show, resume typewriters. Cleaned up in `destroy()`.
- Foreground animated-typewriter behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)