### PR TITLE
fix(screenshot): capture node bodies under the Vue node renderer + restore subgraph scope (#335, #329, #189, #237)

### DIFF
--- a/browser_tests/unit/screenshot-capture.test.mjs
+++ b/browser_tests/unit/screenshot-capture.test.mjs
@@ -1,0 +1,90 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isVueNodesEnabled,
+  computeFitTransform,
+  cssViewport,
+  scopeChanged,
+} from "../../web/js/lib/screenshot-capture.js";
+
+// ---- isVueNodesEnabled (#335/#329/#189 renderer detection) -----------------
+
+test("isVueNodesEnabled: true only when the setting is strictly true", () => {
+  assert.equal(isVueNodesEnabled((id) => (id === "Comfy.VueNodes.Enabled" ? true : undefined)), true);
+  assert.equal(isVueNodesEnabled(() => false), false);
+  assert.equal(isVueNodesEnabled(() => undefined), false);
+  // non-boolean truthy must not count (avoids false positives)
+  assert.equal(isVueNodesEnabled(() => "true"), false);
+  assert.equal(isVueNodesEnabled(() => 1), false);
+});
+
+test("isVueNodesEnabled: swallows a throwing/missing getter", () => {
+  assert.equal(isVueNodesEnabled(undefined), false);
+  assert.equal(isVueNodesEnabled(() => { throw new Error("no store"); }), false);
+});
+
+// ---- computeFitTransform (#335 CSS-vs-device-pixel framing) -----------------
+
+test("computeFitTransform: CSS-pixel viewport frames the whole graph (round-trip)", () => {
+  // A 1000x600 graph at origin, 60px pad, in an 800x600 CSS viewport.
+  const boundsX = 0, boundsY = 0, boundsW = 1000, boundsH = 600;
+  const viewCssW = 800, viewCssH = 600, pad = 60;
+  const { scale, offsetX, offsetY } = computeFitTransform({
+    boundsX, boundsY, boundsW, boundsH, viewCssW, viewCssH, pad,
+  });
+  // world -> screen: s = (world + offset) * scale
+  const leftPad = boundsX;
+  const screenLeft = (leftPad + offsetX) * scale;
+  const screenRight = (boundsX + boundsW + offsetX) * scale;
+  // padded content fits inside the viewport with >= pad*scale margin on the tight axis
+  assert.ok(screenLeft >= 0 - 1e-6, `left in view: ${screenLeft}`);
+  assert.ok(screenRight <= viewCssW + 1e-6, `right in view: ${screenRight}`);
+  const screenBottom = (boundsY + boundsH + offsetY) * scale;
+  assert.ok(screenBottom <= viewCssH + 1e-6, `bottom in view: ${screenBottom}`);
+});
+
+test("computeFitTransform: passing device pixels (DPR) would over-zoom vs CSS pixels", () => {
+  // The bug: fit computed against the backing store (CSS * dpr) yields a scale
+  // dpr-times too large. This test pins that the CSS-pixel path is dpr-invariant.
+  const base = { boundsX: 0, boundsY: 0, boundsW: 1000, boundsH: 600, pad: 60 };
+  const cssFit = computeFitTransform({ ...base, viewCssW: 800, viewCssH: 600 });
+  const deviceFit = computeFitTransform({ ...base, viewCssW: 1600, viewCssH: 1200 }); // dpr=2 backing store
+  // The old code used backing-store dims -> ~2x the correct scale.
+  assert.ok(deviceFit.scale > cssFit.scale * 1.9, "device-px scale is ~dpr larger");
+  assert.ok(Math.abs(deviceFit.scale - cssFit.scale * 2) < 1e-6, "exactly dpr larger");
+});
+
+test("computeFitTransform: clamps to maxScale for tiny graphs", () => {
+  const { scale } = computeFitTransform({
+    boundsX: 0, boundsY: 0, boundsW: 50, boundsH: 50, viewCssW: 800, viewCssH: 600, pad: 60, maxScale: 1.5,
+  });
+  assert.equal(scale, 1.5);
+});
+
+// ---- cssViewport ------------------------------------------------------------
+
+test("cssViewport: prefers clientWidth/clientHeight (true CSS px)", () => {
+  const cv = { clientWidth: 800, clientHeight: 600, width: 1600, height: 1200 };
+  assert.deepEqual(cssViewport(cv, 2), { viewCssW: 800, viewCssH: 600 });
+});
+
+test("cssViewport: falls back to backing store / dpr when client dims are 0", () => {
+  const cv = { clientWidth: 0, clientHeight: 0, width: 1600, height: 1200 };
+  assert.deepEqual(cssViewport(cv, 2), { viewCssW: 800, viewCssH: 600 });
+});
+
+// ---- scopeChanged (#237) ----------------------------------------------------
+
+test("scopeChanged: detects a switched graph reference", () => {
+  const root = { name: "root" }, sub = { name: "sub" };
+  assert.equal(scopeChanged(root, sub), true);
+  assert.equal(scopeChanged(root, root), false);
+});
+
+test("scopeChanged: false when either side is missing (nothing to restore)", () => {
+  const g = {};
+  assert.equal(scopeChanged(null, g), false);
+  assert.equal(scopeChanged(g, null), false);
+  assert.equal(scopeChanged(null, null), false);
+});

