### PR TITLE
fix(history): codex review round for #106 — record identity, causal stamps, live rebinding, dead-panel callbacks

### DIFF
--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -1414,3 +1414,47 @@ test('bounds checkpointed operations, rejects compacted stale resurrection, and 
   assert.equal(Object.hasOwn(reloaded.meta.workflowAliases, 'workflows/deleted-0.json'), false)
   unsubscribe()
 })
+
+test('reviseThread stamps a causal createdRevision on new threads (codex: pre-checkpoint loss)', () => {
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb: null })
+  const thread = { id: 'fresh', createdAt: 1, updatedAt: 1, msgs: [] }
+  store.reviseThread(thread, { workflowKey: 'workflow:new' }, 5_000)
+  assert.ok(thread.createdRevision, 'new thread must carry a causal creation stamp')
+  assert.ok(thread.createdRevision.updatedAt >= 5_000)
+  const existing = thread.createdRevision
+  store.reviseThread(thread, { sessionId: 's1' }, 6_000)
+  assert.equal(thread.createdRevision, existing, 'creation stamp is write-once')
+})
+
+test('touchMessage stamps a causal createdRevision when missing (codex: pre-checkpoint loss)', () => {
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb: null })
+  const message = { id: 'm1', createdAt: 1, text: 'hi' }
+  store.touchMessage(message, 5_000)
+  assert.ok(message.createdRevision)
+  assert.ok(message.createdRevision.updatedAt >= 5_000)
+  const existing = message.createdRevision
+  store.touchMessage(message, 6_000)
+  assert.equal(message.createdRevision, existing, 'creation stamp is write-once')
+})
+
+test('unsubscribe suppresses a pending readCanonical delivery (codex: dead-panel callback)', async () => {
+  const values = new Map()
+  const storage = {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value)
+  }
+  const listeners = new Set()
+  const eventTarget = {
+    addEventListener: (type, listener) => type === 'storage' && listeners.add(listener),
+    removeEventListener: (type, listener) => type === 'storage' && listeners.delete(listener)
+  }
+  const store = new ChatHistoryStore({ storage, indexedDb: null })
+  let calls = 0
+  const unsubscribe = store.subscribe(() => { calls += 1 }, eventTarget)
+
+  for (const listener of listeners) listener({ key: 'comfyui-mcp.panel.threads' })
+  // The read is in flight; destroy the panel before it resolves.
+  unsubscribe()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  assert.equal(calls, 0, 'a read started before unsubscribe must not deliver')
+})

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10589,6 +10589,14 @@ function buildPanel() {
       const panelOwned = sessionFollowsPanel();
       if (refreshed && (panelOwned || isThreadInScope(refreshed, currentTranscriptScopeKey()))) {
         thread = refreshed;
+        // The merge cloned every message — rebind live A2UI cards to the NEW
+        // records by id, or their next action mutates a detached object that
+        // persistThreads no longer writes (codex finding).
+        const byId = new Map((thread.msgs || []).map((m) => [m.id, m]));
+        for (const entry of liveA2uiCards.values()) {
+          const live = byId.get(entry.rec?.id);
+          if (live) entry.rec = live;
+        }
       } else {
         const scopeKey = panelOwned ? null : currentTranscriptScopeKey();
         detachInvalidCurrentThread({ scopeKey, rebind: !panelOwned });
@@ -10643,16 +10651,20 @@ function buildPanel() {
       setActiveThread(currentHistorySelectionKey(), thread.id);
     }
     const now = Date.now();
-    entry = {
-      ...entry,
-      id:
+    // Mutate in place — NEVER clone: callers (appendA2UICard) keep the record
+    // they passed and mutate it later (resolve/dismiss/ui_update). Replacing
+    // it with a spread here detached those mutations from thread.msgs, so card
+    // state silently never persisted (codex finding).
+    if (
+      !(
         typeof entry.id === "string" &&
         entry.id &&
         !Object.hasOwn(thread.deletedMessages || {}, entry.id)
-          ? entry.id
-          : crypto.randomUUID(),
-      createdAt: Number(entry.createdAt) || now,
-    };
+      )
+    ) {
+      entry.id = crypto.randomUUID();
+    }
+    if (!Number(entry.createdAt)) entry.createdAt = now;
     historyStore.touchMessage(entry, now);
     thread.msgs.push(entry);
     if (thread.msgs.length > MAX_THREAD_MSGS) {

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -1039,6 +1039,11 @@ export class ChatHistoryStore {
         updatedAt: revision.updatedAt,
         revision,
       };
+      // A genuinely new thread needs a CAUSAL creation stamp: without one,
+      // normalization synthesizes createdRevision from createdAt, which a
+      // future-dated checkpoint then classifies as pre-checkpoint and drops
+      // (the whole fresh conversation vanishes on merge/reload — codex finding).
+      if (!thread.createdRevision) thread.createdRevision = revision;
       if (deleted) delete thread[field];
       else thread[field] = cloneJson(normalizedValue);
       newestAt = Math.max(newestAt, revision.updatedAt);
@@ -1053,6 +1058,9 @@ export class ChatHistoryStore {
     if (!message || typeof message !== "object") return message;
     this._observeRevision(message.revision || message);
     const revision = this.nextRevision(updatedAt);
+    // Same causal-creation guarantee as threads: a checkpoint at/ahead of wall
+    // clock must not read this genuinely-new message as pre-checkpoint.
+    if (!message.createdRevision) message.createdRevision = revision;
     message.updatedAt = revision.updatedAt;
     message.revision = revision;
     return message;
@@ -1270,18 +1278,27 @@ export class ChatHistoryStore {
       ) return;
       // Resolve through canonical IDB first so quarantined pre-v3 shadows never
       // transiently remount in another live panel.
-      void this.readCanonical().then(listener);
+      notify();
     };
     const onBroadcast = (event) => {
       if (
         !["history-changed", "history-reset"].includes(event?.data?.type) ||
         event.data.writerId === this.writerId
       ) return;
-      void this.readCanonical().then(listener);
+      notify();
+    };
+    let active = true;
+    // A read started before unsubscribe must not deliver into a dead panel —
+    // a slow IDB read can otherwise fire the stale listener AFTER a replacement
+    // panel mounted (it would clear shared session keys / push new_session on
+    // behalf of a delete that panel already handled — codex finding).
+    const notify = () => {
+      void this.readCanonical().then((snapshot) => {
+        if (active) listener(snapshot);
+      });
     };
     eventTarget?.addEventListener?.("storage", onStorage);
     this._broadcastChannel?.addEventListener?.("message", onBroadcast);
-    let active = true;
     const unsubscribe = () => {
       if (!active) return;
       active = false;


### PR DESCRIPTION
Follow-up to #106 (the PR head lived on JusticeWay's fork, so this codex:rescue round couldn't land inside it — cherry-picked here).

1. **[P1] A2UI record identity** — `record()` spread-cloned entries; card resolve/dismiss/ui_update mutations landed on a detached clone and never persisted. Now mutates in place.
2. **[P2] Causal creation stamps** — `reviseThread`/`touchMessage` stamp write-once causal `createdRevision`s so a future-dated checkpoint can't drop genuinely new history as pre-checkpoint.
3. **[P2] Live card rebinding** — cross-tab merges clone every message; `liveA2uiCards` now rebinds by message id.
4. **[P2] Dead-panel callbacks** — `subscribe()` deliveries gated on the subscription still being active.

+3 unit regressions (142 total green); conversation-persistence spec 7/7 green against a live ComfyUI.