### PR TITLE
fix(subgraph): mirror promoted-widget writes onto the parent rail widget (#366)

### DIFF
--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -367,12 +367,20 @@ function makeSubgraphFixture(innerType = "KSampler") {
     constructor: { nodeData: { input: { required: {} } } },
   };
   const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "54" ? inner : null) };
+  // AUTHORITATIVE rail projection, identity-linked from the host input (#366).
+  const railWidget = { name: "sched_alias", type: "combo", options: { values: ["simple", "karras"] }, value: "simple" };
   const parent = {
     id: 66,
     type: "SubgraphNode",
     subgraph,
-    inputs: [{ name: "sched_alias", _subgraphSlot: { name: "sched_alias" } }],
-    widgets: [{ name: "scheduler", type: "combo", options: { values: ["simple"] }, value: 999 }],
+    // Host input carries the OBJECT-IDENTITY link (`_widget`) to the parent's own
+    // authoritative rail projection (#366) — what serializes at queue time.
+    inputs: [{ name: "sched_alias", _widget: railWidget, _subgraphSlot: { name: "sched_alias" } }],
+    widgets: [
+      // Decoy own-widget named after the INNER source — must stay untouched (#233).
+      { name: "scheduler", type: "combo", options: { values: ["simple"] }, value: 999 },
+      railWidget,
+    ],
   };
   const resolveSource = (_n, si) =>
     si?.name === "sched_alias" ? { sourceNodeId: "54", sourceWidgetName: "scheduler" } : null;

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -303,9 +303,13 @@ test("stuck-check fails when a widget callback drifts the value (#240)", () => {
 /**
  * Parent SubgraphNode over an inner KSampler. The promotion has been RENAMED:
  * the OUTER promoted widget the caller sees is "sched_alias" but it maps to the
- * inner "scheduler" widget. The parent ALSO has a decoy own-widget literally
- * named "scheduler" (the shifted-slot corruption vector) — a correct write must
- * never touch it. `resolveSource` mimics the live subgraph link walk.
+ * inner "scheduler" widget. The parent's AUTHORITATIVE rail widget is the litegraph
+ * PROJECTION object linked to the host input via `input._widget` (object identity)
+ * and present in `parent.widgets` — that is what serializes at queue time. There is
+ * ALSO a decoy own-widget literally named "scheduler" (the inner source name, the
+ * shifted-slot corruption vector) — a correct write syncs the rail projection by
+ * IDENTITY and never touches the decoy. `input.widget` is only a `{ name }` stub, as
+ * in real ComfyUI. `resolveSource` mimics the live subgraph link walk.
  */
 function makeSubgraphFixture() {
   const inner = {
@@ -321,22 +325,30 @@ function makeSubgraphFixture() {
     ],
   };
   const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "54" ? inner : null) };
+  // The AUTHORITATIVE rail projection (identity-linked from the host input).
+  const railWidget = { name: "sched_alias", type: "combo", options: { values: ["simple", "karras"] }, value: "simple" };
   const parent = {
     id: 66,
     type: "SubgraphNode",
     subgraph,
     inputs: [
-      // OUTER alias "sched_alias" (renamed) → inner "scheduler".
-      { name: "sched_alias", _subgraphSlot: { name: "sched_alias" } },
+      // OUTER alias "sched_alias" (renamed) → inner "scheduler". `_widget` is the
+      // OBJECT-IDENTITY link to the parent's authoritative rail projection; `widget`
+      // is only a name stub (real ComfyUI shape).
+      { name: "sched_alias", _widget: railWidget, widget: { name: "sched_alias" }, _subgraphSlot: { name: "sched_alias" } },
     ],
-    // Decoy shifted parent slot named "scheduler" — must stay untouched.
-    widgets: [{ name: "scheduler", type: "combo", options: { values: ["simple"] }, value: 999 }],
+    widgets: [
+      // Decoy own-widget named after the INNER source — must stay untouched (#233).
+      { name: "scheduler", type: "combo", options: { values: ["simple"] }, value: 999 },
+      // AUTHORITATIVE parent rail projection (===-linked from the host input).
+      railWidget,
+    ],
   };
   const resolveSource = (_node, subgraphInput) =>
     subgraphInput?.name === "sched_alias"
       ? { sourceNodeId: "54", sourceWidgetName: "scheduler" }
       : null;
-  return { parent, inner, resolveSource };
+  return { parent, inner, railWidget, resolveSource };
 }
 
 test("promoted (renamed) widget resolves to the correct INNER node + widget", () => {
@@ -347,7 +359,7 @@ test("promoted (renamed) widget resolves to the correct INNER node + widget", ()
   assert.equal(res.target.widget.name, "scheduler");
 });
 
-test("writing a RENAMED promoted widget hits the inner target, not the decoy parent slot (#233 blocker 1)", () => {
+test("writing a RENAMED promoted widget hits the inner target + syncs the rail, not the decoy parent slot (#233 blocker 1)", () => {
   const { parent, inner, resolveSource } = makeSubgraphFixture();
   const before = inner.widgets.map((w) => w.value);
 
@@ -358,6 +370,9 @@ test("writing a RENAMED promoted widget hits the inner target, not the decoy par
   assert.equal(set.promoted_from.subgraph_node_id, 66);
   assert.equal(set.promoted_from.inner_node_id, 54);
   assert.equal(inner.widgets.find((w) => w.name === "scheduler").value, "karras");
+  // The AUTHORITATIVE rail widget "sched_alias" is synced (what serializes at queue).
+  assert.equal(parent.widgets.find((w) => w.name === "sched_alias").value, "karras");
+  assert.equal(set.promoted_from.parent_widget_synced, true);
   // The decoy parent widget literally named "scheduler" is untouched.
   assert.equal(parent.widgets[0].value, 999);
   // Every OTHER inner widget is unchanged — no positional-shift corruption.
@@ -368,11 +383,18 @@ test("writing a RENAMED promoted widget hits the inner target, not the decoy par
 
 test("promoted numeric slot REJECTS a non-numeric value (silent-corruption signature)", () => {
   const { parent, inner, resolveSource } = makeSubgraphFixture();
-  // Re-point the promotion at inner numeric "steps".
-  parent.inputs = [{ name: "steps", _subgraphSlot: { name: "steps" } }];
+  // Re-point the promotion at inner numeric "steps", WITH a valid authoritative
+  // rail widget (identity-linked) so the write reaches coercion, not fail-closed.
+  const stepsRail = { name: "steps", type: "INT", value: 1 };
+  parent.inputs = [{ name: "steps", _widget: stepsRail, _subgraphSlot: { name: "steps" } }];
+  parent.widgets.push(stepsRail);
   const rs = (_n, si) => (si?.name === "steps" ? { sourceNodeId: "54", sourceWidgetName: "steps" } : null);
-  assert.throws(() => applyWidgetWrite(parent, "steps", "euler", { resolveSource: rs }), WidgetWriteError);
+  assert.throws(
+    () => applyWidgetWrite(parent, "steps", "euler", { resolveSource: rs }),
+    (err) => err instanceof WidgetWriteError && /is numeric/.test(err.message),
+  );
   assert.equal(inner.widgets.find((w) => w.name === "steps").value, 1);
+  assert.equal(parent.widgets.find((w) => w.name === "steps").value, 1, "rail not mutated on coercion reject");
 });
 
 // ---- fail-CLOSED: promoted but unresolvable must NEVER write the parent slot (#233 blocker 2)
@@ -442,4 +464,709 @@ test("subgraph node's OWN non-promoted widget writes normally (case a)", () => {
   const set = applyWidgetWrite(parent, "scheduler", "karras", { resolveSource: () => null });
   assert.equal(set.value, "karras");
   assert.equal(set.promoted_from, undefined);
+});
+
+// ---- #366: write the AUTHORITATIVE parent rail widget atomically with the inner
+//            widget; fail CLOSED (never silent inner-only) when it can't be found -
+
+/**
+ * Real LTX-2.3 shape: a SubgraphNode whose OWN promoted rail widget "value_2" is
+ * backed by an inner PrimitiveInt (id 257) whose widget is literally named
+ * "value". The rail projection is linked to the host input by OBJECT IDENTITY
+ * (`input._widget`) and present in `parent.widgets` — that is what serializes into
+ * the subgraph INPUT RAIL at queue time. `input.widget` is only a `{ name }` stub
+ * (real ComfyUI shape); we authenticate by identity, never by name.
+ */
+function makePromotedMirrorFixture() {
+  const inner = {
+    id: 257,
+    type: "PrimitiveInt",
+    widgets: [{ name: "value", type: "INT", value: 1280 }],
+  };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "257" ? inner : null) };
+  // The parent's OWN promoted rail projection — the authoritative value, stale.
+  const railWidget = { name: "value_2", type: "INT", value: 1280 };
+  const parent = {
+    id: 267,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [{ name: "value_2", _widget: railWidget, widget: { name: "value_2" }, _subgraphSlot: { name: "value_2" } }],
+    widgets: [railWidget],
+  };
+  const resolveSource = (_node, subgraphInput) =>
+    subgraphInput?.name === "value_2" ? { sourceNodeId: "257", sourceWidgetName: "value" } : null;
+  return { parent, inner, railWidget, resolveSource };
+}
+
+test("#366: a promoted write syncs the AUTHORITATIVE parent rail widget (no stale render)", () => {
+  const { parent, inner, resolveSource } = makePromotedMirrorFixture();
+
+  const set = applyWidgetWrite(parent, "value_2", 704, { resolveSource });
+
+  // Inner write landed + is reported (unchanged behaviour).
+  assert.equal(set.value, 704);
+  assert.equal(set.node_id, 257);
+  assert.equal(set.widget, "value");
+  assert.equal(inner.widgets[0].value, 704);
+
+  // THE FIX: the parent's OWN "value_2" rail widget — what serializes at queue
+  // time — now holds the NEW value, not the stale 1280. Before the fix this
+  // assertion fails (parent stays 1280 → silent stale render).
+  assert.equal(parent.widgets[0].value, 704, "parent rail widget must reflect the new value");
+  assert.equal(set.promoted_from.subgraph_node_id, 267);
+  assert.equal(set.promoted_from.inner_node_id, 257);
+  assert.equal(set.promoted_from.parent_widget_synced, true);
+});
+
+test("#366: the rail widget is resolved by the promotion's own NAME — a DIFFERENTLY-named decoy is never selected (#233)", () => {
+  // The rail projection is identity-linked from the host input (`_widget`). A decoy
+  // own-widget shares NOTHING with the input link. Authentication is by IDENTITY, so
+  // only the linked projection is written — never the decoy — regardless of names.
+  const inner = { id: 257, type: "PrimitiveInt", widgets: [{ name: "value", type: "INT", value: 1280 }] };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "257" ? inner : null) };
+  const railWidget = { name: "value_2", type: "INT", value: 1280 };
+  const decoy = { name: "value_2", type: "INT", value: 9999 }; // SAME name — still never chosen (identity)
+  const parent = {
+    id: 267,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [{ name: "value_2", _widget: railWidget, _subgraphSlot: { name: "value_2" } }],
+    widgets: [decoy, railWidget], // decoy first + same name, but the input links to railWidget by identity
+  };
+  const resolveSource = (_n, si) =>
+    si?.name === "value_2" ? { sourceNodeId: "257", sourceWidgetName: "value" } : null;
+
+  const set = applyWidgetWrite(parent, "value_2", 704, { resolveSource });
+
+  assert.equal(railWidget.value, 704, "authoritative rail projection synced by identity");
+  assert.equal(decoy.value, 9999, "a same-named decoy must never be written (identity, not name)");
+  assert.equal(set.promoted_from.parent_widget_synced, true);
+});
+
+test("#366 FAIL CLOSED runs BEFORE any side-effecting coercion — a dynamic-combo inner is never invoked when the rail is refused", () => {
+  // The inner is a DYNAMIC combo whose options.values() has a side effect. With a
+  // linked (non-authoritative) host input the write must fail closed BEFORE
+  // coercion invokes that callback — otherwise a missing-rail refusal could still
+  // leave an uncaptured inner mutation.
+  let optionsInvoked = false;
+  const innerWidget = {
+    name: "sampler",
+    type: "combo",
+    value: "euler",
+    options: {
+      values: () => {
+        optionsInvoked = true;
+        return ["euler", "dpmpp_2m"];
+      },
+    },
+  };
+  const inner = { id: 54, type: "KSampler", widgets: [innerWidget] };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "54" ? inner : null) };
+  const samplerRail = { name: "sampler", type: "combo", value: "euler", options: { values: ["euler", "dpmpp_2m"] } };
+  const parent = {
+    id: 66,
+    type: "SubgraphNode",
+    subgraph,
+    // linked host input ⇒ non-authoritative rail ⇒ fail closed (even though the
+    // projection is present, the outer link makes it non-authoritative).
+    inputs: [{ name: "sampler", link: 99, _widget: samplerRail, _subgraphSlot: { name: "sampler" } }],
+    widgets: [samplerRail],
+  };
+  const resolveSource = (_n, si) =>
+    si?.name === "sampler" ? { sourceNodeId: "54", sourceWidgetName: "sampler" } : null;
+
+  assert.throws(
+    () => applyWidgetWrite(parent, "sampler", "dpmpp_2m", { resolveSource }),
+    (err) => err instanceof WidgetWriteError && /parent rail widget could not be identified/.test(err.message),
+  );
+  assert.equal(optionsInvoked, false, "no dynamic-combo coercion side effect before the fail-closed refusal");
+});
+
+test("#366 FAIL CLOSED: an EXTERNALLY-LINKED host input (nested/further promotion) refuses — the local widget is not the authoritative rail", () => {
+  // The host input carries an OUTER link (this promoted widget is further promoted
+  // to an enclosing subgraph). Its projection `_widget` is a valid member, but queue
+  // compilation ignores it and follows the outer rail — so writing it would be a
+  // FALSE success. The link check refuses it.
+  const inner = { id: 257, type: "PrimitiveInt", widgets: [{ name: "value", type: "INT", value: 1280 }] };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "257" ? inner : null) };
+  const localWidget = { name: "value_2", type: "INT", value: 1280 };
+  const parent = {
+    id: 267,
+    type: "SubgraphNode",
+    subgraph,
+    // `link` is NON-NULL ⇒ fed by an enclosing subgraph's rail (non-authoritative).
+    inputs: [{ name: "value_2", link: 4242, _widget: localWidget, _subgraphSlot: { name: "value_2" } }],
+    widgets: [localWidget],
+  };
+  const resolveSource = (_n, si) =>
+    si?.name === "value_2" ? { sourceNodeId: "257", sourceWidgetName: "value" } : null;
+
+  assert.throws(
+    () => applyWidgetWrite(parent, "value_2", 704, { resolveSource }),
+    (err) => err instanceof WidgetWriteError && /parent rail widget could not be identified/.test(err.message),
+  );
+  assert.equal(localWidget.value, 1280, "non-authoritative local widget must not be written");
+  assert.equal(inner.widgets[0].value, 1280, "inner must not be written on fail-closed");
+});
+
+test("#366 SEVERE FAIL CLOSED: a NAME-ONLY `input.widget` stub + an unrelated same-named decoy is REFUSED (identity auth, never a name match)", () => {
+  // The exact severe repro: the host input carries ONLY a `{ name }` stub (no
+  // identity-linked projection), and the parent has ONE unrelated widget that
+  // happens to share that name. A name-based resolver (even unique) would select
+  // and write that decoy and report synced:true. Object-identity auth must refuse:
+  // the stub is not `===` any node.widgets member, so FAIL CLOSED, write nothing.
+  const inner = { id: 54, type: "KSampler", widgets: [{ name: "scheduler", type: "combo", options: { values: ["simple", "karras"] }, value: "simple" }] };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "54" ? inner : null) };
+  const decoy = { name: "scheduler", type: "combo", options: { values: ["simple", "karras"] }, value: "simple" };
+  const parent = {
+    id: 66,
+    type: "SubgraphNode",
+    subgraph,
+    // NAME-ONLY stub (a different object from `decoy`), no `_widget` projection.
+    inputs: [{ name: "scheduler", widget: { name: "scheduler" }, _subgraphSlot: { name: "scheduler" } }],
+    widgets: [decoy], // unrelated, coincidentally same-named
+    // Production litegraph's getWidgetFromSlot resolves BY NAME and would hand back
+    // the decoy — the exact trap. The fix must IGNORE this and authenticate by
+    // identity only, so the decoy is never written.
+    getWidgetFromSlot(input) {
+      return this.widgets.find((w) => w.name === input?.widget?.name) ?? null;
+    },
+  };
+  const resolveSource = (_n, si) =>
+    si?.name === "scheduler" ? { sourceNodeId: "54", sourceWidgetName: "scheduler" } : null;
+
+  assert.throws(
+    () => applyWidgetWrite(parent, "scheduler", "karras", { resolveSource }),
+    (err) => err instanceof WidgetWriteError && /parent rail widget could not be identified/.test(err.message),
+  );
+  assert.equal(decoy.value, "simple", "the unrelated same-named decoy must NOT be written (identity, not name)");
+  assert.equal(inner.widgets[0].value, "simple", "inner must not be written on fail-closed");
+});
+
+test("#366 FAIL CLOSED: a promoted write whose authoritative rail widget cannot be identified THROWS — never writes inner-only", () => {
+  // No litegraph backlink and no getWidgetFromSlot → the rail widget cannot be
+  // positively identified (the outward/double-promotion or malformed case). Even
+  // though a same-named widget exists, matching it by name is forbidden; we FAIL
+  // CLOSED so the render can never silently use the OLD value.
+  const inner = { id: 257, type: "PrimitiveInt", widgets: [{ name: "value", type: "INT", value: 1280 }] };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "257" ? inner : null) };
+  const parent = {
+    id: 267,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [{ name: "value_2", _subgraphSlot: { name: "value_2" } }], // no `widget` backlink
+    widgets: [{ name: "value_2", type: "INT", value: 1280 }], // tempting same-named widget
+    // no getWidgetFromSlot
+  };
+  const resolveSource = (_n, si) =>
+    si?.name === "value_2" ? { sourceNodeId: "257", sourceWidgetName: "value" } : null;
+
+  assert.throws(
+    () => applyWidgetWrite(parent, "value_2", 704, { resolveSource }),
+    (err) => err instanceof WidgetWriteError && /parent rail widget could not be identified/.test(err.message),
+  );
+  // Neither the inner widget nor the tempting same-named parent widget was written.
+  assert.equal(inner.widgets[0].value, 1280, "inner must not be written on fail-closed");
+  assert.equal(parent.widgets[0].value, 1280, "same-named parent widget must not be written on fail-closed");
+});
+
+test("#366: a promotion addressed by its LABEL still syncs the rail widget (relationship, not name)", () => {
+  // Renamed promotion: display label "sched_label"; the parent rail widget carries
+  // the stable name "scheduler". The caller addresses by the LABEL. The rail widget
+  // is found by the promotion backlink regardless of the label.
+  const inner = {
+    id: 54,
+    type: "KSampler",
+    widgets: [{ name: "scheduler", type: "combo", options: { values: ["simple", "karras"] }, value: "simple" }],
+  };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "54" ? inner : null) };
+  const railWidget = { name: "scheduler", type: "combo", options: { values: ["simple", "karras"] }, value: "simple" };
+  const parent = {
+    id: 66,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [
+      { name: "scheduler", label: "sched_label", _widget: railWidget, _subgraphSlot: { name: "scheduler", label: "sched_label" } },
+    ],
+    widgets: [railWidget],
+  };
+  const resolveSource = (_n, si) =>
+    si?.name === "scheduler" ? { sourceNodeId: "54", sourceWidgetName: "scheduler" } : null;
+
+  // Address by the LABEL, not the stable name.
+  const set = applyWidgetWrite(parent, "sched_label", "karras", { resolveSource });
+
+  assert.equal(inner.widgets[0].value, "karras");
+  assert.equal(railWidget.value, "karras", "rail widget must be synced when addressed by label");
+  assert.equal(set.promoted_from.parent_widget_synced, true);
+});
+
+test("#366: the rail write lands INSIDE the undo envelope (before afterChange fires)", () => {
+  const { parent, inner, resolveSource } = makePromotedMirrorFixture();
+  let parentValueAtAfterChange;
+  applyWidgetWrite(parent, "value_2", 704, {
+    resolveSource,
+    beforeChange: () => {
+      // Envelope opened but nothing written yet.
+      assert.equal(parent.widgets[0].value, 1280);
+    },
+    afterChange: () => {
+      // BOTH inner and parent must already be written when the envelope closes,
+      // so the two mutations are one atomic undo.
+      parentValueAtAfterChange = parent.widgets[0].value;
+    },
+  });
+  assert.equal(inner.widgets[0].value, 704);
+  assert.equal(parentValueAtAfterChange, 704, "parent must be written before afterChange (single undo op)");
+});
+
+test("#366 ATOMIC: an INNER callback that throws rolls BOTH back — no partial write, surfaced as failure", () => {
+  const { parent, inner, resolveSource } = makePromotedMirrorFixture();
+  // Inner widget callback throws AFTER the inner value is assigned.
+  inner.widgets[0].callback = () => {
+    throw new Error("inner boom");
+  };
+  let afterChangeRan = false;
+  assert.throws(
+    () =>
+      applyWidgetWrite(parent, "value_2", 704, {
+        resolveSource,
+        afterChange: () => {
+          afterChangeRan = true;
+        },
+      }),
+    (err) => err instanceof WidgetWriteError && /callback threw|inner boom/.test(err.message),
+  );
+  // ROLLED BACK: neither inner nor parent rail left at the new value.
+  assert.equal(inner.widgets[0].value, 1280, "inner rolled back");
+  assert.equal(parent.widgets[0].value, 1280, "parent rolled back — never inner=new/parent=stale");
+  assert.equal(afterChangeRan, true, "afterChange still closes the envelope");
+});
+
+test("#366: the SEMANTIC widget callback fires EXACTLY ONCE (inner target) — a forwarding parent view is not double-invoked", () => {
+  // Real ComfyUI shape: the parent's projected promoted widget is a VIEW whose
+  // callback FORWARDS to the inner widget's callback. Firing both would double-run
+  // the side effect; the fix fires only the inner callback (with the inner node
+  // context) and sets the rail value directly.
+  let innerCalls = 0;
+  let innerCtx = null;
+  const inner = {
+    id: 257,
+    type: "PrimitiveInt",
+    widgets: [
+      {
+        name: "value",
+        type: "INT",
+        value: 1280,
+        callback(_v, _canvas, node) {
+          innerCalls += 1;
+          innerCtx = node;
+        },
+      },
+    ],
+  };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "257" ? inner : null) };
+  const railWidget = {
+    name: "value_2",
+    type: "INT",
+    value: 1280,
+    // A view whose callback forwards to the inner widget's callback.
+    callback: (...args) => inner.widgets[0].callback(...args),
+  };
+  const parent = {
+    id: 267,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [{ name: "value_2", _widget: railWidget, _subgraphSlot: { name: "value_2" } }],
+    widgets: [railWidget],
+  };
+  const resolveSource = (_n, si) =>
+    si?.name === "value_2" ? { sourceNodeId: "257", sourceWidgetName: "value" } : null;
+
+  const set = applyWidgetWrite(parent, "value_2", 704, { resolveSource });
+
+  assert.equal(innerCalls, 1, "the semantic callback must fire exactly once");
+  assert.equal(innerCtx, inner, "…with the INNER node as context");
+  assert.equal(inner.widgets[0].value, 704);
+  assert.equal(railWidget.value, 704, "rail value set directly (serializes)");
+  assert.equal(set.promoted_from.parent_widget_synced, true);
+});
+
+test("#366: a value setter that REJECTS the rollback surfaces an HONEST partial-state failure (never falsely claims 'rolled back')", () => {
+  const inner = { id: 257, type: "PrimitiveInt", widgets: [] };
+  // A widget whose `value` accepts the forward write but REJECTS the restore.
+  const w = {
+    name: "value",
+    type: "INT",
+    _v: 1280,
+    _touched: false,
+    get value() {
+      return this._v;
+    },
+    set value(x) {
+      if (x === 1280 && this._touched) throw new Error("setter refuses restore");
+      this._v = x;
+      this._touched = true;
+    },
+    callback() {
+      throw new Error("inner boom");
+    },
+  };
+  inner.widgets.push(w);
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "257" ? inner : null) };
+  const railWidget = { name: "value_2", type: "INT", value: 1280 };
+  const parent = {
+    id: 267,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [{ name: "value_2", _widget: railWidget, _subgraphSlot: { name: "value_2" } }],
+    widgets: [railWidget],
+  };
+  const resolveSource = (_n, si) =>
+    si?.name === "value_2" ? { sourceNodeId: "257", sourceWidgetName: "value" } : null;
+
+  assert.throws(
+    () => applyWidgetWrite(parent, "value_2", 704, { resolveSource }),
+    (err) => err instanceof WidgetWriteError && /partial state/.test(err.message) && !/rolled back to avoid/.test(err.message),
+  );
+});
+
+test("#366: a value setter that SILENTLY IGNORES the rollback (keeps the new value) is detected via read-back, not falsely claimed rolled back", () => {
+  const inner = { id: 257, type: "PrimitiveInt", widgets: [] };
+  // A widget whose setter accepts the forward write but silently REFUSES to go back.
+  const w = {
+    name: "value",
+    type: "INT",
+    _v: 1280,
+    get value() {
+      return this._v;
+    },
+    set value(x) {
+      // Ignore any attempt to restore the old value (silent no-op rollback).
+      if (x === 1280 && this._v === 704) return;
+      this._v = x;
+    },
+    callback() {
+      throw new Error("inner boom");
+    },
+  };
+  inner.widgets.push(w);
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "257" ? inner : null) };
+  const railWidget = { name: "value_2", type: "INT", value: 1280 };
+  const parent = {
+    id: 267,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [{ name: "value_2", _widget: railWidget, _subgraphSlot: { name: "value_2" } }],
+    widgets: [railWidget],
+  };
+  const resolveSource = (_n, si) =>
+    si?.name === "value_2" ? { sourceNodeId: "257", sourceWidgetName: "value" } : null;
+
+  assert.throws(
+    () => applyWidgetWrite(parent, "value_2", 704, { resolveSource }),
+    (err) =>
+      err instanceof WidgetWriteError && /partial state/.test(err.message) && !/rolled back to avoid/.test(err.message),
+  );
+});
+
+test("#366 ATOMIC: a THROWING afterChange hook does not bypass rollback", () => {
+  const { parent, inner, resolveSource } = makePromotedMirrorFixture();
+  inner.widgets[0].callback = () => {
+    throw new Error("inner boom");
+  };
+  const afterChange = () => {
+    throw new Error("afterChange boom");
+  };
+  assert.throws(
+    () => applyWidgetWrite(parent, "value_2", 704, { resolveSource, afterChange }),
+    (err) => err instanceof WidgetWriteError && /callback threw|inner boom/.test(err.message),
+  );
+  assert.equal(inner.widgets[0].value, 1280, "inner rolled back despite a throwing afterChange hook");
+  assert.equal(parent.widgets[0].value, 1280, "rail untouched / rolled back");
+});
+
+test("#366 HARD FAIL: an afterChange HOOK that re-stales the rail (after all callbacks) is still caught + rolled back", () => {
+  const { parent, inner, resolveSource } = makePromotedMirrorFixture();
+  // Verification must run AFTER afterChange: a hook that reverts the rail value must
+  // not escape detection and report success.
+  const afterChange = () => {
+    // Re-stale the rail to its OLD value after the write completed.
+    if (parent.widgets[0].value === 704) parent.widgets[0].value = 1280;
+  };
+  assert.throws(
+    () => applyWidgetWrite(parent, "value_2", 704, { resolveSource, afterChange }),
+    (err) => err instanceof WidgetWriteError && /did not retain the requested value/.test(err.message),
+  );
+  // Rolled back: inner restored too (never inner=new/rail=stale reported as success).
+  assert.equal(inner.widgets[0].value, 1280, "inner rolled back after afterChange re-stale");
+  assert.equal(parent.widgets[0].value, 1280, "rail left at its stale value, not the half-applied new one");
+});
+
+test("#366 HARD FAIL: a callback that CHANGES the promotion topology (adds an outer link) fails + rolls back — never a false synced success", () => {
+  const { parent, inner, resolveSource } = makePromotedMirrorFixture();
+  // The inner (semantic) callback keeps the requested VALUE but mutates the host
+  // input to be externally linked — so at queue time litegraph would follow the
+  // outer link and ignore this rail. The post-callback re-authentication catches it.
+  inner.widgets[0].callback = () => {
+    parent.inputs[0].link = 7777; // now non-authoritative
+  };
+  assert.throws(
+    () => applyWidgetWrite(parent, "value_2", 704, { resolveSource }),
+    (err) => err instanceof WidgetWriteError && /CHANGED during the write/.test(err.message),
+  );
+  assert.equal(inner.widgets[0].value, 1280, "inner rolled back on relationship drift");
+  assert.equal(parent.widgets[0].value, 1280, "rail rolled back on relationship drift");
+});
+
+test("#366 HARD FAIL: a callback that REPLACES node.inputs[i] with a new detached host input fails + rolls back", () => {
+  const { parent, inner, resolveSource } = makePromotedMirrorFixture();
+  // The inner (semantic) callback swaps the live host input for a NEW object (the
+  // captured one is now detached). Re-resolving from live node.inputs detects it.
+  inner.widgets[0].callback = () => {
+    parent.inputs[0] = { name: "value_2", link: 5, widget: { name: "value_2" }, _subgraphSlot: { name: "value_2" } };
+  };
+  assert.throws(
+    () => applyWidgetWrite(parent, "value_2", 704, { resolveSource }),
+    (err) => err instanceof WidgetWriteError && /CHANGED during the write/.test(err.message),
+  );
+  assert.equal(inner.widgets[0].value, 1280, "inner rolled back on host-input replacement");
+  assert.equal(parent.widgets[0].value, 1280, "rail rolled back on host-input replacement");
+});
+
+test("#366 HARD FAIL: a callback that installs a LIVE REPLACEMENT rail preloaded with the value is reported as PARTIAL STATE (not a clean rollback)", () => {
+  const { parent, inner, railWidget } = makePromotedMirrorFixture();
+  // The inner callback swaps in a WHOLE new promotion: a new host input + a new
+  // identity-authenticated rail projection already holding the requested value 704.
+  // Recheck detects the change; restoring the OLD captured rail does not touch the
+  // new live rail (which serializes 704), so this must be surfaced as partial state.
+  const newRail = { name: "value_2", type: "INT", value: 704 };
+  inner.widgets[0].callback = () => {
+    parent.inputs[0] = { name: "value_2", _widget: newRail, _subgraphSlot: { name: "value_2" } };
+    parent.widgets = [newRail];
+  };
+  const rs = (_n, si) => (si?.name === "value_2" ? { sourceNodeId: "257", sourceWidgetName: "value" } : null);
+  assert.throws(
+    () => applyWidgetWrite(parent, "value_2", 704, { resolveSource: rs }),
+    (err) => err instanceof WidgetWriteError && /partial state/.test(err.message) && /live replacement rail/.test(err.message),
+  );
+  assert.equal(railWidget.value, 1280, "the detached captured rail is restored");
+  assert.equal(newRail.value, 704, "the live replacement rail still holds the value — surfaced as partial state");
+});
+
+test("#366 HARD FAIL: a callback that swaps only `input.widgetId` (the serialization binding) is detected + rolled back", () => {
+  // Model ComfyUI's store-backed projection: the rail's value reads/writes a STORE
+  // by a bound id, but queue compilation reads `input.widgetId`. A callback keeps the
+  // same input + projection OBJECTS but re-points widgetId to another store entry
+  // holding the OLD value — object-identity checks all pass, yet the render would be
+  // stale. Snapshotting + verifying widgetId catches it.
+  // Harder case: store entry "b" is PRELOADED with the requested NEW value, so a
+  // swap to "b" would silently serialize the new value while we claim rollback.
+  const store = { a: { value: 1280 }, b: { value: 704 } };
+  const inner = { id: 257, type: "PrimitiveInt", widgets: [{ name: "value", type: "INT", value: 1280 }] };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "257" ? inner : null) };
+  const railWidget = {
+    name: "value_2",
+    type: "INT",
+    get value() {
+      return store.a.value; // projection bound to store entry "a" (closure id)
+    },
+    set value(v) {
+      store.a.value = v;
+    },
+  };
+  const hostInput = { name: "value_2", widgetId: "a", _widget: railWidget, _subgraphSlot: { name: "value_2" } };
+  const parent = { id: 267, type: "SubgraphNode", subgraph, inputs: [hostInput], widgets: [railWidget] };
+  // The inner callback re-points the serialization binding to "b".
+  inner.widgets[0].callback = () => {
+    hostInput.widgetId = "b";
+  };
+  const rs = (_n, si) => (si?.name === "value_2" ? { sourceNodeId: "257", sourceWidgetName: "value" } : null);
+
+  assert.throws(
+    () => applyWidgetWrite(parent, "value_2", 704, { resolveSource: rs }),
+    (err) => err instanceof WidgetWriteError && /CHANGED during the write/.test(err.message),
+  );
+  assert.equal(inner.widgets[0].value, 1280, "inner rolled back on widgetId swap");
+  // The binding is RESTORED to "a" and its entry to the OLD value, so queue
+  // compilation reads the old value — a clean rollback, not the preloaded "b".
+  assert.equal(hostInput.widgetId, "a", "serialization binding restored to the original store key");
+  assert.equal(store.a.value, 1280, "the serialized store entry holds the OLD value after rollback");
+});
+
+test("#366 ATOMIC: an EXCEPTION during the post-afterChange topology recheck triggers full rollback (never escapes with mutated state)", () => {
+  const { parent, inner, railWidget } = makePromotedMirrorFixture();
+  // The inner callback replaces the host input's _subgraphSlot so the recheck's
+  // resolveSource THROWS for the replacement — the recheck exception must drive the
+  // full rollback, not escape with inner=new / rail=new.
+  inner.widgets[0].callback = () => {
+    parent.inputs[0]._subgraphSlot = { name: "REPLACED" };
+  };
+  const rs = (_n, si) => {
+    if (si?.name === "REPLACED") throw new Error("no source for replaced slot");
+    return si?.name === "value_2" ? { sourceNodeId: "257", sourceWidgetName: "value" } : null;
+  };
+  assert.throws(
+    () => applyWidgetWrite(parent, "value_2", 704, { resolveSource: rs }),
+    (err) => err instanceof WidgetWriteError && /CHANGED during the write/.test(err.message),
+  );
+  assert.equal(inner.widgets[0].value, 1280, "inner rolled back after the recheck threw");
+  assert.equal(railWidget.value, 1280, "rail rolled back after the recheck threw");
+});
+
+test("#366 HARD FAIL: a rollback afterChange that mutates the RESTORED composite IN PLACE is caught by STRUCTURAL verification (Object.is would miss it)", () => {
+  const innerW = {
+    name: "value",
+    value: { on: true, lora: "a.safetensors", strength: 1 },
+    callback() {
+      throw new Error("inner boom"); // force entry into rollback
+    },
+  };
+  const inner = { id: 300, type: "Power Lora Loader (rgthree)", widgets: [innerW] };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "300" ? inner : null) };
+  const railWidget = { name: "value", value: { on: true, lora: "a.safetensors", strength: 1 } };
+  const parent = {
+    id: 267,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [{ name: "value", _widget: railWidget, _subgraphSlot: { name: "value" } }],
+    widgets: [railWidget],
+  };
+  const resolveSource = (_n, si) => (si?.name === "value" ? { sourceNodeId: "300", sourceWidgetName: "value" } : null);
+  // afterChange fires twice (main envelope, then the rollback envelope). On the
+  // rollback pass it mutates the RESTORED old objects IN PLACE — Object.is against
+  // the same references would pass, but structural comparison against the deep
+  // clones detects the corruption.
+  let phase = 0;
+  const afterChange = () => {
+    phase += 1;
+    if (phase === 2) {
+      innerW.value.strength = 999;
+      railWidget.value.strength = 999;
+    }
+  };
+  assert.throws(
+    () => applyWidgetWrite(parent, "value", '{"strength":0.6}', { resolveSource, afterChange }),
+    (err) => err instanceof WidgetWriteError && /partial state/.test(err.message),
+  );
+});
+
+test("#366 HARD FAIL + ROLLBACK: a rail VALUE SETTER that DRIFTS (reverts) the value fails loudly AND rolls both back (never inner=new/parent=stale)", () => {
+  const inner = { id: 257, type: "PrimitiveInt", widgets: [{ name: "value", type: "INT", value: 1280 }] };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "257" ? inner : null) };
+  // The rail widget's value SETTER silently reverts a forward write to the old value
+  // (a drift signature) — the rail is authoritative, so this must be caught.
+  const railWidget = {
+    name: "value_2",
+    type: "INT",
+    _v: 1280,
+    get value() {
+      return this._v;
+    },
+    set value(x) {
+      this._v = x === 704 ? 1280 : x; // drift: refuse the new value
+    },
+  };
+  const parent = {
+    id: 267,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [{ name: "value_2", _widget: railWidget, _subgraphSlot: { name: "value_2" } }],
+    widgets: [railWidget],
+  };
+  const resolveSource = (_n, si) =>
+    si?.name === "value_2" ? { sourceNodeId: "257", sourceWidgetName: "value" } : null;
+
+  assert.throws(
+    () => applyWidgetWrite(parent, "value_2", 704, { resolveSource }),
+    (err) => err instanceof WidgetWriteError && /did not\s+retain the requested value/.test(err.message),
+  );
+  // Both restored — never inner=new / rail=stale reported as success.
+  assert.equal(inner.widgets[0].value, 1280, "inner rolled back on rail drift");
+  assert.equal(railWidget.value, 1280, "rail at its (stale) value, not half-applied");
+});
+
+test("#366 FAIL CLOSED: a NAME-only backlink pointing at a decoy (real rail absent) is refused, never written by name", () => {
+  // Host input has a `widget` NAME stub (not an object in node.widgets) and there
+  // is NO getWidgetFromSlot. A widget named "value_2" exists but is a DECOY — the
+  // true rail widget is absent. A name-based lookup would select the decoy and
+  // report success; identity/relationship authentication refuses and FAILS CLOSED.
+  const inner = { id: 257, type: "PrimitiveInt", widgets: [{ name: "value", type: "INT", value: 1280 }] };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "257" ? inner : null) };
+  const decoy = { name: "value_2", type: "INT", value: 9999 };
+  const parent = {
+    id: 267,
+    type: "SubgraphNode",
+    subgraph,
+    // `widget` is a NAME STUB, not one of node.widgets by identity.
+    inputs: [{ name: "value_2", widget: { name: "value_2" }, _subgraphSlot: { name: "value_2" } }],
+    widgets: [decoy],
+    // no getWidgetFromSlot
+  };
+  const resolveSource = (_n, si) =>
+    si?.name === "value_2" ? { sourceNodeId: "257", sourceWidgetName: "value" } : null;
+
+  assert.throws(
+    () => applyWidgetWrite(parent, "value_2", 704, { resolveSource }),
+    (err) => err instanceof WidgetWriteError && /parent rail widget could not be identified/.test(err.message),
+  );
+  assert.equal(decoy.value, 9999, "decoy must NOT be written by name");
+  assert.equal(inner.widgets[0].value, 1280, "inner must not be written on fail-closed");
+});
+
+test("#366: a promoted STRING widget also syncs the parent rail (prompt text)", () => {
+  const inner = {
+    id: 266,
+    type: "PrimitiveStringMultiline",
+    widgets: [{ name: "value", type: "customtext", value: "old landscape prompt" }],
+  };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "266" ? inner : null) };
+  const railWidget = { name: "value", type: "customtext", value: "old landscape prompt" };
+  const parent = {
+    id: 267,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [{ name: "value", _widget: railWidget, _subgraphSlot: { name: "value" } }],
+    widgets: [railWidget],
+  };
+  const resolveSource = (_n, si) =>
+    si?.name === "value" ? { sourceNodeId: "266", sourceWidgetName: "value" } : null;
+
+  const set = applyWidgetWrite(parent, "value", "new vertical prompt", { resolveSource });
+
+  assert.equal(inner.widgets[0].value, "new vertical prompt");
+  assert.equal(railWidget.value, "new vertical prompt", "parent prompt rail widget must reflect the new text");
+  assert.equal(set.promoted_from.parent_widget_synced, true);
+});
+
+test("#366×#179: a promoted COMPOSITE write merges onto the RAIL's current object — the rail's unspecified fields are NOT clobbered by the stale inner", () => {
+  // Inner (non-authoritative) and rail (authoritative) hold DIVERGENT composite
+  // values. A partial write {strength:0.6} must preserve the RAIL's `lora`
+  // ("current"), not resurrect the inner's stale `lora` ("old").
+  const inner = {
+    id: 300,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [{ name: "lora_1", value: { on: true, lora: "old.safetensors", strength: 1 } }],
+  };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "300" ? inner : null) };
+  const railWidget = { name: "lora_1", value: { on: true, lora: "current.safetensors", strength: 0.8 } };
+  const parent = {
+    id: 267,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [{ name: "lora_1", _widget: railWidget, _subgraphSlot: { name: "lora_1" } }],
+    widgets: [railWidget],
+  };
+  const resolveSource = (_n, si) =>
+    si?.name === "lora_1" ? { sourceNodeId: "300", sourceWidgetName: "lora_1" } : null;
+
+  const set = applyWidgetWrite(parent, "lora_1", '{"strength":0.6}', { resolveSource });
+
+  assert.equal(railWidget.value.lora, "current.safetensors", "rail's authoritative lora must be preserved, not clobbered by the stale inner");
+  assert.equal(railWidget.value.strength, 0.6, "requested field applied to the rail");
+  assert.equal(railWidget.value.on, true, "rail's other unspecified field preserved");
+  // Inner is written to the SAME authoritative merged value (read-consistency).
+  assert.equal(inner.widgets[0].value.lora, "current.safetensors");
+  assert.equal(inner.widgets[0].value.strength, 0.6);
+  assert.equal(set.promoted_from.parent_widget_synced, true);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9422,12 +9422,25 @@ function describeCommand(cmd, msg, reply) {
       };
     case "graph_disconnect":
       return { icon: "pi-times-circle", text: `Disconnected ${r.disconnected?.node_id}.${r.disconnected?.input}` };
