### PR TITLE
release: 0.11.21 — Save-As never clobbers original (#375); reliable run completion across drops (#425); set_widget fail-closed (#423)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.21] - 2026-07-31
+
+### Fixed
+- **Save-As never clobbers or moves the original workflow (#285, #309, #289).** External-path Save-As writes with `overwrite:false` so an existing target returns a clean 409 instead of silently replacing/renaming the source, and the node-def cache is refreshed before `add_node` so a freshly-installed pack's nodes are addable. Live-verified on the rig against real ComfyUI: overwrite-refused → 409, original marker survived intact. (#375)
+- **A run's completion event fires reliably even across a connection drop, and top-level prompt rejections surface (#358, #370).** `graph_run` now surfaces a top-level ComfyUI prompt rejection instead of hanging, and run reconciliation gives up only when the prompt is absent from BOTH `/history` and `/queue` — so a WS blip mid-render can no longer strand a running render or drop its completion. (#425)
+- **`set_widget` fails closed on a removed or unverifiable node type (#458 set_widget gap).** A widget write against a node type that can't be verified via a fresh `/object_info` is now refused rather than fabricating success. (#423)
+- **Promoted subgraph writes update the authoritative parent-rail widget (#366).** A write to a promoted widget syncs the parent rail (the source of truth), not just the inner node. (#383)
+- **Unsaved-workflow tabs get a unique per-instance routing identity so graph edits never misroute (#186).** (#386)
+- Ground unsaved workflows on every agent turn, disk-safely (#432).
+- Live-geometry group membership after node moves (#355) + non-no-op revert (#327). (#431)
+- `panel_update_node` reports a Manager task failure instead of false success (#364). (#382)
+- Author/repo install shorthand, dead-collapse fallback, storyboard input litter. (#424)
+- Consistent subgraph scope tracking + rail-id move + boundary cleanup + read/edit scope lockstep (#308, #302, #234, #220). (#373)
+
+
 ## [0.11.20] - 2026-07-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.20"
+version = "0.11.21"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -282,7 +282,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.20";
+const PANEL_VERSION = "0.11.21";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
## Release 0.11.21

Version-bump PR. Bumps `pyproject.toml` version + `PANEL_VERSION` together (0.11.20 → 0.11.21) and stamps the changelog. Registry publish fires on the pyproject change to main.

Ten fixes since 0.11.20 — all previously merged, codex-gated (terra/high), CI-green PRs. Highlights (the three release blockers):

- **#375** — external-path **Save-As never clobbers or moves the original** (`overwrite:false` → clean 409; #285/#309/#289). **Live-verified on the rig** against real ComfyUI 1.47: overwrite-refused → 409, original marker survived intact, new-name copy created.
- **#425** — run completion fires reliably **even across a connection drop**; reconciliation gives up only when the prompt is absent from BOTH `/history` and `/queue`, and `graph_run` surfaces top-level prompt rejection (#358/#370).
- **#423** — `set_widget` **fails closed** on a removed/unverifiable node type via a fresh `/object_info` (#458 set_widget gap).

Plus: promoted subgraph writes sync the authoritative parent rail (#366/#383), unsaved-tab routing identity (#186/#386), Manager-failure honesty (#364/#382), group live-geometry (#355/#431), disk-safe grounding (#432), install shorthand + storyboard litter (#424), subgraph scope lockstep (#373).

The merged panel JS was **live-tested loading clean** in real ComfyUI 1.47 (zero panel-side console errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)