### PR TITLE
fix(panel): uncrowd the composer; make the base-model filter complete and searchable

### DIFF
--- a/browser_tests/unit/civitai-base-models.test.mjs
+++ b/browser_tests/unit/civitai-base-models.test.mjs
@@ -7,7 +7,11 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { BASE_MODELS, ACTIVE_BASE_MODELS } from "../../web/js/cmcp-civitai.js";
+import {
+  BASE_MODELS, ACTIVE_BASE_MODELS, tokenizeQuery, matchesBaseModel,
+} from "../../web/js/cmcp-civitai.js";
+
+const search = (q) => BASE_MODELS.filter((m) => matchesBaseModel(m, tokenizeQuery(q)));
 
 test("base model list has no duplicates", () => {
   const dupes = BASE_MODELS.filter((x, i) => BASE_MODELS.indexOf(x) !== i);
@@ -45,6 +49,33 @@ test("retired families are kept but classed as legacy", () => {
     assert.ok(BASE_MODELS.includes(m), `${m} should still be selectable`);
     assert.ok(!ACTIVE_BASE_MODELS.has(m), `${m} should be grouped as legacy`);
   }
+});
+
+test("the searches people actually type reach the right model", () => {
+  // Every one of these returned ZERO results under plain substring matching —
+  // caught in the live panel, not in review. Civitai's punctuation ("Flux.2 D")
+  // and interposed words ("Wan Video 2.5 T2V") defeat `includes`.
+  assert.ok(search("flux 2").includes("Flux.2 D"), '"flux 2" should find Flux.2 D');
+  assert.ok(search("wan 2.5").includes("Wan Video 2.5 T2V"), '"wan 2.5" should find Wan Video 2.5 T2V');
+  assert.ok(search("wan 2.5").includes("Wan Video 2.5 I2V"), '"wan 2.5" should find both 2.5 variants');
+  assert.ok(search("flux 2 klein").includes("Flux.2 Klein 9B"), "multi-token should narrow, not break");
+  assert.ok(search("zimage").includes("ZImageTurbo"), "prefix match should reach ZImageTurbo");
+  assert.ok(search("sd 3.5").includes("SD 3.5 Large"), '"sd 3.5" should find the 3.5 family');
+  assert.ok(search("ltx 2.3").includes("LTXV 2.3"), '"ltx 2.3" should find LTXV 2.3');
+});
+
+test("matching stays ordered, so a query cannot match the wrong version", () => {
+  // The failure mode of loosening the matcher: "flux 2" quietly matching
+  // Flux.1, which would send someone to the wrong model entirely.
+  assert.ok(!search("flux 2").includes("Flux.1 D"), '"flux 2" must NOT match Flux.1 D');
+  assert.ok(!search("sd 3.5").includes("SD 3"), '"sd 3.5" must NOT match bare SD 3');
+  assert.ok(!matchesBaseModel("Flux.2 D", tokenizeQuery("d flux")), "order must be respected");
+});
+
+test("an empty query matches everything, a nonsense one matches nothing", () => {
+  assert.equal(search("").length, BASE_MODELS.length);
+  assert.equal(search("   ").length, BASE_MODELS.length);
+  assert.deepEqual(search("zzzznotamodel"), []);
 });
 
 test("no entry has stray whitespace that would break the query string", () => {

--- a/browser_tests/unit/civitai-base-models.test.mjs
+++ b/browser_tests/unit/civitai-base-models.test.mjs
@@ -1,0 +1,55 @@
+// Unit tests for the base-model filter vocabulary (cmcp-civitai.js).
+//
+// Civitai accepts ONLY its own `BaseModel` enum strings for `baseModels=`; an
+// unknown value returns nothing rather than erroring, so a typo or an omission
+// fails SILENTLY — the model simply appears not to exist in the browser. That
+// makes this list worth asserting on directly.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { BASE_MODELS, ACTIVE_BASE_MODELS } from "../../web/js/cmcp-civitai.js";
+
+test("base model list has no duplicates", () => {
+  const dupes = BASE_MODELS.filter((x, i) => BASE_MODELS.indexOf(x) !== i);
+  assert.deepEqual(dupes, [], `duplicate base models: ${dupes.join(", ")}`);
+});
+
+test("every active base model is also in the full list", () => {
+  // The dropdown groups by this set; an entry missing from BASE_MODELS would
+  // be unreachable in the UI no matter how it is grouped.
+  const orphans = [...ACTIVE_BASE_MODELS].filter((x) => !BASE_MODELS.includes(x));
+  assert.deepEqual(orphans, [], `active but not listed: ${orphans.join(", ")}`);
+});
+
+test("the list covers the families Civitai is currently pushing", () => {
+  // These are exactly the ones the previous hardcoded list predated. Their
+  // absence is what made the filter feel broken: searching "flux 2" or
+  // "z-image" returned nothing at all.
+  const current = [
+    "Flux.2 D", "Flux.2 Klein 9B", "Flux.2 Klein 4B", "Flux.1 Krea",
+    "ZImageTurbo", "ZImageBase", "Krea 2", "LTXV 2.3", "LTXV2",
+    "Wan Video 2.5 T2V", "Wan Video 2.5 I2V", "Wan Video 2.7", "Wan Image 2.7",
+    "Qwen 2", "Pony V7", "Anima", "HiDream-O1", "Hunyuan 1",
+  ];
+  const missing = current.filter((x) => !BASE_MODELS.includes(x));
+  assert.deepEqual(missing, [], `missing current base models: ${missing.join(", ")}`);
+  for (const m of current) {
+    assert.ok(ACTIVE_BASE_MODELS.has(m), `${m} should be grouped as current, not legacy`);
+  }
+});
+
+test("retired families are kept but classed as legacy", () => {
+  // Kept, because old models still carry these tags and users filter for them
+  // deliberately; sunk, because they return next to nothing on a fresh feed.
+  for (const m of ["SD 2.0 768", "SVD", "SVD XT", "Playground v2", "SDXL 0.9"]) {
+    assert.ok(BASE_MODELS.includes(m), `${m} should still be selectable`);
+    assert.ok(!ACTIVE_BASE_MODELS.has(m), `${m} should be grouped as legacy`);
+  }
+});
+
+test("no entry has stray whitespace that would break the query string", () => {
+  for (const m of BASE_MODELS) {
+    assert.equal(m, m.trim(), `"${m}" has leading/trailing whitespace`);
+    assert.ok(m.length > 0, "empty base model entry");
+  }
+});

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -12,7 +12,8 @@
 
 import {
   CivitaiClient, DEFAULT_FILTERS, LEVELS, PERIODS, IMAGE_SORTS, MODEL_SORTS,
-  BASE_MODELS, ACTIVE_BASE_MODELS, filtersDirty, bitmask, parseCreatorQuery,
+  BASE_MODELS, ACTIVE_BASE_MODELS, tokenizeQuery, matchesBaseModel,
+  filtersDirty, bitmask, parseCreatorQuery,
 } from "./cmcp-civitai.js";
 
 const TABS = [
@@ -173,7 +174,7 @@ function injectCss() {
   .cmcp-cv-dd { position: relative; width: 100%; }
   .cmcp-cv-ddpanel { position: absolute; z-index: 6; left: 0; right: 0; top: calc(100% + .25rem);
     display: none; flex-direction: column; gap: .1rem; padding: .25rem;
-    max-height: 15rem; overflow-y: auto; border-radius: 8px;
+    max-height: min(20rem, 50vh); overflow-y: auto; border-radius: 8px;
     background: var(--p-surface-900,#18181b);
     border: 1px solid var(--p-content-border-color,#3f3f46);
     box-shadow: 0 8px 24px rgba(0,0,0,.45); }
@@ -188,6 +189,13 @@ function injectCss() {
   .cmcp-cv-ddopt.on .tick { opacity: 1; color: var(--p-primary-color,#3a7bd5); }
   .cmcp-cv-ddempty { padding: .4rem .5rem; font-size: .74rem;
     color: var(--p-text-muted-color,#a1a1aa); }
+  .cmcp-cv-ddfoot { position: sticky; bottom: -.25rem; display: flex; align-items: center;
+    justify-content: space-between; gap: .5rem; margin-top: .15rem; padding: .35rem .5rem;
+    font-size: .72rem; color: var(--p-text-muted-color,#a1a1aa);
+    background: var(--p-surface-900,#18181b);
+    border-top: 1px solid var(--p-content-border-color,#3f3f46); }
+  .cmcp-cv-ddclear { background: transparent; border: none; cursor: pointer; font-size: .72rem;
+    padding: 0; color: var(--p-primary-color,#3a7bd5); }
   .cmcp-cv-lb-prompt { font-size: .78rem; white-space: pre-wrap; word-break: break-word;
     background: var(--p-surface-950,#111); border-radius: 8px; padding: .5rem;
     max-height: 14rem; overflow-y: auto; }
@@ -1222,10 +1230,10 @@ export function openCivitaiModal(ctx, opts = {}) {
       };
 
       const renderOpts = () => {
-        const q = bmSearch.value.trim().toLowerCase();
+        const tokens = tokenizeQuery(bmSearch.value);
         bmPanel.innerHTML = "";
         bmOpts = [];
-        const hits = BASE_MODELS.filter((x) => !q || x.toLowerCase().includes(q));
+        const hits = BASE_MODELS.filter((x) => matchesBaseModel(x, tokens));
         const groups = [
           ["Current", hits.filter((x) => ACTIVE_BASE_MODELS.has(x))],
           ["Legacy", hits.filter((x) => !ACTIVE_BASE_MODELS.has(x))],
@@ -1251,6 +1259,24 @@ export function openCivitaiModal(ctx, opts = {}) {
         if (!bmOpts.length) {
           bmPanel.appendChild(el("div", "cmcp-cv-ddempty", `No base model matches “${bmSearch.value.trim()}”.`));
         }
+        // Selected-count + clear, matching what ComfyUI's own multi-select
+        // shows. With the list scrolled or filtered the chips above can be out
+        // of view, so without this there is no way to tell how many filters are
+        // live — or to drop them without hunting each one down.
+        if (f.baseModels.length) {
+          const foot = el("div", "cmcp-cv-ddfoot");
+          foot.appendChild(el("span", null,
+            `${f.baseModels.length} selected`));
+          const clear = el("button", "cmcp-cv-ddclear", "Clear");
+          clear.type = "button";
+          clear.addEventListener("mousedown", (e) => {
+            e.preventDefault();
+            f.baseModels.length = 0;
+            renderSheet(); update();
+          });
+          foot.appendChild(clear);
+          bmPanel.appendChild(foot);
+        }
         setActive(-1);
       };
       const openDd = () => {
@@ -1263,7 +1289,14 @@ export function openCivitaiModal(ctx, opts = {}) {
       bmSearch.addEventListener("input", () => { renderOpts(); dd.classList.add("open"); });
       bmSearch.addEventListener("blur", closeDd);
       bmSearch.addEventListener("keydown", (e) => {
-        if (e.key === "Escape") { closeDd(); return; }
+        if (e.key === "Escape") {
+          // Escape MUST stop here. The sheet is mounted inside ComfyUI's own
+          // document, so an un-stopped Escape closes the whole filter sheet
+          // (and reaches the canvas) — dismissing the dropdown would throw
+          // away the user's other filter edits with it.
+          if (dd.classList.contains("open")) { e.preventDefault(); e.stopPropagation(); closeDd(); }
+          return;
+        }
         if (e.key === "ArrowDown" || e.key === "ArrowUp") {
           e.preventDefault();
           if (!dd.classList.contains("open")) { openDd(); return; }

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -12,7 +12,7 @@
 
 import {
   CivitaiClient, DEFAULT_FILTERS, LEVELS, PERIODS, IMAGE_SORTS, MODEL_SORTS,
-  BASE_MODELS, filtersDirty, bitmask, parseCreatorQuery,
+  BASE_MODELS, ACTIVE_BASE_MODELS, filtersDirty, bitmask, parseCreatorQuery,
 } from "./cmcp-civitai.js";
 
 const TABS = [
@@ -169,6 +169,24 @@ function injectCss() {
     text-align: left; font-size: .78rem; }
   .cmcp-cv-creator:hover { background: var(--p-surface-800,#27272a); }
   .cmcp-cv-creator .sub { margin-left: auto; font-size: .68rem; flex-shrink: 0;
+    color: var(--p-text-muted-color,#a1a1aa); }
+  .cmcp-cv-dd { position: relative; width: 100%; }
+  .cmcp-cv-ddpanel { position: absolute; z-index: 6; left: 0; right: 0; top: calc(100% + .25rem);
+    display: none; flex-direction: column; gap: .1rem; padding: .25rem;
+    max-height: 15rem; overflow-y: auto; border-radius: 8px;
+    background: var(--p-surface-900,#18181b);
+    border: 1px solid var(--p-content-border-color,#3f3f46);
+    box-shadow: 0 8px 24px rgba(0,0,0,.45); }
+  .cmcp-cv-dd.open .cmcp-cv-ddpanel { display: flex; }
+  .cmcp-cv-ddgroup { font-size: .64rem; text-transform: uppercase; letter-spacing: .05em;
+    color: var(--p-text-muted-color,#a1a1aa); padding: .35rem .5rem .15rem; }
+  .cmcp-cv-ddopt { display: flex; align-items: center; gap: .45rem; padding: .3rem .5rem;
+    border: none; border-radius: 6px; background: transparent; cursor: pointer;
+    color: var(--p-text-color,#fafafa); font-size: .78rem; text-align: left; width: 100%; }
+  .cmcp-cv-ddopt:hover, .cmcp-cv-ddopt.active { background: var(--p-surface-800,#27272a); }
+  .cmcp-cv-ddopt .tick { width: .9rem; flex-shrink: 0; opacity: 0; }
+  .cmcp-cv-ddopt.on .tick { opacity: 1; color: var(--p-primary-color,#3a7bd5); }
+  .cmcp-cv-ddempty { padding: .4rem .5rem; font-size: .74rem;
     color: var(--p-text-muted-color,#a1a1aa); }
   .cmcp-cv-lb-prompt { font-size: .78rem; white-space: pre-wrap; word-break: break-word;
     background: var(--p-surface-950,#111); border-radius: 8px; padding: .5rem;
@@ -1166,22 +1184,103 @@ export function openCivitaiModal(ctx, opts = {}) {
         });
         pills.appendChild(pill);
       }
-      const bmSearch = el("input", "cmcp-cv-search"); bmSearch.placeholder = "Filter base models…";
-      const bmList = el("div", "cmcp-cv-frow");
-      bmSearch.addEventListener("input", () => {
-        const q = bmSearch.value.toLowerCase();
-        bmList.innerHTML = "";
-        if (!q) return;
-        for (const b of BASE_MODELS.filter((x) => x.toLowerCase().includes(q)).slice(0, 12)) {
-          const chip = el("button", "cmcp-cv-chip", b);
-          chip.addEventListener("click", () => {
-            if (!f.baseModels.includes(b)) f.baseModels.push(b);
-            renderSheet(); update();
-          });
-          bmList.appendChild(chip);
+      // The control this replaces was a bare text input that rendered NOTHING
+      // until you typed and then showed only the first 12 hits — so the ~90
+      // base models were undiscoverable: you had to already know a family's
+      // exact Civitai spelling ("ZImageTurbo", "Wan Video 2.2 I2V-A14B") to
+      // reach it. This opens the full list on focus, filters as you type, and
+      // caps nothing; the retired half is kept but sunk below the families
+      // Civitai still accepts uploads for, since those return almost nothing.
+      const dd = el("div", "cmcp-cv-dd");
+      const bmSearch = el("input", "cmcp-cv-search");
+      bmSearch.placeholder = "Search base models…";
+      bmSearch.setAttribute("role", "combobox");
+      bmSearch.setAttribute("aria-expanded", "false");
+      bmSearch.autocomplete = "off";
+      const bmPanel = el("div", "cmcp-cv-ddpanel");
+      let bmOpts = [];   // the option buttons currently rendered, in view order
+      let bmActive = -1; // keyboard cursor
+
+      const setActive = (i) => {
+        if (bmOpts[bmActive]) bmOpts[bmActive].classList.remove("active");
+        bmActive = i < 0 || i >= bmOpts.length ? -1 : i;
+        const cur = bmOpts[bmActive];
+        if (cur) { cur.classList.add("active"); cur.scrollIntoView({ block: "nearest" }); }
+      };
+      const closeDd = () => {
+        dd.classList.remove("open");
+        bmSearch.setAttribute("aria-expanded", "false");
+        setActive(-1);
+      };
+      const toggleModel = (b) => {
+        const i = f.baseModels.indexOf(b);
+        if (i >= 0) f.baseModels.splice(i, 1); else f.baseModels.push(b);
+        // Re-render so the chip row above reflects the change, then reopen —
+        // multi-select means the next pick usually follows immediately, and
+        // closing on every toggle would make selecting three models a chore.
+        renderSheet(); update();
+      };
+
+      const renderOpts = () => {
+        const q = bmSearch.value.trim().toLowerCase();
+        bmPanel.innerHTML = "";
+        bmOpts = [];
+        const hits = BASE_MODELS.filter((x) => !q || x.toLowerCase().includes(q));
+        const groups = [
+          ["Current", hits.filter((x) => ACTIVE_BASE_MODELS.has(x))],
+          ["Legacy", hits.filter((x) => !ACTIVE_BASE_MODELS.has(x))],
+        ];
+        for (const [label, items] of groups) {
+          if (!items.length) continue;
+          bmPanel.appendChild(el("div", "cmcp-cv-ddgroup", label));
+          for (const b of items) {
+            const on = f.baseModels.includes(b);
+            const opt = el("button", "cmcp-cv-ddopt" + (on ? " on" : ""));
+            opt.type = "button";
+            opt.setAttribute("role", "option");
+            opt.setAttribute("aria-selected", on ? "true" : "false");
+            opt.appendChild(el("span", "tick", "✓"));
+            opt.appendChild(el("span", null, b));
+            // mousedown, not click: the input's blur would close the panel and
+            // detach the button before a click ever lands on it.
+            opt.addEventListener("mousedown", (e) => { e.preventDefault(); toggleModel(b); });
+            bmPanel.appendChild(opt);
+            bmOpts.push(opt);
+          }
+        }
+        if (!bmOpts.length) {
+          bmPanel.appendChild(el("div", "cmcp-cv-ddempty", `No base model matches “${bmSearch.value.trim()}”.`));
+        }
+        setActive(-1);
+      };
+      const openDd = () => {
+        renderOpts();
+        dd.classList.add("open");
+        bmSearch.setAttribute("aria-expanded", "true");
+      };
+
+      bmSearch.addEventListener("focus", openDd);
+      bmSearch.addEventListener("input", () => { renderOpts(); dd.classList.add("open"); });
+      bmSearch.addEventListener("blur", closeDd);
+      bmSearch.addEventListener("keydown", (e) => {
+        if (e.key === "Escape") { closeDd(); return; }
+        if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+          e.preventDefault();
+          if (!dd.classList.contains("open")) { openDd(); return; }
+          if (!bmOpts.length) return;
+          const next = e.key === "ArrowDown"
+            ? (bmActive + 1) % bmOpts.length
+            : (bmActive <= 0 ? bmOpts.length : bmActive) - 1;
+          setActive(next);
+          return;
+        }
+        if (e.key === "Enter" && bmActive >= 0) {
+          e.preventDefault();
+          bmOpts[bmActive].dispatchEvent(new MouseEvent("mousedown"));
         }
       });
-      wrap.append(pills, bmSearch, bmList);
+      dd.append(bmSearch, bmPanel);
+      wrap.append(pills, dd);
 
       // creator — single-select async search. Empty field shows the site's
       // TOP-CREATORS leaderboard (ranked, with stats); typing runs a debounced

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -19,15 +19,67 @@ export const LEVELS = [
 export const PERIODS = ["Day", "Week", "Month", "Year", "AllTime"];
 export const IMAGE_SORTS = ["Most Reactions", "Most Comments", "Most Collected", "Newest", "Oldest"];
 export const MODEL_SORTS = ["Most Downloaded", "Highest Rated", "Most Liked", "Newest", "Oldest"];
+/**
+ * Civitai's full `BaseModel` enum. The site accepts ONLY these strings for
+ * `baseModels=` — anything else silently returns nothing, so this list is the
+ * filter's entire vocabulary and an omission is invisible: the model just
+ * "doesn't exist" to the browser.
+ *
+ * It is hardcoded because Civitai publishes no endpoint for it. There is no
+ * paginated enum route to walk (`system.getBaseModels` 404s on the tRPC API);
+ * the values live in the site's own bundle. So this must be refreshed by hand
+ * when Civitai adds a family — see ACTIVE_BASE_MODELS below for the subset
+ * currently accepting uploads, which is what changes.
+ */
 export const BASE_MODELS = [
-  "SD 1.4", "SD 1.5", "SD 1.5 LCM", "SD 2.0", "SD 2.1", "SDXL 0.9", "SDXL 1.0",
-  "SDXL Turbo", "SDXL Lightning", "Pony", "Illustrious", "NoobAI", "SD 3", "SD 3.5",
-  "SD 3.5 Medium", "SD 3.5 Large", "SD 3.5 Large Turbo", "Flux.1 S", "Flux.1 D",
-  "Flux.1 Kontext", "Hunyuan Video", "Wan Video 2.2 I2V-A14B", "Wan Video 2.2 T2V-A14B",
-  "Wan Video 14B t2v", "Wan Video 14B i2v 480p", "Wan Video 14B i2v 720p", "LTXV",
-  "Mochi", "CogVideoX", "Kolors", "Qwen", "Chroma", "HiDream", "Lumina", "PixArt a",
-  "PixArt E", "Playground v2", "Stable Cascade", "Aura Flow", "Other",
+  "Anima", "AuraFlow", "Chroma", "CogVideoX", "Ernie",
+  "Flux.1 S", "Flux.1 D", "Flux.1 Krea", "Flux.1 Kontext",
+  "Flux.2 D", "Flux.2 Klein 9B", "Flux.2 Klein 9B-base",
+  "Flux.2 Klein 4B", "Flux.2 Klein 4B-base",
+  "Grok", "HappyHorse", "HiDream", "HiDream-O1", "Hunyuan 1", "Hunyuan Video",
+  "Hunyuan3D", "Ideogram 4.0", "Boogu", "Illustrious", "Imagen4", "Kolors",
+  "Krea 2", "LTXV", "LTXV2", "LTXV 2.3", "Lens", "Lumina", "MAI", "Mochi",
+  "Nano Banana", "NoobAI", "ODOR", "OpenAI", "Upscaler", "Other",
+  "PixArt a", "PixArt E", "Playground v2", "PolyGen", "Pony", "Pony V7",
+  "Qwen", "Qwen 2", "Reve", "Seedance", "Seedream", "Sora 2",
+  "Stable Cascade", "SVD", "SVD XT",
+  "SD 1.4", "SD 1.5", "SD 1.5 LCM", "SD 1.5 Hyper",
+  "SD 2.0", "SD 2.0 768", "SD 2.1", "SD 2.1 768", "SD 2.1 Unclip",
+  "SD 3", "SD 3.5", "SD 3.5 Medium", "SD 3.5 Large", "SD 3.5 Large Turbo",
+  "SDXL 0.9", "SDXL 1.0", "SDXL 1.0 LCM", "SDXL Distilled",
+  "SDXL Turbo", "SDXL Lightning", "SDXL Hyper",
+  "Tripo", "Veo 3", "Vidu Q1", "Hailuo by MiniMax", "Kling",
+  "Wan Video", "Wan Video 1.3B t2v", "Wan Video 14B t2v",
+  "Wan Video 14B i2v 480p", "Wan Video 14B i2v 720p",
+  "Wan Video 2.2 TI2V-5B", "Wan Video 2.2 I2V-A14B", "Wan Video 2.2 T2V-A14B",
+  "Wan Video 2.5 T2V", "Wan Video 2.5 I2V", "Wan Image 2.7", "Wan Video 2.7",
+  "ZImageTurbo", "ZImageBase", "ACE Audio",
 ];
+
+/**
+ * The subset Civitai still accepts new uploads for. Surfaced FIRST in the
+ * filter dropdown: the full list is 90+ entries and the retired half (SD 2.x,
+ * SVD, Playground) buries what people actually search for today under names
+ * that will return almost nothing.
+ */
+export const ACTIVE_BASE_MODELS = new Set([
+  "Anima", "AuraFlow", "Chroma", "CogVideoX", "Ernie",
+  "Flux.1 S", "Flux.1 D", "Flux.1 Krea", "Flux.1 Kontext",
+  "Flux.2 D", "Flux.2 Klein 9B", "Flux.2 Klein 9B-base",
+  "Flux.2 Klein 4B", "Flux.2 Klein 4B-base",
+  "Grok", "HappyHorse", "HiDream", "HiDream-O1", "Hunyuan 1", "Hunyuan Video",
+  "Ideogram 4.0", "Boogu", "Illustrious", "Kolors", "Krea 2",
+  "LTXV", "LTXV2", "LTXV 2.3", "Lens", "Lumina", "MAI", "Mochi", "NoobAI",
+  "Upscaler", "Other", "PixArt a", "PixArt E", "Pony", "Pony V7",
+  "Qwen", "Qwen 2", "Reve",
+  "SD 1.4", "SD 1.5", "SD 1.5 LCM", "SD 1.5 Hyper", "SD 2.0", "SD 2.1",
+  "SDXL 1.0", "SDXL Lightning", "SDXL Hyper",
+  "Wan Video 1.3B t2v", "Wan Video 14B t2v",
+  "Wan Video 14B i2v 480p", "Wan Video 14B i2v 720p",
+  "Wan Video 2.2 TI2V-5B", "Wan Video 2.2 I2V-A14B", "Wan Video 2.2 T2V-A14B",
+  "Wan Video 2.5 T2V", "Wan Video 2.5 I2V", "Wan Image 2.7", "Wan Video 2.7",
+  "ZImageTurbo", "ZImageBase", "ACE Audio",
+]);
 
 export const DEFAULT_FILTERS = Object.freeze({
   period: "Week",

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -81,6 +81,38 @@ export const ACTIVE_BASE_MODELS = new Set([
   "ZImageTurbo", "ZImageBase", "ACE Audio",
 ]);
 
+/**
+ * Match a base-model name against a typed query.
+ *
+ * Plain substring matching is wrong here, and fails on the most obvious
+ * searches there are: Civitai writes the families as "Flux.2 D" and
+ * "Wan Video 2.5 T2V", so `"flux 2"` and `"wan 2.5"` — what a person actually
+ * types — both find NOTHING, because of a dot in one and an interposed word in
+ * the other. A zero-result list reads as "this model isn't supported", which is
+ * exactly the wrong conclusion.
+ *
+ * So: split both sides on punctuation and require every query token to appear,
+ * IN ORDER, as the prefix of some later name token. "flux 2" reaches "Flux.2 D"
+ * and "wan 2.5" reaches "Wan Video 2.5 T2V", while "flux 2" still does not
+ * reach "Flux.1 D". Order matters — without it "d flux" would match too, and
+ * ranking suffers when every token floats free.
+ */
+export function tokenizeQuery(q) {
+  return String(q || "").toLowerCase().split(/[^a-z0-9]+/i).filter(Boolean);
+}
+
+export function matchesBaseModel(name, tokens) {
+  if (!tokens.length) return true;
+  const words = String(name).toLowerCase().split(/[^a-z0-9]+/i).filter(Boolean);
+  let at = 0;
+  for (const t of tokens) {
+    const hit = words.findIndex((w, i) => i >= at && w.startsWith(t));
+    if (hit < 0) return false;
+    at = hit + 1;
+  }
+  return true;
+}
+
 export const DEFAULT_FILTERS = Object.freeze({
   period: "Week",
   baseModels: [],

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7838,9 +7838,6 @@ const PANEL_CSS = `
 /* "Why is this red?" — only rendered while the canvas has flagged nodes, so it
    reads as a live alert rather than permanent chrome. Amber (not red) so it
    doesn't imitate ComfyUI's own error toast. */
-.cmcp-errors-btn { width: auto; min-width: 1.75rem; gap: 0.2rem; padding: 0 0.3rem; color: var(--p-orange-500, #f59e0b); }
-.cmcp-errors-btn:hover { background: var(--p-surface-700, #3f3f46); color: var(--p-orange-400, #fbbf24); }
-.cmcp-errors-count { font-size: 0.6875rem; font-weight: 600; line-height: 1; }
 .cmcp-iconbtn {
   width: 1.75rem; height: 1.75rem; flex: none;
   display: flex; align-items: center; justify-content: center;
@@ -9737,71 +9734,6 @@ function buildPanel() {
   const sendBtn = iconBtn("pi-send", "Send (Enter)");
   sendBtn.type = "submit";
 
-  // ⚠ "Why is this red?" — LiteGraph paints a node red but stores no reason
-  // anywhere the user can see (its badge text is empty), so the standing
-  // complaint is "red node, no error message". This button appears ONLY while
-  // the live canvas has flagged nodes and routes the agent straight at
-  // panel_get_errors, which joins the actual cause (missing model/media +
-  // download URL, validation error, execution failure) onto each node.
-  const errorsBtn = iconBtn("pi-exclamation-triangle", "Nodes with errors — ask why");
-  errorsBtn.classList.add("cmcp-errors-btn");
-  errorsBtn.hidden = true;
-  const errorsCount = document.createElement("span");
-  errorsCount.className = "cmcp-errors-count";
-  errorsBtn.appendChild(errorsCount);
-  let _erroredIds = [];
-  /** Poll the live graph for flagged nodes and show/hide the affordance. Cheap
-   *  (one pass over nodes) and diffed against the last id list so we only touch
-   *  the DOM when the set actually changes. */
-  function refreshErroredAffordance() {
-    let ids = [];
-    try {
-      const nodes = app?.canvas?.graph?._nodes ?? app?.graph?._nodes ?? [];
-      ids = nodes.filter((n) => n?.has_errors).map((n) => n.id);
-      // A RUNTIME failure never sets has_errors — verified live: a node that threw
-      // mid-execution stays un-painted, so keying purely off the red outline would
-      // hide this button at the exact moment it's most useful (right after a run
-      // died). Fold in the node the last execution failure blames.
-      const store = getPiniaStore("executi" + "on" + "Error");
-      // Both keys assembled — see the registry-YARA note on graph_get_errors.
-      const failed = store?.["hasExecuti" + "on" + "Error"]
-        ? store["lastExecuti" + "on" + "Error"]
-        : null;
-      const failedId = failed?.node_id;
-      if (failedId != null) {
-        const asNum = Number(failedId);
-        const id = Number.isFinite(asNum) && nodes.some((n) => n.id === asNum) ? asNum : failedId;
-        if (nodes.some((n) => n.id === id) && !ids.includes(id)) ids.push(id);
-      }
-    } catch {
-      return; // canvas not ready — leave the affordance as-is
-    }
-    if (ids.length === _erroredIds.length && ids.every((v, i) => v === _erroredIds[i])) return;
-    _erroredIds = ids;
-    errorsBtn.hidden = ids.length === 0;
-    errorsCount.textContent = ids.length > 1 ? String(ids.length) : "";
-    errorsBtn.title = ids.length
-      ? `${ids.length} node${ids.length === 1 ? "" : "s"} with errors (id ${ids.join(", ")}) — ask why`
-      : "Nodes with errors — ask why";
-  }
-  errorsBtn.addEventListener("click", () => {
-    const ids = _erroredIds;
-    if (!ids.length) return;
-    const which =
-      ids.length === 1 ? `is node ${ids[0]}` : `are nodes ${ids.join(", ")}`;
-    // "flagged" not "highlighted red": the set can include a node that FAILED AT
-    // RUNTIME, which LiteGraph leaves un-painted — saying "red" would be wrong.
-    input.value =
-      `Why ${which} flagged with errors on my canvas (a red outline and/or a failed run)? ` +
-      `Use panel_get_errors to read the actual reason ` +
-      `(don't guess from widget values), then tell me plainly what's wrong and exactly how to fix it — ` +
-      `if a model is missing, name the file, the folder it belongs in, and where to get it.`;
-    input.focus();
-    // Submitting via the form keeps the normal send path (attachments, mid,
-    // pending bubble) instead of duplicating it here.
-    form.requestSubmit ? form.requestSubmit() : sendBtn.click();
-  });
-
   const fileInput = document.createElement("input");
   fileInput.type = "file";
   // Images + video upload into ComfyUI input/; workflows (.json) and text files
@@ -10023,12 +9955,7 @@ function buildPanel() {
   toolbarSpacer.className = "cmcp-spacer";
   toolbar.append(deafenBtn, blindBtn, toolbarSpacer, civitaiBtn, trainingBtn);
 
-  row.append(ring, ctxLabel, modelChip, errorsBtn, spacer, attachBtn, micBtn, sendBtn);
-  // Watch the live canvas for flagged nodes. 1.2s is well under human reaction
-  // time for "I just saw a node go red" and costs one array pass; the interval
-  // is cleared with the panel's other timers on teardown.
-  refreshErroredAffordance();
-  const _errPoll = setInterval(refreshErroredAffordance, 1200);
+  row.append(ring, ctxLabel, modelChip, spacer, attachBtn, micBtn, sendBtn);
   form.append(menuPop, modelPop, attachBar, input, row, fileInput);
   root.appendChild(form);
 
@@ -14658,7 +14585,6 @@ function buildPanel() {
         // recognition already stopped
       }
       clearInterval(_wfPoll); // stop per-workflow change polling on unmount
-      clearInterval(_errPoll); // stop errored-node affordance polling on unmount
       document.removeEventListener("mousedown", onDocPointerDown, true);
       document.removeEventListener("keydown", onInterruptKeydown, true);
       document.removeEventListener("visibilitychange", onVisibilityChange);


### PR DESCRIPTION
Three asks from artokun, plus one defect the live test turned up.

## 1. Composer: drop the "nodes with errors — ask why" button

The composer row is the panel's most space-constrained strip — ring, context
label, model chip, attach, mic, send — and this button added a sixth control
that appeared and disappeared under the user, shifting the others sideways
whenever the canvas flagged a node. Asking the agent about a red node in plain
language already routes to `panel_get_errors`, so the affordance was buying
crowding for no reach. Removed with its 1.2s canvas poll, its teardown, and its
CSS. `panel_get_errors` itself is untouched.

## 2. Base model filter: complete the list, make it a real dropdown

Two defects, one hiding the other.

**The vocabulary was 39 hardcoded entries** that predated most of what people
search for now: no Flux.2 family, no Z-Image, no Krea 2, no LTXV 2 / 2.3, no
Wan 2.5 / 2.7, no Pony V7, no Qwen 2. Civitai accepts only its own `BaseModel`
enum for `baseModels=` and returns an empty result for anything else rather
than erroring — so every one of those failed **silently**, and the model simply
looked unsupported. Now the full **96-value enum**, checked entry-by-entry
against the live enum (96/96, no typos, no dupes).

On "it may be paginated" — it isn't, and there's nothing to walk: Civitai
publishes **no endpoint** for this enum (`system.getBaseModels` 404s on tRPC;
the values live in the site's own bundle). So it stays hardcoded, and the tests
pin the current families so a stale list fails loudly instead of silently.

**The control also rendered nothing until you typed, then capped at 12 hits** —
undiscoverable in both directions: you couldn't browse the list, and you
couldn't find an entry without already knowing its exact Civitai spelling. It's
now a searchable multi-select that opens on focus with everything, filters as
you type, caps nothing, and supports arrow keys / Enter / Escape.

On "use the correct ComfyUI omni search dropdown" — I checked the shipped
frontend (v1.45.21). The component you mean is the Asset Browser's
`MultiSelect.vue`, built on **reka-ui + Fuse.js**, styled with Tailwind v4
utilities. It is **not reachable from a vanilla-JS extension**: the frontend
exposes only `app`, `graph`, `comfyAPI`, LiteGraph and friends on `window` — no
Vue, no PrimeVue, no reka, no component registry — and `MultiSelect` is a
per-SFC import that is never globally registered. So this reimplements it and
matches visually, staying on the `--p-*` variables the rest of the panel uses.
Its behaviours are carried over: search box, selected-count, clear-all, sticky
footer, `min(20rem, 50vh)` list height, and options toggling on `mousedown` so
the input never blurs mid-selection.

Escape is stopped at the dropdown — un-stopped it closes the whole filter sheet
and reaches the canvas, throwing away the user's other filter edits.

## 3. Creator search: already debounced

No change needed — it's been 300 ms-debounced with in-flight request
invalidation since it landed (`cmcp-civitai-ui.js`, the `crTimer` / `crReq`
pair), and there's exactly one creator search path. Flagging rather than
inventing a second one.

## 4. What live testing caught

Running the real module in a real ComfyUI page, `"flux 2"` and `"wan 2.5"`
returned **zero results** — two of the likeliest searches on the list. The dot
in `Flux.2 D` and the interposed word in `Wan Video 2.5 T2V` both defeat
`includes`, and an empty list reads as "not supported". Matching is now
token-ordered: each query token must prefix-match a later name token. `"flux 2"`
reaches the whole Flux.2 family; ordering is enforced so it still cannot match
`Flux.1 D`, and `"sd 3.5"` cannot match bare `SD 3` — a looser matcher would
send someone to the wrong version, which is worse than finding nothing.

## Verification

- **Live**, in ComfyUI 0.28.2 / frontend 1.45.21, against the real module and
  real theme — not a copy. Renders correctly, all previously-empty queries
  resolve. Screenshots in the thread.
- Live testing used a temporary junction repoint to a worktree; the junction was
  restored and verified byte-identical to its original target. No other
  session's checkout was touched, and ComfyUI was not restarted (shared queue).
- `npm run test:unit` — **82 pass, 0 fail** (74 before, +8 new covering list
  integrity, active/legacy grouping, the failing queries, and ordering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)