-    case "graph_set_widget":
-      return {
-        icon: "pi-sliders-h",
-        text: `Set ${r.set?.widget} = ${JSON.stringify(r.set?.value)} on node ${r.set?.node_id}`,
-        detail: `was ${JSON.stringify(r.set?.previous)}`,
-      };
+    case "graph_set_widget": {
+      // #366: a promoted-subgraph write is only truly applied when the parent RAIL
+      // widget (what serializes at queue time) was synced. The lib fails closed if
+      // it can't, so a success result normally has parent_widget_synced !== false;
+      // but guard defensively — never render an un-synced promoted write as a plain
+      // "Set …" success, or the summary would repeat the exact #366 lie.
+      const railStale = r.set?.promoted_from && r.set.promoted_from.parent_widget_synced === false;
+      return railStale
+        ? {
+            icon: "pi-exclamation-triangle",
+            text: `Set ${r.set?.widget} = ${JSON.stringify(r.set?.value)} on node ${r.set?.node_id} — WARNING: parent subgraph rail NOT synced; the render may use the OLD value (#366)`,
+            detail: `was ${JSON.stringify(r.set?.previous)}`,
+          }
+        : {
+            icon: "pi-sliders-h",
+            text: `Set ${r.set?.widget} = ${JSON.stringify(r.set?.value)} on node ${r.set?.node_id}`,
+            detail: `was ${JSON.stringify(r.set?.previous)}`,
+          };
+    }
     case "graph_get_subgraph":
       return {
         icon: "pi-sitemap",

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -3,18 +3,28 @@
 // RIGHT value and can be unit-tested by driving the SAME code path the handler
 // runs (applyWidgetWrite), not a parallel reimplementation.
 //
-// Two graph-integrity bugs motivate this module:
+// Three graph-integrity bugs motivate this module:
 //   #233 — panel_set_widget on a SUBGRAPH node's PROMOTED widget wrote by a
 //          positionally-shifted slot and silently corrupted a DIFFERENT inner
 //          widget (an INT slot ended up holding "euler"), reporting success.
 //   #240 — a COMBO widget set to a valid enum silently drifted to a different
 //          option (index-vs-value reinterpretation).
+//   #366 — a PROMOTED widget write landed on the INNER node only; the parent's
+//          own rail widget (what serializes at queue time) stayed stale, so the
+//          render used the OLD value while the tool reported success (silent
+//          wrong output).
 //
-// Safety contract (both bugs are silent corruption; we NEVER fail open):
+// Safety contract (all three bugs are silent corruption; we NEVER fail open):
 //   * A promoted widget resolves to its ACTUAL inner (node, widget) and the
 //     write lands THERE. If it looks promoted but cannot be resolved
 //     unambiguously, we THROW before mutating — never fall back to the shifted
 //     parent slot.
+//   * A promoted write also writes the AUTHORITATIVE parent rail widget —
+//     identified by the promotion RELATIONSHIP (host-input↔widget backlink), never
+//     a name/label guess — ATOMICALLY with the inner write (one undo; rollback +
+//     throw on any callback failure, so never inner=new/parent=stale). If the
+//     parent rail widget cannot be positively identified, we FAIL CLOSED (throw)
+//     rather than write inner-only and render silently stale (#366).
 //   * The value is validated against the target widget's declared type and
 //     REJECTED on mismatch (combo must be an exact CURRENT option; numeric must
 //     be numeric; boolean must be boolean; a combo whose options we cannot read
@@ -86,7 +96,7 @@ export function isCompositeObjectWidget(widget) {
  * WidgetWriteError (never silently coerces to a wrong value) when the value is
  * incompatible with the widget's declared type.
  */
-export function coerceWidgetValue(widget, value) {
+export function coerceWidgetValue(widget, value, mergeBaseWidget = widget) {
   const name = widget?.name ?? "(widget)";
 
   // #347: distinguish "clear to empty" from "missing value". An EXPLICIT empty
@@ -182,7 +192,16 @@ export function coerceWidgetValue(widget, value) {
           `{"on":true,"lora":"name.safetensors","strength":1}.`,
       );
     }
-    return { ...widget.value, ...incoming };
+    // #366×#179: for a PROMOTED composite, the AUTHORITATIVE base is the RAIL
+    // widget's current object (what serializes), not the inner widget's — merging
+    // onto a stale inner would clobber the rail's unspecified fields when the same
+    // coerced value is written to both. Prefer the rail's object; fall back to the
+    // target widget's own value when the rail base isn't a usable object.
+    const base =
+      mergeBaseWidget && mergeBaseWidget.value != null && typeof mergeBaseWidget.value === "object" && !Array.isArray(mergeBaseWidget.value)
+        ? mergeBaseWidget.value
+        : widget.value;
+    return { ...base, ...incoming };
   }
 
   // STRING / text / unknown widget: pass through unchanged (an explicit "" clears
@@ -191,8 +210,52 @@ export function coerceWidgetValue(widget, value) {
 }
 
 /**
+ * The parent SubgraphNode's OWN projected promoted widget that is backed by
+ * `hostInput` — i.e. the widget whose value serializes into the subgraph input
+ * rail at queue time (#366).
+ *
+ * Authenticated by OBJECT IDENTITY, never by a name/label lookup. In the ComfyUI
+ * frontend the host input slot stores only a `{ name }` STUB in `input.widget`;
+ * the real authoritative rail widget is the PROJECTION object litegraph builds for
+ * the slot (`input._widget`), whose get/set `value` proxies the subgraph widget
+ * value STORE that is serialized at queue time. `getWidgetFromSlot()` returns that
+ * projection when present but otherwise FALLS BACK to a name-based lookup — and a
+ * name match (even a unique one) could select an unrelated decoy own-widget while
+ * no authenticated rail object exists. So we accept ONLY a candidate that is an
+ * actual widget OBJECT AND is `===` a live member of `node.widgets`, and otherwise
+ * FAIL CLOSED (return null) — never write inner or parent on a name-only stub.
+ */
+export function resolveHostPromotedWidget(subgraphNode, hostInput) {
+  if (!subgraphNode || !hostInput) return null;
+
+  // EXTERNALLY-LINKED host input ⇒ the local projected widget is NOT authoritative.
+  // When the host input carries an outer link, ComfyUI's queue compiler IGNORES
+  // this node's projected widget and recursively follows the OUTER source (the
+  // enclosing subgraph's rail); ComfyUI's own promoted-widget control treats
+  // `input.link != null` as "host store is non-authoritative". Writing the local
+  // widget here would pass verification yet render the enclosing rail's OLD value —
+  // a false success. Refuse (→ caller FAILS CLOSED); the widget must be edited from
+  // the OUTERMOST subgraph node, where its host input has no outer link.
+  if (hostInput.link != null) return null;
+
+  const inWidgets = Array.isArray(subgraphNode.widgets) ? subgraphNode.widgets : [];
+
+  // OBJECT-IDENTITY authentication. The rail widget must be the actual projection
+  // object the host input LINKS to (`_widget`, or an `input.widget` that is itself a
+  // real widget object — NOT a `{ name }` stub) AND must be `===` a live member of
+  // this node's projected widgets. A name-only stub is an object too, but it is NOT
+  // a member of node.widgets, so it is rejected → FAIL CLOSED. This never resolves by
+  // name, so an unrelated same-named decoy can never be selected (#233/#366).
+  for (const cand of [hostInput._widget, hostInput.widget]) {
+    if (cand && typeof cand === "object" && inWidgets.includes(cand)) return cand;
+  }
+  return null;
+}
+
+/**
  * Classify a widget request on `subgraphNode` against `widgetName` and, when it
- * is a PROMOTED subgraph widget, resolve it to the ACTUAL inner (node, widget).
+ * is a PROMOTED subgraph widget, resolve it to the ACTUAL inner (node, widget)
+ * AND the authoritative parent rail widget (via the promotion relationship).
  *
  * Detection matches ONLY the OUTER alias the caller sees on the parent
  * (host-input name/label and the backing subgraph-input name/label) — never the
@@ -205,9 +268,10 @@ export function coerceWidgetValue(widget, value) {
  *
  * Returns a status object — the caller MUST honour it and never fall back to
  * the parent slot when `promoted` is true but `target` is null:
- *   { promoted: false }                             → not a promoted widget
- *   { promoted: true, target: {node,widget,input} } → resolved inner target
- *   { promoted: true, target: null, error }         → promoted but UNRESOLVABLE/ambiguous
+ *   { promoted: false }                                          → not a promoted widget
+ *   { promoted: true, target: {node,widget,input,parentWidget} } → resolved inner target
+ *                                                                  (parentWidget may be null)
+ *   { promoted: true, target: null, error }                      → promoted but UNRESOLVABLE/ambiguous
  */
 export function resolvePromotedInnerTarget(subgraphNode, widgetName, resolveSource) {
   const subgraph = subgraphNode?.subgraph;
@@ -227,6 +291,10 @@ export function resolvePromotedInnerTarget(subgraphNode, widgetName, resolveSour
       subgraphInput?.name,
       subgraphInput?.label,
     ].map((a) => (a == null ? null : String(a).toLowerCase()));
+    // Labels are used ONLY to DETECT which promotion the caller meant (a caller
+    // may address by a renamed promotion's display label). Locating the parent's
+    // authoritative rail widget is done LATER by the promotion RELATIONSHIP
+    // (host-input → backing widget), never by a name match (#366/#233).
     if (aliases.includes(wanted)) matches.push({ input, subgraphInput });
   }
 
@@ -284,7 +352,14 @@ export function resolvePromotedInnerTarget(subgraphNode, widgetName, resolveSour
       error: `promoted widget "${widgetName}" links to missing inner widget "${source.sourceWidgetName}" on node ${source.sourceNodeId}.`,
     };
   }
-  return { promoted: true, target: { node: innerNode, widget: innerWidget, input } };
+  // AUTHENTICATE the parent's own rail widget by the PROMOTION RELATIONSHIP — the
+  // host-input's backing widget — not by any name/label match. This is the widget
+  // that serializes into the subgraph input rail at queue time (#366). May be null
+  // (e.g. the widget is further promoted OUTWARD to an enclosing subgraph and is
+  // exposed here as an input with no settable widget); the caller FAILS CLOSED on
+  // null rather than write inner-only and render silently stale.
+  const parentWidget = resolveHostPromotedWidget(subgraphNode, input);
+  return { promoted: true, target: { node: innerNode, widget: innerWidget, input, parentWidget } };
 }
 
 /**
@@ -297,6 +372,8 @@ export function resolveWidgetWrite(node, widgetName, value, resolveSource, asser
   let targetNode = node;
   let widget = null;
   let promotedFrom = null;
+  let promotedParentWidget = null;
+  let promotedHostInput = null;
 
   if (node?.subgraph) {
     const res = resolvePromotedInnerTarget(node, widgetName, resolveSource);
@@ -312,6 +389,28 @@ export function resolveWidgetWrite(node, widgetName, value, resolveSource, asser
       targetNode = res.target.node;
       widget = res.target.widget;
       promotedFrom = { subgraph_node_id: node.id, inner_node_id: res.target.node.id };
+      promotedHostInput = res.target.input;
+      // The AUTHORITATIVE parent rail widget (backed by the host input via the
+      // promotion relationship). Null ⇒ FAIL CLOSED right here — BEFORE the
+      // assertTargetWritable gate and BEFORE any (potentially side-effecting)
+      // coercion. coerceWidgetValue may INVOKE a dynamic combo's
+      // `options.values(widget)` callback which can mutate the inner widget; if we
+      // refused only after coercion, a missing/linked/ambiguous rail could leave an
+      // uncaptured inner mutation. Refusing first guarantees a promoted write with
+      // no authoritative rail performs NO side effect at all (#366).
+      promotedParentWidget = res.target.parentWidget ?? null;
+      if (!promotedParentWidget) {
+        throw new WidgetWriteError(
+          `promoted widget "${widgetName}" on subgraph node ${node.id} resolves to an inner ` +
+            `widget, but its AUTHORITATIVE parent rail widget could not be identified (the value ` +
+            `that serializes at queue time). This happens when the widget is further promoted to ` +
+            `an enclosing subgraph (fed by an outer link / exposed as an input, not a settable ` +
+            `widget), the promotion metadata is malformed, or its name is duplicated. Refusing to ` +
+            `write the inner widget alone, which would silently render the OLD value (#366). Edit ` +
+            `this widget from the outermost subgraph node, or disconnect the inner input to make ` +
+            `the inner value authoritative.`,
+        );
+      }
     }
   }
 
@@ -334,8 +433,14 @@ export function resolveWidgetWrite(node, widgetName, value, resolveSource, asser
   // injects a registry check; it throws to refuse.
   assertTargetWritable?.(targetNode, widget);
 
-  const coerced = coerceWidgetValue(widget, value);
-  return { targetNode, widget, coerced, promotedFrom };
+  // For a promoted COMPOSITE write, merge onto the AUTHORITATIVE rail widget's
+  // current object (#366×#179) so its unspecified fields are preserved; scalars are
+  // unaffected (they don't merge). Non-promoted writes merge onto their own value.
+  // (A promoted write with no authoritative rail already threw above, BEFORE this
+  // possibly side-effecting coercion — so `promotedParentWidget` is non-null here.)
+  const coerced = coerceWidgetValue(widget, value, promotedParentWidget ?? widget);
+
+  return { targetNode, widget, coerced, promotedFrom, promotedParentWidget, promotedHostInput };
 }
 
 /**
@@ -354,13 +459,17 @@ export function applyWidgetWrite(
   // promoted node for a subgraph write, or the node's own) BEFORE it coerces the
   // value, so no coercion callback and no mutation can touch an unregistered
   // placeholder that is about to be refused (#458).
-  const { targetNode, widget: w, coerced, promotedFrom } = resolveWidgetWrite(
-    node,
-    widgetName,
-    value,
-    resolveSource,
-    assertTargetWritable,
-  );
+  const { targetNode, widget: w, coerced, promotedFrom, promotedParentWidget, promotedHostInput } =
+    resolveWidgetWrite(node, widgetName, value, resolveSource, assertTargetWritable);
+
+  // #366: for a promoted subgraph widget the AUTHORITATIVE value lives on the
+  // parent's OWN rail widget (resolved by the promotion RELATIONSHIP in
+  // resolveWidgetWrite, which already FAILED CLOSED if it could not be identified).
+  // We now write BOTH the inner widget AND the parent rail widget ATOMICALLY inside
+  // one undo envelope: either both land, or neither does and we throw — a thrown
+  // callback on EITHER side must never leave inner=new / parent=stale (a silent
+  // partial write that renders the OLD value while reporting success).
+  const parentWidget = promotedFrom ? promotedParentWidget : null;
 
   // Snapshot the EXPECTED value BEFORE the callback runs. For a COMPOSITE object
   // write (#179) `w.value` and `coerced` are the SAME reference, so a callback
@@ -370,44 +479,236 @@ export function applyWidgetWrite(
   const objectWrite = coerced !== null && typeof coerced === "object";
   const expected = objectWrite ? JSON.parse(JSON.stringify(coerced)) : coerced;
 
-  beforeChange?.();
+  const matchesExpected = (actual) =>
+    objectWrite
+      ? actual !== null &&
+        typeof actual === "object" &&
+        Object.keys(expected).every((k) => JSON.stringify(actual[k]) === JSON.stringify(expected[k]))
+      : actual === expected;
+
+  // Snapshot the PRIOR values AND deep clones of them. Rollback restores the prior
+  // OBJECT REFERENCE (`previous`), but a subsequent afterChange hook could mutate
+  // that object IN PLACE (e.g. `inner.value.strength = …`), so an identity compare
+  // (Object.is) would pass while the restored object holds corrupted fields. We
+  // verify rollback STRUCTURALLY against the pre-mutation deep clone instead.
   const previous = w.value;
+  const previousParent = parentWidget ? parentWidget.value : undefined;
+  const deepClone = (v) => (v !== null && typeof v === "object" ? JSON.parse(JSON.stringify(v)) : v);
+  const structurallyEqual = (a, b) =>
+    (a !== null && typeof a === "object") || (b !== null && typeof b === "object")
+      ? JSON.stringify(a) === JSON.stringify(b)
+      : Object.is(a, b);
+  const previousClone = deepClone(previous);
+  const previousParentClone = parentWidget ? deepClone(previousParent) : undefined;
+  // The ACTUAL serialization binding for an unlinked subgraph input is its
+  // `widgetId` (the widget-value STORE key that queue compilation reads). A callback
+  // could keep the SAME host input and projection objects but re-point `widgetId` to
+  // another store entry holding the OLD value — passing every object-identity check
+  // while the render reads the stale entry. Snapshot it so the recheck can detect a
+  // swap (#366).
+  const promotedHostWidgetId = promotedHostInput ? promotedHostInput.widgetId : undefined;
+
+  // The undo hooks are BOOKKEEPING (litegraph history). Invoke them exception-SAFE
+  // so a throwing hook can never bypass our verification/rollback and leave a silent
+  // partial write; a stateful hook that mutates values is still caught because ALL
+  // verification runs AFTER the hook fires.
+  const safeBefore = () => {
+    try {
+      beforeChange?.();
+    } catch {
+      /* history hook is best-effort */
+    }
+  };
+  const safeAfter = () => {
+    try {
+      afterChange?.();
+    } catch {
+      /* history hook is best-effort */
+    }
+  };
+
+  // Perform the write + callbacks inside ONE undo envelope. A thrown callback is
+  // CAPTURED (not rethrown here) so that VERIFICATION runs AFTER afterChange has
+  // fired its hooks: an afterChange hook can itself re-stale a widget or change the
+  // promotion topology, and that must be caught too (not just callback-time drift).
+  let threw = null;
+  safeBefore();
   try {
+    // Assign BOTH values first. The parent's projected promoted widget is a VIEW of
+    // the inner widget; its own callback typically FORWARDS to the inner one, so we
+    // fire the SEMANTIC widget callback exactly ONCE (the inner target's), NOT the
+    // rail's — otherwise a forwarding view would double-invoke the side effect. The
+    // rail's value serializes directly from `parentWidget.value`, which we set here,
+    // so it needs no callback of its own.
     w.value = coerced;
-    // Fire the widget's own callback so combo/number side effects run — the
-    // same path a manual UI edit takes.
+    if (parentWidget) parentWidget.value = coerced;
+    // Fire the inner widget's own callback so combo/number side effects run — the
+    // same single invocation a manual UI edit of the promoted control performs.
     w.callback?.(coerced, canvas, targetNode, targetNode.pos, undefined);
+  } catch (err) {
+    threw = err;
   } finally {
-    afterChange?.();
+    safeAfter();
   }
