### PR TITLE
fix(panel): stop a heartbeat slamming the settings dropdown shut

### DIFF
--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11647,11 +11647,26 @@ function buildPanel() {
   // In-flight Remote-control pairing request: the open modal registers a handler
   // here; the `pair_url`/`pair_error` reply consumes it (mirrors pendingSetSecret).
   let pendingPair = null;
+  // Last status this panel reconciled the settings box against, so a repeated
+  // "connected" emission cannot re-close a box the user just opened.
+  let settingsStatusApplied = null;
   const client = createBridgeClient({
     onStatus(state) {
       statusText.textContent = state;
       dot.className = "cmcp-dot" + (state === "connected" ? " connected" : state === "connecting" ? " connecting" : "");
-      settingsBox.hidden = state !== "disconnected";
+      // Reconcile the settings box only when the status actually CHANGED.
+      // The bridge re-emits "connected" repeatedly on purpose — its dedupe
+      // guard exempts that state (`s === lastStatus && s !== "connected"`) so
+      // connected-state side effects re-apply. Deriving visibility on every
+      // emission therefore slammed this box shut a moment after the user
+      // opened it: click the status chip while connected, and the next tick
+      // re-hid it. That is the "dropdown flashes open then closes, can't
+      // reach Disconnect" report — the box was being closed by a heartbeat,
+      // not by the click-outside handler.
+      if (state !== settingsStatusApplied) {
+        settingsStatusApplied = state;
+        settingsBox.hidden = state !== "disconnected";
+      }
       const connected = state === "connected";
       connectBtn.hidden = connected;
       disconnectBtn.hidden = !connected;


### PR DESCRIPTION
Reported by **bourbon.420** in Discord:

> clicking on the drop-down menu to try and disconnect only flashes it open then
> quickly closed, making the user unable to actually view/use anything in the drop down

## Cause

Not the click-outside handler — that one correctly exempts the trigger element.
It's two individually reasonable lines interacting:

1. The bridge's status dedupe **deliberately exempts `"connected"`**, so that
   state re-emits on every tick:
   ```js
   if (s === lastStatus && s !== "connected") return;   // ~:6804
   ```
   That exemption is intentional — connected-state side effects need to re-apply.

2. `onStatus` re-derived the box's visibility on **every** emission:
   ```js
   settingsBox.hidden = state !== "disconnected";       // ~:11654
   ```

So while connected, every repeated `"connected"` emission re-hid the box. You
click the status chip, a heartbeat lands, it closes. From the outside that's
indistinguishable from a broken menu — and since Disconnect lives in there, it
made disconnecting unreachable from the UI.

## Fix

Reconcile the box only when the status actually **changes**:

- transition → `disconnected` still reveals it
- transition → `connected` still hides it
- a repeated emission no longer clobbers a box the user opened deliberately

Side benefit: dismissing it manually while disconnected now sticks, instead of
reappearing on the next tick.

## Verification

Unit suite **95 pass**, ESM parse clean.

Worth being straight about the limit of that: this is a timing bug between a
heartbeat and a click, and the unit suite doesn't cover panel DOM behaviour, so
those 95 tests don't actually exercise it. The reasoning above is from reading
both call sites, and the change is conservative — it only removes a redundant
re-application. A quick manual check (connect, click the status chip, wait a few
seconds) would confirm it properly, and I can run that in a live ComfyUI if you
want it verified before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)