### PR TITLE
feat(tools): view_selected / view_nodes_in_viewport / view_errored_nodes

### DIFF
--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3449,6 +3449,234 @@ const GRAPH_TOOL_EXECUTORS = {
     };
   },
 
+  // WHICH NODE(S) THE USER HAS SELECTED. Without this the agent can only guess
+  // what "this node" / "the highlighted one" means and ends up skimming the whole
+  // graph for clues (a user with a 700-node canvas burned a lot of tokens doing
+  // exactly that). Selection is the cheapest possible scope: read it FIRST.
+  // LiteGraph keeps two views of it — `selectedItems` (a Set, the modern one, and
+  // the only one that also holds groups/reroutes) and `selected_nodes` (an
+  // id→node object). Prefer the Set, fall back to the object. `current_node` is
+  // NOT the selection (it tracks the last node under the pointer), so it's ignored.
+  graph_view_selected() {
+    const { graph, canvas } = getGraphCtx();
+    const inGraph = new Set(graph._nodes ?? []);
+    const picked = [];
+    const others = [];
+    const items = canvas?.selectedItems;
+    if (items && typeof items.forEach === "function") {
+      for (const it of items) {
+        if (inGraph.has(it)) picked.push(it);
+        else if (it) others.push(it.constructor?.name ?? "item");
+      }
+    }
+    // Fallback for frontends that only maintain the legacy id→node object.
+    if (!picked.length && canvas?.selected_nodes) {
+      for (const n of Object.values(canvas.selected_nodes)) {
+        if (inGraph.has(n)) picked.push(n);
+      }
+    }
+    return {
+      viewing: describeActiveGraph(graph),
+      selected_count: picked.length,
+      node_count: graph._nodes?.length ?? 0,
+      nodes: picked.slice(0, MAX_STATE_NODES).map(summarizeNode),
+      ...(picked.length > MAX_STATE_NODES ? { truncated: true } : {}),
+      // Groups/reroutes can be selected too — report them so "nothing selected"
+      // is never misreported when the user actually has a group highlighted.
+      ...(others.length ? { other_selected_items: others } : {}),
+      ...(picked.length
+        ? {}
+        : { hint: "Nothing is selected on the canvas. Ask the user to click the node they mean, or use panel_graph_outline / panel_find_nodes to locate it." }),
+    };
+  },
+
+  // WHAT THE USER CAN ACTUALLY SEE. The agent has no eyes on the canvas, so on a
+  // big graph it either dumps everything or guesses. The viewport is the user's
+  // implicit context ("this node", "these ones here"), so scoping to it is both
+  // far cheaper and usually what they meant. `canvas.visible_area` is [x,y,w,h]
+  // in GRAPH coordinates (already accounts for pan+zoom); a node counts as
+  // visible when its full rendered box (getBounding — title bar included)
+  // INTERSECTS that rect, so half-on-screen nodes are included rather than
+  // dropped. Read-only.
+  graph_view_nodes_in_viewport() {
+    const { graph, canvas } = getGraphCtx();
+    // DERIVE the rect rather than trusting `canvas.visible_area`: LiteGraph only
+    // refreshes visible_area when it DRAWS, and it sizes it from the canvas
+    // BACKING store (canvas.width/height). A canvas that hasn't painted yet — a
+    // background tab, a panel opened before the first draw — still reports the
+    // 300x150 HTML default, which yields a viewport ~5x too small and silently
+    // returns ZERO nodes (measured: visible_area 333x167 vs the real 1712x1478).
+    // The element's CSS rect is always the true on-screen size, so compute from
+    // it: origin = -ds.offset (graph coords), extent = css_size / ds.scale.
+    // visible_area stays as the fallback for a headless/detached canvas.
+    const ds = canvas?.ds;
+    const el = canvas?.canvas;
+    let vx, vy, vw, vh;
+    const rect = typeof el?.getBoundingClientRect === "function" ? el.getBoundingClientRect() : null;
+    const scale = Number(ds?.scale);
+    if (rect && rect.width > 0 && rect.height > 0 && Number.isFinite(scale) && scale > 0 && ds?.offset) {
+      vx = -ds.offset[0];
+      vy = -ds.offset[1];
+      vw = rect.width / scale;
+      vh = rect.height / scale;
+    } else {
+      const va = canvas?.visible_area;
+      if (!va || va.length < 4) {
+        throw new Error("Viewport bounds unavailable (no canvas rect and no canvas.visible_area) — the canvas may not be rendered yet.");
+      }
+      [vx, vy, vw, vh] = [va[0], va[1], va[2], va[3]];
+    }
+    const bb = new Float32Array(4);
+    const all = graph._nodes ?? [];
+    const visible = all.filter((n) => {
+      let b = null;
+      try {
+        if (typeof n.getBounding === "function") b = n.getBounding(bb);
+      } catch {
+        /* fall through to pos/size below */
+      }
+      const x = b ? b[0] : n.pos?.[0];
+      const y = b ? b[1] : n.pos?.[1];
+      const w = b ? b[2] : n.size?.[0] ?? 0;
+      const h = b ? b[3] : n.size?.[1] ?? 0;
+      if (!Number.isFinite(x) || !Number.isFinite(y)) return false;
+      // AABB overlap against the viewport rect.
+      return x < vx + vw && x + w > vx && y < vy + vh && y + h > vy;
+    });
+    return {
+      viewing: describeActiveGraph(graph),
+      viewport: {
+        x: Math.round(vx),
+        y: Math.round(vy),
+        width: Math.round(vw),
+        height: Math.round(vh),
+        ...(Number.isFinite(canvas?.ds?.scale) ? { zoom: Number(canvas.ds.scale.toFixed(3)) } : {}),
+      },
+      node_count: all.length,
+      in_view_count: visible.length,
+      truncated: visible.length > MAX_STATE_NODES,
+      nodes: visible.slice(0, MAX_STATE_NODES).map(summarizeNode),
+    };
+  },
+
+  // WHY IS THAT NODE RED? LiteGraph only sets a boolean (`node.has_errors`) and
+  // paints a red outline — the REASON lives somewhere else entirely, which is why
+  // users see "red node, no error message". This gathers every source and joins
+  // them onto the offending node:
+  //   - missingModel store  → the exact missing file, its directory, download URL
+  //   - missingNodesError   → node types this install doesn't have
+  //   - app.lastNodeErrors  → per-node validation errors from the last run attempt
+  //   - executionError      → the last execution failure
+  // Read-only.
+  graph_view_errored_nodes() {
+    const { app: comfy, graph } = getGraphCtx();
+    const nodes = graph._nodes ?? [];
+    const byId = new Map(nodes.map((n) => [String(n.id), n]));
+    // node id → reasons[]
+    const reasons = new Map();
+    const addReason = (id, reason) => {
+      const key = String(id);
+      if (!reasons.has(key)) reasons.set(key, []);
+      reasons.get(key).push(reason);
+    };
+
+    // 1) Missing MODELS — the most common cause of a red loader node.
+    let missingModels = [];
+    try {
+      const store = getPiniaStore("missingModel");
+      const cands = store?.missingModelCandidates ?? [];
+      for (const c of cands) {
+        if (c?.isMissing === false) continue;
+        const r = {
+          kind: "missing_model",
+          file: c?.name ?? null,
+          directory: c?.directory ?? null,
+          ...(c?.widgetName ? { widget: c.widgetName } : {}),
+          ...(c?.url ? { download_url: c.url } : {}),
+        };
+        missingModels.push({ node_id: c?.nodeId ?? null, ...r });
+        if (c?.nodeId != null) addReason(c.nodeId, r);
+      }
+    } catch {
+      /* store unavailable on this frontend — other sources still apply */
+    }
+
+    // 2) Missing NODE TYPES (the pack isn't installed).
+    let missingNodeTypes = [];
+    try {
+      const store = getPiniaStore("missingNodesError");
+      const list = store?.missingNodeTypes ?? store?.missingNodes ?? [];
+      missingNodeTypes = list
+        .map((m) => (typeof m === "string" ? m : m?.type ?? m?.nodeType ?? null))
+        .filter(Boolean);
+    } catch {
+      /* optional */
+    }
+
+    // 3) Per-node VALIDATION errors from the last run attempt.
+    const lastNodeErrors = comfy?.lastNodeErrors ?? null;
+    if (lastNodeErrors && typeof lastNodeErrors === "object") {
+      for (const [id, entry] of Object.entries(lastNodeErrors)) {
+        for (const e of entry?.errors ?? []) {
+          addReason(id, {
+            kind: "validation",
+            message: e?.message ?? String(e),
+            ...(e?.details ? { details: e.details } : {}),
+            ...(e?.extra_info?.input_name ? { input: e.extra_info.input_name } : {}),
+          });
+        }
+      }
+    }
+
+    // 4) The last EXECUTION failure (may name a node that isn't flagged).
+    let executionError = null;
+    try {
+      const store = getPiniaStore("executionError");
+      const e = store?.lastExecutionError ?? comfy?.lastExecutionError ?? null;
+      if (e) {
+        executionError = {
+          node_id: e.node_id ?? null,
+          node_type: e.node_type ?? null,
+          message: e.exception_message ?? e.message ?? null,
+        };
+        if (e.node_id != null) {
+          addReason(e.node_id, { kind: "execution", message: executionError.message });
+        }
+      }
+    } catch {
+      /* optional */
+    }
+
+    // The red-outlined set is has_errors, UNIONed with anything a source blamed
+    // (a source can name a node LiteGraph never flagged).
+    const flagged = new Set(nodes.filter((n) => n.has_errors).map((n) => String(n.id)));
+    for (const id of reasons.keys()) if (byId.has(id)) flagged.add(id);
+
+    const out = [...flagged]
+      .map((id) => byId.get(id))
+      .filter(Boolean)
+      .map((n) => ({
+        ...summarizeNode(n),
+        red_outline: !!n.has_errors,
+        reasons: reasons.get(String(n.id)) ?? [],
+        ...(reasons.get(String(n.id))?.length
+          ? {}
+          : { note: "Flagged by LiteGraph but no source explained it — it may be stale; re-run to refresh, or check the node's widget values." }),
+      }));
+
+    return {
+      viewing: describeActiveGraph(graph),
+      node_count: nodes.length,
+      errored_count: out.length,
+      nodes: out.slice(0, MAX_STATE_NODES),
+      ...(out.length > MAX_STATE_NODES ? { truncated: true } : {}),
+      ...(missingModels.length ? { missing_models: missingModels } : {}),
+      ...(missingNodeTypes.length ? { missing_node_types: missingNodeTypes } : {}),
+      ...(executionError ? { last_execution_error: executionError } : {}),
+      ...(out.length ? {} : { hint: "No nodes are flagged with errors on the canvas right now." }),
+    };
+  },
+
   // A compact, dependency-ordered TEXT outline of the open graph — built to be
   // read top→down by an LLM (sources first, sinks last). Each node is one block:
   //   id  Type "title" [mode] [OUTPUT] · group:X   widget=value …

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7484,6 +7484,12 @@ const PANEL_CSS = `
 }
 .cmcp-composer-row { display: flex; align-items: center; gap: 0.25rem; padding: 0.25rem 0.5rem 0.5rem; }
 .cmcp-spacer { flex: 1; }
+/* "Why is this red?" — only rendered while the canvas has flagged nodes, so it
+   reads as a live alert rather than permanent chrome. Amber (not red) so it
+   doesn't imitate ComfyUI's own error toast. */
+.cmcp-errors-btn { width: auto; min-width: 1.75rem; gap: 0.2rem; padding: 0 0.3rem; color: var(--p-orange-500, #f59e0b); }
+.cmcp-errors-btn:hover { background: var(--p-surface-700, #3f3f46); color: var(--p-orange-400, #fbbf24); }
+.cmcp-errors-count { font-size: 0.6875rem; font-weight: 600; line-height: 1; }
 .cmcp-iconbtn {
   width: 1.75rem; height: 1.75rem; flex: none;
   display: flex; align-items: center; justify-content: center;
@@ -9371,6 +9377,53 @@ function buildPanel() {
   const sendBtn = iconBtn("pi-send", "Send (Enter)");
   sendBtn.type = "submit";
 
+  // ⚠ "Why is this red?" — LiteGraph paints a node red but stores no reason
+  // anywhere the user can see (its badge text is empty), so the standing
+  // complaint is "red node, no error message". This button appears ONLY while
+  // the live canvas has flagged nodes and routes the agent straight at
+  // panel_view_errored_nodes, which joins the actual cause (missing model +
+  // download URL, validation error, execution failure) onto each node.
+  const errorsBtn = iconBtn("pi-exclamation-triangle", "Nodes with errors — ask why");
+  errorsBtn.classList.add("cmcp-errors-btn");
+  errorsBtn.hidden = true;
+  const errorsCount = document.createElement("span");
+  errorsCount.className = "cmcp-errors-count";
+  errorsBtn.appendChild(errorsCount);
+  let _erroredIds = [];
+  /** Poll the live graph for flagged nodes and show/hide the affordance. Cheap
+   *  (one pass over nodes) and diffed against the last id list so we only touch
+   *  the DOM when the set actually changes. */
+  function refreshErroredAffordance() {
+    let ids = [];
+    try {
+      const nodes = app?.canvas?.graph?._nodes ?? app?.graph?._nodes ?? [];
+      ids = nodes.filter((n) => n?.has_errors).map((n) => n.id);
+    } catch {
+      return; // canvas not ready — leave the affordance as-is
+    }
+    if (ids.length === _erroredIds.length && ids.every((v, i) => v === _erroredIds[i])) return;
+    _erroredIds = ids;
+    errorsBtn.hidden = ids.length === 0;
+    errorsCount.textContent = ids.length > 1 ? String(ids.length) : "";
+    errorsBtn.title = ids.length
+      ? `${ids.length} node${ids.length === 1 ? "" : "s"} with errors (id ${ids.join(", ")}) — ask why`
+      : "Nodes with errors — ask why";
+  }
+  errorsBtn.addEventListener("click", () => {
+    const ids = _erroredIds;
+    if (!ids.length) return;
+    const which =
+      ids.length === 1 ? `is node ${ids[0]}` : `are nodes ${ids.join(", ")}`;
+    input.value =
+      `Why ${which} highlighted red on my canvas? Use panel_view_errored_nodes to read the actual reason ` +
+      `(don't guess from widget values), then tell me plainly what's wrong and exactly how to fix it — ` +
+      `if a model is missing, name the file, the folder it belongs in, and where to get it.`;
+    input.focus();
+    // Submitting via the form keeps the normal send path (attachments, mid,
+    // pending bubble) instead of duplicating it here.
+    form.requestSubmit ? form.requestSubmit() : sendBtn.click();
+  });
+
   const fileInput = document.createElement("input");
   fileInput.type = "file";
   // Images + video upload into ComfyUI input/; workflows (.json) and text files
@@ -9555,7 +9608,12 @@ function buildPanel() {
   toolbarSpacer.className = "cmcp-spacer";
   toolbar.append(deafenBtn, blindBtn, toolbarSpacer, civitaiBtn, trainingBtn);
 
-  row.append(ring, ctxLabel, modelChip, spacer, attachBtn, micBtn, sendBtn);
+  row.append(ring, ctxLabel, modelChip, errorsBtn, spacer, attachBtn, micBtn, sendBtn);
+  // Watch the live canvas for flagged nodes. 1.2s is well under human reaction
+  // time for "I just saw a node go red" and costs one array pass; the interval
+  // is cleared with the panel's other timers on teardown.
+  refreshErroredAffordance();
+  const _errPoll = setInterval(refreshErroredAffordance, 1200);
   form.append(menuPop, modelPop, attachBar, input, row, fileInput);
   root.appendChild(form);
 
@@ -14131,6 +14189,7 @@ function buildPanel() {
         // recognition already stopped
       }
       clearInterval(_wfPoll); // stop per-workflow change polling on unmount
+      clearInterval(_errPoll); // stop errored-node affordance polling on unmount
       document.removeEventListener("mousedown", onDocPointerDown, true);
       document.removeEventListener("keydown", onInterruptKeydown, true);
       document.removeEventListener("visibilitychange", onVisibilityChange);


### PR DESCRIPTION
## What

Three read-only live-canvas executors backing the new `panel_view_*` tools, so the agent can scope to the user's actual intent instead of skimming a big graph.

### `graph_view_selected`
Reads `canvas.selectedItems` (the modern `Set`, which also holds groups/reroutes), falling back to the legacy `selected_nodes` object. `current_node` is deliberately **ignored** — verified live that it tracks the pointer, not the selection (it read 66 while the selection was 9). Returns the empty case with a clear hint rather than guessing.

### `graph_view_nodes_in_viewport`
Nodes intersecting the visible rect (any overlap counts, so half-on-screen nodes aren't dropped).

**Bug found by live testing:** it derives the rect from the canvas element's **CSS size ÷ `ds.scale`**, *not* `canvas.visible_area`. LiteGraph only refreshes `visible_area` when it **draws**, and sizes it from the **backing store** — an unpainted/background canvas still reports the `300×150` HTML default:

| source | measured | correct? |
|---|---|---|
| `visible_area` | `333 × 167` | ❌ → returned **0 nodes** |
| CSS rect ÷ scale | `1712 × 1478` | ✅ |

`visible_area` is kept as the fallback for a detached/headless canvas.

### `graph_view_errored_nodes`
LiteGraph only sets a boolean and paints a red outline — the reason lives elsewhere, which is exactly why users report *"red node, no error message"* (confirmed live: `badge.text` was `""` and `lastNodeErrors` was `null`). This joins the reason onto the node from four sources: the `missingModel` store (file, directory, **download URL**), `missingNodesError`, `app.lastNodeErrors` (per-input validation), and `executionError`.

## Testing — verified live against ComfyUI on :8188

On a canvas with 3 missing-model errors:

- **errored** → all 3 red nodes with exact causes, e.g. node 62 `CLIPLoader` → `qwen_3_4b.safetensors` missing from `text_encoders` + HF download URL.
- **selected** → empty case returns the hint; selecting node 62 returned it with its widgets.
- **viewport** → `1712×1478 @ 0.9` with all 10 nodes in view; after panning 6000 away, correctly **0** in view.

`npm run typecheck` clean, `npm run test:unit` **67 passed**. A temporary test scaffold used to exercise the executors was removed (verified absent).

## Pairs with

`comfyui-mcp` PR (the tool declarations). Cmd names verified matching across the bridge.

> **Dev-loop note:** ComfyUI must be restarted to pick up panel JS edits — it serves a snapshot from boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)