### PR TITLE
fix(routing): unique routing identity for unsaved workflow tabs so graph edits never misroute (#186)

### DIFF
--- a/browser_tests/unit/workflow-new-routing.test.mjs
+++ b/browser_tests/unit/workflow-new-routing.test.mjs
@@ -1,0 +1,201 @@
+// #186 — panel_new_workflow collides with an existing "Unsaved Workflow" tab and
+// graph_* edits silently misroute to the wrong graph.
+//
+// Root cause: native ComfyUI reuses the "Unsaved Workflow" TITLE/key and gives a
+// never-saved tab no path, so two unsaved tabs were indistinguishable — both to
+// panel_list_workflows (dedupe collapsed them to one) and to the pinned-target
+// guard (a pin to tab B matched whichever unsaved tab was active). The fix gives
+// every tab a unique per-instance routing id ("tmp:<uuid>" for unsaved, "wf:<path>"
+// for saved), makes that id the SOLE authority for an unsaved tab, and threads it
+// through the list, the pin, the guard, and workflow_open/rename/close.
+//
+// These tests drive the REAL decision helpers the panel uses:
+//   • classifyPinnedTarget / workflowIdentityForms — the guard's match/mismatch,
+//   • dedupeWorkflowTabRecords / workflowTabKey — the list de-duplication,
+// with a two-unsaved-tab scenario. Each has a FAIL-BEFORE assertion (the pre-fix
+// shape false-passes) next to the PASS-AFTER assertion (the fix fails closed).
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  classifyPinnedTarget,
+  workflowIdentityForms
+} from '../../web/js/lib/workflow-chat-identity.js'
+import {
+  dedupeWorkflowTabRecords,
+  workflowTabKey
+} from '../../web/js/lib/session-rebind.js'
+
+// Native ComfyUI shape for an UNSAVED tab: shared title/key, no disk path, and the
+// isTemporary/isPersisted flags that mark it never-saved.
+const unsavedWf = () => ({
+  path: undefined,
+  filename: undefined,
+  key: 'Unsaved Workflow',
+  isPersisted: false,
+  isTemporary: true
+})
+// A PERSISTED tab: unique on-disk identity.
+const savedWf = (p) => ({
+  path: p,
+  filename: p.split('/').pop(),
+  key: p,
+  isPersisted: true,
+  isTemporary: false
+})
+
+// ---------------------------------------------------------------------------
+// Authority model: an unsaved tab answers ONLY to its routing id; a saved tab
+// answers to its unique on-disk forms too.
+// ---------------------------------------------------------------------------
+
+test('an unsaved tab authorizes ONLY its routing id — never the shared title/key', () => {
+  const forms = workflowIdentityForms(unsavedWf(), 'tmp:AAA')
+  assert.deepEqual(forms, ['tmp:AAA'], 'shared native key/title/path must NOT be authority for an unsaved tab')
+})
+
+test('a persisted tab authorizes by path / filename / key / wf: form and its routing id', () => {
+  const forms = workflowIdentityForms(savedWf('workflows/Foo.json'), 'wf:workflows/Foo.json')
+  assert.ok(forms.includes('workflows/Foo.json'))
+  assert.ok(forms.includes('Foo.json'))
+  assert.ok(forms.includes('wf:workflows/Foo.json'))
+})
+
+test('#349 no regression under isTemporary flag-drift: a persisted file still authorizes by path', () => {
+  // A workflow that IS on disk (isPersisted:true) but is transiently mis-flagged
+  // isTemporary:true after an open-ack race (#215). Its unique disk path must still
+  // authorize a path pin — keying authority on isTemporary would spuriously reject.
+  const drifted = { path: 'workflows/Foo.json', filename: 'Foo.json', key: 'workflows/Foo.json', isPersisted: true, isTemporary: true }
+  const forms = workflowIdentityForms(drifted, 'tmp:driftfresh')
+  assert.equal(classifyPinnedTarget('workflows/Foo.json', forms), 'match', 'a correct path pin must not fail under flag-drift')
+})
+
+test('#186 same-instance save: a pre-save tmp: pin still matches the tab after it is saved', () => {
+  // create → pin("tmp:XYZ") → build → SAVE, on a frontend whose save keeps the SAME
+  // workflow OBJECT (ComfyUI 1.45): post-save the routing id is now "wf:...", but the
+  // orchestrator keeps injecting the old "tmp:XYZ" pin. The panel passes the retained
+  // original tmp: id (from _priorTempWorkflowIds, object-keyed) as an extra authority
+  // so the flow continues instead of failing closed. (On 1.47 the save REPLACES the
+  // object, so the tmp id is legitimately gone and the guard fails CLOSED with a
+  // re-target instruction — a safe, non-misrouting outcome, covered in the panel.)
+  const savedAfter = savedWf('workflows/MyFlow.json')
+  const forms = workflowIdentityForms(savedAfter, 'wf:workflows/MyFlow.json', ['tmp:XYZ'])
+  assert.equal(classifyPinnedTarget('tmp:XYZ', forms), 'match', 'pre-save pin must survive a same-object save')
+  // ...but the tmp: id of a DIFFERENT tab must NOT match it (no cross-tab leak).
+  assert.equal(classifyPinnedTarget('tmp:OTHER', forms), 'mismatch')
+})
+
+test('matching is CASE-SENSITIVE so distinct files on a case-sensitive FS never fail open', () => {
+  // #207 preserves case because "Foo.json" and "foo.json" are different files on
+  // Linux. A pin must not authorize the wrong graph by case-folding.
+  const forms = workflowIdentityForms(savedWf('workflows/Foo.json'), 'wf:workflows/Foo.json')
+  assert.equal(classifyPinnedTarget('workflows/foo.json', forms), 'mismatch', 'case-variant path must fail closed')
+  assert.equal(classifyPinnedTarget('workflows/Foo.json', forms), 'match')
+  // Backslash vs forward slash IS normalized (same file, Windows path form).
+  assert.equal(classifyPinnedTarget('workflows\\Foo.json', forms), 'match', 'separators are normalized')
+})
+
+// ---------------------------------------------------------------------------
+// Guard: pinned-target match/mismatch (the silent-misroute half of #186).
+// ---------------------------------------------------------------------------
+
+test('#186 fail-closed: a pin to a NEW unsaved tab mismatches a DIFFERENT active unsaved tab', () => {
+  // Agent created tab B via panel_new_workflow (routing id "tmp:BBB") and pinned to
+  // it, but the active canvas snapped back to the pre-existing tab A ("tmp:AAA").
+  const activeForms = workflowIdentityForms(unsavedWf(), 'tmp:AAA')
+
+  // PASS-AFTER: the routing id makes the two unsaved tabs distinguishable, so the
+  // pin to tab B is a POSITIVE mismatch against active tab A → fail closed.
+  assert.equal(
+    classifyPinnedTarget('tmp:BBB', activeForms),
+    'mismatch',
+    'editing tab A while pinned to tab B must fail closed, not silently misroute'
+  )
+
+  // PASS-AFTER: even the shared native title/key ("Unsaved Workflow"), which
+  // workflow_new still returns as `active` and which a naive agent might pin, no
+  // longer authorizes ANY unsaved tab — it fails closed instead of misrouting.
+  assert.equal(
+    classifyPinnedTarget('Unsaved Workflow', activeForms),
+    'mismatch',
+    'a shared-title pin must fail closed post-fix'
+  )
+
+  // FAIL-BEFORE: the pre-fix identity forms INCLUDED the shared native key for
+  // unsaved tabs, so a pin to that key matched whatever unsaved tab was active —
+  // exactly the silent misroute #186 reported.
+  const preFixForms = ['Unsaved Workflow'] // wf.key was authority pre-fix
+  assert.equal(
+    classifyPinnedTarget('Unsaved Workflow', preFixForms),
+    'match',
+    'documents the pre-fix false-pass the routing-id-only authority closes'
+  )
+})
+
+test('#186 the correctly-targeted unsaved tab still matches its own routing id', () => {
+  const activeForms = workflowIdentityForms(unsavedWf(), 'tmp:BBB')
+  assert.equal(classifyPinnedTarget('tmp:BBB', activeForms), 'match')
+})
+
+test('two unsaved tabs never share a routing id, so cross-pins fail closed both ways', () => {
+  const aActive = workflowIdentityForms(unsavedWf(), 'tmp:AAA')
+  const bActive = workflowIdentityForms(unsavedWf(), 'tmp:BBB')
+  assert.equal(classifyPinnedTarget('tmp:AAA', aActive), 'match')
+  assert.equal(classifyPinnedTarget('tmp:BBB', aActive), 'mismatch')
+  assert.equal(classifyPinnedTarget('tmp:BBB', bActive), 'match')
+  assert.equal(classifyPinnedTarget('tmp:AAA', bActive), 'mismatch')
+})
+
+test('no regression to #349: a saved-workflow pin matches by path / filename / key / wf: form', () => {
+  const forms = workflowIdentityForms(savedWf('workflows/Foo.json'), 'wf:workflows/Foo.json')
+  for (const pin of [
+    'workflows/Foo.json', //         raw path
+    'wf:workflows/Foo.json', //      canonical routing id
+    'Foo.json', //                   filename
+    'Foo' //                         filename sans .json (case-normalized)
+  ]) {
+    assert.equal(classifyPinnedTarget(pin, forms), 'match', `pin "${pin}" should match the saved wf`)
+  }
+  // A pin to a DIFFERENT saved workflow is a positive mismatch (fail closed).
+  assert.equal(classifyPinnedTarget('workflows/Bar.json', forms), 'mismatch')
+})
+
+test('classifier is 3-valued: indeterminate inputs are "unknown" (the guard fails closed on them)', () => {
+  // The PURE classifier reports "unknown" when it cannot decide — no active identity
+  // forms, or an empty/blank pin. The GUARD turns a non-empty pin + "unknown" into a
+  // fail-closed error (it cannot confirm the pin names the live canvas); a blank pin
+  // never reaches the guard (it gates on pinnedPath.trim()). This test pins the
+  // function contract, not the policy.
+  assert.equal(classifyPinnedTarget('tmp:BBB', []), 'unknown') // unresolvable active workflow
+  const forms = workflowIdentityForms(unsavedWf(), 'tmp:AAA')
+  assert.equal(classifyPinnedTarget('', forms), 'unknown')
+  assert.equal(classifyPinnedTarget('   ', forms), 'unknown')
+  assert.equal(classifyPinnedTarget(undefined, forms), 'unknown')
+})
+
+// ---------------------------------------------------------------------------
+// List: panel_list_workflows de-duplication (the "only one Unsaved Workflow
+// shown" half of #186).
+// ---------------------------------------------------------------------------
+
+test('#186 list: distinct unsaved tabs survive dedupe once keyed by routing id', () => {
+  // PASS-AFTER: the fixed brief() reports path:null and key:<routing id> for unsaved
+  // tabs, so the two tabs carry distinct stable keys and both appear.
+  const fixed = [
+    { path: null, filename: undefined, key: 'tmp:AAA', routing_key: 'tmp:AAA', active: true, persisted: false },
+    { path: null, filename: undefined, key: 'tmp:BBB', routing_key: 'tmp:BBB', active: false, persisted: false }
+  ]
+  assert.notEqual(workflowTabKey(fixed[0]), workflowTabKey(fixed[1]), 'unsaved tabs must key distinctly')
+  assert.equal(dedupeWorkflowTabRecords(fixed).length, 2, 'both unsaved tabs must be listed')
+
+  // FAIL-BEFORE: the pre-fix brief() reported the shared native key (and, per the
+  // report, a synthesized "Unsaved Workflow.json" path) for every unsaved tab, so
+  // dedupe collapsed them to one — hiding the second tab.
+  const preFix = [
+    { path: 'workflows/Unsaved Workflow.json', filename: 'Unsaved Workflow.json', key: 'Unsaved Workflow', active: true },
+    { path: 'workflows/Unsaved Workflow.json', filename: 'Unsaved Workflow.json', key: 'Unsaved Workflow', active: false }
+  ]
+  assert.equal(workflowTabKey(preFix[0]), workflowTabKey(preFix[1]), 'documents the pre-fix key collision')
+  assert.equal(dedupeWorkflowTabRecords(preFix).length, 1, 'documents the pre-fix collapse to one tab')
+})

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -95,9 +95,11 @@ import {
   updateMetadataEntry,
 } from "./lib/chat-history-store.js";
 import {
+  classifyPinnedTarget,
   normalizedWorkflowPath,
   shouldForkEmbeddedWorkflowUuid,
   workflowAliasForPath,
+  workflowIdentityForms,
 } from "./lib/workflow-chat-identity.js";
 import { validateA2UISpec, renderA2UICard, renderA2UIInert, renderA2UIFailCard, A2UI_CSS } from "./cmcp-a2ui.js";
 import { openSidePanel } from "./cmcp-sidepanel-ui.js";
