### PR TITLE
feat(history): add workflow chat archive UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Added
+- **Chat archive UI** — multiple named or pinned conversations per workflow,
+  workflow-grouped search and filtering, JSON merge import/export, explicit
+  Panel / Workflow / Ask-on-switch scope modes, provider/model metadata, and
+  per-user-message workflow-version context. Missing provider sessions continue
+  from a bounded transcript replay. Portable imports cannot carry foreign
+  sessions, checkpoints, tombstones, or active pointers into local history;
+  provider-mismatched sessions start fresh with bounded transcript hydration.
+  Import is add-only on colliding IDs and fails closed at thread/message caps
+  instead of evicting local history. Materialized metadata maps are bounded, and
+  an IndexedDB outage now warns when the small localStorage shadow is incomplete.
+  Legacy shadow-only transcripts are never silently truncated by those caps.
+
 ## [0.11.0] - 2026-07-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Each provider runs its own orchestrator on its own loopback port (Claude on
 | **Reasoning effort + model selector** | A per-provider effort/model picker — Claude's models, or ChatGPT's GPT-5-class models via Codex — moved into the model selector; a chosen effort survives a provider switch by mapping to the nearest valid level. |
 | **Pending-message tray + reconnect durability** | Queue messages while the agent is busy (edit / send-now / reorder), and reclaim a wedged orchestrator on Connect. |
 | **Apps (micro-apps)** | Convert any workflow into a named, one-click **app** (name, description, thumbnail, chosen input/output endpoints) from the toolbar's **Apps** button — runs headless (the canvas is never touched), locally or on a connected RunPod pod, with best-effort hidden-workflow packaging and a publish/explore registry (`registry/`, Cloudflare Worker + D1 + R2) shared with the mobile app. |
+| **Durable workflow chat history** | Keep multiple named or pinned chats per workflow, search across them, export/import JSON, survive ComfyUI/browser restarts through IndexedDB, and track the graph version used by every user turn. |
 
 ## Quickstart
 

--- a/browser_tests/chat-history-v2.spec.ts
+++ b/browser_tests/chat-history-v2.spec.ts
@@ -1,0 +1,386 @@
+import { test, expect } from './fixtures/panelTest'
+import { resolveHistoryStoreModuleUrl } from './fixtures/historyStoreModule'
+
+const THREADS_KEY = 'comfyui-mcp.panel.threads'
+const META_KEY = 'comfyui-mcp.panel.historyMeta'
+
+async function forceWorkflowScope(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const settings = app.ui.settings
+    if (!w.__cmcpOriginalGetSettingValue) {
+      w.__cmcpOriginalGetSettingValue = settings.getSettingValue.bind(settings)
+    }
+    settings.getSettingValue = (id: string) =>
+      id === 'comfyui-mcp.chatScope'
+        ? 'workflow'
+        : w.__cmcpOriginalGetSettingValue(id)
+  })
+}
+
+async function indexedThreadCount(page: import('@playwright/test').Page): Promise<number> {
+  return page.evaluate(async () => {
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const req = indexedDB.open('comfyui-mcp-panel-history', 3)
+      req.onsuccess = () => resolve(req.result)
+      req.onerror = () => reject(req.error)
+    })
+    try {
+      return await new Promise<number>((resolve, reject) => {
+        const req = db.transaction('snapshots', 'readonly').objectStore('snapshots').get('state')
+        req.onsuccess = () => resolve(Array.isArray(req.result?.threads) ? req.result.threads.length : 0)
+        req.onerror = () => reject(req.error)
+      })
+    } finally {
+      db.close()
+    }
+  })
+}
+
+async function indexedHasMessage(
+  page: import('@playwright/test').Page,
+  text: string
+): Promise<boolean> {
+  return page.evaluate(async (wanted) => {
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const req = indexedDB.open('comfyui-mcp-panel-history', 3)
+      req.onsuccess = () => resolve(req.result)
+      req.onerror = () => reject(req.error)
+    })
+    try {
+      return await new Promise<boolean>((resolve, reject) => {
+        const req = db.transaction('snapshots', 'readonly').objectStore('snapshots').get('state')
+        req.onsuccess = () => resolve(
+          (req.result?.threads || []).some((thread: any) =>
+            thread.msgs?.some((message: any) => message.text === wanted))
+        )
+        req.onerror = () => reject(req.error)
+      })
+    } finally {
+      db.close()
+    }
+  }, text)
+}
+
+test('keeps multiple chats, supports search and restores from IndexedDB without localStorage', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  let received = mockBridge.waitForUserMessage()
+  await panel.sendMessage('first durable conversation')
+  await received
+  mockBridge.say('first answer')
+
+  await panel.root.locator('button[title="New chat"]').click()
+  received = mockBridge.waitForUserMessage()
+  await panel.sendMessage('second searchable conversation')
+  await received
+  mockBridge.say('second answer')
+
+  await expect(panel.root.locator('.cmcp-workflow-version').last()).toBeVisible()
+  await expect.poll(() => indexedThreadCount(page)).toBe(2)
+
+  await panel.root.locator('button[title="Chat history"]').click()
+  const rows = panel.root.locator('.cmcp-hist-row')
+  await expect(rows).toHaveCount(2)
+  const currentOnly = panel.root.getByTestId('history-current-workflow')
+  await currentOnly.check()
+  await expect(rows).toHaveCount(2)
+  await currentOnly.uncheck()
+
+  const newest = rows.first()
+  await newest.hover()
+  await newest.evaluate((row) => {
+    const original = window.prompt
+    window.prompt = () => 'Pinned test chat'
+    row.querySelector<HTMLButtonElement>('button[aria-label="Rename chat"]')?.click()
+    window.prompt = original
+  })
+  await expect(panel.root.locator('.cmcp-hist-row').first()).toContainText('Pinned test chat')
+  await panel.root.locator('.cmcp-hist-row').first().getByRole('button', { name: 'Pin chat' }).evaluate((button: HTMLButtonElement) => button.click())
+
+  const search = panel.root.getByRole('searchbox', { name: 'Search chat history' })
+  await search.fill('first durable')
+  await expect(panel.root.locator('.cmcp-hist-row')).toHaveCount(1)
+  await expect(panel.root.locator('.cmcp-hist-row')).toContainText('first durable conversation')
+
+  const downloadPromise = page.waitForEvent('download')
+  await panel.root.getByRole('button', { name: 'Export all chat history' }).evaluate((button: HTMLButtonElement) => button.click())
+  const download = await downloadPromise
+  expect(download.suggestedFilename()).toMatch(/^comfyui-agent-panel-history-.*\.json$/)
+
+  await search.fill('')
+  const chooserPromise = page.waitForEvent('filechooser')
+  await panel.root.getByRole('button', { name: 'Import chat history (merge)' }).evaluate((button: HTMLButtonElement) => button.click())
+  const chooser = await chooserPromise
+  await chooser.setFiles({
+    name: 'history-import.json',
+    mimeType: 'application/json',
+    buffer: Buffer.from(JSON.stringify({
+      schemaVersion: 2,
+      threads: [{
+        id: 'imported-thread',
+        ts: 1,
+        workflowKey: 'panel:global',
+        title: 'Imported archive',
+        msgs: [{ role: 'user', text: 'imported history marker' }]
+      }],
+      meta: {}
+    }))
+  })
+  await expect(panel.root.locator('.cmcp-hist-row')).toHaveCount(3)
+  await expect(panel.root.locator('.cmcp-hist-row').filter({ hasText: 'Imported archive' })).toBeVisible()
+  await expect.poll(() => indexedThreadCount(page)).toBe(3)
+
+  // importPayload returns cloned records. The panel must rebind its active
+  // conversation before the next record(), or this message is appended to a
+  // detached object and disappears on reload.
+  await panel.root.locator('button[title="Chat history"]').click()
+  received = mockBridge.waitForUserMessage()
+  await panel.sendMessage('message recorded immediately after import')
+  await received
+  mockBridge.say('post-import answer')
+  await expect.poll(() => indexedHasMessage(page, 'message recorded immediately after import')).toBe(true)
+
+  // Remove both synchronous shadows. IndexedDB alone must recover the newest
+  // conversation after a new page session.
+  await page.evaluate(([threadsKey, metaKey]) => {
+    localStorage.removeItem(threadsKey)
+    localStorage.removeItem(metaKey)
+    localStorage.removeItem('comfyui-mcp.panel.autoConnect')
+    sessionStorage.clear()
+  }, [THREADS_KEY, META_KEY])
+  await page.reload()
+  await panel.openSidebar()
+
+  await expect(panel.userBubble('second searchable conversation')).toBeVisible()
+  await expect(panel.userBubble('message recorded immediately after import')).toBeVisible()
+  await expect(panel.agentBubbles.filter({ hasText: 'post-import answer' }).last()).toBeVisible()
+  await expect(panel.agentBubbles.filter({ hasText: 'second answer' }).last()).toBeVisible()
+})
+
+test('groups duplicate workflow titles by UUID and never resumes a foreign provider session', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  const storeModuleUrl = await resolveHistoryStoreModuleUrl(page)
+  await page.evaluate(async (moduleUrl) => {
+    const { ChatHistoryStore } = await import(moduleUrl)
+    const store = new ChatHistoryStore({ writerId: 'archive-provider-test' })
+    const canonical = await store.readCanonical()
+    const now = Date.now() + 100
+    store.persist([
+      ...(canonical.threads || []),
+      {
+        id: 'same-title-a',
+        createdAt: now,
+        updatedAt: now,
+        workflowKey: 'workflow:uuid-a',
+        workflowTitle: 'Duplicated Workflow',
+        provider: 'codex',
+        sessionId: 'codex-session-must-not-resume',
+        msgs: [{
+          id: 'same-title-a-message',
+          role: 'user',
+          text: 'foreign provider archive',
+          createdAt: now
+        }]
+      },
+      {
+        id: 'same-title-b',
+        createdAt: now + 1,
+        updatedAt: now + 1,
+        workflowKey: 'workflow:uuid-b',
+        workflowTitle: 'Duplicated Workflow',
+        provider: 'claude',
+        msgs: [{
+          id: 'same-title-b-message',
+          role: 'user',
+          text: 'second same-title workflow',
+          createdAt: now + 1
+        }]
+      }
+    ], canonical.meta)
+    const result = await store.flush()
+    if (result !== true && result?.ok !== true) {
+      throw new Error(`archive seed failed: ${JSON.stringify(result)}`)
+    }
+    store.close()
+  }, storeModuleUrl)
+
+  await panel.root.locator('button[title="Chat history"]').click()
+  await expect(
+    panel.root.locator('.cmcp-hist-group').filter({ hasText: 'Duplicated Workflow' })
+  ).toHaveCount(2)
+
+  const controls: Record<string, unknown>[] = []
+  const stopCapture = mockBridge.onFrame((frame) => controls.push(frame))
+  await panel.root
+    .locator('.cmcp-hist-row')
+    .filter({ hasText: 'foreign provider archive' })
+    .locator('.cmcp-hist-open')
+    .click()
+  await expect.poll(() => controls.some((frame) => frame.type === 'new_session')).toBe(true)
+  expect(
+    controls.some((frame) =>
+      frame.type === 'resume_session' &&
+      frame.session_id === 'codex-session-must-not-resume')
+  ).toBe(false)
+  stopCapture()
+})
+
+test('embeds a stable workflow UUID and records provider/model workflow snapshots', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  await forceWorkflowScope(page)
+
+  const received = mockBridge.waitForUserMessage()
+  await panel.sendMessage('workflow identity test')
+  await received
+  await expect.poll(() => page.evaluate((key) => {
+    const threads = JSON.parse(localStorage.getItem(key) || '[]')
+    return threads.some((thread: any) =>
+      thread.msgs?.some((message: any) => message.text === 'workflow identity test'))
+  }, THREADS_KEY)).toBe(true)
+
+  const state = await page.evaluate((key) => {
+    const w = window as unknown as {
+      app?: { graph?: { extra?: Record<string, any> } }
+      comfyAPI?: { app?: { app?: { graph?: { extra?: Record<string, any> } } } }
+    }
+    const app = w.comfyAPI?.app?.app || w.app
+    const threads = JSON.parse(localStorage.getItem(key) || '[]')
+    const current = threads.find((t: any) => t.msgs?.some((m: any) => m.text === 'workflow identity test'))
+    return {
+      uuid: app?.graph?.extra?.comfyui_mcp?.workflow_uuid,
+      workflowKey: current?.workflowKey,
+      provider: current?.provider,
+      model: current?.model,
+      versions: current?.workflowVersions,
+      messageVersion: current?.msgs?.find((m: any) => m.text === 'workflow identity test')?.workflowVersion
+    }
+  }, THREADS_KEY)
+
+  expect(state.uuid).toMatch(/^[0-9a-f-]{36}$/i)
+  expect(state.workflowKey).toBe(`workflow:${state.uuid}`)
+  expect(state.provider).toBe('claude')
+  expect(state.model).toBeTruthy()
+  expect(state.messageVersion).toMatch(/^[0-9a-f]{8}$/)
+  expect(state.versions?.[state.messageVersion]?.nodeCount).toBeGreaterThanOrEqual(0)
+})
+
+test('workflow scope disables foreign chats and never restores a stale foreign pointer', async ({
+  page,
+  panel,
+  mockBridge
+}) => {
+  await panel.goto()
+  await panel.setBridgeUrl(mockBridge.url)
+  await panel.openSidebar()
+  await panel.connect()
+
+  await forceWorkflowScope(page)
+
+  const received = mockBridge.waitForUserMessage()
+  await panel.sendMessage('belongs only to workflow A')
+  await received
+
+  await expect.poll(() => page.evaluate((key) => {
+    const threads = JSON.parse(localStorage.getItem(key) || '[]')
+    return threads.find((thread: any) =>
+      thread.msgs?.some((m: any) => m.text === 'belongs only to workflow A'))?.workflowKey
+  }, THREADS_KEY)).toMatch(/^workflow:/)
+  const current = await page.evaluate((key) => {
+    const threads = JSON.parse(localStorage.getItem(key) || '[]')
+    return threads.find((thread: any) =>
+      thread.msgs?.some((m: any) => m.text === 'belongs only to workflow A'))
+  }, THREADS_KEY)
+  expect(current?.workflowKey).toMatch(/^workflow:/)
+
+  const storeModuleUrl = await resolveHistoryStoreModuleUrl(page)
+  await page.evaluate(async ({
+    currentThread,
+    currentWorkflowKey,
+    storeModuleUrl
+  }) => {
+    const { ChatHistoryStore } = await import(storeModuleUrl)
+    const foreignStore = new ChatHistoryStore({ writerId: 'foreign-archive-test' })
+    const canonical = await foreignStore.readCanonical()
+    const foreignThread = {
+      id: 'foreign-thread',
+      schemaVersion: 2,
+      createdAt: Date.now() + 10,
+      updatedAt: Date.now() + 10,
+      ts: Date.now() + 10,
+      workflowKey: 'workflow:definitely-another-workflow',
+      workflowTitle: 'Workflow B',
+      msgs: [{ id: 'foreign-message', role: 'user', text: 'must never appear on workflow A', createdAt: Date.now() + 10 }]
+    }
+    const meta = canonical.meta || {}
+    meta.activeByScope = {
+      ...(meta.activeByScope || {}),
+      [currentWorkflowKey]: currentThread,
+      'workflow:definitely-another-workflow': 'foreign-thread'
+    }
+    foreignStore.persist([...(canonical.threads || []), foreignThread], meta)
+    const result = await foreignStore.flush()
+    if (result !== true && result?.ok !== true) {
+      throw new Error(`foreign archive seed failed: ${JSON.stringify(result)}`)
+    }
+    foreignStore.close()
+    sessionStorage.setItem('comfyui-mcp.panel.currentThreadId', 'foreign-thread')
+  }, {
+    currentThread: current.id,
+    currentWorkflowKey: current.workflowKey,
+    storeModuleUrl
+  })
+
+  await panel.root.locator('button[title="Chat history"]').click()
+  let currentOnly = panel.root.getByTestId('history-current-workflow')
+  await currentOnly.uncheck()
+  let foreignRow = panel.root.locator('.cmcp-hist-row').filter({ hasText: 'must never appear on workflow A' })
+  await expect(foreignRow).toBeVisible()
+  await expect(foreignRow.locator('.cmcp-hist-open')).toBeDisabled()
+  await expect(foreignRow.locator('.cmcp-hist-open')).toHaveAttribute('title', /open workflow b/i)
+  await panel.root.locator('button[title="Chat history"]').click()
+
+  await page.evaluate(() => sessionStorage.clear())
+
+  await page.reload()
+  await panel.openSidebar()
+  // The hermetic fixture intentionally discards panel-setting writes at the
+  // HTTP boundary, so re-apply the user's persisted workflow mode after reload.
+  await forceWorkflowScope(page)
+  // The fixture's canvas is intentionally unsaved, so a full browser restart
+  // creates a fresh workflow UUID and a clean view. Crucially, the stale pointer
+  // from Workflow B is never used as a fallback.
+  await expect(panel.userBubble('must never appear on workflow A')).toHaveCount(0)
+
+  await panel.root.locator('button[title="Chat history"]').click()
+  currentOnly = panel.root.getByTestId('history-current-workflow')
+  await currentOnly.uncheck()
+  foreignRow = panel.root.locator('.cmcp-hist-row').filter({ hasText: 'must never appear on workflow A' })
+  await expect(foreignRow).toBeVisible()
+  await expect(foreignRow.locator('.cmcp-hist-open')).toBeDisabled()
+  await expect(foreignRow.locator('.cmcp-hist-open')).toHaveAttribute('title', /open workflow b/i)
+})

