### PR TITLE
feat(panel): prefill this pod's URL into the connect command (secure bridge in every browser)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.4.12] - 2026-07-01
+
+### Changed
+
+- **The panel prefills THIS pod's own URL into the `connect` command it shows** (help
+  dropdown, onboarding step, and the "no agent" hint) when served over https — e.g.
+  `npx -y comfyui-mcp@latest connect https://<this-pod>`. Running it with the URL lets
+  the local orchestrator open a secure `wss://` bridge that works in **every browser**
+  (Safari / Firefox / Comet included), not just Chrome-with-a-permission-prompt. The
+  URL is read from `window.location`; on http/localhost the bare form is shown
+  (auto-targets local). Pairs with the secure bridge in comfyui-mcp 0.23.4 + panel
+  0.4.11.
+
 ## [0.4.11] - 2026-07-01
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar — runs locally on your own Claude OR ChatGPT subscription (no API keys, no extra LLM costs). Pick a provider and the agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, and run your workflow — asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.4.11"
+version = "0.4.12"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -96,6 +96,23 @@ function defaultBridgeUrlFor(backend) {
   return DEFAULT_BRIDGE_URL_BY_BACKEND[backend] || DEFAULT_BRIDGE_URL;
 }
 
+// The exact `connect` command to show the user. On an https page (a remote pod)
+// the local orchestrator can't learn this pod's URL on its own — the panel's hello
+// travels over the ws bridge, which the browser blocks from an https origin — so we
+// PREFILL this pod's own hostname (window.location.origin). Running it that way lets
+// the orchestrator open a secure wss:// bridge that works in every browser. On
+// http/localhost the bare form auto-targets the local ComfyUI. Callers wrap in
+// `cmd /c "…"` on Windows.
+function connectCommand() {
+  const base = "npx -y comfyui-mcp@latest connect";
+  try {
+    if (location.protocol === "https:") return `${base} ${location.origin}`;
+  } catch {
+    // location unavailable — fall back to the bare form
+  }
+  return base;
+}
+
 function loadBridgeUrl() {
   // Single-port: the single (advanced) Bridge URL override, else the default. Old
   // per-port localStorage / per-backend values are intentionally ignored so a
@@ -5753,7 +5770,7 @@ function buildPanel() {
   // as "local only". Wrap in `cmd /c` on Windows, where a bare npx line can trip
   // PowerShell's executable policy.
   const _isWin = /win/i.test((navigator.platform || navigator.userAgent || ""));
-  const _connectCmd = "npx -y comfyui-mcp@latest connect";
+  const _connectCmd = connectCommand();
   helpCmd.textContent = _isWin ? `cmd /c "${_connectCmd}"` : _connectCmd;
   helpCmd.title = "Click to copy";
   helpCmd.addEventListener("click", () => {
@@ -5938,9 +5955,7 @@ function buildPanel() {
     // No URL needed: the panel sends the ComfyUI host (window.location) in its
     // hello, so a bare `connect` auto-targets whatever ComfyUI is open.
     void url;
-    const runCmd = isWin
-      ? `cmd /c "npx -y comfyui-mcp@latest connect"`
-      : `npx -y comfyui-mcp@latest connect`;
+    const runCmd = isWin ? `cmd /c "${connectCommand()}"` : connectCommand();
     runCol.append(onboardCmd(runCmd));
     if (isWin) {
       const note = document.createElement("div");
@@ -8727,10 +8742,8 @@ function buildPanel() {
     const bridge = configuredBridgeUrlFor(selectedBackend);
     appendSystem(
       "No agent is listening on the bridge (" + bridge + "). This ComfyUI won’t " +
-        "start one — run the agent on YOUR machine:\n" +
-        "    npx -y comfyui-mcp@latest connect\n" +
-        "It auto-targets the ComfyUI you have open (" + comfyuiUrlForConnect() +
-        "), then click Connect.",
+        "start one — run the agent on YOUR machine, then click Connect:\n" +
+        "    " + connectCommand(),
     );
   }
   function resetAutoReclaim() {


### PR DESCRIPTION
## Why

A remote pod's HTTPS panel page can't open a plain `ws://127.0.0.1` bridge — browsers block insecure sockets from a secure origin (mixed content) and gate public→loopback (Private Network Access). Chrome allows it *with a permission prompt*; **Safari / Firefox / Comet hard-block it**.

The fix is the secure `wss://` bridge (comfyui-mcp **0.23.4** on npm + panel **0.4.11** on the registry): when the orchestrator is started with the pod URL, it opens a token-gated Cloudflare `wss://` tunnel and advertises it to the pod, and the panel fetches + uses it — works in every browser.

The catch: the orchestrator can only learn the pod URL from the CLI (the panel's hello rides the ws bridge, which those browsers block). Full zero-input inference is impossible for Safari/Comet.

## What this PR does

The panel now **prefills this pod's own hostname** (`window.location.origin`) into the `connect` command it displays — help dropdown, onboarding step, and the "no agent" hint:

```
npx -y comfyui-mcp@latest connect https://<this-pod>
```

One copy-paste line, URL already filled — no guessing, no manual typing. On `http`/`localhost` it shows the bare form (auto-targets local). Implemented via a single `connectCommand()` helper.

## Testing
- Server-side secure path verified live against a 0.4.11 pod: tunnel up, advertise succeeded, pod `/bridge_url` returned the wss URL.
- Panel JS syntax-checked; `connectCommand()` returns the URL form on https, bare on http.
- ⚠️ Live browser test (Safari/Comet connecting over wss) to be confirmed.

## Coordination
- Server **0.23.4** already published to npm — `connect <URL>` works today.
- After merge (registry publishes **0.4.12**), **rebuild the `docker/runpod` image** so fresh pods bake the new panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)