### PR TITLE
chore(release): comfyui-agent-panel 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,62 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-07-22
+
+### Added
+- **Micro-apps — turn a workflow into a one-click app.** A WeChat-mini-program-style
+  layer over ComfyUI APP mode, with panel and mobile parity. App bundles live under
+  `user/comfyui-mcp-panel/apps/` (manifest + UI workflow + API prompt snapshot +
+  thumbnail); the run engine patches `<nodeId>.<widget>` into the snapshot and queues
+  it. Includes the AppBuilder (APP-mode config import, heuristic input/output
+  selection, dependency scan), a My Apps grid with a generated run form and output
+  gallery, **Run on RunPod** (dry-patch, then enqueue on the connected pod with
+  pinned deps pushed first), and a Publish / Explore registry with trending, new,
+  stars, search and install. (#114)
+- **Hover a truncated label to read the rest of it.** An ellipsis hides the END of a
+  string, which is usually the identifying part — a quantisation suffix, an Ollama
+  size tag, a date. Hovering a clipped element now scrolls it to its end and hovering
+  away restores the truncation. Delegated from the panel root, so it covers popover
+  rows, the model chip, download and attachment names, pending text and card text —
+  including elements rendered later. Honours `prefers-reduced-motion`. (#120)
+
+### Fixed
+- **The settings dropdown no longer closes itself.** Connection status drove the
+  visibility of that box, and the bridge re-emits `connected` on every handshake
+  frame — so opening the menu while connected got it slammed shut by the next tick,
+  putting **Disconnect out of reach entirely**. Status no longer owns that
+  visibility: the dropdown opens and closes on user intent only (trigger, click-away,
+  Escape, or API Keys). Escape-to-close is new — the box never had a keyboard
+  dismissal. (#116, #117)
+- **The model chip stays on one line at any panel width.** It had no wrapping rules,
+  so a squeezed chip broke across two lines and pushed the composer row taller. The
+  model name now ellipsises instead, keeping a floor so it never truncates to
+  nothing, with the effort suffix yielding first and the full value on the title of
+  the chip. (#118)
+- **A reboot behind a proxy is no longer reported as a failure.** When ComfyUI is
+  reached through a reverse proxy or Cloudflare tunnel, killing the origin returns a
+  gateway error rather than dropping the connection, so a reboot that actually FIRED
+  was misreported and remote agents concluded "restart failed". 502/503/504 are now
+  classified exactly like the connection-drop success branch. (#119)
+
+### Security
+- **Bridge auth tokens are no longer printed to the panel log.** Three status lines
+  echoed the full bridge URL including `token=<64 hex chars>`; those lines get
+  screenshotted into bug reports and pasted into chats. Only the first four
+  characters now survive. The same change wraps long status lines
+  (`overflow-wrap: anywhere`), since an unbreakable 64-char token was also forcing a
+  horizontal scrollbar across the whole log. (#121)
+
+### Internal
+- **CI actually runs again.** The Bandit step had been failing since the micro-apps
+  merge, and because it runs before the YARA and pyproject checks, those three were
+  being **skipped** on every run — the registry-parity gate was not being enforced,
+  not merely reported red. Both findings were false positives: a test used a literal
+  `/tmp` path (now `tempfile.gettempdir()`, which also fixes the test on Windows),
+  and a wildcard-bind comparison that exists precisely to rewrite the bind to
+  loopback is marked `# nosec` with a reason. (#122)
+
+
 ## [0.10.0] - 2026-07-22
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.10.0"
+version = "0.11.0"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -106,7 +106,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.10.0";
+const PANEL_VERSION = "0.11.0";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Cuts **0.11.0**. Minor rather than patch — this carries features (#114 micro-apps,
#120 hover-to-reveal), not only fixes.

Merging this changes `pyproject.toml`, which is what triggers `publish_action.yml`
→ Comfy Registry.

## What's in it

**Added**
- **Micro-apps** — convert a workflow into a one-click app with a real form; run
  locally or on a connected pod; publish to and install from a public registry. (#114)
- **Hover a truncated label to read the rest of it** — the ellipsis hides the end of
  a string, which is usually the identifying part (quantisation suffix, Ollama size
  tag). Honours `prefers-reduced-motion`. (#120)

**Fixed**
- **The settings dropdown no longer closes itself.** Connection status drove its
  visibility and the bridge re-emits `connected` on every handshake frame, so the
  menu was slammed shut by the next tick — putting **Disconnect out of reach
  entirely**. Status no longer owns that visibility; Escape-to-close is new. (#116, #117)
- **Model chip stays on one line** at any panel width, ellipsising the name with a
  floor so it never truncates to nothing. (#118)
- **A reboot behind a proxy isn't reported as a failure** — 502/503/504 now classify
  like the connection-drop success branch, so remote agents stop concluding
  "restart failed" after a reboot that actually fired. (#119)

**Security**
- **Bridge auth tokens are no longer printed to the panel log.** Those lines get
  screenshotted into bug reports; only the first four characters survive now. The
  same change wraps long status lines, which is what was forcing a horizontal
  scrollbar across the log. (#121)

**Internal**
- **CI actually runs again.** Bandit had failed since the micro-apps merge, and since
  it runs first, the YARA and pyproject checks were **skipped** on every run — the
  registry-parity gate wasn't being enforced, merely reported red. (#122)

## Verification

- `pyproject.toml` and `PANEL_VERSION` both at **0.11.0** (CI fails if they drift)
- Unit suite **104 pass**, ESM parse clean
- Changelog written from the actual commit bodies

🤖 Generated with [Claude Code](https://claude.com/claude-code)