### PR TITLE
release: 0.11.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.10] - 2026-07-30
+
+### Fixed
+- **panel_get_errors no longer reports a stale missing-asset for a SUBGRAPH-hosted node after the asset is fixed.** Root-node missing-assets already recomputed live (WS-3), but a subgraph node's candidate id is a NodeLocatorId `<subgraphUUID>:<localNodeId>` (the first segment is the subgraph's global UUID, not a host node id); the previous resolver walked it as host ids, never resolved, and the live cross-check failed OPEN — so a subgraph LoadImage/checkpoint/template asset kept being reported missing even after a `set_widget` fixed it (#247, and the subgraph parts of #235/#257). `findNodeByScopedId` now resolves the locator the way ComfyUI's `getNodeByLocatorId` does (strict two-segment parse + UUID validation + cycle-safe subgraph lookup); malformed locators still fail open so genuine misses are never suppressed. (#260)
+
 ## [0.11.9] - 2026-07-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.9"
+version = "0.11.10"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -216,7 +216,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.9";
+const PANEL_VERSION = "0.11.10";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Panel 0.11.10 — panel_get_errors no longer reports stale missing-assets for subgraph-hosted nodes (NodeLocatorId resolution); codex PASS r2, 359 tests. 🤖 Generated with Claude Code