### PR TITLE
release: 0.11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,26 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.6] - 2026-07-29
+
 ### Fixed
+- **SEVERE data loss: save-as must never move a persisted source (#226, reopened).** The
+  earlier #231 fix trusted the frontend's `saveWorkflowAs` to copy, but on comfyui-frontend
+  1.45.21 that call MOVES a source flagged temporary — and a `panel_open_workflow` ack-timeout
+  race (#215) can leave a real on-disk workflow flagged temporary, so `save_workflow({name})`
+  silently deleted the original. `saveActiveWorkflow` now classifies the source by ACTUAL
+  on-disk state (tri-state: persisted / never-persisted / unknown; only a null oracle result or
+  a doc with no path proves absence — a returned object, a thrown lookup, or a list-miss all fail
+  safe) and REFUSES any rename/move of a persisted-or-unknown source; a persisted save-as copies
+  with the source verified surviving; an empty/unresolved target can no longer be recomputed into
+  a move. Verified by 238 unit tests + a Chrome live-test (the exact repro that destroyed a file
+  under #231 now preserves it). (#239)
+- **Chat media persistence + structured-payload serialization (WS-9).** Inline chat images/video
+  survive a panel reload, and structured error/user payloads render as readable text instead of
+  `[object Object]`. (#228)
+- **Invalidate stale caches/snapshots after a restart+edit (WS-3).** Graph tools see the live
+  graph after a restart instead of a stale snapshot. (#227)
+- **Stop leaking typed-message image attachments in Blind mode (#174).** (#217)
 - **Route panel node ops by Manager generation (#187, #182, #184).** The
   built-in Manager helpers hardcoded the `/v2/manager/queue/task` envelope, so
   `panel_install_node` / `panel_update_node` returned HTTP 405 against Manager

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.5"
+version = "0.11.6"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -205,7 +205,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.5";
+const PANEL_VERSION = "0.11.6";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Panel 0.11.6. Headline: the **reopened #226 save-as data-loss fix (#239)** — codex-clean across 7 rounds (six distinct destructive paths + a backstop false-alarm closed), 238 unit tests, and **Chrome live-verified** (the exact repro that destroyed a workflow under the prior #231 fix now preserves it). Also bundles WS-9 chat media/serialization (#228), WS-3 stale-cache invalidation (#227), Blind-mode attachment leak (#174/#217), and Manager-generation node-op routing (#230). PANEL_VERSION bumped to match pyproject.

Follow-up noted: #215 (panel_open_workflow false-negative ack) causes the open-drift state in which save-as now safely REFUSES rather than copies — data-safe, but fixing #215 restores smooth copy behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)