### PR TITLE
feat: run-to-node — graph_run to_node_id (partial execution) (0.4.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.4.5] - 2026-06-29
+
+### Added
+
+- **Run to node (partial execution).** `graph_run` now accepts `to_node_id`: render only
+  that output node's branch (the node plus everything upstream) via ComfyUI's native
+  partial execution (`app.queuePrompt(0, batch, partial_execution_targets)`), skipping
+  every other output branch — fast/cheap previewing or debugging of part of a big graph.
+  The target must be a root-level **output** node (SaveImage/PreviewImage/SaveVideo/…);
+  non-output or subgraph-nested targets are rejected with actionable guidance instead of
+  silently running the whole graph. Node summaries now tag output nodes `is_output:true`,
+  and the command line shows `→ node N` when a partial run was queued. Omitting
+  `to_node_id` is byte-identical to the previous full-graph run. Pairs with the MCP
+  `panel_run` `to_node_id` parameter and the `debug-render` skill (comfyui-mcp ≥ 0.21.0).
+
+### Fixed
+
+- **Run-result display crash.** A blocked run that returns `{ error }` (the new
+  run-to-node rejection) no longer throws in the activity line — `describeCommand` guarded
+  the `JSON.stringify(node_errors)` path and now shows the returned guidance for `error`
+  and the node-error JSON only when `node_errors` is present.
+
 ## [0.4.4] - 2026-06-27
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar — on Claude OR ChatGPT (your own subscription, no API keys). Pick a provider and the agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, and run your workflow — asking before it spends paid API credits. Part of the comfyui-mcp project."
-version = "0.4.4"
+version = "0.4.5"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1569,6 +1569,9 @@ function summarizeNode(node) {
     ...(node.mode ? { mode: { 2: "mute", 4: "bypass" }[node.mode] ?? `mode_${node.mode}` } : {}),
     ...(node.color ? { color: node.color } : {}),
     ...(node.bgcolor ? { bgcolor: node.bgcolor } : {}),
+    // OUTPUT nodes (SaveImage/PreviewImage/SaveVideo/…) are the only valid
+    // targets for panel_run's to_node_id ("run to node" partial execution).
+    ...(node.constructor?.nodeData?.output_node ? { is_output: true } : {}),
     widgets,
     inputs,
     outputs,
@@ -1832,7 +1835,7 @@ const GRAPH_TOOL_EXECUTORS = {
     const node = LG.createNode(class_type);
     if (!node) {
       throw new Error(
-        `Unknown node type "${class_type}" — check the exact class_type via graph_get_state or the node search`,
+        `Unknown node type "${class_type}" — check the exact class_type via panel_get_graph or panel_search_nodes`,
       );
     }
     graph.beforeChange();
@@ -2242,18 +2245,57 @@ const GRAPH_TOOL_EXECUTORS = {
     };
   },
 
-  async graph_run({ batch_count }) {
+  async graph_run({ batch_count, to_node_id }) {
     const { app } = getGraphCtx();
     if (typeof app.queuePrompt !== "function") {
       throw new Error("app.queuePrompt is unavailable on this frontend");
     }
     const batch = Number(batch_count ?? 1);
-    await app.queuePrompt(0, batch);
+
+    // "Run to node" = ComfyUI partial execution. The server keeps an OUTPUT node
+    // (SaveImage/PreviewImage/SaveVideo/…) as an execution root only when its id
+    // is in partial_execution_targets, then walks back through that node's
+    // dependencies — so only that branch renders. A non-output node can't be a
+    // root (the prompt would have "no outputs"), and an output node nested in a
+    // subgraph needs a path-style NodeExecutionId we don't build yet — reject
+    // both with guidance instead of silently running the whole graph. Stays
+    // undefined for a normal full run (byte-identical to the prior behaviour).
+    let partialTargets;
+    if (to_node_id != null) {
+      const node = app.graph?.getNodeById?.(Number(to_node_id));
+      if (!node) {
+        return {
+          queued: false,
+          error:
+            `node ${to_node_id} is not on the root graph — run-to-node targets a ` +
+            `root-level output node (output nodes inside subgraphs aren't supported yet)`,
+        };
+      }
+      // isOutputNode mirrors ComfyUI's util: node.constructor.nodeData.output_node.
+      if (!node.constructor?.nodeData?.output_node) {
+        return {
+          queued: false,
+          error:
+            `node ${to_node_id} (${node.type}) is not an output node — "run to node" can ` +
+            `only target an output node such as SaveImage, PreviewImage, or SaveVideo. Pick the ` +
+            `output node at the end of the branch you want to render (is_output:true in panel_get_graph).`,
+        };
+      }
+      partialTargets = [String(to_node_id)];
+    }
+
+    // app.queuePrompt(number, batchCount, queueNodeIds) — the 3rd arg becomes the
+    // request's partial_execution_targets (queue-service signature; ComfyUI 0.26.2).
+    await app.queuePrompt(0, batch, partialTargets);
     // queuePrompt swallows validation failures into lastNodeErrors.
     const nodeErrors =
       app.lastNodeErrors && Object.keys(app.lastNodeErrors).length ? app.lastNodeErrors : null;
     if (nodeErrors) return { queued: false, node_errors: nodeErrors };
-    return { queued: true, batch_count: batch };
+    return {
+      queued: true,
+      batch_count: batch,
+      ...(partialTargets ? { ran_to_node: Number(to_node_id) } : {}),
+    };
   },
 
   graph_get_errors() {
@@ -4669,11 +4711,19 @@ function describeCommand(cmd, msg, reply) {
       return { icon: "pi-window-maximize", text: `Canvas: ${r.canvas?.action?.replace(/_/g, " ")}` };
     case "graph_run":
       return r.queued
-        ? { icon: "pi-play", text: `Queued workflow${r.batch_count > 1 ? ` ×${r.batch_count}` : ""}` }
+        ? {
+            icon: "pi-play",
+            text:
+              `Queued workflow${r.batch_count > 1 ? ` ×${r.batch_count}` : ""}` +
+              (r.ran_to_node != null ? ` → node ${r.ran_to_node}` : ""),
+          }
         : {
             icon: "pi-exclamation-triangle",
-            text: "Run blocked by node errors",
-            detail: JSON.stringify(r.node_errors).slice(0, 300),
+            // run-to-node rejection returns { error } (no node_errors); a normal
+            // validation failure returns { node_errors }. Handle both — guard the
+            // JSON.stringify so an undefined node_errors can't throw here.
+            text: r.error ? "Run blocked" : "Run blocked by node errors",
+            detail: r.error ?? (r.node_errors ? JSON.stringify(r.node_errors).slice(0, 300) : undefined),
           };
     case "graph_get_errors":
       return {


### PR DESCRIPTION
Panel side of **run-to-node** (MCP side: comfyui-mcp PR #92). Panel-agent tested live; Codex-reviewed the partial-execution mechanism (correct for ComfyUI 0.26.2).

## What
- **`graph_run` accepts `to_node_id`** — render only that output node's branch (node + everything upstream) via ComfyUI's native partial execution (`app.queuePrompt(0, batch, partial_execution_targets)`), skipping every other branch. Target must be a root-level **output** node; non-output / subgraph-nested targets are rejected with actionable guidance (never a silent full run).
- Node summaries tag output nodes `is_output:true`; the activity line shows `→ node N`.
- Omitting `to_node_id` is byte-identical to the prior full-graph run.

## Fixed
- Run-result display crash: a blocked run returning `{ error }` (the new run-to-node rejection) no longer throws in `describeCommand` — guarded the `JSON.stringify(node_errors)` path (found by Codex review).

Version bumped **0.4.4 → 0.4.5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)