### PR TITLE
fix(canvas): live-geometry group membership (#355) + non-no-op /revert (#327)

### DIFF
--- a/browser_tests/unit/graph-revert.test.mjs
+++ b/browser_tests/unit/graph-revert.test.mjs
@@ -1,0 +1,73 @@
+// Unit tests for per-turn revert snapshot selection (web/js/lib/graph-revert.js).
+//
+// Regression coverage for #327: /revert restored graphSnapshots[last]
+// unconditionally, so after a turn cleared/replaced the graph — and the next
+// message snapshotted that already-changed graph — the newest snapshot equaled
+// the current canvas and reverting to it recovered nothing (silent no-op).
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { pickRevertSnapshot } from "../../web/js/lib/graph-revert.js";
+
+const snap = (data) => ({ mid: null, ts: 0, data });
+// Distinct serialized-graph shapes standing in for rootGraph.serialize() output.
+const GRAPH_A = { nodes: [{ id: 1, type: "KSampler" }], links: [] };
+const GRAPH_B = { nodes: [{ id: 2, type: "SaveImage" }], links: [] };
+const EMPTY = { nodes: [], links: [] };
+
+test("skips an identical latest snapshot, reverts to the prior different one (#327)", () => {
+  // A (non-empty) → turn cleared it → next message snapshotted EMPTY.
+  const ring = [snap(GRAPH_A), snap(EMPTY)];
+  // Current canvas is EMPTY, equal to the newest snapshot.
+  const chosen = pickRevertSnapshot(ring, EMPTY);
+  assert.equal(chosen.data, GRAPH_A, "reverts to the earlier non-empty graph, not the no-op latest");
+});
+
+test("returns null when EVERY snapshot equals the current graph (nothing to revert)", () => {
+  const ring = [snap(GRAPH_A), snap(GRAPH_A)];
+  assert.equal(pickRevertSnapshot(ring, GRAPH_A), null);
+});
+
+test("returns the newest snapshot when it already differs from current", () => {
+  const ring = [snap(GRAPH_A), snap(GRAPH_B)];
+  // Current is something else again → newest (B) is a genuine prior state.
+  assert.equal(pickRevertSnapshot(ring, EMPTY).data, GRAPH_B);
+});
+
+test("walks back past MULTIPLE identical snapshots to the first real difference", () => {
+  const ring = [snap(GRAPH_A), snap(EMPTY), snap(EMPTY)];
+  assert.equal(pickRevertSnapshot(ring, EMPTY).data, GRAPH_A);
+});
+
+test("empty / missing ring yields null", () => {
+  assert.equal(pickRevertSnapshot([], GRAPH_A), null);
+  assert.equal(pickRevertSnapshot(null, GRAPH_A), null);
+  assert.equal(pickRevertSnapshot(undefined, GRAPH_A), null);
+});
+
+test("accepts a pre-stringified snapshot.data and compares canonically", () => {
+  // Key order matches because both come from the same serializer; equality holds.
+  const ring = [snap(JSON.stringify(GRAPH_A)), snap(JSON.stringify(EMPTY))];
+  // Current EMPTY (object) canonicalizes to the same string as the newest snap →
+  // skip it, land on the stringified GRAPH_A.
+  assert.equal(pickRevertSnapshot(ring, EMPTY), ring[0]);
+  // And a differing current still selects the newest.
+  assert.equal(pickRevertSnapshot(ring, GRAPH_B).data, JSON.stringify(EMPTY));
+});
+
+test("tolerates holes in the ring without throwing", () => {
+  const ring = [snap(GRAPH_A), null, snap(EMPTY)];
+  assert.equal(pickRevertSnapshot(ring, EMPTY).data, GRAPH_A);
+});
+
+test("treats key-reordered but structurally-equal graphs as identical (no false revert)", () => {
+  // Same graph, different object key insertion order — must canonicalize equal so
+  // the newest snapshot is recognized as a no-op and skipped, not restored.
+  const newest = { nodes: [{ id: 1, type: "KSampler" }], links: [], version: 0.4 };
+  const currentReordered = { version: 0.4, links: [], nodes: [{ type: "KSampler", id: 1 }] };
+  const ring = [snap(GRAPH_A), snap(newest)];
+  // Current equals `newest` up to key order → skip it, land on the real prior graph.
+  assert.equal(pickRevertSnapshot(ring, currentReordered).data, GRAPH_A);
+  // And when the ONLY snapshot equals current (reordered), nothing to revert.
+  assert.equal(pickRevertSnapshot([snap(newest)], currentReordered), null);
+});

--- a/browser_tests/unit/group-geometry.test.mjs
+++ b/browser_tests/unit/group-geometry.test.mjs
@@ -18,6 +18,7 @@ import {
   groupBoundsOf,
   groupMemberNodes,
   classifyRequestedMembership,
+  refreshNodeArea,
 } from "../../web/js/lib/group-geometry.js";
 
 // Minimal fixtures. No boundingRect => nodeFocusBounds falls back to pos/size
@@ -135,6 +136,69 @@ test("nodeFocusBounds prefers boundingRect when present", () => {
 test("nodeFocusBounds accepts a typed-array boundingRect (current ComfyUI Rectangle)", () => {
   const br = Float32Array.from([1, 2, 3, 4]);
   assert.deepEqual(nodeFocusBounds({ boundingRect: br }), [1, 2, 3, 4]);
+});
+
+// ---- refreshNodeArea: keep boundingRect live after a programmatic move (#355) ----
+
+test("stale boundingRect gives WRONG membership until refreshNodeArea (#355)", () => {
+  // Node lived at [0,0]; its cached boundingRect reflects that old spot.
+  const n = { id: 1, pos: [0, 0], size: [300, 120], boundingRect: [0, -30, 300, 150] };
+  const graph = graphOf(n);
+  // A group box far to the right — the node is NOT in it while at [0,0].
+  const g = groupBox([400, 0, 300, 300]);
+  assert.deepEqual(groupMemberNodes(graph, g).map((x) => x.id), [], "node starts outside");
+
+  // Programmatic move INTO the group box, exactly like graph_move_node writes pos.
+  const prev = [n.pos[0], n.pos[1]];
+  n.pos = [450, 50];
+  // FAIL-BEFORE: without refreshing, the stale boundingRect (which nodeFocusBounds
+  // prefers) still says the node is at [0,-30] → membership misses it.
+  assert.deepEqual(
+    groupMemberNodes(graph, g).map((x) => x.id),
+    [],
+    "stale boundingRect wrongly excludes the moved-in node",
+  );
+
+  // PASS-AFTER: refresh translates the cached rect by the move delta.
+  refreshNodeArea(n, prev);
+  assert.deepEqual(n.boundingRect, [450, 20, 300, 150], "rect shifted by (+450,+50)");
+  assert.deepEqual(
+    groupMemberNodes(graph, g).map((x) => x.id),
+    [1],
+    "refreshed geometry now reports the node as a member",
+  );
+});
+
+test("refreshNodeArea trusts the engine's own updateArea() recompute (#355)", () => {
+  // A build whose updateArea() authoritatively recomputes boundingRect from pos.
+  const n = {
+    id: 7,
+    pos: [1000, 1000],
+    size: [200, 100],
+    boundingRect: [0, -30, 200, 130],
+    updateArea() {
+      this.boundingRect = [this.pos[0], this.pos[1] - 30, this.size[0], this.size[1] + 30];
+    },
+  };
+  refreshNodeArea(n, [0, 0]);
+  // Engine moved the origin → refresh must NOT also apply the delta (no double-shift).
+  assert.deepEqual(n.boundingRect, [1000, 970, 200, 130]);
+});
+
+test("refreshNodeArea is a no-op when there is no boundingRect to correct (#355)", () => {
+  // No boundingRect → nodeFocusBounds already uses fresh pos/size; nothing to do.
+  const n = { id: 9, pos: [10, 10], size: [200, 100] };
+  refreshNodeArea(n, [0, 0]);
+  assert.equal(n.boundingRect, undefined);
+  // Guard against throwing on odd inputs.
+  refreshNodeArea(null, [0, 0]);
+  refreshNodeArea(n, undefined);
+});
+
+test("refreshNodeArea supports a typed-array boundingRect (ComfyUI Rectangle)", () => {
+  const n = { id: 3, pos: [100, 200], size: [80, 40], boundingRect: Float32Array.from([0, 0, 80, 70]) };
+  refreshNodeArea(n, [0, 0]);
+  assert.deepEqual([...n.boundingRect], [100, 200, 80, 70], "typed-array origin shifted in place");
 });
 
 test("membership overlap is edge-inclusive (matches LiteGraph overlapBounding)", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -132,7 +132,9 @@ import {
   boundsAroundNodes,
   groupMemberNodes,
   classifyRequestedMembership,
+  refreshNodeArea,
 } from "./lib/group-geometry.js";
+import { pickRevertSnapshot } from "./lib/graph-revert.js";
 import { saveActiveWorkflow } from "./lib/workflow-save.js";
 import { createRunCompletionTracker } from "./lib/run-completion.js";
 import { composeRunCompletionFrame } from "./lib/run-completion-frame.js";
@@ -3262,9 +3264,22 @@ function restoreSnapshot(snap) {
   }
 }
 
-// Restore the canvas to the most recent pre-turn snapshot (undo the last turn's edits).
+// Restore the canvas to the most recent pre-turn snapshot that ACTUALLY DIFFERS
+// from the current graph (undo the last turn's edits). Skipping an identical
+// latest snapshot fixes the no-op revert (#327): after a turn replaced/cleared
+// the graph, the next message snapshots the already-changed graph, so the newest
+// snapshot equals the canvas and reverting to it recovers nothing. Returns null
+// when nothing genuinely differs — the caller surfaces "nothing to revert".
 function revertGraphToLastSnapshot() {
-  return restoreSnapshot(graphSnapshots[graphSnapshots.length - 1]);
+  try {
+    const current = getGraphCtx().rootGraph.serialize();
+    const snap = pickRevertSnapshot(graphSnapshots, current);
+    return snap ? restoreSnapshot(snap) : null;
+  } catch {
+    // graph unavailable (can't serialize current state) — fall back to the
+    // legacy newest-snapshot behavior rather than silently doing nothing.
+    return restoreSnapshot(graphSnapshots[graphSnapshots.length - 1]);
+  }
 }
 
 // ---- manual-edit awareness --------------------------------------------------
@@ -5272,6 +5287,9 @@ const GRAPH_TOOL_EXECUTORS = {
       graph.beforeChange?.();
       try {
         railNode.pos = [Number(pos[0]), Number(pos[1])];
+        // #355: refresh the cached boundingRect NOW so any later geometric
+        // group-membership read sees the moved footprint, not the pre-move one.
+        refreshNodeArea(railNode, prev);
       } finally {
         graph.afterChange?.();
       }
@@ -5302,6 +5320,9 @@ const GRAPH_TOOL_EXECUTORS = {
     graph.beforeChange();
     try {
       node.pos = [Number(pos[0]), Number(pos[1])];
+      // #355: keep the cached boundingRect live so a follow-up group-membership
+      // read (summarizeGroup / graph_outline / graph_query) uses the NEW footprint.
+      refreshNodeArea(node, previous);
     } finally {
       graph.afterChange();
     }
@@ -5478,7 +5499,12 @@ const GRAPH_TOOL_EXECUTORS = {
     try {
       for (const [id, [nx, ny]] of layout.positions) {
         const n = byId.get(id);
-        if (n) n.pos = [nx, ny];
+        if (!n) continue;
+        const prevPos = [n.pos?.[0] ?? 0, n.pos?.[1] ?? 0];
+        n.pos = [nx, ny];
+        // #355: refresh boundingRect per moved node BEFORE the group re-fit below
+        // (and any later membership read) so recomputeInsideNodes sees live geometry.
+        refreshNodeArea(n, prevPos);
       }
       if (groups !== "ignore") {
         for (const gb of groupBoxes) {

--- a/web/js/lib/graph-revert.js
+++ b/web/js/lib/graph-revert.js
@@ -1,0 +1,64 @@
+// Pure snapshot selection for the per-turn graph revert (#44 rollback, bug #327).
+//
+// The panel keeps a bounded ring of pre-turn graph snapshots (oldest → newest).
+// The naive "revert" restored graphSnapshots[last] unconditionally. But after an
+// agent turn REPLACES or CLEARS the graph, the user's next message captures a
+// fresh pre-turn snapshot of the ALREADY-changed graph, so the newest snapshot
+// equals the current canvas — reverting to it is a silent no-op that can't
+// recover the prior workflow (#327).
+//
+// pickRevertSnapshot walks newest → oldest and returns the first snapshot whose
+// serialized graph actually DIFFERS from the current state, so /revert lands on
+// the nearest genuinely-different pre-turn graph. Returns null when every
+// snapshot equals the current graph (nothing to revert to) — the caller surfaces
+// that honestly instead of pretending a no-op succeeded.
+//
+// Dependency-free (no LiteGraph, no DOM). Comparison is by a STABLE canonical
+// form (object keys sorted recursively; array order preserved, since node/link
+// order is semantically meaningful) so two structurally-equal graphs that merely
+// serialized their object keys in a different insertion order still compare
+// equal — otherwise a logically-identical latest snapshot could slip through the
+// difference test and reintroduce the no-op revert this fix removes. A
+// pre-stringified snapshot.data is re-parsed so it canonicalizes the same way.
+// Unit-testable with plain object fixtures.
+
+/** Recursively key-sorted JSON so equality is independent of key insertion order. */
+function stableStringify(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const keys = Object.keys(value).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(value[k])}`).join(",")}}`;
+}
+
+/** Stable string form of a serialized graph (or a pre-stringified snapshot). */
+function canonicalize(data) {
+  if (data == null) return "";
+  try {
+    // Re-parse a pre-stringified snapshot so it goes through the same key-sort.
+    const obj = typeof data === "string" ? JSON.parse(data) : data;
+    return stableStringify(obj);
+  } catch {
+    // Unparseable / circular — treat as its own unique value so it never
+    // spuriously matches the current graph and blocks a legitimate revert.
+    return null;
+  }
+}
+
+/**
+ * @param {Array<{data:unknown}>} snapshots  pre-turn ring, oldest → newest
+ * @param {unknown} currentSerialized  the LIVE graph's serialize() output (object or string)
+ * @returns the most recent snapshot that differs from the current graph, or null
+ */
+export function pickRevertSnapshot(snapshots, currentSerialized) {
+  if (!Array.isArray(snapshots) || snapshots.length === 0) return null;
+  const current = canonicalize(currentSerialized);
+  for (let i = snapshots.length - 1; i >= 0; i -= 1) {
+    const snap = snapshots[i];
+    if (!snap) continue;
+    const snapForm = canonicalize(snap.data);
+    // A snapshot that can't be compared (null) is always eligible; otherwise
+    // require a genuine difference from the current graph.
+    if (snapForm === null || current === null || snapForm !== current) return snap;
+  }
+  return null;
+}

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -23,6 +23,48 @@ export function nodeFocusBounds(node) {
   return [node.pos[0], node.pos[1] - 30, w, h + 30]; // title bar renders above pos
 }
 
+/**
+ * Keep a node's cached boundingRect in lockstep with a programmatic position
+ * write. LiteGraph only refreshes boundingRect during its own render pass, so
+ * right after `node.pos = ...` the cached rect still describes the PRE-MOVE
+ * footprint — and because nodeFocusBounds (and LiteGraph's own
+ * recomputeInsideNodes → containsCentre) PREFER boundingRect, geometric group
+ * membership would then be computed against stale geometry (#355).
+ *
+ * `prevPos` is the node's [x, y] BEFORE the write. We first let the engine
+ * recompute via its own updateArea() (authoritative in a real ComfyUI/LiteGraph
+ * build); if that method is absent, throws, or leaves the cached rect at its old
+ * origin, we translate the rect by exactly the position delta — a pure move
+ * shifts the bounding-box origin by the same amount, so this correction is exact
+ * and build-independent. Dependency-free (no LiteGraph, no DOM) so it is
+ * unit-testable with plain object fixtures.
+ */
+export function refreshNodeArea(node, prevPos) {
+  if (!node) return;
+  const rectBefore = node.boundingRect;
+  const originBefore =
+    rectBefore && rectBefore.length === 4 ? [rectBefore[0], rectBefore[1]] : null;
+  try {
+    node.updateArea?.();
+  } catch {
+    /* some builds need a canvas ctx; the delta-sync below still corrects it */
+  }
+  const br = node.boundingRect;
+  if (!br || br.length !== 4) return;
+  // Engine already moved the rect origin → trust its authoritative recompute.
+  if (originBefore && (br[0] !== originBefore[0] || br[1] !== originBefore[1])) return;
+  if (!Array.isArray(prevPos) || prevPos.length !== 2) return;
+  const px = Number(prevPos[0]);
+  const py = Number(prevPos[1]);
+  if (!Number.isFinite(px) || !Number.isFinite(py)) return;
+  const dx = (node.pos?.[0] ?? 0) - px;
+  const dy = (node.pos?.[1] ?? 0) - py;
+  if (dx || dy) {
+    br[0] += dx;
+    br[1] += dy;
+  }
+}
+
 /** [x, y, w, h] that wraps the given nodes, padded for the group + node titles. */
 export function boundsAroundNodes(nodes, pad = 30, titlePad = 70) {
   let minX = Infinity;


### PR DESCRIPTION
## Panel canvas-op fixes: #355 (stale group geometry) + #327 (no-op /revert)

Two independent panel canvas-op bugs, each fixed via a pure, testable helper with fail-before/pass-after unit tests.

### #355 — group membership computed against STALE node geometry
LiteGraph refreshes `node.boundingRect` only during its render pass, and `nodeFocusBounds` PREFERS `boundingRect` over `pos`/`size`. So a programmatic `node.pos` write in `graph_move_node` / `graph_auto_layout` left geometric group-membership reads (`groupMemberNodes`, `summarizeGroup`, `graph_outline`, `graph_query`) using the PRE-MOVE footprint — groups reported `node_count: 0` or the wrong members.

- New exported pure helper `refreshNodeArea(node, prevPos)` in `web/js/lib/group-geometry.js`: calls `node.updateArea?.()` (authoritative in a real LiteGraph build), then — only if the engine did not move the cached rect origin — translates `boundingRect` by exactly the position delta (exact for a pure move; supports typed-array/`Float32Array` rects; no double-shift).
- Called after every `pos` write: `graph_move_node` (real-node + rail paths) and the `graph_auto_layout` apply loop (before the group re-fit).

### #327 — /revert restored an identical latest snapshot (silent no-op)
After a turn cleared/replaced the graph, the next message snapshotted the already-changed graph, so `revertGraphToLastSnapshot()` (which always targeted `graphSnapshots[last]`) restored the current state and recovered nothing.

- New exported pure helper `pickRevertSnapshot(snapshots, currentSerialized)` in `web/js/lib/graph-revert.js`: walks newest→oldest and returns the most recent snapshot whose STABLE canonical form (recursively key-sorted; array order preserved, since node/link order is semantically meaningful) differs from the live graph, else `null`.
- `revertGraphToLastSnapshot()` now serializes the live graph and uses it, returning `null` ("nothing to revert") when nothing differs; legacy newest-snapshot behavior kept as the serialize-failure fallback.

### Tests
- `browser_tests/unit/group-geometry.test.mjs`: stale-boundingRect fail-before/pass-after, engine-`updateArea` trust (no double-shift), typed-array rect, no-op guards.
- `browser_tests/unit/graph-revert.test.mjs`: skip-identical-latest, walk past multiple identical, nothing-to-revert → null, key-reordered-but-equal treated identical, holes/empty ring.
- Full panel unit suite green (560/560 `node --test`); `tsc --noEmit` clean; ESM link-checked.

Codex (gpt-5.6-terra, high) embed-diff review: PASS.

Closes #355
Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)
