### PR TITLE
release: 0.11.13 — SEVERE write-tool fabrication fix (#458)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.13] - 2026-07-30
+
+### Fixed
+- **SEVERE: write tools no longer fabricate success when the target can't be resolved (#458).** `graph_add_node` and `graph_set_widget` could return a plausible success payload — a full node schema, a "set" result — even when ComfyUI was unreachable, the node type was unknown, or the resolved target was a stale/unregistered placeholder, silently misleading the agent into thinking a write landed. Both tools now fail closed: `add_node` runs `assertAddNodeResolvable` before `LG.createNode` (distinguishing unreachable / defs-not-loaded from a genuinely unknown type via Comfy core sentinel types), and `set_widget` runs a resolved-target registration guard (`assertResolvedTargetRegistered`) *before* any coercion, hook, mutation, or widget callback — refusing type-less nodes, unresolved `subgraph:{}` placeholders, and stale instances while still trusting native/defless types (Note/Reroute). Shared handler extracted to `lib/set-widget.js` so the unit tests drive the exact production path. Live-verified: an unknown node type errors instead of returning a fabricated schema; a real node (KSampler) still succeeds with its true schema. (#281)
+
 ## [0.11.12] - 2026-07-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.12"
+version = "0.11.13"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -223,7 +223,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.12";
+const PANEL_VERSION = "0.11.13";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Cuts panel **0.11.13**. Bumps `pyproject.toml` version + `PANEL_VERSION` together (Registry publish fires on the pyproject change to main).

## Ships
- **SEVERE #458 (#281):** `graph_add_node` / `graph_set_widget` no longer fabricate a success payload when ComfyUI is unreachable, the node type is unknown, or the resolved target is a stale/unregistered placeholder. Both fail closed now. Shared handler extracted to `lib/set-widget.js` so tests drive the production path.

## Verification
- codex adversarial review (3 rounds of NEEDS-REVISION → final PASS): preflight precedes reconciliation; resolved-target guard precedes coercion/hooks/mutation/callbacks; direct/promoted-subgraph/`subgraph:{}`/type-less/unreachable/stale-instance all fail closed.
- Live-verified on the rig: unknown node type → ERROR (no fabricated schema); KSampler → real schema succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)