### PR TITLE
release: 0.11.18 — screenshot/Vue + get_errors scope + stale-combo refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.18] - 2026-07-30
+
+### Fixed
+- **`graph_screenshot` captures node bodies under ComfyUI's Vue node renderer (#335, #329, #189, #237).** With `Comfy.VueNodes.Enabled` (default-on) node bodies are DOM/Vue elements layered over the LiteGraph canvas, so `toDataURL()` captured only the LiteGraph-painted wires/groups/HUD — screenshots showed zero nodes. Capture now forces the classic LiteGraph paint path by saving/restoring the live `LiteGraph.vueNodesMode` flag (not the async `Comfy.VueNodes.Enabled` setting), fits against CSS-pixel viewport dims, and saves/restores the active subgraph scope in a `finally` (#237). Live-verified on the rig with Vue nodes active: painted node-body pixels rose ~10× (0.34% → 3.52%) with the toggle, and `vueNodesMode` is restored after. (#341)
+- **`panel_get_errors` no longer leaks stale missing-assets from another workflow tab (#316).** A missing-asset candidate whose recognized locator resolves to no node in the ACTIVE graph is now dropped, scoping errors to the currently-active workflow; unparseable/ambiguous locators still fail open so a genuine miss is never swallowed. (Widget-edit/appeared-on-disk staleness was already handled by the shipped #260 live recompute.) (#339)
+- **`panel_set_widget` refreshes stale combo options before validating (#338, #317, #299, #288, #284, #304).** A just-downloaded model / uploaded image / staged output / freshly-installed pack value was refused against the frontend's cached combo list. On a combo rejection only, `set_widget` now awaits an authoritative `/object_info` re-register and revalidates exactly once against the fresh options — a genuinely-invalid value is still rejected (the #240 strictness is preserved). (#340)
+
 ## [0.11.17] - 2026-07-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.17"
+version = "0.11.18"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -236,7 +236,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.17";
+const PANEL_VERSION = "0.11.18";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Cuts panel **0.11.18**. Bumps `pyproject.toml` + `PANEL_VERSION` together (Registry publish on the pyproject change to main).

## Ships (3 merged draft-PR clusters)
- **#335/#329/#189/#237 (#341):** `graph_screenshot` captures node bodies under the Vue node renderer (toggles `LiteGraph.vueNodesMode` for classic paint) + restores subgraph scope. **Live-verified on rig** (node-body pixels 0.34%→3.52%).
- **#316 (#339):** `panel_get_errors` no longer leaks stale missing-assets from another workflow tab (scope to active graph; fail-open preserved).
- **#338/#317/#299/#288/#284/#304 (#340):** `panel_set_widget` refreshes stale combo options before validating; #240 strict rejection preserved.

All three codex PASS + unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)