### PR TITLE
fix(get_errors): recompute missing-assets against the live graph, not a stale snapshot (#235 #247 #257 #352 #364)

### DIFF
--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -10,6 +10,7 @@ import assert from "node:assert/strict";
 
 import {
   findNodeByScopedId,
+  findSubgraphByUuid,
   assetCandidateStillReferenced,
   assetCandidateResolvesLive,
   isStaleAssetCandidate,
@@ -54,6 +55,79 @@ test("findNodeByScopedId walks a subgraph-scoped id one hop per segment", () => 
 test("findNodeByScopedId returns null for a missing node", () => {
   assert.equal(findNodeByScopedId(graphOf([]), 7), null);
   assert.equal(findNodeByScopedId(graphOf([{ id: 6051 }]), "6051:9999"), null);
+});
+
+/** A subgraph whose UUID is its `id` (real LiteGraph shape), holding `nodes`. */
+function subgraphOf(id, nodes) {
+  const byId = new Map(nodes.map((n) => [String(n.id), n]));
+  return { id, _nodes: nodes, getNodeById: (nid) => byId.get(String(nid)) ?? null };
+}
+/** A root graph with a `subgraphs` UUID→Subgraph registry (real ComfyUI shape). */
+function rootWithSubgraphs(rootNodes, subgraphs) {
+  const byId = new Map(rootNodes.map((n) => [String(n.id), n]));
+  return {
+    _nodes: rootNodes,
+    getNodeById: (id) => byId.get(String(id)) ?? null,
+    subgraphs: new Map(subgraphs.map((s) => [s.id, s])),
+  };
+}
+
+const SG_UUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+test("findSubgraphByUuid resolves via the root subgraphs registry", () => {
+  const sub = subgraphOf(SG_UUID, []);
+  const root = rootWithSubgraphs([], [sub]);
+  assert.equal(findSubgraphByUuid(root, SG_UUID), sub);
+});
+
+test("findSubgraphByUuid falls back to a recursive subgraph.id match", () => {
+  const inner = { id: 1913, widgets: [] };
+  const sub = subgraphOf(SG_UUID, [inner]);
+  const host = { id: 6051, subgraph: sub };
+  const root = graphOf([host]); // no registry
+  assert.equal(findSubgraphByUuid(root, SG_UUID), sub);
+});
+
+test("findNodeByScopedId resolves a REAL locator '<subgraphUuid>:<localId>' (#247)", () => {
+  const inner = { id: 1913, widgets: [] };
+  const sub = subgraphOf(SG_UUID, [inner]);
+  const root = rootWithSubgraphs([], [sub]);
+  assert.equal(findNodeByScopedId(root, `${SG_UUID}:1913`), inner);
+});
+
+test("findNodeByScopedId returns null when the subgraph UUID is unknown (fails open)", () => {
+  const root = rootWithSubgraphs([], []);
+  assert.equal(findNodeByScopedId(root, `${SG_UUID}:1913`), null);
+});
+
+test("isStaleAssetCandidate: STALE once a subgraph LoadImage/model widget is fixed via a UUID locator (#247/#352)", () => {
+  // LTX-style subgraph: the store still lists the pre-edit template filename, but
+  // the live widget inside the subgraph now points at the installed alternative.
+  const inner = { id: 6077, widgets: [{ name: "image", value: "ChatGPT Image.png" }] };
+  const sub = subgraphOf(SG_UUID, [inner]);
+  const root = rootWithSubgraphs([], [sub]);
+  assert.equal(
+    isStaleAssetCandidate(root, {
+      nodeId: `${SG_UUID}:6077`,
+      name: "sample_woman.png",
+      widgetName: "image",
+    }),
+    true,
+  );
+});
+
+test("isStaleAssetCandidate: a genuinely-missing subgraph asset STILL reports (UUID locator)", () => {
+  const inner = { id: 6077, widgets: [{ name: "ckpt_name", value: "ltx-2.3-22b-dev.safetensors" }] };
+  const sub = subgraphOf(SG_UUID, [inner]);
+  const root = rootWithSubgraphs([], [sub]);
+  assert.equal(
+    isStaleAssetCandidate(root, {
+      nodeId: `${SG_UUID}:6077`,
+      name: "ltx-2.3-22b-dev.safetensors",
+      widgetName: "ckpt_name",
+    }),
+    false,
+  );
 });
 
 test("assetCandidateStillReferenced: true while a widget still holds the file", () => {

--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -100,6 +100,55 @@ test("findNodeByScopedId returns null when the subgraph UUID is unknown (fails o
   assert.equal(findNodeByScopedId(root, `${SG_UUID}:1913`), null);
 });
 
+test("findNodeByScopedId STRICT-rejects malformed locators ⇒ null ⇒ fail-open (codex round-2 #1)", () => {
+  // The subgraph DOES contain node 6077 — a loose first/last-segment parse would
+  // wrongly resolve it and suppress a genuine miss. Strict parsing must return
+  // null for every malformed shape so the cross-check keeps reporting.
+  const inner = { id: 6077, widgets: [{ name: "image", value: "still-missing.png" }] };
+  const sub = subgraphOf(SG_UUID, [inner]);
+  const root = rootWithSubgraphs([], [sub]);
+  assert.equal(findNodeByScopedId(root, `${SG_UUID}:unexpected:6077`), null); // 3 segments
+  assert.equal(findNodeByScopedId(root, `${SG_UUID}::6077`), null); // empty middle
+  assert.equal(findNodeByScopedId(root, `${SG_UUID}:`), null); // empty local id
+  assert.equal(findNodeByScopedId(root, `not-a-uuid:6077`), null); // bad UUID
+  assert.equal(findNodeByScopedId(root, `${SG_UUID}:6077:extra:more`), null); // 4 segments
+  // The valid two-segment form still resolves.
+  assert.equal(findNodeByScopedId(root, `${SG_UUID}:6077`), inner);
+});
+
+test("isStaleAssetCandidate: a malformed 3-segment locator does NOT suppress a genuine miss (fail-open, codex round-2 #1)", () => {
+  const inner = { id: 6077, widgets: [{ name: "image", value: "moved.png" }] };
+  const sub = subgraphOf(SG_UUID, [inner]);
+  const root = rootWithSubgraphs([], [sub]);
+  // Even though no widget holds "gone.png", the locator is unrecognized ⇒ resolver
+  // returns null ⇒ still-referenced fails OPEN ⇒ candidate is NOT dropped.
+  assert.equal(
+    isStaleAssetCandidate(root, { nodeId: `${SG_UUID}:x:6077`, name: "gone.png", widgetName: "image" }),
+    false,
+  );
+});
+
+test("findSubgraphByUuid terminates on a cyclic subgraph graph (codex round-2 #2)", () => {
+  // Build a cycle: subgraph A hosts a node whose subgraph is B, and B hosts a
+  // node whose subgraph is A again. An unknown UUID must not recurse forever.
+  const a = subgraphOf("uuid-A", []);
+  const b = subgraphOf("uuid-B", []);
+  a._nodes = [{ id: 1, subgraph: b }];
+  b._nodes = [{ id: 2, subgraph: a }];
+  const root = graphOf([{ id: 10, subgraph: a }]);
+  assert.equal(findSubgraphByUuid(root, "does-not-exist"), null); // terminates, no overflow
+  assert.equal(findSubgraphByUuid(root, "uuid-B"), b); // still finds a real one
+});
+
+test("findNodeByScopedId fails open (null) on a cyclic graph with an unknown UUID (codex round-2 #2)", () => {
+  const a = subgraphOf("uuid-A", []);
+  const b = subgraphOf("uuid-B", []);
+  a._nodes = [{ id: 1, subgraph: b }];
+  b._nodes = [{ id: 2, subgraph: a }];
+  const root = graphOf([{ id: 10, subgraph: a }]);
+  assert.equal(findNodeByScopedId(root, `${SG_UUID}:6077`), null); // no overflow, fail-open
+});
+
 test("isStaleAssetCandidate: STALE once a subgraph LoadImage/model widget is fixed via a UUID locator (#247/#352)", () => {
   // LTX-style subgraph: the store still lists the pre-edit template filename, but
   // the live widget inside the subgraph now points at the installed alternative.

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -14,6 +14,12 @@
 
 const UNKNOWN_WIDGET_RE = /^UNKNOWN(_\d+)?$/;
 
+// A canonical RFC-4122-shaped UUID, as ComfyUI mints for subgraph ids. The strict
+// NodeLocatorId parse validates the first segment against this so a malformed or
+// non-UUID first segment falls through to fail-open (keep reporting the miss),
+// matching the frontend's own parseNodeLocatorId.
+const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
 /**
  * Look a node up by a single id segment. ComfyUI supports arbitrary STRING node
  * ids (UUID-like), so we must NOT coerce to Number blindly (that would turn a
@@ -35,8 +41,9 @@ function getNodeBySegment(graph, seg) {
  * falls back to a recursive walk matching each nested `subgraph.id`. Returns the
  * subgraph or null.
  */
-export function findSubgraphByUuid(graph, uuid) {
-  if (!graph || uuid == null) return null;
+export function findSubgraphByUuid(graph, uuid, _seen = new WeakSet()) {
+  if (!graph || uuid == null || _seen.has(graph)) return null;
+  _seen.add(graph);
   const reg = graph.subgraphs;
   if (reg && typeof reg.get === "function") {
     const hit = reg.get(uuid);
@@ -44,9 +51,9 @@ export function findSubgraphByUuid(graph, uuid) {
   }
   for (const node of graph._nodes ?? graph.nodes ?? []) {
     const sub = node?.subgraph;
-    if (!sub) continue;
+    if (!sub || _seen.has(sub)) continue;
     if (String(sub.id) === String(uuid)) return sub;
-    const found = findSubgraphByUuid(sub, uuid);
+    const found = findSubgraphByUuid(sub, uuid, _seen);
     if (found) return found;
   }
   return null;
@@ -67,19 +74,25 @@ export function findSubgraphByUuid(graph, uuid) {
  * fix (#235 #247 #257 #352 #364). We now resolve the subgraph by UUID and read
  * the local node inside it. A purely-NUMERIC multi-segment id (legacy group-node
  * execution id, e.g. "6051:1913") keeps the old node-hop path for compatibility.
+ *
+ * Parsing is STRICT to preserve fail-open safety: a NodeLocatorId is EXACTLY two
+ * segments (`<subgraphUUID>:<localNodeId>`) with a well-formed UUID first. Any
+ * other subgraph-ish shape (3+ segments, an empty segment, a malformed UUID) is
+ * unrecognized and returns null rather than guessing a node from first/last
+ * segments — guessing could resolve the wrong node and SUPPRESS a genuine miss.
  * Returns the node or null (null → cross-check fails open, i.e. keeps reporting).
  */
 export function findNodeByScopedId(rootGraph, scopedId) {
-  const parts = String(scopedId ?? "")
-    .split(":")
-    .filter((p) => p !== "");
-  if (!parts.length) return null;
+  const raw = String(scopedId ?? "");
+  if (!raw) return null;
+  // NOTE: split WITHOUT dropping empty segments, so "<uuid>::6077" (empty middle)
+  // stays 3 parts and is rejected below rather than collapsing to a false 2-part.
+  const parts = raw.split(":");
   if (parts.length === 1) return getNodeBySegment(rootGraph, parts[0]);
 
-  const localId = parts[parts.length - 1];
   const first = parts[0];
-  // A subgraph UUID contains non-digit characters; an all-digits first segment is
-  // a legacy node-id path (group nodes) and keeps the per-segment hop behaviour.
+  // An all-digits first segment is a legacy group-node execution id; keep the
+  // per-segment node-hop behaviour (any depth). Empty segments never match.
   if (/^\d+$/.test(first)) {
     let graph = rootGraph;
     for (let i = 0; i < parts.length; i++) {
@@ -92,9 +105,14 @@ export function findNodeByScopedId(rootGraph, scopedId) {
     return null;
   }
 
+  // A real NodeLocatorId is EXACTLY "<subgraphUUID>:<localNodeId>" — two
+  // segments, a well-formed UUID first, a non-empty local id. Anything else
+  // (extra segments, empty middle/local id, malformed UUID) is unrecognized:
+  // return null so the cross-check fails OPEN and keeps reporting the miss.
+  if (parts.length !== 2 || !UUID_RE.test(first) || parts[1] === "") return null;
   const sub = findSubgraphByUuid(rootGraph, first);
   if (!sub) return null;
-  return getNodeBySegment(sub, localId);
+  return getNodeBySegment(sub, parts[1]);
 }
 
 /**

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -29,23 +29,72 @@ function getNodeBySegment(graph, seg) {
 }
 
 /**
- * Resolve a possibly subgraph-scoped node id ("6051:1913", a plain 42, or a
- * string/UUID id) against the ROOT graph, walking one hop per ':' segment through
- * `.subgraph`. Returns the node or null.
+ * Find a subgraph by its UUID anywhere in the graph hierarchy — mirrors the
+ * ComfyUI frontend's own `findSubgraphByUuid`. Prefers the root graph's O(1)
+ * `subgraphs` registry (a `uuid → Subgraph` Map on real LiteGraph builds), and
+ * falls back to a recursive walk matching each nested `subgraph.id`. Returns the
+ * subgraph or null.
+ */
+export function findSubgraphByUuid(graph, uuid) {
+  if (!graph || uuid == null) return null;
+  const reg = graph.subgraphs;
+  if (reg && typeof reg.get === "function") {
+    const hit = reg.get(uuid);
+    if (hit) return hit;
+  }
+  for (const node of graph._nodes ?? graph.nodes ?? []) {
+    const sub = node?.subgraph;
+    if (!sub) continue;
+    if (String(sub.id) === String(uuid)) return sub;
+    const found = findSubgraphByUuid(sub, uuid);
+    if (found) return found;
+  }
+  return null;
+}
+
+/**
+ * Resolve a store candidate's node id — a ComfyUI **NodeLocatorId** — against the
+ * ROOT graph. Two real shapes exist (see @/types/nodeIdentification):
+ *   - a plain local id ("42" / a UUID-like string) → a node in the root graph;
+ *   - "<subgraphUuid>:<localNodeId>" → a node inside a subgraph, where the FIRST
+ *     segment is that subgraph's globally-unique UUID (registered on the root
+ *     graph), NOT a host node id.
+ *
+ * The prior implementation walked one hop per ':' segment treating each segment
+ * as a node id (`rootGraph.getNodeById(uuid)`), which never resolves a real
+ * subgraph locator — so the missing-asset live cross-check failed OPEN and kept
+ * reporting a subgraph asset as missing long after a widget/checkpoint/LoadImage
+ * fix (#235 #247 #257 #352 #364). We now resolve the subgraph by UUID and read
+ * the local node inside it. A purely-NUMERIC multi-segment id (legacy group-node
+ * execution id, e.g. "6051:1913") keeps the old node-hop path for compatibility.
+ * Returns the node or null (null → cross-check fails open, i.e. keeps reporting).
  */
 export function findNodeByScopedId(rootGraph, scopedId) {
   const parts = String(scopedId ?? "")
     .split(":")
     .filter((p) => p !== "");
   if (!parts.length) return null;
-  let graph = rootGraph;
-  for (let i = 0; i < parts.length; i++) {
-    const node = getNodeBySegment(graph, parts[i]);
-    if (!node) return null;
-    if (i === parts.length - 1) return node;
-    graph = node.subgraph ?? null;
+  if (parts.length === 1) return getNodeBySegment(rootGraph, parts[0]);
+
+  const localId = parts[parts.length - 1];
+  const first = parts[0];
+  // A subgraph UUID contains non-digit characters; an all-digits first segment is
+  // a legacy node-id path (group nodes) and keeps the per-segment hop behaviour.
+  if (/^\d+$/.test(first)) {
+    let graph = rootGraph;
+    for (let i = 0; i < parts.length; i++) {
+      const node = getNodeBySegment(graph, parts[i]);
+      if (!node) return null;
+      if (i === parts.length - 1) return node;
+      graph = node.subgraph ?? null;
+      if (!graph) return null;
+    }
+    return null;
   }
-  return null;
+
+  const sub = findSubgraphByUuid(rootGraph, first);
+  if (!sub) return null;
+  return getNodeBySegment(sub, localId);
 }
 
 /**


### PR DESCRIPTION
## Cluster
`panel_get_errors` keeps reporting an old missing model/media/checkpoint after a `panel_set_widget` / checkpoint / LoadImage / template mutation has already resolved (or changed) it: #235, #247, #257, #352, #364. The node detail shows the new value while `reasons[]` / `missing_models[]` / `missing_media[]` still name the old one.

## Root cause
`collectMissingAssets()` already re-evaluates each missing-asset candidate against the **live** graph every call (WS-3, #227) via `isStaleAssetCandidate` → `assetCandidateStillReferenced`. That check drops a candidate when no widget on its node still holds the file. It works for root nodes but **silently no-ops for any node inside a subgraph** (e.g. the bundled `ltx-2.3-img2vid` pack).

The candidate's `nodeId` from ComfyUI's `missingModel`/`missingMedia` stores is a **NodeLocatorId**. Its subgraph form is `"<subgraphUUID>:<localNodeId>"` — the first segment is the subgraph's globally-unique UUID (registered on the root graph's `subgraphs` map), **not** a host node id. The WS-3 resolver `findNodeByScopedId` walked one hop per `:` segment calling `rootGraph.getNodeById(uuid)`, which never resolves a real locator → resolver returns null → the cross-check **fails OPEN** → the candidate is reported missing forever, even after the fix. (WS-3's own subgraph test used a synthetic `hostNodeId:innerId` shape that never occurs in real ComfyUI, so the gap was masked.)

## Fix
Resolve the locator the way the ComfyUI frontend's own `getNodeByLocatorId` does (see `@/utils/graphTraversalUtil`):
- parse `"<subgraphUUID>:<localId>"`;
- find the subgraph by UUID — root `subgraphs` registry (O(1)), else a recursive `subgraph.id` match (new `findSubgraphByUuid`, mirrors the reference);
- read the local node inside that subgraph.

Plain root ids and purely-numeric legacy group-node execution ids keep their existing paths. Unresolved ids still return `null` (cross-check fails open → keeps reporting), so a genuine miss is never swallowed.

Panel-only, localized to the missing-assets path in `web/js/lib/asset-staleness.js`. No version bump.

## Tests
8 new cases in `browser_tests/unit/asset-staleness.test.mjs`:
- `findSubgraphByUuid` via the root registry and via recursive `subgraph.id`;
- `findNodeByScopedId` resolves a real `<uuid>:<localId>` locator; returns null (fail-open) on an unknown UUID;
- a subgraph asset fixed via `set_widget` is now dropped as **stale** (the regression);
- a genuinely-missing subgraph asset **still reports**.

Full unit suite green: `node --test browser_tests/unit/*.test.mjs` → 355 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)