### PR TITLE
feat(runpod): RunPod control panel + honest host indicator

### DIFF
--- a/web/js/cmcp-runpod-ui.js
+++ b/web/js/cmcp-runpod-ui.js
@@ -26,6 +26,7 @@ function injectStyle(root) {
   if (styleInjected) return;
   styleInjected = true;
   const css = `
+.cmcp-rp-modal{max-width:min(480px,92vw)!important;width:auto;}
 .cmcp-rp-body{display:flex;flex-direction:column;gap:0.75rem;min-width:min(440px,90vw);max-width:520px;}
 .cmcp-rp-host{display:flex;align-items:center;gap:0.5rem;padding:0.55rem 0.7rem;border-radius:8px;
   font-size:0.85rem;font-weight:600;border:1px solid var(--p-content-border-color,#3f3f46);}
@@ -53,9 +54,15 @@ function injectStyle(root) {
 `;
   const el = document.createElement("style");
   el.textContent = css;
-  (root.getRootNode?.() || document).appendChild
-    ? (root.getRootNode?.() || document).appendChild(el)
-    : document.head.appendChild(el);
+  // Append into the same root the modal mounts in: a ShadowRoot when the panel
+  // lives in shadow DOM, else document.head. (A bare `document.appendChild`
+  // throws — the document may hold only one element child.)
+  const r = root?.getRootNode?.();
+  const target =
+    r && typeof r.appendChild === "function" && r.nodeType === 11 /* DOCUMENT_FRAGMENT (ShadowRoot) */
+      ? r
+      : document.head;
+  target.appendChild(el);
 }
 
 /** Pull human text out of a tool_result frame (result = MCP content array). */
