### PR TITLE
fix(save): panel_save_workflow writes a new file, never moves/destroys the original (#579, #363)

### DIFF
--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -3,7 +3,8 @@ import test from 'node:test'
 
 import {
   isDefaultWorkflowName,
-  saveActiveWorkflow
+  saveActiveWorkflow,
+  describeSaveOutcome
 } from '../../web/js/lib/workflow-save.js'
 
 // A minimal ComfyUI workflow-service double that records what was called and
@@ -2050,4 +2051,165 @@ test('refuses to rename-destroy a persisted workflow when no copy API exists', a
   // Source untouched; nothing moved.
   assert.ok(svc.disk.has('workflows/Foo.json'))
   assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'))
+})
+
+// ---------------------------------------------------------------------------
+// EXACT-SCENARIO regressions for mcp#579 and panel#363 (reported on panel 0.11.6
+// against a ComfyUI 0.28.3 / frontend-1.47.x store). Both are reproduced through
+// the SAME saveActiveWorkflow path that panel_save_workflow → workflow_save_as →
+// programmaticSave invokes, on the 1.47 store double that mirrors that frontend.
+// They must NOT move/destroy the original and must NOT refuse a new-workflow save.
+
+test('mcp#579: Save-As of an open PERSISTED workflow COPIES — the original file survives, never moved (1.47)', async () => {
+  // The literal reported case: an on-disk "UGC - 01 …" workflow is open; the agent
+  // calls panel_save_workflow({name:"UGC - 06 …"}) intending a Save-As. The original
+  // must remain on disk (the ComfyUI log's `moving 'UGC - 01…' -> 'UGC - 06…'` must
+  // NOT happen), and a NEW file must be written with the real graph content.
+  const active = {
+    path: 'workflows/UGC - 01 Imagem para Video (TI2V-5B).json',
+    filename: 'UGC - 01 Imagem para Video (TI2V-5B).json',
+    directory: 'workflows',
+    isPersisted: true,
+    isTemporary: false
+  }
+  const { svc, existsOnDisk, graph } = makeStore147Service({ files: [active.path], active })
+  const originalContentBefore = svc.disk.get(active.path)
+
+  const details = {}
+  const saved = await saveActiveWorkflow(svc, 'UGC - 06 Cena 1 Leticia (TI2V-5B + Wav2Lip)', {
+    existsOnDisk,
+    details
+  })
+
+  // AUTHORITATIVE outcome the tool result is built from: a Save-As COPY of the real
+  // source, with the source path/name recorded for the caller's disk re-verification.
+  assert.equal(details.mode, 'save-as-copy', 'reported as a Save-As copy (not silent, not first-save)')
+  assert.equal(details.sourcePath, 'workflows/UGC - 01 Imagem para Video (TI2V-5B).json')
+  assert.deepEqual(describeSaveOutcome(details), {
+    saved_as: true,
+    copied_from: 'UGC - 01 Imagem para Video (TI2V-5B)'
+  })
+
+  // The ORIGINAL is untouched on disk — copy, not move (the #579 data-loss guard).
+  assert.ok(
+    svc.disk.has('workflows/UGC - 01 Imagem para Video (TI2V-5B).json'),
+    'ORIGINAL preserved on disk — not moved/renamed (mcp#579)'
+  )
+  assert.equal(
+    svc.disk.get('workflows/UGC - 01 Imagem para Video (TI2V-5B).json'),
+    originalContentBefore,
+    'original file content byte-identical (untouched)'
+  )
+  // The new file exists with the real graph.
+  assert.ok(
+    svc.disk.has('workflows/UGC - 06 Cena 1 Leticia (TI2V-5B + Wav2Lip).json'),
+    'new Save-As file created'
+  )
+  assert.deepEqual(
+    JSON.parse(svc.disk.get('workflows/UGC - 06 Cena 1 Leticia (TI2V-5B + Wav2Lip).json')),
+    graph,
+    'new file holds the real graph, not "null"'
+  )
+  // It took the move-free atomic copy path; the source was NEVER renamed/moved.
+  assert.ok(svc.calls.some((c) => c[0] === 'saveAs'), 'used the atomic low-level saveAs copy')
+  assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'source was NEVER renamed (no MOVE)')
+  assert.equal(saved, 'UGC - 06 Cena 1 Leticia (TI2V-5B + Wav2Lip)')
+})
+
+test('panel#363: naming a workflow created by panel_new_workflow (temp tab) SUCCEEDS as a first save (1.47)', async () => {
+  // panel_new_workflow opens a blank temporary tab (isTemporary=true, no on-disk
+  // file). Its path 404s on disk. panel_save_workflow({name}) must persist it as a
+  // NEW file — NOT refuse with the destructive-rename guard (the panel#363 bug).
+  const active = {
+    path: 'workflows/Unsaved Workflow.json',
+    filename: 'Unsaved Workflow.json',
+    directory: 'workflows',
+    isPersisted: false,
+    isTemporary: true
+  }
+  const { svc, existsOnDisk, graph } = makeStore147Service({ active }) // disk EMPTY ⇒ 404
+
+  const details = {}
+  const saved = await saveActiveWorkflow(svc, 'Video Face Detail - Second Stage', {
+    autoWorkflowName: () => 'Untitled',
+    existsOnDisk,
+    details
+  })
+
+  // Reported as a FIRST save (no prior file to preserve) — never a Save-As move.
+  assert.equal(details.mode, 'first-save', 'a never-persisted temp tab first-save (panel#363)')
+  assert.deepEqual(describeSaveOutcome(details), { first_save: true })
+  assert.ok(
+    svc.disk.has('workflows/Video Face Detail - Second Stage.json'),
+    'new-workflow tab was named + persisted (panel#363 no longer refuses)'
+  )
+  assert.deepEqual(
+    JSON.parse(svc.disk.get('workflows/Video Face Detail - Second Stage.json')),
+    graph,
+    'persisted content is the real graph, not "null"'
+  )
+  assert.ok(svc.calls.some((c) => c[0] === 'saveAs'), 'used the atomic low-level saveAs copy')
+  assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'no source file to move — never renamed')
+  assert.equal(saved, 'Video Face Detail - Second Stage')
+})
+
+// ---------------------------------------------------------------------------
+// describeSaveOutcome — the pure mapper from saveActiveWorkflow's AUTHORITATIVE
+// `details.mode` to the tool-result fields, so panel_save_workflow reports what a
+// save did (mcp#579's "at minimum (2)": a rename-vs-copy must never be silent).
+// It maps the DECIDED mode, never an after-the-fact guess from the mutable tab.
+
+test('describeSaveOutcome: save-as-copy mode ⇒ saved_as + copied_from, extension stripped (mcp#579)', () => {
+  const out = describeSaveOutcome({
+    mode: 'save-as-copy',
+    copiedFrom: 'UGC - 01 Imagem para Video (TI2V-5B).json'
+  })
+  assert.deepEqual(out, { saved_as: true, copied_from: 'UGC - 01 Imagem para Video (TI2V-5B)' })
+  // It does NOT assert original_on_disk — that is a disk fact the caller verifies.
+  assert.ok(!('original_on_disk' in out), 'preservation is disk-checked by the caller, not inferred')
+})
+
+test('describeSaveOutcome: first-save mode (temp/new_workflow) ⇒ first_save (panel#363)', () => {
+  assert.deepEqual(describeSaveOutcome({ mode: 'first-save' }), { first_save: true })
+})
+
+test('describeSaveOutcome: in-place mode ⇒ no special flags', () => {
+  assert.deepEqual(describeSaveOutcome({ mode: 'in-place', sourcePath: 'workflows/Foo.json' }), {})
+})
+
+test('describeSaveOutcome: absent/undefined mode ⇒ no special flags', () => {
+  assert.deepEqual(describeSaveOutcome({}), {})
+  assert.deepEqual(describeSaveOutcome(), {})
+})
+
+test('outcome: an EXTERNAL-path Save-As reports save-as-copy (NOT first-save), even though the source is non-persisted (mcp#579/#285)', async () => {
+  // Finding-2 guard: an externally-loaded file is isPersisted:false/isTemporary:true
+  // yet is a REAL existing file being COPIED into the user dir — it must report a
+  // Save-As copy, never a first-save (which would wrongly imply "nothing to preserve").
+  const active = {
+    path: 'C:/packs/qwen/Product Label Repair.json',
+    filename: 'Product Label Repair.json',
+    directory: 'C:/packs/qwen',
+    isPersisted: false,
+    isTemporary: true,
+  }
+  const { svc, existsOnDisk } = makeStore147Service({ files: [active.path], active })
+
+  const details = {}
+  await saveActiveWorkflow(svc, 'Product Label Repair - Qwen Edit Q5', {
+    autoWorkflowName: () => 'Untitled',
+    existsOnDisk,
+    details,
+  })
+
+  assert.equal(details.mode, 'save-as-copy', 'external real file copied ⇒ save-as-copy, not first-save')
+  assert.equal(details.sourcePath, 'C:/packs/qwen/Product Label Repair.json', 'source path recorded for re-verification')
+  // sourceExternal must be flagged so the panel-level post-save HEAD is SKIPPED — a
+  // /userdata HEAD 404s on an absolute path and would else throw a false data-loss
+  // error for a perfectly-preserved external original (codex round-2 P1).
+  assert.equal(details.sourceExternal, true, 'external source flagged so the /userdata HEAD is not misread as a move')
+  assert.deepEqual(describeSaveOutcome(details), {
+    saved_as: true,
+    copied_from: 'Product Label Repair'
+  })
 })

