### PR TITLE
feat(panel): external/local orchestrator mode — drive a remote ComfyUI (0.4.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.4.7] - 2026-06-30
+
+### Added
+
+- **Remote ComfyUI URL (drive a RunPod / remote instance).** A new
+  *Settings → Comfy MCP Agent → General → Remote ComfyUI URL (advanced)* field points the
+  agent at a remote ComfyUI (e.g. `https://xxxxxxxx-8188.proxy.runpod.net`) instead of
+  localhost. When set, it's sent on Connect and the orchestrator spawns its MCP with
+  `COMFYUI_URL` targeting the remote server (queue, models, history, uploads all go there);
+  for a non-loopback URL `COMFYUI_PATH` is deliberately omitted so the agent runs in clean
+  remote mode (no local-FS/remote-API split). Blank = local (unchanged default). The URL is
+  validated server-side (`http`/`https` + host) and applied on the next Connect. Your live
+  canvas still follows whichever ComfyUI you opened in the browser. (MCP already supported
+  remote via `COMFYUI_URL`/`isRemoteMode`; this exposes it from the panel — no MCP change.)
+
 ## [0.4.6] - 2026-06-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.4.7] - 2026-06-30
+
+### Added
+
+- **External/local orchestrator mode** (Settings → General → "Use external/local
+  orchestrator (advanced)"). When ON, Connect no longer asks the ComfyUI host to
+  spawn an orchestrator — it connects the bridge WebSocket straight to the
+  configured Bridge URL (default `ws://127.0.0.1:9180`) and treats the host
+  `/comfyui_mcp_panel/connect` POST as skipped. This lets an agent running on the
+  USER's machine (`npx -y comfyui-mcp connect <url>`) drive a REMOTE ComfyUI (e.g.
+  a RunPod pod with no Node/agent) — no agent login on the box, no tunnel. If no
+  orchestrator answers on the bridge, the panel surfaces a clear "start it locally"
+  hint with the exact `npx` command. OFF by default, so the co-located autospawn
+  path is byte-for-byte unchanged. The toggle persists via ComfyUI settings.
+
 ## [0.4.6] - 2026-06-29
 
 ### Added

--- a/__init__.py
+++ b/__init__.py
@@ -183,6 +183,60 @@ def _detect_comfyui_url():
     return "http://{}:{}".format(host, port)
 
 
+_LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1", "0.0.0.0", ""}
+
+
+def _coerce_comfyui_url(val):
+    """Validate + normalize a user-supplied remote ComfyUI URL (panel setting).
+
+    Returns a cleaned ``scheme://host[:port][/path]`` string (no trailing slash),
+    or ``None`` when blank/invalid — callers fall back to the local default. Only
+    http/https with a host are accepted; anything else is rejected rather than
+    silently mis-targeting the agent."""
+    if not val or not isinstance(val, str):
+        return None
+    raw = val.strip()
+    if not raw:
+        return None
+    # Reject any whitespace / control char: urlsplit is permissive and would
+    # otherwise treat "foo bar" (or "https://h/a b") as a valid host and mis-target
+    # the agent. A real ComfyUI URL never contains whitespace.
+    if any(ch.isspace() or ord(ch) < 0x20 for ch in raw):
+        return None
+    # Tolerate a bare host[:port] by assuming http://.
+    if "://" not in raw:
+        raw = "http://" + raw
+    try:
+        from urllib.parse import urlsplit
+
+        parts = urlsplit(raw)
+        host = parts.hostname or ""
+        if parts.scheme not in ("http", "https") or not host:
+            return None
+        # Defensive: hostname must contain at least one usable char and no spaces
+        # (already excluded above) — reject anything else rather than mis-route.
+        if not host.strip():
+            return None
+    except Exception:
+        return None
+    return raw.rstrip("/")
+
+
+def _url_is_loopback(url):
+    """True if ``url`` points at this machine (localhost/127.0.0.1/::1/0.0.0.0).
+    A non-loopback URL means the agent should run in REMOTE mode (no local
+    COMFYUI_PATH), so its filesystem tools don't target the wrong box."""
+    if not url:
+        return True
+    try:
+        from urllib.parse import urlsplit
+
+        host = (urlsplit(url).hostname or "").lower()
+    except Exception:
+        return True
+    return host in _LOOPBACK_HOSTS
+
+
 def _looks_like_comfyui_root(p):
     """True if ``p`` is a dir that looks like a real ComfyUI install root. A
     ComfyUI Desktop-installer *wrapper* dir has NONE of these markers, while the
@@ -550,7 +604,7 @@ def _port_owner_pid(host, port):
     return None
 
 
-def _start_orchestrator(backend=_DEFAULT_BACKEND, port=None, force=False, stall_seconds=None):
+def _start_orchestrator(backend=_DEFAULT_BACKEND, port=None, force=False, stall_seconds=None, comfyui_url=None):
     """Start the panel orchestrator on demand. Returns (ok: bool, message: str).
 
     Called only from the Connect route — i.e. an explicit user action — never at
