### PR TITLE
chore(release): comfyui-agent-panel 0.6.7 — fine-tuned Ollama default + stale-default migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar â€” runs locally on your own Claude OR ChatGPT subscription (no API keys, no extra LLM costs). Pick a provider and the agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, and run your workflow â€” asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.6.6"
+version = "0.6.7"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees


### PR DESCRIPTION
- onboarding card recommends artokun/gemma4-comfyui-mcp:e4b (our free
  ComfyUI fine-tune) as the Ollama setup pull (#62)
- one-time settings migration: a saved gemma4:e4b (the old shipped
  default) upgrades to the fine-tune so it can't silently override the
  new default on connect (#66)
- panel_open_workflow: repaint canvas on switch to an already-open tab
  (#63 #64 #65)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
