### PR TITLE
test: Playwright Tier 1 e2e suite (agent-free MockBridge)

### DIFF
--- a/.comfyignore
+++ b/.comfyignore
@@ -7,3 +7,11 @@ venv/
 node_modules/
 *.log
 .DS_Store
+# Dev-only e2e tooling — never ship with the pack
+browser_tests/
+playwright.config.ts
+playwright-report/
+test-results/
+package.json
+package-lock.json
+tsconfig.json

--- a/.comfyignore
+++ b/.comfyignore
@@ -12,6 +12,7 @@ browser_tests/
 playwright.config.ts
 playwright-report/
 test-results/
+.playwright/
 package.json
 package-lock.json
 tsconfig.json

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ node_modules/
 .panel-guard/
 assets/brand-preview/
 assets/brand-preview-ai/
+# Playwright e2e artifacts
+playwright-report/
+test-results/
+.playwright/

--- a/browser_tests/README.md
+++ b/browser_tests/README.md
@@ -1,0 +1,71 @@
+# Agent Panel — Playwright e2e (Tier 1)
+
+Tier 1 is the **agent-free** e2e tier for the ComfyUI Agent Panel. Every spec
+points the panel at a scriptable **MockBridge** (a fake orchestrator) instead of
+a real Claude/Codex backend, so the tests are deterministic, fast, need no auth,
+and cost nothing. The MockBridge replaces only the **orchestrator** — the tests
+still run against a **real ComfyUI** that hosts the panel.
+
+## Prerequisites
+
+1. **A running ComfyUI at `http://localhost:8188`.** The suite does not start it
+   (mirroring comfyui_frontend, which assumes a running ComfyUI). Playwright
+   launches its own browser and navigates there.
+2. **CORS enabled** so the panel page can open a WebSocket to the MockBridge on a
+   different port:
+   ```
+   comfyui --enable-cors-header
+   ```
+   (ComfyUI Desktop: launch with the equivalent setting.)
+3. **This pack junctioned into `custom_nodes`** so the "Agent" sidebar tab is
+   registered. (In this dev environment the panel is already junctioned in.)
+
+## Install
+
+```
+npm install
+npx playwright install chromium
+```
+
+## Run
+
+```
+npm run test:e2e          # headless
+npm run test:e2e:ui       # Playwright UI mode
+npm run test:e2e:list     # compile + discover specs only (no ComfyUI needed)
+npm run typecheck         # tsc --noEmit
+```
+
+Override the target if ComfyUI is elsewhere:
+
+```
+PLAYWRIGHT_BASE_URL=http://127.0.0.1:8188 npm run test:e2e
+```
+
+## Specs
+
+| Spec | What it covers |
+| --- | --- |
+| `connect.spec.ts` | Point the panel at the MockBridge, connect → status pill flips to "connected" (only the `models` handshake frame does this), greeting renders. |
+| `streaming-render.spec.ts` | Send a message → MockBridge `replyStreamed("hello world")` → the last agent bubble shows the streamed text. |
+| `hidden-tab.spec.ts` | Regression for commit `23a88ad`: with the tab hidden **and rAF neutered**, a streamed reply must still render via the synchronous hidden-path. See the header comment for the rAF limitation. |
+| `pending-queue.spec.ts` | A 2nd message sent during a working turn queues in the pending tray, then drains/materializes when the agent dequeues it. |
+
+## How it connects (agent-free)
+
+The panel's "Connect" button POSTs `/comfyui_mcp_panel/connect`, which would start
+a **real** orchestrator. Tests avoid that: `PanelPage.connect()` seeds the Bridge
+URL (localStorage `comfyui-mcp.panel.bridgeUrl` + the Settings field) and clicks
+**Reconnect**, which calls the bridge client's `setUrl()` → `connect()` directly —
+no `/connect` POST, no real backend. Sticky auto-connect is also disabled in
+`goto()` so opening the panel never spawns an agent.
+
+## Fixtures
+
+- `fixtures/MockBridge.ts` — the scriptable fake bridge (ws server). Emits the
+  HELLO handshake (`models`, `commands`, `agent_status`, ready ack, greeting) and
+  exposes `onUserMessage`, `waitForUserMessage`, `replyStreamed`, `emitWorking`,
+  `turnDone`, `ack`/`markSeen`, `say`, `send`.
+- `fixtures/PanelPage.ts` — the page object (centralized selectors + flows).
+- `fixtures/panelTest.ts` — Playwright fixtures wiring a started `mockBridge` and
+  a `panel` into each test.

