### PR TITLE
Release 0.4.4 — provider onboarding, rich media metadata, code-block tools, render-stall setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-06-27
+
+### Added
+
+- **Rich media metadata in agent pushes.** When a render's media is sent to the agent,
+  the executed-event note (and a structured `metadata` field) now include each output's
+  path (subfolder-relative), file size, pixel dimensions, asset-set grouping ("output K
+  of N from this run" + sibling filenames, or "single output"), render duration, and
+  completion time. Video storyboards add format + real frame count/fps when the payload
+  carries them.
+- **Provider onboarding.** Connect-time readiness detection per provider (CLI on PATH +
+  a login on disk; macOS Keychain handled) via `/backends`. An onboarding card shows
+  only when neither provider is signed in; the panel auto-switches to a ready provider
+  when the saved pick isn't usable (saved preference untouched), and a not-ready
+  provider row becomes a "set up" action that seeds a prompt to the working agent.
+- **Code-block tools.** Rendered fenced code blocks get a Copy button + a persisted
+  global line-wrap toggle (off by default); inline code gets Copy. Hover-gated, styled
+  to match the panel.
+- **Render-stall warning threshold setting** (General; default 180s, range 15–3600).
+  Sent on connect (the orchestrator spawn default) and pushed **live** via a `set_config`
+  frame, so changing it applies without a reconnect.
+
 ## [0.4.3] - 2026-06-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Each provider runs its own orchestrator on its own loopback port (Claude on
 | Capability | What it does |
 |---|---|
 | **Pick a provider** | A backend picker with **Claude** / **ChatGPT** chips — choose the agent, not a port. Switching providers starts a fresh chat (sessions aren't shared across providers) and posts a system note. |
+| **Provider onboarding** | Connect-time readiness detection per provider (CLI on PATH + a login on disk; macOS Keychain handled). An onboarding card shows only when neither provider is signed in; the panel auto-switches to a ready provider when your saved pick isn't usable (your saved preference is untouched), and a not-ready row becomes a "set up" action. |
 | **Live-canvas building** | The agent adds, wires, moves, retitles, colors, collapses, groups, and lays out nodes on the graph you're viewing — all through a fixed `panel_*` allowlist (no arbitrary JS), every edit undoable with **Ctrl+Z**. |
 | **One-shot workflow / pack load** | `panel_load_workflow` drops a whole graph onto the canvas in one call — load a bundled installer pack's local-GPU workflow by name without shuttling the JSON through the chat. |
 | **Local-GPU vs paid-API awareness** | Bundled packs are local/free; for ad-hoc graphs the agent checks the runtime (`check_workflow_runtime`) and **asks before spending paid API credits**. |
@@ -240,7 +241,25 @@ identical across providers.
 - **Reconnect durability.** A wedged orchestrator no longer strands the panel —
   **Connect** reclaims a zombie that still holds the bridge port.
 - **Richer composer attachments.** Attach, drag, or paste **images, video,
-  workflow `.json`, and text** files into the composer.
+  workflow `.json`, and text** files into the composer. Attachments show as
+  expandable **chips** above the input (kind icon + label; click to preview the
+  full content, × to remove), and **pasted text renders inline** in the sent
+  bubble — verbatim, exactly as if you'd typed it, rather than a raw
+  `[Pasted text #N]` token.
+- **Rich media metadata.** When a render's media is pushed to the agent, the
+  executed-event note includes each output's path (subfolder-relative), file
+  size, pixel dimensions, asset-set grouping ("output K of N from this run" +
+  sibling filenames), render duration, and completion time — videos add format +
+  real frame count / fps.
+- **Code-block tools.** Rendered fenced code blocks get a **Copy** button plus a
+  persisted global **line-wrap** toggle (off by default); inline code gets Copy.
+- **Streamed replies in background tabs.** Switching away from the ComfyUI tab
+  mid-turn no longer leaves an empty bubble with a stuck cursor — the reply
+  finalizes synchronously while the tab is hidden and flushes on
+  `visibilitychange`, so long pipeline runs render even if you tab away.
+- **Render-stall warning.** A tunable stall threshold (Settings → General;
+  default 180s, range 15–3600) warns when a render wedges; it's pushed **live**,
+  so changing it applies without a reconnect.
 
 ## Security notes
 

--- a/__init__.py
+++ b/__init__.py
@@ -132,6 +132,21 @@ def _truthy(val):
     return str(val).lower() in ("1", "true", "yes") if val is not None else False
 
 
+def _coerce_stall(val):
+    """Clamp a stall-warning-seconds value to [15, 3600]; None when absent/invalid.
+    Forwarded to the orchestrator as COMFYUI_MCP_STALL_S — how long a render may
+    make no progress before the agent is warned it looks stalled/wedged."""
+    if val is None:
+        return None
+    try:
+        n = int(float(val))
+    except (TypeError, ValueError):
+        return None
+    if n <= 0:
+        return None
+    return max(15, min(3600, n))
+
+
 def _port_in_use(host, port):
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.settimeout(0.3)
@@ -523,7 +538,7 @@ def _port_owner_pid(host, port):
     return None
 
 
-def _start_orchestrator(backend=_DEFAULT_BACKEND, port=None, force=False):
+def _start_orchestrator(backend=_DEFAULT_BACKEND, port=None, force=False, stall_seconds=None):
     """Start the panel orchestrator on demand. Returns (ok: bool, message: str).
 
     Called only from the Connect route — i.e. an explicit user action — never at
@@ -642,6 +657,10 @@ def _start_orchestrator(backend=_DEFAULT_BACKEND, port=None, force=False):
     # the exact same env it always has (the orchestrator defaults to claude too).
     if backend != _DEFAULT_BACKEND:
         env["PANEL_AGENT_BACKEND"] = backend
+    # Render-stall warning threshold (from the panel setting). Only set when given
+    # so an unset setting leaves the orchestrator's own default (180s) in place.
+    if stall_seconds is not None:
+        env["COMFYUI_MCP_STALL_S"] = str(stall_seconds)
     # Subscription lane: the background agent authenticates via the on-disk Claude
     # login, never an API key.
     env.pop("ANTHROPIC_API_KEY", None)
@@ -830,6 +849,9 @@ def _register_routes():
         # that looks healthy by the lockfile but never handshook, and respawn fresh.
         backend = _request.query.get("backend")
         force = _truthy(_request.query.get("force")) or _truthy(_request.query.get("reclaim"))
+        # Optional render-stall threshold (seconds) from the panel setting, applied
+        # to the orchestrator's env on spawn.
+        stall_seconds = _coerce_stall(_request.query.get("stall_seconds"))
         if not backend:
             try:
                 body = await _request.json()
@@ -837,6 +859,8 @@ def _register_routes():
                     backend = body.get("backend")
                     if not force:
                         force = bool(body.get("force") or body.get("reclaim"))
+                    if stall_seconds is None:
+                        stall_seconds = _coerce_stall(body.get("stall_seconds"))
             except Exception:
                 backend = None
         # Reject a non-string backend with a clean 400 (e.g. {"backend": 123})
@@ -852,7 +876,7 @@ def _register_routes():
                 status=400,
             )
         port = _backend_port(backend)
-        ok, message = _start_orchestrator(backend=backend, port=port, force=force)
+        ok, message = _start_orchestrator(backend=backend, port=port, force=force, stall_seconds=stall_seconds)
         return web.json_response(
             {
                 "ok": ok,

--- a/__init__.py
+++ b/__init__.py
@@ -30,6 +30,7 @@ import os
 import shutil
 import socket
 import subprocess
+import sys
 import tempfile
 import time
 
@@ -59,6 +60,55 @@ _DEFAULT_BACKEND = "claude"
 def _backend_port(backend):
     """Bridge port for a backend id; falls back to the claude/default port."""
     return _BACKEND_PORTS.get((backend or _DEFAULT_BACKEND).lower(), _BRIDGE_PORT)
+
+
+# Provider-CLI binary names per backend (Windows resolves .cmd/.exe via PATHEXT,
+# but mirror the defensive npx lookup elsewhere and probe the variants too).
+_PROVIDER_CLIS = {
+    "claude": ("claude", "claude.cmd", "claude.exe"),
+    "codex": ("codex", "codex.cmd", "codex.exe"),
+}
+
+
+def _provider_cli(provider):
+    """True if the provider's CLI binary is resolvable on PATH."""
+    return any(shutil.which(name) for name in _PROVIDER_CLIS.get(provider, ()))
+
+
+def _provider_auth(provider):
+    """Whether a usable login/credential for the provider exists on disk.
+
+    Returns True/False, or None ("unknown") for Claude on macOS, whose token
+    lives in the login Keychain rather than a file we can cheaply read — callers
+    treat unknown as 'don't block' so a logged-in mac user isn't told to sign in.
+    Package-presence is NOT a signal: `npx -y comfyui-mcp` bundles both provider
+    SDKs as optional deps, so the only thing that distinguishes a usable backend
+    is an actual login."""
+    home = os.path.expanduser("~")
+    if provider == "claude":
+        if os.path.isfile(os.path.join(home, ".claude", ".credentials.json")):
+            return True
+        # macOS stores the OAuth token in Keychain — unreadable from here. Report
+        # unknown so a CLI-present mac user is taken as ready rather than nagged.
+        if sys.platform == "darwin":
+            return None
+        return False
+    if provider == "codex":
+        return os.path.isfile(os.path.join(home, ".codex", "auth.json"))
+    return False
+
+
+def _provider_state(provider):
+    """Per-provider readiness for the panel onboarding flow.
+
+    `ready` means the agent can actually run on this provider: its CLI is on PATH
+    AND a login exists. `cli`/`auth` are reported separately so the panel can tell
+    'install the CLI' apart from 'sign in'; `auth` is null when unknown (macOS
+    Keychain), and unknown-with-cli still counts as ready."""
+    cli = _provider_cli(provider)
+    auth = _provider_auth(provider)
+    ready = bool(cli and auth is not False)
+    return {"cli": cli, "auth": auth, "ready": ready}
 
 
 # Per-backend orchestrator handles, keyed by port, so spawning codex doesn't
@@ -189,7 +239,16 @@ def _backend_status(backend):
         # No (valid) lockfile — fall back to a raw port probe (covers a user-run
         # orchestrator or one started before lockfiles).
         running = _orchestrator_running(port)
-    return {"backend": backend, "port": port, "running": running}
+    state = _provider_state(backend)
+    return {
+        "backend": backend,
+        "port": port,
+        "running": running,
+        # Readiness for the onboarding flow: ready = CLI on PATH + a login on disk.
+        "cli": state["cli"],
+        "auth": state["auth"],
+        "ready": state["ready"],
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -751,9 +810,15 @@ def _register_routes():
     @routes.get("/comfyui_mcp_panel/backends")
     async def _backends(_request):
         # Discovery for the panel's backend picker: each known backend with its
-        # mapped port and whether an orchestrator is currently running there.
+        # mapped port, whether an orchestrator is running there, and per-provider
+        # readiness (cli/auth/ready) so the panel can show an onboarding card when
+        # NEITHER provider is signed in and auto-pick a ready one otherwise.
+        backends = [_backend_status(b) for b in _BACKEND_PORTS]
         return web.json_response(
-            {"backends": [_backend_status(b) for b in _BACKEND_PORTS]}
+            {
+                "backends": backends,
+                "any_ready": any(b["ready"] for b in backends),
+            }
         )
 
     @routes.post("/comfyui_mcp_panel/connect")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar — on Claude OR ChatGPT (your own subscription, no API keys). Pick a provider and the agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, and run your workflow — asking before it spends paid API credits. Part of the comfyui-mcp project."
-version = "0.4.3"
+version = "0.4.4"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -297,6 +297,7 @@ const panelHooks = {
   applyEffort: null, // (id|"")
   applyBridgeUrl: null, // (url)
   applyAutoConnect: null, // (bool)
+  applyStallConfig: null, // () — push the live render-stall threshold to the orchestrator
   requestSecret: null, // (envKey, friendly)
 };
 // Best-effort guard so a setSetting() we make while seeding/syncing doesn't bounce
@@ -699,8 +700,10 @@ function panelSettingsList() {
       attrs: { min: 15, max: 3600, step: 5 },
       defaultValue: 180,
       onChange: () => {
-        // Applied via the /connect request when the orchestrator (re)starts; there
-        // is nothing to push live.
+        if (suppressSettingOnChange || !settingsArmed) return;
+        // Push the new threshold to a live orchestrator (set_config) so it applies
+        // without a reconnect; also sent on connect and forwarded on spawn via env.
+        panelHooks.applyStallConfig?.();
       },
     },
     {
@@ -7029,6 +7032,13 @@ function buildPanel() {
     }
     liveBridgeClient = null;
   }
+  // Push the live render-stall threshold (panel setting) to the orchestrator over
+  // the bridge so a change applies WITHOUT a reconnect. No-op until connected.
+  function sendStallConfig() {
+    if (!client?.isConnected?.()) return;
+    client.sendFrame?.({ type: "set_config", stall_seconds: stallSettingSeconds() });
+  }
+
   const client = createBridgeClient({
     onStatus(state) {
       statusText.textContent = state;
@@ -7047,6 +7057,9 @@ function buildPanel() {
       if (connected) {
         resetAutoReclaim();
         clearSoftReloadGuard();
+        // Push the current render-stall threshold so a reused/just-connected
+        // orchestrator reflects the live setting (the spawn env covers a fresh one).
+        sendStallConfig();
       }
       if (!connected) hideThinking();
       // NB: do NOT push set_options here. The saved model id is only known-valid
@@ -9420,6 +9433,7 @@ function buildPanel() {
     lsSet(AUTOCONNECT_KEY, on ? "1" : null);
     if (on && !client.isConnected()) connectAgent();
   };
+  panelHooks.applyStallConfig = () => sendStallConfig();
   panelHooks.requestSecret = (envKey, friendly) => {
     if (!client.isConnected()) {
       appendSystem(
@@ -9508,6 +9522,7 @@ function buildPanel() {
       panelHooks.applyEffort = null;
       panelHooks.applyBridgeUrl = null;
       panelHooks.applyAutoConnect = null;
+      panelHooks.applyStallConfig = null;
       panelHooks.requestSecret = null;
       client.destroy();
       if (liveBridgeClient === client) liveBridgeClient = null;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3978,6 +3978,20 @@ const PANEL_CSS = `
 .cmcp-example:hover { border-color: var(--p-primary-color, #60a5fa); background: var(--p-surface-700, #3f3f46); }
 .cmcp-example .pi { font-size: 0.8125rem; margin: 0; opacity: 1; color: var(--p-primary-color, #60a5fa); flex: none; }
 
+/* Provider onboarding card — shown only when NEITHER provider is signed in. */
+.cmcp-onboard {
+  margin: 0.75rem; padding: 0.75rem 0.875rem;
+  background: var(--p-surface-800, #27272a);
+  border: 1px solid var(--p-content-border-color, #3f3f46);
+  border-radius: var(--p-border-radius-md, 6px);
+  display: flex; flex-direction: column; gap: 0.5rem;
+}
+.cmcp-onboard-title { font-weight: 600; color: var(--p-text-color, #fff); }
+.cmcp-onboard-sub { font-size: 0.75rem; color: var(--p-text-muted-color, #a1a1aa); line-height: 1.4; }
+.cmcp-onboard-col { display: flex; flex-direction: column; gap: 0.25rem; }
+.cmcp-onboard-prov { font-weight: 600; font-size: 0.8125rem; color: var(--p-text-color, #fff); margin-top: 0.25rem; }
+.cmcp-onboard-step { font-size: 0.7rem; color: var(--p-text-muted-color, #a1a1aa); }
+
 .cmcp-bubble {
   padding: 0.5rem 0.75rem; max-width: 92%;
   border-radius: var(--p-border-radius-lg, 8px);
@@ -4106,6 +4120,47 @@ const PANEL_CSS = `
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   white-space: pre; color: var(--p-text-color, #fff);
 }
+/* Hover tools on rendered code (decorateCode): Copy + Wrap on fenced blocks,
+   Copy on inline pills. Buttons are absolute so they never reflow the code, and
+   match the panel's .cmcp-iconbtn style (borderless, muted, hover surface+white). */
+.cmcp-bubble pre.cmcp-codeblock { position: relative; }
+.cmcp-code-tools {
+  position: absolute; top: 0.3rem; right: 0.3rem; display: flex; gap: 0.125rem;
+  opacity: 0; transition: opacity 0.12s;
+}
+.cmcp-bubble pre.cmcp-codeblock:hover .cmcp-code-tools,
+.cmcp-code-tools:focus-within { opacity: 1; }
+.cmcp-code-tool {
+  width: 1.5rem; height: 1.5rem; flex: none; padding: 0;
+  display: flex; align-items: center; justify-content: center;
+  background: transparent; border: none; cursor: pointer;
+  border-radius: var(--p-border-radius-sm, 4px);
+  color: var(--p-text-muted-color, #a1a1aa);
+  transition: background 0.15s, color 0.15s;
+}
+.cmcp-code-tool:hover { background: var(--p-surface-700, #3f3f46); color: var(--p-text-color, #fff); }
+.cmcp-code-tool .pi { font-size: 0.8rem; }
+.cmcp-code-tool.ok { color: #4ade80; }
+.cmcp-wrap-btn.on { color: var(--p-primary-color, #60a5fa); }
+.cmcp-wrap-btn.on:hover { color: var(--p-primary-color, #60a5fa); }
+/* Wrap toggle: flip the block from horizontal-scroll (pre) to wrapping. Higher
+   specificity than the base pre-code rule so no !important is needed. */
+.cmcp-bubble pre.cmcp-codeblock.cmcp-wrap { overflow-x: hidden; }
+.cmcp-bubble pre.cmcp-codeblock.cmcp-wrap code { white-space: pre-wrap; word-break: break-word; }
+/* Inline code copy: a small badge at the pill's top-right corner, shown on hover.
+   Same muted→surface+white treatment as the icon buttons, sized for the pill. */
+.cmcp-bubble.agent code.cmcp-inline-code, .cmcp-bubble.user code.cmcp-inline-code { position: relative; }
+.cmcp-inline-copy {
+  position: absolute; top: -0.5rem; right: -0.35rem; width: 1.1rem; height: 1.1rem; padding: 0;
+  display: none; align-items: center; justify-content: center;
+  background: var(--p-surface-700, #3f3f46); border: none; border-radius: 4px;
+  color: var(--p-text-muted-color, #a1a1aa); cursor: pointer;
+  font-size: 0.55rem; line-height: 1; z-index: 2; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
+  transition: background 0.12s, color 0.12s;
+}
+.cmcp-bubble code.cmcp-inline-code:hover .cmcp-inline-copy { display: flex; }
+.cmcp-inline-copy:hover { background: var(--p-surface-600, #52525b); color: var(--p-text-color, #fff); }
+.cmcp-inline-copy.ok { color: #4ade80; display: flex; }
 .cmcp-bubble table {
   /* Real table layout (NOT display:block) so the header row stays aligned with
      the body; fit the panel width and let long cells wrap instead of scrolling. */
@@ -4552,11 +4607,93 @@ function wireExternalLinks(container) {
   });
 }
 
+// ---- code-block hover tools (copy + global line-wrap toggle) ---------------
+// Line-wrap is a SINGLE global preference (persisted), so toggling one block
+// flips them all — matching how editors expose word-wrap as one setting.
+const CODE_WRAP_KEY = "comfyui-mcp.panel.codeWrap";
+function codeWrapOn() {
+  return lsGet(CODE_WRAP_KEY) === "1";
+}
+function setCodeWrap(on) {
+  lsSet(CODE_WRAP_KEY, on ? "1" : null);
+  // Apply to every rendered block already on screen + sync the toggle buttons.
+  for (const pre of document.querySelectorAll("pre.cmcp-codeblock")) {
+    pre.classList.toggle("cmcp-wrap", on);
+    const wb = pre.querySelector(".cmcp-wrap-btn");
+    if (wb) wb.classList.toggle("on", on);
+  }
+}
+
+/** Flash a tool button green for ~1s as copy confirmation (icon → check). */
+function flashCopied(btn) {
+  const i = btn.querySelector("i");
+  const prev = i ? i.className : null;
+  if (i) i.className = "pi pi-check";
+  btn.classList.add("ok");
+  setTimeout(() => {
+    if (i && prev) i.className = prev;
+    btn.classList.remove("ok");
+  }, 1100);
+}
+
+function copyCodeText(text, btn) {
+  navigator.clipboard?.writeText(text).then(() => flashCopied(btn), () => {});
+}
+
+function codeToolBtn(iconClass, title, onClick) {
+  const b = document.createElement("button");
+  b.type = "button";
+  b.title = title;
+  const i = document.createElement("i");
+  i.className = "pi " + iconClass;
+  b.appendChild(i);
+  b.addEventListener("click", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onClick();
+  });
+  return b;
+}
+
+/** Add hover Copy (+ Wrap-toggle on fenced blocks) UI to rendered code in `el`.
+ *  Idempotent per element; safe to call after every renderRichText. */
+function decorateCode(el) {
+  // Fenced blocks (```): Copy + global Wrap toggle.
+  for (const pre of el.querySelectorAll("pre")) {
+    if (pre.dataset.cmcpTools) continue;
+    pre.dataset.cmcpTools = "1";
+    pre.classList.add("cmcp-codeblock");
+    if (codeWrapOn()) pre.classList.add("cmcp-wrap");
+    const tools = document.createElement("div");
+    tools.className = "cmcp-code-tools";
+    const copyBtn = codeToolBtn("pi-copy", "Copy", () => {
+      const code = pre.querySelector("code");
+      copyCodeText(code ? code.textContent : pre.textContent, copyBtn);
+    });
+    copyBtn.className = "cmcp-code-tool";
+    const wrapBtn = codeToolBtn("pi-bars", "Toggle line wrap (all blocks)", () => setCodeWrap(!codeWrapOn()));
+    wrapBtn.className = "cmcp-code-tool cmcp-wrap-btn" + (codeWrapOn() ? " on" : "");
+    tools.append(copyBtn, wrapBtn);
+    pre.appendChild(tools);
+  }
+  // Inline code (`x`): Copy only (a wrap toggle is meaningless for inline).
+  for (const code of el.querySelectorAll("code")) {
+    if (code.closest("pre") || code.dataset.cmcpCopy) continue;
+    code.dataset.cmcpCopy = "1";
+    code.classList.add("cmcp-inline-code");
+    const text = code.textContent; // capture before appending the button
+    const copyBtn = codeToolBtn("pi-copy", "Copy", () => copyCodeText(text, copyBtn));
+    copyBtn.className = "cmcp-inline-copy";
+    code.appendChild(copyBtn);
+  }
+}
+
 /** Render agent markdown (full GFM) via marked, sanitized with DOMPurify so
  *  agent output can never inject script/handlers into the panel. Links are
  *  forced external via the DOMPurify hook above + wireExternalLinks on the feed. */
 function renderRichText(el, text) {
   el.innerHTML = DOMPurify.sanitize(marked.parse(String(text)));
+  decorateCode(el);
 }
 
 // SINGLETON GUARD: at most ONE bridge client may be live per page. ComfyUI can
@@ -4691,8 +4828,25 @@ function buildPanel() {
   // PROVIDER section can render them (the switcher now lives there, not in
   // settings). Defaults to claude-only until discovery lands.
   let knownBackends = [{ backend: "claude", running: false }];
+  // Durable per-provider readiness (cli/auth/ready), keyed by backend id. Owned by
+  // applyReadiness from GET /backends. Kept SEPARATE from knownBackends because
+  // renderBackendChips is also called from connect/handshake paths that reconstruct
+  // entries as {backend, running} (no readiness) — reading the map instead means a
+  // connect never erases "is this provider signed in", so the set-up affordance and
+  // not-ready hints survive a reconnect.
+  const backendReady = {};
   // Short per-provider hint shown under each provider row in the popup.
   const BACKEND_HINTS = { claude: "Opus · Sonnet · Haiku", codex: "GPT-5 (Codex)" };
+
+  // Hint for a provider that exists but isn't usable yet — distinguishes
+  // "install the CLI" from "sign in". Empty when ready or readiness is unknown.
+  function notReadyHint(b) {
+    if (!b) return "";
+    const r = backendReady[b.backend] || b; // durable readiness survives chip repaints
+    if (r.ready !== false) return "";
+    if (r.cli === false) return `${BACKEND_LABELS[b.backend] || b.backend} CLI not installed`;
+    return b.backend === "codex" ? "Not signed in — run: codex login" : "Not signed in — run: claude auth login";
+  }
 
   function renderBackendChips(backends) {
     backendChips.replaceChildren();
@@ -4708,7 +4862,13 @@ function buildPanel() {
       chip.className = "cmcp-btn cmcp-backend-chip";
       chip.dataset.backend = id;
       chip.textContent = BACKEND_LABELS[id] || id;
-      if (b.running) chip.title = "Running";
+      const hint = notReadyHint(b);
+      if (hint) {
+        chip.title = hint;
+        chip.style.opacity = "0.55"; // dim a provider that isn't signed in yet
+      } else if (b.running) {
+        chip.title = "Running";
+      }
       if (id === selectedBackend) {
         chip.style.cssText =
           "background:var(--p-primary-color,#2563eb);color:var(--p-primary-contrast-color,#fff);border-color:transparent;";
@@ -4724,7 +4884,10 @@ function buildPanel() {
     try {
       const res = await api.fetchApi("/comfyui_mcp_panel/backends");
       const data = await res.json().catch(() => ({}));
-      if (Array.isArray(data?.backends)) renderBackendChips(data.backends);
+      if (Array.isArray(data?.backends)) {
+        renderBackendChips(data.backends);
+        applyReadiness(data);
+      }
     } catch {
       // No /backends route (older host) — keep the default single chip.
     }
@@ -4875,9 +5038,145 @@ function buildPanel() {
   }
   empty.appendChild(examplesBox);
   log.appendChild(empty);
+
+  // ---- provider onboarding ----
+  // `npx -y comfyui-mcp` bundles BOTH provider SDKs as optional deps, so package
+  // presence is meaningless — the real gate is a login. This card walks a fresh
+  // user through installing + signing into a provider, and is shown ONLY when
+  // NEITHER provider is ready (CLI on PATH + a login on disk). The moment one is
+  // ready it hides and the panel auto-picks that provider (see applyReadiness).
+  const PROVIDER_SETUP = {
+    claude: { label: "Claude", install: "npm i -g @anthropic-ai/claude-code", login: "claude auth login" },
+    codex: { label: "ChatGPT", install: "npm i -g @openai/codex", login: "codex login" },
+  };
+  let anyReady = false;
+  let autoPickDone = false; // auto-switch + note fires at most once per panel mount
+  const onboard = document.createElement("div");
+  onboard.className = "cmcp-onboard";
+  onboard.hidden = true;
+
+  function onboardCmd(cmd) {
+    const code = document.createElement("code");
+    code.className = "cmcp-cmd";
+    code.textContent = cmd;
+    code.title = "Click to copy";
+    code.addEventListener("click", () => {
+      navigator.clipboard?.writeText(cmd).then(() => appendSystem("Command copied."), () => {});
+    });
+    return code;
+  }
+
+  function renderOnboard(list) {
+    onboard.replaceChildren();
+    const title = document.createElement("div");
+    title.className = "cmcp-onboard-title";
+    title.textContent = "Sign in to an AI provider to use the agent";
+    const sub = document.createElement("div");
+    sub.className = "cmcp-onboard-sub";
+    sub.textContent =
+      "The agent runs on your own Claude or ChatGPT subscription — no API keys. Set up at least one (Node ≥ 22 required), then click Connect.";
+    onboard.append(title, sub);
+    for (const id of ["claude", "codex"]) {
+      const meta = PROVIDER_SETUP[id];
+      const st = list.find((b) => b.backend === id) || {};
+      const col = document.createElement("div");
+      col.className = "cmcp-onboard-col";
+      const prov = document.createElement("div");
+      prov.className = "cmcp-onboard-prov";
+      prov.textContent = meta.label;
+      col.appendChild(prov);
+      // Only show the install step when the CLI isn't already on PATH (otherwise
+      // the user just needs to sign in).
+      if (!st.cli) {
+        const s1 = document.createElement("div");
+        s1.className = "cmcp-onboard-step";
+        s1.textContent = "1. Install the CLI";
+        col.append(s1, onboardCmd(meta.install));
+      }
+      const s2 = document.createElement("div");
+      s2.className = "cmcp-onboard-step";
+      s2.textContent = st.cli ? "Sign in" : "2. Sign in";
+      col.append(s2, onboardCmd(meta.login));
+      onboard.appendChild(col);
+    }
+  }
+
+  // Apply per-provider readiness from GET /backends: toggle the onboarding card,
+  // and — when a saved pick isn't usable but another provider IS — auto-switch the
+  // active backend (in-memory only; the saved pref is left untouched so it returns
+  // once that provider is set up) and leave a one-line system note.
+  function applyReadiness(data) {
+    const list = Array.isArray(data?.backends) ? data.backends : [];
+    // Only act when the backend actually reports readiness. Derive any_ready from
+    // the per-backend `ready` flags if the top-level field is absent (older Python
+    // / mid-deploy), and treat a backend with NO readiness data at all as "ready"
+    // so the onboarding card never shows spuriously against an old host.
+    const hasReadiness = list.some((b) => typeof b.ready === "boolean");
+    // Persist readiness durably so it survives later renderBackendChips repaints
+    // that only carry {backend, running}.
+    for (const b of list) {
+      if (typeof b.ready === "boolean") backendReady[b.backend] = { cli: b.cli, auth: b.auth, ready: b.ready };
+    }
+    if (!hasReadiness) {
+      anyReady = true;
+      onboard.hidden = true;
+      return;
+    }
+    anyReady = typeof data?.any_ready === "boolean" ? data.any_ready : list.some((b) => b.ready);
+    if (list.length && !anyReady) {
+      renderOnboard(list);
+      onboard.hidden = false;
+    } else {
+      onboard.hidden = true;
+    }
+    if (!anyReady || autoPickDone) return;
+    const sel = list.find((b) => b.backend === selectedBackend);
+    if (sel && sel.ready === false) {
+      const ready = list.find((b) => b.ready);
+      if (ready) {
+        autoPickDone = true;
+        const prevLabel = BACKEND_LABELS[selectedBackend] || selectedBackend;
+        selectedBackend = ready.backend; // active pick only; STORAGE_KEY_BACKEND untouched
+        renderBackendChips(list);
+        setAskPlaceholder(ready.backend);
+        appendSystem(
+          `${prevLabel} isn't signed in — using ${BACKEND_LABELS[ready.backend] || ready.backend}. ` +
+            `Sign in to ${prevLabel} to switch back.`,
+        );
+      }
+    } else {
+      // Saved pick is ready (or readiness unknown) — nothing to switch.
+      autoPickDone = true;
+    }
+  }
+
+  // "Set up the other provider" — when one provider is signed in and the other
+  // isn't, the working agent helps with the install/sign-in. Per design this is
+  // JUST A PROMPT to the agent (no command-runner baked into the panel allowlist):
+  // we send it the request if connected, else drop it in the composer to send once
+  // the user connects to the provider that IS ready.
+  function requestProviderSetup(id) {
+    const meta = PROVIDER_SETUP[id];
+    if (!meta) return;
+    modelPop.hidden = true;
+    const prompt =
+      `Help me set up the ${meta.label} backend so I can use it in this panel — I'm not signed in to it yet. ` +
+      `Walk me through it for my OS: install the CLI (\`${meta.install}\`), sign in (\`${meta.login}\`), ` +
+      `then in this panel pick ${meta.label} in the provider picker and click Connect. Give exact terminal commands.`;
+    if (client.isConnected() && client.sendUserMessage(prompt)) {
+      appendSystem(`Asked the agent to help you set up ${meta.label}.`);
+    } else {
+      input.value = prompt;
+      input.focus();
+      input.dispatchEvent(new Event("input"));
+      appendSystem(`Connect to a signed-in provider, then send this queued request to set up ${meta.label}.`);
+    }
+  }
+
   const body = document.createElement("div");
   body.className = "cmcp-body";
   body.style.position = "relative"; // anchor the "new messages" pill
+  body.appendChild(onboard);
   body.appendChild(log);
 
   // Discord-style sticky autoscroll: follow new content only while the user is
@@ -5380,10 +5679,18 @@ function buildPanel() {
       const activeBackend = connectedBackend || selectedBackend;
       for (const b of knownBackends) {
         const id = b.backend;
-        const small = id === activeBackend ? "connected" : b.running ? "running" : "";
-        item({ label: BACKEND_LABELS[id] || id, small: BACKEND_HINTS[id] || small }, id === activeBackend, () => {
+        const hint = notReadyHint(b);
+        const notReady = (backendReady[id] || b).ready === false;
+        // A not-ready provider can't be connected — tapping it asks the working
+        // agent to help you install/sign in instead of failing a connect.
+        const small = notReady ? `Tap to set up — ${hint}` : BACKEND_HINTS[id] || (id === activeBackend ? "connected" : b.running ? "running" : "");
+        item({ label: BACKEND_LABELS[id] || id, small }, id === activeBackend, () => {
           modelPop.hidden = true;
-          if (id !== activeBackend) connectBackend(id);
+          if (notReady) {
+            requestProviderSetup(id);
+          } else if (id !== activeBackend) {
+            connectBackend(id);
+          }
         });
       }
     }
@@ -9115,6 +9422,11 @@ function buildPanel() {
   // On load, only auto-connect if a bridge is already up (you started the
   // orchestrator yourself, or another tab did). Otherwise sit idle behind the
   // Connect button — we never start a process without an explicit click.
+  // Evaluate provider readiness on open (independent of the connect decision
+  // below): shows the onboarding card if NEITHER provider is signed in, and
+  // auto-picks a ready provider if the saved pick isn't usable.
+  void loadBackends();
+
   (async () => {
     // If a restart we triggered reloaded the page, finish the autonomous resume:
     // respawn the orchestrator and let onStatus(connected) nudge the agent.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -268,6 +268,7 @@ const SETTING_BRIDGE_URL = {
 const LEGACY_SETTING_BRIDGE_URL = "comfyui-mcp.bridgeUrl";
 const SETTING_AUTOCONNECT = "comfyui-mcp.autoConnect";
 const SETTING_FOCUS_FOLLOW = "comfyui-mcp.zoomToAction";
+const SETTING_STALL_S = "comfyui-mcp.stallWarningSeconds";
 const SETTING_TOKEN_CIVITAI = "comfyui-mcp.setCivitaiToken";
 const SETTING_TOKEN_HF = "comfyui-mcp.setHuggingfaceToken";
 // One-time flag: on first load with this feature, push the user's EXISTING
@@ -462,6 +463,16 @@ function triggerSecret(envKey, friendly) {
       }
     }
   }, 150);
+}
+
+// Stall-warning threshold (seconds) from the panel setting, clamped to a sane
+// range — sent on connect so the orchestrator (COMFYUI_MCP_STALL_S) warns the
+// agent once a render has made no progress for this long. null when unset/invalid
+// (the orchestrator then keeps its own 180s default).
+function stallSettingSeconds() {
+  const v = Number(getSetting(SETTING_STALL_S));
+  if (!Number.isFinite(v) || v <= 0) return null;
+  return Math.min(3600, Math.max(15, Math.round(v)));
 }
 
 // Build the settings list registered on the extension. Defined as a function so
@@ -672,6 +683,24 @@ function panelSettingsList() {
       onChange: (v) => {
         if (suppressSettingOnChange || !settingsArmed) return;
         panelHooks.applyAutoConnect?.(!!v);
+      },
+    },
+    {
+      id: SETTING_STALL_S,
+      name: "Render stall warning (seconds)",
+      category: cat("General", "Render stall warning (seconds)"),
+      sortOrder: 142,
+      tooltip:
+        "How long a ComfyUI render may make NO progress before the agent is warned its render looks stalled/wedged " +
+        "(e.g. an OOM-stuck sampler step) and is told to cancel/restart rather than queue another run. Video steps " +
+        "are legitimately slow, so keep this generous. Default 180s; range 15–3600. Applies when the orchestrator " +
+        "next starts — Disconnect then Connect (or /restart) to change it for a running agent.",
+      type: "number",
+      attrs: { min: 15, max: 3600, step: 5 },
+      defaultValue: 180,
+      onChange: () => {
+        // Applied via the /connect request when the orchestrator (re)starts; there
+        // is nothing to push live.
       },
     },
     {
@@ -7757,7 +7786,7 @@ function buildPanel() {
         const res = await api.fetchApi("/comfyui_mcp_panel/connect", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ backend: selectedBackend }),
+          body: JSON.stringify({ backend: selectedBackend, stall_seconds: stallSettingSeconds() }),
         });
         const data = await res.json().catch(() => ({}));
         if (myGen !== connectGen) return; // a newer user connect took over
@@ -7820,7 +7849,7 @@ function buildPanel() {
         const res = await api.fetchApi("/comfyui_mcp_panel/connect", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ backend: selectedBackend, force: true }),
+          body: JSON.stringify({ backend: selectedBackend, force: true, stall_seconds: stallSettingSeconds() }),
         });
         const data = await res.json().catch(() => ({}));
         // A newer user-initiated connect superseded us → let it drive.
@@ -7890,7 +7919,7 @@ function buildPanel() {
       const res = await api.fetchApi("/comfyui_mcp_panel/connect", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ backend: selectedBackend }),
+        body: JSON.stringify({ backend: selectedBackend, stall_seconds: stallSettingSeconds() }),
       });
       const data = await res.json().catch(() => ({}));
       // A newer connect (e.g. a backend switch) superseded this one while the POST


### PR DESCRIPTION
Consolidated session batch for `comfyui-agent-panel` 0.4.4.

## Features
- **Provider onboarding** — Connect-time readiness detection, onboarding card only when neither provider is signed in, auto-switch to a ready provider, not-ready row becomes a 'set up' action.
- **Rich media metadata** in agent pushes — path, size, dimensions, asset-set grouping, render duration, completion time; video format/fps/frame count (#37).
- **Code-block tools** — Copy + persisted line-wrap toggle; inline Copy.
- **Render-stall warning threshold** setting — sent on connect + pushed **live** via `set_config`.
- (earlier today, included) hidden/background-tab streaming reliability fix, pasted-text inline.

## Docs
- CHANGELOG 0.4.4 + README (onboarding, media metadata, code-block tools, stall-threshold, bg-tab streaming).

**Smoke:** `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)