### PR TITLE
Pre-empt comfy-cli's coming exec/eval + multi-statement hard error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,34 @@ jobs:
       - name: Python compile check (__init__.py)
         run: python -m py_compile __init__.py
 
+      # comfy-cli parity: publishing already WARNS that "we will soon disable
+      # exec and eval, and multiple statements in a single line" — when that
+      # becomes a hard error it breaks `Publish to Comfy Registry`, i.e. we
+      # find out at release time. Fail here instead. AST-based on purpose: a
+      # grep for ";" matches semicolons inside string literals and would flag
+      # clean files (it did — every py/ hit was a false positive).
+      - name: comfy-cli parity — no exec/eval, no multi-statement lines
+        run: |
+          python - <<'PY'
+          import ast, collections, pathlib, sys
+          bad = []
+          for f in sorted(pathlib.Path(".").rglob("*.py")):
+              if any(p in f.parts for p in (".git", "node_modules", ".venv", "venv", "__pycache__")):
+                  continue
+              tree = ast.parse(f.read_text(encoding="utf-8"), str(f))
+              per_line = collections.Counter(
+                  n.lineno for n in ast.walk(tree) if isinstance(n, ast.stmt)
+              )
+              for line in sorted(l for l, c in per_line.items() if c > 1):
+                  bad.append(f"{f}:{line}: multiple statements on one line")
+              for n in ast.walk(tree):
+                  if isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id in ("exec", "eval"):
+                      bad.append(f"{f}:{n.lineno}: {n.func.id}() call")
+          for b in bad:
+              print(f"::error::{b}")
+          sys.exit(1 if bad else 0)
+          PY
+
       - name: Install bandit
         run: pip install bandit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- **Pre-empt the coming comfy-cli hard error.** Publishing already warns that
+  "we will soon disable exec and eval, and multiple statements in a single
+  line"; when that lands it breaks `Publish to Comfy Registry`, i.e. we'd find
+  out at release time. Split the four semicolon-joined lines in the brand-asset
+  scripts and turned a `seg = lambda` into a `def`. No exec/eval existed
+  anywhere, and the shipped `__init__.py` / `py/*.py` were already clean.
+
+### Added
+- CI step enforcing comfy-cli parity (no exec/eval, no multi-statement lines).
+  AST-based rather than grep — a `;` search matches semicolons inside string
+  literals and reported false positives on every `py/` file.
+
 ### Changed
 - **Registry tags now claim the local/offline story.** The listing advertised
   Claude/ChatGPT/GPT-5 but nothing about running locally, so a user browsing

--- a/scripts/brand_assets.py
+++ b/scripts/brand_assets.py
@@ -382,9 +382,15 @@ def render_og(W=1200, H=630):
     ty3 = ty2 + int(tf.size * 1.2) + int(30 * SS)
     # measure pill row width using same logic as draw_chip_row
     dd = d
-    f_chip = font(F_SEMI, 30 * SS); f_or = font(F_REG, 28 * SS); f_mut = font(F_REG, 30 * SS)
-    dot_r = int(9 * SS); gap = int(12 * SS); pad = int(16 * SS)
-    seg = lambda l: dot_r * 2 + gap + measure_tracked(dd, l, f_chip)
+    f_chip = font(F_SEMI, 30 * SS)
+    f_or = font(F_REG, 28 * SS)
+    f_mut = font(F_REG, 30 * SS)
+    dot_r = int(9 * SS)
+    gap = int(12 * SS)
+    pad = int(16 * SS)
+
+    def seg(l):
+        return dot_r * 2 + gap + measure_tracked(dd, l, f_chip)
     parts_w = seg("Claude") + measure_tracked(dd, "  or  ", f_or) + seg("ChatGPT")
     pill_w = int(parts_w + pad * 2)
     tail = "your subscription · no API keys"

--- a/scripts/brand_assets_ai.py
+++ b/scripts/brand_assets_ai.py
@@ -211,9 +211,15 @@ def render_og(W=1200, H=630):
     d.text((int(w * 0.5 - tgw / 2), ty2), tg, font=tf, fill=B.OFFWHITE)
 
     ty3 = ty2 + int(tf.size * 1.2) + int(30 * SS)
-    f_chip = B.font(B.F_SEMI, 30 * SS); f_or = B.font(B.F_REG, 28 * SS); f_mut = B.font(B.F_REG, 30 * SS)
-    dot_r = int(9 * SS); gap = int(12 * SS); pad = int(16 * SS)
-    seg = lambda l: dot_r * 2 + gap + B.measure_tracked(d, l, f_chip)
+    f_chip = B.font(B.F_SEMI, 30 * SS)
+    f_or = B.font(B.F_REG, 28 * SS)
+    f_mut = B.font(B.F_REG, 30 * SS)
+    dot_r = int(9 * SS)
+    gap = int(12 * SS)
+    pad = int(16 * SS)
+
+    def seg(l):
+        return dot_r * 2 + gap + B.measure_tracked(d, l, f_chip)
     parts_w = seg("Claude") + B.measure_tracked(d, "  or  ", f_or) + seg("ChatGPT")
     pill_w = int(parts_w + pad * 2)
     tail_w = B.measure_tracked(d, "your subscription · no API keys", f_mut)


### PR DESCRIPTION
The Registry publish log already carries:

> We will soon disable exec and eval, and multiple statements in a single line, so this will be an error soon.

Today it's a warning. When it becomes an error it fails `Publish to Comfy Registry` — which we'd hit at release time, with a version already bumped.

## Actual exposure (smaller than the warning suggests)

- **No `exec`/`eval` anywhere** in the repo
- **The shipped Python was already clean** — `__init__.py` and `py/*.py` have zero true multi-statement lines
- Four semicolon-joined lines in `scripts/brand_assets.py` and `scripts/brand_assets_ai.py` — dev-only and `.comfyignore`'d, but still scanned at publish, which is why the warning fired

Split those, and promoted `seg = lambda l: …` to a `def` (also clears E731).

## The guard

New CI step blocks both patterns going forward. **AST-based deliberately**: my first pass used `grep` for `;` and it flagged every `py/` file — all false positives from semicolons inside string literals. Counting statements per line via the AST is exact.

Verified it fails on a canary containing both a multi-statement line and an `eval()` (2 findings, exit 1), and passes clean on the repo as-is.

## Verification

- Both scripts byte-compile
- Ran `scripts/brand_assets.py` before and after: **identical behavior** — both generate `icon.png` then stop at the same `OSError: cannot open resource` (fonts missing on this machine, pre-existing, not from this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)