### PR TITLE
feat(ui): docs wordmark in the panel header; chat bubble back in the sidebar

### DIFF
--- a/web/img/comfyui-mcp-wordmark.svg
+++ b/web/img/comfyui-mcp-wordmark.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 236 40" role="img" aria-label="comfyui-mcp">
+  <rect x="2" y="6" width="28" height="28" rx="7" fill="#3B82F6"/>
+  <g fill="none" stroke="#0b1220" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="12" cy="16" r="3"/>
+    <circle cx="22" cy="26" r="3"/>
+    <path d="M15 16h3.5a3 3 0 0 1 3 3v3.5"/>
+  </g>
+  <text x="40" y="26" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, sans-serif" font-size="18" font-weight="700" fill="#f1f5f9">comfyui<tspan fill="#60A5FA">-mcp</tspan></text>
+</svg>

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -970,8 +970,10 @@ function applyTabBadge() {
     icon.classList.remove("cmcp-tab-logo", "pi-comments");
     icon.classList.add("pi-spinner", "pi-spin", "cmcp-tab-spinner");
   } else {
-    icon.classList.remove("pi-spinner", "pi-spin", "cmcp-tab-spinner", "pi-comments");
-    icon.classList.add("cmcp-tab-logo");
+    // Back to the chat bubble. `cmcp-tab-logo` is still stripped here so an icon
+    // left masked by an older build recovers on the next repaint.
+    icon.classList.remove("pi-spinner", "pi-spin", "cmcp-tab-spinner", "cmcp-tab-logo");
+    icon.classList.add("pi-comments");
   }
   const btn = icon.closest("button") || icon.parentElement;
   if (!btn) return;
@@ -7325,8 +7327,10 @@ const PANEL_CSS = `
   padding: 0.75rem 1rem;
   border-bottom: 1px solid var(--p-content-border-color, #3f3f46);
 }
-.cmcp-logo { width: 20px; height: 20px; flex: none; border-radius: 4px; object-fit: contain; display: block; }
-.cmcp-title { font-size: 0.9375rem; font-weight: 600; }
+/* The wordmark is ~5.9:1, so pin the HEIGHT and let width follow — the old
+   square 20x20 rule would squash it. max-width keeps it from crowding the
+   header actions on a narrow sidebar. */
+.cmcp-logo { height: 20px; width: auto; max-width: 148px; flex: none; object-fit: contain; display: block; }
 .cmcp-status { display: flex; align-items: center; gap: 0.375rem; margin-left: auto;
   font-size: 0.6875rem; color: var(--p-text-muted-color, #a1a1aa); }
 .cmcp-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--p-red-400, #f87171); flex: none; }
@@ -8343,9 +8347,11 @@ function buildPanel() {
   // it works regardless of where the extension is mounted.
   const logo = document.createElement("img");
   logo.className = "cmcp-logo";
-  logo.alt = "";
-  logo.setAttribute("aria-hidden", "true");
-  const LOGO_SERVED_PATH = "/extensions/comfyui-mcp-panel/img/comfyui-mcp-logo.png";
+  // The wordmark carries the product name, so it IS the header's label — the
+  // separate "Agent" text that used to sit beside it was redundant and is gone.
+  // Keep it announced for screen readers rather than aria-hidden.
+  logo.alt = "comfyui-mcp";
+  const LOGO_SERVED_PATH = "/extensions/comfyui-mcp-panel/img/comfyui-mcp-wordmark.svg";
   // A 404 on the module-resolved URL must also recover — not just a URL()
   // construction failure. Fall back to the served path once (a flag prevents an
   // error loop if the served path itself 404s) (P2 c).
@@ -8355,14 +8361,11 @@ function buildPanel() {
     logo.src = LOGO_SERVED_PATH;
   });
   try {
-    logo.src = new URL("../img/comfyui-mcp-logo.png", import.meta.url).href;
+    logo.src = new URL("../img/comfyui-mcp-wordmark.svg", import.meta.url).href;
   } catch {
     logo.dataset.fellBack = "1";
     logo.src = LOGO_SERVED_PATH;
   }
-  const title = document.createElement("span");
-  title.className = "cmcp-title";
-  title.textContent = "Agent";
   const status = document.createElement("button");
   status.type = "button";
   status.className = "cmcp-status cmcp-status-btn";
@@ -8410,7 +8413,7 @@ function buildPanel() {
   const histPop = document.createElement("div");
   histPop.className = "cmcp-popover cmcp-popover--down";
   histPop.hidden = true;
-  header.append(logo, title, actions, status, histPop);
+  header.append(logo, actions, status, histPop);
   root.appendChild(header);
 
   // ── Utility strip (row 2): agent-feed gates now live here instead of
@@ -14740,10 +14743,11 @@ function registerExtensionWhenReady(tries = 0) {
       const tabSpec = {
         id: tabId,
         title: "Agent",
-        // Our own logo mark (CSS mask, currentColor) — same mark as the
-        // registry icon and mobile app, so every surface shows one identity.
-        // `pi` keeps PrimeIcon box sizing; the mask class paints the glyph.
-        icon: "pi cmcp-tab-logo",
+        // The chat bubble. The sidebar rail is a row of FUNCTION glyphs (assets,
+        // nodes, models, workflows…), so a brand mark there reads as decoration
+        // and doesn't say what the tab does — brand belongs in the panel header,
+        // which is where the wordmark now lives.
+        icon: "pi pi-comments",
         tooltip: "ComfyUI Agent Panel — your agent session's window into this graph",
         type: "custom",
         // KEEP-ALIVE: the panel (bridge client, agent session, chat DOM) is built


### PR DESCRIPTION
Three requested changes.

## 1. Header logo → the docs mark

The header showed the dark-blue app tile (`web/img/comfyui-mcp-logo.png` — byte-identical to `assets/icon.png`, which is what the **registry** uses). The **docs** site uses a different, flatter mark (`docs/logo/dark.svg`: blue tile + two-node glyph + `comfyui-mcp` wordmark).

Shipped that mark here as `web/img/comfyui-mcp-wordmark.svg` so the panel matches the docs surface.

## 2. "Agent" text → removed

The wordmark already says *comfyui-mcp*, so the adjacent label was redundant. The logo is now the header's label and carries its **alt text** for screen readers — it had been `aria-hidden` only because the text was there to announce it.

## 3. Sidebar icon → chat bubble

Back to `pi pi-comments` from the logo mask.

The sidebar rail is a row of **function** glyphs (assets, nodes, models, workflows…), so a brand mark there reads as decoration and doesn't say what the tab does. Brand belongs in the header — which is exactly where it now lives.

`applyTabBadge()` still strips `cmcp-tab-logo` on repaint, so an icon left masked by an older build recovers on the next state change instead of staying stuck.

## One thing that had to change with it

`.cmcp-logo` was `width: 20px; height: 20px`. The wordmark is ~5.9:1, so a square box would have squashed it. Height is pinned and width follows, with a `max-width` so it can't crowd the header actions in a narrow sidebar.

## Verification

Rendered the asset in a standalone replica of the header (same padding, flex, dark background) at its real size — legible at 20px, not distorted, status pill unaffected.

I did **not** verify in the live panel: the running install is served from the main checkout, which currently holds another session's uncommitted work, and this browser has repeatedly executed a cached copy of the panel module through hard reloads, cache revalidation and a ComfyUI restart. Worth a look on a fresh profile when convenient.