### PR TITLE
release: 0.11.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.7] - 2026-07-30
+
+### Fixed
+- **SEVERE graph corruption: `panel_set_widget` on a promoted subgraph widget + combo enums (#233, #240).** `graph_set_widget` did `w.value = value` with no target resolution or value validation. On a SubgraphNode the promoted widget's slot is positionally shifted vs the inner node, so writing by name clobbered a DIFFERENT inner widget (an INT `steps` slot ended up holding `"euler"`) while reporting success; and a combo write was later reinterpreted as a stale dropdown index, drifting to a neighbouring enum. New `web/js/lib/widget-write.js`: `resolvePromotedInnerTarget` walks the subgraph-input link to the ACTUAL inner `(node,widget)` and FAILS CLOSED (throws before any mutation) when a promoted widget can't be resolved or is ambiguous — never writing a shifted parent slot; `coerceWidgetValue` validates by declared type (combo = exact current option only, numeric rejects arrays/objects/blanks/non-finite) and the handler verifies the value stuck exactly. Live-verified: a valid combo value sets exactly, an invalid one is rejected (not silently coerced). (#244)
+- **`[object Object]` at the sidebar + persisted-replay sites (#238, #241).** WS-9 (#228) serialized the live chat but the sidebar output payload and the persisted-message rehydration path still stringified objects. Both now route through the shared `coerceMessageText`; replay drops only content-losing objects, never a legitimately empty message. Live-verified after reload. (#243)
+
 ## [0.11.6] - 2026-07-29
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.6"
+version = "0.11.7"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -206,7 +206,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.6";
+const PANEL_VERSION = "0.11.7";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Panel 0.11.7. Two fixes, both codex-clean + Chrome live-verified:
- **SEVERE set_widget graph corruption (#244 → #233/#240):** promoted-subgraph writes now resolve the real inner target or fail closed (never a shifted parent slot); combos require an exact option (invalid rejected, not silently coerced). 3 codex rounds, 270 unit tests w/ a faithful subgraph model; combo path live-verified (valid sets exactly, invalid rejected).
- **[object Object] at sidebar + persisted-replay (#243 → #238/#241):** both routed through WS-9's coerceMessageText; live-verified readable after reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)