### PR TITLE
fix(chat): media persistence + object serialization (WS-9)

### DIFF
--- a/browser_tests/unit/display-text.test.mjs
+++ b/browser_tests/unit/display-text.test.mjs
@@ -1,0 +1,48 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { toDisplayText } from "../../web/js/lib/display-text.js";
+
+test("passes plain strings through unchanged", () => {
+  assert.equal(toDisplayText("hello"), "hello");
+  assert.equal(toDisplayText(""), "");
+});
+
+test("nullish coerces to empty string, not the literal 'null'/'undefined'", () => {
+  assert.equal(toDisplayText(null), "");
+  assert.equal(toDisplayText(undefined), "");
+});
+
+test("primitives stringify readably", () => {
+  assert.equal(toDisplayText(42), "42");
+  assert.equal(toDisplayText(true), "true");
+});
+
+test("structured backend failure never renders as [object Object] (#176)", () => {
+  const out = toDisplayText({
+    error: "Individual quota reached. Please upgrade your subscription to increase your limits.",
+  });
+  assert.equal(out, "Individual quota reached. Please upgrade your subscription to increase your limits.");
+  assert.ok(!out.includes("[object Object]"));
+});
+
+test("prefers a message field, then serializes unknown objects as JSON", () => {
+  assert.equal(toDisplayText({ message: "boom" }), "boom");
+  const json = toDisplayText({ code: 1, kind: "quota" });
+  assert.ok(!json.includes("[object Object]"));
+  assert.deepEqual(JSON.parse(json), { code: 1, kind: "quota" });
+});
+
+test("unwraps a nested { error: { message } } payload", () => {
+  assert.equal(toDisplayText({ error: { message: "nested detail" } }), "nested detail");
+});
+
+test("Error instances render their message", () => {
+  assert.equal(toDisplayText(new Error("kaboom")), "kaboom");
+});
+
+test("a cyclic object degrades to a constructor hint, never [object Object]", () => {
+  const cyclic = {};
+  cyclic.self = cyclic;
+  const out = toDisplayText(cyclic);
+  assert.ok(!out.includes("[object Object]"));
+});

