### PR TITLE
fix(run-complete): fire completion on authoritative prompt_id lifecycle, full batch, correct duration + reliable resume (#293, #224, #200, #269, #468)

### DIFF
--- a/browser_tests/unit/run-completion.test.mjs
+++ b/browser_tests/unit/run-completion.test.mjs
@@ -264,7 +264,7 @@ test("execution_error drops the buffer — no stale batch delivered", () => {
   h.tracker.onExecutionStart(P);
   h.tracker.onExecutingNode(P, "x");
   h.tracker.onExecuted(P, imgs([img("half.png")]));
-  h.tracker.onExecutionError(P);
+  h.tracker.onExecutionFailed(P);
   h.tracker.onExecutingNull();
   h.tick(10000);
   assert.equal(h.flushes.length, 0, "failed run delivers no completion batch");

--- a/browser_tests/unit/run-completion.test.mjs
+++ b/browser_tests/unit/run-completion.test.mjs
@@ -17,6 +17,7 @@ import {
   createRunCompletionTracker,
   NO_PROMPT_KEY,
 } from "../../web/js/lib/run-completion.js";
+import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame.js";
 
 /** Deterministic scheduler: timers are held until tick() fires the due ones. */
 function makeHarness({ debounceMs = 1500, maxRearms = 40 } = {}) {
@@ -286,4 +287,150 @@ test("execution_success + executing:null ordering yields exactly one event", () 
   h.tracker.onExecutionSuccess(P); // flushes + clears
   h.tracker.onExecutingNull(); // buffer already gone → no-op
   assert.equal(h.flushes.length, 1, "no double delivery across the two end signals");
+});
+
+// ── Presentation layer: ONE combined agent_event per completed prompt ────────
+// The tracker delivers ONE flush per prompt (asserted above). composeRunCompletionFrame
+// (web/js/lib/run-completion-frame.js) turns that flush into the SINGLE outbound
+// agent_event. This guards the #269/#468 blocker: a mixed / multi-video run must
+// emit EXACTLY ONE completion frame carrying stills AND every video's storyboard,
+// never a stills frame plus one frame per video.
+
+/** Fake presentation deps — every I/O helper is deterministic and side-effect free. */
+function makeFrameDeps(overrides = {}) {
+  const frames = [];
+  const painted = [];
+  const deps = {
+    sendFrame: (f) => frames.push(f),
+    coerceMessageText: (v) => (v == null ? "" : typeof v === "string" ? v : String(v)),
+    formatDuration: (ms) => (ms == null ? null : `${Math.round(ms / 1000)}s`),
+    formatClock: () => "12:00:00",
+    imageViewUrl: (m) => `view://${m?.filename ?? "x"}`,
+    fetchImageBytes: async () => 2048,
+    fetchImageDimensions: async () => ({ w: 512, h: 512 }),
+    humanizeBytes: (n) => (n == null ? null : `${n} B`),
+    buildVideoStoryboard: async () => ({ fake: "blob" }),
+    uploadBlobToInput: async (_blob, name) => ({ filename: name, type: "input" }),
+    storyboardFrameCount: () => 20,
+    paintImage: (url, name) => painted.push({ url, name }),
+    videoStoryboardEnabled: true,
+    warn: () => {},
+    ...overrides,
+  };
+  return { deps, frames, painted };
+}
+
+test("#269/#468 presentation: a MIXED run (stills + 2 videos) emits EXACTLY ONE agent_event with all outputs", async () => {
+  const { deps, frames } = makeFrameDeps();
+  const P = "prompt-mixed-multi";
+  const frame = await composeRunCompletionFrame(
+    {
+      promptId: P,
+      images: [{ filename: "final.png", type: "output" }],
+      videos: [
+        { m: { filename: "v1.mp4", type: "output" }, nodeId: "7" },
+        { m: { filename: "v2.mp4", type: "output" }, nodeId: "9" },
+      ],
+      durationMs: 42000,
+    },
+    deps,
+  );
+  // The whole point: ONE send, not 1 stills + 1 per video (which was 3 before).
+  assert.equal(frames.length, 1, "exactly one completion agent_event for the whole run");
+  assert.equal(frames[0], frame, "returned frame is the one that was sent");
+  assert.equal(frames[0].type, "agent_event");
+  assert.equal(frames[0].kind, "executed");
+  assert.equal(frames[0].prompt_id, P, "attributed to the finishing prompt");
+  // All outputs ride in the single frame: the still + both storyboard refs.
+  const names = frames[0].images.map((m) => m.filename);
+  assert.deepEqual(
+    names,
+    ["final.png", "storyboard_v1.png", "storyboard_v2.png"],
+    "one still + BOTH video storyboards consolidated into the single images array",
+  );
+  // The note mentions the still result and both videos in one turn.
+  assert.match(frames[0].note, /final\.png/, "note names the still output");
+  assert.match(frames[0].note, /v1\.mp4/, "note names the first video");
+  assert.match(frames[0].note, /v2\.mp4/, "note names the second video");
+});
+
+test("presentation: a still-storyboard fallback (no blob) still yields ONE frame with the note", async () => {
+  const { deps, frames } = makeFrameDeps({ buildVideoStoryboard: async () => null });
+  const frame = await composeRunCompletionFrame(
+    {
+      promptId: "p-fallback",
+      images: [{ filename: "s.png", type: "output" }],
+      videos: [
+        { m: { filename: "a.mp4", type: "output" }, nodeId: "1" },
+        { m: { filename: "b.mp4", type: "output" }, nodeId: "2" },
+      ],
+      durationMs: 10000,
+    },
+    deps,
+  );
+  assert.equal(frames.length, 1, "still exactly one frame when storyboards fall back to note-only");
+  // Only the still image rides along (no storyboard refs were produced).
+  assert.deepEqual(frame.images.map((m) => m.filename), ["s.png"]);
+  assert.match(frame.note, /a\.mp4/);
+  assert.match(frame.note, /b\.mp4/);
+});
+
+test("presentation: a video-only run (2 videos) is still ONE frame", async () => {
+  const { deps, frames } = makeFrameDeps();
+  await composeRunCompletionFrame(
+    {
+      promptId: "p-video2",
+      images: [],
+      videos: [
+        { m: { filename: "x.mp4", type: "output" }, nodeId: "1" },
+        { m: { filename: "y.mp4", type: "output" }, nodeId: "2" },
+      ],
+      durationMs: 120000,
+    },
+    deps,
+  );
+  assert.equal(frames.length, 1, "two videos, one completion frame");
+  assert.deepEqual(
+    frames[0].images.map((m) => m.filename),
+    ["storyboard_x.png", "storyboard_y.png"],
+    "both storyboards in the single frame",
+  );
+});
+
+test("presentation: an empty batch emits NO frame", async () => {
+  const { deps, frames } = makeFrameDeps();
+  const frame = await composeRunCompletionFrame(
+    { promptId: "p-empty", images: [], videos: [], durationMs: 1000 },
+    deps,
+  );
+  assert.equal(frame, null);
+  assert.equal(frames.length, 0);
+});
+
+test("presentation: a STALLED storyboard upload still yields ONE frame (never wedges the completion)", async () => {
+  // Regression for the consolidation risk: because the single frame awaits every
+  // video segment, an unbounded upload must NOT be able to suppress the frame.
+  // A very short REAL timeout bounds the never-settling upload deterministically.
+  const { deps, frames } = makeFrameDeps({
+    uploadBlobToInput: () => new Promise(() => {}), // never settles
+    videoStoryboardTimeoutMs: 5,
+  });
+  const frame = await composeRunCompletionFrame(
+    {
+      promptId: "p-stall",
+      images: [{ filename: "s.png", type: "output" }],
+      videos: [
+        { m: { filename: "a.mp4", type: "output" }, nodeId: "1" },
+        { m: { filename: "b.mp4", type: "output" }, nodeId: "2" },
+      ],
+      durationMs: 5000,
+    },
+    deps,
+  );
+  assert.equal(frames.length, 1, "the single completion frame is sent despite the stalled upload");
+  assert.equal(frame.images.length, 1, "only the still rides along (storyboards timed out)");
+  assert.equal(frame.images[0].filename, "s.png");
+  assert.match(frame.note, /timed out/, "each stalled video degrades to a note-only fallback");
+  assert.match(frame.note, /a\.mp4/);
+  assert.match(frame.note, /b\.mp4/);
 });

--- a/browser_tests/unit/run-completion.test.mjs
+++ b/browser_tests/unit/run-completion.test.mjs
@@ -156,13 +156,29 @@ test("#224 missing prompt_id: back-to-back id-less runs do NOT merge", () => {
   assert.equal(h.flushes[0].key, NO_PROMPT_KEY);
   assert.deepEqual(h.flushes[0].images.map((m) => m.filename), ["run_a.png"]);
   h.tracker.onExecuted(undefined, imgs([img("run_b.png")]));
-  h.tracker.onExecutingNull(); // queue idle ends run B
+  h.tracker.onExecutionSuccess(undefined); // authoritative end of run B
   assert.equal(h.flushes.length, 2);
   assert.deepEqual(
     h.flushes[1].images.map((m) => m.filename),
     ["run_b.png"],
     "run B is its own batch — outputs never merged with run A",
   );
+});
+
+test("#200/#224: a spurious executing:null mid-run does NOT flush an active run", () => {
+  const h = makeHarness();
+  const P = "prompt-spurious-null";
+  h.tracker.onExecutionStart(P);
+  h.tracker.onExecutingNode(P, "canny");
+  h.tracker.onExecuted(P, imgs([img("preview.png", "temp")]));
+  // A stray null arrives while the KSampler is still running — must be ignored:
+  // the prompt is active, so no early/partial completion.
+  h.tracker.onExecutingNull();
+  assert.equal(h.flushes.length, 0, "active run untouched by a spurious null");
+  h.tracker.onExecuted(P, imgs([img("final.png")]));
+  h.tracker.onExecutionSuccess(P);
+  assert.equal(h.flushes.length, 1, "single complete event on the authoritative end");
+  assert.deepEqual(h.flushes[0].images.map((m) => m.filename), ["preview.png", "final.png"]);
 });
 
 test("missed execution_start: executing(node) keeps the timer from early-flushing", () => {

--- a/browser_tests/unit/run-completion.test.mjs
+++ b/browser_tests/unit/run-completion.test.mjs
@@ -3,19 +3,23 @@
  *
  * Guards the run-completion cluster (#293, #224, #200, #269, #468): completion
  * must fire on the AUTHORITATIVE ComfyUI lifecycle for the CURRENT prompt_id,
- * carry the FULL output batch with the correct start→finish duration, and never
- * flush a partial batch or a previous prompt's outputs.
+ * carry the FULL output batch (stills AND videos) with the correct start→finish
+ * duration and machine-readable attribution, and NEVER flush a partial batch, a
+ * previous prompt's outputs, or an active (still-running) run.
  *
- * A fake clock + fake timer queue lets us drive the debounce deterministically:
- * pending timers only fire when we explicitly `tick()`.
+ * A fake clock + fake timer queue drives the debounce deterministically: pending
+ * timers only fire when we explicitly `tick()`.
  */
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { createRunCompletionTracker } from "../../web/js/lib/run-completion.js";
+import {
+  createRunCompletionTracker,
+  NO_PROMPT_KEY,
+} from "../../web/js/lib/run-completion.js";
 
 /** Deterministic scheduler: timers are held until tick() fires the due ones. */
-function makeHarness({ debounceMs = 1500, maxRearms = 600 } = {}) {
+function makeHarness({ debounceMs = 1500, maxRearms = 40 } = {}) {
   let clock = 0;
   let seq = 0;
   const timers = new Map(); // id -> { at, fn }
@@ -32,15 +36,23 @@ function makeHarness({ debounceMs = 1500, maxRearms = 600 } = {}) {
     debounceMs,
     maxRearms,
   });
-  // Advance the clock by ms and fire every timer that comes due (re-armed timers
-  // scheduled during the tick fire on later ticks, matching real setTimeout).
+  // Advance the clock and fire every timer that comes due (re-armed timers
+  // scheduled during a tick fire in the same tick, matching real setTimeout with
+  // a 0-progress clock — the loop drains until no timer is due).
   const tick = (ms) => {
     clock += ms;
-    for (const [id, t] of [...timers]) {
-      if (t.at <= clock) {
-        timers.delete(id);
-        t.fn();
+    let guard = 0;
+    let fired = true;
+    while (fired) {
+      fired = false;
+      for (const [id, t] of [...timers]) {
+        if (t.at <= clock) {
+          timers.delete(id);
+          fired = true;
+          t.fn();
+        }
       }
+      if (++guard > 100000) throw new Error("timer loop runaway");
     }
   };
   const advance = (ms) => {
@@ -50,17 +62,19 @@ function makeHarness({ debounceMs = 1500, maxRearms = 600 } = {}) {
 }
 
 const img = (name, type = "output") => ({ filename: name, type });
+const imgs = (list) => ({ images: list });
 
 test("#293: two output nodes >1.5s apart yield ONE complete event, not an early partial flush", () => {
   const h = makeHarness();
   const P = "prompt-A";
   h.tracker.onExecutionStart(P); // t=0
-  h.tracker.onExecuted(P, [img("preview_5.png", "temp"), img("preview_6.png", "temp")]);
+  h.tracker.onExecutingNode(P, "5");
+  h.tracker.onExecuted(P, imgs([img("preview_5.png", "temp"), img("preview_6.png", "temp")]));
   // 20s pass while the KSampler runs — the debounce would have flushed a partial
-  // batch at 1.5s under the old behaviour. It must NOT, because P is still active.
+  // batch at 1.5s under the old behaviour. It must NOT: P is active.
   h.tick(20000);
   assert.equal(h.flushes.length, 0, "no partial flush while prompt is in-flight");
-  h.tracker.onExecuted(P, [img("final_15.png"), img("final_17.png")]);
+  h.tracker.onExecuted(P, imgs([img("final_15.png"), img("final_17.png")]));
   h.tracker.onExecutionSuccess(P); // authoritative run-end
   assert.equal(h.flushes.length, 1, "exactly one consolidated completion event");
   const f = h.flushes[0];
@@ -70,17 +84,35 @@ test("#293: two output nodes >1.5s apart yield ONE complete event, not an early 
     "full batch — all four outputs, not just the fast preview branch",
   );
   assert.equal(f.durationMs, 20000, "duration measured start→finish, not to the early flush");
+  assert.equal(f.promptId, P, "attributed to the correct prompt_id");
+});
+
+test("#293 long run: an active run far past the re-arm cap is never flushed partially", () => {
+  const h = makeHarness({ debounceMs: 1500, maxRearms: 5 });
+  const P = "prompt-long";
+  h.tracker.onExecutionStart(P);
+  h.tracker.onExecutingNode(P, "sampler");
+  h.tracker.onExecuted(P, imgs([img("preview.png", "temp")]));
+  // 30 minutes elapse — well past the re-arm churn cap. Still no flush: active.
+  h.tick(30 * 60 * 1000);
+  assert.equal(h.flushes.length, 0, "no partial flush for a legitimately long run");
+  h.tracker.onExecuted(P, imgs([img("final.png")]));
+  h.tracker.onExecutionSuccess(P);
+  assert.equal(h.flushes.length, 1);
+  assert.deepEqual(h.flushes[0].images.map((m) => m.filename), ["preview.png", "final.png"]);
+  assert.equal(h.flushes[0].durationMs, 30 * 60 * 1000, "full run duration");
 });
 
 test("#200: idle executing:null never truncates a mid-flight run", () => {
   const h = makeHarness();
   const P = "prompt-B";
   h.tracker.onExecutionStart(P);
-  h.tracker.onExecuted(P, [img("canny_preview.png", "temp")]);
-  // A spurious idle signal arrives while SaveImage is still seconds from writing.
-  h.tracker.onExecutingNull();
-  assert.equal(h.flushes.length, 0, "active prompt is not flushed by idle signal");
-  h.tracker.onExecuted(P, [img("ComfyUI_00667_.png")]);
+  h.tracker.onExecutingNode(P, "canny");
+  h.tracker.onExecuted(P, imgs([img("canny_preview.png", "temp")]));
+  // The old code flushed a partial here; the timer must not either.
+  h.tick(5000);
+  assert.equal(h.flushes.length, 0);
+  h.tracker.onExecuted(P, imgs([img("ComfyUI_00667_.png")]));
   h.tracker.onExecutionSuccess(P);
   assert.equal(h.flushes.length, 1);
   assert.deepEqual(
@@ -95,16 +127,17 @@ test("#224: a new prompt does not inherit the prior run's buffered outputs", () 
   const A = "prompt-prev";
   const B = "prompt-new";
   h.tracker.onExecutionStart(A);
-  h.tracker.onExecuted(A, [img("pelirroja_00002_.png")]);
-  // Prior run's execution_success is missed (the failure conditions in #224).
-  // The NEW run starting must flush A's buffer as A (its own), never carry it in.
+  h.tracker.onExecutingNode(A, "save");
+  h.tracker.onExecuted(A, imgs([img("pelirroja_00002_.png")]));
+  // Prior run's execution_success is MISSED (the #224 conditions). The NEW run
+  // starting must flush A's buffer as A (its own), never carry it into B.
   h.tracker.onExecutionStart(B);
   assert.equal(h.flushes.length, 1, "prior buffer flushed at new-run start");
-  assert.equal(h.flushes[0].key, A, "attributed to the prior prompt, not the new one");
-  h.tracker.onExecuted(B, [img("maria_pelirroja_00001_.png")]);
+  assert.equal(h.flushes[0].promptId, A, "attributed to the prior prompt, not the new one");
+  h.tracker.onExecuted(B, imgs([img("maria_pelirroja_00001_.png")]));
   h.tracker.onExecutionSuccess(B);
   assert.equal(h.flushes.length, 2);
-  assert.equal(h.flushes[1].key, B);
+  assert.equal(h.flushes[1].promptId, B);
   assert.deepEqual(
     h.flushes[1].images.map((m) => m.filename),
     ["maria_pelirroja_00001_.png"],
@@ -112,26 +145,94 @@ test("#224: a new prompt does not inherit the prior run's buffered outputs", () 
   );
 });
 
+test("#224 missing prompt_id: back-to-back id-less runs do NOT merge", () => {
+  const h = makeHarness();
+  // Legacy/id-less: everything lands in __no_prompt__. A new run starting must
+  // flush the prior __no_prompt__ buffer first so the two runs stay separate.
+  h.tracker.onExecutionStart(undefined);
+  h.tracker.onExecuted(undefined, imgs([img("run_a.png")]));
+  h.tracker.onExecutionStart(undefined); // run B begins
+  assert.equal(h.flushes.length, 1, "run A flushed at run B's start");
+  assert.equal(h.flushes[0].key, NO_PROMPT_KEY);
+  assert.deepEqual(h.flushes[0].images.map((m) => m.filename), ["run_a.png"]);
+  h.tracker.onExecuted(undefined, imgs([img("run_b.png")]));
+  h.tracker.onExecutingNull(); // queue idle ends run B
+  assert.equal(h.flushes.length, 2);
+  assert.deepEqual(
+    h.flushes[1].images.map((m) => m.filename),
+    ["run_b.png"],
+    "run B is its own batch — outputs never merged with run A",
+  );
+});
+
+test("missed execution_start: executing(node) keeps the timer from early-flushing", () => {
+  const h = makeHarness();
+  const P = "prompt-nostart";
+  // No execution_start (dropped). executing(node) marks the prompt active.
+  h.tracker.onExecutingNode(P, "n1");
+  h.tracker.onExecuted(P, imgs([img("a.png", "temp")]));
+  h.tick(10000); // debounce would have flushed a partial under the old model
+  assert.equal(h.flushes.length, 0, "active via executing(node) — no early flush");
+  h.tracker.onExecuted(P, imgs([img("b.png")]));
+  h.tracker.onExecutionSuccess(P);
+  assert.equal(h.flushes.length, 1);
+  assert.deepEqual(h.flushes[0].images.map((m) => m.filename), ["a.png", "b.png"]);
+});
+
+test("orphan safety net: outputs with NO start/executing still flush (never stranded)", () => {
+  const h = makeHarness();
+  const P = "prompt-orphan";
+  // Only an executed frame arrives — no start, no executing(node). We have no
+  // evidence it's running, so the timer flushes it as a last resort.
+  h.tracker.onExecuted(P, imgs([img("orphan.png")]));
+  assert.equal(h.flushes.length, 0, "buffered, waiting on the debounce");
+  h.tick(1500);
+  assert.equal(h.flushes.length, 1, "orphan flushed so images are never stranded");
+  assert.deepEqual(h.flushes[0].images.map((m) => m.filename), ["orphan.png"]);
+});
+
 test("#269/#468: a completed run reliably fires exactly one completion event (resume trigger)", () => {
   const h = makeHarness();
   const P = "prompt-video";
   h.tracker.onExecutionStart(P);
+  h.tracker.onExecutingNode(P, "ltx");
   h.advance(134000); // ~134s render
-  h.tracker.onExecuted(P, [img("LTX_00005.png")]);
+  // Video-only run: no still images, one video descriptor.
+  h.tracker.onExecuted(P, {
+    videos: [{ m: { filename: "LTX_00005.mp4", type: "output" }, nodeId: "49" }],
+  });
   h.tracker.onExecutionSuccess(P);
   assert.equal(h.flushes.length, 1, "completion fires — this is what wakes the agent/TODO");
-  assert.equal(h.flushes[0].durationMs, 134000, "correct duration for the completed run");
+  assert.equal(h.flushes[0].images.length, 0);
+  assert.equal(h.flushes[0].videos.length, 1, "video routed through the authoritative lifecycle");
+  assert.equal(h.flushes[0].videos[0].m.filename, "LTX_00005.mp4");
+  assert.equal(h.flushes[0].durationMs, 134000, "correct start→finish duration for the video");
   // No stray later flush from a lingering timer.
   h.tick(60000);
   assert.equal(h.flushes.length, 1, "no duplicate/late flush");
 });
 
-test("no bogus 0.0s duration: missing start yields null duration, never 0", () => {
+test("video + stills in one run flush together as a single completion", () => {
+  const h = makeHarness();
+  const P = "prompt-mixed";
+  h.tracker.onExecutionStart(P);
+  h.tracker.onExecutingNode(P, "a");
+  h.tracker.onExecuted(P, {
+    images: [img("still.png")],
+    videos: [{ m: { filename: "v.mp4", type: "output" }, nodeId: "7" }],
+  });
+  h.tracker.onExecutionSuccess(P);
+  assert.equal(h.flushes.length, 1, "one completion for the whole run");
+  assert.equal(h.flushes[0].images.length, 1);
+  assert.equal(h.flushes[0].videos.length, 1);
+});
+
+test("no bogus 0.0s duration: missing start yields a real span, never 0", () => {
   const h = makeHarness();
   const P = "prompt-no-start";
-  // execution_start missed; first signal is the executed event.
+  // execution_start missed; first signal is the executed event (fallback start).
   h.advance(5000);
-  h.tracker.onExecuted(P, [img("x.png")]);
+  h.tracker.onExecuted(P, imgs([img("x.png")]));
   h.advance(3000);
   h.tracker.onExecutionSuccess(P);
   assert.equal(h.flushes.length, 1);
@@ -140,37 +241,33 @@ test("no bogus 0.0s duration: missing start yields null duration, never 0", () =
   assert.equal(h.flushes[0].durationMs, 3000);
 });
 
-test("safety net: an interrupted run with no run-end signal still flushes (bounded re-arm)", () => {
-  const h = makeHarness({ debounceMs: 1500, maxRearms: 3 });
-  const P = "prompt-stranded";
-  h.tracker.onExecutionStart(P);
-  h.tracker.onExecuted(P, [img("stranded.png")]);
-  // Prompt stays active and never signals end. The timer re-arms up to maxRearms
-  // then flushes so images are never permanently stranded.
-  h.tick(1500); // re-arm 1
-  h.tick(1500); // re-arm 2
-  h.tick(1500); // re-arm 3
-  assert.equal(h.flushes.length, 0, "still re-arming while active, within budget");
-  h.tick(1500); // budget exhausted -> flush
-  assert.equal(h.flushes.length, 1, "flushes once the re-arm budget is spent");
-  assert.deepEqual(h.flushes[0].images.map((m) => m.filename), ["stranded.png"]);
-});
-
 test("execution_error drops the buffer — no stale batch delivered", () => {
   const h = makeHarness();
   const P = "prompt-err";
   h.tracker.onExecutionStart(P);
-  h.tracker.onExecuted(P, [img("half.png")]);
+  h.tracker.onExecutingNode(P, "x");
+  h.tracker.onExecuted(P, imgs([img("half.png")]));
   h.tracker.onExecutionError(P);
   h.tracker.onExecutingNull();
   h.tick(10000);
   assert.equal(h.flushes.length, 0, "failed run delivers no completion batch");
 });
 
-test("empty buffer never emits a completion event", () => {
+test("empty completion (no buffered output) never emits an event", () => {
   const h = makeHarness();
-  const P = "prompt-video-only";
+  const P = "prompt-empty";
   h.tracker.onExecutionStart(P);
-  h.tracker.onExecutionSuccess(P); // video-only: no inline images buffered
+  h.tracker.onExecutionSuccess(P); // no executed at all
   assert.equal(h.flushes.length, 0);
+});
+
+test("execution_success + executing:null ordering yields exactly one event", () => {
+  const h = makeHarness();
+  const P = "prompt-order";
+  h.tracker.onExecutionStart(P);
+  h.tracker.onExecutingNode(P, "n");
+  h.tracker.onExecuted(P, imgs([img("o.png")]));
+  h.tracker.onExecutionSuccess(P); // flushes + clears
+  h.tracker.onExecutingNull(); // buffer already gone → no-op
+  assert.equal(h.flushes.length, 1, "no double delivery across the two end signals");
 });

--- a/browser_tests/unit/run-completion.test.mjs
+++ b/browser_tests/unit/run-completion.test.mjs
@@ -1,0 +1,176 @@
+/**
+ * Unit tests for web/js/lib/run-completion.js — run with `node --test`.
+ *
+ * Guards the run-completion cluster (#293, #224, #200, #269, #468): completion
+ * must fire on the AUTHORITATIVE ComfyUI lifecycle for the CURRENT prompt_id,
+ * carry the FULL output batch with the correct start→finish duration, and never
+ * flush a partial batch or a previous prompt's outputs.
+ *
+ * A fake clock + fake timer queue lets us drive the debounce deterministically:
+ * pending timers only fire when we explicitly `tick()`.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createRunCompletionTracker } from "../../web/js/lib/run-completion.js";
+
+/** Deterministic scheduler: timers are held until tick() fires the due ones. */
+function makeHarness({ debounceMs = 1500, maxRearms = 600 } = {}) {
+  let clock = 0;
+  let seq = 0;
+  const timers = new Map(); // id -> { at, fn }
+  const flushes = [];
+  const tracker = createRunCompletionTracker({
+    onFlush: (payload) => flushes.push(payload),
+    now: () => clock,
+    setTimer: (fn, ms) => {
+      const id = ++seq;
+      timers.set(id, { at: clock + ms, fn });
+      return id;
+    },
+    clearTimer: (id) => timers.delete(id),
+    debounceMs,
+    maxRearms,
+  });
+  // Advance the clock by ms and fire every timer that comes due (re-armed timers
+  // scheduled during the tick fire on later ticks, matching real setTimeout).
+  const tick = (ms) => {
+    clock += ms;
+    for (const [id, t] of [...timers]) {
+      if (t.at <= clock) {
+        timers.delete(id);
+        t.fn();
+      }
+    }
+  };
+  const advance = (ms) => {
+    clock += ms;
+  };
+  return { tracker, flushes, tick, advance, pending: () => timers.size };
+}
+
+const img = (name, type = "output") => ({ filename: name, type });
+
+test("#293: two output nodes >1.5s apart yield ONE complete event, not an early partial flush", () => {
+  const h = makeHarness();
+  const P = "prompt-A";
+  h.tracker.onExecutionStart(P); // t=0
+  h.tracker.onExecuted(P, [img("preview_5.png", "temp"), img("preview_6.png", "temp")]);
+  // 20s pass while the KSampler runs — the debounce would have flushed a partial
+  // batch at 1.5s under the old behaviour. It must NOT, because P is still active.
+  h.tick(20000);
+  assert.equal(h.flushes.length, 0, "no partial flush while prompt is in-flight");
+  h.tracker.onExecuted(P, [img("final_15.png"), img("final_17.png")]);
+  h.tracker.onExecutionSuccess(P); // authoritative run-end
+  assert.equal(h.flushes.length, 1, "exactly one consolidated completion event");
+  const f = h.flushes[0];
+  assert.deepEqual(
+    f.images.map((m) => m.filename),
+    ["preview_5.png", "preview_6.png", "final_15.png", "final_17.png"],
+    "full batch — all four outputs, not just the fast preview branch",
+  );
+  assert.equal(f.durationMs, 20000, "duration measured start→finish, not to the early flush");
+});
+
+test("#200: idle executing:null never truncates a mid-flight run", () => {
+  const h = makeHarness();
+  const P = "prompt-B";
+  h.tracker.onExecutionStart(P);
+  h.tracker.onExecuted(P, [img("canny_preview.png", "temp")]);
+  // A spurious idle signal arrives while SaveImage is still seconds from writing.
+  h.tracker.onExecutingNull();
+  assert.equal(h.flushes.length, 0, "active prompt is not flushed by idle signal");
+  h.tracker.onExecuted(P, [img("ComfyUI_00667_.png")]);
+  h.tracker.onExecutionSuccess(P);
+  assert.equal(h.flushes.length, 1);
+  assert.deepEqual(
+    h.flushes[0].images.map((m) => m.filename),
+    ["canny_preview.png", "ComfyUI_00667_.png"],
+    "SaveImage output is included — the run was not truncated to the preview",
+  );
+});
+
+test("#224: a new prompt does not inherit the prior run's buffered outputs", () => {
+  const h = makeHarness();
+  const A = "prompt-prev";
+  const B = "prompt-new";
+  h.tracker.onExecutionStart(A);
+  h.tracker.onExecuted(A, [img("pelirroja_00002_.png")]);
+  // Prior run's execution_success is missed (the failure conditions in #224).
+  // The NEW run starting must flush A's buffer as A (its own), never carry it in.
+  h.tracker.onExecutionStart(B);
+  assert.equal(h.flushes.length, 1, "prior buffer flushed at new-run start");
+  assert.equal(h.flushes[0].key, A, "attributed to the prior prompt, not the new one");
+  h.tracker.onExecuted(B, [img("maria_pelirroja_00001_.png")]);
+  h.tracker.onExecutionSuccess(B);
+  assert.equal(h.flushes.length, 2);
+  assert.equal(h.flushes[1].key, B);
+  assert.deepEqual(
+    h.flushes[1].images.map((m) => m.filename),
+    ["maria_pelirroja_00001_.png"],
+    "new run reports ONLY its own output",
+  );
+});
+
+test("#269/#468: a completed run reliably fires exactly one completion event (resume trigger)", () => {
+  const h = makeHarness();
+  const P = "prompt-video";
+  h.tracker.onExecutionStart(P);
+  h.advance(134000); // ~134s render
+  h.tracker.onExecuted(P, [img("LTX_00005.png")]);
+  h.tracker.onExecutionSuccess(P);
+  assert.equal(h.flushes.length, 1, "completion fires — this is what wakes the agent/TODO");
+  assert.equal(h.flushes[0].durationMs, 134000, "correct duration for the completed run");
+  // No stray later flush from a lingering timer.
+  h.tick(60000);
+  assert.equal(h.flushes.length, 1, "no duplicate/late flush");
+});
+
+test("no bogus 0.0s duration: missing start yields null duration, never 0", () => {
+  const h = makeHarness();
+  const P = "prompt-no-start";
+  // execution_start missed; first signal is the executed event.
+  h.advance(5000);
+  h.tracker.onExecuted(P, [img("x.png")]);
+  h.advance(3000);
+  h.tracker.onExecutionSuccess(P);
+  assert.equal(h.flushes.length, 1);
+  // Start anchored at first executed (t=5000), finish at t=8000 ⇒ 3000ms — a real
+  // measured span, never a fabricated 0.
+  assert.equal(h.flushes[0].durationMs, 3000);
+});
+
+test("safety net: an interrupted run with no run-end signal still flushes (bounded re-arm)", () => {
+  const h = makeHarness({ debounceMs: 1500, maxRearms: 3 });
+  const P = "prompt-stranded";
+  h.tracker.onExecutionStart(P);
+  h.tracker.onExecuted(P, [img("stranded.png")]);
+  // Prompt stays active and never signals end. The timer re-arms up to maxRearms
+  // then flushes so images are never permanently stranded.
+  h.tick(1500); // re-arm 1
+  h.tick(1500); // re-arm 2
+  h.tick(1500); // re-arm 3
+  assert.equal(h.flushes.length, 0, "still re-arming while active, within budget");
+  h.tick(1500); // budget exhausted -> flush
+  assert.equal(h.flushes.length, 1, "flushes once the re-arm budget is spent");
+  assert.deepEqual(h.flushes[0].images.map((m) => m.filename), ["stranded.png"]);
+});
+
+test("execution_error drops the buffer — no stale batch delivered", () => {
+  const h = makeHarness();
+  const P = "prompt-err";
+  h.tracker.onExecutionStart(P);
+  h.tracker.onExecuted(P, [img("half.png")]);
+  h.tracker.onExecutionError(P);
+  h.tracker.onExecutingNull();
+  h.tick(10000);
+  assert.equal(h.flushes.length, 0, "failed run delivers no completion batch");
+});
+
+test("empty buffer never emits a completion event", () => {
+  const h = makeHarness();
+  const P = "prompt-video-only";
+  h.tracker.onExecutionStart(P);
+  h.tracker.onExecutionSuccess(P); // video-only: no inline images buffered
+  assert.equal(h.flushes.length, 0);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -119,6 +119,7 @@ import {
 } from "./lib/group-geometry.js";
 import { saveActiveWorkflow } from "./lib/workflow-save.js";
 import { createRunCompletionTracker } from "./lib/run-completion.js";
+import { composeRunCompletionFrame } from "./lib/run-completion-frame.js";
 
 let app = null;
 let api = null;
@@ -14422,116 +14423,6 @@ function buildPanel() {
     }
   }
 
-  // VIDEO-VISION: a video output just landed and was painted as a <video> for the
-  // user — but the agent can't see video bytes. Sample frames → contact sheet PNG
-  // → upload to input/ → deliver THAT as an inline image (own executed event), and
-  // paint it as a card so the user sees it too. Fully non-blocking + best-effort:
-  // any failure just logs and leaves the video player as-is (no agent image).
-  async function deliverVideoStoryboard(m, nodeId, promptId, durationMs) {
-    // Same final-vs-preview distinction as still images: a VHS-style video node
-    // with `type:"output"` is the real SAVED file; `type:"temp"` (save_output off)
-    // is a throwaway preview. Be conservative — only explicit "output" is final.
-    const isFinalVideo = m && m.type === "output";
-    // Coerce descriptor fields once — a structured filename/subfolder/format must
-    // never reach the outbound agent note as "[object Object]" (#276).
-    const fileName = coerceMessageText(m?.filename) || "video";
-    const videoKind = isFinalVideo
-      ? `the FINAL saved video (file ${fileName} — reference THIS filename)`
-      : `a PREVIEW video (file ${fileName}, temporary — not a saved file; add/enable a save to persist it)`;
-    // ── Video metadata (gathered up front) ─────────────────────────────────
-    // path (subfolder-relative), real frame metadata when the VHS/video output
-    // payload carries it, render duration, and completion time. The duration is
-    // the run's authoritative start→finish span, passed in by the completion
-    // flush (execution_success), NOT measured at this node's `executed` time — so
-    // a video is never reported with a truncated or premature duration.
-    const subfolder = coerceMessageText(m?.subfolder);
-    const path = subfolder ? `${subfolder}/${fileName}` : fileName;
-    const duration = durationMs != null ? formatDuration(durationMs) : null;
-    const finishedClock = formatClock(new Date());
-    // Real per-video frame metadata, when present on the descriptor (VHS-style
-    // video/gif outputs may include frame_count / frame_rate / format). Omit if
-    // the payload doesn't carry it (it's not always populated).
-    const realFrames = m?.frame_count ?? m?.frameCount ?? m?.frames ?? null;
-    const realFps = m?.frame_rate ?? m?.frameRate ?? m?.fps ?? null;
-    const format = coerceMessageText(m?.format) || null;
-    // Compose the compact "· a · b · c" metadata suffix appended to a note.
-    // sizeStr (async HEAD) and storyboardN are optional/contextual.
-    const metaSuffix = (sizeStr, storyboardN) => {
-      const parts = [`path: ${path}`];
-      if (format) parts.push(format);
-      if (Number.isFinite(realFrames)) {
-        parts.push(
-          `${realFrames} frames` +
-            (Number.isFinite(realFps) ? ` @ ${realFps} fps` : ""),
-        );
-      } else if (storyboardN) {
-        parts.push(`${storyboardN}-frame storyboard`);
-      }
-      if (sizeStr) parts.push(sizeStr);
-      if (duration) parts.push(`rendered in ${duration}`);
-      if (finishedClock) parts.push(`finished ${finishedClock}`);
-      return parts.length ? `\n• ${fileName} — ${parts.join(" · ")}` : "";
-    };
-    // ALWAYS notify the agent a video rendered — with a storyboard if we can build
-    // one, else a note-only event (no images) so the agent still learns the render
-    // landed even when the preview is off or sampling/upload fails.
-    const noteOnly = (why) =>
-      client.sendFrame({
-        type: "agent_event",
-        kind: "executed",
-        note:
-          `🎬 A video rendered — ${videoKind}. You can't view it directly` +
-          (why ? ` — ${why}` : "") +
-          `; tell the user it's ready and ask how it looks if you need to judge it.` +
-          metaSuffix(null, null),
-        node_id: nodeId,
-        ...(promptId != null ? { prompt_id: promptId } : {}),
-      });
-    if (prefs.videoStoryboard === false) {
-      noteOnly("storyboard preview is turned off in panel settings");
-      return;
-    }
-    try {
-      const blob = await buildVideoStoryboard(imageViewUrl(m));
-      if (!blob) {
-        console.warn("[cmcp] storyboard: could not sample frames from", m.filename);
-        noteOnly("couldn't sample a storyboard from it");
-        return;
-      }
-      const base = (coerceMessageText(m.filename) || "video").replace(/\.[^.]+$/, "");
-      const ref = await uploadBlobToInput(blob, `storyboard_${base}.png`);
-      if (!ref) {
-        console.warn("[cmcp] storyboard: upload failed for", m.filename);
-        noteOnly("couldn't upload its storyboard");
-        return;
-      }
-      const n = storyboardFrameCount();
-      // Best-effort file size of the SOURCE video via HEAD (resilient — null on
-      // any failure, never blocks the storyboard delivery).
-      const sizeStr = humanizeBytes(await fetchImageBytes(imageViewUrl(m)));
-      // Show the user the contact sheet next to the <video> player.
-      paintImage(imageViewUrl(ref), `Storyboard · ${n} frames`);
-      // Deliver the storyboard to BOTH backends via the existing inline-vision
-      // path: the ImageRef rides in the executed event's `images`; the `note`
-      // tells the agent what it's looking at. Do NOT include the raw video ref.
-      client.sendFrame({
-        type: "agent_event",
-        kind: "executed",
-        images: [ref],
-        note:
-          `📽️ ${n}-frame storyboard (contact sheet) of ${videoKind} — ` +
-          `frames run top-left→bottom-right = start→end. ` +
-          `Review motion, sharpness, and temporal consistency.` +
-          metaSuffix(sizeStr, n),
-        node_id: nodeId,
-        ...(promptId != null ? { prompt_id: promptId } : {}),
-      });
-    } catch (err) {
-      console.warn("[cmcp] storyboard pipeline failed:", err);
-      noteOnly("its storyboard preview failed to build");
-    }
-  }
-
   // ── Per-run image batching ────────────────────────────────────────────────
   // ComfyUI fires `executed` once PER output node, so a multi-output run would
   // otherwise inject several fragmented image turns into the agent. We BUFFER
@@ -14553,162 +14444,35 @@ function buildPanel() {
   // batch + duration for a completed prompt and composes the single agent_event.
   const runCompletion = createRunCompletionTracker({
     onFlush: ({ promptId, images: flImages, videos: flVideos, durationMs }) => {
-      // A completed prompt delivers its FULL batch here, exactly once. Stills go
-      // out as one consolidated agent_event; each video (routed through the same
-      // authoritative lifecycle — not a per-node timer) gets its storyboard with
-      // the run's real start→finish duration. Fire-and-forget: these are async
-      // (metadata HEADs / frame sampling), but the batch is already captured — a
-      // failure inside must never wedge the lifecycle.
-      if (flImages && flImages.length) {
-        emitRunImages({ promptId, images: flImages, durationMs }).catch((err) =>
-          console.warn("[cmcp] emitRunImages failed:", err),
-        );
-      }
-      for (const v of flVideos || []) {
-        deliverVideoStoryboard(v.m, v.nodeId, promptId, durationMs);
-      }
+      // A completed prompt delivers its FULL batch here, exactly once. Compose
+      // ONE consolidated agent_event for the whole run — stills AND every video's
+      // storyboard folded into a single images+note+metadata turn — so a mixed /
+      // multi-video run resumes the agent with EXACTLY ONE completion frame, never
+      // a stills frame plus one frame per video (#269/#468). The composer awaits
+      // ALL storyboards for this prompt before its single send. Fire-and-forget:
+      // it's async (metadata HEADs / frame sampling), but the batch is already
+      // captured — a failure inside must never wedge the lifecycle.
+      composeRunCompletionFrame(
+        { promptId, images: flImages, videos: flVideos, durationMs },
+        {
+          sendFrame: (frame) => client.sendFrame(frame),
+          coerceMessageText,
+          formatDuration,
+          formatClock,
+          imageViewUrl,
+          fetchImageBytes,
+          fetchImageDimensions,
+          humanizeBytes,
+          buildVideoStoryboard,
+          uploadBlobToInput,
+          storyboardFrameCount,
+          paintImage,
+          videoStoryboardEnabled: prefs.videoStoryboard !== false,
+          warn: (...a) => console.warn(...a),
+        },
+      ).catch((err) => console.warn("[cmcp] composeRunCompletionFrame failed:", err));
     },
   });
-
-  async function emitRunImages({ promptId, images: bufImages, durationMs }) {
-    const duration = formatDuration(durationMs);
-    const finishedAt = new Date();
-    const finishedClock = formatClock(finishedAt);
-    if (!bufImages.length) return;
-    // Classify by ComfyUI's output type: SaveImage writes `type:"output"` with a
-    // real filename = the FINAL saved result; PreviewImage writes `type:"temp"`
-    // (under a temp/ subfolder, throwaway /tmp-style names) = a preview frame.
-    // Be conservative: ONLY an explicit `type === "output"` counts as final, so a
-    // missing/unknown type defaults to preview and we never mislabel a throwaway
-    // frame as the saved result. Don't crash on odd shapes.
-    const finals = [];
-    const previews = [];
-    for (const m of bufImages) {
-      if (m && m.type === "output") finals.push(m);
-      else previews.push(m);
-    }
-    // Send EVERYTHING for vision (the agent should see previews too), but ordered
-    // finals-first so the primary result is unambiguous as image #1.
-    const images = [...finals, ...previews];
-    const finalNames = finals.map((m) => coerceMessageText(m?.filename)).filter(Boolean);
-    const previewCount = previews.length;
-    let note;
-    if (finalNames.length) {
-      const list = finalNames.join(", ");
-      const fileWord = finalNames.length === 1 ? "output" : "outputs";
-      note =
-        `Run finished. FINAL ${fileWord}: ${list} ` +
-        `(this is the saved result — reference THIS filename` +
-        (finalNames.length === 1 ? "" : "s") +
-        `).`;
-      if (previewCount) {
-        const frameWord = previewCount === 1 ? "preview frame" : "preview frames";
-        note += ` Also shown: ${previewCount} ${frameWord} (temporary, not the final file).`;
-      }
-    } else {
-      // No SaveImage (or equivalent output node) ran — everything we have is a
-      // throwaway preview. Tell the agent so it doesn't cite a /tmp name as final.
-      const previewClause =
-        previewCount === 1
-          ? `this image is a preview (temporary, not a final file)`
-          : `these ${previewCount} images are previews (temporary, not a final file)`;
-      note =
-        `Run finished, but no saved output node ran — ${previewClause}. ` +
-        `Add a SaveImage node to persist the result, or treat the preview as the result if that's intended.`;
-    }
-    // ── Rich per-output metadata ───────────────────────────────────────────
-    // Gather metadata for the FINAL outputs (size + dimensions fetched in
-    // PARALLEL and bounded via allSettled, so a single failed HEAD/decode never
-    // drops the agent_event). Weave a compact human-readable block into the note
-    // (the agent reads TEXT) AND attach a structured `metadata` array for future
-    // programmatic use. Every field is individually optional — omitted when
-    // unavailable rather than shown as a bogus value.
-    const total = finals.length;
-    const finalNameSet = finalNames; // sibling list source (asset set)
-    let metadata = [];
-    try {
-      metadata = await Promise.all(
-        finals.map(async (m, idx) => {
-          // Coerce descriptor fields — a structured filename/subfolder must not
-          // reach the outbound agent note as "[object Object]" (#276).
-          const filename = coerceMessageText(m?.filename) || "(unknown)";
-          const subfolder = coerceMessageText(m?.subfolder);
-          const path = subfolder ? `${subfolder}/${filename}` : filename;
-          const url = imageViewUrl(m);
-          const [sizeRes, dimRes] = await Promise.allSettled([
-            fetchImageBytes(url),
-            fetchImageDimensions(url),
-          ]);
-          const sizeBytes =
-            sizeRes.status === "fulfilled" ? sizeRes.value : null;
-          const dim = dimRes.status === "fulfilled" ? dimRes.value : null;
-          const siblings = finalNameSet.filter((n) => n !== filename);
-          return {
-            filename,
-            path,
-            subfolder,
-            sizeBytes,
-            size: humanizeBytes(sizeBytes),
-            width: dim?.w ?? null,
-            height: dim?.h ?? null,
-            dimensions: dim ? `${dim.w}×${dim.h}` : null,
-            index: idx + 1,
-            total,
-            siblings,
-            durationMs,
-            duration,
-            finishedAt: finishedAt.toISOString(),
-            finishedClock,
-          };
-        }),
-      );
-    } catch {
-      // Defensive: metadata gathering must never block the agent_event.
-      metadata = [];
-    }
-    // Append the readable metadata block (one bullet per final output).
-    if (metadata.length) {
-      const lines = metadata.map((meta) => {
-        const parts = [`path: ${meta.path}`];
-        if (meta.size) parts.push(meta.size);
-        if (meta.dimensions) parts.push(meta.dimensions);
-        // asset set (same-run grouping)
-        parts.push(
-          meta.total === 1
-            ? "single output"
-            : `output ${meta.index} of ${meta.total} from this run`,
-        );
-        if (meta.siblings.length) {
-          parts.push(`alongside: ${meta.siblings.join(", ")}`);
-        }
-        if (meta.duration) parts.push(`rendered in ${meta.duration}`);
-        if (meta.finishedClock) parts.push(`finished ${meta.finishedClock}`);
-        return `• ${meta.filename} — ${parts.join(" · ")}`;
-      });
-      note += `\n${lines.join("\n")}`;
-    } else if (duration || finishedClock) {
-      // Preview-only run (no finals to attach metadata to) — still surface the
-      // run-level render context if we have it.
-      const bits = [];
-      if (duration) bits.push(`rendered in ${duration}`);
-      if (finishedClock) bits.push(`finished ${finishedClock}`);
-      if (bits.length) note += `\n• ${bits.join(" · ")}`;
-    }
-    // One consolidated turn with ALL of the run's directly-viewable images,
-    // finals-first, plus a note naming which file(s) are the real saved output
-    // and the structured metadata array (one entry per final output).
-    client.sendFrame({
-      type: "agent_event",
-      kind: "executed",
-      images,
-      note,
-      metadata,
-      // Machine-readable attribution: which prompt this completion belongs to, so
-      // a delayed prior-run flush can never be mistaken for the current run (#224).
-      ...(promptId != null ? { prompt_id: promptId } : {}),
-    });
-  }
-
 
   function onExecuted(ev) {
     const d = ev?.detail ?? {};

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14515,7 +14515,7 @@ function buildPanel() {
     const d = ev?.detail ?? {};
     // The run failed — drop any images we'd buffered for it so we don't deliver a
     // stale "here are your outputs" batch on top of the run_error interrupt below.
-    runCompletion.onExecutionError(d.prompt_id);
+    runCompletion.onExecutionFailed(d.prompt_id);
     // Name the failing node so the agent (and the user) know WHERE it broke —
     // "Ideogram4PromptBuilderKJ (node 200)" beats a bare exception string.
     // Coerce node descriptors too — never bake "[object Object]" into the

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14427,7 +14427,7 @@ function buildPanel() {
   // → upload to input/ → deliver THAT as an inline image (own executed event), and
   // paint it as a card so the user sees it too. Fully non-blocking + best-effort:
   // any failure just logs and leaves the video player as-is (no agent image).
-  async function deliverVideoStoryboard(m, nodeId, promptId) {
+  async function deliverVideoStoryboard(m, nodeId, promptId, durationMs) {
     // Same final-vs-preview distinction as still images: a VHS-style video node
     // with `type:"output"` is the real SAVED file; `type:"temp"` (save_output off)
     // is a throwaway preview. Be conservative — only explicit "output" is final.
@@ -14440,13 +14440,13 @@ function buildPanel() {
       : `a PREVIEW video (file ${fileName}, temporary — not a saved file; add/enable a save to persist it)`;
     // ── Video metadata (gathered up front) ─────────────────────────────────
     // path (subfolder-relative), real frame metadata when the VHS/video output
-    // payload carries it, render duration, and completion time. Capture the
-    // render-start SYNCHRONOUSLY here (before any await / before the run's flush
-    // retires it) so the duration survives a concurrent execution_success.
+    // payload carries it, render duration, and completion time. The duration is
+    // the run's authoritative start→finish span, passed in by the completion
+    // flush (execution_success), NOT measured at this node's `executed` time — so
+    // a video is never reported with a truncated or premature duration.
     const subfolder = coerceMessageText(m?.subfolder);
     const path = subfolder ? `${subfolder}/${fileName}` : fileName;
-    const startTs = runCompletion.startFor(promptId);
-    const duration = startTs != null ? formatDuration(Date.now() - startTs) : null;
+    const duration = durationMs != null ? formatDuration(durationMs) : null;
     const finishedClock = formatClock(new Date());
     // Real per-video frame metadata, when present on the descriptor (VHS-style
     // video/gif outputs may include frame_count / frame_rate / format). Omit if
@@ -14485,6 +14485,7 @@ function buildPanel() {
           `; tell the user it's ready and ask how it looks if you need to judge it.` +
           metaSuffix(null, null),
         node_id: nodeId,
+        ...(promptId != null ? { prompt_id: promptId } : {}),
       });
     if (prefs.videoStoryboard === false) {
       noteOnly("storyboard preview is turned off in panel settings");
@@ -14523,6 +14524,7 @@ function buildPanel() {
           `Review motion, sharpness, and temporal consistency.` +
           metaSuffix(sizeStr, n),
         node_id: nodeId,
+        ...(promptId != null ? { prompt_id: promptId } : {}),
       });
     } catch (err) {
       console.warn("[cmcp] storyboard pipeline failed:", err);
@@ -14543,22 +14545,32 @@ function buildPanel() {
   // than a debounce timer. That is what stops a partial/early flush (#293, #200),
   // a prior run's buffer being misattributed to the current prompt (#224), and
   // the correct batch being dropped so the agent never resumes (#269, #468). The
-  // debounce survives only as a bounded safety net that re-arms while the prompt
-  // is still in-flight, so images from an interrupted run are never stranded.
+  // debounce NEVER flushes a running prompt — it re-arms while active and only
+  // flushes a true orphan (outputs with no start/executing signal), so a partial
+  // batch can't be emitted for a legitimately long run.
   //
   // This closure owns ONLY presentation: it receives the full, correctly-scoped
   // batch + duration for a completed prompt and composes the single agent_event.
   const runCompletion = createRunCompletionTracker({
-    onFlush: (payload) => {
-      // Fire-and-forget: emitRunImages is async (metadata HEADs), but it already
-      // has the full batch — a failure inside it must never wedge the lifecycle.
-      emitRunImages(payload).catch((err) =>
-        console.warn("[cmcp] emitRunImages failed:", err),
-      );
+    onFlush: ({ promptId, images: flImages, videos: flVideos, durationMs }) => {
+      // A completed prompt delivers its FULL batch here, exactly once. Stills go
+      // out as one consolidated agent_event; each video (routed through the same
+      // authoritative lifecycle — not a per-node timer) gets its storyboard with
+      // the run's real start→finish duration. Fire-and-forget: these are async
+      // (metadata HEADs / frame sampling), but the batch is already captured — a
+      // failure inside must never wedge the lifecycle.
+      if (flImages && flImages.length) {
+        emitRunImages({ promptId, images: flImages, durationMs }).catch((err) =>
+          console.warn("[cmcp] emitRunImages failed:", err),
+        );
+      }
+      for (const v of flVideos || []) {
+        deliverVideoStoryboard(v.m, v.nodeId, promptId, durationMs);
+      }
     },
   });
 
-  async function emitRunImages({ images: bufImages, durationMs }) {
+  async function emitRunImages({ promptId, images: bufImages, durationMs }) {
     const duration = formatDuration(durationMs);
     const finishedAt = new Date();
     const finishedClock = formatClock(finishedAt);
@@ -14691,6 +14703,9 @@ function buildPanel() {
       images,
       note,
       metadata,
+      // Machine-readable attribution: which prompt this completion belongs to, so
+      // a delayed prior-run flush can never be mistaken for the current run (#224).
+      ...(promptId != null ? { prompt_id: promptId } : {}),
     });
   }
 
@@ -14714,25 +14729,23 @@ function buildPanel() {
       const url = imageViewUrl(m);
       if (isVideoOutput(m)) {
         paintVideo(url, m.filename);
-        videos.push(m);
+        // Carry the node id so the deferred storyboard event can name its node.
+        videos.push({ m, nodeId });
       } else {
         paintImage(url, m.filename);
         inlineImages.push(m);
       }
     }
-    // Buffer the directly-viewable images for THIS run instead of sending a turn
-    // per node — they're flushed as one consolidated `executed` event when the
-    // prompt finishes (see runCompletion/onFlush). The image already painted above, so
-    // the user still sees it live; only the agent delivery is deferred+grouped.
-    if (inlineImages.length) {
-      runCompletion.onExecuted(d.prompt_id, inlineImages);
-    } else if (!videos.length) {
-      // No viewable images and no videos (shouldn't happen given the guard above).
-      return;
+    // Buffer this run's outputs (images AND videos) instead of delivering per
+    // node — the tracker flushes them together as ONE completion when the prompt
+    // AUTHORITATIVELY finishes (execution_success / queue idle). Everything is
+    // already painted above, so the user sees it live; only the agent delivery is
+    // deferred+grouped. Routing videos through the SAME lifecycle (rather than a
+    // per-node timer) is what gives a video its real start→finish duration and
+    // guarantees exactly one completion per prompt (#269/#468).
+    if (inlineImages.length || videos.length) {
+      runCompletion.onExecuted(d.prompt_id, { images: inlineImages, videos });
     }
-    // Kick off a storyboard per video — non-blocking; onExecuted has already sent
-    // its event and painted everything. Each storyboard delivers its own event.
-    for (const m of videos) deliverVideoStoryboard(m, nodeId, d.prompt_id);
   }
   function onExecError(ev) {
     const d = ev?.detail ?? {};

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -118,6 +118,7 @@ import {
   classifyRequestedMembership,
 } from "./lib/group-geometry.js";
 import { saveActiveWorkflow } from "./lib/workflow-save.js";
+import { createRunCompletionTracker } from "./lib/run-completion.js";
 
 let app = null;
 let api = null;
@@ -14444,7 +14445,7 @@ function buildPanel() {
     // retires it) so the duration survives a concurrent execution_success.
     const subfolder = coerceMessageText(m?.subfolder);
     const path = subfolder ? `${subfolder}/${fileName}` : fileName;
-    const startTs = runStartTimes.get(promptKey(promptId));
+    const startTs = runCompletion.startFor(promptId);
     const duration = startTs != null ? formatDuration(Date.now() - startTs) : null;
     const finishedClock = formatClock(new Date());
     // Real per-video frame metadata, when present on the descriptor (VHS-style
@@ -14530,69 +14531,38 @@ function buildPanel() {
   }
 
   // ── Per-run image batching ────────────────────────────────────────────────
-  // ComfyUI fires `executed` once PER output node, so a multi-output run used to
-  // inject several fragmented image turns into the agent. Instead we BUFFER each
-  // run's inline image refs by prompt_id as `executed` events arrive (still
-  // painting every image live for the user), then deliver ONE consolidated
-  // `executed` agent_event when that prompt finishes (`execution_success`, or the
-  // legacy `executing` with node===null). A short debounce flushes a buffer that
-  // never sees a run-end signal so images are never stranded.
-  const runImageBuffers = new Map(); // promptId -> { images: ImageRef[], timer }
-  const RUN_FLUSH_DEBOUNCE_MS = 1500;
-  const promptKey = (id) => id ?? "__no_prompt__";
+  // ComfyUI fires `executed` once PER output node, so a multi-output run would
+  // otherwise inject several fragmented image turns into the agent. We BUFFER
+  // each run's inline image refs by prompt_id (still painting every image live
+  // for the user), then deliver ONE consolidated `executed` agent_event when that
+  // prompt AUTHORITATIVELY finishes.
+  //
+  // The completion decision — WHEN to flush and for WHICH prompt_id — lives in
+  // lib/run-completion.js (createRunCompletionTracker), keyed on the ComfyUI
+  // execution lifecycle (execution_start → executed → execution_success) rather
+  // than a debounce timer. That is what stops a partial/early flush (#293, #200),
+  // a prior run's buffer being misattributed to the current prompt (#224), and
+  // the correct batch being dropped so the agent never resumes (#269, #468). The
+  // debounce survives only as a bounded safety net that re-arms while the prompt
+  // is still in-flight, so images from an interrupted run are never stranded.
+  //
+  // This closure owns ONLY presentation: it receives the full, correctly-scoped
+  // batch + duration for a completed prompt and composes the single agent_event.
+  const runCompletion = createRunCompletionTracker({
+    onFlush: (payload) => {
+      // Fire-and-forget: emitRunImages is async (metadata HEADs), but it already
+      // has the full batch — a failure inside it must never wedge the lifecycle.
+      emitRunImages(payload).catch((err) =>
+        console.warn("[cmcp] emitRunImages failed:", err),
+      );
+    },
+  });
 
-  // Render-duration tracking: promptKey -> start Date.now(). The primary start
-  // signal is ComfyUI's `execution_start` (carries prompt_id) — recorded the
-  // instant a run begins. Fallbacks (first `executing`/`executed` for that
-  // prompt) fill in if execution_start is missed, so we never invent a bogus
-  // start. duration = finish - start is computed at flush; the entry is cleaned
-  // up on flush / execution_success / clear. Clock-consistent: BOTH ends use the
-  // client's Date.now(), so a server/client clock skew can't distort it.
-  const runStartTimes = new Map();
-  function markRunStart(promptId) {
-    const key = promptKey(promptId);
-    // First signal wins — don't let a later per-node event reset an earlier start.
-    if (!runStartTimes.has(key)) runStartTimes.set(key, Date.now());
-    // Safety cap: runs are sequential, but if a run starts and never produces a
-    // run-end signal the entry would linger — bound the map so it can't grow.
-    if (runStartTimes.size > 20) {
-      const oldest = runStartTimes.keys().next().value;
-      if (oldest !== key) runStartTimes.delete(oldest);
-    }
-  }
-
-  function bufferRunImages(promptId, images) {
-    if (!images.length) return;
-    // Fallback render-start: if execution_start was missed, anchor the timer at
-    // the first output we see for this run (no-op if a start is already recorded).
-    markRunStart(promptId);
-    const key = promptKey(promptId);
-    let buf = runImageBuffers.get(key);
-    if (!buf) {
-      buf = { images: [], timer: null };
-      runImageBuffers.set(key, buf);
-    }
-    buf.images.push(...images);
-    // Debounce fallback: if no run-end signal lands, flush anyway after a beat.
-    if (buf.timer) clearTimeout(buf.timer);
-    buf.timer = setTimeout(() => flushRunImages(key), RUN_FLUSH_DEBOUNCE_MS);
-  }
-
-  async function flushRunImages(promptId) {
-    const key = promptKey(promptId);
-    const buf = runImageBuffers.get(key);
-    if (!buf) return;
-    if (buf.timer) clearTimeout(buf.timer);
-    runImageBuffers.delete(key);
-    // Render duration: read + retire the start time NOW (synchronously, before any
-    // await) so a concurrent flush can't double-count it. null start ⇒ omit.
-    const startTs = runStartTimes.get(key);
-    runStartTimes.delete(key);
-    const durationMs = startTs != null ? Date.now() - startTs : null;
+  async function emitRunImages({ images: bufImages, durationMs }) {
     const duration = formatDuration(durationMs);
     const finishedAt = new Date();
     const finishedClock = formatClock(finishedAt);
-    if (!buf.images.length) return;
+    if (!bufImages.length) return;
     // Classify by ComfyUI's output type: SaveImage writes `type:"output"` with a
     // real filename = the FINAL saved result; PreviewImage writes `type:"temp"`
     // (under a temp/ subfolder, throwaway /tmp-style names) = a preview frame.
@@ -14601,7 +14571,7 @@ function buildPanel() {
     // frame as the saved result. Don't crash on odd shapes.
     const finals = [];
     const previews = [];
-    for (const m of buf.images) {
+    for (const m of bufImages) {
       if (m && m.type === "output") finals.push(m);
       else previews.push(m);
     }
@@ -14724,17 +14694,6 @@ function buildPanel() {
     });
   }
 
-  function clearRunImages(promptId) {
-    const key = promptKey(promptId);
-    const buf = runImageBuffers.get(key);
-    if (buf?.timer) clearTimeout(buf.timer);
-    runImageBuffers.delete(key);
-    runStartTimes.delete(key);
-  }
-
-  function flushAllRunImages() {
-    for (const key of [...runImageBuffers.keys()]) flushRunImages(key);
-  }
 
   function onExecuted(ev) {
     const d = ev?.detail ?? {};
@@ -14763,10 +14722,10 @@ function buildPanel() {
     }
     // Buffer the directly-viewable images for THIS run instead of sending a turn
     // per node — they're flushed as one consolidated `executed` event when the
-    // prompt finishes (see flushRunImages). The image already painted above, so
+    // prompt finishes (see runCompletion/onFlush). The image already painted above, so
     // the user still sees it live; only the agent delivery is deferred+grouped.
     if (inlineImages.length) {
-      bufferRunImages(d.prompt_id, inlineImages);
+      runCompletion.onExecuted(d.prompt_id, inlineImages);
     } else if (!videos.length) {
       // No viewable images and no videos (shouldn't happen given the guard above).
       return;
@@ -14779,7 +14738,7 @@ function buildPanel() {
     const d = ev?.detail ?? {};
     // The run failed — drop any images we'd buffered for it so we don't deliver a
     // stale "here are your outputs" batch on top of the run_error interrupt below.
-    clearRunImages(d.prompt_id);
+    runCompletion.onExecutionError(d.prompt_id);
     // Name the failing node so the agent (and the user) know WHERE it broke —
     // "Ideogram4PromptBuilderKJ (node 200)" beats a bare exception string.
     // Coerce node descriptors too — never bake "[object Object]" into the
@@ -14807,33 +14766,30 @@ function buildPanel() {
       error: true,
     });
   }
-  // Run-end signal: ComfyUI emits `execution_success` (carrying prompt_id) when a
-  // prompt fully completes — flush THAT run's buffered images as one turn.
+  // Authoritative run-end: ComfyUI emits `execution_success` (carrying prompt_id)
+  // when a prompt FULLY completes — this is the signal completion is keyed on, so
+  // the flush carries the full output set for THAT prompt with the correct
+  // start→finish duration, and reliably wakes the agent on the real result.
   function onExecutionSuccess(ev) {
-    const id = ev?.detail?.prompt_id;
-    flushRunImages(id);
-    // Retire the render-start for runs that produced NO buffered inline images
-    // (e.g. video-only runs) — flushRunImages early-returns for those and leaves
-    // the start entry behind. The video storyboard already captured its duration
-    // synchronously, so deleting here is safe.
-    runStartTimes.delete(promptKey(id));
+    runCompletion.onExecutionSuccess(ev?.detail?.prompt_id);
   }
   // Primary render-duration start signal: ComfyUI emits `execution_start` with the
-  // prompt_id the instant a run begins — anchor the duration timer there.
+  // prompt_id the instant a run begins — anchor the duration timer there and flush
+  // any lingering prior-run buffer so it can't be misattributed to this run.
   function onExecutionStart(ev) {
-    markRunStart(ev?.detail?.prompt_id);
+    runCompletion.onExecutionStart(ev?.detail?.prompt_id);
   }
   // Legacy/secondary run-end: `executing` fires with the current node id, or null
-  // when nothing is left to run. The null event carries no prompt_id, so flush any
-  // remaining buffers (runs are sequential — nothing is executing now).
+  // when the queue is idle. The null event flushes only buffers whose prompt is
+  // NOT still in-flight — it can never truncate a mid-run prompt (#200/#224).
   function onExecuting(ev) {
     if (ev?.detail == null) {
-      flushAllRunImages();
+      runCompletion.onExecutingNull();
       return;
     }
     // Fallback render-start: the first per-node `executing` for a prompt anchors
     // the timer if execution_start was missed (no-op if already recorded).
-    if (ev?.detail?.prompt_id != null) markRunStart(ev.detail.prompt_id);
+    if (ev?.detail?.prompt_id != null) runCompletion.onExecutingNode(ev.detail.prompt_id);
   }
   // Post-restart autonomy (#3): ComfyUI's api fires `reconnecting` when the
   // server goes down (e.g. a Manager reboot) and `reconnected` when it's back.

--- a/web/js/lib/run-completion-frame.js
+++ b/web/js/lib/run-completion-frame.js
@@ -1,0 +1,396 @@
+// Compose EXACTLY ONE completion agent_event per finished prompt_id.
+//
+// The run-completion tracker (run-completion.js) delivers ONE flush payload per
+// prompt with the FULL batch (stills AND videos). This module turns that payload
+// into a SINGLE `agent_event` frame: the run's still images AND every video's
+// storyboard consolidated into one `images` + `note` + `metadata` turn.
+//
+// Why this matters (#269/#468): a mixed / multi-video run must resume the agent
+// with EXACTLY ONE completion frame. The prior wiring emitted a stills frame
+// PLUS one frame per video, so a run with two videos woke the agent three times
+// with three fragmented, separately-attributed batches. The tracker was already
+// one-flush-per-prompt; the fan-out lived here, at presentation. This composer
+// awaits ALL storyboards for the prompt and sends once.
+//
+// The module owns ONLY presentation. All I/O (frame send, metadata HEAD/decode,
+// storyboard sampling/upload, formatting) is injected via `deps` so it stays a
+// pure, testable function — and so a failure inside any single output can never
+// wedge the one send.
+
+/**
+ * Build and send the single consolidated completion frame for one finished
+ * prompt. Resolves to the frame that was sent (for tests), or null when the
+ * batch was empty (no frame emitted).
+ *
+ * @param {{promptId:(string|null), images?:any[], videos?:any[], durationMs:(number|null)}} payload
+ * @param {object} deps  Injected presentation helpers (see call site).
+ * @returns {Promise<object|null>}
+ */
+export async function composeRunCompletionFrame(
+  { promptId, images = [], videos = [], durationMs },
+  deps,
+) {
+  const {
+    sendFrame,
+    coerceMessageText,
+    formatDuration,
+    formatClock,
+    imageViewUrl,
+    fetchImageBytes,
+    fetchImageDimensions,
+    humanizeBytes,
+    buildVideoStoryboard,
+    uploadBlobToInput,
+    storyboardFrameCount,
+    paintImage,
+    videoStoryboardEnabled = true,
+    now = () => new Date(),
+    warn = () => {},
+    // Per-video wall-clock cap. The single completion frame awaits every video
+    // segment before it sends, so an UNBOUNDED storyboard step (e.g. an
+    // /upload/image that never settles) would otherwise suppress the ENTIRE
+    // completion — stills and all other videos included. Each segment is bounded
+    // and, on timeout, degrades to its note-only fallback so the one frame always
+    // sends. Injectable for tests.
+    videoStoryboardTimeoutMs = 25000,
+    setTimer = (fn, ms) => setTimeout(fn, ms),
+    clearTimer = (t) => clearTimeout(t),
+  } = deps;
+
+  // One clock read for the whole run so stills and videos report the SAME
+  // finished time (they're one completion).
+  const finishedAt = now();
+  const finishedClock = formatClock(finishedAt);
+  const duration = durationMs != null ? formatDuration(durationMs) : null;
+
+  const outImages = []; // consolidated images for the single frame
+  const noteSections = []; // note segments joined into the single note
+  let metadata = [];
+
+  // ── Stills segment ─────────────────────────────────────────────────────
+  if (images.length) {
+    const seg = await buildStillsSegment(images, {
+      coerceMessageText,
+      imageViewUrl,
+      fetchImageBytes,
+      fetchImageDimensions,
+      humanizeBytes,
+      duration,
+      durationMs,
+      finishedClock,
+      finishedAt,
+    });
+    outImages.push(...seg.images);
+    if (seg.note) noteSections.push(seg.note);
+    metadata = seg.metadata;
+  }
+
+  // ── Video segments (built in PARALLEL, each bounded, then folded in order) ─
+  // Parallel + per-segment timeout means neither a slow nor a permanently-
+  // pending storyboard for one video can delay or suppress the single frame:
+  // the worst case is ONE timeout window, and a stalled segment degrades to its
+  // note-only fallback. Order is preserved (Promise.all keeps input order), so
+  // the storyboards appear in video order.
+  const videoSegs = await Promise.all(
+    videos.map((v) =>
+      buildVideoSegment(v, {
+        coerceMessageText,
+        formatClock,
+        imageViewUrl,
+        fetchImageBytes,
+        humanizeBytes,
+        buildVideoStoryboard,
+        uploadBlobToInput,
+        storyboardFrameCount,
+        paintImage,
+        videoStoryboardEnabled,
+        duration,
+        finishedClock,
+        warn,
+        videoStoryboardTimeoutMs,
+        setTimer,
+        clearTimer,
+      }).catch((err) => {
+        // buildVideoSegment already swallows its own errors; this is a final
+        // belt-and-braces guard so one video can never reject the whole batch.
+        warn("[cmcp] storyboard segment failed:", err);
+        return null;
+      }),
+    ),
+  );
+  for (const seg of videoSegs) {
+    if (!seg) continue;
+    if (seg.ref) outImages.push(seg.ref);
+    if (seg.note) noteSections.push(seg.note);
+  }
+
+  if (!outImages.length && !noteSections.length) return null;
+
+  const frame = {
+    type: "agent_event",
+    kind: "executed",
+    images: outImages,
+    note: noteSections.join("\n\n"),
+    metadata,
+    // Machine-readable attribution: which prompt this completion belongs to, so
+    // a delayed prior-run flush can never be mistaken for the current run (#224).
+    ...(promptId != null ? { prompt_id: promptId } : {}),
+  };
+  sendFrame(frame);
+  return frame;
+}
+
+/**
+ * Still-image portion: classify final-vs-preview, compose the note, and gather
+ * per-final metadata. Returns { images, note, metadata } — never sends a frame.
+ */
+async function buildStillsSegment(bufImages, deps) {
+  const {
+    coerceMessageText,
+    imageViewUrl,
+    fetchImageBytes,
+    fetchImageDimensions,
+    humanizeBytes,
+    duration,
+    durationMs,
+    finishedClock,
+    finishedAt,
+  } = deps;
+
+  if (!bufImages.length) return { images: [], note: "", metadata: [] };
+
+  // Classify by ComfyUI's output type: SaveImage writes `type:"output"` with a
+  // real filename = the FINAL saved result; PreviewImage writes `type:"temp"` =
+  // a preview frame. Be conservative — only explicit "output" counts as final.
+  const finals = [];
+  const previews = [];
+  for (const m of bufImages) {
+    if (m && m.type === "output") finals.push(m);
+    else previews.push(m);
+  }
+  // Send EVERYTHING for vision (the agent should see previews too), finals-first
+  // so the primary result is unambiguous as image #1.
+  const images = [...finals, ...previews];
+  const finalNames = finals.map((m) => coerceMessageText(m?.filename)).filter(Boolean);
+  const previewCount = previews.length;
+  let note;
+  if (finalNames.length) {
+    const list = finalNames.join(", ");
+    const fileWord = finalNames.length === 1 ? "output" : "outputs";
+    note =
+      `Run finished. FINAL ${fileWord}: ${list} ` +
+      `(this is the saved result — reference THIS filename` +
+      (finalNames.length === 1 ? "" : "s") +
+      `).`;
+    if (previewCount) {
+      const frameWord = previewCount === 1 ? "preview frame" : "preview frames";
+      note += ` Also shown: ${previewCount} ${frameWord} (temporary, not the final file).`;
+    }
+  } else {
+    const previewClause =
+      previewCount === 1
+        ? `this image is a preview (temporary, not a final file)`
+        : `these ${previewCount} images are previews (temporary, not a final file)`;
+    note =
+      `Run finished, but no saved output node ran — ${previewClause}. ` +
+      `Add a SaveImage node to persist the result, or treat the preview as the result if that's intended.`;
+  }
+
+  // ── Rich per-output metadata (parallel, bounded, never drops the note) ──
+  const total = finals.length;
+  const finalNameSet = finalNames;
+  let metadata = [];
+  try {
+    metadata = await Promise.all(
+      finals.map(async (m, idx) => {
+        const filename = coerceMessageText(m?.filename) || "(unknown)";
+        const subfolder = coerceMessageText(m?.subfolder);
+        const path = subfolder ? `${subfolder}/${filename}` : filename;
+        const url = imageViewUrl(m);
+        const [sizeRes, dimRes] = await Promise.allSettled([
+          fetchImageBytes(url),
+          fetchImageDimensions(url),
+        ]);
+        const sizeBytes = sizeRes.status === "fulfilled" ? sizeRes.value : null;
+        const dim = dimRes.status === "fulfilled" ? dimRes.value : null;
+        const siblings = finalNameSet.filter((n) => n !== filename);
+        return {
+          filename,
+          path,
+          subfolder,
+          sizeBytes,
+          size: humanizeBytes(sizeBytes),
+          width: dim?.w ?? null,
+          height: dim?.h ?? null,
+          dimensions: dim ? `${dim.w}×${dim.h}` : null,
+          index: idx + 1,
+          total,
+          siblings,
+          durationMs,
+          duration,
+          finishedAt: finishedAt.toISOString?.() ?? null,
+          finishedClock,
+        };
+      }),
+    );
+  } catch {
+    metadata = [];
+  }
+
+  // Append the readable metadata block (one bullet per final output).
+  if (metadata.length) {
+    const lines = metadata.map((meta) => {
+      const parts = [`path: ${meta.path}`];
+      if (meta.size) parts.push(meta.size);
+      if (meta.dimensions) parts.push(meta.dimensions);
+      parts.push(
+        meta.total === 1
+          ? "single output"
+          : `output ${meta.index} of ${meta.total} from this run`,
+      );
+      if (meta.siblings.length) parts.push(`alongside: ${meta.siblings.join(", ")}`);
+      if (meta.duration) parts.push(`rendered in ${meta.duration}`);
+      if (meta.finishedClock) parts.push(`finished ${meta.finishedClock}`);
+      return `• ${meta.filename} — ${parts.join(" · ")}`;
+    });
+    note += `\n${lines.join("\n")}`;
+  } else if (duration || finishedClock) {
+    const bits = [];
+    if (duration) bits.push(`rendered in ${duration}`);
+    if (finishedClock) bits.push(`finished ${finishedClock}`);
+    if (bits.length) note += `\n• ${bits.join(" · ")}`;
+  }
+
+  return { images, note, metadata };
+}
+
+/**
+ * One video's portion: build a storyboard contact sheet (or a note-only fallback
+ * when the storyboard can't be produced) and return { ref, note }. `ref` is the
+ * uploaded storyboard ImageRef (or null); it never sends a frame itself.
+ */
+async function buildVideoSegment(v, deps) {
+  const {
+    coerceMessageText,
+    imageViewUrl,
+    fetchImageBytes,
+    humanizeBytes,
+    buildVideoStoryboard,
+    uploadBlobToInput,
+    storyboardFrameCount,
+    paintImage,
+    videoStoryboardEnabled,
+    duration,
+    finishedClock,
+    warn,
+  } = deps;
+
+  const {
+    videoStoryboardTimeoutMs = 25000,
+    setTimer = (fn, ms) => setTimeout(fn, ms),
+    clearTimer = (t) => clearTimeout(t),
+  } = deps;
+  const m = v?.m;
+  const isFinalVideo = m && m.type === "output";
+  const fileName = coerceMessageText(m?.filename) || "video";
+  const videoKind = isFinalVideo
+    ? `the FINAL saved video (file ${fileName} — reference THIS filename)`
+    : `a PREVIEW video (file ${fileName}, temporary — not a saved file; add/enable a save to persist it)`;
+  const subfolder = coerceMessageText(m?.subfolder);
+  const path = subfolder ? `${subfolder}/${fileName}` : fileName;
+  const realFrames = m?.frame_count ?? m?.frameCount ?? m?.frames ?? null;
+  const realFps = m?.frame_rate ?? m?.frameRate ?? m?.fps ?? null;
+  const format = coerceMessageText(m?.format) || null;
+
+  const metaSuffix = (sizeStr, storyboardN) => {
+    const parts = [`path: ${path}`];
+    if (format) parts.push(format);
+    if (Number.isFinite(realFrames)) {
+      parts.push(
+        `${realFrames} frames` + (Number.isFinite(realFps) ? ` @ ${realFps} fps` : ""),
+      );
+    } else if (storyboardN) {
+      parts.push(`${storyboardN}-frame storyboard`);
+    }
+    if (sizeStr) parts.push(sizeStr);
+    if (duration) parts.push(`rendered in ${duration}`);
+    if (finishedClock) parts.push(`finished ${finishedClock}`);
+    return parts.length ? `\n• ${fileName} — ${parts.join(" · ")}` : "";
+  };
+
+  const noteOnly = (why) =>
+    `🎬 A video rendered — ${videoKind}. You can't view it directly` +
+    (why ? ` — ${why}` : "") +
+    `; tell the user it's ready and ask how it looks if you need to judge it.` +
+    metaSuffix(null, null);
+
+  if (!videoStoryboardEnabled) {
+    return { ref: null, note: noteOnly("storyboard preview is turned off in panel settings") };
+  }
+  // The storyboard pipeline (sample → upload → HEAD) contains at least one
+  // UNBOUNDED step (uploadBlobToInput does a fetch with no timeout). Bound the
+  // whole pipeline: on timeout, degrade to the note-only fallback so a stalled
+  // upload can never suppress the run's single completion frame.
+  const produce = async () => {
+    try {
+      const blob = await buildVideoStoryboard(imageViewUrl(m));
+      if (!blob) {
+        warn("[cmcp] storyboard: could not sample frames from", m?.filename);
+        return { ref: null, note: noteOnly("couldn't sample a storyboard from it") };
+      }
+      const base = (coerceMessageText(m?.filename) || "video").replace(/\.[^.]+$/, "");
+      const ref = await uploadBlobToInput(blob, `storyboard_${base}.png`);
+      if (!ref) {
+        warn("[cmcp] storyboard: upload failed for", m?.filename);
+        return { ref: null, note: noteOnly("couldn't upload its storyboard") };
+      }
+      const n = storyboardFrameCount();
+      const sizeStr = humanizeBytes(await fetchImageBytes(imageViewUrl(m)));
+      // Show the user the contact sheet next to the <video> player.
+      paintImage(imageViewUrl(ref), `Storyboard · ${n} frames`);
+      const note =
+        `📽️ ${n}-frame storyboard (contact sheet) of ${videoKind} — ` +
+        `frames run top-left→bottom-right = start→end. ` +
+        `Review motion, sharpness, and temporal consistency.` +
+        metaSuffix(sizeStr, n);
+      return { ref, note };
+    } catch (err) {
+      warn("[cmcp] storyboard pipeline failed:", err);
+      return { ref: null, note: noteOnly("its storyboard preview failed to build") };
+    }
+  };
+  return withTimeout(
+    produce(),
+    videoStoryboardTimeoutMs,
+    () => {
+      warn("[cmcp] storyboard: timed out for", m?.filename);
+      return { ref: null, note: noteOnly("its storyboard preview timed out") };
+    },
+    { setTimer, clearTimer },
+  );
+}
+
+/**
+ * Resolve `promise`, but if it hasn't settled within `ms`, resolve with
+ * `onTimeout()` instead. Never rejects (a rejected `promise` also falls back).
+ * A non-positive `ms` disables the bound. The timer is cleared on settle so it
+ * can't leak.
+ */
+function withTimeout(promise, ms, onTimeout, { setTimer, clearTimer }) {
+  if (!(ms > 0)) return promise;
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (v) => {
+      if (settled) return;
+      settled = true;
+      clearTimer(t);
+      resolve(v);
+    };
+    const t = setTimer(() => {
+      if (settled) return;
+      settled = true;
+      resolve(onTimeout());
+    }, ms);
+    promise.then(done, () => done(onTimeout()));
+  });
+}

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -197,16 +197,20 @@ export function createRunCompletionTracker({
     },
 
     /**
-     * Legacy/secondary run-end: `executing` with node===null. ComfyUI emits this
-     * exactly once when a prompt finishes and the queue goes idle — NOT mid-run —
-     * so it is an authoritative per-prompt end. Flush every remaining buffer
-     * under its own key (correct attribution) and clear liveness. On modern
-     * ComfyUI the buffer is already gone (execution_success flushed it); this is
-     * the completion path for legacy servers that emit no execution_success.
+     * Legacy/secondary run-end: `executing` with node===null (queue idle).
+     *
+     * This flushes ONLY buffers whose prompt is NOT currently active — it can
+     * never truncate a run ComfyUI still reports as in-flight (#200/#224). On
+     * modern ComfyUI the authoritative `execution_success` has already cleared
+     * `active` and flushed the buffer, so this is a no-op there; its remaining job
+     * is a backstop for an ORPHAN/non-active leftover (e.g. a legacy __no_prompt__
+     * buffer). Deliberately NOT trusting a possibly-spurious null to end an active
+     * run is what makes an early/partial completion from a stray null unreachable.
      */
     onExecutingNull() {
-      for (const k of [...buffers.keys()]) flush(k);
-      active.clear();
+      for (const k of [...buffers.keys()]) {
+        if (!active.has(k)) flush(k);
+      }
     },
 
     /**

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -2,55 +2,62 @@
 //
 // ComfyUI fires `executed` once PER output node, so a multi-output run would
 // otherwise inject several fragmented image turns into the agent. We BUFFER a
-// run's inline image refs by prompt_id as `executed` events arrive, then deliver
-// ONE consolidated `executed` agent_event when that prompt *authoritatively*
-// finishes.
+// run's inline image refs (and video descriptors) by prompt_id as `executed`
+// events arrive, then deliver ONE consolidated completion when that prompt
+// *authoritatively* finishes.
 //
-// "Authoritative" is the whole point of this module. Completion is keyed on the
-// ComfyUI execution lifecycle for a SPECIFIC prompt_id — execution_start →
-// executed(…) → execution_success — NOT on a debounce timer. Prior behaviour
-// flushed on a 1.5s debounce, which fired mid-run whenever two output nodes were
-// >1.5s apart (a fast PreviewImage upstream of a slow KSampler is the normal
-// shape of many graphs). That produced:
-//   • partial image batches + a wrong (~6× short) duration (#293),
-//   • a previous run's buffer delivered as the current run's FINAL output while
-//     the queued prompt was still executing (#224),
-//   • "no saved output node ran" while SaveImage was still seconds from writing
-//     (#200),
-//   • the correct, later batch being dropped so the agent never resumed on the
-//     real result (#269, #468).
+// "Authoritative" is the whole point. Completion is keyed on the ComfyUI
+// execution lifecycle for a SPECIFIC prompt_id — NOT on a debounce timer. The
+// prior implementation flushed on a 1.5s debounce, which fired mid-run whenever
+// two output nodes were >1.5s apart (a fast PreviewImage upstream of a slow
+// KSampler is the normal shape of many graphs), producing partial batches, wrong
+// durations, a prior run's buffer delivered as the current prompt's result, and
+// the correct batch being dropped so the agent never resumed (#293/#224/#200/
+// #269/#468).
 //
-// Rules enforced here:
-//   1. execution_success(prompt_id) is the authoritative flush for THAT prompt —
-//      it collects the FULL output set buffered for that prompt_id.
-//   2. The debounce is a bounded SAFETY NET only. While ComfyUI still reports the
-//      prompt in-flight, the timer RE-ARMS instead of flushing — it never emits a
-//      partial batch. Bounded re-arming (default 600 × 1.5s = 15 min) preserves
-//      the "never strand images" guarantee for an interrupted run that never
-//      delivers a run-end signal.
-//   3. A run beginning flushes any lingering buffer from the PRIOR (sequential)
-//      run first, so an older buffer can never be misattributed to the new run.
-//   4. The idle `executing:null` signal flushes only buffers whose prompt is NOT
-//      still active — it can never truncate a mid-flight run.
-//   5. duration = finish − start, both from the same clock, anchored on
-//      execution_start (with per-node fallbacks) and read at flush time.
+// Model (the invariants that make partial/misattributed completion unreachable):
+//   • A prompt is ACTIVE from the first sign it is running — `execution_start`
+//     OR `executing(node)` (which always precedes that node's `executed`). This
+//     is what closes the "missed execution_start" hole: even if the start frame
+//     is dropped, the per-node `executing` marks the prompt active before any
+//     output is buffered.
+//   • The debounce timer NEVER flushes an ACTIVE prompt. While active it simply
+//     re-arms (bounded, purely to cap timer churn) and then stops — it never
+//     emits a partial batch, so a legitimately long run (video gen can far
+//     exceed any fixed cutoff) is always completed by its real end signal with
+//     the full batch and correct duration.
+//   • The timer's ONLY flush is a last-resort safety net for an ORPHAN buffer we
+//     have NO evidence is running (outputs arrived but no start and no
+//     executing(node) — i.e. heavily dropped frames). Normal runs are always
+//     active, so this path never fires for them.
+//   • Authoritative flush triggers, each scoped to ONE prompt_id and carrying the
+//     full buffered set: `execution_success(prompt_id)` (primary), the queue
+//     going idle via `executing:null` (per-prompt end signal — ComfyUI emits it
+//     exactly once at prompt end, never mid-run), and a NEW run starting (which
+//     means every prior sequential run is done — flush them first so nothing
+//     bleeds into the new run, including a legacy __no_prompt__ buffer).
+//   • duration = finish − start, both from the same clock, anchored on the run
+//     start and read at flush; a missing start yields a null (omitted) duration,
+//     never a bogus 0.0s.
 //
 // The module owns ONLY lifecycle + buffering + timing. Presentation (note text,
-// metadata fetch, sendFrame) stays with the caller via the `onFlush` callback,
-// which receives the full, correctly-scoped batch exactly once per completion.
+// metadata fetch, sendFrame, video storyboard) stays with the caller via the
+// `onFlush` callback, which receives the full, correctly-scoped batch — plus the
+// prompt_id `key` for machine-readable attribution — exactly once per completion.
 
 export const NO_PROMPT_KEY = "__no_prompt__";
 
 /**
  * @param {object} opts
- * @param {(payload:{key:string, images:any[], durationMs:number|null, finishedAt:number}) => void} opts.onFlush
- *   Called exactly once per completed prompt that buffered ≥1 image, with the
- *   FULL batch for that prompt_id and the correct start→finish duration.
+ * @param {(payload:{key:string, promptId:(string|null), images:any[], videos:any[], durationMs:number|null, finishedAt:number}) => void} opts.onFlush
+ *   Called exactly once per completed prompt that buffered ≥1 image or video,
+ *   with the FULL batch for that prompt_id, the correct start→finish duration,
+ *   and the prompt_id (`key`/`promptId`) so the delivery can be attributed.
  * @param {() => number} [opts.now]        Clock (injectable for tests).
  * @param {(fn:Function, ms:number) => any} [opts.setTimer]
  * @param {(t:any) => void} [opts.clearTimer]
- * @param {number} [opts.debounceMs]       Safety-net interval (default 1500).
- * @param {number} [opts.maxRearms]        Re-arm ceiling (default 600 = ~15 min).
+ * @param {number} [opts.debounceMs]       Orphan-flush / re-arm interval (default 1500).
+ * @param {number} [opts.maxRearms]        Re-arm churn cap for an active buffer (default 40).
  */
 export function createRunCompletionTracker({
   onFlush,
@@ -58,14 +65,15 @@ export function createRunCompletionTracker({
   setTimer = (fn, ms) => setTimeout(fn, ms),
   clearTimer = (t) => clearTimeout(t),
   debounceMs = 1500,
-  maxRearms = 600,
+  maxRearms = 40,
 } = {}) {
   if (typeof onFlush !== "function") {
     throw new TypeError("createRunCompletionTracker requires an onFlush callback");
   }
   const key = (id) => id ?? NO_PROMPT_KEY;
-  const buffers = new Map(); // key -> { images: any[], timer, rearms }
-  const active = new Set(); // keys ComfyUI currently reports in-flight
+  const promptIdOf = (k) => (k === NO_PROMPT_KEY ? null : k);
+  const buffers = new Map(); // key -> { images: any[], videos: any[], timer, rearms }
+  const active = new Set(); // keys ComfyUI currently reports as running
   const starts = new Map(); // key -> start timestamp
 
   function markStart(id) {
@@ -86,14 +94,21 @@ export function createRunCompletionTracker({
     buf.timer = setTimer(() => {
       const b = buffers.get(k);
       if (!b) return;
-      // If ComfyUI still reports this prompt in-flight, the run is NOT done —
-      // re-arm rather than flush a partial batch (#293/#200). Bounded so an
-      // interrupted run that never delivers a run-end signal still flushes.
-      if (active.has(k) && b.rearms < maxRearms) {
-        b.rearms += 1;
-        arm(k);
+      b.timer = null;
+      if (active.has(k)) {
+        // The prompt is (still) running per ComfyUI — NEVER flush a partial batch
+        // (#293/#200). Re-arm a bounded number of times purely to cap timer churn,
+        // then stop and wait for the authoritative end signal (success / queue
+        // idle / next run). A legitimately long run is completed there, in full.
+        if (b.rearms < maxRearms) {
+          b.rearms += 1;
+          arm(k);
+        }
         return;
       }
+      // Not active: we have NO evidence this prompt is running (no start, no
+      // executing(node)) yet outputs arrived — an orphan from dropped frames.
+      // Flush it as a last resort so images are never permanently stranded.
       flush(k);
     }, debounceMs);
   }
@@ -108,47 +123,57 @@ export function createRunCompletionTracker({
     const startTs = starts.get(k);
     starts.delete(k);
     const durationMs = startTs != null ? now() - startTs : null;
-    if (!buf.images.length) return;
-    onFlush({ key: k, images: buf.images, durationMs, finishedAt: now() });
+    if (!buf.images.length && !buf.videos.length) return;
+    onFlush({
+      key: k,
+      promptId: promptIdOf(k),
+      images: buf.images,
+      videos: buf.videos,
+      durationMs,
+      finishedAt: now(),
+    });
+  }
+
+  function ensureBuffer(k) {
+    let buf = buffers.get(k);
+    if (!buf) {
+      buf = { images: [], videos: [], timer: null, rearms: 0 };
+      buffers.set(k, buf);
+    }
+    return buf;
   }
 
   return {
     /** ComfyUI `execution_start` — authoritative run-start for a prompt. */
     onExecutionStart(id) {
       const k = key(id);
-      // Runs are sequential: a new run beginning means EVERY prior run has ended,
-      // even one whose execution_success we missed (the exact #224 conditions).
-      // Finalize every other buffer NOW — attributed to ITS own prompt/timing —
-      // so an older buffer can never be carried into, and misreported as, this
-      // new run (#224). A stale prior prompt is also cleared from `active` so it
-      // can't linger and suppress a future idle flush. Never touch this run's own.
-      for (const other of [...buffers.keys()]) {
-        if (other !== k) {
-          active.delete(other);
-          flush(other);
-        }
-      }
-      // Drop any stale active marker with no buffer (e.g. a prior run that
-      // produced no images and never signalled end) so `active` can't leak.
-      for (const other of [...active]) {
-        if (other !== k) active.delete(other);
-      }
+      // Runs are sequential: a new run beginning means EVERY prior run has ended
+      // (even one whose end signal we missed). Flush every existing buffer under
+      // ITS OWN key/timing first, so an older buffer — including a legacy
+      // __no_prompt__ one from the previous run — can never bleed into, or be
+      // misreported as, this new run (#224). A run cannot have buffered output
+      // before its own start, so nothing belonging to THIS run is lost here.
+      for (const other of [...buffers.keys()]) flush(other);
+      active.clear();
       markStart(id);
       active.add(k);
     },
 
-    /** ComfyUI `executed` (per output node) — buffer this prompt's images. */
-    onExecuted(id, images) {
-      if (!images || !images.length) return;
+    /**
+     * ComfyUI `executed` (per output node) — buffer this prompt's outputs.
+     * @param {string|null} id
+     * @param {{images?: any[], videos?: any[]}} outputs
+     */
+    onExecuted(id, { images = [], videos = [] } = {}) {
+      if (!images.length && !videos.length) return;
       // Fallback render-start if execution_start was missed (no-op otherwise).
+      // Does NOT mark active: `executing(node)` is the run-liveness signal, so an
+      // output with no start AND no executing(node) is treated as an orphan.
       markStart(id);
       const k = key(id);
-      let buf = buffers.get(k);
-      if (!buf) {
-        buf = { images: [], timer: null, rearms: 0 };
-        buffers.set(k, buf);
-      }
-      buf.images.push(...images);
+      const buf = ensureBuffer(k);
+      if (images.length) buf.images.push(...images);
+      if (videos.length) buf.videos.push(...videos);
       arm(k);
     },
 
@@ -157,8 +182,7 @@ export function createRunCompletionTracker({
       const k = key(id);
       active.delete(k);
       flush(k);
-      // Retire start for runs that buffered no inline images (e.g. video-only),
-      // where flush early-returns and would otherwise leave the entry behind.
+      // Retire start for runs that buffered nothing (flush early-returns then).
       starts.delete(k);
     },
 
@@ -172,22 +196,32 @@ export function createRunCompletionTracker({
       starts.delete(k);
     },
 
-    /** Legacy idle signal: `executing` with node===null (no prompt_id). */
+    /**
+     * Legacy/secondary run-end: `executing` with node===null. ComfyUI emits this
+     * exactly once when a prompt finishes and the queue goes idle — NOT mid-run —
+     * so it is an authoritative per-prompt end. Flush every remaining buffer
+     * under its own key (correct attribution) and clear liveness. On modern
+     * ComfyUI the buffer is already gone (execution_success flushed it); this is
+     * the completion path for legacy servers that emit no execution_success.
+     */
     onExecutingNull() {
-      // The queue is idle. Flush only buffers whose prompt ComfyUI is NOT still
-      // running — an active prompt is flushed by execution_success and must
-      // never be truncated here (#200/#224).
-      for (const k of [...buffers.keys()]) {
-        if (!active.has(k)) flush(k);
-      }
+      for (const k of [...buffers.keys()]) flush(k);
+      active.clear();
     },
 
-    /** `executing` with a node id — fallback render-start anchor. */
+    /**
+     * `executing` with a node id. Anchors the render-start AND marks the prompt
+     * active — this is the run-liveness signal that closes the "missed
+     * execution_start" hole (it always precedes that node's `executed`), so the
+     * timer can never early-flush a run whose start frame was dropped.
+     */
     onExecutingNode(id) {
-      if (id != null) markStart(id);
+      if (id == null) return;
+      markStart(id);
+      active.add(key(id));
     },
 
-    /** Synchronous start lookup for the async video-storyboard duration path. */
+    /** Synchronous start lookup (diagnostics / fallbacks). */
     startFor(id) {
       return starts.get(key(id));
     },

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -1,0 +1,200 @@
+// Run-completion lifecycle tracker.
+//
+// ComfyUI fires `executed` once PER output node, so a multi-output run would
+// otherwise inject several fragmented image turns into the agent. We BUFFER a
+// run's inline image refs by prompt_id as `executed` events arrive, then deliver
+// ONE consolidated `executed` agent_event when that prompt *authoritatively*
+// finishes.
+//
+// "Authoritative" is the whole point of this module. Completion is keyed on the
+// ComfyUI execution lifecycle for a SPECIFIC prompt_id — execution_start →
+// executed(…) → execution_success — NOT on a debounce timer. Prior behaviour
+// flushed on a 1.5s debounce, which fired mid-run whenever two output nodes were
+// >1.5s apart (a fast PreviewImage upstream of a slow KSampler is the normal
+// shape of many graphs). That produced:
+//   • partial image batches + a wrong (~6× short) duration (#293),
+//   • a previous run's buffer delivered as the current run's FINAL output while
+//     the queued prompt was still executing (#224),
+//   • "no saved output node ran" while SaveImage was still seconds from writing
+//     (#200),
+//   • the correct, later batch being dropped so the agent never resumed on the
+//     real result (#269, #468).
+//
+// Rules enforced here:
+//   1. execution_success(prompt_id) is the authoritative flush for THAT prompt —
+//      it collects the FULL output set buffered for that prompt_id.
+//   2. The debounce is a bounded SAFETY NET only. While ComfyUI still reports the
+//      prompt in-flight, the timer RE-ARMS instead of flushing — it never emits a
+//      partial batch. Bounded re-arming (default 600 × 1.5s = 15 min) preserves
+//      the "never strand images" guarantee for an interrupted run that never
+//      delivers a run-end signal.
+//   3. A run beginning flushes any lingering buffer from the PRIOR (sequential)
+//      run first, so an older buffer can never be misattributed to the new run.
+//   4. The idle `executing:null` signal flushes only buffers whose prompt is NOT
+//      still active — it can never truncate a mid-flight run.
+//   5. duration = finish − start, both from the same clock, anchored on
+//      execution_start (with per-node fallbacks) and read at flush time.
+//
+// The module owns ONLY lifecycle + buffering + timing. Presentation (note text,
+// metadata fetch, sendFrame) stays with the caller via the `onFlush` callback,
+// which receives the full, correctly-scoped batch exactly once per completion.
+
+export const NO_PROMPT_KEY = "__no_prompt__";
+
+/**
+ * @param {object} opts
+ * @param {(payload:{key:string, images:any[], durationMs:number|null, finishedAt:number}) => void} opts.onFlush
+ *   Called exactly once per completed prompt that buffered ≥1 image, with the
+ *   FULL batch for that prompt_id and the correct start→finish duration.
+ * @param {() => number} [opts.now]        Clock (injectable for tests).
+ * @param {(fn:Function, ms:number) => any} [opts.setTimer]
+ * @param {(t:any) => void} [opts.clearTimer]
+ * @param {number} [opts.debounceMs]       Safety-net interval (default 1500).
+ * @param {number} [opts.maxRearms]        Re-arm ceiling (default 600 = ~15 min).
+ */
+export function createRunCompletionTracker({
+  onFlush,
+  now = () => Date.now(),
+  setTimer = (fn, ms) => setTimeout(fn, ms),
+  clearTimer = (t) => clearTimeout(t),
+  debounceMs = 1500,
+  maxRearms = 600,
+} = {}) {
+  if (typeof onFlush !== "function") {
+    throw new TypeError("createRunCompletionTracker requires an onFlush callback");
+  }
+  const key = (id) => id ?? NO_PROMPT_KEY;
+  const buffers = new Map(); // key -> { images: any[], timer, rearms }
+  const active = new Set(); // keys ComfyUI currently reports in-flight
+  const starts = new Map(); // key -> start timestamp
+
+  function markStart(id) {
+    const k = key(id);
+    // First signal wins — a later per-node event must not reset an earlier start.
+    if (!starts.has(k)) starts.set(k, now());
+    // Bound the map so a run that never signals end can't leak entries.
+    if (starts.size > 20) {
+      const oldest = starts.keys().next().value;
+      if (oldest !== k) starts.delete(oldest);
+    }
+  }
+
+  function arm(k) {
+    const buf = buffers.get(k);
+    if (!buf) return;
+    if (buf.timer) clearTimer(buf.timer);
+    buf.timer = setTimer(() => {
+      const b = buffers.get(k);
+      if (!b) return;
+      // If ComfyUI still reports this prompt in-flight, the run is NOT done —
+      // re-arm rather than flush a partial batch (#293/#200). Bounded so an
+      // interrupted run that never delivers a run-end signal still flushes.
+      if (active.has(k) && b.rearms < maxRearms) {
+        b.rearms += 1;
+        arm(k);
+        return;
+      }
+      flush(k);
+    }, debounceMs);
+  }
+
+  function flush(k) {
+    const buf = buffers.get(k);
+    if (!buf) return;
+    if (buf.timer) clearTimer(buf.timer);
+    buffers.delete(k);
+    // Read + retire the start synchronously so a concurrent flush can't
+    // double-count it. A missing start ⇒ null duration (never a bogus 0.0s).
+    const startTs = starts.get(k);
+    starts.delete(k);
+    const durationMs = startTs != null ? now() - startTs : null;
+    if (!buf.images.length) return;
+    onFlush({ key: k, images: buf.images, durationMs, finishedAt: now() });
+  }
+
+  return {
+    /** ComfyUI `execution_start` — authoritative run-start for a prompt. */
+    onExecutionStart(id) {
+      const k = key(id);
+      // Runs are sequential: a new run beginning means EVERY prior run has ended,
+      // even one whose execution_success we missed (the exact #224 conditions).
+      // Finalize every other buffer NOW — attributed to ITS own prompt/timing —
+      // so an older buffer can never be carried into, and misreported as, this
+      // new run (#224). A stale prior prompt is also cleared from `active` so it
+      // can't linger and suppress a future idle flush. Never touch this run's own.
+      for (const other of [...buffers.keys()]) {
+        if (other !== k) {
+          active.delete(other);
+          flush(other);
+        }
+      }
+      // Drop any stale active marker with no buffer (e.g. a prior run that
+      // produced no images and never signalled end) so `active` can't leak.
+      for (const other of [...active]) {
+        if (other !== k) active.delete(other);
+      }
+      markStart(id);
+      active.add(k);
+    },
+
+    /** ComfyUI `executed` (per output node) — buffer this prompt's images. */
+    onExecuted(id, images) {
+      if (!images || !images.length) return;
+      // Fallback render-start if execution_start was missed (no-op otherwise).
+      markStart(id);
+      const k = key(id);
+      let buf = buffers.get(k);
+      if (!buf) {
+        buf = { images: [], timer: null, rearms: 0 };
+        buffers.set(k, buf);
+      }
+      buf.images.push(...images);
+      arm(k);
+    },
+
+    /** ComfyUI `execution_success` — the authoritative flush for THIS prompt. */
+    onExecutionSuccess(id) {
+      const k = key(id);
+      active.delete(k);
+      flush(k);
+      // Retire start for runs that buffered no inline images (e.g. video-only),
+      // where flush early-returns and would otherwise leave the entry behind.
+      starts.delete(k);
+    },
+
+    /** ComfyUI `execution_error` — drop this prompt's buffer, deliver no batch. */
+    onExecutionError(id) {
+      const k = key(id);
+      active.delete(k);
+      const buf = buffers.get(k);
+      if (buf?.timer) clearTimer(buf.timer);
+      buffers.delete(k);
+      starts.delete(k);
+    },
+
+    /** Legacy idle signal: `executing` with node===null (no prompt_id). */
+    onExecutingNull() {
+      // The queue is idle. Flush only buffers whose prompt ComfyUI is NOT still
+      // running — an active prompt is flushed by execution_success and must
+      // never be truncated here (#200/#224).
+      for (const k of [...buffers.keys()]) {
+        if (!active.has(k)) flush(k);
+      }
+    },
+
+    /** `executing` with a node id — fallback render-start anchor. */
+    onExecutingNode(id) {
+      if (id != null) markStart(id);
+    },
+
+    /** Synchronous start lookup for the async video-storyboard duration path. */
+    startFor(id) {
+      return starts.get(key(id));
+    },
+
+    // Introspection for tests / diagnostics.
+    _active: active,
+    _buffers: buffers,
+    _starts: starts,
+  };
+}

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -187,7 +187,7 @@ export function createRunCompletionTracker({
     },
 
     /** ComfyUI `execution_error` — drop this prompt's buffer, deliver no batch. */
-    onExecutionError(id) {
+    onExecutionFailed(id) {
       const k = key(id);
       active.delete(k);
       const buf = buffers.get(k);


### PR DESCRIPTION
## Summary

The run-completion `agent_event` fired on a **1.5 s debounce timer** rather than the ComfyUI execution lifecycle, so it fired early or attributed a prior run's output to the current prompt:

- **#293** — two output nodes >1.5 s apart delivered a **partial** image batch + ~6× short duration mid-run; the correct later batch was then dropped.
- **#224** — a **previous** run's buffer delivered as the current prompt's FINAL output (wrong `filename_prefix`, `0.0s`) while the queued prompt was still executing.
- **#200** — "no saved output node ran" while `SaveImage` was still seconds from writing, because `executing:null` flushed **every** buffer unconditionally.
- **#269 / #468** — the genuine completion event was lost/dropped, so the agent/TODO never resumed on the real result.

## Fix

Extract the completion lifecycle into `web/js/lib/run-completion.js` (`createRunCompletionTracker`), keyed on `prompt_id`:

- **Authoritative flush** on `execution_success(prompt_id)` — the full buffered output set for THAT prompt, with `duration = execution_start → finish`.
- A prompt is **ACTIVE** from `execution_start` **or** `executing(node)` (which precedes `executed`), closing the missed-start hole.
- The debounce **never flushes an active run** — it re-arms (bounded) and waits for the authoritative end, so a legitimately long run (video gen) is completed in full, never truncated. Its only flush is a true **orphan** (outputs with no start/executing signal).
- `executing:null` flushes **only non-active** buffers — a spurious null can't truncate an in-flight run.
- A **new run's `execution_start` flushes all prior buffers first** (own key/timing), so an older buffer — including a legacy `__no_prompt__` one — can't bleed into the new run; back-to-back id-less runs don't merge.
- Videos are buffered and flushed through the **same lifecycle** (real start→finish duration, not a per-node timer).
- The emitted `agent_event` carries **`prompt_id`** for machine-readable attribution.

Presentation (note text, metadata, `sendFrame`, video storyboard) stays in the panel via the `onFlush` callback.

## Tests

`browser_tests/unit/run-completion.test.mjs` (14 tests): two nodes >1.5 s apart → ONE complete event; long run past the re-arm cap → no partial; spurious mid-run `executing:null` → no flush of an active run; new prompt doesn't inherit prior outputs; id-less back-to-back don't merge; missed-start + orphan safety net; video-through-lifecycle; no bogus `0.0s`; error drops buffer; end-signal ordering yields exactly one event. **FAIL against the old debounce behaviour, PASS after.** Full unit suite: **458/458** (`node --test browser_tests/unit/*.mjs`).

**Completion consolidation (final blocker):** the presentation layer now emits **exactly ONE** combined `agent_event` per `prompt_id`. `onFlush` was extracted into `web/js/lib/run-completion-frame.js` (`composeRunCompletionFrame`), which folds the run stills AND every video storyboard into a single `images`+`note`+`metadata` turn instead of a stills frame plus one frame per video (the two inline `emitRunImages`/`deliverVideoStoryboard` functions were deleted). Each storyboard pipeline is bounded by a per-video timeout and built in parallel, so a stalled/unbounded upload degrades to a note-only fallback and can never suppress the run one completion frame. New presentation regression tests prove a mixed run (stills + 2 videos) yields exactly one event with all outputs (FAIL against the old fan-out, PASS after).

## Codex gate status

Codex (OpenAI acct) drove this across multiple rounds. The tracker-side blockers (missed-start early flush, active-run timeout flush, `__no_prompt__` merge, spurious-null truncation, lost attribution) and the final **single-frame-per-completion** consolidation for the mixed/multi-video path are now all fixed and covered by tests. A final adversarial Codex re-review — which caught a real regression the consolidation introduced (a stalled storyboard upload behind the single await could suppress the whole frame; now bounded per-video) — returned **VERDICT: PASS**.

Closes #293
Closes #224
Closes #200
Closes #269
Closes #468

🤖 Generated with [Claude Code](https://claude.com/claude-code)


