### PR TITLE
fix(discord): replace expired invite with the permanent link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 **An autonomous AI agent embedded in the ComfyUI sidebar that drives your canvas — now on EITHER
 Claude or ChatGPT (your own subscription, no API key).**
 
-[![Deploy on RunPod](https://img.shields.io/badge/Deploy_on-RunPod-673AB7?style=for-the-badge)](https://console.runpod.io/deploy?template=bnqtkvcer3&ref=dkx71w9b) [![Join the Discord](https://img.shields.io/badge/Discord-Join_%26_get_help-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/TtQpf96BHS) &nbsp;**One-click GPU pod** — a ready-to-run ComfyUI with this panel + [comfyui-mcp](https://github.com/artokun/comfyui-mcp) + ComfyUI-Manager v2 preinstalled, on your own GPU. No setup.
+[![Deploy on RunPod](https://img.shields.io/badge/Deploy_on-RunPod-673AB7?style=for-the-badge)](https://console.runpod.io/deploy?template=bnqtkvcer3&ref=dkx71w9b) [![Join the Discord](https://img.shields.io/badge/Discord-Join_%26_get_help-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.gg/cW9arBhzCu) &nbsp;**One-click GPU pod** — a ready-to-run ComfyUI with this panel + [comfyui-mcp](https://github.com/artokun/comfyui-mcp) + ComfyUI-Manager v2 preinstalled, on your own GPU. No setup.
 
-**Stuck or have a question? [Join the Discord](https://discord.gg/TtQpf96BHS)** — or hit **🆘 Need help?** in the panel's Settings → About (it copies a diagnostics summary and opens the Discord for you).
+**Stuck or have a question? [Join the Discord](https://discord.gg/cW9arBhzCu)** — or hit **🆘 Need help?** in the panel's Settings → About (it copies a diagnostics summary and opens the Discord for you).
 
 Pick a provider — **Claude** or **ChatGPT** — and the matching agent runs in the background on
 *your* subscription, sees the graph you're looking at, and edits it live. Both providers reach

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = ["Operating System :: OS Independent"]
 Repository = "https://github.com/artokun/comfyui-mcp-panel"
 Documentation = "https://comfyui-mcp.artokun.io/docs"
 "Bug Tracker" = "https://github.com/artokun/comfyui-mcp-panel/issues"
-Discord = "https://discord.gg/TtQpf96BHS"
+Discord = "https://discord.gg/cW9arBhzCu"
 
 [tool.comfy]
 PublisherId = "artokun"

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -92,7 +92,7 @@ function setupListeners() {
 
 // Community + support. The Discord is the one-tap "I'm stuck" channel surfaced
 // in Settings → About (Join + Need help buttons) and linked from the README.
-const DISCORD_INVITE_URL = "https://discord.gg/TtQpf96BHS";
+const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.


### PR DESCRIPTION
`discord.gg/TtQpf96BHS` had **expired** (invalid-invite error on click). Swaps to the **non-expiring** `discord.gg/cW9arBhzCu` (same server — "ComfyUI MCP + Panel", verified via the Discord API) in:
- `web/js/comfyui-mcp-panel.js` — the panel's **"Join the Discord" button** (what users actually click)
- `README.md` — badge + help line
- `pyproject.toml` — the Discord URL shown on the Comfy Registry listing

⚠️ **Merging this triggers `publish_action.yml`** (pyproject path filter) → a Comfy Registry publish. Since the version isn't bumped, that would try to republish the current version. **Hold the merge** until you decide whether to cut a panel patch release (bump version) so the fix reaches live panel users + the registry, or keep this repo-only for the next release.