### PR TITLE
release: 0.11.20 — session rebind + connect/set-widget edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.20] - 2026-07-30
+
+### Fixed
+- **Session rebinds/preserves the active tab across a tool-triggered reboot, soft reload, or `free_vram` (#278, #334, #207, #332, #310).** Resume the active session after a reboot (gated so a benign WS blip never bounces a live session, and an explicit Disconnect is never overridden); rehello the connected tab after `free_vram`; bounded retry of transient `Failed to fetch` during the reconnect window; `graph_load` replaces the active tab in place (no `Unsaved Workflow` spawn) and `workflow_list` dedupes tab records; the embedded ComfyUI `base_path` is advertised in the session hello. (#349)
+- **panel_connect matches a valid `IMAGE→IMAGE` pair, and set_widget edges (#351, #179, #169; panel-side of #347).** `from_output` arriving JSON-stringified as `"0"` was read as a slot *named* `"0"` → 'no compatible pair' on a valid link; resolution is now name-first with a numeric-string→index fallback (#351). rgthree Power Lora composite widget values are parsed + merged instead of written verbatim (#179). Auto-match no longer clobbers an occupied dynamic-wildcard link (#169). `coerceWidgetValue` allows an explicit empty-string clear and rejects a genuinely-missing value (#347, panel side — the end-to-end empty-string fix also needs an orchestrator serialization change). Strict type-compat (#204) and combo/numeric strictness (#240) preserved. (#353)
+
 ## [0.11.19] - 2026-07-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.19"
+version = "0.11.20"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -247,7 +247,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.19";
+const PANEL_VERSION = "0.11.20";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Cuts panel **0.11.20** (pyproject `version` + `PANEL_VERSION` bumped together → Registry publish on merge).

## Ships
- **#278/#334/#207/#332/#310 (#349):** frontend session rebind/preserve tab across reboot/soft-reload/free_vram + tab-registry dedupe + reconnect-window retry. codex PASS (5 rounds), 26-test pure module.
- **#351/#179/#169 + panel-side #347 (#353):** valid IMAGE→IMAGE match (name-first slot resolution), rgthree Power Lora composite, don't-clobber-wildcard, empty-string clear. codex PASS (3 rounds), 21 tests. #204/#240 strictness preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)