--- a/browser_tests/connect.spec.ts
+++ b/browser_tests/connect.spec.ts
@@ -1,0 +1,24 @@
+/**
+ * Tier 1 — connect handshake.
+ *
+ * Points the panel at the MockBridge, connects, and asserts:
+ *   1. the status pill flips to "connected" (only the `models` handshake frame
+ *      does this — proving the panel saw a real-shaped handshake), and
+ *   2. the greeting `say` renders as an agent bubble.
+ */
+import { test, expect } from './fixtures/panelTest'
+
+test('connects to the bridge and renders the ready greeting', async ({
+  panel,
+  mockBridge
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+
+  await panel.connect()
+
+  await expect(panel.statusPill).toContainText('connected')
+  await expect(panel.statusDot).toHaveClass(/connected/)
+  await expect(panel.agentBubbles.last()).toContainText('Panel agent ready')
+})

--- a/browser_tests/fixtures/MockBridge.ts
+++ b/browser_tests/fixtures/MockBridge.ts
@@ -1,0 +1,295 @@
+/**
+ * MockBridge — a scriptable, agent-free fake of the panel orchestrator ("bridge").
+ *
+ * The real Agent panel connects to a bridge WebSocket that fronts a Claude/Codex
+ * agent. Those backends need auth, cost money, and are non-deterministic, so the
+ * Tier 1 suite points the panel at THIS instead. It speaks exactly the frame
+ * shapes the panel's `createBridgeClient` expects (see
+ * web/js/comfyui-mcp-panel.js ~line 3412 onward).
+ *
+ * Frames the panel RECEIVES (server -> client) that we emit:
+ *   - { type: "models", models: [{id,label,small?}], current?, backend? }
+ *       The HANDSHAKE — receiving this is the ONLY thing that flips the panel's
+ *       status pill to "connected".
+ *   - { type: "commands", commands: [...] }                slash-command catalog
+ *   - { type: "agent_status", context_pct?, cost_usd?, model? }
+ *   - { type: "ack", kind: "ready"|"working"|"seen"|..., mid? }
+ *   - { type: "say", text, id?, streamed? }                committed reply
+ *   - { type: "stream", phase: "think"|"text"|"end", id, delta? }  live deltas
+ *   - { type: "turn", state: "working"|"done" }            turn lifecycle
+ *
+ * Frames the panel SENDS (client -> server) that we parse:
+ *   - { type: "hello", tab_id, title, resume? }            on connect
+ *   - { type: "user_message", text, context?, images?, mid? }
+ *   - { type: "title" | "set_options" | "interrupt" | ... }  control frames
+ *   - { rid, ok, result|error }                            command replies
+ */
+import type { AddressInfo } from 'node:net'
+import { WebSocket, WebSocketServer } from 'ws'
+
+export interface MockModel {
+  id: string
+  label: string
+  small?: string
+}
+
+export interface MockBridgeOptions {
+  /** TCP port to bind. Default 0 = let the OS pick a free port (recommended for
+   *  parallel tests — read the real port via `mockBridge.url`). */
+  port?: number
+  /** Model catalog sent on the handshake. */
+  models?: MockModel[]
+  /** Backend id reported on the handshake ("claude" | "codex"). */
+  backend?: string
+  /** Slash-command catalog sent on the handshake. */
+  commands?: unknown[]
+  /** Optional greeting `say` painted as an agent bubble right after handshake. */
+  greeting?: string | null
+  /** Auto-emit `ack { kind:"ready" }` after the handshake (default true). */
+  ackReady?: boolean
+  /** Auto-emit `ack { kind:"working", mid }` on every received user_message so
+   *  the panel's 7s delivery timer is cancelled (default true). */
+  autoAckWorking?: boolean
+  /** Auto-respond to graph command requests ({rid,cmd}) with a generic ok reply
+   *  so the panel never hangs awaiting a tool result (default true). */
+  autoReplyCommands?: boolean
+}
+
+export interface UserMessage {
+  text: string
+  mid?: string
+  context?: unknown
+  images?: unknown[]
+  raw: Record<string, unknown>
+}
+
+const DEFAULT_MODELS: MockModel[] = [
+  { id: 'claude-mock-sonnet', label: 'Mock Sonnet', small: 'test' },
+  { id: 'claude-mock-opus', label: 'Mock Opus', small: 'test' }
+]
+
+type UserMessageCb = (msg: UserMessage) => void
+type FrameCb = (frame: Record<string, unknown>) => void
+
+export class MockBridge {
+  private wss: WebSocketServer | null = null
+  private readonly opts: Required<Omit<MockBridgeOptions, 'greeting'>> & {
+    greeting: string | null
+  }
+  private readonly sockets = new Set<WebSocket>()
+  private readonly userMessageCbs = new Set<UserMessageCb>()
+  private readonly frameCbs = new Set<FrameCb>()
+  private readonly userMessages: UserMessage[] = []
+  private readonly userMessageWaiters: Array<(m: UserMessage) => void> = []
+  private streamSeq = 0
+
+  constructor(options: MockBridgeOptions = {}) {
+    this.opts = {
+      port: options.port ?? 0,
+      models: options.models ?? DEFAULT_MODELS,
+      backend: options.backend ?? 'claude',
+      commands: options.commands ?? [
+        { cmd: '/compact', description: 'Compact the conversation' }
+      ],
+      greeting: options.greeting ?? 'Panel agent ready.',
+      ackReady: options.ackReady ?? true,
+      autoAckWorking: options.autoAckWorking ?? true,
+      autoReplyCommands: options.autoReplyCommands ?? true
+    }
+  }
+
+  /** Start listening. Resolves once the server is bound. */
+  async start(): Promise<this> {
+    if (this.wss) return this
+    await new Promise<void>((resolve, reject) => {
+      const wss = new WebSocketServer({ port: this.opts.port, host: '127.0.0.1' })
+      wss.on('listening', () => resolve())
+      wss.on('error', reject)
+      wss.on('connection', (sock) => this.handleConnection(sock))
+      this.wss = wss
+    })
+    return this
+  }
+
+  /** The ws:// URL the panel should connect to (host:port actually bound). */
+  get url(): string {
+    const addr = this.wss?.address() as AddressInfo | null
+    if (!addr) throw new Error('MockBridge not started')
+    return `ws://127.0.0.1:${addr.port}`
+  }
+
+  get port(): number {
+    const addr = this.wss?.address() as AddressInfo | null
+    if (!addr) throw new Error('MockBridge not started')
+    return addr.port
+  }
+
+  private handleConnection(sock: WebSocket) {
+    this.sockets.add(sock)
+    sock.on('close', () => this.sockets.delete(sock))
+    sock.on('message', (data) => {
+      let frame: Record<string, unknown>
+      try {
+        frame = JSON.parse(data.toString())
+      } catch {
+        return
+      }
+      for (const cb of this.frameCbs) cb(frame)
+
+      if (frame.type === 'hello') {
+        this.sendHandshake(sock)
+        return
+      }
+      if (frame.type === 'user_message') {
+        const msg: UserMessage = {
+          text: typeof frame.text === 'string' ? frame.text : '',
+          mid: typeof frame.mid === 'string' ? frame.mid : undefined,
+          context: frame.context,
+          images: Array.isArray(frame.images) ? frame.images : undefined,
+          raw: frame
+        }
+        this.userMessages.push(msg)
+        if (this.opts.autoAckWorking && msg.mid) this.ack(msg.mid, 'working')
+        for (const cb of this.userMessageCbs) cb(msg)
+        const waiter = this.userMessageWaiters.shift()
+        if (waiter) waiter(msg)
+        return
+      }
+      // Graph command request: { rid, cmd, ... } -> reply { rid, ok, result }.
+      if (
+        this.opts.autoReplyCommands &&
+        typeof frame.rid === 'string' &&
+        typeof frame.cmd === 'string'
+      ) {
+        this.send({ rid: frame.rid, ok: true, result: { mock: true } }, sock)
+      }
+    })
+  }
+
+  /** The full HELLO handshake the panel expects: models (flips to "connected"),
+   *  the command catalog, an agent_status, and optionally a greeting + ready ack. */
+  private sendHandshake(sock: WebSocket) {
+    this.send(
+      {
+        type: 'models',
+        models: this.opts.models,
+        current: this.opts.models[0]?.id,
+        backend: this.opts.backend
+      },
+      sock
+    )
+    this.send({ type: 'commands', commands: this.opts.commands }, sock)
+    this.send({ type: 'agent_status', context_pct: 0.01, cost_usd: 0 }, sock)
+    if (this.opts.ackReady) this.send({ type: 'ack', kind: 'ready' }, sock)
+    if (this.opts.greeting) {
+      this.send({ type: 'say', text: this.opts.greeting }, sock)
+    }
+  }
+
+  /** Register a callback invoked for every parsed user_message frame. */
+  onUserMessage(cb: UserMessageCb): () => void {
+    this.userMessageCbs.add(cb)
+    return () => this.userMessageCbs.delete(cb)
+  }
+
+  /** Register a callback invoked for EVERY parsed inbound frame (debug/control). */
+  onFrame(cb: FrameCb): () => void {
+    this.frameCbs.add(cb)
+    return () => this.frameCbs.delete(cb)
+  }
+
+  /** Resolve with the NEXT user_message the panel sends. */
+  waitForUserMessage(timeoutMs = 10_000): Promise<UserMessage> {
+    return new Promise<UserMessage>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const i = this.userMessageWaiters.indexOf(wrapped)
+        if (i >= 0) this.userMessageWaiters.splice(i, 1)
+        reject(new Error('MockBridge.waitForUserMessage timed out'))
+      }, timeoutMs)
+      const wrapped = (m: UserMessage) => {
+        clearTimeout(timer)
+        resolve(m)
+      }
+      this.userMessageWaiters.push(wrapped)
+    })
+  }
+
+  /** Number of user_messages received so far. */
+  get receivedCount(): number {
+    return this.userMessages.length
+  }
+
+  /** Low-level: send a raw frame to one socket, or broadcast to all. */
+  send(frame: Record<string, unknown>, sock?: WebSocket): void {
+    const payload = JSON.stringify(frame)
+    const targets = sock ? [sock] : [...this.sockets]
+    for (const s of targets) {
+      if (s.readyState === WebSocket.OPEN) s.send(payload)
+    }
+  }
+
+  /** Mark the turn as in-flight: { type:"turn", state:"working" }. */
+  emitWorking(): void {
+    this.send({ type: 'turn', state: 'working' })
+  }
+
+  /** Alias for emitWorking() — start a turn. */
+  startTurn(): void {
+    this.emitWorking()
+  }
+
+  /** Mark the turn finished: { type:"turn", state:"done" }. */
+  turnDone(): void {
+    this.send({ type: 'turn', state: 'done' })
+  }
+
+  /** Structured ack ({ type:"ack", kind, mid }). */
+  ack(mid: string, kind: 'working' | 'seen' | 'ready' = 'working'): void {
+    this.send({ type: 'ack', kind, mid })
+  }
+
+  /** "seen" ack — the agent dequeued this message (drains a pending bubble). */
+  markSeen(mid: string): void {
+    this.ack(mid, 'seen')
+  }
+
+  /** Commit a non-streamed agent reply. */
+  say(text: string, opts: { id?: string; streamed?: boolean } = {}): void {
+    this.send({
+      type: 'say',
+      text,
+      ...(opts.id ? { id: opts.id } : {}),
+      ...(opts.streamed ? { streamed: true } : {})
+    })
+  }
+
+  /**
+   * Emit a full streamed reply, exactly as the real orchestrator does:
+   *   stream(text delta) -> say(streamed) -> stream(end) -> turn(done)
+   * Returns the message id used (auto-generated if not supplied).
+   */
+  replyStreamed(text: string, opts: { id?: string } = {}): string {
+    const id = opts.id ?? `mock-${Date.now().toString(36)}-${++this.streamSeq}`
+    this.send({ type: 'stream', phase: 'text', id, delta: text })
+    this.send({ type: 'say', text, id, streamed: true })
+    this.send({ type: 'stream', phase: 'end', id })
+    this.send({ type: 'turn', state: 'done' })
+    return id
+  }
+
+  /** Close all sockets and the server. */
+  async close(): Promise<void> {
+    for (const s of this.sockets) {
+      try {
+        s.close()
+      } catch {
+        // already closing
+      }
+    }
+    this.sockets.clear()
+    const wss = this.wss
+    this.wss = null
+    if (!wss) return
+    await new Promise<void>((resolve) => wss.close(() => resolve()))
+  }
+}

