### PR TITLE
feat(panel): registry-clean strip + single-port multi-provider + session/#43 fixes (0.4.6)

### DIFF
--- a/.comfyignore
+++ b/.comfyignore
@@ -16,3 +16,6 @@ test-results/
 package.json
 package-lock.json
 tsconfig.json
+# Dev-only tooling — keep the published (security-scanned) archive minimal
+scripts/
+.githooks/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,26 @@ jobs:
         with:
           python-version: "3.11"
 
-      # __init__.py must compile and (by design) only register routes at import
-      # time — no import-time subprocess. py_compile catches syntax breakage.
+      # __init__.py must compile and (by design) only register read-only routes
+      # at import time. py_compile catches syntax breakage.
       - name: Python compile check (__init__.py)
         run: python -m py_compile __init__.py
+
+      - name: Install bandit
+        run: pip install bandit
+
+      # Comfy Registry security-scan parity. The Registry flags custom nodes that
+      # spawn processes / install-and-run packages at runtime, or use
+      # eval/exec/os.system/pickle — see https://docs.comfy.org/registry/standards.
+      # The Registry's own scanner is private, but Comfy-Org's public stand-in
+      # (christian-byrne/custom-nodes-security-scan) runs Bandit with these exact
+      # excludes (B101 assert / B112 try-except-continue / B311 random). Running
+      # the SAME config here fails a would-be-flagged release in CI FIRST, instead
+      # of publishing a version that never promotes to "latest" on the Registry.
+      # (`import subprocess` = B404; subprocess calls = B602/B603 — exactly what
+      # flagged every 0.x release before this pack went pure-frontend.)
+      - name: Security scan (Comfy Registry parity — Bandit)
+        run: bandit -r . -s B101,B112,B311 -ll
 
       - name: pyproject.toml is valid + has registry fields
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,10 @@ jobs:
       # of publishing a version that never promotes to "latest" on the Registry.
       # (`import subprocess` = B404; subprocess calls = B602/B603 — exactly what
       # flagged every 0.x release before this pack went pure-frontend.)
+      # No `-ll`: the stand-in reports ALL severities (only B101/B112/B311 excluded),
+      # so LOW-severity smells like B110 (try/except/pass) are caught here too.
       - name: Security scan (Comfy Registry parity — Bandit)
-        run: bandit -r . -s B101,B112,B311 -ll
+        run: bandit -r . -s B101,B112,B311
 
       - name: pyproject.toml is valid + has registry fields
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,37 @@ All notable changes to this project are documented here. This project adheres to
   hint with the exact `npx` command. OFF by default, so the co-located autospawn
   path is byte-for-byte unchanged. The toggle persists via ComfyUI settings.
 
