### PR TITLE
fix(search): panel_search_nodes degrades gracefully against unreachable/legacy Manager (#251, #255)

### DIFF
--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -24,6 +24,9 @@ const {
   isMethodNotAllowed,
   legacyUpdateBody,
   rebootCandidates,
+  parseNodeMappings,
+  managerUnavailableResult,
+  searchNodesVia,
 } = ManagerInstall;
 
 test("looksLikeGitUrl recognizes every git protocol", () => {
@@ -616,4 +619,108 @@ test("#425 rebootCandidates keeps POST /v2/manager/reboot first for pip dialects
       `dialect ${dialect} must still offer POST /manager/reboot`,
     );
   }
+});
+
+// ---------------------------------------------------------------------------
+// #251/#255 — panel_search_nodes degrades gracefully against an unreachable /
+// legacy ComfyUI-Manager instead of surfacing a raw throw that blocks the whole
+// install-discovery flow. searchNodesVia is dependency-injected with the panel's
+// managerGet (dialect-routed) + managerCall (absolute) so the REAL decision path
+// is exercised here.
+// ---------------------------------------------------------------------------
+
+const GETMAPPINGS_MAP = {
+  "https://github.com/Fannovel16/ComfyUI-Frame-Interpolation": [
+    ["RIFE VFI"],
+    { title: "ComfyUI Frame Interpolation", description: "RIFE frame interpolation and more" },
+  ],
+  "https://github.com/1038lab/ComfyUI-RMBG": [
+    ["RMBG", "BiRefNet"],
+    { title: "ComfyUI-RMBG", description: "Background removal with BiRefNet / RMBG" },
+  ],
+};
+const UNREACHABLE = new Error("ComfyUI-Manager not reachable (is the built-in Manager enabled?)");
+
+test("#251 nodes_search returns results when the dialect-routed GET works", async () => {
+  const managerGet = async () => GETMAPPINGS_MAP;
+  const managerCall = async () => {
+    throw new Error("absolute route should not be reached");
+  };
+  const res = await searchNodesVia(managerGet, managerCall, { query: "RIFE" });
+  assert.equal(res.count, 1);
+  assert.equal(res.results[0].title, "ComfyUI Frame Interpolation");
+});
+
+test("#255 nodes_search falls back to the ABSOLUTE legacy route when /v2 is unreachable", async () => {
+  // Legacy-UI pip build (or real 3.x Manager): dialect-routed /v2 GET 404s /
+  // throws "not reachable" while the absolute /customnode/getmappings serves.
+  const managerGet = async () => {
+    throw UNREACHABLE;
+  };
+  const managerCall = async () => GETMAPPINGS_MAP;
+  const res = await searchNodesVia(managerGet, managerCall, { query: "BiRefNet" });
+  assert.equal(res.count, 1);
+  assert.equal(res.results[0].id.includes("RMBG"), true);
+});
+
+test("#251/#255 nodes_search returns a structured {supported:false} result when BOTH routes are unreachable — never throws", async () => {
+  const throwUnreachable = async () => {
+    throw UNREACHABLE;
+  };
+  const res = await searchNodesVia(throwUnreachable, throwUnreachable, {
+    query: "RIFE frame interpolation",
+  });
+  assert.equal(res.supported, false);
+  assert.equal(res.managerReachable, false);
+  assert.equal(res.count, 0);
+  assert.deepEqual(res.results, []);
+  assert.equal(res.query, "RIFE frame interpolation");
+  assert.match(res.message, /Manager/i);
+  assert.match(res.message, /panel_list_nodes/);
+});
+
+test("#251/#255 nodes_search does NOT swallow a genuine server error (HTTP 500 propagates)", async () => {
+  const boom = async () => {
+    throw new Error("Manager customnode/getmappings: HTTP 500");
+  };
+  await assert.rejects(
+    () => searchNodesVia(boom, boom, { query: "x" }),
+    /HTTP 500/,
+    "a real server error must propagate, not degrade to supported:false",
+  );
+});
+
+test("#251/#255 a non-unreachable error from the absolute fallback also propagates", async () => {
+  const managerGet = async () => {
+    throw UNREACHABLE;
+  };
+  const managerCall = async () => {
+    throw new Error("Manager customnode/getmappings: HTTP 403");
+  };
+  await assert.rejects(
+    () => searchNodesVia(managerGet, managerCall, { query: "x" }),
+    /HTTP 403/,
+  );
+});
+
+test("parseNodeMappings handles array + map shapes and caps the limit", () => {
+  const arr = [
+    { id: "a/one", title: "One", description: "first" },
+    { id: "b/two", title: "Two", description: "second" },
+  ];
+  assert.equal(parseNodeMappings(arr, "", 15).count, 2);
+  assert.equal(parseNodeMappings(GETMAPPINGS_MAP, "", 15).count, 2);
+  // Filter is case-insensitive across id/title/description.
+  assert.equal(parseNodeMappings(GETMAPPINGS_MAP, "background", 15).count, 1);
+  // limit capped at 40; default 15.
+  const many = Array.from({ length: 60 }, (_, i) => ({ id: `p/${i}`, title: `t${i}` }));
+  assert.equal(parseNodeMappings(many, "", 999).results.length, 40);
+  assert.equal(parseNodeMappings(many, "").results.length, 15);
+});
+
+test("managerUnavailableResult is a safe, actionable structured payload", () => {
+  const r = managerUnavailableResult(undefined, UNREACHABLE);
+  assert.equal(r.supported, false);
+  assert.equal(r.query, "");
+  assert.equal(r.reason, UNREACHABLE.message);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -76,6 +76,7 @@ import {
   legacyUpdateBody,
   queueDrained,
   rebootCandidates,
+  searchNodesVia,
 } from "./lib/manager-install.js";
 import {
   CHAT_HISTORY_MAX_IMPORT_BYTES,
@@ -6846,27 +6847,14 @@ const GRAPH_TOOL_EXECUTORS = {
 
   // --- Custom-node management via the BUILT-IN ComfyUI Manager (/v2 API) ----
   async nodes_search({ query, limit }) {
-    const data = await managerGet("customnode/getmappings?mode=cache");
-    const q = String(query ?? "").toLowerCase();
-    const out = [];
-    const push = (id, title, desc) => {
-      if (!id) return;
-      const hay = `${id} ${title ?? ""} ${desc ?? ""}`.toLowerCase();
-      if (!q || hay.includes(q)) {
-        out.push({ id, title: title ?? id, description: String(desc ?? "").slice(0, 160) });
-      }
-    };
-    if (Array.isArray(data)) {
-      for (const p of data) push(p.id ?? p.reference ?? p.title, p.title, p.description);
-    } else if (data && typeof data === "object") {
-      // getmappings is keyed by repo/url → [ [classNames…], { title, description, … } ]
-      for (const [key, val] of Object.entries(data)) {
-        const meta = Array.isArray(val) ? val[1] : val;
-        push(meta?.id ?? meta?.title ?? key, meta?.title, meta?.description);
-      }
-    }
-    const max = Math.min(Number(limit) || 15, 40);
-    return { count: out.length, results: out.slice(0, max) };
+    // #251/#255: degrade gracefully against an unreachable / legacy Manager
+    // instead of surfacing a raw throw that blocks the whole install-discovery
+    // flow. searchNodesVia tries the dialect-routed GET, retries the ABSOLUTE
+    // (no-/v2) legacy route on an unreachable/404 signal (a legacy-UI pip build
+    // or real 3.x Manager can serve /customnode/getmappings while the /v2 route
+    // 404s — or detectManagerDialect's /v2 probe fails), and returns a
+    // structured {supported:false,…} capability result when BOTH are unreachable.
+    return searchNodesVia(managerGet, managerCall, { query, limit });
   },
 
   async nodes_list() {

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -387,6 +387,92 @@ export function legacyUpdateBody({ ui_id, id, version } = {}) {
   return { ui_id, id, version: version === "nightly" ? "nightly" : "latest" };
 }
 
+/**
+ * Normalize a ComfyUI-Manager `/customnode/getmappings` payload into the
+ * nodes_search result shape `{ count, results:[{id,title,description}] }`,
+ * filtered by `query` and capped at `limit` (default 15, max 40). Pure so the
+ * parse/filter is unit-testable away from the browser Manager client. Handles
+ * both wire shapes: an ARRAY of pack objects, or the documented MAP keyed by
+ * repo/url → [ [classNames…], { title, description, … } ]. Issues #251/#255.
+ */
+export function parseNodeMappings(data, query, limit) {
+  const q = String(query ?? "").toLowerCase();
+  const out = [];
+  const push = (id, title, desc) => {
+    if (!id) return;
+    const hay = `${id} ${title ?? ""} ${desc ?? ""}`.toLowerCase();
+    if (!q || hay.includes(q)) {
+      out.push({ id, title: title ?? id, description: String(desc ?? "").slice(0, 160) });
+    }
+  };
+  if (Array.isArray(data)) {
+    for (const p of data) push(p?.id ?? p?.reference ?? p?.title, p?.title, p?.description);
+  } else if (data && typeof data === "object") {
+    for (const [key, val] of Object.entries(data)) {
+      const meta = Array.isArray(val) ? val[1] : val;
+      push(meta?.id ?? meta?.title ?? key, meta?.title, meta?.description);
+    }
+  }
+  const max = Math.min(Number(limit) || 15, 40);
+  return { count: out.length, results: out.slice(0, max) };
+}
+
+/**
+ * Graceful-degradation result for nodes_search when the ComfyUI-Manager search
+ * backend can NOT be reached on ANY route (dialect-routed /v2 AND the absolute
+ * legacy route both threw "not reachable"). Instead of surfacing a raw throw —
+ * which blocks the whole install-discovery flow even though the agent can keep
+ * using already-registered nodes — return a STRUCTURED, actionable capability
+ * result the caller can branch on. Issues #251/#255.
+ */
+export function managerUnavailableResult(query, err) {
+  return {
+    supported: false,
+    managerReachable: false,
+    count: 0,
+    results: [],
+    query: query == null ? "" : String(query),
+    reason: String(err?.message ?? err ?? "ComfyUI-Manager not reachable"),
+    message:
+      "Node-registry search is unavailable: the built-in ComfyUI-Manager could not " +
+      "be reached on this ComfyUI (it may be disabled, or a legacy/partial Manager " +
+      "build without the search endpoint). Enable the built-in Manager to search the " +
+      "registry, or continue with the nodes already installed — inspect them with " +
+      "panel_list_nodes and the current graph with panel_get_graph.",
+  };
+}
+
+/**
+ * Run the nodes_search flow with graceful degradation against an unreachable /
+ * legacy ComfyUI-Manager (#251/#255). Dependency-injected `managerGet` (dialect-
+ * routed; adds /v2 for pip builds, strips it for legacy) and `managerCall`
+ * (absolute, no-/v2) so the whole decision path is unit-testable away from the
+ * browser Manager client. Order:
+ *   1. dialect-routed GET;
+ *   2. on an unreachable/404 signal, retry the ABSOLUTE legacy route (a legacy-
+ *      UI pip build or real 3.x Manager can serve /customnode/getmappings while
+ *      the /v2 route 404s, or detectManagerDialect's /v2 probe fails);
+ *   3. if the absolute route is ALSO unreachable, return the structured
+ *      {supported:false,…} capability result instead of throwing.
+ * Any non-"unreachable" error still propagates.
+ */
+export async function searchNodesVia(managerGet, managerCall, { query, limit } = {}) {
+  const route = "customnode/getmappings?mode=cache";
+  let data;
+  try {
+    data = await managerGet(route);
+  } catch (err) {
+    if (!isManagerUnreachable(err)) throw err;
+    try {
+      data = await managerCall(route);
+    } catch (err2) {
+      if (isManagerUnreachable(err2)) return managerUnavailableResult(query, err2);
+      throw err2;
+    }
+  }
+  return parseNodeMappings(data, query, limit);
+}
+
 /** #425 — ordered reboot {route, method} candidates for the detected dialect.
  *  The released 3.x Manager serves ONLY `POST /manager/reboot` (the pre-#230
  *  panel tried `GET /manager/reboot` → 404, after `POST /v2/manager/reboot` →


### PR DESCRIPTION
## Problem
`panel_search_nodes` (handler `nodes_search`) threw `Error: ComfyUI-Manager not reachable (is the built-in Manager enabled?)` outright when the connected ComfyUI ran a legacy/partial 3.x Manager, a legacy-UI pip build, or had the built-in Manager disabled. This blocked the whole install-discovery flow even though the agent can keep working with already-registered nodes.

Fixes #251, #255.

## Fix
Mirrors the existing `nodes_list` unreachable-fallback pattern:
- New pure helper `searchNodesVia(managerGet, managerCall, {query,limit})` tries the dialect-routed `/v2` getmappings GET, retries the **absolute** (no-`/v2`) legacy `/customnode/getmappings` route on an unreachable/404 signal, and returns a structured `{supported:false, managerReachable:false, count:0, results:[], reason, message}` capability result when **both** routes are unreachable — never a raw throw.
- Genuine server errors (HTTP 500/403) still propagate; degradation is scoped to `isManagerUnreachable` (404 / "not reachable").
- Parse/normalize logic extracted to pure, unit-testable `parseNodeMappings` + `managerUnavailableResult` in `lib/manager-install.js`.
- `nodes_search` now delegates to `searchNodesVia` with the real `managerGet`/`managerCall`.

## Tests
Added unit tests (`browser_tests/unit/manager-install.test.mjs`) driving the real helper: results path, absolute-route fallback, dual-unreachable structured result, HTTP 500/403 propagation, and `parseNodeMappings` shapes/filter/limit. Full suite: **420 pass, 0 fail**.

## Review
codex read-only review gate: **VERDICT: PASS** (no correctness/regression findings).

No version/PANEL_VERSION bump (release cut separately after merge).