+
+  // VERIFY AFTER afterChange. Compute the failure reason (if any) WITHOUT mutating,
+  // so rollback happens in its own envelope below. Order: a thrown callback; then a
+  // value that did not stick on the inner (#240) or the authoritative rail (#366);
+  // then a promotion-relationship change (re-resolved from the LIVE graph, catching
+  // an outer link, a replaced/detached host input, or a re-pointed slot→widget map).
+  let failure = null;
+  let originalErr = null;
+  let driftFailure = false;
+  if (threw) {
+    originalErr = threw instanceof WidgetWriteError ? threw : null;
+    failure =
+      threw instanceof WidgetWriteError
+        ? threw.message
+        : `a widget callback threw (${threw?.message ?? threw})`;
+  } else if (!matchesExpected(w.value)) {
+    failure =
+      `Widget "${w.name}" on node ${targetNode.id} (${targetNode.type}) did not retain the ` +
+      `requested value: wrote ${JSON.stringify(expected)} but it became ${JSON.stringify(w.value)}.`;
+  } else if (parentWidget && !matchesExpected(parentWidget.value)) {
+    failure =
+      `Promoted rail widget "${parentWidget.name}" on subgraph node ${node.id} did not retain ` +
+      `the requested value: wrote ${JSON.stringify(expected)} but it became ` +
+      `${JSON.stringify(parentWidget.value)}. Refusing to report success with a stale rail that ` +
+      `would render the OLD value (#366).`;
+  } else if (parentWidget) {
+    // RE-RESOLVE the promotion from the LIVE graph. This is wrapped so that ANY
+    // exception thrown DURING the recheck (e.g. a callback replaced `_subgraphSlot`
+    // and the injected resolveSource now THROWS for the replacement) is treated as a
+    // topology change and drives the FULL rollback below — a recheck throw must NEVER
+    // escape with inner/rail left mutated.
+    let recheck = null;
+    let recheckThrew = false;
+    try {
+      recheck = resolvePromotedInnerTarget(node, widgetName, resolveSource);
+    } catch {
+      recheckThrew = true;
+    }
+    const drifted =
+      recheckThrew ||
+      !recheck ||
+      !recheck.promoted ||
+      !recheck.target ||
+      recheck.target.input !== promotedHostInput ||
+      recheck.target.widget !== w ||
+      recheck.target.parentWidget !== parentWidget ||
+      // The host input's serialization binding (`widgetId`, the store key queue
+      // compilation reads) must be UNCHANGED — a swap re-points serialization to a
+      // different store entry even though the input/projection objects are identical.
+      !Object.is(promotedHostInput ? promotedHostInput.widgetId : undefined, promotedHostWidgetId);
+    if (drifted) {
+      driftFailure = true;
+      failure =
+        `Promotion of "${w.name}" on subgraph node ${node.id} CHANGED during the write (a widget ` +
+        `or afterChange hook altered the host input, its link, or the slot→widget mapping${
+          recheckThrew ? "; re-resolving the promotion threw" : ""
+        }), so the rail that was synced is no longer the value that serializes at queue time. Rolled ` +
+        `back to avoid a silently-stale render (#366).`;
+    }
+  }
+
+  if (failure) {
+    // ROLL BACK in its OWN (exception-safe) undo envelope. The restore assignments
+    // are each guarded, then we READ BACK the FINAL values AFTER the envelope closes
+    // — so a setter that throws OR silently ignores the restore, AND a stateful
+    // afterChange hook that re-stales the restored value, are ALL detected. `w.value`
+    // is a plain data property on real widgets so this normally succeeds; when it
+    // does not, we report an HONEST partial-state failure rather than falsely claim
+    // a clean rollback.
+    safeBefore();
+    try {
+      // Restore the serialization BINDING first (the store key queue compilation
+      // reads), so restoring the rail value below lands on the entry that actually
+      // serializes — a callback may have re-pointed it to a different store entry.
+      if (promotedHostInput) {
+        try {
+          promotedHostInput.widgetId = promotedHostWidgetId;
+        } catch {
+          /* restore best-effort; read-back below is authoritative */
+        }
+      }
+      try {
+        w.value = previous;
+      } catch {
+        /* restore best-effort; read-back below is authoritative */
+      }
+      if (parentWidget) {
+        try {
+          parentWidget.value = previousParent;
+        } catch {
+          /* restore best-effort; read-back below is authoritative */
+        }
+      }
+    } finally {
+      safeAfter();
+    }
+    // Authoritative read-back AFTER the rollback envelope, compared STRUCTURALLY
+    // against the pre-mutation deep clones — so a setter that throws or silently
+    // ignores the restore, AND a stateful afterChange hook that mutates the restored
+    // object IN PLACE (which an identity compare would miss), are ALL detected.
+    let rollbackFailed = null;
+    if (!structurallyEqual(w.value, previousClone)) rollbackFailed = `inner "${w.name}"`;
+    if (parentWidget && !structurallyEqual(parentWidget.value, previousParentClone)) {
+      rollbackFailed = rollbackFailed
+        ? `${rollbackFailed} and rail "${parentWidget.name}"`
+        : `rail "${parentWidget.name}"`;
+    }
+    // The serialization binding must be back to its original store key, else queue
+    // compilation still reads whatever entry a callback re-pointed it to.
+    if (promotedHostInput && !Object.is(promotedHostInput.widgetId, promotedHostWidgetId)) {
+      rollbackFailed = rollbackFailed
+        ? `${rollbackFailed} and the serialization binding (widgetId)`
+        : `the serialization binding (widgetId)`;
+    }
+    // On a TOPOLOGY DRIFT, the captured `parentWidget` we just restored may be
+    // DETACHED — a callback could have swapped in a DIFFERENT live authoritative
+    // rail. Restoring the old rail does not touch that replacement, so if the LIVE
+    // promotion now resolves to a different rail that holds the just-written value,
+    // the serialized value is NOT what our rollback restored: report a PARTIAL STATE
+    // rather than falsely claim a clean rollback.
+    if (driftFailure) {
+      let liveRail = null;
+      try {
+        const live = resolvePromotedInnerTarget(node, widgetName, resolveSource);
+        liveRail = live && live.target ? live.target.parentWidget : null;
+      } catch {
+        liveRail = null;
+      }
+      if (liveRail && liveRail !== parentWidget && structurallyEqual(liveRail.value, expected)) {
+        rollbackFailed = rollbackFailed
+          ? `${rollbackFailed} and a live replacement rail "${liveRail.name}"`
+          : `a live replacement rail "${liveRail.name}"`;
+      }
+    }
+    setDirty?.();
+    if (rollbackFailed) {
+      throw new WidgetWriteError(
+        `Widget "${w.name}" on node ${targetNode.id} (${targetNode.type}) write failed: ${failure} ` +
+          `Rollback of ${rollbackFailed} did not take effect (a value setter or history hook ` +
+          `rejected/overrode it) — the graph may be in a partial state; re-set the widget or undo.`,
+      );
+    }
+    // Rollback succeeded: preserve the original WidgetWriteError message where there
+    // was one, else throw the computed failure.
+    if (originalErr) throw originalErr;
+    throw new WidgetWriteError(failure);
+  }
+
   setDirty?.();
 
