### PR TITLE
fix(panel): graph_run surfaces top-level prompt rejection + reconcile runs across a connection drop (#358, #370)

### DIFF
--- a/browser_tests/unit/queue-rejection.test.mjs
+++ b/browser_tests/unit/queue-rejection.test.mjs
@@ -12,7 +12,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { summarizePromptRejection, formatTopError } from "../../web/js/lib/queue-rejection.js";
+import {
+  summarizePromptRejection,
+  formatTopError,
+  buildQueueAcceptResult,
+} from "../../web/js/lib/queue-rejection.js";
 
 // The exact top-level rejection body from issue #358.
 const MISSING_NODE_TYPE = {
@@ -114,4 +118,32 @@ test("empty/whitespace top-level error is NOT treated as a rejection", () => {
     summarizePromptRejection({ rejection: { error: "   ", node_errors: {} }, lastNodeErrors: {} }),
     null,
   );
+});
+
+// ── #358/mcp#531: the ACCEPT result must carry the queued prompt_id(s) ──────────
+
+test("mcp#531: a single accepted run returns the prompt_id", () => {
+  const r = buildQueueAcceptResult({ batchCount: 1, promptIds: ["p1"] });
+  assert.equal(r.queued, true);
+  assert.equal(r.batch_count, 1);
+  assert.equal(r.prompt_id, "p1");
+  assert.equal(r.prompt_ids, undefined, "no prompt_ids array for a single run");
+});
+
+test("a batch>1 accept returns prompt_id (first) AND prompt_ids (all)", () => {
+  const r = buildQueueAcceptResult({ batchCount: 3, promptIds: ["p1", "p2", "p3"] });
+  assert.equal(r.batch_count, 3);
+  assert.equal(r.prompt_id, "p1");
+  assert.deepEqual(r.prompt_ids, ["p1", "p2", "p3"]);
+});
+
+test("run-to-node carries ran_to_node alongside the prompt_id", () => {
+  const r = buildQueueAcceptResult({ batchCount: 1, promptIds: ["p9"], ranToNode: 42 });
+  assert.equal(r.prompt_id, "p9");
+  assert.equal(r.ran_to_node, 42);
+});
+
+test("no captured prompt_id (older frontend) still returns a valid accept", () => {
+  const r = buildQueueAcceptResult({ batchCount: 1, promptIds: [] });
+  assert.deepEqual(r, { queued: true, batch_count: 1 });
 });

--- a/browser_tests/unit/queue-rejection.test.mjs
+++ b/browser_tests/unit/queue-rejection.test.mjs
@@ -159,3 +159,19 @@ test("a NUMERIC prompt_id is normalized to a string at ingestion (#370)", () => 
   assert.strictEqual(c.prompt_id, "p1");
   assert.equal(c.prompt_ids, undefined);
 });
+
+test("a FALSY-but-valid prompt_id 0 is accepted and normalized to '0' (#370 falsy-0 gotcha)", () => {
+  const r = buildQueueAcceptResult({ batchCount: 1, promptIds: [0] });
+  assert.strictEqual(r.prompt_id, "0"); // NOT dropped, NOT the number 0
+  const b = buildQueueAcceptResult({ batchCount: 2, promptIds: [0, 1] });
+  assert.strictEqual(b.prompt_id, "0");
+  assert.deepEqual(b.prompt_ids, ["0", "1"]);
+});
+
+test("mixed-representation ids (0 and '0') dedupe to one after normalization (#370)", () => {
+  const r = buildQueueAcceptResult({ batchCount: 2, promptIds: [0, "0"] });
+  assert.strictEqual(r.prompt_id, "0");
+  assert.equal(r.prompt_ids, undefined, "0 and '0' are the SAME run — deduped to a single id");
+  const b = buildQueueAcceptResult({ batchCount: 3, promptIds: [7, "7", 8] });
+  assert.deepEqual(b.prompt_ids, ["7", "8"]);
+});

--- a/browser_tests/unit/queue-rejection.test.mjs
+++ b/browser_tests/unit/queue-rejection.test.mjs
@@ -147,3 +147,15 @@ test("no captured prompt_id (older frontend) still returns a valid accept", () =
   const r = buildQueueAcceptResult({ batchCount: 1, promptIds: [] });
   assert.deepEqual(r, { queued: true, batch_count: 1 });
 });
+
+test("a NUMERIC prompt_id is normalized to a string at ingestion (#370)", () => {
+  const r = buildQueueAcceptResult({ batchCount: 1, promptIds: [7] });
+  assert.strictEqual(r.prompt_id, "7"); // string, not number
+  const b = buildQueueAcceptResult({ batchCount: 2, promptIds: [7, 8] });
+  assert.strictEqual(b.prompt_id, "7");
+  assert.deepEqual(b.prompt_ids, ["7", "8"]); // all strings
+  // null/undefined ids are dropped before coercion (no "null"/"undefined" strings).
+  const c = buildQueueAcceptResult({ batchCount: 1, promptIds: [null, "p1", undefined] });
+  assert.strictEqual(c.prompt_id, "p1");
+  assert.equal(c.prompt_ids, undefined);
+});

--- a/browser_tests/unit/queue-rejection.test.mjs
+++ b/browser_tests/unit/queue-rejection.test.mjs
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for web/js/lib/queue-rejection.js — run with `node --test`.
+ *
+ * Guards #358: graph_run must NEVER report `queued:true` when ComfyUI refused the
+ * prompt synchronously. ComfyUI rejects on two channels — per-node `node_errors`
+ * (which the frontend stashes on `app.lastNodeErrors`) AND a TOP-LEVEL `error`
+ * (e.g. `missing_node_type`) which the frontend shows in a dialog and then
+ * DISCARDS. The pre-fix code inspected only `lastNodeErrors`, so a pure top-level
+ * rejection left `lastNodeErrors` empty and produced a false `queued:true`. These
+ * tests pin that the top-level error is now surfaced as a real failure.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { summarizePromptRejection, formatTopError } from "../../web/js/lib/queue-rejection.js";
+
+// The exact top-level rejection body from issue #358.
+const MISSING_NODE_TYPE = {
+  type: "missing_node_type",
+  message: "Node 'ID #159' has no class_type. The workflow may be corrupted or a custom node is missing.",
+  details: "Node ID '#159'",
+  extra_info: { node_id: "159", class_type: null, node_title: null },
+};
+
+test("#358: top-level missing_node_type with EMPTY lastNodeErrors is a FAILURE, not queued", () => {
+  // This is the exact regression: pre-fix, lastNodeErrors={} ⇒ verdict null ⇒
+  // caller returned queued:true. Now the captured top-level error yields a failure.
+  const verdict = summarizePromptRejection({
+    rejection: { error: MISSING_NODE_TYPE, node_errors: {} },
+    lastNodeErrors: {},
+  });
+  assert.ok(verdict, "must produce a verdict (not null / not accepted)");
+  assert.equal(verdict.queued, false);
+  assert.equal(verdict.error_type, "missing_node_type");
+  assert.match(verdict.error, /has no class_type/);
+  assert.match(verdict.error, /Node ID '#159'/); // details folded in
+});
+
+test("a genuinely ACCEPTED prompt (no rejection, no node errors) is null ⇒ queued:true", () => {
+  assert.equal(
+    summarizePromptRejection({ rejection: null, lastNodeErrors: {} }),
+    null,
+  );
+  assert.equal(
+    summarizePromptRejection({ rejection: null, lastNodeErrors: null }),
+    null,
+  );
+  // An accepted 200 response carrying an empty node_errors map must NOT be a failure.
+  assert.equal(
+    summarizePromptRejection({ rejection: { error: null, node_errors: {} }, lastNodeErrors: {} }),
+    null,
+  );
+});
+
+test("per-node validation errors (from the rejection body) surface as node_errors", () => {
+  const nodeErrors = { 12: { errors: [{ message: "Value not in list", details: "bad.ckpt" }] } };
+  const verdict = summarizePromptRejection({
+    rejection: { error: null, node_errors: nodeErrors },
+    lastNodeErrors: {},
+  });
+  assert.ok(verdict);
+  assert.equal(verdict.queued, false);
+  assert.deepEqual(verdict.node_errors, nodeErrors);
+  assert.equal(verdict.error, undefined); // no top-level error string when only per-node
+});
+
+test("per-node validation errors from lastNodeErrors (top-level empty) still fail", () => {
+  const nodeErrors = { 7: { errors: [{ message: "required input missing" }] } };
+  const verdict = summarizePromptRejection({
+    rejection: null,
+    lastNodeErrors: nodeErrors,
+  });
+  assert.ok(verdict);
+  assert.equal(verdict.queued, false);
+  assert.deepEqual(verdict.node_errors, nodeErrors);
+});
+
+test("BOTH channels present: top-level error AND per-node errors are both reported", () => {
+  const nodeErrors = { 3: { errors: [{ message: "x" }] } };
+  const verdict = summarizePromptRejection({
+    rejection: { error: MISSING_NODE_TYPE, node_errors: nodeErrors },
+    lastNodeErrors: {},
+  });
+  assert.ok(verdict);
+  assert.equal(verdict.queued, false);
+  assert.equal(verdict.error_type, "missing_node_type");
+  assert.deepEqual(verdict.node_errors, nodeErrors);
+});
+
+test('a string top-level error ("prompt outputs failed validation") is surfaced', () => {
+  const verdict = summarizePromptRejection({
+    rejection: { error: "prompt outputs failed validation", node_errors: {} },
+    lastNodeErrors: {},
+  });
+  assert.ok(verdict);
+  assert.equal(verdict.queued, false);
+  assert.equal(verdict.error, "prompt outputs failed validation");
+  assert.equal(verdict.error_type, undefined); // no structured type for a bare string
+});
+
+test("formatTopError folds message + details and tolerates odd shapes", () => {
+  assert.equal(
+    formatTopError({ type: "t", message: "boom", details: "here" }),
+    "boom (here)",
+  );
+  assert.equal(formatTopError({ type: "only_type" }), "only_type");
+  assert.equal(formatTopError("plain"), "plain");
+  assert.equal(formatTopError(null), "prompt rejected");
+  assert.equal(formatTopError({}), "prompt rejected");
+});
+
+test("empty/whitespace top-level error is NOT treated as a rejection", () => {
+  assert.equal(
+    summarizePromptRejection({ rejection: { error: "   ", node_errors: {} }, lastNodeErrors: {} }),
+    null,
+  );
+});

--- a/browser_tests/unit/run-reconcile.test.mjs
+++ b/browser_tests/unit/run-reconcile.test.mjs
@@ -209,10 +209,11 @@ test("#370 no mis-attribution: reconcile only delivers the queried prompt's outp
   assert.equal(delivered.length, 1);
   assert.equal(delivered[0].promptId, "pA");
   assert.equal(delivered[0].images[0].filename, "A.png");
-  // pB stays pending (unknown), pA delivered — no cross-contamination.
+  // pB stays pending (running — absent /history, queue unknown), pA delivered — no
+  // cross-contamination.
   const byId = Object.fromEntries(summary.map((r) => [r.promptId, r.status]));
   assert.equal(byId.pA, "success");
-  assert.equal(byId.pB, "unknown");
+  assert.equal(byId.pB, "running");
   // pB is still pending → a later reconcile with its history delivers ONLY pB.
   history.pB = successEntry({ 2: { images: [{ filename: "B.png", type: "output" }] } });
   await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
@@ -468,7 +469,9 @@ test("#370 P1-3: entire-run-in-drop + a transient /history miss then terminal �
   // The whole lifecycle happened during the drop — only the queue-time id is known.
   tracker.onQueued("D");
 
-  // First reconcile (reconnect edge) hits a TRANSIENT /history miss (503/empty).
+  // First reconcile (reconnect edge) hits a TRANSIENT /history miss (503/empty) and
+  // the run has already left /queue (finished), so /history should become consistent
+  // shortly — the retry covers that window.
   let historyReady = false;
   const fetchHistory = async (id) => {
     if (id !== "D") return null;
@@ -476,7 +479,8 @@ test("#370 P1-3: entire-run-in-drop + a transient /history miss then terminal �
       ? successEntry({ 7: { images: [{ filename: "D_final.png", type: "output" }] } })
       : null; // transient: not yet populated
   };
-  const summary = await tracker.reconcile({ fetchHistory, isVideo });
+  const fetchQueued = async () => false; // not in /queue
+  const summary = await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
   assert.deepEqual(summary, [{ promptId: "D", status: "unknown" }], "transient miss reported");
   assert.equal(flushes.length, 0, "nothing delivered yet");
 
@@ -492,7 +496,7 @@ test("#370 P1-3: entire-run-in-drop + a transient /history miss then terminal �
   // No further retry fires, and no duplicate on a later reconcile (delivered fence).
   h.advance(3000);
   await h.fireDueTimers();
-  await tracker.reconcile({ fetchHistory, isVideo });
+  await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
   assert.equal(flushes.length, 1, "exactly once — no duplicate delivery");
 });
 
@@ -506,7 +510,8 @@ test("#370 P1-3 (codex): a transient /history miss that later resolves to an ERR
     if (state === "transient") return null; // 503/empty
     return { outputs: {}, status: { status_str: "error" } };
   };
-  const summary = await tracker.reconcile({ fetchHistory, isVideo });
+  const fetchQueued = async () => false; // not in /queue
+  const summary = await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
   assert.deepEqual(summary, [{ promptId: "F", status: "unknown" }]);
   assert.equal(errors.length, 0, "no error surfaced yet");
 
@@ -521,7 +526,7 @@ test("#370 P1-3 (codex): a transient /history miss that later resolves to an ERR
   // No further retry, no duplicate error.
   h.advance(2000);
   await h.fireDueTimers();
-  await tracker.reconcile({ fetchHistory, isVideo });
+  await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
   assert.equal(errors.length, 1, "exactly one run_error");
 });
 
@@ -539,8 +544,9 @@ test("#370 P1 (codex memory-leak): an exhausted-retry /history-ABSENT prompt is 
   const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 3 });
   const { tracker, flushes, giveUps } = h;
   tracker.onQueued("E");
-  const fetchHistory = async () => null; // /history stays absent (cancelled/gone)
-  await tracker.reconcile({ fetchHistory, isVideo });
+  const fetchHistory = async () => null; // absent from /history
+  const fetchQueued = async () => false; // AND absent from /queue ⇒ genuinely gone
+  await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
   assert.equal(tracker._pending.has("E"), true, "pending while retries are in flight");
   // Drain the retry budget.
   for (let i = 0; i < 6; i++) {
@@ -560,11 +566,12 @@ test("#370 P1 (codex memory-leak): an exhausted-retry /history-ABSENT prompt is 
 test("#370 P1 (codex): repeated cancelled queued prompts do NOT accumulate in the ledger", async () => {
   const h = makeHarness({ reconcileRetryMs: 500, maxReconcileRetries: 2 });
   const { tracker, giveUps } = h;
-  const fetchHistory = async () => null; // every one is cancelled/absent
+  const fetchHistory = async () => null; // absent from /history
+  const fetchQueued = async () => false; // AND absent from /queue ⇒ each is gone
   for (let n = 0; n < 5; n++) {
     const id = `c${n}`;
     tracker.onQueued(id);
-    await tracker.reconcile({ fetchHistory, isVideo });
+    await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
     for (let i = 0; i < 3; i++) {
       h.advance(500);
       await h.fireDueTimers();
@@ -582,8 +589,9 @@ test("#370 P1 (codex): give-up RETIRES a partial buffer so no stale output flush
   tracker.onExecuted("P", { images: [{ filename: "P_partial.png", type: "output" }] });
   assert.equal(tracker._buffers.has("P"), true, "P has a buffered partial");
 
-  const fetchHistory = async () => null; // absent
-  await tracker.reconcile({ fetchHistory, isVideo });
+  const fetchHistory = async () => null; // absent from /history
+  const fetchQueued = async () => false; // AND absent from /queue ⇒ gone
+  await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
   for (let i = 0; i < 4; i++) {
     h.advance(1000);
     await h.fireDueTimers();
@@ -605,24 +613,66 @@ test("#370 P2 (codex): maxReconcileRetries=0 gives up an absent-history prompt I
   const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 0 });
   const { tracker, giveUps } = h;
   tracker.onQueued("Z");
-  const fetchHistory = async () => null; // absent
-  await tracker.reconcile({ fetchHistory, isVideo });
+  const fetchHistory = async () => null; // absent from /history
+  const fetchQueued = async () => false; // AND absent from /queue ⇒ gone
+  await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
   assert.deepEqual(giveUps, [{ promptId: "Z" }], "gave up immediately (zero retries)");
   assert.equal(tracker._pending.has("Z"), false, "evicted — not stranded pending forever");
 });
 
-test("#370 P1-3: a RUNNING render whose retries exhaust is left pending (NOT given up)", async () => {
+test("#370 P1 (codex CRITICAL): absent /history BUT present in /queue (running) is NOT given up, and its later live output still delivers", async () => {
   const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 3 });
-  const { tracker, giveUps } = h;
-  tracker.onExecutionStart("R");
-  const fetchHistory = async () => ({ outputs: {}, status: {} }); // known, not terminal
-  await tracker.reconcile({ fetchHistory, isVideo });
+  const { tracker, flushes, giveUps } = h;
+  // A long render: queued during a drop, still RUNNING on reconnect — ComfyUI only
+  // writes /history on task_done, so /history/<id> is legitimately absent while the
+  // prompt sits in /queue. The reconciler MUST NOT give up / fence it.
+  tracker.onQueued("R");
+  const fetchHistory = async () => null; // absent — normal for a running prompt
+  const fetchQueued = async () => true; // BUT still in /queue (running)
+  await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
+  // Exhaust the retry budget while it stays running.
   for (let i = 0; i < 6; i++) {
     h.advance(1000);
     await h.fireDueTimers();
   }
-  assert.equal(giveUps.length, 0, "a confirmably-running render is NOT given up");
+  assert.equal(giveUps.length, 0, "a render still in /queue is NEVER given up");
   assert.equal(tracker._pending.has("R"), true, "left pending for the live path / next reconnect");
+  assert.equal(tracker.wasTerminal("R"), false, "NOT fenced — its live lifecycle must still be honored");
+
+  // The render finishes: its live executed + execution_success must STILL deliver
+  // (fails-before: the prompt was fenced/evicted and this output was dropped).
+  tracker.onExecutionStart("R");
+  tracker.onExecuted("R", { images: [{ filename: "R_final.png", type: "output" }] });
+  tracker.onExecutionSuccess("R");
+  const rFlush = flushes.find((f) => f.promptId === "R");
+  assert.ok(rFlush, "the long render's real output was delivered, not dropped");
+  assert.equal(rFlush.images[0].filename, "R_final.png");
+});
+
+test("#370 P1 (codex): a /history 503 (fetch throws) is UNCERTAIN → running, never given up even if /queue is absent", async () => {
+  const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 2 });
+  const { tracker, flushes, giveUps } = h;
+  // A finished render whose /history is transiently 503 AND already gone from /queue.
+  // The 503 must be treated as uncertain — NOT a clean absence — so it's never
+  // given up (its result may just be temporarily unreadable).
+  tracker.onQueued("H");
+  const fetchHistory = async () => {
+    throw new Error("503"); // /history unreachable
+  };
+  const fetchQueued = async () => false; // not in /queue
+  const summary = await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
+  assert.deepEqual(summary, [{ promptId: "H", status: "running" }], "503 ⇒ running (uncertain), not unknown");
+  for (let i = 0; i < 4; i++) {
+    h.advance(1000);
+    await h.fireDueTimers();
+  }
+  assert.equal(giveUps.length, 0, "a 503 /history is NEVER given up");
+  assert.equal(tracker._pending.has("H"), true, "left pending");
+  assert.equal(tracker.wasTerminal("H"), false, "not fenced");
+  // /history recovers as terminal on a later reconnect → delivered.
+  const okHistory = async (id) => ({ [id]: undefined }[id] ?? successEntry({ 1: { images: [{ filename: "H.png", type: "output" }] } }));
+  await tracker.reconcile({ fetchHistory: okHistory, fetchQueued, isVideo });
+  assert.equal(flushes.filter((f) => f.promptId === "H").length, 1, "delivered once /history recovered");
 });
 
 test("#370 still-running: reconcile leaves it pending and delivers nothing", async () => {

--- a/browser_tests/unit/run-reconcile.test.mjs
+++ b/browser_tests/unit/run-reconcile.test.mjs
@@ -405,6 +405,60 @@ test("#370 P1 (codex): a RE-PENDED terminal P's replayed execution_start still d
   assert.equal(pFlushes.length, 2, "P re-delivered exactly once via reconcile after re-pend");
 });
 
+test("#370 P1 (codex): a terminal fence is NOT aged out while its run is still pending (prolonged outage)", async () => {
+  const TTL = 10 * 60 * 1000;
+  const h = makeHarness();
+  const { tracker, flushes } = h;
+  // P completes and delivers, but the frame can't send → re-pend (bridge down).
+  tracker.onExecutionStart("P");
+  tracker.onExecuted("P", { images: [{ filename: "P.png", type: "output" }] });
+  tracker.onExecutionSuccess("P");
+  tracker.markUndelivered("P");
+  assert.equal(tracker._pending.has("P"), true, "P still pending recovery");
+  assert.equal(tracker.wasTerminal("P"), true);
+
+  // Bridge stays down LONGER than the fence TTL, and a prune runs (its self-arming
+  // sweep fires). P is still pending, so its replay fence must be RETAINED — not
+  // aged out from under the still-pending completion.
+  h.advance(TTL + 1);
+  await h.fireDueTimers(); // fires the fence-prune sweep
+  assert.equal(tracker.wasTerminal("P"), true, "terminal fence retained while P still pending");
+
+  // A different run Q begins and buffers; a replayed execution_start(P) — arriving
+  // before /history(P) resolves — must STILL be fenced (not flush Q).
+  tracker.onExecutionStart("Q");
+  tracker.onExecuted("Q", { images: [{ filename: "Q_preview.png", type: "output" }] });
+  tracker.onExecutionStart("P");
+  assert.equal(tracker._active.has("Q"), true, "Q still active after replayed P start");
+  tracker.onExecuted("Q", { images: [{ filename: "Q_final.png", type: "output" }] });
+  tracker.onExecutionSuccess("Q");
+  const qFlush = flushes.find((f) => f.promptId === "Q");
+  assert.deepEqual(
+    qFlush.images.map((m) => m.filename),
+    ["Q_preview.png", "Q_final.png"],
+    "Q's full batch preserved despite a post-TTL replayed P start",
+  );
+
+  // P still re-delivers exactly once on reconnect.
+  const history = { P: successEntry({ 1: { images: [{ filename: "P.png", type: "output" }] } }) };
+  await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
+  assert.equal(flushes.filter((f) => f.promptId === "P").length, 2, "P re-delivered once via reconcile");
+});
+
+test("#370 a terminal fence for a DELIVERED (not pending) run DOES age out (memory bounded)", async () => {
+  const TTL = 10 * 60 * 1000;
+  const h = makeHarness();
+  const { tracker } = h;
+  tracker.onExecutionStart("A");
+  tracker.onExecuted("A", { images: [{ filename: "A.png", type: "output" }] });
+  tracker.onExecutionSuccess("A"); // delivered AND confirmed (not re-pended) ⇒ not pending
+  assert.equal(tracker._pending.has("A"), false);
+  assert.equal(tracker.wasTerminal("A"), true);
+  h.advance(TTL + 1);
+  await h.fireDueTimers();
+  assert.equal(tracker.wasTerminal("A"), false, "a resolved (non-pending) fence ages out normally");
+});
+
 test("#370 P1-3: entire-run-in-drop + a transient /history miss then terminal → delivered once via retry", async () => {
   const h = makeHarness({ reconcileRetryMs: 3000, maxReconcileRetries: 5 });
   const { tracker, flushes } = h;

--- a/browser_tests/unit/run-reconcile.test.mjs
+++ b/browser_tests/unit/run-reconcile.test.mjs
@@ -722,6 +722,22 @@ test("historyEntryFor: MALFORMED body (null/array/non-object) ⇒ undefined (unc
   assert.strictEqual(historyEntryFor(undefined, "R"), undefined);
 });
 
+test("queueMembership/historyEntryFor: a NUMERIC lookup id coerces to string (defensive)", () => {
+  // Belt-and-suspenders: even if a number reaches the pure helper, it compares as
+  // its string form (ingestion normalizes upstream, so normally it's already "7").
+  assert.equal(queueMembership({ queue_running: [[0, "7", {}]], queue_pending: [] }, 7), true);
+  assert.equal(queueMembership({ queue_running: [[0, "8", {}]], queue_pending: [] }, 7), false);
+  const entry = { status: { status_str: "success" } };
+  assert.strictEqual(historyEntryFor({ 7: entry }, 7), entry);
+  assert.strictEqual(historyEntryFor({ 8: entry }, 7), null);
+  // Non-coercible lookup ids: queueMembership ⇒ null (uncertain), historyEntryFor ⇒
+  // undefined (uncertain), NEVER a definitive absent/give-up signal.
+  assert.equal(queueMembership({ queue_running: [], queue_pending: [] }, null), null);
+  assert.equal(queueMembership({ queue_running: [], queue_pending: [] }, {}), null);
+  assert.strictEqual(historyEntryFor({}, null), undefined);
+  assert.strictEqual(historyEntryFor({}, {}), undefined);
+});
+
 test("historyEntryFor: id PRESENT with a null/undefined value ⇒ undefined (malformed present, NOT clean absence)", () => {
   assert.strictEqual(historyEntryFor({ R: null }, "R"), undefined); // present key, null value
   assert.strictEqual(historyEntryFor({ R: undefined }, "R"), undefined); // present key, undefined value
@@ -809,6 +825,36 @@ test("#370 P1 (codex): a /queue with ONLY TRUNCATED rows is uncertain → NOT gi
   tracker.onExecuted("R", { images: [{ filename: "R.png", type: "output" }] });
   tracker.onExecutionSuccess("R");
   assert.ok(flushes.find((f) => f.promptId === "R"), "output delivered, not dropped");
+});
+
+test("#370 P1 (codex): a NUMERIC prompt_id is normalized to a string at ingestion — matches a string /queue row, not dropped", async () => {
+  const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 0 });
+  const { tracker, flushes, giveUps } = h;
+  tracker.onQueued(7); // a NUMBER enters the ledger
+  assert.equal(tracker._pending.has("7"), true, "numeric id normalized to the string key '7'");
+  assert.equal(tracker._pending.has(7), false, "not stored under the raw number");
+
+  const fetchHistory = async () => null; // clean-absent /history
+  const fetchQueued = async (id) => {
+    // reconcile passes the NORMALIZED string id, so the string queue row matches.
+    assert.equal(id, "7", "reconcile passes the normalized string id");
+    return queueMembership({ queue_running: [[0, "7", { /* prompt */ }, {}, []]], queue_pending: [] }, id);
+  };
+  const summary = await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
+  // Was present in /queue as "7" ⇒ running, NOT given up (fails-before: number 7 !==
+  // string "7" ⇒ reported absent ⇒ evicted + dropped).
+  assert.deepEqual(summary, [{ promptId: "7", status: "running" }]);
+  assert.equal(giveUps.length, 0, "the present render is never given up");
+  assert.equal(tracker.wasTerminal("7"), false, "not fenced");
+
+  // Fence + delivery also key on the normalized string id — a numeric lifecycle id
+  // still resolves to "7".
+  tracker.onExecutionStart(7);
+  tracker.onExecuted(7, { images: [{ filename: "7.png", type: "output" }] });
+  tracker.onExecutionSuccess(7);
+  const f = flushes.find((x) => x.promptId === "7");
+  assert.ok(f, "delivered under the normalized string id");
+  assert.equal(f.promptId, "7", "completion carries the string id, not the number");
 });
 
 test("#370 P1 (codex): a /queue row whose idx2 is an ARRAY is malformed → NOT given up (typeof [] gotcha)", async () => {

--- a/browser_tests/unit/run-reconcile.test.mjs
+++ b/browser_tests/unit/run-reconcile.test.mjs
@@ -15,7 +15,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { createRunCompletionTracker } from "../../web/js/lib/run-completion.js";
-import { parseHistoryEntry } from "../../web/js/lib/history-reconcile.js";
+import { parseHistoryEntry, queueMembership } from "../../web/js/lib/history-reconcile.js";
 
 const isVideo = (m) => /\.(mp4|webm|mov)$/i.test(String(m?.filename || ""));
 
@@ -695,6 +695,88 @@ test("#370 P1 (codex): give-up requires CLEAN-ABSENT /history (null), not a pres
   assert.deepEqual(giveUps, [{ promptId: "gone" }], "only null-history + absent-queue gives up");
   assert.equal(tracker._pending.has("present"), true, "present-non-terminal stays pending (never given up)");
   assert.equal(tracker._pending.has("gone"), false, "genuinely-gone prompt evicted (bounded memory)");
+});
+
+// ── queueMembership: strict-array /queue verdict ────────────────────────────────
+
+test("queueMembership: present in queue_running or queue_pending ⇒ true", () => {
+  assert.equal(queueMembership({ queue_running: [[0, "p1"]], queue_pending: [] }, "p1"), true);
+  assert.equal(queueMembership({ queue_running: [], queue_pending: [[1, "p2"]] }, "p2"), true);
+  // {prompt_id} object form is also matched.
+  assert.equal(queueMembership({ queue_running: [{ prompt_id: "p3" }], queue_pending: [] }, "p3"), true);
+});
+
+test("queueMembership: both arrays well-formed AND id absent ⇒ false (definitive)", () => {
+  assert.equal(queueMembership({ queue_running: [[0, "other"]], queue_pending: [] }, "p1"), false);
+  assert.equal(queueMembership({ queue_running: [], queue_pending: [] }, "p1"), false);
+});
+
+test("queueMembership: MALFORMED / missing fields ⇒ null (uncertain, NOT false)", () => {
+  // The exact repro: queue arrays are objects, not arrays.
+  assert.equal(queueMembership({ queue_running: {}, queue_pending: {} }, "p1"), null);
+  assert.equal(queueMembership({ queue_running: [], queue_pending: {} }, "p1"), null); // one bad
+  assert.equal(queueMembership({ queue_running: {}, queue_pending: [] }, "p1"), null);
+  assert.equal(queueMembership({}, "p1"), null); // both missing
+  assert.equal(queueMembership({ queue_running: null, queue_pending: null }, "p1"), null);
+  assert.equal(queueMembership(null, "p1"), null);
+  assert.equal(queueMembership("nonsense", "p1"), null);
+});
+
+test("queueMembership: MALFORMED ROWS (arrays are valid but a row is unreadable) ⇒ null", () => {
+  // Row missing the prompt_id slot / wrong types — can't trust an "absent" verdict.
+  assert.equal(queueMembership({ queue_running: [[0]], queue_pending: [] }, "p1"), null);
+  assert.equal(queueMembership({ queue_running: [null], queue_pending: [] }, "p1"), null);
+  assert.equal(queueMembership({ queue_running: [{}], queue_pending: [] }, "p1"), null);
+  assert.equal(queueMembership({ queue_running: [[0, 123]], queue_pending: [] }, "p1"), null); // id not a string
+  assert.equal(queueMembership({ queue_running: [], queue_pending: ["bare-string"] }, "p1"), null);
+  // Row's index-0 must be a number (the queue-row shape is [number, prompt_id, …]).
+  assert.equal(queueMembership({ queue_running: [["not-a-number", "other"]], queue_pending: [] }, "p1"), null);
+  // A well-formed [number, prompt_id] that simply doesn't match is a clean absence.
+  assert.equal(queueMembership({ queue_running: [[0, "other"]], queue_pending: [] }, "p1"), false);
+  // A POSITIVE match is trustworthy even if OTHER rows are malformed.
+  assert.equal(queueMembership({ queue_running: [[0, "p1"], [1]], queue_pending: [] }, "p1"), true);
+  // Only when EVERY row is well-formed AND the id is absent ⇒ definitive false.
+  assert.equal(queueMembership({ queue_running: [[0, "a"]], queue_pending: [{ prompt_id: "b" }] }, "p1"), false);
+});
+
+test("#370 P1 (codex): a MALFORMED /queue (non-array fields) is uncertain → NOT given up, later output delivers", async () => {
+  const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 1 });
+  const { tracker, flushes, giveUps } = h;
+  tracker.onQueued("m");
+  const fetchHistory = async () => null; // clean-absent /history
+  // /queue returns a 200 but with malformed (non-array) queue fields — the panel's
+  // queueMembership maps this to null (uncertain), so the tracker must NOT give up.
+  const fetchQueued = async (id) => queueMembership({ queue_running: {}, queue_pending: {} }, id);
+  const summary = await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
+  assert.deepEqual(summary, [{ promptId: "m", status: "running" }], "malformed queue ⇒ running, not unknown");
+  for (let i = 0; i < 3; i++) {
+    h.advance(1000);
+    await h.fireDueTimers();
+  }
+  assert.equal(giveUps.length, 0, "a malformed /queue never causes a give-up");
+  assert.equal(tracker._pending.has("m"), true, "left pending (uncertain)");
+  assert.equal(tracker.wasTerminal("m"), false, "not fenced");
+
+  // Its later live output still delivers.
+  tracker.onExecutionStart("m");
+  tracker.onExecuted("m", { images: [{ filename: "m.png", type: "output" }] });
+  tracker.onExecutionSuccess("m");
+  assert.ok(flushes.find((f) => f.promptId === "m"), "output delivered, not dropped");
+});
+
+test("#370 P1 (codex): give-up STILL fires when /history null AND /queue well-formed both-absent", async () => {
+  const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 1 });
+  const { tracker, giveUps } = h;
+  tracker.onQueued("gone");
+  const fetchHistory = async () => null;
+  const fetchQueued = async (id) => queueMembership({ queue_running: [], queue_pending: [] }, id); // valid + absent ⇒ false
+  await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
+  for (let i = 0; i < 3; i++) {
+    h.advance(1000);
+    await h.fireDueTimers();
+  }
+  assert.deepEqual(giveUps, [{ promptId: "gone" }], "well-formed both-absent still gives up (memory bound intact)");
+  assert.equal(tracker._pending.has("gone"), false, "evicted");
 });
 
 test("#370 P1 (codex): CONCURRENT reconciles give up a gone prompt exactly once (no double notice)", async () => {

--- a/browser_tests/unit/run-reconcile.test.mjs
+++ b/browser_tests/unit/run-reconcile.test.mjs
@@ -827,6 +827,49 @@ test("#370 P1 (codex): a /queue with ONLY TRUNCATED rows is uncertain → NOT gi
   assert.ok(flushes.find((f) => f.promptId === "R"), "output delivered, not dropped");
 });
 
+test("#370 P1 (codex): a FALSY prompt_id 0 is tracked as '0' — onQueued fires, drop→reconcile checks /queue+/history, delivers", async () => {
+  const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 0 });
+  const { tracker, flushes, giveUps } = h;
+  // The whole point of the falsy-0 sweep: onQueued(0) MUST register (a truthiness
+  // guard would skip it, leaving no "0" pending key so a drop loses the completion).
+  tracker.onQueued(0);
+  assert.equal(tracker._pending.has("0"), true, "0 tracked under the normalized string key '0'");
+
+  let queueChecked = false;
+  let historyChecked = false;
+  const fetchHistory = async (id) => {
+    historyChecked = true;
+    assert.equal(id, "0", "reconcile queries /history for the string '0'");
+    return null; // clean-absent (queued/running, not yet in history)
+  };
+  const fetchQueued = async (id) => {
+    queueChecked = true;
+    assert.equal(id, "0", "reconcile queries /queue for the string '0'");
+    return queueMembership({ queue_running: [[0, "0", {}, {}, []]], queue_pending: [] }, id); // present ⇒ true
+  };
+  const summary = await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
+  assert.ok(historyChecked && queueChecked, "a drop→reconcile checks BOTH /history and /queue for 0");
+  assert.deepEqual(summary, [{ promptId: "0", status: "running" }], "0 is present in /queue ⇒ running");
+  assert.equal(giveUps.length, 0, "0 is never given up (it's a real, present render)");
+
+  // And its later live output delivers under the normalized string id.
+  tracker.onExecutionStart(0);
+  tracker.onExecuted(0, { images: [{ filename: "0.png", type: "output" }] });
+  tracker.onExecutionSuccess(0);
+  const f = flushes.find((x) => x.promptId === "0");
+  assert.ok(f, "completion for id 0 delivered under '0'");
+  assert.equal(f.promptId, "0");
+});
+
+test("#370 the id-less (null/undefined) path is STILL excluded from the recovery ledger", () => {
+  const { tracker } = makeHarness();
+  tracker.onQueued(null);
+  tracker.onQueued(undefined);
+  assert.equal(tracker._pending.size, 0, "null/undefined ids are never tracked (NO_PROMPT_KEY, excluded)");
+  assert.equal(tracker._pending.has("null"), false);
+  assert.equal(tracker._pending.has("undefined"), false);
+});
+
 test("#370 P1 (codex): a NUMERIC prompt_id is normalized to a string at ingestion — matches a string /queue row, not dropped", async () => {
   const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 0 });
   const { tracker, flushes, giveUps } = h;