@@ -811,6 +813,12 @@ function getTabId() {
 // tabs. The instance is the only identity that survives that churn (cf.
 // currentWorkflowRef / _workflowObjectUuids).
 const _tempWorkflowInstanceIds = new WeakMap(); // wf object -> "tmp:<uuid>"
+// wf object -> its ORIGINAL "tmp:<uuid>" id, retained even after the tab is saved
+// (unlike _tempWorkflowInstanceIds, which the save-adopt bookkeeping clears). A
+// session pinned to the unsaved tab keeps the tmp: id after the save's tab-id
+// migration (the orchestrator moves the pin unchanged), so the guard must still
+// recognize it as naming this same instance (#186).
+const _priorTempWorkflowIds = new WeakMap();
 const _workflowObjectUuids = new WeakMap();
 const _workflowUuidOwners = new Map();
 const WORKFLOW_UUID_ALIASES_KEY = "comfyui-mcp.panel.workflowUuidAliases";
@@ -851,6 +859,36 @@ function savedWorkflowPath(wf = activeWorkflowRef()) {
   return wf?.isPersisted === true && wf?.isTemporary !== true && typeof wf.path === "string" && wf.path
     ? wf.path
     : null;
+}
+
+// Does this tab have a UNIQUE on-disk identity (a real path), so its path/key/
+// filename may authorize a pinned-target match or a tab lookup? Keyed on
+// `isPersisted` + a real path only — NOT `isTemporary`, which drifts to true for a
+// file that IS on disk after an open-ack race (#215). A never-saved tab has
+// isPersisted=false and is addressable ONLY by its per-instance routing id, which
+// is what keeps two "Unsaved Workflow" tabs from colliding (#186). Distinct from
+// savedWorkflowPath(), whose stricter `isTemporary` gate guards the destructive
+// Save-As move path (#226), a different concern.
+function workflowDiskIdentityPath(wf) {
+  return wf?.isPersisted === true && typeof wf?.path === "string" && wf.path ? wf.path : null;
+}
+
+// Does `sel` (a path / filename / native key / routing id) name workflow record
+// `w`? The per-instance routing id ALWAYS authorizes and is the ONLY authority for
+// an UNSAVED tab; a saved tab additionally answers to its unique on-disk forms.
+// The original tmp: id of a since-saved tab still authorizes it (see
+// _priorTempWorkflowIds) so a pre-save reference keeps working after the save.
+function workflowRecordMatchesSelector(w, sel) {
+  if (!w || typeof sel !== "string" || !sel) return false;
+  if (workflowTabId(w) === sel) return true;
+  if (_priorTempWorkflowIds.get(w) === sel) return true;
+  if (!workflowDiskIdentityPath(w)) return false;
+  return (
+    w.path === sel ||
+    w.filename === sel ||
+    w.key === sel ||
+    (typeof w.filename === "string" && w.filename.replace(/\.json$/i, "") === sel)
+  );
 }
 
 function activeWorkflowExtra(wf = activeWorkflowRef(), { create = false } = {}) {
@@ -988,8 +1026,7 @@ function workflowStorageKey({ embed = false } = {}) {
   return `workflow:${workflowStableUuid(activeWorkflowRef(), { embed })}`;
 }
 
-function workflowTabId() {
-  const wf = activeWorkflowRef();
+function workflowTabId(wf = activeWorkflowRef()) {
   if (!wf) return getTabId();
   const saved = savedWorkflowPath(wf);
   if (saved) return "wf:" + wf.path;
@@ -1000,6 +1037,12 @@ function workflowTabId() {
   if (!id) {
     id = "tmp:" + crypto.randomUUID();
     _tempWorkflowInstanceIds.set(wf, id);
+    // Retain the FIRST tmp: id ever minted for this object, for its whole life, so a
+    // create-time pin survives the tab's first save (tmp:→wf:) — see
+    // _priorTempWorkflowIds. Never overwrite it: save-adopt clears the routing map
+    // above, and a later isTemporary flag-drift (#215) would otherwise mint a fresh
+    // tmp: here and clobber the original create-time pin (guard-off-by-one).
+    if (!_priorTempWorkflowIds.has(wf)) _priorTempWorkflowIds.set(wf, id);
   }
   return id;
 }
@@ -5890,16 +5933,45 @@ const GRAPH_TOOL_EXECUTORS = {
     const s = app?.extensionManager?.workflow;
     if (!s) throw new Error("workflow service unavailable on this frontend");
     const active = s.activeWorkflow;
-    const brief = (w) => ({
-      path: w.path,
-      filename: w.filename,
-      key: w.key,
-      active: !!active && (w === active || w.key === active.key),
-      modified: !!w.isModified,
-      persisted: !!w.isPersisted,
-    });
+    const activeRoutingKey = active ? workflowTabId(active) : null;
+    // Every tab gets its per-instance routing id ("wf:<path>" saved, "tmp:<uuid>"
+    // unsaved). For an UNSAVED tab this is the ONLY unique, matchable handle —
+    // native ComfyUI reuses the "Unsaved Workflow" title/key/filename across unsaved
+    // tabs and a never-saved tab has no path. So for an unsaved tab report path AND
+    // filename as null and expose the routing id as the `key` (and always as
+    // `routing_key`); a human-readable label rides `title`. That makes two unsaved
+    // tabs distinguishable (both to dedupe and to the orchestrator's pin resolver,
+    // which matches records by path/filename/key) so a pin binds to exactly one
+    // graph (#186). A tab with a real on-disk path keeps its native path/filename/key.
+    const brief = (w) => {
+      const diskPath = workflowDiskIdentityPath(w);
+      const routingKey = workflowTabId(w);
+      return {
+        path: diskPath,
+        filename: diskPath ? w.filename : null,
+        // A per-record display label — never used for matching, so the shared
+        // "Unsaved Workflow" is fine here. Do NOT use getWorkflowTitle(): it reads
+        // the ACTIVE tab's document.title and would mislabel other tabs.
+        title: w.filename || "Unsaved Workflow",
+        key: diskPath ? w.key : routingKey,
+        routing_key: routingKey,
+        active: !!active && (w === active || routingKey === activeRoutingKey),
+        modified: !!w.isModified,
+        persisted: !!diskPath,
+      };
+    };
+    const openList = dedupeWorkflowTabRecords((s.openWorkflows ?? []).filter(Boolean).map(brief));
+    const activeDiskPath = workflowDiskIdentityPath(active);
     return {
-      active: active ? { path: active.path, filename: active.filename, key: active.key } : null,
+      active: active
+        ? {
+            path: activeDiskPath,
+            filename: activeDiskPath ? active.filename : null,
+            title: active.filename || getWorkflowTitle(),
+            key: activeDiskPath ? active.key : activeRoutingKey,
+            routing_key: activeRoutingKey,
+          }
+        : null,
       // Guard against nullish entries in openWorkflows: a tab mid-open/close can
       // momentarily leave an undefined slot, and an unguarded `w.path` in `brief`
       // threw "Cannot read properties of undefined (reading 'path')" — removing the
@@ -5909,7 +5981,15 @@ const GRAPH_TOOL_EXECUTORS = {
       // #207 — collapse records that share a stable workflow key so the same
       // active tab is never reported twice (a repeated panel_load_workflow used
       // to append duplicate active records, and a later save then 409'd).
-      open: dedupeWorkflowTabRecords((s.openWorkflows ?? []).filter(Boolean).map(brief)),
+      //
+      // Emit the SAME list under both `open` and `workflows`: the orchestrator's
+      // pin-canonicalizer (resolveOpenWorkflow, #512) enumerates `parsed.workflows`
+      // to verify a pin is open and fail closed (NOT_OPEN) when it isn't — with only
+      // `open` present it saw no list and fell back to the raw pin unverified. The
+      // alias lets a "tmp:<uuid>" pin resolve to its exact tab (#186); `open` stays
+      // for any existing reader.
+      open: openList,
+      workflows: openList,
     };
   },
 
@@ -5918,7 +5998,29 @@ const GRAPH_TOOL_EXECUTORS = {
     if (!mgr?.command?.execute) throw new Error("command service unavailable");
     // Comfy.NewBlankWorkflow opens a fresh TAB — the current workflow is untouched.
     await mgr.command.execute("Comfy.NewBlankWorkflow");
-    return { created: true, active: getWorkflowTitle() };
+    // Bind a UNIQUE, stable routing identity to the just-created tab NOW, at
+    // creation, so a session pinned to this key routes subsequent graph_* edits to
+    // THIS graph and never a pre-existing "Unsaved Workflow" tab (#186). Native
+    // ComfyUI reuses the "Unsaved Workflow" TITLE/key across unsaved tabs, so the
+    // title is not a routing key — the per-instance tmp: id (keyed on the workflow
+    // object) is. FAIL CLOSED if the frontend did not surface the new workflow as
+    // active: without a resolvable object we cannot mint a unique key, and returning
+    // a title alone would invite the agent to edit whatever unsaved tab is active.
+    const wf = activeWorkflowRef();
+    if (!wf) {
+      throw new Error(
+        "workflow_new: created a blank workflow but the frontend did not expose it as the " +
+          "active workflow — cannot establish a unique routing target. Retry, or select the new " +
+          "tab before editing.",
+      );
+    }
+    // Mint the per-instance tmp: routing id (and seed the transcript uuid) eagerly so
+    // the key exists BEFORE the first edit and is returned for pinning.
+    const key = workflowTabId(wf);
+    workflowStableUuid(wf);
+    // `key`/`routing_key` are the unique handle the agent should pass to
+    // panel_set_workflow_target so its session pins to this exact graph.
+    return { created: true, active: getWorkflowTitle(), key, routing_key: key };
   },
 
   async workflow_open({ path }) {
@@ -5926,16 +6028,14 @@ const GRAPH_TOOL_EXECUTORS = {
     if (!s?.openWorkflow) throw new Error("workflow service unavailable");
     const find = () => {
       const all = [...(s.openWorkflows ?? []), ...(s.workflows ?? [])];
+      // getWorkflowByPath resolves a real disk path only (returns null for a
+      // "tmp:<uuid>" routing id). The array scan then resolves EVERY documented
+      // selector — path/filename/key for a saved tab, and the per-instance routing
+      // id for an unsaved one (its ONLY valid selector — the shared filename/key
+      // must never select an arbitrary unsaved tab, #186).
       return (
         (typeof s.getWorkflowByPath === "function" && path && s.getWorkflowByPath(path)) ||
-        all.find(
-          (w) =>
-            w &&
-            (w.path === path ||
-              w.filename === path ||
-              w.key === path ||
-              (w.filename && w.filename.replace(/\.json$/i, "") === path)),
-        )
+        all.find((w) => workflowRecordMatchesSelector(w, path))
       );
     };
     let target = find();
@@ -5996,7 +6096,7 @@ const GRAPH_TOOL_EXECUTORS = {
     if (!name) throw new Error("name is required");
     const all = [...(s.openWorkflows ?? []), ...(s.workflows ?? [])];
     const target = path
-      ? all.find((w) => w && (w.path === path || w.filename === path || w.key === path))
+      ? all.find((w) => workflowRecordMatchesSelector(w, path))
       : s.activeWorkflow;
     if (!target) throw new Error("no target workflow");
     const clean = name.replace(/\.json$/i, "");
@@ -6010,9 +6110,7 @@ const GRAPH_TOOL_EXECUTORS = {
     const s = app?.extensionManager?.workflow;
     if (!s?.closeWorkflow) throw new Error("close unavailable on this frontend");
     const target = path
-      ? (s.openWorkflows ?? []).find(
-          (w) => w && (w.path === path || w.filename === path || w.key === path),
-        )
+      ? (s.openWorkflows ?? []).find((w) => workflowRecordMatchesSelector(w, path))
       : s.activeWorkflow;
     if (!target) throw new Error("no target workflow");
     // Guard against data loss: don't silently close a workflow with unsaved
@@ -7869,34 +7967,62 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // panel has no way to mutate a non-active workflow's graph. So if the
             // pinned workflow is not the active one, executing would SILENTLY write
             // to the wrong graph (the reported data corruption). Fail loudly with a
-            // retryable error instead. Only fires on a POSITIVE mismatch (active
-            // identity resolvable and none of its ids match), so an unresolvable
-            // frontend never spuriously rejects, and current-mode sessions (which
-            // never carry workflow_path) are wholly unaffected.
+            // retryable error instead. Fires on a POSITIVE mismatch (active identity
+            // resolvable and no form matches) AND when the active workflow is
+            // unresolvable while a pin is set (can't confirm the target → fail closed,
+            // #186). Current-mode sessions never carry workflow_path, so they never
+            // reach this branch.
             const pinnedPath = msg?.[WORKFLOW_PATH_FIELD];
             if (typeof pinnedPath === "string" && pinnedPath.trim()) {
               const wf = activeWorkflowRef();
-              const want = normalizedWorkflowPath(pinnedPath);
-              // A pin identifier from panel_list_workflows / panel_set_workflow_target
-              // may be a path, a key, OR a filename (all three are documented as valid
-              // pin ids), so compare against every form the active workflow exposes —
-              // otherwise a legitimate filename-based pin is falsely rejected.
-              const wfFilename = typeof wf?.filename === "string" ? wf.filename : null;
-              const have = [
-                wf?.path,
-                wf?.key,
-                wf?.path ? "wf:" + wf.path : null,
-                wfFilename,
-                wfFilename ? wfFilename.replace(/\.json$/i, "") : null,
-              ]
-                .filter((x) => typeof x === "string" && x)
-                .map(normalizedWorkflowPath);
-              if (have.length && !have.includes(want)) {
+              // A pin identifier from panel_list_workflows / panel_new_workflow /
+              // panel_set_workflow_target may be a path, a native key, a filename, OR
+              // the per-instance routing id ("tmp:<uuid>" / "wf:<path>"). The routing
+              // id is the ONLY form that distinguishes two "Unsaved Workflow" tabs
+              // (#186), so include it — otherwise a pin to one unsaved tab silently
+              // matches whichever unsaved tab is active. Only a POSITIVE mismatch
+              // rejects (active identity resolvable and no form matches), so an
+              // unresolvable frontend never spuriously fails and current-mode sessions
+              // (no workflow_path) are wholly unaffected.
+              // Authorize the active workflow's identity forms PLUS its original
+              // tmp: id: when a tab is saved WITHOUT swapping the underlying object
+              // (same-instance save), the orchestrator keeps injecting the pre-save
+              // "tmp:<uuid>" pin (it moves the pin unchanged across the save's tab-id
+              // migration), so this same instance must still be recognized (#186).
+              const priorTemp = wf ? _priorTempWorkflowIds.get(wf) : null;
+              const forms = wf ? workflowIdentityForms(wf, workflowTabId(wf), [priorTemp]) : [];
+              const verdict = classifyPinnedTarget(pinnedPath, forms);
+              if (verdict === "unknown") {
+                // Pinned, but the panel cannot read the active workflow right now, so
+                // it CANNOT confirm the pin names the live canvas. Editing anyway would
+                // write blindly to app.canvas.graph — exactly the silent misroute #186
+                // must prevent. Fail closed with a retryable error (a transient null
+                // active workflow resolves on retry; a truly serviceless frontend can
+                // never have pinned in the first place).
                 throw new Error(
-                  `workflow mismatch: your session is pinned to "${pinnedPath}", but the active ` +
-                    `canvas is "${wf?.path || wf?.key || "unknown"}". The panel can only edit the ` +
-                    `active workflow — switch to the pinned tab (panel_open_workflow) or re-target ` +
-                    `with panel_set_workflow_target({mode:"current"}), then retry.`,
+                  `workflow target unresolved: your session is pinned to "${pinnedPath}", but the ` +
+                    `panel cannot read the active workflow right now — retry in a moment, or re-target ` +
+                    `with panel_set_workflow_target({mode:"current"}).`,
+                );
+              }
+              if (verdict === "mismatch") {
+                // Fail CLOSED — never edit a graph the session isn't pinned to. The
+                // guidance stays GENERIC: the active canvas may be an UNRELATED tab the
+                // user switched to, so we must NOT claim it is the pinned workflow's
+                // saved successor or recommend pinning it (cross-object lineage is
+                // unknowable). A temporary pin that stopped resolving usually means the
+                // pinned tab was closed, or SAVED on a frontend whose Save-As replaces
+                // the workflow object (its "tmp:" id does not survive a save) — hence
+                // the neutral hint to re-list and re-select the intended workflow.
+                const tempHint = pinnedPath.startsWith("tmp:")
+                  ? ` A "tmp:" id names an UNSAVED tab and does not survive that tab being closed or saved.`
+                  : "";
+                throw new Error(
+                  `workflow mismatch: your session is pinned to "${pinnedPath}", but that is not the ` +
+                    `active canvas ("${wf?.path || wf?.key || "unknown"}").${tempHint} List the open ` +
+                    `workflows (panel_list_workflows) and re-target the intended one with ` +
+                    `panel_set_workflow_target, or switch to it (panel_open_workflow) — or, if you meant ` +
+                    `to edit the current canvas, re-target with panel_set_workflow_target({mode:"current"}). Then retry.`,
                 );
               }
             }

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -40,6 +40,73 @@ export function shouldForkEmbeddedWorkflowUuid({
   );
 }
 
+/** Every identity string the ACTIVE workflow answers to, for pinned-target
+ *  matching (#186/#349). `routingKey` is the per-instance opaque id — "wf:<path>"
+ *  for a saved tab, "tmp:<uuid>" for an unsaved one — and ALWAYS authorizes.
+ *
+ *  Critically, the shared forms (path, native key, filename) authorize ONLY a
+ *  PERSISTED tab, whose on-disk identity is unique. An UNSAVED tab shares the
+ *  native "Unsaved Workflow" key/title with every other unsaved tab and has no real
+ *  path, so accepting those forms would re-open the #186 misroute (a pin to one
+ *  unsaved tab matching whichever unsaved tab is active). For an unsaved tab the
+ *  routing id is therefore the ONLY authority. Persistence is read straight off the
+ *  workflow object's own flags — the same test savedWorkflowPath() uses. */
+export function workflowIdentityForms(wf, routingKey, extraForms = []) {
+  const forms = [];
+  const add = (v) => {
+    if (typeof v === "string" && v) forms.push(v);
+  };
+  add(routingKey);
+  // `extraForms` carries additional per-instance authorities the caller knows —
+  // notably the ORIGINAL "tmp:<uuid>" id of a tab that has since been saved, so a
+  // pin taken before the save still matches the same instance afterwards (the
+  // orchestrator moves the pin unchanged across the save's tab-id migration).
+  for (const e of Array.isArray(extraForms) ? extraForms : []) add(e);
+  // A tab with a real on-disk PATH has a unique identity, so its path/key/filename
+  // may authorize a pin. Deliberately keyed on `isPersisted` + a real path, NOT on
+  // `isTemporary`: that flag is derived from `size` and drifts to true for a file
+  // that IS on disk after a panel_open_workflow ack race (#215), and requiring it
+  // false here would spuriously reject a correct path pin (#349). A never-saved tab
+  // has isPersisted=false → routing id is its ONLY authority, which is what keeps two
+  // "Unsaved Workflow" tabs from colliding (#186).
+  const hasDiskIdentity = wf?.isPersisted === true && typeof wf?.path === "string" && wf.path;
+  if (hasDiskIdentity) {
+    const filename = typeof wf.filename === "string" ? wf.filename : null;
+    add(wf.path);
+    add(wf.key);
+    add("wf:" + wf.path);
+    add(filename);
+    if (filename) add(filename.replace(/\.json$/i, ""));
+  }
+  return forms;
+}
+
+/** Decide whether a pinned workflow identifier addresses the ACTIVE workflow.
+ *  `activeForms` is the output of workflowIdentityForms() for the live canvas.
+ *  Returns:
+ *    "match"    — the pin names the active workflow → the edit may proceed;
+ *    "mismatch" — the active identity is resolvable AND none of its forms match
+ *                 → FAIL CLOSED (the pinned tab is not the active canvas, so
+ *                 running would silently edit the wrong graph — #186);
+ *    "unknown"  — the pin is empty, or the active workflow exposes no identity
+ *                 form → never reject (an unresolvable frontend must not spuriously
+ *                 fail, and current-mode sessions carry no pin).
+ *  Matching is CASE-SENSITIVE (only path separators are normalized): on a
+ *  case-sensitive filesystem "workflows/Foo.json" and "workflows/foo.json" are
+ *  DISTINCT files, so lowercasing here (as normalizedWorkflowPath does for alias
+ *  identity) would let a pin authorize the wrong graph — the same reason #207's
+ *  workflowTabKey preserves case. Routing ids (tmp:/wf:) are case-stable, so exact
+ *  matching never rejects a legitimate routing-id pin. */
+export function classifyPinnedTarget(pinnedId, activeForms) {
+  const norm = (v) =>
+    typeof v === "string" && v.trim() ? v.replaceAll("\\", "/").trim() : null;
+  const want = norm(pinnedId);
+  if (!want) return "unknown";
+  const have = (Array.isArray(activeForms) ? activeForms : []).map(norm).filter(Boolean);
+  if (!have.length) return "unknown";
+  return have.includes(want) ? "match" : "mismatch";
+}
+
 /** Exact-match authorization guard for activating a workflow transcript.
  *  Paths and titles are migration/display metadata, never resume authority. */
 export function isThreadInScope(thread, scopeKey) {


### PR DESCRIPTION
## Problem (#186, SEVERE)

`panel_new_workflow` called while another unsaved tab already existed collided with it: native ComfyUI reuses the **"Unsaved Workflow"** title/key across unsaved tabs and gives a never-saved tab no path, so two unsaved tabs were indistinguishable. A session pinned to the new tab then had its `graph_*` edits **silently land on the wrong graph** (the reported 20 failed `panel_connect` calls against mismatched ids), and `panel_list_workflows` collapsed both tabs into a single record.

Partially mitigated in 0.11.5 (WS-1 pinned-target guard) but the residual unsaved↔unsaved collision remained — this closes it at the root.

## Fix — routing id is the SOLE authority for an unsaved tab, end to end

The panel already mints a unique per-instance id (`tmp:<uuid>` unsaved / `wf:<path>` saved) via `workflowTabId`; it was only used for the bridge `tab_id`. This threads it through every path that identifies a tab:

- **`workflow_new`** resolves the just-created workflow, mints + **returns** its unique `key`/`routing_key`, and **fails closed** if the frontend doesn't expose it as active.
- **`workflow_list`** reports `path`/`filename` `null` and `key` = routing id for unsaved tabs (label rides a non-matching `title`); also mirrors the list under **`workflows`** so the orchestrator's pin resolver (#512) can canonicalize + fail closed instead of falling back to a raw pin.
- **`workflow_open`/`rename`/`close`** use a shared selector that authorizes an unsaved tab **only** by its routing id (or retained prior tmp id), never the shared filename/key.
- **Pinned-target guard** authorizes via a pure, unit-tested classifier (`workflowIdentityForms` + `classifyPinnedTarget`) and **fails closed** on a positive mismatch **and** an unresolvable-active pin. Matching is **case-sensitive** (separators normalized only) so distinct files on a case-sensitive FS never fail open (#207); disk authority keys on `isPersisted`+path, not the drift-prone `isTemporary` flag (#349-safe).
- Each instance's **original `tmp:` id is retained** (`_priorTempWorkflowIds`, first-wins) so a same-object save keeps a pre-save pin valid; an object-swapping Save-As (ComfyUI 1.47) safely **fails closed with a generic re-target message** rather than misrouting.

Net invariant: an unsaved graph edit either targets the intended graph or **fails closed** — it is never silently misrouted.

## Tests / gates

- New `browser_tests/unit/workflow-new-routing.test.mjs`: fail-before/pass-after for the two-unsaved-tab collision, same-object save transition, `isTemporary` flag-drift, case-sensitivity, and list dedupe.
- Full unit suite green (567); `tsc --noEmit` clean; panel verified as ESM (`node --check` as `.mjs`); no `onload`/`onerror`.
- Codex adversarial review: **PASS** (after 5 revision rounds — cross-repo pin contract, save-transition, case-sensitivity, and non-misleading recovery message all hardened).

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)