### PR TITLE
release: 0.11.16 — live-geometry group membership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.16] - 2026-07-30
+
+### Fixed
+- **Group tools report live, accurate membership instead of a stale/empty snapshot (#311, #312, #287, #297, #305).** LiteGraph group membership is purely geometric (a node belongs to a group when its bounds overlap the group's bounds) and has no per-node ownership, but the panel trusted the stale `group._nodes` cache — so members read empty after grouping pasted nodes (#312), went stale after moving nodes in/out or resizing (#287, #311, #305), and `create_group(node_ids)` could silently enclose unrelated neighbors in dense layouts (#297). A new `groupMemberNodes()` recomputes membership from live geometry on every read (edge-inclusive overlap mirroring LiteGraph's `overlapBounding`), routed through all read sites plus `graph_move_group` and auto-layout. `graph_create_group` builds a bounding box tight to exactly the requested nodes and reports honestly — `requested_node_ids` / `extra_node_ids` / `missing_node_ids` with a warning whenever geometry differs from the request, instead of silently mis-reporting. Live-verified on the rig: create-around-two-nodes returns exactly those two (third excluded); moving the third node into the group region re-reports it as a member. (#320)
+
 ## [0.11.15] - 2026-07-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.15"
+version = "0.11.16"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -230,7 +230,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.15";
+const PANEL_VERSION = "0.11.16";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Cuts panel **0.11.16**. Bumps `pyproject.toml` + `PANEL_VERSION` together (Registry publish fires on the pyproject change to main).

## Ships
- **#311/#312/#287/#297/#305 (#320):** group tools recompute membership from live geometry each read (`groupMemberNodes`), and `create_group` builds a tight bbox + reports `requested/extra/missing_node_ids` honestly instead of a stale `_nodes` snapshot. codex PASS (3 rounds), 11 tests. **Live-verified on the rig** (create-around-two returns exactly those two; moving a third node in re-reports it as a member).

🤖 Generated with [Claude Code](https://claude.com/claude-code)