### PR TITLE
feat: Share transcript — good/bad feedback upload + S3 collector Worker

### DIFF
--- a/.comfyignore
+++ b/.comfyignore
@@ -19,6 +19,9 @@ tsconfig.json
 # Dev-only tooling — keep the published (security-scanned) archive minimal
 scripts/
 .githooks/
+# Maintainer-deployed Cloudflare Worker (Share-transcript collector) — server
+# code, never part of the browser pack
+workers/
 # The registry's YARA scan matches code-shaped literals in ANY shipped file,
 # including markdown prose: 0.6.2 was flagged (any-code-execute) because the
 # changelog QUOTED the removed process-spawn call verbatim. The changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Added
+- **Share transcript** — a header flag button (visible only once
+  Settings → “Share-transcript endpoint (advanced)” is set; blank default =
+  feature fully dormant) opens a consent modal: rate the conversation
+  “This was good!” / “This was bad”, optionally say why, and upload the FULL
+  chat transcript + version info (panel/model/mcp/backend/comfyui) to the
+  maintainer's collector — the labeled dataset for the local-model retrain.
+  Privacy by construction (`web/js/lib/feedback.js`, unit-tested): no account
+  identifiers (an anonymous random id only), token-save cards dropped, bridge
+  URLs / sensitive query values / recognizable API-key shapes / bare
+  `token=`-style assignments redacted, home-dir usernames masked, internal
+  message ids stripped, transcript size-capped newest-first. Nothing uploads
+  without an explicit verdict pick + Share click; failures leave the modal
+  open to retry. Ships with the collector as a deployable artifact:
+  `workers/feedback-uploader/` — a zero-dependency Cloudflare Worker
+  (hand-rolled SigV4 pinned to AWS's test vector) that validates, size-caps
+  (1 MiB), CORS-gates, and PUTs each submission to S3 (R2/MinIO via
+  `S3_ENDPOINT`); bucket + credentials are wrangler vars/secrets, 503 until
+  provisioned — see its README for deploy and what the maintainer must set up
+
 ### Fixed
 - CivitAI browser filters actually respond: chips re-render on click (the sheet
   wired a rerender hook that was never defined, so they looked dead), and the

--- a/browser_tests/unit/feedback.test.mjs
+++ b/browser_tests/unit/feedback.test.mjs
@@ -1,0 +1,224 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  FEEDBACK_SCHEMA,
+  MAX_WHY_CHARS,
+  scrubText,
+  scrubTranscript,
+  buildFeedbackPayload,
+  createShareModalState,
+} from "../../web/js/lib/feedback.js";
+
+// ---------------------------------------------------------------------------
+// scrubText — credential material and identity fragments never survive
+// ---------------------------------------------------------------------------
+
+test("scrubText redacts ws:// and wss:// bridge URLs entirely", () => {
+  const s = scrubText("connect to ws://127.0.0.1:9180 or wss://abc-9180.proxy.example.net/bridge?token=deadbeef now");
+  assert.ok(!s.includes("ws://"), s);
+  assert.ok(!s.includes("wss://"), s);
+  assert.ok(!s.includes("deadbeef"), s);
+  assert.ok(s.includes("[bridge-url redacted]"), s);
+  assert.ok(s.endsWith(" now"), s); // surrounding prose survives
+});
+
+test("scrubText masks sensitive query values but keeps the URL readable", () => {
+  const s = scrubText("see https://pod.example.com/view?id=42&token=sekrit123&x=1 and https://a.b/#access_token=abcd1234");
+  assert.ok(!s.includes("sekrit123"), s);
+  assert.ok(!s.includes("abcd1234"), s);
+  assert.ok(s.includes("https://pod.example.com/view?id=42&token=[redacted]&x=1"), s);
+});
+
+test("scrubText masks recognizable API-key shapes and Bearer credentials", () => {
+  const cases = [
+    "key sk-ant-api03-AAAAAAAAAAAAAAAA here",
+    "openai sk-proj-AAAABBBBCCCCDDDDEEEE",
+    "hf hf_abcdefghijklmnopqrstuvwx",
+    "github ghp_ABCDEFGHIJKLMNOP1234",
+    "slack xoxb-1234-5678-abcdef",
+    "aws AKIAIOSFODNN7EXAMPLE",
+    "hdr Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig",
+  ];
+  for (const c of cases) {
+    const s = scrubText(c);
+    assert.ok(s.includes("redacted"), `expected redaction in: ${c} -> ${s}`);
+  }
+  // The specific token bodies are gone.
+  assert.ok(!scrubText("hf hf_abcdefghijklmnopqrstuvwx").includes("hf_abcdefghijklmnopqrstuvwx"));
+});
+
+test("scrubText masks bare token/password assignments in prose and pasted config", () => {
+  const s = scrubText("set HF token=abc123secret and password: hunter2 in the env");
+  assert.ok(!s.includes("abc123secret"), s);
+  assert.ok(!s.includes("hunter2"), s);
+  assert.ok(s.includes("token=[redacted]"), s);
+});
+
+test("scrubText strips home-directory usernames but keeps the useful path tail", () => {
+  const win = scrubText("saved to C:\\Users\\joespamley\\comfy\\models\\checkpoints\\x.safetensors");
+  assert.ok(!win.includes("joespamley"), win);
+  assert.ok(win.includes("models\\checkpoints\\x.safetensors"), win);
+  const posix = scrubText("log at /home/joespamley/.comfyui/log.txt and /Users/joespamley/app");
+  assert.ok(!posix.includes("joespamley"), posix);
+  assert.ok(posix.includes("/home/[user]/"), posix);
+  assert.ok(posix.includes("/Users/[user]/"), posix);
+});
+
+test("scrubText leaves ordinary prose untouched and tolerates non-strings", () => {
+  const plain = "Generate a cyberpunk skyline at 1024x1024 with ksampler settings";
+  assert.equal(scrubText(plain), plain);
+  assert.equal(scrubText(null), null);
+  assert.equal(scrubText(42), 42);
+  assert.equal(scrubText(""), "");
+});
+
+// ---------------------------------------------------------------------------
+// scrubTranscript — token cards dropped, plumbing dropped, size capped
+// ---------------------------------------------------------------------------
+
+const sampleMsgs = () => [
+  { role: "user", text: "make me an image", mid: "m1" },
+  { role: "agent", text: "On it — queueing a workflow." },
+  { role: "card", icon: "pi-cog", text: "graph_build", detail: "12 nodes wired" },
+  // The panel's token-save card (masked preview) — credential UI, must vanish.
+  { role: "card", icon: "pi-lock", text: "HuggingFace token", detail: "saved hf_a…wxyz" },
+  { role: "user", text: "use ws://127.0.0.1:9180 please", mid: "m2", rewindAnchor: "u-123" },
+];
+
+test("scrubTranscript drops token-prompt (pi-lock) cards entirely", () => {
+  const t = scrubTranscript(sampleMsgs());
+  assert.equal(t.length, 4);
+  assert.ok(!t.some((m) => m.icon === "pi-lock"));
+  assert.ok(!JSON.stringify(t).includes("HuggingFace token"));
+});
+
+test("scrubTranscript strips mid/rewindAnchor plumbing and scrubs nested strings", () => {
+  const t = scrubTranscript(sampleMsgs());
+  const json = JSON.stringify(t);
+  assert.ok(!json.includes("mid"), json);
+  assert.ok(!json.includes("rewindAnchor"), json);
+  assert.ok(!json.includes("ws://127.0.0.1"), json);
+  assert.ok(json.includes("[bridge-url redacted]"), json);
+  // Ordinary content (incl. tool cards) survives — the whole point of sharing.
+  assert.ok(json.includes("make me an image"));
+  assert.ok(json.includes("graph_build"));
+});
+
+test("scrubTranscript scrubs user attachments (pasted text) too", () => {
+  const t = scrubTranscript([
+    {
+      role: "user",
+      text: "run with [Pasted text #1]",
+      attachments: [{ id: "1", content: "config with token=abc123secret inside https://x.y/?key=zzz" }],
+    },
+  ]);
+  const json = JSON.stringify(t);
+  assert.ok(!json.includes("zzz"), json);
+  assert.ok(json.includes("attachments"), json); // pasted content itself is kept
+});
+
+test("scrubTranscript trims from the OLD end and marks the trim", () => {
+  const msgs = [];
+  for (let i = 0; i < 50; i++) msgs.push({ role: "agent", text: `message ${i} ${"x".repeat(100)}` });
+  const t = scrubTranscript(msgs, { maxChars: 1000 });
+  assert.ok(t.length < 51);
+  assert.equal(t[0].role, "system");
+  assert.match(t[0].text, /trimmed for size/);
+  // Newest message always survives.
+  assert.ok(JSON.stringify(t).includes("message 49"));
+  assert.ok(!JSON.stringify(t).includes("message 0 "));
+});
+
+test("scrubTranscript tolerates garbage input", () => {
+  assert.deepEqual(scrubTranscript(null), []);
+  assert.deepEqual(scrubTranscript("nope"), []);
+  assert.deepEqual(scrubTranscript([null, 42, "str", {}, { role: 5 }]), []);
+});
+
+// ---------------------------------------------------------------------------
+// buildFeedbackPayload — the exact upload shape
+// ---------------------------------------------------------------------------
+
+test("buildFeedbackPayload produces the documented schema", () => {
+  const p = buildFeedbackPayload({
+    verdict: "good",
+    why: "  nailed the workflow  ",
+    msgs: sampleMsgs(),
+    versions: { model: "gemma4:e4b", panel: "0.8.2", backend: "ollama", comfyui: "1.19.9" },
+    now: 1752537600000,
+  });
+  assert.equal(p.schema, FEEDBACK_SCHEMA);
+  assert.equal(p.verdict, "good");
+  assert.equal(p.why, "nailed the workflow");
+  assert.equal(p.timestamp, new Date(1752537600000).toISOString());
+  assert.deepEqual(p.versions, {
+    model: "gemma4:e4b",
+    panel: "0.8.2",
+    mcp: null, // orchestrator doesn't report it yet — explicit null, never omitted
+    backend: "ollama",
+    comfyui: "1.19.9",
+  });
+  assert.ok(Array.isArray(p.transcript) && p.transcript.length === 4);
+  assert.ok(typeof p.id === "string" && p.id.length >= 8);
+});
+
+test("payload id is anonymous and random — two payloads never share one", () => {
+  const a = buildFeedbackPayload({ verdict: "bad", msgs: [] });
+  const b = buildFeedbackPayload({ verdict: "bad", msgs: [] });
+  assert.notEqual(a.id, b.id);
+});
+
+test("payload contains no account identifiers anywhere", () => {
+  const p = buildFeedbackPayload({ verdict: "bad", msgs: sampleMsgs(), versions: { panel: "0.8.2" } });
+  const keys = JSON.stringify(Object.keys(p)) + JSON.stringify(Object.keys(p.versions));
+  for (const banned of ["email", "user", "account", "token", "hostname"]) {
+    assert.ok(!keys.toLowerCase().includes(banned), `unexpected key material: ${banned}`);
+  }
+});
+
+test("buildFeedbackPayload rejects a missing/invalid verdict", () => {
+  assert.throws(() => buildFeedbackPayload({ msgs: [] }), TypeError);
+  assert.throws(() => buildFeedbackPayload({ verdict: "meh", msgs: [] }), TypeError);
+});
+
+test("why is optional, scrubbed, and capped", () => {
+  const none = buildFeedbackPayload({ verdict: "good", msgs: [] });
+  assert.ok(!("why" in none));
+  const scrubbed = buildFeedbackPayload({ verdict: "bad", msgs: [], why: "it leaked ws://127.0.0.1:9180" });
+  assert.ok(!scrubbed.why.includes("ws://"));
+  const long = buildFeedbackPayload({ verdict: "bad", msgs: [], why: "y".repeat(MAX_WHY_CHARS + 500) });
+  assert.equal(long.why.length, MAX_WHY_CHARS);
+});
+
+// ---------------------------------------------------------------------------
+// createShareModalState — the good/bad gating the modal relies on
+// ---------------------------------------------------------------------------
+
+test("modal state starts unlabeled with submit disabled", () => {
+  const s = createShareModalState();
+  assert.equal(s.verdict, null);
+  assert.equal(s.canSubmit, false);
+});
+
+test("modal state enables submit only after an explicit good/bad pick", () => {
+  const s = createShareModalState();
+  assert.equal(s.setVerdict("excellent"), false); // unknown value rejected
+  assert.equal(s.canSubmit, false);
+  assert.equal(s.setVerdict("good"), true);
+  assert.equal(s.verdict, "good");
+  assert.equal(s.canSubmit, true);
+  assert.equal(s.setVerdict("bad"), true); // user can change their mind
+  assert.equal(s.verdict, "bad");
+  // A later bogus value never clobbers a valid pick.
+  assert.equal(s.setVerdict(undefined), false);
+  assert.equal(s.verdict, "bad");
+  assert.equal(s.canSubmit, true);
+});
+
+test("modal state carries the optional why text", () => {
+  const s = createShareModalState();
+  s.setWhy("looped forever");
+  assert.equal(s.why, "looped forever");
+  s.setWhy(null);
+  assert.equal(s.why, "");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -66,6 +66,7 @@ import { marked } from "./vendor/marked.esm.js";
 import DOMPurify from "./vendor/purify.es.js";
 import qrcodegen from "./vendor/qrcode.esm.js";
 import { computeLayout } from "./lib/layout-engine.js";
+import { buildFeedbackPayload, createShareModalState } from "./lib/feedback.js";
 import { validateA2UISpec, renderA2UICard, renderA2UIInert, renderA2UIFailCard, A2UI_CSS } from "./cmcp-a2ui.js";
 import { openCivitaiModal } from "./cmcp-civitai-ui.js";
 
@@ -963,6 +964,11 @@ const SETTING_SESSION_FOLLOWS_PANEL = "comfyui-mcp.sessionFollowsPanel";
 const MOBILE_IOS_TESTFLIGHT_URL = ""; // e.g. https://testflight.apple.com/join/XXXXXXXX
 const MOBILE_ANDROID_FIREBASE_URL = ""; // e.g. https://appdistribution.firebase.dev/i/XXXXXXXX
 const SETTING_EXTERNAL_ORCH = "comfyui-mcp.externalOrchestrator";
+// "Share transcript" collector endpoint (COMFYUI_MCP_FEEDBACK_URL). Empty
+// (the default) = the feature is entirely hidden and NOTHING ever uploads.
+// When the maintainer publishes the collector (workers/feedback-uploader/),
+// its https URL goes here and the header gains a Share-transcript button.
+const SETTING_FEEDBACK_URL = "comfyui-mcp.feedbackUrl";
 const SETTING_TOKEN_CIVITAI = "comfyui-mcp.setCivitaiToken";
 const SETTING_TOKEN_HF = "comfyui-mcp.setHuggingfaceToken";
 // User-curated agent models (Ollama tags or OpenRouter ids) + the Ollama
@@ -1010,6 +1016,7 @@ const panelHooks = {
   applyStallConfig: null, // () — push the live render-stall threshold to the orchestrator
   applyAgentModelConfig: null, // () — push preferred models + ollama endpoint config
   applyMobileBeta: null, // (bool) — show/hide the header Remote-control (QR) button
+  applyFeedbackUrl: null, // (url) — show/hide the header Share-transcript button
   requestSecret: null, // (envKey, friendly)
 };
 // Best-effort guard so a setSetting() we make while seeding/syncing doesn't bounce
@@ -1201,6 +1208,15 @@ function stallSettingSeconds() {
 function remoteUrlSetting() {
   const v = getSetting(SETTING_REMOTE_URL);
   return typeof v === "string" ? v.trim() : "";
+}
+// "Share transcript" collector endpoint (panel setting). Blank (default) = the
+// feature is hidden and nothing can upload. Only http(s) URLs count — anything
+// else is treated as unset so a typo can't route the transcript somewhere odd.
+function feedbackEndpoint() {
+  const v = getSetting(SETTING_FEEDBACK_URL);
+  if (typeof v !== "string") return "";
+  const url = v.trim();
+  return /^https?:\/\//i.test(url) ? url : "";
 }
 // External/local orchestrator mode (panel setting). The agent is run by the USER
 // on their own machine (`npx -y comfyui-mcp --panel-orchestrator`), NOT spawned by
@@ -1646,6 +1662,24 @@ function panelSettingsList() {
       onChange: () => {
         // No live apply: the URL is baked into the orchestrator's MCP at spawn, so
         // it takes effect on the next Connect (Disconnect → Connect).
+      },
+    },
+    {
+      id: SETTING_FEEDBACK_URL,
+      name: "Share-transcript endpoint (advanced)",
+      category: cat("General", "Share-transcript endpoint (advanced)"),
+      sortOrder: 142,
+      tooltip:
+        "Where the header's Share-transcript button uploads rated conversations (an https collector URL, " +
+        "COMFYUI_MCP_FEEDBACK_URL). Sharing sends the FULL chat transcript plus version info (panel/model/" +
+        "backend) to help improve the local models — no account data; tokens, secrets, and bridge URLs are " +
+        "stripped first, and nothing is EVER sent without you explicitly clicking Share in the consent dialog. " +
+        "Leave BLANK to hide the feature entirely (default).",
+      type: "text",
+      defaultValue: "",
+      onChange: (v) => {
+        if (suppressSettingOnChange || !settingsArmed) return;
+        panelHooks.applyFeedbackUrl?.(v);
       },
     },
     {
@@ -6131,7 +6165,7 @@ const RECONNECT_MAX_MS = 15000;
 let AGENT_MUTED = (() => { try { return localStorage.getItem("cmcp.muteAgents") === "1"; } catch { return false; } })();
 let AGENT_BLIND = (() => { try { return localStorage.getItem("cmcp.blindAgents") === "1"; } catch { return false; } })();
 
-function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk, onSecret, onSecretSaved, onReload, onTodo, onShowMedia, onOpenCivitai, onUiRender, onUiUpdate, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onBackends, onAck, onTurn, onTurnAnchor, getResume, getBackend, onHandshakeTimeout, onBridgeClosed, onPairUrl, onPairError }) {
+function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk, onSecret, onSecretSaved, onReload, onTodo, onShowMedia, onOpenCivitai, onUiRender, onUiUpdate, onDownloads, onThinking, onAgentStatus, onSession, onModels, onMcpVersion, onCommands, onBackends, onAck, onTurn, onTurnAnchor, getResume, getBackend, onHandshakeTimeout, onBridgeClosed, onPairUrl, onPairError }) {
   let sock = null;
   let url = loadBridgeUrl();
   let closed = false;
@@ -6420,6 +6454,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
       // Live model catalog from the orchestrator (SDK-probed). This is also the
       // orchestrator HANDSHAKE — receiving it proves a real panel agent is behind
       // the socket, so it's the moment we truthfully flip to "connected".
+      // Forward-compat: any frame that carries the orchestrator's npm package
+      // version (mcp_version) feeds the Share-transcript payload's versions
+      // block. The orchestrator doesn't send it yet — null until it does.
+      if (msg && typeof msg.mcp_version === "string") {
+        onMcpVersion?.(msg.mcp_version);
+      }
       if (msg && msg.type === "models" && Array.isArray(msg.models)) {
         markConnected();
         onModels?.(
@@ -7814,9 +7854,21 @@ function buildPanel() {
   };
   applyMobileBetaVisibility(getSetting(SETTING_MOBILE_BETA) === true);
   panelHooks.applyMobileBeta = applyMobileBetaVisibility;
+  // "Share transcript" — rate this conversation good/bad and upload it (with
+  // explicit consent) to the maintainer's collector, feeding the local-model
+  // fine-tune dataset. Hidden unless a collector endpoint is configured
+  // (Settings › Share-transcript endpoint) — with no endpoint the feature is
+  // dormant and nothing can upload. Same inline-display trick as remoteBtn.
+  const shareBtn = iconBtn("pi-flag", "Share transcript — rate this chat to help improve the models");
+  shareBtn.addEventListener("click", () => openShareTranscriptModal());
+  const applyFeedbackUrlVisibility = () => {
+    shareBtn.style.display = feedbackEndpoint() ? "" : "none";
+  };
+  applyFeedbackUrlVisibility();
+  panelHooks.applyFeedbackUrl = applyFeedbackUrlVisibility;
   // Reload / restart live as slash commands (/reload, /reload-ui, /restart) — no
   // header buttons for them.
-  actions.append(newChatBtn, historyBtn, remoteBtn);
+  actions.append(newChatBtn, historyBtn, shareBtn, remoteBtn);
 
   header.style.position = "relative";
   const histPop = document.createElement("div");
@@ -8665,6 +8717,10 @@ function buildPanel() {
   // The model the orchestrator reports as ACTIVE for the connected backend (the
   // `current` field on the models frame). Drives the Auto-mode selection mark.
   let orchestratorCurrentModel = null;
+  // The connected orchestrator's comfyui-mcp package version, when it reports
+  // one (mcp_version on any frame — forward-compat; see createBridgeClient).
+  // Feeds the Share-transcript payload's versions block; null until known.
+  let orchestratorMcpVersion = null;
   if (!prefs.model) prefs.model = pickDefaultModel(modelCatalog);
 
   /** The effort ids offered for the currently-selected model. Driven primarily by
@@ -10990,6 +11046,9 @@ function buildPanel() {
       }
       // Apply the catalog AFTER the backend is known so effort mapping is correct.
       applyModelCatalog(list);
+    },
+    onMcpVersion(v) {
+      orchestratorMcpVersion = v;
     },
     onCommands(list) {
       // SDK-provided slash commands → surface in the composer completion menu.
@@ -13351,6 +13410,144 @@ function buildPanel() {
     overlay.appendChild(modal);
     root.appendChild(overlay);
     requestPairing();
+  }
+
+  // "Share transcript": rate this conversation good/bad (+ optional why) and —
+  // with explicit consent, on an explicit click — upload the FULL transcript
+  // plus version info to the maintainer's collector (Settings › Share-transcript
+  // endpoint; see workers/feedback-uploader/). The payload is built by the pure
+  // lib/feedback.js module, which drops the panel's token cards, redacts bridge
+  // URLs / recognizable secrets, and carries NO account identifiers — just an
+  // anonymous random submission id. Rated transcripts feed the local-model
+  // fine-tune dataset (good/bad labels).
+  function openShareTranscriptModal() {
+    const endpoint = feedbackEndpoint();
+    if (!endpoint) return; // button is hidden without an endpoint; belt & braces
+    const msgs = thread && Array.isArray(thread.msgs) ? thread.msgs : [];
+    if (!msgs.length) {
+      appendSystem("Nothing to share yet — have a conversation first, then rate it.");
+      return;
+    }
+    const state = createShareModalState();
+
+    const overlay = document.createElement("div");
+    overlay.className = "cmcp-modal-overlay";
+    const modal = document.createElement("div");
+    modal.className = "cmcp-modal";
+    const title = document.createElement("div");
+    title.className = "cmcp-modal-title";
+    title.textContent = "Share transcript";
+
+    const verdictWrap = document.createElement("div");
+    verdictWrap.className = "cmcp-modal-scopes";
+    const verdicts = [
+      { v: "good", label: "This was good!", hint: "the agent did what I wanted" },
+      { v: "bad", label: "This was bad", hint: "the agent got it wrong or got stuck" },
+    ];
+    for (const s of verdicts) {
+      const lbl = document.createElement("label");
+      lbl.className = "cmcp-modal-scope";
+      const r = document.createElement("input");
+      r.type = "radio";
+      r.name = "cmcp-share-verdict";
+      r.value = s.v;
+      // No pre-selection: submit stays disabled until the user explicitly
+      // picks good or bad, so an unlabeled upload is impossible.
+      r.addEventListener("change", () => {
+        state.setVerdict(s.v);
+        sendBtn.disabled = !state.canSubmit;
+      });
+      const span = document.createElement("span");
+      const strong = document.createElement("strong");
+      strong.textContent = s.label;
+      span.append(strong, document.createTextNode(` — ${s.hint}`));
+      lbl.append(r, span);
+      verdictWrap.appendChild(lbl);
+    }
+
+    const why = document.createElement("textarea");
+    why.className = "cmcp-modal-text";
+    why.rows = 3;
+    why.placeholder = "Why? (optional — what went well or wrong)";
+    why.addEventListener("input", () => state.setWhy(why.value));
+
+    // The consent line — the user must know exactly what leaves the machine
+    // BEFORE clicking Share. Keep it accurate if the payload ever changes.
+    const consent = document.createElement("div");
+    consent.style.cssText = "font-size:0.72rem;opacity:0.75;line-height:1.4;";
+    consent.textContent =
+      "Sharing uploads this full conversation (messages + tool activity) and version info " +
+      "(panel / model / backend) to the comfyui-mcp developer to improve the local models. " +
+      "No account data is sent — tokens, secrets, and bridge URLs are stripped first.";
+
+    const statusMsg = document.createElement("div");
+    statusMsg.style.cssText = "font-size:0.75rem;min-height:1em;";
+
+    const btnRow = document.createElement("div");
+    btnRow.className = "cmcp-modal-btns";
+    const cancel = document.createElement("button");
+    cancel.type = "button";
+    cancel.className = "cmcp-btn";
+    cancel.textContent = "Cancel";
+    const sendBtn = document.createElement("button");
+    sendBtn.type = "button";
+    sendBtn.className = "cmcp-btn cmcp-btn-primary";
+    sendBtn.textContent = "Share";
+    sendBtn.disabled = true; // until a verdict is picked
+    const close = () => overlay.remove();
+    cancel.addEventListener("click", close);
+    overlay.addEventListener("mousedown", (e) => {
+      if (e.target === overlay) close();
+    });
+
+    sendBtn.addEventListener("click", async () => {
+      if (!state.canSubmit || sendBtn.dataset.busy === "1") return;
+      sendBtn.dataset.busy = "1";
+      sendBtn.disabled = true;
+      cancel.disabled = true;
+      statusMsg.textContent = "Uploading…";
+      try {
+        state.setWhy(why.value); // authoritative — covers paste/autofill paths
+        const payload = buildFeedbackPayload({
+          verdict: state.verdict,
+          why: state.why,
+          msgs,
+          versions: {
+            panel: PANEL_VERSION,
+            // In Auto mode the orchestrator's reported model is what actually
+            // ran; otherwise the user's pick (fall back to the report).
+            model: prefs.modelAuto ? orchestratorCurrentModel : prefs.model || orchestratorCurrentModel,
+            mcp: orchestratorMcpVersion,
+            backend: connectedBackend || selectedBackend,
+            comfyui: window.app?.frontendVersion ?? window.app?.extensionManager?.appVersion ?? null,
+          },
+        });
+        const res = await fetch(endpoint, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(payload),
+          // Give slow links a real chance but never hang the modal forever.
+          ...(typeof AbortSignal !== "undefined" && AbortSignal.timeout
+            ? { signal: AbortSignal.timeout(20000) }
+            : {}),
+        });
+        if (!res.ok) throw new Error(`collector answered ${res.status}`);
+        close();
+        appendSystem("✅ Transcript shared — thank you for helping improve the models!");
+      } catch (err) {
+        // Leave the modal open so the user can retry (or cancel) — a failed
+        // upload must never silently discard their rating.
+        statusMsg.textContent = `⚠ Upload failed: ${err instanceof Error ? err.message : String(err)}`;
+        sendBtn.dataset.busy = "";
+        sendBtn.disabled = !state.canSubmit;
+        cancel.disabled = false;
+      }
+    });
+
+    btnRow.append(cancel, sendBtn);
+    modal.append(title, verdictWrap, why, consent, statusMsg, btnRow);
+    overlay.appendChild(modal);
+    root.appendChild(overlay);
   }
 
   // ---- submit ----

--- a/web/js/lib/feedback.js
+++ b/web/js/lib/feedback.js
@@ -1,0 +1,245 @@
+/**
+ * feedback.js — pure helpers for the "Share transcript" feedback feature.
+ *
+ * The panel offers a "Share transcript" action: the user rates the current
+ * conversation ("this was good!" / "this was bad", plus an optional "why"),
+ * and the FULL chat transcript + version info is POSTed to a maintainer-run
+ * collector (a Cloudflare Worker that writes to S3 — see
+ * workers/feedback-uploader/ in this repo). The labeled transcripts feed the
+ * local-model fine-tune dataset.
+ *
+ * PRIVACY CONTRACT (enforced here, unit-tested in
+ * browser_tests/unit/feedback.test.mjs):
+ *   - No account identifiers are ever collected. The payload has no user id,
+ *     no email, no hostname — only an anonymous random submission id.
+ *   - Panel-internal credential material never leaves the machine: token-save
+ *     cards are dropped from the transcript, bridge URLs (ws:// / wss://) are
+ *     redacted, sensitive URL query values and recognizable API-key shapes
+ *     are masked, and home-directory usernames in paths are stripped.
+ *   - What the user themselves typed (and the agent replied) is included
+ *     verbatim apart from the redactions above — that is the point of the
+ *     feature, and the consent modal says so before anything uploads.
+ *
+ * This module is intentionally free of any ComfyUI / DOM / network imports so
+ * it can be unit-tested under plain `node --test` and can never break the
+ * extension loader with side effects. The panel bundle imports the builders
+ * and does the actual fetch itself.
+ *
+ * @module feedback
+ */
+
+/** Payload schema tag — bump when the shape changes so the trainer can route. */
+export const FEEDBACK_SCHEMA = "comfyui-mcp.feedback/1";
+
+/** Hard cap on the serialized transcript (bytes of JSON, roughly chars).
+ *  Newest messages win; a marker entry notes any trimming. Matches the
+ *  collector Worker's 1 MiB body cap with generous headroom for the envelope. */
+export const MAX_TRANSCRIPT_CHARS = 700_000;
+
+/** Cap on the optional "why" free-text field. */
+export const MAX_WHY_CHARS = 2_000;
+
+// ---------------------------------------------------------------------------
+// Scrubbing
+// ---------------------------------------------------------------------------
+
+// Bridge/orchestrator endpoints ride ws:// or wss:// URLs (often carrying a
+// ?token=…). Nothing about them is useful for training — drop them whole.
+const RE_WS_URL = /\bwss?:\/\/[^\s"'<>)\]]+/gi;
+
+// Sensitive query/fragment parameter VALUES inside any remaining URL-ish text
+// (http(s) links to pods, consoles, pair landers, …). Keeps the URL readable,
+// masks the credential.
+const RE_SENSITIVE_PARAM =
+  /([?&#](?:token|key|secret|signature|sig|apikey|api_key|access_token|auth|authorization|credential)s?=)[^&\s"'<>)\]]+/gi;
+
+// "Bearer <credential>" in prose or quoted headers.
+const RE_BEARER = /\b(bearer\s+)[a-z0-9._~+/=-]{8,}/gi;
+
+// Bare "token=…" / "password: …" style assignments in prose, env snippets, or
+// pasted config — not just inside URLs.
+const RE_BARE_ASSIGN =
+  /\b((?:token|secret|password|passwd|api_key|apikey|access_token)\s*[=:]\s*)[^\s"'&]+/gi;
+
+// Recognizable API-key shapes (Anthropic, OpenAI, HuggingFace, GitHub, Slack,
+// AWS access-key ids, Groq, Replicate, Google). Deliberately prefix-anchored
+// so ordinary prose never matches.
+const RE_KNOWN_SECRET =
+  /\b(?:sk-ant-[a-z0-9_-]{8,}|sk-[a-z0-9_-]{16,}|hf_[a-z0-9]{16,}|gh[pousr]_[a-z0-9]{16,}|github_pat_[a-z0-9_]{16,}|xox[abposr]-[a-z0-9-]{8,}|(?:akia|asia)[0-9a-z]{16}|gsk_[a-z0-9]{16,}|r8_[a-z0-9]{16,}|aiza[0-9a-z_-]{30,})\b/gi;
+
+// Home-directory usernames in file-system paths (Windows and POSIX). The path
+// tail is often useful signal ("…\models\checkpoints\x.safetensors"); only the
+// username segment is identity, so only it is masked.
+const RE_WIN_HOME = /([A-Za-z]:[\\/](?:Users|home)[\\/])([^\\/\s"'<>:|?*]+)/g;
+const RE_POSIX_HOME = /(\/(?:home|Users)\/)([^/\s"'<>]+)/g;
+
+/**
+ * Redact credential material and identity fragments from one string.
+ * Idempotent; never throws; non-strings pass through unchanged.
+ * @param {unknown} text
+ * @returns {unknown} the scrubbed string (or the input when not a string)
+ */
+export function scrubText(text) {
+  if (typeof text !== "string" || !text) return text;
+  return text
+    .replace(RE_WS_URL, "[bridge-url redacted]")
+    .replace(RE_SENSITIVE_PARAM, "$1[redacted]")
+    .replace(RE_BARE_ASSIGN, "$1[redacted]")
+    .replace(RE_BEARER, "$1[redacted]")
+    .replace(RE_KNOWN_SECRET, "[secret redacted]")
+    .replace(RE_WIN_HOME, "$1[user]")
+    .replace(RE_POSIX_HOME, "$1[user]");
+}
+
+// Record keys that are panel-internal plumbing, useless (or risky) to upload.
+const DROP_KEYS = new Set(["mid", "rewindAnchor", "sessionId"]);
+
+/** Deep-copy `value`, scrubbing every string and dropping plumbing keys. */
+function deepScrub(value, depth = 0) {
+  if (depth > 12) return undefined; // pathological nesting — cut it off
+  if (typeof value === "string") return scrubText(value);
+  if (Array.isArray(value)) return value.map((v) => deepScrub(v, depth + 1));
+  if (value && typeof value === "object") {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (DROP_KEYS.has(k)) continue;
+      const sv = deepScrub(v, depth + 1);
+      if (sv !== undefined) out[k] = sv;
+    }
+    return out;
+  }
+  if (typeof value === "function") return undefined;
+  return value;
+}
+
+/** True for thread records that must never upload at all: the in-chat token
+ *  prompt cards (they render with the lock icon and hold masked credential
+ *  previews — masked or not, they are credential UI, not conversation). */
+function isSecretRecord(entry) {
+  return !!entry && entry.role === "card" && entry.icon === "pi-lock";
+}
+
+/**
+ * Turn the panel's persisted thread records into an upload-safe transcript:
+ * token-prompt cards dropped, every string scrubbed, plumbing keys removed,
+ * and the whole list size-capped from the OLD end (newest messages win).
+ *
+ * @param {unknown} msgs thread.msgs — [{role, text, …}] (see record() in the panel)
+ * @param {{maxChars?: number}} [opts]
+ * @returns {object[]} the scrubbed transcript, oldest first
+ */
+export function scrubTranscript(msgs, opts = {}) {
+  const maxChars = Number.isFinite(opts.maxChars) ? opts.maxChars : MAX_TRANSCRIPT_CHARS;
+  if (!Array.isArray(msgs)) return [];
+  const clean = [];
+  for (const m of msgs) {
+    if (!m || typeof m !== "object" || Array.isArray(m)) continue;
+    if (isSecretRecord(m)) continue;
+    const scrubbed = deepScrub(m);
+    if (scrubbed && typeof scrubbed.role === "string") clean.push(scrubbed);
+  }
+  // Budget from the end: keep the newest messages whole, drop the oldest.
+  let used = 0;
+  let start = clean.length;
+  while (start > 0) {
+    const cost = JSON.stringify(clean[start - 1]).length + 1;
+    if (used + cost > maxChars) break;
+    used += cost;
+    start--;
+  }
+  const kept = clean.slice(start);
+  if (start > 0) {
+    kept.unshift({ role: "system", text: `[${start} earlier message(s) trimmed for size]` });
+  }
+  return kept;
+}
+
+// ---------------------------------------------------------------------------
+// Payload
+// ---------------------------------------------------------------------------
+
+function randomId() {
+  try {
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+      return crypto.randomUUID();
+    }
+  } catch {
+    // fall through to the arithmetic fallback below
+  }
+  // Non-secure-context fallback — uniqueness only, no identity.
+  return `fb-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function versionOrNull(v) {
+  return typeof v === "string" && v.trim() ? v.trim() : null;
+}
+
+/**
+ * Build the complete upload payload. Pure: no network, no DOM. Throws
+ * TypeError on an invalid verdict so a UI bug can't upload unlabeled data.
+ *
+ * @param {object} args
+ * @param {"good"|"bad"} args.verdict user's rating
+ * @param {string} [args.why] optional free-text reason
+ * @param {unknown} args.msgs thread.msgs (raw panel records; scrubbed here)
+ * @param {{model?: string, panel?: string, mcp?: string, backend?: string, comfyui?: string}} [args.versions]
+ * @param {number} [args.now] epoch ms override (tests)
+ * @returns {object} the JSON-serializable payload
+ */
+export function buildFeedbackPayload({ verdict, why, msgs, versions = {}, now } = {}) {
+  if (verdict !== "good" && verdict !== "bad") {
+    throw new TypeError(`verdict must be "good" or "bad", got ${JSON.stringify(verdict)}`);
+  }
+  const reason = typeof why === "string" ? scrubText(why.trim()).slice(0, MAX_WHY_CHARS) : "";
+  return {
+    schema: FEEDBACK_SCHEMA,
+    id: randomId(),
+    timestamp: new Date(Number.isFinite(now) ? now : Date.now()).toISOString(),
+    verdict,
+    ...(reason ? { why: reason } : {}),
+    versions: {
+      model: versionOrNull(versions.model),
+      panel: versionOrNull(versions.panel),
+      mcp: versionOrNull(versions.mcp),
+      backend: versionOrNull(versions.backend),
+      comfyui: versionOrNull(versions.comfyui),
+    },
+    transcript: scrubTranscript(msgs),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Modal state (pure, so the good/bad gating is unit-testable)
+// ---------------------------------------------------------------------------
+
+/**
+ * Tiny state holder backing the Share-transcript modal: no verdict is
+ * pre-selected, and submit stays disabled until the user explicitly picks
+ * good or bad — unlabeled uploads are impossible by construction.
+ * @returns {{ setVerdict(v: string): boolean, setWhy(t: string): void,
+ *             verdict: "good"|"bad"|null, why: string, canSubmit: boolean }}
+ */
+export function createShareModalState() {
+  let verdict = null;
+  let why = "";
+  return {
+    /** @returns {boolean} whether the value was accepted */
+    setVerdict(v) {
+      if (v !== "good" && v !== "bad") return false;
+      verdict = v;
+      return true;
+    },
+    setWhy(t) {
+      why = typeof t === "string" ? t : "";
+    },
+    get verdict() {
+      return verdict;
+    },
+    get why() {
+      return why;
+    },
+    get canSubmit() {
+      return verdict === "good" || verdict === "bad";
+    },
+  };
+}

--- a/workers/feedback-uploader/.gitignore
+++ b/workers/feedback-uploader/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.wrangler/
+.dev.vars
+worker-configuration.d.ts

--- a/workers/feedback-uploader/README.md
+++ b/workers/feedback-uploader/README.md
@@ -1,0 +1,128 @@
+# comfyui-mcp feedback uploader
+
+A tiny Cloudflare Worker that receives the panel's **Share transcript** feedback
+(good/bad-rated chat transcripts + version info) and writes each submission to
+**S3** under a random key. The stored objects are the labeled dataset for the
+local-model retrain.
+
+```
+panel  ──POST JSON──▶  Worker (validate, size-cap, CORS)  ──SigV4 PUT──▶  s3://$S3_BUCKET/feedback/YYYY/MM/DD/<verdict>-<uuid>.json
+```
+
+- **Zero runtime dependencies** — SigV4 is hand-rolled on Web Crypto
+  (`src/sigv4.js`, pinned to AWS's published test vector in the tests), so
+  `wrangler deploy` needs no `npm install` beyond wrangler itself.
+- **Write-only** — no GET/list surface; the Worker can only add objects.
+- **Nothing sensitive in the repo** — bucket/region are wrangler vars, AWS
+  credentials are Worker secrets. Until all four are set the Worker answers
+  `503 collector not configured` and nothing is stored.
+
+## Payload contract (`comfyui-mcp.feedback/1`)
+
+Produced by `web/js/lib/feedback.js` (see its tests for the privacy scrubbing):
+
+```json
+{
+  "schema": "comfyui-mcp.feedback/1",
+  "id": "<random uuid — anonymous submission id, no account linkage>",
+  "timestamp": "2026-07-15T12:00:00.000Z",
+  "verdict": "good | bad",
+  "why": "optional free text (≤ 2000 chars, scrubbed)",
+  "versions": {
+    "model": "gemma4:e4b | claude-… | null",
+    "panel": "0.8.2 | null",
+    "mcp": "comfyui-mcp package version | null (orchestrator doesn't report it yet)",
+    "backend": "ollama | claude | codex | … | null",
+    "comfyui": "frontend version | null"
+  },
+  "transcript": [
+    { "role": "user",  "text": "…", "attachments": [ { "id": "1", "content": "…" } ] },
+    { "role": "agent", "text": "…" },
+    { "role": "card",  "icon": "pi-cog", "text": "graph_build", "detail": "…" }
+  ]
+}
+```
+
+`transcript` is the panel's full persisted thread (user + agent messages and
+tool-activity cards), already scrubbed panel-side: token cards dropped, bridge
+URLs and recognizable secrets redacted, home-dir usernames masked, internal
+message ids removed. The Worker validates the shape, drops unknown top-level
+fields, adds a server-side `received_at`, and stores the result verbatim.
+
+Request-body cap: **1 MiB** (`413` beyond it). Invalid payloads: `400` with a
+`details` array. Storage failures: `502` (status logged, payload never logged).
+
+## What the maintainer must provision (not done by this repo)
+
+1. **S3 bucket** (private, no public access) + an IAM user/role whose policy
+   allows only `s3:PutObject` on `arn:aws:s3:::<bucket>/feedback/*`.
+2. **Cloudflare account** with Workers enabled.
+3. Deploy this Worker and set the secrets (below).
+4. Put the deployed URL into the panel setting
+   **Settings → comfyui-mcp → “Share-transcript endpoint (advanced)”**
+   (`comfyui-mcp.feedbackUrl`, aka `COMFYUI_MCP_FEEDBACK_URL`). Until then the
+   panel feature is completely dormant — no button, no uploads.
+
+## Deploy
+
+```bash
+cd workers/feedback-uploader
+npm install                       # installs wrangler only
+# 1. fill in S3_BUCKET (and S3_REGION if not us-east-1) in wrangler.jsonc
+# 2. credentials — interactive prompts, never on the command line:
+npx wrangler secret put AWS_ACCESS_KEY_ID
+npx wrangler secret put AWS_SECRET_ACCESS_KEY
+# 3. ship it
+npx wrangler deploy
+```
+
+Optionally restrict browser origins by setting `ALLOWED_ORIGINS` in
+`wrangler.jsonc` (comma-separated), e.g.
+`"http://127.0.0.1:8188,http://localhost:8188"`. The default `*` is acceptable
+for a write-only, credential-free endpoint.
+
+### R2 instead of AWS S3
+
+Implemented as S3 per the spec, but R2 speaks the same protocol — point
+`S3_ENDPOINT` at `https://<ACCOUNT_ID>.r2.cloudflarestorage.com` and use an R2
+API token's key pair as the two secrets (region stays `auto`-compatible with
+`us-east-1`). *Even simpler CF-native alternative:* delete the SigV4 path
+entirely and add an R2 **binding** to `wrangler.jsonc`
+(`"r2_buckets": [{ "binding": "FEEDBACK", "bucket_name": "comfyui-mcp-feedback" }]`),
+then replace the signed `fetch` in `src/index.js` with one line:
+`await env.FEEDBACK.put(key, body, { httpMetadata: { contentType: "application/json" } })` —
+no credentials to manage at all.
+
+## Test
+
+```bash
+npm test          # node --test — SigV4 (AWS test vector), validation, full handler
+```
+
+## Local smoke (wrangler dev)
+
+```bash
+# terminal 1 — vars come from wrangler.jsonc; fake creds via .dev.vars:
+printf 'AWS_ACCESS_KEY_ID=AKIDEXAMPLE\nAWS_SECRET_ACCESS_KEY=fake\n' > .dev.vars
+npx wrangler dev
+
+# terminal 2 — a valid payload (expect 502 with fake creds and a real bucket
+# name, proving validation+signing ran; expect 503 if S3_BUCKET is empty):
+curl -s -X POST http://localhost:8787/ \
+  -H 'content-type: application/json' \
+  -d '{"schema":"comfyui-mcp.feedback/1","verdict":"good","transcript":[{"role":"user","text":"hi"}],"versions":{"panel":"0.8.2"}}'
+
+# and a rejected one (expect 400):
+curl -s -X POST http://localhost:8787/ -H 'content-type: application/json' -d '{"verdict":"meh"}'
+```
+
+## Privacy notes
+
+- The Worker never logs request bodies (they are user conversations) and never
+  echoes storage-provider error bodies to clients.
+- No cookies, no auth, no per-user identifiers — submissions are linkable only
+  by their own random `id`, which the panel generates fresh per share.
+- Abuse consideration: the endpoint is unauthenticated by design (the panel has
+  no shared secret to hold). The 1 MiB cap + strict shape validation bound the
+  damage; if spam appears, add Cloudflare WAF rate-limiting on the route or a
+  Turnstile check.

--- a/workers/feedback-uploader/package.json
+++ b/workers/feedback-uploader/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "comfyui-mcp-feedback-uploader",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Cloudflare Worker that receives the panel's Share-transcript feedback and writes it to S3 (local-model retrain dataset).",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "test": "node --test test/*.test.mjs"
+  },
+  "devDependencies": {
+    "wrangler": "^4.0.0"
+  }
+}

--- a/workers/feedback-uploader/src/index.js
+++ b/workers/feedback-uploader/src/index.js
@@ -1,0 +1,137 @@
+/**
+ * comfyui-mcp feedback uploader — Cloudflare Worker.
+ *
+ * Receives the ComfyUI-MCP panel's "Share transcript" POST (a good/bad-rated
+ * chat transcript + version info; see web/js/lib/feedback.js in this repo for
+ * the exact payload and its privacy scrubbing) and writes it to S3 under a
+ * random key. The stored objects are the local-model retrain dataset.
+ *
+ *   panel ──POST {verdict, why?, transcript, versions, …}──▶ this Worker
+ *                                                              │ SigV4 PUT
+ *                                                              ▼
+ *                                    s3://$S3_BUCKET/feedback/YYYY/MM/DD/<verdict>-<uuid>.json
+ *
+ * Configuration (see README.md — nothing is hardcoded here):
+ *   vars    S3_BUCKET, S3_REGION, [S3_ENDPOINT], [ALLOWED_ORIGINS]
+ *   secrets AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+ *
+ * The Worker never logs payload contents (transcripts are user conversations)
+ * and stores exactly the validated fields plus a server-side received_at.
+ */
+
+import { signRequest } from "./sigv4.js";
+import { validateFeedback, MAX_BODY_BYTES } from "./validate.js";
+
+function corsHeaders(request, env) {
+  const conf = (env.ALLOWED_ORIGINS ?? "*").trim();
+  const headers = {
+    "access-control-allow-methods": "POST, OPTIONS",
+    "access-control-allow-headers": "content-type",
+    "access-control-max-age": "86400",
+  };
+  if (conf === "*" || conf === "") {
+    headers["access-control-allow-origin"] = "*";
+    return headers;
+  }
+  const origin = request.headers.get("origin") ?? "";
+  const allowed = conf.split(",").map((s) => s.trim()).filter(Boolean);
+  if (origin && allowed.includes(origin)) {
+    headers["access-control-allow-origin"] = origin;
+    headers["vary"] = "origin";
+  }
+  return headers;
+}
+
+function json(status, body, cors) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...cors },
+  });
+}
+
+function objectKey(verdict) {
+  const now = new Date();
+  const yyyy = now.getUTCFullYear();
+  const mm = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(now.getUTCDate()).padStart(2, "0");
+  return `feedback/${yyyy}/${mm}/${dd}/${verdict}-${crypto.randomUUID()}.json`;
+}
+
+function s3Url(env, key) {
+  if (env.S3_ENDPOINT) {
+    // Path-style — works for R2's S3-compatible endpoint, MinIO, etc.
+    return `${env.S3_ENDPOINT.replace(/\/+$/, "")}/${env.S3_BUCKET}/${key}`;
+  }
+  return `https://${env.S3_BUCKET}.s3.${env.S3_REGION}.amazonaws.com/${key}`;
+}
+
+export default {
+  async fetch(request, env) {
+    const cors = corsHeaders(request, env);
+
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: cors });
+    }
+    if (request.method !== "POST") {
+      return json(405, { ok: false, error: "POST only" }, { ...cors, allow: "POST, OPTIONS" });
+    }
+
+    if (!env.S3_BUCKET || !env.S3_REGION || !env.AWS_ACCESS_KEY_ID || !env.AWS_SECRET_ACCESS_KEY) {
+      // Deployed but not provisioned yet — fail loudly, never half-store.
+      return json(503, { ok: false, error: "collector not configured" }, cors);
+    }
+
+    const declared = Number(request.headers.get("content-length"));
+    if (Number.isFinite(declared) && declared > MAX_BODY_BYTES) {
+      return json(413, { ok: false, error: `body exceeds ${MAX_BODY_BYTES} bytes` }, cors);
+    }
+    const bodyText = await request.text();
+    // Content-Length can lie (or be absent) — enforce on the actual bytes.
+    if (new TextEncoder().encode(bodyText).length > MAX_BODY_BYTES) {
+      return json(413, { ok: false, error: `body exceeds ${MAX_BODY_BYTES} bytes` }, cors);
+    }
+
+    let parsed;
+    try {
+      parsed = JSON.parse(bodyText);
+    } catch {
+      return json(400, { ok: false, error: "invalid JSON" }, cors);
+    }
+
+    const result = validateFeedback(parsed);
+    if (!result.ok) {
+      return json(400, { ok: false, error: "invalid payload", details: result.errors }, cors);
+    }
+
+    const stored = { ...result.feedback, received_at: new Date().toISOString() };
+    const key = objectKey(stored.verdict);
+    const url = s3Url(env, key);
+    const body = JSON.stringify(stored);
+
+    let putRes;
+    try {
+      const headers = await signRequest({
+        method: "PUT",
+        url,
+        headers: { "content-type": "application/json" },
+        body,
+        accessKeyId: env.AWS_ACCESS_KEY_ID,
+        secretAccessKey: env.AWS_SECRET_ACCESS_KEY,
+        region: env.S3_REGION,
+        service: "s3",
+      });
+      putRes = await fetch(url, { method: "PUT", headers, body });
+    } catch (err) {
+      console.log(`feedback-uploader: PUT threw: ${err instanceof Error ? err.message : String(err)}`);
+      return json(502, { ok: false, error: "storage unreachable" }, cors);
+    }
+    if (!putRes.ok) {
+      // Log the status only — never the payload (it is a user conversation)
+      // and never the S3 error body (it can echo request details).
+      console.log(`feedback-uploader: S3 PUT failed with ${putRes.status}`);
+      return json(502, { ok: false, error: "storage rejected the object" }, cors);
+    }
+
+    return json(200, { ok: true, id: stored.id }, cors);
+  },
+};

--- a/workers/feedback-uploader/src/sigv4.js
+++ b/workers/feedback-uploader/src/sigv4.js
@@ -1,0 +1,145 @@
+/**
+ * sigv4.js — minimal, dependency-free AWS Signature Version 4 signer.
+ *
+ * Uses only Web Crypto (`crypto.subtle`), which exists in Cloudflare Workers
+ * and in Node 18+ — so the same code runs in the Worker and under plain
+ * `node --test` (see test/sigv4.test.mjs, which pins the signer to AWS's
+ * published SigV4 test vector).
+ *
+ * Scope: exactly what the feedback uploader needs (header-signed requests,
+ * single-chunk payload). Not a general SDK replacement.
+ */
+
+const enc = new TextEncoder();
+
+function hex(bytes) {
+  return [...new Uint8Array(bytes)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/** SHA-256 of a string or byte array, as lowercase hex. */
+export async function sha256Hex(data) {
+  const bytes = typeof data === "string" ? enc.encode(data) : data;
+  return hex(await crypto.subtle.digest("SHA-256", bytes));
+}
+
+async function hmac(key, data) {
+  const rawKey = typeof key === "string" ? enc.encode(key) : key;
+  const cryptoKey = await crypto.subtle.importKey(
+    "raw",
+    rawKey,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  return new Uint8Array(await crypto.subtle.sign("HMAC", cryptoKey, enc.encode(data)));
+}
+
+/** RFC 3986 encoding (what SigV4 canonicalization requires — stricter than
+ *  encodeURIComponent, which leaves !'()* unescaped). */
+function encodeRfc3986(str) {
+  return encodeURIComponent(str).replace(
+    /[!'()*]/g,
+    (c) => "%" + c.charCodeAt(0).toString(16).toUpperCase(),
+  );
+}
+
+function safeDecode(segment) {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment; // malformed escape — canonicalize what we were given
+  }
+}
+
+/** 20150830T123600Z */
+function toAmzDate(date) {
+  return date.toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+}
+
+/**
+ * Sign an HTTP request with SigV4. Returns the complete header set to send
+ * (input headers + host + x-amz-date [+ x-amz-content-sha256 for s3] +
+ * authorization).
+ *
+ * @param {object} args
+ * @param {string} args.method e.g. "PUT"
+ * @param {string} args.url absolute URL (query string included)
+ * @param {Record<string, string>} [args.headers] extra headers to sign (e.g. content-type)
+ * @param {string} [args.body] request body ("" when absent)
+ * @param {string} args.accessKeyId
+ * @param {string} args.secretAccessKey
+ * @param {string} args.region e.g. "us-east-1"
+ * @param {string} [args.service] default "s3"
+ * @param {Date} [args.date] override for tests
+ * @returns {Promise<Record<string, string>>} headers including `authorization`
+ */
+export async function signRequest({
+  method,
+  url,
+  headers = {},
+  body = "",
+  accessKeyId,
+  secretAccessKey,
+  region,
+  service = "s3",
+  date = new Date(),
+}) {
+  const u = new URL(url);
+  const amzDate = toAmzDate(date);
+  const dateStamp = amzDate.slice(0, 8);
+  const payloadHash = await sha256Hex(body);
+
+  const hdrs = { host: u.host, "x-amz-date": amzDate };
+  for (const [k, v] of Object.entries(headers)) hdrs[k.toLowerCase()] = String(v);
+  // S3 requires the payload hash as a header; other services (the test vector
+  // uses iam) sign without it.
+  if (service === "s3") hdrs["x-amz-content-sha256"] = payloadHash;
+
+  const signedHeaderNames = Object.keys(hdrs).sort();
+  const canonicalHeaders = signedHeaderNames
+    .map((k) => `${k}:${hdrs[k].trim().replace(/\s+/g, " ")}\n`)
+    .join("");
+  const signedHeaders = signedHeaderNames.join(";");
+
+  const canonicalQuery = [...u.searchParams.entries()]
+    .map(([k, v]) => [encodeRfc3986(k), encodeRfc3986(v)])
+    .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : a[1] < b[1] ? -1 : 1))
+    .map(([k, v]) => `${k}=${v}`)
+    .join("&");
+
+  const canonicalPath =
+    u.pathname
+      .split("/")
+      .map((seg) => encodeRfc3986(safeDecode(seg)))
+      .join("/") || "/";
+
+  const canonicalRequest = [
+    method.toUpperCase(),
+    canonicalPath,
+    canonicalQuery,
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join("\n");
+
+  const scope = `${dateStamp}/${region}/${service}/aws4_request`;
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    amzDate,
+    scope,
+    await sha256Hex(canonicalRequest),
+  ].join("\n");
+
+  let key = await hmac(`AWS4${secretAccessKey}`, dateStamp);
+  key = await hmac(key, region);
+  key = await hmac(key, service);
+  key = await hmac(key, "aws4_request");
+  const signature = hex(await hmac(key, stringToSign));
+
+  return {
+    ...hdrs,
+    authorization:
+      `AWS4-HMAC-SHA256 Credential=${accessKeyId}/${scope}, ` +
+      `SignedHeaders=${signedHeaders}, Signature=${signature}`,
+  };
+}

--- a/workers/feedback-uploader/src/validate.js
+++ b/workers/feedback-uploader/src/validate.js
@@ -1,0 +1,75 @@
+/**
+ * validate.js — payload validation for the feedback uploader.
+ *
+ * Pure (no Worker APIs) so it unit-tests under plain `node --test`. The
+ * Worker accepts ONLY the documented `comfyui-mcp.feedback/1` shape and
+ * stores a sanitized copy — unknown top-level fields are dropped, sizes are
+ * capped, and nothing the panel didn't document can ride along.
+ */
+
+/** Absolute request-body cap (bytes). The panel caps its transcript at
+ *  ~700k chars, so 1 MiB leaves envelope headroom without inviting abuse. */
+export const MAX_BODY_BYTES = 1_048_576;
+
+const MAX_WHY_CHARS = 4_000;
+const MAX_ID_CHARS = 100;
+const MAX_TIMESTAMP_CHARS = 40;
+const MAX_TRANSCRIPT_ENTRIES = 2_000;
+
+function strOrNull(v, cap = 200) {
+  return typeof v === "string" && v.trim() ? v.trim().slice(0, cap) : null;
+}
+
+/**
+ * Validate + sanitize a parsed feedback payload.
+ * @param {unknown} data parsed JSON body
+ * @returns {{ok: true, feedback: object} | {ok: false, errors: string[]}}
+ */
+export function validateFeedback(data) {
+  const errors = [];
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    return { ok: false, errors: ["body must be a JSON object"] };
+  }
+  const { verdict, transcript, why, versions, schema, id, timestamp } = data;
+
+  if (verdict !== "good" && verdict !== "bad") {
+    errors.push('verdict must be "good" or "bad"');
+  }
+  if (!Array.isArray(transcript) || transcript.length === 0) {
+    errors.push("transcript must be a non-empty array");
+  } else if (transcript.length > MAX_TRANSCRIPT_ENTRIES) {
+    errors.push(`transcript exceeds ${MAX_TRANSCRIPT_ENTRIES} entries`);
+  } else if (!transcript.every((m) => m && typeof m === "object" && typeof m.role === "string")) {
+    errors.push("every transcript entry must be an object with a string role");
+  }
+  if (why !== undefined && typeof why !== "string") {
+    errors.push("why must be a string when present");
+  }
+  if (versions !== undefined && (typeof versions !== "object" || versions === null || Array.isArray(versions))) {
+    errors.push("versions must be an object when present");
+  }
+  if (schema !== undefined && (typeof schema !== "string" || !schema.startsWith("comfyui-mcp.feedback/"))) {
+    errors.push("schema must be a comfyui-mcp.feedback/* tag when present");
+  }
+  if (errors.length) return { ok: false, errors };
+
+  const v = versions ?? {};
+  return {
+    ok: true,
+    feedback: {
+      schema: typeof schema === "string" ? schema : "comfyui-mcp.feedback/1",
+      id: strOrNull(id, MAX_ID_CHARS),
+      timestamp: strOrNull(timestamp, MAX_TIMESTAMP_CHARS),
+      verdict,
+      ...(typeof why === "string" && why.trim() ? { why: why.trim().slice(0, MAX_WHY_CHARS) } : {}),
+      versions: {
+        model: strOrNull(v.model),
+        panel: strOrNull(v.panel),
+        mcp: strOrNull(v.mcp),
+        backend: strOrNull(v.backend),
+        comfyui: strOrNull(v.comfyui),
+      },
+      transcript,
+    },
+  };
+}

--- a/workers/feedback-uploader/test/handler.test.mjs
+++ b/workers/feedback-uploader/test/handler.test.mjs
@@ -1,0 +1,124 @@
+// End-to-end handler tests under plain node --test: Node 18+ ships the same
+// Request/Response/fetch/crypto Web APIs the Workers runtime exposes, so the
+// module Worker's fetch() runs as-is — with globalThis.fetch stubbed to stand
+// in for S3.
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import worker from "../src/index.js";
+
+const ENV = {
+  S3_BUCKET: "test-bucket",
+  S3_REGION: "us-east-1",
+  AWS_ACCESS_KEY_ID: "AKIDEXAMPLE",
+  AWS_SECRET_ACCESS_KEY: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+};
+
+const payload = () => ({
+  schema: "comfyui-mcp.feedback/1",
+  verdict: "good",
+  transcript: [{ role: "user", text: "hello" }],
+  versions: { panel: "0.8.2" },
+});
+
+const post = (body, headers = {}) =>
+  new Request("https://collector.example.com/", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+
+const realFetch = globalThis.fetch;
+let putCalls;
+beforeEach(() => {
+  putCalls = [];
+  globalThis.fetch = async (url, init) => {
+    putCalls.push({ url: String(url), init });
+    return new Response("", { status: 200 });
+  };
+});
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+test("happy path: validates, signs, PUTs to S3, answers 200", async () => {
+  const res = await worker.fetch(post(payload()), ENV);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.ok, true);
+  assert.equal(putCalls.length, 1);
+  const { url, init } = putCalls[0];
+  assert.match(url, /^https:\/\/test-bucket\.s3\.us-east-1\.amazonaws\.com\/feedback\/\d{4}\/\d{2}\/\d{2}\/good-[0-9a-f-]{36}\.json$/);
+  assert.equal(init.method, "PUT");
+  assert.match(init.headers.authorization, /^AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE\//);
+  const stored = JSON.parse(init.body);
+  assert.equal(stored.verdict, "good");
+  assert.ok(stored.received_at); // server-side timestamp added
+  assert.ok(!("email" in stored));
+});
+
+test("S3_ENDPOINT switches to path-style addressing (R2/MinIO)", async () => {
+  const res = await worker.fetch(post(payload()), {
+    ...ENV,
+    S3_ENDPOINT: "https://accountid.r2.cloudflarestorage.com/",
+  });
+  assert.equal(res.status, 200);
+  assert.match(putCalls[0].url, /^https:\/\/accountid\.r2\.cloudflarestorage\.com\/test-bucket\/feedback\//);
+});
+
+test("rejects non-POST and answers OPTIONS preflight with CORS", async () => {
+  const get = await worker.fetch(new Request("https://c.example.com/", { method: "GET" }), ENV);
+  assert.equal(get.status, 405);
+  const opt = await worker.fetch(new Request("https://c.example.com/", { method: "OPTIONS" }), ENV);
+  assert.equal(opt.status, 204);
+  assert.equal(opt.headers.get("access-control-allow-origin"), "*");
+  assert.match(opt.headers.get("access-control-allow-methods"), /POST/);
+  assert.equal(putCalls.length, 0);
+});
+
+test("ALLOWED_ORIGINS restricts CORS to the listed origins", async () => {
+  const env = { ...ENV, ALLOWED_ORIGINS: "http://127.0.0.1:8188, http://localhost:8188" };
+  const ok = await worker.fetch(
+    new Request("https://c.example.com/", { method: "OPTIONS", headers: { origin: "http://localhost:8188" } }),
+    env,
+  );
+  assert.equal(ok.headers.get("access-control-allow-origin"), "http://localhost:8188");
+  const nope = await worker.fetch(
+    new Request("https://c.example.com/", { method: "OPTIONS", headers: { origin: "https://evil.example" } }),
+    env,
+  );
+  assert.equal(nope.headers.get("access-control-allow-origin"), null);
+});
+
+test("answers 503 until bucket/region/credentials are provisioned", async () => {
+  const res = await worker.fetch(post(payload()), { S3_REGION: "us-east-1" });
+  assert.equal(res.status, 503);
+  assert.equal(putCalls.length, 0); // nothing ever leaves before config
+});
+
+test("rejects malformed JSON and invalid payloads without touching S3", async () => {
+  const bad = await worker.fetch(post("{nope"), ENV);
+  assert.equal(bad.status, 400);
+  const invalid = await worker.fetch(post({ verdict: "meh", transcript: [] }), ENV);
+  assert.equal(invalid.status, 400);
+  const details = await invalid.json();
+  assert.ok(Array.isArray(details.details));
+  assert.equal(putCalls.length, 0);
+});
+
+test("caps the body size (declared and actual)", async () => {
+  const declared = await worker.fetch(post(payload(), { "content-length": String(10_000_000) }), ENV);
+  assert.equal(declared.status, 413);
+  const big = { ...payload(), why: "x".repeat(1_100_000) };
+  const actual = await worker.fetch(post(big), ENV);
+  assert.equal(actual.status, 413);
+  assert.equal(putCalls.length, 0);
+});
+
+test("maps S3 failures to 502 without leaking details", async () => {
+  globalThis.fetch = async () => new Response("<Error>AccessDenied…</Error>", { status: 403 });
+  const res = await worker.fetch(post(payload()), ENV);
+  assert.equal(res.status, 502);
+  const body = await res.json();
+  assert.equal(body.ok, false);
+  assert.ok(!JSON.stringify(body).includes("AccessDenied"));
+});

--- a/workers/feedback-uploader/test/sigv4.test.mjs
+++ b/workers/feedback-uploader/test/sigv4.test.mjs
@@ -1,0 +1,60 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { signRequest, sha256Hex } from "../src/sigv4.js";
+
+// AWS's published SigV4 test vector ("Example: signature calculations",
+// AWS General Reference — Signature Version 4). If the signer drifts from
+// the spec, this pins it.
+const VECTOR = {
+  method: "GET",
+  url: "https://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08",
+  headers: { "content-type": "application/x-www-form-urlencoded; charset=utf-8" },
+  body: "",
+  accessKeyId: "AKIDEXAMPLE",
+  secretAccessKey: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+  region: "us-east-1",
+  service: "iam",
+  date: new Date("2015-08-30T12:36:00Z"),
+};
+
+test("matches AWS's published SigV4 test vector", async () => {
+  const headers = await signRequest(VECTOR);
+  assert.equal(headers["x-amz-date"], "20150830T123600Z");
+  assert.equal(headers.host, "iam.amazonaws.com");
+  assert.equal(
+    headers.authorization,
+    "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, " +
+      "SignedHeaders=content-type;host;x-amz-date, " +
+      "Signature=5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7",
+  );
+});
+
+test("empty-payload hash is the well-known SHA-256 of the empty string", async () => {
+  assert.equal(
+    await sha256Hex(""),
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  );
+});
+
+test("s3 service adds and signs x-amz-content-sha256", async () => {
+  const headers = await signRequest({
+    method: "PUT",
+    url: "https://my-bucket.s3.us-east-1.amazonaws.com/feedback/2026/07/15/good-abc.json",
+    headers: { "content-type": "application/json" },
+    body: '{"ok":true}',
+    accessKeyId: "AKIDEXAMPLE",
+    secretAccessKey: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+    region: "us-east-1",
+    service: "s3",
+    date: new Date("2026-07-15T00:00:00Z"),
+  });
+  assert.equal(headers["x-amz-content-sha256"], await sha256Hex('{"ok":true}'));
+  assert.match(headers.authorization, /SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date,/);
+  assert.match(headers.authorization, /Credential=AKIDEXAMPLE\/20260715\/us-east-1\/s3\/aws4_request,/);
+});
+
+test("signing is deterministic for identical inputs", async () => {
+  const a = await signRequest(VECTOR);
+  const b = await signRequest(VECTOR);
+  assert.equal(a.authorization, b.authorization);
+});

--- a/workers/feedback-uploader/test/validate.test.mjs
+++ b/workers/feedback-uploader/test/validate.test.mjs
@@ -1,0 +1,73 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { validateFeedback, MAX_BODY_BYTES } from "../src/validate.js";
+
+const good = () => ({
+  schema: "comfyui-mcp.feedback/1",
+  id: "0b6e8a4e-1111-2222-3333-444455556666",
+  timestamp: "2026-07-15T00:00:00.000Z",
+  verdict: "good",
+  why: "nailed it",
+  versions: { model: "gemma4:e4b", panel: "0.8.2", mcp: null, backend: "ollama", comfyui: "1.19.9" },
+  transcript: [
+    { role: "user", text: "make an image" },
+    { role: "agent", text: "done" },
+  ],
+});
+
+test("accepts the documented payload and echoes the sanitized shape", () => {
+  const r = validateFeedback(good());
+  assert.equal(r.ok, true);
+  assert.equal(r.feedback.verdict, "good");
+  assert.equal(r.feedback.why, "nailed it");
+  assert.equal(r.feedback.versions.model, "gemma4:e4b");
+  assert.equal(r.feedback.versions.mcp, null);
+  assert.equal(r.feedback.transcript.length, 2);
+});
+
+test("rejects a missing or unknown verdict", () => {
+  for (const verdict of [undefined, "meh", 1, null]) {
+    const r = validateFeedback({ ...good(), verdict });
+    assert.equal(r.ok, false);
+    assert.ok(r.errors.some((e) => e.includes("verdict")));
+  }
+});
+
+test("rejects a missing/empty/malformed transcript", () => {
+  for (const transcript of [undefined, [], "hi", [{ noRole: true }], [null]]) {
+    const r = validateFeedback({ ...good(), transcript });
+    assert.equal(r.ok, false, JSON.stringify(transcript));
+    assert.ok(r.errors.some((e) => e.includes("transcript")));
+  }
+});
+
+test("rejects non-object bodies and wrong schema tags", () => {
+  assert.equal(validateFeedback(null).ok, false);
+  assert.equal(validateFeedback([1, 2]).ok, false);
+  assert.equal(validateFeedback("x").ok, false);
+  const r = validateFeedback({ ...good(), schema: "something-else/9" });
+  assert.equal(r.ok, false);
+});
+
+test("unknown top-level fields are dropped from the stored object", () => {
+  const r = validateFeedback({ ...good(), email: "x@y.z", hostname: "mybox", extra: 1 });
+  assert.equal(r.ok, true);
+  assert.ok(!("email" in r.feedback));
+  assert.ok(!("hostname" in r.feedback));
+  assert.ok(!("extra" in r.feedback));
+});
+
+test("optional fields degrade to null; why is capped", () => {
+  const r = validateFeedback({ verdict: "bad", transcript: [{ role: "user", text: "x" }] });
+  assert.equal(r.ok, true);
+  assert.equal(r.feedback.id, null);
+  assert.deepEqual(r.feedback.versions, { model: null, panel: null, mcp: null, backend: null, comfyui: null });
+  assert.ok(!("why" in r.feedback));
+  const long = validateFeedback({ ...good(), why: "y".repeat(10_000) });
+  assert.equal(long.ok, true);
+  assert.equal(long.feedback.why.length, 4_000);
+});
+
+test("body cap constant is sane (>= the panel's transcript cap)", () => {
+  assert.ok(MAX_BODY_BYTES >= 700_000);
+});

--- a/workers/feedback-uploader/wrangler.jsonc
+++ b/workers/feedback-uploader/wrangler.jsonc
@@ -1,0 +1,30 @@
+// comfyui-mcp feedback uploader — see README.md for deploy + secrets.
+// Nothing sensitive lives in this file: credentials are Worker secrets
+// (wrangler secret put), and the bucket name is a plain var you set below.
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "comfyui-mcp-feedback-uploader",
+  "main": "src/index.js",
+  "compatibility_date": "2026-07-01",
+  "observability": {
+    "enabled": true
+  },
+  "vars": {
+    // REQUIRED — the S3 bucket that receives feedback objects. Fill in before
+    // deploying (the Worker answers 503 "collector not configured" until every
+    // required var/secret is present).
+    "S3_BUCKET": "",
+    "S3_REGION": "us-east-1",
+    // OPTIONAL — custom S3-compatible endpoint (path-style addressing), e.g.
+    // R2: "https://<ACCOUNT_ID>.r2.cloudflarestorage.com". Leave empty for AWS.
+    "S3_ENDPOINT": "",
+    // OPTIONAL — comma-separated list of allowed browser origins, e.g.
+    // "http://127.0.0.1:8188,http://localhost:8188". "*" (default) allows any
+    // origin — acceptable for a write-only, credential-free collector, but
+    // tighten it if you only serve known ComfyUI hosts.
+    "ALLOWED_ORIGINS": "*"
+  }
+  // Secrets (NOT in this file — set with `wrangler secret put`):
+  //   AWS_ACCESS_KEY_ID
+  //   AWS_SECRET_ACCESS_KEY
+}


### PR DESCRIPTION
Implements the Share-transcript feedback feature from Discord thread 1525829664625393706: rate a conversation **good/bad** (+ optional why) and upload the **entire chat transcript + version info** to a maintainer-run collector — the labeled dataset for the local-model retrain. Upload target per the refinement: a **Cloudflare Worker that writes to S3** (no Discord channels).

## Panel

- **Entry point**: a flag icon in the chat-header utility strip (same idiom as the Remote-control QR button). **Hidden by default** — it appears only once `Settings → comfyui-mcp → "Share-transcript endpoint (advanced)"` (`comfyui-mcp.feedbackUrl` / `COMFYUI_MCP_FEEDBACK_URL`) holds an https URL. Blank default = feature fully dormant, nothing can upload.
- **Modal** (`cmcp-modal` idiom): *"This was good!"* / *"This was bad"* radios with **no pre-selection** (Share stays disabled until an explicit pick — unlabeled uploads impossible), optional "why" textarea, and a consent line: full conversation + version info uploads, no account data, secrets/bridge URLs stripped. Success → system-feed toast; failure → modal stays open to retry.
- **Privacy scrubber** (`web/js/lib/feedback.js`, pure + unit-tested): drops the panel's token-save (`pi-lock`) cards, redacts `ws://`/`wss://` bridge URLs, sensitive URL query values (`token=`, `key=`, …), bare `token=`/`password:` assignments, `Bearer` credentials, recognizable API-key shapes (sk-ant/sk/hf_/ghp_/xox/AKIA/…); masks home-dir usernames in paths; strips internal `mid`/`rewindAnchor`; size-caps the transcript newest-first (700k chars).

## Payload (`comfyui-mcp.feedback/1`)

```json
{
  "schema": "comfyui-mcp.feedback/1",
  "id": "<random uuid — anonymous, no account linkage>",
  "timestamp": "2026-07-15T…Z",
  "verdict": "good" | "bad",
  "why": "optional, ≤2000 chars, scrubbed",
  "versions": { "model": "…", "panel": "0.8.2", "mcp": null, "backend": "ollama", "comfyui": "…" },
  "transcript": [ { "role": "user"|"agent"|"card", "...": "full scrubbed thread incl. tool cards" } ]
}
```

> `versions.mcp` is **null for now**: no bridge frame carries the orchestrator's package version yet. The panel already listens for `mcp_version` on any frame (forward-compat) — a one-line comfyui-mcp follow-up (add `mcp_version: detectInstallMode().currentVersion` to the models-frame push) lights it up.

## Collector — `workers/feedback-uploader/`

Zero-runtime-dependency Cloudflare Worker (deploy artifact only — **not deployed by this PR**): CORS (`ALLOWED_ORIGINS`), 1 MiB cap, strict payload validation (unknown fields dropped, adds `received_at`), then a **SigV4-signed PUT** to `s3://$S3_BUCKET/feedback/YYYY/MM/DD/<verdict>-<uuid>.json`. SigV4 is hand-rolled on Web Crypto and **pinned to AWS's published test vector** in tests. Answers `503 collector not configured` until every var/secret is set — no hardcoded credentials anywhere. Never logs payloads or upstream error bodies. R2/MinIO supported via `S3_ENDPOINT`; the one-line R2-binding alternative is documented in the README. `workers/` is `.comfyignore`d (never in the scanned pack).

## To go live (maintainer, deliberately not done here)

1. Create a private S3 bucket + IAM key with `s3:PutObject` on `feedback/*` only
2. `cd workers/feedback-uploader && npm i && `edit `S3_BUCKET` in wrangler.jsonc` && npx wrangler secret put AWS_ACCESS_KEY_ID && npx wrangler secret put AWS_SECRET_ACCESS_KEY && npx wrangler deploy`
3. Paste the Worker URL into Settings → "Share-transcript endpoint (advanced)"

## Verification

- `npm run test:unit` — **56 pass** (19 new: scrubber, payload builder, good/bad modal-state gating)
- `npm run typecheck` — clean
- `node --check` (as `.mjs`) on all touched/new JS — clean
- Worker: `node --test` — **19 pass** (AWS SigV4 vector, validation, full handler happy-path/CORS/413/400/503/502 with mocked S3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)