--- a/browser_tests/conversation-persistence.spec.ts
+++ b/browser_tests/conversation-persistence.spec.ts
@@ -5,6 +5,7 @@
  */
 import { test, expect } from './fixtures/panelTest'
 import { PanelPage } from './fixtures/PanelPage'
+import { resolveHistoryStoreModuleUrl } from './fixtures/historyStoreModule'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
@@ -46,9 +47,9 @@ test.beforeEach(async ({ context }) => {
   // The target ComfyUI server may have been started before this worktree was
   // created. Route the two reviewed modules from the checked-out source so the
   // browser gate always exercises this commit rather than a stale server copy.
-  await context.route('**/extensions/comfyui-agent-panel/js/comfyui-mcp-panel.js*', (route) =>
+  await context.route(/\/extensions\/[^/]+\/js\/comfyui-mcp-panel\.js(?:\?.*)?$/, (route) =>
     route.fulfill({ contentType: 'text/javascript', body: PANEL_SOURCE }))
-  await context.route('**/extensions/comfyui-agent-panel/js/lib/chat-history-store.js*', (route) =>
+  await context.route(/\/extensions\/[^/]+\/js\/lib\/chat-history-store\.js(?:\?.*)?$/, (route) =>
     route.fulfill({ contentType: 'text/javascript', body: HISTORY_STORE_SOURCE }))
 })
 
@@ -314,28 +315,25 @@ test('panel delete remains final when a stale tab republishes the removed thread
   expect(staleSnapshot.threads?.some((thread: any) => thread.id === removedThreadId)).toBe(true)
 
   await panel.root.getByTitle('Chat history').click()
-  await page.evaluate(() => {
-    const row = Array.from(document.querySelectorAll<HTMLElement>('.cmcp-hist-row'))
-      .find((candidate) => candidate.textContent?.includes('delete me causally'))
-    const button = row?.querySelector<HTMLButtonElement>('.cmcp-hist-del')
-    if (!button) throw new Error('history delete button was not rendered')
-    button.click()
-  })
+  const deletedRow = panel.root.locator('.cmcp-hist-row').filter({ hasText: 'delete me causally' })
+  page.once('dialog', (dialog) => dialog.accept())
+  await deletedRow.getByRole('button', { name: 'Delete this chat' })
+    .evaluate((button: HTMLButtonElement) => button.click())
   await expect.poll(() => page.evaluate(({ snapshotKey }) => {
     const snapshot = JSON.parse(localStorage.getItem(snapshotKey) || '{}')
     return Object.keys(snapshot.meta?.deletedThreads || {})
   }, { snapshotKey: LOCAL_HISTORY_SNAPSHOT_KEY })).toContain(removedThreadId!)
   await expect.poll(() => indexedHasThread(page, removedThreadId!)).toBe(false)
 
-  await staleTab.evaluate(async (snapshot) => {
-    const storeModuleUrl = '/extensions/comfyui-agent-panel/js/lib/chat-history-store.js'
+  const storeModuleUrl = await resolveHistoryStoreModuleUrl(page)
+  await staleTab.evaluate(async ({ snapshot, storeModuleUrl }) => {
     const { ChatHistoryStore } = await import(storeModuleUrl)
     const staleStore = new ChatHistoryStore({ writerId: 'stale-panel-test' })
     staleStore.persist(snapshot.threads || [], snapshot.meta || {})
     const result = await staleStore.flush()
     if (result !== true && result?.ok !== true) throw new Error(`stale write failed: ${JSON.stringify(result)}`)
     await staleStore.close?.()
-  }, staleSnapshot)
+  }, { snapshot: staleSnapshot, storeModuleUrl })
 
   await page.reload()
   await panel.openSidebar()
@@ -368,8 +366,8 @@ test('clear all removes durable transcripts, preserves workflow identity, and fe
   // Workflow aliases are durable identity metadata, not chat content. Seed one
   // through the public store API so clearAll must preserve it while advancing
   // the canonical checkpoint that fences stale transcript snapshots.
-  await page.evaluate(async ({ path, uuid }) => {
-    const storeModuleUrl = '/extensions/comfyui-agent-panel/js/lib/chat-history-store.js'
+  const storeModuleUrl = await resolveHistoryStoreModuleUrl(page)
+  await page.evaluate(async ({ path, uuid, storeModuleUrl }) => {
     const { ChatHistoryStore, updateMetadataEntry } = await import(storeModuleUrl)
     const seedStore = new ChatHistoryStore({ writerId: 'clear-all-alias-seed' })
     const canonical = await seedStore.readCanonical()
@@ -387,7 +385,7 @@ test('clear all removes durable transcripts, preserves workflow identity, and fe
       throw new Error(`alias seed failed: ${JSON.stringify(result)}`)
     }
     await seedStore.close?.()
-  }, { path: workflowPath, uuid: workflowUuid })
+  }, { path: workflowPath, uuid: workflowUuid, storeModuleUrl })
   await expect.poll(() => indexedWorkflowAlias(page, workflowPath)).toBe(workflowUuid)
 
   const staleTab = await context.newPage()
@@ -423,8 +421,7 @@ test('clear all removes durable transcripts, preserves workflow identity, and fe
 
   // A tab that captured the pre-reset snapshot must not resurrect any deleted
   // transcript, but it must continue to converge on the preserved alias.
-  await staleTab.evaluate(async (snapshot) => {
-    const storeModuleUrl = '/extensions/comfyui-agent-panel/js/lib/chat-history-store.js'
+  await staleTab.evaluate(async ({ snapshot, storeModuleUrl }) => {
     const { ChatHistoryStore } = await import(storeModuleUrl)
     const staleStore = new ChatHistoryStore({ writerId: 'stale-clear-all-panel' })
     staleStore.persist(snapshot.threads || [], snapshot.meta || {})
@@ -433,7 +430,7 @@ test('clear all removes durable transcripts, preserves workflow identity, and fe
       throw new Error(`stale write failed: ${JSON.stringify(result)}`)
     }
     await staleStore.close?.()
-  }, staleSnapshot)
+  }, { snapshot: staleSnapshot, storeModuleUrl })
 
   await expect.poll(() => indexedThreadCount(page)).toBe(0)
   await expect.poll(() => indexedWorkflowAlias(page, workflowPath)).toBe(workflowUuid)

--- a/browser_tests/fixtures/historyStoreModule.ts
+++ b/browser_tests/fixtures/historyStoreModule.ts
@@ -1,0 +1,33 @@
+import type { Page } from '@playwright/test'
+
+/**
+ * Resolve the extension mount ComfyUI actually loaded. Registry installs use
+ * `comfyui-agent-panel`, while repository-named dev junctions commonly use
+ * `comfyui-mcp-panel`; tests must work with either without editing the spec.
+ */
+export async function resolveHistoryStoreModuleUrl(page: Page): Promise<string> {
+  return page.evaluate(async () => {
+    const panelResource = performance
+      .getEntriesByType('resource')
+      .map((entry) => entry.name)
+      .find((url) => /\/extensions\/[^/]+\/js\/comfyui-mcp-panel\.js(?:[?#]|$)/.test(url))
+
+    if (panelResource) {
+      return new URL('./lib/chat-history-store.js', panelResource).href
+    }
+
+    // Some browser builds omit module requests from the resource timeline.
+    // Probe the two supported mount names rather than assuming the registry one.
+    for (const mount of ['comfyui-agent-panel', 'comfyui-mcp-panel']) {
+      const candidate = new URL(`/extensions/${mount}/js/lib/chat-history-store.js`, location.href)
+      try {
+        const response = await fetch(candidate, { cache: 'no-store' })
+        if (response.ok) return candidate.href
+      } catch {
+        // Try the next mount.
+      }
+    }
+
+    throw new Error('Unable to resolve the Agent Panel chat-history module mount')
+  })
+}

--- a/browser_tests/unit/chat-history-store.test.mjs
+++ b/browser_tests/unit/chat-history-store.test.mjs
@@ -11,6 +11,7 @@ import {
   normalizeThread,
   retainBoundedThreads,
   selectPanelThread,
+  parseHistoryImport,
   selectRestoreThread,
   selectThreadForScope,
   updateMetadataEntry
@@ -142,6 +143,446 @@ test('merges browser and durable snapshots by newest thread update', () => {
   assert.equal(merged.threads[0].title, 'kept title')
   assert.equal(merged.meta.activeByScope['panel:global'], 'same')
   assert.equal(merged.meta.workflowAliases['workflows/a.json'], 'uuid-a')
+})
+
+test('accepts legacy array exports and rejects unrelated JSON', () => {
+  const imported = parseHistoryImport(JSON.stringify([{ id: 'one', ts: 1, msgs: [] }]))
+  assert.equal(imported.threads[0].id, 'one')
+  assert.throws(() => parseHistoryImport('{"hello":"world"}'), /not a ComfyUI Agent Panel/i)
+})
+
+test('exports and merges portable archive payloads without dropping existing chats', () => {
+  const store = new ChatHistoryStore({
+    storage: createMemoryStorage(),
+    indexedDb: null,
+    broadcastFactory: null
+  })
+  const exported = store.exportPayload([
+    { id: 'portable', ts: 20, title: 'Portable chat', msgs: [] }
+  ])
+  const merged = store.importPayload(JSON.stringify(exported), [
+    { id: 'existing', ts: 10, title: 'Existing chat', msgs: [] }
+  ])
+  assert.equal(exported.format, 'comfyui-agent-panel-chat-history')
+  assert.equal(exported.schemaVersion, CHAT_HISTORY_SCHEMA)
+  assert.deepEqual(merged.threads.map((thread) => thread.id), ['existing', 'portable'])
+  store.close()
+})
+
+test('portable imports cannot carry checkpoints tombstones sessions or active pointers into local history', () => {
+  const store = new ChatHistoryStore({
+    storage: createMemoryStorage(),
+    indexedDb: null,
+    broadcastFactory: null,
+    writerId: 'portable-import-test'
+  })
+  const currentThread = {
+    id: 'local',
+    createdAt: 100,
+    updatedAt: 100,
+    sessionId: 'local-provider-session',
+    provider: 'claude',
+    msgs: [{ id: 'local-message', role: 'user', text: 'must survive', createdAt: 100 }]
+  }
+  const currentMeta = {
+    workflowAliases: { 'workflows/local.json': 'local-uuid' },
+    activeByScope: { 'panel:global': 'local' },
+    checkpoint: {
+      generation: 2,
+      revision: { updatedAt: 200, writerId: 'local-checkpoint', sequence: 1 }
+    }
+  }
+  const maliciousPortable = {
+    format: 'comfyui-agent-panel-chat-history',
+    schemaVersion: CHAT_HISTORY_SCHEMA,
+    threads: [{
+      id: 'imported',
+      createdAt: 10,
+      updatedAt: 10,
+      sessionId: 'foreign-session',
+      provider: 'codex',
+      deletedMessages: { importedMessage: 999999 },
+      msgs: [{
+        id: 'imported-message',
+        role: 'user',
+        text: 'portable content',
+        createdAt: 10,
+        revision: { updatedAt: 999999, writerId: 'foreign', sequence: 9 }
+      }]
+    }],
+    meta: {
+      checkpoint: {
+        generation: 99,
+        revision: { updatedAt: 999999, writerId: 'foreign', sequence: 99 }
+      },
+      deletedThreads: {
+        local: {
+          value: null,
+          deleted: true,
+          updatedAt: 999999,
+          revision: { updatedAt: 999999, writerId: 'foreign', sequence: 100 }
+        }
+      },
+      activeByScope: { 'panel:global': 'imported' },
+      workflowAliases: {
+        'workflows/local.json': 'foreign-overwrite',
+        'workflows/imported.json': 'imported-uuid'
+      }
+    }
+  }
+
+  const merged = store.importPayload(
+    JSON.stringify(maliciousPortable),
+    [currentThread],
+    currentMeta
+  )
+  assert.deepEqual(merged.threads.map((thread) => thread.id), ['local', 'imported'])
+  assert.equal(merged.threads.find((thread) => thread.id === 'local').sessionId, 'local-provider-session')
+  assert.equal(merged.threads.find((thread) => thread.id === 'imported').sessionId, undefined)
+  assert.equal(merged.threads.find((thread) => thread.id === 'imported').msgs[0].text, 'portable content')
+  assert.equal(merged.meta.activeByScope['panel:global'], 'local')
+  assert.equal(merged.meta.workflowAliases['workflows/local.json'], 'local-uuid')
+  assert.equal(merged.meta.workflowAliases['workflows/imported.json'], 'imported-uuid')
+  assert.equal(merged.meta.checkpoint.generation, 2)
+  assert.equal(merged.importedCount, 1)
+
+  const exported = store.exportPayload(merged.threads, merged.meta)
+  const exportedImported = exported.threads.find((thread) => thread.id === 'imported')
+  assert.equal(exportedImported.sessionId, undefined)
+  assert.equal(exportedImported.createdRevision, undefined)
+  assert.equal(exportedImported.fieldOps, undefined)
+  assert.equal(exportedImported.msgs[0].revision, undefined)
+  assert.equal(exported.meta.checkpoint, undefined)
+  assert.equal(exported.meta.deletedThreads, undefined)
+  assert.equal(exported.meta.activeByScope, undefined)
+  store.close()
+})
+
+test('import fails closed instead of evicting local chats at the canonical cap', () => {
+  const store = new ChatHistoryStore({
+    storage: createMemoryStorage(),
+    indexedDb: null,
+    maxThreads: 500,
+    writerId: 'import-cap-test'
+  })
+  const locals = Array.from({ length: 500 }, (_, index) => ({
+    id: `local-${index}`,
+    createdAt: index + 1,
+    updatedAt: index + 1,
+    msgs: []
+  }))
+  const payload = {
+    format: 'comfyui-agent-panel-chat-history',
+    schemaVersion: CHAT_HISTORY_SCHEMA,
+    threads: [{ id: 'imported-new', createdAt: 9999, updatedAt: 9999, msgs: [] }],
+    meta: {}
+  }
+
+  assert.throws(
+    () => store.importPayload(payload, locals, {}),
+    /only 0 of 500 are available.*no history was changed/i
+  )
+  assert.equal(locals.length, 500)
+  assert.equal(locals[0].id, 'local-0')
+  store.close()
+})
+
+test('import fails closed instead of evicting local messages at the per-thread cap', () => {
+  const store = new ChatHistoryStore({
+    storage: createMemoryStorage(),
+    indexedDb: null,
+    maxMessages: 5,
+    writerId: 'import-message-cap-test'
+  })
+  const local = {
+    id: 'full-chat',
+    createdAt: 1,
+    updatedAt: 5,
+    msgs: Array.from({ length: 5 }, (_, index) => ({
+      id: `local-message-${index}`,
+      role: 'user',
+      text: `local ${index}`,
+      createdAt: index + 1
+    }))
+  }
+
+  assert.throws(
+    () => store.importPayload({
+      format: 'comfyui-agent-panel-chat-history',
+      schemaVersion: CHAT_HISTORY_SCHEMA,
+      threads: [{
+        id: 'full-chat',
+        createdAt: 1,
+        updatedAt: 99,
+        msgs: [{ id: 'imported-message', role: 'agent', text: 'would evict local', createdAt: 99 }]
+      }],
+      meta: {}
+    }, [local], {}),
+    /only 0 of 5 are available.*no history was changed/i
+  )
+  assert.equal(local.msgs.length, 5)
+  assert.equal(local.msgs[0].text, 'local 0')
+  store.close()
+})
+
+test('same-id imports are add-only and cannot replace local messages or thread fields', () => {
+  const store = new ChatHistoryStore({
+    storage: createMemoryStorage(),
+    indexedDb: null,
+    writerId: 'import-collision-test'
+  })
+  const local = {
+    id: 'shared-thread',
+    createdAt: 100,
+    updatedAt: 100,
+    workflowKey: 'workflow:local',
+    workflowTitle: 'Local workflow',
+    provider: 'claude',
+    model: 'local-model',
+    title: 'Local title',
+    todos: [{ text: 'keep local todo', status: 'active' }],
+    workflowVersions: {
+      same: { hash: 'same', capturedAt: 100, nodeCount: 1, snapshot: { local: true } }
+    },
+    msgs: [{
+      id: 'same-message',
+      role: 'user',
+      text: 'local body',
+      createdAt: 100,
+      updatedAt: 100
+    }]
+  }
+  const futureRevision = { updatedAt: 999999, writerId: 'foreign', sequence: 1 }
+  const payload = {
+    format: 'comfyui-agent-panel-chat-history',
+    schemaVersion: CHAT_HISTORY_SCHEMA,
+    threads: [{
+      id: 'shared-thread',
+      createdAt: 100,
+      updatedAt: 999999,
+      workflowKey: 'workflow:foreign',
+      workflowTitle: 'Foreign workflow',
+      provider: 'codex',
+      model: 'foreign-model',
+      fieldOps: {
+        title: {
+          value: null,
+          deleted: true,
+          updatedAt: 999999,
+          revision: futureRevision
+        },
+        todos: {
+          value: null,
+          deleted: true,
+          updatedAt: 999999,
+          revision: { ...futureRevision, sequence: 2 }
+        }
+      },
+      workflowVersions: {
+        same: { hash: 'same', capturedAt: 999999, nodeCount: 999, snapshot: { foreign: true } },
+        added: { hash: 'added', capturedAt: 200, nodeCount: 2 }
+      },
+      msgs: [
+        {
+          id: 'same-message',
+          role: 'agent',
+          text: 'foreign replacement',
+          createdAt: 100,
+          updatedAt: 999999,
+          revision: { ...futureRevision, sequence: 3 }
+        },
+        {
+          id: 'new-message',
+          role: 'agent',
+          text: 'new portable addition',
+          createdAt: 200
+        }
+      ]
+    }],
+    meta: {}
+  }
+
+  const merged = store.importPayload(payload, [local], {})
+  const thread = merged.threads[0]
+  assert.equal(thread.workflowKey, 'workflow:local')
+  assert.equal(thread.workflowTitle, 'Local workflow')
+  assert.equal(thread.provider, 'claude')
+  assert.equal(thread.model, 'local-model')
+  assert.equal(thread.title, 'Local title')
+  assert.deepEqual(thread.todos, [{ text: 'keep local todo', status: 'active' }])
+  assert.equal(thread.msgs.find((message) => message.id === 'same-message').text, 'local body')
+  assert.equal(thread.msgs.find((message) => message.id === 'new-message').text, 'new portable addition')
+  assert.deepEqual(thread.workflowVersions.same.snapshot, { local: true })
+  assert.equal(thread.workflowVersions.added.nodeCount, 2)
+  store.close()
+})
+
+test('imported aliases fill bounded free slots without evicting local aliases', () => {
+  const store = new ChatHistoryStore({
+    storage: createMemoryStorage(),
+    indexedDb: null,
+    maxMetadataOps: 512,
+    writerId: 'import-alias-cap-test'
+  })
+  const localAliases = Object.fromEntries(
+    Array.from({ length: 511 }, (_, index) => [`workflows/local-${index}.json`, `uuid-${index}`])
+  )
+  const importedAliases = Object.fromEntries(
+    Array.from({ length: 600 }, (_, index) => [`workflows/imported-${index}.json`, `imported-${index}`])
+  )
+  const merged = store.importPayload({
+    format: 'comfyui-agent-panel-chat-history',
+    schemaVersion: CHAT_HISTORY_SCHEMA,
+    threads: [],
+    meta: { workflowAliases: importedAliases }
+  }, [], { workflowAliases: localAliases })
+
+  assert.equal(Object.keys(merged.meta.workflowAliases).length, 512)
+  assert.equal(merged.meta.workflowAliases['workflows/local-0.json'], 'uuid-0')
+  assert.equal(merged.meta.workflowAliases['workflows/local-510.json'], 'uuid-510')
+  assert.equal(merged.meta.workflowAliases['workflows/imported-0.json'], 'imported-0')
+  assert.equal(merged.importedAliasCount, 1)
+  assert.equal(merged.skippedAliasCount, 599)
+  store.close()
+})
+
+test('duplicate imported records cannot crowd local workflow versions out of a colliding chat', () => {
+  const store = new ChatHistoryStore({
+    storage: createMemoryStorage(),
+    indexedDb: null,
+    writerId: 'import-version-cap-test'
+  })
+  const localVersions = Object.fromEntries(
+    Array.from({ length: 19 }, (_, index) => [
+      `local-${index}`,
+      { hash: `local-${index}`, capturedAt: index + 1, nodeCount: index + 1 }
+    ])
+  )
+  const payload = {
+    format: 'comfyui-agent-panel-chat-history',
+    schemaVersion: CHAT_HISTORY_SCHEMA,
+    threads: [
+      {
+        id: 'shared-thread',
+        createdAt: 1,
+        updatedAt: 999,
+        workflowVersions: {
+          'imported-a': { hash: 'imported-a', capturedAt: 999_999, nodeCount: 100 }
+        },
+        msgs: []
+      },
+      {
+        id: 'shared-thread',
+        createdAt: 1,
+        updatedAt: 1_000,
+        workflowVersions: {
+          'imported-b': { hash: 'imported-b', capturedAt: 1_000_000, nodeCount: 101 }
+        },
+        msgs: []
+      }
+    ],
+    meta: {}
+  }
+
+  const merged = store.importPayload(payload, [{
+    id: 'shared-thread',
+    createdAt: 1,
+    updatedAt: 1,
+    workflowVersions: localVersions,
+    msgs: []
+  }], {})
+  const versions = merged.threads[0].workflowVersions
+
+  assert.equal(Object.keys(versions).length, 20)
+  for (const hash of Object.keys(localVersions)) assert.ok(versions[hash], `${hash} must survive`)
+  assert.ok(versions['imported-a'] || versions['imported-b'])
+  store.close()
+})
+
+test('rejects exports from a future history schema', () => {
+  assert.throws(
+    () => parseHistoryImport(JSON.stringify({
+      format: 'comfyui-agent-panel-chat-history',
+      schemaVersion: CHAT_HISTORY_SCHEMA + 1,
+      threads: []
+    })),
+    /newer than this panel supports/i
+  )
+})
+
+test('unions concurrent workflow versions instead of replacing the older map', () => {
+  const merged = mergeHistorySnapshots(
+    {
+      threads: [{
+        id: 'versioned',
+        createdAt: 1,
+        updatedAt: 10,
+        msgs: [],
+        workflowVersions: {
+          alpha: { hash: 'alpha', capturedAt: 10, nodeCount: 1 }
+        }
+      }],
+      meta: {}
+    },
+    {
+      threads: [{
+        id: 'versioned',
+        createdAt: 1,
+        updatedAt: 20,
+        msgs: [],
+        workflowVersions: {
+          beta: { hash: 'beta', capturedAt: 20, nodeCount: 2 }
+        }
+      }],
+      meta: {}
+    }
+  )
+  assert.deepEqual(Object.keys(merged.threads[0].workflowVersions).sort(), ['alpha', 'beta'])
+})
+
+test('bounds workflow versions and drops only oversized snapshots', () => {
+  const workflowVersions = Object.fromEntries(
+    Array.from({ length: 25 }, (_, index) => {
+      const hash = `version-${index}`
+      return [hash, {
+        hash,
+        capturedAt: index + 1,
+        nodeCount: index,
+        snapshot: index === 24 ? { payload: 'x'.repeat(300_001) } : { nodes: [] }
+      }]
+    })
+  )
+  const normalized = normalizeThread({
+    id: 'bounded-versions',
+    ts: 1,
+    msgs: [],
+    workflowVersions
+  })
+  assert.equal(Object.keys(normalized.workflowVersions).length, 20)
+  assert.ok(normalized.workflowVersions['version-24'])
+  assert.equal(normalized.workflowVersions['version-24'].snapshot, undefined)
+  assert.equal(normalized.workflowVersions['version-24'].nodeCount, 24)
+  assert.equal(normalized.workflowVersions['version-0'], undefined)
+})
+
+test('workflow snapshot cap counts UTF-8 bytes instead of UTF-16 code units', () => {
+  const normalized = normalizeThread({
+    id: 'unicode-version',
+    ts: 1,
+    msgs: [],
+    workflowVersions: {
+      unicode: {
+        hash: 'unicode',
+        capturedAt: 1,
+        nodeCount: 1,
+        // 120k CJK characters are 360k UTF-8 bytes, despite fitting in 120k
+        // JavaScript UTF-16 code units.
+        snapshot: { payload: '界'.repeat(120_000) }
+      }
+    }
+  })
+  assert.equal(normalized.workflowVersions.unicode.snapshot, undefined)
+  assert.equal(normalized.workflowVersions.unicode.nodeCount, 1)
 })
 
 test('merges concurrent messages in the same thread without dropping either tab', () => {
@@ -692,11 +1133,25 @@ test('localStorage shadow retains the active tab thread when IndexedDB is unavai
     updatedAt: 1000 + i,
     msgs: [{ id: `m${i}`, role: 'user', text: `message ${i}` }]
   }))
-  const store = new ChatHistoryStore({ storage, indexedDb: null })
+  const failures = []
+  const store = new ChatHistoryStore({
+    storage,
+    indexedDb: null,
+    onPersistenceError: (failure) => failures.push(failure)
+  })
   store.persist(threads, { activeByScope: { 'panel:global': 't0' } })
-  await store.flush()
+  const result = await store.flush()
 
   const shadow = JSON.parse(values.get('comfyui-mcp.panel.threads'))
+  assert.deepEqual(result, {
+    ok: false,
+    shadowCommitted: true,
+    canonicalCommitted: false,
+    retryable: true,
+    code: 'history-canonical-unavailable-shadow-truncated'
+  })
+  assert.equal(failures.length, 1)
+  assert.equal(store._dirtyWrite.snapshot.threads.length, 21)
   assert.equal(shadow.length, 20)
   assert.equal(shadow.some((thread) => thread.id === 't0'), true)
   assert.equal(shadow.some((thread) => thread.id === 't1'), false)
@@ -705,6 +1160,54 @@ test('localStorage shadow retains the active tab thread when IndexedDB is unavai
   const degradedReload = await degradedStore.load({ protectedThreadIds: ['t0'] })
   await degradedStore.flush()
   assert.equal(degradedReload.threads.some((thread) => thread.id === 't0'), true)
+})
+
+test('canonical compaction bounds materialized aliases as well as alias operations', async () => {
+  const indexedDb = createFakeIndexedDb()
+  const aliases = Object.fromEntries(
+    Array.from({ length: 600 }, (_, index) => [`workflows/alias-${index}.json`, `uuid-${index}`])
+  )
+  const store = new ChatHistoryStore({
+    storage: createMemoryStorage(),
+    indexedDb,
+    maxMetadataOps: 512,
+    writerId: 'materialized-alias-cap-test'
+  })
+
+  store.persist([], { updatedAt: 1_000, workflowAliases: aliases })
+  assert.equal(await store.flush(), true)
+
+  const canonical = indexedDb.readState()
+  assert.equal(Object.keys(canonical.meta.workflowAliases).length, 512)
+  assert.equal(Object.keys(canonical.meta.aliasOps).length, 512)
+  assert.equal(canonical.meta.checkpoint.generation, 1)
+  const droppedPath = Object.keys(aliases).find(
+    (path) => !Object.hasOwn(canonical.meta.workflowAliases, path)
+  )
+  assert.ok(droppedPath)
+
+  const stale = new ChatHistoryStore({
+    storage: createMemoryStorage(),
+    indexedDb,
+    maxMetadataOps: 512,
+    writerId: 'stale-alias-writer'
+  })
+  stale.persist([], {
+    workflowAliases: { [droppedPath]: 'must-not-resurrect' },
+    aliasOps: {
+      [droppedPath]: {
+        value: 'must-not-resurrect',
+        deleted: false,
+        updatedAt: 1,
+        revision: { updatedAt: 1, writerId: 'stale-alias-writer', sequence: 1 }
+      }
+    }
+  })
+  await stale.flush()
+  const reloaded = await store.readCanonical()
+  assert.equal(Object.hasOwn(reloaded.meta.workflowAliases, droppedPath), false)
+  stale.close()
+  store.close()
 })
 
 test('canonical IndexedDB merge enforces thread and message limits after union', async () => {
@@ -1550,12 +2053,15 @@ test('the shadow cap exempts legacyShadow threads (their only copy)', async () =
     threads: []
   })
   const store = new ChatHistoryStore({ storage, indexedDb })
-  // A fully legacy (idless) shadow: 19 normal + 1 foreign = the 20-thread cap
-  // exactly. Without the exemption the oldest could still be evicted because
-  // legacyShadow threads are canonical-excluded (the shadow is their ONLY copy).
-  const many = Array.from({ length: 19 }, (_, i) => ({
+  // A fully legacy (idless) shadow above both ordinary local-shadow caps.
+  // These threads are canonical-excluded, so their shadow is the only copy.
+  const many = Array.from({ length: 21 }, (_, i) => ({
     id: `t${i}`, workflowKey: 'workflow:a', createdAt: now - i, updatedAt: now - i,
-    msgs: [{ role: 'user', text: `legacy msg ${i}`, createdAt: now - i }]
+    msgs: Array.from({ length: i === 0 ? 201 : 1 }, (_, j) => ({
+      role: 'user',
+      text: `legacy msg ${i}:${j}`,
+      createdAt: now - i + j,
+    })),
   }))
   storage.setItem('comfyui-mcp.panel.threads', JSON.stringify([
     ...many,
@@ -1567,14 +2073,62 @@ test('the shadow cap exempts legacyShadow threads (their only copy)', async () =
   await store.flush()
 
   const shadowThreads = JSON.parse(storage.values.get('comfyui-mcp.panel.threads'))
-  assert.ok(
-    shadowThreads.some((thread) => thread.id === 'foreign-thread'),
-    'the shadow cap must never evict a quarantined thread',
+  assert.equal(
+    shadowThreads.length,
+    22,
+    'the shadow cap must retain every quarantined thread',
   )
+  assert.equal(
+    shadowThreads.find((thread) => thread.id === 't0')?.msgs.length,
+    201,
+    'the message cap must retain the full only-copy transcript',
+  )
+  assert.ok(shadowThreads.some((thread) => thread.id === 'foreign-thread'))
   // And every quarantined thread keeps its shadow copy (none merged into canonical).
   const canonicalAfter = indexedDb.readState()
   assert.equal(
     (canonicalAfter?.threads || []).some((thread) => thread?.id === 'foreign-thread'),
     false,
   )
+})
+
+test('a canonical commit cannot hide failure to save a legacyShadow only-copy transcript', async () => {
+  const failures = []
+  const indexedDb = createFakeIndexedDb({
+    schemaVersion: CHAT_HISTORY_SCHEMA,
+    updatedAt: 1,
+    meta: { checkpoint: { generation: 1, revision: { updatedAt: 1, writerId: 'seed', sequence: 1 } } },
+    threads: []
+  })
+  const store = new ChatHistoryStore({
+    storage: createMemoryStorage({ throwOnSet: CHAT_HISTORY_LOCAL_SNAPSHOT_KEY }),
+    indexedDb,
+    writerId: 'legacy-shadow-quota-test',
+    onPersistenceError: (failure) => failures.push(failure)
+  })
+
+  store.persist([{
+    id: 'legacy-only',
+    legacyShadow: true,
+    createdAt: 10,
+    updatedAt: 10,
+    msgs: [{ id: 'legacy-message', role: 'user', text: 'only copy', createdAt: 10 }]
+  }], {})
+  const result = await store.flush()
+
+  assert.deepEqual(result, {
+    ok: false,
+    shadowCommitted: false,
+    canonicalCommitted: true,
+    retryable: true,
+    code: 'history-legacy-shadow-unavailable'
+  })
+  assert.equal(failures.length, 1)
+  assert.equal(store._dirtyWrite.snapshot.threads[0].id, 'legacy-only')
+  assert.equal(
+    (indexedDb.readState()?.threads || []).some((thread) => thread.id === 'legacy-only'),
+    false,
+    'the schema fence must still exclude the legacy-only transcript from canonical IndexedDB',
+  )
+  store.close()
 })

--- a/browser_tests/workflow-chat-identity.spec.ts
+++ b/browser_tests/workflow-chat-identity.spec.ts
@@ -1,31 +1,47 @@
 import { test, expect } from './fixtures/panelTest'
+import { resolveHistoryStoreModuleUrl } from './fixtures/historyStoreModule'
 
 const THREADS_KEY = 'comfyui-mcp.panel.threads'
 const CURRENT_THREAD_KEY = 'comfyui-mcp.panel.currentThreadId'
 const SESSION_KEY = 'comfyui-mcp.panel.sessionId'
+
+async function setWorkflowScope(page: import('@playwright/test').Page) {
+  await page.waitForFunction(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    return typeof app?.ui?.settings?.setSettingValue === 'function'
+  })
+  await page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    const settings = app.ui.settings
+    if (!w.__cmcpOriginalGetSettingValue) {
+      w.__cmcpOriginalGetSettingValue = settings.getSettingValue.bind(settings)
+    }
+    settings.getSettingValue = (id: string) =>
+      id === 'comfyui-mcp.chatScope'
+        ? 'workflow'
+        : w.__cmcpOriginalGetSettingValue(id)
+  })
+  await expect.poll(() => page.evaluate(() => {
+    const w = window as any
+    const app = w.comfyAPI?.app?.app || w.app
+    return app?.ui?.settings?.getSettingValue?.('comfyui-mcp.chatScope')
+  })).toBe('workflow')
+}
 
 test('opening a workflow does not dirty it and first record embeds silently', async ({
   page,
   panel,
   mockBridge
 }) => {
-  await page.route(
-    (url) => /\/(api\/)?settings\/?$/.test(url.pathname),
-    async (route) => {
-      if (route.request().method() !== 'GET') return route.continue()
-      const response = await route.fetch()
-      const settings = await response.json() as Record<string, unknown>
-      settings['comfyui-mcp.sessionFollowsPanel'] = false
-      await route.fulfill({ response, json: settings })
-    }
-  )
-
   await panel.goto()
   await page.waitForFunction(() => {
     const w = window as any
     const app = w.comfyAPI?.app?.app || w.app
     return !!app?.graph && !!app?.extensionManager?.workflow?.activeWorkflow
   })
+  await setWorkflowScope(page)
   const before = await page.evaluate(() => {
     const w = window as any
     const app = w.comfyAPI?.app?.app || w.app
@@ -83,8 +99,9 @@ test('default mode opens pre-upgrade history without re-keying it', async ({
   page,
   panel
 }) => {
-  await panel.goto()
-  await page.evaluate(({ threadsKey, currentThreadKey }) => {
+  // Seed storage before navigation: ComfyUI may eagerly restore the Agent tab
+  // and mount the panel before openSidebar() is called.
+  await page.addInitScript(({ threadsKey, currentThreadKey }) => {
     localStorage.setItem(threadsKey, JSON.stringify([
       {
         id: 'old-current',
@@ -101,6 +118,7 @@ test('default mode opens pre-upgrade history without re-keying it', async ({
     ]))
     sessionStorage.setItem(currentThreadKey, 'old-current')
   }, { threadsKey: THREADS_KEY, currentThreadKey: CURRENT_THREAD_KEY })
+  await panel.goto()
 
   await panel.openSidebar()
   await expect(panel.userBubble('old current thread')).toBeVisible()
@@ -132,8 +150,8 @@ test('settings hydration never adopts a loose session into a workflow thread', a
     const originalGet = settings.getSettingValue.bind(settings)
     w.__cmcpPerWorkflowHydrated = false
     settings.getSettingValue = (id: string) =>
-      id === 'comfyui-mcp.sessionFollowsPanel'
-        ? !w.__cmcpPerWorkflowHydrated
+      id === 'comfyui-mcp.chatScope'
+        ? (w.__cmcpPerWorkflowHydrated ? 'workflow' : 'panel')
         : originalGet(id)
     localStorage.setItem(threadsKey, JSON.stringify([{
       id: 'workflow-before-hydration',
@@ -188,20 +206,10 @@ test('embeds a workflow UUID and blocks a foreign transcript pointer', async ({
   panel,
   mockBridge
 }) => {
-  // Make the legacy per-workflow setting available before the panel mounts and
-  // after reload; the shared fixture intentionally strips real user settings.
-  await page.route(
-    (url) => /\/(api\/)?settings\/?$/.test(url.pathname),
-    async (route) => {
-      if (route.request().method() !== 'GET') return route.continue()
-      const response = await route.fetch()
-      const settings = await response.json() as Record<string, unknown>
-      settings['comfyui-mcp.sessionFollowsPanel'] = false
-      await route.fulfill({ response, json: settings })
-    }
-  )
-
   await panel.goto()
+  // Make the per-workflow setting available before the panel mounts; the
+  // shared fixture intentionally strips real user settings.
+  await setWorkflowScope(page)
   await panel.setBridgeUrl(mockBridge.url)
   await panel.openSidebar()
   await panel.connect()
@@ -227,10 +235,10 @@ test('embeds a workflow UUID and blocks a foreign transcript pointer', async ({
   // do in this architecture: another tab writes it through the store, landing
   // in the shared canonical. (Direct localStorage writes are just this tab's
   // own cache and are legitimately overwritten by the owning panel's flush.)
+  const storeModuleUrl = await resolveHistoryStoreModuleUrl(page)
   const otherTab = await context.newPage()
   await otherTab.goto(page.url())
-  await otherTab.evaluate(async ({ threadsKey, currentThreadKey }) => {
-    const storeModuleUrl = '/extensions/comfyui-agent-panel/js/lib/chat-history-store.js'
+  await otherTab.evaluate(async ({ threadsKey, currentThreadKey, storeModuleUrl }) => {
     const { ChatHistoryStore } = await import(storeModuleUrl)
     const foreignStore = new ChatHistoryStore({ writerId: 'foreign-tab-test' })
     const existing = JSON.parse(localStorage.getItem(threadsKey) || '[]')
@@ -245,14 +253,17 @@ test('embeds a workflow UUID and blocks a foreign transcript pointer', async ({
     ], {})
     await foreignStore.flush()
     await foreignStore.close?.()
-  }, { threadsKey: THREADS_KEY, currentThreadKey: CURRENT_THREAD_KEY })
+  }, { threadsKey: THREADS_KEY, currentThreadKey: CURRENT_THREAD_KEY, storeModuleUrl })
   await otherTab.close()
 
   await page.reload()
+  await setWorkflowScope(page)
   await panel.openSidebar()
   await expect(panel.userBubble('must never restore on this workflow')).toHaveCount(0)
 
   await panel.root.locator('button[title="Chat history"]').click()
+  const currentOnly = panel.root.getByTestId('history-current-workflow')
+  if (await currentOnly.isVisible()) await currentOnly.uncheck()
   const foreign = panel.root.locator('.cmcp-hist-row').filter({ hasText: 'must never restore on this workflow' })
   await expect(foreign).toBeVisible()
   await expect(foreign.locator('.cmcp-hist-open')).toBeDisabled()

--- a/docs/design/chat-history-v2.md
+++ b/docs/design/chat-history-v2.md
@@ -1,0 +1,70 @@
+# Chat History v2
+
+Chat History v2 replaces the legacy `localStorage`-only ring (20 threads, 200
+messages each) with a versioned, workflow-aware history system.
+
+## Conversation scope
+
+Settings → ComfyUI MCP Agent → General → **Chat conversation scope**:
+
+- **Panel** keeps one conversation while canvases change.
+- **Workflow** keeps an independent collection of conversations for every graph.
+- **Ask** chooses between those behaviors whenever the active workflow changes.
+
+The plus button starts a new conversation without deleting older chats. The
+history button opens search, current-workflow filtering, rename, pin, delete,
+export, and merge-import controls.
+
+## Identity
+
+Bridge routing still uses `wf:<path>`/`tmp:<uuid>` because the orchestrator binds
+agents to the current tab. Transcript identity is separate:
+`workflow:<embedded UUID>`. The UUID is stored in
+`workflow.extra.comfyui_mcp.workflow_uuid` on the first per-workflow chat.
+
+Renaming therefore preserves history. Opening a copied graph as another workflow
+detects the repeated UUID and gives the copy a fresh identity. A path→UUID alias
+map provides backward compatibility before the graph is next saved.
+
+## Storage and migration
+
+The canonical browser snapshot is in IndexedDB database
+`comfyui-mcp-panel-history`, schema version 3. A small `localStorage` shadow is
+kept for instant paint and compatibility with older panel builds. On startup the
+panel merges legacy and IndexedDB snapshots by stable record IDs and causal
+revisions, then writes the migrated schema back automatically.
+
+## Continuity and graph versions
+
+Each thread records its provider, model, effort, session ID, active workflow,
+and timestamps. Each user turn points to an FNV-1a graph hash plus node count;
+graphs up to 300 KB also keep the serialized workflow snapshot. The hash is shown
+inside the user bubble and in the history list.
+
+When a provider session ID is absent, stale, or belongs to a different provider,
+the panel creates a fresh session and arms a bounded transcript replay for the
+next message. Only provider-matched session IDs continue through the
+orchestrator's resume path.
+
+Archive export is deliberately portable rather than a raw database dump. It
+contains transcript content, workflow provenance, and safe path→UUID aliases,
+but omits browser-local session IDs, active pointers, causal checkpoints,
+operations, and deletion tombstones. Import rebases the portable records onto
+the local causal clock, fills only missing aliases, and cannot delete or switch
+existing local history. Colliding thread/message IDs are add-only: local content
+and metadata always win. An import that would exceed the 500-thread or
+5,000-entry limit fails atomically instead of evicting local history.
+
+## Limits
+
+IndexedDB keeps up to 500 threads with 5,000 recorded entries per thread. The
+small compatibility shadow remains 20×200. Each thread keeps its 20 newest
+workflow versions; snapshots larger than 300 KB of UTF-8 data fall back to
+hash-only metadata. JSON imports are limited to 25 MB, merge by stable record ID,
+reject unsupported future schemas, and never delete current history. Workflow
+alias and active-pointer maps are causally compacted to 512 entries. If IndexedDB
+is unavailable and the full snapshot no longer fits in the 20×200 shadow, the
+panel warns that overflow remains only in the open tab and retains the complete
+snapshot in memory for retry. Quarantined legacy transcripts, which cannot enter
+the fenced IndexedDB store, are exempt from both shadow caps; a localStorage
+quota failure is reported rather than silently truncating their only copy.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -67,7 +67,10 @@ import DOMPurify from "./vendor/purify.es.js";
 import qrcodegen from "./vendor/qrcode.esm.js";
 import { computeLayout } from "./lib/layout-engine.js";
 import {
+  CHAT_HISTORY_MAX_IMPORT_BYTES,
+  CHAT_HISTORY_SCHEMA,
   ChatHistoryStore,
+  isThreadInScope,
   mergeHistorySnapshots,
   retainBoundedThreads,
   selectRestoreThread,
@@ -75,7 +78,6 @@ import {
   updateMetadataEntry,
 } from "./lib/chat-history-store.js";
 import {
-  isThreadInScope,
   normalizedWorkflowPath,
   shouldForkEmbeddedWorkflowUuid,
   workflowAliasForPath,
@@ -736,7 +738,7 @@ function persistWorkflowAliases() {
   try {
     window.localStorage.setItem(WORKFLOW_UUID_ALIASES_KEY, JSON.stringify(_workflowUuidAliases));
   } catch {
-    // The embedded UUID remains authoritative when localStorage is unavailable.
+    // IndexedDB history still retains the canonical workflowKey.
   }
 }
 
@@ -795,8 +797,9 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
   rememberWorkflowUuidOwner(id, identityObject);
   const aliasMutations = [];
   if (objectUuid && path) {
-    // Rename/Save-As mutates the same live workflow object. Drop stale aliases
-    // so a cold start does not later misclassify the renamed file as a clone.
+    // The same live workflow object moved to a new path (rename/Save-As). Keep
+    // one canonical alias so the next cold start does not see its former path
+    // as evidence that the current file is a clone.
     for (const [knownPath, knownUuid] of Object.entries(_workflowUuidAliases)) {
       if (knownUuid === id && normalizedWorkflowPath(knownPath) !== normalizedWorkflowPath(path)) {
         delete _workflowUuidAliases[knownPath];
@@ -1188,6 +1191,7 @@ const SETTING_FLAG_RUNPOD = "comfyui-mcp.featureFlag.runpod";
 // now operating on. When FALSE, the legacy per-workflow behavior: each workflow
 // keeps its own thread + agent session and switching tabs switches conversations.
 const SETTING_SESSION_FOLLOWS_PANEL = "comfyui-mcp.sessionFollowsPanel";
+const SETTING_CHAT_SCOPE = "comfyui-mcp.chatScope";
 const MOBILE_IOS_TESTFLIGHT_URL = "https://testflight.apple.com/join/ws65s4a2"; // beta-testers external group
 const MOBILE_ANDROID_FIREBASE_URL = "https://appdistribution.firebase.dev/i/27a5cccde72ffb42"; // beta testers group
 const SETTING_EXTERNAL_ORCH = "comfyui-mcp.externalOrchestrator";
@@ -1231,6 +1235,7 @@ const SECRET_SET_AT_PREFIX = "comfyui-mcp.panel.secretSetAt.";
 // (no-ops when the value already matches) so a setSetting→onChange echo can't loop.
 const panelHooks = {
   applyBackend: null, // (id)
+  applyChatScope: null, // ("panel"|"workflow"|"ask")
   applyModel: null, // (id)
   applyEffort: null, // (id|"")
   applyBridgeUrl: null, // (url)
@@ -1363,9 +1368,12 @@ function getSetting(id) {
     return undefined;
   }
 }
-/** Session ownership mode — panel-owned (default) vs legacy per-workflow. */
-function sessionFollowsPanel() {
-  return getSetting(SETTING_SESSION_FOLLOWS_PANEL) !== false;
+/** Conversation ownership. The legacy boolean remains a read-only migration
+ *  source so existing users keep their chosen behavior. */
+function chatScopeMode() {
+  const mode = getSetting(SETTING_CHAT_SCOPE);
+  if (mode === "panel" || mode === "workflow" || mode === "ask") return mode;
+  return getSetting(SETTING_SESSION_FOLLOWS_PANEL) === false ? "workflow" : "panel";
 }
 function setSetting(id, value) {
   try {
@@ -1753,17 +1761,25 @@ function panelSettingsList() {
       },
     },
     {
-      id: SETTING_SESSION_FOLLOWS_PANEL,
-      name: "Conversation follows the panel (not the workflow)",
-      category: cat("General", "Conversation follows the panel"),
+      id: SETTING_CHAT_SCOPE,
+      name: "Chat conversation scope",
+      category: cat("General", "Chat conversation scope"),
       sortOrder: 146,
       tooltip:
-        "ON (default): your chat and the agent's memory persist while you switch, save, rename, or create " +
-        "workflows — the agent is simply told which canvas it now operates on. " +
-        "OFF: the legacy per-workflow mode — every workflow keeps its own separate conversation and agent " +
-        "session, and switching tabs switches chats.",
-      type: "boolean",
-      defaultValue: true,
+        "Panel: one conversation follows every canvas. Workflow: each saved workflow has its own persistent set of chats, " +
+        "identified by an embedded UUID so renames keep history and copies separate. Ask: choose whether to carry the " +
+        "current conversation whenever you switch workflows. All modes survive full ComfyUI/MCP restarts.",
+      type: "combo",
+      options: [
+        { value: "panel", text: "Panel — one chat across workflows" },
+        { value: "workflow", text: "Workflow — separate chat histories" },
+        { value: "ask", text: "Ask whenever the workflow changes" },
+      ],
+      defaultValue: getSetting(SETTING_SESSION_FOLLOWS_PANEL) === false ? "workflow" : "panel",
+      onChange: (v) => {
+        if (suppressSettingOnChange || !settingsArmed) return;
+        panelHooks.applyChatScope?.(v);
+      },
     },
     {
       id: SETTING_AUTOCONNECT,
@@ -8186,6 +8202,9 @@ const PANEL_CSS = `
 .cmcp-iconbtn:disabled { opacity: 0.35; cursor: default; }
 .cmcp-iconbtn.active { color: var(--p-red-400, #f87171); }
 .cmcp-iconbtn .pi { font-size: 0.875rem; }
+.cmcp-workflow-version { margin-top: 0.35rem; font-size: 0.58rem; opacity: 0.62;
+  display: flex; gap: 0.3rem; align-items: center; }
+.cmcp-workflow-version .pi { font-size: 0.58rem; }
 /* ---- sidebar tab badge (these live OUTSIDE .cmcp-root, on the toolbar) ---- */
 /* (.cmcp-tab-logo — the logo-mark tab glyph — is NOT here: it must exist the
    moment registerSidebarTab() paints the toolbar, before the panel ever
@@ -8303,19 +8322,42 @@ const PANEL_CSS = `
 .cmcp-status-btn .pi { color: var(--p-text-muted-color, #a1a1aa); }
 .cmcp-conn-pop { padding: 0.625rem; max-height: none; }
 
-/* History rows: open button + trash, revealed on hover. */
+/* History v2: searchable, workflow-grouped, multi-conversation manager. */
+.cmcp-history-pop { max-height: min(70vh, 34rem); overflow: hidden; padding: 0; }
+.cmcp-hist-tools {
+  position: sticky; top: 0; z-index: 2; display: grid; grid-template-columns: 1fr auto auto;
+  gap: 0.25rem; padding: 0.5rem; background: var(--p-surface-800, #27272a);
+  border-bottom: 1px solid var(--p-content-border-color, #3f3f46);
+}
+.cmcp-hist-search {
+  min-width: 0; border: 1px solid var(--p-form-field-border-color, #52525b);
+  border-radius: var(--p-border-radius-sm, 4px); background: var(--p-form-field-background, #09090b);
+  color: var(--p-form-field-color, #fff); font: inherit; font-size: 0.75rem; padding: 0.35rem 0.45rem;
+}
+.cmcp-hist-filter { grid-column: 1 / -1; display: flex; align-items: center; gap: 0.375rem;
+  color: var(--p-text-muted-color, #a1a1aa); font-size: 0.6875rem; }
+.cmcp-hist-list { max-height: min(58vh, 28rem); overflow-y: auto; padding: 0.25rem; }
+.cmcp-hist-group { padding: 0.35rem 0.5rem 0.2rem; font-size: 0.625rem; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.04em; color: var(--p-text-muted-color, #a1a1aa); }
 .cmcp-hist-row { display: flex; align-items: stretch; gap: 0.125rem; }
+.cmcp-hist-row.active { background: color-mix(in srgb, var(--p-primary-color, #60a5fa) 13%, transparent); border-radius: 4px; }
 .cmcp-hist-row .cmcp-hist-open { flex: 1 1 auto; min-width: 0; }
 .cmcp-hist-row.foreign-workflow { opacity: 0.48; }
 .cmcp-hist-row.foreign-workflow .cmcp-hist-open { cursor: not-allowed; }
-.cmcp-hist-del {
+.cmcp-hist-meta { display: flex; flex-direction: column; min-width: 0; flex: 1; }
+.cmcp-hist-meta .lbl { font-weight: 550; }
+.cmcp-hist-sub { color: var(--p-text-muted-color, #a1a1aa); font-size: 0.625rem;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cmcp-hist-action {
   flex: none; width: 1.75rem; border: none; background: transparent; cursor: pointer;
   color: var(--p-text-muted-color, #a1a1aa); border-radius: var(--p-border-radius-sm, 4px);
   opacity: 0; transition: opacity 0.12s, background 0.12s, color 0.12s;
 }
-.cmcp-hist-row:hover .cmcp-hist-del { opacity: 1; }
-.cmcp-hist-del:hover { background: var(--p-surface-700, #3f3f46); color: var(--p-red-400, #f87171); }
-.cmcp-hist-del .pi { font-size: 0.75rem; }
+.cmcp-hist-row:hover .cmcp-hist-action, .cmcp-hist-action.on { opacity: 1; }
+.cmcp-hist-action:focus-visible { opacity: 1; }
+.cmcp-hist-action:hover { background: var(--p-surface-700, #3f3f46); color: var(--p-text-color, #fff); }
+.cmcp-hist-action.danger:hover { color: var(--p-red-400, #f87171); }
+.cmcp-hist-action .pi { font-size: 0.75rem; }
 .cmcp-hist-footer {
   margin-top: 0.25rem; padding: 0.5rem 0.375rem 0.125rem;
   border-top: 1px solid var(--p-content-border-color, #3f3f46);
@@ -8770,6 +8812,7 @@ function buildPanel() {
     b.type = "button";
     b.className = "cmcp-iconbtn";
     b.title = titleText;
+    b.setAttribute("aria-label", titleText);
     const i = document.createElement("i");
     i.className = `pi ${icon}`;
     b.appendChild(i);
@@ -8797,7 +8840,7 @@ function buildPanel() {
 
   header.style.position = "relative";
   const histPop = document.createElement("div");
-  histPop.className = "cmcp-popover cmcp-popover--down";
+  histPop.className = "cmcp-popover cmcp-popover--down cmcp-history-pop";
   histPop.hidden = true;
   header.append(logo, actions, status, histPop);
   root.appendChild(header);
@@ -10536,20 +10579,31 @@ function buildPanel() {
 
   // ---- feed renderers + thread persistence ----
   // paint* draws DOM only; append* paints AND records into the current
-  // thread. IndexedDB is canonical; localStorage remains a small synchronous
-  // startup shadow and migration source for pre-v2 panel builds.
+  // thread. IndexedDB is canonical; localStorage is a small startup/migration
+  // shadow for compatibility with older panel builds.
   const THREADS_KEY = "comfyui-mcp.panel.threads";
   // Intentional canonical durable caps. The synchronous localStorage startup
   // shadow stays much smaller (20 threads / 200 messages) in ChatHistoryStore.
   const MAX_THREADS = 500;
+  const MAX_WORKFLOW_VERSIONS = 20;
   const MAX_THREAD_MSGS = 5000;
+  let historyPersistenceWarningCode = null;
   const historyStore = new ChatHistoryStore({
     threadsKey: THREADS_KEY,
     maxThreads: MAX_THREADS,
     maxMessages: MAX_THREAD_MSGS,
-    onPersistenceError: () => {
+    onPersistenceError: (failure) => {
+      if (failure?.code === historyPersistenceWarningCode) return;
+      historyPersistenceWarningCode = failure?.code || "history-persistence-unavailable";
       appendSystem(
-        "Chat history could not be saved. Keep this tab open, free browser storage, then send or edit once to retry.",
+        failure?.code === "history-canonical-unavailable-shadow-truncated"
+          ? "IndexedDB is unavailable. Only the newest 20 chats / 200 entries fit in the " +
+            "localStorage fallback; older history is still in this open tab but is not durably saved. " +
+            "Keep this tab open, restore browser storage, then send or edit once to retry."
+          : failure?.code === "history-legacy-shadow-unavailable"
+            ? "Some legacy chat history has no IndexedDB copy and could not be saved to localStorage. " +
+              "Keep this tab open, free browser storage, then send or edit once to retry."
+            : "Chat history could not be saved. Keep this tab open, free browser storage, then send or edit once to retry.",
       );
     },
   });
@@ -10557,6 +10611,9 @@ function buildPanel() {
   let threads = localHistory.threads;
   let historyMeta = localHistory.meta;
   let thread = null; // created lazily on first recorded message
+  // In "ask" mode this is chosen at each workflow switch. The initial canvas
+  // behaves as per-workflow until there is actually a switch to ask about.
+  let askModeFollowsPanel = false;
 
   function nextHistoryRevision() {
     return historyStore.nextRevision(Math.max(Date.now(), Number(historyMeta?.updatedAt) + 1 || 0));
@@ -10579,12 +10636,13 @@ function buildPanel() {
 
   applyWorkflowAliasesFromHistory();
 
-  function currentTranscriptScopeKey({ embed = false } = {}) {
-    return sessionFollowsPanel() ? workflowTabId() : workflowStorageKey({ embed });
+  function historyScopeFollowsPanel() {
+    const mode = chatScopeMode();
+    return mode === "panel" || (mode === "ask" && askModeFollowsPanel);
   }
 
-  function currentHistorySelectionKey({ embed = false } = {}) {
-    return sessionFollowsPanel() ? "panel:global" : workflowStorageKey({ embed });
+  function currentHistoryScopeKey({ embed = false } = {}) {
+    return historyScopeFollowsPanel() ? "panel:global" : workflowStorageKey({ embed });
   }
 
   function setActiveThread(scopeKey, threadId, updatedAt = nextHistoryRevision()) {
@@ -10674,10 +10732,10 @@ function buildPanel() {
       thread = replacement;
       ssSet(CURRENT_THREAD_KEY, replacement.id);
       ssSet(SESSION_KEY, replacement.sessionId || null);
-      setActiveThread(currentHistorySelectionKey(), replacement.id);
+      setActiveThread(currentHistoryScopeKey(), replacement.id);
       paintThread(replacement);
     } else {
-      if (scopeKey) setActiveThread(currentHistorySelectionKey(), null);
+      if (scopeKey) setActiveThread(currentHistoryScopeKey(), null);
       // A remote delete/reset removed the conversation this tab's live agent
       // belonged to. Clear backend memory as well as the visible transcript so
       // the next message cannot continue a history the user just deleted.
@@ -10685,6 +10743,19 @@ function buildPanel() {
     }
     persistThreads();
     return replacement;
+  }
+
+  function rebindCurrentThreadRecord(refreshed) {
+    if (!refreshed) return false;
+    thread = refreshed;
+    // Snapshot merges clone every message. Live A2UI handles must point at the
+    // records now owned by `threads`, not detached pre-merge objects.
+    const byId = new Map((thread.msgs || []).map((message) => [message.id, message]));
+    for (const entry of liveA2uiCards.values()) {
+      const live = byId.get(entry.rec?.id);
+      if (live) entry.rec = live;
+    }
+    return true;
   }
 
   const unsubscribeHistorySync = historyStore.subscribe((incoming) => {
@@ -10697,69 +10768,132 @@ function buildPanel() {
     threads = capHistoryThreads(merged.threads, currentThreadId);
     if (currentThreadId) {
       const refreshed = threads.find((candidate) => candidate.id === currentThreadId);
-      const panelOwned = sessionFollowsPanel();
-      if (refreshed && (panelOwned || isThreadInScope(refreshed, currentTranscriptScopeKey()))) {
-        thread = refreshed;
-        // The merge cloned every message — rebind live A2UI cards to the NEW
-        // records by id, or their next action mutates a detached object that
-        // persistThreads no longer writes (codex finding).
-        const byId = new Map((thread.msgs || []).map((m) => [m.id, m]));
-        for (const entry of liveA2uiCards.values()) {
-          const live = byId.get(entry.rec?.id);
-          if (live) entry.rec = live;
-        }
+      const followsPanel = historyScopeFollowsPanel();
+      if (refreshed && (followsPanel || isThreadInScope(refreshed, currentHistoryScopeKey()))) {
+        rebindCurrentThreadRecord(refreshed);
       } else {
-        const scopeKey = panelOwned ? null : currentTranscriptScopeKey();
-        detachInvalidCurrentThread({ scopeKey, rebind: !panelOwned });
+        const scopeKey = followsPanel ? null : currentHistoryScopeKey();
+        detachInvalidCurrentThread({ scopeKey, rebind: !followsPanel });
       }
     }
     if (!histPop.hidden) renderHistory();
   });
 
-  // Find the (single) thread bound to an exact transcript scope. Old path-keyed
-  // records are adopted only when their path exactly matches the open workflow;
-  // paths never authorize loading after that one-way migration.
+  // Multiple conversations may belong to one workflow. The explicitly active
+  // one wins; otherwise use the most recently updated thread. Legacy path-keyed
+  // records are adopted into the UUID key when that workflow is next opened.
+  function threadsForWorkflow(wfid) {
+    return threads
+      .filter((candidate) => candidate.workflowKey === wfid)
+      .sort((a, b) => Number(b.updatedAt || b.ts || 0) - Number(a.updatedAt || a.ts || 0));
+  }
+
   function threadForWorkflow(wfid) {
-    if (wfid.startsWith("workflow:") && !threads.some((candidate) => candidate.workflowKey === wfid)) {
+    let candidates = threadsForWorkflow(wfid);
+    if (!candidates.length && wfid.startsWith("workflow:")) {
       const path = savedWorkflowPath();
       const legacyKey = path ? `wf:${path}` : null;
       const legacy = legacyKey ? threads.filter((candidate) => candidate.workflowKey === legacyKey) : [];
       if (legacy.length) {
         for (const candidate of legacy) historyStore.reviseThread(candidate, { workflowKey: wfid });
+        candidates = threadsForWorkflow(wfid);
         persistThreads();
       }
     }
-    return selectThreadForScope(threads, historyMeta, wfid);
+    return selectThreadForScope(candidates, historyMeta, wfid);
+  }
+
+  function workflowVersionSnapshot() {
+    try {
+      const workflow = app?.graph?.serialize?.();
+      if (!workflow || typeof workflow !== "object") return null;
+      const json = JSON.stringify(workflow);
+      let hash = 0x811c9dc5;
+      for (let i = 0; i < json.length; i++) {
+        hash ^= json.charCodeAt(i);
+        hash = Math.imul(hash, 0x01000193);
+      }
+      const version = {
+        hash: (hash >>> 0).toString(16).padStart(8, "0"),
+        capturedAt: Date.now(),
+        nodeCount: Array.isArray(workflow.nodes) ? workflow.nodes.length : 0,
+        workflowKey: workflowStorageKey(),
+        title: getWorkflowTitle(),
+        path: savedWorkflowPath() || undefined,
+      };
+      // Keep restorable snapshots when reasonably small. Large graphs still get
+      // an exact hash + node count without multiplying storage uncontrollably.
+      if (new TextEncoder().encode(json).byteLength <= 300_000) version.snapshot = workflow;
+      return version;
+    } catch {
+      return null;
+    }
   }
 
   function record(entry) {
-    const perWorkflow = !sessionFollowsPanel();
-    const scopeKey = perWorkflow ? workflowStorageKey({ embed: true }) : workflowTabId();
+    const followsPanel = historyScopeFollowsPanel();
+    // Panel-owned continuity uses a global active-thread pointer, but the thread
+    // keeps the stable workflow UUID as provenance for archive grouping. Panel
+    // mode does not embed it into the graph; workflow mode does on first record.
+    // Strict UUID scope checks are intentionally exclusive to per-workflow mode.
+    const desiredWorkflowKey = workflowStorageKey({ embed: !followsPanel });
     // Settings can hydrate after a greeting was painted. Never append a real
     // workflow-scoped message to a thread carrying another scope.
-    if (thread && perWorkflow && !isThreadInScope(thread, scopeKey)) {
-      detachInvalidCurrentThread({ scopeKey, rebind: true });
+    if (thread && !followsPanel && !isThreadInScope(thread, desiredWorkflowKey)) {
+      detachInvalidCurrentThread({ scopeKey: desiredWorkflowKey, rebind: true });
     }
     if (!thread) {
       const now = Date.now();
+      const workflowKey = desiredWorkflowKey;
       thread = {
         id: crypto.randomUUID(),
-        schemaVersion: 2,
+        schemaVersion: CHAT_HISTORY_SCHEMA,
         createdAt: now,
         updatedAt: now,
         ts: now,
         msgs: [],
-        workflowKey: scopeKey,
+        workflowKey,
+        workflowTitle: getWorkflowTitle(),
+        provider: connectedBackend || selectedBackend,
+        model: prefs.model || orchestratorCurrentModel || pickDefaultModel(modelCatalog),
+        effort: prefs.effort,
+        workflowVersions: {},
       };
-      historyStore.reviseThread(thread, { workflowKey: scopeKey }, now);
+      historyStore.reviseThread(thread, {
+        workflowKey,
+        workflowTitle: getWorkflowTitle(),
+        provider: connectedBackend || selectedBackend,
+        model: prefs.model || orchestratorCurrentModel || pickDefaultModel(modelCatalog),
+        effort: prefs.effort || null,
+      }, now);
       // A workflow-scoped conversation never adopts a loose tab session. Its
       // session must arrive through a thread selected for this exact scope.
       const sid = ssGet(SESSION_KEY);
-      if (sid && !perWorkflow) historyStore.reviseThread(thread, { sessionId: sid }, now);
+      if (sid && followsPanel) historyStore.reviseThread(thread, { sessionId: sid }, now);
       threads.push(thread);
       if (threads.length > MAX_THREADS) threads = capHistoryThreads(threads, thread.id);
       ssSet(CURRENT_THREAD_KEY, thread.id);
-      setActiveThread(currentHistorySelectionKey(), thread.id);
+      setActiveThread(followsPanel ? "panel:global" : workflowKey, thread.id);
+    }
+    if (entry.role === "user") {
+      const version = workflowVersionSnapshot();
+      if (version) {
+        thread.workflowVersions = thread.workflowVersions || {};
+        thread.workflowVersions[version.hash] = version;
+        thread.workflowVersions = Object.fromEntries(
+          Object.entries(thread.workflowVersions)
+            .sort(([, left], [, right]) =>
+              Number(right?.capturedAt || 0) - Number(left?.capturedAt || 0))
+            .slice(0, MAX_WORKFLOW_VERSIONS),
+        );
+        entry.workflowVersion = version.hash;
+      }
+      if (!thread.title) {
+        historyStore.reviseThread(
+          thread,
+          { title: String(entry.text || "New chat").trim().slice(0, 80) || "New chat" },
+        );
+      }
     }
     const now = Date.now();
     // Mutate in place — NEVER clone: callers (appendA2UICard) keep the record
@@ -10782,16 +10916,31 @@ function buildPanel() {
       thread.msgs.splice(0, thread.msgs.length - MAX_THREAD_MSGS);
     }
     thread.updatedAt = now;
-    thread.ts = now;
+    thread.ts = thread.updatedAt;
+    historyStore.reviseThread(thread, {
+      workflowTitle: getWorkflowTitle(),
+      provider: connectedBackend || selectedBackend,
+      model: prefs.model || orchestratorCurrentModel || pickDefaultModel(modelCatalog),
+      effort: prefs.effort || null,
+    }, now);
     persistThreads();
     return entry;
   }
 
   /** Bind the agent's current session id to the open thread (for reload/resume). */
   function bindSession(sessionId) {
+    const previousSessionId = thread?.sessionId || null;
+    // A provider may reject/expire an otherwise matching saved session. Hydrate
+    // the fresh one once instead of silently dropping the visible transcript.
+    if (!sessionId && previousSessionId) {
+      const replay = buildReplayTranscript();
+      if (replay) client?.armContext?.(replay);
+    }
     ssSet(SESSION_KEY, sessionId);
     if (thread) {
-      historyStore.reviseThread(thread, { sessionId: sessionId || null });
+      const values = { sessionId: sessionId || null };
+      if (sessionId) values.provider = connectedBackend || selectedBackend;
+      historyStore.reviseThread(thread, values);
       persistThreads();
     }
   }
@@ -10851,6 +11000,21 @@ function buildPanel() {
     const b = document.createElement("div");
     b.className = "cmcp-bubble user";
     renderUserText(b, text, opts.attachments);
+    if (opts.workflowVersion) {
+      const version = thread?.workflowVersions?.[opts.workflowVersion];
+      const badge = document.createElement("span");
+      badge.className = "cmcp-workflow-version";
+      badge.title = version?.path || version?.title || "Workflow snapshot";
+      badge.innerHTML = '<i class="pi pi-sitemap"></i>';
+      badge.appendChild(
+        document.createTextNode(
+          version
+            ? `${version.nodeCount} nodes · ${version.hash}`
+            : `workflow · ${opts.workflowVersion}`,
+        ),
+      );
+      b.appendChild(badge);
+    }
     if (opts.mid) b.dataset.mid = opts.mid;
     // Hover edit/rollback button — only on live messages (those with a mid).
     // Absolute-positioned to the LEFT of the bubble so it never causes reflow.
@@ -11307,18 +11471,18 @@ function buildPanel() {
     // this message forks the conversation right before it — stored directly (not as
     // an index, which a bounded-ring shift() would invalidate).
     const rewindAnchor = turnAnchors.length > 0 ? turnAnchors[turnAnchors.length - 1] : null;
-    const painted = paintUser(text, { ...opts, rewindAnchor });
     // Tag the record with its mid so deleteMsg can remove the EXACT message even
     // when several are queued (popping the trailing one would hit the wrong one).
     // Persist any pasted-text attachments ({id, content[, truncated]}) so reload
     // can re-render the bubble chips. `text` stays raw (tokens) for agent/rollback.
     const atts = Array.isArray(opts.attachments) ? opts.attachments : null;
-    record({
+    const recorded = record({
       role: "user",
       text,
       ...(opts.mid ? { mid: opts.mid } : {}),
       ...(atts && atts.length ? { attachments: atts } : {}),
     });
+    const painted = paintUser(text, { ...opts, rewindAnchor, workflowVersion: recorded.workflowVersion });
     return painted;
   }
 
@@ -11745,12 +11909,12 @@ function buildPanel() {
     if (agentWorking) showThinking();
   }
 
-  function newChat() {
+  function newChat({ notifyBackend = true } = {}) {
     // Abandoning the current conversation ends any in-flight turn from THIS
     // tab's point of view — clear agentWorking first so resetFeed() below won't
     // rebuild a working indicator onto the fresh, empty chat.
     endTurnLocally();
-    setActiveThread(currentHistorySelectionKey(), null);
+    setActiveThread(currentHistoryScopeKey(), null);
     thread = null;
     turnAnchors = []; // fresh conversation → no rewind anchors
     ssSet(CURRENT_THREAD_KEY, null);
@@ -11760,18 +11924,18 @@ function buildPanel() {
     resetFeed();
     renderTodo([]); // fresh chat → empty plan tray
     setContextPct(0);
-    persistThreads();
     ctxLabel.textContent = "—";
+    persistThreads();
     // Tell the orchestrator to forget this tab's session so the NEXT message
     // starts a genuinely fresh agent (no memory of the prior conversation).
-    client?.sendFrame?.({ type: "new_session" });
+    if (notifyBackend) client?.sendFrame?.({ type: "new_session" });
   }
 
   function paintThread(t) {
     thread = t;
     resetFeed();
     for (const m of t.msgs) {
-      if (m.role === "user") paintUser(m.text, { attachments: m.attachments });
+      if (m.role === "user") paintUser(m.text, { attachments: m.attachments, workflowVersion: m.workflowVersion });
       else if (m.role === "agent") paintAgent(m.text);
       else if (m.role === "card") {
         if (m.kind === "a2ui") paintA2UIRecord(m);
@@ -11784,21 +11948,54 @@ function buildPanel() {
     renderTodo(t.todos || [], { persist: false });
   }
 
+  function resumableSessionId(t) {
+    const sessionId = typeof t?.sessionId === "string" && t.sessionId ? t.sessionId : null;
+    if (!sessionId) return null;
+    const activeProvider = connectedBackend || selectedBackend;
+    return !t.provider || !activeProvider || t.provider === activeProvider ? sessionId : null;
+  }
+
+  function armVisibleTranscriptReplay() {
+    const replay = buildReplayTranscript();
+    if (replay) client?.armContext?.(replay);
+  }
+
   function loadThread(t) {
-    if (!sessionFollowsPanel() && !isThreadInScope(t, workflowStorageKey())) {
-      detachInvalidCurrentThread({ scopeKey: workflowStorageKey(), rebind: true });
-      appendSystem("Blocked a chat from another workflow. Open its owning workflow before resuming it.");
+    const followsPanel = historyScopeFollowsPanel();
+    const scopeKey = currentHistoryScopeKey();
+    if (!followsPanel && !isThreadInScope(t, scopeKey)) {
+      detachInvalidCurrentThread({ scopeKey, rebind: true });
+      appendSystem(
+        `Blocked a chat from another workflow. Open "${t?.workflowTitle || "its owning workflow"}" before resuming it.`,
+      );
       return false;
     }
+    // An archive switch abandons any in-flight turn in the previously visible
+    // conversation. Late frames must not repaint or append into the selected one.
+    endTurnLocally();
+    const sessionId = resumableSessionId(t);
+    const foreignSession = Boolean(t.sessionId && !sessionId);
+    if (foreignSession) {
+      // Session ids are provider-local. Keep the transcript, but never feed (for
+      // example) a Claude session id to Codex; the fresh provider is hydrated
+      // with a bounded visible-transcript replay below.
+      historyStore.reviseThread(t, { sessionId: null });
+    }
     ssSet(CURRENT_THREAD_KEY, t.id);
-    setActiveThread(currentHistorySelectionKey(), t.id);
+    setActiveThread(followsPanel ? "panel:global" : (t.workflowKey || scopeKey), t.id);
     persistThreads();
     paintThread(t);
     // Resume this conversation's agent session (or start fresh if it has none),
     // so typing continues THIS chat rather than whatever was last active.
-    ssSet(SESSION_KEY, t.sessionId || null);
-    if (t.sessionId) client?.sendFrame?.({ type: "resume_session", session_id: t.sessionId });
-    else client?.sendFrame?.({ type: "new_session" });
+    ssSet(SESSION_KEY, sessionId);
+    if (sessionId) client?.sendFrame?.({ type: "resume_session", session_id: sessionId });
+    else {
+      client?.sendFrame?.({ type: "new_session" });
+      // Provider sessions can expire or be intentionally removed. A new backend
+      // session receives a compact replay once, so continuing an archived chat
+      // still has useful memory instead of only repainting bubbles locally.
+      armVisibleTranscriptReplay();
+    }
     return true;
   }
 
@@ -11825,6 +12022,16 @@ function buildPanel() {
     const wfkey = wf ? (wf.key || wf.id || "unsaved") : null;
     if (wfid === currentWorkflowId) return; // case 1: no change
 
+    const initial = currentWorkflowId == null;
+    if (!initial && chatScopeMode() === "ask") {
+      const name = wf?.filename || wfkey || wfid;
+      askModeFollowsPanel = window.confirm(
+        `Continue the current Agent Panel conversation on "${name}"?\n\n` +
+          "OK: carry this chat to the new canvas.\nCancel: open this workflow's separate chat history.",
+      );
+    }
+    const followsPanel = historyScopeFollowsPanel();
+
     // PANEL-OWNED SESSION (default): the conversation is the unit of continuity
     // and the workflow is just the canvas target — switching, saving, renaming,
     // or creating workflows must never swap or reset the chat (field report:
@@ -11835,12 +12042,14 @@ function buildPanel() {
     // resume_session frame (manager.reset would respawn the agent and wipe
     // in-memory backends like Ollama). The agent learns which canvas it now
     // drives via a one-shot context on the next message.
-    if (sessionFollowsPanel()) {
-      const initial = currentWorkflowId == null;
+    if (followsPanel) {
       // tmp→wf adopt bookkeeping (a save gave the unsaved workflow a real id).
       if (wfid.startsWith("wf:") && wf) _tempWorkflowInstanceIds.delete(wf);
       if (thread) {
-        historyStore.reviseThread(thread, { workflowKey: wfid }); // archive provenance
+        historyStore.reviseThread(thread, {
+          workflowKey: workflowStorageKey(),
+          workflowTitle: getWorkflowTitle(),
+        }); // archive provenance
         setActiveThread("panel:global", thread.id);
         persistThreads();
       }
@@ -11902,6 +12111,7 @@ function buildPanel() {
       wfid.startsWith("wf:");
     if (renaming) {
       const t = threadForWorkflow(historyKey);
+      if (t) persistThreads(); // alias + embedded UUID keep the history identity stable
       currentWorkflowId = wfid;
       currentWorkflowKey = wfkey;
       currentWorkflowRef = wf;
@@ -11944,41 +12154,145 @@ function buildPanel() {
 
   function renderHistory() {
     histPop.textContent = "";
-    const list = [...threads].reverse();
-    if (!list.length) {
-      const none = document.createElement("div");
-      none.className = "cmcp-sys";
-      none.style.padding = "0.375rem";
-      none.textContent = "No past chats yet.";
-      histPop.appendChild(none);
+    const tools = document.createElement("div");
+    tools.className = "cmcp-hist-tools";
+    const search = document.createElement("input");
+    search.type = "search";
+    search.className = "cmcp-hist-search";
+    search.placeholder = "Search chats…";
+    search.setAttribute("aria-label", "Search chat history");
+    search.dataset.testid = "history-search";
+    const exportBtn = iconBtn("pi-download", "Export all chat history");
+    exportBtn.dataset.testid = "history-export";
+    const importBtn = iconBtn("pi-upload", "Import chat history (merge)");
+    importBtn.dataset.testid = "history-import";
+    const currentOnlyLabel = document.createElement("label");
+    currentOnlyLabel.className = "cmcp-hist-filter";
+    const currentOnly = document.createElement("input");
+    currentOnly.type = "checkbox";
+    currentOnly.checked = !historyScopeFollowsPanel();
+    currentOnly.dataset.testid = "history-current-workflow";
+    currentOnlyLabel.append(currentOnly, document.createTextNode("Current workflow only"));
+    tools.append(search, exportBtn, importBtn, currentOnlyLabel);
+
+    const listEl = document.createElement("div");
+    listEl.className = "cmcp-hist-list";
+    histPop.append(tools, listEl);
+
+    function friendlyWorkflowName(t) {
+      if (t.workflowKey === "panel:global") return "Panel-wide conversations";
+      return t.workflowTitle || t.workflowKey?.replace(/^workflow:|^wf:/, "") || "Unknown workflow";
     }
-    for (const t of list) {
+
+    function rowAction(icon, titleText, onClick, extraClass = "") {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = `cmcp-hist-action ${extraClass}`.trim();
+      button.title = titleText;
+      button.setAttribute("aria-label", titleText);
+      const glyph = document.createElement("i");
+      glyph.className = `pi ${icon}`;
+      button.appendChild(glyph);
+      button.addEventListener("click", (ev) => {
+        ev.stopPropagation();
+        onClick();
+      });
+      return button;
+    }
+
+    function paintList() {
+      listEl.textContent = "";
+      const q = search.value.trim().toLocaleLowerCase();
+      // Panel-owned threads keep workflow provenance instead of the global
+      // active-pointer key. Accept both the durable workflow UUID and the
+      // current bridge-tab id so the filter works before and after first save.
+      const currentWorkflowKeys = new Set([workflowStorageKey(), workflowTabId()]);
+      const visible = threads
+        .filter((candidate) =>
+          !currentOnly.checked || currentWorkflowKeys.has(candidate.workflowKey))
+        .filter((candidate) => {
+          if (!q) return true;
+          const haystack = [
+            candidate.title,
+            candidate.workflowTitle,
+            candidate.provider,
+            candidate.model,
+            ...(candidate.msgs || []).map((m) => m.text),
+          ].filter(Boolean).join("\n").toLocaleLowerCase();
+          return haystack.includes(q);
+        })
+        .sort((a, b) => Number(b.pinned) - Number(a.pinned) || Number(b.updatedAt || b.ts) - Number(a.updatedAt || a.ts));
+      if (!visible.length) {
+        const none = document.createElement("div");
+        none.className = "cmcp-sys";
+        none.style.padding = "0.75rem";
+        none.textContent = q ? "No chats match this search." : "No past chats in this scope yet.";
+        listEl.appendChild(none);
+        return;
+      }
+      const groups = new Map();
+      for (const candidate of visible) {
+        // Titles are labels, not identities: two distinct workflow UUIDs may
+        // legitimately share the same filename/title and must stay separate.
+        const groupKey = candidate.workflowKey || "panel:global";
+        if (!groups.has(groupKey)) {
+          groups.set(groupKey, {
+            label: friendlyWorkflowName(candidate),
+            threads: [],
+          });
+        }
+        groups.get(groupKey).threads.push(candidate);
+      }
+      for (const { label, threads: groupThreads } of groups.values()) {
+        const heading = document.createElement("div");
+        heading.className = "cmcp-hist-group";
+        heading.textContent = label;
+        listEl.appendChild(heading);
+        for (const t of groupThreads) paintHistoryRow(t, listEl);
+      }
+    }
+
+    function paintHistoryRow(t, parent) {
       const row = document.createElement("div");
       row.className = "cmcp-hist-row";
+      if (thread?.id === t.id) row.classList.add("active");
+      row.dataset.threadId = t.id;
 
       const item = document.createElement("button");
       item.type = "button";
       item.className = "cmcp-popover-item cmcp-hist-open";
       const i = document.createElement("i");
-      i.className = "pi pi-comment";
+      i.className = `pi ${t.pinned ? "pi-bookmark-fill" : "pi-comment"}`;
+      const meta = document.createElement("span");
+      meta.className = "cmcp-hist-meta";
       const lbl = document.createElement("span");
       lbl.className = "lbl";
       const firstUser = t.msgs.find((m) => m.role === "user");
-      lbl.textContent = (firstUser?.text ?? "(no messages)").slice(0, 48);
+      lbl.textContent = (t.title || firstUser?.text || "(no messages)").slice(0, 80);
+      const sub = document.createElement("span");
+      sub.className = "cmcp-hist-sub";
+      const latestVersion = Object.values(t.workflowVersions || {}).sort(
+        (a, b) => Number(b.capturedAt || 0) - Number(a.capturedAt || 0),
+      )[0];
+      sub.textContent = [t.provider, t.model, latestVersion ? `${latestVersion.nodeCount} nodes · ${latestVersion.hash}` : null]
+        .filter(Boolean)
+        .join(" · ");
+      meta.append(lbl, sub);
       const when = document.createElement("small");
-      when.textContent = new Date(t.ts).toLocaleDateString(undefined, {
+      when.textContent = new Date(t.updatedAt || t.ts).toLocaleDateString(undefined, {
         month: "short",
         day: "numeric",
       });
-      item.append(i, lbl, when);
-      const foreignWorkflow = !sessionFollowsPanel() && !isThreadInScope(t, currentTranscriptScopeKey());
+      item.append(i, meta, when);
+      const foreignWorkflow = !historyScopeFollowsPanel() && !isThreadInScope(t, currentHistoryScopeKey());
       // legacyShadow threads are read-only in EVERY mode: fenced out of the
       // canonical, opening one for editing would build a conversation that can
       // never become durable (codex finding). View it; don't resume it.
       const legacyReadonly = t.legacyShadow === true;
       if (foreignWorkflow) {
         item.disabled = true;
-        item.title = "Open this chat's workflow before resuming it";
+        item.title = `Open ${friendlyWorkflowName(t)} before resuming this chat`;
+        item.setAttribute("aria-label", `${lbl.textContent} — open that workflow before resuming`);
         row.classList.add("foreign-workflow");
       } else if (legacyReadonly) {
         item.disabled = true;
@@ -11991,15 +12305,20 @@ function buildPanel() {
         loadThread(t);
       });
 
-      const del = document.createElement("button");
-      del.type = "button";
-      del.className = "cmcp-hist-del";
-      del.title = "Delete this chat";
-      const di = document.createElement("i");
-      di.className = "pi pi-trash";
-      del.appendChild(di);
-      del.addEventListener("click", (ev) => {
-        ev.stopPropagation();
+      const pin = rowAction(t.pinned ? "pi-bookmark-fill" : "pi-bookmark", t.pinned ? "Unpin chat" : "Pin chat", () => {
+        historyStore.reviseThread(t, { pinned: !t.pinned });
+        persistThreads();
+        paintList();
+      }, t.pinned ? "on" : "");
+      const rename = rowAction("pi-pencil", "Rename chat", () => {
+        const next = window.prompt("Chat title", t.title || firstUser?.text || "New chat");
+        if (next == null) return;
+        historyStore.reviseThread(t, { title: next.trim().slice(0, 160) || null });
+        persistThreads();
+        paintList();
+      });
+      const del = rowAction("pi-trash", "Delete this chat", () => {
+        if (!window.confirm(`Delete chat "${t.title || firstUser?.text || "New chat"}"?`)) return;
         const now = nextHistoryRevision();
         historyMeta.deletedThreads = historyMeta.deletedThreads || {};
         historyMeta.deletedThreads[t.id] = {
@@ -12016,12 +12335,63 @@ function buildPanel() {
         persistThreads();
         // Deleting the open chat clears the feed and starts fresh.
         if (thread && thread.id === t.id) newChat();
-        renderHistory();
-      });
+        paintList();
+      }, "danger");
 
-      row.append(item, del);
-      histPop.appendChild(row);
+      row.append(item, pin, rename, del);
+      parent.appendChild(row);
     }
+
+    search.addEventListener("input", paintList);
+    currentOnly.addEventListener("change", paintList);
+    exportBtn.addEventListener("click", () => {
+      const payload = historyStore.exportPayload(threads, historyMeta);
+      const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = `comfyui-agent-panel-history-${new Date().toISOString().slice(0, 10)}.json`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 1000);
+    });
+    importBtn.addEventListener("click", () => {
+      const picker = document.createElement("input");
+      picker.type = "file";
+      picker.accept = "application/json,.json";
+      picker.addEventListener("change", async () => {
+        const file = picker.files?.[0];
+        if (!file) return;
+        try {
+          if (file.size > CHAT_HISTORY_MAX_IMPORT_BYTES) {
+            throw new Error("Chat history import exceeds the 25 MB limit");
+          }
+          const currentThreadId = thread?.id;
+          const imported = historyStore.importPayload(await file.text(), threads, historyMeta);
+          threads = capHistoryThreads(imported.threads, currentThreadId);
+          historyMeta = imported.meta;
+          applyWorkflowAliasesFromHistory();
+          if (currentThreadId) {
+            rebindCurrentThreadRecord(
+              threads.find((candidate) => candidate.id === currentThreadId),
+            );
+          }
+          persistThreads();
+          paintList();
+          appendSystem(
+            `Merged ${imported.importedCount || 0} imported chat(s); existing history was preserved.` +
+            (imported.skippedAliasCount
+              ? ` ${imported.skippedAliasCount} extra workflow alias(es) were skipped at the storage limit.`
+              : ""),
+          );
+        } catch (error) {
+          appendSystem(`History import failed: ${error?.message || error}`);
+        }
+      }, { once: true });
+      picker.click();
+    });
+    paintList();
 
     const footer = document.createElement("div");
     footer.className = "cmcp-hist-footer";
@@ -12053,7 +12423,10 @@ function buildPanel() {
         clear.disabled = false;
         clearLabel.textContent = "Clear all history";
         appendSystem(
-          "Chat history could not be cleared from IndexedDB. Close other ComfyUI tabs, then try again.",
+          result?.code === "history-clear-canonical-unavailable"
+            ? "Chat history could not be cleared because IndexedDB is unavailable or blocked. " +
+              "Close other ComfyUI tabs and retry; in permanent private-storage mode, clear this site's browser data."
+            : "Chat history could not be cleared. Keep this tab open and try again.",
         );
         return;
       }
@@ -13916,8 +14289,8 @@ function buildPanel() {
     const CAP = 8000;
     if (body.length > CAP) body = "…(earlier messages trimmed)…\n\n" + body.slice(body.length - CAP);
     return (
-      "[Conversation so far — continued from a different AI provider. Context only: the " +
-      "previous session's memory, thinking, and tool history did NOT carry over. Pick it up:]\n\n" +
+      "[Conversation so far — continued in a fresh AI session. Context only: the " +
+      "previous session's private memory, thinking, and tool history did NOT carry over. Pick it up:]\n\n" +
       body
     );
   }
@@ -15652,8 +16025,8 @@ function buildPanel() {
     }
 
     await settingsHydrated;
-    const panelOwned = sessionFollowsPanel();
-    const scopeKey = panelOwned ? "panel:global" : workflowStorageKey();
+    const panelOwned = historyScopeFollowsPanel();
+    const scopeKey = currentHistoryScopeKey();
     const durableActive = selectRestoreThread(threads, historyMeta, {
       panelOwned,
       scopeKey,
@@ -15673,16 +16046,22 @@ function buildPanel() {
 
     // For the exact conversation already owned by this tab, sessionStorage is
     // authoritative even when empty. The stored id is only a full-restart fallback.
-    const boundSessionId = durableActive.id === reloadThreadId
+    const storedSessionId = durableActive.id === reloadThreadId
       ? reloadSessionId
       : (durableActive.sessionId || null);
-    if (durableActive.id === reloadThreadId) {
+    const boundSessionId = resumableSessionId({
+      ...durableActive,
+      sessionId: storedSessionId,
+    });
+    const foreignSession = Boolean(storedSessionId && !boundSessionId);
+    if (durableActive.id === reloadThreadId || foreignSession) {
       historyStore.reviseThread(durableActive, { sessionId: boundSessionId });
     }
     ssSet(CURRENT_THREAD_KEY, durableActive.id);
     ssSet(SESSION_KEY, boundSessionId);
     setActiveThread(scopeKey, durableActive.id);
     paintThread(durableActive);
+    if (foreignSession) armVisibleTranscriptReplay();
     persistThreads();
   })();
 
@@ -15699,6 +16078,33 @@ function buildPanel() {
     // provider row) — exactly ONE connect, and the single post-handshake catalog
     // push carries the new backend's values. No set_options is sent here.
     connectBackend(id);
+  };
+  panelHooks.applyChatScope = (mode) => {
+    if (!['panel', 'workflow', 'ask'].includes(mode)) return;
+    askModeFollowsPanel = mode === "panel";
+    const targetKey = mode === "panel" ? "panel:global" : workflowStorageKey();
+    const panelTargetId = mode === "panel" ? historyMeta.activeByScope?.[targetKey] : null;
+    let target = mode === "panel"
+      ? threads.find((candidate) => candidate.id === panelTargetId)
+      : threadForWorkflow(targetKey);
+    if (!target && mode === "panel" && thread) {
+      // First switch to panel-owned mode: carry the visible conversation into
+      // the global selection slot without discarding its workflow provenance.
+      target = thread;
+      setActiveThread(targetKey, target.id);
+      persistThreads();
+    }
+    if (target) loadThread(target);
+    else newChat({ notifyBackend: false });
+    currentWorkflowId = null;
+    onWorkflowMaybeChanged();
+    appendSystem(
+      mode === "panel"
+        ? "Chat scope → panel-wide conversation."
+        : mode === "workflow"
+          ? "Chat scope → separate histories for each workflow."
+          : "Chat scope → ask whenever the workflow changes.",
+    );
   };
   panelHooks.applyModel = (id) => {
     const next = (id || "").trim();
@@ -15863,6 +16269,7 @@ function buildPanel() {
       // Drop the Settings→panel hooks so the dialog can't drive a torn-down panel
       // (a freshly-mounted panel re-registers them).
       panelHooks.applyBackend = null;
+      panelHooks.applyChatScope = null;
       panelHooks.applyModel = null;
       panelHooks.applyEffort = null;
       panelHooks.applyBridgeUrl = null;

--- a/web/js/lib/chat-history-store.js
+++ b/web/js/lib/chat-history-store.js
@@ -10,6 +10,8 @@ export const CHAT_HISTORY_SCHEMA = 3;
 export const CHAT_HISTORY_DB = "comfyui-mcp-panel-history";
 export const CHAT_HISTORY_STATE_KEY = "state";
 export const CHAT_HISTORY_LOCAL_SNAPSHOT_KEY = "comfyui-mcp.panel.historySnapshot";
+export const CHAT_HISTORY_MAX_IMPORT_BYTES = 25 * 1024 * 1024;
+export const CHAT_HISTORY_EXPORT_FORMAT = "comfyui-agent-panel-chat-history";
 
 const DEFAULT_THREADS_KEY = "comfyui-mcp.panel.threads";
 const DEFAULT_META_KEY = "comfyui-mcp.panel.historyMeta";
@@ -20,6 +22,8 @@ const LOCAL_SHADOW_MESSAGES = 200;
 const IDB_OPEN_TIMEOUT_MS = 2000;
 const DEFAULT_MAX_TOMBSTONES = 512;
 const DEFAULT_MAX_METADATA_OPS = 512;
+const DEFAULT_MAX_WORKFLOW_VERSIONS = 20;
+const MAX_WORKFLOW_SNAPSHOT_BYTES = 300_000;
 const BROADCAST_CHANNEL_NAME = "comfyui-mcp-panel-history-v3";
 const LEGACY_IDLESS_SOURCE = Symbol("legacy-idless-source");
 const THREAD_FIELDS = [
@@ -45,6 +49,10 @@ const THREAD_STRING_LIMITS = {
 };
 const MAX_TODOS = 100;
 const MAX_TODO_TEXT = 2000;
+
+function utf8ByteLength(value) {
+  return new TextEncoder().encode(String(value)).byteLength;
+}
 
 function finiteTs(value) {
   const n = Number(value);
@@ -77,6 +85,59 @@ function stableHash(value) {
     second = Math.imul(second ^ code, 0x85ebca6b) >>> 0;
   }
   return first.toString(16).padStart(8, "0") + second.toString(16).padStart(8, "0");
+}
+
+function normalizeWorkflowVersions(raw) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return Object.create(null);
+  const versions = [];
+  for (const [key, value] of Object.entries(raw)) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+    const hash = String(value.hash || key || "").trim().slice(0, 64);
+    if (!hash) continue;
+    const normalized = {
+      hash,
+      capturedAt: finiteTs(value.capturedAt),
+      nodeCount: Math.max(0, Math.min(1_000_000, Math.floor(Number(value.nodeCount) || 0))),
+    };
+    for (const [field, limit] of [
+      ["workflowKey", 512],
+      ["title", 240],
+      ["path", 1024],
+    ]) {
+      if (typeof value[field] === "string" && value[field]) {
+        normalized[field] = value[field].slice(0, limit);
+      }
+    }
+    if (value.snapshot && typeof value.snapshot === "object") {
+      try {
+        const encoded = JSON.stringify(value.snapshot);
+        if (utf8ByteLength(encoded) <= MAX_WORKFLOW_SNAPSHOT_BYTES) {
+          normalized.snapshot = JSON.parse(encoded);
+        }
+      } catch {
+        // Invalid/cyclic snapshots retain their lightweight version metadata.
+      }
+    }
+    versions.push(normalized);
+  }
+  versions.sort((a, b) => b.capturedAt - a.capturedAt || a.hash.localeCompare(b.hash));
+  const result = Object.create(null);
+  for (const version of versions.slice(0, DEFAULT_MAX_WORKFLOW_VERSIONS)) {
+    const previous = result[version.hash];
+    if (!previous || version.capturedAt >= previous.capturedAt) result[version.hash] = version;
+  }
+  return result;
+}
+
+function mergeWorkflowVersions(...maps) {
+  const combined = Object.create(null);
+  for (const map of maps) {
+    for (const [hash, version] of Object.entries(normalizeWorkflowVersions(map))) {
+      const previous = combined[hash];
+      if (!previous || version.capturedAt >= previous.capturedAt) combined[hash] = version;
+    }
+  }
+  return normalizeWorkflowVersions(combined);
 }
 
 function normalizeRevision(value, fallbackUpdatedAt = 0, fallbackWriterId = "legacy", fallbackSequence = 0) {
@@ -413,10 +474,29 @@ function boundedEntries(map, limit, revisionOf) {
   return [kept, dropped];
 }
 
+function boundedMetadataValues(values, operations, limit, fallbackRevision) {
+  const entries = Object.entries(values || {});
+  if (entries.length <= limit) return [Object.assign(safeMap(), values || {}), []];
+  entries.sort((left, right) =>
+    compareRevisions(
+      operationRevision(operations?.[left[0]]) || fallbackRevision,
+      operationRevision(operations?.[right[0]]) || fallbackRevision,
+    ) || left[0].localeCompare(right[0]),
+  );
+  const dropped = entries.slice(0, entries.length - limit);
+  const kept = safeMap();
+  for (const [key, value] of entries.slice(-limit)) kept[key] = value;
+  return [kept, dropped];
+}
+
 function compactSnapshot(snapshot, { maxTombstones, maxMetadataOps }) {
   const tombstoneLimit = Math.max(1, Math.floor(Number(maxTombstones) || DEFAULT_MAX_TOMBSTONES));
   const operationLimit = Math.max(1, Math.floor(Number(maxMetadataOps) || DEFAULT_MAX_METADATA_OPS));
   const meta = { ...(snapshot.meta || {}) };
+  const originalMetadataOps = {
+    activeOps: meta.activeOps,
+    aliasOps: meta.aliasOps,
+  };
   const droppedRevisions = [];
   let changed = false;
   [meta.deletedThreads, changed] = (() => {
@@ -428,6 +508,27 @@ function compactSnapshot(snapshot, { maxTombstones, maxMetadataOps }) {
     const [kept, dropped] = boundedEntries(meta[name], operationLimit, operationRevision);
     meta[name] = kept;
     for (const [, value] of dropped) droppedRevisions.push(operationRevision(value));
+    if (dropped.length) changed = true;
+  }
+  const fallbackMetadataRevision =
+    normalizeCheckpoint(meta).revision ||
+    normalizeRevision(null, finiteTs(meta.updatedAt) || 1, "metadata-baseline");
+  for (const [valuesName, opsName] of [
+    ["activeByScope", "activeOps"],
+    ["workflowAliases", "aliasOps"],
+  ]) {
+    const [kept, dropped] = boundedMetadataValues(
+      meta[valuesName],
+      originalMetadataOps[opsName],
+      operationLimit,
+      fallbackMetadataRevision,
+    );
+    meta[valuesName] = kept;
+    for (const [key] of dropped) {
+      droppedRevisions.push(
+        operationRevision(originalMetadataOps[opsName]?.[key]) || fallbackMetadataRevision,
+      );
+    }
     if (dropped.length) changed = true;
   }
   const threads = snapshot.threads.map((thread) => {
@@ -477,6 +578,7 @@ export function normalizeThread(raw) {
     ts: updatedAt,
     msgs,
     deletedMessages,
+    workflowVersions: normalizeWorkflowVersions(raw.workflowVersions),
     title: typeof raw.title === "string" ? raw.title.slice(0, 160) : undefined,
     workflowTitle: typeof raw.workflowTitle === "string" ? raw.workflowTitle.slice(0, 240) : undefined,
     provider: typeof raw.provider === "string" ? raw.provider : undefined,
@@ -700,7 +802,16 @@ export function mergeHistorySnapshots(...snapshots) {
         );
       const fieldOps = mergeMetadataOperationMaps(older.fieldOps, newer.fieldOps);
       byId.set(next.id, materializeThreadFields(
-        { ...older, ...overlay, msgs, deletedMessages },
+        {
+          ...older,
+          ...overlay,
+          msgs,
+          deletedMessages,
+          workflowVersions: mergeWorkflowVersions(
+            older.workflowVersions,
+            newer.workflowVersions,
+          ),
+        },
         fieldOps,
       ));
     }
@@ -873,6 +984,92 @@ function boundedSnapshot(snapshot, { maxThreads, maxMessages, protectedThreadIds
       msgs: messageLimit ? thread.msgs.slice(-messageLimit) : [],
     })),
   };
+}
+
+export function parseHistoryImport(value) {
+  let parsed = value;
+  if (typeof value === "string") {
+    if (utf8ByteLength(value) > CHAT_HISTORY_MAX_IMPORT_BYTES) {
+      throw new Error("Chat history import exceeds the 25 MB limit");
+    }
+    parsed = JSON.parse(value);
+  }
+  if (Array.isArray(parsed)) parsed = { threads: parsed, meta: {} };
+  if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.threads)) {
+    throw new Error("Not a ComfyUI Agent Panel history export");
+  }
+  if (parsed.format != null && parsed.format !== CHAT_HISTORY_EXPORT_FORMAT) {
+    throw new Error("Not a ComfyUI Agent Panel history export");
+  }
+  const schemaVersion = Number(parsed.schemaVersion);
+  if (Number.isFinite(schemaVersion) && schemaVersion > CHAT_HISTORY_SCHEMA) {
+    throw new Error(
+      `Chat history schema ${schemaVersion} is newer than this panel supports (${CHAT_HISTORY_SCHEMA})`,
+    );
+  }
+  return {
+    schemaVersion: CHAT_HISTORY_SCHEMA,
+    threads: parsed.threads.map(portableThread).filter(Boolean),
+    // Keep every validated portable alias through parsing so importPayload can
+    // account for (and report) entries skipped by the local metadata cap.
+    meta: {
+      workflowAliases: portableWorkflowAliases(
+        parsed.meta?.workflowAliases,
+        Number.MAX_SAFE_INTEGER,
+      ),
+    },
+  };
+}
+
+function portableWorkflowAliases(raw, limit = DEFAULT_MAX_METADATA_OPS) {
+  const aliases = safeMap();
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return aliases;
+  let count = 0;
+  for (const [rawPath, rawUuid] of Object.entries(raw)) {
+    if (count >= limit) break;
+    if (typeof rawPath !== "string" || !rawPath || rawPath.length > 1024) continue;
+    if (typeof rawUuid !== "string" || !rawUuid || rawUuid.length > 512) continue;
+    aliases[rawPath] = rawUuid;
+    count += 1;
+  }
+  return aliases;
+}
+
+function portableMessage(raw) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const message = cloneJson(raw);
+  delete message.revision;
+  delete message.createdRevision;
+  return message;
+}
+
+/** Produce the portable transcript shape used by export and import.
+ *
+ * Session ids and causal bookkeeping are browser-local implementation details:
+ * carrying them to another installation can resume the wrong provider session,
+ * while a foreign checkpoint/tombstone can delete unrelated local history.
+ */
+function portableThread(raw) {
+  const normalized = normalizeThread(raw);
+  if (!normalized) return null;
+  const thread = {
+    id: normalized.id,
+    schemaVersion: CHAT_HISTORY_SCHEMA,
+    createdAt: normalized.createdAt,
+    updatedAt: normalized.updatedAt,
+    ts: normalized.ts,
+    msgs: normalized.msgs.map(portableMessage).filter(Boolean),
+    workflowKey: normalized.workflowKey,
+    workflowTitle: normalized.workflowTitle,
+    provider: normalized.provider,
+    model: normalized.model,
+    effort: normalized.effort,
+    pinned: normalized.pinned,
+    title: normalized.title,
+    todos: normalized.todos,
+    workflowVersions: normalized.workflowVersions,
+  };
+  return Object.fromEntries(Object.entries(thread).filter(([, field]) => field !== undefined));
 }
 
 function openDb(indexedDb) {
@@ -1166,21 +1363,28 @@ export class ChatHistoryStore {
   }
 
   _writeLocalSnapshot(snapshot, protectedThreadIds) {
-    // legacyShadow threads are exempt from the shadow cap: excluded from
-    // IndexedDB by the fence, the shadow copy is their ONLY copy — eviction
-    // would be silent data loss (codex finding).
-    const protectedWithLegacy = [
-      ...protectedThreadIds,
-      ...(Array.isArray(snapshot.threads) ? snapshot.threads : [])
-        .filter((thread) => thread?.legacyShadow && typeof thread.id === "string")
-        .map((thread) => thread.id),
-    ];
-    const shadow = retainBoundedThreads(
-      snapshot.threads,
+    // legacyShadow threads are excluded from IndexedDB by the schema fence, so
+    // the local shadow is their only copy. Preserve every such thread and all
+    // of its messages. A storage-quota failure is surfaced instead of claiming
+    // that a truncated only-copy transcript was saved durably.
+    const sourceThreads = Array.isArray(snapshot.threads) ? snapshot.threads : [];
+    const legacyThreads = sourceThreads.filter((thread) => thread?.legacyShadow === true);
+    const ordinaryThreads = sourceThreads.filter((thread) => thread?.legacyShadow !== true);
+    const boundedOrdinary = retainBoundedThreads(
+      ordinaryThreads,
       LOCAL_SHADOW_THREADS,
-      protectedWithLegacy,
-    ).map((thread) => ({ ...thread, msgs: thread.msgs.slice(-LOCAL_SHADOW_MESSAGES) }));
+      protectedThreadIds,
+    ).map((thread) => ({
+      ...thread,
+      msgs: thread.msgs.slice(-LOCAL_SHADOW_MESSAGES),
+    }));
+    const shadow = [...boundedOrdinary, ...legacyThreads]
+      .sort((a, b) => finiteTs(a.updatedAt || a.ts) - finiteTs(b.updatedAt || b.ts));
     const localSnapshot = { ...snapshot, threads: shadow };
+    const shadowById = new Map(shadow.map((thread) => [thread.id, thread]));
+    const complete = snapshot.threads.length === shadow.length &&
+      snapshot.threads.every((thread) =>
+        shadowById.get(thread.id)?.msgs?.length === thread.msgs.length);
     try {
       this.storage?.setItem(this.snapshotKey, JSON.stringify(localSnapshot));
       this.lastShadowWriteOk = true;
@@ -1189,7 +1393,7 @@ export class ChatHistoryStore {
       this.lastShadowWriteOk = false;
       this.lastShadowError = error;
       this.onShadowError?.(error);
-      return false;
+      return { committed: false, complete: false, legacyComplete: false };
     }
     try {
       this.storage?.setItem(this.threadsKey, JSON.stringify(shadow));
@@ -1201,7 +1405,7 @@ export class ChatHistoryStore {
     } catch {
       // The atomic shadow is already committed.
     }
-    return true;
+    return { committed: true, complete, legacyComplete: true };
   }
 
   persist(threads, meta = {}, options = {}) {
@@ -1230,7 +1434,7 @@ export class ChatHistoryStore {
       maxMetadataOps: options.maxMetadataOps ?? this.maxMetadataOps,
       protectedThreadIds,
     };
-    const shadowCommitted = this._writeLocalSnapshot(snapshot, protectedThreadIds);
+    const shadowWrite = this._writeLocalSnapshot(snapshot, protectedThreadIds);
     // Start the atomic merge immediately. Chat records are low-frequency and a
     // debounce creates an avoidable shutdown window in which the local shadow
     // exists but IndexedDB has not started its transaction yet.
@@ -1238,22 +1442,41 @@ export class ChatHistoryStore {
       .catch(() => null)
       .then(() => idbMergeWrite(this.indexedDb, snapshot, limits))
       .then((merged) => {
+        let postMergeShadowWrite = null;
         if (merged) {
           this._lastCommitted = merged;
           this._observeSnapshot(merged);
-          this._writeLocalSnapshot(merged, protectedThreadIds);
+          postMergeShadowWrite = this._writeLocalSnapshot(merged, protectedThreadIds);
           try {
             this._broadcastChannel?.postMessage({ type: "history-changed", writerId: this.writerId });
           } catch {
             // localStorage events remain available when the channel is blocked.
           }
         }
+        const shadowOnlyComplete = !merged && shadowWrite.committed && shadowWrite.complete;
+        const hasShadowOnlyLegacy = Boolean(
+          merged?.threads?.some((thread) => thread?.legacyShadow === true),
+        );
+        const legacyShadowCommitted = !hasShadowOnlyLegacy ||
+          shadowWrite.legacyComplete ||
+          postMergeShadowWrite?.legacyComplete;
+        const canonicalComplete = Boolean(merged) && legacyShadowCommitted;
+        const anyShadowCommitted = shadowWrite.committed ||
+          Boolean(postMergeShadowWrite?.committed);
         const result = {
-          ok: Boolean(merged || shadowCommitted),
-          shadowCommitted,
+          ok: Boolean(canonicalComplete || shadowOnlyComplete),
+          shadowCommitted: anyShadowCommitted,
           canonicalCommitted: Boolean(merged),
-          retryable: !merged && !shadowCommitted,
-          code: !merged && !shadowCommitted ? "history-persistence-unavailable" : null,
+          retryable: !canonicalComplete && !shadowOnlyComplete,
+          code: merged && !legacyShadowCommitted
+            ? "history-legacy-shadow-unavailable"
+            : !merged
+            ? shadowWrite.committed && !shadowWrite.complete
+              ? "history-canonical-unavailable-shadow-truncated"
+              : !shadowWrite.committed
+                ? "history-persistence-unavailable"
+                : null
+            : null,
         };
         if (result.ok) {
           this._dirtyWrite = null;
@@ -1306,7 +1529,7 @@ export class ChatHistoryStore {
         this._lastCommitted = reset;
         this._dirtyWrite = null;
         this._observeSnapshot(reset);
-        const shadowCommitted = this._writeLocalSnapshot(reset, []);
+        const shadowWrite = this._writeLocalSnapshot(reset, []);
         try {
           this._broadcastChannel?.postMessage({
             type: "history-reset",
@@ -1319,7 +1542,7 @@ export class ChatHistoryStore {
         return {
           ok: true,
           canonicalCommitted: true,
-          shadowCommitted,
+          shadowCommitted: shadowWrite.committed,
           retryable: false,
           code: null,
           snapshot: reset,
@@ -1396,6 +1619,193 @@ export class ChatHistoryStore {
       // Closing an already-detached native channel is harmless.
     }
     this._broadcastChannel = null;
+  }
+
+  exportPayload(threads, meta = {}) {
+    const snapshot = mergeHistorySnapshots({ threads, meta });
+    return {
+      format: CHAT_HISTORY_EXPORT_FORMAT,
+      schemaVersion: CHAT_HISTORY_SCHEMA,
+      exportedAt: new Date().toISOString(),
+      threads: snapshot.threads.map(portableThread).filter(Boolean),
+      // Workflow identity aliases are portable provenance. Active pointers,
+      // provider sessions, tombstones, checkpoints, and CRDT operations are not:
+      // importing those browser-local records could switch or delete local chats.
+      meta: {
+        workflowAliases: portableWorkflowAliases(snapshot.meta?.workflowAliases),
+      },
+    };
+  }
+
+  importPayload(value, currentThreads = [], currentMeta = {}) {
+    const incoming = parseHistoryImport(value);
+    const current = mergeHistorySnapshots({ threads: currentThreads, meta: currentMeta });
+    const currentById = new Map(current.threads.map((thread) => [thread.id, thread]));
+    const deletedThreadIds = new Set(Object.keys(current.meta?.deletedThreads || {}));
+    const newThreadIds = new Set(
+      incoming.threads
+        .map((thread) => thread.id)
+        .filter((id) => !deletedThreadIds.has(id) && !currentById.has(id)),
+    );
+    const retainedCount = current.threads.length;
+    if (retainedCount + newThreadIds.size > this.maxThreads) {
+      const error = new Error(
+        `Import needs ${newThreadIds.size} new chat slot(s), but only ` +
+        `${Math.max(0, this.maxThreads - retainedCount)} of ${this.maxThreads} are available. ` +
+        "Delete or export older chats first; no history was changed.",
+      );
+      error.code = "history-import-thread-limit";
+      throw error;
+    }
+    const incomingMessageIds = new Map();
+    for (const source of incoming.threads) {
+      if (deletedThreadIds.has(source.id)) continue;
+      const ids = incomingMessageIds.get(source.id) || new Set();
+      for (const message of source.msgs || []) {
+        if (typeof message?.id === "string" && message.id) ids.add(message.id);
+      }
+      incomingMessageIds.set(source.id, ids);
+    }
+    for (const [threadId, ids] of incomingMessageIds) {
+      const existingIds = new Set(
+        (currentById.get(threadId)?.msgs || []).map((message) => message.id),
+      );
+      let additions = 0;
+      for (const id of ids) if (!existingIds.has(id)) additions += 1;
+      if (existingIds.size + additions <= this.maxMessages) continue;
+      const error = new Error(
+        `Import needs ${additions} new message slot(s) in chat ${threadId}, but only ` +
+        `${Math.max(0, this.maxMessages - existingIds.size)} of ${this.maxMessages} are available. ` +
+        "Start a new chat or remove older entries first; no history was changed.",
+      );
+      error.code = "history-import-message-limit";
+      throw error;
+    }
+
+    this._observeSnapshot(current);
+    const rebased = [];
+    const importedVersionState = new Map();
+
+    for (const source of incoming.threads) {
+      const existing = currentById.get(source.id);
+      const thread = existing
+        ? cloneJson(existing)
+        : {
+          id: source.id,
+          schemaVersion: CHAT_HISTORY_SCHEMA,
+          createdAt: finiteTs(source.createdAt) || Date.now(),
+          updatedAt: 0,
+          ts: 0,
+          msgs: [],
+          deletedMessages: safeMap(),
+          workflowVersions: safeMap(),
+        };
+
+      if (!existing) {
+        const creation = this.nextRevision();
+        thread.createdRevision = creation;
+        thread.updatedAt = creation.updatedAt;
+        thread.ts = creation.updatedAt;
+      }
+
+      const messages = new Map(
+        (Array.isArray(thread.msgs) ? thread.msgs : []).map((message) => [message.id, message]),
+      );
+      for (const sourceMessage of source.msgs || []) {
+        const previous = messages.get(sourceMessage.id);
+        // Import is add-only for colliding ids. A portable archive can extend a
+        // known conversation, but can never replace an existing local message.
+        if (previous) continue;
+        const message = portableMessage(sourceMessage);
+        if (!message) continue;
+        this.touchMessage(message);
+        messages.set(message.id, message);
+        thread.updatedAt = Math.max(finiteTs(thread.updatedAt), finiteTs(message.updatedAt));
+      }
+      thread.msgs = [...messages.values()].sort(
+        (left, right) =>
+          finiteTs(left.createdAt || left.ts) - finiteTs(right.createdAt || right.ts) ||
+          String(left.id).localeCompare(String(right.id)),
+      );
+      if (existing) {
+        const versions = Object.assign(safeMap(), thread.workflowVersions || {});
+        let versionState = importedVersionState.get(source.id);
+        if (!versionState) {
+          versionState = {
+            hashes: new Set(Object.keys(versions)),
+            remaining: Math.max(
+              0,
+              DEFAULT_MAX_WORKFLOW_VERSIONS - Object.keys(versions).length,
+            ),
+          };
+          importedVersionState.set(source.id, versionState);
+        }
+        for (const [hash, version] of Object.entries(source.workflowVersions || {})) {
+          if (!versionState.remaining || versionState.hashes.has(hash)) continue;
+          versions[hash] = version;
+          versionState.hashes.add(hash);
+          versionState.remaining -= 1;
+        }
+        thread.workflowVersions = versions;
+      } else {
+        thread.workflowVersions = mergeWorkflowVersions(source.workflowVersions);
+      }
+
+      // A colliding thread id is add-only: every local field wins, even when the
+      // archive carries future timestamps or raw field tombstones. Only a
+      // genuinely new thread materializes portable archive metadata.
+      if (!existing) {
+        const fields = {
+          workflowKey: source.workflowKey,
+          workflowTitle: source.workflowTitle,
+          pinned: source.pinned,
+          title: source.title,
+          todos: source.todos,
+          provider: source.provider,
+          model: source.model,
+          effort: source.effort,
+        };
+        this.reviseThread(thread, fields);
+      }
+      thread.updatedAt = Math.max(finiteTs(thread.updatedAt), finiteTs(thread.createdAt));
+      thread.ts = thread.updatedAt;
+      rebased.push(thread);
+    }
+
+    const baseThreads = current.threads;
+    let meta = current.meta;
+    const localAliases = portableWorkflowAliases(
+      meta?.workflowAliases,
+      Number.MAX_SAFE_INTEGER,
+    );
+    let availableAliases = Math.max(
+      0,
+      this.maxMetadataOps - Object.keys(localAliases).length,
+    );
+    let importedAliasCount = 0;
+    let skippedAliasCount = 0;
+    for (const [path, workflowUuid] of Object.entries(incoming.meta?.workflowAliases || {})) {
+      if (Object.hasOwn(localAliases, path)) continue;
+      if (!availableAliases) {
+        skippedAliasCount += 1;
+        continue;
+      }
+      meta = updateMetadataEntry(meta, "workflowAliases", path, workflowUuid, this.nextRevision());
+      localAliases[path] = workflowUuid;
+      availableAliases -= 1;
+      importedAliasCount += 1;
+    }
+
+    const merged = mergeHistorySnapshots(
+      { threads: baseThreads, meta },
+      { threads: rebased, meta: {} },
+    );
+    return {
+      ...merged,
+      importedCount: incoming.threads.length,
+      importedAliasCount,
+      skippedAliasCount,
+    };
   }
 
 }


### PR DESCRIPTION
## Summary

PR 3 of the durable chat-history series tracked in #98, following merged #101 and #106.

- multiple conversations per workflow with search, current-workflow filtering, pin, rename, delete, and active-chat selection
- portable JSON merge import/export with a 25 MB input limit and bounded workflow snapshots
- explicit Panel / Workflow / Ask-on-switch scope modes, with migration from the legacy boolean
- archive grouping by stable workflow identity across saves and renames
- provider/model/effort metadata plus workflow-version context for each user turn
- bounded transcript hydration when a stored provider session is missing, stale, or belongs to another provider

## Current base

Rebased onto current `main` at `6aa98c1` (Panel 0.11.2). This includes the merged PR 2 store, its post-merge rescue fixes, the #154 reconnect fix, and the GLM provider work from #155/#156.

Workflow UUID remains a transcript/archive scope key only. Bridge routing and the panel-owned live-agent rebind path are unchanged.

## Data-safety response to the latest review

The four findings from the maintainer's adversarial pass are fixed and regression-tested:

1. **Import cannot evict local chats or messages.** Before changing state, import computes all genuinely new thread/message IDs. If the result would exceed 500 chats or 5,000 entries in any chat, the entire import fails with an actionable error. It never relies on recency capping after the merge, so no existing local transcript is silently displaced.
2. **Same-ID import is add-only.** Existing local messages and every existing thread field win regardless of foreign timestamps or raw `fieldOps`. An archive may add a missing message or workflow version, but cannot replace/delete local content, title, todos, workflow metadata, provider/session provenance, or an existing workflow-version record. Duplicate imported records share one remaining-version budget, so they cannot crowd local graph versions out.
3. **IndexedDB fallback no longer reports truncated durability as success.** A complete 20×200 localStorage shadow can still serve as the degraded durable store. Once that shadow is incomplete, persistence returns a retryable failure, retains the full snapshot in memory, and displays a clear warning that overflow is not durable. Recovery retries on the next mutation.
4. **Workflow aliases are bounded.** Both the causal operation map and the materialized alias map are compacted to 512 entries behind a checkpoint. Import fills only free alias slots, preserves all local aliases, and reports how many portable aliases were skipped.

The review also exposed two adjacent only-copy cases, fixed in the same data-safety pass:

- quarantined `legacyShadow` transcripts are exempt from the 20-chat/200-entry shadow caps because the IndexedDB fence deliberately excludes them;
- failure to save those only-copy transcripts to localStorage is no longer masked by a successful canonical write for the rest of history.

The import policy is deliberately fail-closed rather than “protect locals and evict imported rows”: users get an atomic, explainable result, and the success message remains truthful. Colliding IDs are deliberately add-only because an imported archive is untrusted portable data, not an authority allowed to rewrite local causal history.

## Other deep-audit fixes retained

- portable export omits browser-local sessions, active pointers, checkpoints, CRDT operations, and tombstones;
- future schemas are rejected and raw payloads are reduced to the portable allowlist;
- active thread and live A2UI records are rebound after import;
- provider-mismatched or rejected stale sessions start fresh with bounded transcript hydration;
- archive switching ends the previous local in-flight turn before repaint/resume;
- identical workflow display titles remain separate UUID/path groups;
- workflow snapshot limits use UTF-8 bytes;
- clear-all remains canonical and cross-tab safe.

## Verification

Current head: `cb07566`.

- `npm run test:unit` — **162/162 passed**
- `npm run typecheck` — passed
- relevant Playwright history/persistence/identity suite — **15/15 passed** serially against live ComfyUI 0.28.3
- `node --check web/js/comfyui-mcp-panel.js` — passed
- `node --check web/js/lib/chat-history-store.js` — passed
- `git diff --check` — passed
- `npm audit --omit=optional --audit-level=high` — **0 vulnerabilities**

Part of #98.