### PR TITLE
fix(state): invalidate stale caches/snapshots after restart+edit (WS-3)

### DIFF
--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for web/js/lib/asset-staleness.js — run with `node --test`.
+ *
+ * Covers the WS-3 stale-snapshot fixes: subgraph-scoped id resolution, the
+ * missing-asset live-graph cross-check (fixed-by-set_widget and appeared-on-disk),
+ * fail-open/closed safety, and UNKNOWN-widget positional reconciliation.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  findNodeByScopedId,
+  assetCandidateStillReferenced,
+  assetCandidateResolvesLive,
+  isStaleAssetCandidate,
+  orderedWidgetInputNames,
+  reconcileUnknownWidgetNames,
+} from "../../web/js/lib/asset-staleness.js";
+
+/** Minimal fake graph: a Map of id → node, with getNodeById + optional subgraph. */
+function graphOf(nodes) {
+  const byId = new Map(nodes.map((n) => [Number(n.id), n]));
+  return { getNodeById: (id) => byId.get(Number(id)) ?? null };
+}
+
+test("findNodeByScopedId resolves a plain id", () => {
+  const n = { id: 42, widgets: [] };
+  assert.equal(findNodeByScopedId(graphOf([n]), 42), n);
+});
+
+test("findNodeByScopedId walks a subgraph-scoped id one hop per segment", () => {
+  const inner = { id: 1913, widgets: [] };
+  const sub = { id: 6051, subgraph: graphOf([inner]) };
+  const root = graphOf([sub]);
+  assert.equal(findNodeByScopedId(root, "6051:1913"), inner);
+});
+
+test("findNodeByScopedId returns null for a missing node", () => {
+  assert.equal(findNodeByScopedId(graphOf([]), 7), null);
+  assert.equal(findNodeByScopedId(graphOf([{ id: 6051 }]), "6051:9999"), null);
+});
+
+test("assetCandidateStillReferenced: true while a widget still holds the file", () => {
+  const node = { id: 5, widgets: [{ name: "lora_name", value: "old.safetensors" }] };
+  assert.equal(
+    assetCandidateStillReferenced(graphOf([node]), 5, "old.safetensors"),
+    true,
+  );
+});
+
+test("assetCandidateStillReferenced: false after the widget was pointed elsewhere (#196)", () => {
+  const node = { id: 5, widgets: [{ name: "lora_name", value: "new.safetensors" }] };
+  assert.equal(
+    assetCandidateStillReferenced(graphOf([node]), 5, "old.safetensors"),
+    false,
+  );
+});
+
+test("assetCandidateStillReferenced fails OPEN when the node is gone", () => {
+  assert.equal(assetCandidateStillReferenced(graphOf([]), 99, "x.safetensors"), true);
+});
+
+test("assetCandidateResolvesLive: true when the file is now a live combo value (#223/#185)", () => {
+  const node = {
+    id: 4,
+    widgets: [
+      { name: "ckpt_name", value: "model.safetensors", options: { values: ["model.safetensors", "other.safetensors"] } },
+    ],
+  };
+  assert.equal(
+    assetCandidateResolvesLive(graphOf([node]), 4, "model.safetensors", "ckpt_name"),
+    true,
+  );
+});
+
+test("assetCandidateResolvesLive supports a function-valued combo and fails CLOSED when absent", () => {
+  const node = {
+    id: 4,
+    widgets: [{ name: "ckpt_name", value: "a", options: { values: () => ["a", "b"] } }],
+  };
+  assert.equal(assetCandidateResolvesLive(graphOf([node]), 4, "a", "ckpt_name"), true);
+  assert.equal(assetCandidateResolvesLive(graphOf([node]), 4, "missing", "ckpt_name"), false);
+});
+
+test("isStaleAssetCandidate: stale once fixed by set_widget (subgraph-scoped)", () => {
+  const inner = { id: 6077, widgets: [{ name: "model", value: "..._fp8_scaled.safetensors" }] };
+  const sub = { id: 6105, subgraph: graphOf([inner]) };
+  const root = graphOf([sub]);
+  // Store still lists the pre-edit filename — the widget no longer references it.
+  assert.equal(
+    isStaleAssetCandidate(root, { nodeId: "6105:6077", name: "..._fp16.safetensors", widgetName: "model" }),
+    true,
+  );
+});
+
+test("isStaleAssetCandidate: NOT stale for a genuinely missing model", () => {
+  const node = {
+    id: 8,
+    widgets: [{ name: "ckpt_name", value: "gone.safetensors", options: { values: ["present.safetensors"] } }],
+  };
+  assert.equal(
+    isStaleAssetCandidate(graphOf([node]), { nodeId: 8, name: "gone.safetensors", widgetName: "ckpt_name" }),
+    false,
+  );
+});
+
+test("orderedWidgetInputNames concatenates required then optional, honoring input_order", () => {
+  const nodeData = {
+    input: { required: { a: {}, b: {} }, optional: { c: {} } },
+    input_order: { required: ["b", "a"], optional: ["c"] },
+  };
+  assert.deepEqual(orderedWidgetInputNames(nodeData), ["b", "a", "c"]);
+});
+
+test("reconcileUnknownWidgetNames renames placeholders when count matches (#199)", () => {
+  const node = {
+    widgets: [
+      { name: "UNKNOWN", value: "x.safetensors" },
+      { name: "UNKNOWN_1", value: 1.0 },
+    ],
+    constructor: { nodeData: { input: { required: { lora_name: {}, strength_model: {} } } } },
+  };
+  assert.equal(reconcileUnknownWidgetNames(node), true);
+  assert.deepEqual(node.widgets.map((w) => w.name), ["lora_name", "strength_model"]);
+});
+
+test("reconcileUnknownWidgetNames leaves names alone when the mapping is ambiguous", () => {
+  const node = {
+    widgets: [{ name: "UNKNOWN", value: 1 }],
+    constructor: { nodeData: { input: { required: { a: {}, b: {}, c: {} } } } },
+  };
+  assert.equal(reconcileUnknownWidgetNames(node), false);
+  assert.equal(node.widgets[0].name, "UNKNOWN");
+});
+
+test("reconcileUnknownWidgetNames is a no-op when there are no placeholders", () => {
+  const node = {
+    widgets: [{ name: "seed", value: 1 }],
+    constructor: { nodeData: { input: { required: { seed: {} } } } },
+  };
+  assert.equal(reconcileUnknownWidgetNames(node), false);
+});

