### PR TITLE
fix(errors): recompute get_errors missing-assets live + scope to active workflow (#337, #316, #303, #267, #270)

### DIFF
--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -14,6 +14,7 @@ import {
   assetCandidateStillReferenced,
   assetCandidateResolvesLive,
   isStaleAssetCandidate,
+  locatorIsRecognized,
   orderedWidgetInputNames,
   isWidgetInputSpec,
   reconcileUnknownWidgetNames,
@@ -272,6 +273,81 @@ test("a STALE combo still listing a deleted file must NOT suppress a genuine mis
   assert.equal(isStaleAssetCandidate(graphOf([node]), candidate, { trustCombo: false }), false);
   // Only after a confirmed refresh is combo membership trusted to clear it.
   assert.equal(isStaleAssetCandidate(graphOf([node]), candidate, { trustCombo: true }), true);
+});
+
+// ── #316: cross-tab / removed-node scoping ──────────────────────────────────
+test("locatorIsRecognized mirrors findNodeByScopedId's recognized shapes", () => {
+  assert.equal(locatorIsRecognized("66"), true); // plain local id
+  assert.equal(locatorIsRecognized("node-uuid-1"), true); // string/UUID-like id
+  assert.equal(locatorIsRecognized("6051:1913"), true); // legacy numeric hop
+  assert.equal(locatorIsRecognized(`${SG_UUID}:1913`), true); // real subgraph locator
+  assert.equal(locatorIsRecognized(""), false); // empty
+  assert.equal(locatorIsRecognized(`${SG_UUID}:x:6077`), false); // 3 segments
+  assert.equal(locatorIsRecognized(`${SG_UUID}::6077`), false); // empty middle
+  assert.equal(locatorIsRecognized(`${SG_UUID}:`), false); // empty local id
+  assert.equal(locatorIsRecognized("not-a-uuid:6077"), false); // bad UUID
+  assert.equal(locatorIsRecognized("6051:"), false); // trailing empty numeric hop
+});
+
+test("isStaleAssetCandidate: DROPS a candidate whose node isn't in the active graph (#316 cross-tab leak)", () => {
+  // Active workflow tab is a simple 8-node graph WITHOUT node 66. The missingModel
+  // store still holds node 66 from a previously-open tab → it must not be reported.
+  const active = graphOf([{ id: 3 }, { id: 5 }, { id: 6 }, { id: 16 }]);
+  assert.equal(
+    isStaleAssetCandidate(active, {
+      nodeId: "66",
+      name: "z_image_turbo_bf16.safetensors",
+      widgetName: "unet_name",
+    }),
+    true,
+  );
+});
+
+test("isStaleAssetCandidate: DROPS a foreign SUBGRAPH-scoped candidate whose subgraph isn't in the active graph (#316)", () => {
+  const active = rootWithSubgraphs([{ id: 3 }], []); // no subgraph registered
+  assert.equal(
+    isStaleAssetCandidate(active, {
+      nodeId: `${SG_UUID}:6077`,
+      name: "rife_v4.26.safetensors",
+      widgetName: "ckpt_name",
+    }),
+    true,
+  );
+});
+
+test("isStaleAssetCandidate: a foreign candidate is KEPT when scopeToActiveGraph is off (fail-open opt-out)", () => {
+  const active = graphOf([{ id: 3 }]);
+  const candidate = { nodeId: "66", name: "x.safetensors", widgetName: "unet_name" };
+  assert.equal(isStaleAssetCandidate(active, candidate, { scopeToActiveGraph: false }), false);
+});
+
+test("isStaleAssetCandidate: an UNPARSEABLE foreign-looking locator is NOT dropped by scoping (fail-open, #316 safety)", () => {
+  // A malformed locator with no matching node must fail OPEN, not be silently
+  // dropped as 'foreign' — otherwise a genuine miss on an odd id would vanish.
+  const active = graphOf([{ id: 3 }]);
+  assert.equal(
+    isStaleAssetCandidate(active, {
+      nodeId: `${SG_UUID}:x:6077`,
+      name: "gone.safetensors",
+      widgetName: "ckpt_name",
+    }),
+    false,
+  );
+});
+
+test("isStaleAssetCandidate: a genuine miss on a node PRESENT in the active graph still reports (scoping no-op)", () => {
+  const node = {
+    id: 66,
+    widgets: [{ name: "unet_name", value: "z_image_turbo_bf16.safetensors" }],
+  };
+  assert.equal(
+    isStaleAssetCandidate(graphOf([node]), {
+      nodeId: "66",
+      name: "z_image_turbo_bf16.safetensors",
+      widgetName: "unet_name",
+    }),
+    false,
+  );
 });
 
 test("collectAllGraphs walks nested subgraphs", () => {

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -116,6 +116,31 @@ export function findNodeByScopedId(rootGraph, scopedId) {
 }
 
 /**
+ * True when `scopedId` is a RECOGNIZED locator shape — exactly the shapes
+ * `findNodeByScopedId` knows how to resolve:
+ *   - a single non-empty segment (plain local id / UUID-like);
+ *   - an all-numeric first segment with 2+ segments (legacy group-node exec id);
+ *   - EXACTLY "<subgraphUUID>:<localNodeId>" (well-formed UUID first, non-empty
+ *     local id).
+ * Any other shape (extra segments, empty segment, malformed UUID) is UNrecognized.
+ *
+ * This lets callers distinguish "the locator is understood but the node is not in
+ * the active graph" (⇒ the candidate belongs to another workflow tab / was
+ * removed ⇒ safe to drop for the active workflow — #316) from "the locator itself
+ * is ambiguous" (⇒ must fail OPEN and keep reporting). Kept in lockstep with
+ * `findNodeByScopedId`'s parse so the two never disagree.
+ */
+export function locatorIsRecognized(scopedId) {
+  const raw = String(scopedId ?? "");
+  if (!raw) return false;
+  const parts = raw.split(":");
+  if (parts.length === 1) return true;
+  const first = parts[0];
+  if (/^\d+$/.test(first)) return parts.every((p) => p !== "");
+  return parts.length === 2 && UUID_RE.test(first) && parts[1] !== "";
+}
+
+/**
  * Keep a candidate only if some widget on the node STILL literally holds that
  * filename. Fails OPEN (returns true / "still referenced") on any unexpected
  * shape, so the worst case is over-reporting and a real miss is never swallowed.
@@ -166,11 +191,33 @@ export function assetCandidateResolvesLive(rootGraph, nodeId, file, widgetName) 
  * SUPPRESS a genuine `isMissing:true` candidate, which we must never do. Without
  * a confirmed refresh we fall back to over-reporting via the still-referenced
  * check alone.
+ *
+ * `scopeToActiveGraph` (default true) additionally drops a candidate whose
+ * RECOGNIZED locator resolves to NO node in `rootGraph` — the missing-asset Pinia
+ * stores are not cleared when the user switches workflow tabs, so a candidate from
+ * a previously-open tab (or a since-deleted node) otherwise leaks into the active
+ * workflow's errors (#316). This is guarded by `locatorIsRecognized`: an ambiguous
+ * / unparseable locator is NEVER dropped this way and still fails OPEN via the
+ * still-referenced check, so a genuine miss is never swallowed.
  */
-export function isStaleAssetCandidate(rootGraph, candidate, { trustCombo = false } = {}) {
+export function isStaleAssetCandidate(
+  rootGraph,
+  candidate,
+  { trustCombo = false, scopeToActiveGraph = true } = {},
+) {
   const nodeId = candidate?.nodeId;
   const file = candidate?.name;
   const widgetName = candidate?.widgetName;
+  // Cross-tab / removed-node scope check: a recognized locator that finds no node
+  // in the active graph cannot be a red node in the active workflow → drop it.
+  if (
+    scopeToActiveGraph &&
+    nodeId != null &&
+    locatorIsRecognized(nodeId) &&
+    findNodeByScopedId(rootGraph, nodeId) == null
+  ) {
+    return true;
+  }
   if (!assetCandidateStillReferenced(rootGraph, nodeId, file)) return true;
   if (trustCombo && assetCandidateResolvesLive(rootGraph, nodeId, file, widgetName)) return true;
   return false;


### PR DESCRIPTION
## Problem

`panel_get_errors` serves STALE missing-asset (`missing_model` / `missing_media`) reasons after the underlying problem is fixed. Cluster:

- **#337 / #352** stale `missing_model` after a widget edit
- **#316** leaks stale missing models from ANOTHER workflow tab (the residual, cross-workflow bleed)
- **#303** keeps reporting an installed frame-interpolation model as missing after restart
- **#267** stale missing-asset reasons after widgets + assets fixed
- **#270 / #364** stale `missing_media` after LoadImage/LoadVideo input changes

## Root cause & what was already fixed

The missing-asset Pinia stores (`missingModel`/`missingMedia`) are populated once at workflow LOAD and never re-evaluated. The prior WS-3/#260 fix (`web/js/lib/asset-staleness.js`) already recomputes each candidate against the LIVE graph, clearing widget-edit and appeared-on-disk staleness — this covers the widget/asset-fix cases (#337, #352, #267, #270, #303 combo path after a confirmed refresh).

The **residual** bug is #316: the stores are not cleared on workflow-tab switch, so a candidate whose node is not in the ACTIVE graph leaks in. `assetCandidateStillReferenced` fails OPEN when the node isn't found, preserving the leak.

## Fix

- Add `locatorIsRecognized(scopedId)` mirroring `findNodeByScopedId`'s parseable locator shapes.
- In `isStaleAssetCandidate`, drop a candidate when its locator IS recognized but resolves to NO node in the active `rootGraph` — scoping missing-asset reasons to the currently-active workflow only, no cross-tab bleed.
- Guarded so an ambiguous/unparseable locator still fails OPEN — a genuine miss is never swallowed (over-report acceptable, under-report never).

## Tests

Added unit tests in `browser_tests/unit/asset-staleness.test.mjs` (fail before / pass after): cross-tab root + subgraph leak drop, `locatorIsRecognized` lockstep, fail-open on unparseable locators, opt-out, and genuine present-node miss still reported. `node --test browser_tests/unit/*.mjs` → 445 pass.

## Codex gate

`VERDICT: PASS` — "The active-graph guard correctly drops recognized locators that resolve to no active node, while present-node genuine misses continue through the existing fail-open checks. Unparseable locators remain reported. No blocking issues found."

No version bump.

---
Closes #316
