### PR TITLE
fix(set_widget): correct promoted-subgraph-widget target + combo exact-value write (#233 #240)

### DIFF
--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -1,0 +1,169 @@
+/**
+ * Unit tests for web/js/lib/widget-write.js — run with `node --test`.
+ *
+ * Covers the graph_set_widget integrity fixes:
+ *   #233 — a PROMOTED subgraph widget resolves to the correct INNER widget and
+ *          the write leaves neighbouring inner widgets untouched; a numeric
+ *          slot rejects a non-numeric value instead of silently corrupting it.
+ *   #240 — a COMBO widget is set by EXACT value; an invalid value is rejected
+ *          (not silently coerced to a different enum / an index).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  coerceWidgetValue,
+  comboOptions,
+  isComboWidget,
+  isNumericWidget,
+  resolvePromotedInnerTarget,
+  WidgetWriteError,
+} from "../../web/js/lib/widget-write.js";
+
+// ---- combo classification + exact-value writes (#240) ---------------------
+
+test("combo widget is classified by its option list", () => {
+  const combo = { name: "sampler_name", options: { values: ["euler", "dpmpp_2m"] } };
+  assert.equal(isComboWidget(combo), true);
+  assert.deepEqual(comboOptions(combo), ["euler", "dpmpp_2m"]);
+});
+
+test("combo: a valid value writes that EXACT value", () => {
+  const w = {
+    name: "lllite_name",
+    options: {
+      values: [
+        "ANIMA\\anima-lllite-pose-1.safetensors",
+        "ANIMA\\anima-lllite-any-test-like-v2.safetensors",
+      ],
+    },
+  };
+  const out = coerceWidgetValue(w, "ANIMA\\anima-lllite-pose-1.safetensors");
+  assert.equal(out, "ANIMA\\anima-lllite-pose-1.safetensors");
+});
+
+test("combo: an invalid value is REJECTED, not coerced to another enum", () => {
+  const w = {
+    name: "lllite_name",
+    options: { values: ["pose-1.safetensors", "any-test-like-v2.safetensors"] },
+  };
+  assert.throws(
+    () => coerceWidgetValue(w, "not-a-real-file.safetensors"),
+    (err) => err instanceof WidgetWriteError && /not a valid option/.test(err.message),
+  );
+});
+
+test("combo: a numeric index is NOT reinterpreted as a dropdown position", () => {
+  // options[1] would be the WRONG value if an index were honoured (#240 drift).
+  const w = { name: "combo", options: { values: ["alpha", "beta", "gamma"] } };
+  assert.throws(
+    () => coerceWidgetValue(w, 1),
+    (err) => err instanceof WidgetWriteError,
+  );
+});
+
+test("combo: dynamic (function) option list resolves and validates", () => {
+  const w = { name: "ckpt", type: "combo", options: { values: () => ["a.ckpt", "b.ckpt"] } };
+  assert.equal(coerceWidgetValue(w, "b.ckpt"), "b.ckpt");
+  assert.throws(() => coerceWidgetValue(w, "c.ckpt"), WidgetWriteError);
+});
+
+// ---- numeric validation (the #233 corruption signature) -------------------
+
+test("numeric widget accepts a number and a numeric string", () => {
+  const w = { name: "steps", type: "INT" };
+  assert.equal(isNumericWidget(w), true);
+  assert.equal(coerceWidgetValue(w, 20), 20);
+  assert.equal(coerceWidgetValue({ name: "cfg", type: "number" }, "7.5"), 7.5);
+});
+
+test("numeric widget REJECTS a non-numeric string (no 'euler' into an INT)", () => {
+  const w = { name: "steps", type: "INT" };
+  assert.throws(
+    () => coerceWidgetValue(w, "euler"),
+    (err) => err instanceof WidgetWriteError && /not a number/.test(err.message),
+  );
+});
+
+test("boolean widget coerces true/false strings and rejects garbage", () => {
+  const w = { name: "enabled", type: "toggle" };
+  assert.equal(coerceWidgetValue(w, "true"), true);
+  assert.equal(coerceWidgetValue(w, false), false);
+  assert.throws(() => coerceWidgetValue(w, "maybe"), WidgetWriteError);
+});
+
+test("string/text widget passes through unchanged", () => {
+  const w = { name: "text", type: "text" };
+  assert.equal(coerceWidgetValue(w, "hello world"), "hello world");
+});
+
+// ---- promoted-subgraph-widget target resolution (#233) --------------------
+
+/**
+ * Build a mock parent SubgraphNode whose inner KSampler has its `seed`,
+ * `sampler_name`, `scheduler`, `denoise` widgets promoted. `sampler_name` is
+ * promoted; the parent's own widget array is deliberately SHIFTED (the upstream
+ * bug) so writing on the parent by position would hit the wrong slot.
+ */
+function makeSubgraphFixture() {
+  const inner = {
+    id: 54,
+    type: "KSampler",
+    widgets: [
+      { name: "seed", type: "INT", value: 959948902156062 },
+      { name: "steps", type: "INT", value: 1 },
+      { name: "cfg", type: "number", value: 1 },
+      { name: "sampler_name", type: "combo", options: { values: ["euler", "dpmpp_2m"] }, value: "euler" },
+      { name: "scheduler", type: "combo", options: { values: ["simple", "karras"] }, value: "simple" },
+      { name: "denoise", type: "number", value: 1 },
+    ],
+  };
+  const subgraph = {
+    _nodes: [inner],
+    getNodeById: (id) => (String(id) === "54" ? inner : null),
+  };
+  const parent = {
+    id: 66,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [{ name: "sampler_name", _subgraphSlot: { name: "sampler_name" } }],
+    // Parent's own promoted-view widgets are SHIFTED (reproduces the corruption
+    // vector): the widget named sampler_name here sits over the wrong value.
+    widgets: [{ name: "sampler_name", type: "combo", options: { values: ["euler"] }, value: 1 }],
+  };
+  // Stub of the live-graph link walk: sampler_name promotes inner node 54's
+  // sampler_name widget.
+  const resolveSource = (_node, subgraphInput) =>
+    subgraphInput?.name === "sampler_name"
+      ? { sourceNodeId: "54", sourceWidgetName: "sampler_name" }
+      : null;
+  return { parent, inner, resolveSource };
+}
+
+test("promoted widget resolves to the correct INNER node + widget", () => {
+  const { parent, inner, resolveSource } = makeSubgraphFixture();
+  const target = resolvePromotedInnerTarget(parent, "sampler_name", resolveSource);
+  assert.ok(target, "should resolve a promoted target");
+  assert.equal(target.node, inner);
+  assert.equal(target.widget.name, "sampler_name");
+});
+
+test("writing the resolved promoted widget leaves inner NEIGHBOURS untouched", () => {
+  const { parent, inner, resolveSource } = makeSubgraphFixture();
+  const before = inner.widgets.map((w) => w.value);
+
+  const target = resolvePromotedInnerTarget(parent, "sampler_name", resolveSource);
+  const coerced = coerceWidgetValue(target.widget, "dpmpp_2m");
+  target.widget.value = coerced;
+
+  assert.equal(inner.widgets.find((w) => w.name === "sampler_name").value, "dpmpp_2m");
+  // Every OTHER inner widget is unchanged — no positional shift corruption.
+  inner.widgets.forEach((w, i) => {
+    if (w.name !== "sampler_name") assert.equal(w.value, before[i], `${w.name} must be untouched`);
+  });
+});
+
+test("promoted resolution returns null for a plain (non-subgraph) node", () => {
+  const node = { id: 1, type: "KSampler", widgets: [{ name: "steps" }] };
+  assert.equal(resolvePromotedInnerTarget(node, "steps", () => null), null);
+});

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -132,6 +132,21 @@ test("numeric widget REJECTS a non-numeric string (no 'euler' into an INT)", () 
   assert.equal(node.widgets[0].value, 1);
 });
 
