### PR TITLE
fix(settings): one-time upgrade of the stale gemma4:e4b Ollama default to the fine-tune

### DIFF
--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -6697,6 +6697,18 @@ function buildPanel() {
       }
       lsSet(SETTINGS_GROUPS_MIGRATED_KEY, "1");
     }
+    // One-time: upgrade a saved Ollama model of "gemma4:e4b" — the OLD shipped
+    // default — to the comfyui-mcp fine-tune that replaced it. Users with that
+    // value almost always just accepted the old default; leaving it pinned
+    // silently overrides the new default on every connect (field: the header
+    // said gemma4:e4b while the picker showed the fine-tune selected). Anyone
+    // who genuinely wants stock gemma4:e4b can re-pick it — it stays listed.
+    if (!lsGet("comfyui-mcp.migratedOllamaFinetune")) {
+      if (getSetting(SETTING_MODEL.ollama) === "gemma4:e4b") {
+        setSetting(SETTING_MODEL.ollama, "artokun/gemma4-comfyui-mcp:e4b");
+      }
+      lsSet("comfyui-mcp.migratedOllamaFinetune", "1");
+    }
     if (!lsGet(SETTINGS_SEEDED_KEY)) {
       setSetting(SETTING_BACKEND, selectedBackend || "claude");
       // Only persist model/effort the user actually chose — never a synthetic


### PR DESCRIPTION
Field: user selected artokun/gemma4-comfyui-mcp:e4b in the picker but the
session header said gemma4:e4b — the per-backend setting saved back when
stock gemma4:e4b WAS the shipped default replayed on every connect and
silently overrode the new fine-tune default. Users with that exact value
almost always just accepted the old default; migrate it once. Stock
gemma4:e4b stays in the picker for anyone who deliberately wants it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
