### PR TITLE
fix(panel): toolbar buttons ARE the tab bar — active state + <400px collapse (#124)

### DIFF
--- a/web/js/cmcp-sidepanel-ui.js
+++ b/web/js/cmcp-sidepanel-ui.js
@@ -46,6 +46,7 @@ function injectCss() {
   .cmcp-cv-head { display: flex; align-items: center; gap: .5rem; padding: .6rem .7rem;
     border-bottom: 1px solid var(--p-content-border-color, #3f3f46); flex-wrap: wrap; }
   .cmcp-cv-tabs { display: flex; gap: .25rem; flex-wrap: wrap; }
+  .cmcp-sp-title { font-weight: 600; font-size: .85rem; color: var(--p-text-color, #fafafa); padding: 0 .25rem; }
   .cmcp-cv-tab { display: inline-flex; align-items: center; gap: .3rem; padding: .3rem .55rem;
     border-radius: 8px; border: 1px solid transparent; background: transparent;
     color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; font-size: .8rem; }
@@ -139,12 +140,14 @@ export function openSidePanel(ctx = {}, opts = {}) {
   const overlay = el("div", "cmcp-cv-overlay");
   const modal = el("div", "cmcp-modal cmcp-sidepanel");
   const head = el("div", "cmcp-cv-head");
-  const tabsWrap = el("div", "cmcp-cv-tabs");
+  // The four TOOLBAR buttons ARE the tabs (host toggles their active state via
+  // onTabChange); the panel header just names the active surface + carries the ✕.
+  const titleEl = el("div", "cmcp-sp-title");
   const closeBtn = el("button", "cmcp-cv-iconbtn");
   closeBtn.innerHTML = '<i class="pi pi-times"></i>';
   closeBtn.title = "Close";
   closeBtn.style.marginLeft = "auto";
-  head.append(tabsWrap, closeBtn);
+  head.append(titleEl, closeBtn);
 
   const subnav = el("div", "cmcp-cv-subnav");
   const searchEl = el("input", "cmcp-cv-search");
@@ -288,8 +291,11 @@ export function openSidePanel(ctx = {}, opts = {}) {
     extras.textContent = "";
     for (const a of Object.values(ALIAS)) modal.classList.remove(a);
     activeKey = key;
-    for (const b of tabsWrap.children) b.classList.toggle("active", b._key === key);
+    const def = TABS.find((t) => t.key === key);
+    titleEl.textContent = def ? def.label : "";
     if (ALIAS[key]) modal.classList.add(ALIAS[key]);
+    // The toolbar buttons are the tab bar — tell the host to reflect the active one.
+    try { opts.onTabChange?.(key); } catch { /* host toolbar sync only */ }
     const inst = ensureContent(key);
     const ex = typeof inst.subnavExtras === "function" ? inst.subnavExtras() : null;
     for (const n of (ex || [])) if (n) extras.appendChild(n);
@@ -299,14 +305,6 @@ export function openSidePanel(ctx = {}, opts = {}) {
     if (typeof inst.onActivate === "function") { try { inst.onActivate(); } catch { /* ignore */ } }
     applyDock(); // re-dock (no slide replay: cmcp-dock-in stays set)
     return inst;
-  }
-
-  for (const t of TABS) {
-    const b = el("button", "cmcp-cv-tab");
-    b.innerHTML = `<i class="pi ${t.icon}"></i><span>${t.label}</span>`;
-    b._key = t.key;
-    b.addEventListener("click", () => activate(t.key));
-    tabsWrap.appendChild(b);
   }
 
   // ── go: mount the initial tab, then wire the dock + slide-in ──────────────────

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7592,6 +7592,24 @@ const PANEL_CSS = `
 }
 .cmcp-toolbtn.cmcp-toolbtn-iconic .pi { font-size: 0.9375rem; }
 .cmcp-toolbtn.cmcp-toolbtn-iconic svg { width: 15px; height: 15px; }
+/* Active tab: the four surface buttons ARE the tab bar (issue #124) — the open
+   one gets the themed toggled state (inverts light/dark via the primary tokens). */
+.cmcp-toolbtn.cmcp-toolbtn-active {
+  background: var(--p-primary-color, #3a7bd5);
+  color: var(--p-primary-contrast-color, #fff);
+}
+.cmcp-toolbtn.cmcp-toolbtn-active:hover { background: var(--p-primary-color, #3a7bd5); color: var(--p-primary-contrast-color, #fff); }
+/* Responsive tab bar: under 400px the toolbar collapses its labels to icons only
+   (container query on the bar's OWN width, so a narrow docked/sidebar pane
+   collapses even on a wide screen). Mirrors the iconic Deafen/Blind hide. */
+.cmcp-toolbar { container-type: inline-size; }
+@container (max-width: 400px) {
+  .cmcp-toolbar .cmcp-toolbtn span {
+    position: absolute; width: 1px; height: 1px; overflow: hidden;
+    clip: rect(0 0 0 0); clip-path: inset(50%); white-space: nowrap;
+  }
+  .cmcp-toolbar .cmcp-toolbtn { padding: 0.25rem 0.375rem; }
+}
 /* Engaged gates get a colored tint so their state is readable at a glance. */
 .cmcp-toolbtn.gate-on-deafen { color: var(--p-red-400, #f87171); }
 .cmcp-toolbtn.gate-on-deafen svg { animation: cmcp-pulse 1s ease-in-out infinite; }
@@ -10150,6 +10168,15 @@ function buildPanel() {
       },
     };
   }
+  // The four toolbar buttons ARE the tab bar: reflect the open surface with a
+  // themed toggled state (cleared on close). The buttons are const-declared below,
+  // but this only runs at tab-change time, by which point they're initialized.
+  function setActiveToolbarTab(key) {
+    const map = { civitai: civitaiBtn, apps: appsBtn, training: trainingBtn, local: runpodBtn };
+    for (const [k, btn] of Object.entries(map)) {
+      if (btn) btn.classList.toggle("cmcp-toolbtn-active", k === key);
+    }
+  }
   /** Open the unified side panel on `tab`, or switch to it if already open. */
   function openSidePanelTab(tab, { tabOpts, dock = true } = {}) {
     if (_sidePanelHandle?.isOpen?.()) {
@@ -10160,9 +10187,11 @@ function buildPanel() {
       tab,
       dock,
       ...(tabOpts ? { tabOpts: { [tab]: tabOpts } } : {}),
+      // The toolbar buttons are the tabs — highlight the active one on every switch.
+      onTabChange: setActiveToolbarTab,
       // Null the stored handle whenever the panel closes (✕, Escape, backdrop) so
-      // post-open drive cmds get an honest "not open" error.
-      onClose: () => { if (_sidePanelHandle === handle) _sidePanelHandle = null; },
+      // post-open drive cmds get an honest "not open" error; clear the toolbar too.
+      onClose: () => { if (_sidePanelHandle === handle) _sidePanelHandle = null; setActiveToolbarTab(null); },
     });
     _sidePanelHandle = handle;
     return handle;


### PR DESCRIPTION
Follow-up to #128 (issue #124). Two review points from the live pass:

- **the header toolbar didn't collapse** — my collapse rule was on the wrong element (an inner tab row), not the header buttons you actually see.
- **wrong icons** — that inner tab row used generic PrimeIcons instead of the toolbar's custom brand SVGs.

Both trace to a misread: the four **toolbar buttons** (Civitai/Apps/Training/Local) were meant to *be* the tabs. This makes them so:
- **Active/toggled state** (`--p-primary-color` / `--p-primary-contrast-color`) on the open surface, cleared on close — driven by a new `onTabChange` hook from the shell.
- **Collapse to icon-only under 400px** via a `@container` query on `.cmcp-toolbar` (its own width, so a narrow docked/sidebar pane collapses even on a wide screen).
- **Dropped the redundant inner tab row** (and its generic icons); the panel header now just names the active surface + the top-right `✕`. Keeps the custom brand SVGs on the toolbar.

## Verified live (Claude-in-Chrome)
Toolbar button turns themed-blue when its surface is open and the highlight **follows** on switch (Civitai → Training); no inner tab row; header shows the active title; and the toolbar collapses to icons-only when the bar is under the threshold (confirmed by temporarily raising it, then reverting to 400px). `node --check` ×2, `test:unit` 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