--- a/browser_tests/unit/run-reconcile.test.mjs
+++ b/browser_tests/unit/run-reconcile.test.mjs
@@ -236,7 +236,7 @@ test("#370 codex P1 (idempotency): a LATE executed+execution_success after recon
   const history = { pL: successEntry({ 9: { images: [{ filename: "final.png", type: "output" }] } }) };
   await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
   assert.equal(flushes.length, 1, "reconcile delivered once");
-  assert.equal(tracker.wasDelivered("pL"), true);
+  assert.equal(tracker.wasTerminal("pL"), true);
 
   // The live WS now replays the buffered lifecycle for the SAME prompt. None of it
   // may produce a second completion.
@@ -246,13 +246,13 @@ test("#370 codex P1 (idempotency): a LATE executed+execution_success after recon
   assert.equal(flushes.length, 1, "no duplicate completion from the late live events");
 });
 
-test("#370 codex P1 (idempotency): wasDelivered fences a late execution_error after a reconciled error", async () => {
+test("#370 codex P1 (idempotency): wasTerminal fences a late execution_error after a reconciled error", async () => {
   const { tracker, flushes } = makeHarness();
   tracker.onExecutionStart("pX");
   const history = { pX: { outputs: {}, status: { status_str: "error" } } };
   await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
-  assert.equal(tracker.wasDelivered("pX"), true, "reconciled error is marked delivered");
-  // Panel checks wasDelivered() BEFORE onExecutionFailed to skip the duplicate
+  assert.equal(tracker.wasTerminal("pX"), true, "reconciled error is marked delivered");
+  // Panel checks wasTerminal() BEFORE onExecutionFailed to skip the duplicate
   // run_error; the tracker-side late failed event re-buffers nothing.
   tracker.onExecuted("pX", { images: [{ filename: "late.png", type: "output" }] });
   tracker.onExecutionFailed("pX");
@@ -320,15 +320,15 @@ test("#370 delivered-fence ages out: an old fence is pruned once past the 10-min
   tracker.onExecutionStart("p1");
   tracker.onExecuted("p1", { images: [{ filename: "a.png", type: "output" }] });
   tracker.onExecutionSuccess("p1");
-  assert.equal(tracker.wasDelivered("p1"), true, "fenced right after delivery");
+  assert.equal(tracker.wasTerminal("p1"), true, "fenced right after delivery");
 
   // Well past the fence TTL, a new delivery prunes the stale fence (bounded memory).
   advance(10 * 60 * 1000 + 1);
   tracker.onExecutionStart("p2");
   tracker.onExecuted("p2", { images: [{ filename: "b.png", type: "output" }] });
   tracker.onExecutionSuccess("p2");
-  assert.equal(tracker.wasDelivered("p1"), false, "stale fence aged out");
-  assert.equal(tracker.wasDelivered("p2"), true, "recent fence retained");
+  assert.equal(tracker.wasTerminal("p1"), false, "stale fence aged out");
+  assert.equal(tracker.wasTerminal("p2"), true, "recent fence retained");
 });
 
 test("#370 P1-2: a late execution_start(delivered P) does NOT flush a DIFFERENT active run's buffer", async () => {
@@ -338,7 +338,7 @@ test("#370 P1-2: a late execution_start(delivered P) does NOT flush a DIFFERENT 
   const history = { P: successEntry({ 1: { images: [{ filename: "P.png", type: "output" }] } }) };
   await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
   assert.equal(flushes.length, 1, "P delivered via reconcile");
-  assert.equal(tracker.wasDelivered("P"), true);
+  assert.equal(tracker.wasTerminal("P"), true);
 
   // A NEW run Q starts and buffers a preview (still in flight).
   tracker.onExecutionStart("Q");
@@ -360,6 +360,49 @@ test("#370 P1-2: a late execution_start(delivered P) does NOT flush a DIFFERENT 
     ["Q_preview.png", "Q_final.png"],
     "Q's full batch preserved (preview + final)",
   );
+});
+
+test("#370 P1 (codex): a RE-PENDED terminal P's replayed execution_start still does NOT flush active Q", async () => {
+  const { tracker, flushes } = makeHarness();
+  // P completes live and delivers…
+  tracker.onExecutionStart("P");
+  tracker.onExecuted("P", { images: [{ filename: "P.png", type: "output" }] });
+  tracker.onExecutionSuccess("P");
+  assert.equal(flushes.length, 1, "P delivered");
+  assert.equal(tracker.wasTerminal("P"), true);
+
+  // …but its completion frame failed to send (bridge down) → re-pend for retry.
+  // This must NOT clear P's terminal REPLAY fence.
+  tracker.markUndelivered("P");
+  assert.equal(tracker.wasTerminal("P"), true, "terminal replay fence survives re-pend");
+  assert.equal(tracker._pending.has("P"), true, "P re-pended for delivery retry");
+
+  // A DIFFERENT run Q starts and buffers a preview.
+  tracker.onExecutionStart("Q");
+  tracker.onExecuted("Q", { images: [{ filename: "Q_preview.png", type: "output" }] });
+
+  // A late/replayed execution_start(P) arrives. Because P is still TERMINAL-fenced
+  // (despite the re-pend), it must be ignored — not flush Q's partial buffer.
+  tracker.onExecutionStart("P");
+  assert.equal(flushes.length, 1, "re-pended P's stale start did not flush Q");
+  assert.equal(tracker._active.has("Q"), true, "Q still active");
+
+  // Q finishes and delivers its FULL batch — nothing lost.
+  tracker.onExecuted("Q", { images: [{ filename: "Q_final.png", type: "output" }] });
+  tracker.onExecutionSuccess("Q");
+  const qFlush = flushes.find((f) => f.promptId === "Q");
+  assert.ok(qFlush, "Q delivered");
+  assert.deepEqual(
+    qFlush.images.map((m) => m.filename),
+    ["Q_preview.png", "Q_final.png"],
+    "Q's full batch preserved despite P's re-pended replayed start",
+  );
+
+  // And P's re-pended delivery is still recoverable via reconcile (retry path).
+  const history = { P: successEntry({ 1: { images: [{ filename: "P.png", type: "output" }] } }) };
+  await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
+  const pFlushes = flushes.filter((f) => f.promptId === "P");
+  assert.equal(pFlushes.length, 2, "P re-delivered exactly once via reconcile after re-pend");
 });
 
 test("#370 P1-3: entire-run-in-drop + a transient /history miss then terminal → delivered once via retry", async () => {
@@ -416,7 +459,7 @@ test("#370 P1-3 (codex): a transient /history miss that later resolves to an ERR
   await h.fireDueTimers();
   assert.equal(flushes.length, 0, "no completion batch for a failed run");
   assert.deepEqual(errors, [{ promptId: "F" }], "run_error surfaced exactly once via the retry");
-  assert.equal(tracker.wasDelivered("F"), true, "fenced so no duplicate");
+  assert.equal(tracker.wasTerminal("F"), true, "fenced so no duplicate");
 
   // No further retry, no duplicate error.
   h.advance(2000);

--- a/browser_tests/unit/run-reconcile.test.mjs
+++ b/browser_tests/unit/run-reconcile.test.mjs
@@ -731,15 +731,18 @@ test("historyEntryFor: id PRESENT with a null/undefined value ⇒ undefined (mal
 
 // ── queueMembership: strict-array /queue verdict ────────────────────────────────
 
+// Full ComfyUI queue rows carry the prompt dict at index 2: [num, prompt_id, prompt, …].
+const qrow = (n, id) => [n, id, { /* prompt dict */ }, {}, []];
+
 test("queueMembership: present in queue_running or queue_pending ⇒ true", () => {
-  assert.equal(queueMembership({ queue_running: [[0, "p1"]], queue_pending: [] }, "p1"), true);
-  assert.equal(queueMembership({ queue_running: [], queue_pending: [[1, "p2"]] }, "p2"), true);
+  assert.equal(queueMembership({ queue_running: [qrow(0, "p1")], queue_pending: [] }, "p1"), true);
+  assert.equal(queueMembership({ queue_running: [], queue_pending: [qrow(1, "p2")] }, "p2"), true);
   // {prompt_id} object form is also matched.
   assert.equal(queueMembership({ queue_running: [{ prompt_id: "p3" }], queue_pending: [] }, "p3"), true);
 });
 
 test("queueMembership: both arrays well-formed AND id absent ⇒ false (definitive)", () => {
-  assert.equal(queueMembership({ queue_running: [[0, "other"]], queue_pending: [] }, "p1"), false);
+  assert.equal(queueMembership({ queue_running: [qrow(0, "other")], queue_pending: [] }, "p1"), false);
   assert.equal(queueMembership({ queue_running: [], queue_pending: [] }, "p1"), false);
 });
 
@@ -763,12 +766,77 @@ test("queueMembership: MALFORMED ROWS (arrays are valid but a row is unreadable)
   assert.equal(queueMembership({ queue_running: [], queue_pending: ["bare-string"] }, "p1"), null);
   // Row's index-0 must be a number (the queue-row shape is [number, prompt_id, …]).
   assert.equal(queueMembership({ queue_running: [["not-a-number", "other"]], queue_pending: [] }, "p1"), null);
-  // A well-formed [number, prompt_id] that simply doesn't match is a clean absence.
-  assert.equal(queueMembership({ queue_running: [[0, "other"]], queue_pending: [] }, "p1"), false);
-  // A POSITIVE match is trustworthy even if OTHER rows are malformed.
-  assert.equal(queueMembership({ queue_running: [[0, "p1"], [1]], queue_pending: [] }, "p1"), true);
+  // A TRUNCATED [number, prompt_id] row (missing the prompt dict at index 2) is
+  // MALFORMED — it must NOT be read as a valid id-absent entry (codex P1).
+  assert.equal(queueMembership({ queue_running: [[0, "other"]], queue_pending: [] }, "p1"), null);
+  // Index 2 must be a PRESENT object (the prompt dict); null/non-object ⇒ malformed.
+  assert.equal(queueMembership({ queue_running: [[0, "other", null]], queue_pending: [] }, "p1"), null);
+  assert.equal(queueMembership({ queue_running: [[0, "other", 7]], queue_pending: [] }, "p1"), null);
+  // A FULL valid row that simply doesn't match is a clean absence ⇒ false.
+  assert.equal(queueMembership({ queue_running: [qrow(0, "other")], queue_pending: [] }, "p1"), false);
+  // A POSITIVE match is trustworthy even if OTHER rows are malformed (truncated).
+  assert.equal(queueMembership({ queue_running: [qrow(0, "p1"), [1]], queue_pending: [] }, "p1"), true);
   // Only when EVERY row is well-formed AND the id is absent ⇒ definitive false.
-  assert.equal(queueMembership({ queue_running: [[0, "a"]], queue_pending: [{ prompt_id: "b" }] }, "p1"), false);
+  assert.equal(queueMembership({ queue_running: [qrow(0, "a")], queue_pending: [{ prompt_id: "b" }] }, "p1"), false);
+});
+
+test("#370 P1 (codex): a /queue with ONLY TRUNCATED rows is uncertain → NOT given up, later output delivers", async () => {
+  const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 1 });
+  const { tracker, flushes, giveUps } = h;
+  tracker.onQueued("R");
+  const fetchHistory = async () => null; // clean-absent /history
+  // /queue returns 200 with a TRUNCATED row (missing the prompt dict) — malformed,
+  // so queueMembership ⇒ null (uncertain); the tracker must NOT give up.
+  const fetchQueued = async (id) => queueMembership({ queue_running: [[0, "other"]], queue_pending: [] }, id);
+  const summary = await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
+  assert.deepEqual(summary, [{ promptId: "R", status: "running" }], "truncated-row queue ⇒ running, not unknown");
+  for (let i = 0; i < 3; i++) {
+    h.advance(1000);
+    await h.fireDueTimers();
+  }
+  assert.equal(giveUps.length, 0, "a truncated-row /queue never causes a give-up");
+  assert.equal(tracker._pending.has("R"), true, "left pending (uncertain)");
+  assert.equal(tracker.wasTerminal("R"), false, "not fenced");
+
+  // Its later live output still delivers.
+  tracker.onExecutionStart("R");
+  tracker.onExecuted("R", { images: [{ filename: "R.png", type: "output" }] });
+  tracker.onExecutionSuccess("R");
+  assert.ok(flushes.find((f) => f.promptId === "R"), "output delivered, not dropped");
+});
+
+test("#370 P1 (codex): give-up fires on FULL valid /history-map-absent + FULL valid /queue-row-absent; a matching full row ⇒ running", async () => {
+  const full = (n, id) => [n, id, {}, {}, []];
+  // (a) gone: /history well-formed map lacking id, /queue full valid row lacking id ⇒ give up once.
+  {
+    const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 1 });
+    const { tracker, giveUps } = h;
+    tracker.onQueued("gone");
+    const fetchHistory = async (id) => historyEntryFor({}, id); // ⇒ null
+    const fetchQueued = async (id) => queueMembership({ queue_running: [full(0, "x")], queue_pending: [] }, id); // full valid, absent ⇒ false
+    await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
+    for (let i = 0; i < 3; i++) {
+      h.advance(1000);
+      await h.fireDueTimers();
+    }
+    assert.deepEqual(giveUps, [{ promptId: "gone" }], "full-valid-absent both sides ⇒ give up once");
+    assert.equal(tracker._pending.has("gone"), false, "evicted");
+  }
+  // (b) present: a full valid /queue row MATCHING the id ⇒ running (positive wins amid a malformed sibling), never given up.
+  {
+    const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 1 });
+    const { tracker, giveUps } = h;
+    tracker.onQueued("R");
+    const fetchHistory = async () => null; // clean-absent
+    const fetchQueued = async (id) => queueMembership({ queue_running: [full(0, "R"), [9]], queue_pending: [] }, id); // match + malformed sibling ⇒ true
+    await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
+    for (let i = 0; i < 3; i++) {
+      h.advance(1000);
+      await h.fireDueTimers();
+    }
+    assert.equal(giveUps.length, 0, "a matched (running) prompt is never given up");
+    assert.equal(tracker._pending.has("R"), true, "left pending");
+  }
 });
 
 test("#370 P1 (codex): a MALFORMED /queue (non-array fields) is uncertain → NOT given up, later output delivers", async () => {

--- a/browser_tests/unit/run-reconcile.test.mjs
+++ b/browser_tests/unit/run-reconcile.test.mjs
@@ -19,13 +19,15 @@ import { parseHistoryEntry } from "../../web/js/lib/history-reconcile.js";
 
 const isVideo = (m) => /\.(mp4|webm|mov)$/i.test(String(m?.filename || ""));
 
-function makeHarness() {
+function makeHarness(opts = {}) {
   let clock = 0;
   const timers = new Map();
   let seq = 0;
   const flushes = [];
+  const errors = [];
   const tracker = createRunCompletionTracker({
     onFlush: (p) => flushes.push(p),
+    onReconcileError: (e) => errors.push(e),
     now: () => clock,
     setTimer: (fn, ms) => {
       const id = ++seq;
@@ -34,12 +36,25 @@ function makeHarness() {
     },
     clearTimer: (id) => timers.delete(id),
     debounceMs: 1500,
+    ...opts,
   });
   return {
     tracker,
     flushes,
+    errors,
     advance: (ms) => {
       clock += ms;
+    },
+    // Fire (and await) every timer whose deadline is due at the current clock.
+    // A fired timer may schedule another; the caller advances + fires again.
+    fireDueTimers: async () => {
+      const due = [...timers].filter(([, t]) => t.at <= clock);
+      const proms = [];
+      for (const [id, t] of due) {
+        timers.delete(id);
+        proms.push(t.fn());
+      }
+      await Promise.all(proms);
     },
   };
 }
@@ -314,6 +329,125 @@ test("#370 delivered-fence ages out: an old fence is pruned once past the 10-min
   tracker.onExecutionSuccess("p2");
   assert.equal(tracker.wasDelivered("p1"), false, "stale fence aged out");
   assert.equal(tracker.wasDelivered("p2"), true, "recent fence retained");
+});
+
+test("#370 P1-2: a late execution_start(delivered P) does NOT flush a DIFFERENT active run's buffer", async () => {
+  const { tracker, flushes } = makeHarness();
+  // P finished during a drop and was recovered via reconcile (delivered).
+  tracker.onQueued("P");
+  const history = { P: successEntry({ 1: { images: [{ filename: "P.png", type: "output" }] } }) };
+  await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
+  assert.equal(flushes.length, 1, "P delivered via reconcile");
+  assert.equal(tracker.wasDelivered("P"), true);
+
+  // A NEW run Q starts and buffers a preview (still in flight).
+  tracker.onExecutionStart("Q");
+  tracker.onExecuted("Q", { images: [{ filename: "Q_preview.png", type: "output" }] });
+
+  // A DELAYED execution_start(P) — for the already-delivered prompt — arrives. It
+  // must be IGNORED: it must not flush Q's partial buffer or clear Q's active.
+  tracker.onExecutionStart("P");
+  assert.equal(flushes.length, 1, "stale execution_start(P) did not flush Q's partial batch");
+  assert.equal(tracker._active.has("Q"), true, "Q is still active");
+
+  // Q now finishes normally and delivers its FULL output — nothing was lost.
+  tracker.onExecuted("Q", { images: [{ filename: "Q_final.png", type: "output" }] });
+  tracker.onExecutionSuccess("Q");
+  const qFlush = flushes.find((f) => f.promptId === "Q");
+  assert.ok(qFlush, "Q delivered");
+  assert.deepEqual(
+    qFlush.images.map((m) => m.filename),
+    ["Q_preview.png", "Q_final.png"],
+    "Q's full batch preserved (preview + final)",
+  );
+});
+
+test("#370 P1-3: entire-run-in-drop + a transient /history miss then terminal → delivered once via retry", async () => {
+  const h = makeHarness({ reconcileRetryMs: 3000, maxReconcileRetries: 5 });
+  const { tracker, flushes } = h;
+  // The whole lifecycle happened during the drop — only the queue-time id is known.
+  tracker.onQueued("D");
+
+  // First reconcile (reconnect edge) hits a TRANSIENT /history miss (503/empty).
+  let historyReady = false;
+  const fetchHistory = async (id) => {
+    if (id !== "D") return null;
+    return historyReady
+      ? successEntry({ 7: { images: [{ filename: "D_final.png", type: "output" }] } })
+      : null; // transient: not yet populated
+  };
+  const summary = await tracker.reconcile({ fetchHistory, isVideo });
+  assert.deepEqual(summary, [{ promptId: "D", status: "unknown" }], "transient miss reported");
+  assert.equal(flushes.length, 0, "nothing delivered yet");
+
+  // /history becomes terminal WITHOUT another reconnect edge — the scheduled retry
+  // must pick it up and deliver.
+  historyReady = true;
+  h.advance(3000);
+  await h.fireDueTimers();
+  assert.equal(flushes.length, 1, "retry delivered the completion once /history turned terminal");
+  assert.equal(flushes[0].promptId, "D");
+  assert.equal(flushes[0].images[0].filename, "D_final.png");
+
+  // No further retry fires, and no duplicate on a later reconcile (delivered fence).
+  h.advance(3000);
+  await h.fireDueTimers();
+  await tracker.reconcile({ fetchHistory, isVideo });
+  assert.equal(flushes.length, 1, "exactly once — no duplicate delivery");
+});
+
+test("#370 P1-3 (codex): a transient /history miss that later resolves to an ERROR is surfaced via retry", async () => {
+  const h = makeHarness({ reconcileRetryMs: 2000, maxReconcileRetries: 5 });
+  const { tracker, flushes, errors } = h;
+  tracker.onQueued("F");
+  let state = "transient"; // transient → error
+  const fetchHistory = async (id) => {
+    if (id !== "F") return null;
+    if (state === "transient") return null; // 503/empty
+    return { outputs: {}, status: { status_str: "error" } };
+  };
+  const summary = await tracker.reconcile({ fetchHistory, isVideo });
+  assert.deepEqual(summary, [{ promptId: "F", status: "unknown" }]);
+  assert.equal(errors.length, 0, "no error surfaced yet");
+
+  // History turns terminal-ERROR — the scheduled retry must surface run_error.
+  state = "error";
+  h.advance(2000);
+  await h.fireDueTimers();
+  assert.equal(flushes.length, 0, "no completion batch for a failed run");
+  assert.deepEqual(errors, [{ promptId: "F" }], "run_error surfaced exactly once via the retry");
+  assert.equal(tracker.wasDelivered("F"), true, "fenced so no duplicate");
+
+  // No further retry, no duplicate error.
+  h.advance(2000);
+  await h.fireDueTimers();
+  await tracker.reconcile({ fetchHistory, isVideo });
+  assert.equal(errors.length, 1, "exactly one run_error");
+});
+
+test("#370 reconcile-loop error also routes through onReconcileError (single delivery path)", async () => {
+  const { tracker, flushes, errors } = makeHarness();
+  tracker.onExecutionStart("G");
+  const history = { G: { outputs: {}, status: { status_str: "error" } } };
+  const summary = await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
+  assert.deepEqual(summary, [{ promptId: "G", status: "error" }]);
+  assert.equal(flushes.length, 0);
+  assert.deepEqual(errors, [{ promptId: "G" }], "error delivered via the hook, once");
+});
+
+test("#370 P1-3: reconcile retry gives up after the attempt budget (no infinite polling)", async () => {
+  const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 3 });
+  const { tracker, flushes } = h;
+  tracker.onQueued("E");
+  const fetchHistory = async () => null; // permanently transient
+  await tracker.reconcile({ fetchHistory, isVideo });
+  // Drain more than the budget of retries.
+  for (let i = 0; i < 6; i++) {
+    h.advance(1000);
+    await h.fireDueTimers();
+  }
+  assert.equal(flushes.length, 0, "nothing delivered — history never terminal");
+  assert.equal(tracker._pending.has("E"), true, "still pending — a future reconnect edge can retry");
 });
 
 test("#370 still-running: reconcile leaves it pending and delivers nothing", async () => {

--- a/browser_tests/unit/run-reconcile.test.mjs
+++ b/browser_tests/unit/run-reconcile.test.mjs
@@ -25,9 +25,11 @@ function makeHarness(opts = {}) {
   let seq = 0;
   const flushes = [];
   const errors = [];
+  const giveUps = [];
   const tracker = createRunCompletionTracker({
     onFlush: (p) => flushes.push(p),
     onReconcileError: (e) => errors.push(e),
+    onReconcileGiveUp: (e) => giveUps.push(e),
     now: () => clock,
     setTimer: (fn, ms) => {
       const id = ++seq;
@@ -42,6 +44,7 @@ function makeHarness(opts = {}) {
     tracker,
     flushes,
     errors,
+    giveUps,
     advance: (ms) => {
       clock += ms;
     },
@@ -532,19 +535,57 @@ test("#370 reconcile-loop error also routes through onReconcileError (single del
   assert.deepEqual(errors, [{ promptId: "G" }], "error delivered via the hook, once");
 });
 
-test("#370 P1-3: reconcile retry gives up after the attempt budget (no infinite polling)", async () => {
+test("#370 P1 (codex memory-leak): an exhausted-retry /history-ABSENT prompt is EVICTED (given up once), not retained forever", async () => {
   const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 3 });
-  const { tracker, flushes } = h;
+  const { tracker, flushes, giveUps } = h;
   tracker.onQueued("E");
-  const fetchHistory = async () => null; // permanently transient
+  const fetchHistory = async () => null; // /history stays absent (cancelled/gone)
   await tracker.reconcile({ fetchHistory, isVideo });
-  // Drain more than the budget of retries.
+  assert.equal(tracker._pending.has("E"), true, "pending while retries are in flight");
+  // Drain the retry budget.
   for (let i = 0; i < 6; i++) {
     h.advance(1000);
     await h.fireDueTimers();
   }
   assert.equal(flushes.length, 0, "nothing delivered — history never terminal");
-  assert.equal(tracker._pending.has("E"), true, "still pending — a future reconnect edge can retry");
+  // Given up ONCE and evicted → the ledger does not grow without bound.
+  assert.deepEqual(giveUps, [{ promptId: "E" }], "gave up exactly once");
+  assert.equal(tracker._pending.has("E"), false, "EVICTED from pending (bounded memory)");
+  // Its stamped terminal fence is no longer pinned by pending, so it ages out.
+  h.advance(10 * 60 * 1000 + 1);
+  await h.fireDueTimers();
+  assert.equal(tracker.wasTerminal("E"), false, "given-up fence ages out (not retained forever)");
+});
+
+test("#370 P1 (codex): repeated cancelled queued prompts do NOT accumulate in the ledger", async () => {
+  const h = makeHarness({ reconcileRetryMs: 500, maxReconcileRetries: 2 });
+  const { tracker, giveUps } = h;
+  const fetchHistory = async () => null; // every one is cancelled/absent
+  for (let n = 0; n < 5; n++) {
+    const id = `c${n}`;
+    tracker.onQueued(id);
+    await tracker.reconcile({ fetchHistory, isVideo });
+    for (let i = 0; i < 3; i++) {
+      h.advance(500);
+      await h.fireDueTimers();
+    }
+  }
+  assert.equal(giveUps.length, 5, "each unconfirmable prompt given up once");
+  assert.equal(tracker._pending.size, 0, "pending drained — no unbounded growth");
+});
+
+test("#370 P1-3: a RUNNING render whose retries exhaust is left pending (NOT given up)", async () => {
+  const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 3 });
+  const { tracker, giveUps } = h;
+  tracker.onExecutionStart("R");
+  const fetchHistory = async () => ({ outputs: {}, status: {} }); // known, not terminal
+  await tracker.reconcile({ fetchHistory, isVideo });
+  for (let i = 0; i < 6; i++) {
+    h.advance(1000);
+    await h.fireDueTimers();
+  }
+  assert.equal(giveUps.length, 0, "a confirmably-running render is NOT given up");
+  assert.equal(tracker._pending.has("R"), true, "left pending for the live path / next reconnect");
 });
 
 test("#370 still-running: reconcile leaves it pending and delivers nothing", async () => {

--- a/browser_tests/unit/run-reconcile.test.mjs
+++ b/browser_tests/unit/run-reconcile.test.mjs
@@ -649,6 +649,90 @@ test("#370 P1 (codex CRITICAL): absent /history BUT present in /queue (running) 
   assert.equal(rFlush.images[0].filename, "R_final.png");
 });
 
+test("#370 P1 (codex): a PRESENT non-terminal /history entry is NEVER given up, even when /queue is absent", async () => {
+  const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 2 });
+  const { tracker, flushes, giveUps } = h;
+  // /history HAS a record for P but it's not terminal (status running) — a transient
+  // queue↔history handoff where /queue momentarily omits it. A PRESENT record means
+  // the prompt is confirmably NOT gone, so it must never be evicted/fenced.
+  tracker.onQueued("P");
+  const fetchHistory = async () => ({ status: { status_str: "running" }, outputs: {} });
+  const fetchQueued = async () => false; // /queue momentarily omits it
+  const summary = await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
+  assert.deepEqual(summary, [{ promptId: "P", status: "running" }], "present-non-terminal ⇒ running, NOT unknown");
+  for (let i = 0; i < 4; i++) {
+    h.advance(1000);
+    await h.fireDueTimers();
+  }
+  assert.equal(giveUps.length, 0, "a present /history record is NEVER given up");
+  assert.equal(tracker._pending.has("P"), true, "left pending");
+  assert.equal(tracker.wasTerminal("P"), false, "NOT fenced");
+
+  // Its later live output must still deliver (fails-before: it was evicted/fenced).
+  tracker.onExecutionStart("P");
+  tracker.onExecuted("P", { images: [{ filename: "P_final.png", type: "output" }] });
+  tracker.onExecutionSuccess("P");
+  const pFlush = flushes.find((f) => f.promptId === "P");
+  assert.ok(pFlush, "the render's real output delivered, not dropped");
+  assert.equal(pFlush.images[0].filename, "P_final.png");
+});
+
+test("#370 P1 (codex): give-up requires CLEAN-ABSENT /history (null), not a present non-terminal record", async () => {
+  const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 1 });
+  const { tracker, giveUps } = h;
+  const fetchQueued = async () => false; // /queue absent for both
+  // "present" always has a present-non-terminal /history record; "gone" is cleanly
+  // absent (null). Only the latter is give-up eligible.
+  const fetchHistory = async (id) => (id === "present" ? { status: { status_str: "pending" } } : null);
+
+  tracker.onQueued("present");
+  tracker.onQueued("gone");
+  await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
+  for (let i = 0; i < 3; i++) {
+    h.advance(1000);
+    await h.fireDueTimers();
+  }
+  assert.deepEqual(giveUps, [{ promptId: "gone" }], "only null-history + absent-queue gives up");
+  assert.equal(tracker._pending.has("present"), true, "present-non-terminal stays pending (never given up)");
+  assert.equal(tracker._pending.has("gone"), false, "genuinely-gone prompt evicted (bounded memory)");
+});
+
+test("#370 P1 (codex): CONCURRENT reconciles give up a gone prompt exactly once (no double notice)", async () => {
+  const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 0 });
+  const { tracker, giveUps } = h;
+  tracker.onQueued("g");
+  const fetchHistory = async () => null; // clean-absent
+  const fetchQueued = async () => false; // absent from /queue ⇒ gone
+  // Two reconcile passes race over the same pending prompt (both resolve "unknown"
+  // and, with a zero budget, both reach giveUpReconcile). The ownership claim must
+  // ensure the eviction + onReconcileGiveUp notice fire only ONCE.
+  await Promise.all([
+    tracker.reconcile({ fetchHistory, fetchQueued, isVideo }),
+    tracker.reconcile({ fetchHistory, fetchQueued, isVideo }),
+  ]);
+  assert.deepEqual(giveUps, [{ promptId: "g" }], "given up exactly once despite the race");
+  assert.equal(tracker._pending.has("g"), false, "evicted once");
+});
+
+test("#370 P1 (codex): only a STRICT null /history is give-up eligible — undefined stays running", async () => {
+  const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 1 });
+  const { tracker, giveUps } = h;
+  const fetchQueued = async () => false; // /queue absent for both
+  // A custom fetchHistory that resolves `undefined` (not null) must NOT be treated
+  // as a clean absence — undefined is uncertain, never give-up eligible.
+  const fetchHistory = async (id) => (id === "u" ? undefined : null);
+  tracker.onQueued("u");
+  tracker.onQueued("n");
+  await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
+  for (let i = 0; i < 3; i++) {
+    h.advance(1000);
+    await h.fireDueTimers();
+  }
+  assert.deepEqual(giveUps, [{ promptId: "n" }], "only strict-null history gives up (undefined does not)");
+  assert.equal(tracker._pending.has("u"), true, "undefined-history prompt stays pending (uncertain)");
+  assert.equal(tracker._pending.has("n"), false, "null-history + absent-queue evicted");
+});
+
 test("#370 P1 (codex): a /history 503 (fetch throws) is UNCERTAIN → running, never given up even if /queue is absent", async () => {
   const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 2 });
   const { tracker, flushes, giveUps } = h;