--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -4,7 +4,8 @@ import test from 'node:test'
 import {
   isDefaultWorkflowName,
   saveActiveWorkflow,
-  describeSaveOutcome
+  describeSaveOutcome,
+  classifyOriginalOnDisk
 } from '../../web/js/lib/workflow-save.js'
 
 // A minimal ComfyUI workflow-service double that records what was called and
@@ -2212,4 +2213,64 @@ test('outcome: an EXTERNAL-path Save-As reports save-as-copy (NOT first-save), e
     saved_as: true,
     copied_from: 'Product Label Repair'
   })
+})
+
+// ---------------------------------------------------------------------------
+// classifyOriginalOnDisk — the throw/report decision for a Save-As COPY's source.
+// A hard data-loss throw ("lost") requires POSITIVE pre-save evidence (a confirmed
+// 200) now confirmed gone (404). Everything indeterminate degrades to "unverified"
+// so a legitimate first save / phantom source never false-alarms (codex P1 #1).
+
+test('classifyOriginalOnDisk: confirmed present-then-gone ⇒ lost (the only throw case)', () => {
+  assert.equal(classifyOriginalOnDisk({ preExisted: true, postExists: false }), 'lost')
+})
+
+test('classifyOriginalOnDisk: source never proven present ⇒ NEVER lost (no false data-loss throw)', () => {
+  // The exact P1 #1 repro: a non-temporary yet never-persisted tab whose source path
+  // 404s afterward simply because it never existed. preExisted is false/unknown ⇒
+  // must NOT be "lost".
+  assert.equal(classifyOriginalOnDisk({ preExisted: false, postExists: false }), 'unverified')
+  assert.equal(classifyOriginalOnDisk({ preExisted: null, postExists: false }), 'unverified')
+  assert.equal(classifyOriginalOnDisk({ preExisted: undefined, postExists: false }), 'unverified')
+})
+
+test('classifyOriginalOnDisk: source present afterward ⇒ present', () => {
+  assert.equal(classifyOriginalOnDisk({ preExisted: true, postExists: true }), 'present')
+  assert.equal(classifyOriginalOnDisk({ preExisted: null, postExists: true }), 'present')
+})
+
+test('classifyOriginalOnDisk: inconclusive post probe ⇒ unverified (never throws)', () => {
+  assert.equal(classifyOriginalOnDisk({ preExisted: true, postExists: null }), 'unverified')
+  assert.equal(classifyOriginalOnDisk({ preExisted: null, postExists: null }), 'unverified')
+  assert.equal(classifyOriginalOnDisk({}), 'unverified')
+})
+
+test('outcome: a WINDOWS ROOT-RELATIVE external source ("\\packs\\Foo.json") is external ⇒ save-as-copy + sourceExternal (codex P1 #2)', async () => {
+  // A single leading backslash is root-relative on the current drive — an EXTERNAL
+  // file, not a managed store path. It must copy into the user dir and report
+  // save-as-copy + sourceExternal, NEVER first-save (which would hide the real source
+  // and route the post-save HEAD into a false 404 alarm).
+  const srcPath = String.raw`\packs\Foo.json` // real single backslashes (root-relative)
+  const active = {
+    path: srcPath,
+    filename: 'Foo.json',
+    directory: String.raw`\packs`,
+    isPersisted: false,
+    isTemporary: true,
+  }
+  const { svc, existsOnDisk } = makeStore147Service({ files: [active.path], active })
+
+  const details = {}
+  await saveActiveWorkflow(svc, 'Foo Copy', {
+    autoWorkflowName: () => 'Untitled',
+    existsOnDisk,
+    details,
+  })
+
+  assert.equal(details.mode, 'save-as-copy', 'root-relative external source ⇒ save-as-copy, not first-save')
+  assert.equal(details.sourceExternal, true, 'flagged external so the /userdata HEAD is skipped')
+  // Copy landed in the USER workflows dir, external original untouched.
+  assert.ok(svc.disk.has('workflows/Foo Copy.json'), 'copy in the user workflows dir')
+  assert.ok(svc.disk.has(srcPath), 'external original preserved')
+  assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'never moved the external original')
 })

--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -5,7 +5,8 @@ import {
   isDefaultWorkflowName,
   saveActiveWorkflow,
   describeSaveOutcome,
-  classifyOriginalOnDisk
+  classifyOriginalOnDisk,
+  diskExistenceFromStatus
 } from '../../web/js/lib/workflow-save.js'
 
 // A minimal ComfyUI workflow-service double that records what was called and
