### PR TITLE
Add durable IndexedDB transcript storage

### DIFF
--- a/browser_tests/conversation-persistence.spec.ts
+++ b/browser_tests/conversation-persistence.spec.ts
@@ -225,6 +225,57 @@ test('restores from IndexedDB after the localStorage shadow is lost', async ({
   await expect(panel.agentBubbles.filter({ hasText: 'indexeddb-only reply' }).last()).toBeVisible()
 })
 
+test('panel delete remains final when a stale tab republishes the removed thread', async ({
+  page,
+  context,
+  panel,
+  mockBridge
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  const received = mockBridge.waitForUserMessage()
+  await panel.sendMessage('delete me causally')
+  await received
+  await expect.poll(() => indexedHasText(page, 'delete me causally')).toBe(true)
+  const removedThreadId = await page.evaluate((key) => sessionStorage.getItem(key), CURRENT_THREAD_KEY)
+  expect(removedThreadId).not.toBeNull()
+
+  const staleTab = await context.newPage()
+  await staleTab.goto(page.url())
+  const staleSnapshot = await staleTab.evaluate((snapshotKey) =>
+    JSON.parse(localStorage.getItem(snapshotKey) || '{}'), LOCAL_HISTORY_SNAPSHOT_KEY)
+  expect(staleSnapshot.threads?.some((thread: any) => thread.id === removedThreadId)).toBe(true)
+
+  await panel.root.getByTitle('Chat history').click()
+  await panel.root.locator('.cmcp-hist-row', { hasText: 'delete me causally' })
+    .getByTitle('Delete this chat')
+    .click()
+  await expect.poll(() => indexedHasThread(page, removedThreadId!)).toBe(false)
+  await expect.poll(() => page.evaluate(({ snapshotKey, threadId }) => {
+    const snapshot = JSON.parse(localStorage.getItem(snapshotKey) || '{}')
+    const tombstone = snapshot.meta?.deletedThreads?.[threadId]
+    return tombstone?.deleted === true && Number.isFinite(tombstone?.revision?.updatedAt)
+  }, { snapshotKey: LOCAL_HISTORY_SNAPSHOT_KEY, threadId: removedThreadId! })).toBe(true)
+
+  await staleTab.evaluate(async (snapshot) => {
+    const { ChatHistoryStore } = await import('/extensions/comfyui-mcp-panel/lib/chat-history-store.js')
+    const staleStore = new ChatHistoryStore({ writerId: 'stale-panel-test' })
+    staleStore.persist(snapshot.threads || [], snapshot.meta || {})
+    const result = await staleStore.flush()
+    if (result !== true && result?.ok !== true) throw new Error(`stale write failed: ${JSON.stringify(result)}`)
+    await staleStore.close?.()
+  }, staleSnapshot)
+
+  await page.reload()
+  await panel.openSidebar()
+  await expect(panel.userBubble('delete me causally')).toHaveCount(0)
+  await expect.poll(() => indexedHasThread(page, removedThreadId!)).toBe(false)
+  await staleTab.close()
+})
+
 test('reload keeps the pointed conversation and live tab session during durable hydration', async ({
   page,
   panel,

--- a/browser_tests/conversation-persistence.spec.ts
+++ b/browser_tests/conversation-persistence.spec.ts
@@ -48,26 +48,26 @@ async function indexedHasText(page: import('@playwright/test').Page, text: strin
   }, text)
 }
 
-async function seedReloadRace(
+async function seedReloadEvictionRace(
   page: import('@playwright/test').Page,
   currentThreadId: string
 ): Promise<void> {
   await page.evaluate(async ({ pointedId }) => {
     const future = Date.now() + 60_000
-    const background = {
-      id: 'newer-background-thread',
+    const background = Array.from({ length: 500 }, (_, i) => ({
+      id: `newer-background-thread-${i}`,
       schemaVersion: 2,
-      workflowKey: 'workflow:background-race',
-      createdAt: future - 100,
-      updatedAt: future,
-      ts: future,
+      workflowKey: `workflow:background-race-${i}`,
+      createdAt: future + i,
+      updatedAt: future + i,
+      ts: future + i,
       msgs: [{
-        id: 'newer-background-message',
+        id: `newer-background-message-${i}`,
         role: 'user',
-        text: 'newer background transcript',
-        createdAt: future
+        text: i === 0 ? 'newer background transcript' : `background transcript ${i}`,
+        createdAt: future + i
       }]
-    }
+    }))
     const rewrite = (snapshot: any) => {
       const threads = Array.isArray(snapshot?.threads) ? snapshot.threads : []
       const pointed = threads.find((thread: any) => thread.id === pointedId)
@@ -79,7 +79,10 @@ async function seedReloadRace(
       return {
         ...snapshot,
         updatedAt: future,
-        threads: [...threads.filter((thread: any) => thread.id !== background.id), background],
+        threads: [
+          ...threads.filter((thread: any) => !thread.id?.startsWith('newer-background-thread-')),
+          ...background
+        ],
         meta: {
           ...(snapshot?.meta || {}),
           updatedAt: future,
@@ -220,7 +223,7 @@ test('reload keeps the pointed conversation and live tab session during durable 
   )
   expect(currentThreadId).not.toBeNull()
   await expect.poll(() => indexedHasText(page, 'conversation selected by this tab')).toBe(true)
-  await seedReloadRace(page, currentThreadId!)
+  await seedReloadEvictionRace(page, currentThreadId!)
 
   await page.evaluate(() => localStorage.removeItem('comfyui-mcp.panel.autoConnect'))
   await page.reload()
@@ -232,10 +235,20 @@ test('reload keeps the pointed conversation and live tab session during durable 
     () => page.evaluate((key) => sessionStorage.getItem(key), SESSION_KEY)
   ).toBe('live-tab-session')
 
-  // Cross the settings-hydration boundary and the async IndexedDB load. Neither
-  // is allowed to repaint another conversation or replace the live tab session.
-  await page.waitForTimeout(3_000)
+  // The active metadata rewrite occurs only after settings + IndexedDB hydration,
+  // so this is a deterministic completion signal for the final binding.
+  await expect.poll(() => page.evaluate(() => {
+    const meta = JSON.parse(localStorage.getItem('comfyui-mcp.panel.historyMeta') || '{}')
+    return meta.activeByScope?.['panel:global'] || null
+  })).toBe(currentThreadId)
   await expect(panel.userBubble('conversation selected by this tab')).toBeVisible()
   await expect(panel.userBubble('newer background transcript')).toHaveCount(0)
   expect(await page.evaluate((key) => sessionStorage.getItem(key), SESSION_KEY)).toBe('live-tab-session')
+  expect(await page.evaluate((pointedId) => {
+    const shadow = JSON.parse(localStorage.getItem('comfyui-mcp.panel.threads') || '[]')
+    return {
+      count: shadow.length,
+      hasPointed: shadow.some((thread: any) => thread.id === pointedId)
+    }
+  }, currentThreadId)).toEqual({ count: 20, hasPointed: true })
 })

--- a/browser_tests/conversation-persistence.spec.ts
+++ b/browser_tests/conversation-persistence.spec.ts
@@ -380,6 +380,16 @@ test('workflow rename publishes alias tombstones and a stale tab cannot echo the
   panel,
   mockBridge
 }) => {
+  await page.route(
+    (url) => /\/(api\/)?settings\/?$/.test(url.pathname),
+    async (route) => {
+      if (route.request().method() !== 'GET') return route.continue()
+      const response = await route.fetch()
+      const settings = await response.json() as Record<string, unknown>
+      settings['comfyui-mcp.sessionFollowsPanel'] = false
+      await route.fulfill({ response, json: settings })
+    }
+  )
   await panel.goto()
   await panel.openSidebar()
   await page.evaluate(() => {

--- a/browser_tests/conversation-persistence.spec.ts
+++ b/browser_tests/conversation-persistence.spec.ts
@@ -48,6 +48,77 @@ async function indexedHasText(page: import('@playwright/test').Page, text: strin
   }, text)
 }
 
+async function seedReloadRace(
+  page: import('@playwright/test').Page,
+  currentThreadId: string
+): Promise<void> {
+  await page.evaluate(async ({ pointedId }) => {
+    const future = Date.now() + 60_000
+    const background = {
+      id: 'newer-background-thread',
+      schemaVersion: 2,
+      workflowKey: 'workflow:background-race',
+      createdAt: future - 100,
+      updatedAt: future,
+      ts: future,
+      msgs: [{
+        id: 'newer-background-message',
+        role: 'user',
+        text: 'newer background transcript',
+        createdAt: future
+      }]
+    }
+    const rewrite = (snapshot: any) => {
+      const threads = Array.isArray(snapshot?.threads) ? snapshot.threads : []
+      const pointed = threads.find((thread: any) => thread.id === pointedId)
+      if (pointed) {
+        pointed.sessionId = 'stale-stored-session'
+        pointed.updatedAt = future - 1
+        pointed.ts = future - 1
+      }
+      return {
+        ...snapshot,
+        updatedAt: future,
+        threads: [...threads.filter((thread: any) => thread.id !== background.id), background],
+        meta: {
+          ...(snapshot?.meta || {}),
+          updatedAt: future,
+          activeByScope: {
+            ...(snapshot?.meta?.activeByScope || {}),
+            'panel:global': 'missing-active-pointer'
+          }
+        }
+      }
+    }
+
+    const localThreads = JSON.parse(localStorage.getItem('comfyui-mcp.panel.threads') || '[]')
+    const localMeta = JSON.parse(localStorage.getItem('comfyui-mcp.panel.historyMeta') || '{}')
+    const local = rewrite({ threads: localThreads, meta: localMeta })
+    localStorage.setItem('comfyui-mcp.panel.threads', JSON.stringify(local.threads))
+    localStorage.setItem('comfyui-mcp.panel.historyMeta', JSON.stringify(local.meta))
+
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('comfyui-mcp-panel-history', 2)
+      request.onsuccess = () => resolve(request.result)
+      request.onerror = () => reject(request.error)
+    })
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction('snapshots', 'readwrite')
+        const store = tx.objectStore('snapshots')
+        const get = store.get('state')
+        get.onsuccess = () => store.put(rewrite(get.result || {}), 'state')
+        get.onerror = () => reject(get.error)
+        tx.oncomplete = () => resolve()
+        tx.onerror = () => reject(tx.error)
+        tx.onabort = () => reject(tx.error)
+      })
+    } finally {
+      db.close()
+    }
+  }, { pointedId: currentThreadId })
+}
+
 test('restores the latest panel-owned conversation after sessionStorage is lost', async ({
   page,
   panel,
@@ -122,4 +193,49 @@ test('restores from IndexedDB after the localStorage shadow is lost', async ({
 
   await expect(panel.userBubble('indexeddb-only transcript')).toBeVisible()
   await expect(panel.agentBubbles.filter({ hasText: 'indexeddb-only reply' }).last()).toBeVisible()
+})
+
+test('reload keeps the pointed conversation and live tab session during durable hydration', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  mockBridge.send({ type: 'session', session_id: 'live-tab-session' })
+  const received = mockBridge.waitForUserMessage()
+  await panel.sendMessage('conversation selected by this tab')
+  await received
+  mockBridge.say('selected conversation reply')
+
+  await expect.poll(
+    () => page.evaluate((key) => sessionStorage.getItem(key), CURRENT_THREAD_KEY)
+  ).not.toBeNull()
+  const currentThreadId = await page.evaluate(
+    (key) => sessionStorage.getItem(key),
+    CURRENT_THREAD_KEY
+  )
+  expect(currentThreadId).not.toBeNull()
+  await expect.poll(() => indexedHasText(page, 'conversation selected by this tab')).toBe(true)
+  await seedReloadRace(page, currentThreadId!)
+
+  await page.evaluate(() => localStorage.removeItem('comfyui-mcp.panel.autoConnect'))
+  await page.reload()
+  await panel.openSidebar()
+
+  await expect(panel.userBubble('conversation selected by this tab')).toBeVisible()
+  await expect(panel.userBubble('newer background transcript')).toHaveCount(0)
+  await expect.poll(
+    () => page.evaluate((key) => sessionStorage.getItem(key), SESSION_KEY)
+  ).toBe('live-tab-session')
+
+  // Cross the settings-hydration boundary and the async IndexedDB load. Neither
+  // is allowed to repaint another conversation or replace the live tab session.
+  await page.waitForTimeout(3_000)
+  await expect(panel.userBubble('conversation selected by this tab')).toBeVisible()
+  await expect(panel.userBubble('newer background transcript')).toHaveCount(0)
+  expect(await page.evaluate((key) => sessionStorage.getItem(key), SESSION_KEY)).toBe('live-tab-session')
 })

--- a/browser_tests/conversation-persistence.spec.ts
+++ b/browser_tests/conversation-persistence.spec.ts
@@ -116,6 +116,28 @@ async function indexedHasThread(
   }, threadId)
 }
 
+async function indexedWorkflowAlias(
+  page: import('@playwright/test').Page,
+  workflowPath: string
+): Promise<string | null> {
+  return page.evaluate(async (path) => {
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('comfyui-mcp-panel-history', 3)
+      request.onsuccess = () => resolve(request.result)
+      request.onerror = () => reject(request.error)
+    })
+    try {
+      return await new Promise<string | null>((resolve, reject) => {
+        const request = db.transaction('snapshots', 'readonly').objectStore('snapshots').get('state')
+        request.onsuccess = () => resolve(request.result?.meta?.workflowAliases?.[path] || null)
+        request.onerror = () => reject(request.error)
+      })
+    } finally {
+      db.close()
+    }
+  }, workflowPath)
+}
+
 async function seedReloadEvictionRace(
   page: import('@playwright/test').Page,
   currentThreadId: string
@@ -319,6 +341,106 @@ test('panel delete remains final when a stale tab republishes the removed thread
   await panel.openSidebar()
   await expect(panel.userBubble('delete me causally')).toHaveCount(0)
   await expect.poll(() => indexedHasThread(page, removedThreadId!)).toBe(false)
+  await staleTab.close()
+})
+
+test('clear all removes durable transcripts, preserves workflow identity, and fences a stale tab', async ({
+  page,
+  context,
+  panel,
+  mockBridge
+}) => {
+  const workflowPath = 'workflows/identity-survives-clear.json'
+  const workflowUuid = 'identity-survives-clear'
+
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  mockBridge.send({ type: 'session', session_id: 'session-before-clear-all' })
+  const received = mockBridge.waitForUserMessage()
+  await panel.sendMessage('clear every durable transcript')
+  await received
+  mockBridge.say('reply that must also disappear')
+  await expect.poll(() => indexedHasText(page, 'clear every durable transcript')).toBe(true)
+
+  // Workflow aliases are durable identity metadata, not chat content. Seed one
+  // through the public store API so clearAll must preserve it while advancing
+  // the canonical checkpoint that fences stale transcript snapshots.
+  await page.evaluate(async ({ path, uuid }) => {
+    const storeModuleUrl = '/extensions/comfyui-agent-panel/js/lib/chat-history-store.js'
+    const { ChatHistoryStore, updateMetadataEntry } = await import(storeModuleUrl)
+    const seedStore = new ChatHistoryStore({ writerId: 'clear-all-alias-seed' })
+    const canonical = await seedStore.readCanonical()
+    if (!canonical) throw new Error('canonical history was unavailable while seeding an alias')
+    const meta = updateMetadataEntry(
+      canonical.meta,
+      'workflowAliases',
+      path,
+      uuid,
+      seedStore.nextRevision()
+    )
+    seedStore.persist(canonical.threads, meta)
+    const result = await seedStore.flush()
+    if (result !== true && result?.ok !== true) {
+      throw new Error(`alias seed failed: ${JSON.stringify(result)}`)
+    }
+    await seedStore.close?.()
+  }, { path: workflowPath, uuid: workflowUuid })
+  await expect.poll(() => indexedWorkflowAlias(page, workflowPath)).toBe(workflowUuid)
+
+  const staleTab = await context.newPage()
+  await staleTab.goto(page.url())
+  const staleSnapshot = await staleTab.evaluate((snapshotKey) =>
+    JSON.parse(localStorage.getItem(snapshotKey) || '{}'), LOCAL_HISTORY_SNAPSHOT_KEY)
+  expect(staleSnapshot.threads?.some((thread: any) =>
+    thread.msgs?.some((message: any) => message.text === 'clear every durable transcript')
+  )).toBe(true)
+
+  let stopListening = () => {}
+  const resetFrame = new Promise<void>((resolve) => {
+    stopListening = mockBridge.onFrame((frame) => {
+      if (frame.type !== 'new_session') return
+      stopListening()
+      resolve()
+    })
+  })
+
+  await panel.root.getByTitle('Chat history').click()
+  await expect(panel.root.getByText('Transcripts are stored in this browser using IndexedDB.'))
+    .toBeVisible()
+  page.once('dialog', (dialog) => dialog.accept())
+  await panel.root.getByRole('button', { name: 'Clear all history' }).click()
+  await resetFrame
+
+  await expect.poll(() => indexedThreadCount(page)).toBe(0)
+  await expect.poll(() => indexedWorkflowAlias(page, workflowPath)).toBe(workflowUuid)
+  await expect(panel.userBubble('clear every durable transcript')).toHaveCount(0)
+  await expect(panel.agentBubbles.filter({ hasText: 'reply that must also disappear' })).toHaveCount(0)
+  expect(await page.evaluate((key) => sessionStorage.getItem(key), CURRENT_THREAD_KEY)).toBeNull()
+  expect(await page.evaluate((key) => sessionStorage.getItem(key), SESSION_KEY)).toBeNull()
+
+  // A tab that captured the pre-reset snapshot must not resurrect any deleted
+  // transcript, but it must continue to converge on the preserved alias.
+  await staleTab.evaluate(async (snapshot) => {
+    const storeModuleUrl = '/extensions/comfyui-agent-panel/js/lib/chat-history-store.js'
+    const { ChatHistoryStore } = await import(storeModuleUrl)
+    const staleStore = new ChatHistoryStore({ writerId: 'stale-clear-all-panel' })
+    staleStore.persist(snapshot.threads || [], snapshot.meta || {})
+    const result = await staleStore.flush()
+    if (result !== true && result?.ok !== true) {
+      throw new Error(`stale write failed: ${JSON.stringify(result)}`)
+    }
+    await staleStore.close?.()
+  }, staleSnapshot)
+
+  await expect.poll(() => indexedThreadCount(page)).toBe(0)
+  await expect.poll(() => indexedWorkflowAlias(page, workflowPath)).toBe(workflowUuid)
+  await page.reload()
+  await panel.openSidebar()
+  await expect(panel.userBubble('clear every durable transcript')).toHaveCount(0)
+  await expect(panel.agentBubbles.filter({ hasText: 'reply that must also disappear' })).toHaveCount(0)
   await staleTab.close()
 })
 

--- a/browser_tests/conversation-persistence.spec.ts
+++ b/browser_tests/conversation-persistence.spec.ts
@@ -17,6 +17,31 @@ const HISTORY_STORE_SOURCE = readFileSync(
   'utf8'
 )
 
+async function forcePerWorkflowSettings(route: import('@playwright/test').Route) {
+  if (route.request().method() !== 'GET') return route.continue()
+  const response = await route.fetch()
+  const raw = await response.text()
+  let settings: Record<string, unknown> = {}
+  if (raw.trim()) {
+    try {
+      const parsed = JSON.parse(raw)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) settings = parsed
+    } catch {
+      // Some live ComfyUI builds transiently return an empty/truncated settings
+      // body during startup. The test only needs a deterministic scope setting.
+    }
+  }
+  settings['comfyui-mcp.sessionFollowsPanel'] = false
+  const headers = response.headers()
+  delete headers['content-length']
+  delete headers['content-encoding']
+  await route.fulfill({
+    status: 200,
+    headers: { ...headers, 'content-type': 'application/json' },
+    body: JSON.stringify(settings)
+  })
+}
+
 test.beforeEach(async ({ context }) => {
   // The target ComfyUI server may have been started before this worktree was
   // created. Route the two reviewed modules from the checked-out source so the
@@ -363,13 +388,7 @@ test('strict workflow storage sync detaches transcript todos and session before 
 }) => {
   await page.route(
     (url) => /\/(api\/)?settings\/?$/.test(url.pathname),
-    async (route) => {
-      if (route.request().method() !== 'GET') return route.continue()
-      const response = await route.fetch()
-      const settings = await response.json() as Record<string, unknown>
-      settings['comfyui-mcp.sessionFollowsPanel'] = false
-      await route.fulfill({ response, json: settings })
-    }
+    forcePerWorkflowSettings
   )
   await panel.goto()
   await panel.setBridgeUrl(mockBridge.url)
@@ -454,13 +473,7 @@ test('workflow rename publishes alias tombstones and a stale tab cannot echo the
 }) => {
   await page.route(
     (url) => /\/(api\/)?settings\/?$/.test(url.pathname),
-    async (route) => {
-      if (route.request().method() !== 'GET') return route.continue()
-      const response = await route.fetch()
-      const settings = await response.json() as Record<string, unknown>
-      settings['comfyui-mcp.sessionFollowsPanel'] = false
-      await route.fulfill({ response, json: settings })
-    }
+    forcePerWorkflowSettings
   )
   await panel.goto()
   await panel.openSidebar()

--- a/browser_tests/conversation-persistence.spec.ts
+++ b/browser_tests/conversation-persistence.spec.ts
@@ -484,6 +484,49 @@ test('workflow rename publishes alias tombstones and a stale tab cannot echo the
     }
   })).toEqual({ oldDeleted: true, newValue: workflowUuid })
 
+  // Model canonical compaction after the old-path delete has crossed the
+  // metadata-operation bound: the materialized aliases remain complete, while
+  // the delete operation itself no longer exists.
+  await page.evaluate(async () => {
+    const snapshotKey = 'comfyui-mcp.panel.historySnapshot'
+    const snapshot = JSON.parse(localStorage.getItem(snapshotKey) || '{}')
+    const revisions = Object.values(snapshot.meta?.aliasOps || {})
+      .map((operation: any) => operation?.revision)
+      .filter((revision: any) => Number.isFinite(revision?.updatedAt))
+    const revision = revisions.sort((a: any, b: any) => b.updatedAt - a.updatedAt)[0] || {
+      updatedAt: Date.now(), writerId: 'compaction-test', sequence: 1
+    }
+    snapshot.meta = {
+      ...(snapshot.meta || {}),
+      aliasOps: {},
+      checkpoint: {
+        generation: Number(snapshot.meta?.checkpoint?.generation || 0) + 1,
+        revision
+      }
+    }
+    localStorage.setItem(snapshotKey, JSON.stringify(snapshot))
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('comfyui-mcp-panel-history', 3)
+      request.onsuccess = () => resolve(request.result)
+      request.onerror = () => reject(request.error)
+    })
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction('snapshots', 'readwrite')
+        tx.objectStore('snapshots').put(snapshot, 'state')
+        tx.oncomplete = () => resolve()
+        tx.onerror = () => reject(tx.error)
+        tx.onabort = () => reject(tx.error)
+      })
+    } finally {
+      db.close()
+    }
+  })
+  await expect.poll(() => otherTab.evaluate(() => {
+    const aliases = JSON.parse(localStorage.getItem('comfyui-mcp.panel.workflowUuidAliases') || '{}')
+    return Object.hasOwn(aliases, 'workflows/alias-old.json')
+  })).toBe(false)
+
   await otherPanel.setBridgeUrl(mockBridge.url)
   await otherPanel.connect()
   const unrelated = mockBridge.waitForUserMessage()

--- a/browser_tests/conversation-persistence.spec.ts
+++ b/browser_tests/conversation-persistence.spec.ts
@@ -4,6 +4,7 @@
  * transcript and the backend session id from the durable thread record.
  */
 import { test, expect } from './fixtures/panelTest'
+import { PanelPage } from './fixtures/PanelPage'
 
 const SESSION_KEY = 'comfyui-mcp.panel.sessionId'
 const CURRENT_THREAD_KEY = 'comfyui-mcp.panel.currentThreadId'
@@ -370,5 +371,80 @@ test('strict workflow storage sync detaches transcript todos and session before 
   expect(rebound.thread?.workflowKey).toBe(`workflow:${rebound.workflowUuid}`)
   expect(rebound.thread?.sessionId).toBeUndefined()
   expect(rebound.sessionId).toBeNull()
+  await otherTab.close()
+})
+
+test('workflow rename publishes alias tombstones and a stale tab cannot echo them back', async ({
+  page,
+  context,
+  panel,
+  mockBridge
+}) => {
+  await panel.goto()
+  await panel.openSidebar()
+  await page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const workflow = app.extensionManager?.workflow?.activeWorkflow
+    Object.defineProperties(workflow, {
+      path: { configurable: true, writable: true, value: 'workflows/alias-old.json' },
+      isPersisted: { configurable: true, writable: true, value: true },
+      isTemporary: { configurable: true, writable: true, value: false }
+    })
+  })
+  await expect.poll(() => page.evaluate(() => {
+    const aliases = JSON.parse(localStorage.getItem('comfyui-mcp.panel.workflowUuidAliases') || '{}')
+    return aliases['workflows/alias-old.json'] || null
+  })).not.toBeNull()
+  const workflowUuid = await page.evaluate(() => {
+    const aliases = JSON.parse(localStorage.getItem('comfyui-mcp.panel.workflowUuidAliases') || '{}')
+    return aliases['workflows/alias-old.json']
+  })
+
+  const otherTab = await context.newPage()
+  const otherPanel = new PanelPage(otherTab)
+  await otherTab.goto(page.url())
+  await otherPanel.openSidebar()
+  await expect.poll(() => otherTab.evaluate(() => {
+    const aliases = JSON.parse(localStorage.getItem('comfyui-mcp.panel.workflowUuidAliases') || '{}')
+    return aliases['workflows/alias-old.json'] || null
+  })).toBe(workflowUuid)
+
+  await page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    app.extensionManager.workflow.activeWorkflow.path = 'workflows/alias-new.json'
+  })
+  await expect.poll(() => page.evaluate(() => {
+    const snapshot = JSON.parse(localStorage.getItem('comfyui-mcp.panel.historySnapshot') || '{}')
+    return {
+      oldDeleted: snapshot.meta?.aliasOps?.['workflows/alias-old.json']?.deleted === true,
+      newValue: snapshot.meta?.workflowAliases?.['workflows/alias-new.json'] || null
+    }
+  })).toEqual({ oldDeleted: true, newValue: workflowUuid })
+
+  await otherPanel.setBridgeUrl(mockBridge.url)
+  await otherPanel.connect()
+  const unrelated = mockBridge.waitForUserMessage()
+  await otherPanel.sendMessage('unrelated append after remote rename')
+  await unrelated
+  await expect.poll(() => otherTab.evaluate(() => {
+    const snapshot = JSON.parse(localStorage.getItem('comfyui-mcp.panel.historySnapshot') || '{}')
+    return snapshot.meta?.aliasOps?.['workflows/alias-old.json']?.deleted === true
+  })).toBe(true)
+
+  await page.reload()
+  await panel.openSidebar()
+  await otherTab.reload()
+  await otherPanel.openSidebar()
+  for (const tab of [page, otherTab]) {
+    await expect.poll(() => tab.evaluate(() => {
+      const aliases = JSON.parse(localStorage.getItem('comfyui-mcp.panel.workflowUuidAliases') || '{}')
+      return {
+        hasOld: Object.hasOwn(aliases, 'workflows/alias-old.json'),
+        newValue: aliases['workflows/alias-new.json'] || null
+      }
+    })).toEqual({ hasOld: false, newValue: workflowUuid })
+  }
   await otherTab.close()
 })

--- a/browser_tests/conversation-persistence.spec.ts
+++ b/browser_tests/conversation-persistence.spec.ts
@@ -7,6 +7,7 @@ import { test, expect } from './fixtures/panelTest'
 
 const SESSION_KEY = 'comfyui-mcp.panel.sessionId'
 const CURRENT_THREAD_KEY = 'comfyui-mcp.panel.currentThreadId'
+const LOCAL_HISTORY_SNAPSHOT_KEY = 'comfyui-mcp.panel.historySnapshot'
 
 async function indexedThreadCount(page: import('@playwright/test').Page): Promise<number> {
   return page.evaluate(async () => {
@@ -46,6 +47,30 @@ async function indexedHasText(page: import('@playwright/test').Page, text: strin
       db.close()
     }
   }, text)
+}
+
+async function indexedHasThread(
+  page: import('@playwright/test').Page,
+  threadId: string
+): Promise<boolean> {
+  return page.evaluate(async (id) => {
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('comfyui-mcp-panel-history', 2)
+      request.onsuccess = () => resolve(request.result)
+      request.onerror = () => reject(request.error)
+    })
+    try {
+      return await new Promise<boolean>((resolve, reject) => {
+        const request = db.transaction('snapshots', 'readonly').objectStore('snapshots').get('state')
+        request.onsuccess = () => resolve(Boolean(
+          request.result?.threads?.some((thread: any) => thread.id === id)
+        ))
+        request.onerror = () => reject(request.error)
+      })
+    } finally {
+      db.close()
+    }
+  }, threadId)
 }
 
 async function seedReloadEvictionRace(
@@ -186,6 +211,7 @@ test('restores from IndexedDB after the localStorage shadow is lost', async ({
   await expect.poll(() => indexedHasText(page, 'indexeddb-only reply')).toBe(true)
 
   await page.evaluate(() => {
+    localStorage.removeItem('comfyui-mcp.panel.historySnapshot')
     localStorage.removeItem('comfyui-mcp.panel.threads')
     localStorage.removeItem('comfyui-mcp.panel.historyMeta')
     localStorage.removeItem('comfyui-mcp.panel.autoConnect')
@@ -251,4 +277,7 @@ test('reload keeps the pointed conversation and live tab session during durable 
       hasPointed: shadow.some((thread: any) => thread.id === pointedId)
     }
   }, currentThreadId)).toEqual({ count: 20, hasPointed: true })
+  await expect.poll(() => indexedThreadCount(page)).toBe(500)
+  await expect.poll(() => indexedHasThread(page, currentThreadId!)).toBe(true)
+  expect(await page.evaluate((key) => localStorage.getItem(key), LOCAL_HISTORY_SNAPSHOT_KEY)).not.toBeNull()
 })

--- a/browser_tests/conversation-persistence.spec.ts
+++ b/browser_tests/conversation-persistence.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * A full ComfyUI/browser restart creates a new page session: localStorage
+ * survives, sessionStorage does not. The panel must recover both the visible
+ * transcript and the backend session id from the durable thread record.
+ */
+import { test, expect } from './fixtures/panelTest'
+
+const SESSION_KEY = 'comfyui-mcp.panel.sessionId'
+const CURRENT_THREAD_KEY = 'comfyui-mcp.panel.currentThreadId'
+
+async function indexedThreadCount(page: import('@playwright/test').Page): Promise<number> {
+  return page.evaluate(async () => {
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('comfyui-mcp-panel-history', 2)
+      request.onsuccess = () => resolve(request.result)
+      request.onerror = () => reject(request.error)
+    })
+    try {
+      return await new Promise<number>((resolve, reject) => {
+        const request = db.transaction('snapshots', 'readonly').objectStore('snapshots').get('state')
+        request.onsuccess = () => resolve(Array.isArray(request.result?.threads) ? request.result.threads.length : 0)
+        request.onerror = () => reject(request.error)
+      })
+    } finally {
+      db.close()
+    }
+  })
+}
+
+async function indexedHasText(page: import('@playwright/test').Page, text: string): Promise<boolean> {
+  return page.evaluate(async (needle) => {
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('comfyui-mcp-panel-history', 2)
+      request.onsuccess = () => resolve(request.result)
+      request.onerror = () => reject(request.error)
+    })
+    try {
+      return await new Promise<boolean>((resolve, reject) => {
+        const request = db.transaction('snapshots', 'readonly').objectStore('snapshots').get('state')
+        request.onsuccess = () => resolve(Boolean(request.result?.threads?.some(
+          (thread: any) => thread.msgs?.some((message: any) => message.text === needle)
+        )))
+        request.onerror = () => reject(request.error)
+      })
+    } finally {
+      db.close()
+    }
+  }, text)
+}
+
+test('restores the latest panel-owned conversation after sessionStorage is lost', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  mockBridge.send({ type: 'session', session_id: 'persisted-test-session' })
+  await expect
+    .poll(() => page.evaluate((key) => sessionStorage.getItem(key), SESSION_KEY))
+    .toBe('persisted-test-session')
+
+  const received = mockBridge.waitForUserMessage()
+  await panel.sendMessage('persist me across a full restart')
+  await received
+  mockBridge.say('durable agent reply')
+
+  await expect(panel.userBubble('persist me across a full restart')).toBeVisible()
+  await expect(panel.agentBubbles.filter({ hasText: 'durable agent reply' }).last()).toBeVisible()
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem('comfyui-mcp.panel.threads')))
+    .not.toBeNull()
+
+  // Model a fully closed/reopened ComfyUI window: keep localStorage, discard the
+  // tab-scoped pointers, and reload the application/module from scratch.
+  await page.evaluate(() => {
+    localStorage.removeItem('comfyui-mcp.panel.autoConnect')
+    sessionStorage.clear()
+  })
+  await page.reload()
+  await panel.openSidebar()
+
+  await expect(panel.userBubble('persist me across a full restart')).toBeVisible()
+  await expect(panel.agentBubbles.filter({ hasText: 'durable agent reply' }).last()).toBeVisible()
+  await expect
+    .poll(() => page.evaluate((key) => sessionStorage.getItem(key), CURRENT_THREAD_KEY))
+    .not.toBeNull()
+  await expect
+    .poll(() => page.evaluate((key) => sessionStorage.getItem(key), SESSION_KEY))
+    .toBe('persisted-test-session')
+})
+
+test('restores from IndexedDB after the localStorage shadow is lost', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  const received = mockBridge.waitForUserMessage()
+  await panel.sendMessage('indexeddb-only transcript')
+  await received
+  mockBridge.say('indexeddb-only reply')
+  await expect.poll(() => indexedThreadCount(page)).toBeGreaterThan(0)
+  await expect.poll(() => indexedHasText(page, 'indexeddb-only transcript')).toBe(true)
+  await expect.poll(() => indexedHasText(page, 'indexeddb-only reply')).toBe(true)
+
+  await page.evaluate(() => {
+    localStorage.removeItem('comfyui-mcp.panel.threads')
+    localStorage.removeItem('comfyui-mcp.panel.historyMeta')
+    localStorage.removeItem('comfyui-mcp.panel.autoConnect')
+    sessionStorage.clear()
+  })
+  await page.reload()
+  await panel.openSidebar()
+
+  await expect(panel.userBubble('indexeddb-only transcript')).toBeVisible()
+  await expect(panel.agentBubbles.filter({ hasText: 'indexeddb-only reply' }).last()).toBeVisible()
+})

