### PR TITLE
fix(apps): stop listing core nodes as uninstalled custom nodes

### DIFF
--- a/browser_tests/unit/apps-deps.test.mjs
+++ b/browser_tests/unit/apps-deps.test.mjs
@@ -1,0 +1,28 @@
+// Unit tests for the apps dependency side-panel's core-vs-custom node
+// classification (regression: hidden-workflow apps listed core nodes like
+// EmptyImage / PreviewImage as uninstallable "custom nodes").
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { isCoreNodeModule } from '../../web/js/cmcp-apps-ui.js'
+
+test('core ComfyUI modules are recognized as core', () => {
+  assert.equal(isCoreNodeModule('nodes'), true)
+  assert.equal(isCoreNodeModule('comfy_extras'), true)
+  assert.equal(isCoreNodeModule('comfy_extras.nodes_mask'), true)
+  assert.equal(isCoreNodeModule('comfy_extras.nodes_images'), true)
+})
+
+test('custom node pack modules are not core', () => {
+  assert.equal(isCoreNodeModule('custom_nodes.comfyui-manager'), false)
+  assert.equal(isCoreNodeModule('custom_nodes.was-node-suite'), false)
+  // Prefix must match on a module boundary, not a substring.
+  assert.equal(isCoreNodeModule('comfy_extrasx.evil'), false)
+  assert.equal(isCoreNodeModule('nodes2'), false)
+})
+
+test('unknown or missing python_module is NOT treated as core', () => {
+  assert.equal(isCoreNodeModule(undefined), false)
+  assert.equal(isCoreNodeModule(null), false)
+  assert.equal(isCoreNodeModule(''), false)
+})

--- a/web/js/cmcp-apps-ui.js
+++ b/web/js/cmcp-apps-ui.js
@@ -328,6 +328,39 @@ function nodeInstalled(set, name) {
   return false;
 }
 
+/** Does a node def's python_module identify a core/built-in ComfyUI node?
+ *  Core defs load from "nodes" or "comfy_extras.*"; custom packs load from
+ *  "custom_nodes.*". Unknown/missing modules are NOT treated as core. */
+export function isCoreNodeModule(pythonModule) {
+  const m = String(pythonModule || "");
+  return m === "nodes" || m === "comfy_extras" || m.startsWith("comfy_extras.");
+}
+
+/** The connected frontend's live def for a class_type (same def sources as
+ *  liveWidgetChoices). Null when the frontend doesn't expose defs or the
+ *  class_type isn't registered on this server. */
+function liveNodeDef(getApp, classType) {
+  try {
+    if (!classType) return null;
+    const app = typeof getApp === "function" ? getApp() : null;
+    const defs = app?.nodeManager?.defs || app?.extensions?.nodeDefs || app?.nodeDefs;
+    return (defs && defs[classType]) || null;
+  } catch { return null; }
+}
+
+/** Authoritative fallback for liveNodeDef: the connected server's per-class
+ *  object_info route ({ "<class>": { …, python_module } }). Null on any miss
+ *  (unregistered class_type, offline, non-JSON) — never throws. */
+async function fetchNodeDef(classType) {
+  try {
+    if (!classType) return null;
+    const res = await fetch(`/object_info/${encodeURIComponent(classType)}`);
+    if (!res.ok) return null;
+    const data = await res.json();
+    return (data && data[classType]) || null;
+  } catch { return null; }
+}
+
 /** De-dupe [{pack,installed}] by pack name (case-insensitive); installed wins. */
 function dedupePacks(packs) {
   const map = new Map();
@@ -942,8 +975,12 @@ export function createAppsContent(ctx, shell, opts = {}) {
 
     /** Resolve the declared node deps to [{pack, installed}]. Preferred path:
      *  extract_workflow_dependencies (maps class_type→pack + reports installed vs
-     *  missing authoritatively). Fallback when the prompt is unavailable: the
-     *  declared class_types vs list_installed_nodes (loose — see nodeInstalled). */
+     *  missing authoritatively). Fallback when the prompt is unavailable (e.g.
+     *  hidden-workflow apps): the connected frontend's live node defs first —
+     *  a registered core class_type (EmptyImage, PreviewImage, …) is not a
+     *  custom pack at all and a registered custom one is already installed —
+     *  then declared class_types vs list_installed_nodes (loose — see
+     *  nodeInstalled) for whatever the live defs can't answer. */
     async function resolveNodePacks(declared) {
       const wf = await workflow();
       if (wf) {
@@ -953,10 +990,21 @@ export function createAppsContent(ctx, shell, opts = {}) {
           if (coreOnly) return [];
         } catch { /* fall through to the declared-list heuristic */ }
       }
-      let installed = new Set();
-      try { installed = parseInstalledNodeSet(toolText(await callTool("list_installed_nodes", {}))); }
-      catch { /* older/offline bridge — everything reads as unknown */ }
-      return dedupePacks(declared.map((c) => ({ pack: c, installed: installed.size ? nodeInstalled(installed, c) : false })));
+      const resolved = [];
+      const unknown = [];
+      for (const c of declared) {
+        const def = liveNodeDef(getApp, c) || await fetchNodeDef(c);
+        if (!def) { unknown.push(c); continue; }
+        if (isCoreNodeModule(def.python_module)) continue; // core node — no pack to install
+        resolved.push({ pack: c, installed: true }); // registered live → its pack is present
+      }
+      if (unknown.length) {
+        let installed = new Set();
+        try { installed = parseInstalledNodeSet(toolText(await callTool("list_installed_nodes", {}))); }
+        catch { /* older/offline bridge — everything reads as unknown */ }
+        for (const c of unknown) resolved.push({ pack: c, installed: installed.size ? nodeInstalled(installed, c) : false });
+      }
+      return dedupePacks(resolved);
     }
   }
 


### PR DESCRIPTION
On a hidden-workflow app the dependency side-panel showed 'Custom nodes (0/2 installed)' listing EmptyImage and PreviewImage with Install buttons — both core ComfyUI nodes. Hidden apps store no prompt, so resolveNodePacks fell back to matching declared class_types against list_installed_nodes, which only knows custom packs. The fallback now resolves each class_type via the frontend's live node defs, then /object_info/<class>: core python_module (nodes, comfy_extras.*) drops the entry entirely; a registered custom class_type shows as installed. Unknown class_types keep the old heuristic. Verified against live ComfyUI 0.28.2; unit suite passes with new isCoreNodeModule coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)