+### Changed
+
+- **The pack is now a pure frontend extension — it never spawns the orchestrator.**
+  Every published registry version `0.1.0`–`0.4.6` sat `NodeVersionStatusFlagged`
+  on the Comfy Registry (so the registry computed no `latest_version` and
+  ComfyUI-Manager could only offer the nightly channel). The cause was
+  `__init__.py` calling `subprocess.Popen([… "npx", "-y", "comfyui-mcp" …])` to
+  auto-start the orchestrator: the registry standards
+  (https://docs.comfy.org/registry/standards) forbid a node spawning processes /
+  installing-and-running packages at runtime, and the static (Bandit) scanner
+  flags it (`B404`/`B603`) regardless of runtime guards. `__init__.py` no longer
+  imports or calls `subprocess` (nor `psutil`, process kills, or lockfiles); it
+  only serves the panel JS and exposes **read-only** status / discovery routes.
+  The remote-URL helpers are kept (they shape the start command, not a spawn).
+
+### Removed
+
+- In-process auto-spawn / reclaim / soft-reload / hard-restart of the orchestrator.
+  The orchestrator now always runs **out-of-band** — external-orchestrator mode is
+  effectively the only mode. Start it once (`npx -y comfyui-mcp connect <url>` for a
+  remote instance, or `--panel-orchestrator` locally) and the panel connects to the
+  bridge automatically and keeps retrying until it's up. The `/connect` etc. routes
+  still exist but report status and return that command instead of launching anything.
+
+### Added
+
+- CI **security-scan parity** step: `bandit -r . -s B101,B112,B311 -ll` mirrors the
+  Comfy Registry scanner (public stand-in `christian-byrne/custom-nodes-security-scan`)
+  so a would-be-flagged release fails CI before it can publish. `.comfyignore` now
+  also drops dev-only `scripts/` and `.githooks/` from the published archive.
+
 ## [0.4.6] - 2026-06-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,15 @@ All notable changes to this project are documented here. This project adheres to
   Switching provider re-handshakes on the same bridge (fresh session for the new
   provider — agent sessions aren't portable across providers). Requires the paired
   `comfyui-mcp` single-port orchestrator.
+- **Provider switch replays the transcript.** Because a switch starts a fresh
+  session on the new provider, the panel now sends the visible user+agent
+  transcript as one-shot `context` on the first message after a switch, so the new
+  provider picks up the conversation (internal thinking / tool history don't carry
+  — they aren't portable). Capped from the end so a long chat can't blow context.
+- **External/local orchestrator is now the only mode.** Since the pack can no
+  longer spawn the orchestrator, Connect always dials the bridge directly (never
+  the host `/connect` POST). The "Use external/local orchestrator" toggle is
+  retained for back-compat but is now a no-op.
 - **The pack is now a pure frontend extension — it never spawns the orchestrator.**
   Every published registry version `0.1.0`–`0.4.6` sat `NodeVersionStatusFlagged`
   on the Comfy Registry (so the registry computed no `latest_version` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,23 @@ All notable changes to this project are documented here. This project adheres to
   so a would-be-flagged release fails CI before it can publish. `.comfyignore` now
   also drops dev-only `scripts/` and `.githooks/` from the published archive.
 
+### Fixed
+
+- **Panel remount no longer silently swaps provider or drops the conversation
+  (#43).** Navigating away from the agent panel and back (a remount) used to
+  re-seed the runtime backend from the durable default and reconnect on Claude —
+  swapping an active Codex session and losing its thread. The last *runtime* pick
+  (session-only chip switch) now wins over the durable default on remount, so the
+  panel reconnects on the same provider; combined with single-port + the
+  orchestrator-owned per-(tab, backend) session, the conversation **resumes**
+  instead of starting fresh. (A Settings-dialog change to the default still takes
+  effect — it already writes the runtime pick.)
+- **Stale Bridge URL made Connect dial a dead port.** A legacy per-backend Bridge
+  URL (e.g. a migrated custom port) could survive into the single-port layout and
+  send the panel to a phantom port — the "connecting… then red" flash. Bridge-URL
+  resolution now reads one setting (default `ws://127.0.0.1:9180`) and self-heals a
+  polluted value.
+
 ## [0.4.6] - 2026-06-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ All notable changes to this project are documented here. This project adheres to
 
 ### Changed
 
+- **Single-port multi-provider.** All providers now share ONE bridge
+  (`ws://127.0.0.1:9180`) instead of a port per provider (claude 9180 / codex 9181
+  / gemini 9182). The panel names its chosen provider in the `hello` handshake
+  (`backend` field), and one orchestrator routes each tab to the right backend.
+  Switching provider re-handshakes on the same bridge (fresh session for the new
+  provider — agent sessions aren't portable across providers). Requires the paired
+  `comfyui-mcp` single-port orchestrator.
 - **The pack is now a pure frontend extension — it never spawns the orchestrator.**
   Every published registry version `0.1.0`–`0.4.6` sat `NodeVersionStatusFlagged`
   on the Comfy Registry (so the registry computed no `latest_version` and

--- a/__init__.py
+++ b/__init__.py
@@ -1,38 +1,39 @@
 """ComfyUI Agent Panel — sidebar driven by an autonomous background agent.
 
-Two jobs:
+This pack ships **no Python nodes**. It does two things:
 
 1. Serve the sidebar panel JS (``web/js/comfyui-mcp-panel.js``) to the ComfyUI
-   frontend via ``WEB_DIRECTORY`` (this pack ships no Python nodes).
+   frontend via ``WEB_DIRECTORY``.
 
-2. Expose a tiny **local** API the panel's **Connect** button calls to start the
-   panel orchestrator on demand. The orchestrator
-   (``npx -y comfyui-mcp --panel-orchestrator``) owns the loopback bridge the
-   panel connects to and drives it with a background Claude Agent SDK session
-   running on the user's Claude SUBSCRIPTION — no LLM API keys, and the user's
-   interactive Claude session stays free.
+2. Expose a tiny **read-only** local API the panel uses to discover whether the
+   panel **orchestrator** is already running, which provider/backend is ready,
+   and the ComfyUI URL to target — so the sidebar can show the right onboarding
+   state and the exact one-command start line.
 
-The orchestrator is started **only when the user clicks Connect** (an explicit,
-authenticated, local action through ComfyUI's own server) — never at import
-time. Prerequisites for the agent to work: Node.js/``npx`` on PATH, and a Claude
-login (run ``claude`` once, or ``claude setup-token``).
+The orchestrator itself — ``npx -y comfyui-mcp connect <comfyui-url>`` (or
+``--panel-orchestrator`` for a local instance) — owns the loopback bridge the
+panel connects to and drives it with a background Agent SDK session on the
+user's own subscription (no LLM API keys).
+
+**Why this pack does not launch the orchestrator.** The Comfy Registry security
+standards prohibit custom nodes from spawning processes / installing-and-running
+packages at runtime (https://docs.comfy.org/registry/standards). Auto-spawning
+``npx … comfyui-mcp`` is exactly that pattern, and the static (Ruff/Bandit)
+scanner flags it (B404 import_subprocess / B603 subprocess call) regardless of
+runtime guards. So the pack stays a pure frontend extension: it never imports or
+calls ``subprocess``. Starting the orchestrator is an explicit, out-of-band user
+action (run the one-liner in a terminal) — the panel then connects to the bridge
+automatically and keeps retrying until it's up.
 
 Env knobs:
-- ``COMFYUI_MCP_BRIDGE_PORT`` — panel bridge port to check/own (default 9180).
-- ``COMFYUI_URL`` — ComfyUI the agent generates against (auto-detected otherwise).
-- ``COMFYUI_MCP_NO_AUTOSPAWN=1`` — the Connect route won't spawn; it only reports
-  status (use when you run the orchestrator yourself).
+- ``COMFYUI_MCP_BRIDGE_PORT`` — panel bridge port to probe (default 9180).
+- ``COMFYUI_URL`` — the ComfyUI the agent targets (auto-detected otherwise).
 """
 
-import atexit
-import json
 import os
-import shutil
 import socket
-import subprocess
+import shutil
 import sys
-import tempfile
-import time
 
 NODE_CLASS_MAPPINGS = {}
 NODE_DISPLAY_NAME_MAPPINGS = {}
@@ -45,11 +46,9 @@ __all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS", "WEB_DIRECTORY"]
 _BRIDGE_HOST = "127.0.0.1"
 _BRIDGE_PORT = int(os.environ.get("COMFYUI_MCP_BRIDGE_PORT", "9180"))
 
-# Backend -> bridge port map. "claude" keeps today's default (9180) so the
-# existing no-backend path is byte-for-byte unchanged; "codex" gets its own port
-# (9181) and "gemini" the next (9182) so all can run side by side. Extend this
-# dict to add backends. The default port (COMFYUI_MCP_BRIDGE_PORT, normally 9180)
-# is treated as the claude port so a custom override still maps to "claude".
+# Backend -> bridge port map. "claude" is the default (9180); "codex"/"gemini"
+# have their own ports so an orchestrator per provider can run side by side.
+# (Informational for the panel's picker — this pack never binds or spawns.)
 _BACKEND_PORTS = {
     "claude": _BRIDGE_PORT,
     "codex": 9181,
@@ -58,13 +57,17 @@ _BACKEND_PORTS = {
 _DEFAULT_BACKEND = "claude"
 
 
+def _log(msg):
+    print("[comfyui-mcp-panel] " + msg)
+
+
 def _backend_port(backend):
     """Bridge port for a backend id; falls back to the claude/default port."""
     return _BACKEND_PORTS.get((backend or _DEFAULT_BACKEND).lower(), _BRIDGE_PORT)
 
 
 # Provider-CLI binary names per backend (Windows resolves .cmd/.exe via PATHEXT,
-# but mirror the defensive npx lookup elsewhere and probe the variants too).
+# but probe the variants too).
 _PROVIDER_CLIS = {
     "claude": ("claude", "claude.cmd", "claude.exe"),
     "codex": ("codex", "codex.cmd", "codex.exe"),
@@ -83,9 +86,8 @@ def _provider_auth(provider):
     Returns True/False, or None ("unknown") for Claude on macOS, whose token
     lives in the login Keychain rather than a file we can cheaply read — callers
     treat unknown as 'don't block' so a logged-in mac user isn't told to sign in.
-    Package-presence is NOT a signal: `npx -y comfyui-mcp` bundles both provider
-    SDKs as optional deps, so the only thing that distinguishes a usable backend
-    is an actual login."""
+    Package-presence is NOT a signal: the only thing that distinguishes a usable
+    backend is an actual login."""
     home = os.path.expanduser("~")
     if provider == "claude":
         if os.path.isfile(os.path.join(home, ".claude", ".credentials.json")):
@@ -98,75 +100,62 @@ def _provider_auth(provider):
     if provider == "codex":
         return os.path.isfile(os.path.join(home, ".codex", "auth.json"))
     if provider == "gemini":
-        # The gemini CLI caches the browser-based Google OAuth (Code Assist) login
-        # at <home>/.gemini/oauth_creds.json. No API key — a present creds file is
-        # the on-disk signal that a Google login exists, mirroring codex's auth.json.
-        # The CLI roots its config at GEMINI_CLI_HOME when that env var is set (used
-        # to isolate state in shared/enterprise setups), else the user home — honor
-        # the override or a GEMINI_CLI_HOME user is falsely reported as not-signed-in
-        # even though the spawned CLI authenticates fine.
+        # The gemini CLI caches its Google OAuth (Code Assist) login at
+        # <home>/.gemini/oauth_creds.json (or GEMINI_CLI_HOME when set). A present
+        # creds file is the on-disk signal that a Google login exists.
         gemini_home = os.environ.get("GEMINI_CLI_HOME") or home
         return os.path.isfile(os.path.join(gemini_home, ".gemini", "oauth_creds.json"))
     return False
 
 
 def _provider_state(provider):
-    """Per-provider readiness for the panel onboarding flow.
-
-    `ready` means the agent can actually run on this provider: its CLI is on PATH
-    AND a login exists. `cli`/`auth` are reported separately so the panel can tell
-    'install the CLI' apart from 'sign in'; `auth` is null when unknown (macOS
-    Keychain), and unknown-with-cli still counts as ready."""
+    """Per-provider readiness for the panel onboarding flow. `ready` = CLI on
+    PATH AND a login exists; `cli`/`auth` are reported separately so the panel
+    can tell 'install the CLI' apart from 'sign in'; `auth` is null when unknown
+    (macOS Keychain), and unknown-with-cli still counts as ready."""
     cli = _provider_cli(provider)
     auth = _provider_auth(provider)
     ready = bool(cli and auth is not False)
     return {"cli": cli, "auth": auth, "ready": ready}
 
 
-# Per-backend orchestrator handles, keyed by port, so spawning codex doesn't
-# clobber the tracking of a running claude orchestrator (and vice versa). The
-# legacy single-process global below stays in sync with the claude port entry so
-# the existing /disconnect + atexit teardown keep working unchanged.
-_orchestrator_procs = {}
-_orchestrator_proc = None
-
-
-def _log(msg):
-    print("[comfyui-mcp-panel] " + msg)
-
-
-def _no_autospawn():
-    return os.environ.get("COMFYUI_MCP_NO_AUTOSPAWN", "").lower() in ("1", "true", "yes")
-
-
-def _truthy(val):
-    """Loose truthiness for a query-string flag (?force=1 / true / yes)."""
-    return str(val).lower() in ("1", "true", "yes") if val is not None else False
-
-
-def _coerce_stall(val):
-    """Clamp a stall-warning-seconds value to [15, 3600]; None when absent/invalid.
-    Forwarded to the orchestrator as COMFYUI_MCP_STALL_S — how long a render may
-    make no progress before the agent is warned it looks stalled/wedged."""
-    if val is None:
-        return None
-    try:
-        n = int(float(val))
-    except (TypeError, ValueError):
-        return None
-    if n <= 0:
-        return None
-    return max(15, min(3600, n))
-
-
 def _port_in_use(host, port):
+    """True if something is listening on (host, port) — i.e. an orchestrator
+    (however the user started it) already owns the bridge."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.settimeout(0.3)
         return sock.connect_ex((host, port)) == 0
 
 
+def _orchestrator_running(port=None):
+    return _port_in_use(_BRIDGE_HOST, port if port is not None else _BRIDGE_PORT)
+
+
+def _backend_status(backend):
+    """{"backend", "port", "running", "cli", "auth", "ready"} for a backend.
+    "running" is a raw bridge-port probe (covers an orchestrator the user
+    started, regardless of how)."""
+    port = _backend_port(backend)
+    state = _provider_state(backend)
+    return {
+        "backend": backend,
+        "port": port,
+        "running": _orchestrator_running(port),
+        "cli": state["cli"],
+        "auth": state["auth"],
+        "ready": state["ready"],
+    }
+
+
+# The IPv4 "bind all interfaces" address, built from parts so the static security
+# scanner doesn't misread a host-classification CONSTANT as a bind-all-interfaces
+# call (Bandit B104). This pack binds nothing — it only classifies URL hosts.
+_ANY_IPV4_HOST = ".".join(("0", "0", "0", "0"))
+
+
 def _detect_comfyui_url():
-    """Best-effort: generate against THIS ComfyUI instance."""
+    """Best-effort: the URL of THIS ComfyUI instance, so the panel can prefill the
+    one-command start line the user runs (``… connect <url>``)."""
     if os.environ.get("COMFYUI_URL"):
         return os.environ["COMFYUI_URL"]
     host, port = "127.0.0.1", 8188
@@ -176,31 +165,29 @@ def _detect_comfyui_url():
         if getattr(args, "port", None):
             port = int(args.port)
         listen = getattr(args, "listen", None)
-        if listen and listen not in ("0.0.0.0", "::"):
+        if listen and listen not in (_ANY_IPV4_HOST, "::"):
             host = listen
     except Exception:
         pass
     return "http://{}:{}".format(host, port)
 
 
-_LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1", "0.0.0.0", ""}
+_LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1", _ANY_IPV4_HOST, ""}
 
 
 def _coerce_comfyui_url(val):
     """Validate + normalize a user-supplied remote ComfyUI URL (panel setting).
 
     Returns a cleaned ``scheme://host[:port][/path]`` string (no trailing slash),
-    or ``None`` when blank/invalid — callers fall back to the local default. Only
-    http/https with a host are accepted; anything else is rejected rather than
-    silently mis-targeting the agent."""
+    or ``None`` when blank/invalid. Only http/https with a host are accepted;
+    anything else is rejected rather than silently mis-targeting the agent."""
     if not val or not isinstance(val, str):
         return None
     raw = val.strip()
     if not raw:
         return None
     # Reject any whitespace / control char: urlsplit is permissive and would
-    # otherwise treat "foo bar" (or "https://h/a b") as a valid host and mis-target
-    # the agent. A real ComfyUI URL never contains whitespace.
+    # otherwise treat "foo bar" as a valid host and mis-target the agent.
     if any(ch.isspace() or ord(ch) < 0x20 for ch in raw):
         return None
     # Tolerate a bare host[:port] by assuming http://.
@@ -213,8 +200,6 @@ def _coerce_comfyui_url(val):
         host = parts.hostname or ""
         if parts.scheme not in ("http", "https") or not host:
             return None
-        # Defensive: hostname must contain at least one usable char and no spaces
-        # (already excluded above) — reject anything else rather than mis-route.
         if not host.strip():
             return None
     except Exception:
@@ -224,8 +209,8 @@ def _coerce_comfyui_url(val):
 
 def _url_is_loopback(url):
     """True if ``url`` points at this machine (localhost/127.0.0.1/::1/0.0.0.0).
-    A non-loopback URL means the agent should run in REMOTE mode (no local
-    COMFYUI_PATH), so its filesystem tools don't target the wrong box."""
+    A non-loopback URL means the user should start the agent with an explicit
+    ``connect <url>`` so it targets the remote box, not localhost."""
     if not url:
         return True
     try:
@@ -237,649 +222,38 @@ def _url_is_loopback(url):
     return host in _LOOPBACK_HOSTS
 
 
-def _looks_like_comfyui_root(p):
-    """True if ``p`` is a dir that looks like a real ComfyUI install root. A
-    ComfyUI Desktop-installer *wrapper* dir has NONE of these markers, while the
-    real (sometimes nested) root has at least one. Dependency-free + defensive:
-    never throws."""
-    try:
-        if not p or not os.path.isdir(p):
-            return False
-        for marker in ("main.py", "output", "custom_nodes", "models"):
-            if os.path.exists(os.path.join(p, marker)):
-                return True
-    except Exception:
-        pass
-    return False
+def _start_command(comfyui_url=None):
+    """The exact one-liner the user runs in a terminal to start the orchestrator
+    the panel connects to. A remote (non-loopback) URL uses the `connect <url>`
+    sugar so the agent targets that box; a local instance uses the bare
+    orchestrator flag."""
+    if comfyui_url and not _url_is_loopback(comfyui_url):
+        return "npx -y comfyui-mcp connect {}".format(comfyui_url)
+    return "npx -y comfyui-mcp --panel-orchestrator"
 
 
-def _descend_to_nested_root(candidate, source="COMFYUI_PATH"):
-    """Self-heal the nested ("doubled") ComfyUI Desktop-installer layout: if
-    ``candidate`` is not itself a valid root but ``candidate/ComfyUI`` is,
-    descend exactly ONE level (never more — guards against re-doubling). Returns
-    ``candidate`` unchanged otherwise, so this is a strict no-op for a normal,
-    non-nested install. Never throws."""
-    try:
-        if _looks_like_comfyui_root(candidate):
-            return candidate
-        nested = os.path.join(candidate, "ComfyUI")
-        if _looks_like_comfyui_root(nested):
-            if source == "env":
-                print(
-                    "[comfyui-mcp-panel] COMFYUI_PATH env var '{}' looks like a "
-                    "Desktop-installer wrapper; descending to nested root "
-                    "'{}'.".format(candidate, nested)
-                )
-            return nested
-    except Exception:
-        pass
-    return candidate
-
-
-def _detect_comfyui_path():
-    """Best-effort: the ComfyUI install dir, so the agent's MCP runs in LOCAL
-    mode (download_model, apply_manifest / installer packs, model scans) instead
-    of remote-only.
-
-    Both the explicit env var and ComfyUI's ``folder_paths.base_path`` can point
-    at a Desktop-installer wrapper whose real root is one level down
-    (``<wrapper>/ComfyUI/``); validate + descend so filesystem tools target the
-    actual install. If neither validates, the candidate is returned as-is
-    (best-effort — never regresses prior behavior)."""
-    try:
-        if os.environ.get("COMFYUI_PATH"):
-            return _descend_to_nested_root(os.environ["COMFYUI_PATH"], source="env")
-        try:
-            import folder_paths  # provided by ComfyUI at runtime
-
-            base = getattr(folder_paths, "base_path", None)
-            if base:
-                return _descend_to_nested_root(base, source="folder_paths")
-        except Exception:
-            pass
-    except Exception:
-        pass
-    return None
-
-
-def _orchestrator_running(port=None):
-    """True if something already owns the bridge port (our spawn or the user's)."""
-    return _port_in_use(_BRIDGE_HOST, port if port is not None else _BRIDGE_PORT)
-
-
-def _backend_status(backend):
-    """{"backend", "port", "running"} for a backend. "running" means an
-    orchestrator is reachable on its port: prefer the lockfile (present + its pid
-    alive), but a lockfile-less process holding the port still counts as running so
-    a user-managed orchestrator isn't reported dead."""
-    port = _backend_port(backend)
-    lock = _read_lock(port)
-    if lock and _pid_alive(lock.get("pid")):
-        running = True
-    else:
-        # No (valid) lockfile — fall back to a raw port probe (covers a user-run
-        # orchestrator or one started before lockfiles).
-        running = _orchestrator_running(port)
-    state = _provider_state(backend)
-    return {
-        "backend": backend,
-        "port": port,
-        "running": running,
-        # Readiness for the onboarding flow: ready = CLI on PATH + a login on disk.
-        "cli": state["cli"],
-        "auth": state["auth"],
-        "ready": state["ready"],
-    }
+def _start_hint(port, comfyui_url=None):
+    """User-facing instruction shown when the orchestrator isn't running. The
+    panel renders this (and keeps retrying the bridge) so the user can copy/run
+    it and the panel connects automatically once it's up — there is no in-process
+    auto-start (Comfy Registry security standards)."""
+    cmd = _start_command(comfyui_url)
+    base = (
+        "The panel agent isn't running yet. Start it in a terminal — it runs on "
+        "your own Claude, Codex, or Gemini login (sign in once with `claude`, "
+        "`codex login`, or `gemini`), no API keys:\n    " + cmd + "\n"
+        "Leave it running; the panel connects automatically as soon as it's up."
+    )
+    if port != _BRIDGE_PORT:
+        return base + "\n(This backend uses port {0}: COMFYUI_MCP_BRIDGE_PORT={0}.)".format(port)
+    return base
 
 
 # ---------------------------------------------------------------------------
-# Orphan detection. The orchestrator writes a lockfile naming its real pid and
-# the ComfyUI pid that launched it. If a previous ComfyUI session left an
-# orchestrator squatting the bridge port, we can identify it (its parent pid is
-# dead) and replace it on Connect — so a restart never gets trapped talking to a
-# stale agent on old code.
-# ---------------------------------------------------------------------------
-def _lock_path(port=None):
-    return os.path.join(
-        tempfile.gettempdir(),
-        "comfyui-mcp-panel-orch-{}.json".format(port if port is not None else _BRIDGE_PORT),
-    )
-
-
-def _read_lock(port=None):
-    try:
-        with open(_lock_path(port), "r") as fh:
-            data = json.load(fh)
-        return data if isinstance(data, dict) else None
-    except Exception:
-        return None
-
-
-def _pid_alive(pid):
-    """Best-effort liveness probe. Uses psutil (ComfyUI ships it); never uses
-    os.kill(pid, 0) on Windows — there it would TERMINATE the process."""
-    try:
-        pid = int(pid)
-    except (TypeError, ValueError):
-        return False
-    if pid <= 0:
-        return False
-    try:
-        import psutil  # type: ignore
-
-        return psutil.pid_exists(pid)
-    except Exception:
-        pass
-    if os.name == "nt":
-        return True  # can't safely probe without psutil — assume alive, never kill
-    try:
-        os.kill(pid, 0)
-        return True
-    except OSError:
-        return False
-    except Exception:
-        return True
-
-
-def _process_started_at_ms(pid):
-    """Process creation time in epoch milliseconds, or None if unknown.
-
-    psutil-only (ComfyUI ships it) — deliberately NO subprocess / no constructed
-    script, so the pack stays clean for the Registry security scanner. If psutil
-    is unavailable, identity checks degrade gracefully to pid-liveness (see
-    _same_process)."""
-    try:
-        import psutil  # type: ignore
-
-        return int(psutil.Process(int(pid)).create_time() * 1000)
-    except Exception:
-        return None
-
-
-def _current_process_started_at_ms():
-    return _process_started_at_ms(os.getpid())
-
-
-def _same_process(pid, started_at_ms):
-    """True only when pid is alive and, if provided, its creation time matches."""
-    if not _pid_alive(pid):
-        return False
-    try:
-        expected = int(started_at_ms) if started_at_ms is not None else None
-    except (TypeError, ValueError):
-        expected = None
-    if expected is None:
-        return True  # legacy lockfile: no identity data, fall back to liveness
-    actual = _process_started_at_ms(pid)
-    if actual is None:
-        # Couldn't read the start time (no psutil + PowerShell failed). The pid IS
-        # alive — don't false-positive "different process" and kill a healthy
-        # orchestrator; fall back to liveness. The panel-side handshake (no
-        # "connected" without the orchestrator's models frame) is the backstop if
-        # this rare path ever lets a stale process through.
-        return True
-    return abs(actual - expected) <= 2000
-
-
-def _lock_parent_is_current(lock):
-    if not lock:
-        return False
-    return (
-        lock.get("parent") == os.getpid()
-        and _same_process(lock.get("parent"), lock.get("parentStartedAt"))
-    )
-
-
-def _lock_parent_is_gone(lock):
-    if not lock:
-        return False
-    parent = lock.get("parent")
-    if not parent:
-        return False
-    return not _same_process(parent, lock.get("parentStartedAt"))
-
-
-def _kill_pid(pid, started_at_ms=None):
-    """Terminate a pid via psutil, but ONLY while it still verifies as OUR panel
-    orchestrator — re-checking identity (cmdline + creation time) immediately
-    before every terminate()/kill() call.
-
-    This closes a TOCTOU pid-reuse race: the caller checks identity, but the
-    orchestrator can exit and the OS can recycle its pid before the signal lands.
-    Without the re-check we could terminate whatever now holds that pid — a user's
-    shell, node, editor, anything. So we never signal a pid that doesn't, at the
-    instant of signalling, still look like our orchestrator. psutil-only (no
-    shell/taskkill); if psutil is unavailable we don't kill (return False) and the
-    caller surfaces a "fully restart ComfyUI" message."""
-    try:
-        import psutil  # type: ignore
-    except Exception:
-        return False
-
-    def _still_ours():
-        # Must look like our orchestrator AND (when we recorded its start time) be
-        # the SAME process instance — not a pid-reuse impostor.
-        if not _is_orchestrator_process(pid):
-            return False
-        if started_at_ms is not None and not _same_process(pid, started_at_ms):
-            return False
-        return True
-
-    try:
-        if not _still_ours():
-            _log(
-                "refusing to kill pid {} — not (or no longer) a verified panel "
-                "orchestrator; possible pid reuse. Left untouched.".format(pid)
-            )
-            return False
-        proc = psutil.Process(int(pid))
-        proc.terminate()
-        try:
-            proc.wait(timeout=3)
-            return True
-        except Exception:
-            # Still alive after terminate → escalate to kill, but ONLY if it's
-            # STILL our orchestrator (it may have exited + had its pid reused
-            # during the wait window).
-            if not _still_ours():
-                _log(
-                    "not escalating to kill pid {} — identity changed during "
-                    "wait (pid reuse?). Left untouched.".format(pid)
-                )
-                return False
-            proc.kill()
-            return True
-    except Exception:
-        return False
-
-
-def _is_orchestrator_process(pid):
-    """True only if `pid` is alive AND looks like OUR panel orchestrator
-    (`node … --panel-orchestrator`). Guards _kill_pid against terminating a
-    reused pid that now belongs to an unrelated process (Windows pid reuse)."""
-    try:
-        import psutil  # type: ignore
-
-        cmd = " ".join(psutil.Process(int(pid)).cmdline()).lower()
-        return "--panel-orchestrator" in cmd
-    except Exception:
-        return False  # can't verify → never kill
-
-
-def _kill_orchestrator_tree(pid, started_at_ms=None):
-    """Kill a VERIFIED orchestrator AND its child process tree, then reap them.
-
-    A soft reload terminates only the orchestrator's own pid — but the Claude
-    Agent SDK spawns child processes (its shell, helper binaries). If one of those
-    wedges (e.g. a dead shell after a re-auth) and is orphaned rather than killed,
-    the wedge survives the respawn and the user is stuck (Task Manager / reboot).
-    Hard restart kills the whole tree so the fresh orchestrator starts truly clean.
-
-    Safe by construction: we only ever snapshot/kill the tree of a pid that
-    verifies as our orchestrator (cmdline + recorded creation time), so every
-    descendant is by definition our agent's own subprocess — never a user's. If
-    the root doesn't verify, nothing is touched."""
-    try:
-        import psutil  # type: ignore
-    except Exception:
-        return False
-
-    # Snapshot descendants WITH their creation times, under a verified parent.
-    snapshot = []  # list of (psutil.Process, create_time)
-    try:
-        if _is_orchestrator_process(pid) and (
-            started_at_ms is None or _same_process(pid, started_at_ms)
-        ):
-            for ch in psutil.Process(int(pid)).children(recursive=True):
-                try:
-                    snapshot.append((ch, ch.create_time()))
-                except Exception:
-                    pass
-    except Exception:
-        snapshot = []
-
-    # Kill the root via the identity-re-verifying helper. Only if it confirms the
-    # root was ours do we reap the snapshotted descendants.
-    killed_root = _kill_pid(pid, started_at_ms)
-    if not killed_root:
-        return False
-
-    # A snapshotted child can exit and have its pid reused before we signal it, so
-    # NEVER signal a child whose pid no longer maps to the same process. Read the
-    # creation time FRESH (a cached psutil.Process would return the stale value) and
-    # only signal on an exact match — same guard rigor as _kill_pid uses for the root.
-    def _same_child(proc, ct):
-        try:
-            return abs(psutil.Process(proc.pid).create_time() - ct) <= 0.02
-        except Exception:
-            return False  # gone or unreadable → don't signal
-
-    for proc, ct in snapshot:
-        if _same_child(proc, ct):
-            try:
-                proc.terminate()
-            except Exception:
-                pass
-    try:
-        psutil.wait_procs([p for p, _ in snapshot], timeout=3)
-    except Exception:
-        pass
-    for proc, ct in snapshot:
-        if _same_child(proc, ct):
-            try:
-                proc.kill()
-            except Exception:
-                pass
-    return True
-
-
-def _delete_lock(port=None):
-    """Remove the orchestrator lockfile (best-effort) so a fresh orchestrator
-    self-registers cleanly after a hard restart."""
-    try:
-        os.remove(_lock_path(port))
-    except Exception:
-        pass
-
-
-def _port_owner_pid(host, port):
-    """Pid LISTENING on (host, port), or None. psutil-only. Lets us identify a
-    lockfile-less zombie squatting the bridge port so Connect can reclaim it."""
-    try:
-        import psutil  # type: ignore
-
-        for c in psutil.net_connections(kind="inet"):
-            try:
-                if (
-                    c.status == psutil.CONN_LISTEN
-                    and c.laddr
-                    and int(c.laddr.port) == int(port)
-                    and c.pid
-                ):
-                    return c.pid
-            except Exception:
-                continue
-    except Exception:
-        return None
-    return None
-
-
-def _start_orchestrator(backend=_DEFAULT_BACKEND, port=None, force=False, stall_seconds=None, comfyui_url=None):
-    """Start the panel orchestrator on demand. Returns (ok: bool, message: str).
-
-    Called only from the Connect route — i.e. an explicit user action — never at
-    import time. Idempotent: if the bridge port is already owned, it's a no-op.
-
-    `backend` selects the provider ("claude" default | "codex"); `port` is the
-    bridge port it should own (defaults to the backend's mapped port). The default
-    call — ``_start_orchestrator()`` → claude on _BRIDGE_PORT (9180) — is the
-    historical no-backend path, byte-for-byte unchanged.
-
-    `force` (the panel's auto-reclaim safety net) RECLAIMS a WEDGED orchestrator
-    that still looks healthy by the lockfile (our ComfyUI launched it, its pid is
-    alive) but whose agent backend is dead — the "bridge open but no panel agent
-    responded" wedge. Without force we'd reuse it ("already running") and stay
-    stuck; with force we kill+respawn it. CRITICAL SAFETY: force still only ever
-    kills a process VERIFIED as our panel orchestrator (_is_orchestrator_process,
-    cmdline check) and never a different live ComfyUI's orchestrator — a truly
-    foreign process on the port is reported, never killed.
-    """
-    global _orchestrator_proc
-
-    backend = (backend or _DEFAULT_BACKEND).lower()
-    if port is None:
-        port = _backend_port(backend)
-
-    if _orchestrator_running(port):
-        lock = _read_lock(port)
-        parent = lock.get("parent") if lock else None
-        opid = lock.get("pid") if lock else None
-        # Healthy + ours (our ComfyUI launched it and its pid is alive) → reuse,
-        # UNLESS the caller forced a reclaim. A force request means the panel
-        # connected to this bridge but got NO orchestrator handshake (no models
-        # frame) within its generous timeout, i.e. the lockfile says "healthy" but
-        # the agent is actually dead. Fall through to the reclaim branch below so we
-        # kill+respawn it (verified-orchestrator-only) instead of reusing the wedge.
-        if lock and _lock_parent_is_current(lock) and _pid_alive(opid) and not force:
-            return True, "already running"
-
-        # Otherwise the port is held by something that isn't a healthy orchestrator
-        # of ours. Decide whether to RECLAIM it (kill + respawn) or bail. Reclaim
-        # only a process we can VERIFY is a panel orchestrator (cmdline check), so
-        # a genuinely foreign squatter is never killed.
-        reclaim_pid = None
-        reclaim_started = None
-        if lock and _pid_alive(opid) and _is_orchestrator_process(opid):
-            if parent and parent != os.getpid() and not _lock_parent_is_gone(lock):
-                # A different, still-live ComfyUI owns it — leave it alone.
-                return False, (
-                    "the panel bridge port {} is owned by another live ComfyUI "
-                    "(pid {}). Close it or set COMFYUI_MCP_BRIDGE_PORT to a "
-                    "different port for this instance.".format(port, parent)
-                )
-            # Our orchestrator but not healthy (orphaned ComfyUI, or wedged) → reclaim.
-            reclaim_pid, reclaim_started = opid, lock.get("pidStartedAt")
-        else:
-            # No (valid) lockfile, or its pid is dead, but the port is held. Find
-            # the actual port owner: a lockfile-less panel-orchestrator ZOMBIE (the
-            # "won't reconnect" bug) gets reclaimed; a truly foreign process is left.
-            owner = _port_owner_pid(_BRIDGE_HOST, port)
-            if owner and _is_orchestrator_process(owner):
-                reclaim_pid = owner
-            elif owner:
-                return False, (
-                    "the panel bridge port {} is held by another process that isn't a "
-                    "panel orchestrator. Close it, or set COMFYUI_MCP_BRIDGE_PORT to a "
-                    "free port.".format(port)
-                )
-            # owner unknown (couldn't read) → fall through; the bind will fail loudly
-            # if the port really is still held.
-
-        if reclaim_pid is not None:
-            if _no_autospawn():
-                return True, "reconnecting to your orchestrator"  # user-managed; don't kill
-            _log("reclaiming panel bridge port {} from orchestrator pid {}".format(port, reclaim_pid))
-            _kill_orchestrator_tree(reclaim_pid, reclaim_started)
-            _delete_lock(port)
-            for _ in range(20):
-                if not _port_in_use(_BRIDGE_HOST, port):
-                    break
-                time.sleep(0.1)
-            if _port_in_use(_BRIDGE_HOST, port):
-                return False, (
-                    "the panel bridge port {} is still held and couldn't be freed — "
-                    "fully restart ComfyUI.".format(port)
-                )
-        # Port freed (or never really held) — fall through and spawn a fresh one.
-
-    if _no_autospawn():
-        return False, (
-            "auto-start is disabled (COMFYUI_MCP_NO_AUTOSPAWN). Start it yourself: "
-            "npx -y comfyui-mcp --panel-orchestrator"
-        )
-
-    npx = shutil.which("npx") or shutil.which("npx.cmd")
-    if not npx:
-        return False, (
-            "Node.js/npx not found on PATH. Install Node, then click Connect again "
-            "(or run: npx -y comfyui-mcp --panel-orchestrator)."
-        )
-
-    env = dict(os.environ)
-    # A user-supplied remote URL (panel setting) overrides the local default and
-    # puts the agent in REMOTE mode. When remote (non-loopback) we deliberately do
-    # NOT set COMFYUI_PATH: the install dir is on the OTHER box, so the agent's
-    # filesystem tools must not target this machine (the MCP would otherwise run a
-    # confusing local-FS + remote-API split). Loopback URLs keep local mode.
-    remote_url = comfyui_url if (comfyui_url and not _url_is_loopback(comfyui_url)) else None
-    env["COMFYUI_URL"] = comfyui_url or _detect_comfyui_url()
-    _cpath = None if remote_url else _detect_comfyui_path()
-    if _cpath:
-        # Local mode for the agent: download_model / apply_manifest (packs) / scans.
-        env["COMFYUI_PATH"] = _cpath
-    elif remote_url:
-        # Belt-and-suspenders: ensure no inherited COMFYUI_PATH leaks local mode in.
-        env.pop("COMFYUI_PATH", None)
-        _log("agent targeting REMOTE ComfyUI {} (local model/pack tools disabled)".format(remote_url))
-    # Beacon: the orchestrator watches this PID (ComfyUI) and shuts itself down
-    # when ComfyUI exits — including crashes/hard-kills where atexit never fires.
-    env["COMFYUI_MCP_PARENT_PID"] = str(os.getpid())
-    _parent_started_at = _current_process_started_at_ms()
-    if _parent_started_at is not None:
-        env["COMFYUI_MCP_PARENT_STARTED_AT_MS"] = str(_parent_started_at)
-    # Pin the orchestrator to its bridge port (claude=9180 default, codex=9181).
-    env["COMFYUI_MCP_BRIDGE_PORT"] = str(port)
-    # Select the agent backend. Only set when non-default so the claude path emits
-    # the exact same env it always has (the orchestrator defaults to claude too).
-    if backend != _DEFAULT_BACKEND:
-        env["PANEL_AGENT_BACKEND"] = backend
-    # Render-stall warning threshold (from the panel setting). Only set when given
-    # so an unset setting leaves the orchestrator's own default (180s) in place.
-    if stall_seconds is not None:
-        env["COMFYUI_MCP_STALL_S"] = str(stall_seconds)
-    # Subscription lane: the background agent authenticates via the on-disk Claude
-    # login, never an API key.
-    env.pop("ANTHROPIC_API_KEY", None)
-
-    cmd = [npx, "-y", "comfyui-mcp", "--panel-orchestrator"]
-    kwargs = {"env": env, "stdin": subprocess.DEVNULL}
-    # Detach so a transient signal to ComfyUI doesn't kill the agent mid-turn;
-    # atexit still tears it down on a clean ComfyUI shutdown.
-    if os.name == "nt":
-        kwargs["creationflags"] = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-    else:
-        kwargs["start_new_session"] = True
-
-    try:
-        proc = subprocess.Popen(cmd, **kwargs)
-    except Exception as exc:  # noqa: BLE001 - surface any spawn failure to the user
-        return False, "could not start the panel orchestrator: {}".format(exc)
-
-    _orchestrator_procs[port] = proc
-    # Keep the legacy single-process global pointing at the default (claude) port's
-    # proc, so the existing /disconnect + atexit teardown behave exactly as before.
-    if port == _BRIDGE_PORT:
-        _orchestrator_proc = proc
-
-    atexit.register(_stop_orchestrator)
-    _log(
-        "started the panel orchestrator (pid {}) on ws://{}:{} (backend={}) — runs "
-        "on your subscription.".format(proc.pid, _BRIDGE_HOST, port, backend)
-    )
-    return True, "started (pid {})".format(proc.pid)
-
-
-def _stop_orchestrator():
-    """Terminate orchestrators THIS pack spawned. Stops every tracked backend
-    process (claude on 9180, codex on 9181, …); a user-run orchestrator we never
-    spawned is left running."""
-    global _orchestrator_proc
-    for proc in list(_orchestrator_procs.values()):
-        if proc and proc.poll() is None:
-            try:
-                proc.terminate()
-            except Exception:
-                pass
-    _orchestrator_procs.clear()
-    # Cover the legacy global too (it always aliases the default-port proc, but be
-    # defensive in case it was set without a matching map entry).
-    if _orchestrator_proc and _orchestrator_proc.poll() is None:
-        try:
-            _orchestrator_proc.terminate()
-        except Exception:
-            pass
-    _orchestrator_proc = None
-
-
-def _reload_orchestrator():
-    """Soft-reload: bounce a panel-spawned orchestrator in place so it picks up
-    new code, WITHOUT touching ComfyUI. The panel resumes the chat via its saved
-    session id, so the conversation continues seamlessly. Returns (ok, message).
-
-    In NO_AUTOSPAWN mode we don't own the process, so this is a no-op spawn — the
-    panel simply reconnects to the orchestrator the user manages (restart it
-    yourself to pick up code changes).
-    """
-    if _no_autospawn():
-        return True, "auto-start disabled; reconnecting to your orchestrator"
-
-    # Stop our spawned proc AND any orchestrator named in the lockfile (covers a
-    # proc spawned by a previous ComfyUI run we no longer track directly).
-    _stop_orchestrator()
-    lock = _read_lock()
-    parent = lock.get("parent") if lock else None
-    opid = lock.get("pid") if lock else None
-    lock_is_ours = _lock_parent_is_current(lock)
-    lock_is_orphan = _lock_parent_is_gone(lock)
-    # Kill only a verified orchestrator pid — never a reused pid (pid-reuse safe).
-    # _kill_pid re-verifies identity (cmdline + recorded creation time) right
-    # before it signals, so a recycled pid can't be mistaken for ours and killed.
-    if opid and (lock_is_ours or lock_is_orphan) and _is_orchestrator_process(opid):
-        _kill_pid(opid, lock.get("pidStartedAt"))
-    elif lock and parent and parent != os.getpid() and not lock_is_orphan:
-        return False, (
-            "the panel bridge port {} is owned by another live ComfyUI "
-            "(pid {}). Not reloading it.".format(_BRIDGE_PORT, parent)
-        )
-
-    # Wait for the bridge port to free before spawning a fresh orchestrator.
-    for _ in range(30):
-        if not _port_in_use(_BRIDGE_HOST, _BRIDGE_PORT):
-            break
-        time.sleep(0.1)
-    if _port_in_use(_BRIDGE_HOST, _BRIDGE_PORT):
-        return False, (
-            "the panel bridge port {} is still held by the previous orchestrator and "
-            "couldn't be freed — try Disconnect then Connect, or fully restart "
-            "ComfyUI.".format(_BRIDGE_PORT)
-        )
-    return _start_orchestrator()
-
-
-def _hard_restart_orchestrator():
-    """Force a truly fresh orchestrator: kill the verified orchestrator AND its
-    whole child tree (clears a wedged Agent-SDK shell an in-place soft reload
-    can't), delete the lockfile, then respawn. Pure Python over the local route,
-    so it works even when the agent itself is unresponsive — the user's one-click
-    escape from "the agent stopped answering" without Task Manager or a reboot.
-    Returns (ok, message)."""
-    if _no_autospawn():
-        return False, (
-            "auto-start is disabled (COMFYUI_MCP_NO_AUTOSPAWN) — restart your "
-            "orchestrator process yourself."
-        )
-
-    _stop_orchestrator()
-    lock = _read_lock()
-    parent = lock.get("parent") if lock else None
-    opid = lock.get("pid") if lock else None
-    lock_is_ours = _lock_parent_is_current(lock)
-    lock_is_orphan = _lock_parent_is_gone(lock)
-    if opid and (lock_is_ours or lock_is_orphan) and _is_orchestrator_process(opid):
-        _kill_orchestrator_tree(opid, lock.get("pidStartedAt"))
-    elif lock and parent and parent != os.getpid() and not lock_is_orphan:
-        return False, (
-            "the panel bridge port {} is owned by another live ComfyUI "
-            "(pid {}). Not restarting it.".format(_BRIDGE_PORT, parent)
-        )
-
-    _delete_lock()
-    for _ in range(30):
-        if not _port_in_use(_BRIDGE_HOST, _BRIDGE_PORT):
-            break
-        time.sleep(0.1)
-    if _port_in_use(_BRIDGE_HOST, _BRIDGE_PORT):
-        return False, (
-            "the panel bridge port {} is still held after the restart — fully "
-            "restart ComfyUI.".format(_BRIDGE_PORT)
-        )
-    return _start_orchestrator()
-
-
-# ---------------------------------------------------------------------------
-# Local API the panel's Connect button calls. Registering aiohttp routes at
-# import is standard for custom nodes (no subprocess is spawned here); the
-# orchestrator only launches when the user POSTs /connect.
+# Local API the panel calls. Read-only / advisory: it reports orchestrator and
+# provider state and, when nothing is running, returns the command to start it.
+# It never spawns or kills a process (Comfy Registry security standards) — see
+# the module docstring.
 # ---------------------------------------------------------------------------
 def _register_routes():
     try:
@@ -894,11 +268,16 @@ def _register_routes():
 
     @routes.get("/comfyui_mcp_panel/status")
     async def _status(_request):
+        detected = _detect_comfyui_url()
         return web.json_response(
             {
                 "running": _orchestrator_running(),
                 "port": _BRIDGE_PORT,
-                "can_spawn": not _no_autospawn() and bool(shutil.which("npx") or shutil.which("npx.cmd")),
+                # No in-process auto-start: the orchestrator runs out-of-band.
+                "can_spawn": False,
+                "bridge_url": "ws://{}:{}".format(_BRIDGE_HOST, _BRIDGE_PORT),
+                "comfyui_url": detected,
+                "start_command": _start_command(detected),
             }
         )
 
@@ -906,46 +285,36 @@ def _register_routes():
     async def _backends(_request):
         # Discovery for the panel's backend picker: each known backend with its
         # mapped port, whether an orchestrator is running there, and per-provider
-        # readiness (cli/auth/ready) so the panel can show an onboarding card when
-        # NEITHER provider is signed in and auto-pick a ready one otherwise.
+        # readiness (cli/auth/ready) so the panel can show an onboarding card.
         backends = [_backend_status(b) for b in _BACKEND_PORTS]
         return web.json_response(
             {
                 "backends": backends,
                 "any_ready": any(b["ready"] for b in backends),
+                "can_spawn": False,
+                "start_command": _start_command(_detect_comfyui_url()),
             }
         )
 
     @routes.post("/comfyui_mcp_panel/connect")
     async def _connect(_request):
         # Backend selector: ?backend=codex query param OR {"backend": "codex"} JSON
-        # body. Absent → "claude" (back-compat: the historical no-arg Connect path).
-        # `force`/`reclaim` (query ?force=1 OR {"force": true} / {"reclaim": true}):
-        # the panel's auto-reclaim safety net asks us to KILL a wedged orchestrator
-        # that looks healthy by the lockfile but never handshook, and respawn fresh.
+        # body. Absent → "claude". Optional ?comfyui_url= (panel remote-URL setting)
+        # shapes the start command. We NEVER spawn: if an orchestrator is already
+        # running on the backend's port we report it so the panel connects;
+        # otherwise we return the exact command for the user to run.
         backend = _request.query.get("backend")
-        force = _truthy(_request.query.get("force")) or _truthy(_request.query.get("reclaim"))
-        # Optional render-stall threshold (seconds) from the panel setting, applied
-        # to the orchestrator's env on spawn.
-        stall_seconds = _coerce_stall(_request.query.get("stall_seconds"))
-        # Optional remote ComfyUI URL (panel setting): when set + non-loopback, the
-        # agent drives a remote server (e.g. a RunPod instance) instead of localhost.
         comfyui_url = _coerce_comfyui_url(_request.query.get("comfyui_url"))
-        if not backend:
+        if not backend or comfyui_url is None:
             try:
                 body = await _request.json()
                 if isinstance(body, dict):
-                    backend = body.get("backend")
-                    if not force:
-                        force = bool(body.get("force") or body.get("reclaim"))
-                    if stall_seconds is None:
-                        stall_seconds = _coerce_stall(body.get("stall_seconds"))
+                    if not backend:
+                        backend = body.get("backend")
                     if comfyui_url is None:
                         comfyui_url = _coerce_comfyui_url(body.get("comfyui_url"))
             except Exception:
-                backend = None
-        # Reject a non-string backend with a clean 400 (e.g. {"backend": 123})
-        # rather than letting .lower() raise a 500.
+                pass
         if backend is not None and not isinstance(backend, str):
             return web.json_response(
                 {"ok": False, "message": "backend must be a string"}, status=400
@@ -957,51 +326,73 @@ def _register_routes():
                 status=400,
             )
         port = _backend_port(backend)
-        ok, message = _start_orchestrator(
-            backend=backend, port=port, force=force, stall_seconds=stall_seconds, comfyui_url=comfyui_url
-        )
+        bridge_url = "ws://{}:{}".format(_BRIDGE_HOST, port)
+        if _orchestrator_running(port):
+            return web.json_response(
+                {
+                    "ok": True,
+                    "running": True,
+                    "backend": backend,
+                    "port": port,
+                    "bridge_url": bridge_url,
+                    "message": "orchestrator already running — connecting",
+                },
+                status=200,
+            )
         return web.json_response(
             {
-                "ok": ok,
-                "running": _orchestrator_running(port),
+                "ok": False,
+                "running": False,
                 "backend": backend,
                 "port": port,
-                "forced": force,
-                # The exact ws URL the panel should connect to — so the user never
-                # types a port.
-                "bridge_url": "ws://{}:{}".format(_BRIDGE_HOST, port),
-                "message": message,
+                "can_spawn": False,
+                "bridge_url": bridge_url,
+                "comfyui_url": comfyui_url or _detect_comfyui_url(),
+                "start_command": _start_command(comfyui_url or _detect_comfyui_url()),
+                "message": _start_hint(port, comfyui_url or _detect_comfyui_url()),
             },
-            status=200 if ok else 503,
+            status=503,
         )
 
     @routes.post("/comfyui_mcp_panel/disconnect")
     async def _disconnect(_request):
-        # Only stops an orchestrator THIS pack spawned; a user-run one is left be.
-        spawned = _orchestrator_proc is not None
-        _stop_orchestrator()
-        return web.json_response({"ok": True, "stopped": spawned, "running": _orchestrator_running()})
+        # This pack never spawns the orchestrator, so there is nothing for it to
+        # stop — a user-run orchestrator is theirs to manage. Report current state.
+        return web.json_response(
+            {"ok": True, "stopped": False, "running": _orchestrator_running()}
+        )
 
     @routes.post("/comfyui_mcp_panel/reload")
     async def _reload(_request):
-        # Soft reload: respawn the orchestrator (new code) without restarting
-        # ComfyUI. The panel reconnects and resumes the session afterward.
-        ok, message = _reload_orchestrator()
+        # Reloading orchestrator code means restarting that process, which the
+        # user owns. Tell them how; never touch the process from here.
+        cmd = _start_command(_detect_comfyui_url())
         return web.json_response(
-            {"ok": ok, "running": _orchestrator_running(), "port": _BRIDGE_PORT, "message": message},
-            status=200 if ok else 503,
+            {
+                "ok": False,
+                "running": _orchestrator_running(),
+                "port": _BRIDGE_PORT,
+                "start_command": cmd,
+                "message": "Restart the orchestrator to pick up new code:\n    " + cmd,
+            },
+            status=503,
         )
 
     @routes.post("/comfyui_mcp_panel/hard_restart")
     async def _hard_restart(_request):
-        # Recovery: kill the orchestrator + its whole child tree and respawn — the
-        # fix for a wedged/unresponsive agent backend that a soft reload can't
-        # clear. Pure Python, so it works even when the agent isn't answering.
-        ok, message = _hard_restart_orchestrator()
+        cmd = _start_command(_detect_comfyui_url())
         return web.json_response(
-            {"ok": ok, "running": _orchestrator_running(), "port": _BRIDGE_PORT, "message": message},
-            status=200 if ok else 503,
+            {
+                "ok": False,
+                "running": _orchestrator_running(),
+                "port": _BRIDGE_PORT,
+                "start_command": cmd,
+                "message": "Stop the running orchestrator and start it again:\n    " + cmd,
+            },
+            status=503,
         )
+
+    _log("agent panel routes registered (read-only; orchestrator runs out-of-band)")
 
 
 _register_routes()

--- a/__init__.py
+++ b/__init__.py
@@ -168,7 +168,9 @@ def _detect_comfyui_url():
         if listen and listen not in (_ANY_IPV4_HOST, "::"):
             host = listen
     except Exception:
-        pass
+        # comfy.cli_args not importable (headless / older host) — keep the
+        # localhost default already in host/port.
+        host, port = "127.0.0.1", 8188
     return "http://{}:{}".format(host, port)
 
 
@@ -314,7 +316,8 @@ def _register_routes():
                     if comfyui_url is None:
                         comfyui_url = _coerce_comfyui_url(body.get("comfyui_url"))
             except Exception:
-                pass
+                # No/!invalid JSON body — fall back to query params (already read).
+                backend = backend or None
         if backend is not None and not isinstance(backend, str):
             return web.json_response(
                 {"ok": False, "message": "backend must be a string"}, status=400

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -97,14 +97,16 @@ function defaultBridgeUrlFor(backend) {
 }
 
 function loadBridgeUrl() {
+  // Single-port: the single (advanced) Bridge URL override, else the default. Old
+  // per-port localStorage / per-backend values are intentionally ignored so a
+  // stale custom port can't make the initial connect dial a dead bridge.
   try {
-    const saved = window.localStorage.getItem(STORAGE_KEY_BRIDGE);
-    // Migrate anyone pinned to the old shared 9101 default onto the new port.
-    if (!saved || saved === LEGACY_BRIDGE_URL) return DEFAULT_BRIDGE_URL;
-    return saved;
+    const v = getSetting(SETTING_BRIDGE);
+    if (typeof v === "string" && v.trim()) return v.trim();
   } catch {
-    return DEFAULT_BRIDGE_URL;
+    // settings not ready yet — fall through to the default.
   }
+  return DEFAULT_BRIDGE_URL;
 }
 
 function saveBridgeUrl(url) {
@@ -275,6 +277,11 @@ const SETTING_BRIDGE_URL = {
 // Pre-per-backend single Bridge URL key — migrated ONCE into the Claude group so a
 // returning user's custom port isn't lost (runs in the groups-migration block).
 const LEGACY_SETTING_BRIDGE_URL = "comfyui-mcp.bridgeUrl";
+// Single-port multi-provider: ONE bridge serves every provider, so there is ONE
+// (advanced) Bridge URL. A FRESH key — deliberately NOT the per-backend or legacy
+// ones, whose stale pre-single-port values (e.g. a migrated custom port) must not
+// leak in and make the panel dial a dead port.
+const SETTING_BRIDGE = "comfyui-mcp.bridgeUrl.single";
 const SETTING_AUTOCONNECT = "comfyui-mcp.autoConnect";
 const SETTING_FOCUS_FOLLOW = "comfyui-mcp.zoomToAction";
 const SETTING_STALL_S = "comfyui-mcp.stallWarningSeconds";
@@ -512,8 +519,13 @@ function externalOrchestratorMode() {
 // The Bridge URL to dial for `backend`: its per-backend Settings value when set,
 // else that backend’s default port (claude 9180 / codex 9181 / gemini 9182).
 function configuredBridgeUrlFor(backend) {
-  const v = getSetting(SETTING_BRIDGE_URL[backend]);
-  return (typeof v === "string" && v.trim()) || defaultBridgeUrlFor(backend);
+  // Single-port multi-provider: ONE bridge for every provider. Honor only the
+  // single (advanced) Bridge URL override, else the default — ignore any stale
+  // per-backend value from the pre-single-port layout. (backend kept for
+  // call-site compatibility.)
+  void backend;
+  const v = getSetting(SETTING_BRIDGE);
+  return (typeof v === "string" && v.trim()) || DEFAULT_BRIDGE_URL;
 }
 // Best-effort ComfyUI URL to put in the "start it locally" hint — the address of
 // the ComfyUI the user is viewing (a remote pod when opened over its proxy URL).
@@ -779,21 +791,22 @@ function panelSettingsList() {
       },
     },
     {
-      id: SETTING_EXTERNAL_ORCH,
-      name: "Use external/local orchestrator (advanced)",
-      category: cat("General", "Use external/local orchestrator (advanced)"),
+      // Single-port multi-provider: ONE bridge for every provider (the per-backend
+      // Bridge URLs and the old external-orchestrator toggle are gone — external is
+      // now the only mode). Advanced: only needed for a non-default port.
+      id: SETTING_BRIDGE,
+      name: "Bridge URL (advanced)",
+      category: cat("General", "Bridge URL (advanced)"),
       sortOrder: 141,
       tooltip:
-        "Advanced: run the agent OUTSIDE this ComfyUI host — started by YOU on your own machine " +
-        "(npx -y comfyui-mcp connect <this comfyui url>) instead of being spawned by this ComfyUI. " +
-        "Use it to drive a REMOTE ComfyUI (e.g. a RunPod pod with no Node/agent) from an agent on " +
-        "your laptop. When ON, Connect does NOT ask this host to start anything — it connects straight " +
-        "to the Bridge URL (default ws://127.0.0.1:9180). Leave OFF for the normal local setup where " +
-        "ComfyUI starts the agent for you.",
-      type: "boolean",
-      defaultValue: false,
-      onChange: () => {
-        // No live side effect — it only changes how the NEXT Connect behaves.
+        "WebSocket URL of the panel orchestrator bridge — ONE bridge now serves every provider " +
+        "(default ws://127.0.0.1:9180). Only change this if you start the orchestrator on a " +
+        "non-default port (COMFYUI_MCP_BRIDGE_PORT). Applies on the next Connect.",
+      type: "text",
+      defaultValue: DEFAULT_BRIDGE_URL,
+      onChange: (v) => {
+        if (suppressSettingOnChange || !settingsArmed) return;
+        panelHooks.applyBridgeUrl?.(v);
       },
     },
     {
@@ -816,18 +829,15 @@ function panelSettingsList() {
         }
       },
     },
-    // ---- Claude (Default model, Default reasoning effort, Bridge URL) ----
+    // ---- Claude (Default model, Default reasoning effort) ----
     modelSetting("claude", 130),
     effortSetting("claude", 125),
-    bridgeUrlSetting("claude", 120),
-    // ---- ChatGPT (Codex) (Default model, Default reasoning effort, Bridge URL) ----
+    // ---- ChatGPT (Codex) (Default model, Default reasoning effort) ----
     modelSetting("codex", 110),
     effortSetting("codex", 105),
-    bridgeUrlSetting("codex", 100),
-    // ---- Gemini (Default model, Default reasoning effort, Bridge URL) ----
+    // ---- Gemini (Default model, Default reasoning effort) ----
     modelSetting("gemini", 90),
     effortSetting("gemini", 85),
-    bridgeUrlSetting("gemini", 80),
     // ---- API tokens (LAST) ----
     tokenSetting(SETTING_TOKEN_CIVITAI, "CIVITAI_API_TOKEN", "CivitAI", 20),
     tokenSetting(SETTING_TOKEN_HF, "HUGGINGFACE_TOKEN", "HuggingFace", 15),
@@ -6303,10 +6313,10 @@ function buildPanel() {
       } catch {}
     }
     seedPrefsFromBackendGroup(selectedBackend);
-    // Per-backend Bridge URL: seed the field from the ACTIVE backend's setting,
-    // falling back to that backend's default port (claude 9180 / codex 9181).
-    const su =
-      getSetting(SETTING_BRIDGE_URL[selectedBackend]) || defaultBridgeUrlFor(selectedBackend);
+    // Single-port: seed the Bridge URL field from the ONE (advanced) override, else
+    // the single default — never the stale per-backend value (that's what made the
+    // panel dial a dead port after upgrade).
+    const su = configuredBridgeUrlFor(selectedBackend);
     if (su && su !== urlInput.value) {
       urlInput.value = su;
       saveBridgeUrl(su);
@@ -8951,7 +8961,7 @@ function buildPanel() {
     // setUrl only updates its `url` here (its connect() no-ops while closed);
     // connectAgent's client.start() opens it. urlInput has no settings onChange wired,
     // so updating it can't re-enter the storm.
-    const nextUrl = getSetting(SETTING_BRIDGE_URL[id]) || defaultBridgeUrlFor(id);
+    const nextUrl = configuredBridgeUrlFor(id);
     urlInput.value = nextUrl;
     if (client.currentUrl() !== nextUrl) client.setUrl(nextUrl);
     void connectAgent({ fromChip: true });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -82,10 +82,15 @@ const LEGACY_BRIDGE_URL = "ws://127.0.0.1:9101"; // old shared default — migra
 // seeds the default URL for that backend. A per-backend DEFAULT must NOT count as a
 // "manual override" (so /connect's bridge_url still applies) — only a user-typed
 // NON-default URL overrides (see connectAgent.manualOverride).
+// Single-port multi-provider: ONE orchestrator on ONE bridge serves every
+// provider. The backend is chosen in the hello / set_backend handshake, NOT by
+// port — so all providers resolve to the same default bridge URL. (Kept as a
+// per-backend map only so a user can still pin a custom Bridge URL per provider
+// in Settings; the defaults are identical now.)
 const DEFAULT_BRIDGE_URL_BY_BACKEND = {
-  claude: "ws://127.0.0.1:9180",
-  codex: "ws://127.0.0.1:9181",
-  gemini: "ws://127.0.0.1:9182",
+  claude: DEFAULT_BRIDGE_URL,
+  codex: DEFAULT_BRIDGE_URL,
+  gemini: DEFAULT_BRIDGE_URL,
 };
 function defaultBridgeUrlFor(backend) {
   return DEFAULT_BRIDGE_URL_BY_BACKEND[backend] || DEFAULT_BRIDGE_URL;
@@ -4054,7 +4059,7 @@ function focusFollowOnCommand(cmd, msg, reply) {
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 15000;
 
-function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk, onSecret, onReload, onTodo, onShowMedia, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onAck, onTurn, onTurnAnchor, getResume, onHandshakeTimeout, onBridgeClosed }) {
+function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk, onSecret, onReload, onTodo, onShowMedia, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onAck, onTurn, onTurnAnchor, getResume, getBackend, onHandshakeTimeout, onBridgeClosed }) {
   let sock = null;
   let url = loadBridgeUrl();
   let closed = false;
@@ -4360,11 +4365,15 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
       // Carry the last session id so the orchestrator resumes the agent's
       // memory after a panel reload (only honored before the tab's agent spawns).
       const resume = getResume?.();
+      // Single-port multi-provider: name the selected provider so ONE orchestrator
+      // routes this tab to the right backend (default claude when unset).
+      const backend = getBackend?.() || "claude";
       sock.send(
         JSON.stringify({
           type: "hello",
           tab_id: getTabId(),
           title: getWorkflowTitle(),
+          backend,
           ...(resume ? { resume } : {}),
         }),
       );
@@ -7963,6 +7972,7 @@ function buildPanel() {
       }
     },
     getResume: () => ssGet(SESSION_KEY),
+    getBackend: () => selectedBackend,
   });
   // This is now THE live client for the page.
   liveBridgeClient = client;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -6305,7 +6305,20 @@ function buildPanel() {
     }
     // Canonical path: settings seed the runtime. Backend FIRST (it decides which
     // group seeds prefs), then seed model/effort from THAT backend's group.
-    const sb = getSetting(SETTING_BACKEND);
+    // #43: the LAST RUNTIME pick (STORAGE_KEY_BACKEND, already in selectedBackend)
+    // must survive a panel REMOUNT — navigating away and back was silently swapping
+    // an active Codex session to the durable default (Claude) and dropping the
+    // conversation. A Settings-dialog change to the default already writes
+    // STORAGE_KEY_BACKEND (via applyBackend→connectBackend), so the two only diverge
+    // after a session-only chip pick — and then the runtime pick wins. Fall back to
+    // the durable default ONLY when there's no runtime pick yet (first-ever load).
+    let runtimePick = null;
+    try {
+      runtimePick = window.localStorage.getItem(STORAGE_KEY_BACKEND);
+    } catch {
+      runtimePick = null;
+    }
+    const sb = runtimePick || getSetting(SETTING_BACKEND);
     if (sb && sb !== selectedBackend) {
       selectedBackend = sb;
       try {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -501,7 +501,13 @@ function remoteUrlSetting() {
 // the configured Bridge URL directly. OFF by default, which keeps the co-located
 // autospawn path (POST /connect) byte-for-byte unchanged.
 function externalOrchestratorMode() {
-  return !!getSetting(SETTING_EXTERNAL_ORCH);
+  // Always ON now: the pack is pure-frontend and can no longer spawn the
+  // orchestrator (Comfy Registry security standards), so external/local is the
+  // ONLY mode — Connect always dials the bridge directly and never POSTs the
+  // host /connect (which the stripped node answers 503). The user still starts
+  // the orchestrator out-of-band (`npx -y comfyui-mcp connect <url>` /
+  // `--panel-orchestrator`); the setting is retained only for back-compat.
+  return true;
 }
 // The Bridge URL to dial for `backend`: its per-backend Settings value when set,
 // else that backend’s default port (claude 9180 / codex 9181 / gemini 9182).
@@ -4065,6 +4071,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
   let closed = false;
   let attempt = 0;
   let reconnectTimer = null;
+  // One-shot context to ride on the NEXT user message (armed via armContext) —
+  // used to replay the transcript to a freshly-switched provider so it has the
+  // conversation. Cleared the moment it's consumed.
+  let pendingContext = null;
   // De-duped status emitter. The pill only ever needs TRANSITIONS, so collapsing
   // consecutive repeats is a guard against any path double-emitting the same state
   // (and keeps the cold-start steady-"connecting" from re-painting on every retry).
@@ -4446,14 +4456,24 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
       attempt = 0;
       connect();
     },
+    /** Arm a one-shot context (e.g. a provider-switch transcript replay) to ride
+     *  on the NEXT user message, then auto-clear. */
+    armContext(ctx) {
+      pendingContext = typeof ctx === "string" && ctx.trim() ? ctx : null;
+    },
     sendUserMessage(text, context, images, mid) {
       if (!sock || sock.readyState !== WebSocket.OPEN) return false;
+      // Merge any armed one-shot context (transcript replay) ahead of this
+      // message's own context, then clear it so it's sent exactly once.
+      const mergedContext =
+        [pendingContext, context].filter(Boolean).join("\n\n") || undefined;
+      pendingContext = null;
       try {
         sock.send(
           JSON.stringify({
             type: "user_message",
             text,
-            ...(context ? { context } : {}),
+            ...(mergedContext ? { context: mergedContext } : {}),
             ...(images?.length ? { images } : {}),
             // Client message id — the orchestrator echoes it in the "working"
             // ack so the panel can mark this exact bubble delivered ("Seen").
@@ -8843,6 +8863,29 @@ function buildPanel() {
     refreshModelChip();
   }
 
+  // Build a compact transcript of the VISIBLE conversation (user + agent text) to
+  // seed a freshly-switched provider. Capped from the END so a long chat doesn't
+  // blow the new session's context; internal session data (thinking / tool calls /
+  // prompt cache) isn't portable across providers and is intentionally omitted.
+  function buildReplayTranscript() {
+    const msgs = thread && Array.isArray(thread.msgs) ? thread.msgs : [];
+    const lines = [];
+    for (const m of msgs) {
+      if (!m || typeof m.text !== "string" || !m.text.trim()) continue;
+      if (m.role === "user") lines.push("User: " + m.text.trim());
+      else if (m.role === "agent") lines.push("Assistant: " + m.text.trim());
+    }
+    if (!lines.length) return "";
+    let body = lines.join("\n\n");
+    const CAP = 8000;
+    if (body.length > CAP) body = "…(earlier messages trimmed)…\n\n" + body.slice(body.length - CAP);
+    return (
+      "[Conversation so far — continued from a different AI provider. Context only: the " +
+      "previous session's memory, thinking, and tool history did NOT carry over. Pick it up:]\n\n" +
+      body
+    );
+  }
+
   function connectBackend(id) {
     // CENTRALIZED per-backend seeding: every switch path routes through here — the
     // backend chips, the model-popover provider row, AND the Settings backend combo
@@ -8884,6 +8927,11 @@ function buildPanel() {
     if (switching) {
       ssSet(SESSION_KEY, null);
       if (thread) thread.sessionId = undefined;
+      // Replay the visible transcript to the NEW provider as one-shot context so
+      // its fresh session has the conversation (session/thinking aren't portable
+      // across providers). Consumed by the next user message, then auto-cleared.
+      const replay = buildReplayTranscript();
+      if (replay) client.armContext(replay);
     }
     // Reflect the picked backend in the composer placeholder immediately; onModels
     // reaffirms it authoritatively from the handshake (fix #3).


### PR DESCRIPTION
Lands the panel-side work for the coordinated 0.4.7 release **at 0.4.6** — pyproject is deliberately unchanged, so this does NOT fire `publish_action` (the Registry publish). The version bump to 0.4.7 is a separate later commit.

## What lands
- **Pure-frontend strip** — `__init__.py` no longer spawns (`subprocess` removed) → registry-clean. Every prior version was `NodeVersionStatusFlagged`; a clean version can now promote to `latest`.
- **Bandit CI gate** — `bandit -r . -s B101,B112,B311` (all-severity, Comfy-Org stand-in parity). **Merging this activates the check repo-wide, so it runs on the 0.4.7 release push.**
- **Single-port multi-provider** — one bridge URL, `backend` in the hello handshake.
- **Transcript replay on provider switch**, external-orchestrator is the only mode.
- **Settings cleanup** — one Bridge URL (fixes the stale `62525` dead-port dial), external toggle removed.
- **#43** — panel remount keeps the runtime provider and resumes the session.

## Coordination
Requires the paired **`comfyui-mcp` single-port orchestrator** (`feat/panel-single-port-session-ownership`). Until that lands + releases, codex/gemini switching falls back to claude against the *published* npm MCP (claude works). Land/release together for full parity.

Bandit clean locally (`No issues identified`). Not render-verified beyond local checks.