### PR TITLE
feat(panel): Remote ComfyUI URL setting — drive a RunPod/remote instance (0.4.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.4.7] - 2026-06-30
+
+### Added
+
+- **Remote ComfyUI URL (drive a RunPod / remote instance).** A new
+  *Settings → Comfy MCP Agent → General → Remote ComfyUI URL (advanced)* field points the
+  agent at a remote ComfyUI (e.g. `https://xxxxxxxx-8188.proxy.runpod.net`) instead of
+  localhost. When set, it's sent on Connect and the orchestrator spawns its MCP with
+  `COMFYUI_URL` targeting the remote server (queue, models, history, uploads all go there);
+  for a non-loopback URL `COMFYUI_PATH` is deliberately omitted so the agent runs in clean
+  remote mode (no local-FS/remote-API split). Blank = local (unchanged default). The URL is
+  validated server-side (`http`/`https` + host) and applied on the next Connect. Your live
+  canvas still follows whichever ComfyUI you opened in the browser. (MCP already supported
+  remote via `COMFYUI_URL`/`isRemoteMode`; this exposes it from the panel — no MCP change.)
+
 ## [0.4.6] - 2026-06-29
 
 ### Added

--- a/__init__.py
+++ b/__init__.py
@@ -183,6 +183,60 @@ def _detect_comfyui_url():
     return "http://{}:{}".format(host, port)
 
 
+_LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1", "0.0.0.0", ""}
+
+
+def _coerce_comfyui_url(val):
+    """Validate + normalize a user-supplied remote ComfyUI URL (panel setting).
+
+    Returns a cleaned ``scheme://host[:port][/path]`` string (no trailing slash),
+    or ``None`` when blank/invalid — callers fall back to the local default. Only
+    http/https with a host are accepted; anything else is rejected rather than
+    silently mis-targeting the agent."""
+    if not val or not isinstance(val, str):
+        return None
+    raw = val.strip()
+    if not raw:
+        return None
+    # Reject any whitespace / control char: urlsplit is permissive and would
+    # otherwise treat "foo bar" (or "https://h/a b") as a valid host and mis-target
+    # the agent. A real ComfyUI URL never contains whitespace.
+    if any(ch.isspace() or ord(ch) < 0x20 for ch in raw):
+        return None
+    # Tolerate a bare host[:port] by assuming http://.
+    if "://" not in raw:
+        raw = "http://" + raw
+    try:
+        from urllib.parse import urlsplit
+
+        parts = urlsplit(raw)
+        host = parts.hostname or ""
+        if parts.scheme not in ("http", "https") or not host:
+            return None
+        # Defensive: hostname must contain at least one usable char and no spaces
+        # (already excluded above) — reject anything else rather than mis-route.
+        if not host.strip():
+            return None
+    except Exception:
+        return None
+    return raw.rstrip("/")
+
+
+def _url_is_loopback(url):
+    """True if ``url`` points at this machine (localhost/127.0.0.1/::1/0.0.0.0).
+    A non-loopback URL means the agent should run in REMOTE mode (no local
+    COMFYUI_PATH), so its filesystem tools don't target the wrong box."""
+    if not url:
+        return True
+    try:
+        from urllib.parse import urlsplit
+
+        host = (urlsplit(url).hostname or "").lower()
+    except Exception:
+        return True
+    return host in _LOOPBACK_HOSTS
+
+
 def _looks_like_comfyui_root(p):
     """True if ``p`` is a dir that looks like a real ComfyUI install root. A
     ComfyUI Desktop-installer *wrapper* dir has NONE of these markers, while the
@@ -550,7 +604,7 @@ def _port_owner_pid(host, port):
     return None
 
 
-def _start_orchestrator(backend=_DEFAULT_BACKEND, port=None, force=False, stall_seconds=None):
+def _start_orchestrator(backend=_DEFAULT_BACKEND, port=None, force=False, stall_seconds=None, comfyui_url=None):
     """Start the panel orchestrator on demand. Returns (ok: bool, message: str).
 
     Called only from the Connect route — i.e. an explicit user action — never at
@@ -652,11 +706,21 @@ def _start_orchestrator(backend=_DEFAULT_BACKEND, port=None, force=False, stall_
         )
 
     env = dict(os.environ)
