### PR TITLE
fix(panel): keep the model chip on one line at any panel width

### DIFF
--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7974,12 +7974,28 @@ const PANEL_CSS = `
   box-shadow: 0 0 0 2px var(--p-surface-900, #18181b);
   pointer-events: none; z-index: 5;
 }
+/* Model chip (composer). Stays on ONE line at every panel width: a wrapped
+   chip pushed the composer row taller and shoved the send/mic buttons around,
+   and the only way to get it back on one line was to widen the panel until it
+   ate the canvas. The model NAME truncates with an ellipsis instead; the
+   effort suffix and caret never shrink, so "which model + which effort" stays
+   readable even when the name is clipped, and the full value is in the title. */
 .cmcp-chip {
   display: flex; align-items: center; gap: 0.25rem;
   border: none; background: transparent; cursor: pointer;
   color: var(--p-text-muted-color, #a1a1aa); font: inherit; font-size: 0.6875rem;
   padding: 0.125rem 0.375rem; border-radius: var(--p-border-radius-sm, 4px);
+  white-space: nowrap; min-width: 0; overflow: hidden; flex: 0 1 auto;
 }
+/* The NAME keeps a floor so it never truncates to nothing — at very narrow
+   widths an unfloored ellipsis ate the whole model name and left a bare
+   "· medium", which tells you the least useful half. The effort suffix yields
+   first instead: "which model" matters more than "which effort", and the full
+   value is on the chip's title either way. The caret never shrinks, so the
+   dropdown affordance survives at any width. */
+.cmcp-chip .name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 4.5ch; }
+.cmcp-chip .dim { overflow: hidden; text-overflow: ellipsis; min-width: 0; flex: 0 1 auto; }
+.cmcp-chip .pi-angle-down { flex: 0 0 auto; }
 .cmcp-chip:hover { background: var(--p-surface-700, #3f3f46); }
 /* Attachment chip strip (composer): viewable/expandable pasted text + files. */
 .cmcp-attachbar { display: flex; flex-direction: column; gap: 0.25rem; padding: 0.25rem 0.25rem 0; }
@@ -9427,8 +9443,11 @@ function buildPanel() {
   const modelChip = document.createElement("button");
   modelChip.type = "button";
   modelChip.className = "cmcp-chip";
+  // Initial title only — refreshModelChip() replaces it with the live model and
+  // effort, since the name can be ellipsised at narrow widths.
   modelChip.title = "Model & reasoning effort for the background agent";
   const modelChipLabel = document.createElement("span");
+  modelChipLabel.className = "name";
   const modelChipEffort = document.createElement("span");
   modelChipEffort.className = "dim";
   const modelChipCaret = document.createElement("i");
@@ -9436,8 +9455,15 @@ function buildPanel() {
   modelChip.append(modelChipLabel, modelChipEffort, modelChipCaret);
 
   function refreshModelChip() {
-    modelChipLabel.textContent = prefs.modelAuto ? "Auto" : modelLabel(modelCatalog, prefs.model);
+    const name = prefs.modelAuto ? "Auto" : modelLabel(modelCatalog, prefs.model);
+    modelChipLabel.textContent = name;
     modelChipEffort.textContent = prefs.effort ? ` · ${prefs.effort}` : "";
+    // The name ellipsises in a narrow panel, so the hover has to carry the full
+    // value — otherwise a truncated model id is unrecoverable without widening
+    // the panel, which is the thing we're avoiding.
+    modelChip.title =
+      `Model: ${name}${prefs.effort ? ` · effort: ${prefs.effort}` : ""}` +
+      "\nModel & reasoning effort for the background agent";
   }
 
   // Reconcile the ComfyUI Settings defaults with the panel's localStorage runtime.


### PR DESCRIPTION
Reported by **bourbon.420** in Discord:

> When showing which model is loaded/chosen from the drop down. Have it be single
> line. It'll go single line if I stretch the side panel far enough, but then I'm
> losing almost half of my viewport for the canvas.

## Cause

The chip lives in the composer flex row alongside attach/mic/send and had **no
wrapping rules at all**. Squeezed, it broke across two lines — which also pushed
the row taller and shifted the buttons around.

## Fix

One line always; the model **name** ellipsises instead.

The priority is deliberate. My first pass let the name shrink freely, and at
narrow widths it truncated to **nothing**, leaving a bare `· medium` — the least
useful half of the label. So:

- **name** keeps a `4.5ch` floor and always shows something
- **effort suffix** yields first (`which model` beats `which effort`)
- **caret** never shrinks, so the dropdown affordance survives at any width
- the chip's **title** now carries the full model + effort, since a truncated
  model id is otherwise unrecoverable without widening the panel — the exact
  thing being avoided

Scoped: `.cmcp-chip` is used by this chip and nothing else, so no other control
changes.

## Verification

Rendered the **real rules** against the **real composer row** at 130 / 160 / 200 /
240 / 300px, with both short (`GPT-5.6-Sol`) and long
(`claude-opus-4-8-20260101-preview-long`, `Qwen2.5-Coder-32B-Instruct-AWQ`) names:

| width | single line | name visible | caret | overflows row |
|---|---|---|---|---|
| 300 | ✅ | 57px | ✅ | no |
| 240 | ✅ | 117px | ✅ | no |
| 200 | ✅ | 89px | ✅ | no |
| 160 | ✅ | 56px | ✅ | no |
| 130 | ✅ | 32px | ✅ | no |

Chip height is a flat 19px at every width (was 37px and 52px when wrapping).
Unit suite **95 pass**, parse clean.

Worth noting how the floor was found: an earlier run of this harness reported
everything passing when the stylesheet had silently 404'd, so the rules under
test were never applied and short names merely *happened* to fit. Re-running with
the CSS actually attached is what surfaced both the long-name wrap and the
truncate-to-nothing case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)