### PR TITLE
fix(set_widget): fail closed on removed/unverifiable node type via fresh /object_info (#458 set_widget gap)

### DIFF
--- a/browser_tests/unit/module-graph-link.test.mjs
+++ b/browser_tests/unit/module-graph-link.test.mjs
@@ -1,0 +1,58 @@
+/**
+ * MODULE-GRAPH LINK smoke test (P0 guard).
+ *
+ * `node --check <file>.mjs` validates SYNTAX only — it does NOT resolve cross-module
+ * imports, so a panel `import { foo } from "./lib/x.js"` where `x.js` never exports
+ * `foo` passes --check yet FAILS to link at load time, breaking the ENTIRE panel (no
+ * write can run). This test mirrors the panel's actual NAMED imports from the lib
+ * modules this fix touches: if any named export is missing/renamed, THIS test file
+ * itself fails to link and `node --test` reports it — catching the break before load.
+ *
+ * The named imports below MUST stay in lockstep with comfyui-mcp-panel.js's imports
+ * from these modules (and set-widget.js's imports from widget-write.js/node-resolve.js).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// --- Mirror comfyui-mcp-panel.js imports (the panel's own module edges) -------------
+import {
+  isStaleAssetCandidate,
+  reapplyDefsToLiveNodes,
+  refreshComboOptionsFromDefs,
+} from "../../web/js/lib/asset-staleness.js";
+import { assertAddNodeResolvableRefreshing } from "../../web/js/lib/node-resolve.js";
+import { runSetWidget } from "../../web/js/lib/set-widget.js";
+
+// --- Mirror set-widget.js imports (the fix's internal module edges) -----------------
+import {
+  applyWidgetWrite,
+  WidgetWriteError,
+  resolvePromotedInnerTarget,
+  followPromotionToConcrete,
+} from "../../web/js/lib/widget-write.js";
+import {
+  preflightSetWidgetTarget,
+  assertResolvedTargetRegistered,
+  assertTypeAgainstFreshBackend,
+} from "../../web/js/lib/node-resolve.js";
+
+test("panel ↔ asset-staleness.js module edge links (incl. refreshComboOptionsFromDefs — P0)", () => {
+  assert.equal(typeof isStaleAssetCandidate, "function");
+  assert.equal(typeof reapplyDefsToLiveNodes, "function");
+  assert.equal(typeof refreshComboOptionsFromDefs, "function");
+});
+
+test("panel ↔ node-resolve.js / set-widget.js module edges link", () => {
+  assert.equal(typeof assertAddNodeResolvableRefreshing, "function");
+  assert.equal(typeof runSetWidget, "function");
+});
+
+test("set-widget.js ↔ widget-write.js / node-resolve.js module edges link", () => {
+  assert.equal(typeof applyWidgetWrite, "function");
+  assert.equal(typeof WidgetWriteError, "function");
+  assert.equal(typeof resolvePromotedInnerTarget, "function");
+  assert.equal(typeof followPromotionToConcrete, "function");
+  assert.equal(typeof preflightSetWidgetTarget, "function");
+  assert.equal(typeof assertResolvedTargetRegistered, "function");
+  assert.equal(typeof assertTypeAgainstFreshBackend, "function");
+});

--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -351,8 +351,29 @@ const HOOKS = { beforeChange() {}, afterChange() {}, setDirty() {} };
 // GRAPH_TOOL_EXECUTORS.graph_set_widget delegates to (it wires the assertTargetWritable
 // guard internally). So dropping the shipped guard wiring, or reordering
 // preflight/reconcile/guarded-write, FAILS these tests.
+// A permissive fresh /object_info oracle covering every fixture TARGET type used in
+// this file (core sentinels + the custom/ghost/subgraph types). runSetWidget REQUIRES
+// the oracle (#458); here it is intentionally a no-op gate — the fresh backend
+// "provides" every type — so these tests exercise the REGISTRY guard + handler
+// ordering (their subject), while the fresh-gate fail-closed behavior is covered by
+// set-widget-fresh-backend.test.mjs. Ghost/unregistered types are present in the
+// oracle so the fresh gate passes and the REGISTRY guard (which lacks them) is the
+// decider — preserving each test's original refusal message.
+const FRESH_ALL = objectInfo([
+  "MyRegNode",
+  "GhostNode",
+  "GhostSampler",
+  "SubgraphNode",
+  "Note",
+]);
+
 function setViaHandler(registry, node, widgetName, value, resolveSource) {
-  return runSetWidget(node, widgetName, value, { registry, resolveSource, ...HOOKS });
+  return runSetWidget(node, widgetName, value, {
+    registry,
+    getFreshObjectInfo: async () => FRESH_ALL,
+    resolveSource,
+    ...HOOKS,
+  });
 }
 
 // A real SubgraphNode over an inner KSampler whose promoted widget "sched_alias"

--- a/browser_tests/unit/set-widget-fresh-backend.test.mjs
+++ b/browser_tests/unit/set-widget-fresh-backend.test.mjs
@@ -1,0 +1,805 @@
+/**
+ * Unit tests for the FRESH-BACKEND type authorization in web/js/lib/set-widget.js
+ * — run with `node --test`.
+ *
+ * The #458 set_widget gap (found in review of #375): graph_set_widget authorized
+ * the target node's type SOLELY from the mutable LiteGraph registry. That registry
+ * keeps a STALE POSITIVE for an uninstalled pack when the browser tab was never
+ * reloaded after a ComfyUI restart, so a since-removed type ("GoneNode") sailed
+ * through every registry guard and the write reported a fabricated SUCCESS against
+ * a backend that no longer defines it. graph_add_node already authorizes its
+ * class_type against the CURRENT /object_info; these tests prove graph_set_widget
+ * now authorizes the RESOLVED write target's type against the same fresh oracle.
+ *
+ * They drive the REAL production handler body (runSetWidget) — the SAME async unit
+ * GRAPH_TOOL_EXECUTORS.graph_set_widget delegates to — with the fresh-oracle
+ * capability wired exactly as the handler wires it (getRegistry / getFreshObjectInfo
+ * / refreshCombos). So dropping the fresh gate, or letting it fall back to the stale
+ * registry, fails a test.
+ *
+ * Invariants under test:
+ *   1. REMOVED type (stale registry positive, ABSENT from fresh /object_info)
+ *      ⇒ FAIL CLOSED, no mutation — even though every registry-only guard passes.
+ *   2. Backend UNREACHABLE (fresh /object_info returns null) ⇒ FAIL CLOSED.
+ *   3. Transient fetch REJECTION ⇒ FAIL CLOSED (never trust the stale registry).
+ *   4. A LIVE VALID type (present in fresh /object_info + registry) ⇒ still succeeds,
+ *      fetching /object_info exactly once (hot path).
+ *   5. The stale-combo refresh retry (#338/#317/#299/#288) still works with the
+ *      fresh oracle wired, WITHOUT a second /object_info fetch.
+ *   6. No fresh-oracle wired ⇒ degrades to the registry guard (back-compat).
+ *   7. A subgraph PROMOTED write authorizes the INNER target's type (removed/
+ *      unreachable ⇒ fail closed; live ⇒ succeeds), and the promoted target is
+ *      resolved exactly ONCE so the write can't re-resolve to a swapped-in node.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runSetWidget } from "../../web/js/lib/set-widget.js";
+import { refreshComboOptionsFromDefs } from "../../web/js/lib/asset-staleness.js";
+
+// A registry shaped like LG.registered_node_types once /object_info loaded. Each
+// entry carries a `.nodeData` def (registerNodesFromDefs stamps one per class), so
+// a genuinely-resolved instance passes the stale-placeholder-instance cross-check.
+function loadedRegistry(extra = []) {
+  const reg = {};
+  for (const t of [
+    "KSampler",
+    "CheckpointLoaderSimple",
+    "CLIPTextEncode",
+    "VAEDecode",
+    "VAELoader",
+    "EmptyLatentImage",
+    "LoadImage",
+    "SaveImage",
+    ...extra,
+  ]) {
+    const ctor = function NodeCtor() {};
+    ctor.nodeData = { input: { required: {} } };
+    reg[t] = ctor;
+  }
+  return reg;
+}
+
+// Fresh /object_info map (class_type -> def), the authoritative oracle.
+function objectInfo(extra = []) {
+  const info = {};
+  for (const t of [
+    "KSampler",
+    "CheckpointLoaderSimple",
+    "CLIPTextEncode",
+    "VAEDecode",
+    "VAELoader",
+    "EmptyLatentImage",
+    "LoadImage",
+    "SaveImage",
+    ...extra,
+  ]) {
+    info[t] = { input: { required: {} } };
+  }
+  return info;
+}
+
+// A GENUINELY-RESOLVED node instance: its own constructor carries the live def, so
+// the registry-only placeholder-instance guard is satisfied. This is deliberate —
+// it proves ONLY the fresh oracle catches a removed type, not any registry check.
+function regNode(type, widgets, extra = {}) {
+  return {
+    id: 3,
+    type,
+    widgets,
+    constructor: { nodeData: { input: { required: {} } } },
+    ...extra,
+  };
+}
+
+const HOOKS = { beforeChange() {}, afterChange() {}, setDirty() {} };
+
+test("#458 set_widget: REMOVED type (stale registry positive, absent from fresh object_info) ⇒ FAIL CLOSED, no mutation", async () => {
+  // GoneNode's pack was uninstalled + ComfyUI restarted WITHOUT a tab reload: the
+  // registry still holds it (with a def) AND the instance is genuinely-resolved, so
+  // every registry-only guard passes. The fresh /object_info no longer lists it.
+  const reg = loadedRegistry(["GoneNode"]);
+  const node = regNode("GoneNode", [{ name: "steps", type: "INT", value: 20 }]);
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "steps", 30, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => objectInfo(), // backend no longer provides GoneNode
+        ...HOOKS,
+      }),
+    (err) =>
+      err instanceof Error &&
+      /Cannot set widget on node 3 \("GoneNode"\)/.test(err.message) &&
+      /backend does not provide/i.test(err.message),
+  );
+  assert.equal(node.widgets[0].value, 20, "value must NOT be mutated on a removed type");
+});
+
+test("#458 set_widget: REMOVED type carrying a truthy `subgraph` field (no promoted match) ⇒ FAIL CLOSED (subgraph-shaped bypass)", async () => {
+  // The subgraph-shaped bypass: a stale GoneNode survives in the registry (with a
+  // matching instance def) AND carries a truthy `subgraph:{}` field, but the write
+  // targets its OWN widget (resolvePromotedInnerTarget → {promoted:false}). A truthy
+  // `subgraph` field must NOT exempt it from fresh authorization — otherwise authTarget
+  // would be null, preflight would skip (subgraph parents skip the registry preflight),
+  // and only the STALE registry guard would run, fabricating success on a removed type.
+  const reg = loadedRegistry(["GoneNode"]);
+  const node = regNode("GoneNode", [{ name: "steps", type: "INT", value: 20 }], { subgraph: {} });
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "steps", 7, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => ({ KSampler: {} }), // backend does NOT provide GoneNode
+        ...HOOKS,
+      }),
+    (err) =>
+      err instanceof Error &&
+      /Cannot set widget on node 3 \("GoneNode"\)/.test(err.message) &&
+      /backend does not provide/i.test(err.message),
+  );
+  assert.equal(node.widgets[0].value, 20, "removed subgraph-shaped node must NOT be mutated");
+});
+
+test("#458 set_widget: backend UNREACHABLE (fresh object_info null) ⇒ FAIL CLOSED, no mutation", async () => {
+  const reg = loadedRegistry();
+  const node = regNode("KSampler", [{ name: "steps", type: "INT", value: 20 }]);
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "steps", 30, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => null, // fetch unavailable
+        ...HOOKS,
+      }),
+    (err) =>
+      err instanceof Error &&
+      /Cannot set widget on node 3 \("KSampler"\)/.test(err.message) &&
+      /cannot verify node type|object_info is unavailable|backend is unreachable/i.test(err.message),
+  );
+  assert.equal(node.widgets[0].value, 20, "value must NOT be mutated when the backend is unverifiable");
+});
+
+test("#458 set_widget: transient fetch REJECTION ⇒ FAIL CLOSED (never trust the stale registry)", async () => {
+  const reg = loadedRegistry(["GoneNode"]); // registry HIT survives
+  const node = regNode("GoneNode", [{ name: "steps", type: "INT", value: 20 }]);
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "steps", 30, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => {
+          throw new Error("object_info fetch failed (transient)");
+        },
+        ...HOOKS,
+      }),
+    (err) =>
+      err instanceof Error &&
+      /cannot verify (the )?node type|object_info is unavailable/i.test(err.message),
+  );
+  assert.equal(node.widgets[0].value, 20);
+});
+
+test("#458 set_widget: LIVE VALID type (in fresh object_info + registry) ⇒ still succeeds", async () => {
+  const reg = loadedRegistry();
+  const node = regNode("KSampler", [{ name: "steps", type: "INT", value: 20 }]);
+  let objectInfoFetches = 0;
+  const res = await runSetWidget(node, "steps", 30, {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: async () => {
+      objectInfoFetches++;
+      return objectInfo();
+    },
+    ...HOOKS,
+  });
+  assert.equal(res.set.value, 30);
+  assert.equal(node.widgets[0].value, 30);
+  assert.equal(objectInfoFetches, 1, "hot path fetches fresh object_info exactly once");
+});
+
+test("#458 set_widget: stale-combo refresh retry STILL works with the fresh oracle wired (#338)", async () => {
+  // The type is LIVE (passes the fresh oracle) but the combo option list is stale —
+  // the just-staged value is accepted only after refreshCombos pulls the fresh list.
+  const reg = loadedRegistry();
+  const widget = { name: "image", type: "combo", options: { values: ["old_a.png"] }, value: "old_a.png" };
+  const node = regNode("LoadImage", [widget]);
+  let objectInfoFetches = 0;
+  let comboRefreshes = 0;
+  const res = await runSetWidget(node, "image", "just_staged.png", {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: async () => {
+      objectInfoFetches++;
+      return objectInfo();
+    },
+    refreshCombos: async () => {
+      comboRefreshes++;
+      widget.options.values = ["old_a.png", "just_staged.png"];
+    },
+    ...HOOKS,
+  });
+  assert.equal(res.set.value, "just_staged.png");
+  assert.equal(res.refreshed, true, "combo refresh retry path still runs");
+  assert.equal(comboRefreshes, 1, "combo refresh attempted exactly once");
+  assert.equal(objectInfoFetches, 1, "type authorization fetches fresh object_info exactly once (hot path)");
+});
+
+test("#458 P2: combo retry reuses the AUTH /object_info via the PRODUCTION refreshCombos — exactly ONE getNodeDefs total", async () => {
+  // Drives the REAL production refreshCombos wiring (refreshComboOptionsFromDefs from
+  // the already-fetched defs, with a full-refresh FALLBACK) rather than a stub, so it
+  // proves the auth fetch + combo recovery make a SINGLE api.getNodeDefs() call. The
+  // fresh /object_info encodes LoadImage's combo INCLUDING the just-staged value, so
+  // the retry refreshes the widget's options from that payload — no second fetch.
+  const reg = loadedRegistry();
+  const widget = { name: "image", type: "combo", options: { values: ["old_a.png"] }, value: "old_a.png" };
+  const node = regNode("LoadImage", [widget]);
+
+  const FRESH = objectInfo();
+  FRESH.LoadImage = { input: { required: { image: [["old_a.png", "just_staged.png"], {}] } } };
+
+  let getNodeDefsCalls = 0;
+  // The single backend fetch primitive — BOTH the auth oracle and the production
+  // fallback refresh route through it, so this counter is the total /object_info hits.
+  const getNodeDefs = async () => {
+    getNodeDefsCalls++;
+    return FRESH;
+  };
+  let fallbackRefreshes = 0;
+  const refreshComfyNodeDefs = async (defs) => {
+    fallbackRefreshes++;
+    if (!defs) await getNodeDefs(); // the real fallback re-fetches /object_info
+  };
+
+  const res = await runSetWidget(node, "image", "just_staged.png", {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: () => getNodeDefs(),
+    // EXACT production wiring from comfyui-mcp-panel.js: when defs are present, refresh
+    // this target's combo options in place (keyed on the concrete type) and NEVER
+    // re-fetch; only a missing payload falls back to the full (re-fetching) refresh.
+    refreshCombos: (defs, target, concreteType, nameMap) => {
+      if (defs) {
+        refreshComboOptionsFromDefs(target, defs, concreteType, nameMap);
+        return;
+      }
+      return refreshComfyNodeDefs();
+    },
+    ...HOOKS,
+  });
+
+  assert.equal(res.set.value, "just_staged.png");
+  assert.equal(res.refreshed, true, "combo recovery ran and the retry succeeded");
+  assert.equal(fallbackRefreshes, 0, "no full-refresh fallback — combos came from the cached defs");
+  assert.equal(getNodeDefsCalls, 1, "exactly ONE /object_info fetch across auth + combo retry (#458 P2)");
+  assert.equal(widget.value, "just_staged.png");
+});
+
+test("#458 P2: defs present but nothing refreshable (dynamic/non-array combo) ⇒ STILL no second fetch, fails closed", async () => {
+  // Codex regression guard: when refreshComboOptionsFromDefs updates 0 widgets (the
+  // fresh def exposes no array-backed option list for this widget), the production
+  // callback must NOT fall back to the re-fetching full refresh just because the
+  // update count was 0 — a present payload means single-fetch, period. A genuinely
+  // invalid value then stays rejected on the retry.
+  const reg = loadedRegistry();
+  const widget = { name: "image", type: "combo", options: { values: ["old_a.png"] }, value: "old_a.png" };
+  const node = regNode("LoadImage", [widget]);
+
+  const FRESH = objectInfo();
+  // LoadImage present (auth passes) but its `image` input is a TYPE, not an option
+  // array — so refreshComboOptionsFromDefs finds nothing to refresh (returns 0).
+  FRESH.LoadImage = { input: { required: { image: ["IMAGE", {}] } } };
+
+  let getNodeDefsCalls = 0;
+  const getNodeDefs = async () => {
+    getNodeDefsCalls++;
+    return FRESH;
+  };
+  let fallbackRefreshes = 0;
+
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "image", "never_valid.png", {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: () => getNodeDefs(),
+        refreshCombos: (defs, target, concreteType, nameMap) => {
+          if (defs) {
+            refreshComboOptionsFromDefs(target, defs, concreteType, nameMap);
+            return;
+          }
+          fallbackRefreshes++;
+          return getNodeDefs(); // the re-fetching fallback — must NOT run here
+        },
+        ...HOOKS,
+      }),
+    (err) => err instanceof Error && /not a valid option/.test(err.message),
+  );
+  assert.equal(fallbackRefreshes, 0, "present payload must never trigger the re-fetching fallback");
+  assert.equal(getNodeDefsCalls, 1, "exactly ONE /object_info fetch even when nothing was refreshable (#458 P2)");
+  assert.equal(widget.value, "old_a.png", "no mutation on a genuinely-invalid value");
+});
+
+test("#458 set_widget: NO fresh-oracle wired ⇒ FAIL CLOSED (never authorize from the stale registry)", async () => {
+  // P1-A: a caller that omits getFreshObjectInfo must NOT fall back to the stale
+  // registry — that would reopen the exact #458 false-success hole (a stale-positive
+  // GoneNode would write + report success). Even a registered live type is refused
+  // when the backend can't be consulted; the panel always wires the oracle.
+  const reg = loadedRegistry(["GoneNode"]);
+  const node = regNode("GoneNode", [{ name: "steps", type: "INT", value: 20 }]);
+  await assert.rejects(
+    () => runSetWidget(node, "steps", 30, { registry: reg, ...HOOKS }),
+    (err) =>
+      err instanceof Error &&
+      /Cannot set widget on node 3 \("GoneNode"\)/.test(err.message) &&
+      /no \/object_info oracle is wired|cannot verify/i.test(err.message),
+  );
+  assert.equal(node.widgets[0].value, 20, "must not mutate when the backend can't be verified");
+});
+
+// A real SubgraphNode whose promoted "sched_alias" input maps to an inner node's
+// "scheduler" widget. innerType flips the inner node between a live type and a
+// since-removed one so the fresh oracle can be exercised on the RESOLVED target.
+function makeSubgraphFixture(innerType) {
+  const inner = {
+    id: 54,
+    type: innerType,
+    widgets: [{ name: "scheduler", type: "combo", options: { values: ["simple", "karras"] }, value: "simple" }],
+    constructor: { nodeData: { input: { required: {} } } },
+  };
+  // #366: the AUTHORITATIVE parent rail projection — object-identity linked from the
+  // host input (`_widget`) and a live member of parent.widgets. Required so a promoted
+  // write can identify + sync the rail; without it the write fails closed.
+  const railWidget = { name: "sched_alias", type: "combo", options: { values: ["simple", "karras"] }, value: "simple" };
+  const parent = {
+    id: 66,
+    type: "SubgraphNode",
+    subgraph: { _nodes: [inner], getNodeById: (id) => (String(id) === "54" ? inner : null) },
+    inputs: [{ name: "sched_alias", _widget: railWidget, widget: { name: "sched_alias" }, _subgraphSlot: { name: "sched_alias" } }],
+    widgets: [
+      { name: "scheduler", type: "combo", options: { values: ["simple"] }, value: 999 }, // decoy own-widget (#233)
+      railWidget,
+    ],
+  };
+  const resolveSource = (_n, si) =>
+    si?.name === "sched_alias" ? { sourceNodeId: "54", sourceWidgetName: "scheduler" } : null;
+  return { parent, inner, railWidget, resolveSource };
+}
+
+test("#458 set_widget: SUBGRAPH promoted write to a LIVE inner type ⇒ succeeds (inner type fresh-authorized)", async () => {
+  const reg = loadedRegistry();
+  const { parent, inner, resolveSource } = makeSubgraphFixture("KSampler");
+  const { set } = await runSetWidget(parent, "sched_alias", "karras", {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: async () => objectInfo(), // backend defines KSampler
+    resolveSource,
+    ...HOOKS,
+  });
+  assert.equal(set.value, "karras");
+  assert.equal(inner.widgets.find((w) => w.name === "scheduler").value, "karras");
+});
+
+test("#458 set_widget: SUBGRAPH promoted write to a REMOVED inner type ⇒ FAIL CLOSED, inner untouched", async () => {
+  // The inner GoneNode survives in the stale registry (with a def + resolved
+  // instance) so every registry-only guard passes — but the fresh /object_info no
+  // longer lists it. The promoted write must be refused, not fabricated as success.
+  const reg = loadedRegistry(["GoneNode"]);
+  const { parent, inner, resolveSource } = makeSubgraphFixture("GoneNode");
+  await assert.rejects(
+    () =>
+      runSetWidget(parent, "sched_alias", "karras", {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => objectInfo(), // backend no longer provides GoneNode
+        resolveSource,
+        ...HOOKS,
+      }),
+    (err) =>
+      err instanceof Error &&
+      /Cannot set widget on node 54 \("GoneNode"\)/.test(err.message) &&
+      /Unknown node type "GoneNode"|backend does not provide/i.test(err.message),
+  );
+  assert.equal(inner.widgets.find((w) => w.name === "scheduler").value, "simple", "inner widget untouched");
+});
+
+test("#458 set_widget: SUBGRAPH promoted write with UNREACHABLE backend ⇒ FAIL CLOSED, inner untouched", async () => {
+  const reg = loadedRegistry();
+  const { parent, inner, resolveSource } = makeSubgraphFixture("KSampler");
+  await assert.rejects(
+    () =>
+      runSetWidget(parent, "sched_alias", "karras", {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => {
+          throw new Error("object_info fetch failed (transient)");
+        },
+        resolveSource,
+        ...HOOKS,
+      }),
+    (err) =>
+      err instanceof Error &&
+      /Cannot set widget on node 54 \("KSampler"\)/.test(err.message) &&
+      /cannot verify (the )?node type|object_info is unavailable/i.test(err.message),
+  );
+  assert.equal(inner.widgets.find((w) => w.name === "scheduler").value, "simple", "inner widget untouched");
+});
+
+// A TWO-LEVEL nested promotion: outer subgraph A promotes "steps" from inner subgraph
+// B, which promotes "steps" from a concrete node. ComfyUI supports this. The immediate
+// resolved target of A's promotion is the VIRTUAL node B (subgraph id not in
+// /object_info); fresh-auth must TRAVERSE A→B→concrete and authorize the concrete type.
+function makeNestedSubgraphFixture(reg, concreteType) {
+  const concrete = {
+    id: 90,
+    type: concreteType,
+    widgets: [{ name: "steps", type: "INT", value: 20 }],
+    constructor: { nodeData: { input: { required: {} } } },
+  };
+  const b = {
+    id: 80,
+    type: "SubgraphB", // virtual subgraph id — absent from /object_info
+    widgets: [{ name: "steps", type: "INT", value: 20 }],
+    subgraph: { _nodes: [concrete], getNodeById: (id) => (String(id) === "90" ? concrete : null) },
+    inputs: [{ name: "steps", _subgraphSlot: { name: "steps" } }],
+  };
+  // #366 rail projection on the OUTER node A (the write resolves A→B one level, so A's
+  // host input must carry the authoritative rail widget present in A.widgets).
+  const aRail = { name: "steps", type: "INT", value: 20 };
+  const a = {
+    id: 70,
+    type: "SubgraphA", // virtual
+    widgets: [{ name: "steps_decoy", type: "INT", value: 999 }, aRail],
+    subgraph: { _nodes: [b], getNodeById: (id) => (String(id) === "80" ? b : null) },
+    inputs: [{ name: "steps", _widget: aRail, widget: { name: "steps" }, _subgraphSlot: { name: "steps" } }],
+  };
+  // Virtual subgraph nodes register as native/defless types (no nodeData) — the write's
+  // registry guard trusts them, exactly like real litegraph subgraph instances.
+  reg.SubgraphA = function SubgraphA() {};
+  reg.SubgraphB = function SubgraphB() {};
+  const resolveSource = (subgraphNode, si) => {
+    if (subgraphNode === a && si?.name === "steps") return { sourceNodeId: "80", sourceWidgetName: "steps" };
+    if (subgraphNode === b && si?.name === "steps") return { sourceNodeId: "90", sourceWidgetName: "steps" };
+    return null;
+  };
+  return { a, b, concrete, resolveSource };
+}
+
+test("#458 set_widget: NESTED promotion (A→B→KSampler) authorizes the CONCRETE type ⇒ succeeds (not falsely refused)", async () => {
+  // The false-failure: authorizing the immediate inner target (virtual SubgraphB,
+  // absent from /object_info) would refuse a valid write. Following the chain to the
+  // concrete KSampler (present in fresh defs) lets the write proceed.
+  const reg = loadedRegistry();
+  const { a, b, resolveSource } = makeNestedSubgraphFixture(reg, "KSampler");
+  const { set } = await runSetWidget(a, "steps", 30, {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: async () => objectInfo(), // KSampler present; SubgraphA/B are NOT
+    resolveSource,
+    ...HOOKS,
+  });
+  assert.equal(set.value, 30, "nested promoted write is authorized via the concrete type and succeeds");
+  assert.equal(b.widgets.find((w) => w.name === "steps").value, 30);
+});
+
+test("#458 set_widget: NESTED promotion whose ULTIMATE CONCRETE type is REMOVED ⇒ FAIL CLOSED", async () => {
+  // The chain A→B→GoneNode resolves to a concrete node the backend no longer provides
+  // — traversal reaches GoneNode and fresh-auth refuses it (removed pack stays closed).
+  const reg = loadedRegistry(["GoneNode"]);
+  const { a, b, resolveSource } = makeNestedSubgraphFixture(reg, "GoneNode");
+  await assert.rejects(
+    () =>
+      runSetWidget(a, "steps", 30, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => objectInfo(), // backend does NOT provide GoneNode
+        resolveSource,
+        ...HOOKS,
+      }),
+    (err) =>
+      err instanceof Error &&
+      /Cannot set widget on node 90 \("GoneNode"\)/.test(err.message) &&
+      /backend does not provide/i.test(err.message),
+  );
+  assert.equal(b.widgets.find((w) => w.name === "steps").value, 20, "nested write refused — no mutation");
+});
+
+test("#458 set_widget: NESTED promotion to a STALE concrete INSTANCE (registered type, no instance def) ⇒ FAIL CLOSED", async () => {
+  // The stale-INSTANCE bypass: A→B(virtual)→KSampler, where the concrete KSampler
+  // instance is a STALE generic placeholder (constructor carries NO nodeData — the
+  // workflow was loaded while ComfyUI was down). Its TYPE is live in /object_info, so
+  // fresh TYPE auth passes; but applyWidgetWrite only instance-checks the IMMEDIATE
+  // virtual node B (defless/trusted), so without the concrete-instance guard the stale
+  // KSampler would be mutated through B's forwarding callback. Must fail closed.
+  const reg = loadedRegistry();
+  const { a, b, concrete, resolveSource } = makeNestedSubgraphFixture(reg, "KSampler");
+  concrete.constructor = { name: "GenericFallback" }; // stale placeholder: no nodeData
+  await assert.rejects(
+    () =>
+      runSetWidget(a, "steps", 30, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => objectInfo(), // KSampler live on the backend
+        resolveSource,
+        ...HOOKS,
+      }),
+    (err) =>
+      err instanceof Error && /unresolved placeholder|live definition is missing/i.test(err.message),
+  );
+  assert.equal(b.widgets.find((w) => w.name === "steps").value, 20, "stale concrete instance never mutated");
+});
+
+test("#458 set_widget: NESTED chain with an UNRESOLVABLE deeper link ⇒ FAIL CLOSED (no write through the registry guard)", async () => {
+  // A→B resolves, but B's deeper promotion is stale/unresolvable. The chain can't reach
+  // a concrete node, so the ultimate type is unverifiable — must fail closed rather than
+  // mutate the immediate virtual node B behind only the (defless-trusting) registry guard.
+  const reg = loadedRegistry();
+  const { a, b, resolveSource } = makeNestedSubgraphFixture(reg, "KSampler");
+  // Break B's deeper link: resolveSource returns nothing for B.
+  const brokenSource = (subgraphNode, si) =>
+    subgraphNode === a && si?.name === "steps" ? { sourceNodeId: "80", sourceWidgetName: "steps" } : null;
+  await assert.rejects(
+    () =>
+      runSetWidget(a, "steps", 30, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => objectInfo(),
+        resolveSource: brokenSource,
+        ...HOOKS,
+      }),
+    (err) => err instanceof Error && /could not be resolved to a concrete backend node/.test(err.message),
+  );
+  assert.equal(b.widgets.find((w) => w.name === "steps").value, 20, "no mutation on an unresolvable deeper link");
+});
+
+test("#458 set_widget: NESTED chain ending on a terminal VIRTUAL own-widget ⇒ FAIL CLOSED (virtual type never treated as concrete)", async () => {
+  // A→B resolves, but B's "steps" is B's OWN (non-promoted) widget — the chain ends on a
+  // virtual node. A virtual subgraph type is never in /object_info, so treating it as a
+  // verified concrete node would be wrong; fail closed.
+  const reg = loadedRegistry();
+  const { a, b, resolveSource } = makeNestedSubgraphFixture(reg, "KSampler");
+  b.inputs = []; // B no longer promotes "steps" — it becomes B's own virtual widget
+  await assert.rejects(
+    () =>
+      runSetWidget(a, "steps", 30, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => objectInfo(),
+        resolveSource,
+        ...HOOKS,
+      }),
+    (err) => err instanceof Error && /could not be resolved to a concrete backend node/.test(err.message),
+  );
+  assert.equal(b.widgets.find((w) => w.name === "steps").value, 20, "no mutation on a terminal virtual own-widget");
+});
+
+test("#458 set_widget: NESTED chain ending on a concrete node with NO string type ⇒ FAIL CLOSED", async () => {
+  // A→B→{type: undefined}: the terminal node has no `.subgraph` but also no real type,
+  // so it cannot be authorized against /object_info. It must NOT slip through the
+  // "no string type ⇒ skip auth" gap and mutate the immediate virtual node B.
+  const reg = loadedRegistry();
+  const { a, b, concrete, resolveSource } = makeNestedSubgraphFixture(reg, "KSampler");
+  concrete.type = undefined; // malformed terminal — no backend type to verify
+  await assert.rejects(
+    () =>
+      runSetWidget(a, "steps", 30, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => objectInfo(),
+        resolveSource,
+        ...HOOKS,
+      }),
+    (err) => err instanceof Error && /could not be resolved to a concrete backend node/.test(err.message),
+  );
+  assert.equal(b.widgets.find((w) => w.name === "steps").value, 20, "no mutation on a typeless concrete terminal");
+});
+
+test("#458 set_widget: NESTED promotion CYCLE ⇒ FAIL CLOSED (terminates, no mutation)", async () => {
+  // A→B→A cycle: followPromotionToConcrete's seen-set breaks the loop and reports no
+  // concrete node, so the write fails closed instead of spinning or authorizing a virtual.
+  const reg = loadedRegistry();
+  const { a, b, resolveSource } = makeNestedSubgraphFixture(reg, "KSampler");
+  // Make B promote back to A (id 70), and let A be reachable from B's subgraph.
+  b.subgraph.getNodeById = (id) => (String(id) === "70" ? a : String(id) === "90" ? b.subgraph._nodes[0] : null);
+  const cyclicSource = (subgraphNode, si) => {
+    if (subgraphNode === a && si?.name === "steps") return { sourceNodeId: "80", sourceWidgetName: "steps" };
+    if (subgraphNode === b && si?.name === "steps") return { sourceNodeId: "70", sourceWidgetName: "steps" };
+    return null;
+  };
+  await assert.rejects(
+    () =>
+      runSetWidget(a, "steps", 30, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => objectInfo(),
+        resolveSource: cyclicSource,
+        ...HOOKS,
+      }),
+    (err) => err instanceof Error && /could not be resolved to a concrete backend node/.test(err.message),
+  );
+});
+
+test("#458 set_widget: NESTED promoted COMBO recovery keys on the CONCRETE type ⇒ just-staged value accepted (not falsely rejected)", async () => {
+  // A promotes B's `image`; B promotes LoadImage.image. B's exposed combo is stale
+  // (missing a just-uploaded image), but fresh /object_info lists it under the CONCRETE
+  // LoadImage def. The retry must refresh B's widget from LoadImage's options (keyed on
+  // the concrete type), NOT the virtual SubgraphB (absent from /object_info) — otherwise
+  // a legit just-uploaded image on a nested-promoted combo is wrongly rejected.
+  const reg = loadedRegistry();
+  reg.SubgraphA = function SubgraphA() {};
+  reg.SubgraphB = function SubgraphB() {};
+  const loadImage = {
+    id: 90,
+    type: "LoadImage",
+    widgets: [{ name: "image", type: "combo", options: { values: ["old.png"] }, value: "old.png" }],
+    constructor: { nodeData: { input: { required: {} } } },
+  };
+  const b = {
+    id: 80,
+    type: "SubgraphB",
+    widgets: [{ name: "image", type: "combo", options: { values: ["old.png"] }, value: "old.png" }],
+    subgraph: { _nodes: [loadImage], getNodeById: (id) => (String(id) === "90" ? loadImage : null) },
+    inputs: [{ name: "image", _subgraphSlot: { name: "image" } }],
+  };
+  // #366 rail projection on the OUTER node A (the write resolves A→B one level).
+  const aRail = { name: "image", type: "combo", options: { values: ["old.png"] }, value: "old.png" };
+  const a = {
+    id: 70,
+    type: "SubgraphA",
+    widgets: [aRail],
+    subgraph: { _nodes: [b], getNodeById: (id) => (String(id) === "80" ? b : null) },
+    inputs: [{ name: "image", _widget: aRail, widget: { name: "image" }, _subgraphSlot: { name: "image" } }],
+  };
+  const resolveSource = (subgraphNode, si) => {
+    if (subgraphNode === a && si?.name === "image") return { sourceNodeId: "80", sourceWidgetName: "image" };
+    if (subgraphNode === b && si?.name === "image") return { sourceNodeId: "90", sourceWidgetName: "image" };
+    return null;
+  };
+
+  // Fresh /object_info: LoadImage's `image` combo now lists the just-uploaded file;
+  // SubgraphA/B are virtual and absent (as they always are).
+  const FRESH = objectInfo();
+  FRESH.LoadImage = { input: { required: { image: [["old.png", "new_upload.png"], {}] } } };
+
+  let getNodeDefsCalls = 0;
+  const getNodeDefs = async () => {
+    getNodeDefsCalls++;
+    return FRESH;
+  };
+
+  const res = await runSetWidget(a, "image", "new_upload.png", {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: () => getNodeDefs(),
+    // Production wiring: refresh the write-target node's combos keyed on the CONCRETE type.
+    refreshCombos: (defs, target, concreteType, nameMap) => {
+      if (defs) {
+        refreshComboOptionsFromDefs(target, defs, concreteType, nameMap);
+        return;
+      }
+      return getNodeDefs();
+    },
+    resolveSource,
+    ...HOOKS,
+  });
+
+  assert.equal(res.set.value, "new_upload.png", "nested promoted combo accepts the just-staged value after concrete refresh");
+  assert.equal(res.refreshed, true);
+  assert.equal(b.widgets.find((w) => w.name === "image").value, "new_upload.png");
+  assert.equal(getNodeDefsCalls, 1, "single /object_info fetch across auth + nested combo retry");
+});
+
+test("#458×#366 set_widget: RENAMED nested promoted COMBO recovery bridges the widget name ⇒ value accepted", async () => {
+  // #366 supports RENAMED promotions: A exposes "img_a" → B's "img_b" → LoadImage's
+  // "image". The stale combo lives on B's "img_b" widget, but its authoritative options
+  // live under the CONCRETE def's "image" input. The retry must bridge img_b → image
+  // (the ultimate concrete widget name) — keying by the mutated widget's own name would
+  // find nothing in LoadImage's def and reject a valid just-staged value.
+  const reg = loadedRegistry();
+  reg.SubgraphA = function SubgraphA() {};
+  reg.SubgraphB = function SubgraphB() {};
+  const loadImage = {
+    id: 90,
+    type: "LoadImage",
+    widgets: [{ name: "image", type: "combo", options: { values: ["old.png"] }, value: "old.png" }],
+    constructor: { nodeData: { input: { required: {} } } },
+  };
+  const b = {
+    id: 80,
+    type: "SubgraphB",
+    widgets: [{ name: "img_b", type: "combo", options: { values: ["old.png"] }, value: "old.png" }],
+    subgraph: { _nodes: [loadImage], getNodeById: (id) => (String(id) === "90" ? loadImage : null) },
+    inputs: [{ name: "img_b", _subgraphSlot: { name: "img_b" } }],
+  };
+  const aRail = { name: "img_a", type: "combo", options: { values: ["old.png"] }, value: "old.png" };
+  const a = {
+    id: 70,
+    type: "SubgraphA",
+    widgets: [aRail],
+    subgraph: { _nodes: [b], getNodeById: (id) => (String(id) === "80" ? b : null) },
+    inputs: [{ name: "img_a", _widget: aRail, widget: { name: "img_a" }, _subgraphSlot: { name: "img_a" } }],
+  };
+  const resolveSource = (subgraphNode, si) => {
+    if (subgraphNode === a && si?.name === "img_a") return { sourceNodeId: "80", sourceWidgetName: "img_b" };
+    if (subgraphNode === b && si?.name === "img_b") return { sourceNodeId: "90", sourceWidgetName: "image" };
+    return null;
+  };
+
+  const FRESH = objectInfo();
+  FRESH.LoadImage = { input: { required: { image: [["old.png", "new_upload.png"], {}] } } };
+  let getNodeDefsCalls = 0;
+  const getNodeDefs = async () => {
+    getNodeDefsCalls++;
+    return FRESH;
+  };
+
+  const res = await runSetWidget(a, "img_a", "new_upload.png", {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: () => getNodeDefs(),
+    refreshCombos: (defs, target, concreteType, nameMap) => {
+      if (defs) {
+        refreshComboOptionsFromDefs(target, defs, concreteType, nameMap);
+        return;
+      }
+      return getNodeDefs();
+    },
+    resolveSource,
+    ...HOOKS,
+  });
+
+  assert.equal(res.set.value, "new_upload.png", "renamed nested promoted combo accepts the just-staged value");
+  assert.equal(res.refreshed, true);
+  assert.equal(b.widgets.find((w) => w.name === "img_b").value, "new_upload.png");
+  assert.equal(getNodeDefsCalls, 1, "single /object_info fetch across auth + renamed nested combo retry");
+});
+
+test("#458×#366 set_widget: promoted write reuses the THREADED resolution AND syncs the authoritative rail (composed)", async () => {
+  // #423 threads the resolution the fresh-auth gate used into applyWidgetWrite, so the
+  // write targets the authorized inner node; #366 syncs the authoritative parent rail
+  // atomically. A decoy sibling node (GoneNode) sits in the same subgraph and must
+  // NEVER be the write target. Together: the write lands on the authorized live inner
+  // node + the rail, and the decoy is untouched.
+  const reg = loadedRegistry(["GoneNode"]);
+  const live = {
+    id: 54,
+    type: "KSampler",
+    widgets: [{ name: "scheduler", type: "combo", options: { values: ["simple", "karras"] }, value: "simple" }],
+    constructor: { nodeData: { input: { required: {} } } },
+  };
+  const gone = {
+    id: 77,
+    type: "GoneNode",
+    widgets: [{ name: "scheduler", type: "combo", options: { values: ["simple", "karras"] }, value: "simple" }],
+    constructor: { nodeData: { input: { required: {} } } },
+  };
+  const subgraph = {
+    _nodes: [live, gone],
+    getNodeById: (id) => (String(id) === "54" ? live : String(id) === "77" ? gone : null),
+  };
+  // #366 authoritative rail projection identity-linked from the host input.
+  const railWidget = { name: "sched_alias", type: "combo", options: { values: ["simple", "karras"] }, value: "simple" };
+  const parent = {
+    id: 66,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [{ name: "sched_alias", _widget: railWidget, widget: { name: "sched_alias" }, _subgraphSlot: { name: "sched_alias" } }],
+    widgets: [{ name: "scheduler", type: "combo", options: { values: ["simple"] }, value: 999 }, railWidget],
+  };
+  // Deterministic promotion → the LIVE inner (KSampler); GoneNode is only a decoy
+  // sibling, never linked by the promotion.
+  const resolveSource = (_n, si) =>
+    si?.name === "sched_alias" ? { sourceNodeId: "54", sourceWidgetName: "scheduler" } : null;
+
+  const { set } = await runSetWidget(parent, "sched_alias", "karras", {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: async () => objectInfo(), // KSampler live, GoneNode absent
+    resolveSource,
+    ...HOOKS,
+  });
+  assert.equal(set.value, "karras");
+  assert.equal(live.widgets.find((w) => w.name === "scheduler").value, "karras", "write landed on the authorized live inner node");
+  assert.equal(railWidget.value, "karras", "#366: authoritative parent rail synced");
+  assert.equal(gone.widgets.find((w) => w.name === "scheduler").value, "simple", "the decoy sibling was never touched");
+});

--- a/browser_tests/unit/set-widget-refresh.test.mjs
+++ b/browser_tests/unit/set-widget-refresh.test.mjs
@@ -30,6 +30,12 @@ import { runSetWidget } from "../../web/js/lib/set-widget.js";
 // type still resolves as registered.
 const REGISTRY = { LoadImage: {}, ControlNetLoader: {}, KSampler: {} };
 
+// Fresh /object_info oracle is REQUIRED by runSetWidget (#458): a live backend that
+// defines the fixture types, so the fresh-backend type gate is a no-op here and the
+// stale-COMBO recovery (the actual subject of this file) is what is exercised.
+const FRESH = { LoadImage: {}, ControlNetLoader: {}, KSampler: {} };
+const freshOracle = { getFreshObjectInfo: async () => FRESH };
+
 function makeNode(type, widget) {
   return { id: 105, type, widgets: [widget] };
 }
@@ -46,6 +52,7 @@ test("stale combo: a just-staged value ABSENT at first is accepted after refresh
 
   const res = await runSetWidget(node, "image", "ICEDTEA_scene_bg_inpaint_01.png", {
     registry: REGISTRY,
+    ...freshOracle,
     refreshCombos,
   });
 
@@ -64,6 +71,7 @@ test("EMPTY LoadImage combo (0 options) accepts the uploaded file after refresh 
 
   const res = await runSetWidget(node, "image", "wan_reference_woman.png", {
     registry: REGISTRY,
+    ...freshOracle,
     refreshCombos,
   });
   assert.equal(res.set.value, "wan_reference_woman.png");
@@ -82,6 +90,7 @@ test("ControlNetLoader stale 3-item list accepts the 4th model after refresh (#2
   };
   const res = await runSetWidget(node, "control_net_name", "mistoLine_rank256.safetensors", {
     registry: REGISTRY,
+    ...freshOracle,
     refreshCombos,
   });
   assert.equal(res.set.value, "mistoLine_rank256.safetensors");
@@ -101,6 +110,7 @@ test("GENUINELY-invalid value is STILL rejected after refresh (keeps #240 strict
     () =>
       runSetWidget(node, "image", "does_not_exist_anywhere.png", {
         registry: REGISTRY,
+        ...freshOracle,
         refreshCombos,
       }),
     (err) =>
@@ -117,7 +127,7 @@ test("without a refreshCombos injection, a stale-combo miss fails closed (no sil
   const widget = { name: "image", type: "combo", options: { values: ["old_a.png"] }, value: "old_a.png" };
   const node = makeNode("LoadImage", widget);
   await assert.rejects(
-    () => runSetWidget(node, "image", "new.png", { registry: REGISTRY }),
+    () => runSetWidget(node, "image", "new.png", { registry: REGISTRY, ...freshOracle }),
     (err) => err instanceof Error && /not a valid option/.test(err.message),
   );
 });
@@ -130,7 +140,7 @@ test("a NON-combo failure (numeric type mismatch) never triggers a refresh", asy
     refreshCalls += 1;
   };
   await assert.rejects(
-    () => runSetWidget(node, "steps", "euler", { registry: REGISTRY, refreshCombos }),
+    () => runSetWidget(node, "steps", "euler", { registry: REGISTRY, ...freshOracle, refreshCombos }),
     (err) => err instanceof Error && /not a number/.test(err.message),
   );
   assert.equal(refreshCalls, 0, "numeric mismatch must fail closed without refreshing");
@@ -142,6 +152,7 @@ test("a valid value on the FIRST try does not call refresh at all", async () => 
   let refreshCalls = 0;
   const res = await runSetWidget(node, "image", "b.png", {
     registry: REGISTRY,
+    ...freshOracle,
     refreshCombos: async () => {
       refreshCalls += 1;
     },

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -106,6 +106,7 @@ import { openSidePanel } from "./cmcp-sidepanel-ui.js";
 import {
   isStaleAssetCandidate as isStaleAssetCandidateLib,
   reapplyDefsToLiveNodes,
+  refreshComboOptionsFromDefs,
 } from "./lib/asset-staleness.js";
 import { assertAddNodeResolvableRefreshing } from "./lib/node-resolve.js";
 import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
@@ -3959,14 +3960,22 @@ function resolveNode(graph, nodeId) {
 }
 
 // ---- Node-type resolution guard (#458) ------------------------------------
-// The graph WRITE tools resolve node types against LG.registered_node_types:
-// assertAddNodeResolvableRefreshing gates graph_add_node on the class_type before
-// create (refreshing stale node defs once and re-checking, #289/#458);
-// graph_set_widget delegates to runSetWidget (web/js/lib/set-widget.js), whose
-// shared body gates on the ACTUAL RESOLVED write target (inner promoted node for
-// a subgraph, else the node's own) BEFORE any coercion/mutation, so an unresolved
-// placeholder can never be reported as a fabricated success. The predicates live
-// in web/js/lib/node-resolve.js and take the raw registry object.
+// The graph WRITE tools authorize node types against the CURRENT backend
+// /object_info — NOT the mutable LG.registered_node_types registry, which keeps a
+// STALE POSITIVE for an uninstalled pack after a ComfyUI restart-without-reload:
+//   * assertAddNodeResolvableRefreshing gates graph_add_node on the class_type
+//     before create (fresh /object_info is the oracle; refresh stale defs once and
+//     re-check, #289/#458); and
+//   * graph_set_widget delegates to runSetWidget (web/js/lib/set-widget.js), which
+//     first authorizes the type of the ACTUAL RESOLVED write target against the SAME
+//     fresh oracle — the node's own type for a direct write, or the INNER promoted
+//     node's type for a subgraph write (resolved mutation-free up front) — failing
+//     closed on a removed/unverifiable type (#458 set_widget gap). It then gates on
+//     that resolved target's registry+placeholder state BEFORE any coercion/mutation,
+//     so an unresolved placeholder or a since-removed type can never be reported as a
+//     fabricated success.
+// The predicates live in web/js/lib/node-resolve.js and take the raw registry
+// object (plus, for the fresh-oracle path, a getFreshObjectInfo/refresh capability).
 
 
 // ---- Subgraph boundary rails (input/output proxy nodes) -------------------
@@ -5442,12 +5451,36 @@ const GRAPH_TOOL_EXECUTORS = {
     // #284/#304, keeping #240 strictness).
     return runSetWidget(node, widget, value, {
       registry: LG?.registered_node_types ?? {},
+      // Fresh-backend type authorization (#458 set_widget gap): the go/no-go for the
+      // resolved target node's TYPE is decided against the CURRENT /object_info — NOT
+      // the stale LiteGraph registry, which keeps a positive for an uninstalled pack
+      // after a restart-without-reload. Mirrors graph_add_node.
+      getRegistry: () => LG?.registered_node_types ?? {},
+      getFreshObjectInfo: () =>
+        typeof api?.getNodeDefs === "function" ? api.getNodeDefs() : null,
       resolveSource: sourceForSubgraphInput,
       canvas: app.canvas,
       beforeChange: () => graph.beforeChange(),
       afterChange: () => graph.afterChange(),
       setDirty: () => graph.setDirtyCanvas(true, true),
-      refreshCombos: () => refreshComfyNodeDefs(),
+      // Stale-combo retry: reuse the /object_info already fetched for authorization
+      // (passed by runSetWidget) to refresh THIS target's combo option lists in place
+      // — a single fetch total (#458 P2). When a payload IS present we NEVER re-fetch,
+      // even if nothing was updated (a dynamic function-combo is self-refreshing; a
+      // genuinely-invalid value simply stays rejected on the retry). Only a MISSING
+      // payload falls back to the full frontend refresh (refreshComfyNodeDefs →
+      // refreshComboInNodes), which re-fetches /object_info.
+      refreshCombos: (defs, target, concreteType, nameMap) => {
+        if (defs) {
+          // Key the combo options on the ULTIMATE CONCRETE type (resolved through the
+          // promotion chain), not the intermediate virtual node's type, and bridge a
+          // RENAMED nested promotion via nameMap, so a nested promoted combo is refreshed
+          // from the real backend def under the right input name (#458×#366).
+          refreshComboOptionsFromDefs(target, defs, concreteType, nameMap);
+          return;
+        }
+        return refreshComfyNodeDefs();
+      },
     });
   },
 

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -335,6 +335,61 @@ export function collectAllGraphs(rootGraph) {
  * `defsByType` is the `class_type → def` map from api.getNodeDefs(). Returns the
  * number of nodes whose UNKNOWN widgets were repaired. Fully defensive.
  */
+/**
+ * Update a SINGLE node's COMBO widget option lists in place from an already-fetched
+ * /object_info payload (`class_type -> def`), WITHOUT a second network round-trip
+ * (#458 P2). The stale-combo set_widget retry re-validates a just-staged value (a
+ * downloaded model / uploaded image / staged output) against the AUTHORITATIVE list;
+ * that list is already in the /object_info the fresh-backend type gate just fetched,
+ * so we reuse it here instead of calling ComfyUI's refreshComboInNodes() (which
+ * re-fetches /object_info internally). ComfyUI's /object_info encodes a combo as an
+ * input spec whose first element is the array of options: `input[.required|.optional]
+ * [name] = [[opt, ...], {config}]`. Only ARRAY-backed combos are refreshed; a dynamic
+ * `options.values` FUNCTION is left untouched (it computes its own list). Returns the
+ * number of widgets whose option list was refreshed. Fully defensive.
+ *
+ * `defTypeKey` overrides which /object_info class_type the def is looked up under —
+ * REQUIRED for a nested/promoted write, where the widget being mutated lives on an
+ * intermediate VIRTUAL SubgraphNode (absent from /object_info) but its authoritative
+ * options come from the ULTIMATE CONCRETE backend type (#458 nested combo-refresh).
+ * The concrete type must be resolved through the promotion chain, never the virtual
+ * intermediate `node.type`. Defaults to the node's own type for direct writes.
+ *
+ * `widgetNameMap` (optional { nodeWidgetName -> defWidgetName }) bridges a RENAMED
+ * promotion: a nested promotion can rename the widget at each level, so the widget
+ * being mutated (`nodeWidgetName`) may not match the concrete def's input name — the
+ * map supplies the concrete-def key to look its options up under (#458×#366). Widgets
+ * not in the map fall back to their own name.
+ */
+export function refreshComboOptionsFromDefs(node, defsByType, defTypeKey, widgetNameMap) {
+  let refreshed = 0;
+  if (!node || !defsByType) return refreshed;
+  try {
+    const type = defTypeKey ?? node.type ?? node.comfyClass;
+    const def = type ? defsByType[type] : null;
+    if (!def) return refreshed;
+    const inputs = { ...(def.input?.required ?? {}), ...(def.input?.optional ?? {}) };
+    for (const w of node.widgets ?? []) {
+      if (w?.name == null) continue;
+      const defKey = (widgetNameMap && widgetNameMap[w.name]) ?? w.name;
+      const spec = inputs[defKey];
+      if (!spec) continue;
+      // A combo's spec is `[[opt, ...], config?]` — the first element is the option
+      // array. Anything else (a type string like "INT"/"STRING") is not a combo.
+      const first = Array.isArray(spec) ? spec[0] : undefined;
+      if (!Array.isArray(first)) continue;
+      // Never clobber a dynamic (function) option source — it derives its own list.
+      if (typeof w.options?.values === "function") continue;
+      if (!w.options || typeof w.options !== "object") w.options = {};
+      w.options.values = first.slice();
+      refreshed++;
+    }
+  } catch {
+    /* best-effort — a malformed def just means the retry falls back to failing closed */
+  }
+  return refreshed;
+}
+
 export function reapplyDefsToLiveNodes(rootGraph, defsByType) {
   let repaired = 0;
   if (!defsByType) return repaired;

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -159,6 +159,39 @@ export async function assertAddNodeResolvableRefreshing(getRegistry, class_type,
 }
 
 /**
+ * Fresh-backend authorization for graph_set_widget, applied to the type of the
+ * ACTUAL RESOLVED write target (the inner promoted node for a subgraph write, or
+ * the node's own for a direct write) — #458 set_widget gap, found in review of
+ * #375. graph_add_node already authorizes its class_type against the CURRENT
+ * /object_info; set_widget must do the SAME, because the LiteGraph registry keeps
+ * a STALE POSITIVE for an uninstalled pack when the browser tab was never reloaded
+ * after a ComfyUI restart. `freshDefs` is the freshly-fetched /object_info map (or
+ * null/undefined when the fetch failed). FAILS CLOSED in both directions:
+ *   - fetch unavailable (null/non-object) ⇒ "cannot verify against backend"; and
+ *   - type absent from the fresh map ⇒ "backend does not provide" (removed pack).
+ * Never authorizes from the stale registry. Pure — no side effects — so the caller
+ * can run it on the exact target it is about to mutate, before any mutation.
+ */
+export function assertTypeAgainstFreshBackend(freshDefs, type, nodeId = "(unknown)") {
+  const label = typeof type === "string" ? ` ("${type}")` : "";
+  if (!freshDefs || typeof freshDefs !== "object") {
+    throw new Error(
+      `Cannot set widget on node ${nodeId}${label}: cannot verify the node type against the ` +
+        `ComfyUI backend (object_info is unavailable — the backend is unreachable or the fetch ` +
+        `failed). Refusing to write rather than trust a possibly-stale node cache (#458). ` +
+        `Reconnect ComfyUI and retry.`,
+    );
+  }
+  if (typeof type !== "string" || !Object.prototype.hasOwnProperty.call(freshDefs, type)) {
+    throw new Error(
+      `Cannot set widget on node ${nodeId}${label}: the ComfyUI backend does not provide node ` +
+        `type "${type}" (not installed, or its pack was removed) — refusing to write to a node ` +
+        `the live backend no longer defines (#458). Check the exact class_type via panel_search_nodes.`,
+    );
+  }
+}
+
+/**
  * Guard for graph_set_widget, applied to the ACTUAL RESOLVED write target (the
  * inner promoted node for a subgraph write, or the node's own for a direct
  * write) — NOT the outer node. This is the load-bearing check: it must run on

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -16,19 +16,163 @@
 //   3. applyWidgetWrite with the resolved-target registry guard, which runs
 //      BEFORE value coercion and any mutation/callback.
 
-import { applyWidgetWrite, WidgetWriteError } from "./widget-write.js";
+import {
+  applyWidgetWrite,
+  WidgetWriteError,
+  resolvePromotedInnerTarget,
+  followPromotionToConcrete,
+} from "./widget-write.js";
 import { reconcileUnknownWidgetNames } from "./asset-staleness.js";
-import { preflightSetWidgetTarget, assertResolvedTargetRegistered } from "./node-resolve.js";
+import {
+  preflightSetWidgetTarget,
+  assertResolvedTargetRegistered,
+  assertTypeAgainstFreshBackend,
+} from "./node-resolve.js";
 
 export async function runSetWidget(
   node,
   widgetName,
   value,
-  { registry = {}, resolveSource, canvas, beforeChange, afterChange, setDirty, refreshCombos } = {},
+  {
+    registry = {},
+    getRegistry,
+    getFreshObjectInfo,
+    resolveSource,
+    canvas,
+    beforeChange,
+    afterChange,
+    setDirty,
+    refreshCombos,
+  } = {},
 ) {
+  const liveRegistry = () => (typeof getRegistry === "function" ? getRegistry() : registry);
+
+  // (0) FRESH-BACKEND TYPE AUTHORIZATION (#458 set_widget gap, found in review of
+  //     #375). graph_add_node authorizes its class_type against the CURRENT backend
+  //     /object_info; graph_set_widget must do the SAME for the type of the node the
+  //     write ACTUALLY MUTATES, because the LiteGraph registry KEEPS A STALE POSITIVE
+  //     for an uninstalled pack when the browser tab was never reloaded after a
+  //     ComfyUI restart. Without this, a since-removed type ("GoneNode") sails through
+  //     the registry-only guard and the write reports a fabricated SUCCESS against a
+  //     backend that no longer defines it.
+  //
+  //     The fresh /object_info oracle is REQUIRED, never optional: authorizing from
+  //     the stale registry when it is absent would REOPEN exactly this false-success
+  //     hole (a stale-positive GoneNode would be written and reported as success). So
+  //     a missing oracle FAILS CLOSED here, matching graph_add_node's fail-closed
+  //     contract — the panel always wires it (getFreshObjectInfo below).
+  if (typeof getFreshObjectInfo !== "function") {
+    throw new Error(
+      `Cannot set widget on node ${node?.id}${typeof node?.type === "string" ? ` ("${node.type}")` : ""}: ` +
+        `cannot verify the node type against the ComfyUI backend — no /object_info oracle is wired. ` +
+        `Refusing to write from a possibly-stale node registry (#458).`,
+    );
+  }
+
+  //     Fetch the CURRENT /object_info ONCE and resolve any promoted target ONCE —
+  //     the SAME resolution is threaded into applyWidgetWrite, so authorization and
+  //     the write hit the IDENTICAL target and no relink during the await can swap an
+  //     authorized live node for a stale GoneNode (no TOCTOU). The resolved-target
+  //     type is then authorized BEFORE preflight/reconcile/coercion so a removed/
+  //     unverifiable type is refused before a single side effect:
+  //       * DIRECT node → its own type.
+  //       * PROMOTED subgraph widget (positively resolved) → the ULTIMATE CONCRETE
+  //         backend node's type, following the promotion chain through any NESTED
+  //         SubgraphNodes (A → B → KSampler). A virtual subgraph-id type is absent
+  //         from /object_info, so authorizing an INTERMEDIATE virtual node would
+  //         wrongly refuse a valid nested write — the chain is TRAVERSED to the
+  //         concrete node, and only that concrete type is authorized (still fail
+  //         closed if it is genuinely removed).
+  //       * A truthy `subgraph` field with NO promoted match is NOT a real promoted
+  //         write — it writes the node's OWN widget, so it must fresh-authorize its
+  //         OWN type exactly like a direct node. A stale/removed type must never be
+  //         exempted just because it carries a `subgraph` field (#458 subgraph-shaped
+  //         bypass): otherwise a removed GoneNode with `subgraph:{}` + its own widget
+  //         would skip fresh-auth and the stale registry guard would fabricate success.
+  let freshDefs = null;
+  try {
+    freshDefs = await getFreshObjectInfo();
+  } catch {
+    freshDefs = null;
+  }
+
+  // Resolve the promoted inner target ONCE (PURE — no coercion/mutation). Threaded
+  // into applyWidgetWrite so the write never re-resolves to a different node.
+  const promotedResolution = node?.subgraph
+    ? resolvePromotedInnerTarget(node, widgetName, resolveSource)
+    : null;
+  const isResolvedPromotion = !!(
+    promotedResolution &&
+    promotedResolution.promoted &&
+    promotedResolution.target
+  );
+  // The node whose widget the write will actually mutate: the IMMEDIATE resolved inner
+  // node for a positively-resolved promoted write, else the node itself (direct write,
+  // OR a subgraph-shaped node with no promoted match writing its own widget). Threaded
+  // into applyWidgetWrite so the write never re-resolves.
+  const resolvedTargetNode = isResolvedPromotion ? promotedResolution.target.node : node;
+  const promotedButUnresolvable = !!(promotedResolution && promotedResolution.promoted && !promotedResolution.target);
+  // The node whose TYPE to fresh-authorize. For a promoted write, follow the promotion
+  // chain through any NESTED SubgraphNodes to the ULTIMATE CONCRETE backend node and
+  // authorize THAT type (a virtual intermediate subgraph type is never in /object_info
+  // and must be traversed, not authorized). A promoted-but-UNRESOLVABLE write has no
+  // reachable target and fails closed as a WidgetWriteError downstream.
+  let authTarget;
+  // For the stale-combo retry: the widget being MUTATED (on the immediate write target)
+  // and the ULTIMATE CONCRETE widget name whose /object_info options are authoritative.
+  // Nested promotions can RENAME the widget at each level (#366), so the mutated widget's
+  // name may differ from the concrete def's input name — this map bridges them (#458).
+  const writeTargetWidgetName = isResolvedPromotion ? promotedResolution.target.widget?.name : undefined;
+  let concreteWidgetName;
+  if (promotedButUnresolvable) {
+    authTarget = null;
+  } else if (isResolvedPromotion) {
+    const concrete = followPromotionToConcrete(promotedResolution.target, resolveSource);
+    if (concrete.node && !concrete.node.subgraph && typeof concrete.node.type === "string") {
+      // Reached a genuine concrete backend node WITH a real type string — authorize it.
+      // (assertTypeAgainstFreshBackend below then always runs for a promoted write.)
+      authTarget = concrete.node;
+      concreteWidgetName = concrete.widget?.name;
+    } else {
+      // The chain did NOT reach a verifiable concrete backend node: an unresolvable/
+      // stale deeper link ({node:null}), a terminal virtual own-widget, a cycle, OR a
+      // terminal node with NO string type. We cannot authorize such a target against
+      // /object_info, and the reused resolution would let the write mutate the IMMEDIATE
+      // virtual node behind only the registry guard (which trusts defless virtual
+      // subgraph nodes). FAIL CLOSED before any mutation — never treat a virtual/
+      // unresolved/typeless target as a verified concrete node (#458).
+      throw new Error(
+        `Cannot set widget on node ${node?.id} (promoted "${widgetName}"): the promotion ` +
+          `chain could not be resolved to a concrete backend node the ComfyUI backend ` +
+          `defines (nested/stale/ambiguous promotion) — refusing to write rather than ` +
+          `trust a possibly-stale node (#458).`,
+      );
+    }
+  } else {
+    authTarget = node;
+  }
+
+  if (authTarget && typeof authTarget.type === "string") {
+    assertTypeAgainstFreshBackend(freshDefs, authTarget.type, authTarget.id);
+  }
+
+  // #458 stale-INSTANCE guard on the ULTIMATE CONCRETE node. applyWidgetWrite runs the
+  // registered/stale-placeholder check (assertResolvedTargetRegistered) only on the
+  // IMMEDIATE write target — for a NESTED promotion that is the intermediate VIRTUAL
+  // SubgraphNode (defless/trusted), so the concrete backend instance we ultimately drive
+  // through the chain is never instance-checked there. A STALE generic placeholder (its
+  // type is registered but constructor.nodeData is missing — the workflow was loaded
+  // while ComfyUI was down) would then be mutated behind a fresh TYPE auth that only
+  // proves the type is live, not that THIS instance is real. Check the concrete instance
+  // here, before any mutation. (Skipped when the concrete node IS the immediate write
+  // target — single-level/direct — since applyWidgetWrite already checks it.)
+  if (isResolvedPromotion && authTarget && authTarget !== resolvedTargetNode) {
+    assertResolvedTargetRegistered(liveRegistry(), authTarget);
+  }
+
   // (1) Preflight the OUTER node before ANY mutation; decide whether reconcile
   //     may run (never on a placeholder; skipped for subgraph parents).
-  const { reconcile } = preflightSetWidgetTarget(registry, node);
+  const { reconcile } = preflightSetWidgetTarget(liveRegistry(), node);
   // (2) Repair positional UNKNOWN/UNKNOWN_n widget names against the live def so
   //     the caller's real widget name resolves (#199) — resolved direct node only.
   if (reconcile) reconcileUnknownWidgetNames(node);
@@ -38,7 +182,8 @@ export async function runSetWidget(
   // THERE (#233); it validates the value against the target's declared type
   // (#240) and verifies the write stuck exactly. The injected assertTargetWritable
   // runs on the RESOLVED target BEFORE coercion/mutation, so a placeholder is
-  // refused before any side effect (#458).
+  // refused before any side effect (#458). promotedResolution is reused so the
+  // write lands on the exact inner node the fresh oracle authorized.
   const write = () =>
     applyWidgetWrite(node, widgetName, value, {
       resolveSource,
@@ -46,7 +191,8 @@ export async function runSetWidget(
       beforeChange,
       afterChange,
       setDirty,
-      assertTargetWritable: (targetNode) => assertResolvedTargetRegistered(registry, targetNode),
+      assertTargetWritable: (targetNode) => assertResolvedTargetRegistered(liveRegistry(), targetNode),
+      promotedResolution,
     });
 
   try {
@@ -63,7 +209,22 @@ export async function runSetWidget(
     // absent after refresh) is rejected, and no other error class is retried.
     if (err instanceof WidgetWriteError && err.combo && typeof refreshCombos === "function") {
       try {
-        await refreshCombos();
+        // Reuse the /object_info payload already fetched for type authorization so a
+        // combo miss does not round-trip /object_info a SECOND time (#458 P2): the
+        // production refreshCombos refreshes THIS target's combo options from the
+        // passed defs instead of calling refreshComboInNodes (which re-fetches). The
+        // resolved WRITE target (the intermediate inner node for a nested promotion) is
+        // the node whose widget is mutated, but its authoritative options must be keyed
+        // on the ULTIMATE CONCRETE type (authTarget) — a virtual intermediate is absent
+        // from /object_info, so keying on it would refresh nothing and reject a valid
+        // just-staged value (#458 nested combo-refresh). A RENAMED nested promotion also
+        // needs the mutated widget's name bridged to the concrete def's input name (#366
+        // rename support). When defs are unavailable it falls back to a full refresh.
+        const comboNameMap =
+          writeTargetWidgetName && concreteWidgetName
+            ? { [writeTargetWidgetName]: concreteWidgetName }
+            : undefined;
+        await refreshCombos(freshDefs ?? undefined, resolvedTargetNode, authTarget?.type, comboNameMap);
       } catch {
         /* refresh best-effort; fall through to re-raise the original rejection */
       }

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -363,12 +363,55 @@ export function resolvePromotedInnerTarget(subgraphNode, widgetName, resolveSour
 }
 
 /**
+ * Follow a promoted write target through any NESTED SubgraphNodes to the ULTIMATE
+ * CONCRETE backend node (#458 nested-promotion false-failure). ComfyUI supports
+ * promoting an outer subgraph widget from an INNER subgraph that itself promotes from
+ * a real node (A → B → KSampler). The immediate resolved target of the outer
+ * promotion is the inner SubgraphNode (B) — a VIRTUAL node whose subgraph-id type is
+ * absent from /object_info, so authorizing THAT against the backend would wrongly
+ * refuse a valid write. Traverse the chain until a node with no `.subgraph` (the
+ * concrete backend node) is reached, and return it for fresh authorization; a virtual
+ * SubgraphNode type in the chain is TRAVERSED, never authorized. Pure: read-only.
+ *
+ * `target` is the immediate `{ node, widget }` from resolvePromotedInnerTarget.
+ * Returns (always carrying the widget reached at the terminal, for combo-refresh
+ * name mapping — nested promotions may RENAME the widget at each level, #366):
+ *   { node, widget }                        → the CONCRETE backend node + its widget
+ *   { node, widget, terminalVirtual: true } → chain ended on a virtual node's OWN
+ *                                             (non-promoted) widget; authorize its type
+ *   { node: null, widget: null, error }     → a deeper promotion link is unresolvable
+ *   { node, widget, cycle: true }           → a promotion cycle was detected (defensive)
+ */
+export function followPromotionToConcrete(target, resolveSource) {
+  let node = target?.node ?? null;
+  let widget = target?.widget ?? null;
+  const seen = new Set();
+  while (node && node.subgraph) {
+    if (seen.has(node)) return { node, widget, cycle: true };
+    seen.add(node);
+    const res = resolvePromotedInnerTarget(node, widget?.name, resolveSource);
+    if (!res.promoted) return { node, widget, terminalVirtual: true };
+    if (!res.target) return { node: null, widget: null, error: res.error };
+    node = res.target.node;
+    widget = res.target.widget;
+  }
+  return { node, widget };
+}
+
+/**
  * Resolve the true write target (inner promoted widget or the node's own
  * widget) and validate/coerce the value. Throws WidgetWriteError on any
  * unresolved-promotion, missing-widget, or value-mismatch condition — BEFORE
  * any mutation. Pure: no graph side effects.
  */
-export function resolveWidgetWrite(node, widgetName, value, resolveSource, assertTargetWritable) {
+export function resolveWidgetWrite(
+  node,
+  widgetName,
+  value,
+  resolveSource,
+  assertTargetWritable,
+  promotedResolution,
+) {
   let targetNode = node;
   let widget = null;
   let promotedFrom = null;
@@ -376,7 +419,12 @@ export function resolveWidgetWrite(node, widgetName, value, resolveSource, asser
   let promotedHostInput = null;
 
   if (node?.subgraph) {
-    const res = resolvePromotedInnerTarget(node, widgetName, resolveSource);
+    // Reuse a promotion resolution the caller already computed (graph_set_widget
+    // resolves it ONCE up front to fresh-authorize the inner target, #458), so the
+    // write targets the IDENTICAL inner node it authorized — a relink between the
+    // async /object_info fetch and the write can't swap in an unauthorized target.
+    // Falls back to resolving here for direct callers (e.g. unit fixtures).
+    const res = promotedResolution ?? resolvePromotedInnerTarget(node, widgetName, resolveSource);
     if (res.promoted) {
       // Promoted widget: use the resolved inner widget DIRECTLY. Never re-search
       // the inner node by the OUTER name (a rename would hit the wrong inner
@@ -453,14 +501,17 @@ export function applyWidgetWrite(
   node,
   widgetName,
   value,
-  { resolveSource, canvas, beforeChange, afterChange, setDirty, assertTargetWritable } = {},
+  { resolveSource, canvas, beforeChange, afterChange, setDirty, assertTargetWritable, promotedResolution } = {},
 ) {
   // resolveWidgetWrite runs assertTargetWritable on the RESOLVED target (inner
   // promoted node for a subgraph write, or the node's own) BEFORE it coerces the
   // value, so no coercion callback and no mutation can touch an unregistered
-  // placeholder that is about to be refused (#458).
+  // placeholder that is about to be refused (#458). A caller-supplied
+  // promotedResolution is reused so the write targets the EXACT node the fresh
+  // /object_info gate authorized (#458), and resolveWidgetWrite also fails closed if
+  // the AUTHORITATIVE parent rail widget can't be identified (#366).
   const { targetNode, widget: w, coerced, promotedFrom, promotedParentWidget, promotedHostInput } =
-    resolveWidgetWrite(node, widgetName, value, resolveSource, assertTargetWritable);
+    resolveWidgetWrite(node, widgetName, value, resolveSource, assertTargetWritable, promotedResolution);
 
   // #366: for a promoted subgraph widget the AUTHORITATIVE value lives on the
   // parent's OWN rail widget (resolved by the promotion RELATIONSHIP in


### PR DESCRIPTION
Closes #458-class set_widget gap (found in review of #375)

> **Rebased onto `main` (includes #366).** #366 hardened the same write path (rail-widget identity authentication + atomic inner+rail write + deep-clone rollback + `widgetId` binding + drift re-resolution). This PR **composes** with it: a promoted write now BOTH fresh-authorizes the ultimate concrete type (#458) AND authenticates/syncs the authoritative rail by identity (#366) — neither guard removed. The renamed-nested-promotion combo path (#366 supports renames) is bridged so combo-refresh keys on the concrete type **and** concrete widget name.

## Problem
`graph_set_widget` authorized the target node's type **solely from the mutable LiteGraph registry**, which keeps a **stale positive** for an uninstalled pack after a ComfyUI restart-without-reload. A since-removed type (`GoneNode`) sailed through every registry guard and the write reported a **fabricated SUCCESS**. `graph_add_node` already closed this in #375 via a fresh `/object_info`; `graph_set_widget` was missed.

## Fix
`runSetWidget` authorizes the type of the **ultimate concrete backend node** the write reaches (resolved through the promotion chain) against the current `/object_info`, before any mutation — failing closed on absent/unreachable/unresolvable/terminal-virtual/cycle/typeless. Mandatory oracle, single fetch. The stale-combo retry refreshes the write-target node's combos from the cached payload, **keyed on the concrete type and concrete widget name** (bridging renamed nested promotions).

## Tests (`browser_tests/unit/set-widget-fresh-backend.test.mjs`, 21 cases + composed with #366's `widget-write.test.mjs`)
Full fail-closed matrix; direct + single-level + nested (plain and **renamed**) promoted success; nested combo recovery single-fetch; promoted write threads the resolution AND syncs the #366 rail; decoy sibling untouched.

Full unit suite green (**662 pass, 0 fail** — both #366 rail-sync/rollback and #458 fail-closed matrix together); ESM clean.

## Review
Adversarial Codex self-review iterated to **VERDICT: PASS** across all rounds; the post-rebase round confirmed neither #366's rail-identity/rollback/drift nor #458's fresh-auth matrix regressed and they compose (a nested promoted write is both rail-identity-authenticated and concrete-type fresh-authorized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
