### PR TITLE
fix(session): frontend rebind/preserve tab across reboot/soft-reload/free_vram + session-init tool registration (#278, #334, #296, #291, #207, #332, #310)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -270,7 +270,7 @@ def _local_comfyui_path():
             return base
     except Exception:
         # folder_paths not importable (headless / older host) — no local path.
-        pass
+        return ""
     return ""
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -251,6 +251,29 @@ def _detect_comfyui_url():
     return "http://{}:{}".format(host, port)
 
 
+def _local_comfyui_path():
+    """Best-effort filesystem path of THIS ComfyUI install (folder_paths.base_path),
+    so the panel can advertise it in its session-init hello (#296/#291).
+
+    READ-ONLY/advisory only — never used to spawn or write. Prefers an explicit
+    COMFYUI_PATH override, then folder_paths.base_path. Returns "" when it cannot
+    be determined (headless/older host) so the panel advertises no local path and
+    the orchestrator falls back to its own workspace detection."""
+    override = (environ.get("COMFYUI_PATH") or "").strip()
+    if override:
+        return override
+    try:
+        import folder_paths  # type: ignore
+
+        base = getattr(folder_paths, "base_path", None)
+        if base and isinstance(base, str):
+            return base
+    except Exception:
+        # folder_paths not importable (headless / older host) — no local path.
+        pass
+    return ""
+
+
 _LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1", _ANY_IPV4_HOST, ""}
 
 
@@ -383,6 +406,12 @@ def _register_routes():
                 "can_spawn": False,
                 "bridge_url": "ws://{}:{}".format(_BRIDGE_HOST, _BRIDGE_PORT),
                 "comfyui_url": detected,
+                # #296/#291 — the local ComfyUI workspace path (folder_paths.base_path
+                # of the ComfyUI this pack is embedded in). READ-ONLY/advisory: the
+                # panel advertises it in its session-init hello so an out-of-band
+                # orchestrator can register the live panel_* graph tools + local panel
+                # management even with no CLI workspace config. Never used to spawn.
+                "comfyui_path": _local_comfyui_path(),
                 "start_command": _start_command(detected),
             }
         )

