### PR TITLE
fix(chat): media persistence + object serialization (WS-9)

### DIFF
--- a/browser_tests/unit/chat-media-persistence.test.mjs
+++ b/browser_tests/unit/chat-media-persistence.test.mjs
@@ -1,0 +1,208 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ChatHistoryStore,
+  normalizeThread,
+  mergeHistorySnapshots,
+} from "../../web/js/lib/chat-history-store.js";
+import { mediaRecordFor, isDurableMediaUrl, createMediaRecorder } from "../../web/js/lib/chat-media.js";
+
+// Media persistence (#177): image/video cards are recorded as role:"media"
+// messages carrying a SERVABLE url + caption. These tests assert the durable
+// store keeps such messages verbatim across a persist -> reload cycle, so the
+// panel's paintThread() media branch can replay them (previously media painted
+// to the DOM only and vanished on reload).
+
+function createMemoryStorage() {
+  const values = new Map();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+    removeItem: (key) => values.delete(key),
+  };
+}
+
+// Minimal single-record IndexedDB fake matching the store's access pattern.
+function createFakeIndexedDb(initialState = null) {
+  let state = initialState == null ? null : structuredClone(initialState);
+  const createDb = () => ({
+    objectStoreNames: { contains: (name) => name === "snapshots" },
+    createObjectStore() {},
+    close() {},
+    transaction: (_name, mode) => {
+      const tx = { oncomplete: null, onerror: null, onabort: null,
+        objectStore: () => ({
+          get: () => {
+            const request = { result: undefined, onsuccess: null, onerror: null };
+            queueMicrotask(() => {
+              request.result = state == null ? undefined : structuredClone(state);
+              request.onsuccess?.();
+            });
+            return request;
+          },
+          put: (value) => {
+            assert.equal(mode, "readwrite");
+            state = structuredClone(value);
+            queueMicrotask(() => tx.oncomplete?.());
+          },
+        }),
+      };
+      return tx;
+    },
+  });
+  return {
+    open: () => {
+      const request = { result: null, onupgradeneeded: null, onsuccess: null, onerror: null, onblocked: null };
+      queueMicrotask(() => {
+        request.result = createDb();
+        request.onsuccess?.();
+      });
+      return request;
+    },
+  };
+}
+
+const mediaThread = () => ({
+  id: "media-thread",
+  ts: 1000,
+  updatedAt: 1000,
+  workflowKey: "panel:global",
+  msgs: [
+    { id: "m-user", role: "user", text: "make me a picture", createdAt: 100 },
+    { id: "m-img", role: "media", mkind: "image", url: "/view?filename=out.png&type=output", caption: "output", createdAt: 200 },
+    { id: "m-vid", role: "media", mkind: "video", url: "/view?filename=clip.mp4&type=output", caption: "clip", createdAt: 300 },
+  ],
+});
+
+// mediaRecordFor is the exact decision recordMedia() delegates to: it decides
+// whether a painted card becomes a persisted role:"media" record. These tests
+// exercise the real fix (previously the suite only seeded already-correct media
+// messages, so it passed even if recordMedia never ran).
+
+test("a live /view image paints -> exactly one durable record (#177)", () => {
+  const rec = mediaRecordFor("image", "/view?filename=out.png&type=output", "output");
+  assert.ok(rec, "a servable /view url is recorded");
+  assert.equal(rec.role, "media");
+  assert.equal(rec.mkind, "image");
+  assert.equal(rec.url, "/view?filename=out.png&type=output");
+});
+
+test("an absolute http(s) media url is recorded, other schemes/paths are not", () => {
+  assert.ok(mediaRecordFor("video", "https://cdn.example/clip.mp4", "c"), "http(s) is durable");
+  assert.ok(isDurableMediaUrl("/api/view?filename=x.png"), "/api/view is durable");
+  assert.equal(isDurableMediaUrl("/not-a-view/x.png"), false, "arbitrary path rejected");
+  assert.equal(isDurableMediaUrl("//evil.example/x.png"), false, "protocol-relative rejected");
+});
+
+test("data: / blob: / whitespace-prefixed data: urls are NEVER persisted (#177 P1)", () => {
+  assert.equal(mediaRecordFor("image", "data:image/png;base64,AAAA", "x"), null);
+  assert.equal(mediaRecordFor("image", "   data:image/png;base64,AAAA", "x"), null, "whitespace-prefixed data: rejected");
+  assert.equal(mediaRecordFor("video", "blob:http://localhost/abc-123", "x"), null, "blob: rejected (dead after reload)");
+  assert.equal(mediaRecordFor("image", "file:///etc/passwd", "x"), null, "file: rejected");
+});
+
+test("replay never re-records -> reload preserves media count (#177)", () => {
+  // The replay guard: paintThread() repaints stored media with replaying=true,
+  // which must yield NO new record (otherwise every reload would duplicate it).
+  assert.equal(mediaRecordFor("image", "/view?filename=out.png", "x", { replaying: true }), null);
+  assert.equal(mediaRecordFor("video", "https://cdn.example/clip.mp4", "x", { replaying: true }), null);
+});
+
+test("normalizeThread preserves role:media messages with url/caption/kind", () => {
+  const thread = normalizeThread(mediaThread());
+  const media = thread.msgs.filter((m) => m.role === "media");
+  assert.equal(media.length, 2);
+  assert.equal(media[0].mkind, "image");
+  assert.equal(media[0].url, "/view?filename=out.png&type=output");
+  assert.equal(media[0].caption, "output");
+  assert.equal(media[1].mkind, "video");
+});
+
+test("media messages survive a merge round-trip", () => {
+  const merged = mergeHistorySnapshots({ threads: [mediaThread()], meta: {} });
+  const media = merged.threads[0].msgs.filter((m) => m.role === "media");
+  assert.equal(media.length, 2);
+  assert.deepEqual(media.map((m) => m.mkind), ["image", "video"]);
+});
+
+test("media cards persist across a reload (persist -> new store -> load) (#177)", async () => {
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  const seeded = normalizeThread(mediaThread());
+  store.persist([seeded], { activeByScope: { "panel:global": "media-thread" } });
+  await store.flush();
+
+  // Simulate a hard refresh: a brand-new store instance reading the same DB.
+  const reloadStore = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  const reloaded = await reloadStore.load();
+  const thread = reloaded.threads.find((t) => t.id === "media-thread");
+  assert.ok(thread, "thread survived reload");
+  const media = thread.msgs.filter((m) => m.role === "media");
+  assert.equal(media.length, 2, "both media cards survived reload");
+  assert.equal(media[0].url, "/view?filename=out.png&type=output");
+  assert.equal(media[1].mkind, "video");
+});
+
+// Integration seam for the PRODUCTION paint -> record -> replay flow (#177).
+//
+// This drives the ACTUAL production module createMediaRecorder() — the panel's
+// recordMedia() delegates to `mediaRecorder.record()` and paintThread() wraps
+// its replay loop in `mediaRecorder.replay()`. So breaking the record decision
+// or the replay guard in production FAILS this test (it is not a replica).
+//
+// `record` here stands in for the panel's record() (append to thread.msgs +
+// persist). What this test canNOT reach is the DOM-closure WIRING — that
+// paintImage/paintVideo call mediaRecorder.record and that paintThread wraps
+// its loop in mediaRecorder.replay; those two bindings are covered by live-test.
+
+function makeThreadRecorder() {
+  const thread = { id: "seam-thread", ts: 1, msgs: [] };
+  let idSeq = 0;
+  // Stand-in for the panel's record(): assign id + append (mirrors thread.msgs.push).
+  const record = (rec) => {
+    rec.id = `m${(idSeq += 1)}`;
+    rec.createdAt = idSeq;
+    thread.msgs.push(rec);
+    return rec;
+  };
+  return { thread, recorder: createMediaRecorder(record) };
+}
+
+test("production seam: a live /view paint records exactly ONE message; replay leaves the count unchanged (#177)", async () => {
+  const { thread, recorder } = makeThreadRecorder();
+
+  // Live turn paints one servable image → exactly one persisted record.
+  recorder.record("image", "/view?filename=out.png&type=output", "output");
+  assert.equal(thread.msgs.length, 1, "one media record after a live /view paint");
+
+  // A user attachment (data:) paints live but must NOT be persisted.
+  recorder.record("image", "data:image/png;base64,AAAA", "attachment");
+  assert.equal(thread.msgs.length, 1, "data: paint added no record");
+
+  // Reload → paintThread() replays stored msgs inside recorder.replay(); the
+  // guard must add ZERO (otherwise every reload would duplicate the media).
+  // Drive the replay exactly as paintThread does: replay each stored media msg.
+  const replayStored = () =>
+    recorder.replay(() => {
+      for (const m of thread.msgs.slice()) {
+        if (m.role === "media") recorder.record(m.mkind, m.url, m.caption);
+      }
+    });
+
+  const beforeReplay = thread.msgs.length;
+  replayStored();
+  assert.equal(thread.msgs.length, beforeReplay, "replay did not duplicate media");
+  replayStored();
+  assert.equal(thread.msgs.length, beforeReplay, "repeated replay stays stable");
+
+  // And the count round-trips through the store the production path writes to.
+  const indexedDb = createFakeIndexedDb();
+  const store = new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb });
+  store.persist([normalizeThread(thread)], {});
+  await store.flush();
+  const reloaded = await new ChatHistoryStore({ storage: createMemoryStorage(), indexedDb }).load();
+  const media = reloaded.threads[0].msgs.filter((m) => m.role === "media");
+  assert.equal(media.length, 1, "exactly one media message persisted");
+  assert.equal(media[0].url, "/view?filename=out.png&type=output");
+});

