### PR TITLE
feat(civitai): "See more from @creator" + GitHub-style @creator search syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ All notable changes to this project are documented here. This project adheres to
   level/base-model toggles no longer mutate the frozen module defaults
 
 ### Added
+- CivitAI browser: **"See more from @creator"** in the lightbox and in the
+  model detail sheet — one click sets the creator filter (the same removable
+  pill + filter-dot slot the sheet uses), closes the view, and reloads; from
+  Favorites it lands on the matching Images/Videos tab (the favorites feed has
+  no creator param)
+- CivitAI browser: **GitHub-style `@creator` search syntax** — typing
+  `@bab0zi cyberpunk city rain` in the search bar sets the creator filter to
+  `bab0zi` and searches the remaining terms (Meili gets `q` + escaped
+  `user.username` filter in one request; REST feeds get `username=` plus the
+  existing keyword handling). The first `@token` wins and a new `@name`
+  replaces the previous creator; `@name` alone just sets the filter; a lone
+  `@` and mid-word `@` (emails) stay plain text. Agent-seeded queries
+  (`open_civitai`) honor the same syntax
 - CivitAI browser: **Creator filter** in the filter sheet (parity with the
   mobile app) — an empty field shows the site's top-creators leaderboard
   (ranked, with download/like counts; degrades to a friendly note when the

--- a/browser_tests/unit/civitai-at-syntax.test.mjs
+++ b/browser_tests/unit/civitai-at-syntax.test.mjs
@@ -1,0 +1,77 @@
+// Unit tests for the search bar's GitHub-style "@creator" syntax
+// (parseCreatorQuery in cmcp-civitai.js): "@bab0zi cyberpunk city rain" →
+// creator=bab0zi, search="cyberpunk city rain" — plus the escaping edges when
+// the parsed username flows into the Meili filter via searchMedia.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { CivitaiClient, parseCreatorQuery } from "../../web/js/cmcp-civitai.js";
+
+test("@name + terms → creator filter + remaining search terms", () => {
+  assert.deepEqual(parseCreatorQuery("@bab0zi cyberpunk city rain"),
+    { username: "bab0zi", query: "cyberpunk city rain" });
+});
+
+test("@name anywhere in the string is picked up, terms keep their order", () => {
+  assert.deepEqual(parseCreatorQuery("cyberpunk @bab0zi city rain"),
+    { username: "bab0zi", query: "cyberpunk city rain" });
+  assert.deepEqual(parseCreatorQuery("cyberpunk city rain @bab0zi"),
+    { username: "bab0zi", query: "cyberpunk city rain" });
+});
+
+test("@name alone (no terms) just sets the filter", () => {
+  assert.deepEqual(parseCreatorQuery("@bab0zi"), { username: "bab0zi", query: "" });
+  assert.deepEqual(parseCreatorQuery("  @bab0zi  "), { username: "bab0zi", query: "" });
+});
+
+test("no @token → no creator, text passes through", () => {
+  assert.deepEqual(parseCreatorQuery("cyberpunk city rain"),
+    { username: null, query: "cyberpunk city rain" });
+  assert.deepEqual(parseCreatorQuery(""), { username: null, query: "" });
+  assert.deepEqual(parseCreatorQuery("   "), { username: null, query: "" });
+  assert.deepEqual(parseCreatorQuery(null), { username: null, query: "" });
+  assert.deepEqual(parseCreatorQuery(undefined), { username: null, query: "" });
+});
+
+test("FIRST @token wins; later @tokens are consumed, not searched literally", () => {
+  assert.deepEqual(parseCreatorQuery("@alpha @beta neon"),
+    { username: "alpha", query: "neon" });
+});
+
+test("a lone '@' is not a creator token — it stays in the search text", () => {
+  assert.deepEqual(parseCreatorQuery("@"), { username: null, query: "@" });
+  assert.deepEqual(parseCreatorQuery("@ cyberpunk"), { username: null, query: "@ cyberpunk" });
+});
+
+test("mid-word @ (emails, handles-in-prose) is NOT creator syntax", () => {
+  assert.deepEqual(parseCreatorQuery("mail me@example.com please"),
+    { username: null, query: "mail me@example.com please" });
+});
+
+test("whitespace runs collapse; token boundaries are any whitespace", () => {
+  assert.deepEqual(parseCreatorQuery("  @bab0zi   cyberpunk\tcity \n rain "),
+    { username: "bab0zi", query: "cyberpunk city rain" });
+});
+
+test("username is returned RAW — quotes/backslashes survive for escapeMeili", () => {
+  const parsed = parseCreatorQuery('@we"ird\\name cat');
+  assert.equal(parsed.username, 'we"ird\\name');
+  assert.equal(parsed.query, "cat");
+});
+
+test("parsed username flows into searchMedia's Meili filter escaped", async () => {
+  const calls = [];
+  const client = new CivitaiClient({
+    fetchApi: async (_path, opts) => {
+      calls.push(JSON.parse(opts.body));
+      return { ok: true, json: async () => ({ results: [{ hits: [] }] }) };
+    },
+    apiURL: (p) => p,
+  });
+  const parsed = parseCreatorQuery('@we"ird\\name cyberpunk rain');
+  await client.searchMedia(parsed.query, { username: parsed.username });
+  const q = calls[0].body.queries[0];
+  // per Meili docs, q + filter combine in ONE request: the filter narrows the
+  // candidate set, the multi-term q ranks within it
+  assert.equal(q.q, "cyberpunk rain");
+  assert.ok(q.filter.includes('user.username = "we\\"ird\\\\name"'), JSON.stringify(q.filter));
+});

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -11,7 +11,7 @@
 
 import {
   CivitaiClient, DEFAULT_FILTERS, LEVELS, PERIODS, IMAGE_SORTS, MODEL_SORTS,
-  BASE_MODELS, filtersDirty, bitmask,
+  BASE_MODELS, filtersDirty, bitmask, parseCreatorQuery,
 } from "./cmcp-civitai.js";
 
 const TABS = [
@@ -191,6 +191,16 @@ export function openCivitaiModal(ctx, opts = {}) {
   if (Array.isArray(opts.browsingLevels) && opts.browsingLevels.length) {
     state.filters = { ...state.filters, browsingLevels: [...opts.browsingLevels] };
   }
+  {
+    // A pre-seeded query (cmd: open_civitai) honors the same "@name terms"
+    // creator syntax as the search bar — otherwise the box would display an
+    // @token the initial load ignores. An explicit opts.filters.username wins.
+    const seeded = parseCreatorQuery(state.query);
+    if (seeded.username != null) {
+      state.query = seeded.query;
+      if (!state.filters.username) state.filters.username = seeded.username;
+    }
+  }
   const tabDef = () => TABS.find((t) => t.key === state.tab);
   const isModelTab = () => !!tabDef().model;
 
@@ -213,9 +223,21 @@ export function openCivitaiModal(ctx, opts = {}) {
   search.value = state.query;
   let searchTimer = null;
   const applySearch = () => {
-    const q = search.value.trim();
-    if (q === state.query) return;
-    state.query = q;
+    // GitHub-style syntax: "@bab0zi cyberpunk city rain" → creator=bab0zi,
+    // search="cyberpunk city rain". The creator rides the SAME filter slot the
+    // sheet uses (pill + dot reflect it, pill removes it); typing a new @name
+    // replaces the previous one. "@name" alone just sets the filter.
+    const parsed = parseCreatorQuery(search.value);
+    const creatorChanged =
+      parsed.username != null && parsed.username !== state.filters.username;
+    if (parsed.username != null) {
+      // From here the creator lives in the filter pill — strip the @token from
+      // the visible text so removing the pill can't resurrect it on re-search.
+      state.filters.username = parsed.username;
+      search.value = parsed.query;
+    }
+    if (parsed.query === state.query && !creatorChanged) return;
+    state.query = parsed.query;
     reload({ searching: true });
   };
   search.addEventListener("input", () => {
@@ -574,6 +596,22 @@ export function openCivitaiModal(ctx, opts = {}) {
         `♥ ${it.reactions || 0} · ${idx + 1} / ${state.items.length}${state.done ? "" : "+"}`));
 
       const actions = el("div", "cmcp-cv-actions");
+      if (it.author) {
+        // Jump from the lightbox to everything this creator posted — the SAME
+        // filter slot the sheet sets (pill removes it, dot lights up), so no
+        // second creator-filter mechanism. Lives in the actions row and is
+        // appended synchronously (gen info hasn't necessarily landed yet).
+        const moreBtn = el("button", "cmcp-btn", `See more from @${it.author}`);
+        moreBtn.addEventListener("click", () => {
+          state.filters.username = it.author;
+          // Favorites ignores the creator filter (no creator param on the
+          // tRPC feed) — land on the matching media tab so the click works.
+          if (tabDef().fav) state.tab = it.type === "video" ? "videos" : "images";
+          closeLb();
+          reload(); // reload() re-syncs tabs + the filter dot
+        });
+        actions.appendChild(moreBtn);
+      }
       side.appendChild(actions);
       const genBox = el("div");
       genBox.appendChild(el("div", "cmcp-cv-lb-muted", "Loading generation info…"));
@@ -722,6 +760,19 @@ export function openCivitaiModal(ctx, opts = {}) {
     try { detail = await client.fetchModelDetail(m.id, { levels: state.filters.browsingLevels }); }
     catch (e) { sheet.body.innerHTML = ""; sheet.body.appendChild(el("div", null, "Error: " + e.message)); return; }
     sheet.body.innerHTML = "";
+    if (detail.creator) {
+      // Same "See more from @creator" as the lightbox — sets the shared
+      // creator filter slot, closes the sheet, reloads the current model tab.
+      const byRow = el("div", "cmcp-cv-actions");
+      const moreBtn = el("button", "cmcp-btn", `See more from @${detail.creator}`);
+      moreBtn.addEventListener("click", () => {
+        state.filters.username = detail.creator;
+        sheet.close();
+        reload(); // reload() re-syncs tabs + the filter dot
+      });
+      byRow.appendChild(moreBtn);
+      sheet.body.appendChild(byRow);
+    }
     let version = detail.versions[0];
 
     const versionRow = el("div", "cmcp-cv-frow");

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -51,6 +51,30 @@ export function filtersDirty(f) {
   );
 }
 
+/** GitHub-style creator syntax for the explorer search bar: an "@name" token
+ *  sets the creator filter and the remaining words are the search terms —
+ *  "@bab0zi cyberpunk city rain" → { username: "bab0zi", query: "cyberpunk city rain" }.
+ *  The FIRST @token wins; later @tokens are consumed too (as literals they'd
+ *  only pollute the Meili/REST keyword search). A lone "@" is NOT a creator
+ *  token and stays in the text; "me@example.com" doesn't start with "@" so it
+ *  stays too. "@name" alone → { username: "name", query: "" } (filter only).
+ *  username is returned raw — Meili callers must still escapeMeili it, and the
+ *  REST paths URL-encode it via URLSearchParams (per Meili docs, `q` + `filter`
+ *  combine in ONE request: filter narrows the set, q ranks within it). */
+export function parseCreatorQuery(raw) {
+  let username = null;
+  const words = [];
+  for (const t of String(raw || "").trim().split(/\s+/)) {
+    if (!t) continue;
+    if (t.length > 1 && t.startsWith("@")) {
+      if (username == null) username = t.slice(1);
+      continue;
+    }
+    words.push(t);
+  }
+  return { username, query: words.join(" ") };
+}
+
 export function bitmask(levels) {
   if (!levels || levels.length === 0) return 1;
   return levels.reduce((a, b) => a | b, 0);


### PR DESCRIPTION
Implements artokun's spec from Discord thread 1527122588189327421 — two entry points into the just-merged creator filter (#84), reusing its exact filter path (no second mechanism).

## What

**1. "See more from @creator" in the detail views**
- **Lightbox** (image/video): when the item has an author, an action button in the side pane sets `filters.username`, closes the lightbox, and reloads. The sheet's pill and the filter dot reflect it, and the pill removes it — same slot the filter sheet sets.
- **Model detail sheet**: same action from `detail.creator`, closing the sheet and reloading the current model tab.
- From the **Favorites** tab the click lands on the matching Images/Videos tab first, because the favorites tRPC feed has no creator param (the sheet already renders the filter as visibly inert there).

**2. GitHub-style `@creator` search syntax**
`@bab0zi cyberpunk city rain` → creator=`bab0zi`, search=`cyberpunk city rain`.
- New pure `parseCreatorQuery()` export in `web/js/cmcp-civitai.js`; the search bar (and the agent-seeded `open_civitai` query) parse through it.
- First `@token` wins; later `@tokens` are consumed (as literals they'd only pollute the keyword search). A lone `@` and mid-word `@` (emails like `me@example.com`) stay plain text. `@name` alone (no terms) just sets the filter. Typing a new `@name` replaces the previous creator.
- The `@token` is stripped from the visible box after parsing — the removable pill owns the creator from there, so removing the pill can't be undone by a stale token re-parse.
- For a pre-seeded query, an explicit `opts.filters.username` wins over the parsed token.

## Meilisearch combination (maintainer asked)
Checked the Meilisearch docs via context7 ("Search and filter together"): sending `q` + `filter` in ONE request is the canonical combination — the engine first restricts to documents matching the filter, then ranks that set by relevancy to the multi-term `q`. That is exactly what the existing `searchMedia` does (`q` + escaped `user.username = "…"` filter via `escapeMeili`), so no client change was needed — the parser just feeds the two halves into the existing paths. REST feeds/models keep `username=` plus the existing keyword handling, including the `query`×`username` empty-page quirk workaround from #84.

## Tests
New `browser_tests/unit/civitai-at-syntax.test.mjs` (10 tests): the example from the spec, token-anywhere ordering, `@name`-alone, no-token passthrough, first-token-wins, lone `@`, mid-word `@`, whitespace collapsing, raw-username return, and an integration check that a parsed `we"ird\name` username lands escaped in the Meili filter next to the multi-term `q`.

## Verification
- `node --check` (as `.mjs`): both edited files pass
- `npm run test:unit`: 47/47 pass (37 existing + 10 new)
- `npm run typecheck`: clean
- Registry-YARA: no inline event attributes (all `addEventListener`), no new colors, no new external hosts

## Risks / notes
- PR #85 (feat/civitai-load-workflow) also touches `cmcp-civitai-ui.js` — whichever lands second rebases; my lightbox change is a small insertion in `render()` next to the actions row, so conflicts should be trivial.
- Consuming *later* `@tokens` (rather than leaving them as literal search terms) is a judgment call — literals would hit Meili as junk terms; easy to flip if unwanted.
- Search-box whitespace runs now collapse to single spaces when re-parsed (token join) — cosmetic only.
- No visual browser check on this box (no local Chrome) — logic is unit-covered; the lightbox/detail buttons reuse existing `cmcp-btn` styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)