-    env["COMFYUI_URL"] = _detect_comfyui_url()
-    _cpath = _detect_comfyui_path()
+    # A user-supplied remote URL (panel setting) overrides the local default and
+    # puts the agent in REMOTE mode. When remote (non-loopback) we deliberately do
+    # NOT set COMFYUI_PATH: the install dir is on the OTHER box, so the agent's
+    # filesystem tools must not target this machine (the MCP would otherwise run a
+    # confusing local-FS + remote-API split). Loopback URLs keep local mode.
+    remote_url = comfyui_url if (comfyui_url and not _url_is_loopback(comfyui_url)) else None
+    env["COMFYUI_URL"] = comfyui_url or _detect_comfyui_url()
+    _cpath = None if remote_url else _detect_comfyui_path()
     if _cpath:
         # Local mode for the agent: download_model / apply_manifest (packs) / scans.
         env["COMFYUI_PATH"] = _cpath
+    elif remote_url:
+        # Belt-and-suspenders: ensure no inherited COMFYUI_PATH leaks local mode in.
+        env.pop("COMFYUI_PATH", None)
+        _log("agent targeting REMOTE ComfyUI {} (local model/pack tools disabled)".format(remote_url))
     # Beacon: the orchestrator watches this PID (ComfyUI) and shuts itself down
     # when ComfyUI exits — including crashes/hard-kills where atexit never fires.
     env["COMFYUI_MCP_PARENT_PID"] = str(os.getpid())
@@ -864,6 +928,9 @@ def _register_routes():
         # Optional render-stall threshold (seconds) from the panel setting, applied
         # to the orchestrator's env on spawn.
         stall_seconds = _coerce_stall(_request.query.get("stall_seconds"))
+        # Optional remote ComfyUI URL (panel setting): when set + non-loopback, the
+        # agent drives a remote server (e.g. a RunPod instance) instead of localhost.
+        comfyui_url = _coerce_comfyui_url(_request.query.get("comfyui_url"))
         if not backend:
             try:
                 body = await _request.json()
@@ -873,6 +940,8 @@ def _register_routes():
                         force = bool(body.get("force") or body.get("reclaim"))
                     if stall_seconds is None:
                         stall_seconds = _coerce_stall(body.get("stall_seconds"))
+                    if comfyui_url is None:
+                        comfyui_url = _coerce_comfyui_url(body.get("comfyui_url"))
             except Exception:
                 backend = None
         # Reject a non-string backend with a clean 400 (e.g. {"backend": 123})
@@ -888,7 +957,9 @@ def _register_routes():
                 status=400,
             )
         port = _backend_port(backend)
-        ok, message = _start_orchestrator(backend=backend, port=port, force=force, stall_seconds=stall_seconds)
+        ok, message = _start_orchestrator(
+            backend=backend, port=port, force=force, stall_seconds=stall_seconds, comfyui_url=comfyui_url
+        )
         return web.json_response(
             {
                 "ok": ok,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar — on Claude OR ChatGPT (your own subscription, no API keys). Pick a provider and the agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, and run your workflow — asking before it spends paid API credits. Part of the comfyui-mcp project."
-version = "0.4.7"
+version = "0.4.6"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar — on Claude OR ChatGPT (your own subscription, no API keys). Pick a provider and the agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, and run your workflow — asking before it spends paid API credits. Part of the comfyui-mcp project."
-version = "0.4.6"
+version = "0.4.7"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -273,6 +273,7 @@ const LEGACY_SETTING_BRIDGE_URL = "comfyui-mcp.bridgeUrl";
 const SETTING_AUTOCONNECT = "comfyui-mcp.autoConnect";
 const SETTING_FOCUS_FOLLOW = "comfyui-mcp.zoomToAction";
 const SETTING_STALL_S = "comfyui-mcp.stallWarningSeconds";
+const SETTING_REMOTE_URL = "comfyui-mcp.remoteComfyuiUrl";
 const SETTING_TOKEN_CIVITAI = "comfyui-mcp.setCivitaiToken";
 const SETTING_TOKEN_HF = "comfyui-mcp.setHuggingfaceToken";
 // One-time flag: on first load with this feature, push the user's EXISTING
@@ -479,6 +480,14 @@ function stallSettingSeconds() {
   const v = Number(getSetting(SETTING_STALL_S));
   if (!Number.isFinite(v) || v <= 0) return null;
   return Math.min(3600, Math.max(15, Math.round(v)));
+}
+
+// Optional remote ComfyUI URL (panel setting). Blank → drive the local ComfyUI.
+// Sent on every /connect so the orchestrator spawns its MCP against the remote
+// server; validated + normalized server-side in __init__.py (_coerce_comfyui_url).
+function remoteUrlSetting() {
+  const v = getSetting(SETTING_REMOTE_URL);
+  return typeof v === "string" ? v.trim() : "";
 }
 
 // Build the settings list registered on the extension. Defined as a function so
@@ -713,6 +722,25 @@ function panelSettingsList() {
         // Push the new threshold to a live orchestrator (set_config) so it applies
         // without a reconnect; also sent on connect and forwarded on spawn via env.
         panelHooks.applyStallConfig?.();
+      },
+    },
+    {
+      id: SETTING_REMOTE_URL,
+      name: "Remote ComfyUI URL (advanced)",
+      category: cat("General", "Remote ComfyUI URL (advanced)"),
+      sortOrder: 143,
+      tooltip:
+        "Point the AGENT at a remote ComfyUI instead of this machine — e.g. a RunPod pod at " +
+        "https://xxxxxxxx-8188.proxy.runpod.net. Leave BLANK to drive the local ComfyUI (default). " +
+        "When set, the agent's tools (queue, models, history, uploads) target the remote server, and " +
+        "local-only tools (download_model / installer packs / model scans) are disabled. Applies when " +
+        "the orchestrator next starts — Disconnect then Connect to change it. Your live canvas still " +
+        "follows whichever ComfyUI you opened in the browser.",
+      type: "text",
+      defaultValue: "",
+      onChange: () => {
+        // No live apply: the URL is baked into the orchestrator's MCP at spawn, so
+        // it takes effect on the next Connect (Disconnect → Connect).
       },
     },
     {
@@ -8530,7 +8558,7 @@ function buildPanel() {
         const res = await api.fetchApi("/comfyui_mcp_panel/connect", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ backend: selectedBackend, stall_seconds: stallSettingSeconds() }),
+          body: JSON.stringify({ backend: selectedBackend, stall_seconds: stallSettingSeconds(), comfyui_url: remoteUrlSetting() }),
         });
         const data = await res.json().catch(() => ({}));
         if (myGen !== connectGen) return; // a newer user connect took over