@@ -652,11 +706,21 @@ def _start_orchestrator(backend=_DEFAULT_BACKEND, port=None, force=False, stall_
         )
 
     env = dict(os.environ)
-    env["COMFYUI_URL"] = _detect_comfyui_url()
-    _cpath = _detect_comfyui_path()
+    # A user-supplied remote URL (panel setting) overrides the local default and
+    # puts the agent in REMOTE mode. When remote (non-loopback) we deliberately do
+    # NOT set COMFYUI_PATH: the install dir is on the OTHER box, so the agent's
+    # filesystem tools must not target this machine (the MCP would otherwise run a
+    # confusing local-FS + remote-API split). Loopback URLs keep local mode.
+    remote_url = comfyui_url if (comfyui_url and not _url_is_loopback(comfyui_url)) else None
+    env["COMFYUI_URL"] = comfyui_url or _detect_comfyui_url()
+    _cpath = None if remote_url else _detect_comfyui_path()
     if _cpath:
         # Local mode for the agent: download_model / apply_manifest (packs) / scans.
         env["COMFYUI_PATH"] = _cpath
+    elif remote_url:
+        # Belt-and-suspenders: ensure no inherited COMFYUI_PATH leaks local mode in.
+        env.pop("COMFYUI_PATH", None)
+        _log("agent targeting REMOTE ComfyUI {} (local model/pack tools disabled)".format(remote_url))
     # Beacon: the orchestrator watches this PID (ComfyUI) and shuts itself down
     # when ComfyUI exits — including crashes/hard-kills where atexit never fires.
     env["COMFYUI_MCP_PARENT_PID"] = str(os.getpid())
@@ -864,6 +928,9 @@ def _register_routes():
         # Optional render-stall threshold (seconds) from the panel setting, applied
         # to the orchestrator's env on spawn.
         stall_seconds = _coerce_stall(_request.query.get("stall_seconds"))
+        # Optional remote ComfyUI URL (panel setting): when set + non-loopback, the
+        # agent drives a remote server (e.g. a RunPod instance) instead of localhost.
+        comfyui_url = _coerce_comfyui_url(_request.query.get("comfyui_url"))
         if not backend:
             try:
                 body = await _request.json()
@@ -873,6 +940,8 @@ def _register_routes():
                         force = bool(body.get("force") or body.get("reclaim"))
                     if stall_seconds is None:
                         stall_seconds = _coerce_stall(body.get("stall_seconds"))
+                    if comfyui_url is None:
+                        comfyui_url = _coerce_comfyui_url(body.get("comfyui_url"))
             except Exception:
                 backend = None
         # Reject a non-string backend with a clean 400 (e.g. {"backend": 123})
@@ -888,7 +957,9 @@ def _register_routes():
                 status=400,
             )
         port = _backend_port(backend)
