### PR TITLE
fix: unsaved-workflow reconnect-nudge storm (0.11.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.0"
+version = "0.11.1"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11841,10 +11841,15 @@ function buildPanel() {
     // first record(), and even then silently, so viewing a workflow never dirties it.
     const historyKey = workflowStorageKey();
 
+    // Same workflow OBJECT, id flipped tmp:→wf: → ADOPT. Instance-based (like the
+    // RENAME case below), NOT wfkey-based: the unsaved tab id is now stable across
+    // wf.key churn, so a mid-life key change makes the case-1 early return skip
+    // refreshing currentWorkflowKey — a key comparison would then miss the adopt and
+    // misroute the save as a SWITCH (codex review). The instance survives the save.
     const adopting =
+      wf &&
+      wf === currentWorkflowRef &&
       currentWorkflowId &&
-      currentWorkflowKey &&
-      wfkey === currentWorkflowKey &&
       currentWorkflowId.startsWith("tmp:") &&
       wfid.startsWith("wf:");
     if (adopting) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -111,7 +111,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.0";
+const PANEL_VERSION = "0.11.1";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -652,7 +652,14 @@ function getTabId() {
 // ones get a stable temp id for this app session (adopted into the file id on save,
 // see the workflow-change handler). Falls back to the legacy per-browser-session id
 // when no workflow service is present (headless / odd frontend).
-const _tempWorkflowIds = new Map(); // wf.key -> "tmp:<uuid>"
+// Unsaved workflows get a stable temp routing id keyed on the STABLE workflow
+// OBJECT INSTANCE, not wf.key. wf.key is derived and churns for unsaved tabs
+// (ComfyUI re-derives it as tabs open/close/rename), so keying the tmp: id on it
+// minted a FRESH id on the 600ms workflow poll — which re-helloed the socket in a
+// loop and produced a "connection dropped mid-task" nudge storm on idle unsaved
+// tabs. The instance is the only identity that survives that churn (cf.
+// currentWorkflowRef / _workflowObjectUuids).
+const _tempWorkflowInstanceIds = new WeakMap(); // wf object -> "tmp:<uuid>"
 const _workflowObjectUuids = new WeakMap();
 const _workflowUuidOwners = new Map();
 const WORKFLOW_UUID_ALIASES_KEY = "comfyui-mcp.panel.workflowUuidAliases";
@@ -834,11 +841,13 @@ function workflowTabId() {
   if (!wf) return getTabId();
   const saved = savedWorkflowPath(wf);
   if (saved) return "wf:" + wf.path;
-  const k = wf.key || wf.id || "unsaved";
-  let id = _tempWorkflowIds.get(k);
+  // Key on the STABLE object instance, not the mutable wf.key (see the note at
+  // _tempWorkflowInstanceIds): the same unsaved workflow must keep ONE tmp: id for
+  // its lifetime, or the 600ms poll churns it into a re-hello storm.
+  let id = _tempWorkflowInstanceIds.get(wf);
   if (!id) {
     id = "tmp:" + crypto.randomUUID();
-    _tempWorkflowIds.set(k, id);
+    _tempWorkflowInstanceIds.set(wf, id);
   }
   return id;
 }
@@ -11802,7 +11811,7 @@ function buildPanel() {
     if (sessionFollowsPanel()) {
       const initial = currentWorkflowId == null;
       // tmp→wf adopt bookkeeping (a save gave the unsaved workflow a real id).
-      if (wfid.startsWith("wf:") && wf && (wf.key || wf.id)) _tempWorkflowIds.delete(wf.key || wf.id);
+      if (wfid.startsWith("wf:") && wf) _tempWorkflowInstanceIds.delete(wf);
       if (thread) {
         historyStore.reviseThread(thread, { workflowKey: wfid }); // archive provenance
         setActiveThread("panel:global", thread.id);
@@ -11840,7 +11849,7 @@ function buildPanel() {
       wfid.startsWith("wf:");
     if (adopting) {
       const t = threadForWorkflow(historyKey);
-      if (wf && (wf.key || wf.id)) _tempWorkflowIds.delete(wf.key || wf.id);
+      if (wf) _tempWorkflowInstanceIds.delete(wf);
       currentWorkflowId = wfid;
       currentWorkflowKey = wfkey;
       currentWorkflowRef = wf;


### PR DESCRIPTION
Fixes the "✅ Your connection dropped mid-task" nudge storm that fired ~every other message on **idle unsaved-workflow tabs** (reported in #bug-reports; reproduced on multiple users' setups).

## Root cause
`workflowTabId()` minted an unsaved tab's `tmp:` routing id keyed on the **mutable `wf.key`**. A 600ms poll (`onWorkflowMaybeChanged`) recomputes it; for unsaved tabs ComfyUI re-derives `wf.key` (as tabs open/close/rename), so a **fresh `tmp:` id was minted every tick** → the socket re-helloed → the bridge stamped a tab-id migration every time → the panel emitted a "connection dropped" resume nudge, burning agent tokens. Saved workflows were immune (they key on the stable `wf:`+path).

## Fix
- Key the temp id on the **stable workflow object instance** (WeakMap `_tempWorkflowInstanceIds`) — the instance ComfyUI mutates in place — so an unsaved tab keeps ONE id for its lifetime (`b0d8f33`).
- Make the tmp→wf **ADOPT** predicate instance-based (`wf === currentWorkflowRef`), matching RENAME, so a first-save still adopts correctly now that the id is stable across key churn (`042d6b6`, codex-found regression).
- Release bump to **0.11.1** (pyproject + matching `PANEL_VERSION`).

## Verification
- **codex review**: PASS on the root fix (stability/isolation/syntax); caught a save-adopt regression which `042d6b6` fixes (disclosed adversarial re-review: PASS).
- **Live (Claude-in-Chrome) on a real multi-unsaved-tab setup**: idle unsaved tab = zero re-hellos/nudges; two deliberate tab switches → exactly 2 clean "Canvas →" lines, flat over ~23 polls; **zero** "connection dropped" nudges. Under the bug that tab churned a nudge every ~600ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)