### PR TITLE
feat(panel): per-workflow agent sessions + credentials card + provider on/off — ported from MichaelDanCurtis fork

### DIFF
--- a/docs/superpowers/plans/2026-07-10-per-workflow-agent-sessions.md
+++ b/docs/superpowers/plans/2026-07-10-per-workflow-agent-sessions.md
@@ -1,0 +1,429 @@
+# Per-Workflow Agent Sessions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give each ComfyUI workflow its own agent conversation — switching workflow tabs auto-swaps the chat to that workflow's thread; saved workflows keep their conversation across restarts.
+
+**Architecture:** Frontend re-key. The orchestrator already isolates agents per `tabId` and resumes by `sessionId`; the panel already persists multi-thread conversations and `loadThread()` already switches+resumes. We (a) derive `tabId` from the active workflow instead of one per-browser-session UUID, (b) tag each thread with its workflow, (c) detect workflow changes and drive `loadThread()` + a re-hello, and (d) adopt a temp conversation into the file identity on save. One tiny backend fix prevents a retargeted socket from leaking a background workflow's output.
+
+**Tech Stack:** Vanilla browser JS (ComfyUI custom-node frontend, single file `web/js/comfyui-mcp-panel.js`), a Node WS bridge (`comfyui-mcp` orchestrator, TypeScript). No build step for the frontend (served as-is; reload = Cmd+R). Backend change requires `npm run build` + orchestrator restart.
+
+## Global Constraints
+
+- **Frontend file:** `/Users/michaelcurtis/Documents/ComfyUI/ComfyUI/ComfyUI/custom_nodes/comfyui-agent-panel/web/js/comfyui-mcp-panel.js` (one large file; follow its existing idioms — `ssGet/ssSet`, `crypto.randomUUID()`, no framework).
+- **Backend file:** `/Volumes/Main External/Development/comfyui-mcp/src/services/ui-bridge.ts`.
+- **Identity scheme (verbatim):** saved → `"wf:" + wf.path`; unsaved/temporary → `"tmp:" + crypto.randomUUID()` (stable per `wf.key` for the app session).
+- **Never open a second concurrent bridge client** (same-`tabId` reconnect storm). Retarget the existing single client.
+- **Backend stays minimal** — exactly one small change (Task 1). No agent-lifecycle changes.
+- **Verification is live-browser** via the running ComfyUI at `http://127.0.0.1:8188` (drive it with the chrome-devtools MCP: `new_page`, `evaluate_script`). Frontend-only tasks need just a page reload; Task 1 needs an orchestrator rebuild + restart.
+- **Runtime ownership:** the user starts/stops the orchestrator (visible terminal / `comfyui-mcp/scripts/launch-orchestrator.sh`). Do NOT restart it silently — ask, or hand the restart to the user.
+
+---
+
+### Task 1: Backend — drop the stale conn when a socket retargets
+
+**Why first:** it's the safety net that makes re-hello (Task 4) correct. `push(frame, tabId)` sends frames with no `tab_id` (the socket is the tab), so if a socket re-hellos under a new `tabId` while its old `tabId` conn still points at it, a background agent's `push(old)` leaks into the current view. Deleting the stale mapping on re-hello prevents that.
+
+**Files:**
+- Modify: `/Volumes/Main External/Development/comfyui-mcp/src/services/ui-bridge.ts` (hello handler, ~L316-343)
+
+**Interfaces:**
+- Produces: no API change — the `hello` handler now guarantees one socket maps to exactly one live `tabId`.
+
+- [ ] **Step 1: Read the current hello handler**
+
+Run: `sed -n '314,345p' "/Volumes/Main External/Development/comfyui-mcp/src/services/ui-bridge.ts"`
+Confirm it starts with `if (msg.type === "hello" && typeof msg.tab_id === "string") {` and does `tabId = msg.tab_id;` then `this.conns.set(tabId, {...})`.
+
+- [ ] **Step 2: Insert the stale-conn cleanup**
+
+Immediately BEFORE the line `tabId = msg.tab_id;`, add:
+
+```ts
+        // A single socket may RE-HELLO under a new tab id when the user switches
+        // ComfyUI workflow tabs (per-workflow sessions). Drop this socket's PRIOR
+        // tab mapping so a background agent's push() to the old tab can't leak into
+        // the newly-targeted view (frames carry no tab_id — the socket is the tab).
+        if (tabId && tabId !== msg.tab_id && this.conns.get(tabId)?.sock === sock) {
+          this.conns.delete(tabId);
+        }
+```
+
+- [ ] **Step 3: Typecheck + build**
+
+Run: `cd "/Volumes/Main External/Development/comfyui-mcp" && npm run build`
+Expected: exits 0, no TS errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd "/Volumes/Main External/Development/comfyui-mcp"
+git add src/services/ui-bridge.ts
+git commit -m "fix(bridge): drop stale conn when a socket retargets to a new tab id"
+```
+
+- [ ] **Step 5: Hand off restart**
+
+Tell the user: "Backend built — restart the orchestrator when ready so this ships (it's the only backend change in #1)." Do NOT restart it yourself.
+
+---
+
+### Task 2: `workflowTabId()` — workflow-derived agent identity
+
+**Files:**
+- Modify: `web/js/comfyui-mcp-panel.js` — add near `getTabId()` (~L258); rewire `sendHello()` (~L4819) and `sendTitle()` (~L4844) and the per-frame sender (~L4937).
+
+**Interfaces:**
+- Produces:
+  - `workflowTabId(): string` — the active workflow's agent id (`wf:<path>` | `tmp:<uuid>` | legacy `getTabId()` fallback).
+  - `activeWorkflowRef(): object|null` — the ComfyUI active-workflow object or null.
+  - `_tempWorkflowIds: Map<string,string>` — `wf.key → tmp uuid`, module-scoped.
+
+- [ ] **Step 1: Add the identity function** (right after `getTabId()`'s closing brace, ~L270)
+
+```js
+// --- Per-workflow agent identity -----------------------------------------
+// Each ComfyUI workflow gets its OWN agent session. Saved workflows key by file
+// path (stable across restarts → the conversation lives with the file). Unsaved
+// ones get a stable temp id for this app session (adopted into the file id on save,
+// see the workflow-change handler). Falls back to the legacy per-browser-session id
+// when no workflow service is present (headless / odd frontend).
+const _tempWorkflowIds = new Map(); // wf.key -> "tmp:<uuid>"
+function activeWorkflowRef() {
+  try {
+    return (
+      window.comfyAPI?.app?.app?.extensionManager?.workflow?.activeWorkflow ||
+      (typeof app !== "undefined" && app?.extensionManager?.workflow?.activeWorkflow) ||
+      null
+    );
+  } catch {
+    return null;
+  }
+}
+function workflowTabId() {
+  const wf = activeWorkflowRef();
+  if (!wf) return getTabId();
+  const saved =
+    wf.isPersisted === true && wf.isTemporary !== true && typeof wf.path === "string" && wf.path;
+  if (saved) return "wf:" + wf.path;
+  const k = wf.key || wf.id || "unsaved";
+  let id = _tempWorkflowIds.get(k);
+  if (!id) {
+    id = "tmp:" + crypto.randomUUID();
+    _tempWorkflowIds.set(k, id);
+  }
+  return id;
+}
+```
+
+- [ ] **Step 2: Use it in `sendHello()`** — change `tab_id: getTabId(),` (~L4819) to:
+
+```js
+          tab_id: workflowTabId(),
+```
+
+- [ ] **Step 3: Use it in `sendTitle()`** — change `sock.send(JSON.stringify({ type: "title", tab_id: getTabId(), title: t }));` (~L4844) to:
+
+```js
+      sock.send(JSON.stringify({ type: "title", tab_id: workflowTabId(), title: t }));
+```
+
+- [ ] **Step 4: Use it in the per-frame sender** — change `sock.send(JSON.stringify({ tab_id: getTabId(), ...frame }));` (~L4937) to:
+
+```js
+        sock.send(JSON.stringify({ tab_id: workflowTabId(), ...frame }));
+```
+
+- [ ] **Step 5: Syntax check**
+
+Run: `node --check "/Users/michaelcurtis/Documents/ComfyUI/ComfyUI/ComfyUI/custom_nodes/comfyui-agent-panel/web/js/comfyui-mcp-panel.js"`
+Expected: prints nothing, exits 0.
+
+- [ ] **Step 6: Live check — hello carries the workflow id**
+
+Reload ComfyUI (chrome-devtools `new_page` → `http://127.0.0.1:8188`), open the Agent panel, then evaluate:
+
+```js
+() => { const w = window.comfyAPI?.app?.app?.extensionManager?.workflow?.activeWorkflow;
+  return { path: w?.path, key: w?.key, persisted: w?.isPersisted, temporary: w?.isTemporary }; }
+```
+Expected: an object describing the current workflow (so `workflowTabId()` will produce `wf:<path>` for a saved one). Confirm the panel still connects (status "connected").
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd "/Users/michaelcurtis/Documents/ComfyUI/ComfyUI/ComfyUI/custom_nodes/comfyui-agent-panel"
+git add web/js/comfyui-mcp-panel.js
+git commit -m "feat(panel): derive bridge tab id from the active workflow"
+```
+
+---
+
+### Task 3: Tag threads with their workflow
+
+**Files:**
+- Modify: `web/js/comfyui-mcp-panel.js` — `record()` (~L7163) and add `threadForWorkflow()` near it.
+
+**Interfaces:**
+- Consumes: `workflowTabId()` (Task 2); `threads[]`, `thread`, `persistThreads()`, `ssSet`, `CURRENT_THREAD_KEY`.
+- Produces:
+  - Thread records now carry `workflowKey: string`.
+  - `threadForWorkflow(wfid: string): object|null`.
+
+- [ ] **Step 1: Tag new threads in `record()`** — change the thread-creation block (~L7165) from:
+
+```js
+      thread = { id: crypto.randomUUID(), ts: Date.now(), msgs: [] };
+```
+to:
+```js
+      thread = { id: crypto.randomUUID(), ts: Date.now(), msgs: [], workflowKey: workflowTabId() };
+```
+
+- [ ] **Step 2: Add the lookup** (right after `persistThreads()`'s closing brace, ~L7161)
+
+```js
+  // Find the (single) thread bound to a workflow id, or null. One conversation per
+  // workflow: newest wins if duplicates ever exist.
+  function threadForWorkflow(wfid) {
+    for (let i = threads.length - 1; i >= 0; i--) {
+      if (threads[i].workflowKey === wfid) return threads[i];
+    }
+    return null;
+  }
+```
+
+- [ ] **Step 3: Syntax check**
+
+Run: `node --check "/Users/michaelcurtis/Documents/ComfyUI/ComfyUI/ComfyUI/custom_nodes/comfyui-agent-panel/web/js/comfyui-mcp-panel.js"`
+Expected: exits 0.
+
+- [ ] **Step 4: Live check — a new message tags the thread**
+
+Reload, open panel on a saved workflow, send one message ("hi"), then evaluate:
+
+```js
+() => JSON.parse(localStorage.getItem("comfyui-mcp.panel.threads") || "[]")
+       .map(t => ({ id: t.id.slice(0,8), workflowKey: t.workflowKey, msgs: t.msgs.length }))
+```
+Expected: the newest thread has `workflowKey` starting `wf:` (or `tmp:`) matching the current workflow.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/js/comfyui-mcp-panel.js
+git commit -m "feat(panel): tag chat threads with their workflow id"
+```
+
+---
+
+### Task 4: Auto-follow — switch (and adopt-on-save) on workflow change
+
+**Files:**
+- Modify: `web/js/comfyui-mcp-panel.js` — add the change handler; wire it to the existing `titleObserver` (~L4849) and call once after the client connects.
+
+**Closure map (read first):** `sendHello`/`sock`/`titleObserver` live in the **bridge-client** closure (~L4804-4851). `loadThread`/`record`/`thread`/`resetFeed`/`client` live in the **panel-mount** closure (`loadThread` ~L8040, uses `client?.sendFrame`). These are DIFFERENT closures. Therefore: put detection **and** reaction in the panel-mount closure (it has `loadThread`, `thread`, `client`), give the bridge client a public **`rehello()`** so the panel can re-target the socket, and drive detection from the panel closure's **own** title observer (do NOT try to call panel functions from the bridge-client's observer). Confirm with: `grep -n "function sendHello\|function loadThread\|return {" web/js/comfyui-mcp-panel.js` and locate the object `createBridgeClient` returns.
+
+**Interfaces:**
+- Consumes: `workflowTabId()`, `activeWorkflowRef()`, `_tempWorkflowIds` (Task 2); `threadForWorkflow()` (Task 3); `loadThread()`, `resetFeed()`, `persistThreads()`, `thread`, `client`, `ssSet`, `CURRENT_THREAD_KEY`, `SESSION_KEY` (existing, panel-mount closure).
+- Produces:
+  - `client.rehello()` — public method on the bridge client that sends a fresh `hello` (picks up the current `workflowTabId()`) on the existing socket.
+  - `onWorkflowMaybeChanged(): void` and `rehelloForWorkflow(sessionId): void` in the panel-mount closure.
+  - panel-closure state `currentWorkflowId: string|null`, `currentWorkflowKey: string|null`.
+
+- [ ] **Step 1: Expose `rehello` on the bridge client** — find the object `createBridgeClient` returns (the one assigned to `client`/`liveBridgeClient`; it already exposes `sendFrame`, `destroy`). Add `sendHello` to it:
+
+```js
+    // Public re-hello so the panel can re-target this socket to a new workflow's
+    // tab id (per-workflow sessions) without opening a second client.
+    rehello: sendHello,
+```
+
+- [ ] **Step 2: Add the handler in the PANEL-MOUNT closure** (place near `loadThread`, ~L8055, where `loadThread`/`thread`/`client` are in scope)
+
+```js
+  // Per-workflow auto-follow. Called on any workflow change (open/switch/save/rename).
+  // Three cases:
+  //   1) id unchanged -> nothing (title tick during a run/edit).
+  //   2) same wf.key, id flipped tmp:->wf: -> ADOPT: migrate the temp thread to the
+  //      file identity, keep the SAME agent session.
+  //   3) different id -> SWITCH: re-hello + load that workflow's thread (or a fresh
+  //      empty view if it has none).
+  let currentWorkflowId = null;
+  let currentWorkflowKey = null;
+  function rehelloForWorkflow(sessionId) {
+    // Re-target the socket to the current workflow's tab id, then resume that
+    // workflow's agent session. The backend drops the socket's prior tab mapping
+    // (Task 1) so a background workflow's output can't leak here.
+    try {
+      client?.rehello?.();
+      if (sessionId) client?.sendFrame?.({ type: "resume_session", session_id: sessionId });
+    } catch {
+      /* reconnect path retries the hello */
+    }
+  }
+  function onWorkflowMaybeChanged() {
+    const wf = activeWorkflowRef();
+    const wfid = workflowTabId();
+    const wfkey = wf ? (wf.key || wf.id || "unsaved") : null;
+    if (wfid === currentWorkflowId) return; // case 1
+
+    const adopting =
+      currentWorkflowId &&
+      currentWorkflowKey &&
+      wfkey === currentWorkflowKey &&
+      currentWorkflowId.startsWith("tmp:") &&
+      wfid.startsWith("wf:");
+    if (adopting) {
+      const t = threadForWorkflow(currentWorkflowId);
+      if (t) { t.workflowKey = wfid; persistThreads(); }        // migrate to file id
+      if (wf && (wf.key || wf.id)) _tempWorkflowIds.delete(wf.key || wf.id);
+      currentWorkflowId = wfid;
+      currentWorkflowKey = wfkey;
+      rehelloForWorkflow(t?.sessionId || null);                  // same session continues
+      return;
+    }
+
+    currentWorkflowId = wfid;
+    currentWorkflowKey = wfkey;
+    const existing = threadForWorkflow(wfid);
+    rehelloForWorkflow(existing?.sessionId || null);
+    if (existing) {
+      loadThread(existing);                                      // resets feed + repaints + resumes
+    } else {
+      thread = null;                                            // fresh empty view; thread minted on 1st message
+      ssSet(CURRENT_THREAD_KEY, null);
+      ssSet(SESSION_KEY, null);
+      resetFeed();
+    }
+  }
+```
+
+- [ ] **Step 3: Drive it from a panel-closure title observer** — in the panel-mount closure (near where the panel builds), add its OWN observer so detection lives beside the reaction:
+
+```js
+  // The document <title> mutates whenever the active workflow changes (open/switch/
+  // save/rename), so it is a reliable, framework-free change signal.
+  const _wfTitleEl = document.querySelector("title");
+  const _wfObserver = _wfTitleEl ? new MutationObserver(() => onWorkflowMaybeChanged()) : null;
+  _wfObserver?.observe(_wfTitleEl, { childList: true });
+```
+
+Ensure it is torn down in the panel's `destroy()` (add `_wfObserver?.disconnect();` there).
+
+- [ ] **Step 4: Seed the current identity once the client is live** — where `client`/`liveBridgeClient` is assigned in the panel closure (search `liveBridgeClient = client`), seed tracking so the first switch is detected:
+
+```js
+  currentWorkflowId = workflowTabId();
+  currentWorkflowKey = (() => { const w = activeWorkflowRef(); return w ? (w.key || w.id || "unsaved") : null; })();
+```
+
+- [ ] **Step 5: Syntax check**
+
+Run: `node --check "/Users/michaelcurtis/Documents/ComfyUI/ComfyUI/ComfyUI/custom_nodes/comfyui-agent-panel/web/js/comfyui-mcp-panel.js"`
+Expected: exits 0.
+
+- [ ] **Step 6: Live check — switching workflows swaps the thread**
+
+Reload. Open two SAVED workflows in ComfyUI (two tabs at top). In workflow A send "message in A". Switch ComfyUI to workflow B; send "message in B". Switch back to A. Evaluate after each switch:
+
+```js
+() => { const log = document.querySelector(".cmcp-log") || document.querySelector('[class*="cmcp"][class*="log"]');
+  return { visibleText: (log?.innerText || "").slice(0, 200),
+           currentThread: sessionStorage.getItem("comfyui-mcp.panel.currentThreadId") }; }
+```
+Expected: on A the log shows "message in A"; on B it shows "message in B"; switching back to A restores A's transcript. `currentThreadId` differs between A and B.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/js/comfyui-mcp-panel.js
+git commit -m "feat(panel): auto-follow the active workflow (switch + adopt-on-save)"
+```
+
+---
+
+### Task 5: A2UI seam — chat surface width as single owned state
+
+**Why:** the spec's one forward-compatibility requirement so the future A2UI feature can expand/shrink the chat surface without a refactor. Keep it minimal — no resize UI is built now.
+
+**Files:**
+- Modify: `web/js/comfyui-mcp-panel.js` — add a single no-op-by-default surface hook near the panel root creation.
+
+**Interfaces:**
+- Produces: `cmcpSetChatSurface(mode: "normal"|"wide"): void` on the panel bridge object (default `"normal"`, sets one CSS var). Currently unused; A2UI will call it.
+
+- [ ] **Step 1: Find the panel root element** — `grep -n "cmcp-root" web/js/comfyui-mcp-panel.js` and note the variable holding the root element created in `buildPanel()`.
+
+- [ ] **Step 2: Add the hook** (right after the root element is created in `buildPanel()`)
+
+```js
+  // A2UI seam (forward-compat, see spec): the chat surface width is a SINGLE piece
+  // of owned state, not scattered CSS, so a future A2UI layer can widen the surface
+  // (e.g. to show a diagram) and shrink it back. No-op visual default today.
+  root.style.setProperty("--cmcp-surface-width", "100%");
+  function cmcpSetChatSurface(mode) {
+    root.style.setProperty("--cmcp-surface-width", mode === "wide" ? "60%" : "100%");
+    root.dataset.surface = mode === "wide" ? "wide" : "normal";
+  }
+```
+
+- [ ] **Step 3: Expose it** — add `cmcpSetChatSurface` to the object returned by `buildPanel()` (the `{ root, destroy, ... }` return) so A2UI can reach it later. If `buildPanel` returns `{ root, destroy }`, change to `{ root, destroy, setChatSurface: cmcpSetChatSurface }`.
+
+- [ ] **Step 4: Syntax check + confirm no visual regression**
+
+Run: `node --check ".../comfyui-mcp-panel.js"` (exits 0). Reload; the panel looks identical (mode defaults to normal). Evaluate:
+```js
+() => { const r = document.querySelector(".cmcp-root"); return { w: getComputedStyle(r).getPropertyValue("--cmcp-surface-width").trim(), surface: r?.dataset.surface }; }
+```
+Expected: `w` is `100%` (or empty→treated as normal); no layout change.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/js/comfyui-mcp-panel.js
+git commit -m "feat(panel): expose chat-surface width hook (A2UI seam)"
+```
+
+---
+
+### Task 6: Full-stack verification (the four spec acceptance checks)
+
+**Files:** none (verification only). Requires the orchestrator running the Task 1 build (ask the user to restart it first).
+
+- [ ] **Step 1: Two workflows keep separate threads**
+
+Open workflow A and B (saved). Converse in each; switch back and forth. PASS = each shows only its own messages (re-run the Task 4 Step 5 check).
+
+- [ ] **Step 2: Background survival**
+
+In A, ask for something slow (e.g. "list every node type you know, one per line"). Immediately switch to B. Wait ~15s. Switch back to A. PASS = A's answer completed and is visible (reconciled via resume). Confirm no B content leaked into A and vice-versa.
+
+- [ ] **Step 3: Adopt-on-save**
+
+Open a NEW workflow ("Unsaved Workflow"). Send "remember the number 42". Save the workflow (Ctrl+S / menu) with a name. Send "what number did I say?". PASS = the agent answers 42 (the temp conversation was adopted into the saved file's session — no reset). Evaluate that the thread's `workflowKey` is now `wf:<path>`:
+```js
+() => JSON.parse(localStorage.getItem("comfyui-mcp.panel.threads")||"[]").slice(-1)[0]?.workflowKey
+```
+Expected: starts with `wf:`.
+
+- [ ] **Step 4: Persistence across reload**
+
+With A and B having conversations, hard-reload ComfyUI. Reopen workflow A. PASS = A's transcript is restored and typing continues its session.
+
+- [ ] **Step 5: Record results**
+
+Summarize PASS/FAIL for Steps 1-4 to the user. For any FAIL, capture the console (`chrome-devtools` `list_console_messages`) and diagnose before declaring done.
+
+- [ ] **Step 6: Update project memory**
+
+Append to the ComfyUI project memory that the agent panel is now per-workflow (tabId = `wf:<path>` | `tmp:<uuid>`, auto-follow via titleObserver, adopt-on-save, backend already per-tabId + the ui-bridge stale-conn fix), and that A2UI is the next design cycle with the surface-width seam in place.
+
+---
+
+## Notes for the implementer
+
+- **No frontend build.** Editing `comfyui-mcp-panel.js` takes effect on ComfyUI **Cmd+R** (the file is served as-is). Only Task 1 (TypeScript) needs `npm run build` + an orchestrator restart.
+- **Closure scoping is the main hazard.** `sendHello`/`sock` live in the bridge-client closure; `loadThread`/`record`/`thread` live in the panel-mount closure. Verify with grep before Task 4 and, if they are separate, bridge them via the existing `liveBridgeClient` object pattern rather than duplicating.
+- **Don't open a second WS client** on switch — re-hello the existing one (Task 4 `rehelloForWorkflow`).
+- **Greeting on switch:** if re-hello visibly re-greets ("agent ready") on every switch and it's annoying, suppress it by gating the greeting render on a "first hello per socket" flag — note it but only act if observed.

--- a/docs/superpowers/specs/2026-07-10-per-workflow-agent-sessions-design.md
+++ b/docs/superpowers/specs/2026-07-10-per-workflow-agent-sessions-design.md
@@ -1,0 +1,174 @@
+# Per-Workflow Agent Sessions — Design Spec
+
+**Date:** 2026-07-10
+**Status:** Approved (design). Ready for implementation planning.
+**Repos:** `comfyui-agent-panel` (frontend, primary) · `comfyui-mcp` (orchestrator, minimal)
+
+## Goal
+
+Each ComfyUI **workflow** gets its own agent conversation, instead of one shared
+agent session across every workflow open in the panel. Switching ComfyUI workflow
+tabs auto-swaps the chat to that workflow's conversation. Conversations persist with
+saved workflows across restarts.
+
+## Key finding (why this is small)
+
+The backend is **already per-tab**. `PanelAgentManager` keeps
+`agents = Map<tabId::backend → PanelAgent>` — each `tabId` already has its own
+session, model, effort, history, and resume. The frontend already has a persistent
+multi-thread system (`THREADS_KEY = "comfyui-mcp.panel.threads"` in `localStorage`,
+`persistThreads()`, a thread switcher) and already knows the active workflow
+(`app.extensionManager.workflow.activeWorkflow`).
+
+The ONLY reason all workflows share one agent today: `getTabId()`
+(comfyui-mcp-panel.js ~L258) mints **one UUID per browser session** (sessionStorage),
+ignoring which workflow is open. Re-key that to the workflow and the existing
+machinery does the rest.
+
+## Locked decisions
+
+1. **Identity:** hybrid — persistent for saved workflows, **adopt-on-save** for unsaved.
+2. **View:** auto-follow — one sidebar chat view that swaps to the active workflow.
+3. **Threads per workflow:** exactly one conversation per workflow.
+4. **Background work:** a backgrounded workflow's agent keeps running (agents survive
+   tab disconnect); live streaming is for the visible workflow, reconciled on return.
+
+## Architecture
+
+Frontend re-key. Backend essentially untouched.
+
+### Identity — `workflowTabId()` replaces `getTabId()`
+
+- Saved workflow (`wf.isPersisted` / has `wf.path`) → **`wf:<path>`** (stable across
+  restarts → the conversation lives with the file).
+- Unsaved / temporary (`wf.isTemporary === true` || `wf.isPersisted === false`) →
+  **`tmp:<uuid>`**, where the uuid is minted once and kept in an in-memory
+  `Map<wf.key, uuid>` for the app session.
+- The chosen id becomes the `tab_id` the panel sends in its bridge `hello` frame.
+
+Workflow identity fields available (verified): `wf.path`, `wf.filename`, `wf.key`,
+`wf.isModified`, `wf.isPersisted`, `wf.isTemporary`.
+
+### View — auto-follow
+
+Subscribe to ComfyUI's active-workflow change (via
+`app.extensionManager.workflow`). On change:
+1. Compute the new `workflowTabId()`.
+2. Select (or create) that workflow's single thread record.
+3. Re-hello the **single** bridge socket under the new `tab_id`, and resume that
+   workflow's `sessionId` via the existing `resume_session` frame.
+4. Repaint the transcript from the persisted thread.
+
+One conversation per workflow: the thread list is workflow-keyed (one thread per
+workflow). "New chat" archives/clears that workflow's thread and starts a fresh
+session.
+
+### Adopt-on-save
+
+When an unsaved workflow is saved (hook the save path — `programmaticSave` and/or
+ComfyUI's save event), migrate the thread record `tmp:<uuid>` → `wf:<path>`, then
+re-hello under the new `tab_id` passing the OLD `sessionId` via `resume_session`, so
+the conversation started before saving carries over. Backend resume is keyed by
+`sessionId` (provider-side), independent of `tabId`, so the session continues under
+the new tab.
+
+### Bridge / socket model
+
+The bridge binds **one socket to one `tabId` at its `hello` frame**
+(ui-bridge.ts: socket is anonymous until `hello`; per-frame `tab_id` is overwritten
+by the hello identity). So a workflow switch = **re-hello the existing socket** under
+the new `tab_id` (single client — reuse the current connect/hello path; do NOT open a
+second client, to avoid the known same-`tab_id` reconnect storm). Agents for
+non-visible workflows are NOT killed on the implicit disconnect (index.ts has no
+kill-on-disconnect), so they keep running server-side.
+
+## Data model
+
+- **Thread record** (existing `threads[]`, persisted to `THREADS_KEY`): add
+  `workflowKey` (the `wf:<path>` or `tmp:<uuid>` id) so each thread maps to one
+  workflow. Thread selection becomes "find thread where workflowKey === current".
+- **Temp-id map** (in-memory, app-session): `Map<wf.key, uuid>` for unsaved workflows.
+- **Backend:** unchanged — `agents` keyed by `tabId::backend`; `sessionStore` keyed by
+  `sessionId` for resume.
+
+## Data flow
+
+1. Panel loads → resolve active workflow → `workflowTabId()` → hello with that id →
+   select that workflow's thread → resume its session → paint transcript.
+2. User switches ComfyUI workflow tab → change event → new `tabId` → re-hello + resume
+   + repaint. Previous workflow's agent keeps running server-side.
+3. User saves an unsaved workflow → adopt-on-save migrates `tmp:` → `wf:` + re-hello +
+   resume old session.
+4. Backgrounded turn completes → on return, resume + persisted transcript reconcile
+   the result into view.
+
+## What changes
+
+- **Frontend (`comfyui-mcp-panel.js`):**
+  - `getTabId()` → `workflowTabId()` (workflow-derived + temp map).
+  - Active-workflow change subscription → switch thread + re-hello.
+  - Thread records gain `workflowKey`; selection keyed by workflow.
+  - Adopt-on-save handler.
+  - Ensure single bridge client re-hellos cleanly (no storm).
+- **Backend (`comfyui-mcp`):** ~none. Confirm `resume_session` works across a
+  `tabId` change (expected — keyed by `sessionId`). Optional (later): idle-agent
+  reaping so closed workflows' agents don't accumulate.
+
+## Edge cases
+
+- **Multiple unsaved workflows:** each gets its own `tmp:<uuid>` via the temp map.
+- **Same workflow in two browser tabs:** both derive the same `wf:<path>` → same
+  `tab_id`. Last hello wins (bridge replaces the conn). Document as a known limitation.
+- **Closed workflow:** thread persists (localStorage); agent idles server-side
+  (reaping is a later optional).
+- **Deleted workflow file:** orphan thread — prune lazily (e.g., on next full thread
+  list load, drop `wf:` threads whose file no longer exists — optional).
+- **Rename / move a saved workflow:** `wf:<path>` changes → effectively a new
+  conversation. Acceptable v1; adopt-on-rename is a possible later enhancement.
+
+## Verification (manual, in the browser)
+
+1. Open two saved workflows; converse in each; switch back and forth → each shows its
+   own thread.
+2. Kick a long turn in workflow A; switch to B; return to A → the turn completed and is
+   visible (background survival).
+3. Start chatting in an "Unsaved Workflow"; save it → the conversation persists
+   (adopt-on-save).
+4. Reload ComfyUI → each saved workflow's thread is restored and resumes.
+
+## Forward-compatibility (A2UI seam)
+
+A separate, larger feature (**A2UI** — agent-rendered interactive UI in the chat:
+diagrams, choice buttons, forms, with an expand/shrink choreography) is planned as its
+own design cycle *after* this ships. To avoid foreclosing it, this build must satisfy
+one small constraint — no A2UI scope enters here:
+
+- The per-workflow **chat view is a self-contained component whose width/layout is
+  state-driven, not hardcoded.** A future A2UI layer will (a) render a constrained
+  component tree into this view and (b) expand it (~60%) and shrink it back. So keep
+  the view's width/height a single piece of state the component owns, rather than
+  fixed CSS scattered across the panel.
+
+That is the ONLY A2UI concession in this spec. Everything else about A2UI (protocol
+choice, safe renderer, interaction round-trip, agent emission) is out of scope here
+and belongs to the A2UI spec.
+
+## Non-goals (v1)
+
+- Separate/detachable simultaneous chat windows (auto-follow only).
+- Multiple threads per workflow.
+- Server-side transcript storage (frontend localStorage remains the transcript home).
+- Idle-agent reaping / orphan pruning (optional follow-ups).
+
+## Implementation notes / anchors
+
+- `getTabId()` — comfyui-mcp-panel.js ~L258; callers send `tab_id` per frame (~L4819,
+  L4844, L4937) but the socket's hello identity is authoritative.
+- Threads — `THREADS_KEY` ~L7142, `persistThreads()` ~L7155, `bindSession()` ~L7182,
+  `resume_session` frame ~L8053.
+- Active workflow — `app.extensionManager.workflow.activeWorkflow` (fields above);
+  save path `programmaticSave()` ~L1237.
+- Bridge hello/routing — ui-bridge.ts: `conns = Map<tabId, Conn>` ~L91, hello handling
+  ~L317.
+- Backend per-tab — panel-agent.ts: `PanelAgentManager.agents` ~L966, composite key
+  `tabId::backend`; index.ts `agentKeyFor`/`panelTabOf`/`backendForTab`.

--- a/scripts/verify-per-workflow.mjs
+++ b/scripts/verify-per-workflow.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Quick smoke check for per-workflow agent sessions (Task 6 subset).
+ * Requires ComfyUI at PLAYWRIGHT_BASE_URL (default http://127.0.0.1:8188).
+ */
+import { chromium } from "@playwright/test";
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL || "http://127.0.0.1:8188";
+
+async function main() {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  const results = [];
+
+  try {
+    await page.goto(BASE, { waitUntil: "domcontentloaded", timeout: 30000 });
+    await page.waitForTimeout(3000);
+
+    // Panel script should be loaded with workflowTabId helpers.
+    const hasWorkflowFns = await page.evaluate(() => {
+      const src = [...document.scripts].map((s) => s.src).join("\n");
+      return src.includes("comfyui-mcp-panel.js");
+    });
+    results.push({ check: "panel script loaded", pass: hasWorkflowFns });
+
+    const wf = await page.evaluate(() => {
+      const w =
+        window.comfyAPI?.app?.app?.extensionManager?.workflow?.activeWorkflow ||
+        (typeof app !== "undefined" && app?.extensionManager?.workflow?.activeWorkflow) ||
+        null;
+      return w
+        ? {
+            path: w.path,
+            key: w.key,
+            persisted: w.isPersisted,
+            temporary: w.isTemporary,
+          }
+        : null;
+    });
+    results.push({ check: "active workflow readable", pass: !!wf, detail: wf });
+
+    const threads = await page.evaluate(() => {
+      try {
+        return JSON.parse(localStorage.getItem("comfyui-mcp.panel.threads") || "[]").map((t) => ({
+          workflowKey: t.workflowKey,
+          msgs: t.msgs?.length ?? 0,
+        }));
+      } catch {
+        return [];
+      }
+    });
+    const tagged = threads.filter((t) => typeof t.workflowKey === "string");
+    results.push({
+      check: "threads carry workflowKey (if any exist)",
+      pass: threads.length === 0 || tagged.length === threads.length,
+      detail: { total: threads.length, tagged: tagged.length, sample: tagged.slice(0, 3) },
+    });
+
+    const surface = await page.evaluate(() => {
+      const r = document.querySelector(".cmcp-root");
+      if (!r) return { found: false };
+      return {
+        found: true,
+        width: getComputedStyle(r).getPropertyValue("--cmcp-surface-width").trim(),
+        surface: r.dataset.surface,
+      };
+    });
+    results.push({
+      check: "A2UI surface seam (--cmcp-surface-width on .cmcp-root)",
+      pass: !surface.found || surface.width === "100%" || surface.width === "",
+      detail: surface,
+    });
+
+    const failed = results.filter((r) => !r.pass);
+    console.log(JSON.stringify({ base: BASE, results, pass: failed.length === 0 }, null, 2));
+    process.exit(failed.length ? 1 : 0);
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(2);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -613,6 +613,10 @@ const _tempWorkflowIds = new Map(); // wf.key -> "tmp:<uuid>"
 // re-seed them to the now-current workflow and defeat change detection.
 let currentWorkflowId = null;
 let currentWorkflowKey = null;
+// The live workflow OBJECT last seen. ComfyUI mutates the SAME instance's path in
+// place on rename/Save-As (path and the derived .key getter both change), so the
+// instance is the only stable identity a rename leaves intact.
+let currentWorkflowRef = null;
 function activeWorkflowRef() {
   try {
     return (
@@ -9856,10 +9860,11 @@ function buildPanel() {
   }
 
   // Per-workflow auto-follow. Called on any workflow change (open/switch/save/rename).
-  // Three cases: (1) id unchanged → nothing; (2) same wf.key, id flipped tmp:→wf: →
+  // Four cases: (1) id unchanged → nothing; (2) same wf.key, id flipped tmp:→wf: →
   // ADOPT (migrate the temp thread to the file identity, keep the same session);
-  // (3) different id → SWITCH (re-hello + load that workflow's thread, or a fresh
-  // empty view if it has none).
+  // (2b) SAME workflow object, wf:→wf: id change → RENAME/Save-As (migrate the
+  // thread to the new path, keep the same session); (3) different id → SWITCH
+  // (re-hello + load that workflow's thread, or a fresh empty view if it has none).
   function rehelloForWorkflow(sessionId) {
     // Re-target the socket to the current workflow's tab id, then resume that
     // workflow's agent session. The backend drops the socket's prior tab mapping
@@ -9889,12 +9894,39 @@ function buildPanel() {
       if (wf && (wf.key || wf.id)) _tempWorkflowIds.delete(wf.key || wf.id);
       currentWorkflowId = wfid;
       currentWorkflowKey = wfkey;
+      currentWorkflowRef = wf;
       rehelloForWorkflow(t?.sessionId || null); // same session continues
+      return;
+    }
+
+    // Case 2b: RENAME / Save-As of an already-saved workflow. ComfyUI mutates the
+    // SAME object's path in place (instance identity survives; path and the derived
+    // .key getter change), so "same object, wf:→wf: id change" can only be a rename —
+    // a genuine switch always arrives on a different object. Without this branch the
+    // thread stays keyed to the OLD path and the renamed workflow opens a blank chat.
+    const renaming =
+      wf &&
+      wf === currentWorkflowRef &&
+      currentWorkflowId &&
+      currentWorkflowId.startsWith("wf:") &&
+      wfid.startsWith("wf:");
+    if (renaming) {
+      const t = threadForWorkflow(currentWorkflowId);
+      if (t) {
+        t.workflowKey = wfid; // thread follows the workflow to its new path
+        t.ts = Date.now(); // newest-wins lookup must favor the migrated thread over any stray
+        persistThreads();
+      }
+      currentWorkflowId = wfid;
+      currentWorkflowKey = wfkey;
+      currentWorkflowRef = wf;
+      rehelloForWorkflow(t?.sessionId || null); // same session continues under the new id
       return;
     }
 
     currentWorkflowId = wfid;
     currentWorkflowKey = wfkey;
+    currentWorkflowRef = wf;
     const existing = threadForWorkflow(wfid);
     // Bind THIS workflow's session BEFORE the re-hello. sendHello() reads
     // SESSION_KEY at hello time for its spawn-time `resume` — re-helloing first

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -601,6 +601,44 @@ function getTabId() {
   }
 }
 
+// --- Per-workflow agent identity -----------------------------------------
+// Each ComfyUI workflow gets its OWN agent session. Saved workflows key by file
+// path (stable across restarts → the conversation lives with the file). Unsaved
+// ones get a stable temp id for this app session (adopted into the file id on save,
+// see the workflow-change handler). Falls back to the legacy per-browser-session id
+// when no workflow service is present (headless / odd frontend).
+const _tempWorkflowIds = new Map(); // wf.key -> "tmp:<uuid>"
+// MODULE-scoped so they survive buildPanel re-mounts (the panel re-mounts on every
+// ComfyUI workflow switch). If these lived in the panel closure, each re-mount would
+// re-seed them to the now-current workflow and defeat change detection.
+let currentWorkflowId = null;
+let currentWorkflowKey = null;
+function activeWorkflowRef() {
+  try {
+    return (
+      window.comfyAPI?.app?.app?.extensionManager?.workflow?.activeWorkflow ||
+      (typeof app !== "undefined" && app?.extensionManager?.workflow?.activeWorkflow) ||
+      null
+    );
+  } catch {
+    return null;
+  }
+}
+function workflowTabId() {
+  const wf = activeWorkflowRef();
+  if (!wf) return getTabId();
+  const saved =
+    wf.isPersisted === true && wf.isTemporary !== true && typeof wf.path === "string" && wf.path;
+  if (saved) return "wf:" + wf.path;
+  const k = wf.key || wf.id || "unsaved";
+  let id = _tempWorkflowIds.get(k);
+  if (!id) {
+    id = "tmp:" + crypto.randomUUID();
+    _tempWorkflowIds.set(k, id);
+  }
+  return id;
+}
+
 // Per-tab agent session id + which thread this tab is showing. sessionStorage
 // is tab-scoped and survives reload — exactly what "restore the last session on
 // reload" needs, without two tabs clobbering each other.
@@ -3607,6 +3645,244 @@ const GRAPH_TOOL_EXECUTORS = {
     };
   },
 
+  // Domain-aware, READ-ONLY audit for Prompt Director. Correlates visible graph
+  // wiring/widgets with the node pack's sanitized runtime inspection registry.
+  // Recommendations are proposals only; the agent must ask before applying them.
+  async graph_prompt_director_audit() {
+    const { graph } = getGraphCtx();
+    const nodes = graph._nodes ?? [];
+    const isPromptDirector = (node) =>
+      String(node?.type ?? "").startsWith("PromptDirector") || node?.type === "PromptProducer";
+    const directorNodes = nodes.filter(isPromptDirector);
+    const widgetMap = (node) =>
+      Object.fromEntries((node.widgets ?? []).filter((w) => w?.name).map((w) => [w.name, w.value]));
+    const inputConnected = (node, name) => {
+      const input = (node.inputs ?? []).find((item) => item?.name === name);
+      return !!input && input.link != null;
+    };
+    const outputLinked = (node, name) => {
+      const output = (node.outputs ?? []).find((item) => item?.name === name);
+      return !!output && (output.links?.length ?? 0) > 0;
+    };
+    const observations = [];
+    const recommendations = [];
+    const addObservation = (severity, code, message, nodeId = null, evidence = {}) =>
+      observations.push({ severity, code, message, ...(nodeId != null ? { node_id: nodeId } : {}), evidence });
+    const proposeWidget = (node, widget, value, reason) =>
+      recommendations.push({
+        requires_confirmation: true,
+        reason,
+        change: { tool: "panel_set_widget", args: { node_id: node.id, widget, value } },
+      });
+
+    let runtimePayload = { inspections: [] };
+    try {
+      const response = await fetch("/prompt_director/inspection");
+      if (response.ok) runtimePayload = await response.json();
+      else addObservation("warning", "inspection_unavailable", `Prompt Director inspection returned HTTP ${response.status}.`);
+    } catch (error) {
+      addObservation("warning", "inspection_unavailable", String(error?.message ?? error));
+    }
+    const runtimeByNode = new Map(
+      (runtimePayload.inspections ?? []).map((item) => [String(item.node_id), item]),
+    );
+
+    const modelCandidates = [];
+    const loraLoaders = [];
+    const modelWidgetCategories = {
+      ckpt_name: "checkpoints",
+      checkpoint_name: "checkpoints",
+      unet_name: "diffusion_models",
+      diffusion_model: "diffusion_models",
+      diffusion_model_name: "diffusion_models",
+    };
+    for (const node of nodes) {
+      if (isPromptDirector(node)) continue;
+      const widgets = widgetMap(node);
+      for (const [name, value] of Object.entries(widgets)) {
+        if (typeof value !== "string" || !value.toLowerCase().endsWith(".safetensors")) continue;
+        if (name === "lora_name" || /lora/i.test(node.type)) {
+          const modelStrength = Number(widgets.strength_model ?? widgets.model_strength ?? 1);
+          const clipStrength = Number(widgets.strength_clip ?? widgets.clip_strength ?? 1);
+          loraLoaders.push({
+            node_id: node.id,
+            name: value,
+            strength_model: Number.isFinite(modelStrength) ? modelStrength : 1,
+            strength_clip: Number.isFinite(clipStrength) ? clipStrength : 1,
+          });
+          continue;
+        }
+        const category = modelWidgetCategories[name];
+        if (category) modelCandidates.push({ node_id: node.id, widget: name, category, name: value });
+      }
+    }
+
+    if (!directorNodes.length) {
+      addObservation("info", "prompt_director_not_present", "No Prompt Director nodes are present in the graph being viewed.");
+    }
+
+    for (const node of directorNodes) {
+      const widgets = widgetMap(node);
+      const runtime = runtimeByNode.get(String(node.id));
+      if (node.mode) {
+        addObservation(
+          "warning",
+          "node_not_active",
+          `${node.type} is ${node.mode === 4 ? "bypassed" : node.mode === 2 ? "muted" : `in mode ${node.mode}`}.`,
+          node.id,
+        );
+      }
+
+      if (["PromptDirector", "PromptDirectorAuto", "PromptProducer"].includes(node.type)) {
+        const outputName = node.type === "PromptProducer" ? "enhanced_prompt" : "final_prompt";
+        if (!outputLinked(node, outputName)) {
+          addObservation(
+            "warning",
+            "model_prompt_not_connected",
+            `${node.type}.${outputName} is not connected, so this node cannot affect the downstream model prompt.`,
+            node.id,
+          );
+        }
+      }
+
+      if (["PromptDirector", "PromptDirectorAuto", "PromptProducer", "PromptDirectorPromptEnhancer"].includes(node.type)) {
+        if (widgets.model_target === "auto" && !inputConnected(node, "context")) {
+          addObservation(
+            "warning",
+            "auto_target_without_context",
+            `${node.type} uses model_target=auto without a connected Prompt Director Context.`,
+            node.id,
+          );
+        }
+      }
+
+      if (node.type === "PromptDirectorAuto" && inputConnected(node, "image") && !inputConnected(node, "config")) {
+        addObservation(
+          "info",
+          "source_image_not_analyzed",
+          "Prompt Director Auto has a source image but no provider config, so it will compile deterministically without visual inspection.",
+          node.id,
+        );
+      }
+
+      if (node.type === "PromptDirectorResultCritic" && !inputConnected(node, "config")) {
+        addObservation(
+          "warning",
+          "critic_without_provider",
+          "Result Critic has no provider config and cannot perform a two-image visual comparison.",
+          node.id,
+        );
+      }
+
+      if (node.type === "PromptDirectorContext") {
+        const selected = String(widgets.model_asset ?? "none");
+        if (selected === "none" && modelCandidates.length === 1) {
+          const candidate = modelCandidates[0];
+          const value = `${candidate.category}/${candidate.name}`;
+          addObservation(
+            "warning",
+            "model_context_not_bound",
+            `The graph loads ${candidate.name}, but Prompt Director Context has no model selected.`,
+            node.id,
+            { loader_node_id: candidate.node_id, suggested_model_asset: value },
+          );
+          proposeWidget(node, "model_asset", value, `Bind Prompt Director Context to the only detected loaded model, ${candidate.name}.`);
+        } else if (selected !== "none" && modelCandidates.length) {
+          const selectedName = selected.split("/").slice(1).join("/");
+          if (!modelCandidates.some((candidate) => candidate.name === selectedName)) {
+            addObservation(
+              "warning",
+              "model_context_mismatch",
+              `Prompt Director Context selects ${selectedName}, but detected model loaders use ${modelCandidates.map((item) => item.name).join(", ")}.`,
+              node.id,
+            );
+          }
+        }
+
+        if (loraLoaders.length) {
+          let tracked = [];
+          try {
+            tracked = JSON.parse(String(widgets.lora_stack_json ?? "[]"));
+            if (!Array.isArray(tracked)) tracked = [];
+          } catch {
+            addObservation("warning", "invalid_lora_stack_json", "Prompt Director Context lora_stack_json is invalid JSON.", node.id);
+          }
+          const trackedNames = new Set(tracked.map((item) => (typeof item === "string" ? item : item?.name)).filter(Boolean));
+          const missing = loraLoaders.filter((item) => !trackedNames.has(item.name));
+          if (missing.length) {
+            const proposed = loraLoaders.map(({ name, strength_model, strength_clip }) => ({ name, strength_model, strength_clip }));
+            addObservation(
+              "warning",
+              "loaded_loras_missing_from_context",
+              `Loaded LoRAs are missing from Prompt Director Context: ${missing.map((item) => item.name).join(", ")}.`,
+              node.id,
+              { detected_loras: proposed },
+            );
+            proposeWidget(
+              node,
+              "lora_stack_json",
+              JSON.stringify(proposed),
+              "Mirror the detected LoRA loader names and actual model/CLIP strengths into Prompt Director Context.",
+            );
+          }
+        }
+      }
+
+      if (!runtime) {
+        addObservation(
+          "info",
+          "node_not_executed",
+          `${node.type} has no recorded runtime inspection yet; run its downstream output path before judging the compiled plan.`,
+          node.id,
+        );
+        continue;
+      }
+      const payload = runtime.payload ?? {};
+      for (const warning of payload.warnings ?? payload.critique?.warnings ?? []) {
+        addObservation("warning", "runtime_warning", String(warning), node.id);
+      }
+      const incompatible = (payload.context?.loras ?? []).filter((item) => item?.compatibility === "incompatible");
+      if (incompatible.length) {
+        addObservation(
+          "warning",
+          "incompatible_lora_runtime",
+          `Runtime context marks these LoRAs incompatible: ${incompatible.map((item) => item.name).join(", ")}.`,
+          node.id,
+        );
+      }
+      if (payload.context?.model && !incompatible.length && !(payload.warnings ?? []).some((item) => String(item).startsWith("model_"))) {
+        addObservation(
+          "info",
+          "model_context_valid",
+          `Resolved model context is coherent for ${payload.context.target_model ?? "the selected target"}.`,
+          node.id,
+        );
+      }
+      if (payload.critique?.verdict && !["acceptable", "pass", "approved"].includes(String(payload.critique.verdict).toLowerCase())) {
+        addObservation(
+          "warning",
+          "critic_requests_revision",
+          `Result Critic verdict: ${payload.critique.verdict}.`,
+          node.id,
+          { revised_prompt: payload.critique.revised_prompt ?? "", observations: payload.critique.observations ?? [] },
+        );
+      }
+    }
+
+    const severityRank = { warning: 0, info: 1 };
+    observations.sort((a, b) => (severityRank[a.severity] ?? 9) - (severityRank[b.severity] ?? 9));
+    return {
+      viewing: describeActiveGraph(graph),
+      prompt_director_node_count: directorNodes.length,
+      detected_models: modelCandidates,
+      detected_loras: loraLoaders,
+      runtime_inspections: runtimePayload.inspections ?? [],
+      observations,
+      recommendations,
+      changed: false,
+    };
+  },
+
   // Pinpoint nodes in the graph the user is viewing WITHOUT dumping the whole
   // thing. Searches EVERY node (not capped like graph_get_state), applies the
   // filters, and returns only matches — each the same rich summary as
@@ -5784,6 +6060,12 @@ function focusFollowOnCommand(cmd, msg, reply) {
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 15000;
 
+// Agent feed gates (persisted across reloads). MUTE = NO agent_event reaches any
+// agent (total silence). BLIND = agents still get the text/observation but never the
+// image pixels (ToS-safe: reason about the work without receiving the images).
+let AGENT_MUTED = (() => { try { return localStorage.getItem("cmcp.muteAgents") === "1"; } catch { return false; } })();
+let AGENT_BLIND = (() => { try { return localStorage.getItem("cmcp.blindAgents") === "1"; } catch { return false; } })();
+
 function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk, onSecret, onSecretSaved, onReload, onTodo, onShowMedia, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onBackends, onAck, onTurn, onTurnAnchor, getResume, getBackend, onHandshakeTimeout, onBridgeClosed, onPairUrl, onPairError }) {
   let sock = null;
   let url = loadBridgeUrl();
@@ -6141,7 +6423,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
       sock.send(
         JSON.stringify({
           type: "hello",
-          tab_id: getTabId(),
+          tab_id: workflowTabId(),
           title: getWorkflowTitle(),
           backend,
           ...(comfyuiUrl ? { comfyui_url: comfyuiUrl } : {}),
@@ -6166,7 +6448,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
     if (t === lastSentTitle) return;
     lastSentTitle = t;
     try {
-      sock.send(JSON.stringify({ type: "title", tab_id: getTabId(), title: t }));
+      sock.send(JSON.stringify({ type: "title", tab_id: workflowTabId(), title: t }));
     } catch {
       // dropped — next mutation retries
     }
@@ -6206,6 +6488,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
   }
 
   return {
+    // Public re-hello so the panel can re-target this socket to a new workflow's
+    // tab id (per-workflow sessions) without opening a second client.
+    rehello: sendHello,
     start() {
       closed = false;
       // A fresh connect intent (user Connect / sticky reconnect / respawn handoff)
@@ -6249,8 +6534,17 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
     /** Send an arbitrary control frame (set_options, new_session, …). */
     sendFrame(frame) {
       if (!sock || sock.readyState !== WebSocket.OPEN) return false;
+      // Mute/Blind gate — applies ONLY to agent-facing observations (agent_event);
+      // control frames (set_config, interrupt, secrets, hello, …) always pass.
+      if (frame && frame.type === "agent_event") {
+        if (AGENT_MUTED) return false;                     // total silence
+        if (AGENT_BLIND && "images" in frame) {            // keep the note, drop pixels
+          const { images: _drop, ...rest } = frame;
+          frame = rest;
+        }
+      }
       try {
-        sock.send(JSON.stringify({ tab_id: getTabId(), ...frame }));
+        sock.send(JSON.stringify({ tab_id: workflowTabId(), ...frame }));
         return true;
       } catch {
         return false;
@@ -7202,12 +7496,43 @@ function renderRichText(el, text) {
 // clean 1005 closes). Tracking the live client at module scope and tearing down
 // any prior one before creating a new one makes the storm structurally impossible.
 let liveBridgeClient = null;
+// (MDC's fork also proxied all client callbacks through a module-level
+// `panelSink` so the client could outlive panel re-mounts. Upstream's sidebar
+// KEEP-ALIVE already keeps buildPanel a page singleton whose root is detached/
+// reattached on tab switches, so the proxy layer is redundant here and was
+// dropped in the port — the singleton client + keep-alive provide the same
+// persistence. Per-workflow re-targeting rides client.rehello() instead.)
+// Auto-pick ("X isn't signed in — using Y") must fire at most once per PAGE, not
+// per mount — mount-local state re-armed it on every workflow switch and spammed
+// spurious fallbacks (e.g. to Ollama) off pre-orchestrator readiness data.
+let autoPickDone = false;
+// Providers the user turned OFF (chips hidden, never an auto-pick target).
+const DISABLED_BACKENDS_KEY = "comfyui-mcp.panel.disabledBackends";
+function disabledBackends() {
+  try { return new Set(JSON.parse(window.localStorage.getItem(DISABLED_BACKENDS_KEY) || "[]")); }
+  catch { return new Set(); }
+}
+function setBackendDisabled(id, off) {
+  const s = disabledBackends();
+  if (off) s.add(id); else s.delete(id);
+  try { window.localStorage.setItem(DISABLED_BACKENDS_KEY, JSON.stringify([...s])); } catch { /* session-only */ }
+}
+function backendEnabled(id) { return !disabledBackends().has(id); }
+
 
 function buildPanel() {
   ensureStyles();
 
   const root = document.createElement("div");
   root.className = "cmcp-root";
+  // A2UI seam (forward-compat, see spec): the chat surface width is a SINGLE piece
+  // of owned state, not scattered CSS, so a future A2UI layer can widen the surface
+  // (e.g. to show a diagram) and shrink it back. No-op visual default today.
+  root.style.setProperty("--cmcp-surface-width", "100%");
+  function cmcpSetChatSurface(mode) {
+    root.style.setProperty("--cmcp-surface-width", mode === "wide" ? "60%" : "100%");
+    root.dataset.surface = mode === "wide" ? "wide" : "normal";
+  }
   // Expose this panel's root so canvas "fit" can measure how much of the canvas
   // the open panel occludes and frame the graph in the visible area.
   activePanelRoot = root;
@@ -7392,6 +7717,11 @@ function buildPanel() {
         ? backends
         : [{ backend: "claude", running: false }];
     knownBackends = list;
+    // NOTE: paint EVERY provider here — no disabled-filter. This container is a
+    // detached DATA MIRROR (the model popup and switch paths rebuild the provider
+    // list from its chips), so filtering here would permanently drop a hidden
+    // provider from the round-trip and make it unrestorable. The user-visible
+    // on/off filter lives in ONE place: the model popup's Provider section.
     for (const b of list) {
       const id = b.backend;
       const chip = document.createElement("button");
@@ -7484,9 +7814,26 @@ function buildPanel() {
     cmcpOpenCredentialsFrame(client);
   });
 
+  // Opens the orchestrator's "edit every prompt" console page in a new tab. The
+  // page is same-origin to the console server, so its /api/prompts fetches need no
+  // CORS. Token travels as a query param, like the credentials console.
+  const promptsBtn = document.createElement("button");
+  promptsBtn.className = "cmcp-btn";
+  promptsBtn.type = "button";
+  promptsBtn.textContent = "Prompts";
+  promptsBtn.title = "Edit the agent's system prompts (persona, per-backend, Ask-AI)";
+  promptsBtn.style.opacity = "0.8";
+  promptsBtn.addEventListener("click", () => {
+    if (!cmcpConsoleUrl || !cmcpConsoleToken) {
+      alert("Connect the panel first — the prompt editor isn't available yet.");
+      return;
+    }
+    window.open(`${cmcpConsoleUrl}/prompts?token=${encodeURIComponent(cmcpConsoleToken)}`, "_blank", "noopener");
+  });
+
   const btnRow = document.createElement("div");
   btnRow.style.cssText = "display:flex;gap:0.375rem;align-items:center;flex-wrap:wrap;";
-  btnRow.append(connectBtn, disconnectBtn, saveBtn, apiKeysBtn);
+  btnRow.append(connectBtn, disconnectBtn, saveBtn, apiKeysBtn, promptsBtn);
 
   const helpDiv = document.createElement("div");
   helpDiv.className = "cmcp-help";
@@ -7622,7 +7969,8 @@ function buildPanel() {
     custom: { label: "Custom endpoint (any OpenAI-compatible)", install: "", login: "Set the base URL (and API key if needed) in Settings › Custom endpoint" },
   };
   let anyReady = false;
-  let autoPickDone = false; // auto-switch + note fires at most once per panel mount
+  // (autoPickDone is module-scoped now — once per PAGE, not per mount, so workflow
+  // switches can't re-arm the spurious provider fallback.)
   const onboard = document.createElement("div");
   onboard.className = "cmcp-onboard";
   onboard.hidden = true;
@@ -7733,9 +8081,9 @@ function buildPanel() {
     if (sel && sel.ready === false) {
       // Never auto-pick an experimental backend (b.experimental, e.g. Copilot) —
       // those must only become active via explicit user selection in the provider
-      // picker, not silently behind the user's back. (The fork also gates on its
-      // provider on/off toggle — that feature rides another port PR.)
-      const ready = list.find((b) => b.ready && !b.experimental);
+      // picker, not silently behind the user's back. Likewise never fall back to a
+      // provider the user turned OFF (chip hidden = not a target — see backendEnabled).
+      const ready = list.find((b) => b.ready && !b.experimental && backendEnabled(b.backend));
       if (ready) {
         autoPickDone = true;
         const prevLabel = BACKEND_LABELS[selectedBackend] || selectedBackend;
@@ -8326,6 +8674,10 @@ function buildPanel() {
       const activeBackend = connectedBackend || selectedBackend;
       for (const b of knownBackends) {
         const id = b.backend;
+        // A provider the user turned OFF is skipped entirely (and can never be an
+        // auto-pick fallback target — see applyReadiness). The ACTIVE provider
+        // always shows so you can't strand yourself. Restore via the row below.
+        if (!backendEnabled(id) && id !== activeBackend) continue;
         const hint = notReadyHint(b);
         const notReady = (backendReady[id] || b).ready === false;
         // A not-ready provider can't be connected — tapping it asks the working
@@ -8345,9 +8697,39 @@ function buildPanel() {
           }
         });
         // Experimental backends render tinted so the risk reads at a glance.
-        // (The fork's provider on/off ✕ / hidden-row UI rides its per-workflow
-        // sessions stack — not ported here.)
         if (b.experimental && row) row.style.color = "var(--p-orange-500,#f59e0b)";
+        // Provider on/off: a small always-visible ✕ that hides this provider from
+        // the panel (list + fallback). Not shown on the active provider.
+        if (id !== activeBackend && row) {
+          const off = document.createElement("i");
+          off.className = "pi pi-times";
+          off.title = `Hide ${BACKEND_LABELS[id] || id} — you don't use it. Restore it from the "hidden" row below.`;
+          off.style.cssText = "margin-left:0.4rem;opacity:0.4;cursor:pointer;font-size:0.7rem;flex:none;";
+          off.addEventListener("mousedown", (mev) => {
+            // Swallow the row's pick handler — this gesture only hides.
+            mev.preventDefault();
+            mev.stopPropagation();
+            setBackendDisabled(id, true);
+            buildModelPop(); // repaint in place so the row vanishes immediately
+          });
+          row.appendChild(off);
+        }
+      }
+      // Restore row: lists how many providers are hidden; one tap shows them all.
+      const hiddenIds = knownBackends.map((b) => b.backend).filter((id) => !backendEnabled(id) && id !== activeBackend);
+      if (hiddenIds.length) {
+        item(
+          {
+            label: `${hiddenIds.length} provider${hiddenIds.length === 1 ? "" : "s"} hidden`,
+            small: `${hiddenIds.map((id) => BACKEND_LABELS[id] || id).join(", ")} — tap to show`,
+            cls: "cmcp-provider",
+          },
+          false,
+          () => {
+            for (const id of hiddenIds) setBackendDisabled(id, false);
+            buildModelPop();
+          },
+        );
       }
     }
 
@@ -8516,7 +8898,33 @@ function buildPanel() {
   fileInput.multiple = true;
   fileInput.hidden = true;
 
-  row.append(ring, ctxLabel, modelChip, spacer, attachBtn, micBtn, sendBtn);
+  // ── Mute / Blind agent-feed toggles (next to the context ring) ────────────
+  const muteBtn = document.createElement("button");
+  muteBtn.type = "button";
+  muteBtn.title = "Mute agents — feed NOTHING to any agent (images, renders, observations)";
+  muteBtn.style.cssText = "background:none;border:none;cursor:pointer;font-size:13px;padding:0 1px";
+  const blindBtn = document.createElement("button");
+  blindBtn.type = "button";
+  blindBtn.title = "Blind agents — they still get text/results but NEVER image pixels (ToS-safe)";
+  blindBtn.style.cssText = "background:none;border:none;cursor:pointer;font-size:13px;padding:0 1px";
+  function reflectFeedGates() {
+    muteBtn.textContent = AGENT_MUTED ? "🔇" : "🔈";
+    muteBtn.style.opacity = AGENT_MUTED ? "1" : ".5";
+    muteBtn.style.animation = AGENT_MUTED ? "cmcp-pulse 1s ease-in-out infinite" : "none";
+    blindBtn.textContent = AGENT_BLIND ? "🙈" : "👁";
+    blindBtn.style.opacity = AGENT_BLIND ? "1" : ".5";
+    try {
+      const fg = ring.querySelector(".fg");
+      if (fg) fg.style.stroke = AGENT_MUTED ? "#e5484d" : "";
+      ring.style.animation = AGENT_MUTED ? "cmcp-pulse 1s ease-in-out infinite" : "none";
+    } catch {}
+  }
+  muteBtn.onclick = () => { AGENT_MUTED = !AGENT_MUTED; try { localStorage.setItem("cmcp.muteAgents", AGENT_MUTED ? "1" : "0"); } catch {} reflectFeedGates(); };
+  blindBtn.onclick = () => { AGENT_BLIND = !AGENT_BLIND; try { localStorage.setItem("cmcp.blindAgents", AGENT_BLIND ? "1" : "0"); } catch {} reflectFeedGates(); };
+  ring.style.cursor = "pointer"; ring.onclick = muteBtn.onclick; // clicking the ring toggles mute
+  reflectFeedGates();
+
+  row.append(ring, muteBtn, blindBtn, ctxLabel, modelChip, spacer, attachBtn, micBtn, sendBtn);
   form.append(menuPop, modelPop, attachBar, input, row, fileInput);
   root.appendChild(form);
 
@@ -8544,9 +8952,18 @@ function buildPanel() {
     }
   }
 
+  // Find the (single) thread bound to a workflow id, or null. One conversation per
+  // workflow: newest wins if duplicates ever exist.
+  function threadForWorkflow(wfid) {
+    for (let i = threads.length - 1; i >= 0; i--) {
+      if (threads[i].workflowKey === wfid) return threads[i];
+    }
+    return null;
+  }
+
   function record(entry) {
     if (!thread) {
-      thread = { id: crypto.randomUUID(), ts: Date.now(), msgs: [] };
+      thread = { id: crypto.randomUUID(), ts: Date.now(), msgs: [], workflowKey: workflowTabId() };
       // Adopt any session id the orchestrator has already reported for this tab.
       const sid = ssGet(SESSION_KEY);
       if (sid) thread.sessionId = sid;
@@ -9438,6 +9855,76 @@ function buildPanel() {
     else client?.sendFrame?.({ type: "new_session" });
   }
 
+  // Per-workflow auto-follow. Called on any workflow change (open/switch/save/rename).
+  // Three cases: (1) id unchanged → nothing; (2) same wf.key, id flipped tmp:→wf: →
+  // ADOPT (migrate the temp thread to the file identity, keep the same session);
+  // (3) different id → SWITCH (re-hello + load that workflow's thread, or a fresh
+  // empty view if it has none).
+  function rehelloForWorkflow(sessionId) {
+    // Re-target the socket to the current workflow's tab id, then resume that
+    // workflow's agent session. The backend drops the socket's prior tab mapping
+    // so a background workflow's output can't leak here.
+    try {
+      client?.rehello?.();
+      if (sessionId) client?.sendFrame?.({ type: "resume_session", session_id: sessionId });
+    } catch {
+      /* reconnect path retries the hello */
+    }
+  }
+  function onWorkflowMaybeChanged() {
+    const wf = activeWorkflowRef();
+    const wfid = workflowTabId();
+    const wfkey = wf ? (wf.key || wf.id || "unsaved") : null;
+    if (wfid === currentWorkflowId) return; // case 1: no change
+
+    const adopting =
+      currentWorkflowId &&
+      currentWorkflowKey &&
+      wfkey === currentWorkflowKey &&
+      currentWorkflowId.startsWith("tmp:") &&
+      wfid.startsWith("wf:");
+    if (adopting) {
+      const t = threadForWorkflow(currentWorkflowId);
+      if (t) { t.workflowKey = wfid; persistThreads(); } // migrate to the file identity
+      if (wf && (wf.key || wf.id)) _tempWorkflowIds.delete(wf.key || wf.id);
+      currentWorkflowId = wfid;
+      currentWorkflowKey = wfkey;
+      rehelloForWorkflow(t?.sessionId || null); // same session continues
+      return;
+    }
+
+    currentWorkflowId = wfid;
+    currentWorkflowKey = wfkey;
+    const existing = threadForWorkflow(wfid);
+    // Bind THIS workflow's session BEFORE the re-hello. sendHello() reads
+    // SESSION_KEY at hello time for its spawn-time `resume` — re-helloing first
+    // carried the PREVIOUS workflow's session id, so a fresh workspace's agent
+    // spawned as a resume-FORK of the other conversation (verbatim memory bleed
+    // across workspaces). Order is the whole fix.
+    ssSet(SESSION_KEY, existing?.sessionId || null);
+    rehelloForWorkflow(existing?.sessionId || null);
+    if (existing) {
+      loadThread(existing); // resets feed + repaints + resumes
+    } else {
+      thread = null; // fresh empty view; the thread is minted (tagged) on first message
+      ssSet(CURRENT_THREAD_KEY, null);
+      resetFeed();
+      // NOTE: no `new_session` frame here — SESSION_KEY was bound BEFORE the
+      // re-hello, so the hello already spawns a clean agent for this tab. Sending
+      // new_session too caused a rapid double-spawn (double greeting, and two
+      // concurrent Claude session starts that can race token refresh → 401s).
+      // Workspace awareness: ride a one-shot context on the FIRST message so the
+      // fresh agent knows exactly which workflow it serves (and that other
+      // workflows have their own separate conversations).
+      try {
+        client?.armContext?.(
+          `[Workspace context: this chat is dedicated to the ComfyUI workflow "${getWorkflowTitle()}". ` +
+          `Each workflow has its own separate agent conversation — other workflows are NOT in your context.]`,
+        );
+      } catch { /* armContext unavailable — awareness rides the title instead */ }
+    }
+  }
+
   function renderHistory() {
     histPop.textContent = "";
     const list = [...threads].reverse();
@@ -10079,6 +10566,44 @@ function buildPanel() {
   });
   // This is now THE live client for the page.
   liveBridgeClient = client;
+
+  // Per-workflow auto-follow. Sync to the current workflow's thread NOW (initial
+  // bind), then poll: under keep-alive the panel does NOT re-mount on a ComfyUI
+  // workflow switch, so the poll is what detects open/switch/save/rename and
+  // re-targets the client (re-hello + session swap) to the new workflow.
+  // (A <title> MutationObserver proved unreliable in MDC's fork — polling is the
+  // deliberate choice.)
+  onWorkflowMaybeChanged();
+  const _wfPoll = setInterval(() => onWorkflowMaybeChanged(), 600);
+
+  // Model Explorer "Ask AI" → open this chat and seed a rich metadata-curation
+  // brief so the agent investigates THIS model and proposes into the diff-review
+  // window (via its model_metadata tools). Reachable from the Model Explorer node.
+  window.cmcpAskAboutModel = (name, category) => {
+    // Force the chat tab to the front (closing whatever panel was open). A retry
+    // covers the case where the first activate lands before the tab store is ready.
+    try { openSidebarTab(); } catch { /* best effort */ }
+    setTimeout(() => { try { openSidebarTab(); } catch {} }, 120);
+    const cat = category || "loras";
+    const seed = [
+      `Let's curate the embedded metadata for the model file **${name}** (it lives in ComfyUI's \`${cat}\` folder). Work carefully — really look at THIS specific model and figure out the right answer; don't guess.`,
+      ``,
+      `Use your model_metadata tools:`,
+      `1. Call **model_metadata_read** { category: "${cat}", name: "${name}" } to pull its CURRENT embedded metadata (model_card + prompt_director), the read-only \`modelspec\`, and the top training tags (from ss_tag_frequency).`,
+      `2. If the embedded evidence is thin (empty model_card/prompt_director, no ss_tag_frequency) OR to flesh out details, call **model_metadata_fetch_civitai** { category, name } to pull the model's data from **Civitai (civitai.com** — adult models on civitai.red resolve through the same API): description, trainedWords, example prompts, tags. Treat it as RAW input — much of it is marketing fluff; distill it, and if any of it is wrong/junk, clean it up.`,
+      `3. Figure out what this model actually IS and does, and write a tight, factual \`semantic_intent\` + a practical \`prompt_guidance\`.`,
+      `4. Derive **trigger_tokens** from real evidence ONLY — and note the trigger is OFTEN NOT in \`trainedWords\` (frequently empty). **MINE THE EXAMPLE PROMPTS**: if every sample prompt starts with e.g. "photo in the style of redditya", the trigger is \`redditya\`. NEVER invent a trigger. Suggest strength (default_strength_model/clip, min/max) ONLY if a weight like \`<lora:name:0.8>\` actually appears in an example prompt; otherwise leave them blank.`,
+      `5. Push your proposal with **model_metadata_propose** { category, name, fields: { ... } }. That fills the review window on the right for me — it does NOT write the file. Include only fields you're confident about.`,
+      ``,
+      `Then tell me, in chat, what you found and what you changed and why. I'll review in the window, edit, and hit Confirm — so do NOT write anything yourself; \`model_metadata_propose\` is your only output. If I push back ("the prompt guidance is off", "focus on X", "that trigger's wrong"), revise and call model_metadata_propose again with the FULL field set.`,
+    ].join("\n");
+    try {
+      if (!liveBridgeClient?.sendUserMessage?.(seed)) {
+        console.warn("[cmcpAskAboutModel] chat not connected — connect the panel, then Ask AI again");
+      }
+    } catch (e) { console.warn("[cmcpAskAboutModel]", e); }
+  };
+
 
   // ---- ComfyUI execution events → image cards + agent awareness (#7) ----
   // When a run finishes with output images, show them in the chat and notify
@@ -12748,12 +13273,14 @@ function buildPanel() {
       markAgentSeen();
       scrollLog();
     },
+    setChatSurface: cmcpSetChatSurface, // A2UI seam: widen/restore the chat surface
     destroy() {
       try {
         recognition?.stop();
       } catch {
         // recognition already stopped
       }
+      clearInterval(_wfPoll); // stop per-workflow change polling on unmount
       document.removeEventListener("mousedown", onDocPointerDown, true);
       document.removeEventListener("keydown", onInterruptKeydown, true);
       document.removeEventListener("visibilitychange", onVisibilityChange);
@@ -12792,6 +13319,38 @@ function buildPanel() {
 // module eval so a not-yet-populated shim can't throw and deadlock the loader.
 // Defensive deferral contributed by @FreesoSaiFared (PR #2).
 // ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// Sidebar-tab overlap guard. ComfyUI renders every `type:"custom"` sidebar tab
+// into ONE shared host <div> and expects each tab's render() to replace its
+// contents. This panel appends its .cmcp-root rather than clearing, and other
+// extensions (e.g. ComfyUI-Easy-Use's NodesMap) render elsewhere and never touch
+// the shared host — so our panel stays painted when another tab is active and the
+// panels visibly stack. `activeSidebarTabId` is unreliable in this frontend build,
+// so we read the active tab from the DOM: the selected rail button carries
+// `side-bar-button-selected` plus a unique `<tabId>-tab-button` class. When our tab
+// isn't selected we remove our own root; render() rebuilds it on re-entry. We guard
+// only OUR root, never another tab's.
+function installSidebarTabGuard(tabId, getRoot) {
+  const activeTabId = () => {
+    const b = document.querySelector(".side-bar-button-selected");
+    if (!b) return null;
+    const t = [...b.classList].find((c) => c.endsWith("-tab-button"));
+    return t ? t.slice(0, -"-tab-button".length) : null;
+  };
+  const enforce = () => {
+    if (activeTabId() === tabId) return;             // our tab active → keep content
+    const r = getRoot();                              // inactive → drop our stray content
+    if (r && r.isConnected) r.remove();
+  };
+  const start = (tries = 0) => {
+    const toolbar = document.querySelector(".side-tool-bar-container");
+    if (!toolbar) { if (tries < 40) setTimeout(() => start(tries + 1), 250); return; }
+    new MutationObserver(enforce).observe(toolbar, { subtree: true, attributes: true, attributeFilter: ["class"] });
+    enforce();
+  };
+  start();
+}
+
 function registerExtensionWhenReady(tries = 0) {
   const comfyApp = window.comfyAPI?.app?.app || window.app;
   if (!comfyApp || typeof comfyApp.registerExtension !== "function") {
@@ -12856,6 +13415,7 @@ function registerExtensionWhenReady(tries = 0) {
       const mgr = app.extensionManager;
       if (mgr && typeof mgr.registerSidebarTab === "function") {
         mgr.registerSidebarTab(tabSpec);
+        installSidebarTabGuard(tabId, () => document.querySelector(".cmcp-root"));
       } else {
         console.error(
           "[comfyui-mcp-panel] app.extensionManager.registerSidebarTab is unavailable; " +


### PR DESCRIPTION
## What

Ports P-Stack B from the MichaelDanCurtis fork onto current main:

### Per-workflow agent sessions
- **`workflowTabId()` identity**: each ComfyUI workflow gets its OWN agent session. Saved workflows key by file path (`wf:<path>`, stable across restarts — the conversation lives with the file); unsaved ones get a stable `tmp:<uuid>` for the app session, **adopted** into the file id on save (same session continues).
- **Auto-follow**: a 600ms poll detects workflow open/switch/save/rename and re-targets the live socket via a public `client.rehello()` + `resume_session`, loading that workflow's thread (or a fresh view). `SESSION_KEY` is bound **before** the re-hello so a fresh workspace's agent can never spawn as a resume-fork of another workflow's conversation.
- **One-shot workspace context** armed on a fresh workflow's first message so the agent knows which workflow it serves.
- Threads carry a `workflowKey`; hello/title/frames all send the per-workflow tab id.

### Native credentials card ("API Keys")
- The connect box gains an **API Keys** button opening a native card (no iframe) that talks to the orchestrator's token-gated `GET/POST {consoleUrl}/api/secrets`. Values are write-only; only masked previews come back.
- The ComfyUI Settings-dialog "Set … token" buttons (OpenRouter, CivitAI, HuggingFace, custom endpoint) and their `tokenSetting`/`triggerSecret` plumbing are **removed** — credentials now have ONE surface. The agent-initiated masked `panel_request_secret` flow is untouched. Note: the custom-endpoint API key must be a slot in the server's credentials API (see pairing below).
- Also from this stack: a **Prompts** button (opens the orchestrator's prompt-editor console page).

### Provider on/off
- Each provider row in the model popup gets an always-visible ✕ to hide providers you don't use; a "N providers hidden" row restores them. Hidden providers are never auto-pick fallback targets. `autoPickDone` is module-scoped (once per page).

### Extras riding the same upstream commit
- `graph_prompt_director_audit` read-only executor, mute/blind agent-feed gates (🔇/🙈), A2UI chat-surface seam, sidebar-tab overlap guard, Model Explorer "Ask AI" hook, and `scripts/verify-per-workflow.mjs` (Playwright smoke harness for the per-workflow behavior — needs a live ComfyUI).

## Server halves (DUAL pairing)

- Per-workflow session frames pair with comfyui-mcp PR **`feat/per-workflow-sessions`** (workflow-target-store).
- The credentials card pairs with comfyui-mcp PR **`feat/panel-console-credentials`** (`/api/secrets` + CORS).

Frame names/shapes (`hello` tab_id, `resume_session`, `/api/secrets` GET/POST `{slot, value}` → `{ok, masked, slots}`) are kept exactly as in the fork.

## Reconciliation vs upstream keep-alive (what was dropped)

Upstream main (0.7.3) made `buildPanel()` a page singleton: the sidebar tab's render()/destroy() detach/reattach `mounted.root`, and `liveBridgeClient` already persists the ONE socket across tab switches. MDC's fork solved the same problem with a **persistent-client proxy layer** (`panelSink` callback proxies + reuse-on-remount branch) because his base re-mounted the panel per workflow switch. That layer is **redundant** under keep-alive and was **dropped in this port**:

- No `panelSink` / proxy callbacks / client-reuse branch — the upstream teardown-then-create singleton and `destroy()` semantics are kept verbatim.
- Per-workflow re-targeting rides `client.rehello()` + the poll instead; the poll is now the sole switch detector (keep-alive means no re-mount ever fires it).
- Upstream's `onShow()` (keep-alive scroll/badge landing), orchestrator-owned session resume keys (MID_TASK/SOFT_RELOAD/REBOOT), pairing callbacks (`onPairUrl`/`onPairError`), and the `fromOrchestrator` readiness gate are all preserved; MDC's readiness gate and no-fallback-to-hidden-provider rule compose on top.

## Tests

- `node --check` on the panel as `.mjs`: PASS
- `npm run test:unit`: 12/12 PASS
- `npx playwright test --list`: 13 tests in 7 files enumerate
- `scripts/verify-per-workflow.mjs` reviewed — sane (matches `comfyui-mcp.panel.threads` / `workflowKey` shapes); needs a live ComfyUI to execute.

## Credit

Ported from MichaelDanCurtis/comfyui-mcp-panel (ef5e019, 5c15492) with thanks — authorship preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)