### PR TITLE
feat(hello): send panel_version for report version-stamping

### DIFF
--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7386,6 +7386,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           type: "hello",
           tab_id: workflowTabId(),
           title: getWorkflowTitle(),
+          // Our build version, so the orchestrator can auto-stamp it into the
+          // agent's ENV block (bug reports get version-pinned without digging).
+          panel_version: PANEL_VERSION,
           backend,
           // Blind content mode (issue #90): the orchestrator spawns this tab's
           // comfyui tool server with pixel-withholding env when true.


### PR DESCRIPTION
Adds `panel_version: PANEL_VERSION` to the panel's `hello` frame so the orchestrator can auto-stamp the panel version into the agent's ENVIRONMENT block — pairing with comfyui-mcp #339 so every via-panel bug report is version-pinned (mcp + panel) without the agent digging.

One line, no version bump, no `pyproject.toml` change (so no Registry publish fires).

Pairs with: comfyui-mcp#339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)