--- a/browser_tests/unit/screenshot-capture.test.mjs
+++ b/browser_tests/unit/screenshot-capture.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   isVueNodesEnabled,
+  vueNodesActive,
   computeFitTransform,
   cssViewport,
   scopeChanged,
@@ -22,6 +23,21 @@ test("isVueNodesEnabled: true only when the setting is strictly true", () => {
 test("isVueNodesEnabled: swallows a throwing/missing getter", () => {
   assert.equal(isVueNodesEnabled(undefined), false);
   assert.equal(isVueNodesEnabled(() => { throw new Error("no store"); }), false);
+});
+
+// ---- vueNodesActive (live-flag preference; #335 async-setter finding) -------
+
+test("vueNodesActive: prefers the live LiteGraph.vueNodesMode flag over the setting", () => {
+  // Live flag wins even when it disagrees with the persisted setting — this is
+  // the flag the synchronous draw path reads and the one we save/restore.
+  assert.equal(vueNodesActive(() => true, { vueNodesMode: false }), false);
+  assert.equal(vueNodesActive(() => false, { vueNodesMode: true }), true);
+});
+
+test("vueNodesActive: falls back to the setting when no LiteGraph flag is present", () => {
+  assert.equal(vueNodesActive(() => true, null), true);
+  assert.equal(vueNodesActive(() => false, {}), false); // flag absent -> setting
+  assert.equal(vueNodesActive(() => true, undefined), true);
 });
 
 // ---- computeFitTransform (#335 CSS-vs-device-pixel framing) -----------------

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -112,7 +112,7 @@ import {
 } from "./lib/paste-report.js";
 import { createMediaRecorder } from "./lib/chat-media.js";
 import {
-  isVueNodesEnabled,
+  vueNodesActive,
   computeFitTransform,
   cssViewport,
   scopeChanged,
@@ -6701,7 +6701,7 @@ const GRAPH_TOOL_EXECUTORS = {
         "Blind mode is ON: screenshots are withheld from the agent. Ask the user to describe the canvas, or to turn Blind off.",
       );
     }
-    const { app, graph, canvas } = getGraphCtx();
+    const { app, graph, canvas, LG } = getGraphCtx();
     const cv = canvas?.canvas;
     const ds = canvas?.ds;
     if (!cv || typeof cv.toDataURL !== "function" || !ds) {
@@ -6751,16 +6751,21 @@ const GRAPH_TOOL_EXECUTORS = {
     const saved = { scale: ds.scale, ox: ds.offset[0], oy: ds.offset[1] };
     // Under the Vue node renderer, node bodies are DOM/Vue elements layered over
     // the canvas, so cv.toDataURL() would miss them (#335/#329/#189). Force the
-    // classic LiteGraph paint path (which draws node bodies on the 2D canvas) for
-    // the duration of the capture, then restore the user's setting.
-    const vueNodes = isVueNodesEnabled((id) => getSetting(id));
+    // classic LiteGraph paint path for the duration of the capture by flipping
+    // the LIVE LiteGraph flag (LiteGraph.vueNodesMode) — the one the canvas draw
+    // path reads synchronously. Toggling the Comfy.VueNodes.Enabled *setting*
+    // instead is async (batched Vue watcher) and would not take effect before the
+    // synchronous canvas.draw() below.
+    const vueNodes = vueNodesActive((id) => getSetting(id), LG);
+    const canForceVue = !!LG && typeof LG.vueNodesMode === "boolean";
+    const savedVueMode = canForceVue ? LG.vueNodesMode : undefined;
     let vueToggled = false;
     let dataUrl;
     let outW = cv.width;
     let outH = cv.height;
     try {
-      if (vueNodes) {
-        setSetting("Comfy.VueNodes.Enabled", false);
+      if (vueNodes && canForceVue) {
+        LG.vueNodesMode = false;
         vueToggled = true;
       }
       // ds.scale/ds.offset are CSS pixels — fit against CSS-pixel viewport dims,
@@ -6795,7 +6800,7 @@ const GRAPH_TOOL_EXECUTORS = {
         dataUrl = cv.toDataURL("image/png");
       }
     } finally {
-      if (vueToggled) setSetting("Comfy.VueNodes.Enabled", true);
+      if (vueToggled) LG.vueNodesMode = savedVueMode;
       ds.scale = saved.scale;
       ds.offset[0] = saved.ox;
       ds.offset[1] = saved.oy;
@@ -6818,7 +6823,9 @@ const GRAPH_TOOL_EXECUTORS = {
       mimeType: "image/png",
       width: outW,
       height: outH,
-      renderer: vueNodes ? "vue-nodes (forced litegraph paint for capture)" : "litegraph",
+      renderer: vueNodes
+        ? (vueToggled ? "vue-nodes (forced litegraph paint for capture)" : "vue-nodes (could not force litegraph paint)")
+        : "litegraph",
       viewing: describeActiveGraph(app?.canvas?.graph ?? graph),
     };
   },

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -112,6 +112,12 @@ import {
 } from "./lib/paste-report.js";
 import { createMediaRecorder } from "./lib/chat-media.js";
 import {
+  isVueNodesEnabled,
+  computeFitTransform,
+  cssViewport,
+  scopeChanged,
+} from "./lib/screenshot-capture.js";
+import {
   nodeFocusBounds,
   boundsAroundNodes,
   groupMemberNodes,
@@ -6695,12 +6701,16 @@ const GRAPH_TOOL_EXECUTORS = {
         "Blind mode is ON: screenshots are withheld from the agent. Ask the user to describe the canvas, or to turn Blind off.",
       );
     }
-    const { graph, canvas } = getGraphCtx();
+    const { app, graph, canvas } = getGraphCtx();
     const cv = canvas?.canvas;
     const ds = canvas?.ds;
     if (!cv || typeof cv.toDataURL !== "function" || !ds) {
       throw new Error("canvas not available for screenshot");
     }
+    // #237: remember the viewing scope (root vs an opened subgraph) so the
+    // capture can't leave graph tools pointed at a different graph than where
+    // they started.
+    const scopeGraph = app?.canvas?.graph ?? graph;
     const nodes = graph._nodes ?? [];
     const groups = graph._groups ?? [];
     if (!nodes.length && !groups.length) throw new Error("nothing to screenshot (empty graph)");
@@ -6739,16 +6749,37 @@ const GRAPH_TOOL_EXECUTORS = {
     const bounds = [minX, minY, maxX - minX, maxY - minY];
     const pad = Number.isFinite(padding) ? Number(padding) : 60;
     const saved = { scale: ds.scale, ox: ds.offset[0], oy: ds.offset[1] };
+    // Under the Vue node renderer, node bodies are DOM/Vue elements layered over
+    // the canvas, so cv.toDataURL() would miss them (#335/#329/#189). Force the
+    // classic LiteGraph paint path (which draws node bodies on the 2D canvas) for
+    // the duration of the capture, then restore the user's setting.
+    const vueNodes = isVueNodesEnabled((id) => getSetting(id));
+    let vueToggled = false;
     let dataUrl;
     let outW = cv.width;
     let outH = cv.height;
     try {
-      const w = bounds[2] + pad * 2;
-      const h = bounds[3] + pad * 2;
-      const next = Math.min(cv.width / w, cv.height / h, 1.5);
-      ds.scale = next;
-      ds.offset[0] = -bounds[0] + pad + (cv.width / next - w) / 2;
-      ds.offset[1] = -bounds[1] + pad + (cv.height / next - h) / 2;
+      if (vueNodes) {
+        setSetting("Comfy.VueNodes.Enabled", false);
+        vueToggled = true;
+      }
+      // ds.scale/ds.offset are CSS pixels — fit against CSS-pixel viewport dims,
+      // NOT the DPR-scaled backing store cv.width/cv.height (#335 framing bug).
+      const { viewCssW, viewCssH } = cssViewport(cv);
+      const fit = computeFitTransform({
+        boundsX: bounds[0],
+        boundsY: bounds[1],
+        boundsW: bounds[2],
+        boundsH: bounds[3],
+        viewCssW,
+        viewCssH,
+        pad,
+        maxScale: 1.5,
+      });
+      ds.scale = fit.scale;
+      ds.offset[0] = fit.offsetX;
+      ds.offset[1] = fit.offsetY;
+      canvas.setDirty?.(true, true);
       canvas.draw(true, true); // synchronous redraw at the fitted transform
       const MAXW = 1600;
       if (cv.width > MAXW) {
@@ -6764,9 +6795,20 @@ const GRAPH_TOOL_EXECUTORS = {
         dataUrl = cv.toDataURL("image/png");
       }
     } finally {
+      if (vueToggled) setSetting("Comfy.VueNodes.Enabled", true);
       ds.scale = saved.scale;
       ds.offset[0] = saved.ox;
       ds.offset[1] = saved.oy;
+      // #237: if anything switched the active graph during capture, put it back
+      // so subsequent graph tools stay in the scope the caller was in.
+      const nowGraph = app?.canvas?.graph ?? null;
+      if (scopeChanged(scopeGraph, nowGraph) && typeof app?.canvas?.setGraph === "function") {
+        try {
+          app.canvas.setGraph(scopeGraph);
+        } catch {
+          // best-effort — restore of scale/offset below still runs
+        }
+      }
       canvas.setDirty?.(true, true);
       canvas.draw?.(true, true);
     }
@@ -6776,7 +6818,8 @@ const GRAPH_TOOL_EXECUTORS = {
       mimeType: "image/png",
       width: outW,
       height: outH,
-      viewing: describeActiveGraph(graph),
+      renderer: vueNodes ? "vue-nodes (forced litegraph paint for capture)" : "litegraph",
+      viewing: describeActiveGraph(app?.canvas?.graph ?? graph),
     };
   },
 

--- a/web/js/lib/screenshot-capture.js
+++ b/web/js/lib/screenshot-capture.js
@@ -1,0 +1,69 @@
+// Pure helpers for graph_screenshot — kept side-effect-free so they can be
+// unit-tested headlessly (the actual canvas capture / DOM composite cannot be).
+//
+// Covers three defects in the screenshot capture path:
+//  - #335/#329/#189: under ComfyUI's Vue-based node renderer
+//    (`Comfy.VueNodes.Enabled`) node bodies are DOM/Vue elements layered OVER
+//    the LiteGraph canvas, so a raw `canvas.toDataURL()` serializes only what
+//    LiteGraph still paints (groups, link splines, HUD) — every node body is
+//    missing. Detect the renderer so the capture path can force the LiteGraph
+//    paint path before capturing.
+//  - #335 (framing): ds.scale/ds.offset operate in CSS pixels, but the fit math
+//    used the canvas backing-store dims (cv.width === cssPx * devicePixelRatio),
+//    zooming the graph by DPR and clipping it on HiDPI displays.
+//  - #237: the capture must not leave graph tools scoped to a different
+//    (sub)graph than where they started.
+
+/** Whether ComfyUI's Vue-based node renderer is active. When true, node bodies
+ *  are NOT painted on the LiteGraph 2D canvas, so a raw canvas capture misses
+ *  them. `getSettingValue` is `app.ui.settings.getSettingValue` (or any
+ *  id → value getter). Defaults to false on any error / missing store. */
+export function isVueNodesEnabled(getSettingValue) {
+  try {
+    return getSettingValue?.("Comfy.VueNodes.Enabled") === true;
+  } catch {
+    return false;
+  }
+}
+
+/** Fit transform for framing the whole graph within the viewport.
+ *
+ *  ds.scale / ds.offset are in CSS pixels (LGraphCanvas scales the 2D context by
+ *  devicePixelRatio), so the viewport dims passed here MUST be CSS pixels
+ *  (cv.clientWidth/clientHeight, or cv.width / devicePixelRatio) — NOT the
+ *  backing-store cv.width/cv.height, which are DPR times larger.
+ *
+ *  Returns { scale, offsetX, offsetY } to assign to ds.scale / ds.offset. */
+export function computeFitTransform({
+  boundsX,
+  boundsY,
+  boundsW,
+  boundsH,
+  viewCssW,
+  viewCssH,
+  pad = 60,
+  maxScale = 1.5,
+}) {
+  const w = boundsW + pad * 2;
+  const h = boundsH + pad * 2;
+  const scale = Math.min(viewCssW / w, viewCssH / h, maxScale);
+  const offsetX = -boundsX + pad + (viewCssW / scale - w) / 2;
+  const offsetY = -boundsY + pad + (viewCssH / scale - h) / 2;
+  return { scale, offsetX, offsetY };
+}
+
+/** CSS-pixel viewport dims for a canvas element, preferring the laid-out
+ *  clientWidth/clientHeight and falling back to backing-store / devicePixelRatio.
+ *  `dpr` is injected for testability (default reads the global). */
+export function cssViewport(cv, dpr = (typeof window !== "undefined" ? window.devicePixelRatio : 1) || 1) {
+  const w = cv?.clientWidth || (cv?.width || 0) / dpr;
+  const h = cv?.clientHeight || (cv?.height || 0) / dpr;
+  return { viewCssW: w, viewCssH: h };
+}
+
+/** True when the active viewing scope changed during the capture and must be
+ *  restored (#237). Compares graph references — a changed reference means graph
+ *  tools would otherwise be left pointed at the wrong (sub)graph. */
+export function scopeChanged(beforeGraph, afterGraph) {
+  return !!beforeGraph && !!afterGraph && beforeGraph !== afterGraph;
+}

--- a/web/js/lib/screenshot-capture.js
+++ b/web/js/lib/screenshot-capture.js
@@ -26,6 +26,24 @@ export function isVueNodesEnabled(getSettingValue) {
   }
 }
 
+/** Whether the Vue node renderer is actually painting *right now*. Prefers the
+ *  live LiteGraph flag (`LiteGraph.vueNodesMode`), which the canvas draw path
+ *  reads synchronously, and falls back to the persisted setting when the flag is
+ *  absent.
+ *
+ *  This is the flag to save/restore DIRECTLY around a capture: toggling the
+ *  *setting* (`Comfy.VueNodes.Enabled`) is async — ComfyUI's compat setter kicks
+ *  off a store update and the renderer switches through a batched Vue watcher, so
+ *  a synchronous false→draw→true sequence coalesces and never actually forces the
+ *  LiteGraph paint path. Setting `LiteGraph.vueNodesMode = false` takes effect on
+ *  the very next `canvas.draw()`. */
+export function vueNodesActive(getSettingValue, litegraph) {
+  if (litegraph && typeof litegraph.vueNodesMode === "boolean") {
+    return litegraph.vueNodesMode === true;
+  }
+  return isVueNodesEnabled(getSettingValue);
+}
+
 /** Fit transform for framing the whole graph within the viewport.
  *
  *  ds.scale / ds.offset are in CSS pixels (LGraphCanvas scales the 2D context by


### PR DESCRIPTION
## Problem
`graph_screenshot` (`panel_screenshot`) returned PNGs showing link wires, group
boxes and the debug HUD but **zero node bodies** (#335, #329, #189). Root cause:
under ComfyUI's Vue node renderer (`Comfy.VueNodes.Enabled`, default-on) node
bodies are DOM/Vue elements layered **over** the LiteGraph canvas, so
`cv.toDataURL()` only serializes what LiteGraph itself still paints on the 2D
canvas. The capture looked "successful" (HUD reported the true node count) while
being actively misleading.

Secondary defects:
- **Framing (#335):** the fit math used the DPR-scaled backing store
  (`cv.width`/`cv.height`) while `ds.scale`/`ds.offset` are **CSS pixels**, so on
  HiDPI the graph was zoomed `devicePixelRatio`× too far and clipped.
- **Scope (#237):** the capture could leave graph tools scoped to a different
  (sub)graph than where the caller started, breaking subsequent root-node edits.

## Fix
- Detect the Vue node renderer and temporarily force the classic LiteGraph paint
  path for the capture (so node bodies are painted on the 2D canvas), restoring
  the user's setting in `finally`.
- Compute the fit against **CSS-pixel** viewport dims (`clientWidth`/
  `clientHeight`, with a `width / devicePixelRatio` fallback).
- Save the active graph before capture and restore it in `finally` if anything
  switched scope (#237).
- Extract renderer-detection / fit-math / scope helpers to a pure, side-effect-
  free `web/js/lib/screenshot-capture.js` with headless unit tests.

## Tests
`browser_tests/unit/screenshot-capture.test.mjs` — renderer detection (strict
`true` only), CSS-vs-device-pixel fit invariance, `maxScale` clamp, CSS viewport
fallback, and scope-change detection. `node --test browser_tests/unit/*.mjs` →
**448 pass**. ESM-verified.

## Live verification still needed
The actual canvas/DOM capture can't be exercised headlessly. Whether forcing
`Comfy.VueNodes.Enabled=false` makes the very next synchronous `canvas.draw()`
paint node bodies within the same call must be confirmed with a live screenshot
on the rig post-merge. The pure fit/scope/detection logic is unit-covered.

No version bump.

Closes #335 #329 #189 #237

## Codex review
**VERDICT: PASS** (gpt-5.6, OpenAI acct) — no findings on the final revision.

First pass flagged (High) that toggling the `Comfy.VueNodes.Enabled` *setting* synchronously is ineffective (async compat setter + batched Vue watcher), so `canvas.draw()` still skipped node bodies. Fixed by saving/restoring the live `LiteGraph.vueNodesMode` flag directly (the flag the draw path reads synchronously). Re-review: "Cleanup ordering is sound; CSS-pixel fitting and subgraph reference restoration are also correct. VERDICT: PASS."