@@ -90,7 +97,7 @@ export function openRunpodModal(ctx, opts = {}) {
   const overlay = document.createElement("div");
   overlay.className = "cmcp-modal-overlay";
   const modal = document.createElement("div");
-  modal.className = "cmcp-modal";
+  modal.className = "cmcp-modal cmcp-rp-modal";
   const title = document.createElement("div");
   title.className = "cmcp-modal-title";
   title.textContent = "RunPod — cloud GPU for this session";
@@ -152,7 +159,11 @@ export function openRunpodModal(ctx, opts = {}) {
   body.append(host, card, connectRow, actions, linkRow, log, credit);
   modal.append(title, body, btnRow);
   overlay.append(modal);
-  root.appendChild(overlay);
+  // Mount the overlay on <body>, NOT the panel root: the ComfyUI sidebar clips
+  // its descendants, so a root-mounted overlay would be squeezed into the narrow
+  // panel (buttons + status values cut off). On body it's a true viewport-centered
+  // modal at its full width.
+  document.body.appendChild(overlay);
 
   // ── state + rendering ──────────────────────────────────────────────────────
   let busy = false;

--- a/web/js/cmcp-runpod-ui.js
+++ b/web/js/cmcp-runpod-ui.js
@@ -22,7 +22,7 @@
 const GPU_CLI_URL = "https://gpu-cli.sh";
 
 let styleInjected = false;
-function injectStyle(root) {
+function injectStyle() {
   if (styleInjected) return;
   styleInjected = true;
   const css = `
@@ -57,15 +57,11 @@ function injectStyle(root) {
 `;
   const el = document.createElement("style");
   el.textContent = css;
-  // Append into the same root the modal mounts in: a ShadowRoot when the panel
-  // lives in shadow DOM, else document.head. (A bare `document.appendChild`
-  // throws — the document may hold only one element child.)
-  const r = root?.getRootNode?.();
-  const target =
-    r && typeof r.appendChild === "function" && r.nodeType === 11 /* DOCUMENT_FRAGMENT (ShadowRoot) */
-      ? r
-      : document.head;
-  target.appendChild(el);
+  // The overlay mounts on document.body (see openRunpodModal), which is OUTSIDE
+  // any panel ShadowRoot — so the CSS must live in document.head, not the shadow
+  // root, or shadow-DOM hosts would render the modal unstyled. Inject into head
+  // unconditionally.
+  document.head.appendChild(el);
 }
 
 /** Pull human text out of a tool_result frame (result = MCP content array). */
@@ -95,7 +91,7 @@ function fmtCountdown(sec) {
 
 export function openRunpodModal(ctx, opts = {}) {
   const { root, callTool, getStatus, getTarget, openUrl } = ctx;
-  injectStyle(root);
+  injectStyle();
 
   const overlay = document.createElement("div");
   overlay.className = "cmcp-modal-overlay";
@@ -142,6 +138,13 @@ export function openRunpodModal(ctx, opts = {}) {
   podInput.placeholder = "paste pod id (from console.runpod.io)";
   podInput.spellcheck = false;
   manualRow.append(podInput);
+  // Enter in the manual-ID field connects, matching the primary button.
+  podInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      connectBtn.click();
+    }
+  });
   podSelect.addEventListener("change", () => {
     manualRow.style.display = podSelect.value === "__manual__" ? "flex" : "none";
     if (podSelect.value === "__manual__") podInput.focus();
@@ -205,6 +208,13 @@ export function openRunpodModal(ctx, opts = {}) {
     const s = getStatus?.();
     return (s && s.watching && s.pod_id) || selectedPodId();
   }
+  // The pod currently being watched (connected), or null. Stop targets ONLY this
+  // one: Stop is enabled solely for a watched RUNNING pod, so it must never fall
+  // back to a different pod the user merely typed/selected in the dropdown.
+  function watchedPodId() {
+    const s = getStatus?.();
+    return (s && s.watching && s.pod_id) || null;
+  }
 
   // Populate the dropdown from runpod_list_pods (humans pick by name, not id).
   async function loadPods(preselect) {
@@ -240,7 +250,11 @@ export function openRunpodModal(ctx, opts = {}) {
     if (closed) return;
     const s = getStatus?.() || null;
     const t = getTarget?.() || null;
-    const onPod = t ? !t.is_local : !!(s && s.watching && s.status === "RUNNING");
+    // Honesty: only claim "on pod" when the orchestrator's comfyui_target frame
+    // actually says so. Without a target frame the render destination is unknown
+    // — and runpod_watch broadcasts pod status WITHOUT retargeting, so a watched
+    // RUNNING pod does NOT mean renders go there. Default to local when unknown.
+    const onPod = !!(t && !t.is_local);
 
     // Host banner.
     host.classList.toggle("local", !onPod);
@@ -335,19 +349,25 @@ export function openRunpodModal(ctx, opts = {}) {
     run("Starting " + id, () => callTool("runpod_pod_start", { pod_id: id }));
   });
   stopBtn.addEventListener("click", () => {
-    const id = currentPodId();
+    const id = watchedPodId();
     if (!id) return;
     run("Stopping " + id, () => callTool("runpod_pod_stop", { pod_id: id }));
   });
   localBtn.addEventListener("click", () => {
     run("Switching to local ComfyUI", () => callTool("runpod_use_local", {}));
   });
+  // Confirm must be two DISTINCT human decisions, not one double-click. Arming
+  // opens a short cool-down window during which confirm clicks (and keyboard
+  // repeat on Enter/Space) are ignored, so an accidental double-click can't bill.
+  const DEPLOY_ARM_COOLDOWN_MS = 600;
+  let deployArmedAt = 0;
   deployBtn.addEventListener("click", () => {
     // Deploying bills GPU-time immediately — confirm once inline.
     if (deployBtn.dataset.armed !== "1") {
       deployBtn.dataset.armed = "1";
+      deployArmedAt = Date.now();
       deployBtn.textContent = "Deploy — this bills. Click to confirm";
-      setLog("A new pod bills per running GPU-second (~$0.30–0.70/hr). It idle-auto-stops, and Stop ends billing.", "");
+      setLog("A new pod bills per running GPU-second (~$0.30–0.70/hr). It idle-auto-stops; Stop ends GPU billing (disk storage still bills until you terminate the pod in the console).", "");
       setTimeout(() => {
         if (deployBtn.dataset.armed === "1") {
           deployBtn.dataset.armed = "0";
@@ -356,6 +376,9 @@ export function openRunpodModal(ctx, opts = {}) {
       }, 5000);
       return;
     }
+    // Ignore a confirm that lands inside the cool-down (a double-click / key
+    // repeat is not a second human decision). Keep it armed so a real click works.
+    if (Date.now() - deployArmedAt < DEPLOY_ARM_COOLDOWN_MS) return;
     deployBtn.dataset.armed = "0";
     deployBtn.textContent = "Deploy new pod";
     run("Deploying a new pod", () => callTool("runpod_pod_create", {}, { timeout: 120000 })).then((ok) => {

--- a/web/js/cmcp-runpod-ui.js
+++ b/web/js/cmcp-runpod-ui.js
@@ -42,9 +42,12 @@ function injectStyle(root) {
 .cmcp-rp-actions{display:flex;flex-wrap:wrap;gap:0.4rem;}
 .cmcp-rp-actions .cmcp-btn{flex:1 1 auto;min-width:96px;}
 .cmcp-rp-connect{display:flex;gap:0.4rem;}
-.cmcp-rp-connect input{flex:1 1 auto;min-width:0;padding:0.4rem 0.55rem;border-radius:6px;
+.cmcp-rp-connect input,.cmcp-rp-podselect{flex:1 1 auto;min-width:0;padding:0.4rem 0.55rem;border-radius:6px;
   border:1px solid var(--p-content-border-color,#3f3f46);background:var(--p-inputtext-background,#18181b);
-  color:inherit;font-size:0.82rem;font-family:ui-monospace,monospace;}
+  color:inherit;font-size:0.82rem;}
+.cmcp-rp-connect input{font-family:ui-monospace,monospace;}
+.cmcp-rp-podselect{cursor:pointer;}
+.cmcp-rp-refresh{flex:0 0 auto;min-width:auto;padding:0.4rem 0.6rem;}
 .cmcp-rp-log{font-size:0.78rem;opacity:0.85;min-height:1.1em;white-space:pre-wrap;word-break:break-word;}
 .cmcp-rp-log.busy{opacity:0.6;}
 .cmcp-rp-log.err{color:#f87171;}
@@ -117,15 +120,32 @@ export function openRunpodModal(ctx, opts = {}) {
   const card = document.createElement("div");
   card.className = "cmcp-rp-card";
 
-  // Connect-by-id row.
+  // Pod picker row: a dropdown of the account's pods (humans pick by name, not id),
+  // with a manual-ID fallback + a refresh. Populated from runpod_list_pods.
   const connectRow = document.createElement("div");
   connectRow.className = "cmcp-rp-connect";
+  const podSelect = document.createElement("select");
+  podSelect.className = "cmcp-rp-podselect";
+  podSelect.append(new Option("Loading pods…", ""));
+  const refreshBtn = mkBtn("↻");
+  refreshBtn.title = "Refresh pod list";
+  refreshBtn.classList.add("cmcp-rp-refresh");
+  const connectBtn = mkBtn("Connect", "primary");
+  connectRow.append(podSelect, refreshBtn, connectBtn);
+
+  // Manual-ID row (hidden unless "paste a pod ID…" is chosen in the dropdown).
+  const manualRow = document.createElement("div");
+  manualRow.className = "cmcp-rp-connect";
+  manualRow.style.display = "none";
   const podInput = document.createElement("input");
   podInput.type = "text";
-  podInput.placeholder = "pod id (from console.runpod.io)";
+  podInput.placeholder = "paste pod id (from console.runpod.io)";
   podInput.spellcheck = false;
-  const connectBtn = mkBtn("Connect", "primary");
-  connectRow.append(podInput, connectBtn);
+  manualRow.append(podInput);
+  podSelect.addEventListener("change", () => {
+    manualRow.style.display = podSelect.value === "__manual__" ? "flex" : "none";
+    if (podSelect.value === "__manual__") podInput.focus();
+  });
 
   // Action buttons.
   const actions = document.createElement("div");
@@ -156,7 +176,7 @@ export function openRunpodModal(ctx, opts = {}) {
   const doneBtn = mkBtn("Close", "primary");
   btnRow.append(doneBtn);
 
-  body.append(host, card, connectRow, actions, linkRow, log, credit);
+  body.append(host, card, connectRow, manualRow, actions, linkRow, log, credit);
   modal.append(title, body, btnRow);
   overlay.append(modal);
   // Mount the overlay on <body>, NOT the panel root: the ComfyUI sidebar clips
@@ -175,10 +195,46 @@ export function openRunpodModal(ctx, opts = {}) {
     log.className = "cmcp-rp-log" + (kind ? " " + kind : "");
   }
 
+  // The pod a lifecycle action targets: the one being watched (connected), else
+  // the dropdown selection, else a manually-pasted id.
+  function selectedPodId() {
+    if (podSelect.value === "__manual__") return podInput.value.trim() || null;
+    return podSelect.value || null;
+  }
   function currentPodId() {
     const s = getStatus?.();
-    return (s && s.watching && s.pod_id) || (podInput.value.trim() || null);
+    return (s && s.watching && s.pod_id) || selectedPodId();
   }
+
+  // Populate the dropdown from runpod_list_pods (humans pick by name, not id).
+  async function loadPods(preselect) {
+    try {
+      const res = await callTool("runpod_list_pods", {});
+      const txt = toolText(res);
+      const rows = [];
+      const re = /\*\*(.+?)\*\*\s*`([a-z0-9]+)`\s*—\s*(\S+)([^\n]*)/gi;
+      let m;
+      while ((m = re.exec(txt))) {
+        const gpu = (m[4].match(/·\s*([^·$]+?)(?:\s*·|\s*$)/) || [])[1];
+        rows.push({ name: m[1].trim(), id: m[2], status: m[3], gpu: gpu ? gpu.trim() : "" });
+      }
+      const want = preselect || selectedPodId();
+      podSelect.innerHTML = "";
+      podSelect.append(new Option(rows.length ? "— select a pod —" : "no pods yet — deploy one below", ""));
+      for (const r of rows) {
+        podSelect.append(new Option(`${r.name} — ${r.status}${r.gpu ? " · " + r.gpu : ""}`, r.id));
+      }
+      podSelect.append(new Option("＋ paste a pod ID…", "__manual__"));
+      if (want && rows.some((r) => r.id === want)) podSelect.value = want;
+      else if (rows.length === 1) podSelect.value = rows[0].id;
+    } catch (err) {
+      podSelect.innerHTML = "";
+      podSelect.append(new Option("couldn't list pods", ""));
+      podSelect.append(new Option("＋ paste a pod ID…", "__manual__"));
+    }
+    manualRow.style.display = podSelect.value === "__manual__" ? "flex" : "none";
+  }
+  refreshBtn.addEventListener("click", () => loadPods());
 
   function render() {
     if (closed) return;
@@ -242,27 +298,30 @@ export function openRunpodModal(ctx, opts = {}) {
   }, 1000);
 
   async function run(label, fn) {
-    if (busy) return;
+    if (busy) return false;
     busy = true;
     render();
     setLog(label + "…", "busy");
+    let ok = false;
     try {
       const res = await fn();
-      if (closed) return;
+      if (closed) return false;
       const txt = toolText(res);
-      setLog(txt, res && res.ok === false ? "err" : "");
+      ok = !(res && res.ok === false);
+      setLog(txt, ok ? "" : "err");
     } catch (err) {
       if (!closed) setLog((err && err.message) || String(err), "err");
     } finally {
       busy = false;
       if (!closed) render();
     }
+    return ok;
   }
 
   connectBtn.addEventListener("click", () => {
-    const id = podInput.value.trim();
+    const id = selectedPodId();
     if (!id) {
-      setLog("Enter a pod ID first (from the RunPod console).", "err");
+      setLog("Pick a pod from the list first (or deploy a new one).", "err");
       return;
     }
     run("Connecting to " + id, () => callTool("runpod_pod_connect", { pod_id: id }));
@@ -299,7 +358,9 @@ export function openRunpodModal(ctx, opts = {}) {
     }
     deployBtn.dataset.armed = "0";
     deployBtn.textContent = "Deploy new pod";
-    run("Deploying a new pod", () => callTool("runpod_pod_create", {}, { timeout: 120000 }));
+    run("Deploying a new pod", () => callTool("runpod_pod_create", {}, { timeout: 120000 })).then((ok) => {
+      if (ok) loadPods(); // show the new pod in the dropdown
+    });
   });
   linkBtn.addEventListener("click", async (e) => {
     e.preventDefault();
@@ -325,10 +386,9 @@ export function openRunpodModal(ctx, opts = {}) {
     if (e.target === overlay) close();
   });
 
-  // Seed the pod-id field if we're already watching one.
+  // Load the pod dropdown on open, preselecting the watched pod (or opts.pod_id).
   const s0 = getStatus?.();
-  if (s0 && s0.watching && s0.pod_id) podInput.value = s0.pod_id;
-  if (opts.pod_id) podInput.value = opts.pod_id;
+  void loadPods((s0 && s0.watching && s0.pod_id) || opts.pod_id);
 
   render();
 

--- a/web/js/cmcp-runpod-ui.js
+++ b/web/js/cmcp-runpod-ui.js
@@ -1,0 +1,353 @@
+// RunPod control panel — the in-panel modal for the first-party RunPod backend.
+//
+// Renders the live pod status (broadcast by the orchestrator's runpod-watch as
+// `runpod_status` frames) and the honest host indicator (`comfyui_target`), and
+// drives the pod lifecycle + the local⇄pod switch through the whitelisted
+// runpod_* tools over the bridge's callTool (no agent turn needed):
+//   deploy → connect → render on the pod → stop → back to local → reconnect.
+//
+// The pod runs OUR template, so once connected the agent installs the user's
+// exact custom nodes / LoRAs and downloads models → full canvas parity remotely.
+//
+// ctx (from the panel monolith):
+//   root        — element to mount the overlay into
+//   callTool    — (tool, args, opts) => Promise<tool_result frame>
+//   getStatus   — () => last runpod_status frame (or null)
+//   getTarget   — () => last comfyui_target frame (or null)
+//   openUrl     — (url) => void  (open a link in a new tab)
+//
+// Pod control inspired by gpu-cli.sh (https://gpu-cli.sh) — a cloud-GPU CLI
+// worth checking out; this backend is our own (runs the user's real canvas).
+
+const GPU_CLI_URL = "https://gpu-cli.sh";
+
+let styleInjected = false;
+function injectStyle(root) {
+  if (styleInjected) return;
+  styleInjected = true;
+  const css = `
+.cmcp-rp-body{display:flex;flex-direction:column;gap:0.75rem;min-width:min(440px,90vw);max-width:520px;}
+.cmcp-rp-host{display:flex;align-items:center;gap:0.5rem;padding:0.55rem 0.7rem;border-radius:8px;
+  font-size:0.85rem;font-weight:600;border:1px solid var(--p-content-border-color,#3f3f46);}
+.cmcp-rp-host.local{background:rgba(34,197,94,0.10);color:#22c55e;border-color:rgba(34,197,94,0.35);}
+.cmcp-rp-host.pod{background:rgba(59,130,246,0.12);color:#60a5fa;border-color:rgba(59,130,246,0.40);}
+.cmcp-rp-dot{width:8px;height:8px;border-radius:50%;background:currentColor;flex:0 0 auto;}
+.cmcp-rp-card{border:1px solid var(--p-content-border-color,#3f3f46);border-radius:8px;padding:0.7rem;
+  display:flex;flex-direction:column;gap:0.35rem;font-size:0.82rem;}
+.cmcp-rp-row{display:flex;justify-content:space-between;gap:0.75rem;}
+.cmcp-rp-row .k{opacity:0.6;}
+.cmcp-rp-row .v{font-variant-numeric:tabular-nums;text-align:right;}
+.cmcp-rp-warn{color:#f59e0b;}
+.cmcp-rp-actions{display:flex;flex-wrap:wrap;gap:0.4rem;}
+.cmcp-rp-actions .cmcp-btn{flex:1 1 auto;min-width:96px;}
+.cmcp-rp-connect{display:flex;gap:0.4rem;}
+.cmcp-rp-connect input{flex:1 1 auto;min-width:0;padding:0.4rem 0.55rem;border-radius:6px;
+  border:1px solid var(--p-content-border-color,#3f3f46);background:var(--p-inputtext-background,#18181b);
+  color:inherit;font-size:0.82rem;font-family:ui-monospace,monospace;}
+.cmcp-rp-log{font-size:0.78rem;opacity:0.85;min-height:1.1em;white-space:pre-wrap;word-break:break-word;}
+.cmcp-rp-log.busy{opacity:0.6;}
+.cmcp-rp-log.err{color:#f87171;}
+.cmcp-rp-credit{font-size:0.7rem;opacity:0.5;}
+.cmcp-rp-credit a{color:inherit;}
+.cmcp-rp-muted{font-size:0.75rem;opacity:0.6;}
+`;
+  const el = document.createElement("style");
+  el.textContent = css;
+  (root.getRootNode?.() || document).appendChild
+    ? (root.getRootNode?.() || document).appendChild(el)
+    : document.head.appendChild(el);
+}
+
+/** Pull human text out of a tool_result frame (result = MCP content array). */
+function toolText(res) {
+  if (!res) return "";
+  if (res.error) return String(res.error);
+  const r = res.result;
+  if (Array.isArray(r)) return r.map((c) => (c && c.text) || "").join("");
+  if (r && Array.isArray(r.content)) return r.content.map((c) => (c && c.text) || "").join("");
+  if (typeof r === "string") return r;
+  return res.ok === false ? "The action failed." : "Done.";
+}
+
+function fmtUptime(sec) {
+  if (!sec || sec <= 0) return "—";
+  const h = Math.floor(sec / 3600);
+  const m = Math.floor((sec % 3600) / 60);
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+function fmtCountdown(sec) {
+  if (sec == null) return null;
+  if (sec <= 0) return "now";
+  const m = Math.floor(sec / 60);
+  const s = sec % 60;
+  return m > 0 ? `${m}m ${s}s` : `${s}s`;
+}
+
+export function openRunpodModal(ctx, opts = {}) {
+  const { root, callTool, getStatus, getTarget, openUrl } = ctx;
+  injectStyle(root);
+
+  const overlay = document.createElement("div");
+  overlay.className = "cmcp-modal-overlay";
+  const modal = document.createElement("div");
+  modal.className = "cmcp-modal";
+  const title = document.createElement("div");
+  title.className = "cmcp-modal-title";
+  title.textContent = "RunPod — cloud GPU for this session";
+
+  const body = document.createElement("div");
+  body.className = "cmcp-rp-body";
+
+  // Host indicator (honest: where renders run right now).
+  const host = document.createElement("div");
+  host.className = "cmcp-rp-host";
+  const hostDot = document.createElement("span");
+  hostDot.className = "cmcp-rp-dot";
+  const hostText = document.createElement("span");
+  host.append(hostDot, hostText);
+
+  // Live pod status card.
+  const card = document.createElement("div");
+  card.className = "cmcp-rp-card";
+
+  // Connect-by-id row.
+  const connectRow = document.createElement("div");
+  connectRow.className = "cmcp-rp-connect";
+  const podInput = document.createElement("input");
+  podInput.type = "text";
+  podInput.placeholder = "pod id (from console.runpod.io)";
+  podInput.spellcheck = false;
+  const connectBtn = mkBtn("Connect", "primary");
+  connectRow.append(podInput, connectBtn);
+
+  // Action buttons.
+  const actions = document.createElement("div");
+  actions.className = "cmcp-rp-actions";
+  const startBtn = mkBtn("Start");
+  const stopBtn = mkBtn("Stop");
+  const localBtn = mkBtn("Use Local");
+  const deployBtn = mkBtn("Deploy new pod", "primary");
+  actions.append(startBtn, stopBtn, localBtn, deployBtn);
+
+  const linkRow = document.createElement("div");
+  linkRow.className = "cmcp-rp-muted";
+  const linkBtn = document.createElement("a");
+  linkBtn.href = "#";
+  linkBtn.textContent = "New RunPod user? Open the deploy link (supports the project via referral) ↗";
+  linkBtn.style.color = "inherit";
+  linkRow.append(linkBtn);
+
+  const log = document.createElement("div");
+  log.className = "cmcp-rp-log";
+
+  const credit = document.createElement("div");
+  credit.className = "cmcp-rp-credit";
+  credit.innerHTML = `Pod control inspired by <a href="${GPU_CLI_URL}" target="_blank" rel="noopener">gpu-cli.sh</a>.`;
+
+  const btnRow = document.createElement("div");
+  btnRow.className = "cmcp-modal-btns";
+  const doneBtn = mkBtn("Close", "primary");
+  btnRow.append(doneBtn);
+
+  body.append(host, card, connectRow, actions, linkRow, log, credit);
+  modal.append(title, body, btnRow);
+  overlay.append(modal);
+  root.appendChild(overlay);
+
+  // ── state + rendering ──────────────────────────────────────────────────────
+  let busy = false;
+  let closed = false;
+  let tick = null;
+
+  function setLog(text, kind) {
+    log.textContent = text || "";
+    log.className = "cmcp-rp-log" + (kind ? " " + kind : "");
+  }
+
+  function currentPodId() {
+    const s = getStatus?.();
+    return (s && s.watching && s.pod_id) || (podInput.value.trim() || null);
+  }
+
+  function render() {
+    if (closed) return;
+    const s = getStatus?.() || null;
+    const t = getTarget?.() || null;
+    const onPod = t ? !t.is_local : !!(s && s.watching && s.status === "RUNNING");
+
+    // Host banner.
+    host.classList.toggle("local", !onPod);
+    host.classList.toggle("pod", onPod);
+    if (onPod && s && s.watching) {
+      const bits = [s.name || s.pod_id || "RunPod pod"];
+      if (s.gpu) bits.push(s.gpu);
+      if (s.cost_per_hr != null) bits.push(`$${Number(s.cost_per_hr).toFixed(3)}/hr`);
+      hostText.textContent = "Rendering on RunPod · " + bits.join(" · ");
+    } else if (onPod) {
+      hostText.textContent = "Rendering on a remote pod";
+    } else {
+      hostText.textContent = "Rendering locally · this machine";
+    }
+
+    // Status card.
+    card.innerHTML = "";
+    if (s && s.watching && s.pod_id) {
+      addRow(card, "Pod", `${s.name || "(unnamed)"}  ${s.pod_id}`);
+      addRow(card, "Status", s.status || "—");
+      if (s.gpu) addRow(card, "GPU", s.gpu);
+      if (s.cost_per_hr != null) addRow(card, "Cost", `$${Number(s.cost_per_hr).toFixed(3)}/hr`);
+      if (s.uptime_seconds != null) addRow(card, "Uptime", fmtUptime(s.uptime_seconds));
+      if (s.gpu_util != null) addRow(card, "GPU / VRAM", `${s.gpu_util}% / ${s.vram_util ?? "—"}%`);
+      if (s.comfyui_url) addRow(card, "ComfyUI", s.comfyui_url, true);
+      const cd = fmtCountdown(s.autostop_in_seconds);
+      if (cd && s.autostop_minutes) {
+        addRow(card, "Auto-stop", `idle — stops in ${cd}`, false, "cmcp-rp-warn");
+      } else if (s.autostop_minutes) {
+        addRow(card, "Auto-stop", `after ${s.autostop_minutes}m idle`);
+      }
+    } else {
+      const empty = document.createElement("div");
+      empty.className = "cmcp-rp-muted";
+      empty.textContent =
+        "No pod being watched. Deploy a new pod, or paste a pod ID and Connect. " +
+        "The pod runs our template, so the agent can set up your exact nodes, LoRAs and models on it.";
+      card.append(empty);
+    }
+
+    // Button enablement.
+    const running = !!(s && s.watching && s.status === "RUNNING");
+    const haveWatched = !!(s && s.watching && s.pod_id);
+    startBtn.disabled = busy || (haveWatched && running);
+    stopBtn.disabled = busy || !running;
+    localBtn.disabled = busy || !onPod;
+    deployBtn.disabled = busy;
+    connectBtn.disabled = busy;
+  }
+
+  // Re-render the idle countdown every second while a status frame is live.
+  tick = setInterval(() => {
+    const s = getStatus?.();
+    if (s && s.watching && s.autostop_in_seconds != null) render();
+  }, 1000);
+
+  async function run(label, fn) {
+    if (busy) return;
+    busy = true;
+    render();
+    setLog(label + "…", "busy");
+    try {
+      const res = await fn();
+      if (closed) return;
+      const txt = toolText(res);
+      setLog(txt, res && res.ok === false ? "err" : "");
+    } catch (err) {
+      if (!closed) setLog((err && err.message) || String(err), "err");
+    } finally {
+      busy = false;
+      if (!closed) render();
+    }
+  }
+
+  connectBtn.addEventListener("click", () => {
+    const id = podInput.value.trim();
+    if (!id) {
+      setLog("Enter a pod ID first (from the RunPod console).", "err");
+      return;
+    }
+    run("Connecting to " + id, () => callTool("runpod_pod_connect", { pod_id: id }));
+  });
+  startBtn.addEventListener("click", () => {
+    const id = currentPodId();
+    if (!id) {
+      setLog("No pod selected — paste a pod ID, or Deploy a new one.", "err");
+      return;
+    }
+    run("Starting " + id, () => callTool("runpod_pod_start", { pod_id: id }));
+  });
+  stopBtn.addEventListener("click", () => {
+    const id = currentPodId();
+    if (!id) return;
+    run("Stopping " + id, () => callTool("runpod_pod_stop", { pod_id: id }));
+  });
+  localBtn.addEventListener("click", () => {
+    run("Switching to local ComfyUI", () => callTool("runpod_use_local", {}));
+  });
+  deployBtn.addEventListener("click", () => {
+    // Deploying bills GPU-time immediately — confirm once inline.
+    if (deployBtn.dataset.armed !== "1") {
+      deployBtn.dataset.armed = "1";
+      deployBtn.textContent = "Deploy — this bills. Click to confirm";
+      setLog("A new pod bills per running GPU-second (~$0.30–0.70/hr). It idle-auto-stops, and Stop ends billing.", "");
+      setTimeout(() => {
+        if (deployBtn.dataset.armed === "1") {
+          deployBtn.dataset.armed = "0";
+          deployBtn.textContent = "Deploy new pod";
+        }
+      }, 5000);
+      return;
+    }
+    deployBtn.dataset.armed = "0";
+    deployBtn.textContent = "Deploy new pod";
+    run("Deploying a new pod", () => callTool("runpod_pod_create", {}, { timeout: 120000 }));
+  });
+  linkBtn.addEventListener("click", async (e) => {
+    e.preventDefault();
+    try {
+      const res = await callTool("runpod_deploy_link", {});
+      const txt = toolText(res);
+      const m = txt.match(/https?:\/\/console\.runpod\.io\/deploy\S+/);
+      if (m && openUrl) openUrl(m[0]);
+      else if (m) window.open(m[0], "_blank", "noopener");
+      else setLog(txt, "");
+    } catch (err) {
+      setLog((err && err.message) || String(err), "err");
+    }
+  });
+
+  const close = () => {
+    closed = true;
+    if (tick) clearInterval(tick);
+    overlay.remove();
+  };
+  doneBtn.addEventListener("click", close);
+  overlay.addEventListener("mousedown", (e) => {
+    if (e.target === overlay) close();
+  });
+
+  // Seed the pod-id field if we're already watching one.
+  const s0 = getStatus?.();
+  if (s0 && s0.watching && s0.pod_id) podInput.value = s0.pod_id;
+  if (opts.pod_id) podInput.value = opts.pod_id;
+
+  render();
+
+  return {
+    close,
+    /** Called by the panel when a new runpod_status / comfyui_target frame arrives. */
+    update() {
+      render();
+    },
+    isOpen: () => !closed,
+  };
+}
+
+function mkBtn(label, variant) {
+  const b = document.createElement("button");
+  b.type = "button";
+  b.className = "cmcp-btn" + (variant === "primary" ? " cmcp-btn-primary" : "");
+  b.textContent = label;
+  return b;
+}
+function addRow(parent, k, v, mono, vClass) {
+  const row = document.createElement("div");
+  row.className = "cmcp-rp-row";
+  const kk = document.createElement("span");
+  kk.className = "k";
+  kk.textContent = k;
+  const vv = document.createElement("span");
+  vv.className = "v" + (vClass ? " " + vClass : "");
+  if (mono) vv.style.fontFamily = "ui-monospace,monospace";
+  vv.textContent = v;
+  row.append(kk, vv);
+  parent.append(row);
+}

--- a/web/js/cmcp-runpod-ui.js
+++ b/web/js/cmcp-runpod-ui.js
@@ -356,29 +356,44 @@ export function openRunpodModal(ctx, opts = {}) {
   localBtn.addEventListener("click", () => {
     run("Switching to local ComfyUI", () => callTool("runpod_use_local", {}));
   });
-  // Confirm must be two DISTINCT human decisions, not one double-click. Arming
-  // opens a short cool-down window during which confirm clicks (and keyboard
-  // repeat on Enter/Space) are ignored, so an accidental double-click can't bill.
+  // Confirm must be two DISTINCT human decisions, not one gesture. Arming opens
+  // a short cool-down that ignores confirm clicks (rapid double-click), and a
+  // keydown guard suppresses held-key autorepeat entirely — a held Enter fires
+  // repeated click events, and time-elapsed alone would let one through once the
+  // cool-down passes. A fresh discrete click, or a fresh Enter/Space keypress
+  // (repeat=false), after the cool-down still confirms.
   const DEPLOY_ARM_COOLDOWN_MS = 600;
   let deployArmedAt = 0;
+  let deployArmGen = 0; // bumped each arming so a stale disarm timer is inert
+  // Swallow the activation an auto-repeating Enter/Space would synthesize, so a
+  // held key can never produce the confirming click. Discrete presses pass.
+  deployBtn.addEventListener("keydown", (e) => {
+    if (e.repeat && (e.key === "Enter" || e.key === " " || e.key === "Spacebar")) {
+      e.preventDefault();
+    }
+  });
   deployBtn.addEventListener("click", () => {
     // Deploying bills GPU-time immediately — confirm once inline.
     if (deployBtn.dataset.armed !== "1") {
       deployBtn.dataset.armed = "1";
       deployArmedAt = Date.now();
+      const gen = ++deployArmGen;
       deployBtn.textContent = "Deploy — this bills. Click to confirm";
       setLog("A new pod bills per running GPU-second (~$0.30–0.70/hr). It idle-auto-stops; Stop ends GPU billing (disk storage still bills until you terminate the pod in the console).", "");
       setTimeout(() => {
-        if (deployBtn.dataset.armed === "1") {
+        // Only disarm the arming that scheduled this timer — a newer arm (e.g.
+        // after a deploy completes and re-arms) must not be cleared by an old one.
+        if (deployBtn.dataset.armed === "1" && deployArmGen === gen) {
           deployBtn.dataset.armed = "0";
           deployBtn.textContent = "Deploy new pod";
         }
       }, 5000);
       return;
     }
-    // Ignore a confirm that lands inside the cool-down (a double-click / key
-    // repeat is not a second human decision). Keep it armed so a real click works.
+    // Ignore a confirm that lands inside the cool-down (a double-click is not a
+    // second human decision). Keep it armed so a real click still works.
     if (Date.now() - deployArmedAt < DEPLOY_ARM_COOLDOWN_MS) return;
+    deployArmGen++; // invalidate the pending disarm timer for this arming
     deployBtn.dataset.armed = "0";
     deployBtn.textContent = "Deploy new pod";
     run("Deploying a new pod", () => callTool("runpod_pod_create", {}, { timeout: 120000 })).then((ok) => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10004,7 +10004,10 @@ function buildPanel() {
   function reflectRunpodHost() {
     const t = _comfyuiTarget;
     const s = _runpodStatus;
-    const onPod = t ? !t.is_local : !!(s && s.watching && s.status === "RUNNING");
+    // Honesty: "on pod" comes ONLY from the comfyui_target frame — a watched
+    // RUNNING pod does NOT mean renders go there (runpod_watch broadcasts status
+    // without retargeting). Default to Local when the target is unknown.
+    const onPod = !!(t && !t.is_local);
     const label = runpodBtn.querySelector("span");
     if (onPod && s && s.watching) {
       label.textContent = s.name || s.pod_id || "RunPod";

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -74,6 +74,7 @@ import {
 } from "./lib/workflow-chat-identity.js";
 import { validateA2UISpec, renderA2UICard, renderA2UIInert, renderA2UIFailCard, A2UI_CSS } from "./cmcp-a2ui.js";
 import { openCivitaiModal } from "./cmcp-civitai-ui.js";
+import { openRunpodModal } from "./cmcp-runpod-ui.js";
 import { openTrainingModal } from "./cmcp-training-ui.js";
 
 let app = null;
@@ -6705,7 +6706,7 @@ const RECONNECT_MAX_MS = 15000;
 let AGENT_MUTED = (() => { try { return localStorage.getItem("cmcp.muteAgents") === "1"; } catch { return false; } })();
 let AGENT_BLIND = (() => { try { return localStorage.getItem("cmcp.blindAgents") === "1"; } catch { return false; } })();
 
-function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk, onSecret, onSecretSaved, onReload, onTodo, onShowMedia, onOpenCivitai, onUiRender, onUiUpdate, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onBackends, onAck, onTurn, onTurnAnchor, getResume, getBackend, onHandshakeTimeout, onBridgeClosed, onPairUrl, onPairError }) {
+function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk, onSecret, onSecretSaved, onReload, onTodo, onShowMedia, onOpenCivitai, onUiRender, onUiUpdate, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onBackends, onAck, onTurn, onTurnAnchor, getResume, getBackend, onHandshakeTimeout, onBridgeClosed, onPairUrl, onPairError, onRunpodStatus, onComfyuiTarget }) {
   let sock = null;
   let url = loadBridgeUrl();
   let closed = false;
@@ -7053,6 +7054,16 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
       // from the download tool's temp progress file and/or the Manager queue).
       if (msg && msg.type === "download_progress" && Array.isArray(msg.downloads)) {
         onDownloads?.(msg.downloads);
+      }
+      // Live RunPod pod status (services/runpod-watch.ts) → control panel + host
+      // indicator. Change-only frames; a cleared frame (watching:false) means no
+      // pod is being watched.
+      if (msg && msg.type === "runpod_status") {
+        onRunpodStatus?.(msg);
+      }
+      // Honest host indicator: where renders currently run (local ⇄ pod).
+      if (msg && msg.type === "comfyui_target") {
+        onComfyuiTarget?.(msg);
       }
       // Live extended-thinking token count → "thinking… (N)" indicator.
       if (msg && msg.type === "thinking" && typeof msg.tokens === "number") {
@@ -8263,6 +8274,10 @@ function renderRichText(el, text) {
 // clean 1005 closes). Tracking the live client at module scope and tearing down
 // any prior one before creating a new one makes the storm structurally impossible.
 let liveBridgeClient = null;
+// RunPod host indicator/control bridge: the toolbar closure publishes handlers
+// here so the (separately-scoped) createBridgeClient callbacks can forward
+// `runpod_status` / `comfyui_target` frames to the host pill + open modal.
+let panelRunpod = null;
 // (MDC's fork also proxied all client callbacks through a module-level
 // `panelSink` so the client could outlive panel re-mounts. Upstream's sidebar
 // KEEP-ALIVE already keeps buildPanel a page singleton whose root is detached/
@@ -9951,9 +9966,81 @@ function buildPanel() {
     trainingBtn.prepend(svg);
   }
 
+  // RunPod — cloud GPU control panel + honest host indicator. The button label
+  // reflects WHERE renders run (Local vs the pod), so it doubles as the host
+  // pill; clicking opens the control modal (deploy / start / stop / connect /
+  // use-local). Driven by the orchestrator's `runpod_status` + `comfyui_target`
+  // frames (wired below). The pod runs our template → full canvas parity.
+  let _runpodHandle = null;
+  let _runpodStatus = null; // last runpod_status frame
+  let _comfyuiTarget = null; // last comfyui_target frame
+  const runpodBtn = toolbarBtn("pi-circle", "Local");
+  runpodBtn.querySelector(".pi").remove();
+  runpodBtn.title = "RunPod — run this session on a cloud GPU (deploy / start / stop / connect), or switch back to local.";
+  {
+    const svgNs = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(svgNs, "svg");
+    svg.setAttribute("viewBox", "0 0 24 24");
+    svg.setAttribute("fill", "none");
+    svg.setAttribute("stroke", "currentColor");
+    svg.setAttribute("stroke-width", "2");
+    svg.setAttribute("stroke-linecap", "round");
+    svg.setAttribute("stroke-linejoin", "round");
+    svg.setAttribute("aria-hidden", "true");
+    // Two stacked server bricks (cloud-GPU rack).
+    const r1 = document.createElementNS(svgNs, "rect");
+    r1.setAttribute("x", "3"); r1.setAttribute("y", "4"); r1.setAttribute("width", "18");
+    r1.setAttribute("height", "7"); r1.setAttribute("rx", "1.5");
+    const r2 = document.createElementNS(svgNs, "rect");
+    r2.setAttribute("x", "3"); r2.setAttribute("y", "13"); r2.setAttribute("width", "18");
+    r2.setAttribute("height", "7"); r2.setAttribute("rx", "1.5");
+    const d1 = document.createElementNS(svgNs, "line");
+    d1.setAttribute("x1", "7"); d1.setAttribute("y1", "7.5"); d1.setAttribute("x2", "7"); d1.setAttribute("y2", "7.5");
+    const d2 = document.createElementNS(svgNs, "line");
+    d2.setAttribute("x1", "7"); d2.setAttribute("y1", "16.5"); d2.setAttribute("x2", "7"); d2.setAttribute("y2", "16.5");
+    svg.append(r1, r2, d1, d2);
+    runpodBtn.prepend(svg);
+  }
+  function reflectRunpodHost() {
+    const t = _comfyuiTarget;
+    const s = _runpodStatus;
+    const onPod = t ? !t.is_local : !!(s && s.watching && s.status === "RUNNING");
+    const label = runpodBtn.querySelector("span");
+    if (onPod && s && s.watching) {
+      label.textContent = s.name || s.pod_id || "RunPod";
+    } else if (onPod) {
+      label.textContent = "RunPod";
+    } else {
+      label.textContent = "Local";
+    }
+    runpodBtn.classList.toggle("cmcp-runpod-onpod", onPod);
+    runpodBtn.style.color = onPod ? "#60a5fa" : "";
+    const gpu = s && s.watching && s.gpu ? ` · ${s.gpu}` : "";
+    const cost = s && s.watching && s.cost_per_hr != null ? ` · $${Number(s.cost_per_hr).toFixed(3)}/hr` : "";
+    runpodBtn.title = onPod
+      ? `Rendering on RunPod${gpu}${cost} — click to manage the pod or switch back to local.`
+      : "Rendering locally on this machine — click to run this session on a cloud GPU (RunPod).";
+  }
+  runpodBtn.addEventListener("click", () => {
+    try { _runpodHandle?.close(); } catch {}
+    _runpodHandle = openRunpodModal({
+      root,
+      callTool: (tool, args, o) => liveBridgeClient?.callTool(tool, args, o),
+      getStatus: () => _runpodStatus,
+      getTarget: () => _comfyuiTarget,
+      openUrl: (u) => { try { window.open(u, "_blank", "noopener"); } catch {} },
+    });
+  });
+  // Expose for the bridge callbacks (defined outside this closure).
+  panelRunpod = {
+    onStatus: (frame) => { _runpodStatus = frame; reflectRunpodHost(); if (_runpodHandle?.isOpen?.()) _runpodHandle.update(); },
+    onTarget: (frame) => { _comfyuiTarget = frame; reflectRunpodHost(); if (_runpodHandle?.isOpen?.()) _runpodHandle.update(); },
+  };
+  reflectRunpodHost();
+
   const toolbarSpacer = document.createElement("span");
   toolbarSpacer.className = "cmcp-spacer";
-  toolbar.append(deafenBtn, blindBtn, toolbarSpacer, civitaiBtn, trainingBtn);
+  toolbar.append(deafenBtn, blindBtn, toolbarSpacer, civitaiBtn, trainingBtn, runpodBtn);
 
   row.append(ring, ctxLabel, modelChip, spacer, attachBtn, micBtn, sendBtn);
   form.append(menuPop, modelPop, attachBar, input, row, fileInput);
@@ -11557,6 +11644,14 @@ function buildPanel() {
     // Orchestrator pushed live download progress → render rows in the tray.
     onDownloads(list) {
       renderDownloads(list);
+    },
+    // Live RunPod pod status → the host pill + open control modal.
+    onRunpodStatus(frame) {
+      panelRunpod?.onStatus(frame);
+    },
+    // Honest host indicator (local ⇄ pod) → the host pill + open control modal.
+    onComfyuiTarget(frame) {
+      panelRunpod?.onTarget(frame);
     },
     // Live extended-thinking token count → update the working indicator.
     onThinking(tokens) {


### PR DESCRIPTION
Companion to orchestrator PR artokun/comfyui-mcp#251 and mobile PR artokun/comfyui-mcp-mobile (feat/runpod-control).

In-panel RunPod control modal + honest host indicator, driven by the orchestrator's `runpod_status` + `comfyui_target` broadcasts.

## What
- **cmcp-runpod-ui.js** — control modal: live pod status (GPU/VRAM/uptime/$hr/idle-countdown) and one-tap **deploy / start / stop / connect / use-local** over the whitelisted `runpod_*` tools via `callTool` (no agent turn). Deploy is confirm-armed (it bills). gpu-cli.sh credit.
- **Toolbar 'RunPod' button doubles as the honest host pill** — label + tint reflect where renders run (Local vs the pod name); tooltip shows GPU/$hr.
- Bridge client dispatches the two new frames to the pill + open modal.

The pod runs our template, so once connected the agent installs the user's exact custom nodes / LoRAs → full canvas parity remotely.

## Notes
- Stacks on `feat/training-panel-ux` (shares the toolbar append line); merge that first or rebase.
- ESM parse verified; needs a live panel smoke test (reload ComfyUI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)