+test("numeric widget REJECTS non-numeric JSON types (array/object/bool/blank), accepts 5 and \"5\"", () => {
+  const mk = () => ({ id: 1, type: "N", widgets: [{ name: "steps", type: "INT", value: 1 }] });
+  for (const bad of [[], [5], "  ", true, false, {}, null, "", Infinity, NaN]) {
+    const n = mk();
+    assert.throws(
+      () => applyWidgetWrite(n, "steps", bad, HOOKS),
+      WidgetWriteError,
+      `value ${JSON.stringify(bad)} must be rejected`,
+    );
+    assert.equal(n.widgets[0].value, 1, `slot untouched after rejecting ${JSON.stringify(bad)}`);
+  }
+  assert.equal(applyWidgetWrite(mk(), "steps", 5, HOOKS).value, 5);
+  assert.equal(applyWidgetWrite(mk(), "steps", "5", HOOKS).value, 5);
+});
+
 test("boolean widget coerces true/false strings and rejects garbage", () => {
   assert.equal(applyWidgetWrite({ id: 1, type: "N", widgets: [{ name: "e", type: "toggle", value: false }] }, "e", "true", HOOKS).value, true);
   assert.throws(() => applyWidgetWrite({ id: 1, type: "N", widgets: [{ name: "e", type: "toggle", value: false }] }, "e", "maybe", HOOKS), WidgetWriteError);
@@ -259,6 +274,19 @@ test("promoted widget with empty linkIds → THROW, parent slot untouched", () =
     (err) => err instanceof WidgetWriteError && /no resolvable inner link/.test(err.message),
   );
   assert.equal(parent.widgets[0].value, before, "parent slot must not be written on fail-closed");
+});
+
+test("promoted widget whose host input LACKS _subgraphSlot → THROW, parent untouched (round-2 HIGH #1)", () => {
+  const { parent } = makeSubgraphFixture();
+  // Host input matches the requested name but has NO _subgraphSlot — the
+  // missing-metadata case that previously fell open to the parent widget.
+  parent.inputs = [{ name: "scheduler" /* no _subgraphSlot */ }];
+  const before = parent.widgets[0].value;
+  assert.throws(
+    () => applyWidgetWrite(parent, "scheduler", "simple", { resolveSource: () => null }),
+    (err) => err instanceof WidgetWriteError && /no backing subgraph slot/.test(err.message),
+  );
+  assert.equal(parent.widgets[0].value, before, "parent widget must not be written");
 });
 
 test("promoted widget linking to a missing inner node → THROW (no parent fallback)", () => {

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -1,17 +1,23 @@
 /**
  * Unit tests for web/js/lib/widget-write.js — run with `node --test`.
  *
+ * These drive applyWidgetWrite(), the SAME function graph_set_widget delegates
+ * to (resolve target → validate/coerce → write + callback → verify stuck), so
+ * the handler's real code path is exercised — not a parallel reimplementation.
+ *
  * Covers the graph_set_widget integrity fixes:
- *   #233 — a PROMOTED subgraph widget resolves to the correct INNER widget and
- *          the write leaves neighbouring inner widgets untouched; a numeric
- *          slot rejects a non-numeric value instead of silently corrupting it.
- *   #240 — a COMBO widget is set by EXACT value; an invalid value is rejected
- *          (not silently coerced to a different enum / an index).
+ *   #233 — a PROMOTED subgraph widget resolves to the correct INNER widget (even
+ *          when the promotion was RENAMED), leaves inner neighbours untouched,
+ *          rejects a non-numeric value into a numeric slot, and NEVER falls back
+ *          to the shifted parent slot when the promotion can't be resolved.
+ *   #240 — a COMBO widget is set by EXACT value; invalid / index / unreadable-
+ *          option-list cases are rejected, never silently coerced.
  */
 import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  applyWidgetWrite,
   coerceWidgetValue,
   comboOptions,
   isComboWidget,
@@ -19,6 +25,9 @@ import {
   resolvePromotedInnerTarget,
   WidgetWriteError,
 } from "../../web/js/lib/widget-write.js";
+
+// No-op graph hooks so applyWidgetWrite exercises the full write path.
+const HOOKS = {};
 
 // ---- combo classification + exact-value writes (#240) ---------------------
 
@@ -28,82 +37,147 @@ test("combo widget is classified by its option list", () => {
   assert.deepEqual(comboOptions(combo), ["euler", "dpmpp_2m"]);
 });
 
-test("combo: a valid value writes that EXACT value", () => {
-  const w = {
-    name: "lllite_name",
-    options: {
-      values: [
-        "ANIMA\\anima-lllite-pose-1.safetensors",
-        "ANIMA\\anima-lllite-any-test-like-v2.safetensors",
-      ],
-    },
+test("combo: a valid value writes that EXACT value (via handler path)", () => {
+  const node = {
+    id: 5,
+    type: "AnimaLLLiteApply",
+    widgets: [
+      {
+        name: "lllite_name",
+        options: {
+          values: [
+            "ANIMA\\anima-lllite-pose-1.safetensors",
+            "ANIMA\\anima-lllite-any-test-like-v2.safetensors",
+          ],
+        },
+        value: "ANIMA\\anima-lllite-any-test-like-v2.safetensors",
+      },
+    ],
   };
-  const out = coerceWidgetValue(w, "ANIMA\\anima-lllite-pose-1.safetensors");
-  assert.equal(out, "ANIMA\\anima-lllite-pose-1.safetensors");
+  const set = applyWidgetWrite(node, "lllite_name", "ANIMA\\anima-lllite-pose-1.safetensors", HOOKS);
+  assert.equal(set.value, "ANIMA\\anima-lllite-pose-1.safetensors");
+  assert.equal(node.widgets[0].value, "ANIMA\\anima-lllite-pose-1.safetensors");
 });
 
 test("combo: an invalid value is REJECTED, not coerced to another enum", () => {
-  const w = {
-    name: "lllite_name",
-    options: { values: ["pose-1.safetensors", "any-test-like-v2.safetensors"] },
+  const node = {
+    id: 5,
+    type: "AnimaLLLiteApply",
+    widgets: [
+      { name: "lllite_name", options: { values: ["pose-1.safetensors", "any-test-like-v2.safetensors"] }, value: "pose-1.safetensors" },
+    ],
   };
   assert.throws(
-    () => coerceWidgetValue(w, "not-a-real-file.safetensors"),
+    () => applyWidgetWrite(node, "lllite_name", "not-a-real-file.safetensors", HOOKS),
     (err) => err instanceof WidgetWriteError && /not a valid option/.test(err.message),
   );
+  assert.equal(node.widgets[0].value, "pose-1.safetensors", "must not have mutated on reject");
 });
 
 test("combo: a numeric index is NOT reinterpreted as a dropdown position", () => {
-  // options[1] would be the WRONG value if an index were honoured (#240 drift).
-  const w = { name: "combo", options: { values: ["alpha", "beta", "gamma"] } };
-  assert.throws(
-    () => coerceWidgetValue(w, 1),
-    (err) => err instanceof WidgetWriteError,
-  );
+  const node = { id: 1, type: "N", widgets: [{ name: "c", options: { values: ["alpha", "beta", "gamma"] }, value: "alpha" }] };
+  assert.throws(() => applyWidgetWrite(node, "c", 1, HOOKS), WidgetWriteError);
+  assert.equal(node.widgets[0].value, "alpha");
+});
+
+test("combo: numeric-STRING options reject the number 1 (strict, no coercion) but accept \"1\"", () => {
+  const mk = () => ({ id: 1, type: "N", widgets: [{ name: "c", options: { values: ["0", "1", "2"] }, value: "0" }] });
+  const nNum = mk();
+  assert.throws(() => applyWidgetWrite(nNum, "c", 1, HOOKS), WidgetWriteError);
+  const nStr = mk();
+  assert.equal(applyWidgetWrite(nStr, "c", "1", HOOKS).value, "1");
+});
+
+test("combo: numeric options [0,1,2] still accept the number 1", () => {
+  const node = { id: 1, type: "N", widgets: [{ name: "c", options: { values: [0, 1, 2] }, value: 0 }] };
+  assert.equal(applyWidgetWrite(node, "c", 1, HOOKS).value, 1);
 });
 
 test("combo: dynamic (function) option list resolves and validates", () => {
-  const w = { name: "ckpt", type: "combo", options: { values: () => ["a.ckpt", "b.ckpt"] } };
-  assert.equal(coerceWidgetValue(w, "b.ckpt"), "b.ckpt");
-  assert.throws(() => coerceWidgetValue(w, "c.ckpt"), WidgetWriteError);
+  const mk = () => ({ id: 1, type: "N", widgets: [{ name: "ckpt", type: "combo", options: { values: () => ["a.ckpt", "b.ckpt"] }, value: "a.ckpt" }] });
+  assert.equal(applyWidgetWrite(mk(), "ckpt", "b.ckpt", HOOKS).value, "b.ckpt");
+  assert.throws(() => applyWidgetWrite(mk(), "ckpt", "c.ckpt", HOOKS), WidgetWriteError);
 });
 
-// ---- numeric validation (the #233 corruption signature) -------------------
+test("combo: declared combo with UNREADABLE options is refused (fail-closed, HIGH #3)", () => {
+  // Missing options.values entirely.
+  const missing = { id: 1, type: "N", widgets: [{ name: "c", type: "combo", value: "x" }] };
+  assert.throws(
+    () => applyWidgetWrite(missing, "c", 1, HOOKS),
+    (err) => err instanceof WidgetWriteError && /no readable option list/.test(err.message),
+  );
+  // Dynamic options fn that throws.
+  const throwing = {
+    id: 1,
+    type: "N",
+    widgets: [{ name: "c", type: "combo", options: { values: () => { throw new Error("boom"); } }, value: "x" }],
+  };
+  assert.throws(() => applyWidgetWrite(throwing, "c", 1, HOOKS), WidgetWriteError);
+});
+
+// ---- numeric / boolean / string validation --------------------------------
 
 test("numeric widget accepts a number and a numeric string", () => {
-  const w = { name: "steps", type: "INT" };
-  assert.equal(isNumericWidget(w), true);
-  assert.equal(coerceWidgetValue(w, 20), 20);
-  assert.equal(coerceWidgetValue({ name: "cfg", type: "number" }, "7.5"), 7.5);
+  assert.equal(isNumericWidget({ name: "steps", type: "INT" }), true);
+  assert.equal(applyWidgetWrite({ id: 1, type: "N", widgets: [{ name: "steps", type: "INT", value: 0 }] }, "steps", 20, HOOKS).value, 20);
+  assert.equal(applyWidgetWrite({ id: 1, type: "N", widgets: [{ name: "cfg", type: "number", value: 0 }] }, "cfg", "7.5", HOOKS).value, 7.5);
 });
 
 test("numeric widget REJECTS a non-numeric string (no 'euler' into an INT)", () => {
-  const w = { name: "steps", type: "INT" };
+  const node = { id: 1, type: "N", widgets: [{ name: "steps", type: "INT", value: 1 }] };
   assert.throws(
-    () => coerceWidgetValue(w, "euler"),
+    () => applyWidgetWrite(node, "steps", "euler", HOOKS),
     (err) => err instanceof WidgetWriteError && /not a number/.test(err.message),
   );
+  assert.equal(node.widgets[0].value, 1);
 });
 
 test("boolean widget coerces true/false strings and rejects garbage", () => {
-  const w = { name: "enabled", type: "toggle" };
-  assert.equal(coerceWidgetValue(w, "true"), true);
-  assert.equal(coerceWidgetValue(w, false), false);
-  assert.throws(() => coerceWidgetValue(w, "maybe"), WidgetWriteError);
+  assert.equal(applyWidgetWrite({ id: 1, type: "N", widgets: [{ name: "e", type: "toggle", value: false }] }, "e", "true", HOOKS).value, true);
+  assert.throws(() => applyWidgetWrite({ id: 1, type: "N", widgets: [{ name: "e", type: "toggle", value: false }] }, "e", "maybe", HOOKS), WidgetWriteError);
 });
 
 test("string/text widget passes through unchanged", () => {
-  const w = { name: "text", type: "text" };
-  assert.equal(coerceWidgetValue(w, "hello world"), "hello world");
+  assert.equal(applyWidgetWrite({ id: 1, type: "N", widgets: [{ name: "t", type: "text", value: "" }] }, "t", "hello world", HOOKS).value, "hello world");
 });
 
-// ---- promoted-subgraph-widget target resolution (#233) --------------------
+test("missing widget on a plain node throws", () => {
+  assert.throws(
+    () => applyWidgetWrite({ id: 1, type: "N", widgets: [{ name: "steps" }] }, "nope", 1, HOOKS),
+    (err) => err instanceof WidgetWriteError && /has no widget/.test(err.message),
+  );
+});
+
+test("stuck-check fails when a widget callback drifts the value (#240)", () => {
+  // callback rewrites value to a different enum → applyWidgetWrite must throw.
+  const node = {
+    id: 1,
+    type: "N",
+    widgets: [
+      {
+        name: "c",
+        options: { values: ["a", "b"] },
+        value: "a",
+        callback() {
+          this.value = "b"; // silent drift
+        },
+      },
+    ],
+  };
+  assert.throws(
+    () => applyWidgetWrite(node, "c", "a", HOOKS),
+    (err) => err instanceof WidgetWriteError && /did not retain the requested value/.test(err.message),
+  );
+});
+
+// ---- promoted-subgraph-widget resolution + writes (#233) -------------------
 
 /**
- * Build a mock parent SubgraphNode whose inner KSampler has its `seed`,
- * `sampler_name`, `scheduler`, `denoise` widgets promoted. `sampler_name` is
- * promoted; the parent's own widget array is deliberately SHIFTED (the upstream
- * bug) so writing on the parent by position would hit the wrong slot.
+ * Parent SubgraphNode over an inner KSampler. The promotion has been RENAMED:
+ * the OUTER promoted widget the caller sees is "sched_alias" but it maps to the
+ * inner "scheduler" widget. The parent ALSO has a decoy own-widget literally
+ * named "scheduler" (the shifted-slot corruption vector) — a correct write must
+ * never touch it. `resolveSource` mimics the live subgraph link walk.
  */
 function makeSubgraphFixture() {
   const inner = {
@@ -118,52 +192,113 @@ function makeSubgraphFixture() {
       { name: "denoise", type: "number", value: 1 },
     ],
   };
-  const subgraph = {
-    _nodes: [inner],
-    getNodeById: (id) => (String(id) === "54" ? inner : null),
-  };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "54" ? inner : null) };
   const parent = {
     id: 66,
     type: "SubgraphNode",
     subgraph,
-    inputs: [{ name: "sampler_name", _subgraphSlot: { name: "sampler_name" } }],
-    // Parent's own promoted-view widgets are SHIFTED (reproduces the corruption
-    // vector): the widget named sampler_name here sits over the wrong value.
-    widgets: [{ name: "sampler_name", type: "combo", options: { values: ["euler"] }, value: 1 }],
+    inputs: [
+      // OUTER alias "sched_alias" (renamed) → inner "scheduler".
+      { name: "sched_alias", _subgraphSlot: { name: "sched_alias" } },
+    ],
+    // Decoy shifted parent slot named "scheduler" — must stay untouched.
+    widgets: [{ name: "scheduler", type: "combo", options: { values: ["simple"] }, value: 999 }],
   };
-  // Stub of the live-graph link walk: sampler_name promotes inner node 54's
-  // sampler_name widget.
   const resolveSource = (_node, subgraphInput) =>
-    subgraphInput?.name === "sampler_name"
-      ? { sourceNodeId: "54", sourceWidgetName: "sampler_name" }
+    subgraphInput?.name === "sched_alias"
+      ? { sourceNodeId: "54", sourceWidgetName: "scheduler" }
       : null;
   return { parent, inner, resolveSource };
 }
 
-test("promoted widget resolves to the correct INNER node + widget", () => {
+test("promoted (renamed) widget resolves to the correct INNER node + widget", () => {
   const { parent, inner, resolveSource } = makeSubgraphFixture();
-  const target = resolvePromotedInnerTarget(parent, "sampler_name", resolveSource);
-  assert.ok(target, "should resolve a promoted target");
-  assert.equal(target.node, inner);
-  assert.equal(target.widget.name, "sampler_name");
+  const res = resolvePromotedInnerTarget(parent, "sched_alias", resolveSource);
+  assert.equal(res.promoted, true);
+  assert.equal(res.target.node, inner);
+  assert.equal(res.target.widget.name, "scheduler");
 });
 
-test("writing the resolved promoted widget leaves inner NEIGHBOURS untouched", () => {
+test("writing a RENAMED promoted widget hits the inner target, not the decoy parent slot (#233 blocker 1)", () => {
   const { parent, inner, resolveSource } = makeSubgraphFixture();
   const before = inner.widgets.map((w) => w.value);
 
-  const target = resolvePromotedInnerTarget(parent, "sampler_name", resolveSource);
-  const coerced = coerceWidgetValue(target.widget, "dpmpp_2m");
-  target.widget.value = coerced;
+  const set = applyWidgetWrite(parent, "sched_alias", "karras", { resolveSource });
 
-  assert.equal(inner.widgets.find((w) => w.name === "sampler_name").value, "dpmpp_2m");
-  // Every OTHER inner widget is unchanged — no positional shift corruption.
+  // Wrote the INNER scheduler, reported as an inner-node write.
+  assert.equal(set.value, "karras");
+  assert.equal(set.promoted_from.subgraph_node_id, 66);
+  assert.equal(set.promoted_from.inner_node_id, 54);
+  assert.equal(inner.widgets.find((w) => w.name === "scheduler").value, "karras");
+  // The decoy parent widget literally named "scheduler" is untouched.
+  assert.equal(parent.widgets[0].value, 999);
+  // Every OTHER inner widget is unchanged — no positional-shift corruption.
   inner.widgets.forEach((w, i) => {
-    if (w.name !== "sampler_name") assert.equal(w.value, before[i], `${w.name} must be untouched`);
+    if (w.name !== "scheduler") assert.equal(w.value, before[i], `${w.name} must be untouched`);
   });
 });
 
-test("promoted resolution returns null for a plain (non-subgraph) node", () => {
-  const node = { id: 1, type: "KSampler", widgets: [{ name: "steps" }] };
-  assert.equal(resolvePromotedInnerTarget(node, "steps", () => null), null);
+test("promoted numeric slot REJECTS a non-numeric value (silent-corruption signature)", () => {
+  const { parent, inner, resolveSource } = makeSubgraphFixture();
+  // Re-point the promotion at inner numeric "steps".
+  parent.inputs = [{ name: "steps", _subgraphSlot: { name: "steps" } }];
+  const rs = (_n, si) => (si?.name === "steps" ? { sourceNodeId: "54", sourceWidgetName: "steps" } : null);
+  assert.throws(() => applyWidgetWrite(parent, "steps", "euler", { resolveSource: rs }), WidgetWriteError);
+  assert.equal(inner.widgets.find((w) => w.name === "steps").value, 1);
+});
+
+// ---- fail-CLOSED: promoted but unresolvable must NEVER write the parent slot (#233 blocker 2)
+
+test("promoted widget with empty linkIds → THROW, parent slot untouched", () => {
+  const { parent } = makeSubgraphFixture();
+  // Match the alias but resolver returns null (stale/empty linkIds).
+  parent.inputs = [{ name: "scheduler", _subgraphSlot: { name: "scheduler" } }];
+  const before = parent.widgets[0].value;
+  assert.throws(
+    () => applyWidgetWrite(parent, "scheduler", "simple", { resolveSource: () => null }),
+    (err) => err instanceof WidgetWriteError && /no resolvable inner link/.test(err.message),
+  );
+  assert.equal(parent.widgets[0].value, before, "parent slot must not be written on fail-closed");
+});
+
+test("promoted widget linking to a missing inner node → THROW (no parent fallback)", () => {
+  const { parent } = makeSubgraphFixture();
+  parent.inputs = [{ name: "scheduler", _subgraphSlot: { name: "scheduler" } }];
+  const rs = () => ({ sourceNodeId: "999", sourceWidgetName: "scheduler" });
+  assert.throws(
+    () => applyWidgetWrite(parent, "scheduler", "simple", { resolveSource: rs }),
+    (err) => err instanceof WidgetWriteError && /missing inner node/.test(err.message),
+  );
+});
+
+test("promoted widget linking to a missing inner widget → THROW", () => {
+  const { parent } = makeSubgraphFixture();
+  parent.inputs = [{ name: "scheduler", _subgraphSlot: { name: "scheduler" } }];
+  const rs = () => ({ sourceNodeId: "54", sourceWidgetName: "ghost_widget" });
+  assert.throws(
+    () => applyWidgetWrite(parent, "scheduler", "simple", { resolveSource: rs }),
+    (err) => err instanceof WidgetWriteError && /missing inner widget/.test(err.message),
+  );
+});
+
+test("AMBIGUOUS promoted aliases → THROW, no first-match-wins (#233 blocker 2c)", () => {
+  const { parent, resolveSource } = makeSubgraphFixture();
+  parent.inputs = [
+    { name: "scheduler", _subgraphSlot: { name: "scheduler" } },
+    { name: "scheduler", _subgraphSlot: { name: "scheduler_2" } },
+  ];
+  assert.throws(
+    () => applyWidgetWrite(parent, "scheduler", "simple", { resolveSource }),
+    (err) => err instanceof WidgetWriteError && /ambiguous/.test(err.message),
+  );
+});
+
+test("subgraph node's OWN non-promoted widget writes normally (case a)", () => {
+  const { parent } = makeSubgraphFixture();
+  // No input alias matches "scheduler" → not promoted → write parent's own widget.
+  parent.inputs = [];
+  parent.widgets = [{ name: "scheduler", options: { values: ["simple", "karras"] }, value: "simple" }];
+  const set = applyWidgetWrite(parent, "scheduler", "karras", { resolveSource: () => null });
+  assert.equal(set.value, "karras");
+  assert.equal(set.promoted_from, undefined);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -90,11 +90,7 @@ import {
   reconcileUnknownWidgetNames,
   reapplyDefsToLiveNodes,
 } from "./lib/asset-staleness.js";
-import {
-  coerceWidgetValue,
-  resolvePromotedInnerTarget,
-  WidgetWriteError,
-} from "./lib/widget-write.js";
+import { applyWidgetWrite, WidgetWriteError } from "./lib/widget-write.js";
 import { coerceMessageText, isDroppedAgentReplay } from "./lib/chat-serialize.js";
 import { createMediaRecorder } from "./lib/chat-media.js";
 import { saveActiveWorkflow } from "./lib/workflow-save.js";
@@ -5167,81 +5163,31 @@ const GRAPH_TOOL_EXECUTORS = {
     // the caller's real widget name resolves (#199) before we look it up.
     reconcileUnknownWidgetNames(node);
 
-    // #233: if this is a PARENT SubgraphNode and `widget` names a PROMOTED
-    // widget, the parent's own widget slot can be positionally shifted against
-    // the inner node — writing it silently corrupts a DIFFERENT inner widget.
-    // Resolve the promoted widget to its ACTUAL inner (node, widget) and write
-    // THERE, so the value always lands on the intended target. The parent view
-    // re-reads the inner value afterwards.
-    let targetNode = node;
-    let promotedFrom = null;
-    if (node.subgraph) {
-      const inner = resolvePromotedInnerTarget(node, widget, sourceForSubgraphInput);
-      if (inner) {
-        targetNode = inner.node;
-        promotedFrom = { subgraph_node_id: node.id, inner_node_id: inner.node.id };
-      }
-    }
-
-    const w = (targetNode.widgets ?? []).find(
-      (cand) => cand?.name?.toLowerCase() === String(widget).toLowerCase(),
-    );
-    if (!w) {
-      const names = (targetNode.widgets ?? []).map((cand) => cand?.name).join(", ");
-      throw new Error(
-        `Node ${targetNode.id} (${targetNode.type}) has no widget "${widget}" (available: ${names || "none"})`,
-      );
-    }
-
-    // Validate + coerce against the target widget's declared type BEFORE
-    // writing. A combo must be an exact option (no index reinterpretation —
-    // #240); a numeric widget must be a number (no "euler" into an INT slot —
-    // #233). Reject with an actionable message instead of corrupting the graph.
-    let coerced;
+    // applyWidgetWrite owns the whole write: for a PARENT SubgraphNode it
+    // resolves a PROMOTED widget to its ACTUAL inner (node, widget) and writes
+    // THERE — never the positionally-shifted parent slot (#233), throwing if
+    // the promotion can't be resolved unambiguously rather than falling open.
+    // It validates the value against the target's declared type (combo must be
+    // an exact CURRENT option — no index drift, #240; numeric must be numeric)
+    // and verifies the write stuck exactly. Same driveable path the unit tests
+    // exercise.
     try {
-      coerced = coerceWidgetValue(w, value);
+      const set = applyWidgetWrite(node, widget, value, {
+        resolveSource: sourceForSubgraphInput,
+        canvas: app.canvas,
+        beforeChange: () => graph.beforeChange(),
+        afterChange: () => graph.afterChange(),
+        setDirty: () => graph.setDirtyCanvas(true, true),
+      });
+      return { set };
     } catch (err) {
       if (err instanceof WidgetWriteError) {
         throw new Error(
-          `Refusing to set widget "${w.name}" on node ${targetNode.id} ` +
-            `(${targetNode.type}): ${err.message}`,
+          `panel_set_widget refused "${widget}" on node ${node.id} (${node.type}): ${err.message}`,
         );
       }
       throw err;
     }
-
-    graph.beforeChange();
-    const previous = w.value;
-    try {
-      w.value = coerced;
-      // Fire the widget's own callback so combo/number side effects run —
-      // the same path a manual UI edit takes.
-      w.callback?.(coerced, app.canvas, targetNode, targetNode.pos, undefined);
-    } finally {
-      graph.afterChange();
-    }
-    graph.setDirtyCanvas(true, true);
-
-    // #240: verify the write stuck as the EXACT value we resolved. Combo
-    // callbacks that reinterpret an index can drift the value silently — fail
-    // loudly rather than report a false success.
-    if (w.value !== coerced) {
-      throw new Error(
-        `Widget "${w.name}" on node ${targetNode.id} (${targetNode.type}) did ` +
-          `not retain the requested value: wrote ${JSON.stringify(coerced)} but ` +
-          `it became ${JSON.stringify(w.value)}.`,
-      );
-    }
-
-    return {
-      set: {
-        node_id: targetNode.id,
-        widget: w.name,
-        previous,
-        value: w.value,
-        ...(promotedFrom ? { promoted_from: promotedFrom } : {}),
-      },
-    };
   },
 
   graph_move_node({ node_id, pos }) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -90,6 +90,11 @@ import {
   reconcileUnknownWidgetNames,
   reapplyDefsToLiveNodes,
 } from "./lib/asset-staleness.js";
+import {
+  coerceWidgetValue,
+  resolvePromotedInnerTarget,
+  WidgetWriteError,
+} from "./lib/widget-write.js";
 import { coerceMessageText, isDroppedAgentReplay } from "./lib/chat-serialize.js";
 import { createMediaRecorder } from "./lib/chat-media.js";
 import { saveActiveWorkflow } from "./lib/workflow-save.js";
@@ -5161,28 +5166,81 @@ const GRAPH_TOOL_EXECUTORS = {
     // Repair positional UNKNOWN/UNKNOWN_n placeholders against the live def so
     // the caller's real widget name resolves (#199) before we look it up.
     reconcileUnknownWidgetNames(node);
-    const w = (node.widgets ?? []).find(
+
+    // #233: if this is a PARENT SubgraphNode and `widget` names a PROMOTED
+    // widget, the parent's own widget slot can be positionally shifted against
+    // the inner node — writing it silently corrupts a DIFFERENT inner widget.
+    // Resolve the promoted widget to its ACTUAL inner (node, widget) and write
+    // THERE, so the value always lands on the intended target. The parent view
+    // re-reads the inner value afterwards.
+    let targetNode = node;
+    let promotedFrom = null;
+    if (node.subgraph) {
+      const inner = resolvePromotedInnerTarget(node, widget, sourceForSubgraphInput);
+      if (inner) {
+        targetNode = inner.node;
+        promotedFrom = { subgraph_node_id: node.id, inner_node_id: inner.node.id };
+      }
+    }
+
+    const w = (targetNode.widgets ?? []).find(
       (cand) => cand?.name?.toLowerCase() === String(widget).toLowerCase(),
     );
     if (!w) {
-      const names = (node.widgets ?? []).map((cand) => cand?.name).join(", ");
+      const names = (targetNode.widgets ?? []).map((cand) => cand?.name).join(", ");
       throw new Error(
-        `Node ${node.id} (${node.type}) has no widget "${widget}" (available: ${names || "none"})`,
+        `Node ${targetNode.id} (${targetNode.type}) has no widget "${widget}" (available: ${names || "none"})`,
       );
     }
+
+    // Validate + coerce against the target widget's declared type BEFORE
+    // writing. A combo must be an exact option (no index reinterpretation —
+    // #240); a numeric widget must be a number (no "euler" into an INT slot —
+    // #233). Reject with an actionable message instead of corrupting the graph.
+    let coerced;
+    try {
+      coerced = coerceWidgetValue(w, value);
+    } catch (err) {
+      if (err instanceof WidgetWriteError) {
+        throw new Error(
+          `Refusing to set widget "${w.name}" on node ${targetNode.id} ` +
+            `(${targetNode.type}): ${err.message}`,
+        );
+      }
+      throw err;
+    }
+
     graph.beforeChange();
     const previous = w.value;
     try {
-      w.value = value;
+      w.value = coerced;
       // Fire the widget's own callback so combo/number side effects run —
       // the same path a manual UI edit takes.
-      w.callback?.(value, app.canvas, node, node.pos, undefined);
+      w.callback?.(coerced, app.canvas, targetNode, targetNode.pos, undefined);
     } finally {
       graph.afterChange();
     }
     graph.setDirtyCanvas(true, true);
+
+    // #240: verify the write stuck as the EXACT value we resolved. Combo
+    // callbacks that reinterpret an index can drift the value silently — fail
+    // loudly rather than report a false success.
+    if (w.value !== coerced) {
+      throw new Error(
+        `Widget "${w.name}" on node ${targetNode.id} (${targetNode.type}) did ` +
+          `not retain the requested value: wrote ${JSON.stringify(coerced)} but ` +
+          `it became ${JSON.stringify(w.value)}.`,
+      );
+    }
+
     return {
-      set: { node_id: node.id, widget: w.name, previous, value: w.value },
+      set: {
+        node_id: targetNode.id,
+        widget: w.name,
+        previous,
+        value: w.value,
+        ...(promotedFrom ? { promoted_from: promotedFrom } : {}),
+      },
     };
   },
 

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1,6 +1,7 @@
 // Widget-value validation + promoted-subgraph-widget target resolution for
 // graph_set_widget. Extracted so the write targets the RIGHT widget with the
-// RIGHT value and can be unit-tested without a live litegraph.
+// RIGHT value and can be unit-tested by driving the SAME code path the handler
+// runs (applyWidgetWrite), not a parallel reimplementation.
 //
 // Two graph-integrity bugs motivate this module:
 //   #233 — panel_set_widget on a SUBGRAPH node's PROMOTED widget wrote by a
@@ -9,10 +10,15 @@
 //   #240 — a COMBO widget set to a valid enum silently drifted to a different
 //          option (index-vs-value reinterpretation).
 //
-// Fixes: (a) resolve a parent promoted widget to its ACTUAL inner (node,widget)
-// and write there; (b) validate/coerce the value against the target widget's
-// declared type and REJECT a mismatch (combo must be an exact option, numeric
-// must be a number) instead of writing garbage.
+// Safety contract (both bugs are silent corruption; we NEVER fail open):
+//   * A promoted widget resolves to its ACTUAL inner (node, widget) and the
+//     write lands THERE. If it looks promoted but cannot be resolved
+//     unambiguously, we THROW before mutating — never fall back to the shifted
+//     parent slot.
+//   * The value is validated against the target widget's declared type and
+//     REJECTED on mismatch (combo must be an exact CURRENT option; numeric must
+//     be numeric; boolean must be boolean; a combo whose options we cannot read
+//     is refused, not written blindly).
 
 export class WidgetWriteError extends Error {
   constructor(message) {
@@ -22,9 +28,9 @@ export class WidgetWriteError extends Error {
 }
 
 /**
- * The current option list for a combo widget, or null if the widget is not a
- * combo / has no resolvable list. `options.values` may be an array or a
- * function `(widget) => string[]` (litegraph dynamic combos).
+ * The current option list for a combo widget, or null if it cannot be read.
+ * `options.values` may be an array or a function `(widget) => string[]`
+ * (litegraph dynamic combos). A function that throws yields null (unreadable).
  */
 export function comboOptions(widget) {
   const raw = widget?.options?.values;
@@ -40,7 +46,9 @@ export function comboOptions(widget) {
 }
 
 export function isComboWidget(widget) {
-  if (comboOptions(widget)) return true;
+  if (Array.isArray(widget?.options?.values) || typeof widget?.options?.values === "function") {
+    return true;
+  }
   return String(widget?.type ?? "").toLowerCase() === "combo";
 }
 
@@ -58,39 +66,37 @@ export function isBooleanWidget(widget) {
 /**
  * Validate + coerce `value` for `widget`, returning the value to write. Throws
  * WidgetWriteError (never silently coerces to a wrong value) when the value is
- * incompatible with the widget's declared type. This converts the class of
- * silent corruption in #233/#240 into an actionable error.
+ * incompatible with the widget's declared type.
  */
 export function coerceWidgetValue(widget, value) {
   const name = widget?.name ?? "(widget)";
 
   if (isComboWidget(widget)) {
     const options = comboOptions(widget);
-    if (options) {
-      // Require an EXACT value match against the CURRENT option list. Never
-      // reinterpret the value as a dropdown index (the #240 drift) and never
-      // fuzzy-match to a neighbouring option.
-      if (options.includes(value)) return value;
-      // Tolerate only lossless string identity (e.g. a number whose String()
-      // equals a string option), still an exact-value match, not an index.
-      const asStr = String(value);
-      const exact = options.find((o) => String(o) === asStr);
-      if (exact !== undefined) return exact;
-      const preview = options.slice(0, 40).map((o) => JSON.stringify(o)).join(", ");
+    // A declared combo whose option list we cannot read cannot be validated —
+    // refuse rather than write a value that may be reinterpreted as an index
+    // (#240 fail-open). Covers missing options.values and a throwing fn.
+    if (!options) {
       throw new WidgetWriteError(
-        `Value ${JSON.stringify(value)} is not a valid option for combo widget ` +
-          `"${name}". Valid options (${options.length}): ${preview}` +
-          (options.length > 40 ? ", …" : ""),
+        `Combo widget "${name}" has no readable option list; cannot validate ` +
+          `value ${JSON.stringify(value)} — refusing to write.`,
       );
     }
-    // Dynamic combo with no resolvable list: accept the exact value as given;
-    // do NOT coerce a string to an index.
-    return value;
+    // STRICT typed membership: no numeric<->string coercion. Numeric options
+    // [0,1,2] accept numeric 1; string options ["0","1","2"] require "1", never
+    // the number 1 (which would otherwise behave like an index).
+    if (options.includes(value)) return value;
+    const preview = options.slice(0, 40).map((o) => JSON.stringify(o)).join(", ");
+    throw new WidgetWriteError(
+      `Value ${JSON.stringify(value)} is not a valid option for combo widget ` +
+        `"${name}". Valid options (${options.length}): ${preview}` +
+        (options.length > 40 ? ", …" : ""),
+    );
   }
 
   if (isNumericWidget(widget)) {
     const num = typeof value === "number" ? value : Number(value);
-    if (value === null || value === "" || !Number.isFinite(num)) {
+    if (value === null || value === "" || typeof value === "boolean" || !Number.isFinite(num)) {
       throw new WidgetWriteError(
         `Widget "${name}" is numeric (type ${widget?.type}) but value ` +
           `${JSON.stringify(value)} is not a number.`,
@@ -115,56 +121,178 @@ export function coerceWidgetValue(widget, value) {
 }
 
 /**
- * Resolve a PARENT SubgraphNode's promoted widget to the ACTUAL inner
- * (node, widget) it stands for, so a write lands on the real target instead of
- * a positionally-shifted neighbour on the parent (root cause of #233).
+ * Classify a widget request on `subgraphNode` against `widgetName` and, when it
+ * is a PROMOTED subgraph widget, resolve it to the ACTUAL inner (node, widget).
  *
- * A promoted widget is backed by a SubgraphNode input whose `_subgraphSlot`
- * (subgraph input) links, inside the subgraph, to the inner node's widget
- * input. `resolveSource(subgraphNode, subgraphInput)` performs that link walk
- * (the panel injects its live-graph `sourceForSubgraphInput`) and returns
- * `{ sourceNodeId, sourceWidgetName }`.
+ * Detection matches ONLY the OUTER alias the caller sees on the parent
+ * (host-input name/label and the backing subgraph-input name/label) — never the
+ * inner source widget name — so a renamed promotion (`scheduler` on the parent
+ * mapping to inner `sampler_name`) is followed to the RIGHT inner widget.
  *
- * Returns `{ node, widget, input }` for the inner target, or null when the
- * widget is not a promoted subgraph widget (caller then writes on the node
- * directly).
+ * `resolveSource(subgraphNode, subgraphInput)` walks the subgraph link and
+ * returns `{ sourceNodeId, sourceWidgetName }` (the panel injects its live
+ * `sourceForSubgraphInput`).
+ *
+ * Returns a status object — the caller MUST honour it and never fall back to
+ * the parent slot when `promoted` is true but `target` is null:
+ *   { promoted: false }                             → not a promoted widget
+ *   { promoted: true, target: {node,widget,input} } → resolved inner target
+ *   { promoted: true, target: null, error }         → promoted but UNRESOLVABLE/ambiguous
  */
 export function resolvePromotedInnerTarget(subgraphNode, widgetName, resolveSource) {
   const subgraph = subgraphNode?.subgraph;
-  if (!subgraph || typeof resolveSource !== "function") return null;
+  if (!subgraph) return { promoted: false };
   const wanted = String(widgetName).toLowerCase();
 
+  // All promoted inputs whose OUTER alias matches the requested name.
+  const matches = [];
   for (const input of subgraphNode.inputs ?? []) {
     const subgraphInput = input?._subgraphSlot;
     if (!subgraphInput) continue;
-
-    const source = resolveSource(subgraphNode, subgraphInput);
-    if (!source) continue;
-
-    // The promoted widget on the parent is named after the host input
-    // (input.name / label) which mirrors the inner source widget name. Match
-    // on any of them so a rename on either side still resolves.
-    const candidates = [
-      input.name,
-      input.label,
-      subgraphInput.name,
-      subgraphInput.label,
-      source.sourceWidgetName,
-    ].map((c) => (c == null ? null : String(c).toLowerCase()));
-    if (!candidates.includes(wanted)) continue;
-
-    const innerNode =
-      typeof subgraph.getNodeById === "function"
-        ? subgraph.getNodeById(source.sourceNodeId)
-        : (subgraph._nodes ?? []).find((n) => String(n?.id) === String(source.sourceNodeId));
-    if (!innerNode) continue;
-
-    const innerWidget = (innerNode.widgets ?? []).find(
-      (w) => w?.name === source.sourceWidgetName,
+    const aliases = [input.name, input.label, subgraphInput.name, subgraphInput.label].map(
+      (a) => (a == null ? null : String(a).toLowerCase()),
     );
-    if (!innerWidget) continue;
-
-    return { node: innerNode, widget: innerWidget, input };
+    if (aliases.includes(wanted)) matches.push({ input, subgraphInput });
   }
-  return null;
+
+  if (matches.length === 0) return { promoted: false };
+  if (matches.length > 1) {
+    return {
+      promoted: true,
+      target: null,
+      error: `promoted widget "${widgetName}" is ambiguous — ${matches.length} promoted inputs match; refusing to guess.`,
+    };
+  }
+
+  const { input, subgraphInput } = matches[0];
+  if (typeof resolveSource !== "function") {
+    return {
+      promoted: true,
+      target: null,
+      error: `no resolver available for promoted widget "${widgetName}".`,
+    };
+  }
+  const source = resolveSource(subgraphNode, subgraphInput);
+  if (!source) {
+    return {
+      promoted: true,
+      target: null,
+      error: `promoted widget "${widgetName}" has no resolvable inner link (stale/empty linkIds).`,
+    };
+  }
+  const innerNode =
+    typeof subgraph.getNodeById === "function"
+      ? subgraph.getNodeById(source.sourceNodeId)
+      : (subgraph._nodes ?? []).find((n) => String(n?.id) === String(source.sourceNodeId));
+  if (!innerNode) {
+    return {
+      promoted: true,
+      target: null,
+      error: `promoted widget "${widgetName}" links to missing inner node ${source.sourceNodeId}.`,
+    };
+  }
+  const innerWidget = (innerNode.widgets ?? []).find((w) => w?.name === source.sourceWidgetName);
+  if (!innerWidget) {
+    return {
+      promoted: true,
+      target: null,
+      error: `promoted widget "${widgetName}" links to missing inner widget "${source.sourceWidgetName}" on node ${source.sourceNodeId}.`,
+    };
+  }
+  return { promoted: true, target: { node: innerNode, widget: innerWidget, input } };
+}
+
+/**
+ * Resolve the true write target (inner promoted widget or the node's own
+ * widget) and validate/coerce the value. Throws WidgetWriteError on any
+ * unresolved-promotion, missing-widget, or value-mismatch condition — BEFORE
+ * any mutation. Pure: no graph side effects.
+ */
+export function resolveWidgetWrite(node, widgetName, value, resolveSource) {
+  let targetNode = node;
+  let widget = null;
+  let promotedFrom = null;
+
+  if (node?.subgraph) {
+    const res = resolvePromotedInnerTarget(node, widgetName, resolveSource);
+    if (res.promoted) {
+      // Promoted widget: use the resolved inner widget DIRECTLY. Never re-search
+      // the inner node by the OUTER name (a rename would hit the wrong inner
+      // widget), and never fall back to the shifted parent slot on failure.
+      if (!res.target) {
+        throw new WidgetWriteError(
+          res.error || `promoted widget "${widgetName}" could not be resolved to an inner widget.`,
+        );
+      }
+      targetNode = res.target.node;
+      widget = res.target.widget;
+      promotedFrom = { subgraph_node_id: node.id, inner_node_id: res.target.node.id };
+    }
+  }
+
+  if (!widget) {
+    widget = (targetNode.widgets ?? []).find(
+      (cand) => cand?.name?.toLowerCase() === String(widgetName).toLowerCase(),
+    );
+  }
+  if (!widget) {
+    const names = (targetNode.widgets ?? []).map((cand) => cand?.name).join(", ");
+    throw new WidgetWriteError(
+      `Node ${targetNode.id} (${targetNode.type}) has no widget "${widgetName}" (available: ${names || "none"}).`,
+    );
+  }
+
+  const coerced = coerceWidgetValue(widget, value);
+  return { targetNode, widget, coerced, promotedFrom };
+}
+
+/**
+ * The COMPLETE graph_set_widget body as a driveable unit: resolve target →
+ * validate/coerce → write (with the widget's own callback) → verify the value
+ * stuck EXACTLY (fail loudly on drift, #240). Graph hooks are injected so this
+ * runs both live and under unit test. Throws WidgetWriteError on any failure.
+ */
+export function applyWidgetWrite(
+  node,
+  widgetName,
+  value,
+  { resolveSource, canvas, beforeChange, afterChange, setDirty } = {},
+) {
+  const { targetNode, widget: w, coerced, promotedFrom } = resolveWidgetWrite(
+    node,
+    widgetName,
+    value,
+    resolveSource,
+  );
+
+  beforeChange?.();
+  const previous = w.value;
+  try {
+    w.value = coerced;
+    // Fire the widget's own callback so combo/number side effects run — the
+    // same path a manual UI edit takes.
+    w.callback?.(coerced, canvas, targetNode, targetNode.pos, undefined);
+  } finally {
+    afterChange?.();
+  }
+  setDirty?.();
+
+  // Verify the write stuck as the EXACT value. A combo callback that
+  // reinterprets an index can drift the value silently — fail rather than
+  // report a false success.
+  if (w.value !== coerced) {
+    throw new WidgetWriteError(
+      `Widget "${w.name}" on node ${targetNode.id} (${targetNode.type}) did not ` +
+        `retain the requested value: wrote ${JSON.stringify(coerced)} but it ` +
+        `became ${JSON.stringify(w.value)}.`,
+    );
+  }
+
+  return {
+    node_id: targetNode.id,
+    widget: w.name,
+    previous,
+    value: w.value,
+    ...(promotedFrom ? { promoted_from: promotedFrom } : {}),
+  };
 }

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1,0 +1,170 @@
+// Widget-value validation + promoted-subgraph-widget target resolution for
+// graph_set_widget. Extracted so the write targets the RIGHT widget with the
+// RIGHT value and can be unit-tested without a live litegraph.
+//
+// Two graph-integrity bugs motivate this module:
+//   #233 — panel_set_widget on a SUBGRAPH node's PROMOTED widget wrote by a
+//          positionally-shifted slot and silently corrupted a DIFFERENT inner
+//          widget (an INT slot ended up holding "euler"), reporting success.
+//   #240 — a COMBO widget set to a valid enum silently drifted to a different
+//          option (index-vs-value reinterpretation).
+//
+// Fixes: (a) resolve a parent promoted widget to its ACTUAL inner (node,widget)
+// and write there; (b) validate/coerce the value against the target widget's
+// declared type and REJECT a mismatch (combo must be an exact option, numeric
+// must be a number) instead of writing garbage.
+
+export class WidgetWriteError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "WidgetWriteError";
+  }
+}
+
+/**
+ * The current option list for a combo widget, or null if the widget is not a
+ * combo / has no resolvable list. `options.values` may be an array or a
+ * function `(widget) => string[]` (litegraph dynamic combos).
+ */
+export function comboOptions(widget) {
+  const raw = widget?.options?.values;
+  let vals = raw;
+  if (typeof raw === "function") {
+    try {
+      vals = raw(widget);
+    } catch {
+      return null;
+    }
+  }
+  return Array.isArray(vals) ? vals : null;
+}
+
+export function isComboWidget(widget) {
+  if (comboOptions(widget)) return true;
+  return String(widget?.type ?? "").toLowerCase() === "combo";
+}
+
+// litegraph "number"/"slider" and Comfy "INT"/"FLOAT" all render numeric.
+export function isNumericWidget(widget) {
+  const t = String(widget?.type ?? "").toLowerCase();
+  return t === "number" || t === "slider" || t === "int" || t === "float";
+}
+
+export function isBooleanWidget(widget) {
+  const t = String(widget?.type ?? "").toLowerCase();
+  return t === "toggle" || t === "boolean";
+}
+
+/**
+ * Validate + coerce `value` for `widget`, returning the value to write. Throws
+ * WidgetWriteError (never silently coerces to a wrong value) when the value is
+ * incompatible with the widget's declared type. This converts the class of
+ * silent corruption in #233/#240 into an actionable error.
+ */
+export function coerceWidgetValue(widget, value) {
+  const name = widget?.name ?? "(widget)";
+
+  if (isComboWidget(widget)) {
+    const options = comboOptions(widget);
+    if (options) {
+      // Require an EXACT value match against the CURRENT option list. Never
+      // reinterpret the value as a dropdown index (the #240 drift) and never
+      // fuzzy-match to a neighbouring option.
+      if (options.includes(value)) return value;
+      // Tolerate only lossless string identity (e.g. a number whose String()
+      // equals a string option), still an exact-value match, not an index.
+      const asStr = String(value);
+      const exact = options.find((o) => String(o) === asStr);
+      if (exact !== undefined) return exact;
+      const preview = options.slice(0, 40).map((o) => JSON.stringify(o)).join(", ");
+      throw new WidgetWriteError(
+        `Value ${JSON.stringify(value)} is not a valid option for combo widget ` +
+          `"${name}". Valid options (${options.length}): ${preview}` +
+          (options.length > 40 ? ", …" : ""),
+      );
+    }
+    // Dynamic combo with no resolvable list: accept the exact value as given;
+    // do NOT coerce a string to an index.
+    return value;
+  }
+
+  if (isNumericWidget(widget)) {
+    const num = typeof value === "number" ? value : Number(value);
+    if (value === null || value === "" || !Number.isFinite(num)) {
+      throw new WidgetWriteError(
+        `Widget "${name}" is numeric (type ${widget?.type}) but value ` +
+          `${JSON.stringify(value)} is not a number.`,
+      );
+    }
+    return num;
+  }
+
+  if (isBooleanWidget(widget)) {
+    if (typeof value === "boolean") return value;
+    const s = String(value).toLowerCase();
+    if (s === "true" || s === "1") return true;
+    if (s === "false" || s === "0") return false;
+    throw new WidgetWriteError(
+      `Widget "${name}" is boolean but value ${JSON.stringify(value)} is not ` +
+        `a boolean (true/false).`,
+    );
+  }
+
+  // STRING / text / unknown widget: pass through unchanged.
+  return value;
+}
+
+/**
+ * Resolve a PARENT SubgraphNode's promoted widget to the ACTUAL inner
+ * (node, widget) it stands for, so a write lands on the real target instead of
+ * a positionally-shifted neighbour on the parent (root cause of #233).
+ *
+ * A promoted widget is backed by a SubgraphNode input whose `_subgraphSlot`
+ * (subgraph input) links, inside the subgraph, to the inner node's widget
+ * input. `resolveSource(subgraphNode, subgraphInput)` performs that link walk
+ * (the panel injects its live-graph `sourceForSubgraphInput`) and returns
+ * `{ sourceNodeId, sourceWidgetName }`.
+ *
+ * Returns `{ node, widget, input }` for the inner target, or null when the
+ * widget is not a promoted subgraph widget (caller then writes on the node
+ * directly).
+ */
+export function resolvePromotedInnerTarget(subgraphNode, widgetName, resolveSource) {
+  const subgraph = subgraphNode?.subgraph;
+  if (!subgraph || typeof resolveSource !== "function") return null;
+  const wanted = String(widgetName).toLowerCase();
+
+  for (const input of subgraphNode.inputs ?? []) {
+    const subgraphInput = input?._subgraphSlot;
+    if (!subgraphInput) continue;
+
+    const source = resolveSource(subgraphNode, subgraphInput);
+    if (!source) continue;
+
+    // The promoted widget on the parent is named after the host input
+    // (input.name / label) which mirrors the inner source widget name. Match
+    // on any of them so a rename on either side still resolves.
+    const candidates = [
+      input.name,
+      input.label,
+      subgraphInput.name,
+      subgraphInput.label,
+      source.sourceWidgetName,
+    ].map((c) => (c == null ? null : String(c).toLowerCase()));
+    if (!candidates.includes(wanted)) continue;
+
+    const innerNode =
+      typeof subgraph.getNodeById === "function"
+        ? subgraph.getNodeById(source.sourceNodeId)
+        : (subgraph._nodes ?? []).find((n) => String(n?.id) === String(source.sourceNodeId));
+    if (!innerNode) continue;
+
+    const innerWidget = (innerNode.widgets ?? []).find(
+      (w) => w?.name === source.sourceWidgetName,
+    );
+    if (!innerWidget) continue;
+
+    return { node: innerNode, widget: innerWidget, input };
+  }
+  return null;
+}

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -95,8 +95,15 @@ export function coerceWidgetValue(widget, value) {
   }
 
   if (isNumericWidget(widget)) {
-    const num = typeof value === "number" ? value : Number(value);
-    if (value === null || value === "" || typeof value === "boolean" || !Number.isFinite(num)) {
+    // Accept ONLY a finite number, or a non-blank numeric string. Reject
+    // arrays/objects/booleans/null/whitespace — Number([])===0 and
+    // Number([5])===5 would otherwise silently mutate an INT/FLOAT slot.
+    let num;
+    if (typeof value === "number" && Number.isFinite(value)) {
+      num = value;
+    } else if (typeof value === "string" && value.trim() !== "" && Number.isFinite(Number(value))) {
+      num = Number(value);
+    } else {
       throw new WidgetWriteError(
         `Widget "${name}" is numeric (type ${widget?.type}) but value ` +
           `${JSON.stringify(value)} is not a number.`,
@@ -144,17 +151,23 @@ export function resolvePromotedInnerTarget(subgraphNode, widgetName, resolveSour
   if (!subgraph) return { promoted: false };
   const wanted = String(widgetName).toLowerCase();
 
-  // All promoted inputs whose OUTER alias matches the requested name.
+  // Host inputs whose OUTER alias matches the requested name. We match on the
+  // HOST input's own name/label AND (when present) its backing subgraph slot,
+  // so a promoted widget is DETECTED even if `_subgraphSlot` is missing — that
+  // must fail CLOSED, never fall through to the shifted parent widget.
   const matches = [];
   for (const input of subgraphNode.inputs ?? []) {
-    const subgraphInput = input?._subgraphSlot;
-    if (!subgraphInput) continue;
-    const aliases = [input.name, input.label, subgraphInput.name, subgraphInput.label].map(
-      (a) => (a == null ? null : String(a).toLowerCase()),
-    );
+    const subgraphInput = input?._subgraphSlot ?? null;
+    const aliases = [
+      input?.name,
+      input?.label,
+      subgraphInput?.name,
+      subgraphInput?.label,
+    ].map((a) => (a == null ? null : String(a).toLowerCase()));
     if (aliases.includes(wanted)) matches.push({ input, subgraphInput });
   }
 
+  // No matching host input at all ⇒ a genuine non-promoted own-widget.
   if (matches.length === 0) return { promoted: false };
   if (matches.length > 1) {
     return {
@@ -165,6 +178,15 @@ export function resolvePromotedInnerTarget(subgraphNode, widgetName, resolveSour
   }
 
   const { input, subgraphInput } = matches[0];
+  // It IS a promoted widget, but its backing subgraph slot is absent — we
+  // cannot reach the inner target, so refuse rather than corrupt the parent.
+  if (!subgraphInput) {
+    return {
+      promoted: true,
+      target: null,
+      error: `promoted widget "${widgetName}" has no backing subgraph slot (_subgraphSlot missing) — cannot resolve inner target.`,
+    };
+  }
   if (typeof resolveSource !== "function") {
     return {
       promoted: true,


### PR DESCRIPTION
## Summary
Fixes two graph-corruption bugs where `panel_set_widget` (`graph_set_widget`) wrote the WRONG value/target while reporting success.

### #233 (SEVERE) — promoted subgraph widget corrupts the wrong inner node
On a PARENT `SubgraphNode`, writing a PROMOTED widget landed on a positionally-shifted parent slot and silently clobbered a DIFFERENT inner widget (an INT slot ended up holding `"euler"`), returning success. Now the promoted widget is resolved to its ACTUAL inner `(node, widget)` by walking the subgraph-input link (reusing the live `sourceForSubgraphInput` traversal) and the write lands on the real inner widget.

### #240 — combo silently drifts to a different enum
A COMBO widget set to a valid enum could drift to another option (index-vs-value reinterpretation). Combo writes now require an EXACT match against the CURRENT option list — no index reinterpretation, no fuzzy match.

### Shared root
Both stem from the write never validating value-against-target. New `coerceWidgetValue()` rejects a mismatch with an actionable error instead of writing garbage:
- combo → must be an exact current option
- numeric (INT/FLOAT/number) → must be numeric (rejects `"euler"`)
- boolean → must be boolean

After writing, the handler verifies the value stuck as the exact value, or fails loudly rather than false-succeeding.

## Changes
- New `web/js/lib/widget-write.js`: `coerceWidgetValue`, `resolvePromotedInnerTarget`, `WidgetWriteError`, combo/numeric/boolean classifiers.
- `graph_set_widget` in `web/js/comfyui-mcp-panel.js`: resolve promoted target, validate/coerce, verify post-write.
- Tests: `browser_tests/unit/widget-write.test.mjs`.

## Tests
Full unit suite green: **250 pass / 0 fail**. New tests assert: promoted write hits the correct inner widget with neighbours untouched; combo valid writes exact value; combo invalid + numeric-index rejected; numeric rejects non-numeric.

No version bump (release handled separately). Do not merge — pending codex review + Chrome live re-test on a throwaway workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)