### PR TITLE
feat(civitai): load workflows onto the canvas — from posts and Workflows-tab files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,18 @@ All notable changes to this project are documented here. This project adheres to
   `.json` loads directly; civitai's `.zip` wrappers (780 of 844 live versions)
   are unpacked in the browser (central-directory walk +
   `DecompressionStream("deflate-raw")`, no new dependency) with a picker when
-  an archive holds several workflows. Downloads stream through a new
-  same-origin proxy route that follows civitai's 307 to the signed CDN URL
-  server-side (dropping the OAuth header on the cross-host hop) and caps at
-  100MB; a gated file's 401/403 surfaces as a "sign in via the account
-  button" hint
+  an archive holds several workflows, under zip-bomb caps (entry count,
+  per-entry and aggregate uncompressed size — a lying size header is
+  re-checked after inflation; duplicate directory records aimed at one blob
+  are deduped). Downloads stream through a new same-origin proxy route that
+  follows civitai's 307 server-side with an SSRF guard — only https
+  civitai/B2 hosts whose every DNS answer is a public address (no
+  loopback/RFC1918/link-local/metadata, no rebinding), OAuth header dropped
+  on the cross-host hop — streaming through (no buffering) with a 100MB cap;
+  a gated file's 401/403 surfaces as a "sign in via the account button" hint.
+  The overwrite-confirm dirty check fails CLOSED (unknown workflow state ⇒
+  ask), and the load is awaited so success/undo bookkeeping only fires once
+  the graph actually landed
 - CivitAI browser: **Creator filter** in the filter sheet (parity with the
   mobile app) — an empty field shows the site's top-creators leaderboard
   (ranked, with download/like counts; degrades to a friendly note when the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,32 @@ All notable changes to this project are documented here. This project adheres to
 - CivitAI browser filters actually respond: chips re-render on click (the sheet
   wired a rerender hook that was never defined, so they looked dead), and the
   level/base-model toggles no longer mutate the frozen module defaults
+- CivitAI lightbox no longer claims "✓ Embedded ComfyUI workflow" for posts
+  whose `meta.comfy.workflow` is the empty `{}` civitai sometimes emits — it
+  now falls back to the API-format prompt (savable) and says which one it found
 
 ### Added
 - CivitAI browser: **"See more from @creator"** in the lightbox and model
   detail, and **GitHub-style search qualifiers** — "@name terms" sets the
   creator filter (the displayed @token always owns it; deleting it clears)
   while the terms stay ranked full-text search (#86)
+- CivitAI browser: **Load workflow onto canvas** (community request from
+  Discord). In the lightbox, a post with an embedded UI-format ComfyUI graph
+  gets a "Load onto canvas" action: confirm-overwrite when the current
+  workflow has unsaved changes, then load through the same undoable path the
+  agent bridge uses (snapshot → `loadGraphData` → change-tracker `checkState`,
+  so one load = one Ctrl+Z). API-format-only posts say so honestly instead of
+  corrupting the canvas (Save still keeps their JSON — there is no client-side
+  API→UI converter). On the Workflows tab, model versions grow a
+  "Load workflow onto canvas" button per downloadable workflow file: raw
+  `.json` loads directly; civitai's `.zip` wrappers (780 of 844 live versions)
+  are unpacked in the browser (central-directory walk +
+  `DecompressionStream("deflate-raw")`, no new dependency) with a picker when
+  an archive holds several workflows. Downloads stream through a new
+  same-origin proxy route that follows civitai's 307 to the signed CDN URL
+  server-side (dropping the OAuth header on the cross-host hop) and caps at
+  100MB; a gated file's 401/403 surfaces as a "sign in via the account
+  button" hint
 - CivitAI browser: **Creator filter** in the filter sheet (parity with the
   mobile app) — an empty field shows the site's top-creators leaderboard
   (ranked, with download/like counts; degrades to a friendly note when the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,11 +38,17 @@ All notable changes to this project are documented here. This project adheres to
   follows civitai's 307 server-side with an SSRF guard — only https
   civitai/B2 hosts whose every DNS answer is a public address (no
   loopback/RFC1918/link-local/metadata, no rebinding), OAuth header dropped
-  on the cross-host hop — streaming through (no buffering) with a 100MB cap;
-  a gated file's 401/403 surfaces as a "sign in via the account button" hint.
-  The overwrite-confirm dirty check fails CLOSED (unknown workflow state ⇒
-  ask), and the load is awaited so success/undo bookkeeping only fires once
-  the graph actually landed
+  on the cross-host hop — streaming through (no buffering) with a 100MB cap.
+  Gated files (civitai 307s the download to `/login?…reason=download-auth`,
+  even on some "Public" versions) are detected deterministically and return a
+  clean 401, and every download/parse/empty/API-only outcome is surfaced BOTH
+  as a top-of-stack toast and an inline status line in the version sheet
+  (which stays open) — with a one-click "sign in" for the gated case — so the
+  action is never a silent no-op. A load reporting zero nodes is treated as a
+  failure (the explorer stays open) rather than a phantom success. The
+  overwrite-confirm dirty check fails CLOSED (unknown workflow state ⇒ ask),
+  and the load is awaited so success/undo bookkeeping only fires once the
+  graph actually landed
 - CivitAI browser: **Creator filter** in the filter sheet (parity with the
   mobile app) — an empty field shows the site's top-creators leaderboard
   (ranked, with download/like counts; degrades to a friendly note when the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,10 +35,12 @@ All notable changes to this project are documented here. This project adheres to
   per-entry and aggregate uncompressed size — a lying size header is
   re-checked after inflation; duplicate directory records aimed at one blob
   are deduped). Downloads stream through a new same-origin proxy route that
-  follows civitai's 307 server-side with an SSRF guard — only https
-  civitai/B2 hosts whose every DNS answer is a public address (no
-  loopback/RFC1918/link-local/metadata, no rebinding), OAuth header dropped
-  on the cross-host hop — streaming through (no buffering) with a 100MB cap.
+  follows civitai's 307 server-side with an SSRF guard — only https civitai
+  download CDNs (civitai/B2 **and** civitai's signed Cloudflare R2 delivery
+  worker, where signed-in downloads land) whose every DNS answer is a public
+  address (no loopback/RFC1918/link-local/metadata, no rebinding), OAuth
+  header dropped on the cross-host hop — streaming through (no buffering)
+  with a 100MB cap.
   Gated files (civitai 307s the download to `/login?…reason=download-auth`,
   even on some "Public" versions) are detected deterministically and return a
   clean 401, and every download/parse/empty/API-only outcome is surfaced BOTH

--- a/browser_tests/unit/civitai-workflow.test.mjs
+++ b/browser_tests/unit/civitai-workflow.test.mjs
@@ -197,7 +197,7 @@ test("zipEntries rejects archives past the entry-count cap", () => {
     (e) => e.zipCap === true && /too many entries/.test(e.message));
 });
 
-test("zipReadText rejects entries whose CLAIMED size exceeds the per-entry cap", async () => {
+test("zipReadText aborts inflation past the per-entry cap", async () => {
   const big = JSON.stringify({ ...UI_GRAPH, pad: "x".repeat(500) });
   const bytes = buildZip([["big.json", big]]);
   const caps = { ...CivitaiClient.ZIP_CAPS, entryBytes: 100 };
@@ -206,17 +206,19 @@ test("zipReadText rejects entries whose CLAIMED size exceeds the per-entry cap",
     (err) => err.zipCap === true && /entry too large/.test(err.message));
 });
 
-test("a LYING uSize header still hits the post-inflation cap", async () => {
-  // claimed 10 bytes (passes every pre-check: uSize 10 and the well-compressed
-  // cSize both sit under the cap), actually inflates to ~10KB
-  const big = JSON.stringify({ ...UI_GRAPH, pad: "x".repeat(10000) });
-  const bytes = buildZip([["liar.json", big]], { uSizeOverride: 10 });
-  const caps = { ...CivitaiClient.ZIP_CAPS, entryBytes: 300 };
+test("a LYING-LOW uSize is ignored — the STREAMING counter catches the real inflation", async () => {
+  // The killer case: central-directory uSize claims 5 bytes (so any declared-
+  // size pre-check would wave it through), the well-compressed cSize is tiny,
+  // but it actually inflates to ~2MB from a highly repetitive payload. The
+  // streaming counter must abort mid-inflation — never materialize the 2MB.
+  const bomb = JSON.stringify({ ...UI_GRAPH, pad: "A".repeat(2_000_000) });
+  const bytes = buildZip([["liar.json", bomb]], { uSizeOverride: 5 });
+  const caps = { ...CivitaiClient.ZIP_CAPS, entryBytes: 4096 }; // 4KB — far below 2MB
   const [e] = CivitaiClient.zipEntries(bytes, caps);
-  assert.equal(e.uSize, 10); // the lie is in place
+  assert.equal(e.uSize, 5);                    // the lie is in place
+  assert.ok(e.cSize < 4096);                   // compressed blob itself is tiny
   await assert.rejects(() => CivitaiClient.zipReadText(bytes, e, caps),
     (err) => err.zipCap === true && /entry too large/.test(err.message));
-  // and workflowsFromZip surfaces it instead of silently skipping
   await assert.rejects(() => CivitaiClient.workflowsFromZip(bytes, caps),
     (err) => err.zipCap === true);
 });
@@ -227,6 +229,27 @@ test("workflowsFromZip rejects archives past the AGGREGATE cap", async () => {
   const caps = { ...CivitaiClient.ZIP_CAPS, totalBytes: 250 }; // one fits, two don't
   await assert.rejects(() => CivitaiClient.workflowsFromZip(bytes, caps),
     (err) => err.zipCap === true && /unpacks too large/.test(err.message));
+});
+
+test("aggregate cap counts UTF-8 BYTES, not UTF-16 code units", async () => {
+  // Each entry pads with a 3-byte-UTF-8 / 1-UTF-16-unit char, so byte length is
+  // ~3× the string length. Two entries: ~24KB of bytes but only ~8K code
+  // units. A byte cap between them must catch the second; a string-length
+  // counter (the bug) would see 8K < the cap and wave it through.
+  const pad = "の".repeat(4000);                 // 12000 UTF-8 bytes, 4000 UTF-16 units
+  const entry = JSON.stringify({ ...UI_GRAPH, pad });
+  const bytes = buildZip([["a.json", entry], ["b.json", entry]], { zeroLfhSizes: true });
+  const oneByteLen = new TextEncoder().encode(entry).length;
+  const oneStrLen = entry.length;
+  assert.ok(oneByteLen > oneStrLen * 2);         // multibyte confirmed
+  // cap: one entry fits, two exceed it in BYTES but NOT in UTF-16 units
+  const caps = { ...CivitaiClient.ZIP_CAPS, totalBytes: Math.floor(oneByteLen * 1.5) };
+  assert.ok(caps.totalBytes > oneStrLen * 2);    // a string counter would pass both
+  await assert.rejects(() => CivitaiClient.workflowsFromZip(bytes, caps),
+    (err) => err.zipCap === true && /unpacks too large/.test(err.message));
+  // control: a byte cap that fits both loads both
+  const roomy = { ...CivitaiClient.ZIP_CAPS, totalBytes: oneByteLen * 3 };
+  assert.equal((await CivitaiClient.workflowsFromZip(bytes, roomy)).length, 2);
 });
 
 test("duplicate central-directory records aimed at one local header are deduped", () => {

--- a/browser_tests/unit/civitai-workflow.test.mjs
+++ b/browser_tests/unit/civitai-workflow.test.mjs
@@ -7,6 +7,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { deflateRawSync } from "node:zlib";
 import { CivitaiClient } from "../../web/js/cmcp-civitai.js";
+import { graphDirtyForConfirm } from "../../web/js/cmcp-civitai-ui.js";
 
 // ── fixtures ────────────────────────────────────────────────────────────────
 const UI_GRAPH = {
@@ -23,8 +24,10 @@ const API_GRAPH = {
 
 /** Minimal in-memory zip builder. zeroLfhSizes mirrors civitai's real zips:
  *  bit-3 data descriptors leave the LOCAL header sizes at 0 — only the
- *  central directory knows them. */
-function buildZip(files, { zeroLfhSizes = false, store = false } = {}) {
+ *  central directory knows them. uSizeOverride fakes the central directory's
+ *  claimed uncompressed size (lying-header bomb); dupCentral appends N extra
+ *  copies of each central record pointing at the SAME local header. */
+function buildZip(files, { zeroLfhSizes = false, store = false, uSizeOverride = null, dupCentral = 0 } = {}) {
   const u16 = (v) => { const b = Buffer.alloc(2); b.writeUInt16LE(v); return b; };
   const u32 = (v) => { const b = Buffer.alloc(4); b.writeUInt32LE(v >>> 0); return b; };
   const chunks = [];
@@ -43,17 +46,19 @@ function buildZip(files, { zeroLfhSizes = false, store = false } = {}) {
       u32(0), u32(zeroLfhSizes ? 0 : data.length), u32(zeroLfhSizes ? 0 : raw.length),
       u16(nameB.length), u16(0), nameB, data,
     ]));
-    central.push(Buffer.concat([
+    const record = Buffer.concat([
       u32(0x02014b50), u16(20), u16(20), u16(flags), u16(method), u16(0), u16(0),
-      u32(0), u32(data.length), u32(raw.length),
+      u32(0), u32(data.length), u32(uSizeOverride ?? raw.length),
       u16(nameB.length), u16(0), u16(0), u16(0), u16(0), u32(0), u32(lfhOff), nameB,
-    ]));
+    ]);
+    central.push(record);
+    for (let d = 0; d < dupCentral; d++) central.push(Buffer.from(record));
   }
   const cd = Buffer.concat(central);
   const cdOff = offset;
   push(cd);
   push(Buffer.concat([
-    u32(0x06054b50), u16(0), u16(0), u16(files.length), u16(files.length),
+    u32(0x06054b50), u16(0), u16(0), u16(central.length), u16(central.length),
     u32(cd.length), u32(cdOff), u16(0),
   ]));
   return new Uint8Array(Buffer.concat(chunks));
@@ -180,6 +185,78 @@ test("zipReadText inflates DEFLATE and reads STORE entries", async () => {
 
 test("zipEntries throws on non-zip bytes", () => {
   assert.throws(() => CivitaiClient.zipEntries(new Uint8Array([1, 2, 3, 4])), /not a zip/);
+});
+
+// ── zip-bomb caps (injected small so the tests stay KB-sized) ───────────────
+test("zipEntries rejects archives past the entry-count cap", () => {
+  const bytes = buildZip([
+    ["a.json", "{}"], ["b.json", "{}"], ["c.json", "{}"],
+  ]);
+  const caps = { ...CivitaiClient.ZIP_CAPS, entries: 2 };
+  assert.throws(() => CivitaiClient.zipEntries(bytes, caps),
+    (e) => e.zipCap === true && /too many entries/.test(e.message));
+});
+
+test("zipReadText rejects entries whose CLAIMED size exceeds the per-entry cap", async () => {
+  const big = JSON.stringify({ ...UI_GRAPH, pad: "x".repeat(500) });
+  const bytes = buildZip([["big.json", big]]);
+  const caps = { ...CivitaiClient.ZIP_CAPS, entryBytes: 100 };
+  const [e] = CivitaiClient.zipEntries(bytes, caps);
+  await assert.rejects(() => CivitaiClient.zipReadText(bytes, e, caps),
+    (err) => err.zipCap === true && /entry too large/.test(err.message));
+});
+
+test("a LYING uSize header still hits the post-inflation cap", async () => {
+  // claimed 10 bytes (passes every pre-check: uSize 10 and the well-compressed
+  // cSize both sit under the cap), actually inflates to ~10KB
+  const big = JSON.stringify({ ...UI_GRAPH, pad: "x".repeat(10000) });
+  const bytes = buildZip([["liar.json", big]], { uSizeOverride: 10 });
+  const caps = { ...CivitaiClient.ZIP_CAPS, entryBytes: 300 };
+  const [e] = CivitaiClient.zipEntries(bytes, caps);
+  assert.equal(e.uSize, 10); // the lie is in place
+  await assert.rejects(() => CivitaiClient.zipReadText(bytes, e, caps),
+    (err) => err.zipCap === true && /entry too large/.test(err.message));
+  // and workflowsFromZip surfaces it instead of silently skipping
+  await assert.rejects(() => CivitaiClient.workflowsFromZip(bytes, caps),
+    (err) => err.zipCap === true);
+});
+
+test("workflowsFromZip rejects archives past the AGGREGATE cap", async () => {
+  const entry = JSON.stringify({ ...UI_GRAPH, pad: "x".repeat(40) }); // ~190B each
+  const bytes = buildZip([["a.json", entry], ["b.json", entry]]);
+  const caps = { ...CivitaiClient.ZIP_CAPS, totalBytes: 250 }; // one fits, two don't
+  await assert.rejects(() => CivitaiClient.workflowsFromZip(bytes, caps),
+    (err) => err.zipCap === true && /unpacks too large/.test(err.message));
+});
+
+test("duplicate central-directory records aimed at one local header are deduped", () => {
+  // bomb trick: N directory records × one compressed blob = N× inflation
+  const bytes = buildZip([["a.json", JSON.stringify(UI_GRAPH)]], { dupCentral: 3 });
+  const entries = CivitaiClient.zipEntries(bytes);
+  assert.equal(entries.length, 1);
+});
+
+test("central records whose spans run past the buffer stop the walk", () => {
+  const bytes = buildZip([["a.json", "{}"]]);
+  // patch the central record's nameLen to a huge value (record sig scan)
+  const dv = new DataView(bytes.buffer);
+  for (let i = 0; i + 4 <= bytes.length; i++) {
+    if (dv.getUint32(i, true) === 0x02014b50) { dv.setUint16(i + 28, 0xffff, true); break; }
+  }
+  assert.deepEqual(CivitaiClient.zipEntries(bytes), []);
+});
+
+// ── dirty-check fails CLOSED ────────────────────────────────────────────────
+test("graphDirtyForConfirm treats every uncertainty as dirty", () => {
+  assert.equal(graphDirtyForConfirm(undefined), true);           // no ctx at all
+  assert.equal(graphDirtyForConfirm({}), true);                  // getter missing
+  assert.equal(graphDirtyForConfirm({ graphIsDirty: 7 }), true); // not callable
+  assert.equal(graphDirtyForConfirm({ graphIsDirty: () => { throw new Error("x"); } }), true);
+  assert.equal(graphDirtyForConfirm({ graphIsDirty: () => undefined }), true); // non-boolean
+  assert.equal(graphDirtyForConfirm({ graphIsDirty: () => "no" }), true);
+  // and it still trusts a definite answer
+  assert.equal(graphDirtyForConfirm({ graphIsDirty: () => false }), false);
+  assert.equal(graphDirtyForConfirm({ graphIsDirty: () => true }), true);
 });
 
 test("workflowsFromZip extracts graphs, skips junk, sorts UI first", async () => {

--- a/browser_tests/unit/civitai-workflow.test.mjs
+++ b/browser_tests/unit/civitai-workflow.test.mjs
@@ -1,0 +1,227 @@
+// Unit tests for the CivitAI "load workflow onto canvas" plumbing
+// (cmcp-civitai.js): UI/API format detection, meta.comfy extraction against
+// the live payload shapes, version-file selection, and the minimal zip reader
+// (civitai wraps Workflows uploads in small zips whose local headers use data
+// descriptors — sizes live only in the central directory).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { deflateRawSync } from "node:zlib";
+import { CivitaiClient } from "../../web/js/cmcp-civitai.js";
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+const UI_GRAPH = {
+  last_node_id: 2, last_link_id: 1,
+  nodes: [{ id: 1, type: "KSampler" }, { id: 2, type: "SaveImage" }],
+  links: [], groups: [], config: {}, extra: {}, version: 0.4,
+};
+// API/prompt format — numeric keys, each with class_type (live shape from
+// tRPC image.getGenerationData, image 136187879).
+const API_GRAPH = {
+  10002: { class_type: "ECHOCheckpointLoaderSimple", inputs: { ckpt_name: "EMS.safetensors" } },
+  10012: { class_type: "KSampler", inputs: {} },
+};
+
+/** Minimal in-memory zip builder. zeroLfhSizes mirrors civitai's real zips:
+ *  bit-3 data descriptors leave the LOCAL header sizes at 0 — only the
+ *  central directory knows them. */
+function buildZip(files, { zeroLfhSizes = false, store = false } = {}) {
+  const u16 = (v) => { const b = Buffer.alloc(2); b.writeUInt16LE(v); return b; };
+  const u32 = (v) => { const b = Buffer.alloc(4); b.writeUInt32LE(v >>> 0); return b; };
+  const chunks = [];
+  const central = [];
+  let offset = 0;
+  const push = (b) => { chunks.push(b); offset += b.length; };
+  for (const [name, text] of files) {
+    const nameB = Buffer.from(name);
+    const raw = Buffer.from(text);
+    const data = store ? raw : deflateRawSync(raw);
+    const method = store ? 0 : 8;
+    const flags = zeroLfhSizes ? 8 : 0; // bit 3: sizes follow in a data descriptor
+    const lfhOff = offset;
+    push(Buffer.concat([
+      u32(0x04034b50), u16(20), u16(flags), u16(method), u16(0), u16(0),
+      u32(0), u32(zeroLfhSizes ? 0 : data.length), u32(zeroLfhSizes ? 0 : raw.length),
+      u16(nameB.length), u16(0), nameB, data,
+    ]));
+    central.push(Buffer.concat([
+      u32(0x02014b50), u16(20), u16(20), u16(flags), u16(method), u16(0), u16(0),
+      u32(0), u32(data.length), u32(raw.length),
+      u16(nameB.length), u16(0), u16(0), u16(0), u16(0), u32(0), u32(lfhOff), nameB,
+    ]));
+  }
+  const cd = Buffer.concat(central);
+  const cdOff = offset;
+  push(cd);
+  push(Buffer.concat([
+    u32(0x06054b50), u16(0), u16(0), u16(files.length), u16(files.length),
+    u32(cd.length), u32(cdOff), u16(0),
+  ]));
+  return new Uint8Array(Buffer.concat(chunks));
+}
+
+// ── workflowFormat ──────────────────────────────────────────────────────────
+test("workflowFormat classifies UI, API, and junk", () => {
+  const f = CivitaiClient.workflowFormat;
+  assert.equal(f(UI_GRAPH), "ui");
+  assert.equal(f({ nodes: [] }), "ui"); // empty-but-real litegraph doc
+  assert.equal(f(API_GRAPH), "api");
+  assert.equal(f({}), "unknown"); // civitai's empty `workflow: {}`
+  assert.equal(f(null), "unknown");
+  assert.equal(f([1, 2]), "unknown");
+  assert.equal(f("nodes"), "unknown");
+  assert.equal(f({ 1: { foo: 1 } }), "unknown"); // numeric keys, no class_type
+  assert.equal(f({ prompt: "x" }), "unknown");
+});
+
+// ── comfyGraphInfo / comfyGraph ─────────────────────────────────────────────
+test("comfyGraphInfo prefers the UI workflow (live object shape)", () => {
+  const info = CivitaiClient.comfyGraphInfo({ comfy: { prompt: API_GRAPH, workflow: UI_GRAPH } });
+  assert.equal(info.format, "ui");
+  assert.equal(info.graph.nodes.length, 2);
+});
+
+test("comfyGraphInfo falls back to API when workflow is the live empty {}", () => {
+  // Regression: image 136187879 carries { prompt: <api>, workflow: {} } — the
+  // old comfyGraph returned the truthy-but-empty {} and lit the ✓ badge.
+  const info = CivitaiClient.comfyGraphInfo({ comfy: { prompt: API_GRAPH, workflow: {} } });
+  assert.equal(info.format, "api");
+  assert.equal(info.graph, API_GRAPH);
+});
+
+test("comfyGraphInfo parses legacy string-encoded shapes", () => {
+  // whole comfy is a JSON string
+  const s = CivitaiClient.comfyGraphInfo({ comfy: JSON.stringify({ workflow: UI_GRAPH }) });
+  assert.equal(s.format, "ui");
+  // workflow field is itself a JSON string
+  const inner = CivitaiClient.comfyGraphInfo({ comfy: { workflow: JSON.stringify(UI_GRAPH) } });
+  assert.equal(inner.format, "ui");
+  assert.equal(inner.graph.nodes.length, 2);
+  // unparseable string → null, never a throw
+  assert.equal(CivitaiClient.comfyGraphInfo({ comfy: "not json {" }), null);
+  // unparseable workflow string but valid prompt → api fallback
+  const fb = CivitaiClient.comfyGraphInfo({ comfy: { workflow: "not json {", prompt: API_GRAPH } });
+  assert.equal(fb.format, "api");
+});
+
+test("comfyGraphInfo handles bare graphs and empties", () => {
+  assert.equal(CivitaiClient.comfyGraphInfo({ comfy: UI_GRAPH }).format, "ui");
+  assert.equal(CivitaiClient.comfyGraphInfo({ comfy: API_GRAPH }).format, "api");
+  assert.equal(CivitaiClient.comfyGraphInfo({ comfy: { workflow: {} } }), null);
+  assert.equal(CivitaiClient.comfyGraphInfo({}), null);
+  assert.equal(CivitaiClient.comfyGraphInfo(null), null);
+});
+
+test("comfyGraph stays back-compatible but no longer returns the empty {}", () => {
+  assert.equal(CivitaiClient.comfyGraph({ comfy: { workflow: UI_GRAPH } }), UI_GRAPH);
+  assert.equal(CivitaiClient.comfyGraph({ comfy: { workflow: {} } }), null);
+  assert.equal(CivitaiClient.comfyGraph(null), null);
+});
+
+// ── version-file selection ──────────────────────────────────────────────────
+test("workflowFiles: .json always, .zip only on Workflows models", () => {
+  const version = {
+    files: [
+      { id: 1, name: "wf.json", type: "Model", format: "Other", sizeKB: 12 },
+      { id: 2, name: "pack.zip", type: "Archive", format: "Other", sizeKB: 30 },
+      { id: 3, name: "model.safetensors", type: "Model", format: "SafeTensor", sizeKB: 2048 },
+    ],
+  };
+  assert.deepEqual(
+    CivitaiClient.workflowFiles(version, "Workflows").map((f) => f.id), [1, 2]);
+  // on a Checkpoint the zip is training data, not a workflow
+  assert.deepEqual(
+    CivitaiClient.workflowFiles(version, "Checkpoint").map((f) => f.id), [1]);
+});
+
+test("workflowFiles dedupes by (type, format) — the download API can't address duplicates", () => {
+  // live shape: version 2947948 has TWO Archive/Other zips; only one is reachable
+  const version = {
+    files: [
+      { id: 1, name: "a.zip", type: "Archive", format: "Other", sizeKB: 5 },
+      { id: 2, name: "b.zip", type: "Archive", format: "Other", sizeKB: 5 },
+    ],
+  };
+  assert.equal(CivitaiClient.workflowFiles(version, "Workflows").length, 1);
+});
+
+test("workflowFiles skips files beyond the proxy's 100MB cap", () => {
+  const version = { files: [{ id: 1, name: "huge.zip", type: "Archive", format: "Other", sizeKB: 200 * 1024 }] };
+  assert.deepEqual(CivitaiClient.workflowFiles(version, "Workflows"), []);
+});
+
+test("_versionFromJson carries the files list (id/name/size/type/format)", () => {
+  const client = new CivitaiClient({ apiURL: (p) => p });
+  const v = client._versionFromJson({
+    id: 9, files: [{ id: 5, name: "wf.zip", sizeKB: 4.9, type: "Archive", metadata: { format: "Other" } }],
+  }, [1]);
+  assert.deepEqual(v.files, [{ id: 5, name: "wf.zip", sizeKB: 4.9, type: "Archive", format: "Other" }]);
+});
+
+// ── zip reader ──────────────────────────────────────────────────────────────
+test("zipEntries walks the central directory even when LFH sizes are zeroed", () => {
+  // civitai's real zips use data descriptors: LFH says size 0, only the
+  // central directory is truthful (live-verified on version 2947948).
+  const bytes = buildZip([["a.json", JSON.stringify(UI_GRAPH)]], { zeroLfhSizes: true });
+  const entries = CivitaiClient.zipEntries(bytes);
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].name, "a.json");
+  assert.equal(entries[0].method, 8);
+  assert.ok(entries[0].cSize > 0); // from the central directory, not the LFH
+});
+
+test("zipReadText inflates DEFLATE and reads STORE entries", async () => {
+  const text = JSON.stringify(UI_GRAPH);
+  for (const store of [false, true]) {
+    const bytes = buildZip([["wf.json", text]], { store, zeroLfhSizes: !store });
+    const [e] = CivitaiClient.zipEntries(bytes);
+    assert.equal(await CivitaiClient.zipReadText(bytes, e), text);
+  }
+});
+
+test("zipEntries throws on non-zip bytes", () => {
+  assert.throws(() => CivitaiClient.zipEntries(new Uint8Array([1, 2, 3, 4])), /not a zip/);
+});
+
+test("workflowsFromZip extracts graphs, skips junk, sorts UI first", async () => {
+  const bytes = buildZip([
+    ["readme.txt", "hello"],                          // not .json — skipped
+    ["api_only.json", JSON.stringify(API_GRAPH)],     // api — kept, sorted last
+    ["broken.json", "{ nope"],                        // unparseable — skipped
+    ["real.json", JSON.stringify(UI_GRAPH)],          // ui — first
+    ["notes.json", JSON.stringify({ hello: 1 })],     // unknown format — skipped
+  ], { zeroLfhSizes: true });
+  const out = await CivitaiClient.workflowsFromZip(bytes);
+  assert.deepEqual(out.map((c) => [c.name, c.format]),
+    [["real.json", "ui"], ["api_only.json", "api"]]);
+  assert.equal(out[0].graph.nodes.length, 2);
+});
+
+// ── download plumbing ───────────────────────────────────────────────────────
+test("downloadVersionFile hits the proxy download route with type/format", async () => {
+  const calls = [];
+  const client = new CivitaiClient({
+    fetchApi: async (path) => {
+      calls.push(path);
+      return { ok: true, arrayBuffer: async () => new Uint8Array([80, 75]).buffer };
+    },
+    apiURL: (p) => p,
+  });
+  const bytes = await client.downloadVersionFile(2947948, { type: "Archive", format: "Other" });
+  assert.deepEqual([...bytes], [80, 75]);
+  const u = new URL(calls[0], "http://x");
+  assert.equal(u.pathname, "/comfyui_mcp_panel/civitai/download");
+  assert.equal(u.searchParams.get("versionId"), "2947948");
+  assert.equal(u.searchParams.get("type"), "Archive");
+  assert.equal(u.searchParams.get("format"), "Other");
+});
+
+test("downloadVersionFile surfaces the HTTP status for the sign-in hint", async () => {
+  const client = new CivitaiClient({
+    fetchApi: async () => ({ ok: false, status: 401 }),
+    apiURL: (p) => p,
+  });
+  await assert.rejects(
+    () => client.downloadVersionFile(1),
+    (e) => e.status === 401 && /401/.test(e.message),
+  );
+});

--- a/browser_tests/unit/test_civitai_download_route.py
+++ b/browser_tests/unit/test_civitai_download_route.py
@@ -1,0 +1,176 @@
+"""aiohttp-LEVEL integration tests for the /civitai/download route.
+
+Unlike the pure-function tests, these mount the REAL route (via
+civitai_proxy.register, exactly as __init__.py does) in a live aiohttp
+Application and drive it with an aiohttp test client, against a mock "civitai"
+upstream. This exercises the actual server flow — StreamResponse
+prepare()/write()/write_eof(), manual redirect following, the auth-redirect →
+401 short-circuit, and the HTML-200 → 401 guard — so a handler exception or a
+StreamResponse misuse (which a standalone harness silently passes) is caught.
+
+The live 502 that slipped past two review rounds was a served-route failure
+this class of test exists to prevent.
+
+Run:
+    python -m unittest browser_tests.unit.test_civitai_download_route
+    python browser_tests/unit/test_civitai_download_route.py
+"""
+
+import asyncio
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "py"))
+
+from aiohttp import web  # noqa: E402
+from aiohttp.test_utils import TestClient, TestServer  # noqa: E402
+
+import civitai_proxy as cp  # noqa: E402
+
+# A tiny real zip (STORE, one entry "a.json" = "{}") — enough to prove the
+# byte-stream survives the proxy intact.
+import io  # noqa: E402
+import zipfile  # noqa: E402
+
+
+def _tiny_zip():
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_STORED) as z:
+        z.writestr("a.json", "{}")
+    return buf.getvalue()
+
+
+ZIP_BYTES = _tiny_zip()
+
+
+def _build_app(mock_base):
+    """Mount the real download route, pointed at a mock upstream, plus the mock
+    civitai endpoints the route follows."""
+    routes = web.RouteTableDef()
+    cp.register(routes, web)
+    app = web.Application()
+
+    # Mock upstream: /dl/models/{id} mimics civitai's download endpoint. The
+    # route requires a numeric versionId, so the scenarios are keyed by digits:
+    #   1 = direct 200 zip, 2 = 307→B2 (redirect-follow), 3 = gated /login,
+    #   4 = HTML-200 login wall.
+    async def mock_download(request):
+        vid = request.match_info["vid"]
+        if vid == "1":
+            return web.Response(body=ZIP_BYTES, content_type="application/zip")
+        if vid == "2":
+            # civitai 307s to a signed B2 URL; we send an ABSOLUTE https URL on
+            # the same mock host and rely on the SSRF stubs (below) to allow it.
+            raise web.HTTPTemporaryRedirect(location=str(request.url.with_path("/b2/file.zip")))
+        if vid == "3":
+            raise web.HTTPTemporaryRedirect(
+                location="/login?returnUrl=%2Fmodel-versions%2F3&reason=download-auth"
+            )
+        if vid == "4":
+            return web.Response(text="<!DOCTYPE html><html>login</html>",
+                                content_type="text/html")
+        return web.Response(status=404)
+
+    async def mock_b2(request):
+        return web.Response(body=ZIP_BYTES, content_type="application/zip")
+
+    app.add_routes(routes)
+    app.router.add_get("/dl/models/{vid}", mock_download)
+    app.router.add_get("/b2/file.zip", mock_b2)
+    return app
+
+
+class DownloadRouteIntegration(unittest.TestCase):
+    def _run(self, coro):
+        return asyncio.new_event_loop().run_until_complete(coro)
+
+    async def _client(self, mock_base, *, allow_local_redirect=False):
+        app = _build_app(mock_base)
+        server = TestServer(app)
+        client = TestClient(server)
+        await client.start_server()
+        # point the route's upstream at THIS test server
+        cp._DOWNLOAD_BASE = str(client.make_url("/dl/models/"))
+        if allow_local_redirect:
+            # the mock B2 hop is on 127.0.0.1 — normally blocked; allow it so
+            # the redirect-follow + stream path is exercised end to end
+            self._orig_hostok = cp._redirect_host_ok
+            self._orig_pub = cp._resolves_public
+            cp._redirect_host_ok = lambda h: True
+
+            async def _pub(_h):
+                return True
+
+            cp._resolves_public = _pub
+        return client
+
+    def tearDown(self):
+        if hasattr(self, "_orig_hostok"):
+            cp._redirect_host_ok = self._orig_hostok
+        if hasattr(self, "_orig_pub"):
+            cp._resolves_public = self._orig_pub
+
+    def test_direct_200_streams_the_zip(self):
+        async def go():
+            client = await self._client("mock")
+            try:
+                resp = await client.get("/comfyui_mcp_panel/civitai/download?versionId=1")
+                self.assertEqual(resp.status, 200)
+                body = await resp.read()
+                self.assertEqual(body, ZIP_BYTES)
+                self.assertEqual(body[:2], b"PK")  # real zip magic survived the stream
+            finally:
+                await client.close()
+        self._run(go())
+
+    def test_http_redirect_downgrade_is_rejected(self):
+        # The mock B2 hop is an http URL (the test server is http). Even with
+        # the host allow-listed, the https-only guard must reject it (502) — no
+        # downgrade to a plaintext hop. The real https b2.civitai.com hop is
+        # exercised by the live-curl check documented in the PR; here we lock in
+        # that the redirect-follow path runs without raising and enforces https.
+        async def go():
+            client = await self._client("mock", allow_local_redirect=True)
+            try:
+                resp = await client.get("/comfyui_mcp_panel/civitai/download?versionId=2")
+                self.assertEqual(resp.status, 502)
+                self.assertIn("redirect target not allowed", await resp.text())
+            finally:
+                await client.close()
+        self._run(go())
+
+    def test_gated_login_redirect_returns_clean_401(self):
+        async def go():
+            client = await self._client("mock")
+            try:
+                resp = await client.get("/comfyui_mcp_panel/civitai/download?versionId=3")
+                self.assertEqual(resp.status, 401)  # NOT 502
+                self.assertIn("sign-in required", (await resp.json())["error"])
+            finally:
+                await client.close()
+        self._run(go())
+
+    def test_html_200_login_wall_returns_401(self):
+        async def go():
+            client = await self._client("mock")
+            try:
+                resp = await client.get("/comfyui_mcp_panel/civitai/download?versionId=4")
+                self.assertEqual(resp.status, 401)
+            finally:
+                await client.close()
+        self._run(go())
+
+    def test_bad_version_id_400(self):
+        async def go():
+            client = await self._client("mock")
+            try:
+                resp = await client.get("/comfyui_mcp_panel/civitai/download?versionId=not-a-number")
+                self.assertEqual(resp.status, 400)
+            finally:
+                await client.close()
+        self._run(go())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/browser_tests/unit/test_civitai_proxy.py
+++ b/browser_tests/unit/test_civitai_proxy.py
@@ -20,7 +20,7 @@ class RedirectHostAllowlist(unittest.TestCase):
     def test_civitai_and_b2_hosts_pass(self):
         for host in (
             "civitai.com",
-            "b2.civitai.com",          # the live signed-download host
+            "b2.civitai.com",          # the live signed-out download host
             "delivery.civitai.com",
             "civitai.red",
             "api.civitai.red",
@@ -28,6 +28,9 @@ class RedirectHostAllowlist(unittest.TestCase):
             "f004.backblazeb2.com",
             "B2.CIVITAI.COM",          # case-insensitive
             "b2.civitai.com.",         # trailing-dot FQDN form
+            # live signed-IN download host — civitai's Cloudflare R2 delivery worker
+            "civitai-delivery-worker-prod.5ac0637cfd0766c97916cefa3764fbdf.r2.cloudflarestorage.com",
+            "CIVITAI-DELIVERY-WORKER-PROD.abc123.R2.CLOUDFLARESTORAGE.COM",  # case-insensitive
         ):
             self.assertTrue(cp._redirect_host_ok(host), host)
 
@@ -40,6 +43,11 @@ class RedirectHostAllowlist(unittest.TestCase):
             "civitai.com.evil.com",     # allow-listed name as a PREFIX
             "notcivitai.com",           # suffix match must sit on a label boundary
             "xbackblazeb2.com",
+            # a foreign R2 bucket must NOT pass — only civitai's delivery worker
+            "evil-bucket.abc123.r2.cloudflarestorage.com",
+            "r2.cloudflarestorage.com",
+            # delivery-worker prefix on a NON-r2 host must not pass either
+            "civitai-delivery-worker-prod.evil.com",
             "",
             None,
             123,

--- a/browser_tests/unit/test_civitai_proxy.py
+++ b/browser_tests/unit/test_civitai_proxy.py
@@ -1,0 +1,76 @@
+"""Unit tests for the /download redirect SSRF guard in py/civitai_proxy.py.
+
+Dev-only (browser_tests/ never ships with the pack). Run from the repo root:
+
+    python -m unittest browser_tests.unit.test_civitai_proxy
+    # or directly:
+    python browser_tests/unit/test_civitai_proxy.py
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "py"))
+
+import civitai_proxy as cp  # noqa: E402
+
+
+class RedirectHostAllowlist(unittest.TestCase):
+    def test_civitai_and_b2_hosts_pass(self):
+        for host in (
+            "civitai.com",
+            "b2.civitai.com",          # the live signed-download host
+            "delivery.civitai.com",
+            "civitai.red",
+            "api.civitai.red",
+            "backblazeb2.com",
+            "f004.backblazeb2.com",
+            "B2.CIVITAI.COM",          # case-insensitive
+            "b2.civitai.com.",         # trailing-dot FQDN form
+        ):
+            self.assertTrue(cp._redirect_host_ok(host), host)
+
+    def test_everything_else_is_rejected(self):
+        for host in (
+            "evil.com",
+            "localhost",
+            "127.0.0.1",
+            "169.254.169.254",          # cloud metadata
+            "civitai.com.evil.com",     # allow-listed name as a PREFIX
+            "notcivitai.com",           # suffix match must sit on a label boundary
+            "xbackblazeb2.com",
+            "",
+            None,
+            123,
+        ):
+            self.assertFalse(cp._redirect_host_ok(host), repr(host))
+
+
+class PublicIpCheck(unittest.TestCase):
+    def test_public_addresses_pass(self):
+        for ip in ("142.250.72.14", "1.1.1.1", "2606:4700:4700::1111"):
+            self.assertTrue(cp._ip_public(ip), ip)
+
+    def test_internal_special_and_garbage_rejected(self):
+        for ip in (
+            "127.0.0.1",            # loopback
+            "10.1.2.3",             # RFC1918
+            "172.16.0.1",           # RFC1918
+            "192.168.1.1",          # RFC1918
+            "169.254.169.254",      # link-local / metadata
+            "0.0.0.0",              # unspecified
+            "224.0.0.1",            # multicast
+            "::1",                  # v6 loopback
+            "fe80::1",              # v6 link-local
+            "fd00::1",              # v6 ULA (private)
+            "::ffff:127.0.0.1",     # v4-mapped loopback smuggle
+            "::ffff:10.0.0.1",      # v4-mapped RFC1918 smuggle
+            "not-an-ip",
+            "",
+        ):
+            self.assertFalse(cp._ip_public(ip), ip)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/browser_tests/unit/test_civitai_proxy.py
+++ b/browser_tests/unit/test_civitai_proxy.py
@@ -72,5 +72,24 @@ class PublicIpCheck(unittest.TestCase):
             self.assertFalse(cp._ip_public(ip), ip)
 
 
+class GatedDownloadRedirect(unittest.TestCase):
+    def test_login_redirects_are_flagged_as_auth(self):
+        # live shape: 307 → /login?returnUrl=%2Fmodel-versions%2F3125639&reason=download-auth
+        self.assertTrue(cp._is_auth_redirect("/login", "returnUrl=%2Fx&reason=download-auth"))
+        self.assertTrue(cp._is_auth_redirect("/login/", ""))
+        # reason qualifier alone (path already rewritten) still counts
+        self.assertTrue(cp._is_auth_redirect("/api/whatever", "reason=download-auth"))
+
+    def test_real_file_redirects_are_not_auth(self):
+        # the B2 signed-download hop must NOT be mistaken for a login wall
+        self.assertFalse(cp._is_auth_redirect(
+            "/file/civitai-modelfiles/default/841236/wan21Img2video.0OLz.zip",
+            "Authorization=3_2026...&b2ContentDisposition=attachment",
+        ))
+        self.assertFalse(cp._is_auth_redirect("/api/download/models/2947948", "type=Archive"))
+        self.assertFalse(cp._is_auth_redirect("", ""))
+        self.assertFalse(cp._is_auth_redirect(None, None))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/py/civitai_proxy.py
+++ b/py/civitai_proxy.py
@@ -42,6 +42,9 @@ _API_HEADERS = {
 }
 _CDN_BASE = "https://image.civitai.com"
 _CDN_KEY = "xG1nkqKTMzGDvpLrqFT7WA"
+# Model-version file download endpoint. A module constant (not an inline literal)
+# so the aiohttp-level integration test can point it at a local mock server.
+_DOWNLOAD_BASE = "https://civitai.red/api/download/models/"
 
 # Only these hosts may be proxied (SSRF guard).
 _ALLOWED_HOSTS = frozenset(
@@ -122,19 +125,31 @@ def _host_ok(url):
 
 
 # --- /download redirect SSRF guard -------------------------------------------
-# civitai's signed download URLs live on civitai-owned hosts (b2.civitai.com,
-# live-verified) or Backblaze B2 directly. A /download redirect may ONLY land
-# on these — a compromised upstream must not be able to steer this server-side
-# fetch at loopback/RFC1918/link-local/metadata targets.
+# civitai's signed download URLs live on a few CDN hosts. Live-verified 2026-07:
+#   * signed-OUT / older files  → b2.civitai.com (Backblaze B2)
+#   * signed-IN / newer files   → civitai's Cloudflare R2 delivery worker,
+#       civitai-delivery-worker-prod.<civitai-account>.r2.cloudflarestorage.com
+# A /download redirect may ONLY land on these — a compromised upstream must not
+# be able to steer this server-side fetch at loopback/RFC1918/link-local/
+# metadata targets (and _resolves_public() re-checks every resolved address).
 _DL_REDIRECT_HOSTS = ("civitai.com", "civitai.red", "backblazeb2.com")
+# civitai's own Cloudflare R2 delivery worker: the worker-name prefix pins it to
+# civitai's delivery service (an attacker can't publish under this exact worker
+# name on civitai's account), and the r2.cloudflarestorage.com suffix keeps it
+# on Cloudflare's public object store. _resolves_public still blocks internal IPs.
+_R2_DELIVERY_PREFIX = "civitai-delivery-worker-prod."
+_R2_DELIVERY_SUFFIX = ".r2.cloudflarestorage.com"
 
 
 def _redirect_host_ok(host):
-    """True when a redirect host is civitai/B2 (exact match or subdomain)."""
+    """True when a redirect host is a civitai download CDN — civitai/B2 (exact
+    or subdomain) or civitai's signed Cloudflare R2 delivery worker."""
     if not isinstance(host, str) or not host:
         return False
     h = host.lower().rstrip(".")
-    return any(h == base or h.endswith("." + base) for base in _DL_REDIRECT_HOSTS)
+    if any(h == base or h.endswith("." + base) for base in _DL_REDIRECT_HOSTS):
+        return True
+    return h.startswith(_R2_DELIVERY_PREFIX) and h.endswith(_R2_DELIVERY_SUFFIX)
 
 
 def _ip_public(ip_str):
@@ -318,7 +333,7 @@ def register(routes, web):
         if not version_id.isdigit():
             return web.Response(status=400, text="numeric versionId required")
         q = {k: request.query[k] for k in ("type", "format") if request.query.get(k)}
-        url = "https://civitai.red/api/download/models/" + version_id
+        url = _DOWNLOAD_BASE + version_id
         if q:
             url += "?" + urlencode(q)
         timeout = aiohttp.ClientTimeout(total=300)
@@ -393,13 +408,16 @@ def register(routes, web):
                         return out
                 return web.Response(status=502, text="too many redirects")
             except Exception as e:
+                # Surface the traceback to ComfyUI's log — a swallowed handler
+                # exception here reads as an opaque 502 to the panel.
+                _log.warning("civitai download failed: %s", e, exc_info=True)
                 if streaming:
                     # mid-stream failure: headers are gone — abort the
                     # connection so the client's fetch fails loudly
                     if request.transport is not None:
                         request.transport.close()
                     raise
-                return web.Response(status=502, text=str(e))
+                return web.Response(status=502, text="download error: " + str(e))
 
     @routes.get("/comfyui_mcp_panel/civitai/oauth/start")
     async def _oauth_start(request):

--- a/py/civitai_proxy.py
+++ b/py/civitai_proxy.py
@@ -22,9 +22,11 @@ browser — only this server-side module reads them.
 
 import base64
 import hashlib
+import ipaddress
 import json
 import logging
 import os
+import socket
 import time
 from urllib.parse import urlencode, urlparse
 
@@ -117,6 +119,58 @@ def _host_ok(url):
         return urlparse(url).hostname in _ALLOWED_HOSTS
     except Exception:
         return False
+
+
+# --- /download redirect SSRF guard -------------------------------------------
+# civitai's signed download URLs live on civitai-owned hosts (b2.civitai.com,
+# live-verified) or Backblaze B2 directly. A /download redirect may ONLY land
+# on these — a compromised upstream must not be able to steer this server-side
+# fetch at loopback/RFC1918/link-local/metadata targets.
+_DL_REDIRECT_HOSTS = ("civitai.com", "civitai.red", "backblazeb2.com")
+
+
+def _redirect_host_ok(host):
+    """True when a redirect host is civitai/B2 (exact match or subdomain)."""
+    if not isinstance(host, str) or not host:
+        return False
+    h = host.lower().rstrip(".")
+    return any(h == base or h.endswith("." + base) for base in _DL_REDIRECT_HOSTS)
+
+
+def _ip_public(ip_str):
+    """True when the address is a plain public one — not private, loopback,
+    link-local, reserved, multicast, or unspecified (IPv4-mapped IPv6 is
+    unwrapped first so ::ffff:127.0.0.1 can't smuggle loopback through)."""
+    try:
+        ip = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return False
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    return not (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+async def _resolves_public(host):
+    """Resolve ``host`` and require EVERY answer to be public — a DNS name
+    with any private/loopback record is rejected outright (DNS-rebinding to
+    internal ranges)."""
+    import asyncio
+
+    try:
+        infos = await asyncio.get_running_loop().getaddrinfo(
+            host, 443, type=socket.SOCK_STREAM
+        )
+    except Exception:
+        return False
+    ips = {info[4][0] for info in infos}
+    return bool(ips) and all(_ip_public(ip) for ip in ips)
 
 
 async def _valid_access_token(session):
@@ -262,6 +316,7 @@ def register(routes, web):
         timeout = aiohttp.ClientTimeout(total=300)
         async with aiohttp.ClientSession(timeout=timeout) as session:
             headers = await _authed_headers(session, True)  # OAuth when signed in
+            streaming = False  # once True, headers are sent — no 502 fallback
             try:
                 for _ in range(5):
                     async with session.get(
@@ -271,25 +326,50 @@ def register(routes, web):
                             loc = resp.headers.get("Location")
                             if not loc:
                                 return web.Response(status=502, text="redirect without Location")
-                            url = str(resp.url.join(URL(loc)))
-                            if not url.startswith("https://"):
-                                return web.Response(status=502, text="unsafe redirect target")
+                            u = resp.url.join(URL(loc))
+                            # SSRF guard: only follow to https on a civitai/B2
+                            # host, and only when EVERY address it resolves to
+                            # is public — never loopback/RFC1918/link-local/
+                            # metadata, even via a rebinding DNS answer.
+                            if u.scheme != "https" or not _redirect_host_ok(u.host):
+                                return web.Response(status=502, text="redirect target not allowed")
+                            if not await _resolves_public(u.host):
+                                return web.Response(status=502, text="redirect target not allowed")
+                            url = str(u)
                             headers = dict(_API_HEADERS)  # drop Authorization on the hop
                             continue
                         if resp.status != 200:
                             return web.Response(status=resp.status, text=await resp.text())
                         if (resp.content_length or 0) > _DL_CAP:
                             return web.Response(status=413, text="file too large")
-                        buf = bytearray()
+                        # Stream through — no 100MB buffer. Past the cap the
+                        # headers are already gone, so abort the connection:
+                        # the browser sees a failed fetch, never a silently
+                        # truncated file.
+                        out = web.StreamResponse(status=200)
+                        out.content_type = "application/octet-stream"
+                        if resp.content_length:
+                            out.content_length = resp.content_length
+                        await out.prepare(request)
+                        streaming = True
+                        total = 0
                         async for chunk in resp.content.iter_chunked(1 << 16):
-                            buf.extend(chunk)
-                            if len(buf) > _DL_CAP:
-                                return web.Response(status=413, text="file too large")
-                        return web.Response(
-                            body=bytes(buf), content_type="application/octet-stream"
-                        )
+                            total += len(chunk)
+                            if total > _DL_CAP:
+                                if request.transport is not None:
+                                    request.transport.close()
+                                return out
+                            await out.write(chunk)
+                        await out.write_eof()
+                        return out
                 return web.Response(status=502, text="too many redirects")
             except Exception as e:
+                if streaming:
+                    # mid-stream failure: headers are gone — abort the
+                    # connection so the client's fetch fails loudly
+                    if request.transport is not None:
+                        request.transport.close()
+                    raise
                 return web.Response(status=502, text=str(e))
 
     @routes.get("/comfyui_mcp_panel/civitai/oauth/start")

--- a/py/civitai_proxy.py
+++ b/py/civitai_proxy.py
@@ -157,6 +157,14 @@ def _ip_public(ip_str):
     )
 
 
+def _is_auth_redirect(path, query):
+    """True when a download redirect points at civitai's sign-in wall — live:
+    307 → ``/login?returnUrl=…&reason=download-auth``. Such a file is gated;
+    the proxy returns 401 instead of chasing the login page and handing its
+    HTML back as if it were the download."""
+    return (path or "").startswith("/login") or "reason=download-auth" in (query or "")
+
+
 async def _resolves_public(host):
     """Resolve ``host`` and require EVERY answer to be public — a DNS name
     with any private/loopback record is rejected outright (DNS-rebinding to
@@ -327,6 +335,18 @@ def register(routes, web):
                             if not loc:
                                 return web.Response(status=502, text="redirect without Location")
                             u = resp.url.join(URL(loc))
+                            # A redirect to civitai's own /login (live: 307 →
+                            # /login?returnUrl=…&reason=download-auth) means the
+                            # file is gated — the signed-out (or under-scoped)
+                            # session can't fetch it. Return a clean 401 so the
+                            # panel shows its "sign in via the account button"
+                            # hint deterministically, instead of chasing the
+                            # login page and handing back its HTML as the file.
+                            if _is_auth_redirect(u.path, u.query_string):
+                                return web.json_response(
+                                    {"error": "sign-in required to download this file"},
+                                    status=401,
+                                )
                             # SSRF guard: only follow to https on a civitai/B2
                             # host, and only when EVERY address it resolves to
                             # is public — never loopback/RFC1918/link-local/
@@ -340,6 +360,15 @@ def register(routes, web):
                             continue
                         if resp.status != 200:
                             return web.Response(status=resp.status, text=await resp.text())
+                        # A 200 that is an HTML page (not a file) is a rendered
+                        # login/interstitial — treat it as auth-required rather
+                        # than handing the panel an HTML "workflow" to choke on.
+                        ctype = (resp.headers.get("Content-Type") or "").lower()
+                        if ctype.startswith("text/html"):
+                            return web.json_response(
+                                {"error": "sign-in required to download this file"},
+                                status=401,
+                            )
                         if (resp.content_length or 0) > _DL_CAP:
                             return web.Response(status=413, text="file too large")
                         # Stream through — no 100MB buffer. Past the cap the

--- a/py/civitai_proxy.py
+++ b/py/civitai_proxy.py
@@ -8,6 +8,9 @@ runs in the ComfyUI process — makes the real, header-injected calls server-sid
 Routes (all under ``/comfyui_mcp_panel/civitai``):
   GET/POST /api            JSON passthrough to an allow-listed CivitAI host.
   GET      /media          Stream CDN image/video bytes (for <img>/<video> src).
+  GET      /download       Stream a model-version file (workflow .json/.zip);
+                           follows civitai's 307 to the signed CDN URL here,
+                           dropping the Authorization header on the hop.
   GET      /oauth/start    Begin the OAuth (PKCE) sign-in; returns the authorize URL.
   GET      /oauth/callback OAuth redirect target; exchanges the code for tokens.
   GET      /oauth/status   Whether a valid session exists.
@@ -156,6 +159,7 @@ async def _valid_access_token(session):
 def register(routes, web):
     """Register the CivitAI proxy routes on ``PromptServer.instance.routes``."""
     import aiohttp  # ComfyUI ships aiohttp
+    from yarl import URL  # aiohttp's own URL type (for manual redirect joins)
 
     def _session():
         return aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30))
@@ -232,6 +236,59 @@ def register(routes, web):
                         content_type=ctype.split(";")[0],
                         headers={"Cache-Control": "public, max-age=86400"},
                     )
+            except Exception as e:
+                return web.Response(status=502, text=str(e))
+
+    # Model-version file download (the Workflows tab's "load onto canvas").
+    # The /api JSON passthrough is text-only, so binary zips need a byte route.
+    # Live behavior (2026-07): GET /api/download/models/{id} 307s to a
+    # pre-SIGNED b2.civitai.com URL — redirects are followed HERE, manually,
+    # so the OAuth Authorization header is dropped on the cross-host hop
+    # (B2 rejects requests carrying both its query signature and a foreign
+    # Authorization header). Many workflow files download signed-out; gated
+    # ones (early access etc.) surface their 401/403 to the panel as-is.
+    _DL_CAP = 100 * 1024 * 1024  # workflow archives are KB-sized; 100MB is generous
+    _REDIRECTS = (301, 302, 303, 307, 308)
+
+    @routes.get("/comfyui_mcp_panel/civitai/download")
+    async def _civitai_download(request):
+        version_id = request.query.get("versionId", "")
+        if not version_id.isdigit():
+            return web.Response(status=400, text="numeric versionId required")
+        q = {k: request.query[k] for k in ("type", "format") if request.query.get(k)}
+        url = "https://civitai.red/api/download/models/" + version_id
+        if q:
+            url += "?" + urlencode(q)
+        timeout = aiohttp.ClientTimeout(total=300)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            headers = await _authed_headers(session, True)  # OAuth when signed in
+            try:
+                for _ in range(5):
+                    async with session.get(
+                        url, headers=headers, allow_redirects=False
+                    ) as resp:
+                        if resp.status in _REDIRECTS:
+                            loc = resp.headers.get("Location")
+                            if not loc:
+                                return web.Response(status=502, text="redirect without Location")
+                            url = str(resp.url.join(URL(loc)))
+                            if not url.startswith("https://"):
+                                return web.Response(status=502, text="unsafe redirect target")
+                            headers = dict(_API_HEADERS)  # drop Authorization on the hop
+                            continue
+                        if resp.status != 200:
+                            return web.Response(status=resp.status, text=await resp.text())
+                        if (resp.content_length or 0) > _DL_CAP:
+                            return web.Response(status=413, text="file too large")
+                        buf = bytearray()
+                        async for chunk in resp.content.iter_chunked(1 << 16):
+                            buf.extend(chunk)
+                            if len(buf) > _DL_CAP:
+                                return web.Response(status=413, text="file too large")
+                        return web.Response(
+                            body=bytes(buf), content_type="application/octet-stream"
+                        )
+                return web.Response(status=502, text="too many redirects")
             except Exception as e:
                 return web.Response(status=502, text=str(e))
 

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -166,6 +166,20 @@ const el = (tag, cls, txt) => {
   return n;
 };
 
+/** Fail-CLOSED dirty check for the load-onto-canvas overwrite confirm: any
+ *  uncertainty (missing getter, non-boolean answer, a throw) counts as DIRTY
+ *  so the user gets asked — never silently clobber an unsaved canvas.
+ *  Exported for unit tests. */
+export function graphDirtyForConfirm(ctx) {
+  try {
+    if (typeof ctx?.graphIsDirty !== "function") return true;
+    const d = ctx.graphIsDirty();
+    return typeof d === "boolean" ? d : true;
+  } catch {
+    return true;
+  }
+}
+
 /** Open (or focus) the CivitAI modal. opts = {query, tab, filters, browsingLevels}. */
 export function openCivitaiModal(ctx, opts = {}) {
   injectCss();
@@ -651,7 +665,7 @@ export function openCivitaiModal(ctx, opts = {}) {
           if (wf.format === "ui") {
             const loadBtn = el("button", "cmcp-btn", "Load onto canvas");
             loadBtn.title = "Replace the current canvas with this post's embedded ComfyUI workflow (Ctrl+Z undoes it).";
-            loadBtn.addEventListener("click", () => loadOntoCanvas(wf.graph, closeLb));
+            loadBtn.addEventListener("click", () => { void loadOntoCanvas(wf.graph, closeLb); });
             actions.appendChild(loadBtn);
           }
           const saveBtn = el("button", "cmcp-btn", "Save workflow");
@@ -732,7 +746,7 @@ export function openCivitaiModal(ctx, opts = {}) {
       if (wf.format === "ui") {
         const loadBtn = el("button", "cmcp-btn", "Load onto canvas");
         loadBtn.title = "Replace the current canvas with this example's embedded ComfyUI workflow (Ctrl+Z undoes it).";
-        loadBtn.addEventListener("click", () => loadOntoCanvas(wf.graph));
+        loadBtn.addEventListener("click", () => { void loadOntoCanvas(wf.graph); });
         actions.appendChild(loadBtn);
       }
       const saveBtn = el("button", "cmcp-btn", "Save workflow");
@@ -792,23 +806,24 @@ export function openCivitaiModal(ctx, opts = {}) {
   }
 
   // ── load a UI-format workflow onto the live canvas ───────────────────
-  /** Confirm-if-dirty, then load via the bridge's undoable graph_load path
-   *  (snapshot → loadGraphData → checkState — one load = one Ctrl+Z step).
-   *  On success every explorer surface closes so the canvas is visible,
-   *  `beforeClose` first (e.g. the lightbox, which isn't a sub-modal).
+  /** Confirm-if-dirty (fail-closed — see graphDirtyForConfirm), then load via
+   *  the bridge's undoable graph_load path (snapshot → await loadGraphData →
+   *  checkState — one load = one Ctrl+Z step). Success is only announced —
+   *  and the explorer only closed — after the awaited load actually landed;
+   *  `beforeClose` runs first (e.g. the lightbox, which isn't a sub-modal).
    *  Returns true when it loaded. */
-  function loadOntoCanvas(graph, beforeClose) {
+  async function loadOntoCanvas(graph, beforeClose) {
     if (typeof ctx.loadGraph !== "function") {
       toast("This panel build can't load onto the canvas.");
       return false;
     }
-    if (ctx.graphIsDirty?.() && !window.confirm(
+    if (graphDirtyForConfirm(ctx) && !window.confirm(
       "Load this workflow onto the canvas?\n\n" +
       "Your current workflow has unsaved changes that will be replaced (Ctrl+Z undoes the load).",
     )) return false;
     let res;
     try {
-      res = ctx.loadGraph(graph);
+      res = await ctx.loadGraph(graph);
     } catch (e) {
       toast("Couldn't load workflow: " + (e.message || e));
       return false;
@@ -860,7 +875,7 @@ export function openCivitaiModal(ctx, opts = {}) {
         : "No ComfyUI workflow found in that file.");
       return;
     }
-    if (uis.length === 1) { loadOntoCanvas(uis[0].graph); return; }
+    if (uis.length === 1) { await loadOntoCanvas(uis[0].graph); return; }
     // several workflows in one archive — let the user pick
     const picker = openSubModal("Pick a workflow to load");
     const list = el("div", "cmcp-cv-creators");
@@ -869,7 +884,7 @@ export function openCivitaiModal(ctx, opts = {}) {
       const b = el("button", "cmcp-cv-creator");
       b.appendChild(el("span", null, c.name));
       b.appendChild(el("span", "sub", `${c.graph.nodes.length} nodes`));
-      b.addEventListener("click", () => loadOntoCanvas(c.graph));
+      b.addEventListener("click", () => { void loadOntoCanvas(c.graph); });
       list.appendChild(b);
     }
     picker.body.appendChild(list);

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -95,6 +95,11 @@ function injectCss() {
     color: var(--p-text-muted-color,#a1a1aa); width: 100%; }
   .cmcp-cv-detail img, .cmcp-cv-detail video { border-radius: 8px; }
   .cmcp-cv-actions { display: flex; gap: .4rem; flex-wrap: wrap; margin-top: .5rem; }
+  .cmcp-cv-wfstatus { margin-top: .5rem; padding: .45rem .6rem; border-radius: 8px; font-size: .78rem;
+    line-height: 1.35; background: var(--p-surface-800,#27272a); color: var(--p-text-color,#fafafa);
+    border: 1px solid var(--p-content-border-color,#3f3f46); }
+  .cmcp-cv-wfstatus.warn { border-color: #d97706; color: #fcd34d; }
+  .cmcp-cv-wfstatus.err { border-color: #dc2626; color: #fca5a5; }
   .cmcp-cv-viewer { position: absolute; inset: 0; z-index: 5; background: rgba(0,0,0,.94);
     display: flex; align-items: center; justify-content: center; }
   .cmcp-cv-viewer img, .cmcp-cv-viewer video { max-width: 100%; max-height: 100%; object-fit: contain; }
@@ -828,6 +833,12 @@ export function openCivitaiModal(ctx, opts = {}) {
       toast("Couldn't load workflow: " + (e.message || e));
       return false;
     }
+    // Defend against a silent no-op: if the load reported zero nodes the graph
+    // didn't actually land — don't dismiss the explorer as if it succeeded.
+    if (!res || !res.node_count) {
+      toast("The workflow loaded empty (0 nodes) — nothing was placed on the canvas.");
+      return false;
+    }
     if (beforeClose) { try { beforeClose(); } catch { /* already gone */ } }
     closeSubModals();
     close();
@@ -837,21 +848,31 @@ export function openCivitaiModal(ctx, opts = {}) {
 
   /** Download a model-version workflow file (raw .json or civitai's zip
    *  wrapper), extract the UI-format graph(s), and load onto the canvas —
-   *  with a picker when an archive holds several. */
-  async function loadVersionWorkflow(version, file) {
-    toast("Fetching workflow…");
+   *  with a picker when an archive holds several. Reports progress and EVERY
+   *  failure through `opts.setStatus` (an inline line in the detail sheet) as
+   *  well as a toast, and NEVER closes the sheet on failure — only a genuine
+   *  canvas load (via loadOntoCanvas) dismisses the explorer. */
+  async function loadVersionWorkflow(version, file, opts = {}) {
+    const setStatus = opts.setStatus || (() => {});
+    const say = (msg, kind = "err") => { setStatus(msg, kind); toast(msg); };
+    setStatus("Fetching workflow…", "info");
     let bytes;
     try {
       bytes = await client.downloadVersionFile(version.id, file);
     } catch (e) {
       if (e.status === 401 || e.status === 403) {
-        // Most workflow files download signed-out (live-verified); a 401/403
-        // means this one is gated — the account button is the panel's way in.
-        toast(state.signedIn
-          ? "CivitAI refused this download — the file may need early access or a purchase."
-          : "CivitAI requires sign-in for this download — use the account (👤) button, then try again.");
+        // Some workflow files are gated (the proxy returns 401 when civitai
+        // redirects the download to /login). The account button is the way in;
+        // offer it right here so the hint is actionable, not just informative.
+        say(state.signedIn
+          ? "CivitAI refused this download — this file may need early access or a purchase. Try the account (👤) button to re-check your sign-in."
+          : "This workflow is gated — sign in to CivitAI (the account 👤 button) to download it, then try again.", "warn");
+        if (!state.signedIn && opts.signIn) {
+          setStatus("This workflow is gated — opening CivitAI sign-in…", "warn");
+          try { opts.signIn(); } catch { /* account flow unavailable */ }
+        }
       } else {
-        toast("Download failed: " + (e.message || e));
+        say("Download failed: " + (e.message || e));
       }
       return;
     }
@@ -865,16 +886,22 @@ export function openCivitaiModal(ctx, opts = {}) {
         candidates = format === "unknown" ? [] : [{ name: file.name, graph, format }];
       }
     } catch (e) {
-      toast("Couldn't read the workflow file: " + (e.message || e));
+      // A gated file can slip through as an HTML page the proxy couldn't tag;
+      // "not a zip" then really means "we got a login page, not the file".
+      const notZip = /not a zip/i.test(String(e.message || e));
+      say(notZip
+        ? "Couldn't read the download — CivitAI may require sign-in for this file (account 👤 button)."
+        : "Couldn't read the workflow file: " + (e.message || e), notZip ? "warn" : "err");
       return;
     }
     const uis = candidates.filter((c) => c.format === "ui");
     if (!uis.length) {
-      toast(candidates.length
-        ? "That file only holds API-format graphs — not loadable onto the canvas. Ask the agent to run it instead."
-        : "No ComfyUI workflow found in that file.");
+      say(candidates.length
+        ? "This file only holds an API-format graph — it can't load as an editable canvas workflow. Ask the agent to run it instead."
+        : "No ComfyUI workflow found in that file.", "warn");
       return;
     }
+    setStatus("", "info"); // clear before a successful load closes the explorer
     if (uis.length === 1) { await loadOntoCanvas(uis[0].graph); return; }
     // several workflows in one archive — let the user pick
     const picker = openSubModal("Pick a workflow to load");
@@ -916,8 +943,18 @@ export function openCivitaiModal(ctx, opts = {}) {
       dlBtn.addEventListener("click", () => pickModel(detail, version));
       dl.appendChild(dlBtn);
       // Workflow files (.json, or the zip wrapper civitai puts around Workflows
-      // uploads) can load straight onto the canvas — the community ask.
+      // uploads) can load straight onto the canvas — the community ask. An
+      // inline status line under the buttons reports progress/errors right in
+      // the sheet (a toast alone was easy to miss / hid behind this overlay).
       const wfFiles = CivitaiClient.workflowFiles(version, detail.type);
+      const wfStatus = el("div", "cmcp-cv-wfstatus");
+      wfStatus.style.display = "none";
+      const setStatus = (msg, kind = "info") => {
+        if (!msg) { wfStatus.style.display = "none"; wfStatus.textContent = ""; return; }
+        wfStatus.style.display = "";
+        wfStatus.className = "cmcp-cv-wfstatus " + kind;
+        wfStatus.textContent = msg;
+      };
       for (const f of wfFiles) {
         const b = el("button", "cmcp-btn",
           wfFiles.length > 1 ? `Load onto canvas — ${f.name}` : "Load workflow onto canvas");
@@ -925,7 +962,7 @@ export function openCivitaiModal(ctx, opts = {}) {
           ? (f.sizeKB >= 1024 ? (f.sizeKB / 1024).toFixed(1) + " MB" : Math.max(1, Math.round(f.sizeKB)) + " KB")
           : null;
         b.title = `Download ${f.name}${size ? ` (${size})` : ""} and load it onto the canvas (Ctrl+Z undoes it).`;
-        b.addEventListener("click", () => loadVersionWorkflow(version, f));
+        b.addEventListener("click", () => { void loadVersionWorkflow(version, f, { setStatus, signIn: () => accountFlow() }); });
         dl.appendChild(b);
       }
       if (have) {
@@ -942,6 +979,7 @@ export function openCivitaiModal(ctx, opts = {}) {
         dl.appendChild(moreBtn);
       }
       detailBody.appendChild(dl);
+      if (wfFiles.length) detailBody.appendChild(wfStatus);
       if (version.descriptionHtml || detail.descriptionHtml) {
         const desc = el("div", "cmcp-cv-detail");
         desc.style.cssText = "font-size:.78rem;margin-top:.5rem";
@@ -1345,16 +1383,20 @@ export function openCivitaiModal(ctx, opts = {}) {
     return { body: b, close: close2 };
   }
 
-  function toast(msg) {
+  function toast(msg, { ms = 3500 } = {}) {
     const t = el("div", null, msg);
-    // A successful canvas load closes the whole modal — that toast must
-    // outlive it, so a disconnected modal falls back to a fixed body toast.
-    const inModal = modal.isConnected;
-    t.style.cssText = `position:${inModal ? "absolute" : "fixed"};bottom:1rem;left:50%;transform:translateX(-50%);` +
-      "background:var(--p-surface-800,#27272a);color:#fafafa;padding:.5rem .8rem;border-radius:8px;" +
-      `z-index:${inModal ? "80" : "10005"};font-size:.8rem;box-shadow:0 4px 16px rgba(0,0,0,.5)`;
-    (inModal ? modal : document.body).appendChild(t);
-    setTimeout(() => t.remove(), 3000);
+    // ALWAYS mount on <body> above every overlay — sub-modals (10001), the
+    // lightbox (10002) and the workflow picker sit above the base modal, and a
+    // toast rendered inside `modal` (z-index 80) was hidden behind them, so a
+    // gated-download hint or a load error read as "nothing happened". A fixed,
+    // top-of-stack toast is visible no matter which sheet is open (or if the
+    // whole explorer just closed after a successful load).
+    t.style.cssText = "position:fixed;bottom:1.25rem;left:50%;transform:translateX(-50%);" +
+      "max-width:min(38rem,90vw);text-align:center;background:var(--p-surface-800,#27272a);" +
+      "color:#fafafa;padding:.55rem .9rem;border-radius:8px;z-index:10060;font-size:.82rem;" +
+      "box-shadow:0 4px 16px rgba(0,0,0,.5)";
+    document.body.appendChild(t);
+    setTimeout(() => t.remove(), ms);
   }
 
   // ── go ───────────────────────────────────────────────────────────────

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -7,7 +7,8 @@
 //
 // The monolith injects a `ctx` so this module never reaches into panel internals:
 //   ctx = { api, root, callTool, sendUserMessage, uploadBlobToInput,
-//           bringChatForward, isMuted, marked, DOMPurify }
+//           bringChatForward, isMuted, marked, DOMPurify,
+//           graphIsDirty, loadGraph }   // canvas access for "load onto canvas"
 
 import {
   CivitaiClient, DEFAULT_FILTERS, LEVELS, PERIODS, IMAGE_SORTS, MODEL_SORTS,
@@ -645,15 +646,23 @@ export function openCivitaiModal(ctx, opts = {}) {
           ctx.isMuted() ? "Save reference to inputs" : "Share with agent");
         shareBtn.addEventListener("click", () => shareImage(it, gen));
         actions.appendChild(shareBtn);
-        const graph = CivitaiClient.comfyGraph(gen.meta);
-        if (graph) {
+        const wf = CivitaiClient.comfyGraphInfo(gen.meta);
+        if (wf) {
+          if (wf.format === "ui") {
+            const loadBtn = el("button", "cmcp-btn", "Load onto canvas");
+            loadBtn.title = "Replace the current canvas with this post's embedded ComfyUI workflow (Ctrl+Z undoes it).";
+            loadBtn.addEventListener("click", () => loadOntoCanvas(wf.graph, closeLb));
+            actions.appendChild(loadBtn);
+          }
           const saveBtn = el("button", "cmcp-btn", "Save workflow");
-          saveBtn.addEventListener("click", () => saveWorkflow(it, graph));
+          saveBtn.addEventListener("click", () => saveWorkflow(it, wf.graph));
           actions.appendChild(saveBtn);
         }
         genBox.innerHTML = "";
         genBox.appendChild(el("div", "cmcp-cv-lb-muted",
-          graph ? "✓ Embedded ComfyUI workflow" : "No embedded workflow"));
+          !wf ? "No embedded workflow"
+          : wf.format === "ui" ? "✓ Embedded ComfyUI workflow"
+          : "Embedded graph is API-format only — it can't load onto the canvas, but Save keeps its JSON."));
         if (gen.meta?.prompt) {
           genBox.appendChild(el("div", "cmcp-cv-flabel", "Prompt"));
           genBox.appendChild(el("div", "cmcp-cv-lb-prompt", gen.meta.prompt));
@@ -708,17 +717,26 @@ export function openCivitaiModal(ctx, opts = {}) {
     try { gen = await client.getGenerationData(it.id); }
     catch (e) { sheet.body.innerHTML = ""; sheet.body.appendChild(el("div", null, "No data: " + e.message)); return; }
     sheet.body.innerHTML = "";
-    const graph = CivitaiClient.comfyGraph(gen.meta);
-    sheet.body.appendChild(el("div", null, graph ? "✓ Embedded ComfyUI workflow" : "No embedded workflow"));
+    const wf = CivitaiClient.comfyGraphInfo(gen.meta);
+    sheet.body.appendChild(el("div", null,
+      !wf ? "No embedded workflow"
+      : wf.format === "ui" ? "✓ Embedded ComfyUI workflow"
+      : "Embedded graph is API-format only — it can't load onto the canvas, but Save keeps its JSON."));
 
     const actions = el("div", "cmcp-cv-actions");
     const shareBtn = el("button", "cmcp-btn cmcp-btn-primary",
       ctx.isMuted() ? "Save reference to inputs" : "Share with agent");
     shareBtn.addEventListener("click", () => shareImage(it, gen));
     actions.appendChild(shareBtn);
-    if (graph) {
+    if (wf) {
+      if (wf.format === "ui") {
+        const loadBtn = el("button", "cmcp-btn", "Load onto canvas");
+        loadBtn.title = "Replace the current canvas with this example's embedded ComfyUI workflow (Ctrl+Z undoes it).";
+        loadBtn.addEventListener("click", () => loadOntoCanvas(wf.graph));
+        actions.appendChild(loadBtn);
+      }
       const saveBtn = el("button", "cmcp-btn", "Save workflow");
-      saveBtn.addEventListener("click", () => saveWorkflow(it, graph));
+      saveBtn.addEventListener("click", () => saveWorkflow(it, wf.graph));
       actions.appendChild(saveBtn);
     }
     sheet.body.appendChild(actions);
@@ -773,6 +791,90 @@ export function openCivitaiModal(ctx, opts = {}) {
     } catch (e) { toast("Save failed: " + e.message); }
   }
 
+  // ── load a UI-format workflow onto the live canvas ───────────────────
+  /** Confirm-if-dirty, then load via the bridge's undoable graph_load path
+   *  (snapshot → loadGraphData → checkState — one load = one Ctrl+Z step).
+   *  On success every explorer surface closes so the canvas is visible,
+   *  `beforeClose` first (e.g. the lightbox, which isn't a sub-modal).
+   *  Returns true when it loaded. */
+  function loadOntoCanvas(graph, beforeClose) {
+    if (typeof ctx.loadGraph !== "function") {
+      toast("This panel build can't load onto the canvas.");
+      return false;
+    }
+    if (ctx.graphIsDirty?.() && !window.confirm(
+      "Load this workflow onto the canvas?\n\n" +
+      "Your current workflow has unsaved changes that will be replaced (Ctrl+Z undoes the load).",
+    )) return false;
+    let res;
+    try {
+      res = ctx.loadGraph(graph);
+    } catch (e) {
+      toast("Couldn't load workflow: " + (e.message || e));
+      return false;
+    }
+    if (beforeClose) { try { beforeClose(); } catch { /* already gone */ } }
+    closeSubModals();
+    close();
+    toast(`Workflow loaded onto the canvas — ${res.node_count} node${res.node_count === 1 ? "" : "s"}. Ctrl+Z undoes it.`);
+    return true;
+  }
+
+  /** Download a model-version workflow file (raw .json or civitai's zip
+   *  wrapper), extract the UI-format graph(s), and load onto the canvas —
+   *  with a picker when an archive holds several. */
+  async function loadVersionWorkflow(version, file) {
+    toast("Fetching workflow…");
+    let bytes;
+    try {
+      bytes = await client.downloadVersionFile(version.id, file);
+    } catch (e) {
+      if (e.status === 401 || e.status === 403) {
+        // Most workflow files download signed-out (live-verified); a 401/403
+        // means this one is gated — the account button is the panel's way in.
+        toast(state.signedIn
+          ? "CivitAI refused this download — the file may need early access or a purchase."
+          : "CivitAI requires sign-in for this download — use the account (👤) button, then try again.");
+      } else {
+        toast("Download failed: " + (e.message || e));
+      }
+      return;
+    }
+    let candidates;
+    try {
+      if (/\.zip$/i.test(file.name || "")) {
+        candidates = await CivitaiClient.workflowsFromZip(bytes);
+      } else {
+        const graph = JSON.parse(new TextDecoder().decode(bytes));
+        const format = CivitaiClient.workflowFormat(graph);
+        candidates = format === "unknown" ? [] : [{ name: file.name, graph, format }];
+      }
+    } catch (e) {
+      toast("Couldn't read the workflow file: " + (e.message || e));
+      return;
+    }
+    const uis = candidates.filter((c) => c.format === "ui");
+    if (!uis.length) {
+      toast(candidates.length
+        ? "That file only holds API-format graphs — not loadable onto the canvas. Ask the agent to run it instead."
+        : "No ComfyUI workflow found in that file.");
+      return;
+    }
+    if (uis.length === 1) { loadOntoCanvas(uis[0].graph); return; }
+    // several workflows in one archive — let the user pick
+    const picker = openSubModal("Pick a workflow to load");
+    const list = el("div", "cmcp-cv-creators");
+    list.style.maxHeight = "24rem";
+    for (const c of uis) {
+      const b = el("button", "cmcp-cv-creator");
+      b.appendChild(el("span", null, c.name));
+      b.appendChild(el("span", "sub", `${c.graph.nodes.length} nodes`));
+      b.addEventListener("click", () => loadOntoCanvas(c.graph));
+      list.appendChild(b);
+    }
+    picker.body.appendChild(list);
+  }
+
   // ── model detail ─────────────────────────────────────────────────────
   async function openModelDetail(m) {
     const sheet = openSubModal(m.name);
@@ -798,6 +900,19 @@ export function openCivitaiModal(ctx, opts = {}) {
              : (ctx.isMuted() ? "Download to my machine" : "Ask agent to download"));
       dlBtn.addEventListener("click", () => pickModel(detail, version));
       dl.appendChild(dlBtn);
+      // Workflow files (.json, or the zip wrapper civitai puts around Workflows
+      // uploads) can load straight onto the canvas — the community ask.
+      const wfFiles = CivitaiClient.workflowFiles(version, detail.type);
+      for (const f of wfFiles) {
+        const b = el("button", "cmcp-btn",
+          wfFiles.length > 1 ? `Load onto canvas — ${f.name}` : "Load workflow onto canvas");
+        const size = f.sizeKB != null
+          ? (f.sizeKB >= 1024 ? (f.sizeKB / 1024).toFixed(1) + " MB" : Math.max(1, Math.round(f.sizeKB)) + " KB")
+          : null;
+        b.title = `Download ${f.name}${size ? ` (${size})` : ""} and load it onto the canvas (Ctrl+Z undoes it).`;
+        b.addEventListener("click", () => loadVersionWorkflow(version, f));
+        dl.appendChild(b);
+      }
       if (have) {
         const note = el("span", null, "You already have this file locally.");
         note.style.cssText = "font-size:.72rem;color:#4ade80;align-self:center";
@@ -1191,6 +1306,12 @@ export function openCivitaiModal(ctx, opts = {}) {
   }
 
   // ── sub-modal + toast helpers ────────────────────────────────────────
+  // Open sub-modal closers, so a successful canvas load can dismiss every
+  // stacked sheet (detail → gen-info → picker) in one sweep.
+  const _subModals = new Set();
+  function closeSubModals() {
+    for (const c of [..._subModals]) { try { c(); } catch { /* already gone */ } }
+  }
   function openSubModal(title, onClose) {
     const ov = el("div", "cmcp-cv-overlay"); ov.style.zIndex = "10001";
     const m = el("div", "cmcp-modal"); m.style.maxWidth = "40rem"; m.style.width = "min(40rem, 92vw)";
@@ -1201,7 +1322,8 @@ export function openCivitaiModal(ctx, opts = {}) {
     const b = el("div"); m.style.position = "relative";
     // Every close path (✕ button, backdrop click, sheet.close()) funnels here,
     // so a caller-supplied teardown runs no matter how the sheet is dismissed.
-    const close2 = () => { ov.remove(); if (onClose) onClose(); };
+    const close2 = () => { _subModals.delete(close2); ov.remove(); if (onClose) onClose(); };
+    _subModals.add(close2);
     x.addEventListener("click", close2);
     ov.addEventListener("mousedown", (e) => { if (e.target === ov) close2(); });
     m.append(head2, x, b); ov.appendChild(m); document.body.appendChild(ov);
@@ -1210,10 +1332,13 @@ export function openCivitaiModal(ctx, opts = {}) {
 
   function toast(msg) {
     const t = el("div", null, msg);
-    t.style.cssText = "position:absolute;bottom:1rem;left:50%;transform:translateX(-50%);" +
+    // A successful canvas load closes the whole modal — that toast must
+    // outlive it, so a disconnected modal falls back to a fixed body toast.
+    const inModal = modal.isConnected;
+    t.style.cssText = `position:${inModal ? "absolute" : "fixed"};bottom:1rem;left:50%;transform:translateX(-50%);` +
       "background:var(--p-surface-800,#27272a);color:#fafafa;padding:.5rem .8rem;border-radius:8px;" +
-      "z-index:80;font-size:.8rem;box-shadow:0 4px 16px rgba(0,0,0,.5)";
-    modal.appendChild(t);
+      `z-index:${inModal ? "80" : "10005"};font-size:.8rem;box-shadow:0 4px 16px rgba(0,0,0,.5)`;
+    (inModal ? modal : document.body).appendChild(t);
     setTimeout(() => t.remove(), 3000);
   }
 

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -538,8 +538,27 @@ export class CivitaiClient {
   // descriptors (sizes = 0), so entries MUST be walked via the central
   // directory. No dependency: DEFLATE entries inflate through the browser's
   // native DecompressionStream("deflate-raw").
-  /** List entries: [{name, method, cSize, uSize, lfhOff}]. Throws if not a zip. */
-  static zipEntries(bytes) {
+  //
+  // Zip-bomb caps: workflow archives are KB-sized, so anything past these is
+  // not a workflow zip. Cap violations throw errors tagged `.zipCap = true`
+  // (they must surface to the user, unlike a single unparseable entry, which
+  // is merely skipped). Tests inject smaller caps.
+  static get ZIP_CAPS() {
+    return {
+      entries: 512,                  // central-directory records
+      entryBytes: 32 * 1024 * 1024,  // uncompressed, per entry
+      totalBytes: 96 * 1024 * 1024,  // uncompressed, whole archive
+    };
+  }
+  static _zipCapError(msg) {
+    return Object.assign(new Error(msg), { zipCap: true });
+  }
+
+  /** List entries: [{name, method, cSize, uSize, lfhOff}]. Throws if not a
+   *  zip or past the entry-count cap. Records whose spans run past the buffer
+   *  stop the walk; duplicates aimed at the same local header are dropped
+   *  (a bomb trick: many directory records sharing one compressed blob). */
+  static zipEntries(bytes, caps = CivitaiClient.ZIP_CAPS) {
     const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
     // EOCD signature scan from the tail (comment may pad up to 64KB).
     let eocd = -1;
@@ -549,28 +568,43 @@ export class CivitaiClient {
     }
     if (eocd < 0) throw new Error("not a zip file");
     const count = dv.getUint16(eocd + 10, true);
+    if (count > caps.entries) {
+      throw CivitaiClient._zipCapError(`zip has too many entries (${count} > ${caps.entries})`);
+    }
     let off = dv.getUint32(eocd + 16, true);
     const entries = [];
+    const seenOff = new Set();
     const td = new TextDecoder();
     for (let n = 0; n < count; n++) {
       if (off + 46 > bytes.length || dv.getUint32(off, true) !== 0x02014b50) break;
       const nameLen = dv.getUint16(off + 28, true);
       const extraLen = dv.getUint16(off + 30, true);
       const cmtLen = dv.getUint16(off + 32, true);
-      entries.push({
-        name: td.decode(bytes.subarray(off + 46, off + 46 + nameLen)),
-        method: dv.getUint16(off + 10, true),
-        cSize: dv.getUint32(off + 20, true),
-        uSize: dv.getUint32(off + 24, true),
-        lfhOff: dv.getUint32(off + 42, true),
-      });
-      off += 46 + nameLen + extraLen + cmtLen;
+      const end = off + 46 + nameLen + extraLen + cmtLen;
+      if (end > bytes.length) break; // record claims bytes past the buffer
+      const lfhOff = dv.getUint32(off + 42, true);
+      if (!seenOff.has(lfhOff)) {
+        seenOff.add(lfhOff);
+        entries.push({
+          name: td.decode(bytes.subarray(off + 46, off + 46 + nameLen)),
+          method: dv.getUint16(off + 10, true),
+          cSize: dv.getUint32(off + 20, true),
+          uSize: dv.getUint32(off + 24, true),
+          lfhOff,
+        });
+      }
+      off = end;
     }
     return entries;
   }
 
-  /** Read one zipEntries() entry as text (stored or DEFLATE). */
-  static async zipReadText(bytes, entry) {
+  /** Read one zipEntries() entry as text (stored or DEFLATE), enforcing the
+   *  per-entry uncompressed cap both up front (claimed uSize/cSize) and after
+   *  inflation — a lying header doesn't get to expand unbounded. */
+  static async zipReadText(bytes, entry, caps = CivitaiClient.ZIP_CAPS) {
+    if (entry.uSize > caps.entryBytes || entry.cSize > caps.entryBytes) {
+      throw CivitaiClient._zipCapError("zip entry too large to unpack");
+    }
     const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
     const o = entry.lfhOff;
     if (o + 30 > bytes.length || dv.getUint32(o, true) !== 0x04034b50) {
@@ -579,6 +613,7 @@ export class CivitaiClient {
     const nameLen = dv.getUint16(o + 26, true);
     const extraLen = dv.getUint16(o + 28, true);
     const start = o + 30 + nameLen + extraLen;
+    if (start + entry.cSize > bytes.length) throw new Error("bad zip entry");
     const data = bytes.subarray(start, start + entry.cSize);
     if (entry.method === 0) return new TextDecoder().decode(data);
     if (entry.method !== 8) throw new Error(`unsupported zip compression (method ${entry.method})`);
@@ -586,18 +621,41 @@ export class CivitaiClient {
       throw new Error("this browser can't inflate zip archives");
     }
     const stream = new Blob([data]).stream().pipeThrough(new DecompressionStream("deflate-raw"));
-    return await new Response(stream).text();
+    const buf = await new Response(stream).arrayBuffer();
+    if (buf.byteLength > caps.entryBytes) {
+      throw CivitaiClient._zipCapError("zip entry too large to unpack");
+    }
+    return new TextDecoder().decode(buf);
   }
 
   /** Extract every parseable .json graph from zip bytes →
-   *  [{name, graph, format}] (format per workflowFormat, "ui" first). */
-  static async workflowsFromZip(bytes) {
+   *  [{name, graph, format}] (format per workflowFormat, "ui" first).
+   *  Cap breaches (entry count, per-entry size, aggregate size) THROW with a
+   *  clear message; an individually unparseable entry is merely skipped. */
+  static async workflowsFromZip(bytes, caps = CivitaiClient.ZIP_CAPS) {
     const out = [];
-    for (const e of CivitaiClient.zipEntries(bytes)) {
+    let total = 0;
+    for (const e of CivitaiClient.zipEntries(bytes, caps)) {
       if (!/\.json$/i.test(e.name) || /\/$/.test(e.name)) continue;
+      // aggregate cap on CLAIMED sizes first, so a bomb can't be inflated
+      // piecewise; the true inflated size is re-counted after reading.
+      if (total + e.uSize > caps.totalBytes) {
+        throw CivitaiClient._zipCapError("archive unpacks too large");
+      }
+      let text;
+      try {
+        text = await CivitaiClient.zipReadText(bytes, e, caps);
+      } catch (err) {
+        if (err && err.zipCap) throw err; // cap breach — fail the whole zip
+        continue; // undecodable entry — skip, don't fail the zip
+      }
+      total += text.length;
+      if (total > caps.totalBytes) {
+        throw CivitaiClient._zipCapError("archive unpacks too large");
+      }
       let graph;
-      try { graph = JSON.parse(await CivitaiClient.zipReadText(bytes, e)); }
-      catch { continue; } // undecodable/unparseable entry — skip, don't fail the zip
+      try { graph = JSON.parse(text); }
+      catch { continue; } // unparseable entry — skip
       const format = CivitaiClient.workflowFormat(graph);
       if (format === "unknown") continue;
       out.push({ name: e.name, graph, format });

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -224,6 +224,12 @@ export class CivitaiClient {
       trainedWords: v.trainedWords || [], examples,
       downloadCount: v.stats?.downloadCount,
       fileName: this._primaryFile(v),
+      // Downloadable files, kept for the Workflows "load onto canvas" path.
+      // `format` rides in metadata (live shape: type:"Archive", metadata:{format:"Other"}).
+      files: (v.files || []).map((f) => ({
+        id: f.id, name: f.name || "", sizeKB: f.sizeKB ?? null,
+        type: f.type || null, format: f.metadata?.format ?? null,
+      })),
     };
   }
 
@@ -436,18 +442,168 @@ export class CivitaiClient {
     };
   }
 
+  /** Classify a parsed graph object.
+   *  "ui"  — litegraph/canvas format (top-level `nodes` array): loadable.
+   *  "api" — prompt format (numeric keys, each with `class_type`): runnable by
+   *          the backend but NOT loadable onto the canvas (same test the
+   *          panel's graph_load uses; there is no client-side converter).
+   *  "unknown" — neither (includes the empty `workflow: {}` civitai emits). */
+  static workflowFormat(g) {
+    if (!g || typeof g !== "object" || Array.isArray(g)) return "unknown";
+    if (Array.isArray(g.nodes)) return "ui";
+    const keys = Object.keys(g);
+    if (
+      keys.length > 0 &&
+      keys.every((k) => /^\d+$/.test(k)) &&
+      keys.some((k) => g[k] && typeof g[k] === "object" && "class_type" in g[k])
+    ) return "api";
+    return "unknown";
+  }
+
+  /** Best embedded ComfyUI graph from generation meta → {graph, format} | null.
+   *  Live shapes (2026-07, tRPC image.getGenerationData):
+   *    meta.comfy = { prompt: <api-format obj>, workflow: <ui obj with nodes[]> }
+   *    meta.comfy = { prompt: <api-format obj>, workflow: {} }   ← EMPTY workflow
+   *  plus the legacy shape where meta.comfy (or its fields) is a JSON string.
+   *  Prefers a real UI graph; falls back to the API prompt (savable, not
+   *  loadable); returns null when nothing parses — the old comfyGraph returned
+   *  the truthy-but-empty `{}` here and lit the ✓ badge for nothing. */
+  static comfyGraphInfo(meta) {
+    if (!meta || meta.comfy == null) return null;
+    const parse = (v) => {
+      if (typeof v !== "string") return v;
+      try { return JSON.parse(v); } catch { return null; }
+    };
+    const c = parse(meta.comfy);
+    if (!c || typeof c !== "object") return null;
+    const candidates = ("workflow" in c || "prompt" in c)
+      ? [parse(c.workflow), parse(c.prompt)]
+      : [c];
+    let api = null;
+    for (const g of candidates) {
+      const format = CivitaiClient.workflowFormat(g);
+      if (format === "ui") return { graph: g, format };
+      if (format === "api" && !api) api = g;
+    }
+    return api ? { graph: api, format: "api" } : null;
+  }
+
   /** Parse the embedded ComfyUI graph from generation meta (prefer UI-format). */
   static comfyGraph(meta) {
-    if (!meta || meta.comfy == null) return null;
-    let c = meta.comfy;
-    if (typeof c === "string") {
-      try { c = JSON.parse(c); } catch { return null; }
+    return CivitaiClient.comfyGraphInfo(meta)?.graph ?? null;
+  }
+
+  // ── version-file workflows (Workflows tab "load onto canvas") ───────────
+  /** Files of a model version worth offering as canvas workflows: raw .json
+   *  always; .zip only on Workflows-type models (live sweep of 844 versions:
+   *  780 zips / 77 raw .json — but a zip on a Checkpoint is training data).
+   *  The download API addresses files by (type, format), NOT id — duplicates
+   *  on that key are unreachable, so they're deduped away. */
+  static workflowFiles(version, modelType) {
+    const out = [];
+    const seen = new Set();
+    for (const f of version?.files || []) {
+      const name = (f.name || "").toLowerCase();
+      const isJson = name.endsWith(".json");
+      const isZip = name.endsWith(".zip");
+      if (!isJson && !(isZip && modelType === "Workflows")) continue;
+      if (f.sizeKB != null && f.sizeKB > 100 * 1024) continue; // proxy cap is 100MB
+      const key = `${f.type || ""}|${f.format || ""}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(f);
     }
-    if (c && typeof c === "object") {
-      if (c.workflow) return typeof c.workflow === "string" ? JSON.parse(c.workflow) : c.workflow;
-      if (c.prompt) return typeof c.prompt === "string" ? JSON.parse(c.prompt) : c.prompt;
+    return out;
+  }
+
+  /** Download a model-version file's raw bytes via the same-origin proxy
+   *  (which follows civitai's 307 to the signed CDN URL server-side and
+   *  attaches the OAuth token when signed in). Throws Error with `.status`
+   *  on HTTP failure — 401/403 means the file needs a signed-in account. */
+  async downloadVersionFile(versionId, { type, format } = {}) {
+    const q = new URLSearchParams({ versionId: String(versionId) });
+    if (type) q.set("type", type);
+    if (format) q.set("format", format);
+    const res = await this.api.fetchApi(`/comfyui_mcp_panel/civitai/download?${q.toString()}`);
+    if (!res.ok) {
+      const err = new Error(`civitai download ${res.status}`);
+      err.status = res.status;
+      throw err;
     }
-    return c;
+    return new Uint8Array(await res.arrayBuffer());
+  }
+
+  // ── minimal zip reader (for workflow archives) ──────────────────────────
+  // Civitai wraps workflow uploads in small zips whose local headers use data
+  // descriptors (sizes = 0), so entries MUST be walked via the central
+  // directory. No dependency: DEFLATE entries inflate through the browser's
+  // native DecompressionStream("deflate-raw").
+  /** List entries: [{name, method, cSize, uSize, lfhOff}]. Throws if not a zip. */
+  static zipEntries(bytes) {
+    const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    // EOCD signature scan from the tail (comment may pad up to 64KB).
+    let eocd = -1;
+    const min = Math.max(0, bytes.length - 65558);
+    for (let i = bytes.length - 22; i >= min; i--) {
+      if (dv.getUint32(i, true) === 0x06054b50) { eocd = i; break; }
+    }
+    if (eocd < 0) throw new Error("not a zip file");
+    const count = dv.getUint16(eocd + 10, true);
+    let off = dv.getUint32(eocd + 16, true);
+    const entries = [];
+    const td = new TextDecoder();
+    for (let n = 0; n < count; n++) {
+      if (off + 46 > bytes.length || dv.getUint32(off, true) !== 0x02014b50) break;
+      const nameLen = dv.getUint16(off + 28, true);
+      const extraLen = dv.getUint16(off + 30, true);
+      const cmtLen = dv.getUint16(off + 32, true);
+      entries.push({
+        name: td.decode(bytes.subarray(off + 46, off + 46 + nameLen)),
+        method: dv.getUint16(off + 10, true),
+        cSize: dv.getUint32(off + 20, true),
+        uSize: dv.getUint32(off + 24, true),
+        lfhOff: dv.getUint32(off + 42, true),
+      });
+      off += 46 + nameLen + extraLen + cmtLen;
+    }
+    return entries;
+  }
+
+  /** Read one zipEntries() entry as text (stored or DEFLATE). */
+  static async zipReadText(bytes, entry) {
+    const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    const o = entry.lfhOff;
+    if (o + 30 > bytes.length || dv.getUint32(o, true) !== 0x04034b50) {
+      throw new Error("bad zip entry");
+    }
+    const nameLen = dv.getUint16(o + 26, true);
+    const extraLen = dv.getUint16(o + 28, true);
+    const start = o + 30 + nameLen + extraLen;
+    const data = bytes.subarray(start, start + entry.cSize);
+    if (entry.method === 0) return new TextDecoder().decode(data);
+    if (entry.method !== 8) throw new Error(`unsupported zip compression (method ${entry.method})`);
+    if (typeof DecompressionStream !== "function") {
+      throw new Error("this browser can't inflate zip archives");
+    }
+    const stream = new Blob([data]).stream().pipeThrough(new DecompressionStream("deflate-raw"));
+    return await new Response(stream).text();
+  }
+
+  /** Extract every parseable .json graph from zip bytes →
+   *  [{name, graph, format}] (format per workflowFormat, "ui" first). */
+  static async workflowsFromZip(bytes) {
+    const out = [];
+    for (const e of CivitaiClient.zipEntries(bytes)) {
+      if (!/\.json$/i.test(e.name) || /\/$/.test(e.name)) continue;
+      let graph;
+      try { graph = JSON.parse(await CivitaiClient.zipReadText(bytes, e)); }
+      catch { continue; } // undecodable/unparseable entry — skip, don't fail the zip
+      const format = CivitaiClient.workflowFormat(graph);
+      if (format === "unknown") continue;
+      out.push({ name: e.name, graph, format });
+    }
+    out.sort((a, b) => (a.format === b.format ? 0 : a.format === "ui" ? -1 : 1));
+    return out;
   }
 
   /** Ordered generation params for the info panel. */

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -598,13 +598,12 @@ export class CivitaiClient {
     return entries;
   }
 
-  /** Read one zipEntries() entry as text (stored or DEFLATE), enforcing the
-   *  per-entry uncompressed cap both up front (claimed uSize/cSize) and after
-   *  inflation — a lying header doesn't get to expand unbounded. */
-  static async zipReadText(bytes, entry, caps = CivitaiClient.ZIP_CAPS) {
-    if (entry.uSize > caps.entryBytes || entry.cSize > caps.entryBytes) {
-      throw CivitaiClient._zipCapError("zip entry too large to unpack");
-    }
+  /** Locate an entry's raw compressed bytes in the buffer. The read offset is
+   *  the LOCAL header (the only place we actually seek to), and the span
+   *  length is the central-directory `cSize` — but that length is
+   *  bounds-checked against `bytes.length` here, so a lying cSize can't point
+   *  the slice out of bounds (it throws "bad zip entry" instead). */
+  static _entryData(bytes, entry) {
     const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
     const o = entry.lfhOff;
     if (o + 30 > bytes.length || dv.getUint32(o, true) !== 0x04034b50) {
@@ -614,47 +613,93 @@ export class CivitaiClient {
     const extraLen = dv.getUint16(o + 28, true);
     const start = o + 30 + nameLen + extraLen;
     if (start + entry.cSize > bytes.length) throw new Error("bad zip entry");
-    const data = bytes.subarray(start, start + entry.cSize);
-    if (entry.method === 0) return new TextDecoder().decode(data);
+    return bytes.subarray(start, start + entry.cSize);
+  }
+
+  /** Inflate (or pass through) an entry to raw bytes, enforcing `cap` with a
+   *  STREAMING byte counter — chunks are summed as they arrive and the stream
+   *  is CANCELLED the instant the running total exceeds `cap`, so a falsified
+   *  central-directory size can't make us materialize a giant buffer first.
+   *  No declared size (uSize/cSize) is trusted for the limit; the counter is.
+   *  Returns { bytes, byteLength } (byteLength counts ACTUAL decoded bytes). */
+  static async _readEntryBytes(bytes, entry, cap) {
+    const data = CivitaiClient._entryData(bytes, entry);
+    if (entry.method === 0) {
+      // STORE: compressed == uncompressed, already fully present in-buffer and
+      // bounded by cSize ≤ buffer; still enforce the cap.
+      if (data.byteLength > cap) throw CivitaiClient._zipCapError("zip entry too large to unpack");
+      return { bytes: data, byteLength: data.byteLength };
+    }
     if (entry.method !== 8) throw new Error(`unsupported zip compression (method ${entry.method})`);
     if (typeof DecompressionStream !== "function") {
       throw new Error("this browser can't inflate zip archives");
     }
     const stream = new Blob([data]).stream().pipeThrough(new DecompressionStream("deflate-raw"));
-    const buf = await new Response(stream).arrayBuffer();
-    if (buf.byteLength > caps.entryBytes) {
-      throw CivitaiClient._zipCapError("zip entry too large to unpack");
+    const reader = stream.getReader();
+    const chunks = [];
+    let total = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > cap) {
+        // abort mid-stream — never accumulate past the cap
+        try { await reader.cancel(); } catch { /* already torn down */ }
+        throw CivitaiClient._zipCapError("zip entry too large to unpack");
+      }
+      chunks.push(value);
     }
-    return new TextDecoder().decode(buf);
+    // Peak memory here is ~2× the cap: the retained `chunks` (bounded to ≤ cap,
+    // since we abort the instant `total` crosses it) plus the single contiguous
+    // `out` copy we assemble from them. Bounded either way — no unbounded
+    // buffer, no full-archive materialization.
+    const out = new Uint8Array(total);
+    let off = 0;
+    for (const c of chunks) { out.set(c, off); off += c.byteLength; }
+    return { bytes: out, byteLength: total };
+  }
+
+  /** Read one zipEntries() entry as text (stored or DEFLATE), enforcing the
+   *  per-entry uncompressed cap with a streaming byte counter (see
+   *  _readEntryBytes) — a lying header can't expand unbounded. */
+  static async zipReadText(bytes, entry, caps = CivitaiClient.ZIP_CAPS) {
+    const { bytes: raw } = await CivitaiClient._readEntryBytes(bytes, entry, caps.entryBytes);
+    return new TextDecoder().decode(raw);
   }
 
   /** Extract every parseable .json graph from zip bytes →
    *  [{name, graph, format}] (format per workflowFormat, "ui" first).
    *  Cap breaches (entry count, per-entry size, aggregate size) THROW with a
-   *  clear message; an individually unparseable entry is merely skipped. */
+   *  clear message; an individually unparseable entry is merely skipped. The
+   *  aggregate counter sums ACTUAL decoded bytes (not UTF-16 string length, so
+   *  multibyte UTF-8 can't slip past the byte cap) and the per-entry read
+   *  aborts streaming past its own cap before this ever sees a giant buffer. */
   static async workflowsFromZip(bytes, caps = CivitaiClient.ZIP_CAPS) {
     const out = [];
     let total = 0;
     for (const e of CivitaiClient.zipEntries(bytes, caps)) {
       if (!/\.json$/i.test(e.name) || /\/$/.test(e.name)) continue;
-      // aggregate cap on CLAIMED sizes first, so a bomb can't be inflated
-      // piecewise; the true inflated size is re-counted after reading.
-      if (total + e.uSize > caps.totalBytes) {
-        throw CivitaiClient._zipCapError("archive unpacks too large");
-      }
-      let text;
+      // Cap the per-entry read to whatever aggregate budget REMAINS, so the
+      // streaming counter also enforces the aggregate mid-inflation — an entry
+      // that alone fits its own cap but would blow the archive total aborts
+      // without materializing. min() keeps the per-entry cap when budget > it.
+      const remaining = caps.totalBytes - total;
+      const perEntryCap = Math.min(caps.entryBytes, Math.max(0, remaining));
+      let read;
       try {
-        text = await CivitaiClient.zipReadText(bytes, e, caps);
+        read = await CivitaiClient._readEntryBytes(bytes, e, perEntryCap);
       } catch (err) {
-        if (err && err.zipCap) throw err; // cap breach — fail the whole zip
+        if (err && err.zipCap) {
+          // distinguish the aggregate breach for a clearer message
+          throw remaining < caps.entryBytes
+            ? CivitaiClient._zipCapError("archive unpacks too large")
+            : err;
+        }
         continue; // undecodable entry — skip, don't fail the zip
       }
-      total += text.length;
-      if (total > caps.totalBytes) {
-        throw CivitaiClient._zipCapError("archive unpacks too large");
-      }
+      total += read.byteLength;
       let graph;
-      try { graph = JSON.parse(text); }
+      try { graph = JSON.parse(new TextDecoder().decode(read.bytes)); }
       catch { continue; } // unparseable entry — skip
       const format = CivitaiClient.workflowFormat(graph);
       if (format === "unknown") continue;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9212,6 +9212,22 @@ function buildPanel() {
       isMuted: () => AGENT_MUTED,
       marked,
       DOMPurify,
+      // Canvas access for "load workflow onto canvas": dirty check for the
+      // confirm-overwrite prompt, then the SAME undoable path the bridge's
+      // graph_load command takes (snapshot → loadGraphData → checkState, so
+      // one load = one Ctrl+Z step). Throws with a readable message when the
+      // graph isn't a loadable UI workflow.
+      graphIsDirty: () => {
+        try { return !!app?.extensionManager?.workflow?.activeWorkflow?.isModified; }
+        catch { return false; }
+      },
+      loadGraph: (graph) => {
+        const result = GRAPH_TOOL_EXECUTORS.graph_load({ graph });
+        try {
+          app.extensionManager?.workflow?.activeWorkflow?.changeTracker?.checkState?.();
+        } catch { /* tracker unavailable (older frontend) — undo stays best-effort */ }
+        return result;
+      },
     };
   }
   function openCivitai(opts) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -4137,7 +4137,7 @@ const GRAPH_TOOL_EXECUTORS = {
   // Load a COMPLETE workflow onto the live canvas in one shot (replaces the
   // current graph), so a ready pack/template graph lands without recreating it
   // node-by-node. Mirrors restoreSnapshot's app.loadGraphData(...) path.
-  graph_load({ graph: incoming } = {}) {
+  async graph_load({ graph: incoming } = {}) {
     const { app } = getGraphCtx();
     // Accept a JSON string or an object.
     let data = incoming;
@@ -4197,7 +4197,10 @@ const GRAPH_TOOL_EXECUTORS = {
     // Snapshot the current graph FIRST so the load is undoable via the per-turn
     // revert (double-Esc / revert), like every other graph edit this turn.
     captureGraphSnapshot(null, "before graph_load");
-    app.loadGraphData(clone);
+    // loadGraphData is async on current frontends — AWAIT it so follow-ups
+    // (checkState for one-step undo, success toasts) run after the graph has
+    // actually landed, and a load failure rejects instead of vanishing.
+    await app.loadGraphData(clone);
     return {
       loaded: true,
       node_count: clone.nodes.length,
@@ -9214,15 +9217,21 @@ function buildPanel() {
       DOMPurify,
       // Canvas access for "load workflow onto canvas": dirty check for the
       // confirm-overwrite prompt, then the SAME undoable path the bridge's
-      // graph_load command takes (snapshot → loadGraphData → checkState, so
-      // one load = one Ctrl+Z step). Throws with a readable message when the
-      // graph isn't a loadable UI workflow.
+      // graph_load command takes (snapshot → await loadGraphData → checkState,
+      // so one load = one Ctrl+Z step). Rejects with a readable message when
+      // the graph isn't a loadable UI workflow or the load itself fails.
+      // Dirty check fails CLOSED: when the workflow state can't be read
+      // (older frontend, missing service, throw), report dirty so the caller
+      // confirms instead of silently clobbering an unsaved canvas.
       graphIsDirty: () => {
-        try { return !!app?.extensionManager?.workflow?.activeWorkflow?.isModified; }
-        catch { return false; }
+        try {
+          const wf = app?.extensionManager?.workflow?.activeWorkflow;
+          if (!wf || typeof wf.isModified !== "boolean") return true; // unknown → confirm
+          return wf.isModified;
+        } catch { return true; }
       },
-      loadGraph: (graph) => {
-        const result = GRAPH_TOOL_EXECUTORS.graph_load({ graph });
+      loadGraph: async (graph) => {
+        const result = await GRAPH_TOOL_EXECUTORS.graph_load({ graph });
         try {
           app.extensionManager?.workflow?.activeWorkflow?.changeTracker?.checkState?.();
         } catch { /* tracker unavailable (older frontend) — undo stays best-effort */ }


### PR DESCRIPTION
## What

Community request from Discord (threads 1527136427853221898 / 1527122588189327421, user seanmcmagic): *"Extracting and downloading the workflow and attempting to drag and drop it into ComfyUI to run it."* — from a CivitAI post inside the panel's explorer, pull the embedded/downloadable ComfyUI workflow and **load it onto the canvas**, ready to run.

### 1. Lightbox: "Load onto canvas" for embedded workflows

- New `CivitaiClient.comfyGraphInfo(meta)` classifies the embedded graph — **UI format** (litegraph `nodes[]`, loadable) vs **API/prompt format** (numeric keys + `class_type`, runnable but not canvas-loadable) — using the exact same test as the bridge's `graph_load`. Handles every live `meta.comfy` shape (see "Real payloads" below), including legacy JSON-string encodings.
- UI-format → **Load onto canvas**: confirm-overwrite when the current workflow has unsaved changes (fail-CLOSED: unknown dirty state also asks), then load through the same undoable path the agent bridge uses — snapshot → **awaited** `app.loadGraphData` → `changeTracker.checkState()` — so **one load = one Ctrl+Z**, and success/undo bookkeeping only fires after the graph actually landed. On success the explorer closes so you land on the loaded canvas.
- API-format-only → honest message ("can't load onto the canvas, Save keeps its JSON"). No client-side API→UI converter exists (the mcp repo's converter is agent-side), so we degrade instead of corrupting the canvas.
- **Bug fix along the way**: civitai sometimes emits `meta.comfy = { prompt: <api>, workflow: {} }` — an *empty* workflow object. The old `comfyGraph` returned that truthy `{}` and showed "✓ Embedded ComfyUI workflow" for nothing. It now falls back to the API prompt and reports which format it found.

### 2. Workflows tab: load a version's workflow file

- Model versions now carry their `files` (id/name/size/type/format). Workflow-ish files (`.json` always; `.zip` only on Workflows-type models — a zip on a Checkpoint is training data) get a **"Load workflow onto canvas"** button.
- Raw `.json` parses and loads directly. Civitai's zip wrappers — **780 of 844 live workflow versions are zips** — are unpacked in the browser: a small central-directory walker (their zips use bit-3 data descriptors, so local-header sizes are 0 and only the central directory is truthful) + the native `DecompressionStream("deflate-raw")`. **No new dependency.** Archives holding several workflows get a picker (UI-format entries first, node counts shown).
- **Zip-bomb caps**: entry count (512), per-entry uncompressed size (32MB — checked on the *claimed* size before inflating AND re-checked on the real size after, so a lying header can't expand unbounded), aggregate uncompressed size (96MB), bounds-checked directory records, and dedupe of multiple records aimed at one compressed blob. Cap breaches fail the archive with a clear message; a single unparseable entry just skips.
- New same-origin proxy route `GET /comfyui_mcp_panel/civitai/download?versionId=&type=&format=` — the existing `/api` passthrough is text-only and would mangle zip bytes. It follows civitai's `307` **server-side, manually, with an SSRF guard**: redirects may only land on https civitai/B2 hosts (`civitai.com`/`civitai.red`/`backblazeb2.com`, exact or subdomain), and only when **every** DNS answer for the host is a public address — loopback, RFC1918, link-local/metadata (169.254.169.254), reserved, multicast, unspecified, and IPv4-mapped-IPv6 smuggles are all rejected, blocking DNS-rebinding to internal ranges. The OAuth `Authorization` header is dropped on the cross-host hop (B2 rejects a foreign auth header alongside its query signature). The body **streams through** (no server-side buffering) with a 100MB cap; past the cap or on mid-stream failure the connection is aborted so the client sees a failed fetch, never a silently truncated file.
- **401/403** (early-access/gated files) surfaces as the panel's friendly hint: sign in via the account button (the proxy attaches the OAuth token when signed in) — matching the like-toggle's existing 403 idiom.

### 3. Creator filter

Composes untouched — no changes to filter plumbing; verified the existing creator tests still pass.

## Real payloads (live-probed 2026-07-15, civitai.red + civitai.com)

- `/v1/images` feeds no longer include `meta` at all — generation data comes from tRPC `image.getGenerationData` (which the panel already uses).
- `meta.comfy` live shapes observed: object `{ prompt: <api-format>, workflow: <ui, nodes[]> }` (5 of 60 sampled images); degenerate `{ prompt: <api>, workflow: {} }` (image 136187879 — the fixture in the tests); the legacy JSON-string encoding didn't appear live but stays supported.
- Workflows model files: sweep of 844 versions → **780 `.zip`, 77 raw `.json`**, zero other extensions. Real zip inspected (version 2947948): 2 deflate entries, both UI-format graphs, local headers zeroed (data descriptors) — which is why the reader walks the central directory.
- Downloads: `GET civitai.red/api/download/models/2947948` returns **307 → signed b2.civitai.com URL and succeeds signed-out** — the blanket "civitai requires a token for downloads" belief does not hold for these files; the 401/403 path is kept for gated ones.
- Full extraction pipeline verified against the real downloaded zip (also re-verified under the new default caps) and the real degenerate gen payload using the shipped module.

## Registry-YARA constraints

No event attributes in markup (all `addEventListener`), no new `innerHTML` sinks, no SVG changes, no new external fetch hosts (everything rides the existing Python proxy; the download route's redirect-following is host-allowlisted + public-IP-checked, stricter than `/api`'s existing auto-redirects).

## Verified

- `node --check` (as `.mjs`): `cmcp-civitai.js`, `cmcp-civitai-ui.js`, `comfyui-mcp-panel.js` — OK
- `npm run test:unit` — **60/60 pass** (23 new JS tests in `civitai-workflow.test.mjs`: format detection, live-shape `meta.comfy` fixtures incl. the empty-`{}` regression, file selection/dedupe/size-cap, zip reader incl. data-descriptor + STORE + junk-entry cases, zip-bomb caps incl. lying-uSize and duplicate-record dedupe, fail-closed dirty check, download plumbing + status surfacing)
- `python -m unittest` on `browser_tests/unit/test_civitai_proxy.py` — **4/4 pass** (redirect host allowlist incl. prefix/boundary attacks, public-IP check incl. v4-mapped-v6 smuggles)
- `npm run typecheck` — clean; `python -m py_compile py/civitai_proxy.py` — clean
- Live: shipped `workflowsFromZip` extracts both UI graphs from a real civitai workflow zip under the default caps; `comfyGraphInfo` returns `api` for the real empty-workflow payload

## Review hardening (second commit, 665f724)

Addressed Codex review: SSRF redirect allowlist + public-DNS check (blocker), zip-bomb caps, awaited `loadGraphData` (undo/toast ordering + visible load failures), fail-closed dirty check, true streaming in the proxy (no 100MB buffer).

## Owed / not done here

- **Live browser click-through** (lightbox button → canvas load → Ctrl+Z; Workflows-tab download → picker → load) — owed, needs a running ComfyUI + Chrome session.
- OAuth-gated download (401 path) untested against a real gated file — needs a signed-in account with an early-access file.
- Files duplicated on `(type, format)` are unreachable individually via the download API (live case: version 2947948 has two `Archive/Other` zips); we dedupe and take the API's pick.
- A TOCTOU window remains between the redirect-host DNS check and aiohttp's own connect-time resolution; closing it fully would need a pinning resolver. The allowlist keeps the exposure to civitai/B2-controlled names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
