### PR TITLE
fix(apps): convert flow offered zero inputs on current frontends

### DIFF
--- a/browser_tests/apps.spec.ts
+++ b/browser_tests/apps.spec.ts
@@ -182,11 +182,11 @@ async function stubAppsBackend(page: Page) {
           version: 0.4
         }
       })
-      const node = (id: number, type: string, widgets: unknown[], outputNode = false) => ({
+      const node = (id: number, type: string, widgets: unknown[], outputNode = false, inputs: unknown[] = []) => ({
         id,
         type,
         title: type,
-        inputs: [],
+        inputs,
         widgets,
         constructor: { nodeData: { output_node: outputNode } }
       })
@@ -197,10 +197,17 @@ async function stubAppsBackend(page: Page) {
           node(4, 'CheckpointLoaderSimple', [
             { name: 'ckpt_name', value: 'flux.safetensors', type: 'combo', options: { values: ['flux.safetensors', 'sdxl.safetensors'] } }
           ]),
-          node(6, 'CLIPTextEncode', [{ name: 'text', value: 'a cat', type: 'text' }]),
+          // Unconnected widget-input SOCKET (link: null — how modern frontends
+          // materialize every widget): must STAY a candidate.
+          node(6, 'CLIPTextEncode', [{ name: 'text', value: 'a cat', type: 'text' }], false, [
+            { name: 'text', widget: { name: 'text' }, link: null }
+          ]),
           node(3, 'KSampler', [
             { name: 'seed', value: 42, type: 'number' },
             { name: 'steps', value: 20, type: 'number' }
+          ], false, [
+            // CONNECTED widget input: seed is link-driven → excluded.
+            { name: 'seed', widget: { name: 'seed' }, link: 7 }
           ]),
           node(9, 'SaveImage', [], true)
         ]
@@ -241,6 +248,12 @@ test('convert canvas → app card → detail → one-click run with patched valu
   await installFixtureCanvas()
   await modal.getByRole('button', { name: 'Convert current workflow' }).click()
   await expect(modal.getByText('Inputs — the endpoints this app exposes')).toBeVisible()
+  // Widget-input guard: the UNCONNECTED text socket stays a candidate; the
+  // CONNECTED (link-driven) seed is excluded.
+  const pickRows = modal.locator('.cmcp-apps-pick label')
+  await expect(pickRows.filter({ hasText: 'text' })).not.toHaveCount(0)
+  await expect(pickRows.filter({ hasText: 'seed' })).toHaveCount(0)
+  await expect(pickRows.filter({ hasText: 'steps' })).not.toHaveCount(0)
   await modal.locator('.cmcp-apps-field input[type=text]').fill('Fixture App')
   await modal.locator('.cmcp-apps-field textarea').fill('Made from a fixture graph')
   await modal.getByRole('button', { name: 'Create app' }).click()

--- a/web/js/cmcp-apps-ui.js
+++ b/web/js/cmcp-apps-ui.js
@@ -157,10 +157,14 @@ async function draftFromCanvas(getApp) {
     }
     const nodeHasImported = [...importedKeys].some((k) => Number(k.split(".")[0]) === id);
     if (!AppBuilder.INPUT_HINT_TYPES.has(String(node.type || "")) && !nodeHasImported) continue;
+    // Only a CONNECTED widget-input makes a widget link-driven. Modern
+    // frontends materialize an input socket (link: null) for EVERY widget —
+    // treating mere presence as link-driven excluded every candidate on
+    // current ComfyUI (found dogfooding: an EmptyImage offered zero inputs).
     const linkDriven = new Set(
       (Array.isArray(node.inputs) ? node.inputs : [])
-        .map((inp) => inp && inp.widget && inp.widget.name)
-        .filter(Boolean),
+        .filter((inp) => inp && inp.link != null && inp.widget && inp.widget.name)
+        .map((inp) => inp.widget.name),
     );
     for (const w of Array.isArray(node.widgets) ? node.widgets : []) {
       if (!w || !w.name || linkDriven.has(w.name)) continue;
@@ -191,6 +195,7 @@ async function draftFromCanvas(getApp) {
   }
   return { prompt: gp.output, workflow, imported, inputs, outputs };
 }
+
 
 export function openAppsModal(ctx, opts = {}) {
   const { getApp, uploadBlobToInput, callTool, getRunpodTarget } = ctx;

--- a/web/js/cmcp-apps.js
+++ b/web/js/cmcp-apps.js
@@ -235,7 +235,10 @@ export class AppBuilder {
 
   /** Node types whose widgets are natural app INPUTS by default (mirrors what
    *  the frontend APP builder highlights: prompt text, images, models,
-   *  primitives, seeds/steps-samplers). */
+   *  primitives, seeds/steps-samplers, and the empty-latent/image generators
+   *  whose size/batch widgets are among the most-exposed app endpoints — found
+   *  dogfooding: an EmptyImage→Preview graph offered NO candidates without
+   *  these). */
   static INPUT_HINT_TYPES = new Set([
     "CLIPTextEncode",
     "LoadImage",
@@ -255,6 +258,12 @@ export class AppBuilder {
     "KSampler",
     "KSamplerAdvanced",
     "SamplerCustom",
+    "EmptyImage",
+    "EmptyLatentImage",
+    "EmptySD3LatentImage",
+    "EmptyLTXVLatentVideo",
+    "EmptyHunyuanLatentVideo",
+    "EmptyMochiLatentVideo",
   ]);
 
   /** Widget value → app input kind. `nodeType` refines (LoadImage → image


### PR DESCRIPTION
Two bugs found **dogfooding** the Apps convert flow end to end (real ComfyUI, real registry):

1. **Widget-socket guard treated every widget as link-driven.** Modern frontends materialize an input socket (`link: null`) for EVERY widget, so "has a widget input" excluded all candidates — a plain EmptyImage→Preview graph offered **zero** inputs. Now only a CONNECTED widget-input (`link != null`) excludes a widget.
2. **`INPUT_HINT_TYPES` missed the empty-latent/image generators** (EmptyImage, EmptyLatentImage, EmptySD3LatentImage, LTXV/Hunyuan/Mochi latents) — their size/batch widgets are among the most-exposed app endpoints.

**Verification:** e2e fixture now carries an unconnected widget socket (stays a candidate) and a connected one (excluded) with pick-list assertions — 6/6 green against a live ComfyUI. Plus the full real drive: convert → run (256px swatch, real generation) → publish → explore → star, all against the production registry (which now hosts its first app, `artokun/solid-color-swatch-4b041650` ★1).