### PR TITLE
fix(blind): stop leaking typed-message image attachments in Blind mode (#174)

### DIFF
--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7551,6 +7551,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     },
     sendUserMessage(text, context, images, mid) {
       if (!sock || sock.readyState !== WebSocket.OPEN) return false;
+      // Blind mode withholds pixels from EVERY agent-facing path — including
+      // images explicitly attached to a typed user message. The sendFrame() gate
+      // below only covers agent_event, so without this a blind session still
+      // leaks user attachments into the user_message frame (#174, privacy).
+      if (AGENT_BLIND) images = undefined;
       // Merge any armed one-shot context (transcript replay) ahead of this
       // message's own context, then clear it so it's sent exactly once.
       const mergedContext =


### PR DESCRIPTION
## Privacy bug (via-panel #174)
Blind mode's contract: the agent NEVER receives image pixels. But `sendUserMessage()` serialized its `images` arg into the `user_message` frame with no `AGENT_BLIND` check — the blind gate only existed in `sendFrame()` (for `agent_event`). So an image attached to a typed message reached the agent despite Blind mode. Silent gate bypass.

## Fix
Drop `images` in `sendUserMessage()` when `AGENT_BLIND`, matching the existing `sendFrame` gate. (Reporter diagnosed + verified this exact fix.)

Verified: ES module parses (`node --check`), typecheck clean, unit 164/164. Done by hand — Anthropic API was 529-overloaded, blocking the subagent + codex (disclosed self-review). [reports ≤panel 0.11.5]

🤖 Generated with [Claude Code](https://claude.com/claude-code)