### PR TITLE
fix: author/repo install shorthand, dead collapse fallback, storyboard input litter

### DIFF
--- a/browser_tests/unit/graph-set-node-collapsed.test.mjs
+++ b/browser_tests/unit/graph-set-node-collapsed.test.mjs
@@ -1,0 +1,126 @@
+// Regression coverage for #345: graph_set_node_collapsed (web/js/comfyui-mcp-panel.js)
+// was a silent no-op for any node whose `collapsible` is falsy, because
+// node.collapse() early-returns for such a node unless a truthy `force` is
+// passed, and the panel called it with none — the direct flag-write fallback
+// branch was therefore dead code (node.collapse is always a function on a real
+// LGraphNode, so the `else` never ran).
+//
+// graph_set_node_collapsed lives inline inside the GRAPH_TOOL_EXECUTORS object
+// literal in comfyui-mcp-panel.js (can't be imported under plain Node — it
+// references browser/ComfyUI globals), so this follows the same "real panel
+// source" extraction convention already used by manager-install.test.mjs's
+// "waitForQueueDrain (real panel source)" test: regex the method's source text
+// out of the file and evaluate it via `new Function`, with `getGraphCtx` /
+// `resolveNode` injected as stubs so the test drives the ACTUAL shipped logic.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8");
+
+const methodMatch = panelSrc.match(/graph_set_node_collapsed\(\{ node_id, collapsed \}\) \{[\s\S]*?\n  \},/);
+assert.ok(methodMatch, "could not locate graph_set_node_collapsed in panel source");
+
+/** Build a fresh graph_set_node_collapsed bound to the given getGraphCtx/resolveNode
+ *  stubs, evaluating the REAL method source pulled from the panel file. */
+function realGraphSetNodeCollapsed(getGraphCtx, resolveNode) {
+  const factory = new Function(
+    "getGraphCtx",
+    "resolveNode",
+    `const executors = { ${methodMatch[0]} };\nreturn executors.graph_set_node_collapsed;`,
+  );
+  return factory(getGraphCtx, resolveNode);
+}
+
+/** A node whose `collapse` mirrors the real ComfyUI frontend's
+ *  LGraphNode.prototype.collapse(force): a silent no-op when `collapsible` is
+ *  falsy and no truthy `force` is passed, otherwise toggles flags.collapsed. */
+function makeNode({ id = 170, collapsible = true, collapsed = false } = {}) {
+  return {
+    id,
+    collapsible,
+    flags: { collapsed },
+    collapse(force) {
+      if (!this.collapsible && !force) return;
+      this.flags.collapsed = !this.flags.collapsed;
+    },
+  };
+}
+
+function makeGraph() {
+  const calls = { before: 0, after: 0, dirty: 0 };
+  return {
+    calls,
+    beforeChange: () => { calls.before += 1; },
+    afterChange: () => { calls.after += 1; },
+    setDirtyCanvas: () => { calls.dirty += 1; },
+  };
+}
+
+test("#345 FAIL-before regression fixture: node.collapse() alone is a no-op when non-collapsible", () => {
+  // This is not the panel's fix — it's a direct demonstration of the bug's root
+  // cause (LGraphNode.prototype.collapse's own guard), so the fix's necessity is
+  // provable independent of the panel source extraction below.
+  const node = makeNode({ collapsible: false });
+  node.collapse(); // no force — exactly what the OLD panel code called
+  assert.equal(node.flags.collapsed, false, "collapse() with no force must not apply on a non-collapsible node");
+});
+
+test("#345 graph_set_node_collapsed FORCES collapse on a non-collapsible node (real panel source)", () => {
+  const node = makeNode({ collapsible: false, collapsed: false });
+  const graph = makeGraph();
+  const fn = realGraphSetNodeCollapsed(() => ({ graph }), () => node);
+
+  const result = fn({ node_id: node.id, collapsed: true });
+
+  assert.equal(node.flags.collapsed, true, "the node's actual flag must flip even though collapsible is false");
+  assert.equal(result.collapsed, true, "the reported state must match reality, not silently stay false");
+  assert.equal(graph.calls.dirty >= 1, true, "must redraw so the collapsed state is visible");
+});
+
+test("#345 graph_set_node_collapsed FORCES expand on a non-collapsible, already-collapsed node", () => {
+  const node = makeNode({ collapsible: false, collapsed: true });
+  const graph = makeGraph();
+  const fn = realGraphSetNodeCollapsed(() => ({ graph }), () => node);
+
+  const result = fn({ node_id: node.id, collapsed: false });
+
+  assert.equal(node.flags.collapsed, false);
+  assert.equal(result.collapsed, false);
+});
+
+test("#345 graph_set_node_collapsed still works normally on an ordinary collapsible node (no regression)", () => {
+  const node = makeNode({ collapsible: true, collapsed: false });
+  const graph = makeGraph();
+  const fn = realGraphSetNodeCollapsed(() => ({ graph }), () => node);
+
+  const result = fn({ node_id: node.id, collapsed: true });
+  assert.equal(node.flags.collapsed, true);
+  assert.equal(result.collapsed, true);
+
+  const result2 = fn({ node_id: node.id, collapsed: false });
+  assert.equal(node.flags.collapsed, false);
+  assert.equal(result2.collapsed, false);
+});
+
+test("#345 graph_set_node_collapsed is a no-op when already in the requested state (no spurious toggle)", () => {
+  const node = makeNode({ collapsible: false, collapsed: true });
+  const graph = makeGraph();
+  const fn = realGraphSetNodeCollapsed(() => ({ graph }), () => node);
+
+  const result = fn({ node_id: node.id, collapsed: true });
+  assert.equal(node.flags.collapsed, true);
+  assert.equal(result.collapsed, true);
+});
+
+test("#345 falls back to a direct flag write when node.collapse is not a function at all", () => {
+  const node = { id: 170, flags: { collapsed: false } }; // no collapse() method whatsoever
+  const graph = makeGraph();
+  const fn = realGraphSetNodeCollapsed(() => ({ graph }), () => node);
+
+  const result = fn({ node_id: node.id, collapsed: true });
+  assert.equal(node.flags.collapsed, true);
+  assert.equal(result.collapsed, true);
+});