@@ -437,7 +438,10 @@ test('item 2: a genuine NEW workflow with NO path grounds/saves (never refused) 
 test('disk-existence backstop catches a low-level copy that moves a persisted source (#226)', async () => {
   // Rogue frontend: the low-level saveAs ALSO deletes the source (a move). The pre-
   // check can't foresee this, so the post-op disk-existence backstop must catch the
-  // vanished source and throw rather than report success.
+  // vanished source and throw rather than report success. The backstop is now gated on
+  // CONFIRMED disk evidence (200 before -> 404 after), so the test supplies a disk
+  // oracle backed by svc.disk (an in-memory-only signal must NOT trip it — see the
+  // dedicated no-false-throw test below).
   const active = {
     path: 'workflows/zz226b-orig.json',
     filename: 'zz226b-orig.json',
@@ -446,6 +450,7 @@ test('disk-existence backstop catches a low-level copy that moves a persisted so
     isTemporary: false
   }
   const svc = makeFaithfulService({ files: [active.path], active })
+  const existsOnDisk = async (p) => svc.disk.has(p) // 200 while on disk, 404 once deleted
   const origSaveAs = svc.saveAs
   svc.saveAs = (wf, path) => {
     svc.disk.delete(wf.path) // ROGUE: consumes (moves) the source
@@ -453,7 +458,7 @@ test('disk-existence backstop catches a low-level copy that moves a persisted so
   }
 
   await assert.rejects(
-    () => saveActiveWorkflow(svc, 'zz226b-copy', {}),
+    () => saveActiveWorkflow(svc, 'zz226b-copy', { existsOnDisk }),
     /moved the original workflow .* instead of copying it/
   )
 })
@@ -2272,5 +2277,78 @@ test('outcome: a WINDOWS ROOT-RELATIVE external source ("\\packs\\Foo.json") is 
   // Copy landed in the USER workflows dir, external original untouched.
   assert.ok(svc.disk.has('workflows/Foo Copy.json'), 'copy in the user workflows dir')
   assert.ok(svc.disk.has(srcPath), 'external original preserved')
+  assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'never moved the external original')
+})
+
+// ---------------------------------------------------------------------------
+// Round-2 re-review: two MORE false-throw routes had to be closed.
+
+test('P1 #1b: an IN-MEMORY-absent source with an UNKNOWN disk oracle does NOT throw (backstop is disk-gated, #226)', async () => {
+  // The old backstop threw whenever getWorkflowByPath(source)==null after a copy — an
+  // in-memory signal that drifts stale once the copy activates. Here the copy succeeds,
+  // the source's in-memory lookup is null (stale), and the disk oracle is UNKNOWN for
+  // the source (a timed-out HEAD). That is NOT proof of on-disk loss ⇒ must NOT throw.
+  const active = {
+    path: 'workflows/Foo.json',
+    filename: 'Foo.json',
+    directory: 'workflows',
+    isPersisted: true,
+    isTemporary: false
+  }
+  const { svc } = makeStore147Service({ files: ['workflows/Foo.json'], active })
+  // Source disk-state UNKNOWN (null); everything else resolves via the seeded disk.
+  const existsOnDisk = async (p) => (p === 'workflows/Foo.json' ? null : svc.disk.has(p))
+  // Simulate in-memory staleness: the SOURCE lookup returns null (as if evicted), while
+  // target lookups behave normally (free).
+  const realGWBP = svc.getWorkflowByPath.bind(svc)
+  svc.getWorkflowByPath = (p) => (p === 'workflows/Foo.json' ? null : realGWBP(p))
+
+  const saved = await saveActiveWorkflow(svc, 'Bar', { existsOnDisk })
+
+  assert.equal(saved, 'Bar', 'reported success — no false "moved" throw')
+  assert.ok(svc.disk.has('workflows/Foo.json'), 'source still on disk (the copy never moved it)')
+  assert.ok(svc.disk.has('workflows/Bar.json'), 'copy created')
+  assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'never renamed')
+})
+
+test('P1 #1c: diskExistenceFromStatus treats ONLY 200 as present; non-200 2xx / redirects / 5xx are indeterminate', () => {
+  assert.equal(diskExistenceFromStatus(200), true, '200 ⇒ present')
+  assert.equal(diskExistenceFromStatus(404), false, '404 ⇒ absent')
+  // A non-200 2xx a proxy might return must NOT count as the confirmed 200 the data-loss
+  // gate requires — else a 204-then-404 pair would read as "lost".
+  assert.equal(diskExistenceFromStatus(204), null, '204 ⇒ indeterminate')
+  assert.equal(diskExistenceFromStatus(206), null, '206 ⇒ indeterminate')
+  assert.equal(diskExistenceFromStatus(301), null, '301 ⇒ indeterminate')
+  assert.equal(diskExistenceFromStatus(500), null, '500 ⇒ indeterminate')
+  assert.equal(diskExistenceFromStatus(undefined), null, 'missing ⇒ indeterminate')
+  // And a 204 pre / 404 post must classify UNVERIFIED, never lost:
+  assert.equal(
+    classifyOriginalOnDisk({ preExisted: diskExistenceFromStatus(204), postExists: diskExistenceFromStatus(404) }),
+    'unverified',
+    'non-200 pre-probe never yields a data-loss verdict'
+  )
+})
+
+test('P2: a Windows DRIVE-RELATIVE source ("C:Foo.json", no separator) is external ⇒ save-as-copy + sourceExternal', async () => {
+  const active = {
+    path: 'C:Foo.json',
+    filename: 'Foo.json',
+    directory: 'C:',
+    isPersisted: false,
+    isTemporary: true,
+  }
+  const { svc, existsOnDisk } = makeStore147Service({ files: [active.path], active })
+
+  const details = {}
+  await saveActiveWorkflow(svc, 'Foo Copy', {
+    autoWorkflowName: () => 'Untitled',
+    existsOnDisk,
+    details,
+  })
+
+  assert.equal(details.mode, 'save-as-copy', 'drive-relative external source ⇒ save-as-copy, not first-save')
+  assert.equal(details.sourceExternal, true, 'flagged external so the /userdata HEAD is skipped')
+  assert.ok(svc.disk.has('workflows/Foo Copy.json'), 'copy landed in the user workflows dir')
+  assert.ok(svc.disk.has('C:Foo.json'), 'external original preserved')
   assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'never moved the external original')
 })

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -149,6 +149,8 @@ import {
   shouldGroundBeforeTurn,
   groundActiveWorkflow,
   describeSaveOutcome,
+  classifyOriginalOnDisk,
+  normalizePath,
 } from "./lib/workflow-save.js";
 import { createRunCompletionTracker } from "./lib/run-completion.js";
 import { composeRunCompletionFrame } from "./lib/run-completion-frame.js";
