### PR TITLE
feat(apps): transfer image inputs to the pod before RunPod runs

### DIFF
--- a/browser_tests/apps.spec.ts
+++ b/browser_tests/apps.spec.ts
@@ -288,7 +288,10 @@ test('run on RunPod: dry-patches locally, enqueues on the pod via the bridge', a
       version: 1,
       hideWorkflow: false,
       appMode: {
-        inputs: [{ nodeId: 6, widget: 'text', label: 'Prompt', kind: 'text', default: 'a cat' }],
+        inputs: [
+          { nodeId: 6, widget: 'text', label: 'Prompt', kind: 'text', default: 'a cat' },
+          { nodeId: 5, widget: 'image', label: 'Face', kind: 'image' }
+        ],
         outputs: [],
         importedFromFrontend: false
       },
@@ -296,12 +299,27 @@ test('run on RunPod: dry-patches locally, enqueues on the pod via the bridge', a
       published: null
     },
     workflow: FIXTURE_WORKFLOW,
-    prompt: FIXTURE_PROMPT
+    prompt: {
+      ...FIXTURE_PROMPT,
+      '5': { class_type: 'LoadImage', inputs: { image: 'placeholder.png' } }
+    }
   })
 
   // Answer the bridge's whitelisted call_tool surface: capture enqueue_workflow.
   const toolCalls: { tool: string; args: Record<string, unknown> }[] = []
