### PR TITLE
fix(save/registry): external-path save-as (#285); clean 409 handling (#309); refresh stale node-def cache for add_node (#289)

### DIFF
--- a/browser_tests/unit/frontend-contract.test.mjs
+++ b/browser_tests/unit/frontend-contract.test.mjs
@@ -67,7 +67,10 @@ const SAVE_AS_ROUTES = [
 
 // Optional, always called behind a `typeof … === "function"` guard, so its
 // absence is not a regression. Listed so the derivation guard does not flag it.
-const OPTIONAL_METHODS = ['syncWorkflows']
+// `removeWorkflow` is a best-effort orphan-copy cleanup on a failed 1.47 persist
+// (#309) — only called when the store exposes it (else it falls back to closeWorkflow
+// or splicing the open-tabs array), so it is optional, not required.
+const OPTIONAL_METHODS = ['syncWorkflows', 'removeWorkflow']
 
 // Reactive store PROPERTIES the panel reads off the service.
 const STORE_PROPS = ['activeWorkflow', 'workflows', 'openWorkflows']

--- a/browser_tests/unit/frontend-contract.test.mjs
+++ b/browser_tests/unit/frontend-contract.test.mjs
@@ -57,12 +57,13 @@ const REQUIRED_METHODS = [
   'renameWorkflow'
 ]
 
-// Save-As is version-variable. The panel is viable if ANY of these routes is
-// fully present. This is the crux of the #268 fix: never depend on a single
-// method that a future frontend may drop.
+// Save-As: the panel now uses ONLY the ATOMIC low-level trio. The high-level
+// `saveWorkflowAs` is DELIBERATELY not used — it writes by prompting and can
+// delete+overwrite an existing target (a TOCTOU data-loss no pre-check can close,
+// #226/#309 P1-1), so the panel refuses rather than route a collision-capable
+// Save-As through it. The trio must be present for Save-As to work.
 const SAVE_AS_ROUTES = [
-  ['saveWorkflowAs'], //                              1.45.x high-level copy
-  ['saveAs', 'saveWorkflow', 'openWorkflow'] //       1.47.x low-level copy trio
+  ['saveAs', 'saveWorkflow', 'openWorkflow'] //       1.47.x low-level atomic copy trio
 ]
 
 // Optional, always called behind a `typeof … === "function"` guard, so its

--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -137,75 +137,137 @@ test("add_node: REAL type on a reachable server ⇒ resolves (no false negative)
   assert.doesNotThrow(() => assertAddNodeResolvable(reg, "KSamplerAdvanced"));
 });
 
-// ---- assertAddNodeResolvableRefreshing: stale node-def cache (#289) ----------
-// After install+restart the frontend registry predates the new pack's classes, so
-// a correct class_type reads Unknown until /object_info is re-fetched. The guard
-// must refresh once and re-check — but never fabricate a type (fail closed, #458).
+// ---- assertAddNodeResolvableRefreshing: authoritative fresh /object_info --------
+// The go/no-go is decided against the CURRENT backend /object_info, never the
+// mutated add-only registry: it MISSES freshly-installed classes (#289) and KEEPS
+// stale positives for uninstalled ones (#458/P1-C). Fail closed on both edges.
 
-test("add_node refresh: a freshly-installed type unknown at first is RESOLVED after a refresh (#289)", async () => {
-  // Model the stale cache: the page-load registry has core sentinels but NOT the
-  // just-installed pack's class. The refresh re-registers node defs, adding it.
-  const reg = loadedRegistry(); // no SeedVR2* yet
+// Build a fresh /object_info map (class_type -> def) with the core set + extras.
+function objectInfo(extra = []) {
+  const info = {};
+  for (const t of [
+    "KSampler",
+    "CheckpointLoaderSimple",
+    "CLIPTextEncode",
+    "VAEDecode",
+    "VAELoader",
+    "EmptyLatentImage",
+    "LoadImage",
+    "SaveImage",
+    ...extra,
+  ]) {
+    info[t] = { input: { required: {} } };
+  }
+  return info;
+}
+
+const regCtor = () => {
+  const c = function NodeCtor() {};
+  c.nodeData = { input: { required: {} } };
+  return c;
+};
+
+test("#289: a freshly-installed type — in fresh object_info but NOT the stale registry — resolves after a refresh", async () => {
+  const reg = loadedRegistry(); // page-load registry: no SeedVR2* yet
+  const fresh = objectInfo(["SeedVR2LoadDiTModel"]); // backend now provides it
   let refreshed = 0;
-  const refresh = async () => {
-    refreshed++;
-    reg["SeedVR2LoadDiTModel"] = (() => {
-      const c = function NodeCtor() {};
-      c.nodeData = { input: { required: {} } };
-      return c;
-    })();
+  const opts = {
+    getFreshObjectInfo: async () => fresh,
+    refresh: async () => {
+      refreshed++;
+      reg["SeedVR2LoadDiTModel"] = regCtor(); // registerNodesFromDefs adds it
+    },
   };
-  // Before the refresh the type is absent; the guard must NOT reject it outright.
   await assert.doesNotReject(() =>
-    assertAddNodeResolvableRefreshing(() => reg, "SeedVR2LoadDiTModel", refresh),
+    assertAddNodeResolvableRefreshing(() => reg, "SeedVR2LoadDiTModel", opts),
   );
-  assert.equal(refreshed, 1, "refreshed the node defs exactly once");
+  assert.equal(refreshed, 1, "refreshed once to register the newly-installed class");
   assert.ok(isRegisteredNodeType(reg, "SeedVR2LoadDiTModel"), "type registered after refresh");
 });
 
-test("add_node refresh: a GENUINELY-unknown type still ERRORS after a refresh (fail closed, #458)", async () => {
-  const reg = loadedRegistry();
+test("#458/P1-C: a STALE registry positive absent from fresh object_info FAILS CLOSED (removed pack)", async () => {
+  // GoneNode's pack was uninstalled + backend restarted: the add-only refresh never
+  // purged it, so it survives in the registry — but the fresh /object_info does NOT
+  // list it. The go/no-go MUST use the fresh payload and refuse, not the stale reg.
+  const reg = loadedRegistry(["GoneNode"]); // stale positive still registered
+  assert.ok(isRegisteredNodeType(reg, "GoneNode"), "precondition: stale registry entry present")
+  const fresh = objectInfo(); // backend no longer provides GoneNode
   let refreshed = 0;
-  const refresh = async () => {
-    refreshed++; // a real refresh that registers nothing new (server has no such type)
-  };
   await assert.rejects(
-    () => assertAddNodeResolvableRefreshing(() => reg, "TotallyMadeUpNode", refresh),
-    /Unknown node type "TotallyMadeUpNode"/,
+    () =>
+      assertAddNodeResolvableRefreshing(() => reg, "GoneNode", {
+        getFreshObjectInfo: async () => fresh,
+        refresh: async () => {
+          refreshed++;
+        },
+      }),
+    /Unknown node type "GoneNode"|backend does not provide/i,
   );
-  assert.equal(refreshed, 1, "attempted a refresh before failing closed");
+  assert.equal(refreshed, 0, "never refreshed — the fresh backend simply lacks the type");
 });
 
-test("add_node refresh: an ALREADY-registered type resolves WITHOUT refreshing", async () => {
+test("#458: a type absent from BOTH fresh object_info and the registry FAILS CLOSED", async () => {
+  const reg = loadedRegistry();
+  await assert.rejects(
+    () =>
+      assertAddNodeResolvableRefreshing(() => reg, "TotallyMadeUpNode", {
+        getFreshObjectInfo: async () => objectInfo(),
+        refresh: async () => {},
+      }),
+    /Unknown node type "TotallyMadeUpNode"|backend does not provide/i,
+  );
+});
+
+test("add_node: a type in BOTH fresh object_info and the registry resolves WITHOUT refreshing", async () => {
   const reg = loadedRegistry();
   let refreshed = 0;
-  const refresh = async () => {
-    refreshed++;
-  };
   await assert.doesNotReject(() =>
-    assertAddNodeResolvableRefreshing(() => reg, "KSampler", refresh),
+    assertAddNodeResolvableRefreshing(() => reg, "KSampler", {
+      getFreshObjectInfo: async () => objectInfo(),
+      refresh: async () => {
+        refreshed++;
+      },
+    }),
   );
-  assert.equal(refreshed, 0, "no refresh needed when the type is already registered");
+  assert.equal(refreshed, 0, "no refresh needed when already registered");
 });
 
-test("add_node refresh: backend still unreachable after refresh ⇒ unreachable error (fail closed)", async () => {
-  const reg = unreachableRegistry(); // no core sentinels
-  const refresh = async () => {
-    /* backend still down — registers nothing, sentinels stay absent */
-  };
+test("#458: backend defines the type but the refresh CANNOT register it ⇒ FAIL CLOSED (no placeholder)", async () => {
+  const reg = loadedRegistry(); // lacks NewNode
   await assert.rejects(
-    () => assertAddNodeResolvableRefreshing(() => reg, "SeedVR2LoadDiTModel", refresh),
+    () =>
+      assertAddNodeResolvableRefreshing(() => reg, "NewNode", {
+        getFreshObjectInfo: async () => objectInfo(["NewNode"]),
+        refresh: async () => {
+          /* refresh runs but fails to register NewNode into the registry */
+        },
+      }),
+    /could not be registered|Refusing to add an unresolved placeholder/i,
+  );
+});
+
+test("#458: no fresh object_info (backend unreachable) ⇒ degrade to registry guard, unknown fails closed", async () => {
+  const reg = unreachableRegistry(); // no core sentinels
+  await assert.rejects(
+    () =>
+      assertAddNodeResolvableRefreshing(() => reg, "SeedVR2LoadDiTModel", {
+        getFreshObjectInfo: async () => null, // fetch failed
+        refresh: async () => {},
+      }),
     /node definitions are not loaded|backend is unreachable/i,
   );
 });
 
-test("add_node refresh: a THROWING refresh does not crash — re-checks and fails closed", async () => {
-  const reg = loadedRegistry();
-  const refresh = async () => {
-    throw new Error("object_info fetch failed");
-  };
+test("add_node: a THROWING object_info fetch degrades to the registry guard", async () => {
+  const reg = loadedRegistry(); // reachable per registry; type unknown
   await assert.rejects(
-    () => assertAddNodeResolvableRefreshing(() => reg, "StillUnknown", refresh),
+    () =>
+      assertAddNodeResolvableRefreshing(() => reg, "StillUnknown", {
+        getFreshObjectInfo: async () => {
+          throw new Error("object_info fetch failed");
+        },
+        refresh: async () => {},
+      }),
     /Unknown node type "StillUnknown"/,
   );
 });

--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -18,6 +18,7 @@ import {
   isRegisteredNodeType,
   comfyNodeDefsLoaded,
   assertAddNodeResolvable,
+  assertAddNodeResolvableRefreshing,
   assertResolvedTargetRegistered,
 } from "../../web/js/lib/node-resolve.js";
 // The PRODUCTION graph_set_widget handler body — the executor and these tests
@@ -134,6 +135,79 @@ test("add_node: REAL type on a reachable server ⇒ resolves (no false negative)
   assert.doesNotThrow(() => assertAddNodeResolvable(reg, "CheckpointLoaderSimple"));
   assert.doesNotThrow(() => assertAddNodeResolvable(reg, "KSampler"));
   assert.doesNotThrow(() => assertAddNodeResolvable(reg, "KSamplerAdvanced"));
+});
+
+// ---- assertAddNodeResolvableRefreshing: stale node-def cache (#289) ----------
+// After install+restart the frontend registry predates the new pack's classes, so
+// a correct class_type reads Unknown until /object_info is re-fetched. The guard
+// must refresh once and re-check — but never fabricate a type (fail closed, #458).
+
+test("add_node refresh: a freshly-installed type unknown at first is RESOLVED after a refresh (#289)", async () => {
+  // Model the stale cache: the page-load registry has core sentinels but NOT the
+  // just-installed pack's class. The refresh re-registers node defs, adding it.
+  const reg = loadedRegistry(); // no SeedVR2* yet
+  let refreshed = 0;
+  const refresh = async () => {
+    refreshed++;
+    reg["SeedVR2LoadDiTModel"] = (() => {
+      const c = function NodeCtor() {};
+      c.nodeData = { input: { required: {} } };
+      return c;
+    })();
+  };
+  // Before the refresh the type is absent; the guard must NOT reject it outright.
+  await assert.doesNotReject(() =>
+    assertAddNodeResolvableRefreshing(() => reg, "SeedVR2LoadDiTModel", refresh),
+  );
+  assert.equal(refreshed, 1, "refreshed the node defs exactly once");
+  assert.ok(isRegisteredNodeType(reg, "SeedVR2LoadDiTModel"), "type registered after refresh");
+});
+
+test("add_node refresh: a GENUINELY-unknown type still ERRORS after a refresh (fail closed, #458)", async () => {
+  const reg = loadedRegistry();
+  let refreshed = 0;
+  const refresh = async () => {
+    refreshed++; // a real refresh that registers nothing new (server has no such type)
+  };
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => reg, "TotallyMadeUpNode", refresh),
+    /Unknown node type "TotallyMadeUpNode"/,
+  );
+  assert.equal(refreshed, 1, "attempted a refresh before failing closed");
+});
+
+test("add_node refresh: an ALREADY-registered type resolves WITHOUT refreshing", async () => {
+  const reg = loadedRegistry();
+  let refreshed = 0;
+  const refresh = async () => {
+    refreshed++;
+  };
+  await assert.doesNotReject(() =>
+    assertAddNodeResolvableRefreshing(() => reg, "KSampler", refresh),
+  );
+  assert.equal(refreshed, 0, "no refresh needed when the type is already registered");
+});
+
+test("add_node refresh: backend still unreachable after refresh ⇒ unreachable error (fail closed)", async () => {
+  const reg = unreachableRegistry(); // no core sentinels
+  const refresh = async () => {
+    /* backend still down — registers nothing, sentinels stay absent */
+  };
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => reg, "SeedVR2LoadDiTModel", refresh),
+    /node definitions are not loaded|backend is unreachable/i,
+  );
+});
+
+test("add_node refresh: a THROWING refresh does not crash — re-checks and fails closed", async () => {
+  const reg = loadedRegistry();
+  const refresh = async () => {
+    throw new Error("object_info fetch failed");
+  };
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => reg, "StillUnknown", refresh),
+    /Unknown node type "StillUnknown"/,
+  );
 });
 
 // ---- assertResolvedTargetRegistered (the predicate, on a RESOLVED target) ----

--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -246,19 +246,37 @@ test("#458: backend defines the type but the refresh CANNOT register it ⇒ FAIL
   );
 });
 
-test("#458: no fresh object_info (backend unreachable) ⇒ degrade to registry guard, unknown fails closed", async () => {
+test("#458: fresh object_info unavailable (null) ⇒ FAIL CLOSED, does not authorize from the registry", async () => {
   const reg = unreachableRegistry(); // no core sentinels
   await assert.rejects(
     () =>
       assertAddNodeResolvableRefreshing(() => reg, "SeedVR2LoadDiTModel", {
-        getFreshObjectInfo: async () => null, // fetch failed
+        getFreshObjectInfo: async () => null, // fetch failed / unavailable
         refresh: async () => {},
       }),
-    /node definitions are not loaded|backend is unreachable/i,
+    /cannot verify node type|object_info is unavailable|backend is unreachable/i,
   );
 });
 
-test("add_node: a THROWING object_info fetch degrades to the registry guard", async () => {
+test("#458/P1-2: a REGISTERED type + a REJECTING object_info fetch ⇒ FAIL CLOSED (no stale-registry authorization)", async () => {
+  // The exact P1-2 hole: GoneNode is still in the registry (pack removed but not
+  // purged), and the fresh /object_info fetch transiently REJECTS. The old fallback
+  // authorized from the registry and would construct GoneNode. It must fail closed.
+  const reg = loadedRegistry(["GoneNode"]); // registry HIT
+  assert.ok(isRegisteredNodeType(reg, "GoneNode"), "precondition: registry still holds GoneNode");
+  await assert.rejects(
+    () =>
+      assertAddNodeResolvableRefreshing(() => reg, "GoneNode", {
+        getFreshObjectInfo: async () => {
+          throw new Error("object_info fetch failed (transient)");
+        },
+        refresh: async () => {},
+      }),
+    /cannot verify node type|object_info is unavailable/i,
+  );
+});
+
+test("add_node: a THROWING object_info fetch FAILS CLOSED (does not trust the registry)", async () => {
   const reg = loadedRegistry(); // reachable per registry; type unknown
   await assert.rejects(
     () =>
@@ -268,7 +286,7 @@ test("add_node: a THROWING object_info fetch degrades to the registry guard", as
         },
         refresh: async () => {},
       }),
-    /Unknown node type "StillUnknown"/,
+    /cannot verify node type|object_info is unavailable/i,
   );
 });
 

--- a/browser_tests/unit/refresh-coalesce.test.mjs
+++ b/browser_tests/unit/refresh-coalesce.test.mjs
@@ -1,0 +1,100 @@
+// Unit tests for web/js/lib/refresh-coalesce.js — the node-def refresh coalescer.
+// The load-bearing property (#289 P2): a caller-supplied FRESH payload must NEVER be
+// dropped by joining an OLDER in-flight refresh.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { makeRefreshCoalescer } from "../../web/js/lib/refresh-coalesce.js";
+
+// A tiny deferred so a test can hold a refresh "in flight" until it chooses.
+function deferred() {
+  let resolve;
+  const promise = new Promise((r) => (resolve = r));
+  return { promise, resolve };
+}
+
+// Build a coalescer over a module-like single slot, recording every payload that
+// runRegister actually registered.
+function makeHarness(runImpl) {
+  let inFlight = null;
+  const registered = [];
+  const coalescer = makeRefreshCoalescer({
+    getInFlight: () => inFlight,
+    setInFlight: (p) => {
+      inFlight = p;
+    },
+    runRegister: async (defs) => {
+      registered.push(defs);
+      if (runImpl) await runImpl(defs);
+    },
+  });
+  return { coalescer, registered, getInFlight: () => inFlight };
+}
+
+test("#289 P2: a fresh payload is NOT dropped when an OLDER refresh is in flight", async () => {
+  // Gate the first (older, payload-less reconnect) refresh so it stays in flight
+  // while the second call arrives with a NEW payload.
+  const gate = deferred();
+  const { coalescer, registered } = makeHarness(async (defs) => {
+    if (defs == null) await gate.promise; // the older reconnect refresh blocks here
+  });
+
+  const older = coalescer(); // no payload — the reconnect refresh, now in flight
+  const NEW_DEFS = { NewNode: { input: { required: {} } } };
+  const withPayload = coalescer(NEW_DEFS); // graph_add_node's fresh payload
+
+  // Let the older refresh finish; the payload call must then run its OWN refresh.
+  gate.resolve();
+  await older;
+  await withPayload;
+
+  assert.ok(
+    registered.includes(NEW_DEFS),
+    "the fresh payload was registered (not dropped by joining the older refresh)",
+  );
+});
+
+test("a payload-less call while a refresh is in flight simply JOINS it (no extra run)", async () => {
+  const gate = deferred();
+  const { coalescer, registered } = makeHarness(async () => {
+    await gate.promise;
+  });
+
+  const first = coalescer(); // in flight
+  const second = coalescer(); // no payload ⇒ joins, does not start a new run
+
+  gate.resolve();
+  await Promise.all([first, second]);
+
+  assert.equal(registered.length, 1, "only ONE registration ran for two payload-less calls");
+});
+
+test("a single call registers its payload and clears the in-flight slot", async () => {
+  const { coalescer, registered, getInFlight } = makeHarness();
+  const DEFS = { A: {} };
+  await coalescer(DEFS);
+  assert.deepEqual(registered, [DEFS], "registered the supplied payload");
+  assert.equal(getInFlight(), null, "in-flight slot cleared after settle");
+});
+
+test("a payload call still runs even if the in-flight refresh REJECTS", async () => {
+  const gate = deferred();
+  let first = true;
+  const { coalescer, registered } = makeHarness(async () => {
+    if (first) {
+      first = false;
+      await gate.promise;
+      throw new Error("older refresh failed");
+    }
+  });
+
+  const older = coalescer(); // will reject
+  const NEW_DEFS = { NewNode: {} };
+  const withPayload = coalescer(NEW_DEFS);
+
+  gate.resolve();
+  await older.catch(() => {});
+  await withPayload;
+
+  assert.ok(registered.includes(NEW_DEFS), "the payload was registered despite the older refresh failing");
+});

--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -1048,9 +1048,11 @@ test('#309: post-write rollback on getter-only workflow flags never throws, rest
   const svc = {
     activeWorkflow: wf,
     calls,
-    // Store doesn't index the never-saved temp ⇒ null ⇒ classifier proves absence.
-    getWorkflowByPath(p) {
-      return disk.has(p) ? { path: p, isPersisted: true } : null
+    // STALE registry: the store index knows neither the never-saved temp (source)
+    // nor the on-disk target — so the pre-check cannot pre-empt and we reach the
+    // rollback net. (getWorkflowByPath(source)=null also proves the source absent.)
+    getWorkflowByPath() {
+      return null
     },
     async renameWorkflow() {},
     async saveWorkflow() {},
@@ -1099,8 +1101,10 @@ test('#309: low-level (1.47) copy that 409s on persist removes the orphaned copy
     activeWorkflow: active,
     openWorkflows,
     calls,
-    getWorkflowByPath(p) {
-      return disk.has(p) ? { path: p, isPersisted: true } : null
+    // STALE registry: the store does not know the on-disk target, so neither the
+    // pre-check nor the classifier pre-empts — the 409 surfaces from saveWorkflow.
+    getWorkflowByPath() {
+      return null
     },
     saveAs(wf, path) {
       calls.push(['saveAs', wf.path, path])
@@ -1133,6 +1137,257 @@ test('#309: low-level (1.47) copy that 409s on persist removes the orphaned copy
   // The orphaned copy tab was removed and the original tab restored as active.
   assert.deepEqual(openWorkflows, [active], 'orphaned copy tab removed from open tabs')
   assert.equal(svc.activeWorkflow, active, 'original tab restored as active')
+})
+
+test('#309/P1-A: an UNKNOWN disk probe + a persisted target in the store ⇒ REFUSE, never call the overwriting saveWorkflowAs', async () => {
+  // The exact P1-A repro: the disk probe THROWS (unknown), but the store knows a
+  // PERSISTED workflow already sits at the target. The high-level saveWorkflowAs
+  // would prompt-and-overwrite (deleting the existing target) — so we must refuse
+  // up front, never reaching it.
+  const active = {
+    path: 'workflows/Orig.json',
+    filename: 'Orig.json',
+    directory: 'workflows',
+    isPersisted: true,
+    isTemporary: false,
+  }
+  const disk = new Set(['workflows/Orig.json', 'workflows/Copy.json'])
+  const calls = []
+  const svc = {
+    activeWorkflow: active,
+    calls,
+    disk,
+    getWorkflowByPath(p) {
+      if (p === active.path) return active
+      if (disk.has(p)) return { path: p, isPersisted: true } // Copy.json is a known persisted target
+      return null
+    },
+    async saveWorkflow() {},
+    async renameWorkflow() {},
+    async saveWorkflowAs() {
+      calls.push('saveWorkflowAs')
+    },
+  }
+  const existsOnDisk = async () => {
+    throw new Error('userdata unreachable') // probe is UNKNOWN
+  }
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'Copy', { existsOnDisk }),
+    /already exists \(409 Conflict\)|choose a different name/,
+  )
+  assert.ok(!calls.includes('saveWorkflowAs'), 'never invoked the overwriting Save-As')
+  assert.ok(svc.disk.has('workflows/Copy.json'), 'the existing target is untouched')
+  assert.ok(svc.disk.has('workflows/Orig.json'), 'the source is untouched')
+})
+
+test('#309/P1-A: an UNKNOWN disk probe with only the overwriting high-level API ⇒ REFUSE (no store signal)', async () => {
+  // Ambiguous collision (probe threw), store can't confirm either way, and the only
+  // Save-As is the OVERWRITING high-level one. Refuse rather than risk destroying a
+  // possibly-existing target (#226/#309).
+  const active = {
+    path: 'workflows/Orig.json',
+    filename: 'Orig.json',
+    directory: 'workflows',
+    isPersisted: true,
+    isTemporary: false,
+  }
+  const calls = []
+  const svc = {
+    activeWorkflow: active,
+    calls,
+    getWorkflowByPath: (p) => (p === active.path ? active : null), // no signal about the target
+    async saveWorkflow() {},
+    async renameWorkflow() {},
+    async saveWorkflowAs() {
+      calls.push('saveWorkflowAs')
+    },
+  }
+  const existsOnDisk = async () => {
+    throw new Error('userdata unreachable') // UNKNOWN
+  }
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'Copy', { existsOnDisk }),
+    /cannot verify that "Copy" is free|Refusing to save-as/,
+  )
+  assert.ok(!calls.includes('saveWorkflowAs'), 'never invoked the overwriting Save-As on an ambiguous probe')
+})
+
+test('#309/P1-A: saveWorkflowAs returning FALSE is a failure, and rollback leaves a REAL pre-existing target intact', async () => {
+  // Faithful decline: the pre-check sees the target absent (TOCTOU), then the real
+  // target appears + gets indexed/opened by the frontend and the OVERWRITE is
+  // DECLINED (saveWorkflowAs returns false). The rollback must NOT treat that real
+  // persisted target as an orphan and evict it — it is a legitimate workflow.
+  const active = {
+    path: 'workflows/Foo.json',
+    filename: 'Foo.json',
+    directory: 'workflows',
+    isPersisted: true,
+    isTemporary: false,
+  }
+  const barTarget = {
+    path: 'workflows/Bar.json',
+    filename: 'Bar.json',
+    directory: 'workflows',
+    isPersisted: true, // a REAL persisted workflow, not a temporary copy
+    isTemporary: false,
+  }
+  const openWorkflows = [active]
+  let barIndexed = false // the real Bar isn't indexed until the (declined) save runs
+  const calls = []
+  const svc = {
+    activeWorkflow: active,
+    calls,
+    openWorkflows,
+    getWorkflowByPath(p) {
+      if (p === active.path) return active
+      if (p === 'workflows/Bar.json' && barIndexed) return barTarget
+      return null
+    },
+    async saveWorkflow() {},
+    async renameWorkflow() {},
+    async closeWorkflow(wf) {
+      const i = openWorkflows.indexOf(wf)
+      if (i >= 0) openWorkflows.splice(i, 1)
+    },
+    async saveWorkflowAs() {
+      calls.push('saveWorkflowAs')
+      // The real target appeared (TOCTOU): the frontend indexes + opens it, then
+      // the overwrite prompt is DECLINED, so nothing is written and false returns.
+      barIndexed = true
+      if (!openWorkflows.includes(barTarget)) openWorkflows.push(barTarget)
+      return false
+    },
+  }
+  const existsOnDisk = async () => false // pre-check sees Bar absent (TOCTOU)
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'Bar', { existsOnDisk }),
+    /was not completed|already exists|409/i,
+  )
+  assert.ok(calls.includes('saveWorkflowAs'), 'attempted the save')
+  // The REAL pre-existing target must remain indexed and open — never evicted as a
+  // phantom orphan.
+  assert.equal(svc.getWorkflowByPath('workflows/Bar.json'), barTarget, 'real target still indexed')
+  assert.ok(openWorkflows.includes(barTarget), 'real target still open (not evicted)')
+  // The original active tab is restored.
+  assert.equal(svc.activeWorkflow, active, 'active restored to the original')
+})
+
+test('#309/P1-B: a high-level saveWorkflowAs that INSERTS a copy then 409s ⇒ orphan removed, active restored, lookup repaired', async () => {
+  // Persisted-source path: the frontend inserts+opens a COPY at the target, indexes
+  // it under the target path, THEN persistence 409s. The rollback must remove that
+  // orphaned copy from the store lookup + open tabs and restore the original active.
+  const active = {
+    path: 'workflows/Orig.json',
+    filename: 'Orig.json',
+    directory: 'workflows',
+    isPersisted: true,
+    isTemporary: false,
+  }
+  const disk = new Set(['workflows/Orig.json', 'workflows/Copy.json'])
+  const store = new Map([['workflows/Orig.json', active]])
+  const openWorkflows = [active]
+  const calls = []
+  const svc = {
+    activeWorkflow: active,
+    openWorkflows,
+    calls,
+    disk,
+    // STALE: the store does not know the on-disk Copy.json until the frontend
+    // inserts its copy — so neither the pre-check nor classify pre-empts.
+    getWorkflowByPath: (p) => store.get(p) ?? null,
+    async saveWorkflow() {},
+    async renameWorkflow() {},
+    async closeWorkflow(wf) {
+      const i = openWorkflows.indexOf(wf)
+      if (i >= 0) openWorkflows.splice(i, 1)
+      store.delete(wf.path)
+    },
+    async saveWorkflowAs(w, { filename }) {
+      calls.push('saveWorkflowAs')
+      const target = `workflows/${stripExt(filename)}.json`
+      const copy = { path: target, filename: target.split('/').pop(), directory: 'workflows', isTemporary: true, isPersisted: false }
+      store.set(target, copy)
+      openWorkflows.push(copy)
+      svc.activeWorkflow = copy
+      const err = new Error(`Error storing user data file '${target}': 409 Conflict`)
+      err.status = 409
+      throw err
+    },
+  }
+
+  // No existsOnDisk ⇒ the store-stale path reaches the failing saveWorkflowAs.
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'Copy', {}),
+    /already exists \(409 Conflict\)/,
+  )
+  assert.deepEqual(openWorkflows, [active], 'orphaned copy removed from open tabs')
+  assert.equal(svc.activeWorkflow, active, 'original tab restored as active')
+  assert.equal(store.get('workflows/Copy.json'), undefined, 'orphan removed from the store lookup')
+  assert.ok(svc.disk.has('workflows/Copy.json'), 'the pre-existing target file is untouched')
+})
+
+test('#309/P1-B: a high-level REKEY of a temporary source that 409s ⇒ store rekeyed back to the original path', async () => {
+  // Temporary-source path: the frontend rekeys the SAME object to the target before
+  // the 409. Reassigning fields on wf does NOT rekey the store lookup — the rollback
+  // must rekey it back via the store's own (in-memory) rename.
+  const wf = {
+    path: 'workflows/Unsaved Workflow.json',
+    filename: 'Unsaved Workflow.json',
+    directory: 'workflows',
+    isTemporary: true,
+    isPersisted: false,
+  }
+  const store = new Map([[wf.path, wf]])
+  const openPaths = [wf.path]
+  const calls = []
+  const svc = {
+    activeWorkflow: wf,
+    calls,
+    getWorkflowByPath: (p) => store.get(p) ?? null,
+    async saveWorkflow() {},
+    async renameWorkflow(w, to) {
+      // A TEMPORARY rename is a pure in-memory updatePath + rekey (no server write).
+      calls.push(['renameWorkflow', w.path, to])
+      store.delete(w.path)
+      const i = openPaths.indexOf(w.path)
+      if (i >= 0) openPaths[i] = to
+      w.path = to
+      w.filename = to.split('/').pop()
+      store.set(to, w)
+    },
+    async saveWorkflowAs(w, { filename }) {
+      calls.push('saveWorkflowAs')
+      const target = `workflows/${stripExt(filename)}.json`
+      // REKEY the same object to the target BEFORE the 409.
+      store.delete(w.path)
+      const i = openPaths.indexOf(w.path)
+      if (i >= 0) openPaths[i] = target
+      w.path = target
+      w.filename = target.split('/').pop()
+      store.set(target, w)
+      svc.activeWorkflow = w
+      const err = new Error(`Error storing user data file '${target}': 409 Conflict`)
+      err.status = 409
+      throw err
+    },
+  }
+  // existsOnDisk reports everything absent (a TOCTOU: the target appeared after the
+  // probe), so the pre-check passes and the source classifies never-persisted.
+  const existsOnDisk = async () => false
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'Existing', { existsOnDisk }),
+    /already exists \(409 Conflict\)/,
+  )
+  // The store lookup + open-tab path were rekeyed BACK to the original.
+  assert.equal(store.get('workflows/Unsaved Workflow.json'), wf, 'source rekeyed back in the store lookup')
+  assert.equal(store.get('workflows/Existing.json'), undefined, 'no stale target key remains')
+  assert.equal(wf.path, 'workflows/Unsaved Workflow.json', 'path restored')
+  assert.deepEqual(openPaths, ['workflows/Unsaved Workflow.json'], 'open-tab path rekeyed back')
+  assert.equal(svc.activeWorkflow, wf, 'active reference restored')
 })
 
 test('refuses to rename-destroy a persisted workflow when no copy API exists', async () => {

--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -876,6 +876,265 @@ test('1.47: saveAs+saveWorkflow but NO openWorkflow ⇒ refuse, never persist nu
   assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'never moved')
 })
 
