### PR TITLE
fix(ci): unblock the Bandit gate — main has been red since the micro-apps merge

### DIFF
--- a/browser_tests/unit/test_apps_routes.py
+++ b/browser_tests/unit/test_apps_routes.py
@@ -8,6 +8,7 @@ Dev-only. Run from the repo root:
 
 import os
 import sys
+import tempfile
 import unittest
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "py"))
@@ -19,12 +20,12 @@ UUID = "123e4567-e89b-42d3-a456-426614174000"
 
 class BundleDir(unittest.TestCase):
     def test_uuid_contained(self):
-        root = os.path.realpath("/tmp/apps-root")
+        root = os.path.realpath(os.path.join(tempfile.gettempdir(), "apps-root"))
         path = ar._bundle_dir(root, UUID)
         self.assertTrue(path.startswith(root + os.sep), path)
 
     def test_non_uuid_rejected(self):
-        root = os.path.realpath("/tmp/apps-root")
+        root = os.path.realpath(os.path.join(tempfile.gettempdir(), "apps-root"))
         for bad in ("", "..", "../etc", "not-a-uuid", UUID + "/..", None, UUID.upper() + "x"):
             with self.assertRaises(ValueError, msg=repr(bad)):
                 ar._bundle_dir(root, bad)

--- a/py/apps_routes.py
+++ b/py/apps_routes.py
@@ -223,7 +223,7 @@ def _self_base_url() -> str:
 
     inst = PromptServer.instance
     addr = getattr(inst, "address", "127.0.0.1") or "127.0.0.1"
-    if addr in ("0.0.0.0", "::"):
+    if addr in ("0.0.0.0", "::"):  # nosec B104 — DETECTS a wildcard bind to replace it with loopback; nothing binds here
         addr = "127.0.0.1"
     if ":" in addr and not addr.startswith("["):
         # IPv6 literal (e.g. --listen ::1) — URLs need [::1] bracket form.


### PR DESCRIPTION
**main has been failing CI since `9264a65c` (micro-apps)**, so every panel PR
opened since inherits the failure — including #120 and #121.

There's a worse consequence than a red badge. The Bandit step runs **before** the
YARA and pyproject checks, so those three have been **skipped** on every run
since:

```
8.  Security scan (Bandit)                 = failure
9.  Security scan (YARA SUSP_SVG)          = skipped
10. Security scan (YARA exec literals)     = skipped
11. pyproject valid + JS version matches   = skipped
```

The registry-parity gate hasn't been *enforced* at all for the last several
merges, not merely reported red. Worth knowing given how much the registry
review depends on it.

## Two findings, both false positives — fixed at source, not suppressed wholesale

**`B108 hardcoded_tmp_directory`** — `test_apps_routes.py` used a literal
`"/tmp/apps-root"`. That path is never created or written; the tests only
exercise string containment in `_bundle_dir`. Now `tempfile.gettempdir()`, which
has the side benefit of making the test correct on **Windows**, where `/tmp`
doesn't exist.

**`B104 hardcoded_bind_all_interfaces`** — `apps_routes.py:226` compares against
`"0.0.0.0"`/`"::"` **in order to replace a wildcard bind with loopback**. The line
is the mitigation, not the risk, and nothing binds there. Marked `# nosec B104`
with a reason, matching the existing convention in `test_civitai_proxy.py:70`.

I used `nosec` only for the one that is genuinely un-fixable-by-rewriting; the
other got a real fix.

## Verification

Ran the **exact CI invocation**:

```
$ bandit -r . -s B101,B112,B311
No issues identified.
$ echo $?
0
```

Plus: 12 apps-routes unit tests pass, `apps_routes.py` parses.

Merging this first turns the other open panel PRs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)