@@ -2508,6 +2510,21 @@ async function programmaticSave(name) {
   // move); this only enriches the RESULT. The mode is taken from saveActiveWorkflow's
   // AUTHORITATIVE `details` sink (the branch it actually took), NOT inferred from the
   // mutable active workflow afterward — so a tab switch during the await can't fool it.
+  //
+  // Capture POSITIVE pre-save evidence of the source file's existence FIRST: a
+  // confirmed 200 is the ONLY basis on which a post-save 404 may be treated as a real
+  // move/deletion of a persisted original. Without it, a source that 404s afterward
+  // simply never existed (a never-persisted tab whose classification was inconclusive),
+  // and throwing would be a false data-loss error on a legitimate first save.
+  const preSourcePath = svc?.activeWorkflow?.path ?? null;
+  let preExisted = null; // true = confirmed 200, false = confirmed 404, null = unknown
+  if (preSourcePath) {
+    try {
+      preExisted = await workflowExistsOnDisk(preSourcePath);
+    } catch {
+      preExisted = null;
+    }
+  }
   const details = {};
   const saved = await saveActiveWorkflow(svc, name, {
     autoWorkflowName,
@@ -2516,36 +2533,45 @@ async function programmaticSave(name) {
     details,
   });
   const outcome = describeSaveOutcome(details);
-  // INDEPENDENT post-save verification (a second backstop, at the tool layer): for a
-  // Save-As COPY the REAL source file must still be on disk. Probe /userdata for the
-  // exact source path saveActiveWorkflow reported — if it is GONE, a move happened
-  // despite everything upstream: surface it as a hard error rather than a phantom
-  // success (mcp#579). This attests PATH PRESENCE (`original_on_disk`), not content
-  // identity — an honest, disk-checked fact, not an inferred "preserved" claim; a
-  // 404 is the actionable data-loss signal. An inconclusive probe ⇒ "unverified".
+  // INDEPENDENT post-save verification (a second backstop, at the tool layer) for a
+  // Save-As COPY: attest whether the REAL source file is still on disk. This reports
+  // PATH PRESENCE (`original_on_disk`), not content identity — an honest, disk-checked
+  // fact, not an inferred "preserved" claim.
   //
-  // EXTERNAL sources (absolute paths, #285) are NOT /userdata-addressable, so the HEAD
-  // would 404 for a perfectly-preserved external original. The external copy path never
-  // references the source file (it copies the live graph into the user dir), so the
-  // external original is intact — just unverifiable from here. Report "unverified" and
-  // NEVER throw a false data-loss error for it.
+  // EXTERNAL sources (absolute / root-relative paths, #285) are NOT /userdata-
+  // addressable, so a HEAD would 404 for a perfectly-preserved external original. The
+  // external copy path never references the source file, so it is intact — just
+  // unverifiable from here ⇒ "unverified", NEVER a throw.
+  //
+  // Managed sources: only a source CONFIRMED present before the save (preExisted===true,
+  // same path) that is now CONFIRMED gone is a genuine data-loss event → throw. Every
+  // indeterminate case degrades to "unverified" (classifyOriginalOnDisk enforces this),
+  // so a transient classification or a never-existed phantom source never false-alarms.
   if (outcome.saved_as && details.sourcePath) {
     if (details.sourceExternal) {
       outcome.original_on_disk = "unverified";
     } else {
-      let stillOnDisk = null;
+      let postExists = null;
       try {
-        stillOnDisk = await workflowExistsOnDisk(details.sourcePath);
+        postExists = await workflowExistsOnDisk(details.sourcePath);
       } catch {
-        stillOnDisk = null;
+        postExists = null;
       }
-      if (stillOnDisk === false) {
+      // Only trust pre-save evidence when it was measured on the SAME source path.
+      const samePath =
+        !!preSourcePath && normalizePath(preSourcePath) === normalizePath(details.sourcePath);
+      const status = classifyOriginalOnDisk({
+        preExisted: samePath ? preExisted : null,
+        postExists,
+      });
+      if (status === "lost") {
         throw new Error(
-          `save-as of "${saved}" appears to have MOVED/destroyed the original "${outcome.copied_from ?? details.sourcePath}" ` +
-            `— it is no longer on disk. Aborting to surface data loss (issue #579).`,
+          `the original workflow "${outcome.copied_from ?? details.sourcePath}" is no longer on disk ` +
+            `after saving "${saved}". The save was performed as a COPY and should not have removed it — ` +
+            `surfacing a possible data-loss event rather than reporting a phantom success (issue #579).`,
         );
       }
-      outcome.original_on_disk = stillOnDisk === true ? true : "unverified";
+      outcome.original_on_disk = status === "present" ? true : "unverified";
     }
   }
   return { name: saved || getWorkflowTitle(), ...outcome };

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -150,6 +150,7 @@ import {
   groundActiveWorkflow,
   describeSaveOutcome,
   classifyOriginalOnDisk,
+  diskExistenceFromStatus,
   normalizePath,
 } from "./lib/workflow-save.js";
 import { createRunCompletionTracker } from "./lib/run-completion.js";
@@ -2511,12 +2512,18 @@ async function programmaticSave(name) {
   // AUTHORITATIVE `details` sink (the branch it actually took), NOT inferred from the
   // mutable active workflow afterward — so a tab switch during the await can't fool it.
   //
-  // Capture POSITIVE pre-save evidence of the source file's existence FIRST: a
-  // confirmed 200 is the ONLY basis on which a post-save 404 may be treated as a real
-  // move/deletion of a persisted original. Without it, a source that 404s afterward
-  // simply never existed (a never-persisted tab whose classification was inconclusive),
-  // and throwing would be a false data-loss error on a legitimate first save.
-  const preSourcePath = svc?.activeWorkflow?.path ?? null;
+  // Snapshot the target workflow SYNCHRONOUSLY (before any await), so the pre-save HEAD
+  // below cannot let a tab switch redirect the save to a DIFFERENT workflow. It is
+  // passed to saveActiveWorkflow as `expect` (#330), which refuses if the active
+  // workflow changed during our pre-probe — restoring the "capture A before the first
+  // await" guarantee the pre-probe would otherwise have widened into a wrong-tab window.
+  const expectWf = svc?.activeWorkflow;
+  // Capture POSITIVE pre-save evidence of the source file's existence: a confirmed 200
+  // is the ONLY basis on which a post-save 404 may be treated as a real move/deletion
+  // of a persisted original. Without it, a source that 404s afterward simply never
+  // existed (a never-persisted tab whose classification was inconclusive), and throwing
+  // would be a false data-loss error on a legitimate first save.
+  const preSourcePath = expectWf?.path ?? null;
   let preExisted = null; // true = confirmed 200, false = confirmed 404, null = unknown
   if (preSourcePath) {
     try {
@@ -2531,6 +2538,7 @@ async function programmaticSave(name) {
     existsOnDisk: workflowExistsOnDisk,
     reconcileSavedCopy: reconcileSavedWorkflowCopy,
     details,
+    expect: expectWf, // #330: refuse if the user switched tabs during our pre-save HEAD
   });
   const outcome = describeSaveOutcome(details);
   // INDEPENDENT post-save verification (a second backstop, at the tool layer) for a
@@ -2640,9 +2648,11 @@ async function workflowExistsOnDisk(rawPath) {
       typeof api.getUserData === "function"
         ? await api.getUserData(rawPath, { method: "HEAD" })
         : await api.fetchApi(`/userdata/${encodeURIComponent(rawPath)}`, { method: "HEAD" });
-    if (res.status === 404) return false;
-    if (res.ok) return true;
-    return null; // inconclusive ⇒ classifier stays "unknown" ⇒ refuse
+    // STRICT: only a true 200 is positive existence evidence; a non-200 2xx (204/206/…)
+    // from a proxy/intermediary is INDETERMINATE (null), never "present" — else it could
+    // stand in for the confirmed pre-save 200 the data-loss gate requires and, paired
+    // with a later 404, yield a FALSE "moved" verdict. 404 ⇒ false; anything else ⇒ null.
+    return diskExistenceFromStatus(res.status);
   } catch {
     return null; // network/other error ⇒ unknown ⇒ fail safe
   }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -144,7 +144,12 @@ import {
   refreshNodeArea,
 } from "./lib/group-geometry.js";
 import { pickRevertSnapshot } from "./lib/graph-revert.js";
-import { saveActiveWorkflow, shouldGroundBeforeTurn, groundActiveWorkflow } from "./lib/workflow-save.js";
+import {
+  saveActiveWorkflow,
+  shouldGroundBeforeTurn,
+  groundActiveWorkflow,
+  describeSaveOutcome,
+} from "./lib/workflow-save.js";
 import { createRunCompletionTracker } from "./lib/run-completion.js";
 import { composeRunCompletionFrame } from "./lib/run-completion-frame.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
@@ -2496,12 +2501,54 @@ function autoWorkflowName() {
  *  fallback. */
 async function programmaticSave(name) {
   const svc = app?.extensionManager?.workflow;
+  // Report what the save actually DID (in-place / first-save / Save-As copy) instead
+  // of the old opaque {saved:true} — the silent, unrecoverable move is what made
+  // mcp#579 a data-loss footgun. saveActiveWorkflow itself NEVER moves a persisted
+  // source (it copies via the atomic overwrite:false trio and throws on a detected
+  // move); this only enriches the RESULT. The mode is taken from saveActiveWorkflow's
+  // AUTHORITATIVE `details` sink (the branch it actually took), NOT inferred from the
+  // mutable active workflow afterward — so a tab switch during the await can't fool it.
+  const details = {};
   const saved = await saveActiveWorkflow(svc, name, {
     autoWorkflowName,
     existsOnDisk: workflowExistsOnDisk,
     reconcileSavedCopy: reconcileSavedWorkflowCopy,
+    details,
   });
-  return saved || getWorkflowTitle();
+  const outcome = describeSaveOutcome(details);
+  // INDEPENDENT post-save verification (a second backstop, at the tool layer): for a
+  // Save-As COPY the REAL source file must still be on disk. Probe /userdata for the
+  // exact source path saveActiveWorkflow reported — if it is GONE, a move happened
+  // despite everything upstream: surface it as a hard error rather than a phantom
+  // success (mcp#579). This attests PATH PRESENCE (`original_on_disk`), not content
+  // identity — an honest, disk-checked fact, not an inferred "preserved" claim; a
+  // 404 is the actionable data-loss signal. An inconclusive probe ⇒ "unverified".
+  //
+  // EXTERNAL sources (absolute paths, #285) are NOT /userdata-addressable, so the HEAD
+  // would 404 for a perfectly-preserved external original. The external copy path never
+  // references the source file (it copies the live graph into the user dir), so the
+  // external original is intact — just unverifiable from here. Report "unverified" and
+  // NEVER throw a false data-loss error for it.
+  if (outcome.saved_as && details.sourcePath) {
+    if (details.sourceExternal) {
+      outcome.original_on_disk = "unverified";
+    } else {
+      let stillOnDisk = null;
+      try {
+        stillOnDisk = await workflowExistsOnDisk(details.sourcePath);
+      } catch {
+        stillOnDisk = null;
+      }
+      if (stillOnDisk === false) {
+        throw new Error(
+          `save-as of "${saved}" appears to have MOVED/destroyed the original "${outcome.copied_from ?? details.sourcePath}" ` +
+            `— it is no longer on disk. Aborting to surface data loss (issue #579).`,
+        );
+      }
+      outcome.original_on_disk = stillOnDisk === true ? true : "unverified";
+    }
+  }
+  return { name: saved || getWorkflowTitle(), ...outcome };
 }
 
 /** Authoritative read-back oracle for saveActiveWorkflow's post-write guards.
@@ -6140,14 +6187,16 @@ const GRAPH_TOOL_EXECUTORS = {
   async workflow_save({ name } = {}) {
     // Fully programmatic — no Save/Rename dialog. Auto-names a never-saved
     // workflow; saves in place otherwise.
-    const saved = await programmaticSave(name);
-    return { saved: true, workflow: saved };
+    const { name: workflow, ...outcome } = await programmaticSave(name);
+    // outcome surfaces WHAT happened (saved_as/copied_from/original_preserved or
+    // first_save) so a rename-vs-copy is never silent (mcp#579).
+    return { saved: true, workflow, ...outcome };
   },
 
   async workflow_save_as({ name }) {
     if (!name || typeof name !== "string") throw new Error("name (string) is required");
-    const saved = await programmaticSave(name);
-    return { saved: true, workflow: saved };
+    const { name: workflow, ...outcome } = await programmaticSave(name);
+    return { saved: true, workflow, ...outcome };
   },
 
   // --- Workflow tabs: new / list / open / switch / rename / close ----------

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -81,6 +81,28 @@ export function describeSaveOutcome(details = {}) {
   return {};
 }
 
+/** Decide what to report about a Save-As COPY's ORIGINAL source file from two disk
+ *  probes, and — critically — WHEN a missing source is a genuine data-loss event vs
+ *  a benign "never existed / can't tell". Pure + total, so the panel's throw decision
+ *  is unit-testable and can never fire on a transient/indeterminate classification.
+ *
+ *  A data-loss THROW ("lost") requires POSITIVE prior evidence the source existed —
+ *  a CONFIRMED pre-save 200 (`preExisted === true`) that is now a CONFIRMED 404
+ *  (`postExists === false`). Every weaker combination degrades to "unverified":
+ *   - `preExisted` unknown/false (the source was never proven present — e.g. a
+ *     non-temporary yet never-persisted tab whose classification was `unknown`, or a
+ *     phantom "workflows/Unsaved Workflow.json" that 404s simply because it never
+ *     existed) ⇒ NEVER throw, even if postExists is false;
+ *   - `postExists` true ⇒ "present";
+ *   - anything else (post probe inconclusive) ⇒ "unverified".
+ *  This closes a false data-loss throw on a legitimate first save and avoids blaming
+ *  this Save-As for an unrelated deletion we cannot attribute to it. */
+export function classifyOriginalOnDisk({ preExisted, postExists } = {}) {
+  if (preExisted === true && postExists === false) return "lost";
+  if (postExists === true) return "present";
+  return "unverified";
+}
+
 /** Record the authoritative outcome into an optional `details` sink (a plain object
  *  the caller passes to saveActiveWorkflow). No-op when absent, so behaviour and the
  *  return value are unchanged for every existing caller/test. */
@@ -756,17 +778,23 @@ async function classifySource(svc, wf, rawPath, existsOnDisk) {
  *  can write to. Store paths are always relative under it ("workflows/…"). */
 const WORKFLOWS_ROOT = "workflows";
 
-/** True when `path` is an ABSOLUTE filesystem path — a Windows drive ("C:\\", "C:/"),
- *  a UNC share ("\\\\server"), or a POSIX absolute ("/…"). Such a path is a workflow
- *  loaded from OUTSIDE the managed workflows dir (panel_load_workflow path:<file>);
- *  it can never be a /userdata store path, so a Save-As of it must copy into the
- *  user workflows dir rather than the unwritable external directory (#285). Only
- *  absolute paths qualify — a relative "workflows/…" store path is never external,
- *  so the everyday save path is untouched. */
+/** True when `path` is an ABSOLUTE or ROOT-RELATIVE filesystem path — a Windows drive
+ *  ("C:\\", "C:/"), a UNC share ("\\\\server"), a POSIX absolute ("/…"), OR a Windows
+ *  root-relative path with a single leading separator ("\packs\…" / "/packs/…", which
+ *  resolves against the current drive root). Such a path is a workflow loaded from
+ *  OUTSIDE the managed workflows dir (panel_load_workflow path:<file>); it can never be
+ *  a /userdata store path (those are relative "workflows/…"), so a Save-As of it must
+ *  copy into the user workflows dir rather than the unwritable external directory
+ *  (#285). A single leading "\" was previously MISSED, so an external file at
+ *  "\packs\Foo.json" was mis-classified as a managed never-persisted tab and reported
+ *  as a first save (hiding that a real external source was copied). A managed store
+ *  path never begins with a separator, so this never touches the everyday save path. */
 function isExternalWorkflowPath(path) {
   const raw = String(path || "");
   if (!raw) return false;
-  return /^[a-zA-Z]:[\\/]/.test(raw) || /^[\\/]{2}/.test(raw) || /^\//.test(raw);
+  // A leading "\" or "/" (single, double/UNC, or POSIX absolute) is external/root-
+  // relative; a drive-qualified prefix ("C:\" / "C:/") is external too.
+  return /^[a-zA-Z]:[\\/]/.test(raw) || /^[\\/]/.test(raw);
 }
 
 /** Directory prefix (with trailing slash) that a new sibling file should live in,
@@ -782,7 +810,7 @@ function directoryOf(wf) {
 /** Normalize a workflow path for a stable same-file comparison: forward slashes,
  *  no doubled/trailing separators. Case is preserved (a case-only difference is
  *  treated as a Save-As, which is the safe direction — it copies). */
-function normalizePath(path) {
+export function normalizePath(path) {
   return String(path || "")
     .replaceAll("\\", "/")
     .replace(/\/{2,}/g, "/")

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -103,6 +103,21 @@ export function classifyOriginalOnDisk({ preExisted, postExists } = {}) {
   return "unverified";
 }
 
+/** Map a /userdata HEAD status to the tri-state existence oracle used everywhere a
+ *  save decision is made. Deliberately STRICT: ONLY `200` is positive proof a file is
+ *  present; `404` is proof of absence; ANY other status — including a non-200 2xx a
+ *  proxy/intermediary might return (204/206/…), a redirect, or a 5xx — is INDETERMINATE
+ *  (null), never "present". A loose `res.ok` (200–299) mapping let a 2xx-non-200
+ *  pre-save probe count as a confirmed 200, which — paired with a real 404 later —
+ *  produced a FALSE "lost" data-loss verdict. Both the pre- and post-save existence
+ *  probes flow through this, so the "confirmed 200" the data-loss gate requires is a
+ *  true 200. */
+export function diskExistenceFromStatus(status) {
+  if (status === 200) return true;
+  if (status === 404) return false;
+  return null;
+}
+
 /** Record the authoritative outcome into an optional `details` sink (a plain object
  *  the caller passes to saveActiveWorkflow). No-op when absent, so behaviour and the
  *  return value are unchanged for every existing caller/test. */
@@ -251,17 +266,17 @@ export async function saveActiveWorkflow(
   const wf = svc?.activeWorkflow;
   if (!wf) throw new Error("no active workflow to save");
 
-  // #330 TOCTOU guard: a grounding caller passes `expect` — the exact workflow it
-  // probed on disk before this save. If the active workflow changed in between (the
-  // user switched tabs during the async /userdata HEAD), we'd authorize on workflow
-  // A but write to workflow B — an overwrite of a DIFFERENT, possibly persisted file.
-  // REFUSE instead. Re-checked again immediately before every write (assertExpect),
-  // since the classify/collision probes below also await. `expect` is undefined for
-  // ordinary (explicit) saves, so their behaviour is unchanged.
+  // #330 TOCTOU guard: a caller passes `expect` — the exact workflow it snapshotted
+  // BEFORE any async work (a grounding disk probe, or the tool layer's pre-save HEAD).
+  // If the active workflow changed in between (the user switched tabs during that async
+  // gap), we'd authorize on workflow A but write to workflow B — an overwrite of a
+  // DIFFERENT, possibly persisted file. REFUSE instead. Re-checked immediately before
+  // every write (assertExpect), since the classify/collision probes below also await.
+  // `expect` is undefined only when a caller opts out, leaving behaviour unchanged.
   const assertExpect = () => {
     if (expect !== undefined && svc?.activeWorkflow !== expect) {
       throw new Error(
-        "active workflow changed during grounding — refusing to save the wrong workflow (issue #330)",
+        "active workflow changed during save — refusing to save the wrong workflow (issue #330)",
       );
     }
   };
@@ -432,16 +447,32 @@ export async function saveActiveWorkflow(
         targetPath: finalTargetPath,
         copiedFrom: cls === "never-persisted" ? undefined : currentName,
       });
+      // Capture POSITIVE pre-copy DISK evidence of the source, so the post-copy
+      // backstop can only fire on a CONFIRMED 200 → 404 (a genuine move). An in-memory
+      // getWorkflowByPath()==null is NOT proof of on-disk loss (it can be transiently
+      // stale after the copy activates), so the old in-memory backstop could throw
+      // "save moved the original" on a file that is still on disk. Gate on disk only.
+      const sourceNorm = normalizePath(sourcePath);
+      const sourceOnDiskBefore = await probeSourceOnDisk(existsOnDisk, sourceNorm);
+      assertExpect(); // #330: the extra pre-copy probe must not open a switch window
       const activeName = await withConflictRollback(svc, wf, effectiveName, finalTargetPath, () =>
         atomicCopy(wf, effectiveName, finalTargetPath),
       );
-      // BACKSTOP: if the copy somehow relocated a persisted source, fail LOUDLY
-      // rather than report a phantom success (#226).
-      if (cls === "persisted" && confirmedAbsentAt(svc, sourcePath)) {
-        throw new Error(
-          `save moved the original workflow "${sourcePath}" instead of copying it — ` +
-            `the source no longer exists on disk (issue #226)`,
-        );
+      // BACKSTOP: fail LOUDLY only if the copy actually REMOVED a source we CONFIRMED
+      // (disk 200) was present and is now CONFIRMED absent (disk 404) — classifyOriginalOnDisk
+      // "lost". Every indeterminate case (no oracle / unknown pre or post / in-memory-only
+      // signal) is a NO-OP, never a false "moved" (#226).
+      if (cls === "persisted") {
+        const sourceOnDiskAfter = await probeSourceOnDisk(existsOnDisk, sourceNorm);
+        if (
+          classifyOriginalOnDisk({ preExisted: sourceOnDiskBefore, postExists: sourceOnDiskAfter }) ===
+          "lost"
+        ) {
+          throw new Error(
+            `save moved the original workflow "${sourcePath}" instead of copying it — ` +
+              `the source no longer exists on disk (issue #226)`,
+          );
+        }
       }
       return activeName;
     }
@@ -472,19 +503,19 @@ export async function saveActiveWorkflow(
   return desired || currentName || null;
 }
 
-/** Tri-state existence probe for the post-save backstop, mirroring classifySource:
- *  returns true ONLY when the oracle SUCCESSFULLY confirms nothing is at `rawPath`
- *  (getWorkflowByPath returns null/undefined). A getter THROW or the absence of a
- *  usable oracle is UNKNOWN → false (do not alarm) — so a valid save-as copy is
- *  never misreported as a destructive move (#226). A list-miss is likewise not
- *  proof of absence, so lists never trigger the alarm. */
-function confirmedAbsentAt(svc, rawPath) {
-  if (!rawPath) return false;
-  if (typeof svc?.getWorkflowByPath !== "function") return false;
+/** Authoritative tri-state DISK probe for the post-save backstop — the ONLY evidence
+ *  trusted to declare a source moved. Returns `true` (confirmed present), `false`
+ *  (confirmed absent), or `null` (no oracle / probe threw / inconclusive). Deliberately
+ *  NOT backed by the in-memory `getWorkflowByPath`: an in-memory absence is not proof of
+ *  on-disk loss (it drifts stale after the copy activates), and treating it as proof
+ *  produced a false "save moved the original" on a file still on disk (#226). */
+async function probeSourceOnDisk(existsOnDisk, normPath) {
+  if (typeof existsOnDisk !== "function" || !normPath) return null;
   try {
-    return svc.getWorkflowByPath(rawPath) == null;
+    const r = await existsOnDisk(normPath);
+    return r === true ? true : r === false ? false : null;
   } catch {
-    return false; // oracle threw ⇒ unknown ⇒ never alarm
+    return null; // probe threw ⇒ unknown ⇒ never alarm
   }
 }
 
@@ -793,8 +824,12 @@ function isExternalWorkflowPath(path) {
   const raw = String(path || "");
   if (!raw) return false;
   // A leading "\" or "/" (single, double/UNC, or POSIX absolute) is external/root-
-  // relative; a drive-qualified prefix ("C:\" / "C:/") is external too.
-  return /^[a-zA-Z]:[\\/]/.test(raw) || /^[\\/]/.test(raw);
+  // relative; ANY "<letter>:" drive prefix is external — INCLUDING drive-relative
+  // "C:Foo.json" (no following separator), which resolves against the drive's current
+  // directory and is still outside the managed /userdata store. A managed store path is
+  // always relative "workflows/…" (no drive letter, no leading separator), so this
+  // never touches the everyday save path.
+  return /^[a-zA-Z]:/.test(raw) || /^[\\/]/.test(raw);
 }
 
 /** Directory prefix (with trailing slash) that a new sibling file should live in,

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -54,6 +54,49 @@ export function needsGrounding(wf) {
   return !!wf && (wf.isPersisted === false || wf.isTemporary === true);
 }
 
+/** Map the AUTHORITATIVE save outcome that `saveActiveWorkflow` reports (via its
+ *  optional `details` sink) into the tool-result fields, so `panel_save_workflow`
+ *  no longer returns the opaque `{saved:true}` (mcp#579's "at minimum (2)": a
+ *  silent rename-vs-copy is what made the bug unrecoverable). This is a PURE
+ *  mapper over the mode saveActiveWorkflow DECIDED — NOT an after-the-fact guess
+ *  from the (mutable, race-prone) active workflow — so it can never be fooled by
+ *  a tab switch during the save await.
+ *
+ *  `details.mode`:
+ *   - "save-as-copy" → a NEW file was written from a REAL existing source (an
+ *     already-persisted workflow OR an externally-loaded file, #285) which stays
+ *     put ⇒ `{ saved_as: true, copied_from }`. The caller then disk-verifies the
+ *     source path and stamps `original_on_disk` (a disk claim must be disk-checked).
+ *   - "first-save"   → a never-persisted temp / new_workflow tab got its first real
+ *     name+file; there is no prior file to preserve (panel#363) ⇒ `{ first_save: true }`.
+ *   - "in-place" / anything else → same-path overwrite or no-name grounding ⇒ `{}`. */
+export function describeSaveOutcome(details = {}) {
+  const mode = details?.mode;
+  if (mode === "save-as-copy") {
+    return { saved_as: true, copied_from: baseName(details.copiedFrom) || null };
+  }
+  if (mode === "first-save") {
+    return { first_save: true };
+  }
+  return {};
+}
+
+/** Record the authoritative outcome into an optional `details` sink (a plain object
+ *  the caller passes to saveActiveWorkflow). No-op when absent, so behaviour and the
+ *  return value are unchanged for every existing caller/test. */
+function recordOutcome(details, mode, { sourcePath, targetPath: tPath, copiedFrom, sourceExternal } = {}) {
+  if (!details || typeof details !== "object") return;
+  details.mode = mode;
+  if (sourcePath !== undefined) details.sourcePath = sourcePath;
+  if (tPath !== undefined) details.targetPath = tPath;
+  if (copiedFrom !== undefined) details.copiedFrom = copiedFrom;
+  // `sourceExternal` marks a source path OUTSIDE the managed workflows dir (an
+  // absolute path, #285). The /userdata HEAD oracle cannot address such a path, so a
+  // caller must NOT read its 404 as data loss — the external copy path never touches
+  // the source file, so the external original is intact but simply unverifiable here.
+  if (sourceExternal !== undefined) details.sourceExternal = sourceExternal;
+}
+
 /** #330 — decide whether to ground (auto-save) the active workflow BEFORE an agent
  *  turn. Grounding must run on EVERY turn that targets an unsaved tab, not only a
  *  brand-new chat: continuing an existing chat inside an unsaved tab still leaves
@@ -181,7 +224,7 @@ export async function groundActiveWorkflow(svc, opts = {}) {
 export async function saveActiveWorkflow(
   svc,
   name,
-  { autoWorkflowName, existsOnDisk, reconcileSavedCopy, expect } = {},
+  { autoWorkflowName, existsOnDisk, reconcileSavedCopy, expect, details } = {},
 ) {
   const wf = svc?.activeWorkflow;
   if (!wf) throw new Error("no active workflow to save");
@@ -303,6 +346,15 @@ export async function saveActiveWorkflow(
         );
       }
       assertExpect(); // #330: still the workflow we probed?
+      // An external source is a REAL existing file (absolute path) copied into the
+      // user dir — Save-As COPY semantics, never a first-save (#285). Record it as
+      // such so the tool result reports the copy (fixes a first_save mislabel).
+      recordOutcome(details, "save-as-copy", {
+        sourcePath,
+        targetPath: finalTargetPath,
+        copiedFrom: currentName,
+        sourceExternal: true, // absolute external path — not /userdata-verifiable
+      });
       return await withConflictRollback(svc, wf, effectiveName, finalTargetPath, () =>
         copyToUserDir(wf, effectiveName, finalTargetPath),
       );
@@ -348,6 +400,16 @@ export async function saveActiveWorkflow(
     const atomicCopy = resolveSaveAsCopy(svc, { reconcileSavedCopy });
     if (atomicCopy) {
       assertExpect(); // #330: still the workflow we probed?
+      // Authoritative outcome: a "never-persisted" source (a temp / new_workflow tab
+      // with no backing file) is a FIRST SAVE (panel#363 — no original to preserve);
+      // a "persisted" source is a Save-As COPY of a real file that stays put (#579).
+      // (cls is only ever "persisted" or "never-persisted" here — the #226 guard above
+      // has already thrown for a temporary source that isn't provably never-persisted.)
+      recordOutcome(details, cls === "never-persisted" ? "first-save" : "save-as-copy", {
+        sourcePath,
+        targetPath: finalTargetPath,
+        copiedFrom: cls === "never-persisted" ? undefined : currentName,
+      });
       const activeName = await withConflictRollback(svc, wf, effectiveName, finalTargetPath, () =>
         atomicCopy(wf, effectiveName, finalTargetPath),
       );
@@ -383,6 +445,7 @@ export async function saveActiveWorkflow(
   // No relocation — the target path equals the current on-disk path. Overwriting
   // the same file in place is safe (no move can occur).
   assertExpect(); // #330: never in-place-overwrite a workflow the user switched to
+  recordOutcome(details, "in-place", { sourcePath: currentPath, targetPath: finalTargetPath });
   await saveInPlace(svc, wf);
   return desired || currentName || null;
 }


### PR DESCRIPTION
Closes artokun/comfyui-mcp#579
Closes #363

## TL;DR â€” the destructive MOVE was already fixed on main; this locks it and closes the residual footgun

Both issues were filed against **panel 0.11.6** (ComfyUI 0.28.3 / frontend 1.47.x). On current `main`, `panel_save_workflow({name})` already goes through the safe path:

`panel_save_workflow(name)` â†’ panel command `workflow_save_as` â†’ `programmaticSave(name)` â†’ `saveActiveWorkflow` (in `web/js/lib/workflow-save.js`), which classifies a relocation and writes a NEW file via the **atomic `overwrite:false` copy trio** (`saveAs` + `openWorkflow` + `saveWorkflow`), **refusing to move a persisted source** (accumulated #226 / #268 / #285 / #309 work). It never calls `renameWorkflow` for a save. The only `renameWorkflow` call in the panel is the separate, explicit `workflow_rename` command.

So the `moving 'UGC - 01â€¦' -> 'UGC - 06â€¦'` in mcp#579 and the "refusing to rename and destroy the original" refusal for a `panel_new_workflow` tab in panel#363 were **0.11.6 behaviour, fixed before this PR**. New regression tests model both **exact** reported scenarios on the 1.47 store double and pass on `main`.

## What this PR actually changes (the residual footgun mcp#579 asked for)

mcp#579's "at minimum (2)": a rename-vs-copy must never be **silent**. The tool returned only `{ saved: true, workflow }` â€” no way to see a new file was written vs an in-place save. This PR makes the result self-describing, **without changing any save behaviour**:

- **`describeSaveOutcome(details)`** â€” pure mapper from `saveActiveWorkflow`'s **authoritative** `details.mode` (the branch it actually took) â†’ `{ saved_as, copied_from }` / `{ first_save }` / `{}`. It is **not** inferred from the mutable active workflow after the await, so a tab switch mid-save cannot fool it.
- **`saveActiveWorkflow`** records the outcome into an optional `details` sink at each decision point (external copy / atomic copy / in-place). Optional â‡’ **behaviour and return value unchanged for every existing caller and test**.
- **`programmaticSave`** takes a **positive pre-save HEAD** of the source, then after a Save-As copy reports `original_on_disk: true | "unverified"`. A hard data-loss error is thrown **only** on a confirmed 200â†’404 transition on the same path (`classifyOriginalOnDisk === "lost"`); every indeterminate/never-existed case degrades to `"unverified"` (never a false alarm). External (absolute / root-relative, #285) sources are `"unverified"` â€” `/userdata` can't HEAD them.

## Scope of the safety claim (honest bounds)

"Writes a NEW file and leaves the **source** workflow on disk" holds for the **source** workflow under normal **single-user** use â€” the copy path never references the source's on-disk file, so it cannot move/destroy it. It does **not** claim collision-proofing of the *target* name: ComfyUI's `/userdata` write is **not** exclusive-create (`os.path.exists` â†’ await body â†’ `os.replace`), so a *concurrently-created* file at the target name can be overwritten by the server within that window (200, not 409). That is a **known, accepted, irreducible upstream ComfyUI race** â€” impossible for a single user, not fixable from the panel â€” and is already documented in `workflow-save.js`. This PR adds store+disk pre-checks, a final synchronous re-check, and post-write clobber **detection** of our own write, but does not (and cannot) eliminate that upstream victim-file race.

## Tests
- `mcp#579`: persisted `UGC - 01 â€¦` open â†’ save-as `UGC - 06 â€¦` â†’ COPIES, original file byte-identical on disk, `renameWorkflow` never called, `details.mode === "save-as-copy"`.
- `panel#363`: `panel_new_workflow` temp tab â†’ first named save succeeds (no refusal), `details.mode === "first-save"`.
- `describeSaveOutcome` mapping (all modes); `classifyOriginalOnDisk` (all pre/post combinations â€” `"lost"` only on confirmed 200â†’404); external-source flag incl. Windows **root-relative** `\packs\Foo.json` â‡’ save-as-copy + `sourceExternal`.
- Full panel unit suite green: **772 passing**.

## Review
Self-gated with codex (gpt-5.6-terra/high), 6 rounds, plus TWO independent coordinator review passes. Findings fixed across rounds: active-workflow read race; `first_save` mislabel of the external path; over-claimed `original_preserved`; false throw for external absolute paths; false throw on an `unknown`/never-existed source; root-relative & drive-relative external paths missed; an in-memory backstop that threw on stale in-memory absence (now disk-gated); loose `res.ok` (2xx) treated as a confirmed 200 (now strict 200 via `diskExistenceFromStatus`); and a pre-save-HEAD tab-switch window (now guarded by `expect`/#330). Final codex round: **PASS, no regressions**. Not merging - independent adversarial codex runs before merge.

Companion (MCP tool description reword): artokun/comfyui-mcp#583
