### PR TITLE
fix(serialize): route sidebar output + persisted-message replay through the WS-9 serializer (#238 #241)

### DIFF
--- a/browser_tests/unit/chat-serialize.test.mjs
+++ b/browser_tests/unit/chat-serialize.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { coerceMessageText, buttonReplyText } from "../../web/js/lib/chat-serialize.js";
+import { coerceMessageText, buttonReplyText, isDroppedAgentReplay } from "../../web/js/lib/chat-serialize.js";
 
 test("strings pass through unchanged", () => {
   assert.equal(coerceMessageText("hello"), "hello");
@@ -123,4 +123,38 @@ test("a persisted codex-style content-parts assistant message replays as joined 
   const out = coerceMessageText(record.text);
   assert.notEqual(out, "[object Object]");
   assert.equal(out, "line one\nline two");
+});
+
+// --- replay drop decision (#241 codex round-1 follow-up) -------------------
+// paintAgent drops a record on replay iff isDroppedAgentReplay(text) — ONLY an
+// object that coerced to nothing. A genuinely-empty STRING is valid stored
+// input and must still render its (empty) bubble.
+test("a persisted empty-STRING assistant record is NOT dropped on replay (renders empty bubble) (#241)", () => {
+  assert.equal(isDroppedAgentReplay(""), false);
+  // and it coerces to "" so the empty bubble is what renders
+  assert.equal(coerceMessageText(""), "");
+});
+
+test("a persisted structured object that coerces to '' IS dropped on replay (#241)", () => {
+  // Only a value that coerces to "" is dropped — e.g. an unserializable/cyclic
+  // object (the old "[object Object]" case). A serializable object like {} is
+  // NOT dropped; it coerces to readable JSON ("{}") and renders.
+  const cyclic = {};
+  cyclic.self = cyclic;
+  assert.equal(isDroppedAgentReplay(cyclic), true);
+  assert.equal(isDroppedAgentReplay({}), false);
+  assert.equal(coerceMessageText({}), "{}");
+});
+
+test("a persisted structured object WITH readable text is NOT dropped (#241)", () => {
+  assert.equal(isDroppedAgentReplay({ text: "hi" }), false);
+  assert.equal(isDroppedAgentReplay({ content: [{ text: "hi" }] }), false);
+});
+
+test("null/undefined persisted text is dropped, never rendered as literal 'null' (#241)", () => {
+  // These are non-string and carry no content; the pre-fix path rendered the
+  // literal "null"/"undefined" via String(). Dropping is strictly better and
+  // matches the predicate (a real empty STRING is the only empty kept).
+  assert.equal(isDroppedAgentReplay(null), true);
+  assert.equal(isDroppedAgentReplay(undefined), true);
 });

--- a/browser_tests/unit/chat-serialize.test.mjs
+++ b/browser_tests/unit/chat-serialize.test.mjs
@@ -86,3 +86,41 @@ test("a SUBMIT button with an object reply does NOT bake [object Object] into th
 test("falls back to label when reply is absent", () => {
   assert.equal(buttonReplyText({ label: "Cancel" }), "Cancel");
 });
+
+// --- sidebar render of a completed OUTPUT payload (#238) --------------------
+// The LIVE `say` handler now routes a structured payload through
+// coerceMessageText before onSay/paintAgent, so a completed render/output
+// object must serialize to readable text, never "[object Object]".
+test("a completed output payload renders as readable text in the sidebar path (#238)", () => {
+  const out = coerceMessageText({ caption: "portrait_00001.png", filename: "portrait_00001.png" });
+  assert.notEqual(out, "[object Object]");
+  assert.equal(out, "portrait_00001.png");
+});
+
+test("an output payload with no known label degrades to JSON, never [object Object] (#238)", () => {
+  const out = coerceMessageText({ type: "output", images: [{ subfolder: "", node: 9 }] });
+  assert.notEqual(out, "[object Object]");
+  assert.ok(!out.includes("[object Object]"), `got: ${out}`);
+  assert.ok(out.startsWith("{"), `expected JSON, got: ${out}`);
+});
+
+// --- persisted structured assistant message replay (#241) ------------------
+// paintAgent(m.text) on history replay now re-normalizes through the SAME
+// serializer, so a record whose `text` is a structured object rehydrates as
+// readable text after reload/restart instead of "[object Object]".
+test("a persisted structured assistant message rehydrates as readable text (#241)", () => {
+  const record = { role: "agent", text: { text: "Here are your outputs." } };
+  const out = coerceMessageText(record.text);
+  assert.notEqual(out, "[object Object]");
+  assert.equal(out, "Here are your outputs.");
+});
+
+test("a persisted codex-style content-parts assistant message replays as joined text (#241)", () => {
+  const record = {
+    role: "agent",
+    text: { content: [{ type: "text", text: "line one" }, { type: "text", text: "line two" }] },
+  };
+  const out = coerceMessageText(record.text);
+  assert.notEqual(out, "[object Object]");
+  assert.equal(out, "line one\nline two");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7524,9 +7524,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         }
         return;
       }
-      if (msg && msg.type === "say" && typeof msg.text === "string") {
+      if (msg && msg.type === "say" && msg.text != null) {
+        // A completed render/output frame can arrive as a structured payload,
+        // not a bare string (#238). Route it through the SAME serializer the
+        // A2UI/replay paths use so the sidebar shows readable text instead of a
+        // dropped frame or an "[object Object]" bubble.
         // `id` reconciles this committed reply with its live streaming preview.
-        onSay(msg.text, { id: msg.id, streamed: !!msg.streamed });
+        onSay(coerceMessageText(msg.text), { id: msg.id, streamed: !!msg.streamed });
       }
       // Live streaming deltas: incremental thinking / reply text before the final
       // `say` commits. phase: "think" | "text" | "end".
@@ -11771,10 +11775,17 @@ function buildPanel() {
   }
 
   function paintAgent(text) {
+    // History can contain structured assistant payloads persisted by an older
+    // runtime (e.g. codex app-server callback shapes). Re-normalize on replay
+    // through the SHARED serializer so reload/restart cannot resurrect the
+    // literal "[object Object]" that renderRichText's String() coercion would
+    // otherwise produce, even after the live `say` path has been fixed (#241).
+    const safeText = coerceMessageText(text);
+    if (!safeText) return;
     clearEmpty();
     const b = document.createElement("div");
     b.className = "cmcp-bubble agent";
-    renderRichText(b, text);
+    renderRichText(b, safeText);
     log.appendChild(b);
     scrollLog();
   }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -90,7 +90,7 @@ import {
   reconcileUnknownWidgetNames,
   reapplyDefsToLiveNodes,
 } from "./lib/asset-staleness.js";
-import { coerceMessageText } from "./lib/chat-serialize.js";
+import { coerceMessageText, isDroppedAgentReplay } from "./lib/chat-serialize.js";
 import { createMediaRecorder } from "./lib/chat-media.js";
 import { saveActiveWorkflow } from "./lib/workflow-save.js";
 
@@ -11780,8 +11780,11 @@ function buildPanel() {
     // through the SHARED serializer so reload/restart cannot resurrect the
     // literal "[object Object]" that renderRichText's String() coercion would
     // otherwise produce, even after the live `say` path has been fixed (#241).
+    // Drop ONLY a structured payload that coerced to nothing (see
+    // isDroppedAgentReplay) — a genuinely-empty STRING record is valid stored
+    // input and must still render its empty bubble (#241).
+    if (isDroppedAgentReplay(text)) return;
     const safeText = coerceMessageText(text);
-    if (!safeText) return;
     clearEmpty();
     const b = document.createElement("div");
     b.className = "cmcp-bubble agent";

--- a/web/js/lib/chat-serialize.js
+++ b/web/js/lib/chat-serialize.js
@@ -49,6 +49,16 @@ export function coerceMessageText(value) {
   }
 }
 
+/** Decide whether a persisted assistant record should be dropped on history
+ *  replay (#241). Drop ONLY a structured payload that coerced to nothing (an
+ *  object with no extractable text / an unserializable value) — that's the
+ *  "[object Object]" case being killed. A genuinely-empty STRING record is
+ *  valid stored input (chat-history-store accepts it; imports preserve it) and
+ *  must still render its empty bubble, so it is NEVER dropped. */
+export function isDroppedAgentReplay(text) {
+  return typeof text !== "string" && coerceMessageText(text) === "";
+}
+
 /** Compute the outgoing chat text for an A2UI Button click (#219).
  *
  *  The reply is `component.reply ?? component.label`, coerced to a string via

--- a/web/js/lib/chat-serialize.js
+++ b/web/js/lib/chat-serialize.js
@@ -9,15 +9,20 @@
 // stringified via Object.prototype.toString.
 
 // Preferred string-bearing fields, in priority order, for a structured payload
-// (card reply, backend error/message object, UI action).
-const STRING_FIELDS = ["reply", "text", "label", "value", "message", "error", "detail"];
+// (card reply, backend error/message object, UI action). `caption`/`filename`
+// let a completed render/output payload (#238) surface its media label rather
+// than JSON; `content` is handled specially below (codex-style parts array).
+const STRING_FIELDS = ["reply", "text", "label", "value", "message", "error", "detail", "caption", "filename"];
 
 /** Coerce an arbitrary chat payload to a human/agent-readable string.
  *  - strings pass through unchanged;
  *  - null/undefined become "";
  *  - primitives use String();
- *  - objects yield the first non-empty known string field, else JSON, else "".
- *  Never returns "[object Object]" for a plain object. */
+ *  - objects yield the first non-empty known string field, else the joined text
+ *    of a `content` parts array (codex app-server shape), else JSON, else "".
+ *  Never returns "[object Object]" for a plain object. Shared by the LIVE say
+ *  render (#238), the A2UI button path (#219), and persisted-message replay
+ *  (#241) so every path serializes structured payloads identically. */
 export function coerceMessageText(value) {
   if (typeof value === "string") return value;
   if (value == null) return "";
@@ -25,6 +30,15 @@ export function coerceMessageText(value) {
   for (const key of STRING_FIELDS) {
     const field = value[key];
     if (typeof field === "string" && field) return field;
+  }
+  // Codex/app-server assistant shapes carry the visible text in a `content`
+  // parts array (e.g. [{ type:"text", text:"…" }]). Older persisted records of
+  // this shape (#241) must replay as their joined text, not raw JSON.
+  if (Array.isArray(value.content)) {
+    const parts = value.content
+      .map((part) => (typeof part === "string" ? part : typeof part?.text === "string" ? part.text : ""))
+      .filter(Boolean);
+    if (parts.length) return parts.join("\n");
   }
   try {
     const json = JSON.stringify(value);


### PR DESCRIPTION
## Summary
WS-9 (#228) introduced `coerceMessageText()` in `web/js/lib/chat-serialize.js` as the shared structured-payload serializer for the LIVE chat, but two sibling paths still stringified objects via `String()` → `[object Object]`. This routes BOTH through that same serializer.

### Root cause (confirmed same omission, two sites)
- **#238 — sidebar LIVE output**: the bridge `say` handler forwarded `msg.text` to `onSay` only `if (typeof msg.text === "string")`. A completed render/output payload arriving as a structured object was therefore dropped or surfaced as `[object Object]`. Fixed by coercing `msg.text` through `coerceMessageText` before `onSay`.
- **#241 — persisted replay**: `paintThread` replays history via `paintAgent(m.text)` → `renderRichText(String(text))`. A persisted structured assistant record (older codex app-server callback shapes) rendered as `[object Object]` on reload/restart. `paintAgent` now re-normalizes through the SAME serializer, matching the fix the issue itself suggested.

Both are the identical missing-serializer omission, not distinct bugs.

### Shared serializer reused (not duplicated)
Both sites call `coerceMessageText`. It was extended **once, centrally**: added `caption`/`filename` to the preferred string fields (so an output payload surfaces its media label) and a codex-style `content` parts-array branch (so persisted `{content:[{text}]}` records replay as joined text). No second serializer.

### Diff summary
- `web/js/lib/chat-serialize.js` — extend `coerceMessageText` (caption/filename fields + `content` parts array); docs.
- `web/js/comfyui-mcp-panel.js` — `say` handler coerces object `msg.text` (#238); `paintAgent` coerces on replay (#241).
- `browser_tests/unit/chat-serialize.test.mjs` — 4 new tests (output-payload sidebar render; JSON-degrade guard; persisted structured + codex-content replay).

### Tests
`npm run test:unit` → **242/242 pass**. `node --check` clean. No version bump.

Closes #238, #241.