### PR TITLE
fix(credentials): render each slot's help text in the API Keys card

### DIFF
--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -182,7 +182,8 @@ function cmcpOpenCredentialsFrame(client) {
         <button data-save style="padding:6px 12px;border-radius:4px;cursor:pointer">Save</button>
         <button data-clear title="Remove this key from the orchestrator's store"
                 style="padding:6px 10px;border-radius:4px;cursor:pointer;${s.set ? "" : "display:none"}">Clear</button>
-      </div>`;
+      </div>
+      ${s.help ? `<div data-help style="font-size:11px;opacity:.55;margin-top:4px;line-height:1.45">${esc2(s.help)}</div>` : ""}`;
     const input = r.querySelector("[data-input]");
     const badge = r.querySelector("[data-badge]");
     const btn = r.querySelector("[data-save]");


### PR DESCRIPTION
Every credential slot has carried a `help` string from the orchestrator — and the API Keys card has **never rendered any of it**:

| slot | help text nobody has ever seen |
|---|---|
| OpenRouter | "Hosted models (MiMo, MiniMax, GPT, Claude…)" |
| Civitai | "Model downloads" |
| HuggingFace | "Model downloads" |
| RunPod | "Manage GPU pods (status/start/stop/connect)" |
| Google / Gemini | "Nano Banana concept images" |
| … | (all 10 slots) |

The field is sent by `panel-secrets.CREDENTIAL_SLOTS` and silently dropped by `row()`, so that guidance has been dead weight the whole time.

## Change

Two lines: render `s.help` as a muted line under the input.

```js
${s.help ? `<div data-help style="font-size:11px;opacity:.55;margin-top:4px;line-height:1.45">${esc2(s.help)}</div>` : ""}
```

Escaped via the existing `esc2`, and omitted entirely when a slot has no help.

## Paired with

**comfyui-mcp#264** — adds *"which model am I on / how do I change it"* to the api-key providers' help (so a Z.AI Coding Plan user can discover `COMFYUI_MCP_GLM_MODEL` to reach GLM 5.2). That text is **invisible without this PR**.

Verified the server serves the updated module (`hasDataHelp=true`). I could not get a screenshot of it rendered — the browser kept executing a cached copy of the panel module through a hard reload, an HTTP cache revalidation, and a ComfyUI restart (no service worker involved). Worth a look on a fresh profile.