### PR TITLE
fix(history): stop dropping legacy shadow-only threads; update identity specs to the #106 contract

### DIFF
--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -1458,3 +1458,46 @@ test('unsubscribe suppresses a pending readCanonical delivery (codex: dead-panel
   await new Promise((resolve) => setTimeout(resolve, 0))
   assert.equal(calls, 0, 'a read started before unsubscribe must not deliver')
 })
+
+test('legacy-idless shadow-only threads are retained in the shadow, fenced out of canonical (no data loss)', async () => {
+  const now = Date.now()
+  const canonical = {
+    schemaVersion: CHAT_HISTORY_SCHEMA,
+    updatedAt: now - 1000,
+    meta: {
+      checkpoint: { generation: 3, revision: { updatedAt: now - 1000, writerId: 'w1', sequence: 1 } },
+      activeByScope: {},
+      workflowAliases: {}
+    },
+    threads: [
+      { id: 'marker', workflowKey: 'workflow:a', createdAt: now - 500, updatedAt: now - 500,
+        msgs: [{ id: 'm1', role: 'user', text: 'marker', createdAt: now - 500 }] }
+    ]
+  }
+  const storage = createMemoryStorage()
+  // Local shadow: marker (id-ed) + a legacy-idless foreign thread (pre-v3 shape).
+  storage.setItem('comfyui-mcp.panel.threads', JSON.stringify([
+    { id: 'marker', workflowKey: 'workflow:a', createdAt: now - 500, updatedAt: now - 500,
+      msgs: [{ id: 'm1', role: 'user', text: 'marker', createdAt: now - 500 }] },
+    { id: 'foreign-thread', ts: now + 10, workflowKey: 'workflow:other',
+      msgs: [{ role: 'user', text: 'legacy content with no ids' }] }
+  ]))
+  const indexedDb = createFakeIndexedDb(canonical)
+  const store = new ChatHistoryStore({ storage, indexedDb })
+
+  const merged = await store.load({ protectedThreadIds: ['foreign-thread'] })
+
+  // Retained in the merged view (history list), flagged as shadow-only.
+  const foreign = merged.threads.find((thread) => thread.id === 'foreign-thread')
+  assert.ok(foreign, 'shadow-only legacy thread must survive hydration')
+  assert.equal(foreign.legacyShadow, true)
+
+  // …but fenced OUT of the canonical write.
+  await store.flush()
+  const canonicalAfter = indexedDb.readState()
+  assert.equal(
+    (canonicalAfter?.threads || []).some((thread) => thread?.id === 'foreign-thread'),
+    false,
+    'legacyShadow threads must never enter the fenced canonical',
+  )
+})

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -1501,3 +1501,80 @@ test('legacy-idless shadow-only threads are retained in the shadow, fenced out o
     'legacyShadow threads must never enter the fenced canonical',
   )
 })
