### PR TITLE
fix(panel): ground unsaved workflows on every agent turn, disk-safely

### DIFF
--- a/browser_tests/unit/workflow-grounding.test.mjs
+++ b/browser_tests/unit/workflow-grounding.test.mjs
@@ -1,0 +1,105 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  needsGrounding,
+  shouldGroundBeforeTurn,
+  groundingIsSafe
+} from '../../web/js/lib/workflow-save.js'
+
+// #330 — unsaved workflows were grounded ONLY on a brand-new chat (the freshChat
+// gate). Continuing an existing chat inside an unsaved tab left the user's edits
+// unprotected. Grounding must run on EVERY agent turn that targets an unsaved tab.
+
+test('needsGrounding is true for a never-persisted / temporary workflow', () => {
+  assert.equal(needsGrounding({ isPersisted: false }), true)
+  assert.equal(needsGrounding({ isTemporary: true }), true)
+})
+
+test('needsGrounding is false for a persisted workflow and for no workflow', () => {
+  assert.equal(needsGrounding({ isPersisted: true, isTemporary: false }), false)
+  assert.equal(needsGrounding(null), false)
+  assert.equal(needsGrounding(undefined), false)
+})
+
+// CORE #330 regression: a CONTINUED chat (freshChat === false) on an unsaved tab
+// must STILL ground. A fresh-chat-only gate (freshChat && needsGrounding) would
+// return false here — this test fails against that old behavior and passes now.
+test('shouldGroundBeforeTurn grounds an unsaved tab on a CONTINUED (non-fresh) chat', () => {
+  assert.equal(
+    shouldGroundBeforeTurn({ isPersisted: false }, { freshChat: false }),
+    true
+  )
+  assert.equal(
+    shouldGroundBeforeTurn({ isTemporary: true }, { freshChat: false }),
+    true
+  )
+})
+
+test('shouldGroundBeforeTurn also grounds an unsaved tab on a fresh chat', () => {
+  assert.equal(
+    shouldGroundBeforeTurn({ isPersisted: false }, { freshChat: true }),
+    true
+  )
+})
+
+test('shouldGroundBeforeTurn never grounds an already-persisted workflow', () => {
+  assert.equal(
+    shouldGroundBeforeTurn({ isPersisted: true, isTemporary: false }, { freshChat: true }),
+    false
+  )
+  assert.equal(
+    shouldGroundBeforeTurn({ isPersisted: true, isTemporary: false }, { freshChat: false }),
+    false
+  )
+})
+
+// #330 safety gate — a per-turn save must NOT overwrite a real on-disk file whose
+// `isTemporary` flag merely drifted (#215/#226). groundingIsSafe authorizes a save
+// only when the source is PROVABLY never-persisted via the disk oracle.
+test('groundingIsSafe grounds a brand-new tab with no backing path (no oracle needed)', async () => {
+  assert.equal(await groundingIsSafe({ isPersisted: false }, async () => 404), true)
+  assert.equal(await groundingIsSafe({ isTemporary: true, path: '' }, async () => 404), true)
+})
+
+test('groundingIsSafe grounds a placeholder tab the oracle PROVES absent (404)', async () => {
+  const oracle = async () => false // 404 → absent
+  assert.equal(
+    await groundingIsSafe({ isPersisted: false, path: 'workflows/Unsaved Workflow.json' }, oracle),
+    true
+  )
+})
+
+// CORE #330 data-loss guard: a workflow flagged temporary (drifted) but PRESENT on
+// disk must NEVER be auto-saved over. FAIL-BEFORE (flag-only needsGrounding) would
+// authorize the overwrite; groundingIsSafe refuses it.
+test('groundingIsSafe REFUSES a drifted-temporary workflow that exists on disk', async () => {
+  const oracle = async () => true // 200 → real file present
+  assert.equal(
+    await groundingIsSafe({ isTemporary: true, isPersisted: false, path: 'workflows/MyFlow.json' }, oracle),
+    false
+  )
+})
+
+test('groundingIsSafe fails safe (refuses) when the disk oracle is unknown or missing', async () => {
+  assert.equal(
+    await groundingIsSafe({ isTemporary: true, path: 'workflows/MyFlow.json' }, async () => null),
+    false
+  )
+  assert.equal(
+    await groundingIsSafe({ isTemporary: true, path: 'workflows/MyFlow.json' }, async () => { throw new Error('net') }),
+    false
+  )
+  // No oracle function at all ⇒ cannot prove ⇒ refuse.
+  assert.equal(
+    await groundingIsSafe({ isTemporary: true, path: 'workflows/MyFlow.json' }),
+    false
+  )
+})
+
+test('groundingIsSafe never grounds a genuinely persisted workflow', async () => {
+  assert.equal(
+    await groundingIsSafe({ isPersisted: true, path: 'workflows/MyFlow.json' }, async () => false),
+    false
+  )
+})

