### PR TITLE
Add workflow-scoped chat identity

### DIFF
--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -4,7 +4,8 @@ import test from 'node:test'
 import {
   isThreadInScope,
   normalizedWorkflowPath,
-  shouldForkEmbeddedWorkflowUuid
+  shouldForkEmbeddedWorkflowUuid,
+  workflowAliasForPath
 } from '../../web/js/lib/workflow-chat-identity.js'
 
 test('normalizes Windows paths for stable identity comparisons', () => {
@@ -51,6 +52,13 @@ test('keeps the canonical path when stale aliases still mention the same UUID', 
       'workflows/current.json': 'same-uuid'
     }
   }), false)
+})
+
+test('reuses the path alias minted for an unsaved fork after a browser restart', () => {
+  assert.equal(workflowAliasForPath({
+    'workflows/original.json': 'embedded-original',
+    'Workflows\\Copy.JSON': 'stable-fork'
+  }, 'workflows/copy.json'), 'stable-fork')
 })
 
 test('scope guard authorizes only an exact workflow UUID key', () => {

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  isThreadInScope,
+  normalizedWorkflowPath,
+  shouldForkEmbeddedWorkflowUuid
+} from '../../web/js/lib/workflow-chat-identity.js'
+
+test('normalizes Windows paths for stable identity comparisons', () => {
+  assert.equal(
+    normalizedWorkflowPath('Workflows\\Portrait.JSON'),
+    'workflows/portrait.json'
+  )
+})
+
+test('forks a copied workflow with an embedded UUID on a clean browser', () => {
+  assert.equal(shouldForkEmbeddedWorkflowUuid({
+    embeddedUuid: 'same-uuid',
+    embeddedPath: 'workflows/original.json',
+    currentPath: 'workflows/copy.json'
+  }), true)
+})
+
+test('keeps identity for the same live object during rename or Save As', () => {
+  assert.equal(shouldForkEmbeddedWorkflowUuid({
+    objectUuid: 'same-uuid',
+    embeddedUuid: 'same-uuid',
+    embeddedPath: 'workflows/original.json',
+    currentPath: 'workflows/renamed.json'
+  }), false)
+})
+
+test('forks repeated aliases even for old workflows without an embedded path', () => {
+  assert.equal(shouldForkEmbeddedWorkflowUuid({
+    embeddedUuid: 'same-uuid',
+    currentPath: 'workflows/copy.json',
+    aliases: {
+      'workflows/original.json': 'same-uuid'
+    }
+  }), true)
+})
+
+test('keeps the canonical path when stale aliases still mention the same UUID', () => {
+  assert.equal(shouldForkEmbeddedWorkflowUuid({
+    embeddedUuid: 'same-uuid',
+    embeddedPath: 'workflows/current.json',
+    currentPath: 'workflows/current.json',
+    aliases: {
+      'workflows/old-name.json': 'same-uuid',
+      'workflows/current.json': 'same-uuid'
+    }
+  }), false)
+})
+
+test('scope guard authorizes only an exact workflow UUID key', () => {
+  const thread = { workflowKey: 'workflow:abc-123' }
+  assert.equal(isThreadInScope(thread, 'workflow:abc-123'), true)
+  assert.equal(isThreadInScope(thread, 'workflow:abc'), false)
+  assert.equal(isThreadInScope(thread, 'workflow:abc-123-copy'), false)
+  assert.equal(isThreadInScope(thread, ''), false)
+})

--- a/browser_tests/workflow-chat-identity.spec.ts
+++ b/browser_tests/workflow-chat-identity.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from './fixtures/panelTest'
+
+const THREADS_KEY = 'comfyui-mcp.panel.threads'
+const CURRENT_THREAD_KEY = 'comfyui-mcp.panel.currentThreadId'
+
+test('embeds a workflow UUID and blocks a foreign transcript pointer', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  // Make the legacy per-workflow setting available before the panel mounts and
+  // after reload; the shared fixture intentionally strips real user settings.
+  await page.route(
+    (url) => /\/(api\/)?settings\/?$/.test(url.pathname),
+    async (route) => {
+      const response = await route.fetch()
+      const settings = await response.json() as Record<string, unknown>
+      settings['comfyui-mcp.sessionFollowsPanel'] = false
+      await route.fulfill({ response, json: settings })
+    }
+  )
+
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  const received = mockBridge.waitForUserMessage()
+  await panel.sendMessage('workflow identity marker')
+  await received
+
+  const current = await page.evaluate((threadsKey) => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const threads = JSON.parse(localStorage.getItem(threadsKey) || '[]')
+    return {
+      uuid: app?.graph?.extra?.comfyui_mcp?.workflow_uuid,
+      thread: threads.find((t: any) => t.msgs?.some((m: any) => m.text === 'workflow identity marker'))
+    }
+  }, THREADS_KEY)
+
+  expect(current.uuid).toMatch(/^[0-9a-f-]{36}$/i)
+  expect(current.thread?.workflowKey).toBe(`workflow:${current.uuid}`)
+
+  await page.evaluate(({ threadsKey, currentThreadKey }) => {
+    const threads = JSON.parse(localStorage.getItem(threadsKey) || '[]')
+    threads.push({
+      id: 'foreign-thread',
+      ts: Date.now() + 10,
+      workflowKey: 'workflow:definitely-another-workflow',
+      msgs: [{ role: 'user', text: 'must never restore on this workflow' }]
+    })
+    localStorage.setItem(threadsKey, JSON.stringify(threads))
+    sessionStorage.setItem(currentThreadKey, 'foreign-thread')
+  }, { threadsKey: THREADS_KEY, currentThreadKey: CURRENT_THREAD_KEY })
+
+  await page.reload()
+  await panel.openSidebar()
+  await expect(panel.userBubble('must never restore on this workflow')).toHaveCount(0)
+
+  await panel.root.locator('button[title="Chat history"]').click()
+  const foreign = panel.root.locator('.cmcp-hist-row').filter({ hasText: 'must never restore on this workflow' })
+  await expect(foreign).toBeVisible()
+  await expect(foreign.locator('.cmcp-hist-open')).toBeDisabled()
+})

