### PR TITLE
feat(civitai): 'See more from @creator' + GitHub-style @creator search qualifiers

### DIFF
--- a/browser_tests/unit/civitai-creator.test.mjs
+++ b/browser_tests/unit/civitai-creator.test.mjs
@@ -4,7 +4,7 @@
 // query the explorer makes.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { CivitaiClient, DEFAULT_FILTERS, filtersDirty } from "../../web/js/cmcp-civitai.js";
+import { CivitaiClient, DEFAULT_FILTERS, filtersDirty, parseCreatorQuery } from "../../web/js/cmcp-civitai.js";
 
 /** Client whose proxy calls are captured. `payload` may be a single response
  *  (every call resolves it) or an array consumed one per call (last repeats). */
@@ -167,4 +167,39 @@ test("searchCreators shapes /v1/creators and short-circuits empty queries", asyn
   calls.length = 0;
   assert.deepEqual(await client.searchCreators("   "), []);
   assert.equal(calls.length, 0); // no network call for a blank query
+});
+
+// ── parseCreatorQuery: GitHub-style "@creator terms" search qualifiers ──────
+test("parseCreatorQuery: @name + terms split into creator and ranked query", () => {
+  assert.deepEqual(parseCreatorQuery("@ba0zi cyberpunk city rain"), {
+    creator: "ba0zi",
+    query: "cyberpunk city rain",
+  });
+});
+
+test("parseCreatorQuery: @token position doesn't matter", () => {
+  assert.deepEqual(parseCreatorQuery("cyberpunk @ba0zi rain"), {
+    creator: "ba0zi",
+    query: "cyberpunk rain",
+  });
+});
+
+test("parseCreatorQuery: no qualifier → plain query, null creator", () => {
+  assert.deepEqual(parseCreatorQuery("cyberpunk city"), { creator: null, query: "cyberpunk city" });
+});
+
+test("parseCreatorQuery: bare '@' is a plain term, not an empty creator", () => {
+  assert.deepEqual(parseCreatorQuery("@ rain"), { creator: null, query: "@ rain" });
+});
+
+test("parseCreatorQuery: only the FIRST @token is the creator; later ones stay terms", () => {
+  assert.deepEqual(parseCreatorQuery("@first @second rain"), {
+    creator: "first",
+    query: "@second rain",
+  });
+});
+
+test("parseCreatorQuery: empty/whitespace input", () => {
+  assert.deepEqual(parseCreatorQuery("   "), { creator: null, query: "" });
+  assert.deepEqual(parseCreatorQuery(""), { creator: null, query: "" });
 });

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -214,8 +214,19 @@ export function openCivitaiModal(ctx, opts = {}) {
   let searchTimer = null;
   // An @token in the search box OWNS the creator filter: typing one sets it,
   // deleting it clears it — but a creator picked in the filter sheet is left
-  // alone (creatorFromSearch tracks whose it is).
+  // alone (creatorFromSearch tracks whose it is). setCreator is the ONE place
+  // filters.username changes outside applySearch: it also rewrites the box's
+  // @token so the sheet's pill/picker/reset and the box can never desync
+  // (codex review: a removed pill used to resurrect from the stale token).
   let creatorFromSearch = false;
+  function setCreator(name, { fromSearch = false } = {}) {
+    const f = state.filters;
+    f.username = name ? String(name) : null;
+    creatorFromSearch = !!name && fromSearch;
+    // Rewrite only the qualifier part of the box; keep the user's terms.
+    const { query } = parseCreatorQuery(search.value);
+    search.value = f.username ? `@${f.username}${query ? " " + query : " "}` : query;
+  }
   const applySearch = () => {
     const { creator, query } = parseCreatorQuery(search.value);
     const f = state.filters;
@@ -233,15 +244,25 @@ export function openCivitaiModal(ctx, opts = {}) {
     syncTabs();
     reload({ searching: true });
   };
+  // Finding: a pre-seeded opts.query may carry an @qualifier (the agent's
+  // open_civitai can pass one) — reconcile it into the filter BEFORE the
+  // first reload instead of searching for the literal token.
+  {
+    const seeded = parseCreatorQuery(state.query);
+    if (seeded.creator) {
+      state.filters.username = seeded.creator;
+      creatorFromSearch = true;
+      state.query = seeded.query;
+    }
+  }
   /** "See more from @creator" — set the creator filter and reflect it in the
    *  search box as an @token (the box is the source of truth for it). The
    *  favorites tab has no creator param, so it jumps to Images. */
   function seeMoreFromCreator(name, { toModelTab = false } = {}) {
     if (!name) return;
-    state.filters.username = String(name);
-    creatorFromSearch = true;
     state.query = "";
-    search.value = `@${name} `;
+    search.value = "";
+    setCreator(name, { fromSearch: true });
     if (tabDef().fav) state.tab = toModelTab ? state.tab : "images";
     syncTabs();
     reload({ searching: true });
@@ -959,7 +980,7 @@ export function openCivitaiModal(ctx, opts = {}) {
         if (f.username) {
           const pill = el("button", "cmcp-cv-chip on", f.username + "  ✕");
           pill.title = "Remove creator filter";
-          pill.addEventListener("click", () => { f.username = null; renderSheet(); update(); });
+          pill.addEventListener("click", () => { setCreator(null); renderSheet(); update(); });
           box.appendChild(pill);
         }
         box.appendChild(el("div", "cmcp-cv-lb-muted",
@@ -970,7 +991,7 @@ export function openCivitaiModal(ctx, opts = {}) {
         if (f.username) {
           const pill = el("button", "cmcp-cv-chip on", f.username + "  ✕");
           pill.title = "Remove creator filter";
-          pill.addEventListener("click", () => { f.username = null; renderSheet(); update(); });
+          pill.addEventListener("click", () => { setCreator(null); renderSheet(); update(); });
           crPills.appendChild(pill);
         }
         const crSearch = el("input", "cmcp-cv-search");
@@ -994,7 +1015,7 @@ export function openCivitaiModal(ctx, opts = {}) {
               : `${c.modelCount ?? 0} model${(c.modelCount ?? 0) === 1 ? "" : "s"}`;
             if (sub) b.appendChild(el("span", "sub", sub));
             b.addEventListener("click", () => {
-              f.username = c.username;
+              setCreator(c.username);
               renderSheet(); update();
             });
             crList.appendChild(b);
@@ -1046,6 +1067,7 @@ export function openCivitaiModal(ctx, opts = {}) {
           baseModels: [...DEFAULT_FILTERS.baseModels],
           browsingLevels: [...DEFAULT_FILTERS.browsingLevels],
         };
+        setCreator(null); // also strips a stale @token from the search box
         renderSheet(); update();
       });
       wrap.appendChild(reset);

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -11,7 +11,7 @@
 
 import {
   CivitaiClient, DEFAULT_FILTERS, LEVELS, PERIODS, IMAGE_SORTS, MODEL_SORTS,
-  BASE_MODELS, filtersDirty, bitmask,
+  BASE_MODELS, filtersDirty, bitmask, parseCreatorQuery,
 } from "./cmcp-civitai.js";
 
 const TABS = [
@@ -212,12 +212,40 @@ export function openCivitaiModal(ctx, opts = {}) {
   search.placeholder = "Search CivitAI…";
   search.value = state.query;
   let searchTimer = null;
+  // An @token in the search box OWNS the creator filter: typing one sets it,
+  // deleting it clears it — but a creator picked in the filter sheet is left
+  // alone (creatorFromSearch tracks whose it is).
+  let creatorFromSearch = false;
   const applySearch = () => {
-    const q = search.value.trim();
-    if (q === state.query) return;
-    state.query = q;
+    const { creator, query } = parseCreatorQuery(search.value);
+    const f = state.filters;
+    let changed = query !== state.query;
+    if (creator) {
+      if (f.username !== creator) { f.username = creator; changed = true; }
+      creatorFromSearch = true;
+    } else if (creatorFromSearch && f.username) {
+      f.username = null;
+      creatorFromSearch = false;
+      changed = true;
+    }
+    if (!changed) return;
+    state.query = query;
+    syncTabs();
     reload({ searching: true });
   };
+  /** "See more from @creator" — set the creator filter and reflect it in the
+   *  search box as an @token (the box is the source of truth for it). The
+   *  favorites tab has no creator param, so it jumps to Images. */
+  function seeMoreFromCreator(name, { toModelTab = false } = {}) {
+    if (!name) return;
+    state.filters.username = String(name);
+    creatorFromSearch = true;
+    state.query = "";
+    search.value = `@${name} `;
+    if (tabDef().fav) state.tab = toModelTab ? state.tab : "images";
+    syncTabs();
+    reload({ searching: true });
+  }
   search.addEventListener("input", () => {
     clearTimeout(searchTimer);
     searchTimer = setTimeout(applySearch, 500);
@@ -574,6 +602,14 @@ export function openCivitaiModal(ctx, opts = {}) {
         `♥ ${it.reactions || 0} · ${idx + 1} / ${state.items.length}${state.done ? "" : "+"}`));
 
       const actions = el("div", "cmcp-cv-actions");
+      if (it.author) {
+        const moreBtn = el("button", "cmcp-btn", `See more from @${it.author}`);
+        moreBtn.addEventListener("click", () => {
+          closeLb();
+          seeMoreFromCreator(it.author);
+        });
+        actions.appendChild(moreBtn);
+      }
       side.appendChild(actions);
       const genBox = el("div");
       genBox.appendChild(el("div", "cmcp-cv-lb-muted", "Loading generation info…"));
@@ -743,6 +779,14 @@ export function openCivitaiModal(ctx, opts = {}) {
         const note = el("span", null, "You already have this file locally.");
         note.style.cssText = "font-size:.72rem;color:#4ade80;align-self:center";
         dl.appendChild(note);
+      }
+      if (detail.creator) {
+        const moreBtn = el("button", "cmcp-btn", `See more from @${detail.creator}`);
+        moreBtn.addEventListener("click", () => {
+          sheet.close();
+          seeMoreFromCreator(detail.creator, { toModelTab: true });
+        });
+        dl.appendChild(moreBtn);
       }
       detailBody.appendChild(dl);
       if (version.descriptionHtml || detail.descriptionHtml) {

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -212,17 +212,19 @@ export function openCivitaiModal(ctx, opts = {}) {
   search.placeholder = "Search CivitAI…";
   search.value = state.query;
   let searchTimer = null;
-  // An @token in the search box OWNS the creator filter: typing one sets it,
-  // deleting it clears it — but a creator picked in the filter sheet is left
-  // alone (creatorFromSearch tracks whose it is). setCreator is the ONE place
-  // filters.username changes outside applySearch: it also rewrites the box's
-  // @token so the sheet's pill/picker/reset and the box can never desync
-  // (codex review: a removed pill used to resurrect from the stale token).
+  // The @token displayed in the search box ALWAYS owns the creator filter:
+  // setCreator mirrors every creator change (sheet picker, pill ✕, reset,
+  // "See more from") into the box as an @token, so deleting that token must
+  // clear the filter no matter where it came from — ownership is "the token
+  // is displayed", not "who typed it" (codex round-3: a sheet-picked creator's
+  // mirrored token previously didn't own the filter, making deletion
+  // history-dependent). setCreator is the ONE mutation point outside
+  // applySearch.
   let creatorFromSearch = false;
-  function setCreator(name, { fromSearch = false } = {}) {
+  function setCreator(name) {
     const f = state.filters;
     f.username = name ? String(name) : null;
-    creatorFromSearch = !!name && fromSearch;
+    creatorFromSearch = !!name; // displayed token == owned token, always
     // Rewrite only the qualifier part of the box; keep the user's terms.
     const { query } = parseCreatorQuery(search.value);
     search.value = f.username ? `@${f.username}${query ? " " + query : " "}` : query;
@@ -262,7 +264,7 @@ export function openCivitaiModal(ctx, opts = {}) {
     if (!name) return;
     state.query = "";
     search.value = "";
-    setCreator(name, { fromSearch: true });
+    setCreator(name);
     if (tabDef().fav) state.tab = toModelTab ? state.tab : "images";
     syncTabs();
     reload({ searching: true });

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -39,6 +39,24 @@ export const DEFAULT_FILTERS = Object.freeze({
   username: null, // creator filter — null means everyone
 });
 
+/**
+ * GitHub-style search qualifiers: an "@name" token anywhere in the input sets
+ * the creator filter; every other token stays part of the ranked full-text
+ * query. "@ba0zi cyberpunk city rain" -> { creator: "ba0zi", query:
+ * "cyberpunk city rain" }. The terms deliberately remain Meili `q` (typo-
+ * tolerant, relevance-ranked) rather than exact tagNames filters, which would
+ * be brittle. Only the FIRST @token is the creator; later ones are treated as
+ * plain terms so a pasted sentence can't silently retarget the filter.
+ */
+export function parseCreatorQuery(raw) {
+  const tokens = String(raw ?? "").trim().split(/\s+/).filter(Boolean);
+  const at = tokens.find((t) => t.length > 1 && t.startsWith("@"));
+  return {
+    creator: at ? at.slice(1) : null,
+    query: tokens.filter((t) => t !== at).join(" "),
+  };
+}
+
 export function filtersDirty(f) {
   return (
     f.period !== "Week" ||

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -50,10 +50,12 @@ export const DEFAULT_FILTERS = Object.freeze({
  */
 export function parseCreatorQuery(raw) {
   const tokens = String(raw ?? "").trim().split(/\s+/).filter(Boolean);
-  const at = tokens.find((t) => t.length > 1 && t.startsWith("@"));
+  const atIdx = tokens.findIndex((t) => t.length > 1 && t.startsWith("@"));
   return {
-    creator: at ? at.slice(1) : null,
-    query: tokens.filter((t) => t !== at).join(" "),
+    creator: atIdx >= 0 ? tokens[atIdx].slice(1) : null,
+    // Remove only the FIRST qualifier occurrence — a later identical token is
+    // a plain term per the documented rule ("@alice cats @alice").
+    query: tokens.filter((_, i) => i !== atIdx).join(" "),
   };
 }
 


### PR DESCRIPTION
Builds on #84's creator-filter plumbing with the two drill-down UX pieces:

- **See more from @creator** — button in the lightbox side pane (closes the lightbox; the favorites tab jumps to Images since favorites have no creator param) and in the model detail sheet (stays on the model tab — /v1/models supports username).
- **GitHub-style search qualifiers** — `@name terms` in the search box: the first `@token` sets the creator filter, the remaining words stay Meili's ranked full-text `q` (deliberately NOT `tagNames` filters — typo-tolerant relevance beats brittle exact matches; `user.username` filterability probed live against images_v6). The box OWNS a creator it set (deleting the token clears it) while `setCreator()` keeps the filter sheet's pill/picker/reset and the box text in lockstep.

## Codex review
Ran pre-PR; all three findings fixed in the second commit: sheet↔box desync (major — pill removal used to resurrect from stale box text), pre-seeded `opts.query` @qualifiers not parsed before the first reload, and duplicate-token removal in the parser.

## Verification
- 6 new parser unit tests; suite 43/43 green
- Live in Chrome: lightbox "See more from @Cinnadust" → box shows `@Cinnadust`, grid is 100% that creator, filter dot lit; `@Cinnadust cat` → only Cinnadust's cat pieces, blur+spinner overlay visible mid-search

🤖 Generated with [Claude Code](https://claude.com/claude-code)