### PR TITLE
release: 0.11.17 — fix retired-tool hints (#318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.17] - 2026-07-30
+
+### Fixed
+- **Error/tip messages no longer recommend the retired `panel_get_graph` tool (#318).** `panel_add_node`'s unknown-node-type error, plus several wiring/output-node/group-listing tips, pointed at `panel_get_graph`, which is no longer exposed. Unknown-node errors now point at `panel_search_nodes` (the node-type registry search), and graph-inspection tips point at `panel_query_graph` (the live-graph query that replaced the old full-JSON dump). Regression test asserts the unknown-type message never references the retired tool.
+
 ## [0.11.16] - 2026-07-30
 
 ### Fixed

--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -116,6 +116,19 @@ test("add_node: unknown type on a REACHABLE server ⇒ ERRORS with unknown-type"
   });
 });
 
+test("add_node: unknown-type error points at a LIVE tool, not the retired panel_get_graph (#318)", () => {
+  const reg = loadedRegistry();
+  try {
+    assertAddNodeResolvable(reg, "DefinitelyNotARealNode");
+    throw new Error("expected a throw");
+  } catch (e) {
+    // The retired panel_get_graph must never be recommended.
+    assert.doesNotMatch(e.message, /panel_get_graph/);
+    // Should steer the caller to the registry-search tool instead.
+    assert.match(e.message, /panel_search_nodes/);
+  }
+});
+
 test("add_node: REAL type on a reachable server ⇒ resolves (no false negative)", () => {
   const reg = loadedRegistry(["KSamplerAdvanced"]);
   assert.doesNotThrow(() => assertAddNodeResolvable(reg, "CheckpointLoaderSimple"));

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.16"
+version = "0.11.17"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -230,7 +230,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.16";
+const PANEL_VERSION = "0.11.17";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;
@@ -4053,11 +4053,11 @@ function slotDiagnostic(origin, target, requested = {}) {
     const hint = SLOT_TYPE_HINTS[typeName];
     tail =
       `No input on node ${target.id} accepts type ${renderSlotType(failType)}. ` +
-      `Tip: ${hint ? hint + "; " : ""}check wiring with panel_get_graph.`;
+      `Tip: ${hint ? hint + "; " : ""}check wiring with panel_query_graph.`;
   } else {
     tail =
       `No compatible output→input pair found between node ${origin.id} and node ${target.id}. ` +
-      `Tip: check wiring with panel_get_graph.`;
+      `Tip: check wiring with panel_query_graph.`;
   }
 
   const oType = origin.type ?? origin.comfyClass ?? origin.title ?? "node";
@@ -4982,7 +4982,7 @@ const GRAPH_TOOL_EXECUTORS = {
     const node = LG.createNode(class_type);
     if (!node) {
       throw new Error(
-        `Unknown node type "${class_type}" — check the exact class_type via panel_get_graph or panel_search_nodes`,
+        `Unknown node type "${class_type}" — check the exact class_type via panel_search_nodes`,
       );
     }
     graph.beforeChange();
@@ -5648,7 +5648,7 @@ const GRAPH_TOOL_EXECUTORS = {
           error:
             `node ${to_node_id} (${node.type}) is not an output node — "run to node" can ` +
             `only target an output node such as SaveImage, PreviewImage, or SaveVideo. Pick the ` +
-            `output node at the end of the branch you want to render (is_output:true in panel_get_graph).`,
+            `output node at the end of the branch you want to render (is_output:true in panel_query_graph).`,
         };
       }
       partialTargets = [String(to_node_id)];
@@ -6024,7 +6024,7 @@ const GRAPH_TOOL_EXECUTORS = {
     const g = resolveGroupRef(graph, group);
     if (!g) {
       throw new Error(
-        `no group matching "${group}" — list groups via panel_get_graph (each has id, title, node_ids)`,
+        `no group matching "${group}" — list groups via panel_query_graph (each has id, title, node_ids)`,
       );
     }
     const ns = groupMemberNodes(graph, g);

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -438,7 +438,7 @@ export function managerUnavailableResult(query, err) {
       "be reached on this ComfyUI (it may be disabled, or a legacy/partial Manager " +
       "build without the search endpoint). Enable the built-in Manager to search the " +
       "registry, or continue with the nodes already installed — inspect them with " +
-      "panel_list_nodes and the current graph with panel_get_graph.",
+      "panel_list_nodes and the current graph with panel_query_graph.",
   };
 }
 

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -63,7 +63,7 @@ export function assertAddNodeResolvable(registry, class_type) {
     );
   }
   throw new Error(
-    `Unknown node type "${class_type}" — check the exact class_type via panel_get_graph or panel_search_nodes`,
+    `Unknown node type "${class_type}" — check the exact class_type via panel_search_nodes`,
   );
 }
 


### PR DESCRIPTION
Cuts panel **0.11.17**. Bumps `pyproject.toml` + `PANEL_VERSION` together.

## Ships
- **#318:** panel error/tip strings no longer recommend the retired `panel_get_graph`. Unknown-node-type errors point at `panel_search_nodes` (registry search); wiring/output/group-listing tips point at `panel_query_graph` (live-graph query). Regression test added. codex PASS; 439 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)