-  // Verify the write stuck. A combo callback that reinterprets an index can
-  // drift a SCALAR value silently — fail rather than report a false success, by
-  // strict identity (#240). For a COMPOSITE object value (#179) the callback may
-  // clone/normalize the object, so strict identity would false-fail; require
-  // instead that every field we set is present with the value we wrote, compared
-  // against the pre-callback snapshot so an in-place drift is still caught.
-  const stuck = objectWrite
-    ? w.value !== null &&
-      typeof w.value === "object" &&
-      Object.keys(expected).every(
-        (k) => JSON.stringify(w.value[k]) === JSON.stringify(expected[k]),
-      )
-    : w.value === expected;
-  if (!stuck) {
-    throw new WidgetWriteError(
-      `Widget "${w.name}" on node ${targetNode.id} (${targetNode.type}) did not ` +
-        `retain the requested value: wrote ${JSON.stringify(expected)} but it ` +
-        `became ${JSON.stringify(w.value)}.`,
-    );
-  }
-
+  // On success, a promoted write has ALWAYS synced the authoritative parent rail
+  // widget (verified AFTER afterChange, or it would have rolled back + thrown).
+  // parent_widget_synced is reported for observability / defense-in-depth in the
+  // panel summary.
   return {
     node_id: targetNode.id,
     widget: w.name,
     previous,
     value: w.value,
-    ...(promotedFrom ? { promoted_from: promotedFrom } : {}),
+    ...(promotedFrom ? { promoted_from: { ...promotedFrom, parent_widget_synced: parentWidget != null } } : {}),
   };
 }


