### PR TITLE
feat(panel): auto-target ComfyUI from the browser host (drop connect <url>)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -10,10 +10,12 @@ This pack ships **no Python nodes**. It does two things:
    and the ComfyUI URL to target — so the sidebar can show the right onboarding
    state and the exact one-command start line.
 
-The orchestrator itself — ``npx -y comfyui-mcp connect <comfyui-url>`` (or
-``--panel-orchestrator`` for a local instance) — owns the loopback bridge the
-panel connects to and drives it with a background Agent SDK session on the
-user's own subscription (no LLM API keys).
+The orchestrator itself — ``npx -y comfyui-mcp --panel-orchestrator`` — owns the
+loopback bridge the panel connects to and drives it with a background Agent SDK
+session on the user's own subscription (no LLM API keys). The panel sends the
+ComfyUI URL it was served from (window.location) in its hello, so the orchestrator
+auto-targets whatever ComfyUI is open (local or a remote proxy) with no
+``connect <url>`` needed.
 
 **Why this pack does not launch the orchestrator.** The Comfy Registry security
 standards prohibit custom nodes from spawning processes / installing-and-running
@@ -226,11 +228,11 @@ def _url_is_loopback(url):
 
 def _start_command(comfyui_url=None):
     """The exact one-liner the user runs in a terminal to start the orchestrator
-    the panel connects to. A remote (non-loopback) URL uses the `connect <url>`
-    sugar so the agent targets that box; a local instance uses the bare
-    orchestrator flag."""
-    if comfyui_url and not _url_is_loopback(comfyui_url):
-        return "npx -y comfyui-mcp connect {}".format(comfyui_url)
+    the panel connects to. ALWAYS the bare orchestrator flag now — the panel sends
+    the ComfyUI URL it was served from (window.location) in its hello, and the
+    orchestrator retargets to it (local OR remote), so no `connect <url>` is needed.
+    `comfyui_url` is accepted for call-site compatibility but unused."""
+    del comfyui_url
     return "npx -y comfyui-mcp --panel-orchestrator"
 
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -502,18 +502,16 @@ function remoteUrlSetting() {
   const v = getSetting(SETTING_REMOTE_URL);
   return typeof v === "string" ? v.trim() : "";
 }
-// External/local orchestrator mode (panel setting). When ON, the agent is run
-// by the USER on their own machine (`npx -y comfyui-mcp connect <url>`), NOT
-// spawned by the ComfyUI host — so Connect skips the host /connect POST and dials
-// the configured Bridge URL directly. OFF by default, which keeps the co-located
-// autospawn path (POST /connect) byte-for-byte unchanged.
+// External/local orchestrator mode (panel setting). The agent is run by the USER
+// on their own machine (`npx -y comfyui-mcp --panel-orchestrator`), NOT spawned by
+// the ComfyUI host — so Connect dials the configured Bridge URL directly.
 function externalOrchestratorMode() {
   // Always ON now: the pack is pure-frontend and can no longer spawn the
   // orchestrator (Comfy Registry security standards), so external/local is the
   // ONLY mode — Connect always dials the bridge directly and never POSTs the
-  // host /connect (which the stripped node answers 503). The user still starts
-  // the orchestrator out-of-band (`npx -y comfyui-mcp connect <url>` /
-  // `--panel-orchestrator`); the setting is retained only for back-compat.
+  // host /connect (which the stripped node answers 503). The user starts the
+  // orchestrator out-of-band (`npx -y comfyui-mcp --panel-orchestrator`), which
+  // auto-targets the ComfyUI the browser is on; the setting is a back-compat no-op.
   return true;
 }
 // The Bridge URL to dial for `backend`: its per-backend Settings value when set,
@@ -534,6 +532,20 @@ function comfyuiUrlForConnect() {
     return window.location.origin;
   } catch {
     return "<this-comfyui-url>";
+  }
+}
+// The ComfyUI URL to hand the orchestrator in `hello`: the advanced Remote-URL
+// override if the user set one, else the URL the browser was SERVED FROM
+// (window.location) — so the agent auto-targets whatever ComfyUI is open (local or
+// a RunPod proxy) with zero config. The orchestrator retargets to it and decides
+// local vs remote mode from the host, so a bare `--panel-orchestrator` just works.
+function comfyuiUrlForAgent() {
+  const override = remoteUrlSetting();
+  if (override) return override;
+  try {
+    return window.location.origin;
+  } catch {
+    return "";
   }
 }
 
@@ -4393,12 +4405,16 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
       // Single-port multi-provider: name the selected provider so ONE orchestrator
       // routes this tab to the right backend (default claude when unset).
       const backend = getBackend?.() || "claude";
+      // Auto-target: the URL the browser was served from (or the manual override),
+      // so a bare `--panel-orchestrator` points the agent at whatever ComfyUI is open.
+      const comfyuiUrl = comfyuiUrlForAgent();
       sock.send(
         JSON.stringify({
           type: "hello",
           tab_id: getTabId(),
           title: getWorkflowTitle(),
           backend,
+          ...(comfyuiUrl ? { comfyui_url: comfyuiUrl } : {}),
           ...(resume ? { resume } : {}),
         }),
       );
@@ -5819,9 +5835,12 @@ function buildPanel() {
       /win/i.test(navigator.platform || "") || /Windows/i.test(navigator.userAgent || "");
     // On Windows, `cmd /c` sidesteps the PowerShell execution-policy trap that
     // blocks the npx.ps1 shim ("running scripts is disabled on this system").
+    // No URL needed: the panel sends the ComfyUI host (window.location) in its
+    // hello, so a bare `--panel-orchestrator` auto-targets whatever ComfyUI is open.
+    void url;
     const runCmd = isWin
-      ? `cmd /c "npx -y comfyui-mcp connect ${url}"`
-      : `npx -y comfyui-mcp connect ${url}`;
+      ? `cmd /c "npx -y comfyui-mcp --panel-orchestrator"`
+      : `npx -y comfyui-mcp --panel-orchestrator`;
     runCol.append(onboardCmd(runCmd));
     if (isWin) {
       const note = document.createElement("div");
@@ -8579,10 +8598,11 @@ function buildPanel() {
     externalHintShown = true;
     const bridge = configuredBridgeUrlFor(selectedBackend);
     appendSystem(
-      "No agent is listening on the bridge (" + bridge + "). External orchestrator " +
-        "mode is ON, so this ComfyUI won’t start one. Run the agent on YOUR machine:\n" +
-        "    npx -y comfyui-mcp connect " + comfyuiUrlForConnect() + "\n" +
-        "then click Connect.",
+      "No agent is listening on the bridge (" + bridge + "). This ComfyUI won’t " +
+        "start one — run the agent on YOUR machine:\n" +
+        "    npx -y comfyui-mcp --panel-orchestrator\n" +
+        "It auto-targets the ComfyUI you have open (" + comfyuiUrlForConnect() +
+        "), then click Connect.",
     );
   }
   function resetAutoReclaim() {


### PR DESCRIPTION
The panel is served by ComfyUI, so `window.location` **is** the ComfyUI the user is on. Send it (or the advanced Remote-URL override) as `comfyui_url` in the `hello` handshake; the paired orchestrator retargets to it and picks local/remote mode from the host — so `npx -y comfyui-mcp --panel-orchestrator` just works with zero config.

- new `comfyuiUrlForAgent()` = Remote-URL override || `window.location.origin`, sent as `hello.comfyui_url`.
- every `connect <url>` → `--panel-orchestrator` (onboarding command, "no agent" hint, `_start_command`, comments, docstring). Remote ComfyUI URL setting kept as an advanced override (subpath/tunnel cases).

`node --check` + `py_compile` + bandit clean; pyproject stays **0.4.6** (no publish). Pairs with `comfyui-mcp` `feat/comfyui-url-host`.