### PR TITLE
fix(subgraph): consistent scope tracking + rail-id move + boundary cleanup + read/edit scope lockstep (#308, #302, #234, #220)

### DIFF
--- a/browser_tests/unit/subgraph-scope.test.mjs
+++ b/browser_tests/unit/subgraph-scope.test.mjs
@@ -111,6 +111,24 @@ test("resolveRailNode: a normal node id is NOT a rail (move_node falls through t
   assert.equal(resolveRailNode(root, SUBGRAPH_INPUT_RAIL_ID), null);
 });
 
+test("#302 collision: a REAL node whose id is -10/-20 WINS over the reserved rail id (rail defers)", () => {
+  const sub = makeSubgraph();
+  const realNode = { id: SUBGRAPH_INPUT_RAIL_ID, type: "Note" };
+  sub.getNodeById = (n) => (Number(n) === SUBGRAPH_INPUT_RAIL_ID ? realNode : null);
+  // -10 now names a real interior node, so resolveRailNode must NOT claim it as a rail
+  // (else move_node would move the input rail instead of that node).
+  assert.equal(
+    resolveRailNode(sub, SUBGRAPH_INPUT_RAIL_ID),
+    null,
+    "a real node with id -10 must win over the input rail",
+  );
+  // -20 has no colliding node ⇒ still resolves to the output rail.
+  assert.equal(resolveRailNode(sub, SUBGRAPH_OUTPUT_RAIL_ID).rail, "output");
+  // The rail's OWN frontend id stays rail-first even when getNodeById is present.
+  sub.inputNode.id = 7;
+  assert.equal(resolveRailNode(sub, 7).rail, "input");
+});
+
 test("railKindFor: reports intent even when the graph has no rails (root-graph error path)", () => {
   assert.equal(railKindFor(SUBGRAPH_INPUT_RAIL_ID), "input");
   assert.equal(railKindFor(SUBGRAPH_OUTPUT_RAIL_ID), "output");

--- a/browser_tests/unit/subgraph-scope.test.mjs
+++ b/browser_tests/unit/subgraph-scope.test.mjs
@@ -1,0 +1,296 @@
+/**
+ * Unit tests for web/js/lib/subgraph-scope.js — run with `node --test`.
+ *
+ * These drive the SAME pure helpers the panel's graph_* tools call, modelling the
+ * subgraph scope/cleanup bug cluster:
+ *   - #308: exit_subgraph reported "already at root" right after a query showed a
+ *           live subgraph scope (read + navigation disagreed).
+ *   - #302: the boundary RAIL ids (-10/-20) reported by query_graph were rejected
+ *           by move_node.
+ *   - #234: removing the last interior consumer left the boundary slot orphaned.
+ *   - #220: after a reconnect the READ scope and the EDIT scope diverged (stale
+ *           canvas subgraph the rebuilt root no longer owns).
+ *
+ * FAIL-before / PASS-after: with the OLD shallow describeActiveGraph +
+ * app.canvas.graph read, a stale subgraph reference reports "subgraph" for reads
+ * while writes target a ghost — the lockstep test below encodes that divergence and
+ * only passes with resolveScope's reconciliation.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  SUBGRAPH_INPUT_RAIL_ID,
+  SUBGRAPH_OUTPUT_RAIL_ID,
+  railKindFor,
+  resolveRailNode,
+  findSubgraphOwner,
+  isSubgraphInRoot,
+  resolveScope,
+  describeScope,
+  computeOrphanedBoundaries,
+} from "../../web/js/lib/subgraph-scope.js";
+
+// ---- Fixtures --------------------------------------------------------------
+
+// Minimal rail nodes as LiteGraph exposes them: inputNode.id === -10,
+// outputNode.id === -20. query_graph reports these ids as rail_node_id.
+function makeSubgraph({ name = "sub", inputs = [], outputs = [], nodes = [], links = [] } = {}) {
+  const inputNode = { id: SUBGRAPH_INPUT_RAIL_ID, pos: [100, 100] };
+  const outputNode = { id: SUBGRAPH_OUTPUT_RAIL_ID, pos: [900, 100] };
+  const linkMap = new Map(links.map((l) => [Number(l.id), l]));
+  const sub = {
+    name,
+    inputs,
+    outputs,
+    inputNode,
+    outputNode,
+    _nodes: nodes,
+    getLink: (id) => linkMap.get(Number(id)) ?? null,
+    removeInput(slot) {
+      const i = this.inputs.indexOf(slot);
+      if (i >= 0) this.inputs.splice(i, 1);
+    },
+    removeOutput(slot) {
+      const i = this.outputs.indexOf(slot);
+      if (i >= 0) this.outputs.splice(i, 1);
+    },
+  };
+  return sub;
+}
+
+// An `app` whose canvas points at `canvasGraph`, with a root graph whose nodes may
+// (or may NOT) own the open subgraph — the latter models the post-reconnect stale ref.
+function makeApp({ rootNodes = [], canvasGraph } = {}) {
+  const root = { _nodes: rootNodes };
+  let current = canvasGraph ?? root;
+  return {
+    graph: root,
+    canvas: {
+      graph: current,
+      setGraph(g) {
+        current = g;
+        this.graph = g;
+      },
+      setDirty() {},
+    },
+  };
+}
+
+// ---- #302: move_node must accept the rail ids query_graph returns ----------
+
+test("resolveRailNode: -10 / -20 (the ids query_graph reports) resolve to the rails", () => {
+  const sub = makeSubgraph();
+  const inRail = resolveRailNode(sub, SUBGRAPH_INPUT_RAIL_ID);
+  assert.ok(inRail, "input rail id -10 must resolve");
+  assert.equal(inRail.rail, "input");
+  assert.equal(inRail.node, sub.inputNode);
+
+  const outRail = resolveRailNode(sub, SUBGRAPH_OUTPUT_RAIL_ID);
+  assert.ok(outRail, "output rail id -20 must resolve");
+  assert.equal(outRail.rail, "output");
+  assert.equal(outRail.node, sub.outputNode);
+});
+
+test("resolveRailNode: aliases and the frontend-assigned rail node id also resolve", () => {
+  const sub = makeSubgraph();
+  assert.equal(resolveRailNode(sub, "input").rail, "input");
+  assert.equal(resolveRailNode(sub, "output_rail").rail, "output");
+  // A rail node carrying a non-canonical positive id still matches by its own id.
+  sub.inputNode.id = 42;
+  assert.equal(resolveRailNode(sub, 42).rail, "input");
+  // -10 STILL resolves to input even when the node id was reassigned (reserved id).
+  assert.equal(resolveRailNode(sub, SUBGRAPH_INPUT_RAIL_ID).rail, "input");
+});
+
+test("resolveRailNode: a normal node id is NOT a rail (move_node falls through to resolveNode)", () => {
+  const sub = makeSubgraph();
+  assert.equal(resolveRailNode(sub, 5), null);
+  // The ROOT graph has no rails, so even -10 resolves to nothing there.
+  const root = { _nodes: [] };
+  assert.equal(resolveRailNode(root, SUBGRAPH_INPUT_RAIL_ID), null);
+});
+
+test("railKindFor: reports intent even when the graph has no rails (root-graph error path)", () => {
+  assert.equal(railKindFor(SUBGRAPH_INPUT_RAIL_ID), "input");
+  assert.equal(railKindFor(SUBGRAPH_OUTPUT_RAIL_ID), "output");
+  assert.equal(railKindFor("input"), "input");
+  assert.equal(railKindFor(3), null);
+});
+
+// Model the production move path decision: rail id ⇒ move the rail node, not resolveNode.
+test("#302 move_node path: a -10 rail id from query_graph is MOVABLE", () => {
+  const sub = makeSubgraph();
+  const rail = resolveRailNode(sub, SUBGRAPH_INPUT_RAIL_ID);
+  assert.ok(rail);
+  rail.node.pos = [160, 2500];
+  assert.deepEqual(sub.inputNode.pos, [160, 2500]);
+});
+
+// ---- #234: removing an interior node prunes ITS orphaned boundary slot -----
+
+test("#234 computeOrphanedBoundaries: slot whose only consumer was removed ⇒ pruned", () => {
+  // Boundary input "text" fed ONLY interior node 87 (the removed CLIPTextEncode).
+  const inputs = [
+    { name: "text", index: 0, targetNodeIds: [87] },
+    { name: "seed", index: 1, targetNodeIds: [88] }, // still feeds a surviving node
+  ];
+  const out = computeOrphanedBoundaries({ inputs, removedNodeIds: [87] });
+  assert.deepEqual(out.inputs.map((s) => s.name), ["text"]);
+  assert.equal(out.outputs.length, 0);
+});
+
+test("#234: a boundary still feeding a SURVIVING node is KEPT (never yank a live slot)", () => {
+  const inputs = [{ name: "text", index: 0, targetNodeIds: [87, 99] }]; // 99 survives
+  const out = computeOrphanedBoundaries({ inputs, removedNodeIds: [87] });
+  assert.equal(out.inputs.length, 0, "slot with a surviving consumer must be kept");
+});
+
+test("#234: a freshly-added empty boundary (no interior link) is LEFT ALONE", () => {
+  const inputs = [{ name: "text", index: 0, targetNodeIds: [] }];
+  const out = computeOrphanedBoundaries({ inputs, removedNodeIds: [87] });
+  assert.equal(out.inputs.length, 0);
+});
+
+test("#234: output boundary orphaned by removing its only producer ⇒ pruned", () => {
+  const outputs = [{ name: "conditioning", index: 0, sourceNodeIds: [87] }];
+  const out = computeOrphanedBoundaries({ outputs, removedNodeIds: [87] });
+  assert.deepEqual(out.outputs.map((s) => s.name), ["conditioning"]);
+});
+
+// End-to-end prune against a live-ish subgraph object, exactly like the handler does.
+test("#234 e2e: removing the interior owner prunes the orphaned `text` slot off the rail", () => {
+  const textSlot = { name: "text", linkIds: [1] };
+  const seedSlot = { name: "seed", linkIds: [2] };
+  const sub = makeSubgraph({
+    inputs: [textSlot, seedSlot],
+    links: [
+      { id: 1, origin_id: SUBGRAPH_INPUT_RAIL_ID, origin_slot: 0, target_id: 87, target_slot: 0 },
+      { id: 2, origin_id: SUBGRAPH_INPUT_RAIL_ID, origin_slot: 1, target_id: 88, target_slot: 0 },
+    ],
+  });
+  // Model = boundary→interior endpoints (what subgraphBoundaryModel builds).
+  const model = {
+    inputs: [
+      { name: "text", index: 0, slot: textSlot, targetNodeIds: [87] },
+      { name: "seed", index: 1, slot: seedSlot, targetNodeIds: [88] },
+    ],
+    outputs: [],
+  };
+  const orphans = computeOrphanedBoundaries({ ...model, removedNodeIds: [87] });
+  for (const s of orphans.inputs) sub.removeInput(s.slot);
+  // The orphaned `text` slot is gone; `seed` (live) remains — so re-exposing the
+  // replacement node's input as `text` reuses the name instead of minting `text_1`.
+  assert.deepEqual(sub.inputs.map((s) => s.name), ["seed"]);
+});
+
+// ---- #220 / #308: ONE authoritative scope for reads AND writes -------------
+
+test("findSubgraphOwner: locates the owning SubgraphNode (incl. nested)", () => {
+  const deep = makeSubgraph({ name: "inner" });
+  const midOwner = { id: 5, subgraph: makeSubgraph({ name: "mid", nodes: [{ id: 9, subgraph: deep }] }) };
+  const root = { _nodes: [{ id: 1 }, midOwner] };
+  // deep is owned by node 9, which lives inside node 5's subgraph — nesting-aware.
+  const owner = findSubgraphOwner(root, deep);
+  assert.ok(owner);
+  assert.equal(owner.id, 9);
+  // An unrelated graph has no owner.
+  assert.equal(findSubgraphOwner(root, makeSubgraph({ name: "orphan" })), null);
+});
+
+test("resolveScope: valid open subgraph ⇒ scope 'subgraph', not stale", () => {
+  const sub = makeSubgraph({ name: "s", nodes: [{ id: 87 }] });
+  const owner = { id: 130, subgraph: sub };
+  const app = makeApp({ rootNodes: [owner], canvasGraph: sub });
+  const scope = resolveScope(app);
+  assert.equal(scope.scope, "subgraph");
+  assert.equal(scope.stale, false);
+  assert.equal(scope.owner.id, 130);
+  assert.equal(scope.graph, sub);
+  // title falls back to the subgraph name when the owner node has no title.
+  assert.deepEqual(describeScope(scope), { scope: "subgraph", owner_node_id: 130, title: "s" });
+});
+
+test("resolveScope: at root ⇒ scope 'root'", () => {
+  const app = makeApp({ rootNodes: [{ id: 1 }] });
+  const scope = resolveScope(app);
+  assert.equal(scope.scope, "root");
+  assert.equal(scope.stale, false);
+  assert.equal(scope.graph, app.graph);
+  assert.deepEqual(describeScope(scope), { scope: "root" });
+});
+
+// THE #220 lockstep test: after a reconnect the root graph is REBUILT (new owner
+// instance whose .subgraph is a NEW object), but the canvas still references the OLD
+// subgraph. The old canvas subgraph is unreachable from the live root ⇒ STALE.
+test("#220/#308: stale canvas subgraph (rebuilt root) ⇒ reconcile to root, read+edit in lockstep", () => {
+  const staleSub = makeSubgraph({ name: "old", nodes: [{ id: 87 }, { id: 88 }] });
+  // Rebuilt root: a fresh owner node whose subgraph is a DIFFERENT object.
+  const freshSub = makeSubgraph({ name: "new", nodes: [{ id: 87 }, { id: 88 }] });
+  const freshOwner = { id: 128, subgraph: freshSub };
+  const app = makeApp({ rootNodes: [freshOwner], canvasGraph: staleSub });
+
+  const scope = resolveScope(app);
+  // The read scope resolves to ROOT (not a phantom subgraph) because staleSub is
+  // unreachable from the rebuilt root — so it AGREES with where writes would land.
+  assert.equal(scope.stale, true, "unreachable canvas subgraph must be flagged stale");
+  assert.equal(scope.scope, "root");
+  assert.equal(scope.graph, app.graph, "reads reconcile to the live root");
+  assert.equal(scope.rootGraph, app.graph);
+  // describeScope reports root — NOT 'subgraph, owner 128' — so graph_outline and
+  // set_widget can no longer diverge (outline said subgraph, set_widget said 'no
+  // node' in the bug).
+  assert.deepEqual(describeScope(scope), { scope: "root" });
+
+  // Caller rebinds the canvas to root (the getGraphCtx side effect) — physical view
+  // now matches the reconciled scope, keeping read + edit in lockstep.
+  if (scope.stale) app.canvas.setGraph(scope.rootGraph);
+  assert.equal(app.canvas.graph, app.graph);
+  // Re-resolving is now cleanly at root (no residual subgraph claim).
+  assert.equal(resolveScope(app).scope, "root");
+});
+
+// #308 specifically: query and exit must AGREE. A valid subgraph → both see it; a
+// stale one → both see root (so exit's "already at root" is truthful, not a
+// contradiction of a preceding query that claimed subgraph).
+// Guard against over-eager stale detection: a subgraph registered in the root's
+// uuid→Subgraph registry (a definition with NO current owner-node instance) must NOT
+// be misclassified as stale and force-exited to root.
+test("resolveScope: subgraph reachable via rootGraph.subgraphs registry (no owner node) ⇒ NOT stale", () => {
+  const sub = makeSubgraph({ name: "reg" });
+  sub.id = "uuid-123";
+  const app = makeApp({ rootNodes: [], canvasGraph: sub });
+  // Root exposes the authoritative registry (a uuid→Subgraph Map), same shape
+  // findSubgraphByUuid prefers — but there is no SubgraphNode instance for it.
+  app.graph.subgraphs = new Map([["uuid-123", sub]]);
+  assert.equal(isSubgraphInRoot(app.graph, sub), true);
+  const scope = resolveScope(app);
+  assert.equal(scope.stale, false, "a registered subgraph must not be flagged stale");
+  assert.equal(scope.scope, "subgraph");
+  assert.equal(scope.graph, sub);
+  // owner node is null, but the title still resolves from the subgraph name.
+  assert.deepEqual(describeScope(scope), { scope: "subgraph", owner_node_id: null, title: "reg" });
+});
+
+test("isSubgraphInRoot: a subgraph the registry does NOT hold ⇒ false (still stale-eligible)", () => {
+  const sub = makeSubgraph({ name: "ghost" });
+  sub.id = "uuid-x";
+  const root = { _nodes: [], subgraphs: new Map([["uuid-y", makeSubgraph({ name: "other" })]]) };
+  assert.equal(isSubgraphInRoot(root, sub), false);
+});
+
+test("#308: query scope and exit scope derive from the SAME resolver (cannot disagree)", () => {
+  // Valid subgraph: query sees subgraph, exit would proceed (graph !== root).
+  const sub = makeSubgraph({ name: "s" });
+  const app = makeApp({ rootNodes: [{ id: 130, subgraph: sub }], canvasGraph: sub });
+  const q = resolveScope(app);
+  assert.equal(q.scope, "subgraph");
+  assert.notEqual(q.graph, q.rootGraph, "exit_subgraph would proceed, not report 'already at root'");
+
+  // Stale subgraph: query reconciles to root, so a following exit reporting root is
+  // consistent — no 'subgraph then already-at-root' contradiction.
+  const app2 = makeApp({ rootNodes: [{ id: 130, subgraph: makeSubgraph({ name: "fresh" }) }], canvasGraph: makeSubgraph({ name: "stale" }) });
+  const q2 = resolveScope(app2);
+  assert.equal(q2.scope, "root");
+  assert.equal(q2.graph, q2.rootGraph, "exit truthfully reports root; query already said root too");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -5281,8 +5281,16 @@ const GRAPH_TOOL_EXECUTORS = {
       };
     }
     // A rail reference at the ROOT graph (rails only exist inside a subgraph) —
-    // give the precise reason instead of a bare "No node with id -10".
-    const intent = railKindFor(node_id);
+    // give the precise reason instead of a bare "No node with id -10". But only
+    // when node_id isn't actually a REAL node: a normal node whose id happens to be
+    // -10/-20 must still move (ComfyUI permits any integer node id), so never let
+    // the reserved-id warning shadow it.
+    const numId = Number(node_id);
+    const realNode =
+      Number.isFinite(numId) && typeof graph.getNodeById === "function"
+        ? graph.getNodeById(numId)
+        : null;
+    const intent = realNode ? null : railKindFor(node_id);
     if (intent && graph === rootGraph) {
       throw new Error(
         `${node_id} is the ${intent} boundary rail, which only exists INSIDE a subgraph — ` +

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -101,6 +101,15 @@ import {
   reapplyDefsToLiveNodes,
 } from "./lib/asset-staleness.js";
 import { assertAddNodeResolvable } from "./lib/node-resolve.js";
+import {
+  resolveScope,
+  describeScope,
+  findSubgraphOwner,
+  isSubgraphInRoot,
+  resolveRailNode,
+  railKindFor,
+  computeOrphanedBoundaries,
+} from "./lib/subgraph-scope.js";
 import { runSetWidget } from "./lib/set-widget.js";
 import { autoMatchSlots, slotDiagnostic } from "./lib/connect-match.js";
 import { coerceMessageText, isDroppedAgentReplay, serializeContext } from "./lib/chat-serialize.js";
@@ -2981,11 +2990,29 @@ function getWorkflowTitle() {
 const MAX_STATE_NODES = 100;
 
 function getGraphCtx() {
-  // app.canvas.graph is the graph the user is LOOKING at — the root graph or
-  // an opened subgraph — so reads and edits target what's on screen.
-  const graph = app?.canvas?.graph ?? app?.graph;
+  // app.canvas.graph is the graph the user is LOOKING at — the root graph or an
+  // opened subgraph — so reads and edits target what's on screen. But after a
+  // reconnect/tab-switch the canvas can still point at a subgraph object that the
+  // REBUILT root graph no longer owns; resolveScope detects that STALE reference
+  // and reconciles to root so graph READS and graph WRITES can never diverge
+  // (#220/#308). It is the ONE authoritative viewing-scope source.
   const LG = window.LiteGraph ?? globalThis.LiteGraph;
-  if (!app || !graph || !LG) {
+  if (!app || !app.graph || !LG) {
+    throw new Error("ComfyUI graph is not available (app.graph / LiteGraph missing)");
+  }
+  const scope = resolveScope(app);
+  // When the scope was stale, rebind the CANVAS to root too, so the physical view
+  // matches the graph reads/edits now target (keeps read + edit in lockstep).
+  if (scope.stale && typeof app.canvas?.setGraph === "function") {
+    try {
+      app.canvas.setGraph(scope.rootGraph);
+      app.canvas.setDirty?.(true, true);
+    } catch {
+      // best-effort — the resolved `graph` below is still the reconciled root
+    }
+  }
+  const graph = scope.graph ?? app.graph;
+  if (!graph) {
     throw new Error("ComfyUI graph is not available (app.graph / LiteGraph missing)");
   }
   return { app, graph, rootGraph: app.graph, canvas: app.canvas, LG };
@@ -3176,15 +3203,33 @@ function refreshPromotedParents(parents, canvas) {
   canvas?.setDirty?.(true, true);
 }
 
-/** Where is the user looking right now — root graph or inside a subgraph? */
+/** Where is the user looking right now — root graph or inside a subgraph? Uses the
+ *  SAME owner search as the authoritative resolver (findSubgraphOwner, nesting-aware)
+ *  so the reported `viewing` scope always agrees with the graph reads/edits act on.
+ *  A subgraph the live root no longer owns is a STALE reference (post-reconnect);
+ *  report root, matching getGraphCtx()'s reconciliation, so read+edit stay in
+ *  lockstep (#220/#308). */
 function describeActiveGraph(graph) {
-  if (!app?.graph || graph === app.graph) return { scope: "root" };
-  const owner = (app.graph._nodes ?? []).find((n) => n.subgraph === graph);
-  return {
-    scope: "subgraph",
-    owner_node_id: owner?.id ?? null,
-    title: owner?.title ?? graph?.name ?? "subgraph",
-  };
+  const root = app?.graph;
+  if (!root || !graph || graph === root) return { scope: "root" };
+  const owner = findSubgraphOwner(root, graph);
+  if (owner) {
+    return {
+      scope: "subgraph",
+      owner_node_id: owner.id ?? null,
+      title: owner.title ?? graph?.name ?? "subgraph",
+    };
+  }
+  // Ownerless but authoritatively part of the root via its subgraphs registry — a
+  // valid registry-owned subgraph, exactly what resolveScope keeps (NOT stale). Must
+  // report "subgraph" here too, else `viewing` would say root while reads/edits act
+  // on the subgraph — reintroducing the #308/#220 divergence.
+  if (isSubgraphInRoot(root, graph)) {
+    return { scope: "subgraph", owner_node_id: null, title: graph?.name ?? "subgraph" };
+  }
+  // Neither owned nor registered — a stale reference; report root to match
+  // getGraphCtx()'s reconciliation (read + edit stay in lockstep).
+  return { scope: "root" };
 }
 
 // ---- per-turn graph snapshots (rollback foundation, #44) -------------------
@@ -3768,6 +3813,73 @@ function resolveRail(graph, ref) {
       return { rail: "output", node: outNode };
   }
   return null;
+}
+
+/** Build the {inputs, outputs} boundary→interior link model for computeOrphanedBoundaries
+ *  (#234): resolve every boundary slot's linkIds to the INTERIOR node they touch, so
+ *  after an interior node is removed we can tell which boundary slots lost their only
+ *  consumer/producer. Keeps the live slot OBJECT on each entry so the pruner can pass
+ *  it straight to subgraph.removeInput/removeOutput. */
+function subgraphBoundaryModel(subgraph) {
+  const getLink = (id) =>
+    typeof subgraph?.getLink === "function"
+      ? subgraph.getLink(id)
+      : (subgraph?.links ?? []).find((l) => Number(l?.id ?? l?.[0]) === Number(id)) ?? null;
+  const endpointIds = (slot, key, arrIdx) =>
+    (slot?.linkIds ?? [])
+      .map((lid) => {
+        const l = getLink(lid);
+        if (!l) return null;
+        const v = l[key] ?? l[arrIdx];
+        return v == null ? null : Number(v);
+      })
+      .filter((n) => n != null && Number.isFinite(n));
+  return {
+    inputs: (subgraph?.inputs ?? []).map((s, index) => ({
+      name: s?.name ?? null,
+      index,
+      slot: s,
+      targetNodeIds: endpointIds(s, "target_id", 3),
+    })),
+    outputs: (subgraph?.outputs ?? []).map((s, index) => ({
+      name: s?.name ?? null,
+      index,
+      slot: s,
+      sourceNodeIds: endpointIds(s, "origin_id", 1),
+    })),
+  };
+}
+
+/** Remove any boundary slots the removal of `removedIds` orphaned (#234), pruning
+ *  the live subgraph's exposed input/output slots so no dangling `text` slot lingers
+ *  on the parent SubgraphNode. Only slots whose EVERY interior endpoint was removed
+ *  are pruned (a slot still feeding a surviving node is kept). The CALLER owns the
+ *  beforeChange/afterChange transaction so the node removal and this pruning collapse
+ *  into ONE Ctrl+Z step. Returns the removed slot names { inputs, outputs }. */
+function pruneOrphanedBoundaries(subgraph, model, removedIds) {
+  const orphans = computeOrphanedBoundaries({
+    inputs: model.inputs,
+    outputs: model.outputs,
+    removedNodeIds: removedIds,
+  });
+  const removedInputs = [];
+  const removedOutputs = [];
+  for (const s of orphans.inputs) {
+    if (typeof subgraph.removeInput === "function") {
+      subgraph.removeInput(s.slot);
+      removedInputs.push(s.name);
+    }
+  }
+  for (const s of orphans.outputs) {
+    if (typeof subgraph.removeOutput === "function") {
+      subgraph.removeOutput(s.slot);
+      removedOutputs.push(s.name);
+    }
+  }
+  if (removedInputs.length || removedOutputs.length) {
+    findSubgraphHostNode(subgraph)?.invalidatePromotedViews?.();
+  }
+  return { inputs: removedInputs, outputs: removedOutputs };
 }
 
 /** Detect rail INTENT independent of whether rails actually exist on the active
@@ -4791,17 +4903,46 @@ const GRAPH_TOOL_EXECUTORS = {
   },
 
   graph_remove_node({ node_id }) {
-    const { graph } = getGraphCtx();
+    const { graph, rootGraph } = getGraphCtx();
     const node = resolveNode(graph, node_id);
     const summary = summarizeNode(node);
+    const removedId = node.id;
+    // #234: inside a subgraph, snapshot the boundary→interior link model BEFORE
+    // removal so we can prune any exposed input/output slot the removal orphans
+    // (whose only interior consumer/producer was this node) — otherwise a dangling
+    // `text` slot lingers on the parent SubgraphNode and re-exposing mints `text_1`.
+    const inSubgraph = graph !== rootGraph;
+    const boundaryModel = inSubgraph ? subgraphBoundaryModel(graph) : null;
+    // Node removal AND the orphan-boundary prune run inside ONE
+    // beforeChange/afterChange pair, so a single Ctrl+Z restores BOTH (otherwise
+    // one undo would resurrect only the slot and leave the node deleted).
+    let cleaned = null;
+    let removedOk = false;
     graph.beforeChange();
     try {
       graph.remove(node);
+      // graph.remove() is a NO-OP for protected nodes (ignore_remove). Only prune
+      // (and report success) once the node has ACTUALLY left the graph — otherwise
+      // we would delete boundary slots still connected to a surviving node.
+      removedOk = graph.getNodeById?.(Number(removedId)) !== node;
+      if (removedOk && inSubgraph && boundaryModel) {
+        cleaned = pruneOrphanedBoundaries(graph, boundaryModel, [removedId]);
+      }
     } finally {
       graph.afterChange();
     }
+    if (!removedOk) {
+      throw new Error(
+        `Node ${removedId} could not be removed (it may be protected / ignore_remove).`,
+      );
+    }
     graph.setDirtyCanvas(true, true);
-    return { removed: summary };
+    return {
+      removed: summary,
+      ...(cleaned && (cleaned.inputs.length || cleaned.outputs.length)
+        ? { cleaned_boundary_slots: cleaned }
+        : {}),
+    };
   },
 
   graph_clear() {
@@ -5118,9 +5259,37 @@ const GRAPH_TOOL_EXECUTORS = {
   },
 
   graph_move_node({ node_id, pos }) {
-    const { graph } = getGraphCtx();
-    const node = resolveNode(graph, node_id);
+    const { graph, rootGraph } = getGraphCtx();
     if (!Array.isArray(pos) || pos.length !== 2) throw new Error("pos must be [x, y]");
+    // #302: accept the boundary RAIL ids (-10/-20, or the aliases) that
+    // panel_query_graph reports as rails.{input,output}.rail_node_id, moving the
+    // rail node exactly like graph_move_rail (they are NOT in graph._nodes_by_id,
+    // so resolveNode alone can't find them).
+    const rail = resolveRailNode(graph, node_id);
+    if (rail) {
+      const railNode = rail.node;
+      const prev = [railNode.pos?.[0], railNode.pos?.[1]];
+      graph.beforeChange?.();
+      try {
+        railNode.pos = [Number(pos[0]), Number(pos[1])];
+      } finally {
+        graph.afterChange?.();
+      }
+      graph.setDirtyCanvas?.(true, true);
+      return {
+        moved: { node_id: railNode.id, rail: rail.rail, from: prev, to: [railNode.pos[0], railNode.pos[1]] },
+      };
+    }
+    // A rail reference at the ROOT graph (rails only exist inside a subgraph) —
+    // give the precise reason instead of a bare "No node with id -10".
+    const intent = railKindFor(node_id);
+    if (intent && graph === rootGraph) {
+      throw new Error(
+        `${node_id} is the ${intent} boundary rail, which only exists INSIDE a subgraph — ` +
+          `enter the subgraph first (panel_enter_subgraph).`,
+      );
+    }
+    const node = resolveNode(graph, node_id);
     const previous = [node.pos[0], node.pos[1]];
     graph.beforeChange();
     try {
@@ -8884,8 +9053,12 @@ function describeCommand(cmd, msg, reply) {
       return { icon: "pi-copy", text: `Captured canvas — ${r.node_count} node${r.node_count === 1 ? "" : "s"}` };
     case "graph_add_node":
       return { icon: "pi-plus-circle", text: `Added ${r.added?.type ?? "node"} (id ${r.added?.id})` };
-    case "graph_remove_node":
-      return { icon: "pi-minus-circle", text: `Removed ${r.removed?.type ?? "node"} (id ${r.removed?.id})` };
+    case "graph_remove_node": {
+      const cb = r.cleaned_boundary_slots;
+      const cleaned = [...(cb?.inputs ?? []), ...(cb?.outputs ?? [])].filter(Boolean);
+      const suffix = cleaned.length ? ` — cleaned orphaned boundary ${cleaned.length === 1 ? "slot" : "slots"} ${cleaned.join(", ")}` : "";
+      return { icon: "pi-minus-circle", text: `Removed ${r.removed?.type ?? "node"} (id ${r.removed?.id})${suffix}` };
+    }
     case "graph_clear":
       return {
         icon: "pi-eraser",

--- a/web/js/lib/subgraph-scope.js
+++ b/web/js/lib/subgraph-scope.js
@@ -1,0 +1,186 @@
+// Authoritative subgraph scope tracking + boundary-rail helpers, extracted so the
+// SAME logic the panel's graph_* tools run is unit-testable headlessly (the live
+// LiteGraph canvas cannot be driven from `node --test`).
+//
+// Fixes a cluster of subgraph scope/cleanup defects:
+//  - #308: panel_exit_subgraph reported "already at root" immediately after a
+//    query showed a live subgraph scope — the read tool and the navigation tool
+//    disagreed about where the user was.
+//  - #220: after a panel reconnect the READ scope (graph_outline) and the EDIT
+//    scope (set_widget / move_node) diverged — the outline listed inner node ids
+//    while mutations answered "No node with id ...". The canvas still pointed at a
+//    subgraph object that the REBUILT root graph no longer owns (a STALE ref).
+//  - #302: the input/output boundary RAIL ids (-10/-20) that query_graph reports
+//    were rejected by move_node.
+//  - #234: removing the last interior consumer of an exposed boundary slot left
+//    the now-orphaned slot behind on the parent SubgraphNode.
+//
+// The unifying idea is ONE authoritative scope resolver (`resolveScope`) that BOTH
+// reads and writes derive their target graph from, and that treats a canvas graph
+// unreachable from the LIVE root as stale — reconciling to root so a read and an
+// edit issued back-to-back can never target two different graphs.
+
+export const SUBGRAPH_INPUT_RAIL_ID = -10;
+export const SUBGRAPH_OUTPUT_RAIL_ID = -20;
+
+const RAIL_INPUT_ALIASES = new Set(["input", "input_rail", "inputs", "in"]);
+const RAIL_OUTPUT_ALIASES = new Set(["output", "output_rail", "outputs", "out"]);
+
+/** Rail INTENT from a reference, independent of whether rails exist on the active
+ *  graph: an alias string ("input"/"output"/…) or the reserved rail ids -10/-20.
+ *  Returns "input" | "output" | null. Used to give a precise error when a rail
+ *  endpoint is used at the ROOT graph (which has no rails). */
+export function railKindFor(ref) {
+  if (typeof ref === "string") {
+    const key = ref.trim().toLowerCase();
+    if (RAIL_INPUT_ALIASES.has(key)) return "input";
+    if (RAIL_OUTPUT_ALIASES.has(key)) return "output";
+  }
+  const num = Number(ref);
+  if (Number.isFinite(num)) {
+    if (num === SUBGRAPH_INPUT_RAIL_ID) return "input";
+    if (num === SUBGRAPH_OUTPUT_RAIL_ID) return "output";
+  }
+  return null;
+}
+
+/** Resolve a reference to a subgraph boundary rail NODE on `graph`, by the rail
+ *  node's real id (-10 / -20), by the frontend-assigned node id, or by an alias.
+ *  Returns { rail: "input"|"output", node } or null when it isn't a rail reference
+ *  or the graph has no such rail (e.g. the root graph). This is exactly the id form
+ *  panel_query_graph reports as `rails.input.rail_node_id`, so move_node can accept
+ *  it (#302). */
+export function resolveRailNode(graph, ref) {
+  const inNode = graph?.inputNode ?? graph?._inputNode ?? null;
+  const outNode = graph?.outputNode ?? graph?._outputNode ?? null;
+  if (typeof ref === "string") {
+    const key = ref.trim().toLowerCase();
+    if (RAIL_INPUT_ALIASES.has(key)) return inNode ? { rail: "input", node: inNode } : null;
+    if (RAIL_OUTPUT_ALIASES.has(key)) return outNode ? { rail: "output", node: outNode } : null;
+  }
+  const num = Number(ref);
+  if (Number.isFinite(num)) {
+    if (inNode && (Number(inNode.id) === num || num === SUBGRAPH_INPUT_RAIL_ID))
+      return { rail: "input", node: inNode };
+    if (outNode && (Number(outNode.id) === num || num === SUBGRAPH_OUTPUT_RAIL_ID))
+      return { rail: "output", node: outNode };
+  }
+  return null;
+}
+
+/** Walk the root graph (through nested subgraphs) to find the SubgraphNode that
+ *  owns `subgraph`. Returns { id, node, title } or null when unreachable — the
+ *  signal that a canvas graph reference is STALE (its owner was replaced when the
+ *  root graph was rebuilt on reconnect). */
+export function findSubgraphOwner(rootGraph, subgraph) {
+  if (!rootGraph || !subgraph) return null;
+  const stack = [...(rootGraph._nodes ?? [])];
+  const seen = new Set();
+  while (stack.length) {
+    const node = stack.pop();
+    if (!node || seen.has(node)) continue;
+    seen.add(node);
+    if (node.subgraph === subgraph) {
+      return { id: node.id ?? null, node, title: node.title ?? subgraph?.name ?? "subgraph" };
+    }
+    const inner = node.subgraph?._nodes;
+    if (inner?.length) stack.push(...inner);
+  }
+  return null;
+}
+
+/** Whether `subgraph` is authoritatively part of `rootGraph` via the root's
+ *  `subgraphs` registry (a uuid → Subgraph Map on real LiteGraph builds, the same
+ *  registry findSubgraphByUuid in asset-staleness.js prefers). A subgraph DEFINITION
+ *  can be owned through this registry with no current presentation-owner node, so we
+ *  must NOT treat "no owner node found" alone as stale — only a subgraph the root
+ *  neither owns via a node NOR registers is genuinely a ghost. Matches by IDENTITY,
+ *  not just uuid, so a rebuilt root carrying a NEW subgraph under the same uuid does
+ *  not mask the old (stale) instance. */
+export function isSubgraphInRoot(rootGraph, subgraph) {
+  const reg = rootGraph?.subgraphs;
+  if (!reg || !subgraph) return false;
+  const id = subgraph.id;
+  if (id != null && typeof reg.get === "function" && reg.get(id) === subgraph) return true;
+  if (typeof reg.values === "function") {
+    for (const v of reg.values()) if (v === subgraph) return true;
+  } else if (typeof reg.forEach === "function") {
+    let found = false;
+    reg.forEach((v) => {
+      if (v === subgraph) found = true;
+    });
+    if (found) return true;
+  } else if (typeof reg === "object") {
+    for (const v of Object.values(reg)) if (v === subgraph) return true;
+  }
+  return false;
+}
+
+/** THE authoritative viewing-scope resolver. Both graph reads and graph mutations
+ *  derive their target graph from this, so they can never diverge (#220 / #308).
+ *
+ *  Returns { graph, rootGraph, scope, owner, stale }:
+ *   - root             → { graph: root,     scope: "root" }
+ *   - a valid subgraph → { graph: subgraph, scope: "subgraph", owner? } — valid when
+ *     the live root reaches it via an owner NODE or its `subgraphs` registry.
+ *   - a STALE subgraph (the canvas still points at a subgraph the rebuilt root
+ *     neither owns nor registers — e.g. after a reconnect) → reconcile to root:
+ *     { graph: root, scope: "root", stale: true }. The caller rebinds the canvas
+ *     so the physical view matches, keeping read + edit in lockstep. */
+export function resolveScope(app) {
+  const rootGraph = app?.graph ?? null;
+  const canvasGraph = app?.canvas?.graph ?? null;
+  if (!rootGraph) {
+    return { graph: canvasGraph ?? null, rootGraph: null, scope: "root", owner: null, stale: false };
+  }
+  if (!canvasGraph || canvasGraph === rootGraph) {
+    return { graph: rootGraph, rootGraph, scope: "root", owner: null, stale: false };
+  }
+  const owner = findSubgraphOwner(rootGraph, canvasGraph);
+  if (owner) {
+    return { graph: canvasGraph, rootGraph, scope: "subgraph", owner, stale: false };
+  }
+  // No presentation-owner node — but the subgraph may still be authoritative via the
+  // root's uuid→Subgraph registry (a registered definition without a live instance
+  // node). Only when it is NEITHER owned NOR registered is it a genuine post-reconnect
+  // ghost; then fall back to root so reads AND writes agree rather than target a ghost.
+  if (isSubgraphInRoot(rootGraph, canvasGraph)) {
+    return { graph: canvasGraph, rootGraph, scope: "subgraph", owner: null, stale: false };
+  }
+  return { graph: rootGraph, rootGraph, scope: "root", owner: null, stale: true };
+}
+
+/** Compact JSON scope descriptor for tool responses (the `viewing` field). Derived
+ *  from resolveScope so `viewing` and the graph the tool actually acted on always
+ *  match. */
+export function describeScope(scope) {
+  if (!scope || scope.scope !== "subgraph") return { scope: "root" };
+  return {
+    scope: "subgraph",
+    owner_node_id: scope.owner?.id ?? null,
+    title: scope.owner?.title ?? scope.graph?.name ?? "subgraph",
+  };
+}
+
+/** Compute which subgraph boundary slots become ORPHANED when the given interior
+ *  node(s) are removed (#234): a boundary whose every interior endpoint is among
+ *  the removed nodes (and which had at least one) no longer has a consumer/producer
+ *  and should be pruned. Freshly-added empty boundaries (no interior endpoint) are
+ *  LEFT ALONE — they were not orphaned by this removal, and a boundary that still
+ *  feeds a surviving node is KEPT (never yank a slot with a live consumer).
+ *
+ *  `inputs`  : [{ name, index, slot?, targetNodeIds: number[] }] (input rail → interior)
+ *  `outputs` : [{ name, index, slot?, sourceNodeIds: number[] }] (interior → output rail)
+ *  Returns { inputs, outputs } — the SAME item objects to remove (so callers keep
+ *  the `slot` handle). */
+export function computeOrphanedBoundaries({ inputs = [], outputs = [], removedNodeIds = [] } = {}) {
+  const removed = new Set((removedNodeIds ?? []).map((id) => Number(id)));
+  const allRemoved = (ids) => {
+    const nums = (ids ?? []).map((id) => Number(id)).filter((n) => Number.isFinite(n));
+    return nums.length > 0 && nums.every((id) => removed.has(id));
+  };
+  return {
+    inputs: (inputs ?? []).filter((s) => allRemoved(s?.targetNodeIds)),
+    outputs: (outputs ?? []).filter((s) => allRemoved(s?.sourceNodeIds)),
+  };
+}

--- a/web/js/lib/subgraph-scope.js
+++ b/web/js/lib/subgraph-scope.js
@@ -60,10 +60,22 @@ export function resolveRailNode(graph, ref) {
   }
   const num = Number(ref);
   if (Number.isFinite(num)) {
-    if (inNode && (Number(inNode.id) === num || num === SUBGRAPH_INPUT_RAIL_ID))
-      return { rail: "input", node: inNode };
-    if (outNode && (Number(outNode.id) === num || num === SUBGRAPH_OUTPUT_RAIL_ID))
-      return { rail: "output", node: outNode };
+    // A REAL node always wins a numeric reference: rail nodes are not in
+    // graph._nodes_by_id, so getNodeById only ever returns an ordinary node. When one
+    // owns this id the ref names that node — even if the id collides with a reserved
+    // rail id (-10/-20) or the rail's own id — so defer (return null) and let move_node
+    // resolve it as a normal node (#302 numeric collision; ComfyUI permits any integer
+    // node id). The `!== inNode/outNode` guard keeps a legit rail move working even if a
+    // build DID surface a rail through getNodeById.
+    const found =
+      typeof graph?.getNodeById === "function" ? graph.getNodeById(num) : null;
+    const collidingNode = found && found !== inNode && found !== outNode ? found : null;
+    if (!collidingNode) {
+      if (inNode && (Number(inNode.id) === num || num === SUBGRAPH_INPUT_RAIL_ID))
+        return { rail: "input", node: inNode };
+      if (outNode && (Number(outNode.id) === num || num === SUBGRAPH_OUTPUT_RAIL_ID))
+        return { rail: "output", node: outNode };
+    }
   }
   return null;
 }