+  const uploads: { filename: string; mime: string }[] = []
   mockBridge.onFrame((frame) => {
+    if (frame.type === 'upload_media') {
+      uploads.push({ filename: String(frame.filename), mime: String(frame.mime) })
+      mockBridge.send({
+        type: 'media_uploaded',
+        cid: frame.cid,
+        ok: true,
+        name: 'pod_img_00001.png',
+        kind: 'image'
+      })
+      return
+    }
     if (frame.type !== 'call_tool') return
     toolCalls.push({ tool: String(frame.tool), args: (frame.args || {}) as Record<string, unknown> })
     mockBridge.send({
@@ -325,13 +343,22 @@ test('run on RunPod: dry-patches locally, enqueues on the pod via the bridge', a
   const modal = page.locator('.cmcp-apps-modal')
   await modal.locator('.cmcp-app-card', { hasText: 'Pod App' }).click()
   await modal.locator('.cmcp-apps-field textarea').first().fill('a pod dog')
+  // Image input: the bytes must go THROUGH THE BRIDGE to the pod, and the
+  // patched prompt must carry the pod-side filename.
+  await modal.locator('input[type=file]').setInputFiles({
+    name: 'face.png',
+    mimeType: 'image/png',
+    buffer: PIXEL
+  })
   await modal.getByRole('button', { name: '☁ Run on RunPod' }).click()
 
   await expect(modal.locator('.cmcp-apps-status')).toContainText('queued on pod (prompt_id pod-1)')
+  expect(uploads).toEqual([{ filename: 'face.png', mime: 'image/png' }])
   const enqueue = toolCalls.find((c) => c.tool === 'enqueue_workflow')
   expect(enqueue).toBeTruthy()
   const wf = enqueue!.args.workflow as Record<string, { inputs: Record<string, unknown> }>
   expect(wf['6'].inputs.text).toBe('a pod dog')
+  expect(wf['5'].inputs.image).toBe('pod_img_00001.png')
   // App inputs are the user's choices — the seed is never re-rolled.
   expect(enqueue!.args.disable_random_seed).toBe(true)
   // Nothing hit the LOCAL queue path.

--- a/browser_tests/apps.spec.ts
+++ b/browser_tests/apps.spec.ts
@@ -353,7 +353,11 @@ test('run on RunPod: dry-patches locally, enqueues on the pod via the bridge', a
   await modal.getByRole('button', { name: '☁ Run on RunPod' }).click()
 
   await expect(modal.locator('.cmcp-apps-status')).toContainText('queued on pod (prompt_id pod-1)')
-  expect(uploads).toEqual([{ filename: 'face.png', mime: 'image/png' }])
+  // The remote name is uniquified (app prefix + random) so same-basename
+  // inputs can never overwrite each other on the pod.
+  expect(uploads).toHaveLength(1)
+  expect(uploads[0].mime).toBe('image/png')
+  expect(uploads[0].filename).toMatch(/^cmcp-app-123e4567-[0-9a-f]{8}-face\.png$/)
   const enqueue = toolCalls.find((c) => c.tool === 'enqueue_workflow')
   expect(enqueue).toBeTruthy()
   const wf = enqueue!.args.workflow as Record<string, { inputs: Record<string, unknown> }>

--- a/browser_tests/fixtures/PanelPage.ts
+++ b/browser_tests/fixtures/PanelPage.ts
@@ -199,6 +199,10 @@ export class PanelPage {
       await this.reconnectButton.click()
     }
     await this.waitForStatus('connected')
+    // The connection popover stays open after Connect (dropdown semantics from
+    // #116/#117) and covers the toolbar — dismiss it so tests can click on.
+    await this.page.keyboard.press('Escape')
+    await this.connectionPopover.waitFor({ state: 'hidden' }).catch(() => {})
   }
 
   async openConnectionSettings(): Promise<void> {

--- a/registry/wrangler.toml
+++ b/registry/wrangler.toml
@@ -2,13 +2,13 @@ name = "cmcp-apps-registry"
 main = "src/worker.js"
 compatibility_date = "2026-01-01"
 
-# D1 database — create with:  wrangler d1 create cmcp-apps-registry
-# then paste the database_id below and run:
-#   wrangler d1 execute cmcp-apps-registry --file migrations/0001_init.sql
+# D1 database — created 2026-07-22 (region WNAM).
+# Migration applied via:
+#   wrangler d1 execute cmcp-apps-registry --remote --file migrations/0001_init.sql
 [[d1_databases]]
 binding = "DB"
 database_name = "cmcp-apps-registry"
-database_id = "REPLACE_ME"
+database_id = "f5d56b93-fc8a-4bb1-9098-9c52abcc0acb"
 
 # R2 bucket — create with:  wrangler r2 bucket create cmcp-app-bundles
 [[r2_buckets]]

--- a/web/js/cmcp-apps-ui.js
+++ b/web/js/cmcp-apps-ui.js
@@ -6,6 +6,9 @@
 // ctx (from the panel monolith):
 //   getApp()           — the live ComfyUI app object (graph, graphToPrompt)
 //   uploadBlobToInput  — (blob, name) => Promise<{filename, subfolder, type}|null>
+//                        (LOCAL ComfyUI /upload/image — the local run path)
+//   uploadMedia        — (blob, name) => Promise<media_uploaded frame> over the
+//                        bridge; writes to the CONNECTED ComfyUI (pod) input/
 //   callTool           — (tool, args, opts) => Promise<tool_result> (P2: RunPod)
 //   getRunpodTarget    — () => last comfyui_target frame (P2: honest host)
 //
@@ -682,17 +685,10 @@ export function openAppsModal(ctx, opts = {}) {
         const fileInput = document.createElement("input");
         fileInput.type = "file";
         fileInput.accept = "image/*";
-        const hint = el("span", "cmcp-apps-status");
-        field.append(fileInput, hint);
-        getter = async () => {
-          const f = fileInput.files && fileInput.files[0];
-          if (!f) return undefined;
-          hint.textContent = "Uploading…";
-          const ref = await uploadBlobToInput(f, f.name);
-          if (!ref) throw new Error("image upload failed");
-          hint.textContent = "";
-          return ref.subfolder ? `${ref.subfolder}/${ref.filename}` : ref.filename;
-        };
+        field.append(fileInput);
+        // Return the raw File — the RUN path decides where the bytes go
+        // (local /upload/image, or the bridge's upload_media → the pod).
+        getter = () => (fileInput.files && fileInput.files[0]) || undefined;
       } else if (input.kind === "combo" && Array.isArray(input.choices) && input.choices.length) {
         const sel = document.createElement("select");
         for (const c of input.choices) {
@@ -835,13 +831,40 @@ export function openAppsModal(ctx, opts = {}) {
       await showGrid();
     });
 
-    async function collectValues() {
+    /** Collect form values; image Files are handed to `uploadImage` (the run
+     *  path picks WHERE the bytes go) and replaced by the returned input
+     *  filename. */
+    async function collectValues(uploadImage) {
       const values = {};
       for (const [key, getter] of fieldEls) {
-        const v = await getter();
+        let v = await getter();
+        if (v instanceof File) {
+          if (!uploadImage) continue;
+          v = await uploadImage(v);
+        }
         if (v !== undefined) values[key] = v;
       }
       return values;
+    }
+
+    /** Local image transfer: same-origin /upload/image. */
+    async function uploadImageLocal(f) {
+      status.textContent = "Uploading image…";
+      const ref = await uploadBlobToInput(f, f.name);
+      if (!ref) throw new Error("image upload failed");
+      return ref.subfolder ? `${ref.subfolder}/${ref.filename}` : ref.filename;
+    }
+
+    /** Pod image transfer: the bridge's upload_media handler writes the bytes
+     *  to the CONNECTED ComfyUI's input/ — i.e. the pod when we're on a pod. */
+    async function uploadImageToPod(f) {
+      if (typeof ctx.uploadMedia !== "function") {
+        throw new Error("pod image transfer needs a newer panel bridge — update the orchestrator");
+      }
+      status.textContent = `Transferring ${f.name} to the pod…`;
+      const res = await ctx.uploadMedia(f, f.name);
+      if (!res || res.ok === false) throw new Error((res && res.error) || "pod image transfer failed");
+      return res.name;
     }
 
     async function runApp() {
@@ -851,7 +874,7 @@ export function openAppsModal(ctx, opts = {}) {
       status.textContent = "Queueing…";
       outputs.textContent = "";
       try {
-        const values = await collectValues();
+        const values = await collectValues(uploadImageLocal);
         const res = await client.run(app.id, values);
         const promptId = res.prompt_id;
         if (!promptId) throw new Error("queue returned no prompt_id");
@@ -939,9 +962,11 @@ export function openAppsModal(ctx, opts = {}) {
       status.classList.add("err");
     }));
 
-    /** One-click pod run: the LOCAL apps route dry-patches the snapshot, then
-     *  the orchestrator's enqueue_workflow sends it to the connected pod. Deps
-     *  pinned to a CivitAI version are pushed first (download_civitai_model is
+    /** One-click pod run: image inputs are transferred to the pod through the
+     *  bridge's upload_media handler FIRST (it writes to the connected target),
+     *  then the LOCAL apps route dry-patches the snapshot and the
+     *  orchestrator's enqueue_workflow sends it to the pod. Deps pinned to a
+     *  CivitAI version are pushed first (download_civitai_model is
      *  whitelisted); anything unpinned is reported, not silently skipped. */
     async function runOnPod() {
       status.classList.remove("err");
@@ -954,22 +979,7 @@ export function openAppsModal(ctx, opts = {}) {
       runBtn.disabled = true;
       try {
         status.textContent = "Preparing…";
-        const values = await collectValues();
-        // Image inputs upload to the LOCAL ComfyUI's input/ — the pod can't
-        // see those bytes, so a pod run with an image input would fail on a
-        // missing file. Refuse honestly rather than silently enqueueing a
-        // broken prompt (pod-side media transfer is a follow-up).
-        const imageKeys = new Set(
-          (app.appMode?.inputs || [])
-            .filter((i) => i.kind === "image")
-            .map((i) => `${i.nodeId}.${i.widget}`),
-        );
-        if ([...imageKeys].some((k) => values[k] !== undefined)) {
-          throw new Error(
-            "This app takes an image input, which uploads to the LOCAL ComfyUI — pod runs can't " +
-              "reach those bytes yet. Run it locally, or remove the image input.",
-          );
-        }
+        const values = await collectValues(uploadImageToPod);
         const dry = await client.run(app.id, values, { dry: true });
         const patched = dry.prompt;
         if (!patched) throw new Error("couldn't build the prompt snapshot");

--- a/web/js/cmcp-apps-ui.js
+++ b/web/js/cmcp-apps-ui.js
@@ -856,13 +856,18 @@ export function openAppsModal(ctx, opts = {}) {
     }
 
     /** Pod image transfer: the bridge's upload_media handler writes the bytes
-     *  to the CONNECTED ComfyUI's input/ — i.e. the pod when we're on a pod. */
+     *  to the CONNECTED ComfyUI's input/ — i.e. the pod when we're on a pod.
+     *  The remote name is uniquified per app+input: ComfyUI's /upload/image
+     *  OVERWRITES on name collision, so two inputs sharing a basename (or a
+     *  repeat run with "image.png") would otherwise silently swap in the last
+     *  upload (codex finding). */
     async function uploadImageToPod(f) {
       if (typeof ctx.uploadMedia !== "function") {
         throw new Error("pod image transfer needs a newer panel bridge — update the orchestrator");
       }
+      const unique = `cmcp-app-${app.id.slice(0, 8)}-${crypto.randomUUID().slice(0, 8)}-${f.name}`;
       status.textContent = `Transferring ${f.name} to the pod…`;
-      const res = await ctx.uploadMedia(f, f.name);
+      const res = await ctx.uploadMedia(f, unique);
       if (!res || res.ok === false) throw new Error((res && res.error) || "pod image transfer failed");
       return res.name;
     }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7454,7 +7454,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
         const timer = setTimeout(() => {
           pendingCalls.delete(cid);
           reject(new Error("upload_media timed out"));
-        }, 60000);
+          // Large images over slow pod links legitimately exceed a minute;
+          // the mobile client uses the same 3-minute budget for this frame.
+        }, 180_000);
         pendingCalls.set(cid, { resolve, reject, timer });
         try {
           sock.send(

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7111,6 +7111,16 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
         }
         return;
       }
+      // Reply to a direct uploadMedia() request (cid-correlated).
+      if (msg && msg.type === "media_uploaded" && typeof msg.cid === "string") {
+        const pend = pendingCalls.get(msg.cid);
+        if (pend) {
+          pendingCalls.delete(msg.cid);
+          clearTimeout(pend.timer);
+          pend.resolve(msg);
+        }
+        return;
+      }
       if (msg && msg.type === "say" && typeof msg.text === "string") {
         // `id` reconciles this committed reply with its live streaming preview.
         onSay(msg.text, { id: msg.id, streamed: !!msg.streamed });
@@ -7413,6 +7423,48 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
               cid,
               tool,
               args: args || {},
+            }),
+          );
+        } catch (e) {
+          pendingCalls.delete(cid);
+          clearTimeout(timer);
+          reject(e);
+        }
+      });
+    },
+    /** Upload image bytes to the ComfyUI input/ folder OF THE CURRENT TARGET —
+     *  when the session is connected to a pod, the orchestrator's upload_media
+     *  handler writes the bytes to the POD's input/ (same handler the mobile
+     *  app uses). cid-correlated like callTool; resolves the media_uploaded
+     *  frame { ok, name, kind } or rejects on timeout/socket close. Used by
+     *  the Apps modal to transfer image inputs before a pod run. */
+    async uploadMedia(blob, name) {
+      if (!sock || sock.readyState !== WebSocket.OPEN) {
+        throw new Error("bridge not connected");
+      }
+      const cid = `um-${Date.now()}-${cidSeq++}`;
+      const buf = new Uint8Array(await blob.arrayBuffer());
+      let bin = "";
+      const CHUNK = 0x8000;
+      for (let i = 0; i < buf.length; i += CHUNK) {
+        bin += String.fromCharCode.apply(null, buf.subarray(i, i + CHUNK));
+      }
+      const data_base64 = btoa(bin);
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+          pendingCalls.delete(cid);
+          reject(new Error("upload_media timed out"));
+        }, 60000);
+        pendingCalls.set(cid, { resolve, reject, timer });
+        try {
+          sock.send(
+            JSON.stringify({
+              type: "upload_media",
+              tab_id: workflowTabId(),
+              cid,
+              filename: name || "upload.png",
+              mime: blob.type || "image/png",
+              data_base64,
             }),
           );
         } catch (e) {
@@ -10140,6 +10192,10 @@ function buildPanel() {
         getApp: () => app,
         uploadBlobToInput,
         callTool: (t, a, o) => liveBridgeClient?.callTool(t, a, o),
+        // Pod image transfer for app runs: bytes go through the bridge's
+        // upload_media handler, which writes to the CONNECTED ComfyUI (the
+        // pod when we're on one) — NOT the local /upload/image.
+        uploadMedia: (b, n) => liveBridgeClient?.uploadMedia(b, n),
         getRunpodTarget: () => _comfyuiTarget,
       },
       {


### PR DESCRIPTION
Follow-up to the Apps epic (#114) — removes the honest-refusal guard from the codex round: **pod runs with image inputs now work end to end**.

- The panel bridge client gains `uploadMedia(blob, name)`: the same cid-correlated `upload_media` frame the mobile app uses. The orchestrator's existing handler writes the bytes to the CONNECTED ComfyUI's `input/` — the pod when the session is on a pod — so **no new server surface** (`media_uploaded` replies route into the same pending-call map as `tool_result`).
- The Apps detail form keeps image inputs as raw Files and the run path picks the destination: local runs upload same-origin to `/upload/image` (unchanged); pod runs transfer through the bridge FIRST, then dry-patch with the pod-side filename and enqueue.

**Tests:** pod e2e spec seeds a `LoadImage` input and asserts the bytes go through the bridge and the enqueued prompt carries the pod-side filename; full apps spec 6/6 green against a live ComfyUI serving this branch; 104 unit green; `tsc` clean.

Drive-by fixture fix: `connect()` dismisses the connection popover (main's #116/#117 dropdown semantics leave it open over the toolbar, which was blocking toolbar clicks in every bridge-connecting spec).

Note: verified against a worktree-serving spare ComfyUI instance (the junctioned checkout is on another agent's branch); no real pod run — the pod path is mocked-bridge e2e.