### PR TITLE
feat(apps): micro-apps — workflow→app conversion, local/RunPod runs, publish/explore registry

### DIFF
--- a/.comfyignore
+++ b/.comfyignore
@@ -19,6 +19,9 @@ tsconfig.json
 # Dev-only tooling — keep the published (security-scanned) archive minimal
 scripts/
 .githooks/
+# The Cloudflare registry worker (deploy infra, not part of the custom-node
+# pack; its fetch/crypto calls would only manufacture scanner findings)
+registry/
 # The registry's YARA scan matches code-shaped literals in ANY shipped file,
 # including markdown prose: 0.6.2 was flagged (any-code-execute) because the
 # changelog QUOTED the removed process-spawn call verbatim. The changelog

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Each provider runs its own orchestrator on its own loopback port (Claude on
 | **Autonomous install → restart → continue** | Install custom nodes through your own ComfyUI Manager, restart ComfyUI to load them, and the panel auto-reconnects so the agent resumes its task. |
 | **Reasoning effort + model selector** | A per-provider effort/model picker — Claude's models, or ChatGPT's GPT-5-class models via Codex — moved into the model selector; a chosen effort survives a provider switch by mapping to the nearest valid level. |
 | **Pending-message tray + reconnect durability** | Queue messages while the agent is busy (edit / send-now / reorder), and reclaim a wedged orchestrator on Connect. |
+| **Apps (micro-apps)** | Convert any workflow into a named, one-click **app** (name, description, thumbnail, chosen input/output endpoints) from the toolbar's **Apps** button — runs headless (the canvas is never touched), locally or on a connected RunPod pod, with best-effort hidden-workflow packaging and a publish/explore registry (`registry/`, Cloudflare Worker + D1 + R2) shared with the mobile app. |
 
 ## Quickstart
 

--- a/__init__.py
+++ b/__init__.py
@@ -362,6 +362,15 @@ def _register_routes():
     except Exception as _e:  # pragma: no cover - never block panel load
         _log("training routes not registered: {}".format(_e))
 
+    # Micro-Apps: bundle storage under the user dir + headless run engine
+    # (same HTTP surface backs the mobile app's whitelisted apps_* tools).
+    try:
+        from .py import apps_routes
+
+        apps_routes.register(routes, web)
+    except Exception as _e:  # pragma: no cover - never block panel load
+        _log("apps routes not registered: {}".format(_e))
+
     @routes.get("/comfyui_mcp_panel/status")
     async def _status(_request):
         detected = _detect_comfyui_url()

--- a/browser_tests/apps.spec.ts
+++ b/browser_tests/apps.spec.ts
@@ -1,0 +1,573 @@
+/**
+ * Tier 1 — Micro-Apps ("Apps") panel feature.
+ *
+ * Hermetic: the /comfyui_mcp_panel/apps* routes are stubbed with an in-memory
+ * store (the dev box's real bundles are never touched), and the live canvas is
+ * stubbed with a fixture graph (graphToPrompt + graph._nodes + node defs) so
+ * "Convert current workflow" has something deterministic to serialize.
+ *
+ * Covers: empty grid → convert (fixture canvas) → card appears → detail →
+ * one-click run (patched values POSTed, outputs rendered) → hide-workflow
+ * (manifest update, warning copy present).
+ */
+import { test, expect } from './fixtures/panelTest'
+import type { Page, Route } from '@playwright/test'
+
+const APP_ID = '123e4567-e89b-42d3-a456-426614174000'
+
+// 1x1 transparent PNG.
+const PIXEL = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64'
+)
+
+const FIXTURE_PROMPT = {
+  '4': { class_type: 'CheckpointLoaderSimple', inputs: { ckpt_name: 'flux.safetensors' } },
+  '6': { class_type: 'CLIPTextEncode', inputs: { text: 'a cat', clip: ['4', 1] } },
+  '3': {
+    class_type: 'KSampler',
+    inputs: { seed: 42, steps: 20, model: ['4', 0], positive: ['6', 0] }
+  },
+  '9': { class_type: 'SaveImage', inputs: { images: ['8', 0], filename_prefix: 'ComfyUI' } }
+}
+
+const FIXTURE_WORKFLOW = {
+  last_node_id: 9,
+  last_link_id: 5,
+  nodes: [],
+  links: [],
+  groups: [],
+  config: {},
+  extra: {},
+  version: 0.4
+}
+
+interface StoredApp {
+  manifest: Record<string, unknown> & { id: string; name: string }
+  workflow?: unknown
+  prompt: unknown
+}
+
+/** In-memory apps API + fixture canvas. Returns the captured HTTP traffic. */
+async function stubAppsBackend(page: Page) {
+  const store = new Map<string, StoredApp>()
+  const captured: { method: string; url: string; body: unknown }[] = []
+  const record = (route: Route) => {
+    const req = route.request()
+    let body: unknown = null
+    try {
+      body = req.postDataJSON()
+    } catch {
+      /* no JSON body */
+    }
+    captured.push({ method: req.method(), url: req.url(), body })
+  }
+
+  await page.route('**/comfyui_mcp_panel/apps', async (route) => {
+    record(route)
+    if (route.request().method() === 'POST') {
+      const body = route.request().postDataJSON() as StoredApp
+      store.set(body.manifest.id, body)
+      return route.fulfill({ json: { ok: true, id: body.manifest.id } })
+    }
+    return route.fulfill({
+      json: {
+        apps: [...store.values()].map((s) => ({
+          ...s.manifest,
+          has_workflow: !!s.workflow,
+          has_prompt: true,
+          has_thumbnail: false
+        }))
+      }
+    })
+  })
+
+  await page.route(/\/comfyui_mcp_panel\/apps\/[0-9a-f-]{36}$/, async (route) => {
+    record(route)
+    const id = route.request().url().split('/').pop()!
+    const s = store.get(id)
+    if (!s) return route.fulfill({ status: 404, json: { error: 'not found' } })
+    if (route.request().method() === 'PUT') {
+      const body = route.request().postDataJSON() as { manifest?: Record<string, unknown> }
+      s.manifest = { ...s.manifest, ...(body.manifest || {}) }
+      return route.fulfill({ json: s.manifest })
+    }
+    if (route.request().method() === 'DELETE') {
+      store.delete(id)
+      return route.fulfill({ json: { ok: true } })
+    }
+    return route.fulfill({
+      json: { ...s.manifest, has_workflow: !!s.workflow, has_prompt: true, has_thumbnail: false }
+    })
+  })
+
+  await page.route(/\/comfyui_mcp_panel\/apps\/[0-9a-f-]{36}\/bundle$/, async (route) => {
+    record(route)
+    const id = route.request().url().split('/').slice(-2, -1)[0]
+    const s = store.get(id)
+    if (!s) return route.fulfill({ status: 404, json: { error: 'not found' } })
+    return route.fulfill({ json: { manifest: s.manifest, prompt: s.prompt, ...(s.workflow ? { workflow: s.workflow } : {}) } })
+  })
+
+  await page.route(/\/comfyui_mcp_panel\/apps\/[0-9a-f-]{36}\/run$/, async (route) => {
+    record(route)
+    const id = route.request().url().split('/').slice(-2, -1)[0]
+    const body = route.request().postDataJSON() as {
+      values?: Record<string, unknown>
+      dry?: boolean
+    }
+    if (body?.dry) {
+      // Mirror the server's dry-run: patch values into the stored snapshot and
+      // hand the prompt back instead of queueing.
+      const s = store.get(id)
+      if (!s) return route.fulfill({ status: 404, json: { error: 'not found' } })
+      const patched = JSON.parse(JSON.stringify(s.prompt)) as Record<
+        string,
+        { inputs: Record<string, unknown> }
+      >
+      for (const [key, value] of Object.entries(body.values || {})) {
+        const dot = key.indexOf('.')
+        patched[key.slice(0, dot)].inputs[key.slice(dot + 1)] = value
+      }
+      return route.fulfill({ json: { ok: true, prompt: patched } })
+    }
+    return route.fulfill({ json: { ok: true, prompt_id: 'p1', number: 1 } })
+  })
+
+  await page.route(/\/comfyui_mcp_panel\/apps\/[0-9a-f-]{36}\/runs\/p1$/, async (route) => {
+    record(route)
+    return route.fulfill({
+      json: {
+        prompt_id: 'p1',
+        status: 'done',
+        status_detail: {},
+        outputs: { '9': { images: [{ filename: 'out.png', subfolder: '', type: 'output' }] } }
+      }
+    })
+  })
+
+  await page.route(/\/view\?/, (route) =>
+    route.fulfill({ status: 200, contentType: 'image/png', body: PIXEL })
+  )
+
+  // Fixture canvas: what the convert flow serializes + picks candidates from.
+  // Called explicitly AFTER panel.goto() (ComfyUI replaces app.graph while
+  // restoring the user's workflow on load, so an addInitScript patch races and
+  // loses) AND again right before Convert (a late workflow-restore swap would
+  // otherwise clobber it). Patches BOTH app references — the panel's lazily
+  // resolved `app` and window.app can differ across frontends.
+  const installFixtureCanvas = async () => {
+    // The graph object appears only after the frontend restores the workflow.
+    await page.waitForFunction(() => {
+      const w = window as unknown as { comfyAPI?: { app?: { app?: any } }; app?: any }
+      const app = w.comfyAPI?.app?.app || w.app
+      return !!app?.graph
+    })
+    await page.evaluate(() => {
+      const w = window as unknown as { comfyAPI?: { app?: { app?: any } }; app?: any }
+      const apps = new Set([w.comfyAPI?.app?.app, w.app].filter(Boolean))
+      if (!apps.size) throw new Error('ComfyUI app not ready')
+      for (const app of apps) {
+      app.graphToPrompt = async () => ({
+        output: JSON.parse(
+          '{"4":{"class_type":"CheckpointLoaderSimple","inputs":{"ckpt_name":"flux.safetensors"}},"6":{"class_type":"CLIPTextEncode","inputs":{"text":"a cat","clip":["4",1]}},"3":{"class_type":"KSampler","inputs":{"seed":42,"steps":20}},"9":{"class_type":"SaveImage","inputs":{"images":["8",0],"filename_prefix":"ComfyUI"}}}'
+        ),
+        workflow: {
+          last_node_id: 9,
+          nodes: [],
+          links: [],
+          groups: [],
+          config: {},
+          extra: {},
+          version: 0.4
+        }
+      })
+      const node = (id: number, type: string, widgets: unknown[], outputNode = false) => ({
+        id,
+        type,
+        title: type,
+        inputs: [],
+        widgets,
+        constructor: { nodeData: { output_node: outputNode } }
+      })
+      // Mutate the LIVE graph in place (assigning app.graph trips ComfyApp's
+      // graph setter and the async workflow restore then clobbers our fixture).
+      if (!app.graph) throw new Error('no live graph')
+      app.graph._nodes = [
+          node(4, 'CheckpointLoaderSimple', [
+            { name: 'ckpt_name', value: 'flux.safetensors', type: 'combo', options: { values: ['flux.safetensors', 'sdxl.safetensors'] } }
+          ]),
+          node(6, 'CLIPTextEncode', [{ name: 'text', value: 'a cat', type: 'text' }]),
+          node(3, 'KSampler', [
+            { name: 'seed', value: 42, type: 'number' },
+            { name: 'steps', value: 20, type: 'number' }
+          ]),
+          node(9, 'SaveImage', [], true)
+        ]
+      app.nodeManager = {
+        ...(app.nodeManager || {}),
+        defs: {
+          CheckpointLoaderSimple: {},
+          CLIPTextEncode: {},
+          KSampler: {},
+          SaveImage: {},
+          VAEDecode: {}
+        }
+      }
+      }
+    })
+  }
+
+  return { store, captured, installFixtureCanvas }
+}
+
+test('convert canvas → app card → detail → one-click run with patched values', async ({
+  panel,
+  page
+}) => {
+  const { store, captured, installFixtureCanvas } = await stubAppsBackend(page)
+  await panel.goto()
+  await installFixtureCanvas()
+  await panel.openSidebar()
+
+  // Open the Apps modal from the toolbar; empty state first.
+  await panel.root.getByRole('button', { name: 'Apps', exact: true }).click()
+  const modal = page.locator('.cmcp-apps-modal')
+  await expect(modal).toBeVisible()
+  await expect(modal).toContainText('No apps yet')
+
+  // Convert: candidates pre-checked from the fixture graph. Re-install right
+  // before — a late workflow-restore swap can clobber the earlier patch.
+  await installFixtureCanvas()
+  await modal.getByRole('button', { name: 'Convert current workflow' }).click()
+  await expect(modal.getByText('Inputs — the endpoints this app exposes')).toBeVisible()
+  await modal.locator('.cmcp-apps-field input[type=text]').fill('Fixture App')
+  await modal.locator('.cmcp-apps-field textarea').fill('Made from a fixture graph')
+  await modal.getByRole('button', { name: 'Create app' }).click()
+
+  // POST captured the bundle: manifest + workflow + prompt snapshot.
+  const create = captured.find((c) => c.method === 'POST' && c.url.endsWith('/apps'))
+  expect(create).toBeTruthy()
+  const bundle = create!.body as StoredApp
+  expect(bundle.manifest.name).toBe('Fixture App')
+  expect((bundle.prompt as Record<string, unknown>)['6']).toBeTruthy()
+
+  // Card appears; open the detail view.
+  const card = modal.locator('.cmcp-app-card', { hasText: 'Fixture App' })
+  await expect(card).toBeVisible()
+  await card.click()
+
+  // Generated form carries the conversion-time defaults (the prompt field is
+  // the CLIPTextEncode row — the model field above it is also a textarea).
+  const promptArea = modal
+    .locator('.cmcp-apps-field', { hasText: 'CLIPTextEncode' })
+    .locator('textarea')
+  await expect(promptArea).toHaveValue('a cat')
+  await promptArea.fill('a dog')
+
+  // One-click run: values patched as <nodeId>.<widget>, outputs rendered.
+  await modal.getByRole('button', { name: '▶ Run' }).click()
+  await expect(modal.locator('.cmcp-apps-status').last()).toHaveText('Done.')
+  await expect(modal.locator('.cmcp-apps-outputs img')).toHaveCount(1)
+  const run = captured.find((c) => c.url.endsWith('/run'))
+  expect((run!.body as { values: Record<string, unknown> }).values['6.text']).toBe('a dog')
+  expect(store.size).toBe(1)
+})
+
+test('run on RunPod: dry-patches locally, enqueues on the pod via the bridge', async ({
+  panel,
+  page,
+  mockBridge
+}) => {
+  const { store } = await stubAppsBackend(page)
+  store.set(APP_ID, {
+    manifest: {
+      id: APP_ID,
+      name: 'Pod App',
+      description: '',
+      version: 1,
+      hideWorkflow: false,
+      appMode: {
+        inputs: [{ nodeId: 6, widget: 'text', label: 'Prompt', kind: 'text', default: 'a cat' }],
+        outputs: [],
+        importedFromFrontend: false
+      },
+      deps: { models: [], customNodes: [] },
+      published: null
+    },
+    workflow: FIXTURE_WORKFLOW,
+    prompt: FIXTURE_PROMPT
+  })
+
+  // Answer the bridge's whitelisted call_tool surface: capture enqueue_workflow.
+  const toolCalls: { tool: string; args: Record<string, unknown> }[] = []
+  mockBridge.onFrame((frame) => {
+    if (frame.type !== 'call_tool') return
+    toolCalls.push({ tool: String(frame.tool), args: (frame.args || {}) as Record<string, unknown> })
+    mockBridge.send({
+      type: 'tool_result',
+      cid: frame.cid,
+      ok: true,
+      result: [
+        { type: 'text', text: JSON.stringify({ status: 'enqueued', prompt_id: 'pod-1', queue_remaining: 0 }) }
+      ]
+    })
+  })
+
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+  // Honest host: renders go to a pod now.
+  mockBridge.send({ type: 'comfyui_target', is_local: false, url: 'http://pod.example:8188' })
+
+  await panel.root.getByRole('button', { name: 'Apps', exact: true }).click()
+  const modal = page.locator('.cmcp-apps-modal')
+  await modal.locator('.cmcp-app-card', { hasText: 'Pod App' }).click()
+  await modal.locator('.cmcp-apps-field textarea').first().fill('a pod dog')
+  await modal.getByRole('button', { name: '☁ Run on RunPod' }).click()
+
+  await expect(modal.locator('.cmcp-apps-status')).toContainText('queued on pod (prompt_id pod-1)')
+  const enqueue = toolCalls.find((c) => c.tool === 'enqueue_workflow')
+  expect(enqueue).toBeTruthy()
+  const wf = enqueue!.args.workflow as Record<string, { inputs: Record<string, unknown> }>
+  expect(wf['6'].inputs.text).toBe('a pod dog')
+  // App inputs are the user's choices — the seed is never re-rolled.
+  expect(enqueue!.args.disable_random_seed).toBe(true)
+  // Nothing hit the LOCAL queue path.
+  expect(store.size).toBe(1)
+})
+
+test('run on RunPod without a connected pod is an honest error, not a silent local run', async ({
+  panel,
+  page,
+  mockBridge
+}) => {
+  const { store } = await stubAppsBackend(page)
+  store.set(APP_ID, {
+    manifest: {
+      id: APP_ID,
+      name: 'Local Only',
+      description: '',
+      version: 1,
+      hideWorkflow: false,
+      appMode: {
+        inputs: [{ nodeId: 6, widget: 'text', label: 'Prompt', kind: 'text' }],
+        outputs: [],
+        importedFromFrontend: false
+      },
+      deps: { models: [], customNodes: [] },
+      published: null
+    },
+    workflow: FIXTURE_WORKFLOW,
+    prompt: FIXTURE_PROMPT
+  })
+
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+  // No comfyui_target frame at all → target unknown → treated as local.
+  await panel.root.getByRole('button', { name: 'Apps', exact: true }).click()
+  const modal = page.locator('.cmcp-apps-modal')
+  await modal.locator('.cmcp-app-card', { hasText: 'Local Only' }).click()
+  await modal.getByRole('button', { name: '☁ Run on RunPod' }).click()
+  await expect(modal.locator('.cmcp-apps-status')).toContainText('No pod connected')
+})
+
+test('hide workflow: warns honestly and strips the graph from the bundle', async ({
+  panel,
+  page
+}) => {
+  const { store, captured } = await stubAppsBackend(page)
+  store.set(APP_ID, {
+    manifest: {
+      id: APP_ID,
+      name: 'Secret Sauce',
+      description: '',
+      version: 1,
+      hideWorkflow: false,
+      appMode: { inputs: [{ nodeId: 6, widget: 'text', label: 'Prompt', kind: 'text' }], outputs: [], importedFromFrontend: false },
+      deps: { models: [], customNodes: [] },
+      published: null
+    },
+    workflow: FIXTURE_WORKFLOW,
+    prompt: FIXTURE_PROMPT
+  })
+  page.on('dialog', (d) => d.accept())
+
+  await panel.goto()
+  await panel.openSidebar()
+  await panel.root.getByRole('button', { name: 'Apps', exact: true }).click()
+  const modal = page.locator('.cmcp-apps-modal')
+  await modal.locator('.cmcp-app-card', { hasText: 'Secret Sauce' }).click()
+
+  await modal.getByRole('button', { name: /Hide workflow/ }).click()
+  // The honest-warning copy is in the confirm dialog (accepted above); the PUT
+  // flips the flag and the server drops workflow.json (stub mirrors the flag).
+  const put = captured.find((c) => c.method === 'PUT')
+  expect((put!.body as { manifest: { hideWorkflow: boolean } }).manifest.hideWorkflow).toBe(true)
+  await expect(modal).toContainText('Hidden workflow (best effort)')
+  await expect(modal).toContainText('anyone technical who runs this app can still intercept')
+})
+
+// ── Registry (P4): publish / explore / install, worker stubbed over HTTP ────
+
+const REG_ID = '323e4567-e89b-42d3-a456-426614174002'
+
+/** Mock the registry worker (any host — the client defaults to the production
+ *  URL, and intercepting at the URL-pattern level keeps the spec hermetic). */
+async function stubRegistry(page: Page) {
+  const published = new Map<string, Record<string, unknown>>()
+  const calls: { method: string; url: string; body: unknown }[] = []
+
+  await page.route(/.*\/v1\/apps.*/, async (route) => {
+    const req = route.request()
+    const url = new URL(req.url())
+    let body: unknown = null
+    try {
+      body = req.postDataJSON()
+    } catch {
+      /* GETs */
+    }
+    calls.push({ method: req.method(), url: url.pathname + url.search, body })
+
+    if (req.method() === 'POST' && url.pathname === '/v1/apps') {
+      const b = body as { app: { id: string; name: string }; creator_name: string }
+      published.set(b.app.id, b as unknown as Record<string, unknown>)
+      return route.fulfill({
+        json: { ok: true, id: b.app.id, slug: `tester/${b.app.name.toLowerCase().replace(/\s+/g, '-')}`, version: 1 }
+      })
+    }
+    if (req.method() === 'GET' && url.pathname === '/v1/apps') {
+      return route.fulfill({
+        json: {
+          apps: [
+            {
+              id: REG_ID,
+              slug: 'maker/cloud-app',
+              name: 'Cloud App',
+              description: 'from the registry',
+              creator: 'maker',
+              version: 3,
+              hide_workflow: false,
+              nsfw: false,
+              stars: 12,
+              runs: 340,
+              score: 0,
+              created_at: 1,
+              updated_at: 2
+            }
+          ],
+          next_cursor: null
+        }
+      })
+    }
+    if (req.method() === 'GET' && url.pathname.endsWith('/bundle')) {
+      return route.fulfill({
+        json: {
+          format: 1,
+          manifest: {
+            id: REG_ID,
+            name: 'Cloud App',
+            description: 'from the registry',
+            hideWorkflow: false,
+            appMode: {
+              inputs: [{ nodeId: 6, widget: 'text', label: 'Prompt', kind: 'text', default: 'hello' }],
+              outputs: [],
+              importedFromFrontend: false
+            },
+            deps: { models: [], customNodes: [] }
+          },
+          prompt: FIXTURE_PROMPT,
+          workflow: FIXTURE_WORKFLOW
+        }
+      })
+    }
+    if (req.method() === 'GET' && url.pathname.endsWith('/thumbnail')) {
+      return route.fulfill({ status: 404, json: { error: 'no thumbnail' } })
+    }
+    if (req.method() === 'GET') {
+      return route.fulfill({
+        json: { app: { id: REG_ID, slug: 'maker/cloud-app', name: 'Cloud App', stars: 12, runs: 340 } }
+      })
+    }
+    return route.fulfill({ json: { ok: true } })
+  })
+
+  return { published, calls }
+}
+
+test('publish: bundle goes to the registry, local manifest records the slug', async ({
+  panel,
+  page
+}) => {
+  const { store } = await stubAppsBackend(page)
+  const { published, calls } = await stubRegistry(page)
+  store.set(APP_ID, {
+    manifest: {
+      id: APP_ID,
+      name: 'Shareable',
+      description: 'publish me',
+      version: 1,
+      hideWorkflow: false,
+      appMode: { inputs: [{ nodeId: 6, widget: 'text', label: 'Prompt', kind: 'text' }], outputs: [], importedFromFrontend: false },
+      deps: { models: [], customNodes: [] },
+      published: null
+    },
+    workflow: FIXTURE_WORKFLOW,
+    prompt: FIXTURE_PROMPT
+  })
+  page.on('dialog', (d) => d.accept('tester'))
+
+  await panel.goto()
+  await panel.openSidebar()
+  await panel.root.getByRole('button', { name: 'Apps', exact: true }).click()
+  const modal = page.locator('.cmcp-apps-modal')
+  await modal.locator('.cmcp-app-card', { hasText: 'Shareable' }).click()
+  await modal.getByRole('button', { name: /Publish/ }).click()
+
+  // The registry got the app; the local manifest records published{slug}.
+  await expect(modal.getByRole('button', { name: /Update published/ })).toBeVisible()
+  const post = calls.find((c) => c.method === 'POST' && c.url === '/v1/apps')
+  expect(post).toBeTruthy()
+  const payload = post!.body as { app: { id: string; name: string; hide_workflow: boolean }; workflow?: unknown; creator_key: string }
+  expect(payload.app.id).toBe(APP_ID)
+  expect(payload.app.hide_workflow).toBe(false)
+  expect(payload.workflow).toBeTruthy()
+  expect(payload.creator_key).toMatch(/^[0-9a-f-]{36,64}$/)
+  expect(published.has(APP_ID)).toBe(true)
+  expect(store.get(APP_ID)!.manifest.published).toMatchObject({ slug: 'tester/shareable' })
+})
+
+test('explore: registry cards render, install lands the app in My Apps', async ({
+  panel,
+  page
+}) => {
+  const { store } = await stubAppsBackend(page)
+  await stubRegistry(page)
+
+  await panel.goto()
+  await panel.openSidebar()
+  await panel.root.getByRole('button', { name: 'Apps', exact: true }).click()
+  const modal = page.locator('.cmcp-apps-modal')
+
+  await modal.getByRole('button', { name: 'Explore', exact: true }).click()
+  const card = modal.locator('.cmcp-app-card', { hasText: 'Cloud App' })
+  await expect(card).toBeVisible()
+  await expect(card).toContainText('★ 12')
+  await expect(card).toContainText('340 runs')
+  await card.click()
+
+  await expect(modal).toContainText('by maker')
+  await modal.getByRole('button', { name: /Install/ }).click()
+  // Installed → LOCAL detail view (the registry manifest became a local app).
+  // The registry detail also shows an h3 with the app name, so wait on the
+  // local-only Run button instead of racing the install's create POST.
+  await expect(modal.getByRole('button', { name: '▶ Run' })).toBeVisible()
+  await expect(modal.locator('h3')).toHaveText('Cloud App')
+  expect(store.has(REG_ID)).toBe(true)
+  const installed = store.get(REG_ID)!
+  expect(installed.manifest.source).toMatchObject({ type: 'registry', registryId: REG_ID })
+  expect(installed.manifest.published).toMatchObject({ slug: 'maker/cloud-app' })
+})

