### PR TITLE
feat(apps): P1 UI — themed modals, real input widgets, polish

### DIFF
--- a/browser_tests/apps.spec.ts
+++ b/browser_tests/apps.spec.ts
@@ -438,21 +438,25 @@ test('hide workflow: warns honestly and strips the graph from the bundle', async
     workflow: FIXTURE_WORKFLOW,
     prompt: FIXTURE_PROMPT
   })
-  page.on('dialog', (d) => d.accept())
-
   await panel.goto()
   await panel.openSidebar()
   await panel.root.getByRole('button', { name: 'Apps', exact: true }).click()
   const modal = page.locator('.cmcp-apps-modal')
   await modal.locator('.cmcp-app-card', { hasText: 'Secret Sauce' }).click()
 
+  // The native window.confirm is now a themed modal (cmcp-modal.js). The
+  // honest-warning copy lives inside it; click its confirm button to proceed.
   await modal.getByRole('button', { name: /Hide workflow/ }).click()
-  // The honest-warning copy is in the confirm dialog (accepted above); the PUT
-  // flips the flag and the server drops workflow.json (stub mirrors the flag).
-  const put = captured.find((c) => c.method === 'PUT')
-  expect((put!.body as { manifest: { hideWorkflow: boolean } }).manifest.hideWorkflow).toBe(true)
+  const confirm = page.locator('.cmcp-mdl')
+  await expect(confirm).toContainText('DELETES the stored node graph')
+  await page.locator('.cmcp-mdl-ok').click()
+
+  // After confirming: the PUT flips the flag (stub drops workflow.json) and the
+  // detail re-renders with the honest below-the-fold warning.
   await expect(modal).toContainText('Hidden workflow (best effort)')
   await expect(modal).toContainText('anyone technical who runs this app can still intercept')
+  const put = captured.find((c) => c.method === 'PUT')
+  expect((put!.body as { manifest: { hideWorkflow: boolean } }).manifest.hideWorkflow).toBe(true)
 })
 
 // ── Registry (P4): publish / explore / install, worker stubbed over HTTP ────
@@ -562,14 +566,19 @@ test('publish: bundle goes to the registry, local manifest records the slug', as
     workflow: FIXTURE_WORKFLOW,
     prompt: FIXTURE_PROMPT
   })
-  page.on('dialog', (d) => d.accept('tester'))
-
   await panel.goto()
   await panel.openSidebar()
   await panel.root.getByRole('button', { name: 'Apps', exact: true }).click()
   const modal = page.locator('.cmcp-apps-modal')
   await modal.locator('.cmcp-app-card', { hasText: 'Shareable' }).click()
   await modal.getByRole('button', { name: /Publish/ }).click()
+
+  // The window.prompt for the creator name is now a themed prompt modal
+  // (cmcp-modal.js): type the name and submit.
+  const creatorField = page.locator('.cmcp-mdl input')
+  await expect(creatorField).toBeVisible()
+  await creatorField.fill('tester')
+  await page.locator('.cmcp-mdl-ok').click()
 
   // The registry got the app; the local manifest records published{slug}.
   await expect(modal.getByRole('button', { name: /Update published/ })).toBeVisible()

--- a/browser_tests/unit/apps.test.mjs
+++ b/browser_tests/unit/apps.test.mjs
@@ -87,6 +87,17 @@ test("classifyWidget", () => {
   assert.equal(AppBuilder.classifyWidget("Foo", "enabled", true), "toggle");
   assert.equal(AppBuilder.classifyWidget("Foo", "sampler", ["euler", "dpm"]), "combo");
   assert.equal(AppBuilder.classifyWidget("CLIPTextEncode", "text", "hello"), "text");
+  // seed control: seed/noise_seed names get the dedicated 🎲 widget.
+  assert.equal(AppBuilder.classifyWidget("KSampler", "seed", 42), "seed");
+  assert.equal(AppBuilder.classifyWidget("KSamplerAdvanced", "noise_seed", 7), "seed");
+  // color: an explicit color widget type, or a color-named hex-valued string.
+  assert.equal(AppBuilder.classifyWidget("SolidColor", "value", "#ff0000", "color"), "color");
+  assert.equal(AppBuilder.classifyWidget("Node", "background_color", "#00ff00"), "color");
+  // a plain 6-char string that isn't color-named stays text (no false positive).
+  assert.equal(AppBuilder.classifyWidget("Node", "label", "abcdef"), "text");
+  // loader still wins over a seed-ish name; positional (nameless) never seeds.
+  assert.equal(AppBuilder.classifyWidget("VAELoader", "vae_name", "v.pt"), "model");
+  assert.equal(AppBuilder.classifyWidget("KSampler", "", 42), "number");
 });
 
 // ── dependency scan ─────────────────────────────────────────────────────────

--- a/browser_tests/unit/test_apps_routes.py
+++ b/browser_tests/unit/test_apps_routes.py
@@ -69,6 +69,50 @@ class SanitizeManifest(unittest.TestCase):
         self.assertEqual(m["appMode"]["inputs"][0]["nodeId"], 6)
         self.assertEqual(m["appMode"]["outputs"], [{"nodeId": 9, "kind": "images"}])
 
+    def test_widget_metadata_kept(self):
+        # min/max/step + seedBehavior + nodeType flow through for the richer
+        # run-form controls; a bool must NOT pose as a numeric bound.
+        m = ar._sanitize_manifest(
+            {
+                "id": UUID,
+                "name": "x",
+                "appMode": {
+                    "inputs": [
+                        {
+                            "nodeId": 3,
+                            "widget": "steps",
+                            "kind": "number",
+                            "min": 1,
+                            "max": 100,
+                            "step": 0.5,
+                        },
+                        {
+                            "nodeId": 3,
+                            "widget": "seed",
+                            "kind": "seed",
+                            "seedBehavior": "randomize",
+                            "control_after_generate": "randomize",
+                            "min": True,  # bool must be dropped, not kept as 1
+                        },
+                        {
+                            "nodeId": 4,
+                            "widget": "ckpt_name",
+                            "kind": "model",
+                            "nodeType": "CheckpointLoaderSimple",
+                        },
+                    ],
+                },
+            }
+        )
+        ins = m["appMode"]["inputs"]
+        self.assertEqual(ins[0]["min"], 1)
+        self.assertEqual(ins[0]["max"], 100)
+        self.assertEqual(ins[0]["step"], 0.5)
+        self.assertEqual(ins[1]["seedBehavior"], "randomize")
+        self.assertEqual(ins[1]["control_after_generate"], "randomize")
+        self.assertNotIn("min", ins[1])  # bool rejected
+        self.assertEqual(ins[2]["nodeType"], "CheckpointLoaderSimple")
+
     def test_truncation(self):
         m = ar._sanitize_manifest({"id": UUID, "name": "n" * 500, "description": "d" * 9000})
         self.assertEqual(len(m["name"]), 120)

