### PR TITLE
feat(panel): dock + slide the three toolbar side-panels; CivitAI share closes + right-aligned actions

### DIFF
--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -237,6 +237,25 @@ const el = (tag, cls, txt) => {
   return n;
 };
 
+/** Slide/fade the panel out before detaching (shared exit for the three docked
+ *  side-panels). Docked: reverse the translateX slide-in (drop cmcp-dock-in) so
+ *  the card slides back out; centered/narrow: a plain opacity fade — no
+ *  horizontal slide. The DOM is removed after the transition window (jsdom fires
+ *  no transitionend, so a fixed timer drives it). Idempotent — remove() on an
+ *  already-detached node is a no-op. */
+const DOCK_SLIDE_OUT_MS = 240;
+function slideOutThenRemove(overlay) {
+  const docked = overlay.classList.contains("cmcp-docked");
+  overlay.style.pointerEvents = "none";
+  if (docked) {
+    overlay.classList.remove("cmcp-dock-in"); // card returns to translateX(24px)/opacity 0
+  } else {
+    overlay.style.transition = "opacity .18s ease";
+    overlay.style.opacity = "0";
+  }
+  setTimeout(() => { try { overlay.remove(); } catch { /* already gone */ } }, DOCK_SLIDE_OUT_MS);
+}
+
 /** Fail-CLOSED dirty check for the load-onto-canvas overwrite confirm: any
  *  uncertainty (missing getter, non-boolean answer, a throw) counts as DIRTY
  *  so the user gets asked — never silently clobber an unsaved canvas.
@@ -351,7 +370,10 @@ export function openCivitaiModal(ctx, opts = {}) {
     if (_onEscape) { document.removeEventListener("keydown", _onEscape); _onEscape = null; }
     if (_onDockResize) { window.removeEventListener("resize", _onDockResize); _onDockResize = null; }
     if (_dockDispose) { try { _dockDispose(); } catch { /* best effort */ } _dockDispose = null; }
-    overlay.remove();
+    // Slide/fade the card out, THEN detach (parity with the Training + RunPod
+    // side-panels). isOpen already flipped above, so drive methods + re-close are
+    // inert during the ~240ms exit; host bookkeeping (onClose) still runs now.
+    slideOutThenRemove(overlay);
     try { opts.onClose?.(); } catch { /* host bookkeeping only */ }
   };
   // In docked mode the overlay itself is click-through (pointer-events:none), so a
@@ -445,6 +467,10 @@ export function openCivitaiModal(ctx, opts = {}) {
     if (e.key === "Enter") { clearTimeout(searchTimer); applySearch(); }
   });
   const filterBtn = el("button", "cmcp-cv-iconbtn");
+  // First of the three right-side actions (filters ⚙ / account 👤 / close ✕):
+  // margin-left:auto pushes this trio to the right edge while the tab row stays
+  // left-aligned in the flex header.
+  filterBtn.style.marginLeft = "auto";
   filterBtn.innerHTML = '<i class="pi pi-sliders-h"></i>';
   const filterDot = el("span", "cmcp-cv-dot"); filterDot.style.display = "none";
   filterBtn.appendChild(filterDot);
@@ -1089,6 +1115,11 @@ export function openCivitaiModal(ctx, opts = {}) {
         ctx.bringChatForward();
         toast("Shared with the agent.");
       }
+      // Hand-off is done (either variant) — close the explorer so the chat/agent
+      // is visible. Only on SUCCESS; a failed share (below) leaves it open to
+      // retry. The toast is body-mounted (survives the close) so the confirmation
+      // stays on screen. close() is idempotent + tears down the lightbox/sheets.
+      close();
     } catch (e) { toast("Share failed: " + e.message); }
   }
 