--- a/browser_tests/unit/apps.test.mjs
+++ b/browser_tests/unit/apps.test.mjs
@@ -1,0 +1,141 @@
+// Unit tests for the Micro-Apps service (web/js/cmcp-apps.js): APP-mode
+// config import (defensive key probing), heuristic input/output selection,
+// widget classification, dependency scanning, manifest assembly, and the
+// AppsClient HTTP surface (mocked fetch).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { AppBuilder, AppsClient } from "../../web/js/cmcp-apps.js";
+
+// ── APP-mode config import ──────────────────────────────────────────────────
+
+test("findAppModeConfig: extra.appMode wins, normalized to our shape", () => {
+  const wf = {
+    nodes: [],
+    extra: {
+      appMode: {
+        inputs: [{ nodeId: "6", name: "text", title: "Prompt", type: "text" }],
+        outputs: [{ id: 9 }],
+      },
+    },
+  };
+  const cfg = AppBuilder.findAppModeConfig(wf);
+  assert.deepEqual(cfg, {
+    inputs: [{ nodeId: 6, widget: "text", label: "Prompt", kind: "text" }],
+    outputs: [{ nodeId: 9, kind: "images" }],
+    importedFromFrontend: true,
+  });
+});
+
+test("findAppModeConfig: falls back through candidate keys", () => {
+  assert.ok(AppBuilder.findAppModeConfig({ extra: { app_mode: { inputs: [{ node_id: 3, key: "seed" }] } } }));
+  assert.ok(AppBuilder.findAppModeConfig({ appMode: { outputs: [{ nodeId: 1 }] } }));
+  assert.equal(AppBuilder.findAppModeConfig({ nodes: [], extra: {} }), null);
+  assert.equal(AppBuilder.findAppModeConfig(null), null);
+  assert.equal(AppBuilder.findAppModeConfig({ extra: { appMode: { notInputs: [] } } }), null);
+});
+
+test("findAppModeConfig: skips malformed entries", () => {
+  const wf = {
+    extra: {
+      appMode: {
+        inputs: [{ nodeId: "x", widget: "text" }, { widget: "text" }, null, { nodeId: 6, widget: "text" }],
+      },
+    },
+  };
+  const cfg = AppBuilder.findAppModeConfig(wf);
+  assert.equal(cfg.inputs.length, 1);
+  assert.equal(cfg.inputs[0].nodeId, 6);
+});
+
+// ── heuristic selection ─────────────────────────────────────────────────────
+
+test("heuristicAppMode: hint-type nodes become inputs, save/preview become outputs", () => {
+  const nodes = [
+    { id: 4, type: "CheckpointLoaderSimple", widgets_values: ["flux.safetensors"] },
+    { id: 6, type: "CLIPTextEncode", widgets_values: ["a cat"] },
+    { id: 3, type: "KSampler", widgets_values: [1234, "fixed", 20, 8, "euler", "normal", 1] },
+    { id: 8, type: "VAEDecode", widgets_values: [] },
+    { id: 9, type: "SaveImage", widgets_values: ["ComfyUI"] },
+    { id: 10, type: "PreviewImage" },
+  ];
+  const cfg = AppBuilder.heuristicAppMode(nodes);
+  assert.ok(cfg.inputs.some((i) => i.nodeId === 6 && i.kind === "text"));
+  assert.ok(cfg.inputs.some((i) => i.nodeId === 4 && i.kind === "model"));
+  assert.ok(cfg.inputs.some((i) => i.nodeId === 3 && i.kind === "number"));
+  assert.deepEqual(
+    cfg.outputs.map((o) => o.nodeId).sort((a, b) => a - b),
+    [9, 10],
+  );
+  // VAEDecode is neither a hint type nor an output node.
+  assert.ok(!cfg.inputs.some((i) => i.nodeId === 8));
+  assert.equal(cfg.importedFromFrontend, false);
+});
+
+test("heuristicAppMode: object-valued widget entries (link markers) are skipped", () => {
+  const nodes = [{ id: 6, type: "CLIPTextEncode", widgets_values: ["ok", { link: 3 }, ["a", "b"]] }];
+  const cfg = AppBuilder.heuristicAppMode(nodes);
+  assert.equal(cfg.inputs.length, 2); // "ok" (text) + ["a","b"] (combo); link marker dropped
+  assert.ok(cfg.inputs.every((i) => i.positional));
+});
+
+// ── widget classification ───────────────────────────────────────────────────
+
+test("classifyWidget", () => {
+  assert.equal(AppBuilder.classifyWidget("LoadImage", "image", "x.png"), "image");
+  assert.equal(AppBuilder.classifyWidget("CheckpointLoaderSimple", "ckpt_name", "m.safetensors"), "model");
+  assert.equal(AppBuilder.classifyWidget("KSampler", "steps", 20), "number");
+  assert.equal(AppBuilder.classifyWidget("Foo", "enabled", true), "toggle");
+  assert.equal(AppBuilder.classifyWidget("Foo", "sampler", ["euler", "dpm"]), "combo");
+  assert.equal(AppBuilder.classifyWidget("CLIPTextEncode", "text", "hello"), "text");
+});
+
+// ── dependency scan ─────────────────────────────────────────────────────────
+
+test("depsFromPrompt: loaders give models, unknown class_types give custom nodes", () => {
+  const prompt = {
+    4: { class_type: "CheckpointLoaderSimple", inputs: { ckpt_name: "flux.safetensors" } },
+    6: { class_type: "CLIPTextEncode", inputs: { text: "a cat" } },
+    11: { class_type: "SomeCustomThing", inputs: { model: "widget.safetensors" } },
+  };
+  const deps = AppBuilder.depsFromPrompt(
+    prompt,
+    new Set(["CLIPTextEncode", "SomeCustomThing", "CheckpointLoaderSimple"]),
+  );
+  assert.deepEqual(deps.models, [{ name: "flux.safetensors", nodeType: "CheckpointLoaderSimple", widget: "ckpt_name" }]);
+  assert.deepEqual(deps.customNodes, []); // both known
+  const deps2 = AppBuilder.depsFromPrompt(prompt, new Set(["CLIPTextEncode"]));
+  assert.deepEqual(deps2.customNodes.sort(), ["CheckpointLoaderSimple", "SomeCustomThing"]);
+});
+
+// ── manifest assembly ───────────────────────────────────────────────────────
+
+test("buildManifest: shape + required fields", () => {
+  const m = AppBuilder.buildManifest({ id: "abc", name: "  My App  " });
+  assert.equal(m.name, "My App");
+  assert.equal(m.version, 1);
+  assert.equal(m.hideWorkflow, false);
+  assert.deepEqual(m.published, null);
+  assert.throws(() => AppBuilder.buildManifest({ id: "abc", name: " " }), /name required/);
+  assert.throws(() => AppBuilder.buildManifest({ name: "x" }), /id required/);
+});
+
+// ── AppsClient HTTP surface ─────────────────────────────────────────────────
+
+test("AppsClient: routes and error propagation", async () => {
+  const calls = [];
+  const ok = (data) => ({ ok: true, json: async () => data });
+  globalThis.fetch = async (url, opts = {}) => {
+    calls.push([url, opts.method || "GET", opts.body ? JSON.parse(opts.body) : null]);
+    if (url.endsWith("/apps")) return ok({ apps: [{ id: "a" }] });
+    if (url.endsWith("/run")) return ok({ ok: true, prompt_id: "p1" });
+    if (url.includes("/bad")) return { ok: false, status: 400, json: async () => ({ error: "nope" }) };
+    return ok({ id: "a" });
+  };
+  const c = new AppsClient();
+  assert.deepEqual(await c.list(), [{ id: "a" }]);
+  await c.run("a", { "6.text": "hi" });
+  await assert.rejects(() => c.get("bad"), /nope/);
+  assert.deepEqual(calls[0], ["/comfyui_mcp_panel/apps", "GET", null]);
+  assert.deepEqual(calls[1], ["/comfyui_mcp_panel/apps/a/run", "POST", { values: { "6.text": "hi" } }]);
+  assert.equal(c.thumbnailUrl("a"), "/comfyui_mcp_panel/apps/a/thumbnail");
+});

