### PR TITLE
fix(agent-drive): civitai_search resolves on dispatch, not on fetch completion (#282)

### DIFF
--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -1930,9 +1930,18 @@ export function openCivitaiModal(ctx, opts = {}) {
     clearTimeout(searchTimer); // cancel the 500ms debounce so it can't double-fire
     syncTabs();
     // FORCE a reload even when the text is unchanged (a re-search is an explicit
-    // agent intent, unlike applySearch's typing-debounce dedupe).
-    await reload({ searching: true });
-    return { tab: state.tab, query: state.query, creator: state.filters.username || null, renderRev: state.renderRev };
+    // agent intent, unlike applySearch's typing-debounce dedupe) — but resolve on
+    // DISPATCH, not on fetch completion (#282): awaiting the cold first fetch
+    // (modal still docking) blew the 10s ctx.call bridge timeout and cost the
+    // agent several retry turns. reload() tracks its own promise
+    // (state.activeReloadPromise) for drive methods that need the first page, and
+    // _loadMore swallows fetch errors into the sentinel (never rejects), so the
+    // dropped promise is safe. _reload's reqId/renderRev bumps run SYNCHRONOUSLY
+    // (before its first await), so state.renderRev below is already the new
+    // generation. The agent reads the data via panel_civitai_results
+    // (loading/done flags) — the metadata-poll design.
+    void reload({ searching: true });
+    return { tab: state.tab, query: state.query, creator: state.filters.username || null, renderRev: state.renderRev, dispatched: true };
   }
   function driveGetResults({ limit = 20 } = {}) {
     _assertOpen();


### PR DESCRIPTION
Closes artokun/comfyui-mcp#282.

## Problem
Found in the live Claude-in-Chrome pass of agent-drive: when the agent opens the CivitAI browser docked AND searches in quick succession, the first `panel_civitai_search` could hit the 10s `ctx.call` bridge timeout — the panel's `driveSearch` awaited the full `reload()` (dispatch + fetch), and a cold first fetch while the modal is still docking exceeds 10s. The agent recovered by retrying, at a cost of several turns of thrashing.

## Fix (option (a) from the issue)
`driveSearch` now resolves the bridge reply as soon as the search is **dispatched** (`web/js/cmcp-civitai-ui.js`):
- `reload()` already tracks its own promise (`state.activeReloadPromise`) for the drive methods that genuinely need the first page (e.g. `driveHighlight`), and `_loadMore` swallows fetch errors into the sentinel (it never rejects) — so the dropped promise is safe, no unhandled rejection.
- `renderRev` in the reply still reflects the NEW generation: the bump runs synchronously inside `_reload` before its first await.
- The reply gains `dispatched: true` so the agent can tell ack-from-completion.
- The agent reads the actual data by polling `panel_civitai_results` (`loading`/`done` flags) — exactly the metadata-poll design the issue blessed.

## Verification
- `node --check` clean; the existing Playwright spec `a reload (switch_tab / search) clears the glow` remains valid (the glow-clear is synchronous pre-dispatch).
- codex review: **no BLOCKER/MAJOR/MINOR findings** (104 unit tests pass).