--- a/browser_tests/unit/workflow-grounding.test.mjs
+++ b/browser_tests/unit/workflow-grounding.test.mjs
@@ -4,12 +4,16 @@ import test from 'node:test'
 import {
   needsGrounding,
   shouldGroundBeforeTurn,
-  groundingIsSafe
+  groundingIsSafe,
+  groundActiveWorkflow
 } from '../../web/js/lib/workflow-save.js'
 
 // #330 — unsaved workflows were grounded ONLY on a brand-new chat (the freshChat
 // gate). Continuing an existing chat inside an unsaved tab left the user's edits
-// unprotected. Grounding must run on EVERY agent turn that targets an unsaved tab.
+// unprotected. Grounding must run on EVERY agent turn that targets an unsaved tab —
+// but a per-turn auto-save must never overwrite a real file (drift #215/#226), never
+// authorize on tab A and write to tab B (TOCTOU), and never duplicate on concurrent
+// turns (single-flight).
 
 test('needsGrounding is true for a never-persisted / temporary workflow', () => {
   assert.equal(needsGrounding({ isPersisted: false }), true)
@@ -23,78 +27,49 @@ test('needsGrounding is false for a persisted workflow and for no workflow', () 
 })
 
 // CORE #330 regression: a CONTINUED chat (freshChat === false) on an unsaved tab
-// must STILL ground. A fresh-chat-only gate (freshChat && needsGrounding) would
-// return false here — this test fails against that old behavior and passes now.
-test('shouldGroundBeforeTurn grounds an unsaved tab on a CONTINUED (non-fresh) chat', () => {
-  assert.equal(
-    shouldGroundBeforeTurn({ isPersisted: false }, { freshChat: false }),
-    true
-  )
-  assert.equal(
-    shouldGroundBeforeTurn({ isTemporary: true }, { freshChat: false }),
-    true
-  )
+// must STILL be a grounding candidate. A fresh-chat-only gate would return false.
+test('shouldGroundBeforeTurn flags an unsaved tab on a CONTINUED (non-fresh) chat', () => {
+  assert.equal(shouldGroundBeforeTurn({ isPersisted: false }, { freshChat: false }), true)
+  assert.equal(shouldGroundBeforeTurn({ isTemporary: true }, { freshChat: false }), true)
 })
 
-test('shouldGroundBeforeTurn also grounds an unsaved tab on a fresh chat', () => {
-  assert.equal(
-    shouldGroundBeforeTurn({ isPersisted: false }, { freshChat: true }),
-    true
-  )
+test('shouldGroundBeforeTurn also flags an unsaved tab on a fresh chat, never a persisted one', () => {
+  assert.equal(shouldGroundBeforeTurn({ isPersisted: false }, { freshChat: true }), true)
+  assert.equal(shouldGroundBeforeTurn({ isPersisted: true, isTemporary: false }, { freshChat: true }), false)
+  assert.equal(shouldGroundBeforeTurn({ isPersisted: true, isTemporary: false }, { freshChat: false }), false)
 })
 
-test('shouldGroundBeforeTurn never grounds an already-persisted workflow', () => {
-  assert.equal(
-    shouldGroundBeforeTurn({ isPersisted: true, isTemporary: false }, { freshChat: true }),
-    false
-  )
-  assert.equal(
-    shouldGroundBeforeTurn({ isPersisted: true, isTemporary: false }, { freshChat: false }),
-    false
-  )
-})
-
-// #330 safety gate — a per-turn save must NOT overwrite a real on-disk file whose
-// `isTemporary` flag merely drifted (#215/#226). groundingIsSafe authorizes a save
-// only when the source is PROVABLY never-persisted via the disk oracle.
-test('groundingIsSafe grounds a brand-new tab with no backing path (no oracle needed)', async () => {
-  assert.equal(await groundingIsSafe({ isPersisted: false }, async () => 404), true)
-  assert.equal(await groundingIsSafe({ isTemporary: true, path: '' }, async () => 404), true)
-})
-
+// groundingIsSafe authorizes a per-turn save ONLY on positive disk proof of absence.
 test('groundingIsSafe grounds a placeholder tab the oracle PROVES absent (404)', async () => {
-  const oracle = async () => false // 404 → absent
   assert.equal(
-    await groundingIsSafe({ isPersisted: false, path: 'workflows/Unsaved Workflow.json' }, oracle),
+    await groundingIsSafe({ isPersisted: false, path: 'workflows/Unsaved Workflow.json' }, async () => false),
     true
   )
 })
 
-// CORE #330 data-loss guard: a workflow flagged temporary (drifted) but PRESENT on
-// disk must NEVER be auto-saved over. FAIL-BEFORE (flag-only needsGrounding) would
-// authorize the overwrite; groundingIsSafe refuses it.
+// #330 data-loss guard: a drifted-temporary workflow PRESENT on disk must never be
+// auto-saved over. A flag-only predicate would authorize it; groundingIsSafe refuses.
 test('groundingIsSafe REFUSES a drifted-temporary workflow that exists on disk', async () => {
-  const oracle = async () => true // 200 → real file present
   assert.equal(
-    await groundingIsSafe({ isTemporary: true, isPersisted: false, path: 'workflows/MyFlow.json' }, oracle),
+    await groundingIsSafe({ isTemporary: true, isPersisted: false, path: 'workflows/MyFlow.json' }, async () => true),
     false
   )
 })
 
-test('groundingIsSafe fails safe (refuses) when the disk oracle is unknown or missing', async () => {
-  assert.equal(
-    await groundingIsSafe({ isTemporary: true, path: 'workflows/MyFlow.json' }, async () => null),
-    false
-  )
+// P1 — refuse whenever we cannot POSITIVELY prove absence: unknown/throwing oracle,
+// missing oracle, AND the pathless case (cannot probe ⇒ do not blanket-approve).
+test('groundingIsSafe fails safe (refuses) when absence cannot be proven', async () => {
+  // unknown / throwing oracle
+  assert.equal(await groundingIsSafe({ isTemporary: true, path: 'workflows/MyFlow.json' }, async () => null), false)
   assert.equal(
     await groundingIsSafe({ isTemporary: true, path: 'workflows/MyFlow.json' }, async () => { throw new Error('net') }),
     false
   )
-  // No oracle function at all ⇒ cannot prove ⇒ refuse.
-  assert.equal(
-    await groundingIsSafe({ isTemporary: true, path: 'workflows/MyFlow.json' }),
-    false
-  )
+  // no oracle at all
+  assert.equal(await groundingIsSafe({ isTemporary: true, path: 'workflows/MyFlow.json' }), false)
+  // pathless tab — cannot probe ⇒ refuse (even with an oracle available)
+  assert.equal(await groundingIsSafe({ isPersisted: false }, async () => false), false)
+  assert.equal(await groundingIsSafe({ isTemporary: true, path: '' }, async () => false), false)
 })
 
 test('groundingIsSafe never grounds a genuinely persisted workflow', async () => {
@@ -102,4 +77,86 @@ test('groundingIsSafe never grounds a genuinely persisted workflow', async () =>
     await groundingIsSafe({ isPersisted: true, path: 'workflows/MyFlow.json' }, async () => false),
     false
   )
+})
+
+// P0 — the safety probe and the write must bind to the SAME workflow. If the user
+// switches from a genuinely-temporary tab A to a drifted-temporary REAL tab B while
+// A's disk HEAD is pending, A's 404 must NOT authorize a write to B. groundActiveWorkflow
+// passes expect:A → saveActiveWorkflow refuses because activeWorkflow is now B.
+test('groundActiveWorkflow REFUSES a tab switch during the probe — never overwrites tab B (P0)', async () => {
+  const A = { isPersisted: false, isTemporary: true, path: 'workflows/Untitled A.json', filename: 'Untitled A', directory: 'workflows' }
+  const B = { isPersisted: true, isTemporary: false, path: 'workflows/MyFlow.json', filename: 'MyFlow', directory: 'workflows' }
+  let active = A
+  const writes = []
+  const svc = {
+    get activeWorkflow() { return active },
+    getWorkflowByPath: () => null,
+    saveWorkflow: async (wf) => { writes.push(['saveWorkflow', wf.path]) },
+    saveWorkflowAs: async (wf) => { writes.push(['saveWorkflowAs', wf.path]) },
+    saveAs: (wf, path) => { writes.push(['saveAs', path]); return { path, filename: path.split('/').pop() } },
+    openWorkflow: async () => {},
+    renameWorkflow: async () => { writes.push(['renameWorkflow']) }
+  }
+  // A's HEAD proves absent (safe) but the user switches to B during the await.
+  const existsOnDisk = async () => { active = B; return false }
+  const result = await groundActiveWorkflow(svc, { existsOnDisk, autoWorkflowName: () => 'Untitled X' })
+  assert.equal(result, null)      // refused — nothing saved
+  assert.equal(writes.length, 0)  // B's real file was NEVER written
+})
+
+// P1 — a single-flight guard: two concurrent turns must produce exactly ONE grounded
+// copy, not two (delayed HEADs crossing the auto-name boundary otherwise double-save).
+test('groundActiveWorkflow single-flights concurrent turns into ONE save (no duplicate)', async () => {
+  const A = { isPersisted: false, isTemporary: true, path: 'workflows/Unsaved Workflow.json', filename: 'Unsaved Workflow', directory: 'workflows', initialMode: 'default' }
+  let active = A
+  const disk = new Set(['workflows/Unsaved Workflow.json'])
+  let copySaves = 0
+  const svc = {
+    get activeWorkflow() { return active },
+    set activeWorkflow(v) { active = v },
+    getWorkflowByPath: (p) => (disk.has(p) && p !== A.path ? { path: p, isPersisted: true } : (active && active.path === p ? active : null)),
+    saveAs: (wf, path) => ({ path, filename: path.split('/').pop(), directory: 'workflows', initialMode: 'default', isPersisted: false, isTemporary: true, changeTracker: { prepareForSave() {} } }),
+    openWorkflow: async (copy) => { active = copy },
+    saveWorkflow: async (copy) => { copySaves += 1; disk.add(copy.path) }
+  }
+  // Slow, always-absent HEAD so both turns overlap before either save completes.
+  const existsOnDisk = async () => { await new Promise((r) => setTimeout(r, 5)); return false }
+  const opts = { existsOnDisk, autoWorkflowName: () => 'Untitled X', reconcileSavedCopy: async () => 'unknown' }
+  await Promise.all([groundActiveWorkflow(svc, opts), groundActiveWorkflow(svc, opts)])
+  assert.equal(copySaves, 1) // exactly one grounded copy despite two concurrent turns
+})
+
+// P1 (deeper interleaving) — the atomic copy-trio activates a FRESH temporary copy
+// (openWorkflow) BEFORE its write commits. A turn arriving in THAT window must not
+// ground the pre-commit copy as a second save. Serializing per SERVICE prevents it.
+test('groundActiveWorkflow does not double-save a turn that arrives during the copy pre-commit window', async () => {
+  const A = { isPersisted: false, isTemporary: true, path: 'workflows/Unsaved Workflow.json', filename: 'Unsaved Workflow', directory: 'workflows', initialMode: 'default' }
+  let active = A
+  const disk = new Set([A.path])
+  let copySaves = 0
+  let firstSave = true
+  let releaseSave
+  const saveGate = new Promise((r) => { releaseSave = r })
+  const svc = {
+    get activeWorkflow() { return active },
+    set activeWorkflow(v) { active = v },
+    getWorkflowByPath: (p) => (disk.has(p) && p !== A.path ? { path: p, isPersisted: true } : (active && active.path === p ? active : null)),
+    saveAs: (wf, path) => ({ path, filename: path.split('/').pop(), directory: 'workflows', initialMode: 'default', isPersisted: false, isTemporary: true, changeTracker: { prepareForSave() {} } }),
+    openWorkflow: async (copy) => { active = copy }, // copy becomes active BEFORE the commit
+    saveWorkflow: async (copy) => {
+      if (firstSave) { firstSave = false; await saveGate } // hang the first commit
+      copySaves += 1
+      disk.add(copy.path)
+      copy.isPersisted = true
+      copy.isTemporary = false
+    }
+  }
+  const opts = { existsOnDisk: async () => false, autoWorkflowName: () => 'Untitled X', reconcileSavedCopy: async () => 'unknown' }
+  const p1 = groundActiveWorkflow(svc, opts)
+  await new Promise((r) => setTimeout(r, 15)) // let turn1 reach the hung commit (active is now the copy)
+  const p2 = groundActiveWorkflow(svc, opts) // arrives DURING the copy pre-commit window
+  await new Promise((r) => setTimeout(r, 5))
+  releaseSave()
+  await Promise.all([p1, p2])
+  assert.equal(copySaves, 1) // the pre-commit copy was NOT grounded a second time
 })

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -144,7 +144,7 @@ import {
   refreshNodeArea,
 } from "./lib/group-geometry.js";
 import { pickRevertSnapshot } from "./lib/graph-revert.js";
-import { saveActiveWorkflow } from "./lib/workflow-save.js";
+import { saveActiveWorkflow, needsGrounding, shouldGroundBeforeTurn, groundingIsSafe } from "./lib/workflow-save.js";
 import { createRunCompletionTracker } from "./lib/run-completion.js";
 import { composeRunCompletionFrame } from "./lib/run-completion-frame.js";
 import {
@@ -2572,7 +2572,11 @@ async function workflowExistsOnDisk(rawPath) {
 async function groundUnsavedWorkflow() {
   try {
     const wf = app?.extensionManager?.workflow?.activeWorkflow;
-    if (!wf || (wf.isPersisted !== false && wf.isTemporary !== true)) return null;
+    if (!needsGrounding(wf)) return null;
+    // #330: per-turn grounding must NOT overwrite a real on-disk file whose
+    // temporary flag merely drifted (#215/#226). Only save when the source is
+    // provably never-persisted, confirmed against the disk oracle.
+    if (!(await groundingIsSafe(wf, workflowExistsOnDisk))) return null;
     return await programmaticSave();
   } catch {
     return null; // best-effort — never block the chat on a save hiccup
@@ -17005,9 +17009,13 @@ function buildPanel() {
         `Load Video/file node or pass the path to the comfyui tools):\n${lines}]`;
     }
 
-    // Ground a brand-new chat: if the open workflow was never saved, save it
-    // first so the agent works from a real file (Ctrl+S / reload behave).
-    if (freshChat) {
+    // Ground an unsaved workflow before EVERY turn (#330) — NOT only a brand-new
+    // chat. Continuing an existing chat inside an unsaved tab still leaves the
+    // user's edits unprotected until they hit disk, so save first so the agent
+    // works from a real file (Ctrl+S / reload behave). groundUnsavedWorkflow is
+    // idempotent (a no-op once persisted); shouldGroundBeforeTurn ignores chat
+    // freshness so a per-turn continuation is protected too.
+    if (shouldGroundBeforeTurn(app?.extensionManager?.workflow?.activeWorkflow, { freshChat })) {
       const saved = await groundUnsavedWorkflow();
       if (saved) appendSystem(`Saved your workflow as “${saved}” — grounded base for the agent.`);
     }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -144,7 +144,7 @@ import {
   refreshNodeArea,
 } from "./lib/group-geometry.js";
 import { pickRevertSnapshot } from "./lib/graph-revert.js";
-import { saveActiveWorkflow, needsGrounding, shouldGroundBeforeTurn, groundingIsSafe } from "./lib/workflow-save.js";
+import { saveActiveWorkflow, shouldGroundBeforeTurn, groundActiveWorkflow } from "./lib/workflow-save.js";
 import { createRunCompletionTracker } from "./lib/run-completion.js";
 import { composeRunCompletionFrame } from "./lib/run-completion-frame.js";
 import {
@@ -2571,13 +2571,16 @@ async function workflowExistsOnDisk(rawPath) {
  *  agent works from a grounded file. Best-effort. Returns the saved name or null. */
 async function groundUnsavedWorkflow() {
   try {
-    const wf = app?.extensionManager?.workflow?.activeWorkflow;
-    if (!needsGrounding(wf)) return null;
-    // #330: per-turn grounding must NOT overwrite a real on-disk file whose
-    // temporary flag merely drifted (#215/#226). Only save when the source is
-    // provably never-persisted, confirmed against the disk oracle.
-    if (!(await groundingIsSafe(wf, workflowExistsOnDisk))) return null;
-    return await programmaticSave();
+    // #330: ground the active workflow ATOMICALLY — probe its on-disk state and save
+    // the EXACT SAME workflow (refusing if the user switched tabs during the async
+    // probe, so we can't authorize on tab A and overwrite tab B), single-flighted so
+    // concurrent turns can't create duplicate copies. Only a provably never-persisted
+    // source is saved; anything unprovable is left for a manual Ctrl+S.
+    return await groundActiveWorkflow(app?.extensionManager?.workflow, {
+      existsOnDisk: workflowExistsOnDisk,
+      autoWorkflowName,
+      reconcileSavedCopy: reconcileSavedWorkflowCopy,
+    });
   } catch {
     return null; // best-effort — never block the chat on a save hiccup
   }

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -72,27 +72,82 @@ export function shouldGroundBeforeTurn(wf, { freshChat } = {}) {
  *  (#215/#226). Grounding once per fresh chat made that a rare edge; grounding on
  *  EVERY turn (#330) would repeatedly reach saveActiveWorkflow's in-place branch and
  *  overwrite a REAL file with the current (possibly mid-load) canvas. So authorize a
- *  per-turn save only when the source is PROVABLY never-persisted — mirroring
- *  classifySource's tri-state proof — via an async disk oracle
+ *  per-turn save ONLY on POSITIVE disk proof that the source is never-persisted —
+ *  mirroring classifySource's tri-state proof — via an async disk oracle
  *  `existsOnDisk(rawPath) => true | false | null`:
  *    - isPersisted === true              → false (genuinely saved; never auto-ground)
- *    - no backing path                   → true  (brand-new tab, nothing to lose)
+ *    - no usable disk oracle             → false (cannot prove ⇒ refuse)
+ *    - no backing path to probe          → false (cannot prove absence ⇒ refuse; the
+ *                                          user can still Ctrl+S. An automatic save we
+ *                                          cannot verify could still collide.)
  *    - oracle proves ABSENT (404)        → true
- *    - oracle proves PRESENT / unknown   → false (fail safe — the user can Ctrl+S)
- *  With no usable oracle we can prove nothing → false (refuse), never a blind save. */
+ *    - oracle proves PRESENT / unknown   → false (fail safe)
+ *  Anything short of a proven absence refuses — never a blind auto-save. */
 export async function groundingIsSafe(wf, existsOnDisk) {
   if (!wf) return false;
   if (wf.isPersisted === true) return false;
+  if (typeof existsOnDisk !== "function") return false; // no oracle ⇒ cannot prove ⇒ refuse
   const raw = wf.path;
-  if (!raw) return true; // no path at all ⇒ nothing on disk to lose
-  if (typeof existsOnDisk !== "function") return false; // cannot prove ⇒ refuse
+  if (!raw) return false; // pathless ⇒ cannot probe ⇒ refuse (do not blanket-approve)
   let exists = null;
   try {
     exists = await existsOnDisk(raw);
   } catch {
     exists = null; // probe failed ⇒ unknown ⇒ refuse
   }
-  return exists === false; // ONLY a proven absence authorizes the save
+  return exists === false; // ONLY a proven absence (404) authorizes the save
+}
+
+// #330 single-flight: SERIALIZE grounding per workflow SERVICE, not per workflow
+// instance. The atomic copy-trio activates a FRESH temporary copy (openWorkflow)
+// BEFORE its write commits, so the active-workflow identity changes mid-save — a
+// concurrent turn keyed by instance would ground that pre-commit copy under a new
+// key and double-save. A per-service chain makes each grounding wait for the prior
+// one, then RE-EVALUATE the (now possibly persisted) active workflow.
+const _groundingChain = new Map(); // svc -> tail Promise<void>
+
+/** One grounding attempt: probe the ACTIVE workflow's on-disk state, then save the
+ *  EXACT SAME workflow it probed (`expect: wf` → saveActiveWorkflow refuses if the
+ *  active workflow changed during the async probe, so we never authorize on tab A
+ *  and write to tab B). Best-effort: any refusal/hiccup ⇒ null (leave ungrounded). */
+async function groundOnce(svc, { existsOnDisk, autoWorkflowName, reconcileSavedCopy } = {}) {
+  try {
+    const wf = svc?.activeWorkflow;
+    if (!needsGrounding(wf)) return null;
+    if (!(await groundingIsSafe(wf, existsOnDisk))) return null;
+    return await saveActiveWorkflow(svc, undefined, {
+      autoWorkflowName,
+      existsOnDisk,
+      reconcileSavedCopy,
+      expect: wf,
+    });
+  } catch {
+    return null;
+  }
+}
+
+/** #330 — atomically ground the ACTIVE workflow on every agent turn, SERIALIZED per
+ *  service so concurrent turns can't create duplicate grounded copies. A later turn
+ *  waits for the in-flight grounding to finish and then re-evaluates against the
+ *  current active workflow (which, after a successful ground, is persisted → a no-op).
+ *  Returns the saved name, or null when nothing was (safely) saved. */
+export async function groundActiveWorkflow(svc, opts = {}) {
+  // Fast path: nothing to ground and no chain running → skip without touching state.
+  if (!needsGrounding(svc?.activeWorkflow) && !_groundingChain.get(svc)) return null;
+  const prior = _groundingChain.get(svc) ?? Promise.resolve();
+  // Chain AFTER the prior grounding (ignoring its outcome), then re-evaluate now.
+  const result = prior.then(() => groundOnce(svc, opts));
+  const tail = result.then(
+    () => {},
+    () => {},
+  );
+  _groundingChain.set(svc, tail);
+  try {
+    return await result;
+  } finally {
+    // Only clear if we're still the tail — a newer queued turn may have extended it.
+    if (_groundingChain.get(svc) === tail) _groundingChain.delete(svc);
+  }
 }
 
 /** Save the active workflow through ComfyUI's workflow service — NO dialog.
@@ -126,10 +181,26 @@ export async function groundingIsSafe(wf, existsOnDisk) {
 export async function saveActiveWorkflow(
   svc,
   name,
-  { autoWorkflowName, existsOnDisk, reconcileSavedCopy } = {},
+  { autoWorkflowName, existsOnDisk, reconcileSavedCopy, expect } = {},
 ) {
   const wf = svc?.activeWorkflow;
   if (!wf) throw new Error("no active workflow to save");
+
+  // #330 TOCTOU guard: a grounding caller passes `expect` — the exact workflow it
+  // probed on disk before this save. If the active workflow changed in between (the
+  // user switched tabs during the async /userdata HEAD), we'd authorize on workflow
+  // A but write to workflow B — an overwrite of a DIFFERENT, possibly persisted file.
+  // REFUSE instead. Re-checked again immediately before every write (assertExpect),
+  // since the classify/collision probes below also await. `expect` is undefined for
+  // ordinary (explicit) saves, so their behaviour is unchanged.
+  const assertExpect = () => {
+    if (expect !== undefined && svc?.activeWorkflow !== expect) {
+      throw new Error(
+        "active workflow changed during grounding — refusing to save the wrong workflow (issue #330)",
+      );
+    }
+  };
+  assertExpect();
 
   // An EXPLICIT name (any string, even "  ") must resolve to a real name. If it
   // normalizes to empty, refuse — never silently reinterpret an explicit-but-
@@ -231,6 +302,7 @@ export async function saveActiveWorkflow(
             "refusing to move or destroy the original file outside the workflows folder (issue #285/#226)",
         );
       }
+      assertExpect(); // #330: still the workflow we probed?
       return await withConflictRollback(svc, wf, effectiveName, finalTargetPath, () =>
         copyToUserDir(wf, effectiveName, finalTargetPath),
       );
@@ -275,6 +347,7 @@ export async function saveActiveWorkflow(
     // retroactively protect a victim file the server already replaced) is upstream-only.
     const atomicCopy = resolveSaveAsCopy(svc, { reconcileSavedCopy });
     if (atomicCopy) {
+      assertExpect(); // #330: still the workflow we probed?
       const activeName = await withConflictRollback(svc, wf, effectiveName, finalTargetPath, () =>
         atomicCopy(wf, effectiveName, finalTargetPath),
       );
@@ -309,6 +382,7 @@ export async function saveActiveWorkflow(
 
   // No relocation — the target path equals the current on-disk path. Overwriting
   // the same file in place is safe (no move can occur).
+  assertExpect(); // #330: never in-place-overwrite a workflow the user switched to
   await saveInPlace(svc, wf);
   return desired || currentName || null;
 }

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -47,6 +47,54 @@ export function isDefaultWorkflowName(name) {
   return !n || /^Unsaved Workflow\b/i.test(n) || /^Untitled\b/.test(n);
 }
 
+/** True when the active workflow has never been persisted to disk (a temporary /
+ *  unsaved tab), so grounding must save it. Mirrors saveActiveWorkflow's
+ *  `wasUnsaved` (isTemporary === true || isPersisted === false). */
+export function needsGrounding(wf) {
+  return !!wf && (wf.isPersisted === false || wf.isTemporary === true);
+}
+
+/** #330 — decide whether to ground (auto-save) the active workflow BEFORE an agent
+ *  turn. Grounding must run on EVERY turn that targets an unsaved tab, not only a
+ *  brand-new chat: continuing an existing chat inside an unsaved tab still leaves
+ *  the user's edits unprotected until they hit disk. `freshChat` is accepted (the
+ *  call site has it) but is DELIBERATELY NOT a factor — a future change that
+ *  reintroduces a fresh-chat-only gate would flip this contract and fail its test. */
+export function shouldGroundBeforeTurn(wf, { freshChat } = {}) {
+  void freshChat; // intentionally ignored — grounding is per-turn, see #330
+  return needsGrounding(wf);
+}
+
+/** #330 safety gate: is a per-turn grounding SAVE actually safe to perform?
+ *
+ *  needsGrounding() trusts the in-memory `isTemporary`/`isPersisted` flags, but
+ *  `isTemporary` DRIFTS true for a workflow already on disk after an open-ack race
+ *  (#215/#226). Grounding once per fresh chat made that a rare edge; grounding on
+ *  EVERY turn (#330) would repeatedly reach saveActiveWorkflow's in-place branch and
+ *  overwrite a REAL file with the current (possibly mid-load) canvas. So authorize a
+ *  per-turn save only when the source is PROVABLY never-persisted — mirroring
+ *  classifySource's tri-state proof — via an async disk oracle
+ *  `existsOnDisk(rawPath) => true | false | null`:
+ *    - isPersisted === true              → false (genuinely saved; never auto-ground)
+ *    - no backing path                   → true  (brand-new tab, nothing to lose)
+ *    - oracle proves ABSENT (404)        → true
+ *    - oracle proves PRESENT / unknown   → false (fail safe — the user can Ctrl+S)
+ *  With no usable oracle we can prove nothing → false (refuse), never a blind save. */
+export async function groundingIsSafe(wf, existsOnDisk) {
+  if (!wf) return false;
+  if (wf.isPersisted === true) return false;
+  const raw = wf.path;
+  if (!raw) return true; // no path at all ⇒ nothing on disk to lose
+  if (typeof existsOnDisk !== "function") return false; // cannot prove ⇒ refuse
+  let exists = null;
+  try {
+    exists = await existsOnDisk(raw);
+  } catch {
+    exists = null; // probe failed ⇒ unknown ⇒ refuse
+  }
+  return exists === false; // ONLY a proven absence authorizes the save
+}
+
 /** Save the active workflow through ComfyUI's workflow service — NO dialog.
  *
  *  Behaviour:


### PR DESCRIPTION
## #330 — ground unsaved workflows on every turn (not just a brand-new chat)

`groundUnsavedWorkflow()` ran only under the `if (freshChat)` gate, so **continuing an existing chat inside an unsaved tab** left the user's edits ungrounded (no real file → Ctrl+S / reload misbehave, and the agent works from a non-persisted graph).

Per-turn grounding is now correct **and** data-safe:

- **Per-turn predicate** — pure `needsGrounding(wf)` / `shouldGroundBeforeTurn(wf, {freshChat})` (freshChat deliberately ignored) in `lib/workflow-save.js`; the call site grounds on every turn.
- **Atomic bind (P0 data-loss)** — the safety probe and the write must target the SAME workflow. `groundActiveWorkflow()` captures the probed `wf` and passes `expect: wf` to `saveActiveWorkflow`, which re-verifies `svc.activeWorkflow === expect` at entry **and before every write** (external copy / atomic copy-trio / in-place) and refuses on mismatch. A tab switch during the async `/userdata` HEAD can no longer authorize on tab A and overwrite tab B.
- **Fail-closed (P1)** — `groundingIsSafe()` grounds only on POSITIVE disk proof of absence: `isPersisted===true` → refuse; no oracle → refuse; **pathless → refuse**; 404 → ground; present/unknown/throw → refuse.
- **Single-flight, per service (P1)** — grounding is serialized per workflow service via a chain that re-evaluates the current active workflow after the prior grounding completes. This closes both the naive concurrent-submit double-save **and** the subtle interleaving where the copy-trio's `openWorkflow(copy)` activates a fresh temporary before its write commits.

## Tests
`browser_tests/unit/workflow-grounding.test.mjs` (11):
- continued (non-fresh) unsaved chat is a grounding candidate; persisted never is.
- `groundingIsSafe` grounds a 404 tab; **refuses** a drifted-temporary on-disk file, pathless, unknown/throwing, and missing-oracle.
- **P0**: tab-switch-during-probe refuses — B's real file is never written.
- **P1**: concurrent turns → exactly one save; a turn arriving during the copy pre-commit window → no double-save.
- Full panel unit suite green (652); typecheck clean; ES-module parse verified.

## Codex self-gate
gpt-5.6-terra/high adversarial embed-diff review (blocking): round 1 → drift-overwrite P1; round 2 → **P0 TOCTOU** + pathless/unknown bypass + instance-keyed single-flight; round 3 → per-service serialization → **VERDICT: PASS**.

Companion PR (orchestrator repo, #360/#376): artokun/comfyui-mcp#576.

Closes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)
