### PR TITLE
0.11.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.4"
+version = "0.11.5"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -113,7 +113,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.4";
+const PANEL_VERSION = "0.11.5";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Panel release 0.11.5 — ships the panel-side Wave-1 fixes: workflow-tab targeting / anti-cross-tab-corruption (#206) and CivitAI upstream + favorites error surfacing (#204). Bumps pyproject `version` + `PANEL_VERSION` together (Registry publish fires on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)