--- a/py/apps_routes.py
+++ b/py/apps_routes.py
@@ -152,6 +152,21 @@ def _sanitize_manifest(raw, *, for_update: bool = False) -> dict:
                 entry["choices"] = [str(c) for c in item["choices"]][:200]
             if "default" in item and isinstance(item["default"], (str, int, float, bool)):
                 entry["default"] = item["default"]
+            # Widget metadata for the richer run-form controls: numeric bounds
+            # for the slider, the seed 🎲 behavior, and the source node type so
+            # the model picker can read the connected server's live object_info.
+            # bool is a subclass of int — exclude it so a stray True can't pose
+            # as a numeric bound.
+            for f in ("min", "max", "step"):
+                v = item.get(f)
+                if isinstance(v, (int, float)) and not isinstance(v, bool):
+                    entry[f] = v
+            if isinstance(item.get("seedBehavior"), str):
+                entry["seedBehavior"] = item["seedBehavior"][:32]
+            if isinstance(item.get("control_after_generate"), str):
+                entry["control_after_generate"] = item["control_after_generate"][:32]
+            if isinstance(item.get("nodeType"), str):
+                entry["nodeType"] = item["nodeType"][:128]
             inputs.append(entry)
         outputs = []
         for item in app_mode.get("outputs") or []:

--- a/web/js/cmcp-apps-ui.js
+++ b/web/js/cmcp-apps-ui.js
@@ -16,6 +16,7 @@
 // offered — see the hide toggle copy. True protection = hosted runs (P5).
 
 import { AppBuilder, AppsClient, RegistryClient } from "./cmcp-apps.js";