--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -15,12 +15,15 @@ import {
   isStaleAssetCandidate,
   orderedWidgetInputNames,
   reconcileUnknownWidgetNames,
+  collectAllGraphs,
+  reapplyDefsToLiveNodes,
 } from "../../web/js/lib/asset-staleness.js";
 
-/** Minimal fake graph: a Map of id → node, with getNodeById + optional subgraph. */
+/** Minimal fake graph: id → node keyed as a STRING (so numeric AND string/UUID
+ *  ids both resolve), exposes _nodes + getNodeById + optional per-node subgraph. */
 function graphOf(nodes) {
-  const byId = new Map(nodes.map((n) => [Number(n.id), n]));
-  return { getNodeById: (id) => byId.get(Number(id)) ?? null };
+  const byId = new Map(nodes.map((n) => [String(n.id), n]));
+  return { _nodes: nodes, getNodeById: (id) => byId.get(String(id)) ?? null };
 }
 
 test("findNodeByScopedId resolves a plain id", () => {
@@ -102,6 +105,76 @@ test("isStaleAssetCandidate: NOT stale for a genuinely missing model", () => {
     isStaleAssetCandidate(graphOf([node]), { nodeId: 8, name: "gone.safetensors", widgetName: "ckpt_name" }),
     false,
   );
+});
+
+test("findNodeByScopedId resolves a string/UUID node id without NaN coercion (finding #5)", () => {
+  const n = { id: "a1b2c3d4-uuid", widgets: [] };
+  assert.equal(findNodeByScopedId(graphOf([n]), "a1b2c3d4-uuid"), n);
+});
+
+test("isStaleAssetCandidate clears a fixed candidate on a string/UUID-keyed graph (finding #5)", () => {
+  // Widget was pointed at a new file; the store still lists the old one. The
+  // still-referenced check must work even though the id is a non-numeric string.
+  const node = { id: "node-uuid-1", widgets: [{ name: "ckpt_name", value: "new.safetensors" }] };
+  assert.equal(
+    isStaleAssetCandidate(graphOf([node]), { nodeId: "node-uuid-1", name: "old.safetensors", widgetName: "ckpt_name" }),
+    true,
+  );
+});
+
+test("a STALE combo still listing a deleted file must NOT suppress a genuine miss (finding #4)", () => {
+  // The model was deleted, but the combo populated at page load still lists it.
+  // The widget still references it → still-referenced can't clear it. Combo
+  // membership could — but only when a refresh is CONFIRMED.
+  const node = {
+    id: 5,
+    widgets: [{ name: "ckpt_name", value: "deleted.safetensors", options: { values: ["deleted.safetensors"] } }],
+  };
+  const candidate = { nodeId: 5, name: "deleted.safetensors", widgetName: "ckpt_name" };
+  // Default (no confirmed refresh): must keep reporting the genuine miss.
+  assert.equal(isStaleAssetCandidate(graphOf([node]), candidate), false);
+  assert.equal(isStaleAssetCandidate(graphOf([node]), candidate, { trustCombo: false }), false);
+  // Only after a confirmed refresh is combo membership trusted to clear it.
+  assert.equal(isStaleAssetCandidate(graphOf([node]), candidate, { trustCombo: true }), true);
+});
+
+test("collectAllGraphs walks nested subgraphs", () => {
+  const inner = { id: 2, widgets: [] };
+  const innerGraph = graphOf([inner]);
+  const host = { id: 1, subgraph: innerGraph };
+  const root = graphOf([host]);
+  const graphs = collectAllGraphs(root);
+  assert.ok(graphs.includes(root));
+  assert.ok(graphs.includes(innerGraph));
+});
+
+test("reapplyDefsToLiveNodes repairs an ALREADY-LOADED node using fresh defs (finding #3)", () => {
+  // Existing instance: stale/generic constructor (nodeData absent), widgets came
+  // in as positional UNKNOWN placeholders. The fresh def must repair it in place.
+  const node = {
+    id: 7,
+    type: "LTXICLoRALoaderModelOnly",
+    widgets: [
+      { name: "UNKNOWN", value: "x.safetensors" },
+      { name: "UNKNOWN_1", value: 1.0 },
+    ],
+    constructor: {}, // generic fallback — no nodeData
+  };
+  const defs = {
+    LTXICLoRALoaderModelOnly: { input: { required: { lora_name: {}, strength_model: {} } } },
+  };
+  const repaired = reapplyDefsToLiveNodes(graphOf([node]), defs);
+  assert.equal(repaired, 1);
+  assert.deepEqual(node.widgets.map((w) => w.name), ["lora_name", "strength_model"]);
+});
+
+test("reapplyDefsToLiveNodes stamps fresh nodeData onto a type-specific constructor", () => {
+  const oldDef = { input: { required: { seed: {} } } };
+  const newDef = { input: { required: { seed: {}, box_toggle_max_frames: {} } } };
+  const shared = { nodeData: oldDef }; // type-specific constructor shared by instances
+  const node = { id: 9, type: "CyberpunkWindowNode", widgets: [], constructor: shared };
+  reapplyDefsToLiveNodes(graphOf([node]), { CyberpunkWindowNode: newDef });
+  assert.equal(node.constructor.nodeData, newDef);
 });
 
 test("orderedWidgetInputNames concatenates required then optional, honoring input_order", () => {

--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -14,10 +14,23 @@ import {
   assetCandidateResolvesLive,
   isStaleAssetCandidate,
   orderedWidgetInputNames,
+  isWidgetInputSpec,
   reconcileUnknownWidgetNames,
   collectAllGraphs,
   reapplyDefsToLiveNodes,
 } from "../../web/js/lib/asset-staleness.js";
+
+/** The REAL LTXICLoRALoaderModelOnly schema: a `model` CONNECTION input plus two
+ *  WIDGET inputs. Connection inputs must not be counted as widgets (finding #3). */
+const LTX_ICLORA_DEF = {
+  input: {
+    required: {
+      model: ["MODEL"],
+      lora_name: [["lora_a.safetensors", "lora_b.safetensors"]],
+      strength_model: ["FLOAT", { default: 1.0 }],
+    },
+  },
+};
 
 /** Minimal fake graph: id → node keyed as a STRING (so numeric AND string/UUID
  *  ids both resolve), exposes _nodes + getNodeById + optional per-node subgraph. */
@@ -150,7 +163,9 @@ test("collectAllGraphs walks nested subgraphs", () => {
 
 test("reapplyDefsToLiveNodes repairs an ALREADY-LOADED node using fresh defs (finding #3)", () => {
   // Existing instance: stale/generic constructor (nodeData absent), widgets came
-  // in as positional UNKNOWN placeholders. The fresh def must repair it in place.
+  // in as positional UNKNOWN placeholders. The fresh def (which INCLUDES the
+  // `model` CONNECTION input, as the real schema does) must repair it in place —
+  // counting only the two WIDGET inputs, not the connection input.
   const node = {
     id: 7,
     type: "LTXICLoRALoaderModelOnly",
@@ -160,9 +175,7 @@ test("reapplyDefsToLiveNodes repairs an ALREADY-LOADED node using fresh defs (fi
     ],
     constructor: {}, // generic fallback — no nodeData
   };
-  const defs = {
-    LTXICLoRALoaderModelOnly: { input: { required: { lora_name: {}, strength_model: {} } } },
-  };
+  const defs = { LTXICLoRALoaderModelOnly: LTX_ICLORA_DEF };
   const repaired = reapplyDefsToLiveNodes(graphOf([node]), defs);
   assert.equal(repaired, 1);
   assert.deepEqual(node.widgets.map((w) => w.name), ["lora_name", "strength_model"]);
@@ -177,21 +190,38 @@ test("reapplyDefsToLiveNodes stamps fresh nodeData onto a type-specific construc
   assert.equal(node.constructor.nodeData, newDef);
 });
 
-test("orderedWidgetInputNames concatenates required then optional, honoring input_order", () => {
-  const nodeData = {
-    input: { required: { a: {}, b: {} }, optional: { c: {} } },
-    input_order: { required: ["b", "a"], optional: ["c"] },
-  };
-  assert.deepEqual(orderedWidgetInputNames(nodeData), ["b", "a", "c"]);
+test("isWidgetInputSpec: combos + primitive widget types are widgets; connections + forced inputs are not", () => {
+  assert.equal(isWidgetInputSpec([["a", "b"]]), true); // combo
+  assert.equal(isWidgetInputSpec(["FLOAT", { default: 1 }]), true);
+  assert.equal(isWidgetInputSpec(["INT"]), true);
+  assert.equal(isWidgetInputSpec(["MODEL"]), false); // connection
+  assert.equal(isWidgetInputSpec(["CLIP"]), false);
+  assert.equal(isWidgetInputSpec(["STRING", { forceInput: true }]), false);
+  assert.equal(isWidgetInputSpec(["INT", { widget: false }]), false);
 });
 
-test("reconcileUnknownWidgetNames renames placeholders when count matches (#199)", () => {
+test("orderedWidgetInputNames EXCLUDES connection inputs, honoring input_order (finding #3)", () => {
+  // The real LTX schema: `model` connection must be dropped; only the 2 widgets
+  // remain, in declaration order.
+  assert.deepEqual(orderedWidgetInputNames(LTX_ICLORA_DEF), ["lora_name", "strength_model"]);
+  const withOrder = {
+    input: {
+      required: { model: ["MODEL"], seed: ["INT"], name: ["STRING"] },
+    },
+    input_order: { required: ["model", "name", "seed"] },
+  };
+  assert.deepEqual(orderedWidgetInputNames(withOrder), ["name", "seed"]);
+});
+
+test("reconcileUnknownWidgetNames renames placeholders against the REAL schema with a connection input (#199 / finding #3)", () => {
+  // 2 UNKNOWN widgets vs a def with 3 inputs (1 connection + 2 widgets). Counting
+  // only widget inputs makes this the unambiguous 2==2 case and repairs it.
   const node = {
     widgets: [
       { name: "UNKNOWN", value: "x.safetensors" },
       { name: "UNKNOWN_1", value: 1.0 },
     ],
-    constructor: { nodeData: { input: { required: { lora_name: {}, strength_model: {} } } } },
+    constructor: { nodeData: LTX_ICLORA_DEF },
   };
   assert.equal(reconcileUnknownWidgetNames(node), true);
   assert.deepEqual(node.widgets.map((w) => w.name), ["lora_name", "strength_model"]);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -87,6 +87,7 @@ import { openSidePanel } from "./cmcp-sidepanel-ui.js";
 import {
   isStaleAssetCandidate as isStaleAssetCandidateLib,
   reconcileUnknownWidgetNames,
+  reapplyDefsToLiveNodes,
 } from "./lib/asset-staleness.js";
 
 let app = null;
@@ -115,25 +116,46 @@ let lastExecFailure = null;
  * today's stale behaviour, never a thrown tool call).
  */
 let nodeDefRefreshInFlight = null;
+// True only AFTER a node-def + combo refresh has completed successfully. The
+// missing-asset combo cross-check is trusted only when this is set — a combo left
+// from page load can be stale (still listing a deleted file) and must never
+// suppress a genuine miss (codex WS-3 finding #4). Reset to false whenever the
+// backend socket drops, since the combos may be about to change under us.
+let nodeDefsRefreshConfirmed = false;
 async function refreshComfyNodeDefs() {
   if (nodeDefRefreshInFlight) return nodeDefRefreshInFlight;
   nodeDefRefreshInFlight = (async () => {
+    let ok = false;
     try {
       const a =
         typeof app !== "undefined" && app ? app : window.comfyAPI?.app?.app;
       if (!a) return;
       // Re-register node definitions so newly installed/updated classes and
       // their current widget schemas are known to LiteGraph (#221/#171).
+      let defs = null;
       if (typeof a.registerNodesFromDefs === "function" && typeof api?.getNodeDefs === "function") {
-        const defs = await api.getNodeDefs();
+        defs = await api.getNodeDefs();
         if (defs) await a.registerNodesFromDefs(defs);
+      }
+      // registerNodesFromDefs mints NEW classes; already-loaded node INSTANCES
+      // keep their old constructor and would never see the fresh schema. Stamp
+      // the fresh def onto existing instances + repair UNKNOWN widgets so old
+      // nodes are actually fixed, not just newly-created ones (finding #3).
+      if (defs) {
+        const rootGraph = a.graph ?? a.canvas?.graph;
+        if (rootGraph) reapplyDefsToLiveNodes(rootGraph, defs);
       }
       // Refresh combo widget option lists (model dropdowns etc.) so freshly
       // installed models resolve and stale entries clear (#185/#181/#223).
       if (typeof a.refreshComboInNodes === "function") await a.refreshComboInNodes();
+      ok = true;
     } catch (e) {
       console.warn("[comfyui-mcp-panel] node-def refresh after reconnect failed:", e);
     } finally {
+      // Only trust the live combos for suppressing missing-asset candidates once
+      // a refresh has FULLY succeeded — a swallowed failure must not license
+      // trusting a stale combo (finding #4).
+      nodeDefsRefreshConfirmed = ok;
       nodeDefRefreshInFlight = null;
     }
   })();
@@ -148,6 +170,15 @@ function setupListeners() {
     });
     api.addEventListener("execution_start", () => {
       lastExecFailure = null;
+    });
+    // While the backend socket is down, distrust the combos (they may be about
+    // to change) so a stale combo can't suppress a genuine miss (finding #4).
+    api.addEventListener("reconnecting", () => {
+      nodeDefsRefreshConfirmed = false;
+    });
+    api.addEventListener("status", (ev) => {
+      // A null status payload is ComfyUI's "backend connection lost" signal.
+      if (ev?.detail == null) nodeDefsRefreshConfirmed = false;
     });
     // ComfyUI's own socket to its backend re-establishing is the reliable
     // in-tab signal that the server came back after a restart — refresh the
@@ -3165,7 +3196,10 @@ function isStaleAssetCandidate(c) {
   } catch {
     return false; // no graph → can't prove stale, keep reporting
   }
-  return isStaleAssetCandidateLib(rootGraph, c);
+  // Only trust live combo membership to clear a candidate once a node-def refresh
+  // has confirmably succeeded — otherwise a stale combo could suppress a genuine
+  // miss (finding #4). The widget-still-references check is always safe.
+  return isStaleAssetCandidateLib(rootGraph, c, { trustCombo: nodeDefsRefreshConfirmed });
 }
 
 function collectMissingAssets() {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -125,7 +125,12 @@ let nodeDefsRefreshConfirmed = false;
 async function refreshComfyNodeDefs() {
   if (nodeDefRefreshInFlight) return nodeDefRefreshInFlight;
   nodeDefRefreshInFlight = (async () => {
-    let ok = false;
+    // Trust the live combos for suppressing missing-asset candidates ONLY once
+    // the combo refresh has ACTUALLY RUN and succeeded. If refreshComboInNodes is
+    // absent on this ComfyUI build (or throws), the combos are still whatever
+    // page-load left them — possibly stale — so we must stay in over-report-safe
+    // mode and NOT trust them (finding #4).
+    let comboRefreshed = false;
     try {
       const a =
         typeof app !== "undefined" && app ? app : window.comfyAPI?.app?.app;
@@ -147,15 +152,14 @@ async function refreshComfyNodeDefs() {
       }
       // Refresh combo widget option lists (model dropdowns etc.) so freshly
       // installed models resolve and stale entries clear (#185/#181/#223).
-      if (typeof a.refreshComboInNodes === "function") await a.refreshComboInNodes();
-      ok = true;
+      if (typeof a.refreshComboInNodes === "function") {
+        await a.refreshComboInNodes();
+        comboRefreshed = true;
+      }
     } catch (e) {
       console.warn("[comfyui-mcp-panel] node-def refresh after reconnect failed:", e);
     } finally {
-      // Only trust the live combos for suppressing missing-asset candidates once
-      // a refresh has FULLY succeeded — a swallowed failure must not license
-      // trusting a stale combo (finding #4).
-      nodeDefsRefreshConfirmed = ok;
+      nodeDefsRefreshConfirmed = comboRefreshed;
       nodeDefRefreshInFlight = null;
     }
   })();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -84,6 +84,10 @@ import {
 } from "./lib/workflow-chat-identity.js";
 import { validateA2UISpec, renderA2UICard, renderA2UIInert, renderA2UIFailCard, A2UI_CSS } from "./cmcp-a2ui.js";
 import { openSidePanel } from "./cmcp-sidepanel-ui.js";
+import {
+  isStaleAssetCandidate as isStaleAssetCandidateLib,
+  reconcileUnknownWidgetNames,
+} from "./lib/asset-staleness.js";
 
 let app = null;
 let api = null;
@@ -93,6 +97,49 @@ let api = null;
 // setupListeners, called from registerExtensionWhenReady). execution_start clears
 // state for the new run.
 let lastExecFailure = null;
+
+/**
+ * After a ComfyUI restart (panel_restart_comfyui / Manager reboot), the browser
+ * tab stays loaded but the backend rescanned node packs and model folders. The
+ * ComfyUI frontend does NOT re-fetch its node definitions on its own when its
+ * websocket to the backend reconnects, so the live LiteGraph registry and the
+ * loader combo lists go stale:
+ *   - newly installed node classes are "Unknown node type" to panel_add_node,
+ *     and existing nodes keep the old input/widget schema (#221 / #171)
+ *   - freshly downloaded/rescanned models are absent from loader combos, so a
+ *     genuinely installed file still looks missing (#185 / #181), and the
+ *     collectMissingAssets live-combo cross-check can't clear stale candidates.
+ * Re-pull /object_info and re-register the defs + refresh every combo so graph
+ * tools resume against the current server. Fully defensive: each frontend method
+ * is optional across ComfyUI versions, and any failure is a no-op (worst case is
+ * today's stale behaviour, never a thrown tool call).
+ */
+let nodeDefRefreshInFlight = null;
+async function refreshComfyNodeDefs() {
+  if (nodeDefRefreshInFlight) return nodeDefRefreshInFlight;
+  nodeDefRefreshInFlight = (async () => {
+    try {
+      const a =
+        typeof app !== "undefined" && app ? app : window.comfyAPI?.app?.app;
+      if (!a) return;
+      // Re-register node definitions so newly installed/updated classes and
+      // their current widget schemas are known to LiteGraph (#221/#171).
+      if (typeof a.registerNodesFromDefs === "function" && typeof api?.getNodeDefs === "function") {
+        const defs = await api.getNodeDefs();
+        if (defs) await a.registerNodesFromDefs(defs);
+      }
+      // Refresh combo widget option lists (model dropdowns etc.) so freshly
+      // installed models resolve and stale entries clear (#185/#181/#223).
+      if (typeof a.refreshComboInNodes === "function") await a.refreshComboInNodes();
+    } catch (e) {
+      console.warn("[comfyui-mcp-panel] node-def refresh after reconnect failed:", e);
+    } finally {
+      nodeDefRefreshInFlight = null;
+    }
+  })();
+  return nodeDefRefreshInFlight;
+}
+
 function setupListeners() {
   if (!api) return;
   try {
@@ -101,6 +148,12 @@ function setupListeners() {
     });
     api.addEventListener("execution_start", () => {
       lastExecFailure = null;
+    });
+    // ComfyUI's own socket to its backend re-establishing is the reliable
+    // in-tab signal that the server came back after a restart — refresh the
+    // stale node registry + combos then (#221/#171/#185/#181).
+    api.addEventListener("reconnected", () => {
+      void refreshComfyNodeDefs();
     });
   } catch {
     // api unavailable — graph_get_errors reports null.
@@ -3097,6 +3150,24 @@ let lastInjectedValidationSig = null;
  * Shared by graph_get_errors and validationBanner so the tool and the proactive
  * turn-start injection can never drift apart again.
  */
+/** The missing-asset Pinia stores (`missingModel`/`missingMedia`) are populated
+ *  ONCE at workflow LOAD and never re-evaluated, so a candidate the user or the
+ *  agent has since fixed (set_widget) — or a file that has since appeared on disk
+ *  (download + restart) — keeps getting reported missing until a full reload.
+ *  Delegate the live-graph cross-check to the pure helper: drop a candidate when
+ *  no widget still references the file OR it now resolves against the node's live
+ *  combo. Fails toward over-reporting, never swallowing a genuine miss.
+ *  (#196/#352/#364/#203/#223/#185/#181) */
+function isStaleAssetCandidate(c) {
+  let rootGraph;
+  try {
+    rootGraph = getGraphCtx().rootGraph;
+  } catch {
+    return false; // no graph → can't prove stale, keep reporting
+  }
+  return isStaleAssetCandidateLib(rootGraph, c);
+}
+
 function collectMissingAssets() {
   const models = [];
   const media = [];
@@ -3105,6 +3176,7 @@ function collectMissingAssets() {
   try {
     for (const c of getPiniaStore("missingModel")?.missingModelCandidates ?? []) {
       if (c?.isMissing === false) continue;
+      if (isStaleAssetCandidate(c)) continue;
       models.push({
         node_id: c?.nodeId ?? null,
         file: c?.name ?? null,
@@ -3119,6 +3191,7 @@ function collectMissingAssets() {
   try {
     for (const c of getPiniaStore("missingMedia")?.missingMediaCandidates ?? []) {
       if (c?.isMissing === false) continue;
+      if (isStaleAssetCandidate(c)) continue;
       media.push({
         node_id: c?.nodeId ?? null,
         file: c?.name ?? null,
@@ -3350,6 +3423,7 @@ function resolveNode(graph, nodeId) {
   if (!node) throw new Error(`No node with id ${nodeId} in the current graph`);
   return node;
 }
+
 
 // ---- Subgraph boundary rails (input/output proxy nodes) -------------------
 // LiteGraph: subgraph.inputNode.id === SUBGRAPH_INPUT_ID (-10),
@@ -4967,6 +5041,9 @@ const GRAPH_TOOL_EXECUTORS = {
   graph_set_widget({ node_id, widget, value }) {
     const { app, graph } = getGraphCtx();
     const node = resolveNode(graph, node_id);
+    // Repair positional UNKNOWN/UNKNOWN_n placeholders against the live def so
+    // the caller's real widget name resolves (#199) before we look it up.
+    reconcileUnknownWidgetNames(node);
     const w = (node.widgets ?? []).find(
       (cand) => cand?.name?.toLowerCase() === String(widget).toLowerCase(),
     );

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -1,0 +1,138 @@
+/**
+ * Pure helpers for reconciling the ComfyUI frontend's LOAD-TIME snapshots against
+ * the live graph — extracted from comfyui-mcp-panel.js so they can be unit-tested
+ * without a browser. No DOM / no ComfyUI globals: every input is passed in.
+ *
+ * Two stale-state classes are handled:
+ *   1. Missing-asset candidates (`missingModel`/`missingMedia` Pinia stores) are
+ *      populated ONCE at workflow load and never re-evaluated, so a file the user
+ *      or agent has since fixed (set_widget) or that has since appeared on disk
+ *      (download + restart) keeps getting reported missing. (#196/#223/#203/#185/#181)
+ *   2. Widgets deserialized as positional `UNKNOWN`/`UNKNOWN_n` placeholders when
+ *      the class def wasn't matched at load, even though the live def names them. (#199)
+ */
+
+const UNKNOWN_WIDGET_RE = /^UNKNOWN(_\d+)?$/;
+
+/**
+ * Resolve a possibly subgraph-scoped node id ("6051:1913", or plain 42) against
+ * the ROOT graph, walking one hop per ':' segment through `.subgraph`. Returns
+ * the node or null.
+ */
+export function findNodeByScopedId(rootGraph, scopedId) {
+  const parts = String(scopedId ?? "")
+    .split(":")
+    .filter((p) => p !== "");
+  if (!parts.length) return null;
+  let graph = rootGraph;
+  for (let i = 0; i < parts.length; i++) {
+    const node = graph?.getNodeById?.(Number(parts[i])) ?? null;
+    if (!node) return null;
+    if (i === parts.length - 1) return node;
+    graph = node.subgraph ?? null;
+  }
+  return null;
+}
+
+/**
+ * Keep a candidate only if some widget on the node STILL literally holds that
+ * filename. Fails OPEN (returns true / "still referenced") on any unexpected
+ * shape, so the worst case is over-reporting and a real miss is never swallowed.
+ */
+export function assetCandidateStillReferenced(rootGraph, nodeId, file) {
+  try {
+    if (nodeId == null || !file) return true;
+    const node = findNodeByScopedId(rootGraph, nodeId);
+    if (!node || !Array.isArray(node.widgets) || !node.widgets.length) return true;
+    return node.widgets.some((w) => w?.value === file);
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * True when the candidate's filename IS an accepted value on the live node widget
+ * combo — i.e. the server already knows the file and the store entry is stale.
+ * Fails CLOSED (returns false / "keep it") on any unexpected shape, so a genuinely
+ * missing model is never silently swallowed.
+ */
+export function assetCandidateResolvesLive(rootGraph, nodeId, file, widgetName) {
+  try {
+    if (nodeId == null || !file) return false;
+    const node = findNodeByScopedId(rootGraph, nodeId);
+    if (!node || !Array.isArray(node.widgets)) return false;
+    const w = widgetName
+      ? node.widgets.find((x) => x?.name === widgetName)
+      : node.widgets.find((x) => Array.isArray(x?.options?.values));
+    if (!w) return false;
+    const raw = w.options?.values;
+    const list = typeof raw === "function" ? raw(w, node) : raw;
+    return Array.isArray(list) && list.includes(file);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * A missing-asset store candidate is stale (should NOT be reported) when either
+ * no widget still references the file (the value was changed to a fix) OR the
+ * file now resolves against the node's live combo options (it appeared on disk).
+ * Anything else keeps it reported — genuine misses always survive.
+ */
+export function isStaleAssetCandidate(rootGraph, candidate) {
+  const nodeId = candidate?.nodeId;
+  const file = candidate?.name;
+  const widgetName = candidate?.widgetName;
+  if (!assetCandidateStillReferenced(rootGraph, nodeId, file)) return true;
+  if (assetCandidateResolvesLive(rootGraph, nodeId, file, widgetName)) return true;
+  return false;
+}
+
+/**
+ * Ordered widget-input names for a node definition (`node.constructor.nodeData`):
+ * required inputs then optional, honoring `input_order` when present.
+ */
+export function orderedWidgetInputNames(nodeData) {
+  const input = nodeData?.input;
+  if (!input) return [];
+  const req =
+    input.required && typeof input.required === "object"
+      ? Object.keys(input.required)
+      : [];
+  const opt =
+    input.optional && typeof input.optional === "object"
+      ? Object.keys(input.optional)
+      : [];
+  const order = nodeData?.input_order;
+  if (order && (Array.isArray(order.required) || Array.isArray(order.optional))) {
+    return [...(order.required ?? req), ...(order.optional ?? opt)];
+  }
+  return [...req, ...opt];
+}
+
+/**
+ * Repair positional `UNKNOWN`/`UNKNOWN_n` widget placeholders in place by mapping
+ * them to the node's live definition widget-input order — but ONLY in the
+ * unambiguous case where the def's widget-input count equals the widget count, so
+ * a mismatch never mis-assigns. Fails open (leaves names untouched) otherwise.
+ * Returns true if it renamed at least one widget.
+ */
+export function reconcileUnknownWidgetNames(node) {
+  try {
+    const widgets = node?.widgets;
+    if (!Array.isArray(widgets) || !widgets.length) return false;
+    if (!widgets.some((w) => UNKNOWN_WIDGET_RE.test(w?.name ?? ""))) return false;
+    const ordered = orderedWidgetInputNames(node.constructor?.nodeData);
+    if (ordered.length !== widgets.length) return false;
+    let changed = false;
+    widgets.forEach((w, i) => {
+      if (w && UNKNOWN_WIDGET_RE.test(w.name ?? "") && ordered[i]) {
+        w.name = ordered[i];
+        changed = true;
+      }
+    });
+    return changed;
+  } catch {
+    return false;
+  }
+}

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -109,26 +109,51 @@ export function isStaleAssetCandidate(rootGraph, candidate, { trustCombo = false
   return false;
 }
 
+// Input types that ComfyUI renders as a WIDGET rather than a connection socket.
+// A combo (the type spec is an array of option values) is also a widget.
+const WIDGET_INPUT_TYPES = new Set(["INT", "FLOAT", "STRING", "BOOLEAN", "COMBO"]);
+
 /**
- * Ordered widget-input names for a node definition (`node.constructor.nodeData`):
- * required inputs then optional, honoring `input_order` when present.
+ * True when an object_info input SPEC (`[type, config?]`) is rendered as a widget
+ * — i.e. it maps to a positional entry in the node's `widgets` array. Connection
+ * inputs (MODEL, CLIP, LATENT, IMAGE, …) and any input forced to a socket
+ * (`config.forceInput` / `config.widget === false`) are NOT widgets and must be
+ * excluded when counting/ordering widgets (codex WS-3 round-2 finding #3).
+ */
+export function isWidgetInputSpec(spec) {
+  const arr = Array.isArray(spec) ? spec : [spec];
+  const type = arr[0];
+  const config = arr[1];
+  if (config && typeof config === "object") {
+    if (config.forceInput) return false;
+    if (config.widget === false) return false;
+  }
+  if (Array.isArray(type)) return true; // combo: option list as the type
+  return WIDGET_INPUT_TYPES.has(String(type ?? "").toUpperCase());
+}
+
+/**
+ * Ordered WIDGET-input names for a node definition (`node.constructor.nodeData`):
+ * required inputs then optional, honoring `input_order` when present, and
+ * EXCLUDING connection-only inputs so the count lines up with the node's
+ * positional `widgets` array. LTXICLoRALoaderModelOnly = connection `model` +
+ * widgets `lora_name`,`strength_model` → ["lora_name","strength_model"].
  */
 export function orderedWidgetInputNames(nodeData) {
   const input = nodeData?.input;
   if (!input) return [];
-  const req =
-    input.required && typeof input.required === "object"
-      ? Object.keys(input.required)
-      : [];
-  const opt =
-    input.optional && typeof input.optional === "object"
-      ? Object.keys(input.optional)
-      : [];
+  const req = input.required && typeof input.required === "object" ? input.required : {};
+  const opt = input.optional && typeof input.optional === "object" ? input.optional : {};
   const order = nodeData?.input_order;
-  if (order && (Array.isArray(order.required) || Array.isArray(order.optional))) {
-    return [...(order.required ?? req), ...(order.optional ?? opt)];
-  }
-  return [...req, ...opt];
+  const reqNames =
+    order && Array.isArray(order.required) ? order.required : Object.keys(req);
+  const optNames =
+    order && Array.isArray(order.optional) ? order.optional : Object.keys(opt);
+  const ordered = [...reqNames, ...optNames];
+  return ordered.filter((name) => {
+    const spec = name in req ? req[name] : name in opt ? opt[name] : undefined;
+    return spec !== undefined && isWidgetInputSpec(spec);
+  });
 }
 
 /**

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -15,9 +15,23 @@
 const UNKNOWN_WIDGET_RE = /^UNKNOWN(_\d+)?$/;
 
 /**
- * Resolve a possibly subgraph-scoped node id ("6051:1913", or plain 42) against
- * the ROOT graph, walking one hop per ':' segment through `.subgraph`. Returns
- * the node or null.
+ * Look a node up by a single id segment. ComfyUI supports arbitrary STRING node
+ * ids (UUID-like), so we must NOT coerce to Number blindly (that would turn a
+ * UUID into NaN and never match). Try the raw segment first; only fall back to a
+ * numeric lookup for an all-digits segment, since some LiteGraph builds key
+ * `_nodes_by_id` by number.
+ */
+function getNodeBySegment(graph, seg) {
+  if (!graph?.getNodeById) return null;
+  let node = graph.getNodeById(seg) ?? null;
+  if (!node && /^\d+$/.test(seg)) node = graph.getNodeById(Number(seg)) ?? null;
+  return node;
+}
+
+/**
+ * Resolve a possibly subgraph-scoped node id ("6051:1913", a plain 42, or a
+ * string/UUID id) against the ROOT graph, walking one hop per ':' segment through
+ * `.subgraph`. Returns the node or null.
  */
 export function findNodeByScopedId(rootGraph, scopedId) {
   const parts = String(scopedId ?? "")
@@ -26,7 +40,7 @@ export function findNodeByScopedId(rootGraph, scopedId) {
   if (!parts.length) return null;
   let graph = rootGraph;
   for (let i = 0; i < parts.length; i++) {
-    const node = graph?.getNodeById?.(Number(parts[i])) ?? null;
+    const node = getNodeBySegment(graph, parts[i]);
     if (!node) return null;
     if (i === parts.length - 1) return node;
     graph = node.subgraph ?? null;
@@ -76,15 +90,22 @@ export function assetCandidateResolvesLive(rootGraph, nodeId, file, widgetName) 
 /**
  * A missing-asset store candidate is stale (should NOT be reported) when either
  * no widget still references the file (the value was changed to a fix) OR the
- * file now resolves against the node's live combo options (it appeared on disk).
+ * file resolves against the node's live combo options (it appeared on disk).
  * Anything else keeps it reported — genuine misses always survive.
+ *
+ * The combo-membership check is ONLY trusted when `trustCombo` is true — i.e.
+ * after a CONFIRMED successful node-def/combo refresh. A combo populated at page
+ * load can be STALE (still listing a since-deleted file); trusting it then would
+ * SUPPRESS a genuine `isMissing:true` candidate, which we must never do. Without
+ * a confirmed refresh we fall back to over-reporting via the still-referenced
+ * check alone.
  */
-export function isStaleAssetCandidate(rootGraph, candidate) {
+export function isStaleAssetCandidate(rootGraph, candidate, { trustCombo = false } = {}) {
   const nodeId = candidate?.nodeId;
   const file = candidate?.name;
   const widgetName = candidate?.widgetName;
   if (!assetCandidateStillReferenced(rootGraph, nodeId, file)) return true;
-  if (assetCandidateResolvesLive(rootGraph, nodeId, file, widgetName)) return true;
+  if (trustCombo && assetCandidateResolvesLive(rootGraph, nodeId, file, widgetName)) return true;
   return false;
 }
 
@@ -112,17 +133,23 @@ export function orderedWidgetInputNames(nodeData) {
 
 /**
  * Repair positional `UNKNOWN`/`UNKNOWN_n` widget placeholders in place by mapping
- * them to the node's live definition widget-input order — but ONLY in the
- * unambiguous case where the def's widget-input count equals the widget count, so
- * a mismatch never mis-assigns. Fails open (leaves names untouched) otherwise.
+ * them to the node's definition widget-input order — but ONLY in the unambiguous
+ * case where the def's widget-input count equals the widget count, so a mismatch
+ * never mis-assigns. Fails open (leaves names untouched) otherwise.
+ *
+ * `freshDef` lets a post-restart refresh pass the CURRENT def straight in: an
+ * already-loaded node keeps its old constructor after registerNodesFromDefs (each
+ * registration makes a new class), so `node.constructor.nodeData` alone is stale
+ * or absent for exactly the nodes that need repairing. Falls back to the
+ * constructor's nodeData when no fresh def is supplied.
  * Returns true if it renamed at least one widget.
  */
-export function reconcileUnknownWidgetNames(node) {
+export function reconcileUnknownWidgetNames(node, freshDef) {
   try {
     const widgets = node?.widgets;
     if (!Array.isArray(widgets) || !widgets.length) return false;
     if (!widgets.some((w) => UNKNOWN_WIDGET_RE.test(w?.name ?? ""))) return false;
-    const ordered = orderedWidgetInputNames(node.constructor?.nodeData);
+    const ordered = orderedWidgetInputNames(freshDef ?? node.constructor?.nodeData);
     if (ordered.length !== widgets.length) return false;
     let changed = false;
     widgets.forEach((w, i) => {
@@ -135,4 +162,65 @@ export function reconcileUnknownWidgetNames(node) {
   } catch {
     return false;
   }
+}
+
+/**
+ * Every graph reachable from a root graph, including nested subgraphs (one entry
+ * per `.subgraph` on any node). Used to sweep ALL live node instances after a
+ * def refresh, not just the root canvas.
+ */
+export function collectAllGraphs(rootGraph) {
+  const out = [];
+  const seen = new Set();
+  const stack = [rootGraph];
+  while (stack.length) {
+    const g = stack.pop();
+    if (!g || seen.has(g)) continue;
+    seen.add(g);
+    out.push(g);
+    for (const node of g._nodes ?? []) {
+      if (node?.subgraph) stack.push(node.subgraph);
+    }
+  }
+  return out;
+}
+
+/**
+ * After a node-def refresh, re-apply the fresh definitions to ALREADY-LOADED node
+ * instances (finding #3): registerNodesFromDefs mints a NEW class per type, so
+ * existing instances keep their old/generic constructor and would otherwise never
+ * see the updated schema. For each live node we (a) stamp the fresh def onto its
+ * type-specific constructor's `nodeData` so schema reads are current, and (b)
+ * reconcile any UNKNOWN widget placeholders using the fresh def directly (works
+ * even when the instance sits on a generic fallback constructor with no nodeData).
+ * `defsByType` is the `class_type → def` map from api.getNodeDefs(). Returns the
+ * number of nodes whose UNKNOWN widgets were repaired. Fully defensive.
+ */
+export function reapplyDefsToLiveNodes(rootGraph, defsByType) {
+  let repaired = 0;
+  if (!defsByType) return repaired;
+  try {
+    for (const graph of collectAllGraphs(rootGraph)) {
+      for (const node of graph._nodes ?? []) {
+        const type = node?.type ?? node?.comfyClass;
+        const def = type ? defsByType[type] : null;
+        if (!def) continue;
+        // Stamp only onto a TYPE-SPECIFIC constructor (already carries nodeData
+        // for this type) — never onto a shared generic/unknown fallback class,
+        // which would corrupt every other unknown node.
+        const ctor = node.constructor;
+        if (ctor && ctor.nodeData) {
+          try {
+            ctor.nodeData = def;
+          } catch {
+            /* frozen / non-writable — skip */
+          }
+        }
+        if (reconcileUnknownWidgetNames(node, def)) repaired++;
+      }
+    }
+  } catch {
+    /* best-effort sweep */
+  }
+  return repaired;
 }


### PR DESCRIPTION
Root theme: the panel's load-time snapshots (missingModel/missingMedia Pinia stores) and the ComfyUI frontend node registry are captured once and never re-evaluated after a widget edit or a ComfyUI restart. Invalidate/reconcile on the triggering event.

## Fixes
- Closes #196 — get_errors stale missing_models/missing_media (load-time snapshot never re-evaluated).
- Closes #203 — stale missing_model after set_widget.
- Closes #223 — stale missing_model for a checkpoint the server DOES list in /object_info + /models.
- Closes #185 — freshly installed models reported missing after restart.
- Closes #181 — installed upscale model falsely reported missing after download.
- Closes #171 — stale custom-node schemas after restart.
- Closes #221 — refresh panel node registry after restart.
- Closes #199 — load_workflow exposes known custom-node widgets as UNKNOWN.

## Approach
- `collectMissingAssets()` now cross-checks each store candidate against the LIVE graph (subgraph-scoped ids like `6051:1913` supported): a candidate is stale — and dropped — when no widget still references the file (fixed via set_widget) OR the filename resolves in the node's live combo options (appeared on disk after a download/restart). Fails toward over-reporting; a genuine miss is never swallowed. Combines the two community-proposed patches (#196 + #223).
- On ComfyUI's `reconnected` event (the in-tab signal the backend came back after a restart), re-pull `/object_info` and call `registerNodesFromDefs` + `refreshComboInNodes`, so newly installed node classes, updated widget schemas, and fresh model dropdowns are live before graph tools resume (#221/#171 — also feeds the combo cross-check above for #185/#181).
- `panel_set_widget` reconciles positional `UNKNOWN`/`UNKNOWN_n` widget placeholders against the node's live definition widget-input order, but only in the unambiguous 1:1 case, before resolving the requested name (#199).

## Tests
Pure logic extracted to `web/js/lib/asset-staleness.js`; `browser_tests/unit/asset-staleness.test.mjs` adds 14 `node --test` cases (scoped-id walk, fixed-by-edit, appeared-on-disk, fail-open/closed, UNKNOWN reconciliation). `npm run test:unit` green (178 total). `node --check` passes on the panel module as an ES module.

Note for the merger: full in-browser behavioural verification (hard refresh + a live restart) is deferred to the coordinator's live-test — the pure logic is unit-covered, the frontend-glue (`refreshComfyNodeDefs`, `reconcileUnknownWidgetNames` call site) is guarded and fails open.

MCP-side sibling PR: artokun/comfyui-mcp#402 (#352/#364/#353/#357/#394/#378/#399).

[reports ≤mcp 0.48.6 / panel 0.11.5]