--- a/browser_tests/fixtures/PanelPage.ts
+++ b/browser_tests/fixtures/PanelPage.ts
@@ -1,0 +1,232 @@
+/**
+ * PanelPage — page object for the ComfyUI Agent Panel sidebar extension.
+ *
+ * Mirrors comfyui_frontend's ComfyPage: it owns the panel's selectors and the
+ * user-flow helpers (open the sidebar, point at a bridge, connect, send a
+ * message, read replies). Selectors are centralized here so a class rename in
+ * web/js/comfyui-mcp-panel.js only needs fixing in one place.
+ *
+ * Selector reference (from web/js/comfyui-mcp-panel.js):
+ *   - sidebar tab id .............. "comfyui-mcp.agent"  (button class
+ *                                    "comfyui-mcp.agent-tab-button")
+ *   - panel root .................. .cmcp-root
+ *   - status pill (button) ........ .cmcp-status   (state word as text)
+ *   - status dot .................. .cmcp-dot      (+ .connected / .connecting)
+ *   - connection popover .......... .cmcp-conn-pop
+ *   - bridge URL input ............ .cmcp-input    (inside .cmcp-advanced)
+ *   - Reconnect button ............ .cmcp-btn with text "Reconnect"
+ *   - composer input (textarea) ... .cmcp-composer-input
+ *   - send button ................. button[type=submit] in .cmcp-composer
+ *   - agent reply bubble .......... .cmcp-bubble.agent
+ *   - user bubble ................. .cmcp-bubble.user
+ *   - pending tray ................ .cmcp-tray  /  .cmcp-pending-item
+ *
+ * localStorage keys (read by the panel at build time):
+ *   - comfyui-mcp.panel.bridgeUrl    bridge ws URL
+ *   - comfyui-mcp.panel.autoConnect  sticky auto-connect ("1" to enable)
+ *   - comfyui-mcp.panel.backend      selected backend ("claude"|"codex")
+ */
+import type { Locator, Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+
+const SIDEBAR_TAB_ID = 'comfyui-mcp.agent'
+
+export type PanelStatus = 'connected' | 'connecting' | 'disconnected' | string
+
+export class PanelPage {
+  readonly root: Locator
+  readonly statusPill: Locator
+  readonly statusDot: Locator
+  readonly connectionPopover: Locator
+  readonly bridgeUrlInput: Locator
+  readonly reconnectButton: Locator
+  readonly connectButton: Locator
+  readonly disconnectButton: Locator
+  readonly composerInput: Locator
+  readonly sendButton: Locator
+  readonly agentBubbles: Locator
+  readonly userBubbles: Locator
+  readonly streamingBubble: Locator
+  readonly pendingTray: Locator
+  readonly pendingItems: Locator
+
+  constructor(public readonly page: Page) {
+    this.root = page.locator('.cmcp-root')
+    this.statusPill = this.root.locator('.cmcp-status')
+    this.statusDot = this.statusPill.locator('.cmcp-dot')
+    this.connectionPopover = this.root.locator('.cmcp-conn-pop')
+    this.bridgeUrlInput = this.connectionPopover.locator('.cmcp-input')
+    this.reconnectButton = this.connectionPopover.getByRole('button', {
+      name: 'Reconnect'
+    })
+    this.connectButton = this.connectionPopover.getByRole('button', {
+      name: 'Connect',
+      exact: true
+    })
+    this.disconnectButton = this.connectionPopover.getByRole('button', {
+      name: 'Disconnect'
+    })
+    this.composerInput = this.root.locator('.cmcp-composer-input')
+    this.sendButton = this.root.locator('.cmcp-composer button[type="submit"]')
+    this.agentBubbles = this.root.locator('.cmcp-bubble.agent')
+    this.userBubbles = this.root.locator('.cmcp-bubble.user')
+    this.streamingBubble = this.root.locator('.cmcp-bubble.agent.streaming')
+    this.pendingTray = this.root.locator('.cmcp-tray')
+    this.pendingItems = this.root.locator('.cmcp-pending-item')
+  }
+
+  /**
+   * Navigate to ComfyUI and wait for the frontend to be ready, then neutralize
+   * sticky auto-connect so the panel never spawns a REAL orchestrator via the
+   * /connect route — Tier 1 connects only to the MockBridge, explicitly.
+   */
+  async goto(): Promise<void> {
+    await this.page.goto('/')
+    await this.page.waitForFunction(
+      () => {
+        const w = window as unknown as {
+          comfyAPI?: { app?: { app?: { extensionManager?: unknown } } }
+          app?: { extensionManager?: unknown }
+        }
+        const app = w.comfyAPI?.app?.app || w.app
+        return !!(app && app.extensionManager)
+      },
+      undefined,
+      { timeout: 30_000 }
+    )
+    await this.page.evaluate(() => {
+      try {
+        localStorage.setItem('comfyui-mcp.panel.autoConnect', '0')
+        localStorage.setItem('comfyui-mcp.panel.backend', 'claude')
+      } catch {
+        // private mode / storage disabled — tests set the URL another way
+      }
+    })
+  }
+
+  /**
+   * Open the Agent sidebar tab. Tries the real user path (clicking the tab
+   * button — the pi-comments icon), then falls back to the extension manager
+   * API the panel itself uses (the tab id contains a dot, which makes the
+   * generated CSS class awkward to target).
+   */
+  async openSidebar(): Promise<void> {
+    if (await this.root.isVisible().catch(() => false)) return
+    // The tab registers a beat after window.app is ready — wait for the button.
+    const tabButton = this.page.locator(
+      `[class~="${SIDEBAR_TAB_ID}-tab-button"]`
+    )
+    await tabButton
+      .first()
+      .waitFor({ state: 'visible', timeout: 30_000 })
+      .catch(() => {})
+
+    if (await tabButton.count()) {
+      await tabButton.first().click().catch(() => {})
+    } else {
+      await this.activateSidebarProgrammatically()
+    }
+
+    // If the click didn't mount the panel, fall back to the extension manager.
+    try {
+      await this.root.waitFor({ state: 'visible', timeout: 8_000 })
+    } catch {
+      await this.activateSidebarProgrammatically()
+      await this.root.waitFor({ state: 'visible', timeout: 8_000 })
+    }
+  }
+
+  private async activateSidebarProgrammatically(): Promise<void> {
+    await this.page.evaluate((tabId) => {
+      const w = window as unknown as {
+        comfyAPI?: { app?: { app?: Record<string, unknown> } }
+        app?: Record<string, unknown>
+      }
+      const app = (w.comfyAPI?.app?.app || w.app) as
+        | { extensionManager?: Record<string, unknown> }
+        | undefined
+      const em = app?.extensionManager as
+        | {
+            setActiveSidebarTab?: (id: string) => void
+            toggleSidebarTab?: (id: string) => void
+          }
+        | undefined
+      if (!em) return
+      em.setActiveSidebarTab?.(tabId)
+      em.toggleSidebarTab?.(tabId)
+    }, SIDEBAR_TAB_ID)
+  }
+
+  /**
+   * Point the panel at a bridge URL. Writes the localStorage key the panel reads
+   * at build time AND, if the panel is already mounted, fills the visible Bridge
+   * URL field so the Reconnect button uses it. Call BEFORE openSidebar() for the
+   * cleanest path (the URL field is seeded from localStorage on mount).
+   */
+  async setBridgeUrl(url: string): Promise<void> {
+    await this.page.evaluate((u) => {
+      try {
+        localStorage.setItem('comfyui-mcp.panel.bridgeUrl', u)
+      } catch {
+        // ignore — fall back to the input below
+      }
+      const input = document.querySelector<HTMLInputElement>(
+        '.cmcp-root .cmcp-input'
+      )
+      if (input) input.value = u
+    }, url)
+  }
+
+  /**
+   * Open the connection settings popover and click Reconnect, which calls the
+   * bridge client's setUrl(urlInput.value) -> connect(). This is the agent-free
+   * connect path: it does NOT POST /connect (which would start a real backend).
+   * Waits for the handshake (status "connected").
+   */
+  async connect(): Promise<void> {
+    await this.openConnectionSettings()
+    await this.reconnectButton.click()
+    await this.waitForStatus('connected')
+  }
+
+  async openConnectionSettings(): Promise<void> {
+    if (!(await this.connectionPopover.isVisible().catch(() => false))) {
+      await this.statusPill.click()
+    }
+    await this.connectionPopover.waitFor({ state: 'visible' })
+  }
+
+  /** Current connection state word shown in the status pill. */
+  async status(): Promise<PanelStatus> {
+    return (await this.statusPill.innerText()).trim().toLowerCase()
+  }
+
+  async waitForStatus(state: PanelStatus, timeout = 20_000): Promise<void> {
+    await expect(this.statusPill).toContainText(state, { timeout })
+  }
+
+  /** Type a message into the composer and submit it (Enter). */
+  async sendMessage(text: string): Promise<void> {
+    await this.composerInput.click()
+    await this.composerInput.fill(text)
+    await this.composerInput.press('Enter')
+  }
+
+  /** Text of the last agent reply bubble. */
+  async lastAgentReply(): Promise<string> {
+    const last = this.agentBubbles.last()
+    await last.waitFor({ state: 'visible' })
+    return (await last.innerText()).trim()
+  }
+
+  /** Number of messages currently waiting in the pending tray. */
+  async pendingCount(): Promise<number> {
+    if (!(await this.pendingTray.isVisible().catch(() => false))) return 0
+    return this.pendingItems.count()
+  }
+
+  /** A user bubble for a specific message text (most recent match). */
+  userBubble(text: string): Locator {
+    return this.userBubbles.filter({ hasText: text }).last()
+  }
+}

--- a/browser_tests/fixtures/panelTest.ts
+++ b/browser_tests/fixtures/panelTest.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared Playwright fixtures for the Agent panel Tier 1 suite.
+ *
+ * Provides:
+ *   - `mockBridge`: a started MockBridge on an OS-assigned free port, auto-closed
+ *     after each test.
+ *   - `panel`: a PanelPage bound to the test's page.
+ *
+ * A typical spec: point the panel at `mockBridge.url`, open the sidebar, connect,
+ * then drive the conversation via the MockBridge helpers.
+ */
+import { test as base } from '@playwright/test'
+
+import { MockBridge } from './MockBridge'
+import { PanelPage } from './PanelPage'
+
+interface PanelFixtures {
+  mockBridge: MockBridge
+  panel: PanelPage
+}
+
+export const test = base.extend<PanelFixtures>({
+  mockBridge: async ({}, use) => {
+    const bridge = new MockBridge({ port: 0 })
+    await bridge.start()
+    await use(bridge)
+    await bridge.close()
+  },
+  panel: async ({ page }, use) => {
+    await use(new PanelPage(page))
+  }
+})
+
+export { expect } from '@playwright/test'

--- a/browser_tests/hidden-tab.spec.ts
+++ b/browser_tests/hidden-tab.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * Tier 1 — hidden/background-tab streaming regression (commit 23a88ad).
+ *
+ * THE BUG: the panel's streaming typewriter (pumpStreams) runs on
+ * requestAnimationFrame. Browsers PAUSE rAF in a hidden/background tab, so a
+ * reply that committed while the user was on another tab would never paint — the
+ * agent bubble sat empty with a stuck cursor ("stuck thinking / never drains").
+ *
+ * THE FIX: commitStream() checks `document.hidden` and, when hidden, renders the
+ * final text SYNCHRONOUSLY (finalizeStream) instead of waiting for an rAF tick
+ * that will not come.
+ *
+ * WHAT THIS TEST ASSERTS: with the tab reporting hidden, a streamed reply still
+ * lands in the agent bubble.
+ *
+ * LIMITATION / WHY WE ALSO NEUTER rAF: headless Chromium does not reliably pause
+ * requestAnimationFrame just because we spoof document.hidden — so spoofing
+ * visibility alone would pass even against the OLD (buggy) code. To make this a
+ * REAL regression test we additionally replace requestAnimationFrame with a
+ * no-op, deterministically reproducing the "rAF never fires" condition a true
+ * background tab creates. Under that condition only the synchronous hidden-path
+ * (the fix) can paint the reply; the pre-fix rAF-only path would leave the bubble
+ * empty and this test would fail.
+ */
+import { test, expect } from './fixtures/panelTest'
+
+test('renders a streamed reply while the tab is hidden (rAF paused)', async ({
+  panel,
+  page,
+  mockBridge
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  // Simulate a hidden tab with paused rAF: spoof visibility AND stop rAF from
+  // ever firing, so only the synchronous hidden-path can render the reply.
+  await page.evaluate(() => {
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      get: () => true
+    })
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden'
+    })
+    window.requestAnimationFrame = (() => 0) as typeof window.requestAnimationFrame
+    document.dispatchEvent(new Event('visibilitychange'))
+  })
+
+  const received = mockBridge.waitForUserMessage()
+  await panel.sendMessage('reply while hidden')
+  await received
+
+  mockBridge.replyStreamed('hidden tab reply text')
+
+  await expect(panel.agentBubbles.last()).toContainText('hidden tab reply text')
+})