--- a/browser_tests/conversation-persistence.spec.ts
+++ b/browser_tests/conversation-persistence.spec.ts
@@ -261,7 +261,8 @@ test('panel delete remains final when a stale tab republishes the removed thread
   }, { snapshotKey: LOCAL_HISTORY_SNAPSHOT_KEY, threadId: removedThreadId! })).toBe(true)
 
   await staleTab.evaluate(async (snapshot) => {
-    const { ChatHistoryStore } = await import('/extensions/comfyui-mcp-panel/lib/chat-history-store.js')
+    const storeModuleUrl = '/extensions/comfyui-mcp-panel/lib/chat-history-store.js'
+    const { ChatHistoryStore } = await import(storeModuleUrl)
     const staleStore = new ChatHistoryStore({ writerId: 'stale-panel-test' })
     staleStore.persist(snapshot.threads || [], snapshot.meta || {})
     const result = await staleStore.flush()

--- a/browser_tests/conversation-persistence.spec.ts
+++ b/browser_tests/conversation-persistence.spec.ts
@@ -17,13 +17,13 @@ const HISTORY_STORE_SOURCE = readFileSync(
   'utf8'
 )
 
-test.beforeEach(async ({ page }) => {
+test.beforeEach(async ({ context }) => {
   // The target ComfyUI server may have been started before this worktree was
   // created. Route the two reviewed modules from the checked-out source so the
   // browser gate always exercises this commit rather than a stale server copy.
-  await page.route('**/extensions/comfyui-mcp-panel/comfyui-mcp-panel.js*', (route) =>
+  await context.route('**/extensions/comfyui-agent-panel/js/comfyui-mcp-panel.js*', (route) =>
     route.fulfill({ contentType: 'text/javascript', body: PANEL_SOURCE }))
-  await page.route('**/extensions/comfyui-mcp-panel/lib/chat-history-store.js*', (route) =>
+  await context.route('**/extensions/comfyui-agent-panel/js/lib/chat-history-store.js*', (route) =>
     route.fulfill({ contentType: 'text/javascript', body: HISTORY_STORE_SOURCE }))
 })
 
@@ -267,18 +267,21 @@ test('panel delete remains final when a stale tab republishes the removed thread
   expect(staleSnapshot.threads?.some((thread: any) => thread.id === removedThreadId)).toBe(true)
 
   await panel.root.getByTitle('Chat history').click()
-  await panel.root.locator('.cmcp-hist-row', { hasText: 'delete me causally' })
-    .getByTitle('Delete this chat')
-    .click()
-  await expect.poll(() => indexedHasThread(page, removedThreadId!)).toBe(false)
-  await expect.poll(() => page.evaluate(({ snapshotKey, threadId }) => {
+  await page.evaluate(() => {
+    const row = Array.from(document.querySelectorAll<HTMLElement>('.cmcp-hist-row'))
+      .find((candidate) => candidate.textContent?.includes('delete me causally'))
+    const button = row?.querySelector<HTMLButtonElement>('.cmcp-hist-del')
+    if (!button) throw new Error('history delete button was not rendered')
+    button.click()
+  })
+  await expect.poll(() => page.evaluate(({ snapshotKey }) => {
     const snapshot = JSON.parse(localStorage.getItem(snapshotKey) || '{}')
-    const tombstone = snapshot.meta?.deletedThreads?.[threadId]
-    return tombstone?.deleted === true && Number.isFinite(tombstone?.revision?.updatedAt)
-  }, { snapshotKey: LOCAL_HISTORY_SNAPSHOT_KEY, threadId: removedThreadId! })).toBe(true)
+    return Object.keys(snapshot.meta?.deletedThreads || {})
+  }, { snapshotKey: LOCAL_HISTORY_SNAPSHOT_KEY })).toContain(removedThreadId!)
+  await expect.poll(() => indexedHasThread(page, removedThreadId!)).toBe(false)
 
   await staleTab.evaluate(async (snapshot) => {
-    const storeModuleUrl = '/extensions/comfyui-mcp-panel/lib/chat-history-store.js'
+    const storeModuleUrl = '/extensions/comfyui-agent-panel/js/lib/chat-history-store.js'
     const { ChatHistoryStore } = await import(storeModuleUrl)
     const staleStore = new ChatHistoryStore({ writerId: 'stale-panel-test' })
     staleStore.persist(snapshot.threads || [], snapshot.meta || {})
@@ -552,8 +555,15 @@ test('workflow rename publishes alias tombstones and a stale tab cannot echo the
   await unrelated
   await expect.poll(() => otherTab.evaluate(() => {
     const snapshot = JSON.parse(localStorage.getItem('comfyui-mcp.panel.historySnapshot') || '{}')
-    return snapshot.meta?.aliasOps?.['workflows/alias-old.json']?.deleted === true
-  })).toBe(true)
+    return {
+      hasMaterializedOld: Object.hasOwn(
+        snapshot.meta?.workflowAliases || {}, 'workflows/alias-old.json'
+      ),
+      hasRepublishedOperation: Object.hasOwn(
+        snapshot.meta?.aliasOps || {}, 'workflows/alias-old.json'
+      )
+    }
+  })).toEqual({ hasMaterializedOld: false, hasRepublishedOperation: false })
 
   await page.reload()
   await panel.openSidebar()

--- a/browser_tests/conversation-persistence.spec.ts
+++ b/browser_tests/conversation-persistence.spec.ts
@@ -12,7 +12,7 @@ const LOCAL_HISTORY_SNAPSHOT_KEY = 'comfyui-mcp.panel.historySnapshot'
 async function indexedThreadCount(page: import('@playwright/test').Page): Promise<number> {
   return page.evaluate(async () => {
     const db = await new Promise<IDBDatabase>((resolve, reject) => {
-      const request = indexedDB.open('comfyui-mcp-panel-history', 2)
+      const request = indexedDB.open('comfyui-mcp-panel-history', 3)
       request.onsuccess = () => resolve(request.result)
       request.onerror = () => reject(request.error)
     })
@@ -31,7 +31,7 @@ async function indexedThreadCount(page: import('@playwright/test').Page): Promis
 async function indexedHasText(page: import('@playwright/test').Page, text: string): Promise<boolean> {
   return page.evaluate(async (needle) => {
     const db = await new Promise<IDBDatabase>((resolve, reject) => {
-      const request = indexedDB.open('comfyui-mcp-panel-history', 2)
+      const request = indexedDB.open('comfyui-mcp-panel-history', 3)
       request.onsuccess = () => resolve(request.result)
       request.onerror = () => reject(request.error)
     })
@@ -55,7 +55,7 @@ async function indexedHasThread(
 ): Promise<boolean> {
   return page.evaluate(async (id) => {
     const db = await new Promise<IDBDatabase>((resolve, reject) => {
-      const request = indexedDB.open('comfyui-mcp-panel-history', 2)
+      const request = indexedDB.open('comfyui-mcp-panel-history', 3)
       request.onsuccess = () => resolve(request.result)
       request.onerror = () => reject(request.error)
     })
@@ -126,7 +126,7 @@ async function seedReloadEvictionRace(
     localStorage.setItem('comfyui-mcp.panel.historyMeta', JSON.stringify(local.meta))
 
     const db = await new Promise<IDBDatabase>((resolve, reject) => {
-      const request = indexedDB.open('comfyui-mcp-panel-history', 2)
+      const request = indexedDB.open('comfyui-mcp-panel-history', 3)
       request.onsuccess = () => resolve(request.result)
       request.onerror = () => reject(request.error)
     })
@@ -280,4 +280,95 @@ test('reload keeps the pointed conversation and live tab session during durable 
   await expect.poll(() => indexedThreadCount(page)).toBe(500)
   await expect.poll(() => indexedHasThread(page, currentThreadId!)).toBe(true)
   expect(await page.evaluate((key) => localStorage.getItem(key), LOCAL_HISTORY_SNAPSHOT_KEY)).not.toBeNull()
+})
+
+test('strict workflow storage sync detaches transcript todos and session before the next record', async ({
+  page,
+  context,
+  panel,
+  mockBridge
+}) => {
+  await page.route(
+    (url) => /\/(api\/)?settings\/?$/.test(url.pathname),
+    async (route) => {
+      if (route.request().method() !== 'GET') return route.continue()
+      const response = await route.fetch()
+      const settings = await response.json() as Record<string, unknown>
+      settings['comfyui-mcp.sessionFollowsPanel'] = false
+      await route.fulfill({ response, json: settings })
+    }
+  )
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+  mockBridge.send({ type: 'session', session_id: 'workflow-a-session' })
+
+  const initial = mockBridge.waitForUserMessage()
+  await panel.sendMessage('workflow A visible transcript')
+  await initial
+  await expect.poll(
+    () => page.evaluate((key) => sessionStorage.getItem(key), SESSION_KEY)
+  ).toBe('workflow-a-session')
+  const currentThreadId = await page.evaluate(
+    (key) => sessionStorage.getItem(key),
+    CURRENT_THREAD_KEY
+  )
+  expect(currentThreadId).not.toBeNull()
+
+  const otherTab = await context.newPage()
+  await otherTab.goto(page.url())
+  await otherTab.evaluate(({ snapshotKey, threadId }) => {
+    const snapshot = JSON.parse(localStorage.getItem(snapshotKey) || '{}')
+    const thread = snapshot.threads?.find((candidate: any) => candidate.id === threadId)
+    if (!thread) throw new Error('current thread missing from shared shadow')
+    const updatedAt = Date.now() + 10_000
+    const revision = { updatedAt, writerId: 'tab-b', sequence: 1 }
+    thread.workflowKey = 'workflow:foreign-provenance'
+    thread.todos = [{ text: 'foreign todo', status: 'active' }]
+    thread.updatedAt = updatedAt
+    thread.ts = updatedAt
+    thread.fieldOps = {
+      ...(thread.fieldOps || {}),
+      workflowKey: {
+        value: 'workflow:foreign-provenance',
+        deleted: false,
+        updatedAt,
+        revision
+      },
+      todos: {
+        value: [{ text: 'foreign todo', status: 'active' }],
+        deleted: false,
+        updatedAt,
+        revision: { ...revision, sequence: 2 }
+      }
+    }
+    localStorage.setItem(snapshotKey, JSON.stringify(snapshot))
+  }, { snapshotKey: LOCAL_HISTORY_SNAPSHOT_KEY, threadId: currentThreadId })
+
+  await expect.poll(
+    () => page.evaluate((key) => sessionStorage.getItem(key), SESSION_KEY)
+  ).toBeNull()
+  await expect.poll(
+    () => page.evaluate((key) => sessionStorage.getItem(key), CURRENT_THREAD_KEY)
+  ).toBeNull()
+  await expect(panel.userBubble('workflow A visible transcript')).toHaveCount(0)
+  await expect(panel.root.locator('.cmcp-todo-item')).toHaveCount(0)
+
+  const next = mockBridge.waitForUserMessage()
+  await panel.sendMessage('fresh workflow A transcript')
+  await next
+  const rebound = await page.evaluate(({ snapshotKey, sessionKey }) => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const workflowUuid = app.graph?.extra?.comfyui_mcp?.workflow_uuid
+    const snapshot = JSON.parse(localStorage.getItem(snapshotKey) || '{}')
+    const thread = snapshot.threads?.find((candidate: any) =>
+      candidate.msgs?.some((message: any) => message.text === 'fresh workflow A transcript'))
+    return { workflowUuid, thread, sessionId: sessionStorage.getItem(sessionKey) }
+  }, { snapshotKey: LOCAL_HISTORY_SNAPSHOT_KEY, sessionKey: SESSION_KEY })
+  expect(rebound.thread?.workflowKey).toBe(`workflow:${rebound.workflowUuid}`)
+  expect(rebound.thread?.sessionId).toBeUndefined()
+  expect(rebound.sessionId).toBeNull()
+  await otherTab.close()
 })

--- a/browser_tests/conversation-persistence.spec.ts
+++ b/browser_tests/conversation-persistence.spec.ts
@@ -5,10 +5,27 @@
  */
 import { test, expect } from './fixtures/panelTest'
 import { PanelPage } from './fixtures/PanelPage'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 
 const SESSION_KEY = 'comfyui-mcp.panel.sessionId'
 const CURRENT_THREAD_KEY = 'comfyui-mcp.panel.currentThreadId'
 const LOCAL_HISTORY_SNAPSHOT_KEY = 'comfyui-mcp.panel.historySnapshot'
+const PANEL_SOURCE = readFileSync(resolve('web/js/comfyui-mcp-panel.js'), 'utf8')
+const HISTORY_STORE_SOURCE = readFileSync(
+  resolve('web/js/lib/chat-history-store.js'),
+  'utf8'
+)
+
+test.beforeEach(async ({ page }) => {
+  // The target ComfyUI server may have been started before this worktree was
+  // created. Route the two reviewed modules from the checked-out source so the
+  // browser gate always exercises this commit rather than a stale server copy.
+  await page.route('**/extensions/comfyui-mcp-panel/comfyui-mcp-panel.js*', (route) =>
+    route.fulfill({ contentType: 'text/javascript', body: PANEL_SOURCE }))
+  await page.route('**/extensions/comfyui-mcp-panel/lib/chat-history-store.js*', (route) =>
+    route.fulfill({ contentType: 'text/javascript', body: HISTORY_STORE_SOURCE }))
+})
 
 async function indexedThreadCount(page: import('@playwright/test').Page): Promise<number> {
   return page.evaluate(async () => {

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -502,6 +502,25 @@ test('legacy local shadow migration preserves the valid half of split or corrupt
   assert.deepEqual(loaded.meta.activeByScope, {})
 })
 
+test('partially corrupt atomic shadow recovers each invalid half from legacy storage', () => {
+  const storage = createMemoryStorage()
+  storage.values.set(CHAT_HISTORY_LOCAL_SNAPSHOT_KEY, JSON.stringify({
+    schemaVersion: CHAT_HISTORY_SCHEMA,
+    threads: 'broken',
+    meta: { activeByScope: { 'panel:global': 'legacy-thread' } }
+  }))
+  storage.values.set('comfyui-mcp.panel.threads', JSON.stringify([
+    { id: 'legacy-thread', workflowKey: 'panel:global', updatedAt: 10, msgs: [] }
+  ]))
+  storage.values.set('comfyui-mcp.panel.historyMeta', '{broken')
+  const store = new ChatHistoryStore({ storage, indexedDb: null })
+
+  const loaded = store.readLocal()
+
+  assert.equal(loaded.threads[0].id, 'legacy-thread')
+  assert.equal(loaded.meta.activeByScope['panel:global'], 'legacy-thread')
+})
+
 test('notifies another tab when the local history shadow changes', () => {
   const values = new Map()
   const storage = {

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -473,6 +473,63 @@ test('two stores migrate id-less messages once and preserve concurrent append an
   }
 })
 
+test('legacy migration fence handles duplicate shifts and content changes in both write orders', async () => {
+  const legacy = {
+    updatedAt: 100,
+    threads: [{
+      id: 'legacy-fence',
+      workflowKey: 'panel:global',
+      updatedAt: 100,
+      msgs: [
+        { role: 'user', text: 'duplicate', createdAt: 10 },
+        { role: 'user', text: 'duplicate', createdAt: 20 },
+        { role: 'card', text: 'old card', spec: { title: 'old' }, createdAt: 30 }
+      ]
+    }],
+    meta: {}
+  }
+  const staleChanged = [{
+    id: 'legacy-fence',
+    workflowKey: 'panel:global',
+    updatedAt: 500,
+    msgs: [
+      { role: 'user', text: 'duplicate', createdAt: 20 },
+      { role: 'card', text: 'changed card', spec: { title: 'changed' }, createdAt: 30 }
+    ]
+  }]
+
+  // Migration wins: a later id-less snapshot is quarantined.
+  const migratedFirstDb = createFakeIndexedDb(legacy)
+  const migrator = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb: migratedFirstDb })
+  const migrated = await migrator.load()
+  await migrator.flush()
+  assert.equal(migrated.threads[0].msgs.length, 3)
+  const staleAfterFence = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb: migratedFirstDb })
+  staleAfterFence.persist(staleChanged, {})
+  await staleAfterFence.flush()
+  const fenced = await new ChatHistoryStore({
+    storage: createMemoryStorage(), indexedDb: migratedFirstDb
+  }).load()
+  assert.deepEqual(fenced.threads[0].msgs.map((message) => message.text), [
+    'duplicate', 'duplicate', 'old card'
+  ])
+
+  // Stale legacy write wins: replace the matching pre-v3 thread before IDs are
+  // assigned, so the shifted duplicate/card never fork into extra messages.
+  const staleFirstDb = createFakeIndexedDb(legacy)
+  const staleBeforeFence = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb: staleFirstDb })
+  staleBeforeFence.persist(staleChanged, {})
+  await staleBeforeFence.flush()
+  const migratedAfter = await new ChatHistoryStore({
+    storage: createMemoryStorage(), indexedDb: staleFirstDb
+  }).load()
+  assert.deepEqual(migratedAfter.threads[0].msgs.map((message) => message.text), [
+    'duplicate', 'changed card'
+  ])
+  assert.equal(new Set(migratedAfter.threads[0].msgs.map((message) => message.id)).size, 2)
+  assert.equal(migratedAfter.threads[0].msgs[1].spec.title, 'changed')
+})
+
 test('metadata tombstones clear active pointers and aliases across stale snapshots', () => {
   const merged = mergeHistorySnapshots(
     {

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  CHAT_HISTORY_LOCAL_SNAPSHOT_KEY,
   CHAT_HISTORY_SCHEMA,
   ChatHistoryStore,
   isThreadInScope,
@@ -12,6 +13,74 @@ import {
   selectRestoreThread,
   selectThreadForScope
 } from '../../web/js/lib/chat-history-store.js'
+
+function createMemoryStorage({ throwOnSet = null } = {}) {
+  const values = new Map()
+  return {
+    values,
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => {
+      if (key === throwOnSet) throw new Error(`blocked write: ${key}`)
+      values.set(key, value)
+    }
+  }
+}
+
+function createFakeIndexedDb(initialState = null, { blockedThenSuccess = false } = {}) {
+  let state = initialState == null ? null : structuredClone(initialState)
+  let closeCount = 0
+
+  const createDb = () => ({
+    objectStoreNames: { contains: (name) => name === 'snapshots' },
+    createObjectStore() {},
+    close: () => { closeCount += 1 },
+    transaction: (_name, mode) => {
+      const tx = {
+        oncomplete: null,
+        onerror: null,
+        onabort: null,
+        objectStore: () => ({
+          get: () => {
+            const request = { result: undefined, onsuccess: null, onerror: null }
+            queueMicrotask(() => {
+              request.result = state == null ? undefined : structuredClone(state)
+              request.onsuccess?.()
+            })
+            return request
+          },
+          put: (value) => {
+            assert.equal(mode, 'readwrite')
+            state = structuredClone(value)
+            queueMicrotask(() => tx.oncomplete?.())
+          }
+        })
+      }
+      return tx
+    }
+  })
+
+  return {
+    open: () => {
+      const request = {
+        result: null,
+        onupgradeneeded: null,
+        onsuccess: null,
+        onerror: null,
+        onblocked: null
+      }
+      queueMicrotask(() => {
+        if (blockedThenSuccess) request.onblocked?.()
+        queueMicrotask(() => {
+          request.result = createDb()
+          request.onsuccess?.()
+        })
+      })
+      return request
+    },
+    readState: () => state == null ? null : structuredClone(state),
+    closeCount: () => closeCount
+  }
+}
 
 test('normalizes legacy threads into schema v2 without losing messages', () => {
   const thread = normalizeThread({ id: 'legacy', ts: 123, msgs: [{ role: 'user', text: 'hello' }] })
@@ -92,6 +161,94 @@ test('thread tombstones prevent deleted chats from being resurrected by stale sn
 
   assert.equal(merged.threads.some((thread) => thread.id === 'removed'), false)
   assert.equal(merged.meta.deletedThreads.removed, deletedAt)
+})
+
+test('thread tombstones remain final even when another tab writes the thread later', () => {
+  const merged = mergeHistorySnapshots(
+    {
+      updatedAt: 500,
+      threads: [],
+      meta: { updatedAt: 500, deletedThreads: { removed: 500 } }
+    },
+    {
+      updatedAt: 900,
+      threads: [{ id: 'removed', updatedAt: 900, workflowKey: 'workflow:wf-a', msgs: [] }],
+      meta: { updatedAt: 900 }
+    }
+  )
+
+  assert.equal(merged.threads.some((thread) => thread.id === 'removed'), false)
+  assert.equal(merged.meta.deletedThreads.removed, 500)
+})
+
+test('message tombstones survive concurrent append and later reload merges', () => {
+  const base = {
+    id: 'shared',
+    workflowKey: 'workflow:wf-a',
+    createdAt: 100,
+    updatedAt: 100,
+    msgs: [{ id: 'm1', role: 'user', text: 'remove me', createdAt: 100 }]
+  }
+  const merged = mergeHistorySnapshots(
+    {
+      threads: [{ ...base, updatedAt: 300, msgs: [], deletedMessages: { m1: 300 } }],
+      meta: {}
+    },
+    {
+      threads: [{
+        ...base,
+        updatedAt: 400,
+        msgs: [
+          ...base.msgs,
+          { id: 'm2', role: 'agent', text: 'concurrent append', createdAt: 400 }
+        ]
+      }],
+      meta: {}
+    }
+  )
+  const reloaded = mergeHistorySnapshots(merged, {
+    threads: [{ ...base, updatedAt: 500 }],
+    meta: {}
+  })
+
+  assert.deepEqual(merged.threads[0].msgs.map((message) => message.id), ['m2'])
+  assert.equal(merged.threads[0].deletedMessages.m1, 300)
+  assert.deepEqual(reloaded.threads[0].msgs.map((message) => message.id), ['m2'])
+})
+
+test('metadata tombstones clear active pointers and aliases across stale snapshots', () => {
+  const merged = mergeHistorySnapshots(
+    {
+      updatedAt: 100,
+      threads: [],
+      meta: {
+        updatedAt: 100,
+        activeByScope: { 'panel:global': 'old-thread' },
+        workflowAliases: { 'workflows/old.json': 'old-workflow' }
+      }
+    },
+    {
+      updatedAt: 300,
+      threads: [],
+      meta: {
+        updatedAt: 300,
+        activeOps: {
+          'panel:global': { value: null, deleted: true, updatedAt: 300 }
+        },
+        aliasOps: {
+          'workflows/old.json': { value: null, deleted: true, updatedAt: 300 }
+        }
+      }
+    }
+  )
+
+  assert.equal(Object.hasOwn(merged.meta.activeByScope, 'panel:global'), false)
+  assert.equal(Object.hasOwn(merged.meta.workflowAliases, 'workflows/old.json'), false)
+  assert.equal(merged.meta.activeOps['panel:global'].deleted, true)
+  assert.equal(merged.meta.aliasOps['workflows/old.json'].deleted, true)
+  assert.equal(selectPanelThread([
+    { id: 'old-thread', workflowKey: 'panel:global', updatedAt: 100, msgs: [] }
+  ], merged.meta), null)
 })
 
 test('scope selection never falls back to a chat from another workflow', () => {
@@ -194,6 +351,155 @@ test('localStorage shadow retains the active tab thread when IndexedDB is unavai
   const degradedReload = await degradedStore.load({ protectedThreadIds: ['t0'] })
   await degradedStore.flush()
   assert.equal(degradedReload.threads.some((thread) => thread.id === 't0'), true)
+})
+
+test('canonical IndexedDB merge enforces thread and message limits after union', async () => {
+  const oldMessages = Array.from({ length: 5000 }, (_, i) => ({
+    id: `old-${i}`,
+    role: 'user',
+    text: `old ${i}`,
+    createdAt: i + 1
+  }))
+  const seededThreads = Array.from({ length: 501 }, (_, i) => ({
+    id: `t${i}`,
+    workflowKey: 'panel:global',
+    updatedAt: i + 1,
+    msgs: i === 0 ? oldMessages : []
+  }))
+  const indexedDb = createFakeIndexedDb({
+    updatedAt: 10_000,
+    threads: seededThreads,
+    meta: { activeByScope: { 'panel:global': 't0' } }
+  })
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb })
+  const incomingMessages = [
+    ...oldMessages.slice(1),
+    { id: 'newest', role: 'agent', text: 'newest', createdAt: 10_001 }
+  ]
+
+  store.persist([
+    { id: 't0', workflowKey: 'panel:global', updatedAt: 10_001, msgs: incomingMessages },
+    ...seededThreads.slice(2)
+  ], { activeByScope: { 'panel:global': 't0' } }, { protectedThreadIds: ['t0'] })
+  await store.flush()
+
+  const canonical = indexedDb.readState()
+  const protectedThread = canonical.threads.find((thread) => thread.id === 't0')
+  assert.equal(canonical.threads.length, 500)
+  assert.equal(canonical.threads.some((thread) => thread.id === 't0'), true)
+  assert.equal(canonical.threads.some((thread) => thread.id === 't1'), false)
+  assert.equal(protectedThread.msgs.length, 5000)
+  assert.equal(protectedThread.msgs.some((message) => message.id === 'old-0'), false)
+  assert.equal(protectedThread.msgs.at(-1).id, 'newest')
+})
+
+test('atomic writes keep message, metadata, and chat deletions through stale writers and reload', async () => {
+  const indexedDb = createFakeIndexedDb({
+    updatedAt: 100,
+    threads: [
+      {
+        id: 'shared',
+        workflowKey: 'panel:global',
+        updatedAt: 100,
+        msgs: [{ id: 'm1', role: 'user', text: 'deleted', createdAt: 100 }]
+      },
+      { id: 'removed-chat', workflowKey: 'panel:global', updatedAt: 100, msgs: [] }
+    ],
+    meta: {
+      updatedAt: 100,
+      activeByScope: { 'panel:global': 'removed-chat' },
+      workflowAliases: { 'workflows/old.json': 'old-workflow' }
+    }
+  })
+  const deletingTab = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb })
+  const staleTab = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb })
+
+  deletingTab.persist([
+    {
+      id: 'shared',
+      workflowKey: 'panel:global',
+      updatedAt: 300,
+      msgs: [],
+      deletedMessages: { m1: 300 }
+    }
+  ], {
+    updatedAt: 300,
+    deletedThreads: { 'removed-chat': 300 },
+    activeOps: { 'panel:global': { value: null, deleted: true, updatedAt: 300 } },
+    aliasOps: {
+      'workflows/old.json': { value: null, deleted: true, updatedAt: 300 }
+    }
+  })
+  await deletingTab.flush()
+
+  staleTab.persist([
+    {
+      id: 'shared',
+      workflowKey: 'panel:global',
+      updatedAt: 900,
+      msgs: [
+        { id: 'm1', role: 'user', text: 'deleted', createdAt: 100 },
+        { id: 'm2', role: 'agent', text: 'late append', createdAt: 900 }
+      ]
+    },
+    { id: 'removed-chat', workflowKey: 'panel:global', updatedAt: 900, msgs: [] }
+  ], {
+    updatedAt: 100,
+    activeByScope: { 'panel:global': 'removed-chat' },
+    workflowAliases: { 'workflows/old.json': 'old-workflow' }
+  })
+  await staleTab.flush()
+
+  const reloadedStore = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb })
+  const reloaded = await reloadedStore.load()
+  await reloadedStore.flush()
+
+  assert.deepEqual(reloaded.threads.find((thread) => thread.id === 'shared').msgs.map((m) => m.id), ['m2'])
+  assert.equal(reloaded.threads.some((thread) => thread.id === 'removed-chat'), false)
+  assert.equal(Object.hasOwn(reloaded.meta.activeByScope, 'panel:global'), false)
+  assert.equal(Object.hasOwn(reloaded.meta.workflowAliases, 'workflows/old.json'), false)
+})
+
+test('blocked IndexedDB opens can continue to success and always close the connection', async () => {
+  const indexedDb = createFakeIndexedDb({
+    threads: [{ id: 'durable', workflowKey: 'panel:global', updatedAt: 10, msgs: [] }],
+    meta: {}
+  }, { blockedThenSuccess: true })
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb })
+
+  const loaded = await store.load()
+  await store.flush()
+
+  assert.equal(loaded.threads.some((thread) => thread.id === 'durable'), true)
+  assert.equal(indexedDb.closeCount(), 2)
+})
+
+test('atomic local shadow survives a failed legacy metadata write', async () => {
+  const storage = createMemoryStorage({ throwOnSet: 'comfyui-mcp.panel.historyMeta' })
+  const store = new ChatHistoryStore({ storage, indexedDb: null })
+  store.persist(
+    [{ id: 'kept', workflowKey: 'panel:global', updatedAt: 10, msgs: [] }],
+    { activeByScope: { 'panel:global': 'kept' } }
+  )
+  await store.flush()
+
+  assert.notEqual(storage.values.get(CHAT_HISTORY_LOCAL_SNAPSHOT_KEY), undefined)
+  assert.equal(store.readLocal().threads[0].id, 'kept')
+  assert.equal(store.readLocal().meta.activeByScope['panel:global'], 'kept')
+})
+
+test('legacy local shadow migration preserves the valid half of split or corrupt state', () => {
+  const storage = createMemoryStorage()
+  storage.values.set('comfyui-mcp.panel.threads', JSON.stringify([
+    { id: 'legacy-thread', workflowKey: 'panel:global', updatedAt: 10, msgs: [] }
+  ]))
+  storage.values.set('comfyui-mcp.panel.historyMeta', '{broken')
+  const store = new ChatHistoryStore({ storage, indexedDb: null })
+
+  const loaded = store.readLocal()
+
+  assert.equal(loaded.threads[0].id, 'legacy-thread')
+  assert.deepEqual(loaded.meta.activeByScope, {})
 })
 
 test('notifies another tab when the local history shadow changes', () => {

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -258,6 +258,87 @@ test('exact revision ties use writer and sequence deterministically in both merg
   }
 })
 
+test('observed revisions advance every mutable field and card state despite backward clocks', async () => {
+  const future = { updatedAt: 50_000, writerId: 'future-tab', sequence: 9 }
+  const fields = {
+    sessionId: 'old-session',
+    todos: [{ text: 'old', status: 'pending' }],
+    workflowKey: 'workflow:old',
+    workflowTitle: 'Old workflow',
+    provider: 'claude',
+    model: 'old-model',
+    effort: 'low',
+    pinned: false,
+    title: 'Old title'
+  }
+  const fieldOps = Object.fromEntries(Object.entries(fields).map(([field, value]) => [field, {
+    value,
+    deleted: false,
+    updatedAt: future.updatedAt,
+    revision: future
+  }]))
+  const thread = normalizeThread({
+    id: 'clock-skew-thread',
+    ...fields,
+    updatedAt: future.updatedAt,
+    fieldOps,
+    msgs: [{
+      id: 'card',
+      role: 'card',
+      text: 'old card',
+      createdAt: 10,
+      updatedAt: future.updatedAt,
+      revision: future
+    }]
+  })
+  const store = new ChatHistoryStore({
+    storage: createMemoryStorage(),
+    indexedDb: null,
+    writerId: 'backward-clock'
+  })
+  store.reviseThread(thread, {
+    sessionId: 'new-session',
+    todos: [{ text: 'new', status: 'done' }],
+    workflowKey: 'workflow:new',
+    workflowTitle: 'New workflow',
+    provider: 'codex',
+    model: 'new-model',
+    effort: 'high',
+    pinned: true,
+    title: 'New title'
+  }, 1_000)
+  thread.msgs[0].text = 'new card'
+  store.touchMessage(thread.msgs[0], 900)
+
+  for (const operation of Object.values(thread.fieldOps)) {
+    assert.ok(operation.revision.updatedAt > future.updatedAt)
+  }
+  assert.ok(thread.msgs[0].revision.updatedAt > future.updatedAt)
+
+  const canonicalFuture = normalizeThread({
+    id: 'remote',
+    sessionId: 'remote-session',
+    updatedAt: 90_000,
+    fieldOps: {
+      sessionId: {
+        value: 'remote-session',
+        deleted: false,
+        updatedAt: 90_000,
+        revision: { updatedAt: 90_000, writerId: 'remote', sequence: 1 }
+      }
+    },
+    msgs: []
+  })
+  const hydrated = new ChatHistoryStore({
+    storage: createMemoryStorage(),
+    indexedDb: createFakeIndexedDb({ threads: [canonicalFuture], meta: {} }),
+    writerId: 'hydrated-backward-clock'
+  })
+  const loaded = await hydrated.load()
+  hydrated.reviseThread(loaded.threads[0], { sessionId: null }, 500)
+  assert.ok(loaded.threads[0].fieldOps.sessionId.revision.updatedAt > 90_000)
+})
+
 test('thread tombstones preserve causal delete operations and prevent stale resurrection', () => {
   const deletedAt = { updatedAt: 500, writerId: 'delete-tab', sequence: 1 }
   const merged = mergeHistorySnapshots(

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -5,6 +5,7 @@ import {
   CHAT_HISTORY_LOCAL_SNAPSHOT_KEY,
   CHAT_HISTORY_SCHEMA,
   ChatHistoryStore,
+  createHistoryResetSnapshot,
   isThreadInScope,
   mergeHistorySnapshots,
   normalizeThread,
@@ -811,6 +812,140 @@ test('atomic writes keep message, metadata, and chat deletions through stale wri
   assert.equal(reloaded.threads.some((thread) => thread.id === 'removed-chat'), false)
   assert.equal(Object.hasOwn(reloaded.meta.activeByScope, 'panel:global'), false)
   assert.equal(Object.hasOwn(reloaded.meta.workflowAliases, 'workflows/old.json'), false)
+})
+
+test('history reset creates an empty checkpoint while preserving workflow identity aliases', () => {
+  const reset = createHistoryResetSnapshot({
+    threads: [
+      { id: 'chat-a', workflowKey: 'workflow:wf-a', updatedAt: 100, msgs: [] },
+      { id: 'chat-b', workflowKey: 'workflow:wf-b', updatedAt: 200, msgs: [] }
+    ],
+    meta: {
+      updatedAt: 200,
+      checkpoint: {
+        generation: 4,
+        revision: { updatedAt: 150, writerId: 'old-checkpoint', sequence: 1 }
+      },
+      activeByScope: { 'workflow:wf-a': 'chat-a', 'workflow:wf-b': 'chat-b' },
+      workflowAliases: {
+        'workflows/a.json': 'wf-a',
+        'workflows/b.json': 'wf-b'
+      },
+      aliasOps: {
+        'workflows/a.json': {
+          value: 'wf-a',
+          deleted: false,
+          updatedAt: 100,
+          revision: { updatedAt: 100, writerId: 'alias', sequence: 1 }
+        }
+      }
+    }
+  }, { updatedAt: 300, writerId: 'clear-all', sequence: 1 })
+
+  assert.deepEqual(reset.threads, [])
+  assert.deepEqual({ ...reset.meta.activeByScope }, {})
+  assert.deepEqual({ ...reset.meta.activeOps }, {})
+  assert.deepEqual({ ...reset.meta.deletedThreads }, {})
+  assert.deepEqual({ ...reset.meta.workflowAliases }, {
+    'workflows/a.json': 'wf-a',
+    'workflows/b.json': 'wf-b'
+  })
+  assert.deepEqual({ ...reset.meta.aliasOps }, {})
+  assert.equal(reset.meta.checkpoint.generation, 5)
+  assert.deepEqual(reset.meta.checkpoint.revision, {
+    updatedAt: 300,
+    writerId: 'clear-all',
+    sequence: 1
+  })
+})
+
+test('clear all is canonical, broadcasts, and fences a stale tab without deleting aliases', async () => {
+  const initial = {
+    schemaVersion: CHAT_HISTORY_SCHEMA,
+    updatedAt: 200,
+    threads: [
+      {
+        id: 'chat-a',
+        workflowKey: 'workflow:wf-a',
+        createdAt: 100,
+        updatedAt: 200,
+        msgs: [{ id: 'message-a', role: 'user', text: 'erase me', createdAt: 200 }]
+      }
+    ],
+    meta: {
+      updatedAt: 200,
+      activeByScope: { 'workflow:wf-a': 'chat-a' },
+      workflowAliases: { 'workflows/a.json': 'wf-a' }
+    }
+  }
+  const staleSnapshot = structuredClone(initial)
+  const indexedDb = createFakeIndexedDb(initial)
+  const clearingStorage = createMemoryStorage()
+  const staleStorage = createMemoryStorage()
+  const hub = createBroadcastHub()
+  const clearingStore = new ChatHistoryStore({
+    storage: clearingStorage,
+    indexedDb,
+    writerId: 'clearing-tab',
+    broadcastChannelFactory: hub.factory
+  })
+  const observingStore = new ChatHistoryStore({
+    storage: createMemoryStorage(),
+    indexedDb,
+    writerId: 'observing-tab',
+    broadcastChannelFactory: hub.factory
+  })
+  const observedReset = new Promise((resolve) => {
+    observingStore.subscribe((snapshot) => resolve(snapshot), {
+      addEventListener() {},
+      removeEventListener() {}
+    })
+  })
+
+  const result = await clearingStore.clearAll(initial.threads, initial.meta)
+  assert.equal(result.ok, true)
+  assert.equal(result.canonicalCommitted, true)
+  assert.deepEqual(result.snapshot.threads, [])
+  assert.equal(result.snapshot.meta.workflowAliases['workflows/a.json'], 'wf-a')
+
+  const peerSnapshot = await observedReset
+  assert.deepEqual(peerSnapshot.threads, [])
+  assert.equal(peerSnapshot.meta.workflowAliases['workflows/a.json'], 'wf-a')
+  const shadow = JSON.parse(clearingStorage.getItem(CHAT_HISTORY_LOCAL_SNAPSHOT_KEY))
+  assert.deepEqual(shadow.threads, [])
+  assert.equal(shadow.meta.workflowAliases['workflows/a.json'], 'wf-a')
+
+  const staleStore = new ChatHistoryStore({
+    storage: staleStorage,
+    indexedDb,
+    writerId: 'stale-tab'
+  })
+  staleStore.persist(staleSnapshot.threads, staleSnapshot.meta)
+  await staleStore.flush()
+  const canonical = indexedDb.readState()
+  assert.deepEqual(canonical.threads, [])
+  assert.deepEqual({ ...canonical.meta.activeByScope }, {})
+  assert.equal(canonical.meta.workflowAliases['workflows/a.json'], 'wf-a')
+
+  clearingStore.close()
+  observingStore.close()
+  staleStore.close()
+})
+
+test('clear all fails closed when the canonical IndexedDB store is unavailable', async () => {
+  const storage = createMemoryStorage()
+  const store = new ChatHistoryStore({ storage, indexedDb: null })
+  const threads = [{ id: 'shadow-only', workflowKey: 'panel:global', updatedAt: 100, msgs: [] }]
+  store.persist(threads, {})
+  await store.flush()
+  const before = storage.getItem(CHAT_HISTORY_LOCAL_SNAPSHOT_KEY)
+
+  const result = await store.clearAll(threads, {})
+
+  assert.equal(result.ok, false)
+  assert.equal(result.retryable, true)
+  assert.equal(result.code, 'history-clear-canonical-unavailable')
+  assert.equal(storage.getItem(CHAT_HISTORY_LOCAL_SNAPSHOT_KEY), before)
 })
 
 test('blocked IndexedDB opens can continue to success and always close the connection', async () => {

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -145,6 +145,94 @@ test('merges concurrent messages in the same thread without dropping either tab'
   ])
 })
 
+test('stale append cannot roll back independently revised session todos provenance or card state', () => {
+  const base = normalizeThread({
+    id: 'causal-thread',
+    workflowKey: 'workflow:old',
+    sessionId: 'old-session',
+    todos: [{ text: 'old todo', status: 'pending' }],
+    createdAt: 100,
+    updatedAt: 100,
+    msgs: [{
+      id: 'card',
+      role: 'card',
+      kind: 'a2ui',
+      spec: { title: 'old card' },
+      resolved: false,
+      createdAt: 100
+    }]
+  })
+  const stateTab = new ChatHistoryStore({
+    storage: createMemoryStorage(),
+    indexedDb: null,
+    writerId: 'writer-a'
+  })
+  const appendTab = new ChatHistoryStore({
+    storage: createMemoryStorage(),
+    indexedDb: null,
+    writerId: 'writer-b'
+  })
+  const stateThread = structuredClone(base)
+  stateTab.reviseThread(stateThread, {
+    sessionId: 'new-session',
+    todos: [{ text: 'new todo', status: 'done' }],
+    workflowKey: 'workflow:new'
+  }, 1_000)
+  stateThread.msgs[0].spec = { title: 'new card' }
+  stateThread.msgs[0].resolved = true
+  stateTab.touchMessage(stateThread.msgs[0], 1_000)
+
+  const staleAppend = structuredClone(base)
+  const reply = { id: 'reply', role: 'agent', text: 'late reply', createdAt: 2_000 }
+  appendTab.touchMessage(reply, 2_000)
+  staleAppend.msgs.push(reply)
+  staleAppend.updatedAt = 2_000
+  staleAppend.ts = 2_000
+
+  for (const pair of [[stateThread, staleAppend], [staleAppend, stateThread]]) {
+    const merged = mergeHistorySnapshots(
+      { threads: [pair[0]], meta: {} },
+      { threads: [pair[1]], meta: {} }
+    ).threads[0]
+    assert.equal(merged.sessionId, 'new-session')
+    assert.deepEqual(merged.todos, [{ text: 'new todo', status: 'done' }])
+    assert.equal(merged.workflowKey, 'workflow:new')
+    assert.equal(merged.msgs.find((message) => message.id === 'card').spec.title, 'new card')
+    assert.equal(merged.msgs.find((message) => message.id === 'card').resolved, true)
+    assert.equal(merged.msgs.find((message) => message.id === 'reply').text, 'late reply')
+  }
+})
+
+test('exact revision ties use writer and sequence deterministically in both merge orders', () => {
+  const base = normalizeThread({
+    id: 'tie-thread',
+    workflowKey: 'workflow:base',
+    sessionId: 'base-session',
+    updatedAt: 100,
+    msgs: [{ id: 'card', role: 'card', text: 'base', createdAt: 100 }]
+  })
+  const lowerWriter = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb: null, writerId: 'a' })
+  const higherWriter = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb: null, writerId: 'z' })
+  const left = structuredClone(base)
+  const right = structuredClone(base)
+  lowerWriter.reviseThread(left, { sessionId: 'from-a', workflowKey: 'workflow:a' }, 1_000)
+  higherWriter.reviseThread(right, { sessionId: 'from-z', workflowKey: 'workflow:z' }, 1_000)
+  left.msgs[0].text = 'card-a'
+  right.msgs[0].text = 'card-z'
+  lowerWriter.touchMessage(left.msgs[0], 1_000)
+  higherWriter.touchMessage(right.msgs[0], 1_000)
+
+  for (const pair of [[left, right], [right, left]]) {
+    const merged = mergeHistorySnapshots(
+      { threads: [pair[0]], meta: {} },
+      { threads: [pair[1]], meta: {} }
+    ).threads[0]
+    assert.equal(merged.sessionId, 'from-z')
+    assert.equal(merged.workflowKey, 'workflow:z')
+    assert.equal(merged.msgs[0].text, 'card-z')
+  }
+})
+
 test('thread tombstones prevent deleted chats from being resurrected by stale snapshots', () => {
   const deletedAt = 500
   const merged = mergeHistorySnapshots(

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -499,7 +499,7 @@ test('legacy local shadow migration preserves the valid half of split or corrupt
   const loaded = store.readLocal()
 
   assert.equal(loaded.threads[0].id, 'legacy-thread')
-  assert.deepEqual(loaded.meta.activeByScope, {})
+  assert.deepEqual(Object.keys(loaded.meta.activeByScope), [])
 })
 
 test('partially corrupt atomic shadow recovers each invalid half from legacy storage', () => {
@@ -519,6 +519,64 @@ test('partially corrupt atomic shadow recovers each invalid half from legacy sto
 
   assert.equal(loaded.threads[0].id, 'legacy-thread')
   assert.equal(loaded.meta.activeByScope['panel:global'], 'legacy-thread')
+})
+
+test('drops malformed nested tombstones and metadata operations before canonical merge', async () => {
+  const canonical = {
+    updatedAt: 500,
+    threads: [{
+      id: 'keep',
+      workflowKey: 'panel:global',
+      updatedAt: 500,
+      msgs: [{ id: 'keep-message', role: 'user', text: 'durable', createdAt: 500 }]
+    }],
+    meta: {
+      updatedAt: 500,
+      activeByScope: { 'panel:global': 'keep' },
+      workflowAliases: { 'workflows/keep.json': 'keep-workflow' }
+    }
+  }
+  const storage = createMemoryStorage()
+  storage.values.set(CHAT_HISTORY_LOCAL_SNAPSHOT_KEY, JSON.stringify({
+    updatedAt: 900,
+    threads: [{
+      id: 'keep',
+      workflowKey: 'panel:global',
+      updatedAt: 100,
+      msgs: [],
+      deletedMessages: {
+        'keep-message': 'bad',
+        'also-bad': -1,
+        'still-bad': null
+      }
+    }],
+    meta: {
+      updatedAt: 900,
+      deletedThreads: { keep: 'bad', nope: 0 },
+      activeByScope: { 'panel:global': 'malformed-shadow' },
+      activeOps: {
+        'panel:global': { value: null, deleted: true, updatedAt: 'bad' },
+        broken: { value: 'x', deleted: true, updatedAt: 900 }
+      },
+      workflowAliases: { 'workflows/keep.json': 'malformed-shadow' },
+      aliasOps: {
+        'workflows/keep.json': { value: null, deleted: true, updatedAt: NaN },
+        'workflows/broken.json': { value: null, deleted: false, updatedAt: 900 }
+      }
+    }
+  }))
+  const indexedDb = createFakeIndexedDb(canonical)
+  const store = new ChatHistoryStore({ storage, indexedDb })
+
+  const loaded = await store.load()
+  await store.flush()
+  const reloaded = await new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb }).load()
+
+  assert.deepEqual(loaded.threads[0].msgs.map((message) => message.id), ['keep-message'])
+  assert.equal(loaded.meta.activeByScope['panel:global'], 'keep')
+  assert.equal(loaded.meta.workflowAliases['workflows/keep.json'], 'keep-workflow')
+  assert.deepEqual(reloaded.threads[0].msgs.map((message) => message.id), ['keep-message'])
+  assert.equal(Object.hasOwn(reloaded.meta.deletedThreads, 'keep'), false)
 })
 
 test('notifies another tab when the local history shadow changes', () => {

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -868,6 +868,83 @@ test('drops malformed nested tombstones and metadata operations before canonical
   assert.equal(Object.hasOwn(reloaded.meta.deletedThreads, 'keep'), false)
 })
 
+test('canonical IndexedDB checkpoint quarantines forged empty and partial local baselines', async () => {
+  const checkpoint = {
+    generation: 4,
+    revision: { updatedAt: 5_000, writerId: 'canonical-checkpoint', sequence: 1 }
+  }
+  const canonical = {
+    updatedAt: 5_000,
+    threads: [{
+      id: 'keep',
+      workflowKey: 'panel:global',
+      createdAt: 100,
+      createdRevision: { updatedAt: 100, writerId: 'canonical', sequence: 1 },
+      updatedAt: 5_000,
+      msgs: [{
+        id: 'keep-message',
+        role: 'user',
+        text: 'canonical history',
+        createdAt: 100,
+        createdRevision: { updatedAt: 100, writerId: 'canonical', sequence: 2 }
+      }]
+    }],
+    meta: {
+      updatedAt: 5_000,
+      checkpoint,
+      activeByScope: { 'panel:global': 'keep' },
+      workflowAliases: { 'workflows/keep.json': 'keep-workflow' }
+    }
+  }
+
+  for (const forged of [
+    {
+      updatedAt: 99_000,
+      threads: [],
+      meta: {
+        updatedAt: 99_000,
+        checkpoint: {
+          generation: 999,
+          revision: { updatedAt: 99_000, writerId: 'forged', sequence: 1 }
+        }
+      }
+    },
+    {
+      updatedAt: 99_001,
+      threads: [{
+        id: 'forged-partial',
+        workflowKey: 'panel:global',
+        createdAt: 10,
+        createdRevision: { updatedAt: 10, writerId: 'forged', sequence: 1 },
+        updatedAt: 99_001,
+        msgs: []
+      }],
+      meta: {
+        updatedAt: 99_001,
+        checkpoint: {
+          generation: 1_000,
+          revision: { updatedAt: 99_001, writerId: 'forged', sequence: 1 }
+        },
+        activeByScope: { 'panel:global': 'forged-partial' }
+      }
+    }
+  ]) {
+    const storage = createMemoryStorage()
+    storage.values.set(CHAT_HISTORY_LOCAL_SNAPSHOT_KEY, JSON.stringify(forged))
+    const indexedDb = createFakeIndexedDb(canonical)
+    const store = new ChatHistoryStore({ storage, indexedDb })
+    const loaded = await store.load()
+    const flush = await store.flush()
+
+    assert.equal(flush, true)
+    assert.deepEqual(loaded.threads.map((thread) => thread.id), ['keep'])
+    assert.equal(loaded.threads[0].msgs[0].text, 'canonical history')
+    assert.equal(loaded.meta.activeByScope['panel:global'], 'keep')
+    assert.equal(loaded.meta.workflowAliases['workflows/keep.json'], 'keep-workflow')
+    assert.equal(indexedDb.readState().meta.checkpoint.generation, checkpoint.generation)
+  }
+})
+
 test('notifies another tab when the local history shadow changes', () => {
   const values = new Map()
   const storage = {

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -258,8 +258,8 @@ test('exact revision ties use writer and sequence deterministically in both merg
   }
 })
 
-test('thread tombstones prevent deleted chats from being resurrected by stale snapshots', () => {
-  const deletedAt = 500
+test('thread tombstones preserve causal delete operations and prevent stale resurrection', () => {
+  const deletedAt = { updatedAt: 500, writerId: 'delete-tab', sequence: 1 }
   const merged = mergeHistorySnapshots(
     {
       threads: [],
@@ -276,7 +276,8 @@ test('thread tombstones prevent deleted chats from being resurrected by stale sn
   )
 
   assert.equal(merged.threads.some((thread) => thread.id === 'removed'), false)
-  assert.equal(merged.meta.deletedThreads.removed, deletedAt)
+  assert.deepEqual(merged.meta.deletedThreads.removed.revision, deletedAt)
+  assert.equal(merged.meta.deletedThreads.removed.deleted, true)
 })
 
 test('thread tombstones remain final even when another tab writes the thread later', () => {
@@ -294,7 +295,7 @@ test('thread tombstones remain final even when another tab writes the thread lat
   )
 
   assert.equal(merged.threads.some((thread) => thread.id === 'removed'), false)
-  assert.equal(merged.meta.deletedThreads.removed, 500)
+  assert.equal(merged.meta.deletedThreads.removed.updatedAt, 500)
 })
 
 test('message tombstones survive concurrent append and later reload merges', () => {

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -7,6 +7,7 @@ import {
   isThreadInScope,
   mergeHistorySnapshots,
   normalizeThread,
+  retainBoundedThreads,
   selectPanelThread,
   selectRestoreThread,
   selectThreadForScope
@@ -144,6 +145,55 @@ test('reload never accepts a tab pointer from another workflow', () => {
     scopeKey: 'workflow:wf-a',
     preferredThreadId: 'visible-elsewhere'
   })?.id, 'scoped')
+})
+
+test('canonical eviction retains the pointed thread and fills the rest by recency', () => {
+  const threads = Array.from({ length: 501 }, (_, i) => ({
+    id: `t${i}`,
+    workflowKey: 'panel:global',
+    updatedAt: 1000 + i,
+    msgs: [{ id: `m${i}` }]
+  }))
+  const kept = retainBoundedThreads(threads, 500, ['t0'])
+
+  assert.equal(kept.length, 500)
+  assert.equal(kept.some((thread) => thread.id === 't0'), true)
+  assert.equal(kept.some((thread) => thread.id === 't1'), false)
+  assert.equal(kept.some((thread) => thread.id === 't500'), true)
+  assert.equal(selectRestoreThread(kept, {}, {
+    panelOwned: true,
+    preferredThreadId: 't0'
+  })?.id, 't0')
+
+  const protectedOverflow = retainBoundedThreads(threads.slice(0, 3), 2, ['t0', 't1', 't2'])
+  assert.deepEqual(protectedOverflow.map((thread) => thread.id), ['t0', 't1'])
+})
+
+test('localStorage shadow retains the active tab thread when IndexedDB is unavailable', async () => {
+  const values = new Map()
+  const storage = {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value)
+  }
+  const threads = Array.from({ length: 21 }, (_, i) => ({
+    id: `t${i}`,
+    workflowKey: 'panel:global',
+    updatedAt: 1000 + i,
+    msgs: [{ id: `m${i}`, role: 'user', text: `message ${i}` }]
+  }))
+  const store = new ChatHistoryStore({ storage, indexedDb: null })
+  store.persist(threads, { activeByScope: { 'panel:global': 't0' } })
+  await store.flush()
+
+  const shadow = JSON.parse(values.get('comfyui-mcp.panel.threads'))
+  assert.equal(shadow.length, 20)
+  assert.equal(shadow.some((thread) => thread.id === 't0'), true)
+  assert.equal(shadow.some((thread) => thread.id === 't1'), false)
+  assert.equal(store.readLocal().threads.some((thread) => thread.id === 't0'), true)
+  const degradedStore = new ChatHistoryStore({ storage, indexedDb: null })
+  const degradedReload = await degradedStore.load({ protectedThreadIds: ['t0'] })
+  await degradedStore.flush()
+  assert.equal(degradedReload.threads.some((thread) => thread.id === 't0'), true)
 })
 
 test('notifies another tab when the local history shadow changes', () => {

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  CHAT_HISTORY_SCHEMA,
+  ChatHistoryStore,
+  isThreadInScope,
+  mergeHistorySnapshots,
+  normalizeThread,
+  selectPanelThread,
+  selectThreadForScope
+} from '../../web/js/lib/chat-history-store.js'
+
+test('normalizes legacy threads into schema v2 without losing messages', () => {
+  const thread = normalizeThread({ id: 'legacy', ts: 123, msgs: [{ role: 'user', text: 'hello' }] })
+  assert.equal(thread.schemaVersion, CHAT_HISTORY_SCHEMA)
+  assert.equal(thread.workflowKey, 'panel:global')
+  assert.equal(thread.updatedAt, 123)
+  assert.equal(thread.msgs[0].text, 'hello')
+})
+
+test('merges browser and durable snapshots by newest thread update', () => {
+  const merged = mergeHistorySnapshots(
+    {
+      threads: [{ id: 'same', ts: 100, msgs: [{ role: 'user', text: 'old' }], title: 'kept title' }],
+      meta: { activeByScope: { 'panel:global': 'same' } }
+    },
+    {
+      threads: [{ id: 'same', updatedAt: 200, msgs: [{ role: 'agent', text: 'new' }] }],
+      meta: { workflowAliases: { 'workflows/a.json': 'uuid-a' } }
+    }
+  )
+  assert.equal(merged.threads.length, 1)
+  assert.equal(merged.threads[0].msgs[0].text, 'new')
+  assert.equal(merged.threads[0].title, 'kept title')
+  assert.equal(merged.meta.activeByScope['panel:global'], 'same')
+  assert.equal(merged.meta.workflowAliases['workflows/a.json'], 'uuid-a')
+})
+
+test('merges concurrent messages in the same thread without dropping either tab', () => {
+  const base = {
+    id: 'shared',
+    workflowKey: 'workflow:wf-a',
+    createdAt: 100,
+    updatedAt: 100,
+    msgs: [{ id: 'm1', role: 'user', text: 'base', createdAt: 100 }]
+  }
+  const merged = mergeHistorySnapshots(
+    {
+      threads: [{
+        ...base,
+        updatedAt: 200,
+        msgs: [...base.msgs, { id: 'm2', role: 'agent', text: 'from tab A', createdAt: 200 }]
+      }],
+      meta: {}
+    },
+    {
+      threads: [{
+        ...base,
+        updatedAt: 210,
+        msgs: [...base.msgs, { id: 'm3', role: 'user', text: 'from tab B', createdAt: 210 }]
+      }],
+      meta: {}
+    }
+  )
+
+  assert.deepEqual(merged.threads[0].msgs.map((message) => message.text), [
+    'base',
+    'from tab A',
+    'from tab B'
+  ])
+})
+
+test('thread tombstones prevent deleted chats from being resurrected by stale snapshots', () => {
+  const deletedAt = 500
+  const merged = mergeHistorySnapshots(
+    {
+      threads: [],
+      meta: { deletedThreads: { removed: deletedAt } }
+    },
+    {
+      threads: [{ id: 'removed', updatedAt: 400, workflowKey: 'workflow:wf-a', msgs: [] }],
+      meta: {}
+    },
+    {
+      threads: [],
+      meta: { deletedThreads: { removed: 100 } }
+    }
+  )
+
+  assert.equal(merged.threads.some((thread) => thread.id === 'removed'), false)
+  assert.equal(merged.meta.deletedThreads.removed, deletedAt)
+})
+
+test('scope selection never falls back to a chat from another workflow', () => {
+  const threads = [
+    { id: 'a-old', workflowKey: 'workflow:wf-a', updatedAt: 100, msgs: [] },
+    { id: 'a-active', workflowKey: 'workflow:wf-a', updatedAt: 90, msgs: [] },
+    { id: 'b-newest', workflowKey: 'workflow:wf-b', updatedAt: 999, msgs: [] }
+  ]
+  const meta = { activeByScope: { 'workflow:wf-a': 'a-active' } }
+
+  assert.equal(isThreadInScope(threads[0], 'workflow:wf-a'), true)
+  assert.equal(isThreadInScope(threads[2], 'workflow:wf-a'), false)
+  assert.equal(selectThreadForScope(threads, meta, 'workflow:wf-a')?.id, 'a-active')
+  assert.equal(selectThreadForScope(threads, meta, 'workflow:missing'), null)
+})
+
+test('panel selection preserves provenance and recovers when its tab pointer is lost', () => {
+  const threads = [
+    { id: 'older-selected', workflowKey: 'wf:workflows/a.json', updatedAt: 100, msgs: [] },
+    { id: 'newest', workflowKey: 'tmp:browser-restart', updatedAt: 200, msgs: [] }
+  ]
+
+  assert.equal(
+    selectPanelThread(threads, { activeByScope: { 'panel:global': 'older-selected' } })?.id,
+    'older-selected'
+  )
+  assert.equal(selectPanelThread(threads, {})?.id, 'newest')
+  assert.equal(threads[0].workflowKey, 'wf:workflows/a.json')
+})
+
+test('notifies another tab when the local history shadow changes', () => {
+  const values = new Map()
+  const storage = {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value)
+  }
+  const listeners = new Set()
+  const eventTarget = {
+    addEventListener: (type, listener) => type === 'storage' && listeners.add(listener),
+    removeEventListener: (type, listener) => type === 'storage' && listeners.delete(listener)
+  }
+  const store = new ChatHistoryStore({ storage, indexedDb: null })
+  values.set('comfyui-mcp.panel.threads', JSON.stringify([
+    { id: 'from-other-tab', workflowKey: 'workflow:wf-a', updatedAt: 10, msgs: [] }
+  ]))
+  let received = null
+  const unsubscribe = store.subscribe((snapshot) => { received = snapshot }, eventTarget)
+
+  for (const listener of listeners) listener({ key: 'unrelated' })
+  assert.equal(received, null)
+  for (const listener of listeners) listener({ key: 'comfyui-mcp.panel.threads' })
+  assert.equal(received.threads[0].id, 'from-other-tab')
+  unsubscribe()
+  assert.equal(listeners.size, 0)
+})

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -8,6 +8,7 @@ import {
   mergeHistorySnapshots,
   normalizeThread,
   selectPanelThread,
+  selectRestoreThread,
   selectThreadForScope
 } from '../../web/js/lib/chat-history-store.js'
 
@@ -118,6 +119,31 @@ test('panel selection preserves provenance and recovers when its tab pointer is 
   )
   assert.equal(selectPanelThread(threads, {})?.id, 'newest')
   assert.equal(threads[0].workflowKey, 'wf:workflows/a.json')
+})
+
+test('reload keeps the tab-pointed panel conversation instead of switching to a newer thread', () => {
+  const threads = [
+    { id: 'visible', workflowKey: 'workflow:wf-a', updatedAt: 100, msgs: [] },
+    { id: 'newer-background', workflowKey: 'workflow:wf-b', updatedAt: 999, msgs: [] }
+  ]
+
+  assert.equal(selectRestoreThread(threads, {}, {
+    panelOwned: true,
+    preferredThreadId: 'visible'
+  })?.id, 'visible')
+})
+
+test('reload never accepts a tab pointer from another workflow', () => {
+  const threads = [
+    { id: 'visible-elsewhere', workflowKey: 'workflow:wf-b', updatedAt: 999, msgs: [] },
+    { id: 'scoped', workflowKey: 'workflow:wf-a', updatedAt: 100, msgs: [] }
+  ]
+
+  assert.equal(selectRestoreThread(threads, {}, {
+    panelOwned: false,
+    scopeKey: 'workflow:wf-a',
+    preferredThreadId: 'visible-elsewhere'
+  })?.id, 'scoped')
 })
 
 test('notifies another tab when the local history shadow changes', () => {

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -777,6 +777,40 @@ test('atomic local shadow survives a failed legacy metadata write', async () => 
   assert.equal(store.readLocal().meta.activeByScope['panel:global'], 'kept')
 })
 
+test('flush reports total persistence failure and retries the retained dirty snapshot', async () => {
+  const failures = []
+  const blockedStorage = createMemoryStorage({ throwOnSet: CHAT_HISTORY_LOCAL_SNAPSHOT_KEY })
+  const store = new ChatHistoryStore({
+    storage: blockedStorage,
+    indexedDb: null,
+    onPersistenceError: (failure) => failures.push(failure)
+  })
+  store.persist(
+    [{ id: 'retry-thread', workflowKey: 'panel:global', updatedAt: 10, msgs: [] }],
+    { activeByScope: { 'panel:global': 'retry-thread' } }
+  )
+
+  const failed = await store.flush()
+  assert.deepEqual(failed, {
+    ok: false,
+    shadowCommitted: false,
+    canonicalCommitted: false,
+    retryable: true,
+    code: 'history-persistence-unavailable'
+  })
+  assert.equal(failures.length, 1)
+  assert.equal(store._lastCommitted, null)
+
+  const recoveredStorage = createMemoryStorage()
+  const recoveredIndexedDb = createFakeIndexedDb()
+  store.storage = recoveredStorage
+  store.indexedDb = recoveredIndexedDb
+  store.persist([], {})
+  assert.equal(await store.flush(), true)
+  assert.equal(recoveredIndexedDb.readState().threads[0].id, 'retry-thread')
+  assert.equal(store.readLocal().threads[0].id, 'retry-thread')
+})
+
 test('legacy local shadow migration preserves the valid half of split or corrupt state', () => {
   const storage = createMemoryStorage()
   storage.values.set('comfyui-mcp.panel.threads', JSON.stringify([

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -85,6 +85,7 @@ function createFakeIndexedDb(initialState = null, { blockedThenSuccess = false }
 
 function createBroadcastHub() {
   const channels = new Set()
+  let closeCount = 0
   return {
     factory: () => {
       const listeners = new Set()
@@ -99,11 +100,17 @@ function createBroadcastHub() {
         },
         dispatch: (data) => {
           for (const listener of listeners) listener({ data })
+        },
+        close: () => {
+          if (!channels.delete(channel)) return
+          closeCount += 1
+          listeners.clear()
         }
       }
       channels.add(channel)
       return channel
-    }
+    },
+    closeCount: () => closeCount
   }
 }
 
@@ -1036,7 +1043,7 @@ test('canonical IndexedDB checkpoint quarantines forged empty and partial local 
   }
 })
 
-test('notifies another tab when the local history shadow changes', () => {
+test('notifies another tab when the local history shadow changes', async () => {
   const values = new Map()
   const storage = {
     getItem: (key) => values.get(key) ?? null,
@@ -1057,8 +1064,34 @@ test('notifies another tab when the local history shadow changes', () => {
   for (const listener of listeners) listener({ key: 'unrelated' })
   assert.equal(received, null)
   for (const listener of listeners) listener({ key: 'comfyui-mcp.panel.threads' })
+  await new Promise((resolve) => setTimeout(resolve, 0))
   assert.equal(received.threads[0].id, 'from-other-tab')
   unsubscribe()
+  assert.equal(listeners.size, 0)
+})
+
+test('store close is idempotent and releases subscriptions and BroadcastChannel once', () => {
+  const listeners = new Set()
+  const eventTarget = {
+    addEventListener: (type, listener) => type === 'storage' && listeners.add(listener),
+    removeEventListener: (type, listener) => type === 'storage' && listeners.delete(listener)
+  }
+  const hub = createBroadcastHub()
+  const store = new ChatHistoryStore({
+    storage: createMemoryStorage(),
+    indexedDb: null,
+    broadcastChannelFactory: hub.factory
+  })
+  store.subscribe(() => {}, eventTarget)
+  assert.equal(listeners.size, 1)
+
+  store.close()
+  store.close()
+
+  assert.equal(listeners.size, 0)
+  assert.equal(hub.closeCount(), 1)
+  const unsubscribeAfterClose = store.subscribe(() => {}, eventTarget)
+  unsubscribeAfterClose()
   assert.equal(listeners.size, 0)
 })
 

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -11,7 +11,8 @@ import {
   retainBoundedThreads,
   selectPanelThread,
   selectRestoreThread,
-  selectThreadForScope
+  selectThreadForScope,
+  updateMetadataEntry
 } from '../../web/js/lib/chat-history-store.js'
 
 function createMemoryStorage({ throwOnSet = null } = {}) {
@@ -399,6 +400,38 @@ test('metadata tombstones clear active pointers and aliases across stale snapsho
   assert.equal(selectPanelThread([
     { id: 'old-thread', workflowKey: 'panel:global', updatedAt: 100, msgs: [] }
   ], merged.meta), null)
+})
+
+test('alias tombstones and exact-time writer ties remain deterministic in both merge orders', () => {
+  const base = {
+    updatedAt: 100,
+    workflowAliases: { 'workflows/old.json': 'workflow-id' }
+  }
+  const deleted = updateMetadataEntry(base, 'workflowAliases', 'workflows/old.json', null, {
+    updatedAt: 500,
+    writerId: 'z-renamer',
+    sequence: 1
+  })
+  const staleSet = updateMetadataEntry(base, 'workflowAliases', 'workflows/old.json', 'workflow-id', {
+    updatedAt: 500,
+    writerId: 'a-stale',
+    sequence: 99
+  })
+  const unrelated = updateMetadataEntry(staleSet, 'activeByScope', 'panel:global', 'thread-b', {
+    updatedAt: 600,
+    writerId: 'a-stale',
+    sequence: 100
+  })
+
+  for (const pair of [[deleted, unrelated], [unrelated, deleted]]) {
+    const merged = mergeHistorySnapshots(
+      { threads: [], meta: pair[0] },
+      { threads: [], meta: pair[1] }
+    )
+    assert.equal(Object.hasOwn(merged.meta.workflowAliases, 'workflows/old.json'), false)
+    assert.equal(merged.meta.aliasOps['workflows/old.json'].deleted, true)
+    assert.equal(merged.meta.activeByScope['panel:global'], 'thread-b')
+  }
 })
 
 test('scope selection never falls back to a chat from another workflow', () => {

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -908,6 +908,85 @@ test('partially corrupt atomic shadow recovers each invalid half from legacy sto
   assert.equal(loaded.meta.activeByScope['panel:global'], 'legacy-thread')
 })
 
+test('validates and caps field operations while preserving legacy clear migration', () => {
+  const base = normalizeThread({
+    id: 'field-validation',
+    sessionId: 'canonical-session',
+    pinned: true,
+    todos: [{ text: 'canonical todo', status: 'active' }],
+    title: 'canonical title',
+    workflowTitle: 'canonical workflow title',
+    updatedAt: 100,
+    msgs: []
+  })
+  const malformed = normalizeThread({
+    ...base,
+    updatedAt: 1_000,
+    fieldOps: {
+      ...base.fieldOps,
+      sessionId: {
+        value: { forged: true },
+        deleted: false,
+        updatedAt: 1_000,
+        revision: { updatedAt: 1_000, writerId: 'attacker', sequence: 1 }
+      },
+      pinned: {
+        value: 'yes',
+        deleted: false,
+        updatedAt: 1_001,
+        revision: { updatedAt: 1_001, writerId: 'attacker', sequence: 2 }
+      },
+      todos: {
+        value: 'not-an-array',
+        deleted: false,
+        updatedAt: 1_002,
+        revision: { updatedAt: 1_002, writerId: 'attacker', sequence: 3 }
+      },
+      title: {
+        value: 'x'.repeat(500),
+        deleted: false,
+        updatedAt: 1_003,
+        revision: { updatedAt: 1_003, writerId: 'attacker', sequence: 4 }
+      },
+      workflowTitle: {
+        value: 'y'.repeat(500),
+        deleted: false,
+        updatedAt: 1_004,
+        revision: { updatedAt: 1_004, writerId: '', sequence: -1 }
+      }
+    }
+  })
+
+  assert.equal(malformed.sessionId, 'canonical-session')
+  assert.equal(malformed.pinned, true)
+  assert.deepEqual(malformed.todos, [{ text: 'canonical todo', status: 'active' }])
+  assert.equal(malformed.title.length, 160)
+  assert.equal(malformed.workflowTitle, 'canonical workflow title')
+
+  const cappedTodos = Array.from({ length: 140 }, (_, index) => ({
+    text: `todo-${index}-${'z'.repeat(2_100)}`,
+    status: index === 0 ? 'done' : 'unknown'
+  }))
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb: null })
+  store.reviseThread(malformed, { todos: cappedTodos, pinned: 'invalid', model: { bad: true } }, 2_000)
+  assert.equal(malformed.todos.length, 100)
+  assert.equal(malformed.todos[0].text.length, 2_000)
+  assert.equal(malformed.todos[0].status, 'done')
+  assert.equal(malformed.todos[1].status, 'pending')
+  assert.equal(malformed.pinned, true)
+  assert.equal(malformed.model, undefined)
+
+  const legacyClear = normalizeThread({
+    ...base,
+    fieldOps: {
+      ...base.fieldOps,
+      sessionId: { value: null, deleted: true, updatedAt: 3_000 }
+    }
+  })
+  assert.equal(legacyClear.sessionId, undefined)
+  assert.equal(legacyClear.fieldOps.sessionId.deleted, true)
+})
+
 test('drops malformed nested tombstones and metadata operations before canonical merge', async () => {
   const canonical = {
     updatedAt: 500,

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -82,22 +82,25 @@ function createFakeIndexedDb(initialState = null, { blockedThenSuccess = false }
   }
 }
 
-test('normalizes legacy threads into schema v2 without losing messages', () => {
+test('migrates legacy messages to stable schema identities without losing content', () => {
   const thread = normalizeThread({ id: 'legacy', ts: 123, msgs: [{ role: 'user', text: 'hello' }] })
+  const sameMigration = normalizeThread({ id: 'legacy', ts: 123, msgs: [{ role: 'user', text: 'hello' }] })
   assert.equal(thread.schemaVersion, CHAT_HISTORY_SCHEMA)
   assert.equal(thread.workflowKey, 'panel:global')
   assert.equal(thread.updatedAt, 123)
   assert.equal(thread.msgs[0].text, 'hello')
+  assert.match(thread.msgs[0].id, /^legacy-[a-f0-9]{16}$/)
+  assert.equal(thread.msgs[0].id, sameMigration.msgs[0].id)
 })
 
 test('merges browser and durable snapshots by newest thread update', () => {
   const merged = mergeHistorySnapshots(
     {
-      threads: [{ id: 'same', ts: 100, msgs: [{ role: 'user', text: 'old' }], title: 'kept title' }],
+      threads: [{ id: 'same', ts: 100, msgs: [{ id: 'same-message', role: 'user', text: 'old', createdAt: 100 }], title: 'kept title' }],
       meta: { activeByScope: { 'panel:global': 'same' } }
     },
     {
-      threads: [{ id: 'same', updatedAt: 200, msgs: [{ role: 'agent', text: 'new' }] }],
+      threads: [{ id: 'same', updatedAt: 200, msgs: [{ id: 'same-message', role: 'agent', text: 'new', createdAt: 100, updatedAt: 200 }] }],
       meta: { workflowAliases: { 'workflows/a.json': 'uuid-a' } }
     }
   )
@@ -214,6 +217,65 @@ test('message tombstones survive concurrent append and later reload merges', () 
   assert.deepEqual(merged.threads[0].msgs.map((message) => message.id), ['m2'])
   assert.equal(merged.threads[0].deletedMessages.m1, 300)
   assert.deepEqual(reloaded.threads[0].msgs.map((message) => message.id), ['m2'])
+})
+
+test('two stores migrate id-less messages once and preserve concurrent append and delete in both orders', async () => {
+  async function run(order) {
+    const indexedDb = createFakeIndexedDb({
+      updatedAt: 100,
+      threads: [{
+        id: 'legacy-shared',
+        workflowKey: 'panel:global',
+        updatedAt: 100,
+        msgs: [
+          { role: 'user', text: 'delete this', createdAt: 90 },
+          { role: 'agent', text: 'keep this', createdAt: 100 }
+        ]
+      }],
+      meta: {}
+    })
+    const stores = [
+      new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb }),
+      new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb })
+    ]
+    const snapshots = await Promise.all(stores.map((store) => store.load()))
+    await Promise.all(stores.map((store) => store.flush()))
+    const migratedIds = snapshots.map((snapshot) => snapshot.threads[0].msgs.map((message) => message.id))
+    assert.deepEqual(migratedIds[0], migratedIds[1])
+
+    const [deletedId] = migratedIds[0]
+    const aThread = structuredClone(snapshots[0].threads[0])
+    aThread.msgs = [
+      ...aThread.msgs.filter((message) => message.id !== deletedId),
+      { id: 'append-a', role: 'user', text: 'from A', createdAt: 300 }
+    ]
+    aThread.deletedMessages = { [deletedId]: 300 }
+    aThread.updatedAt = 300
+    const bThread = structuredClone(snapshots[1].threads[0])
+    bThread.msgs.push({ id: 'append-b', role: 'agent', text: 'from B', createdAt: 400 })
+    bThread.updatedAt = 400
+    const writes = [
+      () => stores[0].persist([aThread], {}),
+      () => stores[1].persist([bThread], {})
+    ]
+    for (const index of order) {
+      writes[index]()
+      await stores[index].flush()
+    }
+
+    const reloadStore = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb })
+    const reloaded = await reloadStore.load()
+    await reloadStore.flush()
+    return reloaded.threads[0]
+  }
+
+  for (const order of [[0, 1], [1, 0]]) {
+    const thread = await run(order)
+    assert.equal(thread.schemaVersion, CHAT_HISTORY_SCHEMA)
+    assert.deepEqual(thread.msgs.map((message) => message.text), ['keep this', 'from A', 'from B'])
+    assert.equal(Object.hasOwn(thread.deletedMessages, thread.msgs[0].id), false)
+    assert.equal(Object.values(thread.deletedMessages).length, 1)
+  }
 })
 
 test('metadata tombstones clear active pointers and aliases across stale snapshots', () => {

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -83,6 +83,30 @@ function createFakeIndexedDb(initialState = null, { blockedThenSuccess = false }
   }
 }
 
+function createBroadcastHub() {
+  const channels = new Set()
+  return {
+    factory: () => {
+      const listeners = new Set()
+      const channel = {
+        addEventListener: (type, listener) => type === 'message' && listeners.add(listener),
+        removeEventListener: (type, listener) => type === 'message' && listeners.delete(listener),
+        postMessage: (data) => {
+          for (const peer of channels) {
+            if (peer === channel) continue
+            queueMicrotask(() => peer.dispatch(data))
+          }
+        },
+        dispatch: (data) => {
+          for (const listener of listeners) listener({ data })
+        }
+      }
+      channels.add(channel)
+      return channel
+    }
+  }
+}
+
 test('migrates legacy messages to stable schema identities without losing content', () => {
   const thread = normalizeThread({ id: 'legacy', ts: 123, msgs: [{ role: 'user', text: 'hello' }] })
   const sameMigration = normalizeThread({ id: 'legacy', ts: 123, msgs: [{ role: 'user', text: 'hello' }] })
@@ -786,4 +810,110 @@ test('notifies another tab when the local history shadow changes', () => {
   assert.equal(received.threads[0].id, 'from-other-tab')
   unsubscribe()
   assert.equal(listeners.size, 0)
+})
+
+test('bounds checkpointed operations, rejects compacted stale resurrection, and broadcasts quota failures', async () => {
+  const indexedDb = createFakeIndexedDb()
+  const hub = createBroadcastHub()
+  const shadowErrors = []
+  const quotaStorage = createMemoryStorage({ throwOnSet: CHAT_HISTORY_LOCAL_SNAPSHOT_KEY })
+  const writer = new ChatHistoryStore({
+    storage: quotaStorage,
+    indexedDb,
+    writerId: 'quota-writer',
+    maxTombstones: 3,
+    maxMetadataOps: 3,
+    broadcastChannelFactory: hub.factory,
+    onShadowError: (error) => shadowErrors.push(error.message)
+  })
+  const receiver = new ChatHistoryStore({
+    storage: createMemoryStorage(),
+    indexedDb,
+    writerId: 'receiver',
+    maxTombstones: 3,
+    maxMetadataOps: 3,
+    broadcastChannelFactory: hub.factory
+  })
+  let invalidated = null
+  const unsubscribe = receiver.subscribe((snapshot) => { invalidated = snapshot }, null)
+  const deletedMessages = Object.fromEntries(
+    Array.from({ length: 10 }, (_, index) => [`m${index}`, 1_000 + index])
+  )
+  const deletedThreads = Object.fromEntries(
+    Array.from({ length: 10 }, (_, index) => [`t${index}`, 1_000 + index])
+  )
+  const aliasOps = Object.fromEntries(Array.from({ length: 10 }, (_, index) => [
+    `workflows/deleted-${index}.json`,
+    {
+      value: null,
+      deleted: true,
+      updatedAt: 1_000 + index,
+      revision: { updatedAt: 1_000 + index, writerId: 'quota-writer', sequence: index + 1 }
+    }
+  ]))
+  const activeOps = Object.fromEntries(Array.from({ length: 10 }, (_, index) => [
+    `workflow:deleted-${index}`,
+    {
+      value: null,
+      deleted: true,
+      updatedAt: 1_100 + index,
+      revision: { updatedAt: 1_100 + index, writerId: 'quota-writer', sequence: index + 20 }
+    }
+  ]))
+
+  writer.persist([{
+    id: 'live',
+    workflowKey: 'panel:global',
+    createdAt: 100,
+    updatedAt: 1_200,
+    msgs: [],
+    deletedMessages
+  }], { updatedAt: 1_200, deletedThreads, aliasOps, activeOps })
+  await writer.flush()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+
+  const compacted = indexedDb.readState()
+  assert.equal(writer.lastShadowWriteOk, false)
+  assert.match(shadowErrors[0], /blocked write/)
+  assert.ok(invalidated?.meta?.checkpoint?.generation > 0)
+  assert.ok(Object.keys(compacted.meta.deletedThreads).length <= 3)
+  assert.ok(Object.keys(compacted.meta.aliasOps).length <= 3)
+  assert.ok(Object.keys(compacted.meta.activeOps).length <= 3)
+  assert.ok(Object.keys(compacted.threads[0].deletedMessages).length <= 3)
+
+  const stale = new ChatHistoryStore({
+    storage: createMemoryStorage(),
+    indexedDb,
+    writerId: 'stale-writer',
+    maxTombstones: 3,
+    maxMetadataOps: 3
+  })
+  stale.persist([
+    {
+      id: 'live',
+      workflowKey: 'panel:global',
+      createdAt: 100,
+      updatedAt: 2_000,
+      msgs: [{ id: 'm0', role: 'user', text: 'must stay deleted', createdAt: 100 }]
+    },
+    { id: 't0', workflowKey: 'panel:global', createdAt: 100, updatedAt: 2_000, msgs: [] }
+  ], {
+    updatedAt: 2_000,
+    workflowAliases: { 'workflows/deleted-0.json': 'must-stay-deleted' },
+    aliasOps: {
+      'workflows/deleted-0.json': {
+        value: 'must-stay-deleted',
+        deleted: false,
+        updatedAt: 100,
+        revision: { updatedAt: 100, writerId: 'stale-writer', sequence: 1 }
+      }
+    }
+  })
+  await stale.flush()
+  const reloaded = await receiver.readCanonical()
+
+  assert.equal(reloaded.threads.some((thread) => thread.id === 't0'), false)
+  assert.equal(reloaded.threads.find((thread) => thread.id === 'live').msgs.some((message) => message.id === 'm0'), false)
+  assert.equal(Object.hasOwn(reloaded.meta.workflowAliases, 'workflows/deleted-0.json'), false)
+  unsubscribe()
 })

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -667,6 +667,7 @@ let _workflowUuidAliases = (() => {
     return {};
   }
 })();
+let workflowAliasMutationSink = null;
 // MODULE-scoped so they survive buildPanel re-mounts (the panel re-mounts on every
 // ComfyUI workflow switch). If these lived in the panel closure, each re-mount would
 // re-seed them to the now-current workflow and defeat change detection.
@@ -784,18 +785,24 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
 
   _workflowObjectUuids.set(identityObject, id);
   rememberWorkflowUuidOwner(id, identityObject);
+  const aliasMutations = [];
   if (objectUuid && path) {
     // Rename/Save-As mutates the same live workflow object. Drop stale aliases
     // so a cold start does not later misclassify the renamed file as a clone.
     for (const [knownPath, knownUuid] of Object.entries(_workflowUuidAliases)) {
       if (knownUuid === id && normalizedWorkflowPath(knownPath) !== normalizedWorkflowPath(path)) {
         delete _workflowUuidAliases[knownPath];
+        aliasMutations.push([knownPath, null]);
       }
     }
   }
   if (path && _workflowUuidAliases[path] !== id) {
     _workflowUuidAliases[path] = id;
+    aliasMutations.push([path, id]);
+  }
+  if (aliasMutations.length) {
     persistWorkflowAliases();
+    for (const [aliasPath, value] of aliasMutations) workflowAliasMutationSink?.(aliasPath, value);
   }
   if (embed) {
     try {
@@ -10470,8 +10477,8 @@ function buildPanel() {
     );
   }
 
-  function persistThreads() {
-    syncWorkflowAliases();
+  function persistThreads({ syncAliases = true } = {}) {
+    if (syncAliases) syncWorkflowAliases();
     threads = capHistoryThreads(threads);
     historyStore.persist(threads, historyMeta, {
       protectedThreadIds: protectedHistoryThreadIds(),
@@ -10479,6 +10486,18 @@ function buildPanel() {
       maxMessages: MAX_THREAD_MSGS,
     });
   }
+
+  const panelAliasMutationSink = (path, value) => {
+    historyMeta = updateMetadataEntry(
+      historyMeta,
+      "workflowAliases",
+      path,
+      value,
+      nextHistoryRevision(),
+    );
+    persistThreads({ syncAliases: false });
+  };
+  workflowAliasMutationSink = panelAliasMutationSink;
 
   function detachInvalidCurrentThread({ scopeKey = null, rebind = false } = {}) {
     thread = null;
@@ -10506,6 +10525,9 @@ function buildPanel() {
     const currentThreadId = thread?.id;
     const merged = mergeHistorySnapshots({ threads, meta: historyMeta }, incoming);
     historyMeta = merged.meta;
+    // Remote alias operations are authoritative cache updates. Apply them before
+    // any local-diff pass so a received tombstone cannot be echoed as a new set.
+    applyWorkflowAliasesFromHistory();
     threads = capHistoryThreads(merged.threads, currentThreadId);
     if (currentThreadId) {
       const refreshed = threads.find((candidate) => candidate.id === currentThreadId);
@@ -15385,6 +15407,7 @@ function buildPanel() {
       document.removeEventListener("visibilitychange", onVisibilityChange);
       window.removeEventListener("pagehide", onPageHide);
       unsubscribeHistorySync();
+      if (workflowAliasMutationSink === panelAliasMutationSink) workflowAliasMutationSink = null;
       try {
         api.removeEventListener("executed", onExecuted);
         api.removeEventListener("execution_success", onExecutionSuccess);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10412,13 +10412,16 @@ function buildPanel() {
   }
 
   function applyWorkflowAliasesFromHistory() {
-    const operations = historyMeta.aliasOps || {};
-    for (const [path, operation] of Object.entries(operations)) {
-      if (operation?.deleted === true || operation?.value == null) delete _workflowUuidAliases[path];
-      else _workflowUuidAliases[path] = operation.value;
+    // This materialized map is the complete canonical view, including the
+    // current checkpoint baseline plus every newer local/remote operation in
+    // the merge. Replace the cache wholesale so a compacted delete cannot
+    // leave a stale module-level alias that the next local diff republishes.
+    const materialized = historyMeta.workflowAliases || {};
+    for (const path of Object.keys(_workflowUuidAliases)) {
+      if (!Object.hasOwn(materialized, path)) delete _workflowUuidAliases[path];
     }
-    for (const [path, value] of Object.entries(historyMeta.workflowAliases || {})) {
-      if (!Object.hasOwn(operations, path)) _workflowUuidAliases[path] = value;
+    for (const [path, value] of Object.entries(materialized)) {
+      _workflowUuidAliases[path] = value;
     }
     persistWorkflowAliases();
   }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15433,6 +15433,7 @@ function buildPanel() {
       document.removeEventListener("visibilitychange", onVisibilityChange);
       window.removeEventListener("pagehide", onPageHide);
       unsubscribeHistorySync();
+      void historyStore.flush().finally(() => historyStore.close());
       if (workflowAliasMutationSink === panelAliasMutationSink) workflowAliasMutationSink = null;
       try {
         api.removeEventListener("executed", onExecuted);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10490,6 +10490,13 @@ function buildPanel() {
     });
   }
 
+  async function invalidateDurableAgentSession() {
+    ssSet(SESSION_KEY, null);
+    if (thread) historyStore.reviseThread(thread, { sessionId: null });
+    persistThreads();
+    return historyStore.flush();
+  }
+
   const panelAliasMutationSink = (path, value) => {
     historyMeta = updateMetadataEntry(
       historyMeta,
@@ -13508,7 +13515,7 @@ function buildPanel() {
     );
   }
 
-  function connectBackend(id) {
+  async function connectBackend(id) {
     // CENTRALIZED per-backend seeding: every switch path routes through here — the
     // backend chips, the model-popover provider row, AND the Settings backend combo
     // (panelHooks.applyBackend). When the target backend differs from the one prefs
@@ -13547,13 +13554,15 @@ function buildPanel() {
     // the visible chat log stays, only the agent session resets.
     const switching = connectedBackend !== null && connectedBackend !== id;
     if (switching) {
-      ssSet(SESSION_KEY, null);
-      if (thread) historyStore.reviseThread(thread, { sessionId: null });
       // Replay the visible transcript to the NEW provider as one-shot context so
       // its fresh session has the conversation (session/thinking aren't portable
       // across providers). Consumed by the next user message, then auto-cleared.
       const replay = buildReplayTranscript();
       if (replay) client.armContext(replay);
+      // The old provider's session must be durably invalid before any reconnect
+      // can observe it. If reconnect fails or the browser closes here, reload
+      // still starts fresh instead of restoring a foreign session.
+      await invalidateDurableAgentSession();
     }
     // Reflect the picked backend in the composer placeholder immediately; onModels
     // reaffirms it authoritatively from the handshake (fix #3).
@@ -13674,7 +13683,7 @@ function buildPanel() {
       // Start FRESH on reconnect: clear the saved session id so hello sends no
       // resume (resuming would restore the wedged shell). Don't arm the resume
       // nudge. The reconnect spins up a brand-new agent.
-      ssSet(SESSION_KEY, null);
+      await invalidateDurableAgentSession();
       ssSet(SOFT_RELOAD_KEY, null);
       ssSet(MID_TASK_KEY, null);
       appendSystem("Agent restarted with a fresh session — your message history is still here.");

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -72,6 +72,7 @@ import {
   retainBoundedThreads,
   selectRestoreThread,
   selectThreadForScope,
+  updateMetadataEntry,
 } from "./lib/chat-history-store.js";
 import {
   isThreadInScope,
@@ -10389,11 +10390,33 @@ function buildPanel() {
   // shadow stays much smaller (20 threads / 200 messages) in ChatHistoryStore.
   const MAX_THREADS = 500;
   const MAX_THREAD_MSGS = 5000;
-  const historyStore = new ChatHistoryStore({ threadsKey: THREADS_KEY });
+  const historyStore = new ChatHistoryStore({
+    threadsKey: THREADS_KEY,
+    maxThreads: MAX_THREADS,
+    maxMessages: MAX_THREAD_MSGS,
+  });
   const localHistory = historyStore.readLocal();
   let threads = localHistory.threads;
   let historyMeta = localHistory.meta;
   let thread = null; // created lazily on first recorded message
+
+  function nextHistoryRevision() {
+    return Math.max(Date.now(), Number(historyMeta?.updatedAt) + 1 || 0);
+  }
+
+  function applyWorkflowAliasesFromHistory() {
+    const operations = historyMeta.aliasOps || {};
+    for (const [path, operation] of Object.entries(operations)) {
+      if (operation?.deleted === true || operation?.value == null) delete _workflowUuidAliases[path];
+      else _workflowUuidAliases[path] = operation.value;
+    }
+    for (const [path, value] of Object.entries(historyMeta.workflowAliases || {})) {
+      if (!Object.hasOwn(operations, path)) _workflowUuidAliases[path] = value;
+    }
+    persistWorkflowAliases();
+  }
+
+  applyWorkflowAliasesFromHistory();
 
   function currentTranscriptScopeKey({ embed = false } = {}) {
     return sessionFollowsPanel() ? workflowTabId() : workflowStorageKey({ embed });
@@ -10403,10 +10426,33 @@ function buildPanel() {
     return sessionFollowsPanel() ? "panel:global" : workflowStorageKey({ embed });
   }
 
-  function setActiveThread(scopeKey, threadId) {
-    historyMeta.activeByScope = historyMeta.activeByScope || {};
-    if (threadId) historyMeta.activeByScope[scopeKey] = threadId;
-    else delete historyMeta.activeByScope[scopeKey];
+  function setActiveThread(scopeKey, threadId, updatedAt = nextHistoryRevision()) {
+    historyMeta = updateMetadataEntry(
+      historyMeta,
+      "activeByScope",
+      scopeKey,
+      threadId || null,
+      updatedAt,
+    );
+  }
+
+  function syncWorkflowAliases() {
+    const previous = historyMeta.workflowAliases || {};
+    const paths = new Set([...Object.keys(previous), ...Object.keys(_workflowUuidAliases)]);
+    let revision = nextHistoryRevision();
+    for (const path of paths) {
+      const oldValue = previous[path];
+      const newValue = _workflowUuidAliases[path];
+      if (oldValue === newValue) continue;
+      historyMeta = updateMetadataEntry(
+        historyMeta,
+        "workflowAliases",
+        path,
+        newValue ?? null,
+        revision,
+      );
+      revision += 1;
+    }
   }
 
   function protectedHistoryThreadIds(preferredThreadId = null) {
@@ -10427,10 +10473,12 @@ function buildPanel() {
   }
 
   function persistThreads() {
-    historyMeta.workflowAliases = { ..._workflowUuidAliases };
+    syncWorkflowAliases();
     threads = capHistoryThreads(threads);
     historyStore.persist(threads, historyMeta, {
       protectedThreadIds: protectedHistoryThreadIds(),
+      maxThreads: MAX_THREADS,
+      maxMessages: MAX_THREAD_MSGS,
     });
   }
 
@@ -10441,8 +10489,21 @@ function buildPanel() {
     threads = capHistoryThreads(merged.threads, currentThreadId);
     if (currentThreadId) {
       const refreshed = threads.find((candidate) => candidate.id === currentThreadId);
-      if (refreshed && isThreadInScope(refreshed, currentTranscriptScopeKey())) thread = refreshed;
-      else if (historyMeta.deletedThreads?.[currentThreadId]) newChat();
+      const panelOwned = sessionFollowsPanel();
+      if (refreshed && (panelOwned || isThreadInScope(refreshed, currentTranscriptScopeKey()))) {
+        thread = refreshed;
+      } else {
+        // Never keep a reference to an object no longer present in `threads`.
+        // The next record must create/rebind a valid conversation rather than
+        // append to a detached object that persistThreads() cannot serialize.
+        thread = null;
+        ssSet(CURRENT_THREAD_KEY, null);
+        if (historyMeta.deletedThreads?.[currentThreadId]) {
+          ssSet(SESSION_KEY, null);
+          resetFeed();
+          renderTodo([]);
+        }
+      }
     }
     if (!histPop.hidden) renderHistory();
   });
@@ -10494,7 +10555,12 @@ function buildPanel() {
     const now = Date.now();
     entry = {
       ...entry,
-      id: typeof entry.id === "string" && entry.id ? entry.id : crypto.randomUUID(),
+      id:
+        typeof entry.id === "string" &&
+        entry.id &&
+        !Object.hasOwn(thread.deletedMessages || {}, entry.id)
+          ? entry.id
+          : crypto.randomUUID(),
       createdAt: Number(entry.createdAt) || now,
     };
     thread.msgs.push(entry);
@@ -11222,7 +11288,14 @@ function buildPanel() {
     if (msgs) {
       const i = msgs.findIndex((m) => m.role === "user" && m.mid === mid);
       if (i >= 0) {
-        msgs.splice(i, 1);
+        const [removed] = msgs.splice(i, 1);
+        const now = Math.max(Date.now(), Number(thread.updatedAt) + 1 || 0);
+        if (removed?.id) {
+          thread.deletedMessages = thread.deletedMessages || {};
+          thread.deletedMessages[removed.id] = now;
+        }
+        thread.updatedAt = now;
+        thread.ts = now;
         persistThreads();
       }
     }
@@ -11684,11 +11757,13 @@ function buildPanel() {
       del.appendChild(di);
       del.addEventListener("click", (ev) => {
         ev.stopPropagation();
+        const now = nextHistoryRevision();
         historyMeta.deletedThreads = historyMeta.deletedThreads || {};
-        historyMeta.deletedThreads[t.id] = Date.now();
+        historyMeta.deletedThreads[t.id] = now;
+        historyMeta.updatedAt = now;
         threads = threads.filter((x) => x.id !== t.id);
         for (const [key, value] of Object.entries(historyMeta.activeByScope || {})) {
-          if (value === t.id) delete historyMeta.activeByScope[key];
+          if (value === t.id) setActiveThread(key, null, now);
         }
         persistThreads();
         // Deleting the open chat clears the feed and starts fresh.
@@ -14346,7 +14421,14 @@ function buildPanel() {
   function retractLastUserMessage() {
     const msgs = thread?.msgs;
     if (!msgs || !msgs.length || msgs[msgs.length - 1].role !== "user") return;
-    msgs.pop();
+    const removed = msgs.pop();
+    const now = Math.max(Date.now(), Number(thread.updatedAt) + 1 || 0);
+    if (removed?.id) {
+      thread.deletedMessages = thread.deletedMessages || {};
+      thread.deletedMessages[removed.id] = now;
+    }
+    thread.updatedAt = now;
+    thread.ts = now;
     persistThreads();
     for (const s of streamBubbles.values()) s.el.remove(); // interrupting → drop previews
     streamBubbles.clear();
@@ -15089,10 +15171,7 @@ function buildPanel() {
       const merged = mergeHistorySnapshots({ threads, meta: historyMeta }, loaded);
       historyMeta = merged.meta;
       threads = capHistoryThreads(merged.threads, reloadThreadId);
-      if (historyMeta.workflowAliases && typeof historyMeta.workflowAliases === "object") {
-        _workflowUuidAliases = { ...historyMeta.workflowAliases, ..._workflowUuidAliases };
-        persistWorkflowAliases();
-      }
+      applyWorkflowAliasesFromHistory();
       persistThreads();
     } catch {
       // localStorage shadow remains usable when IndexedDB is unavailable.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10401,6 +10401,11 @@ function buildPanel() {
     threadsKey: THREADS_KEY,
     maxThreads: MAX_THREADS,
     maxMessages: MAX_THREAD_MSGS,
+    onPersistenceError: () => {
+      appendSystem(
+        "Chat history could not be saved. Keep this tab open, free browser storage, then send or edit once to retry.",
+      );
+    },
   });
   const localHistory = historyStore.readLocal();
   let threads = localHistory.threads;
@@ -10494,7 +10499,8 @@ function buildPanel() {
     ssSet(SESSION_KEY, null);
     if (thread) historyStore.reviseThread(thread, { sessionId: null });
     persistThreads();
-    return historyStore.flush();
+    const result = await historyStore.flush();
+    return result === true || result?.ok === true;
   }
 
   const panelAliasMutationSink = (path, value) => {
@@ -13562,7 +13568,7 @@ function buildPanel() {
       // The old provider's session must be durably invalid before any reconnect
       // can observe it. If reconnect fails or the browser closes here, reload
       // still starts fresh instead of restoring a foreign session.
-      await invalidateDurableAgentSession();
+      if (!await invalidateDurableAgentSession()) return;
     }
     // Reflect the picked backend in the composer placeholder immediately; onModels
     // reaffirms it authoritatively from the handshake (fix #3).
@@ -13683,7 +13689,10 @@ function buildPanel() {
       // Start FRESH on reconnect: clear the saved session id so hello sends no
       // resume (resuming would restore the wedged shell). Don't arm the resume
       // nudge. The reconnect spins up a brand-new agent.
-      await invalidateDurableAgentSession();
+      if (!await invalidateDurableAgentSession()) {
+        appendSystem("The old session could not be invalidated durably; reconnect is paused to avoid restoring it.");
+        return;
+      }
       ssSet(SOFT_RELOAD_KEY, null);
       ssSet(MID_TASK_KEY, null);
       appendSystem("Agent restarted with a fresh session — your message history is still here.");

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10480,6 +10480,28 @@ function buildPanel() {
     });
   }
 
+  function detachInvalidCurrentThread({ scopeKey = null, rebind = false } = {}) {
+    thread = null;
+    ssSet(CURRENT_THREAD_KEY, null);
+    ssSet(SESSION_KEY, null);
+    resetFeed();
+    renderTodo([], { persist: false });
+    const replacement = rebind && scopeKey
+      ? selectThreadForScope(threads, historyMeta, scopeKey)
+      : null;
+    if (replacement) {
+      thread = replacement;
+      ssSet(CURRENT_THREAD_KEY, replacement.id);
+      ssSet(SESSION_KEY, replacement.sessionId || null);
+      setActiveThread(currentHistorySelectionKey(), replacement.id);
+      paintThread(replacement);
+    } else if (scopeKey) {
+      setActiveThread(currentHistorySelectionKey(), null);
+    }
+    persistThreads();
+    return replacement;
+  }
+
   const unsubscribeHistorySync = historyStore.subscribe((incoming) => {
     const currentThreadId = thread?.id;
     const merged = mergeHistorySnapshots({ threads, meta: historyMeta }, incoming);
@@ -10491,16 +10513,8 @@ function buildPanel() {
       if (refreshed && (panelOwned || isThreadInScope(refreshed, currentTranscriptScopeKey()))) {
         thread = refreshed;
       } else {
-        // Never keep a reference to an object no longer present in `threads`.
-        // The next record must create/rebind a valid conversation rather than
-        // append to a detached object that persistThreads() cannot serialize.
-        thread = null;
-        ssSet(CURRENT_THREAD_KEY, null);
-        if (historyMeta.deletedThreads?.[currentThreadId]) {
-          ssSet(SESSION_KEY, null);
-          resetFeed();
-          renderTodo([]);
-        }
+        const scopeKey = panelOwned ? null : currentTranscriptScopeKey();
+        detachInvalidCurrentThread({ scopeKey, rebind: !panelOwned });
       }
     }
     if (!histPop.hidden) renderHistory();
@@ -10528,8 +10542,7 @@ function buildPanel() {
     // Settings can hydrate after a greeting was painted. Never append a real
     // workflow-scoped message to a thread carrying another scope.
     if (thread && perWorkflow && !isThreadInScope(thread, scopeKey)) {
-      thread = null;
-      ssSet(CURRENT_THREAD_KEY, null);
+      detachInvalidCurrentThread({ scopeKey, rebind: true });
     }
     if (!thread) {
       const now = Date.now();
@@ -10543,9 +10556,10 @@ function buildPanel() {
         workflowKey: scopeKey,
       };
       historyStore.reviseThread(thread, { workflowKey: scopeKey }, now);
-      // Adopt any session id the orchestrator has already reported for this tab.
+      // A workflow-scoped conversation never adopts a loose tab session. Its
+      // session must arrive through a thread selected for this exact scope.
       const sid = ssGet(SESSION_KEY);
-      if (sid) historyStore.reviseThread(thread, { sessionId: sid }, now);
+      if (sid && !perWorkflow) historyStore.reviseThread(thread, { sessionId: sid }, now);
       threads.push(thread);
       if (threads.length > MAX_THREADS) threads = capHistoryThreads(threads, thread.id);
       ssSet(CURRENT_THREAD_KEY, thread.id);
@@ -11556,6 +11570,7 @@ function buildPanel() {
 
   function loadThread(t) {
     if (!sessionFollowsPanel() && !isThreadInScope(t, workflowStorageKey())) {
+      detachInvalidCurrentThread({ scopeKey: workflowStorageKey(), rebind: true });
       appendSystem("Blocked a chat from another workflow. Open its owning workflow before resuming it.");
       return false;
     }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -8229,6 +8229,23 @@ const PANEL_CSS = `
 .cmcp-hist-row:hover .cmcp-hist-del { opacity: 1; }
 .cmcp-hist-del:hover { background: var(--p-surface-700, #3f3f46); color: var(--p-red-400, #f87171); }
 .cmcp-hist-del .pi { font-size: 0.75rem; }
+.cmcp-hist-footer {
+  margin-top: 0.25rem; padding: 0.5rem 0.375rem 0.125rem;
+  border-top: 1px solid var(--p-content-border-color, #3f3f46);
+}
+.cmcp-hist-note {
+  margin: 0 0 0.375rem; color: var(--p-text-muted-color, #a1a1aa);
+  font-size: 0.625rem; line-height: 1.35;
+}
+.cmcp-hist-clear {
+  display: flex; align-items: center; justify-content: center; gap: 0.375rem;
+  width: 100%; padding: 0.3125rem 0.5rem; border-radius: var(--p-border-radius-sm, 4px);
+  border: 1px solid color-mix(in srgb, var(--p-red-400, #f87171) 45%, transparent);
+  background: transparent; color: var(--p-red-400, #f87171); cursor: pointer;
+  font: inherit; font-size: 0.6875rem;
+}
+.cmcp-hist-clear:hover:not(:disabled) { background: color-mix(in srgb, var(--p-red-400, #f87171) 12%, transparent); }
+.cmcp-hist-clear:disabled { opacity: 0.4; cursor: not-allowed; }
 
 /* Model/effort picker popover (anchored above the composer). */
 .cmcp-pop-section { padding: 0.25rem 0.5rem 0.125rem; font-size: 0.625rem; font-weight: 600;
@@ -10530,8 +10547,12 @@ function buildPanel() {
       ssSet(SESSION_KEY, replacement.sessionId || null);
       setActiveThread(currentHistorySelectionKey(), replacement.id);
       paintThread(replacement);
-    } else if (scopeKey) {
-      setActiveThread(currentHistorySelectionKey(), null);
+    } else {
+      if (scopeKey) setActiveThread(currentHistorySelectionKey(), null);
+      // A remote delete/reset removed the conversation this tab's live agent
+      // belonged to. Clear backend memory as well as the visible transcript so
+      // the next message cannot continue a history the user just deleted.
+      client?.sendFrame?.({ type: "new_session" });
     }
     persistThreads();
     return replacement;
@@ -11768,7 +11789,6 @@ function buildPanel() {
       none.style.padding = "0.375rem";
       none.textContent = "No past chats yet.";
       histPop.appendChild(none);
-      return;
     }
     for (const t of list) {
       const row = document.createElement("div");
@@ -11832,6 +11852,61 @@ function buildPanel() {
       row.append(item, del);
       histPop.appendChild(row);
     }
+
+    const footer = document.createElement("div");
+    footer.className = "cmcp-hist-footer";
+    const note = document.createElement("p");
+    note.className = "cmcp-hist-note";
+    note.textContent = "Transcripts are stored in this browser using IndexedDB.";
+    const clear = document.createElement("button");
+    clear.type = "button";
+    clear.className = "cmcp-hist-clear";
+    clear.disabled = !threads.length;
+    clear.title = "Permanently clear chat history for every workflow in this browser";
+    const clearIcon = document.createElement("i");
+    clearIcon.className = "pi pi-trash";
+    const clearLabel = document.createElement("span");
+    clearLabel.textContent = "Clear all history";
+    clear.append(clearIcon, clearLabel);
+    clear.addEventListener("click", async () => {
+      if (!threads.length) return;
+      const confirmed = globalThis.confirm?.(
+        "Clear all Agent Panel chat history from this browser?\n\n" +
+        "This affects every workflow and open ComfyUI tab. It cannot be undone. " +
+        "Your workflows and their stable identities will not be deleted.",
+      );
+      if (!confirmed) return;
+      clear.disabled = true;
+      clearLabel.textContent = "Clearing…";
+      const result = await historyStore.clearAll(threads, historyMeta);
+      if (!result?.ok || !result.snapshot) {
+        clear.disabled = false;
+        clearLabel.textContent = "Clear all history";
+        appendSystem(
+          "Chat history could not be cleared from IndexedDB. Close other ComfyUI tabs, then try again.",
+        );
+        return;
+      }
+
+      threads = result.snapshot.threads;
+      historyMeta = result.snapshot.meta;
+      applyWorkflowAliasesFromHistory();
+      thread = null;
+      turnAnchors = [];
+      ssSet(CURRENT_THREAD_KEY, null);
+      ssSet(SESSION_KEY, null);
+      ssSet(CTX_KEY, null);
+      if (typeof resetAttachments === "function") resetAttachments();
+      resetFeed();
+      renderTodo([], { persist: false });
+      setContextPct(0);
+      ctxLabel.textContent = "—";
+      client?.sendFrame?.({ type: "new_session" });
+      histPop.hidden = true;
+      appendSystem("Chat history was cleared from this browser.");
+    });
+    footer.append(note, clear);
+    histPop.appendChild(footer);
   }
 
   newChatBtn.addEventListener("click", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -69,6 +69,7 @@ import { computeLayout } from "./lib/layout-engine.js";
 import {
   ChatHistoryStore,
   mergeHistorySnapshots,
+  retainBoundedThreads,
   selectRestoreThread,
   selectThreadForScope,
 } from "./lib/chat-history-store.js";
@@ -10408,16 +10409,36 @@ function buildPanel() {
     else delete historyMeta.activeByScope[scopeKey];
   }
 
+  function protectedHistoryThreadIds(preferredThreadId = null) {
+    return [
+      preferredThreadId,
+      thread?.id,
+      ssGet(CURRENT_THREAD_KEY),
+      ...Object.values(historyMeta.activeByScope || {}),
+    ].filter(Boolean);
+  }
+
+  function capHistoryThreads(candidates, preferredThreadId = null) {
+    return retainBoundedThreads(
+      candidates,
+      MAX_THREADS,
+      protectedHistoryThreadIds(preferredThreadId),
+    );
+  }
+
   function persistThreads() {
     historyMeta.workflowAliases = { ..._workflowUuidAliases };
-    historyStore.persist(threads.slice(-MAX_THREADS), historyMeta);
+    threads = capHistoryThreads(threads);
+    historyStore.persist(threads, historyMeta, {
+      protectedThreadIds: protectedHistoryThreadIds(),
+    });
   }
 
   const unsubscribeHistorySync = historyStore.subscribe((incoming) => {
     const currentThreadId = thread?.id;
     const merged = mergeHistorySnapshots({ threads, meta: historyMeta }, incoming);
-    threads = merged.threads.slice(-MAX_THREADS);
     historyMeta = merged.meta;
+    threads = capHistoryThreads(merged.threads, currentThreadId);
     if (currentThreadId) {
       const refreshed = threads.find((candidate) => candidate.id === currentThreadId);
       if (refreshed && isThreadInScope(refreshed, currentTranscriptScopeKey())) thread = refreshed;
@@ -10466,7 +10487,7 @@ function buildPanel() {
       const sid = ssGet(SESSION_KEY);
       if (sid) thread.sessionId = sid;
       threads.push(thread);
-      if (threads.length > MAX_THREADS) threads = threads.slice(-MAX_THREADS);
+      if (threads.length > MAX_THREADS) threads = capHistoryThreads(threads, thread.id);
       ssSet(CURRENT_THREAD_KEY, thread.id);
       setActiveThread(currentHistorySelectionKey(), thread.id);
     }
@@ -15064,10 +15085,10 @@ function buildPanel() {
   // legacy records before making the final, settings-aware binding.
   const historyRestoreReady = (async () => {
     try {
-      const loaded = await historyStore.load();
+      const loaded = await historyStore.load({ protectedThreadIds: [reloadThreadId].filter(Boolean) });
       const merged = mergeHistorySnapshots({ threads, meta: historyMeta }, loaded);
-      threads = merged.threads.slice(-MAX_THREADS);
       historyMeta = merged.meta;
+      threads = capHistoryThreads(merged.threads, reloadThreadId);
       if (historyMeta.workflowAliases && typeof historyMeta.workflowAliases === "object") {
         _workflowUuidAliases = { ...historyMeta.workflowAliases, ..._workflowUuidAliases };
         persistWorkflowAliases();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9439,13 +9439,13 @@ function buildPanel() {
     }
     scrollLog();
   }
-  function renderTodo(items) {
+  function renderTodo(items, { persist = true } = {}) {
     todoItems = Array.isArray(items) ? items : [];
     renderTray();
     // Persist the plan ON the active thread so it survives a reload / panel
     // remount (the tray is otherwise rebuilt empty) and follows thread switches.
-    if (thread) {
-      thread.todos = todoItems;
+    if (thread && persist) {
+      historyStore.reviseThread(thread, { todos: todoItems });
       persistThreads();
     }
   }
@@ -10401,7 +10401,7 @@ function buildPanel() {
   let thread = null; // created lazily on first recorded message
 
   function nextHistoryRevision() {
-    return Math.max(Date.now(), Number(historyMeta?.updatedAt) + 1 || 0);
+    return historyStore.nextRevision(Math.max(Date.now(), Number(historyMeta?.updatedAt) + 1 || 0));
   }
 
   function applyWorkflowAliasesFromHistory() {
@@ -10439,7 +10439,6 @@ function buildPanel() {
   function syncWorkflowAliases() {
     const previous = historyMeta.workflowAliases || {};
     const paths = new Set([...Object.keys(previous), ...Object.keys(_workflowUuidAliases)]);
-    let revision = nextHistoryRevision();
     for (const path of paths) {
       const oldValue = previous[path];
       const newValue = _workflowUuidAliases[path];
@@ -10449,9 +10448,8 @@ function buildPanel() {
         "workflowAliases",
         path,
         newValue ?? null,
-        revision,
+        nextHistoryRevision(),
       );
-      revision += 1;
     }
   }
 
@@ -10517,7 +10515,7 @@ function buildPanel() {
       const legacyKey = path ? `wf:${path}` : null;
       const legacy = legacyKey ? threads.filter((candidate) => candidate.workflowKey === legacyKey) : [];
       if (legacy.length) {
-        for (const candidate of legacy) candidate.workflowKey = wfid;
+        for (const candidate of legacy) historyStore.reviseThread(candidate, { workflowKey: wfid });
         persistThreads();
       }
     }
@@ -10544,9 +10542,10 @@ function buildPanel() {
         msgs: [],
         workflowKey: scopeKey,
       };
+      historyStore.reviseThread(thread, { workflowKey: scopeKey }, now);
       // Adopt any session id the orchestrator has already reported for this tab.
       const sid = ssGet(SESSION_KEY);
-      if (sid) thread.sessionId = sid;
+      if (sid) historyStore.reviseThread(thread, { sessionId: sid }, now);
       threads.push(thread);
       if (threads.length > MAX_THREADS) threads = capHistoryThreads(threads, thread.id);
       ssSet(CURRENT_THREAD_KEY, thread.id);
@@ -10563,6 +10562,7 @@ function buildPanel() {
           : crypto.randomUUID(),
       createdAt: Number(entry.createdAt) || now,
     };
+    historyStore.touchMessage(entry, now);
     thread.msgs.push(entry);
     if (thread.msgs.length > MAX_THREAD_MSGS) {
       thread.msgs.splice(0, thread.msgs.length - MAX_THREAD_MSGS);
@@ -10577,7 +10577,7 @@ function buildPanel() {
   function bindSession(sessionId) {
     ssSet(SESSION_KEY, sessionId);
     if (thread) {
-      thread.sessionId = sessionId || undefined;
+      historyStore.reviseThread(thread, { sessionId: sessionId || null });
       persistThreads();
     }
   }
@@ -10827,6 +10827,7 @@ function buildPanel() {
       onAction(text) {
         rec.resolved = true;
         rec.choice = text;
+        historyStore.touchMessage(rec);
         persistThreads();
         liveA2uiCards.delete(handle.cardId);
         setChatSurfaceForCards();
@@ -10834,6 +10835,7 @@ function buildPanel() {
       },
       onDismiss() {
         rec.resolved = true; // dismissed: inert, no choice, agent NOT notified
+        historyStore.touchMessage(rec);
         persistThreads();
         liveA2uiCards.delete(handle.cardId);
         setChatSurfaceForCards();
@@ -11549,7 +11551,7 @@ function buildPanel() {
         else paintCard(m);
       }
     }
-    renderTodo(t.todos || []);
+    renderTodo(t.todos || [], { persist: false });
   }
 
   function loadThread(t) {
@@ -11607,9 +11609,7 @@ function buildPanel() {
       // tmp→wf adopt bookkeeping (a save gave the unsaved workflow a real id).
       if (wfid.startsWith("wf:") && wf && (wf.key || wf.id)) _tempWorkflowIds.delete(wf.key || wf.id);
       if (thread) {
-        thread.workflowKey = wfid; // thread rides along for archive provenance
-        thread.updatedAt = Date.now();
-        thread.ts = thread.updatedAt;
+        historyStore.reviseThread(thread, { workflowKey: wfid }); // archive provenance
         setActiveThread("panel:global", thread.id);
         persistThreads();
       }
@@ -12162,6 +12162,7 @@ function buildPanel() {
       if (!v.ok) throw new Error(`invalid a2ui spec: ${v.errors.slice(0, 5).join("; ")}`);
       if (!entry.handle.update(v.spec)) throw new Error(`card "${msg.card_id}" is resolved`);
       entry.rec.spec = v.spec;
+      historyStore.touchMessage(entry.rec);
       persistThreads();
       setChatSurfaceForCards();
       return { ok: true };
@@ -13502,7 +13503,7 @@ function buildPanel() {
     const switching = connectedBackend !== null && connectedBackend !== id;
     if (switching) {
       ssSet(SESSION_KEY, null);
-      if (thread) thread.sessionId = undefined;
+      if (thread) historyStore.reviseThread(thread, { sessionId: null });
       // Replay the visible transcript to the NEW provider as one-shot context so
       // its fresh session has the conversation (session/thinking aren't portable
       // across providers). Consumed by the next user message, then auto-cleared.
@@ -15202,7 +15203,9 @@ function buildPanel() {
     const boundSessionId = durableActive.id === reloadThreadId
       ? reloadSessionId
       : (durableActive.sessionId || null);
-    if (durableActive.id === reloadThreadId) durableActive.sessionId = boundSessionId;
+    if (durableActive.id === reloadThreadId) {
+      historyStore.reviseThread(durableActive, { sessionId: boundSessionId });
+    }
     ssSet(CURRENT_THREAD_KEY, durableActive.id);
     ssSet(SESSION_KEY, boundSessionId);
     setActiveThread(scopeKey, durableActive.id);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -67,6 +67,12 @@ import DOMPurify from "./vendor/purify.es.js";
 import qrcodegen from "./vendor/qrcode.esm.js";
 import { computeLayout } from "./lib/layout-engine.js";
 import {
+  ChatHistoryStore,
+  mergeHistorySnapshots,
+  selectPanelThread,
+  selectThreadForScope,
+} from "./lib/chat-history-store.js";
+import {
   isThreadInScope,
   normalizedWorkflowPath,
   shouldForkEmbeddedWorkflowUuid,
@@ -10370,31 +10376,48 @@ function buildPanel() {
 
   // ---- feed renderers + thread persistence ----
   // paint* draws DOM only; append* paints AND records into the current
-  // thread (localStorage), so history can replay a conversation verbatim.
+  // thread. IndexedDB is canonical; localStorage remains a small synchronous
+  // startup shadow and migration source for pre-v2 panel builds.
   const THREADS_KEY = "comfyui-mcp.panel.threads";
-  const MAX_THREADS = 20;
-  const MAX_THREAD_MSGS = 200;
-  let threads = (() => {
-    try {
-      const t = JSON.parse(window.localStorage.getItem(THREADS_KEY) ?? "[]");
-      return Array.isArray(t) ? t : [];
-    } catch {
-      return [];
-    }
-  })();
+  const MAX_THREADS = 500;
+  const MAX_THREAD_MSGS = 5000;
+  const historyStore = new ChatHistoryStore({ threadsKey: THREADS_KEY });
+  const localHistory = historyStore.readLocal();
+  let threads = localHistory.threads;
+  let historyMeta = localHistory.meta;
   let thread = null; // created lazily on first recorded message
 
   function currentTranscriptScopeKey({ embed = false } = {}) {
     return sessionFollowsPanel() ? workflowTabId() : workflowStorageKey({ embed });
   }
 
-  function persistThreads() {
-    try {
-      window.localStorage.setItem(THREADS_KEY, JSON.stringify(threads.slice(-MAX_THREADS)));
-    } catch {
-      // localStorage unavailable — history is session-only.
-    }
+  function currentHistorySelectionKey({ embed = false } = {}) {
+    return sessionFollowsPanel() ? "panel:global" : workflowStorageKey({ embed });
   }
+
+  function setActiveThread(scopeKey, threadId) {
+    historyMeta.activeByScope = historyMeta.activeByScope || {};
+    if (threadId) historyMeta.activeByScope[scopeKey] = threadId;
+    else delete historyMeta.activeByScope[scopeKey];
+  }
+
+  function persistThreads() {
+    historyMeta.workflowAliases = { ..._workflowUuidAliases };
+    historyStore.persist(threads.slice(-MAX_THREADS), historyMeta);
+  }
+
+  const unsubscribeHistorySync = historyStore.subscribe((incoming) => {
+    const currentThreadId = thread?.id;
+    const merged = mergeHistorySnapshots({ threads, meta: historyMeta }, incoming);
+    threads = merged.threads.slice(-MAX_THREADS);
+    historyMeta = merged.meta;
+    if (currentThreadId) {
+      const refreshed = threads.find((candidate) => candidate.id === currentThreadId);
+      if (refreshed && isThreadInScope(refreshed, currentTranscriptScopeKey())) thread = refreshed;
+      else if (historyMeta.deletedThreads?.[currentThreadId]) newChat();
+    }
+    if (!histPop.hidden) renderHistory();
+  });
 
   // Find the (single) thread bound to an exact transcript scope. Old path-keyed
   // records are adopted only when their path exactly matches the open workflow;
@@ -10409,10 +10432,7 @@ function buildPanel() {
         persistThreads();
       }
     }
-    for (let i = threads.length - 1; i >= 0; i--) {
-      if (threads[i].workflowKey === wfid) return threads[i];
-    }
-    return null;
+    return selectThreadForScope(threads, historyMeta, wfid);
   }
 
   function record(entry) {
@@ -10425,20 +10445,38 @@ function buildPanel() {
       ssSet(CURRENT_THREAD_KEY, null);
     }
     if (!thread) {
-      thread = { id: crypto.randomUUID(), ts: Date.now(), msgs: [], workflowKey: scopeKey };
+      const now = Date.now();
+      thread = {
+        id: crypto.randomUUID(),
+        schemaVersion: 2,
+        createdAt: now,
+        updatedAt: now,
+        ts: now,
+        msgs: [],
+        workflowKey: scopeKey,
+      };
       // Adopt any session id the orchestrator has already reported for this tab.
       const sid = ssGet(SESSION_KEY);
       if (sid) thread.sessionId = sid;
       threads.push(thread);
       if (threads.length > MAX_THREADS) threads = threads.slice(-MAX_THREADS);
       ssSet(CURRENT_THREAD_KEY, thread.id);
+      setActiveThread(currentHistorySelectionKey(), thread.id);
     }
+    const now = Date.now();
+    entry = {
+      ...entry,
+      id: typeof entry.id === "string" && entry.id ? entry.id : crypto.randomUUID(),
+      createdAt: Number(entry.createdAt) || now,
+    };
     thread.msgs.push(entry);
     if (thread.msgs.length > MAX_THREAD_MSGS) {
       thread.msgs.splice(0, thread.msgs.length - MAX_THREAD_MSGS);
     }
-    thread.ts = Date.now();
+    thread.updatedAt = now;
+    thread.ts = now;
     persistThreads();
+    return entry;
   }
 
   /** Bind the agent's current session id to the open thread (for reload/resume). */
@@ -11382,6 +11420,7 @@ function buildPanel() {
   }
 
   function newChat() {
+    setActiveThread(currentHistorySelectionKey(), null);
     thread = null;
     turnAnchors = []; // fresh conversation → no rewind anchors
     ssSet(CURRENT_THREAD_KEY, null);
@@ -11391,6 +11430,7 @@ function buildPanel() {
     resetFeed();
     renderTodo([]); // fresh chat → empty plan tray
     setContextPct(0);
+    persistThreads();
     ctxLabel.textContent = "—";
     // Tell the orchestrator to forget this tab's session so the NEXT message
     // starts a genuinely fresh agent (no memory of the prior conversation).
@@ -11404,6 +11444,8 @@ function buildPanel() {
     }
     thread = t;
     ssSet(CURRENT_THREAD_KEY, t.id);
+    setActiveThread(currentHistorySelectionKey(), t.id);
+    persistThreads();
     resetFeed();
     for (const m of t.msgs) {
       if (m.role === "user") paintUser(m.text, { attachments: m.attachments });
@@ -11461,7 +11503,9 @@ function buildPanel() {
       if (wfid.startsWith("wf:") && wf && (wf.key || wf.id)) _tempWorkflowIds.delete(wf.key || wf.id);
       if (thread) {
         thread.workflowKey = wfid; // thread rides along for archive provenance
-        thread.ts = Date.now();
+        thread.updatedAt = Date.now();
+        thread.ts = thread.updatedAt;
+        setActiveThread("panel:global", thread.id);
         persistThreads();
       }
       currentWorkflowId = wfid;
@@ -11608,7 +11652,12 @@ function buildPanel() {
       del.appendChild(di);
       del.addEventListener("click", (ev) => {
         ev.stopPropagation();
+        historyMeta.deletedThreads = historyMeta.deletedThreads || {};
+        historyMeta.deletedThreads[t.id] = Date.now();
         threads = threads.filter((x) => x.id !== t.id);
+        for (const [key, value] of Object.entries(historyMeta.activeByScope || {})) {
+          if (value === t.id) delete historyMeta.activeByScope[key];
+        }
         persistThreads();
         // Deleting the open chat clears the feed and starts fresh.
         if (thread && thread.id === t.id) newChat();
@@ -14962,6 +15011,7 @@ function buildPanel() {
   // gets stranded as an empty cursor bubble; when it returns, resume the typewriters.
   function onVisibilityChange() {
     if (document.hidden) {
+      void historyStore.flush();
       for (const s of [...streamBubbles.values()]) {
         if (s.commitText != null) finalizeStream(s);
       }
@@ -14973,6 +15023,8 @@ function buildPanel() {
     }
   }
   document.addEventListener("visibilitychange", onVisibilityChange);
+  const onPageHide = () => { void historyStore.flush(); };
+  window.addEventListener("pagehide", onPageHide);
 
   // Reload restore: repaint the chat this tab was last showing. The agent's
   // memory continues automatically — either the orchestrator's agent for this
@@ -14983,12 +15035,16 @@ function buildPanel() {
       const cur = ssGet(CURRENT_THREAD_KEY);
       const pointed = cur ? threads.find((x) => x.id === cur) : null;
       if (sessionFollowsPanel()) {
-        // Main/default behavior: restore the pointed chat exactly as stored.
-        // Settings may not be hydrated yet, so this path must never rewrite keys.
-        if (!pointed || !pointed.msgs?.length) return;
-        thread = pointed;
+        // Recover from a lost tab pointer using durable metadata/newest fallback.
+        // Settings may not be hydrated yet, so never rewrite the thread's key.
+        const panelThread = pointed || selectPanelThread(threads, historyMeta);
+        if (!panelThread || !panelThread.msgs?.length) return;
+        thread = panelThread;
+        ssSet(CURRENT_THREAD_KEY, panelThread.id);
+        ssSet(SESSION_KEY, panelThread.sessionId || null);
+        setActiveThread("panel:global", panelThread.id);
         resetFeed();
-        for (const m of pointed.msgs) {
+        for (const m of panelThread.msgs) {
           if (m.role === "user") paintUser(m.text, { attachments: m.attachments });
           else if (m.role === "agent") paintAgent(m.text);
           else if (m.role === "card") {
@@ -14996,7 +15052,7 @@ function buildPanel() {
             else paintCard(m);
           }
         }
-        renderTodo(pointed.todos || []);
+        renderTodo(panelThread.todos || []);
         return;
       }
       const scopeKey = workflowStorageKey();
@@ -15006,6 +15062,7 @@ function buildPanel() {
       thread = t;
       ssSet(CURRENT_THREAD_KEY, t.id);
       ssSet(SESSION_KEY, t.sessionId || null);
+      setActiveThread(t.workflowKey, t.id);
       resetFeed();
       for (const m of t.msgs) {
         if (m.role === "user") paintUser(m.text, { attachments: m.attachments });
@@ -15020,6 +15077,25 @@ function buildPanel() {
       // Corrupt/absent state — start clean.
     }
   })();
+
+  // Paint the localStorage shadow immediately, then hydrate the canonical
+  // IndexedDB snapshot in the background and promote any legacy records.
+  void historyStore.load().then((loaded) => {
+    const merged = mergeHistorySnapshots({ threads, meta: historyMeta }, loaded);
+    threads = merged.threads.slice(-MAX_THREADS);
+    historyMeta = merged.meta;
+    if (historyMeta.workflowAliases && typeof historyMeta.workflowAliases === "object") {
+      _workflowUuidAliases = { ...historyMeta.workflowAliases, ..._workflowUuidAliases };
+      persistWorkflowAliases();
+    }
+    persistThreads();
+    const durableActive = sessionFollowsPanel()
+      ? selectPanelThread(threads, historyMeta)
+      : threadForWorkflow(currentTranscriptScopeKey());
+    if (durableActive && durableActive.id !== thread?.id) loadThread(durableActive);
+  }).catch(() => {
+    // localStorage shadow already painted; persistence degrades gracefully.
+  });
 
   // ---- Settings dialog → live panel hooks ----
   // Registered now that the runtime + connect functions exist. Each applier is
@@ -15175,6 +15251,8 @@ function buildPanel() {
       clearTimeout(revealResetTimer);
       document.removeEventListener("keydown", onInterruptKeydown, true);
       document.removeEventListener("visibilitychange", onVisibilityChange);
+      window.removeEventListener("pagehide", onPageHide);
+      unsubscribeHistorySync();
       try {
         api.removeEventListener("executed", onExecuted);
         api.removeEventListener("execution_success", onExecutionSuccess);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -69,7 +69,7 @@ import { computeLayout } from "./lib/layout-engine.js";
 import {
   ChatHistoryStore,
   mergeHistorySnapshots,
-  selectPanelThread,
+  selectRestoreThread,
   selectThreadForScope,
 } from "./lib/chat-history-store.js";
 import {
@@ -1218,8 +1218,9 @@ let suppressSettingOnChange = false;
 // side effects: a persisted Auto-connect/Bridge-URL would call connectAgent() and
 // race the sticky-autoconnect path, and with the bridge's one-socket-per-tab policy
 // each new socket closes the other → a ~1s reconnect storm. So onChange appliers
-// stay disarmed until the panel has mounted AND made its single initial connect
-// decision; only genuine post-load user edits in the Settings dialog take effect.
+// stay disarmed until the panel has mounted and the startup volley has settled.
+// Reload restore and the single initial connect decision wait on that boundary;
+// only genuine post-load user edits in the Settings dialog take effect.
 let settingsArmed = false;
 
 // Per-backend FETCHED model catalog PUBLISHED for the Settings dialog's
@@ -9734,13 +9735,17 @@ function buildPanel() {
     }
   }
   seedFromSettings();
-  // Arm the setting onChange appliers only AFTER mount + the startup onChange volley
-  // and the initial (sticky) connect decision have settled — so ComfyUI applying a
-  // persisted Auto-connect/Bridge-URL at load can't drive a connect that storms.
-  // Genuine user edits in the Settings dialog happen long after this window.
-  setTimeout(() => {
-    settingsArmed = true;
-  }, 2500);
+  // Resolve only after ComfyUI's startup onChange volley has settled. Reload
+  // restore and the initial connection both wait on this same boundary, so neither
+  // can bind a thread/session using the default value before settings hydrate.
+  const settingsHydrated = settingsArmed
+    ? Promise.resolve()
+    : new Promise((resolve) => {
+      setTimeout(() => {
+        settingsArmed = true;
+        resolve();
+      }, 2500);
+    });
 
   refreshModelChip();
 
@@ -10379,6 +10384,8 @@ function buildPanel() {
   // thread. IndexedDB is canonical; localStorage remains a small synchronous
   // startup shadow and migration source for pre-v2 panel builds.
   const THREADS_KEY = "comfyui-mcp.panel.threads";
+  // Intentional canonical durable caps. The synchronous localStorage startup
+  // shadow stays much smaller (20 threads / 200 messages) in ChatHistoryStore.
   const MAX_THREADS = 500;
   const MAX_THREAD_MSGS = 5000;
   const historyStore = new ChatHistoryStore({ threadsKey: THREADS_KEY });
@@ -11437,15 +11444,8 @@ function buildPanel() {
     client?.sendFrame?.({ type: "new_session" });
   }
 
-  function loadThread(t) {
-    if (!sessionFollowsPanel() && !isThreadInScope(t, workflowStorageKey())) {
-      appendSystem("Blocked a chat from another workflow. Open its owning workflow before resuming it.");
-      return false;
-    }
+  function paintThread(t) {
     thread = t;
-    ssSet(CURRENT_THREAD_KEY, t.id);
-    setActiveThread(currentHistorySelectionKey(), t.id);
-    persistThreads();
     resetFeed();
     for (const m of t.msgs) {
       if (m.role === "user") paintUser(m.text, { attachments: m.attachments });
@@ -11455,7 +11455,18 @@ function buildPanel() {
         else paintCard(m);
       }
     }
-    renderTodo(t.todos || []); // restore this thread's plan into the tray
+    renderTodo(t.todos || []);
+  }
+
+  function loadThread(t) {
+    if (!sessionFollowsPanel() && !isThreadInScope(t, workflowStorageKey())) {
+      appendSystem("Blocked a chat from another workflow. Open its owning workflow before resuming it.");
+      return false;
+    }
+    ssSet(CURRENT_THREAD_KEY, t.id);
+    setActiveThread(currentHistorySelectionKey(), t.id);
+    persistThreads();
+    paintThread(t);
     // Resume this conversation's agent session (or start fresh if it has none),
     // so typing continues THIS chat rather than whatever was last active.
     ssSet(SESSION_KEY, t.sessionId || null);
@@ -13208,6 +13219,9 @@ function buildPanel() {
   }
 
   async function connectAgent(opts = {}) {
+    // hello reads SESSION_KEY, so wait until reload reconciliation has made the
+    // single settings-aware thread/session binding for this browser tab.
+    await historyRestoreReady;
     // A chip pick (opts.fromChip) is an EXPLICIT backend choice — it must always
     // (re)connect to that backend's port, so it bypasses the in-flight guard (which
     // a sticky-reconnect could otherwise hold) and the manual-URL override below.
@@ -15026,76 +15040,75 @@ function buildPanel() {
   const onPageHide = () => { void historyStore.flush(); };
   window.addEventListener("pagehide", onPageHide);
 
-  // Reload restore: repaint the chat this tab was last showing. The agent's
-  // memory continues automatically — either the orchestrator's agent for this
-  // (stable) tab id is still alive, or hello's `resume` (the session id kept in
-  // sessionStorage) rehydrates it from disk after an orchestrator restart.
+  // Reload restore preserves this tab's exact conversation/session pair. When
+  // those tab-scoped pointers were lost in a full browser restart, the durable
+  // active pointer supplies the fallback after settings and IndexedDB hydrate.
+  const reloadThreadId = ssGet(CURRENT_THREAD_KEY);
+  const reloadSessionId = ssGet(SESSION_KEY);
+
+  // This synchronous pass is paint-only. Settings may not be hydrated, so it
+  // must not infer a scope, rewrite session keys, persist metadata, or send a
+  // session frame. With no tab pointer, canonical IndexedDB recovery paints later.
   (function restoreLastThread() {
     try {
-      const cur = ssGet(CURRENT_THREAD_KEY);
-      const pointed = cur ? threads.find((x) => x.id === cur) : null;
-      if (sessionFollowsPanel()) {
-        // Recover from a lost tab pointer using durable metadata/newest fallback.
-        // Settings may not be hydrated yet, so never rewrite the thread's key.
-        const panelThread = pointed || selectPanelThread(threads, historyMeta);
-        if (!panelThread || !panelThread.msgs?.length) return;
-        thread = panelThread;
-        ssSet(CURRENT_THREAD_KEY, panelThread.id);
-        ssSet(SESSION_KEY, panelThread.sessionId || null);
-        setActiveThread("panel:global", panelThread.id);
-        resetFeed();
-        for (const m of panelThread.msgs) {
-          if (m.role === "user") paintUser(m.text, { attachments: m.attachments });
-          else if (m.role === "agent") paintAgent(m.text);
-          else if (m.role === "card") {
-            if (m.kind === "a2ui") paintA2UIRecord(m);
-            else paintCard(m);
-          }
-        }
-        renderTodo(panelThread.todos || []);
-        return;
-      }
-      const scopeKey = workflowStorageKey();
-      const scopedPointed = pointed && isThreadInScope(pointed, scopeKey) ? pointed : null;
-      const t = scopedPointed || threadForWorkflow(scopeKey);
-      if (!t || !t.msgs?.length) return;
-      thread = t;
-      ssSet(CURRENT_THREAD_KEY, t.id);
-      ssSet(SESSION_KEY, t.sessionId || null);
-      setActiveThread(t.workflowKey, t.id);
-      resetFeed();
-      for (const m of t.msgs) {
-        if (m.role === "user") paintUser(m.text, { attachments: m.attachments });
-        else if (m.role === "agent") paintAgent(m.text);
-        else if (m.role === "card") {
-          if (m.kind === "a2ui") paintA2UIRecord(m);
-          else paintCard(m);
-        }
-      }
-      renderTodo(t.todos || []); // restore this thread's plan into the tray
+      const pointed = reloadThreadId
+        ? threads.find((candidate) => candidate.id === reloadThreadId)
+        : null;
+      if (pointed?.msgs?.length) paintThread(pointed);
     } catch {
       // Corrupt/absent state — start clean.
     }
   })();
 
-  // Paint the localStorage shadow immediately, then hydrate the canonical
-  // IndexedDB snapshot in the background and promote any legacy records.
-  void historyStore.load().then((loaded) => {
-    const merged = mergeHistorySnapshots({ threads, meta: historyMeta }, loaded);
-    threads = merged.threads.slice(-MAX_THREADS);
-    historyMeta = merged.meta;
-    if (historyMeta.workflowAliases && typeof historyMeta.workflowAliases === "object") {
-      _workflowUuidAliases = { ...historyMeta.workflowAliases, ..._workflowUuidAliases };
-      persistWorkflowAliases();
+  // Merge the canonical IndexedDB snapshot in the background and promote any
+  // legacy records before making the final, settings-aware binding.
+  const historyRestoreReady = (async () => {
+    try {
+      const loaded = await historyStore.load();
+      const merged = mergeHistorySnapshots({ threads, meta: historyMeta }, loaded);
+      threads = merged.threads.slice(-MAX_THREADS);
+      historyMeta = merged.meta;
+      if (historyMeta.workflowAliases && typeof historyMeta.workflowAliases === "object") {
+        _workflowUuidAliases = { ...historyMeta.workflowAliases, ..._workflowUuidAliases };
+        persistWorkflowAliases();
+      }
+      persistThreads();
+    } catch {
+      // localStorage shadow remains usable when IndexedDB is unavailable.
     }
+
+    await settingsHydrated;
+    const panelOwned = sessionFollowsPanel();
+    const scopeKey = panelOwned ? "panel:global" : workflowStorageKey();
+    const durableActive = selectRestoreThread(threads, historyMeta, {
+      panelOwned,
+      scopeKey,
+      preferredThreadId: reloadThreadId,
+    });
+
+    if (!durableActive) {
+      thread = null;
+      ssSet(CURRENT_THREAD_KEY, null);
+      ssSet(SESSION_KEY, null);
+      setActiveThread(scopeKey, null);
+      resetFeed();
+      renderTodo([]);
+      persistThreads();
+      return;
+    }
+
+    // For the exact conversation already owned by this tab, sessionStorage is
+    // authoritative even when empty. The stored id is only a full-restart fallback.
+    const boundSessionId = durableActive.id === reloadThreadId
+      ? reloadSessionId
+      : (durableActive.sessionId || null);
+    if (durableActive.id === reloadThreadId) durableActive.sessionId = boundSessionId;
+    ssSet(CURRENT_THREAD_KEY, durableActive.id);
+    ssSet(SESSION_KEY, boundSessionId);
+    setActiveThread(scopeKey, durableActive.id);
+    paintThread(durableActive);
     persistThreads();
-    const durableActive = sessionFollowsPanel()
-      ? selectPanelThread(threads, historyMeta)
-      : threadForWorkflow(currentTranscriptScopeKey());
-    if (durableActive && durableActive.id !== thread?.id) loadThread(durableActive);
-  }).catch(() => {
-    // localStorage shadow already painted; persistence degrades gracefully.
-  });
+  })();
 
   // ---- Settings dialog → live panel hooks ----
   // Registered now that the runtime + connect functions exist. Each applier is
@@ -15204,6 +15217,7 @@ function buildPanel() {
   void loadBackends();
 
   (async () => {
+    await historyRestoreReady;
     // If a restart we triggered reloaded the page, finish the autonomous resume:
     // respawn the orchestrator and let onStatus(connected) nudge the agent.
     if (ssGet(REBOOT_KEY)) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11796,8 +11796,13 @@ function buildPanel() {
         ev.stopPropagation();
         const now = nextHistoryRevision();
         historyMeta.deletedThreads = historyMeta.deletedThreads || {};
-        historyMeta.deletedThreads[t.id] = now;
-        historyMeta.updatedAt = now;
+        historyMeta.deletedThreads[t.id] = {
+          value: null,
+          deleted: true,
+          updatedAt: now.updatedAt,
+          revision: now,
+        };
+        historyMeta.updatedAt = Math.max(Number(historyMeta.updatedAt) || 0, now.updatedAt);
         threads = threads.filter((x) => x.id !== t.id);
         for (const [key, value] of Object.entries(historyMeta.activeByScope || {})) {
           if (value === t.id) setActiveThread(key, null, now);

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -737,6 +737,40 @@ export function mergeHistorySnapshots(...snapshots) {
   };
 }
 
+/** Build a canonical empty-history checkpoint without discarding workflow
+ * identity aliases. Advancing the generation fences every older browser tab:
+ * a stale pre-clear snapshot cannot republish a thread that no longer exists in
+ * this empty baseline. Alias operations are folded into the new checkpoint
+ * baseline because they identify workflows, not transcripts. */
+export function createHistoryResetSnapshot(snapshot, revision = null) {
+  const normalized = mergeHistorySnapshots(snapshot);
+  const resetRevision = normalizeExplicitRevision(revision) ||
+    normalizeRevision(null, Date.now(), "history-clear", 0);
+  const previousCheckpoint = normalizeCheckpoint(normalized.meta);
+  const workflowAliases = safeMap();
+  for (const [path, value] of Object.entries(normalized.meta?.workflowAliases || {})) {
+    workflowAliases[path] = value;
+  }
+  return {
+    schemaVersion: CHAT_HISTORY_SCHEMA,
+    updatedAt: resetRevision.updatedAt,
+    threads: [],
+    meta: {
+      ...(normalized.meta || {}),
+      updatedAt: resetRevision.updatedAt,
+      checkpoint: {
+        generation: previousCheckpoint.generation + 1,
+        revision: resetRevision,
+      },
+      activeByScope: safeMap(),
+      activeOps: safeMap(),
+      deletedThreads: safeMap(),
+      workflowAliases,
+      aliasOps: safeMap(),
+    },
+  };
+}
+
 function withoutCheckpoint(snapshot) {
   if (!snapshot || typeof snapshot !== "object") return snapshot;
   const hadCheckpoint = snapshot.meta?.checkpoint != null;
@@ -878,6 +912,31 @@ async function idbMergeWrite(indexedDb, snapshot, limits) {
       };
       get.onerror = () => store.put(merged, CHAT_HISTORY_STATE_KEY);
       tx.oncomplete = () => resolve(merged);
+      tx.onerror = () => resolve(null);
+      tx.onabort = () => resolve(null);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+async function idbResetHistory(indexedDb, snapshot, createReset) {
+  const db = await openDb(indexedDb);
+  if (!db) return null;
+  try {
+    return await new Promise((resolve) => {
+      const tx = db.transaction("snapshots", "readwrite");
+      const store = tx.objectStore("snapshots");
+      const get = store.get(CHAT_HISTORY_STATE_KEY);
+      let reset = null;
+      const replace = (canonical) => {
+        const merged = mergeUnderCanonicalCheckpoint(canonical, snapshot);
+        reset = createReset(merged);
+        store.put(reset, CHAT_HISTORY_STATE_KEY);
+      };
+      get.onsuccess = () => replace(get.result);
+      get.onerror = () => replace(null);
+      tx.oncomplete = () => resolve(reset);
       tx.onerror = () => resolve(null);
       tx.onabort = () => resolve(null);
     });
@@ -1140,6 +1199,64 @@ export class ChatHistoryStore {
     return snapshot;
   }
 
+  /** Remove every transcript as one canonical checkpoint. This deliberately
+   * does not delete the IndexedDB database: doing so would also erase workflow
+   * aliases and would let a stale open tab recreate the old snapshot. */
+  async clearAll(threads, meta = {}) {
+    if (this._closed) {
+      return {
+        ok: false,
+        canonicalCommitted: false,
+        shadowCommitted: false,
+        retryable: false,
+        code: "history-store-closed",
+      };
+    }
+    const localSnapshot = this._dirtyWrite
+      ? mergeHistorySnapshots(this._dirtyWrite.snapshot, { threads, meta })
+      : mergeHistorySnapshots({ threads, meta });
+    this._observeSnapshot(localSnapshot);
+    this._writePromise = this._writePromise
+      .catch(() => null)
+      .then(() => idbResetHistory(this.indexedDb, localSnapshot, (canonical) => {
+        this._observeSnapshot(canonical);
+        return createHistoryResetSnapshot(canonical, this.nextRevision());
+      }))
+      .then((reset) => {
+        if (!reset) {
+          return {
+            ok: false,
+            canonicalCommitted: false,
+            shadowCommitted: false,
+            retryable: true,
+            code: "history-clear-canonical-unavailable",
+          };
+        }
+        this._lastCommitted = reset;
+        this._dirtyWrite = null;
+        this._observeSnapshot(reset);
+        const shadowCommitted = this._writeLocalSnapshot(reset, []);
+        try {
+          this._broadcastChannel?.postMessage({
+            type: "history-reset",
+            writerId: this.writerId,
+            generation: reset.meta?.checkpoint?.generation || 0,
+          });
+        } catch {
+          // localStorage events remain available when the channel is blocked.
+        }
+        return {
+          ok: true,
+          canonicalCommitted: true,
+          shadowCommitted,
+          retryable: false,
+          code: null,
+          snapshot: reset,
+        };
+      });
+    return this._writePromise;
+  }
+
   /** Watch the localStorage compatibility shadow. Browsers fire `storage` only
    *  in the other tabs, making it a cheap cross-tab invalidation channel while
    *  IndexedDB remains the full, atomically merged source of truth. */
@@ -1156,7 +1273,10 @@ export class ChatHistoryStore {
       void this.readCanonical().then(listener);
     };
     const onBroadcast = (event) => {
-      if (event?.data?.type !== "history-changed" || event.data.writerId === this.writerId) return;
+      if (
+        !["history-changed", "history-reset"].includes(event?.data?.type) ||
+        event.data.writerId === this.writerId
+      ) return;
       void this.readCanonical().then(listener);
     };
     eventTarget?.addEventListener?.("storage", onStorage);

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -857,6 +857,8 @@ export class ChatHistoryStore {
     this._writePromise = Promise.resolve(null);
     this._lastCommitted = null;
     this._dirtyWrite = null;
+    this._closed = false;
+    this._subscriptions = new Set();
     const channelFactory = options.broadcastChannelFactory || (
       globalThis.window === globalThis && typeof globalThis.BroadcastChannel === "function"
         ? (name) => new globalThis.BroadcastChannel(name)
@@ -1025,6 +1027,7 @@ export class ChatHistoryStore {
   }
 
   persist(threads, meta = {}, options = {}) {
+    if (this._closed) return this._lastCommitted || mergeHistorySnapshots({ threads, meta });
     const freshSnapshot = mergeHistorySnapshots({ threads, meta });
     if (hasIdlessMessages(threads)) freshSnapshot[LEGACY_IDLESS_SOURCE] = true;
     const snapshot = this._dirtyWrite
@@ -1086,7 +1089,7 @@ export class ChatHistoryStore {
    *  in the other tabs, making it a cheap cross-tab invalidation channel while
    *  IndexedDB remains the full, atomically merged source of truth. */
   subscribe(listener, eventTarget = globalThis) {
-    if (typeof listener !== "function") return () => {};
+    if (this._closed || typeof listener !== "function") return () => {};
     const onStorage = (event) => {
       if (
         event?.key !== this.snapshotKey &&
@@ -1103,10 +1106,16 @@ export class ChatHistoryStore {
     };
     eventTarget?.addEventListener?.("storage", onStorage);
     this._broadcastChannel?.addEventListener?.("message", onBroadcast);
-    return () => {
+    let active = true;
+    const unsubscribe = () => {
+      if (!active) return;
+      active = false;
       eventTarget?.removeEventListener?.("storage", onStorage);
       this._broadcastChannel?.removeEventListener?.("message", onBroadcast);
+      this._subscriptions.delete(unsubscribe);
     };
+    this._subscriptions.add(unsubscribe);
+    return unsubscribe;
   }
 
   async flush() {
@@ -1119,6 +1128,19 @@ export class ChatHistoryStore {
       error: error?.message || String(error),
     }));
     return result == null || result.ok === true ? true : result;
+  }
+
+  close() {
+    if (this._closed) return;
+    this._closed = true;
+    for (const unsubscribe of [...this._subscriptions]) unsubscribe();
+    this._subscriptions.clear();
+    try {
+      this._broadcastChannel?.close?.();
+    } catch {
+      // Closing an already-detached native channel is harmless.
+    }
+    this._broadcastChannel = null;
   }
 
 }

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -677,6 +677,36 @@ export function mergeHistorySnapshots(...snapshots) {
   };
 }
 
+function withoutCheckpoint(snapshot) {
+  if (!snapshot || typeof snapshot !== "object") return snapshot;
+  const hadCheckpoint = snapshot.meta?.checkpoint != null;
+  return {
+    ...snapshot,
+    meta: snapshot.meta && typeof snapshot.meta === "object"
+      ? {
+        ...snapshot.meta,
+        checkpoint: undefined,
+        // Materialized maps in a checkpointed shadow are baseline cache, not
+        // fresh operations. The canonical record supplies that baseline.
+        activeByScope: hadCheckpoint ? {} : snapshot.meta.activeByScope,
+        workflowAliases: hadCheckpoint ? {} : snapshot.meta.workflowAliases,
+      }
+      : {},
+  };
+}
+
+/** Merge an untrusted shadow/write intent under the baseline owned by IndexedDB.
+ * Local checkpoints are deliberately removed even when they repeat the current
+ * generation: only the canonical record may define which compacted records
+ * existed at that generation. Newer causal operations still pass the normal
+ * post-checkpoint filters. */
+function mergeUnderCanonicalCheckpoint(canonical, ...untrusted) {
+  return mergeHistorySnapshots(
+    canonical && typeof canonical === "object" ? canonical : null,
+    ...untrusted.map(withoutCheckpoint),
+  );
+}
+
 function boundedSnapshot(snapshot, { maxThreads, maxMessages, protectedThreadIds = [] }) {
   const activeThreadIds = Object.values(snapshot?.meta?.activeByScope || {})
     .filter((id) => typeof id === "string" && id);
@@ -756,10 +786,10 @@ async function idbMergeWrite(indexedDb, snapshot, limits) {
       const tx = db.transaction("snapshots", "readwrite");
       const store = tx.objectStore("snapshots");
       const get = store.get(CHAT_HISTORY_STATE_KEY);
-      let merged = compactSnapshot(boundedSnapshot(snapshot, limits), limits);
+      let merged = compactSnapshot(boundedSnapshot(withoutCheckpoint(snapshot), limits), limits);
       get.onsuccess = () => {
         merged = compactSnapshot(
-          boundedSnapshot(mergeHistorySnapshots(get.result, snapshot), limits),
+          boundedSnapshot(mergeUnderCanonicalCheckpoint(get.result, snapshot), limits),
           limits,
         );
         store.put(merged, CHAT_HISTORY_STATE_KEY);
@@ -879,7 +909,7 @@ export class ChatHistoryStore {
     return message;
   }
 
-  readLocal() {
+  readLocal({ quarantineCheckpoint = false } = {}) {
     const readJson = (key, fallback) => {
       try {
         const raw = this.storage?.getItem(key);
@@ -901,16 +931,17 @@ export class ChatHistoryStore {
       ? atomicObject.meta
       : legacyMeta;
     try {
-      return mergeHistorySnapshots({ threads: Array.isArray(threads) ? threads : [], meta });
+      const local = { threads: Array.isArray(threads) ? threads : [], meta };
+      return mergeHistorySnapshots(quarantineCheckpoint ? withoutCheckpoint(local) : local);
     } catch {
       return mergeHistorySnapshots({ threads: [], meta: {} });
     }
   }
 
   async load(options = {}) {
-    const local = this.readLocal();
     const indexed = await idbRead(this.indexedDb);
-    const merged = mergeHistorySnapshots(local, indexed);
+    const local = this.readLocal({ quarantineCheckpoint: indexed != null });
+    const merged = mergeUnderCanonicalCheckpoint(indexed, local);
     this._observeSnapshot(merged);
     // Migration is automatic: once loaded, the full merged set is promoted to
     // IndexedDB while a small legacy shadow remains for older panel builds.
@@ -919,7 +950,11 @@ export class ChatHistoryStore {
   }
 
   async readCanonical() {
-    const merged = mergeHistorySnapshots(this.readLocal(), await idbRead(this.indexedDb));
+    const indexed = await idbRead(this.indexedDb);
+    const merged = mergeUnderCanonicalCheckpoint(
+      indexed,
+      this.readLocal({ quarantineCheckpoint: indexed != null }),
+    );
     this._observeSnapshot(merged);
     return merged;
   }

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -791,6 +791,7 @@ export class ChatHistoryStore {
     this.writerId = options.writerId || globalThis.crypto?.randomUUID?.() || `writer-${Math.random().toString(16).slice(2)}`;
     this._revisionSequence = 0;
     this._lastRevisionAt = 0;
+    this._observedRevision = null;
     this._writePromise = Promise.resolve(null);
     this._lastCommitted = null;
     const channelFactory = options.broadcastChannelFactory || (
@@ -806,13 +807,42 @@ export class ChatHistoryStore {
   }
 
   nextRevision(updatedAt = Date.now()) {
-    const at = finiteTs(updatedAt) || Date.now();
+    const wallAt = finiteTs(updatedAt) || Date.now();
+    const observedAt = finiteTs(this._observedRevision?.updatedAt);
+    const floor = Math.max(this._lastRevisionAt, observedAt);
+    const at = wallAt > floor ? wallAt : floor + 1;
     if (at !== this._lastRevisionAt) {
       this._lastRevisionAt = at;
       this._revisionSequence = 0;
     }
     this._revisionSequence += 1;
-    return { updatedAt: at, writerId: this.writerId, sequence: this._revisionSequence };
+    const revision = { updatedAt: at, writerId: this.writerId, sequence: this._revisionSequence };
+    this._observedRevision = revision;
+    return revision;
+  }
+
+  _observeRevision(value) {
+    const revision = normalizeRevision(value);
+    if (revision && compareRevisions(revision, this._observedRevision) > 0) {
+      this._observedRevision = revision;
+      this._lastRevisionAt = Math.max(this._lastRevisionAt, revision.updatedAt);
+    }
+  }
+
+  _observeSnapshot(snapshot) {
+    if (!snapshot || typeof snapshot !== "object") return;
+    this._observeRevision(snapshot.meta?.checkpoint?.revision);
+    for (const operation of Object.values(snapshot.meta?.activeOps || {})) this._observeRevision(operation);
+    for (const operation of Object.values(snapshot.meta?.aliasOps || {})) this._observeRevision(operation);
+    for (const operation of Object.values(snapshot.meta?.deletedThreads || {})) this._observeRevision(operation);
+    for (const thread of Array.isArray(snapshot.threads) ? snapshot.threads : []) {
+      this._observeRevision(thread?.createdRevision);
+      for (const operation of Object.values(thread?.fieldOps || {})) this._observeRevision(operation);
+      for (const message of Array.isArray(thread?.msgs) ? thread.msgs : []) {
+        this._observeRevision(message?.createdRevision);
+        this._observeRevision(message?.revision || message);
+      }
+    }
   }
 
   reviseThread(thread, values, updatedAt = Date.now()) {
@@ -821,6 +851,7 @@ export class ChatHistoryStore {
     let newestAt = finiteTs(thread.updatedAt);
     for (const [field, value] of Object.entries(values)) {
       if (!THREAD_FIELDS.includes(field)) continue;
+      this._observeRevision(fieldOps[field]);
       const revision = this.nextRevision(updatedAt);
       const deleted = value == null;
       fieldOps[field] = {
@@ -841,6 +872,7 @@ export class ChatHistoryStore {
 
   touchMessage(message, updatedAt = Date.now()) {
     if (!message || typeof message !== "object") return message;
+    this._observeRevision(message.revision || message);
     const revision = this.nextRevision(updatedAt);
     message.updatedAt = revision.updatedAt;
     message.revision = revision;
@@ -879,6 +911,7 @@ export class ChatHistoryStore {
     const local = this.readLocal();
     const indexed = await idbRead(this.indexedDb);
     const merged = mergeHistorySnapshots(local, indexed);
+    this._observeSnapshot(merged);
     // Migration is automatic: once loaded, the full merged set is promoted to
     // IndexedDB while a small legacy shadow remains for older panel builds.
     this.persist(merged.threads, merged.meta, options);
@@ -886,7 +919,9 @@ export class ChatHistoryStore {
   }
 
   async readCanonical() {
-    return mergeHistorySnapshots(this.readLocal(), await idbRead(this.indexedDb));
+    const merged = mergeHistorySnapshots(this.readLocal(), await idbRead(this.indexedDb));
+    this._observeSnapshot(merged);
+    return merged;
   }
 
   _writeLocalSnapshot(snapshot, protectedThreadIds) {
@@ -921,6 +956,7 @@ export class ChatHistoryStore {
 
   persist(threads, meta = {}, options = {}) {
     const snapshot = mergeHistorySnapshots({ threads, meta });
+    this._observeSnapshot(snapshot);
     const protectedThreadIds = [
       ...(Array.isArray(options.protectedThreadIds) ? options.protectedThreadIds : []),
       ...Object.values(snapshot.meta.activeByScope || {}),
@@ -942,6 +978,7 @@ export class ChatHistoryStore {
       .then((merged) => {
         if (merged) {
           this._lastCommitted = merged;
+          this._observeSnapshot(merged);
           this._writeLocalSnapshot(merged, protectedThreadIds);
           try {
             this._broadcastChannel?.postMessage({ type: "history-changed", writerId: this.writerId });

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -816,6 +816,9 @@ export class ChatHistoryStore {
     this.maxTombstones = options.maxTombstones ?? DEFAULT_MAX_TOMBSTONES;
     this.maxMetadataOps = options.maxMetadataOps ?? DEFAULT_MAX_METADATA_OPS;
     this.onShadowError = typeof options.onShadowError === "function" ? options.onShadowError : null;
+    this.onPersistenceError = typeof options.onPersistenceError === "function"
+      ? options.onPersistenceError
+      : null;
     this.lastShadowWriteOk = null;
     this.lastShadowError = null;
     this.writerId = options.writerId || globalThis.crypto?.randomUUID?.() || `writer-${Math.random().toString(16).slice(2)}`;
@@ -824,6 +827,7 @@ export class ChatHistoryStore {
     this._observedRevision = null;
     this._writePromise = Promise.resolve(null);
     this._lastCommitted = null;
+    this._dirtyWrite = null;
     const channelFactory = options.broadcastChannelFactory || (
       globalThis.window === globalThis && typeof globalThis.BroadcastChannel === "function"
         ? (name) => new globalThis.BroadcastChannel(name)
@@ -990,7 +994,10 @@ export class ChatHistoryStore {
   }
 
   persist(threads, meta = {}, options = {}) {
-    const snapshot = mergeHistorySnapshots({ threads, meta });
+    const freshSnapshot = mergeHistorySnapshots({ threads, meta });
+    const snapshot = this._dirtyWrite
+      ? mergeHistorySnapshots(this._dirtyWrite.snapshot, freshSnapshot)
+      : freshSnapshot;
     this._observeSnapshot(snapshot);
     const protectedThreadIds = [
       ...(Array.isArray(options.protectedThreadIds) ? options.protectedThreadIds : []),
@@ -1003,7 +1010,7 @@ export class ChatHistoryStore {
       maxMetadataOps: options.maxMetadataOps ?? this.maxMetadataOps,
       protectedThreadIds,
     };
-    this._writeLocalSnapshot(snapshot, protectedThreadIds);
+    const shadowCommitted = this._writeLocalSnapshot(snapshot, protectedThreadIds);
     // Start the atomic merge immediately. Chat records are low-frequency and a
     // debounce creates an avoidable shutdown window in which the local shadow
     // exists but IndexedDB has not started its transaction yet.
@@ -1021,7 +1028,24 @@ export class ChatHistoryStore {
             // localStorage events remain available when the channel is blocked.
           }
         }
-        return merged;
+        const result = {
+          ok: Boolean(merged || shadowCommitted),
+          shadowCommitted,
+          canonicalCommitted: Boolean(merged),
+          retryable: !merged && !shadowCommitted,
+          code: !merged && !shadowCommitted ? "history-persistence-unavailable" : null,
+        };
+        if (result.ok) {
+          this._dirtyWrite = null;
+        } else {
+          // Neither durability layer accepted this state. Keep the complete
+          // intent so the next persist can retry it after quota/IDB recovery.
+          // No BroadcastChannel message is sent: peers must only invalidate
+          // against a committed canonical revision.
+          this._dirtyWrite = { snapshot, limits, protectedThreadIds };
+          this.onPersistenceError?.(result);
+        }
+        return result;
       });
     return snapshot;
   }
@@ -1052,8 +1076,15 @@ export class ChatHistoryStore {
   }
 
   async flush() {
-    await this._writePromise.catch(() => null);
-    return true;
+    const result = await this._writePromise.catch((error) => ({
+      ok: false,
+      shadowCommitted: false,
+      canonicalCommitted: false,
+      retryable: true,
+      code: "history-persistence-error",
+      error: error?.message || String(error),
+    }));
+    return result == null || result.ok === true ? true : result;
   }
 
 }

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -18,6 +18,9 @@ const DEFAULT_MAX_MESSAGES = 5000;
 const LOCAL_SHADOW_THREADS = 20;
 const LOCAL_SHADOW_MESSAGES = 200;
 const IDB_OPEN_TIMEOUT_MS = 2000;
+const DEFAULT_MAX_TOMBSTONES = 512;
+const DEFAULT_MAX_METADATA_OPS = 512;
+const BROADCAST_CHANNEL_NAME = "comfyui-mcp-panel-history-v3";
 const THREAD_FIELDS = [
   "sessionId",
   "todos",
@@ -98,7 +101,12 @@ function normalizeMessage(message, threadId, ordinal) {
     updatedAt,
     `legacy-${stableHash(`${threadId}:${id}:${canonicalJson(message)}`)}`,
   );
-  return { ...message, id, createdAt, updatedAt, revision };
+  const createdRevision = normalizeRevision(
+    message.createdRevision,
+    createdAt,
+    `created-${stableHash(`${threadId}:${id}`)}`,
+  );
+  return { ...message, id, createdAt, updatedAt, revision, createdRevision };
 }
 
 function normalizeMessages(threadId, messages) {
@@ -179,6 +187,15 @@ function normalizeMetadataOperations(operations, values, fallbackUpdatedAt) {
   return normalized;
 }
 
+function sanitizedMetadataValues(values, operations) {
+  const sanitized = safeMap();
+  for (const [key, value] of Object.entries(values || {})) sanitized[key] = value;
+  for (const [key, operation] of Object.entries(operations || {})) {
+    if (!normalizeMetadataOperation(operation, null, 0)) delete sanitized[key];
+  }
+  return sanitized;
+}
+
 function mergeMetadataOperationMaps(current, incoming) {
   const merged = safeMap();
   for (const [key, operation] of Object.entries(current || {})) merged[key] = operation;
@@ -196,10 +213,12 @@ function mergeMetadataOperationMaps(current, incoming) {
   return merged;
 }
 
-function materializeMetadataOperations(operations) {
+function materializeMetadataOperations(operations, base = null) {
   const values = safeMap();
+  for (const [key, value] of Object.entries(base || {})) values[key] = value;
   for (const [key, operation] of Object.entries(operations || {})) {
-    if (operation?.deleted !== true && operation?.value != null) values[key] = operation.value;
+    if (operation?.deleted === true || operation?.value == null) delete values[key];
+    else values[key] = operation.value;
   }
   return values;
 }
@@ -274,6 +293,67 @@ function materializeThreadFields(thread, fieldOps) {
   return materialized;
 }
 
+function normalizeCheckpoint(meta) {
+  const generation = Number(meta?.checkpoint?.generation);
+  const revision = normalizeRevision(meta?.checkpoint?.revision);
+  return {
+    generation: Number.isSafeInteger(generation) && generation > 0 ? generation : 0,
+    revision,
+  };
+}
+
+function operationRevision(operation) {
+  return normalizeRevision(operation?.revision || operation);
+}
+
+function boundedEntries(map, limit, revisionOf) {
+  const entries = Object.entries(map || {});
+  if (entries.length <= limit) return [map, []];
+  entries.sort((left, right) =>
+    compareRevisions(revisionOf(left[1]), revisionOf(right[1])) || left[0].localeCompare(right[0]),
+  );
+  const dropped = entries.slice(0, entries.length - limit);
+  const kept = safeMap();
+  for (const [key, value] of entries.slice(-limit)) kept[key] = value;
+  return [kept, dropped];
+}
+
+function compactSnapshot(snapshot, { maxTombstones, maxMetadataOps }) {
+  const tombstoneLimit = Math.max(1, Math.floor(Number(maxTombstones) || DEFAULT_MAX_TOMBSTONES));
+  const operationLimit = Math.max(1, Math.floor(Number(maxMetadataOps) || DEFAULT_MAX_METADATA_OPS));
+  const meta = { ...(snapshot.meta || {}) };
+  const droppedRevisions = [];
+  let changed = false;
+  [meta.deletedThreads, changed] = (() => {
+    const [kept, dropped] = boundedEntries(meta.deletedThreads, tombstoneLimit, finiteTs);
+    for (const [, value] of dropped) droppedRevisions.push(normalizeRevision(null, value, "tombstone"));
+    return [kept, changed || dropped.length > 0];
+  })();
+  for (const name of ["activeOps", "aliasOps"]) {
+    const [kept, dropped] = boundedEntries(meta[name], operationLimit, operationRevision);
+    meta[name] = kept;
+    for (const [, value] of dropped) droppedRevisions.push(operationRevision(value));
+    if (dropped.length) changed = true;
+  }
+  const threads = snapshot.threads.map((thread) => {
+    const [deletedMessages, dropped] = boundedEntries(thread.deletedMessages, tombstoneLimit, finiteTs);
+    for (const [, value] of dropped) droppedRevisions.push(normalizeRevision(null, value, "tombstone"));
+    if (dropped.length) changed = true;
+    return dropped.length ? { ...thread, deletedMessages } : thread;
+  });
+  if (!changed) return { ...snapshot, threads, meta };
+  const previous = normalizeCheckpoint(meta);
+  let revision = previous.revision;
+  for (const candidate of droppedRevisions) {
+    if (compareRevisions(candidate, revision) > 0) revision = candidate;
+  }
+  meta.checkpoint = {
+    generation: previous.generation + 1,
+    revision: revision || normalizeRevision(null, Date.now(), "checkpoint"),
+  };
+  return { ...snapshot, threads, meta };
+}
+
 export function normalizeThread(raw) {
   if (!raw || typeof raw !== "object" || typeof raw.id !== "string" || !raw.id) return null;
   const deletedMessages = mergeTimestampMaps(raw.deletedMessages);
@@ -293,6 +373,11 @@ export function normalizeThread(raw) {
     id: raw.id,
     schemaVersion: CHAT_HISTORY_SCHEMA,
     createdAt,
+    createdRevision: normalizeRevision(
+      raw.createdRevision,
+      createdAt,
+      `created-${stableHash(raw.id)}`,
+    ),
     updatedAt,
     ts: updatedAt,
     msgs,
@@ -395,6 +480,41 @@ function mergeThreadMessages(older, newer) {
 /** Merge snapshots by thread id; the newest record wins without dropping fields
  *  added by an older copy (useful while migrating localStorage -> IndexedDB). */
 export function mergeHistorySnapshots(...snapshots) {
+  const usableSnapshots = snapshots.filter((snap) => snap && typeof snap === "object");
+  let checkpointGeneration = 0;
+  let checkpointRevision = null;
+  for (const snap of usableSnapshots) {
+    const checkpoint = normalizeCheckpoint(snap.meta);
+    if (checkpoint.generation > checkpointGeneration) {
+      checkpointGeneration = checkpoint.generation;
+      checkpointRevision = checkpoint.revision;
+    } else if (
+      checkpoint.generation === checkpointGeneration &&
+      compareRevisions(checkpoint.revision, checkpointRevision) > 0
+    ) {
+      checkpointRevision = checkpoint.revision;
+    }
+  }
+  const checkpointThreadIds = new Set();
+  const checkpointMessageIds = new Map();
+  const checkpointActive = safeMap();
+  const checkpointAliases = safeMap();
+  if (checkpointGeneration) {
+    for (const snap of usableSnapshots) {
+      if (normalizeCheckpoint(snap.meta).generation !== checkpointGeneration) continue;
+      for (const [key, value] of Object.entries(snap.meta?.activeByScope || {})) checkpointActive[key] = value;
+      for (const [key, value] of Object.entries(snap.meta?.workflowAliases || {})) checkpointAliases[key] = value;
+      for (const rawThread of Array.isArray(snap.threads) ? snap.threads : []) {
+        if (!rawThread || typeof rawThread.id !== "string" || !rawThread.id) continue;
+        checkpointThreadIds.add(rawThread.id);
+        const ids = checkpointMessageIds.get(rawThread.id) || new Set();
+        for (const message of Array.isArray(rawThread.msgs) ? rawThread.msgs : []) {
+          if (typeof message?.id === "string" && message.id) ids.add(message.id);
+        }
+        checkpointMessageIds.set(rawThread.id, ids);
+      }
+    }
+  }
   const byId = new Map();
   let meta = {};
   let activeOps = {};
@@ -402,32 +522,66 @@ export function mergeHistorySnapshots(...snapshots) {
   let deletedThreads = {};
   let metaUpdatedAt = 0;
   let snapshotUpdatedAt = 0;
-  for (const snap of snapshots) {
-    if (!snap || typeof snap !== "object") continue;
+  for (const snap of usableSnapshots) {
+    const snapCheckpoint = normalizeCheckpoint(snap.meta);
+    const beforeCheckpoint = snapCheckpoint.generation < checkpointGeneration;
     const incomingUpdatedAt = Math.max(finiteTs(snap.updatedAt), finiteTs(snap.meta?.updatedAt));
     snapshotUpdatedAt = Math.max(snapshotUpdatedAt, incomingUpdatedAt);
     if (snap.meta && typeof snap.meta === "object") {
+      const snapMeta = {
+        ...snap.meta,
+        activeByScope: sanitizedMetadataValues(snap.meta.activeByScope, snap.meta.activeOps),
+        workflowAliases: sanitizedMetadataValues(snap.meta.workflowAliases, snap.meta.aliasOps),
+      };
       const incomingNewer = incomingUpdatedAt >= metaUpdatedAt;
-      const older = incomingNewer ? meta : snap.meta;
-      const newer = incomingNewer ? snap.meta : meta;
+      const older = incomingNewer ? meta : snapMeta;
+      const newer = incomingNewer ? snapMeta : meta;
       meta = {
         ...older,
         ...newer,
       };
       activeOps = mergeMetadataOperationMaps(
         activeOps,
-        normalizeMetadataOperations(snap.meta.activeOps, snap.meta.activeByScope, incomingUpdatedAt || 1),
+        Object.fromEntries(Object.entries(normalizeMetadataOperations(
+          snap.meta.activeOps,
+          beforeCheckpoint ? null : snapMeta.activeByScope,
+          incomingUpdatedAt || 1,
+        )).filter(([, operation]) =>
+          !beforeCheckpoint || compareRevisions(operation.revision, checkpointRevision) > 0)),
       );
       aliasOps = mergeMetadataOperationMaps(
         aliasOps,
-        normalizeMetadataOperations(snap.meta.aliasOps, snap.meta.workflowAliases, incomingUpdatedAt || 1),
+        Object.fromEntries(Object.entries(normalizeMetadataOperations(
+          snap.meta.aliasOps,
+          beforeCheckpoint ? null : snapMeta.workflowAliases,
+          incomingUpdatedAt || 1,
+        )).filter(([, operation]) =>
+          !beforeCheckpoint || compareRevisions(operation.revision, checkpointRevision) > 0)),
       );
-      deletedThreads = mergeTimestampMaps(deletedThreads, snap.meta.deletedThreads);
+      const acceptedDeletedThreads = beforeCheckpoint
+        ? Object.fromEntries(Object.entries(snap.meta.deletedThreads || {}).filter(([, value]) =>
+          finiteTs(value) > finiteTs(checkpointRevision?.updatedAt)))
+        : snap.meta.deletedThreads;
+      deletedThreads = mergeTimestampMaps(deletedThreads, acceptedDeletedThreads);
       metaUpdatedAt = Math.max(metaUpdatedAt, incomingUpdatedAt);
     }
     for (const candidate of Array.isArray(snap.threads) ? snap.threads : []) {
       const next = normalizeThread(candidate);
       if (!next) continue;
+      if (
+        beforeCheckpoint &&
+        !checkpointThreadIds.has(next.id) &&
+        compareRevisions(next.createdRevision, checkpointRevision) <= 0
+      ) continue;
+      if (beforeCheckpoint && checkpointMessageIds.has(next.id)) {
+        const baselineIds = checkpointMessageIds.get(next.id);
+        next.msgs = next.msgs.filter((message) =>
+          baselineIds.has(message.id) || compareRevisions(message.createdRevision, checkpointRevision) > 0);
+        next.deletedMessages = mergeTimestampMaps(Object.fromEntries(
+          Object.entries(next.deletedMessages).filter(([, value]) =>
+            finiteTs(value) > finiteTs(checkpointRevision?.updatedAt)),
+        ));
+      }
       const prev = byId.get(next.id);
       if (!prev) {
         byId.set(next.id, next);
@@ -469,11 +623,20 @@ export function mergeHistorySnapshots(...snapshots) {
       workflowAliases: {},
       deletedThreads: {},
       ...meta,
+      checkpoint: checkpointGeneration
+        ? { generation: checkpointGeneration, revision: checkpointRevision }
+        : undefined,
       updatedAt: metaUpdatedAt,
       activeOps,
       aliasOps,
-      activeByScope: materializeMetadataOperations(activeOps),
-      workflowAliases: materializeMetadataOperations(aliasOps),
+      activeByScope: materializeMetadataOperations(
+        activeOps,
+        checkpointGeneration ? checkpointActive : meta.activeByScope,
+      ),
+      workflowAliases: materializeMetadataOperations(
+        aliasOps,
+        checkpointGeneration ? checkpointAliases : meta.workflowAliases,
+      ),
       deletedThreads,
     },
   };
@@ -558,9 +721,12 @@ async function idbMergeWrite(indexedDb, snapshot, limits) {
       const tx = db.transaction("snapshots", "readwrite");
       const store = tx.objectStore("snapshots");
       const get = store.get(CHAT_HISTORY_STATE_KEY);
-      let merged = boundedSnapshot(snapshot, limits);
+      let merged = compactSnapshot(boundedSnapshot(snapshot, limits), limits);
       get.onsuccess = () => {
-        merged = boundedSnapshot(mergeHistorySnapshots(get.result, snapshot), limits);
+        merged = compactSnapshot(
+          boundedSnapshot(mergeHistorySnapshots(get.result, snapshot), limits),
+          limits,
+        );
         store.put(merged, CHAT_HISTORY_STATE_KEY);
       };
       get.onerror = () => store.put(merged, CHAT_HISTORY_STATE_KEY);
@@ -582,11 +748,26 @@ export class ChatHistoryStore {
     this.snapshotKey = options.snapshotKey ?? CHAT_HISTORY_LOCAL_SNAPSHOT_KEY;
     this.maxThreads = options.maxThreads ?? DEFAULT_MAX_THREADS;
     this.maxMessages = options.maxMessages ?? DEFAULT_MAX_MESSAGES;
+    this.maxTombstones = options.maxTombstones ?? DEFAULT_MAX_TOMBSTONES;
+    this.maxMetadataOps = options.maxMetadataOps ?? DEFAULT_MAX_METADATA_OPS;
+    this.onShadowError = typeof options.onShadowError === "function" ? options.onShadowError : null;
+    this.lastShadowWriteOk = null;
+    this.lastShadowError = null;
     this.writerId = options.writerId || globalThis.crypto?.randomUUID?.() || `writer-${Math.random().toString(16).slice(2)}`;
     this._revisionSequence = 0;
     this._lastRevisionAt = 0;
     this._writePromise = Promise.resolve(null);
     this._lastCommitted = null;
+    const channelFactory = options.broadcastChannelFactory || (
+      globalThis.window === globalThis && typeof globalThis.BroadcastChannel === "function"
+        ? (name) => new globalThis.BroadcastChannel(name)
+        : null
+    );
+    try {
+      this._broadcastChannel = channelFactory?.(BROADCAST_CHANNEL_NAME) || null;
+    } catch {
+      this._broadcastChannel = null;
+    }
   }
 
   nextRevision(updatedAt = Date.now()) {
@@ -669,6 +850,40 @@ export class ChatHistoryStore {
     return merged;
   }
 
+  async readCanonical() {
+    return mergeHistorySnapshots(this.readLocal(), await idbRead(this.indexedDb));
+  }
+
+  _writeLocalSnapshot(snapshot, protectedThreadIds) {
+    const shadow = retainBoundedThreads(
+      snapshot.threads,
+      LOCAL_SHADOW_THREADS,
+      protectedThreadIds,
+    ).map((thread) => ({ ...thread, msgs: thread.msgs.slice(-LOCAL_SHADOW_MESSAGES) }));
+    const localSnapshot = { ...snapshot, threads: shadow };
+    try {
+      this.storage?.setItem(this.snapshotKey, JSON.stringify(localSnapshot));
+      this.lastShadowWriteOk = true;
+      this.lastShadowError = null;
+    } catch (error) {
+      this.lastShadowWriteOk = false;
+      this.lastShadowError = error;
+      this.onShadowError?.(error);
+      return false;
+    }
+    try {
+      this.storage?.setItem(this.threadsKey, JSON.stringify(shadow));
+    } catch {
+      // The atomic shadow is already committed.
+    }
+    try {
+      this.storage?.setItem(this.metaKey, JSON.stringify(snapshot.meta));
+    } catch {
+      // The atomic shadow is already committed.
+    }
+    return true;
+  }
+
   persist(threads, meta = {}, options = {}) {
     const snapshot = mergeHistorySnapshots({ threads, meta });
     const protectedThreadIds = [
@@ -678,37 +893,11 @@ export class ChatHistoryStore {
     const limits = {
       maxThreads: options.maxThreads ?? this.maxThreads,
       maxMessages: options.maxMessages ?? this.maxMessages,
+      maxTombstones: options.maxTombstones ?? this.maxTombstones,
+      maxMetadataOps: options.maxMetadataOps ?? this.maxMetadataOps,
       protectedThreadIds,
     };
-    const shadow = retainBoundedThreads(
-      snapshot.threads,
-      LOCAL_SHADOW_THREADS,
-      protectedThreadIds,
-    )
-      .map((thread) => ({ ...thread, msgs: thread.msgs.slice(-LOCAL_SHADOW_MESSAGES) }));
-    const localSnapshot = { ...snapshot, threads: shadow };
-    let atomicWritten = false;
-    try {
-      this.storage?.setItem(this.snapshotKey, JSON.stringify(localSnapshot));
-      atomicWritten = true;
-    } catch {
-      // IndexedDB remains canonical when localStorage is unavailable or full.
-    }
-    if (atomicWritten) {
-      // Keep the pre-v2 keys as best-effort compatibility mirrors. Current code
-      // always reads the atomic snapshot first, so a partial legacy write cannot
-      // create a mixed generation for this implementation.
-      try {
-        this.storage?.setItem(this.threadsKey, JSON.stringify(shadow));
-      } catch {
-        // The atomic shadow is already committed.
-      }
-      try {
-        this.storage?.setItem(this.metaKey, JSON.stringify(snapshot.meta));
-      } catch {
-        // The atomic shadow is already committed.
-      }
-    }
+    this._writeLocalSnapshot(snapshot, protectedThreadIds);
     // Start the atomic merge immediately. Chat records are low-frequency and a
     // debounce creates an avoidable shutdown window in which the local shadow
     // exists but IndexedDB has not started its transaction yet.
@@ -716,7 +905,15 @@ export class ChatHistoryStore {
       .catch(() => null)
       .then(() => idbMergeWrite(this.indexedDb, snapshot, limits))
       .then((merged) => {
-        if (merged) this._lastCommitted = merged;
+        if (merged) {
+          this._lastCommitted = merged;
+          this._writeLocalSnapshot(merged, protectedThreadIds);
+          try {
+            this._broadcastChannel?.postMessage({ type: "history-changed", writerId: this.writerId });
+          } catch {
+            // localStorage events remain available when the channel is blocked.
+          }
+        }
         return merged;
       });
     return snapshot;
@@ -726,7 +923,7 @@ export class ChatHistoryStore {
    *  in the other tabs, making it a cheap cross-tab invalidation channel while
    *  IndexedDB remains the full, atomically merged source of truth. */
   subscribe(listener, eventTarget = globalThis) {
-    if (!eventTarget?.addEventListener || typeof listener !== "function") return () => {};
+    if (typeof listener !== "function") return () => {};
     const onStorage = (event) => {
       if (
         event?.key !== this.snapshotKey &&
@@ -735,8 +932,16 @@ export class ChatHistoryStore {
       ) return;
       listener(this.readLocal());
     };
-    eventTarget.addEventListener("storage", onStorage);
-    return () => eventTarget.removeEventListener?.("storage", onStorage);
+    const onBroadcast = (event) => {
+      if (event?.data?.type !== "history-changed" || event.data.writerId === this.writerId) return;
+      void this.readCanonical().then(listener);
+    };
+    eventTarget?.addEventListener?.("storage", onStorage);
+    this._broadcastChannel?.addEventListener?.("message", onBroadcast);
+    return () => {
+      eventTarget?.removeEventListener?.("storage", onStorage);
+      this._broadcastChannel?.removeEventListener?.("message", onBroadcast);
+    };
   }
 
   async flush() {

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -135,6 +135,41 @@ function mergeTimestampMaps(...maps) {
   return merged;
 }
 
+function normalizeThreadDeletion(operation) {
+  const legacyAt = finiteTs(operation);
+  if (legacyAt) {
+    const revision = legacyRevision(null, legacyAt);
+    return { value: null, deleted: true, updatedAt: revision.updatedAt, revision };
+  }
+  if (!operation || typeof operation !== "object" || Array.isArray(operation)) return null;
+  const normalized = operation.deleted === true
+    ? normalizeMetadataOperation(operation, null, 0)
+    : null;
+  if (normalized?.deleted === true) return normalized;
+  // Schema-3 builds briefly wrote a bare causal revision here. Accept that
+  // transitional shape, but always materialize the canonical delete operation.
+  const revision = normalizeRevision(operation);
+  return revision
+    ? { value: null, deleted: true, updatedAt: revision.updatedAt, revision }
+    : null;
+}
+
+function mergeThreadDeletionMaps(...maps) {
+  const merged = safeMap();
+  for (const map of maps) {
+    if (!map || typeof map !== "object" || Array.isArray(map)) continue;
+    for (const [key, value] of Object.entries(map)) {
+      if (typeof key !== "string" || !key) continue;
+      const operation = normalizeThreadDeletion(value);
+      if (!operation) continue;
+      if (!merged[key] || compareRevisions(operation.revision, merged[key].revision) > 0) {
+        merged[key] = operation;
+      }
+    }
+  }
+  return merged;
+}
+
 function normalizeMetadataOperation(operation, fallbackValue, fallbackUpdatedAt) {
   if (operation && typeof operation === "object" && !Array.isArray(operation)) {
     const revision = normalizeRevision(
@@ -325,8 +360,8 @@ function compactSnapshot(snapshot, { maxTombstones, maxMetadataOps }) {
   const droppedRevisions = [];
   let changed = false;
   [meta.deletedThreads, changed] = (() => {
-    const [kept, dropped] = boundedEntries(meta.deletedThreads, tombstoneLimit, finiteTs);
-    for (const [, value] of dropped) droppedRevisions.push(normalizeRevision(null, value, "tombstone"));
+    const [kept, dropped] = boundedEntries(meta.deletedThreads, tombstoneLimit, operationRevision);
+    for (const [, value] of dropped) droppedRevisions.push(operationRevision(value));
     return [kept, changed || dropped.length > 0];
   })();
   for (const name of ["activeOps", "aliasOps"]) {
@@ -560,9 +595,9 @@ export function mergeHistorySnapshots(...snapshots) {
       );
       const acceptedDeletedThreads = beforeCheckpoint
         ? Object.fromEntries(Object.entries(snap.meta.deletedThreads || {}).filter(([, value]) =>
-          finiteTs(value) > finiteTs(checkpointRevision?.updatedAt)))
+          compareRevisions(normalizeThreadDeletion(value)?.revision, checkpointRevision) > 0))
         : snap.meta.deletedThreads;
-      deletedThreads = mergeTimestampMaps(deletedThreads, acceptedDeletedThreads);
+      deletedThreads = mergeThreadDeletionMaps(deletedThreads, acceptedDeletedThreads);
       metaUpdatedAt = Math.max(metaUpdatedAt, incomingUpdatedAt);
     }
     for (const candidate of Array.isArray(snap.threads) ? snap.threads : []) {

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -95,6 +95,38 @@ export function selectRestoreThread(
     : selectThreadForScope(threads, meta, scopeKey);
 }
 
+/** Apply a strict recency cap without evicting conversations that are still
+ * bound to a browser tab or durable active-scope pointer. Protected ids are
+ * ordered by priority; remaining capacity is filled with the newest threads. */
+export function retainBoundedThreads(threads, limit, protectedThreadIds = []) {
+  const max = Math.max(0, Math.floor(Number(limit) || 0));
+  if (!max) return [];
+  const ordered = [...(Array.isArray(threads) ? threads : [])]
+    .filter((candidate) => candidate && typeof candidate.id === "string" && candidate.id)
+    .sort((a, b) => finiteTs(a.updatedAt || a.ts) - finiteTs(b.updatedAt || b.ts));
+  if (ordered.length <= max) return ordered;
+
+  const available = new Set(ordered.map((candidate) => candidate.id));
+  const protectedIds = [];
+  const protectedSet = new Set();
+  for (const id of Array.isArray(protectedThreadIds) ? protectedThreadIds : []) {
+    if (typeof id !== "string" || !id || !available.has(id) || protectedSet.has(id)) continue;
+    protectedIds.push(id);
+    protectedSet.add(id);
+    if (protectedIds.length === max) break;
+  }
+
+  const remaining = max - protectedIds.length;
+  const newestIds = remaining
+    ? ordered
+      .filter((candidate) => !protectedSet.has(candidate.id))
+      .slice(-remaining)
+      .map((candidate) => candidate.id)
+    : [];
+  const keptIds = new Set([...protectedIds, ...newestIds]);
+  return ordered.filter((candidate) => keptIds.has(candidate.id));
+}
+
 function mergeThreadMessages(older, newer) {
   const oldMessages = Array.isArray(older?.msgs) ? older.msgs : [];
   const newMessages = Array.isArray(newer?.msgs) ? newer.msgs : [];
@@ -277,21 +309,28 @@ export class ChatHistoryStore {
     }
   }
 
-  async load() {
+  async load(options = {}) {
     const local = this.readLocal();
     const indexed = await idbRead(this.indexedDb);
     const merged = mergeHistorySnapshots(local, indexed);
     // Migration is automatic: once loaded, the full merged set is promoted to
     // IndexedDB while a small legacy shadow remains for older panel builds.
-    this.persist(merged.threads, merged.meta);
+    this.persist(merged.threads, merged.meta, options);
     return merged;
   }
 
-  persist(threads, meta = {}) {
+  persist(threads, meta = {}, options = {}) {
     const snapshot = mergeHistorySnapshots({ threads, meta });
     try {
-      const shadow = snapshot.threads
-        .slice(-LOCAL_SHADOW_THREADS)
+      const protectedThreadIds = [
+        ...(Array.isArray(options.protectedThreadIds) ? options.protectedThreadIds : []),
+        ...Object.values(snapshot.meta.activeByScope || {}),
+      ];
+      const shadow = retainBoundedThreads(
+        snapshot.threads,
+        LOCAL_SHADOW_THREADS,
+        protectedThreadIds,
+      )
         .map((t) => ({ ...t, msgs: t.msgs.slice(-LOCAL_SHADOW_MESSAGES) }));
       this.storage?.setItem(this.threadsKey, JSON.stringify(shadow));
       this.storage?.setItem(this.metaKey, JSON.stringify(snapshot.meta));

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -1,0 +1,312 @@
+// Durable chat-history storage for the Agent Panel.
+//
+// IndexedDB is the canonical browser store. A small localStorage shadow remains
+// for instant startup and backward compatibility with pre-v2 panel builds.
+
+import { isThreadInScope } from "./workflow-chat-identity.js";
+export { isThreadInScope };
+
+export const CHAT_HISTORY_SCHEMA = 2;
+export const CHAT_HISTORY_DB = "comfyui-mcp-panel-history";
+export const CHAT_HISTORY_STATE_KEY = "state";
+
+const DEFAULT_THREADS_KEY = "comfyui-mcp.panel.threads";
+const DEFAULT_META_KEY = "comfyui-mcp.panel.historyMeta";
+const LOCAL_SHADOW_THREADS = 20;
+const LOCAL_SHADOW_MESSAGES = 200;
+
+function finiteTs(value) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function mergeTimestampMaps(...maps) {
+  const merged = {};
+  for (const map of maps) {
+    if (!map || typeof map !== "object") continue;
+    for (const [key, value] of Object.entries(map)) {
+      merged[key] = Math.max(finiteTs(merged[key]), finiteTs(value));
+    }
+  }
+  return merged;
+}
+
+export function normalizeThread(raw) {
+  if (!raw || typeof raw !== "object" || typeof raw.id !== "string" || !raw.id) return null;
+  const msgs = Array.isArray(raw.msgs) ? raw.msgs.filter((m) => m && typeof m === "object") : [];
+  const ts = finiteTs(raw.ts) || finiteTs(raw.createdAt) || Date.now();
+  const createdAt = finiteTs(raw.createdAt) || ts;
+  const updatedAt = finiteTs(raw.updatedAt) || ts;
+  return {
+    ...raw,
+    id: raw.id,
+    schemaVersion: CHAT_HISTORY_SCHEMA,
+    createdAt,
+    updatedAt,
+    ts: updatedAt,
+    msgs,
+    pinned: raw.pinned === true,
+    title: typeof raw.title === "string" ? raw.title.slice(0, 160) : undefined,
+    workflowKey: typeof raw.workflowKey === "string" ? raw.workflowKey : "panel:global",
+    workflowTitle: typeof raw.workflowTitle === "string" ? raw.workflowTitle.slice(0, 240) : undefined,
+    provider: typeof raw.provider === "string" ? raw.provider : undefined,
+    model: typeof raw.model === "string" ? raw.model : undefined,
+    effort: typeof raw.effort === "string" ? raw.effort : undefined,
+  };
+}
+
+export function selectThreadForScope(threads, meta, scopeKey) {
+  const candidates = (Array.isArray(threads) ? threads : [])
+    .filter((thread) => isThreadInScope(thread, scopeKey))
+    .sort((a, b) => finiteTs(b.updatedAt || b.ts) - finiteTs(a.updatedAt || a.ts));
+  const activeId = meta?.activeByScope?.[scopeKey];
+  return candidates.find((thread) => thread.id === activeId) || candidates[0] || null;
+}
+
+/** Select the panel-owned conversation without changing its workflowKey. The
+ *  global id lives only in metadata; each thread keeps its ride-along workflow
+ *  provenance for archive grouping. Legacy snapshots without that pointer
+ *  recover the most recently updated conversation. */
+export function selectPanelThread(threads, meta) {
+  const candidates = [...(Array.isArray(threads) ? threads : [])]
+    .sort((a, b) => finiteTs(b?.updatedAt || b?.ts) - finiteTs(a?.updatedAt || a?.ts));
+  const activeId = meta?.activeByScope?.["panel:global"];
+  return candidates.find((thread) => thread?.id === activeId) || candidates[0] || null;
+}
+
+function mergeThreadMessages(older, newer) {
+  const oldMessages = Array.isArray(older?.msgs) ? older.msgs : [];
+  const newMessages = Array.isArray(newer?.msgs) ? newer.msgs : [];
+  // Schema-v2 messages carry UUIDs. Unioning them makes append-only chat writes
+  // safe when two tabs persist the same workflow between each other's reads.
+  // Legacy messages had no ids, so retain the historical newest-snapshot rule
+  // rather than guessing whether equal-looking entries are duplicates.
+  const identified = [...oldMessages, ...newMessages].every(
+    (message) => message && typeof message.id === "string" && message.id,
+  );
+  if (!identified) return newMessages;
+  const byId = new Map();
+  for (const message of [...oldMessages, ...newMessages]) {
+    const previous = byId.get(message.id);
+    if (!previous || finiteTs(message.updatedAt || message.createdAt) >= finiteTs(previous.updatedAt || previous.createdAt)) {
+      byId.set(message.id, message);
+    }
+  }
+  return [...byId.values()].sort(
+    (a, b) => finiteTs(a.createdAt || a.ts) - finiteTs(b.createdAt || b.ts),
+  );
+}
+
+/** Merge snapshots by thread id; the newest record wins without dropping fields
+ *  added by an older copy (useful while migrating localStorage -> IndexedDB). */
+export function mergeHistorySnapshots(...snapshots) {
+  const byId = new Map();
+  let meta = {};
+  let metaUpdatedAt = 0;
+  let snapshotUpdatedAt = 0;
+  for (const snap of snapshots) {
+    if (!snap || typeof snap !== "object") continue;
+    const incomingUpdatedAt = Math.max(finiteTs(snap.updatedAt), finiteTs(snap.meta?.updatedAt));
+    snapshotUpdatedAt = Math.max(snapshotUpdatedAt, incomingUpdatedAt);
+    if (snap.meta && typeof snap.meta === "object") {
+      const incomingNewer = incomingUpdatedAt >= metaUpdatedAt;
+      const older = incomingNewer ? meta : snap.meta;
+      const newer = incomingNewer ? snap.meta : meta;
+      meta = {
+        ...older,
+        ...newer,
+        activeByScope: {
+          ...(older.activeByScope && typeof older.activeByScope === "object" ? older.activeByScope : {}),
+          ...(newer.activeByScope && typeof newer.activeByScope === "object" ? newer.activeByScope : {}),
+        },
+        // Aliases are additive; a newer path entry naturally wins on collision.
+        workflowAliases: {
+          ...(older.workflowAliases && typeof older.workflowAliases === "object" ? older.workflowAliases : {}),
+          ...(newer.workflowAliases && typeof newer.workflowAliases === "object" ? newer.workflowAliases : {}),
+        },
+        deletedThreads: {
+          ...mergeTimestampMaps(older.deletedThreads, newer.deletedThreads),
+        },
+      };
+      metaUpdatedAt = Math.max(metaUpdatedAt, incomingUpdatedAt);
+    }
+    for (const candidate of Array.isArray(snap.threads) ? snap.threads : []) {
+      const next = normalizeThread(candidate);
+      if (!next) continue;
+      const prev = byId.get(next.id);
+      if (!prev) {
+        byId.set(next.id, next);
+        continue;
+      }
+      const newer = finiteTs(next.updatedAt) >= finiteTs(prev.updatedAt) ? next : prev;
+      const older = newer === next ? prev : next;
+      const overlay = Object.fromEntries(
+        Object.entries(newer).filter(([, value]) => value !== undefined),
+      );
+      // normalizeThread supplies compatibility defaults for standalone legacy
+      // records. During a partial merge those defaults must not erase richer
+      // metadata already present in the older snapshot.
+      if (newer === next && !Object.hasOwn(candidate, "workflowKey")) delete overlay.workflowKey;
+      if (newer === next && !Object.hasOwn(candidate, "pinned")) delete overlay.pinned;
+      byId.set(next.id, { ...older, ...overlay, msgs: mergeThreadMessages(older, newer) });
+    }
+  }
+  const deletedThreads =
+    meta.deletedThreads && typeof meta.deletedThreads === "object" ? meta.deletedThreads : {};
+  const threads = [...byId.values()]
+    .filter((thread) => finiteTs(deletedThreads[thread.id]) < finiteTs(thread.updatedAt || thread.ts))
+    .sort((a, b) => finiteTs(a.updatedAt) - finiteTs(b.updatedAt));
+  const newestThreadAt = threads.reduce((max, thread) => Math.max(max, finiteTs(thread.updatedAt)), 0);
+  return {
+    schemaVersion: CHAT_HISTORY_SCHEMA,
+    updatedAt: Math.max(snapshotUpdatedAt, newestThreadAt) || Date.now(),
+    threads,
+    meta: {
+      activeByScope: {},
+      workflowAliases: {},
+      deletedThreads: {},
+      ...meta,
+      activeByScope:
+        meta.activeByScope && typeof meta.activeByScope === "object" ? meta.activeByScope : {},
+      workflowAliases:
+        meta.workflowAliases && typeof meta.workflowAliases === "object" ? meta.workflowAliases : {},
+      deletedThreads,
+    },
+  };
+}
+
+function openDb(indexedDb) {
+  if (!indexedDb || typeof indexedDb.open !== "function") return Promise.resolve(null);
+  return new Promise((resolve) => {
+    let request;
+    try {
+      request = indexedDb.open(CHAT_HISTORY_DB, CHAT_HISTORY_SCHEMA);
+    } catch {
+      resolve(null);
+      return;
+    }
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains("snapshots")) db.createObjectStore("snapshots");
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => resolve(null);
+    request.onblocked = () => resolve(null);
+  });
+}
+
+async function idbRead(indexedDb) {
+  const db = await openDb(indexedDb);
+  if (!db) return null;
+  try {
+    return await new Promise((resolve) => {
+      const tx = db.transaction("snapshots", "readonly");
+      const req = tx.objectStore("snapshots").get(CHAT_HISTORY_STATE_KEY);
+      req.onsuccess = () => resolve(req.result || null);
+      req.onerror = () => resolve(null);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+async function idbMergeWrite(indexedDb, snapshot) {
+  const db = await openDb(indexedDb);
+  if (!db) return null;
+  try {
+    return await new Promise((resolve) => {
+      const tx = db.transaction("snapshots", "readwrite");
+      const store = tx.objectStore("snapshots");
+      const get = store.get(CHAT_HISTORY_STATE_KEY);
+      let merged = snapshot;
+      get.onsuccess = () => {
+        merged = mergeHistorySnapshots(get.result, snapshot);
+        store.put(merged, CHAT_HISTORY_STATE_KEY);
+      };
+      get.onerror = () => store.put(snapshot, CHAT_HISTORY_STATE_KEY);
+      tx.oncomplete = () => resolve(merged);
+      tx.onerror = () => resolve(null);
+      tx.onabort = () => resolve(null);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+export class ChatHistoryStore {
+  constructor(options = {}) {
+    this.storage = options.storage ?? globalThis.localStorage;
+    this.indexedDb = options.indexedDb ?? globalThis.indexedDB;
+    this.threadsKey = options.threadsKey ?? DEFAULT_THREADS_KEY;
+    this.metaKey = options.metaKey ?? DEFAULT_META_KEY;
+    this._writePromise = Promise.resolve(null);
+    this._lastCommitted = null;
+  }
+
+  readLocal() {
+    try {
+      const threads = JSON.parse(this.storage?.getItem(this.threadsKey) ?? "[]");
+      const meta = JSON.parse(this.storage?.getItem(this.metaKey) ?? "{}");
+      return mergeHistorySnapshots({ threads: Array.isArray(threads) ? threads : [], meta });
+    } catch {
+      return mergeHistorySnapshots({ threads: [], meta: {} });
+    }
+  }
+
+  async load() {
+    const local = this.readLocal();
+    const indexed = await idbRead(this.indexedDb);
+    const merged = mergeHistorySnapshots(local, indexed);
+    // Migration is automatic: once loaded, the full merged set is promoted to
+    // IndexedDB while a small legacy shadow remains for older panel builds.
+    this.persist(merged.threads, merged.meta);
+    return merged;
+  }
+
+  persist(threads, meta = {}) {
+    const snapshot = mergeHistorySnapshots({ threads, meta });
+    try {
+      const shadow = snapshot.threads
+        .slice(-LOCAL_SHADOW_THREADS)
+        .map((t) => ({ ...t, msgs: t.msgs.slice(-LOCAL_SHADOW_MESSAGES) }));
+      this.storage?.setItem(this.threadsKey, JSON.stringify(shadow));
+      this.storage?.setItem(this.metaKey, JSON.stringify(snapshot.meta));
+    } catch {
+      // IndexedDB remains canonical when localStorage is unavailable or full.
+    }
+    // Start the atomic merge immediately. Chat records are low-frequency and a
+    // debounce creates an avoidable shutdown window in which the local shadow
+    // exists but IndexedDB has not started its transaction yet.
+    this._writePromise = this._writePromise
+      .catch(() => null)
+      .then(() => idbMergeWrite(this.indexedDb, snapshot))
+      .then((merged) => {
+        if (merged) this._lastCommitted = merged;
+        return merged;
+      });
+    return snapshot;
+  }
+
+  /** Watch the localStorage compatibility shadow. Browsers fire `storage` only
+   *  in the other tabs, making it a cheap cross-tab invalidation channel while
+   *  IndexedDB remains the full, atomically merged source of truth. */
+  subscribe(listener, eventTarget = globalThis) {
+    if (!eventTarget?.addEventListener || typeof listener !== "function") return () => {};
+    const onStorage = (event) => {
+      if (event?.key !== this.threadsKey && event?.key !== this.metaKey) return;
+      listener(this.readLocal());
+    };
+    eventTarget.addEventListener("storage", onStorage);
+    return () => eventTarget.removeEventListener?.("storage", onStorage);
+  }
+
+  async flush() {
+    await this._writePromise.catch(() => null);
+    return true;
+  }
+
+}

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -33,6 +33,18 @@ const THREAD_FIELDS = [
   "pinned",
   "title",
 ];
+const INVALID_FIELD_VALUE = Symbol("invalid-thread-field-value");
+const THREAD_STRING_LIMITS = {
+  sessionId: 512,
+  workflowKey: 512,
+  workflowTitle: 240,
+  provider: 80,
+  model: 200,
+  effort: 40,
+  title: 160,
+};
+const MAX_TODOS = 100;
+const MAX_TODO_TEXT = 2000;
 
 function finiteTs(value) {
   const n = Number(value);
@@ -142,6 +154,36 @@ function mergeTimestampMaps(...maps) {
   return merged;
 }
 
+function normalizeExplicitRevision(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const updatedAt = finiteTs(value.updatedAt);
+  const writerId = typeof value.writerId === "string" ? value.writerId.trim() : "";
+  const sequence = Number(value.sequence);
+  if (
+    !updatedAt || !writerId || writerId.length > 200 ||
+    !Number.isSafeInteger(sequence) || sequence < 0
+  ) return null;
+  return { updatedAt, writerId, sequence };
+}
+
+function normalizeThreadFieldValue(field, value) {
+  if (value == null) return null;
+  if (field === "pinned") return typeof value === "boolean" ? value : INVALID_FIELD_VALUE;
+  if (field === "todos") {
+    if (!Array.isArray(value)) return INVALID_FIELD_VALUE;
+    const todos = [];
+    for (const item of value.slice(0, MAX_TODOS)) {
+      if (!item || typeof item !== "object" || Array.isArray(item) || typeof item.text !== "string") continue;
+      const status = item.status === "active" || item.status === "done" ? item.status : "pending";
+      todos.push({ text: item.text.slice(0, MAX_TODO_TEXT), status });
+    }
+    return todos;
+  }
+  const limit = THREAD_STRING_LIMITS[field];
+  if (limit) return typeof value === "string" ? value.slice(0, limit) : INVALID_FIELD_VALUE;
+  return INVALID_FIELD_VALUE;
+}
+
 function normalizeThreadDeletion(operation) {
   const legacyAt = finiteTs(operation);
   if (legacyAt) {
@@ -179,11 +221,10 @@ function mergeThreadDeletionMaps(...maps) {
 
 function normalizeMetadataOperation(operation, fallbackValue, fallbackUpdatedAt) {
   if (operation && typeof operation === "object" && !Array.isArray(operation)) {
-    const revision = normalizeRevision(
-      operation.revision || operation,
-      0,
-      `legacy-${stableHash(canonicalJson(operation))}`,
-    );
+    const hasExplicitRevision = Object.hasOwn(operation, "revision");
+    const revision = hasExplicitRevision
+      ? normalizeExplicitRevision(operation.revision)
+      : legacyRevision(operation.value, finiteTs(operation.updatedAt));
     const deleted = operation.deleted;
     const coherent =
       deleted === true
@@ -299,7 +340,12 @@ function normalizeThreadFieldOperations(raw, fallbackUpdatedAt) {
   for (const field of THREAD_FIELDS) {
     if (source && Object.hasOwn(source, field)) {
       const operation = normalizeMetadataOperation(source[field], null, 0);
-      if (operation) operations[field] = operation;
+      if (operation) {
+        const value = operation.deleted ? null : normalizeThreadFieldValue(field, operation.value);
+        if (operation.deleted || value !== INVALID_FIELD_VALUE) {
+          operations[field] = { ...operation, value };
+        }
+      }
       continue;
     }
     let hasValue = Object.hasOwn(raw, field);
@@ -309,6 +355,8 @@ function normalizeThreadFieldOperations(raw, fallbackUpdatedAt) {
       value = "panel:global";
     }
     if (!hasValue || value == null) continue;
+    value = normalizeThreadFieldValue(field, value);
+    if (value === INVALID_FIELD_VALUE) continue;
     const revision = legacyRevision(value, fallbackUpdatedAt);
     operations[field] = {
       value: cloneJson(value),
@@ -324,9 +372,14 @@ function materializeThreadFields(thread, fieldOps) {
   const materialized = { ...thread, fieldOps };
   for (const field of THREAD_FIELDS) {
     const operation = fieldOps[field];
-    if (!operation) continue;
-    if (operation.deleted === true) delete materialized[field];
-    else materialized[field] = cloneJson(operation.value);
+    if (operation) {
+      if (operation.deleted === true) delete materialized[field];
+      else materialized[field] = cloneJson(operation.value);
+      continue;
+    }
+    const normalized = normalizeThreadFieldValue(field, materialized[field]);
+    if (normalized === INVALID_FIELD_VALUE || normalized == null) delete materialized[field];
+    else materialized[field] = cloneJson(normalized);
   }
   materialized.pinned = materialized.pinned === true;
   materialized.workflowKey = typeof materialized.workflowKey === "string"
@@ -337,9 +390,9 @@ function materializeThreadFields(thread, fieldOps) {
 
 function normalizeCheckpoint(meta) {
   const generation = Number(meta?.checkpoint?.generation);
-  const revision = normalizeRevision(meta?.checkpoint?.revision);
+  const revision = normalizeExplicitRevision(meta?.checkpoint?.revision);
   return {
-    generation: Number.isSafeInteger(generation) && generation > 0 ? generation : 0,
+    generation: Number.isSafeInteger(generation) && generation > 0 && revision ? generation : 0,
     revision,
   };
 }
@@ -916,17 +969,19 @@ export class ChatHistoryStore {
     let newestAt = finiteTs(thread.updatedAt);
     for (const [field, value] of Object.entries(values)) {
       if (!THREAD_FIELDS.includes(field)) continue;
+      const normalizedValue = value == null ? null : normalizeThreadFieldValue(field, value);
+      if (normalizedValue === INVALID_FIELD_VALUE) continue;
       this._observeRevision(fieldOps[field]);
       const revision = this.nextRevision(updatedAt);
-      const deleted = value == null;
+      const deleted = normalizedValue == null;
       fieldOps[field] = {
-        value: deleted ? null : cloneJson(value),
+        value: deleted ? null : cloneJson(normalizedValue),
         deleted,
         updatedAt: revision.updatedAt,
         revision,
       };
       if (deleted) delete thread[field];
-      else thread[field] = cloneJson(value);
+      else thread[field] = cloneJson(normalizedValue);
       newestAt = Math.max(newestAt, revision.updatedAt);
     }
     thread.fieldOps = fieldOps;

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -451,17 +451,17 @@ export class ChatHistoryStore {
       }
     };
     const atomic = readJson(this.snapshotKey, null);
-    if (
-      atomic &&
-      typeof atomic === "object" &&
-      (Array.isArray(atomic.threads) || (atomic.meta && typeof atomic.meta === "object"))
-    ) {
-      return mergeHistorySnapshots(atomic);
-    }
     // Migrate legacy two-key shadows defensively: one corrupt half must not
     // discard the other valid half.
-    const threads = readJson(this.threadsKey, []);
-    const meta = readJson(this.metaKey, {});
+    const legacyThreads = readJson(this.threadsKey, []);
+    const legacyMeta = readJson(this.metaKey, {});
+    const atomicObject = atomic && typeof atomic === "object" ? atomic : null;
+    const threads = Array.isArray(atomicObject?.threads)
+      ? atomicObject.threads
+      : legacyThreads;
+    const meta = atomicObject?.meta && typeof atomicObject.meta === "object"
+      ? atomicObject.meta
+      : legacyMeta;
     try {
       return mergeHistorySnapshots({ threads: Array.isArray(threads) ? threads : [], meta });
     } catch {

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -18,6 +18,17 @@ const DEFAULT_MAX_MESSAGES = 5000;
 const LOCAL_SHADOW_THREADS = 20;
 const LOCAL_SHADOW_MESSAGES = 200;
 const IDB_OPEN_TIMEOUT_MS = 2000;
+const THREAD_FIELDS = [
+  "sessionId",
+  "todos",
+  "workflowKey",
+  "workflowTitle",
+  "provider",
+  "model",
+  "effort",
+  "pinned",
+  "title",
+];
 
 function finiteTs(value) {
   const n = Number(value);
@@ -46,21 +57,55 @@ function stableHash(value) {
   return first.toString(16).padStart(8, "0") + second.toString(16).padStart(8, "0");
 }
 
+function normalizeRevision(value, fallbackUpdatedAt = 0, fallbackWriterId = "legacy", fallbackSequence = 0) {
+  const source = value && typeof value === "object" && !Array.isArray(value)
+    ? (value.revision && typeof value.revision === "object" ? value.revision : value)
+    : null;
+  const updatedAt = finiteTs(source?.updatedAt) || finiteTs(fallbackUpdatedAt);
+  if (!updatedAt) return null;
+  const writerId = typeof source?.writerId === "string" && source.writerId
+    ? source.writerId
+    : fallbackWriterId;
+  const sequenceValue = Number(source?.sequence ?? fallbackSequence);
+  const sequence = Number.isSafeInteger(sequenceValue) && sequenceValue >= 0 ? sequenceValue : 0;
+  return { updatedAt, writerId, sequence };
+}
+
+function compareRevisions(left, right) {
+  const a = normalizeRevision(left);
+  const b = normalizeRevision(right);
+  if (!a) return b ? -1 : 0;
+  if (!b) return 1;
+  if (a.updatedAt !== b.updatedAt) return a.updatedAt < b.updatedAt ? -1 : 1;
+  if (a.writerId !== b.writerId) return a.writerId < b.writerId ? -1 : 1;
+  if (a.sequence !== b.sequence) return a.sequence < b.sequence ? -1 : 1;
+  return 0;
+}
+
+function legacyRevision(value, updatedAt) {
+  return normalizeRevision(null, updatedAt || 1, `legacy-${stableHash(canonicalJson(value))}`, 0);
+}
+
+function normalizeMessage(message, threadId, ordinal) {
+  if (!message || typeof message !== "object" || Array.isArray(message)) return null;
+  const id = typeof message.id === "string" && message.id
+    ? message.id
+    : `legacy-${stableHash(`${threadId}:${ordinal}:${canonicalJson(message)}`)}`;
+  const createdAt = finiteTs(message.createdAt) || finiteTs(message.ts) || 1;
+  const updatedAt = finiteTs(message.updatedAt) || createdAt;
+  const revision = normalizeRevision(
+    message.revision || message,
+    updatedAt,
+    `legacy-${stableHash(`${threadId}:${id}:${canonicalJson(message)}`)}`,
+  );
+  return { ...message, id, createdAt, updatedAt, revision };
+}
+
 function normalizeMessages(threadId, messages) {
   const normalized = [];
   for (const [ordinal, message] of (Array.isArray(messages) ? messages : []).entries()) {
-    if (!message || typeof message !== "object" || Array.isArray(message)) continue;
-    if (typeof message.id === "string" && message.id) {
-      normalized.push(message);
-      continue;
-    }
-    // Legacy records predate message UUIDs. The thread id, original ordinal and
-    // canonical content make the migration identical in every tab, including
-    // duplicate messages, so it is safe to union and tombstone immediately.
-    normalized.push({
-      ...message,
-      id: `legacy-${stableHash(`${threadId}:${ordinal}:${canonicalJson(message)}`)}`,
-    });
+    const next = normalizeMessage(message, threadId, ordinal);
+    if (next) normalized.push(next);
   }
   return normalized;
 }
@@ -84,25 +129,32 @@ function mergeTimestampMaps(...maps) {
 
 function normalizeMetadataOperation(operation, fallbackValue, fallbackUpdatedAt) {
   if (operation && typeof operation === "object" && !Array.isArray(operation)) {
-    const updatedAt = finiteTs(operation.updatedAt);
+    const revision = normalizeRevision(
+      operation.revision || operation,
+      0,
+      `legacy-${stableHash(canonicalJson(operation))}`,
+    );
     const deleted = operation.deleted;
     const coherent =
       deleted === true
         ? operation.value == null
         : deleted === false && operation.value != null;
-    if (!updatedAt || !coherent) return null;
+    if (!revision || !coherent) return null;
     return {
       value: deleted ? null : cloneJson(operation.value),
       deleted,
-      updatedAt,
+      updatedAt: revision.updatedAt,
+      revision,
     };
   }
   const updatedAt = finiteTs(fallbackUpdatedAt);
   if (!updatedAt || fallbackValue == null) return null;
+  const revision = legacyRevision(fallbackValue, updatedAt);
   return {
     value: cloneJson(fallbackValue),
     deleted: false,
     updatedAt,
+    revision,
   };
 }
 
@@ -132,14 +184,11 @@ function mergeMetadataOperationMaps(current, incoming) {
   for (const [key, operation] of Object.entries(current || {})) merged[key] = operation;
   for (const [key, operation] of Object.entries(incoming || {})) {
     const previous = merged[key];
-    const previousAt = finiteTs(previous?.updatedAt);
-    const incomingAt = finiteTs(operation?.updatedAt);
-    // Deletion wins an exact-time tie so a concurrent stale value cannot revive
-    // a pointer/alias merely because two tabs happened to mutate in one clock tick.
+    const order = compareRevisions(operation?.revision || operation, previous?.revision || previous);
     if (
       !previous ||
-      incomingAt > previousAt ||
-      (incomingAt === previousAt && (operation.deleted === true || previous.deleted !== true))
+      order > 0 ||
+      (order === 0 && operation.deleted === true && previous.deleted !== true)
     ) {
       merged[key] = operation;
     }
@@ -163,7 +212,7 @@ export function updateMetadataEntry(meta, mapName, key, value, updatedAt = Date.
       ? "aliasOps"
       : null;
   if (!opsName || typeof key !== "string" || !key) return meta;
-  const revision = finiteTs(updatedAt) || Date.now();
+  const revision = normalizeRevision(updatedAt, Date.now(), "local", 0);
   const values = safeMap();
   for (const [existingKey, existingValue] of Object.entries(meta?.[mapName] || {})) {
     values[existingKey] = existingValue;
@@ -173,12 +222,56 @@ export function updateMetadataEntry(meta, mapName, key, value, updatedAt = Date.
   else values[key] = value;
   return {
     ...(meta && typeof meta === "object" ? meta : {}),
-    updatedAt: Math.max(finiteTs(meta?.updatedAt), revision),
+    updatedAt: Math.max(finiteTs(meta?.updatedAt), revision.updatedAt),
     [mapName]: values,
     [opsName]: Object.assign(safeMap(), meta?.[opsName] || {}, {
-      [key]: { value: deleted ? null : value, deleted, updatedAt: revision },
+      [key]: { value: deleted ? null : value, deleted, updatedAt: revision.updatedAt, revision },
     }),
   };
+}
+
+function normalizeThreadFieldOperations(raw, fallbackUpdatedAt) {
+  const operations = safeMap();
+  const source = raw?.fieldOps && typeof raw.fieldOps === "object" && !Array.isArray(raw.fieldOps)
+    ? raw.fieldOps
+    : null;
+  for (const field of THREAD_FIELDS) {
+    if (source && Object.hasOwn(source, field)) {
+      const operation = normalizeMetadataOperation(source[field], null, 0);
+      if (operation) operations[field] = operation;
+      continue;
+    }
+    let hasValue = Object.hasOwn(raw, field);
+    let value = raw[field];
+    if (field === "workflowKey" && !hasValue) {
+      hasValue = true;
+      value = "panel:global";
+    }
+    if (!hasValue || value == null) continue;
+    const revision = legacyRevision(value, fallbackUpdatedAt);
+    operations[field] = {
+      value: cloneJson(value),
+      deleted: false,
+      updatedAt: revision.updatedAt,
+      revision,
+    };
+  }
+  return operations;
+}
+
+function materializeThreadFields(thread, fieldOps) {
+  const materialized = { ...thread, fieldOps };
+  for (const field of THREAD_FIELDS) {
+    const operation = fieldOps[field];
+    if (!operation) continue;
+    if (operation.deleted === true) delete materialized[field];
+    else materialized[field] = cloneJson(operation.value);
+  }
+  materialized.pinned = materialized.pinned === true;
+  materialized.workflowKey = typeof materialized.workflowKey === "string"
+    ? materialized.workflowKey
+    : "panel:global";
+  return materialized;
 }
 
 export function normalizeThread(raw) {
@@ -194,7 +287,8 @@ export function normalizeThread(raw) {
   const ts = finiteTs(raw.ts) || finiteTs(raw.createdAt) || Date.now();
   const createdAt = finiteTs(raw.createdAt) || ts;
   const updatedAt = finiteTs(raw.updatedAt) || ts;
-  return {
+  const fieldOps = normalizeThreadFieldOperations(raw, updatedAt);
+  return materializeThreadFields({
     ...raw,
     id: raw.id,
     schemaVersion: CHAT_HISTORY_SCHEMA,
@@ -203,14 +297,12 @@ export function normalizeThread(raw) {
     ts: updatedAt,
     msgs,
     deletedMessages,
-    pinned: raw.pinned === true,
     title: typeof raw.title === "string" ? raw.title.slice(0, 160) : undefined,
-    workflowKey: typeof raw.workflowKey === "string" ? raw.workflowKey : "panel:global",
     workflowTitle: typeof raw.workflowTitle === "string" ? raw.workflowTitle.slice(0, 240) : undefined,
     provider: typeof raw.provider === "string" ? raw.provider : undefined,
     model: typeof raw.model === "string" ? raw.model : undefined,
     effort: typeof raw.effort === "string" ? raw.effort : undefined,
-  };
+  }, fieldOps);
 }
 
 export function selectThreadForScope(threads, meta, scopeKey) {
@@ -289,12 +381,14 @@ function mergeThreadMessages(older, newer) {
   const byId = new Map();
   for (const message of [...oldMessages, ...newMessages]) {
     const previous = byId.get(message.id);
-    if (!previous || finiteTs(message.updatedAt || message.createdAt) >= finiteTs(previous.updatedAt || previous.createdAt)) {
+    if (!previous || compareRevisions(message.revision || message, previous.revision || previous) > 0) {
       byId.set(message.id, message);
     }
   }
   return [...byId.values()].sort(
-    (a, b) => finiteTs(a.createdAt || a.ts) - finiteTs(b.createdAt || b.ts),
+    (a, b) =>
+      finiteTs(a.createdAt || a.ts) - finiteTs(b.createdAt || b.ts) ||
+      String(a.id).localeCompare(String(b.id)),
   );
 }
 
@@ -355,7 +449,11 @@ export function mergeHistorySnapshots(...snapshots) {
           (message) =>
             !(typeof message?.id === "string" && Object.hasOwn(deletedMessages, message.id)),
         );
-      byId.set(next.id, { ...older, ...overlay, msgs, deletedMessages });
+      const fieldOps = mergeMetadataOperationMaps(older.fieldOps, newer.fieldOps);
+      byId.set(next.id, materializeThreadFields(
+        { ...older, ...overlay, msgs, deletedMessages },
+        fieldOps,
+      ));
     }
   }
   const threads = [...byId.values()]
@@ -484,8 +582,53 @@ export class ChatHistoryStore {
     this.snapshotKey = options.snapshotKey ?? CHAT_HISTORY_LOCAL_SNAPSHOT_KEY;
     this.maxThreads = options.maxThreads ?? DEFAULT_MAX_THREADS;
     this.maxMessages = options.maxMessages ?? DEFAULT_MAX_MESSAGES;
+    this.writerId = options.writerId || globalThis.crypto?.randomUUID?.() || `writer-${Math.random().toString(16).slice(2)}`;
+    this._revisionSequence = 0;
+    this._lastRevisionAt = 0;
     this._writePromise = Promise.resolve(null);
     this._lastCommitted = null;
+  }
+
+  nextRevision(updatedAt = Date.now()) {
+    const at = finiteTs(updatedAt) || Date.now();
+    if (at !== this._lastRevisionAt) {
+      this._lastRevisionAt = at;
+      this._revisionSequence = 0;
+    }
+    this._revisionSequence += 1;
+    return { updatedAt: at, writerId: this.writerId, sequence: this._revisionSequence };
+  }
+
+  reviseThread(thread, values, updatedAt = Date.now()) {
+    if (!thread || typeof thread !== "object" || !values || typeof values !== "object") return thread;
+    const fieldOps = Object.assign(safeMap(), thread.fieldOps || {});
+    let newestAt = finiteTs(thread.updatedAt);
+    for (const [field, value] of Object.entries(values)) {
+      if (!THREAD_FIELDS.includes(field)) continue;
+      const revision = this.nextRevision(updatedAt);
+      const deleted = value == null;
+      fieldOps[field] = {
+        value: deleted ? null : cloneJson(value),
+        deleted,
+        updatedAt: revision.updatedAt,
+        revision,
+      };
+      if (deleted) delete thread[field];
+      else thread[field] = cloneJson(value);
+      newestAt = Math.max(newestAt, revision.updatedAt);
+    }
+    thread.fieldOps = fieldOps;
+    thread.updatedAt = newestAt || Date.now();
+    thread.ts = thread.updatedAt;
+    return thread;
+  }
+
+  touchMessage(message, updatedAt = Date.now()) {
+    if (!message || typeof message !== "object") return message;
+    const revision = this.nextRevision(updatedAt);
+    message.updatedAt = revision.updatedAt;
+    message.revision = revision;
+    return message;
   }
 
   readLocal() {

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -6,7 +6,7 @@
 import { isThreadInScope } from "./workflow-chat-identity.js";
 export { isThreadInScope };
 
-export const CHAT_HISTORY_SCHEMA = 2;
+export const CHAT_HISTORY_SCHEMA = 3;
 export const CHAT_HISTORY_DB = "comfyui-mcp-panel-history";
 export const CHAT_HISTORY_STATE_KEY = "state";
 export const CHAT_HISTORY_LOCAL_SNAPSHOT_KEY = "comfyui-mcp.panel.historySnapshot";
@@ -26,6 +26,43 @@ function finiteTs(value) {
 
 function cloneJson(value) {
   return JSON.parse(JSON.stringify(value));
+}
+
+function canonicalJson(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(",")}}`;
+}
+
+function stableHash(value) {
+  const input = String(value);
+  let first = 0x811c9dc5;
+  let second = 0x9e3779b9;
+  for (let i = 0; i < input.length; i += 1) {
+    const code = input.charCodeAt(i);
+    first = Math.imul(first ^ code, 0x01000193) >>> 0;
+    second = Math.imul(second ^ code, 0x85ebca6b) >>> 0;
+  }
+  return first.toString(16).padStart(8, "0") + second.toString(16).padStart(8, "0");
+}
+
+function normalizeMessages(threadId, messages) {
+  const normalized = [];
+  for (const [ordinal, message] of (Array.isArray(messages) ? messages : []).entries()) {
+    if (!message || typeof message !== "object" || Array.isArray(message)) continue;
+    if (typeof message.id === "string" && message.id) {
+      normalized.push(message);
+      continue;
+    }
+    // Legacy records predate message UUIDs. The thread id, original ordinal and
+    // canonical content make the migration identical in every tab, including
+    // duplicate messages, so it is safe to union and tombstone immediately.
+    normalized.push({
+      ...message,
+      id: `legacy-${stableHash(`${threadId}:${ordinal}:${canonicalJson(message)}`)}`,
+    });
+  }
+  return normalized;
 }
 
 function safeMap() {
@@ -147,14 +184,13 @@ export function updateMetadataEntry(meta, mapName, key, value, updatedAt = Date.
 export function normalizeThread(raw) {
   if (!raw || typeof raw !== "object" || typeof raw.id !== "string" || !raw.id) return null;
   const deletedMessages = mergeTimestampMaps(raw.deletedMessages);
-  const msgs = Array.isArray(raw.msgs)
-    ? raw.msgs.filter(
+  const msgs = normalizeMessages(raw.id, raw.msgs)
+    .filter(
       (message) =>
         message &&
         typeof message === "object" &&
         !(typeof message.id === "string" && Object.hasOwn(deletedMessages, message.id)),
-    )
-    : [];
+    );
   const ts = finiteTs(raw.ts) || finiteTs(raw.createdAt) || Date.now();
   const createdAt = finiteTs(raw.createdAt) || ts;
   const updatedAt = finiteTs(raw.updatedAt) || ts;
@@ -250,14 +286,6 @@ export function retainBoundedThreads(threads, limit, protectedThreadIds = []) {
 function mergeThreadMessages(older, newer) {
   const oldMessages = Array.isArray(older?.msgs) ? older.msgs : [];
   const newMessages = Array.isArray(newer?.msgs) ? newer.msgs : [];
-  // Schema-v2 messages carry UUIDs. Unioning them makes append-only chat writes
-  // safe when two tabs persist the same workflow between each other's reads.
-  // Legacy messages had no ids, so retain the historical newest-snapshot rule
-  // rather than guessing whether equal-looking entries are duplicates.
-  const identified = [...oldMessages, ...newMessages].every(
-    (message) => message && typeof message.id === "string" && message.id,
-  );
-  if (!identified) return newMessages;
   const byId = new Map();
   for (const message of [...oldMessages, ...newMessages]) {
     const previous = byId.get(message.id);

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -9,11 +9,15 @@ export { isThreadInScope };
 export const CHAT_HISTORY_SCHEMA = 2;
 export const CHAT_HISTORY_DB = "comfyui-mcp-panel-history";
 export const CHAT_HISTORY_STATE_KEY = "state";
+export const CHAT_HISTORY_LOCAL_SNAPSHOT_KEY = "comfyui-mcp.panel.historySnapshot";
 
 const DEFAULT_THREADS_KEY = "comfyui-mcp.panel.threads";
 const DEFAULT_META_KEY = "comfyui-mcp.panel.historyMeta";
+const DEFAULT_MAX_THREADS = 500;
+const DEFAULT_MAX_MESSAGES = 5000;
 const LOCAL_SHADOW_THREADS = 20;
 const LOCAL_SHADOW_MESSAGES = 200;
+const IDB_OPEN_TIMEOUT_MS = 2000;
 
 function finiteTs(value) {
   const n = Number(value);
@@ -35,9 +39,103 @@ function mergeTimestampMaps(...maps) {
   return merged;
 }
 
+function normalizeMetadataOperation(operation, fallbackValue, fallbackUpdatedAt) {
+  if (operation && typeof operation === "object") {
+    const deleted = operation.deleted === true || operation.value == null;
+    return {
+      value: deleted ? null : operation.value,
+      deleted,
+      updatedAt: finiteTs(operation.updatedAt) || finiteTs(fallbackUpdatedAt),
+    };
+  }
+  return {
+    value: fallbackValue,
+    deleted: false,
+    updatedAt: finiteTs(fallbackUpdatedAt),
+  };
+}
+
+function normalizeMetadataOperations(operations, values, fallbackUpdatedAt) {
+  const normalized = {};
+  if (operations && typeof operations === "object") {
+    for (const [key, operation] of Object.entries(operations)) {
+      normalized[key] = normalizeMetadataOperation(operation, null, fallbackUpdatedAt);
+    }
+  }
+  if (values && typeof values === "object") {
+    for (const [key, value] of Object.entries(values)) {
+      if (!Object.hasOwn(normalized, key)) {
+        normalized[key] = normalizeMetadataOperation(null, value, fallbackUpdatedAt);
+      }
+    }
+  }
+  return normalized;
+}
+
+function mergeMetadataOperationMaps(current, incoming) {
+  const merged = { ...(current && typeof current === "object" ? current : {}) };
+  for (const [key, operation] of Object.entries(incoming || {})) {
+    const previous = merged[key];
+    const previousAt = finiteTs(previous?.updatedAt);
+    const incomingAt = finiteTs(operation?.updatedAt);
+    // Deletion wins an exact-time tie so a concurrent stale value cannot revive
+    // a pointer/alias merely because two tabs happened to mutate in one clock tick.
+    if (
+      !previous ||
+      incomingAt > previousAt ||
+      (incomingAt === previousAt && (operation.deleted === true || previous.deleted !== true))
+    ) {
+      merged[key] = operation;
+    }
+  }
+  return merged;
+}
+
+function materializeMetadataOperations(operations) {
+  const values = {};
+  for (const [key, operation] of Object.entries(operations || {})) {
+    if (operation?.deleted !== true && operation?.value != null) values[key] = operation.value;
+  }
+  return values;
+}
+
+/** Return metadata with a versioned set/delete operation for one keyed value. */
+export function updateMetadataEntry(meta, mapName, key, value, updatedAt = Date.now()) {
+  const opsName = mapName === "activeByScope"
+    ? "activeOps"
+    : mapName === "workflowAliases"
+      ? "aliasOps"
+      : null;
+  if (!opsName || typeof key !== "string" || !key) return meta;
+  const revision = finiteTs(updatedAt) || Date.now();
+  const values = {
+    ...(meta?.[mapName] && typeof meta[mapName] === "object" ? meta[mapName] : {}),
+  };
+  const deleted = value == null;
+  if (deleted) delete values[key];
+  else values[key] = value;
+  return {
+    ...(meta && typeof meta === "object" ? meta : {}),
+    updatedAt: Math.max(finiteTs(meta?.updatedAt), revision),
+    [mapName]: values,
+    [opsName]: {
+      ...(meta?.[opsName] && typeof meta[opsName] === "object" ? meta[opsName] : {}),
+      [key]: { value: deleted ? null : value, deleted, updatedAt: revision },
+    },
+  };
+}
+
 export function normalizeThread(raw) {
   if (!raw || typeof raw !== "object" || typeof raw.id !== "string" || !raw.id) return null;
-  const msgs = Array.isArray(raw.msgs) ? raw.msgs.filter((m) => m && typeof m === "object") : [];
+  const deletedMessages = mergeTimestampMaps(raw.deletedMessages);
+  const msgs = Array.isArray(raw.msgs)
+    ? raw.msgs.filter(
+      (message) =>
+        message &&
+        typeof message === "object" &&
+        !(typeof message.id === "string" && Object.hasOwn(deletedMessages, message.id)),
+    )
+    : [];
   const ts = finiteTs(raw.ts) || finiteTs(raw.createdAt) || Date.now();
   const createdAt = finiteTs(raw.createdAt) || ts;
   const updatedAt = finiteTs(raw.updatedAt) || ts;
@@ -49,6 +147,7 @@ export function normalizeThread(raw) {
     updatedAt,
     ts: updatedAt,
     msgs,
+    deletedMessages,
     pinned: raw.pinned === true,
     title: typeof raw.title === "string" ? raw.title.slice(0, 160) : undefined,
     workflowKey: typeof raw.workflowKey === "string" ? raw.workflowKey : "panel:global",
@@ -64,6 +163,7 @@ export function selectThreadForScope(threads, meta, scopeKey) {
     .filter((thread) => isThreadInScope(thread, scopeKey))
     .sort((a, b) => finiteTs(b.updatedAt || b.ts) - finiteTs(a.updatedAt || a.ts));
   const activeId = meta?.activeByScope?.[scopeKey];
+  if (!activeId && meta?.activeOps?.[scopeKey]?.deleted === true) return null;
   return candidates.find((thread) => thread.id === activeId) || candidates[0] || null;
 }
 
@@ -75,6 +175,7 @@ export function selectPanelThread(threads, meta) {
   const candidates = [...(Array.isArray(threads) ? threads : [])]
     .sort((a, b) => finiteTs(b?.updatedAt || b?.ts) - finiteTs(a?.updatedAt || a?.ts));
   const activeId = meta?.activeByScope?.["panel:global"];
+  if (!activeId && meta?.activeOps?.["panel:global"]?.deleted === true) return null;
   return candidates.find((thread) => thread?.id === activeId) || candidates[0] || null;
 }
 
@@ -155,6 +256,9 @@ function mergeThreadMessages(older, newer) {
 export function mergeHistorySnapshots(...snapshots) {
   const byId = new Map();
   let meta = {};
+  let activeOps = {};
+  let aliasOps = {};
+  let deletedThreads = {};
   let metaUpdatedAt = 0;
   let snapshotUpdatedAt = 0;
   for (const snap of snapshots) {
@@ -168,19 +272,16 @@ export function mergeHistorySnapshots(...snapshots) {
       meta = {
         ...older,
         ...newer,
-        activeByScope: {
-          ...(older.activeByScope && typeof older.activeByScope === "object" ? older.activeByScope : {}),
-          ...(newer.activeByScope && typeof newer.activeByScope === "object" ? newer.activeByScope : {}),
-        },
-        // Aliases are additive; a newer path entry naturally wins on collision.
-        workflowAliases: {
-          ...(older.workflowAliases && typeof older.workflowAliases === "object" ? older.workflowAliases : {}),
-          ...(newer.workflowAliases && typeof newer.workflowAliases === "object" ? newer.workflowAliases : {}),
-        },
-        deletedThreads: {
-          ...mergeTimestampMaps(older.deletedThreads, newer.deletedThreads),
-        },
       };
+      activeOps = mergeMetadataOperationMaps(
+        activeOps,
+        normalizeMetadataOperations(snap.meta.activeOps, snap.meta.activeByScope, incomingUpdatedAt),
+      );
+      aliasOps = mergeMetadataOperationMaps(
+        aliasOps,
+        normalizeMetadataOperations(snap.meta.aliasOps, snap.meta.workflowAliases, incomingUpdatedAt),
+      );
+      deletedThreads = mergeTimestampMaps(deletedThreads, snap.meta.deletedThreads);
       metaUpdatedAt = Math.max(metaUpdatedAt, incomingUpdatedAt);
     }
     for (const candidate of Array.isArray(snap.threads) ? snap.threads : []) {
@@ -201,13 +302,17 @@ export function mergeHistorySnapshots(...snapshots) {
       // metadata already present in the older snapshot.
       if (newer === next && !Object.hasOwn(candidate, "workflowKey")) delete overlay.workflowKey;
       if (newer === next && !Object.hasOwn(candidate, "pinned")) delete overlay.pinned;
-      byId.set(next.id, { ...older, ...overlay, msgs: mergeThreadMessages(older, newer) });
+      const deletedMessages = mergeTimestampMaps(older.deletedMessages, newer.deletedMessages);
+      const msgs = mergeThreadMessages(older, newer)
+        .filter(
+          (message) =>
+            !(typeof message?.id === "string" && Object.hasOwn(deletedMessages, message.id)),
+        );
+      byId.set(next.id, { ...older, ...overlay, msgs, deletedMessages });
     }
   }
-  const deletedThreads =
-    meta.deletedThreads && typeof meta.deletedThreads === "object" ? meta.deletedThreads : {};
   const threads = [...byId.values()]
-    .filter((thread) => finiteTs(deletedThreads[thread.id]) < finiteTs(thread.updatedAt || thread.ts))
+    .filter((thread) => !Object.hasOwn(deletedThreads, thread.id))
     .sort((a, b) => finiteTs(a.updatedAt) - finiteTs(b.updatedAt));
   const newestThreadAt = threads.reduce((max, thread) => Math.max(max, finiteTs(thread.updatedAt)), 0);
   return {
@@ -219,12 +324,31 @@ export function mergeHistorySnapshots(...snapshots) {
       workflowAliases: {},
       deletedThreads: {},
       ...meta,
-      activeByScope:
-        meta.activeByScope && typeof meta.activeByScope === "object" ? meta.activeByScope : {},
-      workflowAliases:
-        meta.workflowAliases && typeof meta.workflowAliases === "object" ? meta.workflowAliases : {},
+      updatedAt: metaUpdatedAt,
+      activeOps,
+      aliasOps,
+      activeByScope: materializeMetadataOperations(activeOps),
+      workflowAliases: materializeMetadataOperations(aliasOps),
       deletedThreads,
     },
+  };
+}
+
+function boundedSnapshot(snapshot, { maxThreads, maxMessages, protectedThreadIds = [] }) {
+  const activeThreadIds = Object.values(snapshot?.meta?.activeByScope || {})
+    .filter((id) => typeof id === "string" && id);
+  const boundedThreads = retainBoundedThreads(
+    snapshot?.threads,
+    maxThreads,
+    [...protectedThreadIds, ...activeThreadIds],
+  );
+  const messageLimit = Math.max(0, Math.floor(Number(maxMessages) || 0));
+  return {
+    ...snapshot,
+    threads: boundedThreads.map((thread) => ({
+      ...thread,
+      msgs: messageLimit ? thread.msgs.slice(-messageLimit) : [],
+    })),
   };
 }
 
@@ -232,10 +356,21 @@ function openDb(indexedDb) {
   if (!indexedDb || typeof indexedDb.open !== "function") return Promise.resolve(null);
   return new Promise((resolve) => {
     let request;
+    let settled = false;
+    let timeout = null;
+    const finish = (db) => {
+      if (settled) {
+        db?.close?.();
+        return;
+      }
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      resolve(db);
+    };
     try {
       request = indexedDb.open(CHAT_HISTORY_DB, CHAT_HISTORY_SCHEMA);
     } catch {
-      resolve(null);
+      finish(null);
       return;
     }
     // The schema number is also the IndexedDB version: every future bump fires
@@ -245,9 +380,13 @@ function openDb(indexedDb) {
       const db = request.result;
       if (!db.objectStoreNames.contains("snapshots")) db.createObjectStore("snapshots");
     };
-    request.onsuccess = () => resolve(request.result);
-    request.onerror = () => resolve(null);
-    request.onblocked = () => resolve(null);
+    request.onsuccess = () => finish(request.result);
+    request.onerror = () => finish(null);
+    // A blocked upgrade may still succeed after another tab closes its older
+    // connection. Keep waiting; if it outlives the bound below, late success is
+    // closed by finish() instead of leaking an unowned IDBDatabase.
+    request.onblocked = () => {};
+    timeout = setTimeout(() => finish(null), IDB_OPEN_TIMEOUT_MS);
   });
 }
 
@@ -266,7 +405,7 @@ async function idbRead(indexedDb) {
   }
 }
 
-async function idbMergeWrite(indexedDb, snapshot) {
+async function idbMergeWrite(indexedDb, snapshot, limits) {
   const db = await openDb(indexedDb);
   if (!db) return null;
   try {
@@ -274,12 +413,12 @@ async function idbMergeWrite(indexedDb, snapshot) {
       const tx = db.transaction("snapshots", "readwrite");
       const store = tx.objectStore("snapshots");
       const get = store.get(CHAT_HISTORY_STATE_KEY);
-      let merged = snapshot;
+      let merged = boundedSnapshot(snapshot, limits);
       get.onsuccess = () => {
-        merged = mergeHistorySnapshots(get.result, snapshot);
+        merged = boundedSnapshot(mergeHistorySnapshots(get.result, snapshot), limits);
         store.put(merged, CHAT_HISTORY_STATE_KEY);
       };
-      get.onerror = () => store.put(snapshot, CHAT_HISTORY_STATE_KEY);
+      get.onerror = () => store.put(merged, CHAT_HISTORY_STATE_KEY);
       tx.oncomplete = () => resolve(merged);
       tx.onerror = () => resolve(null);
       tx.onabort = () => resolve(null);
@@ -295,14 +434,35 @@ export class ChatHistoryStore {
     this.indexedDb = options.indexedDb ?? globalThis.indexedDB;
     this.threadsKey = options.threadsKey ?? DEFAULT_THREADS_KEY;
     this.metaKey = options.metaKey ?? DEFAULT_META_KEY;
+    this.snapshotKey = options.snapshotKey ?? CHAT_HISTORY_LOCAL_SNAPSHOT_KEY;
+    this.maxThreads = options.maxThreads ?? DEFAULT_MAX_THREADS;
+    this.maxMessages = options.maxMessages ?? DEFAULT_MAX_MESSAGES;
     this._writePromise = Promise.resolve(null);
     this._lastCommitted = null;
   }
 
   readLocal() {
+    const readJson = (key, fallback) => {
+      try {
+        const raw = this.storage?.getItem(key);
+        return raw == null ? fallback : JSON.parse(raw);
+      } catch {
+        return fallback;
+      }
+    };
+    const atomic = readJson(this.snapshotKey, null);
+    if (
+      atomic &&
+      typeof atomic === "object" &&
+      (Array.isArray(atomic.threads) || (atomic.meta && typeof atomic.meta === "object"))
+    ) {
+      return mergeHistorySnapshots(atomic);
+    }
+    // Migrate legacy two-key shadows defensively: one corrupt half must not
+    // discard the other valid half.
+    const threads = readJson(this.threadsKey, []);
+    const meta = readJson(this.metaKey, {});
     try {
-      const threads = JSON.parse(this.storage?.getItem(this.threadsKey) ?? "[]");
-      const meta = JSON.parse(this.storage?.getItem(this.metaKey) ?? "{}");
       return mergeHistorySnapshots({ threads: Array.isArray(threads) ? threads : [], meta });
     } catch {
       return mergeHistorySnapshots({ threads: [], meta: {} });
@@ -321,28 +481,50 @@ export class ChatHistoryStore {
 
   persist(threads, meta = {}, options = {}) {
     const snapshot = mergeHistorySnapshots({ threads, meta });
+    const protectedThreadIds = [
+      ...(Array.isArray(options.protectedThreadIds) ? options.protectedThreadIds : []),
+      ...Object.values(snapshot.meta.activeByScope || {}),
+    ];
+    const limits = {
+      maxThreads: options.maxThreads ?? this.maxThreads,
+      maxMessages: options.maxMessages ?? this.maxMessages,
+      protectedThreadIds,
+    };
+    const shadow = retainBoundedThreads(
+      snapshot.threads,
+      LOCAL_SHADOW_THREADS,
+      protectedThreadIds,
+    )
+      .map((thread) => ({ ...thread, msgs: thread.msgs.slice(-LOCAL_SHADOW_MESSAGES) }));
+    const localSnapshot = { ...snapshot, threads: shadow };
+    let atomicWritten = false;
     try {
-      const protectedThreadIds = [
-        ...(Array.isArray(options.protectedThreadIds) ? options.protectedThreadIds : []),
-        ...Object.values(snapshot.meta.activeByScope || {}),
-      ];
-      const shadow = retainBoundedThreads(
-        snapshot.threads,
-        LOCAL_SHADOW_THREADS,
-        protectedThreadIds,
-      )
-        .map((t) => ({ ...t, msgs: t.msgs.slice(-LOCAL_SHADOW_MESSAGES) }));
-      this.storage?.setItem(this.threadsKey, JSON.stringify(shadow));
-      this.storage?.setItem(this.metaKey, JSON.stringify(snapshot.meta));
+      this.storage?.setItem(this.snapshotKey, JSON.stringify(localSnapshot));
+      atomicWritten = true;
     } catch {
       // IndexedDB remains canonical when localStorage is unavailable or full.
+    }
+    if (atomicWritten) {
+      // Keep the pre-v2 keys as best-effort compatibility mirrors. Current code
+      // always reads the atomic snapshot first, so a partial legacy write cannot
+      // create a mixed generation for this implementation.
+      try {
+        this.storage?.setItem(this.threadsKey, JSON.stringify(shadow));
+      } catch {
+        // The atomic shadow is already committed.
+      }
+      try {
+        this.storage?.setItem(this.metaKey, JSON.stringify(snapshot.meta));
+      } catch {
+        // The atomic shadow is already committed.
+      }
     }
     // Start the atomic merge immediately. Chat records are low-frequency and a
     // debounce creates an avoidable shutdown window in which the local shadow
     // exists but IndexedDB has not started its transaction yet.
     this._writePromise = this._writePromise
       .catch(() => null)
-      .then(() => idbMergeWrite(this.indexedDb, snapshot))
+      .then(() => idbMergeWrite(this.indexedDb, snapshot, limits))
       .then((merged) => {
         if (merged) this._lastCommitted = merged;
         return merged;
@@ -356,7 +538,11 @@ export class ChatHistoryStore {
   subscribe(listener, eventTarget = globalThis) {
     if (!eventTarget?.addEventListener || typeof listener !== "function") return () => {};
     const onStorage = (event) => {
-      if (event?.key !== this.threadsKey && event?.key !== this.metaKey) return;
+      if (
+        event?.key !== this.snapshotKey &&
+        event?.key !== this.threadsKey &&
+        event?.key !== this.metaKey
+      ) return;
       listener(this.readLocal());
     };
     eventTarget.addEventListener("storage", onStorage);

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -78,6 +78,23 @@ export function selectPanelThread(threads, meta) {
   return candidates.find((thread) => thread?.id === activeId) || candidates[0] || null;
 }
 
+/** Choose the durable conversation for reload without replacing a conversation
+ * already selected by this browser tab. In per-workflow mode that preferred
+ * pointer is still subject to the strict workflow scope guard. */
+export function selectRestoreThread(
+  threads,
+  meta,
+  { panelOwned = true, scopeKey = null, preferredThreadId = null } = {},
+) {
+  const preferred = preferredThreadId
+    ? (Array.isArray(threads) ? threads : []).find((candidate) => candidate?.id === preferredThreadId)
+    : null;
+  if (preferred && (panelOwned || isThreadInScope(preferred, scopeKey))) return preferred;
+  return panelOwned
+    ? selectPanelThread(threads, meta)
+    : selectThreadForScope(threads, meta, scopeKey);
+}
+
 function mergeThreadMessages(older, newer) {
   const oldMessages = Array.isArray(older?.msgs) ? older.msgs : [];
   const newMessages = Array.isArray(newer?.msgs) ? newer.msgs : [];
@@ -189,6 +206,9 @@ function openDb(indexedDb) {
       resolve(null);
       return;
     }
+    // The schema number is also the IndexedDB version: every future bump fires
+    // this callback. Structural store/index migrations belong here; record-shape
+    // migration remains app-layer normalization in mergeHistorySnapshots().
     request.onupgradeneeded = () => {
       const db = request.result;
       if (!db.objectStoreNames.contains("snapshots")) db.createObjectStore("snapshots");

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -21,6 +21,7 @@ const IDB_OPEN_TIMEOUT_MS = 2000;
 const DEFAULT_MAX_TOMBSTONES = 512;
 const DEFAULT_MAX_METADATA_OPS = 512;
 const BROADCAST_CHANNEL_NAME = "comfyui-mcp-panel-history-v3";
+const LEGACY_IDLESS_SOURCE = Symbol("legacy-idless-source");
 const THREAD_FIELDS = [
   "sessionId",
   "todos",
@@ -40,6 +41,12 @@ function finiteTs(value) {
 
 function cloneJson(value) {
   return JSON.parse(JSON.stringify(value));
+}
+
+function hasIdlessMessages(threads) {
+  return (Array.isArray(threads) ? threads : []).some((thread) =>
+    (Array.isArray(thread?.msgs) ? thread.msgs : []).some((message) =>
+      !message || typeof message.id !== "string" || !message.id));
 }
 
 function canonicalJson(value) {
@@ -701,9 +708,31 @@ function withoutCheckpoint(snapshot) {
  * existed at that generation. Newer causal operations still pass the normal
  * post-checkpoint filters. */
 function mergeUnderCanonicalCheckpoint(canonical, ...untrusted) {
+  const canonicalFenced = Number(canonical?.schemaVersion) >= CHAT_HISTORY_SCHEMA &&
+    !hasIdlessMessages(canonical?.threads);
+  const accepted = untrusted.filter((snapshot) =>
+    !(canonicalFenced && snapshot?.[LEGACY_IDLESS_SOURCE] === true));
+  let canonicalBaseline = canonical && typeof canonical === "object" ? canonical : null;
+  if (!canonicalFenced) {
+    // Before the one-way schema-3 fence, a pre-v3 tab writes a complete thread.
+    // Replace matching legacy threads as a unit; UUID-unioning independently
+    // hashed positions/content would duplicate shifted or edited messages.
+    const legacyThreadIds = new Set(accepted
+      .filter((snapshot) => snapshot?.[LEGACY_IDLESS_SOURCE] === true)
+      .flatMap((snapshot) => (Array.isArray(snapshot?.threads) ? snapshot.threads : []))
+      .map((thread) => thread?.id)
+      .filter(Boolean));
+    if (canonicalBaseline && legacyThreadIds.size) {
+      canonicalBaseline = {
+        ...canonicalBaseline,
+        threads: (Array.isArray(canonicalBaseline.threads) ? canonicalBaseline.threads : [])
+          .filter((thread) => !legacyThreadIds.has(thread?.id)),
+      };
+    }
+  }
   return mergeHistorySnapshots(
-    canonical && typeof canonical === "object" ? canonical : null,
-    ...untrusted.map(withoutCheckpoint),
+    canonicalBaseline,
+    ...accepted.map(withoutCheckpoint),
   );
 }
 
@@ -936,7 +965,9 @@ export class ChatHistoryStore {
       : legacyMeta;
     try {
       const local = { threads: Array.isArray(threads) ? threads : [], meta };
-      return mergeHistorySnapshots(quarantineCheckpoint ? withoutCheckpoint(local) : local);
+      const normalized = mergeHistorySnapshots(quarantineCheckpoint ? withoutCheckpoint(local) : local);
+      if (hasIdlessMessages(local.threads)) normalized[LEGACY_IDLESS_SOURCE] = true;
+      return normalized;
     } catch {
       return mergeHistorySnapshots({ threads: [], meta: {} });
     }
@@ -995,6 +1026,7 @@ export class ChatHistoryStore {
 
   persist(threads, meta = {}, options = {}) {
     const freshSnapshot = mergeHistorySnapshots({ threads, meta });
+    if (hasIdlessMessages(threads)) freshSnapshot[LEGACY_IDLESS_SOURCE] = true;
     const snapshot = this._dirtyWrite
       ? mergeHistorySnapshots(this._dirtyWrite.snapshot, freshSnapshot)
       : freshSnapshot;
@@ -1061,7 +1093,9 @@ export class ChatHistoryStore {
         event?.key !== this.threadsKey &&
         event?.key !== this.metaKey
       ) return;
-      listener(this.readLocal());
+      // Resolve through canonical IDB first so quarantined pre-v3 shadows never
+      // transiently remount in another live panel.
+      void this.readCanonical().then(listener);
     };
     const onBroadcast = (event) => {
       if (event?.data?.type !== "history-changed" || event.data.writerId === this.writerId) return;

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -28,52 +28,71 @@ function cloneJson(value) {
   return JSON.parse(JSON.stringify(value));
 }
 
+function safeMap() {
+  return Object.create(null);
+}
+
 function mergeTimestampMaps(...maps) {
-  const merged = {};
+  const merged = safeMap();
   for (const map of maps) {
-    if (!map || typeof map !== "object") continue;
+    if (!map || typeof map !== "object" || Array.isArray(map)) continue;
     for (const [key, value] of Object.entries(map)) {
-      merged[key] = Math.max(finiteTs(merged[key]), finiteTs(value));
+      const revision = finiteTs(value);
+      if (typeof key !== "string" || !key || !revision) continue;
+      merged[key] = Math.max(finiteTs(merged[key]), revision);
     }
   }
   return merged;
 }
 
 function normalizeMetadataOperation(operation, fallbackValue, fallbackUpdatedAt) {
-  if (operation && typeof operation === "object") {
-    const deleted = operation.deleted === true || operation.value == null;
+  if (operation && typeof operation === "object" && !Array.isArray(operation)) {
+    const updatedAt = finiteTs(operation.updatedAt);
+    const deleted = operation.deleted;
+    const coherent =
+      deleted === true
+        ? operation.value == null
+        : deleted === false && operation.value != null;
+    if (!updatedAt || !coherent) return null;
     return {
-      value: deleted ? null : operation.value,
+      value: deleted ? null : cloneJson(operation.value),
       deleted,
-      updatedAt: finiteTs(operation.updatedAt) || finiteTs(fallbackUpdatedAt),
+      updatedAt,
     };
   }
+  const updatedAt = finiteTs(fallbackUpdatedAt);
+  if (!updatedAt || fallbackValue == null) return null;
   return {
-    value: fallbackValue,
+    value: cloneJson(fallbackValue),
     deleted: false,
-    updatedAt: finiteTs(fallbackUpdatedAt),
+    updatedAt,
   };
 }
 
 function normalizeMetadataOperations(operations, values, fallbackUpdatedAt) {
-  const normalized = {};
-  if (operations && typeof operations === "object") {
+  const normalized = safeMap();
+  const seen = new Set();
+  if (operations && typeof operations === "object" && !Array.isArray(operations)) {
     for (const [key, operation] of Object.entries(operations)) {
-      normalized[key] = normalizeMetadataOperation(operation, null, fallbackUpdatedAt);
+      if (typeof key !== "string" || !key) continue;
+      seen.add(key);
+      const valid = normalizeMetadataOperation(operation, null, fallbackUpdatedAt);
+      if (valid) normalized[key] = valid;
     }
   }
-  if (values && typeof values === "object") {
+  if (values && typeof values === "object" && !Array.isArray(values)) {
     for (const [key, value] of Object.entries(values)) {
-      if (!Object.hasOwn(normalized, key)) {
-        normalized[key] = normalizeMetadataOperation(null, value, fallbackUpdatedAt);
-      }
+      if (typeof key !== "string" || !key || seen.has(key)) continue;
+      const valid = normalizeMetadataOperation(null, value, fallbackUpdatedAt);
+      if (valid) normalized[key] = valid;
     }
   }
   return normalized;
 }
 
 function mergeMetadataOperationMaps(current, incoming) {
-  const merged = { ...(current && typeof current === "object" ? current : {}) };
+  const merged = safeMap();
+  for (const [key, operation] of Object.entries(current || {})) merged[key] = operation;
   for (const [key, operation] of Object.entries(incoming || {})) {
     const previous = merged[key];
     const previousAt = finiteTs(previous?.updatedAt);
@@ -92,7 +111,7 @@ function mergeMetadataOperationMaps(current, incoming) {
 }
 
 function materializeMetadataOperations(operations) {
-  const values = {};
+  const values = safeMap();
   for (const [key, operation] of Object.entries(operations || {})) {
     if (operation?.deleted !== true && operation?.value != null) values[key] = operation.value;
   }
@@ -108,9 +127,10 @@ export function updateMetadataEntry(meta, mapName, key, value, updatedAt = Date.
       : null;
   if (!opsName || typeof key !== "string" || !key) return meta;
   const revision = finiteTs(updatedAt) || Date.now();
-  const values = {
-    ...(meta?.[mapName] && typeof meta[mapName] === "object" ? meta[mapName] : {}),
-  };
+  const values = safeMap();
+  for (const [existingKey, existingValue] of Object.entries(meta?.[mapName] || {})) {
+    values[existingKey] = existingValue;
+  }
   const deleted = value == null;
   if (deleted) delete values[key];
   else values[key] = value;
@@ -118,10 +138,9 @@ export function updateMetadataEntry(meta, mapName, key, value, updatedAt = Date.
     ...(meta && typeof meta === "object" ? meta : {}),
     updatedAt: Math.max(finiteTs(meta?.updatedAt), revision),
     [mapName]: values,
-    [opsName]: {
-      ...(meta?.[opsName] && typeof meta[opsName] === "object" ? meta[opsName] : {}),
+    [opsName]: Object.assign(safeMap(), meta?.[opsName] || {}, {
       [key]: { value: deleted ? null : value, deleted, updatedAt: revision },
-    },
+    }),
   };
 }
 
@@ -275,11 +294,11 @@ export function mergeHistorySnapshots(...snapshots) {
       };
       activeOps = mergeMetadataOperationMaps(
         activeOps,
-        normalizeMetadataOperations(snap.meta.activeOps, snap.meta.activeByScope, incomingUpdatedAt),
+        normalizeMetadataOperations(snap.meta.activeOps, snap.meta.activeByScope, incomingUpdatedAt || 1),
       );
       aliasOps = mergeMetadataOperationMaps(
         aliasOps,
-        normalizeMetadataOperations(snap.meta.aliasOps, snap.meta.workflowAliases, incomingUpdatedAt),
+        normalizeMetadataOperations(snap.meta.aliasOps, snap.meta.workflowAliases, incomingUpdatedAt || 1),
       );
       deletedThreads = mergeTimestampMaps(deletedThreads, snap.meta.deletedThreads);
       metaUpdatedAt = Math.max(metaUpdatedAt, incomingUpdatedAt);


### PR DESCRIPTION
## Summary

Make Agent Panel transcripts survive full ComfyUI/browser restarts by moving canonical chat storage to IndexedDB while retaining a bounded localStorage startup/fallback shadow.

This is PR 2 of the focused series requested in #98. It is rebased on current `main` (`add9920`, Agent Panel 0.11.0), contains the merged workflow identity foundation from #101, and composes with the current tabbed side-panel UI.

Archive UX and optional server backup remain separate follow-up PRs.

## What changed

- Added a pure `ChatHistoryStore` library with schema-v3 normalization and a fenced one-way legacy-message migration.
- IndexedDB is the canonical atomic snapshot store.
- A bounded localStorage shadow provides synchronous startup, fallback, and migration from existing installs.
- Concurrent thread and message updates merge with observed monotonic causal revisions.
- Mutable session, TODO, provenance, title/pin, and card state have independent revisions, so stale appends cannot roll them back.
- Causal message and thread tombstones prevent stale tabs from resurrecting deleted content.
- Canonical post-merge limits are 500 conversations and 5,000 messages per conversation.
- Tombstone and metadata operation maps are bounded through canonical checkpoints.
- Committed history synchronizes across tabs, with BroadcastChannel invalidation when the localStorage shadow cannot be written.
- Dirty history is retained and retried when both persistence backends fail.
- Reload restores the active panel-owned conversation without switching to a newer background conversation.
- Per-workflow mode keeps exact UUID-only selection and clears transcript, TODO, and session state after strict scope rejection.
- Workflow alias set/delete operations publish immediately and survive stale-tab rename and compaction cases.
- Backend switch and hard restart durably invalidate the previous agent session before reconnect.
- Canonical and shadow eviction preserve the current tab's active thread.
- Synchronous reload restore remains paint-only until settings and IndexedDB hydrate.
- Initial hello/connect waits for final settings-aware thread and session binding.
- Pending persistence flushes on visibility and page lifecycle boundaries.
- The history popover explains where transcripts persist and provides a confirmed **Clear all history** action.

## Clear-all semantics

Clear All performs an atomic canonical reset rather than a bare `indexedDB.deleteDatabase()`:

1. Re-read and merge the latest canonical state inside one IndexedDB `readwrite` transaction.
2. Write an empty transcript checkpoint with an incremented generation.
3. Preserve materialized `workflowAliases`, because stable workflow identity is metadata rather than chat content.
4. Clear transcripts, active chat pointers, chat tombstones, and operation maps.
5. Write an empty localStorage shadow.
6. Broadcast a reset invalidation so other open ComfyUI tabs reload the canonical checkpoint.

Each affected tab also clears visible transcript, TODO, and session state and sends `new_session`, so backend memory cannot continue a conversation the user deleted.

If the canonical IndexedDB transaction cannot commit, the action fails closed and leaves the shadow untouched. It does not briefly claim success and then rehydrate old history on reload.

A plain database deletion would erase workflow UUID aliases and allow a still-open stale tab to recreate the database and republish deleted transcripts. The checkpoint reset prevents both failure modes.

## Complexity decision

The merge/checkpoint implementation is intentionally retained for PR 2.

Replacing it with per-thread last-write-wins would be a semantic redesign rather than a mechanical simplification. It would remove the reviewed guarantees for:

- concurrent messages in the same thread;
- durable deletes;
- independently revised mutable fields;
- backward clocks;
- bounded compaction;
- stale-tab fencing.

Those guarantees match #98's durable and correctly scoped multi-tab history requirement and now have deterministic regressions.

The implementation surface is substantial, so this is a conscious tradeoff. A later behavior-preserving extraction or startup-write optimization can be reviewed separately after the storage semantics land. The existing startup `load()` migration write is unchanged in this PR.

## Storage bounds

| Store | Limit |
|---|---:|
| Canonical IndexedDB history | 500 conversations |
| Canonical transcript | 5,000 messages per conversation |
| localStorage startup shadow | 20 conversations / 200 messages each |
| Tombstone and metadata operation maps | Bounded through canonical checkpoints |

## Invariants retained from PR 1

- Workflow UUID is a transcript scope key, not a bridge routing key.
- Bridge `wf:` / `tmp:` routing and the orchestrator rebind path are unchanged.
- Default panel-owned mode remains compatible with pre-upgrade threads and keeps ride-along workflow provenance.
- Strict exact-match scope selection is active only in per-workflow mode.
- Opening a workflow does not dirty it.
- Clearing chat history does not remove workflow UUID identity.

## Scope

This PR intentionally does not add archive search/pin/export controls, workflow snapshot hydration, or Python backup routes. Those remain PR 3 and PR 4.

## Validation

Rebased HEAD: `d5f56d1`

- `npm run test:unit` — **139/139 passed**.
- `npm run typecheck` — passed.
- `node --check` for both reviewed modules — passed.
- `git diff --check` — passed.
- `npm audit --omit=dev` — **0 vulnerabilities**.
- `conversation-persistence.spec.ts` — **7/7 passed** against live ComfyUI at `127.0.0.1:8188` with one Chromium worker.
- GitHub Actions lint/security run `29992435822` — passed.

The new browser case covers the complete destructive path: confirmation UI and persistence note, atomic IndexedDB empty state, local tab/session reset, preserved workflow alias, reload persistence, and rejection of a stale tab's attempt to republish the pre-clear snapshot.

The rest of the browser suite covers full restart, IndexedDB-only recovery, pointed-thread/session hydration, strict workflow detachment, individual-delete resurrection, and alias rename/compaction echo prevention.

Part of #98.
