### PR TITLE
fix(groups): live-geometry group membership + tight create bbox (#311, #312, #287, #297, #305)

### DIFF
--- a/browser_tests/unit/group-geometry.test.mjs
+++ b/browser_tests/unit/group-geometry.test.mjs
@@ -1,0 +1,150 @@
+// Unit tests for LIVE geometric group membership (web/js/lib/group-geometry.js).
+//
+// Regression coverage for the group-membership bug cluster:
+//   #312 pasted-then-grouped nodes report zero members (stale/empty _nodes)
+//   #311 stale node_ids after creating/moving explicit group bounds
+//   #287 node_ids stay stale after moving nodes inside a resized group
+//   #305 create_group(node_ids) produces incorrect live membership
+//   #297 create_group(node_ids) silently encloses unrelated nodes in dense layouts
+//
+// The core invariant: membership is recomputed from LIVE node + group geometry
+// on every read, NEVER trusting the cached LGraphGroup._nodes array.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  nodeFocusBounds,
+  boundsAroundNodes,
+  groupBoundsOf,
+  groupMemberNodes,
+  classifyRequestedMembership,
+} from "../../web/js/lib/group-geometry.js";
+
+// Minimal fixtures. No boundingRect => nodeFocusBounds falls back to pos/size
+// (with the title band), exactly like a fresh node on the live graph.
+const node = (id, x, y, w = 300, h = 120) => ({ id, pos: [x, y], size: [w, h] });
+const graphOf = (...nodes) => ({ _nodes: nodes });
+// A group whose _nodes cache is deliberately WRONG/stale — the helper must ignore it.
+const groupBox = (bounding, staleNodes = null) => ({
+  _bounding: bounding,
+  _nodes: staleNodes ?? [],
+  recomputeInsideNodes() {
+    /* simulate a frontend build that leaves _nodes empty/stale */
+  },
+});
+
+test("create-around-specific-nodes yields exactly those members (#305)", () => {
+  const a = node(1, 100, 100);
+  const b = node(2, 100, 300);
+  const graph = graphOf(a, b);
+  const bbox = boundsAroundNodes([a, b]);
+  const g = groupBox(bbox);
+  const ids = groupMemberNodes(graph, g).map((n) => n.id);
+  assert.deepEqual(ids.sort(), [1, 2]);
+});
+
+test("pasted-then-grouped nodes are counted despite empty _nodes cache (#312)", () => {
+  // Bounds + node positions taken straight from issue #312.
+  const nodes = [
+    node(10, 550, 60, 350, 140),
+    node(11, 550, 250, 350, 140),
+    node(12, 930, 60, 341, 118),
+    node(13, 930, 250, 341, 118),
+  ];
+  const graph = graphOf(...nodes);
+  const g = groupBox([520, -10, 781, 430], /* stale */ []);
+  const members = groupMemberNodes(graph, g);
+  assert.equal(members.length, 4, "all four pasted nodes must be members");
+  assert.deepEqual(members.map((n) => n.id).sort(), [10, 11, 12, 13]);
+});
+
+test("moving a node OUT of the group updates membership (#287/#311)", () => {
+  const a = node(1, 200, 200);
+  const b = node(2, 250, 400);
+  const graph = graphOf(a, b);
+  const g = groupBox([140, -80, 680, 1200], /* stale, still lists both */ [a, b]);
+  assert.equal(groupMemberNodes(graph, g).length, 2);
+
+  // Move b far outside the box — live recompute must drop it.
+  b.pos = [5000, 5000];
+  const ids = groupMemberNodes(graph, g).map((n) => n.id);
+  assert.deepEqual(ids, [1], "node moved out is no longer a member");
+});
+
+test("moving a node INTO a resized group updates membership (#287)", () => {
+  // Group starts small with 2 members; a 3rd node lives outside.
+  const a = node(33, 200, 0);
+  const b = node(49, 200, 200);
+  const c = node(62, 200, 1000, 400, 200);
+  const graph = graphOf(a, b, c);
+  const small = groupBox([140, -80, 680, 400], [a, b]);
+  assert.deepEqual(
+    groupMemberNodes(graph, small).map((n) => n.id).sort(),
+    [33, 49],
+    "c is outside the small box",
+  );
+
+  // Resize the group to enclose c (issue #287 expanded [140,-80,800,1600]).
+  const resized = groupBox([140, -80, 800, 1600], /* stale cache still 2 */ [a, b]);
+  const ids = groupMemberNodes(graph, resized).map((n) => n.id).sort();
+  assert.deepEqual(ids, [33, 49, 62], "resized group now includes the moved-in node");
+});
+
+test("dense-layout create surfaces unrelated captured nodes (#297)", () => {
+  // Six intended nodes, but an unrelated node sits between them.
+  const intended = [
+    node(379, 0, 0),
+    node(380, 0, 400),
+    node(384, 0, 800),
+  ];
+  const unrelated = node(999, 20, 200); // physically inside the wrapping rect
+  const graph = graphOf(intended[0], unrelated, intended[1], intended[2]);
+  const bbox = boundsAroundNodes(intended);
+  const g = groupBox(bbox);
+  const memberIds = groupMemberNodes(graph, g).map((n) => n.id);
+  assert.ok(memberIds.includes(999), "geometric membership DOES capture the neighbor");
+
+  const cls = classifyRequestedMembership([379, 380, 384], memberIds);
+  assert.deepEqual(cls.extra, [999], "the neighbor is reported as extra, not hidden");
+  assert.deepEqual(cls.missing, [], "no requested node is missing");
+});
+
+test("classifyRequestedMembership reports missing requested nodes", () => {
+  const cls = classifyRequestedMembership([1, 2, 3], [1, 3]);
+  assert.deepEqual(cls.missing, [2]);
+  assert.deepEqual(cls.extra, []);
+});
+
+test("groupBoundsOf handles _bounding and pos/size, rejects garbage", () => {
+  assert.deepEqual(groupBoundsOf({ _bounding: [1, 2, 3, 4] }), [1, 2, 3, 4]);
+  assert.deepEqual(groupBoundsOf({ pos: [5, 6], size: [7, 8] }), [5, 6, 7, 8]);
+  assert.equal(groupBoundsOf({ _bounding: [NaN, 0, 0, 0] }), null);
+  assert.equal(groupBoundsOf({}), null);
+});
+
+test("groupMemberNodes returns [] for a group with no finite bounds", () => {
+  assert.deepEqual(groupMemberNodes(graphOf(node(1, 0, 0)), {}), []);
+});
+
+test("nodeFocusBounds prefers boundingRect when present", () => {
+  assert.deepEqual(nodeFocusBounds({ boundingRect: [10, 20, 30, 40] }), [10, 20, 30, 40]);
+  // Fallback includes the title band above pos.
+  assert.deepEqual(nodeFocusBounds({ pos: [0, 100], size: [200, 100] }), [0, 70, 200, 130]);
+});
+
+test("nodeFocusBounds accepts a typed-array boundingRect (current ComfyUI Rectangle)", () => {
+  const br = Float32Array.from([1, 2, 3, 4]);
+  assert.deepEqual(nodeFocusBounds({ boundingRect: br }), [1, 2, 3, 4]);
+});
+
+test("membership overlap is edge-inclusive (matches LiteGraph overlapBounding)", () => {
+  // Node's right edge exactly touches the group's left edge.
+  const n = { id: 1, boundingRect: [0, 0, 100, 100] }; // spans x:0..100
+  const graph = graphOf(n);
+  const g = groupBox([100, 0, 200, 200]); // starts exactly at x=100
+  assert.deepEqual(
+    groupMemberNodes(graph, g).map((x) => x.id),
+    [1],
+    "edge contact counts as membership",
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -111,6 +111,12 @@ import {
   formatDroppedWarning,
 } from "./lib/paste-report.js";
 import { createMediaRecorder } from "./lib/chat-media.js";
+import {
+  nodeFocusBounds,
+  boundsAroundNodes,
+  groupMemberNodes,
+  classifyRequestedMembership,
+} from "./lib/group-geometry.js";
 import { saveActiveWorkflow } from "./lib/workflow-save.js";
 
 let app = null;
@@ -3793,35 +3799,10 @@ function setGroupBounds(group, [x, y, w, h]) {
   }
 }
 
-/** [x, y, w, h] that wraps the given nodes, padded for the group + node titles. */
-function boundsAroundNodes(nodes, pad = 30, titlePad = 70) {
-  let minX = Infinity;
-  let minY = Infinity;
-  let maxX = -Infinity;
-  let maxY = -Infinity;
-  for (const n of nodes) {
-    const x = n.pos?.[0] ?? 0;
-    const y = n.pos?.[1] ?? 0;
-    const w = n.size?.[0] ?? 200;
-    const h = n.size?.[1] ?? 100;
-    minX = Math.min(minX, x);
-    minY = Math.min(minY, y);
-    maxX = Math.max(maxX, x + w);
-    maxY = Math.max(maxY, y + h);
-  }
-  if (!Number.isFinite(minX)) return [100, 100, 400, 300];
-  return [minX - pad, minY - titlePad, maxX - minX + pad * 2, maxY - minY + titlePad + pad];
-}
-
 /** Compact JSON-friendly view of a group box. */
 function summarizeGroup(graph, g) {
   const b = g._bounding ?? [g.pos?.[0] ?? 0, g.pos?.[1] ?? 0, g.size?.[0] ?? 0, g.size?.[1] ?? 0];
-  // LiteGraph groups do NOT own their nodes — membership is purely geometric
-  // (which nodes sit inside the group box). Recompute it so the agent gets the
-  // actual member node_ids (to wrap a group into a subgraph, toggle it as a unit,
-  // etc.) instead of reconstructing membership from coordinates by hand.
-  g.recomputeInsideNodes?.();
-  const memberIds = (g._nodes ?? []).map((n) => n.id);
+  const memberIds = groupMemberNodes(graph, g).map((n) => n.id);
   return {
     id: g.id != null ? g.id : (graph._groups ?? []).indexOf(g),
     title: g.title ?? "",
@@ -4364,8 +4345,7 @@ const GRAPH_TOOL_EXECUTORS = {
     const groupOf = new Map();
     const groupLines = [];
     for (const g of groups) {
-      g.recomputeInsideNodes?.();
-      const ids = (g._nodes ?? []).map((n) => n.id);
+      const ids = groupMemberNodes(graph, g).map((n) => n.id);
       const tag = { 2: " [mute]", 4: " [bypass]" }[g.mode] ?? "";
       groupLines.push(`  "${g.title ?? ""}"${tag} → ${ids.join(",") || "(empty)"}`);
       for (const id of ids) {
@@ -5418,8 +5398,7 @@ const GRAPH_TOOL_EXECUTORS = {
 
     // Group boxes (geometric membership recomputed, same as summarizeGroup).
     const groupBoxes = (graph._groups ?? []).map((g) => {
-      g.recomputeInsideNodes?.();
-      const memberIds = (g._nodes ?? []).map((n) => n.id).filter((id) => targetIds.has(id));
+      const memberIds = groupMemberNodes(graph, g).map((n) => n.id).filter((id) => targetIds.has(id));
       const collapsed = !!(g.flags?.collapsed || g.collapsed);
       return { g, memberIds, collapsed };
     });
@@ -5467,14 +5446,22 @@ const GRAPH_TOOL_EXECUTORS = {
 
     // Predicted group boxes (new member positions, current pos for un-moved
     // members). preserve + cluster re-fit; ignore leaves boxes untouched.
-    const predictGroupBounds = (g) => {
-      const members = (g._nodes ?? []).map((n) => {
-        const p = layout.positions.get(n.id);
-        return {
-          pos: p ? [p[0], p[1]] : [n.pos?.[0] ?? 0, n.pos?.[1] ?? 0],
-          size: [n.size?.[0] ?? 200, n.size?.[1] ?? 100],
-        };
-      });
+    // Predict from the PRE-MOVE member snapshot (gb.memberIds, captured before
+    // any node moved), not a live recompute — the apply path moves nodes first,
+    // and a member's NEW position may fall outside the OLD box, so recomputing
+    // live here would silently drop it and shrink the group box.
+    const nodeById = new Map((graph._nodes ?? []).map((n) => [n.id, n]));
+    const predictGroupBounds = (memberIds) => {
+      const members = memberIds
+        .map((id) => nodeById.get(id))
+        .filter(Boolean)
+        .map((n) => {
+          const p = layout.positions.get(n.id);
+          return {
+            pos: p ? [p[0], p[1]] : [n.pos?.[0] ?? 0, n.pos?.[1] ?? 0],
+            size: [n.size?.[0] ?? 200, n.size?.[1] ?? 100],
+          };
+        });
       return boundsAroundNodes(members);
     };
     const groupResults =
@@ -5485,7 +5472,7 @@ const GRAPH_TOOL_EXECUTORS = {
             .map((gb) => ({
               group_id: gb.g.id != null ? gb.g.id : (graph._groups ?? []).indexOf(gb.g),
               title: gb.g.title ?? "",
-              bounds: predictGroupBounds(gb.g).map(Math.round),
+              bounds: predictGroupBounds(gb.memberIds).map(Math.round),
             }));
 
     if (dry_run) {
@@ -5510,7 +5497,7 @@ const GRAPH_TOOL_EXECUTORS = {
       if (groups !== "ignore") {
         for (const gb of groupBoxes) {
           if (!gb.memberIds.length) continue;
-          setGroupBounds(gb.g, predictGroupBounds(gb.g));
+          setGroupBounds(gb.g, predictGroupBounds(gb.memberIds));
           gb.g.recomputeInsideNodes?.();
         }
       }
@@ -6040,8 +6027,7 @@ const GRAPH_TOOL_EXECUTORS = {
         `no group matching "${group}" — list groups via panel_get_graph (each has id, title, node_ids)`,
       );
     }
-    g.recomputeInsideNodes?.();
-    const ns = [...(g._nodes ?? [])];
+    const ns = groupMemberNodes(graph, g);
     if (!ns.length) {
       throw new Error(`group "${g.title}" has no nodes inside its box to wrap into a subgraph`);
     }
@@ -6472,9 +6458,14 @@ const GRAPH_TOOL_EXECUTORS = {
     if (typeof GroupCls !== "function") throw new Error("LGraphGroup unavailable on this frontend");
     const group = new GroupCls(typeof title === "string" && title ? title : "Group");
     let bbox;
+    let requestedIds = null;
     if (Array.isArray(node_ids) && node_ids.length) {
+      // Record EVERY requested id (including ids that don't resolve) so the
+      // honesty report below can list nonexistent ones as missing (#297).
+      requestedIds = node_ids.map(Number).filter(Number.isFinite);
       const ns = node_ids.map((id) => graph.getNodeById(Number(id))).filter(Boolean);
       if (!ns.length) throw new Error("none of the given node_ids exist in the current graph");
+      // Tight box around exactly the requested nodes that exist (title height + padding).
       bbox = boundsAroundNodes(ns);
     } else if (Array.isArray(bounds) && bounds.length === 4) {
       bbox = bounds.map(Number);
@@ -6493,7 +6484,27 @@ const GRAPH_TOOL_EXECUTORS = {
       graph.afterChange();
     }
     graph.setDirtyCanvas(true, true);
-    return { group: summarizeGroup(graph, group) };
+    const summary = summarizeGroup(graph, group);
+    // Honesty for dense layouts (#297): group membership is purely GEOMETRIC, so
+    // any unrelated node whose box overlaps the computed rectangle is now a member
+    // — LiteGraph has no per-node ownership to exclude it. When the live members
+    // differ from what was requested, surface both sets and a warning instead of
+    // silently reporting a misleading success.
+    if (requestedIds) {
+      const { extra, missing } = classifyRequestedMembership(requestedIds, summary.node_ids);
+      summary.requested_node_ids = requestedIds;
+      if (extra.length || missing.length) {
+        summary.extra_node_ids = extra;
+        summary.missing_node_ids = missing;
+        summary.warning =
+          "group membership is geometric: the box that wraps the requested nodes " +
+          `also overlaps ${extra.length} unrelated node(s)` +
+          (missing.length ? ` and misses ${missing.length} requested node(s)` : "") +
+          ". Move the intended nodes into a contiguous region (panel_move_node / " +
+          "panel_arrange) before grouping, or edit the group bounds, to get an exact set.";
+      }
+    }
+    return { group: summary };
   },
 
   // Move a group's box to [x,y]; by default the contained nodes move with it
@@ -6506,9 +6517,17 @@ const GRAPH_TOOL_EXECUTORS = {
     const dy = Number(pos[1]) - b[1];
     graph.beforeChange();
     try {
-      if (move_nodes !== false && typeof g.move === "function") {
-        g.recomputeInsideNodes?.();
-        g.move(dx, dy, false); // moves the box AND the nodes inside it
+      if (move_nodes !== false) {
+        // Move the box AND the LIVE geometric members together. We don't rely on
+        // g.move(), which shifts LiteGraph's cached g._nodes — that cache is stale
+        // or empty on affected builds (#287/#311/#312), so it would move the wrong
+        // nodes or none. Recompute membership from live geometry, then translate
+        // each member plus the box by the same delta.
+        const members = groupMemberNodes(graph, g);
+        setGroupBounds(g, [Number(pos[0]), Number(pos[1]), b[2], b[3]]);
+        for (const n of members) {
+          n.pos = [(n.pos?.[0] ?? 0) + dx, (n.pos?.[1] ?? 0) + dy];
+        }
       } else {
         setGroupBounds(g, [Number(pos[0]), Number(pos[1]), b[2], b[3]]);
       }
@@ -7206,17 +7225,6 @@ function focusFollowEnabled() {
 const FOCUS_TARGETS = {
   graph_set_widget: (m) => [m.node_id],
 };
-
-/** [x, y, w, h] for a node — prefer litegraph's boundingRect (includes title). */
-function nodeFocusBounds(node) {
-  const br = node.boundingRect;
-  if (Array.isArray(br) && br.length === 4 && (br[2] || br[3])) {
-    return [br[0], br[1], br[2], br[3]];
-  }
-  const w = node.size?.[0] ?? 200;
-  const h = node.size?.[1] ?? 100;
-  return [node.pos[0], node.pos[1] - 30, w, h + 30]; // title bar renders above pos
-}
 
 function unionBounds(list) {
   let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
@@ -9046,8 +9054,13 @@ function describeCommand(cmd, msg, reply) {
         icon: "pi-th-large",
         text: `Auto-arranged ${r.node_count} node${r.node_count === 1 ? "" : "s"} (${r.columns} column${r.columns === 1 ? "" : "s"})`,
       };
-    case "graph_create_group":
-      return { icon: "pi-clone", text: `Created group “${r.group?.title}” (id ${r.group?.id})` };
+    case "graph_create_group": {
+      const extra = r.group?.extra_node_ids?.length ?? 0;
+      const suffix = extra
+        ? ` — ⚠ ${extra} unrelated node${extra === 1 ? "" : "s"} also enclosed (geometric)`
+        : "";
+      return { icon: "pi-clone", text: `Created group “${r.group?.title}” (id ${r.group?.id})${suffix}` };
+    }
     case "graph_move_group":
       return { icon: "pi-arrows-alt", text: `Moved group ${r.group?.id} (“${r.group?.title}”)` };
     case "graph_edit_group":

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -1,0 +1,94 @@
+// Pure geometry helpers for LiteGraph GROUP membership.
+//
+// LiteGraph groups do NOT own their nodes. Membership is purely GEOMETRIC: a
+// node belongs to a group when its bounding box overlaps the group's bounding
+// box. Several ComfyUI frontend builds leave LGraphGroup._nodes stale or empty
+// after programmatic bounds / pos / paste changes, so the panel must recompute
+// membership from LIVE node + group geometry on every read rather than trust the
+// cached _nodes array (issues #287, #305, #311, #312).
+//
+// These functions are intentionally dependency-free (no LiteGraph, no DOM) so
+// they can be unit-tested with plain object fixtures.
+
+/** [x, y, w, h] for a node — prefer litegraph's boundingRect (includes title). */
+export function nodeFocusBounds(node) {
+  // Accept plain arrays AND typed arrays (current ComfyUI Rectangle is a
+  // Float32Array subclass): any indexable of length 4 with a non-zero extent.
+  const br = node.boundingRect;
+  if (br && br.length === 4 && (br[2] || br[3])) {
+    return [br[0], br[1], br[2], br[3]];
+  }
+  const w = node.size?.[0] ?? 200;
+  const h = node.size?.[1] ?? 100;
+  return [node.pos[0], node.pos[1] - 30, w, h + 30]; // title bar renders above pos
+}
+
+/** [x, y, w, h] that wraps the given nodes, padded for the group + node titles. */
+export function boundsAroundNodes(nodes, pad = 30, titlePad = 70) {
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (const n of nodes) {
+    const x = n.pos?.[0] ?? 0;
+    const y = n.pos?.[1] ?? 0;
+    const w = n.size?.[0] ?? 200;
+    const h = n.size?.[1] ?? 100;
+    minX = Math.min(minX, x);
+    minY = Math.min(minY, y);
+    maxX = Math.max(maxX, x + w);
+    maxY = Math.max(maxY, y + h);
+  }
+  if (!Number.isFinite(minX)) return [100, 100, 400, 300];
+  return [minX - pad, minY - titlePad, maxX - minX + pad * 2, maxY - minY + titlePad + pad];
+}
+
+/** Current [x,y,w,h] of a group box, or null if not finite. */
+export function groupBoundsOf(g) {
+  const b = g?._bounding ?? [g?.pos?.[0], g?.pos?.[1], g?.size?.[0], g?.size?.[1]];
+  const x = Number(b?.[0]), y = Number(b?.[1]), w = Number(b?.[2]), h = Number(b?.[3]);
+  return [x, y, w, h].every(Number.isFinite) ? [x, y, w, h] : null;
+}
+
+/**
+ * LIVE geometric membership of a LiteGraph group.
+ *
+ * Recomputes from the CURRENT node + group geometry (overlap test, mirroring
+ * LiteGraph's own overlapBounding) instead of trusting the cached g._nodes.
+ * Best-effort calls g.recomputeInsideNodes?.() first to keep LiteGraph's own
+ * cache (used by convertToSubgraph / canvas selection) in sync, but never
+ * depends on its result.
+ *
+ * NOTE (dense-layout limitation, #297): because membership is purely geometric,
+ * ANY unrelated node whose box overlaps the group rectangle IS a member — there
+ * is no per-node ownership to exclude it. Callers creating a group around a
+ * specific node set must report requested-vs-actual honestly.
+ */
+export function groupMemberNodes(graph, g) {
+  try { g?.recomputeInsideNodes?.(); } catch { /* build-specific; ignore */ }
+  const gb = groupBoundsOf(g);
+  if (!gb) return [];
+  const [gx, gy, gw, gh] = gb;
+  return (graph?._nodes ?? []).filter((n) => {
+    const [nx, ny, nw, nh] = nodeFocusBounds(n);
+    // Inclusive overlap, matching LiteGraph's overlapBounding (edge contact counts).
+    return nx <= gx + gw && nx + nw >= gx && ny <= gy + gh && ny + nh >= gy;
+  });
+}
+
+/**
+ * Compare the node ids actually enclosed (geometric) against the ids the caller
+ * asked to group. Returns { requested, members, extra, missing } so a create
+ * handler can warn honestly in dense layouts (#297) instead of reporting a
+ * misleading success.
+ */
+export function classifyRequestedMembership(requestedIds, memberIds) {
+  const req = new Set(requestedIds);
+  const members = new Set(memberIds);
+  return {
+    requested: [...requestedIds],
+    members: [...memberIds],
+    extra: memberIds.filter((id) => !req.has(id)),
+    missing: requestedIds.filter((id) => !members.has(id)),
+  };
+}


### PR DESCRIPTION
## Problem
Five issues (#311, #312, #287, #297, #305) all trace to one root cause: **LiteGraph groups do not own their nodes — membership is purely GEOMETRIC** (a node is "in" a group when its bounding box overlaps the group's). Several ComfyUI frontend builds leave `LGraphGroup._nodes` **stale or empty** after programmatic bounds / pos / paste changes, and the panel trusted that cache when reporting or consuming membership. Result: zero/wrong/stale `node_ids`.

## Fix
- New pure, dependency-free module `web/js/lib/group-geometry.js` exporting `groupMemberNodes(graph, g)` that **recomputes membership from LIVE node + group geometry on every read** (edge-inclusive overlap, mirroring LiteGraph `overlapBounding`), never trusting `g._nodes`. `nodeFocusBounds` / `boundsAroundNodes` moved here too; `nodeFocusBounds` now handles typed-array `boundingRect` (current ComfyUI `Rectangle`).
- Every membership read routed through `groupMemberNodes`: `summarizeGroup`, `graph_outline`, auto-layout group boxes, `graph_subgraph_group` — fixes stale membership after move/resize/paste (#287, #305, #311, #312).
- `graph_move_group` moves the **live** members with the box instead of relying on `g.move()`'s stale cache.
- Auto-layout `predictGroupBounds` uses the **pre-move member snapshot** so a member's new position can't silently shrink the group box.

## Dense-layout capture (#297)
Because membership is purely geometric, there is **no per-node ownership** to exclude an unrelated node whose box overlaps the group rectangle — this is a fundamental LiteGraph limitation, now documented in the module. `graph_create_group(node_ids)` builds a **tight** bbox around exactly the requested nodes, then reports **honestly**: `requested_node_ids`, `extra_node_ids`, `missing_node_ids`, and a `warning` (also surfaced on the activity card) whenever the geometric set differs from the request — instead of a misleading `node_count` success. Nonexistent requested ids are listed as missing.

## Tests
`browser_tests/unit/group-geometry.test.mjs` (11 tests): create-around-specific-nodes yields exactly those members; pasted-then-grouped counted despite empty `_nodes` (#312); move node out / into a resized group updates membership (#287/#311); dense-layout create surfaces the captured neighbor as `extra` (#297); edge-inclusive overlap; typed-array boundingRect. Full unit suite green (**438 tests**).

## codex gate
Read-only review: **VERDICT: PASS** (after 2 iterations — caught the `g.move` stale-cache path and an auto-layout recompute-after-move timing bug, both fixed). Confirmed no membership read still uses a stale snapshot and dense-layout capture is handled honestly.

No version / PANEL_VERSION bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)