--- a/browser_tests/pending-queue.spec.ts
+++ b/browser_tests/pending-queue.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * Tier 1 — pending queue drains.
+ *
+ * While a turn is in flight (the bridge emitted turn:working and is withholding
+ * the result), a second message must QUEUE in the pending tray rather than paint
+ * inline. When the agent dequeues it (a "seen" ack) the message materializes in
+ * the chat and leaves the tray.
+ *
+ * The panel only queues when its internal `agentWorking` flag is set, which
+ * happens solely on a turn:working frame. We confirm the panel processed that
+ * frame by polling the sessionStorage marker the working-turn handler writes
+ * (comfyui-mcp.panel.midTaskResume) before sending the second message — avoiding
+ * a race where the 2nd send would otherwise be treated as an idle (inline) send.
+ */
+import { test, expect } from './fixtures/panelTest'
+
+const MID_TASK_KEY = 'comfyui-mcp.panel.midTaskResume'
+
+test('queues a message during a working turn, then drains it on dequeue', async ({
+  panel,
+  page,
+  mockBridge
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  // First message — sent while idle, so it paints inline immediately.
+  const first = mockBridge.waitForUserMessage()
+  await panel.sendMessage('first message')
+  await first
+
+  // A turn is now in flight and its result is withheld.
+  mockBridge.emitWorking()
+  await expect
+    .poll(() => page.evaluate((k) => sessionStorage.getItem(k), MID_TASK_KEY))
+    .toBe('1')
+
+  // Second message — must queue (turn busy), not paint inline.
+  const second = mockBridge.waitForUserMessage()
+  await panel.sendMessage('second queued message')
+  const secondMsg = await second
+  expect(secondMsg.mid).toBeTruthy()
+
+  await expect(panel.pendingTray).toBeVisible()
+  await expect(panel.pendingItems).toHaveCount(1)
+  await expect(panel.pendingTray).toContainText('Pending · 1')
+  // Queued: no inline user bubble for it yet.
+  await expect(panel.userBubble('second queued message')).toHaveCount(0)
+
+  // The agent dequeues it — it materializes in the chat and leaves the tray.
+  mockBridge.markSeen(secondMsg.mid!)
+  mockBridge.turnDone()
+
+  await expect(panel.pendingItems).toHaveCount(0)
+  await expect(panel.userBubble('second queued message')).toBeVisible()
+})

--- a/browser_tests/streaming-render.spec.ts
+++ b/browser_tests/streaming-render.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * Tier 1 — streamed reply renders.
+ *
+ * Sends a message, then has the MockBridge emit a full streamed reply
+ * (stream/text -> say/streamed -> stream/end -> turn/done). Asserts the last
+ * agent bubble actually shows the streamed text — i.e. the typewriter caught up
+ * and the committed `say` reconciled with its live preview, instead of leaving
+ * an empty bubble with a stuck cursor.
+ */
+import { test, expect } from './fixtures/panelTest'
+
+test('renders a streamed agent reply into the last agent bubble', async ({
+  panel,
+  mockBridge
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  const received = mockBridge.waitForUserMessage()
+  await panel.sendMessage('say hello')
+  const msg = await received
+  expect(msg.text).toContain('say hello')
+
+  mockBridge.replyStreamed('hello world')
+
+  await expect(panel.agentBubbles.last()).toContainText('hello world')
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,145 @@
+{
+  "name": "comfyui-agent-panel-e2e",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "comfyui-agent-panel-e2e",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.49.0",
+        "@types/node": "^22.10.0",
+        "@types/ws": "^8.5.13",
+        "typescript": "^5.7.2",
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "comfyui-agent-panel-e2e",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Dev-only Playwright e2e harness for the ComfyUI Agent Panel. NOT shipped with the pack (see .comfyignore).",
+  "scripts": {
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:list": "playwright test --list",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0",
+    "@types/node": "^22.10.0",
+    "@types/ws": "^8.5.13",
+    "typescript": "^5.7.2",
+    "ws": "^8.18.0"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,49 @@
+/**
+ * Playwright config for the ComfyUI Agent Panel — Tier 1 e2e suite.
+ *
+ * Modeled on comfyui_frontend's browser_tests/playwright.config.ts.
+ *
+ * PREREQUISITES (this suite does NOT start ComfyUI for you):
+ *   1. A real ComfyUI must be running and reachable at http://localhost:8188.
+ *      Playwright launches its OWN browser which navigates there.
+ *   2. ComfyUI must be started with cross-origin allowed so the panel page can
+ *      open a WebSocket to the test's MockBridge on a different port:
+ *        comfyui --enable-cors-header
+ *      (ComfyUI Desktop users: launch with that flag, or set the equivalent.)
+ *   3. THIS pack (comfyui-agent-panel) must be junctioned/symlinked into
+ *      ComfyUI's custom_nodes so the Agent sidebar tab is registered.
+ *
+ * Tier 1 is AGENT-FREE: every spec points the panel at a scriptable MockBridge
+ * (browser_tests/fixtures/MockBridge.ts) instead of a real Claude/Codex
+ * orchestrator. Deterministic, fast, no auth, no cost.
+ *
+ * Run:  npm run test:e2e          (headless)
+ *       npm run test:e2e:ui       (Playwright UI mode)
+ *       npm run test:e2e:list     (compile + discover only — no ComfyUI needed)
+ */
+import { defineConfig, devices } from '@playwright/test'
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:8188'
+
+export default defineConfig({
+  testDir: './browser_tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure'
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+      timeout: 30_000
+    }
+  ]
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["node"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["browser_tests/**/*.ts", "playwright.config.ts"]
+}


### PR DESCRIPTION
## What

Adds a Playwright "Tier 1" e2e suite for the ComfyUI Agent panel, modeled on comfyui_frontend's `browser_tests` setup. Tier 1 is **agent-free**: every spec points the panel at a scriptable **MockBridge** (a fake orchestrator) instead of a real Claude/Codex backend, so tests are deterministic, fast, and need no auth or cost. The MockBridge replaces only the orchestrator — tests still run against a real ComfyUI hosting the panel.

## Files

- **`package.json`** — private, dev-only (the pack had none). devDeps `@playwright/test`, `ws`, `@types/ws`, `@types/node`, `typescript`; scripts `test:e2e`, `test:e2e:ui`, `test:e2e:list`, `typecheck`. Excluded from the shipped pack via `.comfyignore`, so it does not change what the pack ships. `package-lock.json` committed.
- **`playwright.config.ts`** — `testDir browser_tests`, baseURL `http://localhost:8188`, `chromium` (Desktop Chrome) project, html reporter, `trace: on-first-retry`. Header documents the live-ComfyUI + `--enable-cors-header` + junction requirements.
- **`browser_tests/fixtures/MockBridge.ts`** — `ws` server on an OS-assigned port. On `hello` it emits the panel's handshake frames (`models` → flips to "connected", `commands`, `agent_status`, `ack {kind:ready}`, a greeting `say`). Helpers: `onUserMessage`, `waitForUserMessage`, `replyStreamed`, `emitWorking`/`startTurn`, `turnDone`, `ack`/`markSeen`, `say`, `send`. Auto-acks `working` on each user_message and auto-replies to graph command requests.
- **`browser_tests/fixtures/PanelPage.ts`** — page object: `goto`, `openSidebar`, `setBridgeUrl`, `connect`, `sendMessage`, `lastAgentReply`, `status`, `pendingCount`, with centralized selectors.
- **`browser_tests/fixtures/panelTest.ts`** — fixtures wiring a started `mockBridge` + a `panel` into each test.
- **Specs**: `connect`, `streaming-render`, `hidden-tab` (regression for `23a88ad`), `pending-queue`.
- **`browser_tests/README.md`** — run instructions.

## Frame shapes (verified against `createBridgeClient` in `web/js/comfyui-mcp-panel.js`)

- Handshake: `{type:"models",models:[{id,label,small?}],current?,backend?}` (only this flips status to connected), `{type:"commands",commands}`, `{type:"agent_status",context_pct,cost_usd}`, `{type:"ack",kind:"ready"}`.
- Streamed reply: `{type:"stream",phase:"text",id,delta}` → `{type:"say",text,id,streamed:true}` → `{type:"stream",phase:"end",id}` → `{type:"turn",state:"done"}`.
- Turn lifecycle: `{type:"turn",state:"working"|"done"}`. Acks: `{type:"ack",kind:"working"|"seen",mid}`.
- Inbound parsed: `{type:"hello",...}`, `{type:"user_message",text,mid,context?,images?}`, `{rid,cmd}` command requests.

## Connect path (agent-free)

The "Connect" button POSTs `/comfyui_mcp_panel/connect`, which starts a real orchestrator. Tests avoid that: `PanelPage.connect()` seeds the Bridge URL (localStorage + Settings field) and clicks **Reconnect**, which calls the bridge client's `setUrl()` → `connect()` directly. Sticky auto-connect is disabled in `goto()`.

## Verification

- `npx playwright test --list` ✅ (4 specs discovered)
- `tsc --noEmit` ✅
- **Full suite ✅ 4/4 passed** against a live local ComfyUI (`:8188`) with the panel junctioned in.

No panel runtime JS was modified — no testids added; all selectors reuse existing classes (`.cmcp-root`, `.cmcp-status`, `.cmcp-composer-input`, `.cmcp-bubble.agent`, `.cmcp-pending-item`, …).

### hidden-tab limitation
Headless Chromium doesn't reliably pause `requestAnimationFrame` on a spoofed-hidden tab, so the spec ALSO neuters `requestAnimationFrame` to deterministically reproduce the paused-rAF condition. Under that condition only the fix's synchronous hidden-path can paint the streamed reply (the pre-fix rAF-only path would leave the bubble empty and fail the test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
