### PR TITLE
fix(manager): complete the 3.x-legacy dialect for list/update-self/restart (#423 #424 #425)

### DIFF
--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -19,6 +19,11 @@ const {
   isReadableInstalledList,
   queueFailureSignal,
   classifyInstallOutcome,
+  installedListRoute,
+  isManagerUnreachable,
+  isMethodNotAllowed,
+  legacyUpdateBody,
+  rebootCandidates,
 } = ManagerInstall;
 
 test("looksLikeGitUrl recognizes every git protocol", () => {
@@ -539,4 +544,76 @@ test("waitForQueueDrain (real panel source) returns a drained status without Ref
   const status = await realWait({ timeoutMs: 5000, intervalMs: 10 });
   assert.equal(queueDrained(status), true, "should return a positively-drained status");
   assert.ok(polls >= 2, "should have polled until drained");
+});
+
+// ---------------------------------------------------------------------------
+// 3.x-LEGACY dialect completeness (#423 list / #424 update-self / #425 restart)
+// ---------------------------------------------------------------------------
+
+test("#423 installedListRoute passes ?mode=default and no /v2 prefix (managerGet/Call add it)", () => {
+  const route = installedListRoute();
+  assert.equal(route, "customnode/installed?mode=default");
+  assert.ok(!route.startsWith("/v2"), "route must not carry a /v2 prefix");
+  assert.ok(!route.startsWith("/"), "route is a tail managerGet/managerCall prefix");
+});
+
+test("#423 isManagerUnreachable flags 404 / not-reachable → triggers the absolute legacy list fallback", () => {
+  assert.equal(isManagerUnreachable(new Error("ComfyUI-Manager not reachable (is the built-in Manager enabled?)")), true);
+  assert.equal(isManagerUnreachable(new Error("Manager customnode/installed: HTTP 404")), true);
+  // A genuine server error must NOT be swallowed by the fallback.
+  assert.equal(isManagerUnreachable(new Error("Manager customnode/installed: HTTP 500")), false);
+  assert.equal(isManagerUnreachable(new Error("Manager manager/queue/update: HTTP 405")), false);
+});
+
+test("#423 legacy list payload parses via parseInstalled (map + array shapes)", () => {
+  // released 3.x /customnode/installed returns the get_installed_node_packs MAP.
+  const legacyMap = {
+    "ComfyUI-Manager": { ver: "3.10", cnr_id: "comfyui-manager", enabled: true },
+    "rgthree-comfy": { ver: "1.0", cnr_id: "rgthree-comfy", enabled: true },
+  };
+  const parsed = parseInstalled(legacyMap);
+  assert.equal(parsed.length, 2);
+  assert.ok(nodeInstalledMatches("comfyui-manager", parsed), "Manager itself resolves from the legacy map");
+});
+
+test("#424 isMethodNotAllowed detects the /v2 envelope 405 that legacy self-update must dodge", () => {
+  assert.equal(isMethodNotAllowed(new Error("Manager manager/queue/task: HTTP 405")), true);
+  assert.equal(isMethodNotAllowed(new Error("405 Method Not Allowed")), true);
+  assert.equal(isMethodNotAllowed(new Error("Manager manager/queue/task: HTTP 403")), false);
+  assert.equal(isMethodNotAllowed(new Error("boom")), false);
+});
+
+test("#424 legacyUpdateBody targets the Manager self-update by id (unified_update keys off id)", () => {
+  // released-3.x update route: version !== 'unknown' ⇒ node_name = id.
+  assert.deepEqual(legacyUpdateBody({ ui_id: "u1", id: "comfyui-manager", version: "latest" }), {
+    ui_id: "u1",
+    id: "comfyui-manager",
+    version: "latest",
+  });
+  // nightly is preserved; anything else normalizes to latest.
+  assert.equal(legacyUpdateBody({ id: "x", version: "nightly" }).version, "nightly");
+  assert.equal(legacyUpdateBody({ id: "x", version: undefined }).version, "latest");
+  assert.equal(legacyUpdateBody({ id: "x", version: "1.2.3" }).version, "latest");
+});
+
+test("#425 rebootCandidates puts POST /manager/reboot first for legacy (never GET-only)", () => {
+  const legacy = rebootCandidates("legacy");
+  assert.deepEqual(legacy[0], { route: "/manager/reboot", method: "POST" });
+  // The released 3.x Manager has NO GET /manager/reboot — a POST route must be
+  // tried before the very-old GET fallback.
+  const idxPost = legacy.findIndex((c) => c.route === "/manager/reboot" && c.method === "POST");
+  const idxGet = legacy.findIndex((c) => c.route === "/manager/reboot" && c.method === "GET");
+  assert.ok(idxPost >= 0 && idxPost < idxGet, "legacy POST reboot precedes the GET fallback");
+});
+
+test("#425 rebootCandidates keeps POST /v2/manager/reboot first for pip dialects", () => {
+  for (const dialect of ["v2", "v2-batch", null, undefined]) {
+    const cands = rebootCandidates(dialect);
+    assert.deepEqual(cands[0], { route: "/v2/manager/reboot", method: "POST" });
+    // POST /manager/reboot is still present as a fallback for a legacy-UI build.
+    assert.ok(
+      cands.some((c) => c.route === "/manager/reboot" && c.method === "POST"),
+      `dialect ${dialect} must still offer POST /manager/reboot`,
+    );
+  }
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -66,7 +66,17 @@ import { marked } from "./vendor/marked.esm.js";
 import DOMPurify from "./vendor/purify.es.js";
 import qrcodegen from "./vendor/qrcode.esm.js";
 import { computeLayout } from "./lib/layout-engine.js";
-import { buildInstallRequest, classifyInstallOutcome, installGitUrl, queueDrained } from "./lib/manager-install.js";
+import {
+  buildInstallRequest,
+  classifyInstallOutcome,
+  installGitUrl,
+  installedListRoute,
+  isManagerUnreachable,
+  isMethodNotAllowed,
+  legacyUpdateBody,
+  queueDrained,
+  rebootCandidates,
+} from "./lib/manager-install.js";
 import {
   CHAT_HISTORY_MAX_IMPORT_BYTES,
   CHAT_HISTORY_SCHEMA,
@@ -6786,7 +6796,21 @@ const GRAPH_TOOL_EXECUTORS = {
   },
 
   async nodes_list() {
-    return { installed: await managerGet("customnode/installed") };
+    // #423: route the installed-node list by dialect (managerGet strips /v2 for
+    // legacy) with an explicit ?mode=default — matching the live-tested
+    // orchestrator. A pip Manager in --enable-manager-legacy-ui mode can answer
+    // the /v2 queue probe yet NOT register the /v2 data GETs, so the dialect-
+    // routed /v2/customnode/installed 404s ("not reachable") while the absolute
+    // /customnode/installed serves fine. On that unreachable signal, fall back
+    // to the absolute (no-/v2) legacy list route instead of surfacing a generic
+    // "unreachable" error.
+    const route = installedListRoute();
+    try {
+      return { installed: await managerGet(route) };
+    } catch (err) {
+      if (!isManagerUnreachable(err)) throw err;
+      return { installed: await managerCall(route) };
+    }
   },
 
   async nodes_install(args) {
@@ -6873,6 +6897,17 @@ const GRAPH_TOOL_EXECUTORS = {
     const client_id = api.clientId ?? api.initialClientId ?? "comfyui-mcp-panel";
     const note =
       "Update queued. Poll nodes_queue_status; a ComfyUI restart (comfy_reboot) is usually required to load the updated node.";
+    // #424: the absolute (no-/v2) legacy self-update route. Updating the
+    // ComfyUI-Manager node ITSELF (id 'comfyui-manager') through a /v2 task or
+    // batch envelope 405s on a legacy Manager — that POST /v2 route is a
+    // frontend catchall. The released-3.x `/manager/queue/update` handler keys
+    // the update off `id` (unified_update) and DOES update the Manager itself,
+    // so we retry it whenever the /v2 envelope is method-rejected.
+    const legacyUpdate = async () => {
+      const body = legacyUpdateBody({ ui_id, id, version });
+      await managerCall("manager/queue/update", { method: "POST", body });
+      await managerCall("manager/queue/start", { method: "POST" });
+    };
     if (dialect === "v2") {
       const params = {
         // The Manager's update task keys off node_name; include id too for
@@ -6884,25 +6919,36 @@ const GRAPH_TOOL_EXECUTORS = {
         mode: mode || "remote",
         channel: channel || "default",
       };
-      await managerV2("manager/queue/task", {
-        method: "POST",
-        body: { kind: "update", params, ui_id, client_id },
-      });
-      await managerV2("manager/queue/start", { method: "POST" });
+      try {
+        await managerV2("manager/queue/task", {
+          method: "POST",
+          body: { kind: "update", params, ui_id, client_id },
+        });
+        await managerV2("manager/queue/start", { method: "POST" });
+      } catch (err) {
+        if (!isMethodNotAllowed(err)) throw err;
+        await legacyUpdate();
+        return { queued: true, ui_id, id, version: sel, dialect, via: "legacy-self-update", note };
+      }
       return { queued: true, ui_id, id, version: sel, dialect, note };
     }
     // v2-batch + legacy: 3.x update body {ui_id, id, version} (issues #187/#182).
     const body = { ui_id, id, version: sel };
     if (dialect === "v2-batch") {
-      const res = await managerV2("manager/queue/batch", {
-        method: "POST",
-        body: { update: [body] },
-      });
-      assertBatchOk(res, id, "update");
-      await managerV2("manager/queue/start", { method: "POST" });
+      try {
+        const res = await managerV2("manager/queue/batch", {
+          method: "POST",
+          body: { update: [body] },
+        });
+        assertBatchOk(res, id, "update");
+        await managerV2("manager/queue/start", { method: "POST" });
+      } catch (err) {
+        if (!isMethodNotAllowed(err)) throw err;
+        await legacyUpdate();
+        return { queued: true, ui_id, id, version: sel, dialect, via: "legacy-self-update", note };
+      }
     } else {
-      await managerCall("manager/queue/update", { method: "POST", body });
-      await managerCall("manager/queue/start", { method: "POST" });
+      await legacyUpdate();
     }
     return { queued: true, ui_id, id, version: sel, dialect, note };
   },
@@ -6947,8 +6993,14 @@ const GRAPH_TOOL_EXECUTORS = {
     // INSIDE the live ComfyUI frontend, the server was demonstrably up a moment
     // ago, so a dropped connection here means the reboot fired (not that the
     // endpoint is unreachable). Treat that as success and let the auto-reconnect/
-    // resume flow take over. Try the canonical v2 route first, then the legacy
-    // GET route for older Manager builds. Classification of a real Response:
+    // resume flow take over. #425: the released 3.x Manager serves ONLY
+    // `POST /manager/reboot` — the old candidate list tried `POST /v2/manager/
+    // reboot` (405) then `GET /manager/reboot` (404), leaving a legacy Manager
+    // unrestartable and unable to bridge to a freshly-staged v4 install (issue
+    // #214). rebootCandidates() now orders real, method-correct routes by the
+    // detected dialect, so legacy gets `POST /manager/reboot` first. Detection is
+    // best-effort — a probe failure defaults to the pip (v2-first) ordering, and
+    // every route is still tried. Classification of a real Response:
     // 403 means Manager security blocked it (a real, actionable failure); a
     // 502/503/504 means we're reaching ComfyUI through a reverse proxy / tunnel
     // whose origin was just killed by the reboot (the proxy can't reach it) —
@@ -6956,10 +7008,14 @@ const GRAPH_TOOL_EXECUTORS = {
     // non-OK (404, etc.) means "wrong route on this build" → try the next. On
     // total failure we RETURN a structured error (rebooting:false) rather than
     // throw, so the agent is told accurately AND the auto-resume flag is not armed.
-    const candidates = [
-      { route: "/v2/manager/reboot", method: "POST" },
-      { route: "/manager/reboot", method: "GET" },
-    ];
+    let dialect = null;
+    try {
+      dialect = await detectManagerDialect();
+    } catch {
+      // Detection unreachable — fall back to the pip-first ordering; every
+      // candidate is still attempted below.
+    }
+    const candidates = rebootCandidates(dialect);
     const errors = [];
     for (const { route, method } of candidates) {
       try {

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -343,3 +343,62 @@ function unverifiedMessage(target, why) {
     `new nodes. If it still does not appear, check the ComfyUI server log.`
   );
 }
+
+// ---------------------------------------------------------------------------
+// 3.x-LEGACY dialect completeness (#423 list / #424 update-self / #425 restart)
+// #230 routed install/update/status by dialect but left three legacy-branch
+// gaps. These pure helpers keep the per-dialect route/method choices testable
+// under `node --test`, away from the browser Manager client.
+// ---------------------------------------------------------------------------
+
+/** #423 — the installed-node list route, WITHOUT the /v2 prefix (managerV2 adds
+ *  it for the pip dialects; managerCall hits it absolutely for legacy). The
+ *  released 3.x `/customnode/installed` handler reads `mode` (defaulting to
+ *  'default'); passing it explicitly matches the live-tested orchestrator
+ *  (listInstalledNodes) and keeps the legacy + pip shapes identical. */
+export function installedListRoute() {
+  return "customnode/installed?mode=default";
+}
+
+/** #423 — does a Manager error mean "route/prefix not present on this build"
+ *  (a 404 / the panel's "not reachable" throw), i.e. we should retry the
+ *  absolute (no-/v2) legacy route? A legacy-UI pip build can answer the queue
+ *  probe on /v2 yet NOT register the /v2 data GETs, so the dialect-routed
+ *  /v2/customnode/installed 404s while /customnode/installed serves fine. */
+export function isManagerUnreachable(err) {
+  const msg = String(err?.message ?? err ?? "");
+  return /not reachable/i.test(msg) || /HTTP\s*404\b/.test(msg);
+}
+
+/** #424 — did the Manager reject the method (HTTP 405)? Updating ComfyUI-Manager
+ *  ITSELF through a /v2 task/batch envelope 405s on a legacy Manager (the /v2
+ *  POST route is a frontend catchall); the fix is to retry the absolute legacy
+ *  `/manager/queue/update` self-update route. */
+export function isMethodNotAllowed(err) {
+  const msg = String(err?.message ?? err ?? "");
+  return /HTTP\s*405\b/.test(msg) || /method not allowed/i.test(msg);
+}
+
+/** #424 — the released-3.x `/manager/queue/update` body. The handler keys the
+ *  update off `id` when `version` !== 'unknown' (node_name = id), so a plain
+ *  installed pack name — including 'comfyui-manager' for a Manager self-update —
+ *  resolves via unified_update. Mirrors graph_update_node's legacy body. */
+export function legacyUpdateBody({ ui_id, id, version } = {}) {
+  return { ui_id, id, version: version === "nightly" ? "nightly" : "latest" };
+}
+
+/** #425 — ordered reboot {route, method} candidates for the detected dialect.
+ *  The released 3.x Manager serves ONLY `POST /manager/reboot` (the pre-#230
+ *  panel tried `GET /manager/reboot` → 404, after `POST /v2/manager/reboot` →
+ *  405, leaving a legacy Manager unrestartable — issue #214). pip builds keep
+ *  `POST /v2/manager/reboot` first; a very old `GET /manager/reboot` stays last
+ *  as a final fallback. Every candidate is a real, method-correct route so the
+ *  bridge from a legacy Manager to a freshly-staged v4 install works either way. */
+export function rebootCandidates(dialect) {
+  const v2 = { route: "/v2/manager/reboot", method: "POST" };
+  const legacyPost = { route: "/manager/reboot", method: "POST" };
+  const legacyGet = { route: "/manager/reboot", method: "GET" };
+  return dialect === "legacy"
+    ? [legacyPost, v2, legacyGet]
+    : [v2, legacyPost, legacyGet];
+}


### PR DESCRIPTION
## Summary
#230 routed panel node ops by Manager generation (v2 / v2-batch / legacy) but left three **legacy-branch** completeness gaps. Fixes verified against the released ComfyUI-Manager 3.x source (`glob/manager_server.py`) — the legacy dialect serves `GET /customnode/installed` (mode defaults), `POST /manager/queue/update`, and **`POST /manager/reboot`** (no GET, no /v2).

> Note: this repo has no issues numbered 423/424/425; the restart gap is tracked live as **#214** (`panel_restart_comfyui does not support ComfyUI-Manager 3.x legacy reboot endpoints`). The three IDs are kept as the task-supplied cluster labels.

### #423 — `panel_list_nodes` (`nodes_list`)
- Requests `customnode/installed?mode=default` (matches the live-tested orchestrator `listInstalledNodes`).
- On a `not reachable` / HTTP 404 (a pip `--enable-manager-legacy-ui` build can answer the `/v2` queue probe yet not register the `/v2` data GETs), falls back to the **absolute** `/customnode/installed` via `managerCall` instead of surfacing a generic "unreachable" error.

### #424 — `panel_update_node` (`graph_update_node`)
- Updating **ComfyUI-Manager itself** through the `/v2` task/batch envelope 405s on a legacy Manager (that POST route is a frontend catchall). On HTTP 405 the v2 and v2-batch paths now retry the absolute legacy `POST /manager/queue/update` self-update route (`unified_update` keys off `id`), returning `via: "legacy-self-update"`.

### #425 / #214 — `panel_restart_comfyui` (`comfy_reboot`)
- Old candidate list: `POST /v2/manager/reboot` (405) → `GET /manager/reboot` (404) ⇒ a legacy Manager was **unrestartable** and couldn't bridge to a freshly-staged v4 install.
- `rebootCandidates(dialect)` now orders real, method-correct routes by detected dialect — legacy gets **`POST /manager/reboot`** first; pip keeps `POST /v2/manager/reboot` first, with `POST /manager/reboot` as a fallback. Detection is best-effort (probe failure ⇒ pip ordering); all 403 / 502-4 / connection-drop handling preserved.

## Design
Per-dialect route/method choices are pure, unit-testable helpers in `web/js/lib/manager-install.js` (`installedListRoute`, `isManagerUnreachable`, `isMethodNotAllowed`, `legacyUpdateBody`, `rebootCandidates`). Orchestration stays localized in `comfyui-mcp-panel.js`. `detectManagerDialect` reused; **v2 / v2-batch happy paths unchanged**.

## Tests
7 new `node --test` cases in `browser_tests/unit/manager-install.test.mjs` (legacy list route+parse, 405 detection + self-update body, reboot candidate ordering per dialect). Full unit suite green: **349 pass / 0 fail**. Panel JS verified to parse as an ES module.

No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)