--- a/browser_tests/unit/chat-serialize.test.mjs
+++ b/browser_tests/unit/chat-serialize.test.mjs
@@ -1,0 +1,88 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { coerceMessageText, buttonReplyText } from "../../web/js/lib/chat-serialize.js";
+
+test("strings pass through unchanged", () => {
+  assert.equal(coerceMessageText("hello"), "hello");
+  assert.equal(coerceMessageText(""), "");
+});
+
+test("null/undefined become empty string", () => {
+  assert.equal(coerceMessageText(null), "");
+  assert.equal(coerceMessageText(undefined), "");
+});
+
+test("primitives coerce with String()", () => {
+  assert.equal(coerceMessageText(42), "42");
+  assert.equal(coerceMessageText(true), "true");
+});
+
+test("a plain object never renders as [object Object] (#219/#176/#175/#168)", () => {
+  const out = coerceMessageText({ foo: 1, bar: 2 });
+  assert.notEqual(out, "[object Object]");
+  assert.equal(out, '{"foo":1,"bar":2}');
+});
+
+test("known string field is extracted from a card reply object (#219)", () => {
+  assert.equal(coerceMessageText({ reply: "Yes" }), "Yes");
+  assert.equal(coerceMessageText({ label: "Click me" }), "Click me");
+  assert.equal(coerceMessageText({ value: "v" }), "v");
+});
+
+test("string-field priority prefers reply/text over value", () => {
+  assert.equal(coerceMessageText({ value: "v", text: "t", reply: "r" }), "r");
+  assert.equal(coerceMessageText({ value: "v", text: "t" }), "t");
+});
+
+test("structured backend error object extracts a readable message (#176)", () => {
+  assert.equal(
+    coerceMessageText({ error: "Individual quota reached." }),
+    "Individual quota reached.",
+  );
+  assert.equal(coerceMessageText({ message: "boom" }), "boom");
+});
+
+test("empty string fields are skipped in favor of JSON", () => {
+  const out = coerceMessageText({ reply: "", code: 1 });
+  assert.notEqual(out, "[object Object]");
+  assert.equal(out, '{"reply":"","code":1}');
+});
+
+test("cyclic / unserializable objects degrade to empty string, never [object Object]", () => {
+  const cyclic = {};
+  cyclic.self = cyclic;
+  const out = coerceMessageText(cyclic);
+  assert.notEqual(out, "[object Object]");
+  assert.equal(out, "");
+});
+
+// buttonReplyText is the A2UI Button click chokepoint — the value it returns is
+// exactly what ctx.choose()/sendCardReply() forward into user_message.text, so
+// these assertions exercise the real #219 regression path (a button click must
+// emit a STRING, never "[object Object]").
+test("a normal string Button reply passes through (#219)", () => {
+  assert.equal(buttonReplyText({ reply: "Approve" }), "Approve");
+});
+
+test("a Button click always yields a string, even for an object reply (#219)", () => {
+  const out = buttonReplyText({ reply: { unexpected: "object" } });
+  assert.equal(typeof out, "string");
+  assert.notEqual(out, "[object Object]");
+});
+
+test("a SUBMIT button with an object reply does NOT bake [object Object] into the fields template (#219)", () => {
+  const fields = [
+    { name: "email", read: () => "a@b.com" },
+    { name: "note", read: () => "hi" },
+  ];
+  const out = buttonReplyText({ reply: { bad: 1 }, submit: true }, fields);
+  assert.equal(typeof out, "string");
+  assert.ok(!out.includes("[object Object]"), `got: ${out}`);
+  assert.ok(out.includes("email: a@b.com"));
+  assert.ok(out.includes("note: hi"));
+});
+
+test("falls back to label when reply is absent", () => {
+  assert.equal(buttonReplyText({ label: "Cancel" }), "Cancel");
+});

