### PR TITLE
feat(agent-drive): agent-drivable CivitAI + training modals with side-dock + green highlights

### DIFF
--- a/browser_tests/agent-drive.spec.ts
+++ b/browser_tests/agent-drive.spec.ts
@@ -8,9 +8,14 @@
  * MockBridge.command({rid,cmd,...}) — and we assert the reply shape AND the DOM
  * (green-glow cards/steps, dock geometry, teardown).
  *
- * These are the audit item-12 coverage: highlight-before-load, reload clears
- * glow, appended-card highlight on scroll, stale-handle throw, training-first
- * glow, dock orientation/collapse/detach, Escape cleanup.
+ * Audit item-12 coverage present here: highlight-before-load, reload clears
+ * glow, appended-card highlight on scroll, results shape, stale-handle throw
+ * (CivitAI + Training), docked click-through, and training-first glow.
+ *
+ * NOT covered here (require real ComfyUI splitter/pane geometry the MockBridge
+ * harness can't drive deterministically): dock ORIENTATION flip (pane docked
+ * left vs right), pane COLLAPSE, and Agent-root DETACH re-centering. Those stay
+ * manual checks in the live browser pass — see the report.
  *
  * NOTE: like the rest of this suite, these specs require a LIVE ComfyUI at
  * localhost:8188 with the pack junctioned in (see playwright.config.ts). They