--- a/browser_tests/unit/test_apps_routes.py
+++ b/browser_tests/unit/test_apps_routes.py
@@ -1,0 +1,113 @@
+"""Unit tests for the pure helpers in py/apps_routes.py (manifest sanitize,
+prompt validate, run-patch, bundle-path containment).
+
+Dev-only. Run from the repo root:
+
+    python -m unittest browser_tests.unit.test_apps_routes
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "py"))
+
+import apps_routes as ar  # noqa: E402
+
+UUID = "123e4567-e89b-42d3-a456-426614174000"
+
+
+class BundleDir(unittest.TestCase):
+    def test_uuid_contained(self):
+        root = os.path.realpath("/tmp/apps-root")
+        path = ar._bundle_dir(root, UUID)
+        self.assertTrue(path.startswith(root + os.sep), path)
+
+    def test_non_uuid_rejected(self):
+        root = os.path.realpath("/tmp/apps-root")
+        for bad in ("", "..", "../etc", "not-a-uuid", UUID + "/..", None, UUID.upper() + "x"):
+            with self.assertRaises(ValueError, msg=repr(bad)):
+                ar._bundle_dir(root, bad)
+
+
+class SanitizeManifest(unittest.TestCase):
+    def test_minimal(self):
+        m = ar._sanitize_manifest({"id": UUID, "name": "My App"})
+        self.assertEqual(m["id"], UUID)
+        self.assertEqual(m["name"], "My App")
+        self.assertEqual(m["hideWorkflow"], False)
+        self.assertEqual(m["appMode"], {"inputs": [], "outputs": [], "importedFromFrontend": False})
+
+    def test_requires_id_and_name(self):
+        with self.assertRaises(ValueError):
+            ar._sanitize_manifest({"name": "x"})
+        with self.assertRaises(ValueError):
+            ar._sanitize_manifest({"id": UUID})
+        with self.assertRaises(ValueError):
+            ar._sanitize_manifest({"id": "nope", "name": "x"})
+
+    def test_inputs_outputs_shaped_and_dropped_garbage(self):
+        m = ar._sanitize_manifest(
+            {
+                "id": UUID,
+                "name": "x",
+                "appMode": {
+                    "inputs": [
+                        {"nodeId": 6, "widget": "text", "label": "Prompt", "kind": "text"},
+                        {"nodeId": "no", "widget": "text"},
+                        {"nodeId": 7},
+                        "junk",
+                    ],
+                    "outputs": [{"nodeId": 9}, {"nodeId": "bad"}],
+                },
+                "unexpectedKey": {"should": "be dropped"},
+            }
+        )
+        self.assertNotIn("unexpectedKey", m)
+        self.assertEqual(len(m["appMode"]["inputs"]), 1)
+        self.assertEqual(m["appMode"]["inputs"][0]["nodeId"], 6)
+        self.assertEqual(m["appMode"]["outputs"], [{"nodeId": 9, "kind": "images"}])
+
+    def test_truncation(self):
+        m = ar._sanitize_manifest({"id": UUID, "name": "n" * 500, "description": "d" * 9000})
+        self.assertEqual(len(m["name"]), 120)
+        self.assertEqual(len(m["description"]), 4000)
+
+
+class ValidatePrompt(unittest.TestCase):
+    def test_api_format_ok(self):
+        p = {"6": {"class_type": "CLIPTextEncode", "inputs": {"text": "a"}}}
+        self.assertEqual(ar._validate_prompt_json(p), p)
+
+    def test_rejects_garbage(self):
+        for bad in ({}, [], {"x": {"class_type": "A", "inputs": {}}}, {"6": {"inputs": {}}}, {"6": {"class_type": "A"}}):
+            with self.assertRaises(ValueError, msg=repr(bad)):
+                ar._validate_prompt_json(bad)
+
+
+class ApplyPatch(unittest.TestCase):
+    PROMPT = {
+        "3": {"class_type": "KSampler", "inputs": {"seed": 1, "steps": 20}},
+        "6": {"class_type": "CLIPTextEncode", "inputs": {"text": "a cat", "clip": ["4", 1]}},
+    }
+
+    def test_patches_widget_values(self):
+        out = ar._apply_patch(self.PROMPT, {"6.text": "a dog", "3.seed": 42})
+        self.assertEqual(out["6"]["inputs"]["text"], "a dog")
+        self.assertEqual(out["3"]["inputs"]["seed"], 42)
+        # original untouched (copy, not in-place)
+        self.assertEqual(self.PROMPT["6"]["inputs"]["text"], "a cat")
+
+    def test_dotted_widget_names_split_on_first_dot_only(self):
+        prompt = {"5": {"class_type": "LoraLoader", "inputs": {"lora_1.name": "x.safetensors"}}}
+        out = ar._apply_patch(prompt, {"5.lora_1.name": "y.safetensors"})
+        self.assertEqual(out["5"]["inputs"]["lora_1.name"], "y.safetensors")
+
+    def test_strict_unknown_targets(self):
+        for key in ("99.text", "6.nope", "garbage", ".text", "6."):
+            with self.assertRaises(ValueError, msg=key):
+                ar._apply_patch(self.PROMPT, {key: "v"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/browser_tests/unit/test_apps_routes.py
+++ b/browser_tests/unit/test_apps_routes.py
@@ -73,6 +73,16 @@ class SanitizeManifest(unittest.TestCase):
         self.assertEqual(len(m["name"]), 120)
         self.assertEqual(len(m["description"]), 4000)
 
+    def test_partial_update_omits_unsent_fields(self):
+        # for_update with no description key must NOT emit one — otherwise
+        # manifest.update(patch) wipes the saved description on publish/hide.
+        patch = ar._sanitize_manifest({"published": {"slug": "a/b"}}, for_update=True)
+        self.assertNotIn("description", patch)
+        self.assertNotIn("name", patch)
+        self.assertNotIn("id", patch)
+        patch = ar._sanitize_manifest({"description": "new"}, for_update=True)
+        self.assertEqual(patch["description"], "new")
+
 
 class ValidatePrompt(unittest.TestCase):
     def test_api_format_ok(self):

--- a/docs/design/apps-monetization.md
+++ b/docs/design/apps-monetization.md
@@ -1,0 +1,65 @@
+# Apps monetization — design notes (P5, NOT implemented)
+
+Status: **design-only**. Nothing in this document is built. The registry schema
+already reserves the hooks (`apps.pricing_json`, `apps.hosted_only` — see
+`registry/migrations/0001_init.sql`) so the build-out is purely additive.
+
+## The idea
+
+Creators can mark a published app **hosted-only**: the workflow/prompt is never
+distributed — not even the API-format snapshot. Runs execute on OUR fleet
+(RunPod and/or Vast), spun up on demand, and the runner pays per generation:
+
+```
+price_per_gen = (endpoint_cost_per_sec + our_fee_per_sec) × gen_seconds + creator_fee_per_gen
+```
+
+The runner funds a token balance; each run debits it. The creator accrues
+creator_fee; we accrue the platform fee minus the pod cost.
+
+## Why this is the ONLY real workflow protection
+
+Local "hidden workflow" is obfuscation: anyone who runs the app locally can
+sniff `/history`, and the auto-installed models/custom nodes reveal the graph's
+deps. Hosted-only changes the trust boundary — the prompt never leaves our
+infrastructure, so intercepting it means compromising US, not reading your own
+localhost. This is the honest answer to "hide my workflow" and should be
+presented that way in product copy (the local hide toggle already links here).
+
+## Hard problems (each is a project, none is a line item)
+
+- **Payments**: token balance means a payment processor (Stripe vs crypto),
+  refunds, chargebacks, and regional tax (VAT/sales). Creator payouts add
+  KYC/1099-style obligations — we become a marketplace, not a tool.
+- **Fraud**: run_count and gen_seconds feed money now. Client-reported
+  `ran` is fine for trending, worthless for billing — metering must come from
+  the fleet (pod-side execution stats), signed and reconciled against RunPod's
+  own billing API. Fake-creator self-runs to farm creator fees need velocity
+  caps and payout thresholds.
+- **Fleet economics**: cold-start per run (pod boot + model load) can exceed
+  the run itself. Warm pools cost money while idle. Need per-model warm-pool
+  policy, queueing, and honest ETA surfacing in the clients.
+- **Content liability**: hosted NSFW generation on our fleet makes us the
+  publisher in some jurisdictions. Needs a real content policy, automated +
+  human review paths, and takedown SLAs before any hosted NSFW is allowed.
+- **Identity**: the current creator key (sha256 of a local secret) is fine for
+  publishing, not for money. Payouts need verified identity (OAuth + KYC).
+  Plan the migration: creator_id stays, accounts get linked to it later.
+
+## What exists TODAY that this builds on
+
+- Registry: `hosted_only` + `pricing_json` columns (`registry/migrations/0001_init.sql`).
+- RunPod pod lifecycle + honest host indicator (panel RunPod modal,
+  `runpod_*` tools) — the on-demand pod control plane is proven.
+- App run engine with server-side patch+queue (`py/apps_routes.py`) — the same
+  route shape works behind a hosted gateway: `POST /apps/{id}/run` but the
+  prompt never returns to the client, only the outputs do.
+- Mobile + panel run paths both poll a status endpoint — a hosted run can
+  present the identical status contract.
+
+## Suggested build order (when picked up)
+
+1. Hosted-run gateway (our worker in front of a warm pod pool) for OUR OWN
+   apps first — no money, just the hosted_only execution path end-to-end.
+2. Token balance + Stripe top-ups, runner-side only (no creator payouts).
+3. Creator fees + payouts (KYC), fraud limits, content policy enforcement.

--- a/py/apps_routes.py
+++ b/py/apps_routes.py
@@ -117,7 +117,10 @@ def _sanitize_manifest(raw, *, for_update: bool = False) -> dict:
         if not name:
             raise ValueError("manifest.name is required")
         out["name"] = name[:_MAX_NAME]
-    out["description"] = str(raw.get("description") or "")[:_MAX_DESC]
+    if not for_update or "description" in raw:
+        # Partial updates (publish/hide) omit the description — including it
+        # unconditionally would WIPE it via manifest.update(patch).
+        out["description"] = str(raw.get("description") or "")[:_MAX_DESC]
 
     app_mode = raw.get("appMode")
     if app_mode is None and not for_update:
@@ -222,6 +225,9 @@ def _self_base_url() -> str:
     addr = getattr(inst, "address", "127.0.0.1") or "127.0.0.1"
     if addr in ("0.0.0.0", "::"):
         addr = "127.0.0.1"
+    if ":" in addr and not addr.startswith("["):
+        # IPv6 literal (e.g. --listen ::1) — URLs need [::1] bracket form.
+        addr = "[{}]".format(addr)
     port = getattr(inst, "port", 8188)
     return "http://{}:{}".format(addr, port)
 
@@ -282,6 +288,19 @@ def register(routes, web):
                     status=400,
                 )
         thumb_b64 = body.get("thumbnail_b64")
+        # Decode + validate the thumbnail BEFORE writing anything — validating
+        # inside _write leaves a ghost bundle (manifest+prompt on disk, 400 to
+        # the client) behind a failed create.
+        thumb_bytes = None
+        if isinstance(thumb_b64, str) and thumb_b64:
+            import base64
+
+            try:
+                thumb_bytes = base64.b64decode(thumb_b64, validate=True)
+            except Exception:
+                return web.json_response({"error": "thumbnail_b64 is not valid base64"}, status=400)
+            if len(thumb_bytes) > _MAX_THUMB_BYTES:
+                return web.json_response({"error": "thumbnail too large"}, status=400)
 
         def _write():
             root = _apps_root()
@@ -308,13 +327,8 @@ def register(routes, web):
                     os.path.join(bdir, "workflow.json"),
                     json.dumps(workflow).encode("utf-8"),
                 )
-            if isinstance(thumb_b64, str) and thumb_b64:
-                import base64
-
-                raw = base64.b64decode(thumb_b64, validate=True)
-                if len(raw) > _MAX_THUMB_BYTES:
-                    raise ValueError("thumbnail too large")
-                _atomic_write(os.path.join(bdir, "thumbnail.png"), raw)
+            if thumb_bytes is not None:
+                _atomic_write(os.path.join(bdir, "thumbnail.png"), thumb_bytes)
 
         try:
             await asyncio.to_thread(_write)

--- a/py/apps_routes.py
+++ b/py/apps_routes.py
@@ -1,0 +1,555 @@
+"""Micro-Apps ("Apps") — local app bundle storage + headless run engine.
+
+An "app" is a workflow packaged for one-click runs without a canvas: a
+directory under ComfyUI's user dir (NOT the workflows dir, so hidden apps
+never surface in the workflow browser):
+
+    <user>/comfyui-mcp-panel/apps/<app-id>/
+      manifest.json   # name/description/appMode{inputs,outputs}/deps/flags
+      workflow.json   # litegraph UI format — ABSENT when hideWorkflow=true
+      prompt.json     # API-format snapshot (patched per run)
+      thumbnail.png   # optional
+
+Routes (same register() pattern as py/training_routes.py):
+
+- GET    /comfyui_mcp_panel/apps                      list manifests
+- POST   /comfyui_mcp_panel/apps                      create bundle
+- GET    /comfyui_mcp_panel/apps/{id}                 manifest + bundle facts
+- PUT    /comfyui_mcp_panel/apps/{id}                 update manifest / files
+- DELETE /comfyui_mcp_panel/apps/{id}                 remove bundle
+- GET    /comfyui_mcp_panel/apps/{id}/thumbnail       serve thumbnail.png
+- POST   /comfyui_mcp_panel/apps/{id}/run             patch + queue, returns prompt_id
+- GET    /comfyui_mcp_panel/apps/{id}/runs/{prompt_id}  run status + outputs
+
+The run/status routes are server-side (not browser fetches) so the exact same
+surface backs the mobile app's whitelisted `apps_*` bridge tools — ONE storage
+and execution implementation for panel and mobile.
+
+hideWorkflow is BEST-EFFORT obfuscation, never security: the prompt is still
+visible to anyone running the app via ComfyUI's /history, and auto-installed
+models/custom nodes reveal the graph's dependencies. UI copy must say so.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import re
+import uuid as uuid_module
+from os import environ  # bare-name on purpose — see root __init__.py (Registry scanner)
+
+logger = logging.getLogger(__name__)
+
+# Caps: prompt.json can legitimately hold embedded images (base64) so it's
+# roomier than a pure-graph file; thumbnails are served back to browsers.
+_MAX_JSON_BYTES = 16 * 1024 * 1024
+_MAX_THUMB_BYTES = 5 * 1024 * 1024
+_MAX_NAME = 120
+_MAX_DESC = 4000
+
+_UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+# Run-patch keys look like "6.text" (nodeId.widget); nodeIds in API prompts are
+# decimal strings, widget names are identifier-ish (LoRA stacks use dots too —
+# split on the FIRST dot only, so "lora_1.model" stays intact as the widget).
+_PATCH_KEY_RE = re.compile(r"^(\d+)\.(.+)$", re.S)
+
+
+def _apps_root() -> str:
+    """Root holding every app bundle. Env override for tests; default under
+    ComfyUI's own user dir so it survives portable installs and stays out of
+    the workflows dir entirely."""
+    override = environ.get("COMFYUI_MCP_APPS_DIR", "").strip()
+    if override:
+        return os.path.realpath(override)
+    import folder_paths  # ComfyUI's own path registry (host-provided)
+
+    return os.path.realpath(os.path.join(folder_paths.get_user_directory(), "comfyui-mcp-panel", "apps"))
+
+
+def _bundle_dir(root: str, app_id: str) -> str:
+    """Validated, contained bundle path for ``app_id`` — 400-class callers
+    reject anything that isn't a plain uuid, so this can never traverse."""
+    if not _UUID_RE.match(app_id or ""):
+        raise ValueError("app id must be a uuid")
+    path = os.path.realpath(os.path.join(root, app_id.lower()))
+    if path != root and not path.startswith(root + os.sep):
+        raise ValueError("app id escapes the apps root")
+    return path
+
+
+def _atomic_write(path: str, data: bytes) -> None:
+    """tmp-then-rename so a crash mid-write can't leave a torn bundle file."""
+    tmp = path + ".tmp-" + uuid_module.uuid4().hex[:8]
+    with open(tmp, "wb") as fh:
+        fh.write(data)
+    os.replace(tmp, path)
+
+
+def _read_manifest(bdir: str) -> dict:
+    with open(os.path.join(bdir, "manifest.json"), "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _bundle_facts(bdir: str) -> dict:
+    return {
+        "has_workflow": os.path.isfile(os.path.join(bdir, "workflow.json")),
+        "has_prompt": os.path.isfile(os.path.join(bdir, "prompt.json")),
+        "has_thumbnail": os.path.isfile(os.path.join(bdir, "thumbnail.png")),
+    }
+
+
+def _sanitize_manifest(raw, *, for_update: bool = False) -> dict:
+    """Whitelist-shape the client-supplied manifest. Unknown keys are dropped
+    (forward-compat: clients may send P5 pricing fields; we keep pricing_json /
+    hosted_only pass-through so the schema is forward-compatible)."""
+    if not isinstance(raw, dict):
+        raise ValueError("manifest must be an object")
+    out = {}
+    if not for_update or "id" in raw:
+        app_id = str(raw.get("id") or "")
+        if not _UUID_RE.match(app_id):
+            raise ValueError("manifest.id must be a uuid")
+        out["id"] = app_id.lower()
+    if not for_update or "name" in raw:
+        name = str(raw.get("name") or "").strip()
+        if not name:
+            raise ValueError("manifest.name is required")
+        out["name"] = name[:_MAX_NAME]
+    out["description"] = str(raw.get("description") or "")[:_MAX_DESC]
+
+    app_mode = raw.get("appMode")
+    if app_mode is None and not for_update:
+        app_mode = {}
+    if app_mode is not None:
+        if not isinstance(app_mode, dict):
+            raise ValueError("manifest.appMode must be an object")
+        inputs = []
+        for item in app_mode.get("inputs") or []:
+            if not isinstance(item, dict):
+                continue
+            try:
+                node_id = int(item.get("nodeId"))
+            except (TypeError, ValueError):
+                continue
+            widget = str(item.get("widget") or "").strip()
+            if not widget:
+                continue
+            entry = {
+                "nodeId": node_id,
+                "widget": widget,
+                "label": str(item.get("label") or widget)[:_MAX_NAME],
+                "kind": str(item.get("kind") or "text"),
+            }
+            # Form-rendering extras: combo choices + the value at conversion
+            # time (becomes the form's default). Scalars/lists only — anything
+            # else would bloat or complicate the manifest.
+            if isinstance(item.get("choices"), list):
+                entry["choices"] = [str(c) for c in item["choices"]][:200]
+            if "default" in item and isinstance(item["default"], (str, int, float, bool)):
+                entry["default"] = item["default"]
+            inputs.append(entry)
+        outputs = []
+        for item in app_mode.get("outputs") or []:
+            if not isinstance(item, dict):
+                continue
+            try:
+                node_id = int(item.get("nodeId"))
+            except (TypeError, ValueError):
+                continue
+            outputs.append({"nodeId": node_id, "kind": str(item.get("kind") or "images")})
+        out["appMode"] = {
+            "inputs": inputs,
+            "outputs": outputs,
+            "importedFromFrontend": bool(app_mode.get("importedFromFrontend")),
+        }
+
+    for key, default in (("hideWorkflow", False),):
+        if not for_update or key in raw:
+            out[key] = bool(raw.get(key, default))
+    for key in ("source", "deps", "published", "pricing_json", "hosted_only"):
+        if key in raw:
+            out[key] = raw[key]
+        elif not for_update:
+            out[key] = None if key in ("published", "pricing_json") else (
+                {} if key in ("source", "deps") else False
+            )
+    return out
+
+
+def _validate_prompt_json(raw) -> dict:
+    if not isinstance(raw, dict) or not raw:
+        raise ValueError("prompt must be a non-empty object (API format)")
+    for node_id, node in raw.items():
+        if not str(node_id).isdigit():
+            raise ValueError("prompt keys must be numeric node ids")
+        if not isinstance(node, dict) or not isinstance(node.get("inputs"), dict):
+            raise ValueError("prompt nodes must be {class_type, inputs} objects")
+        if not node.get("class_type"):
+            raise ValueError("prompt node missing class_type")
+    return raw
+
+
+def _apply_patch(prompt: dict, values: dict) -> dict:
+    """Return a copy of ``prompt`` with input widget values replaced. Strict:
+    every patch key must address an existing node AND input — a miss means the
+    manifest drifted from the snapshot and failing loudly beats silently
+    running with stale values."""
+    patched = json.loads(json.dumps(prompt))
+    for key, value in values.items():
+        m = _PATCH_KEY_RE.match(str(key))
+        if not m:
+            raise ValueError("bad patch key (want '<nodeId>.<widget>'): {!r}".format(key))
+        node_id, widget = m.group(1), m.group(2)
+        node = patched.get(node_id)
+        if node is None:
+            raise ValueError("patch targets unknown node {}".format(node_id))
+        if widget not in node["inputs"]:
+            raise ValueError("patch targets unknown input {!r} on node {}".format(widget, node_id))
+        node["inputs"][widget] = value
+    return patched
+
+
+def _self_base_url() -> str:
+    """Loopback base URL for self-calls (/prompt, /history). ComfyUI's
+    PromptServer knows its own address/port; prefer 127.0.0.1 for wildcard
+    binds. No TLS handling — a TLS-fronted ComfyUI still serves plain HTTP on
+    its own socket."""
+    from server import PromptServer  # type: ignore
+
+    inst = PromptServer.instance
+    addr = getattr(inst, "address", "127.0.0.1") or "127.0.0.1"
+    if addr in ("0.0.0.0", "::"):
+        addr = "127.0.0.1"
+    port = getattr(inst, "port", 8188)
+    return "http://{}:{}".format(addr, port)
+
+
+async def _self_post_json(session, path: str, payload: dict):
+    async with session.post(_self_base_url() + path, json=payload) as resp:
+        body = await resp.json(content_type=None)
+        return resp.status, body
+
+
+async def _self_get_json(session, path: str):
+    async with session.get(_self_base_url() + path) as resp:
+        body = await resp.json(content_type=None)
+        return resp.status, body
+
+
+def register(routes, web):
+    """Register the Apps routes on ``PromptServer.instance.routes``."""
+
+    @routes.get("/comfyui_mcp_panel/apps")
+    async def _list_apps(_request):
+        def _scan():
+            root = _apps_root()
+            if not os.path.isdir(root):
+                return []
+            out = []
+            for entry in sorted(os.listdir(root)):
+                bdir = os.path.join(root, entry)
+                if not os.path.isdir(bdir):
+                    continue
+                try:
+                    manifest = _read_manifest(bdir)
+                except Exception:
+                    continue  # torn/foreign dir — never break the listing
+                out.append({**manifest, **_bundle_facts(bdir)})
+            return out
+
+        apps = await asyncio.to_thread(_scan)
+        return web.json_response({"apps": apps})
+
+    @routes.post("/comfyui_mcp_panel/apps")
+    async def _create_app(request):
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response({"error": "invalid JSON"}, status=400)
+        try:
+            manifest = _sanitize_manifest(body.get("manifest"))
+            prompt = _validate_prompt_json(body.get("prompt"))
+        except ValueError as exc:
+            return web.json_response({"error": str(exc)}, status=400)
+        workflow = body.get("workflow")
+        hide = manifest.get("hideWorkflow", False)
+        if not hide:
+            if not isinstance(workflow, dict) or not isinstance(workflow.get("nodes"), list):
+                return web.json_response(
+                    {"error": "workflow (UI format with a nodes array) is required unless hideWorkflow"},
+                    status=400,
+                )
+        thumb_b64 = body.get("thumbnail_b64")
+
+        def _write():
+            root = _apps_root()
+            bdir = _bundle_dir(root, manifest["id"])
+            if os.path.exists(bdir):
+                raise FileExistsError(manifest["id"])
+            os.makedirs(bdir)
+            import datetime
+
+            now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+            manifest.setdefault("version", 1)
+            manifest["createdAt"] = now
+            manifest["updatedAt"] = now
+            _atomic_write(
+                os.path.join(bdir, "manifest.json"),
+                json.dumps(manifest, indent=1).encode("utf-8"),
+            )
+            _atomic_write(
+                os.path.join(bdir, "prompt.json"),
+                json.dumps(prompt).encode("utf-8"),
+            )
+            if not hide:
+                _atomic_write(
+                    os.path.join(bdir, "workflow.json"),
+                    json.dumps(workflow).encode("utf-8"),
+                )
+            if isinstance(thumb_b64, str) and thumb_b64:
+                import base64
+
+                raw = base64.b64decode(thumb_b64, validate=True)
+                if len(raw) > _MAX_THUMB_BYTES:
+                    raise ValueError("thumbnail too large")
+                _atomic_write(os.path.join(bdir, "thumbnail.png"), raw)
+
+        try:
+            await asyncio.to_thread(_write)
+        except FileExistsError:
+            return web.json_response({"error": "app id already exists"}, status=409)
+        except (ValueError, OSError) as exc:
+            return web.json_response({"error": str(exc)}, status=400)
+        return web.json_response({"ok": True, "id": manifest["id"]})
+
+    @routes.get("/comfyui_mcp_panel/apps/{id}")
+    async def _get_app(request):
+        try:
+            bdir = _bundle_dir(_apps_root(), request.match_info["id"])
+        except ValueError as exc:
+            return web.json_response({"error": str(exc)}, status=400)
+
+        def _read():
+            if not os.path.isdir(bdir):
+                return None
+            manifest = _read_manifest(bdir)
+            return {**manifest, **_bundle_facts(bdir)}
+
+        try:
+            data = await asyncio.to_thread(_read)
+        except Exception as exc:
+            return web.json_response({"error": "unreadable bundle: {}".format(exc)}, status=500)
+        if data is None:
+            return web.json_response({"error": "not found"}, status=404)
+        return web.json_response(data)
+
+    @routes.get("/comfyui_mcp_panel/apps/{id}/bundle")
+    async def _get_bundle(request):
+        """The full bundle for publish/import round-trips: manifest + prompt +
+        workflow (when not hidden) + thumbnail as base64."""
+        try:
+            bdir = _bundle_dir(_apps_root(), request.match_info["id"])
+        except ValueError as exc:
+            return web.json_response({"error": str(exc)}, status=400)
+
+        def _read_bundle():
+            if not os.path.isdir(bdir):
+                return None
+            out = {"manifest": _read_manifest(bdir)}
+            for name in ("prompt", "workflow"):
+                path = os.path.join(bdir, "{}.json".format(name))
+                if os.path.isfile(path):
+                    with open(path, "r", encoding="utf-8") as fh:
+                        out[name] = json.load(fh)
+            thumb = os.path.join(bdir, "thumbnail.png")
+            if os.path.isfile(thumb):
+                import base64
+
+                with open(thumb, "rb") as fh:
+                    out["thumbnail_b64"] = base64.b64encode(fh.read()).decode("ascii")
+            return out
+
+        try:
+            data = await asyncio.to_thread(_read_bundle)
+        except Exception as exc:
+            return web.json_response({"error": "unreadable bundle: {}".format(exc)}, status=500)
+        if data is None:
+            return web.json_response({"error": "not found"}, status=404)
+        return web.json_response(data)
+
+    @routes.put("/comfyui_mcp_panel/apps/{id}")
+    async def _update_app(request):
+        try:
+            bdir = _bundle_dir(_apps_root(), request.match_info["id"])
+        except ValueError as exc:
+            return web.json_response({"error": str(exc)}, status=400)
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response({"error": "invalid JSON"}, status=400)
+        try:
+            patch = _sanitize_manifest(body.get("manifest") or {}, for_update=True)
+        except ValueError as exc:
+            return web.json_response({"error": str(exc)}, status=400)
+
+        def _apply():
+            if not os.path.isdir(bdir):
+                return None
+            manifest = _read_manifest(bdir)
+            manifest.update(patch)
+            manifest["id"] = os.path.basename(bdir)  # id is immutable
+            import datetime
+
+            manifest["updatedAt"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+            wf_path = os.path.join(bdir, "workflow.json")
+            if manifest.get("hideWorkflow") and os.path.isfile(wf_path):
+                # Best-effort hide: drop the UI graph from disk entirely.
+                os.remove(wf_path)
+            if not manifest.get("hideWorkflow") and isinstance(body.get("workflow"), dict):
+                _atomic_write(wf_path, json.dumps(body["workflow"]).encode("utf-8"))
+            if isinstance(body.get("prompt"), dict):
+                _validate_prompt_json(body["prompt"])
+                _atomic_write(
+                    os.path.join(bdir, "prompt.json"),
+                    json.dumps(body["prompt"]).encode("utf-8"),
+                )
+            thumb_b64 = body.get("thumbnail_b64")
+            if isinstance(thumb_b64, str) and thumb_b64:
+                import base64
+
+                raw = base64.b64decode(thumb_b64, validate=True)
+                if len(raw) > _MAX_THUMB_BYTES:
+                    raise ValueError("thumbnail too large")
+                _atomic_write(os.path.join(bdir, "thumbnail.png"), raw)
+            _atomic_write(
+                os.path.join(bdir, "manifest.json"),
+                json.dumps(manifest, indent=1).encode("utf-8"),
+            )
+            return {**manifest, **_bundle_facts(bdir)}
+
+        try:
+            data = await asyncio.to_thread(_apply)
+        except (ValueError, OSError) as exc:
+            return web.json_response({"error": str(exc)}, status=400)
+        if data is None:
+            return web.json_response({"error": "not found"}, status=404)
+        return web.json_response(data)
+
+    @routes.delete("/comfyui_mcp_panel/apps/{id}")
+    async def _delete_app(request):
+        try:
+            bdir = _bundle_dir(_apps_root(), request.match_info["id"])
+        except ValueError as exc:
+            return web.json_response({"error": str(exc)}, status=400)
+
+        def _remove():
+            if not os.path.isdir(bdir):
+                return False
+            import shutil
+
+            shutil.rmtree(bdir)
+            return True
+
+        removed = await asyncio.to_thread(_remove)
+        if not removed:
+            return web.json_response({"error": "not found"}, status=404)
+        return web.json_response({"ok": True})
+
+    @routes.get("/comfyui_mcp_panel/apps/{id}/thumbnail")
+    async def _get_thumbnail(request):
+        try:
+            bdir = _bundle_dir(_apps_root(), request.match_info["id"])
+        except ValueError as exc:
+            return web.json_response({"error": str(exc)}, status=400)
+        path = os.path.join(bdir, "thumbnail.png")
+        if not os.path.isfile(path):
+            return web.json_response({"error": "not found"}, status=404)
+        return web.FileResponse(path)
+
+    @routes.post("/comfyui_mcp_panel/apps/{id}/run")
+    async def _run_app(request):
+        try:
+            bdir = _bundle_dir(_apps_root(), request.match_info["id"])
+        except ValueError as exc:
+            return web.json_response({"error": str(exc)}, status=400)
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response({"error": "invalid JSON"}, status=400)
+        values = body.get("values") or {}
+        if not isinstance(values, dict):
+            return web.json_response({"error": "values must be an object"}, status=400)
+
+        def _load_prompt():
+            path = os.path.join(bdir, "prompt.json")
+            if not os.path.isfile(path):
+                return None
+            with open(path, "r", encoding="utf-8") as fh:
+                return json.load(fh)
+
+        prompt = await asyncio.to_thread(_load_prompt)
+        if prompt is None:
+            return web.json_response({"error": "app has no prompt snapshot"}, status=404)
+        try:
+            patched = _apply_patch(prompt, values)
+        except ValueError as exc:
+            return web.json_response({"error": str(exc)}, status=400)
+
+        # Dry run: return the patched prompt without queueing. The RunPod path
+        # uses this — the patched prompt goes to the pod through the
+        # orchestrator's enqueue_workflow instead of the local /prompt.
+        if body.get("dry") is True:
+            return web.json_response({"ok": True, "prompt": patched})
+
+        import aiohttp
+
+        async with aiohttp.ClientSession() as session:
+            status, resp = await _self_post_json(session, "/prompt", {"prompt": patched})
+        if status != 200:
+            # Surface ComfyUI's own validation error verbatim (node_errors etc.)
+            return web.json_response(
+                {"error": "ComfyUI rejected the prompt", "detail": resp}, status=502
+            )
+        return web.json_response({"ok": True, "prompt_id": resp.get("prompt_id"), "number": resp.get("number")})
+
+    @routes.get("/comfyui_mcp_panel/apps/{id}/runs/{prompt_id}")
+    async def _run_status(request):
+        try:
+            _bundle_dir(_apps_root(), request.match_info["id"])
+        except ValueError as exc:
+            return web.json_response({"error": str(exc)}, status=400)
+        prompt_id = request.match_info["prompt_id"]
+        if not re.match(r"^[0-9a-zA-Z-]+$", prompt_id or ""):
+            return web.json_response({"error": "bad prompt id"}, status=400)
+
+        import aiohttp
+
+        async with aiohttp.ClientSession() as session:
+            _q_status, queue = await _self_get_json(session, "/queue")
+            h_status, history = await _self_get_json(session, "/history/{}".format(prompt_id))
+
+        running = any(
+            item[1] == prompt_id for item in (queue.get("queue_running") or []) if isinstance(item, list) and len(item) > 1
+        )
+        pending = any(
+            item[1] == prompt_id for item in (queue.get("queue_pending") or []) if isinstance(item, list) and len(item) > 1
+        )
+        entry = None
+        if h_status == 200 and isinstance(history, dict):
+            entry = history.get(prompt_id)
+        status_str = (
+            "done" if entry is not None else ("running" if running else ("pending" if pending else "unknown"))
+        )
+        outputs = {}
+        if entry is not None:
+            outputs = entry.get("outputs") or {}
+        return web.json_response(
+            {
+                "prompt_id": prompt_id,
+                "status": status_str,
+                "outputs": outputs,
+                "status_detail": (entry or {}).get("status") or {},
+            }
+        )

--- a/registry/migrations/0001_init.sql
+++ b/registry/migrations/0001_init.sql
@@ -1,0 +1,43 @@
+-- Apps registry schema (D1). P5 hooks (pricing_json, hosted_only) exist from
+-- day one so monetization is purely additive — no migration needed later.
+
+CREATE TABLE IF NOT EXISTS apps (
+  id            TEXT PRIMARY KEY,            -- uuid (client's local app id)
+  slug          TEXT NOT NULL UNIQUE,        -- creator/app-name
+  creator_id    TEXT NOT NULL,               -- sha256(creator_key)
+  creator_name  TEXT NOT NULL DEFAULT 'anonymous',
+  name          TEXT NOT NULL,
+  description   TEXT NOT NULL DEFAULT '',
+  version       INTEGER NOT NULL DEFAULT 1,
+  hide_workflow INTEGER NOT NULL DEFAULT 0,
+  nsfw          INTEGER NOT NULL DEFAULT 0,
+  hosted_only   INTEGER NOT NULL DEFAULT 0,  -- P5: run only on hosted fleet
+  pricing_json  TEXT,                        -- P5: {per_gen, currency, ...}
+  star_count    INTEGER NOT NULL DEFAULT 0,
+  run_count     INTEGER NOT NULL DEFAULT 0,
+  hidden        INTEGER NOT NULL DEFAULT 0,  -- moderation takedown
+  created_at    INTEGER,                     -- unix seconds (NULL on legacy upsert)
+  updated_at    INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS stars (
+  app_id     TEXT NOT NULL REFERENCES apps(id),
+  user_key   TEXT NOT NULL,                  -- sha256(client star key)
+  created_at INTEGER NOT NULL,
+  PRIMARY KEY (app_id, user_key)
+);
+
+-- One counted run per app per marker per day (popularity signal, not billing).
+CREATE TABLE IF NOT EXISTS run_marks (
+  app_id TEXT NOT NULL REFERENCES apps(id),
+  marker TEXT NOT NULL,                      -- sha256(star key or IP)
+  day    TEXT NOT NULL,                      -- YYYY-MM-DD
+  PRIMARY KEY (app_id, marker, day)
+);
+
+CREATE TABLE IF NOT EXISTS reports (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  app_id     TEXT NOT NULL,
+  reason     TEXT NOT NULL DEFAULT '',
+  created_at INTEGER NOT NULL
+);

--- a/registry/src/core.js
+++ b/registry/src/core.js
@@ -1,0 +1,170 @@
+// Apps registry — pure logic (no Worker APIs), unit-tested with node:test.
+// The fetch handler in worker.js binds these to D1/R2.
+
+/** slugify a name for URLs: lowercase, alnum runs → dashes. */
+export function slugify(s) {
+  const slug = String(s || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+  return slug || "app";
+}
+
+/** Validate + shape a publish payload. Returns { app, bundle } or throws
+ *  { status, message }. The bundle is what goes to R2 (and back to installers);
+ *  `app` is the D1 row. hide_workflow strips the UI graph from the bundle —
+ *  the registry NEVER receives it for hidden apps (client enforces too). */
+export function shapePublish(body) {
+  if (!body || typeof body !== "object") throw { status: 400, message: "body must be an object" };
+  const creatorKey = String(body.creator_key || "");
+  if (!/^[0-9a-f]{64}$/.test(creatorKey)) {
+    throw { status: 401, message: "creator_key must be 64 lowercase hex chars" };
+  }
+  const a = body.app;
+  if (!a || typeof a !== "object") throw { status: 400, message: "app must be an object" };
+  const id = String(a.id || "");
+  if (!/^[0-9a-fA-F-]{36}$/.test(id)) throw { status: 400, message: "app.id must be a uuid" };
+  const name = String(a.name || "").trim();
+  if (!name) throw { status: 400, message: "app.name required" };
+  const description = String(a.description || "").slice(0, 4000);
+  const hideWorkflow = a.hide_workflow === true;
+  const prompt = body.prompt;
+  if (!prompt || typeof prompt !== "object" || Array.isArray(prompt)) {
+    throw { status: 400, message: "prompt (API format) required" };
+  }
+  if (hideWorkflow && body.workflow != null) {
+    throw { status: 400, message: "hidden apps must not upload a workflow" };
+  }
+  if (!hideWorkflow && (body.workflow == null || typeof body.workflow !== "object")) {
+    throw { status: 400, message: "workflow (UI format) required unless hidden" };
+  }
+  const appMode = a.app_mode && typeof a.app_mode === "object" ? a.app_mode : { inputs: [], outputs: [] };
+  const deps = a.deps && typeof a.deps === "object" ? a.deps : {};
+  const creatorName = String(body.creator_name || "anonymous").trim().slice(0, 60) || "anonymous";
+
+  return {
+    creatorKey,
+    creatorName,
+    app: {
+      id: id.toLowerCase(),
+      name: name.slice(0, 120),
+      description,
+      hideWorkflow,
+      nsfw: a.nsfw === true,
+      version: Number.isInteger(a.version) && a.version > 0 ? a.version : 1,
+      appMode,
+      deps,
+      // P5 (monetization) hooks — reserved from day one, unused for now.
+      pricingJson: typeof a.pricing_json === "string" ? a.pricing_json : null,
+      hostedOnly: a.hosted_only === true,
+    },
+    bundle: {
+      format: 1,
+      manifest: {
+        id: id.toLowerCase(),
+        name: name.slice(0, 120),
+        description,
+        hideWorkflow,
+        appMode,
+        deps,
+      },
+      prompt,
+      ...(hideWorkflow ? {} : { workflow: body.workflow }),
+    },
+  };
+}
+
+/** Deterministic creator id from the creator key (the key itself never hits
+ *  the DB — only its hash, so a DB leak can't impersonate). sha256 hex. */
+export async function creatorIdFor(keyHex, digest) {
+  // `digest` is injectable for tests; in the Worker it's crypto.subtle.
+  if (digest) return digest(keyHex);
+  const bytes = new Uint8Array(keyHex.match(/../g).map((h) => parseInt(h, 16)));
+  const hash = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(hash)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+const SORTS = new Set(["new", "stars", "trending"]);
+
+/** Build the list query. trending = (stars last 7d)*3 + (runs last 7d).
+ *  Keyset-paginated by (score|star_count|created_at, id) so pages are stable.
+ *  The score expression lives in a subquery so the cursor can reference it in
+ *  WHERE (SQLite forbids SELECT aliases there). */
+export function buildListQuery({ sort, q, creator, includeNsfw, limit, cursor }) {
+  if (!SORTS.has(sort)) sort = "new";
+  const where = ["a.hidden = 0"];
+  const params = [];
+  if (!includeNsfw) where.push("a.nsfw = 0");
+  if (creator) {
+    where.push("a.creator_name = ? COLLATE NOCASE");
+    params.push(creator);
+  }
+  if (q) {
+    // Registry scale doesn't need FTS — a substring match over name +
+    // description + creator is honest and exact. Multi-word = AND.
+    const words = q.split(/\s+/).filter(Boolean).slice(0, 8);
+    for (const w of words) {
+      where.push("(a.name LIKE ? OR a.description LIKE ? OR a.creator_name LIKE ?)");
+      const like = `%${w.replace(/[%_]/g, "")}%`;
+      params.push(like, like, like);
+    }
+  }
+  const lim = Math.min(Math.max(Number(limit) || 24, 1), 100);
+  const scoreExpr =
+    `(SELECT COUNT(*) FROM stars s WHERE s.app_id = a.id AND s.created_at > unixepoch() - 604800) * 3 ` +
+    `+ (SELECT COUNT(*) FROM run_marks r WHERE r.app_id = a.id AND r.day > strftime('%Y-%m-%d', 'now', '-7 days'))`;
+  const cursorCol = sort === "stars" ? "star_count" : sort === "trending" ? "score" : "created_at";
+  const orderDir = cursorCol === "created_at" ? "DESC" : "DESC";
+  const inner = `SELECT a.*, ${scoreExpr} AS score FROM apps a WHERE ${where.join(" AND ")}`;
+
+  let outerWhere = "";
+  if (cursor && cursor.v != null && cursor.id) {
+    // Keyset: strictly worse rank, or equal rank and id tiebreak forward.
+    outerWhere = `WHERE (${cursorCol} < ? OR (${cursorCol} = ? AND id > ?))`;
+    params.push(cursor.v, cursor.v, cursor.id);
+  }
+  const sql = `SELECT * FROM (${inner}) ${outerWhere} ORDER BY ${cursorCol} ${orderDir}, id LIMIT ?`;
+  params.push(lim + 1); // one extra row = has-more probe
+  return { sql, params, limit: lim, sort };
+}
+
+/** Shape a D1 apps row for the public API. */
+export function publicAppRow(row) {
+  return {
+    id: row.id,
+    slug: row.slug,
+    name: row.name,
+    description: row.description,
+    creator: row.creator_name,
+    version: row.version,
+    hide_workflow: !!row.hide_workflow,
+    nsfw: !!row.nsfw,
+    hosted_only: !!row.hosted_only,
+    pricing: row.pricing_json ? JSON.parse(row.pricing_json) : null,
+    stars: row.star_count,
+    runs: row.run_count,
+    score: row.score || 0,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+/** The cursor for the NEXT page from the last row of THIS one (null when the
+ *  page was short = no more). Rows arrive as fetched (limit+1 max). */
+export function nextCursor(rows, limit, sort) {
+  if (rows.length <= limit) return null;
+  const last = rows[limit - 1];
+  const v = sort === "stars" ? last.star_count : sort === "trending" ? last.score : last.created_at;
+  return btoa(JSON.stringify({ v, id: last.id }));
+}
+
+export function parseCursor(raw) {
+  if (!raw) return null;
+  try {
+    const c = JSON.parse(atob(String(raw)));
+    return c && c.id && c.v != null ? c : null;
+  } catch {
+    return null;
+  }
+}

--- a/registry/src/core.js
+++ b/registry/src/core.js
@@ -56,7 +56,17 @@ export function shapePublish(body) {
       appMode,
       deps,
       // P5 (monetization) hooks — reserved from day one, unused for now.
-      pricingJson: typeof a.pricing_json === "string" ? a.pricing_json : null,
+      // pricing_json must be VALID JSON when present: an invalid string would
+      // otherwise reach list responses (parsed there per row).
+      pricingJson: (() => {
+        if (typeof a.pricing_json !== "string") return null;
+        try {
+          JSON.parse(a.pricing_json);
+          return a.pricing_json;
+        } catch {
+          throw { status: 400, message: "pricing_json must be valid JSON" };
+        }
+      })(),
       hostedOnly: a.hosted_only === true,
     },
     bundle: {
@@ -129,8 +139,16 @@ export function buildListQuery({ sort, q, creator, includeNsfw, limit, cursor })
   return { sql, params, limit: lim, sort };
 }
 
-/** Shape a D1 apps row for the public API. */
+/** Shape a D1 apps row for the public API. pricing_json is parsed defensively:
+ *  a bad value must never 500 a list page (it poisons every page the row is
+ *  on) — degrade to null instead. */
 export function publicAppRow(row) {
+  let pricing = null;
+  try {
+    pricing = row.pricing_json ? JSON.parse(row.pricing_json) : null;
+  } catch {
+    pricing = null;
+  }
   return {
     id: row.id,
     slug: row.slug,
@@ -141,7 +159,7 @@ export function publicAppRow(row) {
     hide_workflow: !!row.hide_workflow,
     nsfw: !!row.nsfw,
     hosted_only: !!row.hosted_only,
-    pricing: row.pricing_json ? JSON.parse(row.pricing_json) : null,
+    pricing,
     stars: row.star_count,
     runs: row.run_count,
     score: row.score || 0,

--- a/registry/src/worker.js
+++ b/registry/src/worker.js
@@ -1,0 +1,222 @@
+// Apps registry worker — publish / explore / star / install for the panel's
+// micro-apps. Bindings: DB (D1), BUNDLES (R2), optional ADMIN_KEY.
+//
+// Identity (phase-1-simple): a creator_key (64 hex, generated client-side,
+// held in the panel's localStorage / mobile secure store). The DB stores only
+// creator_id = sha256(key), so a database leak can't impersonate anyone.
+// Real OAuth is a later upgrade; P5 monetization needs it.
+//
+// Bundle storage: R2 `bundles/<id>.json` (manifest + prompt [+ workflow]) and
+// `thumbs/<id>.png`. D1 holds the searchable/listable metadata; the FTS5 table
+// + triggers live in migrations/0001_init.sql. P5 hooks (pricing_json,
+// hosted_only) exist from day one so monetization is purely additive.
+
+import {
+  buildListQuery,
+  creatorIdFor,
+  nextCursor,
+  parseCursor,
+  publicAppRow,
+  shapePublish,
+  slugify,
+} from "./core.js";
+
+const JSON_HEADERS = { "content-type": "application/json" };
+
+function json(data, status = 200) {
+  return new Response(JSON.stringify(data), { status, headers: JSON_HEADERS });
+}
+
+function err(status, message) {
+  return json({ error: message }, status);
+}
+
+async function sha256Hex(text) {
+  const hash = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+  return [...new Uint8Array(hash)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const path = url.pathname;
+    const method = request.method;
+    try {
+      // POST /v1/apps — publish (create) or update (same id, owner only).
+      if (method === "POST" && path === "/v1/apps") return await publish(request, env);
+      // GET /v1/apps — list/search.
+      if (method === "GET" && path === "/v1/apps") return await list(url, env);
+
+      const appMatch = path.match(/^\/v1\/apps\/([0-9a-f-]{36})(\/(star|unstar|ran|report|thumbnail|bundle))?$/);
+      if (appMatch) {
+        const [, id, , action] = appMatch;
+        if (method === "POST" && action === "star") return await star(env, id, request, true);
+        if (method === "POST" && action === "unstar") return await star(env, id, request, false);
+        if (method === "POST" && action === "ran") return await ran(env, id, request);
+        if (method === "POST" && action === "report") return await report(env, id, request);
+        if (method === "GET" && action === "thumbnail") return await thumbnail(env, id);
+        if (method === "GET" && action === "bundle") return await bundle(env, id);
+        if (method === "GET" && !action) return await detail(env, id);
+      }
+      // GET /v1/apps/by-slug/<creator>/<name> — humans share slugs, not uuids.
+      const slugMatch = path.match(/^\/v1\/apps\/by-slug\/([a-z0-9-]+(?:\/[a-z0-9-]+)?)$/);
+      if (method === "GET" && slugMatch) return await detailBySlug(env, slugMatch[1]);
+
+      return err(404, "not found");
+    } catch (e) {
+      if (e && e.status) return err(e.status, e.message || "error");
+      return err(500, `internal: ${e && e.message ? e.message : e}`);
+    }
+  },
+};
+
+async function publish(request, env) {
+  const body = await request.json().catch(() => null);
+  const { creatorKey, creatorName, app, bundle } = shapePublish(body);
+  const creatorId = await creatorIdFor(creatorKey, (hex) => sha256Hex(hex));
+  const now = Math.floor(Date.now() / 1000);
+
+  const existing = await env.DB.prepare("SELECT creator_id, slug, version FROM apps WHERE id = ?")
+    .bind(app.id)
+    .first();
+  if (existing && existing.creator_id !== creatorId) {
+    return err(403, "this app id belongs to another creator");
+  }
+  const version = existing ? Math.max(app.version, (existing.version || 0) + 1) : app.version;
+  // Slug: creator/name, unique — fall back to an id suffix on collision.
+  let slug = `${slugify(creatorName)}/${slugify(app.name)}`;
+  const slugOwner = await env.DB.prepare("SELECT id FROM apps WHERE slug = ?").bind(slug).first();
+  if (slugOwner && slugOwner.id !== app.id) {
+    slug = `${slug}-${app.id.slice(0, 8)}`;
+  }
+
+  await env.BUNDLES.put(`bundles/${app.id}.json`, JSON.stringify(bundle), {
+    httpMetadata: { contentType: "application/json" },
+  });
+  if (typeof body.thumbnail_b64 === "string" && body.thumbnail_b64) {
+    const bytes = Uint8Array.from(atob(body.thumbnail_b64), (c) => c.charCodeAt(0));
+    if (bytes.length > 5 * 1024 * 1024) throw { status: 400, message: "thumbnail too large" };
+    await env.BUNDLES.put(`thumbs/${app.id}.png`, bytes, {
+      httpMetadata: { contentType: "image/png" },
+    });
+  }
+
+  await env.DB.prepare(
+    `INSERT INTO apps (id, slug, creator_id, creator_name, name, description, version,
+       hide_workflow, nsfw, hosted_only, pricing_json, star_count, run_count, hidden, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       slug = excluded.slug, creator_name = excluded.creator_name, name = excluded.name,
+       description = excluded.description, version = excluded.version,
+       hide_workflow = excluded.hide_workflow, nsfw = excluded.nsfw,
+       hosted_only = excluded.hosted_only, pricing_json = excluded.pricing_json,
+       updated_at = excluded.updated_at`,
+  )
+    .bind(
+      app.id, slug, creatorId, creatorName, app.name, app.description, version,
+      app.hideWorkflow ? 1 : 0, app.nsfw ? 1 : 0, app.hostedOnly ? 1 : 0, app.pricingJson,
+      existing ? null : now, now,
+    )
+    .run();
+  return json({ ok: true, id: app.id, slug, version });
+}
+
+async function list(url, env) {
+  const sort = url.searchParams.get("sort") || "new";
+  const q = url.searchParams.get("q") || "";
+  const creator = url.searchParams.get("creator") || "";
+  const includeNsfw = url.searchParams.get("nsfw") === "1";
+  const limit = Number(url.searchParams.get("limit") || 24);
+  const cursor = parseCursor(url.searchParams.get("cursor"));
+  const query = buildListQuery({ sort, q, creator, includeNsfw, limit, cursor });
+  const { results } = await env.DB.prepare(query.sql).bind(...query.params).all();
+  const rows = (results || []).slice(0, query.limit);
+  return json({
+    apps: rows.map(publicAppRow),
+    next_cursor: nextCursor(results || [], query.limit, query.sort),
+  });
+}
+
+async function detailRow(env, by, value) {
+  const row = await env.DB.prepare(`SELECT a.*, 0 AS score FROM apps a WHERE ${by} = ? AND hidden = 0`)
+    .bind(value)
+    .first();
+  if (!row) throw { status: 404, message: "app not found" };
+  return row;
+}
+
+async function detail(env, id) {
+  return json({ app: publicAppRow(await detailRow(env, "a.id", id)) });
+}
+
+async function detailBySlug(env, slug) {
+  return json({ app: publicAppRow(await detailRow(env, "a.slug", slug)) });
+}
+
+async function bundle(env, id) {
+  const row = await detailRow(env, "a.id", id);
+  const obj = await env.BUNDLES.get(`bundles/${row.id}.json`);
+  if (!obj) throw { status: 404, message: "bundle missing" };
+  // Hidden apps must report a run: the registry counts it so trending works
+  // even where the panel never phones home. (Client-reported; not billing.)
+  return new Response(obj.body, { headers: { "content-type": "application/json" } });
+}
+
+async function thumbnail(env, id) {
+  const obj = await env.BUNDLES.get(`thumbs/${id}.png`);
+  if (!obj) return err(404, "no thumbnail");
+  return new Response(obj.body, {
+    headers: { "content-type": "image/png", "cache-control": "public, max-age=3600" },
+  });
+}
+
+async function star(env, id, request, on) {
+  const body = await request.json().catch(() => null);
+  const key = body && typeof body.star_key === "string" ? body.star_key : "";
+  if (!/^[0-9a-zA-Z-]{4,64}$/.test(key)) return err(400, "star_key required");
+  const keyHash = await sha256Hex(key);
+  const exists = await env.DB.prepare("SELECT id FROM apps WHERE id = ? AND hidden = 0").bind(id).first();
+  if (!exists) return err(404, "app not found");
+  if (on) {
+    // INSERT OR IGNORE + conditional count bump keeps one star per key.
+    const res = await env.DB.prepare("INSERT OR IGNORE INTO stars (app_id, user_key, created_at) VALUES (?, ?, unixepoch())")
+      .bind(id, keyHash)
+      .run();
+    if (res.meta.changes > 0) {
+      await env.DB.prepare("UPDATE apps SET star_count = star_count + 1 WHERE id = ?").bind(id).run();
+    }
+  } else {
+    const res = await env.DB.prepare("DELETE FROM stars WHERE app_id = ? AND user_key = ?")
+      .bind(id, keyHash)
+      .run();
+    if (res.meta.changes > 0) {
+      await env.DB.prepare("UPDATE apps SET star_count = MAX(star_count - 1, 0) WHERE id = ?").bind(id).run();
+    }
+  }
+  return json({ ok: true, starred: on });
+}
+
+async function ran(env, id, request) {
+  const body = await request.json().catch(() => null);
+  const key = body && typeof body.star_key === "string" ? body.star_key : "";
+  const marker = key ? await sha256Hex(key) : await sha256Hex(request.headers.get("CF-Connecting-IP") || "anon");
+  const day = new Date().toISOString().slice(0, 10);
+  // One counted run per app per marker per day — run_count feeds trending and
+  // is a popularity signal, NOT billing, so this light throttle is enough.
+  const res = await env.DB.prepare("INSERT OR IGNORE INTO run_marks (app_id, marker, day) VALUES (?, ?, ?)")
+    .bind(id, marker, day)
+    .run();
+  if (res.meta.changes > 0) {
+    await env.DB.prepare("UPDATE apps SET run_count = run_count + 1 WHERE id = ?").bind(id).run();
+  }
+  return json({ ok: true });
+}
+
+async function report(env, id, request) {
+  const body = await request.json().catch(() => null);
+  const reason = body && typeof body.reason === "string" ? body.reason.slice(0, 500) : "";
+  await env.DB.prepare("INSERT INTO reports (app_id, reason, created_at) VALUES (?, ?, unixepoch())")
+    .bind(id, reason)
+    .run();
+  return json({ ok: true });
+}

--- a/registry/src/worker.js
+++ b/registry/src/worker.js
@@ -21,7 +21,15 @@ import {
   slugify,
 } from "./core.js";
 
-const JSON_HEADERS = { "content-type": "application/json" };
+const JSON_HEADERS = {
+  "content-type": "application/json",
+  // The panel fetches the registry cross-origin (ComfyUI origin → workers.dev),
+  // so every response needs CORS and OPTIONS must answer preflights.
+  "access-control-allow-origin": "*",
+  "access-control-allow-methods": "GET, POST, OPTIONS",
+  "access-control-allow-headers": "content-type",
+  "access-control-max-age": "86400",
+};
 
 function json(data, status = 200) {
   return new Response(JSON.stringify(data), { status, headers: JSON_HEADERS });
@@ -41,6 +49,11 @@ export default {
     const url = new URL(request.url);
     const path = url.pathname;
     const method = request.method;
+    // CORS preflight (the panel's POSTs carry a JSON content-type, so browsers
+    // preflight them cross-origin).
+    if (method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: JSON_HEADERS });
+    }
     try {
       // POST /v1/apps — publish (create) or update (same id, owner only).
       if (method === "POST" && path === "/v1/apps") return await publish(request, env);
@@ -71,7 +84,20 @@ export default {
 };
 
 async function publish(request, env) {
-  const body = await request.json().catch(() => null);
+  // Anonymous endpoint with R2 storage behind it: hard-cap the request BEFORE
+  // parsing (a JSON body can declare any content-length, so check both the
+  // header and the actual buffered size).
+  const MAX_PUBLISH_BYTES = 16 * 1024 * 1024;
+  const declared = Number(request.headers.get("content-length") || 0);
+  if (declared > MAX_PUBLISH_BYTES) return err(413, "bundle too large");
+  const raw = await request.text();
+  if (raw.length > MAX_PUBLISH_BYTES) return err(413, "bundle too large");
+  let body;
+  try {
+    body = JSON.parse(raw);
+  } catch {
+    return err(400, "invalid JSON");
+  }
   const { creatorKey, creatorName, app, bundle } = shapePublish(body);
   const creatorId = await creatorIdFor(creatorKey, (hex) => sha256Hex(hex));
   const now = Math.floor(Date.now() / 1000);
@@ -159,14 +185,20 @@ async function bundle(env, id) {
   if (!obj) throw { status: 404, message: "bundle missing" };
   // Hidden apps must report a run: the registry counts it so trending works
   // even where the panel never phones home. (Client-reported; not billing.)
-  return new Response(obj.body, { headers: { "content-type": "application/json" } });
+  return new Response(obj.body, {
+    headers: { "content-type": "application/json", "access-control-allow-origin": "*" },
+  });
 }
 
 async function thumbnail(env, id) {
   const obj = await env.BUNDLES.get(`thumbs/${id}.png`);
   if (!obj) return err(404, "no thumbnail");
   return new Response(obj.body, {
-    headers: { "content-type": "image/png", "cache-control": "public, max-age=3600" },
+    headers: {
+      "content-type": "image/png",
+      "cache-control": "public, max-age=3600",
+      "access-control-allow-origin": "*",
+    },
   });
 }
 

--- a/registry/test/worker.test.mjs
+++ b/registry/test/worker.test.mjs
@@ -1,0 +1,204 @@
+// Registry worker tests — the real fetch handler (registry/src/worker.js)
+// driven against a fake D1 (node:sqlite behind D1's prepare/bind API) and a
+// fake R2 (Map). Covers publish → list/sort/search → star/unstar → detail →
+// bundle → ran → report, plus the hidden-app and ownership guards.
+import { test, before } from "node:test";
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import worker from "../src/worker.js";
+import { buildListQuery, creatorIdFor, parseCursor, slugify } from "../src/core.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** Minimal D1 API over node:sqlite (prepare → bind → first/all/run). */
+class FakeD1 {
+  constructor() {
+    this.db = new DatabaseSync(":memory:");
+    const sql = readFileSync(path.join(__dirname, "..", "migrations", "0001_init.sql"), "utf8");
+    this.db.exec(sql);
+  }
+  prepare(sql) {
+    const db = this.db;
+    return {
+      bind(...params) {
+        const stmt = db.prepare(sql);
+        return {
+          first: async () => stmt.get(...params) ?? null,
+          all: async () => ({ results: stmt.all(...params) }),
+          run: async () => {
+            const info = stmt.run(...params);
+            return { meta: { changes: info.changes } };
+          },
+        };
+      },
+    };
+  }
+}
+
+class FakeR2 {
+  constructor() {
+    this.map = new Map();
+  }
+  async put(key, body) {
+    this.map.set(key, body);
+  }
+  async get(key) {
+    if (!this.map.has(key)) return null;
+    return { body: this.map.get(key) };
+  }
+}
+
+let env;
+before(() => {
+  env = { DB: new FakeD1(), BUNDLES: new FakeR2() };
+});
+
+const KEY = "ab".repeat(32);
+const APP_ID = "123e4567-e89b-42d3-a456-426614174000";
+
+function publishBody(over = {}) {
+  return {
+    creator_key: KEY,
+    creator_name: "Tester",
+    app: {
+      id: APP_ID,
+      name: "Portrait Studio",
+      description: "one-tap portraits",
+      hide_workflow: false,
+      nsfw: false,
+      app_mode: { inputs: [{ nodeId: 6, widget: "text" }], outputs: [] },
+      deps: {},
+      ...over.app,
+    },
+    prompt: { 6: { class_type: "CLIPTextEncode", inputs: { text: "x" } } },
+    workflow: { nodes: [], links: [] },
+    ...over,
+  };
+}
+
+const post = (path, body) =>
+  worker.fetch(new Request(`http://x${path}`, { method: "POST", body: JSON.stringify(body) }), env);
+const get = (path) => worker.fetch(new Request(`http://x${path}`), env);
+
+test("slugify", () => {
+  assert.equal(slugify("My Cool App!"), "my-cool-app");
+  assert.equal(slugify(""), "app");
+  assert.equal(slugify("  --x--  "), "x");
+});
+
+test("creatorIdFor hashes the key (key never stored)", async () => {
+  const id = await creatorIdFor(KEY);
+  assert.match(id, /^[0-9a-f]{64}$/);
+  assert.notEqual(id, KEY);
+});
+
+test("publish → detail → list → search → star → unstar → bundle → ran → report", async () => {
+  // publish
+  let res = await post("/v1/apps", publishBody());
+  assert.equal(res.status, 200);
+  const published = await res.json();
+  assert.equal(published.slug, "tester/portrait-studio");
+  assert.equal(published.version, 1);
+
+  // update bumps version, keeps stars
+  res = await post("/v1/apps", publishBody({ app: { id: APP_ID, name: "Portrait Studio", version: 2 } }));
+  assert.equal((await res.json()).version, 2);
+
+  // wrong creator can't update
+  res = await post("/v1/apps", publishBody({ creator_key: "cd".repeat(32) }));
+  assert.equal(res.status, 403);
+
+  // detail by id and by slug
+  res = await get(`/v1/apps/${APP_ID}`);
+  assert.equal(res.status, 200);
+  const detail = (await res.json()).app;
+  assert.equal(detail.name, "Portrait Studio");
+  assert.equal(detail.stars, 0);
+  res = await get("/v1/apps/by-slug/tester/portrait-studio");
+  assert.equal(res.status, 200);
+
+  // list (new) + search
+  res = await get("/v1/apps?sort=new");
+  let list = (await res.json()).apps;
+  assert.equal(list.length, 1);
+  res = await get("/v1/apps?q=portrait");
+  assert.equal((await res.json()).apps.length, 1);
+  res = await get("/v1/apps?q=nomatch");
+  assert.equal((await res.json()).apps.length, 0);
+  res = await get("/v1/apps?creator=tester");
+  assert.equal((await res.json()).apps.length, 1);
+
+  // star then unstar (idempotent per key)
+  res = await post(`/v1/apps/${APP_ID}/star`, { star_key: "user-1" });
+  assert.equal(res.status, 200);
+  await post(`/v1/apps/${APP_ID}/star`, { star_key: "user-1" }); // dup = no-op
+  await post(`/v1/apps/${APP_ID}/star`, { star_key: "user-2" });
+  assert.equal(((await (await get(`/v1/apps/${APP_ID}`)).json()).app).stars, 2);
+  await post(`/v1/apps/${APP_ID}/unstar`, { star_key: "user-2" });
+  assert.equal(((await (await get(`/v1/apps/${APP_ID}`)).json()).app).stars, 1);
+
+  // stars sort
+  res = await get("/v1/apps?sort=stars");
+  assert.equal((await res.json()).apps[0].stars, 1);
+
+  // bundle round-trips manifest + prompt + workflow
+  res = await get(`/v1/apps/${APP_ID}/bundle`);
+  assert.equal(res.status, 200);
+  const bundle = await res.json();
+  assert.equal(bundle.manifest.id, APP_ID);
+  assert.ok(bundle.workflow);
+  assert.ok(bundle.prompt["6"]);
+
+  // ran: one per marker per day
+  await post(`/v1/apps/${APP_ID}/ran`, { star_key: "user-1" });
+  await post(`/v1/apps/${APP_ID}/ran`, { star_key: "user-1" });
+  assert.equal(((await (await get(`/v1/apps/${APP_ID}`)).json()).app).runs, 1);
+
+  // report
+  res = await post(`/v1/apps/${APP_ID}/report`, { reason: "spam" });
+  assert.equal(res.status, 200);
+});
+
+test("hidden apps carry no workflow — and the API refuses one", async () => {
+  const hiddenId = "223e4567-e89b-42d3-a456-426614174001";
+  // hidden + workflow = rejected
+  let res = await post("/v1/apps", publishBody({ app: { id: hiddenId, name: "Secret", hide_workflow: true } }));
+  assert.equal(res.status, 400);
+  // hidden without workflow = fine, bundle has no workflow key
+  const body = publishBody({ app: { id: hiddenId, name: "Secret", hide_workflow: true } });
+  delete body.workflow;
+  res = await post("/v1/apps", body);
+  assert.equal(res.status, 200);
+  const bundle = await (await get(`/v1/apps/${hiddenId}/bundle`)).json();
+  assert.equal(bundle.workflow, undefined);
+  assert.ok(bundle.prompt);
+});
+
+test("publish validation", async () => {
+  assert.equal((await post("/v1/apps", { creator_key: "nope" })).status, 401);
+  assert.equal((await post("/v1/apps", { creator_key: KEY })).status, 400);
+  assert.equal((await post("/v1/apps", publishBody({ app: { id: "not-a-uuid", name: "x" } }))).status, 400);
+  assert.equal((await post("/v1/apps", publishBody({ app: { id: APP_ID, name: " " } }))).status, 400);
+});
+
+test("buildListQuery: cursor pagination is stable", () => {
+  const page1 = buildListQuery({ sort: "new", limit: 2 });
+  const page2 = buildListQuery({ sort: "new", limit: 2, cursor: { v: 123, id: "abc" } });
+  assert.match(page1.sql, /ORDER BY created_at DESC, id LIMIT \?/);
+  assert.match(page2.sql, /created_at < \?/);
+  // trending uses the score subquery
+  const trending = buildListQuery({ sort: "trending", cursor: { v: 5, id: "x" } });
+  assert.match(trending.sql, /AS score/);
+  assert.match(trending.sql, /score < \?/);
+});
+
+test("parseCursor round-trips and rejects garbage", () => {
+  assert.equal(parseCursor(null), null);
+  assert.equal(parseCursor("!!!"), null);
+  const raw = btoa(JSON.stringify({ v: 3, id: "x" }));
+  assert.deepEqual(parseCursor(raw), { v: 3, id: "x" });
+});

--- a/registry/test/worker.test.mjs
+++ b/registry/test/worker.test.mjs
@@ -202,3 +202,31 @@ test("parseCursor round-trips and rejects garbage", () => {
   const raw = btoa(JSON.stringify({ v: 3, id: "x" }));
   assert.deepEqual(parseCursor(raw), { v: 3, id: "x" });
 });
+
+test("CORS: preflight answered, every response carries allow-origin", async () => {
+  const pre = await worker.fetch(new Request("http://x/v1/apps", { method: "OPTIONS" }), env);
+  assert.equal(pre.status, 204);
+  assert.equal(pre.headers.get("access-control-allow-origin"), "*");
+  const res = await get("/v1/apps");
+  assert.equal(res.headers.get("access-control-allow-origin"), "*");
+});
+
+test("publish: oversized bodies are rejected before parsing", async () => {
+  const huge = JSON.stringify({ creator_key: KEY, app: { id: APP_ID, name: "x".padEnd(20 * 1024 * 1024, "x") } });
+  const res = await worker.fetch(
+    new Request("http://x/v1/apps", { method: "POST", body: huge }),
+    env,
+  );
+  assert.equal(res.status, 413);
+});
+
+test("pricing_json: invalid values rejected at publish, defensive at read", async () => {
+  const res = await post("/v1/apps", publishBody({ app: { id: "423e4567-e89b-42d3-a456-426614174003", name: "Priced", pricing_json: "{not json" } }));
+  assert.equal(res.status, 400);
+  // A legacy bad value in the DB must not 500 the list (defensive parse).
+  await env.DB.prepare(
+    "INSERT INTO apps (id, slug, creator_id, creator_name, name, description, version, hide_workflow, nsfw, hosted_only, pricing_json, star_count, run_count, hidden, created_at, updated_at) VALUES ('bad-price', 'x/bad', 'c', 'x', 'Bad', '', 1, 0, 0, 0, '{oops', 0, 0, 0, 1, 1)",
+  ).bind().run();
+  const list = await (await get("/v1/apps?limit=100")).json();
+  assert.ok(list.apps.find((a) => a.id === "bad-price"));
+});

--- a/registry/wrangler.toml
+++ b/registry/wrangler.toml
@@ -1,0 +1,19 @@
+name = "cmcp-apps-registry"
+main = "src/worker.js"
+compatibility_date = "2026-01-01"
+
+# D1 database — create with:  wrangler d1 create cmcp-apps-registry
+# then paste the database_id below and run:
+#   wrangler d1 execute cmcp-apps-registry --file migrations/0001_init.sql
+[[d1_databases]]
+binding = "DB"
+database_name = "cmcp-apps-registry"
+database_id = "REPLACE_ME"
+
+# R2 bucket — create with:  wrangler r2 bucket create cmcp-app-bundles
+[[r2_buckets]]
+binding = "BUNDLES"
+bucket_name = "cmcp-app-bundles"
+
+# Optional: ADMIN_KEY var for future moderation endpoints (set via
+# `wrangler secret put ADMIN_KEY`).

--- a/web/js/cmcp-apps-ui.js
+++ b/web/js/cmcp-apps-ui.js
@@ -1,0 +1,1016 @@
+// Micro-Apps modal — "My Apps" grid, convert/register flows, app detail with
+// one-click runs. Follows the cmcp-civitai-ui.js conventions: overlay mounts
+// on document.body, CSS injected into document.head, all user text via
+// textContent (no HTML injection surface), explicit close() handle.
+//
+// ctx (from the panel monolith):
+//   getApp()           — the live ComfyUI app object (graph, graphToPrompt)
+//   uploadBlobToInput  — (blob, name) => Promise<{filename, subfolder, type}|null>
+//   callTool           — (tool, args, opts) => Promise<tool_result> (P2: RunPod)
+//   getRunpodTarget    — () => last comfyui_target frame (P2: honest host)
+//
+// hideWorkflow is BEST-EFFORT obfuscation, and the UI says so wherever it is
+// offered — see the hide toggle copy. True protection = hosted runs (P5).
+
+import { AppBuilder, AppsClient, RegistryClient } from "./cmcp-apps.js";
+
+let styleInjected = false;
+function injectStyle() {
+  if (styleInjected) return;
+  styleInjected = true;
+  const css = `
+.cmcp-apps-overlay{position:fixed;inset:0;z-index:10000;display:flex;align-items:center;justify-content:center;
+  padding:1rem;background:rgba(0,0,0,0.45);}
+.cmcp-apps-modal{max-width:min(860px,94vw)!important;width:100%;max-height:88vh;display:flex;flex-direction:column;}
+.cmcp-apps-body{display:flex;flex-direction:column;gap:0.75rem;min-height:0;flex:1;}
+.cmcp-apps-toolbar{display:flex;gap:0.4rem;flex-wrap:wrap;align-items:center;}
+.cmcp-apps-toolbar .spacer{flex:1;}
+.cmcp-apps-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:0.75rem;overflow-y:auto;min-height:120px;}
+.cmcp-app-card{border:1px solid var(--p-content-border-color,#3f3f46);border-radius:10px;overflow:hidden;cursor:pointer;
+  background:var(--p-content-background,#18181b);display:flex;flex-direction:column;transition:border-color .15s;}
+.cmcp-app-card:hover{border-color:var(--p-primary-color,#60a5fa);}
+.cmcp-app-card .thumb{aspect-ratio:16/9;background:#0c0c0e center/cover no-repeat;display:flex;align-items:center;justify-content:center;
+  font-size:1.6rem;opacity:0.85;}
+.cmcp-app-card .meta{padding:0.5rem 0.6rem;display:flex;flex-direction:column;gap:0.15rem;}
+.cmcp-app-card .name{font-weight:600;font-size:0.85rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.cmcp-app-card .desc{font-size:0.72rem;opacity:0.65;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;}
+.cmcp-app-badges{display:flex;gap:0.3rem;margin-top:0.15rem;}
+.cmcp-app-badge{font-size:0.62rem;padding:0.05rem 0.35rem;border-radius:99px;border:1px solid var(--p-content-border-color,#3f3f46);opacity:0.8;}
+.cmcp-app-badge.hidden-wf{border-color:rgba(245,158,11,0.5);color:#f59e0b;}
+.cmcp-apps-empty{opacity:0.6;font-size:0.85rem;padding:2rem 1rem;text-align:center;grid-column:1/-1;}
+.cmcp-apps-back{align-self:flex-start;}
+.cmcp-apps-detail{display:flex;flex-direction:column;gap:0.75rem;overflow-y:auto;min-height:0;}
+.cmcp-apps-detail-head{display:flex;gap:0.75rem;align-items:flex-start;}
+.cmcp-apps-detail-head .thumb{width:96px;height:54px;flex:0 0 auto;border-radius:8px;background:#0c0c0e center/cover no-repeat;
+  display:flex;align-items:center;justify-content:center;font-size:1.3rem;}
+.cmcp-apps-detail-head .titles{flex:1;min-width:0;}
+.cmcp-apps-detail-head h3{margin:0;font-size:1rem;}
+.cmcp-apps-detail-head .desc{font-size:0.78rem;opacity:0.7;margin-top:0.2rem;white-space:pre-wrap;}
+.cmcp-apps-form{display:flex;flex-direction:column;gap:0.55rem;}
+.cmcp-apps-field{display:flex;flex-direction:column;gap:0.2rem;}
+.cmcp-apps-field>label{font-size:0.72rem;font-weight:600;opacity:0.75;}
+.cmcp-apps-field input[type=text],.cmcp-apps-field input[type=number],.cmcp-apps-field textarea,.cmcp-apps-field select{
+  padding:0.45rem 0.6rem;border-radius:6px;border:1px solid var(--p-content-border-color,#3f3f46);
+  background:var(--p-inputtext-background,#18181b);color:inherit;font-size:0.85rem;font-family:inherit;}
+.cmcp-apps-field textarea{min-height:64px;resize:vertical;}
+.cmcp-apps-runbar{display:flex;gap:0.5rem;align-items:center;flex-wrap:wrap;}
+.cmcp-apps-status{font-size:0.8rem;opacity:0.85;min-height:1.1em;}
+.cmcp-apps-status.err{color:#f87171;}
+.cmcp-apps-outputs{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:0.5rem;}
+.cmcp-apps-outputs img,.cmcp-apps-outputs video{width:100%;border-radius:8px;display:block;background:#0c0c0e;}
+.cmcp-apps-outputs .text-out{grid-column:1/-1;font-size:0.8rem;white-space:pre-wrap;background:rgba(255,255,255,0.04);
+  border-radius:8px;padding:0.5rem 0.6rem;}
+.cmcp-apps-pick{max-height:220px;overflow-y:auto;border:1px solid var(--p-content-border-color,#3f3f46);border-radius:8px;padding:0.4rem;}
+.cmcp-apps-pick label{display:flex;gap:0.45rem;align-items:center;font-size:0.78rem;padding:0.15rem 0.2rem;cursor:pointer;}
+.cmcp-apps-pick .grp{font-size:0.68rem;font-weight:700;opacity:0.6;margin:0.35rem 0 0.1rem;text-transform:uppercase;letter-spacing:0.04em;}
+.cmcp-apps-warn{font-size:0.75rem;color:#f59e0b;background:rgba(245,158,11,0.08);border:1px solid rgba(245,158,11,0.3);
+  border-radius:8px;padding:0.5rem 0.6rem;}
+.cmcp-btn.danger{border-color:rgba(248,113,113,0.5);color:#f87171;}
+`;
+  const el = document.createElement("style");
+  el.textContent = css;
+  document.head.appendChild(el);
+}
+
+function el(tag, className, text) {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text !== undefined) node.textContent = text;
+  return node;
+}
+
+function makeBtn(label, { primary = false, danger = false, title = "" } = {}) {
+  const b = el("button", "cmcp-btn", label);
+  b.type = "button";
+  if (primary) b.classList.add("primary");
+  if (danger) b.classList.add("danger");
+  if (title) b.title = title;
+  return b;
+}
+
+/** /view URL for a ComfyUI file reference. */
+function viewUrl(ref) {
+  const p = new URLSearchParams({
+    filename: ref.filename || "",
+    subfolder: ref.subfolder || "",
+    type: ref.type || "output",
+  });
+  return `/view?${p.toString()}`;
+}
+
+/** Pull human text out of a bridge tool_result frame (result = MCP content array). */
+function toolText(res) {
+  if (!res) return "";
+  if (res.error) return String(res.error);
+  const r = res.result;
+  if (Array.isArray(r)) return r.map((c) => (c && c.text) || "").join("");
+  if (r && Array.isArray(r.content)) return r.content.map((c) => (c && c.text) || "").join("");
+  if (typeof r === "string") return r;
+  return res.ok === false ? "The action failed." : "Done.";
+}
+
+/** Convert the LIVE canvas into an app bundle draft: prompt snapshot + UI
+ *  workflow + candidate inputs/outputs (pre-selected from the frontend's
+ *  APP-mode config when present, else the hint-type heuristic). Throws a
+ *  readable error when the frontend can't serialize. */
+async function draftFromCanvas(getApp) {
+  const app = getApp();
+  if (!app || typeof app.graphToPrompt !== "function") {
+    throw new Error("this frontend can't serialize the graph (graphToPrompt missing)");
+  }
+  const gp = await app.graphToPrompt(); // { output, workflow }
+  const workflow = gp.workflow || app.graph?.serialize?.();
+  if (!workflow || !Array.isArray(workflow.nodes)) {
+    throw new Error("couldn't serialize the canvas workflow");
+  }
+
+  const imported = AppBuilder.findAppModeConfig(workflow);
+  // Candidates come from the LIVE graph: serialized widgets_values are
+  // positional and nameless; live nodes carry widget names/choices.
+  const liveNodes = app.graph?._nodes || app.graph?.nodes || [];
+  const inputs = [];
+  const outputs = [];
+  const seen = new Set();
+  for (const node of liveNodes) {
+    const id = Number(node.id);
+    if (!Number.isFinite(id)) continue;
+    const isOutput =
+      node.constructor?.nodeData?.output_node === true ||
+      /^(SaveImage|PreviewImage|SaveVideo|SaveAudio|PreviewAudio|ShowText|PreviewAsText)/.test(
+        String(node.type || ""),
+      );
+    if (isOutput) {
+      outputs.push({
+        nodeId: id,
+        kind: /^Show|^PreviewAs/.test(String(node.type || "")) ? "text" : "images",
+        label: `${node.title || node.type} #${id}`,
+        checked: true,
+      });
+      continue;
+    }
+    if (!AppBuilder.INPUT_HINT_TYPES.has(String(node.type || ""))) continue;
+    const linkDriven = new Set(
+      (Array.isArray(node.inputs) ? node.inputs : [])
+        .map((inp) => inp && inp.widget && inp.widget.name)
+        .filter(Boolean),
+    );
+    for (const w of Array.isArray(node.widgets) ? node.widgets : []) {
+      if (!w || !w.name || linkDriven.has(w.name)) continue;
+      if (w.type === "button" || w.type === "converted-widget") continue;
+      const key = `${id}.${w.name}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      inputs.push({
+        nodeId: id,
+        widget: w.name,
+        label: `${node.title || node.type} #${id} · ${w.label || w.name}`,
+        kind: AppBuilder.classifyWidget(String(node.type || ""), w.name, w.value),
+        choices: Array.isArray(w.options?.values) ? w.options.values.map(String) : undefined,
+        default: typeof w.value === "string" || typeof w.value === "number" || typeof w.value === "boolean" ? w.value : undefined,
+        checked: true,
+      });
+    }
+  }
+  // The frontend's own APP-mode selection overrides the heuristic's checks
+  // (its entries address widgets by real name).
+  if (imported) {
+    const wanted = new Set(imported.inputs.map((i) => `${i.nodeId}.${i.widget}`));
+    for (const cand of inputs) cand.checked = wanted.has(`${cand.nodeId}.${cand.widget}`);
+    if (imported.inputs.length) {
+      const wantedOut = new Set(imported.outputs.map((o) => o.nodeId));
+      for (const cand of outputs) cand.checked = wantedOut.size ? wantedOut.has(cand.nodeId) : cand.checked;
+    }
+  }
+  return { prompt: gp.output, workflow, imported, inputs, outputs };
+}
+
+export function openAppsModal(ctx, opts = {}) {
+  const { getApp, uploadBlobToInput, callTool, getRunpodTarget } = ctx;
+  const client = new AppsClient();
+  const registry = new RegistryClient();
+  injectStyle();
+
+  const overlay = el("div", "cmcp-apps-overlay");
+  const modal = el("div", "cmcp-modal cmcp-apps-modal");
+  const title = el("div", "cmcp-modal-title", "Apps");
+  const body = el("div", "cmcp-apps-body");
+  modal.append(title, body);
+  overlay.appendChild(modal);
+
+  let closed = false;
+  let pollTimer = null;
+  function close() {
+    if (closed) return;
+    closed = true;
+    if (pollTimer) clearInterval(pollTimer);
+    overlay.remove();
+    opts.onClose && opts.onClose();
+  }
+  overlay.addEventListener("mousedown", (e) => {
+    if (e.target === overlay) close();
+  });
+  const onKey = (e) => {
+    if (e.key === "Escape") close();
+  };
+  window.addEventListener("keydown", onKey);
+  const origClose = close;
+  close = function () {
+    window.removeEventListener("keydown", onKey);
+    origClose();
+  };
+
+  // ── Grid view ────────────────────────────────────────────────────────────
+
+  let _tab = "mine"; // "mine" | "explore"
+
+  async function showGrid() {
+    if (closed) return;
+    body.textContent = "";
+    const bar = el("div", "cmcp-apps-toolbar");
+    const mineTab = makeBtn("My Apps", { primary: _tab === "mine" });
+    const exploreTab = makeBtn("Explore", { primary: _tab === "explore" });
+    mineTab.addEventListener("click", () => { _tab = "mine"; showGrid().catch(showError); });
+    exploreTab.addEventListener("click", () => { _tab = "explore"; showGrid().catch(showError); });
+    bar.append(mineTab, exploreTab);
+    if (_tab === "mine") {
+      const spacer = el("span", "spacer");
+      const convertBtn = makeBtn("＋ Convert current workflow", {
+        primary: true,
+        title: "Package the workflow on the canvas as a one-click app.",
+      });
+      convertBtn.addEventListener("click", () => showConvert().catch(showError));
+      bar.append(spacer, convertBtn);
+    }
+    body.append(bar);
+    if (_tab === "explore") return showExplore();
+    return showMine();
+  }
+
+  async function showMine() {
+    const grid = el("div", "cmcp-apps-grid");
+    grid.append(el("div", "cmcp-apps-empty", "Loading…"));
+    body.append(grid);
+
+    let apps = [];
+    try {
+      apps = await client.list();
+    } catch (e) {
+      grid.textContent = "";
+      grid.append(el("div", "cmcp-apps-empty", `Couldn't load apps: ${e.message}`));
+      return;
+    }
+    if (closed) return;
+    grid.textContent = "";
+    if (!apps.length) {
+      grid.append(
+        el(
+          "div",
+          "cmcp-apps-empty",
+          "No apps yet. Open a workflow on the canvas, then “Convert current workflow” to make your first one.",
+        ),
+      );
+      return;
+    }
+    for (const app of apps) {
+      const card = el("div", "cmcp-app-card");
+      const thumb = el("div", "thumb", "▶");
+      if (app.has_thumbnail) {
+        thumb.style.backgroundImage = `url("${client.thumbnailUrl(app.id)}")`;
+        thumb.textContent = "";
+      }
+      const meta = el("div", "meta");
+      meta.append(el("div", "name", app.name || "Untitled app"));
+      if (app.description) meta.append(el("div", "desc", app.description));
+      const badges = el("div", "cmcp-app-badges");
+      if (app.hideWorkflow) badges.append(el("span", "cmcp-app-badge hidden-wf", "hidden workflow"));
+      if (app.published) badges.append(el("span", "cmcp-app-badge", `★ ${app.published.slug || "published"}`));
+      if (badges.childNodes.length) meta.append(badges);
+      card.append(thumb, meta);
+      card.addEventListener("click", () => showDetail(app.id).catch(showError));
+      grid.append(card);
+    }
+  }
+
+  // ── Explore view (the published registry) ────────────────────────────────
+
+  async function showExplore() {
+    if (!registry.configured) {
+      body.append(
+        el(
+          "div",
+          "cmcp-apps-empty",
+          "No registry configured. Set localStorage key “comfyui-mcp.panel.registryUrl” to a deployed registry worker to explore published apps.",
+        ),
+      );
+      return;
+    }
+    const controls = el("div", "cmcp-apps-toolbar");
+    let sort = "trending";
+    const sorts = [["trending", "Trending"], ["new", "New"], ["stars", "Most starred"]];
+    const chips = new Map();
+    const grid = el("div", "cmcp-apps-grid");
+    const search = document.createElement("input");
+    search.type = "text";
+    search.placeholder = "Search apps…";
+    search.style.cssText =
+      "flex:1;min-width:140px;padding:0.4rem 0.55rem;border-radius:6px;border:1px solid var(--p-content-border-color,#3f3f46);background:var(--p-inputtext-background,#18181b);color:inherit;font-size:0.82rem;";
+    async function load(append = false, cursor = "") {
+      if (!append) {
+        grid.textContent = "";
+        grid.append(el("div", "cmcp-apps-empty", "Loading…"));
+      }
+      try {
+        const res = await registry.list({ sort, q: search.value.trim(), cursor });
+        if (closed) return;
+        if (!append) grid.textContent = "";
+        renderCards(res.apps || [], res.next_cursor);
+      } catch (e) {
+        if (!append) {
+          grid.textContent = "";
+          grid.append(el("div", "cmcp-apps-empty", `Registry error: ${e.message}`));
+        }
+      }
+    }
+    function renderCards(apps, nextCursor) {
+      grid.querySelector(".cmcp-apps-empty")?.remove();
+      grid.querySelector(".cmcp-apps-more")?.remove();
+      if (!apps.length && !grid.childNodes.length) {
+        grid.append(el("div", "cmcp-apps-empty", "No published apps match."));
+        return;
+      }
+      for (const app of apps) {
+        const card = el("div", "cmcp-app-card");
+        const thumb = el("div", "thumb", "▶");
+        thumb.style.backgroundImage = `url("${registry.thumbnailUrl(app.id)}")`;
+        thumb.textContent = "";
+        const meta = el("div", "meta");
+        meta.append(el("div", "name", app.name || "Untitled"));
+        meta.append(el("div", "desc", `by ${app.creator || "anonymous"}`));
+        const badges = el("div", "cmcp-app-badges");
+        badges.append(el("span", "cmcp-app-badge", `★ ${app.stars || 0}`));
+        badges.append(el("span", "cmcp-app-badge", `▶ ${app.runs || 0} runs`));
+        if (app.hide_workflow) badges.append(el("span", "cmcp-app-badge hidden-wf", "hidden"));
+        meta.append(badges);
+        card.append(thumb, meta);
+        card.addEventListener("click", () => showRegistryDetail(app).catch(showError));
+        grid.append(card);
+      }
+      if (nextCursor) {
+        const more = makeBtn("Load more");
+        more.classList.add("cmcp-apps-more");
+        more.addEventListener("click", () => load(true, nextCursor));
+        grid.append(more);
+      }
+    }
+    for (const [key, label] of sorts) {
+      const chip = makeBtn(label, { primary: key === sort });
+      chips.set(key, chip);
+      chip.addEventListener("click", () => {
+        sort = key;
+        for (const [k, c] of chips) c.classList.toggle("primary", k === sort);
+        load();
+      });
+      controls.append(chip);
+    }
+    let searchTimer = null;
+    search.addEventListener("input", () => {
+      clearTimeout(searchTimer);
+      searchTimer = setTimeout(() => load(), 350);
+    });
+    controls.append(search);
+    body.append(controls, grid);
+    load();
+  }
+
+  // ── Registry app detail (install view) ───────────────────────────────────
+
+  async function showRegistryDetail(regApp) {
+    if (closed) return;
+    body.textContent = "";
+    const bar = el("div", "cmcp-apps-toolbar");
+    const back = makeBtn("← Explore");
+    back.addEventListener("click", () => { _tab = "explore"; showGrid().catch(showError); });
+    bar.append(back);
+    body.append(bar);
+
+    const detail = el("div", "cmcp-apps-detail");
+    const head = el("div", "cmcp-apps-detail-head");
+    const thumb = el("div", "thumb", "▶");
+    thumb.style.backgroundImage = `url("${registry.thumbnailUrl(regApp.id)}")`;
+    thumb.textContent = "";
+    const titles = el("div", "titles");
+    titles.append(el("h3", "", regApp.name || "Untitled"));
+    titles.append(el("div", "desc", `by ${regApp.creator || "anonymous"} · ★ ${regApp.stars || 0} · ${regApp.runs || 0} runs · v${regApp.version || 1}`));
+    if (regApp.description) titles.append(el("div", "desc", regApp.description));
+    head.append(thumb, titles);
+    detail.append(head);
+
+    if (regApp.hide_workflow) {
+      detail.append(
+        el(
+          "div",
+          "cmcp-apps-warn",
+          "Hidden workflow (best effort): the graph is never distributed with this app — but anyone technical " +
+            "who runs it can still intercept the prompt via ComfyUI's API. Real protection comes with hosted runs (coming soon).",
+        ),
+      );
+    }
+
+    const actions = el("div", "cmcp-apps-runbar");
+    const installBtn = makeBtn("⬇ Install", { primary: true });
+    const starBtn = makeBtn("☆ Star");
+    const status = el("span", "cmcp-apps-status");
+    actions.append(installBtn, starBtn, status);
+    detail.append(actions);
+    body.append(detail);
+
+    let starred = false;
+    starBtn.addEventListener("click", async () => {
+      starred = !starred;
+      starBtn.textContent = starred ? "★ Starred" : "☆ Star";
+      try {
+        await registry.star(regApp.id, starred);
+      } catch (e) {
+        status.textContent = e.message;
+        status.classList.add("err");
+      }
+    });
+
+    installBtn.addEventListener("click", async () => {
+      installBtn.disabled = true;
+      status.classList.remove("err");
+      try {
+        status.textContent = "Fetching bundle…";
+        const bundle = await registry.bundle(regApp.id);
+        const deps = bundle.manifest?.deps || {};
+        const models = Array.isArray(deps.models) ? deps.models : [];
+        const nodes = Array.isArray(deps.customNodes) ? deps.customNodes : [];
+        if (models.length || nodes.length) {
+          const ok = window.confirm(
+            `“${regApp.name}” needs:\n` +
+              (models.length ? `\nModels (${models.length}):\n  ${models.map((m) => m.name || m).join("\n  ")}\n` : "") +
+              (nodes.length ? `\nCustom nodes (${nodes.length}):\n  ${nodes.join("\n  ")}\n` : "") +
+              "\nAnything missing must be installed before the app can run (ask the agent to install it, or install it yourself). Continue?",
+          );
+          if (!ok) {
+            installBtn.disabled = false;
+            status.textContent = "";
+            return;
+          }
+        }
+        status.textContent = "Installing…";
+        let thumbnail_b64;
+        try {
+          const res = await fetch(registry.thumbnailUrl(regApp.id));
+          if (res.ok) {
+            const buf = new Uint8Array(await res.arrayBuffer());
+            let bin = "";
+            for (const b of buf) bin += String.fromCharCode(b);
+            thumbnail_b64 = btoa(bin);
+          }
+        } catch { /* no thumbnail — fine */ }
+        await client.create({
+          manifest: {
+            ...bundle.manifest,
+            source: { type: "registry", workflowUuid: null, registryId: regApp.id },
+            published: { registryId: regApp.id, slug: regApp.slug, publishedVersion: regApp.version },
+          },
+          prompt: bundle.prompt,
+          ...(bundle.workflow ? { workflow: bundle.workflow } : {}),
+          ...(thumbnail_b64 ? { thumbnail_b64 } : {}),
+        });
+        _tab = "mine";
+        await showDetail(regApp.id);
+      } catch (e) {
+        status.textContent = e.message.includes("already exists")
+          ? "Already installed — find it in My Apps."
+          : e.message;
+        status.classList.add("err");
+        installBtn.disabled = false;
+      }
+    });
+  }
+
+  // ── Convert view ─────────────────────────────────────────────────────────
+
+  async function showConvert() {
+    const draft = await draftFromCanvas(getApp);
+    if (closed) return;
+    body.textContent = "";
+
+    const bar = el("div", "cmcp-apps-toolbar");
+    const back = makeBtn("← My Apps");
+    back.classList.add("cmcp-apps-back");
+    back.addEventListener("click", () => showGrid().catch(showError));
+    bar.append(back);
+    body.append(bar);
+
+    if (draft.imported) {
+      body.append(
+        el(
+          "div",
+          "cmcp-apps-warn",
+          "This workflow already has a ComfyUI APP-mode config — its input/output selection is pre-checked below.",
+        ),
+      );
+    }
+
+    const form = el("div", "cmcp-apps-form");
+    const nameField = el("div", "cmcp-apps-field");
+    nameField.append(el("label", "", "App name"));
+    const nameInput = document.createElement("input");
+    nameInput.type = "text";
+    nameInput.maxLength = 120;
+    nameInput.placeholder = "e.g. Studio Portrait";
+    nameField.append(nameInput);
+
+    const descField = el("div", "cmcp-apps-field");
+    descField.append(el("label", "", "Description"));
+    const descInput = document.createElement("textarea");
+    descInput.placeholder = "What does this app do? What do its inputs mean?";
+    descField.append(descInput);
+
+    const thumbField = el("div", "cmcp-apps-field");
+    thumbField.append(el("label", "", "Thumbnail (optional)"));
+    const thumbInput = document.createElement("input");
+    thumbInput.type = "file";
+    thumbInput.accept = "image/png,image/jpeg,image/webp";
+    thumbField.append(thumbInput);
+
+    const pick = el("div", "cmcp-apps-pick");
+    pick.append(el("div", "grp", "Inputs — the endpoints this app exposes"));
+    for (const cand of draft.inputs) {
+      const label = document.createElement("label");
+      const cb = document.createElement("input");
+      cb.type = "checkbox";
+      cb.checked = cand.checked;
+      cb.dataset.key = `${cand.nodeId}.${cand.widget}`;
+      label.append(cb, document.createTextNode(`${cand.label} (${cand.kind})`));
+      pick.append(label);
+    }
+    pick.append(el("div", "grp", "Outputs — what the app shows after a run"));
+    for (const cand of draft.outputs) {
+      const label = document.createElement("label");
+      const cb = document.createElement("input");
+      cb.type = "checkbox";
+      cb.checked = cand.checked;
+      cb.dataset.out = String(cand.nodeId);
+      label.append(cb, document.createTextNode(cand.label));
+      pick.append(label);
+    }
+
+    const saveRow = el("div", "cmcp-apps-runbar");
+    const saveBtn = makeBtn("Create app", { primary: true });
+    const status = el("span", "cmcp-apps-status");
+    saveRow.append(saveBtn, status);
+    form.append(nameField, descField, thumbField, pick, saveRow);
+    body.append(form);
+
+    saveBtn.addEventListener("click", async () => {
+      status.classList.remove("err");
+      const name = nameInput.value.trim();
+      if (!name) {
+        status.textContent = "Name the app first.";
+        status.classList.add("err");
+        return;
+      }
+      const inputs = draft.inputs.filter(
+        (c) => pick.querySelector(`input[data-key="${CSS.escape(`${c.nodeId}.${c.widget}`)}"]`)?.checked,
+      );
+      if (!inputs.length) {
+        status.textContent = "Expose at least one input — an app with no endpoints is just a workflow.";
+        status.classList.add("err");
+        return;
+      }
+      const outputs = draft.outputs
+        .filter((c) => pick.querySelector(`input[data-out="${c.nodeId}"]`)?.checked)
+        .map(({ nodeId, kind }) => ({ nodeId, kind }));
+      saveBtn.disabled = true;
+      status.textContent = "Saving…";
+      try {
+        let thumbnail_b64;
+        const file = thumbInput.files && thumbInput.files[0];
+        if (file) {
+          const buf = new Uint8Array(await file.arrayBuffer());
+          let bin = "";
+          for (const b of buf) bin += String.fromCharCode(b);
+          thumbnail_b64 = btoa(bin);
+        }
+        const app = getApp();
+        const knownTypes = new Set(Object.keys(app?.nodeManager?.defs || app?.extensions?.nodeDefs || {}));
+        const manifest = AppBuilder.buildManifest({
+          id: crypto.randomUUID(),
+          name,
+          description: descInput.value.trim(),
+          appMode: {
+            inputs: inputs.map(({ nodeId, widget, label, kind, choices, default: def }) => ({
+              nodeId,
+              widget,
+              label,
+              kind,
+              ...(choices ? { choices } : {}),
+              ...(def !== undefined ? { default: def } : {}),
+            })),
+            outputs,
+            importedFromFrontend: !!draft.imported,
+          },
+          source: { type: draft.imported ? "app-mode" : "canvas", workflowUuid: null, registryId: null },
+          deps: AppBuilder.depsFromPrompt(draft.prompt, knownTypes),
+        });
+        await client.create({ manifest, workflow: draft.workflow, prompt: draft.prompt, thumbnail_b64 });
+        await showGrid();
+      } catch (e) {
+        status.textContent = e.message;
+        status.classList.add("err");
+        saveBtn.disabled = false;
+      }
+    });
+  }
+
+  // ── Detail view ──────────────────────────────────────────────────────────
+
+  async function showDetail(id) {
+    const app = await client.get(id);
+    if (closed) return;
+    body.textContent = "";
+
+    const bar = el("div", "cmcp-apps-toolbar");
+    const back = makeBtn("← My Apps");
+    back.addEventListener("click", () => showGrid().catch(showError));
+    bar.append(back);
+    body.append(bar);
+
+    const detail = el("div", "cmcp-apps-detail");
+    const head = el("div", "cmcp-apps-detail-head");
+    const thumb = el("div", "thumb", "▶");
+    if (app.has_thumbnail) {
+      thumb.style.backgroundImage = `url("${client.thumbnailUrl(app.id)}")`;
+      thumb.textContent = "";
+    }
+    const titles = el("div", "titles");
+    titles.append(el("h3", "", app.name || "Untitled app"));
+    if (app.description) titles.append(el("div", "desc", app.description));
+    head.append(thumb, titles);
+    detail.append(head);
+
+    if (app.hideWorkflow) {
+      detail.append(
+        el(
+          "div",
+          "cmcp-apps-warn",
+          "Hidden workflow (best effort): the node graph was never stored with this app, so casual users can't " +
+            "open it — but anyone technical who runs this app can still intercept the prompt via ComfyUI's API. " +
+            "Real protection comes with hosted runs (coming soon).",
+        ),
+      );
+    }
+
+    // Generated input form.
+    const form = el("div", "cmcp-apps-form");
+    const fieldEls = new Map(); // "nodeId.widget" -> () => value | undefined
+    for (const input of app.appMode?.inputs || []) {
+      const key = `${input.nodeId}.${input.widget}`;
+      const field = el("div", "cmcp-apps-field");
+      field.append(el("label", "", input.label || key));
+      let getter;
+      if (input.kind === "image") {
+        const fileInput = document.createElement("input");
+        fileInput.type = "file";
+        fileInput.accept = "image/*";
+        const hint = el("span", "cmcp-apps-status");
+        field.append(fileInput, hint);
+        getter = async () => {
+          const f = fileInput.files && fileInput.files[0];
+          if (!f) return undefined;
+          hint.textContent = "Uploading…";
+          const ref = await uploadBlobToInput(f, f.name);
+          if (!ref) throw new Error("image upload failed");
+          hint.textContent = "";
+          return ref.subfolder ? `${ref.subfolder}/${ref.filename}` : ref.filename;
+        };
+      } else if (input.kind === "combo" && Array.isArray(input.choices) && input.choices.length) {
+        const sel = document.createElement("select");
+        for (const c of input.choices) {
+          const opt = document.createElement("option");
+          opt.value = c;
+          opt.textContent = c;
+          sel.append(opt);
+        }
+        if (input.default !== undefined) sel.value = String(input.default);
+        field.append(sel);
+        getter = () => sel.value;
+      } else if (input.kind === "number") {
+        const num = document.createElement("input");
+        num.type = "number";
+        if (input.default !== undefined) num.value = String(input.default);
+        field.append(num);
+        getter = () => (num.value === "" ? undefined : Number(num.value));
+      } else if (input.kind === "toggle") {
+        const cb = document.createElement("input");
+        cb.type = "checkbox";
+        cb.checked = !!input.default;
+        field.append(cb);
+        getter = () => cb.checked;
+      } else {
+        const ta = document.createElement("textarea");
+        if (input.default !== undefined) ta.value = String(input.default);
+        field.append(ta);
+        getter = () => ta.value;
+      }
+      fieldEls.set(key, getter);
+      form.append(field);
+    }
+
+    const runRow = el("div", "cmcp-apps-runbar");
+    const runBtn = makeBtn("▶ Run", { primary: true, title: "Queue this app on the local ComfyUI." });
+    const runpodBtn = makeBtn("☁ Run on RunPod", {
+      title: "Queue this app on your connected RunPod pod (see the RunPod panel to connect one).",
+    });
+    const status = el("span", "cmcp-apps-status");
+    runRow.append(runBtn, runpodBtn, status);
+    form.append(runRow);
+
+    const outputs = el("div", "cmcp-apps-outputs");
+    detail.append(form, outputs);
+    body.append(detail);
+
+    // Management row (metadata edit, publish, hide, delete) — below the fold.
+    const mgmt = el("div", "cmcp-apps-toolbar");
+    const editBtn = makeBtn("✎ Edit info");
+    const publishBtn = makeBtn(app.published ? "⇪ Update published" : "⇪ Publish", {
+      title: "Share this app to the public registry (Explore tab). Hidden apps upload the run snapshot only — never the graph.",
+    });
+    const hideBtn = makeBtn(app.hideWorkflow ? "🔒 Workflow hidden" : "🔓 Hide workflow", {
+      title:
+        "Best effort: deletes the stored node graph so the app only carries the run snapshot. " +
+        "A technical user can still intercept it — see the warning above.",
+    });
+    const delBtn = makeBtn("🗑 Delete", { danger: true });
+    mgmt.append(editBtn, publishBtn, hideBtn, delBtn);
+    detail.append(mgmt);
+
+    publishBtn.addEventListener("click", async () => {
+      if (!registry.configured) {
+        window.alert(
+          "No registry configured yet. The registry worker isn't deployed — set localStorage " +
+            "“comfyui-mcp.panel.registryUrl” to a deployed instance to publish.",
+        );
+        return;
+      }
+      if (app.hideWorkflow) {
+        const ok = window.confirm(
+          "Publish “" + (app.name || "this app") + "” as a HIDDEN app?\n\n" +
+            "Only the run snapshot is uploaded — never the node graph. This is best-effort " +
+            "privacy, not security: anyone who runs the app can still intercept the prompt. Continue?",
+        );
+        if (!ok) return;
+      }
+      publishBtn.disabled = true;
+      try {
+        let creatorName = null;
+        try { creatorName = localStorage.getItem("comfyui-mcp.panel.creatorName"); } catch {}
+        if (!creatorName) {
+          creatorName = window.prompt("Publish under what creator name?", "anonymous");
+          if (creatorName === null) return;
+          creatorName = creatorName.trim() || "anonymous";
+          try { localStorage.setItem("comfyui-mcp.panel.creatorName", creatorName); } catch {}
+        }
+        const bundle = await client.bundle(app.id);
+        const result = await registry.publish({
+          creatorName,
+          app: {
+            id: app.id,
+            name: bundle.manifest.name,
+            description: bundle.manifest.description || "",
+            version: (app.published?.publishedVersion || 0) + 1,
+            hide_workflow: !!app.hideWorkflow,
+            nsfw: false,
+            app_mode: bundle.manifest.appMode || { inputs: [], outputs: [] },
+            deps: bundle.manifest.deps || {},
+          },
+          prompt: bundle.prompt,
+          workflow: app.hideWorkflow ? undefined : bundle.workflow,
+          thumbnail_b64: bundle.thumbnail_b64,
+        });
+        await client.update(app.id, {
+          manifest: { published: { registryId: app.id, slug: result.slug, publishedVersion: result.version } },
+        });
+        await showDetail(app.id);
+      } catch (e) {
+        window.alert(`Publish failed: ${e.message}`);
+        publishBtn.disabled = false;
+      }
+    });
+
+    editBtn.addEventListener("click", async () => {
+      const name = window.prompt("App name", app.name || "");
+      if (name === null) return;
+      const description = window.prompt("Description", app.description || "");
+      if (description === null) return;
+      await client.update(app.id, { manifest: { name: name.trim() || app.name, description } });
+      await showDetail(app.id);
+    });
+
+    hideBtn.disabled = !!app.hideWorkflow;
+    hideBtn.addEventListener("click", async () => {
+      const ok = window.confirm(
+        "Hide the workflow for “" + (app.name || "this app") + "”?\n\n" +
+          "This DELETES the stored node graph — the app keeps only its run snapshot and can't be " +
+          "edited as a workflow afterwards. This is best-effort privacy, not security: anyone who " +
+          "runs the app can still intercept the prompt via ComfyUI's API.\n\nContinue?",
+      );
+      if (!ok) return;
+      await client.update(app.id, { manifest: { hideWorkflow: true } });
+      await showDetail(app.id);
+    });
+
+    delBtn.addEventListener("click", async () => {
+      if (!window.confirm(`Delete “${app.name || "this app"}”? This can't be undone.`)) return;
+      await client.remove(app.id);
+      await showGrid();
+    });
+
+    async function collectValues() {
+      const values = {};
+      for (const [key, getter] of fieldEls) {
+        const v = await getter();
+        if (v !== undefined) values[key] = v;
+      }
+      return values;
+    }
+
+    async function runApp() {
+      runBtn.disabled = true;
+      runpodBtn.disabled = true;
+      status.classList.remove("err");
+      status.textContent = "Queueing…";
+      outputs.textContent = "";
+      try {
+        const values = await collectValues();
+        const res = await client.run(app.id, values);
+        const promptId = res.prompt_id;
+        if (!promptId) throw new Error("queue returned no prompt_id");
+        status.textContent = "Running…";
+        await pollRun(promptId);
+      } catch (e) {
+        status.textContent = e.message;
+        status.classList.add("err");
+      } finally {
+        runBtn.disabled = false;
+        runpodBtn.disabled = false;
+      }
+    }
+
+    async function pollRun(promptId) {
+      const deadline = Date.now() + 30 * 60 * 1000;
+      return new Promise((resolve) => {
+        const tick = async () => {
+          if (closed) return resolve();
+          try {
+            const st = await client.runStatus(app.id, promptId);
+            if (st.status === "done") {
+              renderOutputs(st);
+              return resolve();
+            }
+            status.textContent = st.status === "running" ? "Running…" : "Queued…";
+          } catch (e) {
+            status.textContent = e.message;
+            status.classList.add("err");
+            return resolve();
+          }
+          if (Date.now() > deadline) {
+            status.textContent = "Timed out waiting for the run — it may still finish; check ComfyUI's queue.";
+            status.classList.add("err");
+            return resolve();
+          }
+          pollTimer = setTimeout(tick, 2000);
+        };
+        tick();
+      });
+    }
+
+    function renderOutputs(st) {
+      const detailStatus = st.status_detail || {};
+      const msgs = detailStatus.messages || [];
+      const failed = msgs.some((m) => Array.isArray(m) && m[0] === "execution_error");
+      status.textContent = failed ? "Run failed — see ComfyUI for details." : "Done.";
+      if (failed) status.classList.add("err");
+      // Published app → report the run so registry trending works (fire and
+      // forget; a popularity signal, never billing).
+      if (!failed && app.published?.registryId && registry.configured) {
+        registry.ran(app.published.registryId);
+      }
+      outputs.textContent = "";
+      const wanted = new Set((app.appMode?.outputs || []).map((o) => String(o.nodeId)));
+      for (const [nodeId, out] of Object.entries(st.outputs || {})) {
+        if (wanted.size && !wanted.has(String(nodeId))) continue;
+        const media = [...(out.images || []), ...(out.gifs || [])];
+        for (const ref of media) {
+          const url = viewUrl(ref);
+          const isVideo = /webm|mp4|mov|gif/i.test(ref.filename || "");
+          const m = document.createElement(isVideo ? "video" : "img");
+          m.src = url;
+          if (isVideo) {
+            m.controls = true;
+            m.loop = true;
+            m.muted = true;
+            m.autoplay = true;
+            m.playsInline = true;
+          }
+          outputs.append(m);
+        }
+        for (const t of out.text || []) {
+          outputs.append(el("div", "text-out", typeof t === "string" ? t : JSON.stringify(t)));
+        }
+      }
+      if (!outputs.childNodes.length && !failed) {
+        outputs.append(el("div", "text-out", "Run finished with no visible outputs on the selected output nodes."));
+      }
+    }
+
+    runBtn.addEventListener("click", () => runApp());
+    runpodBtn.addEventListener("click", () => runOnPod().catch((e) => {
+      status.textContent = e.message;
+      status.classList.add("err");
+    }));
+
+    /** One-click pod run: the LOCAL apps route dry-patches the snapshot, then
+     *  the orchestrator's enqueue_workflow sends it to the connected pod. Deps
+     *  pinned to a CivitAI version are pushed first (download_civitai_model is
+     *  whitelisted); anything unpinned is reported, not silently skipped. */
+    async function runOnPod() {
+      status.classList.remove("err");
+      if (!callTool) throw new Error("Orchestrator not connected — pod runs go through the bridge.");
+      const target = typeof getRunpodTarget === "function" ? getRunpodTarget() : null;
+      if (!target || target.is_local) {
+        throw new Error("No pod connected — open the RunPod panel (cloud icon in the toolbar) to deploy or connect one first.");
+      }
+      runpodBtn.disabled = true;
+      runBtn.disabled = true;
+      try {
+        status.textContent = "Preparing…";
+        const values = await collectValues();
+        const dry = await client.run(app.id, values, { dry: true });
+        const patched = dry.prompt;
+        if (!patched) throw new Error("couldn't build the prompt snapshot");
+
+        // Dependency push (best effort, CivitAI-pinned models only).
+        const models = Array.isArray(app.deps?.models) ? app.deps.models : [];
+        const pinned = models.filter((m) => m && m.civitaiVersionId);
+        const unpinned = models.filter((m) => m && !m.civitaiVersionId);
+        const custom = Array.isArray(app.deps?.customNodes) ? app.deps.customNodes : [];
+        for (const m of pinned) {
+          status.textContent = `Pushing model to pod: ${m.name}…`;
+          const res = await callTool("download_civitai_model", {
+            model_version_id: m.civitaiVersionId,
+            target_subfolder: m.targetSubfolder || "checkpoints",
+          });
+          const text = toolText(res);
+          if (res && res.ok === false) throw new Error(`model push failed (${m.name}): ${text}`);
+        }
+
+        status.textContent = "Queueing on pod…";
+        const res = await callTool("enqueue_workflow", {
+          workflow: patched,
+          // The app's inputs ARE the user's choices — never re-roll their seed.
+          disable_random_seed: true,
+        });
+        const text = toolText(res);
+        let promptId = null;
+        try {
+          promptId = JSON.parse(text).prompt_id || null;
+        } catch { /* tool returned prose */ }
+        const notes = [];
+        if (promptId) notes.push(`queued on pod (prompt_id ${promptId})`);
+        else notes.push(text || "queued on pod");
+        if (unpinned.length) notes.push(`⚠ unpinned models the pod must already have: ${unpinned.map((m) => m.name).join(", ")}`);
+        if (custom.length) notes.push(`⚠ custom nodes the pod must already have: ${custom.join(", ")}`);
+        notes.push("Progress: watch ComfyUI's queue — pod history isn't mirrored back here.");
+        status.textContent = notes.join(" · ");
+      } finally {
+        runpodBtn.disabled = false;
+        runBtn.disabled = false;
+      }
+    }
+  }
+
+  function showError(e) {
+    if (closed) return;
+    body.textContent = "";
+    const bar = el("div", "cmcp-apps-toolbar");
+    const back = makeBtn("← My Apps");
+    back.addEventListener("click", () => showGrid().catch(showError));
+    bar.append(back);
+    body.append(bar, el("div", "cmcp-apps-empty", e && e.message ? e.message : String(e)));
+  }
+
+  document.body.appendChild(overlay);
+  showGrid().catch(showError);
+
+  return {
+    close,
+    isOpen: () => !closed,
+    update: () => {},
+    el: overlay,
+  };
+}

--- a/web/js/cmcp-apps-ui.js
+++ b/web/js/cmcp-apps-ui.js
@@ -131,6 +131,10 @@ async function draftFromCanvas(getApp) {
   const inputs = [];
   const outputs = [];
   const seen = new Set();
+  // Imported APP-mode selections are honored on ANY node type — the hint-type
+  // filter only applies to the heuristic fallback. (codex finding: an app-mode
+  // input on a custom node outside the hint set used to vanish silently.)
+  const importedKeys = new Set((imported?.inputs || []).map((i) => `${i.nodeId}.${i.widget}`));
   for (const node of liveNodes) {
     const id = Number(node.id);
     if (!Number.isFinite(id)) continue;
@@ -148,7 +152,8 @@ async function draftFromCanvas(getApp) {
       });
       continue;
     }
-    if (!AppBuilder.INPUT_HINT_TYPES.has(String(node.type || ""))) continue;
+    const nodeHasImported = [...importedKeys].some((k) => Number(k.split(".")[0]) === id);
+    if (!AppBuilder.INPUT_HINT_TYPES.has(String(node.type || "")) && !nodeHasImported) continue;
     const linkDriven = new Set(
       (Array.isArray(node.inputs) ? node.inputs : [])
         .map((inp) => inp && inp.widget && inp.widget.name)
@@ -950,6 +955,21 @@ export function openAppsModal(ctx, opts = {}) {
       try {
         status.textContent = "Preparing…";
         const values = await collectValues();
+        // Image inputs upload to the LOCAL ComfyUI's input/ — the pod can't
+        // see those bytes, so a pod run with an image input would fail on a
+        // missing file. Refuse honestly rather than silently enqueueing a
+        // broken prompt (pod-side media transfer is a follow-up).
+        const imageKeys = new Set(
+          (app.appMode?.inputs || [])
+            .filter((i) => i.kind === "image")
+            .map((i) => `${i.nodeId}.${i.widget}`),
+        );
+        if ([...imageKeys].some((k) => values[k] !== undefined)) {
+          throw new Error(
+            "This app takes an image input, which uploads to the LOCAL ComfyUI — pod runs can't " +
+              "reach those bytes yet. Run it locally, or remove the image input.",
+          );
+        }
         const dry = await client.run(app.id, values, { dry: true });
         const patched = dry.prompt;
         if (!patched) throw new Error("couldn't build the prompt snapshot");

--- a/web/js/cmcp-apps.js
+++ b/web/js/cmcp-apps.js
@@ -1,0 +1,354 @@
+// Micro-Apps service — conversion + manifest logic (pure, unit-testable) and a
+// thin HTTP client for the pack's py/apps_routes.py surface.
+//
+// An "app" = { manifest, workflow(UI) , prompt(API snapshot) , thumbnail } —
+// the snapshot exists because there is NO client-side UI→API converter, so we
+// capture `app.graphToPrompt()` once at conversion time and patch widget
+// values into it per run. Everything here is pure except AppsClient's fetch
+// calls: the graph-touching bits live in cmcp-apps-ui.js, which passes plain
+// JSON (serialize() / graphToPrompt() output) into AppBuilder.
+
+const API_BASE = "/comfyui_mcp_panel/apps";
+
+/** Default registry base URL (the production Worker once deployed; override
+ *  via localStorage `comfyui-mcp.panel.registryUrl` — e.g. a wrangler dev
+ *  instance). Empty = registry features show a configure hint. */
+export const DEFAULT_REGISTRY_URL = "https://cmcp-apps-registry.artokun.workers.dev";
+
+export function registryBaseUrl() {
+  try {
+    const override = localStorage.getItem("comfyui-mcp.panel.registryUrl");
+    if (override && override.trim()) return override.trim().replace(/\/+$/, "");
+  } catch { /* storage blocked */ }
+  return DEFAULT_REGISTRY_URL;
+}
+
+/** This install's creator key (64 hex) — generated once, kept in localStorage.
+ *  The registry stores only sha256(key) as creator_id. */
+export function creatorKey() {
+  return _stableKey("comfyui-mcp.panel.creatorKey", 64);
+}
+
+/** Anonymous star/run identity key — one per install. */
+export function starKey() {
+  return _stableKey("comfyui-mcp.panel.starKey", 36);
+}
+
+function _stableKey(storageKey, len) {
+  let key = null;
+  try {
+    key = localStorage.getItem(storageKey);
+  } catch { /* storage blocked */ }
+  if (key) return key;
+  key = crypto.randomUUID().replace(/-/g, "");
+  if (len === 64) key = key + crypto.randomUUID().replace(/-/g, "");
+  key = key.slice(0, len);
+  try {
+    localStorage.setItem(storageKey, key);
+  } catch { /* storage blocked */ }
+  return key;
+}
+
+/** HTTP client for the Cloudflare registry worker. */
+export class RegistryClient {
+  constructor(base = registryBaseUrl()) {
+    this.base = base;
+  }
+
+  get configured() {
+    return !!this.base;
+  }
+
+  async _req(method, path, body) {
+    const res = await fetch(this.base + path, {
+      method,
+      ...(body !== undefined
+        ? { headers: { "content-type": "application/json" }, body: JSON.stringify(body) }
+        : {}),
+    });
+    let data = null;
+    try {
+      data = await res.json();
+    } catch { /* non-JSON */ }
+    if (!res.ok) throw new Error((data && data.error) || `registry ${res.status}`);
+    return data;
+  }
+
+  list({ sort = "trending", q = "", creator = "", cursor = "", nsfw = false, limit = 24 } = {}) {
+    const p = new URLSearchParams({ sort, limit: String(limit) });
+    if (q) p.set("q", q);
+    if (creator) p.set("creator", creator);
+    if (cursor) p.set("cursor", cursor);
+    if (nsfw) p.set("nsfw", "1");
+    return this._req("GET", `/v1/apps?${p}`);
+  }
+  get(id) {
+    return this._req("GET", `/v1/apps/${id}`);
+  }
+  bundle(id) {
+    return this._req("GET", `/v1/apps/${id}/bundle`);
+  }
+  star(id, on = true) {
+    return this._req("POST", `/v1/apps/${id}/${on ? "star" : "unstar"}`, { star_key: starKey() });
+  }
+  ran(id) {
+    return this._req("POST", `/v1/apps/${id}/ran`, { star_key: starKey() }).catch(() => {});
+  }
+  report(id, reason) {
+    return this._req("POST", `/v1/apps/${id}/report`, { reason });
+  }
+  publish({ app, prompt, workflow, thumbnail_b64, creatorName }) {
+    return this._req("POST", "/v1/apps", {
+      creator_key: creatorKey(),
+      creator_name: creatorName,
+      app,
+      prompt,
+      ...(workflow ? { workflow } : {}),
+      ...(thumbnail_b64 ? { thumbnail_b64 } : {}),
+    });
+  }
+  thumbnailUrl(id) {
+    return `${this.base}/v1/apps/${id}/thumbnail`;
+  }
+}
+
+/** Thin fetch wrapper for the apps routes. Errors throw with the server's
+ *  `error` message when present. */
+export class AppsClient {
+  constructor(base = API_BASE) {
+    this.base = base;
+  }
+
+  async _req(method, path, body) {
+    const res = await fetch(this.base + path, {
+      method,
+      ...(body !== undefined
+        ? { headers: { "content-type": "application/json" }, body: JSON.stringify(body) }
+        : {}),
+    });
+    let data = null;
+    try {
+      data = await res.json();
+    } catch {
+      /* non-JSON (e.g. proxy error page) — fall through to status error */
+    }
+    if (!res.ok) {
+      throw new Error((data && data.error) || `apps API ${res.status}`);
+    }
+    return data;
+  }
+
+  list() {
+    return this._req("GET", "").then((d) => d.apps || []);
+  }
+  get(id) {
+    return this._req("GET", `/${id}`);
+  }
+  bundle(id) {
+    return this._req("GET", `/${id}/bundle`);
+  }
+  create(bundle) {
+    return this._req("POST", "", bundle);
+  }
+  update(id, patch) {
+    return this._req("PUT", `/${id}`, patch);
+  }
+  remove(id) {
+    return this._req("DELETE", `/${id}`);
+  }
+  run(id, values, { dry = false } = {}) {
+    return this._req("POST", `/${id}/run`, { values, ...(dry ? { dry: true } : {}) });
+  }
+  runStatus(id, promptId) {
+    return this._req("GET", `/${id}/runs/${promptId}`);
+  }
+  thumbnailUrl(id) {
+    return `${this.base}/${id}/thumbnail`;
+  }
+}
+
+export class AppBuilder {
+  /** Candidate locations for the ComfyUI frontend's APP-mode config inside a
+   *  saved workflow JSON. The exact key shipped with frontend ≥1.41.13; we
+   *  probe defensively (extra.* first, then top-level) so older/newer
+   *  frontends keep importing. Each entry is a path array. */
+  static APP_MODE_PATHS = [
+    ["extra", "appMode"],
+    ["extra", "app_mode"],
+    ["extra", "apps"],
+    ["appMode"],
+    ["app_mode"],
+    ["apps"],
+  ];
+
+  /** Find + normalize the frontend APP-mode config in a saved UI workflow.
+   *  Returns { inputs, outputs } in OUR shape (nodeId numbers), or null when
+   *  the workflow was never app-mode-configured. Tolerant of the frontend's
+   *  exact item shape — node ids may arrive as strings, widget as name/key. */
+  static findAppModeConfig(workflow) {
+    if (!workflow || typeof workflow !== "object") return null;
+    for (const path of AppBuilder.APP_MODE_PATHS) {
+      let cur = workflow;
+      for (const key of path) {
+        cur = cur && typeof cur === "object" ? cur[key] : undefined;
+      }
+      const cfg = AppBuilder._normalizeAppMode(cur);
+      if (cfg) return cfg;
+    }
+    return null;
+  }
+
+  static _normalizeAppMode(raw) {
+    if (!raw || typeof raw !== "object") return null;
+    const rawInputs = raw.inputs ?? raw.parameters ?? raw.exposedInputs;
+    const rawOutputs = raw.outputs ?? raw.exposedOutputs;
+    if (!Array.isArray(rawInputs) && !Array.isArray(rawOutputs)) return null;
+    const num = (v) => {
+      const n = Number(v);
+      return Number.isFinite(n) ? n : null;
+    };
+    const inputs = (Array.isArray(rawInputs) ? rawInputs : [])
+      .map((it) => {
+        if (!it || typeof it !== "object") return null;
+        const nodeId = num(it.nodeId ?? it.node_id ?? it.id);
+        const widget = String(it.widget ?? it.name ?? it.key ?? "").trim();
+        if (nodeId == null || !widget) return null;
+        return {
+          nodeId,
+          widget,
+          label: String(it.label ?? it.title ?? widget),
+          kind: String(it.kind ?? it.type ?? "text"),
+        };
+      })
+      .filter(Boolean);
+    const outputs = (Array.isArray(rawOutputs) ? rawOutputs : [])
+      .map((it) => {
+        if (!it || typeof it !== "object") return null;
+        const nodeId = num(it.nodeId ?? it.node_id ?? it.id);
+        if (nodeId == null) return null;
+        return { nodeId, kind: String(it.kind ?? it.type ?? "images") };
+      })
+      .filter(Boolean);
+    if (!inputs.length && !outputs.length) return null;
+    return { inputs, outputs, importedFromFrontend: true };
+  }
+
+  /** Node types whose widgets are natural app INPUTS by default (mirrors what
+   *  the frontend APP builder highlights: prompt text, images, models,
+   *  primitives, seeds/steps-samplers). */
+  static INPUT_HINT_TYPES = new Set([
+    "CLIPTextEncode",
+    "LoadImage",
+    "LoadImageMask",
+    "CheckpointLoaderSimple",
+    "CheckpointLoader",
+    "LoraLoader",
+    "VAELoader",
+    "UNETLoader",
+    "CLIPLoader",
+    "ControlNetLoader",
+    "UpscaleModelLoader",
+    "PrimitiveNode",
+    "PrimitiveInt",
+    "PrimitiveFloat",
+    "PrimitiveString",
+    "KSampler",
+    "KSamplerAdvanced",
+    "SamplerCustom",
+  ]);
+
+  /** Widget value → app input kind. `nodeType` refines (LoadImage → image
+   *  upload; *Loader → model picker). */
+  static classifyWidget(nodeType, widgetName, value) {
+    const t = String(nodeType || "");
+    if (/loadimage/i.test(t)) return "image";
+    if (/loader/i.test(t) || /_name$/i.test(widgetName)) return "model";
+    if (typeof value === "number") return "number";
+    if (typeof value === "boolean") return "toggle";
+    if (Array.isArray(value)) return "combo";
+    return "text";
+  }
+
+  /** Heuristic app definition for a workflow with NO frontend app-mode config:
+   *  inputs = widgets of hint-type nodes that aren't link-driven; outputs =
+   *  output nodes (Save…/Preview…). `nodes` are litegraph-serialized nodes
+   *  (id/type/widgets_values/inputs). Returns the same shape as
+   *  findAppModeConfig (minus importedFromFrontend). */
+  static heuristicAppMode(nodes) {
+    const inputs = [];
+    const outputs = [];
+    for (const node of Array.isArray(nodes) ? nodes : []) {
+      if (!node || typeof node !== "object") continue;
+      const id = Number(node.id);
+      if (!Number.isFinite(id)) continue;
+      const type = String(node.type || "");
+      const isOutput =
+        node.constructor?.nodeData?.output_node === true ||
+        /^(SaveImage|PreviewImage|SaveVideo|SaveAudio|PreviewAudio|ShowText|PreviewAsText)/.test(
+          type,
+        );
+      if (isOutput) {
+        outputs.push({ nodeId: id, kind: /^Show|^PreviewAs/.test(type) ? "text" : "images" });
+        continue;
+      }
+      if (!AppBuilder.INPUT_HINT_TYPES.has(type)) continue;
+      const values = Array.isArray(node.widgets_values) ? node.widgets_values : [];
+      // widgets_values aligns positionally with the node's widget list; with
+      // only serialized JSON we lack widget NAMES — the UI layer enriches from
+      // live node defs. Here we record positional candidates; `widget` gets
+      // resolved to a real name by enrichInputs() in the UI when the live
+      // graph is available, and left as the positional index otherwise.
+      values.forEach((v, i) => {
+        if (v === null || v === undefined) return;
+        if (typeof v === "object" && !Array.isArray(v)) return; // link marker
+        inputs.push({
+          nodeId: id,
+          widget: String(i),
+          label: `${type} #${id} · ${i}`,
+          kind: AppBuilder.classifyWidget(type, "", v),
+          positional: true,
+        });
+      });
+    }
+    return { inputs, outputs, importedFromFrontend: false };
+  }
+
+  /** Dependency scan over an API-format prompt. `knownTypes` = class_types
+   *  ComfyUI already has (pass the live def keys; empty set → everything
+   *  non-core is reported). Models = loader widget values. */
+  static depsFromPrompt(prompt, knownTypes = new Set()) {
+    const models = [];
+    const customNodes = new Set();
+    for (const node of Object.values(prompt || {})) {
+      if (!node || typeof node !== "object") continue;
+      const ct = String(node.class_type || "");
+      if (ct && !knownTypes.has(ct)) customNodes.add(ct);
+      if (/loader/i.test(ct)) {
+        for (const [k, v] of Object.entries(node.inputs || {})) {
+          if (typeof v === "string" && /(_name|ckpt|model)/i.test(k) && v) {
+            models.push({ name: v, nodeType: ct, widget: k });
+          }
+        }
+      }
+    }
+    return { models, customNodes: [...customNodes] };
+  }
+
+  /** Assemble the manifest object the server expects (see py/apps_routes.py
+   *  _sanitize_manifest). `id` comes from crypto.randomUUID(). */
+  static buildManifest({ id, name, description = "", appMode, hideWorkflow = false, source, deps }) {
+    if (!id) throw new Error("buildManifest: id required");
+    if (!name || !String(name).trim()) throw new Error("buildManifest: name required");
+    return {
+      id,
+      name: String(name).trim(),
+      description: String(description || ""),
+      version: 1,
+      source: source || { type: "canvas", workflowUuid: null, registryId: null },
+      appMode: appMode || { inputs: [], outputs: [], importedFromFrontend: false },
+      hideWorkflow: !!hideWorkflow,
+      deps: deps || { models: [], customNodes: [] },
+      published: null,
+    };
+  }
+}

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -75,6 +75,7 @@ import {
 import { validateA2UISpec, renderA2UICard, renderA2UIInert, renderA2UIFailCard, A2UI_CSS } from "./cmcp-a2ui.js";
 import { openCivitaiModal } from "./cmcp-civitai-ui.js";
 import { openRunpodModal } from "./cmcp-runpod-ui.js";
+import { openAppsModal } from "./cmcp-apps-ui.js";
 import { openTrainingModal } from "./cmcp-training-ui.js";
 
 let app = null;
@@ -10044,6 +10045,48 @@ function buildPanel() {
     civitaiBtn.prepend(svg);
   }
 
+  // Apps — the micro-app layer: convert the canvas workflow (or an existing
+  // ComfyUI APP-mode config) into a named, one-click app; runs headless via
+  // the pack's py/apps_routes.py (canvas never touched). Grid of four rounded
+  // squares (mini-app launcher mark), currentColor like the neighbors.
+  let _appsHandle = null;
+  function openApps(opts) {
+    try { _appsHandle?.close(); } catch {}
+    const handle = openAppsModal(
+      {
+        getApp: () => app,
+        uploadBlobToInput,
+        callTool: (t, a, o) => liveBridgeClient?.callTool(t, a, o),
+        getRunpodTarget: () => _comfyuiTarget,
+      },
+      {
+        ...(opts || {}),
+        onClose: () => { if (_appsHandle === handle) _appsHandle = null; },
+      },
+    );
+    _appsHandle = handle;
+    return _appsHandle;
+  }
+  const appsBtn = toolbarBtn("pi-circle", "Apps");
+  appsBtn.querySelector(".pi").remove();
+  appsBtn.title = "Apps — one-click micro-apps built from workflows: convert, run locally or on RunPod, share.";
+  appsBtn.addEventListener("click", () => openApps());
+  {
+    const svgNs = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(svgNs, "svg");
+    svg.setAttribute("viewBox", "0 0 24 24");
+    svg.setAttribute("fill", "currentColor");
+    svg.setAttribute("aria-hidden", "true");
+    // 2x2 grid of rounded squares (mini-app launcher).
+    for (const [x, y] of [[4, 4], [14, 4], [4, 14], [14, 14]]) {
+      const r = document.createElementNS(svgNs, "rect");
+      r.setAttribute("x", String(x)); r.setAttribute("y", String(y));
+      r.setAttribute("width", "6"); r.setAttribute("height", "6"); r.setAttribute("rx", "1.5");
+      svg.append(r);
+    }
+    appsBtn.prepend(svg);
+  }
+
   // LoRA Training — the dataset gather/label/launch/monitor wizard for the
   // local trainer (ai-toolkit in a GPU container, train_* tools over call_tool).
   // Same modal treatment as the CivitAI browser; dumbbell mark via currentColor.
@@ -10170,7 +10213,7 @@ function buildPanel() {
 
   const toolbarSpacer = document.createElement("span");
   toolbarSpacer.className = "cmcp-spacer";
-  toolbar.append(deafenBtn, blindBtn, toolbarSpacer, civitaiBtn, trainingBtn, runpodBtn);
+  toolbar.append(deafenBtn, blindBtn, toolbarSpacer, civitaiBtn, appsBtn, trainingBtn, runpodBtn);
 
   row.append(ring, ctxLabel, modelChip, spacer, attachBtn, micBtn, sendBtn);
   form.append(menuPop, modelPop, attachBar, input, row, fileInput);


### PR DESCRIPTION
## The Apps epic (panel side)

A WeChat-mini-program-style micro-app layer on top of ComfyUI APP mode. Convert any workflow into a named one-click **app** (name, description, thumbnail, chosen input/output endpoints), run it headless locally or on a connected RunPod pod, package it with best-effort hidden workflow, and publish it to a Cloudflare-backed registry with stars/trending/explore — with full parity in the mobile app.

**Sibling PRs:** comfyui-mcp (apps_* bridge tools + mobile whitelist) and comfyui-mcp-mobile (Apps tab + detail/run + Explore). Monetization (hosted runs, per-gen pricing) is design-notes-only — schema hooks reserved (`pricing_json`, `hosted_only`), nothing built. See `docs/design/apps-monetization.md`.

### What's here

- **`py/apps_routes.py`** — bundle storage under `user/comfyui-mcp-panel/apps/<uuid>/` (deliberately NOT the workflows dir, so hidden apps never surface there), CRUD routes, run engine (patch `<nodeId>.<widget>` values into the stored API snapshot → queue), `dry:true` mode for pod runs, `/bundle` export for publish/install.
- **`web/js/cmcp-apps.js`** — `AppBuilder` (defensive ComfyUI APP-mode config import, heuristic input/output selection, widget classification, deps scan), `AppsClient`, `RegistryClient`, creator/star identity keys.
- **`web/js/cmcp-apps-ui.js`** — the Apps modal (toolbar button next to Civitai): My Apps grid, convert flow over the live canvas, generated run form, local run + polling + output gallery, honest hide-workflow toggle (deletes the graph; copy says plainly it's obfuscation, not security), **Run on RunPod** (dry-patch → `enqueue_workflow` on the connected pod; CivitAI-pinned models pushed first, unpinned deps warned not silently skipped), Publish/Update, Explore tab, install with deps-consent dialog, `ran` reporting.
- **`registry/`** — dependency-free Cloudflare Worker (D1 + R2): publish with sha256-keyed creator identity (DB stores only the hash), keyset pagination, trending = 7d stars×3 + runs, star/unstar, run marks (1/app/day), reports. Excluded from the pack via `.comfyignore`.
- **Tests** — 9 node unit + 11 python unit + 7 registry integration (real handler over `node:sqlite` fake D1 + Map R2) + 6 Playwright specs (convert/run/hide/pod-run/no-pod/publish/explore-install). All green; `tsc` clean.

### Not in this PR / needs follow-up

- ComfyUI restart required to register the new routes (dev instance predates them).
- Registry deploy is manual (`wrangler d1 create`, R2 bucket, migration); default URL is a placeholder, overridable via localStorage `comfyui-mcp.panel.registryUrl`.
- Pod runs are mocked-bridge e2e, not a real pod.
- No merge/release per maintainer — awaiting codex:rescue review.