--- a/browser_tests/unit/media-persistence.test.mjs
+++ b/browser_tests/unit/media-persistence.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CHAT_HISTORY_SCHEMA,
+  mergeHistorySnapshots,
+  normalizeThread,
+  parseHistoryImport,
+} from "../../web/js/lib/chat-history-store.js";
+
+// Regression guard for panel issue #177: image/video cards are recorded as
+// `role: "media"` messages so they survive a reload / thread switch. The store
+// must preserve those records intact through normalization, merge, and the
+// portable export/import path — otherwise media would silently vanish again.
+
+const mediaThread = () => ({
+  id: "t-media",
+  schemaVersion: CHAT_HISTORY_SCHEMA,
+  createdAt: 1000,
+  updatedAt: 3000,
+  ts: 3000,
+  workflowKey: "panel:global",
+  msgs: [
+    { id: "m1", role: "user", text: "make me a cat", createdAt: 1000 },
+    { id: "m2", role: "agent", text: "here you go", createdAt: 2000 },
+    {
+      id: "m3",
+      role: "media",
+      kind: "image",
+      url: "/view?filename=cat_00001_.png&type=output",
+      caption: "cat",
+      createdAt: 2500,
+    },
+    {
+      id: "m4",
+      role: "media",
+      kind: "video",
+      url: "http://127.0.0.1:8188/view?filename=clip.mp4&type=output",
+      caption: "clip",
+      createdAt: 3000,
+    },
+  ],
+});
+
+test("normalizeThread preserves media records (url/kind/caption) so reload can replay them", () => {
+  const t = normalizeThread(mediaThread());
+  const media = t.msgs.filter((m) => m.role === "media");
+  assert.equal(media.length, 2);
+  const img = media.find((m) => m.kind === "image");
+  const vid = media.find((m) => m.kind === "video");
+  assert.equal(img.url, "/view?filename=cat_00001_.png&type=output");
+  assert.equal(img.caption, "cat");
+  assert.equal(vid.url, "http://127.0.0.1:8188/view?filename=clip.mp4&type=output");
+  assert.equal(vid.caption, "clip");
+});
+
+test("media records survive a snapshot merge (the reload/restore path)", () => {
+  const merged = mergeHistorySnapshots({
+    schemaVersion: CHAT_HISTORY_SCHEMA,
+    updatedAt: 3000,
+    threads: [mediaThread()],
+    meta: {},
+  });
+  const restored = merged.threads.find((t) => t.id === "t-media");
+  const media = restored.msgs.filter((m) => m.role === "media");
+  assert.equal(media.length, 2);
+  assert.deepEqual(
+    media.map((m) => `${m.kind}:${m.url}`).sort(),
+    [
+      "image:/view?filename=cat_00001_.png&type=output",
+      "video:http://127.0.0.1:8188/view?filename=clip.mp4&type=output",
+    ],
+  );
+});
+
+test("media records round-trip through the portable export/import path", () => {
+  const imported = parseHistoryImport({
+    format: "comfyui-agent-panel-chat-history",
+    schemaVersion: CHAT_HISTORY_SCHEMA,
+    threads: [mediaThread()],
+    meta: {},
+  });
+  const restored = imported.threads.find((t) => t.id === "t-media");
+  const media = restored.msgs.filter((m) => m.role === "media");
+  assert.equal(media.length, 2);
+  assert.ok(media.every((m) => typeof m.url === "string" && m.url));
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -66,6 +66,7 @@ import { marked } from "./vendor/marked.esm.js";
 import DOMPurify from "./vendor/purify.es.js";
 import qrcodegen from "./vendor/qrcode.esm.js";
 import { computeLayout } from "./lib/layout-engine.js";
+import { toDisplayText } from "./lib/display-text.js";
 import {
   CHAT_HISTORY_MAX_IMPORT_BYTES,
   CHAT_HISTORY_SCHEMA,
@@ -11426,6 +11427,21 @@ function buildPanel() {
     return entry;
   }
 
+  // True while paintThread() is replaying a stored conversation, so the paint*
+  // helpers repaint without re-recording what they are replaying.
+  let replaying = false;
+
+  /** Record an image/video card so history can replay it (see paintThread).
+   *  Only SERVABLE urls are stored (ComfyUI /view links, http(s)) — a data:/blob:
+   *  URI from a user attachment can be megabytes and would blow the localStorage
+   *  quota, taking the whole thread down with it. Those still paint live; they
+   *  just don't survive a reload (tracked residual — see #177). */
+  function recordMedia(kind, url, caption) {
+    if (replaying) return;
+    if (typeof url !== "string" || url.startsWith("data:") || url.startsWith("blob:")) return;
+    record({ role: "media", kind, url, caption: caption || "" });
+  }
+
   /** Bind the agent's current session id to the open thread (for reload/resume). */
   function bindSession(sessionId) {
     const previousSessionId = thread?.sessionId || null;
@@ -11576,6 +11592,7 @@ function buildPanel() {
 
   function paintImage(url, name) {
     clearEmpty();
+    recordMedia("image", url, name);
     const card = document.createElement("div");
     card.className = "cmcp-bubble agent cmcp-imgcard";
     const img = document.createElement("img");
@@ -11650,6 +11667,7 @@ function buildPanel() {
 
   function paintVideo(url, name) {
     clearEmpty();
+    recordMedia("video", url, name);
     const card = document.createElement("div");
     card.className = "cmcp-bubble agent cmcp-imgcard";
     // Self-sizing holder: a live <video> when on-screen, a gray aspect-ratio box
@@ -12181,8 +12199,11 @@ function buildPanel() {
   }
 
   function appendAgent(text) {
-    paintAgent(text);
-    record({ role: "agent", text });
+    // Normalize before paint AND record so a structured payload never renders
+    // (or persists) as the literal "[object Object]" (#176).
+    const readable = toDisplayText(text);
+    paintAgent(readable);
+    record({ role: "agent", text: readable });
   }
 
   // ```a2ui fence fallback — for backends without panel tools (Ollama family).
@@ -12371,10 +12392,12 @@ function buildPanel() {
   }
 
   function appendSystem(text) {
-    // System notices are transient — painted, never recorded.
+    // System notices are transient — painted, never recorded. A structured
+    // payload (e.g. a backend failure object) is normalized to readable text so
+    // it never renders as the literal "[object Object]" (#176).
     const b = document.createElement("div");
     b.className = "cmcp-sys";
-    b.textContent = text;
+    b.textContent = toDisplayText(text);
     log.appendChild(b);
     scrollLog();
   }
@@ -12433,13 +12456,23 @@ function buildPanel() {
   function paintThread(t) {
     thread = t;
     resetFeed();
-    for (const m of t.msgs) {
-      if (m.role === "user") paintUser(m.text, { attachments: m.attachments, workflowVersion: m.workflowVersion });
-      else if (m.role === "agent") paintAgent(m.text);
-      else if (m.role === "card") {
-        if (m.kind === "a2ui") paintA2UIRecord(m);
-        else paintCard(m);
+    // Replaying stored history — the paint* helpers must NOT re-record what they
+    // are repainting (recordMedia is the media equivalent of the append* record).
+    replaying = true;
+    try {
+      for (const m of t.msgs) {
+        if (m.role === "user") paintUser(m.text, { attachments: m.attachments, workflowVersion: m.workflowVersion });
+        else if (m.role === "agent") paintAgent(m.text);
+        else if (m.role === "media") {
+          if (m.kind === "video") paintVideo(m.url, m.caption);
+          else paintImage(m.url, m.caption);
+        } else if (m.role === "card") {
+          if (m.kind === "a2ui") paintA2UIRecord(m);
+          else paintCard(m);
+        }
       }
+    } finally {
+      replaying = false;
     }
     // resetFeed() recreated the indicator (if a turn is live) ABOVE these
     // repainted messages — re-pin it to the bottom so it trails the newest one.

--- a/web/js/lib/display-text.js
+++ b/web/js/lib/display-text.js
@@ -1,0 +1,38 @@
+// Coerce an arbitrary chat payload into readable display text.
+//
+// Structured backend failures and multi-part messages sometimes arrive at the
+// render layer as objects. Painting them with implicit string coercion yields
+// the useless literal "[object Object]" (see panel issue #176). This helper is
+// the panel's last line of defense: prefer a human-readable string field, then
+// fall back to a safe JSON serialization — never Object.prototype.toString.
+
+/** Return readable text for a value that may be a string, error, or object. */
+export function toDisplayText(value) {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  if (value instanceof Error) return value.message || value.name || "Error";
+  if (typeof value === "object") {
+    // Prefer a conventional human-readable field before serializing the whole
+    // object, so a { error | message | text | detail } payload reads cleanly.
+    for (const key of ["message", "error", "text", "detail", "description"]) {
+      const field = value[key];
+      if (typeof field === "string" && field) return field;
+      // A nested { error: { message } } style payload is common for quota/API errors.
+      if (field && typeof field === "object") {
+        const nested = toDisplayText(field);
+        if (nested && nested !== "[object Object]") return nested;
+      }
+    }
+    try {
+      const json = JSON.stringify(value);
+      if (json && json !== "{}" && json !== "null") return json;
+    } catch {
+      // Cyclic / non-serializable — fall through to the constructor-name hint.
+    }
+    return value.constructor?.name ? `[${value.constructor.name}]` : "[object]";
+  }
+  return String(value);
+}


### PR DESCRIPTION
WS-9 chat/media serialization + persistence. Two clusters — media persistence (panel-side) and the "[object Object]" family (panel-side defense; the orchestrator root fixes for #175/#176/#168 ship in a companion comfyui-mcp PR).

## Closes
- Closes #177 — chat history dropped every image/video card. `paintImage`/`paintVideo` never recorded, and the replay loop had no media branch. Now both record servable urls as `role:"media"` messages and `paintThread` replays them, so cards survive reload / thread switch.
- Partially addresses #176 — panel-side last line of defense: a structured backend-failure object now renders as readable text (message/error field, else safe JSON) instead of the literal `[object Object]`. Root fix (orchestrator forwarding proper text) is in the companion comfyui-mcp PR.

## What changed
- `paintImage`/`paintVideo` call a new `recordMedia(kind, url, caption)` — records only SERVABLE urls (ComfyUI `/view`, http(s)); `data:`/`blob:` attachment urls are skipped to protect the localStorage quota (known residual, unchanged from #177's note).
- `paintThread` gains a `role:"media"` replay branch wrapped in a `replaying` guard so replays repaint without re-recording.
- New `web/js/lib/display-text.js` `toDisplayText()` helper; `appendSystem`/`appendAgent` normalize structured payloads before paint (and record).

## Tests
- `browser_tests/unit/media-persistence.test.mjs` — media records survive normalize / merge / portable round-trip (reload path).
- `browser_tests/unit/display-text.test.mjs` — structured failures never yield `[object Object]`.
- `npm run test:unit` (175 pass) + `npm run typecheck` green; `node --check` valid as ES module.

Note: #175 and #168 (canvas-context serialization + missing `panel_*` tools) are orchestrator-side and handled in the companion comfyui-mcp PR. #163 (lightbox) deferred — not clean to include here.

[reports ≤panel 0.11.5]

🤖 Generated with [Claude Code](https://claude.com/claude-code)