### PR TITLE
release: 0.11.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.8] - 2026-07-30
+
+### Fixed
+- **SEVERE: `panel_install_node` no longer silently reports success without installing (#232).** ComfyUI-Manager marks every queued task "done" even when the git clone fails, and its status surface exposes only aggregate counts — so a GitHub-repo install that never landed reported identically to a real success. Install now goes through a tri-state verifier: **installed** only on a positively-observed queue drain + the pack actually present in `/customnode/installed`; **failed** only when the queue drained with readable data, explicit failure evidence, and an identifiable target definitively absent; **unverified** (honest `pending`, never a false success or false failure) for everything else — a rename-prone install (git URL / `owner/repo` whose on-disk dir differs), a still-processing queue, or a malformed/unreadable status or installed-list. Every Manager request (dialect probe, install, start, status, list) is now timeout-bounded. Live-verified: a bogus git-URL install returns `installed:false, verified:false, pending:true` with no false success and no crash. (#246)
+
 ## [0.11.7] - 2026-07-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.7"
+version = "0.11.8"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -206,7 +206,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.7";
+const PANEL_VERSION = "0.11.8";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Panel 0.11.8 — SEVERE #232: panel_install_node no longer silently reports success. Tri-state verifier (installed/failed/unverified), all Manager fetches bounded. 6 codex rounds (caught a queueDrained ReferenceError that would've broken all installs) + Chrome live-verified (bogus install → unverified/pending, no false success, no crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)