--- a/browser_tests/workflow-chat-identity.spec.ts
+++ b/browser_tests/workflow-chat-identity.spec.ts
@@ -2,6 +2,170 @@ import { test, expect } from './fixtures/panelTest'
 
 const THREADS_KEY = 'comfyui-mcp.panel.threads'
 const CURRENT_THREAD_KEY = 'comfyui-mcp.panel.currentThreadId'
+const SESSION_KEY = 'comfyui-mcp.panel.sessionId'
+
+test('opening a workflow does not dirty it and first record embeds silently', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  await page.route(
+    (url) => /\/(api\/)?settings\/?$/.test(url.pathname),
+    async (route) => {
+      const response = await route.fetch()
+      const settings = await response.json() as Record<string, unknown>
+      settings['comfyui-mcp.sessionFollowsPanel'] = false
+      await route.fulfill({ response, json: settings })
+    }
+  )
+
+  await panel.goto()
+  await page.waitForFunction(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    return !!app?.graph && !!app?.extensionManager?.workflow?.activeWorkflow
+  })
+  const before = await page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const graph = app.graph
+    const workflow = app.extensionManager?.workflow?.activeWorkflow
+    if (graph.extra?.comfyui_mcp) delete graph.extra.comfyui_mcp
+    w.__cmcpIdentityMutationCalls = { before: 0, after: 0, dirty: 0 }
+    const originalBefore = graph.beforeChange?.bind(graph)
+    const originalAfter = graph.afterChange?.bind(graph)
+    const originalDirty = graph.setDirtyCanvas?.bind(graph)
+    graph.beforeChange = (...args: unknown[]) => {
+      w.__cmcpIdentityMutationCalls.before++
+      return originalBefore?.(...args)
+    }
+    graph.afterChange = (...args: unknown[]) => {
+      w.__cmcpIdentityMutationCalls.after++
+      return originalAfter?.(...args)
+    }
+    graph.setDirtyCanvas = (...args: unknown[]) => {
+      w.__cmcpIdentityMutationCalls.dirty++
+      return originalDirty?.(...args)
+    }
+    return { isModified: workflow?.isModified ?? null }
+  })
+
+  await panel.openSidebar()
+  await page.waitForTimeout(700)
+  const opened = await page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const workflow = app.extensionManager?.workflow?.activeWorkflow
+    return {
+      isModified: workflow?.isModified ?? null,
+      calls: w.__cmcpIdentityMutationCalls
+    }
+  })
+  expect(opened.isModified).toBe(before.isModified)
+  expect(opened.calls).toEqual({ before: 0, after: 0, dirty: 0 })
+
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.connect()
+  const recorded = await page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    return {
+      uuid: app.graph?.extra?.comfyui_mcp?.workflow_uuid,
+      calls: w.__cmcpIdentityMutationCalls
+    }
+  })
+  expect(recorded.uuid).toMatch(/^[0-9a-f-]{36}$/i)
+  expect(recorded.calls).toEqual({ before: 0, after: 0, dirty: 0 })
+})
+
+test('default mode opens pre-upgrade history without re-keying it', async ({
+  page,
+  panel
+}) => {
+  await panel.goto()
+  await page.evaluate(({ threadsKey, currentThreadKey }) => {
+    localStorage.setItem(threadsKey, JSON.stringify([
+      {
+        id: 'old-current',
+        ts: Date.now() - 10,
+        workflowKey: 'wf:workflows/original.json',
+        msgs: [{ role: 'user', text: 'old current thread' }]
+      },
+      {
+        id: 'old-secondary',
+        ts: Date.now(),
+        workflowKey: 'wf:workflows/another.json',
+        msgs: [{ role: 'user', text: 'old secondary thread' }]
+      }
+    ]))
+    sessionStorage.setItem(currentThreadKey, 'old-current')
+  }, { threadsKey: THREADS_KEY, currentThreadKey: CURRENT_THREAD_KEY })
+
+  await panel.openSidebar()
+  await expect(panel.userBubble('old current thread')).toBeVisible()
+  await panel.root.locator('button[title="Chat history"]').click()
+  const secondary = panel.root.locator('.cmcp-hist-row').filter({ hasText: 'old secondary thread' })
+  await expect(secondary.locator('.cmcp-hist-open')).toBeEnabled()
+  await secondary.locator('.cmcp-hist-open').click()
+  await expect(panel.userBubble('old secondary thread')).toBeVisible()
+
+  const keys = await page.evaluate((threadsKey) =>
+    JSON.parse(localStorage.getItem(threadsKey) || '[]').map((t: any) => [t.id, t.workflowKey]),
+  THREADS_KEY)
+  expect(keys).toEqual([
+    ['old-current', 'wf:workflows/original.json'],
+    ['old-secondary', 'wf:workflows/another.json']
+  ])
+})
+
+test('settings hydration cannot rewrite a workflow thread or clear the live session', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  await panel.goto()
+  await page.evaluate(({ threadsKey, currentThreadKey }) => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const settings = app.ui.settings
+    const originalGet = settings.getSettingValue.bind(settings)
+    w.__cmcpPerWorkflowHydrated = false
+    settings.getSettingValue = (id: string) =>
+      id === 'comfyui-mcp.sessionFollowsPanel'
+        ? !w.__cmcpPerWorkflowHydrated
+        : originalGet(id)
+    localStorage.setItem(threadsKey, JSON.stringify([{
+      id: 'workflow-before-hydration',
+      ts: Date.now(),
+      workflowKey: 'workflow:existing-scope',
+      msgs: [{ role: 'user', text: 'workflow thread before hydration' }]
+    }]))
+    sessionStorage.setItem(currentThreadKey, 'workflow-before-hydration')
+  }, { threadsKey: THREADS_KEY, currentThreadKey: CURRENT_THREAD_KEY })
+
+  await panel.openSidebar()
+  await expect(panel.userBubble('workflow thread before hydration')).toBeVisible()
+  await page.evaluate((sessionKey) => {
+    const w = window as any
+    w.__cmcpPerWorkflowHydrated = true
+    sessionStorage.setItem(sessionKey, 'live-tab-session')
+  }, SESSION_KEY)
+
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.connect()
+
+  const state = await page.evaluate(({ threadsKey, sessionKey }) => ({
+    sessionId: sessionStorage.getItem(sessionKey),
+    threads: JSON.parse(localStorage.getItem(threadsKey) || '[]')
+  }), { threadsKey: THREADS_KEY, sessionKey: SESSION_KEY })
+  expect(state.sessionId).toBe('live-tab-session')
+  expect(state.threads.find((t: any) => t.id === 'workflow-before-hydration')?.workflowKey)
+    .toBe('workflow:existing-scope')
+  const greetingThread = state.threads.find((t: any) =>
+    t.msgs?.some((m: any) => m.text === 'Panel agent ready.'))
+  expect(greetingThread?.workflowKey).toMatch(/^workflow:/)
+  expect(greetingThread?.sessionId).toBe('live-tab-session')
+})
 
 test('embeds a workflow UUID and blocks a foreign transcript pointer', async ({
   page,
@@ -62,4 +226,5 @@ test('embeds a workflow UUID and blocks a foreign transcript pointer', async ({
   const foreign = panel.root.locator('.cmcp-hist-row').filter({ hasText: 'must never restore on this workflow' })
   await expect(foreign).toBeVisible()
   await expect(foreign.locator('.cmcp-hist-open')).toBeDisabled()
+  await expect(foreign).toHaveCSS('opacity', '0.48')
 })

--- a/browser_tests/workflow-chat-identity.spec.ts
+++ b/browser_tests/workflow-chat-identity.spec.ts
@@ -12,6 +12,7 @@ test('opening a workflow does not dirty it and first record embeds silently', as
   await page.route(
     (url) => /\/(api\/)?settings\/?$/.test(url.pathname),
     async (route) => {
+      if (route.request().method() !== 'GET') return route.continue()
       const response = await route.fetch()
       const settings = await response.json() as Record<string, unknown>
       settings['comfyui-mcp.sessionFollowsPanel'] = false
@@ -177,6 +178,7 @@ test('embeds a workflow UUID and blocks a foreign transcript pointer', async ({
   await page.route(
     (url) => /\/(api\/)?settings\/?$/.test(url.pathname),
     async (route) => {
+      if (route.request().method() !== 'GET') return route.continue()
       const response = await route.fetch()
       const settings = await response.json() as Record<string, unknown>
       settings['comfyui-mcp.sessionFollowsPanel'] = false

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -70,6 +70,7 @@ import {
   isThreadInScope,
   normalizedWorkflowPath,
   shouldForkEmbeddedWorkflowUuid,
+  workflowAliasForPath,
 } from "./lib/workflow-chat-identity.js";
 import { validateA2UISpec, renderA2UICard, renderA2UIInert, renderA2UIFailCard, A2UI_CSS } from "./cmcp-a2ui.js";
 import { openCivitaiModal } from "./cmcp-civitai-ui.js";
@@ -721,6 +722,25 @@ function persistWorkflowAliases() {
   }
 }
 
+function workflowUuidOwner(id) {
+  const stored = _workflowUuidOwners.get(id);
+  const owner = stored && typeof stored.deref === "function" ? stored.deref() ?? null : stored ?? null;
+  if (!owner) _workflowUuidOwners.delete(id);
+  return owner;
+}
+
+function rememberWorkflowUuidOwner(id, owner) {
+  _workflowUuidOwners.set(id, typeof WeakRef === "function" ? new WeakRef(owner) : owner);
+  // WeakRef is unavailable only on older embedded browsers. Keep that fallback
+  // bounded rather than retaining every workflow object for the life of the page.
+  if (typeof WeakRef !== "function" && _workflowUuidOwners.size > 64) {
+    for (const key of _workflowUuidOwners.keys()) {
+      if (key !== id) _workflowUuidOwners.delete(key);
+      if (_workflowUuidOwners.size <= 64) break;
+    }
+  }
+}
+
 /** Stable transcript identity, deliberately separate from workflowTabId(): the
  *  latter is bridge routing, while this UUID follows a workflow across rename.
  *  Copies carrying the same embedded UUID get a fresh identity when opened as a
@@ -732,9 +752,10 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
   const objectUuid = _workflowObjectUuids.get(identityObject);
   const embedded = embeddedWorkflowUuid(wf);
   const embeddedPath = embeddedWorkflowPath(wf);
-  let id = objectUuid || embedded || (path ? _workflowUuidAliases[path] : null) || crypto.randomUUID();
+  const pathAlias = workflowAliasForPath(_workflowUuidAliases, path);
+  let id = objectUuid || embedded || pathAlias || crypto.randomUUID();
 
-  const embeddedOwner = embedded ? _workflowUuidOwners.get(embedded) : null;
+  const embeddedOwner = embedded ? workflowUuidOwner(embedded) : null;
   if (!objectUuid && embeddedOwner && embeddedOwner !== identityObject) id = crypto.randomUUID();
   if (
     wf !== currentWorkflowRef &&
@@ -746,11 +767,14 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
       aliases: _workflowUuidAliases,
     })
   ) {
-    id = crypto.randomUUID();
+    // A previously-opened but not-yet-saved copy still carries the source UUID
+    // in its JSON. Its path alias is the durable fork identity until the next
+    // user-initiated save embeds it, so reuse that alias across browser restarts.
+    id = pathAlias && pathAlias !== embedded ? pathAlias : crypto.randomUUID();
   }
 
   _workflowObjectUuids.set(identityObject, id);
-  _workflowUuidOwners.set(id, identityObject);
+  rememberWorkflowUuidOwner(id, identityObject);
   if (objectUuid && path) {
     // Rename/Save-As mutates the same live workflow object. Drop stale aliases
     // so a cold start does not later misclassify the renamed file as a clone.
@@ -770,15 +794,13 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
       const previous = extra?.[WORKFLOW_META_NAMESPACE];
       const pathChanged = path && normalizedWorkflowPath(previous?.[WORKFLOW_PATH_FIELD]) !== normalizedWorkflowPath(path);
       if (extra && (previous?.[WORKFLOW_UUID_FIELD] !== id || pathChanged)) {
-        app?.graph?.beforeChange?.();
+        // Transcript metadata silently rides the next save the user initiates.
+        // It must never create a dirty asterisk or an undo/graph-change entry.
         extra[WORKFLOW_META_NAMESPACE] = {
           ...(previous && typeof previous === "object" ? previous : {}),
           [WORKFLOW_UUID_FIELD]: id,
           ...(path ? { [WORKFLOW_PATH_FIELD]: path } : {}),
         };
-        app?.graph?.afterChange?.();
-        app?.graph?.setDirtyCanvas?.(true, true);
-        try { wf.isModified = true; } catch { /* getter-only on older builds */ }
       }
     } catch {
       // The path alias still makes the identity durable in this browser.
@@ -7915,6 +7937,8 @@ const PANEL_CSS = `
 /* History rows: open button + trash, revealed on hover. */
 .cmcp-hist-row { display: flex; align-items: stretch; gap: 0.125rem; }
 .cmcp-hist-row .cmcp-hist-open { flex: 1 1 auto; min-width: 0; }
+.cmcp-hist-row.foreign-workflow { opacity: 0.48; }
+.cmcp-hist-row.foreign-workflow .cmcp-hist-open { cursor: not-allowed; }
 .cmcp-hist-del {
   flex: none; width: 1.75rem; border: none; background: transparent; cursor: pointer;
   color: var(--p-text-muted-color, #a1a1aa); border-radius: var(--p-border-radius-sm, 4px);
@@ -9999,7 +10023,7 @@ function buildPanel() {
   let thread = null; // created lazily on first recorded message
 
   function currentTranscriptScopeKey({ embed = false } = {}) {
-    return sessionFollowsPanel() ? "panel:global" : workflowStorageKey({ embed });
+    return sessionFollowsPanel() ? workflowTabId() : workflowStorageKey({ embed });
   }
 
   function persistThreads() {
@@ -10030,13 +10054,13 @@ function buildPanel() {
   }
 
   function record(entry) {
-    const scopeKey = currentTranscriptScopeKey({ embed: !sessionFollowsPanel() });
+    const perWorkflow = !sessionFollowsPanel();
+    const scopeKey = perWorkflow ? workflowStorageKey({ embed: true }) : workflowTabId();
     // Settings can hydrate after a greeting was painted. Never append a real
     // workflow-scoped message to a thread carrying another scope.
-    if (thread && !sessionFollowsPanel() && !isThreadInScope(thread, scopeKey)) {
+    if (thread && perWorkflow && !isThreadInScope(thread, scopeKey)) {
       thread = null;
       ssSet(CURRENT_THREAD_KEY, null);
-      ssSet(SESSION_KEY, null);
     }
     if (!thread) {
       thread = { id: crypto.randomUUID(), ts: Date.now(), msgs: [], workflowKey: scopeKey };
@@ -11012,8 +11036,7 @@ function buildPanel() {
   }
 
   function loadThread(t) {
-    const scopeKey = currentTranscriptScopeKey();
-    if (!isThreadInScope(t, scopeKey)) {
+    if (!sessionFollowsPanel() && !isThreadInScope(t, workflowStorageKey())) {
       appendSystem("Blocked a chat from another workflow. Open its owning workflow before resuming it.");
       return false;
     }
@@ -11059,7 +11082,6 @@ function buildPanel() {
     const wfid = workflowTabId();
     const wfkey = wf ? (wf.key || wf.id || "unsaved") : null;
     if (wfid === currentWorkflowId) return; // case 1: no change
-    const historyKey = currentTranscriptScopeKey({ embed: !sessionFollowsPanel() });
 
     // PANEL-OWNED SESSION (default): the conversation is the unit of continuity
     // and the workflow is just the canvas target — switching, saving, renaming,
@@ -11076,7 +11098,7 @@ function buildPanel() {
       // tmp→wf adopt bookkeeping (a save gave the unsaved workflow a real id).
       if (wfid.startsWith("wf:") && wf && (wf.key || wf.id)) _tempWorkflowIds.delete(wf.key || wf.id);
       if (thread) {
-        thread.workflowKey = "panel:global";
+        thread.workflowKey = wfid; // thread rides along for archive provenance
         thread.ts = Date.now();
         persistThreads();
       }
@@ -11099,6 +11121,10 @@ function buildPanel() {
       }
       return;
     }
+
+    // Identity is read-only while switching/opening. Embedding happens only on
+    // first record(), and even then silently, so viewing a workflow never dirties it.
+    const historyKey = workflowStorageKey();
 
     const adopting =
       currentWorkflowId &&
@@ -14420,11 +14446,24 @@ function buildPanel() {
     try {
       const cur = ssGet(CURRENT_THREAD_KEY);
       const pointed = cur ? threads.find((x) => x.id === cur) : null;
-      const scopeKey = currentTranscriptScopeKey();
-      if (sessionFollowsPanel() && pointed && pointed.workflowKey !== "panel:global") {
-        pointed.workflowKey = "panel:global";
-        persistThreads();
+      if (sessionFollowsPanel()) {
+        // Main/default behavior: restore the pointed chat exactly as stored.
+        // Settings may not be hydrated yet, so this path must never rewrite keys.
+        if (!pointed || !pointed.msgs?.length) return;
+        thread = pointed;
+        resetFeed();
+        for (const m of pointed.msgs) {
+          if (m.role === "user") paintUser(m.text, { attachments: m.attachments });
+          else if (m.role === "agent") paintAgent(m.text);
+          else if (m.role === "card") {
+            if (m.kind === "a2ui") paintA2UIRecord(m);
+            else paintCard(m);
+          }
+        }
+        renderTodo(pointed.todos || []);
+        return;
       }
+      const scopeKey = workflowStorageKey();
       const scopedPointed = pointed && isThreadInScope(pointed, scopeKey) ? pointed : null;
       const t = scopedPointed || threadForWorkflow(scopeKey);
       if (!t || !t.msgs?.length) return;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -66,6 +66,11 @@ import { marked } from "./vendor/marked.esm.js";
 import DOMPurify from "./vendor/purify.es.js";
 import qrcodegen from "./vendor/qrcode.esm.js";
 import { computeLayout } from "./lib/layout-engine.js";
+import {
+  isThreadInScope,
+  normalizedWorkflowPath,
+  shouldForkEmbeddedWorkflowUuid,
+} from "./lib/workflow-chat-identity.js";
 import { validateA2UISpec, renderA2UICard, renderA2UIInert, renderA2UIFailCard, A2UI_CSS } from "./cmcp-a2ui.js";
 import { openCivitaiModal } from "./cmcp-civitai-ui.js";
 import { openTrainingModal } from "./cmcp-training-ui.js";
@@ -638,6 +643,20 @@ function getTabId() {
 // see the workflow-change handler). Falls back to the legacy per-browser-session id
 // when no workflow service is present (headless / odd frontend).
 const _tempWorkflowIds = new Map(); // wf.key -> "tmp:<uuid>"
+const _workflowObjectUuids = new WeakMap();
+const _workflowUuidOwners = new Map();
+const WORKFLOW_UUID_ALIASES_KEY = "comfyui-mcp.panel.workflowUuidAliases";
+const WORKFLOW_META_NAMESPACE = "comfyui_mcp";
+const WORKFLOW_UUID_FIELD = "workflow_uuid";
+const WORKFLOW_PATH_FIELD = "workflow_path";
+let _workflowUuidAliases = (() => {
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(WORKFLOW_UUID_ALIASES_KEY) || "{}");
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+})();
 // MODULE-scoped so they survive buildPanel re-mounts (the panel re-mounts on every
 // ComfyUI workflow switch). If these lived in the panel closure, each re-mount would
 // re-seed them to the now-current workflow and defeat change detection.
@@ -658,11 +677,124 @@ function activeWorkflowRef() {
     return null;
   }
 }
+
+function savedWorkflowPath(wf = activeWorkflowRef()) {
+  return wf?.isPersisted === true && wf?.isTemporary !== true && typeof wf.path === "string" && wf.path
+    ? wf.path
+    : null;
+}
+
+function activeWorkflowExtra(wf = activeWorkflowRef(), { create = false } = {}) {
+  try {
+    const root = app?.graph;
+    if (root && typeof root === "object") {
+      if (root.extra && typeof root.extra === "object") return root.extra;
+      if (create) {
+        root.extra = {};
+        return root.extra;
+      }
+    }
+  } catch {
+    // Fall through to workflow-owned metadata variants used by older builds.
+  }
+  const candidate = wf?.extra || wf?.workflow?.extra || wf?.data?.extra;
+  return candidate && typeof candidate === "object" ? candidate : null;
+}
+
+function embeddedWorkflowUuid(wf = activeWorkflowRef()) {
+  const ns = activeWorkflowExtra(wf)?.[WORKFLOW_META_NAMESPACE];
+  const id = ns?.[WORKFLOW_UUID_FIELD];
+  return typeof id === "string" && id ? id : null;
+}
+
+function embeddedWorkflowPath(wf = activeWorkflowRef()) {
+  const ns = activeWorkflowExtra(wf)?.[WORKFLOW_META_NAMESPACE];
+  const path = ns?.[WORKFLOW_PATH_FIELD];
+  return typeof path === "string" && path ? path : null;
+}
+
+function persistWorkflowAliases() {
+  try {
+    window.localStorage.setItem(WORKFLOW_UUID_ALIASES_KEY, JSON.stringify(_workflowUuidAliases));
+  } catch {
+    // The embedded UUID remains authoritative when localStorage is unavailable.
+  }
+}
+
+/** Stable transcript identity, deliberately separate from workflowTabId(): the
+ *  latter is bridge routing, while this UUID follows a workflow across rename.
+ *  Copies carrying the same embedded UUID get a fresh identity when opened as a
+ *  different workflow object/path. */
+function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
+  const identityObject = wf || app?.graph;
+  if (!identityObject || typeof identityObject !== "object") return getTabId();
+  const path = savedWorkflowPath(wf);
+  const objectUuid = _workflowObjectUuids.get(identityObject);
+  const embedded = embeddedWorkflowUuid(wf);
+  const embeddedPath = embeddedWorkflowPath(wf);
+  let id = objectUuid || embedded || (path ? _workflowUuidAliases[path] : null) || crypto.randomUUID();
+
+  const embeddedOwner = embedded ? _workflowUuidOwners.get(embedded) : null;
+  if (!objectUuid && embeddedOwner && embeddedOwner !== identityObject) id = crypto.randomUUID();
+  if (
+    wf !== currentWorkflowRef &&
+    shouldForkEmbeddedWorkflowUuid({
+      objectUuid,
+      embeddedUuid: embedded,
+      embeddedPath,
+      currentPath: path,
+      aliases: _workflowUuidAliases,
+    })
+  ) {
+    id = crypto.randomUUID();
+  }
+
+  _workflowObjectUuids.set(identityObject, id);
+  _workflowUuidOwners.set(id, identityObject);
+  if (objectUuid && path) {
+    // Rename/Save-As mutates the same live workflow object. Drop stale aliases
+    // so a cold start does not later misclassify the renamed file as a clone.
+    for (const [knownPath, knownUuid] of Object.entries(_workflowUuidAliases)) {
+      if (knownUuid === id && normalizedWorkflowPath(knownPath) !== normalizedWorkflowPath(path)) {
+        delete _workflowUuidAliases[knownPath];
+      }
+    }
+  }
+  if (path && _workflowUuidAliases[path] !== id) {
+    _workflowUuidAliases[path] = id;
+    persistWorkflowAliases();
+  }
+  if (embed) {
+    try {
+      const extra = activeWorkflowExtra(wf, { create: true });
+      const previous = extra?.[WORKFLOW_META_NAMESPACE];
+      const pathChanged = path && normalizedWorkflowPath(previous?.[WORKFLOW_PATH_FIELD]) !== normalizedWorkflowPath(path);
+      if (extra && (previous?.[WORKFLOW_UUID_FIELD] !== id || pathChanged)) {
+        app?.graph?.beforeChange?.();
+        extra[WORKFLOW_META_NAMESPACE] = {
+          ...(previous && typeof previous === "object" ? previous : {}),
+          [WORKFLOW_UUID_FIELD]: id,
+          ...(path ? { [WORKFLOW_PATH_FIELD]: path } : {}),
+        };
+        app?.graph?.afterChange?.();
+        app?.graph?.setDirtyCanvas?.(true, true);
+        try { wf.isModified = true; } catch { /* getter-only on older builds */ }
+      }
+    } catch {
+      // The path alias still makes the identity durable in this browser.
+    }
+  }
+  return id;
+}
+
+function workflowStorageKey({ embed = false } = {}) {
+  return `workflow:${workflowStableUuid(activeWorkflowRef(), { embed })}`;
+}
+
 function workflowTabId() {
   const wf = activeWorkflowRef();
   if (!wf) return getTabId();
-  const saved =
-    wf.isPersisted === true && wf.isTemporary !== true && typeof wf.path === "string" && wf.path;
+  const saved = savedWorkflowPath(wf);
   if (saved) return "wf:" + wf.path;
   const k = wf.key || wf.id || "unsaved";
   let id = _tempWorkflowIds.get(k);
@@ -9866,6 +9998,10 @@ function buildPanel() {
   })();
   let thread = null; // created lazily on first recorded message
 
+  function currentTranscriptScopeKey({ embed = false } = {}) {
+    return sessionFollowsPanel() ? "panel:global" : workflowStorageKey({ embed });
+  }
+
   function persistThreads() {
     try {
       window.localStorage.setItem(THREADS_KEY, JSON.stringify(threads.slice(-MAX_THREADS)));
@@ -9874,9 +10010,19 @@ function buildPanel() {
     }
   }
 
-  // Find the (single) thread bound to a workflow id, or null. One conversation per
-  // workflow: newest wins if duplicates ever exist.
+  // Find the (single) thread bound to an exact transcript scope. Old path-keyed
+  // records are adopted only when their path exactly matches the open workflow;
+  // paths never authorize loading after that one-way migration.
   function threadForWorkflow(wfid) {
+    if (wfid.startsWith("workflow:") && !threads.some((candidate) => candidate.workflowKey === wfid)) {
+      const path = savedWorkflowPath();
+      const legacyKey = path ? `wf:${path}` : null;
+      const legacy = legacyKey ? threads.filter((candidate) => candidate.workflowKey === legacyKey) : [];
+      if (legacy.length) {
+        for (const candidate of legacy) candidate.workflowKey = wfid;
+        persistThreads();
+      }
+    }
     for (let i = threads.length - 1; i >= 0; i--) {
       if (threads[i].workflowKey === wfid) return threads[i];
     }
@@ -9884,8 +10030,16 @@ function buildPanel() {
   }
 
   function record(entry) {
+    const scopeKey = currentTranscriptScopeKey({ embed: !sessionFollowsPanel() });
+    // Settings can hydrate after a greeting was painted. Never append a real
+    // workflow-scoped message to a thread carrying another scope.
+    if (thread && !sessionFollowsPanel() && !isThreadInScope(thread, scopeKey)) {
+      thread = null;
+      ssSet(CURRENT_THREAD_KEY, null);
+      ssSet(SESSION_KEY, null);
+    }
     if (!thread) {
-      thread = { id: crypto.randomUUID(), ts: Date.now(), msgs: [], workflowKey: workflowTabId() };
+      thread = { id: crypto.randomUUID(), ts: Date.now(), msgs: [], workflowKey: scopeKey };
       // Adopt any session id the orchestrator has already reported for this tab.
       const sid = ssGet(SESSION_KEY);
       if (sid) thread.sessionId = sid;
@@ -10858,6 +11012,11 @@ function buildPanel() {
   }
 
   function loadThread(t) {
+    const scopeKey = currentTranscriptScopeKey();
+    if (!isThreadInScope(t, scopeKey)) {
+      appendSystem("Blocked a chat from another workflow. Open its owning workflow before resuming it.");
+      return false;
+    }
     thread = t;
     ssSet(CURRENT_THREAD_KEY, t.id);
     resetFeed();
@@ -10875,6 +11034,7 @@ function buildPanel() {
     ssSet(SESSION_KEY, t.sessionId || null);
     if (t.sessionId) client?.sendFrame?.({ type: "resume_session", session_id: t.sessionId });
     else client?.sendFrame?.({ type: "new_session" });
+    return true;
   }
 
   // Per-workflow auto-follow. Called on any workflow change (open/switch/save/rename).
@@ -10899,6 +11059,7 @@ function buildPanel() {
     const wfid = workflowTabId();
     const wfkey = wf ? (wf.key || wf.id || "unsaved") : null;
     if (wfid === currentWorkflowId) return; // case 1: no change
+    const historyKey = currentTranscriptScopeKey({ embed: !sessionFollowsPanel() });
 
     // PANEL-OWNED SESSION (default): the conversation is the unit of continuity
     // and the workflow is just the canvas target — switching, saving, renaming,
@@ -10915,7 +11076,7 @@ function buildPanel() {
       // tmp→wf adopt bookkeeping (a save gave the unsaved workflow a real id).
       if (wfid.startsWith("wf:") && wf && (wf.key || wf.id)) _tempWorkflowIds.delete(wf.key || wf.id);
       if (thread) {
-        thread.workflowKey = wfid; // thread rides along for per-workflow lookups
+        thread.workflowKey = "panel:global";
         thread.ts = Date.now();
         persistThreads();
       }
@@ -10946,8 +11107,7 @@ function buildPanel() {
       currentWorkflowId.startsWith("tmp:") &&
       wfid.startsWith("wf:");
     if (adopting) {
-      const t = threadForWorkflow(currentWorkflowId);
-      if (t) { t.workflowKey = wfid; persistThreads(); } // migrate to the file identity
+      const t = threadForWorkflow(historyKey);
       if (wf && (wf.key || wf.id)) _tempWorkflowIds.delete(wf.key || wf.id);
       currentWorkflowId = wfid;
       currentWorkflowKey = wfkey;
@@ -10968,12 +11128,7 @@ function buildPanel() {
       currentWorkflowId.startsWith("wf:") &&
       wfid.startsWith("wf:");
     if (renaming) {
-      const t = threadForWorkflow(currentWorkflowId);
-      if (t) {
-        t.workflowKey = wfid; // thread follows the workflow to its new path
-        t.ts = Date.now(); // newest-wins lookup must favor the migrated thread over any stray
-        persistThreads();
-      }
+      const t = threadForWorkflow(historyKey);
       currentWorkflowId = wfid;
       currentWorkflowKey = wfkey;
       currentWorkflowRef = wf;
@@ -10984,7 +11139,7 @@ function buildPanel() {
     currentWorkflowId = wfid;
     currentWorkflowKey = wfkey;
     currentWorkflowRef = wf;
-    const existing = threadForWorkflow(wfid);
+    const existing = threadForWorkflow(historyKey);
     // Bind THIS workflow's session BEFORE the re-hello. sendHello() reads
     // SESSION_KEY at hello time for its spawn-time `resume` — re-helloing first
     // carried the PREVIOUS workflow's session id, so a fresh workspace's agent
@@ -11044,7 +11199,14 @@ function buildPanel() {
         day: "numeric",
       });
       item.append(i, lbl, when);
+      const foreignWorkflow = !sessionFollowsPanel() && !isThreadInScope(t, currentTranscriptScopeKey());
+      if (foreignWorkflow) {
+        item.disabled = true;
+        item.title = "Open this chat's workflow before resuming it";
+        row.classList.add("foreign-workflow");
+      }
       item.addEventListener("click", () => {
+        if (foreignWorkflow) return;
         histPop.hidden = true;
         loadThread(t);
       });
@@ -14257,9 +14419,18 @@ function buildPanel() {
   (function restoreLastThread() {
     try {
       const cur = ssGet(CURRENT_THREAD_KEY);
-      const t = cur ? threads.find((x) => x.id === cur) : null;
+      const pointed = cur ? threads.find((x) => x.id === cur) : null;
+      const scopeKey = currentTranscriptScopeKey();
+      if (sessionFollowsPanel() && pointed && pointed.workflowKey !== "panel:global") {
+        pointed.workflowKey = "panel:global";
+        persistThreads();
+      }
+      const scopedPointed = pointed && isThreadInScope(pointed, scopeKey) ? pointed : null;
+      const t = scopedPointed || threadForWorkflow(scopeKey);
       if (!t || !t.msgs?.length) return;
       thread = t;
+      ssSet(CURRENT_THREAD_KEY, t.id);
+      ssSet(SESSION_KEY, t.sessionId || null);
       resetFeed();
       for (const m of t.msgs) {
         if (m.role === "user") paintUser(m.text, { attachments: m.attachments });

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -1,7 +1,17 @@
 // Pure workflow transcript-identity rules shared by the panel and unit tests.
 
 export function normalizedWorkflowPath(path) {
-  return typeof path === "string" ? path.replaceAll("\\", "/").toLocaleLowerCase() : null;
+  return typeof path === "string" ? path.replaceAll("\\", "/").toLowerCase() : null;
+}
+
+/** Resolve a persisted path alias without making identity locale-dependent. */
+export function workflowAliasForPath(aliases, path) {
+  const normalized = normalizedWorkflowPath(path);
+  if (!normalized) return null;
+  const match = Object.entries(aliases || {}).find(
+    ([knownPath]) => normalizedWorkflowPath(knownPath) === normalized,
+  );
+  return typeof match?.[1] === "string" && match[1] ? match[1] : null;
 }
 
 /** Return true when an embedded UUID belongs to a different workflow file.

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -1,0 +1,43 @@
+// Pure workflow transcript-identity rules shared by the panel and unit tests.
+
+export function normalizedWorkflowPath(path) {
+  return typeof path === "string" ? path.replaceAll("\\", "/").toLocaleLowerCase() : null;
+}
+
+/** Return true when an embedded UUID belongs to a different workflow file.
+ *  An existing objectUuid means ComfyUI mutated the same live workflow object
+ *  during rename/Save-As, so continuity wins. Otherwise an embedded path or a
+ *  known path alias can prove that copied JSON needs a fresh identity. */
+export function shouldForkEmbeddedWorkflowUuid({
+  objectUuid,
+  embeddedUuid,
+  embeddedPath,
+  currentPath,
+  aliases = {},
+} = {}) {
+  if (objectUuid || !embeddedUuid || !currentPath) return false;
+  if (embeddedPath) {
+    return normalizedWorkflowPath(embeddedPath) !== normalizedWorkflowPath(currentPath);
+  }
+  const canonicalAlias = Object.entries(aliases || {}).find(
+    ([knownPath]) => normalizedWorkflowPath(knownPath) === normalizedWorkflowPath(currentPath),
+  );
+  if (canonicalAlias?.[1] === embeddedUuid) return false;
+  return Object.entries(aliases || {}).some(
+    ([knownPath, knownUuid]) =>
+      knownUuid === embeddedUuid &&
+      normalizedWorkflowPath(knownPath) !== normalizedWorkflowPath(currentPath),
+  );
+}
+
+/** Exact-match authorization guard for activating a workflow transcript.
+ *  Paths and titles are migration/display metadata, never resume authority. */
+export function isThreadInScope(thread, scopeKey) {
+  return Boolean(
+    thread &&
+      typeof scopeKey === "string" &&
+      scopeKey &&
+      typeof thread.workflowKey === "string" &&
+      thread.workflowKey === scopeKey,
+  );
+}


### PR DESCRIPTION
## Summary

Introduce a stable workflow UUID for transcript scoping and enforce an exact-match guard before any workflow-owned chat/session is restored or resumed.

This is PR 1 of the focused series requested in #98. It remains limited to the identity and safety foundation; IndexedDB storage, archive UX, and optional server backup are kept in separate follow-up branches.

## What changed

- persist `extra.comfyui_mcp.workflow_uuid` plus the last known workflow path only when the first chat entry is recorded;
- embed identity silently, so merely opening/switching a workflow never dirties the canvas;
- keep transcript identity (`workflow:<uuid>`) separate from bridge routing (`wf:<path>` / `tmp:<uuid>`);
- keep default panel-owned behavior unchanged and preserve its ride-along workflow provenance;
- apply strict scope guards only in per-workflow mode, including load and reload restore;
- avoid destructive thread re-keying during the settings-hydration race;
- preserve identity across rename/Save As and reuse a copied workflow's path alias across restarts until it is saved;
- migrate an exact legacy `wf:<full-path>` transcript once, with no fuzzy matching;
- retain the live tab `SESSION_KEY` during a scope correction;
- use a weak/bounded workflow owner registry and locale-independent path normalization;
- dim disabled foreign-workflow history rows.

## Review follow-up

Commit `984d3e9` addresses every item from the maintainer review. It also adds regressions for opening without dirtying, default-mode opening of pre-upgrade threads, hydration safety, stable unsaved fork identity, and foreign-row presentation.

## Validation

- `npm run typecheck`
- `npm run test:unit` — 74/74 passed on this branch
- ES module parse checks — passed
- `npm audit --omit=dev` — 0 vulnerabilities
- targeted Playwright (`workflow-chat-identity.spec.ts`) — 4/4 passed

Part of #98.