--- a/browser_tests/unit/run-reconcile.test.mjs
+++ b/browser_tests/unit/run-reconcile.test.mjs
@@ -1,0 +1,332 @@
+/**
+ * Unit tests for #370 — reconcile a run's completion across a connection drop.
+ *
+ * When the connection drops mid-render, the terminal `execution_success` can be
+ * MISSED (WS lost) or the composed completion frame can be DROPPED (bridge down),
+ * so the run finishes with no completion delivered and its status is unknowable.
+ * On reconnect we reconcile still-pending prompt_ids against `/history` and
+ * deliver the terminal outcome EXACTLY ONCE — never double-delivering and never
+ * mis-attributing a different prompt_id.
+ *
+ * Covers both the pure parse (history-reconcile.js) and the tracker orchestration
+ * (run-completion.js reconcile / pending / delivered).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createRunCompletionTracker } from "../../web/js/lib/run-completion.js";
+import { parseHistoryEntry } from "../../web/js/lib/history-reconcile.js";
+
+const isVideo = (m) => /\.(mp4|webm|mov)$/i.test(String(m?.filename || ""));
+
+function makeHarness() {
+  let clock = 0;
+  const timers = new Map();
+  let seq = 0;
+  const flushes = [];
+  const tracker = createRunCompletionTracker({
+    onFlush: (p) => flushes.push(p),
+    now: () => clock,
+    setTimer: (fn, ms) => {
+      const id = ++seq;
+      timers.set(id, { at: clock + ms, fn });
+      return id;
+    },
+    clearTimer: (id) => timers.delete(id),
+    debounceMs: 1500,
+  });
+  return {
+    tracker,
+    flushes,
+    advance: (ms) => {
+      clock += ms;
+    },
+  };
+}
+
+const successEntry = (outputs) => ({
+  outputs,
+  status: { status_str: "success", completed: true, messages: [] },
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure parse
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("parseHistoryEntry: terminal success classifies stills vs videos", () => {
+  const parsed = parseHistoryEntry(
+    successEntry({
+      9: { images: [{ filename: "final.png", type: "output" }] },
+      10: { gifs: [{ filename: "clip.mp4", type: "output" }] },
+    }),
+    { isVideo },
+  );
+  assert.equal(parsed.terminal, true);
+  assert.equal(parsed.status, "success");
+  assert.equal(parsed.images.length, 1);
+  assert.equal(parsed.images[0].filename, "final.png");
+  assert.equal(parsed.videos.length, 1);
+  assert.equal(parsed.videos[0].m.filename, "clip.mp4");
+  assert.equal(parsed.videos[0].nodeId, "10");
+});
+
+test("parseHistoryEntry: an errored run is terminal with status error and no batch delivered", () => {
+  const parsed = parseHistoryEntry(
+    { outputs: {}, status: { status_str: "error", completed: false } },
+    { isVideo },
+  );
+  assert.equal(parsed.terminal, true);
+  assert.equal(parsed.status, "error");
+});
+
+test("parseHistoryEntry: a still-running / missing entry is NOT terminal", () => {
+  assert.equal(parseHistoryEntry(null, { isVideo }), null);
+  const running = parseHistoryEntry({ outputs: {}, status: {} }, { isVideo });
+  assert.equal(running.terminal, false);
+  assert.equal(running.status, "unknown");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tracker reconcile
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("#370 drop-during-render: missed execution_success → reconcile delivers via /history exactly once", async () => {
+  const { tracker, flushes } = makeHarness();
+  // Render starts, one output arrives, THEN the WS drops — no execution_success.
+  tracker.onExecutionStart("p1");
+  tracker.onExecuted("p1", { images: [{ filename: "partial.png", type: "output" }] });
+  assert.equal(flushes.length, 0, "no completion delivered yet (success was missed)");
+
+  // Reconnect: /history has the authoritative, COMPLETE output set.
+  const history = {
+    p1: successEntry({
+      9: { images: [{ filename: "final.png", type: "output" }] },
+    }),
+  };
+  const fetchHistory = async (id) => history[id] ?? null;
+  const summary = await tracker.reconcile({ fetchHistory, isVideo });
+
+  assert.equal(flushes.length, 1, "exactly one completion delivered on reconcile");
+  assert.equal(flushes[0].promptId, "p1");
+  assert.equal(flushes[0].reconciled, true);
+  // History is authoritative — the delivered batch is the /history output, not the
+  // partial pre-drop buffer.
+  assert.equal(flushes[0].images.length, 1);
+  assert.equal(flushes[0].images[0].filename, "final.png");
+  assert.deepEqual(summary, [{ promptId: "p1", status: "success", delivered: true }]);
+
+  // A SECOND reconcile (e.g. another reconnect) must NOT double-deliver.
+  await tracker.reconcile({ fetchHistory, isVideo });
+  assert.equal(flushes.length, 1, "no double-delivery on a second reconcile");
+});
+
+test("#370: a stale pre-drop buffer can't double-deliver after reconcile (executing:null is a no-op)", async () => {
+  const { tracker, flushes } = makeHarness();
+  tracker.onExecutionStart("p1");
+  tracker.onExecuted("p1", { images: [{ filename: "partial.png", type: "output" }] });
+  const history = { p1: successEntry({ 9: { images: [{ filename: "final.png", type: "output" }] } }) };
+  await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
+  assert.equal(flushes.length, 1);
+  // A late queue-idle / next-run signal must not re-flush the (now cleared) buffer.
+  tracker.onExecutingNull();
+  assert.equal(flushes.length, 1, "cleared buffer does not re-deliver");
+});
+
+test("#370 bridge-down drop: execution_success fired but frame was dropped → markUndelivered re-pends → reconcile delivers", async () => {
+  const { tracker, flushes } = makeHarness();
+  tracker.onExecutionStart("p1");
+  tracker.onExecuted("p1", { images: [{ filename: "final.png", type: "output" }] });
+  // We DID observe success live → the buffer flushed (delivered optimistically).
+  tracker.onExecutionSuccess("p1");
+  assert.equal(flushes.length, 1, "flushed on execution_success");
+  // …but the bridge was down, so the send failed. Caller re-pends it.
+  tracker.markUndelivered("p1");
+
+  // Reconnect → reconcile re-delivers from /history (the ONLY way this run's
+  // result reaches the agent, since the live frame was lost).
+  const history = { p1: successEntry({ 9: { images: [{ filename: "final.png", type: "output" }] } }) };
+  const summary = await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
+  assert.equal(flushes.length, 2, "reconcile re-delivers the lost completion");
+  assert.equal(flushes[1].reconciled, true);
+  assert.deepEqual(summary, [{ promptId: "p1", status: "success", delivered: true }]);
+});
+
+test("#370 happy path: a CONFIRMED-delivered run is NOT reconciled (no double-delivery)", async () => {
+  const { tracker, flushes } = makeHarness();
+  tracker.onExecutionStart("p1");
+  tracker.onExecuted("p1", { images: [{ filename: "final.png", type: "output" }] });
+  tracker.onExecutionSuccess("p1"); // delivered
+  tracker.markDelivered("p1"); // caller confirms the send succeeded
+  assert.equal(flushes.length, 1);
+
+  const history = { p1: successEntry({ 9: { images: [{ filename: "final.png", type: "output" }] } }) };
+  const summary = await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
+  assert.equal(flushes.length, 1, "no reconcile delivery for a confirmed run");
+  assert.deepEqual(summary, [], "nothing pending to reconcile");
+});
+
+test("#370 entire-run-in-drop: onQueued alone (no WS events) is still reconcilable", async () => {
+  const { tracker, flushes } = makeHarness();
+  // The run was accepted (prompt_id known) but started AND finished inside the
+  // drop — no execution_start/executing/executed ever arrived.
+  tracker.onQueued("p9");
+  const history = { p9: successEntry({ 4: { images: [{ filename: "done.png", type: "output" }] } }) };
+  const summary = await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
+  assert.equal(flushes.length, 1);
+  assert.equal(flushes[0].promptId, "p9");
+  assert.equal(summary[0].status, "success");
+});
+
+test("#370 no mis-attribution: reconcile only delivers the queried prompt's outputs", async () => {
+  const { tracker, flushes } = makeHarness();
+  tracker.onQueued("pA");
+  tracker.onQueued("pB");
+  // History only knows about pA (pB still running / no entry).
+  const history = {
+    pA: successEntry({ 1: { images: [{ filename: "A.png", type: "output" }] } }),
+    // pB: absent → not terminal
+  };
+  const summary = await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
+  const delivered = flushes.filter((f) => f.images.length);
+  assert.equal(delivered.length, 1);
+  assert.equal(delivered[0].promptId, "pA");
+  assert.equal(delivered[0].images[0].filename, "A.png");
+  // pB stays pending (unknown), pA delivered — no cross-contamination.
+  const byId = Object.fromEntries(summary.map((r) => [r.promptId, r.status]));
+  assert.equal(byId.pA, "success");
+  assert.equal(byId.pB, "unknown");
+  // pB is still pending → a later reconcile with its history delivers ONLY pB.
+  history.pB = successEntry({ 2: { images: [{ filename: "B.png", type: "output" }] } });
+  await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
+  const bFlush = flushes.find((f) => f.promptId === "pB");
+  assert.ok(bFlush, "pB delivered on the later reconcile");
+  assert.equal(bFlush.images[0].filename, "B.png");
+});
+
+test("#370 errored run recovered from history: no batch delivered, status error reported", async () => {
+  const { tracker, flushes } = makeHarness();
+  tracker.onExecutionStart("pE");
+  tracker.onExecuted("pE", { images: [{ filename: "partial.png", type: "output" }] });
+  // Drop before we saw execution_error; history says it failed.
+  const history = { pE: { outputs: {}, status: { status_str: "error" } } };
+  const summary = await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
+  assert.equal(flushes.length, 0, "no completion batch for a failed run");
+  assert.deepEqual(summary, [{ promptId: "pE", status: "error" }]);
+});
+
+test("#370 codex P1 (idempotency): a LATE executed+execution_success after reconcile does NOT double-deliver", async () => {
+  const { tracker, flushes } = makeHarness();
+  // Run dropped, reconcile recovers it from /history.
+  tracker.onExecutionStart("pL");
+  const history = { pL: successEntry({ 9: { images: [{ filename: "final.png", type: "output" }] } }) };
+  await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
+  assert.equal(flushes.length, 1, "reconcile delivered once");
+  assert.equal(tracker.wasDelivered("pL"), true);
+
+  // The live WS now replays the buffered lifecycle for the SAME prompt. None of it
+  // may produce a second completion.
+  tracker.onExecutingNode("pL");
+  tracker.onExecuted("pL", { images: [{ filename: "final.png", type: "output" }] });
+  tracker.onExecutionSuccess("pL");
+  assert.equal(flushes.length, 1, "no duplicate completion from the late live events");
+});
+
+test("#370 codex P1 (idempotency): wasDelivered fences a late execution_error after a reconciled error", async () => {
+  const { tracker, flushes } = makeHarness();
+  tracker.onExecutionStart("pX");
+  const history = { pX: { outputs: {}, status: { status_str: "error" } } };
+  await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
+  assert.equal(tracker.wasDelivered("pX"), true, "reconciled error is marked delivered");
+  // Panel checks wasDelivered() BEFORE onExecutionFailed to skip the duplicate
+  // run_error; the tracker-side late failed event re-buffers nothing.
+  tracker.onExecuted("pX", { images: [{ filename: "late.png", type: "output" }] });
+  tracker.onExecutionFailed("pX");
+  assert.equal(flushes.length, 0, "no batch, no duplicate from the late error");
+});
+
+test("#370 codex P1 (TOCTOU): a live execution_success during the /history await is NOT double-delivered", async () => {
+  const { tracker, flushes } = makeHarness();
+  tracker.onExecutionStart("pT");
+  tracker.onExecuted("pT", { images: [{ filename: "live.png", type: "output" }] });
+
+  // fetchHistory resolves the run's terminal record, but WHILE it is in flight the
+  // live `execution_success` arrives and delivers the buffered batch. reconcile
+  // must notice the run was delivered during its await and NOT deliver again.
+  const fetchHistory = async (id) => {
+    tracker.onExecutionSuccess(id); // live delivery lands mid-await
+    return { [id]: undefined }[id] ?? { outputs: { 1: { images: [{ filename: "hist.png", type: "output" }] } }, status: { status_str: "success" } };
+  };
+  const summary = await tracker.reconcile({ fetchHistory, isVideo });
+  assert.equal(flushes.length, 1, "exactly one delivery (the live success), no reconcile duplicate");
+  assert.equal(flushes[0].images[0].filename, "live.png");
+  assert.deepEqual(summary, [], "reconcile delivered nothing — the live event already resolved it");
+});
+
+test("#370 codex P1: an error whose run_error frame failed to send is re-pended and retried", async () => {
+  const { tracker, flushes } = makeHarness();
+  tracker.onExecutionStart("pE");
+  const history = { pE: { outputs: {}, status: { status_str: "error" } } };
+  const fetchHistory = async (id) => history[id] ?? null;
+
+  const s1 = await tracker.reconcile({ fetchHistory, isVideo });
+  assert.deepEqual(s1, [{ promptId: "pE", status: "error" }]);
+  assert.equal(flushes.length, 0);
+  // Panel's run_error frame couldn't be delivered (bridge dropped again) → re-pend.
+  tracker.markUndelivered("pE");
+
+  // The error is NOT lost: a later reconnect reconciles it again.
+  const s2 = await tracker.reconcile({ fetchHistory, isVideo });
+  assert.deepEqual(s2, [{ promptId: "pE", status: "error" }]);
+
+  // …and once the run_error is confirmed delivered, it stops retrying.
+  tracker.markDelivered("pE");
+  const s3 = await tracker.reconcile({ fetchHistory, isVideo });
+  assert.deepEqual(s3, [], "no further retry after the error was delivered");
+});
+
+test("#370 a prior run flushed partial at next-run start is delivered (not re-delivered by reconcile)", async () => {
+  const { tracker, flushes } = makeHarness();
+  // Run A's end signal missed (a dropped frame on a LIVE connection — no reconnect
+  // coming), then run B starts: A is flushed partial at B's start (#224 default).
+  tracker.onExecutionStart("pA");
+  tracker.onExecuted("pA", { images: [{ filename: "A.png", type: "output" }] });
+  tracker.onExecutionStart("pB");
+  assert.equal(flushes.length, 1, "A delivered at B's start (deliver-what-we-have)");
+  assert.equal(flushes[0].promptId, "pA");
+  // A was marked delivered by that flush → a later reconcile must NOT re-deliver it.
+  const history = { pA: successEntry({ 9: { images: [{ filename: "A.png", type: "output" }] } }) };
+  const summary = await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
+  assert.equal(flushes.length, 1, "no reconcile re-delivery of an already-delivered run");
+  assert.equal(summary.find((r) => r.promptId === "pA"), undefined);
+});
+
+test("#370 delivered-fence ages out: an old fence is pruned once past the 10-min TTL", () => {
+  const { tracker, advance } = makeHarness();
+  tracker.onExecutionStart("p1");
+  tracker.onExecuted("p1", { images: [{ filename: "a.png", type: "output" }] });
+  tracker.onExecutionSuccess("p1");
+  assert.equal(tracker.wasDelivered("p1"), true, "fenced right after delivery");
+
+  // Well past the fence TTL, a new delivery prunes the stale fence (bounded memory).
+  advance(10 * 60 * 1000 + 1);
+  tracker.onExecutionStart("p2");
+  tracker.onExecuted("p2", { images: [{ filename: "b.png", type: "output" }] });
+  tracker.onExecutionSuccess("p2");
+  assert.equal(tracker.wasDelivered("p1"), false, "stale fence aged out");
+  assert.equal(tracker.wasDelivered("p2"), true, "recent fence retained");
+});
+
+test("#370 still-running: reconcile leaves it pending and delivers nothing", async () => {
+  const { tracker, flushes } = makeHarness();
+  tracker.onExecutionStart("pR");
+  // History entry exists but has no terminal status yet.
+  const history = { pR: { outputs: {}, status: {} } };
+  const summary = await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
+  assert.equal(flushes.length, 0);
+  assert.deepEqual(summary, [{ promptId: "pR", status: "running" }]);
+  // Later the run finishes → a subsequent reconcile delivers it.
+  history.pR = successEntry({ 1: { images: [{ filename: "late.png", type: "output" }] } });
+  await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
+  assert.equal(flushes.length, 1);
+  assert.equal(flushes[0].promptId, "pR");
+});

--- a/browser_tests/unit/run-reconcile.test.mjs
+++ b/browser_tests/unit/run-reconcile.test.mjs
@@ -15,7 +15,11 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { createRunCompletionTracker } from "../../web/js/lib/run-completion.js";
-import { parseHistoryEntry, queueMembership } from "../../web/js/lib/history-reconcile.js";
+import {
+  parseHistoryEntry,
+  queueMembership,
+  historyEntryFor,
+} from "../../web/js/lib/history-reconcile.js";
 
 const isVideo = (m) => /\.(mp4|webm|mov)$/i.test(String(m?.filename || ""));
 
@@ -697,6 +701,34 @@ test("#370 P1 (codex): give-up requires CLEAN-ABSENT /history (null), not a pres
   assert.equal(tracker._pending.has("gone"), false, "genuinely-gone prompt evicted (bounded memory)");
 });
 
+// ── historyEntryFor: strict /history map verdict ────────────────────────────────
+
+test("historyEntryFor: well-formed map WITH the id ⇒ the entry (present record)", () => {
+  const entry = { status: { status_str: "success" }, outputs: {} };
+  assert.strictEqual(historyEntryFor({ R: entry }, "R"), entry);
+});
+
+test("historyEntryFor: well-formed map LACKING the id ⇒ null (clean absence)", () => {
+  assert.strictEqual(historyEntryFor({}, "R"), null);
+  assert.strictEqual(historyEntryFor({ other: { status: {} } }, "R"), null);
+});
+
+test("historyEntryFor: MALFORMED body (null/array/non-object) ⇒ undefined (uncertain, NOT null)", () => {
+  assert.strictEqual(historyEntryFor(null, "R"), undefined); // the exact repro: 200 body `null`
+  assert.strictEqual(historyEntryFor([], "R"), undefined); // 200 body `[]`
+  assert.strictEqual(historyEntryFor([{ R: 1 }], "R"), undefined); // array, not a map
+  assert.strictEqual(historyEntryFor("nonsense", "R"), undefined);
+  assert.strictEqual(historyEntryFor(42, "R"), undefined);
+  assert.strictEqual(historyEntryFor(undefined, "R"), undefined);
+});
+
+test("historyEntryFor: id PRESENT with a null/undefined value ⇒ undefined (malformed present, NOT clean absence)", () => {
+  assert.strictEqual(historyEntryFor({ R: null }, "R"), undefined); // present key, null value
+  assert.strictEqual(historyEntryFor({ R: undefined }, "R"), undefined); // present key, undefined value
+  // A sibling present-null must not make an ABSENT id look present-null.
+  assert.strictEqual(historyEntryFor({ other: null }, "R"), null); // R's key genuinely absent ⇒ clean absence
+});
+
 // ── queueMembership: strict-array /queue verdict ────────────────────────────────
 
 test("queueMembership: present in queue_running or queue_pending ⇒ true", () => {
@@ -762,6 +794,48 @@ test("#370 P1 (codex): a MALFORMED /queue (non-array fields) is uncertain → NO
   tracker.onExecuted("m", { images: [{ filename: "m.png", type: "output" }] });
   tracker.onExecutionSuccess("m");
   assert.ok(flushes.find((f) => f.promptId === "m"), "output delivered, not dropped");
+});
+
+test("#370 P1 (codex): a MALFORMED /history 200 body (null) is uncertain → NOT given up, later output delivers", async () => {
+  const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 1 });
+  const { tracker, flushes, giveUps } = h;
+  tracker.onQueued("R");
+  // /history/R returns 200 with a malformed body (`null`) — historyEntryFor maps
+  // this to `undefined` (uncertain), so the reconciler must NOT give up even though
+  // /queue is well-formed-both-absent.
+  const fetchHistory = async (id) => historyEntryFor(null, id); // ⇒ undefined
+  const fetchQueued = async (id) => queueMembership({ queue_running: [], queue_pending: [] }, id); // false
+  const summary = await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
+  assert.deepEqual(summary, [{ promptId: "R", status: "running" }], "malformed history ⇒ running, not unknown");
+  for (let i = 0; i < 3; i++) {
+    h.advance(1000);
+    await h.fireDueTimers();
+  }
+  assert.equal(giveUps.length, 0, "a malformed /history never causes a give-up");
+  assert.equal(tracker._pending.has("R"), true, "left pending (uncertain)");
+  assert.equal(tracker.wasTerminal("R"), false, "not fenced");
+
+  // Its later live output still delivers.
+  tracker.onExecutionStart("R");
+  tracker.onExecuted("R", { images: [{ filename: "R.png", type: "output" }] });
+  tracker.onExecutionSuccess("R");
+  assert.ok(flushes.find((f) => f.promptId === "R"), "output delivered, not dropped");
+});
+
+test("#370 P1 (codex): give-up requires BOTH a well-formed absent /history map AND well-formed absent /queue", async () => {
+  const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 1 });
+  const { tracker, giveUps } = h;
+  // well-formed /history map lacking the id (⇒ null) AND well-formed empty /queue (⇒ false).
+  const fetchHistory = async (id) => historyEntryFor({}, id); // ⇒ null (clean absence)
+  const fetchQueued = async (id) => queueMembership({ queue_running: [], queue_pending: [] }, id); // ⇒ false
+  tracker.onQueued("gone");
+  await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
+  for (let i = 0; i < 3; i++) {
+    h.advance(1000);
+    await h.fireDueTimers();
+  }
+  assert.deepEqual(giveUps, [{ promptId: "gone" }], "both sides well-formed-absent ⇒ give up once (memory bound)");
+  assert.equal(tracker._pending.has("gone"), false, "evicted");
 });
 
 test("#370 P1 (codex): give-up STILL fires when /history null AND /queue well-formed both-absent", async () => {

--- a/browser_tests/unit/run-reconcile.test.mjs
+++ b/browser_tests/unit/run-reconcile.test.mjs
@@ -574,6 +574,43 @@ test("#370 P1 (codex): repeated cancelled queued prompts do NOT accumulate in th
   assert.equal(tracker._pending.size, 0, "pending drained — no unbounded growth");
 });
 
+test("#370 P1 (codex): give-up RETIRES a partial buffer so no stale output flushes on the next run", async () => {
+  const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 2 });
+  const { tracker, flushes, giveUps } = h;
+  // P emitted a partial preview, then went history-absent (cancelled mid-run).
+  tracker.onExecutionStart("P");
+  tracker.onExecuted("P", { images: [{ filename: "P_partial.png", type: "output" }] });
+  assert.equal(tracker._buffers.has("P"), true, "P has a buffered partial");
+
+  const fetchHistory = async () => null; // absent
+  await tracker.reconcile({ fetchHistory, isVideo });
+  for (let i = 0; i < 4; i++) {
+    h.advance(1000);
+    await h.fireDueTimers();
+  }
+  assert.deepEqual(giveUps, [{ promptId: "P" }], "P given up once");
+  assert.equal(tracker._buffers.has("P"), false, "P's stale buffer was RETIRED on give-up");
+  assert.equal(tracker._active.has("P"), false, "P no longer active");
+
+  // A different run Q starts — P's stale partial must NOT be flushed here.
+  tracker.onExecutionStart("Q");
+  assert.equal(
+    flushes.some((f) => f.promptId === "P"),
+    false,
+    "no stale P output ever delivered",
+  );
+});
+
+test("#370 P2 (codex): maxReconcileRetries=0 gives up an absent-history prompt IMMEDIATELY", async () => {
+  const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 0 });
+  const { tracker, giveUps } = h;
+  tracker.onQueued("Z");
+  const fetchHistory = async () => null; // absent
+  await tracker.reconcile({ fetchHistory, isVideo });
+  assert.deepEqual(giveUps, [{ promptId: "Z" }], "gave up immediately (zero retries)");
+  assert.equal(tracker._pending.has("Z"), false, "evicted — not stranded pending forever");
+});
+
 test("#370 P1-3: a RUNNING render whose retries exhaust is left pending (NOT given up)", async () => {
   const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 3 });
   const { tracker, giveUps } = h;

--- a/browser_tests/unit/run-reconcile.test.mjs
+++ b/browser_tests/unit/run-reconcile.test.mjs
@@ -769,9 +769,15 @@ test("queueMembership: MALFORMED ROWS (arrays are valid but a row is unreadable)
   // A TRUNCATED [number, prompt_id] row (missing the prompt dict at index 2) is
   // MALFORMED — it must NOT be read as a valid id-absent entry (codex P1).
   assert.equal(queueMembership({ queue_running: [[0, "other"]], queue_pending: [] }, "p1"), null);
-  // Index 2 must be a PRESENT object (the prompt dict); null/non-object ⇒ malformed.
+  // Index 2 must be a PRESENT, NON-ARRAY object (the prompt dict); null/primitive/
+  // ARRAY ⇒ malformed (the classic `typeof [] === "object"` gotcha — codex P1).
   assert.equal(queueMembership({ queue_running: [[0, "other", null]], queue_pending: [] }, "p1"), null);
   assert.equal(queueMembership({ queue_running: [[0, "other", 7]], queue_pending: [] }, "p1"), null);
+  assert.equal(queueMembership({ queue_running: [[0, "other", []]], queue_pending: [] }, "p1"), null); // idx2 array
+  assert.equal(queueMembership({ queue_running: [[1, "other", [1, 2]]], queue_pending: [] }, "target"), null);
+  // An object-row whose prompt_id is an array/non-string ⇒ malformed ⇒ null.
+  assert.equal(queueMembership({ queue_running: [{ prompt_id: ["a"] }], queue_pending: [] }, "p1"), null);
+  assert.equal(queueMembership({ queue_running: [{ prompt_id: 5 }], queue_pending: [] }, "p1"), null);
   // A FULL valid row that simply doesn't match is a clean absence ⇒ false.
   assert.equal(queueMembership({ queue_running: [qrow(0, "other")], queue_pending: [] }, "p1"), false);
   // A POSITIVE match is trustworthy even if OTHER rows are malformed (truncated).
@@ -803,6 +809,28 @@ test("#370 P1 (codex): a /queue with ONLY TRUNCATED rows is uncertain → NOT gi
   tracker.onExecuted("R", { images: [{ filename: "R.png", type: "output" }] });
   tracker.onExecutionSuccess("R");
   assert.ok(flushes.find((f) => f.promptId === "R"), "output delivered, not dropped");
+});
+
+test("#370 P1 (codex): a /queue row whose idx2 is an ARRAY is malformed → NOT given up (typeof [] gotcha)", async () => {
+  const h = makeHarness({ reconcileRetryMs: 1000, maxReconcileRetries: 0 });
+  const { tracker, flushes, giveUps } = h;
+  tracker.onQueued("target");
+  const fetchHistory = async () => null; // clean-absent /history
+  // /queue row [1,"other",[]] — idx2 is an ARRAY, not a prompt dict ⇒ malformed ⇒
+  // queueMembership null (uncertain). With a ZERO retry budget the tracker must
+  // STILL not give up (the malformed row must not read as a valid absent entry).
+  const fetchQueued = async (id) => queueMembership({ queue_running: [[1, "other", []]], queue_pending: [] }, id);
+  const summary = await tracker.reconcile({ fetchHistory, fetchQueued, isVideo });
+  assert.deepEqual(summary, [{ promptId: "target", status: "running" }], "idx2-array row ⇒ running, not unknown");
+  assert.equal(giveUps.length, 0, "idx2-array malformed row never causes give-up (even at maxRetries=0)");
+  assert.equal(tracker._pending.has("target"), true, "left pending (uncertain)");
+  assert.equal(tracker.wasTerminal("target"), false, "not fenced");
+
+  // Its later live output still delivers.
+  tracker.onExecutionStart("target");
+  tracker.onExecuted("target", { images: [{ filename: "t.png", type: "output" }] });
+  tracker.onExecutionSuccess("target");
+  assert.ok(flushes.find((f) => f.promptId === "target"), "output delivered, not dropped");
 });
 
 test("#370 P1 (codex): give-up fires on FULL valid /history-map-absent + FULL valid /queue-row-absent; a matching full row ⇒ running", async () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -5937,10 +5937,16 @@ const GRAPH_TOOL_EXECUTORS = {
               if (promptRejection == null && body && (body.error || body.node_errors)) {
                 promptRejection = { error: body.error ?? null, node_errors: body.node_errors ?? null };
               }
-            } else if (body && body.prompt_id && !queuedPromptIds.includes(body.prompt_id)) {
+            } else if (body && body.prompt_id != null) {
               // Accepted — remember EACH prompt_id so #370 reconcile can recover a
-              // run that starts AND finishes entirely inside a connection drop.
-              queuedPromptIds.push(body.prompt_id);
+              // run that starts AND finishes entirely inside a connection drop. Use a
+              // NULLISH presence check (!= null), NOT truthiness — a falsy-but-valid
+              // id like 0 must flow through ingestion, or a drop before lifecycle
+              // frames would lose the completion (#370). Normalize to a STRING AT
+              // CAPTURE so dedupe is canonical (0 and "0" are the same run) and
+              // everything downstream stays string-vs-string.
+              const pid = String(body.prompt_id);
+              if (!queuedPromptIds.includes(pid)) queuedPromptIds.push(pid);
             }
           }
         } catch {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -147,7 +147,7 @@ import { pickRevertSnapshot } from "./lib/graph-revert.js";
 import { saveActiveWorkflow, shouldGroundBeforeTurn, groundActiveWorkflow } from "./lib/workflow-save.js";
 import { createRunCompletionTracker } from "./lib/run-completion.js";
 import { composeRunCompletionFrame } from "./lib/run-completion-frame.js";
-import { summarizePromptRejection } from "./lib/queue-rejection.js";
+import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
 import {
   shouldResumeAfterComfyReconnect,
   shouldRehelloAfterCommand,
@@ -5964,11 +5964,14 @@ const GRAPH_TOOL_EXECUTORS = {
       lastNodeErrors: app.lastNodeErrors,
     });
     if (rejection) return rejection;
-    return {
-      queued: true,
-      batch_count: batch,
-      ...(partialTargets ? { ran_to_node: Number(to_node_id) } : {}),
-    };
+    // Surface the queued prompt_id(s) so the agent can correlate/track the run —
+    // #370 reconciliation and mcp#531 (panel_run must return the prompt_id even
+    // when a render is already running) both depend on this being reported.
+    return buildQueueAcceptResult({
+      batchCount: batch,
+      promptIds: queuedPromptIds,
+      ranToNode: partialTargets ? Number(to_node_id) : null,
+    });
   },
 
   // WHY IS THAT NODE RED? — the single error surface. LiteGraph only sets a
@@ -15067,6 +15070,23 @@ function buildPanel() {
           else runCompletion.markUndelivered(promptId);
         });
     },
+    // #370: deliver a reconcile-discovered terminal ERROR. Routed through the
+    // tracker (not the reconcile summary) so it fires whether the error is found
+    // by the reconnect reconcile loop OR by a later /history RETRY — otherwise a
+    // transient-miss-then-error would fence the prompt but never surface a
+    // run_error to the agent (codex P1). Mute/re-pend mirror the completion path.
+    onReconcileError: ({ promptId }) => {
+      const sent = client.sendFrame({
+        type: "agent_event",
+        kind: "run_error",
+        error: `A queued render failed while the connection was down (prompt ${promptId}).`,
+      });
+      if (sent) appendSystem("A queued render failed while the connection was down.");
+      // A muted agent intentionally suppresses this (sendFrame also returns false);
+      // reconcileKey already marked it delivered, so leave it. Only a genuine
+      // transport failure re-pends so the next reconnect/retry re-delivers it.
+      else if (!AGENT_MUTED) runCompletion.markUndelivered(promptId);
+    },
   });
   runCompletionRef = runCompletion;
 
@@ -15099,29 +15119,18 @@ function buildPanel() {
           isVideo: isVideoOutput,
         });
         for (const row of summary) {
-          if (row.status === "error") {
-            // A run we never saw fail (missed execution_error) — surface it so the
-            // agent stops waiting on a render that already died. reconcile already
-            // retired this prompt from pending, so — exactly as the success path
-            // re-pends on a dropped completion frame — if THIS run_error frame
-            // can't be delivered (bridge dropped again mid-reconcile), re-pend it
-            // so the next reconnect retries. Otherwise the error would be lost
-            // permanently with no way to recover it (codex P1).
-            const sent = client.sendFrame({
-              type: "agent_event",
-              kind: "run_error",
-              error: `A queued render failed while the connection was down (prompt ${row.promptId}).`,
-            });
-            if (sent) appendSystem("A queued render failed while the connection was down.");
-            else if (!AGENT_MUTED) runCompletion.markUndelivered(row.promptId);
-          } else if (row.status === "unknown") {
+          if (row.status === "unknown") {
             // History couldn't confirm a terminal outcome — tell the user plainly.
+            // (A scheduled retry may still recover it; this is honest at this
+            // instant.)
             appendSystem(
               `Render status unknown after reconnect (prompt ${row.promptId}) — safe to requeue if no result arrives.`,
             );
           }
-          // success+delivered ⇒ the completion frame was already sent via onFlush;
-          // success without a batch and "running" need no message.
+          // A terminal ERROR is delivered via the tracker's onReconcileError hook
+          // (so a retry-discovered error is surfaced too). success+delivered ⇒ the
+          // completion frame was already sent via onFlush; success-without-batch
+          // and "running" need no message.
         }
       } catch (err) {
         console.warn("[cmcp] run reconcile failed:", err);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -147,6 +147,7 @@ import { pickRevertSnapshot } from "./lib/graph-revert.js";
 import { saveActiveWorkflow, shouldGroundBeforeTurn, groundActiveWorkflow } from "./lib/workflow-save.js";
 import { createRunCompletionTracker } from "./lib/run-completion.js";
 import { composeRunCompletionFrame } from "./lib/run-completion-frame.js";
+import { summarizePromptRejection } from "./lib/queue-rejection.js";
 import {
   shouldResumeAfterComfyReconnect,
   shouldRehelloAfterCommand,
@@ -158,6 +159,12 @@ import {
 
 let app = null;
 let api = null;
+
+// The live run-completion tracker (created in buildPanel). Held at module scope
+// so the module-level tool handlers (e.g. graph_run) can register a freshly
+// queued prompt_id for #370 reconnect reconciliation, even though the tracker
+// lives in buildPanel's closure.
+let runCompletionRef = null;
 
 // Execution-error capture so graph_get_errors can report the most recent failure
 // even if it predates the agent's question. Wired once `api` is ready (via
@@ -5886,11 +5893,77 @@ const GRAPH_TOOL_EXECUTORS = {
 
     // app.queuePrompt(number, batchCount, queueNodeIds) — the 3rd arg becomes the
     // request's partial_execution_targets (queue-service signature; ComfyUI 0.26.2).
-    await app.queuePrompt(0, batch, partialTargets);
-    // queuePrompt swallows validation failures into lastNodeErrors.
-    const nodeErrors =
-      app.lastNodeErrors && Object.keys(app.lastNodeErrors).length ? app.lastNodeErrors : null;
-    if (nodeErrors) return { queued: false, node_errors: nodeErrors };
+    //
+    // #358: app.queuePrompt SWALLOWS a synchronous rejection. It stores per-node
+    // validation errors on `lastNodeErrors`, but a TOP-LEVEL rejection (e.g.
+    // `missing_node_type` when a node has no resolvable class_type, or "prompt
+    // outputs failed validation") is shown in a dialog and then DISCARDED — it
+    // never reaches `lastNodeErrors` (which stays `{}`). Inspecting only
+    // `lastNodeErrors` therefore reports a false `queued:true` for a prompt
+    // ComfyUI refused ~1ms after "got prompt". Capture the raw non-200 /prompt
+    // body — the only place the top-level `error` exists — by wrapping fetchApi
+    // for the duration of THIS queue call, then let summarizePromptRejection turn
+    // it into a real failure. All queue paths POST /prompt through fetchApi, so
+    // this is version-robust regardless of app.queuePrompt's internal plumbing.
+    // Capture the FIRST top-level rejection (app.queuePrompt breaks its batch loop
+    // on the first rejected prompt, so there is at most one) plus EVERY accepted
+    // prompt_id — a batch>1 run queues N separate prompts, each of which needs its
+    // own #370 recovery-ledger entry. The panel dispatches agent commands serially
+    // (each command is replied to before the next tool runs), so graph_run's queue
+    // call does not overlap another graph_run; we save + restore the exact prior
+    // api.fetchApi so even a hypothetical nested wrap unwinds cleanly.
+    let promptRejection = null;
+    const queuedPromptIds = [];
+    const prevFetchApi =
+      typeof api?.fetchApi === "function" ? api.fetchApi : null;
+    const origFetchApi = prevFetchApi ? prevFetchApi.bind(api) : null;
+    if (origFetchApi) {
+      api.fetchApi = async (route, options) => {
+        const res = await origFetchApi(route, options);
+        try {
+          const method = String(options?.method || "GET").toUpperCase();
+          const path = typeof route === "string" ? route.split("?")[0] : "";
+          if (method === "POST" && path.endsWith("/prompt") && res) {
+            const body = await res.clone().json();
+            if (res.status !== 200) {
+              if (promptRejection == null && body && (body.error || body.node_errors)) {
+                promptRejection = { error: body.error ?? null, node_errors: body.node_errors ?? null };
+              }
+            } else if (body && body.prompt_id && !queuedPromptIds.includes(body.prompt_id)) {
+              // Accepted — remember EACH prompt_id so #370 reconcile can recover a
+              // run that starts AND finishes entirely inside a connection drop.
+              queuedPromptIds.push(body.prompt_id);
+            }
+          }
+        } catch {
+          // non-JSON body / clone unsupported — fall back to lastNodeErrors below.
+        }
+        return res;
+      };
+    }
+    try {
+      await app.queuePrompt(0, batch, partialTargets);
+    } finally {
+      if (origFetchApi) api.fetchApi = prevFetchApi;
+    }
+    // Register EVERY accepted prompt_id for reconnect reconciliation (#370) —
+    // BEFORE the rejection check. With batch>1, app.queuePrompt breaks its loop on
+    // the first rejection, so an EARLIER repetition can be accepted (already
+    // queued + running) while a LATER one rejects. That accepted run still needs a
+    // recovery-ledger entry, or a disconnect that swallows its whole lifecycle
+    // would leave it unreconcilable even though we return a rejection here.
+    for (const pid of queuedPromptIds) {
+      try {
+        runCompletionRef?.onQueued(pid);
+      } catch {}
+    }
+    // Verdict from BOTH channels: the captured top-level rejection (#358) and the
+    // per-node errors the frontend stashed. null ⇒ genuinely accepted.
+    const rejection = summarizePromptRejection({
+      rejection: promptRejection,
+      lastNodeErrors: app.lastNodeErrors,
+    });
+    if (rejection) return rejection;
     return {
       queued: true,
       batch_count: batch,
@@ -14324,6 +14397,13 @@ function buildPanel() {
       // release the soft-reload interlock: the (possibly slow) reload's orchestrator
       // handshook, so auto-respawn can guard the next drop normally.
       if (connected) {
+        // Bridge came back after a drop — the completion frame for a run that
+        // finished while it was down was silently dropped by sendFrame, so
+        // reconcile pending runs against /history to redeliver it (#370).
+        if (bridgeWasDown) {
+          bridgeWasDown = false;
+          void reconcileRunsAfterReconnect();
+        }
         resetAutoReclaim();
         clearSoftReloadGuard();
         // Push the current render-stall threshold so a reused/just-connected
@@ -14343,6 +14423,8 @@ function buildPanel() {
       // here falsely reads as "turn finished", so keep it up (with a reconnecting
       // banner) while a turn is live; only hide when nothing is in flight.
       if (!connected) {
+        // Remember the drop so the next "connected" reconciles pending runs (#370).
+        bridgeWasDown = true;
         if (agentWorking) {
           thinkingReconnecting = true;
           // Keep the indicator up with the reconnecting banner, but DON'T re-arm
@@ -14928,6 +15010,12 @@ function buildPanel() {
   // batch + duration for a completed prompt and composes the single agent_event.
   const runCompletion = createRunCompletionTracker({
     onFlush: ({ promptId, images: flImages, videos: flVideos, durationMs }) => {
+      // #370: track whether the composed completion frame actually reached the
+      // agent. sendFrame returns false when the bridge socket is down — in that
+      // case the completion is LOST, so we re-pend the prompt (markUndelivered) so
+      // the next reconnect recovers it via /history. A confirmed send (or an empty
+      // batch that emits no frame) retires it from pending.
+      let framePushed = false;
       // A completed prompt delivers its FULL batch here, exactly once. Compose
       // ONE consolidated agent_event for the whole run — stills AND every video's
       // storyboard folded into a single images+note+metadata turn — so a mixed /
@@ -14939,7 +15027,11 @@ function buildPanel() {
       composeRunCompletionFrame(
         { promptId, images: flImages, videos: flVideos, durationMs },
         {
-          sendFrame: (frame) => client.sendFrame(frame),
+          sendFrame: (frame) => {
+            const ok = client.sendFrame(frame);
+            if (ok) framePushed = true;
+            return ok;
+          },
           coerceMessageText,
           formatDuration,
           formatClock,
@@ -14954,9 +15046,91 @@ function buildPanel() {
           videoStoryboardEnabled: prefs.videoStoryboard !== false,
           warn: (...a) => console.warn(...a),
         },
-      ).catch((err) => console.warn("[cmcp] composeRunCompletionFrame failed:", err));
+      )
+        .then((frame) => {
+          // frame===null ⇒ empty batch (nothing to deliver) ⇒ delivered. A frame
+          // that was pushed ⇒ delivered. A frame that FAILED to push ⇒ re-pend —
+          // UNLESS it failed because agents are MUTED, which is intentional,
+          // permanent suppression (sendFrame returns false for both a down socket
+          // AND AGENT_MUTED): a muted completion must NOT be recovered/replayed on
+          // a later unmute+reconnect, so treat it as delivered (codex P1).
+          if (frame == null || framePushed) runCompletion.markDelivered(promptId);
+          else if (AGENT_MUTED) runCompletion.markDelivered(promptId);
+          else runCompletion.markUndelivered(promptId);
+        })
+        .catch((err) => {
+          console.warn("[cmcp] composeRunCompletionFrame failed:", err);
+          // Composition threw before/around the send — treat as undelivered so a
+          // reconnect can recover the outcome from /history rather than lose it
+          // (but respect an intentional mute, as above).
+          if (framePushed || AGENT_MUTED) runCompletion.markDelivered(promptId);
+          else runCompletion.markUndelivered(promptId);
+        });
     },
   });
+  runCompletionRef = runCompletion;
+
+  // #370: recover run completions across a connection drop. When the WS drops
+  // mid-render the terminal `execution_success` can be missed, and when the
+  // bridge is down the composed completion frame is silently dropped by
+  // sendFrame — either way the run finishes with NO completion delivered and its
+  // status is unknowable. On reconnect we reconcile every still-pending prompt_id
+  // against ComfyUI's authoritative `/history/<id>` record and deliver the
+  // terminal outcome exactly once (the `delivered` set makes double-delivery and
+  // mis-attribution unreachable). A run still in flight is left pending; a run
+  // whose status can't be recovered surfaces a "safe to requeue" notice.
+  let reconcileInFlight = null;
+  // True once the bridge has been observed DOWN, so a later "connected" is a real
+  // reconnect (not one of the many handshake frames the bridge re-emits) and we
+  // reconcile exactly on the drop→reconnect edge.
+  let bridgeWasDown = false;
+  async function reconcileRunsAfterReconnect() {
+    if (reconcileInFlight) return reconcileInFlight;
+    reconcileInFlight = (async () => {
+      try {
+        const summary = await runCompletion.reconcile({
+          fetchHistory: async (promptId) => {
+            if (typeof api?.fetchApi !== "function") return null;
+            const res = await api.fetchApi(`/history/${encodeURIComponent(promptId)}`);
+            if (!res || !res.ok) return null;
+            const j = await res.json();
+            return (j && j[promptId]) ?? null;
+          },
+          isVideo: isVideoOutput,
+        });
+        for (const row of summary) {
+          if (row.status === "error") {
+            // A run we never saw fail (missed execution_error) — surface it so the
+            // agent stops waiting on a render that already died. reconcile already
+            // retired this prompt from pending, so — exactly as the success path
+            // re-pends on a dropped completion frame — if THIS run_error frame
+            // can't be delivered (bridge dropped again mid-reconcile), re-pend it
+            // so the next reconnect retries. Otherwise the error would be lost
+            // permanently with no way to recover it (codex P1).
+            const sent = client.sendFrame({
+              type: "agent_event",
+              kind: "run_error",
+              error: `A queued render failed while the connection was down (prompt ${row.promptId}).`,
+            });
+            if (sent) appendSystem("A queued render failed while the connection was down.");
+            else if (!AGENT_MUTED) runCompletion.markUndelivered(row.promptId);
+          } else if (row.status === "unknown") {
+            // History couldn't confirm a terminal outcome — tell the user plainly.
+            appendSystem(
+              `Render status unknown after reconnect (prompt ${row.promptId}) — safe to requeue if no result arrives.`,
+            );
+          }
+          // success+delivered ⇒ the completion frame was already sent via onFlush;
+          // success without a batch and "running" need no message.
+        }
+      } catch (err) {
+        console.warn("[cmcp] run reconcile failed:", err);
+      } finally {
+        reconcileInFlight = null;
+      }
+    })();
+    return reconcileInFlight;
+  }
 
   function onExecuted(ev) {
     const d = ev?.detail ?? {};
@@ -14997,9 +15171,15 @@ function buildPanel() {
   }
   function onExecError(ev) {
     const d = ev?.detail ?? {};
+    // Idempotency fence (codex P1): if a /history reconcile already surfaced this
+    // run's outcome, a late live `execution_error` for the same prompt must NOT
+    // re-send run_error or re-paint the card. Check BEFORE onExecutionFailed marks
+    // it delivered (otherwise the check would always be true).
+    const alreadyDelivered = runCompletion.wasDelivered(d.prompt_id);
     // The run failed — drop any images we'd buffered for it so we don't deliver a
     // stale "here are your outputs" batch on top of the run_error interrupt below.
     runCompletion.onExecutionFailed(d.prompt_id);
+    if (alreadyDelivered) return;
     // Name the failing node so the agent (and the user) know WHERE it broke —
     // "Ideogram4PromptBuilderKJ (node 200)" beats a bare exception string.
     // Coerce node descriptors too — never bake "[object Object]" into the
@@ -15017,7 +15197,16 @@ function buildPanel() {
     const error = where ? `${where}: ${msg}` : msg;
     // 1) Push it to the agent — the orchestrator INTERRUPTS its live turn and
     //    front-queues this so it stops and fixes the error instead of running blind.
-    client.sendFrame({ type: "agent_event", kind: "run_error", error });
+    //    onExecutionFailed already retired this prompt from pending, so if the
+    //    bridge is down and this frame can't be delivered the error would be lost
+    //    with no way to recover it. Re-pend on a dropped send (mirroring the
+    //    completion + reconciled-error paths) so the next reconnect reconciles it
+    //    against /history and re-delivers the failure (codex P1).
+    const runErrorSent = client.sendFrame({ type: "agent_event", kind: "run_error", error });
+    // Re-pend only on a TRANSPORT failure. A muted agent intentionally suppresses
+    // this frame (sendFrame also returns false then) — onExecutionFailed already
+    // marked it delivered, so leaving it there keeps the mute permanent (codex P1).
+    if (!runErrorSent && !AGENT_MUTED) runCompletion.markUndelivered(d.prompt_id);
     // 2) Render it immediately as an error widget in the chat, so the user sees it
     //    even before the agent reacts (no waiting on a check-errors call).
     paintCard({
@@ -15064,6 +15253,10 @@ function buildPanel() {
     }
   }
   function onComfyReconnected() {
+    // ComfyUI's WS is back — this is exactly when a mid-render `execution_success`
+    // may have been missed, so reconcile pending runs against /history first,
+    // independent of whether we go on to resume the agent below (#370).
+    void reconcileRunsAfterReconnect();
     // After ComfyUI comes back (backend-only reboot — the page didn't reload),
     // the orchestrator died with it. Respawn + reconnect if the agent was in use.
     // ComfyUI fires "reconnected" for BENIGN WS blips too — viewing assets,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -148,7 +148,7 @@ import { saveActiveWorkflow, shouldGroundBeforeTurn, groundActiveWorkflow } from
 import { createRunCompletionTracker } from "./lib/run-completion.js";
 import { composeRunCompletionFrame } from "./lib/run-completion-frame.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
-import { queueMembership } from "./lib/history-reconcile.js";
+import { queueMembership, historyEntryFor } from "./lib/history-reconcile.js";
 import {
   shouldResumeAfterComfyReconnect,
   shouldRehelloAfterCommand,
@@ -15137,13 +15137,15 @@ function buildPanel() {
             // A non-OK response (e.g. 503 while the server is busy/restarting) is
             // UNCERTAIN — NOT a clean "absent from history". THROW so the reconciler
             // takes its "history unreachable → running" path and never gives up on a
-            // prompt whose result might just be temporarily unreadable (codex P1). A
-            // clean 200 with no entry for this id is the real absence → return null.
+            // prompt whose result might just be temporarily unreadable (codex P1).
             if (!res || !res.ok) {
               throw new Error(`/history ${res ? res.status : "unreachable"}`);
             }
-            const j = await res.json();
-            return (j && j[promptId]) ?? null;
+            // historyEntryFor applies the SAME strictness as /queue: only a
+            // WELL-FORMED history map lacking the id normalizes to null (clean
+            // absence, give-up eligible); a malformed 200 body (null/array/non-
+            // object) ⇒ undefined (uncertain → running, never given up).
+            return historyEntryFor(await res.json(), promptId);
           },
           // Is the prompt still in ComfyUI's /queue (running OR pending)? Absence
           // from /history is NORMAL for a queued/running prompt — ComfyUI writes

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -148,6 +148,7 @@ import { saveActiveWorkflow, shouldGroundBeforeTurn, groundActiveWorkflow } from
 import { createRunCompletionTracker } from "./lib/run-completion.js";
 import { composeRunCompletionFrame } from "./lib/run-completion-frame.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
+import { queueMembership } from "./lib/history-reconcile.js";
 import {
   shouldResumeAfterComfyReconnect,
   shouldRehelloAfterCommand,
@@ -15154,11 +15155,10 @@ function buildPanel() {
             if (typeof api?.fetchApi !== "function") return null;
             const res = await api.fetchApi("/queue");
             if (!res || !res.ok) return null;
-            const j = await res.json();
-            const has = (arr) =>
-              Array.isArray(arr) &&
-              arr.some((item) => (Array.isArray(item) ? item[1] === promptId : item?.prompt_id === promptId));
-            return has(j?.queue_running) || has(j?.queue_pending);
+            // queueMembership returns false ONLY when both queue arrays are
+            // well-formed and lack the id; a missing/malformed payload ⇒ null
+            // (uncertain), so a malformed /queue never causes a give-up (codex P1).
+            return queueMembership(await res.json(), promptId);
           },
           isVideo: isVideoOutput,
         });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -5857,7 +5857,14 @@ const GRAPH_TOOL_EXECUTORS = {
     if (typeof app.queuePrompt !== "function") {
       throw new Error("app.queuePrompt is unavailable on this frontend");
     }
-    const batch = Number(batch_count ?? 1);
+    // Clamp batch_count to a sane range: coerce to a positive integer and cap it,
+    // so an absurd value can't queue thousands of prompts (each of which would
+    // register a #370 recovery-ledger entry) — bounding memory + the ComfyUI queue.
+    const MAX_BATCH = 64;
+    const requestedBatch = Math.floor(Number(batch_count ?? 1));
+    const batch = Number.isFinite(requestedBatch)
+      ? Math.min(Math.max(requestedBatch, 1), MAX_BATCH)
+      : 1;
 
     // "Run to node" = ComfyUI partial execution. The server keeps an OUTPUT node
     // (SaveImage/PreviewImage/SaveVideo/…) as an execution root only when its id
@@ -15087,6 +15094,20 @@ function buildPanel() {
       // transport failure re-pends so the next reconnect/retry re-delivers it.
       else if (!AGENT_MUTED) runCompletion.markUndelivered(promptId);
     },
+    // #370 (P1 memory-leak): the tracker GAVE UP on a prompt whose outcome it
+    // couldn't confirm after the bounded retries (its /history stayed absent —
+    // cancelled/disconnected). It's been evicted from the ledger; surface a
+    // one-time "status unknown, safe to requeue" notice so the agent stops waiting.
+    onReconcileGiveUp: ({ promptId }) => {
+      client.sendFrame({
+        type: "agent_event",
+        kind: "run_error",
+        error:
+          `Render status for prompt ${promptId} could not be confirmed after reconnecting ` +
+          `(no history for it) — it was likely cancelled or interrupted. Safe to requeue.`,
+      });
+      appendSystem(`Render status unknown for prompt ${promptId} — safe to requeue.`);
+    },
   });
   runCompletionRef = runCompletion;
 
@@ -15118,20 +15139,13 @@ function buildPanel() {
           },
           isVideo: isVideoOutput,
         });
-        for (const row of summary) {
-          if (row.status === "unknown") {
-            // History couldn't confirm a terminal outcome — tell the user plainly.
-            // (A scheduled retry may still recover it; this is honest at this
-            // instant.)
-            appendSystem(
-              `Render status unknown after reconnect (prompt ${row.promptId}) — safe to requeue if no result arrives.`,
-            );
-          }
-          // A terminal ERROR is delivered via the tracker's onReconcileError hook
-          // (so a retry-discovered error is surfaced too). success+delivered ⇒ the
-          // completion frame was already sent via onFlush; success-without-batch
-          // and "running" need no message.
-        }
+        // Nothing to surface synchronously from `summary`: a terminal SUCCESS is
+        // delivered via onFlush, a terminal ERROR via the onReconcileError hook, an
+        // "unknown"/"running" schedules a bounded retry, and a definitively
+        // unconfirmable prompt is surfaced ONCE via the onReconcileGiveUp hook when
+        // its retries exhaust (not prematurely here — the retry may still recover
+        // it). `summary` is retained for diagnostics only.
+        void summary;
       } catch (err) {
         console.warn("[cmcp] run reconcile failed:", err);
       } finally {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15180,15 +15180,16 @@ function buildPanel() {
   }
   function onExecError(ev) {
     const d = ev?.detail ?? {};
-    // Idempotency fence (codex P1): if a /history reconcile already surfaced this
-    // run's outcome, a late live `execution_error` for the same prompt must NOT
-    // re-send run_error or re-paint the card. Check BEFORE onExecutionFailed marks
-    // it delivered (otherwise the check would always be true).
-    const alreadyDelivered = runCompletion.wasDelivered(d.prompt_id);
+    // Idempotency fence (codex P1): if this run already reached a TERMINAL outcome
+    // (e.g. a /history reconcile surfaced it — even if its delivery is being
+    // re-pended for retry), a late live `execution_error` for the same prompt must
+    // NOT re-send run_error or re-paint the card. Check BEFORE onExecutionFailed
+    // (otherwise it would always be true).
+    const alreadyTerminal = runCompletion.wasTerminal(d.prompt_id);
     // The run failed — drop any images we'd buffered for it so we don't deliver a
     // stale "here are your outputs" batch on top of the run_error interrupt below.
     runCompletion.onExecutionFailed(d.prompt_id);
-    if (alreadyDelivered) return;
+    if (alreadyTerminal) return;
     // Name the failing node so the agent (and the user) know WHERE it broke —
     // "Ideogram4PromptBuilderKJ (node 200)" beats a bare exception string.
     // Coerce node descriptors too — never bake "[object Object]" into the

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15133,9 +15133,32 @@ function buildPanel() {
           fetchHistory: async (promptId) => {
             if (typeof api?.fetchApi !== "function") return null;
             const res = await api.fetchApi(`/history/${encodeURIComponent(promptId)}`);
-            if (!res || !res.ok) return null;
+            // A non-OK response (e.g. 503 while the server is busy/restarting) is
+            // UNCERTAIN — NOT a clean "absent from history". THROW so the reconciler
+            // takes its "history unreachable → running" path and never gives up on a
+            // prompt whose result might just be temporarily unreadable (codex P1). A
+            // clean 200 with no entry for this id is the real absence → return null.
+            if (!res || !res.ok) {
+              throw new Error(`/history ${res ? res.status : "unreachable"}`);
+            }
             const j = await res.json();
             return (j && j[promptId]) ?? null;
+          },
+          // Is the prompt still in ComfyUI's /queue (running OR pending)? Absence
+          // from /history is NORMAL for a queued/running prompt — ComfyUI writes
+          // /history only on task_done — so the reconciler must not treat it as
+          // "gone" until /queue also lacks it. Returns true/false definitively, or
+          // null when /queue can't be read (then the reconciler stays conservative
+          // and never gives up). Queue rows are [number, prompt_id, prompt, …].
+          fetchQueued: async (promptId) => {
+            if (typeof api?.fetchApi !== "function") return null;
+            const res = await api.fetchApi("/queue");
+            if (!res || !res.ok) return null;
+            const j = await res.json();
+            const has = (arr) =>
+              Array.isArray(arr) &&
+              arr.some((item) => (Array.isArray(item) ? item[1] === promptId : item?.prompt_id === promptId));
+            return has(j?.queue_running) || has(j?.queue_pending);
           },
           isVideo: isVideoOutput,
         });

--- a/web/js/lib/history-reconcile.js
+++ b/web/js/lib/history-reconcile.js
@@ -143,13 +143,20 @@ export function historyEntryFor(historyJson, promptId) {
   return entry == null ? undefined : entry; // present-but-null ⇒ uncertain
 }
 
-// Extract a row's prompt_id: array rows are `[number, prompt_id, …]` (index 0 a
-// number, index 1 a string), object rows are `{prompt_id: string}`. Anything that
-// doesn't match a recognized shape is malformed ⇒ null (so it can't masquerade as
-// a well-formed, id-absent row and enable a false "definitive absence").
+// Extract a row's prompt_id from a recognized ComfyUI queue-row shape. A genuine
+// array row is `[number(idx), prompt_id(string), prompt(dict), extra?, outputs?]`
+// — the prompt DICT at index 2 must be present, so a TRUNCATED `[number, string]`
+// row is MALFORMED (it must NOT masquerade as a valid id-absent row and enable a
+// false "definitive absence"). An object row must carry a string `prompt_id`.
+// Anything else ⇒ null (malformed).
 function rowPromptId(item) {
   if (Array.isArray(item)) {
-    return typeof item[0] === "number" && typeof item[1] === "string" ? item[1] : null;
+    return typeof item[0] === "number" &&
+      typeof item[1] === "string" &&
+      item[2] !== null &&
+      typeof item[2] === "object"
+      ? item[1]
+      : null;
   }
   if (item && typeof item === "object") {
     return typeof item.prompt_id === "string" ? item.prompt_id : null;

--- a/web/js/lib/history-reconcile.js
+++ b/web/js/lib/history-reconcile.js
@@ -108,6 +108,41 @@ export function queueMembership(queueJson, promptId) {
   return false; // every row well-formed AND id absent ⇒ DEFINITIVE absence
 }
 
+/**
+ * Extract the per-prompt entry from a `GET /history/<id>` response body, applying
+ * the SAME strictness as queueMembership so a give-up needs a positively-confirmed
+ * absence on BOTH sides.
+ *
+ * A well-formed /history response is a plain-object MAP keyed by prompt_id. Only
+ * then can a MISSING key be trusted as a clean absence.
+ *
+ * @param {any} historyJson  Parsed body of `GET /history/<id>`.
+ * @param {string} promptId
+ * @returns {object|null|undefined}
+ *   - the entry object when the map has the id with a usable record (reconciler
+ *     parses it);
+ *   - `null` when the body is a well-formed map that GENUINELY LACKS the id (its
+ *     own key is absent) — a CLEAN ABSENCE, the only history state that can make
+ *     give-up eligible;
+ *   - `undefined` when the body is MALFORMED — `null`, an array, any non-object,
+ *     OR the id's key is PRESENT but its value is null/undefined (a malformed
+ *     present record, NOT confirmed absence) — i.e. UNCERTAIN (the reconciler
+ *     treats undefined as "running", never gives up).
+ */
+export function historyEntryFor(historyJson, promptId) {
+  if (historyJson === null || typeof historyJson !== "object" || Array.isArray(historyJson)) {
+    return undefined; // malformed body ⇒ uncertain, never a clean absence
+  }
+  // Distinguish a GENUINELY ABSENT own key (clean absence ⇒ null) from a PRESENT
+  // key carrying a null/undefined value (a malformed present record ⇒ uncertain).
+  // Only a truly-absent key is give-up eligible (codex P1).
+  if (!Object.prototype.hasOwnProperty.call(historyJson, promptId)) {
+    return null; // key absent ⇒ clean absence
+  }
+  const entry = historyJson[promptId];
+  return entry == null ? undefined : entry; // present-but-null ⇒ uncertain
+}
+
 // Extract a row's prompt_id: array rows are `[number, prompt_id, …]` (index 0 a
 // number, index 1 a string), object rows are `{prompt_id: string}`. Anything that
 // doesn't match a recognized shape is malformed ⇒ null (so it can't masquerade as

