### PR TITLE
Registry: claim the local/offline tags in Manager search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Changed
+- **Registry tags now claim the local/offline story.** The listing advertised
+  Claude/ChatGPT/GPT-5 but nothing about running locally, so a user browsing
+  ComfyUI-Manager for a self-hosted option had no way to find it. Adds `local`,
+  `local-first`, `offline`, `self-hosted`, `ollama`, `local-llm`, `no-api-key`,
+  and `gemini` — the differentiators against a cloud-only agent.
+
 ### Added
 - **Chat archive UI** — multiple named or pinned conversations per workflow,
   workflow-grouped search and filtering, JSON merge import/export, explicit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,6 @@ Discord = "https://discord.gg/cW9arBhzCu"
 [tool.comfy]
 PublisherId = "artokun"
 DisplayName = "ComfyUI MCP | Agent Panel"
-Tags = ["agent", "ai-agent", "assistant", "copilot", "claude", "chatgpt", "gpt-5", "codex", "mcp", "autonomous", "natural-language", "workflow", "sidebar", "automation"]
+Tags = ["agent", "ai-agent", "assistant", "copilot", "claude", "chatgpt", "gpt-5", "codex", "mcp", "autonomous", "natural-language", "workflow", "sidebar", "automation", "local", "local-first", "offline", "self-hosted", "ollama", "local-llm", "no-api-key", "gemini"]
 Icon = "https://raw.githubusercontent.com/artokun/comfyui-mcp-panel/main/assets/icon.png"
 Banner = "https://raw.githubusercontent.com/artokun/comfyui-mcp-panel/main/assets/banner.png"


### PR DESCRIPTION
Adds `local`, `local-first`, `offline`, `self-hosted`, `ollama`, `local-llm`, `no-api-key`, `gemini` to `[tool.comfy] Tags` (14 → 22).

The listing advertised Claude/ChatGPT/GPT-5 but nothing about running locally — so someone browsing ComfyUI-Manager specifically for a self-hosted option had no way to surface this pack. Those are the differentiators against a cloud-only official agent.

**No version bump.** `main` already has unreleased work in the changelog, so these ride the next normal release rather than forcing one. Registry publishes are versioned, so the tags reach the live listing on that release — not before.

*(Supersedes #208, which I built against a stale checkout: the mojibake it "fixed" is already clean on main, and its 0.9.7 bump would have been a downgrade from 0.11.4.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)