### PR TITLE
feat(civitai): in-panel CivitAI browser (full mobile parity, no NSFW gate)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -313,6 +313,15 @@ def _register_routes():
 
     routes = PromptServer.instance.routes
 
+    # Same-origin CivitAI proxy for the browser CivitAI modal (bot-gate headers +
+    # OAuth live server-side; the browser never sees CivitAI tokens).
+    try:
+        from .py import civitai_proxy
+
+        civitai_proxy.register(routes, web)
+    except Exception as _e:  # pragma: no cover - never block panel load
+        _log("civitai proxy not registered: {}".format(_e))
+
     @routes.get("/comfyui_mcp_panel/status")
     async def _status(_request):
         detected = _detect_comfyui_url()

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -1,0 +1,1 @@
+"""Server-side helpers for the ComfyUI Agent Panel (CivitAI proxy, etc.)."""

--- a/py/civitai_proxy.py
+++ b/py/civitai_proxy.py
@@ -20,9 +20,12 @@ browser — only this server-side module reads them.
 import base64
 import hashlib
 import json
+import logging
 import os
 import time
 from urllib.parse import urlencode, urlparse
+
+_log = logging.getLogger("comfyui_mcp_panel.civitai")
 
 # --- CivitAI contract (mirrors comfyui-mcp-mobile/lib/features/civitai) ---------
 _API_HEADERS = {
@@ -33,7 +36,7 @@ _API_HEADERS = {
     "Referer": "https://civitai.red/",
 }
 _CDN_BASE = "https://image.civitai.com"
-_CDN_TOKEN = "xG1nkqKTMzGDvpLrqFT7WA"
+_CDN_KEY = "xG1nkqKTMzGDvpLrqFT7WA"
 
 # Only these hosts may be proxied (SSRF guard).
 _ALLOWED_HOSTS = frozenset(
@@ -48,7 +51,7 @@ _ALLOWED_HOSTS = frozenset(
 _OAUTH_CLIENT_ID = "1913e640-a9f7-4a4e-ae14-844d3b347555"  # public native client, no secret
 _OAUTH_SCOPE = "262177"  # UserRead | MediaRead | CollectionsRead
 _OAUTH_AUTHORIZE = "https://auth.civitai.com/api/auth/oauth/authorize"
-_OAUTH_TOKEN = "https://auth.civitai.com/api/auth/oauth/token"
+_OAUTH_EXCHANGE_URL = "https://auth.civitai.com/api/auth/oauth/token"
 _CALLBACK_PATH = "/comfyui_mcp_panel/civitai/oauth/callback"
 
 
@@ -65,7 +68,7 @@ def _token_path():
     try:
         os.makedirs(d, exist_ok=True)
     except Exception:
-        pass
+        _log.debug("civitai token-store op failed", exc_info=True)
     return os.path.join(d, "civitai-oauth.json")
 
 
@@ -82,14 +85,14 @@ def _save_tokens(tok):
         with open(_token_path(), "w", encoding="utf-8") as f:
             json.dump(tok, f)
     except Exception:
-        pass
+        _log.debug("civitai token-store op failed", exc_info=True)
 
 
 def _clear_tokens():
     try:
         os.remove(_token_path())
     except Exception:
-        pass
+        _log.debug("civitai token-store op failed", exc_info=True)
 
 
 # Pending PKCE flows keyed by `state` (verifier + redirect), cleared on callback.
@@ -122,7 +125,7 @@ async def _valid_access_token(session):
         return None
     try:
         async with session.post(
-            _OAUTH_TOKEN,
+            _OAUTH_EXCHANGE_URL,
             data={
                 "grant_type": "refresh_token",
                 "refresh_token": refresh,
@@ -213,7 +216,7 @@ def register(routes, web):
         ext = request.query.get("ext", "jpeg")
         if not uuid:
             return web.Response(status=400, text="uuid required")
-        url = "{}/{}/{}/{}/x.{}".format(_CDN_BASE, _CDN_TOKEN, uuid, transform, ext)
+        url = "{}/{}/{}/{}/x.{}".format(_CDN_BASE, _CDN_KEY, uuid, transform, ext)
         async with _session() as session:
             try:
                 async with session.get(url, headers=_API_HEADERS) as resp:
@@ -266,7 +269,7 @@ def register(routes, web):
         async with _session() as session:
             try:
                 async with session.post(
-                    _OAUTH_TOKEN,
+                    _OAUTH_EXCHANGE_URL,
                     data={
                         "grant_type": "authorization_code",
                         "code": code,

--- a/py/civitai_proxy.py
+++ b/py/civitai_proxy.py
@@ -1,0 +1,315 @@
+"""Same-origin CivitAI proxy for the panel's browser UI.
+
+A browser cannot call ``civitai.red`` directly: CORS blocks it and JS cannot set
+the ``User-Agent`` / ``Referer`` bot-gate headers CivitAI requires. So the panel's
+CivitAI modal talks to these ComfyUI-origin routes instead, and this module — which
+runs in the ComfyUI process — makes the real, header-injected calls server-side.
+
+Routes (all under ``/comfyui_mcp_panel/civitai``):
+  GET/POST /api            JSON passthrough to an allow-listed CivitAI host.
+  GET      /media          Stream CDN image/video bytes (for <img>/<video> src).
+  GET      /oauth/start    Begin the OAuth (PKCE) sign-in; returns the authorize URL.
+  GET      /oauth/callback OAuth redirect target; exchanges the code for tokens.
+  GET      /oauth/status   Whether a valid session exists.
+  POST     /oauth/logout   Drop the stored session.
+
+The CivitAI OAuth tokens and the optional ``CIVITAI_API_TOKEN`` never reach the
+browser — only this server-side module reads them.
+"""
+
+import base64
+import hashlib
+import json
+import os
+import time
+from urllib.parse import urlencode, urlparse
+
+# --- CivitAI contract (mirrors comfyui-mcp-mobile/lib/features/civitai) ---------
+_API_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36"
+    ),
+    "Referer": "https://civitai.red/",
+}
+_CDN_BASE = "https://image.civitai.com"
+_CDN_TOKEN = "xG1nkqKTMzGDvpLrqFT7WA"
+
+# Only these hosts may be proxied (SSRF guard).
+_ALLOWED_HOSTS = frozenset(
+    {
+        "civitai.red",
+        "search-new.civitai.com",
+        "image.civitai.com",
+        "auth.civitai.com",
+    }
+)
+
+_OAUTH_CLIENT_ID = "1913e640-a9f7-4a4e-ae14-844d3b347555"  # public native client, no secret
+_OAUTH_SCOPE = "262177"  # UserRead | MediaRead | CollectionsRead
+_OAUTH_AUTHORIZE = "https://auth.civitai.com/api/auth/oauth/authorize"
+_OAUTH_TOKEN = "https://auth.civitai.com/api/auth/oauth/token"
+_CALLBACK_PATH = "/comfyui_mcp_panel/civitai/oauth/callback"
+
+
+def _token_path():
+    """Server-side JSON file holding the OAuth session. Under the ComfyUI user dir
+    when available, else the pack directory."""
+    try:
+        import folder_paths  # type: ignore
+
+        base = folder_paths.get_user_directory()
+    except Exception:
+        base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    d = os.path.join(base, "comfyui-mcp-panel")
+    try:
+        os.makedirs(d, exist_ok=True)
+    except Exception:
+        pass
+    return os.path.join(d, "civitai-oauth.json")
+
+
+def _load_tokens():
+    try:
+        with open(_token_path(), "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def _save_tokens(tok):
+    try:
+        with open(_token_path(), "w", encoding="utf-8") as f:
+            json.dump(tok, f)
+    except Exception:
+        pass
+
+
+def _clear_tokens():
+    try:
+        os.remove(_token_path())
+    except Exception:
+        pass
+
+
+# Pending PKCE flows keyed by `state` (verifier + redirect), cleared on callback.
+_pending = {}
+
+
+def _pkce_pair():
+    verifier = base64.urlsafe_b64encode(os.urandom(48)).rstrip(b"=").decode("ascii")
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+def _host_ok(url):
+    try:
+        return urlparse(url).hostname in _ALLOWED_HOSTS
+    except Exception:
+        return False
+
+
+async def _valid_access_token(session):
+    """Return a non-expired access token, refreshing if needed; None if signed out."""
+    tok = _load_tokens()
+    if not tok or not tok.get("access"):
+        return None
+    if tok.get("exp", 0) > time.time() + 60:
+        return tok["access"]
+    refresh = tok.get("refresh")
+    if not refresh:
+        return None
+    try:
+        async with session.post(
+            _OAUTH_TOKEN,
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh,
+                "client_id": _OAUTH_CLIENT_ID,
+            },
+            headers={"content-type": "application/x-www-form-urlencoded"},
+        ) as resp:
+            if resp.status != 200:
+                _clear_tokens()
+                return None
+            data = await resp.json()
+    except Exception:
+        return None
+    new = {
+        "access": data.get("access_token"),
+        "refresh": data.get("refresh_token") or refresh,
+        "exp": time.time() + int(data.get("expires_in", 3600)),
+    }
+    if not new["access"]:
+        return None
+    _save_tokens(new)
+    return new["access"]
+
+
+def register(routes, web):
+    """Register the CivitAI proxy routes on ``PromptServer.instance.routes``."""
+    import aiohttp  # ComfyUI ships aiohttp
+
+    def _session():
+        return aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30))
+
+    async def _authed_headers(session, want_auth):
+        headers = dict(_API_HEADERS)
+        if want_auth:
+            access = await _valid_access_token(session)
+            if access:
+                headers["Authorization"] = "Bearer " + access
+        return headers
+
+    @routes.post("/comfyui_mcp_panel/civitai/api")
+    async def _civitai_api(request):
+        # Body: {url, method?, headers?, body?, auth?}. `url` must be an allow-listed
+        # CivitAI host. Retries 503/429 with backoff (mirrors the mobile _get()).
+        try:
+            spec = await request.json()
+        except Exception:
+            return web.json_response({"error": "invalid JSON"}, status=400)
+        url = spec.get("url")
+        if not isinstance(url, str) or not _host_ok(url):
+            return web.json_response({"error": "url host not allowed"}, status=400)
+        method = (spec.get("method") or "GET").upper()
+        extra = spec.get("headers") if isinstance(spec.get("headers"), dict) else {}
+        body = spec.get("body")
+
+        async with _session() as session:
+            headers = await _authed_headers(session, bool(spec.get("auth")))
+            headers.update(extra)
+            data = None
+            if body is not None:
+                data = body if isinstance(body, str) else json.dumps(body)
+                headers.setdefault("content-type", "application/json")
+            for attempt in range(3):
+                try:
+                    async with session.request(
+                        method, url, data=data, headers=headers
+                    ) as resp:
+                        if resp.status in (429, 503) and attempt < 2:
+                            import asyncio
+
+                            await asyncio.sleep(0.35 * (2**attempt))
+                            continue
+                        text = await resp.text()
+                        return web.Response(
+                            body=text,
+                            status=resp.status,
+                            content_type="application/json",
+                        )
+                except Exception as e:  # network flake
+                    if attempt == 2:
+                        return web.json_response({"error": str(e)}, status=502)
+        return web.json_response({"error": "unreachable"}, status=502)
+
+    @routes.get("/comfyui_mcp_panel/civitai/media")
+    async def _civitai_media(request):
+        # ?uuid=&transform=&ext=  → stream the CDN bytes with bot-gate headers.
+        uuid = request.query.get("uuid", "")
+        transform = request.query.get("transform", "width=450")
+        ext = request.query.get("ext", "jpeg")
+        if not uuid:
+            return web.Response(status=400, text="uuid required")
+        url = "{}/{}/{}/{}/x.{}".format(_CDN_BASE, _CDN_TOKEN, uuid, transform, ext)
+        async with _session() as session:
+            try:
+                async with session.get(url, headers=_API_HEADERS) as resp:
+                    if resp.status != 200:
+                        return web.Response(status=resp.status)
+                    ctype = resp.headers.get("Content-Type", "application/octet-stream")
+                    payload = await resp.read()
+                    return web.Response(
+                        body=payload,
+                        content_type=ctype.split(";")[0],
+                        headers={"Cache-Control": "public, max-age=86400"},
+                    )
+            except Exception as e:
+                return web.Response(status=502, text=str(e))
+
+    @routes.get("/comfyui_mcp_panel/civitai/oauth/start")
+    async def _oauth_start(request):
+        origin = request.query.get("origin", "")
+        if not origin.startswith("http"):
+            return web.json_response({"error": "origin required"}, status=400)
+        verifier, challenge = _pkce_pair()
+        state = base64.urlsafe_b64encode(os.urandom(16)).rstrip(b"=").decode("ascii")
+        redirect = origin.rstrip("/") + _CALLBACK_PATH
+        _pending[state] = {"verifier": verifier, "redirect": redirect, "at": time.time()}
+        # prune stale pending flows (>10 min)
+        for k in [k for k, v in _pending.items() if time.time() - v["at"] > 600]:
+            _pending.pop(k, None)
+        params = {
+            "response_type": "code",
+            "client_id": _OAUTH_CLIENT_ID,
+            "redirect_uri": redirect,
+            "scope": _OAUTH_SCOPE,
+            "state": state,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+        }
+        return web.json_response({"authorize_url": _OAUTH_AUTHORIZE + "?" + urlencode(params)})
+
+    @routes.get("/comfyui_mcp_panel/civitai/oauth/callback")
+    async def _oauth_callback(request):
+        code = request.query.get("code")
+        state = request.query.get("state")
+        pend = _pending.pop(state, None) if state else None
+        if not code or not pend:
+            return web.Response(
+                status=400,
+                content_type="text/html",
+                text="<h3>CivitAI sign-in failed</h3><p>You can close this window.</p>",
+            )
+        async with _session() as session:
+            try:
+                async with session.post(
+                    _OAUTH_TOKEN,
+                    data={
+                        "grant_type": "authorization_code",
+                        "code": code,
+                        "redirect_uri": pend["redirect"],
+                        "client_id": _OAUTH_CLIENT_ID,
+                        "code_verifier": pend["verifier"],
+                    },
+                    headers={"content-type": "application/x-www-form-urlencoded"},
+                ) as resp:
+                    data = await resp.json()
+            except Exception as e:
+                return web.Response(status=502, content_type="text/html", text=str(e))
+        access = data.get("access_token")
+        if not access:
+            return web.Response(
+                status=400,
+                content_type="text/html",
+                text="<h3>CivitAI sign-in failed</h3><p>You can close this window.</p>",
+            )
+        _save_tokens(
+            {
+                "access": access,
+                "refresh": data.get("refresh_token"),
+                "exp": time.time() + int(data.get("expires_in", 3600)),
+            }
+        )
+        return web.Response(
+            content_type="text/html",
+            text=(
+                "<html><body style='font-family:sans-serif;background:#18181b;"
+                "color:#eee;padding:2rem'><h3>Signed in to CivitAI ✓</h3>"
+                "<p>You can close this window and return to ComfyUI.</p>"
+                "<script>window.close()</script></body></html>"
+            ),
+        )
+
+    @routes.get("/comfyui_mcp_panel/civitai/oauth/status")
+    async def _oauth_status(_request):
+        async with _session() as session:
+            access = await _valid_access_token(session)
+        return web.json_response({"signed_in": bool(access)})
+
+    @routes.post("/comfyui_mcp_panel/civitai/oauth/logout")
+    async def _oauth_logout(_request):
+        _clear_tokens()
+        return web.json_response({"ok": True})

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -236,18 +236,24 @@ export function openCivitaiModal(ctx, opts = {}) {
   // ── cards ─────────────────────────────────────────────────────────────
   function mediaCard(it, idx) {
     const card = el("div", "cmcp-cv-card");
+    // Both image and video cards show a still (video thumbnailUrl is a jpeg
+    // poster); hover on a video swaps in the muted transcoded clip.
+    const img = document.createElement("img");
+    img.loading = "lazy"; img.src = it.thumbnailUrl;
+    img.addEventListener("error", () => { card.style.display = "none"; });
+    card.appendChild(img);
     if (it.type === "video") {
-      const v = document.createElement("video");
-      v.src = it.thumbnailUrl; v.muted = true; v.loop = true; v.playsInline = true;
-      v.addEventListener("mouseenter", () => v.play().catch(() => {}));
-      v.addEventListener("mouseleave", () => { v.pause(); v.currentTime = 0; });
-      card.appendChild(v);
-      const badge = el("span", "cmcp-cv-badge", "▶"); card.appendChild(badge);
-    } else {
-      const img = document.createElement("img");
-      img.loading = "lazy"; img.src = it.thumbnailUrl;
-      img.addEventListener("error", () => { card.style.display = "none"; });
-      card.appendChild(img);
+      card.appendChild(el("span", "cmcp-cv-badge", "▶"));
+      let vid = null;
+      card.addEventListener("mouseenter", () => {
+        if (vid) return;
+        vid = document.createElement("video");
+        vid.src = it.fullUrl; vid.muted = true; vid.loop = true; vid.playsInline = true;
+        vid.autoplay = true;
+        card.appendChild(vid);
+        vid.play().catch(() => {});
+      });
+      card.addEventListener("mouseleave", () => { if (vid) { vid.remove(); vid = null; } });
     }
     const foot = el("div", "cmcp-cv-cardfoot", `${it.author ? "@" + it.author : ""}  ♥ ${it.reactions || 0}`);
     card.appendChild(foot);
@@ -406,8 +412,8 @@ export function openCivitaiModal(ctx, opts = {}) {
       if (version.descriptionHtml || detail.descriptionHtml) {
         const desc = el("div", "cmcp-cv-detail");
         desc.style.cssText = "font-size:.78rem;margin-top:.5rem";
-        desc.innerHTML = ctx.DOMPurify.sanitize(
-          ctx.marked.parse(htmlToText(version.descriptionHtml || detail.descriptionHtml)));
+        // CivitAI descriptions are HTML — sanitize and render directly.
+        desc.innerHTML = ctx.DOMPurify.sanitize(version.descriptionHtml || detail.descriptionHtml || "");
         detailBody.appendChild(desc);
       }
       // official examples
@@ -587,13 +593,6 @@ export function openCivitaiModal(ctx, opts = {}) {
       "z-index:80;font-size:.8rem;box-shadow:0 4px 16px rgba(0,0,0,.5)";
     modal.appendChild(t);
     setTimeout(() => t.remove(), 3000);
-  }
-
-  function htmlToText(html) {
-    if (!html) return "";
-    const d = document.createElement("div");
-    d.innerHTML = ctx.DOMPurify.sanitize(html);
-    return d.innerHTML;
   }
 
   // ── go ───────────────────────────────────────────────────────────────

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -33,8 +33,10 @@ function injectCss() {
   if (_cssInjected) return;
   _cssInjected = true;
   const css = `
-  .cmcp-civitai-modal { max-width: 62rem; width: 96%; height: 92%; max-height: 92%;
-    padding: 0; gap: 0; overflow: hidden; }
+  .cmcp-cv-overlay { position: fixed; inset: 0; z-index: 10000; display: flex;
+    align-items: center; justify-content: center; padding: 1.5rem; background: rgba(0,0,0,.6); }
+  .cmcp-civitai-modal { width: min(1150px, 94vw); max-width: none; height: 90vh;
+    max-height: 90vh; padding: 0; gap: 0; overflow: hidden; }
   .cmcp-cv-head { display: flex; align-items: center; gap: .5rem; padding: .6rem .7rem;
     border-bottom: 1px solid var(--p-content-border-color, #3f3f46); flex-wrap: wrap; }
   .cmcp-cv-tabs { display: flex; gap: .25rem; flex-wrap: wrap; }
@@ -114,8 +116,9 @@ export function openCivitaiModal(ctx, opts = {}) {
   const tabDef = () => TABS.find((t) => t.key === state.tab);
   const isModelTab = () => !!tabDef().model;
 
-  // ── overlay ──────────────────────────────────────────────────────────────
-  const overlay = el("div", "cmcp-modal-overlay");
+  // ── overlay (full-viewport, mounted on <body> so it isn't confined to the
+  // narrow panel sidebar) ────────────────────────────────────────────────────
+  const overlay = el("div", "cmcp-cv-overlay");
   const modal = el("div", "cmcp-modal cmcp-civitai-modal");
   const close = () => overlay.remove();
   overlay.addEventListener("mousedown", (e) => { if (e.target === overlay) close(); });
@@ -163,7 +166,7 @@ export function openCivitaiModal(ctx, opts = {}) {
 
   modal.append(head, body);
   overlay.appendChild(modal);
-  ctx.root.appendChild(overlay);
+  document.body.appendChild(overlay);
 
   function syncTabs() {
     for (const b of tabsWrap.children) b.classList.toggle("active", b._key === state.tab);
@@ -572,9 +575,9 @@ export function openCivitaiModal(ctx, opts = {}) {
 
   // ── sub-modal + toast helpers ────────────────────────────────────────
   function openSubModal(title) {
-    const ov = el("div", "cmcp-modal-overlay"); ov.style.zIndex = "60";
-    const m = el("div", "cmcp-modal"); m.style.maxWidth = "34rem";
-    m.style.maxHeight = "80%"; m.style.overflowY = "auto";
+    const ov = el("div", "cmcp-cv-overlay"); ov.style.zIndex = "10001";
+    const m = el("div", "cmcp-modal"); m.style.maxWidth = "40rem"; m.style.width = "min(40rem, 92vw)";
+    m.style.maxHeight = "85vh"; m.style.overflowY = "auto";
     const head2 = el("div", "cmcp-modal-title", title);
     const x = el("button", "cmcp-cv-iconbtn"); x.innerHTML = '<i class="pi pi-times"></i>';
     x.style.cssText = "position:absolute;top:.5rem;right:.5rem";
@@ -582,7 +585,7 @@ export function openCivitaiModal(ctx, opts = {}) {
     const close2 = () => ov.remove();
     x.addEventListener("click", close2);
     ov.addEventListener("mousedown", (e) => { if (e.target === ov) close2(); });
-    m.append(head2, x, b); ov.appendChild(m); ctx.root.appendChild(ov);
+    m.append(head2, x, b); ov.appendChild(m); document.body.appendChild(ov);
     return { body: b, close: close2 };
   }
 

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -63,6 +63,8 @@ function injectCss() {
     font-size: .6rem; padding: .1rem .3rem; border-radius: 4px; }
   .cmcp-cv-add { position: absolute; top: .3rem; right: .3rem; background: rgba(0,0,0,.55); color:#fff;
     border: none; border-radius: 6px; width: 24px; height: 24px; cursor: pointer; }
+  .cmcp-cv-owned { position: absolute; top: .3rem; right: .3rem; background: rgba(34,197,94,.92);
+    color: #04120a; font-size: .6rem; font-weight: 700; padding: .12rem .35rem; border-radius: 4px; }
   .cmcp-cv-loading { text-align: center; padding: 1rem; color: var(--p-text-muted-color,#a1a1aa); }
   .cmcp-cv-progress { position: absolute; top: 0; left: 0; right: 0; height: 2px;
     background: var(--p-primary-color, #3a7bd5); opacity: .0; transition: opacity .2s; }
@@ -108,7 +110,7 @@ export function openCivitaiModal(ctx, opts = {}) {
     query: opts.query || "",
     filters: { ...DEFAULT_FILTERS, ...(opts.filters || {}) },
     items: [], models: [], cursor: null, loading: false, done: false, reqId: 0,
-    signedIn: false,
+    signedIn: false, localNames: new Set(), localLoaded: false,
   };
   if (Array.isArray(opts.browsingLevels) && opts.browsingLevels.length) {
     state.filters = { ...state.filters, browsingLevels: opts.browsingLevels };
@@ -199,6 +201,7 @@ export function openCivitaiModal(ctx, opts = {}) {
         state.cursor = page.nextCursor; state.done = !page.nextCursor;
         appendItems(page.items);
       } else if (t.model) {
+        if (!state.localLoaded) await refreshLocalModels(); // for "in library" marks
         const page = await client.fetchModels({
           type: t.model, sort: f.modelSort, period: f.period,
           baseModels: f.baseModels, levels, cursor: state.cursor,
@@ -270,6 +273,7 @@ export function openCivitaiModal(ctx, opts = {}) {
     img.loading = "lazy"; img.src = m.coverUrl;
     img.addEventListener("error", () => { card.style.display = "none"; });
     card.append(img, el("span", "cmcp-cv-badge", m.type));
+    if (owned(m.fileName)) card.appendChild(el("span", "cmcp-cv-owned", "✓ In library"));
     const foot = el("div", "cmcp-cv-cardfoot", `${m.name}\n${m.baseModel || ""} · ⬇ ${m.downloadCount ?? "?"}`);
     foot.style.whiteSpace = "pre-line";
     card.appendChild(foot);
@@ -407,10 +411,17 @@ export function openCivitaiModal(ctx, opts = {}) {
         detailBody.appendChild(tw);
       }
       const dl = el("div", "cmcp-cv-actions");
+      const have = owned(version.fileName);
       const dlBtn = el("button", "cmcp-btn cmcp-btn-primary",
-        ctx.isMuted() ? "Download to my machine" : "Ask agent to download");
+        have ? "✓ In library — re-download"
+             : (ctx.isMuted() ? "Download to my machine" : "Ask agent to download"));
       dlBtn.addEventListener("click", () => pickModel(detail, version));
       dl.appendChild(dlBtn);
+      if (have) {
+        const note = el("span", null, "You already have this file locally.");
+        note.style.cssText = "font-size:.72rem;color:#4ade80;align-self:center";
+        dl.appendChild(note);
+      }
       detailBody.appendChild(dl);
       if (version.descriptionHtml || detail.descriptionHtml) {
         const desc = el("div", "cmcp-cv-detail");
@@ -540,6 +551,21 @@ export function openCivitaiModal(ctx, opts = {}) {
     wrap.appendChild(reset);
 
     sheet.body.appendChild(wrap);
+  }
+
+  // ── local model index ("in library" marks) ──────────────────────────
+  async function refreshLocalModels() {
+    try {
+      const res = await ctx.callTool("list_local_models", {}, { timeout: 15000 });
+      const text = (res.result || []).map((b) => (b && b.text) || "").join("\n");
+      state.localNames = CivitaiClient.parseLocalNames(text);
+    } catch { /* no marks if the call fails */ }
+    state.localLoaded = true;
+  }
+  function owned(fileName) {
+    if (!fileName || !state.localNames.size) return false;
+    const n = fileName.toLowerCase();
+    return state.localNames.has(n) || state.localNames.has(n.replace(/\.[a-z0-9]+$/, ""));
   }
 
   // ── account / OAuth ──────────────────────────────────────────────────

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -1,0 +1,604 @@
+// CivitAI browser modal for the panel — a browser port of the mobile app's
+// civitai_browse_screen / viewer / filter sheet. Opens from the (formerly parked)
+// "Civitai" toolbar button, and can be opened BY the agent pre-seeded with a query
+// + filters (cmd: open_civitai). Every network call goes through CivitaiClient →
+// the same-origin proxy. Actions are mute-aware: un-muted hands the pick to the
+// agent (share-with-agent), muted downloads directly via call_tool.
+//
+// The monolith injects a `ctx` so this module never reaches into panel internals:
+//   ctx = { api, root, callTool, sendUserMessage, uploadBlobToInput,
+//           bringChatForward, isMuted, marked, DOMPurify }
+
+import {
+  CivitaiClient, DEFAULT_FILTERS, LEVELS, PERIODS, IMAGE_SORTS, MODEL_SORTS,
+  BASE_MODELS, filtersDirty, bitmask,
+} from "./cmcp-civitai.js";
+
+const TABS = [
+  { key: "images", label: "Images", icon: "pi-image", media: "image" },
+  { key: "videos", label: "Videos", icon: "pi-video", media: "video" },
+  { key: "checkpoints", label: "Checkpoints", icon: "pi-box", model: "Checkpoint" },
+  { key: "loras", label: "LoRAs", icon: "pi-sliders-h", model: "LORA" },
+  { key: "workflows", label: "Workflows", icon: "pi-share-alt", model: "Workflows" },
+  { key: "favorites", label: "Favorites", icon: "pi-heart", media: "image", fav: true },
+];
+
+const SUBFOLDER = {
+  LORA: "loras", Workflows: "workflows", TextualInversion: "embeddings",
+  VAE: "vae", Controlnet: "controlnet", Checkpoint: "checkpoints",
+};
+
+let _cssInjected = false;
+function injectCss() {
+  if (_cssInjected) return;
+  _cssInjected = true;
+  const css = `
+  .cmcp-civitai-modal { max-width: 62rem; width: 96%; height: 92%; max-height: 92%;
+    padding: 0; gap: 0; overflow: hidden; }
+  .cmcp-cv-head { display: flex; align-items: center; gap: .5rem; padding: .6rem .7rem;
+    border-bottom: 1px solid var(--p-content-border-color, #3f3f46); flex-wrap: wrap; }
+  .cmcp-cv-tabs { display: flex; gap: .25rem; flex-wrap: wrap; }
+  .cmcp-cv-tab { display: inline-flex; align-items: center; gap: .3rem; padding: .3rem .55rem;
+    border-radius: 8px; border: 1px solid transparent; background: transparent;
+    color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; font-size: .8rem; }
+  .cmcp-cv-tab.active { background: var(--p-surface-800, #27272a);
+    color: var(--p-text-color, #fafafa); border-color: var(--p-content-border-color, #3f3f46); }
+  .cmcp-cv-search { flex: 1 1 8rem; min-width: 6rem; padding: .35rem .5rem; border-radius: 8px;
+    background: var(--p-surface-950, #111); border: 1px solid var(--p-content-border-color, #3f3f46);
+    color: var(--p-text-color, #fafafa); }
+  .cmcp-cv-iconbtn { position: relative; background: transparent; border: 1px solid var(--p-content-border-color,#3f3f46);
+    color: var(--p-text-color,#fafafa); border-radius: 8px; padding: .35rem .5rem; cursor: pointer; }
+  .cmcp-cv-dot { position: absolute; top: -3px; right: -3px; width: 8px; height: 8px; border-radius: 50%;
+    background: var(--p-primary-color, #3a7bd5); }
+  .cmcp-cv-body { position: relative; flex: 1; overflow-y: auto; padding: .6rem; }
+  .cmcp-cv-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: .5rem; }
+  .cmcp-cv-card { position: relative; border-radius: 10px; overflow: hidden; cursor: pointer;
+    background: var(--p-surface-900, #18181b); aspect-ratio: .72; }
+  .cmcp-cv-card img, .cmcp-cv-card video { width: 100%; height: 100%; object-fit: cover; display: block; }
+  .cmcp-cv-cardfoot { position: absolute; left: 0; right: 0; bottom: 0; padding: .3rem .4rem;
+    font-size: .7rem; color: #fff; background: linear-gradient(transparent, rgba(0,0,0,.75)); }
+  .cmcp-cv-badge { position: absolute; top: .3rem; left: .3rem; background: rgba(0,0,0,.6); color:#fff;
+    font-size: .6rem; padding: .1rem .3rem; border-radius: 4px; }
+  .cmcp-cv-add { position: absolute; top: .3rem; right: .3rem; background: rgba(0,0,0,.55); color:#fff;
+    border: none; border-radius: 6px; width: 24px; height: 24px; cursor: pointer; }
+  .cmcp-cv-loading { text-align: center; padding: 1rem; color: var(--p-text-muted-color,#a1a1aa); }
+  .cmcp-cv-progress { position: absolute; top: 0; left: 0; right: 0; height: 2px;
+    background: var(--p-primary-color, #3a7bd5); opacity: .0; transition: opacity .2s; }
+  .cmcp-cv-progress.on { opacity: 1; animation: cmcp-cv-pulse 1s ease-in-out infinite; }
+  @keyframes cmcp-cv-pulse { 0%,100%{opacity:.3} 50%{opacity:1} }
+  .cmcp-cv-filters { display: flex; flex-direction: column; gap: .7rem; }
+  .cmcp-cv-frow { display: flex; flex-wrap: wrap; gap: .3rem; align-items: center; }
+  .cmcp-cv-chip { padding: .25rem .5rem; border-radius: 999px; font-size: .75rem; cursor: pointer;
+    border: 1px solid var(--p-content-border-color,#3f3f46); background: transparent; color: var(--p-text-color,#fafafa); }
+  .cmcp-cv-chip.on { background: var(--p-primary-color,#3a7bd5); border-color: transparent; color:#fff; }
+  .cmcp-cv-flabel { font-size: .7rem; text-transform: uppercase; letter-spacing: .04em;
+    color: var(--p-text-muted-color,#a1a1aa); width: 100%; }
+  .cmcp-cv-detail img, .cmcp-cv-detail video { border-radius: 8px; }
+  .cmcp-cv-actions { display: flex; gap: .4rem; flex-wrap: wrap; margin-top: .5rem; }
+  .cmcp-cv-viewer { position: absolute; inset: 0; z-index: 5; background: rgba(0,0,0,.94);
+    display: flex; align-items: center; justify-content: center; }
+  .cmcp-cv-viewer img, .cmcp-cv-viewer video { max-width: 100%; max-height: 100%; object-fit: contain; }
+  .cmcp-cv-vtop { position: absolute; top: .5rem; right: .5rem; display: flex; gap: .4rem; z-index: 6; }
+  .cmcp-cv-triggers { display: flex; flex-wrap: wrap; gap: .3rem; margin: .4rem 0; }
+  .cmcp-cv-trigger { font-size: .72rem; padding: .15rem .4rem; border-radius: 6px;
+    background: var(--p-surface-800,#27272a); color: var(--p-text-color,#fafafa); }
+  `;
+  const style = document.createElement("style");
+  style.textContent = css;
+  document.head.appendChild(style);
+}
+
+const el = (tag, cls, txt) => {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (txt != null) n.textContent = txt;
+  return n;
+};
+
+/** Open (or focus) the CivitAI modal. opts = {query, tab, filters, browsingLevels}. */
+export function openCivitaiModal(ctx, opts = {}) {
+  injectCss();
+  const client = new CivitaiClient(ctx.api);
+
+  // ── state ────────────────────────────────────────────────────────────────
+  const state = {
+    tab: opts.tab && TABS.some((t) => t.key === opts.tab) ? opts.tab : "images",
+    query: opts.query || "",
+    filters: { ...DEFAULT_FILTERS, ...(opts.filters || {}) },
+    items: [], models: [], cursor: null, loading: false, done: false, reqId: 0,
+    signedIn: false,
+  };
+  if (Array.isArray(opts.browsingLevels) && opts.browsingLevels.length) {
+    state.filters = { ...state.filters, browsingLevels: opts.browsingLevels };
+  }
+  const tabDef = () => TABS.find((t) => t.key === state.tab);
+  const isModelTab = () => !!tabDef().model;
+
+  // ── overlay ──────────────────────────────────────────────────────────────
+  const overlay = el("div", "cmcp-modal-overlay");
+  const modal = el("div", "cmcp-modal cmcp-civitai-modal");
+  const close = () => overlay.remove();
+  overlay.addEventListener("mousedown", (e) => { if (e.target === overlay) close(); });
+
+  // header
+  const head = el("div", "cmcp-cv-head");
+  const tabsWrap = el("div", "cmcp-cv-tabs");
+  const search = el("input", "cmcp-cv-search");
+  search.placeholder = "Search CivitAI…";
+  search.value = state.query;
+  search.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") { state.query = search.value.trim(); reload(); }
+  });
+  const filterBtn = el("button", "cmcp-cv-iconbtn");
+  filterBtn.innerHTML = '<i class="pi pi-sliders-h"></i>';
+  const filterDot = el("span", "cmcp-cv-dot"); filterDot.style.display = "none";
+  filterBtn.appendChild(filterDot);
+  filterBtn.addEventListener("click", () => toggleFilters());
+  const acctBtn = el("button", "cmcp-cv-iconbtn");
+  acctBtn.innerHTML = '<i class="pi pi-user"></i>';
+  acctBtn.title = "CivitAI account";
+  acctBtn.addEventListener("click", () => accountFlow());
+  const closeBtn = el("button", "cmcp-cv-iconbtn");
+  closeBtn.innerHTML = '<i class="pi pi-times"></i>';
+  closeBtn.addEventListener("click", close);
+
+  for (const t of TABS) {
+    const b = el("button", "cmcp-cv-tab");
+    b.innerHTML = `<i class="pi ${t.icon}"></i><span>${t.label}</span>`;
+    b.addEventListener("click", () => { state.tab = t.key; syncTabs(); reload(); });
+    b._key = t.key;
+    tabsWrap.appendChild(b);
+  }
+  head.append(tabsWrap, search, filterBtn, acctBtn, closeBtn);
+
+  // body
+  const body = el("div", "cmcp-cv-body");
+  const progress = el("div", "cmcp-cv-progress");
+  const grid = el("div", "cmcp-cv-grid");
+  const sentinel = el("div", "cmcp-cv-loading");
+  body.append(progress, grid, sentinel);
+  body.addEventListener("scroll", () => {
+    if (body.scrollTop + body.clientHeight >= body.scrollHeight - 600) loadMore();
+  });
+
+  modal.append(head, body);
+  overlay.appendChild(modal);
+  ctx.root.appendChild(overlay);
+
+  function syncTabs() {
+    for (const b of tabsWrap.children) b.classList.toggle("active", b._key === state.tab);
+    search.style.display = isModelTab() ? "none" : "";
+    filterDot.style.display = filtersDirty(state.filters) ? "" : "none";
+  }
+
+  // ── data ───────────────────────────────────────────────────────────────
+  function setLoading(on) { state.loading = on; progress.classList.toggle("on", on); }
+
+  async function reload() {
+    state.items = []; state.models = []; state.cursor = null; state.done = false;
+    grid.innerHTML = ""; syncTabs();
+    await loadMore();
+  }
+
+  async function loadMore() {
+    if (state.loading || state.done) return;
+    const req = ++state.reqId;
+    setLoading(true);
+    sentinel.textContent = "Loading…";
+    try {
+      const f = state.filters;
+      const levels = f.browsingLevels;
+      const t = tabDef();
+      if (t.fav) {
+        if (!state.signedIn) { sentinel.textContent = "Sign in to see your favorites."; setLoading(false); return; }
+        const page = await client.fetchFavorites({ levels, cursor: state.cursor });
+        if (req !== state.reqId) return;
+        state.cursor = page.nextCursor; state.done = !page.nextCursor;
+        appendItems(page.items);
+      } else if (t.model) {
+        const page = await client.fetchModels({
+          type: t.model, sort: f.modelSort, period: f.period,
+          baseModels: f.baseModels, levels, cursor: state.cursor,
+        });
+        if (req !== state.reqId) return;
+        state.cursor = page.nextCursor; state.done = !page.nextCursor;
+        appendModels(page.models);
+      } else if (state.query) {
+        const items = await client.searchMedia(state.query, { type: t.media, levels, offset: state.items.length });
+        if (req !== state.reqId) return;
+        state.done = items.length === 0;
+        appendItems(items);
+      } else {
+        const page = await client.fetchFeed({ type: t.media, period: f.period, sort: f.imageSort, levels, cursor: state.cursor });
+        if (req !== state.reqId) return;
+        state.cursor = page.nextCursor; state.done = !page.nextCursor;
+        appendItems(page.items);
+      }
+      sentinel.textContent = state.done ? "" : "";
+    } catch (e) {
+      sentinel.textContent = "CivitAI error: " + (e.message || e);
+    } finally {
+      if (req === state.reqId) setLoading(false);
+    }
+  }
+
+  function appendItems(items) {
+    for (const it of items) {
+      state.items.push(it);
+      const idx = state.items.length - 1;
+      grid.appendChild(mediaCard(it, idx));
+    }
+  }
+  function appendModels(models) {
+    for (const m of models) { state.models.push(m); grid.appendChild(modelCard(m)); }
+  }
+
+  // ── cards ─────────────────────────────────────────────────────────────
+  function mediaCard(it, idx) {
+    const card = el("div", "cmcp-cv-card");
+    if (it.type === "video") {
+      const v = document.createElement("video");
+      v.src = it.thumbnailUrl; v.muted = true; v.loop = true; v.playsInline = true;
+      v.addEventListener("mouseenter", () => v.play().catch(() => {}));
+      v.addEventListener("mouseleave", () => { v.pause(); v.currentTime = 0; });
+      card.appendChild(v);
+      const badge = el("span", "cmcp-cv-badge", "▶"); card.appendChild(badge);
+    } else {
+      const img = document.createElement("img");
+      img.loading = "lazy"; img.src = it.thumbnailUrl;
+      img.addEventListener("error", () => { card.style.display = "none"; });
+      card.appendChild(img);
+    }
+    const foot = el("div", "cmcp-cv-cardfoot", `${it.author ? "@" + it.author : ""}  ♥ ${it.reactions || 0}`);
+    card.appendChild(foot);
+    card.addEventListener("click", () => openViewer(idx));
+    return card;
+  }
+
+  function modelCard(m) {
+    const card = el("div", "cmcp-cv-card");
+    const img = document.createElement("img");
+    img.loading = "lazy"; img.src = m.coverUrl;
+    img.addEventListener("error", () => { card.style.display = "none"; });
+    card.append(img, el("span", "cmcp-cv-badge", m.type));
+    const foot = el("div", "cmcp-cv-cardfoot", `${m.name}\n${m.baseModel || ""} · ⬇ ${m.downloadCount ?? "?"}`);
+    foot.style.whiteSpace = "pre-line";
+    card.appendChild(foot);
+    card.addEventListener("click", () => openModelDetail(m));
+    return card;
+  }
+
+  // ── viewer ───────────────────────────────────────────────────────────
+  function openViewer(startIdx) {
+    let idx = startIdx;
+    const v = el("div", "cmcp-cv-viewer");
+    const top = el("div", "cmcp-cv-vtop");
+    const mk = (icon, fn, title) => {
+      const b = el("button", "cmcp-cv-iconbtn"); b.innerHTML = `<i class="pi ${icon}"></i>`;
+      if (title) b.title = title; b.addEventListener("click", fn); return b;
+    };
+    const stage = el("div"); stage.style.cssText = "max-width:100%;max-height:100%";
+    const render = () => {
+      const it = state.items[idx];
+      stage.innerHTML = "";
+      if (it.type === "video") {
+        const vid = document.createElement("video");
+        vid.src = it.fullUrl; vid.controls = true; vid.autoplay = true; vid.loop = true;
+        stage.appendChild(vid);
+      } else {
+        const img = document.createElement("img"); img.src = it.fullUrl; stage.appendChild(img);
+      }
+    };
+    const step = (d) => {
+      idx = Math.max(0, Math.min(state.items.length - 1, idx + d));
+      if (idx >= state.items.length - 3) loadMore();
+      render();
+    };
+    top.append(
+      mk("pi-info-circle", () => showGenInfo(state.items[idx]), "Generation info"),
+      mk("pi-chevron-up", () => step(-1)),
+      mk("pi-chevron-down", () => step(1)),
+      mk("pi-times", () => v.remove()),
+    );
+    v.append(stage, top);
+    v.addEventListener("wheel", (e) => { step(e.deltaY > 0 ? 1 : -1); }, { passive: true });
+    body.appendChild(v);
+    render();
+  }
+
+  // ── generation info + share/save (mute-aware) ────────────────────────
+  async function showGenInfo(it) {
+    const sheet = openSubModal("Generation info");
+    sheet.body.appendChild(el("div", "cmcp-cv-loading", "Loading…"));
+    let gen;
+    try { gen = await client.getGenerationData(it.id); }
+    catch (e) { sheet.body.innerHTML = ""; sheet.body.appendChild(el("div", null, "No data: " + e.message)); return; }
+    sheet.body.innerHTML = "";
+    const graph = CivitaiClient.comfyGraph(gen.meta);
+    sheet.body.appendChild(el("div", null, graph ? "✓ Embedded ComfyUI workflow" : "No embedded workflow"));
+
+    const actions = el("div", "cmcp-cv-actions");
+    const shareBtn = el("button", "cmcp-btn cmcp-btn-primary",
+      ctx.isMuted() ? "Save reference to inputs" : "Share with agent");
+    shareBtn.addEventListener("click", () => shareImage(it, gen));
+    actions.appendChild(shareBtn);
+    if (graph) {
+      const saveBtn = el("button", "cmcp-btn", "Save workflow");
+      saveBtn.addEventListener("click", () => saveWorkflow(it, graph));
+      actions.appendChild(saveBtn);
+    }
+    sheet.body.appendChild(actions);
+
+    for (const [k, val] of CivitaiClient.params(gen.meta)) {
+      const row = el("div"); row.style.cssText = "font-size:.78rem;margin-top:.2rem";
+      row.textContent = `${k}: ${val}`;
+      sheet.body.appendChild(row);
+    }
+    if (gen.meta?.prompt) {
+      const p = el("div"); p.style.cssText = "font-size:.78rem;margin-top:.5rem;white-space:pre-wrap";
+      p.textContent = "Prompt: " + gen.meta.prompt; sheet.body.appendChild(p);
+    }
+  }
+
+  function buildCaption(gen) {
+    const m = gen.meta || {};
+    const lines = [
+      "Recreate this CivitAI example as closely as you can — match the reference and use these settings (use our local model if we have it, else download it first):",
+      "",
+    ];
+    if (m.prompt) lines.push("Prompt: " + m.prompt);
+    if (m.negativePrompt) lines.push("Negative: " + m.negativePrompt);
+    for (const [k, v] of CivitaiClient.params(m)) lines.push(`${k}: ${v}`);
+    return lines.join("\n");
+  }
+
+  async function shareImage(it, gen) {
+    try {
+      const blob = await (await fetch(it.fullUrl)).blob();
+      const name = `civitai_ref_${it.id}.${it.type === "video" ? "mp4" : "jpeg"}`;
+      const ref = await ctx.uploadBlobToInput(blob, name);
+      if (ctx.isMuted()) {
+        toast(`Saved ${name} to ComfyUI inputs.`);
+      } else {
+        const caption = buildCaption(gen);
+        ctx.sendUserMessage(
+          `${caption}\n\nThe reference is uploaded to the ComfyUI input/ folder as \`${ref.filename}\` — use it as the target to match.`,
+          undefined, [ref],
+        );
+        ctx.bringChatForward();
+        toast("Shared with the agent.");
+      }
+    } catch (e) { toast("Share failed: " + e.message); }
+  }
+
+  async function saveWorkflow(it, graph) {
+    try {
+      const res = await ctx.callTool("save_workflow",
+        { filename: `civitai_${it.id}.json`, workflow: graph }, { timeout: 60000 });
+      toast(res.ok ? "Workflow saved to your machine." : "Save failed: " + (res.error || "?"));
+    } catch (e) { toast("Save failed: " + e.message); }
+  }
+
+  // ── model detail ─────────────────────────────────────────────────────
+  async function openModelDetail(m) {
+    const sheet = openSubModal(m.name);
+    sheet.body.appendChild(el("div", "cmcp-cv-loading", "Loading…"));
+    let detail;
+    try { detail = await client.fetchModelDetail(m.id, { levels: state.filters.browsingLevels }); }
+    catch (e) { sheet.body.innerHTML = ""; sheet.body.appendChild(el("div", null, "Error: " + e.message)); return; }
+    sheet.body.innerHTML = "";
+    let version = detail.versions[0];
+
+    const versionRow = el("div", "cmcp-cv-frow");
+    const renderBody = () => {
+      detailBody.innerHTML = "";
+      if (version.trainedWords.length) {
+        const tw = el("div", "cmcp-cv-triggers");
+        for (const w of version.trainedWords) tw.appendChild(el("span", "cmcp-cv-trigger", w));
+        detailBody.appendChild(tw);
+      }
+      const dl = el("div", "cmcp-cv-actions");
+      const dlBtn = el("button", "cmcp-btn cmcp-btn-primary",
+        ctx.isMuted() ? "Download to my machine" : "Ask agent to download");
+      dlBtn.addEventListener("click", () => pickModel(detail, version));
+      dl.appendChild(dlBtn);
+      detailBody.appendChild(dl);
+      if (version.descriptionHtml || detail.descriptionHtml) {
+        const desc = el("div", "cmcp-cv-detail");
+        desc.style.cssText = "font-size:.78rem;margin-top:.5rem";
+        desc.innerHTML = ctx.DOMPurify.sanitize(
+          ctx.marked.parse(htmlToText(version.descriptionHtml || detail.descriptionHtml)));
+        detailBody.appendChild(desc);
+      }
+      // official examples
+      if (version.examples.length) {
+        const carousel = el("div", "cmcp-cv-grid"); carousel.style.marginTop = ".5rem";
+        version.examples.slice(0, 12).forEach((ex) => {
+          const c = el("div", "cmcp-cv-card");
+          const img = document.createElement("img"); img.loading = "lazy"; img.src = ex.thumbnailUrl;
+          c.appendChild(img);
+          c.addEventListener("click", () => showGenInfo(ex));
+          carousel.appendChild(c);
+        });
+        detailBody.appendChild(el("div", "cmcp-cv-flabel", "Examples"));
+        detailBody.appendChild(carousel);
+      }
+    };
+    if (detail.versions.length > 1) {
+      detail.versions.forEach((v) => {
+        const chip = el("button", "cmcp-cv-chip", v.name || `v${v.id}`);
+        chip.addEventListener("click", () => {
+          version = v;
+          for (const c of versionRow.children) c.classList.toggle("on", c._v === v.id);
+          renderBody();
+        });
+        chip._v = v.id;
+        if (v.id === version.id) chip.classList.add("on");
+        versionRow.appendChild(chip);
+      });
+      sheet.body.appendChild(versionRow);
+    }
+    const detailBody = el("div");
+    sheet.body.appendChild(detailBody);
+    renderBody();
+  }
+
+  async function pickModel(detail, version) {
+    const subfolder = SUBFOLDER[detail.type] || "checkpoints";
+    if (ctx.isMuted()) {
+      toast("Downloading…");
+      try {
+        const res = await ctx.callTool("download_civitai_model",
+          { model_id: detail.id, model_version_id: version.id, target_subfolder: subfolder },
+          { timeout: 20 * 60000 });
+        toast(res.ok ? "Downloaded to your machine." : "Download failed: " + (res.error || "?"));
+      } catch (e) { toast("Download error: " + e.message); }
+    } else {
+      ctx.sendUserMessage(
+        `Please download the CivitAI ${detail.type} "${detail.name}"` +
+        (version.name ? ` (version "${version.name}")` : "") +
+        ` — model_id ${detail.id}, version ${version.id} — into ${subfolder}, then we'll use it.`);
+      ctx.bringChatForward();
+      toast("Asked the agent to download it.");
+    }
+  }
+
+  // ── filters ──────────────────────────────────────────────────────────
+  function toggleFilters() {
+    const sheet = openSubModal("Filters");
+    const f = state.filters;
+    const wrap = el("div", "cmcp-cv-filters");
+    const update = () => { syncTabs(); reload(); };
+
+    const chipRow = (label, options, isOn, onToggle) => {
+      wrap.appendChild(el("div", "cmcp-cv-flabel", label));
+      const row = el("div", "cmcp-cv-frow");
+      for (const o of options) {
+        const chip = el("button", "cmcp-cv-chip", o.label);
+        if (isOn(o.value)) chip.classList.add("on");
+        chip.addEventListener("click", () => { onToggle(o.value); update(); toggleFilters._rerender?.(); });
+        row.appendChild(chip);
+      }
+      wrap.appendChild(row);
+    };
+
+    chipRow("Time period", PERIODS.map((p) => ({ label: p, value: p })),
+      (v) => f.period === v, (v) => { f.period = v; });
+    const sorts = isModelTab() ? MODEL_SORTS : IMAGE_SORTS;
+    chipRow("Sort", sorts.map((s) => ({ label: s, value: s })),
+      (v) => (isModelTab() ? f.modelSort : f.imageSort) === v,
+      (v) => { if (isModelTab()) f.modelSort = v; else f.imageSort = v; });
+    // browsing levels — ALL selectable, no sign-in gate
+    chipRow("Browsing level", LEVELS.map((l) => ({ label: l.label, value: l.level })),
+      (v) => f.browsingLevels.includes(v),
+      (v) => {
+        const i = f.browsingLevels.indexOf(v);
+        if (i >= 0) f.browsingLevels.splice(i, 1); else f.browsingLevels.push(v);
+        if (f.browsingLevels.length === 0) f.browsingLevels.push(1);
+      });
+
+    // base model omni-search
+    wrap.appendChild(el("div", "cmcp-cv-flabel", "Base model"));
+    const pills = el("div", "cmcp-cv-frow");
+    const renderPills = () => {
+      pills.innerHTML = "";
+      for (const b of f.baseModels) {
+        const pill = el("button", "cmcp-cv-chip on", b + "  ✕");
+        pill.addEventListener("click", () => { f.baseModels = f.baseModels.filter((x) => x !== b); renderPills(); update(); });
+        pills.appendChild(pill);
+      }
+    };
+    const bmSearch = el("input", "cmcp-cv-search"); bmSearch.placeholder = "Filter base models…";
+    const bmList = el("div", "cmcp-cv-frow");
+    bmSearch.addEventListener("input", () => {
+      const q = bmSearch.value.toLowerCase();
+      bmList.innerHTML = "";
+      if (!q) return;
+      for (const b of BASE_MODELS.filter((x) => x.toLowerCase().includes(q)).slice(0, 12)) {
+        const chip = el("button", "cmcp-cv-chip", b);
+        chip.addEventListener("click", () => {
+          if (!f.baseModels.includes(b)) f.baseModels.push(b);
+          bmSearch.value = ""; bmList.innerHTML = ""; renderPills(); update();
+        });
+        bmList.appendChild(chip);
+      }
+    });
+    wrap.append(pills, bmSearch, bmList);
+    renderPills();
+
+    const reset = el("button", "cmcp-btn", "Reset filters");
+    reset.addEventListener("click", () => { state.filters = { ...DEFAULT_FILTERS, browsingLevels: [1] }; sheet.close(); update(); });
+    wrap.appendChild(reset);
+
+    sheet.body.appendChild(wrap);
+  }
+
+  // ── account / OAuth ──────────────────────────────────────────────────
+  async function refreshAuth() {
+    try {
+      const r = await ctx.api.fetchApi("/comfyui_mcp_panel/civitai/oauth/status");
+      state.signedIn = (await r.json()).signed_in;
+    } catch { state.signedIn = false; }
+    acctBtn.style.color = state.signedIn ? "var(--p-primary-color,#3a7bd5)" : "";
+  }
+  async function accountFlow() {
+    await refreshAuth();
+    if (state.signedIn) {
+      await ctx.api.fetchApi("/comfyui_mcp_panel/civitai/oauth/logout", { method: "POST" });
+      await refreshAuth(); toast("Signed out of CivitAI.");
+      return;
+    }
+    try {
+      const r = await ctx.api.fetchApi("/comfyui_mcp_panel/civitai/oauth/start?origin=" + encodeURIComponent(location.origin));
+      const { authorize_url } = await r.json();
+      window.open(authorize_url, "_blank", "width=520,height=720");
+      // poll for completion
+      let tries = 0;
+      const iv = setInterval(async () => {
+        await refreshAuth();
+        if (state.signedIn || ++tries > 120) {
+          clearInterval(iv);
+          if (state.signedIn) { toast("Signed in to CivitAI."); if (tabDef().fav) reload(); }
+        }
+      }, 2000);
+    } catch (e) { toast("Sign-in failed: " + e.message); }
+  }
+
+  // ── sub-modal + toast helpers ────────────────────────────────────────
+  function openSubModal(title) {
+    const ov = el("div", "cmcp-modal-overlay"); ov.style.zIndex = "60";
+    const m = el("div", "cmcp-modal"); m.style.maxWidth = "34rem";
+    m.style.maxHeight = "80%"; m.style.overflowY = "auto";
+    const head2 = el("div", "cmcp-modal-title", title);
+    const x = el("button", "cmcp-cv-iconbtn"); x.innerHTML = '<i class="pi pi-times"></i>';
+    x.style.cssText = "position:absolute;top:.5rem;right:.5rem";
+    const b = el("div"); m.style.position = "relative";
+    const close2 = () => ov.remove();
+    x.addEventListener("click", close2);
+    ov.addEventListener("mousedown", (e) => { if (e.target === ov) close2(); });
+    m.append(head2, x, b); ov.appendChild(m); ctx.root.appendChild(ov);
+    return { body: b, close: close2 };
+  }
+
+  function toast(msg) {
+    const t = el("div", null, msg);
+    t.style.cssText = "position:absolute;bottom:1rem;left:50%;transform:translateX(-50%);" +
+      "background:var(--p-surface-800,#27272a);color:#fafafa;padding:.5rem .8rem;border-radius:8px;" +
+      "z-index:80;font-size:.8rem;box-shadow:0 4px 16px rgba(0,0,0,.5)";
+    modal.appendChild(t);
+    setTimeout(() => t.remove(), 3000);
+  }
+
+  function htmlToText(html) {
+    if (!html) return "";
+    const d = document.createElement("div");
+    d.innerHTML = ctx.DOMPurify.sanitize(html);
+    return d.innerHTML;
+  }
+
+  // ── go ───────────────────────────────────────────────────────────────
+  syncTabs();
+  refreshAuth();
+  reload();
+  return { close, focus: () => search.focus() };
+}

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -145,17 +145,15 @@ export class CivitaiClient {
     };
   }
 
-  // pick the highest-level cover image within `levels`; drop the model if none qualify
+  // pick the highest-level cover image whose level is in the selected set (mask);
+  // drop the model entirely if none qualify (no NSFW cover leaking into an SFW view)
   _modelFromJson(j, levels) {
     const mask = bitmask(levels);
     let best = null, bestLvl = -1;
     for (const v of j.modelVersions || []) {
       for (const img of v.images || []) {
         const lvl = img.nsfwLevel || 1;
-        if ((lvl & mask) === 0 && lvl > 1) continue; // outside selected set (allow lvl1 always)
-        if ((mask & lvl) !== 0 || lvl <= (levels[0] || 1)) {
-          if (lvl > bestLvl) { best = img; bestLvl = lvl; }
-        }
+        if ((lvl & mask) !== 0 && lvl > bestLvl) { best = img; bestLvl = lvl; }
       }
     }
     if (!best) return null;
@@ -173,7 +171,7 @@ export class CivitaiClient {
   _versionFromJson(v, levels) {
     const mask = bitmask(levels);
     const examples = (v.images || [])
-      .filter((img) => ((img.nsfwLevel || 1) & mask) !== 0 || (img.nsfwLevel || 1) === 1)
+      .filter((img) => (((img.nsfwLevel || 1) & mask) !== 0))
       .map((img) => this._fromRest({ ...img, url: img.url }));
     return {
       id: v.id, name: v.name || null, baseModel: v.baseModel || null,
@@ -213,6 +211,7 @@ export class CivitaiClient {
       url: SEARCH_URL, method: "POST",
       headers: {
         authorization: `Bearer ${SEARCH_KEY}`,
+        origin: "https://civitai.red",
         "x-meilisearch-client":
           "Meilisearch instant-meilisearch (v0.13.5) ; Meilisearch JavaScript (v0.34.0)",
       },

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -1,0 +1,299 @@
+// CivitAI data client for the panel's CivitAI modal — a JS port of the mobile
+// app's civitai_service.dart + civitai_models.dart. Every network call goes
+// through the same-origin Python proxy (/comfyui_mcp_panel/civitai/*, see
+// py/civitai_proxy.py) because a browser can't set the bot-gate headers or beat
+// CORS. Media (thumbs/full/video) resolve to same-origin /media URLs usable as
+// <img>/<video> src and fetchable as Blobs for share-with-agent.
+//
+// NOTE (parity, no NSFW gate): all browsing levels are freely selectable; there
+// is no sign-in clamp. OAuth only enables the Favorites tab.
+
+// ── constants (mirror civitai_models.dart) ─────────────────────────────────
+export const LEVELS = [
+  { label: "PG", level: 1 },
+  { label: "PG-13", level: 2 },
+  { label: "R", level: 4 },
+  { label: "X", level: 8 },
+  { label: "XXX", level: 16 },
+];
+export const PERIODS = ["Day", "Week", "Month", "Year", "AllTime"];
+export const IMAGE_SORTS = ["Most Reactions", "Most Comments", "Most Collected", "Newest", "Oldest"];
+export const MODEL_SORTS = ["Most Downloaded", "Highest Rated", "Most Liked", "Newest", "Oldest"];
+export const BASE_MODELS = [
+  "SD 1.4", "SD 1.5", "SD 1.5 LCM", "SD 2.0", "SD 2.1", "SDXL 0.9", "SDXL 1.0",
+  "SDXL Turbo", "SDXL Lightning", "Pony", "Illustrious", "NoobAI", "SD 3", "SD 3.5",
+  "SD 3.5 Medium", "SD 3.5 Large", "SD 3.5 Large Turbo", "Flux.1 S", "Flux.1 D",
+  "Flux.1 Kontext", "Hunyuan Video", "Wan Video 2.2 I2V-A14B", "Wan Video 2.2 T2V-A14B",
+  "Wan Video 14B t2v", "Wan Video 14B i2v 480p", "Wan Video 14B i2v 720p", "LTXV",
+  "Mochi", "CogVideoX", "Kolors", "Qwen", "Chroma", "HiDream", "Lumina", "PixArt a",
+  "PixArt E", "Playground v2", "Stable Cascade", "Aura Flow", "Other",
+];
+
+export const DEFAULT_FILTERS = Object.freeze({
+  period: "Week",
+  baseModels: [],
+  imageSort: "Most Reactions",
+  modelSort: "Most Downloaded",
+  browsingLevels: [1],
+  favorited: false,
+});
+
+export function filtersDirty(f) {
+  return (
+    f.period !== "Week" ||
+    f.imageSort !== "Most Reactions" ||
+    f.modelSort !== "Most Downloaded" ||
+    f.baseModels.length > 0 ||
+    f.favorited ||
+    !(f.browsingLevels.length === 1 && f.browsingLevels[0] === 1)
+  );
+}
+
+export function bitmask(levels) {
+  if (!levels || levels.length === 0) return 1;
+  return levels.reduce((a, b) => a | b, 0);
+}
+
+// ── hosts / keys (mirror civitai_service.dart) ─────────────────────────────
+const API = "https://civitai.red/api";
+const SEARCH_URL = "https://search-new.civitai.com/multi-search";
+const SEARCH_KEY =
+  "8c46eb2508e21db1e9828a97968d91ab1ca1caa5f70a00e88a2ba1e286603b61";
+const CDN_TOKEN = "xG1nkqKTMzGDvpLrqFT7WA";
+
+const _levelFromString = (s) =>
+  ({ None: 1, Soft: 2, Mature: 4, X: 8, XXX: 16 }[s] || 1);
+
+export class CivitaiClient {
+  /** @param {object} api ComfyUI api ({fetchApi, apiURL}) injected by the monolith. */
+  constructor(api) {
+    this.api = api;
+  }
+
+  // ── proxy plumbing ───────────────────────────────────────────────────────
+  async _get(url, { auth = false, headers } = {}) {
+    return this._request({ url, method: "GET", auth, headers });
+  }
+
+  async _request({ url, method = "GET", body, auth = false, headers }) {
+    const res = await this.api.fetchApi("/comfyui_mcp_panel/civitai/api", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ url, method, body, auth, headers }),
+    });
+    if (!res.ok) throw new Error(`civitai proxy ${res.status}`);
+    return res.json();
+  }
+
+  /** Same-origin CDN media URL (usable as <img>/<video> src AND fetchable as a Blob). */
+  mediaUrl(uuid, transform, ext) {
+    const q = new URLSearchParams({ uuid, transform, ext });
+    return this.api.apiURL(`/comfyui_mcp_panel/civitai/media?${q.toString()}`);
+  }
+
+  _thumb(uuid, isVideo) {
+    return isVideo
+      ? this.mediaUrl(uuid, "anim=false,transcode=true,width=450,original=false,optimized=true", "jpeg")
+      : this.mediaUrl(uuid, "width=450", "jpeg");
+  }
+  _full(uuid, isVideo) {
+    return isVideo
+      ? this.mediaUrl(uuid, "transcode=true,width=450,optimized=true", "mp4")
+      : this.mediaUrl(uuid, "original=true", "jpeg");
+  }
+
+  // Strip a full CDN url down to its uuid (the path segment after the token);
+  // MeiliSearch already gives a bare uuid.
+  _uuid(u) {
+    if (typeof u !== "string" || !u.startsWith("http")) return u;
+    const parts = u.split("/").filter(Boolean);
+    const i = parts.indexOf(CDN_TOKEN);
+    return i >= 0 && parts[i + 1] ? parts[i + 1] : parts[parts.length - 2] || u;
+  }
+
+  _reactions(m) {
+    const k = (a, b) => (m[a] ?? m[b] ?? 0);
+    return k("likeCount", "likeCountAllTime") + k("heartCount", "heartCountAllTime") +
+      k("laughCount", "laughCountAllTime") + k("cryCount", "cryCountAllTime");
+  }
+
+  // ── parsers ────────────────────────────────────────────────────────────
+  _fromRest(j) {
+    const isVideo = (j.type || "image") === "video";
+    const uuid = this._uuid(j.url);
+    const nsfw = typeof j.nsfwLevel === "string" ? _levelFromString(j.nsfwLevel) : (j.nsfwLevel || 1);
+    return {
+      id: j.id, uuid, type: isVideo ? "video" : "image",
+      thumbnailUrl: this._thumb(uuid, isVideo), fullUrl: this._full(uuid, isVideo),
+      width: j.width || 0, height: j.height || 0, nsfwLevel: nsfw,
+      prompt: j.meta?.prompt || null, modelName: j.meta?.Model || j.baseModel || null,
+      author: j.username || null, reactions: this._reactions(j.stats || {}),
+      meta: j.meta || null,
+    };
+  }
+
+  _fromMeili(j) {
+    const isVideo = (j.type || "image") === "video";
+    const uuid = this._uuid(j.url);
+    return {
+      id: j.id, uuid, type: isVideo ? "video" : "image",
+      thumbnailUrl: this._thumb(uuid, isVideo), fullUrl: this._full(uuid, isVideo),
+      width: j.width || 0, height: j.height || 0, nsfwLevel: j.nsfwLevel || 1,
+      prompt: j.meta?.prompt || null, modelName: j.meta?.Model || j.baseModel || null,
+      author: j.user?.username || j.username || null, reactions: this._reactions(j.stats || j),
+      meta: j.meta || null,
+    };
+  }
+
+  // pick the highest-level cover image within `levels`; drop the model if none qualify
+  _modelFromJson(j, levels) {
+    const mask = bitmask(levels);
+    let best = null, bestLvl = -1;
+    for (const v of j.modelVersions || []) {
+      for (const img of v.images || []) {
+        const lvl = img.nsfwLevel || 1;
+        if ((lvl & mask) === 0 && lvl > 1) continue; // outside selected set (allow lvl1 always)
+        if ((mask & lvl) !== 0 || lvl <= (levels[0] || 1)) {
+          if (lvl > bestLvl) { best = img; bestLvl = lvl; }
+        }
+      }
+    }
+    if (!best) return null;
+    const uuid = this._uuid(best.url);
+    const isVideo = (best.type || "image") === "video";
+    return {
+      id: j.id, name: j.name, type: j.type,
+      coverUrl: this._thumb(uuid, isVideo), coverIsVideo: isVideo,
+      nsfwLevel: bestLvl, baseModel: j.modelVersions?.[0]?.baseModel || null,
+      creator: j.creator?.username || null,
+      downloadCount: j.stats?.downloadCount, thumbsUp: j.stats?.thumbsUpCount,
+    };
+  }
+
+  _versionFromJson(v, levels) {
+    const mask = bitmask(levels);
+    const examples = (v.images || [])
+      .filter((img) => ((img.nsfwLevel || 1) & mask) !== 0 || (img.nsfwLevel || 1) === 1)
+      .map((img) => this._fromRest({ ...img, url: img.url }));
+    return {
+      id: v.id, name: v.name || null, baseModel: v.baseModel || null,
+      descriptionHtml: v.description || null,
+      trainedWords: v.trainedWords || [], examples,
+      downloadCount: v.stats?.downloadCount,
+    };
+  }
+
+  // ── public API ───────────────────────────────────────────────────────────
+  async fetchFeed({ type = "image", period = "Week", sort = "Most Reactions", levels = [1], limit = 60, cursor } = {}) {
+    const q = new URLSearchParams({
+      limit: String(limit), browsingLevel: String(bitmask(levels)),
+      period, type, sort,
+    });
+    if (cursor) q.set("cursor", cursor);
+    const data = await this._get(`${API}/v1/images?${q.toString()}`);
+    return {
+      items: (data.items || []).map((x) => this._fromRest(x)),
+      nextCursor: data.metadata?.nextCursor || null,
+    };
+  }
+
+  async fetchModelImages(modelVersionId, { levels = [1], sort = "Most Reactions", limit = 30 } = {}) {
+    const q = new URLSearchParams({
+      limit: String(limit), modelVersionId: String(modelVersionId),
+      browsingLevel: String(bitmask(levels)), sort,
+      nsfw: bitmask(levels) > 2 ? "X" : "None",
+    });
+    const data = await this._get(`${API}/v1/images?${q.toString()}`);
+    return (data.items || []).map((x) => this._fromRest(x));
+  }
+
+  async searchMedia(query, { type = "image", levels = [1], limit = 40, offset = 0 } = {}) {
+    const filter = [`type = ${type}`, `nsfwLevel IN [${levels.join(", ")}]`];
+    const data = await this._request({
+      url: SEARCH_URL, method: "POST",
+      headers: {
+        authorization: `Bearer ${SEARCH_KEY}`,
+        "x-meilisearch-client":
+          "Meilisearch instant-meilisearch (v0.13.5) ; Meilisearch JavaScript (v0.34.0)",
+      },
+      body: { queries: [{ indexUid: "images_v6", q: query, limit, offset, filter }] },
+    });
+    return (data.results?.[0]?.hits || []).map((x) => this._fromMeili(x));
+  }
+
+  async fetchFavorites({ levels = [1, 2, 4, 8, 16], cursor } = {}) {
+    const input = {
+      json: {
+        period: "AllTime", sort: "Newest", reactions: ["Like"],
+        browsingLevel: bitmask(levels), cursor: cursor ?? null, authed: true,
+      },
+    };
+    if (cursor == null) input.meta = { values: { cursor: ["undefined"] } };
+    const enc = encodeURIComponent(JSON.stringify(input));
+    const data = await this._get(`${API}/trpc/image.getInfinite?input=${enc}`, { auth: true });
+    const j = data.result?.data?.json || {};
+    return { items: (j.items || []).map((x) => this._fromMeili(x)), nextCursor: j.nextCursor || null };
+  }
+
+  async fetchModels({ type, sort = "Most Downloaded", period = "Week", baseModels = [], levels = [1], limit = 40, cursor } = {}) {
+    const q = new URLSearchParams({
+      limit: String(limit), types: type, sort, period,
+      nsfw: bitmask(levels) > 2 ? "true" : "false",
+    });
+    for (const b of baseModels) q.append("baseModels", b);
+    if (cursor) q.set("cursor", cursor);
+    const data = await this._get(`${API}/v1/models?${q.toString()}`);
+    const models = (data.items || [])
+      .map((x) => this._modelFromJson(x, levels))
+      .filter(Boolean);
+    return { models, nextCursor: data.metadata?.nextCursor || null };
+  }
+
+  async fetchModelDetail(modelId, { levels = [1] } = {}) {
+    const j = await this._get(`${API}/v1/models/${modelId}`);
+    return {
+      id: j.id, name: j.name, type: j.type,
+      versions: (j.modelVersions || []).map((v) => this._versionFromJson(v, levels)),
+      creator: j.creator?.username || null, descriptionHtml: j.description || null,
+      downloadCount: j.stats?.downloadCount, thumbsUp: j.stats?.thumbsUpCount,
+      tags: j.tags || [],
+    };
+  }
+
+  async getGenerationData(imageId) {
+    const enc = encodeURIComponent(JSON.stringify({ json: { id: imageId } }));
+    const data = await this._get(`${API}/trpc/image.getGenerationData?input=${enc}`);
+    const j = data.result?.data?.json || {};
+    return {
+      meta: j.meta || {},
+      hasComfyWorkflow: j.meta?.comfy != null,
+      resourceCount: (j.resources || []).length,
+    };
+  }
+
+  /** Parse the embedded ComfyUI graph from generation meta (prefer UI-format). */
+  static comfyGraph(meta) {
+    if (!meta || meta.comfy == null) return null;
+    let c = meta.comfy;
+    if (typeof c === "string") {
+      try { c = JSON.parse(c); } catch { return null; }
+    }
+    if (c && typeof c === "object") {
+      if (c.workflow) return typeof c.workflow === "string" ? JSON.parse(c.workflow) : c.workflow;
+      if (c.prompt) return typeof c.prompt === "string" ? JSON.parse(c.prompt) : c.prompt;
+    }
+    return c;
+  }
+
+  /** Ordered generation params for the info panel. */
+  static params(meta) {
+    if (!meta) return [];
+    const val = (v) => (v && typeof v === "object" && v.inputs ? v.inputs.value ?? "" : v);
+    const rows = [
+      ["Model", meta.Model], ["sampler", meta.sampler], ["scheduler", meta.scheduler],
+      ["steps", meta.steps], ["cfg", meta.cfgScale], ["seed", meta.seed],
+      ["denoise", meta.denoise], ["size", meta.width && meta.height ? `${val(meta.width)}×${val(meta.height)}` : null],
+    ];
+    return rows.filter(([, v]) => v != null && v !== "").map(([k, v]) => [k, String(val(v))]);
+  }
+}

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -111,6 +111,28 @@ export class CivitaiClient {
     return i >= 0 && parts[i + 1] ? parts[i + 1] : parts[parts.length - 2] || u;
   }
 
+  // primary downloadable file name for a model version (for "in library" matching)
+  _primaryFile(v) {
+    const files = (v && v.files) || [];
+    const f = files.find((x) => x.primary) || files[0];
+    return f && f.name ? f.name : null;
+  }
+
+  /** Parse the `list_local_models` markdown into a Set of normalized local
+   *  filenames (lowercased full name AND stem) for "in library" matching. */
+  static parseLocalNames(text) {
+    const set = new Set();
+    for (const line of (text || "").split("\n")) {
+      const m = line.match(/^\s*-\s+(.+?)(?:\s+\(\d|\s*$)/);
+      if (!m) continue;
+      const name = m[1].trim().toLowerCase();
+      if (!name || name.startsWith("trigger words") || name.startsWith("base:")) continue;
+      set.add(name);
+      set.add(name.replace(/\.[a-z0-9]+$/, "")); // stem, for extension mismatches
+    }
+    return set;
+  }
+
   _reactions(m) {
     const k = (a, b) => (m[a] ?? m[b] ?? 0);
     return k("likeCount", "likeCountAllTime") + k("heartCount", "heartCountAllTime") +
@@ -165,6 +187,7 @@ export class CivitaiClient {
       nsfwLevel: bestLvl, baseModel: j.modelVersions?.[0]?.baseModel || null,
       creator: j.creator?.username || null,
       downloadCount: j.stats?.downloadCount, thumbsUp: j.stats?.thumbsUpCount,
+      fileName: this._primaryFile(j.modelVersions?.[0]),
     };
   }
 
@@ -178,6 +201,7 @@ export class CivitaiClient {
       descriptionHtml: v.description || null,
       trainedWords: v.trainedWords || [], examples,
       downloadCount: v.stats?.downloadCount,
+      fileName: this._primaryFile(v),
     };
   }
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -67,6 +67,7 @@ import DOMPurify from "./vendor/purify.es.js";
 import qrcodegen from "./vendor/qrcode.esm.js";
 import { computeLayout } from "./lib/layout-engine.js";
 import { validateA2UISpec, renderA2UICard, renderA2UIInert, renderA2UIFailCard, A2UI_CSS } from "./cmcp-a2ui.js";
+import { openCivitaiModal } from "./cmcp-civitai-ui.js";
 
 let app = null;
 let api = null;
@@ -6107,7 +6108,7 @@ const RECONNECT_MAX_MS = 15000;
 let AGENT_MUTED = (() => { try { return localStorage.getItem("cmcp.muteAgents") === "1"; } catch { return false; } })();
 let AGENT_BLIND = (() => { try { return localStorage.getItem("cmcp.blindAgents") === "1"; } catch { return false; } })();
 
-function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk, onSecret, onSecretSaved, onReload, onTodo, onShowMedia, onUiRender, onUiUpdate, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onBackends, onAck, onTurn, onTurnAnchor, getResume, getBackend, onHandshakeTimeout, onBridgeClosed, onPairUrl, onPairError }) {
+function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk, onSecret, onSecretSaved, onReload, onTodo, onShowMedia, onOpenCivitai, onUiRender, onUiUpdate, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onBackends, onAck, onTurn, onTurnAnchor, getResume, getBackend, onHandshakeTimeout, onBridgeClosed, onPairUrl, onPairError }) {
   let sock = null;
   let url = loadBridgeUrl();
   let closed = false;
@@ -6310,6 +6311,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
             const mediaItems = Array.isArray(msg.items) ? msg.items : [];
             onShowMedia?.(mediaItems);
             result = { ok: true, count: mediaItems.length };
+          } else if (msg.cmd === "open_civitai") {
+            // Agent opens the CivitAI browser pre-seeded with a query + filters so
+            // the user can visually pick a resource.
+            if (!onOpenCivitai) throw new Error("This panel build can't open the CivitAI browser.");
+            result = onOpenCivitai(msg) || { ok: true };
           } else if (msg.cmd === "ui_render") {
             // A2UI card render. Validation errors THROW so the agent gets a
             // retryable tool error instead of a broken card.
@@ -6350,7 +6356,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
         // ask_user / request_secret paint their OWN cards and their replies carry
         // user input (a choice, or a SECRET) — never echo them as an activity card
         // (and never record them). Other commands get the normal activity card.
-        if (msg.cmd !== "ask_user" && msg.cmd !== "request_secret" && msg.cmd !== "set_todo" && msg.cmd !== "show_media" && msg.cmd !== "ui_render" && msg.cmd !== "ui_update") {
+        if (msg.cmd !== "ask_user" && msg.cmd !== "request_secret" && msg.cmd !== "set_todo" && msg.cmd !== "show_media" && msg.cmd !== "open_civitai" && msg.cmd !== "ui_render" && msg.cmd !== "ui_update") {
           onCommand?.(msg.cmd, msg, reply);
         }
         return;
@@ -9137,14 +9143,33 @@ function buildPanel() {
   ring.style.cursor = "pointer"; ring.onclick = muteBtn.onclick; // clicking the ring toggles mute
   reflectFeedGates();
 
-  // Civitai explorer — parked slot on the strip (greyed until it ships).
+  // Civitai explorer — opens the in-panel CivitAI browser modal. Also opened BY
+  // the agent (cmd:open_civitai) pre-seeded with a query + filters.
   // Mark: Civitai's hexagon-C, monochrome via currentColor (no brand gradients,
   // no event attrs — keeps the registry's SVG YARA gate happy).
+  let _civitaiHandle = null;
+  function civitaiCtx() {
+    return {
+      api,
+      root,
+      callTool: (t, a, o) => liveBridgeClient?.callTool(t, a, o),
+      sendUserMessage: (t, c, i) => liveBridgeClient?.sendUserMessage(t, c, i),
+      uploadBlobToInput,
+      bringChatForward: () => { try { openSidebarTab(); } catch {} },
+      isMuted: () => AGENT_MUTED,
+      marked,
+      DOMPurify,
+    };
+  }
+  function openCivitai(opts) {
+    try { _civitaiHandle?.close(); } catch {}
+    _civitaiHandle = openCivitaiModal(civitaiCtx(), opts || {});
+    return _civitaiHandle;
+  }
   const civitaiBtn = toolbarBtn("pi-circle", "Civitai");
   civitaiBtn.querySelector(".pi").remove();
-  civitaiBtn.dataset.soon = "1";
-  civitaiBtn.setAttribute("aria-disabled", "true");
-  civitaiBtn.title = "Civitai explorer — browse and pull models, LoRAs, and workflows without leaving the panel. Coming soon.";
+  civitaiBtn.title = "Civitai explorer — browse and pull models, LoRAs, and workflows without leaving the panel.";
+  civitaiBtn.addEventListener("click", () => openCivitai());
   {
     const svgNs = "http://www.w3.org/2000/svg";
     const svg = document.createElementNS(svgNs, "svg");
@@ -9165,10 +9190,6 @@ function buildPanel() {
     svg.append(shell, cMark);
     civitaiBtn.prepend(svg);
   }
-  const soonTag = document.createElement("span");
-  soonTag.textContent = "soon";
-  soonTag.style.cssText = "font-size:0.5625rem;opacity:.7;letter-spacing:.03em;text-transform:uppercase";
-  civitaiBtn.appendChild(soonTag);
 
   const toolbarSpacer = document.createElement("span");
   toolbarSpacer.className = "cmcp-spacer";
@@ -10662,6 +10683,17 @@ function buildPanel() {
           paintImage(item.dataUrl, caption);
         }
       }
+    },
+    // The agent called panel_open_civitai — open the CivitAI browser pre-seeded
+    // with a query + suggested filters so the user can visually pick a resource.
+    onOpenCivitai(msg) {
+      openCivitai({
+        query: typeof msg.query === "string" ? msg.query : "",
+        tab: msg.tab,
+        filters: msg.filters,
+        browsingLevels: msg.browsingLevels,
+      });
+      return { ok: true };
     },
     // The agent called panel_ui_render / panel_ui_update — A2UI cards in the chat.
     onUiRender(msg) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -6117,6 +6117,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
   // used to replay the transcript to a freshly-switched provider so it has the
   // conversation. Cleared the moment it's consumed.
   let pendingContext = null;
+  // Direct call_tool requests, cid-correlated. The CivitAI modal uses these to run
+  // whitelisted backend tools (download_civitai_model, save_workflow) synchronously
+  // without an agent turn — mirrors the mobile bridge_client.callTool. The
+  // orchestrator's call_tool handler + whitelist already exist server-side.
+  const pendingCalls = new Map(); // cid -> { resolve, reject, timer }
+  let cidSeq = 0;
   // De-duped status emitter. The pill only ever needs TRANSITIONS, so collapsing
   // consecutive repeats is a guard against any path double-emitting the same state
   // (and keeps the cold-start steady-"connecting" from re-painting on every retry).
@@ -6349,6 +6355,16 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
         }
         return;
       }
+      // Reply to a direct callTool() request (cid-correlated).
+      if (msg && msg.type === "tool_result" && typeof msg.cid === "string") {
+        const pend = pendingCalls.get(msg.cid);
+        if (pend) {
+          pendingCalls.delete(msg.cid);
+          clearTimeout(pend.timer);
+          pend.resolve(msg);
+        }
+        return;
+      }
       if (msg && msg.type === "say" && typeof msg.text === "string") {
         // `id` reconciles this committed reply with its live streaming preview.
         onSay(msg.text, { id: msg.id, streamed: !!msg.streamed });
@@ -6442,6 +6458,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
     sock.addEventListener("close", () => {
       sock = null;
       handshakeDone = false;
+      // Fail any in-flight direct tool calls — the reply can never arrive now.
+      for (const [, pend] of pendingCalls) {
+        clearTimeout(pend.timer);
+        pend.reject(new Error("bridge connection lost"));
+      }
+      pendingCalls.clear();
       clearHandshake();
       lastBridgeDownAt = Date.now(); // for the fast-vs-slow reconnect heuristic
       if (!closed) {
@@ -6598,6 +6620,40 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
       } catch {
         return false;
       }
+    },
+    /** Run a whitelisted backend tool directly (no agent turn), cid-correlated.
+     *  Resolves { ok, result, error } where result is the MCP content array
+     *  ([{type:"text",text}], flatten by joining .text). Rejects on timeout or
+     *  socket close. Used by the CivitAI modal for download_civitai_model /
+     *  save_workflow. */
+    callTool(tool, args, opts) {
+      if (!sock || sock.readyState !== WebSocket.OPEN) {
+        return Promise.reject(new Error("bridge not connected"));
+      }
+      const cid = `ct-${Date.now()}-${cidSeq++}`;
+      const timeoutMs = (opts && opts.timeout) || 60000;
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          pendingCalls.delete(cid);
+          reject(new Error(`call_tool ${tool} timed out`));
+        }, timeoutMs);
+        pendingCalls.set(cid, { resolve, reject, timer });
+        try {
+          sock.send(
+            JSON.stringify({
+              type: "call_tool",
+              tab_id: workflowTabId(),
+              cid,
+              tool,
+              args: args || {},
+            }),
+          );
+        } catch (e) {
+          pendingCalls.delete(cid);
+          clearTimeout(timer);
+          reject(e);
+        }
+      });
     },
     setUrl(next, opts) {
       url = next || DEFAULT_BRIDGE_URL;


### PR DESCRIPTION
Brings the mobile app's full CivitAI browser into the panel — opens from the (formerly parked) **Civitai** toolbar button. **Verified live** in the browser against real civitai.red.

## What
- **Same-origin proxy** (`py/civitai_proxy.py`, new `/comfyui_mcp_panel/civitai/*` routes): a browser can't set the CivitAI bot-gate headers or beat CORS, so this makes the calls server-side — `/api` (JSON, host-allowlisted + retry), `/media` (image/video bytes for `<img>`/`<video>`), `/oauth/*` (PKCE; tokens stay server-side).
- **`CivitaiClient`** (`web/js/cmcp-civitai.js`): JS port of `civitai_service.dart` — feed / MeiliSearch / models / model-detail / generation-data (tRPC) / favorites, bitmask, CDN grammar.
- **The modal** (`web/js/cmcp-civitai-ui.js`): 5 tabs + Favorites, grid + infinite scroll, reactive filters (period/sort/**all levels, no sign-in gate**/base-model omni-search), fullscreen viewer, model detail w/ version picker + examples, generation-info, OAuth account. **Full-viewport** (mounts on `<body>`).
- **`callTool()`** bridge primitive (reuses the orchestrator's existing whitelist).
- **Mute-aware actions**: un-muted → share the pick with the agent (upload ref + brief); muted → download / save directly via `call_tool`.
- **Agent integration**: `open_civitai` cmd handler (pairs with the `panel_open_civitai` orchestrator tool) so the agent can open the browser pre-seeded with a query + filters.
- **"In library" badge**: cross-references your local models (`list_local_models`) so already-downloaded checkpoints/LoRAs are marked.

## Verified live
Modal + all tabs, feed + images via the proxy, viewer, generation-info (real params via tRPC), Checkpoints model cards. Proxy routes curl-tested (JSON + 61KB image + OAuth start).

No `pyproject.toml` change → no Registry publish triggered by merging this.