--- a/web/js/cmcp-runpod-ui.js
+++ b/web/js/cmcp-runpod-ui.js
@@ -54,6 +54,21 @@ function injectStyle() {
 .cmcp-rp-credit{font-size:0.7rem;opacity:0.5;}
 .cmcp-rp-credit a{color:inherit;}
 .cmcp-rp-muted{font-size:0.75rem;opacity:0.6;}
+/* Agent-drive/manual side-dock (parity with the CivitAI + Training modals):
+   anchor the card to the canvas side OPPOSITE the Agent pane, drop the backdrop,
+   let clicks pass THROUGH the overlay so chat stays interactive; only the card
+   catches pointer events. Bumped above the canvas (z 10000) to match. Slides in
+   via translateX; the close() path reverses it before detaching. The base
+   .cmcp-modal-overlay (panel monolith CSS, always loaded) styles the centered
+   fallback — this only overrides the docked case, so centered opens are
+   unchanged. */
+.cmcp-modal-overlay.cmcp-docked{position:fixed;display:block;padding:0;background:transparent;
+  pointer-events:none;z-index:10000;}
+.cmcp-modal-overlay.cmcp-docked .cmcp-rp-modal{position:fixed;pointer-events:auto;
+  width:auto;max-width:none!important;height:auto;max-height:none;overflow-y:auto;
+  border-radius:0;box-shadow:-8px 0 32px rgba(0,0,0,.45);
+  transform:translateX(24px);opacity:0;transition:transform .28s ease,opacity .28s ease;}
+.cmcp-modal-overlay.cmcp-docked.cmcp-dock-in .cmcp-rp-modal{transform:translateX(0);opacity:1;}
 `;
   const el = document.createElement("style");
   el.textContent = css;
@@ -192,6 +207,61 @@ export function openRunpodModal(ctx, opts = {}) {
   let busy = false;
   let closed = false;
   let tick = null;
+  let _onDockResize = null; // window-resize fallback when ctx.watchDock is absent
+  let _dockDispose = null;  // ResizeObserver+listener disposer from ctx.watchDock
+
+  // ── docked mode (parity with the CivitAI + Training modals) ──────────────────
+  // Geometry from the host (ctx.dockGeometry owns pane/canvas measurement +
+  // left/right detection); three states detached(hide)/centered/docked. See the
+  // CivitAI modal for the full rationale. When opts.dock is unset this is inert
+  // and the modal stays the plain centered overlay it always was.
+  applyDock.centered = false;
+  function applyDock() {
+    if (!opts.dock) { setCentered(); return; }
+    const geo = _dockGeometry();
+    if (geo && geo.status === "detached") { overlay.style.display = "none"; return; }
+    overlay.style.display = "";
+    if (geo && geo.status === "docked" && window.innerWidth >= 900) {
+      overlay.classList.add("cmcp-docked");
+      modal.style.left = `${Math.round(geo.left)}px`;
+      modal.style.top = `${Math.round(geo.top)}px`;
+      modal.style.right = `${Math.round(geo.right)}px`;
+      modal.style.bottom = `${Math.round(geo.bottom)}px`;
+      applyDock.centered = false;
+    } else { setCentered(); }
+  }
+  function setCentered() {
+    overlay.classList.remove("cmcp-docked");
+    overlay.style.display = "";
+    modal.style.left = modal.style.right = modal.style.top = modal.style.bottom = "";
+    applyDock.centered = true;
+  }
+  function _dockGeometry() {
+    if (typeof ctx.dockGeometry === "function") {
+      try { const g = ctx.dockGeometry(); if (g) return g; } catch { /* fall through */ }
+    }
+    try {
+      if (root && !root.isConnected) return { status: "detached" };
+      const pane = root?.closest?.(".side-bar-panel") || root?.closest?.("[class*='sidebar']") || root;
+      const pr = pane?.getBoundingClientRect?.();
+      if (!pr || pr.width < 1 || pr.height < 1) return { status: "centered" };
+      const vw = window.innerWidth, vh = window.innerHeight;
+      const paneOnLeft = (pr.left + pr.right) / 2 < vw / 2;
+      const left = paneOnLeft ? Math.max(0, pr.right) : 0;
+      const right = paneOnLeft ? 0 : Math.max(0, vw - pr.left);
+      if (vw - left - right < 320) return { status: "centered" };
+      return { status: "docked", left, right, top: Math.max(0, pr.top), bottom: Math.max(0, vh - pr.bottom) };
+    } catch { return { status: "centered" }; }
+  }
+  if (opts.dock) {
+    applyDock();
+    if (typeof ctx.watchDock === "function") {
+      try { _dockDispose = ctx.watchDock(applyDock); } catch { _dockDispose = null; }
+    }
+    if (!_dockDispose) { _onDockResize = () => applyDock(); window.addEventListener("resize", _onDockResize); }
+    // Slide-in on the next frame so the transition runs from the initial state.
+    requestAnimationFrame(() => overlay.classList.add("cmcp-dock-in"));
+  }
 
   function setLog(text, kind) {
     log.textContent = text || "";
@@ -415,9 +485,12 @@ export function openRunpodModal(ctx, opts = {}) {
   });
 
   const close = () => {
+    if (closed) return; // idempotent
     closed = true;
-    if (tick) clearInterval(tick);
-    overlay.remove();
+    if (tick) { clearInterval(tick); tick = null; }
+    if (_onDockResize) { window.removeEventListener("resize", _onDockResize); _onDockResize = null; }
+    if (_dockDispose) { try { _dockDispose(); } catch { /* best effort */ } _dockDispose = null; }
+    slideOutThenRemove(overlay);
   };
   doneBtn.addEventListener("click", close);
   overlay.addEventListener("mousedown", (e) => {
@@ -438,6 +511,24 @@ export function openRunpodModal(ctx, opts = {}) {
     },
     isOpen: () => !closed,
   };
+}
+
+/** Slide/fade the panel out before detaching (parity across the three
+ *  side-panels). Docked: reverse the translateX slide-in (drop cmcp-dock-in);
+ *  centered/narrow: a plain opacity fade — no horizontal slide. The DOM is
+ *  removed after the transition window (jsdom fires no transitionend, so a fixed
+ *  timer drives it). Idempotent — remove() on a detached node is a no-op. */
+const DOCK_SLIDE_OUT_MS = 240;
+function slideOutThenRemove(overlay) {
+  const docked = overlay.classList.contains("cmcp-docked");
+  overlay.style.pointerEvents = "none";
+  if (docked) {
+    overlay.classList.remove("cmcp-dock-in"); // card returns to translateX(24px)/opacity 0
+  } else {
+    overlay.style.transition = "opacity .18s ease";
+    overlay.style.opacity = "0";
+  }
+  setTimeout(() => { try { overlay.remove(); } catch { /* already gone */ } }, DOCK_SLIDE_OUT_MS);
 }
 
 function mkBtn(label, variant) {

--- a/web/js/cmcp-training-ui.js
+++ b/web/js/cmcp-training-ui.js
@@ -152,6 +152,25 @@ function el(tag, cls, text) {
   return e;
 }
 
+/** Slide/fade the panel out before detaching (shared exit for the three docked
+ *  side-panels). Docked: reverse the translateX slide-in (drop cmcp-dock-in) so
+ *  the card slides back out; centered/narrow: a plain opacity fade — no
+ *  horizontal slide. The DOM is removed after the transition window (jsdom fires
+ *  no transitionend, so a fixed timer drives it). Idempotent — remove() on an
+ *  already-detached node is a no-op. */
+const DOCK_SLIDE_OUT_MS = 240;
+function slideOutThenRemove(overlay) {
+  const docked = overlay.classList.contains("cmcp-docked");
+  overlay.style.pointerEvents = "none";
+  if (docked) {
+    overlay.classList.remove("cmcp-dock-in"); // card returns to translateX(24px)/opacity 0
+  } else {
+    overlay.style.transition = "opacity .18s ease";
+    overlay.style.opacity = "0";
+  }
+  setTimeout(() => { try { overlay.remove(); } catch { /* already gone */ } }, DOCK_SLIDE_OUT_MS);
+}
+
 /** callTool envelope → parsed JSON (train_* tools return text-wrapped JSON). */
 async function callJson(ctx, tool, args, opts) {
   if (!ctx.callTool) throw new Error("panel bridge not connected — start the comfyui-mcp orchestrator");
@@ -260,7 +279,10 @@ export function openTrainingModal(ctx = {}, opts = {}) {
     if (_dockDispose) { try { _dockDispose(); } catch { /* best effort */ } _dockDispose = null; }
     wiz.launchGen++; // a pending launch's continuation self-discards (codex finding)
     wiz.uploadGen++;
-    overlay.remove();
+    // Slide/fade the card out, THEN detach (parity with the CivitAI + RunPod
+    // side-panels). `closed` already true above, so the exit window is inert;
+    // host bookkeeping (onClose) still runs now.
+    slideOutThenRemove(overlay);
     try { opts.onClose?.(); } catch { /* host bookkeeping only */ }
   };
   overlay.addEventListener("mousedown", (e) => { if (e.target === overlay) close(); });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10021,7 +10021,8 @@ function buildPanel() {
   const civitaiBtn = toolbarBtn("pi-circle", "Civitai");
   civitaiBtn.querySelector(".pi").remove();
   civitaiBtn.title = "Civitai explorer — browse and pull models, LoRAs, and workflows without leaving the panel.";
-  civitaiBtn.addEventListener("click", () => openCivitai());
+  // Manual open side-docks too (chat stays visible) — parity with the agent open.
+  civitaiBtn.addEventListener("click", () => openCivitai({ dock: true }));
   {
     const svgNs = "http://www.w3.org/2000/svg";
     const svg = document.createElementNS(svgNs, "svg");
@@ -10070,7 +10071,8 @@ function buildPanel() {
   const trainingBtn = toolbarBtn("pi-circle", "Training");
   trainingBtn.querySelector(".pi").remove();
   trainingBtn.title = "LoRA Training — train a character LoRA locally on FLUX.1-dev (style/edit/slider/video coming in P2).";
-  trainingBtn.addEventListener("click", () => openTraining());
+  // Manual open side-docks too (chat stays visible) — parity with the agent open.
+  trainingBtn.addEventListener("click", () => openTraining({ dock: true }));
   {
     const svgNs = "http://www.w3.org/2000/svg";
     const svg = document.createElementNS(svgNs, "svg");
@@ -10153,7 +10155,11 @@ function buildPanel() {
       getStatus: () => _runpodStatus,
       getTarget: () => _comfyuiTarget,
       openUrl: (u) => { try { window.open(u, "_blank", "noopener"); } catch {} },
-    });
+      // Agent-drive side-dock geometry/observation (pane may be docked L or R),
+      // same helpers the CivitAI/Training modals use.
+      dockGeometry: panelDockGeometry,
+      watchDock: panelWatchDock,
+    }, { dock: true });
   });
   // Expose for the bridge callbacks (defined outside this closure).
   panelRunpod = {


### PR DESCRIPTION
Four UX-polish changes on top of the agent-drive dock:

1. **Three toolbar side-panels dock + slide.** CivitAI, Training, and RunPod/"Local" now open **docked** (chat stays visible) with a slide-in, and slide **out** on close via a shared per-module `slideOutThenRemove()` (docked → reverse the translateX; centered → opacity fade; detach on a fixed 240ms timer since jsdom fires no `transitionend`). RunPod gains full docked mode (`applyDock`/`setCentered`/`_dockGeometry`) mirroring the other two, watched via `ctx.watchDock` with a window-resize fallback and an idempotent `close()`.
2. **CivitAI "Share with agent" closes the modal** on success only (failed share stays open to retry); the toast is body-mounted so it survives the close.
3. **Slide in/out animation** for all three (item 1).
4. **Right-aligned header actions** — `margin-left:auto` on the filters button pushes the filters/account/close trio to the right edge while the tab row stays left.

## Gates
- `node --check` on all four changed files pass; `test:unit` 95/95.
- Independent adversarial review (substituted after codex's sandbox blocked its git): **CLEAN TO MERGE**. Six lifecycle hazards traced confirmed-safe — slide-out re-open race (each open mints a fresh overlay node), double-close idempotency (all three modules), RunPod dock var ordering, `margin-left:auto` right-align, narrow-window degrade-to-centered, and module-isolated triple-declared helpers. One non-blocking cosmetic note (sub-frame close-after-open briefly slides in, still removed correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