+// ---------------------------------------------------------------------------
+// #285 — Save-As of a workflow loaded from an EXTERNAL absolute path (outside the
+// managed workflows dir, via panel_load_workflow path:<file>). The copy must land
+// in the USER workflows dir and the external original file must never be moved.
+
+test('#285: external-path Save-As COPIES into the user workflows dir, external original survives', async () => {
+  // A pack workflow loaded from an absolute path OUTSIDE workflows/. It is a live
+  // temporary tab whose graph the user is editing; its file is on disk externally.
+  const active = {
+    path: 'C:/packs/qwen/Product Label Repair.json',
+    filename: 'Product Label Repair.json',
+    directory: 'C:/packs/qwen',
+    isPersisted: false,
+    isTemporary: true,
+  }
+  const { svc, existsOnDisk, graph } = makeStore147Service({ files: [active.path], active })
+
+  const saved = await saveActiveWorkflow(svc, 'Product Label Repair - Qwen Edit Q5', {
+    autoWorkflowName: () => 'Untitled',
+    existsOnDisk,
+  })
+
+  // The copy lands in the USER workflows dir — NOT the external pack folder.
+  assert.ok(
+    svc.disk.has('workflows/Product Label Repair - Qwen Edit Q5.json'),
+    'copy created in the user workflows dir',
+  )
+  assert.ok(
+    !svc.disk.has('C:/packs/qwen/Product Label Repair - Qwen Edit Q5.json'),
+    'no copy written into the unwritable external folder',
+  )
+  // The external ORIGINAL is untouched (copy, never move).
+  assert.ok(svc.disk.has('C:/packs/qwen/Product Label Repair.json'), 'external original preserved')
+  // Real graph content, not null (regression guard for the unopened-copy bug).
+  assert.deepEqual(
+    JSON.parse(svc.disk.get('workflows/Product Label Repair - Qwen Edit Q5.json')),
+    graph,
+    'copy content is the real graph',
+  )
+  assert.ok(svc.calls.some((c) => c[0] === 'saveAs'), 'used the move-free explicit-target copy')
+  assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'never moved the external original')
+  assert.equal(saved, 'Product Label Repair - Qwen Edit Q5')
+})
+
+test('#285: external-path Save-As REFUSES (never moves) when only the moving high-level copy exists', async () => {
+  // A 1.45-style frontend exposes ONLY saveWorkflowAs (which MOVES a temporary and
+  // cannot retarget the directory). For an external temporary source that would
+  // destroy the external original — refuse instead, leaving it on disk.
+  const active = {
+    path: 'C:/packs/qwen/External.json',
+    filename: 'External.json',
+    directory: 'C:/packs/qwen',
+    isPersisted: false,
+    isTemporary: true,
+  }
+  const svc = makeFaithfulService({ files: [active.path], active }) // saveWorkflowAs only
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'External Copy', {}),
+    /externally-loaded workflow|outside the workflows folder/,
+  )
+  assert.ok(svc.disk.has('C:/packs/qwen/External.json'), 'external original preserved')
+  assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'never moved')
+  assert.ok(!svc.calls.some((c) => c[0] === 'saveWorkflowAs'), 'never delegated a move')
+})
+
+// ---------------------------------------------------------------------------
+// #309 — a Save-As whose server write 409-conflicts (name already exists) must not
+// leave the active tab rebound to the conflicting path.
+
+// A service double whose saveWorkflowAs OPTIMISTICALLY rebinds the active tab to
+// the target path (the reported bug) and THEN throws a 409 when the target file
+// already exists on disk. The rebind persists across the throw unless rolled back.
+function makeConflictService({ files = [], active } = {}) {
+  const disk = new Set(files)
+  const calls = []
+  const svc = {
+    activeWorkflow: active,
+    calls,
+    disk,
+    getWorkflowByPath(path) {
+      if (active && active.path === path) return active
+      if (disk.has(path)) return { path, isPersisted: true }
+      return null
+    },
+    async renameWorkflow(wf, to) {
+      calls.push(['renameWorkflow', wf.path, to])
+      wf.path = to
+      wf.filename = to.split('/').pop()
+    },
+    async saveWorkflow(wf) {
+      calls.push(['saveWorkflow', wf.path])
+      disk.add(wf.path)
+    },
+    async saveWorkflowAs(wf, { filename }) {
+      calls.push(['saveWorkflowAs', wf.path, filename])
+      const target = `workflows/${stripExt(filename)}${extFor(wf)}`
+      // OPTIMISTIC in-memory rebind BEFORE the server write (the #309 bug).
+      wf.path = target
+      wf.filename = target.split('/').pop()
+      wf.isPersisted = false
+      wf.isTemporary = true
+      svc.activeWorkflow = wf
+      if (disk.has(target)) {
+        const err = new Error(`Error storing user data file '${target}': 409 Conflict`)
+        err.status = 409
+        throw err // server rejected — nothing written on disk
+      }
+      disk.add(target)
+      svc.activeWorkflow = { path: target, filename: wf.filename, directory: 'workflows', isPersisted: true, isTemporary: false }
+    },
+  }
+  return svc
+}
+
+test('#309: a name collision is pre-empted before any rebind, and a re-save under a new name succeeds', async () => {
+  const active = {
+    path: 'workflows/Unsaved Workflow.json',
+    filename: 'Unsaved Workflow.json',
+    directory: 'workflows',
+    isPersisted: false,
+    isTemporary: true,
+  }
+  const svc = makeConflictService({ files: ['workflows/FourRef_Identity.json'], active })
+  const existsOnDisk = async (p) => svc.disk.has(p)
+
+  // Save under a name that already exists on disk ⇒ clean conflict.
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'FourRef_Identity', { existsOnDisk }),
+    /already exists \(409 Conflict\)|choose a different name/,
+  )
+
+  // The collision was caught UP FRONT: no save/copy API was ever called, so the
+  // tab was never optimistically rebound to the conflicting path (which is what
+  // tripped the #226 guard before). The tab stands exactly as it was.
+  assert.ok(!svc.calls.some((c) => c[0] === 'saveWorkflowAs'), 'never invoked the rebinding save')
+  assert.equal(active.path, 'workflows/Unsaved Workflow.json', 'tab path unchanged')
+  assert.equal(active.filename, 'Unsaved Workflow.json', 'tab filename unchanged')
+  assert.equal(svc.activeWorkflow, active, 'active reference unchanged')
+  assert.ok(svc.disk.has('workflows/FourRef_Identity.json'), 'the pre-existing file is untouched')
+
+  // Because the tab is consistent, saving under a DIFFERENT unique name now works
+  // (before the fix this refused via the #226 guard).
+  const saved = await saveActiveWorkflow(svc, 'FourRef_Identity_v2', { existsOnDisk })
+  assert.ok(svc.disk.has('workflows/FourRef_Identity_v2.json'), 're-save under a new name succeeded')
+  assert.equal(saved, 'FourRef_Identity_v2')
+})
+
+test('#309: post-write rollback on getter-only workflow flags never throws, restores active + path', async () => {
+  // The production hazard the pre-check net must also survive: a REAL ComfyUI
+  // workflow object exposes DERIVED, getter-only flags (get isTemporary(){...}).
+  // With NO disk oracle the pre-check can't fire, so saveWorkflowAs rebinds the tab
+  // and 409s; the rollback must restore the settable identity + active reference
+  // WITHOUT throwing a TypeError on the getter-only flags (which would swallow the
+  // clean 409 and abort the restore).
+  let size = -1 // -1 ⇒ temporary, mirrors the frontend's `get isTemporary(){return this.size===-1}`
+  const wf = {
+    path: 'workflows/Unsaved Workflow.json',
+    filename: 'Unsaved Workflow.json',
+    directory: 'workflows',
+    get isTemporary() {
+      return size === -1
+    },
+    get isPersisted() {
+      return size !== -1
+    },
+  }
+  const disk = new Set(['workflows/Existing.json'])
+  const calls = []
+  const svc = {
+    activeWorkflow: wf,
+    calls,
+    // Store doesn't index the never-saved temp ⇒ null ⇒ classifier proves absence.
+    getWorkflowByPath(p) {
+      return disk.has(p) ? { path: p, isPersisted: true } : null
+    },
+    async renameWorkflow() {},
+    async saveWorkflow() {},
+    async saveWorkflowAs(w, { filename }) {
+      calls.push(['saveWorkflowAs', w.path, filename])
+      const target = `workflows/${stripExt(filename)}.json`
+      // Optimistic in-memory rebind (settable fields), THEN a 409.
+      w.path = target
+      w.filename = target.split('/').pop()
+      svc.activeWorkflow = w
+      const err = new Error(`Error storing user data file '${target}': 409 Conflict`)
+      err.status = 409
+      throw err
+    },
+  }
+
+  // NO existsOnDisk ⇒ the pre-check is skipped and we exercise the rollback net.
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'Existing', {}),
+    /already exists \(409 Conflict\)/,
+  )
+
+  // The rollback ran to completion (no TypeError from the getter-only assignments):
+  // the active reference and settable path/filename are restored.
+  assert.equal(svc.activeWorkflow, wf, 'active reference restored')
+  assert.equal(wf.path, 'workflows/Unsaved Workflow.json', 'path rolled back')
+  assert.equal(wf.filename, 'Unsaved Workflow.json', 'filename rolled back')
+  assert.equal(wf.isTemporary, true, 'derived getter intact')
+})
+
+test('#309: low-level (1.47) copy that 409s on persist removes the orphaned copy tab, restores active', async () => {
+  // On a 1.47 store the copy is created + opened (becoming active) BEFORE its
+  // persist. If saveWorkflow(copy) 409s, the copy must be removed from the open
+  // tabs and the previously-active workflow restored — no phantom unsaved tab.
+  const active = {
+    path: 'workflows/Unsaved Workflow.json',
+    filename: 'Unsaved Workflow.json',
+    directory: 'workflows',
+    isPersisted: false,
+    isTemporary: true,
+  }
+  const openWorkflows = [active]
+  const disk = new Set(['workflows/Existing.json'])
+  const calls = []
+  const svc = {
+    activeWorkflow: active,
+    openWorkflows,
+    calls,
+    getWorkflowByPath(p) {
+      return disk.has(p) ? { path: p, isPersisted: true } : null
+    },
+    saveAs(wf, path) {
+      calls.push(['saveAs', wf.path, path])
+      const copy = { path, filename: path.split('/').pop(), directory: 'workflows', changeTracker: { prepareForSave() {} } }
+      openWorkflows.push(copy)
+      return copy
+    },
+    async openWorkflow(wf) {
+      calls.push(['openWorkflow', wf.path])
+      svc.activeWorkflow = wf
+    },
+    async saveWorkflow(wf) {
+      calls.push(['saveWorkflow', wf.path])
+      if (disk.has(wf.path)) {
+        const err = new Error(`Error storing user data file '${wf.path}': 409 Conflict`)
+        err.status = 409
+        throw err
+      }
+      disk.add(wf.path)
+    },
+    async renameWorkflow() {},
+  }
+
+  // No existsOnDisk ⇒ pre-check skipped; the 409 surfaces from saveWorkflow(copy).
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'Existing', {}),
+    /already exists \(409 Conflict\)/,
+  )
+
+  // The orphaned copy tab was removed and the original tab restored as active.
+  assert.deepEqual(openWorkflows, [active], 'orphaned copy tab removed from open tabs')
+  assert.equal(svc.activeWorkflow, active, 'original tab restored as active')
+})
+
 test('refuses to rename-destroy a persisted workflow when no copy API exists', async () => {
   const active = {
     path: 'workflows/Foo.json',

--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -28,6 +28,14 @@ function makeService({ files = [], active } = {}) {
     activeWorkflow: active,
     calls,
     disk,
+    // The real store always exposes getWorkflowByPath (a REQUIRED member); the copy
+    // path's final synchronous collision re-check needs it. Nothing on disk / not the
+    // active tab ⇒ the target is free.
+    getWorkflowByPath(path) {
+      if (active && active.path === path) return active
+      if (disk.has(path)) return { path, isPersisted: true }
+      return null
+    },
     // Mirrors ComfyUI's saveWorkflow: it recomputes the expected path from the
     // workflow's mode-derived extension, and if that differs from the current
     // path it RENAMES (moves) the file before saving. This is the exact upstream
@@ -50,15 +58,15 @@ function makeService({ files = [], active } = {}) {
       disk.add(newPath)
     },
     async saveWorkflowAs(wf, { filename }) {
+      // Present but the panel must PREFER the atomic low-level trio over this
+      // (potentially-overwriting) high-level API — its presence lets tests prove we
+      // never call it. Modeled as a safe copy so a wrong call would still "succeed".
       calls.push(['saveWorkflowAs', wf.path, filename])
-      // Copy: new file in the SOURCE's directory, with the mode-correct
-      // extension; the original is left untouched.
       const dir = wf.directory || 'workflows'
       const base = stripExt(filename)
       const newFilename = `${base}${extFor(wf)}`
       const newPath = `${dir}/${newFilename}`
       disk.add(newPath)
-      // The copy becomes the active workflow (mirrors the real frontend).
       svc.activeWorkflow = {
         path: newPath,
         filename: newFilename,
@@ -67,6 +75,25 @@ function makeService({ files = [], active } = {}) {
         isPersisted: true,
         isTemporary: false
       }
+    },
+    // Low-level ATOMIC copy trio (the route the real 1.47.x frontend exposes). saveAs
+    // builds a NEW copy object at an explicit target; openWorkflow activates it;
+    // saveWorkflow persists it. The source object + file are never touched (#226).
+    saveAs(wf, path) {
+      calls.push(['saveAs', wf.path, path])
+      return {
+        path,
+        filename: path.split('/').pop(),
+        directory: path.split('/').slice(0, -1).join('/') || 'workflows',
+        initialMode: wf.initialMode,
+        isPersisted: false,
+        isTemporary: true,
+        changeTracker: { prepareForSave() {} }
+      }
+    },
+    async openWorkflow(copy) {
+      calls.push(['openWorkflow', copy.path])
+      svc.activeWorkflow = copy
     }
   }
   return svc
@@ -98,10 +125,15 @@ test('Save-As with a new name COPIES and leaves the original file on disk (#226)
   assert.ok(svc.disk.has('workflows/_a_exporter/Foo.json'), 'original preserved')
   // A new copy exists, in the SAME containing folder (folder preserved).
   assert.ok(svc.disk.has('workflows/_a_exporter/Bar.json'), 'copy created in place')
-  // It went through the copy path, never renameWorkflow.
+  // It went through the ATOMIC low-level copy path — never the overwriting
+  // high-level saveWorkflowAs, and never renameWorkflow.
   assert.ok(
-    svc.calls.some((c) => c[0] === 'saveWorkflowAs'),
-    'used saveWorkflowAs'
+    svc.calls.some((c) => c[0] === 'saveAs'),
+    'used the atomic low-level saveAs copy'
+  )
+  assert.ok(
+    !svc.calls.some((c) => c[0] === 'saveWorkflowAs'),
+    'never called the overwriting high-level saveWorkflowAs'
   )
   assert.ok(
     !svc.calls.some((c) => c[0] === 'renameWorkflow'),
@@ -161,7 +193,7 @@ test('a never-saved placeholder tab is grounded safely via the FAITHFUL frontend
 
   // Grounded to a real file; nothing on disk was destroyed (there was nothing).
   assert.ok(svc.disk.has('workflows/Untitled 2026-07-24.json'), 'temp grounded to a file')
-  assert.ok(svc.calls.some((c) => c[0] === 'saveWorkflowAs'), 'delegated to saveWorkflowAs')
+  assert.ok(svc.calls.some((c) => c[0] === 'saveAs'), 'delegated to the atomic low-level saveAs copy')
   assert.equal(saved, 'Untitled 2026-07-24')
 })
 
@@ -200,7 +232,7 @@ test('double-extension Save-As to the base name still COPIES, never renames (#22
 
   assert.ok(svc.disk.has('workflows/Foo.json.json'), 'original preserved')
   assert.ok(svc.disk.has('workflows/Foo.json'), 'copy created')
-  assert.ok(svc.calls.some((c) => c[0] === 'saveWorkflowAs'), 'used saveWorkflowAs')
+  assert.ok(svc.calls.some((c) => c[0] === 'saveAs'), 'used the atomic low-level saveAs copy')
   assert.ok(
     !svc.calls.some((c) => c[0] === 'renameWorkflow'),
     'never renamed the source'
@@ -227,7 +259,7 @@ test('app-mode Save-As to the base name COPIES, never renames the source (#226)'
 
   assert.ok(svc.disk.has('workflows/Foo.json'), 'original preserved')
   assert.ok(svc.disk.has('workflows/Foo.app.json'), 'app-mode copy created')
-  assert.ok(svc.calls.some((c) => c[0] === 'saveWorkflowAs'), 'used saveWorkflowAs')
+  assert.ok(svc.calls.some((c) => c[0] === 'saveAs'), 'used the atomic low-level saveAs copy')
   assert.ok(
     !svc.calls.some((c) => c[0] === 'renameWorkflow'),
     'never renamed the source'
@@ -268,15 +300,15 @@ function makeFaithfulService({ files = [], active } = {}) {
       disk.add(wf.path)
     },
     async saveWorkflowAs(wf, { filename }) {
+      // The DANGEROUS high-level API (MOVES a temporary). Kept so tests prove the
+      // panel PREFERS the atomic low-level trio and NEVER calls this.
       calls.push(['saveWorkflowAs', wf.path, filename, !!wf.isTemporary])
       const dir = wf.directory || 'workflows'
       const newPath = `${dir}/${stripExt(filename)}${extFor(wf)}`
       if (wf.isTemporary) {
-        // Frontend's TEMPORARY branch: renameWorkflow(e, a) — MOVES the source.
         await svc.renameWorkflow(wf, newPath)
         svc.activeWorkflow = wf
       } else {
-        // PERSISTED branch: copy, original untouched.
         disk.add(newPath)
         svc.activeWorkflow = {
           path: newPath,
@@ -287,6 +319,24 @@ function makeFaithfulService({ files = [], active } = {}) {
           isTemporary: false
         }
       }
+    },
+    // Low-level ATOMIC copy trio (the real 1.47.x route). Move-free by construction:
+    // saveAs snapshots the source into a NEW copy object; the source is never touched.
+    saveAs(wf, path) {
+      calls.push(['saveAs', wf.path, path])
+      return {
+        path,
+        filename: path.split('/').pop(),
+        directory: path.split('/').slice(0, -1).join('/') || 'workflows',
+        initialMode: wf.initialMode,
+        isPersisted: false,
+        isTemporary: true,
+        changeTracker: { prepareForSave() {} }
+      }
+    },
+    async openWorkflow(copy) {
+      calls.push(['openWorkflow', copy.path])
+      svc.activeWorkflow = copy
     }
   }
   return svc
@@ -378,14 +428,14 @@ test('item 2: a genuine NEW workflow with NO path grounds/saves (never refused) 
   })
 
   assert.ok(svc.disk.has('workflows/Untitled 2026-07-29.json'), 'new workflow grounded to a file')
-  assert.ok(svc.calls.some((c) => c[0] === 'saveWorkflowAs'), 'delegated to saveWorkflowAs')
+  assert.ok(svc.calls.some((c) => c[0] === 'saveAs'), 'delegated to the atomic low-level saveAs copy')
   assert.equal(saved, 'Untitled 2026-07-29')
 })
 
-test('disk-existence backstop catches a saveWorkflowAs that moves a persisted source (#226)', async () => {
-  // Rogue frontend: even a NON-temporary persisted source gets moved by
-  // saveWorkflowAs. The pre-check can't foresee this, so the post-op
-  // disk-existence guard must catch it and throw rather than report success.
+test('disk-existence backstop catches a low-level copy that moves a persisted source (#226)', async () => {
+  // Rogue frontend: the low-level saveAs ALSO deletes the source (a move). The pre-
+  // check can't foresee this, so the post-op disk-existence backstop must catch the
+  // vanished source and throw rather than report success.
   const active = {
     path: 'workflows/zz226b-orig.json',
     filename: 'zz226b-orig.json',
@@ -394,11 +444,10 @@ test('disk-existence backstop catches a saveWorkflowAs that moves a persisted so
     isTemporary: false
   }
   const svc = makeFaithfulService({ files: [active.path], active })
-  // Force the move branch regardless of flags.
-  const origSaveAs = svc.saveWorkflowAs
-  svc.saveWorkflowAs = async (wf, opts) => {
-    wf.isTemporary = true
-    return origSaveAs(wf, opts)
+  const origSaveAs = svc.saveAs
+  svc.saveAs = (wf, path) => {
+    svc.disk.delete(wf.path) // ROGUE: consumes (moves) the source
+    return origSaveAs(wf, path)
   }
 
   await assert.rejects(
@@ -464,9 +513,13 @@ test('round-6: a THROWING post-save probe does NOT false-alarm — a valid copy 
     isTemporary: false
   }
   const svc = makeFaithfulService({ files: [active.path], active })
-  // Probe throws AFTER the (successful, copying) saveWorkflowAs.
-  svc.getWorkflowByPath = () => {
-    throw new Error('store index unavailable')
+  // The lookup for the SOURCE path throws (the post-save backstop probe); the TARGET
+  // path resolves free (so the copy path's final re-check proceeds normally). A throw
+  // on the source lookup is UNKNOWN — not proof the source vanished — so the backstop
+  // must NOT report a valid copy as "moved".
+  svc.getWorkflowByPath = (p) => {
+    if (p === 'workflows/zz226b-orig.json') throw new Error('store index unavailable')
+    return null
   }
 
   const saved = await saveActiveWorkflow(svc, 'zz226b-copy', {})
@@ -609,7 +662,7 @@ test('P0-b: no-name save of an on-disk app-mode workflow COPIES to .app.json, so
 
   assert.ok(svc.disk.has('workflows/Foo.json'), 'original source preserved')
   assert.ok(svc.disk.has('workflows/Foo.app.json'), 'app-mode copy created')
-  assert.ok(svc.calls.some((c) => c[0] === 'saveWorkflowAs'), 'routed to the copy path')
+  assert.ok(svc.calls.some((c) => c[0] === 'saveAs'), 'routed to the atomic low-level saveAs copy')
   assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'never renamed the source')
 })
 
@@ -866,7 +919,7 @@ test('1.47: saveAs+saveWorkflow but NO openWorkflow ⇒ refuse, never persist nu
 
   await assert.rejects(
     () => saveActiveWorkflow(svc, 'Bar', { existsOnDisk }),
-    /save-as \(copy\) is unavailable on this frontend/
+    /Save-As \(copy\) is unavailable on this frontend|refusing to rename and destroy/i
   )
   // NOTHING was copied or persisted — no null-content file; source untouched.
   assert.ok(!svc.disk.has('workflows/Bar.json'), 'no null-content copy written')
@@ -931,7 +984,9 @@ test('#285: external-path Save-As REFUSES (never moves) when only the moving hig
     isPersisted: false,
     isTemporary: true,
   }
-  const svc = makeFaithfulService({ files: [active.path], active }) // saveWorkflowAs only
+  const svc = makeFaithfulService({ files: [active.path], active })
+  delete svc.saveAs // only the moving high-level saveWorkflowAs remains (no atomic trio)
+  delete svc.openWorkflow
 
   await assert.rejects(
     () => saveActiveWorkflow(svc, 'External Copy', {}),
@@ -987,6 +1042,15 @@ function makeConflictService({ files = [], active } = {}) {
       disk.add(target)
       svc.activeWorkflow = { path: target, filename: wf.filename, directory: 'workflows', isPersisted: true, isTemporary: false }
     },
+    // Atomic low-level trio (the route the panel actually uses).
+    saveAs(wf, path) {
+      calls.push(['saveAs', wf.path, path])
+      return { path, filename: path.split('/').pop(), directory: 'workflows', initialMode: wf.initialMode, isPersisted: false, isTemporary: true, changeTracker: { prepareForSave() {} } }
+    },
+    async openWorkflow(copy) {
+      calls.push(['openWorkflow', copy.path])
+      svc.activeWorkflow = copy
+    },
   }
   return svc
 }
@@ -1024,14 +1088,13 @@ test('#309: a name collision is pre-empted before any rebind, and a re-save unde
   assert.equal(saved, 'FourRef_Identity_v2')
 })
 
-test('#309: post-write rollback on getter-only workflow flags never throws, restores active + path', async () => {
-  // The production hazard the pre-check net must also survive: a REAL ComfyUI
-  // workflow object exposes DERIVED, getter-only flags (get isTemporary(){...}).
-  // With NO disk oracle the pre-check can't fire, so saveWorkflowAs rebinds the tab
-  // and 409s; the rollback must restore the settable identity + active reference
-  // WITHOUT throwing a TypeError on the getter-only flags (which would swallow the
-  // clean 409 and abort the restore).
-  let size = -1 // -1 ⇒ temporary, mirrors the frontend's `get isTemporary(){return this.size===-1}`
+test('#309: a low-level 409 rollback on a getter-only source never throws (getter-safe restore)', async () => {
+  // withConflictRollback restores the SOURCE's fields on any conflict. A REAL
+  // ComfyUI workflow exposes DERIVED, getter-only flags (get isTemporary(){...}); a
+  // plain assignment to those throws a TypeError and would swallow the clean 409. On
+  // the low-level path the source is never rebound (the copy is separate), so the
+  // restore is a no-op — but it must still not throw on the getter-only flags.
+  let size = -1 // -1 ⇒ temporary
   const wf = {
     path: 'workflows/Unsaved Workflow.json',
     filename: 'Unsaved Workflow.json',
@@ -1048,38 +1111,35 @@ test('#309: post-write rollback on getter-only workflow flags never throws, rest
   const svc = {
     activeWorkflow: wf,
     calls,
-    // STALE registry: the store index knows neither the never-saved temp (source)
-    // nor the on-disk target — so the pre-check cannot pre-empt and we reach the
-    // rollback net. (getWorkflowByPath(source)=null also proves the source absent.)
     getWorkflowByPath() {
-      return null
+      return null // stale: proves the temp source absent; target unknown
     },
     async renameWorkflow() {},
-    async saveWorkflow() {},
-    async saveWorkflowAs(w, { filename }) {
-      calls.push(['saveWorkflowAs', w.path, filename])
-      const target = `workflows/${stripExt(filename)}.json`
-      // Optimistic in-memory rebind (settable fields), THEN a 409.
-      w.path = target
-      w.filename = target.split('/').pop()
-      svc.activeWorkflow = w
-      const err = new Error(`Error storing user data file '${target}': 409 Conflict`)
-      err.status = 409
-      throw err
+    saveAs(w, path) {
+      calls.push(['saveAs', w.path, path])
+      return { path, filename: path.split('/').pop(), directory: 'workflows', isPersisted: false, isTemporary: true, changeTracker: { prepareForSave() {} } }
+    },
+    async openWorkflow(copy) {
+      svc.activeWorkflow = copy
+    },
+    async saveWorkflow(w) {
+      calls.push(['saveWorkflow', w.path])
+      if (disk.has(w.path)) {
+        const err = new Error(`Error storing user data file '${w.path}': 409 Conflict`)
+        err.status = 409
+        throw err
+      }
+      disk.add(w.path)
     },
   }
+  const existsOnDisk = async () => false // pre-check passes (TOCTOU); 409 from saveWorkflow
 
-  // NO existsOnDisk ⇒ the pre-check is skipped and we exercise the rollback net.
   await assert.rejects(
-    () => saveActiveWorkflow(svc, 'Existing', {}),
+    () => saveActiveWorkflow(svc, 'Existing', { existsOnDisk }),
     /already exists \(409 Conflict\)/,
   )
-
-  // The rollback ran to completion (no TypeError from the getter-only assignments):
-  // the active reference and settable path/filename are restored.
-  assert.equal(svc.activeWorkflow, wf, 'active reference restored')
-  assert.equal(wf.path, 'workflows/Unsaved Workflow.json', 'path rolled back')
-  assert.equal(wf.filename, 'Unsaved Workflow.json', 'filename rolled back')
+  // Clean conflict surfaced (no TypeError); source identity + derived getter intact.
+  assert.equal(wf.path, 'workflows/Unsaved Workflow.json', 'source path untouched')
   assert.equal(wf.isTemporary, true, 'derived getter intact')
 })
 
@@ -1181,10 +1241,159 @@ test('#309/P1-A: an UNKNOWN disk probe + a persisted target in the store ⇒ REF
   assert.ok(svc.disk.has('workflows/Orig.json'), 'the source is untouched')
 })
 
-test('#309/P1-A: an UNKNOWN disk probe with only the overwriting high-level API ⇒ REFUSE (no store signal)', async () => {
-  // Ambiguous collision (probe threw), store can't confirm either way, and the only
-  // Save-As is the OVERWRITING high-level one. Refuse rather than risk destroying a
-  // possibly-existing target (#226/#309).
+test('#226: a Save-As whose target is occupied by ANOTHER unsaved TEMPORARY tab REFUSES, never orphans it', async () => {
+  // The real 1.47 store's saveAs unconditionally replaces workflowLookup[target].
+  // If an UNSAVED temporary tab already owns the target path, saving over it would
+  // orphan its graph (data loss) — and a disk 404 can't see an unsaved tab, so the
+  // store index is the only signal. A DISTINCT object at the target (persisted OR
+  // temporary) must refuse, not overwrite.
+  const active = {
+    path: 'workflows/Unsaved Workflow.json',
+    filename: 'Unsaved Workflow.json',
+    directory: 'workflows',
+    isPersisted: false,
+    isTemporary: true,
+  }
+  const otherTemp = {
+    path: 'workflows/Draft.json',
+    filename: 'Draft.json',
+    directory: 'workflows',
+    isPersisted: false, // ANOTHER unsaved tab already at the target path
+    isTemporary: true,
+  }
+  const store = new Map([
+    ['workflows/Unsaved Workflow.json', active],
+    ['workflows/Draft.json', otherTemp],
+  ])
+  const calls = []
+  const svc = {
+    activeWorkflow: active,
+    calls,
+    getWorkflowByPath: (p) => store.get(p) ?? null,
+    saveAs(wf, path) {
+      calls.push(['saveAs', path])
+      const c = { path, filename: path.split('/').pop(), isPersisted: false, isTemporary: true, changeTracker: { prepareForSave() {} } }
+      store.set(path, c) // the real store REPLACES the lookup entry (orphaning otherTemp)
+      return c
+    },
+    async openWorkflow(c) {
+      svc.activeWorkflow = c
+    },
+    async saveWorkflow() {},
+    async renameWorkflow() {},
+  }
+  const existsOnDisk = async () => false // disk 404s (the other tab is unsaved)
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'Draft', { existsOnDisk }),
+    /already exists \(409 Conflict\)|choose a different name/,
+  )
+  assert.ok(!calls.some((c) => c[0] === 'saveAs'), 'never created a copy over the existing tab')
+  assert.equal(store.get('workflows/Draft.json'), otherTemp, 'the existing temporary tab is intact (not orphaned)')
+})
+
+test('#226: a temp tab that occupies the target DURING the async disk probe is caught by the final re-check (TOCTOU)', async () => {
+  // The residual race: probeTargetCollision's store check sees the target FREE, then
+  // awaits the disk HEAD; while it is pending, another unsaved tab occupies the
+  // target. The final SYNCHRONOUS re-check right before saveAs must catch it — the
+  // store's saveAs would otherwise replace the lookup entry and orphan that tab.
+  const active = {
+    path: 'workflows/Unsaved Workflow.json',
+    filename: 'Unsaved Workflow.json',
+    directory: 'workflows',
+    isPersisted: false,
+    isTemporary: true,
+  }
+  const otherTemp = { path: 'workflows/Draft.json', filename: 'Draft.json', isPersisted: false, isTemporary: true }
+  const store = new Map([['workflows/Unsaved Workflow.json', active]]) // otherTemp NOT present yet
+  const calls = []
+  const svc = {
+    activeWorkflow: active,
+    calls,
+    getWorkflowByPath: (p) => store.get(p) ?? null,
+    saveAs(wf, path) {
+      calls.push(['saveAs', path])
+      const c = { path, filename: path.split('/').pop(), isPersisted: false, isTemporary: true, changeTracker: { prepareForSave() {} } }
+      store.set(path, c) // REPLACES the lookup entry (would orphan otherTemp)
+      return c
+    },
+    async openWorkflow(c) {
+      svc.activeWorkflow = c
+    },
+    async saveWorkflow() {},
+    async renameWorkflow() {},
+  }
+  // The disk HEAD probe: another tab occupies the target WHILE the probe is pending.
+  const existsOnDisk = async (p) => {
+    if (p === 'workflows/Draft.json') {
+      store.set('workflows/Draft.json', otherTemp) // occupies the target mid-probe
+      return false // 404 — the disk can't see the unsaved tab
+    }
+    return false
+  }
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'Draft', { existsOnDisk }),
+    /already occupies|already exists \(409 Conflict\)|choose a different name/,
+  )
+  assert.ok(!calls.some((c) => c[0] === 'saveAs'), 'never overwrote the tab that appeared mid-probe')
+  assert.equal(store.get('workflows/Draft.json'), otherTemp, 'the appeared temporary tab is intact (not orphaned)')
+})
+
+test('#226: the copy path FAILS CLOSED when the target cannot be verified (lookup absent or throwing)', async () => {
+  // The atomic re-check must not fail OPEN: if getWorkflowByPath is absent, or throws,
+  // we cannot prove the target is free, so we refuse rather than risk saveAs
+  // overwriting an in-memory tab.
+  const base = {
+    path: 'workflows/Unsaved Workflow.json',
+    filename: 'Unsaved Workflow.json',
+    directory: 'workflows',
+    isPersisted: false,
+    isTemporary: true,
+  }
+  const mkSvc = (lookup) => {
+    const calls = []
+    const svc = {
+      activeWorkflow: { ...base },
+      calls,
+      saveAs(wf, path) {
+        calls.push(['saveAs', path])
+        return { path, filename: path.split('/').pop(), isPersisted: false, isTemporary: true, changeTracker: { prepareForSave() {} } }
+      },
+      async openWorkflow(c) {
+        svc.activeWorkflow = c
+      },
+      async saveWorkflow() {},
+      async renameWorkflow() {},
+    }
+    if (lookup) svc.getWorkflowByPath = lookup
+    return svc
+  }
+  const existsOnDisk = async () => false // target provably absent on disk
+
+  // (a) No getWorkflowByPath at all ⇒ refuse.
+  const noLookup = mkSvc(null)
+  await assert.rejects(
+    () => saveActiveWorkflow(noLookup, 'Draft', { existsOnDisk }),
+    /cannot verify the target|refusing to avoid overwriting/i,
+  )
+  assert.ok(!noLookup.calls.some((c) => c[0] === 'saveAs'), 'never wrote without a lookup')
+
+  // (b) A THROWING getWorkflowByPath ⇒ refuse.
+  const throwingLookup = mkSvc(() => {
+    throw new Error('store index unavailable')
+  })
+  await assert.rejects(
+    () => saveActiveWorkflow(throwingLookup, 'Draft', { existsOnDisk }),
+    /could not verify the target|refusing to avoid overwriting/i,
+  )
+  assert.ok(!throwingLookup.calls.some((c) => c[0] === 'saveAs'), 'never wrote on a throwing lookup')
+})
+
+test('#226/#309 P1-1: a frontend with ONLY the overwriting high-level saveWorkflowAs ⇒ REFUSE the relocating Save-As', async () => {
+  // The only Save-As is the high-level one, which writes by prompting and can
+  // delete+overwrite an existing target — no pre-check can make it atomic. A
+  // collision-capable Save-As must be REFUSED, never routed through it.
   const active = {
     path: 'workflows/Orig.json',
     filename: 'Orig.json',
@@ -1196,29 +1405,27 @@ test('#309/P1-A: an UNKNOWN disk probe with only the overwriting high-level API 
   const svc = {
     activeWorkflow: active,
     calls,
-    getWorkflowByPath: (p) => (p === active.path ? active : null), // no signal about the target
+    getWorkflowByPath: (p) => (p === active.path ? active : null),
     async saveWorkflow() {},
     async renameWorkflow() {},
     async saveWorkflowAs() {
       calls.push('saveWorkflowAs')
     },
   }
-  const existsOnDisk = async () => {
-    throw new Error('userdata unreachable') // UNKNOWN
-  }
+  const existsOnDisk = async (p) => p === active.path // target absent; source present
 
   await assert.rejects(
     () => saveActiveWorkflow(svc, 'Copy', { existsOnDisk }),
-    /cannot verify that "Copy" is free|Refusing to save-as/,
+    /atomic Save-As.*unavailable|refused to avoid data loss/i,
   )
-  assert.ok(!calls.includes('saveWorkflowAs'), 'never invoked the overwriting Save-As on an ambiguous probe')
+  assert.ok(!calls.includes('saveWorkflowAs'), 'never invoked the overwriting Save-As')
 })
 
-test('#309/P1-A: saveWorkflowAs returning FALSE is a failure, and rollback leaves a REAL pre-existing target intact', async () => {
-  // Faithful decline: the pre-check sees the target absent (TOCTOU), then the real
-  // target appears + gets indexed/opened by the frontend and the OVERWRITE is
-  // DECLINED (saveWorkflowAs returns false). The rollback must NOT treat that real
-  // persisted target as an orphan and evict it — it is a legitimate workflow.
+test('#226/#309 P1-1: atomic Save-As — target appears AFTER the pre-check, overwrite:false 409s, NO delete of the real target', async () => {
+  // The TOCTOU repro P1-1 is about: the disk oracle reports the target ABSENT, then a
+  // real persisted target appears BEFORE the write. The atomic low-level saveWorkflow
+  // (overwrite:false) 409s WITHOUT deleting/overwriting the pre-existing target — the
+  // exact property a non-atomic pre-check + overwriting API could not guarantee.
   const active = {
     path: 'workflows/Foo.json',
     filename: 'Foo.json',
@@ -1226,168 +1433,163 @@ test('#309/P1-A: saveWorkflowAs returning FALSE is a failure, and rollback leave
     isPersisted: true,
     isTemporary: false,
   }
-  const barTarget = {
-    path: 'workflows/Bar.json',
-    filename: 'Bar.json',
-    directory: 'workflows',
-    isPersisted: true, // a REAL persisted workflow, not a temporary copy
-    isTemporary: false,
-  }
-  const openWorkflows = [active]
-  let barIndexed = false // the real Bar isn't indexed until the (declined) save runs
-  const calls = []
-  const svc = {
-    activeWorkflow: active,
-    calls,
-    openWorkflows,
-    getWorkflowByPath(p) {
-      if (p === active.path) return active
-      if (p === 'workflows/Bar.json' && barIndexed) return barTarget
-      return null
-    },
-    async saveWorkflow() {},
-    async renameWorkflow() {},
-    async closeWorkflow(wf) {
-      const i = openWorkflows.indexOf(wf)
-      if (i >= 0) openWorkflows.splice(i, 1)
-    },
-    async saveWorkflowAs() {
-      calls.push('saveWorkflowAs')
-      // The real target appeared (TOCTOU): the frontend indexes + opens it, then
-      // the overwrite prompt is DECLINED, so nothing is written and false returns.
-      barIndexed = true
-      if (!openWorkflows.includes(barTarget)) openWorkflows.push(barTarget)
-      return false
-    },
-  }
-  const existsOnDisk = async () => false // pre-check sees Bar absent (TOCTOU)
-
-  await assert.rejects(
-    () => saveActiveWorkflow(svc, 'Bar', { existsOnDisk }),
-    /was not completed|already exists|409/i,
-  )
-  assert.ok(calls.includes('saveWorkflowAs'), 'attempted the save')
-  // The REAL pre-existing target must remain indexed and open — never evicted as a
-  // phantom orphan.
-  assert.equal(svc.getWorkflowByPath('workflows/Bar.json'), barTarget, 'real target still indexed')
-  assert.ok(openWorkflows.includes(barTarget), 'real target still open (not evicted)')
-  // The original active tab is restored.
-  assert.equal(svc.activeWorkflow, active, 'active restored to the original')
-})
-
-test('#309/P1-B: a high-level saveWorkflowAs that INSERTS a copy then 409s ⇒ orphan removed, active restored, lookup repaired', async () => {
-  // Persisted-source path: the frontend inserts+opens a COPY at the target, indexes
-  // it under the target path, THEN persistence 409s. The rollback must remove that
-  // orphaned copy from the store lookup + open tabs and restore the original active.
-  const active = {
-    path: 'workflows/Orig.json',
-    filename: 'Orig.json',
-    directory: 'workflows',
-    isPersisted: true,
-    isTemporary: false,
-  }
-  const disk = new Set(['workflows/Orig.json', 'workflows/Copy.json'])
-  const store = new Map([['workflows/Orig.json', active]])
+  // The real target that appears mid-flight (its content stands in for its file).
+  const barContent = 'REAL-BAR-CONTENT'
+  const disk = new Map([['workflows/Foo.json', 'FOO']])
+  const store = new Map([['workflows/Foo.json', active]])
   const openWorkflows = [active]
   const calls = []
+  let probed = false
   const svc = {
     activeWorkflow: active,
     openWorkflows,
     calls,
-    disk,
-    // STALE: the store does not know the on-disk Copy.json until the frontend
-    // inserts its copy — so neither the pre-check nor classify pre-empts.
     getWorkflowByPath: (p) => store.get(p) ?? null,
-    async saveWorkflow() {},
-    async renameWorkflow() {},
+    saveAs(wf, path) {
+      calls.push(['saveAs', wf.path, path])
+      const copy = { path, filename: path.split('/').pop(), directory: 'workflows', isPersisted: false, isTemporary: true, changeTracker: { prepareForSave() {} } }
+      store.set(path, copy)
+      openWorkflows.push(copy)
+      return copy
+    },
+    async openWorkflow(copy) {
+      svc.activeWorkflow = copy
+    },
     async closeWorkflow(wf) {
       const i = openWorkflows.indexOf(wf)
       if (i >= 0) openWorkflows.splice(i, 1)
       store.delete(wf.path)
     },
-    async saveWorkflowAs(w, { filename }) {
-      calls.push('saveWorkflowAs')
-      const target = `workflows/${stripExt(filename)}.json`
-      const copy = { path: target, filename: target.split('/').pop(), directory: 'workflows', isTemporary: true, isPersisted: false }
-      store.set(target, copy)
-      openWorkflows.push(copy)
-      svc.activeWorkflow = copy
-      const err = new Error(`Error storing user data file '${target}': 409 Conflict`)
-      err.status = 409
-      throw err
+    async saveWorkflow(wf) {
+      calls.push(['saveWorkflow', wf.path])
+      // overwrite:false semantics — the server 409s if the target already exists,
+      // WITHOUT deleting it (no prompt/overwrite).
+      if (disk.has(wf.path)) {
+        const err = new Error(`Error storing user data file '${wf.path}': 409 Conflict`)
+        err.status = 409
+        throw err
+      }
+      disk.set(wf.path, 'COPY')
     },
+    async renameWorkflow() {},
+  }
+  const existsOnDisk = async (p) => {
+    // First probe (the pre-check) says the target is ABSENT; the real Bar then
+    // appears on disk BEFORE the write (TOCTOU).
+    if (p === 'workflows/Bar.json' && !probed) {
+      probed = true
+      return false
+    }
+    return disk.has(p)
+  }
+  // The real Bar appears right after the pre-check.
+  const origSaveAs = svc.saveAs
+  svc.saveAs = (wf, path) => {
+    disk.set('workflows/Bar.json', barContent) // TOCTOU: real target now exists
+    return origSaveAs(wf, path)
   }
 
-  // No existsOnDisk ⇒ the store-stale path reaches the failing saveWorkflowAs.
   await assert.rejects(
-    () => saveActiveWorkflow(svc, 'Copy', {}),
+    () => saveActiveWorkflow(svc, 'Bar', { existsOnDisk }),
     /already exists \(409 Conflict\)/,
   )
-  assert.deepEqual(openWorkflows, [active], 'orphaned copy removed from open tabs')
-  assert.equal(svc.activeWorkflow, active, 'original tab restored as active')
-  assert.equal(store.get('workflows/Copy.json'), undefined, 'orphan removed from the store lookup')
-  assert.ok(svc.disk.has('workflows/Copy.json'), 'the pre-existing target file is untouched')
+  // The pre-existing real target was NOT deleted/overwritten — its content stands.
+  assert.equal(disk.get('workflows/Bar.json'), barContent, 'real target untouched (no overwrite/delete)')
+  // The orphaned copy the atomic path created is cleaned up; source stays active.
+  assert.deepEqual(openWorkflows, [active], 'orphaned copy removed')
+  assert.equal(svc.activeWorkflow, active, 'source restored as active')
 })
 
-test('#309/P1-B: a high-level REKEY of a temporary source that 409s ⇒ store rekeyed back to the original path', async () => {
-  // Temporary-source path: the frontend rekeys the SAME object to the target before
-  // the 409. Reassigning fields on wf does NOT rekey the store lookup — the rollback
-  // must rekey it back via the store's own (in-memory) rename.
-  const wf = {
-    path: 'workflows/Unsaved Workflow.json',
-    filename: 'Unsaved Workflow.json',
-    directory: 'workflows',
-    isTemporary: true,
-    isPersisted: false,
-  }
-  const store = new Map([[wf.path, wf]])
-  const openPaths = [wf.path]
+test('#226: a persisted target already indexed in the store pre-empts with a clean conflict (never evicted)', async () => {
+  // The store shows a persisted Bar at the target ⇒ the collision pre-check refuses
+  // BEFORE any write, and barTarget is untouched.
+  const active = { path: 'workflows/Foo.json', filename: 'Foo.json', directory: 'workflows', isPersisted: true, isTemporary: false }
+  const barTarget = { path: 'workflows/Bar.json', filename: 'Bar.json', isPersisted: true, isTemporary: false }
+  const openWorkflows = [active, barTarget]
+  const store = new Map([['workflows/Foo.json', active], ['workflows/Bar.json', barTarget]])
   const calls = []
   const svc = {
-    activeWorkflow: wf,
+    activeWorkflow: active,
+    openWorkflows,
     calls,
     getWorkflowByPath: (p) => store.get(p) ?? null,
+    saveAs(wf, path) {
+      calls.push(['saveAs', path])
+      return { path, filename: path.split('/').pop(), isPersisted: false, isTemporary: true, changeTracker: { prepareForSave() {} } }
+    },
+    async openWorkflow(copy) {
+      svc.activeWorkflow = copy
+    },
+    async closeWorkflow() {},
     async saveWorkflow() {},
-    async renameWorkflow(w, to) {
-      // A TEMPORARY rename is a pure in-memory updatePath + rekey (no server write).
-      calls.push(['renameWorkflow', w.path, to])
-      store.delete(w.path)
-      const i = openPaths.indexOf(w.path)
-      if (i >= 0) openPaths[i] = to
-      w.path = to
-      w.filename = to.split('/').pop()
-      store.set(to, w)
-    },
-    async saveWorkflowAs(w, { filename }) {
-      calls.push('saveWorkflowAs')
-      const target = `workflows/${stripExt(filename)}.json`
-      // REKEY the same object to the target BEFORE the 409.
-      store.delete(w.path)
-      const i = openPaths.indexOf(w.path)
-      if (i >= 0) openPaths[i] = target
-      w.path = target
-      w.filename = target.split('/').pop()
-      store.set(target, w)
-      svc.activeWorkflow = w
-      const err = new Error(`Error storing user data file '${target}': 409 Conflict`)
-      err.status = 409
-      throw err
-    },
+    async renameWorkflow() {},
   }
-  // existsOnDisk reports everything absent (a TOCTOU: the target appeared after the
-  // probe), so the pre-check passes and the source classifies never-persisted.
-  const existsOnDisk = async () => false
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'Bar', {}),
+    /already exists \(409 Conflict\)|already occupies/,
+  )
+  assert.ok(!calls.some((c) => c[0] === 'saveAs'), 'never wrote — pre-empted')
+  assert.equal(store.get('workflows/Bar.json'), barTarget, 'real persisted target still indexed (never evicted)')
+  assert.ok(openWorkflows.includes(barTarget), 'real persisted target still open')
+})
+
+test('#226: a LATE occupant that claims the copy path during the awaited persist is NOT evicted by orphan cleanup', async () => {
+  // The deep late-occupant race: our copy is created at the target, then DURING the
+  // awaited openWorkflow another temporary tab claims the same store path. When
+  // saveWorkflow then 409s, the orphan cleanup must NOT close-by-path (which the real
+  // 1.47 store does by `delete workflowLookup[path]`) — that would delete the late
+  // occupant. It must only splice OUR copy out by identity, leaving the occupant.
+  const active = { path: 'workflows/Unsaved Workflow.json', filename: 'Unsaved Workflow.json', directory: 'workflows', isPersisted: false, isTemporary: true }
+  const lateOccupant = { path: 'workflows/Draft.json', filename: 'Draft.json', isPersisted: false, isTemporary: true }
+  const store = new Map([['workflows/Unsaved Workflow.json', active]])
+  const openWorkflows = [active]
+  const disk = new Set(['workflows/Draft.json']) // target exists on disk ⇒ saveWorkflow 409s
+  const calls = []
+  const svc = {
+    activeWorkflow: active,
+    openWorkflows,
+    calls,
+    getWorkflowByPath: (p) => store.get(p) ?? null,
+    saveAs(wf, path) {
+      calls.push(['saveAs', path])
+      const copy = { path, filename: path.split('/').pop(), isPersisted: false, isTemporary: true, changeTracker: { prepareForSave() {} } }
+      store.set(path, copy)
+      openWorkflows.push(copy)
+      return copy
+    },
+    async openWorkflow(copy) {
+      // DURING this await, a late temporary tab claims the SAME store path.
+      store.set('workflows/Draft.json', lateOccupant)
+      openWorkflows.push(lateOccupant)
+      svc.activeWorkflow = copy
+    },
+    async saveWorkflow(wf) {
+      if (disk.has(wf.path)) {
+        const err = new Error(`Error storing user data file '${wf.path}': 409 Conflict`)
+        err.status = 409
+        throw err
+      }
+      disk.add(wf.path)
+    },
+    // Real 1.47 closeWorkflow deletes by PATH (would evict whatever is at the path).
+    async closeWorkflow(wf) {
+      const i = openWorkflows.indexOf(wf)
+      if (i >= 0) openWorkflows.splice(i, 1)
+      store.delete(wf.path)
+    },
+    async renameWorkflow() {},
+  }
+  // The target's own path is absent from the store at the pre-check (only appears via
+  // saveAs), so the collision pre-check passes and we reach the awaited persist.
+  const existsOnDisk = async (p) => (p === 'workflows/Draft.json' ? false : false)
 
   await assert.rejects(
-    () => saveActiveWorkflow(svc, 'Existing', { existsOnDisk }),
+    () => saveActiveWorkflow(svc, 'Draft', { existsOnDisk }),
     /already exists \(409 Conflict\)/,
   )
-  // The store lookup + open-tab path were rekeyed BACK to the original.
-  assert.equal(store.get('workflows/Unsaved Workflow.json'), wf, 'source rekeyed back in the store lookup')
-  assert.equal(store.get('workflows/Existing.json'), undefined, 'no stale target key remains')
-  assert.equal(wf.path, 'workflows/Unsaved Workflow.json', 'path restored')
-  assert.deepEqual(openPaths, ['workflows/Unsaved Workflow.json'], 'open-tab path rekeyed back')
-  assert.equal(svc.activeWorkflow, wf, 'active reference restored')
+  // The late occupant is NOT evicted — its lookup entry and unsaved graph survive.
+  assert.equal(store.get('workflows/Draft.json'), lateOccupant, 'late occupant NOT evicted (identity-safe cleanup)')
+  assert.ok(openWorkflows.includes(lateOccupant), 'late occupant still open')
 })
 
 test('refuses to rename-destroy a persisted workflow when no copy API exists', async () => {
@@ -1399,7 +1601,11 @@ test('refuses to rename-destroy a persisted workflow when no copy API exists', a
     isTemporary: false
   }
   const svc = makeService({ files: [active.path], active })
-  delete svc.saveWorkflowAs // older frontend without a copy path
+  // Older frontend with NO copy path at all (neither the atomic low-level trio nor
+  // even the high-level saveWorkflowAs).
+  delete svc.saveWorkflowAs
+  delete svc.saveAs
+  delete svc.openWorkflow
 
   await assert.rejects(
     () => saveActiveWorkflow(svc, 'Bar', {}),

--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -1421,83 +1421,519 @@ test('#226/#309 P1-1: a frontend with ONLY the overwriting high-level saveWorkfl
   assert.ok(!calls.includes('saveWorkflowAs'), 'never invoked the overwriting Save-As')
 })
 
-test('#226/#309 P1-1: atomic Save-As — target appears AFTER the pre-check, overwrite:false 409s, NO delete of the real target', async () => {
-  // The TOCTOU repro P1-1 is about: the disk oracle reports the target ABSENT, then a
-  // real persisted target appears BEFORE the write. The atomic low-level saveWorkflow
-  // (overwrite:false) 409s WITHOUT deleting/overwriting the pre-existing target — the
-  // exact property a non-atomic pre-check + overwriting API could not guarantee.
-  const active = {
-    path: 'workflows/Foo.json',
-    filename: 'Foo.json',
-    directory: 'workflows',
-    isPersisted: true,
-    isTemporary: false,
+// A minimal 1.47-style low-level store double whose saveWorkflow is NON-atomic
+// (mirrors the real server: overwrite:false does exists→await→os.replace, so it does
+// NOT 409 a target that appears during the body-read). Parameterized by a saveWorkflow
+// implementation so a test can model commit/reject/clobber precisely.
+function makeLowLevelStore({ active, saveWorkflowImpl } = {}) {
+  const store = new Map() // path -> RAW object (like reactive workflowLookup's targets)
+  const openWorkflows = [] // holds PROXIES (like the store's computed open-tabs array)
+  // Model Vue/Pinia reactivity: the RAW object goes into the lookup, but reads come
+  // back as a STABLE reactive PROXY that is NOT === the raw object (Vue's documented
+  // proxy-vs-raw identity). getWorkflowByPath returns the proxy; saveAs returns the raw.
+  const proxies = new WeakMap()
+  const proxyOf = (raw) => {
+    if (!raw) return raw
+    let p = proxies.get(raw)
+    if (!p) {
+      p = new Proxy(raw, {}) // transparent proxy: reflects props (incl. our token), !== raw
+      proxies.set(raw, p)
+    }
+    return p
   }
-  // The real target that appears mid-flight (its content stands in for its file).
-  const barContent = 'REAL-BAR-CONTENT'
-  const disk = new Map([['workflows/Foo.json', 'FOO']])
-  const store = new Map([['workflows/Foo.json', active]])
-  const openWorkflows = [active]
+  if (active) {
+    store.set(active.path, active)
+    openWorkflows.push(proxyOf(active))
+  }
   const calls = []
-  let probed = false
   const svc = {
     activeWorkflow: active,
     openWorkflows,
     calls,
-    getWorkflowByPath: (p) => store.get(p) ?? null,
+    getWorkflowByPath: (p) => (store.has(p) ? proxyOf(store.get(p)) : null),
     saveAs(wf, path) {
-      calls.push(['saveAs', wf.path, path])
-      const copy = { path, filename: path.split('/').pop(), directory: 'workflows', isPersisted: false, isTemporary: true, changeTracker: { prepareForSave() {} } }
-      store.set(path, copy)
-      openWorkflows.push(copy)
-      return copy
+      calls.push(['saveAs', path])
+      // Faithful UserFile shape: isTemporary/isPersisted are DERIVED from `size`
+      // (get isTemporary(){return size===-1}); a fresh copy starts temporary.
+      const copy = {
+        path,
+        filename: path.split('/').pop(),
+        directory: 'workflows',
+        size: -1,
+        get isTemporary() {
+          return this.size === -1
+        },
+        get isPersisted() {
+          return this.size !== -1
+        },
+        content: '{"id":"OUR-ID"}',
+        changeTracker: { prepareForSave() {} }
+      }
+      store.set(path, copy) // raw into the lookup
+      openWorkflows.push(proxyOf(copy)) // computed open-tabs hold the proxy
+      return copy // saveAs returns the RAW object (like the real store)
     },
     async openWorkflow(copy) {
       svc.activeWorkflow = copy
     },
+    // Real 1.47 closeWorkflow, KEYED BY PATH: remove from open tabs; TEMPORARY → delete
+    // the lookup entry; PERSISTED → merely unload (lookup record REMAINS). Never disk.
     async closeWorkflow(wf) {
-      const i = openWorkflows.indexOf(wf)
-      if (i >= 0) openWorkflows.splice(i, 1)
-      store.delete(wf.path)
+      const path = wf.path
+      for (let i = openWorkflows.length - 1; i >= 0; i--) {
+        if (openWorkflows[i] && openWorkflows[i].path === path) openWorkflows.splice(i, 1)
+      }
+      const raw = store.get(path)
+      if (raw && raw.isTemporary) store.delete(path)
+      else if (raw) raw.content = null
     },
     async saveWorkflow(wf) {
       calls.push(['saveWorkflow', wf.path])
-      // overwrite:false semantics — the server 409s if the target already exists,
-      // WITHOUT deleting it (no prompt/overwrite).
-      if (disk.has(wf.path)) {
-        const err = new Error(`Error storing user data file '${wf.path}': 409 Conflict`)
-        err.status = 409
-        throw err
+      if (saveWorkflowImpl) await saveWorkflowImpl(wf) // may throw (pre/post-commit)
+      wf.size = 100 // a successful write marks the copy PERSISTED (size from resp.json)
+      // Upstream 1.47: after a SUCCESSFUL save, re-baseline the change tracker to the
+      // LIVE canvas and mark the workflow clean — the behavior our success-path
+      // bookkeeping must OVERRIDE when an edit happened during the save await.
+      wf.changeTracker?.reset?.()
+      try {
+        wf.isModified = false
+      } catch {
+        /* getter-only ⇒ tracker reset above already re-baselined */
       }
-      disk.set(wf.path, 'COPY')
     },
     async renameWorkflow() {},
   }
-  const existsOnDisk = async (p) => {
-    // First probe (the pre-check) says the target is ABSENT; the real Bar then
-    // appears on disk BEFORE the write (TOCTOU).
-    if (p === 'workflows/Bar.json' && !probed) {
-      probed = true
-      return false
-    }
-    return disk.has(p)
-  }
-  // The real Bar appears right after the pre-check.
-  const origSaveAs = svc.saveAs
-  svc.saveAs = (wf, path) => {
-    disk.set('workflows/Bar.json', barContent) // TOCTOU: real target now exists
-    return origSaveAs(wf, path)
-  }
+  return { svc, store, openWorkflows, calls }
+}
+
+test('#226/#309 P0: a concurrent clobber of our just-written file is DETECTED, not silently reported as success (upstream os.replace race)', async () => {
+  // ComfyUI's /userdata write is NOT exclusive-create — the server does
+  // os.path.exists → await request.read() → os.replace, so a target appearing during
+  // the body-read is silently overwritten (200, not 409). The residual we CAN detect:
+  // our persist reports success, but a concurrent save then clobbered the target with
+  // a DIFFERENT workflow. The post-write read-back returns "foreign" ⇒ surface a
+  // detected error instead of a false success.
+  const active = { path: 'workflows/Foo.json', filename: 'Foo.json', directory: 'workflows', isPersisted: true, isTemporary: false }
+  const { svc } = makeLowLevelStore({ active, saveWorkflowImpl: async () => {} /* 200, non-atomic */ })
+  const existsOnDisk = async () => false // target absent at the pre-check
+  const reconcileSavedCopy = async () => 'foreign' // a concurrent save clobbered ours
 
   await assert.rejects(
-    () => saveActiveWorkflow(svc, 'Bar', { existsOnDisk }),
-    /already exists \(409 Conflict\)/,
+    () => saveActiveWorkflow(svc, 'Bar', { existsOnDisk, reconcileSavedCopy }),
+    /does not contain the saved workflow|concurrent save clobbered|not exclusive-create/i,
   )
-  // The pre-existing real target was NOT deleted/overwritten — its content stands.
-  assert.equal(disk.get('workflows/Bar.json'), barContent, 'real target untouched (no overwrite/delete)')
-  // The orphaned copy the atomic path created is cleaned up; source stays active.
-  assert.deepEqual(openWorkflows, [active], 'orphaned copy removed')
+})
+
+test('P0: a reported-success save whose read-back confirms OUR content reports SUCCESS (no false alarm)', async () => {
+  const active = { path: 'workflows/Foo.json', filename: 'Foo.json', directory: 'workflows', isPersisted: true, isTemporary: false }
+  const { svc } = makeLowLevelStore({ active, saveWorkflowImpl: async () => {} })
+  const existsOnDisk = async () => false
+  const reconcileSavedCopy = async () => 'ours'
+
+  const saved = await saveActiveWorkflow(svc, 'Bar', { existsOnDisk, reconcileSavedCopy })
+  assert.equal(saved, 'Bar', 'a verified-ours save reports success')
+})
+
+test('#226 P1: post-write "foreign" detection removes our copy + restores active, so a later in-place Save does NOT overwrite the foreign target', async () => {
+  // After a reported-success persist, the copy is ACTIVE and PERSISTED. If read-back
+  // proves the on-disk target is FOREIGN (a concurrent clobber), merely throwing but
+  // leaving the copy active+persisted is itself a data-loss setup: a later plain Save
+  // (no new name) takes the in-place branch and ComfyUI's persisted save uses
+  // overwrite:this.isPersisted → it would SILENTLY OVERWRITE the foreign file. So the
+  // copy must be identity-safely removed and prevActive restored BEFORE throwing.
+  const active = { path: 'workflows/Foo.json', filename: 'Foo.json', directory: 'workflows', isPersisted: true, isTemporary: false }
+  const diskWrites = []
+  const { svc, store, openWorkflows } = makeLowLevelStore({
+    active,
+    // A successful write marks the copy PERSISTED (the store's saveWorkflow sets its
+    // size); we only record the write here.
+    saveWorkflowImpl: async (wf) => {
+      diskWrites.push(wf.path)
+    },
+  })
+  const existsOnDisk = async () => false
+
+  // First save: succeeds on the wire, but a concurrent writer replaced Bar before
+  // our read-back ⇒ "foreign".
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'Bar', { existsOnDisk, reconcileSavedCopy: async () => 'foreign' }),
+    /a concurrent save clobbered it|does not contain the saved workflow/i,
+  )
+  // The Bar copy is NOT left active/owned: active restored to Foo, copy gone.
+  assert.equal(svc.activeWorkflow, active, 'active restored to the original (not the foreign Bar copy)')
+  assert.equal(store.get('workflows/Bar.json'), undefined, 'our (persisted) copy PURGED from the store lookup')
+  assert.ok(!openWorkflows.some((w) => w.path === 'workflows/Bar.json'), 'copy removed from open tabs')
+
+  // A subsequent plain Save (no new name) now saves FOO in place — it must NEVER
+  // touch the foreign Bar.
+  diskWrites.length = 0
+  await saveActiveWorkflow(svc, undefined, { existsOnDisk, reconcileSavedCopy: async () => 'ours' })
+  assert.ok(!diskWrites.includes('workflows/Bar.json'), 'later in-place Save never overwrote the foreign Bar')
+  assert.deepEqual(diskWrites, ['workflows/Foo.json'], 'later in-place Save wrote only the original Foo')
+})
+
+test('#226 P1: foreign-detection PURGES a now-PERSISTED copy from the store lookup, so a later Save-As to the same name is not blocked', async () => {
+  // ComfyUI 1.47's closeWorkflow deletes the lookup entry ONLY for a TEMPORARY
+  // workflow; a PERSISTED one is merely unloaded and LINGERS in workflowLookup. After
+  // a reported-success write, our copy is persisted — so the foreign-detection cleanup
+  // must COERCE it temporary so closeWorkflow fully purges the lookup, else the stale
+  // record blocks a future Save-As to that name (getWorkflowByPath still returns it).
+  const active = { path: 'workflows/Foo.json', filename: 'Foo.json', directory: 'workflows', isPersisted: true, isTemporary: false }
+  const { svc, store } = makeLowLevelStore({ active, saveWorkflowImpl: async () => {} })
+  const existsOnDisk = async () => false
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'Bar', { existsOnDisk, reconcileSavedCopy: async () => 'foreign' }),
+    /a concurrent save clobbered it|does not contain the saved workflow/i,
+  )
+  // The now-PERSISTED copy is FULLY purged from the lookup (not merely unloaded).
+  assert.equal(svc.getWorkflowByPath('workflows/Bar.json'), null, 'persisted copy purged from the store lookup')
+  assert.equal(store.get('workflows/Bar.json'), undefined, 'lookup entry deleted')
+  assert.equal(svc.activeWorkflow, active, 'active restored to the original')
+
+  // A later Save-As to the SAME name is NOT blocked by a lingering stale record.
+  const saved = await saveActiveWorkflow(svc, 'Bar', { existsOnDisk, reconcileSavedCopy: async () => 'ours' })
+  assert.equal(saved, 'Bar', 'later Save-As to the same name succeeds (not blocked by a stale record)')
+})
+
+test('#226 P1: the purge identifies "our copy" by a proxy-safe token, NOT object === (Vue reactive store returns a proxy)', async () => {
+  // Guards the exact bug: the real reactive store returns getWorkflowByPath as a Vue
+  // PROXY that is NOT === the raw object saveAs returned. A `===` identity check makes
+  // the purge a no-op. This double models that (getWorkflowByPath ≠ the raw copy);
+  // the cleanup must still purge our copy via its stable token.
+  const active = { path: 'workflows/Foo.json', filename: 'Foo.json', directory: 'workflows', isPersisted: true, isTemporary: false }
+  const { svc } = makeLowLevelStore({ active, saveWorkflowImpl: async () => {} })
+  const existsOnDisk = async () => false
+
+  // Sanity: the store returns a PROXY, not the raw object — proving === would fail.
+  const before = svc.getWorkflowByPath('workflows/Foo.json')
+  assert.equal(before === active, false, 'store getter returns a proxy, not === the raw object')
+  assert.equal(before.path, 'workflows/Foo.json', 'proxy transparently reflects the raw properties')
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'Bar', { existsOnDisk, reconcileSavedCopy: async () => 'foreign' }),
+    /a concurrent save clobbered it|does not contain the saved workflow/i,
+  )
+  // Purged despite the proxy-vs-raw identity mismatch.
+  assert.equal(svc.getWorkflowByPath('workflows/Bar.json'), null, 'copy purged via proxy-safe token match')
+})
+
+test('#226 P2: an AMBIGUOUS post-commit persist failure that actually COMMITTED is ADOPTED, not orphaned', async () => {
+  // A persist can COMMIT to disk and THEN reject (connection reset after commit, or a
+  // resp.json() parse error — the frontend updates persisted metadata only after
+  // parsing). Blindly removing the copy would ORPHAN the on-disk file (a retry then
+  // 409s). The reconcile read-back shows OUR content landed ⇒ adopt the copy, report
+  // success, never orphan it.
+  const active = { path: 'workflows/Foo.json', filename: 'Foo.json', directory: 'workflows', isPersisted: true, isTemporary: false }
+  const committed = new Set()
+  const { svc, store, openWorkflows } = makeLowLevelStore({
+    active,
+    saveWorkflowImpl: async (wf) => {
+      committed.add(wf.path) // the write LANDS on disk...
+      throw new Error('connection reset after commit') // ...then the response is lost
+    },
+  })
+  const existsOnDisk = async () => false
+  const reconcileSavedCopy = async (p) => (committed.has(p) ? 'ours' : 'absent')
+
+  const saved = await saveActiveWorkflow(svc, 'Bar', { existsOnDisk, reconcileSavedCopy })
+  assert.equal(saved, 'Bar', 'reported success (the write DID commit)')
+  assert.ok(store.get('workflows/Bar.json') != null, 'copy ADOPTED in the store lookup (not orphaned)')
+  assert.ok(openWorkflows.some((w) => w.path === 'workflows/Bar.json'), 'copy still open (not removed)')
+})
+
+test('#309 P2: an adopted copy is marked PERSISTED (size != -1) so a later in-place Save does not 409 and close does not purge it', async () => {
+  // On 1.47 isTemporary/isPersisted are GETTER-ONLY, derived from `size`; the adopt
+  // path must update `size`, not assign the getters (silently discarded). Otherwise
+  // the adopted copy stays "temporary": a later in-place Save uses overwrite:false and
+  // 409s, and closing it takes the temporary-purge path (dropping the saved copy).
+  const active = { path: 'workflows/Foo.json', filename: 'Foo.json', directory: 'workflows', isPersisted: true, isTemporary: false }
+  const committed = new Set()
+  let firstSave = true
+  const { svc, store } = makeLowLevelStore({
+    active,
+    saveWorkflowImpl: async (wf) => {
+      if (firstSave) {
+        firstSave = false
+        committed.add(wf.path) // the write COMMITS to disk...
+        throw new Error('resp.json parse error after commit') // ...then the response fails
+      }
+      // A subsequent in-place save models the real overwrite:this.isPersisted — a
+      // TEMPORARY workflow saved in place onto an EXISTING target 409s (overwrite:false).
+      if (committed.has(wf.path) && wf.isTemporary) {
+        const e = new Error(`Error storing user data file '${wf.path}': 409 Conflict`)
+        e.status = 409
+        throw e
+      }
+    },
+  })
+  const existsOnDisk = async () => false
+  const reconcileSavedCopy = async (p) => (committed.has(p) ? 'ours' : 'absent')
+
+  // First save: post-commit reject → read-back "ours" → ADOPT.
+  const saved = await saveActiveWorkflow(svc, 'Bar', { existsOnDisk, reconcileSavedCopy })
+  assert.equal(saved, 'Bar', 'adoption reports success')
+
+  // The adopted copy is active and marked PERSISTED via `size` (not the getter-only flags).
+  const adopted = svc.activeWorkflow
+  assert.equal(adopted.path, 'workflows/Bar.json', 'adopted copy is the active workflow')
+  assert.notEqual(adopted.size, -1, 'size is non-(-1) ⇒ persisted')
+  assert.equal(adopted.isPersisted, true, 'isPersisted derives true')
+  assert.equal(adopted.isTemporary, false, 'isTemporary derives false')
+
+  // A subsequent ordinary in-place Save (no new name) must NOT 409 (overwrite:true now).
+  await assert.doesNotReject(
+    () => saveActiveWorkflow(svc, undefined, { existsOnDisk, reconcileSavedCopy: async () => 'ours' }),
+    'in-place Save of the adopted (persisted) copy does not 409',
+  )
+
+  // Closing the adopted copy must NOT take the TEMPORARY purge path — persisted, so
+  // its lookup record remains (unload only).
+  await svc.closeWorkflow(adopted)
+  assert.notEqual(store.get('workflows/Bar.json'), undefined, 'persisted copy not purged by close (lookup remains)')
+})
+
+// Attach a faithful ComfyWorkflow change tracker to a copy: `content` is the COMMITTED
+// snapshot (what the write persisted); the tracker's initialState is the baseline and
+// activeState the live canvas; updateModified sets isModified = !graphEqual(initial,
+// active) (JSON compare here). reset() re-baselines to activeState (the WRONG direction
+// the fix must avoid). undo() restores the previous state and recomputes.
+function attachChangeTracker(copy, { committedContent, activeState, undoStack = [] }) {
+  copy.content = committedContent
+  const eq = (a, b) => JSON.stringify(a) === JSON.stringify(b)
+  const ct = {
+    initialState: JSON.parse(committedContent),
+    activeState,
+    _undo: [...undoStack],
+    updateModified() {
+      copy.isModified = !eq(ct.initialState, ct.activeState)
+    },
+    reset() {
+      ct.initialState = ct.activeState
+      ct.updateModified()
+    },
+    undo() {
+      const prev = ct._undo.pop()
+      if (prev !== undefined) {
+        ct.activeState = prev
+        ct.updateModified()
+      }
+    },
+    prepareForSave() {},
+  }
+  copy.isModified = false
+  copy.changeTracker = ct
+  return ct
+}
+
+test('#309 P1: adoption keeps the copy DIRTY when the canvas was edited DURING the save (baseline = COMMITTED snapshot, not live)', async () => {
+  // The race the previous (reset-to-activeState) direction introduced: the save
+  // committed S1, but the user edited the live canvas to S2 WHILE the persist awaited;
+  // the response then failed and read-back returned "ours". Re-baselining to the LIVE
+  // activeState (S2) and forcing clean would let workflow_close silently drop the
+  // unsaved S2 edit. The baseline must be the COMMITTED snapshot (S1), so isModified
+  // reflects that the canvas has DIVERGED ⇒ the copy stays DIRTY.
+  const active = { path: 'workflows/Foo.json', filename: 'Foo.json', directory: 'workflows', isPersisted: true, isTemporary: false }
+  const { svc } = makeLowLevelStore({
+    active,
+    saveWorkflowImpl: async () => {
+      throw new Error('resp.json parse error after commit') // committed S1, response lost
+    },
+  })
+  const origSaveAs = svc.saveAs
+  svc.saveAs = (wf, path) => {
+    const copy = origSaveAs(wf, path)
+    // The write committed S1; the user edited the live canvas to S2 during the await.
+    attachChangeTracker(copy, { committedContent: JSON.stringify({ v: 'S1' }), activeState: { v: 'S2' } })
+    return copy
+  }
+  const existsOnDisk = async () => false
+  const reconcileSavedCopy = async () => 'ours'
+
+  const saved = await saveActiveWorkflow(svc, 'Bar', { existsOnDisk, reconcileSavedCopy })
+  assert.equal(saved, 'Bar', 'adoption reports success')
+  const adopted = svc.activeWorkflow
+
+  // The live canvas (S2) diverged from what committed (S1) ⇒ the copy stays DIRTY.
+  assert.equal(adopted.isModified, true, 'in-flight edit ⇒ copy stays DIRTY (holds the unsaved S2)')
+
+  // workflow_close's clean-guard must NOT silently unload a modified workflow.
+  let unloaded = false
+  const closeIfClean = (wf) => {
+    if (!wf.isModified) unloaded = true
+  }
+  closeIfClean(adopted)
+  assert.equal(unloaded, false, 'workflow_close does NOT silently unload the unsaved in-flight edit')
+})
+
+test('#309 P1: adoption sets isModified on OUR copy directly — a distinct late occupant that claimed the path is NOT marked clean', async () => {
+  // During the reconcile read-back await, a distinct DIRTY workflow B claims copy A's
+  // path. 1.47's ct.updateModified() re-resolves BY PATH and would write isModified on
+  // B (marking B falsely clean → workflow_close unloads B's unsaved graph). Adoption
+  // must set isModified on OUR copy A directly, never path-resolving, so B stays dirty.
+  const active = { path: 'workflows/Foo.json', filename: 'Foo.json', directory: 'workflows', isPersisted: true, isTemporary: false }
+  const B = { path: 'workflows/Bar.json', filename: 'Bar.json', isModified: true } // distinct, UNSAVED
+  const { svc, store } = makeLowLevelStore({
+    active,
+    saveWorkflowImpl: async () => {
+      throw new Error('resp.json parse error after commit')
+    },
+  })
+  const origSaveAs = svc.saveAs
+  svc.saveAs = (wf, path) => {
+    const copy = origSaveAs(wf, path)
+    copy.content = JSON.stringify({ v: 'S1' }) // committed S1; A itself is clean (active S1)
+    copy.changeTracker = {
+      initialState: JSON.parse(copy.content),
+      activeState: { v: 'S1' },
+      workflow: copy,
+      // Faithful 1.47: resolve the workflow BY PATH and write isModified on it.
+      updateModified() {
+        const resolved = svc.getWorkflowByPath(this.workflow.path)
+        if (resolved) resolved.isModified = false // (initial == active for A)
+      },
+    }
+    copy.isModified = false
+    return copy
+  }
+  const existsOnDisk = async () => false
+  // During the reconcile await, B claims A's path in the store lookup.
+  const reconcileSavedCopy = async (p) => {
+    store.set(p, B)
+    return 'ours'
+  }
+
+  await saveActiveWorkflow(svc, 'Bar', { existsOnDisk, reconcileSavedCopy })
+  // The distinct late occupant B (now at the path) must NOT have been marked clean.
+  assert.equal(B.isModified, true, 'a distinct late occupant is NOT marked clean by adoption (no path-resolving write)')
+})
+
+test('#309 P1: adoption with NO in-flight edit is CLEAN, and a later Undo makes it correctly DIRTY', async () => {
+  // The healthy case: the live canvas still equals what committed (S1) ⇒ clean. A later
+  // Undo restores an earlier UNSAVED state (S0) ⇒ correctly DIRTY (baseline = committed
+  // S1, not re-based to S0), so close won't silently drop it.
+  const active = { path: 'workflows/Foo.json', filename: 'Foo.json', directory: 'workflows', isPersisted: true, isTemporary: false }
+  const { svc } = makeLowLevelStore({
+    active,
+    saveWorkflowImpl: async () => {
+      throw new Error('resp.json parse error after commit')
+    },
+  })
+  const origSaveAs = svc.saveAs
+  svc.saveAs = (wf, path) => {
+    const copy = origSaveAs(wf, path)
+    // Committed S1; live canvas still S1 (no edit during the await); undo stack has S0.
+    attachChangeTracker(copy, {
+      committedContent: JSON.stringify({ v: 'S1' }),
+      activeState: { v: 'S1' },
+      undoStack: [{ v: 'S0' }],
+    })
+    return copy
+  }
+  const existsOnDisk = async () => false
+  const reconcileSavedCopy = async () => 'ours'
+
+  await saveActiveWorkflow(svc, 'Bar', { existsOnDisk, reconcileSavedCopy })
+  const adopted = svc.activeWorkflow
+
+  // Canvas equals committed ⇒ clean.
+  assert.equal(adopted.isModified, false, 'no in-flight edit ⇒ clean (canvas equals the committed snapshot)')
+
+  // Undo to the earlier UNSAVED state ⇒ correctly DIRTY.
+  adopted.changeTracker.undo()
+  assert.equal(adopted.isModified, true, 'after Undo the copy is correctly DIRTY (unsaved change)')
+})
+
+test('#309 P1: a SUCCESSFUL Save-As with an in-flight edit keeps the copy DIRTY (mirror of the adoption fix, success branch)', async () => {
+  // The success-path mirror: ComfyUI's saveWorkflow(copy) captures S1, awaits the write,
+  // THEN reset()s the tracker to the LIVE canvas and marks clean. If the user edited to
+  // S2 DURING the successful save await, upstream would mark the copy "clean" at the
+  // UNSAVED S2 (disk has S1) → close silently unloads S2. Our success-path bookkeeping
+  // must OVERRIDE that: baseline to the COMMITTED snapshot (S1) so the copy stays DIRTY.
+  const active = { path: 'workflows/Foo.json', filename: 'Foo.json', directory: 'workflows', isPersisted: true, isTemporary: false }
+  const { svc } = makeLowLevelStore({
+    active,
+    // The write PERSISTS S1; the user edits the live canvas to S2 during the (successful)
+    // save await.
+    saveWorkflowImpl: async (wf) => {
+      wf.changeTracker.activeState = { v: 'S2' }
+    },
+  })
+  const origSaveAs = svc.saveAs
+  svc.saveAs = (wf, path) => {
+    const copy = origSaveAs(wf, path)
+    attachChangeTracker(copy, { committedContent: JSON.stringify({ v: 'S1' }), activeState: { v: 'S1' } })
+    return copy
+  }
+  const existsOnDisk = async () => false
+  const reconcileSavedCopy = async () => 'ours' // P0 read-back: our content is on disk
+
+  const saved = await saveActiveWorkflow(svc, 'Bar', { existsOnDisk, reconcileSavedCopy })
+  assert.equal(saved, 'Bar', 'save reports success')
+  const copy = svc.activeWorkflow
+  // The live canvas (S2) diverged from what committed (S1) ⇒ DIRTY despite the success.
+  assert.equal(copy.isModified, true, 'in-flight edit ⇒ copy stays DIRTY after a SUCCESSFUL save')
+  let unloaded = false
+  const closeIfClean = (wf) => {
+    if (!wf.isModified) unloaded = true
+  }
+  closeIfClean(copy)
+  assert.equal(unloaded, false, 'close does NOT silently unload the unsaved in-flight edit')
+})
+
+test('#309 P1: a SUCCESSFUL Save-As with NO in-flight edit leaves the copy CLEAN', async () => {
+  const active = { path: 'workflows/Foo.json', filename: 'Foo.json', directory: 'workflows', isPersisted: true, isTemporary: false }
+  const { svc } = makeLowLevelStore({ active, saveWorkflowImpl: async () => {} }) // no edit during save
+  const origSaveAs = svc.saveAs
+  svc.saveAs = (wf, path) => {
+    const copy = origSaveAs(wf, path)
+    attachChangeTracker(copy, { committedContent: JSON.stringify({ v: 'S1' }), activeState: { v: 'S1' } })
+    return copy
+  }
+  const existsOnDisk = async () => false
+  const reconcileSavedCopy = async () => 'ours'
+
+  const saved = await saveActiveWorkflow(svc, 'Bar', { existsOnDisk, reconcileSavedCopy })
+  assert.equal(saved, 'Bar', 'save reports success')
+  assert.equal(svc.activeWorkflow.isModified, false, 'no in-flight edit ⇒ clean (canvas equals committed)')
+})
+
+test('#226 P2: a persist failure whose read-back proves ABSENT removes the copy and rethrows (safe)', async () => {
+  const active = { path: 'workflows/Foo.json', filename: 'Foo.json', directory: 'workflows', isPersisted: true, isTemporary: false }
+  const { svc, store, openWorkflows } = makeLowLevelStore({
+    active,
+    saveWorkflowImpl: async () => {
+      throw new Error('write failed before commit')
+    },
+  })
+  const existsOnDisk = async () => false
+  const reconcileSavedCopy = async () => 'absent' // the write did NOT land
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'Bar', { existsOnDisk, reconcileSavedCopy }),
+    /write failed before commit/,
+  )
+  assert.equal(store.get('workflows/Bar.json'), undefined, 'orphan copy removed from the store')
+  assert.ok(!openWorkflows.some((w) => w.path === 'workflows/Bar.json'), 'copy removed from open tabs')
   assert.equal(svc.activeWorkflow, active, 'source restored as active')
+})
+
+test('#226 P2: a persist failure whose read-back shows FOREIGN content surfaces a clobber error, removes the copy', async () => {
+  const active = { path: 'workflows/Foo.json', filename: 'Foo.json', directory: 'workflows', isPersisted: true, isTemporary: false }
+  const { svc, store } = makeLowLevelStore({
+    active,
+    saveWorkflowImpl: async () => {
+      throw new Error('connection reset after commit')
+    },
+  })
+  const existsOnDisk = async () => false
+  const reconcileSavedCopy = async () => 'foreign' // the target holds someone else's content
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'Bar', { existsOnDisk, reconcileSavedCopy }),
+    /a concurrent save clobbered it|holds a DIFFERENT workflow/i,
+  )
+  assert.equal(store.get('workflows/Bar.json'), undefined, 'our copy removed (target is not ours)')
 })
 
 test('#226: a persisted target already indexed in the store pre-empts with a clean conflict (never evicted)', async () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -100,7 +100,7 @@ import {
   isStaleAssetCandidate as isStaleAssetCandidateLib,
   reapplyDefsToLiveNodes,
 } from "./lib/asset-staleness.js";
-import { assertAddNodeResolvable } from "./lib/node-resolve.js";
+import { assertAddNodeResolvableRefreshing } from "./lib/node-resolve.js";
 import {
   resolveScope,
   describeScope,
@@ -3776,7 +3776,8 @@ function resolveNode(graph, nodeId) {
 
 // ---- Node-type resolution guard (#458) ------------------------------------
 // The graph WRITE tools resolve node types against LG.registered_node_types:
-// assertAddNodeResolvable gates graph_add_node on the class_type before create;
+// assertAddNodeResolvableRefreshing gates graph_add_node on the class_type before
+// create (refreshing stale node defs once and re-checking, #289/#458);
 // graph_set_widget delegates to runSetWidget (web/js/lib/set-widget.js), whose
 // shared body gates on the ACTUAL RESOLVED write target (inner promoted node for
 // a subgraph, else the node's own) BEFORE any coercion/mutation, so an unresolved
@@ -4875,15 +4876,23 @@ const GRAPH_TOOL_EXECUTORS = {
     };
   },
 
-  graph_add_node({ class_type, pos, title }) {
+  async graph_add_node({ class_type, pos, title }) {
     const { graph, LG } = getGraphCtx();
     if (!class_type || typeof class_type !== "string") {
       throw new Error("class_type (string) is required");
     }
     // Resolve against the REAL registry BEFORE creating, so an unresolved type
-    // can never be added as a fabricated placeholder node (#458). Throws with a
-    // clear unreachable-vs-unknown-type message, mirroring the read-path hard error.
-    assertAddNodeResolvable(LG?.registered_node_types ?? {}, class_type);
+    // can never be added as a fabricated placeholder node (#458). If the type is
+    // absent, refresh node defs (re-fetch /object_info + re-register) ONCE and
+    // re-check — a freshly-installed pack's classes are unknown to the stale
+    // page-load registry until then (#289). A type the server still doesn't
+    // define after a refresh stays unresolved and fails closed (unreachable-vs-
+    // unknown message preserved), never a fabricated placeholder.
+    await assertAddNodeResolvableRefreshing(
+      () => LG?.registered_node_types ?? {},
+      class_type,
+      refreshComfyNodeDefs,
+    );
     const node = LG.createNode(class_type);
     if (!node) {
       throw new Error(

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -101,6 +101,7 @@ import {
   reapplyDefsToLiveNodes,
 } from "./lib/asset-staleness.js";
 import { assertAddNodeResolvableRefreshing } from "./lib/node-resolve.js";
+import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
 import {
   resolveScope,
   describeScope,
@@ -177,54 +178,56 @@ let nodeDefRefreshInFlight = null;
 // suppress a genuine miss (codex WS-3 finding #4). Reset to false whenever the
 // backend socket drops, since the combos may be about to change under us.
 let nodeDefsRefreshConfirmed = false;
-async function refreshComfyNodeDefs(preloadedDefs) {
-  if (nodeDefRefreshInFlight) return nodeDefRefreshInFlight;
-  nodeDefRefreshInFlight = (async () => {
-    // Trust the live combos for suppressing missing-asset candidates ONLY once
-    // the combo refresh has ACTUALLY RUN and succeeded. If refreshComboInNodes is
-    // absent on this ComfyUI build (or throws), the combos are still whatever
-    // page-load left them — possibly stale — so we must stay in over-report-safe
-    // mode and NOT trust them (finding #4).
-    let comboRefreshed = false;
-    try {
-      const a =
-        typeof app !== "undefined" && app ? app : window.comfyAPI?.app?.app;
-      if (!a) return;
-      // Re-register node definitions so newly installed/updated classes and
-      // their current widget schemas are known to LiteGraph (#221/#171). Reuse
-      // an already-fetched /object_info payload when the caller supplies one
-      // (graph_add_node passes the fresh defs it just validated against, #289) so
-      // we never round-trip /object_info twice for a single add.
-      let defs = preloadedDefs ?? null;
-      if (typeof a.registerNodesFromDefs === "function") {
-        if (!defs && typeof api?.getNodeDefs === "function") {
-          defs = await api.getNodeDefs();
-        }
-        if (defs) await a.registerNodesFromDefs(defs);
+// The actual (idempotent) node-def registration; the coalescer owns the in-flight
+// slot lifecycle, so this MUST NOT clear it. Reuses a caller-supplied /object_info
+// payload when present (graph_add_node passes the fresh defs it just validated
+// against, #289) so a single add never round-trips /object_info twice.
+async function registerComfyNodeDefs(preloadedDefs) {
+  // Trust the live combos for suppressing missing-asset candidates ONLY once the
+  // combo refresh has ACTUALLY RUN and succeeded. If refreshComboInNodes is absent on
+  // this ComfyUI build (or throws), the combos are still whatever page-load left them
+  // — possibly stale — so we must stay in over-report-safe mode (finding #4).
+  let comboRefreshed = false;
+  try {
+    const a = typeof app !== "undefined" && app ? app : window.comfyAPI?.app?.app;
+    if (!a) return;
+    // Re-register node definitions so newly installed/updated classes and their
+    // current widget schemas are known to LiteGraph (#221/#171).
+    let defs = preloadedDefs ?? null;
+    if (typeof a.registerNodesFromDefs === "function") {
+      if (!defs && typeof api?.getNodeDefs === "function") {
+        defs = await api.getNodeDefs();
       }
-      // registerNodesFromDefs mints NEW classes; already-loaded node INSTANCES
-      // keep their old constructor and would never see the fresh schema. Stamp
-      // the fresh def onto existing instances + repair UNKNOWN widgets so old
-      // nodes are actually fixed, not just newly-created ones (finding #3).
-      if (defs) {
-        const rootGraph = a.graph ?? a.canvas?.graph;
-        if (rootGraph) reapplyDefsToLiveNodes(rootGraph, defs);
-      }
-      // Refresh combo widget option lists (model dropdowns etc.) so freshly
-      // installed models resolve and stale entries clear (#185/#181/#223).
-      if (typeof a.refreshComboInNodes === "function") {
-        await a.refreshComboInNodes();
-        comboRefreshed = true;
-      }
-    } catch (e) {
-      console.warn("[comfyui-mcp-panel] node-def refresh after reconnect failed:", e);
-    } finally {
-      nodeDefsRefreshConfirmed = comboRefreshed;
-      nodeDefRefreshInFlight = null;
+      if (defs) await a.registerNodesFromDefs(defs);
     }
-  })();
-  return nodeDefRefreshInFlight;
+    // registerNodesFromDefs mints NEW classes; already-loaded node INSTANCES keep
+    // their old constructor and would never see the fresh schema. Stamp the fresh
+    // def onto existing instances + repair UNKNOWN widgets (finding #3).
+    if (defs) {
+      const rootGraph = a.graph ?? a.canvas?.graph;
+      if (rootGraph) reapplyDefsToLiveNodes(rootGraph, defs);
+    }
+    // Refresh combo widget option lists (model dropdowns etc.) so freshly installed
+    // models resolve and stale entries clear (#185/#181/#223).
+    if (typeof a.refreshComboInNodes === "function") {
+      await a.refreshComboInNodes();
+      comboRefreshed = true;
+    }
+  } catch (e) {
+    console.warn("[comfyui-mcp-panel] node-def refresh after reconnect failed:", e);
+  } finally {
+    nodeDefsRefreshConfirmed = comboRefreshed;
+  }
 }
+
+// Single-flight refresh that never drops a caller-supplied fresh payload (#289 P2).
+const refreshComfyNodeDefs = makeRefreshCoalescer({
+  getInFlight: () => nodeDefRefreshInFlight,
+  setInFlight: (p) => {
+    nodeDefRefreshInFlight = p;
+  },
+  runRegister: registerComfyNodeDefs,
+});
 
 function setupListeners() {
   if (!api) return;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2440,8 +2440,59 @@ async function programmaticSave(name) {
   const saved = await saveActiveWorkflow(svc, name, {
     autoWorkflowName,
     existsOnDisk: workflowExistsOnDisk,
+    reconcileSavedCopy: reconcileSavedWorkflowCopy,
   });
   return saved || getWorkflowTitle();
+}
+
+/** Authoritative read-back oracle for saveActiveWorkflow's post-write guards.
+ *  Reads the on-disk /userdata file at `targetPath` and compares it against the
+ *  content the Save-As COPY was built from, returning:
+ *    "ours"    — the file exists and carries OUR copy's content (matched by the
+ *                workflow `id` the store's saveAs mints fresh, else raw content);
+ *    "foreign" — the file exists but is a DIFFERENT workflow (a concurrent clobber);
+ *    "absent"  — no file (404);
+ *    "unknown" — could not determine (no api / non-2xx-non-404 / network error /
+ *                content not comparable) ⇒ callers treat it as non-authoritative.
+ *  Backs P2 (adopt an on-disk copy after an ambiguous post-commit failure instead
+ *  of orphaning it) and P0 (detect a concurrent clobber of our just-written file).
+ *  ComfyUI's /userdata write is NOT exclusive-create, so this read-back is the only
+ *  way to detect a clobber of our write — it cannot protect a victim the server
+ *  already replaced (upstream-only). */
+async function reconcileSavedWorkflowCopy(targetPath, copy) {
+  try {
+    if (!api || !targetPath) return "unknown";
+    const res =
+      typeof api.getUserData === "function"
+        ? await api.getUserData(targetPath)
+        : await api.fetchApi(`/userdata/${encodeURIComponent(targetPath)}`);
+    if (res.status === 404) return "absent";
+    if (!res.ok) return "unknown";
+    const onDisk = await res.text();
+    const ourId = workflowContentId(copy?.content);
+    const diskId = workflowContentId(onDisk);
+    if (ourId && diskId) return ourId === diskId ? "ours" : "foreign";
+    // Fall back to a raw content compare when an id can't be extracted from either.
+    if (typeof copy?.content === "string" && typeof onDisk === "string") {
+      return onDisk === copy.content ? "ours" : "foreign";
+    }
+    return "unknown"; // can't compare ⇒ non-authoritative
+  } catch {
+    return "unknown";
+  }
+}
+
+/** Extract the workflow `id` (the store's saveAs mints a fresh UUID per copy) from a
+ *  serialized workflow JSON string, or null if not parseable. */
+function workflowContentId(content) {
+  if (typeof content !== "string") return null;
+  try {
+    const parsed = JSON.parse(content);
+    const id = parsed?.id;
+    return typeof id === "string" && id ? id : null;
+  } catch {
+    return null;
+  }
 }
 
 /** Authoritative filesystem oracle for saveActiveWorkflow's #226 classifier:

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -177,7 +177,7 @@ let nodeDefRefreshInFlight = null;
 // suppress a genuine miss (codex WS-3 finding #4). Reset to false whenever the
 // backend socket drops, since the combos may be about to change under us.
 let nodeDefsRefreshConfirmed = false;
-async function refreshComfyNodeDefs() {
+async function refreshComfyNodeDefs(preloadedDefs) {
   if (nodeDefRefreshInFlight) return nodeDefRefreshInFlight;
   nodeDefRefreshInFlight = (async () => {
     // Trust the live combos for suppressing missing-asset candidates ONLY once
@@ -191,10 +191,15 @@ async function refreshComfyNodeDefs() {
         typeof app !== "undefined" && app ? app : window.comfyAPI?.app?.app;
       if (!a) return;
       // Re-register node definitions so newly installed/updated classes and
-      // their current widget schemas are known to LiteGraph (#221/#171).
-      let defs = null;
-      if (typeof a.registerNodesFromDefs === "function" && typeof api?.getNodeDefs === "function") {
-        defs = await api.getNodeDefs();
+      // their current widget schemas are known to LiteGraph (#221/#171). Reuse
+      // an already-fetched /object_info payload when the caller supplies one
+      // (graph_add_node passes the fresh defs it just validated against, #289) so
+      // we never round-trip /object_info twice for a single add.
+      let defs = preloadedDefs ?? null;
+      if (typeof a.registerNodesFromDefs === "function") {
+        if (!defs && typeof api?.getNodeDefs === "function") {
+          defs = await api.getNodeDefs();
+        }
         if (defs) await a.registerNodesFromDefs(defs);
       }
       // registerNodesFromDefs mints NEW classes; already-loaded node INSTANCES
@@ -4881,18 +4886,18 @@ const GRAPH_TOOL_EXECUTORS = {
     if (!class_type || typeof class_type !== "string") {
       throw new Error("class_type (string) is required");
     }
-    // Resolve against the REAL registry BEFORE creating, so an unresolved type
-    // can never be added as a fabricated placeholder node (#458). If the type is
-    // absent, refresh node defs (re-fetch /object_info + re-register) ONCE and
-    // re-check — a freshly-installed pack's classes are unknown to the stale
-    // page-load registry until then (#289). A type the server still doesn't
-    // define after a refresh stays unresolved and fails closed (unreachable-vs-
-    // unknown message preserved), never a fabricated placeholder.
-    await assertAddNodeResolvableRefreshing(
-      () => LG?.registered_node_types ?? {},
-      class_type,
-      refreshComfyNodeDefs,
-    );
+    // Resolve BEFORE creating so an unresolved type can never be added as a
+    // fabricated placeholder (#458). The go/no-go is decided against the CURRENT
+    // backend /object_info (fetched fresh) — NOT the LiteGraph registry, which
+    // keeps STALE POSITIVES for uninstalled packs (#458/P1-C) and MISSES freshly-
+    // installed ones (#289). When the backend defines the type but the stale
+    // page-load registry lacks it, the defs are refreshed + re-registered so
+    // LG.createNode works; a type the live backend does not provide fails closed.
+    await assertAddNodeResolvableRefreshing(() => LG?.registered_node_types ?? {}, class_type, {
+      getFreshObjectInfo: () =>
+        typeof api?.getNodeDefs === "function" ? api.getNodeDefs() : null,
+      refresh: (defs) => refreshComfyNodeDefs(defs),
+    });
     const node = LG.createNode(class_type);
     if (!node) {
       throw new Error(

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -68,54 +68,83 @@ export function assertAddNodeResolvable(registry, class_type) {
 }
 
 /**
- * Async graph_add_node guard that TOLERATES a stale frontend node-def cache (#289).
+ * Async graph_add_node guard whose go/no-go decision is made against the CURRENT
+ * backend /object_info — NOT the mutated LiteGraph registry (#289 + #458/P1-C).
  *
- * After ComfyUI installs a pack and restarts, the already-open frontend's
- * LiteGraph registry still holds the PRE-INSTALL node set (it is populated from
- * /object_info at page load and is not re-fetched on a websocket reconnect). So a
- * correct class_type from a just-installed pack reads as "Unknown node type" even
- * though the server defines it — the only recovery used to be a manual F5.
+ * The registry is unreliable in BOTH directions after a pack change + restart:
+ *   - it MISSES a freshly-installed pack's classes until /object_info is re-fetched
+ *     and re-registered — so a correct class_type reads "Unknown" (#289); and
+ *   - it KEEPS a STALE POSITIVE for an UNINSTALLED pack — an add-only refresh never
+ *     purges the removed class, so `LG.registered_node_types.GoneNode` survives and
+ *     the type would wrongly "add" against a backend that no longer provides it
+ *     (violating the #458 fail-closed invariant).
  *
- * This resolves the type against the live registry; if it is absent, it performs
- * ONE node-def refresh (re-fetch /object_info + re-register defs) via `refresh`,
- * then re-checks against the FRESH registry before deciding the type is unknown.
+ * So the AUTHORITATIVE oracle is the freshly-fetched /object_info payload:
+ *   1. Fetch fresh /object_info via `getFreshObjectInfo`.
+ *   2. If the backend does NOT define the type → fail closed (unknown/removed),
+ *      regardless of any stale registry entry.
+ *   3. If the backend DOES define it → ensure LiteGraph can construct it: if the
+ *      page-load registry predates it, `refresh` (re-register the fresh defs) and
+ *      re-check; if it still can't be registered, fail closed rather than let
+ *      LiteGraph mint a placeholder.
+ *   4. If fresh /object_info is UNAVAILABLE (backend unreachable / no fetch) →
+ *      degrade to the registry-only guard, which fails closed for unknown types and
+ *      distinguishes "unreachable" from "unknown".
  *
- * The #458 fail-closed invariant is preserved end-to-end: the refresh only ever
- * registers what the server actually returns (registerNodesFromDefs), so a
- * GENUINELY-unknown type stays unregistered and still throws via
- * assertAddNodeResolvable — with the SAME distinct unreachable-vs-unknown-type
- * messages. The refresh never fabricates a type or a placeholder.
- *
- *   getRegistry : () => the LIVE registry object. It is re-invoked AFTER the
- *                 refresh, because registerNodesFromDefs mutates the registry in
- *                 place, so a fresh read observes the newly-registered classes.
- *   refresh     : optional async node-def refresh. Best-effort — a throw or its
- *                 absence just means we re-check the current registry and, if the
- *                 type is still absent, fail closed exactly like the sync guard.
+ *   getRegistry        : () => the LIVE registry object (re-invoked after refresh).
+ *   getFreshObjectInfo : optional async () => the CURRENT /object_info map (keyed by
+ *                        class_type), or null when it can't be fetched.
+ *   refresh            : optional async (defs?) => re-register node defs into the
+ *                        registry; receives the already-fetched defs to avoid a
+ *                        second /object_info round-trip.
  */
-export async function assertAddNodeResolvableRefreshing(getRegistry, class_type, refresh) {
+export async function assertAddNodeResolvableRefreshing(getRegistry, class_type, opts = {}) {
+  const { getFreshObjectInfo, refresh } = opts;
   const readRegistry = () =>
     typeof getRegistry === "function" ? getRegistry() : getRegistry;
-  const before = readRegistry();
-  if (isRegisteredNodeType(before, class_type)) return;
-  // Absent from the CURRENT (possibly stale) registry. Before rejecting it as
-  // unknown, refresh node defs once and re-check — this is the whole point of
-  // #289: a freshly-installed pack's classes only become addressable after
-  // /object_info is re-fetched and re-registered.
-  if (typeof refresh === "function") {
+
+  let freshDefs = null;
+  if (typeof getFreshObjectInfo === "function") {
     try {
-      await refresh();
+      freshDefs = await getFreshObjectInfo();
     } catch {
-      /* refresh is best-effort — fall through to a fresh-registry re-check */
+      freshDefs = null; // fetch failed ⇒ fall back to the registry-only guard
     }
-    const after = readRegistry();
-    if (isRegisteredNodeType(after, class_type)) return;
-    // Still unresolved after a real refresh ⇒ the server does not define it
-    // either. Fail closed with the correct unreachable-vs-unknown distinction.
-    assertAddNodeResolvable(after, class_type);
-    return;
   }
-  assertAddNodeResolvable(before, class_type);
+
+  if (freshDefs && typeof freshDefs === "object") {
+    // AUTHORITATIVE: does the LIVE backend provide this type right now?
+    if (!Object.prototype.hasOwnProperty.call(freshDefs, class_type)) {
+      // Not defined by the current backend (never installed, or its pack was
+      // removed). Fail closed even if a stale registry entry survives (#458/P1-C).
+      throw new Error(
+        `Unknown node type "${class_type}" — the ComfyUI backend does not provide it ` +
+          `(not installed, or its pack was removed). Check the exact class_type via panel_search_nodes`,
+      );
+    }
+    // Backend HAS it. Make sure LiteGraph can construct it — refresh to register the
+    // fresh defs when the page-load registry predates the install (#289), re-check.
+    if (!isRegisteredNodeType(readRegistry(), class_type) && typeof refresh === "function") {
+      try {
+        await refresh(freshDefs);
+      } catch {
+        /* refresh best-effort — the post-refresh re-check decides go/no-go */
+      }
+    }
+    if (isRegisteredNodeType(readRegistry(), class_type)) return;
+    // Backend defines it but the frontend couldn't register it (refresh failed) —
+    // fail closed rather than let LiteGraph mint an unresolved placeholder (#458).
+    throw new Error(
+      `Node type "${class_type}" exists on the ComfyUI backend but could not be registered in the ` +
+        `frontend (node-def refresh failed) — reload the ComfyUI tab and retry. ` +
+        `Refusing to add an unresolved placeholder node.`,
+    );
+  }
+
+  // No fresh /object_info (backend unreachable, or no fetch capability): degrade to
+  // the registry-only guard — still fails closed for unknown types, and names the
+  // "backend unreachable" vs "unknown type" cases distinctly (#458).
+  assertAddNodeResolvable(readRegistry(), class_type);
 }
 
 /**

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -87,9 +87,11 @@ export function assertAddNodeResolvable(registry, class_type) {
  *      page-load registry predates it, `refresh` (re-register the fresh defs) and
  *      re-check; if it still can't be registered, fail closed rather than let
  *      LiteGraph mint a placeholder.
- *   4. If fresh /object_info is UNAVAILABLE (backend unreachable / no fetch) →
- *      degrade to the registry-only guard, which fails closed for unknown types and
- *      distinguishes "unreachable" from "unknown".
+ *   4. If a fresh-oracle IS wired but /object_info is UNAVAILABLE (fetch rejected /
+ *      returned nothing) → FAIL CLOSED with a "cannot verify against backend" error.
+ *      We must NOT fall back to the stale registry: a transient fetch failure would
+ *      otherwise authorize a since-removed type (#458/P1-2). Only a caller that
+ *      wires NO fresh-oracle at all degrades to the registry-only guard.
  *
  *   getRegistry        : () => the LIVE registry object (re-invoked after refresh).
  *   getFreshObjectInfo : optional async () => the CURRENT /object_info map (keyed by
@@ -103,16 +105,25 @@ export async function assertAddNodeResolvableRefreshing(getRegistry, class_type,
   const readRegistry = () =>
     typeof getRegistry === "function" ? getRegistry() : getRegistry;
 
-  let freshDefs = null;
+  // When a fresh-oracle capability is wired (the panel always wires it), the FRESH
+  // /object_info is the ONLY authority. If it can't be consulted (fetch rejected /
+  // returned nothing), we must FAIL CLOSED — NOT fall back to the stale registry,
+  // which keeps positives for removed packs (a transient fetch failure would
+  // otherwise authorize a since-uninstalled type, #458/P1-2).
   if (typeof getFreshObjectInfo === "function") {
+    let freshDefs = null;
     try {
       freshDefs = await getFreshObjectInfo();
     } catch {
-      freshDefs = null; // fetch failed ⇒ fall back to the registry-only guard
+      freshDefs = null;
     }
-  }
-
-  if (freshDefs && typeof freshDefs === "object") {
+    if (!freshDefs || typeof freshDefs !== "object") {
+      throw new Error(
+        `cannot verify node type "${class_type}" against the ComfyUI backend ` +
+          `(object_info is unavailable — the backend is unreachable or the fetch failed). ` +
+          `Refusing to add rather than trust a possibly-stale node cache (#458). Reconnect ComfyUI and retry.`,
+      );
+    }
     // AUTHORITATIVE: does the LIVE backend provide this type right now?
     if (!Object.prototype.hasOwnProperty.call(freshDefs, class_type)) {
       // Not defined by the current backend (never installed, or its pack was
@@ -141,9 +152,9 @@ export async function assertAddNodeResolvableRefreshing(getRegistry, class_type,
     );
   }
 
-  // No fresh /object_info (backend unreachable, or no fetch capability): degrade to
-  // the registry-only guard — still fails closed for unknown types, and names the
-  // "backend unreachable" vs "unknown type" cases distinctly (#458).
+  // No fresh-oracle capability wired at all (a caller that does not supply
+  // getFreshObjectInfo — not the panel): degrade to the registry-only guard, which
+  // still fails closed for unknown types and names unreachable-vs-unknown (#458).
   assertAddNodeResolvable(readRegistry(), class_type);
 }
 

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -68,6 +68,57 @@ export function assertAddNodeResolvable(registry, class_type) {
 }
 
 /**
+ * Async graph_add_node guard that TOLERATES a stale frontend node-def cache (#289).
+ *
+ * After ComfyUI installs a pack and restarts, the already-open frontend's
+ * LiteGraph registry still holds the PRE-INSTALL node set (it is populated from
+ * /object_info at page load and is not re-fetched on a websocket reconnect). So a
+ * correct class_type from a just-installed pack reads as "Unknown node type" even
+ * though the server defines it — the only recovery used to be a manual F5.
+ *
+ * This resolves the type against the live registry; if it is absent, it performs
+ * ONE node-def refresh (re-fetch /object_info + re-register defs) via `refresh`,
+ * then re-checks against the FRESH registry before deciding the type is unknown.
+ *
+ * The #458 fail-closed invariant is preserved end-to-end: the refresh only ever
+ * registers what the server actually returns (registerNodesFromDefs), so a
+ * GENUINELY-unknown type stays unregistered and still throws via
+ * assertAddNodeResolvable — with the SAME distinct unreachable-vs-unknown-type
+ * messages. The refresh never fabricates a type or a placeholder.
+ *
+ *   getRegistry : () => the LIVE registry object. It is re-invoked AFTER the
+ *                 refresh, because registerNodesFromDefs mutates the registry in
+ *                 place, so a fresh read observes the newly-registered classes.
+ *   refresh     : optional async node-def refresh. Best-effort — a throw or its
+ *                 absence just means we re-check the current registry and, if the
+ *                 type is still absent, fail closed exactly like the sync guard.
+ */
+export async function assertAddNodeResolvableRefreshing(getRegistry, class_type, refresh) {
+  const readRegistry = () =>
+    typeof getRegistry === "function" ? getRegistry() : getRegistry;
+  const before = readRegistry();
+  if (isRegisteredNodeType(before, class_type)) return;
+  // Absent from the CURRENT (possibly stale) registry. Before rejecting it as
+  // unknown, refresh node defs once and re-check — this is the whole point of
+  // #289: a freshly-installed pack's classes only become addressable after
+  // /object_info is re-fetched and re-registered.
+  if (typeof refresh === "function") {
+    try {
+      await refresh();
+    } catch {
+      /* refresh is best-effort — fall through to a fresh-registry re-check */
+    }
+    const after = readRegistry();
+    if (isRegisteredNodeType(after, class_type)) return;
+    // Still unresolved after a real refresh ⇒ the server does not define it
+    // either. Fail closed with the correct unreachable-vs-unknown distinction.
+    assertAddNodeResolvable(after, class_type);
+    return;
+  }
+  assertAddNodeResolvable(before, class_type);
+}
+
+/**
  * Guard for graph_set_widget, applied to the ACTUAL RESOLVED write target (the
  * inner promoted node for a subgraph write, or the node's own for a direct
  * write) — NOT the outer node. This is the load-bearing check: it must run on

--- a/web/js/lib/refresh-coalesce.js
+++ b/web/js/lib/refresh-coalesce.js
@@ -1,0 +1,47 @@
+// Coalesces overlapping node-def refreshes so a caller-supplied FRESH /object_info
+// payload is never DROPPED by joining an OLDER in-flight refresh (#289 P2).
+//
+// The panel keeps a SINGLE in-flight refresh promise so concurrent triggers (a
+// websocket reconnect + a graph_add_node) don't stampede registerNodesFromDefs.
+// The naive "if in-flight, return it" dedupe silently drops a newer payload:
+// graph_add_node fetches fresh /object_info (containing a just-installed NewNode)
+// and calls refresh(freshDefs), but if a reconnect refresh carrying an OLDER
+// payload is already running, joining it leaves NewNode unregistered and the add
+// re-check fails — a false "unknown node type" for a genuinely-installed node.
+//
+// This coordinator fixes that: with NO payload, joining the in-flight refresh is
+// enough. With a payload, it WAITS for the in-flight refresh to settle, THEN runs a
+// fresh refresh that registers the newer payload — so the payload is never dropped.
+//
+//   getInFlight / setInFlight : accessors for the shared single-flight promise slot
+//                               (module-level in the panel).
+//   runRegister(preloadedDefs) : performs the actual (idempotent) registration; its
+//                                own cleanup must NOT clear the slot — the coalescer
+//                                owns the slot lifecycle.
+export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister }) {
+  return async function refresh(preloadedDefs) {
+    const current = getInFlight();
+    if (current) {
+      try {
+        await current;
+      } catch {
+        /* the in-flight refresh failed — fall through and run our own */
+      }
+      // No specific payload to guarantee ⇒ joining the settled refresh is enough.
+      if (preloadedDefs == null) return;
+      // Otherwise fall through: register the NEWER payload now the older run settled,
+      // so a freshly-installed node's defs are not dropped (#289 P2).
+    }
+    const p = (async () => {
+      try {
+        return await runRegister(preloadedDefs);
+      } finally {
+        // Clear the slot only if it still points at THIS run (a later run may have
+        // already replaced it).
+        if (getInFlight() === p) setInFlight(null);
+      }
+    })();
+    setInFlight(p);
+    return p;
+  };
+}

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -147,26 +147,18 @@ export async function saveActiveWorkflow(svc, name, { autoWorkflowName, existsOn
     // source is PROVABLY never-persisted (no backing file to destroy).
     const sourcePath = wf.path;
 
-    // #309 — PRE-EMPT a filename collision BEFORE invoking any save/copy API. If the
-    // resolved target already exists on disk, the /userdata write would 409, and the
-    // frontend's saveWorkflowAs rebinds the tab (or the low-level path orphans a copy
-    // tab) BEFORE that failure surfaces — stranding the tab bound to a file it can't
-    // own (which then tripped the #226 guard so it could not be saved under any other
-    // name). Detecting the collision up front means NOTHING is mutated: no rebind, no
-    // copy, and a clean conflict is returned. Only an AUTHORITATIVE positive from the
-    // disk oracle acts here; an absent/unknown oracle falls through to the post-write
-    // rollback net below. The oracle is the same /userdata HEAD the #226 classifier
-    // uses, so it is available on the real panel path.
-    if (typeof existsOnDisk === "function") {
-      let targetExists = null;
-      try {
-        targetExists = await existsOnDisk(finalTargetPath);
-      } catch {
-        targetExists = null; // probe failed ⇒ unknown ⇒ fall through to rollback net
-      }
-      if (targetExists === true) {
-        throw conflictError(effectiveName);
-      }
+    // #309 — classify a filename COLLISION at the resolved target BEFORE invoking any
+    // save/copy API. Combines two oracles: a PERSISTED workflow already indexed at the
+    // target (store), and the authoritative /userdata disk probe. States:
+    //   "exists"    — a real workflow already occupies the target → refuse now, so
+    //                 NOTHING is mutated (no rebind, no copy, no overwrite prompt);
+    //   "absent"    — the disk oracle proved the target free → safe to proceed;
+    //   "unknown"   — an oracle was present but could not confirm (probe threw / a
+    //                 non-conclusive status) → AMBIGUOUS;
+    //   "no-oracle" — no disk oracle at all (older frontend / test) → legacy path.
+    const targetState = await probeTargetCollision(svc, finalTargetPath, existsOnDisk);
+    if (targetState === "exists") {
+      throw conflictError(effectiveName);
     }
 
     // #285 — EXTERNAL source: a real file loaded from an ABSOLUTE path OUTSIDE the
@@ -187,12 +179,28 @@ export async function saveActiveWorkflow(svc, name, { autoWorkflowName, existsOn
             "refusing to move or destroy the original file outside the workflows folder (issue #285/#226)",
         );
       }
-      return await withConflictRollback(svc, wf, effectiveName, () =>
+      return await withConflictRollback(svc, wf, effectiveName, finalTargetPath, () =>
         copyToUserDir(wf, effectiveName, finalTargetPath),
       );
     }
 
     const cls = await classifySource(svc, wf, sourcePath, existsOnDisk);
+
+    // #309/P1-A — the high-level `saveWorkflowAs` (1.45.x) can OVERWRITE an existing
+    // target (it prompts, then DELETES the file on confirm) and it silently returns
+    // `false` on decline. It is only safe to reach when the target is PROVABLY free.
+    // If an oracle was present but could NOT confirm the target is free (unknown),
+    // refuse rather than fall through to that destructive/overwriting API (#226). The
+    // move-free low-level copy (overwrite:false → 409s) is unaffected, so this only
+    // gates the high-level route. A "no-oracle" frontend keeps the legacy path.
+    const willUseHighLevel = typeof svc?.saveWorkflowAs === "function";
+    if (willUseHighLevel && targetState === "unknown") {
+      throw new Error(
+        `cannot verify that "${baseName(effectiveName)}" is free — the workflows directory ` +
+          `could not be checked, and this frontend's Save-As can overwrite an existing workflow. ` +
+          `Refusing to save-as to avoid destroying another workflow (issue #226/#309); retry.`,
+      );
+    }
 
     // Resolve the copy (Save-As) API across frontend versions. On 1.45.x the
     // workflow store exposes the high-level `saveWorkflowAs(wf,{filename})`. On
@@ -222,7 +230,7 @@ export async function saveActiveWorkflow(svc, name, { autoWorkflowName, existsOn
       // the never-saved tab to a real file. No Save dialog. Wrapped so a 409
       // filename conflict rolls back any optimistic tab rebind instead of leaving
       // the tab stranded on the conflicting path (#309).
-      const activeName = await withConflictRollback(svc, wf, effectiveName, () =>
+      const activeName = await withConflictRollback(svc, wf, effectiveName, finalTargetPath, () =>
         saveAsCopy(wf, effectiveName, finalTargetPath),
       );
       // BACKSTOP: if the copy relocated a persisted source anyway, fail LOUDLY
@@ -295,7 +303,20 @@ function resolveSaveAsCopy(svc, { explicitTargetOnly = false } = {}) {
   // so ONLY the move-free, explicit-path low-level copy is selected (#285).
   if (!explicitTargetOnly && typeof svc?.saveWorkflowAs === "function") {
     return async (wf, effectiveName) => {
-      await svc.saveWorkflowAs(wf, { filename: effectiveName });
+      // saveWorkflowAs returns `false` when the copy did NOT happen (the user
+      // declined the overwrite prompt, or the target already exists) — reporting the
+      // active filename as success in that case is a phantom save (#309/P1-A). HONOR
+      // the false return: treat it as a conflict so withConflictRollback rolls back
+      // and a clean error surfaces, never a false success.
+      const result = await svc.saveWorkflowAs(wf, { filename: effectiveName });
+      if (result === false) {
+        const err = new Error(
+          `save-as of "${effectiveName}" was not completed — the target already exists or the ` +
+            `overwrite was declined (409 Conflict)`,
+        );
+        err.status = 409;
+        throw err;
+      }
       // saveWorkflowAs makes the new copy the active workflow.
       return baseName(svc.activeWorkflow?.filename) || effectiveName;
     };
@@ -533,7 +554,7 @@ function safeAssign(obj, key, value) {
  *  Derived getter-only flags are skipped via safeAssign so restoration never throws.
  *  A non-conflict error is rethrown untouched. Nothing on disk is modified here — a
  *  409 means the server wrote nothing, and the pre-existing file is never our source. */
-async function withConflictRollback(svc, wf, desiredName, fn) {
+async function withConflictRollback(svc, wf, desiredName, finalTargetPath, fn) {
   const prevActive = svc?.activeWorkflow;
   const snap = wf
     ? {
@@ -545,6 +566,18 @@ async function withConflictRollback(svc, wf, desiredName, fn) {
         isPersisted: wf.isPersisted,
       }
     : null;
+  // Snapshot whatever object (if any) ALREADY occupied the target path BEFORE the
+  // save. This distinguishes a PRE-EXISTING real target (which must never be
+  // removed on rollback — e.g. an overwrite declined after a TOCTOU) from a copy
+  // the failing save NEWLY inserted at the target (#309/P1-B).
+  let targetBefore = null;
+  if (typeof svc?.getWorkflowByPath === "function") {
+    try {
+      targetBefore = svc.getWorkflowByPath(finalTargetPath) ?? null;
+    } catch {
+      targetBefore = null;
+    }
+  }
   try {
     return await fn();
   } catch (err) {
@@ -553,6 +586,12 @@ async function withConflictRollback(svc, wf, desiredName, fn) {
     // load-bearing fix (the conflicting/copy tab must not remain active), so it
     // must happen even if a later field restore is a no-op.
     if (svc && prevActive !== undefined) svc.activeWorkflow = prevActive;
+    // #309/P1-B — the frontend's saveWorkflowAs may have mutated its store INDEX
+    // (workflowLookup + open-tab list) before the 409: it either inserted an
+    // orphaned COPY at the target (persisted-source path) or REKEYED the source
+    // object to the target (temporary-source path). Reassigning fields on `wf`
+    // alone can't repair the store's path→object map, so repair the topology here.
+    await repairStoreAfterConflict(svc, wf, snap, finalTargetPath, targetBefore);
     if (wf && snap) {
       safeAssign(wf, "path", snap.path);
       safeAssign(wf, "filename", snap.filename);
@@ -562,6 +601,88 @@ async function withConflictRollback(svc, wf, desiredName, fn) {
       safeAssign(wf, "isPersisted", snap.isPersisted);
     }
     throw conflictError(desiredName);
+  }
+}
+
+/** Tri/quad-state collision classification for the resolved Save-As target, used to
+ *  pre-empt a destructive/overwriting save BEFORE any API call (#309). Returns
+ *  "exists" (a persisted workflow is already at the target — via the store index or
+ *  a 200 from the disk oracle), "absent" (the disk oracle 404'd — provably free),
+ *  "unknown" (an oracle was present but inconclusive — probe threw / ambiguous), or
+ *  "no-oracle" (no disk oracle at all). The store check runs first so a persisted
+ *  target is caught even when the disk probe is unavailable (the #309/P1-A repro). */
+async function probeTargetCollision(svc, finalTargetPath, existsOnDisk) {
+  if (typeof svc?.getWorkflowByPath === "function") {
+    try {
+      const atTarget = svc.getWorkflowByPath(finalTargetPath);
+      if (atTarget && atTarget.isPersisted === true) return "exists";
+    } catch {
+      /* store threw ⇒ no signal from this oracle */
+    }
+  }
+  if (typeof existsOnDisk === "function") {
+    let probe = null;
+    try {
+      probe = await existsOnDisk(finalTargetPath);
+    } catch {
+      probe = null; // oracle present but threw ⇒ ambiguous
+    }
+    if (probe === true) return "exists";
+    if (probe === false) return "absent";
+    return "unknown";
+  }
+  return "no-oracle";
+}
+
+/** Repair the frontend store's path→object index after a high-level saveWorkflowAs
+ *  409 (#309/P1-B). Two shapes the frontend leaves behind:
+ *   - an ORPHANED COPY inserted at the target (persisted-source path): a DIFFERENT
+ *     object now sits at the target path → remove it from the store + open tabs;
+ *   - a REKEYED SOURCE (temporary-source path): the SAME `wf` was rekeyed to the
+ *     target before the 409 → rekey it back to its original path via the store's own
+ *     rename (a TEMPORARY rename is a pure in-memory updatePath, no server write),
+ *     which also restores workflowLookup + the derived fullFilename/suffix that a
+ *     bare field reassignment cannot. Fully defensive; never throws. */
+async function repairStoreAfterConflict(svc, wf, snap, finalTargetPath, targetBefore) {
+  if (!svc || !finalTargetPath || typeof svc.getWorkflowByPath !== "function") return;
+  let atTarget = null;
+  try {
+    atTarget = svc.getWorkflowByPath(finalTargetPath);
+  } catch {
+    return; // store threw ⇒ nothing we can safely repair
+  }
+  if (!atTarget) return;
+  if (atTarget !== wf) {
+    // Something other than our source sits at the target. Only remove it if it is a
+    // PROVEN orphan our failing save NEWLY inserted — i.e. it was NOT already there
+    // before the op AND it is a never-persisted (temporary) copy. A PRE-EXISTING or
+    // PERSISTED workflow at the target (e.g. the real file after a declined
+    // overwrite TOCTOU) is a legitimate tab and MUST be left indexed/open (#309).
+    const isNewlyInserted = atTarget !== targetBefore;
+    const isTemporaryCopy = atTarget.isPersisted !== true;
+    if (isNewlyInserted && isTemporaryCopy) {
+      try {
+        removeInMemoryWorkflow(svc, atTarget);
+      } catch {
+        /* best-effort */
+      }
+    }
+    return;
+  }
+  // The SAME source object was rekeyed to the target — rekey it back. Guard on
+  // TEMPORARY so we never trigger a server moveUserData on a persisted doc.
+  const origPath = snap?.path;
+  if (
+    origPath &&
+    normalizePath(origPath) !== normalizePath(finalTargetPath) &&
+    wf?.isTemporary === true &&
+    typeof svc.renameWorkflow === "function"
+  ) {
+    try {
+      await svc.renameWorkflow(wf, origPath);
+    } catch {
+      /* best-effort — the field restore below still corrects path/filename */
+    }
   }
 }
 

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -156,7 +156,7 @@ export async function saveActiveWorkflow(svc, name, { autoWorkflowName, existsOn
     //   "unknown"   — an oracle was present but could not confirm (probe threw / a
     //                 non-conclusive status) → AMBIGUOUS;
     //   "no-oracle" — no disk oracle at all (older frontend / test) → legacy path.
-    const targetState = await probeTargetCollision(svc, finalTargetPath, existsOnDisk);
+    const targetState = await probeTargetCollision(svc, wf, finalTargetPath, existsOnDisk);
     if (targetState === "exists") {
       throw conflictError(effectiveName);
     }
@@ -172,7 +172,7 @@ export async function saveActiveWorkflow(svc, name, { autoWorkflowName, existsOn
     // never references the source's on-disk file. If that copy API is unavailable,
     // REFUSE rather than risk moving the external original.
     if (isExternalWorkflowPath(sourcePath)) {
-      const copyToUserDir = resolveSaveAsCopy(svc, { explicitTargetOnly: true });
+      const copyToUserDir = resolveSaveAsCopy(svc);
       if (!copyToUserDir) {
         throw new Error(
           "save-as (copy) is unavailable on this frontend for an externally-loaded workflow; " +
@@ -186,59 +186,35 @@ export async function saveActiveWorkflow(svc, name, { autoWorkflowName, existsOn
 
     const cls = await classifySource(svc, wf, sourcePath, existsOnDisk);
 
-    // #309/P1-A — the high-level `saveWorkflowAs` (1.45.x) can OVERWRITE an existing
-    // target (it prompts, then DELETES the file on confirm) and it silently returns
-    // `false` on decline. It is only safe to reach when the target is PROVABLY free.
-    // If an oracle was present but could NOT confirm the target is free (unknown),
-    // refuse rather than fall through to that destructive/overwriting API (#226). The
-    // move-free low-level copy (overwrite:false → 409s) is unaffected, so this only
-    // gates the high-level route. A "no-oracle" frontend keeps the legacy path.
-    const willUseHighLevel = typeof svc?.saveWorkflowAs === "function";
-    if (willUseHighLevel && targetState === "unknown") {
+    // #226 CLASSIFICATION GUARD (hoisted so it applies regardless of which copy API
+    // is used) — a source ACTING temporary that isn't PROVABLY never-persisted must
+    // not be relocated: it might be a real on-disk file a relocate could move or
+    // destroy. This is about the SOURCE, not the write mechanism. A correctly-opened
+    // persisted workflow (isTemporary === false) hits the copy path below.
+    if (wf.isTemporary === true && cls !== "never-persisted") {
       throw new Error(
-        `cannot verify that "${baseName(effectiveName)}" is free — the workflows directory ` +
-          `could not be checked, and this frontend's Save-As can overwrite an existing workflow. ` +
-          `Refusing to save-as to avoid destroying another workflow (issue #226/#309); retry.`,
+        `refusing to save: the active workflow is flagged unsaved but its source "${sourcePath}" ` +
+          `${cls === "persisted" ? "exists on disk" : "cannot be proven absent from disk"} — ` +
+          `saving now could MOVE (destroy) the original (issue #226). Re-open the workflow and try again.`,
       );
     }
 
-    // Resolve the copy (Save-As) API across frontend versions. On 1.45.x the
-    // workflow store exposes the high-level `saveWorkflowAs(wf,{filename})`. On
-    // 1.47.x that method was removed from `extensionManager.workflow`; the store
-    // instead exposes the low-level pair `saveAs(wf, path)` (creates a NEW copy
-    // object at `path`, leaving the source object AND its on-disk file untouched)
-    // + `saveWorkflow(copy)` (persists the copy). Both are true copies — neither
-    // moves/destroys the source — so both satisfy the #226 invariant.
-    const saveAsCopy = resolveSaveAsCopy(svc);
-
-    if (saveAsCopy) {
-      // PREVENT the destructive move. saveWorkflowAs relocates-by-rename whenever
-      // it treats the doc as temporary. That is only SAFE when the source is
-      // provably never-persisted; for a persisted OR UNKNOWN source it would (or
-      // might) destroy a real file — refuse instead (the sanctioned safe outcome).
-      // A correctly-opened persisted workflow has isTemporary === false and hits
-      // the COPY branch, so it is unaffected by this guard.
-      if (wf.isTemporary === true && cls !== "never-persisted") {
-        throw new Error(
-          `refusing to save: the active workflow is flagged unsaved but its source "${sourcePath}" ` +
-            `${cls === "persisted" ? "exists on disk" : "cannot be proven absent from disk"} — ` +
-            `saving now could MOVE (destroy) the original (issue #226). Re-open the workflow and try again.`,
-        );
-      }
-      // Copy path. For a persisted workflow this copies (new file, original
-      // untouched); for a genuine (provably never-persisted) temporary it grounds
-      // the never-saved tab to a real file. No Save dialog. Wrapped so a 409
-      // filename conflict rolls back any optimistic tab rebind instead of leaving
-      // the tab stranded on the conflicting path (#309).
+    // #226/#309 P1-1 — a relocating Save-As can COLLIDE with an existing file, and a
+    // non-atomic HEAD pre-check can NEVER make an OVERWRITING write safe (a target can
+    // appear between the check and the write — TOCTOU). So the ONLY sanctioned write
+    // is the ATOMIC low-level trio: saveAs builds an explicit-target copy and
+    // saveWorkflow persists it with overwrite:false — which the server 409s if the
+    // target already exists, WITHOUT any prompt/delete. No TOCTOU window remains. This
+    // is exactly the route the real (1.47.x) frontend exposes. A 409 (whether the
+    // pre-check missed it or a TOCTOU created it) surfaces as a clean conflict via
+    // withConflictRollback, and the low-level adapter removes its own orphaned copy.
+    const atomicCopy = resolveSaveAsCopy(svc);
+    if (atomicCopy) {
       const activeName = await withConflictRollback(svc, wf, effectiveName, finalTargetPath, () =>
-        saveAsCopy(wf, effectiveName, finalTargetPath),
+        atomicCopy(wf, effectiveName, finalTargetPath),
       );
-      // BACKSTOP: if the copy relocated a persisted source anyway, fail LOUDLY
-      // instead of reporting a phantom success (the prior fix's exact miss). Uses
-      // the SAME tri-state rule as classifySource: only a SUCCESSFUL, affirmative
-      // absence (getWorkflowByPath returns null/undefined at the path) proves the
-      // move. A getter THROW or a list-miss is UNKNOWN — a valid save-as copy must
-      // NOT be reported as "moved" (false alarm).
+      // BACKSTOP: if the copy somehow relocated a persisted source, fail LOUDLY
+      // rather than report a phantom success (#226).
       if (cls === "persisted" && confirmedAbsentAt(svc, sourcePath)) {
         throw new Error(
           `save moved the original workflow "${sourcePath}" instead of copying it — ` +
@@ -247,17 +223,22 @@ export async function saveActiveWorkflow(svc, name, { autoWorkflowName, existsOn
       }
       return activeName;
     }
-    // Fallback (older frontend with no copy API): renaming is a MOVE, so it is
-    // only permitted when the source is PROVABLY never-persisted (an in-memory
-    // temporary tab with no backing file). Persisted OR UNKNOWN → refuse (#226).
-    if (cls === "never-persisted" && typeof svc.renameWorkflow === "function") {
-      await svc.renameWorkflow(wf, finalTargetPath);
-      await saveInPlace(svc, wf);
-      return effectiveName;
-    }
-    // No safe way to relocate: refuse rather than move/destroy the original.
+
+    // No atomic low-level copy trio. Every remaining relocation mechanism is unsafe:
+    //  - the high-level `saveWorkflowAs` writes by PROMPTING and can DELETE+overwrite
+    //    an existing target (an unavoidable TOCTOU + data-loss #226/#309 P1-1); and
+    //  - a `renameWorkflow` fallback MOVES the workflow and cannot be made atomic
+    //    against a target appearing between the HEAD probe and the write (a 409 on
+    //    the follow-up save would strand the tab rekeyed at the conflicting path).
+    // The real frontend always exposes the atomic saveAs/openWorkflow/saveWorkflow
+    // trio, so REFUSE rather than route a collision-capable Save-As through an unsafe
+    // path. (This never blocks a genuine 1.47.x frontend; it only refuses a build
+    // that offers no safe copy API.)
     throw new Error(
-      "save-as (copy) is unavailable on this frontend; refusing to rename and destroy the original workflow",
+      "atomic Save-As (copy) is unavailable on this frontend — it exposes no safe " +
+        "saveAs/openWorkflow/saveWorkflow copy API, and the alternatives (prompting " +
+        "saveWorkflowAs / renameWorkflow) can overwrite or strand a workflow; refusing to " +
+        "rename and destroy the original workflow (issue #226/#309). Update ComfyUI.",
     );
   }
 
@@ -283,44 +264,21 @@ function confirmedAbsentAt(svc, rawPath) {
   }
 }
 
-/** Resolve the frontend's Save-As (COPY) capability into a single async adapter
- *  `(wf, effectiveName, finalTargetPath) => resolvedActiveName`, or null when no
- *  copy API exists. Every branch is a genuine COPY that leaves the source file
- *  on disk untouched (the #226 invariant) — the temporary-vs-persisted move
- *  decision is made by the caller via classifySource, never here.
+/** Resolve the frontend's ATOMIC Save-As (COPY) capability into a single async
+ *  adapter `(wf, effectiveName, finalTargetPath) => resolvedActiveName`, or null
+ *  when the atomic trio is unavailable.
  *
- *   - 1.45.x: `svc.saveWorkflowAs(wf, { filename })` (high-level; makes the new
- *     copy the active workflow, so read the resolved name back off it).
- *   - 1.47.x: the store dropped `saveWorkflowAs` and exposes the low-level pair
- *     `svc.saveAs(wf, path)` — which builds a NEW workflow object at `path`
- *     (fresh id, source object and its file untouched) and returns it — plus
- *     `svc.saveWorkflow(copy)` to persist that copy. We drive them together. */
-function resolveSaveAsCopy(svc, { explicitTargetOnly = false } = {}) {
-  // The high-level `saveWorkflowAs(wf, { filename })` writes into the SOURCE's own
-  // directory and can MOVE a temporary — it cannot honour an explicit target path.
-  // For an EXTERNAL source (whose copy must land in the user workflows dir, never
-  // the source's unwritable external folder), the caller passes explicitTargetOnly
-  // so ONLY the move-free, explicit-path low-level copy is selected (#285).
-  if (!explicitTargetOnly && typeof svc?.saveWorkflowAs === "function") {
-    return async (wf, effectiveName) => {
-      // saveWorkflowAs returns `false` when the copy did NOT happen (the user
-      // declined the overwrite prompt, or the target already exists) — reporting the
-      // active filename as success in that case is a phantom save (#309/P1-A). HONOR
-      // the false return: treat it as a conflict so withConflictRollback rolls back
-      // and a clean error surfaces, never a false success.
-      const result = await svc.saveWorkflowAs(wf, { filename: effectiveName });
-      if (result === false) {
-        const err = new Error(
-          `save-as of "${effectiveName}" was not completed — the target already exists or the ` +
-            `overwrite was declined (409 Conflict)`,
-        );
-        err.status = 409;
-        throw err;
-      }
-      // saveWorkflowAs makes the new copy the active workflow.
-      return baseName(svc.activeWorkflow?.filename) || effectiveName;
-    };
-  }
+ *  ONLY the low-level trio is offered — `saveAs(wf, path)` builds a NEW copy object
+ *  at an explicit `path` (source object + file untouched), `openWorkflow` loads its
+ *  graph, and `saveWorkflow(copy)` persists it with overwrite:false (the server
+ *  409s if the target already exists, with NO prompt/delete). This is a genuine
+ *  COPY (never moves/destroys the source, #226) AND atomic against a colliding
+ *  target (no TOCTOU window, #309 P1-1).
+ *
+ *  The high-level `saveWorkflowAs` is DELIBERATELY NOT used: it writes by prompting
+ *  and can DELETE+overwrite an existing target, which no pre-check can make safe.
+ *  The caller refuses a collision-capable Save-As when only that API exists. */
+function resolveSaveAsCopy(svc) {
   // `openWorkflow` is MANDATORY for this path, not optional. The object saveAs
   // returns is UNLOADED (no changeTracker → activeState === null), and
   // ComfyWorkflow.save() serializes `activeState ?? null` — so persisting a copy
@@ -336,6 +294,39 @@ function resolveSaveAsCopy(svc, { explicitTargetOnly = false } = {}) {
     typeof svc?.openWorkflow === "function"
   ) {
     return async (wf, effectiveName, finalTargetPath) => {
+      // FINAL, SYNCHRONOUS collision re-check IMMEDIATELY before saveAs — this closes
+      // the TOCTOU window between probeTargetCollision's async disk HEAD and this
+      // write: another unsaved tab may have occupied the target WHILE the HEAD was
+      // pending, and the real store's saveAs unconditionally REPLACES the lookup
+      // entry (orphaning that tab's unsaved graph, a data loss #226). No `await`
+      // separates this check from the synchronous saveAs below, so it is atomic.
+      //
+      // It FAILS CLOSED: if the store lookup is absent or THROWS we cannot prove the
+      // target is free, so we refuse rather than risk overwriting an in-memory tab
+      // (the real 1.47 store always exposes getWorkflowByPath — it is a REQUIRED
+      // member — so this never blocks a genuine frontend).
+      if (typeof svc.getWorkflowByPath !== "function") {
+        throw new Error(
+          `save-as (copy) cannot verify the target "${finalTargetPath}" is free on this frontend ` +
+            `(no workflow lookup) — refusing to avoid overwriting an in-memory tab (#226).`,
+        );
+      }
+      let occupant;
+      try {
+        occupant = svc.getWorkflowByPath(finalTargetPath);
+      } catch {
+        throw new Error(
+          `save-as (copy) could not verify the target "${finalTargetPath}" is free (workflow ` +
+            `lookup failed) — refusing to avoid overwriting an in-memory tab (#226). Retry.`,
+        );
+      }
+      if (occupant && occupant !== wf) {
+        const err = new Error(
+          `a workflow already occupies "${finalTargetPath}" (409 Conflict) — choose a different name`,
+        );
+        err.status = 409;
+        throw err;
+      }
       // saveAs builds the copy in memory at the resolved target path (source
       // object untouched); the source's on-disk file is never referenced, so it
       // cannot be moved/destroyed (#226).
@@ -566,32 +557,16 @@ async function withConflictRollback(svc, wf, desiredName, finalTargetPath, fn) {
         isPersisted: wf.isPersisted,
       }
     : null;
-  // Snapshot whatever object (if any) ALREADY occupied the target path BEFORE the
-  // save. This distinguishes a PRE-EXISTING real target (which must never be
-  // removed on rollback — e.g. an overwrite declined after a TOCTOU) from a copy
-  // the failing save NEWLY inserted at the target (#309/P1-B).
-  let targetBefore = null;
-  if (typeof svc?.getWorkflowByPath === "function") {
-    try {
-      targetBefore = svc.getWorkflowByPath(finalTargetPath) ?? null;
-    } catch {
-      targetBefore = null;
-    }
-  }
   try {
     return await fn();
   } catch (err) {
     if (!isConflictError(err)) throw err;
     // Restore the active reference FIRST — it is a plain store field and is the
     // load-bearing fix (the conflicting/copy tab must not remain active), so it
-    // must happen even if a later field restore is a no-op.
+    // must happen even if a later field restore is a no-op. The low-level adapter
+    // has already removed ITS OWN orphaned copy IDENTITY-SAFELY (it never evicts a
+    // distinct late occupant), so there is no store-topology repair to do here.
     if (svc && prevActive !== undefined) svc.activeWorkflow = prevActive;
-    // #309/P1-B — the frontend's saveWorkflowAs may have mutated its store INDEX
-    // (workflowLookup + open-tab list) before the 409: it either inserted an
-    // orphaned COPY at the target (persisted-source path) or REKEYED the source
-    // object to the target (temporary-source path). Reassigning fields on `wf`
-    // alone can't repair the store's path→object map, so repair the topology here.
-    await repairStoreAfterConflict(svc, wf, snap, finalTargetPath, targetBefore);
     if (wf && snap) {
       safeAssign(wf, "path", snap.path);
       safeAssign(wf, "filename", snap.filename);
@@ -606,16 +581,23 @@ async function withConflictRollback(svc, wf, desiredName, finalTargetPath, fn) {
 
 /** Tri/quad-state collision classification for the resolved Save-As target, used to
  *  pre-empt a destructive/overwriting save BEFORE any API call (#309). Returns
- *  "exists" (a persisted workflow is already at the target — via the store index or
- *  a 200 from the disk oracle), "absent" (the disk oracle 404'd — provably free),
+ *  "exists" (a workflow already occupies the target — via the store index or a 200
+ *  from the disk oracle), "absent" (the disk oracle 404'd — provably free),
  *  "unknown" (an oracle was present but inconclusive — probe threw / ambiguous), or
- *  "no-oracle" (no disk oracle at all). The store check runs first so a persisted
+ *  "no-oracle" (no disk oracle at all). The store check runs first so an occupied
  *  target is caught even when the disk probe is unavailable (the #309/P1-A repro). */
-async function probeTargetCollision(svc, finalTargetPath, existsOnDisk) {
+async function probeTargetCollision(svc, wf, finalTargetPath, existsOnDisk) {
   if (typeof svc?.getWorkflowByPath === "function") {
     try {
       const atTarget = svc.getWorkflowByPath(finalTargetPath);
-      if (atTarget && atTarget.isPersisted === true) return "exists";
+      // ANY DISTINCT workflow object already at the target is a collision — PERSISTED
+      // or TEMPORARY. The real 1.47 store's saveAs unconditionally REPLACES
+      // workflowLookup[target] with the new copy; if an UNSAVED temporary tab already
+      // owns the target path, that would orphan its graph (data loss). A disk 404
+      // can't see an unsaved tab, so the store index is the only signal here — refuse
+      // rather than overwrite it. (Never the source itself — a relocate targets a
+      // different path — but guard `!== wf` for safety.)
+      if (atTarget && atTarget !== wf) return "exists";
     } catch {
       /* store threw ⇒ no signal from this oracle */
     }
@@ -634,71 +616,47 @@ async function probeTargetCollision(svc, finalTargetPath, existsOnDisk) {
   return "no-oracle";
 }
 
-/** Repair the frontend store's path→object index after a high-level saveWorkflowAs
- *  409 (#309/P1-B). Two shapes the frontend leaves behind:
- *   - an ORPHANED COPY inserted at the target (persisted-source path): a DIFFERENT
- *     object now sits at the target path → remove it from the store + open tabs;
- *   - a REKEYED SOURCE (temporary-source path): the SAME `wf` was rekeyed to the
- *     target before the 409 → rekey it back to its original path via the store's own
- *     rename (a TEMPORARY rename is a pure in-memory updatePath, no server write),
- *     which also restores workflowLookup + the derived fullFilename/suffix that a
- *     bare field reassignment cannot. Fully defensive; never throws. */
-async function repairStoreAfterConflict(svc, wf, snap, finalTargetPath, targetBefore) {
-  if (!svc || !finalTargetPath || typeof svc.getWorkflowByPath !== "function") return;
-  let atTarget = null;
-  try {
-    atTarget = svc.getWorkflowByPath(finalTargetPath);
-  } catch {
-    return; // store threw ⇒ nothing we can safely repair
-  }
-  if (!atTarget) return;
-  if (atTarget !== wf) {
-    // Something other than our source sits at the target. Only remove it if it is a
-    // PROVEN orphan our failing save NEWLY inserted — i.e. it was NOT already there
-    // before the op AND it is a never-persisted (temporary) copy. A PRE-EXISTING or
-    // PERSISTED workflow at the target (e.g. the real file after a declined
-    // overwrite TOCTOU) is a legitimate tab and MUST be left indexed/open (#309).
-    const isNewlyInserted = atTarget !== targetBefore;
-    const isTemporaryCopy = atTarget.isPersisted !== true;
-    if (isNewlyInserted && isTemporaryCopy) {
-      try {
-        removeInMemoryWorkflow(svc, atTarget);
-      } catch {
-        /* best-effort */
-      }
-    }
-    return;
-  }
-  // The SAME source object was rekeyed to the target — rekey it back. Guard on
-  // TEMPORARY so we never trigger a server moveUserData on a persisted doc.
-  const origPath = snap?.path;
-  if (
-    origPath &&
-    normalizePath(origPath) !== normalizePath(finalTargetPath) &&
-    wf?.isTemporary === true &&
-    typeof svc.renameWorkflow === "function"
-  ) {
-    try {
-      await svc.renameWorkflow(wf, origPath);
-    } catch {
-      /* best-effort — the field restore below still corrects path/filename */
-    }
-  }
-}
-
-/** Best-effort removal of an in-memory (never-persisted) workflow copy from the
- *  store, used to undo an orphaned copy tab when its persist throws (#309). Prefers
- *  a store close/remove API; falls back to splicing the known list arrays. */
+/** IDENTITY-SAFE removal of an in-memory (never-persisted) workflow copy from the
+ *  store — used to undo an orphaned copy tab when its persist throws (#309).
+ *
+ *  The store's path-keyed removers (the real 1.47 `closeWorkflow` does
+ *  `delete workflowLookup[wf.path]`) would evict WHATEVER currently occupies
+ *  `wf.path`. If a DISTINCT late occupant claimed that path while we awaited
+ *  openWorkflow/saveWorkflow, closing by path would delete IT (orphaning its unsaved
+ *  graph, a data loss #226). So the path-keyed removers are used ONLY when the store
+ *  lookup STILL points to `wf`; otherwise `wf` is spliced out of the open-tab arrays
+ *  by IDENTITY and the occupant's lookup entry is left untouched. */
 function removeInMemoryWorkflow(svc, wf) {
   if (!svc || !wf) return;
-  if (typeof svc.closeWorkflow === "function") {
-    svc.closeWorkflow(wf);
-    return;
+  // Does the store's path→object lookup still point at OUR copy?
+  let stillOurs = true;
+  if (typeof svc.getWorkflowByPath === "function") {
+    try {
+      stillOurs = svc.getWorkflowByPath(wf.path) === wf;
+    } catch {
+      stillOurs = false; // can't confirm ⇒ don't risk a path-keyed delete
+    }
   }
-  if (typeof svc.removeWorkflow === "function") {
-    svc.removeWorkflow(wf);
-    return;
+  if (stillOurs) {
+    if (typeof svc.closeWorkflow === "function") {
+      try {
+        svc.closeWorkflow(wf);
+        return;
+      } catch {
+        /* fall through to identity splice */
+      }
+    }
+    if (typeof svc.removeWorkflow === "function") {
+      try {
+        svc.removeWorkflow(wf);
+        return;
+      } catch {
+        /* fall through to identity splice */
+      }
+    }
   }
+  // Identity-only cleanup: remove OUR object from the known list arrays without
+  // touching any path-keyed lookup entry a distinct occupant may now own.
   for (const listName of ["openWorkflows", "workflows"]) {
     const list = svc[listName];
     if (Array.isArray(list)) {

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -75,7 +75,11 @@ export function isDefaultWorkflowName(name) {
  *  is only ever consulted after the in-memory oracles are inconclusive, and its
  *  absence / failure leaves the classification "unknown" → refuse (fail safe).
  */
-export async function saveActiveWorkflow(svc, name, { autoWorkflowName, existsOnDisk } = {}) {
+export async function saveActiveWorkflow(
+  svc,
+  name,
+  { autoWorkflowName, existsOnDisk, reconcileSavedCopy } = {},
+) {
   const wf = svc?.activeWorkflow;
   if (!wf) throw new Error("no active workflow to save");
 
@@ -172,7 +176,7 @@ export async function saveActiveWorkflow(svc, name, { autoWorkflowName, existsOn
     // never references the source's on-disk file. If that copy API is unavailable,
     // REFUSE rather than risk moving the external original.
     if (isExternalWorkflowPath(sourcePath)) {
-      const copyToUserDir = resolveSaveAsCopy(svc);
+      const copyToUserDir = resolveSaveAsCopy(svc, { reconcileSavedCopy });
       if (!copyToUserDir) {
         throw new Error(
           "save-as (copy) is unavailable on this frontend for an externally-loaded workflow; " +
@@ -201,14 +205,27 @@ export async function saveActiveWorkflow(svc, name, { autoWorkflowName, existsOn
 
     // #226/#309 P1-1 — a relocating Save-As can COLLIDE with an existing file, and a
     // non-atomic HEAD pre-check can NEVER make an OVERWRITING write safe (a target can
-    // appear between the check and the write — TOCTOU). So the ONLY sanctioned write
-    // is the ATOMIC low-level trio: saveAs builds an explicit-target copy and
-    // saveWorkflow persists it with overwrite:false — which the server 409s if the
-    // target already exists, WITHOUT any prompt/delete. No TOCTOU window remains. This
-    // is exactly the route the real (1.47.x) frontend exposes. A 409 (whether the
-    // pre-check missed it or a TOCTOU created it) surfaces as a clean conflict via
-    // withConflictRollback, and the low-level adapter removes its own orphaned copy.
-    const atomicCopy = resolveSaveAsCopy(svc);
+    // appear between the check and the write — TOCTOU). So the ONLY sanctioned write is
+    // the low-level trio: saveAs builds an explicit-target copy and saveWorkflow
+    // persists it with overwrite:false, which asks the server NOT to overwrite an
+    // existing target and never prompts/deletes. This is the route the real 1.47.x
+    // frontend exposes.
+    //
+    // ACCEPTED UPSTREAM LIMITATION (documented, not fixable from the panel): ComfyUI's
+    // /userdata POST is NOT exclusive-create — user_manager.py does
+    // `os.path.exists(target)` → `await request.read()` → `os.replace(tmp, target)`,
+    // and neither the server nor the frontend `storeUserData` exposes an
+    // exclusive-create/no-replace/conditional flag (only the boolean `overwrite`
+    // query). So a target CREATED during the server's request-body-read await gap is
+    // silently overwritten (200, not 409). We do everything a client CAN — store+disk
+    // pre-check, a final SYNCHRONOUS re-check immediately before saveAs, the atomic
+    // trio only, no prompting/deleting API — and POST-WRITE DETECTION (below) that
+    // reads the target back and verifies it is OUR content, converting a silent
+    // clobber-of-our-write into a surfaced error. The user's OWN original is never
+    // touched. The residual (a concurrent save to the identical brand-new name within
+    // that sub-second window, which cannot occur in a single-user session, and cannot
+    // retroactively protect a victim file the server already replaced) is upstream-only.
+    const atomicCopy = resolveSaveAsCopy(svc, { reconcileSavedCopy });
     if (atomicCopy) {
       const activeName = await withConflictRollback(svc, wf, effectiveName, finalTargetPath, () =>
         atomicCopy(wf, effectiveName, finalTargetPath),
@@ -270,15 +287,28 @@ function confirmedAbsentAt(svc, rawPath) {
  *
  *  ONLY the low-level trio is offered — `saveAs(wf, path)` builds a NEW copy object
  *  at an explicit `path` (source object + file untouched), `openWorkflow` loads its
- *  graph, and `saveWorkflow(copy)` persists it with overwrite:false (the server
- *  409s if the target already exists, with NO prompt/delete). This is a genuine
- *  COPY (never moves/destroys the source, #226) AND atomic against a colliding
- *  target (no TOCTOU window, #309 P1-1).
+ *  graph, and `saveWorkflow(copy)` persists it with overwrite:false (asks the server
+ *  not to overwrite an existing target; NO prompt/delete). This is a genuine COPY
+ *  (never moves/destroys the source, #226).
  *
  *  The high-level `saveWorkflowAs` is DELIBERATELY NOT used: it writes by prompting
  *  and can DELETE+overwrite an existing target, which no pre-check can make safe.
- *  The caller refuses a collision-capable Save-As when only that API exists. */
-function resolveSaveAsCopy(svc) {
+ *  The caller refuses a collision-capable Save-As when only that API exists.
+ *
+ *  `reconcileSavedCopy(targetPath, copy)` is an OPTIONAL authoritative read-back
+ *  oracle → "ours" | "foreign" | "absent" | "unknown". It backs two guards the
+ *  server's non-exclusive-create /userdata write demands:
+ *   - AMBIGUOUS post-commit failure (P2): a persist can COMMIT to disk and THEN
+ *     reject while receiving/parsing the response (connection reset / resp.json()
+ *     error — the frontend updates persisted metadata only AFTER parsing). Blindly
+ *     removing the copy on every rejection would ORPHAN the on-disk file. On a
+ *     NON-conflict failure we reconcile: if the target holds OUR content the write
+ *     landed → ADOPT the copy (never orphan) and report success.
+ *   - POST-WRITE CLOBBER DETECTION (P0): after a "successful" persist, verify the
+ *     target still holds OUR content; a concurrent save in the server's body-read
+ *     window can silently overwrite it (200, not 409) → surface a detected error
+ *     instead of a false success. */
+function resolveSaveAsCopy(svc, { reconcileSavedCopy } = {}) {
   // `openWorkflow` is MANDATORY for this path, not optional. The object saveAs
   // returns is UNLOADED (no changeTracker → activeState === null), and
   // ComfyWorkflow.save() serializes `activeState ?? null` — so persisting a copy
@@ -331,6 +361,12 @@ function resolveSaveAsCopy(svc) {
       // object untouched); the source's on-disk file is never referenced, so it
       // cannot be moved/destroyed (#226).
       const copy = svc.saveAs(wf, finalTargetPath);
+      // STAMP a stable, proxy-safe token on OUR copy. The real store inserts the raw
+      // object into a reactive `workflowLookup`, and reading it back via
+      // getWorkflowByPath returns Vue's REACTIVE PROXY — which is NOT `===` the raw
+      // object. So later cleanup must identify "our copy" by this token (which reads
+      // through the proxy) rather than object identity, or the purge silently no-ops.
+      stampCopyToken(copy);
       if (!copy) {
         throw new Error("save-as (copy) failed to create a copy on this frontend");
       }
@@ -338,23 +374,103 @@ function resolveSaveAsCopy(svc) {
       // (loads the graph into changeTracker/activeState, makes it active), THEN
       // persist — so save() writes the real graph, not null. A throw here aborts
       // BEFORE any saveWorkflow, so a failed open never persists null.
-      //
-      // If OPEN or PERSIST throws (e.g. saveWorkflow 409s on a name collision), the
-      // copy exists only IN MEMORY (nothing was written to disk). Remove that
-      // orphaned copy tab and restore the previously-active workflow so a failed
-      // persist doesn't strand a phantom unsaved tab in the store (#309); then
-      // rethrow so withConflictRollback can surface a clean conflict.
       const prevActive = svc.activeWorkflow;
+      const resolvedName = () =>
+        baseName(svc.activeWorkflow?.filename) || baseName(copy.filename) || effectiveName;
       try {
         await svc.openWorkflow(copy);
         copy.changeTracker?.prepareForSave?.();
         await svc.saveWorkflow(copy);
       } catch (err) {
+        // P2 — distinguish a CONFIRMED pre-commit failure (409 conflict, or the
+        // target is provably absent afterward → the server wrote nothing) from an
+        // AMBIGUOUS post-commit failure (the persist COMMITTED to disk, then the
+        // response was lost/failed to parse). Blindly removing the copy on ambiguity
+        // ORPHANS the on-disk file (a later retry then 409s). So on a NON-conflict
+        // failure, RECONCILE by reading the target back:
+        if (!isConflictError(err) && typeof reconcileSavedCopy === "function") {
+          let state = "unknown";
+          try {
+            state = await reconcileSavedCopy(finalTargetPath, copy);
+          } catch {
+            state = "unknown";
+          }
+          if (state === "ours") {
+            // The write LANDED despite the failed response — the workflow IS saved.
+            // Adopt the copy (never orphan it) and mark it PERSISTED by updating the
+            // REAL backing field the store's getters derive from: on 1.47 `isTemporary`
+            // and `isPersisted` are GETTER-ONLY (isTemporary === size===-1), so
+            // assigning them is a silent no-op — we must set `size`. Without this the
+            // adopted copy stays "temporary": a later in-place Save uses overwrite:false
+            // and 409s, and closing the tab takes the temporary-purge path (dropping the
+            // saved copy). markCopyPersisted sets size + resyncs originalContent so the
+            // store treats it as a normal saved, unmodified workflow. Report success.
+            markCopyPersisted(copy);
+            return resolvedName();
+          }
+          if (state === "foreign") {
+            // The target holds SOMEONE ELSE's content — our write was clobbered or
+            // never landed. Remove our orphan, restore active, and surface a
+            // clobber-aware error (never a false success).
+            removeInMemoryWorkflow(svc, copy);
+            if (prevActive !== undefined) svc.activeWorkflow = prevActive;
+            throw new Error(
+              `save-as could not save "${finalTargetPath}": the target now holds a DIFFERENT ` +
+                `workflow (a concurrent save clobbered it). Retry with a new name (#226).`,
+            );
+          }
+          // "absent"/"unknown" ⇒ the write did not land (or can't be confirmed) ⇒
+          // fall through to the safe removal below.
+        }
         removeInMemoryWorkflow(svc, copy);
         if (prevActive !== undefined) svc.activeWorkflow = prevActive;
         throw err;
       }
-      return baseName(svc.activeWorkflow?.filename) || baseName(copy.filename) || effectiveName;
+      // SUCCESS-PATH BOOKKEEPING (#309 P1, mirror of the adoption branch). ComfyUI's own
+      // saveWorkflow(copy) captures copy.content, awaits the write, THEN calls
+      // changeTracker.reset() (re-baselining to the LIVE canvas) and forces
+      // isModified=false. If the user edited the graph DURING the successful save await,
+      // the live canvas advanced past what committed (disk holds S1, canvas is S2), so
+      // upstream marks the copy "clean" at S2 while S2 is UNSAVED — workflow_close then
+      // silently unloads it (data loss). Re-run our committed-vs-live bookkeeping to
+      // OVERRIDE that: baseline to the COMMITTED snapshot (copy.content) and set
+      // isModified DIRECTLY on OUR copy (never path-resolving). Identical to upstream
+      // when no edit occurred; strictly more correct when an in-flight edit happened.
+      markCopyPersisted(copy);
+      // P0 — POST-WRITE CLOBBER DETECTION. The server's overwrite:false is NOT
+      // exclusive-create (os.path.exists → await body-read → os.replace), so a target
+      // created during the body-read window is silently overwritten (200, not 409).
+      // After a reported-success persist, verify the target still holds OUR content;
+      // if not, a concurrent save clobbered ours → surface a detected error rather
+      // than a false success. (This detects a clobber OF our write; it cannot
+      // retroactively protect a victim file the server already replaced — that is
+      // upstream-only. Best-effort: "unknown" leaves the reported success intact.)
+      if (typeof reconcileSavedCopy === "function") {
+        let state = "unknown";
+        try {
+          state = await reconcileSavedCopy(finalTargetPath, copy);
+        } catch {
+          state = "unknown";
+        }
+        if (state === "foreign" || state === "absent") {
+          // The copy is currently ACTIVE and (from the reported-success persist) would
+          // read as PERSISTED, but the on-disk target is proven NOT ours. Leaving the
+          // tab bound to it is itself a data-loss setup: a later plain Save (no new
+          // name) takes the in-place branch, and ComfyUI's persisted save uses
+          // overwrite:this.isPersisted → it would SILENTLY OVERWRITE the foreign file.
+          // So IDENTITY-SAFELY remove our copy and restore the previously-active
+          // workflow BEFORE surfacing the error — never retain ownership of a target
+          // we just proved isn't ours (#226).
+          removeInMemoryWorkflow(svc, copy);
+          if (prevActive !== undefined) svc.activeWorkflow = prevActive;
+          throw new Error(
+            `save-as reported success but "${finalTargetPath}" does not contain the saved ` +
+              `workflow — a concurrent save clobbered it (ComfyUI's /userdata write is not ` +
+              `exclusive-create). Retry with a new name (#226).`,
+          );
+        }
+      }
+      return resolvedName();
     };
   }
   return null;
@@ -616,52 +732,198 @@ async function probeTargetCollision(svc, wf, finalTargetPath, existsOnDisk) {
   return "no-oracle";
 }
 
-/** IDENTITY-SAFE removal of an in-memory (never-persisted) workflow copy from the
- *  store — used to undo an orphaned copy tab when its persist throws (#309).
+/** IDENTITY-SAFE removal of a workflow copy from the store — used to undo an
+ *  orphaned/clobbered copy tab (#309/#226). The IN-MEMORY record is dropped; the
+ *  copy's on-disk file is NEVER deleted.
  *
- *  The store's path-keyed removers (the real 1.47 `closeWorkflow` does
- *  `delete workflowLookup[wf.path]`) would evict WHATEVER currently occupies
- *  `wf.path`. If a DISTINCT late occupant claimed that path while we awaited
- *  openWorkflow/saveWorkflow, closing by path would delete IT (orphaning its unsaved
- *  graph, a data loss #226). So the path-keyed removers are used ONLY when the store
- *  lookup STILL points to `wf`; otherwise `wf` is spliced out of the open-tab arrays
- *  by IDENTITY and the occupant's lookup entry is left untouched. */
+ *  Two hazards this navigates:
+ *   1. LATE OCCUPANT — the store's path-keyed removers (the real 1.47 `closeWorkflow`
+ *      does `delete workflowLookup[wf.path]`) would evict WHATEVER occupies `wf.path`.
+ *      If a DISTINCT late occupant claimed that path while we awaited, closing by path
+ *      would delete IT. So path-keyed removal runs ONLY when the store lookup STILL
+ *      points to `wf`; otherwise `wf` is spliced out of the open-tab arrays by
+ *      IDENTITY and the occupant's lookup entry is left untouched.
+ *   2. PERSISTED COPY LINGERS — ComfyUI 1.47's `closeWorkflow` deletes the lookup
+ *      entry ONLY for a TEMPORARY workflow (`get isTemporary(){return size===-1}`); a
+ *      PERSISTED one is merely `unload()`ed and its record STAYS in workflowLookup,
+ *      where it would block a future Save-As to that name. When our copy is persisted
+ *      (a reported-success write set its `size`), we COERCE it back to temporary
+ *      (`size = -1`) BEFORE closing so `closeWorkflow`'s temporary branch fully purges
+ *      the lookup — an IN-MEMORY-only change; `closeWorkflow` never touches disk. */
 function removeInMemoryWorkflow(svc, wf) {
   if (!svc || !wf) return;
-  // Does the store's path→object lookup still point at OUR copy?
-  let stillOurs = true;
-  if (typeof svc.getWorkflowByPath === "function") {
+  // Proxy-safe "is this record OUR copy?": read the record's token (reflected
+  // through Vue's reactive proxy) and compare to ours. Falls back to `===` only when
+  // our copy carries no token (un-stamped callers/tests).
+  const lookupIsOurs = () => {
+    if (typeof svc.getWorkflowByPath !== "function") return null; // unknown
     try {
-      stillOurs = svc.getWorkflowByPath(wf.path) === wf;
+      return isSameCopy(wf, svc.getWorkflowByPath(wf.path));
     } catch {
-      stillOurs = false; // can't confirm ⇒ don't risk a path-keyed delete
+      return null; // unknown
     }
-  }
+  };
+  // Does the store's path→object lookup still point at OUR copy?
+  const stillOurs = lookupIsOurs() === true;
   if (stillOurs) {
+    // Coerce to TEMPORARY so the store's path-keyed removal fully purges the lookup
+    // entry even for a copy that a successful write marked persisted (#226). `size`
+    // === -1 is the frontend's temporary marker; flipping it changes only the
+    // in-memory record — the on-disk file is untouched by closeWorkflow.
+    safeAssign(wf, "size", -1);
+    safeAssign(wf, "isTemporary", true);
+    safeAssign(wf, "isPersisted", false);
     if (typeof svc.closeWorkflow === "function") {
       try {
         svc.closeWorkflow(wf);
-        return;
+        if (lookupIsOurs() !== true) return; // purged (or unknown) ⇒ done
       } catch {
-        /* fall through to identity splice */
+        /* fall through */
       }
     }
     if (typeof svc.removeWorkflow === "function") {
       try {
         svc.removeWorkflow(wf);
-        return;
+        if (lookupIsOurs() !== true) return;
       } catch {
-        /* fall through to identity splice */
+        /* fall through */
       }
     }
   }
-  // Identity-only cleanup: remove OUR object from the known list arrays without
-  // touching any path-keyed lookup entry a distinct occupant may now own.
+  // Identity-only cleanup: remove OUR object from the known list arrays. Match by the
+  // proxy-safe token (the arrays may hold the REACTIVE PROXY, not the raw copy), so a
+  // distinct occupant is never touched.
   for (const listName of ["openWorkflows", "workflows"]) {
     const list = svc[listName];
     if (Array.isArray(list)) {
-      const i = list.indexOf(wf);
-      if (i >= 0) list.splice(i, 1);
+      for (let i = list.length - 1; i >= 0; i--) {
+        if (isSameCopy(wf, list[i])) list.splice(i, 1);
+      }
     }
   }
+}
+
+/** Structural (best-effort) equality of two graph states, via a stable JSON encode.
+ *  Only a fallback for builds/doubles without ChangeTracker.updateModified. */
+function stateContentEqual(a, b) {
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+}
+
+/** Mark an ADOPTED copy (whose write committed but whose response was lost, #309 P2)
+ *  as a normal PERSISTED workflow — mirroring the bookkeeping a SUCCESSFUL saveWorkflow
+ *  does. On ComfyUI 1.47 `isTemporary` / `isPersisted` are DERIVED getters (isTemporary
+ *  === size===-1), so assigning them is a no-op — the REAL field is `size`.
+ *
+ *  For the MODIFIED flag the baseline MUST be the COMMITTED SNAPSHOT (what was written
+ *  to disk — the content the write used, i.e. `copy.content`), NOT the current live
+ *  activeState. A plain `changeTracker.reset()` re-baselines to activeState, which is
+ *  WRONG when the user edited the graph DURING the save await: activeState advanced past
+ *  what committed, so resetting-to-activeState marks that UNSAVED edit "clean" and
+ *  workflow_close then silently UNLOADS it (data loss). Instead we set the tracker's
+ *  baseline to the committed snapshot and RECOMPUTE isModified from (committed vs live
+ *  activeState): clean iff the canvas still equals what was saved, else DIRTY — exactly
+ *  what a real save leaves. All best-effort / getter-safe / in-memory only. */
+function markCopyPersisted(copy) {
+  if (!copy || typeof copy !== "object") return;
+  try {
+    if (copy.size === -1 || copy.size == null) {
+      const len = typeof copy.content === "string" ? copy.content.length : 0;
+      copy.size = len > 0 ? len : 1; // any non-(-1) value ⇒ isTemporary false
+    }
+  } catch {
+    /* size not settable ⇒ best-effort */
+  }
+  try {
+    if (typeof copy.content === "string") copy.originalContent = copy.content;
+  } catch {
+    /* best-effort */
+  }
+  // Baseline the change tracker to the COMMITTED SNAPSHOT, then recompute modified.
+  try {
+    const ct = copy.changeTracker;
+    if (ct && typeof copy.content === "string") {
+      let committed;
+      try {
+        committed = JSON.parse(copy.content);
+      } catch {
+        committed = undefined;
+      }
+      if (committed !== undefined) {
+        ct.initialState = committed; // baseline := the SAVED snapshot (not live activeState)
+        // Set isModified DIRECTLY on OUR copy — do NOT call ct.updateModified(), which on
+        // 1.47 RE-RESOLVES the workflow by `this.workflow.path` and writes isModified on
+        // whatever object occupies that path. A distinct late occupant that claimed the
+        // path during the reconcile await would be wrongly marked clean → workflow_close
+        // could then unload ITS unsaved graph (#226). Compute clean = (committed baseline
+        // equals live activeState) using the frontend's own graphEqual when reachable
+        // (via the tracker class) for precision, else a JSON structural compare — but
+        // only when we actually have a live activeState to compare against.
+        if (ct.activeState !== undefined) {
+          const graphEqual =
+            typeof ct.constructor?.graphEqual === "function" ? ct.constructor.graphEqual : null;
+          let clean;
+          try {
+            clean = graphEqual
+              ? graphEqual(committed, ct.activeState)
+              : stateContentEqual(committed, ct.activeState);
+          } catch {
+            clean = stateContentEqual(committed, ct.activeState);
+          }
+          safeAssign(copy, "isModified", !clean);
+        }
+      }
+    }
+  } catch {
+    /* best-effort */
+  }
+  safeAssign(copy, "isPersisted", true);
+  safeAssign(copy, "isTemporary", false);
+}
+
+// A stable, proxy-safe token stamped on each Save-As COPY so later cleanup can
+// identify "our copy" even when the store returns a Vue reactive PROXY (which is not
+// `===` the raw object). Reading the token through the proxy reflects the raw value.
+const COPY_TOKEN_KEY = "__cmcpSaveCopyToken";
+let copyTokenCounter = 0;
+function stampCopyToken(copy) {
+  if (!copy || typeof copy !== "object") return;
+  try {
+    // Non-enumerable so it never leaks into spreads/Object.keys/serialization. (The
+    // workflow's disk content is serialized from changeTracker.activeState, not this
+    // object, so a token here can never reach disk regardless.)
+    Object.defineProperty(copy, COPY_TOKEN_KEY, {
+      value: `cmcp-copy-${Date.now()}-${++copyTokenCounter}`,
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+  } catch {
+    /* frozen/sealed ⇒ token-less; isSameCopy falls back to === */
+  }
+}
+
+/** True when `candidate` (possibly a reactive proxy read back from the store) is OUR
+ *  copy `wf`. Prefers the stable stamped token (reflected through the proxy); falls
+ *  back to object identity only when `wf` carries no token. Never matches a distinct
+ *  record that lacks our token. */
+function isSameCopy(wf, candidate) {
+  if (!candidate) return false;
+  let token;
+  try {
+    token = wf?.[COPY_TOKEN_KEY];
+  } catch {
+    token = undefined;
+  }
+  if (token != null) {
+    try {
+      return candidate[COPY_TOKEN_KEY] === token;
+    } catch {
+      return false;
+    }
+  }
+  return candidate === wf; // fallback: un-stamped copy
 }

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -146,6 +146,52 @@ export async function saveActiveWorkflow(svc, name, { autoWorkflowName, existsOn
     // UNKNOWN must FAIL SAFE (refuse) — we only ever take a move path when the
     // source is PROVABLY never-persisted (no backing file to destroy).
     const sourcePath = wf.path;
+
+    // #309 — PRE-EMPT a filename collision BEFORE invoking any save/copy API. If the
+    // resolved target already exists on disk, the /userdata write would 409, and the
+    // frontend's saveWorkflowAs rebinds the tab (or the low-level path orphans a copy
+    // tab) BEFORE that failure surfaces — stranding the tab bound to a file it can't
+    // own (which then tripped the #226 guard so it could not be saved under any other
+    // name). Detecting the collision up front means NOTHING is mutated: no rebind, no
+    // copy, and a clean conflict is returned. Only an AUTHORITATIVE positive from the
+    // disk oracle acts here; an absent/unknown oracle falls through to the post-write
+    // rollback net below. The oracle is the same /userdata HEAD the #226 classifier
+    // uses, so it is available on the real panel path.
+    if (typeof existsOnDisk === "function") {
+      let targetExists = null;
+      try {
+        targetExists = await existsOnDisk(finalTargetPath);
+      } catch {
+        targetExists = null; // probe failed ⇒ unknown ⇒ fall through to rollback net
+      }
+      if (targetExists === true) {
+        throw conflictError(effectiveName);
+      }
+    }
+
+    // #285 — EXTERNAL source: a real file loaded from an ABSOLUTE path OUTSIDE the
+    // managed workflows dir (panel_load_workflow path:<file>). Two hazards make the
+    // normal copy path unsafe here: (a) /userdata cannot prove/relocate an external
+    // path, so the disk oracle can't classify it; and (b) the high-level
+    // saveWorkflowAs writes into the source's own (unwritable) directory and MOVES
+    // a temporary — either would misplace or DESTROY the external original (#226).
+    // So copy the CURRENT graph into the USER workflows dir via the move-free,
+    // explicit-target low-level copy (saveAs + openWorkflow + saveWorkflow), which
+    // never references the source's on-disk file. If that copy API is unavailable,
+    // REFUSE rather than risk moving the external original.
+    if (isExternalWorkflowPath(sourcePath)) {
+      const copyToUserDir = resolveSaveAsCopy(svc, { explicitTargetOnly: true });
+      if (!copyToUserDir) {
+        throw new Error(
+          "save-as (copy) is unavailable on this frontend for an externally-loaded workflow; " +
+            "refusing to move or destroy the original file outside the workflows folder (issue #285/#226)",
+        );
+      }
+      return await withConflictRollback(svc, wf, effectiveName, () =>
+        copyToUserDir(wf, effectiveName, finalTargetPath),
+      );
+    }
+
     const cls = await classifySource(svc, wf, sourcePath, existsOnDisk);
 
     // Resolve the copy (Save-As) API across frontend versions. On 1.45.x the
@@ -173,8 +219,12 @@ export async function saveActiveWorkflow(svc, name, { autoWorkflowName, existsOn
       }
       // Copy path. For a persisted workflow this copies (new file, original
       // untouched); for a genuine (provably never-persisted) temporary it grounds
-      // the never-saved tab to a real file. No Save dialog.
-      const activeName = await saveAsCopy(wf, effectiveName, finalTargetPath);
+      // the never-saved tab to a real file. No Save dialog. Wrapped so a 409
+      // filename conflict rolls back any optimistic tab rebind instead of leaving
+      // the tab stranded on the conflicting path (#309).
+      const activeName = await withConflictRollback(svc, wf, effectiveName, () =>
+        saveAsCopy(wf, effectiveName, finalTargetPath),
+      );
       // BACKSTOP: if the copy relocated a persisted source anyway, fail LOUDLY
       // instead of reporting a phantom success (the prior fix's exact miss). Uses
       // the SAME tri-state rule as classifySource: only a SUCCESSFUL, affirmative
@@ -237,8 +287,13 @@ function confirmedAbsentAt(svc, rawPath) {
  *     `svc.saveAs(wf, path)` — which builds a NEW workflow object at `path`
  *     (fresh id, source object and its file untouched) and returns it — plus
  *     `svc.saveWorkflow(copy)` to persist that copy. We drive them together. */
-function resolveSaveAsCopy(svc) {
-  if (typeof svc?.saveWorkflowAs === "function") {
+function resolveSaveAsCopy(svc, { explicitTargetOnly = false } = {}) {
+  // The high-level `saveWorkflowAs(wf, { filename })` writes into the SOURCE's own
+  // directory and can MOVE a temporary — it cannot honour an explicit target path.
+  // For an EXTERNAL source (whose copy must land in the user workflows dir, never
+  // the source's unwritable external folder), the caller passes explicitTargetOnly
+  // so ONLY the move-free, explicit-path low-level copy is selected (#285).
+  if (!explicitTargetOnly && typeof svc?.saveWorkflowAs === "function") {
     return async (wf, effectiveName) => {
       await svc.saveWorkflowAs(wf, { filename: effectiveName });
       // saveWorkflowAs makes the new copy the active workflow.
@@ -271,9 +326,22 @@ function resolveSaveAsCopy(svc) {
       // (loads the graph into changeTracker/activeState, makes it active), THEN
       // persist — so save() writes the real graph, not null. A throw here aborts
       // BEFORE any saveWorkflow, so a failed open never persists null.
-      await svc.openWorkflow(copy);
-      copy.changeTracker?.prepareForSave?.();
-      await svc.saveWorkflow(copy);
+      //
+      // If OPEN or PERSIST throws (e.g. saveWorkflow 409s on a name collision), the
+      // copy exists only IN MEMORY (nothing was written to disk). Remove that
+      // orphaned copy tab and restore the previously-active workflow so a failed
+      // persist doesn't strand a phantom unsaved tab in the store (#309); then
+      // rethrow so withConflictRollback can surface a clean conflict.
+      const prevActive = svc.activeWorkflow;
+      try {
+        await svc.openWorkflow(copy);
+        copy.changeTracker?.prepareForSave?.();
+        await svc.saveWorkflow(copy);
+      } catch (err) {
+        removeInMemoryWorkflow(svc, copy);
+        if (prevActive !== undefined) svc.activeWorkflow = prevActive;
+        throw err;
+      }
       return baseName(svc.activeWorkflow?.filename) || baseName(copy.filename) || effectiveName;
     };
   }
@@ -371,11 +439,31 @@ async function classifySource(svc, wf, rawPath, existsOnDisk) {
   return "unknown";
 }
 
+/** The managed user workflows root — the only directory ComfyUI's /userdata API
+ *  can write to. Store paths are always relative under it ("workflows/…"). */
+const WORKFLOWS_ROOT = "workflows";
+
+/** True when `path` is an ABSOLUTE filesystem path — a Windows drive ("C:\\", "C:/"),
+ *  a UNC share ("\\\\server"), or a POSIX absolute ("/…"). Such a path is a workflow
+ *  loaded from OUTSIDE the managed workflows dir (panel_load_workflow path:<file>);
+ *  it can never be a /userdata store path, so a Save-As of it must copy into the
+ *  user workflows dir rather than the unwritable external directory (#285). Only
+ *  absolute paths qualify — a relative "workflows/…" store path is never external,
+ *  so the everyday save path is untouched. */
+function isExternalWorkflowPath(path) {
+  const raw = String(path || "");
+  if (!raw) return false;
+  return /^[a-zA-Z]:[\\/]/.test(raw) || /^[\\/]{2}/.test(raw) || /^\//.test(raw);
+}
+
 /** Directory prefix (with trailing slash) that a new sibling file should live in,
- *  preserving the workflow's containing folder. Defaults to the workflows root. */
+ *  preserving the workflow's containing folder. An EXTERNAL (absolute) source
+ *  directory is unwritable via /userdata, so its Save-As copy is redirected to the
+ *  user workflows root (#285). Defaults to the workflows root. */
 function directoryOf(wf) {
   const dir = String(wf?.directory || "").replace(/[\\/]+$/, "");
-  return dir ? `${dir}/` : "workflows/";
+  if (!dir || isExternalWorkflowPath(dir)) return `${WORKFLOWS_ROOT}/`;
+  return `${dir}/`;
 }
 
 /** Normalize a workflow path for a stable same-file comparison: forward slashes,
@@ -392,4 +480,109 @@ async function saveInPlace(svc, wf) {
   if (typeof svc.saveWorkflow === "function") await svc.saveWorkflow(wf);
   else if (typeof wf.save === "function") await wf.save();
   else throw new Error("workflow save API unavailable on this frontend");
+}
+
+/** True when `err` is a name-collision (HTTP 409) from the userdata write — the
+ *  target filename already exists on disk (#309). Recognised by an explicit
+ *  status field or the conflict wording ComfyUI's /userdata surfaces. */
+function isConflictError(err) {
+  if (!err) return false;
+  const status = err.status ?? err.statusCode ?? err.response?.status;
+  if (status === 409) return true;
+  const msg = String(err?.message ?? err).toLowerCase();
+  return msg.includes("409") || msg.includes("conflict") || msg.includes("already exists");
+}
+
+/** The clean, uniform filename-conflict error surfaced by both the pre-check and
+ *  the post-write rollback (#309). */
+function conflictError(desiredName) {
+  const nm = baseName(desiredName) || "that name";
+  return new Error(
+    `a workflow named "${nm}" already exists (409 Conflict) — choose a different name. ` +
+      `The active tab was left unchanged (issue #309).`,
+  );
+}
+
+/** Assign `obj[key] = value` WITHOUT throwing. Real ComfyUI workflow objects expose
+ *  DERIVED, getter-only flags (`get isTemporary(){return this.size===-1}`, etc.), and
+ *  a plain assignment to those throws a TypeError under ES-module strict mode — which
+ *  would replace the clean 409 and abort the rest of the rollback. Getter-only /
+ *  frozen properties are silently skipped: they are computed from store state we do
+ *  not restore here, so leaving them be is correct (restoring `path`/`filename` and
+ *  the active reference is what un-strands the tab). */
+function safeAssign(obj, key, value) {
+  try {
+    obj[key] = value;
+  } catch {
+    /* getter-only / non-writable — nothing to restore for a derived flag */
+  }
+}
+
+/** Run a relocating save (`fn`) and, on a 409 filename CONFLICT that slips past the
+ *  up-front pre-check (e.g. no disk oracle, or a TOCTOU race), ROLL BACK any
+ *  optimistic in-memory rebind before surfacing a clean error (#309).
+ *
+ *  The frontend's saveWorkflowAs renames/rebinds the active tab to the target path
+ *  BEFORE its server write; when that write 409s (name already exists) the tab was
+ *  left stranded — bound to a file it can't own and flagged unsaved, which then
+ *  tripped the #226 guard so it could no longer be saved under ANY other name
+ *  without a manual rename. We snapshot the tab's identity + the active reference up
+ *  front and, on a conflict, restore the ACTIVE REFERENCE FIRST (always settable),
+ *  then best-effort restore the settable identity fields (`path`/`filename`), so
+ *  panel_list_workflows shows the tab as it was and a re-save under a new name works.
+ *  Derived getter-only flags are skipped via safeAssign so restoration never throws.
+ *  A non-conflict error is rethrown untouched. Nothing on disk is modified here — a
+ *  409 means the server wrote nothing, and the pre-existing file is never our source. */
+async function withConflictRollback(svc, wf, desiredName, fn) {
+  const prevActive = svc?.activeWorkflow;
+  const snap = wf
+    ? {
+        path: wf.path,
+        filename: wf.filename,
+        key: wf.key,
+        directory: wf.directory,
+        isTemporary: wf.isTemporary,
+        isPersisted: wf.isPersisted,
+      }
+    : null;
+  try {
+    return await fn();
+  } catch (err) {
+    if (!isConflictError(err)) throw err;
+    // Restore the active reference FIRST — it is a plain store field and is the
+    // load-bearing fix (the conflicting/copy tab must not remain active), so it
+    // must happen even if a later field restore is a no-op.
+    if (svc && prevActive !== undefined) svc.activeWorkflow = prevActive;
+    if (wf && snap) {
+      safeAssign(wf, "path", snap.path);
+      safeAssign(wf, "filename", snap.filename);
+      if ("key" in wf) safeAssign(wf, "key", snap.key);
+      safeAssign(wf, "directory", snap.directory);
+      safeAssign(wf, "isTemporary", snap.isTemporary);
+      safeAssign(wf, "isPersisted", snap.isPersisted);
+    }
+    throw conflictError(desiredName);
+  }
+}
+
+/** Best-effort removal of an in-memory (never-persisted) workflow copy from the
+ *  store, used to undo an orphaned copy tab when its persist throws (#309). Prefers
+ *  a store close/remove API; falls back to splicing the known list arrays. */
+function removeInMemoryWorkflow(svc, wf) {
+  if (!svc || !wf) return;
+  if (typeof svc.closeWorkflow === "function") {
+    svc.closeWorkflow(wf);
+    return;
+  }
+  if (typeof svc.removeWorkflow === "function") {
+    svc.removeWorkflow(wf);
+    return;
+  }
+  for (const listName of ["openWorkflows", "workflows"]) {
+    const list = svc[listName];
+    if (Array.isArray(list)) {
+      const i = list.indexOf(wf);
+      if (i >= 0) list.splice(i, 1);
+    }
+  }
 }


### PR DESCRIPTION
Closes #285
Closes #309
Closes #289

## Summary

Three panel save/registry edge fixes, all preserving the #226 (never move/destroy an original) and #458 (add_node fail-closed) invariants.

### #285 — external-path Save-As
`panel_save_workflow` could not Save-As a workflow loaded from an EXTERNAL absolute path (outside the managed `workflows/` dir, via `panel_load_workflow path:<file>`). The copy now targets the USER `workflows/` dir via the move-free, explicit-target low-level copy (`saveAs` + `openWorkflow` + `saveWorkflow`); the external original file is never moved/destroyed. If no move-free copy API is available, it refuses rather than risk a move. `directoryOf` redirects an absolute source directory to the workflows root; only absolute paths are treated as "external" so relative store paths are unaffected.

### #309 — clean 409 conflict handling
A Save-As whose `/userdata` write 409-conflicts (name already exists) no longer strands the tab bound to the conflicting path (which then tripped the #226 guard, blocking any re-save). Two layers:
- **Pre-check**: when the disk oracle is available (the panel always passes it), a name collision is detected BEFORE any save/copy API runs, so nothing is mutated — no rebind, no copy.
- **Rollback net**: for the no-oracle / TOCTOU case, `withConflictRollback` restores the active reference first, then best-effort restores settable identity fields via `safeAssign` (real ComfyUI workflow flags `isTemporary`/`isPersisted`/`key` are getter-only — a plain assignment would throw `TypeError` and abort the rollback). The 1.47 low-level adapter also removes an orphaned copy tab and restores the prior active workflow if the persist throws.

### #289 — refresh stale node-def cache for add_node
`panel_add_node` failed with "Unknown node type" for a freshly-installed pack because the frontend node-def cache is stale after install+restart. `graph_add_node` now refreshes node defs (re-fetch `/object_info` + re-register) ONCE and re-checks before rejecting a type. A type the server still doesn't define after a refresh stays unresolved and fails closed (#458) — the refresh never fabricates a type or placeholder.

## Tests
- `node-resolve.test.mjs`: stale-cache refresh resolves a fresh type; genuinely-unknown / unreachable / throwing-refresh all still fail closed.
- `workflow-save.test.mjs`: external Save-As copies into the user dir without destroying the original (+ refuses safely when only a moving copy API exists); 409 pre-empted before any rebind + re-save succeeds; getter-only rollback never throws; low-level orphan copy cleaned up.
- `frontend-contract.test.mjs`: contract updated for the optional `removeWorkflow` cleanup.
- All 558 unit tests pass; `tsc --noEmit` clean; ESM parses.

## Review
Codex adversarial review to **VERDICT: PASS** (re-review after fixing a P1 it caught: the getter-only rollback `TypeError` and the orphaned-copy path — both now fixed and verified against the installed ComfyUI 1.47.11 frontend store).

No version bump.