### PR TITLE
release: 0.11.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.11] - 2026-07-30
+
+### Fixed
+- **Regression: saving a brand-new workflow was broken on ComfyUI frontend 1.47.x (#268).** The 0.11.6 #226 data-loss guard routes the safe path through `svc.saveWorkflowAs`, which the 1.47 frontend removed from `extensionManager.workflow` — so the guard fail-safe refused and `panel_save_workflow` could not save any never-persisted workflow (no data loss, but the flow was dead). `resolveSaveAsCopy` now probes the copy API across frontends — `saveWorkflowAs` (1.45.x) or `saveAs`+`openWorkflow`+`saveWorkflow` (1.47.x, mirroring upstream's Save-As sequence so the copy is activated and its real graph is persisted, never `null`); and `classifySource` consults an authoritative `/userdata` filesystem oracle (404-only ⇒ never-persisted) to distinguish a genuinely-new tab from a drifted real file, which 1.47's in-memory store can't. The #226 invariant is fully preserved (a real on-disk source is never moved/destroyed). Live-verified: a new workflow saves real content; a save-as still preserves the original. (#273)
+
 ## [0.11.10] - 2026-07-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.10"
+version = "0.11.11"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -216,7 +216,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.10";
+const PANEL_VERSION = "0.11.11";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Panel 0.11.11 — fixes #268 (new-workflow save broken on ComfyUI frontend 1.47.x, a regression from the #226 guard). Version-robust copy-API probe + FS oracle; #226 invariant preserved; codex PASS r3 + Chrome live-verified (new workflow saves real content, save-as preserves original). 🤖 Generated with Claude Code