### PR TITLE
feat(model-picker): omni-search across connected providers (spec + impl)

### DIFF
--- a/docs/design/model-picker-omni-search.md
+++ b/docs/design/model-picker-omni-search.md
@@ -1,0 +1,74 @@
+# Design: Model picker → omni-search (spec)
+
+**Status:** DRAFT / spec-only — no implementation yet. Opening as a draft PR for review before building.
+
+## Motivation
+
+Today each provider has its own model **dropdown**. Two problems:
+
+1. **Truncation.** OpenRouter serves ~300–400 models; the orchestrator alphabetically-sorted then sliced to 150, so late-alphabet vendors (`z-ai/*` GLM 5.x) were unreachable — the list "stopped at moonshot/kimi-k3" ([mcp #326](https://github.com/artokun/comfyui-mcp/issues/326)). Fixed backend-side (mcp #333 raises the cap to serve the whole catalog).
+2. **A 400-item `<select>` is unusable.** Even with the full list served, a raw dropdown of hundreds of models — across several connected providers — is a wall you scroll, not something you *find* a model in.
+
+**Goal:** replace the per-provider dropdown with a single **omni-search** picker: start typing, see matching models across **all connected providers**, virtualized so hundreds of rows scroll smoothly.
+
+## The feature
+
+A searchable, keyboard-navigable model picker that:
+
+- **Searches across every connected provider at once.** Type `glm` → GLM models from OpenRouter *and* the direct z.ai provider; type `qwen` → Qwen across Ollama / OpenRouter / etc. Each row shows the model label + a **provider tag** so identical-named models are distinguishable and picking one also selects its provider.
+- **Empty query = the good defaults.** With no text, show the **pinned/recommended** models on top (the curated arena-winners already surfaced), then the current selection, then recents — not a raw dump.
+- **Infinite scroll / virtualization for long lists.** Any list > ~150 rows renders windowed (only visible rows in the DOM) and loads more on scroll, so the full OpenRouter catalog scrolls at 60fps instead of injecting ~400 `<option>` nodes at once.
+- **Keyboard-first.** ↑/↓ to move, Enter to select, Esc to close; the search input is focused on open. Fuzzy/substring match on both the model id and its label.
+
+## Design
+
+### Data — aggregate every connected backend
+
+The picker's source is the union of each **connected** provider's `listModels()`:
+
+```
+connectedProviders()               // from the readiness/backends frame
+  .flatMap(p => p.models.map(m => ({ ...m, provider: p.id, providerLabel: p.label })))
+```
+
+- Backends already expose `listModels()` (Claude/Codex/Gemini/Grok/Ollama/OpenRouter/GLM/Kimi/Moonshot/…); the panel already receives per-provider catalogs. This change **aggregates** them into one searchable index instead of showing one provider's list at a time.
+- The full lists are now available (mcp #333). Fetch lazily per provider (on connect / on first open) and cache; refresh on the readiness push.
+- Selecting a row sets **both** the model and its provider (a cross-provider pick may switch the active backend — confirm/route through the existing backend-select path).
+
+### Component
+
+Replace the `<select>` with a combobox:
+
+```
+[ search input ]                         ← focus on open, filters as you type
+─────────────────────────────
+★ Pinned / recommended         (empty query only)
+  Current: <model>  ·  <provider>
+─────────────────────────────
+<virtualized result rows>                ← windowed; row = label + provider tag
+  … loads more on scroll …
+```
+
+- **Virtualization:** a lightweight windowing pass (render only rows in view + a small buffer); no heavy dep needed for a single-column list.
+- **Filtering:** client-side substring/fuzzy over the aggregated index; cheap enough for a few hundred rows without a worker.
+- **Provider tag:** small pill (`OpenRouter`, `z.ai`, `Ollama`, …) so `glm-4.6` on OpenRouter vs the direct z.ai `glm` are distinct.
+
+### Edge cases
+
+- **One provider connected** → still works, just no cross-provider mixing; the search + virtualization still help for OpenRouter's long list.
+- **A provider mid-fetch** → show what's cached, mark the rest "loading…"; never block the picker on a slow `listModels()`.
+- **Selection that switches backend** → route through the existing provider-switch flow (it may reset/rebind the session per current rules) rather than silently swapping.
+- **No results** → "No model matches '…' across N connected providers" + a hint to connect more.
+
+## Scope / phasing
+
+1. **MVP:** aggregate connected providers → searchable combobox + virtualization + pinned-on-empty. Replaces the current dropdown.
+2. **Polish:** recents, fuzzy ranking, per-provider "loading" states, remembering last query.
+3. **Later (optional):** show *disconnected* providers' models greyed with a "connect to use" affordance.
+
+## Dependencies / open questions
+
+- Rides on **mcp #333** (full catalog served) — already up.
+- Confirm the readiness/backends frame carries each connected provider's model list (or add a lazy per-provider fetch on first open).
+- Decide whether a cross-provider pick may **switch the active backend** inline, or is limited to models of the currently-selected provider (leaning: allow the switch, routed through the existing backend-select path with its session rules).
+- Virtualization approach: hand-rolled windowing vs a tiny vendored helper — lean hand-rolled for one column.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -8408,6 +8408,12 @@ const PANEL_CSS = `
 .cmcp-modelrow .check { flex: none; width: 1rem; text-align: center; color: var(--p-primary-color, #60a5fa); visibility: hidden; }
 .cmcp-modelrow .check.on { visibility: visible; }
 .cmcp-modelempty { padding: 0.5rem; font-size: 0.75rem; color: var(--p-text-muted-color, #a1a1aa); }
+/* Recently-used section (non-virtualized; bounded to the last few picks). Rows
+   flow normally (override the absolute positioning the virtualized list uses). */
+.cmcp-modelrecents .cmcp-modelrow { position: static; }
+.cmcp-modelrecent-x { flex: none; margin-left: 0.15rem; padding: 0 0.2rem; background: none; border: none;
+  color: var(--p-text-muted-color, #a1a1aa); cursor: pointer; opacity: 0.55; font-size: 0.7rem; line-height: 1; }
+.cmcp-modelrecent-x:hover { opacity: 1; color: var(--p-text-color, #e4e4e7); }
 `;
 
 let styleInjected = false;
@@ -9975,6 +9981,11 @@ function buildPanel() {
   modelSearchInput.setAttribute("aria-label", "Search models across connected providers");
   const modelSearchCap = document.createElement("div");
   modelSearchCap.className = "cmcp-modelsearch-cap";
+  // Recently-used section (non-virtualized; bounded to RECENTS_CAP). Shown only in
+  // the empty-query view, above the caption + recommended list.
+  const modelRecents = document.createElement("div");
+  modelRecents.className = "cmcp-modelrecents";
+  modelRecents.hidden = true;
   const modelResults = document.createElement("div");
   modelResults.className = "cmcp-modelresults";
   const modelSizer = document.createElement("div");
@@ -9983,7 +9994,50 @@ function buildPanel() {
   const modelEmpty = document.createElement("div");
   modelEmpty.className = "cmcp-modelempty";
   modelEmpty.hidden = true;
-  modelSearchWrap.append(modelSearchInput, modelSearchCap, modelResults, modelEmpty);
+  modelSearchWrap.append(modelSearchInput, modelRecents, modelSearchCap, modelResults, modelEmpty);
+
+  // ---- Recently-used models (persisted across sessions) --------------------
+  // Keyed per provider+id (same dedupe key as aggregatedModels) so identical model
+  // ids across providers stay distinct. Display fields (label/providerLabel/small)
+  // are stored too, so a recent still renders even if its provider isn't currently
+  // connected (its live catalog absent).
+  const RECENTS_KEY = "comfyui-mcp.panel.modelRecents";
+  const RECENTS_CAP = 8;
+  const recentKeyOf = (provider, id) => provider + " " + id;
+  function loadRecents() {
+    try {
+      const arr = JSON.parse(window.localStorage.getItem(RECENTS_KEY) ?? "[]");
+      return Array.isArray(arr)
+        ? arr.filter((r) => r && typeof r.id === "string" && typeof r.provider === "string")
+        : [];
+    } catch {
+      return [];
+    }
+  }
+  function saveRecents(list) {
+    try {
+      window.localStorage.setItem(RECENTS_KEY, JSON.stringify(list.slice(0, RECENTS_CAP)));
+    } catch {
+      // localStorage unavailable — recents are session-only.
+    }
+  }
+  function pushRecent(m) {
+    if (!m || !m.provider || !m.id) return;
+    const key = recentKeyOf(m.provider, m.id);
+    const list = loadRecents().filter((r) => recentKeyOf(r.provider, r.id) !== key);
+    list.unshift({
+      provider: m.provider,
+      providerLabel: m.providerLabel || BACKEND_LABELS[m.provider] || m.provider,
+      id: m.id,
+      label: m.label || m.id,
+      small: m.small || "",
+    });
+    saveRecents(list);
+  }
+  function removeRecent(provider, id) {
+    const key = recentKeyOf(provider, id);
+    saveRecents(loadRecents().filter((r) => recentKeyOf(r.provider, r.id) !== key));
+  }
 
   /** The union of every connected/known provider's catalog, each row tagged with
    *  its provider. Active backend first (from the freshest live modelCatalog);
@@ -10077,6 +10131,7 @@ function buildPanel() {
    *  silent cross-provider state swap. A same-provider pick mirrors the old handler. */
   function pickModelRow(m) {
     modelPop.hidden = true;
+    pushRecent(m); // an actual selection — record it for the "Recently used" section
     const activeBk = connectedBackend || selectedBackend;
     if (m.provider && m.provider !== activeBk) {
       // Seed the target provider's group so seedPrefsForBackendSwitch adopts this
@@ -10107,12 +10162,8 @@ function buildPanel() {
     }
   }
 
-  /** Build one absolutely-positioned result row for the virtualized window. */
-  function buildModelRow(m, idx) {
-    const el = document.createElement("button");
-    el.type = "button";
-    el.className = "cmcp-modelrow" + (idx === modelActiveIdx ? " active" : "");
-    el.style.top = idx * MODEL_ROW_H + "px";
+  /** Fill a row element with the shared label + description + provider-tag layout. */
+  function modelRowInner(el, m) {
     const lbl = document.createElement("span");
     lbl.className = "lbl";
     lbl.textContent = m.label;
@@ -10127,15 +10178,82 @@ function buildPanel() {
     tag.className = "cmcp-provtag";
     tag.textContent = m.providerLabel;
     el.appendChild(tag);
+    el.title = `${m.label}${m.small ? " — " + m.small : ""} · ${m.providerLabel}`;
+  }
+
+  /** Build one absolutely-positioned result row for the virtualized window. */
+  function buildModelRow(m, idx) {
+    const el = document.createElement("button");
+    el.type = "button";
+    el.className = "cmcp-modelrow" + (idx === modelActiveIdx ? " active" : "");
+    el.style.top = idx * MODEL_ROW_H + "px";
+    modelRowInner(el, m);
     const c = document.createElement("i");
     c.className = "pi pi-check check" + (isModelRowSelected(m) ? " on" : "");
     el.appendChild(c);
-    el.title = `${m.label}${m.small ? " — " + m.small : ""} · ${m.providerLabel}`;
     el.addEventListener("mousedown", (mev) => {
       mev.preventDefault();
       pickModelRow(m);
     });
     return el;
+  }
+
+  /** Build one recently-used row (normal flow) with a secondary × remove control.
+   *  The row is a <div> (role button) so the real <button> × can nest legally; the
+   *  × is NOT in the ↑/↓ selection path — clicking it removes the entry and repaints
+   *  without selecting the model or closing the picker. */
+  function buildRecentRow(m) {
+    const el = document.createElement("div");
+    el.className = "cmcp-modelrow";
+    el.setAttribute("role", "button");
+    modelRowInner(el, m);
+    const c = document.createElement("i");
+    c.className = "pi pi-check check" + (isModelRowSelected(m) ? " on" : "");
+    el.appendChild(c);
+    const x = document.createElement("button");
+    x.type = "button";
+    x.className = "cmcp-modelrecent-x";
+    x.title = "Remove from recently used";
+    x.setAttribute("aria-label", "Remove from recently used");
+    const xi = document.createElement("i");
+    xi.className = "pi pi-times";
+    x.appendChild(xi);
+    x.addEventListener("mousedown", (mev) => {
+      mev.preventDefault();
+      mev.stopPropagation(); // must NOT select the model or close the picker
+      removeRecent(m.provider, m.id);
+      renderModelResults();
+    });
+    el.appendChild(x);
+    el.addEventListener("mousedown", (mev) => {
+      mev.preventDefault();
+      pickModelRow(m);
+    });
+    return el;
+  }
+
+  /** (Re)render the Recently-used section for the empty-query view. Returns the
+   *  number of recents shown (0 when hidden — non-empty query or no recents). */
+  function renderModelRecents(all) {
+    modelRecents.textContent = "";
+    const recents = loadRecents();
+    if (modelQuery.trim() || !recents.length) {
+      modelRecents.hidden = true;
+      return 0;
+    }
+    modelRecents.hidden = false;
+    const h = document.createElement("div");
+    h.className = "cmcp-pop-section";
+    h.textContent = "Recently used";
+    modelRecents.appendChild(h);
+    // Prefer the live aggregated row (fresh label/effort) when the provider is
+    // connected; otherwise fall back to the stored display fields.
+    const byKey = new Map(all.map((m) => [recentKeyOf(m.provider, m.id), m]));
+    for (const r of recents) {
+      const m = byKey.get(recentKeyOf(r.provider, r.id)) || { ...r };
+      modelRecents.appendChild(buildRecentRow(m));
+    }
+    return recents.length;
   }
 
   /** Render only the rows in view (+ buffer); positions come from the fixed row
@@ -10154,25 +10272,45 @@ function buildPanel() {
   /** Recompute the ordered row set for the current query and repaint the window. */
   function renderModelResults() {
     const all = aggregatedModels();
+    const recentCount = renderModelRecents(all); // empty-query section above the list
     const filtered = filterModels(all, modelQuery);
-    modelCurrentRows = filtered === null ? recommendedModels(all) : filtered;
+    const isSearch = filtered !== null;
+    if (isSearch) {
+      modelCurrentRows = filtered;
+    } else {
+      // Empty query: recommended list, minus anything already shown in Recently used
+      // (so a model never appears twice).
+      const recentKeys = new Set(recentCount ? loadRecents().map((r) => recentKeyOf(r.provider, r.id)) : []);
+      modelCurrentRows = recommendedModels(all).filter((m) => !recentKeys.has(recentKeyOf(m.provider, m.id)));
+    }
     if (modelActiveIdx >= modelCurrentRows.length) modelActiveIdx = modelCurrentRows.length - 1;
     if (modelActiveIdx < 0) modelActiveIdx = 0;
     const providerCount = new Set(all.map((m) => m.provider)).size;
     if (!modelCurrentRows.length) {
-      modelEmpty.hidden = false;
-      modelEmpty.textContent =
-        `No model matches “${modelQuery.trim()}” across ${providerCount} connected provider${providerCount === 1 ? "" : "s"}` +
-        (providerCount <= 1 ? " — connect more to search wider." : ".");
       modelResults.style.display = "none";
-      modelSearchCap.textContent = "";
+      modelSizer.style.height = "0px";
+      renderModelWindow();
+      if (isSearch) {
+        modelEmpty.hidden = false;
+        modelEmpty.textContent =
+          `No model matches “${modelQuery.trim()}” across ${providerCount} connected provider${providerCount === 1 ? "" : "s"}` +
+          (providerCount <= 1 ? " — connect more to search wider." : ".");
+        modelSearchCap.textContent = "";
+      } else {
+        // Empty query with nothing left to recommend (e.g. all models are recents).
+        modelEmpty.hidden = recentCount > 0;
+        if (!recentCount) modelEmpty.textContent = "No models yet — connect a provider to search.";
+        modelSearchCap.textContent = "";
+      }
       return;
     }
     modelEmpty.hidden = true;
     modelResults.style.display = "";
-    modelSearchCap.textContent = filtered === null
-      ? `Recommended · ${modelCurrentRows.length} model${modelCurrentRows.length === 1 ? "" : "s"} across ${providerCount} provider${providerCount === 1 ? "" : "s"}`
-      : `${modelCurrentRows.length} result${modelCurrentRows.length === 1 ? "" : "s"}`;
+    modelSearchCap.textContent = isSearch
+      ? `${modelCurrentRows.length} result${modelCurrentRows.length === 1 ? "" : "s"}`
+      : recentCount
+        ? "Recommended"
+        : `Recommended · ${modelCurrentRows.length} model${modelCurrentRows.length === 1 ? "" : "s"} across ${providerCount} provider${providerCount === 1 ? "" : "s"}`;
     modelSizer.style.height = modelCurrentRows.length * MODEL_ROW_H + "px";
     renderModelWindow();
   }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -8384,6 +8384,30 @@ const PANEL_CSS = `
 .cmcp-popover-item .check.on { visibility: visible; }
 .cmcp-chip .pi-angle-down { font-size: 0.5625rem; opacity: 0.7; }
 .cmcp-chip .dim { opacity: 0.65; }
+/* Omni-search model picker (aggregates every connected provider's catalog into
+   one virtualized, keyboard-navigable list). Row height is FIXED at 30px so the
+   windowing math (MODEL_ROW_H) can position rows absolutely without measuring. */
+.cmcp-modelsearch { display: flex; flex-direction: column; }
+.cmcp-modelsearch-input { margin: 0.25rem 0.5rem; padding: 0.3rem 0.5rem; border-radius: 6px;
+  border: 1px solid var(--p-content-border-color, #3f3f46); background: var(--p-surface-900, #18181b);
+  color: var(--p-text-color, #e4e4e7); font-size: 0.8rem; }
+.cmcp-modelsearch-input:focus { outline: none; border-color: var(--p-focus-ring-color, #60a5fa); }
+.cmcp-modelsearch-cap { padding: 0.125rem 0.5rem 0.25rem; font-size: 0.625rem; color: var(--p-text-muted-color, #a1a1aa); }
+.cmcp-modelresults { position: relative; overflow-y: auto; max-height: 15rem; }
+.cmcp-modelsizer { position: relative; width: 100%; }
+.cmcp-modelrow { position: absolute; left: 0; right: 0; height: 30px; display: flex; align-items: center;
+  gap: 0.375rem; padding: 0 0.5rem; background: none; border: none; color: inherit; font: inherit;
+  text-align: left; cursor: pointer; box-sizing: border-box; }
+.cmcp-modelrow:hover, .cmcp-modelrow.active { background: var(--p-surface-700, #3f3f46); }
+.cmcp-modelrow .lbl { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cmcp-modelrow .sub { flex: none; color: var(--p-text-muted-color, #a1a1aa); font-size: 0.6875rem; overflow: hidden;
+  text-overflow: ellipsis; white-space: nowrap; max-width: 40%; }
+.cmcp-provtag { flex: none; font-size: 0.5625rem; text-transform: uppercase; letter-spacing: 0.03em;
+  padding: 0.05rem 0.35rem; border-radius: 999px; background: var(--p-surface-800, #27272a);
+  color: var(--p-text-muted-color, #a1a1aa); border: 1px solid var(--p-content-border-color, #3f3f46); }
+.cmcp-modelrow .check { flex: none; width: 1rem; text-align: center; color: var(--p-primary-color, #60a5fa); visibility: hidden; }
+.cmcp-modelrow .check.on { visibility: visible; }
+.cmcp-modelempty { padding: 0.5rem; font-size: 0.75rem; color: var(--p-text-muted-color, #a1a1aa); }
 `;
 
 let styleInjected = false;
@@ -9926,6 +9950,275 @@ function buildPanel() {
   modelPop.className = "cmcp-popover";
   modelPop.hidden = true;
 
+  // ---- Omni-search model picker -------------------------------------------
+  // Replaces the flat per-provider model list with a single searchable, keyboard-
+  // navigable combobox over the UNION of every connected provider's catalog. The
+  // aggregation source is the same per-backend catalog cache the Settings dialog
+  // reads (settingsBackendState.modelsByBackend) plus the live modelCatalog for the
+  // active backend, so it stays fully client-side over already-received data.
+  const MODEL_ROW_H = 30; // must match .cmcp-modelrow height in PANEL_CSS
+  const MODEL_ROW_BUF = 4; // rows rendered above/below the viewport
+  let modelQuery = "";
+  let modelActiveIdx = 0;
+  let modelCurrentRows = []; // the flattened, ordered rows the keyboard nav walks
+  let modelWindowRaf = 0;
+
+  // Persistent search widget nodes — created ONCE and re-parented by buildModelPop
+  // (which wipes the popover on each repaint). Keeping them stable preserves the
+  // input value + listeners across the loadBackends() repaint that follows an open.
+  const modelSearchWrap = document.createElement("div");
+  modelSearchWrap.className = "cmcp-modelsearch";
+  const modelSearchInput = document.createElement("input");
+  modelSearchInput.type = "text";
+  modelSearchInput.className = "cmcp-modelsearch-input";
+  modelSearchInput.placeholder = "Search models across connected providers…";
+  modelSearchInput.setAttribute("aria-label", "Search models across connected providers");
+  const modelSearchCap = document.createElement("div");
+  modelSearchCap.className = "cmcp-modelsearch-cap";
+  const modelResults = document.createElement("div");
+  modelResults.className = "cmcp-modelresults";
+  const modelSizer = document.createElement("div");
+  modelSizer.className = "cmcp-modelsizer";
+  modelResults.appendChild(modelSizer);
+  const modelEmpty = document.createElement("div");
+  modelEmpty.className = "cmcp-modelempty";
+  modelEmpty.hidden = true;
+  modelSearchWrap.append(modelSearchInput, modelSearchCap, modelResults, modelEmpty);
+
+  /** The union of every connected/known provider's catalog, each row tagged with
+   *  its provider. Active backend first (from the freshest live modelCatalog);
+   *  then the other cached backends. Deduped per provider+id (identical model ids
+   *  across providers stay DISTINCT so the tag disambiguates them). */
+  function aggregatedModels() {
+    const activeBk = connectedBackend || selectedBackend;
+    const rows = [];
+    const seen = new Set();
+    const add = (bk, list) => {
+      if (!bk || !Array.isArray(list)) return;
+      const plabel = BACKEND_LABELS[bk] || bk;
+      for (const m of list) {
+        const key = bk + " " + m.id;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        rows.push({ ...m, provider: bk, providerLabel: plabel });
+      }
+    };
+    add(activeBk, modelCatalog);
+    for (const bk of Object.keys(settingsBackendState.modelsByBackend)) {
+      if (bk === activeBk) continue;
+      add(bk, settingsBackendState.modelsByBackend[bk]);
+    }
+    return rows;
+  }
+
+  /** Substring/subsequence filter over id + label + provider. Returns null for an
+   *  empty query (the caller then shows the recommended ordering instead). */
+  function filterModels(all, q) {
+    const query = q.trim().toLowerCase();
+    if (!query) return null;
+    const terms = query.split(/\s+/).filter(Boolean);
+    const activeBk = connectedBackend || selectedBackend;
+    const scored = [];
+    for (const m of all) {
+      const id = String(m.id).toLowerCase();
+      const label = String(m.label).toLowerCase();
+      const hay = id + " " + label + " " + String(m.providerLabel).toLowerCase();
+      let ok = true;
+      let score = 0;
+      for (const t of terms) {
+        const at = hay.indexOf(t);
+        if (at < 0) { ok = false; break; }
+        // Prefer earlier hits, prefix matches on id/label, and the active provider.
+        score += at + (id.startsWith(t) || label.startsWith(t) ? 0 : 40);
+      }
+      if (!ok) continue;
+      if (m.provider !== activeBk) score += 5;
+      scored.push({ m, score });
+    }
+    scored.sort((a, b) => a.score - b.score);
+    return scored.map((s) => s.m);
+  }
+
+  /** Empty-query ordering: current selection first, then the active provider's
+   *  catalog (the immediately-usable "recommended" set), then everything else. No
+   *  curated arena-winner list exists client-side, so the active provider stands
+   *  in as the recommended surface. */
+  function recommendedModels(all) {
+    const activeBk = connectedBackend || selectedBackend;
+    const out = [];
+    const pushed = new Set();
+    const take = (m) => {
+      const key = m.provider + " " + m.id;
+      if (pushed.has(key)) return;
+      pushed.add(key);
+      out.push(m);
+    };
+    if (!prefs.modelAuto && prefs.model) {
+      const cur = all.find((m) => m.provider === activeBk && m.id === prefs.model) || all.find((m) => m.id === prefs.model);
+      if (cur) take(cur);
+    }
+    for (const m of all) if (m.provider === activeBk) take(m);
+    for (const m of all) take(m);
+    return out;
+  }
+
+  /** Selected-mark test mirroring the old flat list: an explicit pick, or, in Auto
+   *  mode, the model the orchestrator reports as loaded on the active provider. */
+  function isModelRowSelected(m) {
+    const activeBk = connectedBackend || selectedBackend;
+    if (m.provider !== activeBk) return false;
+    if (!prefs.modelAuto) return m.id === prefs.model;
+    return !!orchestratorCurrentModel && m.id === orchestratorCurrentModel;
+  }
+
+  /** Commit a picked row. A row from a DIFFERENT provider routes through the
+   *  existing backend-switch path (connectBackend) after persisting the choice into
+   *  that provider's Settings group, so the post-handshake push adopts it — never a
+   *  silent cross-provider state swap. A same-provider pick mirrors the old handler. */
+  function pickModelRow(m) {
+    modelPop.hidden = true;
+    const activeBk = connectedBackend || selectedBackend;
+    if (m.provider && m.provider !== activeBk) {
+      // Seed the target provider's group so seedPrefsForBackendSwitch adopts this
+      // model, then run the full switch flow (fresh orchestrator + session rules).
+      if (SETTING_MODEL[m.provider]) setSetting(SETTING_MODEL[m.provider], m.id);
+      appendSystem(`Model → ${m.label} · switching to ${m.providerLabel}…`);
+      void connectBackend(m.provider);
+      return;
+    }
+    prefs.model = m.id;
+    prefs.modelAuto = false; // an explicit pick clears the Auto state
+    prefs.userSet = true;
+    const before = prefs.effort;
+    const avail = effortsForModel(m.id);
+    if (prefs.effort && !avail.includes(prefs.effort)) {
+      prefs.effort = avail.length ? nearestInList(prefs.effort, avail) : undefined;
+    }
+    savePrefs(prefs);
+    const bk = connectedBackend || selectedBackend;
+    setSetting(SETTING_MODEL[bk], m.id);
+    setSetting(SETTING_EFFORT[bk], prefs.effort ?? "");
+    refreshModelChip();
+    client?.sendFrame?.({ type: "set_options", model: m.id, effort: prefs.effort ?? null });
+    if (prefs.effort && prefs.effort !== before) {
+      appendSystem(`Model → ${m.label}. Reasoning effort set to ${effortMeta(prefs.effort).label} (nearest level this model supports).`);
+    } else {
+      appendSystem(`Model → ${m.label}.`);
+    }
+  }
+
+  /** Build one absolutely-positioned result row for the virtualized window. */
+  function buildModelRow(m, idx) {
+    const el = document.createElement("button");
+    el.type = "button";
+    el.className = "cmcp-modelrow" + (idx === modelActiveIdx ? " active" : "");
+    el.style.top = idx * MODEL_ROW_H + "px";
+    const lbl = document.createElement("span");
+    lbl.className = "lbl";
+    lbl.textContent = m.label;
+    el.appendChild(lbl);
+    if (m.small) {
+      const sub = document.createElement("span");
+      sub.className = "sub";
+      sub.textContent = m.small;
+      el.appendChild(sub);
+    }
+    const tag = document.createElement("span");
+    tag.className = "cmcp-provtag";
+    tag.textContent = m.providerLabel;
+    el.appendChild(tag);
+    const c = document.createElement("i");
+    c.className = "pi pi-check check" + (isModelRowSelected(m) ? " on" : "");
+    el.appendChild(c);
+    el.title = `${m.label}${m.small ? " — " + m.small : ""} · ${m.providerLabel}`;
+    el.addEventListener("mousedown", (mev) => {
+      mev.preventDefault();
+      pickModelRow(m);
+    });
+    return el;
+  }
+
+  /** Render only the rows in view (+ buffer); positions come from the fixed row
+   *  height, so hundreds of models never hit the DOM at once. */
+  function renderModelWindow() {
+    modelWindowRaf = 0;
+    const rows = modelCurrentRows;
+    const scrollTop = modelResults.scrollTop;
+    const h = modelResults.clientHeight || 240;
+    const start = Math.max(0, Math.floor(scrollTop / MODEL_ROW_H) - MODEL_ROW_BUF);
+    const end = Math.min(rows.length, Math.ceil((scrollTop + h) / MODEL_ROW_H) + MODEL_ROW_BUF);
+    for (const el of Array.from(modelResults.querySelectorAll(".cmcp-modelrow"))) el.remove();
+    for (let i = start; i < end; i++) modelResults.appendChild(buildModelRow(rows[i], i));
+  }
+
+  /** Recompute the ordered row set for the current query and repaint the window. */
+  function renderModelResults() {
+    const all = aggregatedModels();
+    const filtered = filterModels(all, modelQuery);
+    modelCurrentRows = filtered === null ? recommendedModels(all) : filtered;
+    if (modelActiveIdx >= modelCurrentRows.length) modelActiveIdx = modelCurrentRows.length - 1;
+    if (modelActiveIdx < 0) modelActiveIdx = 0;
+    const providerCount = new Set(all.map((m) => m.provider)).size;
+    if (!modelCurrentRows.length) {
+      modelEmpty.hidden = false;
+      modelEmpty.textContent =
+        `No model matches “${modelQuery.trim()}” across ${providerCount} connected provider${providerCount === 1 ? "" : "s"}` +
+        (providerCount <= 1 ? " — connect more to search wider." : ".");
+      modelResults.style.display = "none";
+      modelSearchCap.textContent = "";
+      return;
+    }
+    modelEmpty.hidden = true;
+    modelResults.style.display = "";
+    modelSearchCap.textContent = filtered === null
+      ? `Recommended · ${modelCurrentRows.length} model${modelCurrentRows.length === 1 ? "" : "s"} across ${providerCount} provider${providerCount === 1 ? "" : "s"}`
+      : `${modelCurrentRows.length} result${modelCurrentRows.length === 1 ? "" : "s"}`;
+    modelSizer.style.height = modelCurrentRows.length * MODEL_ROW_H + "px";
+    renderModelWindow();
+  }
+
+  /** Scroll the keyboard-active row into view within the windowed list. */
+  function ensureModelRowVisible() {
+    const top = modelActiveIdx * MODEL_ROW_H;
+    const bottom = top + MODEL_ROW_H;
+    const viewTop = modelResults.scrollTop;
+    const viewBottom = viewTop + (modelResults.clientHeight || 240);
+    if (top < viewTop) modelResults.scrollTop = top;
+    else if (bottom > viewBottom) modelResults.scrollTop = bottom - (modelResults.clientHeight || 240);
+  }
+
+  modelResults.addEventListener("scroll", () => {
+    if (modelWindowRaf) return;
+    modelWindowRaf = requestAnimationFrame(renderModelWindow);
+  });
+  modelSearchInput.addEventListener("input", () => {
+    modelQuery = modelSearchInput.value;
+    modelActiveIdx = 0;
+    modelResults.scrollTop = 0;
+    renderModelResults();
+  });
+  modelSearchInput.addEventListener("keydown", (ev) => {
+    if (ev.key === "ArrowDown") {
+      ev.preventDefault();
+      if (modelActiveIdx < modelCurrentRows.length - 1) modelActiveIdx++;
+      ensureModelRowVisible();
+      renderModelWindow();
+    } else if (ev.key === "ArrowUp") {
+      ev.preventDefault();
+      if (modelActiveIdx > 0) modelActiveIdx--;
+      ensureModelRowVisible();
+      renderModelWindow();
+    } else if (ev.key === "Enter") {
+      ev.preventDefault();
+      const m = modelCurrentRows[modelActiveIdx];
+      if (m) pickModelRow(m);
+    } else if (ev.key === "Escape") {
+      ev.preventDefault();
+      modelPop.hidden = true;
+      modelChip.focus();
+    }
+  });
+
   function buildModelPop() {
     modelPop.textContent = "";
     const section = (label) => {
@@ -10029,39 +10322,14 @@ function buildPanel() {
       }
     }
 
+    // Omni-search across every connected provider's catalog (virtualized). The
+    // search widget is a persistent node re-parented here; renderModelResults()
+    // repaints its rows for the current query. Picking a row selects the model AND
+    // its provider (a cross-provider pick routes through the switch flow).
     section("Model");
-    for (const m of modelCatalog) {
-      // Checked when explicitly picked — or, in Auto mode, on the model the
-      // orchestrator reports as actually loaded (so Auto isn't a blank column).
-      const isCurrent =
-        (m.id === prefs.model && !prefs.modelAuto) ||
-        (prefs.modelAuto && !!orchestratorCurrentModel && m.id === orchestratorCurrentModel);
-      item({ label: m.label, small: m.small }, isCurrent, () => {
-        prefs.model = m.id;
-        prefs.modelAuto = false; // an explicit pick clears the Auto state
-        prefs.userSet = true;
-        // SNAP the effort to the nearest level the new model supports (don't wipe
-        // it silently); only clear if the model has no effort control at all.
-        const before = prefs.effort;
-        const avail = effortsForModel(m.id);
-        if (prefs.effort && !avail.includes(prefs.effort)) {
-          prefs.effort = avail.length ? nearestInList(prefs.effort, avail) : undefined;
-        }
-        savePrefs(prefs);
-        // Keep the ACTIVE backend's Settings group in sync with the picker.
-        const bk = connectedBackend || selectedBackend;
-        setSetting(SETTING_MODEL[bk], m.id);
-        setSetting(SETTING_EFFORT[bk], prefs.effort ?? "");
-        refreshModelChip();
-        modelPop.hidden = true;
-        client?.sendFrame?.({ type: "set_options", model: m.id, effort: prefs.effort ?? null });
-        if (prefs.effort && prefs.effort !== before) {
-          appendSystem(`Model → ${m.label}. Reasoning effort set to ${effortMeta(prefs.effort).label} (nearest level this model supports).`);
-        } else {
-          appendSystem(`Model → ${m.label}.`);
-        }
-      });
-    }
+    modelSearchInput.value = modelQuery;
+    modelPop.appendChild(modelSearchWrap);
+    renderModelResults();
 
     const efforts = effortsForModel(prefs.model);
     if (efforts.length) {
@@ -10164,13 +10432,23 @@ function buildPanel() {
   modelChip.addEventListener("click", (e) => {
     e.stopPropagation();
     if (modelPop.hidden) {
+      modelQuery = "";
+      modelActiveIdx = 0;
       buildModelPop();
       modelPop.hidden = false;
+      // Now that the results container is measurable, repaint the window at the
+      // real height and focus the search input (keyboard-first).
+      renderModelResults();
+      setTimeout(() => modelSearchInput.focus(), 0);
       // Refresh provider discovery (running status) in the background; rebuild the
       // popup if it's still open and the list changed, so the PROVIDER section is
-      // current without blocking the open.
+      // current without blocking the open. Preserve search focus across the repaint.
       void loadBackends().then(() => {
-        if (!modelPop.hidden) buildModelPop();
+        if (!modelPop.hidden) {
+          const refocus = document.activeElement === modelSearchInput;
+          buildModelPop();
+          if (refocus) modelSearchInput.focus();
+        }
       });
     } else {
       modelPop.hidden = true;


### PR DESCRIPTION
**Draft** — spec + implementation of the omni-search model picker. Still a draft for @artokun's review (not merged, not released).

## Design (spec)

`docs/design/model-picker-omni-search.md` specs replacing the per-provider dropdown with a single **omni-search** picker:
- **Search across all connected providers** as you type (label + provider tag), so `glm` surfaces OpenRouter *and* direct z.ai models
- **Infinite scroll / virtualization** for lists >150 so OpenRouter's ~400-model catalog scrolls smoothly instead of dumping ~400 `<option>`s
- **Pinned/recommended on empty query**, keyboard-first, fuzzy match

Rides on **mcp #333** (raises the OpenRouter cap so the full catalog is served — already up).

## Implementation

**File touched:** `web/js/comfyui-mcp-panel.js` (two commits: omni-search +312/−34, then Recently-used +155/−17). No new deps, no version bump, no `pyproject`/`PANEL_VERSION` change — self-contained, registry-safe. All new code lives inside the `buildPanel()` closure (no new module-scope declarations).

Replaces the composer model popover's flat, single-provider **Model** list with an omni-search combobox. The **Provider** and **Effort** sections of the popover are unchanged.

### Aggregation (client-side)
- New `aggregatedModels()` builds the union of every connected/known provider's catalog from the data the panel already holds: `settingsBackendState.modelsByBackend` (the same per-backend cache the Settings dialog reads) plus the live `modelCatalog` for the active backend.
- Each row is tagged with `provider` + `providerLabel`; rows are deduped per `provider+id`, so identical model ids across providers stay **distinct** and the provider pill disambiguates them.
- Fully local over already-received catalogs — no new fetches.

### Search / ordering
- `filterModels()` — multi-term substring match over id + label + provider, ranked by hit position, prefix matches, and active-provider preference. Empty query → `recommendedModels()`: current selection first, then the active provider's catalog (the immediately-usable "recommended" set), then everything else. (There is no pre-existing curated arena-winner list client-side, so the active provider stands in as the recommended surface — see Open questions.)

### Recently used
- The empty-query view shows a **Recently used** section at the very top (above Recommended). A model is recorded when it's actually selected from the picker (`pickModelRow` → `pushRecent`). Recents persist across sessions in `localStorage` (`comfyui-mcp.panel.modelRecents`), keyed per `provider+id` (the same dedupe key aggregation uses, so identical ids across providers stay distinct), most-recent first, capped at 8. Display fields (label/tag/desc) are stored alongside, so a recent still renders — and can be re-picked via the switch flow — even when its provider isn't currently connected.
- Each recent row uses the shared row layout (label + provider tag) plus a small **×** aligned right. The × removes just that entry (updates `localStorage` + repaints) and does **not** select the model or close the picker (`stopPropagation`); it is a secondary control, not part of the ↑/↓ path. The recents block is non-virtualized (bounded to ≤8) and is omitted entirely (no header) when there are none. Recents are excluded from the Recommended list below so a model never appears twice.

### Virtualization (hand-rolled, single column)
- Fixed 30px rows (`MODEL_ROW_H`, matched in CSS). A sizer div carries the full scroll height; only the visible window (+4-row buffer) is rendered, repositioned absolutely on scroll via `requestAnimationFrame`. Hundreds of models never hit the DOM at once.

### Keyboard-first
- Search input focused on open; ↑/↓ move the active row (with scroll-into-view), Enter selects, Esc closes and returns focus to the chip.

### Selection / provider routing
- Same-provider pick mirrors the old handler (persists model + effort to the active backend's Settings group, pushes `set_options`).
- **Cross-provider** pick persists the chosen model into the target provider's `SETTING_MODEL[provider]` group, then routes through the existing `connectBackend()` switch flow, so `seedPrefsForBackendSwitch` adopts it and the session/switch rules apply. No silent cross-provider state swap; the chip does not revert to `claude`.

### Persistence of the widget across repaints
- The search input + results container are persistent nodes re-parented by `buildModelPop()` (which wipes the popover on each repaint), so the query and listeners survive the `loadBackends()` repaint that follows an open; focus is restored if it was in the search box.

## Verified
- Parses cleanly as an **ES module** (`node --check` on a `.mjs` copy) — no duplicate top-level declarations.
- Full unit suite green: `node --test browser_tests/unit/*.test.mjs` → **162 pass / 0 fail**.
- Static review of the DOM wiring, virtualization math, keyboard handlers, and the cross-provider switch path.

## Could NOT verify
- **No live browser test** (no Chrome/live ComfyUI session available in this environment). The virtualization, focus handling, recents ×/persistence, and cross-provider switch were reviewed statically but not exercised in-browser. Recommend a quick manual pass: open the picker, type across ≥2 connected providers, scroll OpenRouter's long list, pick a model from a non-active provider to confirm the switch flow, then reopen and confirm it appears under **Recently used** and its × removes it (without selecting/closing).

## Open questions / risks for @artokun
- **"Recommended" on empty query** currently = current selection + active-provider catalog. If you want a real curated pin list (arena winners), that data structure doesn't exist client-side yet and would need to be added/served.
- Aggregation only includes providers whose catalog the panel has **already received** this session (connected at least once). Disconnected providers' models aren't searchable — matches the spec's MVP ("later/optional" greyed disconnected providers).
- Effort section still keys off the active provider's `modelCatalog`; for a cross-provider pick, effort reconciles after the switch handshake (existing `applyModelCatalog` path), not at pick time.
