### PR TITLE
feat(civitai): Creator filter — top-creators leaderboard picker + username search across every feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ All notable changes to this project are documented here. This project adheres to
   level/base-model toggles no longer mutate the frozen module defaults
 
 ### Added
+- CivitAI browser: **Creator filter** in the filter sheet (parity with the
+  mobile app) — an empty field shows the site's top-creators leaderboard
+  (ranked, with download/like counts; degrades to a friendly note when the
+  endpoint balks), typing runs a debounced username search, and the picked
+  creator becomes a removable pill that narrows every feed: images/videos
+  (`/v1/images?username=`), media search (Meili `user.username` filter,
+  escaped), and model tabs (`/v1/models?username=` — keyword+creator matches
+  the keyword client-side around an API quirk). Favorites shows the filter as
+  visibly ignored (your likes come from every creator); Reset clears it
 - CivitAI browser: **like/unlike toggle** — heart on card hover and in the
   lightbox (signed out, the heart opens sign-in); likes mirror into a **default
   likes collection** picked (or created) in the new account sheet

--- a/browser_tests/unit/civitai-creator.test.mjs
+++ b/browser_tests/unit/civitai-creator.test.mjs
@@ -6,18 +6,27 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { CivitaiClient, DEFAULT_FILTERS, filtersDirty } from "../../web/js/cmcp-civitai.js";
 
-/** Client whose proxy calls are captured; each call resolves `payload`. */
+/** Client whose proxy calls are captured. `payload` may be a single response
+ *  (every call resolves it) or an array consumed one per call (last repeats). */
 const stub = (payload) => {
   const calls = [];
+  const pages = Array.isArray(payload) ? [...payload] : null;
   const client = new CivitaiClient({
     fetchApi: async (_path, opts) => {
       calls.push(JSON.parse(opts.body));
-      return { ok: true, json: async () => payload };
+      const body = pages ? (pages.length > 1 ? pages.shift() : pages[0]) : payload;
+      return { ok: true, json: async () => body };
     },
     apiURL: (p) => p,
   });
   return { client, calls };
 };