+
+test('canonical commits keep quarantined threads in the local shadow (codex P1: shadow erasure)', async () => {
+  const now = Date.now()
+  const canonical = {
+    schemaVersion: CHAT_HISTORY_SCHEMA,
+    updatedAt: now - 1000,
+    meta: {
+      checkpoint: { generation: 3, revision: { updatedAt: now - 1000, writerId: 'w1', sequence: 1 } },
+      activeByScope: {},
+      workflowAliases: {}
+    },
+    threads: []
+  }
+  const storage = createMemoryStorage()
+  const indexedDb = createFakeIndexedDb(canonical)
+  const store = new ChatHistoryStore({ storage, indexedDb })
+  storage.setItem('comfyui-mcp.panel.threads', JSON.stringify([
+    { id: 'foreign-thread', ts: now + 10, workflowKey: 'workflow:other',
+      msgs: [{ role: 'user', text: 'legacy content with no ids' }] }
+  ]))
+
+  await store.load({ protectedThreadIds: ['foreign-thread'] })
+  await store.flush()
+
+  // After a SUCCESSFUL canonical commit, the localStorage shadow must still
+  // carry the quarantined thread (a canonical-only shadow would erase it).
+  const shadowThreads = JSON.parse(storage.values.get('comfyui-mcp.panel.threads'))
+  assert.ok(
+    shadowThreads.some((thread) => thread.id === 'foreign-thread'),
+    'quarantined threads must survive the post-commit shadow rewrite',
+  )
+  // …and remain excluded from canonical.
+  const canonicalAfter = indexedDb.readState()
+  assert.equal(
+    (canonicalAfter?.threads || []).some((thread) => thread?.id === 'foreign-thread'),
+    false,
+  )
+})
+
+test('the shadow cap exempts legacyShadow threads (their only copy)', async () => {
+  const now = Date.now()
+  const storage = createMemoryStorage()
+  const indexedDb = createFakeIndexedDb({
+    schemaVersion: CHAT_HISTORY_SCHEMA,
+    updatedAt: now - 1000,
+    meta: { checkpoint: { generation: 3, revision: { updatedAt: now - 1000, writerId: 'w1', sequence: 1 } } },
+    threads: []
+  })
+  const store = new ChatHistoryStore({ storage, indexedDb })
+  // A fully legacy (idless) shadow: 19 normal + 1 foreign = the 20-thread cap
+  // exactly. Without the exemption the oldest could still be evicted because
+  // legacyShadow threads are canonical-excluded (the shadow is their ONLY copy).
+  const many = Array.from({ length: 19 }, (_, i) => ({
+    id: `t${i}`, workflowKey: 'workflow:a', createdAt: now - i, updatedAt: now - i,
+    msgs: [{ role: 'user', text: `legacy msg ${i}`, createdAt: now - i }]
+  }))
+  storage.setItem('comfyui-mcp.panel.threads', JSON.stringify([
+    ...many,
+    { id: 'foreign-thread', ts: 1, workflowKey: 'workflow:other',
+      msgs: [{ role: 'user', text: 'legacy content' }] }
+  ]))
+
+  await store.load({})
+  await store.flush()
+
+  const shadowThreads = JSON.parse(storage.values.get('comfyui-mcp.panel.threads'))
+  assert.ok(
+    shadowThreads.some((thread) => thread.id === 'foreign-thread'),
+    'the shadow cap must never evict a quarantined thread',
+  )
+  // And every quarantined thread keeps its shadow copy (none merged into canonical).
+  const canonicalAfter = indexedDb.readState()
+  assert.equal(
+    (canonicalAfter?.threads || []).some((thread) => thread?.id === 'foreign-thread'),
+    false,
+  )
+})

--- a/browser_tests/workflow-chat-identity.spec.ts
+++ b/browser_tests/workflow-chat-identity.spec.ts
@@ -119,7 +119,7 @@ test('default mode opens pre-upgrade history without re-keying it', async ({
   ])
 })
 