--- a/web/js/cmcp-a2ui-lit-adapter.js
+++ b/web/js/cmcp-a2ui-lit-adapter.js
@@ -28,6 +28,8 @@
 // module top level, so this file (and cmcp-a2ui.js, which imports it) stays
 // importable under `node --test` with no DOM/browser present.
 
+import { buttonReplyText } from "./lib/chat-serialize.js";
+
 let _bundlePromise = null;
 function loadBundle() {
   if (!_bundlePromise) _bundlePromise = import("./vendor/a2ui-lit.bundle.js");
@@ -129,12 +131,10 @@ export function mountStandardComponent(c, ctx) {
     const wrap = mountA2uiLeaf(c, {
       onFire: () => {
         if (ctx.isResolved()) return;
-        let text = c.reply ?? c.label;
-        if (c.submit) {
-          const lines = ctx.fields.map((f) => `${f.name}: ${f.read()}`);
-          if (lines.length) text = `${text}\n${lines.join("\n")}`;
-        }
-        ctx.choose(wrap, text);
+        // buttonReplyText coerces an object reply to a string BEFORE the submit
+        // fields template interpolates it, so a malformed spec can't bake
+        // "[object Object]" into the outgoing message (#219).
+        ctx.choose(wrap, buttonReplyText(c, ctx.fields));
       },
     });
     ctx.buttons.push(wrap);

--- a/web/js/cmcp-a2ui.js
+++ b/web/js/cmcp-a2ui.js
@@ -6,6 +6,8 @@
 // Component types and attributes come from the enums validated here. See
 // docs/superpowers/specs/2026-07-10-a2ui-chat-design.md.
 
+import { coerceMessageText } from "./lib/chat-serialize.js";
+
 export const A2UI_CAPS = Object.freeze({
   maxComponents: 64,
   maxDepth: 8,
@@ -552,8 +554,14 @@ export function renderA2UICard(spec, { onAction, onDismiss } = {}) {
     fields: [],
     isResolved: () => resolved,
     choose: (btn, text) => {
-      handle.resolve(text, btn);
-      onAction?.(text);
+      // A button's `reply`/`label` should be a string, but a malformed spec (or
+      // a submit-serialized object) can arrive as a non-string here. Normalize
+      // at this single chokepoint so an object never reaches resolve()'s
+      // choiceText.split() or the outgoing user_message as "[object Object]"
+      // (#219). Both the hand-rolled and Lit Button paths flow through choose().
+      const reply = coerceMessageText(text);
+      handle.resolve(reply, btn);
+      onAction?.(reply);
     },
   };
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -89,6 +89,8 @@ import {
   reconcileUnknownWidgetNames,
   reapplyDefsToLiveNodes,
 } from "./lib/asset-staleness.js";
+import { coerceMessageText } from "./lib/chat-serialize.js";
+import { createMediaRecorder } from "./lib/chat-media.js";
 
 let app = null;
 let api = null;
@@ -11541,6 +11543,16 @@ function buildPanel() {
     return entry;
   }
 
+  // Media persistence controller (#177): owns the record decision + replay
+  // guard (see lib/chat-media.js). paintImage/paintVideo call mediaRecorder.record
+  // after painting; paintThread wraps its replay loop in mediaRecorder.replay so
+  // stored media repaints without re-recording. Only DURABLE urls are persisted
+  // (ComfyUI /view / absolute http(s)); data:/blob:/other are rejected.
+  const mediaRecorder = createMediaRecorder(record);
+  function recordMedia(mkind, url, caption) {
+    mediaRecorder.record(mkind, url, caption);
+  }
+
   /** Bind the agent's current session id to the open thread (for reload/resume). */
   function bindSession(sessionId) {
     const previousSessionId = thread?.sessionId || null;
@@ -11708,6 +11720,8 @@ function buildPanel() {
     }
     log.appendChild(card);
     scrollLog();
+    // Persist servable images so they survive reload / thread switch (#177).
+    recordMedia("image", url, name);
   }
 
   // Lazy chat-video manager: only videos currently scrolled into view hold a live
@@ -11784,6 +11798,8 @@ function buildPanel() {
     log.appendChild(card);
     videoObserver().observe(holder);
     scrollLog();
+    // Persist servable videos so they survive reload / thread switch (#177).
+    recordMedia("video", url, name);
   }
 
   /** Decide whether a ComfyUI output descriptor is a VIDEO (render <video>) vs an
@@ -11806,8 +11822,14 @@ function buildPanel() {
 
   /** Round-trip: a card interaction becomes a normal, visible user message. */
   function sendCardReply(text) {
-    appendUser(text, {});
-    const ok = client?.sendUserMessage?.(text);
+    // Card interactions are supposed to hand us a string reply, but a malformed
+    // A2UI spec can send an object through this boundary — coerce it so neither
+    // the visible bubble nor the outgoing user_message becomes "[object Object]"
+    // (#219). cmcp-a2ui already normalizes at ctx.choose(); this is the panel's
+    // own guard for any other caller.
+    const reply = coerceMessageText(text);
+    appendUser(reply, {});
+    const ok = client?.sendUserMessage?.(reply);
     if (!ok) appendSystem("Card reply couldn't be sent — agent disconnected.");
   }
 
@@ -12548,14 +12570,22 @@ function buildPanel() {
   function paintThread(t) {
     thread = t;
     resetFeed();
-    for (const m of t.msgs) {
-      if (m.role === "user") paintUser(m.text, { attachments: m.attachments, workflowVersion: m.workflowVersion });
-      else if (m.role === "agent") paintAgent(m.text);
-      else if (m.role === "card") {
-        if (m.kind === "a2ui") paintA2UIRecord(m);
-        else paintCard(m);
+    // Replay guard: paintImage/paintVideo record servable media as they paint;
+    // during a stored-history replay they must repaint WITHOUT re-recording
+    // (which would duplicate the media on every reload / thread switch) (#177).
+    mediaRecorder.replay(() => {
+      for (const m of t.msgs) {
+        if (m.role === "user") paintUser(m.text, { attachments: m.attachments, workflowVersion: m.workflowVersion });
+        else if (m.role === "agent") paintAgent(m.text);
+        else if (m.role === "media") {
+          if (m.mkind === "video") paintVideo(m.url, m.caption);
+          else paintImage(m.url, m.caption);
+        } else if (m.role === "card") {
+          if (m.kind === "a2ui") paintA2UIRecord(m);
+          else paintCard(m);
+        }
       }
-    }
+    });
     // resetFeed() recreated the indicator (if a turn is live) ABOVE these
     // repainted messages — re-pin it to the bottom so it trails the newest one.
     if (agentWorking) bumpThinking();

--- a/web/js/lib/chat-media.js
+++ b/web/js/lib/chat-media.js
@@ -1,0 +1,87 @@
+// Media-card persistence helpers (issue #177).
+//
+// Image/video cards are persisted as role:"media" messages so they survive a
+// reload / thread switch. Only DURABLE, re-servable urls may be stored: a
+// ComfyUI `/view` link or an absolute http(s) URL. Everything else is rejected
+// on a POSITIVE-admission basis:
+//   - `data:` URIs can be multiple MB and would blow the localStorage quota,
+//     taking the whole thread down with it;
+//   - `blob:` URLs are dead after a reload (object-URL lifetime is the page);
+//   - any other scheme (file:, ws:, protocol-relative //host, …) is not a
+//     durable panel media location.
+
+// A generous cap so a pathological query string can't bloat the transcript, yet
+// far above any real /view URL.
+export const MAX_MEDIA_URL_LENGTH = 4096;
+const MAX_MEDIA_CAPTION_LENGTH = 500;
+
+/** True only for a durable, re-servable media url (absolute http(s) or a
+ *  same-origin ComfyUI /view or /api/view link). Whitespace-tolerant. */
+export function isDurableMediaUrl(url) {
+  if (typeof url !== "string") return false;
+  const trimmed = url.trim();
+  if (!trimmed || trimmed.length > MAX_MEDIA_URL_LENGTH) return false;
+  if (/^https?:\/\//i.test(trimmed)) return true;
+  // Same-origin ComfyUI view links: "/view?…" or "/api/view?…" (api.apiURL may
+  // prefix the base). Requires the query so a bare "/view" directory can't slip
+  // through, and the leading "/[^/]" excludes protocol-relative "//host".
+  if (/^\/(?:api\/)?view\?/i.test(trimmed)) return true;
+  return false;
+}
+
+/** Build the role:"media" record for a painted card, or null when it must not
+ *  be persisted (currently replaying stored history, or a non-durable url).
+ *  Kept pure so the admission + replay-guard logic is unit-testable. */
+export function mediaRecordFor(mkind, url, caption, { replaying = false } = {}) {
+  if (replaying) return null; // replay repaints; it must never re-record (would dupe every reload)
+  if (!isDurableMediaUrl(url)) return null;
+  const kind = mkind === "video" ? "video" : "image";
+  return {
+    role: "media",
+    mkind: kind,
+    url: url.trim(),
+    caption: caption ? String(caption).slice(0, MAX_MEDIA_CAPTION_LENGTH) : "",
+  };
+}
+
+/** The media persistence controller the panel actually uses (#177).
+ *
+ *  This owns BOTH the record decision and the replay-guard state, so the exact
+ *  production logic is importable and unit-testable — not a replica. The DOM
+ *  closure wires it up:
+ *    - `record(rec)` is the panel's record() (append to thread + persist);
+ *    - paintImage()/paintVideo() call `recorder.record(kind, url, caption)`
+ *      after painting a card;
+ *    - paintThread() wraps its replay loop in `recorder.replay(() => …)` so the
+ *      media branch repaints WITHOUT re-recording.
+ *
+ *  A live paint persists exactly one durable card; a paint during replay(), or
+ *  of a non-durable url, persists nothing.
+ *
+ *  Not unit-testable from here (verified by live-test): that paintImage/
+ *  paintVideo actually call recorder.record and that paintThread wraps its loop
+ *  in recorder.replay — those bindings live in the DOM closure. */
+export function createMediaRecorder(record) {
+  let replaying = false;
+  return {
+    /** True while a stored conversation is being replayed. */
+    get replaying() {
+      return replaying;
+    },
+    /** Persist a painted card if durable and not replaying. Returns the record
+     *  appended, or null. */
+    record(mkind, url, caption) {
+      const rec = mediaRecordFor(mkind, url, caption, { replaying });
+      return rec ? record(rec) : null;
+    },
+    /** Run `fn` (the paintThread replay loop) with the re-record guard on. */
+    replay(fn) {
+      replaying = true;
+      try {
+        return fn();
+      } finally {
+        replaying = false;
+      }
+    },
+  };
+}

--- a/web/js/lib/chat-serialize.js
+++ b/web/js/lib/chat-serialize.js
@@ -1,0 +1,57 @@
+// Defensive text coercion for chat payloads.
+//
+// Several chat paths (A2UI card replies, structured backend messages, forwarded
+// user payloads) can receive an object where a string is expected. Implicit
+// coercion turns those into the literal "[object Object]" — a silent context
+// loss that has surfaced in the panel chat and in the agent prompt (issues
+// #219/#176/#175/#168). Route such values through coerceMessageText() so an
+// object is either reduced to a known string field or JSON-serialized, never
+// stringified via Object.prototype.toString.
+
+// Preferred string-bearing fields, in priority order, for a structured payload
+// (card reply, backend error/message object, UI action).
+const STRING_FIELDS = ["reply", "text", "label", "value", "message", "error", "detail"];
+
+/** Coerce an arbitrary chat payload to a human/agent-readable string.
+ *  - strings pass through unchanged;
+ *  - null/undefined become "";
+ *  - primitives use String();
+ *  - objects yield the first non-empty known string field, else JSON, else "".
+ *  Never returns "[object Object]" for a plain object. */
+export function coerceMessageText(value) {
+  if (typeof value === "string") return value;
+  if (value == null) return "";
+  if (typeof value !== "object") return String(value);
+  for (const key of STRING_FIELDS) {
+    const field = value[key];
+    if (typeof field === "string" && field) return field;
+  }
+  try {
+    const json = JSON.stringify(value);
+    // JSON.stringify returns undefined for e.g. a bare function; guard it.
+    return typeof json === "string" ? json : "";
+  } catch {
+    return "";
+  }
+}
+
+/** Compute the outgoing chat text for an A2UI Button click (#219).
+ *
+ *  The reply is `component.reply ?? component.label`, coerced to a string via
+ *  coerceMessageText FIRST — a malformed spec can carry an object reply, and if
+ *  a `submit` button then interpolates it into the fields template
+ *  (`${text}\n…`) BEFORE any downstream guard runs, the object stringifies to
+ *  "[object Object]" and is baked into the message. Coercing up front makes the
+ *  whole path string-safe regardless of the submit branch.
+ *
+ *  `fields` is the optional list of `{ name, read() }` collected by the form,
+ *  appended only for a submit button.
+ */
+export function buttonReplyText(component, fields = []) {
+  const base = coerceMessageText(component?.reply ?? component?.label ?? "");
+  if (component?.submit && Array.isArray(fields) && fields.length) {
+    const lines = fields.map((f) => `${f?.name}: ${f?.read?.() ?? ""}`);
+    if (lines.length) return `${base}\n${lines.join("\n")}`;
+  }
+  return base;
+}


### PR DESCRIPTION
## WS-9 chat remainder: media persistence + object serialization

Two clusters of the WS-9 work-set.

### Media persistence (#177) — Closes #177
Every image/video card was painted to the DOM but never written into the thread, so a reload or History thread-switch replayed all text with **zero media**.

- New `recordMedia(kind, url, caption)` records a `role:"media"` message. Only **servable** urls are persisted (ComfyUI `/view` links, http(s)); `data:` URIs (user attachments) are intentionally skipped so a multi-MB blob can't blow the localStorage quota.
- `paintImage`/`paintVideo` now call `recordMedia`, guarded by a new `replaying` flag so `paintThread()`'s replay repaints without re-recording (which would duplicate media every reload).
- `paintThread()` gains the missing `role:"media"` replay branch.

### Object serialization (#219) — Closes #219
A2UI card replies are normalized at the single `ctx.choose()` chokepoint in `cmcp-a2ui.js` (covers both the hand-rolled and Lit Button paths) and defensively in `sendCardReply()`, via a new `coerceMessageText()` helper (`web/js/lib/chat-serialize.js`). An object reply is reduced to a known string field (`reply`/`text`/`label`/`value`/...) or JSON-serialized — never `String(obj)` -> `"[object Object]"`.

### Related (companion PR)
`#176`/`#175`/`#168` are the same serialization family but originate in the **comfyui-mcp orchestrator** (the panel's `say`/`user_message` frames are already string-guarded). Fixed in the companion comfyui-mcp PR. `#163` (in-app media lightbox) is deferred — it's a self-contained feature (gallery/prev-next/keyboard/focus-trap) best done on its own.

### Tests
- `browser_tests/unit/chat-serialize.test.mjs` — `coerceMessageText` never yields `[object Object]` (objects, card-reply fields, structured errors, cyclic).
- `browser_tests/unit/chat-media-persistence.test.mjs` — `role:"media"` messages survive normalize/merge and a full persist -> new-store -> load reload cycle.
- `npm run test:unit` (now 188 tests) and `npm run typecheck` pass; both edited sources pass `node --check` as ES modules.

[reports <=panel 0.11.5]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
