### PR TITLE
feat(providers): add GLM (z.ai) provider chip

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -72,6 +72,7 @@ _BACKEND_PORTS = {
     "grok": _BRIDGE_PORT,  # single-port multi-provider — same orchestrator
     "kimi": _BRIDGE_PORT,  # single-port multi-provider — same orchestrator
     "moonshot": _BRIDGE_PORT,  # hosted (Moonshot / Kimi K3) — same orchestrator, key-gated
+    "glm": _BRIDGE_PORT,  # hosted (z.ai coding plan / GLM) — same orchestrator, key-gated
     "ollama": _BRIDGE_PORT,  # single-port multi-provider — same orchestrator
     "openrouter": _BRIDGE_PORT,  # hosted (OpenRouter) — same orchestrator, key-gated
 }

--- a/browser_tests/glm-provider.spec.ts
+++ b/browser_tests/glm-provider.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * Tier 1 — GLM (z.ai) provider chip.
+ *
+ * The orchestrator has a `glm` backend (the hosted z.ai coding plan —
+ * api.z.ai/api/coding/paas/v4, key ZAI_API_KEY). This spec connects the panel to
+ * a MockBridge, pushes the orchestrator's authoritative `backends` frame (claude +
+ * glm, both ready) over the SAME bridge channel the real orchestrator uses
+ * (createBridgeClient's onBackends, panel.js ~6453), and asserts the model popup's
+ * Provider section renders glm's chip labeled "GLM (z.ai)" (BACKEND_LABELS) with
+ * the hint "GLM · z.ai coding plan" (BACKEND_HINTS) — i.e. the backend id is a
+ * KNOWN label the panel renders, not an unrecognized id that would fall through to
+ * the raw "glm" string (or be dropped entirely, as it was before this change).
+ *
+ * GLM is a hosted API-key provider with no CLI (like Moonshot / Kimi K3): setup is
+ * pasting a z.ai coding-plan key, not a CLI login. The handshake-backend ADOPTION
+ * path (selecting the chip connects as glm without reverting to claude) is
+ * exercised manually against a live orchestrator; here we pin the deterministic UI
+ * wiring.
+ *
+ * HARNESS NOTE: the panel can double-mount under a test harness → a documented
+ * "reconnect storm" (two clients, same tab_id — panel.js ~7674) that resets
+ * knownBackends and detaches the popup after ~1s. connect.spec.ts beats it by being
+ * fast; so do we — connect, advertise, then open + read the row in a single fast
+ * pass. Spec-level retries reload the page to dodge a load that storms early.
+ */
+import { test, expect } from './fixtures/panelTest'
+import { MockBridge } from './fixtures/MockBridge'
+
+test.describe.configure({ retries: 2 })
+
+test('a ready GLM (z.ai) backend renders a "GLM (z.ai)" provider chip with its hint', async ({
+  panel
+}) => {
+  const bridge = new MockBridge({ greeting: 'Panel agent ready.' })
+  await bridge.start()
+  try {
+    // Standard proven connect path (connect.spec.ts).
+    await panel.goto()
+    await panel.setBridgeUrl(bridge.url)
+    await panel.openSidebar()
+    await panel.connect()
+    await expect(panel.statusPill).toContainText('connected')
+
+    // The authoritative readiness frame: claude (the connected, selected backend —
+    // so no auto-pick/switch fires) + a ready glm. The Provider section renders
+    // only when >1 provider is known. Same {type:"backends"} frame the real
+    // orchestrator sends post-hello; the panel ingests it via onBackends.
+    bridge.send({
+      type: 'backends',
+      any_ready: true,
+      backends: [
+        { backend: 'claude', running: true, cli: true, auth: true, ready: true },
+        { backend: 'glm', running: false, cli: true, auth: true, ready: true }
+      ]
+    })
+
+    // Let the frame land (ingested synchronously by the ws onmessage handler), then
+    // open the model popup and read glm's row FAST — capture label + full text in a
+    // single pass before any reconnect can detach it.
+    await panel.page.waitForTimeout(400)
+    await panel.root.locator('.cmcp-chip').first().click()
+    const glm = panel.root
+      .locator('.cmcp-popover-item.cmcp-provider')
+      .filter({ hasText: 'GLM (z.ai)' })
+    await expect(glm).toHaveCount(1, { timeout: 8_000 })
+    const [label, rowText] = await Promise.all([
+      glm.locator('.lbl').textContent(),
+      glm.textContent()
+    ])
+    // Exact label — reads "GLM (z.ai)", never the raw id. Proves glm is in
+    // BACKEND_LABELS (the render allowlist), not an unknown/dropped id.
+    expect(label?.trim()).toBe('GLM (z.ai)')
+    // BACKEND_HINTS ("GLM · z.ai coding plan") wired through to the visible chip.
+    expect(rowText).toContain('GLM · z.ai coding plan')
+  } finally {
+    await bridge.close()
+  }
+})

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -596,6 +596,7 @@ const DEFAULT_BRIDGE_URL_BY_BACKEND = {
   grok: DEFAULT_BRIDGE_URL,
   kimi: DEFAULT_BRIDGE_URL,
   moonshot: DEFAULT_BRIDGE_URL,
+  glm: DEFAULT_BRIDGE_URL,
   ollama: DEFAULT_BRIDGE_URL,
 };
 function defaultBridgeUrlFor(backend) {
@@ -1110,6 +1111,7 @@ const SETTING_MODEL = {
   grok: "comfyui-mcp.defaultModel.grok",
   kimi: "comfyui-mcp.defaultModel.kimi",
   moonshot: "comfyui-mcp.defaultModel.moonshot",
+  glm: "comfyui-mcp.defaultModel.glm",
   ollama: "comfyui-mcp.defaultModel.ollama",
   openrouter: "comfyui-mcp.defaultModel.openrouter",
   lmstudio: "comfyui-mcp.defaultModel.lmstudio",
@@ -1124,6 +1126,7 @@ const SETTING_EFFORT = {
   grok: "comfyui-mcp.defaultEffort.grok",
   kimi: "comfyui-mcp.defaultEffort.kimi",
   moonshot: "comfyui-mcp.defaultEffort.moonshot",
+  glm: "comfyui-mcp.defaultEffort.glm",
   ollama: "comfyui-mcp.defaultEffort.ollama",
   openrouter: "comfyui-mcp.defaultEffort.openrouter",
   lmstudio: "comfyui-mcp.defaultEffort.lmstudio",
@@ -1146,6 +1149,7 @@ const SETTING_BRIDGE_URL = {
   grok: "comfyui-mcp.bridgeUrl.grok",
   kimi: "comfyui-mcp.bridgeUrl.kimi",
   moonshot: "comfyui-mcp.bridgeUrl.moonshot",
+  glm: "comfyui-mcp.bridgeUrl.glm",
   ollama: "comfyui-mcp.bridgeUrl.ollama",
   openrouter: "comfyui-mcp.bridgeUrl.openrouter",
   lmstudio: "comfyui-mcp.bridgeUrl.lmstudio",
@@ -1214,10 +1218,10 @@ const SETTINGS_SEEDED_KEY = "comfyui-mcp.panel.settingsSeeded";
 // per-backend groups (runs independently of SETTINGS_SEEDED_KEY).
 const SETTINGS_GROUPS_MIGRATED_KEY = "comfyui-mcp.panel.settingsGroupsMigrated";
 // Section (sub-category) labels for the grouped Settings dialog, per backend.
-const BACKEND_SECTION = { claude: "Claude", codex: "ChatGPT (Codex)", gemini: "Gemini", antigravity: "Antigravity (Google)", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", ollama: "Ollama (local)", openrouter: "OpenRouter", lmstudio: "LM Studio (local)", llamacpp: "llama.cpp (local)", custom: "Custom endpoint" };
+const BACKEND_SECTION = { claude: "Claude", codex: "ChatGPT (Codex)", gemini: "Gemini", antigravity: "Antigravity (Google)", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", ollama: "Ollama (local)", openrouter: "OpenRouter", lmstudio: "LM Studio (local)", llamacpp: "llama.cpp (local)", custom: "Custom endpoint" };
 // Backend display names at module scope (the Settings dialog's render-fns live
 // outside buildPanel's closure, so they need their own copy).
-const BACKEND_TEXT = { claude: "Claude", codex: "ChatGPT", gemini: "Gemini", antigravity: "Antigravity", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint" };
+const BACKEND_TEXT = { claude: "Claude", codex: "ChatGPT", gemini: "Gemini", antigravity: "Antigravity", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint" };
 // The allowlisted secure-store keys (mirrors the orchestrator's #59 allowlist).
 const SECRET_SET_AT_PREFIX = "comfyui-mcp.panel.secretSetAt.";
 
@@ -1267,7 +1271,7 @@ const settingsBackendState = {
 // render-fns when the dialog opens, so a freshly-arrived catalog can repaint the
 // matching backend's dropdown in place (a render-fn setting has no static options
 // to re-key). Keyed by backend; null when that group isn't mounted.
-const settingsModelSelectEls = { claude: null, codex: null, gemini: null, antigravity: null, grok: null, kimi: null, moonshot: null, ollama: null, openrouter: null, lmstudio: null, llamacpp: null, custom: null };
+const settingsModelSelectEls = { claude: null, codex: null, gemini: null, antigravity: null, grok: null, kimi: null, moonshot: null, glm: null, ollama: null, openrouter: null, lmstudio: null, llamacpp: null, custom: null };
 // Disabled placeholder <option> value — mapped to "" (Auto) if ever selected so
 // it can never persist as a bogus model id.
 const SETTINGS_PLACEHOLDER = "__cmcp_placeholder__";
@@ -1279,7 +1283,7 @@ function currentSettingsBackend() {
   const b = getSetting(SETTING_BACKEND);
   // Every selectable backend counts — this list lagging a provider addition
   // silently stops that provider's Settings edits from driving the live panel.
-  return ["codex", "gemini", "antigravity", "grok", "kimi", "moonshot", "ollama", "openrouter", "lmstudio", "llamacpp", "custom"].includes(b) ? b : "claude";
+  return ["codex", "gemini", "antigravity", "grok", "kimi", "moonshot", "glm", "ollama", "openrouter", "lmstudio", "llamacpp", "custom"].includes(b) ? b : "claude";
 }
 /** Fetched model rows for `backend` (the same presentable catalog the composer
  *  picker uses), or null when none is cached (backend never connected this session). */
@@ -1735,6 +1739,7 @@ function panelSettingsList() {
         { value: "grok", text: "Grok" },
         { value: "kimi", text: "Kimi" },
         { value: "moonshot", text: "Kimi K3" },
+        { value: "glm", text: "GLM (z.ai)" },
         { value: "ollama", text: "Ollama (local)" },
         { value: "openrouter", text: "OpenRouter (1M · SOTA)" },
         { value: "lmstudio", text: "LM Studio (local)" },
@@ -1982,6 +1987,9 @@ function panelSettingsList() {
     // ---- Kimi K3 (Moonshot platform, hosted API key) (Default model; no effort scale) ----
     modelSetting("moonshot", 71),
     effortSetting("moonshot", 71),
+    // ---- GLM (z.ai coding plan, hosted API key) (Default model; no effort scale) ----
+    modelSetting("glm", 71),
+    effortSetting("glm", 71),
     // ---- Ollama (local) (Default model; no effort scale) ----
     modelSetting("ollama", 70),
     {
@@ -2119,6 +2127,8 @@ const BACKEND_EFFORTS = {
   kimi: [],
   // Moonshot (Kimi K3) is a hosted OpenAI-compatible API — no reasoning-effort scale.
   moonshot: [],
+  // GLM (z.ai coding plan) is a hosted OpenAI-compatible API — no reasoning-effort scale.
+  glm: [],
   // Ollama local models expose no reasoning-effort control — selector hidden.
   ollama: [],
   // OpenRouter rides the same backend as ollama — no effort control either.
@@ -6950,13 +6960,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
   // `codex app-server` cold-starts much slower than Claude's Agent SDK, so it gets
   // ~3x the window. This is the escalation THRESHOLD only — the respawn/reclaim
   // BOUNDS (MAX_AUTO_RESPAWNS / MAX_AUTO_RECLAIMS) are untouched.
-  const RESPAWN_AFTER_BY_BACKEND = { codex: 6, gemini: 6, antigravity: 6, grok: 6, kimi: 6, moonshot: 6, ollama: 6, claude: 2 };
+  const RESPAWN_AFTER_BY_BACKEND = { codex: 6, gemini: 6, antigravity: 6, grok: 6, kimi: 6, moonshot: 6, glm: 6, ollama: 6, claude: 2 };
   function respawnAfterAttempts() {
     return RESPAWN_AFTER_BY_BACKEND[backendNow()] ?? 2;
   }
   // Failed (re)connect attempts ridden out as a steady "connecting" before a
   // terminal "disconnected". Backend-aware, ~3x for Codex's slower cold start.
-  const CONNECT_PATIENCE_BY_BACKEND = { codex: 12, gemini: 12, antigravity: 12, grok: 12, kimi: 12, moonshot: 12, ollama: 12, claude: 4 };
+  const CONNECT_PATIENCE_BY_BACKEND = { codex: 12, gemini: 12, antigravity: 12, grok: 12, kimi: 12, moonshot: 12, glm: 12, ollama: 12, claude: 4 };
   function connectPatienceAttempts() {
     return CONNECT_PATIENCE_BY_BACKEND[backendNow()] ?? 4;
   }
@@ -6971,7 +6981,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
   // so it gets a wider window before we treat the open socket as wedged (FIX 2).
   // Ollama gets the long handshake too: a cold model load into VRAM can take
   // tens of seconds before the first token.
-  const HANDSHAKE_MS_BY_BACKEND = { codex: 45000, gemini: 45000, antigravity: 45000, grok: 45000, kimi: 45000, moonshot: 45000, ollama: 45000, claude: 20000 };
+  const HANDSHAKE_MS_BY_BACKEND = { codex: 45000, gemini: 45000, antigravity: 45000, grok: 45000, kimi: 45000, moonshot: 45000, glm: 45000, ollama: 45000, claude: 20000 };
   function handshakeMs() {
     return HANDSHAKE_MS_BY_BACKEND[backendNow()] ?? 20000;
   }
@@ -8818,7 +8828,7 @@ function buildPanel() {
   // ChatGPT). Clicking one asks the pack to ensure that backend's orchestrator is
   // running and returns the bridge URL to connect to — the user never types a
   // port. Populated from GET /comfyui_mcp_panel/backends when settings open.
-  const BACKEND_LABELS = { claude: "Claude", codex: "ChatGPT", gemini: "Gemini", antigravity: "Antigravity", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint", copilot: "GitHub Copilot" };
+  const BACKEND_LABELS = { claude: "Claude", codex: "ChatGPT", gemini: "Gemini", antigravity: "Antigravity", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint", copilot: "GitHub Copilot" };
   // Appends a visible "(experimental)" marker to a backend's display label when
   // the readiness data flags it (b.experimental, e.g. Copilot — device-code,
   // GitHub ToS risk). Keeps picking it a deliberate, informed act everywhere a
@@ -8862,7 +8872,7 @@ function buildPanel() {
   // (GET /backends, blind to the laptop behind a remote pod) must not override it.
   let readinessFromOrchestrator = false;
   // Short per-provider hint shown under each provider row in the popup.
-  const BACKEND_HINTS = { claude: "Fable · Opus · Sonnet · Haiku", codex: "GPT-5 (Codex)", gemini: "Gemini 2.5 Pro · Flash", antigravity: "Gemini 3 · Google subscription", grok: "Grok Composer · Build", kimi: "Kimi (Moonshot)", moonshot: "Kimi K3 · Moonshot", ollama: "Local LLMs", openrouter: "MiMo · MiniMax (1M · SOTA)", lmstudio: "Local LLMs · no account", llamacpp: "Local LLMs · no account", custom: "DeepSeek · vLLM · any OpenAI-compatible API" };
+  const BACKEND_HINTS = { claude: "Fable · Opus · Sonnet · Haiku", codex: "GPT-5 (Codex)", gemini: "Gemini 2.5 Pro · Flash", antigravity: "Gemini 3 · Google subscription", grok: "Grok Composer · Build", kimi: "Kimi (Moonshot)", moonshot: "Kimi K3 · Moonshot", glm: "GLM · z.ai coding plan", ollama: "Local LLMs", openrouter: "MiMo · MiniMax (1M · SOTA)", lmstudio: "Local LLMs · no account", llamacpp: "Local LLMs · no account", custom: "DeepSeek · vLLM · any OpenAI-compatible API" };
 
   // Hint for a provider that exists but isn't usable yet — distinguishes
   // "install the CLI" from "sign in". Empty when ready or readiness is unknown.
@@ -8896,6 +8906,7 @@ function buildPanel() {
     if (b.backend === "llamacpp") return "llama-server not running — llama-server -m model.gguf --jinja -c 16384";
     if (b.backend === "openrouter") return "No OpenRouter API key — add it via API Keys (▾ menu by “connected”); takes effect immediately";
     if (b.backend === "moonshot") return "No Moonshot API key — add MOONSHOT_API_KEY via API Keys (▾ menu by “connected”); takes effect immediately";
+    if (b.backend === "glm") return "No z.ai API key — add ZAI_API_KEY via API Keys (▾ menu by “connected”); takes effect immediately";
     if (b.backend === "custom") return "No endpoint URL — Settings › Custom endpoint (works with DeepSeek, vLLM, any OpenAI-compatible API)";
     return "Not signed in — run: claude auth login";
   }
@@ -9148,6 +9159,8 @@ function buildPanel() {
     kimi: { label: "Kimi", install: "install the Kimi CLI (Moonshot)", login: "kimi" },
     // No CLI — "setup" is pasting a Moonshot platform API key (Kimi K3).
     moonshot: { label: "Kimi K3 (Moonshot, hosted)", install: "", login: "Set MOONSHOT_API_KEY via API Keys (▾ menu by “connected”)" },
+    // No CLI — "setup" is pasting a z.ai coding-plan API key (GLM).
+    glm: { label: "GLM (z.ai coding plan, hosted)", install: "", login: "Set ZAI_API_KEY via API Keys (▾ menu by “connected”)" },
     // No sign-in — "login" is pulling OUR FINE-TUNE: gemma4 QLoRA-trained on
     // 1,055 server-verified comfyui-mcp trajectories (hf.co/artokun/
     // gemma4-comfyui-mcp) — it knows this tool suite natively. :e2b fits
@@ -9191,7 +9204,7 @@ function buildPanel() {
     sub.textContent =
       "The agent runs on YOUR machine on your own AI subscription (Claude, ChatGPT, Gemini, …) or a local model (Ollama, LM Studio, llama.cpp) — no API keys. Set up a provider (Node ≥ 22), start the agent with the command below, then click Connect.";
     onboard.append(title, sub);
-    for (const id of ["claude", "codex", "gemini", "antigravity", "grok", "kimi", "moonshot", "ollama", "openrouter", "lmstudio", "llamacpp", "custom"]) {
+    for (const id of ["claude", "codex", "gemini", "antigravity", "grok", "kimi", "moonshot", "glm", "ollama", "openrouter", "lmstudio", "llamacpp", "custom"]) {
       const meta = PROVIDER_SETUP[id];
       const st = list.find((b) => b.backend === id) || {};
       const col = document.createElement("div");
@@ -9330,6 +9343,20 @@ function buildPanel() {
           `  • Or set the MOONSHOT_API_KEY environment variable and (re)start the orchestrator.
 ` +
           `Then pick Kimi K3 here again and Connect.`,
+      );
+      return;
+    }
+    // GLM (z.ai coding plan) is a hosted API — no CLI, no login flow. Same shape
+    // as Moonshot/OpenRouter: show the key-setup path inline and stop; no agent chat.
+    if (id === "glm") {
+      appendSystem(
+        `GLM (z.ai) is a hosted coding-plan API — no CLI, no login flow. Enable it by setting your z.ai API key (create one in your z.ai dashboard at https://z.ai/manage-apikey/apikey-list):
+` +
+          `  • API Keys (▾ menu next to “connected”) → set ZAI_API_KEY — masked input, stored by the orchestrator in ~/.comfyui-mcp (0600), never in ComfyUI settings. Applies immediately.
+` +
+          `  • Or set the ZAI_API_KEY environment variable and (re)start the orchestrator.
+` +
+          `Then pick GLM (z.ai) here again and Connect.`,
       );
       return;
     }
@@ -13496,7 +13523,7 @@ function buildPanel() {
   // backend's handshake window (handshakeMs()) so a healthy slow reload completes
   // on its own backoff before the guard releases — Codex's app-server handshake is
   // 45s, so its guard is ~50s; Claude keeps 28s (still > its 20s handshake).
-  const SOFT_RELOAD_GUARD_MS_BY_BACKEND = { codex: 50000, gemini: 50000, antigravity: 50000, grok: 50000, kimi: 50000, moonshot: 50000, ollama: 50000, claude: 28000 };
+  const SOFT_RELOAD_GUARD_MS_BY_BACKEND = { codex: 50000, gemini: 50000, antigravity: 50000, grok: 50000, kimi: 50000, moonshot: 50000, glm: 50000, ollama: 50000, claude: 28000 };
   function softReloadGuardMs() {
     return SOFT_RELOAD_GUARD_MS_BY_BACKEND[selectedBackend] ?? 28000;
   }
@@ -13513,7 +13540,7 @@ function buildPanel() {
   // normal cold-start handshake (handshakeMs()) so a healthy-but-slow reload is
   // never pre-empted — Codex (45s handshake) escalates at ~40s, comfortably under
   // its ~50s guard; Claude keeps 11s (under its 28s guard and > its 20s handshake).
-  const SOFT_RELOAD_ESCALATE_MS_BY_BACKEND = { codex: 40000, gemini: 40000, antigravity: 40000, grok: 40000, kimi: 40000, moonshot: 40000, ollama: 40000, claude: 11000 };
+  const SOFT_RELOAD_ESCALATE_MS_BY_BACKEND = { codex: 40000, gemini: 40000, antigravity: 40000, grok: 40000, kimi: 40000, moonshot: 40000, glm: 40000, ollama: 40000, claude: 11000 };
   function softReloadEscalateMs() {
     return SOFT_RELOAD_ESCALATE_MS_BY_BACKEND[selectedBackend] ?? 11000;
   }


### PR DESCRIPTION
Surfaces the orchestrator's existing `glm` backend (hosted z.ai coding plan — `api.z.ai/api/coding/paas/v4`, key `ZAI_API_KEY`) as a first-class provider chip, mirroring the `moonshot` (Kimi K3) hosted-api-key-no-CLI pattern (#89). Requested by a user with a z.ai coding-plan subscription who doesn't want to pay OpenRouter credits on top.

## Touch points (mirrors #89)
`__init__.py` `_BACKEND_PORTS` · `DEFAULT_BRIDGE_URL_BY_BACKEND` · SETTING_MODEL/EFFORT/BRIDGE_URL · BACKEND_SECTION/TEXT · settingsModelSelectEls · **currentSettingsBackend allowlist** · Settings `<select>` · model/effort registration · BACKEND_EFFORTS · RESPAWN/CONNECT/HANDSHAKE/SOFT_RELOAD maps · BACKEND_LABELS · BACKEND_HINTS · notReadyHint · PROVIDER_SETUP · onboarding array · requestProviderSetup inline branch. Label "GLM (z.ai)", hint "GLM · z.ai coding plan".

## Verification
- **codex review: PASS** — glm at every site incl. both known-critical ones (`_BACKEND_PORTS`, `currentSettingsBackend`), correct `ZAI_API_KEY`, no copy-paste leftovers.
- typecheck clean, 155/155 unit tests, new `browser_tests/glm-provider.spec.ts`.
- **Not live-tested** — neither maintainer has a z.ai account. Merge to main (nightly) for a z.ai coding-plan user to verify before release; the API-key console URL + default model id should be confirmed then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)