### PR TITLE
feat(training): Local/Pod target switch in the training wizard (P4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,16 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.9.7] - 2026-07-20
+
 ### Changed
 - Codex/ChatGPT reasoning-effort scale extends to `max` and `ultra` for the
   GPT-5.6 family (per-model ceilings still intersect with the model list —
   Luna tops out at `max`); pairs with comfyui-mcp >= 0.41.0
+
+### Added
+- max + ultra on the Codex scale for GPT-5.6 (#94)
+
 
 ## [0.9.6] - 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Changed
+- Codex/ChatGPT reasoning-effort scale extends to `max` and `ultra` for the
+  GPT-5.6 family (per-model ceilings still intersect with the model list —
+  Luna tops out at `max`); pairs with comfyui-mcp >= 0.41.0
+
 ## [0.9.6] - 2026-07-19
 
 ### Fixed

--- a/__init__.py
+++ b/__init__.py
@@ -323,6 +323,15 @@ def _register_routes():
     except Exception as _e:  # pragma: no cover - never block panel load
         _log("civitai proxy not registered: {}".format(_e))
 
+    # Training-wizard helpers: image-ref → absolute-path resolution for dataset
+    # staging, and serving training-sample images from under the training root.
+    try:
+        from .py import training_routes
+
+        training_routes.register(routes, web)
+    except Exception as _e:  # pragma: no cover - never block panel load
+        _log("training routes not registered: {}".format(_e))
+
     @routes.get("/comfyui_mcp_panel/status")
     async def _status(_request):
         detected = _detect_comfyui_url()

--- a/browser_tests/training-wizard.spec.ts
+++ b/browser_tests/training-wizard.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Tier 1 — LoRA Training wizard.
+ *
+ * Drives the Character-LoRA wizard end-to-end against canned backends:
+ *   - the /comfyui_mcp_panel/training/* py routes are route-intercepted
+ *     (deterministic, no dependence on real output files), and
+ *   - train_* call_tool frames over the bridge are answered by the MockBridge
+ *     (onFrame) with scripted train_doctor / train_prepare_dataset /
+ *     train_start / train_status payloads.
+ *
+ * Asserts the wizard walks gather → label → launch → monitor, issues the
+ * right tool calls with the right payloads, and renders the completion card.
+ */
+import { test, expect } from './fixtures/panelTest'
+
+const OUT_IMAGES = [
+  { filename: 'char_a.png', subfolder: '', type: 'output', size: 100, mtime: 2000 },
+  { filename: 'char_b.png', subfolder: '', type: 'output', size: 100, mtime: 1000 }
+]
+
+function toolResult(text: unknown) {
+  return [{ type: 'text', text: JSON.stringify(text) }]
+}
+
+test('character LoRA wizard: gather → label → launch → monitor', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  // --- canned py routes -------------------------------------------------
+  await page.route('**/comfyui_mcp_panel/training/list-outputs*', (route) =>
+    route.fulfill({ json: { images: OUT_IMAGES } })
+  )
+  await page.route('**/comfyui_mcp_panel/training/resolve-paths', (route) =>
+    route.fulfill({
+      json: {
+        paths: OUT_IMAGES.map((i) => ({
+          path: `C:/rig/output/${i.filename}`,
+          filename: i.filename,
+          subfolder: null,
+          type: 'output'
+        }))
+      }
+    })
+  )
+  // Thumbnails via /view — any tiny body is fine (background-image doesn't care).
+  await page.route('**/view?*', (route) =>
+    route.fulfill({ body: Buffer.from([0x89, 0x50, 0x4e, 0x47]), contentType: 'image/png' })
+  )
+
+  // --- scripted train_* tool answers ------------------------------------
+  const calls: Array<{ tool: string; args: Record<string, unknown> }> = []
+  let statusPayload: unknown = null
+  mockBridge.onFrame((frame) => {
+    if (frame.type !== 'call_tool') return
+    const cid = frame.cid as string
+    const tool = frame.tool as string
+    const args = (frame.args ?? {}) as Record<string, unknown>
+    calls.push({ tool, args })
+    const reply = (payload: unknown, ok = true) =>
+      mockBridge.send({ type: 'tool_result', cid, tool, ok, result: toolResult(payload) })
+    if (tool === 'train_doctor') {
+      reply({ ok: true, command: 'train_doctor', data: { docker: true, gpu: true, image: true, image_tag: 't:latest', hints: [], hfTokenSet: true, localFs: true } })
+    } else if (tool === 'train_list_flows') {
+      reply({ ok: true, flows: [{ id: 'character' }], defaultParams: {} })
+    } else if (tool === 'train_prepare_dataset') {
+      reply({ ok: true, datasetPath: 'C:/rig/training/datasets/test_char', imageCount: 2, captionedCount: 2, warnings: [] })
+    } else if (tool === 'train_start') {
+      const job = {
+        id: 'tjob1', name: 'test_char', flow: 'character', model: 'flux1-dev',
+        trigger: 'ohwx', status: 'running',
+        progress: { samples: [] }, containerName: 'c1',
+        datasetPath: args.datasetPath, jobDir: 'j', outputDir: 'o', log: [],
+        createdAt: new Date().toISOString(), updatedAt: new Date().toISOString()
+      }
+      reply({ ok: true, job })
+      statusPayload = {
+        ok: true,
+        job: { ...job, progress: { samples: [], step: 40, totalSteps: 200, loss: 0.42 }, log: ['40/200 loss: 0.42'] }
+      }
+    } else if (tool === 'train_status') {
+      reply(statusPayload ?? { ok: true, count: 0, jobs: [] })
+    } else if (tool === 'train_cancel') {
+      reply({ ok: true })
+    }
+  })
+
+  // --- walk the wizard ---------------------------------------------------
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  await page.getByRole('button', { name: 'Training', exact: true }).click()
+  const modal = page.locator('.cmcp-tr-modal')
+  await expect(modal).toBeVisible()
+  await modal.getByRole('button', { name: 'Start' }).click()
+
+  // Gather: name + trigger, pick both canned outputs.
+  await modal.locator('input[type=text]').first().fill('test_char')
+  await modal.locator('input[type=text]').nth(1).fill('ohwx')
+  const cells = modal.locator('.cmcp-tr-pick')
+  await expect(cells).toHaveCount(2)
+  await cells.nth(0).click()
+  await cells.nth(1).click()
+  await expect(modal.locator('.cmcp-tr-chip')).toHaveCount(2)
+  await modal.getByRole('button', { name: /Next: label captions/ }).click()
+
+  // Label: prefix the trigger into both captions.
+  await expect(modal.locator('textarea')).toHaveCount(2)
+  await modal.getByRole('button', { name: /Prefix/ }).click()
+  await expect(modal.locator('textarea').nth(0)).toHaveValue('ohwx')
+  await expect(modal.locator('textarea').nth(1)).toHaveValue('ohwx')
+  await modal.locator('textarea').nth(0).fill('ohwx woman, studio portrait')
+  await modal.getByRole('button', { name: /Next: review & launch/ }).click()
+
+  // Launch: preflight renders, then fire.
+  await expect(modal.locator('.cmcp-tr-preflight')).toContainText('docker:', { timeout: 15_000 })
+  await modal.getByRole('button', { name: 'Launch training' }).click()
+
+  // Monitor: running progress renders from the scripted train_status.
+  await expect(modal.locator('.cmcp-tr-hint').filter({ hasText: /step 40\/200/ })).toBeVisible({ timeout: 15_000 })
+
+  // Complete the run: flip the scripted status to completed and let the next poll land.
+  statusPayload = {
+    ok: true,
+    job: {
+      id: 'tjob1', name: 'test_char', flow: 'character', model: 'flux1-dev', trigger: 'ohwx',
+      status: 'completed',
+      progress: { samples: [], step: 200, totalSteps: 200, loss: 0.2 },
+      containerName: 'c1', datasetPath: 'd', jobDir: 'j', outputDir: 'o',
+      log: ['done'], createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
+      finishedAt: new Date().toISOString(),
+      result: { loraPath: 'x', loraRelPath: 'loras/test_char.safetensors', catalogId: 'loras-test-char' }
+    }
+  }
+  await expect(modal.getByText('LoRA ready ✓')).toBeVisible({ timeout: 15_000 })
+
+  // --- assert the tool-call sequence ------------------------------------
+  const tools = calls.map((c) => c.tool)
+  expect(tools).toContain('train_doctor')
+  expect(tools).toContain('train_prepare_dataset')
+  expect(tools).toContain('train_start')
+  expect(tools).toContain('train_status')
+
+  const prep = calls.find((c) => c.tool === 'train_prepare_dataset')!
+  expect(prep.args.name).toBe('test_char')
+  expect(prep.args.defaultCaption).toBe('ohwx')
+  const items = prep.args.items as Array<{ path: string; caption?: string }>
+  expect(items).toHaveLength(2)
+  expect(items[0].path).toBe('C:/rig/output/char_a.png')
+  expect(items[0].caption).toBe('ohwx woman, studio portrait')
+  expect(items[1].caption).toBe('ohwx')
+
+  const start = calls.find((c) => c.tool === 'train_start')!
+  expect(start.args.name).toBe('test_char')
+  expect(start.args.flow).toBe('character')
+  expect(start.args.model).toBe('flux1-dev')
+  expect(start.args.datasetPath).toBe('C:/rig/training/datasets/test_char')
+  expect(start.args.trigger).toBe('ohwx')
+  expect((start.args.params as { steps: number }).steps).toBe(2000)
+})

