### PR TITLE
fix(onboard): [hidden] beaten by display:flex — onboarding card never hides (#59)

### DIFF
--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -4973,6 +4973,9 @@ const PANEL_CSS = `
   border-radius: var(--p-border-radius-md, 6px);
   display: flex; flex-direction: column; gap: 0.5rem;
 }
+/* The base rule sets display, which beats the UA [hidden] rule — so re-assert
+   it or "onboard.hidden = true" won't actually hide the card. */
+.cmcp-onboard[hidden] { display: none; }
 .cmcp-onboard-title { font-weight: 600; color: var(--p-text-color, #fff); }
 .cmcp-onboard-sub { font-size: 0.75rem; color: var(--p-text-muted-color, #a1a1aa); line-height: 1.4; }
 .cmcp-onboard-col { display: flex; flex-direction: column; gap: 0.25rem; }


### PR DESCRIPTION
## Summary
The provider-onboarding card (\"Sign in to an AI provider to use the agent\") stays visible and squeezes the chat log even after `onboard.hidden = true` is set — including after a provider is clearly connected (see the user report in #59).

Root cause: the `.cmcp-onboard` base rule sets `display: flex`, and an author-stylesheet `display` declaration always beats the UA `[hidden] { display: none }` rule. The JS readiness logic was toggling `onboard.hidden` correctly in all five places; the CSS just ignored it.

## Fix
Add `.cmcp-onboard[hidden] { display: none; }`, matching the identical overrides that already exist in this file for `.cmcp-newmsg` and `.cmcp-dropzone`.

Fixes #59

## Testing
- `node --check` passes (as ES module).
- Manual: load panel with no provider signed in → card shows; sign in / reach connected status → card hides. Detailed manual steps in the PR conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)