### PR TITLE
release: 0.11.14 — search_nodes graceful degradation (#251, #255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.14] - 2026-07-30
+
+### Fixed
+- **`panel_search_nodes` degrades gracefully against an unreachable or legacy ComfyUI-Manager (#251, #255).** Node search called the dialect-routed `customnode/getmappings` and threw `ComfyUI-Manager not reachable` whenever the built-in Manager was disabled or was an older/partial 3.x build — blocking the whole install-discovery flow. It now retries the absolute (no-`/v2`) legacy route on an unreachable/404 signal, and returns a structured `{supported:false, managerReachable:false, results:[]}` result (pointing at `panel_list_nodes`) instead of a raw throw when both routes are unreachable. Genuine server errors (500/403) still propagate. Logic extracted to a dependency-injected `searchNodesVia` so the unit tests exercise the real decision path. (#294)
+
 ## [0.11.13] - 2026-07-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.13"
+version = "0.11.14"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -224,7 +224,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.13";
+const PANEL_VERSION = "0.11.14";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Cuts panel **0.11.14**. Bumps `pyproject.toml` + `PANEL_VERSION` together (Registry publish fires on the pyproject change to main).

## Ships
- **#251/#255 (#294, merged f74cbf6):** `panel_search_nodes` no longer hard-throws when ComfyUI-Manager is unreachable or a legacy 3.x build — retries the absolute legacy route, then returns a structured `{supported:false}` result; genuine 500/403 still propagate. 420 unit tests pass; codex PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)