### PR TITLE
feat(apps): P1c — shared filter component + Create App from workflow

### DIFF
--- a/web/js/cmcp-apps-ui.js
+++ b/web/js/cmcp-apps-ui.js
@@ -16,7 +16,8 @@
 // offered — see the hide toggle copy. True protection = hosted runs (P5).
 
 import { AppBuilder, AppsClient, RegistryClient } from "./cmcp-apps.js";
-import { confirmModal, promptModal, formModal, toast } from "./cmcp-modal.js";
+import { confirmModal, promptModal, formModal, toast, openSubModal as openSubModalBase } from "./cmcp-modal.js";
+import { chipRow, makeFilterButton, openFilterPanel } from "./cmcp-filter.js";
 
 let styleInjected = false;
 function injectStyle() {
@@ -338,15 +339,58 @@ export function createAppsContent(ctx, shell, opts = {}) {
   let _tab = "mine"; // "mine" | "explore"
   let _started = false;
   let exploreQuery = "";
+  let exploreSort = "trending"; // Explore sort — the shared filter panel's Sort row
   let _exploreReload = null; // showExplore's load(), so onSearch can re-run it
   let _exploreTimer = null;
+  // Stacked-sheet tracker (mirrors CivitAI's) so the filter panel joins the
+  // Escape-gated close set — see escapeBlocked() below.
+  const _subModals = new Set();
 
   // ── My / Explore toggle → chips in the shared subnav (decision D) ──────────
   const mineChip = el("button", "cmcp-cv-chip", "My Apps");
   const exploreChip = el("button", "cmcp-cv-chip", "Explore");
+
+  // ── Shared filter affordance (P1c) — the SAME header filter button + chip
+  // panel CivitAI uses (cmcp-filter.js). Sort-only for now; structured so
+  // tag/category rows drop straight in as the catalogue grows. Shown on Explore
+  // (My Apps has nothing to sort). Sort keys match RegistryClient.list.
+  const APPS_SORTS = [
+    { value: "trending", label: "Trending" },
+    { value: "new", label: "Newest" },
+    { value: "stars", label: "Most Stars" },
+  ];
+  const { btn: filterBtn, setActive: setFilterActive } =
+    makeFilterButton({ onOpen: () => openAppsFilters(), title: "Filter apps" });
+  function syncFilterBtn() {
+    filterBtn.style.display = _tab === "explore" ? "" : "none";
+    setFilterActive(exploreSort !== "trending"); // "dirty" dot once sort != default
+  }
+  function openAppsFilters() {
+    openFilterPanel({
+      // Thread the tracker so Escape peels the sheet before it can close the panel.
+      openModal: (title, onClose) => openSubModalBase(title, onClose, _subModals),
+      title: "Filter apps",
+      render: (wrap, rerender) => {
+        chipRow(
+          wrap, "Sort", APPS_SORTS,
+          (v) => exploreSort === v,
+          (v) => {
+            if (exploreSort === v) return;
+            exploreSort = v;
+            syncFilterBtn();
+            rerender();                       // flip the pressed chip in the open sheet
+            if (_exploreReload) _exploreReload(); // reload the feed behind it
+          },
+        );
+        // Future rows (tags / categories) append here — same chipRow calls.
+      },
+    });
+  }
+
   function syncChips() {
     mineChip.classList.toggle("on", _tab === "mine");
     exploreChip.classList.toggle("on", _tab === "explore");
+    syncFilterBtn();
   }
   mineChip.addEventListener("click", () => {
     if (_tab === "mine") return;
@@ -434,20 +478,18 @@ export function createAppsContent(ctx, shell, opts = {}) {
       );
       return;
     }
-    const controls = el("div", "cmcp-apps-toolbar");
-    let sort = "trending";
-    const sorts = [["trending", "Trending"], ["new", "New"], ["stars", "Most starred"]];
-    const chips = new Map();
     const grid = el("div", "cmcp-apps-grid");
-    // Search is the shell's shared box (shown only on Explore); its value is
-    // mirrored into exploreQuery and re-runs load() via onSearch.
+    // Sort lives in the shared header filter panel (openAppsFilters), not inline
+    // chips — Explore reads the module-scoped exploreSort. Search is the shell's
+    // shared box (shown only on Explore); its value is mirrored into exploreQuery
+    // and re-runs load() via onSearch.
     async function load(append = false, cursor = "") {
       if (!append) {
         grid.textContent = "";
         grid.append(el("div", "cmcp-apps-empty", "Loading…"));
       }
       try {
-        const res = await registry.list({ sort, q: exploreQuery.trim(), cursor });
+        const res = await registry.list({ sort: exploreSort, q: exploreQuery.trim(), cursor });
         if (closed) return;
         if (!append) grid.textContent = "";
         renderCards(res.apps || [], res.next_cursor);
@@ -489,18 +531,8 @@ export function createAppsContent(ctx, shell, opts = {}) {
         grid.append(more);
       }
     }
-    for (const [key, label] of sorts) {
-      const chip = makeBtn(label, { primary: key === sort });
-      chips.set(key, chip);
-      chip.addEventListener("click", () => {
-        sort = key;
-        for (const [k, c] of chips) c.classList.toggle("primary", k === sort);
-        load();
-      });
-      controls.append(chip);
-    }
-    _exploreReload = () => load(); // onSearch (shared box) re-runs this
-    body.append(controls, grid);
+    _exploreReload = () => load(); // onSearch (shared box) + filter panel re-run this
+    body.append(grid);
     load();
   }
 
@@ -1296,11 +1328,31 @@ export function createAppsContent(ctx, shell, opts = {}) {
     body.append(bar, el("div", "cmcp-apps-empty", e && e.message ? e.message : String(e)));
   }
 
+  // Cross-tab hop seed (CivitAI's "Create App from workflow" → shell.switchTab
+  // ("apps", { view: "convert" })): open straight into the convert view seeded
+  // from the now-loaded canvas. Runs during activate BEFORE onActivate; setting
+  // _started here suppresses onActivate's default showGrid so it can't clobber
+  // the convert form.
+  function reseed(o) {
+    if (!o) return;
+    if (o.view === "convert" || o.convert) {
+      _tab = "mine";
+      _started = true;
+      syncChips();
+      shell.syncSearch();
+      showConvert().catch(showError);
+    }
+  }
+
   return {
     key: "apps", label: "Apps", icon: "pi-th-large", driveKind: null,
     hasSearch: () => _tab === "explore",
     searchPlaceholder: "Search apps…",
-    subnavExtras: () => [mineChip, exploreChip],
+    subnavExtras: () => [mineChip, exploreChip, filterBtn],
+    reseed,
+    // Escape peels an open filter (or other stacked) sheet before it can close the
+    // panel — mirrors CivitAI's escapeBlocked.
+    escapeBlocked: () => _subModals.size > 0,
     mount(bodyEl) { bodyEl.appendChild(body); },
     onActivate() {
       _hidden = false;

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -887,7 +887,9 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
             // then jump to the Apps tab's convert view seeded from the live canvas.
             const appBtn = el("button", "cmcp-btn", "Create App from workflow");
             appBtn.title = "Load this workflow onto the canvas and package it as a one-click app.";
-            appBtn.addEventListener("click", () => { void createAppFromWorkflow(wf.graph, closeLb); });
+            appBtn.addEventListener("click", () => {
+              void createAppFromWorkflow(() => loadOntoCanvas(wf.graph, closeLb, { keepPanelOpen: true }));
+            });
             actions.appendChild(appBtn);
           }
           const saveBtn = el("button", "cmcp-btn", "Save workflow");
@@ -1078,14 +1080,16 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     return true;
   }
 
-  /** "Create App from workflow": load a UI-format graph onto the canvas (reusing
-   *  loadOntoCanvas so the dirty-confirm + undoable graph_load + empty-guard are
-   *  identical to the plain "Load onto canvas" button), keep the side-panel open,
-   *  then hop to the Apps tab and open its convert view seeded from the now-loaded
-   *  canvas. `closeSurface` dismisses the originating lightbox so the user lands on
-   *  the convert form. */
-  async function createAppFromWorkflow(graph, closeSurface) {
-    const loaded = await loadOntoCanvas(graph, closeSurface, { keepPanelOpen: true });
+  /** "Create App from workflow": run `loadWorkflow` (a thunk that loads a UI-format
+   *  graph onto the canvas with the panel kept open — reusing whichever existing
+   *  load path the calling surface uses, so the dirty-confirm + undoable graph_load
+   *  + empty-guard stay identical to that surface's plain "Load onto canvas"
+   *  button), then hop to the Apps tab and open its convert view seeded from the
+   *  now-loaded canvas. The loader resolves truthy only when the graph actually
+   *  landed; on a failed/cancelled/gated load we stay put (the loader already
+   *  toasted). Both the media lightbox and the model-detail surface share this. */
+  async function createAppFromWorkflow(loadWorkflow) {
+    const loaded = await loadWorkflow();
     if (!loaded) return; // load failed / was cancelled — stay put (toast already shown)
     try {
       if (typeof shell.switchTab === "function") shell.switchTab("apps", { view: "convert" });
@@ -1100,7 +1104,10 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
    *  with a picker when an archive holds several. Reports progress and EVERY
    *  failure through `opts.setStatus` (an inline line in the detail sheet) as
    *  well as a toast, and NEVER closes the sheet on failure — only a genuine
-   *  canvas load (via loadOntoCanvas) dismisses the explorer. */
+   *  canvas load (via loadOntoCanvas) dismisses the explorer. `opts.keepPanelOpen`
+   *  threads through to loadOntoCanvas so the create-app-from-workflow hop keeps
+   *  the side-panel up. Resolves truthy only when a graph actually landed (the
+   *  single-file case, or a chosen entry from the multi-workflow picker). */
   async function loadVersionWorkflow(version, file, opts = {}) {
     const setStatus = opts.setStatus || (() => {});
     const say = (msg, kind = "err") => { setStatus(msg, kind); toast(msg); };
@@ -1151,19 +1158,33 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       return;
     }
     setStatus("", "info"); // clear before a successful load closes the explorer
-    if (uis.length === 1) { await loadOntoCanvas(uis[0].graph); return; }
-    // several workflows in one archive — let the user pick
-    const picker = openSubModal("Pick a workflow to load");
-    const list = el("div", "cmcp-cv-creators");
-    list.style.maxHeight = "24rem";
-    for (const c of uis) {
-      const b = el("button", "cmcp-cv-creator");
-      b.appendChild(el("span", null, c.name));
-      b.appendChild(el("span", "sub", `${c.graph.nodes.length} nodes`));
-      b.addEventListener("click", () => { void loadOntoCanvas(c.graph); });
-      list.appendChild(b);
-    }
-    picker.body.appendChild(list);
+    // keepPanelOpen threads through to every loadOntoCanvas call so the create-app
+    // flow keeps the side-panel up (the detail sheet still closes). The resolved
+    // boolean = "a graph actually landed", so createAppFromWorkflow hops only on a
+    // real load.
+    const keepPanelOpen = !!opts.keepPanelOpen;
+    if (uis.length === 1) return await loadOntoCanvas(uis[0].graph, undefined, { keepPanelOpen });
+    // several workflows in one archive — let the user pick.
+    return await new Promise((resolve) => {
+      let picking = false; // a pick is in flight — its closeSubModals teardown must not resolve false
+      const picker = openSubModal("Pick a workflow to load", () => { if (!picking) resolve(false); });
+      const list = el("div", "cmcp-cv-creators");
+      list.style.maxHeight = "24rem";
+      for (const c of uis) {
+        const b = el("button", "cmcp-cv-creator");
+        b.appendChild(el("span", null, c.name));
+        b.appendChild(el("span", "sub", `${c.graph.nodes.length} nodes`));
+        b.addEventListener("click", () => {
+          picking = true;
+          loadOntoCanvas(c.graph, undefined, { keepPanelOpen }).then((ok) => {
+            if (ok) resolve(true);
+            else picking = false; // failed — let another pick (or a close) settle it
+          });
+        });
+        list.appendChild(b);
+      }
+      picker.body.appendChild(list);
+    });
   }
 
   // ── model detail ─────────────────────────────────────────────────────
@@ -1213,6 +1234,18 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
         b.title = `Download ${f.name}${size ? ` (${size})` : ""} and load it onto the canvas (Ctrl+Z undoes it).`;
         b.addEventListener("click", () => { void loadVersionWorkflow(version, f, { setStatus, signIn: () => accountFlow() }); });
         dl.appendChild(b);
+        // Same loadable-workflow condition as "Load onto canvas" (every wfFile is
+        // loadable): load the SELECTED version's workflow with the panel kept open,
+        // then hop to the Apps convert view seeded from the now-loaded canvas.
+        const appB = el("button", "cmcp-btn",
+          wfFiles.length > 1 ? `Create App — ${f.name}` : "Create App from workflow");
+        appB.title = "Download this workflow, load it onto the canvas, and package it as a one-click app.";
+        appB.addEventListener("click", () => {
+          void createAppFromWorkflow(
+            () => loadVersionWorkflow(version, f, { setStatus, signIn: () => accountFlow(), keepPanelOpen: true }),
+          );
+        });
+        dl.appendChild(appB);
       }
       if (have) {
         const note = el("span", null, "You already have this file locally.");

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -17,6 +17,7 @@ import {
 } from "./cmcp-civitai.js";
 import { openSidePanel } from "./cmcp-sidepanel-ui.js";
 import { openSubModal as openSubModalBase, toast } from "./cmcp-modal.js";
+import { chipRow as filterChipRow, makeFilterButton } from "./cmcp-filter.js";
 
 const TABS = [
   { key: "images", label: "Images", icon: "pi-image", media: "image" },
@@ -390,14 +391,12 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
   }
   // The shell wires its single search input → onSearch (returned below); no
   // direct input/keydown listeners are attached here.
-  const filterBtn = el("button", "cmcp-cv-iconbtn");
-  // margin-left:auto pushes the filter ⚙ + account 👤 pair to the subnav's right
-  // edge while the sub-tab row stays left-aligned.
-  filterBtn.style.marginLeft = "auto";
-  filterBtn.innerHTML = '<i class="pi pi-sliders-h"></i>';
-  const filterDot = el("span", "cmcp-cv-dot"); filterDot.style.display = "none";
-  filterBtn.appendChild(filterDot);
-  filterBtn.addEventListener("click", () => toggleFilters());
+  // Header filter button + "dirty" dot via the shared filter helper (cmcp-filter.js)
+  // — same DOM CivitAI always rendered (button.cmcp-cv-iconbtn + child span.cmcp-cv-dot,
+  // margin-left:auto pushing the filter ⚙ + account 👤 pair to the subnav's right
+  // edge, no title to stay byte-identical). setFilterActive lights the dot.
+  const { btn: filterBtn, setActive: setFilterActive } =
+    makeFilterButton({ onOpen: () => toggleFilters(), title: null });
   const acctBtn = el("button", "cmcp-cv-iconbtn");
   acctBtn.innerHTML = '<i class="pi pi-user"></i>';
   acctBtn.title = "CivitAI account";
@@ -445,7 +444,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     for (const b of subTabsWrap.children) b.classList.toggle("active", b._key === state.tab);
     favChips.style.display = tabDef().fav ? "" : "none";
     for (const c of favChips.children) c.classList.toggle("on", c._fv === state.favType);
-    filterDot.style.display = filtersDirty(state.filters) ? "" : "none";
+    setFilterActive(filtersDirty(state.filters));
   }
 
   // ── data ───────────────────────────────────────────────────────────────
@@ -884,6 +883,12 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
             loadBtn.title = "Replace the current canvas with this post's embedded ComfyUI workflow (Ctrl+Z undoes it).";
             loadBtn.addEventListener("click", () => { void loadOntoCanvas(wf.graph, closeLb); });
             actions.appendChild(loadBtn);
+            // Same loadable-workflow condition as "Load onto canvas": load the graph,
+            // then jump to the Apps tab's convert view seeded from the live canvas.
+            const appBtn = el("button", "cmcp-btn", "Create App from workflow");
+            appBtn.title = "Load this workflow onto the canvas and package it as a one-click app.";
+            appBtn.addEventListener("click", () => { void createAppFromWorkflow(wf.graph, closeLb); });
+            actions.appendChild(appBtn);
           }
           const saveBtn = el("button", "cmcp-btn", "Save workflow");
           saveBtn.addEventListener("click", () => saveWorkflow(it, wf.graph));
@@ -1038,8 +1043,11 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
    *  checkState — one load = one Ctrl+Z step). Success is only announced —
    *  and the explorer only closed — after the awaited load actually landed;
    *  `beforeClose` runs first (e.g. the lightbox, which isn't a sub-modal).
+   *  `opts.keepPanelOpen` keeps the unified side-panel up after a successful land
+   *  (the create-app-from-workflow hop needs to switch to the Apps tab rather than
+   *  dismiss the explorer); the originating lightbox/sub-modal is still closed.
    *  Returns true when it loaded. */
-  async function loadOntoCanvas(graph, beforeClose) {
+  async function loadOntoCanvas(graph, beforeClose, opts = {}) {
     if (typeof ctx.loadGraph !== "function") {
       toast("This panel build can't load onto the canvas.");
       return false;
@@ -1063,9 +1071,28 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     }
     if (beforeClose) { try { beforeClose(); } catch { /* already gone */ } }
     closeSubModals();
-    close();
+    // keepPanelOpen: the create-app-from-workflow flow hops to the Apps tab next,
+    // so the side-panel must stay up; a plain load closes the whole explorer.
+    if (!opts.keepPanelOpen) close();
     toast(`Workflow loaded onto the canvas — ${res.node_count} node${res.node_count === 1 ? "" : "s"}. Ctrl+Z undoes it.`);
     return true;
+  }
+
+  /** "Create App from workflow": load a UI-format graph onto the canvas (reusing
+   *  loadOntoCanvas so the dirty-confirm + undoable graph_load + empty-guard are
+   *  identical to the plain "Load onto canvas" button), keep the side-panel open,
+   *  then hop to the Apps tab and open its convert view seeded from the now-loaded
+   *  canvas. `closeSurface` dismisses the originating lightbox so the user lands on
+   *  the convert form. */
+  async function createAppFromWorkflow(graph, closeSurface) {
+    const loaded = await loadOntoCanvas(graph, closeSurface, { keepPanelOpen: true });
+    if (!loaded) return; // load failed / was cancelled — stay put (toast already shown)
+    try {
+      if (typeof shell.switchTab === "function") shell.switchTab("apps", { view: "convert" });
+      else toast("This panel build can't open the Apps tab.");
+    } catch (e) {
+      toast("Couldn't open the Apps tab: " + (e.message || e));
+    }
   }
 
   /** Download a model-version workflow file (raw .json or civitai's zip
@@ -1303,17 +1330,11 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       sheet.body.innerHTML = "";
       const wrap = el("div", "cmcp-cv-filters");
 
-      const chipRow = (label, options, isOn, onToggle) => {
-        wrap.appendChild(el("div", "cmcp-cv-flabel", label));
-        const row = el("div", "cmcp-cv-frow");
-        for (const o of options) {
-          const chip = el("button", "cmcp-cv-chip", o.label);
-          if (isOn(o.value)) chip.classList.add("on");
-          chip.addEventListener("click", () => { onToggle(o.value); renderSheet(); update(); });
-          row.appendChild(chip);
-        }
-        wrap.appendChild(row);
-      };
+      // Delegates to the shared chip-row builder (cmcp-filter.js) — same DOM, same
+      // click semantics (toggle → re-render the sheet so the pressed state flips,
+      // then reload the feed behind it).
+      const chipRow = (label, options, isOn, onToggle) =>
+        filterChipRow(wrap, label, options, isOn, (v) => { onToggle(v); renderSheet(); update(); });
 
       chipRow("Time period", PERIODS.map((p) => ({ label: p, value: p })),
         (v) => f.period === v, (v) => { f.period = v; });

--- a/web/js/cmcp-filter.js
+++ b/web/js/cmcp-filter.js
@@ -1,0 +1,98 @@
+// Shared filter affordance for the side-panel surfaces (Apps redesign P1c).
+//
+// Extracted from cmcp-civitai-ui.js so the CivitAI browser AND the Apps tab share
+// ONE filter paradigm: a header filter icon-button (with a "dirty" dot) that opens
+// a themed chip-row panel. CivitAI keeps its own panel BODY (creator picker +
+// base-model omni-search + browsing levels), but now builds its chip rows and its
+// header filter button through these helpers instead of local copies, so the two
+// surfaces stay in visual + behavioural lockstep as the catalogue grows. Apps
+// reuses the same three helpers to render a Sort chip-row (and, later, tag/category
+// rows) with identical UX + theme.
+//
+// DOM + class vocabulary is CivitAI's, VERBATIM (cmcp-cv-iconbtn / cmcp-cv-dot /
+// cmcp-cv-filters / cmcp-cv-flabel / cmcp-cv-frow / cmcp-cv-chip) so CivitAI's
+// filter panel + its Playwright/agent-drive specs keep working unchanged.
+
+import { openSubModal as openSubModalBase } from "./cmcp-modal.js";
+
+const el = (tag, cls, txt) => {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (txt != null) n.textContent = txt;
+  return n;
+};
+
+// The shell (cmcp-sidepanel-ui.js) already injects .cmcp-cv-frow / .cmcp-cv-chip /
+// .cmcp-cv-iconbtn / .cmcp-cv-dot; CivitAI injects .cmcp-cv-filters / .cmcp-cv-flabel
+// only when ITS tab is first opened. Re-inject those two here (idempotent, same
+// values) so the Apps tab has them even if CivitAI was never visited this session.
+let _cssInjected = false;
+function injectFilterCss() {
+  if (_cssInjected) return;
+  _cssInjected = true;
+  const css = `
+  .cmcp-cv-filters { display: flex; flex-direction: column; gap: .7rem; }
+  .cmcp-cv-flabel { font-size: .7rem; text-transform: uppercase; letter-spacing: .04em;
+    color: var(--p-text-muted-color,#a1a1aa); width: 100%; }
+  `;
+  const style = document.createElement("style");
+  style.textContent = css;
+  document.head.appendChild(style);
+}
+
+/** Build one labeled chip row into `container`: a .cmcp-cv-flabel caption + a
+ *  .cmcp-cv-frow of .cmcp-cv-chip buttons. `isOn(value)` decides the pressed
+ *  (.on) chip; clicking a chip calls `onPick(value)`. Byte-identical to the chip
+ *  rows CivitAI's filter sheet has always rendered. Returns the row element so a
+ *  caller can rebuild it in place (as CivitAI's base-model pills do). */
+export function chipRow(container, label, options, isOn, onPick) {
+  container.appendChild(el("div", "cmcp-cv-flabel", label));
+  const row = el("div", "cmcp-cv-frow");
+  for (const o of options) {
+    const chip = el("button", "cmcp-cv-chip", o.label);
+    if (isOn(o.value)) chip.classList.add("on");
+    chip.addEventListener("click", () => onPick(o.value));
+    row.appendChild(chip);
+  }
+  container.appendChild(row);
+  return row;
+}
+
+/** The header filter button: a .cmcp-cv-iconbtn carrying the sliders icon and a
+ *  .cmcp-cv-dot "dirty" indicator (hidden until setActive(true)). `onOpen` fires
+ *  on click. marginLeftAuto pushes it to the subnav's right edge (CivitAI's
+ *  layout). `title` is applied only when truthy — CivitAI passes null to stay
+ *  byte-identical to its original title-less button. Returns { btn, dot,
+ *  setActive }. */
+export function makeFilterButton({ onOpen, title = "Filters", marginLeftAuto = true } = {}) {
+  const btn = el("button", "cmcp-cv-iconbtn");
+  if (marginLeftAuto) btn.style.marginLeft = "auto";
+  if (title) btn.title = title;
+  btn.innerHTML = '<i class="pi pi-sliders-h"></i>';
+  const dot = el("span", "cmcp-cv-dot");
+  dot.style.display = "none";
+  btn.appendChild(dot);
+  btn.addEventListener("click", () => { if (onOpen) onOpen(); });
+  const setActive = (on) => { dot.style.display = on ? "" : "none"; };
+  return { btn, dot, setActive };
+}
+
+/** Open a themed chip-row filter panel. Opens a sub-modal (via `openModal`,
+ *  default the shared openSubModal — pass a tracker-threading opener to keep the
+ *  sheet in a surface's stacked-close/Escape set) titled `title`, and calls
+ *  `render(wrap, rerender)` to fill a .cmcp-cv-filters column. `rerender`
+ *  re-invokes render after a chip toggles so its pressed state flips immediately
+ *  (the pattern CivitAI's sheet uses). `onClose` runs on any dismissal. Returns
+ *  the sheet handle ({ body, close }). */
+export function openFilterPanel({ openModal = openSubModalBase, title = "Filters", onClose, render } = {}) {
+  injectFilterCss();
+  const sheet = openModal(title, onClose);
+  const rerender = () => {
+    sheet.body.innerHTML = "";
+    const wrap = el("div", "cmcp-cv-filters");
+    sheet.body.appendChild(wrap);
+    if (render) render(wrap, rerender);
+  };
+  rerender();
+  return sheet;
+}

--- a/web/js/cmcp-sidepanel-ui.js
+++ b/web/js/cmcp-sidepanel-ui.js
@@ -264,6 +264,12 @@ export function openSidePanel(ctx = {}, opts = {}) {
   const shell = {
     ctx, overlay, modal, body, searchEl, subnav, extras, head,
     close, applyDock, syncSearch,
+    // Cross-tab hop for content providers (e.g. CivitAI's "Create App from
+    // workflow" jumping to the Apps tab). `reseed` is forwarded to the target
+    // tab's reseed()/factory opt — the same seam the host handle's switchTab uses.
+    // `activate` is a hoisted declaration below, so this closure resolves it at
+    // call time.
+    switchTab: (key, reseed) => activate(key, { reseed }),
     isDocked: () => overlay.classList.contains("cmcp-docked") && !applyDock.centered,
     isCentered: () => applyDock.centered,
   };


### PR DESCRIPTION
P1c of the Apps redesign (`~/.claude/plans/apps-redesign.md`).

- **Shared filter component** (`cmcp-filter.js`): extracted CivitAI's `chipRow` + filter-button + collapsible chip-panel; CivitAI imports them (byte-identical DOM), Apps Explore now uses the same filter button → Sort chip-row (Trending/Newest/Most Stars), structured for future tag/category rows.
- **"Create App from workflow"** on both the media lightbox (`openViewer`) and the Workflows model detail (`openModelDetail`, next to "Load workflow onto canvas", per selected version). One shared `createAppFromWorkflow(loaderThunk)`: load onto canvas (keep-panel-open) → `shell.switchTab("apps",{view:"convert"})` → Apps `reseed` → `showConvert` reads the loaded canvas.

node --check ×changed OK, test:unit 104/104. Playwright compiles (35 tests) but can't run vs the worktree (serve-path); traced.