### PR TITLE
fix(panel): keep the working indicator alive through long turns (#132)

### DIFF
--- a/browser_tests/working-indicator-liveness.spec.ts
+++ b/browser_tests/working-indicator-liveness.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Tier 1 — the working indicator survives the 120s safety deadline.
+ *
+ * Regression for issue #132: `THINKING_SAFETY_MS` (120s) unconditionally hid the
+ * working/thinking indicator when it fired, so a long SILENT Codex turn (tools
+ * running, no user-visible text) looked like it had ended after ~2 minutes even
+ * though the orchestrator still owned the turn. Newly typed messages then queued
+ * against a composer that appeared idle.
+ *
+ * Uses the Playwright clock to jump past the old 121s deadline and asserts:
+ *   1. an `action` frame surfaces the current operation on the indicator;
+ *   2. the indicator is STILL visible (and still shows the action) after 130s of
+ *      silence, because the turn is still authoritative (`agentWorking`);
+ *   3. it disappears only after an authoritative terminal frame (`turn: done`).
+ *
+ * The clock is installed AFTER connect so ComfyUI's own load timers run on real
+ * time; only the indicator's safety/word timers (armed on `turn: working`) are
+ * faked, which is all this test advances.
+ */
+import { test, expect } from './fixtures/panelTest'
+
+test('keeps the working indicator alive past the 120s safety timeout while a turn runs', async ({
+  panel,
+  mockBridge,
+  page
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  // Fake time only from here — the indicator's timers are armed on turn:working.
+  await page.clock.install()
+
+  const thinking = page.locator('.cmcp-root .cmcp-thinking')
+
+  // A turn begins and runs a silent tool — no say/stream frames arrive.
+  mockBridge.startTurn()
+  await expect(thinking).toBeVisible()
+
+  // An `action` frame names the current operation → live label on the indicator.
+  mockBridge.send({ type: 'action', name: 'panel.panel_query_graph' })
+  await expect(thinking).toContainText('query graph')
+
+  // Jump PAST the old 121s deadline. Pre-fix, armSafety() → hideThinking() here.
+  await page.clock.fastForward(130_000)
+
+  // Still running → still visible, still showing what it's doing.
+  await expect(thinking).toBeVisible()
+  await expect(thinking).toContainText('query graph')
+
+  // Only an authoritative terminal frame clears it.
+  mockBridge.turnDone()
+  await expect(thinking).toBeHidden()
+})

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11409,6 +11409,10 @@ function buildPanel() {
   }
 
   function newChat() {
+    // Abandoning the current conversation ends any in-flight turn from THIS
+    // tab's point of view — clear agentWorking first so resetFeed() below won't
+    // rebuild a working indicator onto the fresh, empty chat.
+    endTurnLocally();
     thread = null;
     turnAnchors = []; // fresh conversation → no rewind anchors
     ssSet(CURRENT_THREAD_KEY, null);
@@ -11706,7 +11710,10 @@ function buildPanel() {
   // no turn is in flight (covers a missed turn:done so it can't stick forever).
   function onThinkingSafety() {
     thinkingSafety = null;
-    if (agentWorking) {
+    // Persist only while the turn is genuinely live — working AND connected.
+    // A permanent disconnect leaves agentWorking true with no more frames, so
+    // gating on bridgeConnected too lets this backstop still hide it in ≤120s.
+    if (agentWorking && bridgeConnected) {
       if (!thinkingEl) showThinking(); // rebuilds the indicator AND re-arms
       else armSafety();
       return;
@@ -11864,6 +11871,11 @@ function buildPanel() {
   // tray) rather than start immediately. Drives the tray-vs-inline decision so
   // an idle send doesn't briefly flash through the tray.
   let agentWorking = false;
+  // Best-effort "is the bridge live" flag (mirrors onStatus). The working
+  // indicator persists past the 120s backstop only while a turn is BOTH working
+  // AND connected — so a permanent bridge drop mid-turn still self-clears in
+  // ≤120s instead of spinning "Reconnecting…" forever.
+  let bridgeConnected = false;
 
   // Set by a Settings "Set … token" button just before it asks the agent to open
   // the secure input, so the resolved value can be marked set/not-set (timestamp
@@ -11938,6 +11950,7 @@ function buildPanel() {
       // (clicking Disconnect, or trying to send while disconnected) and live
       // at those call sites.
       const connected = state === "connected";
+      bridgeConnected = connected; // bounds the working-indicator backstop
       connectBtn.hidden = connected;
       disconnectBtn.hidden = !connected;
       connectBtn.disabled = state === "connecting";
@@ -12124,8 +12137,11 @@ function buildPanel() {
     onRunpodAlert(frame) {
       panelRunpod?.onAlert(frame);
     },
-    // Live extended-thinking token count → update the working indicator.
+    // Live extended-thinking token count → update the working indicator. Gate
+    // on agentWorking (like onAction): a late thinking frame arriving AFTER a
+    // local interrupt must not resurrect the indicator the user just dismissed.
     onThinking(tokens) {
+      if (!agentWorking) return;
       setThinkingTokens(tokens);
     },
     // The agent called panel_request_secret — collect a token securely.
@@ -13589,6 +13605,11 @@ function buildPanel() {
     lsSet(AUTOCONNECT_KEY, null);
     setSetting(SETTING_AUTOCONNECT, false);
     client.stop();
+    // client.stop() sets closed=true, so the socket onclose suppresses onStatus
+    // — end the turn locally so the working indicator can't spin forever against
+    // a turn the user just walked away from (no turn:done will ever arrive).
+    bridgeConnected = false;
+    endTurnLocally();
     connectBtn.hidden = false;
     disconnectBtn.hidden = true;
     connectBtn.disabled = false;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -6818,7 +6818,7 @@ function redactBridgeUrl(u) {
   }
 }
 
-function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk, onSecret, onSecretSaved, onReload, onTodo, onShowMedia, onOpenCivitai, onCivitaiCmd, onTrainingCmd, onUiRender, onUiUpdate, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onBackends, onAck, onTurn, onTurnAnchor, getResume, getBackend, onHandshakeTimeout, onBridgeClosed, onPairUrl, onPairError, onRunpodStatus, onComfyuiTarget, onRunpodAlert }) {
+function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk, onSecret, onSecretSaved, onReload, onTodo, onShowMedia, onOpenCivitai, onCivitaiCmd, onTrainingCmd, onUiRender, onUiUpdate, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onBackends, onAck, onTurn, onAction, onTurnAnchor, getResume, getBackend, onHandshakeTimeout, onBridgeClosed, onPairUrl, onPairError, onRunpodStatus, onComfyuiTarget, onRunpodAlert }) {
   let sock = null;
   let url = loadBridgeUrl();
   let closed = false;
@@ -7198,6 +7198,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onAsk
       // turn incl. silent tool work; done clears it).
       if (msg && msg.type === "turn" && typeof msg.state === "string") {
         onTurn?.(msg.state);
+      }
+      // The tool/operation the agent is currently running (e.g.
+      // "panel.panel_query_graph") → live activity label on the working
+      // indicator, so a long SILENT tool phase shows progress instead of
+      // looking idle. Emitted throughout a turn; cleared on turn:done.
+      if (msg && msg.type === "action" && typeof msg.name === "string") {
+        onAction?.(msg.name);
       }
       // Live download progress for the status tray (sourced orchestrator-side
       // from the download tool's temp progress file and/or the Manager queue).
@@ -11388,8 +11395,17 @@ function buildPanel() {
     // claiming success; and a stale unresolved surface:"wide" entry would keep
     // the sidebar wide forever. Cards replay INERT from the thread instead.
     liveA2uiCards.clear();
+    // The thinking indicator lived in `log` and was just detached along with
+    // everything else. Drop the stale refs — otherwise a later showThinking()
+    // sees a truthy-but-detached thinkingEl and silently no-ops, hiding a live
+    // turn's progress (reachable when an async history/thread repaint runs mid
+    // turn). If a turn is still authoritative, recreate the indicator so it
+    // stays visible; loadThread re-pins it below the repainted messages.
+    thinkingEl = null;
+    thinkingLabel = null;
     setChatSurfaceForCards();
     log.appendChild(empty);
+    if (agentWorking) showThinking();
   }
 
   function newChat() {
@@ -11424,6 +11440,9 @@ function buildPanel() {
         else paintCard(m);
       }
     }
+    // resetFeed() recreated the indicator (if a turn is live) ABOVE these
+    // repainted messages — re-pin it to the bottom so it trails the newest one.
+    if (agentWorking) bumpThinking();
     renderTodo(t.todos || []); // restore this thread's plan into the tray
     // Resume this conversation's agent session (or start fresh if it has none),
     // so typing continues THIS chat rather than whatever was last active.
@@ -11669,6 +11688,8 @@ function buildPanel() {
   let workWordIdx = 0;
   let thinkingSafety = null;
   let thinkingTokens = 0;
+  let thinkingAction = null; // current tool/operation label (from `action` frames)
+  let thinkingReconnecting = false; // transient bridge drop while a turn is live
   // Backstop: if no activity (say/command/turn signal) for this long, auto-hide
   // — covers a missed turn:done (e.g. an older orchestrator, or an errored turn)
   // so the indicator never sticks forever.
@@ -11676,7 +11697,21 @@ function buildPanel() {
 
   function armSafety() {
     if (thinkingSafety) clearTimeout(thinkingSafety);
-    thinkingSafety = setTimeout(hideThinking, THINKING_SAFETY_MS);
+    thinkingSafety = setTimeout(onThinkingSafety, THINKING_SAFETY_MS);
+  }
+
+  // The 120s backstop must never make a STILL-RUNNING turn look finished (a
+  // silent tool phase can exceed two minutes). If the turn is still
+  // authoritative, repair a detached indicator and re-arm; only auto-hide when
+  // no turn is in flight (covers a missed turn:done so it can't stick forever).
+  function onThinkingSafety() {
+    thinkingSafety = null;
+    if (agentWorking) {
+      if (!thinkingEl) showThinking(); // rebuilds the indicator AND re-arms
+      else armSafety();
+      return;
+    }
+    hideThinking();
   }
 
   function fmtThinkTokens(n) {
@@ -11684,19 +11719,44 @@ function buildPanel() {
   }
   function cycleWord() {
     if (!thinkingLabel) return;
-    const base =
-      thinkingTokens > 0
-        ? `Thinking… (${fmtThinkTokens(thinkingTokens)} tokens)`
-        : `${WORK_WORDS[workWordIdx % WORK_WORDS.length]}…`;
+    // Priority: a transient reconnect banner > the live token meter (active
+    // extended thinking) > the current tool/operation label > playful idle
+    // words. A running tool clears the token meter (setThinkingAction), so the
+    // action label wins during silent tool phases rather than a stale count.
+    let base;
+    if (thinkingReconnecting) base = "Reconnecting… (turn still running)";
+    else if (thinkingTokens > 0) base = `Thinking… (${fmtThinkTokens(thinkingTokens)} tokens)`;
+    else if (thinkingAction) base = thinkingAction;
+    else base = `${WORK_WORDS[workWordIdx % WORK_WORDS.length]}…`;
     thinkingLabel.textContent = `${base} (Esc or Ctrl+C to stop)`;
     workWordIdx += 1;
   }
   // Live extended-thinking token meter (from the orchestrator's thinking frame).
   function setThinkingTokens(n) {
     thinkingTokens = Number(n) || 0;
+    thinkingAction = null; // live thinking supersedes the last tool's label
     if (!thinkingEl) showThinking();
     cycleWord();
     armSafety();
+  }
+
+  // Humanize an `action` frame name — "panel.panel_query_graph" → "Using query
+  // graph…" — into a live activity label so silent tool phases show what the
+  // agent is doing. Rebuilds a detached indicator and re-pins/re-arms it.
+  function humanizeAction(name) {
+    let s = String(name || "").trim();
+    s = s.split(".").pop() || s; // drop a "panel." (etc.) namespace prefix
+    s = s.replace(/^panel_/, "").replace(/_/g, " ").trim();
+    return s ? `Using ${s}…` : "Working…";
+  }
+  function setThinkingAction(name) {
+    thinkingAction = humanizeAction(name);
+    thinkingTokens = 0; // a tool is running now, not extended thinking
+    if (!thinkingEl) showThinking(); // rebuilds + re-arms; cycleWord shows the label
+    else {
+      cycleWord();
+      bumpThinking(); // re-pin below the newest activity + re-arm the safety timer
+    }
   }
 
   function hideThinking() {
@@ -11716,6 +11776,18 @@ function buildPanel() {
       thinkingLabel = null;
     }
     thinkingTokens = 0; // reset so the next turn doesn't show a stale count
+    thinkingAction = null;
+    thinkingReconnecting = false;
+  }
+
+  // A user-initiated local stop (Esc / Ctrl+C, or discarding the last turn).
+  // Mark the turn terminated authoritatively BEFORE hiding, so the safety timer
+  // and a transient reconnect (both of which now keep a live turn visible) can't
+  // resurrect the indicator in the window before the orchestrator's turn:done.
+  function endTurnLocally() {
+    agentWorking = false;
+    ssSet(MID_TASK_KEY, null); // turn stopped — nothing to resume
+    hideThinking();
   }
 
   function showThinking() {
@@ -11883,8 +11955,23 @@ function buildPanel() {
         sendStallConfig();
         // Sync preferred models + ollama endpoint config (only when non-default).
         sendAgentModelConfig(false);
+        // Reconnected — drop any transient "reconnecting" banner; live frames
+        // resume the normal label from here.
+        thinkingReconnecting = false;
       }
-      if (!connected) hideThinking();
+      // A transient drop mid-turn keeps the turn AUTHORITATIVE — the orchestrator
+      // still owns it and the bridge will rebind/resume. Clearing the indicator
+      // here falsely reads as "turn finished", so keep it up (with a reconnecting
+      // banner) while a turn is live; only hide when nothing is in flight.
+      if (!connected) {
+        if (agentWorking) {
+          thinkingReconnecting = true;
+          if (!thinkingEl) showThinking();
+          else cycleWord();
+        } else {
+          hideThinking();
+        }
+      }
       if (state === "disconnected" && externalOrchestratorMode()) showExternalHintOnce();
       // NB: do NOT push set_options here. The saved model id is only known-valid
       // once the live catalog arrives, so the push happens in applyModelCatalog
@@ -12085,6 +12172,13 @@ function buildPanel() {
     onReload(scope) {
       softReload("agent", scope);
     },
+    onAction(name) {
+      // A tool/operation started (or changed). Only meaningful while a turn is
+      // in flight; keep the indicator alive with its label so a silent tool
+      // phase never looks idle.
+      if (!agentWorking) return;
+      setThinkingAction(name);
+    },
     onTurn(state) {
       if (state === "working") {
         agentWorking = true;
@@ -12092,7 +12186,7 @@ function buildPanel() {
         ssSet(MID_TASK_KEY, "1"); // a turn is in flight — arm the resume nudge
       } else if (state === "done") {
         agentWorking = false;
-        hideThinking();
+        hideThinking(); // authoritative terminal frame — clears the action label too
         ssSet(MID_TASK_KEY, null); // turn finished cleanly — nothing to resume
         // Snapshot the graph the agent is leaving behind; the next user turn diffs
         // the live graph against this to surface MANUAL edits made between turns.
@@ -14290,7 +14384,7 @@ function buildPanel() {
     }
     if (thinkingEl) {
       client?.sendFrame?.({ type: "interrupt" });
-      hideThinking();
+      endTurnLocally();
     }
   }
 
@@ -14813,7 +14907,7 @@ function buildPanel() {
     }
     if (client.sendFrame({ type: "interrupt" })) {
       ev.preventDefault();
-      hideThinking();
+      endTurnLocally();
       appendSystem("Interrupted.");
     }
   }


### PR DESCRIPTION
Fixes #132 — a long, silent Codex turn (tools running, no user-visible text) hid the working/thinking indicator after ~120s, so the composer looked idle and newly typed messages queued against a turn the orchestrator still owned.

## Root causes → fixes (all in `web/js/comfyui-mcp-panel.js`)

1. **120s backstop hid a healthy turn.** `THINKING_SAFETY_MS` fired `hideThinking()` unconditionally. Split `armSafety` → **`onThinkingSafety`**, which checks the authoritative `agentWorking`: while a turn is live it **repairs** a detached indicator and **re-arms**; it only auto-hides when nothing is in flight (still covering a missed `turn:done` so it can't stick forever).
2. **`action` frames were ignored.** Wire `onAction` through `createBridgeClient` + a new `action` frame branch → a humanized live label (`panel.panel_query_graph` → **"Using query graph…"**) that re-pins and re-arms the indicator, so silent tool phases show progress instead of looking idle.
3. **`resetFeed()` left stale detached refs.** It removed `.cmcp-thinking` but kept `thinkingEl`/`thinkingLabel` pointing at the detached node, making a later `showThinking()` a silent no-op (reachable when an async history/thread repaint runs mid-turn). Null the refs, recreate for a live turn, and `loadThread` re-pins it below the repainted messages.
4. **Transient disconnect falsely read as "done".** A drop keeps the turn authoritative (rebind/resume). Keep the indicator up with a **"Reconnecting…"** banner while `agentWorking`; only hide when nothing is in flight.

**Hardening:** the two user-interrupt paths (Esc/Ctrl+C) now go through **`endTurnLocally()`**, which clears `agentWorking` *before* hiding — otherwise the new safety/disconnect "rebuild while working" logic could resurrect the indicator in the window before the orchestrator's `turn:done`. `turn:done`/`hideThinking` also clear the action + reconnecting labels.

## Test
`browser_tests/working-indicator-liveness.spec.ts` — with the Playwright clock: start a turn + `action`, fast-forward **past the old 121s deadline**, assert the indicator is still visible and still shows the action, then that it clears only on `turn:done`.

## Verification
- `tsc --noEmit` — clean
- unit suite (`node --test`) — **104/104**
- `node --check` — OK

The Playwright e2e needs a ComfyUI serving this branch (CI / local) — deliberately **not** run in this session to avoid disturbing the live `:8188` primary clone another agent is using. Pure client-side JS; no orchestrator/mcp change needed (the orchestrator already emits `action`/`turn` frames — the panel was just ignoring them).

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)