--- a/py/training_routes.py
+++ b/py/training_routes.py
@@ -1,0 +1,167 @@
+"""ComfyUI-origin helpers for the panel's LoRA-training wizard.
+
+Two routes, same register() pattern as py/civitai_proxy.py:
+
+- POST /comfyui_mcp_panel/training/resolve-paths
+    The wizard picks images by ComfyUI reference ({filename, subfolder, type})
+    but the trainer's train_prepare_dataset MCP tool needs absolute host paths.
+    This resolves refs against ComfyUI's folder_paths roots (output/input/temp),
+    containment- and existence-checked.
+
+- GET /comfyui_mcp_panel/training/file?path=...
+    train_status reports sample images as ABSOLUTE paths under the training
+    root (~/.comfyui-mcp/training/) — unreadable by the browser. This serves
+    them back over the ComfyUI origin, restricted to that root.
+
+- GET /comfyui_mcp_panel/training/list-outputs?limit=..&pattern=..
+    Structured (JSON) recent-output listing for the wizard's image picker — the
+    MCP list_output_images tool returns markdown for LLMs; the grid needs data.
+"""
+
+import asyncio
+import logging
+import os
+import pathlib
+from os import environ  # bare-name on purpose — see root __init__.py (Registry scanner)
+
+logger = logging.getLogger(__name__)
+
+# Formats the trainer accepts (mirrors train_prepare_dataset's IMAGE_EXTS) —
+# drives the output picker so every selectable image can actually be staged.
+_PICK_EXTS = {".png", ".jpg", ".jpeg", ".webp"}
+# Anything the /file route may serve (training samples, previews).
+_SERVE_EXTS = {".png", ".jpg", ".jpeg", ".webp", ".bmp", ".gif"}
+
+_TYPE_DIRS = {
+    "output": "get_output_directory",
+    "input": "get_input_directory",
+    "temp": "get_temp_directory",
+}
+
+
+def _training_roots() -> list:
+    """Roots the /file route may serve from: the env override when set, plus the
+    default. Both processes (ComfyUI + orchestrator) normally share the default;
+    when the orchestrator is launched with an override ComfyUI doesn't have,
+    sample paths land outside every root here and we 403 — which is correct:
+    two processes with different training roots can't share a job registry
+    anyway (codex finding; fail closed, never widen containment client-side)."""
+    roots = []
+    override = environ.get("COMFYUI_MCP_TRAINING_DIR", "").strip()
+    if override:
+        roots.append(override)
+    base = environ.get("COMFYUI_MCP_DATA_DIR", "").strip() or os.path.join(
+        pathlib.Path.home(), ".comfyui-mcp"
+    )
+    roots.append(os.path.join(base, "training"))
+    return roots
+
+
+def _newest_outputs(root: str, pattern: str, limit: int) -> list:
+    """The `limit` newest image files under `root` (sync; runs in a worker
+    thread). A size-bounded heap avoids materializing the whole tree."""
+    import heapq
+
+    heap = []  # min-heap by mtime, max size `limit`
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for name in filenames:
+            if os.path.splitext(name)[1].lower() not in _PICK_EXTS:
+                continue
+            if pattern and pattern not in name.lower():
+                continue
+            full = os.path.join(dirpath, name)
+            try:
+                st = os.stat(full)
+            except OSError:
+                continue
+            sub = os.path.relpath(dirpath, root)
+            item = {
+                "filename": name,
+                "subfolder": "" if sub == "." else sub.replace(os.sep, "/"),
+                "type": "output",
+                "size": st.st_size,
+                "mtime": st.st_mtime,
+            }
+            if len(heap) < limit:
+                heapq.heappush(heap, (st.st_mtime, id(item), item))
+            elif st.st_mtime > heap[0][0]:
+                heapq.heapreplace(heap, (st.st_mtime, id(item), item))
+    return [item for _mtime, _i, item in sorted(heap, key=lambda x: -x[0])]
+
+
+def register(routes, web):
+    """Register the training-wizard routes on ``PromptServer.instance.routes``."""
+
+    @routes.post("/comfyui_mcp_panel/training/resolve-paths")
+    async def _resolve_paths(request):
+        try:
+            spec = await request.json()
+        except Exception:
+            return web.json_response({"error": "invalid JSON"}, status=400)
+        images = spec.get("images")
+        if not isinstance(images, list) or not images:
+            return web.json_response({"error": "images must be a non-empty list"}, status=400)
+
+        import folder_paths  # ComfyUI's own path registry (host-provided)
+
+        out = []
+        for item in images:
+            if not isinstance(item, dict):
+                out.append({"error": "not an object"})
+                continue
+            filename = str(item.get("filename") or "").strip()
+            subfolder = str(item.get("subfolder") or "").strip()
+            typ = str(item.get("type") or "output").strip()
+            getter = _TYPE_DIRS.get(typ)
+            if not filename:
+                out.append({"error": "filename required"})
+                continue
+            if getter is None:
+                out.append({"error": f"type must be one of {sorted(_TYPE_DIRS)}"})
+                continue
+            root = os.path.realpath(getattr(folder_paths, getter)())
+            rel = os.path.join(subfolder, filename) if subfolder else filename
+            path = os.path.realpath(os.path.join(root, rel))
+            # Containment: the resolved file must stay inside its root.
+            if path != root and not path.startswith(root + os.sep):
+                out.append({"error": f"escapes {typ} directory: {rel}"})
+                continue
+            if not os.path.isfile(path):
+                out.append({"error": f"not found: {rel}"})
+                continue
+            out.append({"path": path, "filename": filename, "subfolder": subfolder or None, "type": typ})
+        return web.json_response({"paths": out})
+
+    @routes.get("/comfyui_mcp_panel/training/file")
+    async def _training_file(request):
+        raw = (request.query.get("path") or "").strip()
+        if not raw:
+            return web.json_response({"error": "path required"}, status=400)
+        path = os.path.realpath(raw)
+        roots = [os.path.realpath(r) for r in _training_roots()]
+        if not any(path == root or path.startswith(root + os.sep) for root in roots):
+            return web.json_response({"error": "path is outside the training root"}, status=403)
+        if os.path.splitext(path)[1].lower() not in _SERVE_EXTS:
+            return web.json_response({"error": "not an image file"}, status=400)
+        if not os.path.isfile(path):
+            return web.json_response({"error": "not found"}, status=404)
+        return web.FileResponse(path)
+
+    @routes.get("/comfyui_mcp_panel/training/list-outputs")
+    async def _list_outputs(request):
+        try:
+            limit = int(request.query.get("limit", "60"))
+        except ValueError:
+            limit = 60
+        limit = max(1, min(limit, 200))
+        pattern = (request.query.get("pattern") or "").strip().lower()
+
+        import folder_paths  # ComfyUI's own path registry (host-provided)
+
+        root = folder_paths.get_output_directory()
+        # Off the event loop (a large output dir or slow/network storage would
+        # otherwise block ComfyUI's HTTP/WS handling), and bounded: keep only
+        # the `limit` newest entries instead of collecting-then-sorting the
+        # whole tree (codex finding).
+        images = await asyncio.to_thread(_newest_outputs, root, pattern, limit)
+        return web.json_response({"images": images})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar â€” runs locally on your own Claude OR ChatGPT subscription (no API keys, no extra LLM costs). Pick a provider and the agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, and run your workflow â€” asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.9.6"
+version = "0.9.7"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/cmcp-training-ui.js
+++ b/web/js/cmcp-training-ui.js
@@ -252,6 +252,8 @@ export function openTrainingModal(ctx = {}) {
     job: null,
     launching: false,
     launchError: null,
+    target: "local",
+    podInfo: null,
     uploadsPending: 0,
     /** Generations: bumped on launch/reset so a stale async continuation (an
      *  in-flight launch or upload batch from a PREVIOUS wizard run) can't
@@ -736,6 +738,30 @@ export function openTrainingModal(ctx = {}) {
     fetchGpuLabel(ctx.api).then((gpu) => { if (gpu) gpuLine.textContent = `Local GPU: ${gpu}`; });
     callJson(ctx, "train_doctor", {}, { timeout: 180000 }).then((d) => {
       const dd = d.data || {};
+      wiz.podInfo = dd.pod && dd.pod.status === "RUNNING" ? dd.pod : null;
+      // Local ⇄ Pod switch — only when a RUNNING pod is connected (connector).
+      if (wiz.podInfo) {
+        const pod = wiz.podInfo;
+        const targetSeg = el("div", "cmcp-tr-seg");
+        targetSeg.style.margin = "0";
+        const localBtn = el("button", wiz.target !== "pod" ? "active" : null, "Local (docker)");
+        const podBtn = el("button", wiz.target === "pod" ? "active" : null, `Pod (${pod.name || pod.id}${pod.gpu ? ` · ${pod.gpu}` : ""})`);
+        if (!pod.ssh) podBtn.title = "pod has no working SSH endpoint";
+        localBtn.onclick = () => { wiz.target = "local"; localBtn.classList.add("active"); podBtn.classList.remove("active"); syncLaunchEnabled(); syncSummary(); };
+        podBtn.onclick = () => {
+          if (!pod.ssh) return;
+          wiz.target = "pod";
+          podBtn.classList.add("active");
+          localBtn.classList.remove("active");
+          syncLaunchEnabled();
+          syncSummary();
+        };
+        targetSeg.append(localBtn, podBtn);
+        pre.before(targetSeg);
+        const podNote = el("p", "cmcp-tr-hint",
+          `Pod training runs ai-toolkit natively ON the pod (no docker there). Fresh pods need a one-time bootstrap (~10 min) — run train_bootstrap (or ask the agent) once; it persists on the pod's volume. The pod bills GPU-time while it's up.`);
+        pre.after(podNote);
+      }
       pre.textContent = "";
       const mk = (label, ok) => el("span", null, `${label}: `);
       for (const [label, ok] of [["docker", dd.docker], ["gpu", dd.gpu], ["image", dd.image], ["hf token", dd.hfTokenSet]]) {
@@ -780,9 +806,14 @@ export function openTrainingModal(ctx = {}) {
     body.appendChild(sec);
 
     syncLaunchEnabled = () => {
-      launch.disabled = wiz.launching || preflightState !== "local" && preflightState !== "failed" || !syncCustomValidity();
+      // Pod target: docker/gpu/image are irrelevant — the gate is a working pod
+      // SSH endpoint (plus the custom-param check).
+      const podReady = wiz.target === "pod" && !!wiz.podInfo?.ssh;
+      launch.disabled = wiz.launching
+        || (wiz.target === "pod" ? !podReady : preflightState !== "local" && preflightState !== "failed")
+        || !syncCustomValidity();
       if (wiz.launching) launch.textContent = "Launching…";
-      else launch.textContent = "Launch training";
+      else launch.textContent = wiz.target === "pod" ? "Launch on pod" : "Launch training";
     };
     syncLaunchEnabled();
 
@@ -840,6 +871,8 @@ export function openTrainingModal(ctx = {}) {
         const started = await callJson(ctx, "train_start", {
           name: snap.name, flow: "character", model: "flux1-dev",
           datasetPath: prep.datasetPath, trigger: snap.trigger, params: snap.params,
+          target: wiz.target,
+          ...(wiz.target === "pod" && wiz.podInfo ? { pod_id: wiz.podInfo.id } : {}),
         }, { timeout: 120000 });
         if (gen !== wiz.launchGen) return; // a newer launch/reset superseded this one
         wiz.jobId = started.job.id;
@@ -872,7 +905,12 @@ export function openTrainingModal(ctx = {}) {
   }
 
   function jobStatusBadge(job) {
-    return el("span", `cmcp-tr-badge ${STATUS_BADGE[job.status] || ""}`, job.status);
+    const b = el("span", `cmcp-tr-badge ${STATUS_BADGE[job.status] || ""}`, job.status);
+    if (job.target === "pod") {
+      b.textContent = `${job.status} · pod`;
+      b.title = "Trained on a RunPod pod";
+    }
+    return b;
   }
 
   function renderMonitor() {

--- a/web/js/cmcp-training-ui.js
+++ b/web/js/cmcp-training-ui.js
@@ -1,10 +1,14 @@
-// LoRA Training modal — a navigable COMING-SOON preview, parity with the
-// mobile app's Training tab. Everything is intentionally inert placeholder
-// UI: six training flows as cards (base-model dropdown + description), all
-// badged "Coming soon", under a Local/Cloud switch previewing the two
-// backends we plan to support (this rig vs a RunPod pod managed headlessly by
-// our own trainer, built by decoding how Ostris' AI Toolkit drives the
-// process). Same overlay treatment as the CivitAI browser modal.
+// LoRA Training modal — the panel's dataset-gather → label → launch → monitor
+// wizard for the local trainer (ai-toolkit in a GPU Docker container, driven by
+// the comfyui-mcp train_* tools). Parity target for the mobile app's Training
+// tab; the Character card is functional (FLUX.1-dev), the rest are P2 previews.
+//
+// Backend channels (both already existed):
+//  - ctx.callTool(tool, args, {timeout}) — cid-correlated call_tool over the
+//    orchestrator bridge (train_* tools; whitelisted server-side).
+//  - /comfyui_mcp_panel/training/* — same-origin py routes for structured
+//    output listing, image-ref → absolute-path resolution, and serving
+//    training-sample images from the rig's training root.
 
 let cssInjected = false;
 function injectCss() {
@@ -12,12 +16,15 @@ function injectCss() {
   cssInjected = true;
   const style = document.createElement("style");
   style.textContent = `
-    /* Same containment as the CivitAI modal: fixed-height flex column with
-       overflow hidden; only .cmcp-tr-body scrolls, the header/switch stay put. */
-    .cmcp-tr-modal { width: min(92vw, 860px); max-width: none;
-      max-height: min(90vh, 840px); padding: 0; gap: 0; overflow: hidden;
+    /* Self-contained overlay + modal base (the CivitAI modal's .cmcp-cv-overlay
+       styles only exist once that modal has opened, and the base .cmcp-modal is
+       a narrow confirm-dialog — neither can be relied on here). */
+    .cmcp-cv-overlay { position: fixed; inset: 0; z-index: 10000; display: flex;
+      align-items: center; justify-content: center; padding: 1.5rem; background: rgba(0,0,0,.6); }
+    .cmcp-modal.cmcp-tr-modal { width: min(94vw, 960px); max-width: none;
+      max-height: min(92vh, 880px); padding: 0; gap: 0; overflow: hidden;
       display: flex; flex-direction: column; }
-    .cmcp-tr-body { flex: 1; overflow-y: auto; min-height: 0; }
+    .cmcp-tr-body { flex: 1; overflow-y: auto; min-height: 0; padding-bottom: 1rem; }
     .cmcp-tr-head { display:flex; align-items:center; gap:.75rem; padding:1rem 1.25rem .5rem;
       border-bottom: 1px solid var(--p-content-border-color, #3f3f46); }
     .cmcp-tr-head h2 { margin:0; font-size:1.05rem; flex:1; }
@@ -26,30 +33,79 @@ function injectCss() {
     .cmcp-tr-seg { display:flex; gap:0; margin:.75rem 1.25rem; border:1px solid var(--p-surface-500,#555); border-radius:999px; overflow:hidden; width:fit-content; flex:none; }
     .cmcp-tr-seg button { border:none; background:transparent; color:inherit; padding:.4rem .9rem; cursor:pointer; font-size:.85rem; display:flex; align-items:center; gap:.4rem; }
     .cmcp-tr-seg button.active { background: var(--p-surface-700,#3f3f46); }
-    .cmcp-tr-token { margin:0 1.25rem .75rem; display:flex; flex-direction:column; gap:.25rem; }
-    .cmcp-tr-token input { background:var(--p-surface-800,#27272a); border:1px solid var(--p-surface-600,#52525b); border-radius:8px; padding:.5rem .75rem; color:inherit; opacity:.55; }
-    .cmcp-tr-token small { opacity:.6; }
     .cmcp-tr-grid { display:grid; grid-template-columns:repeat(3,1fr); gap:.75rem; padding:0 1.25rem 1rem; }
     @media (max-width: 640px) { .cmcp-tr-grid { grid-template-columns:repeat(2,1fr); } }
     .cmcp-tr-card { background:var(--p-surface-800,#27272a); border:1px solid var(--p-surface-600,#3f3f46); border-radius:12px; padding:.75rem; display:flex; flex-direction:column; gap:.45rem; }
+    .cmcp-tr-card.active { border-color: var(--p-primary-color,#94a3b8); }
     .cmcp-tr-icon { aspect-ratio:1.6; border-radius:10px; background:color-mix(in srgb, currentColor 8%, transparent); display:flex; align-items:center; justify-content:center; font-size:1.6rem; opacity:.8; }
     .cmcp-tr-card select { background:var(--p-surface-900,#18181b); color:inherit; border:1px solid var(--p-surface-600,#52525b); border-radius:6px; padding:.25rem .4rem; font-size:.8rem; width:100%; }
     .cmcp-tr-card h3 { margin:0; font-size:.9rem; }
     .cmcp-tr-card p { margin:0; font-size:.78rem; opacity:.65; line-height:1.35; flex:1; }
     .cmcp-tr-badge { align-self:flex-start; font-size:.72rem; padding:.1rem .5rem; border-radius:999px; background:color-mix(in srgb, currentColor 10%, transparent); opacity:.75; }
+    .cmcp-tr-badge.ok { background: color-mix(in srgb, #22c55e 18%, transparent); opacity:1; }
+    .cmcp-tr-badge.err { background: color-mix(in srgb, #ef4444 18%, transparent); opacity:1; }
+    .cmcp-tr-badge.warn { background: color-mix(in srgb, #eab308 18%, transparent); opacity:1; }
     .cmcp-tr-foot { padding:0 1.25rem 1rem; font-size:.8rem; opacity:.55; }
+    .cmcp-tr-section { padding: .25rem 1.25rem; display:flex; flex-direction:column; gap:.6rem; }
+    .cmcp-tr-row { display:flex; gap:.6rem; align-items:center; flex-wrap:wrap; }
+    .cmcp-tr-row > label { font-size:.8rem; opacity:.75; min-width:6.5rem; }
+    .cmcp-tr-input, .cmcp-tr-section input[type=text], .cmcp-tr-section input[type=number] {
+      background:var(--p-surface-800,#27272a); border:1px solid var(--p-surface-600,#52525b);
+      border-radius:8px; padding:.45rem .7rem; color:inherit; font-size:.85rem; flex:1; min-width:0; }
+    .cmcp-tr-hint { font-size:.75rem; opacity:.55; margin:0; }
+    .cmcp-tr-btn { background:var(--p-surface-700,#3f3f46); border:1px solid var(--p-surface-600,#52525b);
+      color:inherit; border-radius:8px; padding:.45rem .9rem; cursor:pointer; font-size:.85rem; }
+    .cmcp-tr-btn:hover { filter:brightness(1.2); }
+    .cmcp-tr-btn:disabled { opacity:.45; cursor:not-allowed; }
+    .cmcp-tr-btn.primary { background:var(--p-primary-color,#64748b); border-color:transparent; color:#fff; }
+    .cmcp-tr-btn.danger { background: color-mix(in srgb, #ef4444 25%, transparent); }
+    .cmcp-tr-pickgrid { display:grid; grid-template-columns:repeat(auto-fill,minmax(96px,1fr)); gap:.5rem; max-height:38vh; overflow-y:auto; padding:.25rem; }
+    .cmcp-tr-pick { position:relative; aspect-ratio:1; border-radius:8px; overflow:hidden; cursor:pointer; border:2px solid transparent; background:var(--p-surface-900,#18181b); }
+    .cmcp-tr-pick img { width:100%; height:100%; object-fit:cover; display:block; }
+    .cmcp-tr-pick.sel { border-color: var(--p-primary-color,#94a3b8); }
+    .cmcp-tr-pick .mark { position:absolute; top:4px; right:4px; background:rgba(0,0,0,.65); border-radius:999px; width:20px; height:20px; display:flex; align-items:center; justify-content:center; font-size:.7rem; }
+    .cmcp-tr-pick.sel .mark { background:var(--p-primary-color,#64748b); color:#fff; }
+    .cmcp-tr-drop { border:2px dashed var(--p-surface-600,#52525b); border-radius:12px; padding:1.5rem; text-align:center; opacity:.8; cursor:pointer; }
+    .cmcp-tr-drop.over { border-color: var(--p-primary-color,#94a3b8); opacity:1; }
+    .cmcp-tr-tray { display:flex; gap:.4rem; flex-wrap:wrap; }
+    .cmcp-tr-chip { position:relative; width:44px; height:44px; border-radius:6px; background-size:cover; background-position:center; }
+    .cmcp-tr-chip button { position:absolute; top:-6px; right:-6px; width:16px; height:16px; border-radius:999px; border:none; background:#ef4444; color:#fff; font-size:.65rem; line-height:1; cursor:pointer; }
+    .cmcp-tr-labelgrid { display:grid; grid-template-columns:repeat(auto-fill,minmax(200px,1fr)); gap:.75rem; }
+    .cmcp-tr-labelitem { background:var(--p-surface-800,#27272a); border-radius:10px; padding:.5rem; display:flex; flex-direction:column; gap:.4rem; }
+    .cmcp-tr-labelitem .thumb { aspect-ratio:1; border-radius:8px; background-size:cover; background-position:center; }
+    .cmcp-tr-labelitem textarea { background:var(--p-surface-900,#18181b); border:1px solid var(--p-surface-600,#52525b); border-radius:6px; color:inherit; font-size:.78rem; padding:.35rem .5rem; resize:vertical; min-height:2.6rem; width:100%; box-sizing:border-box; }
+    .cmcp-tr-steps { display:flex; gap:.35rem; margin:.6rem 1.25rem 0; flex:none; }
+    .cmcp-tr-steps span { font-size:.72rem; padding:.15rem .6rem; border-radius:999px; background:color-mix(in srgb, currentColor 8%, transparent); opacity:.55; }
+    .cmcp-tr-steps span.on { opacity:1; background:var(--p-surface-700,#3f3f46); }
+    .cmcp-tr-progress { height:10px; border-radius:999px; background:var(--p-surface-800,#27272a); overflow:hidden; }
+    .cmcp-tr-progress > div { height:100%; background:var(--p-primary-color,#64748b); transition:width .4s; }
+    .cmcp-tr-log { background:var(--p-surface-900,#18181b); border-radius:8px; padding:.5rem .7rem; font-family:monospace; font-size:.72rem; max-height:140px; overflow-y:auto; white-space:pre-wrap; word-break:break-all; opacity:.85; }
+    .cmcp-tr-samples { display:flex; gap:.5rem; flex-wrap:wrap; }
+    .cmcp-tr-samples img { width:120px; height:120px; object-fit:cover; border-radius:8px; cursor:pointer; }
+    .cmcp-tr-jobrow { display:flex; align-items:center; gap:.6rem; padding:.5rem .25rem; border-bottom:1px solid var(--p-surface-700,#3f3f46); cursor:pointer; }
+    .cmcp-tr-jobrow:hover { background:color-mix(in srgb, currentColor 4%, transparent); }
+    .cmcp-tr-jobrow .name { flex:1; font-size:.85rem; }
+    .cmcp-tr-jobrow .meta { font-size:.75rem; opacity:.6; }
+    .cmcp-tr-preflight { display:flex; gap:1rem; flex-wrap:wrap; font-size:.78rem; }
+    .cmcp-tr-preflight span b { font-weight:600; }
   `;
   document.head.appendChild(style);
 }
 
 const FLOWS = [
-  { title: "Image Character", icon: "pi-user", models: ["Krea2", "Flux2", "ZImg"], desc: "Train a person or character into an image model." },
+  { title: "Image Character", icon: "pi-user", models: ["FLUX.1-dev"], desc: "Train a person or character into an image model.", live: true },
   { title: "Image Edit", icon: "pi-pencil", models: ["Qwen Edit 2509"], desc: "Teach an edit model your custom transformation." },
   { title: "Image Style", icon: "pi-palette", models: ["Krea2", "Flux2", "ZImg"], desc: "Capture an art style you can apply to any prompt." },
   { title: "Image Slider", icon: "pi-sliders-h", models: ["Krea2", "Flux2", "ZImg"], desc: "A concept slider with adjustable strength." },
   { title: "Video Character", icon: "pi-video", models: ["LTX 2.3", "Wan 2.2"], desc: "Bring a character into video generation." },
   { title: "Video Action", icon: "pi-forward", models: ["LTX 2.3", "Wan 2.2"], desc: "Teach a motion or action to a video model." },
 ];
+
+const PRESETS = {
+  smoke: { label: "Smoke test", params: { steps: 200, saveEvery: 100, sampleEvery: 100, resolution: [512] }, note: "~10 min on a 4090 — proves the pipeline, not a usable LoRA." },
+  standard: { label: "Standard", params: { steps: 2000, lr: 1e-4, rank: 16, resolution: [512, 768, 1024], saveEvery: 250, sampleEvery: 250, quantize: true }, note: "~1–2 h on a 4090. The real thing." },
+  custom: { label: "Custom", params: null, note: "Edit every parameter yourself." },
+};
 
 /** The rig's GPU ("RTX 4090 24GB") from ComfyUI's /system_stats — the panel
  *  runs on the ComfyUI origin, so this always reaches the right instance. */
@@ -73,94 +129,905 @@ async function fetchGpuLabel(api) {
   }
 }
 
+function el(tag, cls, text) {
+  const e = document.createElement(tag);
+  if (cls) e.className = cls;
+  if (text !== undefined) e.textContent = text;
+  return e;
+}
+
+/** callTool envelope → parsed JSON (train_* tools return text-wrapped JSON). */
+async function callJson(ctx, tool, args, opts) {
+  if (!ctx.callTool) throw new Error("panel bridge not connected — start the comfyui-mcp orchestrator");
+  const res = await ctx.callTool(tool, args, opts);
+  const text = (res?.result || []).map((c) => c?.text || "").join("").trim();
+  if (!res || res.ok === false) {
+    // The bridge flags MCP errors with ok:false but KEEPS the tool's own
+    // content — prefer the actionable tool message (JSON error, root message,
+    // or plain text) over the generic bridge one (codex finding).
+    let msg = res?.error || `${tool} failed`;
+    if (text) {
+      try {
+        const errData = JSON.parse(text);
+        if (errData?.error?.message) msg = errData.error.message;
+        else if (errData?.message) msg = errData.message;
+        else msg = text;
+      } catch {
+        msg = text; // plain-text tool error (e.g. dataset rejection)
+      }
+    }
+    throw new Error(msg);
+  }
+  let data;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    throw new Error(`${tool} returned unexpected output`);
+  }
+  if (data && data.ok === false) {
+    throw new Error(data.error?.message || `${tool} failed`);
+  }
+  return data;
+}
+
+function apiUrl(ctx, path) {
+  // Route through ComfyUI's API base (supports non-root base-path deployments);
+  // fall back to root-relative when the api helper isn't around (codex finding).
+  try {
+    if (ctx.api?.apiURL) return ctx.api.apiURL(path);
+  } catch { /* fall through */ }
+  return path;
+}
+
+async function apiFetch(ctx, path, opts) {
+  if (ctx.api?.fetchApi) return ctx.api.fetchApi(path, opts);
+  return fetch(apiUrl(ctx, path), opts);
+}
+
+function viewUrl(ctx, ref) {
+  const q = new URLSearchParams({ filename: ref.filename, type: ref.type || "output" });
+  if (ref.subfolder) q.set("subfolder", ref.subfolder);
+  return apiUrl(ctx, `/view?${q.toString()}`);
+}
+
+function sampleUrl(ctx, path) {
+  return apiUrl(ctx, `/comfyui_mcp_panel/training/file?path=${encodeURIComponent(path)}`);
+}
+
+function sanitizeNameClient(name) {
+  const cleaned = String(name || "").trim().replace(/[^a-zA-Z0-9._-]+/g, "_").replace(/^_+|_+$/g, "");
+  // Dot-only names ("."/"..") fall back server-side ("dataset"/"lora") — reject
+  // them here so the launched name can't silently diverge from the reviewed one.
+  if (!cleaned || /^\.+$/.test(cleaned)) return "";
+  return cleaned;
+}
+
+function fmtAgo(iso) {
+  const t = Date.parse(iso || "");
+  if (!t) return "";
+  const s = Math.max(0, (Date.now() - t) / 1000);
+  if (s < 60) return `${Math.floor(s)}s ago`;
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`;
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`;
+  return `${Math.floor(s / 86400)}d ago`;
+}
+
+const STATUS_BADGE = { running: "ok", queued: "warn", completed: "ok", failed: "err", cancelled: "warn" };
+
 export function openTrainingModal(ctx = {}) {
   injectCss();
   const overlay = document.createElement("div");
   overlay.className = "cmcp-cv-overlay";
   const modal = document.createElement("div");
   modal.className = "cmcp-modal cmcp-tr-modal";
-  const close = () => overlay.remove();
+
+  let pollTimer = null;
+  let pollGen = 0;
+  let closed = false;
+  const stopPolling = () => {
+    pollGen++; // invalidate any in-flight poll response
+    if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; }
+  };
+  const close = () => {
+    closed = true;
+    stopPolling();
+    wiz.launchGen++; // a pending launch's continuation self-discards (codex finding)
+    wiz.uploadGen++;
+    overlay.remove();
+  };
   overlay.addEventListener("mousedown", (e) => { if (e.target === overlay) close(); });
 
-  const head = document.createElement("div");
-  head.className = "cmcp-tr-head";
-  const title = document.createElement("h2");
-  title.textContent = "LoRA Training";
-  const badge = document.createElement("span");
-  badge.className = "cmcp-tr-badge";
-  badge.textContent = "Coming soon";
-  const closeBtn = document.createElement("button");
-  closeBtn.className = "cmcp-tr-close";
+  // Wizard state (one character-LoRA job being configured/tracked). Held at
+  // modal scope so it survives view navigation: launching/uploadsPending MUST
+  // outlive individual renders (codex findings: double-launch via Back, stale
+  // upload tracking across gather re-entry).
+  const wiz = {
+    datasetName: "",
+    trigger: "",
+    images: [], // { ref: {filename, subfolder, type}, thumb, caption }
+    preset: "standard",
+    params: { ...PRESETS.standard.params },
+    customParams: undefined,
+    jobId: null,
+    job: null,
+    launching: false,
+    launchError: null,
+    uploadsPending: 0,
+    /** Generations: bumped on launch/reset so a stale async continuation (an
+     *  in-flight launch or upload batch from a PREVIOUS wizard run) can't
+     *  mutate the new run's state (codex findings). */
+    launchGen: 0,
+    uploadGen: 0,
+  };
+  /** Reset the configuration fields for a genuinely NEW run (Jobs → "New
+   *  character LoRA") — a fresh run must not silently reuse the previous
+   *  dataset (codex finding). Bumps both generations so stale continuations
+   *  self-discard. REFUSED while a launch is in flight: the backend may still
+   *  start that container, and resetting would orphan it from this modal
+   *  (and invite a second GPU job alongside it). */
+  function resetWizardConfig() {
+    if (wiz.launching) return false;
+    wiz.datasetName = "";
+    wiz.trigger = "";
+    wiz.images = [];
+    wiz.preset = "standard";
+    wiz.params = { ...PRESETS.standard.params };
+    wiz.customParams = undefined;
+    wiz.jobId = null;
+    wiz.job = null;
+    wiz.launchError = null;
+    wiz.uploadsPending = 0;
+    wiz.launchGen++;
+    wiz.uploadGen++;
+    return true;
+  }
+
+  const head = el("div", "cmcp-tr-head");
+  const title = el("h2", null, "LoRA Training");
+  const jobsBtn = el("button", "cmcp-tr-btn", "Jobs");
+  jobsBtn.style.flex = "none";
+  const closeBtn = el("button", "cmcp-tr-close");
   closeBtn.innerHTML = "&#10005;";
   closeBtn.title = "Close";
   closeBtn.onclick = close;
-  head.append(title, badge, closeBtn);
+  head.append(title, jobsBtn, closeBtn);
 
-  // Local / Cloud switch — cosmetic for now; Local shows the REAL GPU.
-  const seg = document.createElement("div");
-  seg.className = "cmcp-tr-seg";
-  const localBtn = document.createElement("button");
-  localBtn.className = "active";
-  localBtn.textContent = "Local (your rig)";
-  const cloudBtn = document.createElement("button");
-  cloudBtn.textContent = "Cloud (RunPod)";
-  seg.append(localBtn, cloudBtn);
-  fetchGpuLabel(ctx.api).then((gpu) => {
-    if (gpu) localBtn.textContent = `Local (${gpu})`;
-  });
-
-  const token = document.createElement("div");
-  token.className = "cmcp-tr-token";
-  token.hidden = true;
-  const tokenInput = document.createElement("input");
-  tokenInput.type = "password";
-  tokenInput.placeholder = "RunPod API token";
-  tokenInput.disabled = true;
-  const tokenNote = document.createElement("small");
-  tokenNote.textContent = "Coming soon — pods and training runs managed for you, headlessly.";
-  token.append(tokenInput, tokenNote);
-
-  localBtn.onclick = () => { localBtn.classList.add("active"); cloudBtn.classList.remove("active"); token.hidden = true; };
-  cloudBtn.onclick = () => { cloudBtn.classList.add("active"); localBtn.classList.remove("active"); token.hidden = false; };
-
-  const grid = document.createElement("div");
-  grid.className = "cmcp-tr-grid";
-  for (const f of FLOWS) {
-    const card = document.createElement("div");
-    card.className = "cmcp-tr-card";
-    const icon = document.createElement("div");
-    icon.className = "cmcp-tr-icon";
-    const i = document.createElement("i");
-    i.className = `pi ${f.icon}`;
-    icon.appendChild(i);
-    const select = document.createElement("select");
-    for (const m of f.models) {
-      const o = document.createElement("option");
-      o.textContent = m;
-      select.appendChild(o);
-    }
-    const h = document.createElement("h3");
-    h.textContent = f.title;
-    const p = document.createElement("p");
-    p.textContent = f.desc;
-    const b = document.createElement("span");
-    b.className = "cmcp-tr-badge";
-    b.textContent = "Coming soon";
-    card.append(icon, select, h, p, b);
-    grid.appendChild(card);
-  }
-
-  const foot = document.createElement("div");
-  foot.className = "cmcp-tr-foot";
-  foot.textContent = "LoRA training is on the roadmap — nothing here works yet.";
-
-  // Scroll containment (CivitAI-modal structure): head + switch stay fixed;
-  // the card grid scrolls inside the body.
-  const body = document.createElement("div");
-  body.className = "cmcp-tr-body";
-  body.append(grid, foot);
-  modal.append(head, seg, token, body);
+  const stepsBar = el("div", "cmcp-tr-steps");
+  const body = el("div", "cmcp-tr-body");
+  modal.append(head, stepsBar, body);
   overlay.appendChild(modal);
   document.body.appendChild(overlay);
+
+  function setSteps(names, current) {
+    stepsBar.textContent = "";
+    stepsBar.style.display = names ? "" : "none";
+    (names || []).forEach((n, i) => {
+      const s = el("span", i === current ? "on" : null, n);
+      stepsBar.appendChild(s);
+    });
+  }
+
+  let currentView = "flows";
+  function show(view) {
+    if (closed) return;
+    currentView = view;
+    stopPolling();
+    body.textContent = "";
+    if (view === "flows") { setSteps(null); renderFlows(); }
+    else if (view === "jobs") { setSteps(null); renderJobs(); }
+    else if (view === "wizard-1") { setSteps(["1 · Dataset", "2 · Label", "3 · Launch", "4 · Monitor"], 0); renderGather(); }
+    else if (view === "wizard-2") { setSteps(["1 · Dataset", "2 · Label", "3 · Launch", "4 · Monitor"], 1); renderLabel(); }
+    else if (view === "wizard-3") { setSteps(["1 · Dataset", "2 · Label", "3 · Launch", "4 · Monitor"], 2); renderLaunch(); }
+    else if (view === "wizard-4") { setSteps(["1 · Dataset", "2 · Label", "3 · Launch", "4 · Monitor"], 3); renderMonitor(); }
+  }
+
+  jobsBtn.onclick = () => show("jobs");
+
+  // ---------------------------------------------------------------- flows ---
+  function renderFlows() {
+    const grid = el("div", "cmcp-tr-grid");
+    for (const f of FLOWS) {
+      const card = el("div", `cmcp-tr-card${f.live ? " active" : ""}`);
+      const icon = el("div", "cmcp-tr-icon");
+      const i = el("i", `pi ${f.icon}`);
+      icon.appendChild(i);
+      const select = document.createElement("select");
+      for (const m of f.models) {
+        const o = document.createElement("option");
+        o.textContent = m;
+        select.appendChild(o);
+      }
+      if (f.live) select.disabled = true;
+      const h = el("h3", null, f.title);
+      const p = el("p", null, f.desc);
+      if (f.live) {
+        const b = el("span", "cmcp-tr-badge ok", "Local · ready");
+        const start = el("button", "cmcp-tr-btn primary", "Start");
+        start.onclick = () => {
+          if (!resetWizardConfig()) { alert("A launch is still in flight — let it settle (or cancel it from Jobs) before starting a new run."); return; }
+          show("wizard-1");
+        };
+        card.append(icon, select, h, p, b, start);
+      } else {
+        const b = el("span", "cmcp-tr-badge", "Coming soon (P2)");
+        card.append(icon, select, h, p, b);
+      }
+      grid.appendChild(card);
+    }
+    const foot = el("div", "cmcp-tr-foot",
+      "Character LoRAs train locally on this rig (ai-toolkit in a GPU container, FLUX.1-dev). Style / edit / slider / video flows land in P2; RunPod in P4.");
+    body.append(grid, foot);
+  }
+
+  // --------------------------------------------------------------- gather ---
+  let backendChecked = false;
+  let backendCapable = false;
+  /** One-time capability gate: train_* tools only exist on an orchestrator
+   *  running the trainer release (mcp PR #237+). Older orchestrators reject
+   *  call_tool — detect that at wizard entry instead of letting the user walk
+   *  into a doomed launch (codex finding). */
+  async function checkBackendCapable() {
+    if (backendChecked) return backendCapable;
+    try {
+      await callJson(ctx, "train_list_flows", {}, { timeout: 15000 });
+      backendCapable = true;
+    } catch {
+      backendCapable = false;
+    }
+    backendChecked = true;
+    return backendCapable;
+  }
+
+  function renderGather() {
+    const sec = el("div", "cmcp-tr-section");
+    // Capability gate (async): swap in a blocking notice when the orchestrator
+    // predates the trainer.
+    checkBackendCapable().then((capable) => {
+      syncNext();
+      if (capable) return;
+      sec.textContent = "";
+      const card = el("div", "cmcp-tr-card");
+      card.append(el("h3", null, "Trainer backend not available"));
+      card.append(el("p", null,
+        "The connected orchestrator doesn't expose the train_* tools — it needs to run the comfyui-mcp release that includes the LoRA trainer (PR #237 or later), and the panel's bridge must point at it. Upgrade/restart the orchestrator, then reopen this wizard."));
+      const back2 = el("button", "cmcp-tr-btn", "← Flows");
+      back2.onclick = () => show("flows");
+      card.append(back2);
+      sec.appendChild(card);
+    });
+
+    const nameRow = el("div", "cmcp-tr-row");
+    nameRow.append(el("label", null, "Dataset name"));
+    const nameInput = el("input", null);
+    nameInput.type = "text";
+    nameInput.placeholder = "e.g. aria_character";
+    nameInput.value = wiz.datasetName;
+    nameInput.oninput = () => { wiz.datasetName = nameInput.value; syncNext(); };
+    nameRow.appendChild(nameInput);
+
+    const trigRow = el("div", "cmcp-tr-row");
+    trigRow.append(el("label", null, "Trigger word"));
+    const trigInput = el("input", null);
+    trigInput.type = "text";
+    trigInput.placeholder = "e.g. ohwx — a rare token, not a real word";
+    trigInput.value = wiz.trigger;
+    trigInput.oninput = () => { wiz.trigger = trigInput.value.trim(); };
+    trigRow.appendChild(trigInput);
+    sec.append(nameRow, trigRow, el("p", "cmcp-tr-hint",
+      "10–30 varied images of the subject work best (angles, lighting, backgrounds). The trigger word goes in every caption."));
+
+    // Source tabs.
+    const tabs = el("div", "cmcp-tr-seg");
+    tabs.style.margin = "0";
+    const outTab = el("button", "active", "From outputs");
+    const upTab = el("button", null, "Upload");
+    tabs.append(outTab, upTab);
+    const tabBody = el("div");
+    sec.append(tabs, tabBody);
+
+    // Selection tray.
+    const trayLabel = el("p", "cmcp-tr-hint");
+    const tray = el("div", "cmcp-tr-tray");
+    const nav = el("div", "cmcp-tr-row");
+    nav.style.marginTop = ".4rem";
+    const back = el("button", "cmcp-tr-btn", "← Flows");
+    back.onclick = () => show("flows");
+    const next = el("button", "cmcp-tr-btn primary", "Next: label captions →");
+    next.onclick = () => show("wizard-2");
+    nav.append(back, next);
+    sec.append(trayLabel, tray, nav);
+    body.appendChild(sec);
+
+    function syncTray() {
+      trayLabel.textContent = wiz.images.length
+        ? `${wiz.images.length} selected${wiz.images.length < 6 ? " — add more for a usable LoRA (10–30 recommended)" : ""}`
+        : "Nothing selected yet.";
+      tray.textContent = "";
+      wiz.images.forEach((img, idx) => {
+        const chip = el("div", "cmcp-tr-chip");
+        chip.style.backgroundImage = `url("${img.thumb}")`;
+        const x = el("button", null, "×");
+        x.title = "Remove";
+        x.onclick = () => { wiz.images.splice(idx, 1); syncTray(); syncNext(); if (refreshGridSel) refreshGridSel(); };
+        chip.appendChild(x);
+        tray.appendChild(chip);
+      });
+    }
+
+    function syncNext() {
+      // Also gated on the backend capability check: until train_list_flows
+      // resolves, advancing is blocked (codex finding: the gate was bypassable
+      // while pending).
+      next.disabled = !backendCapable || wiz.uploadsPending > 0 || !(wiz.images.length >= 1 && sanitizeNameClient(wiz.datasetName));
+      next.title = !backendCapable && !backendChecked ? "Checking trainer backend…"
+        : wiz.uploadsPending > 0 ? `Waiting for ${wiz.uploadsPending} upload(s)…` : "";
+    }
+
+    // Outputs tab.
+    let refreshGridSel = null;
+    async function renderOutputs() {
+      tabBody.textContent = "";
+      const filterRow = el("div", "cmcp-tr-row");
+      const filter = el("input", null);
+      filter.type = "text";
+      filter.placeholder = "Filter by filename…";
+      filterRow.appendChild(filter);
+      const grid = el("div", "cmcp-tr-pickgrid");
+      const status = el("p", "cmcp-tr-hint", "Loading recent outputs…");
+      tabBody.append(filterRow, status, grid);
+      let images = [];
+      try {
+        const res = await apiFetch(ctx, "/comfyui_mcp_panel/training/list-outputs?limit=120");
+        const data = await res.json();
+        images = data.images || [];
+        status.textContent = images.length ? "" : "No output images found — generate something first, or use Upload.";
+      } catch (e) {
+        status.textContent = `Could not list outputs: ${e.message || e}`;
+        return;
+      }
+      const isSel = (img) => wiz.images.some((w) => w.ref.filename === img.filename && (w.ref.subfolder || "") === (img.subfolder || "") && w.ref.type === "output");
+      function paint() {
+        grid.textContent = "";
+        const pat = filter.value.trim().toLowerCase();
+        for (const img of images) {
+          if (pat && !img.filename.toLowerCase().includes(pat)) continue;
+          const cell = el("div", "cmcp-tr-pick");
+          const url = viewUrl(ctx, { filename: img.filename, subfolder: img.subfolder, type: "output" });
+          // <img loading=lazy> — CSS backgrounds would eagerly decode ALL ~120
+          // full-res outputs at once (codex finding: hundreds of MB, stalled modal).
+          const thumb = document.createElement("img");
+          thumb.loading = "lazy";
+          thumb.src = url;
+          thumb.alt = img.filename;
+          cell.appendChild(thumb);
+          if (isSel(img)) cell.classList.add("sel");
+          const mark = el("div", "mark", isSel(img) ? "✓" : "+");
+          cell.appendChild(mark);
+          cell.title = img.subfolder ? `${img.subfolder}/${img.filename}` : img.filename;
+          cell.onclick = () => {
+            const at = wiz.images.findIndex((w) => w.ref.filename === img.filename && (w.ref.subfolder || "") === (img.subfolder || "") && w.ref.type === "output");
+            if (at >= 0) wiz.images.splice(at, 1);
+            else wiz.images.push({ ref: { filename: img.filename, subfolder: img.subfolder || undefined, type: "output" }, thumb: url, caption: "" });
+            syncTray(); syncNext(); paint();
+          };
+          grid.appendChild(cell);
+        }
+        refreshGridSel = paint;
+      }
+      filter.oninput = paint;
+      paint();
+    }
+
+    // Upload tab.
+    function renderUpload() {
+      tabBody.textContent = "";
+      const drop = el("div", "cmcp-tr-drop", "Drop images here, or click to browse");
+      const picker = document.createElement("input");
+      picker.type = "file";
+      picker.accept = "image/png,image/jpeg,image/webp";
+      picker.multiple = true;
+      picker.style.display = "none";
+      const status = el("p", "cmcp-tr-hint");
+      tabBody.append(drop, picker, status);
+      async function addFiles(files) {
+        if (!ctx.uploadBlobToInput) { status.textContent = "Upload unavailable (no bridge helper)."; return; }
+        // Track the batch: Next stays disabled until every upload settles, so a
+        // user can't advance mid-batch and silently lose/re-caption the files
+        // still in flight (codex finding).
+        const batch = files.filter((f) => /\.(png|jpe?g|webp)$/i.test(f.name));
+        const skipped = files.length - batch.length;
+        const failed = [];
+        const gen = wiz.uploadGen;
+        wiz.uploadsPending += batch.length;
+        syncNext();
+        for (const f of batch) {
+          status.textContent = `Uploading ${f.name}… (${wiz.images.length} added)`;
+          try {
+            const ref = await ctx.uploadBlobToInput(f, f.name.replace(/[^a-zA-Z0-9._-]+/g, "_"));
+            if (gen !== wiz.uploadGen) return; // wizard was reset mid-batch — discard
+            if (!ref) { failed.push(f.name); continue; }
+            wiz.images.push({ ref: { filename: ref.filename, subfolder: ref.subfolder, type: "input" }, thumb: viewUrl(ctx, { ...ref, type: "input" }), caption: "" });
+          } finally {
+            // Only settle the counter when the batch still belongs to the
+            // current wizard run (a reset zeroed it already).
+            if (gen === wiz.uploadGen) wiz.uploadsPending -= 1;
+            syncTray(); syncNext();
+          }
+        }
+        // Batch summary PERSISTS (codex finding: per-file errors were cleared
+        // by the next success, hiding an incomplete dataset).
+        const parts = [];
+        if (skipped) parts.push(`${skipped} skipped (png/jpg/webp only)`);
+        if (failed.length) parts.push(`${failed.length} FAILED: ${failed.join(", ")}`);
+        status.textContent = parts.join(" · ");
+        status.style.color = failed.length ? "#ef4444" : "";
+      }
+      drop.onclick = () => picker.click();
+      picker.onchange = () => addFiles([...picker.files]);
+      drop.ondragover = (e) => { e.preventDefault(); drop.classList.add("over"); };
+      drop.ondragleave = () => drop.classList.remove("over");
+      drop.ondrop = (e) => { e.preventDefault(); drop.classList.remove("over"); addFiles([...e.dataTransfer.files]); };
+    }
+
+    outTab.onclick = () => { outTab.classList.add("active"); upTab.classList.remove("active"); renderOutputs(); };
+    upTab.onclick = () => { upTab.classList.add("active"); outTab.classList.remove("active"); renderUpload(); };
+    renderOutputs();
+    syncTray();
+    syncNext();
+  }
+
+  // ---------------------------------------------------------------- label ---
+  function renderLabel() {
+    const sec = el("div", "cmcp-tr-section");
+    const bulk = el("div", "cmcp-tr-row");
+    const prefixBtn = el("button", "cmcp-tr-btn", `Prefix "${wiz.trigger || "trigger"}" to all`);
+    prefixBtn.onclick = () => {
+      const t = wiz.trigger.trim();
+      if (!t) return;
+      wiz.images.forEach((img) => {
+        const c = img.caption.trim();
+        if (!c) img.caption = t;
+        else if (!c.toLowerCase().startsWith(t.toLowerCase())) img.caption = `${t} ${c}`;
+      });
+      paint();
+    };
+    const applyAllBtn = el("button", "cmcp-tr-btn", "Apply first caption to all");
+    applyAllBtn.onclick = () => {
+      const first = (wiz.images[0]?.caption || "").trim();
+      if (!first) return;
+      wiz.images.forEach((img) => { img.caption = first; });
+      paint();
+    };
+    const clearBtn = el("button", "cmcp-tr-btn", "Clear all");
+    clearBtn.onclick = () => { wiz.images.forEach((img) => { img.caption = ""; }); paint(); };
+    bulk.append(prefixBtn, applyAllBtn, clearBtn);
+    const countHint = el("p", "cmcp-tr-hint");
+    const grid = el("div", "cmcp-tr-labelgrid");
+    const nav = el("div", "cmcp-tr-row");
+    const back = el("button", "cmcp-tr-btn", "← Dataset");
+    back.onclick = () => show("wizard-1");
+    const next = el("button", "cmcp-tr-btn primary", "Next: review & launch →");
+    next.onclick = () => show("wizard-3");
+    nav.append(back, next);
+    sec.append(bulk, countHint, grid, nav);
+    body.appendChild(sec);
+
+    function syncHint() {
+      const captioned = wiz.images.filter((i) => i.caption.trim()).length;
+      countHint.textContent = `${captioned}/${wiz.images.length} captioned — caption what CHANGES between images (pose, setting, clothing); the trigger word covers identity. Empty captions fall back to the trigger word.`;
+    }
+    function paint() {
+      grid.textContent = "";
+      wiz.images.forEach((img) => {
+        const item = el("div", "cmcp-tr-labelitem");
+        const thumb = el("div", "thumb");
+        thumb.style.backgroundImage = `url("${img.thumb}")`;
+        const ta = document.createElement("textarea");
+        ta.placeholder = wiz.trigger ? `${wiz.trigger} …` : "caption…";
+        ta.value = img.caption;
+        ta.oninput = () => { img.caption = ta.value; syncHint(); };
+        item.append(thumb, ta);
+        grid.appendChild(item);
+      });
+      syncHint();
+    }
+    paint();
+  }
+
+  // --------------------------------------------------------------- launch ---
+  function renderLaunch() {
+    const sec = el("div", "cmcp-tr-section");
+    const captioned = wiz.images.filter((i) => i.caption.trim()).length;
+    // Live summary (rank updates with preset switches + custom edits).
+    const summaryHint = el("p", "cmcp-tr-hint");
+    const syncSummary = () => {
+      const effRank = wiz.preset === "custom" ? (wiz.customParams?.rank ?? 16) : (PRESETS[wiz.preset].params?.rank ?? 16);
+      summaryHint.textContent = `Dataset "${sanitizeNameClient(wiz.datasetName)}" — ${wiz.images.length} images, ${captioned} with custom captions${wiz.trigger ? `, trigger "${wiz.trigger}"` : ""}. Model: FLUX.1-dev (quantized, rank ${effRank}).`;
+    };
+    syncSummary();
+    sec.append(summaryHint);
+
+    // Presets.
+    const presetSeg = el("div", "cmcp-tr-seg");
+    presetSeg.style.margin = "0";
+    const presetNote = el("p", "cmcp-tr-hint");
+    const customBox = el("div", "cmcp-tr-row");
+    // Initialize visibility from the CURRENT preset and seed fields from the
+    // user's saved custom edits (codex finding: navigating away and back used
+    // to silently reseed defaults and submit them).
+    customBox.style.display = wiz.preset === "custom" ? "" : "none";
+    const customFields = {};
+    // Assigned once the launch button exists (below); persist() calls it during
+    // seeding too, so start with a no-op.
+    let syncLaunchEnabled = () => {};
+    // Strict full-token parsers — parseInt/parseFloat truncate ("2000oops" →
+    // 2000), which would submit a value the user can't see (codex finding).
+    const parseIntStrict = (v) => (/^\d+$/.test(v.trim()) ? parseInt(v.trim(), 10) : NaN);
+    const parseLrStrict = (v) => (/^\d+(\.\d+)?([eE][-+]?\d+)?$/.test(v.trim()) ? parseFloat(v.trim()) : NaN);
+    const parseResStrict = (v) => {
+      const parts = v.split(",").map((s) => s.trim()).filter(Boolean);
+      return parts.length && parts.every((p) => /^\d+$/.test(p) && parseInt(p, 10) > 0) ? parts.map((p) => parseInt(p, 10)) : null;
+    };
+    for (const [key, label] of [["steps", "Steps"], ["lr", "Learning rate"], ["rank", "LoRA rank"], ["resolution", "Resolutions (comma)"]]) {
+      const l = el("label", null, label);
+      l.style.minWidth = "auto";
+      const inp = el("input", null);
+      inp.type = "text";
+      inp.style.flex = "0 1 110px";
+      const saved = wiz.customParams?.[key];
+      inp.value = saved !== undefined
+        ? (key === "resolution" ? saved.join(",") : String(saved))
+        : (key === "resolution" ? "512,768,1024" : String(PRESETS.standard.params[key] ?? ""));
+      customFields[key] = inp;
+      const persist = () => {
+        wiz.customParams = wiz.customParams || {};
+        if (key === "resolution") {
+          const list = parseResStrict(inp.value);
+          if (list) wiz.customParams.resolution = list;
+          else delete wiz.customParams.resolution;
+        } else {
+          const n = key === "lr" ? parseLrStrict(inp.value) : parseIntStrict(inp.value);
+          if (Number.isFinite(n) && n > 0) wiz.customParams[key] = n;
+          else delete wiz.customParams[key];
+        }
+        syncLaunchEnabled();
+      };
+      inp.oninput = () => { persist(); syncSummary(); };
+      persist(); // capture the seeded values too
+      customBox.append(l, inp);
+    }
+    function syncCustomValidity() {
+      // Launch is blocked while a custom field is visibly invalid — submitting a
+      // stale previously-valid value the user no longer sees would silently
+      // change an expensive run (codex finding).
+      if (wiz.preset !== "custom") return true;
+      return ["steps", "lr", "rank"].every((k) => {
+        const n = k === "lr" ? parseLrStrict(customFields[k].value) : parseIntStrict(customFields[k].value);
+        return Number.isFinite(n) && n > 0;
+      }) && !!parseResStrict(customFields.resolution.value);
+    }
+    for (const key of Object.keys(PRESETS)) {
+      const b = el("button", key === wiz.preset ? "active" : null, PRESETS[key].label);
+      b.onclick = () => {
+        wiz.preset = key;
+        [...presetSeg.children].forEach((c) => c.classList.remove("active"));
+        b.classList.add("active");
+        customBox.style.display = key === "custom" ? "" : "none";
+        presetNote.textContent = PRESETS[key].note;
+        // Hidden custom fields can't be invalid — recompute the launch gate
+        // (codex finding: switching off Custom left a stale disable).
+        syncLaunchEnabled();
+        syncSummary();
+      };
+      presetSeg.appendChild(b);
+    }
+    presetNote.textContent = PRESETS[wiz.preset].note;
+    sec.append(presetSeg, presetNote, customBox);
+
+    // Preflight. Launch stays disabled until the doctor resolves — a pending
+    // call that eventually reports a remote (non-local) ComfyUI must not leave
+    // a clickable window for a doomed launch (codex finding).
+    let preflightState = "pending"; // pending | local | remote | failed
+    const pre = el("div", "cmcp-tr-preflight");
+    pre.append(el("span", null, "Preflight: checking…"));
+    sec.append(pre);
+    const gpuLine = el("p", "cmcp-tr-hint");
+    sec.append(gpuLine);
+    fetchGpuLabel(ctx.api).then((gpu) => { if (gpu) gpuLine.textContent = `Local GPU: ${gpu}`; });
+    callJson(ctx, "train_doctor", {}, { timeout: 180000 }).then((d) => {
+      const dd = d.data || {};
+      pre.textContent = "";
+      const mk = (label, ok) => el("span", null, `${label}: `);
+      for (const [label, ok] of [["docker", dd.docker], ["gpu", dd.gpu], ["image", dd.image], ["hf token", dd.hfTokenSet]]) {
+        const s = el("span");
+        s.innerHTML = `${label}: <b style="color:${ok ? "#22c55e" : "#ef4444"}">${ok ? "✓" : "✗"}</b>`;
+        pre.appendChild(s);
+      }
+      (dd.hints || []).forEach((h) => sec.appendChild(el("p", "cmcp-tr-hint", `⚠ ${h}`)));
+      if (dd.localFs === false) {
+        preflightState = "remote";
+        sec.appendChild(el("p", "cmcp-tr-hint",
+          "⚠ The orchestrator targets a REMOTE ComfyUI — dataset staging and the LoRA handoff need a ComfyUI local to the orchestrator's machine; launching from here would fail at staging. Point the orchestrator at this local ComfyUI first."));
+      } else if (!dd.docker || !dd.gpu || !dd.image) {
+        // Missing prerequisites guarantee a rejected/failed run — keep Launch
+        // disabled until the doctor passes (codex finding).
+        preflightState = "prereq";
+      } else {
+        preflightState = "local";
+      }
+      syncLaunchEnabled();
+    }).catch((e) => {
+      // Doctor unreachable/unavailable: train_start does its own docker+image
+      // preflight server-side and reports honestly, so don't block on this.
+      preflightState = "failed";
+      syncLaunchEnabled();
+      pre.textContent = "";
+      pre.appendChild(el("span", null, `Preflight unavailable: ${e.message}`));
+    });
+
+    // Launch.
+    const err = el("p", "cmcp-tr-hint");
+    err.style.color = "#ef4444";
+    // Persisted across renders: a failure that lands while the user is on a
+    // different view is shown when they return here (codex finding).
+    if (wiz.launchError) err.textContent = wiz.launchError;
+    const nav = el("div", "cmcp-tr-row");
+    const back = el("button", "cmcp-tr-btn", "← Label");
+    back.onclick = () => show("wizard-2");
+    const launch = el("button", "cmcp-tr-btn primary", "Launch training");
+    nav.append(back, launch);
+    sec.append(err, nav);
+    body.appendChild(sec);
+
+    syncLaunchEnabled = () => {
+      launch.disabled = wiz.launching || preflightState !== "local" && preflightState !== "failed" || !syncCustomValidity();
+      if (wiz.launching) launch.textContent = "Launching…";
+      else launch.textContent = "Launch training";
+    };
+    syncLaunchEnabled();
+
+    launch.onclick = async () => {
+      err.textContent = "";
+      if (!syncCustomValidity()) {
+        err.textContent = "Fix the custom parameters first — every field needs a positive value.";
+        return;
+      }
+      // Modal-scoped lock: navigating Back/Jobs and returning must NOT allow a
+      // second launch while this one is mid-flight (codex finding).
+      const gen = ++wiz.launchGen;
+      wiz.launching = true;
+      wiz.launchError = null;
+      syncLaunchEnabled();
+      // Snapshot the FULL launch configuration up front (codex finding): the
+      // user can navigate and edit while the async resolve/stage/start is in
+      // flight — the submitted job must be exactly what was reviewed at click
+      // time, not a mix of old paths and new captions/settings.
+      const snapTrigger = wiz.trigger || undefined;
+      const snap = {
+        name: sanitizeNameClient(wiz.datasetName),
+        trigger: snapTrigger,
+        images: wiz.images.map((i) => {
+          let caption = i.caption.trim();
+          // The UI tells users the trigger belongs in EVERY caption — enforce it
+          // at snapshot time too (defaultCaption only covers empty ones, so a
+          // hand-written caption could otherwise omit it and waste a run on a
+          // LoRA unassociated with the token; codex finding).
+          if (caption && snapTrigger && !caption.toLowerCase().startsWith(snapTrigger.toLowerCase())) {
+            caption = `${snapTrigger} ${caption}`;
+          }
+          return { ref: { ...i.ref }, caption: caption || undefined };
+        }),
+        params: wiz.preset === "custom"
+          ? (Object.keys(wiz.customParams || {}).length ? { ...wiz.customParams } : undefined)
+          : { ...PRESETS[wiz.preset].params },
+      };
+      try {
+        // 1) Resolve image refs → host paths.
+        const res = await apiFetch(ctx, "/comfyui_mcp_panel/training/resolve-paths", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ images: snap.images.map((i) => i.ref) }),
+        });
+        const resolved = (await res.json()).paths || [];
+        if (gen !== wiz.launchGen) return; // superseded BEFORE any side effect
+        const bad = resolved.filter((r) => r.error);
+        if (bad.length) throw new Error(`${bad.length} image(s) could not be resolved: ${bad[0].error}`);
+        // 2) Stage dataset.
+        const items = resolved.map((r, i) => ({ path: r.path, caption: snap.images[i].caption }));
+        const prep = await callJson(ctx, "train_prepare_dataset", { name: snap.name, items, defaultCaption: snap.trigger }, { timeout: 60000 });
+        if (gen !== wiz.launchGen) return; // superseded after staging, before launch
+        // 3) Launch.
+        const started = await callJson(ctx, "train_start", {
+          name: snap.name, flow: "character", model: "flux1-dev",
+          datasetPath: prep.datasetPath, trigger: snap.trigger, params: snap.params,
+        }, { timeout: 120000 });
+        if (gen !== wiz.launchGen) return; // a newer launch/reset superseded this one
+        wiz.jobId = started.job.id;
+        wiz.job = started.job;
+        wiz.launching = false;
+        // Success must be VISIBLE: take the user to the new run's monitor
+        // regardless of where they wandered mid-launch (codex finding).
+        show("wizard-4");
+      } catch (e) {
+        if (gen !== wiz.launchGen) return; // stale handler — new run owns the state
+        wiz.launching = false;
+        wiz.launchError = e.message || String(e);
+        // Failures must also be visible when the user left the launch step.
+        if (currentView === "wizard-3") {
+          err.textContent = wiz.launchError;
+        } else {
+          alert(`Training launch failed: ${wiz.launchError}`);
+        }
+        syncLaunchEnabled();
+      }
+    };
+  }
+
+  // -------------------------------------------------------------- monitor ---
+  /** Persistent badge node — updated in place (replaceWith would detach it on
+   *  the first poll and leave every later status invisible; codex finding). */
+  function setBadge(badgeEl, status) {
+    badgeEl.textContent = status;
+    badgeEl.className = `cmcp-tr-badge ${STATUS_BADGE[status] || ""}`;
+  }
+
+  function jobStatusBadge(job) {
+    return el("span", `cmcp-tr-badge ${STATUS_BADGE[job.status] || ""}`, job.status);
+  }
+
+  function renderMonitor() {
+    // Monotonic generation: bumps on every monitor (re)entry AND on stopPolling,
+    // so a slow in-flight response from a previous monitor view is dropped
+    // instead of overwriting the new one (codex finding).
+    const myGen = ++pollGen;
+    const sec = el("div", "cmcp-tr-section");
+    const headRow = el("div", "cmcp-tr-row");
+    const nameEl = el("h3", null, wiz.job?.name || wiz.jobId || "job");
+    nameEl.style.margin = "0";
+    const badge = el("span", "cmcp-tr-badge", "…");
+    headRow.append(nameEl, badge);
+    const barWrap = el("div", "cmcp-tr-progress");
+    const bar = el("div");
+    bar.style.width = "0%";
+    barWrap.appendChild(bar);
+    const statLine = el("p", "cmcp-tr-hint");
+    const samplesLabel = el("p", "cmcp-tr-hint");
+    const samples = el("div", "cmcp-tr-samples");
+    const logBox = el("div", "cmcp-tr-log");
+    const resultBox = el("div", "cmcp-tr-section");
+    resultBox.style.padding = "0";
+    const nav = el("div", "cmcp-tr-row");
+    const cancelBtn = el("button", "cmcp-tr-btn danger", "Cancel run");
+    const jobsNavBtn = el("button", "cmcp-tr-btn", "All jobs");
+    jobsNavBtn.onclick = () => show("jobs");
+    nav.append(cancelBtn, jobsNavBtn);
+    sec.append(headRow, barWrap, statLine, samplesLabel, samples, resultBox, logBox, nav);
+    body.appendChild(sec);
+
+    let lastStep = null;
+    let lastStepAt = null;
+
+    cancelBtn.onclick = async () => {
+      if (!wiz.jobId) return;
+      if (!confirm("Cancel this training run? Saved checkpoints stay in the job's output dir; no LoRA is handed off.")) return;
+      cancelBtn.disabled = true;
+      try {
+        await callJson(ctx, "train_cancel", { id: wiz.jobId }, { timeout: 60000 });
+      } catch (e) {
+        alert(e.message || String(e));
+      } finally {
+        cancelBtn.disabled = false;
+      }
+    };
+
+    async function poll() {
+      if (!wiz.jobId || myGen !== pollGen) return;
+      try {
+        const d = await callJson(ctx, "train_status", { id: wiz.jobId }, { timeout: 30000 });
+        if (myGen !== pollGen) return; // view changed while the request was out
+        const job = d.job;
+        wiz.job = job;
+        setBadge(badge, job.status);
+        const p = job.progress || {};
+        if (p.totalSteps) {
+          const pct = Math.min(100, Math.round(((p.step || 0) / p.totalSteps) * 100));
+          bar.style.width = `${pct}%`;
+          let eta = "";
+          if (p.step !== undefined && lastStep !== null && p.step > lastStep) {
+            const perSec = (Date.now() - lastStepAt) / (p.step - lastStep);
+            const left = Math.round(((p.totalSteps - p.step) * perSec) / 1000);
+            if (left > 5) eta = ` · ~${Math.floor(left / 60)}m${left % 60 ? ` ${left % 60}s` : ""} left`;
+          }
+          if (p.step !== lastStep) { lastStep = p.step; lastStepAt = Date.now(); }
+          statLine.textContent = `step ${p.step ?? "—"}/${p.totalSteps}${p.loss !== undefined ? ` · loss ${Number(p.loss).toFixed(4)}` : ""}${eta} · updated ${fmtAgo(job.updatedAt)}`;
+        } else {
+          statLine.textContent = `${job.status} — model download / dataset caching can take several minutes on first run · updated ${fmtAgo(job.updatedAt)}`;
+        }
+        const s = p.samples || [];
+        if (s.length) {
+          samplesLabel.textContent = "Latest samples:";
+          samples.textContent = "";
+          for (const sp of s) {
+            const img = document.createElement("img");
+            img.src = sampleUrl(ctx, sp);
+            img.onclick = () => window.open(sampleUrl(ctx, sp), "_blank");
+            samples.appendChild(img);
+          }
+        } else {
+          samplesLabel.textContent = job.status === "running" ? "Samples appear here as the run produces them." : "";
+        }
+        logBox.textContent = (job.log || []).slice(-8).join("\n") || "(no log yet)";
+        logBox.scrollTop = logBox.scrollHeight;
+        const terminal = ["completed", "failed", "cancelled"].includes(job.status);
+        cancelBtn.style.display = terminal ? "none" : "";
+        resultBox.textContent = "";
+        if (job.status === "completed") {
+          stopPolling();
+          const card = el("div", "cmcp-tr-card active");
+          card.append(el("h3", null, "LoRA ready ✓"));
+          card.append(el("p", null, `${job.result?.loraRelPath || "copied to models/loras"} — in the LoRA picker now. Load it with LoraLoaderModelOnly on FLUX.1-dev${job.trigger ? ` and prompt with "${job.trigger}"` : ""}.`));
+          resultBox.appendChild(card);
+        } else if (job.status === "failed") {
+          stopPolling();
+          const card = el("div", "cmcp-tr-card");
+          card.append(el("h3", null, "Run failed"));
+          card.append(el("p", null, (job.error || "").slice(0, 600)));
+          resultBox.appendChild(card);
+        } else if (job.status === "cancelled") {
+          stopPolling();
+        }
+      } catch (e) {
+        if (myGen === pollGen) statLine.textContent = `status poll failed (bridge?) — retrying… (${e.message || e})`;
+      } finally {
+        // Chained (never overlapping) scheduling: the next poll starts only
+        // after this one settles — a slow bridge can't stack up requests or
+        // resolve them out of order (codex finding). stopPolling() bumps the
+        // generation, so terminal/navigation paths never reschedule.
+        if (myGen === pollGen) pollTimer = setTimeout(poll, 5000);
+      }
+    }
+    poll();
+  }
+
+  // ----------------------------------------------------------------- jobs ---
+  async function renderJobs() {
+    const sec = el("div", "cmcp-tr-section");
+    const topRow = el("div", "cmcp-tr-row");
+    const newBtn = el("button", "cmcp-tr-btn primary", "New character LoRA");
+    newBtn.onclick = () => {
+      if (!resetWizardConfig()) { alert("A launch is still in flight — let it settle (or cancel it from Jobs) before starting a new run."); return; }
+      show("wizard-1");
+    };
+    topRow.appendChild(newBtn);
+    const list = el("div");
+    list.append(el("p", "cmcp-tr-hint", "Loading jobs…"));
+    sec.append(topRow, list);
+    body.appendChild(sec);
+    let jobs = [];
+    try {
+      const d = await callJson(ctx, "train_status", {}, { timeout: 30000 });
+      jobs = d.jobs || [];
+    } catch (e) {
+      list.textContent = "";
+      list.append(el("p", "cmcp-tr-hint", `Could not load jobs: ${e.message || e}`));
+      return;
+    }
+    list.textContent = "";
+    if (!jobs.length) {
+      list.append(el("p", "cmcp-tr-hint", "No training runs yet."));
+      return;
+    }
+    for (const job of jobs) {
+      const row = el("div", "cmcp-tr-jobrow");
+      const name = el("span", "name", job.name);
+      const meta = el("span", "meta",
+        `${job.model}${job.progress?.totalSteps ? ` · ${job.progress.step ?? 0}/${job.progress.totalSteps}` : ""} · ${fmtAgo(job.createdAt)}`);
+      row.append(name, meta, jobStatusBadge(job));
+      row.onclick = () => { wiz.jobId = job.id; wiz.job = job; show("wizard-4"); };
+      list.appendChild(row);
+    }
+  }
+
+  show("flows");
   return { close };
 }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1362,7 +1362,7 @@ function panelSettingsList() {
     },
   });
   // A per-backend "Default reasoning effort" — a STATIC combo of THAT backend's
-  // fixed scale (Claude: low–max; Codex: none–xhigh; Gemini: no effort control).
+  // fixed scale (Claude: low–max; Codex: none–ultra; Gemini: no effort control).
   // No dynamic remap needed since the groups are separate. Drives the live panel
   // only for the active group.
   const effortSetting = (backend, sortOrder) => ({
@@ -1373,7 +1373,7 @@ function panelSettingsList() {
     tooltip:
       ((BACKEND_EFFORTS[backend] || ALL_EFFORTS).length
         ? `Default reasoning effort for the ${BACKEND_TEXT[backend]} agent, from its scale ` +
-          `(${backend === "codex" ? "none–xhigh" : "low–max"}). 'Model default' leaves it unset.`
+          `(${backend === "codex" ? "none–ultra" : "low–max"}). 'Model default' leaves it unset.`
         : `${BACKEND_TEXT[backend]} exposes no reasoning-effort control; leave this at 'Model default'.`),
     type: "combo",
     options: effortComboOptions(backend),
@@ -1818,6 +1818,7 @@ const EFFORT_META = {
   high: { label: "High", small: "thorough" },
   xhigh: { label: "Extra high", small: "deep" },
   max: { label: "Max", small: "exhaustive" },
+  ultra: { label: "Ultra", small: "no limits" },
 };
 const ALL_EFFORTS = ["low", "medium", "high", "xhigh", "max"];
 
@@ -1827,14 +1828,16 @@ const ALL_EFFORTS = ["low", "medium", "high", "xhigh", "max"];
 // nearest valid level for the target (the orchestrator backends do the same
 // mapping server-side; this keeps the picker honest about what's selectable).
 //   • Claude: low | medium | high | xhigh | max
-//   • Codex:  none | minimal | low | medium | high | xhigh
+//   • Codex:  none | minimal | low | medium | high | xhigh | max | ultra (GPT-5.6)
 //   • Gemini: (none) — the gemini CLI (run via `gemini --acp`) exposes no
 //     user-facing reasoning-effort levels, so the effort selector is hidden for
 //     it (empty scale → effortsForModel returns [], intersecting any model-
 //     reported levels down to none). The orchestrator maps effort server-side.
 const BACKEND_EFFORTS = {
   claude: ["low", "medium", "high", "xhigh", "max"],
-  codex: ["none", "minimal", "low", "medium", "high", "xhigh"],
+  // GPT-5.6 adds max + ultra (per-model ceilings come from the model list —
+  // Luna tops out at max; the intersection in effortsForModel handles that).
+  codex: ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"],
   gemini: [],
   // Grok rides the ACP CLI like gemini — no user-facing reasoning-effort scale.
   grok: [],
@@ -1851,7 +1854,7 @@ const BACKEND_EFFORTS = {
   custom: [],
 };
 // Ordered low→high across BOTH scales, for nearest-level mapping on a switch.
-const EFFORT_ORDER = ["none", "minimal", "low", "medium", "high", "xhigh", "max"];
+const EFFORT_ORDER = ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"];
 /** Snap `effort` to the nearest level present in `list` by EFFORT_ORDER rank.
  *  Shared levels pass through 1:1; an off-list source snaps to the closest by
  *  ordered rank (ties prefer the lower level). Returns `effort` unchanged when

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9725,15 +9725,21 @@ function buildPanel() {
     civitaiBtn.prepend(svg);
   }
 
-  // LoRA Training — the coming-soon preview modal (mobile-app parity). Same
-  // modal treatment as the CivitAI browser; dumbbell mark via currentColor.
+  // LoRA Training — the dataset gather/label/launch/monitor wizard for the
+  // local trainer (ai-toolkit in a GPU container, train_* tools over call_tool).
+  // Same modal treatment as the CivitAI browser; dumbbell mark via currentColor.
   let _trainingHandle = null;
   const trainingBtn = toolbarBtn("pi-circle", "Training");
   trainingBtn.querySelector(".pi").remove();
-  trainingBtn.title = "LoRA Training — coming soon: train character/style/edit/slider and video LoRAs, locally or on RunPod.";
+  trainingBtn.title = "LoRA Training — train a character LoRA locally on FLUX.1-dev (style/edit/slider/video coming in P2).";
   trainingBtn.addEventListener("click", () => {
     try { _trainingHandle?.close(); } catch {}
-    _trainingHandle = openTrainingModal({ api });
+    _trainingHandle = openTrainingModal({
+      api,
+      root,
+      callTool: (t, a, o) => liveBridgeClient?.callTool(t, a, o),
+      uploadBlobToInput,
+    });
   });
   {
     const svgNs = "http://www.w3.org/2000/svg";

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -98,7 +98,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.9.6";
+const PANEL_VERSION = "0.9.7";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1818,7 +1818,7 @@ const EFFORT_META = {
   high: { label: "High", small: "thorough" },
   xhigh: { label: "Extra high", small: "deep" },
   max: { label: "Max", small: "exhaustive" },
-  ultra: { label: "Ultra", small: "no limits" },
+  ultra: { label: "Ultra", small: "4 parallel agents" },
 };
 const ALL_EFFORTS = ["low", "medium", "high", "xhigh", "max"];
 


### PR DESCRIPTION
## What

Adds a **Local / Pod** target switch to the LoRA training wizard (stacked on #96): pick local docker training on the rig, or a connected RunPod pod — matching the mcp-side `train_start` `target` param (Artokun/comfyui-mcp#263).

- Local: unchanged flow (docker on this rig)
- Pod: enabled when the RunPod connector has a connected/watched pod; surfaces the pod id; disabled with an honest hint otherwise

E2E-proven through the real tool surface on an A40 pod (mcp PR #263 has the run details: 200 steps, loss 0.16, LoRA delivered pod+local, catalog upsert).

🤖 Generated with [Kimi Code](https://github.com/MoonshotAI/kimi-code)