### PR TITLE
fix(set-widget): refresh stale combo options before validating (#338, #317, #299, #288, #284, #304)

### DIFF
--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -225,17 +225,17 @@ function makeSubgraphFixture(innerType = "KSampler") {
   return { parent, inner, resolveSource };
 }
 
-test("set_widget e2e: DIRECT registered node ⇒ write succeeds", () => {
+test("set_widget e2e: DIRECT registered node ⇒ write succeeds", async () => {
   const reg = loadedRegistry();
   const node = regNode("KSampler", [{ name: "steps", type: "INT", value: 0 }]);
-  const { set } = setViaHandler(reg, node, "steps", 20);
+  const { set } = await setViaHandler(reg, node, "steps", 20);
   assert.equal(set.value, 20);
 });
 
 // FINDING #1: the guard must run BEFORE coerceWidgetValue, which reads (and thus
 // may INVOKE) a dynamic combo's options.values(widget) callback. On a placeholder
 // that callback must NEVER fire — the write is refused first.
-test("set_widget e2e (finding #1): placeholder w/ dynamic-combo widget ⇒ REFUSE before values() callback runs", () => {
+test("set_widget e2e (finding #1): placeholder w/ dynamic-combo widget ⇒ REFUSE before values() callback runs", async () => {
   const reg = loadedRegistry();
   let valuesCalled = false;
   const ghost = {
@@ -257,14 +257,14 @@ test("set_widget e2e (finding #1): placeholder w/ dynamic-combo widget ⇒ REFUS
   };
   // Through the REAL handler body, so the guard's position ahead of coercion is
   // exercised in production order.
-  assert.throws(() => setViaHandler(reg, ghost, "opt", "b"), /not registered|placeholder/i);
+  await assert.rejects(() => setViaHandler(reg, ghost, "opt", "b"), /not registered|placeholder/i);
   assert.equal(valuesCalled, false, "combo values() callback must not run on a refused placeholder");
   assert.equal(ghost.widgets[0].value, "a");
 });
 
 // FINDING #2 (e2e): a stale placeholder INSTANCE whose type is now registered
 // must be refused rather than accept a write to its generic 'value' widget.
-test("set_widget e2e (finding #2): registered TYPE but placeholder INSTANCE ⇒ REFUSE, no mutation", () => {
+test("set_widget e2e (finding #2): registered TYPE but placeholder INSTANCE ⇒ REFUSE, no mutation", async () => {
   const reg = loadedRegistry(); // KSampler registered WITH nodeData
   const stale = {
     id: 9,
@@ -273,59 +273,59 @@ test("set_widget e2e (finding #2): registered TYPE but placeholder INSTANCE ⇒ 
     constructor: { name: "GenericFallback" }, // no nodeData ⇒ unresolved instance
   };
   // Through the REAL handler body (preflight → reconcile → guarded write).
-  assert.throws(() => setViaHandler(reg, stale, "value", 5), /unresolved placeholder|live definition is missing/i);
+  await assert.rejects(() => setViaHandler(reg, stale, "value", 5), /unresolved placeholder|live definition is missing/i);
   assert.equal(stale.widgets[0].value, 0);
 });
 
-test("set_widget e2e: DIRECT unregistered placeholder (reachable) ⇒ REFUSE, no mutation", () => {
+test("set_widget e2e: DIRECT unregistered placeholder (reachable) ⇒ REFUSE, no mutation", async () => {
   const reg = loadedRegistry();
   const ghost = { id: 1, type: "GhostNode", widgets: [{ name: "value", type: "number", value: 0 }] };
-  assert.throws(() => setViaHandler(reg, ghost, "value", 5), /not registered|placeholder/i);
+  await assert.rejects(() => setViaHandler(reg, ghost, "value", 5), /not registered|placeholder/i);
   assert.equal(ghost.widgets[0].value, 0);
 });
 
 // case a/b/keep go through the REAL handler (setViaHandler): the REFUSAL/PASS is
 // decided by the guard HOOK inside runSetWidget (these paths bypass outer
 // preflight), so dropping the shipped guard wiring FAILS these tests.
-test("set_widget e2e (case a): placeholder carrying `subgraph:{}` + generic widget ⇒ REFUSE (via handler)", () => {
+test("set_widget e2e (case a): placeholder carrying `subgraph:{}` + generic widget ⇒ REFUSE (via handler)", async () => {
   const reg = loadedRegistry();
   // subgraph:{} is truthy but has no promoted inputs, so it resolves to its OWN
   // generic widget — the exact fail-open the outer-node check allowed. Refusal
   // here comes from the guard hook, not outer preflight.
   const ghost = { id: 2, type: "GhostNode", subgraph: {}, widgets: [{ name: "value", type: "number", value: 0 }] };
-  assert.throws(() => setViaHandler(reg, ghost, "value", 7), /not registered|placeholder/i);
+  await assert.rejects(() => setViaHandler(reg, ghost, "value", 7), /not registered|placeholder/i);
   assert.equal(ghost.widgets[0].value, 0);
 });
 
-test("set_widget e2e (case b): real subgraph → UNREGISTERED inner placeholder ⇒ REFUSE (via handler), inner untouched", () => {
+test("set_widget e2e (case b): real subgraph → UNREGISTERED inner placeholder ⇒ REFUSE (via handler), inner untouched", async () => {
   const reg = loadedRegistry();
   const { parent, inner, resolveSource } = makeSubgraphFixture("GhostSampler");
-  assert.throws(
+  await assert.rejects(
     () => setViaHandler(reg, parent, "sched_alias", "karras", resolveSource),
     /not registered|placeholder/i,
   );
   assert.equal(inner.widgets.find((w) => w.name === "scheduler").value, "simple");
 });
 
-test("set_widget e2e (case c): type-less node ⇒ REFUSE", () => {
+test("set_widget e2e (case c): type-less node ⇒ REFUSE", async () => {
   const reg = loadedRegistry();
   const node = { id: 5, widgets: [{ name: "value", type: "number", value: 0 }] };
-  assert.throws(() => setViaHandler(reg, node, "value", 3), /not registered/i);
+  await assert.rejects(() => setViaHandler(reg, node, "value", 3), /not registered/i);
 });
 
-test("set_widget e2e (keep): real subgraph → REGISTERED inner node ⇒ still succeeds (via handler)", () => {
+test("set_widget e2e (keep): real subgraph → REGISTERED inner node ⇒ still succeeds (via handler)", async () => {
   const reg = loadedRegistry();
   const { parent, inner, resolveSource } = makeSubgraphFixture("KSampler");
-  const { set } = setViaHandler(reg, parent, "sched_alias", "karras", resolveSource);
+  const { set } = await setViaHandler(reg, parent, "sched_alias", "karras", resolveSource);
   assert.equal(set.value, "karras");
   assert.equal(set.promoted_from.inner_node_id, 54);
   assert.equal(inner.widgets.find((w) => w.name === "scheduler").value, "karras");
 });
 
-test("set_widget e2e: unreachable ⇒ REFUSE even for a would-be-core type, no mutation", () => {
+test("set_widget e2e: unreachable ⇒ REFUSE even for a would-be-core type, no mutation", async () => {
   const reg = unreachableRegistry();
   const node = { id: 1, type: "CheckpointLoaderSimple", widgets: [{ name: "ckpt_name", type: "text", value: "" }] };
-  assert.throws(() => setViaHandler(reg, node, "ckpt_name", "x.safetensors"), /not loaded|unreachable/i);
+  await assert.rejects(() => setViaHandler(reg, node, "ckpt_name", "x.safetensors"), /not loaded|unreachable/i);
   assert.equal(node.widgets[0].value, "");
 });
 
@@ -356,38 +356,38 @@ function nodeWithUnknownWidgets(type) {
   };
 }
 
-test("handler: a REGISTERED node's UNKNOWN widgets are reconciled THEN written", () => {
+test("handler: a REGISTERED node's UNKNOWN widgets are reconciled THEN written", async () => {
   const reg = loadedRegistry(["MyRegNode"]);
   const node = nodeWithUnknownWidgets("MyRegNode");
   // reconcile renames UNKNOWN→steps, UNKNOWN_1→cfg, then the write lands on "cfg".
-  const { set } = setViaHandler(reg, node, "cfg", 7.5);
+  const { set } = await setViaHandler(reg, node, "cfg", 7.5);
   assert.deepEqual(node.widgets.map((w) => w.name), ["steps", "cfg"]);
   assert.equal(set.value, 7.5);
 });
 
-test("handler: UNREGISTERED placeholder w/ UNKNOWN widgets ⇒ REFUSE, names UNCHANGED (reconcile never ran)", () => {
+test("handler: UNREGISTERED placeholder w/ UNKNOWN widgets ⇒ REFUSE, names UNCHANGED (reconcile never ran)", async () => {
   const reg = loadedRegistry(); // reachable, but type not registered
   const node = nodeWithUnknownWidgets("GhostNode");
-  assert.throws(() => setViaHandler(reg, node, "steps", 5), /not registered|placeholder/i);
+  await assert.rejects(() => setViaHandler(reg, node, "steps", 5), /not registered|placeholder/i);
   // The load-bearing assertion: reconcile never ran, so the UNKNOWN names stand.
   assert.deepEqual(node.widgets.map((w) => w.name), ["UNKNOWN", "UNKNOWN_1"]);
 });
 
-test("handler: TYPE-LESS node w/ UNKNOWN widgets ⇒ REFUSE, names UNCHANGED", () => {
+test("handler: TYPE-LESS node w/ UNKNOWN widgets ⇒ REFUSE, names UNCHANGED", async () => {
   const reg = loadedRegistry();
   const node = nodeWithUnknownWidgets(undefined);
-  assert.throws(() => setViaHandler(reg, node, "steps", 5), /not registered/i);
+  await assert.rejects(() => setViaHandler(reg, node, "steps", 5), /not registered/i);
   assert.deepEqual(node.widgets.map((w) => w.name), ["UNKNOWN", "UNKNOWN_1"]);
 });
 
-test("handler: unreachable placeholder w/ UNKNOWN widgets ⇒ REFUSE, names UNCHANGED", () => {
+test("handler: unreachable placeholder w/ UNKNOWN widgets ⇒ REFUSE, names UNCHANGED", async () => {
   const reg = unreachableRegistry();
   const node = nodeWithUnknownWidgets("CheckpointLoaderSimple");
-  assert.throws(() => setViaHandler(reg, node, "steps", 5), /not loaded|unreachable/i);
+  await assert.rejects(() => setViaHandler(reg, node, "steps", 5), /not loaded|unreachable/i);
   assert.deepEqual(node.widgets.map((w) => w.name), ["UNKNOWN", "UNKNOWN_1"]);
 });
 
-test("handler: stale placeholder INSTANCE (registered type, no instance def) ⇒ REFUSE before reconcile", () => {
+test("handler: stale placeholder INSTANCE (registered type, no instance def) ⇒ REFUSE before reconcile", async () => {
   const reg = loadedRegistry(); // KSampler registered WITH nodeData
   const stale = {
     id: 42,
@@ -395,18 +395,18 @@ test("handler: stale placeholder INSTANCE (registered type, no instance def) ⇒
     widgets: [{ name: "UNKNOWN", type: "number", value: 0 }],
     constructor: { name: "GenericFallback" }, // no nodeData ⇒ unresolved instance
   };
-  assert.throws(() => setViaHandler(reg, stale, "steps", 5), /unresolved placeholder|live definition is missing/i);
+  await assert.rejects(() => setViaHandler(reg, stale, "steps", 5), /unresolved placeholder|live definition is missing/i);
   assert.deepEqual(stale.widgets.map((w) => w.name), ["UNKNOWN"]);
 });
 
-test("handler: SUBGRAPH parent ⇒ reconcile SKIPPED (parent's own UNKNOWN widgets untouched), inner write lands", () => {
+test("handler: SUBGRAPH parent ⇒ reconcile SKIPPED (parent's own UNKNOWN widgets untouched), inner write lands", async () => {
   const reg = loadedRegistry();
   const { parent, inner, resolveSource } = makeSubgraphFixture("KSampler");
   // Give the parent its OWN UNKNOWN widgets + a def, so IF reconcile wrongly ran it
   // would rename them — it must not (reconcile is skipped for subgraph parents).
   parent.widgets.push({ name: "UNKNOWN", type: "number", value: 0 });
   parent.constructor = { nodeData: { input: { required: { foo: ["FLOAT", {}] } } } };
-  const { set } = setViaHandler(reg, parent, "sched_alias", "karras", resolveSource);
+  const { set } = await setViaHandler(reg, parent, "sched_alias", "karras", resolveSource);
   assert.equal(set.value, "karras");
   assert.equal(inner.widgets.find((w) => w.name === "scheduler").value, "karras");
   // Parent's own UNKNOWN widget name is untouched — reconcile did not run.

--- a/browser_tests/unit/set-widget-refresh.test.mjs
+++ b/browser_tests/unit/set-widget-refresh.test.mjs
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for the STALE-COMBO refresh-before-validate recovery in
+ * web/js/lib/set-widget.js — run with `node --test`.
+ *
+ * These drive runSetWidget(), the SAME async unit graph_set_widget delegates to,
+ * so the production path is exercised (not a parallel reimplementation). The
+ * `refreshCombos` callback stands in for the live frontend refresh
+ * (refreshComfyNodeDefs → object_info re-register + refreshComboInNodes), which
+ * mutates the widget's option list IN PLACE.
+ *
+ * Cluster fixed: #338 (downloaded model), #317 / #284 (staged output), #288
+ * (uploaded image into an EMPTY LoadImage combo), #299 (ControlNet loader), #304.
+ *
+ * Invariants under test:
+ *   1. A value ABSENT from the stale combo but PRESENT after an authoritative
+ *      refresh is accepted on a single revalidation (was rejected before).
+ *   2. A genuinely-invalid value (still absent AFTER refresh) is STILL rejected —
+ *      #240 strictness is preserved; refresh cannot make a bad value sneak in.
+ *   3. Only COMBO rejections trigger the refresh; a numeric type mismatch fails
+ *      closed immediately without any refresh attempt.
+ *   4. refresh is attempted AT MOST ONCE.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runSetWidget } from "../../web/js/lib/set-widget.js";
+
+// A registry whose entries have no `nodeData` so the placeholder cross-check in
+// assertResolvedTargetRegistered is skipped (registeredDef undefined) while the
+// type still resolves as registered.
+const REGISTRY = { LoadImage: {}, ControlNetLoader: {}, KSampler: {} };
+
+function makeNode(type, widget) {
+  return { id: 105, type, widgets: [widget] };
+}
+
+test("stale combo: a just-staged value ABSENT at first is accepted after refresh (#317/#284/#338)", async () => {
+  const widget = { name: "image", type: "combo", options: { values: ["old_a.png", "old_b.png"] }, value: "old_a.png" };
+  const node = makeNode("LoadImage", widget);
+  let refreshCalls = 0;
+  const refreshCombos = async () => {
+    refreshCalls += 1;
+    // Authoritative source now lists the newly-staged file — mutate in place.
+    widget.options.values = ["old_a.png", "old_b.png", "ICEDTEA_scene_bg_inpaint_01.png"];
+  };
+
+  const res = await runSetWidget(node, "image", "ICEDTEA_scene_bg_inpaint_01.png", {
+    registry: REGISTRY,
+    refreshCombos,
+  });
+
+  assert.equal(res.set.value, "ICEDTEA_scene_bg_inpaint_01.png");
+  assert.equal(res.refreshed, true);
+  assert.equal(widget.value, "ICEDTEA_scene_bg_inpaint_01.png");
+  assert.equal(refreshCalls, 1, "refresh must be attempted exactly once");
+});
+
+test("EMPTY LoadImage combo (0 options) accepts the uploaded file after refresh (#288)", async () => {
+  const widget = { name: "image", type: "combo", options: { values: [] }, value: "" };
+  const node = makeNode("LoadImage", widget);
+  const refreshCombos = async () => {
+    widget.options.values = ["wan_reference_woman.png"];
+  };
+
+  const res = await runSetWidget(node, "image", "wan_reference_woman.png", {
+    registry: REGISTRY,
+    refreshCombos,
+  });
+  assert.equal(res.set.value, "wan_reference_woman.png");
+});
+
+test("ControlNetLoader stale 3-item list accepts the 4th model after refresh (#299)", async () => {
+  const widget = {
+    name: "control_net_name",
+    type: "combo",
+    options: { values: ["a.safetensors", "b.safetensors", "c.safetensors"] },
+    value: "a.safetensors",
+  };
+  const node = { id: 18, type: "ControlNetLoader", widgets: [widget] };
+  const refreshCombos = async () => {
+    widget.options.values.push("mistoLine_rank256.safetensors");
+  };
+  const res = await runSetWidget(node, "control_net_name", "mistoLine_rank256.safetensors", {
+    registry: REGISTRY,
+    refreshCombos,
+  });
+  assert.equal(res.set.value, "mistoLine_rank256.safetensors");
+});
+
+test("GENUINELY-invalid value is STILL rejected after refresh (keeps #240 strictness)", async () => {
+  const widget = { name: "image", type: "combo", options: { values: ["old_a.png"] }, value: "old_a.png" };
+  const node = makeNode("LoadImage", widget);
+  let refreshCalls = 0;
+  const refreshCombos = async () => {
+    refreshCalls += 1;
+    // Refresh adds OTHER files but NOT the requested one — a real typo/bad value.
+    widget.options.values = ["old_a.png", "some_other.png"];
+  };
+
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "image", "does_not_exist_anywhere.png", {
+        registry: REGISTRY,
+        refreshCombos,
+      }),
+    (err) =>
+      err instanceof Error &&
+      /refused/.test(err.message) &&
+      /after refreshing combo options/.test(err.message) &&
+      /not a valid option/.test(err.message),
+  );
+  assert.equal(widget.value, "old_a.png", "must not mutate on a genuinely-invalid value");
+  assert.equal(refreshCalls, 1, "refresh attempted exactly once, then fails closed");
+});
+
+test("without a refreshCombos injection, a stale-combo miss fails closed (no silent accept)", async () => {
+  const widget = { name: "image", type: "combo", options: { values: ["old_a.png"] }, value: "old_a.png" };
+  const node = makeNode("LoadImage", widget);
+  await assert.rejects(
+    () => runSetWidget(node, "image", "new.png", { registry: REGISTRY }),
+    (err) => err instanceof Error && /not a valid option/.test(err.message),
+  );
+});
+
+test("a NON-combo failure (numeric type mismatch) never triggers a refresh", async () => {
+  const widget = { name: "steps", type: "INT", value: 20 };
+  const node = { id: 3, type: "KSampler", widgets: [widget] };
+  let refreshCalls = 0;
+  const refreshCombos = async () => {
+    refreshCalls += 1;
+  };
+  await assert.rejects(
+    () => runSetWidget(node, "steps", "euler", { registry: REGISTRY, refreshCombos }),
+    (err) => err instanceof Error && /not a number/.test(err.message),
+  );
+  assert.equal(refreshCalls, 0, "numeric mismatch must fail closed without refreshing");
+});
+
+test("a valid value on the FIRST try does not call refresh at all", async () => {
+  const widget = { name: "image", type: "combo", options: { values: ["a.png", "b.png"] }, value: "a.png" };
+  const node = makeNode("LoadImage", widget);
+  let refreshCalls = 0;
+  const res = await runSetWidget(node, "image", "b.png", {
+    registry: REGISTRY,
+    refreshCombos: async () => {
+      refreshCalls += 1;
+    },
+  });
+  assert.equal(res.set.value, "b.png");
+  assert.equal(res.refreshed, undefined);
+  assert.equal(refreshCalls, 0);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -5298,6 +5298,13 @@ const GRAPH_TOOL_EXECUTORS = {
     // reconcile-only-a-resolved-node → applyWidgetWrite with the resolved-target
     // registry guard (before coercion/mutation). A reorder or a dropped guard
     // therefore fails a test rather than silently regressing (#458).
+    //
+    // refreshCombos pulls the AUTHORITATIVE option list from the connected server
+    // (object_info re-register + refreshComboInNodes, mutating combos in place)
+    // so a just-downloaded model / uploaded image / staged output / freshly
+    // installed pack is accepted on a single revalidation, while a genuinely
+    // invalid value stays rejected against the FRESH list (#338/#317/#299/#288/
+    // #284/#304, keeping #240 strictness).
     return runSetWidget(node, widget, value, {
       registry: LG?.registered_node_types ?? {},
       resolveSource: sourceForSubgraphInput,
@@ -5305,6 +5312,7 @@ const GRAPH_TOOL_EXECUTORS = {
       beforeChange: () => graph.beforeChange(),
       afterChange: () => graph.afterChange(),
       setDirty: () => graph.setDirtyCanvas(true, true),
+      refreshCombos: () => refreshComfyNodeDefs(),
     });
   },
 

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -20,11 +20,11 @@ import { applyWidgetWrite, WidgetWriteError } from "./widget-write.js";
 import { reconcileUnknownWidgetNames } from "./asset-staleness.js";
 import { preflightSetWidgetTarget, assertResolvedTargetRegistered } from "./node-resolve.js";
 
-export function runSetWidget(
+export async function runSetWidget(
   node,
   widgetName,
   value,
-  { registry = {}, resolveSource, canvas, beforeChange, afterChange, setDirty } = {},
+  { registry = {}, resolveSource, canvas, beforeChange, afterChange, setDirty, refreshCombos } = {},
 ) {
   // (1) Preflight the OUTER node before ANY mutation; decide whether reconcile
   //     may run (never on a placeholder; skipped for subgraph parents).
@@ -39,8 +39,8 @@ export function runSetWidget(
   // (#240) and verifies the write stuck exactly. The injected assertTargetWritable
   // runs on the RESOLVED target BEFORE coercion/mutation, so a placeholder is
   // refused before any side effect (#458).
-  try {
-    const set = applyWidgetWrite(node, widgetName, value, {
+  const write = () =>
+    applyWidgetWrite(node, widgetName, value, {
       resolveSource,
       canvas,
       beforeChange,
@@ -48,8 +48,37 @@ export function runSetWidget(
       setDirty,
       assertTargetWritable: (targetNode) => assertResolvedTargetRegistered(registry, targetNode),
     });
-    return { set };
+
+  try {
+    return { set: write() };
   } catch (err) {
+    // STALE-COMBO RECOVERY (#338/#317/#299/#288/#284/#304): the ONLY retryable
+    // failure is a COMBO value rejected against the widget's CURRENT option list
+    // — a just-downloaded model / uploaded image / staged output / freshly
+    // installed pack that the frontend combo snapshot doesn't list yet. When a
+    // refresh source is injected, pull the AUTHORITATIVE option list from the
+    // connected server (object_info + refreshComboInNodes, in place) and
+    // revalidate EXACTLY ONCE. This keeps #240's strictness intact: the retry
+    // validates against the FRESH list, so a genuinely-invalid value (still
+    // absent after refresh) is rejected, and no other error class is retried.
+    if (err instanceof WidgetWriteError && err.combo && typeof refreshCombos === "function") {
+      try {
+        await refreshCombos();
+      } catch {
+        /* refresh best-effort; fall through to re-raise the original rejection */
+      }
+      try {
+        return { set: write(), refreshed: true };
+      } catch (retryErr) {
+        if (retryErr instanceof WidgetWriteError) {
+          throw new Error(
+            `panel_set_widget refused "${widgetName}" on node ${node?.id} (${node?.type}) ` +
+              `after refreshing combo options: ${retryErr.message}`,
+          );
+        }
+        throw retryErr;
+      }
+    }
     if (err instanceof WidgetWriteError) {
       throw new Error(
         `panel_set_widget refused "${widgetName}" on node ${node?.id} (${node?.type}): ${err.message}`,

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -21,9 +21,15 @@
 //     is refused, not written blindly).
 
 export class WidgetWriteError extends Error {
-  constructor(message) {
+  constructor(message, { combo = false } = {}) {
     super(message);
     this.name = "WidgetWriteError";
+    // `combo` marks the failure as "combo value rejected against the current
+    // option list" (unreadable OR not-a-member). runSetWidget uses this as the
+    // ONLY signal that a stale-combo refresh + single revalidation may help —
+    // no other validation failure (numeric/boolean/promotion/stuck-check) is
+    // retryable, so those still fail closed immediately.
+    this.combo = combo;
   }
 }
 
@@ -80,6 +86,7 @@ export function coerceWidgetValue(widget, value) {
       throw new WidgetWriteError(
         `Combo widget "${name}" has no readable option list; cannot validate ` +
           `value ${JSON.stringify(value)} — refusing to write.`,
+        { combo: true },
       );
     }
     // STRICT typed membership: no numeric<->string coercion. Numeric options
@@ -91,6 +98,7 @@ export function coerceWidgetValue(widget, value) {
       `Value ${JSON.stringify(value)} is not a valid option for combo widget ` +
         `"${name}". Valid options (${options.length}): ${preview}` +
         (options.length > 40 ? ", …" : ""),
+      { combo: true },
     );
   }
 


### PR DESCRIPTION
## Problem

`panel_set_widget` rejected a COMBO value whenever the frontend node-def / combo option list was **stale** — a value that is genuinely valid on the connected ComfyUI server, but not yet in the cached dropdown:

- **#338** — downloaded model not in `LTXAVTextEncoderLoader.text_encoder`
- **#288** — uploaded image into an **empty** `LoadImage.image` combo (0 options)
- **#317 / #284** — `stage_output_as_input` file not in the live `LoadImage` combo
- **#299** — new ControlNet model not in `ControlNetLoader.control_net_name` (stale 3-item list vs server's 4)
- **#304** — LoRA that became available on disk still flagged missing

Root cause: the frontend combo option list is cached at page load and not refreshed after a mutation that adds a valid option, so the strict #240 membership check refuses a now-valid value.

## Fix

On a **COMBO rejection only**, `runSetWidget` pulls the **authoritative** option list from the connected server (`refreshComfyNodeDefs` → `/object_info` re-register + `refreshComboInNodes`, mutating `widget.options.values` in place) and revalidates **exactly once** against the **fresh** list.

Strictness preserved (keeps #240): the retry re-runs the same `applyWidgetWrite` membership check, so a genuinely-invalid value (still absent after refresh) is **still rejected**, and **no other failure class** (numeric / boolean / promotion / placeholder-guard / stuck-check) is ever retried.

- `WidgetWriteError` gains a `combo` flag; both combo throws (unreadable list + not-a-member) set it — the only retryable signal.
- `runSetWidget` is now async; the handler injects `refreshCombos: () => refreshComfyNodeDefs()`, and the executor dispatch already `await`s. Existing `node-resolve` e2e tests updated to `await` / `assert.rejects`.

## Tests

New `browser_tests/unit/set-widget-refresh.test.mjs`:
- stale-then-refreshed value **accepted** (#317/#284/#338/#288/#299)
- **genuinely-invalid value still rejected** after refresh (#240 strictness)
- non-combo failures never trigger a refresh; refresh attempted **at most once**

**6/7 fail before, 7/7 pass after.** Full suite: `node --test browser_tests/unit/*.mjs` → **446 pass, 0 fail**.

## Codex gate

**VERDICT: PASS** — "No invalid-combo acceptance path found ... a value still absent from the refreshed list is rejected without being written ... this change does not weaken #240's strict-membership guarantee."

No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Closes #338
Closes #317
Closes #299
Closes #288
Closes #284
Closes #304
