### PR TITLE
Registry listing: fix mojibake description + claim local/offline tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.9.7] - 2026-07-24
+
+### Fixed
+- **Registry listing description rendered mojibake.** The em dash in
+  `pyproject.toml`'s `description` had been decoded as CP1252 and re-encoded as
+  UTF-8, leaving a literal mojibake sequence (U+00E2 U+20AC U+201D) — visible
+  on the Comfy Registry listing and in
+  ComfyUI-Manager search, at the moment a user decides whether to install.
+
+### Changed
+- Registry `Tags` now claim `local`, `local-first`, `offline`, `self-hosted`,
+  `ollama`, `local-llm`, `no-api-key`, and `gemini`. The listing advertised
+  Claude/ChatGPT but nothing about running locally — the differentiators for
+  anyone browsing for a local option.
+
 ## [0.9.6] - 2026-07-19
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,6 @@ Discord = "https://discord.gg/cW9arBhzCu"
 [tool.comfy]
 PublisherId = "artokun"
 DisplayName = "ComfyUI Agent Panel"
-Tags = ["agent", "ai-agent", "assistant", "copilot", "claude", "chatgpt", "gpt-5", "codex", "mcp", "autonomous", "natural-language", "workflow", "sidebar", "automation"]
+Tags = ["agent", "ai-agent", "assistant", "copilot", "claude", "chatgpt", "gpt-5", "codex", "mcp", "autonomous", "natural-language", "workflow", "sidebar", "automation", "local", "local-first", "offline", "self-hosted", "ollama", "local-llm", "no-api-key", "gemini"]
 Icon = "https://raw.githubusercontent.com/artokun/comfyui-mcp-panel/main/assets/icon.png"
 Banner = "https://raw.githubusercontent.com/artokun/comfyui-mcp-panel/main/assets/banner.png"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comfyui-agent-panel"
-description = "Autonomous AI agent in the ComfyUI sidebar â€” runs locally on your own Claude OR ChatGPT subscription (no API keys, no extra LLM costs). Pick a provider and the agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, and run your workflow â€” asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
+description = "Autonomous AI agent in the ComfyUI sidebar — runs locally on your own Claude OR ChatGPT subscription (no API keys, no extra LLM costs). Pick a provider and the agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, and run your workflow — asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
 version = "0.9.6"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar — runs locally on your own Claude OR ChatGPT subscription (no API keys, no extra LLM costs). Pick a provider and the agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, and run your workflow — asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.9.6"
+version = "0.9.7"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees


### PR DESCRIPTION
The `[project] description` in `pyproject.toml` carried a double-encoded em dash (`â€"`), rendering as "sidebar â€" runs locally" **on the Comfy Registry listing and in ComfyUI-Manager search** — the highest-visibility text this project has, shown at the moment someone decides whether to install.

Also adds the tags the listing never claimed: `local`, `local-first`, `offline`, `self-hosted`, `ollama`, `local-llm`, `no-api-key`, `gemini`. It advertised claude/chatgpt/gpt-5 but nothing about running locally — the differentiator against a cloud-only official agent.

Verified: `pyproject.toml` parses via `tomllib`, no mojibake remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)