### PR TITLE
fix(registry): explicit column whitelists for list + detail queries (defense-in-depth)

### DIFF
--- a/registry/src/core.js
+++ b/registry/src/core.js
@@ -124,8 +124,9 @@ export function buildListQuery({ sort, q, creator, includeNsfw, limit, cursor })
   const scoreExpr =
     `(SELECT COUNT(*) FROM stars s WHERE s.app_id = a.id AND s.created_at > unixepoch() - 604800) * 3 ` +
     `+ (SELECT COUNT(*) FROM run_marks r WHERE r.app_id = a.id AND r.day > strftime('%Y-%m-%d', 'now', '-7 days'))`;
-  const cursorCol = sort === "stars" ? "star_count" : sort === "trending" ? "score" : "created_at";
-  const orderDir = cursorCol === "created_at" ? "DESC" : "DESC";
+  const CURSOR_COLS = { stars: "star_count", trending: "score", new: "created_at" };
+  const cursorCol = CURSOR_COLS[sort] || "created_at";
+  const orderDir = "DESC";
   const inner = `SELECT a.*, ${scoreExpr} AS score FROM apps a WHERE ${where.join(" AND ")}`;
 
   let outerWhere = "";

--- a/registry/src/worker.js
+++ b/registry/src/worker.js
@@ -164,10 +164,14 @@ async function list(url, env) {
   });
 }
 
+const DETAIL_QUERIES = {
+  "a.id": "SELECT a.*, 0 AS score FROM apps a WHERE a.id = ? AND hidden = 0",
+  "a.slug": "SELECT a.*, 0 AS score FROM apps a WHERE a.slug = ? AND hidden = 0",
+};
 async function detailRow(env, by, value) {
-  const row = await env.DB.prepare(`SELECT a.*, 0 AS score FROM apps a WHERE ${by} = ? AND hidden = 0`)
-    .bind(value)
-    .first();
+  const sql = DETAIL_QUERIES[by];
+  if (!sql) throw { status: 400, message: "invalid lookup column" };
+  const row = await env.DB.prepare(sql).bind(value).first();
   if (!row) throw { status: 404, message: "app not found" };
   return row;
 }


### PR DESCRIPTION
Cherry-picks @anupamme's fix from #146 onto an in-repo branch so CI can run (the fork PR couldn't trigger the required check). Authorship preserved.

Replaces string-interpolated SQL identifiers with explicit whitelist maps in the registry Worker:
- `core.js buildListQuery`: `CURSOR_COLS = { stars, trending, new }` map for the cursor/order column (was a ternary).
- `worker.js detailRow`: `DETAIL_QUERIES` map keyed by `"a.id"`/`"a.slug"`, throwing 400 on an unknown lookup column (was `WHERE ${by} = ?`).

**Note — this is defense-in-depth, not an active-vuln fix:** `by` is always a hardcoded `"a.id"`/`"a.slug"` from the three internal callers, and `cursorCol` was already constrained by the ternary to three fixed column names — neither was user-injectable. Making the whitelist explicit guards against a future caller wiring user input in. Behavior-preserving (verified: same column mapping, same SQL).

Supersedes #146 (fork PR, CI-blocked) and #145 (redundant, already closed).

Verification: registry `node --test` **10/10**; `node --check` both files OK.

Co-authored-by: anupamme <mediratta@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)