### PR TITLE
release: 0.11.15 — chat context serialization (#276, #272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.15] - 2026-07-30
+
+### Fixed
+- **Chat context no longer reaches the agent as the literal `[object Object]` (#276).** The real culprit was not attachments (those already travel over structured image/text channels) but the `{workflow, subgraph}` **context object**, which `sendUserMessage` `Array.join`-coerced to `[object Object]` and the orchestrator prepended above every user message (a regression from the transcript-replay change). A new `serializeContext()` renders it to readable text (`Workflow: <name>` / `Viewing subgraph: <name>`, JSON fallback for unknown shapes, string passthrough for transcript replay). Outbound image descriptors are normalized at the wire choke-points and every other plausibly-object outbound/inject field is routed through `coerceMessageText`. Live-verified on the rig: the agent now receives `"Workflow: <name>"` instead of `[object Object]`. (#313)
+- **Hardened the ordinary-card replay path** so structured panel messages can never render as `[object Object]` (#272 was already handled on main for the say/agent/card-reply paths; this closes the remaining replay sink).
+
 ## [0.11.14] - 2026-07-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.14"
+version = "0.11.15"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -224,7 +224,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.14";
+const PANEL_VERSION = "0.11.15";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Cuts panel **0.11.15**. Bumps `pyproject.toml` + `PANEL_VERSION` together (Registry publish fires on the pyproject change to main).

## Ships
- **#276 (#313):** chat `{workflow, subgraph}` context no longer reaches the agent as `[object Object]` — new `serializeContext()` renders readable grounding text; ~20 outbound/inject sinks routed through `coerceMessageText`; image descriptors normalized at wire choke-points. **Live-verified on the rig** (agent received `"Workflow: zzsave-orig"`, not `[object Object]`).
- **#272:** ordinary-card replay path hardened (rest already handled on main).

codex PASS (multi-round sweep of every outbound interpolation); 427 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)