### PR TITLE
release: 0.11.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.9] - 2026-07-30
+
+### Fixed
+- **Complete the ComfyUI-Manager 3.x legacy dialect for restart / update-self / list.** A legacy Manager (released 3.x, or a pip build in `--enable-manager-legacy-ui` mode) serves reboot ONLY at `POST /manager/reboot`; the previous candidate list tried `POST /v2/manager/reboot` (405) then `GET /manager/reboot` (404), leaving a legacy Manager unrestartable (panel #214). `panel_restart_comfyui` now picks the reboot route by detected dialect (legacy → `POST /manager/reboot` first; v2/pip unchanged). Also: `panel_update_node` retries the absolute legacy `POST /manager/queue/update` on a `405` when updating ComfyUI-Manager itself, and `panel_list_nodes` falls back to the absolute `/customnode/installed` when a legacy build answers the `/v2` queue probe but not the `/v2` data GET. v2/v2-batch happy paths unchanged. (#250)
+
 ## [0.11.8] - 2026-07-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.8"
+version = "0.11.9"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -216,7 +216,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.8";
+const PANEL_VERSION = "0.11.9";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Panel 0.11.9 — completes the ComfyUI-Manager 3.x legacy dialect: legacy reboot route (fixes #214), legacy self-update on 405, legacy list fallback. v2/v2-batch unchanged. codex PASS. 🤖 Generated with Claude Code