### PR TITLE
feat(about): Discord + Need-help buttons + version-sync guard (recover stranded 0.6.8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,10 @@ jobs:
           done < <(find __init__.py README.md pyproject.toml web -type f \( -name '*.py' -o -name '*.js' -o -name '*.md' -o -name '*.toml' -o -name '*.json' -o -name '*.html' -o -name '*.css' \) -print0)
           [ "$fail" = "0" ] || exit 1
 
-      - name: pyproject.toml is valid + has registry fields
+      - name: pyproject.toml is valid + has registry fields + JS version matches
         run: |
           python - <<'PY'
-          import tomllib
+          import tomllib, re, sys
           d = tomllib.load(open("pyproject.toml", "rb"))
           proj = d.get("project", {})
           comfy = d.get("tool", {}).get("comfy", {})
@@ -118,5 +118,18 @@ jobs:
           if not comfy.get("PublisherId"):
               missing.append("tool.comfy.PublisherId")
           assert not missing, f"pyproject missing required fields: {missing}"
-          print(f"pyproject OK: {proj['name']} {proj['version']}")
+          # The panel JS carries PANEL_VERSION for its "Need help?" diagnostics blob;
+          # a build step can't inject it (the file is served raw), so ENFORCE that it
+          # equals pyproject's version here — a mismatch fails CI + the publish gate
+          # so a stale panel version can never ship (see scripts/set-version.mjs to
+          # bump both at once).
+          js = open("web/js/comfyui-mcp-panel.js", encoding="utf-8").read()
+          m = re.search(r'const PANEL_VERSION = "([^"]+)"', js)
+          assert m, "PANEL_VERSION constant not found in web/js/comfyui-mcp-panel.js"
+          if m.group(1) != proj["version"]:
+              sys.exit(
+                  f"VERSION MISMATCH: pyproject={proj['version']} but PANEL_VERSION={m.group(1)} "
+                  f"in comfyui-mcp-panel.js — run `node scripts/set-version.mjs {proj['version']}`."
+              )
+          print(f"pyproject OK: {proj['name']} {proj['version']} (JS PANEL_VERSION matches)")
           PY

--- a/.github/workflows/publish_action.yml
+++ b/.github/workflows/publish_action.yml
@@ -81,10 +81,10 @@ jobs:
       - name: Python compile check (__init__.py)
         run: python -m py_compile __init__.py
 
-      - name: pyproject.toml is valid + has registry fields
+      - name: pyproject.toml is valid + has registry fields + JS version matches
         run: |
           python - <<'PY'
-          import tomllib
+          import tomllib, re, sys
           d = tomllib.load(open("pyproject.toml", "rb"))
           proj = d.get("project", {})
           comfy = d.get("tool", {}).get("comfy", {})
@@ -92,7 +92,14 @@ jobs:
           if not comfy.get("PublisherId"):
               missing.append("tool.comfy.PublisherId")
           assert not missing, f"pyproject missing required fields: {missing}"
-          print(f"publishing {proj['name']} {proj['version']}")
+          # Block a publish whose panel JS PANEL_VERSION (shown in "Need help?"
+          # diagnostics) drifted from pyproject — run scripts/set-version.mjs to sync.
+          js = open("web/js/comfyui-mcp-panel.js", encoding="utf-8").read()
+          m = re.search(r'const PANEL_VERSION = "([^"]+)"', js)
+          assert m, "PANEL_VERSION constant not found in web/js/comfyui-mcp-panel.js"
+          if m.group(1) != proj["version"]:
+              sys.exit(f"VERSION MISMATCH: pyproject={proj['version']} PANEL_VERSION={m.group(1)} — run scripts/set-version.mjs")
+          print(f"publishing {proj['name']} {proj['version']} (JS PANEL_VERSION matches)")
           PY
       # --------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.6.8] - 2026-07-08
+
+### Added
+
+- **Discord community + one-tap "Need help?" in Settings → About.** Alongside
+  ⭐ Star on GitHub there's now **💬 Join the Discord** and a **🆘 Need help?**
+  button that copies a short diagnostics summary (panel version, backend,
+  ComfyUI version, page URL, user-agent) to the clipboard and opens the Discord,
+  so a stuck user pastes exactly what's needed to help fast. README links the
+  Discord too. Invite: https://discord.gg/TtQpf96BHS
+
+### Changed
+
+- **Panel version can no longer drift out of the diagnostics blob.** The JS
+  `PANEL_VERSION` is now bumped together with `pyproject.toml` via
+  `node scripts/set-version.mjs <v>`, and CI + the publish gate FAIL if the two
+  disagree — a stale version can't be shipped.
+
 ## [0.6.6] - 2026-07-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ All notable changes to this project are documented here. This project adheres to
   `node scripts/set-version.mjs <v>`, and CI + the publish gate FAIL if the two
   disagree — a stale version can't be shipped.
 
+## [0.6.7] - 2026-07-08
+
+### Changed
+
+- **Local (Ollama) backend now defaults to the fine-tuned `gemma4-comfyui-mcp`
+  ladder**, with a one-time migration of the stale `gemma4:e4b` default to the
+  fine-tune. (#62, #66)
+
 ## [0.6.6] - 2026-07-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 **An autonomous AI agent embedded in the ComfyUI sidebar that drives your canvas — now on EITHER
 Claude or ChatGPT (your own subscription, no API key).**
 
-[![Deploy on RunPod](https://img.shields.io/badge/Deploy_on-RunPod-673AB7?style=for-the-badge)](https://console.runpod.io/deploy?template=bnqtkvcer3&ref=dkx71w9b) &nbsp;**One-click GPU pod** — a ready-to-run ComfyUI with this panel + [comfyui-mcp](https://github.com/artokun/comfyui-mcp) + ComfyUI-Manager v2 preinstalled, on your own GPU. No setup.
+[![Deploy on RunPod](https://img.shields.io/badge/Deploy_on-RunPod-673AB7?style=for-the-badge)](https://console.runpod.io/deploy?template=bnqtkvcer3&ref=dkx71w9b) [![Join the Discord](https://img.shields.io/badge/Discord-Join_%26_get_help-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/TtQpf96BHS) &nbsp;**One-click GPU pod** — a ready-to-run ComfyUI with this panel + [comfyui-mcp](https://github.com/artokun/comfyui-mcp) + ComfyUI-Manager v2 preinstalled, on your own GPU. No setup.
+
+**Stuck or have a question? [Join the Discord](https://discord.gg/TtQpf96BHS)** — or hit **🆘 Need help?** in the panel's Settings → About (it copies a diagnostics summary and opens the Discord for you).
 
 Pick a provider — **Claude** or **ChatGPT** — and the matching agent runs in the background on
 *your* subscription, sees the graph you're looking at, and edits it live. Both providers reach

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar â€” runs locally on your own Claude OR ChatGPT subscription (no API keys, no extra LLM costs). Pick a provider and the agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, and run your workflow â€” asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.6.7"
+version = "0.6.8"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees
@@ -13,6 +13,7 @@ classifiers = ["Operating System :: OS Independent"]
 Repository = "https://github.com/artokun/comfyui-mcp-panel"
 Documentation = "https://comfyui-mcp.artokun.io/docs"
 "Bug Tracker" = "https://github.com/artokun/comfyui-mcp-panel/issues"
+Discord = "https://discord.gg/TtQpf96BHS"
 
 [tool.comfy]
 PublisherId = "artokun"

--- a/scripts/set-version.mjs
+++ b/scripts/set-version.mjs
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// Single source of truth for bumping the panel version — updates BOTH
+// pyproject.toml [project].version AND the PANEL_VERSION constant in
+// web/js/comfyui-mcp-panel.js so they can never drift. CI + the publish gate
+// assert they match, so forgetting one is a red build, not a silent stale
+// version in the "Need help?" diagnostics.
+//
+//   node scripts/set-version.mjs 0.6.8
+//
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const version = process.argv[2];
+if (!version || !/^\d+\.\d+\.\d+([-.].+)?$/.test(version)) {
+  console.error(`usage: node scripts/set-version.mjs <version>  (got: ${version ?? "nothing"})`);
+  process.exit(1);
+}
+
+const pyPath = join(root, "pyproject.toml");
+const jsPath = join(root, "web/js/comfyui-mcp-panel.js");
+
+const py = readFileSync(pyPath, "utf-8");
+const py2 = py.replace(/^version = "[^"]+"/m, `version = "${version}"`);
+if (py2 === py || !/^version = "/m.test(py)) {
+  console.error("could not find `version = \"...\"` in pyproject.toml");
+  process.exit(1);
+}
+
+const js = readFileSync(jsPath, "utf-8");
+const js2 = js.replace(/const PANEL_VERSION = "[^"]+"/, `const PANEL_VERSION = "${version}"`);
+if (js2 === js) {
+  console.error("could not find `const PANEL_VERSION = \"...\"` in comfyui-mcp-panel.js");
+  process.exit(1);
+}
+
+writeFileSync(pyPath, py2);
+writeFileSync(jsPath, js2);
+console.log(`set version ${version} in pyproject.toml + PANEL_VERSION (web/js/comfyui-mcp-panel.js)`);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -87,6 +87,14 @@ function setupListeners() {
   }
 }
 
+// Community + support. The Discord is the one-tap "I'm stuck" channel surfaced
+// in Settings → About (Join + Need help buttons) and linked from the README.
+const DISCORD_INVITE_URL = "https://discord.gg/TtQpf96BHS";
+// Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
+// `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
+// and the publish gate FAIL if the two ever drift, so this can't go stale.
+const PANEL_VERSION = "0.6.8";
+
 // ---------------------------------------------------------------------------
 // localStorage-backed settings.
 // ---------------------------------------------------------------------------
@@ -772,6 +780,68 @@ function panelSettingsList() {
           "border:1px solid var(--p-surface-500,#555);background:var(--p-surface-800,#27272a);" +
           "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:0.8rem;white-space:nowrap;";
         return a;
+      },
+    },
+    {
+      // A link row — "💬 Join the Discord" (community). Same render-fn pattern.
+      id: "comfyui-mcp.joinDiscord",
+      name: "Community",
+      category: cat("About", "Community"),
+      sortOrder: 199,
+      tooltip: "Join the comfyui-mcp Discord — announcements, tips, and help. Opens in a new tab.",
+      type: () => {
+        const a = document.createElement("a");
+        a.href = DISCORD_INVITE_URL;
+        a.target = "_blank";
+        a.rel = "noopener noreferrer";
+        a.textContent = "💬 Join the Discord";
+        a.style.cssText =
+          "display:inline-flex;align-items:center;gap:0.4rem;padding:0.3rem 0.7rem;border-radius:6px;" +
+          "border:1px solid var(--p-surface-500,#555);background:var(--p-surface-800,#27272a);" +
+          "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:0.8rem;white-space:nowrap;";
+        return a;
+      },
+    },
+    {
+      // "🆘 Need help?" — copies a small diagnostics blob to the clipboard, then
+      // opens the Discord, so a stuck user pastes exactly what's needed for
+      // triage instead of a back-and-forth. Uses openExternalUrl (blob-safe on
+      // remote pods). Distinct, warmer-colored button so it reads as "support".
+      id: "comfyui-mcp.getHelp",
+      name: "Need help?",
+      category: cat("About", "Need help?"),
+      sortOrder: 198,
+      tooltip:
+        "Stuck? This copies a short diagnostics summary (panel version, backend, ComfyUI, OS) to your clipboard and opens the Discord — paste it into your message so we can help fast.",
+      type: () => {
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.textContent = "🆘 Need help? Contact me on Discord";
+        btn.style.cssText =
+          "display:inline-flex;align-items:center;gap:0.4rem;padding:0.3rem 0.7rem;border-radius:6px;" +
+          "border:1px solid var(--p-primary-color,#8b5cf6);background:var(--p-primary-color,#8b5cf6);" +
+          "color:#fff;font-size:0.8rem;white-space:nowrap;cursor:pointer;";
+        btn.addEventListener("click", async () => {
+          const diag = [
+            "--- comfyui-mcp panel diagnostics ---",
+            `panel: ${PANEL_VERSION}`,
+            `backend: ${(getSetting(SETTING_BACKEND) ?? "claude")}`,
+            `comfyui: ${window.app?.frontendVersion ?? window.app?.extensionManager?.appVersion ?? "unknown"}`,
+            `page: ${location.origin}`,
+            `ua: ${navigator.userAgent}`,
+            `time: ${new Date().toISOString()}`,
+          ].join("\n");
+          try {
+            await navigator.clipboard.writeText(diag);
+            btn.textContent = "✅ Diagnostics copied — paste them in Discord";
+            setTimeout(() => { btn.textContent = "🆘 Need help? Contact me on Discord"; }, 4000);
+          } catch {
+            // clipboard blocked (permissions/insecure context) — still open Discord;
+            // the user can describe the issue manually.
+          }
+          openExternalUrl(DISCORD_INVITE_URL);
+        });
+        return btn;
       },
     },
     // ---- General (backend selector is the first row) ----


### PR DESCRIPTION
Recovers the 0.6.8 work that got stranded on `release/0.6.7` (commit 3992265) when a concurrent session's 0.6.7 release (#67) landed on main separately — main had none of it.

- **Settings → About:** 💬 Join the Discord + 🆘 Need help? (copies a diagnostics blob — panel version, backend, ComfyUI, page URL, UA — then opens the Discord). README + pyproject link the Discord.
- **Version-drift guard:** `PANEL_VERSION` + pyproject bumped together via `scripts/set-version.mjs`; CI + publish gate FAIL on mismatch so a stale version can't ship.
- Backfills the 0.6.7 changelog entry the release skipped.

Cherry-picked cleanly onto current main; version guard matches (0.6.8), JS syntax clean, workflow_open repaint fix from main preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)