### PR TITLE
release: 0.11.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.12] - 2026-07-30
+
+### Fixed
+- **Copy/paste no longer SILENTLY drops unregistered node types (#261).** Pasting a graph that contains node types not registered on the current server (e.g. AudioCrop / AudioSeparation) used to lose them with no signal. `graph_paste_nodes` now diffs the clipboard against what actually landed (byte-identical-fingerprint-guarded snapshot fallback) and returns `dropped_nodes`/`dropped_types` + a clear warning, so the agent knows which nodes were dropped instead of silently continuing. (#275)
+
 ## [0.11.11] - 2026-07-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.11"
+version = "0.11.12"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -223,7 +223,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.11";
+const PANEL_VERSION = "0.11.12";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Panel 0.11.12 — copy/paste no longer silently drops unregistered node types (#261); codex PASS. 🤖 Generated with Claude Code