--- a/web/js/lib/history-reconcile.js
+++ b/web/js/lib/history-reconcile.js
@@ -82,6 +82,10 @@ export function parseHistoryEntry(entry, { isVideo } = {}) {
  * @returns {boolean|null}  true present · false definitively absent · null uncertain
  */
 export function queueMembership(queueJson, promptId) {
+  // Defensive: a non-coercible lookup id is uncertain (never a definitive absence).
+  // Ingestion normalizes ids to strings, so in practice this is always a string.
+  const wantId = coerceLookupId(promptId);
+  if (wantId === null) return null;
   if (!queueJson || typeof queueJson !== "object") return null;
   const running = queueJson.queue_running;
   const pending = queueJson.queue_pending;
@@ -98,7 +102,7 @@ export function queueMembership(queueJson, promptId) {
         malformed = true;
         continue;
       }
-      if (id === promptId) present = true;
+      if (id === wantId) present = true;
     }
   };
   scan(running);
@@ -130,17 +134,31 @@ export function queueMembership(queueJson, promptId) {
  *     treats undefined as "running", never gives up).
  */
 export function historyEntryFor(historyJson, promptId) {
+  // Defensive: a non-coercible lookup id is UNCERTAIN (undefined ⇒ "running"),
+  // NEVER a clean absence — a give-up must never hinge on an unusable id. Ingestion
+  // normalizes ids to strings, so in practice this is always a string.
+  const wantId = coerceLookupId(promptId);
+  if (wantId === null) return undefined;
   if (historyJson === null || typeof historyJson !== "object" || Array.isArray(historyJson)) {
     return undefined; // malformed body ⇒ uncertain, never a clean absence
   }
   // Distinguish a GENUINELY ABSENT own key (clean absence ⇒ null) from a PRESENT
   // key carrying a null/undefined value (a malformed present record ⇒ uncertain).
   // Only a truly-absent key is give-up eligible (codex P1).
-  if (!Object.prototype.hasOwnProperty.call(historyJson, promptId)) {
+  if (!Object.prototype.hasOwnProperty.call(historyJson, wantId)) {
     return null; // key absent ⇒ clean absence
   }
-  const entry = historyJson[promptId];
+  const entry = historyJson[wantId];
   return entry == null ? undefined : entry; // present-but-null ⇒ uncertain
+}
+
+// Coerce a lookup prompt_id to a comparable STRING (ingestion already normalizes,
+// this is belt-and-suspenders). A string or a finite number coerces; null/
+// undefined/object/array/NaN/etc are non-coercible ⇒ null (uncertain lookup).
+function coerceLookupId(id) {
+  if (typeof id === "string") return id;
+  if (typeof id === "number" && Number.isFinite(id)) return String(id);
+  return null;
 }
 
 // Extract a row's prompt_id from a recognized ComfyUI queue-row shape. A genuine

--- a/web/js/lib/history-reconcile.js
+++ b/web/js/lib/history-reconcile.js
@@ -1,0 +1,65 @@
+// Parse a ComfyUI `/history/<prompt_id>` entry into a terminal completion batch.
+//
+// The run-completion tracker keys delivery on live WS lifecycle events
+// (execution_start → executed → execution_success). If the connection drops
+// while a prompt is in flight, the terminal signal (execution_success) can be
+// MISSED entirely, or the composed completion frame can be dropped by a bridge
+// that's momentarily down — either way the run finishes with NO completion
+// delivered and its status is unknowable (#370).
+//
+// `/history/<prompt_id>` is the authoritative server-side record of a finished
+// prompt: its full `outputs` and a terminal `status`. On reconnect we reconcile
+// each still-pending prompt_id against it to recover the outcome and deliver the
+// completion exactly once. This module owns ONLY the pure parse; the tracker owns
+// the reconcile orchestration (fetch + dedupe + deliver).
+
+/**
+ * @param {object|null} entry  The per-prompt value from `/history/<id>` — i.e.
+ *   `historyResponse[promptId]`, shape `{ outputs:{[nodeId]:{images?,gifs?,videos?}},
+ *   status:{status_str?, completed?} }`. Pass `null` when absent.
+ * @param {object}   [opts]
+ * @param {(m:object)=>boolean} [opts.isVideo]  Classifies an output ref as video
+ *   (else still image), matching the live path's classification.
+ * @returns {null | { terminal:boolean, status:("success"|"error"|"unknown"),
+ *   images:object[], videos:{m:object,nodeId:string}[] }}
+ *   `null` when there's no usable entry.
+ */
+export function parseHistoryEntry(entry, { isVideo } = {}) {
+  if (!entry || typeof entry !== "object") return null;
+
+  const status = entry.status && typeof entry.status === "object" ? entry.status : {};
+  const statusStr = typeof status.status_str === "string" ? status.status_str : null;
+  const completedFlag = status.completed === true;
+
+  // Terminal ONLY when ComfyUI marks the prompt done. `status_str:"error"` is a
+  // terminal failure; `status_str:"success"` or `completed:true` is a terminal
+  // success. Anything else (still running, or an entry without a terminal status)
+  // is NOT reconcilable yet — leave it pending so a later reconnect retries.
+  const isError = statusStr === "error";
+  const isSuccess = !isError && (statusStr === "success" || completedFlag);
+  const terminal = isError || isSuccess;
+
+  const images = [];
+  const videos = [];
+  const outputs = entry.outputs && typeof entry.outputs === "object" ? entry.outputs : {};
+  for (const [nodeId, out] of Object.entries(outputs)) {
+    if (!out || typeof out !== "object") continue;
+    const media = [
+      ...(Array.isArray(out.images) ? out.images : []),
+      ...(Array.isArray(out.gifs) ? out.gifs : []),
+      ...(Array.isArray(out.videos) ? out.videos : []),
+    ];
+    for (const m of media) {
+      if (!m || !m.filename) continue;
+      if (typeof isVideo === "function" && isVideo(m)) videos.push({ m, nodeId: String(nodeId) });
+      else images.push(m);
+    }
+  }
+
+  return {
+    terminal,
+    status: isError ? "error" : isSuccess ? "success" : "unknown",
+    images,
+    videos,
+  };
+}

--- a/web/js/lib/history-reconcile.js
+++ b/web/js/lib/history-reconcile.js
@@ -145,21 +145,27 @@ export function historyEntryFor(historyJson, promptId) {
 
 // Extract a row's prompt_id from a recognized ComfyUI queue-row shape. A genuine
 // array row is `[number(idx), prompt_id(string), prompt(dict), extra?, outputs?]`
-// — the prompt DICT at index 2 must be present, so a TRUNCATED `[number, string]`
-// row is MALFORMED (it must NOT masquerade as a valid id-absent row and enable a
-// false "definitive absence"). An object row must carry a string `prompt_id`.
-// Anything else ⇒ null (malformed).
+// — the prompt DICT at index 2 must be present AND a real object (a truncated
+// `[number, string]` row, or one whose index 2 is an ARRAY/primitive/null, is
+// MALFORMED and must NOT masquerade as a valid id-absent row and enable a false
+// "definitive absence"). An object row must carry a string `prompt_id`. Anything
+// else ⇒ null (malformed).
 function rowPromptId(item) {
   if (Array.isArray(item)) {
-    return typeof item[0] === "number" &&
-      typeof item[1] === "string" &&
-      item[2] !== null &&
-      typeof item[2] === "object"
+    return typeof item[0] === "number" && typeof item[1] === "string" && isPlainObject(item[2])
       ? item[1]
       : null;
   }
-  if (item && typeof item === "object") {
+  // Object-row form `{prompt_id, …}` — NOT an array (arrays handled above), and the
+  // prompt_id must be a string (an array/number/other ⇒ malformed ⇒ null).
+  if (isPlainObject(item)) {
     return typeof item.prompt_id === "string" ? item.prompt_id : null;
   }
   return null;
+}
+
+// A non-null, NON-ARRAY object. Guards the `typeof [] === "object"` gotcha so an
+// array can never pass where a real dict is required (codex P1).
+function isPlainObject(v) {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
 }

--- a/web/js/lib/history-reconcile.js
+++ b/web/js/lib/history-reconcile.js
@@ -63,3 +63,61 @@ export function parseHistoryEntry(entry, { isVideo } = {}) {
     videos,
   };
 }
+
+/**
+ * Is `promptId` present in ComfyUI's `/queue` (running OR pending)?
+ *
+ * STRICT, mirroring the strict-null /history discipline: a definitive "absent"
+ * (`false`) is returned ONLY when BOTH `queue_running` AND `queue_pending` are
+ * well-formed ARRAYS and neither contains the id. If the payload is missing, not
+ * an object, or EITHER field is absent / not an array / malformed, the answer is
+ * UNCERTAIN → `null` (the reconciler then treats the prompt as "running" and never
+ * gives up). Only a positively-confirmed absence permits give-up (codex P1).
+ *
+ * Queue rows are `[number, prompt_id, prompt, extra_data, outputs]`; some builds
+ * use `{prompt_id}` objects — both forms are matched.
+ *
+ * @param {any} queueJson  Parsed body of `GET /queue`.
+ * @param {string} promptId
+ * @returns {boolean|null}  true present · false definitively absent · null uncertain
+ */
+export function queueMembership(queueJson, promptId) {
+  if (!queueJson || typeof queueJson !== "object") return null;
+  const running = queueJson.queue_running;
+  const pending = queueJson.queue_pending;
+  // Both containers MUST be arrays for any trustworthy verdict.
+  if (!Array.isArray(running) || !Array.isArray(pending)) return null;
+  let present = false;
+  let malformed = false;
+  const scan = (arr) => {
+    for (const item of arr) {
+      const id = rowPromptId(item);
+      if (id == null) {
+        // A row we can't read a prompt_id from taints the "absent" verdict — we
+        // can't be sure this row isn't OUR prompt in an unrecognized shape.
+        malformed = true;
+        continue;
+      }
+      if (id === promptId) present = true;
+    }
+  };
+  scan(running);
+  scan(pending);
+  if (present) return true; // a positive match is trustworthy regardless of other rows
+  if (malformed) return null; // some row unreadable ⇒ can't trust "absent" ⇒ uncertain
+  return false; // every row well-formed AND id absent ⇒ DEFINITIVE absence
+}
+
+// Extract a row's prompt_id: array rows are `[number, prompt_id, …]` (index 0 a
+// number, index 1 a string), object rows are `{prompt_id: string}`. Anything that
+// doesn't match a recognized shape is malformed ⇒ null (so it can't masquerade as
+// a well-formed, id-absent row and enable a false "definitive absence").
+function rowPromptId(item) {
+  if (Array.isArray(item)) {
+    return typeof item[0] === "number" && typeof item[1] === "string" ? item[1] : null;
+  }
+  if (item && typeof item === "object") {
+    return typeof item.prompt_id === "string" ? item.prompt_id : null;
+  }
+  return null;
+}

--- a/web/js/lib/queue-rejection.js
+++ b/web/js/lib/queue-rejection.js
@@ -79,9 +79,12 @@ export function buildQueueAcceptResult({ batchCount, promptIds = [], ranToNode =
   // NORMALIZE to strings at this ingestion boundary (drop null/undefined) so the
   // reported prompt_id(s), and everything that later reconciles against them, are
   // string-vs-string — a numeric /prompt id can't slip through as a number (#370).
-  const ids = (Array.isArray(promptIds) ? promptIds : [])
-    .filter((x) => x != null)
-    .map((x) => String(x));
+  // Dedupe AFTER normalization (via Set) so a mixed 0 / "0" batch reports one id.
+  const ids = [
+    ...new Set(
+      (Array.isArray(promptIds) ? promptIds : []).filter((x) => x != null).map((x) => String(x)),
+    ),
+  ];
   return {
     queued: true,
     batch_count: batchCount,

--- a/web/js/lib/queue-rejection.js
+++ b/web/js/lib/queue-rejection.js
@@ -76,7 +76,12 @@ function normalizeNodeErrors(ne) {
  * @param {number|null} [args.ranToNode]      Present for a run-to-node partial run.
  */
 export function buildQueueAcceptResult({ batchCount, promptIds = [], ranToNode = null } = {}) {
-  const ids = Array.isArray(promptIds) ? promptIds.filter((x) => x != null) : [];
+  // NORMALIZE to strings at this ingestion boundary (drop null/undefined) so the
+  // reported prompt_id(s), and everything that later reconciles against them, are
+  // string-vs-string — a numeric /prompt id can't slip through as a number (#370).
+  const ids = (Array.isArray(promptIds) ? promptIds : [])
+    .filter((x) => x != null)
+    .map((x) => String(x));
   return {
     queued: true,
     batch_count: batchCount,

--- a/web/js/lib/queue-rejection.js
+++ b/web/js/lib/queue-rejection.js
@@ -1,0 +1,79 @@
+// Interpret ComfyUI's response to a queue attempt (POST /prompt).
+//
+// ComfyUI rejects a prompt on TWO channels, and the frontend surfaces them very
+// differently:
+//
+//   • Per-node VALIDATION errors → `node_errors` (a map keyed by node id). The
+//     frontend stores these on `app.lastNodeErrors`, so they're readable after
+//     the queue call returns.
+//
+//   • A TOP-LEVEL rejection → `error` (e.g. `{type:"missing_node_type", …}` when
+//     a node has no resolvable class_type, or "prompt outputs failed validation").
+//     `app.queuePrompt` shows this in a DIALOG and then DISCARDS it — it never
+//     lands on `app.lastNodeErrors` (which stays `{}` for a pure top-level
+//     rejection). So a caller that only inspects `lastNodeErrors` sees "no
+//     errors" and wrongly reports `queued:true` for a prompt ComfyUI refused
+//     synchronously (#358). The caller must capture the raw non-200 body's
+//     top-level `error` to see it at all.
+//
+// This module is the pure verdict: given the captured rejection body (if any) and
+// the post-attempt `lastNodeErrors`, decide whether the prompt was REFUSED and
+// with what detail. Returns `null` when the prompt was genuinely accepted (the
+// caller then reports `queued:true`), or a `{queued:false, …}` failure otherwise.
+
+/**
+ * @param {object}   args
+ * @param {object|null} [args.rejection]  Raw body of a non-200 POST /prompt,
+ *   shape `{ error?, node_errors? }`. `null` when the POST returned 200.
+ * @param {object|null} [args.lastNodeErrors]  `app.lastNodeErrors` read AFTER the
+ *   queue attempt (per-node validation errors; `{}`/null when none).
+ * @returns {null | {queued:false, error?:string, error_type?:string, node_errors?:object}}
+ *   `null` ⇒ accepted (report queued). Otherwise the failure to return verbatim.
+ */
+export function summarizePromptRejection({ rejection = null, lastNodeErrors = null } = {}) {
+  const topError = rejection && typeof rejection === "object" ? rejection.error ?? null : null;
+  // Prefer the node_errors carried on the rejection body itself; fall back to
+  // what the frontend stored. Either is authoritative for per-node validation.
+  const nodeErrors =
+    normalizeNodeErrors(rejection && typeof rejection === "object" ? rejection.node_errors : null) ??
+    normalizeNodeErrors(lastNodeErrors);
+
+  // No top-level error AND no per-node errors ⇒ the prompt was accepted.
+  if (!hasTopError(topError) && !nodeErrors) return null;
+
+  const result = { queued: false };
+  if (hasTopError(topError)) {
+    result.error = formatTopError(topError);
+    const type = typeof topError === "object" && topError ? topError.type : null;
+    if (type) result.error_type = String(type);
+  }
+  if (nodeErrors) result.node_errors = nodeErrors;
+  return result;
+}
+
+function hasTopError(err) {
+  if (err == null) return false;
+  if (typeof err === "string") return err.trim().length > 0;
+  if (typeof err === "object") return Object.keys(err).length > 0;
+  return Boolean(err);
+}
+
+function normalizeNodeErrors(ne) {
+  if (ne && typeof ne === "object" && !Array.isArray(ne) && Object.keys(ne).length) return ne;
+  return null;
+}
+
+/** Human-readable one-liner for a top-level rejection object. */
+export function formatTopError(err) {
+  if (err == null) return "prompt rejected";
+  if (typeof err === "string") return err;
+  if (typeof err === "object") {
+    const msg =
+      (typeof err.message === "string" && err.message) ||
+      (typeof err.type === "string" && err.type) ||
+      "prompt rejected";
+    const details = typeof err.details === "string" && err.details ? ` (${err.details})` : "";
+    return `${msg}${details}`;
+  }
+  return String(err);
+}

--- a/web/js/lib/queue-rejection.js
+++ b/web/js/lib/queue-rejection.js
@@ -63,6 +63,29 @@ function normalizeNodeErrors(ne) {
   return null;
 }
 
+/**
+ * Build the ACCEPT result for a queued run. Surfaces the queued prompt_id(s) so
+ * the agent can correlate/track the run — #370 reconciliation and mcp#531
+ * (panel_run must return the prompt_id, even when a render is already running)
+ * both depend on this. `prompt_id` is the first accepted id; `prompt_ids` is only
+ * added for a batch that queued more than one.
+ *
+ * @param {object} args
+ * @param {number} args.batchCount
+ * @param {(string|null)[]} [args.promptIds]  Accepted prompt_ids, in queue order.
+ * @param {number|null} [args.ranToNode]      Present for a run-to-node partial run.
+ */
+export function buildQueueAcceptResult({ batchCount, promptIds = [], ranToNode = null } = {}) {
+  const ids = Array.isArray(promptIds) ? promptIds.filter((x) => x != null) : [];
+  return {
+    queued: true,
+    batch_count: batchCount,
+    ...(ids.length ? { prompt_id: ids[0] } : {}),
+    ...(ids.length > 1 ? { prompt_ids: [...ids] } : {}),
+    ...(ranToNode != null ? { ran_to_node: ranToNode } : {}),
+  };
+}
+
 /** Human-readable one-liner for a top-level rejection object. */
 export function formatTopError(err) {
   if (err == null) return "prompt rejected";

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -63,11 +63,14 @@ export const NO_PROMPT_KEY = "__no_prompt__";
  */
 export function createRunCompletionTracker({
   onFlush,
+  onReconcileError,
   now = () => Date.now(),
   setTimer = (fn, ms) => setTimeout(fn, ms),
   clearTimer = (t) => clearTimeout(t),
   debounceMs = 1500,
   maxRearms = 40,
+  reconcileRetryMs = 3000,
+  maxReconcileRetries = 5,
 } = {}) {
   if (typeof onFlush !== "function") {
     throw new TypeError("createRunCompletionTracker requires an onFlush callback");
@@ -93,6 +96,14 @@ export function createRunCompletionTracker({
   // Far beyond any realistic WS-replay-after-reconnect delay, so pruning an entry
   // older than this can never re-open the double-delivery window it guards.
   const deliveredTtlMs = 10 * 60 * 1000;
+  // #370 P1-3: reconnect only fires reconcile on its EDGE. If `/history` is
+  // transiently unavailable at that instant (503/empty while the server catches
+  // up), a run whose ENTIRE lifecycle happened during the drop would be stranded
+  // until the next reconnect that may never come. So a transient/non-terminal
+  // reconcile result schedules a bounded self-repolling retry that delivers once
+  // /history turns terminal — still exactly once, via the same `delivered` fence.
+  const retryTimers = new Map(); // key -> timer
+  const retryCounts = new Map(); // key -> attempts already made
 
   // Pending is a RECOVERY LEDGER, not a debounce cache: it holds exactly the runs
   // whose completion has NOT been confirmed delivered. Every entry is removed the
@@ -148,7 +159,15 @@ export function createRunCompletionTracker({
     delivered.delete(k); // re-insert at the end so the map stays in delivery order
     delivered.set(k, now());
     pending.delete(k);
+    clearReconcileRetry(k); // a delivery (any path) cancels a scheduled /history retry
     scheduleDeliveredPrune(); // ensure idle fences also age out
+  }
+
+  function clearReconcileRetry(k) {
+    const t = retryTimers.get(k);
+    if (t != null) clearTimer(t);
+    retryTimers.delete(k);
+    retryCounts.delete(k);
   }
 
   function markStart(id) {
@@ -222,10 +241,110 @@ export function createRunCompletionTracker({
     return buf;
   }
 
+  // Reconcile ONE pending prompt against `/history`. Idempotent: a no-op (returns
+  // null) if the prompt was resolved (delivered/removed) meanwhile, incl. across
+  // the fetch await (TOCTOU). Delivers a terminal SUCCESS via onFlush exactly
+  // once. Returns a status row; `retriable:true` means the outcome isn't known
+  // yet (transient /history miss or still-running) so the caller should schedule
+  // a retry rather than strand it.
+  async function reconcileKey(promptId, fetchHistory, isVideo) {
+    const k = key(promptId);
+    if (delivered.has(k) || !pending.has(k)) return null;
+    let entry = null;
+    let fetchThrew = false;
+    try {
+      entry = await fetchHistory(promptId);
+    } catch {
+      fetchThrew = true;
+    }
+    // Re-check AFTER the await: a live execution_success/error may have delivered
+    // and retired this prompt while /history was in flight — never double-deliver.
+    if (delivered.has(k) || !pending.has(k)) return null;
+    if (fetchThrew) return { promptId, status: "unknown", retriable: true };
+    const parsed = parseHistoryEntry(entry, { isVideo });
+    if (!parsed) return { promptId, status: "unknown", retriable: true }; // 503/empty
+    if (!parsed.terminal) return { promptId, status: "running", retriable: true };
+    // Terminal. Retire ALL live state for this key so a stale partial buffer (from
+    // pre-drop `executed` events) can't double-deliver later, and mark it delivered
+    // BEFORE onFlush so a concurrent reconcile can't race it.
+    const buf = buffers.get(k);
+    if (buf?.timer) clearTimer(buf.timer);
+    buffers.delete(k);
+    active.delete(k);
+    const startTs = starts.get(k);
+    starts.delete(k);
+    markDelivered(k); // also clears any scheduled retry for this key
+    if (parsed.status === "error") {
+      // Deliver the terminal error through the SAME hook whether we're in the
+      // reconcile loop OR a scheduled retry — otherwise a transient /history miss
+      // that later resolves to an error (only discovered by a retry) would fence
+      // the prompt but NEVER surface a run_error to the agent (codex P1). The hook
+      // owns frame delivery (+ mute/re-pend); the returned row is for diagnostics.
+      if (typeof onReconcileError === "function") {
+        try {
+          onReconcileError({ promptId });
+        } catch {
+          /* presentation error must never wedge reconciliation */
+        }
+      }
+      return { promptId, status: "error" };
+    }
+    const hasBatch = parsed.images.length > 0 || parsed.videos.length > 0;
+    if (hasBatch) {
+      const durationMs = startTs != null ? now() - startTs : null;
+      onFlush({
+        key: k,
+        promptId,
+        images: parsed.images,
+        videos: parsed.videos,
+        durationMs,
+        finishedAt: now(),
+        reconciled: true,
+      });
+    }
+    return { promptId, status: "success", delivered: hasBatch };
+  }
+
+  // Schedule a bounded, self-repolling retry for a prompt whose /history is not yet
+  // terminal (P1-3). Each attempt re-runs reconcileKey; it stops the instant the
+  // outcome is delivered, the prompt is otherwise resolved, or the attempt budget
+  // is exhausted (then it waits for the next reconnect edge). Uses the injected
+  // timer so it's deterministic under test.
+  function scheduleReconcileRetry(promptId, fetchHistory, isVideo) {
+    const k = key(promptId);
+    if (k === NO_PROMPT_KEY) return; // id-less runs aren't reconcilable
+    if (delivered.has(k) || !pending.has(k)) {
+      clearReconcileRetry(k);
+      return;
+    }
+    if (retryTimers.has(k)) return; // one retry in flight per key
+    if ((retryCounts.get(k) ?? 0) >= maxReconcileRetries) return; // budget spent
+    const timer = setTimer(async () => {
+      retryTimers.delete(k);
+      retryCounts.set(k, (retryCounts.get(k) ?? 0) + 1);
+      if (delivered.has(k) || !pending.has(k)) {
+        clearReconcileRetry(k);
+        return;
+      }
+      const row = await reconcileKey(promptId, fetchHistory, isVideo);
+      if (row && row.retriable) scheduleReconcileRetry(promptId, fetchHistory, isVideo);
+      else clearReconcileRetry(k);
+    }, reconcileRetryMs);
+    retryTimers.set(k, timer);
+  }
+
   return {
     /** ComfyUI `execution_start` — authoritative run-start for a prompt. */
     onExecutionStart(id) {
       const k = key(id);
+      // Idempotency fence (P1-2): a late / replayed execution_start for an ALREADY-
+      // DELIVERED prompt must be IGNORED — it must not run the sequential-flush
+      // below, which would truncate a DIFFERENT, currently-active prompt's buffer
+      // (delivering it partial) and clear active, losing that live run's final
+      // output (#293 buffering regression). A delivered prompt has already been
+      // completed; a stray "it's starting" for it is stale noise. NO_PROMPT_KEY is
+      // never in `delivered`, so id-less runs always proceed.
+      if (delivered.has(k)) return;
       // Runs are sequential: a new run beginning means EVERY prior run has ended
       // (even one whose end signal we missed). Flush every existing buffer under
       // ITS OWN key/timing first, so an older buffer — including a legacy
@@ -395,67 +514,27 @@ export function createRunCompletionTracker({
       const summary = [];
       pruneDeliveredFence(); // reconnect is a natural sweep point for old fences
       if (typeof fetchHistory !== "function") return summary;
-      for (const [k, info] of [...pending.entries()]) {
-        if (delivered.has(k)) {
-          pending.delete(k);
-          continue;
-        }
+      for (const [, info] of [...pending.entries()]) {
         const promptId = info.promptId;
         if (promptId == null) continue;
-        let entry = null;
-        try {
-          entry = await fetchHistory(promptId);
-        } catch {
-          // A live lifecycle event may have delivered+retired this prompt while
-          // we awaited /history — don't emit an "unknown" for an already-resolved
-          // run (TOCTOU across the await).
-          if (delivered.has(k) || !pending.has(k)) continue;
-          summary.push({ promptId, status: "unknown" });
-          continue; // leave pending — a later reconnect can retry
+        const row = await reconcileKey(promptId, fetchHistory, isVideo);
+        if (!row) continue; // resolved by a live event meanwhile — nothing to report
+        const clean = { promptId: row.promptId, status: row.status };
+        if (row.delivered !== undefined) clean.delivered = row.delivered;
+        summary.push(clean);
+        // A not-yet-terminal outcome (transient /history miss OR still running)
+        // must not be stranded: schedule a bounded retry that delivers once it
+        // turns terminal, instead of waiting for a reconnect edge that may never
+        // come again (P1-3). A terminal outcome cancels any prior retry. This
+        // reconcile call is itself a fresh episode (a reconnect edge / explicit
+        // poll), so reset the retry budget first — a prompt stranded by one
+        // episode's exhausted budget gets a fresh set of attempts on the next.
+        if (row.retriable) {
+          retryCounts.delete(key(promptId));
+          scheduleReconcileRetry(promptId, fetchHistory, isVideo);
+        } else {
+          clearReconcileRetry(key(promptId));
         }
-        // Re-check AFTER the await: if a live `execution_success`/`execution_error`
-        // delivered and retired this prompt while /history was in flight, deliver
-        // nothing here — otherwise we'd emit the same batch or run_error twice
-        // (codex P1, reconcile TOCTOU).
-        if (delivered.has(k) || !pending.has(k)) continue;
-        const parsed = parseHistoryEntry(entry, { isVideo });
-        if (!parsed) {
-          summary.push({ promptId, status: "unknown" });
-          continue; // leave pending
-        }
-        if (!parsed.terminal) {
-          summary.push({ promptId, status: "running" });
-          continue; // still in flight — the live lifecycle will complete it
-        }
-        // Terminal. Retire ALL live state for this key so a stale partial buffer
-        // (from the pre-drop `executed` events) can never double-deliver later,
-        // and mark it delivered BEFORE onFlush so a concurrent reconcile can't
-        // race it.
-        const buf = buffers.get(k);
-        if (buf?.timer) clearTimer(buf.timer);
-        buffers.delete(k);
-        active.delete(k);
-        const startTs = starts.get(k);
-        starts.delete(k);
-        markDelivered(k);
-        if (parsed.status === "error") {
-          summary.push({ promptId, status: "error" });
-          continue; // no batch for a failed run (mirrors onExecutionFailed)
-        }
-        const hasBatch = parsed.images.length > 0 || parsed.videos.length > 0;
-        if (hasBatch) {
-          const durationMs = startTs != null ? now() - startTs : null;
-          onFlush({
-            key: k,
-            promptId,
-            images: parsed.images,
-            videos: parsed.videos,
-            durationMs,
-            finishedAt: now(),
-            reconciled: true,
-          });
-        }
-        summary.push({ promptId, status: "success", delivered: hasBatch });
       }
       return summary;
     },

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -138,18 +138,28 @@ export function createRunCompletionTracker({
     if (!pending.has(k)) pending.set(k, { promptId: id, at: now() });
   }
 
-  // Drop every entry older than the TTL from BOTH fences. Each is kept in strict
-  // last-touched order (setters re-insert, below), so the expired entries are
-  // always a prefix — stop at the first fresh one. O(number actually pruned).
-  function pruneFence(map, cutoff) {
+  // Drop entries older than the TTL. Each fence is kept in strict last-touched
+  // order (setters re-insert, below); an entry the `retain` predicate keeps is
+  // skipped (not deleted) but scanning continues, and we still stop at the first
+  // FRESH entry (recency order). O(scanned) — bounded by the retained prefix +
+  // one fresh entry.
+  function pruneFence(map, cutoff, retain) {
     for (const [dk, at] of map) {
       if (at >= cutoff) break;
+      if (retain && retain(dk)) continue; // still needed — do NOT age it out
       map.delete(dk);
     }
   }
   function pruneFences() {
     const cutoff = now() - deliveredTtlMs;
-    pruneFence(terminal, cutoff);
+    // NEVER age out a `terminal` replay fence while its run is STILL PENDING
+    // recovery. A bridge-down completion can stay pending well past the TTL (long
+    // outage); pruning its fence would strip the replay guard out from under a
+    // still-pending prompt, and a later replayed execution_start for it would run
+    // the sequential-start loop and clobber a DIFFERENT active run's buffer (codex
+    // P1). The fence is refreshed when the run is finally delivered, then ages
+    // normally; a `delivered` entry is never in `pending`, so it needs no guard.
+    pruneFence(terminal, cutoff, (k) => pending.has(k));
     pruneFence(delivered, cutoff);
   }
 

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -64,6 +64,7 @@ export const NO_PROMPT_KEY = "__no_prompt__";
 export function createRunCompletionTracker({
   onFlush,
   onReconcileError,
+  onReconcileGiveUp,
   now = () => Date.now(),
   setTimer = (fn, ms) => setTimeout(fn, ms),
   clearTimer = (t) => clearTimeout(t),
@@ -350,11 +351,35 @@ export function createRunCompletionTracker({
     return { promptId, status: "success", delivered: hasBatch };
   }
 
+  // GIVE UP on a prompt whose outcome can't be confirmed after the retry budget is
+  // spent (P1 memory leak). Without this, a prompt whose /history stays ABSENT
+  // (cancelled / disconnected while queued) would sit in `pending` forever — and
+  // because the fence prune deliberately RETAINS a terminal fence while its run is
+  // pending, both `pending` and `terminal` would grow without bound. Evicting the
+  // entry (once, with a one-time "couldn't confirm — safe to requeue" notice) keeps
+  // the ledger bounded to the live queue depth + in-flight retries; the terminal
+  // fence we stamp here is then no longer pinned, so it ages out normally.
+  function giveUpReconcile(promptId) {
+    const k = key(promptId);
+    clearReconcileRetry(k);
+    pending.delete(k); // EVICT — bounds the ledger
+    markTerminal(promptId); // fence any stray late execution_start; ages out (not pinned)
+    if (typeof onReconcileGiveUp === "function") {
+      try {
+        onReconcileGiveUp({ promptId });
+      } catch {
+        /* presentation error must never wedge reconciliation */
+      }
+    }
+  }
+
   // Schedule a bounded, self-repolling retry for a prompt whose /history is not yet
   // terminal (P1-3). Each attempt re-runs reconcileKey; it stops the instant the
-  // outcome is delivered, the prompt is otherwise resolved, or the attempt budget
-  // is exhausted (then it waits for the next reconnect edge). Uses the injected
-  // timer so it's deterministic under test.
+  // outcome is delivered or the prompt is otherwise resolved. When the attempt
+  // budget is spent WITHOUT a terminal outcome: an UNKNOWN (/history absent —
+  // couldn't even find it) is GIVEN UP + evicted so the ledger stays bounded, while
+  // a RUNNING render (confirmably in progress) is left pending for the live path /
+  // next reconnect edge. Uses the injected timer so it's deterministic under test.
   function scheduleReconcileRetry(promptId, fetchHistory, isVideo) {
     const k = key(promptId);
     if (k === NO_PROMPT_KEY) return; // id-less runs aren't reconcilable
@@ -366,14 +391,24 @@ export function createRunCompletionTracker({
     if ((retryCounts.get(k) ?? 0) >= maxReconcileRetries) return; // budget spent
     const timer = setTimer(async () => {
       retryTimers.delete(k);
-      retryCounts.set(k, (retryCounts.get(k) ?? 0) + 1);
+      const attempts = (retryCounts.get(k) ?? 0) + 1;
+      retryCounts.set(k, attempts);
       if (delivered.has(k) || !pending.has(k)) {
         clearReconcileRetry(k);
         return;
       }
       const row = await reconcileKey(promptId, fetchHistory, isVideo);
-      if (row && row.retriable) scheduleReconcileRetry(promptId, fetchHistory, isVideo);
-      else clearReconcileRetry(k);
+      if (!row || !row.retriable) {
+        clearReconcileRetry(k); // resolved (terminal / delivered)
+        return;
+      }
+      if (attempts >= maxReconcileRetries) {
+        // Budget exhausted this episode without a terminal outcome.
+        if (row.status === "unknown") giveUpReconcile(promptId); // absent ⇒ evict
+        else clearReconcileRetry(k); // still "running" ⇒ leave pending, stop polling
+        return;
+      }
+      scheduleReconcileRetry(promptId, fetchHistory, isVideo);
     }, reconcileRetryMs);
     retryTimers.set(k, timer);
   }

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -86,12 +86,26 @@ export function createRunCompletionTracker({
   // frame silently dropped by sendFrame), the run stays pending and can be
   // recovered on reconnect by reconciling its prompt_id against `/history`.
   const pending = new Map(); // key -> { promptId, at }  (real prompt_ids only)
-  // `delivered` is the IDEMPOTENCY FENCE: keys whose completion has been delivered
-  // (live or via reconcile). It exists to suppress a DUPLICATE from a late WS
-  // lifecycle replay for an already-delivered prompt (a reconnect replays the
-  // buffered executed/execution_success within seconds). key -> deliveredAt so the
-  // fence can be pruned by AGE — only once no late event could still arrive — which
-  // bounds memory WITHOUT ever evicting a fence that's still doing its job.
+  // Two SEPARATE fences, deliberately distinct (codex P1):
+  //
+  //  • `terminal` — the LIFECYCLE REPLAY fence. A key is here once the prompt has
+  //    reached a terminal outcome (success/error/reconcile), and it STAYS here even
+  //    if delivery of that outcome is later re-pended for retry. It suppresses a
+  //    late/replayed WS lifecycle event (execution_start / executed /
+  //    execution_success / execution_error) from re-opening a completed run — which
+  //    matters most for execution_start, whose sequential-flush would otherwise
+  //    truncate a DIFFERENT currently-active prompt's buffer (#293/#370).
+  //
+  //  • `delivered` — the DELIVERY / RECONCILE-dedup fence. A key is here once its
+  //    completion frame is CONFIRMED delivered. markUndelivered REMOVES it (only
+  //    this one) so a bridge-down completion is re-reconciled and re-delivered.
+  //
+  // Conflating the two (the previous single `delivered` map) meant markUndelivered
+  // deleted the replay fence too, so a re-pended prompt's late execution_start was
+  // no longer fenced and clobbered a live run. Keeping them separate closes that.
+  // Both are `key -> ts` so they can be pruned by AGE (never evicting a fence still
+  // doing its job) to bound memory.
+  const terminal = new Map();
   const delivered = new Map();
   // Far beyond any realistic WS-replay-after-reconnect delay, so pruning an entry
   // older than this can never re-open the double-delivery window it guards.
@@ -118,49 +132,70 @@ export function createRunCompletionTracker({
   function trackPending(id) {
     if (id == null) return; // no prompt_id ⇒ not reconcilable against /history
     const k = key(id);
-    if (delivered.has(k)) return;
+    // A prompt that already reached terminal must not be re-pended by a stray
+    // liveness signal — its pending state is owned by markDelivered/markUndelivered.
+    if (terminal.has(k)) return;
     if (!pending.has(k)) pending.set(k, { promptId: id, at: now() });
   }
 
-  // Drop every fence older than the TTL. `delivered` is kept in strict
-  // last-delivered order (markDelivered re-inserts, below), so the expired entries
-  // are always a prefix — stop at the first fresh one. O(number actually pruned),
-  // i.e. each entry is visited once over its lifetime.
-  function pruneDeliveredFence() {
-    const cutoff = now() - deliveredTtlMs;
-    for (const [dk, at] of delivered) {
+  // Drop every entry older than the TTL from BOTH fences. Each is kept in strict
+  // last-touched order (setters re-insert, below), so the expired entries are
+  // always a prefix — stop at the first fresh one. O(number actually pruned).
+  function pruneFence(map, cutoff) {
+    for (const [dk, at] of map) {
       if (at >= cutoff) break;
-      delivered.delete(dk);
+      map.delete(dk);
     }
+  }
+  function pruneFences() {
+    const cutoff = now() - deliveredTtlMs;
+    pruneFence(terminal, cutoff);
+    pruneFence(delivered, cutoff);
   }
 
   // Age fences out even when NO further completion arrives (idle): a single
   // self-disarming sweep that re-arms only while fences remain, so memory is
   // bounded without a perpetual timer.
-  let deliveredPruneTimer = null;
-  function scheduleDeliveredPrune() {
-    if (deliveredPruneTimer != null) return;
-    deliveredPruneTimer = setTimer(() => {
-      deliveredPruneTimer = null;
-      pruneDeliveredFence();
-      if (delivered.size) scheduleDeliveredPrune();
+  let fencePruneTimer = null;
+  function scheduleFencePrune() {
+    if (fencePruneTimer != null) return;
+    fencePruneTimer = setTimer(() => {
+      fencePruneTimer = null;
+      pruneFences();
+      if (terminal.size || delivered.size) scheduleFencePrune();
     }, deliveredTtlMs);
+  }
+
+  // Re-insert a key at the end of a fence map so it stays in strict recency order.
+  function touchFence(map, k) {
+    map.delete(k);
+    map.set(k, now());
+  }
+
+  // Record that `id` reached a TERMINAL outcome — the replay fence. Set whether or
+  // not its delivery is confirmed, and NEVER cleared by markUndelivered, so a late
+  // execution_start for it stays fenced across a re-pend (codex P1).
+  function markTerminal(id) {
+    const k = key(id);
+    if (k === NO_PROMPT_KEY) return; // reused key — never fence id-less runs (#224)
+    pruneFences();
+    touchFence(terminal, k);
+    scheduleFencePrune();
   }
 
   function markDelivered(id) {
     const k = key(id);
     // NO_PROMPT_KEY is a SHARED, reused key for every id-less run — it is never
-    // reconcilable and must never enter the `delivered` fence, or the first id-less
-    // run would permanently block all later ones (back-to-back id-less runs must
-    // still each deliver, #224). It's also never in `pending` (trackPending skips
-    // null ids), so there is nothing to retire here for it.
+    // reconcilable and must never enter either fence, or the first id-less run
+    // would permanently block all later ones (back-to-back id-less runs must still
+    // each deliver, #224). It's also never in `pending` (trackPending skips null
+    // ids), so there is nothing to retire here for it.
     if (k === NO_PROMPT_KEY) return;
-    pruneDeliveredFence(); // trim expired fences on every delivery (active path)
-    delivered.delete(k); // re-insert at the end so the map stays in delivery order
-    delivered.set(k, now());
+    // A confirmed delivery IS a terminal outcome — set BOTH fences.
+    markTerminal(id);
+    touchFence(delivered, k);
     pending.delete(k);
     clearReconcileRetry(k); // a delivery (any path) cancels a scheduled /history retry
-    scheduleDeliveredPrune(); // ensure idle fences also age out
   }
 
   function clearReconcileRetry(k) {
@@ -337,14 +372,15 @@ export function createRunCompletionTracker({
     /** ComfyUI `execution_start` — authoritative run-start for a prompt. */
     onExecutionStart(id) {
       const k = key(id);
-      // Idempotency fence (P1-2): a late / replayed execution_start for an ALREADY-
-      // DELIVERED prompt must be IGNORED — it must not run the sequential-flush
-      // below, which would truncate a DIFFERENT, currently-active prompt's buffer
-      // (delivering it partial) and clear active, losing that live run's final
-      // output (#293 buffering regression). A delivered prompt has already been
-      // completed; a stray "it's starting" for it is stale noise. NO_PROMPT_KEY is
-      // never in `delivered`, so id-less runs always proceed.
-      if (delivered.has(k)) return;
+      // Idempotency fence (P1-2, codex): a late / replayed execution_start for a
+      // prompt that already reached TERMINAL must be IGNORED — it must not run the
+      // sequential-flush below, which would truncate a DIFFERENT, currently-active
+      // prompt's buffer (delivering it partial) and clear active, losing that live
+      // run's final output (#293 buffering regression). This fences on `terminal`,
+      // NOT `delivered`, so it holds even when the terminal prompt's delivery is
+      // being RE-PENDED for retry (markUndelivered clears `delivered` but not
+      // `terminal`). NO_PROMPT_KEY is never in `terminal`, so id-less runs proceed.
+      if (terminal.has(k)) return;
       // Runs are sequential: a new run beginning means EVERY prior run has ended
       // (even one whose end signal we missed). Flush every existing buffer under
       // ITS OWN key/timing first, so an older buffer — including a legacy
@@ -373,11 +409,12 @@ export function createRunCompletionTracker({
      */
     onExecuted(id, { images = [], videos = [] } = {}) {
       if (!images.length && !videos.length) return;
-      // Idempotency fence: if this prompt was ALREADY delivered (a /history
+      // Idempotency fence: if this prompt already reached TERMINAL (a /history
       // reconcile beat the live WS, which then replayed a late `executed`), do NOT
       // re-buffer it — otherwise the trailing execution_success would flush a
-      // second, duplicate completion for the same run (codex P1).
-      if (delivered.has(key(id))) return;
+      // second, duplicate completion for the same run (codex P1). Fences on
+      // `terminal` so it still holds if delivery is being re-pended for retry.
+      if (terminal.has(key(id))) return;
       // Fallback render-start if execution_start was missed (no-op otherwise).
       // Does NOT mark active: `executing(node)` is the run-liveness signal, so an
       // output with no start AND no executing(node) is treated as an orphan.
@@ -394,9 +431,11 @@ export function createRunCompletionTracker({
     onExecutionSuccess(id) {
       const k = key(id);
       active.delete(k);
-      // Already delivered (e.g. via reconcile) — a late success must not deliver
-      // again. Just retire any residual live state (codex P1 idempotency fence).
-      if (delivered.has(k)) {
+      // Already terminal (e.g. delivered via reconcile, even if its delivery is
+      // being re-pended) — a late/replayed success must not re-flush or re-mark
+      // (which would clear the re-pend and lose the retry). Just retire residual
+      // live state (codex P1 idempotency fence; `terminal`, not `delivered`).
+      if (terminal.has(k)) {
         starts.delete(k);
         return;
       }
@@ -417,10 +456,10 @@ export function createRunCompletionTracker({
       if (buf?.timer) clearTimer(buf.timer);
       buffers.delete(k);
       starts.delete(k);
-      // If already delivered (reconcile surfaced this run's outcome), don't touch
-      // pending/delivered again — the caller uses wasDelivered() BEFORE calling
+      // If already terminal (reconcile surfaced this run's outcome), don't re-mark
+      // (which would clear a re-pend). The caller uses wasTerminal() BEFORE calling
       // this to suppress a duplicate run_error frame (codex P1).
-      if (!delivered.has(k)) markDelivered(k);
+      if (!terminal.has(k)) markDelivered(k);
     },
 
     /**
@@ -448,20 +487,21 @@ export function createRunCompletionTracker({
      */
     onExecutingNode(id) {
       if (id == null) return;
-      // A late `executing` for an already-delivered run must not re-open it.
-      if (delivered.has(key(id))) return;
+      // A late `executing` for an already-terminal run must not re-open it.
+      if (terminal.has(key(id))) return;
       markStart(id);
       active.add(key(id));
       trackPending(id);
     },
 
     /**
-     * Has this prompt's completion already been delivered (via live success or a
-     * /history reconcile)? The caller checks this BEFORE surfacing a live
-     * execution_error so a reconciled outcome isn't duplicated by a late WS event.
+     * Has this prompt already reached a TERMINAL outcome (via live success/error or
+     * a /history reconcile)? The caller checks this BEFORE surfacing a live
+     * execution_error so a reconciled/completed outcome isn't duplicated by a late
+     * WS event — true even while its delivery is being re-pended for retry.
      */
-    wasDelivered(id) {
-      return delivered.has(key(id));
+    wasTerminal(id) {
+      return terminal.has(key(id));
     },
 
     /**
@@ -492,7 +532,13 @@ export function createRunCompletionTracker({
     markUndelivered(id) {
       if (id == null) return;
       const k = key(id);
+      // Clear ONLY the delivery/reconcile fence so the outcome is re-reconciled and
+      // re-delivered. The `terminal` REPLAY fence is deliberately LEFT intact: the
+      // run already completed, so a late/replayed execution_start for it must stay
+      // fenced (or it would clobber a different live run's buffer — codex P1). Also
+      // cancel any in-flight retry so the re-pend restarts cleanly on the next edge.
       delivered.delete(k);
+      clearReconcileRetry(k);
       if (!pending.has(k)) pending.set(k, { promptId: id, at: now() });
     },
 
@@ -512,7 +558,7 @@ export function createRunCompletionTracker({
      */
     async reconcile({ fetchHistory, isVideo } = {}) {
       const summary = [];
-      pruneDeliveredFence(); // reconnect is a natural sweep point for old fences
+      pruneFences(); // reconnect is a natural sweep point for old fences
       if (typeof fetchHistory !== "function") return summary;
       for (const [, info] of [...pending.entries()]) {
         const promptId = info.promptId;
@@ -550,5 +596,6 @@ export function createRunCompletionTracker({
     _starts: starts,
     _pending: pending,
     _delivered: delivered,
+    _terminal: terminal,
   };
 }

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -362,6 +362,16 @@ export function createRunCompletionTracker({
   function giveUpReconcile(promptId) {
     const k = key(promptId);
     clearReconcileRetry(k);
+    // Retire ALL live state for this key, exactly as a terminal outcome would.
+    // Otherwise a stale PARTIAL buffer left from pre-drop `executed` events would
+    // be flushed by the NEXT different execution_start's sequential-flush — emitting
+    // stale output that contradicts "status unknown", and leaking the buffered media
+    // until then (codex P1).
+    const buf = buffers.get(k);
+    if (buf?.timer) clearTimer(buf.timer);
+    buffers.delete(k);
+    active.delete(k);
+    starts.delete(k);
     pending.delete(k); // EVICT — bounds the ledger
     markTerminal(promptId); // fence any stray late execution_start; ages out (not pinned)
     if (typeof onReconcileGiveUp === "function") {
@@ -373,13 +383,31 @@ export function createRunCompletionTracker({
     }
   }
 
-  // Schedule a bounded, self-repolling retry for a prompt whose /history is not yet
-  // terminal (P1-3). Each attempt re-runs reconcileKey; it stops the instant the
-  // outcome is delivered or the prompt is otherwise resolved. When the attempt
-  // budget is spent WITHOUT a terminal outcome: an UNKNOWN (/history absent —
-  // couldn't even find it) is GIVEN UP + evicted so the ledger stays bounded, while
-  // a RUNNING render (confirmably in progress) is left pending for the live path /
-  // next reconnect edge. Uses the injected timer so it's deterministic under test.
+  // Decide what to do with a reconcileKey result. Terminal/resolved ⇒ stop. Still
+  // retriable with budget left ⇒ schedule another poll. Budget SPENT this episode
+  // without a terminal outcome ⇒ an UNKNOWN (/history absent — couldn't even find
+  // it) is GIVEN UP + evicted so the ledger stays bounded, while a RUNNING render
+  // (confirmably in progress) is left pending for the live path / next reconnect.
+  // Centralizing the decision here makes it fire even when maxReconcileRetries===0
+  // (give up immediately for an absent history) — codex P2.
+  function afterReconcileRow(row, promptId, fetchHistory, isVideo) {
+    const k = key(promptId);
+    if (!row || !row.retriable) {
+      clearReconcileRetry(k); // resolved (terminal / delivered)
+      return;
+    }
+    if ((retryCounts.get(k) ?? 0) >= maxReconcileRetries) {
+      if (row.status === "unknown") giveUpReconcile(promptId); // absent ⇒ evict
+      else clearReconcileRetry(k); // still "running" ⇒ leave pending, stop polling
+      return;
+    }
+    scheduleReconcileRetry(promptId, fetchHistory, isVideo);
+  }
+
+  // Arm one bounded, self-repolling retry for a prompt whose /history is not yet
+  // terminal (P1-3). The budget/give-up decision lives in afterReconcileRow; this
+  // just schedules the next poll. Uses the injected timer so it's deterministic
+  // under test.
   function scheduleReconcileRetry(promptId, fetchHistory, isVideo) {
     const k = key(promptId);
     if (k === NO_PROMPT_KEY) return; // id-less runs aren't reconcilable
@@ -388,27 +416,15 @@ export function createRunCompletionTracker({
       return;
     }
     if (retryTimers.has(k)) return; // one retry in flight per key
-    if ((retryCounts.get(k) ?? 0) >= maxReconcileRetries) return; // budget spent
     const timer = setTimer(async () => {
       retryTimers.delete(k);
-      const attempts = (retryCounts.get(k) ?? 0) + 1;
-      retryCounts.set(k, attempts);
+      retryCounts.set(k, (retryCounts.get(k) ?? 0) + 1);
       if (delivered.has(k) || !pending.has(k)) {
         clearReconcileRetry(k);
         return;
       }
       const row = await reconcileKey(promptId, fetchHistory, isVideo);
-      if (!row || !row.retriable) {
-        clearReconcileRetry(k); // resolved (terminal / delivered)
-        return;
-      }
-      if (attempts >= maxReconcileRetries) {
-        // Budget exhausted this episode without a terminal outcome.
-        if (row.status === "unknown") giveUpReconcile(promptId); // absent ⇒ evict
-        else clearReconcileRetry(k); // still "running" ⇒ leave pending, stop polling
-        return;
-      }
-      scheduleReconcileRetry(promptId, fetchHistory, isVideo);
+      afterReconcileRow(row, promptId, fetchHistory, isVideo);
     }, reconcileRetryMs);
     retryTimers.set(k, timer);
   }
@@ -614,18 +630,14 @@ export function createRunCompletionTracker({
         if (row.delivered !== undefined) clean.delivered = row.delivered;
         summary.push(clean);
         // A not-yet-terminal outcome (transient /history miss OR still running)
-        // must not be stranded: schedule a bounded retry that delivers once it
-        // turns terminal, instead of waiting for a reconnect edge that may never
-        // come again (P1-3). A terminal outcome cancels any prior retry. This
-        // reconcile call is itself a fresh episode (a reconnect edge / explicit
-        // poll), so reset the retry budget first — a prompt stranded by one
-        // episode's exhausted budget gets a fresh set of attempts on the next.
-        if (row.retriable) {
-          retryCounts.delete(key(promptId));
-          scheduleReconcileRetry(promptId, fetchHistory, isVideo);
-        } else {
-          clearReconcileRetry(key(promptId));
-        }
+        // must not be stranded: this reconcile call is a FRESH episode (a reconnect
+        // edge / explicit poll), so reset the retry budget first — a prompt stranded
+        // by one episode's exhausted budget gets a fresh set of attempts on the
+        // next. afterReconcileRow then either schedules a bounded retry, gives up +
+        // evicts an absent-history prompt, or leaves a running one pending (P1-3,
+        // and the memory-leak give-up — fires even when maxReconcileRetries===0).
+        if (row.retriable) retryCounts.delete(key(promptId));
+        afterReconcileRow(row, promptId, fetchHistory, isVideo);
       }
       return summary;
     },

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -76,7 +76,15 @@ export function createRunCompletionTracker({
   if (typeof onFlush !== "function") {
     throw new TypeError("createRunCompletionTracker requires an onFlush callback");
   }
-  const key = (id) => id ?? NO_PROMPT_KEY;
+  // INGESTION-BOUNDARY NORMALIZATION: every prompt_id becomes a STRING the instant
+  // it enters the tracker (a numeric /prompt id, e.g. 7, would otherwise never
+  // `=== "7"` the string ids in /history keys and /queue rows, so a running render
+  // would look absent and be given up — codex P1). Because this is the single
+  // choke-point for map keys AND the stored ledger id, EVERY downstream comparison
+  // (history key lookup, queue row match, fences, delivery) is string-vs-string,
+  // closing the whole number-vs-string class at the source. A null/undefined id
+  // (no real prompt) collapses to the shared NO_PROMPT_KEY.
+  const key = (id) => (id == null ? NO_PROMPT_KEY : String(id));
   const promptIdOf = (k) => (k === NO_PROMPT_KEY ? null : k);
   const buffers = new Map(); // key -> { images: any[], videos: any[], timer, rearms }
   const active = new Set(); // keys ComfyUI currently reports as running
@@ -136,7 +144,9 @@ export function createRunCompletionTracker({
     // A prompt that already reached terminal must not be re-pended by a stray
     // liveness signal — its pending state is owned by markDelivered/markUndelivered.
     if (terminal.has(k)) return;
-    if (!pending.has(k)) pending.set(k, { promptId: id, at: now() });
+    // Store the NORMALIZED string id (k), so reconcile passes a string to
+    // fetchHistory/fetchQueued and every downstream compare stays string-vs-string.
+    if (!pending.has(k)) pending.set(k, { promptId: k, at: now() });
   }
 
   // Drop entries older than the TTL. Each fence is kept in strict last-touched
@@ -641,7 +651,7 @@ export function createRunCompletionTracker({
       // cancel any in-flight retry so the re-pend restarts cleanly on the next edge.
       delivered.delete(k);
       clearReconcileRetry(k);
-      if (!pending.has(k)) pending.set(k, { promptId: id, at: now() });
+      if (!pending.has(k)) pending.set(k, { promptId: k, at: now() }); // normalized string id
     },
 
     /**

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -307,15 +307,24 @@ export function createRunCompletionTracker({
     // and retired this prompt while /history was in flight — never double-deliver.
     if (delivered.has(k) || !pending.has(k)) return null;
 
+    // parseHistoryEntry returns null for null/undefined/non-object entries.
     const parsed = fetchThrew ? null : parseHistoryEntry(entry, { isVideo });
+
+    // ── NON-terminal outcomes (never deliver here; decide retry vs give-up) ──
     if (!parsed || !parsed.terminal) {
-      // NOT terminal in /history. CRITICAL: absence from /history is NORMAL for a
-      // QUEUED or RUNNING prompt — ComfyUI only writes /history on task_done. So an
-      // absent /history must NOT be treated as "gone": consult /queue to tell a
-      // still-in-flight render apart from a genuinely cancelled/removed one, and
-      // NEVER fence/give up a prompt /queue still shows running (codex P1 — it would
-      // drop the live output of a legitimately long render).
-      if (fetchThrew) return { promptId, status: "running", retriable: true }; // /history unreachable ⇒ uncertain, keep polling
+      // /history unreachable (503/threw) ⇒ uncertain; keep polling, never give up.
+      if (fetchThrew) return { promptId, status: "running", retriable: true };
+      // STRICT: only a `null` entry is a clean 200-with-no-entry (give-up eligible
+      // below). ANYTHING else that isn't a terminal record — a present-but-non-
+      // terminal record (status running/pending), a malformed/unparseable record,
+      // OR an unexpected `undefined`/other value from a custom fetchHistory — is
+      // NOT a confirmed clean absence, so treat it as running/uncertain and NEVER
+      // give up (codex P1: it must not be evicted/fenced); keep polling so its live
+      // lifecycle / a later terminal record delivers it.
+      if (entry !== null) return { promptId, status: "running", retriable: true };
+      // entry === null ⇒ CLEANLY ABSENT from /history. Absence is NORMAL for a
+      // QUEUED/RUNNING prompt (ComfyUI writes /history only on task_done), so consult
+      // /queue to tell a still-in-flight render apart from a genuinely gone one.
       let queued = null; // null = couldn't determine; true/false = definitive
       if (typeof fetchQueued === "function") {
         try {
@@ -325,17 +334,15 @@ export function createRunCompletionTracker({
         }
         if (delivered.has(k) || !pending.has(k)) return null; // re-check after 2nd await
       }
-      if (queued === false) {
-        // DEFINITIVELY absent from BOTH /history AND /queue ⇒ genuinely gone
-        // (cancelled / interrupted). Only THIS is give-up eligible.
-        return { promptId, status: "unknown", retriable: true };
-      }
-      // Still queued/running, OR queue membership couldn't be confirmed — either
-      // way keep polling and NEVER give up (a live/uncertain render must not be
-      // fenced or evicted).
+      // DEFINITIVELY absent from BOTH /history (clean null) AND /queue ⇒ genuinely
+      // gone (cancelled / interrupted). This is the ONLY give-up-eligible state.
+      if (queued === false) return { promptId, status: "unknown", retriable: true };
+      // Still queued/running, OR queue membership couldn't be confirmed — keep
+      // polling and NEVER give up (a live/uncertain render must not be evicted).
       return { promptId, status: "running", retriable: true };
     }
-    // Terminal. Retire ALL live state for this key so a stale partial buffer (from
+
+    // ── Terminal. Retire ALL live state for this key so a stale partial buffer (from
     // pre-drop `executed` events) can't double-deliver later, and mark it delivered
     // BEFORE onFlush so a concurrent reconcile can't race it.
     const buf = buffers.get(k);
@@ -387,6 +394,13 @@ export function createRunCompletionTracker({
   // so it ages out normally.
   function giveUpReconcile(promptId) {
     const k = key(promptId);
+    // ONE-TIME ownership claim: two concurrent reconcile()/retry paths can each
+    // return "unknown" for the same gone prompt and both reach here — but only the
+    // FIRST (which still sees it in `pending`) may retire state + fire the notice.
+    // Any later caller finds it already evicted and no-ops, so onReconcileGiveUp
+    // (and the eviction) happen exactly once (codex P1). Synchronous from here on,
+    // so the has→delete claim is atomic.
+    if (!pending.has(k)) return;
     clearReconcileRetry(k);
     // Retire ALL live state for this key, exactly as a terminal outcome would.
     // Otherwise a stale PARTIAL buffer left from pre-drop `executed` events would

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -45,6 +45,8 @@
 // `onFlush` callback, which receives the full, correctly-scoped batch — plus the
 // prompt_id `key` for machine-readable attribution — exactly once per completion.
 
+import { parseHistoryEntry } from "./history-reconcile.js";
+
 export const NO_PROMPT_KEY = "__no_prompt__";
 
 /**
@@ -75,6 +77,79 @@ export function createRunCompletionTracker({
   const buffers = new Map(); // key -> { images: any[], videos: any[], timer, rearms }
   const active = new Set(); // keys ComfyUI currently reports as running
   const starts = new Map(); // key -> start timestamp
+  // #370 reconciliation state. A run is PENDING from its first liveness signal
+  // until its completion is CONFIRMED delivered to the agent. If the connection
+  // drops (WS lost → execution_success missed, OR bridge down → the composed
+  // frame silently dropped by sendFrame), the run stays pending and can be
+  // recovered on reconnect by reconciling its prompt_id against `/history`.
+  const pending = new Map(); // key -> { promptId, at }  (real prompt_ids only)
+  // `delivered` is the IDEMPOTENCY FENCE: keys whose completion has been delivered
+  // (live or via reconcile). It exists to suppress a DUPLICATE from a late WS
+  // lifecycle replay for an already-delivered prompt (a reconnect replays the
+  // buffered executed/execution_success within seconds). key -> deliveredAt so the
+  // fence can be pruned by AGE — only once no late event could still arrive — which
+  // bounds memory WITHOUT ever evicting a fence that's still doing its job.
+  const delivered = new Map();
+  // Far beyond any realistic WS-replay-after-reconnect delay, so pruning an entry
+  // older than this can never re-open the double-delivery window it guards.
+  const deliveredTtlMs = 10 * 60 * 1000;
+
+  // Pending is a RECOVERY LEDGER, not a debounce cache: it holds exactly the runs
+  // whose completion has NOT been confirmed delivered. Every entry is removed the
+  // instant its run reaches a confirmed terminal outcome — execution_success/error
+  // with a delivered frame, or a /history reconcile — so the map is self-limiting
+  // to the (normally ≤1–2) currently-undelivered runs. It is deliberately NOT
+  // size-capped: evicting an entry would permanently forfeit the ONLY record that
+  // lets a bridge-down completion be recovered on reconnect, defeating #370 for
+  // that prompt (codex P1). Entries are tiny ({promptId, at}); a large batch simply
+  // registers each of its accepted prompt_ids and drains them as they finish —
+  // ledger depth mirrors the actual ComfyUI queue depth, which the server bounds.
+  function trackPending(id) {
+    if (id == null) return; // no prompt_id ⇒ not reconcilable against /history
+    const k = key(id);
+    if (delivered.has(k)) return;
+    if (!pending.has(k)) pending.set(k, { promptId: id, at: now() });
+  }
+
+  // Drop every fence older than the TTL. `delivered` is kept in strict
+  // last-delivered order (markDelivered re-inserts, below), so the expired entries
+  // are always a prefix — stop at the first fresh one. O(number actually pruned),
+  // i.e. each entry is visited once over its lifetime.
+  function pruneDeliveredFence() {
+    const cutoff = now() - deliveredTtlMs;
+    for (const [dk, at] of delivered) {
+      if (at >= cutoff) break;
+      delivered.delete(dk);
+    }
+  }
+
+  // Age fences out even when NO further completion arrives (idle): a single
+  // self-disarming sweep that re-arms only while fences remain, so memory is
+  // bounded without a perpetual timer.
+  let deliveredPruneTimer = null;
+  function scheduleDeliveredPrune() {
+    if (deliveredPruneTimer != null) return;
+    deliveredPruneTimer = setTimer(() => {
+      deliveredPruneTimer = null;
+      pruneDeliveredFence();
+      if (delivered.size) scheduleDeliveredPrune();
+    }, deliveredTtlMs);
+  }
+
+  function markDelivered(id) {
+    const k = key(id);
+    // NO_PROMPT_KEY is a SHARED, reused key for every id-less run — it is never
+    // reconcilable and must never enter the `delivered` fence, or the first id-less
+    // run would permanently block all later ones (back-to-back id-less runs must
+    // still each deliver, #224). It's also never in `pending` (trackPending skips
+    // null ids), so there is nothing to retire here for it.
+    if (k === NO_PROMPT_KEY) return;
+    pruneDeliveredFence(); // trim expired fences on every delivery (active path)
+    delivered.delete(k); // re-insert at the end so the map stays in delivery order
+    delivered.set(k, now());
+    pending.delete(k);
+    scheduleDeliveredPrune(); // ensure idle fences also age out
+  }
 
   function markStart(id) {
     const k = key(id);
@@ -124,6 +199,10 @@ export function createRunCompletionTracker({
     starts.delete(k);
     const durationMs = startTs != null ? now() - startTs : null;
     if (!buf.images.length && !buf.videos.length) return;
+    // Optimistically mark delivered so a reconnect-triggered reconcile racing
+    // this flush can't double-deliver the same prompt. If the caller reports the
+    // send FAILED (bridge down), it calls markUndelivered() to re-pend it (#370).
+    markDelivered(k);
     onFlush({
       key: k,
       promptId: promptIdOf(k),
@@ -153,10 +232,19 @@ export function createRunCompletionTracker({
       // __no_prompt__ one from the previous run — can never bleed into, or be
       // misreported as, this new run (#224). A run cannot have buffered output
       // before its own start, so nothing belonging to THIS run is lost here.
+      //
+      // NB: a prior run whose end signal was missed is flushed here with whatever
+      // it buffered — the #224 safe default of "deliver what we have" — because a
+      // missed end is USUALLY a dropped frame on a live connection with no
+      // reconnect (hence no /history reconcile) ever coming. flush() marks it
+      // delivered, so a LATER reconcile for that prompt is correctly a no-op; the
+      // drop-with-reconnect case (where the next run does NOT start before the
+      // reconnect) is still recovered in full by reconcile.
       for (const other of [...buffers.keys()]) flush(other);
       active.clear();
       markStart(id);
       active.add(k);
+      trackPending(id);
     },
 
     /**
@@ -166,10 +254,16 @@ export function createRunCompletionTracker({
      */
     onExecuted(id, { images = [], videos = [] } = {}) {
       if (!images.length && !videos.length) return;
+      // Idempotency fence: if this prompt was ALREADY delivered (a /history
+      // reconcile beat the live WS, which then replayed a late `executed`), do NOT
+      // re-buffer it — otherwise the trailing execution_success would flush a
+      // second, duplicate completion for the same run (codex P1).
+      if (delivered.has(key(id))) return;
       // Fallback render-start if execution_start was missed (no-op otherwise).
       // Does NOT mark active: `executing(node)` is the run-liveness signal, so an
       // output with no start AND no executing(node) is treated as an orphan.
       markStart(id);
+      trackPending(id);
       const k = key(id);
       const buf = ensureBuffer(k);
       if (images.length) buf.images.push(...images);
@@ -181,9 +275,19 @@ export function createRunCompletionTracker({
     onExecutionSuccess(id) {
       const k = key(id);
       active.delete(k);
+      // Already delivered (e.g. via reconcile) — a late success must not deliver
+      // again. Just retire any residual live state (codex P1 idempotency fence).
+      if (delivered.has(k)) {
+        starts.delete(k);
+        return;
+      }
       flush(k);
       // Retire start for runs that buffered nothing (flush early-returns then).
       starts.delete(k);
+      // A terminal success we OBSERVED live needs no /history reconcile — clear it
+      // from pending. (If the completion frame is later reported undelivered, the
+      // caller's markUndelivered re-pends it, so a bridge-down drop still recovers.)
+      markDelivered(k);
     },
 
     /** ComfyUI `execution_error` — drop this prompt's buffer, deliver no batch. */
@@ -194,6 +298,10 @@ export function createRunCompletionTracker({
       if (buf?.timer) clearTimer(buf.timer);
       buffers.delete(k);
       starts.delete(k);
+      // If already delivered (reconcile surfaced this run's outcome), don't touch
+      // pending/delivered again — the caller uses wasDelivered() BEFORE calling
+      // this to suppress a duplicate run_error frame (codex P1).
+      if (!delivered.has(k)) markDelivered(k);
     },
 
     /**
@@ -221,8 +329,135 @@ export function createRunCompletionTracker({
      */
     onExecutingNode(id) {
       if (id == null) return;
+      // A late `executing` for an already-delivered run must not re-open it.
+      if (delivered.has(key(id))) return;
       markStart(id);
       active.add(key(id));
+      trackPending(id);
+    },
+
+    /**
+     * Has this prompt's completion already been delivered (via live success or a
+     * /history reconcile)? The caller checks this BEFORE surfacing a live
+     * execution_error so a reconciled outcome isn't duplicated by a late WS event.
+     */
+    wasDelivered(id) {
+      return delivered.has(key(id));
+    },
+
+    /**
+     * Register a prompt_id the instant it is QUEUED (from the POST /prompt
+     * response), before any WS lifecycle event. Closes the worst-case #370 hole:
+     * a run that STARTS AND FINISHES entirely inside a connection drop — no
+     * execution_start/executing/executed ever reaches us — is still reconcilable
+     * against /history because we recorded its prompt_id at queue time.
+     */
+    onQueued(id) {
+      trackPending(id);
+    },
+
+    /**
+     * Caller reports the completion frame for `id` was CONFIRMED delivered to the
+     * agent (sendFrame succeeded / batch was empty). Retires it from pending.
+     */
+    markDelivered(id) {
+      markDelivered(id);
+    },
+
+    /**
+     * Caller reports the completion frame for `id` could NOT be delivered (bridge
+     * down when the flush fired). Re-pend it so the next reconnect recovers it via
+     * /history — this is what makes a bridge-down drop, where we DID observe the
+     * terminal success, still deliver the result on reconnect (#370).
+     */
+    markUndelivered(id) {
+      if (id == null) return;
+      const k = key(id);
+      delivered.delete(k);
+      if (!pending.has(k)) pending.set(k, { promptId: id, at: now() });
+    },
+
+    /**
+     * Reconcile every still-pending prompt against ComfyUI's `/history` and
+     * deliver any terminal outcome exactly once. Call on reconnect (WS back OR
+     * bridge back).
+     *
+     * @param {object} args
+     * @param {(promptId:string)=>Promise<object|null>} args.fetchHistory  Resolves
+     *   the per-prompt `/history/<id>` entry (already unwrapped from `{[id]:…}`), or
+     *   null when absent.
+     * @param {(m:object)=>boolean} [args.isVideo]  Output classifier (see parse).
+     * @returns {Promise<Array<{promptId:string, status:string, delivered?:boolean}>>}
+     *   One row per pending prompt inspected — the caller surfaces error/unknown
+     *   notices; SUCCESS batches are delivered here via onFlush.
+     */
+    async reconcile({ fetchHistory, isVideo } = {}) {
+      const summary = [];
+      pruneDeliveredFence(); // reconnect is a natural sweep point for old fences
+      if (typeof fetchHistory !== "function") return summary;
+      for (const [k, info] of [...pending.entries()]) {
+        if (delivered.has(k)) {
+          pending.delete(k);
+          continue;
+        }
+        const promptId = info.promptId;
+        if (promptId == null) continue;
+        let entry = null;
+        try {
+          entry = await fetchHistory(promptId);
+        } catch {
+          // A live lifecycle event may have delivered+retired this prompt while
+          // we awaited /history — don't emit an "unknown" for an already-resolved
+          // run (TOCTOU across the await).
+          if (delivered.has(k) || !pending.has(k)) continue;
+          summary.push({ promptId, status: "unknown" });
+          continue; // leave pending — a later reconnect can retry
+        }
+        // Re-check AFTER the await: if a live `execution_success`/`execution_error`
+        // delivered and retired this prompt while /history was in flight, deliver
+        // nothing here — otherwise we'd emit the same batch or run_error twice
+        // (codex P1, reconcile TOCTOU).
+        if (delivered.has(k) || !pending.has(k)) continue;
+        const parsed = parseHistoryEntry(entry, { isVideo });
+        if (!parsed) {
+          summary.push({ promptId, status: "unknown" });
+          continue; // leave pending
+        }
+        if (!parsed.terminal) {
+          summary.push({ promptId, status: "running" });
+          continue; // still in flight — the live lifecycle will complete it
+        }
+        // Terminal. Retire ALL live state for this key so a stale partial buffer
+        // (from the pre-drop `executed` events) can never double-deliver later,
+        // and mark it delivered BEFORE onFlush so a concurrent reconcile can't
+        // race it.
+        const buf = buffers.get(k);
+        if (buf?.timer) clearTimer(buf.timer);
+        buffers.delete(k);
+        active.delete(k);
+        const startTs = starts.get(k);
+        starts.delete(k);
+        markDelivered(k);
+        if (parsed.status === "error") {
+          summary.push({ promptId, status: "error" });
+          continue; // no batch for a failed run (mirrors onExecutionFailed)
+        }
+        const hasBatch = parsed.images.length > 0 || parsed.videos.length > 0;
+        if (hasBatch) {
+          const durationMs = startTs != null ? now() - startTs : null;
+          onFlush({
+            key: k,
+            promptId,
+            images: parsed.images,
+            videos: parsed.videos,
+            durationMs,
+            finishedAt: now(),
+            reconciled: true,
+          });
+        }
+        summary.push({ promptId, status: "success", delivered: hasBatch });
+      }
+      return summary;
     },
 
     /** Synchronous start lookup (diagnostics / fallbacks). */
@@ -234,5 +469,7 @@ export function createRunCompletionTracker({
     _active: active,
     _buffers: buffers,
     _starts: starts,
+    _pending: pending,
+    _delivered: delivered,
   };
 }

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -293,7 +293,7 @@ export function createRunCompletionTracker({
   // once. Returns a status row; `retriable:true` means the outcome isn't known
   // yet (transient /history miss or still-running) so the caller should schedule
   // a retry rather than strand it.
-  async function reconcileKey(promptId, fetchHistory, isVideo) {
+  async function reconcileKey(promptId, fetchHistory, fetchQueued, isVideo) {
     const k = key(promptId);
     if (delivered.has(k) || !pending.has(k)) return null;
     let entry = null;
@@ -306,10 +306,35 @@ export function createRunCompletionTracker({
     // Re-check AFTER the await: a live execution_success/error may have delivered
     // and retired this prompt while /history was in flight — never double-deliver.
     if (delivered.has(k) || !pending.has(k)) return null;
-    if (fetchThrew) return { promptId, status: "unknown", retriable: true };
-    const parsed = parseHistoryEntry(entry, { isVideo });
-    if (!parsed) return { promptId, status: "unknown", retriable: true }; // 503/empty
-    if (!parsed.terminal) return { promptId, status: "running", retriable: true };
+
+    const parsed = fetchThrew ? null : parseHistoryEntry(entry, { isVideo });
+    if (!parsed || !parsed.terminal) {
+      // NOT terminal in /history. CRITICAL: absence from /history is NORMAL for a
+      // QUEUED or RUNNING prompt — ComfyUI only writes /history on task_done. So an
+      // absent /history must NOT be treated as "gone": consult /queue to tell a
+      // still-in-flight render apart from a genuinely cancelled/removed one, and
+      // NEVER fence/give up a prompt /queue still shows running (codex P1 — it would
+      // drop the live output of a legitimately long render).
+      if (fetchThrew) return { promptId, status: "running", retriable: true }; // /history unreachable ⇒ uncertain, keep polling
+      let queued = null; // null = couldn't determine; true/false = definitive
+      if (typeof fetchQueued === "function") {
+        try {
+          queued = await fetchQueued(promptId);
+        } catch {
+          queued = null;
+        }
+        if (delivered.has(k) || !pending.has(k)) return null; // re-check after 2nd await
+      }
+      if (queued === false) {
+        // DEFINITIVELY absent from BOTH /history AND /queue ⇒ genuinely gone
+        // (cancelled / interrupted). Only THIS is give-up eligible.
+        return { promptId, status: "unknown", retriable: true };
+      }
+      // Still queued/running, OR queue membership couldn't be confirmed — either
+      // way keep polling and NEVER give up (a live/uncertain render must not be
+      // fenced or evicted).
+      return { promptId, status: "running", retriable: true };
+    }
     // Terminal. Retire ALL live state for this key so a stale partial buffer (from
     // pre-drop `executed` events) can't double-deliver later, and mark it delivered
     // BEFORE onFlush so a concurrent reconcile can't race it.
@@ -351,14 +376,15 @@ export function createRunCompletionTracker({
     return { promptId, status: "success", delivered: hasBatch };
   }
 
-  // GIVE UP on a prompt whose outcome can't be confirmed after the retry budget is
-  // spent (P1 memory leak). Without this, a prompt whose /history stays ABSENT
-  // (cancelled / disconnected while queued) would sit in `pending` forever — and
-  // because the fence prune deliberately RETAINS a terminal fence while its run is
+  // GIVE UP on a prompt confirmed absent from BOTH /history AND /queue after the
+  // retry budget is spent (P1 memory leak) — i.e. genuinely cancelled/gone, NOT a
+  // still-queued/running render (which reconcileKey reports as "running", never
+  // reaching here). Without this, a truly-gone prompt would sit in `pending`
+  // forever — and because the fence prune RETAINS a terminal fence while its run is
   // pending, both `pending` and `terminal` would grow without bound. Evicting the
   // entry (once, with a one-time "couldn't confirm — safe to requeue" notice) keeps
-  // the ledger bounded to the live queue depth + in-flight retries; the terminal
-  // fence we stamp here is then no longer pinned, so it ages out normally.
+  // the ledger bounded; the terminal fence we stamp here is then no longer pinned,
+  // so it ages out normally.
   function giveUpReconcile(promptId) {
     const k = key(promptId);
     clearReconcileRetry(k);
@@ -385,30 +411,31 @@ export function createRunCompletionTracker({
 
   // Decide what to do with a reconcileKey result. Terminal/resolved ⇒ stop. Still
   // retriable with budget left ⇒ schedule another poll. Budget SPENT this episode
-  // without a terminal outcome ⇒ an UNKNOWN (/history absent — couldn't even find
-  // it) is GIVEN UP + evicted so the ledger stays bounded, while a RUNNING render
-  // (confirmably in progress) is left pending for the live path / next reconnect.
+  // without a terminal outcome ⇒ an "unknown" (confirmed absent from BOTH /history
+  // AND /queue ⇒ genuinely gone) is GIVEN UP + evicted so the ledger stays bounded,
+  // while a "running" render (still in /queue, or membership uncertain) is left
+  // PENDING for the live path / next reconnect — never fenced or dropped (codex P1).
   // Centralizing the decision here makes it fire even when maxReconcileRetries===0
-  // (give up immediately for an absent history) — codex P2.
-  function afterReconcileRow(row, promptId, fetchHistory, isVideo) {
+  // (give up immediately for a confirmed-gone prompt) — codex P2.
+  function afterReconcileRow(row, promptId, fetchHistory, fetchQueued, isVideo) {
     const k = key(promptId);
     if (!row || !row.retriable) {
       clearReconcileRetry(k); // resolved (terminal / delivered)
       return;
     }
     if ((retryCounts.get(k) ?? 0) >= maxReconcileRetries) {
-      if (row.status === "unknown") giveUpReconcile(promptId); // absent ⇒ evict
+      if (row.status === "unknown") giveUpReconcile(promptId); // gone ⇒ evict
       else clearReconcileRetry(k); // still "running" ⇒ leave pending, stop polling
       return;
     }
-    scheduleReconcileRetry(promptId, fetchHistory, isVideo);
+    scheduleReconcileRetry(promptId, fetchHistory, fetchQueued, isVideo);
   }
 
   // Arm one bounded, self-repolling retry for a prompt whose /history is not yet
   // terminal (P1-3). The budget/give-up decision lives in afterReconcileRow; this
   // just schedules the next poll. Uses the injected timer so it's deterministic
   // under test.
-  function scheduleReconcileRetry(promptId, fetchHistory, isVideo) {
+  function scheduleReconcileRetry(promptId, fetchHistory, fetchQueued, isVideo) {
     const k = key(promptId);
     if (k === NO_PROMPT_KEY) return; // id-less runs aren't reconcilable
     if (delivered.has(k) || !pending.has(k)) {
@@ -423,8 +450,8 @@ export function createRunCompletionTracker({
         clearReconcileRetry(k);
         return;
       }
-      const row = await reconcileKey(promptId, fetchHistory, isVideo);
-      afterReconcileRow(row, promptId, fetchHistory, isVideo);
+      const row = await reconcileKey(promptId, fetchHistory, fetchQueued, isVideo);
+      afterReconcileRow(row, promptId, fetchHistory, fetchQueued, isVideo);
     }, reconcileRetryMs);
     retryTimers.set(k, timer);
   }
@@ -612,19 +639,24 @@ export function createRunCompletionTracker({
      * @param {(promptId:string)=>Promise<object|null>} args.fetchHistory  Resolves
      *   the per-prompt `/history/<id>` entry (already unwrapped from `{[id]:…}`), or
      *   null when absent.
+     * @param {(promptId:string)=>Promise<boolean|null>} [args.fetchQueued]  Resolves
+     *   whether the prompt is still in ComfyUI's `/queue` (running OR pending): true
+     *   present, false definitively absent, null couldn't determine. Consulted only
+     *   when /history is non-terminal, to tell a still-running render apart from a
+     *   genuinely gone one — a running render is NEVER given up (codex P1).
      * @param {(m:object)=>boolean} [args.isVideo]  Output classifier (see parse).
      * @returns {Promise<Array<{promptId:string, status:string, delivered?:boolean}>>}
      *   One row per pending prompt inspected — the caller surfaces error/unknown
      *   notices; SUCCESS batches are delivered here via onFlush.
      */
-    async reconcile({ fetchHistory, isVideo } = {}) {
+    async reconcile({ fetchHistory, fetchQueued, isVideo } = {}) {
       const summary = [];
       pruneFences(); // reconnect is a natural sweep point for old fences
       if (typeof fetchHistory !== "function") return summary;
       for (const [, info] of [...pending.entries()]) {
         const promptId = info.promptId;
         if (promptId == null) continue;
-        const row = await reconcileKey(promptId, fetchHistory, isVideo);
+        const row = await reconcileKey(promptId, fetchHistory, fetchQueued, isVideo);
         if (!row) continue; // resolved by a live event meanwhile — nothing to report
         const clean = { promptId: row.promptId, status: row.status };
         if (row.delivered !== undefined) clean.delivered = row.delivered;
@@ -637,7 +669,7 @@ export function createRunCompletionTracker({
         // evicts an absent-history prompt, or leaves a running one pending (P1-3,
         // and the memory-leak give-up — fires even when maxReconcileRetries===0).
         if (row.retriable) retryCounts.delete(key(promptId));
-        afterReconcileRow(row, promptId, fetchHistory, isVideo);
+        afterReconcileRow(row, promptId, fetchHistory, fetchQueued, isVideo);
       }
       return summary;
     },


### PR DESCRIPTION
## Summary

Fixes the panel run-reliability cluster: a run that ComfyUI **rejected synchronously** was reported as `queued:true`, a run that finished **during a connection drop** delivered no completion, and a successful run **omitted its prompt_id**.

Closes #358
Closes #370
Closes artokun/comfyui-mcp#531

### #358 — false `queued:true` on a synchronous rejection
`app.queuePrompt` swallows a synchronous rejection: it stores per-node errors on `lastNodeErrors` but **shows-then-discards** a top-level `error` (e.g. `missing_node_type`), which never reaches `lastNodeErrors`. `graph_run` now captures the raw non-200 `/prompt` body via a scoped `fetchApi` wrap and returns a real `{queued:false, error, error_type, node_errors?}` failure (`summarizePromptRejection`).

### mcp#531 — successful run omitted the prompt_id
A 200 `/prompt` accept returned only `{queued, batch_count}`. It now returns `prompt_id` (first) and, for a batch, `prompt_ids` (all) via `buildQueueAcceptResult`, so the agent can correlate/track the run even when a render is already running.

### #370 — no completion delivered after a connection drop
A recovery ledger tracks each prompt as *pending* from its first liveness signal (and from `onQueued` at queue time) until its completion is **confirmed delivered**. On reconnect it reconciles pending prompt_ids against `/history/<id>` (`parseHistoryEntry`) and delivers the terminal outcome exactly once. Additionally:
- **Transient `/history` miss** (503/empty at the reconnect edge) no longer strands an entire-run-in-drop completion — a bounded, self-repolling retry (`reconcileKey` + `scheduleReconcileRetry`) delivers once `/history` turns terminal; each fresh reconcile episode restarts the budget.
- **Terminal errors** (loop- or retry-discovered) route through a single `onReconcileError` hook so a retry-discovered failure still surfaces `run_error`.

### Correctness properties (hardened over adversarial review)
- **No double-delivery / no mis-attribution**: a timestamped `delivered` fence + post-`await` re-checks make a live event landing mid-reconcile, and a late WS replay after reconcile, both no-ops. `onExecutionStart` is also fenced — a stale start for an already-delivered prompt can't flush a *different* live run's buffer (#293). `NO_PROMPT_KEY` excluded so back-to-back id-less runs (#224) still each deliver.
- **No lost completion/error**: a completion or `run_error` frame that fails to send (bridge down) re-pends for the next reconnect/retry; a **muted** agent (also a false `sendFrame`) is treated as intentional permanent suppression, not a transport failure.
- **Bounded memory**: the fence is timestamped and aged out by a self-disarming sweep + prune-on-delivery; the pending ledger drains on terminal delivery; retries are attempt-bounded.

## Tests
- `browser_tests/unit/queue-rejection.test.mjs` — #358 rejection verdict + mcp#531 accept-result (single/batch/run-to-node/no-id).
- `browser_tests/unit/run-reconcile.test.mjs` — drop-during-render `/history` recovery; no double-delivery; TOCTOU + late-replay idempotency; batch/entire-run-in-drop recovery; delivered-fence on `onExecutionStart`; transient-miss→success and transient-miss→error via retry; retry bounds/reset; error single-path.
- Full unit suite green (601), `tsc --noEmit` clean, all `web/js` files pass `node --check` (ESM) + registry YARA parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)