### PR TITLE
fix(chat): serialize attachments + structured panel messages instead of [object Object] (#272, #276)

### DIFF
--- a/browser_tests/unit/chat-serialize.test.mjs
+++ b/browser_tests/unit/chat-serialize.test.mjs
@@ -1,7 +1,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { coerceMessageText, buttonReplyText, isDroppedAgentReplay } from "../../web/js/lib/chat-serialize.js";
+import {
+  coerceMessageText,
+  buttonReplyText,
+  isDroppedAgentReplay,
+  serializeContext,
+} from "../../web/js/lib/chat-serialize.js";
 
 test("strings pass through unchanged", () => {
   assert.equal(coerceMessageText("hello"), "hello");
@@ -157,4 +162,59 @@ test("null/undefined persisted text is dropped, never rendered as literal 'null'
   // matches the predicate (a real empty STRING is the only empty kept).
   assert.equal(isDroppedAgentReplay(null), true);
   assert.equal(isDroppedAgentReplay(undefined), true);
+});
+
+// --- outbound user_message context serialization (#276) --------------------
+// The composer passes context as a `{ workflow, subgraph }` OBJECT, but the
+// orchestrator only reads STRING context (it prepends it above the user's
+// text). The panel joins context parts into one string, so a raw object would
+// coerce via Array.join to the literal "[object Object]" and land above EVERY
+// message — the reported #276 symptom. serializeContext() must render readable
+// text and NEVER "[object Object]".
+
+// Reproduces the exact pre-fix coercion: joining an object context with the
+// same [pending, context].join("\n\n") the bridge uses.
+test("PRE-FIX repro: raw join of an object context yields [object Object] (#276)", () => {
+  const context = { workflow: "My WF", subgraph: "Detailer" };
+  const raw = [null, context].filter(Boolean).join("\n\n");
+  assert.equal(raw, "[object Object]"); // this is the bug being fixed
+});
+
+test("an object context serializes to readable workflow/subgraph lines, never [object Object] (#276)", () => {
+  const out = serializeContext({ workflow: "My WF", subgraph: "Detailer" });
+  assert.notEqual(out, "[object Object]");
+  assert.ok(!out.includes("[object Object]"), `got: ${out}`);
+  assert.equal(out, "Workflow: My WF\nViewing subgraph: Detailer");
+});
+
+test("an object context with only a workflow renders a single line (#276)", () => {
+  assert.equal(serializeContext({ workflow: "Base" }), "Workflow: Base");
+});
+
+test("the merged-context join used on the send path stays a clean string (#276)", () => {
+  // Mirror bridge sendUserMessage: [pendingContext, serializeContext(context)]
+  const pendingContext = null;
+  const context = { workflow: "Base" };
+  const merged =
+    [pendingContext, serializeContext(context)].filter(Boolean).join("\n\n") || undefined;
+  assert.equal(merged, "Workflow: Base");
+  assert.ok(!String(merged).includes("[object Object]"));
+});
+
+test("a string context (transcript replay) passes through untouched (#276)", () => {
+  const replay = "USER: hi\nASSISTANT: hello";
+  assert.equal(serializeContext(replay), replay);
+});
+
+test("null/empty context serializes to '' so it drops out of the join (#276)", () => {
+  assert.equal(serializeContext(null), "");
+  assert.equal(serializeContext(undefined), "");
+  assert.equal(serializeContext({}), "");
+});
+
+test("an unknown-shape object context degrades to JSON, never [object Object] (#276)", () => {
+  const out = serializeContext({ foo: 1, bar: 2 });
+  assert.notEqual(out, "[object Object]");
+  assert.ok(!out.includes("[object Object]"), `got: ${out}`);
+  assert.equal(out, '{"foo":1,"bar":2}');
 });

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -18,6 +18,7 @@ import {
 import { openSidePanel } from "./cmcp-sidepanel-ui.js";
 import { openSubModal as openSubModalBase, toast } from "./cmcp-modal.js";
 import { chipRow as filterChipRow, makeFilterButton } from "./cmcp-filter.js";
+import { coerceMessageText } from "./lib/chat-serialize.js";
 
 const TABS = [
   { key: "images", label: "Images", icon: "pi-image", media: "image" },
@@ -248,7 +249,10 @@ export function graphDirtyForConfirm(ctx) {
  *  exported for unit tests. `limit` is clamped to [1, 200]. */
 export const CIVITAI_PROMPT_CAP = 600; // chars — bound the agent's token budget
 function _capPrompt(p) {
-  if (typeof p !== "string" || !p) return p || null;
+  // Coerce a structured prompt so the outbound civitai_results contract never
+  // carries a raw object (would reach the agent as "[object Object]") (#276).
+  if (typeof p !== "string") p = coerceMessageText(p);
+  if (!p) return null;
   return p.length > CIVITAI_PROMPT_CAP ? p.slice(0, CIVITAI_PROMPT_CAP) + "…" : p;
 }
 export function serializeCivitaiResults(source, { model = false, limit = 20, loading = false } = {}) {
@@ -676,7 +680,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
         // The client throws Errors carrying an HTTP `status` (see CivitaiClient);
         // fall back to the message alone when it doesn't.
         const status = e && typeof e.status === "number" ? e.status : null;
-        state.error = { status, message: e && e.message ? e.message : String(e) };
+        state.error = { status, message: coerceMessageText(e?.message ?? e) };
       }
     } finally {
       if (req === state.reqId) setLoading(false);
@@ -1058,7 +1062,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     }
     if (gen.meta?.prompt) {
       const p = el("div"); p.style.cssText = "font-size:.78rem;margin-top:.5rem;white-space:pre-wrap";
-      p.textContent = "Prompt: " + gen.meta.prompt; sheet.body.appendChild(p);
+      p.textContent = "Prompt: " + coerceMessageText(gen.meta.prompt); sheet.body.appendChild(p);
     }
   }
 
@@ -1068,8 +1072,10 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       "Recreate this CivitAI example as closely as you can — match the reference and use these settings (use our local model if we have it, else download it first):",
       "",
     ];
-    if (m.prompt) lines.push("Prompt: " + m.prompt);
-    if (m.negativePrompt) lines.push("Negative: " + m.negativePrompt);
+    // Coerce prompt fields — a structured prompt/negative must not reach the
+    // outbound share-with-agent caption as "[object Object]" (#276).
+    if (m.prompt) lines.push("Prompt: " + coerceMessageText(m.prompt));
+    if (m.negativePrompt) lines.push("Negative: " + coerceMessageText(m.negativePrompt));
     for (const [k, v] of CivitaiClient.params(m)) lines.push(`${k}: ${v}`);
     return lines.join("\n");
   }
@@ -1084,7 +1090,7 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       } else {
         const caption = buildCaption(gen);
         ctx.sendUserMessage(
-          `${caption}\n\nThe reference is uploaded to the ComfyUI input/ folder as \`${ref.filename}\` — use it as the target to match.`,
+          `${caption}\n\nThe reference is uploaded to the ComfyUI input/ folder as \`${coerceMessageText(ref.filename)}\` — use it as the target to match.`,
           undefined, [ref],
         );
         ctx.bringChatForward();

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -8,6 +8,8 @@
 // NOTE (parity, no NSFW gate): all browsing levels are freely selectable; there
 // is no sign-in clamp. OAuth only enables the Favorites tab.
 
+import { coerceMessageText } from "./lib/chat-serialize.js";
+
 // ── constants (mirror civitai_models.dart) ─────────────────────────────────
 export const LEVELS = [
   { label: "PG", level: 1 },
@@ -922,8 +924,11 @@ export class CivitaiClient {
     const rows = [
       ["Model", meta.Model], ["sampler", meta.sampler], ["scheduler", meta.scheduler],
       ["steps", meta.steps], ["cfg", meta.cfgScale], ["seed", meta.seed],
-      ["denoise", meta.denoise], ["size", meta.width && meta.height ? `${val(meta.width)}×${val(meta.height)}` : null],
+      ["denoise", meta.denoise],
+      ["size", meta.width && meta.height ? `${coerceMessageText(val(meta.width))}×${coerceMessageText(val(meta.height))}` : null],
     ];
-    return rows.filter(([, v]) => v != null && v !== "").map(([k, v]) => [k, String(val(v))]);
+    // coerceMessageText (not String) so a structured param value can never become
+    // "[object Object]" in the info panel or the outbound share-with-agent caption (#276).
+    return rows.filter(([, v]) => v != null && v !== "").map(([k, v]) => [k, coerceMessageText(val(v))]);
   }
 }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -102,7 +102,7 @@ import {
 } from "./lib/asset-staleness.js";
 import { assertAddNodeResolvable } from "./lib/node-resolve.js";
 import { runSetWidget } from "./lib/set-widget.js";
-import { coerceMessageText, isDroppedAgentReplay } from "./lib/chat-serialize.js";
+import { coerceMessageText, isDroppedAgentReplay, serializeContext } from "./lib/chat-serialize.js";
 import {
   recordCopiedNodes,
   getVerifiedSnapshot,
@@ -2663,12 +2663,31 @@ async function verifyInstalled(target, dialect, { batchFailed, renameProne } = {
   return classifyInstallOutcome({ target, dialect, status, installed, listError, batchFailed, renameProne });
 }
 
+/** Normalize an outbound image descriptor so its string-ish fields can never
+ *  reach the wire (user_message.images / agent_event.images) as a coerced
+ *  "[object Object]" — the orchestrator builds /view URLs and prompt notes from
+ *  these (#276). Non-descriptor fields (data URLs, refs) are preserved as-is. */
+function normalizeImageDescriptor(img) {
+  if (!img || typeof img !== "object" || Array.isArray(img)) return img;
+  const out = { ...img };
+  if ("filename" in out) out.filename = coerceMessageText(out.filename);
+  if ("subfolder" in out && out.subfolder != null) out.subfolder = coerceMessageText(out.subfolder);
+  if ("type" in out && out.type != null) out.type = coerceMessageText(out.type) || "output";
+  if ("format" in out && out.format != null) out.format = coerceMessageText(out.format);
+  return out;
+}
+function normalizeImageList(images) {
+  return Array.isArray(images) ? images.map(normalizeImageDescriptor) : images;
+}
+
 /** Build a ComfyUI /view URL for an output image descriptor. */
 function imageViewUrl(img) {
   const qs = new URLSearchParams({
-    filename: img.filename ?? "",
-    subfolder: img.subfolder ?? "",
-    type: img.type ?? "output",
+    // Coerce — a structured filename/subfolder must not become "[object Object]"
+    // in the media URL (which reaches the agent via imageRefs / notes) (#276).
+    filename: coerceMessageText(img.filename),
+    subfolder: coerceMessageText(img.subfolder),
+    type: coerceMessageText(img.type) || "output",
   }).toString();
   const path = `/view?${qs}`;
   try {
@@ -3496,15 +3515,19 @@ function validationBanner() {
   if (nodeErrors) {
     const lines = [];
     for (const [nid, info] of Object.entries(nodeErrors)) {
-      const ct = (info && info.class_type) || "?";
+      const ct = coerceMessageText(info && info.class_type) || "?";
       const errs = info && Array.isArray(info.errors) ? info.errors : [];
       if (!errs.length) {
         lines.push(`node ${nid} (${ct}): invalid`);
         continue;
       }
       for (const e of errs) {
-        const detail = e && e.details ? ` — ${e.details}` : "";
-        lines.push(`node ${nid} (${ct}): ${(e && (e.message || e.type)) || "error"}${detail}`);
+        // Coerce before interpolation — a structured details/message payload
+        // must not become "[object Object]" in this outbound banner (#276).
+        const detailStr = e && e.details != null ? coerceMessageText(e.details) : "";
+        const detail = detailStr ? ` — ${detailStr}` : "";
+        const head = coerceMessageText(e && (e.message || e.type)) || "error";
+        lines.push(`node ${nid} (${ct}): ${head}${detail}`);
       }
     }
     const MAX = 30;
@@ -3522,23 +3545,26 @@ function validationBanner() {
   }
   if (missing.any) {
     const lines = [];
+    // Coerce every interpolated descriptor field — no structured value may bake
+    // "[object Object]" into this outbound banner (#276).
+    const s = (v, dflt = "") => coerceMessageText(v) || dflt;
     for (const m of missing.models.slice(0, 12)) {
       lines.push(
-        `node ${m.node_id ?? "?"}: MODEL missing — ${m.file ?? "?"}` +
-          (m.directory ? ` (belongs in models/${m.directory})` : "") +
-          (m.widget ? ` [widget ${m.widget}]` : "") +
-          (m.download_url ? `\n    download: ${m.download_url}` : ""),
+        `node ${s(m.node_id, "?")}: MODEL missing — ${s(m.file, "?")}` +
+          (m.directory ? ` (belongs in models/${s(m.directory)})` : "") +
+          (m.widget ? ` [widget ${s(m.widget)}]` : "") +
+          (m.download_url ? `\n    download: ${s(m.download_url)}` : ""),
       );
     }
     for (const m of missing.media.slice(0, 12)) {
       lines.push(
-        `node ${m.node_id ?? "?"}: INPUT ${m.media_type ?? "file"} missing — ${m.file ?? "?"}` +
-          (m.widget ? ` [widget ${m.widget}]` : "") +
+        `node ${s(m.node_id, "?")}: INPUT ${s(m.media_type, "file")} missing — ${s(m.file, "?")}` +
+          (m.widget ? ` [widget ${s(m.widget)}]` : "") +
           ` (the user must re-upload it; it's their own asset, not a download)`,
       );
     }
     if (missing.nodeTypes.length) {
-      lines.push(`node types not installed: ${missing.nodeTypes.slice(0, 12).join(", ")}`);
+      lines.push(`node types not installed: ${missing.nodeTypes.slice(0, 12).map((t) => coerceMessageText(t)).join(", ")}`);
     } else if (missing.nodeCount) {
       lines.push(`${missing.nodeCount} node type(s) not installed on this ComfyUI`);
     }
@@ -3552,10 +3578,13 @@ function validationBanner() {
       `re-upload the input file. Full detail anytime with panel_get_errors.\n\n`;
   }
   if (execErr) {
-    const msg = execErr.exception_message || execErr.exception_type || "execution error";
-    const where = execErr.node_type
-      ? ` in ${execErr.node_type} (node ${execErr.node_id ?? "?"})`
-      : "";
+    const msg =
+      coerceMessageText(execErr.exception_message) ||
+      coerceMessageText(execErr.exception_type) ||
+      "execution error";
+    const nodeType = coerceMessageText(execErr.node_type);
+    const nodeId = execErr.node_id != null ? coerceMessageText(execErr.node_id) : "?";
+    const where = nodeType ? ` in ${nodeType} (node ${nodeId})` : "";
     out +=
       `⚠️ LAST RUN FAILED${where}: ${msg}\nThis is a RUNTIME error from the most recent ` +
       `execution (distinct from the validation errors above).\n\n`;
@@ -5028,7 +5057,7 @@ const GRAPH_TOOL_EXECUTORS = {
       try {
         data = JSON.parse(data);
       } catch (err) {
-        throw new Error(`graph is not valid JSON: ${err?.message ?? err}`);
+        throw new Error(`graph is not valid JSON: ${coerceMessageText(err?.message ?? err)}`);
       }
     }
     if (!data || typeof data !== "object") {
@@ -5721,8 +5750,8 @@ const GRAPH_TOOL_EXECUTORS = {
         for (const e of entry?.errors ?? []) {
           addReason(id, {
             kind: "validation",
-            message: e?.message ?? String(e),
-            ...(e?.details ? { details: e.details } : {}),
+            message: coerceMessageText(e?.message ?? e),
+            ...(e?.details ? { details: coerceMessageText(e.details) } : {}),
             ...(e?.extra_info?.input_name ? { input: e.extra_info.input_name } : {}),
           });
         }
@@ -5746,7 +5775,7 @@ const GRAPH_TOOL_EXECUTORS = {
         e = store?.["lastExecuti" + "on" + "Error"] ?? null;
       }
       if (e) {
-        const msg = String(e.exception_message ?? e.message ?? "").trim();
+        const msg = coerceMessageText(e.exception_message ?? e.message ?? "").trim();
         execFailure = {
           node_id: e.node_id ?? null,
           node_type: e.node_type ?? null,
@@ -6405,7 +6434,7 @@ const GRAPH_TOOL_EXECUTORS = {
       bp = store.getBlueprint(type);
     } catch (err) {
       throw new Error(
-        `No saved subgraph blueprint "${name}" (${err?.message ?? err}). List them with graph_list_subgraphs.`,
+        `No saved subgraph blueprint "${name}" (${coerceMessageText(err?.message ?? err)}). List them with graph_list_subgraphs.`,
       );
     }
     const position = placementFor(graph, pos);
@@ -7701,7 +7730,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           reply = {
             rid: msg.rid,
             ok: false,
-            error: err && err.message ? err.message : String(err),
+            // Never String(err) — a thrown plain object (or one with an OBJECT
+            // .message) would become the dead literal "[object Object]" on the
+            // wire (#276). coerceMessageText extracts .message/.error or JSONs.
+            error: coerceMessageText(err?.message ?? err),
           };
         }
         try {
@@ -8004,8 +8036,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       if (AGENT_BLIND) images = undefined;
       // Merge any armed one-shot context (transcript replay) ahead of this
       // message's own context, then clear it so it's sent exactly once.
+      // The composer passes context as a `{ workflow, subgraph }` OBJECT; the
+      // wire contract requires a STRING (the orchestrator only prepends string
+      // context). serializeContext() renders the object to readable lines so a
+      // raw join() can never coerce it to "[object Object]" above the user's
+      // text (#276). pendingContext is already a string (transcript replay).
       const mergedContext =
-        [pendingContext, context].filter(Boolean).join("\n\n") || undefined;
+        [pendingContext, serializeContext(context)].filter(Boolean).join("\n\n") || undefined;
       pendingContext = null;
       try {
         sock.send(
@@ -8013,7 +8050,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             type: "user_message",
             text,
             ...(mergedContext ? { context: mergedContext } : {}),
-            ...(images?.length ? { images } : {}),
+            ...(images?.length ? { images: normalizeImageList(images) } : {}),
             // Client message id — the orchestrator echoes it in the "working"
             // ack so the panel can mark this exact bubble delivered ("Seen").
             ...(mid ? { mid } : {}),
@@ -8034,6 +8071,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         if (AGENT_BLIND && "images" in frame) {            // keep the note, drop pixels
           const { images: _drop, ...rest } = frame;
           frame = rest;
+        } else if (Array.isArray(frame.images)) {
+          // Normalize descriptor fields so no object filename/subfolder/type/format
+          // reaches the wire as "[object Object]" (#276).
+          frame = { ...frame, images: normalizeImageList(frame.images) };
         }
       }
       try {
@@ -11923,7 +11964,7 @@ function buildPanel() {
   // Surrounding text renders verbatim too. Tokens with no matching attachment
   // content fall back to their literal text. Never throws into the render.
   function renderUserText(container, text, atts) {
-    const raw = text != null ? String(text) : "";
+    const raw = coerceMessageText(text);
     try {
       const byId = new Map();
       if (Array.isArray(atts)) {
@@ -11938,7 +11979,7 @@ function buildPanel() {
         if (att && att.content != null) {
           // Interpolate the pasted content INLINE as plain text — render the message
           // exactly as if the user had typed it (no chip / preview widget).
-          container.appendChild(document.createTextNode(att.content));
+          container.appendChild(document.createTextNode(coerceMessageText(att.content)));
         } else {
           container.appendChild(document.createTextNode(m[0])); // graceful fallback
         }
@@ -12017,6 +12058,10 @@ function buildPanel() {
   }
 
   function paintCard({ icon, text, detail, error }) {
+    // Coerce both slots: a structured error/detail (e.g. reply.error object) must
+    // never reach textContent as "[object Object]" — live OR on card replay (#276).
+    text = coerceMessageText(text);
+    detail = detail == null ? detail : coerceMessageText(detail);
     clearEmpty();
     const card = document.createElement("div");
     card.className = "cmcp-card" + (error ? " error" : "");
@@ -12041,6 +12086,9 @@ function buildPanel() {
   }
 
   function paintImage(url, name) {
+    // Coerce the caption at the painter boundary — a structured/persisted caption
+    // must never render (or re-persist) as "[object Object]", live OR on replay (#276).
+    name = name == null ? name : coerceMessageText(name);
     clearEmpty();
     const card = document.createElement("div");
     card.className = "cmcp-bubble agent cmcp-imgcard";
@@ -12117,6 +12165,8 @@ function buildPanel() {
   }
 
   function paintVideo(url, name) {
+    // Coerce the caption at the painter boundary — see paintImage (#276).
+    name = name == null ? name : coerceMessageText(name);
     clearEmpty();
     const card = document.createElement("div");
     card.className = "cmcp-bubble agent cmcp-imgcard";
@@ -12239,12 +12289,12 @@ function buildPanel() {
       const chip = document.createElement("div");
       chip.className = "cmcp-card-head";
       chip.style.cssText = "text-transform:uppercase;font-size:0.6rem;letter-spacing:0.05em;opacity:0.7;";
-      chip.textContent = msg.header;
+      chip.textContent = coerceMessageText(msg.header);
       card.appendChild(chip);
     }
     const q = document.createElement("div");
     q.style.cssText = "font-weight:600;margin:0.15rem 0 0.5rem;";
-    renderRichText(q, msg.question || "Pick one:");
+    renderRichText(q, coerceMessageText(msg.question) || "Pick one:");
     card.appendChild(q);
 
     const selected = new Set();
@@ -12260,18 +12310,22 @@ function buildPanel() {
       card.replaceChildren();
       card.classList.remove("cmcp-question");
       card.style.cssText = "border-left:3px solid var(--p-primary-color,#3a7bd5);opacity:0.9;";
-      if (msg.question) {
+      // Coerce question/answer — a structured question must not render (or record)
+      // as "[object Object]"; answer is already a coerced label / free text (#276).
+      const questionText = coerceMessageText(msg.question);
+      const answerText = coerceMessageText(answer);
+      if (questionText) {
         const q = document.createElement("div");
         q.style.cssText = "font-size:0.72rem;opacity:0.65;";
-        q.textContent = msg.question;
+        q.textContent = questionText;
         card.appendChild(q);
       }
       const a = document.createElement("div");
       a.style.cssText = "font-weight:600;margin-top:0.15rem;color:var(--p-primary-color,#6ea8fe);";
-      a.textContent = `✓ ${answer}`;
+      a.textContent = `✓ ${answerText}`;
       card.appendChild(a);
       // Record as a plain card so a reload restores it as static text, not a widget.
-      record({ role: "card", icon: "pi-check", text: msg.question || "Choice", detail: answer });
+      record({ role: "card", icon: "pi-check", text: questionText || "Choice", detail: answerText });
       scrollLog();
       resolveFn(answer);
     };
@@ -12287,22 +12341,22 @@ function buildPanel() {
         "background:var(--p-surface-800,#2a2a2a);color:inherit;cursor:pointer;font-size:0.8rem;";
       const lbl = document.createElement("div");
       lbl.style.fontWeight = "600";
-      lbl.textContent = opt.label ?? String(opt);
+      lbl.textContent = coerceMessageText(opt.label ?? opt);
       b.appendChild(lbl);
       if (opt.description) {
         const d = document.createElement("div");
         d.style.cssText = "font-size:0.7rem;opacity:0.7;margin-top:0.1rem;";
-        d.textContent = opt.description;
+        d.textContent = coerceMessageText(opt.description);
         b.appendChild(d);
       }
       b.addEventListener("click", () => {
         if (done) return;
         if (multi) {
-          const label = opt.label ?? String(opt);
+          const label = coerceMessageText(opt.label ?? opt);
           if (selected.has(label)) { selected.delete(label); b.style.borderColor = "var(--p-surface-500,#555)"; }
           else { selected.add(label); b.style.borderColor = "var(--p-primary-color,#3a7bd5)"; }
         } else {
-          finish(opt.label ?? String(opt));
+          finish(coerceMessageText(opt.label ?? opt));
         }
       });
       btnRow.appendChild(b);
@@ -12847,10 +12901,11 @@ function buildPanel() {
   }
 
   function appendSystem(text) {
-    // System notices are transient — painted, never recorded.
+    // System notices are transient — painted, never recorded. Coerce so a
+    // structured value can never render as "[object Object]" (#276).
     const b = document.createElement("div");
     b.className = "cmcp-sys";
-    b.textContent = text;
+    b.textContent = coerceMessageText(text);
     log.appendChild(b);
     scrollLog();
   }
@@ -13369,7 +13424,7 @@ function buildPanel() {
               : ""),
           );
         } catch (error) {
-          appendSystem(`History import failed: ${error?.message || error}`);
+          appendSystem(`History import failed: ${coerceMessageText(error?.message || error)}`);
         }
       }, { once: true });
       picker.click();
@@ -13868,7 +13923,7 @@ function buildPanel() {
     // The agent called panel_show_media — render images/videos directly in the chat.
     onShowMedia(items) {
       for (const item of items) {
-        const caption = item.caption || item.filename || "";
+        const caption = coerceMessageText(item.caption) || coerceMessageText(item.filename) || "";
         if (item.kind === "viewRef" && item.viewRef) {
           const url = imageViewUrl(item.viewRef);
           // Determine if ComfyUI ref is a video by extension
@@ -14019,7 +14074,7 @@ function buildPanel() {
             : `🔒 ${friendly} key saved — the provider is enabled now (stored by the orchestrator in ~/.comfyui-mcp, never in ComfyUI settings).`,
         );
       } else {
-        appendSystem(`Couldn't save the ${friendly} key: ${msg.error || "unknown error"}.`);
+        appendSystem(`Couldn't save the ${friendly} key: ${coerceMessageText(msg.error) || "unknown error"}.`);
       }
     },
     // The agent called panel_reload — perform the soft reload it asked for.
@@ -14363,16 +14418,19 @@ function buildPanel() {
     // with `type:"output"` is the real SAVED file; `type:"temp"` (save_output off)
     // is a throwaway preview. Be conservative — only explicit "output" is final.
     const isFinalVideo = m && m.type === "output";
+    // Coerce descriptor fields once — a structured filename/subfolder/format must
+    // never reach the outbound agent note as "[object Object]" (#276).
+    const fileName = coerceMessageText(m?.filename) || "video";
     const videoKind = isFinalVideo
-      ? `the FINAL saved video (file ${m.filename} — reference THIS filename)`
-      : `a PREVIEW video (file ${m.filename}, temporary — not a saved file; add/enable a save to persist it)`;
+      ? `the FINAL saved video (file ${fileName} — reference THIS filename)`
+      : `a PREVIEW video (file ${fileName}, temporary — not a saved file; add/enable a save to persist it)`;
     // ── Video metadata (gathered up front) ─────────────────────────────────
     // path (subfolder-relative), real frame metadata when the VHS/video output
     // payload carries it, render duration, and completion time. Capture the
     // render-start SYNCHRONOUSLY here (before any await / before the run's flush
     // retires it) so the duration survives a concurrent execution_success.
-    const subfolder = m?.subfolder || "";
-    const path = subfolder ? `${subfolder}/${m?.filename || ""}` : (m?.filename || "");
+    const subfolder = coerceMessageText(m?.subfolder);
+    const path = subfolder ? `${subfolder}/${fileName}` : fileName;
     const startTs = runStartTimes.get(promptKey(promptId));
     const duration = startTs != null ? formatDuration(Date.now() - startTs) : null;
     const finishedClock = formatClock(new Date());
@@ -14381,12 +14439,12 @@ function buildPanel() {
     // the payload doesn't carry it (it's not always populated).
     const realFrames = m?.frame_count ?? m?.frameCount ?? m?.frames ?? null;
     const realFps = m?.frame_rate ?? m?.frameRate ?? m?.fps ?? null;
-    const format = m?.format || null;
+    const format = coerceMessageText(m?.format) || null;
     // Compose the compact "· a · b · c" metadata suffix appended to a note.
     // sizeStr (async HEAD) and storyboardN are optional/contextual.
     const metaSuffix = (sizeStr, storyboardN) => {
       const parts = [`path: ${path}`];
-      if (format) parts.push(String(format));
+      if (format) parts.push(format);
       if (Number.isFinite(realFrames)) {
         parts.push(
           `${realFrames} frames` +
@@ -14398,7 +14456,7 @@ function buildPanel() {
       if (sizeStr) parts.push(sizeStr);
       if (duration) parts.push(`rendered in ${duration}`);
       if (finishedClock) parts.push(`finished ${finishedClock}`);
-      return parts.length ? `\n• ${m?.filename || "video"} — ${parts.join(" · ")}` : "";
+      return parts.length ? `\n• ${fileName} — ${parts.join(" · ")}` : "";
     };
     // ALWAYS notify the agent a video rendered — with a storyboard if we can build
     // one, else a note-only event (no images) so the agent still learns the render
@@ -14425,7 +14483,7 @@ function buildPanel() {
         noteOnly("couldn't sample a storyboard from it");
         return;
       }
-      const base = String(m.filename || "video").replace(/\.[^.]+$/, "");
+      const base = (coerceMessageText(m.filename) || "video").replace(/\.[^.]+$/, "");
       const ref = await uploadBlobToInput(blob, `storyboard_${base}.png`);
       if (!ref) {
         console.warn("[cmcp] storyboard: upload failed for", m.filename);
@@ -14537,7 +14595,7 @@ function buildPanel() {
     // Send EVERYTHING for vision (the agent should see previews too), but ordered
     // finals-first so the primary result is unambiguous as image #1.
     const images = [...finals, ...previews];
-    const finalNames = finals.map((m) => m?.filename).filter(Boolean);
+    const finalNames = finals.map((m) => coerceMessageText(m?.filename)).filter(Boolean);
     const previewCount = previews.length;
     let note;
     if (finalNames.length) {
@@ -14576,8 +14634,10 @@ function buildPanel() {
     try {
       metadata = await Promise.all(
         finals.map(async (m, idx) => {
-          const filename = m?.filename || "(unknown)";
-          const subfolder = m?.subfolder || "";
+          // Coerce descriptor fields — a structured filename/subfolder must not
+          // reach the outbound agent note as "[object Object]" (#276).
+          const filename = coerceMessageText(m?.filename) || "(unknown)";
+          const subfolder = coerceMessageText(m?.subfolder);
           const path = subfolder ? `${subfolder}/${filename}` : filename;
           const url = imageViewUrl(m);
           const [sizeRes, dimRes] = await Promise.allSettled([
@@ -14709,12 +14769,18 @@ function buildPanel() {
     clearRunImages(d.prompt_id);
     // Name the failing node so the agent (and the user) know WHERE it broke —
     // "Ideogram4PromptBuilderKJ (node 200)" beats a bare exception string.
-    const where = d.node_type
-      ? `${d.node_type} (node ${d.node_id})`
-      : d.node_id != null
-        ? `node ${d.node_id}`
+    // Coerce node descriptors too — never bake "[object Object]" into the
+    // outbound "where" string a structured node_type/node_id would produce (#276).
+    const nodeType = coerceMessageText(d.node_type);
+    const nodeId = d.node_id != null ? coerceMessageText(d.node_id) : "";
+    const where = nodeType
+      ? `${nodeType} (node ${nodeId})`
+      : nodeId
+        ? `node ${nodeId}`
         : "";
-    const msg = d.exception_message || d.exception_type || "execution error";
+    // Coerce before interpolation — a structured exception payload must not
+    // become "[object Object]" on the outbound agent_event or the card (#276).
+    const msg = coerceMessageText(d.exception_message) || coerceMessageText(d.exception_type) || "execution error";
     const error = where ? `${where}: ${msg}` : msg;
     // 1) Push it to the agent — the orchestrator INTERRUPTS its live turn and
     //    front-queues this so it stops and fixes the error instead of running blind.
@@ -15016,7 +15082,7 @@ function buildPanel() {
         }
       } catch (err) {
         if (myGen !== connectGen) return;
-        appendSystem(`Auto-restart failed: ${err?.message ?? err}`);
+        appendSystem(`Auto-restart failed: ${coerceMessageText(err?.message ?? err)}`);
         autoRespawnsLeft = 0; // can't reach the pack → don't loop
         client.start(); // resume the bare WS retry so the client isn't left idle
       } finally {
@@ -15083,7 +15149,7 @@ function buildPanel() {
         }
       } catch (err) {
         if (myGen !== connectGen) return;
-        appendSystem(`Auto-restart failed: ${err?.message ?? err}`);
+        appendSystem(`Auto-restart failed: ${coerceMessageText(err?.message ?? err)}`);
         autoReclaimsLeft = 0; // can't reach the pack → don't loop
       } finally {
         autoReclaiming = false;
@@ -15229,7 +15295,7 @@ function buildPanel() {
       if (myGen !== connectGen) return; // superseded → swallow the stale error too
       // No /connect route (older/headless host) — fall through and try the
       // bridge directly in case the user started the orchestrator themselves.
-      appendSystem(`Couldn't reach ComfyUI to start the agent: ${err?.message ?? err}`);
+      appendSystem(`Couldn't reach ComfyUI to start the agent: ${coerceMessageText(err?.message ?? err)}`);
     } finally {
       connecting = false;
     }
@@ -15412,7 +15478,7 @@ function buildPanel() {
     } catch (err) {
       ssSet(SOFT_RELOAD_KEY, null);
       clearSoftReloadGuard(); // POST failed → re-enable auto-respawn
-      appendSystem(`Couldn't reach ComfyUI to reload the agent: ${err?.message ?? err}`);
+      appendSystem(`Couldn't reach ComfyUI to reload the agent: ${coerceMessageText(err?.message ?? err)}`);
       return;
     } finally {
       reloading = false;
@@ -15450,7 +15516,7 @@ function buildPanel() {
         );
       }
     } catch (err) {
-      appendSystem(`Couldn't reach ComfyUI to restart the agent: ${err?.message ?? err}`);
+      appendSystem(`Couldn't reach ComfyUI to restart the agent: ${coerceMessageText(err?.message ?? err)}`);
     } finally {
       reloading = false;
     }
@@ -15501,7 +15567,7 @@ function buildPanel() {
       const result = await GRAPH_TOOL_EXECUTORS[cmd](args);
       appendActivity(cmd, args, { ok: true, result });
     } catch (err) {
-      appendActivity(cmd, args, { ok: false, error: err?.message ?? String(err) });
+      appendActivity(cmd, args, { ok: false, error: coerceMessageText(err?.message ?? err) });
     }
   }
 

--- a/web/js/lib/chat-serialize.js
+++ b/web/js/lib/chat-serialize.js
@@ -49,6 +49,40 @@ export function coerceMessageText(value) {
   }
 }
 
+/** Serialize an outbound user_message `context` into the STRING the wire
+ *  contract requires (#276). The orchestrator only reads `context` when it is a
+ *  string (it prepends it above the user's text as grounding/transcript replay);
+ *  a non-string is either silently dropped (older orchestrators) or, once the
+ *  panel began joining context parts into one string, coerced by
+ *  `Array.prototype.join` into the literal "[object Object]" and prepended above
+ *  EVERY message — the exact #276 symptom (a lone "[object Object]" line over the
+ *  user's typed text).
+ *
+ *  The panel composes context as `{ workflow, subgraph }` to ground the agent in
+ *  what the user is viewing. Render that known shape as readable lines; fall back
+ *  to coerceMessageText for anything else so an object can never become
+ *  "[object Object]". A string passes through untouched (transcript replay).
+ */
+export function serializeContext(context) {
+  if (context == null) return "";
+  if (typeof context === "string") return context;
+  if (typeof context === "object" && !Array.isArray(context)) {
+    const lines = [];
+    if (typeof context.workflow === "string" && context.workflow) {
+      lines.push(`Workflow: ${context.workflow}`);
+    }
+    if (typeof context.subgraph === "string" && context.subgraph) {
+      lines.push(`Viewing subgraph: ${context.subgraph}`);
+    }
+    if (lines.length) return lines.join("\n");
+    // An empty object carries no context — drop it out of the join rather than
+    // emitting "{}" above the user's text.
+    if (Object.keys(context).length === 0) return "";
+  }
+  // Unknown shape: JSON/known-field serialize, never "[object Object]".
+  return coerceMessageText(context);
+}
+
 /** Decide whether a persisted assistant record should be dropped on history
  *  replay (#241). Drop ONLY a structured payload that coerced to nothing (an
  *  object with no extractable text / an unserializable value) — that's the


### PR DESCRIPTION
## Summary

The panel string-coerced JS objects to the literal `[object Object]` on several paths that either go **outbound to the agent** or are **injected into the chat transcript**, silently losing the content.

### Coercion-site inventory

**#276 root cause (primary bug):** the composer passes `user_message.context` as a `{ workflow, subgraph }` **object**, but the wire contract only reads a **string** context — the orchestrator prepends string context above the user's text (`index.ts` `typeof event.context === "string"`). A regression (0b880fd, the transcript-replay feature) began joining context parts with `Array.join`, coercing the object to `[object Object]` and prepending it above **every** message. Before that commit the object context was silently dropped by the orchestrator's `typeof` guard, so the join is what turned a dead-but-silent object into a live `[object Object]` line over the typed text — matching the report exactly.

Additional plausibly-object fields on outbound / chat-injection paths that could also emit `[object Object]`:
- bridge command-error result + local slash-command error result (`String(err)` → object)
- `validationBanner()` — `class_type` / `message` / `details` / missing-asset `file`/`node_id`/`widget`/`download_url` / `exception_message`/`type` / node descriptors — this banner is **prepended to outbound user messages**
- `run_error` `agent_event` + its card, secret-save error, restart/connect/reload catches, history-import error
- `paintCard` / `appendSystem` / `paintImage` / `paintVideo` caption boundaries (+ history replay)
- `ask_user` question / option labels / descriptions / answers + the recorded card
- pasted-text attachment replay (`createTextNode`), `imageViewUrl` descriptor fields
- executed-event media notes + filenames + subfolders + formats
- CivitAI params / prompt / share caption / backend error / `_capPrompt` / share ref filename
- **outbound image descriptors** (`user_message.images`, `agent_event.images`) — object-valued `filename`/`subfolder`/`type`/`format`

### The fix

New `serializeContext()` in `web/js/lib/chat-serialize.js` renders the context object to readable `Workflow: … / Viewing subgraph: …` lines (JSON fallback, `""` for empty), and `sendUserMessage()` routes context through it before the join. Every other site above is routed through the existing `coerceMessageText()` chokepoint; outbound image descriptors are normalized at the two wire chokepoints (`sendUserMessage` + `sendFrame` agent_event) via a new `normalizeImageList()` helper.

### #272 — already fixed on main

The structured-event injection path (`say`, `paintAgent`, card-reply, history-replay) already routes through `coerceMessageText()` on current main. Confirmed by codex; no change needed there. This PR additionally hardens the ordinary-card replay path (`paintCard`) which main replayed uncoerced.

## Tests

Added `serializeContext` coverage to `browser_tests/unit/chat-serialize.test.mjs` — object → readable lines (never `[object Object]`), string passthrough, empty/null drop-out, unknown → JSON, plus a **PRE-FIX repro** asserting the raw `[pending, context].join()` produced the bug. Full unit suite green: **427 passing**.

## codex gate

`codex exec -s read-only` review: **VERDICT: PASS** — no remaining in-scope panel send/inject site can emit `[object Object]`; remaining raw conversions are contract-fixed integers/enums or debug output (out of scope).

Does **not** bump version / PANEL_VERSION.

🤖 Generated with [Claude Code](https://claude.com/claude-code)