+import { confirmModal, promptModal, formModal, toast } from "./cmcp-modal.js";
 
 let styleInjected = false;
 function injectStyle() {
@@ -27,49 +28,86 @@ function injectStyle() {
    its !important max-width would leak onto the shared shell (shrinking the card
    on the Apps tab + breaking docked-fill). Keep only the flex-column layout. */
 .cmcp-apps-modal{display:flex;flex-direction:column;}
-.cmcp-apps-body{display:flex;flex-direction:column;gap:0.75rem;min-height:0;flex:1;}
+.cmcp-apps-body{display:flex;flex-direction:column;gap:0.7rem;min-height:0;flex:1;}
 .cmcp-apps-toolbar{display:flex;gap:0.4rem;flex-wrap:wrap;align-items:center;}
 .cmcp-apps-toolbar .spacer{flex:1;}
-.cmcp-apps-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:0.75rem;overflow-y:auto;min-height:120px;}
-.cmcp-app-card{border:1px solid var(--p-content-border-color,#3f3f46);border-radius:10px;overflow:hidden;cursor:pointer;
-  background:var(--p-content-background,#18181b);display:flex;flex-direction:column;transition:border-color .15s;}
-.cmcp-app-card:hover{border-color:var(--p-primary-color,#60a5fa);}
-.cmcp-app-card .thumb{aspect-ratio:16/9;background:#0c0c0e center/cover no-repeat;display:flex;align-items:center;justify-content:center;
-  font-size:1.6rem;opacity:0.85;}
-.cmcp-app-card .meta{padding:0.5rem 0.6rem;display:flex;flex-direction:column;gap:0.15rem;}
-.cmcp-app-card .name{font-weight:600;font-size:0.85rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
-.cmcp-app-card .desc{font-size:0.72rem;opacity:0.65;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;}
-.cmcp-app-badges{display:flex;gap:0.3rem;margin-top:0.15rem;}
-.cmcp-app-badge{font-size:0.62rem;padding:0.05rem 0.35rem;border-radius:99px;border:1px solid var(--p-content-border-color,#3f3f46);opacity:0.8;}
+/* Buttons: primary pops, everything else reads as a quiet secondary so the
+   hierarchy is legible (matches the CivitAI tab's chip/button vocabulary). */
+.cmcp-apps-body .cmcp-btn{align-self:auto;padding:0.4rem 0.75rem;border-radius:8px;font-size:0.8rem;}
+.cmcp-apps-body .cmcp-btn:not(.primary):not(.danger){background:var(--p-surface-800,#27272a);
+  color:var(--p-text-color,#fafafa);border:1px solid var(--p-content-border-color,#3f3f46);font-weight:500;}
+.cmcp-apps-body .cmcp-btn:not(.primary):not(.danger):hover{border-color:var(--p-primary-color,#60a5fa);opacity:1;}
+.cmcp-apps-body .cmcp-btn.primary{background:var(--p-button-primary-background,var(--p-primary-color,#3a7bd5));
+  color:var(--p-primary-contrast-color,#fff);border:1px solid transparent;}
+.cmcp-apps-body .cmcp-btn.danger{background:transparent;border:1px solid rgba(248,113,113,0.5);color:#f87171;font-weight:500;}
+.cmcp-apps-body .cmcp-btn.danger:hover{background:rgba(248,113,113,0.12);border-color:#f87171;opacity:1;}
+.cmcp-apps-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(172px,1fr));gap:0.7rem;
+  overflow-y:auto;min-height:120px;padding:0.1rem 0.1rem 0.6rem;align-content:start;}
+.cmcp-app-card{border:1px solid var(--p-content-border-color,#3f3f46);border-radius:12px;overflow:hidden;cursor:pointer;
+  background:var(--p-surface-900,#18181b);display:flex;flex-direction:column;
+  transition:border-color .15s,transform .15s,box-shadow .15s;}
+.cmcp-app-card:hover{border-color:var(--p-primary-color,#60a5fa);transform:translateY(-2px);
+  box-shadow:0 6px 18px rgba(0,0,0,0.35);}
+.cmcp-app-card .thumb{aspect-ratio:16/9;background:linear-gradient(135deg,#1b1b20,#0c0c0e) center/cover no-repeat;
+  display:flex;align-items:center;justify-content:center;font-size:1.6rem;opacity:0.9;color:var(--p-text-muted-color,#a1a1aa);}
+.cmcp-app-card .meta{padding:0.5rem 0.6rem 0.55rem;display:flex;flex-direction:column;gap:0.2rem;}
+.cmcp-app-card .name{font-weight:600;font-size:0.83rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+.cmcp-app-card .desc{font-size:0.71rem;line-height:1.35;opacity:0.62;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;}
+.cmcp-app-badges{display:flex;gap:0.3rem;margin-top:0.25rem;flex-wrap:wrap;}
+.cmcp-app-badge{font-size:0.62rem;padding:0.1rem 0.4rem;border-radius:99px;border:1px solid var(--p-content-border-color,#3f3f46);
+  color:var(--p-text-muted-color,#a1a1aa);opacity:0.9;white-space:nowrap;}
 .cmcp-app-badge.hidden-wf{border-color:rgba(245,158,11,0.5);color:#f59e0b;}
-.cmcp-apps-empty{opacity:0.6;font-size:0.85rem;padding:2rem 1rem;text-align:center;grid-column:1/-1;}
+.cmcp-apps-empty{opacity:0.6;font-size:0.85rem;line-height:1.5;padding:2.5rem 1rem;text-align:center;grid-column:1/-1;}
+.cmcp-apps-more{grid-column:1/-1;justify-self:center;margin-top:0.4rem;}
 .cmcp-apps-back{align-self:flex-start;}
-.cmcp-apps-detail{display:flex;flex-direction:column;gap:0.75rem;overflow-y:auto;min-height:0;}
-.cmcp-apps-detail-head{display:flex;gap:0.75rem;align-items:flex-start;}
-.cmcp-apps-detail-head .thumb{width:96px;height:54px;flex:0 0 auto;border-radius:8px;background:#0c0c0e center/cover no-repeat;
-  display:flex;align-items:center;justify-content:center;font-size:1.3rem;}
+.cmcp-apps-detail{display:flex;flex-direction:column;gap:0.8rem;overflow-y:auto;min-height:0;padding-bottom:0.4rem;}
+.cmcp-apps-detail-head{display:flex;gap:0.8rem;align-items:flex-start;padding-bottom:0.7rem;
+  border-bottom:1px solid var(--p-content-border-color,#3f3f46);}
+.cmcp-apps-detail-head .thumb{width:104px;height:58px;flex:0 0 auto;border-radius:10px;
+  background:linear-gradient(135deg,#1b1b20,#0c0c0e) center/cover no-repeat;
+  display:flex;align-items:center;justify-content:center;font-size:1.3rem;color:var(--p-text-muted-color,#a1a1aa);}
 .cmcp-apps-detail-head .titles{flex:1;min-width:0;}
-.cmcp-apps-detail-head h3{margin:0;font-size:1rem;}
-.cmcp-apps-detail-head .desc{font-size:0.78rem;opacity:0.7;margin-top:0.2rem;white-space:pre-wrap;}
-.cmcp-apps-form{display:flex;flex-direction:column;gap:0.55rem;}
-.cmcp-apps-field{display:flex;flex-direction:column;gap:0.2rem;}
-.cmcp-apps-field>label{font-size:0.72rem;font-weight:600;opacity:0.75;}
+.cmcp-apps-detail-head h3{margin:0;font-size:1.05rem;}
+.cmcp-apps-detail-head .desc{font-size:0.78rem;opacity:0.7;margin-top:0.25rem;line-height:1.45;white-space:pre-wrap;}
+.cmcp-apps-form{display:flex;flex-direction:column;gap:0.65rem;}
+.cmcp-apps-field{display:flex;flex-direction:column;gap:0.28rem;}
+.cmcp-apps-field>label{font-size:0.7rem;font-weight:600;opacity:0.8;text-transform:uppercase;letter-spacing:0.03em;}
 .cmcp-apps-field input[type=text],.cmcp-apps-field input[type=number],.cmcp-apps-field textarea,.cmcp-apps-field select{
-  padding:0.45rem 0.6rem;border-radius:6px;border:1px solid var(--p-content-border-color,#3f3f46);
-  background:var(--p-inputtext-background,#18181b);color:inherit;font-size:0.85rem;font-family:inherit;}
+  padding:0.5rem 0.6rem;border-radius:8px;border:1px solid var(--p-content-border-color,#3f3f46);
+  background:var(--p-surface-950,#111113);color:var(--p-text-color,#fafafa);font-size:0.85rem;font-family:inherit;box-sizing:border-box;width:100%;}
+.cmcp-apps-field input:focus,.cmcp-apps-field textarea:focus,.cmcp-apps-field select:focus{outline:none;border-color:var(--p-primary-color,#60a5fa);}
+.cmcp-apps-field input[type=file]{font-size:0.78rem;}
 .cmcp-apps-field textarea{min-height:64px;resize:vertical;}
-.cmcp-apps-runbar{display:flex;gap:0.5rem;align-items:center;flex-wrap:wrap;}
-.cmcp-apps-status{font-size:0.8rem;opacity:0.85;min-height:1.1em;}
+.cmcp-apps-hint{font-size:0.68rem;opacity:0.6;}
+/* number-with-bounds slider + synced readout */
+.cmcp-apps-sliderrow{display:flex;gap:0.6rem;align-items:center;}
+.cmcp-apps-sliderrow input[type=range]{flex:1;min-width:0;accent-color:var(--p-primary-color,#60a5fa);}
+.cmcp-apps-sliderval{flex:0 0 5.5rem;width:5.5rem;}
+/* seed number + 🎲 randomize/fix toggle */
+.cmcp-apps-seedrow{display:flex;gap:0.5rem;align-items:center;}
+.cmcp-apps-seedrow input[type=number]{flex:1;min-width:0;}
+.cmcp-apps-seedrow .cmcp-btn{flex:0 0 auto;padding:0.4rem 0.6rem;}
+.cmcp-apps-field input[type=color]{width:3rem;height:2rem;padding:0.15rem;border-radius:8px;
+  border:1px solid var(--p-content-border-color,#3f3f46);background:var(--p-surface-950,#111113);cursor:pointer;}
+.cmcp-apps-runbar{display:flex;gap:0.5rem;align-items:center;flex-wrap:wrap;padding-top:0.15rem;}
+.cmcp-apps-status{font-size:0.8rem;opacity:0.85;min-height:1.1em;flex:1 1 8rem;}
 .cmcp-apps-status.err{color:#f87171;}
 .cmcp-apps-outputs{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:0.5rem;}
-.cmcp-apps-outputs img,.cmcp-apps-outputs video{width:100%;border-radius:8px;display:block;background:#0c0c0e;}
+.cmcp-apps-outputs:empty{display:none;}
+.cmcp-apps-outputs img,.cmcp-apps-outputs video{width:100%;border-radius:10px;display:block;background:#0c0c0e;
+  border:1px solid var(--p-content-border-color,#3f3f46);}
 .cmcp-apps-outputs .text-out{grid-column:1/-1;font-size:0.8rem;white-space:pre-wrap;background:rgba(255,255,255,0.04);
   border-radius:8px;padding:0.5rem 0.6rem;}
-.cmcp-apps-pick{max-height:220px;overflow-y:auto;border:1px solid var(--p-content-border-color,#3f3f46);border-radius:8px;padding:0.4rem;}
-.cmcp-apps-pick label{display:flex;gap:0.45rem;align-items:center;font-size:0.78rem;padding:0.15rem 0.2rem;cursor:pointer;}
-.cmcp-apps-pick .grp{font-size:0.68rem;font-weight:700;opacity:0.6;margin:0.35rem 0 0.1rem;text-transform:uppercase;letter-spacing:0.04em;}
-.cmcp-apps-warn{font-size:0.75rem;color:#f59e0b;background:rgba(245,158,11,0.08);border:1px solid rgba(245,158,11,0.3);
-  border-radius:8px;padding:0.5rem 0.6rem;}
+.cmcp-apps-pick{display:flex;flex-direction:column;gap:0.1rem;max-height:240px;overflow-y:auto;
+  border:1px solid var(--p-content-border-color,#3f3f46);border-radius:10px;padding:0.5rem;background:var(--p-surface-950,#111113);}
+.cmcp-apps-pick label{display:flex;gap:0.45rem;align-items:center;font-size:0.78rem;padding:0.22rem 0.3rem;
+  border-radius:6px;cursor:pointer;transition:background .12s;}
+.cmcp-apps-pick label:hover{background:rgba(255,255,255,0.05);}
+.cmcp-apps-pick .grp{font-size:0.66rem;font-weight:700;opacity:0.6;margin:0.45rem 0 0.15rem;text-transform:uppercase;letter-spacing:0.05em;}
+.cmcp-apps-pick .grp:first-child{margin-top:0.1rem;}
+.cmcp-apps-warn{font-size:0.75rem;line-height:1.45;color:#f59e0b;background:rgba(245,158,11,0.08);border:1px solid rgba(245,158,11,0.3);
+  border-radius:8px;padding:0.55rem 0.65rem;}
+/* Fallback for danger buttons rendered outside .cmcp-apps-body (defensive). */
 .cmcp-btn.danger{border-color:rgba(248,113,113,0.5);color:#f87171;}
 `;
   const el = document.createElement("style");
@@ -112,6 +150,65 @@ function toolText(res) {
   if (r && Array.isArray(r.content)) return r.content.map((c) => (c && c.text) || "").join("");
   if (typeof r === "string") return r;
   return res.ok === false ? "The action failed." : "Done.";
+}
+
+// ── run-form model picker helpers ──────────────────────────────────────────
+
+/** Map a model-loader widget name to a ComfyUI models subfolder (the
+ *  list_local_models `model_type` enum) so the picker can scope its server
+ *  query. Best effort — null means "list everything". */
+const MODEL_DIR_BY_WIDGET = [
+  [/ckpt|checkpoint/i, "checkpoints"],
+  [/lora/i, "loras"],
+  [/vae/i, "vae"],
+  [/control_?net/i, "controlnet"],
+  [/upscale/i, "upscale_models"],
+  [/unet|diffusion/i, "diffusion_models"],
+  [/clip|text_encoder/i, "text_encoders"],
+  [/style/i, "style_models"],
+  [/gligen/i, "gligen"],
+  [/hypernet/i, "hypernetworks"],
+  [/embed/i, "embeddings"],
+];
+function modelDirForWidget(widget) {
+  for (const [re, dir] of MODEL_DIR_BY_WIDGET) if (re.test(String(widget || ""))) return dir;
+  return null;
+}
+
+/** The connected server's current valid values for a widget, read from the
+ *  ComfyUI frontend's object_info (defs are keyed by class_type, so they cover
+ *  node types not currently on the canvas too). Null when unavailable. */
+function liveWidgetChoices(getApp, nodeType, widget) {
+  try {
+    if (!nodeType) return null;
+    const app = typeof getApp === "function" ? getApp() : null;
+    const defs = app?.nodeManager?.defs || app?.extensions?.nodeDefs || app?.nodeDefs;
+    const def = defs && defs[nodeType];
+    const spec = def?.input?.required?.[widget] || def?.input?.optional?.[widget];
+    const values = Array.isArray(spec) && Array.isArray(spec[0]) ? spec[0] : null;
+    return values ? values.map(String) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Best-effort extraction of model filenames from a list_local_models
+ *  tool_result (the bridge returns grouped JSON or prose). Filtered to real
+ *  model-file extensions so a stray label can't pollute the picker. */
+const _MODEL_EXT = /\.(safetensors|ckpt|pt|pth|bin|gguf|sft|onnx|vae|pkl)$/i;
+function parseModelList(res, dir) {
+  const text = toolText(res);
+  if (!text) return [];
+  const cand = new Set();
+  try {
+    const j = JSON.parse(text);
+    const src = dir && j && typeof j === "object" && !Array.isArray(j) && Array.isArray(j[dir]) ? j[dir] : j;
+    // Collect every string anywhere in the structure, then extension-filter.
+    JSON.stringify(src, (_k, v) => { if (typeof v === "string") cand.add(v); return v; });
+  } catch {
+    for (const line of text.split(/\r?\n/)) cand.add(line.trim());
+  }
+  return [...cand].filter((s) => _MODEL_EXT.test(s));
 }
 
 /** Convert the LIVE canvas into an app bundle draft: prompt snapshot + UI
@@ -174,13 +271,33 @@ async function draftFromCanvas(getApp) {
       const key = `${id}.${w.name}`;
       if (seen.has(key)) continue;
       seen.add(key);
+      const nodeType = String(node.type || "");
+      const kind = AppBuilder.classifyWidget(nodeType, w.name, w.value, w.type);
+      const opts = w.options || {};
+      const num = (x) => (typeof x === "number" && Number.isFinite(x) ? x : undefined);
+      // control_after_generate lives on a sibling combo widget for seed nodes;
+      // its value ("randomize"/"fixed"/"increment"/…) seeds the 🎲 default.
+      let seedBehavior;
+      if (kind === "seed") {
+        const ctrl = (Array.isArray(node.widgets) ? node.widgets : []).find(
+          (x) => x && /control_after_generate/i.test(String(x.name || "")),
+        );
+        seedBehavior = typeof ctrl?.value === "string" ? ctrl.value : "randomize";
+      }
       inputs.push({
         nodeId: id,
         widget: w.name,
+        // nodeType lets the run-form model picker read the live /object_info
+        // (defs[nodeType]) for the connected server's current choices.
+        nodeType,
         label: `${node.title || node.type} #${id} · ${w.label || w.name}`,
-        kind: AppBuilder.classifyWidget(String(node.type || ""), w.name, w.value),
-        choices: Array.isArray(w.options?.values) ? w.options.values.map(String) : undefined,
+        kind,
+        choices: Array.isArray(opts.values) ? opts.values.map(String) : undefined,
         default: typeof w.value === "string" || typeof w.value === "number" || typeof w.value === "boolean" ? w.value : undefined,
+        min: num(opts.min),
+        max: num(opts.max),
+        step: num(opts.step),
+        ...(seedBehavior ? { seedBehavior } : {}),
         checked: true,
       });
     }
@@ -451,12 +568,14 @@ export function createAppsContent(ctx, shell, opts = {}) {
         const models = Array.isArray(deps.models) ? deps.models : [];
         const nodes = Array.isArray(deps.customNodes) ? deps.customNodes : [];
         if (models.length || nodes.length) {
-          const ok = window.confirm(
-            `“${regApp.name}” needs:\n` +
-              (models.length ? `\nModels (${models.length}):\n  ${models.map((m) => m.name || m).join("\n  ")}\n` : "") +
-              (nodes.length ? `\nCustom nodes (${nodes.length}):\n  ${nodes.join("\n  ")}\n` : "") +
-              "\nAnything missing must be installed before the app can run (ask the agent to install it, or install it yourself). Continue?",
-          );
+          const ok = await confirmModal({
+            title: `Install “${regApp.name}”`,
+            message:
+              (models.length ? `Models (${models.length}):\n  ${models.map((m) => m.name || m).join("\n  ")}\n\n` : "") +
+              (nodes.length ? `Custom nodes (${nodes.length}):\n  ${nodes.join("\n  ")}\n\n` : "") +
+              "Anything missing must be installed before the app can run (ask the agent to install it, or install it yourself).",
+            confirmLabel: "Install",
+          });
           if (!ok) {
             installBtn.disabled = false;
             status.textContent = "";
@@ -608,13 +727,18 @@ export function createAppsContent(ctx, shell, opts = {}) {
           name,
           description: descInput.value.trim(),
           appMode: {
-            inputs: inputs.map(({ nodeId, widget, label, kind, choices, default: def }) => ({
+            inputs: inputs.map(({ nodeId, widget, nodeType, label, kind, choices, default: def, min, max, step, seedBehavior }) => ({
               nodeId,
               widget,
               label,
               kind,
+              ...(nodeType ? { nodeType } : {}),
               ...(choices ? { choices } : {}),
               ...(def !== undefined ? { default: def } : {}),
+              ...(min !== undefined ? { min } : {}),
+              ...(max !== undefined ? { max } : {}),
+              ...(step !== undefined ? { step } : {}),
+              ...(seedBehavior ? { seedBehavior } : {}),
             })),
             outputs,
             importedFromFrontend: !!draft.imported,
@@ -686,6 +810,88 @@ export function createAppsContent(ctx, shell, opts = {}) {
         // Return the raw File — the RUN path decides where the bytes go
         // (local /upload/image, or the bridge's upload_media → the pod).
         getter = () => (fileInput.files && fileInput.files[0]) || undefined;
+      } else if (input.kind === "model") {
+        // A real, searchable picker — NEVER a bare textarea. Options come from
+        // the connected server's live object_info first, the convert-time
+        // choices next, and a bridge list_local_models query as a last resort.
+        const inp = document.createElement("input");
+        inp.type = "text";
+        inp.autocomplete = "off";
+        inp.placeholder = "Pick or type a model…";
+        inp.className = "cmcp-apps-modelpick";
+        const dl = document.createElement("datalist");
+        dl.id = `cmcp-models-${key.replace(/[^\w-]/g, "_")}-${Math.random().toString(36).slice(2, 7)}`;
+        inp.setAttribute("list", dl.id);
+        const caption = el("div", "cmcp-apps-hint");
+        const applyOptions = (list) => {
+          const uniq = [...new Set(list.filter(Boolean).map(String))];
+          dl.textContent = "";
+          for (const v of uniq) {
+            const o = document.createElement("option");
+            o.value = v;
+            dl.append(o);
+          }
+          caption.textContent = uniq.length
+            ? `${uniq.length} model${uniq.length === 1 ? "" : "s"} available — type to filter`
+            : "No models found on the server — type a filename.";
+          return uniq;
+        };
+        let known = applyOptions([
+          ...(liveWidgetChoices(getApp, input.nodeType, input.widget) || []),
+          ...(Array.isArray(input.choices) ? input.choices : []),
+        ]);
+        if (input.default !== undefined) inp.value = String(input.default);
+        field.append(inp, dl, caption);
+        getter = () => inp.value.trim() || undefined;
+        // Augment from the CONNECTED server (best effort; the bridge may be
+        // absent on a local-only session, in which case callTool resolves
+        // undefined and this is a no-op).
+        if (typeof callTool === "function") {
+          const dir = modelDirForWidget(input.widget);
+          Promise.resolve(callTool("list_local_models", dir ? { model_type: dir } : {}))
+            .then((res) => {
+              const more = parseModelList(res, dir);
+              if (more.length) known = applyOptions([...known, ...more]);
+            })
+            .catch(() => { /* offline / older bridge — keep the local options */ });
+        }
+      } else if (input.kind === "color") {
+        const c = document.createElement("input");
+        c.type = "color";
+        const raw = typeof input.default === "string" ? input.default : "";
+        c.value = /^#?[0-9a-fA-F]{6}$/.test(raw) ? (raw[0] === "#" ? raw : "#" + raw) : "#000000";
+        field.append(c);
+        getter = () => c.value;
+      } else if (input.kind === "seed") {
+        // Classic ComfyUI seed control: a number + a 🎲 randomize/fix toggle.
+        const row = el("div", "cmcp-apps-seedrow");
+        const num = document.createElement("input");
+        num.type = "number";
+        num.step = "1";
+        num.min = "0";
+        const init = input.default !== undefined ? Number(input.default) : 0;
+        num.value = String(Number.isFinite(init) ? init : 0);
+        let randomize = input.seedBehavior ? input.seedBehavior !== "fixed" : true;
+        const rollSeed = () => Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
+        const dice = makeBtn("🎲");
+        const syncDice = () => {
+          dice.classList.toggle("primary", randomize);
+          dice.title = randomize
+            ? "Seed is randomized on every run — click to fix it"
+            : "Seed is fixed — click to randomize each run";
+        };
+        dice.addEventListener("click", () => {
+          randomize = !randomize;
+          if (randomize) num.value = String(rollSeed());
+          syncDice();
+        });
+        syncDice();
+        row.append(num, dice);
+        field.append(row);
+        getter = () => {
+          if (randomize) num.value = String(rollSeed());
+          return num.value === "" ? undefined : Number(num.value);
+        };
       } else if (input.kind === "combo" && Array.isArray(input.choices) && input.choices.length) {
         const sel = document.createElement("select");
         for (const c of input.choices) {
@@ -698,10 +904,33 @@ export function createAppsContent(ctx, shell, opts = {}) {
         field.append(sel);
         getter = () => sel.value;
       } else if (input.kind === "number") {
+        const hasRange = typeof input.min === "number" && typeof input.max === "number" && input.max > input.min;
+        const step = typeof input.step === "number" && input.step > 0 ? String(input.step) : "";
         const num = document.createElement("input");
         num.type = "number";
+        if (step) num.step = step;
+        if (typeof input.min === "number") num.min = String(input.min);
+        if (typeof input.max === "number") num.max = String(input.max);
         if (input.default !== undefined) num.value = String(input.default);
-        field.append(num);
+        if (hasRange) {
+          // Slider + a synced numeric readout when the manifest carries bounds.
+          const row = el("div", "cmcp-apps-sliderrow");
+          const range = document.createElement("input");
+          range.type = "range";
+          range.min = String(input.min);
+          range.max = String(input.max);
+          if (step) range.step = step;
+          num.classList.add("cmcp-apps-sliderval");
+          const init = input.default !== undefined ? Number(input.default) : Number(input.min);
+          range.value = String(Number.isFinite(init) ? init : input.min);
+          if (input.default === undefined) num.value = range.value;
+          range.addEventListener("input", () => { num.value = range.value; });
+          num.addEventListener("input", () => { if (num.value !== "") range.value = num.value; });
+          row.append(range, num);
+          field.append(row);
+        } else {
+          field.append(num);
+        }
         getter = () => (num.value === "" ? undefined : Number(num.value));
       } else if (input.kind === "toggle") {
         const cb = document.createElement("input");
@@ -749,18 +978,18 @@ export function createAppsContent(ctx, shell, opts = {}) {
 
     publishBtn.addEventListener("click", async () => {
       if (!registry.configured) {
-        window.alert(
-          "No registry configured yet. The registry worker isn't deployed — set localStorage " +
-            "“comfyui-mcp.panel.registryUrl” to a deployed instance to publish.",
-        );
+        toast("No registry configured yet — set “comfyui-mcp.panel.registryUrl” to a deployed registry to publish.");
         return;
       }
       if (app.hideWorkflow) {
-        const ok = window.confirm(
-          "Publish “" + (app.name || "this app") + "” as a HIDDEN app?\n\n" +
+        const ok = await confirmModal({
+          title: "Publish a hidden app?",
+          message:
+            "Publish “" + (app.name || "this app") + "” as a HIDDEN app?\n\n" +
             "Only the run snapshot is uploaded — never the node graph. This is best-effort " +
-            "privacy, not security: anyone who runs the app can still intercept the prompt. Continue?",
-        );
+            "privacy, not security: anyone who runs the app can still intercept the prompt.",
+          confirmLabel: "Publish hidden",
+        });
         if (!ok) return;
       }
       publishBtn.disabled = true;
@@ -768,8 +997,14 @@ export function createAppsContent(ctx, shell, opts = {}) {
         let creatorName = null;
         try { creatorName = localStorage.getItem("comfyui-mcp.panel.creatorName"); } catch {}
         if (!creatorName) {
-          creatorName = window.prompt("Publish under what creator name?", "anonymous");
-          if (creatorName === null) return;
+          creatorName = await promptModal({
+            title: "Publish to the registry",
+            label: "Creator name",
+            value: "anonymous",
+            placeholder: "anonymous",
+            submitLabel: "Continue",
+          });
+          if (creatorName === null) { publishBtn.disabled = false; return; }
           creatorName = creatorName.trim() || "anonymous";
           try { localStorage.setItem("comfyui-mcp.panel.creatorName", creatorName); } catch {}
         }
@@ -795,35 +1030,50 @@ export function createAppsContent(ctx, shell, opts = {}) {
         });
         await showDetail(app.id);
       } catch (e) {
-        window.alert(`Publish failed: ${e.message}`);
+        toast(`Publish failed: ${e.message}`);
         publishBtn.disabled = false;
       }
     });
 
     editBtn.addEventListener("click", async () => {
-      const name = window.prompt("App name", app.name || "");
-      if (name === null) return;
-      const description = window.prompt("Description", app.description || "");
-      if (description === null) return;
-      await client.update(app.id, { manifest: { name: name.trim() || app.name, description } });
+      const vals = await formModal({
+        title: "Edit app info",
+        submitLabel: "Save",
+        fields: [
+          { key: "name", label: "App name", value: app.name || "", maxLength: 120 },
+          { key: "description", label: "Description", value: app.description || "", multiline: true, rows: 4 },
+        ],
+      });
+      if (!vals) return;
+      await client.update(app.id, { manifest: { name: vals.name.trim() || app.name, description: vals.description } });
       await showDetail(app.id);
     });
 
     hideBtn.disabled = !!app.hideWorkflow;
     hideBtn.addEventListener("click", async () => {
-      const ok = window.confirm(
-        "Hide the workflow for “" + (app.name || "this app") + "”?\n\n" +
+      const ok = await confirmModal({
+        title: "Hide the workflow?",
+        message:
+          "Hide the workflow for “" + (app.name || "this app") + "”?\n\n" +
           "This DELETES the stored node graph — the app keeps only its run snapshot and can't be " +
-          "edited as a workflow afterwards. This is best-effort privacy, not security: anyone who " +
-          "runs the app can still intercept the prompt via ComfyUI's API.\n\nContinue?",
-      );
+          "edited as a workflow afterwards. Best-effort privacy, not security: anyone who runs the " +
+          "app can still intercept the prompt via ComfyUI's API.",
+        confirmLabel: "Hide workflow",
+        danger: true,
+      });
       if (!ok) return;
       await client.update(app.id, { manifest: { hideWorkflow: true } });
       await showDetail(app.id);
     });
 
     delBtn.addEventListener("click", async () => {
-      if (!window.confirm(`Delete “${app.name || "this app"}”? This can't be undone.`)) return;
+      const ok = await confirmModal({
+        title: "Delete app",
+        message: `Delete “${app.name || "this app"}”? This can't be undone.`,
+        confirmLabel: "Delete",
+        danger: true,
+      });
+      if (!ok) return;
       await client.remove(app.id);
       await showGrid();
     });

--- a/web/js/cmcp-apps.js
+++ b/web/js/cmcp-apps.js
@@ -267,11 +267,19 @@ export class AppBuilder {
   ]);
 
   /** Widget value → app input kind. `nodeType` refines (LoadImage → image
-   *  upload; *Loader → model picker). */
-  static classifyWidget(nodeType, widgetName, value) {
+   *  upload; *Loader → model picker); `widgetType` is the live litegraph widget
+   *  type when available (lets us spot a `color` widget, which is otherwise an
+   *  ordinary string). seed/noise_seed get the dedicated seed control. */
+  static classifyWidget(nodeType, widgetName, value, widgetType) {
     const t = String(nodeType || "");
+    const name = String(widgetName || "");
+    const wt = String(widgetType || "").toLowerCase();
     if (/loadimage/i.test(t)) return "image";
-    if (/loader/i.test(t) || /_name$/i.test(widgetName)) return "model";
+    if (/loader/i.test(t) || /_name$/i.test(name)) return "model";
+    if (wt === "color" || (/color/i.test(name) && typeof value === "string" && /^#?[0-9a-fA-F]{6}$/.test(value))) {
+      return "color";
+    }
+    if (name === "seed" || name === "noise_seed" || name === "rand_seed") return "seed";
     if (typeof value === "number") return "number";
     if (typeof value === "boolean") return "toggle";
     if (Array.isArray(value)) return "combo";

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -16,6 +16,7 @@ import {
   filtersDirty, bitmask, parseCreatorQuery,
 } from "./cmcp-civitai.js";
 import { openSidePanel } from "./cmcp-sidepanel-ui.js";
+import { openSubModal as openSubModalBase, toast } from "./cmcp-modal.js";
 
 const TABS = [
   { key: "images", label: "Images", icon: "pi-image", media: "image" },
@@ -1702,38 +1703,11 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
   function closeSubModals() {
     for (const c of [..._subModals]) { try { c(); } catch { /* already gone */ } }
   }
+  // openSubModal + toast now live in the shared cmcp-modal.js (the Apps tab reuses
+  // them). This wrapper threads Civitai's own `_subModals` tracker so the stacked
+  // close-sweep + Escape gating stay byte-identical; `toast` is imported directly.
   function openSubModal(title, onClose) {
-    const ov = el("div", "cmcp-cv-overlay"); ov.style.zIndex = "10001";
-    const m = el("div", "cmcp-modal"); m.style.maxWidth = "40rem"; m.style.width = "min(40rem, 92vw)";
-    m.style.maxHeight = "85vh"; m.style.overflowY = "auto";
-    const head2 = el("div", "cmcp-modal-title", title);
-    const x = el("button", "cmcp-cv-iconbtn"); x.innerHTML = '<i class="pi pi-times"></i>';
-    x.style.cssText = "position:absolute;top:.5rem;right:.5rem";
-    const b = el("div"); m.style.position = "relative";
-    // Every close path (✕ button, backdrop click, sheet.close()) funnels here,
-    // so a caller-supplied teardown runs no matter how the sheet is dismissed.
-    const close2 = () => { _subModals.delete(close2); ov.remove(); if (onClose) onClose(); };
-    _subModals.add(close2);
-    x.addEventListener("click", close2);
-    ov.addEventListener("mousedown", (e) => { if (e.target === ov) close2(); });
-    m.append(head2, x, b); ov.appendChild(m); document.body.appendChild(ov);
-    return { body: b, close: close2 };
-  }
-
-  function toast(msg, { ms = 3500 } = {}) {
-    const t = el("div", null, msg);
-    // ALWAYS mount on <body> above every overlay — sub-modals (10001), the
-    // lightbox (10002) and the workflow picker sit above the base modal, and a
-    // toast rendered inside `modal` (z-index 80) was hidden behind them, so a
-    // gated-download hint or a load error read as "nothing happened". A fixed,
-    // top-of-stack toast is visible no matter which sheet is open (or if the
-    // whole explorer just closed after a successful load).
-    t.style.cssText = "position:fixed;bottom:1.25rem;left:50%;transform:translateX(-50%);" +
-      "max-width:min(38rem,90vw);text-align:center;background:var(--p-surface-800,#27272a);" +
-      "color:#fafafa;padding:.55rem .9rem;border-radius:8px;z-index:10060;font-size:.82rem;" +
-      "box-shadow:0 4px 16px rgba(0,0,0,.5)";
-    document.body.appendChild(t);
-    setTimeout(() => t.remove(), ms);
+    return openSubModalBase(title, onClose, _subModals);
   }
 
   // ── agent-driven handle ────────────────────────────────────────────────

--- a/web/js/cmcp-modal.js
+++ b/web/js/cmcp-modal.js
@@ -1,0 +1,192 @@
+// Shared themed-modal primitives for the side-panel surfaces.
+//
+// `openSubModal` + `toast` were originally private to cmcp-civitai-ui.js; they
+// are lifted here VERBATIM (same DOM, same class vocabulary, same z-indexes) so
+// the Apps tab can reuse the exact same themed chrome instead of native
+// window.* dialogs. Civitai imports them back and passes its own `_subModals`
+// tracker Set, keeping its behavior byte-identical (its Playwright specs depend
+// on the sub-modal DOM + the stacked-close/escape semantics).
+//
+// On top of those primitives this module builds three promise-returning helpers
+// the Apps UI uses to replace confirm()/alert()/prompt():
+//   confirmModal({title,message,confirmLabel,cancelLabel,danger}) -> Promise<bool>
+//   promptModal ({title,label,value,placeholder,multiline})       -> Promise<string|null>
+//   formModal   ({title,fields[],submitLabel,cancelLabel})        -> Promise<values|null>
+//
+// All user text goes through textContent (el() below) — no HTML injection.
+
+const el = (tag, cls, txt) => {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (txt != null) n.textContent = txt;
+  return n;
+};
+
+/** Themed sub-modal on document.body — overlay z-10001, above the side-panel
+ *  shell. `tracker`, when given, is a Set the closer registers itself in (so a
+ *  caller can sweep every stacked sheet + gate Escape); omit it for one-off
+ *  modals. Returns { body, close }. Behaviorally identical to civitai-ui's
+ *  original private openSubModal. */
+export function openSubModal(title, onClose, tracker) {
+  const ov = el("div", "cmcp-cv-overlay"); ov.style.zIndex = "10001";
+  const m = el("div", "cmcp-modal"); m.style.maxWidth = "40rem"; m.style.width = "min(40rem, 92vw)";
+  m.style.maxHeight = "85vh"; m.style.overflowY = "auto";
+  const head2 = el("div", "cmcp-modal-title", title);
+  const x = el("button", "cmcp-cv-iconbtn"); x.innerHTML = '<i class="pi pi-times"></i>';
+  x.style.cssText = "position:absolute;top:.5rem;right:.5rem";
+  const b = el("div"); m.style.position = "relative";
+  // Every close path (✕ button, backdrop click, sheet.close()) funnels here,
+  // so a caller-supplied teardown runs no matter how the sheet is dismissed.
+  const close2 = () => { if (tracker) tracker.delete(close2); ov.remove(); if (onClose) onClose(); };
+  if (tracker) tracker.add(close2);
+  x.addEventListener("click", close2);
+  ov.addEventListener("mousedown", (e) => { if (e.target === ov) close2(); });
+  m.append(head2, x, b); ov.appendChild(m); document.body.appendChild(ov);
+  return { body: b, close: close2 };
+}
+
+export function toast(msg, { ms = 3500 } = {}) {
+  const t = el("div", null, msg);
+  // ALWAYS mount on <body> above every overlay — sub-modals (10001), the
+  // lightbox (10002) and the workflow picker sit above the base modal, and a
+  // toast rendered inside `modal` (z-index 80) was hidden behind them, so a
+  // gated-download hint or a load error read as "nothing happened". A fixed,
+  // top-of-stack toast is visible no matter which sheet is open (or if the
+  // whole explorer just closed after a successful load).
+  t.style.cssText = "position:fixed;bottom:1.25rem;left:50%;transform:translateX(-50%);" +
+    "max-width:min(38rem,90vw);text-align:center;background:var(--p-surface-800,#27272a);" +
+    "color:#fafafa;padding:.55rem .9rem;border-radius:8px;z-index:10060;font-size:.82rem;" +
+    "box-shadow:0 4px 16px rgba(0,0,0,.5)";
+  document.body.appendChild(t);
+  setTimeout(() => t.remove(), ms);
+}
+
+let _mdlCss = false;
+function injectModalCss() {
+  if (_mdlCss) return;
+  _mdlCss = true;
+  const css = `
+.cmcp-mdl{display:flex;flex-direction:column;gap:.85rem;}
+.cmcp-mdl-msg{font-size:.85rem;line-height:1.55;white-space:pre-wrap;color:var(--p-text-color,#fafafa);}
+.cmcp-mdl-field{display:flex;flex-direction:column;gap:.3rem;}
+.cmcp-mdl-label{font-size:.72rem;font-weight:600;opacity:.8;text-transform:uppercase;letter-spacing:.03em;}
+.cmcp-mdl-field input,.cmcp-mdl-field textarea{padding:.5rem .6rem;border-radius:8px;
+  border:1px solid var(--p-content-border-color,#3f3f46);background:var(--p-surface-950,#111113);
+  color:var(--p-text-color,#fafafa);font:inherit;font-size:.85rem;box-sizing:border-box;width:100%;}
+.cmcp-mdl-field input:focus,.cmcp-mdl-field textarea:focus{outline:none;border-color:var(--p-primary-color,#60a5fa);}
+.cmcp-mdl-field textarea{resize:vertical;min-height:4.5rem;}
+.cmcp-mdl-btns{display:flex;justify-content:flex-end;gap:.5rem;margin-top:.15rem;}
+.cmcp-mdl-btns .cmcp-btn{align-self:auto;}
+.cmcp-mdl-secondary{background:transparent;border:1px solid var(--p-content-border-color,#3f3f46);
+  color:var(--p-text-color,#fafafa);font-weight:600;}
+.cmcp-btn.cmcp-mdl-danger{background:var(--p-red-500,#dc2626);border:1px solid transparent;color:#fff;}
+.cmcp-btn.cmcp-mdl-danger:hover{opacity:.9;}
+`;
+  const style = document.createElement("style");
+  style.textContent = css;
+  document.head.appendChild(style);
+}
+
+/** Yes/No confirmation. Resolves true only when the confirm button is clicked;
+ *  ✕ / backdrop / cancel all resolve false. */
+export function confirmModal({
+  title = "Confirm",
+  message = "",
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  danger = false,
+} = {}) {
+  injectModalCss();
+  return new Promise((resolve) => {
+    let settled = false;
+    let sheet;
+    const finish = (v) => { if (settled) return; settled = true; resolve(v); sheet.close(); };
+    sheet = openSubModal(title, () => finish(false));
+    const wrap = el("div", "cmcp-mdl");
+    if (message) wrap.append(el("div", "cmcp-mdl-msg", message));
+    const btns = el("div", "cmcp-mdl-btns");
+    const cancel = el("button", "cmcp-btn cmcp-mdl-secondary cmcp-mdl-cancel", cancelLabel);
+    cancel.type = "button";
+    const ok = el("button", "cmcp-btn primary cmcp-mdl-ok", confirmLabel);
+    ok.type = "button";
+    if (danger) ok.classList.add("cmcp-mdl-danger");
+    cancel.addEventListener("click", () => finish(false));
+    ok.addEventListener("click", () => finish(true));
+    btns.append(cancel, ok);
+    wrap.append(btns);
+    sheet.body.append(wrap);
+    ok.focus();
+  });
+}
+
+/** Multi-field form modal. `fields` = [{key,label,value,placeholder,type,multiline,rows}].
+ *  Resolves a { key: value } object on submit, or null when dismissed. */
+export function formModal({ title = "", fields = [], submitLabel = "Save", cancelLabel = "Cancel" } = {}) {
+  injectModalCss();
+  return new Promise((resolve) => {
+    let settled = false;
+    let sheet;
+    const finish = (v) => { if (settled) return; settled = true; resolve(v); sheet.close(); };
+    sheet = openSubModal(title, () => finish(null));
+    const form = document.createElement("form");
+    form.className = "cmcp-mdl";
+    const getters = [];
+    for (const f of fields) {
+      const row = el("div", "cmcp-mdl-field");
+      if (f.label) row.append(el("label", "cmcp-mdl-label", f.label));
+      let input;
+      if (f.type === "textarea" || f.multiline) {
+        input = document.createElement("textarea");
+        input.rows = f.rows || 4;
+      } else {
+        input = document.createElement("input");
+        input.type = f.type || "text";
+      }
+      if (f.placeholder) input.placeholder = f.placeholder;
+      if (f.value != null) input.value = String(f.value);
+      if (f.maxLength) input.maxLength = f.maxLength;
+      row.append(input);
+      getters.push([f.key, () => input.value]);
+      form.append(row);
+    }
+    const submit = () => {
+      const out = {};
+      for (const [k, g] of getters) out[k] = g();
+      finish(out);
+    };
+    const btns = el("div", "cmcp-mdl-btns");
+    const cancel = el("button", "cmcp-btn cmcp-mdl-secondary cmcp-mdl-cancel", cancelLabel);
+    cancel.type = "button";
+    const ok = el("button", "cmcp-btn primary cmcp-mdl-ok", submitLabel);
+    ok.type = "submit";
+    cancel.addEventListener("click", () => finish(null));
+    // Native <form> submit → Enter in any single-line input confirms; the
+    // textarea keeps Enter for newlines. Guard against a full page navigation.
+    form.addEventListener("submit", (e) => { e.preventDefault(); submit(); });
+    btns.append(cancel, ok);
+    form.append(btns);
+    sheet.body.append(form);
+    const first = form.querySelector("input, textarea");
+    if (first) { first.focus(); if (first.select) first.select(); }
+  });
+}
+
+/** Single-field prompt (window.prompt replacement). Resolves the typed string
+ *  (possibly empty) on submit, or null when dismissed — matching prompt()'s
+ *  "" vs null distinction. */
+export function promptModal({
+  title = "",
+  label = "",
+  value = "",
+  placeholder = "",
+  multiline = false,
+  submitLabel = "OK",
+  cancelLabel = "Cancel",
+} = {}) {
+  return formModal({
+    title,
+    submitLabel,
+    cancelLabel,
+    fields: [{ key: "value", label, value, placeholder, multiline }],
+  }).then((v) => (v ? v.value : null));
+}


### PR DESCRIPTION
P1a of the Apps redesign (spec: `~/.claude/plans/apps-redesign.md`). Panel-only; no registry/auth yet.

- **Shared themed modal system** — extracted `openSubModal`/`toast` into `cmcp-modal.js` (CivitAI imports them back, behavior byte-identical) + `confirmModal`/`promptModal`/`formModal` on top. Replaces all 8 native `window.*` dialogs in the Apps tab.
- **Real run-form widgets** — model picker (live `/object_info` ∪ `list_local_models`), number slider (min/max/step), seed (🎲 randomize/fix), color; manifest now carries min/max/step/seedBehavior/nodeType (`_sanitize_manifest` + `classifyWidget` + `draftFromCanvas`).
- **Visual polish** across the Apps grids/cards/detail/run-form.

Gates: `tsc --noEmit` clean, `node --check` ×4 OK, `test:unit` 104 pass, python `test_apps_routes.py` 13 pass. Playwright couldn't run vs the worktree (serve-path); apps.spec.ts updated for the dialog→modal change (verified by trace).