+
+/** A minimal /v1/models item whose cover survives _modelFromJson at PG. */
+const modelItem = (name) => ({
+  id: 1, name, type: "LORA",
+  modelVersions: [{ baseModel: "SDXL 1.0", images: [{ url: "u1", nsfwLevel: 1 }], files: [] }],
+});
 
 test("escapeMeili escapes backslashes FIRST, then quotes", () => {
   // the other order would re-escape the quote escaping and let a trailing
@@ -57,25 +66,59 @@ test("searchMedia adds an escaped user.username Meili filter", async () => {
 });
 
 test("fetchModels QUIRK: query+username sends only username, filters keyword client-side", async () => {
-  const item = (name) => ({
-    id: 1, name, type: "LORA",
-    modelVersions: [{ baseModel: "SDXL 1.0", images: [{ url: "u1", nsfwLevel: 1 }], files: [] }],
-  });
-  const { client, calls } = stub({ items: [item("Anime Style"), item("Realism Pack")], metadata: {} });
+  const { client, calls } = stub({ items: [modelItem("Anime Style"), modelItem("Realism Pack")], metadata: {} });
   const page = await client.fetchModels({ type: "LORA", query: "anime", username: "artist" });
   const url = new URL(calls[0].url);
   // both together return an empty page server-side — query must NOT be sent
   assert.equal(url.searchParams.has("query"), false);
   assert.equal(url.searchParams.get("username"), "artist");
   assert.deepEqual(page.models.map((m) => m.name), ["Anime Style"]);
+  assert.equal(calls.length, 1); // matched on page one — no chase
 });
 
-test("fetchModels without username still sends query server-side", async () => {
-  const { client, calls } = stub({ items: [], metadata: {} });
-  await client.fetchModels({ type: "LORA", query: "anime" });
-  const url = new URL(calls[0].url);
-  assert.equal(url.searchParams.get("query"), "anime");
-  assert.equal(url.searchParams.has("username"), false);
+test("fetchModels default path is ONE request — even on an empty page with a cursor", async () => {
+  // no creator filter → no page-chasing, identical to pre-creator behavior
+  const empty = { items: [], metadata: { nextCursor: "c2" } };
+  {
+    const { client, calls } = stub(empty);
+    const page = await client.fetchModels({ type: "LORA" });
+    assert.equal(calls.length, 1);
+    assert.equal(page.nextCursor, "c2");
+  }
+  {
+    const { client, calls } = stub(empty);
+    await client.fetchModels({ type: "LORA", query: "anime" }); // keyword only
+    assert.equal(calls.length, 1);
+    assert.equal(new URL(calls[0].url).searchParams.get("query"), "anime");
+  }
+  {
+    const { client, calls } = stub(empty);
+    await client.fetchModels({ type: "LORA", username: "artist" }); // creator only
+    assert.equal(calls.length, 1);
+  }
+});
+
+test("fetchModels keyword×creator chases past client-side-emptied pages", async () => {
+  const { client, calls } = stub([
+    { items: [modelItem("Realism Pack")], metadata: { nextCursor: "c2" } }, // filtered to zero
+    { items: [modelItem("Anime Style")], metadata: { nextCursor: "c3" } },  // match — stop
+  ]);
+  const page = await client.fetchModels({ type: "LORA", query: "anime", username: "artist" });
+  assert.equal(calls.length, 2);
+  assert.equal(new URL(calls[1].url).searchParams.get("cursor"), "c2"); // hop used the page-1 cursor
+  assert.deepEqual(page.models.map((m) => m.name), ["Anime Style"]);
+  assert.equal(page.nextCursor, "c3"); // resumes AFTER the matched page
+});
+
+test("fetchModels keyword×creator chase is capped (initial + 4 hops)", async () => {
+  const { client, calls } = stub({
+    items: [modelItem("Realism Pack")], // never matches "anime"
+    metadata: { nextCursor: "again" },
+  });
+  const page = await client.fetchModels({ type: "LORA", query: "anime", username: "artist" });
+  assert.equal(calls.length, 5);
+  assert.deepEqual(page.models, []);
+  assert.equal(page.nextCursor, "again"); // caller can keep going explicitly
 });
 
 test("fetchTopCreators parses the leaderboard tRPC shape", async () => {

--- a/browser_tests/unit/civitai-creator.test.mjs
+++ b/browser_tests/unit/civitai-creator.test.mjs
@@ -1,0 +1,127 @@
+// Unit tests for the CivitAI creator filter plumbing (cmcp-civitai.js):
+// Meili escaping order, the /v1/models query×username API quirk, leaderboard
+// parsing, /v1/creators search shaping, and username threading into every
+// query the explorer makes.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { CivitaiClient, DEFAULT_FILTERS, filtersDirty } from "../../web/js/cmcp-civitai.js";
+
+/** Client whose proxy calls are captured; each call resolves `payload`. */
+const stub = (payload) => {
+  const calls = [];
+  const client = new CivitaiClient({
+    fetchApi: async (_path, opts) => {
+      calls.push(JSON.parse(opts.body));
+      return { ok: true, json: async () => payload };
+    },
+    apiURL: (p) => p,
+  });
+  return { client, calls };
+};
+
+test("escapeMeili escapes backslashes FIRST, then quotes", () => {
+  // the other order would re-escape the quote escaping and let a trailing
+  // backslash break out of the quoted filter string
+  assert.equal(CivitaiClient.escapeMeili('a\\b"c'), 'a\\\\b\\"c');
+  assert.equal(CivitaiClient.escapeMeili('end\\'), "end\\\\");
+  assert.equal(CivitaiClient.escapeMeili('"'), '\\"');
+  assert.equal(CivitaiClient.escapeMeili("plain"), "plain");
+});
+
+test("filters: username participates in defaults + dirtiness", () => {
+  assert.equal(DEFAULT_FILTERS.username, null);
+  assert.equal(filtersDirty({ ...DEFAULT_FILTERS }), false);
+  assert.equal(filtersDirty({ ...DEFAULT_FILTERS, username: "someone" }), true);
+});
+
+test("fetchFeed threads username into /v1/images", async () => {
+  const { client, calls } = stub({ items: [], metadata: {} });
+  await client.fetchFeed({ username: "artist" });
+  const url = new URL(calls[0].url);
+  assert.equal(url.pathname, "/api/v1/images");
+  assert.equal(url.searchParams.get("username"), "artist");
+  calls.length = 0;
+  await client.fetchFeed({});
+  assert.equal(new URL(calls[0].url).searchParams.has("username"), false);
+});
+
+test("searchMedia adds an escaped user.username Meili filter", async () => {
+  const { client, calls } = stub({ results: [{ hits: [] }] });
+  await client.searchMedia("cat", { username: 'we"ird\\name' });
+  const filter = calls[0].body.queries[0].filter;
+  assert.ok(filter.includes('user.username = "we\\"ird\\\\name"'),
+    JSON.stringify(filter));
+  calls.length = 0;
+  await client.searchMedia("cat", {});
+  assert.ok(!calls[0].body.queries[0].filter.some((f) => f.startsWith("user.username")));
+});
+
+test("fetchModels QUIRK: query+username sends only username, filters keyword client-side", async () => {
+  const item = (name) => ({
+    id: 1, name, type: "LORA",
+    modelVersions: [{ baseModel: "SDXL 1.0", images: [{ url: "u1", nsfwLevel: 1 }], files: [] }],
+  });
+  const { client, calls } = stub({ items: [item("Anime Style"), item("Realism Pack")], metadata: {} });
+  const page = await client.fetchModels({ type: "LORA", query: "anime", username: "artist" });
+  const url = new URL(calls[0].url);
+  // both together return an empty page server-side — query must NOT be sent
+  assert.equal(url.searchParams.has("query"), false);
+  assert.equal(url.searchParams.get("username"), "artist");
+  assert.deepEqual(page.models.map((m) => m.name), ["Anime Style"]);
+});
+
+test("fetchModels without username still sends query server-side", async () => {
+  const { client, calls } = stub({ items: [], metadata: {} });
+  await client.fetchModels({ type: "LORA", query: "anime" });
+  const url = new URL(calls[0].url);
+  assert.equal(url.searchParams.get("query"), "anime");
+  assert.equal(url.searchParams.has("username"), false);
+});
+
+test("fetchTopCreators parses the leaderboard tRPC shape", async () => {
+  const entry = (username, position, extra = {}) => ({
+    position, score: position * 100,
+    user: { username, ...extra },
+    metrics: [
+      { type: "downloadCount", value: 12345 },
+      { type: "thumbsUpCount", value: 678 },
+    ],
+  });
+  const { client } = stub({
+    result: { data: { json: [
+      entry("alpha", 1),
+      entry("gone", 2, { deletedAt: "2026-01-01" }), // dropped
+      { position: 3, user: {} },                      // no username — dropped
+      entry("beta", 4),
+    ] } },
+  });
+  const top = await client.fetchTopCreators({ limit: 25 });
+  assert.deepEqual(top.map((c) => c.username), ["alpha", "beta"]);
+  assert.equal(top[0].position, 1);
+  assert.equal(top[0].downloads, 12345);
+  assert.equal(top[0].thumbsUp, 678);
+});
+
+test("fetchTopCreators degrades to [] on an unexpected payload", async () => {
+  const { client } = stub({ result: { data: { json: { error: "nope" } } } });
+  assert.deepEqual(await client.fetchTopCreators(), []);
+});
+
+test("searchCreators shapes /v1/creators and short-circuits empty queries", async () => {
+  const { client, calls } = stub({ items: [
+    { username: "alpha", modelCount: 3 },
+    { username: "", modelCount: 1 }, // dropped
+    { username: "beta" },
+  ] });
+  const out = await client.searchCreators("  alp  ");
+  const url = new URL(calls[0].url);
+  assert.equal(url.pathname, "/api/v1/creators");
+  assert.equal(url.searchParams.get("query"), "alp");
+  assert.deepEqual(out, [
+    { username: "alpha", modelCount: 3 },
+    { username: "beta", modelCount: 0 },
+  ]);
+  calls.length = 0;
+  assert.deepEqual(await client.searchCreators("   "), []);
+  assert.equal(calls.length, 0); // no network call for a blank query
+});

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -292,6 +292,12 @@ export function openCivitaiModal(ctx, opts = {}) {
   function setLoading(on) { state.loading = on; progress.classList.toggle("on", on); }
 
   async function reload({ searching = false } = {}) {
+    // Invalidate any page load already IN FLIGHT: its response belongs to the
+    // OLD tab/query/filters and must not repopulate the just-cleared grid (nor
+    // leave its cursor behind). The stale request's guarded `finally` won't
+    // clear the loading flag anymore, so reset it here too.
+    state.reqId++;
+    setLoading(false);
     state.items = []; state.models = []; state.cursor = null; state.done = false;
     grid.innerHTML = ""; syncTabs();
     if (searching) searchOverlay.style.display = "";
@@ -307,6 +313,11 @@ export function openCivitaiModal(ctx, opts = {}) {
     const req = ++state.reqId;
     setLoading(true);
     sentinel.textContent = "Loading…";
+    // keyword × creator on model tabs matches client-side (API quirk — see
+    // fetchModels): even after its bounded page-chase a load can come back
+    // empty with more pages left. That must not dead-end the list — the
+    // scroll sentinel only re-fires when the grid grows.
+    let stalled = false;
     try {
       const f = state.filters;
       const levels = f.browsingLevels;
@@ -327,23 +338,16 @@ export function openCivitaiModal(ctx, opts = {}) {
           (it.prompt || "").toLowerCase().includes(q) || (it.author || "").toLowerCase().includes(q)));
       } else if (t.model) {
         if (!state.localLoaded) await refreshLocalModels(); // for "in library" marks
-        const fetchPage = (cursor) => client.fetchModels({
+        const page = await client.fetchModels({
           type: t.model, sort: f.modelSort, period: f.period,
-          baseModels: f.baseModels, levels, cursor,
+          baseModels: f.baseModels, levels, cursor: state.cursor,
           ...(state.query ? { query: state.query } : {}),
           ...(f.username ? { username: f.username } : {}),
         });
-        let page = await fetchPage(state.cursor);
-        // keyword × creator matches client-side (API quirk — see fetchModels),
-        // and the cover-level filter can thin pages too: a page that filters
-        // down to nothing would stall the scroll sentinel, so chase a few
-        // more pages before giving up.
-        for (let hop = 0; req === state.reqId && !page.models.length && page.nextCursor && hop < 4; hop++) {
-          page = await fetchPage(page.nextCursor);
-        }
         if (req !== state.reqId) return;
         state.cursor = page.nextCursor; state.done = !page.nextCursor;
         appendModels(page.models);
+        stalled = !page.models.length && !state.done;
       } else if (state.query) {
         const items = await client.searchMedia(state.query, {
           type: t.media, levels, offset: state.items.length,
@@ -361,9 +365,19 @@ export function openCivitaiModal(ctx, opts = {}) {
         state.cursor = page.nextCursor; state.done = !page.nextCursor;
         appendItems(page.items);
       }
-      sentinel.textContent = state.done ? "" : "";
+      if (stalled) {
+        // Explicit affordance instead of a silent dead end.
+        sentinel.textContent = "";
+        const more = el("button", "cmcp-btn", "No matches yet — keep searching");
+        more.addEventListener("click", () => loadMore());
+        sentinel.appendChild(more);
+      } else if (state.done && !grid.children.length) {
+        sentinel.textContent = "No results.";
+      } else {
+        sentinel.textContent = "";
+      }
     } catch (e) {
-      sentinel.textContent = "CivitAI error: " + (e.message || e);
+      if (req === state.reqId) sentinel.textContent = "CivitAI error: " + (e.message || e);
     } finally {
       if (req === state.reqId) setLoading(false);
     }
@@ -806,11 +820,16 @@ export function openCivitaiModal(ctx, opts = {}) {
   function toggleFilters() {
     const sheet = openSubModal("Filters");
     const update = () => { syncTabs(); reload(); };
-    // Creator-lookup generation counter — lives OUTSIDE renderSheet so a
-    // re-render can't resurrect a stale in-flight response (debounce race).
+    // Creator-lookup generation counter + debounce timer — live OUTSIDE
+    // renderSheet so a re-render can't resurrect a stale in-flight response
+    // (debounce race), and so a timer armed before a re-render can be
+    // cancelled instead of firing against the torn-down sheet (which would
+    // bump crReq and strand the new sheet on "Looking up creators…").
     let crReq = 0;
+    let crTimer = null;
 
     const renderSheet = () => {
+      clearTimeout(crTimer); crTimer = null; // pending lookups target dead nodes
       const f = state.filters;
       sheet.body.innerHTML = "";
       const wrap = el("div", "cmcp-cv-filters");
@@ -926,6 +945,7 @@ export function openCivitaiModal(ctx, opts = {}) {
           }
         };
         const loadMatches = () => {
+          if (!crSearch.isConnected) return; // sheet closed or re-rendered
           const req = ++crReq;
           const cq = crSearch.value.trim();
           crNote.style.display = ""; crNote.textContent = "Looking up creators…";
@@ -949,7 +969,6 @@ export function openCivitaiModal(ctx, opts = {}) {
                 : "Top creators unavailable right now.";
             });
         };
-        let crTimer = null;
         crSearch.addEventListener("input", () => {
           crReq++; // invalidate lookups in flight for the previous text NOW
           clearTimeout(crTimer);

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -184,6 +184,7 @@ export function openCivitaiModal(ctx, opts = {}) {
       browsingLevels: [...(opts.filters?.browsingLevels ?? DEFAULT_FILTERS.browsingLevels)],
     },
     items: [], models: [], cursor: null, loading: false, done: false, reqId: 0,
+    searchSeq: 0, // searching-overlay ownership (see reload)
     signedIn: false, localNames: new Set(), localLoaded: false,
     favType: "all", // favorites sub-filter: all | image | video
   };
@@ -300,11 +301,15 @@ export function openCivitaiModal(ctx, opts = {}) {
     setLoading(false);
     state.items = []; state.models = []; state.cursor = null; state.done = false;
     grid.innerHTML = ""; syncTabs();
+    // Overlay ownership: only the NEWEST reload may hide the searching
+    // spinner — a superseded reload's finally must not kill the overlay of
+    // the search that replaced it (same generation pattern as the grid).
+    const mySearch = ++state.searchSeq;
     if (searching) searchOverlay.style.display = "";
     try {
       await loadMore();
     } finally {
-      searchOverlay.style.display = "none";
+      if (mySearch === state.searchSeq) searchOverlay.style.display = "none";
     }
   }
 
@@ -818,8 +823,6 @@ export function openCivitaiModal(ctx, opts = {}) {
   // hook that was never defined, so chips looked completely dead — field
   // report: "I press them, nothing happens").
   function toggleFilters() {
-    const sheet = openSubModal("Filters");
-    const update = () => { syncTabs(); reload(); };
     // Creator-lookup generation counter + debounce timer — live OUTSIDE
     // renderSheet so a re-render can't resurrect a stale in-flight response
     // (debounce race), and so a timer armed before a re-render can be
@@ -827,6 +830,15 @@ export function openCivitaiModal(ctx, opts = {}) {
     // bump crReq and strand the new sheet on "Looking up creators…").
     let crReq = 0;
     let crTimer = null;
+    // Closing the sheet (✕ / backdrop) tears the picker down for good:
+    // cancel the pending debounce and invalidate any lookup already in
+    // flight so its completion early-returns instead of touching the
+    // detached nodes.
+    const sheet = openSubModal("Filters", () => {
+      clearTimeout(crTimer); crTimer = null;
+      crReq++;
+    });
+    const update = () => { syncTabs(); reload(); };
 
     const renderSheet = () => {
       clearTimeout(crTimer); crTimer = null; // pending lookups target dead nodes
@@ -946,6 +958,9 @@ export function openCivitaiModal(ctx, opts = {}) {
         };
         const loadMatches = () => {
           if (!crSearch.isConnected) return; // sheet closed or re-rendered
+          // Direct calls (the focus path) must also cancel a pending debounce
+          // tick, or the same text fires a second, redundant lookup.
+          clearTimeout(crTimer); crTimer = null;
           const req = ++crReq;
           const cq = crSearch.value.trim();
           crNote.style.display = ""; crNote.textContent = "Looking up creators…";
@@ -1108,7 +1123,7 @@ export function openCivitaiModal(ctx, opts = {}) {
   }
 
   // ── sub-modal + toast helpers ────────────────────────────────────────
-  function openSubModal(title) {
+  function openSubModal(title, onClose) {
     const ov = el("div", "cmcp-cv-overlay"); ov.style.zIndex = "10001";
     const m = el("div", "cmcp-modal"); m.style.maxWidth = "40rem"; m.style.width = "min(40rem, 92vw)";
     m.style.maxHeight = "85vh"; m.style.overflowY = "auto";
@@ -1116,7 +1131,9 @@ export function openCivitaiModal(ctx, opts = {}) {
     const x = el("button", "cmcp-cv-iconbtn"); x.innerHTML = '<i class="pi pi-times"></i>';
     x.style.cssText = "position:absolute;top:.5rem;right:.5rem";
     const b = el("div"); m.style.position = "relative";
-    const close2 = () => ov.remove();
+    // Every close path (✕ button, backdrop click, sheet.close()) funnels here,
+    // so a caller-supplied teardown runs no matter how the sheet is dismissed.
+    const close2 = () => { ov.remove(); if (onClose) onClose(); };
     x.addEventListener("click", close2);
     ov.addEventListener("mousedown", (e) => { if (e.target === ov) close2(); });
     m.append(head2, x, b); ov.appendChild(m); document.body.appendChild(ov);

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -134,6 +134,15 @@ function injectCss() {
     animation: cmcp-cv-spin .8s linear infinite; }
   @keyframes cmcp-cv-spin { to { transform: rotate(360deg); } }
   .cmcp-cv-lb-muted { font-size: .74rem; color: var(--p-text-muted-color,#a1a1aa); }
+  .cmcp-cv-creators { display: flex; flex-direction: column; gap: .2rem; width: 100%;
+    max-height: 13rem; overflow-y: auto; }
+  .cmcp-cv-creator { display: flex; align-items: baseline; gap: .5rem; padding: .3rem .5rem;
+    border-radius: 8px; border: 1px solid var(--p-content-border-color,#3f3f46);
+    background: transparent; color: var(--p-text-color,#fafafa); cursor: pointer;
+    text-align: left; font-size: .78rem; }
+  .cmcp-cv-creator:hover { background: var(--p-surface-800,#27272a); }
+  .cmcp-cv-creator .sub { margin-left: auto; font-size: .68rem; flex-shrink: 0;
+    color: var(--p-text-muted-color,#a1a1aa); }
   .cmcp-cv-lb-prompt { font-size: .78rem; white-space: pre-wrap; word-break: break-word;
     background: var(--p-surface-950,#111); border-radius: 8px; padding: .5rem;
     max-height: 14rem; overflow-y: auto; }
@@ -318,21 +327,36 @@ export function openCivitaiModal(ctx, opts = {}) {
           (it.prompt || "").toLowerCase().includes(q) || (it.author || "").toLowerCase().includes(q)));
       } else if (t.model) {
         if (!state.localLoaded) await refreshLocalModels(); // for "in library" marks
-        const page = await client.fetchModels({
+        const fetchPage = (cursor) => client.fetchModels({
           type: t.model, sort: f.modelSort, period: f.period,
-          baseModels: f.baseModels, levels, cursor: state.cursor,
+          baseModels: f.baseModels, levels, cursor,
           ...(state.query ? { query: state.query } : {}),
+          ...(f.username ? { username: f.username } : {}),
         });
+        let page = await fetchPage(state.cursor);
+        // keyword × creator matches client-side (API quirk — see fetchModels),
+        // and the cover-level filter can thin pages too: a page that filters
+        // down to nothing would stall the scroll sentinel, so chase a few
+        // more pages before giving up.
+        for (let hop = 0; req === state.reqId && !page.models.length && page.nextCursor && hop < 4; hop++) {
+          page = await fetchPage(page.nextCursor);
+        }
         if (req !== state.reqId) return;
         state.cursor = page.nextCursor; state.done = !page.nextCursor;
         appendModels(page.models);
       } else if (state.query) {
-        const items = await client.searchMedia(state.query, { type: t.media, levels, offset: state.items.length });
+        const items = await client.searchMedia(state.query, {
+          type: t.media, levels, offset: state.items.length,
+          ...(f.username ? { username: f.username } : {}),
+        });
         if (req !== state.reqId) return;
         state.done = items.length === 0;
         appendItems(items);
       } else {
-        const page = await client.fetchFeed({ type: t.media, period: f.period, sort: f.imageSort, levels, cursor: state.cursor });
+        const page = await client.fetchFeed({
+          type: t.media, period: f.period, sort: f.imageSort, levels, cursor: state.cursor,
+          ...(f.username ? { username: f.username } : {}),
+        });
         if (req !== state.reqId) return;
         state.cursor = page.nextCursor; state.done = !page.nextCursor;
         appendItems(page.items);
@@ -763,6 +787,18 @@ export function openCivitaiModal(ctx, opts = {}) {
   }
 
   // ── filters ──────────────────────────────────────────────────────────
+  // Top-creators leaderboard for the Creator picker, cached for the modal's
+  // lifetime (the board changes daily — a session-stale list is fine here).
+  let _topCreators = null;
+  async function topCreators() {
+    if (!_topCreators) _topCreators = await client.fetchTopCreators();
+    return _topCreators;
+  }
+  const compactCount = (n) =>
+    n >= 1e6 ? (n / 1e6).toFixed(1).replace(/\.0$/, "") + "M"
+    : n >= 1e3 ? (n / 1e3).toFixed(1).replace(/\.0$/, "") + "K"
+    : String(n);
+
   // The whole sheet re-renders after every change: a chip click must flip its
   // own highlight immediately (the original wired a `toggleFilters._rerender`
   // hook that was never defined, so chips looked completely dead — field
@@ -770,6 +806,9 @@ export function openCivitaiModal(ctx, opts = {}) {
   function toggleFilters() {
     const sheet = openSubModal("Filters");
     const update = () => { syncTabs(); reload(); };
+    // Creator-lookup generation counter — lives OUTSIDE renderSheet so a
+    // re-render can't resurrect a stale in-flight response (debounce race).
+    let crReq = 0;
 
     const renderSheet = () => {
       const f = state.filters;
@@ -830,6 +869,97 @@ export function openCivitaiModal(ctx, opts = {}) {
         }
       });
       wrap.append(pills, bmSearch, bmList);
+
+      // creator — single-select async search. Empty field shows the site's
+      // TOP-CREATORS leaderboard (ranked, with stats); typing runs a debounced
+      // (300ms) /v1/creators username search. Picking one threads `username`
+      // through every feed/search/model query; no selection = everyone.
+      wrap.appendChild(el("div", "cmcp-cv-flabel", "Creator"));
+      if (tabDef().fav) {
+        // Favorites are "images YOU liked", from every creator — the tRPC
+        // favorites feed has no creator param, so render the filter visibly
+        // inert here instead of silently no-oping.
+        const box = el("div", "cmcp-cv-frow");
+        box.style.opacity = ".6";
+        if (f.username) {
+          const pill = el("button", "cmcp-cv-chip on", f.username + "  ✕");
+          pill.title = "Remove creator filter";
+          pill.addEventListener("click", () => { f.username = null; renderSheet(); update(); });
+          box.appendChild(pill);
+        }
+        box.appendChild(el("div", "cmcp-cv-lb-muted",
+          "Ignored on the Favorites tab — favorites are the images you liked, from every creator."));
+        wrap.appendChild(box);
+      } else {
+        const crPills = el("div", "cmcp-cv-frow");
+        if (f.username) {
+          const pill = el("button", "cmcp-cv-chip on", f.username + "  ✕");
+          pill.title = "Remove creator filter";
+          pill.addEventListener("click", () => { f.username = null; renderSheet(); update(); });
+          crPills.appendChild(pill);
+        }
+        const crSearch = el("input", "cmcp-cv-search");
+        crSearch.placeholder = f.username
+          ? "Switch creator…"
+          : "All creators — search, or pick from the top";
+        const crNote = el("div", "cmcp-cv-lb-muted");
+        crNote.style.display = "none";
+        const crList = el("div", "cmcp-cv-creators");
+        const renderMatches = (matches) => {
+          crList.innerHTML = "";
+          for (const c of matches) {
+            const b = el("button", "cmcp-cv-creator");
+            b.appendChild(el("span", null,
+              c.position != null ? `#${c.position}  ${c.username}` : c.username));
+            const sub = c.position != null
+              ? [
+                  c.downloads != null ? compactCount(c.downloads) + " downloads" : null,
+                  c.thumbsUp != null ? compactCount(c.thumbsUp) + " likes" : null,
+                ].filter(Boolean).join(" · ")
+              : `${c.modelCount ?? 0} model${(c.modelCount ?? 0) === 1 ? "" : "s"}`;
+            if (sub) b.appendChild(el("span", "sub", sub));
+            b.addEventListener("click", () => {
+              f.username = c.username;
+              renderSheet(); update();
+            });
+            crList.appendChild(b);
+          }
+        };
+        const loadMatches = () => {
+          const req = ++crReq;
+          const cq = crSearch.value.trim();
+          crNote.style.display = ""; crNote.textContent = "Looking up creators…";
+          (cq ? client.searchCreators(cq) : topCreators())
+            .then((matches) => {
+              if (req !== crReq) return; // a newer lookup owns the list
+              renderMatches(matches);
+              crNote.style.display = matches.length ? "none" : "";
+              crNote.textContent = cq
+                ? "No creators match."
+                : "Top creators unavailable right now.";
+            })
+            .catch(() => {
+              // The leaderboard tRPC intermittently 401s bare user agents —
+              // degrade to a note without breaking the rest of the sheet.
+              if (req !== crReq) return;
+              crList.innerHTML = "";
+              crNote.style.display = "";
+              crNote.textContent = cq
+                ? "Creator search failed — try again."
+                : "Top creators unavailable right now.";
+            });
+        };
+        let crTimer = null;
+        crSearch.addEventListener("input", () => {
+          crReq++; // invalidate lookups in flight for the previous text NOW
+          clearTimeout(crTimer);
+          crTimer = setTimeout(loadMatches, 300);
+        });
+        crSearch.addEventListener("focus", () => {
+          if (!crList.children.length) loadMatches();
+        });
+        wrap.append(crPills, crSearch, crNote, crList);
+      }
 
       const reset = el("button", "cmcp-btn", "Reset filters");
       reset.addEventListener("click", () => {

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -36,6 +36,7 @@ export const DEFAULT_FILTERS = Object.freeze({
   modelSort: "Most Downloaded",
   browsingLevels: [1],
   favorited: false,
+  username: null, // creator filter — null means everyone
 });
 
 export function filtersDirty(f) {
@@ -45,6 +46,7 @@ export function filtersDirty(f) {
     f.modelSort !== "Most Downloaded" ||
     f.baseModels.length > 0 ||
     f.favorited ||
+    !!f.username ||
     !(f.browsingLevels.length === 1 && f.browsingLevels[0] === 1)
   );
 }
@@ -205,12 +207,21 @@ export class CivitaiClient {
     };
   }
 
+  /** Escape a string for use inside a quoted MeiliSearch filter value.
+   *  Backslashes FIRST, then quotes — the other order would re-escape the
+   *  quote escaping, letting a trailing `\` (or a crafted `\"`) break out of
+   *  the quoted string and alter the filter. */
+  static escapeMeili(s) {
+    return String(s).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  }
+
   // ── public API ───────────────────────────────────────────────────────────
-  async fetchFeed({ type = "image", period = "Week", sort = "Most Reactions", levels = [1], limit = 100, cursor } = {}) {
+  async fetchFeed({ type = "image", period = "Week", sort = "Most Reactions", levels = [1], limit = 100, cursor, username } = {}) {
     const q = new URLSearchParams({
       limit: String(limit), browsingLevel: String(bitmask(levels)),
       period, type, sort,
     });
+    if (username) q.set("username", username); // narrow to one creator's posts
     if (cursor) q.set("cursor", cursor);
     const data = await this._get(`${API}/v1/images?${q.toString()}`);
     return {
@@ -229,8 +240,12 @@ export class CivitaiClient {
     return (data.items || []).map((x) => this._fromRest(x));
   }
 
-  async searchMedia(query, { type = "image", levels = [1], limit = 100, offset = 0 } = {}) {
+  async searchMedia(query, { type = "image", levels = [1], limit = 100, offset = 0, username } = {}) {
     const filter = [`type = ${type}`, `nsfwLevel IN [${levels.join(", ")}]`];
+    // Creator filter — the index exposes the author under `user.username`
+    // (live-verified filterable on the mobile app). Quoted + escaped so any
+    // legal username parses without breaking out of the filter string.
+    if (username) filter.push(`user.username = "${CivitaiClient.escapeMeili(username)}"`);
     const data = await this._request({
       url: SEARCH_URL, method: "POST",
       headers: {
@@ -308,18 +323,26 @@ export class CivitaiClient {
     return { items: (j.items || []).map((x) => this._fromMeili(x)), nextCursor: j.nextCursor || null };
   }
 
-  async fetchModels({ type, sort = "Most Downloaded", period = "Week", baseModels = [], levels = [1], limit = 100, cursor, query } = {}) {
+  async fetchModels({ type, sort = "Most Downloaded", period = "Week", baseModels = [], levels = [1], limit = 100, cursor, query, username } = {}) {
     const q = new URLSearchParams({
       limit: String(limit), types: type, sort, period,
       nsfw: bitmask(levels) > 2 ? "true" : "false",
     });
     for (const b of baseModels) q.append("baseModels", b);
-    if (query) q.set("query", query);
+    // API QUIRK (live-verified on mobile): /v1/models returns an EMPTY page
+    // when BOTH `query` and `username` are sent — so with a creator picked,
+    // send only `username` and match the keyword client-side below.
+    if (query && !username) q.set("query", query);
+    if (username) q.set("username", username);
     if (cursor) q.set("cursor", cursor);
     const data = await this._get(`${API}/v1/models?${q.toString()}`);
-    const models = (data.items || [])
+    let models = (data.items || [])
       .map((x) => this._modelFromJson(x, levels))
       .filter(Boolean);
+    if (query && username) {
+      const kw = String(query).toLowerCase();
+      models = models.filter((m) => (m.name || "").toLowerCase().includes(kw));
+    }
     return { models, nextCursor: data.metadata?.nextCursor || null };
   }
 
@@ -332,6 +355,45 @@ export class CivitaiClient {
       downloadCount: j.stats?.downloadCount, thumbsUp: j.stats?.thumbsUpCount,
       tags: j.tags || [],
     };
+  }
+
+  // ── creators (leaderboard tRPC + /v1/creators search) ────────────────────
+  /** The site's creator leaderboard (civitai.com/leaderboard, "Creators"
+   *  board) via tRPC — the public v1 API exposes NO leaderboard ordering
+   *  (/v1/creators is join-date ordered), so this mirrors the website's own
+   *  request. The endpoint intermittently 401s bare user agents; the proxy's
+   *  browser-shaped headers usually pass, but callers must degrade gracefully
+   *  (the picker shows "Top creators unavailable right now"). */
+  async fetchTopCreators({ limit = 25 } = {}) {
+    const enc = encodeURIComponent(JSON.stringify({ json: { id: "overall" } }));
+    const data = await this._get(`${API}/trpc/leaderboard.getLeaderboard?input=${enc}`);
+    const entries = data.result?.data?.json;
+    if (!Array.isArray(entries)) return [];
+    const out = [];
+    for (const e of entries) {
+      const username = e?.user?.username;
+      if (!username || e?.user?.deletedAt != null) continue;
+      const metric = (t) =>
+        Array.isArray(e.metrics) ? e.metrics.find((m) => m?.type === t)?.value ?? null : null;
+      out.push({
+        username, position: e.position ?? null, score: e.score ?? null,
+        downloads: metric("downloadCount"), thumbsUp: metric("thumbsUpCount"),
+      });
+      if (out.length >= limit) break;
+    }
+    return out;
+  }
+
+  /** Search creators by (partial) username via the public /v1/creators API.
+   *  Unranked (join-date order) — for ranked names use fetchTopCreators. */
+  async searchCreators(query, { limit = 20 } = {}) {
+    const trimmed = String(query || "").trim();
+    if (!trimmed) return [];
+    const q = new URLSearchParams({ query: trimmed, limit: String(limit) });
+    const data = await this._get(`${API}/v1/creators?${q.toString()}`);
+    return (data.items || [])
+      .filter((j) => j && j.username)
+      .map((j) => ({ username: j.username, modelCount: j.modelCount ?? 0 }));
   }
 
   async getGenerationData(imageId) {

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -324,26 +324,35 @@ export class CivitaiClient {
   }
 
   async fetchModels({ type, sort = "Most Downloaded", period = "Week", baseModels = [], levels = [1], limit = 100, cursor, query, username } = {}) {
-    const q = new URLSearchParams({
+    const base = new URLSearchParams({
       limit: String(limit), types: type, sort, period,
       nsfw: bitmask(levels) > 2 ? "true" : "false",
     });
-    for (const b of baseModels) q.append("baseModels", b);
+    for (const b of baseModels) base.append("baseModels", b);
     // API QUIRK (live-verified on mobile): /v1/models returns an EMPTY page
     // when BOTH `query` and `username` are sent — so with a creator picked,
     // send only `username` and match the keyword client-side below.
-    if (query && !username) q.set("query", query);
-    if (username) q.set("username", username);
-    if (cursor) q.set("cursor", cursor);
-    const data = await this._get(`${API}/v1/models?${q.toString()}`);
-    let models = (data.items || [])
-      .map((x) => this._modelFromJson(x, levels))
-      .filter(Boolean);
-    if (query && username) {
-      const kw = String(query).toLowerCase();
-      models = models.filter((m) => (m.name || "").toLowerCase().includes(kw));
+    const clientFilter = !!(query && username);
+    if (query && !username) base.set("query", query);
+    if (username) base.set("username", username);
+    const kw = clientFilter ? String(query).toLowerCase() : null;
+    let next = cursor || null;
+    let models = [];
+    // Exactly ONE request on every path except keyword×creator, whose
+    // client-side matching can empty a page — that combo (and ONLY that
+    // combo) chases a few more pages so a thinned page isn't a dead end.
+    for (let hop = 0; ; hop++) {
+      const q = new URLSearchParams(base);
+      if (next) q.set("cursor", next);
+      const data = await this._get(`${API}/v1/models?${q.toString()}`);
+      models = (data.items || [])
+        .map((x) => this._modelFromJson(x, levels))
+        .filter(Boolean);
+      if (kw) models = models.filter((m) => (m.name || "").toLowerCase().includes(kw));
+      next = data.metadata?.nextCursor || null;
+      if (!clientFilter || models.length || !next || hop >= 4) break;
     }
-    return { models, nextCursor: data.metadata?.nextCursor || null };
+    return { models, nextCursor: next };
   }
 
   async fetchModelDetail(modelId, { levels = [1] } = {}) {


### PR DESCRIPTION
Adds a **Creator filter** to the CivitAI explorer's filter sheet — feature parity with the mobile app (comfyui-mcp-mobile PR #2), requested in Discord help thread `1527122588189327421` and by the maintainer.

## What it does

- **Creator section in the filter sheet**: an empty search field shows the site's **top-creators leaderboard** (tRPC `leaderboard.getLeaderboard` via the existing header-injecting Python proxy), ranked with compact download/like counts. Typing swaps to a **debounced (300ms) `GET /v1/creators` username search** (with model counts).
- **Picked creator = removable pill**, threaded through every query the explorer makes:
  - image/video feed: `/v1/images?username=<creator>`
  - media keyword search: Meilisearch filter `user.username = "<escaped>"` (backslashes escaped **before** quotes so a trailing `\` or crafted `\"` can't break out of the filter string)
  - model tabs: `/v1/models?username=<creator>`
- **Reset filters** clears it (`username` is now part of `DEFAULT_FILTERS` / `filtersDirty`, so the header's filter dot lights up while a creator is active).

## Known API quirks handled (discovered during the mobile pass)

- `/v1/models` with **both** `query` and `username` returns an empty page — with a creator picked we send only `username` and match the keyword client-side; the models loader chases up to 4 extra pages when a page filters down to nothing so the infinite-scroll sentinel can't stall.
- The leaderboard endpoint intermittently 401s bare user agents — the proxy's browser-shaped headers usually pass, and on failure the picker degrades to *"Top creators unavailable right now."* without breaking the rest of the sheet.

## Review findings from the mobile pass, avoided here

- Meili escaping order: backslashes first, then quotes (unit-tested).
- Debounced creator lookups carry a **generation counter** (bumped on every keystroke, not just at debounce fire) so a slow stale response can't repopulate the dropdown under a newer query. The counter lives outside the sheet's re-render closure so re-renders can't resurrect stale responses either.
- **Favorites tab shows the filter visibly inert** (dimmed pill + "Ignored on the Favorites tab…") instead of silently no-oping — favorites are *your* likes, from every creator; the tRPC favorites feed has no creator param. Matches the mobile semantics.

## Verified

- `node --check` on `cmcp-civitai.js`, `cmcp-civitai-ui.js`, and `comfyui-mcp-panel.js` as `.mjs` copies — clean.
- `npm run test:unit` — 35 pass (9 new in `browser_tests/unit/civitai-creator.test.mjs`: escaping order, the models quirk, leaderboard parsing incl. deleted-user drop and non-array degrade, `/v1/creators` shaping + blank-query short-circuit, username threading into feed/search).
- `npm run typecheck` — clean.

## Owed

- **Live browser verification** (open the explorer, pick a leaderboard creator, confirm each tab narrows, confirm the 401 degrade path) — not run in this environment; needs a ComfyUI + Chrome pass before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)