### PR TITLE
fix(civitai): defects in the base-model filter found reviewing #108

### DIFF
--- a/browser_tests/unit/civitai-base-models.test.mjs
+++ b/browser_tests/unit/civitai-base-models.test.mjs
@@ -8,10 +8,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
-  BASE_MODELS, ACTIVE_BASE_MODELS, tokenizeQuery, matchesBaseModel,
+  BASE_MODELS, ACTIVE_BASE_MODELS, tokenizeQuery, prepareQuery, matchesBaseModel,
 } from "../../web/js/cmcp-civitai.js";
 
-const search = (q) => BASE_MODELS.filter((m) => matchesBaseModel(m, tokenizeQuery(q)));
+const search = (q) => BASE_MODELS.filter((m) => matchesBaseModel(m, prepareQuery(q)));
 
 test("base model list has no duplicates", () => {
   const dupes = BASE_MODELS.filter((x, i) => BASE_MODELS.indexOf(x) !== i);
@@ -76,6 +76,70 @@ test("an empty query matches everything, a nonsense one matches nothing", () => 
   assert.equal(search("").length, BASE_MODELS.length);
   assert.equal(search("   ").length, BASE_MODELS.length);
   assert.deepEqual(search("zzzznotamodel"), []);
+});
+
+test("hyphenated and spaced queries reach concatenated names", () => {
+  // Names like "ZImageTurbo" and "AuraFlow" are a SINGLE token, so ordered
+  // token matching alone can never reach them from a two-token query — the
+  // exact failure the first version shipped with: "z-image" returned nothing.
+  for (const q of ["z-image", "z image", "zimage", "Z-Image"]) {
+    assert.ok(search(q).includes("ZImageTurbo"), `"${q}" should find ZImageTurbo`);
+    assert.ok(search(q).includes("ZImageBase"), `"${q}" should find ZImageBase`);
+  }
+  assert.ok(search("aura flow").includes("AuraFlow"), '"aura flow" should find AuraFlow');
+  assert.ok(search("noob ai").includes("NoobAI"), '"noob ai" should find NoobAI');
+  assert.ok(search("open ai").includes("OpenAI"), '"open ai" should find OpenAI');
+  assert.ok(search("hi dream").includes("HiDream"), '"hi dream" should find HiDream');
+});
+
+test("a version query does not drag in a neighbouring version", () => {
+  // "wan 2.5" previously also returned "Wan Video 2.2 TI2V-5B": split into
+  // ["wan","2","5"] it matched the 2 of 2.2 and the 5 of 5B. Keeping "2.5"
+  // whole is what stops it — and offering the wrong Wan is worse than
+  // offering none, since the user downloads it before finding out.
+  const wan = search("wan 2.5");
+  assert.ok(wan.includes("Wan Video 2.5 T2V"));
+  assert.ok(wan.includes("Wan Video 2.5 I2V"));
+  assert.ok(!wan.includes("Wan Video 2.2 TI2V-5B"), "must not offer the 2.2 model for a 2.5 search");
+  assert.ok(!wan.includes("Wan Video 2.2 I2V-A14B"), "must not offer any 2.2 model for a 2.5 search");
+  assert.deepEqual(wan, ["Wan Video 2.5 T2V", "Wan Video 2.5 I2V"]);
+});
+
+test("tokenizer keeps version numbers whole", () => {
+  assert.deepEqual(tokenizeQuery("wan 2.5"), ["wan", "2.5"]);
+  assert.deepEqual(tokenizeQuery("Flux.2 D"), ["flux", "2", "d"]);
+  assert.deepEqual(tokenizeQuery("SD 3.5 Large"), ["sd", "3.5", "large"]);
+  assert.deepEqual(tokenizeQuery("TI2V-5B"), ["ti2v", "5b"]);
+  assert.deepEqual(tokenizeQuery(""), []);
+  assert.deepEqual(tokenizeQuery(null), []);
+});
+
+test("punctuation, emoji and non-ASCII match nothing rather than everything", () => {
+  // These tokenize to nothing. Treating "no tokens" as "no filter" answered a
+  // nonsense search with the full list, which reads as if all 96 matched.
+  for (const q of [".", "...", "___", "-", "🔥", "é", "α", "!!!"]) {
+    assert.deepEqual(search(q), [], `"${q}" should match nothing`);
+  }
+  // ...but genuinely empty input is still "no filter".
+  assert.equal(search("").length, BASE_MODELS.length);
+});
+
+test("a very long query terminates and matches nothing", () => {
+  assert.deepEqual(search("a".repeat(5000)), []);
+  assert.deepEqual(search("wan ".repeat(500)), []);
+});
+
+test("the enum is pinned exactly, so a silent deletion fails the suite", () => {
+  // Without this, removing an unmentioned entry like "Veo 3" left every other
+  // test green — the list is the filter's whole vocabulary, so it needs a
+  // full-set assertion, not a spot check.
+  assert.equal(BASE_MODELS.length, 96);
+  assert.equal(new Set(BASE_MODELS).size, 96);
+  assert.equal(ACTIVE_BASE_MODELS.size, 65);
+  for (const m of ["Veo 3", "Sora 2", "Kling", "Seedance", "Tripo", "PolyGen",
+                   "Hunyuan3D", "Nano Banana", "Imagen4", "ODOR", "Boogu", "Lens"]) {
+    assert.ok(BASE_MODELS.includes(m), `${m} disappeared from the enum`);
+  }
 });
 
 test("no entry has stray whitespace that would break the query string", () => {

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -12,7 +12,7 @@
 
 import {
   CivitaiClient, DEFAULT_FILTERS, LEVELS, PERIODS, IMAGE_SORTS, MODEL_SORTS,
-  BASE_MODELS, ACTIVE_BASE_MODELS, tokenizeQuery, matchesBaseModel,
+  BASE_MODELS, ACTIVE_BASE_MODELS, prepareQuery, matchesBaseModel,
   filtersDirty, bitmask, parseCreatorQuery,
 } from "./cmcp-civitai.js";
 
@@ -1184,14 +1184,19 @@ export function openCivitaiModal(ctx, opts = {}) {
       // base model omni-search
       wrap.appendChild(el("div", "cmcp-cv-flabel", "Base model"));
       const pills = el("div", "cmcp-cv-frow");
-      for (const b of f.baseModels) {
-        const pill = el("button", "cmcp-cv-chip on", b + "  ✕");
-        pill.addEventListener("click", () => {
-          f.baseModels = f.baseModels.filter((x) => x !== b);
-          renderSheet(); update();
-        });
-        pills.appendChild(pill);
-      }
+      // Rebuilt in place rather than via renderSheet(), so toggling a model
+      // does not tear down the dropdown mid-selection (see toggleModel).
+      const syncPills = () => {
+        pills.textContent = "";
+        for (const b of f.baseModels) {
+          const pill = el("button", "cmcp-cv-chip on", b + "  ✕");
+          pill.addEventListener("click", () => {
+            f.baseModels = f.baseModels.filter((x) => x !== b);
+            syncPills(); renderOpts(); update();
+          });
+          pills.appendChild(pill);
+        }
+      };
       // The control this replaces was a bare text input that rendered NOTHING
       // until you typed and then showed only the first 12 hits — so the ~90
       // base models were undiscoverable: you had to already know a family's
@@ -1200,12 +1205,22 @@ export function openCivitaiModal(ctx, opts = {}) {
       // caps nothing; the retired half is kept but sunk below the families
       // Civitai still accepts uploads for, since those return almost nothing.
       const dd = el("div", "cmcp-cv-dd");
+      const ddId = `cmcp-cv-bm-${Math.random().toString(36).slice(2, 8)}`;
       const bmSearch = el("input", "cmcp-cv-search");
       bmSearch.placeholder = "Search base models…";
       bmSearch.setAttribute("role", "combobox");
       bmSearch.setAttribute("aria-expanded", "false");
+      bmSearch.setAttribute("aria-controls", ddId);
+      bmSearch.setAttribute("aria-autocomplete", "list");
       bmSearch.autocomplete = "off";
       const bmPanel = el("div", "cmcp-cv-ddpanel");
+      bmPanel.id = ddId;
+      // The options already claim role="option"; without a listbox parent that
+      // is invalid, and without aria-activedescendant the arrow keys move a
+      // purely VISUAL cursor — a screen reader announces nothing at all.
+      bmPanel.setAttribute("role", "listbox");
+      bmPanel.setAttribute("aria-multiselectable", "true");
+      bmPanel.setAttribute("aria-label", "Base model");
       let bmOpts = [];   // the option buttons currently rendered, in view order
       let bmActive = -1; // keyboard cursor
 
@@ -1213,7 +1228,13 @@ export function openCivitaiModal(ctx, opts = {}) {
         if (bmOpts[bmActive]) bmOpts[bmActive].classList.remove("active");
         bmActive = i < 0 || i >= bmOpts.length ? -1 : i;
         const cur = bmOpts[bmActive];
-        if (cur) { cur.classList.add("active"); cur.scrollIntoView({ block: "nearest" }); }
+        if (cur) {
+          cur.classList.add("active");
+          cur.scrollIntoView({ block: "nearest" });
+          bmSearch.setAttribute("aria-activedescendant", cur.id);
+        } else {
+          bmSearch.removeAttribute("aria-activedescendant");
+        }
       };
       const closeDd = () => {
         dd.classList.remove("open");
@@ -1223,17 +1244,22 @@ export function openCivitaiModal(ctx, opts = {}) {
       const toggleModel = (b) => {
         const i = f.baseModels.indexOf(b);
         if (i >= 0) f.baseModels.splice(i, 1); else f.baseModels.push(b);
-        // Re-render so the chip row above reflects the change, then reopen —
-        // multi-select means the next pick usually follows immediately, and
-        // closing on every toggle would make selecting three models a chore.
-        renderSheet(); update();
+        // Update the chip row and the option ticks IN PLACE. Calling
+        // renderSheet() here rebuilds the whole sheet, which destroys this
+        // input and its text — so picking "Wan Video 2.5 T2V" out of a "wan 2.5"
+        // search would close the list and clear the query, and reaching the
+        // I2V sibling right below it meant retyping the search. In a
+        // multi-select the second pick is the common case, not the rare one.
+        syncPills();
+        renderOpts();
+        update();
       };
 
       const renderOpts = () => {
-        const tokens = tokenizeQuery(bmSearch.value);
+        const query = prepareQuery(bmSearch.value);
         bmPanel.innerHTML = "";
         bmOpts = [];
-        const hits = BASE_MODELS.filter((x) => matchesBaseModel(x, tokens));
+        const hits = BASE_MODELS.filter((x) => matchesBaseModel(x, query));
         const groups = [
           ["Current", hits.filter((x) => ACTIVE_BASE_MODELS.has(x))],
           ["Legacy", hits.filter((x) => !ACTIVE_BASE_MODELS.has(x))],
@@ -1245,13 +1271,21 @@ export function openCivitaiModal(ctx, opts = {}) {
             const on = f.baseModels.includes(b);
             const opt = el("button", "cmcp-cv-ddopt" + (on ? " on" : ""));
             opt.type = "button";
+            opt.id = `${ddId}-o${bmOpts.length}`;
             opt.setAttribute("role", "option");
             opt.setAttribute("aria-selected", on ? "true" : "false");
             opt.appendChild(el("span", "tick", "✓"));
             opt.appendChild(el("span", null, b));
             // mousedown, not click: the input's blur would close the panel and
-            // detach the button before a click ever lands on it.
-            opt.addEventListener("mousedown", (e) => { e.preventDefault(); toggleModel(b); });
+            // detach the button before a click ever lands on it. Left button
+            // ONLY — mousedown fires for every button, so without this guard a
+            // right-click meant to open a context menu silently toggles the
+            // filter under the cursor.
+            opt.addEventListener("mousedown", (e) => {
+              if (e.button !== 0) return;
+              e.preventDefault();
+              toggleModel(b);
+            });
             bmPanel.appendChild(opt);
             bmOpts.push(opt);
           }
@@ -1269,10 +1303,13 @@ export function openCivitaiModal(ctx, opts = {}) {
             `${f.baseModels.length} selected`));
           const clear = el("button", "cmcp-cv-ddclear", "Clear");
           clear.type = "button";
+          // Left button only — right-clicking "Clear" would otherwise wipe every
+          // selected model before the context menu even appeared.
           clear.addEventListener("mousedown", (e) => {
+            if (e.button !== 0) return;
             e.preventDefault();
             f.baseModels.length = 0;
-            renderSheet(); update();
+            syncPills(); renderOpts(); update();
           });
           foot.appendChild(clear);
           bmPanel.appendChild(foot);
@@ -1313,6 +1350,7 @@ export function openCivitaiModal(ctx, opts = {}) {
         }
       });
       dd.append(bmSearch, bmPanel);
+      syncPills(); // paint the chips for models already selected on this sheet
       wrap.append(pills, dd);
 
       // creator — single-select async search. Empty field shows the site's

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -179,6 +179,7 @@ function injectCss() {
     border: 1px solid var(--p-content-border-color,#3f3f46);
     box-shadow: 0 8px 24px rgba(0,0,0,.45); }
   .cmcp-cv-dd.open .cmcp-cv-ddpanel { display: flex; }
+  .cmcp-cv-ddlist, .cmcp-cv-ddgroupwrap { display: flex; flex-direction: column; gap: .1rem; }
   .cmcp-cv-ddgroup { font-size: .64rem; text-transform: uppercase; letter-spacing: .05em;
     color: var(--p-text-muted-color,#a1a1aa); padding: .35rem .5rem .15rem; }
   .cmcp-cv-ddopt { display: flex; align-items: center; gap: .45rem; padding: .3rem .5rem;
@@ -1213,14 +1214,11 @@ export function openCivitaiModal(ctx, opts = {}) {
       bmSearch.setAttribute("aria-controls", ddId);
       bmSearch.setAttribute("aria-autocomplete", "list");
       bmSearch.autocomplete = "off";
+      // bmPanel is the visual popup container. The listbox lives INSIDE it and
+      // owns only option/group children (a listbox may not own the group-label
+      // divs, the empty notice, or the Clear button) — those siblings sit in the
+      // panel, outside the listbox, which is rebuilt each render.
       const bmPanel = el("div", "cmcp-cv-ddpanel");
-      bmPanel.id = ddId;
-      // The options already claim role="option"; without a listbox parent that
-      // is invalid, and without aria-activedescendant the arrow keys move a
-      // purely VISUAL cursor — a screen reader announces nothing at all.
-      bmPanel.setAttribute("role", "listbox");
-      bmPanel.setAttribute("aria-multiselectable", "true");
-      bmPanel.setAttribute("aria-label", "Base model");
       let bmOpts = [];   // the option buttons currently rendered, in view order
       let bmActive = -1; // keyboard cursor
 
@@ -1259,6 +1257,15 @@ export function openCivitaiModal(ctx, opts = {}) {
         const query = prepareQuery(bmSearch.value);
         bmPanel.innerHTML = "";
         bmOpts = [];
+        // The listbox owns ONLY options (grouped under role="group"); it is
+        // rebuilt each render but keeps the stable ddId so aria-controls and
+        // aria-activedescendant keep resolving.
+        const listbox = el("div", "cmcp-cv-ddlist");
+        listbox.id = ddId;
+        listbox.setAttribute("role", "listbox");
+        listbox.setAttribute("aria-multiselectable", "true");
+        listbox.setAttribute("aria-label", "Base model");
+        bmPanel.appendChild(listbox);
         const hits = BASE_MODELS.filter((x) => matchesBaseModel(x, query));
         const groups = [
           ["Current", hits.filter((x) => ACTIVE_BASE_MODELS.has(x))],
@@ -1266,7 +1273,14 @@ export function openCivitaiModal(ctx, opts = {}) {
         ];
         for (const [label, items] of groups) {
           if (!items.length) continue;
-          bmPanel.appendChild(el("div", "cmcp-cv-ddgroup", label));
+          // A listbox may only own option/group children — so each labelled
+          // section is a role="group" (named via aria-label), not a bare div.
+          const group = el("div", "cmcp-cv-ddgroupwrap");
+          group.setAttribute("role", "group");
+          group.setAttribute("aria-label", label);
+          const heading = el("div", "cmcp-cv-ddgroup", label);
+          heading.setAttribute("aria-hidden", "true"); // group's aria-label already names it
+          group.appendChild(heading);
           for (const b of items) {
             const on = f.baseModels.includes(b);
             const opt = el("button", "cmcp-cv-ddopt" + (on ? " on" : ""));
@@ -1286,11 +1300,13 @@ export function openCivitaiModal(ctx, opts = {}) {
               e.preventDefault();
               toggleModel(b);
             });
-            bmPanel.appendChild(opt);
+            group.appendChild(opt);
             bmOpts.push(opt);
           }
+          listbox.appendChild(group);
         }
         if (!bmOpts.length) {
+          // Not an option — belongs in the panel, outside the listbox.
           bmPanel.appendChild(el("div", "cmcp-cv-ddempty", `No base model matches “${bmSearch.value.trim()}”.`));
         }
         // Selected-count + clear, matching what ComfyUI's own multi-select

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -97,15 +97,61 @@ export const ACTIVE_BASE_MODELS = new Set([
  * reach "Flux.1 D". Order matters — without it "d flux" would match too, and
  * ranking suffers when every token floats free.
  */
+/**
+ * Split into words, keeping a version number whole: "wan 2.5" -&gt; ["wan","2.5"],
+ * "Flux.2 D" -&gt; ["flux","2","d"]. The dot survives only BETWEEN DIGITS, which
+ * is what separates a version from ordinary punctuation — and it is what keeps
+ * "wan 2.5" off "Wan Video 2.2 TI2V-5B", where a naive split into ["wan","2","5"]
+ * happily matches the "2" of 2.2 and the "5" of 5B and offers the wrong model.
+ */
 export function tokenizeQuery(q) {
-  return String(q || "").toLowerCase().split(/[^a-z0-9]+/i).filter(Boolean);
+  return String(q ?? "").toLowerCase().match(/[0-9]+(?:\.[0-9]+)+|[a-z0-9]+/g) || [];
 }
 
-export function matchesBaseModel(name, tokens) {
-  if (!tokens.length) return true;
-  const words = String(name).toLowerCase().split(/[^a-z0-9]+/i).filter(Boolean);
+/** Everything that isn't alphanumeric, dropped — "z-image" and "Z Image" both
+ *  collapse onto "zimage", which is how they reach "ZImageTurbo". */
+function compactify(s) {
+  return String(s ?? "").toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+export function prepareQuery(q) {
+  const raw = String(q ?? "").trim();
+  return { raw, tokens: tokenizeQuery(raw), compact: compactify(raw) };
+}
+
+/**
+ * Match a base-model name against a typed query.
+ *
+ * Two matching strategies, because Civitai's names break each one alone:
+ *
+ * - **Ordered token prefixes** handle names with words in between. "wan 2.5"
+ *   has to cross "Video" to reach "Wan Video 2.5 T2V".
+ * - **Compacted substring** handles names that are jammed together. "z-image"
+ *   and "aura flow" have to reach "ZImageTurbo" and "AuraFlow", which are one
+ *   token each — no amount of token matching gets there, since the query has
+ *   two tokens and the name has one.
+ *
+ * Either one hitting is a match. Both are ordered, so "flux 2" still cannot
+ * reach "Flux.1 D" and "sd 3.5" cannot reach bare "SD 3" — matching the wrong
+ * version is worse than matching nothing, because it sends someone off to
+ * download a model that will not do what they asked.
+ */
+export function matchesBaseModel(name, query) {
+  const q = query && typeof query === "object" && "raw" in query
+    ? query
+    : prepareQuery(Array.isArray(query) ? query.join(" ") : query);
+
+  // An empty box means "no filter". But a query of "🔥" or "..." is NOT empty —
+  // it tokenizes to nothing, and treating that as no-filter would answer a
+  // nonsense search with all 96 models, which reads as if they all matched.
+  if (!q.raw) return true;
+  if (!q.tokens.length && !q.compact) return false;
+
+  if (q.compact && compactify(name).includes(q.compact)) return true;
+
+  const words = tokenizeQuery(name);
   let at = 0;
-  for (const t of tokens) {
+  for (const t of q.tokens) {
     const hit = words.findIndex((w, i) => i >= at && w.startsWith(t));
     if (hit < 0) return false;
     at = hit + 1;


### PR DESCRIPTION
#108 merged without the adversarial review that normally gates a PR — my miss.
This is that review's fallout, run after the fact. Six real defects, four of
them in code I had just called verified.

| # | Defect | Before → after |
|---|---|---|
| 1 | `"z-image"`, `"aura flow"`, `"noob ai"` found **nothing** | 0 → 2 / 1 / 1 |
| 2 | `"wan 2.5"` offered the **2.2** model | 3 → 2 (correct pair) |
| 3 | Picking an option **closed the dropdown and erased the search** | fixed in place |
| 4 | **Right-click** toggled options / wiped all selections | left-button only |
| 5 | `"."`, `"🔥"`, `"é"` matched **all 96** | 96 → 0 |
| 6 | Arrow keys **invisible to screen readers** | aria wired |

### 1 — the bug #108 claimed to fix, still live

Ordered token matching can't reach a name that is one jammed-together token:
the query has two tokens, `ZImageTurbo` has one. So "type the obvious thing,
get an empty list, conclude the model isn't supported" survived for a whole
class of names — `ZImage*`, `AuraFlow`, `NoobAI`, `OpenAI`, `HiDream`. Matching
now also compares a punctuation-stripped form.

### 2 — I knew about this one and shrugged

I saw `"wan 2.5"` returning `Wan Video 2.2 TI2V-5B` before merging and wrote it
off as an acceptable false positive. It isn't: split to `["wan","2","5"]` it
matched the `2` of 2.2 and the `5` of 5B, and the cost of taking it is
downloading a multi-GB model that does the wrong thing. The tokenizer now keeps
a dot **between digits**, so `2.5` stays whole.

### 3 — the comment was lying

`toggleModel` called `renderSheet()`, which rebuilds the sheet and with it a
fresh empty input. Choosing `Wan Video 2.5 T2V` out of a `wan 2.5` search closed
the list and cleared the query — so reaching the I2V sibling *directly below it*
meant retyping. In a multi-select the second pick is the common case, not the
rare one. The comment directly above claimed it would "reopen", which is worse
than no comment at all. Chips and options now update in place.

### 4, 5, 6

`mousedown` fires for every button, so right-clicking anywhere in the list
silently changed the filter and right-clicking **Clear** dropped every selection
before the context menu appeared. Junk queries tokenize to nothing, and "no
tokens" was treated as "no filter", returning all 96 as though everything
matched. Options claimed `role="option"` with no listbox parent, and the arrow
keys moved a CSS class with no `aria-activedescendant`, announcing nothing.

## Test gaps this also closes

The previous set had three holes, all of which let a confirmed defect through:

- cited `"z-image"` in a comment but asserted `"zimage"` — the hyphenated case,
  the one that was broken, was never run
- checked `"wan 2.5"` only for **inclusion**, so the 2.2 false positive passed
- spot-checked 18 entries, so deleting an unmentioned entry like `"Veo 3"` left
  every test green

Now pins the enum exactly (96 / 65 active), asserts the 2.2 **exclusion**, and
covers hyphenated/concatenated names, non-ASCII, punctuation-only and very long
inputs.

## Verification

`npm run test:unit` — **88 pass, 0 fail** (82 before). Each fix measured
before/after against the merged matcher, so none of the new tests are
decoration: z-image 0→2, aura flow 0→1, noob ai 0→1, wan 2.5 3→2, emoji 96→0.

Worth noting the reviewer could not run the suite itself — the repo sits outside
its sandbox root, so `npm run test:unit` was blocked by policy. The pass numbers
above are mine, run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)