### PR TITLE
release: 0.11.19 — run-completion lifecycle fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.19] - 2026-07-30
+
+### Fixed
+- **Run completion fires once on the authoritative lifecycle, with the full batch + correct duration + reliable resume (#293, #224, #200, #269, #468).** The completion `agent_event` was driven by a debounce timer, so it could flush mid-run (a partial image batch, a bogus `0.0s`/"no saved output node ran", or a previous run's output) and sometimes failed to resume the agent — leaving a TODO stuck. Completion now keys on the ComfyUI execution lifecycle for the specific `prompt_id` (flush on `execution_success`, full batch, real `execution_start→finish` duration), never flushes an active run, and never inherits a prior prompt's outputs. Mixed/multi-video runs emit exactly ONE combined event (stills + every video's storyboard folded into one `agent_event`, built in parallel with a per-video timeout so a stalled upload can't suppress completion) instead of a frame per output. Frame composition extracted to `web/js/lib/run-completion-frame.js` with headless tests. (#344)
+
 ## [0.11.18] - 2026-07-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.18"
+version = "0.11.19"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -238,7 +238,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.18";
+const PANEL_VERSION = "0.11.19";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Cuts panel **0.11.19** (pyproject `version` + `PANEL_VERSION` bumped together → Registry publish on merge).

## Ships
- **#293/#224/#200/#269/#468 (#344):** run completion fires once on the authoritative ComfyUI `prompt_id` lifecycle — full batch, correct duration, reliable resume, one combined event for mixed/multi-video runs (per-video timeout so a stalled upload can't suppress it). codex PASS; 458 unit tests (mixed-run mutation-verified).

**Live-test note:** the end-to-end multi-video timing scenario (stills + ≥2 videos >1.5s apart) isn't reproducible on-demand on the rig, so the browser live-test is deferred — covered by the mutation-verified unit suite (fails against the old debounce fan-out, passes after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)