### PR TITLE
fix(ui): crop, centre and whiten the header wordmark

### DIFF
--- a/web/img/comfyui-mcp-wordmark.svg
+++ b/web/img/comfyui-mcp-wordmark.svg
@@ -1,6 +1,8 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 236 40" role="img" aria-label="comfyui-mcp">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 4 156 32" role="img" aria-label="comfyui-mcp">
   <rect x="2" y="6" width="28" height="28" rx="7" fill="#3B82F6"/>
-  <g fill="none" stroke="#0b1220" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Mark translated (-1,-1): its geometric centre is (17,21) but the tile's is
+       (16,20), so untranslated it sits low and right inside the tile. -->
+  <g transform="translate(-1 -1)" fill="none" stroke="#ffffff" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
     <circle cx="12" cy="16" r="3"/>
     <circle cx="22" cy="26" r="3"/>
     <path d="M15 16h3.5a3 3 0 0 1 3 3v3.5"/>

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7338,7 +7338,7 @@ const PANEL_CSS = `
   padding: 0.75rem 1rem;
   border-bottom: 1px solid var(--p-content-border-color, #3f3f46);
 }
-/* The wordmark is ~5.9:1, so pin the HEIGHT and let width follow — the old
+/* The wordmark is ~4.9:1, so pin the HEIGHT and let width follow — the old
    square 20x20 rule would squash it. max-width keeps it from crowding the
    header actions on a narrow sidebar. */
 .cmcp-logo { height: 20px; width: auto; max-width: 148px; flex: none; object-fit: contain; display: block; }


### PR DESCRIPTION
Three defects in the asset shipped by #105 — all caught on sight, all confirmed by measuring rather than eyeballing (`getBBox` in a browser):

| # | defect | measured | fix |
|---|---|---|---|
| 1 | **trailing whitespace** | viewBox 236 wide, content ends at **x=152.7** → 35% empty; 12 of 40 vertical units empty too | crop to `0 4 156 32` |
| 2 | **mark not centred** | mark centre **(17,21)** vs tile centre **(16,20)** — sat low and right | `translate(-1 -1)` |
| 3 | **mark was black** | docs source strokes `#0b1220` | `#ffffff` |

**Why (1) mattered:** the header pins *height*, so that dead space shrank the visible glyph. Aspect goes 5.9:1 → **4.9:1**, so the same 20px slot renders a noticeably bigger logo (~98px wide instead of ~148px of mostly air).

**Why (3) happened:** I lifted `docs/logo/dark.svg` verbatim. That file is built for the docs page, where the near-black mark works — but on the blue tile at 20px it reads as a smudge, and it's inconsistent with every other surface (favicon, registry icon, app icons all use a **white** mark). Should have caught that when I copied it.

Also updates the `.cmcp-logo` comment's aspect ratio to match the new crop.