### PR TITLE
fix(civitai): Favorites broken — decode CivitAI's new devalue tRPC responses

### DIFF
--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -516,14 +516,28 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
         // Dedup on id: the feed pages by "last item id" (see the client's
         // cursor quirk) — if CivitAI ever flips its keyset comparison to
         // inclusive, the boundary item would come back twice.
-        // The favorites feed has no text query — search filters client-side.
+        // Favorites has no server-side text / base-model / creator filter — apply
+        // the active filter panel client-side. image.getInfinite carries no prompt
+        // text, so a text query matches the author or model name; the base-model
+        // chips match the item's own baseModel; the @creator qualifier matches the
+        // author. (A page emptied by these shows the manual "Load more" below.)
         const seen = new Set(state.items.map((i) => i.id));
         const q = state.query.toLowerCase();
-        const fresh = page.items.filter((it) => !seen.has(it.id) &&
-          (!q || (it.prompt || "").toLowerCase().includes(q) ||
-            (it.author || "").toLowerCase().includes(q)));
+        const bms = f.baseModels;
+        const creator = f.username ? f.username.toLowerCase() : null;
+        const favMatch = (it) => {
+          const model = (it.modelName || "").toLowerCase();
+          const author = (it.author || "").toLowerCase();
+          if (q && !(author.includes(q) || model.includes(q) ||
+                     (it.prompt || "").toLowerCase().includes(q))) return false;
+          if (bms.length && !bms.some((b) => matchesBaseModel(it.modelName || "", b))) return false;
+          if (creator && author !== creator) return false;
+          return true;
+        };
+        const fresh = page.items.filter((it) => !seen.has(it.id) && favMatch(it));
         appendItems(fresh);
-        stalled = !fresh.length && !state.done && !!q;
+        const filtering = !!q || bms.length > 0 || !!creator;
+        stalled = !fresh.length && !state.done && filtering;
       } else if (t.model) {
         if (!state.localLoaded) await refreshLocalModels(); // for "in library" marks
         const page = await client.fetchModels({

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -216,6 +216,38 @@ const CDN_TOKEN = "xG1nkqKTMzGDvpLrqFT7WA";
 const _levelFromString = (s) =>
   ({ None: 1, Soft: 2, Mature: 4, X: 8, XXX: 16 }[s] || 1);
 
+// CivitAI's tRPC responses switched from superjson ({json,meta}) to the devalue
+// "flattened" form: result.data is a STRING that parses to a flat array where
+// index 0 is the root and EVERY container value is an integer index into that
+// array (negatives are special values). Our readers all expect result.data.json,
+// so on a string result.data we unflatten and rewrap as { json: <root> }. This
+// is what broke Favorites (the only tab on tRPC image.getInfinite) on prod while
+// the REST-backed tabs kept working. No-op on already-normal / REST responses.
+const _DEVALUE_SPECIAL = { "-1": undefined, "-2": null, "-3": NaN, "-4": Infinity, "-5": -Infinity, "-6": -0 };
+export function unflattenDevalue(flat) {
+  if (!Array.isArray(flat) || flat.length === 0) return flat;
+  const seen = new Array(flat.length);
+  const build = (i) => {
+    if (typeof i === "number" && i < 0) return _DEVALUE_SPECIAL[i];
+    if (typeof i !== "number") return i;
+    if (i in seen) return seen[i];
+    const v = flat[i];
+    if (v === null || typeof v !== "object") { seen[i] = v; return v; }
+    if (Array.isArray(v)) { const a = []; seen[i] = a; for (const e of v) a.push(build(e)); return a; }
+    const o = {}; seen[i] = o; for (const k in v) o[k] = build(v[k]); return o;
+  };
+  return build(0);
+}
+export function normalizeTrpcResponse(data) {
+  const d = data && data.result ? data.result.data : undefined;
+  if (typeof d !== "string") return data; // already {json:…} or a REST/plain response
+  try {
+    const flat = JSON.parse(d);
+    if (Array.isArray(flat)) data.result.data = { json: unflattenDevalue(flat) };
+  } catch { /* not the devalue string form — leave untouched */ }
+  return data;
+}
+
 export class CivitaiClient {
   /** @param {object} api ComfyUI api ({fetchApi, apiURL}) injected by the monolith. */
   constructor(api) {
@@ -234,7 +266,7 @@ export class CivitaiClient {
       body: JSON.stringify({ url, method, body, auth, headers }),
     });
     if (!res.ok) throw new Error(`civitai proxy ${res.status}`);
-    return res.json();
+    return normalizeTrpcResponse(await res.json());
   }
 
   /** Same-origin CDN media URL (usable as <img>/<video> src AND fetchable as a Blob). */


### PR DESCRIPTION
## The bug (prod)
Favorites shows nothing / "can't search, filters don't work". Root cause, confirmed by cURL + **live proxy calls on the running panel**: CivitAI switched `image.getInfinite` from superjson (`{json,meta}`) to the **devalue** serialization — `result.data` is now a *string* (a flat, index-referenced array). The client reads `data.result.data.json` → `undefined` → **0 items**. Favorites-only because it's the sole tRPC tab; images/videos/models use REST and were unaffected.

## Fix
- `unflattenDevalue` + `normalizeTrpcResponse`, applied in the client's `_request` layer → every tRPC response (favorites + the collection lookup it needs) is normalized back to `{json:…}`. **Live-verified: `fetchFavorites` 0 → 18 items** on real prod data (decoder validated against actual items before shipping).
- Favorites filter panel now applies **client-side**: base-model chips (item `baseModel`), `@creator`, and text (author/model — `getInfinite` returns no prompt text).

Mobile has the identical bug and is fixed in a sibling PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)