@@ -8593,7 +8621,7 @@ function buildPanel() {
         const res = await api.fetchApi("/comfyui_mcp_panel/connect", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ backend: selectedBackend, force: true, stall_seconds: stallSettingSeconds() }),
+          body: JSON.stringify({ backend: selectedBackend, force: true, stall_seconds: stallSettingSeconds(), comfyui_url: remoteUrlSetting() }),
         });
         const data = await res.json().catch(() => ({}));
         // A newer user-initiated connect superseded us → let it drive.
@@ -8663,7 +8691,7 @@ function buildPanel() {
       const res = await api.fetchApi("/comfyui_mcp_panel/connect", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ backend: selectedBackend, stall_seconds: stallSettingSeconds() }),
+        body: JSON.stringify({ backend: selectedBackend, stall_seconds: stallSettingSeconds(), comfyui_url: remoteUrlSetting() }),
       });
       const data = await res.json().catch(() => ({}));
       // A newer connect (e.g. a backend switch) superseded this one while the POST


### PR DESCRIPTION
Reddit-driven: let the Agent Panel drive a **remote** ComfyUI (e.g. RunPod) instead of localhost.

## What
New **Settings → Comfy MCP Agent → General → Remote ComfyUI URL (advanced)** text field.
- Blank → drive the local ComfyUI (unchanged default).
- Set (e.g. `https://xxxx-8188.proxy.runpod.net`) → sent on `/connect`; the orchestrator spawns its MCP with `COMFYUI_URL` pointed at the remote server, so the agent's tools (queue, models, history, uploads) target it.
- For a **non-loopback** URL, `COMFYUI_PATH` is deliberately **omitted** so the agent runs in clean remote mode (avoids the local-FS + remote-API split). Loopback URLs keep local mode.
- Applies on the **next Connect** (the URL is baked into the MCP at spawn). The live canvas still follows whichever ComfyUI you opened in the browser.

## Why it's panel-only
The MCP already supports remote ComfyUI (`COMFYUI_URL` / `isRemoteMode`, HTTPS, gateway auth) and the orchestrator already forwards `COMFYUI_URL` — the only gap was the panel had no UI to set it and `__init__.py` hardcoded localhost + always set `COMFYUI_PATH`. **No MCP change.**

## Validation
URL validated server-side (`_coerce_comfyui_url`): http/https + host required; whitespace/control/junk rejected (Codex-flagged + fixed). Unit-tested: RunPod https proxy ✓, trailing-slash strip ✓, bare `host:port` ✓, loopback classification ✓, `foo bar`/`ftp://`/empty → rejected ✓. JS + Python syntax clean.

## ⏳ NOT merged — pending live test
Holding merge/publish until tested against a real remote (RunPod) instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)