### PR TITLE
feat(panel): unify Civitai / Apps / Training / Local into one tabbed side-panel (#124)

### DIFF
--- a/web/js/cmcp-apps-ui.js
+++ b/web/js/cmcp-apps-ui.js
@@ -189,64 +189,57 @@ async function draftFromCanvas(getApp) {
   return { prompt: gp.output, workflow, imported, inputs, outputs };
 }
 
-export function openAppsModal(ctx, opts = {}) {
+/** Content-provider factory for the Apps tab of the unified side panel. The
+ *  shell owns the overlay/header/✕/dock/Escape; this builds the grid/convert/
+ *  detail body. The My/Explore toggle is chips in the shared subnav (decision D);
+ *  the shared search shows only on Explore. */
+export function createAppsContent(ctx, shell, opts = {}) {
   const { getApp, uploadBlobToInput, callTool, getRunpodTarget } = ctx;
   const client = new AppsClient();
   const registry = new RegistryClient();
   injectStyle();
 
-  const overlay = el("div", "cmcp-apps-overlay");
-  const modal = el("div", "cmcp-modal cmcp-apps-modal");
-  const title = el("div", "cmcp-modal-title", "Apps");
-  const body = el("div", "cmcp-apps-body");
-  modal.append(title, body);
-  overlay.appendChild(modal);
+  const body = el("div", "cmcp-apps-body"); // content root (mounted in shell body)
 
   let closed = false;
   let pollTimer = null;
-  function close() {
-    if (closed) return;
-    closed = true;
-    if (pollTimer) clearInterval(pollTimer);
-    overlay.remove();
-    opts.onClose && opts.onClose();
+  let _tab = "mine"; // "mine" | "explore"
+  let _started = false;
+  let exploreQuery = "";
+  let _exploreReload = null; // showExplore's load(), so onSearch can re-run it
+  let _exploreTimer = null;
+
+  // ── My / Explore toggle → chips in the shared subnav (decision D) ──────────
+  const mineChip = el("button", "cmcp-cv-chip", "My Apps");
+  const exploreChip = el("button", "cmcp-cv-chip", "Explore");
+  function syncChips() {
+    mineChip.classList.toggle("on", _tab === "mine");
+    exploreChip.classList.toggle("on", _tab === "explore");
   }
-  overlay.addEventListener("mousedown", (e) => {
-    if (e.target === overlay) close();
+  mineChip.addEventListener("click", () => {
+    if (_tab === "mine") return;
+    _tab = "mine"; syncChips(); shell.syncSearch(); showGrid().catch(showError);
   });
-  const onKey = (e) => {
-    if (e.key === "Escape") close();
-  };
-  window.addEventListener("keydown", onKey);
-  const origClose = close;
-  close = function () {
-    window.removeEventListener("keydown", onKey);
-    origClose();
-  };
+  exploreChip.addEventListener("click", () => {
+    if (_tab === "explore") return;
+    _tab = "explore"; syncChips(); shell.syncSearch(); showGrid().catch(showError);
+  });
 
   // ── Grid view ────────────────────────────────────────────────────────────
-
-  let _tab = "mine"; // "mine" | "explore"
-
   async function showGrid() {
     if (closed) return;
+    syncChips();
     body.textContent = "";
-    const bar = el("div", "cmcp-apps-toolbar");
-    const mineTab = makeBtn("My Apps", { primary: _tab === "mine" });
-    const exploreTab = makeBtn("Explore", { primary: _tab === "explore" });
-    mineTab.addEventListener("click", () => { _tab = "mine"; showGrid().catch(showError); });
-    exploreTab.addEventListener("click", () => { _tab = "explore"; showGrid().catch(showError); });
-    bar.append(mineTab, exploreTab);
     if (_tab === "mine") {
-      const spacer = el("span", "spacer");
+      const bar = el("div", "cmcp-apps-toolbar");
       const convertBtn = makeBtn("＋ Convert current workflow", {
         primary: true,
         title: "Package the workflow on the canvas as a one-click app.",
       });
       convertBtn.addEventListener("click", () => showConvert().catch(showError));
-      bar.append(spacer, convertBtn);
+      bar.append(convertBtn);
+      body.append(bar);
     }
-    body.append(bar);
     if (_tab === "explore") return showExplore();
     return showMine();
   }
@@ -314,18 +307,15 @@ export function openAppsModal(ctx, opts = {}) {
     const sorts = [["trending", "Trending"], ["new", "New"], ["stars", "Most starred"]];
     const chips = new Map();
     const grid = el("div", "cmcp-apps-grid");
-    const search = document.createElement("input");
-    search.type = "text";
-    search.placeholder = "Search apps…";
-    search.style.cssText =
-      "flex:1;min-width:140px;padding:0.4rem 0.55rem;border-radius:6px;border:1px solid var(--p-content-border-color,#3f3f46);background:var(--p-inputtext-background,#18181b);color:inherit;font-size:0.82rem;";
+    // Search is the shell's shared box (shown only on Explore); its value is
+    // mirrored into exploreQuery and re-runs load() via onSearch.
     async function load(append = false, cursor = "") {
       if (!append) {
         grid.textContent = "";
         grid.append(el("div", "cmcp-apps-empty", "Loading…"));
       }
       try {
-        const res = await registry.list({ sort, q: search.value.trim(), cursor });
+        const res = await registry.list({ sort, q: exploreQuery.trim(), cursor });
         if (closed) return;
         if (!append) grid.textContent = "";
         renderCards(res.apps || [], res.next_cursor);
@@ -377,12 +367,7 @@ export function openAppsModal(ctx, opts = {}) {
       });
       controls.append(chip);
     }
-    let searchTimer = null;
-    search.addEventListener("input", () => {
-      clearTimeout(searchTimer);
-      searchTimer = setTimeout(() => load(), 350);
-    });
-    controls.append(search);
+    _exploreReload = () => load(); // onSearch (shared box) re-runs this
     body.append(controls, grid);
     load();
   }
@@ -1024,13 +1009,28 @@ export function openAppsModal(ctx, opts = {}) {
     body.append(bar, el("div", "cmcp-apps-empty", e && e.message ? e.message : String(e)));
   }
 
-  document.body.appendChild(overlay);
-  showGrid().catch(showError);
-
   return {
-    close,
-    isOpen: () => !closed,
+    key: "apps", label: "Apps", icon: "pi-th-large", driveKind: null,
+    hasSearch: () => _tab === "explore",
+    searchPlaceholder: "Search apps…",
+    subnavExtras: () => [mineChip, exploreChip],
+    mount(bodyEl) { bodyEl.appendChild(body); },
+    onActivate() {
+      syncChips();
+      if (!_started) { _started = true; showGrid().catch(showError); }
+    },
+    // Shared search → Explore registry query (debounced), no-op on My Apps.
+    onSearch(value) {
+      exploreQuery = value;
+      if (_tab !== "explore" || !_exploreReload) return;
+      clearTimeout(_exploreTimer);
+      _exploreTimer = setTimeout(() => { if (_exploreReload) _exploreReload(); }, 350);
+    },
     update: () => {},
-    el: overlay,
+    teardown() {
+      closed = true;
+      if (pollTimer) clearInterval(pollTimer);
+      if (_exploreTimer) clearTimeout(_exploreTimer);
+    },
   };
 }

--- a/web/js/cmcp-apps-ui.js
+++ b/web/js/cmcp-apps-ui.js
@@ -19,9 +19,11 @@ function injectStyle() {
   if (styleInjected) return;
   styleInjected = true;
   const css = `
-.cmcp-apps-overlay{position:fixed;inset:0;z-index:10000;display:flex;align-items:center;justify-content:center;
-  padding:1rem;background:rgba(0,0,0,0.45);}
-.cmcp-apps-modal{max-width:min(860px,94vw)!important;width:100%;max-height:88vh;display:flex;flex-direction:column;}
+/* The unified side-panel shell (cmcp-sidepanel-ui.js) owns the overlay + card
+   sizing; .cmcp-apps-modal is only the active-tab alias now — no sizing here, or
+   its !important max-width would leak onto the shared shell (shrinking the card
+   on the Apps tab + breaking docked-fill). Keep only the flex-column layout. */
+.cmcp-apps-modal{display:flex;flex-direction:column;}
 .cmcp-apps-body{display:flex;flex-direction:column;gap:0.75rem;min-height:0;flex:1;}
 .cmcp-apps-toolbar{display:flex;gap:0.4rem;flex-wrap:wrap;align-items:center;}
 .cmcp-apps-toolbar .spacer{flex:1;}
@@ -202,7 +204,13 @@ export function createAppsContent(ctx, shell, opts = {}) {
   const body = el("div", "cmcp-apps-body"); // content root (mounted in shell body)
 
   let closed = false;
-  let pollTimer = null;
+  let pollTimer = null; // setTimeout id for the in-flight run poll
+  // Run-poll pause/resume across tab switches: _hidden gates rescheduling,
+  // _lastTick is the resume anchor, _polling guards against double-arming while a
+  // tick is mid-flight.
+  let _hidden = false;
+  let _lastTick = null;
+  let _polling = false;
   let _tab = "mine"; // "mine" | "explore"
   let _started = false;
   let exploreQuery = "";
@@ -854,27 +862,37 @@ export function createAppsContent(ctx, shell, opts = {}) {
     async function pollRun(promptId) {
       const deadline = Date.now() + 30 * 60 * 1000;
       return new Promise((resolve) => {
+        // Terminal: clear the resume anchor so a later re-activate can't restart
+        // a finished run.
+        const done = () => { _polling = false; _lastTick = null; resolve(); };
         const tick = async () => {
-          if (closed) return resolve();
+          if (closed) return done();
+          _polling = true;
           try {
             const st = await client.runStatus(app.id, promptId);
             if (st.status === "done") {
               renderOutputs(st);
-              return resolve();
+              return done();
             }
             status.textContent = st.status === "running" ? "Running…" : "Queued…";
           } catch (e) {
             status.textContent = e.message;
             status.classList.add("err");
-            return resolve();
+            return done();
           }
           if (Date.now() > deadline) {
             status.textContent = "Timed out waiting for the run — it may still finish; check ComfyUI's queue.";
             status.classList.add("err");
-            return resolve();
+            return done();
           }
+          _polling = false;
+          // Paused while the Apps tab is hidden — onDeactivate cleared pollTimer,
+          // and onActivate re-arms via _lastTick. The shell only detaches the
+          // detail DOM (same nodes), so the resumed poll updates the right nodes.
+          if (_hidden) { pollTimer = null; return; }
           pollTimer = setTimeout(tick, 2000);
         };
+        _lastTick = tick; // resume anchor for re-activation
         tick();
       });
     }
@@ -1016,8 +1034,19 @@ export function createAppsContent(ctx, shell, opts = {}) {
     subnavExtras: () => [mineChip, exploreChip],
     mount(bodyEl) { bodyEl.appendChild(body); },
     onActivate() {
+      _hidden = false;
       syncChips();
       if (!_started) { _started = true; showGrid().catch(showError); }
+      // Re-arm a paused run poll (the detail DOM is preserved by the shell). The
+      // _polling / !pollTimer guards prevent double-arming when a tick is still
+      // mid-flight or already scheduled.
+      else if (_lastTick && !_polling && !pollTimer) { pollTimer = setTimeout(_lastTick, 0); }
+    },
+    // Halt the in-flight run poll while hidden — it would otherwise keep polling +
+    // writing to the DOM the shell detached on switch.
+    onDeactivate() {
+      _hidden = true;
+      if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; }
     },
     // Shared search → Explore registry query (debounced), no-op on My Apps.
     onSearch(value) {
@@ -1029,7 +1058,7 @@ export function createAppsContent(ctx, shell, opts = {}) {
     update: () => {},
     teardown() {
       closed = true;
-      if (pollTimer) clearInterval(pollTimer);
+      if (pollTimer) clearTimeout(pollTimer); // pollTimer is a setTimeout id, not an interval
       if (_exploreTimer) clearTimeout(_exploreTimer);
     },
   };

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -15,6 +15,7 @@ import {
   BASE_MODELS, ACTIVE_BASE_MODELS, prepareQuery, matchesBaseModel,
   filtersDirty, bitmask, parseCreatorQuery,
 } from "./cmcp-civitai.js";
+import { openSidePanel } from "./cmcp-sidepanel-ui.js";
 
 const TABS = [
   { key: "images", label: "Images", icon: "pi-image", media: "image" },
@@ -70,27 +71,11 @@ let _cssInjected = false;
 function injectCss() {
   if (_cssInjected) return;
   _cssInjected = true;
+  // Shared-chrome rules (.cmcp-cv-overlay / .cmcp-modal.cmcp-sidepanel / -head /
+  // -tabs / -tab / -search / -iconbtn / -dot / -body / -subnav + the docked rules)
+  // now live in the shell (cmcp-sidepanel-ui.js). This block keeps ONLY Civitai's
+  // body CSS so the -cv-* card/lightbox/filter styles still resolve.
   const css = `
-  .cmcp-cv-overlay { position: fixed; inset: 0; z-index: 10000; display: flex;
-    align-items: center; justify-content: center; padding: 1.5rem; background: rgba(0,0,0,.6); }
-  .cmcp-civitai-modal { width: min(1150px, 94vw); max-width: none; height: 90vh;
-    max-height: 90vh; padding: 0; gap: 0; overflow: hidden; }
-  .cmcp-cv-head { display: flex; align-items: center; gap: .5rem; padding: .6rem .7rem;
-    border-bottom: 1px solid var(--p-content-border-color, #3f3f46); flex-wrap: wrap; }
-  .cmcp-cv-tabs { display: flex; gap: .25rem; flex-wrap: wrap; }
-  .cmcp-cv-tab { display: inline-flex; align-items: center; gap: .3rem; padding: .3rem .55rem;
-    border-radius: 8px; border: 1px solid transparent; background: transparent;
-    color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; font-size: .8rem; }
-  .cmcp-cv-tab.active { background: var(--p-surface-800, #27272a);
-    color: var(--p-text-color, #fafafa); border-color: var(--p-content-border-color, #3f3f46); }
-  .cmcp-cv-search { flex: 1 1 8rem; min-width: 6rem; padding: .35rem .5rem; border-radius: 8px;
-    background: var(--p-surface-950, #111); border: 1px solid var(--p-content-border-color, #3f3f46);
-    color: var(--p-text-color, #fafafa); }
-  .cmcp-cv-iconbtn { position: relative; background: transparent; border: 1px solid var(--p-content-border-color,#3f3f46);
-    color: var(--p-text-color,#fafafa); border-radius: 8px; padding: .35rem .5rem; cursor: pointer; }
-  .cmcp-cv-dot { position: absolute; top: -3px; right: -3px; width: 8px; height: 8px; border-radius: 50%;
-    background: var(--p-primary-color, #3a7bd5); }
-  .cmcp-cv-body { position: relative; flex: 1; overflow-y: auto; padding: .6rem; }
   .cmcp-cv-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: .5rem; }
   .cmcp-cv-card { position: relative; border-radius: 10px; overflow: hidden; cursor: pointer;
     background: var(--p-surface-900, #18181b); aspect-ratio: .72; }
@@ -146,8 +131,6 @@ function injectCss() {
     gap: .5rem; padding-right: 2.2rem; }
   .cmcp-cv-like { margin-left: auto; }
   .cmcp-cv-like.on { color: #f43f5e; border-color: #f43f5e; }
-  .cmcp-cv-subnav { display: flex; align-items: center; gap: .4rem; padding: .45rem .7rem;
-    border-bottom: 1px solid var(--p-content-border-color, #3f3f46); }
   .cmcp-cv-cardlike { position: absolute; top: .3rem; right: .3rem; z-index: 2;
     background: rgba(0,0,0,.55); border: none; color: #fff; border-radius: 8px;
     width: 28px; height: 28px; cursor: pointer; display: none; align-items: center;
@@ -212,18 +195,6 @@ function injectCss() {
     animation: cmcp-glow 1.4s ease-in-out infinite; }
   @keyframes cmcp-glow { 50% { box-shadow: 0 0 0 3px var(--p-green-400,#4ade80),
     0 0 24px 6px rgba(74,222,128,.9); } }
-  /* Agent-driven side-dock: anchor to the sidebar's right edge (measured in JS),
-     drop the dim backdrop and let clicks pass THROUGH the overlay so chat stays
-     interactive; only the modal card itself catches pointer events. Slide-in via
-     the first translateX transition in the codebase. Kept below the lightbox
-     (z 10002) so the lightbox still overlays. */
-  .cmcp-cv-overlay.cmcp-docked { display: block; padding: 0; background: transparent;
-    pointer-events: none; }
-  .cmcp-cv-overlay.cmcp-docked .cmcp-civitai-modal { position: fixed; pointer-events: auto;
-    width: auto; max-width: none; height: auto; max-height: none; border-radius: 0;
-    box-shadow: -8px 0 32px rgba(0,0,0,.45); transform: translateX(24px); opacity: 0;
-    transition: transform .28s ease, opacity .28s ease; }
-  .cmcp-cv-overlay.cmcp-docked.cmcp-dock-in .cmcp-civitai-modal { transform: translateX(0); opacity: 1; }
   `;
   const style = document.createElement("style");
   style.textContent = css;
@@ -236,25 +207,6 @@ const el = (tag, cls, txt) => {
   if (txt != null) n.textContent = txt;
   return n;
 };
-
-/** Slide/fade the panel out before detaching (shared exit for the three docked
- *  side-panels). Docked: reverse the translateX slide-in (drop cmcp-dock-in) so
- *  the card slides back out; centered/narrow: a plain opacity fade — no
- *  horizontal slide. The DOM is removed after the transition window (jsdom fires
- *  no transitionend, so a fixed timer drives it). Idempotent — remove() on an
- *  already-detached node is a no-op. */
-const DOCK_SLIDE_OUT_MS = 240;
-function slideOutThenRemove(overlay) {
-  const docked = overlay.classList.contains("cmcp-docked");
-  overlay.style.pointerEvents = "none";
-  if (docked) {
-    overlay.classList.remove("cmcp-dock-in"); // card returns to translateX(24px)/opacity 0
-  } else {
-    overlay.style.transition = "opacity .18s ease";
-    overlay.style.opacity = "0";
-  }
-  setTimeout(() => { try { overlay.remove(); } catch { /* already gone */ } }, DOCK_SLIDE_OUT_MS);
-}
 
 /** Fail-CLOSED dirty check for the load-onto-canvas overwrite confirm: any
  *  uncertainty (missing getter, non-boolean answer, a throw) counts as DIRTY
@@ -300,10 +252,15 @@ export function serializeCivitaiResults(source, { model = false, limit = 20, loa
   return { items, total: rows.length, loading: !!loading };
 }
 
-/** Open (or focus) the CivitAI modal. opts = {query, tab, filters, browsingLevels, dock, onClose}. */
-export function openCivitaiModal(ctx, opts = {}) {
+/** Content-provider factory for the CivitAI browser tab of the unified side
+ *  panel. Builds the grid/lightbox/filter body + the agent-drive surface; the
+ *  shell (cmcp-sidepanel-ui.js) owns the overlay, header, tab bar, single search
+ *  box, ✕, dock and Escape. opts = {query, tab, filters, browsingLevels}. */
+export function createCivitaiContent(ctx, shell, opts = {}) {
   injectCss();
   const client = new CivitaiClient(ctx.api);
+  const { body } = shell;
+  const search = shell.searchEl; // the shell's single search input
 
   // ── state ────────────────────────────────────────────────────────────────
   const state = {
@@ -340,68 +297,31 @@ export function openCivitaiModal(ctx, opts = {}) {
   const tabDef = () => TABS.find((t) => t.key === state.tab);
   const isModelTab = () => !!tabDef().model;
 
-  // ── overlay (full-viewport, mounted on <body> so it isn't confined to the
-  // narrow panel sidebar) ────────────────────────────────────────────────────
-  const overlay = el("div", "cmcp-cv-overlay");
-  const modal = el("div", "cmcp-modal cmcp-civitai-modal");
-  // Self-invalidating handle: isOpen flips false on the FIRST close() and every
-  // drive method asserts it, so a stale reference held past close throws instead
-  // of poking a detached grid. onClose lets the host compare-and-null its stored
-  // handle. close() is idempotent and tears down EVERY async/listener owned here.
+  // Self-invalidating internal open flag: drive methods assert it and the shell
+  // facade also gates on the active tab. teardown() (run by the shell's close)
+  // tears down every async/listener owned here. close() closes the WHOLE side
+  // panel — shareImage / loadOntoCanvas call it on success to reveal the chat.
   let isOpen = true;
-  let _onDockResize = null;   // window-resize fallback when ctx.watchDock is absent
-  let _dockDispose = null;    // ResizeObserver+listener disposer from ctx.watchDock
-  let _oauthPollIv = null;    // sign-in completion poll (accountFlow)
-  let _onEscape = null;       // document Escape → close
+  let _oauthPollIv = null;         // sign-in completion poll (accountFlow)
   let _activeLightboxClose = null; // openViewer's teardown (owns its own doc keydown listener)
-  const close = () => {
-    if (!isOpen) return;      // idempotent
+  let searchTimer = null;
+  const close = () => { try { shell.close(); } catch { /* already gone */ } };
+  function teardown() {
+    if (!isOpen) return;           // idempotent
     isOpen = false;
-    state.reqId++;            // invalidate any in-flight fetch (its guarded finally no-ops)
+    state.reqId++;                 // invalidate any in-flight fetch (its guarded finally no-ops)
     state.activeReloadPromise = null;
     state.activeLoadPromise = null;
     try { clearTimeout(searchTimer); } catch { /* not armed */ }
     if (_oauthPollIv) { clearInterval(_oauthPollIv); _oauthPollIv = null; }
-    // The lightbox is body-mounted with its OWN document keydown listener — a
-    // programmatic reopen would otherwise strand it (+ its listener) above the
-    // new modal (codex finding). Tear it down through this one path.
+    // The lightbox is body-mounted with its OWN document keydown listener — tear
+    // it down through this one path (codex finding).
     if (_activeLightboxClose) { try { _activeLightboxClose(); } catch { /* already gone */ } _activeLightboxClose = null; }
     try { closeSubModals(); } catch { /* already gone */ }
-    if (_onEscape) { document.removeEventListener("keydown", _onEscape); _onEscape = null; }
-    if (_onDockResize) { window.removeEventListener("resize", _onDockResize); _onDockResize = null; }
-    if (_dockDispose) { try { _dockDispose(); } catch { /* best effort */ } _dockDispose = null; }
-    // Slide/fade the card out, THEN detach (parity with the Training + RunPod
-    // side-panels). isOpen already flipped above, so drive methods + re-close are
-    // inert during the ~240ms exit; host bookkeeping (onClose) still runs now.
-    slideOutThenRemove(overlay);
-    try { opts.onClose?.(); } catch { /* host bookkeeping only */ }
-  };
-  // In docked mode the overlay itself is click-through (pointer-events:none), so a
-  // backdrop mousedown never fires here — the header ✕ / Escape are the dismissals.
-  // Centered mode keeps the backdrop-click-to-close affordance.
-  overlay.addEventListener("mousedown", (e) => { if (e.target === overlay) close(); });
-  // Base modals had no Escape handler (audit item 9): add one that funnels through
-  // close(), but yield to a stacked lightbox / sub-modal so Escape peels the top.
-  _onEscape = (e) => {
-    if (e.key !== "Escape") return;
-    if (_subModals.size > 0) return;
-    if (document.querySelector(".cmcp-cv-lb")) return;
-    e.stopPropagation();
-    close();
-  };
-  document.addEventListener("keydown", _onEscape);
+  }
 
-  // header
-  const head = el("div", "cmcp-cv-head");
-  const tabsWrap = el("div", "cmcp-cv-tabs");
-  // Search lives in the SUBNAV under the tabs (every tab gets it) — debounced
-  // 500ms; while the debounced search request is in flight the grid sits under
-  // a blur overlay with a spinner. Favorites search filters client-side (the
-  // tRPC favorites feed has no text query), everything else hits Meili/REST.
-  const search = el("input", "cmcp-cv-search");
-  search.placeholder = "Search CivitAI…";
-  search.value = state.query;
-  let searchTimer = null;
+  // The search box is the shell's single input (aliased `search`). The debounce +
+  // creator-token parsing stay here; the shell dispatches keystrokes to onSearch.
   // The @token displayed in the search box ALWAYS owns the creator filter:
   // setCreator mirrors every creator change (sheet picker, pill ✕, reset,
   // "See more from") into the box as an @token, so deleting that token must
@@ -459,17 +379,11 @@ export function openCivitaiModal(ctx, opts = {}) {
     syncTabs();
     reload({ searching: true });
   }
-  search.addEventListener("input", () => {
-    clearTimeout(searchTimer);
-    searchTimer = setTimeout(applySearch, 500);
-  });
-  search.addEventListener("keydown", (e) => {
-    if (e.key === "Enter") { clearTimeout(searchTimer); applySearch(); }
-  });
+  // The shell wires its single search input → onSearch (returned below); no
+  // direct input/keydown listeners are attached here.
   const filterBtn = el("button", "cmcp-cv-iconbtn");
-  // First of the three right-side actions (filters ⚙ / account 👤 / close ✕):
-  // margin-left:auto pushes this trio to the right edge while the tab row stays
-  // left-aligned in the flex header.
+  // margin-left:auto pushes the filter ⚙ + account 👤 pair to the subnav's right
+  // edge while the sub-tab row stays left-aligned.
   filterBtn.style.marginLeft = "auto";
   filterBtn.innerHTML = '<i class="pi pi-sliders-h"></i>';
   const filterDot = el("span", "cmcp-cv-dot"); filterDot.style.display = "none";
@@ -479,21 +393,20 @@ export function openCivitaiModal(ctx, opts = {}) {
   acctBtn.innerHTML = '<i class="pi pi-user"></i>';
   acctBtn.title = "CivitAI account";
   acctBtn.addEventListener("click", () => accountFlow());
-  const closeBtn = el("button", "cmcp-cv-iconbtn");
-  closeBtn.innerHTML = '<i class="pi pi-times"></i>';
-  closeBtn.addEventListener("click", close);
 
+  // Civitai sub-tabs (images / videos / checkpoints / …) — mounted in the shell
+  // subnav via subnavExtras(). Reuse .cmcp-cv-tab so the themed active state +
+  // the responsive container query apply here too.
+  const subTabsWrap = el("div", "cmcp-cv-tabs");
   for (const t of TABS) {
     const b = el("button", "cmcp-cv-tab");
     b.innerHTML = `<i class="pi ${t.icon}"></i><span>${t.label}</span>`;
     b.addEventListener("click", () => { state.tab = t.key; syncTabs(); reload(); });
     b._key = t.key;
-    tabsWrap.appendChild(b);
+    subTabsWrap.appendChild(b);
   }
-  head.append(tabsWrap, filterBtn, acctBtn, closeBtn);
 
-  // subnav: search (all tabs) + favorites media-type chips
-  const subnav = el("div", "cmcp-cv-subnav");
+  // Favorites media-type chips (shown only on the Favorites sub-tab).
   const favChips = el("div", "cmcp-cv-frow");
   for (const [label, val] of [["All", "all"], ["Images", "image"], ["Videos", "video"]]) {
     const chip = el("button", "cmcp-cv-chip", label);
@@ -506,96 +419,21 @@ export function openCivitaiModal(ctx, opts = {}) {
     });
     favChips.appendChild(chip);
   }
-  subnav.append(search, favChips);
 
-  // body
-  const body = el("div", "cmcp-cv-body");
+  // Body content (appended into the shell's .cmcp-cv-body scroll surface on mount).
   const progress = el("div", "cmcp-cv-progress");
   const grid = el("div", "cmcp-cv-grid");
   const sentinel = el("div", "cmcp-cv-loading");
-  body.append(progress, grid, sentinel);
-  body.addEventListener("scroll", () => {
-    if (body.scrollTop + body.clientHeight >= body.scrollHeight - 600) loadMore();
-  });
-
   const searchOverlay = el("div", "cmcp-cv-searching");
   searchOverlay.appendChild(el("div", "cmcp-cv-spinner"));
   searchOverlay.style.display = "none";
-  body.appendChild(searchOverlay);
-
-  modal.append(head, subnav, body);
-  overlay.appendChild(modal);
-  document.body.appendChild(overlay);
-
-  // ── docked mode (agent-driven) ─────────────────────────────────────────────
-  // Dock into the canvas area OPPOSITE the Agent pane (which may be docked left
-  // OR right) so chat stays visible + interactive. Geometry comes from the host
-  // (ctx.dockGeometry: it owns the ComfyUI pane/canvas measurement and the
-  // left/right detection), so this module stays ComfyUI-agnostic. Three states:
-  //  - detached  → the Agent tab was switched away; the body-mounted modal is
-  //    orphaned, so HIDE it (don't float centered over an unrelated screen).
-  //  - centered  → no eligible anchor (missing/zero-size/too-small/narrow window)
-  //  - docked    → anchored rect from the host.
-  applyDock.centered = false;
-  function applyDock() {
-    if (!opts.dock) { setCentered(); return; }
-    const geo = _dockGeometry();
-    if (geo?.status === "detached") {
-      overlay.style.display = "none";
-      return;
-    }
-    overlay.style.display = "";
-    if (geo?.status === "docked" && window.innerWidth >= 900) {
-      overlay.classList.add("cmcp-docked");
-      modal.style.left = `${Math.round(geo.left)}px`;
-      modal.style.top = `${Math.round(geo.top)}px`;
-      modal.style.right = `${Math.round(geo.right)}px`;
-      modal.style.bottom = `${Math.round(geo.bottom)}px`;
-      applyDock.centered = false;
-    } else {
-      setCentered();
-    }
-  }
-  function setCentered() {
-    overlay.classList.remove("cmcp-docked");
-    overlay.style.display = "";
-    modal.style.left = modal.style.right = modal.style.top = modal.style.bottom = "";
-    applyDock.centered = true;
-  }
-  /** Host geometry, with a self-contained fallback (single-pane / no host help /
-   *  tests): measure ctx.root's pane and dock to the wider viewport side. */
-  function _dockGeometry() {
-    if (typeof ctx.dockGeometry === "function") {
-      try { const g = ctx.dockGeometry(); if (g) return g; } catch { /* fall through */ }
-    }
-    try {
-      const root = ctx.root;
-      if (root && !root.isConnected) return { status: "detached" };
-      const pane = root?.closest?.(".side-bar-panel") || root?.closest?.("[class*='sidebar']") || root;
-      const pr = pane?.getBoundingClientRect?.();
-      if (!pr || pr.width < 1 || pr.height < 1) return { status: "centered" };
-      const vw = window.innerWidth, vh = window.innerHeight;
-      const paneOnLeft = (pr.left + pr.right) / 2 < vw / 2;
-      const left = paneOnLeft ? Math.max(0, pr.right) : 0;
-      const right = paneOnLeft ? 0 : Math.max(0, vw - pr.left);
-      if (vw - left - right < 320) return { status: "centered" };
-      return { status: "docked", left, right, top: Math.max(0, pr.top), bottom: Math.max(0, vh - pr.bottom) };
-    } catch { return { status: "centered" }; }
-  }
-  if (opts.dock) {
-    applyDock();
-    // Watch pane + canvas (splitter drags don't fire window-resize) via the host;
-    // fall back to a bare window-resize listener when the host can't help.
-    if (typeof ctx.watchDock === "function") {
-      try { _dockDispose = ctx.watchDock(applyDock); } catch { _dockDispose = null; }
-    }
-    if (!_dockDispose) { _onDockResize = () => applyDock(); window.addEventListener("resize", _onDockResize); }
-    // Slide-in on the next frame so the transition runs from the initial state.
-    requestAnimationFrame(() => overlay.classList.add("cmcp-dock-in"));
-  }
+  // Infinite scroll: the shell body is the scroll surface. Wired on activate.
+  const onBodyScroll = () => {
+    if (body.scrollTop + body.clientHeight >= body.scrollHeight - 600) loadMore();
+  };
 
   function syncTabs() {
-    for (const b of tabsWrap.children) b.classList.toggle("active", b._key === state.tab);
+    for (const b of subTabsWrap.children) b.classList.toggle("active", b._key === state.tab);
     favChips.style.display = tabDef().fav ? "" : "none";
     for (const c of favChips.children) c.classList.toggle("on", c._fv === state.favType);
     filterDot.style.display = filtersDirty(state.filters) ? "" : "none";
@@ -2005,19 +1843,62 @@ export function openCivitaiModal(ctx, opts = {}) {
   function driveGetState() {
     return {
       isOpen, tab: state.tab, loading: !!state.loading, done: !!state.done,
-      renderRev: state.renderRev, docked: !applyDock.centered && overlay.classList.contains("cmcp-docked"),
+      renderRev: state.renderRev, docked: shell.isDocked(),
       highlighted: state.highlightOrder.slice(),
     };
   }
 
-  // ── go ───────────────────────────────────────────────────────────────
-  syncTabs();
-  refreshAuth();
-  reload();
+  // ── content provider (the shell owns the chrome; this owns the body) ──────
+  let _started = false;
   return {
-    close, focus: () => search.focus(),
-    switchTab: driveSwitchTab, search: driveSearch, getResults: driveGetResults,
-    highlight: driveHighlight, clearHighlight: driveClearHighlight,
-    openLightbox: driveOpenLightbox, getState: driveGetState,
+    key: "civitai", label: "Civitai", icon: "pi-images", driveKind: "civitai",
+    hasSearch: true, searchPlaceholder: "Search CivitAI…",
+    subnavExtras: () => [subTabsWrap, favChips, filterBtn, acctBtn],
+    mount(bodyEl) {
+      search.value = state.query;
+      bodyEl.append(progress, grid, sentinel, searchOverlay);
+    },
+    // The shell dispatches every keystroke here; keep the 500ms debounce + the
+    // creator-token parse (applySearch reads the shared box). Enter flushes.
+    onSearch(_value, o = {}) {
+      clearTimeout(searchTimer);
+      if (o.enter) applySearch();
+      else searchTimer = setTimeout(applySearch, 500);
+    },
+    onActivate() {
+      body.addEventListener("scroll", onBodyScroll);
+      if (!_started) { _started = true; syncTabs(); refreshAuth(); reload(); }
+      else syncTabs();
+    },
+    onDeactivate() { body.removeEventListener("scroll", onBodyScroll); },
+    // Re-open onto an already-mounted Civitai tab with a fresh query/filters
+    // (host switches tabs on open_civitai while the panel is already up).
+    reseed(o) {
+      if (!o || !isOpen) return;
+      if (o.tab) { try { driveSwitchTab(o.tab); } catch { /* ignore */ } }
+      if (o.query != null || o.filters || o.browsingLevels) {
+        try { driveSearch({ query: o.query, filters: o.filters, browsingLevels: o.browsingLevels }); } catch { /* ignore */ }
+      }
+    },
+    teardown,
+    // Escape peels the lightbox / a stacked sub-modal before it can close the panel.
+    escapeBlocked: () => _subModals.size > 0 || !!document.querySelector(".cmcp-cv-lb"),
+    drive: {
+      switchTab: driveSwitchTab, search: driveSearch, getResults: driveGetResults,
+      highlight: driveHighlight, clearHighlight: driveClearHighlight,
+      openLightbox: driveOpenLightbox, getState: driveGetState,
+    },
   };
+}
+
+/** Thin back-compat wrapper: opens the unified side panel on the Civitai tab.
+ *  Returns the shell handle. */
+export function openCivitaiModal(ctx, opts = {}) {
+  const { query, tab, filters, browsingLevels, dock, onClose } = opts;
+  return openSidePanel(ctx, {
+    tab: "civitai",
+    dock,
+    onClose,
+    tabOpts: { civitai: { query, tab, filters, browsingLevels } },
+  });
 }

--- a/web/js/cmcp-runpod-ui.js
+++ b/web/js/cmcp-runpod-ui.js
@@ -54,21 +54,9 @@ function injectStyle() {
 .cmcp-rp-credit{font-size:0.7rem;opacity:0.5;}
 .cmcp-rp-credit a{color:inherit;}
 .cmcp-rp-muted{font-size:0.75rem;opacity:0.6;}
-/* Agent-drive/manual side-dock (parity with the CivitAI + Training modals):
-   anchor the card to the canvas side OPPOSITE the Agent pane, drop the backdrop,
-   let clicks pass THROUGH the overlay so chat stays interactive; only the card
-   catches pointer events. Bumped above the canvas (z 10000) to match. Slides in
-   via translateX; the close() path reverses it before detaching. The base
-   .cmcp-modal-overlay (panel monolith CSS, always loaded) styles the centered
-   fallback — this only overrides the docked case, so centered opens are
-   unchanged. */
-.cmcp-modal-overlay.cmcp-docked{position:fixed;display:block;padding:0;background:transparent;
-  pointer-events:none;z-index:10000;}
-.cmcp-modal-overlay.cmcp-docked .cmcp-rp-modal{position:fixed;pointer-events:auto;
-  width:auto;max-width:none!important;height:auto;max-height:none;overflow-y:auto;
-  border-radius:0;box-shadow:-8px 0 32px rgba(0,0,0,.45);
-  transform:translateX(24px);opacity:0;transition:transform .28s ease,opacity .28s ease;}
-.cmcp-modal-overlay.cmcp-docked.cmcp-dock-in .cmcp-rp-modal{transform:translateX(0);opacity:1;}
+/* The unified side-panel shell (cmcp-sidepanel-ui.js) owns the overlay + dock +
+   slide; the Local tab centers this body in the shared card. */
+.cmcp-rp-title{font-weight:600;font-size:0.85rem;}
 `;
   const el = document.createElement("style");
   el.textContent = css;
@@ -104,20 +92,20 @@ function fmtCountdown(sec) {
   return m > 0 ? `${m}m ${s}s` : `${s}s`;
 }
 
-export function openRunpodModal(ctx, opts = {}) {
-  const { root, callTool, getStatus, getTarget, openUrl } = ctx;
+/** Content-provider factory for the Local/RunPod tab of the unified side panel.
+ *  The shell owns the overlay/dock/close; this builds the centered control body.
+ *  hasSearch:false, drive:null; update() re-renders on runpod_status frames. */
+export function createLocalContent(ctx, shell, opts = {}) {
+  const { callTool, getStatus, getTarget, openUrl } = ctx;
   injectStyle();
-
-  const overlay = document.createElement("div");
-  overlay.className = "cmcp-modal-overlay";
-  const modal = document.createElement("div");
-  modal.className = "cmcp-modal cmcp-rp-modal";
-  const title = document.createElement("div");
-  title.className = "cmcp-modal-title";
-  title.textContent = "RunPod — cloud GPU for this session";
 
   const body = document.createElement("div");
   body.className = "cmcp-rp-body";
+  // Center the control body in the shared card (was a viewport-centered modal).
+  body.style.margin = "1rem auto";
+  const title = document.createElement("div");
+  title.className = "cmcp-rp-title";
+  title.textContent = "RunPod — cloud GPU for this session";
 
   // Host indicator (honest: where renders run right now).
   const host = document.createElement("div");
@@ -189,79 +177,12 @@ export function openRunpodModal(ctx, opts = {}) {
   credit.className = "cmcp-rp-credit";
   credit.innerHTML = `Pod control inspired by <a href="${GPU_CLI_URL}" target="_blank" rel="noopener">gpu-cli.sh</a>.`;
 
-  const btnRow = document.createElement("div");
-  btnRow.className = "cmcp-modal-btns";
-  const doneBtn = mkBtn("Close", "primary");
-  btnRow.append(doneBtn);
-
-  body.append(host, card, connectRow, manualRow, actions, linkRow, log, credit);
-  modal.append(title, body, btnRow);
-  overlay.append(modal);
-  // Mount the overlay on <body>, NOT the panel root: the ComfyUI sidebar clips
-  // its descendants, so a root-mounted overlay would be squeezed into the narrow
-  // panel (buttons + status values cut off). On body it's a true viewport-centered
-  // modal at its full width.
-  document.body.appendChild(overlay);
+  body.append(title, host, card, connectRow, manualRow, actions, linkRow, log, credit);
 
   // ── state + rendering ──────────────────────────────────────────────────────
   let busy = false;
   let closed = false;
   let tick = null;
-  let _onDockResize = null; // window-resize fallback when ctx.watchDock is absent
-  let _dockDispose = null;  // ResizeObserver+listener disposer from ctx.watchDock
-
-  // ── docked mode (parity with the CivitAI + Training modals) ──────────────────
-  // Geometry from the host (ctx.dockGeometry owns pane/canvas measurement +
-  // left/right detection); three states detached(hide)/centered/docked. See the
-  // CivitAI modal for the full rationale. When opts.dock is unset this is inert
-  // and the modal stays the plain centered overlay it always was.
-  applyDock.centered = false;
-  function applyDock() {
-    if (!opts.dock) { setCentered(); return; }
-    const geo = _dockGeometry();
-    if (geo && geo.status === "detached") { overlay.style.display = "none"; return; }
-    overlay.style.display = "";
-    if (geo && geo.status === "docked" && window.innerWidth >= 900) {
-      overlay.classList.add("cmcp-docked");
-      modal.style.left = `${Math.round(geo.left)}px`;
-      modal.style.top = `${Math.round(geo.top)}px`;
-      modal.style.right = `${Math.round(geo.right)}px`;
-      modal.style.bottom = `${Math.round(geo.bottom)}px`;
-      applyDock.centered = false;
-    } else { setCentered(); }
-  }
-  function setCentered() {
-    overlay.classList.remove("cmcp-docked");
-    overlay.style.display = "";
-    modal.style.left = modal.style.right = modal.style.top = modal.style.bottom = "";
-    applyDock.centered = true;
-  }
-  function _dockGeometry() {
-    if (typeof ctx.dockGeometry === "function") {
-      try { const g = ctx.dockGeometry(); if (g) return g; } catch { /* fall through */ }
-    }
-    try {
-      if (root && !root.isConnected) return { status: "detached" };
-      const pane = root?.closest?.(".side-bar-panel") || root?.closest?.("[class*='sidebar']") || root;
-      const pr = pane?.getBoundingClientRect?.();
-      if (!pr || pr.width < 1 || pr.height < 1) return { status: "centered" };
-      const vw = window.innerWidth, vh = window.innerHeight;
-      const paneOnLeft = (pr.left + pr.right) / 2 < vw / 2;
-      const left = paneOnLeft ? Math.max(0, pr.right) : 0;
-      const right = paneOnLeft ? 0 : Math.max(0, vw - pr.left);
-      if (vw - left - right < 320) return { status: "centered" };
-      return { status: "docked", left, right, top: Math.max(0, pr.top), bottom: Math.max(0, vh - pr.bottom) };
-    } catch { return { status: "centered" }; }
-  }
-  if (opts.dock) {
-    applyDock();
-    if (typeof ctx.watchDock === "function") {
-      try { _dockDispose = ctx.watchDock(applyDock); } catch { _dockDispose = null; }
-    }
-    if (!_dockDispose) { _onDockResize = () => applyDock(); window.addEventListener("resize", _onDockResize); }
-    // Slide-in on the next frame so the transition runs from the initial state.
-    requestAnimationFrame(() => overlay.classList.add("cmcp-dock-in"));
-  }
 
   function setLog(text, kind) {
     log.textContent = text || "";
@@ -376,10 +297,16 @@ export function openRunpodModal(ctx, opts = {}) {
   }
 
   // Re-render the idle countdown every second while a status frame is live.
-  tick = setInterval(() => {
-    const s = getStatus?.();
-    if (s && s.watching && s.autostop_in_seconds != null) render();
-  }, 1000);
+  // Re-render the idle countdown every second while a status frame is live —
+  // only while the Local tab is active (started/stopped by the shell).
+  function startTick() {
+    if (tick) return;
+    tick = setInterval(() => {
+      const s = getStatus?.();
+      if (s && s.watching && s.autostop_in_seconds != null) render();
+    }, 1000);
+  }
+  function stopTick() { if (tick) { clearInterval(tick); tick = null; } }
 
   async function run(label, fn) {
     if (busy) return false;
@@ -484,51 +411,26 @@ export function openRunpodModal(ctx, opts = {}) {
     }
   });
 
-  const close = () => {
-    if (closed) return; // idempotent
-    closed = true;
-    if (tick) { clearInterval(tick); tick = null; }
-    if (_onDockResize) { window.removeEventListener("resize", _onDockResize); _onDockResize = null; }
-    if (_dockDispose) { try { _dockDispose(); } catch { /* best effort */ } _dockDispose = null; }
-    slideOutThenRemove(overlay);
-  };
-  doneBtn.addEventListener("click", close);
-  overlay.addEventListener("mousedown", (e) => {
-    if (e.target === overlay) close();
-  });
-
-  // Load the pod dropdown on open, preselecting the watched pod (or opts.pod_id).
-  const s0 = getStatus?.();
-  void loadPods((s0 && s0.watching && s0.pod_id) || opts.pod_id);
-
-  render();
+  // Load the pod dropdown once, preselecting the watched pod (or opts.pod_id).
+  let _loaded = false;
+  function loadOnce() {
+    if (_loaded) return;
+    _loaded = true;
+    const s0 = getStatus?.();
+    void loadPods((s0 && s0.watching && s0.pod_id) || opts.pod_id);
+  }
 
   return {
-    close,
-    /** Called by the panel when a new runpod_status / comfyui_target frame arrives. */
-    update() {
-      render();
-    },
-    isOpen: () => !closed,
+    key: "local", label: "RunPod", icon: "pi-server", driveKind: null,
+    hasSearch: false, drive: null,
+    subnavExtras: () => [],
+    mount(bodyEl) { bodyEl.appendChild(body); render(); },
+    onActivate() { startTick(); loadOnce(); render(); },
+    onDeactivate() { stopTick(); },
+    // RunPod status / comfyui_target frames → re-render (no-op unless mounted).
+    update() { if (!closed) render(); },
+    teardown() { closed = true; stopTick(); },
   };
-}
-
-/** Slide/fade the panel out before detaching (parity across the three
- *  side-panels). Docked: reverse the translateX slide-in (drop cmcp-dock-in);
- *  centered/narrow: a plain opacity fade — no horizontal slide. The DOM is
- *  removed after the transition window (jsdom fires no transitionend, so a fixed
- *  timer drives it). Idempotent — remove() on a detached node is a no-op. */
-const DOCK_SLIDE_OUT_MS = 240;
-function slideOutThenRemove(overlay) {
-  const docked = overlay.classList.contains("cmcp-docked");
-  overlay.style.pointerEvents = "none";
-  if (docked) {
-    overlay.classList.remove("cmcp-dock-in"); // card returns to translateX(24px)/opacity 0
-  } else {
-    overlay.style.transition = "opacity .18s ease";
-    overlay.style.opacity = "0";
-  }
-  setTimeout(() => { try { overlay.remove(); } catch { /* already gone */ } }, DOCK_SLIDE_OUT_MS);
 }
 
 function mkBtn(label, variant) {

--- a/web/js/cmcp-sidepanel-ui.js
+++ b/web/js/cmcp-sidepanel-ui.js
@@ -1,0 +1,361 @@
+// Unified side-panel shell (issue #124) — ONE tabbed overlay that hosts the four
+// former sidebar modals (Civitai / Apps / Training / Local-RunPod) as tabs. It
+// owns everything that used to be duplicated 4× — the overlay, header + tab bar,
+// the single filter/search row, the top-right ✕, the agent-drive side-dock
+// (applyDock / setCentered / _dockGeometry / watchDock), the slide-out exit, and
+// Escape/backdrop close — and delegates the body of the active tab to a
+// content-provider.
+//
+// Class vocabulary is Civitai's, VERBATIM (cmcp-cv-overlay / cmcp-modal /
+// cmcp-cv-head / cmcp-cv-tabs·tab / cmcp-cv-subnav / cmcp-cv-search /
+// cmcp-cv-iconbtn / cmcp-docked·dock-in) so the docked CSS + the agent-drive
+// Playwright spec keep working unchanged. The active tab also carries a legacy
+// ALIAS class (cmcp-civitai-modal / cmcp-tr-modal / cmcp-apps-modal) so the
+// existing per-surface specs and -cv-*/-tr-*/-apps-* body CSS still resolve.
+//
+// A content-provider is `{ key, label, icon, hasSearch, searchPlaceholder,
+// mount(bodyEl), onSearch(v,opts), subnavExtras(), drive, driveKind, update(),
+// onActivate(), onDeactivate(), teardown(), escapeBlocked() }`.
+
+import { createCivitaiContent } from "./cmcp-civitai-ui.js";
+import { createAppsContent } from "./cmcp-apps-ui.js";
+import { createTrainingContent } from "./cmcp-training-ui.js";
+import { createLocalContent } from "./cmcp-runpod-ui.js";
+
+// key → content factory + tab presentation. Order = tab-bar order.
+const TABS = [
+  { key: "civitai", label: "Civitai", icon: "pi-images", factory: createCivitaiContent },
+  { key: "apps", label: "Apps", icon: "pi-th-large", factory: createAppsContent },
+  { key: "training", label: "Training", icon: "pi-bolt", factory: createTrainingContent },
+  { key: "local", label: "RunPod", icon: "pi-server", factory: createLocalContent },
+];
+// Legacy per-surface alias classes applied to the modal while that tab is active.
+const ALIAS = { civitai: "cmcp-civitai-modal", training: "cmcp-tr-modal", apps: "cmcp-apps-modal" };
+
+let _cssInjected = false;
+function injectCss() {
+  if (_cssInjected) return;
+  _cssInjected = true;
+  const css = `
+  .cmcp-cv-overlay { position: fixed; inset: 0; z-index: 10000; display: flex;
+    align-items: center; justify-content: center; padding: 1.5rem; background: rgba(0,0,0,.6); }
+  /* The unified card. container-type makes it the query container so a NARROW
+     docked panel collapses the tab labels even on a wide screen. */
+  .cmcp-modal.cmcp-sidepanel { width: min(1150px, 94vw); max-width: none; height: 90vh;
+    max-height: 90vh; padding: 0; gap: 0; overflow: hidden; container-type: inline-size; }
+  .cmcp-cv-head { display: flex; align-items: center; gap: .5rem; padding: .6rem .7rem;
+    border-bottom: 1px solid var(--p-content-border-color, #3f3f46); flex-wrap: wrap; }
+  .cmcp-cv-tabs { display: flex; gap: .25rem; flex-wrap: wrap; }
+  .cmcp-cv-tab { display: inline-flex; align-items: center; gap: .3rem; padding: .3rem .55rem;
+    border-radius: 8px; border: 1px solid transparent; background: transparent;
+    color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; font-size: .8rem; }
+  /* Active tab uses the ComfyUI/PrimeVue theme primary so it inverts correctly in
+     light + dark (precedent: .cmcp-btn primary). */
+  .cmcp-cv-tab.active { background: var(--p-primary-color, #3a7bd5);
+    color: var(--p-primary-contrast-color, #fff); border-color: transparent; }
+  .cmcp-cv-subnav { display: flex; align-items: center; gap: .4rem; padding: .45rem .7rem;
+    border-bottom: 1px solid var(--p-content-border-color, #3f3f46); flex-wrap: wrap; }
+  .cmcp-cv-search { flex: 1 1 8rem; min-width: 6rem; padding: .35rem .5rem; border-radius: 8px;
+    background: var(--p-surface-950, #111); border: 1px solid var(--p-content-border-color, #3f3f46);
+    color: var(--p-text-color, #fafafa); }
+  .cmcp-cv-iconbtn { position: relative; background: transparent; border: 1px solid var(--p-content-border-color,#3f3f46);
+    color: var(--p-text-color,#fafafa); border-radius: 8px; padding: .35rem .5rem; cursor: pointer; }
+  .cmcp-cv-dot { position: absolute; top: -3px; right: -3px; width: 8px; height: 8px; border-radius: 50%;
+    background: var(--p-primary-color, #3a7bd5); }
+  .cmcp-cv-body { position: relative; flex: 1; overflow-y: auto; padding: .6rem; }
+  .cmcp-cv-frow { display: flex; flex-wrap: wrap; gap: .3rem; align-items: center; }
+  .cmcp-cv-chip { padding: .25rem .5rem; border-radius: 999px; font-size: .75rem; cursor: pointer;
+    border: 1px solid var(--p-content-border-color,#3f3f46); background: transparent; color: var(--p-text-color,#fafafa); }
+  .cmcp-cv-chip.on { background: var(--p-primary-color,#3a7bd5); border-color: transparent; color:#fff; }
+  /* Agent-driven "glow" — shared across every surface (steps, cards, fields). */
+  .cmcp-agent-glow { outline: 2px solid var(--p-green-400,#4ade80);
+    box-shadow: 0 0 0 2px var(--p-green-400,#4ade80), 0 0 16px 2px rgba(74,222,128,.6);
+    border-radius: 8px; animation: cmcp-glow 1.4s ease-in-out infinite; }
+  @keyframes cmcp-glow { 50% { box-shadow: 0 0 0 3px var(--p-green-400,#4ade80),
+    0 0 24px 6px rgba(74,222,128,.9); } }
+  /* Agent-driven side-dock: anchor to the canvas side opposite the Agent pane,
+     drop the dim backdrop, let clicks pass THROUGH the overlay so chat stays
+     interactive; only the card catches pointer events. Slides in via translateX;
+     close() reverses it before detaching. Below the lightbox (z 10002). */
+  .cmcp-cv-overlay.cmcp-docked { display: block; padding: 0; background: transparent;
+    pointer-events: none; }
+  .cmcp-cv-overlay.cmcp-docked .cmcp-modal { position: fixed; pointer-events: auto;
+    width: auto; max-width: none; height: auto; max-height: none; border-radius: 0;
+    box-shadow: -8px 0 32px rgba(0,0,0,.45); transform: translateX(24px); opacity: 0;
+    transition: transform .28s ease, opacity .28s ease; }
+  .cmcp-cv-overlay.cmcp-docked.cmcp-dock-in .cmcp-modal { transform: translateX(0); opacity: 1; }
+  /* Responsive tab bar (container query): a narrow docked panel collapses to
+     icon-only tabs even on a wide screen. */
+  @container (max-width: 400px) {
+    .cmcp-cv-tab span { position: absolute; width: 1px; height: 1px; overflow: hidden;
+      clip-path: inset(50%); white-space: nowrap; }
+    .cmcp-cv-tab { padding: .3rem .45rem; }
+  }
+  `;
+  const style = document.createElement("style");
+  style.textContent = css;
+  document.head.appendChild(style);
+}
+
+const el = (tag, cls, txt) => {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (txt != null) n.textContent = txt;
+  return n;
+};
+
+/** Slide/fade the panel out before detaching (shared exit). Docked: reverse the
+ *  translateX slide-in (drop cmcp-dock-in); centered/narrow: a plain opacity
+ *  fade. The DOM is removed after the transition window (jsdom fires no
+ *  transitionend, so a fixed timer drives it). Idempotent. */
+const DOCK_SLIDE_OUT_MS = 240;
+function slideOutThenRemove(overlay) {
+  const docked = overlay.classList.contains("cmcp-docked");
+  overlay.style.pointerEvents = "none";
+  if (docked) {
+    overlay.classList.remove("cmcp-dock-in");
+  } else {
+    overlay.style.transition = "opacity .18s ease";
+    overlay.style.opacity = "0";
+  }
+  setTimeout(() => { try { overlay.remove(); } catch { /* already gone */ } }, DOCK_SLIDE_OUT_MS);
+}
+
+/**
+ * Open the unified side-panel. Returns a single self-invalidating handle:
+ *   { close, focus, isOpen, update, switchTab, activeTab, civitai:{…}, training:{…} }
+ * The civitai/training facades delegate to the ACTIVE content's `drive`; if the
+ * active tab isn't that surface they throw the legacy "…not open" message the
+ * bridge expects.
+ *
+ * opts = { tab, tabOpts:{civitai?,apps?,training?,local?}, dock, onClose }.
+ */
+export function openSidePanel(ctx = {}, opts = {}) {
+  injectCss();
+  const tabOpts = opts.tabOpts || {};
+  const initialKey = TABS.some((t) => t.key === opts.tab) ? opts.tab : "civitai";
+
+  // ── DOM skeleton ───────────────────────────────────────────────────────────
+  const overlay = el("div", "cmcp-cv-overlay");
+  const modal = el("div", "cmcp-modal cmcp-sidepanel");
+  const head = el("div", "cmcp-cv-head");
+  const tabsWrap = el("div", "cmcp-cv-tabs");
+  const closeBtn = el("button", "cmcp-cv-iconbtn");
+  closeBtn.innerHTML = '<i class="pi pi-times"></i>';
+  closeBtn.title = "Close";
+  closeBtn.style.marginLeft = "auto";
+  head.append(tabsWrap, closeBtn);
+
+  const subnav = el("div", "cmcp-cv-subnav");
+  const searchEl = el("input", "cmcp-cv-search");
+  // type=search (not text) so a visible shared box never collides with a tab
+  // body's own input[type=text] fields (e.g. training's dataset-name/trigger,
+  // which specs locate positionally).
+  searchEl.type = "search";
+  searchEl.placeholder = "Search…";
+  const extras = el("div", "cmcp-cv-frow"); // content-provided subnav content
+  extras.style.flex = "1 1 auto";
+  subnav.append(searchEl, extras);
+
+  const body = el("div", "cmcp-cv-body");
+
+  modal.append(head, subnav, body);
+  overlay.appendChild(modal);
+  document.body.appendChild(overlay);
+
+  // ── lifecycle state ─────────────────────────────────────────────────────────
+  let isOpen = true;
+  let activeKey = null;
+  const contents = new Map(); // key → content instance (lazy)
+  let _onEscape = null;
+  let _onDockResize = null;
+  let _dockDispose = null;
+
+  const close = () => {
+    if (!isOpen) return; // idempotent
+    isOpen = false;
+    if (_onEscape) { document.removeEventListener("keydown", _onEscape); _onEscape = null; }
+    if (_onDockResize) { window.removeEventListener("resize", _onDockResize); _onDockResize = null; }
+    if (_dockDispose) { try { _dockDispose(); } catch { /* best effort */ } _dockDispose = null; }
+    for (const c of contents.values()) { try { c.teardown?.(); } catch { /* already gone */ } }
+    slideOutThenRemove(overlay);
+    try { opts.onClose?.(); } catch { /* host bookkeeping only */ }
+  };
+  // In docked mode the overlay is click-through, so a backdrop mousedown never
+  // fires; the header ✕ / Escape are the dismissals. Centered keeps backdrop-close.
+  overlay.addEventListener("mousedown", (e) => { if (e.target === overlay) close(); });
+  closeBtn.addEventListener("click", close);
+  _onEscape = (e) => {
+    if (e.key !== "Escape") return;
+    // Yield to a content-owned stacked layer (the Civitai lightbox / sub-modals).
+    const active = contents.get(activeKey);
+    if (active && typeof active.escapeBlocked === "function") {
+      try { if (active.escapeBlocked()) return; } catch { /* fall through to close */ }
+    }
+    e.stopPropagation();
+    close();
+  };
+  document.addEventListener("keydown", _onEscape);
+
+  // ── docked mode ─────────────────────────────────────────────────────────────
+  applyDock.centered = false;
+  function applyDock() {
+    if (!opts.dock) { setCentered(); return; }
+    const geo = _dockGeometry();
+    if (geo?.status === "detached") { overlay.style.display = "none"; return; }
+    overlay.style.display = "";
+    if (geo?.status === "docked" && window.innerWidth >= 900) {
+      overlay.classList.add("cmcp-docked");
+      modal.style.left = `${Math.round(geo.left)}px`;
+      modal.style.top = `${Math.round(geo.top)}px`;
+      modal.style.right = `${Math.round(geo.right)}px`;
+      modal.style.bottom = `${Math.round(geo.bottom)}px`;
+      applyDock.centered = false;
+    } else {
+      setCentered();
+    }
+  }
+  function setCentered() {
+    overlay.classList.remove("cmcp-docked");
+    overlay.style.display = "";
+    modal.style.left = modal.style.right = modal.style.top = modal.style.bottom = "";
+    applyDock.centered = true;
+  }
+  function _dockGeometry() {
+    if (typeof ctx.dockGeometry === "function") {
+      try { const g = ctx.dockGeometry(); if (g) return g; } catch { /* fall through */ }
+    }
+    try {
+      const root = ctx.root;
+      if (root && !root.isConnected) return { status: "detached" };
+      const pane = root?.closest?.(".side-bar-panel") || root?.closest?.("[class*='sidebar']") || root;
+      const pr = pane?.getBoundingClientRect?.();
+      if (!pr || pr.width < 1 || pr.height < 1) return { status: "centered" };
+      const vw = window.innerWidth, vh = window.innerHeight;
+      const paneOnLeft = (pr.left + pr.right) / 2 < vw / 2;
+      const left = paneOnLeft ? Math.max(0, pr.right) : 0;
+      const right = paneOnLeft ? 0 : Math.max(0, vw - pr.left);
+      if (vw - left - right < 320) return { status: "centered" };
+      return { status: "docked", left, right, top: Math.max(0, pr.top), bottom: Math.max(0, vh - pr.bottom) };
+    } catch { return { status: "centered" }; }
+  }
+
+  // ── shared search row ────────────────────────────────────────────────────────
+  function syncSearch() {
+    const c = contents.get(activeKey);
+    const has = c ? (typeof c.hasSearch === "function" ? c.hasSearch() : !!c.hasSearch) : false;
+    searchEl.style.display = has ? "" : "none";
+    if (has && c) searchEl.placeholder = c.searchPlaceholder || "Search…";
+  }
+  searchEl.addEventListener("input", () => {
+    const c = contents.get(activeKey);
+    if (c && typeof c.onSearch === "function") c.onSearch(searchEl.value, {});
+  });
+  searchEl.addEventListener("keydown", (e) => {
+    if (e.key !== "Enter") return;
+    const c = contents.get(activeKey);
+    if (c && typeof c.onSearch === "function") c.onSearch(searchEl.value, { enter: true });
+  });
+
+  // ── the object handed to content providers ───────────────────────────────────
+  const shell = {
+    ctx, overlay, modal, body, searchEl, subnav, extras, head,
+    close, applyDock, syncSearch,
+    isDocked: () => overlay.classList.contains("cmcp-docked") && !applyDock.centered,
+    isCentered: () => applyDock.centered,
+  };
+
+  // ── tab bar + activation ─────────────────────────────────────────────────────
+  function ensureContent(key) {
+    if (contents.has(key)) return contents.get(key);
+    const def = TABS.find((t) => t.key === key);
+    const inst = def.factory(ctx, shell, tabOpts[key] || {});
+    contents.set(key, inst);
+    return inst;
+  }
+  /** Activate a tab: deactivate the prior one, clear the body/subnav, mount the
+   *  next, then re-dock WITHOUT replaying the slide-in. */
+  function activate(key, { reseed = null } = {}) {
+    if (!isOpen) return null;
+    if (activeKey === key) {
+      const cur = contents.get(key);
+      if (reseed && cur && typeof cur.reseed === "function") { try { cur.reseed(reseed); } catch { /* ignore */ } }
+      return cur;
+    }
+    const prev = contents.get(activeKey);
+    if (prev && typeof prev.onDeactivate === "function") { try { prev.onDeactivate(); } catch { /* ignore */ } }
+    body.textContent = "";
+    extras.textContent = "";
+    for (const a of Object.values(ALIAS)) modal.classList.remove(a);
+    activeKey = key;
+    for (const b of tabsWrap.children) b.classList.toggle("active", b._key === key);
+    if (ALIAS[key]) modal.classList.add(ALIAS[key]);
+    const inst = ensureContent(key);
+    const ex = typeof inst.subnavExtras === "function" ? inst.subnavExtras() : null;
+    for (const n of (ex || [])) if (n) extras.appendChild(n);
+    inst.mount(body);
+    if (reseed && typeof inst.reseed === "function") { try { inst.reseed(reseed); } catch { /* ignore */ } }
+    syncSearch();
+    if (typeof inst.onActivate === "function") { try { inst.onActivate(); } catch { /* ignore */ } }
+    applyDock(); // re-dock (no slide replay: cmcp-dock-in stays set)
+    return inst;
+  }
+
+  for (const t of TABS) {
+    const b = el("button", "cmcp-cv-tab");
+    b.innerHTML = `<i class="pi ${t.icon}"></i><span>${t.label}</span>`;
+    b._key = t.key;
+    b.addEventListener("click", () => activate(t.key));
+    tabsWrap.appendChild(b);
+  }
+
+  // ── go: mount the initial tab, then wire the dock + slide-in ──────────────────
+  activate(initialKey);
+  if (opts.dock) {
+    applyDock();
+    if (typeof ctx.watchDock === "function") {
+      try { _dockDispose = ctx.watchDock(applyDock); } catch { _dockDispose = null; }
+    }
+    if (!_dockDispose) { _onDockResize = () => applyDock(); window.addEventListener("resize", _onDockResize); }
+    requestAnimationFrame(() => overlay.classList.add("cmcp-dock-in"));
+  }
+
+  // ── agent-drive facade ───────────────────────────────────────────────────────
+  function _driveOf(kind, legacyMsg, method, args) {
+    const c = contents.get(activeKey);
+    if (!isOpen || !c || c.driveKind !== kind || !c.drive || typeof c.drive[method] !== "function") {
+      throw new Error(legacyMsg);
+    }
+    return c.drive[method](...args);
+  }
+  const civitai = {
+    getResults: (a) => _driveOf("civitai", "civitai browser not open", "getResults", [a]),
+    highlight: (ids, o) => _driveOf("civitai", "civitai browser not open", "highlight", [ids, o]),
+    clearHighlight: () => _driveOf("civitai", "civitai browser not open", "clearHighlight", []),
+    switchTab: (t) => _driveOf("civitai", "civitai browser not open", "switchTab", [t]),
+    search: (a) => _driveOf("civitai", "civitai browser not open", "search", [a]),
+    openLightbox: (id, o) => _driveOf("civitai", "civitai browser not open", "openLightbox", [id, o]),
+    getState: () => _driveOf("civitai", "civitai browser not open", "getState", []),
+  };
+  const training = {
+    getState: () => _driveOf("training", "training wizard not open", "getState", []),
+    setField: (n, v) => _driveOf("training", "training wizard not open", "setField", [n, v]),
+    gotoStep: (s) => _driveOf("training", "training wizard not open", "gotoStep", [s]),
+    setTarget: (t) => _driveOf("training", "training wizard not open", "setTarget", [t]),
+    highlight: (r) => _driveOf("training", "training wizard not open", "highlight", [r]),
+    clearHighlight: () => _driveOf("training", "training wizard not open", "clearHighlight", []),
+  };
+
+  return {
+    close,
+    isOpen: () => isOpen,
+    activeTab: () => activeKey,
+    focus: () => { try { if (searchEl.style.display !== "none") searchEl.focus(); } catch { /* detached */ } },
+    // RunPod status frames → re-render the active content (no-op unless Local).
+    update: () => { const c = contents.get(activeKey); if (c && typeof c.update === "function") { try { c.update(); } catch { /* ignore */ } } },
+    // Switch the top-level tab (host uses this when the panel is already open).
+    switchTab: (key, reseed) => { activate(key, { reseed }); return { tab: activeKey }; },
+    civitai,
+    training,
+  };
+}

--- a/web/js/cmcp-training-ui.js
+++ b/web/js/cmcp-training-ui.js
@@ -1339,7 +1339,18 @@ export function createTrainingContent(ctx = {}, shell, opts = {}) {
     searchPlaceholder: "Filter outputs by filename…",
     subnavExtras: () => [jobsBtn],
     mount(bodyEl) { bodyEl.append(stepsBar, body); },
-    onActivate() { if (!_started) { _started = true; show("flows"); } },
+    onActivate() {
+      // First activation lands on Flows; every re-activation RE-ENTERS the
+      // current view so its renderer rebinds to the freshly re-mounted DOM — and
+      // in particular the Monitor poll re-arms (renderMonitor bumps pollGen +
+      // poll()) after having been stopped on deactivate. All field state lives in
+      // `wiz`, so a re-render is lossless (inputs re-seed from wiz).
+      if (!_started) { _started = true; show("flows"); }
+      else show(currentView);
+    },
+    // Halt the monitor poll while the tab is hidden — otherwise it keeps writing
+    // to the DOM the shell detached on switch (frozen monitor after a round-trip).
+    onDeactivate() { stopPolling(); },
     onSearch(value) {
       outputsFilter = value;
       if (repaintOutputs) repaintOutputs();

--- a/web/js/cmcp-training-ui.js
+++ b/web/js/cmcp-training-ui.js
@@ -10,17 +10,17 @@
 //    output listing, image-ref → absolute-path resolution, and serving
 //    training-sample images from the rig's training root.
 
+import { openSidePanel } from "./cmcp-sidepanel-ui.js";
+
 let cssInjected = false;
 function injectCss() {
   if (cssInjected) return;
   cssInjected = true;
   const style = document.createElement("style");
   style.textContent = `
-    /* Self-contained overlay + modal base (the CivitAI modal's .cmcp-cv-overlay
-       styles only exist once that modal has opened, and the base .cmcp-modal is
-       a narrow confirm-dialog — neither can be relied on here). */
-    .cmcp-cv-overlay { position: fixed; inset: 0; z-index: 10000; display: flex;
-      align-items: center; justify-content: center; padding: 1.5rem; background: rgba(0,0,0,.6); }
+    /* The unified side-panel shell (cmcp-sidepanel-ui.js) owns the overlay + dock
+       + slide + Escape; this keeps only the .cmcp-tr-* wizard body CSS. The
+       .cmcp-modal.cmcp-tr-modal sizing rule is the active-tab alias. */
     .cmcp-modal.cmcp-tr-modal { width: min(94vw, 960px); max-width: none;
       max-height: min(92vh, 880px); padding: 0; gap: 0; overflow: hidden;
       display: flex; flex-direction: column; }
@@ -95,15 +95,6 @@ function injectCss() {
       border-radius: 8px; animation: cmcp-glow 1.4s ease-in-out infinite; }
     @keyframes cmcp-glow { 50% { box-shadow: 0 0 0 3px var(--p-green-400,#4ade80),
       0 0 24px 6px rgba(74,222,128,.9); } }
-    /* Agent-driven side-dock (parity with the CivitAI modal): anchor to the
-       sidebar's right edge, drop the backdrop, keep chat interactive. */
-    .cmcp-cv-overlay.cmcp-docked { display: block; padding: 0; background: transparent;
-      pointer-events: none; }
-    .cmcp-cv-overlay.cmcp-docked .cmcp-tr-modal { position: fixed; pointer-events: auto;
-      width: auto; max-width: none; max-height: none; border-radius: 0;
-      box-shadow: -8px 0 32px rgba(0,0,0,.45); transform: translateX(24px); opacity: 0;
-      transition: transform .28s ease, opacity .28s ease; }
-    .cmcp-cv-overlay.cmcp-docked.cmcp-dock-in .cmcp-tr-modal { transform: translateX(0); opacity: 1; }
   `;
   document.head.appendChild(style);
 }
@@ -150,25 +141,6 @@ function el(tag, cls, text) {
   if (cls) e.className = cls;
   if (text !== undefined) e.textContent = text;
   return e;
-}
-
-/** Slide/fade the panel out before detaching (shared exit for the three docked
- *  side-panels). Docked: reverse the translateX slide-in (drop cmcp-dock-in) so
- *  the card slides back out; centered/narrow: a plain opacity fade — no
- *  horizontal slide. The DOM is removed after the transition window (jsdom fires
- *  no transitionend, so a fixed timer drives it). Idempotent — remove() on an
- *  already-detached node is a no-op. */
-const DOCK_SLIDE_OUT_MS = 240;
-function slideOutThenRemove(overlay) {
-  const docked = overlay.classList.contains("cmcp-docked");
-  overlay.style.pointerEvents = "none";
-  if (docked) {
-    overlay.classList.remove("cmcp-dock-in"); // card returns to translateX(24px)/opacity 0
-  } else {
-    overlay.style.transition = "opacity .18s ease";
-    overlay.style.opacity = "0";
-  }
-  setTimeout(() => { try { overlay.remove(); } catch { /* already gone */ } }, DOCK_SLIDE_OUT_MS);
 }
 
 /** callTool envelope → parsed JSON (train_* tools return text-wrapped JSON). */
@@ -249,46 +221,42 @@ function fmtAgo(iso) {
 
 const STATUS_BADGE = { running: "ok", queued: "warn", completed: "ok", failed: "err", cancelled: "warn" };
 
-export function openTrainingModal(ctx = {}, opts = {}) {
+/** Content-provider factory for the LoRA Training tab of the unified side panel.
+ *  The shell owns the overlay/header/✕/dock/Escape; this builds the wizard body +
+ *  the agent-drive surface. The shared search filters the outputs grid on the
+ *  Dataset step (decision B); it's hidden everywhere else. */
+export function createTrainingContent(ctx = {}, shell, opts = {}) {
   injectCss();
-  const overlay = document.createElement("div");
-  overlay.className = "cmcp-cv-overlay";
-  const modal = document.createElement("div");
-  modal.className = "cmcp-modal cmcp-tr-modal";
+  const modal = shell.modal; // for data-ref query + highlight scoping
 
   let pollTimer = null;
   let pollGen = 0;
   let closed = false;
-  let _onDockResize = null;
-  let _dockDispose = null;
-  let _onEscape = null;
   // train_doctor generation: every doctor request captures the current value;
   // only the NEWEST completion may write wiz.podInfo, so a slow stale doctor
   // can't resurrect a pod that a later check found gone (codex finding).
   let doctorGen = 0;
+  let _started = false;
+  // Shared-search → outputs filename filter (decision B). outputsTabActive gates
+  // whether the search shows at all (the Upload sub-tab has nothing to filter).
+  let outputsFilter = "";
+  let outputsTabActive = false;
+  let repaintOutputs = null; // renderOutputs' paint(), so onSearch can re-run it
   const stopPolling = () => {
     pollGen++; // invalidate any in-flight poll response
     if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; }
   };
-  const close = () => {
+  // close() closes the WHOLE side panel; teardown() (run by the shell) does the
+  // async cleanup — parity with the old close() minus the DOM/dock/Escape/slide
+  // that the shell now owns.
+  const close = () => { try { shell.close(); } catch { /* already gone */ } };
+  function teardown() {
     if (closed) return; // idempotent
     closed = true;
     stopPolling();
-    if (_onEscape) { document.removeEventListener("keydown", _onEscape); _onEscape = null; }
-    if (_onDockResize) { window.removeEventListener("resize", _onDockResize); _onDockResize = null; }
-    if (_dockDispose) { try { _dockDispose(); } catch { /* best effort */ } _dockDispose = null; }
     wiz.launchGen++; // a pending launch's continuation self-discards (codex finding)
     wiz.uploadGen++;
-    // Slide/fade the card out, THEN detach (parity with the CivitAI + RunPod
-    // side-panels). `closed` already true above, so the exit window is inert;
-    // host bookkeeping (onClose) still runs now.
-    slideOutThenRemove(overlay);
-    try { opts.onClose?.(); } catch { /* host bookkeeping only */ }
-  };
-  overlay.addEventListener("mousedown", (e) => { if (e.target === overlay) close(); });
-  // Base modal had no Escape handler (audit item 9) — add one through close().
-  _onEscape = (e) => { if (e.key === "Escape") { e.stopPropagation(); close(); } };
-  document.addEventListener("keydown", _onEscape);
+  }
 
   // Wizard state (one character-LoRA job being configured/tracked). Held at
   // modal scope so it survives view navigation: launching/uploadsPending MUST
@@ -348,74 +316,14 @@ export function openTrainingModal(ctx = {}, opts = {}) {
     return true;
   }
 
-  const head = el("div", "cmcp-tr-head");
-  const title = el("h2", null, "LoRA Training");
+  // Jobs button → shell subnav (via subnavExtras). The shell owns the ✕/title.
   const jobsBtn = el("button", "cmcp-tr-btn", "Jobs");
   jobsBtn.style.flex = "none";
-  const closeBtn = el("button", "cmcp-tr-close");
-  closeBtn.innerHTML = "&#10005;";
-  closeBtn.title = "Close";
-  closeBtn.onclick = close;
-  head.append(title, jobsBtn, closeBtn);
 
+  // Step chips (carry data-ref) + the wizard body, mounted into the shell's
+  // .cmcp-cv-body scroll surface.
   const stepsBar = el("div", "cmcp-tr-steps");
   const body = el("div", "cmcp-tr-body");
-  modal.append(head, stepsBar, body);
-  overlay.appendChild(modal);
-  document.body.appendChild(overlay);
-
-  // ── docked mode (agent-driven, parity with the CivitAI modal) ───────────────
-  // Geometry from the host (ctx.dockGeometry owns pane/canvas measurement +
-  // left/right detection); three states detached(hide)/centered/docked. See the
-  // CivitAI modal for the full rationale.
-  applyDock.centered = false;
-  function applyDock() {
-    if (!opts.dock) { setCentered(); return; }
-    const geo = _dockGeometry();
-    if (geo?.status === "detached") { overlay.style.display = "none"; return; }
-    overlay.style.display = "";
-    if (geo?.status === "docked" && window.innerWidth >= 900) {
-      overlay.classList.add("cmcp-docked");
-      modal.style.left = `${Math.round(geo.left)}px`;
-      modal.style.top = `${Math.round(geo.top)}px`;
-      modal.style.right = `${Math.round(geo.right)}px`;
-      modal.style.bottom = `${Math.round(geo.bottom)}px`;
-      modal.style.height = "auto";
-      applyDock.centered = false;
-    } else { setCentered(); }
-  }
-  function setCentered() {
-    overlay.classList.remove("cmcp-docked");
-    overlay.style.display = "";
-    modal.style.left = modal.style.right = modal.style.top = modal.style.bottom = modal.style.height = "";
-    applyDock.centered = true;
-  }
-  function _dockGeometry() {
-    if (typeof ctx.dockGeometry === "function") {
-      try { const g = ctx.dockGeometry(); if (g) return g; } catch { /* fall through */ }
-    }
-    try {
-      const root = ctx.root;
-      if (root && !root.isConnected) return { status: "detached" };
-      const pane = root?.closest?.(".side-bar-panel") || root?.closest?.("[class*='sidebar']") || root;
-      const pr = pane?.getBoundingClientRect?.();
-      if (!pr || pr.width < 1 || pr.height < 1) return { status: "centered" };
-      const vw = window.innerWidth, vh = window.innerHeight;
-      const paneOnLeft = (pr.left + pr.right) / 2 < vw / 2;
-      const left = paneOnLeft ? Math.max(0, pr.right) : 0;
-      const right = paneOnLeft ? 0 : Math.max(0, vw - pr.left);
-      if (vw - left - right < 320) return { status: "centered" };
-      return { status: "docked", left, right, top: Math.max(0, pr.top), bottom: Math.max(0, vh - pr.bottom) };
-    } catch { return { status: "centered" }; }
-  }
-  if (opts.dock) {
-    applyDock();
-    if (typeof ctx.watchDock === "function") {
-      try { _dockDispose = ctx.watchDock(applyDock); } catch { _dockDispose = null; }
-    }
-    if (!_dockDispose) { _onDockResize = () => applyDock(); window.addEventListener("resize", _onDockResize); }
-    requestAnimationFrame(() => overlay.classList.add("cmcp-dock-in"));
-  }
 
   // Stable step namespace (audit item 7): refs survive the body rebuild every
   // show(view) because they're regenerated deterministically per render.
@@ -445,6 +353,10 @@ export function openTrainingModal(ctx = {}, opts = {}) {
     if (closed) return;
     currentView = view;
     stopPolling();
+    // Leaving/re-entering any view resets the outputs-filter binding; renderOutputs
+    // re-arms it. The shell re-evaluates search visibility at the end.
+    outputsTabActive = false;
+    repaintOutputs = null;
     body.textContent = "";
     if (view === "flows") { setSteps(null); renderFlows(); }
     else if (view === "jobs") { setSteps(null); renderJobs(); }
@@ -455,6 +367,7 @@ export function openTrainingModal(ctx = {}, opts = {}) {
     // Re-glow after the new view's DOM exists (renderers can be async but stamp
     // their static refs synchronously; async content re-applies on its own).
     reapplyHighlight();
+    try { shell.syncSearch(); } catch { /* not mounted yet */ }
   }
 
   jobsBtn.onclick = () => show("jobs");
@@ -601,18 +514,17 @@ export function openTrainingModal(ctx = {}, opts = {}) {
         : wiz.uploadsPending > 0 ? `Waiting for ${wiz.uploadsPending} upload(s)…` : "";
     }
 
-    // Outputs tab.
+    // Outputs tab. The filename filter is the shell's shared search box
+    // (decision B) — no local input; paint() reads `outputsFilter`.
     let refreshGridSel = null;
     async function renderOutputs() {
       tabBody.textContent = "";
-      const filterRow = el("div", "cmcp-tr-row");
-      const filter = el("input", null);
-      filter.type = "text";
-      filter.placeholder = "Filter by filename…";
-      filterRow.appendChild(filter);
+      outputsTabActive = true;
+      try { shell.searchEl.value = outputsFilter; } catch { /* not mounted */ }
+      try { shell.syncSearch(); } catch { /* not mounted */ }
       const grid = el("div", "cmcp-tr-pickgrid");
       const status = el("p", "cmcp-tr-hint", "Loading recent outputs…");
-      tabBody.append(filterRow, status, grid);
+      tabBody.append(status, grid);
       let images = [];
       try {
         const res = await apiFetch(ctx, "/comfyui_mcp_panel/training/list-outputs?limit=120");
@@ -626,7 +538,7 @@ export function openTrainingModal(ctx = {}, opts = {}) {
       const isSel = (img) => wiz.images.some((w) => w.ref.filename === img.filename && (w.ref.subfolder || "") === (img.subfolder || "") && w.ref.type === "output");
       function paint() {
         grid.textContent = "";
-        const pat = filter.value.trim().toLowerCase();
+        const pat = outputsFilter.trim().toLowerCase();
         for (const img of images) {
           if (pat && !img.filename.toLowerCase().includes(pat)) continue;
           const cell = el("div", "cmcp-tr-pick");
@@ -651,8 +563,8 @@ export function openTrainingModal(ctx = {}, opts = {}) {
           grid.appendChild(cell);
         }
         refreshGridSel = paint;
+        repaintOutputs = paint; // the shared search re-runs this via onSearch
       }
-      filter.oninput = paint;
       paint();
     }
 
@@ -752,7 +664,13 @@ export function openTrainingModal(ctx = {}, opts = {}) {
     }
 
     outTab.onclick = () => { outTab.classList.add("active"); upTab.classList.remove("active"); renderOutputs(); };
-    upTab.onclick = () => { upTab.classList.add("active"); outTab.classList.remove("active"); renderUpload(); };
+    upTab.onclick = () => {
+      upTab.classList.add("active"); outTab.classList.remove("active");
+      // Upload has nothing to filter — hide the shared search.
+      outputsTabActive = false; repaintOutputs = null;
+      try { shell.syncSearch(); } catch { /* not mounted */ }
+      renderUpload();
+    };
     renderOutputs();
     syncTray();
     syncNext();
@@ -1324,7 +1242,7 @@ export function openTrainingModal(ctx = {}, opts = {}) {
       preset: wiz.preset, images: wiz.images.length,
       launching: !!wiz.launching, jobId: wiz.jobId || null,
       podAvailable: !!(wiz.podInfo && wiz.podInfo.ssh),
-      docked: !applyDock.centered && overlay.classList.contains("cmcp-docked"),
+      docked: shell.isDocked(),
       highlighted: wiz.highlightRefs.slice(),
       readiness: _readiness(),
     };
@@ -1413,10 +1331,29 @@ export function openTrainingModal(ctx = {}, opts = {}) {
     return { ok: true };
   }
 
-  show("flows");
+  // ── content provider (the shell owns the chrome; this owns the body) ──────
   return {
-    close, getState: driveGetState, setField: driveSetField,
-    gotoStep: driveGotoStep, setTarget: driveSetTarget,
-    highlight: driveHighlight, clearHighlight: driveClearHighlight,
+    key: "training", label: "Training", icon: "pi-bolt", driveKind: "training",
+    // Search filters the outputs grid on the Dataset step only (decision B).
+    hasSearch: () => currentView === "wizard-1" && outputsTabActive,
+    searchPlaceholder: "Filter outputs by filename…",
+    subnavExtras: () => [jobsBtn],
+    mount(bodyEl) { bodyEl.append(stepsBar, body); },
+    onActivate() { if (!_started) { _started = true; show("flows"); } },
+    onSearch(value) {
+      outputsFilter = value;
+      if (repaintOutputs) repaintOutputs();
+    },
+    update: () => {},
+    teardown,
+    drive: {
+      getState: driveGetState, setField: driveSetField, gotoStep: driveGotoStep,
+      setTarget: driveSetTarget, highlight: driveHighlight, clearHighlight: driveClearHighlight,
+    },
   };
+}
+
+/** Thin back-compat wrapper: opens the unified side panel on the Training tab. */
+export function openTrainingModal(ctx = {}, opts = {}) {
+  return openSidePanel(ctx, { tab: "training", dock: opts.dock, onClose: opts.onClose });
 }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -73,10 +73,7 @@ import {
   workflowAliasForPath,
 } from "./lib/workflow-chat-identity.js";
 import { validateA2UISpec, renderA2UICard, renderA2UIInert, renderA2UIFailCard, A2UI_CSS } from "./cmcp-a2ui.js";
-import { openCivitaiModal } from "./cmcp-civitai-ui.js";
-import { openRunpodModal } from "./cmcp-runpod-ui.js";
-import { openAppsModal } from "./cmcp-apps-ui.js";
-import { openTrainingModal } from "./cmcp-training-ui.js";
+import { openSidePanel } from "./cmcp-sidepanel-ui.js";
 
 let app = null;
 let api = null;
@@ -10047,12 +10044,13 @@ function buildPanel() {
   ring.style.cursor = "pointer"; ring.onclick = deafenBtn.onclick; // clicking the ring toggles deafen
   reflectFeedGates();
 
-  // Civitai explorer — opens the in-panel CivitAI browser modal. Also opened BY
-  // the agent (cmd:open_civitai) pre-seeded with a query + filters.
+  // Unified side panel (issue #124): ONE tabbed overlay hosting Civitai / Apps /
+  // Training / Local-RunPod. openSidePanelTab opens it (or switches tab if it is
+  // already open); the four openX wrappers + toolbar buttons all route through it.
   // Mark: Civitai's hexagon-C, monochrome via currentColor (no brand gradients,
   // no event attrs — keeps the registry's SVG YARA gate happy).
-  let _civitaiHandle = null;
-  function civitaiCtx() {
+  let _sidePanelHandle = null;
+  function sidePanelCtx() {
     return {
       api,
       root,
@@ -10066,14 +10064,18 @@ function buildPanel() {
       isMuted: () => AGENT_MUTED,
       marked,
       DOMPurify,
-      // Canvas access for "load workflow onto canvas": dirty check for the
-      // confirm-overwrite prompt, then the SAME undoable path the bridge's
-      // graph_load command takes (snapshot → await loadGraphData → checkState,
-      // so one load = one Ctrl+Z step). Rejects with a readable message when
-      // the graph isn't a loadable UI workflow or the load itself fails.
-      // Dirty check fails CLOSED: when the workflow state can't be read
-      // (older frontend, missing service, throw), report dirty so the caller
-      // confirms instead of silently clobbering an unsaved canvas.
+      // Apps tab: live canvas app; Local tab: honest host + pod status frames.
+      getApp: () => app,
+      getRunpodTarget: () => _comfyuiTarget,
+      getStatus: () => _runpodStatus,
+      getTarget: () => _comfyuiTarget,
+      openUrl: (u) => { try { window.open(u, "_blank", "noopener"); } catch {} },
+      // Canvas access for "load workflow onto canvas" (Civitai tab): dirty check
+      // for the confirm-overwrite prompt, then the SAME undoable path the bridge's
+      // graph_load command takes (snapshot → await loadGraphData → checkState, so
+      // one load = one Ctrl+Z step). Dirty check fails CLOSED: when the workflow
+      // state can't be read (older frontend, missing service, throw), report dirty
+      // so the caller confirms instead of silently clobbering an unsaved canvas.
       graphIsDirty: () => {
         try {
           const wf = app?.extensionManager?.workflow?.activeWorkflow;
@@ -10090,18 +10092,30 @@ function buildPanel() {
       },
     };
   }
-  function openCivitai(opts) {
-    try { _civitaiHandle?.close(); } catch {}
-    const handle = openCivitaiModal(civitaiCtx(), {
-      ...(opts || {}),
-      // Null the stored handle whenever THIS modal closes (✕, reopen, backdrop)
-      // so post-open drive cmds get an honest "not open" error instead of
-      // operating on a detached grid.
-      onClose: () => { if (_civitaiHandle === handle) _civitaiHandle = null; },
+  /** Open the unified side panel on `tab`, or switch to it if already open. */
+  function openSidePanelTab(tab, { tabOpts, dock = true } = {}) {
+    if (_sidePanelHandle?.isOpen?.()) {
+      try { _sidePanelHandle.switchTab(tab, tabOpts); } catch { /* stale */ }
+      return _sidePanelHandle;
+    }
+    const handle = openSidePanel(sidePanelCtx(), {
+      tab,
+      dock,
+      ...(tabOpts ? { tabOpts: { [tab]: tabOpts } } : {}),
+      // Null the stored handle whenever the panel closes (✕, Escape, backdrop) so
+      // post-open drive cmds get an honest "not open" error.
+      onClose: () => { if (_sidePanelHandle === handle) _sidePanelHandle = null; },
     });
-    _civitaiHandle = handle;
-    return _civitaiHandle;
+    _sidePanelHandle = handle;
+    return handle;
   }
+  const openCivitai = (opts = {}) => openSidePanelTab("civitai", {
+    dock: opts.dock !== false,
+    tabOpts: { query: opts.query, tab: opts.tab, filters: opts.filters, browsingLevels: opts.browsingLevels },
+  });
+  const openApps = () => openSidePanelTab("apps");
+  const openTraining = (opts = {}) => openSidePanelTab("training", { dock: opts.dock !== false });
+  const openRunpod = () => openSidePanelTab("local");
   const civitaiBtn = toolbarBtn("pi-circle", "Civitai");
   civitaiBtn.querySelector(".pi").remove();
   civitaiBtn.title = "Civitai explorer — browse and pull models, LoRAs, and workflows without leaving the panel.";
@@ -10132,24 +10146,6 @@ function buildPanel() {
   // ComfyUI APP-mode config) into a named, one-click app; runs headless via
   // the pack's py/apps_routes.py (canvas never touched). Grid of four rounded
   // squares (mini-app launcher mark), currentColor like the neighbors.
-  let _appsHandle = null;
-  function openApps(opts) {
-    try { _appsHandle?.close(); } catch {}
-    const handle = openAppsModal(
-      {
-        getApp: () => app,
-        uploadBlobToInput,
-        callTool: (t, a, o) => liveBridgeClient?.callTool(t, a, o),
-        getRunpodTarget: () => _comfyuiTarget,
-      },
-      {
-        ...(opts || {}),
-        onClose: () => { if (_appsHandle === handle) _appsHandle = null; },
-      },
-    );
-    _appsHandle = handle;
-    return _appsHandle;
-  }
   const appsBtn = toolbarBtn("pi-circle", "Apps");
   appsBtn.querySelector(".pi").remove();
   appsBtn.title = "Apps — one-click micro-apps built from workflows: convert, run locally or on RunPod, share.";
@@ -10172,28 +10168,7 @@ function buildPanel() {
 
   // LoRA Training — the dataset gather/label/launch/monitor wizard for the
   // local trainer (ai-toolkit in a GPU container, train_* tools over call_tool).
-  // Same modal treatment as the CivitAI browser; dumbbell mark via currentColor.
-  let _trainingHandle = null;
-  function trainingCtx() {
-    return {
-      api,
-      root,
-      dockGeometry: panelDockGeometry,
-      watchDock: panelWatchDock,
-      callTool: (t, a, o) => liveBridgeClient?.callTool(t, a, o),
-      uploadBlobToInput,
-    };
-  }
-  // Reused by both the toolbar button (centered) and the agent bridge (docked).
-  function openTraining(opts) {
-    try { _trainingHandle?.close(); } catch {}
-    const handle = openTrainingModal(trainingCtx(), {
-      ...(opts || {}),
-      onClose: () => { if (_trainingHandle === handle) _trainingHandle = null; },
-    });
-    _trainingHandle = handle;
-    return _trainingHandle;
-  }
+  // Same side-panel treatment as the CivitAI browser; dumbbell mark via currentColor.
   const trainingBtn = toolbarBtn("pi-circle", "Training");
   trainingBtn.querySelector(".pi").remove();
   trainingBtn.title = "LoRA Training — train a character LoRA locally on FLUX.1-dev (style/edit/slider/video coming in P2).";
@@ -10217,10 +10192,9 @@ function buildPanel() {
 
   // RunPod — cloud GPU control panel + honest host indicator. The button label
   // reflects WHERE renders run (Local vs the pod), so it doubles as the host
-  // pill; clicking opens the control modal (deploy / start / stop / connect /
-  // use-local). Driven by the orchestrator's `runpod_status` + `comfyui_target`
-  // frames (wired below). The pod runs our template → full canvas parity.
-  let _runpodHandle = null;
+  // pill; clicking opens the unified side panel on the Local tab (deploy / start
+  // / stop / connect / use-local). Driven by the orchestrator's `runpod_status` +
+  // `comfyui_target` frames (wired below). The pod runs our template → full parity.
   let _runpodStatus = null; // last runpod_status frame
   let _comfyuiTarget = null; // last comfyui_target frame
   const runpodBtn = toolbarBtn("pi-circle", "Local");
@@ -10281,31 +10255,20 @@ function buildPanel() {
       ? `Rendering on RunPod${gpu}${cost} — click to manage the pod or switch back to local.`
       : "Rendering locally on this machine — click to run this session on a cloud GPU (RunPod).") + alertNote;
   }
-  runpodBtn.addEventListener("click", () => {
-    try { _runpodHandle?.close(); } catch {}
-    _runpodHandle = openRunpodModal({
-      root,
-      callTool: (tool, args, o) => liveBridgeClient?.callTool(tool, args, o),
-      getStatus: () => _runpodStatus,
-      getTarget: () => _comfyuiTarget,
-      openUrl: (u) => { try { window.open(u, "_blank", "noopener"); } catch {} },
-      // Agent-drive side-dock geometry/observation (pane may be docked L or R),
-      // same helpers the CivitAI/Training modals use.
-      dockGeometry: panelDockGeometry,
-      watchDock: panelWatchDock,
-    }, { dock: true });
-  });
-  // Expose for the bridge callbacks (defined outside this closure).
+  runpodBtn.addEventListener("click", () => openRunpod());
+  // Expose for the bridge callbacks (defined outside this closure). Status/target
+  // frames update the host pill independently, and re-render the side panel's
+  // Local tab only when it's the active tab (update() no-ops on other tabs).
   panelRunpod = {
-    onStatus: (frame) => { _runpodStatus = frame; reflectRunpodHost(); if (_runpodHandle?.isOpen?.()) _runpodHandle.update(); },
-    onTarget: (frame) => { _comfyuiTarget = frame; reflectRunpodHost(); if (_runpodHandle?.isOpen?.()) _runpodHandle.update(); },
+    onStatus: (frame) => { _runpodStatus = frame; reflectRunpodHost(); if (_sidePanelHandle?.isOpen?.()) _sidePanelHandle.update(); },
+    onTarget: (frame) => { _comfyuiTarget = frame; reflectRunpodHost(); if (_sidePanelHandle?.isOpen?.()) _sidePanelHandle.update(); },
     onAlert: (frame) => {
       const id = frame && frame.pod_id;
       if (!id) return;
       if (frame.resolved || frame.reason === "resolved") _runpodAlerts.delete(id);
       else _runpodAlerts.set(id, frame);
       reflectRunpodHost();
-      if (_runpodHandle?.isOpen?.()) _runpodHandle.update();
+      if (_sidePanelHandle?.isOpen?.()) _sidePanelHandle.update();
     },
   };
   reflectRunpodHost();
@@ -11898,36 +11861,37 @@ function buildPanel() {
       });
       return { ok: true };
     },
-    // The agent DRIVES the already-open CivitAI browser (switch tab, re-search,
-    // read results, glow-highlight). Routes to the live modal handle; throws an
-    // honest "not open" error the agent can retry after re-opening.
+    // The agent DRIVES the already-open CivitAI browser tab (switch sub-tab,
+    // re-search, read results, glow-highlight). Routes to the unified side-panel
+    // handle's civitai facade; throws an honest "civitai browser not open" error
+    // (guard here, plus the facade re-checks the active tab).
     onCivitaiCmd(msg) {
-      const h = _civitaiHandle;
+      const h = _sidePanelHandle;
       if (!h) throw new Error("civitai browser not open");
       switch (msg.cmd) {
-        case "civitai_results": return h.getResults({ limit: msg.limit });
-        case "civitai_highlight": return h.highlight(Array.isArray(msg.ids) ? msg.ids : (msg.ids != null ? [msg.ids] : []), { kind: msg.kind });
-        case "civitai_clear_highlight": return h.clearHighlight();
-        case "civitai_switch_tab": return h.switchTab(msg.tab);
-        case "civitai_search": return h.search({ query: msg.query, filters: msg.filters, browsingLevels: msg.browsingLevels });
-        case "civitai_open_lightbox": return h.openLightbox(msg.id);
+        case "civitai_results": return h.civitai.getResults({ limit: msg.limit });
+        case "civitai_highlight": return h.civitai.highlight(Array.isArray(msg.ids) ? msg.ids : (msg.ids != null ? [msg.ids] : []), { kind: msg.kind });
+        case "civitai_clear_highlight": return h.civitai.clearHighlight();
+        case "civitai_switch_tab": return h.civitai.switchTab(msg.tab);
+        case "civitai_search": return h.civitai.search({ query: msg.query, filters: msg.filters, browsingLevels: msg.browsingLevels });
+        case "civitai_open_lightbox": return h.civitai.openLightbox(msg.id);
         default: throw new Error(`unknown civitai cmd "${msg.cmd}"`);
       }
     },
-    // The agent opens/drives the training wizard (parity with CivitAI).
+    // The agent opens/drives the training wizard tab (parity with CivitAI).
     onTrainingCmd(msg) {
       if (msg.cmd === "open_training") {
         openTraining({ dock: msg.dock !== false });
         return { ok: true };
       }
-      const h = _trainingHandle;
+      const h = _sidePanelHandle;
       if (!h) throw new Error("training wizard not open");
       switch (msg.cmd) {
-        case "training_get_state": return h.getState();
-        case "training_set_field": return h.setField(msg.name, msg.value);
-        case "training_goto_step": return h.gotoStep(msg.step);
-        case "training_set_target": return h.setTarget(msg.target);
-        case "training_highlight": return h.highlight(Array.isArray(msg.refs) ? msg.refs : (msg.refs != null ? [msg.refs] : []));
+        case "training_get_state": return h.training.getState();
+        case "training_set_field": return h.training.setField(msg.name, msg.value);
+        case "training_goto_step": return h.training.gotoStep(msg.step);
+        case "training_set_target": return h.training.setTarget(msg.target);
+        case "training_highlight": return h.training.highlight(Array.isArray(msg.refs) ? msg.refs : (msg.refs != null ? [msg.refs] : []));
         default: throw new Error(`unknown training cmd "${msg.cmd}"`);
       }
     },


### PR DESCRIPTION
Closes #124.

## What
Unifies the four sidebar surfaces — **Civitai / Apps / Training / Local (RunPod)** — into ONE tabbed side-panel. A new shared shell `web/js/cmcp-sidepanel-ui.js` (`openSidePanel`) owns the overlay, header + tab bar, single filter/search row, top-right `✕`, the agent-drive side-dock, slide-out, and self-invalidating close; each former modal becomes a **content provider** (`createCivitaiContent`/`createAppsContent`/`createTrainingContent`/`createLocalContent`). One `_sidePanelHandle` replaces the four; switching tabs closes the prior one.

## Decisions (per issue)
- **Search:** Civitai always; Apps on Explore only; **Training** → the existing per-step image filename filter; **Local** none.
- **Collapse:** `@container (max-width:400px)` — a narrow *docked* panel collapses to icon-only tabs even on a wide screen.
- **Apps My/Explore** → subnav chips. **Active tab** → `--p-primary-color`/`--p-primary-contrast-color` (inverts light/dark). **Local** adopts Civitai's `position:fixed` overlay — fixes the old top-left placement.

## Compatibility
Reuses Civitai's classnames verbatim; keeps `.cmcp-civitai-modal`/`.cmcp-tr-modal`/`.cmcp-apps-modal` as **active-tab alias classes** so the agent-drive + Playwright specs and per-surface CSS still resolve. The agent-drive facade throws the exact legacy `"…not open"` messages on wrong-tab/after-close.

## Review + gates
Independent adversarial review: core **CLEAN** (facade, alias swap, dock-on-switch, Escape-yields-to-lightbox, RunPod frames, deletions, container-query, themed tab). Two findings **fixed**: apps `!important` width leak (broke docked-fill on the Apps tab) and a hidden-tab poll leak (Training Monitor / Apps run now `onDeactivate`-halt + re-arm).
- `node --check` (as `.mjs`) on all 6 changed files ✓ · `npm run test:unit` **104 pass** ✓ · real-module DOM-shim smoke **24/24** ✓.
- **Not yet run:** the Playwright browser specs (ComfyUI caches its serve path, so it won't serve the worktree without a restart) — the real in-browser pass is the one remaining verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