@@ -182,9 +187,46 @@ test.describe('agent-driven Training modal', () => {
     await openPanel(panel, mockBridge)
     await mockBridge.command('open_training', { dock: true })
     await expect(page.locator('.cmcp-tr-modal')).toBeVisible()
+    // open_training lands on the FLOWS view (step bar cleared) — navigate to the
+    // Dataset step so the step:dataset chip exists before highlighting it. Step 1
+    // has no prerequisite gate, so gotoStep(1) enters directly.
+    await mockBridge.command('training_goto_step', { step: 1 })
+    await expect(page.locator('[data-ref="step:dataset"]')).toBeVisible()
     const hl = await mockBridge.command('training_highlight', { refs: ['step:dataset'] })
     expect(hl.ok).toBe(true)
     await expect(page.locator('[data-ref="step:dataset"].cmcp-agent-glow')).toBeVisible()
+  })
+
+  test('training_get_state is routed (not "Unknown command") and reports readiness', async ({
+    page,
+    panel,
+    mockBridge
+  }) => {
+    await openPanel(panel, mockBridge)
+    await mockBridge.command('open_training', { dock: true })
+    await expect(page.locator('.cmcp-tr-modal')).toBeVisible()
+    const st = await mockBridge.command('training_get_state', {})
+    expect(st.ok).toBe(true)
+    expect(st.result.view).toBe('flows')
+    expect(st.result.readiness).toBeTruthy()
+    // A fresh wizard has no dataset name/images yet → not advance-ready.
+    expect(st.result.readiness.nameOk).toBe(false)
+    expect(st.result.readiness.hasImages).toBe(false)
+  })
+
+  test('gotoStep enforces prerequisites — jumping to Label without a dataset is rejected', async ({
+    page,
+    panel,
+    mockBridge
+  }) => {
+    await openPanel(panel, mockBridge)
+    await mockBridge.command('open_training', { dock: true })
+    await expect(page.locator('.cmcp-tr-modal')).toBeVisible()
+    const reply = await mockBridge.command('training_goto_step', { step: 2 })
+    expect(reply.ok).toBe(false)
+    // Backend-capability or dataset-name/image gate fires — either is an honest
+    // rejection rather than a silent jump.
+    expect(String(reply.error)).toMatch(/backend|dataset name|image/i)
   })
 
   test('stale training handle after Escape → honest not-open error', async ({

--- a/browser_tests/agent-drive.spec.ts
+++ b/browser_tests/agent-drive.spec.ts
@@ -1,0 +1,204 @@
+/**
+ * Tier 1 — agent-driven CivitAI + Training modals.
+ *
+ * Exercises the post-open "drive" surface the agent reaches over the bridge:
+ * open_civitai (docked), civitai_results / civitai_highlight / civitai_search /
+ * civitai_switch_tab, and the training parity (open_training / training_highlight).
+ * The bridge cmds are sent the way the real orchestrator sends them — via
+ * MockBridge.command({rid,cmd,...}) — and we assert the reply shape AND the DOM
+ * (green-glow cards/steps, dock geometry, teardown).
+ *
+ * These are the audit item-12 coverage: highlight-before-load, reload clears
+ * glow, appended-card highlight on scroll, stale-handle throw, training-first
+ * glow, dock orientation/collapse/detach, Escape cleanup.
+ *
+ * NOTE: like the rest of this suite, these specs require a LIVE ComfyUI at
+ * localhost:8188 with the pack junctioned in (see playwright.config.ts). They
+ * are written to run under `npm run test:e2e` and are GATED ON THE LIVE PASS —
+ * they do not run under `npm run test:unit` (node --test) which has no DOM.
+ */
+import { test, expect } from './fixtures/panelTest'
+
+// A canned /v1/images feed page. Distinct ids so highlight-by-id is meaningful.
+// `page` selects which ids come back so a later "page" can carry a target that
+// the first page didn't (the scroll/append-highlight case).
+function imagesPage(ids: number[], nextCursor: string | null) {
+  return {
+    items: ids.map((id) => ({
+      id,
+      url: `https://cdn/${id}.jpeg`,
+      type: 'image',
+      width: 512,
+      height: 512,
+      nsfwLevel: 1,
+      username: `user${id}`,
+      stats: { likeCount: id },
+      meta: { prompt: `prompt for ${id}` }
+    })),
+    metadata: { nextCursor }
+  }
+}
+
+async function stubCivitai(page: import('@playwright/test').Page, pages: Record<string, unknown>[]) {
+  let call = 0
+  // All CivitAI REST/tRPC calls funnel through the same-origin POST proxy.
+  await page.route('**/comfyui_mcp_panel/civitai/api', (route) => {
+    const body = pages[Math.min(call, pages.length - 1)]
+    call += 1
+    route.fulfill({ json: body })
+  })
+  // Media proxy — a 1px PNG is enough for <img>/<video> src.
+  await page.route('**/comfyui_mcp_panel/civitai/media*', (route) =>
+    route.fulfill({ body: Buffer.from([0x89, 0x50, 0x4e, 0x47]), contentType: 'image/png' })
+  )
+  // Signed-out OAuth status so the favorites tab / account button stay inert.
+  await page.route('**/comfyui_mcp_panel/civitai/oauth/status', (route) =>
+    route.fulfill({ json: { signedIn: false } })
+  )
+}
+
+async function openPanel(panel: any, mockBridge: any) {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+}
+
+test.describe('agent-driven CivitAI modal', () => {
+  test('highlight issued BEFORE the first page lands still glows once it arrives', async ({
+    page,
+    panel,
+    mockBridge
+  }) => {
+    await stubCivitai(page, [imagesPage([11, 12, 13], null)])
+    await openPanel(panel, mockBridge)
+
+    // Agent opens docked and IMMEDIATELY highlights — before results exist.
+    await mockBridge.command('open_civitai', { query: 'cats', dock: true })
+    const hl = await mockBridge.command('civitai_highlight', { ids: [12] })
+    expect(hl.ok).toBe(true)
+    // highlight() awaited the in-flight first-page load, so the card is glowing.
+    await expect(page.locator('.cmcp-cv-card[data-id="12"].cmcp-agent-glow')).toBeVisible()
+    expect(hl.result.highlighted).toBe(1)
+    expect(hl.result.missing).toEqual([])
+  })
+
+  test('a reload (switch_tab / search) clears the glow', async ({ page, panel, mockBridge }) => {
+    await stubCivitai(page, [imagesPage([21, 22], null)])
+    await openPanel(panel, mockBridge)
+    await mockBridge.command('open_civitai', { query: 'a', dock: true })
+    await mockBridge.command('civitai_highlight', { ids: [21] })
+    await expect(page.locator('.cmcp-cv-card[data-id="21"].cmcp-agent-glow')).toBeVisible()
+
+    await mockBridge.command('civitai_search', { query: 'b' })
+    // The grid was wiped + re-fetched → no lingering glow.
+    await expect(page.locator('.cmcp-agent-glow')).toHaveCount(0)
+  })
+
+  test('append-on-scroll re-applies the highlight to a card from a LATER page', async ({
+    page,
+    panel,
+    mockBridge
+  }) => {
+    // First page lacks id 99; the second page (next cursor) carries it.
+    await stubCivitai(page, [
+      imagesPage([31, 32], 'c1'),
+      imagesPage([99], null)
+    ])
+    await openPanel(panel, mockBridge)
+    await mockBridge.command('open_civitai', { query: 'x', dock: true })
+    const hl = await mockBridge.command('civitai_highlight', { ids: [99] })
+    // Not on the first page yet → reported missing, but the set persists.
+    expect(hl.result.missing).toContain('99')
+
+    // Scroll the body to trigger loadMore → the second page appends id 99, and
+    // appendItems re-applies the retained highlight set.
+    await page.locator('.cmcp-cv-body').evaluate((el) => { el.scrollTop = el.scrollHeight })
+    await expect(page.locator('.cmcp-cv-card[data-id="99"].cmcp-agent-glow')).toBeVisible()
+  })
+
+  test('civitai_results returns bounded metadata + URLs (no image bytes)', async ({
+    page,
+    panel,
+    mockBridge
+  }) => {
+    await stubCivitai(page, [imagesPage([41, 42, 43, 44], null)])
+    await openPanel(panel, mockBridge)
+    await mockBridge.command('open_civitai', { query: 'y', dock: true })
+    const res = await mockBridge.command('civitai_results', { limit: 2 })
+    expect(res.ok).toBe(true)
+    expect(res.result.count).toBe(2)
+    expect(res.result.truncated).toBe(true)
+    expect(typeof res.result.renderRev).toBe('number')
+    for (const it of res.result.items) {
+      expect(typeof it.id).not.toBe('undefined')
+      for (const u of it.urls) expect(typeof u).toBe('string')
+    }
+  })
+
+  test('stale handle: a drive cmd after close is an honest error (outer ok:false)', async ({
+    page,
+    panel,
+    mockBridge
+  }) => {
+    await stubCivitai(page, [imagesPage([51], null)])
+    await openPanel(panel, mockBridge)
+    await mockBridge.command('open_civitai', { query: 'z', dock: true })
+    await expect(page.locator('.cmcp-civitai-modal')).toBeVisible()
+    // Close via Escape (audit item 9 — base modals now handle it).
+    await page.keyboard.press('Escape')
+    await expect(page.locator('.cmcp-civitai-modal')).toHaveCount(0)
+
+    const reply = await mockBridge.command('civitai_results', {})
+    expect(reply.ok).toBe(false) // the bridge THREW, not swallowed as success
+    expect(String(reply.error)).toContain('not open')
+  })
+
+  test('docked mode leaves the chat interactive (overlay is click-through)', async ({
+    page,
+    panel,
+    mockBridge
+  }) => {
+    await stubCivitai(page, [imagesPage([61], null)])
+    await openPanel(panel, mockBridge)
+    await mockBridge.command('open_civitai', { query: 'q', dock: true })
+    const overlay = page.locator('.cmcp-cv-overlay.cmcp-docked')
+    await expect(overlay).toBeVisible()
+    // The overlay must not intercept pointer events (chat stays usable).
+    await expect(overlay).toHaveCSS('pointer-events', 'none')
+    // The card itself DOES catch them.
+    await expect(page.locator('.cmcp-docked .cmcp-civitai-modal')).toHaveCSS('pointer-events', 'auto')
+  })
+})
+
+test.describe('agent-driven Training modal', () => {
+  test('training-first glow: step highlight works without the CivitAI CSS ever loading', async ({
+    page,
+    panel,
+    mockBridge
+  }) => {
+    // No CivitAI modal is ever opened here — proves .cmcp-agent-glow is injected
+    // by the training module itself (audit item 4).
+    await openPanel(panel, mockBridge)
+    await mockBridge.command('open_training', { dock: true })
+    await expect(page.locator('.cmcp-tr-modal')).toBeVisible()
+    const hl = await mockBridge.command('training_highlight', { refs: ['step:dataset'] })
+    expect(hl.ok).toBe(true)
+    await expect(page.locator('[data-ref="step:dataset"].cmcp-agent-glow')).toBeVisible()
+  })
+
+  test('stale training handle after Escape → honest not-open error', async ({
+    page,
+    panel,
+    mockBridge
+  }) => {
+    await openPanel(panel, mockBridge)
+    await mockBridge.command('open_training', { dock: true })
+    await expect(page.locator('.cmcp-tr-modal')).toBeVisible()
+    await page.keyboard.press('Escape')
+    await expect(page.locator('.cmcp-tr-modal')).toHaveCount(0)
+    const reply = await mockBridge.command('training_highlight', { refs: ['step:dataset'] })
+    expect(reply.ok).toBe(false)
+    expect(String(reply.error)).toContain('not open')
+  })
+})

--- a/browser_tests/unit/civitai-drive-results.test.mjs
+++ b/browser_tests/unit/civitai-drive-results.test.mjs
@@ -7,7 +7,7 @@
 // returns METADATA + URLs ONLY, never image bytes, and clamps `limit`.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { serializeCivitaiResults } from "../../web/js/cmcp-civitai-ui.js";
+import { serializeCivitaiResults, CIVITAI_PROMPT_CAP } from "../../web/js/cmcp-civitai-ui.js";
 
 // Media rows as produced by CivitaiClient._fromRest / _fromMeili.
 const mediaRows = [
@@ -92,4 +92,21 @@ test("missing/empty urls are dropped, not emitted as null/undefined", () => {
 test("non-array source is tolerated", () => {
   const out = serializeCivitaiResults(null, { model: false });
   assert.deepEqual(out, { items: [], total: 0, loading: false });
+});
+
+test("long prompts are capped to the token budget with an ellipsis", () => {
+  const long = "x".repeat(CIVITAI_PROMPT_CAP + 500);
+  const out = serializeCivitaiResults(
+    [{ id: 1, type: "image", author: "a", reactions: 0, prompt: long, thumbnailUrl: "/t/1", fullUrl: "/f/1" }],
+    { model: false },
+  );
+  const p = out.items[0].prompt;
+  assert.equal(p.length, CIVITAI_PROMPT_CAP + 1); // cap + the "…"
+  assert.ok(p.endsWith("…"));
+  // A short prompt is passed through verbatim.
+  const short = serializeCivitaiResults(
+    [{ id: 2, type: "image", author: "a", reactions: 0, prompt: "tiny", thumbnailUrl: "/t/2", fullUrl: "/f/2" }],
+    { model: false },
+  );
+  assert.equal(short.items[0].prompt, "tiny");
 });

--- a/browser_tests/unit/civitai-drive-results.test.mjs
+++ b/browser_tests/unit/civitai-drive-results.test.mjs
@@ -1,0 +1,95 @@
+// Unit tests for the agent-drive results serializer (cmcp-civitai-ui.js).
+//
+// `serializeCivitaiResults` is the pure core behind the `civitai_results` bridge
+// cmd: it turns the modal's in-memory `state.items` (media) / `state.models`
+// (models) into the agent contract shape — id, kind, title, creator,
+// baseModel/type, stats, prompt, urls. The invariant that matters most: it
+// returns METADATA + URLs ONLY, never image bytes, and clamps `limit`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { serializeCivitaiResults } from "../../web/js/cmcp-civitai-ui.js";
+
+// Media rows as produced by CivitaiClient._fromRest / _fromMeili.
+const mediaRows = [
+  {
+    id: 101, type: "image", author: "alice", modelName: "FLUX.1-dev",
+    reactions: 42, prompt: "a cat astronaut",
+    thumbnailUrl: "/proxy/thumb/101.jpeg", fullUrl: "/proxy/full/101.jpeg",
+  },
+  {
+    id: 102, type: "video", author: "bob", modelName: "Wan 2.2",
+    reactions: 7, prompt: null,
+    thumbnailUrl: "/proxy/thumb/102.jpeg", fullUrl: "/proxy/full/102.mp4",
+  },
+];
+
+// Model rows as produced by CivitaiClient._modelFromJson.
+const modelRows = [
+  {
+    id: 5, name: "Dreamy LoRA", creator: "carol", baseModel: "SDXL 1.0",
+    type: "LORA", downloadCount: 1234, thumbsUp: 88, coverUrl: "/proxy/cover/5.jpeg",
+  },
+];
+
+test("media serialization matches the contract shape", () => {
+  const out = serializeCivitaiResults(mediaRows, { model: false, loading: false });
+  assert.equal(out.total, 2);
+  assert.equal(out.loading, false);
+  assert.equal(out.items.length, 2);
+
+  const [a, b] = out.items;
+  assert.deepEqual(a, {
+    id: 101, kind: "image", title: null, creator: "alice",
+    baseModel: "FLUX.1-dev", type: "image",
+    stats: { reactions: 42 }, prompt: "a cat astronaut",
+    urls: ["/proxy/thumb/101.jpeg", "/proxy/full/101.jpeg"],
+  });
+  assert.equal(b.kind, "video"); // type:"video" → kind:"video"
+  assert.equal(b.prompt, null);
+  assert.deepEqual(b.urls, ["/proxy/thumb/102.jpeg", "/proxy/full/102.mp4"]);
+});
+
+test("model serialization matches the contract shape", () => {
+  const out = serializeCivitaiResults(modelRows, { model: true, loading: true });
+  assert.equal(out.total, 1);
+  assert.equal(out.loading, true);
+  assert.deepEqual(out.items[0], {
+    id: 5, kind: "model", title: "Dreamy LoRA", creator: "carol",
+    baseModel: "SDXL 1.0", type: "LORA",
+    stats: { downloadCount: 1234, thumbsUp: 88 },
+    prompt: null, urls: ["/proxy/cover/5.jpeg"],
+  });
+});
+
+test("every serialized url is a string, never image bytes/blobs", () => {
+  const out = serializeCivitaiResults(mediaRows, { model: false });
+  for (const it of out.items) {
+    assert.ok(Array.isArray(it.urls));
+    for (const u of it.urls) assert.equal(typeof u, "string");
+  }
+});
+
+test("limit is honored and clamped to [1,200]", () => {
+  const many = Array.from({ length: 300 }, (_, i) => ({
+    id: i, type: "image", author: "x", reactions: 0,
+    thumbnailUrl: `/t/${i}`, fullUrl: `/f/${i}`,
+  }));
+  assert.equal(serializeCivitaiResults(many, { limit: 5 }).items.length, 5);
+  assert.equal(serializeCivitaiResults(many, { limit: 1000 }).items.length, 200); // clamped
+  assert.equal(serializeCivitaiResults(many, { limit: 0 }).items.length, 20); // invalid → default
+  assert.equal(serializeCivitaiResults(many, { limit: -3 }).items.length, 20); // invalid → default
+  assert.equal(serializeCivitaiResults(many).items.length, 20); // default
+  // total always reflects the full source, not the truncated page.
+  assert.equal(serializeCivitaiResults(many, { limit: 5 }).total, 300);
+});
+
+test("missing/empty urls are dropped, not emitted as null/undefined", () => {
+  const partial = [{ id: 1, type: "image", author: "z", reactions: 0, thumbnailUrl: "/t/1", fullUrl: null }];
+  const out = serializeCivitaiResults(partial, { model: false });
+  assert.deepEqual(out.items[0].urls, ["/t/1"]);
+});
+
+test("non-array source is tolerated", () => {
+  const out = serializeCivitaiResults(null, { model: false });
+  assert.deepEqual(out, { items: [], total: 0, loading: false });
+});

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -256,6 +256,11 @@ export function graphDirtyForConfirm(ctx) {
  *  baseModel/type, stats, prompt, and media URL(s). Metadata + URLs ONLY — never
  *  image bytes (the agent reasons from text; the human clicks to view). Pure and
  *  exported for unit tests. `limit` is clamped to [1, 200]. */
+export const CIVITAI_PROMPT_CAP = 600; // chars — bound the agent's token budget
+function _capPrompt(p) {
+  if (typeof p !== "string" || !p) return p || null;
+  return p.length > CIVITAI_PROMPT_CAP ? p.slice(0, CIVITAI_PROMPT_CAP) + "…" : p;
+}
 export function serializeCivitaiResults(source, { model = false, limit = 20, loading = false } = {}) {
   const n = Number(limit);
   const lim = Number.isFinite(n) && n > 0 ? Math.min(Math.floor(n), 200) : 20;
@@ -270,7 +275,7 @@ export function serializeCivitaiResults(source, { model = false, limit = 20, loa
     title: null, creator: x.author || null,
     baseModel: x.modelName || null, type: x.type || null,
     stats: { reactions: x.reactions ?? null },
-    prompt: x.prompt || null,
+    prompt: _capPrompt(x.prompt), // bounded — token budget (audit item 3)
     urls: [x.thumbnailUrl, x.fullUrl].filter(Boolean),
   });
   return { items, total: rows.length, loading: !!loading };
@@ -298,6 +303,17 @@ export function openCivitaiModal(ctx, opts = {}) {
     searchSeq: 0, // searching-overlay ownership (see reload)
     signedIn: false, localNames: new Set(), localLoaded: false,
     favType: "all", // favorites sub-filter: all | image | video
+    // Agent-drive: a render generation bumped on every reload/tab/filter so a
+    // highlight that survives the await knows whether it's stale, and the
+    // highlight target set (ids, in input order) that appendItems/appendModels
+    // re-applies as later pages stream in on scroll.
+    renderRev: 0,
+    highlightSet: new Set(),
+    highlightOrder: [],
+    // The in-flight first-page reload / current page load, so drive methods can
+    // truly await the modal settling.
+    activeReloadPromise: null,
+    activeLoadPromise: null,
   };
   if (Array.isArray(opts.browsingLevels) && opts.browsingLevels.length) {
     state.filters = { ...state.filters, browsingLevels: [...opts.browsingLevels] };
@@ -309,16 +325,44 @@ export function openCivitaiModal(ctx, opts = {}) {
   // narrow panel sidebar) ────────────────────────────────────────────────────
   const overlay = el("div", "cmcp-cv-overlay");
   const modal = el("div", "cmcp-modal cmcp-civitai-modal");
-  let _onDockResize = null;
+  // Self-invalidating handle: isOpen flips false on the FIRST close() and every
+  // drive method asserts it, so a stale reference held past close throws instead
+  // of poking a detached grid. onClose lets the host compare-and-null its stored
+  // handle. close() is idempotent and tears down EVERY async/listener owned here.
+  let isOpen = true;
+  let _onDockResize = null;   // window-resize fallback when ctx.watchDock is absent
+  let _dockDispose = null;    // ResizeObserver+listener disposer from ctx.watchDock
+  let _oauthPollIv = null;    // sign-in completion poll (accountFlow)
+  let _onEscape = null;       // document Escape → close
   const close = () => {
+    if (!isOpen) return;      // idempotent
+    isOpen = false;
+    state.reqId++;            // invalidate any in-flight fetch (its guarded finally no-ops)
+    state.activeReloadPromise = null;
+    state.activeLoadPromise = null;
+    try { clearTimeout(searchTimer); } catch { /* not armed */ }
+    if (_oauthPollIv) { clearInterval(_oauthPollIv); _oauthPollIv = null; }
+    try { closeSubModals(); } catch { /* already gone */ }
+    if (_onEscape) { document.removeEventListener("keydown", _onEscape); _onEscape = null; }
     if (_onDockResize) { window.removeEventListener("resize", _onDockResize); _onDockResize = null; }
+    if (_dockDispose) { try { _dockDispose(); } catch { /* best effort */ } _dockDispose = null; }
     overlay.remove();
     try { opts.onClose?.(); } catch { /* host bookkeeping only */ }
   };
   // In docked mode the overlay itself is click-through (pointer-events:none), so a
-  // backdrop mousedown never fires here — the header ✕ is the only dismiss. Centered
-  // mode keeps the backdrop-click-to-close affordance.
+  // backdrop mousedown never fires here — the header ✕ / Escape are the dismissals.
+  // Centered mode keeps the backdrop-click-to-close affordance.
   overlay.addEventListener("mousedown", (e) => { if (e.target === overlay) close(); });
+  // Base modals had no Escape handler (audit item 9): add one that funnels through
+  // close(), but yield to a stacked lightbox / sub-modal so Escape peels the top.
+  _onEscape = (e) => {
+    if (e.key !== "Escape") return;
+    if (_subModals.size > 0) return;
+    if (document.querySelector(".cmcp-cv-lb")) return;
+    e.stopPropagation();
+    close();
+  };
+  document.addEventListener("keydown", _onEscape);
 
   // header
   const head = el("div", "cmcp-cv-head");
@@ -453,32 +497,68 @@ export function openCivitaiModal(ctx, opts = {}) {
   document.body.appendChild(overlay);
 
   // ── docked mode (agent-driven) ─────────────────────────────────────────────
-  // Anchor the card to the sidebar's right edge so chat stays visible + usable;
-  // below a narrow breakpoint fall back to the centered overlay. Recomputed on
-  // window resize (listener torn down in close()).
-  const DOCK_MIN_WIDTH = 900;
+  // Dock into the canvas area OPPOSITE the Agent pane (which may be docked left
+  // OR right) so chat stays visible + interactive. Geometry comes from the host
+  // (ctx.dockGeometry: it owns the ComfyUI pane/canvas measurement and the
+  // left/right detection), so this module stays ComfyUI-agnostic. Three states:
+  //  - detached  → the Agent tab was switched away; the body-mounted modal is
+  //    orphaned, so HIDE it (don't float centered over an unrelated screen).
+  //  - centered  → no eligible anchor (missing/zero-size/too-small/narrow window)
+  //  - docked    → anchored rect from the host.
+  applyDock.centered = false;
   function applyDock() {
-    const docked = !!opts.dock && window.innerWidth >= DOCK_MIN_WIDTH;
-    overlay.classList.toggle("cmcp-docked", docked);
-    if (!docked) {
-      modal.style.left = modal.style.right = modal.style.top = modal.style.bottom = "";
+    if (!opts.dock) { setCentered(); return; }
+    const geo = _dockGeometry();
+    if (geo?.status === "detached") {
+      overlay.style.display = "none";
       return;
     }
-    let left = 0, top = 0;
+    overlay.style.display = "";
+    if (geo?.status === "docked" && window.innerWidth >= 900) {
+      overlay.classList.add("cmcp-docked");
+      modal.style.left = `${Math.round(geo.left)}px`;
+      modal.style.top = `${Math.round(geo.top)}px`;
+      modal.style.right = `${Math.round(geo.right)}px`;
+      modal.style.bottom = `${Math.round(geo.bottom)}px`;
+      applyDock.centered = false;
+    } else {
+      setCentered();
+    }
+  }
+  function setCentered() {
+    overlay.classList.remove("cmcp-docked");
+    overlay.style.display = "";
+    modal.style.left = modal.style.right = modal.style.top = modal.style.bottom = "";
+    applyDock.centered = true;
+  }
+  /** Host geometry, with a self-contained fallback (single-pane / no host help /
+   *  tests): measure ctx.root's pane and dock to the wider viewport side. */
+  function _dockGeometry() {
+    if (typeof ctx.dockGeometry === "function") {
+      try { const g = ctx.dockGeometry(); if (g) return g; } catch { /* fall through */ }
+    }
     try {
-      const pane = ctx.root?.closest?.(".side-bar-panel") || ctx.root?.closest?.("[class*='sidebar']");
-      const r = pane?.getBoundingClientRect();
-      if (r) { left = Math.max(0, Math.round(r.right)); top = Math.max(0, Math.round(r.top)); }
-    } catch { /* fall back to full-height right edge */ }
-    modal.style.left = `${left}px`;
-    modal.style.top = `${top}px`;
-    modal.style.right = "0px";
-    modal.style.bottom = "0px";
+      const root = ctx.root;
+      if (root && !root.isConnected) return { status: "detached" };
+      const pane = root?.closest?.(".side-bar-panel") || root?.closest?.("[class*='sidebar']") || root;
+      const pr = pane?.getBoundingClientRect?.();
+      if (!pr || pr.width < 1 || pr.height < 1) return { status: "centered" };
+      const vw = window.innerWidth, vh = window.innerHeight;
+      const paneOnLeft = (pr.left + pr.right) / 2 < vw / 2;
+      const left = paneOnLeft ? Math.max(0, pr.right) : 0;
+      const right = paneOnLeft ? 0 : Math.max(0, vw - pr.left);
+      if (vw - left - right < 320) return { status: "centered" };
+      return { status: "docked", left, right, top: Math.max(0, pr.top), bottom: Math.max(0, vh - pr.bottom) };
+    } catch { return { status: "centered" }; }
   }
   if (opts.dock) {
     applyDock();
-    _onDockResize = () => applyDock();
-    window.addEventListener("resize", _onDockResize);
+    // Watch pane + canvas (splitter drags don't fire window-resize) via the host;
+    // fall back to a bare window-resize listener when the host can't help.
+    if (typeof ctx.watchDock === "function") {
+      try { _dockDispose = ctx.watchDock(applyDock); } catch { _dockDispose = null; }
+    }
+    if (!_dockDispose) { _onDockResize = () => applyDock(); window.addEventListener("resize", _onDockResize); }
     // Slide-in on the next frame so the transition runs from the initial state.
     requestAnimationFrame(() => overlay.classList.add("cmcp-dock-in"));
   }
@@ -493,12 +573,24 @@ export function openCivitaiModal(ctx, opts = {}) {
   // ── data ───────────────────────────────────────────────────────────────
   function setLoading(on) { state.loading = on; progress.classList.toggle("on", on); }
 
-  async function reload({ searching = false } = {}) {
+  // Public reload: stores the in-flight promise so drive methods can await the
+  // first page settling, and returns it.
+  function reload(opts2 = {}) {
+    const p = _reload(opts2);
+    state.activeReloadPromise = p;
+    return p;
+  }
+  async function _reload({ searching = false } = {}) {
     // Invalidate any page load already IN FLIGHT: its response belongs to the
     // OLD tab/query/filters and must not repopulate the just-cleared grid (nor
     // leave its cursor behind). The stale request's guarded `finally` won't
     // clear the loading flag anymore, so reset it here too.
     state.reqId++;
+    // New render generation: any highlight awaiting the previous load is now
+    // stale, and the target set is cleared so it can't re-apply to fresh cards.
+    state.renderRev++;
+    state.highlightSet = new Set();
+    state.highlightOrder = [];
     setLoading(false);
     state.items = []; state.models = []; state.cursor = null; state.done = false;
     grid.innerHTML = ""; syncTabs();
@@ -514,7 +606,12 @@ export function openCivitaiModal(ctx, opts = {}) {
     }
   }
 
-  async function loadMore() {
+  function loadMore() {
+    const p = _loadMore();
+    state.activeLoadPromise = p;
+    return p;
+  }
+  async function _loadMore() {
     if (state.loading || state.done) return;
     const req = ++state.reqId;
     setLoading(true);
@@ -610,16 +707,29 @@ export function openCivitaiModal(ctx, opts = {}) {
     }
   }
 
+  // Re-apply the agent's highlight to a freshly-appended card: a highlight can
+  // target an id that only lands on a LATER page (scroll), so the glow must be
+  // (re)applied as cards stream in — not just at the moment highlight() ran.
+  function _applyGlowIfTargeted(card, id) {
+    if (state.highlightSet.has(String(id))) card.classList.add("cmcp-agent-glow");
+  }
   function appendItems(items) {
     for (const it of items) {
       if (tabDef().fav && !_liked.has(it.id)) _liked.set(it.id, true);
       state.items.push(it);
       const idx = state.items.length - 1;
-      grid.appendChild(mediaCard(it, idx));
+      const card = mediaCard(it, idx);
+      _applyGlowIfTargeted(card, it.id);
+      grid.appendChild(card);
     }
   }
   function appendModels(models) {
-    for (const m of models) { state.models.push(m); grid.appendChild(modelCard(m)); }
+    for (const m of models) {
+      state.models.push(m);
+      const card = modelCard(m);
+      _applyGlowIfTargeted(card, m.id);
+      grid.appendChild(card);
+    }
   }
 
   // ── cards ─────────────────────────────────────────────────────────────
@@ -1665,12 +1775,14 @@ export function openCivitaiModal(ctx, opts = {}) {
       const r = await ctx.api.fetchApi("/comfyui_mcp_panel/civitai/oauth/start?origin=" + encodeURIComponent(location.origin));
       const { authorize_url } = await r.json();
       window.open(authorize_url, "_blank", "width=520,height=720");
-      // poll for completion
+      // poll for completion — tracked so close() can cancel a pending sign-in.
       let tries = 0;
-      const iv = setInterval(async () => {
+      if (_oauthPollIv) clearInterval(_oauthPollIv);
+      _oauthPollIv = setInterval(async () => {
+        if (!isOpen) { clearInterval(_oauthPollIv); _oauthPollIv = null; return; }
         await refreshAuth();
         if (state.signedIn || ++tries > 120) {
-          clearInterval(iv);
+          clearInterval(_oauthPollIv); _oauthPollIv = null;
           if (state.signedIn) { toast("Signed in to CivitAI."); if (tabDef().fav) reload(); }
         }
       }, 2000);
@@ -1722,21 +1834,37 @@ export function openCivitaiModal(ctx, opts = {}) {
   // Post-open control surface: the same inner state/functions the UI drives,
   // exposed so the bridge (and through it the agent) can switch tabs, re-search,
   // read results (metadata + URLs only — never image bytes), and glow-highlight
-  // the interesting cards. Every method throws or returns a small plain object;
-  // no dynamic exec (registry-YARA safe).
-  function driveSwitchTab(key) {
+  // the interesting cards. Every method awaits the modal settling, throws on a
+  // closed handle, and returns a small plain object; no dynamic exec (YARA safe).
+  function _assertOpen() { if (!isOpen) throw new Error("civitai browser not open"); }
+  async function driveSwitchTab(key) {
+    _assertOpen();
     if (!TABS.some((t) => t.key === key)) throw new Error(`unknown tab "${key}"`);
-    if (state.tab !== key) { state.tab = key; syncTabs(); reload(); }
+    if (state.tab !== key) { state.tab = key; syncTabs(); await reload(); }
     else syncTabs();
-    return { tab: state.tab };
+    return { tab: state.tab, renderRev: state.renderRev };
   }
-  function driveSearch({ query, filters } = {}) {
+  async function driveSearch({ query, filters, browsingLevels } = {}) {
+    _assertOpen();
+    // Atomic normalize: fold filters, then query→(creator,text) in one shot so a
+    // half-applied state never reaches reload.
     if (filters && typeof filters === "object") {
       state.filters = {
         ...state.filters, ...filters,
         baseModels: Array.isArray(filters.baseModels) ? [...filters.baseModels] : state.filters.baseModels,
         browsingLevels: Array.isArray(filters.browsingLevels) ? [...filters.browsingLevels] : state.filters.browsingLevels,
       };
+    }
+    // NSFW browsing levels arrive already server-clamped (mcp strips adult
+    // levels without consent). Defense-in-depth: the client has no NSFW gate, so
+    // drop any level ∉ the known enum {1,2,4,8,16} before applying — never let a
+    // malformed/unknown level reach the query. Omitted → leave the filter as-is.
+    const lvlSrc = Array.isArray(browsingLevels) ? browsingLevels
+      : (filters && Array.isArray(filters.browsingLevels) ? filters.browsingLevels : null);
+    if (lvlSrc) {
+      const KNOWN = new Set(LEVELS.map((l) => l.level));
+      const clean = [...new Set(lvlSrc.map(Number).filter((n) => KNOWN.has(n)))];
+      state.filters = { ...state.filters, browsingLevels: clean.length ? clean : [1] };
     }
     if (typeof query === "string") {
       search.value = query;
@@ -1745,34 +1873,68 @@ export function openCivitaiModal(ctx, opts = {}) {
       if (parsed.creator) setCreator(parsed.creator); // normalizes @token + username
       else if (creatorFromSearch && state.filters.username) { setCreator(null); }
     }
+    clearTimeout(searchTimer); // cancel the 500ms debounce so it can't double-fire
     syncTabs();
-    reload({ searching: true });
-    return { tab: state.tab, query: state.query, creator: state.filters.username || null };
+    // FORCE a reload even when the text is unchanged (a re-search is an explicit
+    // agent intent, unlike applySearch's typing-debounce dedupe).
+    await reload({ searching: true });
+    return { tab: state.tab, query: state.query, creator: state.filters.username || null, renderRev: state.renderRev };
   }
   function driveGetResults({ limit = 20 } = {}) {
+    _assertOpen();
     const model = isModelTab();
-    return serializeCivitaiResults(model ? state.models : state.items,
-      { model, limit, loading: state.loading });
+    const source = model ? state.models : state.items;
+    const ser = serializeCivitaiResults(source, { model, limit, loading: state.loading });
+    return {
+      ...ser, // { items, total, loading }
+      count: ser.items.length,
+      done: !!state.done,
+      renderRev: state.renderRev,
+      truncated: source.length > ser.items.length,
+    };
   }
-  function driveHighlight(ids, { kind } = {}) { // eslint-disable-line no-unused-vars
-    const list = Array.isArray(ids) ? ids : (ids != null ? [ids] : []);
-    let first = null, n = 0;
-    for (const id of list) {
-      const card = grid.querySelector(`.cmcp-cv-card[data-id="${CSS.escape(String(id))}"]`);
-      if (!card) continue;
-      card.classList.add("cmcp-agent-glow");
-      if (!first) first = card;
-      n++;
+  /** Highlight a set of ids (REPLACEMENT semantics). Awaits the in-flight
+   *  first-page load so a highlight issued before results land still lands; if a
+   *  reload/tab/filter supersedes us mid-await the set was cleared and we no-op.
+   *  Persists the set so later pages glow as they stream in (see appendItems). */
+  async function driveHighlight(ids, { kind } = {}) { // eslint-disable-line no-unused-vars
+    _assertOpen();
+    const list = (Array.isArray(ids) ? ids : (ids != null ? [ids] : [])).map((x) => String(x));
+    const rev = state.renderRev;
+    try { await state.activeReloadPromise; } catch { /* fetch error surfaces elsewhere */ }
+    _assertOpen();
+    if (state.renderRev !== rev) {
+      // A reload superseded this highlight while we awaited — honor the newest
+      // intent by applying to the CURRENT generation rather than a stale grid.
+    }
+    // Replacement: strip the prior set, install the new one, then paint.
+    driveClearHighlight();
+    state.highlightOrder = [...list];
+    state.highlightSet = new Set(list);
+    let first = null, hit = 0;
+    const missing = [];
+    for (const id of list) { // input order → first found scrolls into view
+      const card = grid.querySelector(`.cmcp-cv-card[data-id="${CSS.escape(id)}"]`);
+      if (card) { card.classList.add("cmcp-agent-glow"); if (!first) first = card; hit++; }
+      else missing.push(id);
     }
     if (first) first.scrollIntoView({ behavior: "smooth", block: "nearest" });
-    return { highlighted: n };
+    return { highlighted: hit, missing, renderRev: state.renderRev };
   }
   function driveClearHighlight() {
+    _assertOpen();
+    state.highlightSet = new Set();
+    state.highlightOrder = [];
     for (const c of grid.querySelectorAll(".cmcp-cv-card.cmcp-agent-glow")) c.classList.remove("cmcp-agent-glow");
     return { ok: true };
   }
-  function driveOpenLightbox(id) {
-    if (isModelTab()) {
+  /** Open the lightbox for a card. Dispatch by KIND: media → openViewer(index)
+   *  (index-addressed); model → openModelDetail (model tabs leave state.items
+   *  empty, so an index lookup there is meaningless). */
+  function driveOpenLightbox(id, { kind } = {}) {
+    _assertOpen();
+    const wantModel = kind === "model" || (kind == null && isModelTab());
+    if (wantModel) {
       const m = state.models.find((x) => String(x.id) === String(id));
       if (!m) throw new Error(`no model card for id ${id}`);
       openModelDetail(m);
@@ -1783,7 +1945,13 @@ export function openCivitaiModal(ctx, opts = {}) {
     openViewer(i);
     return { opened: "media", id };
   }
-  function driveGetState() { return { tab: state.tab, loading: !!state.loading }; }
+  function driveGetState() {
+    return {
+      isOpen, tab: state.tab, loading: !!state.loading, done: !!state.done,
+      renderRev: state.renderRev, docked: !applyDock.centered && overlay.classList.contains("cmcp-docked"),
+      highlighted: state.highlightOrder.slice(),
+    };
+  }
 
   // ── go ───────────────────────────────────────────────────────────────
   syncTabs();

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -334,6 +334,7 @@ export function openCivitaiModal(ctx, opts = {}) {
   let _dockDispose = null;    // ResizeObserver+listener disposer from ctx.watchDock
   let _oauthPollIv = null;    // sign-in completion poll (accountFlow)
   let _onEscape = null;       // document Escape → close
+  let _activeLightboxClose = null; // openViewer's teardown (owns its own doc keydown listener)
   const close = () => {
     if (!isOpen) return;      // idempotent
     isOpen = false;
@@ -342,6 +343,10 @@ export function openCivitaiModal(ctx, opts = {}) {
     state.activeLoadPromise = null;
     try { clearTimeout(searchTimer); } catch { /* not armed */ }
     if (_oauthPollIv) { clearInterval(_oauthPollIv); _oauthPollIv = null; }
+    // The lightbox is body-mounted with its OWN document keydown listener — a
+    // programmatic reopen would otherwise strand it (+ its listener) above the
+    // new modal (codex finding). Tear it down through this one path.
+    if (_activeLightboxClose) { try { _activeLightboxClose(); } catch { /* already gone */ } _activeLightboxClose = null; }
     try { closeSubModals(); } catch { /* already gone */ }
     if (_onEscape) { document.removeEventListener("keydown", _onEscape); _onEscape = null; }
     if (_onDockResize) { window.removeEventListener("resize", _onDockResize); _onDockResize = null; }
@@ -627,14 +632,18 @@ export function openCivitaiModal(ctx, opts = {}) {
       const t = tabDef();
       if (t.fav) {
         if (!state.signedIn) { sentinel.textContent = "Sign in to see your favorites."; setLoading(false); return; }
-        // YOUR likes are yours: no browsing-level gate here (the PG default was
-        // silently hiding most of the list), and the subnav chips narrow by type.
-        // The feed reads the likes COLLECTION (auto-detected) — reactions only
-        // hold in-app hearts; see resolveLikesCollectionId.
+        // The favorites feed is still browsing-level gated by the ACTIVE filter:
+        // fetchFavorites defaults to ALL levels, so an agent-driven session that
+        // clamped the levels (no NSFW consent) would otherwise leak R/X/XXX here
+        // (security: codex finding). Pass the same clamped set as every other
+        // feed. The subnav chips narrow by type; the feed reads the likes
+        // COLLECTION (auto-detected) — reactions only hold in-app hearts; see
+        // resolveLikesCollectionId.
         const colId = await resolveLikesCollectionId(client);
         if (req !== state.reqId) return;
         const page = await client.fetchFavorites({
           cursor: state.cursor,
+          levels,
           ...(colId ? { collectionId: colId } : {}),
           ...(state.favType !== "all" ? { types: [state.favType] } : {}),
         });
@@ -843,7 +852,14 @@ export function openCivitaiModal(ctx, opts = {}) {
       const b = el("button", "cmcp-cv-iconbtn"); b.innerHTML = `<i class="pi ${icon}"></i>`;
       if (title) b.title = title; b.addEventListener("click", fn); return b;
     };
-    const closeLb = () => { lb.remove(); document.removeEventListener("keydown", onKey, true); };
+    const closeLb = () => {
+      lb.remove();
+      document.removeEventListener("keydown", onKey, true);
+      if (_activeLightboxClose === closeLb) _activeLightboxClose = null;
+    };
+    // Track the live lightbox so the modal's unified close() can dismiss it (and
+    // remove its listener) on a programmatic reopen (codex finding).
+    _activeLightboxClose = closeLb;
     const onKey = (e) => {
       if (e.key === "Escape") { e.stopPropagation(); closeLb(); }
       else if (e.key === "ArrowRight" || e.key === "ArrowDown") { e.stopPropagation(); step(1); }
@@ -1781,6 +1797,9 @@ export function openCivitaiModal(ctx, opts = {}) {
       _oauthPollIv = setInterval(async () => {
         if (!isOpen) { clearInterval(_oauthPollIv); _oauthPollIv = null; return; }
         await refreshAuth();
+        // Re-check AFTER the await: close() may have fired during the fetch, and
+        // the continuation must not toast/reload a torn-down modal (codex finding).
+        if (!isOpen) { if (_oauthPollIv) { clearInterval(_oauthPollIv); _oauthPollIv = null; } return; }
         if (state.signedIn || ++tries > 120) {
           clearInterval(_oauthPollIv); _oauthPollIv = null;
           if (state.signedIn) { toast("Signed in to CivitAI."); if (tabDef().fav) reload(); }
@@ -1894,8 +1913,7 @@ export function openCivitaiModal(ctx, opts = {}) {
     };
   }
   /** Highlight a set of ids (REPLACEMENT semantics). Awaits the in-flight
-   *  first-page load so a highlight issued before results land still lands; if a
-   *  reload/tab/filter supersedes us mid-await the set was cleared and we no-op.
+   *  first-page load so a highlight issued before results land still lands.
    *  Persists the set so later pages glow as they stream in (see appendItems). */
   async function driveHighlight(ids, { kind } = {}) { // eslint-disable-line no-unused-vars
     _assertOpen();
@@ -1904,8 +1922,12 @@ export function openCivitaiModal(ctx, opts = {}) {
     try { await state.activeReloadPromise; } catch { /* fetch error surfaces elsewhere */ }
     _assertOpen();
     if (state.renderRev !== rev) {
-      // A reload superseded this highlight while we awaited — honor the newest
-      // intent by applying to the CURRENT generation rather than a stale grid.
+      // A reload/tab/filter superseded this highlight while we awaited: these ids
+      // belonged to the OLD search and MUST NOT be installed on the new
+      // generation (they'd glow same-id cards from a different query). Bail
+      // without touching the current set — the agent can re-issue against the
+      // new results (codex finding).
+      return { highlighted: 0, missing: list, renderRev: state.renderRev, superseded: true };
     }
     // Replacement: strip the prior set, install the new one, then paint.
     driveClearHighlight();

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -206,6 +206,24 @@ function injectCss() {
   @media (max-width: 760px) { .cmcp-cv-lb { flex-direction: column; }
     .cmcp-cv-lb-side { flex: 0 0 45%; max-width: none; border-left: none;
       border-top: 1px solid var(--p-content-border-color,#3f3f46); } }
+  /* Agent-driven "glow" — the modal highlights the cards the agent points at. */
+  .cmcp-cv-card.cmcp-agent-glow { outline: 2px solid var(--p-green-400,#4ade80);
+    box-shadow: 0 0 0 2px var(--p-green-400,#4ade80), 0 0 16px 2px rgba(74,222,128,.6);
+    animation: cmcp-glow 1.4s ease-in-out infinite; }
+  @keyframes cmcp-glow { 50% { box-shadow: 0 0 0 3px var(--p-green-400,#4ade80),
+    0 0 24px 6px rgba(74,222,128,.9); } }
+  /* Agent-driven side-dock: anchor to the sidebar's right edge (measured in JS),
+     drop the dim backdrop and let clicks pass THROUGH the overlay so chat stays
+     interactive; only the modal card itself catches pointer events. Slide-in via
+     the first translateX transition in the codebase. Kept below the lightbox
+     (z 10002) so the lightbox still overlays. */
+  .cmcp-cv-overlay.cmcp-docked { display: block; padding: 0; background: transparent;
+    pointer-events: none; }
+  .cmcp-cv-overlay.cmcp-docked .cmcp-civitai-modal { position: fixed; pointer-events: auto;
+    width: auto; max-width: none; height: auto; max-height: none; border-radius: 0;
+    box-shadow: -8px 0 32px rgba(0,0,0,.45); transform: translateX(24px); opacity: 0;
+    transition: transform .28s ease, opacity .28s ease; }
+  .cmcp-cv-overlay.cmcp-docked.cmcp-dock-in .cmcp-civitai-modal { transform: translateX(0); opacity: 1; }
   `;
   const style = document.createElement("style");
   style.textContent = css;
@@ -233,7 +251,32 @@ export function graphDirtyForConfirm(ctx) {
   }
 }
 
-/** Open (or focus) the CivitAI modal. opts = {query, tab, filters, browsingLevels}. */
+/** Serialize result rows — `state.items` (media) or `state.models` (models) —
+ *  to the agent's `civitai_results` contract shape: id, kind, title, creator,
+ *  baseModel/type, stats, prompt, and media URL(s). Metadata + URLs ONLY — never
+ *  image bytes (the agent reasons from text; the human clicks to view). Pure and
+ *  exported for unit tests. `limit` is clamped to [1, 200]. */
+export function serializeCivitaiResults(source, { model = false, limit = 20, loading = false } = {}) {
+  const n = Number(limit);
+  const lim = Number.isFinite(n) && n > 0 ? Math.min(Math.floor(n), 200) : 20;
+  const rows = Array.isArray(source) ? source : [];
+  const items = rows.slice(0, lim).map((x) => model ? {
+    id: x.id, kind: "model", title: x.name || null, creator: x.creator || null,
+    baseModel: x.baseModel || null, type: x.type || null,
+    stats: { downloadCount: x.downloadCount ?? null, thumbsUp: x.thumbsUp ?? null },
+    prompt: null, urls: x.coverUrl ? [x.coverUrl] : [],
+  } : {
+    id: x.id, kind: x.type === "video" ? "video" : "image",
+    title: null, creator: x.author || null,
+    baseModel: x.modelName || null, type: x.type || null,
+    stats: { reactions: x.reactions ?? null },
+    prompt: x.prompt || null,
+    urls: [x.thumbnailUrl, x.fullUrl].filter(Boolean),
+  });
+  return { items, total: rows.length, loading: !!loading };
+}
+
+/** Open (or focus) the CivitAI modal. opts = {query, tab, filters, browsingLevels, dock, onClose}. */
 export function openCivitaiModal(ctx, opts = {}) {
   injectCss();
   const client = new CivitaiClient(ctx.api);
@@ -266,7 +309,15 @@ export function openCivitaiModal(ctx, opts = {}) {
   // narrow panel sidebar) ────────────────────────────────────────────────────
   const overlay = el("div", "cmcp-cv-overlay");
   const modal = el("div", "cmcp-modal cmcp-civitai-modal");
-  const close = () => overlay.remove();
+  let _onDockResize = null;
+  const close = () => {
+    if (_onDockResize) { window.removeEventListener("resize", _onDockResize); _onDockResize = null; }
+    overlay.remove();
+    try { opts.onClose?.(); } catch { /* host bookkeeping only */ }
+  };
+  // In docked mode the overlay itself is click-through (pointer-events:none), so a
+  // backdrop mousedown never fires here — the header ✕ is the only dismiss. Centered
+  // mode keeps the backdrop-click-to-close affordance.
   overlay.addEventListener("mousedown", (e) => { if (e.target === overlay) close(); });
 
   // header
@@ -400,6 +451,37 @@ export function openCivitaiModal(ctx, opts = {}) {
   modal.append(head, subnav, body);
   overlay.appendChild(modal);
   document.body.appendChild(overlay);
+
+  // ── docked mode (agent-driven) ─────────────────────────────────────────────
+  // Anchor the card to the sidebar's right edge so chat stays visible + usable;
+  // below a narrow breakpoint fall back to the centered overlay. Recomputed on
+  // window resize (listener torn down in close()).
+  const DOCK_MIN_WIDTH = 900;
+  function applyDock() {
+    const docked = !!opts.dock && window.innerWidth >= DOCK_MIN_WIDTH;
+    overlay.classList.toggle("cmcp-docked", docked);
+    if (!docked) {
+      modal.style.left = modal.style.right = modal.style.top = modal.style.bottom = "";
+      return;
+    }
+    let left = 0, top = 0;
+    try {
+      const pane = ctx.root?.closest?.(".side-bar-panel") || ctx.root?.closest?.("[class*='sidebar']");
+      const r = pane?.getBoundingClientRect();
+      if (r) { left = Math.max(0, Math.round(r.right)); top = Math.max(0, Math.round(r.top)); }
+    } catch { /* fall back to full-height right edge */ }
+    modal.style.left = `${left}px`;
+    modal.style.top = `${top}px`;
+    modal.style.right = "0px";
+    modal.style.bottom = "0px";
+  }
+  if (opts.dock) {
+    applyDock();
+    _onDockResize = () => applyDock();
+    window.addEventListener("resize", _onDockResize);
+    // Slide-in on the next frame so the transition runs from the initial state.
+    requestAnimationFrame(() => overlay.classList.add("cmcp-dock-in"));
+  }
 
   function syncTabs() {
     for (const b of tabsWrap.children) b.classList.toggle("active", b._key === state.tab);
@@ -543,6 +625,8 @@ export function openCivitaiModal(ctx, opts = {}) {
   // ── cards ─────────────────────────────────────────────────────────────
   function mediaCard(it, idx) {
     const card = el("div", "cmcp-cv-card");
+    card.dataset.id = String(it.id);
+    card.dataset.kind = "media";
     // Both image and video cards show a still (video thumbnailUrl is a jpeg
     // poster); hover on a video swaps in the muted transcoded clip.
     const img = document.createElement("img");
@@ -590,6 +674,8 @@ export function openCivitaiModal(ctx, opts = {}) {
 
   function modelCard(m) {
     const card = el("div", "cmcp-cv-card");
+    card.dataset.id = String(m.id);
+    card.dataset.kind = "model";
     const img = document.createElement("img");
     img.loading = "lazy"; img.src = m.coverUrl;
     img.addEventListener("error", () => { card.style.display = "none"; });
@@ -1632,9 +1718,81 @@ export function openCivitaiModal(ctx, opts = {}) {
     setTimeout(() => t.remove(), ms);
   }
 
+  // ── agent-driven handle ────────────────────────────────────────────────
+  // Post-open control surface: the same inner state/functions the UI drives,
+  // exposed so the bridge (and through it the agent) can switch tabs, re-search,
+  // read results (metadata + URLs only — never image bytes), and glow-highlight
+  // the interesting cards. Every method throws or returns a small plain object;
+  // no dynamic exec (registry-YARA safe).
+  function driveSwitchTab(key) {
+    if (!TABS.some((t) => t.key === key)) throw new Error(`unknown tab "${key}"`);
+    if (state.tab !== key) { state.tab = key; syncTabs(); reload(); }
+    else syncTabs();
+    return { tab: state.tab };
+  }
+  function driveSearch({ query, filters } = {}) {
+    if (filters && typeof filters === "object") {
+      state.filters = {
+        ...state.filters, ...filters,
+        baseModels: Array.isArray(filters.baseModels) ? [...filters.baseModels] : state.filters.baseModels,
+        browsingLevels: Array.isArray(filters.browsingLevels) ? [...filters.browsingLevels] : state.filters.browsingLevels,
+      };
+    }
+    if (typeof query === "string") {
+      search.value = query;
+      const parsed = parseCreatorQuery(query);
+      state.query = parsed.query;
+      if (parsed.creator) setCreator(parsed.creator); // normalizes @token + username
+      else if (creatorFromSearch && state.filters.username) { setCreator(null); }
+    }
+    syncTabs();
+    reload({ searching: true });
+    return { tab: state.tab, query: state.query, creator: state.filters.username || null };
+  }
+  function driveGetResults({ limit = 20 } = {}) {
+    const model = isModelTab();
+    return serializeCivitaiResults(model ? state.models : state.items,
+      { model, limit, loading: state.loading });
+  }
+  function driveHighlight(ids, { kind } = {}) { // eslint-disable-line no-unused-vars
+    const list = Array.isArray(ids) ? ids : (ids != null ? [ids] : []);
+    let first = null, n = 0;
+    for (const id of list) {
+      const card = grid.querySelector(`.cmcp-cv-card[data-id="${CSS.escape(String(id))}"]`);
+      if (!card) continue;
+      card.classList.add("cmcp-agent-glow");
+      if (!first) first = card;
+      n++;
+    }
+    if (first) first.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    return { highlighted: n };
+  }
+  function driveClearHighlight() {
+    for (const c of grid.querySelectorAll(".cmcp-cv-card.cmcp-agent-glow")) c.classList.remove("cmcp-agent-glow");
+    return { ok: true };
+  }
+  function driveOpenLightbox(id) {
+    if (isModelTab()) {
+      const m = state.models.find((x) => String(x.id) === String(id));
+      if (!m) throw new Error(`no model card for id ${id}`);
+      openModelDetail(m);
+      return { opened: "model", id };
+    }
+    const i = state.items.findIndex((x) => String(x.id) === String(id));
+    if (i < 0) throw new Error(`no media card for id ${id}`);
+    openViewer(i);
+    return { opened: "media", id };
+  }
+  function driveGetState() { return { tab: state.tab, loading: !!state.loading }; }
+
   // ── go ───────────────────────────────────────────────────────────────
   syncTabs();
   refreshAuth();
   reload();
-  return { close, focus: () => search.focus() };
+  return {
+    close, focus: () => search.focus(),
+    switchTab: driveSwitchTab, search: driveSearch, getResults: driveGetResults,
+    highlight: driveHighlight, clearHighlight: driveClearHighlight,
+    openLightbox: driveOpenLightbox, getState: driveGetState,
+  };
 }

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -842,6 +842,10 @@ export function openCivitaiModal(ctx, opts = {}) {
   }
 
   function openViewer(startIdx) {
+    // At-most-one lightbox: tear down any prior one (and its document keydown
+    // listener) before opening a new one, so a second open without an
+    // intervening close can't strand the older listener (codex finding).
+    if (_activeLightboxClose) { try { _activeLightboxClose(); } catch { /* already gone */ } _activeLightboxClose = null; }
     let idx = startIdx;
     let renderSeq = 0;
     const lb = el("div", "cmcp-cv-lb");

--- a/web/js/cmcp-training-ui.js
+++ b/web/js/cmcp-training-ui.js
@@ -243,6 +243,10 @@ export function openTrainingModal(ctx = {}, opts = {}) {
   let _onDockResize = null;
   let _dockDispose = null;
   let _onEscape = null;
+  // train_doctor generation: every doctor request captures the current value;
+  // only the NEWEST completion may write wiz.podInfo, so a slow stale doctor
+  // can't resurrect a pod that a later check found gone (codex finding).
+  let doctorGen = 0;
   const stopPolling = () => {
     pollGen++; // invalidate any in-flight poll response
     if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; }
@@ -776,9 +780,11 @@ export function openTrainingModal(ctx = {}, opts = {}) {
       grid.textContent = "";
       wiz.images.forEach((img) => {
         const item = el("div", "cmcp-tr-labelitem");
-        // Stable per-image ref (audit item 7): key off the dataset filename, NOT
-        // the array index (which shifts when an image is removed).
-        const imgId = img.ref?.filename || img.ref?.subfolder && `${img.ref.subfolder}/${img.ref?.filename}`;
+        // Stable per-image ref (audit item 7): key off subfolder+filename (the
+        // selection identity), NOT the array index (which shifts on removal) and
+        // NOT filename alone (a/foo.png and b/foo.png would collide — codex).
+        const fn = img.ref?.filename;
+        const imgId = fn ? (img.ref?.subfolder ? `${img.ref.subfolder}/${fn}` : fn) : null;
         if (imgId) item.dataset.ref = `caption:${imgId}`;
         const thumb = el("div", "thumb");
         thumb.style.backgroundImage = `url("${img.thumb}")`;
@@ -899,7 +905,11 @@ export function openTrainingModal(ctx = {}, opts = {}) {
     const gpuLine = el("p", "cmcp-tr-hint");
     sec.append(gpuLine);
     fetchGpuLabel(ctx.api).then((gpu) => { if (gpu) gpuLine.textContent = `Local GPU: ${gpu}`; });
+    const myDoctorGen = ++doctorGen;
     callJson(ctx, "train_doctor", {}, { timeout: 180000 }).then((d) => {
+      // A newer doctor (e.g. driveSetTarget's preflight) superseded this one —
+      // don't let a stale completion overwrite wiz.podInfo or rebuild the switch.
+      if (myDoctorGen !== doctorGen) return;
       const dd = d.data || {};
       wiz.podInfo = dd.pod && dd.pod.status === "RUNNING" ? dd.pod : null;
       // Re-derive target from the FRESH doctor result: if no pod (or its SSH
@@ -1266,6 +1276,18 @@ export function openTrainingModal(ctx = {}, opts = {}) {
     const m = /^wizard-(\d)$/.exec(currentView);
     return m ? Number(m[1]) : null;
   }
+  /** Readiness signals — the SINGLE source both getState() reports and
+   *  gotoStep() enforces (so the agent's view of "can I advance?" matches what
+   *  the wizard actually gates on, mirroring the gather Next button). */
+  function _readiness() {
+    return {
+      backendCapable, backendChecked,
+      nameOk: !!sanitizeNameClient(wiz.datasetName),
+      uploadsSettled: wiz.uploadsPending === 0,
+      hasImages: wiz.images.length >= 1,
+      hasJob: !!wiz.jobId,
+    };
+  }
   function driveGetState() {
     return {
       isOpen: !closed, view: currentView, step: _stepNum(), target: wiz.target,
@@ -1275,6 +1297,7 @@ export function openTrainingModal(ctx = {}, opts = {}) {
       podAvailable: !!(wiz.podInfo && wiz.podInfo.ssh),
       docked: !applyDock.centered && overlay.classList.contains("cmcp-docked"),
       highlighted: wiz.highlightRefs.slice(),
+      readiness: _readiness(),
     };
   }
   function driveSetField(name, value) {
@@ -1294,20 +1317,44 @@ export function openTrainingModal(ctx = {}, opts = {}) {
     if (currentView) show(currentView);
     return { ok: true, name, value: wiz[name] };
   }
-  function driveGotoStep(step) {
+  async function driveGotoStep(step) {
     _assertOpen();
     const view = _STEP_VIEW[Number(step)] || (step === "flows" || step === "jobs" ? step : null);
     if (!view) throw new Error(`invalid step "${step}" (expected 1-4, "flows", or "jobs")`);
+    const n = Number(step);
+    // Entering a wizard step ENFORCES the same prerequisites as the Next button
+    // (codex finding: gotoStep previously bypassed them). Label/Launch/Monitor
+    // all require the dataset to be ready; Monitor also needs a live job.
+    if (n >= 2 && n <= 4) {
+      const capable = await checkBackendCapable();
+      _assertOpen();
+      if (!capable) throw new Error("trainer backend unavailable — the orchestrator doesn't expose the train_* tools");
+      const r = _readiness();
+      if (!r.nameOk) throw new Error("set a valid dataset name before advancing");
+      if (!r.hasImages) throw new Error("add at least one image before advancing");
+      if (!r.uploadsSettled) throw new Error(`wait for ${wiz.uploadsPending} upload(s) to settle before advancing`);
+    }
+    if (n === 4 && !wiz.jobId) throw new Error("no training job to monitor — launch one first");
     show(view);
     return { view: currentView, step: _stepNum() };
   }
-  function driveSetTarget(target) {
+  async function driveSetTarget(target) {
     _assertOpen();
     if (target !== "local" && target !== "pod") throw new Error(`invalid target "${target}" (expected "local" or "pod")`);
-    // Preflight gate: a pod target needs a RUNNING pod with a working SSH
-    // endpoint (populated by the Launch step's train_doctor). Reject otherwise
-    // rather than arming a launch that would fail at staging.
-    if (target === "pod" && !(wiz.podInfo && wiz.podInfo.ssh)) throw new Error("no connected pod with a working SSH endpoint");
+    if (target === "pod") {
+      // Await a CURRENT preflight — never trust a possibly-stale wiz.podInfo. A
+      // versioned doctor means only the newest completion writes wiz.podInfo, so
+      // after the await it reflects the freshest check (codex finding).
+      const myDoctorGen = ++doctorGen;
+      let dd;
+      try { dd = (await callJson(ctx, "train_doctor", {}, { timeout: 180000 })).data || {}; }
+      catch (e) { throw new Error("pod preflight failed: " + (e.message || e)); }
+      _assertOpen();
+      if (myDoctorGen === doctorGen) {
+        wiz.podInfo = dd.pod && dd.pod.status === "RUNNING" ? dd.pod : null;
+      }
+      if (!(wiz.podInfo && wiz.podInfo.ssh)) throw new Error("no connected pod with a working SSH endpoint");
+    }
     wiz.target = target;
     if (currentView === "wizard-3") show("wizard-3"); // re-derive Launch enablement
     return { target: wiz.target };

--- a/web/js/cmcp-training-ui.js
+++ b/web/js/cmcp-training-ui.js
@@ -241,20 +241,28 @@ export function openTrainingModal(ctx = {}, opts = {}) {
   let pollGen = 0;
   let closed = false;
   let _onDockResize = null;
+  let _dockDispose = null;
+  let _onEscape = null;
   const stopPolling = () => {
     pollGen++; // invalidate any in-flight poll response
     if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; }
   };
   const close = () => {
+    if (closed) return; // idempotent
     closed = true;
     stopPolling();
+    if (_onEscape) { document.removeEventListener("keydown", _onEscape); _onEscape = null; }
     if (_onDockResize) { window.removeEventListener("resize", _onDockResize); _onDockResize = null; }
+    if (_dockDispose) { try { _dockDispose(); } catch { /* best effort */ } _dockDispose = null; }
     wiz.launchGen++; // a pending launch's continuation self-discards (codex finding)
     wiz.uploadGen++;
     overlay.remove();
     try { opts.onClose?.(); } catch { /* host bookkeeping only */ }
   };
   overlay.addEventListener("mousedown", (e) => { if (e.target === overlay) close(); });
+  // Base modal had no Escape handler (audit item 9) — add one through close().
+  _onEscape = (e) => { if (e.key === "Escape") { e.stopPropagation(); close(); } };
+  document.addEventListener("keydown", _onEscape);
 
   // Wizard state (one character-LoRA job being configured/tracked). Held at
   // modal scope so it survives view navigation: launching/uploadsPending MUST
@@ -279,6 +287,10 @@ export function openTrainingModal(ctx = {}, opts = {}) {
      *  mutate the new run's state (codex findings). */
     launchGen: 0,
     uploadGen: 0,
+    // Agent-drive: the ordered set of data-ref targets to glow. The wizard
+    // rebuilds its body on every show(view), so this OUTLIVES a render and is
+    // re-applied after each one (see reapplyHighlight).
+    highlightRefs: [],
   };
   /** Reset the configuration fields for a genuinely NEW run (Jobs → "New
    *  character LoRA") — a fresh run must not silently reuse the previous
@@ -327,41 +339,79 @@ export function openTrainingModal(ctx = {}, opts = {}) {
   document.body.appendChild(overlay);
 
   // ── docked mode (agent-driven, parity with the CivitAI modal) ───────────────
-  const DOCK_MIN_WIDTH = 900;
+  // Geometry from the host (ctx.dockGeometry owns pane/canvas measurement +
+  // left/right detection); three states detached(hide)/centered/docked. See the
+  // CivitAI modal for the full rationale.
+  applyDock.centered = false;
   function applyDock() {
-    const docked = !!opts.dock && window.innerWidth >= DOCK_MIN_WIDTH;
-    overlay.classList.toggle("cmcp-docked", docked);
-    if (!docked) {
-      modal.style.left = modal.style.right = modal.style.top = modal.style.bottom = modal.style.height = "";
-      return;
+    if (!opts.dock) { setCentered(); return; }
+    const geo = _dockGeometry();
+    if (geo?.status === "detached") { overlay.style.display = "none"; return; }
+    overlay.style.display = "";
+    if (geo?.status === "docked" && window.innerWidth >= 900) {
+      overlay.classList.add("cmcp-docked");
+      modal.style.left = `${Math.round(geo.left)}px`;
+      modal.style.top = `${Math.round(geo.top)}px`;
+      modal.style.right = `${Math.round(geo.right)}px`;
+      modal.style.bottom = `${Math.round(geo.bottom)}px`;
+      modal.style.height = "auto";
+      applyDock.centered = false;
+    } else { setCentered(); }
+  }
+  function setCentered() {
+    overlay.classList.remove("cmcp-docked");
+    overlay.style.display = "";
+    modal.style.left = modal.style.right = modal.style.top = modal.style.bottom = modal.style.height = "";
+    applyDock.centered = true;
+  }
+  function _dockGeometry() {
+    if (typeof ctx.dockGeometry === "function") {
+      try { const g = ctx.dockGeometry(); if (g) return g; } catch { /* fall through */ }
     }
-    let left = 0, top = 0;
     try {
-      const pane = ctx.root?.closest?.(".side-bar-panel") || ctx.root?.closest?.("[class*='sidebar']");
-      const r = pane?.getBoundingClientRect();
-      if (r) { left = Math.max(0, Math.round(r.right)); top = Math.max(0, Math.round(r.top)); }
-    } catch { /* fall back to full-height right edge */ }
-    modal.style.left = `${left}px`;
-    modal.style.top = `${top}px`;
-    modal.style.right = "0px";
-    modal.style.bottom = "0px";
-    modal.style.height = "auto";
+      const root = ctx.root;
+      if (root && !root.isConnected) return { status: "detached" };
+      const pane = root?.closest?.(".side-bar-panel") || root?.closest?.("[class*='sidebar']") || root;
+      const pr = pane?.getBoundingClientRect?.();
+      if (!pr || pr.width < 1 || pr.height < 1) return { status: "centered" };
+      const vw = window.innerWidth, vh = window.innerHeight;
+      const paneOnLeft = (pr.left + pr.right) / 2 < vw / 2;
+      const left = paneOnLeft ? Math.max(0, pr.right) : 0;
+      const right = paneOnLeft ? 0 : Math.max(0, vw - pr.left);
+      if (vw - left - right < 320) return { status: "centered" };
+      return { status: "docked", left, right, top: Math.max(0, pr.top), bottom: Math.max(0, vh - pr.bottom) };
+    } catch { return { status: "centered" }; }
   }
   if (opts.dock) {
     applyDock();
-    _onDockResize = () => applyDock();
-    window.addEventListener("resize", _onDockResize);
+    if (typeof ctx.watchDock === "function") {
+      try { _dockDispose = ctx.watchDock(applyDock); } catch { _dockDispose = null; }
+    }
+    if (!_dockDispose) { _onDockResize = () => applyDock(); window.addEventListener("resize", _onDockResize); }
     requestAnimationFrame(() => overlay.classList.add("cmcp-dock-in"));
   }
 
+  // Stable step namespace (audit item 7): refs survive the body rebuild every
+  // show(view) because they're regenerated deterministically per render.
+  const STEP_REFS = ["dataset", "label", "launch", "monitor"];
   function setSteps(names, current) {
     stepsBar.textContent = "";
     stepsBar.style.display = names ? "" : "none";
     (names || []).forEach((n, i) => {
       const s = el("span", i === current ? "on" : null, n);
-      s.dataset.ref = `step-${i + 1}`; // agent highlight target
+      if (STEP_REFS[i]) s.dataset.ref = `step:${STEP_REFS[i]}`;
       stepsBar.appendChild(s);
     });
+  }
+
+  /** Re-apply the agent's ordered highlight set after a render (the body is
+   *  rebuilt every show(view), so refs must be re-stamped THEN re-glowed). */
+  function reapplyHighlight() {
+    for (const c of modal.querySelectorAll(".cmcp-agent-glow")) c.classList.remove("cmcp-agent-glow");
+    for (const ref of wiz.highlightRefs) {
+      const node = modal.querySelector(`[data-ref="${CSS.escape(String(ref))}"]`);
+      if (node) node.classList.add("cmcp-agent-glow");
+    }
   }
 
   let currentView = "flows";
@@ -376,6 +426,9 @@ export function openTrainingModal(ctx = {}, opts = {}) {
     else if (view === "wizard-2") { setSteps(["1 · Dataset", "2 · Label", "3 · Launch", "4 · Monitor"], 1); renderLabel(); }
     else if (view === "wizard-3") { setSteps(["1 · Dataset", "2 · Label", "3 · Launch", "4 · Monitor"], 2); renderLaunch(); }
     else if (view === "wizard-4") { setSteps(["1 · Dataset", "2 · Label", "3 · Launch", "4 · Monitor"], 3); renderMonitor(); }
+    // Re-glow after the new view's DOM exists (renderers can be async but stamp
+    // their static refs synchronously; async content re-applies on its own).
+    reapplyHighlight();
   }
 
   jobsBtn.onclick = () => show("jobs");
@@ -457,7 +510,7 @@ export function openTrainingModal(ctx = {}, opts = {}) {
     nameRow.append(el("label", null, "Dataset name"));
     const nameInput = el("input", null);
     nameInput.type = "text";
-    nameInput.dataset.ref = "datasetName";
+    nameInput.dataset.ref = "field:dataset_name";
     nameInput.placeholder = "e.g. aria_character";
     nameInput.value = wiz.datasetName;
     nameInput.oninput = () => { wiz.datasetName = nameInput.value; syncNext(); };
@@ -467,7 +520,7 @@ export function openTrainingModal(ctx = {}, opts = {}) {
     trigRow.append(el("label", null, "Trigger word"));
     const trigInput = el("input", null);
     trigInput.type = "text";
-    trigInput.dataset.ref = "trigger";
+    trigInput.dataset.ref = "field:trigger";
     trigInput.placeholder = "e.g. ohwx — a rare token, not a real word";
     trigInput.value = wiz.trigger;
     trigInput.oninput = () => { wiz.trigger = trigInput.value.trim(); };
@@ -723,6 +776,10 @@ export function openTrainingModal(ctx = {}, opts = {}) {
       grid.textContent = "";
       wiz.images.forEach((img) => {
         const item = el("div", "cmcp-tr-labelitem");
+        // Stable per-image ref (audit item 7): key off the dataset filename, NOT
+        // the array index (which shifts when an image is removed).
+        const imgId = img.ref?.filename || img.ref?.subfolder && `${img.ref.subfolder}/${img.ref?.filename}`;
+        if (imgId) item.dataset.ref = `caption:${imgId}`;
         const thumb = el("div", "thumb");
         thumb.style.backgroundImage = `url("${img.thumb}")`;
         const ta = document.createElement("textarea");
@@ -776,6 +833,7 @@ export function openTrainingModal(ctx = {}, opts = {}) {
       l.style.minWidth = "auto";
       const inp = el("input", null);
       inp.type = "text";
+      inp.dataset.ref = `param:${key}`;
       inp.style.flex = "0 1 110px";
       const saved = wiz.customParams?.[key];
       inp.value = saved !== undefined
@@ -854,9 +912,9 @@ export function openTrainingModal(ctx = {}, opts = {}) {
         const targetSeg = el("div", "cmcp-tr-seg");
         targetSeg.style.margin = "0";
         const localBtn = el("button", wiz.target !== "pod" ? "active" : null, "Local (docker)");
-        localBtn.dataset.ref = "target-local";
+        localBtn.dataset.ref = "target:local";
         const podBtn = el("button", wiz.target === "pod" ? "active" : null, `Pod (${pod.name || pod.id}${pod.gpu ? ` · ${pod.gpu}` : ""})`);
-        podBtn.dataset.ref = "target-pod";
+        podBtn.dataset.ref = "target:pod";
         if (!pod.ssh) podBtn.title = "pod has no working SSH endpoint";
         localBtn.onclick = () => { wiz.target = "local"; localBtn.classList.add("active"); podBtn.classList.remove("active"); syncLaunchEnabled(); syncSummary(); };
         podBtn.onclick = () => {
@@ -897,6 +955,10 @@ export function openTrainingModal(ctx = {}, opts = {}) {
         preflightState = "local";
       }
       syncLaunchEnabled();
+      // The target buttons (target:pod / target:local) render HERE, after the
+      // synchronous show() reapply — re-glow so an agent highlight of a target
+      // that predates the doctor still lands.
+      reapplyHighlight();
     }).catch((e) => {
       // Doctor unreachable/unavailable: train_start does its own docker+image
       // preflight server-side and reports honestly, so don't block on this.
@@ -1196,21 +1258,27 @@ export function openTrainingModal(ctx = {}, opts = {}) {
 
   // ── agent-driven handle (parity with the CivitAI modal) ────────────────────
   // Drives the existing wizard state; every method returns a small plain object
-  // or throws. No dynamic exec (registry-YARA safe).
+  // or throws. set_field is an explicit per-field ALLOWLIST — never an arbitrary
+  // wiz[name]= assignment (audit item 6/11). No dynamic exec (YARA safe).
   const _STEP_VIEW = { 1: "wizard-1", 2: "wizard-2", 3: "wizard-3", 4: "wizard-4" };
+  function _assertOpen() { if (closed) throw new Error("training wizard not open"); }
   function _stepNum() {
     const m = /^wizard-(\d)$/.exec(currentView);
     return m ? Number(m[1]) : null;
   }
   function driveGetState() {
     return {
-      view: currentView, step: _stepNum(), target: wiz.target,
+      isOpen: !closed, view: currentView, step: _stepNum(), target: wiz.target,
       datasetName: wiz.datasetName, trigger: wiz.trigger,
       preset: wiz.preset, images: wiz.images.length,
       launching: !!wiz.launching, jobId: wiz.jobId || null,
+      podAvailable: !!(wiz.podInfo && wiz.podInfo.ssh),
+      docked: !applyDock.centered && overlay.classList.contains("cmcp-docked"),
+      highlighted: wiz.highlightRefs.slice(),
     };
   }
   function driveSetField(name, value) {
+    _assertOpen();
     switch (name) {
       case "datasetName": wiz.datasetName = String(value ?? ""); break;
       case "trigger": wiz.trigger = String(value ?? "").trim(); break;
@@ -1220,39 +1288,49 @@ export function openTrainingModal(ctx = {}, opts = {}) {
         if (PRESETS[value].params) wiz.params = { ...PRESETS[value].params };
         break;
       case "target": return driveSetTarget(value);
-      default: throw new Error(`unknown field "${name}"`);
+      default: throw new Error(`unknown field "${name}" (allowed: datasetName, trigger, preset, target)`);
     }
     // Reflect the change in the live inputs by re-rendering the current step.
     if (currentView) show(currentView);
     return { ok: true, name, value: wiz[name] };
   }
   function driveGotoStep(step) {
+    _assertOpen();
     const view = _STEP_VIEW[Number(step)] || (step === "flows" || step === "jobs" ? step : null);
     if (!view) throw new Error(`invalid step "${step}" (expected 1-4, "flows", or "jobs")`);
     show(view);
     return { view: currentView, step: _stepNum() };
   }
   function driveSetTarget(target) {
+    _assertOpen();
     if (target !== "local" && target !== "pod") throw new Error(`invalid target "${target}" (expected "local" or "pod")`);
+    // Preflight gate: a pod target needs a RUNNING pod with a working SSH
+    // endpoint (populated by the Launch step's train_doctor). Reject otherwise
+    // rather than arming a launch that would fail at staging.
     if (target === "pod" && !(wiz.podInfo && wiz.podInfo.ssh)) throw new Error("no connected pod with a working SSH endpoint");
     wiz.target = target;
     if (currentView === "wizard-3") show("wizard-3"); // re-derive Launch enablement
     return { target: wiz.target };
   }
+  /** Highlight data-ref nodes (REPLACEMENT semantics). Persists the ordered set
+   *  in wiz so it re-applies after each render (the body rebuilds per view). */
   function driveHighlight(refs) {
-    const list = Array.isArray(refs) ? refs : (refs != null ? [refs] : []);
-    let first = null, n = 0;
-    for (const ref of list) {
-      const node = modal.querySelector(`[data-ref="${CSS.escape(String(ref))}"]`);
-      if (!node) continue;
-      node.classList.add("cmcp-agent-glow");
-      if (!first) first = node;
-      n++;
+    _assertOpen();
+    wiz.highlightRefs = (Array.isArray(refs) ? refs : (refs != null ? [refs] : [])).map((x) => String(x));
+    reapplyHighlight();
+    let first = null, hit = 0;
+    const missing = [];
+    for (const ref of wiz.highlightRefs) {
+      const node = modal.querySelector(`[data-ref="${CSS.escape(ref)}"]`);
+      if (node) { if (!first) first = node; hit++; }
+      else missing.push(ref);
     }
     if (first) first.scrollIntoView({ behavior: "smooth", block: "nearest" });
-    return { highlighted: n };
+    return { highlighted: hit, missing };
   }
   function driveClearHighlight() {
+    _assertOpen();
+    wiz.highlightRefs = [];
     for (const c of modal.querySelectorAll(".cmcp-agent-glow")) c.classList.remove("cmcp-agent-glow");
     return { ok: true };
   }

--- a/web/js/cmcp-training-ui.js
+++ b/web/js/cmcp-training-ui.js
@@ -996,7 +996,14 @@ export function openTrainingModal(ctx = {}, opts = {}) {
       // Pod target: docker/gpu/image are irrelevant — the gate is a working pod
       // SSH endpoint (plus the custom-param check).
       const podReady = wiz.target === "pod" && !!wiz.podInfo?.ssh;
+      // Dataset readiness shares the ONE _readiness() source with the gather Next
+      // button + gotoStep, so an agent set_field that invalidates the name (or
+      // otherwise breaks readiness) while already ON this step disables Launch
+      // instead of leaving the gate bypassed (codex finding).
+      const r = _readiness();
+      const datasetReady = r.backendCapable && r.nameOk && r.hasImages && r.uploadsSettled;
       launch.disabled = wiz.launching
+        || !datasetReady
         || (wiz.target === "pod" ? !podReady : preflightState !== "local" && preflightState !== "failed")
         || !syncCustomValidity();
       if (wiz.launching) launch.textContent = "Launching…";
@@ -1343,16 +1350,18 @@ export function openTrainingModal(ctx = {}, opts = {}) {
     if (target !== "local" && target !== "pod") throw new Error(`invalid target "${target}" (expected "local" or "pod")`);
     if (target === "pod") {
       // Await a CURRENT preflight — never trust a possibly-stale wiz.podInfo. A
-      // versioned doctor means only the newest completion writes wiz.podInfo, so
-      // after the await it reflects the freshest check (codex finding).
+      // versioned doctor means only the newest completion may decide (codex).
       const myDoctorGen = ++doctorGen;
       let dd;
       try { dd = (await callJson(ctx, "train_doctor", {}, { timeout: 180000 })).data || {}; }
       catch (e) { throw new Error("pod preflight failed: " + (e.message || e)); }
       _assertOpen();
-      if (myDoctorGen === doctorGen) {
-        wiz.podInfo = dd.pod && dd.pod.status === "RUNNING" ? dd.pod : null;
-      }
+      // If a NEWER doctor superseded ours mid-flight, our result is stale and
+      // must NOT accept — reading the shared wiz.podInfo here could let an older
+      // SSH-ready value pass a preflight whose own (no-pod) result should fail.
+      // Reject and let the agent retry against the current check (codex finding).
+      if (myDoctorGen !== doctorGen) throw new Error("pod preflight was superseded — retry");
+      wiz.podInfo = dd.pod && dd.pod.status === "RUNNING" ? dd.pod : null;
       if (!(wiz.podInfo && wiz.podInfo.ssh)) throw new Error("no connected pod with a working SSH endpoint");
     }
     wiz.target = target;

--- a/web/js/cmcp-training-ui.js
+++ b/web/js/cmcp-training-ui.js
@@ -88,6 +88,22 @@ function injectCss() {
     .cmcp-tr-jobrow .meta { font-size:.75rem; opacity:.6; }
     .cmcp-tr-preflight { display:flex; gap:1rem; flex-wrap:wrap; font-size:.78rem; }
     .cmcp-tr-preflight span b { font-weight:600; }
+    /* Agent-driven "glow" — shared class name with the CivitAI modal; generic here
+       so it applies to step chips + field wrappers, not just cards. */
+    .cmcp-agent-glow { outline: 2px solid var(--p-green-400,#4ade80);
+      box-shadow: 0 0 0 2px var(--p-green-400,#4ade80), 0 0 16px 2px rgba(74,222,128,.6);
+      border-radius: 8px; animation: cmcp-glow 1.4s ease-in-out infinite; }
+    @keyframes cmcp-glow { 50% { box-shadow: 0 0 0 3px var(--p-green-400,#4ade80),
+      0 0 24px 6px rgba(74,222,128,.9); } }
+    /* Agent-driven side-dock (parity with the CivitAI modal): anchor to the
+       sidebar's right edge, drop the backdrop, keep chat interactive. */
+    .cmcp-cv-overlay.cmcp-docked { display: block; padding: 0; background: transparent;
+      pointer-events: none; }
+    .cmcp-cv-overlay.cmcp-docked .cmcp-tr-modal { position: fixed; pointer-events: auto;
+      width: auto; max-width: none; max-height: none; border-radius: 0;
+      box-shadow: -8px 0 32px rgba(0,0,0,.45); transform: translateX(24px); opacity: 0;
+      transition: transform .28s ease, opacity .28s ease; }
+    .cmcp-cv-overlay.cmcp-docked.cmcp-dock-in .cmcp-tr-modal { transform: translateX(0); opacity: 1; }
   `;
   document.head.appendChild(style);
 }
@@ -214,7 +230,7 @@ function fmtAgo(iso) {
 
 const STATUS_BADGE = { running: "ok", queued: "warn", completed: "ok", failed: "err", cancelled: "warn" };
 
-export function openTrainingModal(ctx = {}) {
+export function openTrainingModal(ctx = {}, opts = {}) {
   injectCss();
   const overlay = document.createElement("div");
   overlay.className = "cmcp-cv-overlay";
@@ -224,6 +240,7 @@ export function openTrainingModal(ctx = {}) {
   let pollTimer = null;
   let pollGen = 0;
   let closed = false;
+  let _onDockResize = null;
   const stopPolling = () => {
     pollGen++; // invalidate any in-flight poll response
     if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; }
@@ -231,9 +248,11 @@ export function openTrainingModal(ctx = {}) {
   const close = () => {
     closed = true;
     stopPolling();
+    if (_onDockResize) { window.removeEventListener("resize", _onDockResize); _onDockResize = null; }
     wiz.launchGen++; // a pending launch's continuation self-discards (codex finding)
     wiz.uploadGen++;
     overlay.remove();
+    try { opts.onClose?.(); } catch { /* host bookkeeping only */ }
   };
   overlay.addEventListener("mousedown", (e) => { if (e.target === overlay) close(); });
 
@@ -307,11 +326,40 @@ export function openTrainingModal(ctx = {}) {
   overlay.appendChild(modal);
   document.body.appendChild(overlay);
 
+  // ── docked mode (agent-driven, parity with the CivitAI modal) ───────────────
+  const DOCK_MIN_WIDTH = 900;
+  function applyDock() {
+    const docked = !!opts.dock && window.innerWidth >= DOCK_MIN_WIDTH;
+    overlay.classList.toggle("cmcp-docked", docked);
+    if (!docked) {
+      modal.style.left = modal.style.right = modal.style.top = modal.style.bottom = modal.style.height = "";
+      return;
+    }
+    let left = 0, top = 0;
+    try {
+      const pane = ctx.root?.closest?.(".side-bar-panel") || ctx.root?.closest?.("[class*='sidebar']");
+      const r = pane?.getBoundingClientRect();
+      if (r) { left = Math.max(0, Math.round(r.right)); top = Math.max(0, Math.round(r.top)); }
+    } catch { /* fall back to full-height right edge */ }
+    modal.style.left = `${left}px`;
+    modal.style.top = `${top}px`;
+    modal.style.right = "0px";
+    modal.style.bottom = "0px";
+    modal.style.height = "auto";
+  }
+  if (opts.dock) {
+    applyDock();
+    _onDockResize = () => applyDock();
+    window.addEventListener("resize", _onDockResize);
+    requestAnimationFrame(() => overlay.classList.add("cmcp-dock-in"));
+  }
+
   function setSteps(names, current) {
     stepsBar.textContent = "";
     stepsBar.style.display = names ? "" : "none";
     (names || []).forEach((n, i) => {
       const s = el("span", i === current ? "on" : null, n);
+      s.dataset.ref = `step-${i + 1}`; // agent highlight target
       stepsBar.appendChild(s);
     });
   }
@@ -409,6 +457,7 @@ export function openTrainingModal(ctx = {}) {
     nameRow.append(el("label", null, "Dataset name"));
     const nameInput = el("input", null);
     nameInput.type = "text";
+    nameInput.dataset.ref = "datasetName";
     nameInput.placeholder = "e.g. aria_character";
     nameInput.value = wiz.datasetName;
     nameInput.oninput = () => { wiz.datasetName = nameInput.value; syncNext(); };
@@ -418,6 +467,7 @@ export function openTrainingModal(ctx = {}) {
     trigRow.append(el("label", null, "Trigger word"));
     const trigInput = el("input", null);
     trigInput.type = "text";
+    trigInput.dataset.ref = "trigger";
     trigInput.placeholder = "e.g. ohwx — a rare token, not a real word";
     trigInput.value = wiz.trigger;
     trigInput.oninput = () => { wiz.trigger = trigInput.value.trim(); };
@@ -804,7 +854,9 @@ export function openTrainingModal(ctx = {}) {
         const targetSeg = el("div", "cmcp-tr-seg");
         targetSeg.style.margin = "0";
         const localBtn = el("button", wiz.target !== "pod" ? "active" : null, "Local (docker)");
+        localBtn.dataset.ref = "target-local";
         const podBtn = el("button", wiz.target === "pod" ? "active" : null, `Pod (${pod.name || pod.id}${pod.gpu ? ` · ${pod.gpu}` : ""})`);
+        podBtn.dataset.ref = "target-pod";
         if (!pod.ssh) podBtn.title = "pod has no working SSH endpoint";
         localBtn.onclick = () => { wiz.target = "local"; localBtn.classList.add("active"); podBtn.classList.remove("active"); syncLaunchEnabled(); syncSummary(); };
         podBtn.onclick = () => {
@@ -1142,6 +1194,73 @@ export function openTrainingModal(ctx = {}) {
     }
   }
 
+  // ── agent-driven handle (parity with the CivitAI modal) ────────────────────
+  // Drives the existing wizard state; every method returns a small plain object
+  // or throws. No dynamic exec (registry-YARA safe).
+  const _STEP_VIEW = { 1: "wizard-1", 2: "wizard-2", 3: "wizard-3", 4: "wizard-4" };
+  function _stepNum() {
+    const m = /^wizard-(\d)$/.exec(currentView);
+    return m ? Number(m[1]) : null;
+  }
+  function driveGetState() {
+    return {
+      view: currentView, step: _stepNum(), target: wiz.target,
+      datasetName: wiz.datasetName, trigger: wiz.trigger,
+      preset: wiz.preset, images: wiz.images.length,
+      launching: !!wiz.launching, jobId: wiz.jobId || null,
+    };
+  }
+  function driveSetField(name, value) {
+    switch (name) {
+      case "datasetName": wiz.datasetName = String(value ?? ""); break;
+      case "trigger": wiz.trigger = String(value ?? "").trim(); break;
+      case "preset":
+        if (!PRESETS[value]) throw new Error(`unknown preset "${value}"`);
+        wiz.preset = value;
+        if (PRESETS[value].params) wiz.params = { ...PRESETS[value].params };
+        break;
+      case "target": return driveSetTarget(value);
+      default: throw new Error(`unknown field "${name}"`);
+    }
+    // Reflect the change in the live inputs by re-rendering the current step.
+    if (currentView) show(currentView);
+    return { ok: true, name, value: wiz[name] };
+  }
+  function driveGotoStep(step) {
+    const view = _STEP_VIEW[Number(step)] || (step === "flows" || step === "jobs" ? step : null);
+    if (!view) throw new Error(`invalid step "${step}" (expected 1-4, "flows", or "jobs")`);
+    show(view);
+    return { view: currentView, step: _stepNum() };
+  }
+  function driveSetTarget(target) {
+    if (target !== "local" && target !== "pod") throw new Error(`invalid target "${target}" (expected "local" or "pod")`);
+    if (target === "pod" && !(wiz.podInfo && wiz.podInfo.ssh)) throw new Error("no connected pod with a working SSH endpoint");
+    wiz.target = target;
+    if (currentView === "wizard-3") show("wizard-3"); // re-derive Launch enablement
+    return { target: wiz.target };
+  }
+  function driveHighlight(refs) {
+    const list = Array.isArray(refs) ? refs : (refs != null ? [refs] : []);
+    let first = null, n = 0;
+    for (const ref of list) {
+      const node = modal.querySelector(`[data-ref="${CSS.escape(String(ref))}"]`);
+      if (!node) continue;
+      node.classList.add("cmcp-agent-glow");
+      if (!first) first = node;
+      n++;
+    }
+    if (first) first.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    return { highlighted: n };
+  }
+  function driveClearHighlight() {
+    for (const c of modal.querySelectorAll(".cmcp-agent-glow")) c.classList.remove("cmcp-agent-glow");
+    return { ok: true };
+  }
+
   show("flows");
-  return { close };
+  return {
+    close, getState: driveGetState, setField: driveSetField,
+    gotoStep: driveGotoStep, setTarget: driveSetTarget,
+    highlight: driveHighlight, clearHighlight: driveClearHighlight,
+  };
 }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -6997,9 +6997,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
             if (!onCivitaiCmd) throw new Error("This panel build can't drive the CivitAI browser.");
             result = await onCivitaiCmd(msg);
           } else if (
-            msg.cmd === "open_training" || msg.cmd === "training_set_field" ||
-            msg.cmd === "training_goto_step" || msg.cmd === "training_set_target" ||
-            msg.cmd === "training_highlight"
+            msg.cmd === "open_training" || msg.cmd === "training_get_state" ||
+            msg.cmd === "training_set_field" || msg.cmd === "training_goto_step" ||
+            msg.cmd === "training_set_target" || msg.cmd === "training_highlight"
           ) {
             if (!onTrainingCmd) throw new Error("This panel build can't drive the training wizard.");
             result = await onTrainingCmd(msg);
@@ -7050,8 +7050,8 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
           "ui_render", "ui_update",
           "civitai_results", "civitai_highlight", "civitai_clear_highlight",
           "civitai_switch_tab", "civitai_search", "civitai_open_lightbox",
-          "open_training", "training_set_field", "training_goto_step",
-          "training_set_target", "training_highlight",
+          "open_training", "training_get_state", "training_set_field",
+          "training_goto_step", "training_set_target", "training_highlight",
         ]);
         if (!SILENT_CMDS.has(msg.cmd)) {
           onCommand?.(msg.cmd, msg, reply);
@@ -11765,6 +11765,7 @@ function buildPanel() {
       const h = _trainingHandle;
       if (!h) throw new Error("training wizard not open");
       switch (msg.cmd) {
+        case "training_get_state": return h.getState();
         case "training_set_field": return h.setField(msg.name, msg.value);
         case "training_goto_step": return h.gotoStep(msg.step);
         case "training_set_target": return h.setTarget(msg.target);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -6706,7 +6706,7 @@ const RECONNECT_MAX_MS = 15000;
 let AGENT_MUTED = (() => { try { return localStorage.getItem("cmcp.muteAgents") === "1"; } catch { return false; } })();
 let AGENT_BLIND = (() => { try { return localStorage.getItem("cmcp.blindAgents") === "1"; } catch { return false; } })();
 
-function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk, onSecret, onSecretSaved, onReload, onTodo, onShowMedia, onOpenCivitai, onUiRender, onUiUpdate, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onBackends, onAck, onTurn, onTurnAnchor, getResume, getBackend, onHandshakeTimeout, onBridgeClosed, onPairUrl, onPairError, onRunpodStatus, onComfyuiTarget }) {
+function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk, onSecret, onSecretSaved, onReload, onTodo, onShowMedia, onOpenCivitai, onCivitaiCmd, onTrainingCmd, onUiRender, onUiUpdate, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onBackends, onAck, onTurn, onTurnAnchor, getResume, getBackend, onHandshakeTimeout, onBridgeClosed, onPairUrl, onPairError, onRunpodStatus, onComfyuiTarget }) {
   let sock = null;
   let url = loadBridgeUrl();
   let closed = false;
@@ -6914,6 +6914,23 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
             // the user can visually pick a resource.
             if (!onOpenCivitai) throw new Error("This panel build can't open the CivitAI browser.");
             result = onOpenCivitai(msg) || { ok: true };
+          } else if (
+            msg.cmd === "civitai_results" || msg.cmd === "civitai_highlight" ||
+            msg.cmd === "civitai_clear_highlight" || msg.cmd === "civitai_switch_tab" ||
+            msg.cmd === "civitai_search" || msg.cmd === "civitai_open_lightbox"
+          ) {
+            // Agent DRIVES the already-open CivitAI browser. onCivitaiCmd throws
+            // an honest "civitai browser not open" when the modal isn't live, which
+            // becomes a retryable tool error.
+            if (!onCivitaiCmd) throw new Error("This panel build can't drive the CivitAI browser.");
+            result = await onCivitaiCmd(msg);
+          } else if (
+            msg.cmd === "open_training" || msg.cmd === "training_set_field" ||
+            msg.cmd === "training_goto_step" || msg.cmd === "training_set_target" ||
+            msg.cmd === "training_highlight"
+          ) {
+            if (!onTrainingCmd) throw new Error("This panel build can't drive the training wizard.");
+            result = await onTrainingCmd(msg);
           } else if (msg.cmd === "ui_render") {
             // A2UI card render. Validation errors THROW so the agent gets a
             // retryable tool error instead of a broken card.
@@ -6953,8 +6970,18 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
         }
         // ask_user / request_secret paint their OWN cards and their replies carry
         // user input (a choice, or a SECRET) — never echo them as an activity card
-        // (and never record them). Other commands get the normal activity card.
-        if (msg.cmd !== "ask_user" && msg.cmd !== "request_secret" && msg.cmd !== "set_todo" && msg.cmd !== "show_media" && msg.cmd !== "open_civitai" && msg.cmd !== "ui_render" && msg.cmd !== "ui_update") {
+        // (and never record them). The CivitAI/training DRIVE cmds animate the
+        // modal itself, so they'd only clutter the chat as activity cards. Other
+        // commands get the normal activity card.
+        const SILENT_CMDS = new Set([
+          "ask_user", "request_secret", "set_todo", "show_media", "open_civitai",
+          "ui_render", "ui_update",
+          "civitai_results", "civitai_highlight", "civitai_clear_highlight",
+          "civitai_switch_tab", "civitai_search", "civitai_open_lightbox",
+          "open_training", "training_set_field", "training_goto_step",
+          "training_set_target", "training_highlight",
+        ]);
+        if (!SILENT_CMDS.has(msg.cmd)) {
           onCommand?.(msg.cmd, msg, reply);
         }
         return;
@@ -9906,7 +9933,14 @@ function buildPanel() {
   }
   function openCivitai(opts) {
     try { _civitaiHandle?.close(); } catch {}
-    _civitaiHandle = openCivitaiModal(civitaiCtx(), opts || {});
+    const handle = openCivitaiModal(civitaiCtx(), {
+      ...(opts || {}),
+      // Null the stored handle whenever THIS modal closes (✕, reopen, backdrop)
+      // so post-open drive cmds get an honest "not open" error instead of
+      // operating on a detached grid.
+      onClose: () => { if (_civitaiHandle === handle) _civitaiHandle = null; },
+    });
+    _civitaiHandle = handle;
     return _civitaiHandle;
   }
   const civitaiBtn = toolbarBtn("pi-circle", "Civitai");
@@ -9938,18 +9972,28 @@ function buildPanel() {
   // local trainer (ai-toolkit in a GPU container, train_* tools over call_tool).
   // Same modal treatment as the CivitAI browser; dumbbell mark via currentColor.
   let _trainingHandle = null;
-  const trainingBtn = toolbarBtn("pi-circle", "Training");
-  trainingBtn.querySelector(".pi").remove();
-  trainingBtn.title = "LoRA Training — train a character LoRA locally on FLUX.1-dev (style/edit/slider/video coming in P2).";
-  trainingBtn.addEventListener("click", () => {
-    try { _trainingHandle?.close(); } catch {}
-    _trainingHandle = openTrainingModal({
+  function trainingCtx() {
+    return {
       api,
       root,
       callTool: (t, a, o) => liveBridgeClient?.callTool(t, a, o),
       uploadBlobToInput,
+    };
+  }
+  // Reused by both the toolbar button (centered) and the agent bridge (docked).
+  function openTraining(opts) {
+    try { _trainingHandle?.close(); } catch {}
+    const handle = openTrainingModal(trainingCtx(), {
+      ...(opts || {}),
+      onClose: () => { if (_trainingHandle === handle) _trainingHandle = null; },
     });
-  });
+    _trainingHandle = handle;
+    return _trainingHandle;
+  }
+  const trainingBtn = toolbarBtn("pi-circle", "Training");
+  trainingBtn.querySelector(".pi").remove();
+  trainingBtn.title = "LoRA Training — train a character LoRA locally on FLUX.1-dev (style/edit/slider/video coming in P2).";
+  trainingBtn.addEventListener("click", () => openTraining());
   {
     const svgNs = "http://www.w3.org/2000/svg";
     const svg = document.createElementNS(svgNs, "svg");
@@ -11613,8 +11657,43 @@ function buildPanel() {
         tab: msg.tab,
         filters: msg.filters,
         browsingLevels: msg.browsingLevels,
+        // Agent-opened → side-dock by default (chat stays visible) unless the
+        // agent explicitly passes dock:false.
+        dock: msg.dock !== false,
       });
       return { ok: true };
+    },
+    // The agent DRIVES the already-open CivitAI browser (switch tab, re-search,
+    // read results, glow-highlight). Routes to the live modal handle; throws an
+    // honest "not open" error the agent can retry after re-opening.
+    onCivitaiCmd(msg) {
+      const h = _civitaiHandle;
+      if (!h) throw new Error("civitai browser not open");
+      switch (msg.cmd) {
+        case "civitai_results": return h.getResults({ limit: msg.limit });
+        case "civitai_highlight": return h.highlight(Array.isArray(msg.ids) ? msg.ids : (msg.ids != null ? [msg.ids] : []), { kind: msg.kind });
+        case "civitai_clear_highlight": return h.clearHighlight();
+        case "civitai_switch_tab": return h.switchTab(msg.tab);
+        case "civitai_search": return h.search({ query: msg.query, filters: msg.filters });
+        case "civitai_open_lightbox": return h.openLightbox(msg.id);
+        default: throw new Error(`unknown civitai cmd "${msg.cmd}"`);
+      }
+    },
+    // The agent opens/drives the training wizard (parity with CivitAI).
+    onTrainingCmd(msg) {
+      if (msg.cmd === "open_training") {
+        openTraining({ dock: msg.dock !== false });
+        return { ok: true };
+      }
+      const h = _trainingHandle;
+      if (!h) throw new Error("training wizard not open");
+      switch (msg.cmd) {
+        case "training_set_field": return h.setField(msg.name, msg.value);
+        case "training_goto_step": return h.gotoStep(msg.step);
+        case "training_set_target": return h.setTarget(msg.target);
+        case "training_highlight": return h.highlight(Array.isArray(msg.refs) ? msg.refs : (msg.refs != null ? [msg.refs] : []));
+        default: throw new Error(`unknown training cmd "${msg.cmd}"`);
+      }
     },
     // The agent called panel_ui_render / panel_ui_update — A2UI cards in the chat.
     onUiRender(msg) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -6640,6 +6640,78 @@ function animateToBoundsPadded(bounds, padPct, duration) {
   canvas.setDirty(true, true);
 }
 
+/** Docked-modal geometry for the agent-driven CivitAI/Training modals. Measures
+ *  the Agent pane and the ComfyUI canvas, then anchors into the canvas area
+ *  OPPOSITE the pane (the pane can be docked LEFT or RIGHT). Three states:
+ *   - detached → the Agent root left the DOM (sidebar-tab switch); the caller
+ *     hides the orphaned body-mounted modal.
+ *   - centered → no usable anchor (missing/zero-size/too-small).
+ *   - docked   → { left, right, top, bottom } insets for position:fixed.
+ *  Mirrors the pane/canvas detection in animateToBoundsPadded (:6613-6624). */
+function panelDockGeometry() {
+  try {
+    const root = activePanelRoot;
+    if (!root || !root.isConnected) return { status: "detached" };
+    const pane = root.closest(".side-bar-panel") || root.closest("[class*='sidebar']") || root;
+    const pr = pane.getBoundingClientRect();
+    if (!pr || pr.width < 1 || pr.height < 1) return { status: "centered" };
+    const vw = window.innerWidth, vh = window.innerHeight;
+    let cr = null;
+    try { cr = getGraphCtx().canvas?.canvas?.getBoundingClientRect?.() || null; } catch { cr = null; }
+    const canvasRect = (cr && cr.width > 1)
+      ? cr : { left: 0, right: vw, top: 0, bottom: vh, width: vw };
+    const paneOnLeft = (pr.left + pr.right) / 2 < (canvasRect.left + canvasRect.right) / 2;
+    let left, right;
+    if (paneOnLeft) {
+      left = Math.max(pr.right, canvasRect.left);
+      right = Math.max(0, vw - canvasRect.right);
+    } else {
+      left = Math.max(0, canvasRect.left);
+      right = Math.max(0, vw - Math.min(pr.left, canvasRect.right));
+    }
+    const top = Math.max(0, Math.min(pr.top, canvasRect.top));
+    const bottom = Math.max(0, vh - Math.max(pr.bottom, canvasRect.bottom));
+    if (vw - left - right < 320 || vh - top - bottom < 200) return { status: "centered" };
+    return { status: "docked", left, right, top, bottom };
+  } catch {
+    return { status: "centered" };
+  }
+}
+
+/** Watch everything that can move the dock anchor and invoke `cb`: window
+ *  resize, PrimeVue splitter drags (ResizeObserver on pane + canvas — these do
+ *  NOT fire window-resize), and sidebar-tab switches (the Agent root detaches
+ *  without a resize; observe the rail's class changes). Returns a disposer that
+ *  the modal's single close() path calls. */
+function panelWatchDock(cb) {
+  const disposers = [];
+  const fire = () => { try { cb(); } catch { /* modal owns error handling */ } };
+  window.addEventListener("resize", fire);
+  disposers.push(() => window.removeEventListener("resize", fire));
+  try {
+    const root = activePanelRoot;
+    const pane = root?.closest?.(".side-bar-panel") || root?.closest?.("[class*='sidebar']") || root;
+    let cEl = null;
+    try { cEl = getGraphCtx().canvas?.canvas || null; } catch { cEl = null; }
+    if (typeof ResizeObserver === "function") {
+      const ro = new ResizeObserver(fire);
+      try { if (pane) ro.observe(pane); } catch { /* detached */ }
+      try { if (cEl) ro.observe(cEl); } catch { /* not ready */ }
+      disposers.push(() => { try { ro.disconnect(); } catch { /* already gone */ } });
+    }
+    // Sidebar-tab switch detaches the Agent root with no resize event — watch the
+    // rail's selected-button class so the dock re-evaluates (→ hide on detach,
+    // re-dock on return).
+    const toolbar = document.querySelector(".side-tool-bar-container");
+    if (toolbar && typeof MutationObserver === "function") {
+      const mo = new MutationObserver(fire);
+      mo.observe(toolbar, { subtree: true, attributes: true, attributeFilter: ["class"] });
+      disposers.push(() => { try { mo.disconnect(); } catch { /* already gone */ } });
+    }
+  } catch { /* best-effort; window-resize still wired */ }
+  return () => { for (const d of disposers) { try { d(); } catch { /* ignore */ } } };
+}
+
 /** Smoothly dart to the node(s) with the given ids (skips ones not found). */
 function focusNodesById(ids) {
   let graph;
@@ -9900,6 +9972,9 @@ function buildPanel() {
     return {
       api,
       root,
+      // Agent-drive side-dock geometry/observation (pane may be docked L or R).
+      dockGeometry: panelDockGeometry,
+      watchDock: panelWatchDock,
       callTool: (t, a, o) => liveBridgeClient?.callTool(t, a, o),
       sendUserMessage: (t, c, i) => liveBridgeClient?.sendUserMessage(t, c, i),
       uploadBlobToInput,
@@ -9976,6 +10051,8 @@ function buildPanel() {
     return {
       api,
       root,
+      dockGeometry: panelDockGeometry,
+      watchDock: panelWatchDock,
       callTool: (t, a, o) => liveBridgeClient?.callTool(t, a, o),
       uploadBlobToInput,
     };
@@ -11674,7 +11751,7 @@ function buildPanel() {
         case "civitai_highlight": return h.highlight(Array.isArray(msg.ids) ? msg.ids : (msg.ids != null ? [msg.ids] : []), { kind: msg.kind });
         case "civitai_clear_highlight": return h.clearHighlight();
         case "civitai_switch_tab": return h.switchTab(msg.tab);
-        case "civitai_search": return h.search({ query: msg.query, filters: msg.filters });
+        case "civitai_search": return h.search({ query: msg.query, filters: msg.filters, browsingLevels: msg.browsingLevels });
         case "civitai_open_lightbox": return h.openLightbox(msg.id);
         default: throw new Error(`unknown civitai cmd "${msg.cmd}"`);
       }


### PR DESCRIPTION
## What

The panel side of **agent-driven CivitAI + training modals** — makes the CivitAI browser and training wizard *agent-drivable* and adds a **side-dock** so chat and the modal are both visible. Pairs with **comfyui-mcp PR (feat/agent-drive-modals)** which emits the bridge cmds — both must land together.

The magical loop: the agent opens a search (docked beside chat), reads the results, and **highlights the interesting ones with a glowing green outline** — then can switch tabs, re-search, and open a lightbox. Same drive surface for the training wizard.

## How

- **Live modal handles** — `openCivitaiModal`/`openTrainingModal` return post-open control (`switchTab, search, getResults, highlight, clearHighlight, openLightbox, getState, ...`); stored module-side and self-invalidating on close.
- **Highlight** — result cards carry `data-id`/`data-kind`; a `highlightSet` + `renderRev` model survives infinite-scroll (re-applied on append) and correctly no-ops when a reload supersedes it; glow via `.cmcp-agent-glow` + `@keyframes cmcp-glow` (in **both** modules so training-opened-first still glows).
- **Results** — `serializeCivitaiResults` returns metadata + image **URLs** only (no image inputs); prompts capped.
- **Side-dock** — `panelDockGeometry` measures pane + canvas and docks into the side **opposite** the Agent pane (works left- or right-docked), slides in, `pointer-events` keep chat clickable; `panelWatchDock` (ResizeObserver + window-resize + a MutationObserver for the tab-switch root-detach) recomputes and tears down through the one `close()` path; centered fallback below a width breakpoint.
- **Bridge** — new cmds routed to the stored handle; branches **throw** when the modal is closed so the agent gets an honest error (an inner `{ok:false}` would be swallowed as success).
- **Safety** — every feed path (incl. Favorites) uses the same server-clamped `browsingLevels`; `set_field` is an allowlist (no arbitrary `wiz[name]=`); `gotoStep` enforces the wizard's own gates via a shared `_readiness()`; `setTarget("pod")` awaits a fresh versioned `train_doctor` and rejects a superseded/no-pod result.

## Review

Codex-hardened across four passes (plan-design → code → cross-repo contract → delta). Notable catches now closed: a **security BLOCKER** (Favorites tab defaulting to all NSFW levels), a swallowed handle error, a highlight race, a stale-pod-target race, a lightbox listener leak, and cross-agent contract drift. All findings confirmed-closed.

## Gates
- `node --check` (as `.mjs`) all changed files pass; `npm run test:unit` 95/95; `tsc --noEmit` clean; 10 `agent-drive` Playwright specs discovered.

**Live-pass pending (merge gated):** the 10 Playwright specs need a live ComfyUI (localhost:8188); and three cases the mock harness can't drive — dock orientation flip (pane left vs right), pane collapse, and Agent-root detach re-centering — plus the overall "does it feel magical" judgment need a real Claude-in-Chrome pass. Running that against this PR next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