-        ok, message = _start_orchestrator(backend=backend, port=port, force=force, stall_seconds=stall_seconds)
+        ok, message = _start_orchestrator(
+            backend=backend, port=port, force=force, stall_seconds=stall_seconds, comfyui_url=comfyui_url
+        )
         return web.json_response(
             {
                 "ok": ok,

--- a/browser_tests/external-orchestrator.spec.ts
+++ b/browser_tests/external-orchestrator.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * Tier 1 — external/local orchestrator mode.
+ *
+ * Covers the "Use external/local orchestrator (advanced)" Settings toggle: when
+ * ON, Connect must NOT ask the ComfyUI host to spawn an orchestrator (the host —
+ * e.g. a remote RunPod pod — may have no Node/agent). Instead it dials the
+ * configured Bridge URL directly. This is the path that lets an agent running on
+ * the USER's machine (`npx -y comfyui-mcp connect <url>`) drive a remote ComfyUI.
+ *
+ * Asserts:
+ *   1. clicking the real Connect button connects to the MockBridge (handshake →
+ *      status pill "connected"), and
+ *   2. the host spawn route `/comfyui_mcp_panel/connect` is NEVER POSTed.
+ */
+import { test, expect } from './fixtures/panelTest'
+
+const CONNECT_ROUTE = '**/comfyui_mcp_panel/connect'
+const EXTERNAL_SETTING = 'comfyui-mcp.externalOrchestrator'
+
+test('external mode connects to the bridge WITHOUT a host /connect spawn', async ({
+  panel,
+  mockBridge
+}) => {
+  await panel.goto()
+  // Point the panel at the MockBridge. In external mode this non-default URL is a
+  // manual override, so Connect dials it straight (no host involvement).
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+
+  // Turn ON the external/local orchestrator toggle via ComfyUI's settings store —
+  // the same store the panel reads through getSetting().
+  await panel.page.evaluate((id) => {
+    const w = window as unknown as {
+      comfyAPI?: { app?: { app?: { ui?: { settings?: { setSettingValue?: (k: string, v: unknown) => void } } } } }
+      app?: { ui?: { settings?: { setSettingValue?: (k: string, v: unknown) => void } } }
+    }
+    const app = w.comfyAPI?.app?.app || w.app
+    app?.ui?.settings?.setSettingValue?.(id, true)
+  }, EXTERNAL_SETTING)
+
+  // Guard: fail loudly if the panel POSTs the host spawn route. External mode must
+  // never depend on the ComfyUI host starting anything.
+  let connectPosts = 0
+  await panel.page.route(CONNECT_ROUTE, async (route) => {
+    if (route.request().method() === 'POST') connectPosts += 1
+    await route.fulfill({
+      status: 503,
+      contentType: 'application/json',
+      body: '{"ok":false,"message":"external mode should not call this"}'
+    })
+  })
+
+  // Click the REAL Connect button (whose default path would POST /connect) — in
+  // external mode it must skip that and dial the Bridge URL directly.
+  await panel.openConnectionSettings()
+  await panel.connectButton.click()
+
+  await expect(panel.statusPill).toContainText('connected')
+  await expect(panel.statusDot).toHaveClass(/connected/)
+  expect(connectPosts).toBe(0)
+})

--- a/browser_tests/external-orchestrator.spec.ts
+++ b/browser_tests/external-orchestrator.spec.ts
@@ -25,10 +25,28 @@ test('external mode connects to the bridge WITHOUT a host /connect spawn', async
   // Point the panel at the MockBridge. In external mode this non-default URL is a
   // manual override, so Connect dials it straight (no host involvement).
   await panel.setBridgeUrl(mockBridge.url)
-  await panel.openSidebar()
 
-  // Turn ON the external/local orchestrator toggle via ComfyUI's settings store —
-  // the same store the panel reads through getSetting().
+  // EVERYTHING that shapes the connect decision must be in place BEFORE the panel
+  // mounts (openSidebar), otherwise the panel can auto-connect during mount and
+  // POST /connect before the guard below exists — silently MISSING the very
+  // host-spawn behavior this test forbids.
+
+  // 1) Truly disable sticky auto-connect. goto() writes "0", but the panel's
+  //    lsGet() returns the raw string and treats ANY non-null value as truthy —
+  //    so "0" would still fire a mount-time connectAgent(). Remove the key so the
+  //    panel sits idle on mount and the explicit Connect click below is the ONLY
+  //    connect attempt.
+  await panel.page.evaluate(() => {
+    try {
+      localStorage.removeItem('comfyui-mcp.panel.autoConnect')
+    } catch {
+      // storage disabled — nothing persisted to auto-connect from anyway.
+    }
+  })
+
+  // 2) Turn ON the external/local orchestrator toggle via ComfyUI's settings store
+  //    (the same store the panel reads through getSetting()) — before mount, so the
+  //    mount-time connect decision and the Connect click both see external mode.
   await panel.page.evaluate((id) => {
     const w = window as unknown as {
       comfyAPI?: { app?: { app?: { ui?: { settings?: { setSettingValue?: (k: string, v: unknown) => void } } } } }
@@ -38,8 +56,9 @@ test('external mode connects to the bridge WITHOUT a host /connect spawn', async
     app?.ui?.settings?.setSettingValue?.(id, true)
   }, EXTERNAL_SETTING)
 
-  // Guard: fail loudly if the panel POSTs the host spawn route. External mode must
-  // never depend on the ComfyUI host starting anything.
+  // 3) Install the host-spawn guard/spy. External mode must never depend on the
+  //    ComfyUI host starting anything, so fail loudly if the panel POSTs /connect —
+  //    installed BEFORE mount so even a stray mount-time connect would be caught.
   let connectPosts = 0
   await panel.page.route(CONNECT_ROUTE, async (route) => {
     if (route.request().method() === 'POST') connectPosts += 1
@@ -49,6 +68,9 @@ test('external mode connects to the bridge WITHOUT a host /connect spawn', async
       body: '{"ok":false,"message":"external mode should not call this"}'
     })
   })
+
+  // Now mount the panel — external mode on, auto-connect off, guard armed.
+  await panel.openSidebar()
 
   // Click the REAL Connect button (whose default path would POST /connect) — in
   // external mode it must skip that and dial the Bridge URL directly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar — on Claude OR ChatGPT (your own subscription, no API keys). Pick a provider and the agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, and run your workflow — asking before it spends paid API credits. Part of the comfyui-mcp project."
-version = "0.4.6"
+version = "0.4.7"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -273,6 +273,7 @@ const LEGACY_SETTING_BRIDGE_URL = "comfyui-mcp.bridgeUrl";
 const SETTING_AUTOCONNECT = "comfyui-mcp.autoConnect";
 const SETTING_FOCUS_FOLLOW = "comfyui-mcp.zoomToAction";
 const SETTING_STALL_S = "comfyui-mcp.stallWarningSeconds";
+const SETTING_EXTERNAL_ORCH = "comfyui-mcp.externalOrchestrator";
 const SETTING_TOKEN_CIVITAI = "comfyui-mcp.setCivitaiToken";
 const SETTING_TOKEN_HF = "comfyui-mcp.setHuggingfaceToken";
 // One-time flag: on first load with this feature, push the user's EXISTING
@@ -479,6 +480,30 @@ function stallSettingSeconds() {
   const v = Number(getSetting(SETTING_STALL_S));
   if (!Number.isFinite(v) || v <= 0) return null;
   return Math.min(3600, Math.max(15, Math.round(v)));
+}
+
+// External/local orchestrator mode (panel setting). When ON, the agent is run
+// by the USER on their own machine (`npx -y comfyui-mcp connect <url>`), NOT
+// spawned by the ComfyUI host — so Connect skips the host /connect POST and dials
+// the configured Bridge URL directly. OFF by default, which keeps the co-located
+// autospawn path (POST /connect) byte-for-byte unchanged.
+function externalOrchestratorMode() {
+  return !!getSetting(SETTING_EXTERNAL_ORCH);
+}
+// The Bridge URL to dial for `backend`: its per-backend Settings value when set,
+// else that backend’s default port (claude 9180 / codex 9181 / gemini 9182).
+function configuredBridgeUrlFor(backend) {
+  const v = getSetting(SETTING_BRIDGE_URL[backend]);
+  return (typeof v === "string" && v.trim()) || defaultBridgeUrlFor(backend);
+}
+// Best-effort ComfyUI URL to put in the "start it locally" hint — the address of
+// the ComfyUI the user is viewing (a remote pod when opened over its proxy URL).
+function comfyuiUrlForConnect() {
+  try {
+    return window.location.origin;
+  } catch {
+    return "<this-comfyui-url>";
+  }
 }
 
 // Build the settings list registered on the extension. Defined as a function so
@@ -713,6 +738,24 @@ function panelSettingsList() {
         // Push the new threshold to a live orchestrator (set_config) so it applies
         // without a reconnect; also sent on connect and forwarded on spawn via env.
         panelHooks.applyStallConfig?.();
+      },
+    },
+    {
+      id: SETTING_EXTERNAL_ORCH,
+      name: "Use external/local orchestrator (advanced)",
+      category: cat("General", "Use external/local orchestrator (advanced)"),
+      sortOrder: 141,
+      tooltip:
+        "Advanced: run the agent OUTSIDE this ComfyUI host — started by YOU on your own machine " +
+        "(npx -y comfyui-mcp connect <this comfyui url>) instead of being spawned by this ComfyUI. " +
+        "Use it to drive a REMOTE ComfyUI (e.g. a RunPod pod with no Node/agent) from an agent on " +
+        "your laptop. When ON, Connect does NOT ask this host to start anything — it connects straight " +
+        "to the Bridge URL (default ws://127.0.0.1:9180). Leave OFF for the normal local setup where " +
+        "ComfyUI starts the agent for you.",
+      type: "boolean",
+      defaultValue: false,
+      onChange: () => {
+        // No live side effect — it only changes how the NEXT Connect behaves.
       },
     },
     {
@@ -7621,6 +7664,7 @@ function buildPanel() {
         sendStallConfig();
       }
       if (!connected) hideThinking();
+      if (state === "disconnected" && externalOrchestratorMode()) showExternalHintOnce();
       // NB: do NOT push set_options here. The saved model id is only known-valid
       // once the live catalog arrives, so the push happens in applyModelCatalog
       // — sending an unvalidated fallback id can wedge the agent on a model the
@@ -7770,6 +7814,13 @@ function buildPanel() {
     // bounded + reset on a successful handshake, so neither can become a storm.
     // Returns true if it handled it (suppresses the manual warning).
     onHandshakeTimeout(timedOutUrl) {
+      if (externalOrchestratorMode()) {
+        // No host to reclaim — re-dial once (the local agent may still be booting),
+        // then show the "start it locally" hint instead of the squatter warning.
+        if (tryHandshakeRedial(timedOutUrl)) return true;
+        showExternalHintOnce();
+        return true; // handled — suppress the generic "port held by something" warning
+      }
       if (tryHandshakeRedial(timedOutUrl)) return true;
       return tryAutoReclaim(timedOutUrl);
     },
@@ -8401,11 +8452,27 @@ function buildPanel() {
   // Connect AND every successful handshake), so it can NEVER become a redial storm.
   const MAX_HANDSHAKE_REDIALS = 2;
   let handshakeRedialsLeft = MAX_HANDSHAKE_REDIALS;
+  // One-shot "start it locally" hint for external-orchestrator mode: shown when
+  // no agent answers on the bridge. Reset on each user Connect AND on a successful
+  // handshake (both call resetAutoReclaim) so it can re-appear for a later drop.
+  let externalHintShown = false;
+  function showExternalHintOnce() {
+    if (externalHintShown) return;
+    externalHintShown = true;
+    const bridge = configuredBridgeUrlFor(selectedBackend);
+    appendSystem(
+      "No agent is listening on the bridge (" + bridge + "). External orchestrator " +
+        "mode is ON, so this ComfyUI won’t start one. Run the agent on YOUR machine:\n" +
+        "    npx -y comfyui-mcp connect " + comfyuiUrlForConnect() + "\n" +
+        "then click Connect.",
+    );
+  }
   function resetAutoReclaim() {
     autoReclaimsLeft = MAX_AUTO_RECLAIMS;
     autoRespawnsLeft = MAX_AUTO_RESPAWNS;
     respawnGaveUpNoticed = false;
     handshakeRedialsLeft = MAX_HANDSHAKE_REDIALS;
+    externalHintShown = false;
   }
 
   // SOFT-RELOAD ↔ AUTO-RESPAWN interlock. A deliberate softReload(orchestrator)
@@ -8502,6 +8569,10 @@ function buildPanel() {
   // true if it drove a respawn (the caller then skips its bare WS retry), false to
   // let the WS keep retrying / fall back to the manual warning.
   function tryAutoRespawn() {
+    // External/local orchestrator: this host doesn’t own the agent process, so it
+    // can’t respawn it. Let the bare WS retry keep trying (the user restarts it
+    // locally); never POST /connect here.
+    if (externalOrchestratorMode()) return false;
     if (!lsGet(AUTOCONNECT_KEY)) return false; // user never connected / disconnected
     // A deliberate soft-reload owns the respawn — DON'T compete. Return false so
     // scheduleReconnect keeps doing bare WS retries (the soft-reload's own backoff
@@ -8575,6 +8646,8 @@ function buildPanel() {
   // Returns true if it kicked off a reclaim (the bridge client then suppresses its
   // manual warning); false to let the warning show (budget spent / can't reclaim).
   function tryAutoReclaim(timedOutUrl) {
+    // External/local orchestrator: nothing on this host to reclaim.
+    if (externalOrchestratorMode()) return false;
     if (autoReclaiming) return true; // one in flight already — don't stack
     if (autoReclaimsLeft <= 0) return false; // budget spent → fall back to warning
     autoReclaimsLeft -= 1;
@@ -8657,6 +8730,25 @@ function buildPanel() {
     const manualOverride =
       !!wanted && wanted !== defaultBridgeUrlFor(selectedBackend) && wanted !== lastAutoUrl;
     if (manualOverride && wanted !== client.currentUrl()) client.setUrl(wanted);
+    // EXTERNAL/LOCAL ORCHESTRATOR MODE: the agent is run by the user on THEIR
+    // machine, not spawned by this ComfyUI host — so do NOT POST /connect (this
+    // host may have no Node/agent, e.g. a remote pod). Dial the configured Bridge
+    // URL for the selected backend directly; the bounded WS retry surfaces a clear
+    // "start it locally" hint if nothing is listening yet (showExternalHintOnce).
+    if (externalOrchestratorMode()) {
+      connecting = false;
+      if (!manualOverride) {
+        const target = configuredBridgeUrlFor(selectedBackend);
+        if (target && target !== client.currentUrl()) {
+          client.setUrl(target);
+          urlInput.value = target;
+          lastAutoUrl = target;
+        }
+      }
+      if (myGen !== connectGen) return;
+      client.start();
+      return;
+    }
     try {
       // Send the selected backend so the pack starts (and points us at) the right
       // orchestrator. Default "claude" keeps the historical no-pick Connect path.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -273,6 +273,7 @@ const LEGACY_SETTING_BRIDGE_URL = "comfyui-mcp.bridgeUrl";
 const SETTING_AUTOCONNECT = "comfyui-mcp.autoConnect";
 const SETTING_FOCUS_FOLLOW = "comfyui-mcp.zoomToAction";
 const SETTING_STALL_S = "comfyui-mcp.stallWarningSeconds";
+const SETTING_REMOTE_URL = "comfyui-mcp.remoteComfyuiUrl";
 const SETTING_TOKEN_CIVITAI = "comfyui-mcp.setCivitaiToken";
 const SETTING_TOKEN_HF = "comfyui-mcp.setHuggingfaceToken";
 // One-time flag: on first load with this feature, push the user's EXISTING
@@ -479,6 +480,14 @@ function stallSettingSeconds() {
   const v = Number(getSetting(SETTING_STALL_S));
   if (!Number.isFinite(v) || v <= 0) return null;
   return Math.min(3600, Math.max(15, Math.round(v)));
+}
+
+// Optional remote ComfyUI URL (panel setting). Blank → drive the local ComfyUI.
+// Sent on every /connect so the orchestrator spawns its MCP against the remote
+// server; validated + normalized server-side in __init__.py (_coerce_comfyui_url).
+function remoteUrlSetting() {
+  const v = getSetting(SETTING_REMOTE_URL);
+  return typeof v === "string" ? v.trim() : "";
 }
 
 // Build the settings list registered on the extension. Defined as a function so
@@ -713,6 +722,25 @@ function panelSettingsList() {
         // Push the new threshold to a live orchestrator (set_config) so it applies
         // without a reconnect; also sent on connect and forwarded on spawn via env.
         panelHooks.applyStallConfig?.();
+      },
+    },
+    {
+      id: SETTING_REMOTE_URL,
+      name: "Remote ComfyUI URL (advanced)",
+      category: cat("General", "Remote ComfyUI URL (advanced)"),
+      sortOrder: 143,
+      tooltip:
+        "Point the AGENT at a remote ComfyUI instead of this machine — e.g. a RunPod pod at " +
+        "https://xxxxxxxx-8188.proxy.runpod.net. Leave BLANK to drive the local ComfyUI (default). " +
+        "When set, the agent's tools (queue, models, history, uploads) target the remote server, and " +
+        "local-only tools (download_model / installer packs / model scans) are disabled. Applies when " +
+        "the orchestrator next starts — Disconnect then Connect to change it. Your live canvas still " +
+        "follows whichever ComfyUI you opened in the browser.",
+      type: "text",
+      defaultValue: "",
+      onChange: () => {
+        // No live apply: the URL is baked into the orchestrator's MCP at spawn, so
+        // it takes effect on the next Connect (Disconnect → Connect).
       },
     },
     {
@@ -8530,7 +8558,7 @@ function buildPanel() {
         const res = await api.fetchApi("/comfyui_mcp_panel/connect", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ backend: selectedBackend, stall_seconds: stallSettingSeconds() }),
+          body: JSON.stringify({ backend: selectedBackend, stall_seconds: stallSettingSeconds(), comfyui_url: remoteUrlSetting() }),
         });
         const data = await res.json().catch(() => ({}));
         if (myGen !== connectGen) return; // a newer user connect took over
@@ -8593,7 +8621,7 @@ function buildPanel() {
         const res = await api.fetchApi("/comfyui_mcp_panel/connect", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ backend: selectedBackend, force: true, stall_seconds: stallSettingSeconds() }),
+          body: JSON.stringify({ backend: selectedBackend, force: true, stall_seconds: stallSettingSeconds(), comfyui_url: remoteUrlSetting() }),
         });
         const data = await res.json().catch(() => ({}));
         // A newer user-initiated connect superseded us → let it drive.
@@ -8663,7 +8691,7 @@ function buildPanel() {
       const res = await api.fetchApi("/comfyui_mcp_panel/connect", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ backend: selectedBackend, stall_seconds: stallSettingSeconds() }),
+        body: JSON.stringify({ backend: selectedBackend, stall_seconds: stallSettingSeconds(), comfyui_url: remoteUrlSetting() }),
       });
       const data = await res.json().catch(() => ({}));
       // A newer connect (e.g. a backend switch) superseded this one while the POST


### PR DESCRIPTION
## What

Adds a **Settings → General** toggle **"Use external/local orchestrator (advanced)"**. When ON, **Connect** no longer depends on the ComfyUI host spawning an orchestrator — it connects the bridge WebSocket straight to the configured Bridge URL (default `ws://127.0.0.1:9180`) and treats the host `/comfyui_mcp_panel/connect` POST as **skipped**. OFF by default, so the co-located autospawn path is **byte-for-byte unchanged**.

## The external-orchestrator flow (verified architecture)

The panel JS runs in the user's **local browser** even when ComfyUI is served from a remote box. So the panel↔orchestrator bridge (`ws://127.0.0.1:9180`) is already on the user's machine. The only gap was that **Connect** POSTs the ComfyUI **host's** `/connect` route to *spawn* the orchestrator there — which fails for a remote ComfyUI (RunPod pod, cloud box) that has no Node/agent.

With this toggle ON:
- Connect dials `configuredBridgeUrlFor(backend)` directly (no host POST).
- `tryAutoRespawn` / `tryAutoReclaim` stand down (there's no host process to spawn/reclaim) — the bounded WS retry just keeps trying, so when the user starts the agent locally it connects.
- If nothing answers on the bridge, the panel surfaces a one-shot, clear hint:
  > No agent is listening on the bridge (ws://127.0.0.1:9180). External orchestrator mode is ON, so this ComfyUI won't start one. Run the agent on YOUR machine:
  >     `npx -y comfyui-mcp connect <this comfyui url>`
  > then click Connect.

The user runs that one command on their own machine (on their Claude/Codex login), and the orchestrator drives the remote ComfyUI via `COMFYUI_URL` — **no agent login on the box, no tunnel.**

This is the **panel half**; it pairs with the comfyui-mcp `connect <comfyui-url>` subcommand and **PR #42 (remote URL)**.

## Changes

- New setting `SETTING_EXTERNAL_ORCH` (`comfyui-mcp.externalOrchestrator`, boolean, default false), registered in **General** and persisted via ComfyUI settings like the other panel settings.
- `connectAgent` — external branch dials the Bridge URL directly and returns before any `/connect` POST.
- `tryAutoRespawn` / `tryAutoReclaim` — early-return in external mode (never POST the host).
- `onHandshakeTimeout` + the terminal-disconnect path in `onStatus` — surface `showExternalHintOnce()`.
- `browser_tests/external-orchestrator.spec.ts` — Tier-1 e2e: enable the toggle, click the real **Connect**, assert the pill flips to **connected** via the MockBridge **and** the host `/comfyui_mcp_panel/connect` route is **never POSTed** (route-intercept counts 0).
- `pyproject.toml` 0.4.6 → **0.4.7**; CHANGELOG entry.

## Tests / build

- `npm run typecheck` (tsc --noEmit) clean.
- `node --check web/js/comfyui-mcp-panel.js` — syntax OK.
- `npm run test:e2e:list` — the new spec compiles & is discovered (5 specs total).
- The full Tier-1 e2e run needs a live ComfyUI with this worktree junctioned into `custom_nodes` (the suite is not self-contained — see `browser_tests/README.md`); that final run is left to the owner's dev env.

## UX decisions (need owner review)

- **Label**: "Use external/local orchestrator (advanced)" in **General**, `sortOrder: 141` (just under "Render stall warning", above "Zoom to agent edits").
- **Hint copy** + the suggested URL: uses `window.location.origin` (the ComfyUI the user is viewing) as `<this comfyui url>`.
- **Skipped vs best-effort**: chose to **skip** the host `/connect` POST entirely in external mode (not "best-effort, non-fatal"), since a remote host that can't spawn would only add latency/noise.
- Built **unattended** by an agent; wording/labels are first-draft and should be reviewed.

## Notes

- Codex review was requested but Codex CLI is not installed in this environment (needs an interactive `codex login`), so a manual self-review was done instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)