--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 import * as ManagerInstall from "../../web/js/lib/manager-install.js";
 const {
   looksLikeGitUrl,
+  looksLikeOwnerRepoShorthand,
   gitRepoName,
   installGitUrl,
   buildInstallRequest,
@@ -29,7 +30,7 @@ const {
   searchNodesVia,
 } = ManagerInstall;
 
-test("looksLikeGitUrl recognizes every git protocol", () => {
+test("looksLikeGitUrl recognizes every git protocol, plus author/repo shorthand (#301)", () => {
   for (const u of [
     "https://github.com/foo/bar",
     "http://example.com/foo/bar.git",
@@ -39,13 +40,30 @@ test("looksLikeGitUrl recognizes every git protocol", () => {
     "git@github.com:foo/bar.git",
     "git@github.com:foo/bar",
     "something.git",
+    "kijai/ComfyUI-Hunyuan3DWrapper", // #301 — bare author/repo shorthand
+    "ltdrdata/ComfyUI-Manager",
   ]) {
     assert.equal(looksLikeGitUrl(u), true, `expected git URL: ${u}`);
   }
-  for (const id of ["rgthree-comfy", "comfyui-manager", "author/pack", ""]) {
+  for (const id of ["rgthree-comfy", "comfyui-manager", ""]) {
     assert.equal(looksLikeGitUrl(id), false, `expected registry id: ${id}`);
   }
   assert.equal(looksLikeGitUrl(undefined), false);
+});
+
+test("looksLikeOwnerRepoShorthand matches only a bare, single-slash owner/repo (#301)", () => {
+  for (const s of ["kijai/ComfyUI-Hunyuan3DWrapper", "a/b", "foo-bar/baz_qux.thing"]) {
+    assert.equal(looksLikeOwnerRepoShorthand(s), true, `expected shorthand: ${s}`);
+  }
+  for (const s of [
+    "rgthree-comfy", // no slash — plain registry id
+    "https://github.com/foo/bar", // already a full URL
+    "git@github.com:foo/bar", // scp-form, has a colon
+    "foo/bar/baz", // more than one slash
+    "", undefined, null,
+  ]) {
+    assert.equal(looksLikeOwnerRepoShorthand(s), false, `expected non-shorthand: ${s}`);
+  }
 });
 
 test("gitRepoName derives the repo name for every form", () => {
@@ -68,6 +86,23 @@ test("installGitUrl accepts a git URL via id OR repository, null for registry id
   assert.equal(installGitUrl({}), null);
 });
 
+// #301 — regression: panel_install_node({id:"author/repo"}) used to fall through
+// to the plain registry-id branch (sent verbatim to Manager → 502 on v4, silent
+// failure on 3.x) because looksLikeGitUrl didn't recognize the shorthand. It must
+// now be expanded to a real, clonable GitHub URL via id OR repository.
+test("installGitUrl expands a bare author/repo shorthand to a clonable GitHub URL (#301)", () => {
+  assert.equal(
+    installGitUrl({ id: "kijai/ComfyUI-Hunyuan3DWrapper" }),
+    "https://github.com/kijai/ComfyUI-Hunyuan3DWrapper",
+  );
+  assert.equal(
+    installGitUrl({ repository: "ltdrdata/ComfyUI-Manager" }),
+    "https://github.com/ltdrdata/ComfyUI-Manager",
+  );
+  // A real registry id (no slash) must NOT be reinterpreted as a shorthand.
+  assert.equal(installGitUrl({ id: "rgthree-comfy" }), null);
+});
+
 // --- v2 (Manager v4) ---------------------------------------------------------
 test("v2 git URL → id is repo name, no files, channel dev (via id and via repository)", () => {
   for (const src of [
@@ -86,6 +121,29 @@ test("v2 git URL → id is repo name, no files, channel dev (via id and via repo
     assert.ok(!looksLikeGitUrl(req.params.id), "id must not be a full URL");
   }
 });
+
+// #301 — author/repo shorthand must route exactly like an equivalent full git
+// URL would: v4 by repo name only (no files), v2-batch/legacy via a real
+// clonable files[] URL derived from the shorthand.
+test("v2 author/repo shorthand → id is repo name, no files, channel dev (#301)", () => {
+  const req = buildInstallRequest("v2", { id: "kijai/ComfyUI-Hunyuan3DWrapper" }, "uid-1");
+  assert.equal(req.envelope, "task");
+  assert.equal(req.params.id, "ComfyUI-Hunyuan3DWrapper");
+  assert.equal(req.params.selected_version, "nightly");
+  assert.equal(req.params.channel, "dev");
+  assert.ok(!("files" in req.params), "v4 must NOT send files");
+  assert.ok(!looksLikeGitUrl(req.params.id), "id must not be a full URL or shorthand");
+});
+
+for (const dialect of ["v2-batch", "legacy"]) {
+  test(`${dialect} author/repo shorthand → native files install with a real clonable URL (#301)`, () => {
+    const req = buildInstallRequest(dialect, { id: "kijai/ComfyUI-Hunyuan3DWrapper" }, "uid-1");
+    assert.equal(req.body.id, "ComfyUI-Hunyuan3DWrapper");
+    assert.deepEqual(req.body.files, ["https://github.com/kijai/ComfyUI-Hunyuan3DWrapper"]);
+    assert.equal(req.body.version, "unknown");
+    assert.equal(req.body.ui_id, "uid-1");
+  });
+}
 
 test("v2 registry id keeps the versioned body", () => {
   const req = buildInstallRequest("v2", { id: "rgthree-comfy" }, "uid-1");

--- a/browser_tests/unit/run-completion.test.mjs
+++ b/browser_tests/unit/run-completion.test.mjs
@@ -300,24 +300,28 @@ test("execution_success + executing:null ordering yields exactly one event", () 
 function makeFrameDeps(overrides = {}) {
   const frames = [];
   const painted = [];
+  const uploadCalls = [];
   const deps = {
     sendFrame: (f) => frames.push(f),
     coerceMessageText: (v) => (v == null ? "" : typeof v === "string" ? v : String(v)),
     formatDuration: (ms) => (ms == null ? null : `${Math.round(ms / 1000)}s`),
     formatClock: () => "12:00:00",
-    imageViewUrl: (m) => `view://${m?.filename ?? "x"}`,
+    imageViewUrl: (m) => `view://${m?.filename ?? "x"}?type=${m?.type ?? "output"}`,
     fetchImageBytes: async () => 2048,
     fetchImageDimensions: async () => ({ w: 512, h: 512 }),
     humanizeBytes: (n) => (n == null ? null : `${n} B`),
     buildVideoStoryboard: async () => ({ fake: "blob" }),
-    uploadBlobToInput: async (_blob, name) => ({ filename: name, type: "input" }),
+    uploadBlobToInput: async (_blob, name, opts) => {
+      uploadCalls.push({ name, opts });
+      return { filename: name, type: opts?.type || "input" };
+    },
     storyboardFrameCount: () => 20,
     paintImage: (url, name) => painted.push({ url, name }),
     videoStoryboardEnabled: true,
     warn: () => {},
     ...overrides,
   };
-  return { deps, frames, painted };
+  return { deps, frames, painted, uploadCalls };
 }
 
 test("#269/#468 presentation: a MIXED run (stills + 2 videos) emits EXACTLY ONE agent_event with all outputs", async () => {
@@ -395,6 +399,36 @@ test("presentation: a video-only run (2 videos) is still ONE frame", async () =>
     ["storyboard_x.png", "storyboard_y.png"],
     "both storyboards in the single frame",
   );
+});
+
+// #209 — the storyboard contact sheet is a panel-generated PREVIEW, never a
+// real user input, so it must upload into ComfyUI's swept temp/ namespace
+// (type:"temp") instead of permanently littering input/. FAIL-before: the OLD
+// call site (`uploadBlobToInput(blob, name)`, no options) left `opts` undefined,
+// so this test's stub would have recorded `opts: undefined` and the ImageRef
+// would fall back to `type: "input"`.
+test("#209 storyboard upload requests ComfyUI's temp namespace, never input/", async () => {
+  const { deps, frames, uploadCalls } = makeFrameDeps();
+  await composeRunCompletionFrame(
+    {
+      promptId: "p-storyboard-temp",
+      images: [{ filename: "final.png", type: "output" }],
+      videos: [{ m: { filename: "clip.mp4", type: "output" }, nodeId: "7" }],
+      durationMs: 5000,
+    },
+    deps,
+  );
+  assert.equal(uploadCalls.length, 1, "one storyboard upload for the one video");
+  assert.equal(uploadCalls[0].name, "storyboard_clip.png");
+  assert.equal(uploadCalls[0].opts?.type, "temp", "must request the temp namespace, not input/");
+
+  // The resulting ImageRef must carry type:"temp" all the way into the sent
+  // frame, so the chat preview resolves via /view?...&type=temp — never silently
+  // falls back to type:"input" (which would defeat the fix even if the upload
+  // call itself requested temp).
+  const storyboardImg = frames[0].images.find((m) => m.filename === "storyboard_clip.png");
+  assert.ok(storyboardImg, "storyboard ref must be present in the sent frame");
+  assert.equal(storyboardImg.type, "temp");
 });
 
 test("presentation: an empty batch emits NO frame", async () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -6755,8 +6755,16 @@ const GRAPH_TOOL_EXECUTORS = {
     try {
       const isCollapsed = !!(node.flags && node.flags.collapsed);
       if (isCollapsed !== want) {
-        if (typeof node.collapse === "function") node.collapse();
-        else {
+        // node.collapse() early-returns a silent no-op for a non-collapsible
+        // node unless a truthy `force` is passed — pass it, since an explicit
+        // tool call is a direct request for an exact state, not a UI gesture
+        // that should respect `collapsible` (#345). Then verify: if the flag
+        // still doesn't match `want` (collapse() missing, or an older build
+        // without the `force` parameter), write it directly — node.flags.collapsed
+        // is the single source of truth every other read site in this file
+        // already relies on, so this fallback is never a lie about state.
+        if (typeof node.collapse === "function") node.collapse(true);
+        if (!!(node.flags && node.flags.collapsed) !== want) {
           node.flags = node.flags || {};
           node.flags.collapsed = want;
         }
@@ -14729,18 +14737,24 @@ function buildPanel() {
   // When a run finishes with output images, show them in the chat and notify
   // the agent so it knows its render landed (the orchestrator drops the event
   // if no session is attending). On error, notify the agent to diagnose.
-  // Upload a Blob into ComfyUI's input/ folder via the SAME endpoint chat
-  // attachments use (/upload/image writes any blob verbatim) → returns an
-  // ImageRef ({filename, subfolder, type:"input"}) the vision path can resolve,
-  // or null on failure. Mirrors handleImageFile's upload.
-  async function uploadBlobToInput(blob, name) {
+  // Upload a Blob via the SAME endpoint chat attachments use (/upload/image
+  // writes any blob verbatim) → returns an ImageRef ({filename, subfolder, type})
+  // the vision path can resolve, or null on failure. Mirrors handleImageFile's
+  // upload. Defaults to ComfyUI's input/ folder — real user-facing uploads
+  // (chat/apps/civitai/training inputs) need that persistence. Pass
+  // `{ type: "temp" }` for ephemeral panel-generated artifacts (e.g. the
+  // storyboard contact sheet, #209) that must NOT accumulate in input/ —
+  // ComfyUI's own /upload/image + /view both understand `type=temp` and store it
+  // in ComfyUI's swept temp directory instead.
+  async function uploadBlobToInput(blob, name, { type } = {}) {
     try {
       const fd = new FormData();
       fd.append("image", blob, name);
+      if (type) fd.append("type", type);
       const res = await api.fetchApi("/upload/image", { method: "POST", body: fd });
       if (res.status !== 200) return null;
       const info = await res.json();
-      return { filename: info.name, subfolder: info.subfolder || undefined, type: info.type || "input" };
+      return { filename: info.name, subfolder: info.subfolder || undefined, type: info.type || type || "input" };
     } catch {
       return null;
     }

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -6,16 +6,29 @@
 // installCustomNode / looksLikeGitUrl / gitCheckoutDir logic
 // (src/services/node-management.ts).
 
-/** Does this identifier look like a git URL (vs a registry id)? Recognizes
+/** Does `s` look like a bare "author/repo" GitHub shorthand — no protocol/scp
+ *  prefix, no ".git" suffix, exactly one "/", plausible path-segment chars on
+ *  both sides? Distinguishes it from a slash-free registry id (e.g.
+ *  "rgthree-comfy") and from anything already caught by looksLikeGitUrl's other
+ *  branches (a "://" or "git@" form has more than one meaningful "/" or a colon
+ *  that this pattern's char class excludes). #301. */
+export function looksLikeOwnerRepoShorthand(s) {
+  return typeof s === "string" && /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/.test(s);
+}
+
+/** Does this identifier look like a git URL (vs a plain registry id)? Recognizes
  *  https(s)://, ssh://, git:// (and git+…), the scp-form git@host:owner/repo,
- *  and any value ending in ".git". */
+ *  any value ending in ".git", and a bare "author/repo" shorthand (#301 — the
+ *  documented `id` form that a plain registry lookup can't resolve, so it must
+ *  route like a git install instead of being sent verbatim to Manager). */
 export function looksLikeGitUrl(s) {
   return (
     typeof s === "string" &&
     (/^(https?|ssh|git):\/\//i.test(s) ||
       /^git\+/i.test(s) ||
       /^git@/i.test(s) ||
-      s.endsWith(".git"))
+      s.endsWith(".git") ||
+      looksLikeOwnerRepoShorthand(s))
   );
 }
 
@@ -34,12 +47,17 @@ export function gitRepoName(url) {
 }
 
 /** Resolve the git URL for an install request, if any. A caller may pass the
- *  URL as `repository` OR directly as `id`; either counts. Returns null for a
- *  plain registry id. */
+ *  URL as `repository` OR directly as `id`; either counts. A bare "author/repo"
+ *  shorthand is expanded to a real, clonable GitHub URL (#301) — v4 only ever
+ *  uses the repo NAME (gitRepoName strips the expansion right back off), but
+ *  the v2-batch/legacy dialects put this value straight into Manager's `files`
+ *  clone list, where the bare shorthand alone is not a fetchable URL. Returns
+ *  null for a plain registry id. */
 export function installGitUrl({ id, repository } = {}) {
-  if (repository && looksLikeGitUrl(repository)) return repository;
-  if (id && looksLikeGitUrl(id)) return id;
-  return null;
+  const candidate =
+    repository && looksLikeGitUrl(repository) ? repository : id && looksLikeGitUrl(id) ? id : null;
+  if (!candidate) return null;
+  return looksLikeOwnerRepoShorthand(candidate) ? `https://github.com/${candidate}` : candidate;
 }
 
 /**

--- a/web/js/lib/run-completion-frame.js
+++ b/web/js/lib/run-completion-frame.js
@@ -339,7 +339,12 @@ async function buildVideoSegment(v, deps) {
         return { ref: null, note: noteOnly("couldn't sample a storyboard from it") };
       }
       const base = (coerceMessageText(m?.filename) || "video").replace(/\.[^.]+$/, "");
-      const ref = await uploadBlobToInput(blob, `storyboard_${base}.png`);
+      // #209 — the storyboard contact sheet is a PANEL-GENERATED preview, not a
+      // real user input; upload it into ComfyUI's swept temp/ namespace (NOT
+      // input/) so it never accumulates as permanent input litter. imageViewUrl
+      // reads ref.type through to the /view request, so the chat preview still
+      // resolves correctly.
+      const ref = await uploadBlobToInput(blob, `storyboard_${base}.png`, { type: "temp" });
       if (!ref) {
         warn("[cmcp] storyboard: upload failed for", m?.filename);
         return { ref: null, note: noteOnly("couldn't upload its storyboard") };


### PR DESCRIPTION
## Summary

Three independent, older, small bugs in one cluster:

- **#301** — `panel_install_node returns HTTP 502 for documented author/repo id`. `looksLikeGitUrl`/`installGitUrl` (`web/js/lib/manager-install.js`) didn't recognize a bare `author/repo` shorthand, so it fell through to the plain registry-id branch and was sent verbatim to Manager (502 on v4, silent failure on 3.x). Now recognized via a new `looksLikeOwnerRepoShorthand` and expanded to a real, clonable GitHub URL — routes identically to an equivalent full git URL for every dialect (v2/v2-batch/legacy).
- **#345** — `panel_set_node_collapsed is a silent no-op`. `graph_set_node_collapsed` preferred `node.collapse()` over its own direct flag-write fallback, but `LGraphNode.prototype.collapse()` early-returns for a non-collapsible node unless `force=true` is passed — so the fallback branch (which would have worked) was dead code, and the tool call silently no-opped. Now calls `collapse(true)`, verifies `node.flags.collapsed` actually changed, and falls back to a direct write if it still didn't.
- **#209** — `Video storyboard previews are permanently uploaded into ComfyUI input`. `uploadBlobToInput`'s storyboard call site (`run-completion-frame.js`) always wrote into ComfyUI's persistent `input/` folder, so the 20-frame contact-sheet preview generated after every video render accumulated there forever, even though the panel calls it "temporary". The storyboard call site now requests ComfyUI's own swept `temp/` namespace (`type:"temp"`) instead. Conservative: `uploadBlobToInput`'s default (used by chat attachments, apps-tab image input, Civitai reference saves, and training dataset uploads — all genuinely persistent user inputs) is untouched; no deletion logic was added anywhere.

**#236** (capability negotiation / old-panel tool gating) was investigated but its root cause is in the **orchestrator repo** (`comfyui-mcp`'s `ui-bridge.ts`), not here — the panel's hello already sends everything the gate needs (`panel_version`), and the panel has no capability-listing concept to add. Fixed as a companion PR there: https://github.com/Artokun/comfyui-mcp/pull/new/fix/236-panel-capability-gate (not included in this PR's Closes list).

## Test plan
- [x] Each bug has a fail-before/pass-after regression test driving the real path (verified by reverting each source change locally and re-running its test).
- [x] `npm run test:unit` — 583 pass, 0 fail.
- [x] `npm run typecheck` (tsc --noEmit) — clean.
- [x] Changed files verified as valid ES modules (`node --check`).
- [x] Independent adversarial codex review of the diff — PASS, no findings.

Closes #301
Closes #345
Closes #209