### PR TITLE
fix(manager): panel_update_node reports Manager task failure instead of false success (#364)

### DIFF
--- a/browser_tests/unit/manager-update-verify.test.mjs
+++ b/browser_tests/unit/manager-update-verify.test.mjs
@@ -1,0 +1,156 @@
+// Unit tests for #364: panel_update_node must report a REAL failure when the
+// ComfyUI-Manager update task actually failed, instead of a blind queued:true.
+// The aggregate /v2/manager/queue/status endpoint marks a CRASHED do_update
+// "done" (it still counts toward done_count), so the authoritative verdict lives
+// in the per-task history (/v2/manager/queue/history). These tests exercise the
+// pure interpretation helpers (web/js/lib/manager-install.js) against the exact
+// wire shapes the live Manager v4 emits (data_models: OperationResult =
+// success|failed|skipped|error|skip; TaskExecutionStatus = {status_str, completed,
+// messages}; the worker records status_str="error" + messages=[exc] on a crash).
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  taskFailureReason,
+  taskSucceeded,
+  parseTaskHistoryItem,
+  collectRecentTaskFailures,
+  classifyUpdateOutcome,
+} from "../../web/js/lib/manager-install.js";
+
+// The exact record the worker writes on the #364 crash: do_update raised
+// AttributeError, so the worker's except-branch calls task_done with
+// status_str="error" and the exception text in messages.
+const CRASH_ITEM = {
+  ui_id: "u-crash",
+  client_id: "comfyui-mcp-panel",
+  kind: "update",
+  result: "Exception: ('update', QueueTaskItem(...))",
+  status: {
+    status_str: "error",
+    completed: true,
+    messages: [
+      "Exception: 'InstallPackParams' object has no attribute 'node_name'",
+    ],
+  },
+  params: { node_name: "ComfyUI-GGUF", id: "ComfyUI-GGUF" },
+};
+
+const SUCCESS_ITEM = {
+  ui_id: "u-ok",
+  kind: "update",
+  result: "success",
+  status: { status_str: "success", completed: true, messages: [] },
+  params: { node_name: "ComfyUI-GGUF" },
+};
+
+const SKIP_ITEM = {
+  ui_id: "u-skip",
+  kind: "update",
+  result: "skip",
+  status: { status_str: "skip", completed: true, messages: [] },
+  params: { node_name: "ComfyUI-GGUF" },
+};
+
+test("taskFailureReason surfaces the crash reason ONLY for a failure terminal", () => {
+  assert.equal(
+    taskFailureReason(CRASH_ITEM),
+    "Exception: 'InstallPackParams' object has no attribute 'node_name'",
+  );
+  // failed status with no messages falls back to result, then a generic reason.
+  assert.equal(
+    taskFailureReason({ status: { status_str: "failed" }, result: "boom" }),
+    "boom",
+  );
+  assert.match(
+    taskFailureReason({ status: { status_str: "failed" } }),
+    /reported the task as failed/,
+  );
+  // Never a false failure: success / skip / running / unknown / junk ⇒ null.
+  assert.equal(taskFailureReason(SUCCESS_ITEM), null);
+  assert.equal(taskFailureReason(SKIP_ITEM), null);
+  assert.equal(taskFailureReason({ status: { status_str: "success" } }), null);
+  assert.equal(taskFailureReason(null), null);
+  assert.equal(taskFailureReason({}), null);
+  assert.equal(taskFailureReason("done"), null);
+});
+
+test("taskSucceeded is true ONLY for success/skip terminals", () => {
+  assert.equal(taskSucceeded(SUCCESS_ITEM), true);
+  assert.equal(taskSucceeded(SKIP_ITEM), true);
+  assert.equal(taskSucceeded({ status: { status_str: "skipped" } }), true);
+  assert.equal(taskSucceeded(CRASH_ITEM), false);
+  assert.equal(taskSucceeded({ status: { status_str: "error" } }), false);
+  assert.equal(taskSucceeded(null), false);
+  assert.equal(taskSucceeded({}), false);
+});
+
+test("parseTaskHistoryItem handles the ui_id-queried single-item shape", () => {
+  // ui_id-queried: server returns { history: <item> } (the item itself).
+  const resp = { history: CRASH_ITEM };
+  assert.equal(parseTaskHistoryItem(resp, "u-crash"), CRASH_ITEM);
+  // A mismatched embedded ui_id is rejected (defensive).
+  assert.equal(parseTaskHistoryItem(resp, "someone-else"), null);
+});
+
+test("parseTaskHistoryItem handles the map-keyed shape and absence", () => {
+  const resp = { history: { "u-crash": CRASH_ITEM, "u-ok": SUCCESS_ITEM } };
+  assert.equal(parseTaskHistoryItem(resp, "u-crash"), CRASH_ITEM);
+  assert.equal(parseTaskHistoryItem(resp, "u-ok"), SUCCESS_ITEM);
+  // Task not yet recorded (still running) ⇒ { history: {} } ⇒ null.
+  assert.equal(parseTaskHistoryItem({ history: {} }, "u-crash"), null);
+  assert.equal(parseTaskHistoryItem(null, "u-crash"), null);
+});
+
+// ---- The #364 regression: a failed update MUST NOT report success ----------
+
+test("classifyUpdateOutcome reports FAILURE for the crashed do_update task", () => {
+  const item = parseTaskHistoryItem({ history: CRASH_ITEM }, "u-crash");
+  const outcome = classifyUpdateOutcome({
+    item,
+    status: { total_count: 0, done_count: 1, in_progress_count: 0, is_processing: false },
+    target: "ComfyUI-GGUF",
+    dialect: "v2",
+  });
+  assert.equal(outcome.state, "failed");
+  // The Manager-side reason is surfaced verbatim.
+  assert.match(outcome.message, /FAILED/);
+  assert.match(outcome.message, /no attribute 'node_name'/);
+  assert.match(outcome.message, /ComfyUI-GGUF/);
+});
+
+test("classifyUpdateOutcome reports SUCCESS for a real success (no false failure)", () => {
+  for (const item of [SUCCESS_ITEM, SKIP_ITEM]) {
+    const outcome = classifyUpdateOutcome({ item, target: "ComfyUI-GGUF", dialect: "v2" });
+    assert.equal(outcome.state, "updated");
+  }
+});
+
+test("classifyUpdateOutcome stays UNVERIFIED (never a false failure) when inconclusive", () => {
+  // Task not yet terminal / legacy Manager without /v2 history / unknown shape.
+  for (const item of [null, undefined, {}, { status: { status_str: "in_progress" } }]) {
+    const outcome = classifyUpdateOutcome({ item, target: "ComfyUI-GGUF", dialect: "legacy" });
+    assert.equal(outcome.state, "unverified");
+    assert.match(outcome.message, /could NOT be confirmed/);
+    assert.doesNotMatch(outcome.message, /FAILED/);
+  }
+});
+
+test("collectRecentTaskFailures extracts only failures from a mixed history map", () => {
+  const hist = {
+    history: {
+      "u-ok": SUCCESS_ITEM,
+      "u-skip": SKIP_ITEM,
+      "u-crash": CRASH_ITEM,
+    },
+  };
+  const failures = collectRecentTaskFailures(hist);
+  assert.equal(failures.length, 1);
+  assert.equal(failures[0].ui_id, "u-crash");
+  assert.equal(failures[0].kind, "update");
+  assert.equal(failures[0].id, "ComfyUI-GGUF");
+  assert.match(failures[0].result, /no attribute 'node_name'/);
+  // Empty / malformed history ⇒ no failures (best-effort, never throws).
+  assert.deepEqual(collectRecentTaskFailures({ history: {} }), []);
+  assert.deepEqual(collectRecentTaskFailures(null), []);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -69,14 +69,19 @@ import { computeLayout } from "./lib/layout-engine.js";
 import {
   buildInstallRequest,
   classifyInstallOutcome,
+  classifyUpdateOutcome,
+  collectRecentTaskFailures,
   installGitUrl,
   installedListRoute,
   isManagerUnreachable,
   isMethodNotAllowed,
   legacyUpdateBody,
+  parseTaskHistoryItem,
   queueDrained,
   rebootCandidates,
   searchNodesVia,
+  taskFailureReason,
+  taskSucceeded,
 } from "./lib/manager-install.js";
 import {
   CHAT_HISTORY_MAX_IMPORT_BYTES,
@@ -2716,6 +2721,68 @@ async function verifyInstalled(target, dialect, { batchFailed, renameProne } = {
     listError = true;
   }
   return classifyInstallOutcome({ target, dialect, status, installed, listError, batchFailed, renameProne });
+}
+
+/** Budget for the post-enqueue update verification (#364). Bounded well under
+ *  the orchestrator's per-command timeout (panel_update_node calls with 30s) so
+ *  a genuine, slow update reports an honest "unverified/pending" rather than
+ *  timing the whole command out. A crashed do_update records its error terminal
+ *  within a poll or two, so this comfortably catches the false-success bug. */
+const UPDATE_VERIFY_BUDGET_MS = 15000;
+
+/**
+ * After an update is queued+started, resolve the task's TRUE terminal outcome by
+ * polling the Manager's PER-TASK history (by ui_id) — the authoritative signal
+ * the aggregate queue/status cannot give (a crashed `do_update` still increments
+ * done_count and looks "done", #364). Bounded: never runs past the deadline, and
+ * returns the last { item, status } seen (item null if the task never reached a
+ * terminal record in the window — legacy Manager without /v2 history, still
+ * running, or an unrecognized shape). Never throws — classifyUpdateOutcome
+ * re-derives the verdict, so an absent/unreadable record is "unverified", never
+ * a false verdict.
+ */
+async function waitForUpdateResult(ui_id, { timeoutMs = UPDATE_VERIFY_BUDGET_MS, intervalMs = 1200 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  const route = `manager/queue/history?ui_id=${encodeURIComponent(ui_id)}`;
+  let item = null;
+  let status = null;
+  const readHistory = async () => {
+    const perFetch = Math.max(1000, Math.min(MANAGER_FETCH_TIMEOUT_MS, deadline - Date.now()));
+    try {
+      const resp = await managerGet(route, { signal: AbortSignal.timeout(perFetch) });
+      return parseTaskHistoryItem(resp, ui_id);
+    } catch {
+      // history endpoint absent (legacy Manager) or transient — inconclusive.
+      return null;
+    }
+  };
+  const readStatus = async () => {
+    const perFetch = Math.max(1000, Math.min(MANAGER_FETCH_TIMEOUT_MS, deadline - Date.now()));
+    try {
+      return await managerGet("manager/queue/status", { signal: AbortSignal.timeout(perFetch) });
+    } catch {
+      return null;
+    }
+  };
+  // Give the worker a beat to pick up the task before the first history read.
+  await boundedDelay(800, deadline);
+  while (Date.now() < deadline) {
+    item = await readHistory();
+    // A terminal per-task record (success OR failure) ends the wait immediately.
+    if (item && (taskSucceeded(item) || taskFailureReason(item))) {
+      status = await readStatus();
+      return { item, status };
+    }
+    // No terminal record yet. If the queue has POSITIVELY drained the worker is
+    // done, so one last history read then stop — no point waiting out the budget.
+    status = await readStatus();
+    if (queueDrained(status)) {
+      item = await readHistory();
+      return { item, status };
+    }
+    await boundedDelay(intervalMs, deadline);
+  }
+  return { item, status };
 }
 
 /** Normalize an outbound image descriptor so its string-ish fields can never
@@ -7046,8 +7113,6 @@ const GRAPH_TOOL_EXECUTORS = {
     const dialect = await detectManagerDialect();
     const ui_id = crypto.randomUUID();
     const client_id = api.clientId ?? api.initialClientId ?? "comfyui-mcp-panel";
-    const note =
-      "Update queued. Poll nodes_queue_status; a ComfyUI restart (comfy_reboot) is usually required to load the updated node.";
     // #424: the absolute (no-/v2) legacy self-update route. Updating the
     // ComfyUI-Manager node ITSELF (id 'comfyui-manager') through a /v2 task or
     // batch envelope 405s on a legacy Manager — that POST /v2 route is a
@@ -7058,6 +7123,31 @@ const GRAPH_TOOL_EXECUTORS = {
       const body = legacyUpdateBody({ ui_id, id, version });
       await managerCall("manager/queue/update", { method: "POST", body });
       await managerCall("manager/queue/start", { method: "POST" });
+    };
+    // #364: after the task is queued+started, VERIFY its terminal per-task status
+    // instead of blindly reporting `queued:true`. The aggregate queue/status
+    // marks a CRASHED do_update "done" (it still increments done_count), so a
+    // Manager-side failure — e.g. `AttributeError: 'InstallPackParams' object has
+    // no attribute 'node_name'` — used to be reported as a success. classify the
+    // authoritative task-history record: a failure THROWS (surfaced to the agent
+    // as a real error with the Manager reason); a real success still reports
+    // success; anything inconclusive reports an honest "pending".
+    const finalizeUpdate = async (via) => {
+      const { item, status } = await waitForUpdateResult(ui_id);
+      const outcome = classifyUpdateOutcome({ item, status, target: id, dialect });
+      if (outcome.state === "failed") throw new Error(outcome.message);
+      const base = { queued: true, ui_id, id, version: sel, dialect, ...(via ? { via } : {}) };
+      if (outcome.state === "updated") {
+        return {
+          ...base,
+          updated: true,
+          verified: true,
+          note:
+            "Update applied and VERIFIED by the ComfyUI-Manager task. A ComfyUI restart " +
+            "(comfy_reboot) is usually required to load the updated node.",
+        };
+      }
+      return { ...base, updated: false, verified: false, pending: true, note: outcome.message };
     };
     if (dialect === "v2") {
       const params = {
@@ -7079,9 +7169,9 @@ const GRAPH_TOOL_EXECUTORS = {
       } catch (err) {
         if (!isMethodNotAllowed(err)) throw err;
         await legacyUpdate();
-        return { queued: true, ui_id, id, version: sel, dialect, via: "legacy-self-update", note };
+        return finalizeUpdate("legacy-self-update");
       }
-      return { queued: true, ui_id, id, version: sel, dialect, note };
+      return finalizeUpdate();
     }
     // v2-batch + legacy: 3.x update body {ui_id, id, version} (issues #187/#182).
     const body = { ui_id, id, version: sel };
@@ -7096,16 +7186,42 @@ const GRAPH_TOOL_EXECUTORS = {
       } catch (err) {
         if (!isMethodNotAllowed(err)) throw err;
         await legacyUpdate();
-        return { queued: true, ui_id, id, version: sel, dialect, via: "legacy-self-update", note };
+        return finalizeUpdate("legacy-self-update");
       }
     } else {
       await legacyUpdate();
     }
-    return { queued: true, ui_id, id, version: sel, dialect, note };
+    return finalizeUpdate();
   },
 
   async nodes_queue_status() {
-    return { status: await managerGet("manager/queue/status") };
+    const status = await managerGet("manager/queue/status");
+    // #364: the aggregate status cannot reveal a FAILED task — a crashed
+    // do_update still counts toward done_count and looks "done". Surface the
+    // recent per-task FAILURES from the Manager task history so a post-hoc poll
+    // of an idle queue does not read a silent "done" over a task that errored.
+    // Best-effort: a legacy Manager without /v2 history (or a transient error)
+    // just returns the status alone, exactly as before.
+    let recentFailures = [];
+    try {
+      const hist = await managerGet("manager/queue/history?max_items=20", {
+        signal: AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS),
+      });
+      recentFailures = collectRecentTaskFailures(hist);
+    } catch {
+      /* history endpoint absent/transient — status alone */
+    }
+    if (recentFailures.length) {
+      return {
+        status,
+        recent_failures: recentFailures,
+        note:
+          `${recentFailures.length} recent ComfyUI-Manager task(s) FAILED (see recent_failures). ` +
+          `A drained queue that shows "done" does NOT mean every task succeeded — check these ` +
+          `before reporting an install/update as successful.`,
+      };
+    }
+    return { status };
   },
 
   async comfy_reboot({ force } = {}) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7132,11 +7132,34 @@ const GRAPH_TOOL_EXECUTORS = {
     // authoritative task-history record: a failure THROWS (surfaced to the agent
     // as a real error with the Manager reason); a real success still reports
     // success; anything inconclusive reports an honest "pending".
+    //
+    // The per-task terminal record is ONLY reachable on the real pip Manager v4
+    // (the "v2" dialect), whose /v2/manager/queue/history?ui_id= returns the task
+    // by id. Released 3.x ("legacy") has NO per-task history endpoint, and the
+    // bundled 3.x server used in --enable-manager-legacy-ui mode ("v2-batch")
+    // serves only BATCH-file history keyed by `id` and REJECTS a ui_id query — so
+    // a per-ui_id poll there would just burn the budget and still learn nothing.
+    // For those dialects keep the fast queued result (a v2-batch failure is
+    // already caught synchronously by assertBatchOk) and report honest pending;
+    // the #364 crash is a v4 do_update, so "v2" is the path that matters.
     const finalizeUpdate = async (via) => {
+      const base = { queued: true, ui_id, id, version: sel, dialect, ...(via ? { via } : {}) };
+      if (dialect !== "v2") {
+        return {
+          ...base,
+          updated: false,
+          verified: false,
+          pending: true,
+          note:
+            "Update queued. This ComfyUI-Manager build does not expose a per-task result, " +
+            "so the outcome could not be auto-verified — poll panel_node_queue_status " +
+            "(which surfaces any recent task failure), then a ComfyUI restart (comfy_reboot) " +
+            "is usually required to load the updated node.",
+        };
+      }
       const { item, status } = await waitForUpdateResult(ui_id);
       const outcome = classifyUpdateOutcome({ item, status, target: id, dialect });
       if (outcome.state === "failed") throw new Error(outcome.message);
-      const base = { queued: true, ui_id, id, version: sel, dialect, ...(via ? { via } : {}) };
       if (outcome.state === "updated") {
         return {
           ...base,

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -488,3 +488,172 @@ export function rebootCandidates(dialect) {
     ? [legacyPost, v2, legacyGet]
     : [v2, legacyPost, legacyGet];
 }
+
+// ---------------------------------------------------------------------------
+// Per-task terminal-status interpretation (#364)
+//
+// The aggregate /v2/manager/queue/status endpoint CANNOT reveal a failed task:
+// a task that crashed (e.g. `do_update` raising AttributeError) is still moved
+// into history and still counts toward `done_count` — so the queue reports
+// `done_count:1 / is_processing:false` and looks exactly like a success. The
+// AUTHORITATIVE per-task verdict lives in the Manager task history
+// (/v2/manager/queue/history), where each task carries a
+// `status: { status_str, completed, messages }` and a `result` string. On a
+// crash the worker records `status.status_str = "error"` (or `"failed"`) with
+// the exception text in `messages`/`result`. These pure helpers interpret that
+// record so `graph_update_node` can report a REAL failure instead of a blind
+// `queued:true`, and so `nodes_queue_status` can surface recent task failures.
+// Kept standalone (no browser globals) for `node --test`.
+// ---------------------------------------------------------------------------
+
+/** Manager OperationResult values (data_models/generated_models.py):
+ *  success | failed | skipped | error | skip. "success"/"skip"/"skipped" are
+ *  non-failure terminals; "error"/"failed" are failures. */
+const TASK_SUCCESS_STATUS = new Set(["success", "skip", "skipped"]);
+const TASK_FAILURE_STATUS = new Set(["error", "failed"]);
+
+/** Is `v` a plausible Manager task-history ENTRY — a plain object carrying at
+ *  least one recognizable task field? Guards map/array traversal and the
+ *  single-item (ui_id-queried) shape against error envelopes and junk. */
+function isTaskHistoryItem(v) {
+  if (!v || typeof v !== "object" || Array.isArray(v)) return false;
+  return "status" in v || "result" in v || "kind" in v || "ui_id" in v;
+}
+
+/** The task's `status.status_str` (an OperationResult value) if present. */
+function taskStatusStr(item) {
+  const status = item && typeof item === "object" ? item.status : undefined;
+  const s = status && typeof status === "object" ? status.status_str : undefined;
+  return typeof s === "string" ? s : undefined;
+}
+
+/**
+ * POSITIVE failure reason for a Manager task-history item, or null when the item
+ * is NOT a definitive failure. A failure is asserted ONLY on an explicit failure
+ * terminal (`status.status_str` ∈ {error, failed}) — never inferred from a
+ * missing/unknown status (that stays inconclusive, so a task still running or a
+ * shape we don't recognize can never become a FALSE failure). Prefers the
+ * `status.messages` (the crash/exception text) for the reason, then `result`.
+ */
+export function taskFailureReason(item) {
+  if (!isTaskHistoryItem(item)) return null;
+  if (!TASK_FAILURE_STATUS.has(taskStatusStr(item))) return null;
+  const status = item.status;
+  const messages =
+    status && Array.isArray(status.messages)
+      ? status.messages.filter((m) => typeof m === "string" && m.trim())
+      : [];
+  if (messages.length) return messages.join("; ");
+  if (typeof item.result === "string" && item.result.trim() && item.result !== "success") {
+    return item.result;
+  }
+  return "the Manager reported the task as failed (no detail provided)";
+}
+
+/** POSITIVE success terminal — an explicit success/skip status. A skip ("already
+ *  up to date") is a legitimate no-op success for an update. */
+export function taskSucceeded(item) {
+  return isTaskHistoryItem(item) && TASK_SUCCESS_STATUS.has(taskStatusStr(item));
+}
+
+/**
+ * Extract the single task-history item for `ui_id` from a /v2/manager/queue/history
+ * response. Handles BOTH server shapes:
+ *   - ui_id-queried: `{ history: <item> }` (the item itself), and
+ *   - unfiltered/map: `{ history: { <ui_id>: <item>, … } }`.
+ * A bare item (already unwrapped) is accepted too. Returns null when absent
+ * (task not yet recorded) or malformed — the caller then stays "unverified".
+ */
+export function parseTaskHistoryItem(resp, ui_id) {
+  const history =
+    resp && typeof resp === "object" && "history" in resp ? resp.history : resp;
+  if (!history || typeof history !== "object") return null;
+  // Single-item (ui_id-queried) shape: the item carries task fields directly.
+  if (isTaskHistoryItem(history)) {
+    const own = typeof history.ui_id === "string" ? history.ui_id : undefined;
+    if (ui_id && own && own !== ui_id) return null;
+    return history;
+  }
+  // Map keyed by ui_id.
+  if (ui_id && isTaskHistoryItem(history[ui_id])) return history[ui_id];
+  return null;
+}
+
+/** The pack id a task acted on, for correlation in surfaced failures. */
+function taskParamId(item) {
+  const p = item && typeof item === "object" ? item.params : undefined;
+  if (p && typeof p === "object") {
+    for (const k of ["node_name", "id", "cnr_id", "aux_id"]) {
+      if (typeof p[k] === "string" && p[k].trim()) return p[k];
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Collect the FAILED tasks from a /v2/manager/queue/history response (map or
+ * array form) as compact `{ ui_id, kind, id, result }` records. Used by
+ * nodes_queue_status so a post-hoc poll of an idle queue does not read a silent
+ * "done" over a task that actually errored (#364). Only positive failures
+ * (taskFailureReason) are included; capped to the most recent `limit`.
+ */
+export function collectRecentTaskFailures(resp, { limit = 20 } = {}) {
+  const history =
+    resp && typeof resp === "object" && "history" in resp ? resp.history : resp;
+  if (!history || typeof history !== "object") return [];
+  const items = Array.isArray(history) ? history : Object.values(history);
+  const out = [];
+  for (const item of items) {
+    const reason = taskFailureReason(item);
+    if (!reason) continue;
+    out.push({
+      ui_id: typeof item.ui_id === "string" ? item.ui_id : undefined,
+      kind: typeof item.kind === "string" ? item.kind : undefined,
+      id: taskParamId(item),
+      result: reason,
+    });
+  }
+  return out.slice(-limit);
+}
+
+/**
+ * Decide the TRUE outcome of an UPDATE after it was queued+started (#364). Pure,
+ * unit-testable. Precedence guarantees neither a false success nor a false
+ * failure:
+ *   1. "failed"    — the per-task history item is an explicit failure terminal
+ *                    (status_str error/failed). Surfaces the Manager reason.
+ *   2. "updated"   — the per-task item is an explicit success/skip terminal.
+ *   3. "unverified"— no terminal task record yet (still running, history not
+ *                    served by a legacy Manager, or a shape we don't recognize).
+ *                    Honest "queued, could not confirm" — NEVER a failure.
+ * @param {{ item?:unknown, status?:unknown, target:string, dialect?:string }} input
+ */
+export function classifyUpdateOutcome({ item, status, target, dialect } = {}) {
+  const reason = taskFailureReason(item);
+  if (reason) {
+    return {
+      state: "failed",
+      status,
+      message:
+        `Update of "${target}" FAILED: the ComfyUI-Manager task terminated with an ` +
+        `error` +
+        (dialect ? ` (dialect ${dialect})` : "") +
+        `: ${reason}. The pack was NOT updated — check the ComfyUI server log for the ` +
+        `full traceback.`,
+    };
+  }
+  if (taskSucceeded(item)) {
+    return { state: "updated", status };
+  }
+  return {
+    state: "unverified",
+    status,
+    message:
+      `Update of "${target}" was queued but its outcome could NOT be confirmed` +
+      (dialect ? ` (dialect ${dialect})` : "") +
+      ` — the Manager task has not reported a terminal result. This is NOT a reported ` +
+      `failure. Poll panel_node_queue_status; a ComfyUI restart (comfy_reboot) is ` +
+      `usually required to load an updated node. If it still misbehaves, check the ` +
+      `ComfyUI server log.`,
+  };
+}


### PR DESCRIPTION
## Problem (#364)

`panel_update_node(id='ComfyUI-GGUF', version='nightly')` returned `queued:true` and `panel_node_queue_status` showed `done_count:1`, but the Manager task had actually **crashed** (`AttributeError: 'InstallPackParams' object has no attribute 'node_name'` in `manager_server.py do_update`). The panel surfaced **no failure** and made the update look successful.

### Root cause (error-interpretation gap, not the dialect gap)

- `graph_update_node` enqueued the Manager `update` task and returned `queued:true` **without ever checking whether the task succeeded**.
- `nodes_queue_status` was a bare passthrough of `/v2/manager/queue/status`.
- The aggregate queue-status endpoint **cannot** reveal a failed task: a crashed `do_update` is still moved into `history_tasks` and still counts toward `done_count`, so the queue reads `done_count:1 / is_processing:false` — identical to a success.

The authoritative per-task verdict lives in `/v2/manager/queue/history?ui_id=`, where each task carries `status.status_str` (`OperationResult`: `success|skip|skipped` vs `error|failed`) and `messages` (the crash text). The worker records a crashed `do_update` as `status_str="error"` with the exception in `messages`.

## Fix

- After the task is queued+started, **poll the per-task history by `ui_id`** and interpret the terminal status (`classifyUpdateOutcome`):
  - explicit `error`/`failed` → **throws** with the Manager-side reason (surfaced to the agent as a real failure — `graph_update_node` no longer reports false success);
  - explicit `success`/`skip` → reports success (honest-reporting invariant preserved — no false failure);
  - no terminal record yet → honest `pending`.
- **Bounded**: `UPDATE_VERIFY_BUDGET_MS = 15000`, comfortably under the orchestrator's 30s per-command timeout, with a `queueDrained` short-circuit and per-fetch `AbortSignal` — so a genuinely slow update never false-times-out and the poll can never hang.
- **Dialect-scoped**: per-task terminal polling runs only for the real pip Manager v4 (`v2` dialect) that serves the endpoint. `legacy` (no per-task history) and `v2-batch` (batch-file history keyed by `id`, rejects `ui_id`) keep the fast queued path — a `v2-batch` failure is already caught synchronously by `assertBatchOk`. The `#424` legacy-self-update fallback routing is preserved.
- `nodes_queue_status` additionally surfaces recent per-task failures (`recent_failures`) so a post-hoc poll of an idle queue doesn't read a silent "done" over a task that errored.

New pure, unit-tested helpers in `web/js/lib/manager-install.js`: `taskFailureReason`, `taskSucceeded`, `parseTaskHistoryItem`, `collectRecentTaskFailures`, `classifyUpdateOutcome` — tested against the exact live Manager v4 wire shapes.

## Verification

- New suite `browser_tests/unit/manager-update-verify.test.mjs` (8 tests): fail-before/pass-after on the crashed-`do_update` terminal record → **failure with the reason** (not success); real success/skip → success; inconclusive → unverified, never a false failure.
- Full unit suite green (556 tests), `tsc --noEmit` clean, ESM parse clean, no `onload`/`onerror` tokens (YARA).
- Adversarial codex review: **VERDICT: PASS** (a first pass flagged a legacy/v2-batch latency regression; the dialect gating above resolved it).

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)