--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -1,0 +1,256 @@
+// Unit tests for web/js/lib/session-rebind.js — the frontend half of the
+// session/tab-rebind cluster (#278, #334, #296, #291, #207, #332, #310).
+// Run with `node --test browser_tests/unit/*.mjs`.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  shouldResumeAfterComfyReconnect,
+  shouldRehelloAfterCommand,
+  isTransientReconnectError,
+  retryDuringReconnect,
+  workflowTabKey,
+  dedupeWorkflowTabRecords,
+  resolveLoadGraphArgs,
+  buildHelloPayload,
+} from "../../web/js/lib/session-rebind.js";
+
+// ---- #278 post-reboot resume guard ----------------------------------------
+
+test("#278: a live bridge never bounces, whatever the markers say", () => {
+  assert.equal(
+    shouldResumeAfterComfyReconnect({
+      bridgeConnected: true,
+      rebootPending: true,
+      autoConnect: true,
+      hasResumableSession: true,
+    }),
+    false,
+  );
+});
+
+test("#278: reboot marker present + bridge down → resume (pre-existing behavior)", () => {
+  assert.equal(
+    shouldResumeAfterComfyReconnect({ bridgeConnected: false, rebootPending: true }),
+    true,
+  );
+});
+
+test("#278 REGRESSION: reboot marker LOST but a resumable session survives → resume", () => {
+  // This is the bug: the old guard returned early (no REBOOT_KEY / AUTOCONNECT_KEY)
+  // and stranded the live workflow conversation as "Connected: none".
+  assert.equal(
+    shouldResumeAfterComfyReconnect({
+      bridgeConnected: false,
+      rebootPending: false,
+      autoConnect: false,
+      hasResumableSession: true,
+    }),
+    true,
+  );
+});
+
+test("#278: nothing to resume + bridge down → stay idle", () => {
+  assert.equal(shouldResumeAfterComfyReconnect({ bridgeConnected: false }), false);
+});
+
+// ---- #310 rehello after free_vram -----------------------------------------
+
+test("#310: a successful free_vram re-advertises the tab", () => {
+  assert.equal(shouldRehelloAfterCommand("free_vram", { ok: true }), true);
+});
+
+test("#310: a FAILED free_vram does not rehello", () => {
+  assert.equal(shouldRehelloAfterCommand("free_vram", { ok: false }), false);
+});
+
+test("#310: other commands never trigger the free_vram rehello", () => {
+  assert.equal(shouldRehelloAfterCommand("graph_add_node", { ok: true }), false);
+  assert.equal(shouldRehelloAfterCommand("free_vram", undefined), false);
+});
+
+// ---- #332 transient reconnect-window retry --------------------------------
+
+test("#332: classifies a bare transport error as transient", () => {
+  assert.equal(isTransientReconnectError(new TypeError("Failed to fetch")), true);
+  assert.equal(isTransientReconnectError("NetworkError when attempting to fetch"), true);
+  assert.equal(isTransientReconnectError(new Error("socket hang up")), true);
+});
+
+test("#332: a real HTTP error is NOT transient (must propagate unchanged)", () => {
+  assert.equal(isTransientReconnectError(new Error("Manager customnode/installed: HTTP 500")), false);
+  assert.equal(isTransientReconnectError(new Error("ComfyUI-Manager not reachable")), false);
+});
+
+test("#332: retries a transient failure then succeeds, with backoff", async () => {
+  const sleeps = [];
+  let calls = 0;
+  const result = await retryDuringReconnect(
+    async () => {
+      calls += 1;
+      if (calls < 3) throw new TypeError("Failed to fetch");
+      return { installed: ["a", "b"] };
+    },
+    { baseDelayMs: 10, sleep: async (ms) => sleeps.push(ms) },
+  );
+  assert.deepEqual(result, { installed: ["a", "b"] });
+  assert.equal(calls, 3);
+  assert.deepEqual(sleeps, [10, 20]); // exponential, only between attempts
+});
+
+test("#332: a persistent transient failure is reworded AND preserves the cause", async () => {
+  const original = new TypeError("Failed to fetch");
+  await assert.rejects(
+    retryDuringReconnect(async () => { throw original; }, {
+      attempts: 3,
+      sleep: async () => {},
+    }),
+    (err) => {
+      assert.match(err.message, /not reachable right now/i);
+      assert.match(err.message, /may still be reconnecting/i);
+      assert.match(err.message, /Failed to fetch/); // original text preserved
+      assert.equal(err.cause, original); // type/stack preserved via cause
+      return true;
+    },
+  );
+});
+
+test("#332: a non-transient error propagates immediately without retrying", async () => {
+  let calls = 0;
+  await assert.rejects(
+    retryDuringReconnect(async () => { calls += 1; throw new Error("HTTP 500"); }, { sleep: async () => {} }),
+    /HTTP 500/,
+  );
+  assert.equal(calls, 1); // no retries for a real server error
+});
+
+// ---- #207 tab-record dedupe -----------------------------------------------
+
+test("#207: stable key normalizes separators + .json, strips path-scheme, preserves case", () => {
+  // separators + lowercase .json normalized; case PRESERVED (no Linux case collapse)
+  assert.equal(workflowTabKey({ path: "Workflows\\I2V_00025-audio.json" }), "Workflows/I2V_00025-audio");
+  // a wf: key unifies with the path form (wf: always denotes a saved path)
+  assert.equal(workflowTabKey({ key: "wf:workflows/a.json" }), workflowTabKey({ path: "workflows/a.json" }));
+  // even a ROOT-LEVEL saved key unifies with its path form
+  assert.equal(workflowTabKey({ key: "wf:foo.json" }), workflowTabKey({ path: "foo.json" }));
+  assert.equal(workflowTabKey({ key: "tmp:workflows/a.json" }), "workflows/a");
+  // a bare filename is NOT a stable identity → "" (kept distinct, never deduped)
+  assert.equal(workflowTabKey({ filename: "Foo.json" }), "");
+  assert.equal(workflowTabKey(null), "");
+});
+
+test("#207: a pathless temp key keeps its scheme and never collides with a saved file", () => {
+  // "tmp:foo" (an unsaved tab, no path) must NOT collapse into saved "foo.json".
+  assert.equal(workflowTabKey({ key: "tmp:foo" }), "tmp:foo");
+  const deduped = dedupeWorkflowTabRecords([{ key: "tmp:foo" }, { path: "foo.json" }]);
+  assert.equal(deduped.length, 2);
+});
+
+test("#207: multiple filename-only unsaved tabs stay DISTINCT (no destructive merge)", () => {
+  const deduped = dedupeWorkflowTabRecords([
+    { filename: "Unsaved Workflow", active: false },
+    { filename: "Unsaved Workflow", active: true },
+    { filename: "foo" }, // must NOT collide with a saved foo.json
+    { path: "foo.json" },
+  ]);
+  assert.equal(deduped.length, 4);
+});
+
+test("#207: case-sensitive .json strip does not merge case-distinct extensions", () => {
+  // Foo.JSON is left intact (case-sensitive strip) so it can't merge with foo.json.
+  assert.notEqual(workflowTabKey({ path: "Foo.JSON" }), workflowTabKey({ path: "foo.json" }));
+});
+
+test("#207: distinct-case filenames are NOT collapsed (case-sensitive FS safe)", () => {
+  const deduped = dedupeWorkflowTabRecords([{ path: "workflows/Foo.json" }, { path: "workflows/foo.json" }]);
+  assert.equal(deduped.length, 2);
+});
+
+test("#207: a path-form and a wf:-key-form of the same file dedupe together", () => {
+  const deduped = dedupeWorkflowTabRecords([
+    { key: "tmp:workflows/I2V.json", active: false },
+    { path: "workflows/I2V.json", active: true },
+  ]);
+  assert.equal(deduped.length, 1);
+  assert.equal(deduped[0].active, true);
+});
+
+test("#207: duplicate active records for the same file collapse to one", () => {
+  const records = [
+    { path: "workflows/I2V.json", key: "tmp:abc", active: true, persisted: false, modified: true },
+    { path: "workflows/I2V.json", key: "wf:workflows/I2V.json", active: true, persisted: true, modified: false },
+    { path: "workflows/I2V.json", active: false, persisted: true },
+  ];
+  const deduped = dedupeWorkflowTabRecords(records);
+  assert.equal(deduped.length, 1);
+  assert.equal(deduped[0].active, true);
+  assert.equal(deduped[0].persisted, true);
+  assert.equal(deduped[0].modified, true); // OR-merged across the collapsed records
+});
+
+test("#207: distinct workflows and blank/unsaved tabs are preserved", () => {
+  const records = [
+    { path: "workflows/A.json", active: true },
+    { path: "workflows/B.json", active: false },
+    { filename: "Unsaved Workflow" /* no path/key → distinct */ },
+    {}, // fully blank
+  ];
+  const deduped = dedupeWorkflowTabRecords(records);
+  assert.equal(deduped.length, 4);
+});
+
+test("#207: order is preserved (first occurrence wins its slot)", () => {
+  const deduped = dedupeWorkflowTabRecords([
+    { path: "a.json" },
+    { path: "b.json" },
+    { path: "a.json", modified: true },
+  ]);
+  assert.deepEqual(deduped.map((r) => r.path), ["a.json", "b.json"]);
+  assert.equal(deduped[0].modified, true);
+});
+
+// ---- #207 / #334 load-into-active-tab args --------------------------------
+
+test("#334: a load with an active workflow stays in the SAME tab (no Unsaved spawn)", () => {
+  const wf = { path: "workflows/Cyberpunk.json", key: "wf:workflows/Cyberpunk.json" };
+  const args = resolveLoadGraphArgs({ nodes: [] }, wf);
+  assert.equal(args.length, 4);
+  assert.equal(args[3], wf); // 4th arg associates the load with the existing tab
+  assert.equal(args[1], true);
+  assert.equal(args[2], true);
+});
+
+test("#334: a load onto a truly blank canvas falls back to a single-arg load", () => {
+  const args = resolveLoadGraphArgs({ nodes: [] }, null);
+  assert.deepEqual(args, [{ nodes: [] }]);
+});
+
+// ---- #296 / #291 session-init hello frame ---------------------------------
+
+test("#296: hello advertises comfyui_path when a local workspace is known", () => {
+  const frame = buildHelloPayload({
+    tabId: "wf:workflows/x.json",
+    title: "x",
+    panelVersion: "0.11.19",
+    backend: "codex",
+    comfyuiUrl: "http://127.0.0.1:8188",
+    comfyuiPath: "C:\\AI\\ComfyUI_windows_portable",
+  });
+  assert.equal(frame.type, "hello");
+  assert.equal(frame.comfyui_path, "C:\\AI\\ComfyUI_windows_portable");
+  assert.equal(frame.backend, "codex");
+  assert.equal(frame.comfyui_url, "http://127.0.0.1:8188");
+});
+
+test("#296: comfyui_path is omitted (never blank) when unknown", () => {
+  const frame = buildHelloPayload({ tabId: "t", comfyuiPath: "   " });
+  assert.equal("comfyui_path" in frame, false);
+  assert.equal(frame.backend, "claude"); // default provider
+  assert.equal(frame.blind, false);
+});
+
+test("#296: resume rides the hello only when present", () => {
+  assert.equal("resume" in buildHelloPayload({ tabId: "t" }), false);
+  assert.equal(buildHelloPayload({ tabId: "t", resume: "sess-1" }).resume, "sess-1");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -126,6 +126,14 @@ import {
 import { saveActiveWorkflow } from "./lib/workflow-save.js";
 import { createRunCompletionTracker } from "./lib/run-completion.js";
 import { composeRunCompletionFrame } from "./lib/run-completion-frame.js";
+import {
+  shouldResumeAfterComfyReconnect,
+  shouldRehelloAfterCommand,
+  retryDuringReconnect,
+  dedupeWorkflowTabRecords,
+  resolveLoadGraphArgs,
+  buildHelloPayload,
+} from "./lib/session-rebind.js";
 
 let app = null;
 let api = null;
@@ -1197,6 +1205,12 @@ function ssSet(key, val) {
 // open — until they explicitly Disconnect. localStorage so it survives a full
 // frontend reload, not just a tab session.
 const AUTOCONNECT_KEY = "comfyui-mcp.panel.autoConnect";
+// #278 — Persistent explicit-Disconnect latch. Set when the user clicks
+// Disconnect, cleared on any connect intent. localStorage (not just an in-memory
+// flag) so the opt-out SURVIVES a full frontend reload — otherwise a page reload
+// would reset it while SESSION_KEY persists, letting the blocked session-resume
+// path fire after a later ComfyUI restart.
+const USER_DISCONNECTED_KEY = "comfyui-mcp.panel.userDisconnected";
 function lsGet(key) {
   try {
     return window.localStorage.getItem(key) || null;
@@ -1612,6 +1626,23 @@ function comfyuiUrlForAgent() {
   } catch {
     return "";
   }
+}
+
+// #296/#291 — Local ComfyUI workspace path, learned from the read-only panel
+// status route (folder_paths.base_path of the ComfyUI this panel is embedded
+// in). Advertised in the session-init hello so the orchestrator can register the
+// live panel_* graph tools + local panel management even with no CLI workspace
+// config. Empty for a remote/pod ComfyUI (no local filesystem to manage).
+let _localComfyuiPath = "";
+// Settled once the local-path probe finishes (resolve or reject). connectAgent
+// awaits this before the first hello so the very first session advertises the
+// path, not just a later reconnect. Assigned by the mount-time probe below.
+let localComfyuiPathReady = Promise.resolve();
+function localComfyuiPathForAgent() {
+  // A manual remote-URL override means the agent is NOT driving this local
+  // ComfyUI's filesystem — don't advertise a path that isn't the live target.
+  if (remoteUrlSetting()) return "";
+  return typeof _localComfyuiPath === "string" ? _localComfyuiPath : "";
 }
 
 // Build the settings list registered on the extension. Defined as a function so
@@ -5100,7 +5131,15 @@ const GRAPH_TOOL_EXECUTORS = {
     // loadGraphData is async on current frontends — AWAIT it so follow-ups
     // (checkState for one-step undo, success toasts) run after the graph has
     // actually landed, and a load failure rejects instead of vanishing.
-    await app.loadGraphData(clone);
+    //
+    // #207/#334 — pass the ACTIVE workflow as the 4th arg so the load REPLACES
+    // the active tab in place (like workflow_open does) instead of spawning a
+    // new "Unsaved Workflow" tab. Repeated loads on the same named workflow
+    // otherwise appended duplicate tab records (panel_list_workflows showed the
+    // same active tab twice, and a later save 409'd), and a soft-reload-then-
+    // reload left graph routing stranded on a frozen Unsaved tab.
+    const activeWorkflow = app?.extensionManager?.workflow?.activeWorkflow || null;
+    await app.loadGraphData(...resolveLoadGraphArgs(clone, activeWorkflow));
     return {
       loaded: true,
       node_count: clone.nodes.length,
@@ -5868,7 +5907,11 @@ const GRAPH_TOOL_EXECUTORS = {
       // threw "Cannot read properties of undefined (reading 'path')" — removing the
       // only way to list open tabs exactly when it was needed to diagnose a desync
       // (panel #197). Filter first so the list is best-effort rather than fatal.
-      open: (s.openWorkflows ?? []).filter(Boolean).map(brief),
+      //
+      // #207 — collapse records that share a stable workflow key so the same
+      // active tab is never reported twice (a repeated panel_load_workflow used
+      // to append duplicate active records, and a later save then 409'd).
+      open: dedupeWorkflowTabRecords((s.openWorkflows ?? []).filter(Boolean).map(brief)),
     };
   },
 
@@ -6975,12 +7018,19 @@ const GRAPH_TOOL_EXECUTORS = {
     // to the absolute (no-/v2) legacy list route instead of surfacing a generic
     // "unreachable" error.
     const route = installedListRoute();
-    try {
-      return { installed: await managerGet(route) };
-    } catch (err) {
-      if (!isManagerUnreachable(err)) throw err;
-      return { installed: await managerCall(route) };
-    }
+    // #332 — immediately after panel_restart_comfyui, a Manager fetch throws a
+    // bare transport error ("Failed to fetch") before any HTTP status exists, so
+    // the 404/unreachable fallback below never fires and the raw error leaked to
+    // the agent. Retry transient transport failures with a short bounded backoff,
+    // then reword into an actionable "still reconnecting" status.
+    return retryDuringReconnect(async () => {
+      try {
+        return { installed: await managerGet(route) };
+      } catch (err) {
+        if (!isManagerUnreachable(err)) throw err;
+        return { installed: await managerCall(route) };
+      }
+    });
   },
 
   async nodes_install(args) {
@@ -8003,20 +8053,24 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // so a bare `--panel-orchestrator` points the agent at whatever ComfyUI is open.
       const comfyuiUrl = comfyuiUrlForAgent();
       sock.send(
-        JSON.stringify({
-          type: "hello",
-          tab_id: workflowTabId(),
-          title: getWorkflowTitle(),
-          // Our build version, so the orchestrator can auto-stamp it into the
-          // agent's ENV block (bug reports get version-pinned without digging).
-          panel_version: PANEL_VERSION,
-          backend,
-          // Blind content mode (issue #90): the orchestrator spawns this tab's
-          // comfyui tool server with pixel-withholding env when true.
-          blind: AGENT_BLIND,
-          ...(comfyuiUrl ? { comfyui_url: comfyuiUrl } : {}),
-          ...(resume ? { resume } : {}),
-        }),
+        JSON.stringify(
+          buildHelloPayload({
+            tabId: workflowTabId(),
+            title: getWorkflowTitle(),
+            // Our build version, so the orchestrator can auto-stamp it into the
+            // agent's ENV block (bug reports get version-pinned without digging).
+            panelVersion: PANEL_VERSION,
+            backend,
+            // Blind content mode (issue #90): the orchestrator spawns this tab's
+            // comfyui tool server with pixel-withholding env when true.
+            blind: AGENT_BLIND,
+            comfyuiUrl,
+            // #296/#291 — advertise the embedded local ComfyUI path so the
+            // orchestrator registers panel_* tools + local panel management.
+            comfyuiPath: localComfyuiPathForAgent(),
+            resume,
+          }),
+        ),
       );
     } catch {
       // Reconnect path will retry.
@@ -14222,6 +14276,17 @@ function buildPanel() {
         ssSet(REBOOT_KEY, "1");
         appendSystem("Restarting ComfyUI to load new nodes — I'll reconnect and pick up automatically when it's back.");
       }
+      // #310 — free_vram unloads models and can BOUNCE the ComfyUI connection,
+      // which drops the orchestrator's tab mapping (the next graph tool then
+      // failed with "Connected: none"). Re-advertise this tab so the binding
+      // survives, exactly as the restart path re-establishes it on reconnect.
+      if (shouldRehelloAfterCommand(cmd, reply)) {
+        try {
+          client?.rehello?.();
+        } catch {
+          /* the reconnect path retries the hello */
+        }
+      }
     },
     onAgentStatus(s) {
       // Percentage of the context window used (label + ring), persisted so a
@@ -14639,16 +14704,36 @@ function buildPanel() {
   }
   function onComfyReconnected() {
     // After ComfyUI comes back (backend-only reboot — the page didn't reload),
-    // the orchestrator died with it. Respawn + reconnect if the agent was in use:
-    // either a restart WE triggered (REBOOT_KEY) or sticky auto-connect.
-    if (!ssGet(REBOOT_KEY) && !lsGet(AUTOCONNECT_KEY)) return;
+    // the orchestrator died with it. Respawn + reconnect if the agent was in use.
     // ComfyUI fires "reconnected" for BENIGN WS blips too — viewing assets,
     // checking an image's status, a tab refocus — and those do NOT kill the
     // orchestrator. If OUR bridge is still up, the agent is alive and well, so
     // do NOT bounce a live session (that was the spurious "you reconnected"). A
     // real ComfyUI restart drops the bridge (the orchestrator dies with it, and
     // the bridge's own retry can't respawn it) — only then do we respawn here.
-    if (client.isConnected()) return;
+    //
+    // #278: resume not only on an explicit restart marker (REBOOT_KEY) or sticky
+    // auto-connect, but also when the CURRENT conversation still has a resumable
+    // agent session. A tool-triggered reboot that lost REBOOT_KEY otherwise
+    // stranded a live workflow chat as "Connected: none" until a manual refresh.
+    const activeThread = threads.find((t) => t.id === ssGet(CURRENT_THREAD_KEY)) || null;
+    const hasResumableSession =
+      !lsGet(USER_DISCONNECTED_KEY) &&
+      Boolean(
+        resumableSessionId(
+          activeThread || { sessionId: ssGet(SESSION_KEY), provider: connectedBackend || selectedBackend },
+        ),
+      );
+    if (
+      !shouldResumeAfterComfyReconnect({
+        bridgeConnected: client.isConnected(),
+        rebootPending: !!ssGet(REBOOT_KEY),
+        autoConnect: !!lsGet(AUTOCONNECT_KEY),
+        hasResumableSession,
+      })
+    ) {
+      return;
+    }
     appendSystem("ComfyUI is back — reconnecting the agent…");
     connectAgent();
   }
@@ -14680,6 +14765,11 @@ function buildPanel() {
   // bridge_url / setUrl / start) — otherwise it could reconnect the PREVIOUS provider
   // after the user already picked a new one. Only the newest generation wins.
   let connectGen = 0;
+  // Monotonic explicit-Disconnect epoch: bumped on every user Disconnect. A
+  // connectAgent() that started BEFORE a Disconnect (and is parked on its entry
+  // awaits) must NOT resurrect the connection when it wakes — it snapshots this
+  // at entry and bails if a Disconnect bumped it during the await (#278 race).
+  let disconnectEpoch = 0;
   // The last ws URL the picker auto-applied (from /connect's bridge_url). Lets us
   // tell a MANUAL Advanced-URL override apart from an auto-managed one, so a user
   // who typed their own bridge URL isn't silently overwritten by the backend's port.
@@ -15008,9 +15098,20 @@ function buildPanel() {
   }
 
   async function connectAgent(opts = {}) {
-    // hello reads SESSION_KEY, so wait until reload reconciliation has made the
-    // single settings-aware thread/session binding for this browser tab.
+    // Entry awaits, grouped so NO async gap sits between the in-flight guard and
+    // `connecting = true` (that gap would let two connects race). (1) hello reads
+    // SESSION_KEY, so wait for reload reconciliation to make this tab's single
+    // settings-aware thread/session binding; (2) #296/#291 — ensure the local
+    // ComfyUI path probe has settled so the FIRST hello (not just a later
+    // reconnect) can advertise comfyui_path. localComfyuiPathReady is itself
+    // bounded to 2s and never rejects, so this can't stall Connect.
+    const myDisconnectEpoch = disconnectEpoch;
     await historyRestoreReady;
+    await localComfyuiPathReady;
+    // If the user hit Disconnect WHILE we were parked on the entry awaits, abort —
+    // do NOT clear the explicit-disconnect latch or start connecting. Honors the
+    // user's choice against the up-to-2s await window (#278 cancellation race).
+    if (disconnectEpoch !== myDisconnectEpoch) return;
     // A chip pick (opts.fromChip) is an EXPLICIT backend choice — it must always
     // (re)connect to that backend's port, so it bypasses the in-flight guard (which
     // a sticky-reconnect could otherwise hold) and the manual-URL override below.
@@ -15024,6 +15125,11 @@ function buildPanel() {
     // took over — re-arm normal auto-respawn).
     resetAutoReclaim();
     clearSoftReloadGuard();
+    // Any connect intent clears the explicit-disconnect latch so the post-reboot
+    // session-resume path (#278) is armed again for this fresh session. Done
+    // synchronously right before `connecting = true` (no await between) so an
+    // explicit Disconnect can't be straddled by this latch clear.
+    lsSet(USER_DISCONNECTED_KEY, null);
     connecting = true;
     connectBtn.disabled = true;
     connectBtn.textContent = "Starting…";
@@ -15345,6 +15451,17 @@ function buildPanel() {
     // Explicit Disconnect = opt out of sticky auto-reconnect (and the matching setting).
     lsSet(AUTOCONNECT_KEY, null);
     setSetting(SETTING_AUTOCONNECT, false);
+    // Latch the explicit opt-out (persistently, survives reload) so a later
+    // ComfyUI restart does NOT auto-resume via the #278 session-resume path.
+    // SESSION_KEY intentionally persists so a manual Reconnect can still resume —
+    // but only when the USER asks for it.
+    lsSet(USER_DISCONNECTED_KEY, "1");
+    // Bump the disconnect epoch so any connectAgent() parked on its entry awaits
+    // aborts instead of resurrecting the connection when it wakes.
+    disconnectEpoch += 1;
+    // Also cancel any pending tool-triggered reboot resume: an explicit Disconnect
+    // during a reboot window must not be overridden by a surviving REBOOT_KEY.
+    ssSet(REBOOT_KEY, null);
     client.stop();
     // client.stop() sets closed=true, so the socket onclose suppresses onStatus
     // — end the turn locally so the working indicator can't spin forever against
@@ -17057,6 +17174,30 @@ function buildPanel() {
   // below): shows the onboarding card if NEITHER provider is signed in, and
   // auto-picks a ready provider if the saved pick isn't usable.
   void loadBackends();
+
+  // #296/#291 — Learn the embedded local ComfyUI workspace path (read-only, from
+  // folder_paths.base_path) BEFORE the first hello so the session-init frame can
+  // advertise it. Runs independently of the connect decision below so the path is
+  // known whether we auto-connect or sit idle. Best-effort: a remote/pod ComfyUI
+  // or an older pack (no field) simply advertises no path.
+  const probeLocalComfyuiPath = async () => {
+    try {
+      const res = await api.fetchApi("/comfyui_mcp_panel/status");
+      const data = await res.json().catch(() => ({}));
+      if (typeof data?.comfyui_path === "string") _localComfyuiPath = data.comfyui_path;
+    } catch {
+      // No status route — advertise no local path (orchestrator falls back to
+      // its own workspace detection).
+    }
+  };
+  // Bounded: connectAgent awaits this before the first hello, so a slow/hung
+  // status route — OR a stalled res.json() — must never stall Connect. Race the
+  // WHOLE probe (fetch AND body read) against a 2s cap and proceed with no local
+  // path if it doesn't settle in time.
+  localComfyuiPathReady = Promise.race([
+    probeLocalComfyuiPath(),
+    new Promise((resolve) => setTimeout(resolve, 2000)),
+  ]);
 
   (async () => {
     await historyRestoreReady;

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -1,0 +1,206 @@
+// Session / reconnect / tab-rebind helpers — pure, side-effect-free logic split
+// out of comfyui-mcp-panel.js so it can be unit-tested with `node --test`.
+//
+// These back the frontend half of the session/tab-binding cluster (panel repo
+// issues #278, #334, #296, #291, #207, #332, #310). The orchestrator owns the
+// authoritative tab-target + tool registration (comfyui-mcp #512); the panel
+// must (a) preserve/rebind the active tab across reboot/soft-reload/free_vram,
+// (b) advertise the local COMFYUI_PATH at session init, (c) not report the same
+// active tab twice, and (d) degrade gracefully during the reconnect window.
+
+const DEFAULT_SLEEP = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// #278 — Post-reboot autonomous resume. ComfyUI fires `reconnected` after it
+// comes back (a Manager reboot, a free_vram bounce, …). We respawn + reconnect
+// the orchestrator ONLY when the bridge is actually down AND the session is
+// worth resuming. The prior guard resumed only on an explicit REBOOT_KEY /
+// AUTOCONNECT_KEY marker, so a reboot that lost the marker stranded a still-live
+// workflow conversation ("Connected: none"). A resumable active session is now
+// a third, independent reason to reconnect.
+export function shouldResumeAfterComfyReconnect({
+  bridgeConnected = false,
+  rebootPending = false,
+  autoConnect = false,
+  hasResumableSession = false,
+} = {}) {
+  // Bridge still up → the orchestrator (and agent) never died; a benign ComfyUI
+  // WS blip must NOT bounce a live session.
+  if (bridgeConnected) return false;
+  return Boolean(rebootPending || autoConnect || hasResumableSession);
+}
+
+// #310 — free_vram can bounce the ComfyUI connection (models unloaded, the WS
+// blips), which drops the orchestrator's tab mapping the way a restart does.
+// Re-advertise (rehello) this tab after a successful free_vram so the very next
+// graph tool still routes to the connected tab instead of "Connected: none".
+export function shouldRehelloAfterCommand(cmd, reply) {
+  return cmd === "free_vram" && Boolean(reply && reply.ok);
+}
+
+// #332 — During the post-restart reconnect window a Manager-backed fetch (e.g.
+// panel_list_nodes) throws a bare transport error ("Failed to fetch") before any
+// HTTP status exists, so the usual 404/"unreachable" handling never fires. Match
+// those transient transport failures so they can be retried / reworded instead
+// of surfaced raw.
+export function isTransientReconnectError(err) {
+  const msg = String((err && err.message) || err || "");
+  return /failed to fetch|networkerror|network error|load failed|fetch failed|connection (was )?lost|err_connection|econnrefused|econnreset|socket hang up/i.test(
+    msg,
+  );
+}
+
+// Bounded retry for a call that may hit the reconnect window. Retries ONLY
+// transient transport failures (isTransient), with capped exponential backoff.
+// A non-transient error propagates immediately (unchanged behavior); a transient
+// failure that never clears is reworded into an actionable "still reconnecting"
+// message rather than a raw "Failed to fetch".
+export async function retryDuringReconnect(
+  fn,
+  {
+    attempts = 4,
+    baseDelayMs = 250,
+    maxDelayMs = 2000,
+    sleep = DEFAULT_SLEEP,
+    isTransient = isTransientReconnectError,
+    label = "ComfyUI/Manager",
+  } = {},
+) {
+  let lastErr;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      const last = i === attempts - 1;
+      if (!isTransient(err) || last) break;
+      await sleep(Math.min(maxDelayMs, baseDelayMs * 2 ** i));
+    }
+  }
+  if (isTransient(lastErr)) {
+    const detail = String((lastErr && lastErr.message) || lastErr || "");
+    // Preserve the original error as `cause` so its type/stack are not lost —
+    // and word it as "not reachable right now (may still be reconnecting)"
+    // rather than asserting a restart, since a persistent CORS/proxy/Manager
+    // outage can look the same at the transport layer.
+    throw new Error(
+      `${label} is not reachable right now (it may still be reconnecting after a restart) — retry in a moment.` +
+        (detail ? ` (${detail})` : ""),
+      { cause: lastErr },
+    );
+  }
+  throw lastErr;
+}
+
+// #207 / #334 — Stable identity for a workflow tab record. A load that replaces
+// the active canvas can flip the tab id (tmp: → wf:) or re-add the same file, so
+// dedupe on the rename-stable identity. Strip the tmp:/wf: scheme prefix so the
+// path form ("workflows/a.json") and the key form ("wf:workflows/a.json") of the
+// SAME file converge, normalize separators, and drop the .json suffix. Case is
+// PRESERVED so distinct files on a case-sensitive (Linux) filesystem are never
+// collapsed; the frontend reports a stable casing per file so real duplicates
+// still match.
+export function workflowTabKey(rec) {
+  if (!rec || typeof rec !== "object") return "";
+  // ONLY a path or a path-bearing key is a stable identity. A bare `filename` is
+  // NOT: multiple unsaved tabs share the name "Unsaved Workflow", and a filename
+  // "foo" would otherwise collide with the saved file "foo.json". Records with no
+  // real path/key return "" and are kept as DISTINCT (never deduped).
+  let s = String(rec.path || rec.key || "").replace(/\\/g, "/");
+  const scheme = s.match(/^(tmp|wf):(.*)$/);
+  if (scheme) {
+    // `wf:` always denotes a real SAVED path (even a root-level "wf:foo.json"),
+    // so strip it unconditionally to unify with the path form "foo.json". `tmp:`
+    // is an ephemeral tab id that may be a bare token ("tmp:<uuid>") — strip it
+    // ONLY when a real path follows (contains "/") so a pathless temp tab keeps
+    // its own namespace and can never collide with a saved file of the same name.
+    if (scheme[1] === "wf" || scheme[2].includes("/")) s = scheme[2];
+  }
+  // Case-sensitive .json strip (workflows are always lowercase ".json") and
+  // case-PRESERVING otherwise, so case-distinct files on a case-sensitive
+  // (Linux) filesystem are never collapsed.
+  return s.replace(/\.json$/, "").trim();
+}
+
+// #207 — panel_load_workflow could leave panel_list_workflows reporting the SAME
+// active tab several times (each load appended a record instead of updating one),
+// and a later save then 409'd. Collapse records that share a stable key into one,
+// preferring the active/persisted flags and the freshest fields. Unkeyed records
+// (a blank/Unsaved tab with no path) are kept as-is — they are genuinely distinct.
+export function dedupeWorkflowTabRecords(records) {
+  if (!Array.isArray(records)) return [];
+  const byKey = new Map();
+  const out = [];
+  for (const rec of records) {
+    if (!rec) continue;
+    const key = workflowTabKey(rec);
+    if (!key) {
+      out.push(rec);
+      continue;
+    }
+    const prev = byKey.get(key);
+    if (!prev) {
+      const slot = { index: out.length };
+      byKey.set(key, slot);
+      out.push(rec);
+      slot.ref = rec;
+    } else {
+      out[prev.index] = mergeTabRecord(out[prev.index], rec);
+    }
+  }
+  return out;
+}
+
+function mergeTabRecord(prev, next) {
+  return {
+    ...prev,
+    ...next,
+    active: Boolean(prev.active || next.active),
+    persisted: Boolean(prev.persisted || next.persisted),
+    modified: Boolean(prev.modified || next.modified),
+  };
+}
+
+// #207 / #334 — Args for app.loadGraphData when panel_load_workflow replaces the
+// active canvas. Passing the active workflow as the 4th arg ASSOCIATES the load
+// with the existing tab (exactly like workflow_open does), so the graph replaces
+// the persisted tab IN PLACE instead of spawning a new "Unsaved Workflow" tab
+// (the dup-tab-record + frozen-routing report). With no active workflow (a truly
+// blank canvas) we fall back to the plain single-arg load.
+export function resolveLoadGraphArgs(graphData, activeWorkflow) {
+  if (activeWorkflow && typeof activeWorkflow === "object") {
+    return [graphData, true, true, activeWorkflow];
+  }
+  return [graphData];
+}
+
+// #296 / #291 — Session-init hello frame. Centralizing it guarantees every
+// session advertises the same fields, and adds `comfyui_path`: for a LOCAL
+// portable ComfyUI the orchestrator otherwise has no workspace path, so it
+// reports "no COMFYUI_PATH configured" and skips registering the live panel_*
+// graph tools. Propagating the embedded ComfyUI's base path at init lets the
+// orchestrator register those tools independent of any CLI workspace config.
+export function buildHelloPayload({
+  tabId,
+  title,
+  panelVersion,
+  backend,
+  blind = false,
+  comfyuiUrl,
+  comfyuiPath,
+  resume,
+} = {}) {
+  const frame = {
+    type: "hello",
+    tab_id: tabId,
+    title,
+    panel_version: panelVersion,
+    backend: backend || "claude",
+    blind: Boolean(blind),
+  };
+  if (comfyuiUrl) frame.comfyui_url = comfyuiUrl;
+  if (typeof comfyuiPath === "string" && comfyuiPath.trim()) {
+    frame.comfyui_path = comfyuiPath.trim();
+  }
+  if (resume) frame.resume = resume;
+  return frame;
+}


### PR DESCRIPTION
Frontend half of the session/tab-binding cluster. The orchestrator's authoritative tab-target + tool registration already shipped in comfyui-mcp #512; this makes the panel honor it and stop losing state on reconnect/reload/free_vram.

## What changed
New pure, unit-tested module `web/js/lib/session-rebind.js`, wired into `web/js/comfyui-mcp-panel.js`, plus a read-only local-path field on the panel status route (`__init__.py`).

- **#278** — resume the active workflow session after a tool-triggered ComfyUI reboot even when `REBOOT_KEY` was lost, if a resumable session exists. Gated so a benign WS blip (bridge still up) never bounces a live session, and an explicit Disconnect (now a persistent, epoch-guarded latch that also clears `REBOOT_KEY`) is never overridden.
- **#310** — re-advertise (rehello) the connected tab after a successful `free_vram`, which can bounce the connection, so the next graph tool still routes to the tab instead of `Connected: none`.
- **#332** — retry transient `Failed to fetch` during the post-restart reconnect window with bounded backoff, preserving the original error via `cause` and rewording into an actionable message. Real HTTP errors still propagate immediately (no masking).
- **#207 / #334** — `graph_load` (panel_load_workflow) now passes the active workflow as `loadGraphData`'s 4th arg so it replaces the active tab **in place** instead of spawning an `Unsaved Workflow` tab; `workflow_list` dedupes tab records by a scheme-stripped, case-preserving stable key (root-level `wf:` unifies with its path form; pathless `tmp:` and filename-only unsaved tabs stay distinct).
- **#296 / #291** — advertise the embedded local ComfyUI `base_path` (read-only status route) in the session-init `hello`, so the orchestrator can register the live `panel_*` graph tools + local panel management without CLI workspace config.

## Scope note
`panel_*` tool **registration** itself lives in the orchestrator (comfyui-mcp), not this repo. This PR delivers the frontend half of #296/#291 — propagating the local `COMFYUI_PATH` at session init; the orchestrator consuming it to register tools is the remaining orchestrator-side work.

## Tests
`browser_tests/unit/session-rebind.test.mjs` (26 cases) — tab-registry dedupe, reconnect resume guard, free_vram rehello, reconnect-window retry, load-in-place args, hello payload. `node --test browser_tests/unit/*.mjs` all green.

## Codex gate
Adversarial codex review (OpenAI acct): **VERDICT: PASS** (after 5 rounds; earlier rounds caught and fixed a disconnect-resume regression, a first-hello path race, a probe-hang, and several tab-key identity collisions).

Closes #278
Closes #334
Partially addresses #296 (frontend advertises the local COMFYUI_PATH at session init; orchestrator-side tool registration deferred — NOT auto-closing)
Partially addresses #291 (orchestrator-side panel_* tool registration deferred — NOT auto-closing)
Closes #207
Closes #332
Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)