### PR TITLE
fix: self-heal a reconnect wedged on the unauthenticated loopback fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-07-06
+
+### Fixed
+
+- **Reconnect wedged forever on a remote pod's `wss://` secure bridge.** On an
+  https pod page, if a tab's first autoconnect raced the orchestrator's advertise
+  of the secure tunnel URL (e.g. right at orchestrator startup, or a background
+  tab that was already retrying before this orchestrator came up), it fell back
+  to the plain unauthenticated `ws://127.0.0.1:<port>` default. Contrary to this
+  file's own long-standing assumption, Chrome does **not** mixed-content-block a
+  `ws://127.0.0.1` dial from an `https://` page (loopback is exempt) — so that
+  fallback actually reached the real local bridge directly and got rejected for a
+  missing token, then retried that SAME wrong URL forever (capped at 15s) with no
+  way back to the correct tunnel short of a manual Reconnect. The reconnect loop
+  now re-fetches the advertised bridge URL on every retry and switches over the
+  moment one becomes available, self-healing without user action.
+
 ## [0.4.13] - 2026-07-01
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar â€” runs locally on your own Claude OR ChatGPT subscription (no API keys, no extra LLM costs). Pick a provider and the agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, and run your workflow â€” asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.6.0"
+version = "0.6.1"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9086,8 +9086,15 @@ function buildPanel() {
   function tryAutoRespawn() {
     // External/local orchestrator: this host doesn’t own the agent process, so it
     // can’t respawn it. Let the bare WS retry keep trying (the user restarts it
-    // locally); never POST /connect here.
-    if (externalOrchestratorMode()) return false;
+    // locally); never POST /connect here — but DO try to reclaim a fresher
+    // advertised bridge URL in case this retry loop is wedged on the wrong one
+    // (see reclaimAdvertisedBridgeUrl). Always return false: this is a best-effort
+    // side channel, not a replacement for the bare retry — if it finds a new URL,
+    // client.setUrl() immediately supersedes whatever connect() below dials.
+    if (externalOrchestratorMode()) {
+      void reclaimAdvertisedBridgeUrl();
+      return false;
+    }
     if (!lsGet(AUTOCONNECT_KEY)) return false; // user never connected / disconnected
     // A deliberate soft-reload owns the respawn — DON'T compete. Return false so
     // scheduleReconnect keeps doing bare WS retries (the soft-reload's own backoff
@@ -9223,6 +9230,35 @@ function buildPanel() {
     } catch {
       return null;
     }
+  }
+
+  // Self-heal a wedged external-orchestrator reconnect: a tab's FIRST autoconnect
+  // (page load, or a background tab that's been retrying since before this
+  // orchestrator started) can race the orchestrator's advertise POST and get back
+  // no wss:// URL yet, falling back to the plain unauthenticated loopback default
+  // (configuredBridgeUrlFor). Contrary to this file's own long-standing assumption
+  // above ("blocked by the browser (mixed-content / Private Network Access)"),
+  // Chrome does NOT block a ws://127.0.0.1 dial from an https:// page — loopback is
+  // exempt from mixed-content blocking (the same reason local dev-server HMR works
+  // over an https page) — so that fallback actually reaches the real local bridge
+  // and gets rejected for a missing token. scheduleReconnect then retries that SAME
+  // wrong URL forever (capped at RECONNECT_MAX_MS = 15s), which is exactly the
+  // "rejected a bridge connection with a missing/invalid token" drumbeat every 15s
+  // this was firing in practice — with no way back to the correct tunnel short of a
+  // manual Reconnect, even once the orchestrator's advertise has long since landed.
+  // Called from tryAutoRespawn on every bridge-closed retry so a later-landing
+  // advertise (or the orchestrator itself coming up after this tab started
+  // retrying) self-heals instead of wedging permanently.
+  async function reclaimAdvertisedBridgeUrl() {
+    if (location.protocol !== "https:") return;
+    const wanted = urlInput.value.trim();
+    const manualOverride =
+      !!wanted && wanted !== defaultBridgeUrlFor(selectedBackend) && wanted !== lastAutoUrl;
+    if (manualOverride) return; // a user-typed Advanced Bridge URL is never clobbered
+    const secure = await fetchAdvertisedBridgeUrl();
+    if (!secure || secure === client.currentUrl()) return;
+    client.setUrl(secure, { persist: false });
+    lastAutoUrl = secure;
   }
 
   async function connectAgent(opts = {}) {


### PR DESCRIPTION
## Summary
- On an https pod page (RunPod-style `connect <url>` usage), a tab's first autoconnect can race the orchestrator's advertise of its secure `wss://` tunnel URL and fall back to the plain `ws://127.0.0.1:<port>` default.
- That fallback was assumed to be blocked by mixed-content policy — it isn't: Chrome exempts loopback addresses from mixed-content blocking, so the dial actually reaches the real local bridge (comfyui-mcp's orchestrator, running on the user's own machine) and gets rejected for a missing token.
- `scheduleReconnect` then retries that SAME wrong URL forever (capped at `RECONNECT_MAX_MS` = 15s) — with no way back to the correct tunnel short of a manual Reconnect click.
- Confirmed live in a user's terminal log: a rejection arrived *before the cloudflared tunnel even existed*, and a steady 15s-interval drumbeat of rejections kept firing continuously, independent of an already-connected, working tab.

## Fix
`tryAutoRespawn()` (invoked on every bridge-closed retry) now also fire-and-forget re-fetches the advertised bridge URL and switches over via `client.setUrl()` the moment a real `wss://` one becomes available — never blocking or replacing the existing bare-retry fallback, so behavior is unchanged whenever this doesn't trigger (http/localhost pages, a manual Advanced Bridge URL override, or once already connected via the correct URL).

Pairs with comfyui-mcp v0.24.2's server-side fix (re-advertise on every hello).

## Test plan
- [x] `node --check web/js/comfyui-mcp-panel.js`
- [x] `npm run typecheck`
- [ ] Live retest on the reporting user's RunPod pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)