### PR DESCRIPTION
Fixes a cluster of subgraph scope/cleanup defects with ONE authoritative scope resolver (`web/js/lib/subgraph-scope.js`) that both graph READS and graph WRITES derive their target graph from, so they can never diverge.

## What changed
- **New module** `web/js/lib/subgraph-scope.js` — `resolveScope` (authoritative viewing scope, stale-ref reconciliation), `findSubgraphOwner`/`isSubgraphInRoot` (owner-node walk + `subgraphs` registry check), `resolveRailNode`/`railKindFor` (boundary rail id/alias resolution), `computeOrphanedBoundaries` (orphan-slot pruning model). Fully unit-testable headlessly.
- **Wiring** in `web/js/comfyui-mcp-panel.js` — `getGraphCtx` reconciles a stale canvas subgraph to root (and rebinds the canvas) so read + edit stay in lockstep; `describeActiveGraph` reports scope via the SAME resolver; `graph_remove_node` prunes orphaned boundary slots in the same undo transaction; `graph_move_node` accepts rail ids (-10/-20/aliases) and gives a precise root-graph error.
- **Tests** `browser_tests/unit/subgraph-scope.test.mjs` — 548 unit tests green.

## Issue coverage
Closes #308
Closes #302
Closes #234
Closes #220

## Verification
- Full unit suite: 548 pass / 0 fail (`node --test browser_tests/unit/*.mjs`).
- All three changed files ESM-verify (`node --check`).
- CI YARA gate: no new `onload`/`onerror` identifiers in comfyui-mcp-panel.js.
- Codex adversarial self-gate (read-only, gpt-5.6): round 1 flagged a P2 numeric rail-id collision (a real node whose id is literally -10/-20 was shadowed by the rail) — fixed so a real node found via `getNodeById` always wins a numeric ref, with a regression test. Round 2 **VERDICT: PASS** (scope lockstep, rail-id collision, protected-node guard, boundary pruning, undo transaction, root behavior all correct).

Draft — no version bump; not for merge yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)