### PR DESCRIPTION
## Problem (#366 — SEVERE, silent wrong output)

`panel_set_widget` on a **promoted subgraph widget** wrote **only the inner node's** widget. For a ComfyUI subgraph the inner widget is fed from the subgraph **input rail**, so the **authoritative** value is the **parent subgraph node's own promoted (rail) widget** — what serializes into the rail at queue time. The parent was left stale, so the render silently used the **OLD** value while both the tool result and a follow-up inner-node read reported the **NEW** one. Invisible until you look at the output.

## Fix (`web/js/lib/widget-write.js` + the `graph_set_widget` activity summary)

- **Authenticate the rail widget by the promotion relationship** — litegraph's `getWidgetFromSlot(hostInput)` / an identity `input.widget` object that is a real member of `node.widgets` — **never a name/label guess**. A **unique-name disambiguation guard** fails closed on duplicate names; a differently-named decoy is never selected (**#233 stays safe**).
- **Fail closed** (before *any* side effect / coercion) when the rail can't be positively identified: `hostInput.link != null` (further-promoted / externally linked → non-authoritative), duplicate names, a name-only stub, or no rail. Never a silent inner-only write; `parent_widget_synced` is never a false `true`.
- **Atomic dual write.** Both values are assigned directly and the **semantic callback fires exactly once** (the inner widget's, inner-node context) so a forwarding parent view isn't double-invoked. All verification — inner value, rail value, and a **full live re-resolution of the promotion relationship** — runs **after** an exception-safe `afterChange`, so a throw, a silent drift, an `afterChange` hook that re-stales, or a mid-write topology change all **roll both values back** (second exception-safe envelope, read-back verified; a rejecting/ignoring setter → honest partial-state error, never a false "rolled back").
- Promoted **composite** (#179) writes merge onto the rail's authoritative object.
- The panel activity summary **warns** instead of printing "Set …" as success when a promoted write comes back `parent_widget_synced:false`.

## Tests

Fail-before/pass-after regression tests: rail sync (INT/STRING/composite), label-addressed promotion, differently-named decoy safety, duplicate-name / name-only-stub / linked-host / missing-rail **fail-closed** (incl. no side effect before refusal), single semantic-callback invocation, undo-envelope ordering, and atomic rollback on inner-callback throw, value drift, rail-setter drift, host-input link mutation + replacement, `afterChange` re-stale, throwing `afterChange` hook, and rollback-refusal.

- `node --test browser_tests/unit/*.test.mjs` → **587/587 pass**
- `tsc --noEmit` → clean · no `onload`/`onerror`
- Adversarial **codex review: PASS** (verified against current ComfyUI frontend that `getWidgetFromSlot` resolves the backing promoted widget and subgraph serialization reads its widget-store value)

Not browser-live-verified from the agent side (no local canvas).

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)