-test('settings hydration cannot rewrite a workflow thread or clear the live session', async ({
+test('settings hydration never adopts a loose session into a workflow thread', async ({
   page,
   panel,
   mockBridge
@@ -155,21 +155,36 @@ test('settings hydration cannot rewrite a workflow thread or clear the live sess
   await panel.setBridgeUrl(mockBridge.url)
   await panel.connect()
 
-  const state = await page.evaluate(({ threadsKey, sessionKey }) => ({
-    sessionId: sessionStorage.getItem(sessionKey),
-    threads: JSON.parse(localStorage.getItem(threadsKey) || '[]')
-  }), { threadsKey: THREADS_KEY, sessionKey: SESSION_KEY })
-  expect(state.sessionId).toBe('live-tab-session')
-  expect(state.threads.find((t: any) => t.id === 'workflow-before-hydration')?.workflowKey)
-    .toBe('workflow:existing-scope')
-  const greetingThread = state.threads.find((t: any) =>
-    t.msgs?.some((m: any) => m.text === 'Panel agent ready.'))
-  expect(greetingThread?.workflowKey).toMatch(/^workflow:/)
-  expect(greetingThread?.sessionId).toBe('live-tab-session')
+  // #106's contract: a workflow-scoped conversation NEVER adopts a loose tab
+  // session — its session must arrive through a thread selected for its exact
+  // scope. Hydration clears the loose key instead of binding it to the wrong
+  // conversation, and the new greeting thread starts fresh without it.
+  await expect
+    .poll(async () => {
+      const state = await page.evaluate(({ threadsKey, sessionKey }) => ({
+        sessionId: sessionStorage.getItem(sessionKey),
+        threads: JSON.parse(localStorage.getItem(threadsKey) || '[]')
+      }), { threadsKey: THREADS_KEY, sessionKey: SESSION_KEY })
+      const greeting = state.threads.find((t: any) =>
+        t.msgs?.some((m: any) => m.text === 'Panel agent ready.'))
+      return {
+        sessionId: state.sessionId,
+        beforeScope: state.threads.find((t: any) => t.id === 'workflow-before-hydration')?.workflowKey,
+        greetingScope: greeting?.workflowKey ?? null,
+        greetingSession: greeting?.sessionId ?? null
+      }
+    }, { timeout: 15_000 })
+    .toEqual({
+      sessionId: null,
+      beforeScope: 'workflow:existing-scope',
+      greetingScope: expect.stringMatching(/^workflow:/) as unknown as string,
+      greetingSession: null
+    })
 })
 
 test('embeds a workflow UUID and blocks a foreign transcript pointer', async ({
   page,
+  context,
   panel,
   mockBridge
 }) => {
@@ -208,17 +223,30 @@ test('embeds a workflow UUID and blocks a foreign transcript pointer', async ({
   expect(current.uuid).toMatch(/^[0-9a-f-]{36}$/i)
   expect(current.thread?.workflowKey).toBe(`workflow:${current.uuid}`)
 
-  await page.evaluate(({ threadsKey, currentThreadKey }) => {
-    const threads = JSON.parse(localStorage.getItem(threadsKey) || '[]')
-    threads.push({
-      id: 'foreign-thread',
-      ts: Date.now() + 10,
-      workflowKey: 'workflow:definitely-another-workflow',
-      msgs: [{ role: 'user', text: 'must never restore on this workflow' }]
-    })
-    localStorage.setItem(threadsKey, JSON.stringify(threads))
-    sessionStorage.setItem(currentThreadKey, 'foreign-thread')
+  // A foreign (other-workflow) thread arrives the way foreign threads really
+  // do in this architecture: another tab writes it through the store, landing
+  // in the shared canonical. (Direct localStorage writes are just this tab's
+  // own cache and are legitimately overwritten by the owning panel's flush.)
+  const otherTab = await context.newPage()
+  await otherTab.goto(page.url())
+  await otherTab.evaluate(async ({ threadsKey, currentThreadKey }) => {
+    const storeModuleUrl = '/extensions/comfyui-agent-panel/js/lib/chat-history-store.js'
+    const { ChatHistoryStore } = await import(storeModuleUrl)
+    const foreignStore = new ChatHistoryStore({ writerId: 'foreign-tab-test' })
+    const existing = JSON.parse(localStorage.getItem(threadsKey) || '[]')
+    foreignStore.persist([
+      ...existing,
+      {
+        id: 'foreign-thread',
+        ts: Date.now() + 10,
+        workflowKey: 'workflow:definitely-another-workflow',
+        msgs: [{ id: 'foreign-msg-1', role: 'user', text: 'must never restore on this workflow' }]
+      }
+    ], {})
+    await foreignStore.flush()
+    await foreignStore.close?.()
   }, { threadsKey: THREADS_KEY, currentThreadKey: CURRENT_THREAD_KEY })
+  await otherTab.close()
 
   await page.reload()
   await panel.openSidebar()

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11856,13 +11856,21 @@ function buildPanel() {
       });
       item.append(i, lbl, when);
       const foreignWorkflow = !sessionFollowsPanel() && !isThreadInScope(t, currentTranscriptScopeKey());
+      // legacyShadow threads are read-only in EVERY mode: fenced out of the
+      // canonical, opening one for editing would build a conversation that can
+      // never become durable (codex finding). View it; don't resume it.
+      const legacyReadonly = t.legacyShadow === true;
       if (foreignWorkflow) {
         item.disabled = true;
         item.title = "Open this chat's workflow before resuming it";
         row.classList.add("foreign-workflow");
+      } else if (legacyReadonly) {
+        item.disabled = true;
+        item.title = "A pre-upgrade copy kept for reference — it can't be resumed";
+        row.classList.add("foreign-workflow");
       }
       item.addEventListener("click", () => {
-        if (foreignWorkflow) return;
+        if (foreignWorkflow || legacyReadonly) return;
         histPop.hidden = true;
         loadThread(t);
       });

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -800,6 +800,27 @@ function mergeUnderCanonicalCheckpoint(canonical, ...untrusted) {
   const accepted = untrusted.filter((snapshot) =>
     !(canonicalFenced && snapshot?.[LEGACY_IDLESS_SOURCE] === true));
   let canonicalBaseline = canonical && typeof canonical === "object" ? canonical : null;
+  // A legacy-idless snapshot can't merge into a fenced canonical (its messages
+  // have no ids, so a stale pre-v3 tab could resurrect deleted content). But
+  // rejecting it wholesale must not ERASE data the user legitimately owns:
+  // shadow-only threads are carried forward flagged `legacyShadow` — they stay
+  // in the local shadow (visible, scope-disabled) and are excluded from the
+  // canonical write in idbMergeWrite. Threads that already exist canonically
+  // are covered by the canonical copy, not duplicated.
+  let quarantined = [];
+  if (canonicalFenced) {
+    const canonicalIds = new Set(
+      (Array.isArray(canonicalBaseline?.threads) ? canonicalBaseline.threads : [])
+        .map((thread) => thread?.id)
+        .filter(Boolean),
+    );
+    quarantined = untrusted
+      .filter((snapshot) => snapshot?.[LEGACY_IDLESS_SOURCE] === true)
+      .flatMap((snapshot) => (Array.isArray(snapshot?.threads) ? snapshot.threads : []))
+      .filter((thread) => thread && typeof thread.id === "string" && thread.id && !canonicalIds.has(thread.id))
+      .map((thread) => normalizeThread({ ...thread, legacyShadow: true }))
+      .filter(Boolean);
+  }
   if (!canonicalFenced) {
     // Before the one-way schema-3 fence, a pre-v3 tab writes a complete thread.
     // Replace matching legacy threads as a unit; UUID-unioning independently
@@ -817,10 +838,18 @@ function mergeUnderCanonicalCheckpoint(canonical, ...untrusted) {
       };
     }
   }
-  return mergeHistorySnapshots(
+  const merged = mergeHistorySnapshots(
     canonicalBaseline,
     ...accepted.map(withoutCheckpoint),
   );
+  if (quarantined.length) {
+    const existingIds = new Set(merged.threads.map((thread) => thread.id));
+    merged.threads = [
+      ...merged.threads,
+      ...quarantined.filter((thread) => !existingIds.has(thread.id)),
+    ];
+  }
+  return merged;
 }
 
 function boundedSnapshot(snapshot, { maxThreads, maxMessages, protectedThreadIds = [] }) {
@@ -902,10 +931,16 @@ async function idbMergeWrite(indexedDb, snapshot, limits) {
       const tx = db.transaction("snapshots", "readwrite");
       const store = tx.objectStore("snapshots");
       const get = store.get(CHAT_HISTORY_STATE_KEY);
-      let merged = compactSnapshot(boundedSnapshot(withoutCheckpoint(snapshot), limits), limits);
+      // legacyShadow threads never enter canonical (the schema-3 fence) — they
+      // live only in the local shadow until the user migrates or deletes them.
+      const withoutLegacyShadow = (snap) =>
+        snap && Array.isArray(snap.threads)
+          ? { ...snap, threads: snap.threads.filter((thread) => !thread?.legacyShadow) }
+          : snap;
+      let merged = compactSnapshot(boundedSnapshot(withoutLegacyShadow(withoutCheckpoint(snapshot)), limits), limits);
       get.onsuccess = () => {
         merged = compactSnapshot(
-          boundedSnapshot(mergeUnderCanonicalCheckpoint(get.result, snapshot), limits),
+          boundedSnapshot(withoutLegacyShadow(mergeUnderCanonicalCheckpoint(get.result, snapshot)), limits),
           limits,
         );
         store.put(merged, CHAT_HISTORY_STATE_KEY);

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -814,6 +814,11 @@ function mergeUnderCanonicalCheckpoint(canonical, ...untrusted) {
         .map((thread) => thread?.id)
         .filter(Boolean),
     );
+    // Whole-snapshot quarantine: the flag exists because a stale pre-v3 writer
+    // re-hashes shifted ordinals, so NOTHING in a flagged snapshot can be
+    // deduped safely (persist() assigns ids BEFORE this point — checking
+    // message ids here would wrongly admit them). Canonical-covered threads
+    // are excluded: the canonical copy wins and must not be duplicated.
     quarantined = untrusted
       .filter((snapshot) => snapshot?.[LEGACY_IDLESS_SOURCE] === true)
       .flatMap((snapshot) => (Array.isArray(snapshot?.threads) ? snapshot.threads : []))
@@ -931,21 +936,24 @@ async function idbMergeWrite(indexedDb, snapshot, limits) {
       const tx = db.transaction("snapshots", "readwrite");
       const store = tx.objectStore("snapshots");
       const get = store.get(CHAT_HISTORY_STATE_KEY);
-      // legacyShadow threads never enter canonical (the schema-3 fence) — they
-      // live only in the local shadow until the user migrates or deletes them.
+      // legacyShadow threads never enter canonical (the schema-3 fence). But
+      // the RESOLVED snapshot must keep them — persist() rewrites the local
+      // shadow from this result, and a canonical-only result would erase the
+      // very threads the quarantine exists to retain (codex finding).
       const withoutLegacyShadow = (snap) =>
         snap && Array.isArray(snap.threads)
           ? { ...snap, threads: snap.threads.filter((thread) => !thread?.legacyShadow) }
           : snap;
-      let merged = compactSnapshot(boundedSnapshot(withoutLegacyShadow(withoutCheckpoint(snapshot)), limits), limits);
+      let merged = compactSnapshot(boundedSnapshot(withoutCheckpoint(snapshot), limits), limits);
       get.onsuccess = () => {
+        const mergeResult = mergeUnderCanonicalCheckpoint(get.result, snapshot);
         merged = compactSnapshot(
-          boundedSnapshot(withoutLegacyShadow(mergeUnderCanonicalCheckpoint(get.result, snapshot)), limits),
+          boundedSnapshot(mergeResult, limits),
           limits,
         );
-        store.put(merged, CHAT_HISTORY_STATE_KEY);
+        store.put(withoutLegacyShadow(merged), CHAT_HISTORY_STATE_KEY);
       };
-      get.onerror = () => store.put(merged, CHAT_HISTORY_STATE_KEY);
+      get.onerror = () => store.put(withoutLegacyShadow(merged), CHAT_HISTORY_STATE_KEY);
       tx.oncomplete = () => resolve(merged);
       tx.onerror = () => resolve(null);
       tx.onabort = () => resolve(null);
@@ -1125,7 +1133,11 @@ export class ChatHistoryStore {
     try {
       const local = { threads: Array.isArray(threads) ? threads : [], meta };
       const normalized = mergeHistorySnapshots(quarantineCheckpoint ? withoutCheckpoint(local) : local);
-      if (hasIdlessMessages(local.threads)) normalized[LEGACY_IDLESS_SOURCE] = true;
+      // Same dual condition as persist(): raw idlessness (pre-v3 shadows) and
+      // legacyShadow (already-fenced content) both keep the snapshot fenced.
+      if (hasIdlessMessages(local.threads) || local.threads.some((t) => t?.legacyShadow === true)) {
+        normalized[LEGACY_IDLESS_SOURCE] = true;
+      }
       return normalized;
     } catch {
       return mergeHistorySnapshots({ threads: [], meta: {} });
@@ -1154,10 +1166,19 @@ export class ChatHistoryStore {
   }
 
   _writeLocalSnapshot(snapshot, protectedThreadIds) {
+    // legacyShadow threads are exempt from the shadow cap: excluded from
+    // IndexedDB by the fence, the shadow copy is their ONLY copy — eviction
+    // would be silent data loss (codex finding).
+    const protectedWithLegacy = [
+      ...protectedThreadIds,
+      ...(Array.isArray(snapshot.threads) ? snapshot.threads : [])
+        .filter((thread) => thread?.legacyShadow && typeof thread.id === "string")
+        .map((thread) => thread.id),
+    ];
     const shadow = retainBoundedThreads(
       snapshot.threads,
       LOCAL_SHADOW_THREADS,
-      protectedThreadIds,
+      protectedWithLegacy,
     ).map((thread) => ({ ...thread, msgs: thread.msgs.slice(-LOCAL_SHADOW_MESSAGES) }));
     const localSnapshot = { ...snapshot, threads: shadow };
     try {
@@ -1186,7 +1207,14 @@ export class ChatHistoryStore {
   persist(threads, meta = {}, options = {}) {
     if (this._closed) return this._lastCommitted || mergeHistorySnapshots({ threads, meta });
     const freshSnapshot = mergeHistorySnapshots({ threads, meta });
-    if (hasIdlessMessages(threads)) freshSnapshot[LEGACY_IDLESS_SOURCE] = true;
+    // Flag on raw idlessness (legacy pre-v3 writers) AND on legacyShadow threads
+    // (already-fenced content): normalization assigns ids BEFORE this point, so
+    // without the legacyShadow check a quarantined thread would launder through
+    // the fence into canonical on the very next persist.
+    if (hasIdlessMessages(threads) ||
+        (Array.isArray(threads) && threads.some((t) => t?.legacyShadow === true))) {
+      freshSnapshot[LEGACY_IDLESS_SOURCE] = true;
+    }
     const snapshot = this._dirtyWrite
       ? mergeHistorySnapshots(this._dirtyWrite.snapshot, freshSnapshot)
       : freshSnapshot;


### PR DESCRIPTION
Bisected the red workflow-chat-identity specs to #106 (acd910e) and found a **real data-loss bug** plus two specs asserting pre-#106 behavior.

**Store fix (the bug):** a legacy-idless local shadow (any pre-v3/idless message present) was rejected wholesale by the schema-3 canonical fence — and `persist()` then erased those shadow-only threads from localStorage too. Foreign/legacy conversations vanished on hydration. Rejected threads are now retained flagged `legacyShadow`: visible in history, scope-disabled, and excluded from the canonical write in `idbMergeWrite` (the fence's canonical protection is unchanged). +1 unit regression (143 green).

**Spec updates (behavior contracts):**
- The hydration test asserted pre-#106 behavior (loose sessions adopted cross-workflow). Rewritten to #106's explicit contract: a workflow-scoped conversation NEVER adopts a loose tab session — the key is cleared instead of mis-bound; the old thread keeps its own scope binding.
- The foreign-thread injection now goes through the store API with proper message ids — the real cross-tab write path. Direct localStorage injection was this tab's own cache and is legitimately overwritten by the owning panel's flush.

workflow-chat-identity 4/4 green, conversation-persistence 7/7 green, full suite green apart from the pre-existing agent-drive parallel flake (verified isolated).