### PR TITLE
fix(set_widget): refuse scalar-to-composite corruption (#560) + warn on control_after_generate (#558)

### DIFF
--- a/browser_tests/unit/control-after-generate.test.mjs
+++ b/browser_tests/unit/control-after-generate.test.mjs
@@ -1,0 +1,289 @@
+/**
+ * Unit tests for web/js/lib/control-after-generate.js (#558) — run with `node --test`.
+ *
+ * control_after_generate SILENTLY rewrites a seed/INT/COMBO value after each
+ * generation, and the ComfyUI frontend adds it as a serialize:false/canvasOnly
+ * widget that renders UNASSOCIATED from the seed it governs — so a value the agent
+ * explicitly set never holds, with nothing in the read/write surface revealing it.
+ * These tests pin the detection that summarizeNode / graph_outline / runSetWidget use.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  CONTROL_AFTER_GENERATE_MODES,
+  isControlAfterGenerateWidget,
+  controlAfterGenerateEntries,
+  controlAfterGenerateModes,
+  controlEntryForWidget,
+  controlAfterGenerateWarning,
+} from "../../web/js/lib/control-after-generate.js";
+
+// A KSampler-shaped node: seed value widget followed by its control combo, exactly
+// as the ComfyUI frontend builds it (control widget serialize:false/canvasOnly).
+function seedNode(mode = "randomize", { linked = true, prefix = "" } = {}) {
+  const seed = { name: "seed", type: "INT", value: 777777 };
+  const control = {
+    name: `${prefix}control_after_generate`,
+    type: "combo",
+    value: mode,
+    options: { values: [...CONTROL_AFTER_GENERATE_MODES], serialize: false, canvasOnly: true },
+  };
+  if (linked) seed.linkedWidgets = [control];
+  return { id: 30, type: "KSampler", widgets: [seed, control, { name: "steps", type: "INT", value: 20 }] };
+}
+
+test("detects the control_after_generate combo by name + option shape", () => {
+  const { widgets } = seedNode("randomize");
+  assert.equal(isControlAfterGenerateWidget(widgets[1]), true);
+  assert.equal(isControlAfterGenerateWidget(widgets[0]), false); // the seed itself
+  assert.equal(isControlAfterGenerateWidget({ name: "sampler", options: { values: ["euler"] } }), false);
+});
+
+test("detection requires BOTH control markers (serialize:false AND canvasOnly:true) plus the mode options", () => {
+  // No marker at all (an unrelated combo that merely shares the option strings) ⇒ NOT a control.
+  assert.equal(
+    isControlAfterGenerateWidget({ name: "mode", type: "combo", options: { values: [...CONTROL_AFTER_GENERATE_MODES] } }),
+    false,
+  );
+  // Only ONE marker (serialize:false, no canvasOnly) ⇒ NOT a control (P2 false-positive guard).
+  assert.equal(
+    isControlAfterGenerateWidget({ name: "mode", options: { values: [...CONTROL_AFTER_GENERATE_MODES], serialize: false } }),
+    false,
+  );
+  // Only canvasOnly, no serialize:false ⇒ NOT a control.
+  assert.equal(
+    isControlAfterGenerateWidget({ name: "mode", options: { values: [...CONTROL_AFTER_GENERATE_MODES], canvasOnly: true } }),
+    false,
+  );
+  // BOTH markers present but options are NOT the modes ⇒ NOT a control.
+  assert.equal(
+    isControlAfterGenerateWidget({ name: "x", options: { values: ["a", "b"], serialize: false, canvasOnly: true } }),
+    false,
+  );
+  // BOTH markers AND the mode options ⇒ detected (the real frontend shape).
+  assert.equal(
+    isControlAfterGenerateWidget({
+      name: "control_after_generate",
+      type: "combo",
+      value: "increment",
+      options: { values: [...CONTROL_AFTER_GENERATE_MODES], serialize: false, canvasOnly: true },
+    }),
+    true,
+  );
+});
+
+test("associates the mode with the seed via linkedWidgets", () => {
+  const node = seedNode("randomize", { linked: true });
+  assert.deepEqual(controlAfterGenerateModes(node), { seed: "randomize" });
+  const entries = controlAfterGenerateEntries(node);
+  assert.equal(entries.length, 1);
+  assert.deepEqual(entries[0], { widget: "seed", control: "control_after_generate", mode: "randomize" });
+});
+
+test("associates the mode with the seed by POSITION when linkedWidgets is absent", () => {
+  const node = seedNode("increment", { linked: false });
+  assert.deepEqual(controlAfterGenerateModes(node), { seed: "increment" });
+});
+
+test("handles a control_prefix-renamed control widget", () => {
+  const node = seedNode("decrement", { linked: true, prefix: "Base " });
+  const entries = controlAfterGenerateEntries(node);
+  assert.equal(entries[0].widget, "seed");
+  assert.equal(entries[0].mode, "decrement");
+  assert.equal(entries[0].control, "Base control_after_generate");
+});
+
+test("P2: a combo-governed control with a 5th 'increment-wrap' option IS detected (superset, not exact)", () => {
+  // ComfyUI appends 'increment-wrap' when the governed widget is a combo — detection must
+  // accept a SUPERSET of the base modes, else a combo-governed control is missed.
+  const w = {
+    name: "control_after_generate",
+    type: "combo",
+    value: "increment",
+    options: { values: [...CONTROL_AFTER_GENERATE_MODES, "increment-wrap"], serialize: false, canvasOnly: true },
+  };
+  assert.equal(isControlAfterGenerateWidget(w), true);
+});
+
+test("P2: a coincidental mode-option combo WITHOUT the control marker is NOT a control (no false warn)", () => {
+  // A plain combo (no serialize:false/canvasOnly) that happens to list the mode strings
+  // after a numeric widget must NOT be treated as a control.
+  const seed = { name: "seed", type: "INT", value: 5 };
+  const combo = {
+    name: "mode",
+    type: "combo",
+    value: "randomize",
+    options: { values: [...CONTROL_AFTER_GENERATE_MODES] }, // NO marker
+  };
+  const node = { id: 60, type: "SomeNode", widgets: [seed, combo] };
+  assert.equal(isControlAfterGenerateWidget(combo), false);
+  assert.deepEqual(controlAfterGenerateModes(node), {});
+  assert.equal(controlAfterGenerateWarning(node, "seed"), null);
+});
+
+test("P2: a real control whose predecessor is INELIGIBLE (text) does not attach its mode there", () => {
+  const text = { name: "notes", type: "text", value: "hello" };
+  const combo = {
+    name: "control_after_generate",
+    type: "combo",
+    value: "randomize",
+    options: { values: [...CONTROL_AFTER_GENERATE_MODES], serialize: false, canvasOnly: true },
+  };
+  const node = { id: 62, type: "SomeNode", widgets: [text, combo] };
+  assert.equal(controlAfterGenerateWarning(node, "notes"), null);
+  assert.deepEqual(controlAfterGenerateModes(node), { control_after_generate: "randomize" }); // self-keyed display
+});
+
+test("P2: an ELIGIBLE numeric predecessor IS associated (real seed still detected)", () => {
+  const seed = { name: "seed", type: "INT", value: 5 };
+  const combo = {
+    name: "control_after_generate",
+    type: "combo",
+    value: "randomize",
+    options: { values: [...CONTROL_AFTER_GENERATE_MODES], serialize: false, canvasOnly: true },
+  };
+  const node = { id: 61, type: "KSampler", widgets: [seed, combo] }; // no linkedWidgets
+  assert.deepEqual(controlAfterGenerateModes(node), { seed: "randomize" });
+  assert.match(controlAfterGenerateWarning(node, "seed"), /randomize/);
+});
+
+test("P1: detection is SIDE-EFFECT-FREE — a function-valued options list is NOT invoked (and not classified)", () => {
+  // A real control combo always has a STATIC array; detection must never invoke a dynamic
+  // values() (it runs AFTER a write is verified and could mutate the graph). Prove the
+  // function is NEVER called and such a widget is not treated as a control.
+  let called = false;
+  const w = {
+    name: "seed_control",
+    type: "combo",
+    value: "randomize",
+    options: {
+      values: () => {
+        called = true;
+        return [...CONTROL_AFTER_GENERATE_MODES];
+      },
+      serialize: false,
+      canvasOnly: true,
+    },
+  };
+  assert.equal(isControlAfterGenerateWidget(w), false);
+  assert.equal(called, false, "detection must NOT invoke the dynamic values() callback");
+});
+
+test("P1: a side-effecting values() on a marker-qualified widget cannot change a written value via detection", () => {
+  // Even if a widget carries both markers and a mode-returning function, detection does not
+  // invoke it, so entries/warning never trigger the side effect.
+  const seed = { name: "seed", type: "INT", value: 77 };
+  let sideEffectFired = false;
+  const control = {
+    name: "control_after_generate",
+    type: "combo",
+    value: "randomize",
+    options: {
+      values: () => {
+        sideEffectFired = true;
+        seed.value = 0; // malicious side effect
+        return [...CONTROL_AFTER_GENERATE_MODES];
+      },
+      serialize: false,
+      canvasOnly: true,
+    },
+  };
+  seed.linkedWidgets = [control];
+  const node = { id: 70, type: "KSampler", widgets: [seed, control] };
+  // Reading entries / computing the warning must not fire the side effect nor change seed.
+  controlAfterGenerateModes(node);
+  controlAfterGenerateWarning(node, "seed");
+  assert.equal(sideEffectFired, false);
+  assert.equal(seed.value, 77, "the written seed value must be untouched by detection");
+});
+
+test("P1: a control widget with an ARBITRARY name (not 'control_after_generate') is still detected", () => {
+  // ComfyUI lets a node def name the control widget freely; detection is by marker +
+  // option shape, not name — otherwise a governed seed writes with NO warning.
+  const seed = { name: "seed", type: "INT", value: 5 };
+  const control = {
+    name: "seed_behavior",
+    type: "combo",
+    value: "randomize",
+    options: { values: [...CONTROL_AFTER_GENERATE_MODES], serialize: false, canvasOnly: true },
+  };
+  seed.linkedWidgets = [control];
+  const node = { id: 31, type: "CustomSampler", widgets: [seed, control] };
+  assert.equal(isControlAfterGenerateWidget(control), true);
+  assert.deepEqual(controlAfterGenerateModes(node), { seed: "randomize" });
+  const warn = controlAfterGenerateWarning(node, "seed");
+  assert.match(warn, /control_after_generate='randomize'/);
+  assert.match(warn, /widget='seed_behavior'/); // points at the ACTUAL control widget name
+});
+
+test("controlEntryForWidget matches the governed widget case-insensitively; returns null otherwise", () => {
+  const node = seedNode("randomize");
+  assert.equal(controlEntryForWidget(node, "seed").mode, "randomize");
+  assert.equal(controlEntryForWidget(node, "SEED").mode, "randomize");
+  assert.equal(controlEntryForWidget(node, "steps"), null);
+  assert.equal(controlEntryForWidget(node, "control_after_generate"), null); // the control widget itself
+});
+
+test("warning fires for a NON-fixed mode and points at the control widget + fix", () => {
+  const warn = controlAfterGenerateWarning(seedNode("randomize"), "seed");
+  assert.match(warn, /control_after_generate='randomize'/);
+  assert.match(warn, /automatically CHANGES this value/);
+  assert.match(warn, /new random value each run/);
+  assert.match(warn, /will NOT persist/);
+  assert.match(warn, /'fixed'/);
+  assert.match(warn, /widget='control_after_generate'/);
+});
+
+test("warning is MODE-ACCURATE: increment/decrement are deterministic, not 're-rolled'", () => {
+  const inc = controlAfterGenerateWarning(seedNode("increment"), "seed");
+  assert.match(inc, /increased by 1 each run/);
+  assert.doesNotMatch(inc, /random/);
+  const dec = controlAfterGenerateWarning(seedNode("decrement"), "seed");
+  assert.match(dec, /decreased by 1 each run/);
+});
+
+test("NO warning when the mode is 'fixed' (the value will hold)", () => {
+  assert.equal(controlAfterGenerateWarning(seedNode("fixed"), "seed"), null);
+});
+
+test("NO warning when writing an unrelated widget (steps)", () => {
+  assert.equal(controlAfterGenerateWarning(seedNode("randomize"), "steps"), null);
+});
+
+test("NO warning when writing the control widget itself (it changes the MODE, not a governed value)", () => {
+  // Normal node: control governs seed → writing 'control_after_generate' matches no
+  // governed entry.
+  assert.equal(controlAfterGenerateWarning(seedNode("randomize"), "control_after_generate"), null);
+});
+
+test("NO false warning for an ORPHAN control widget with no governed value widget", () => {
+  // A control combo with no linked/predecessor value widget keys on itself for DISPLAY,
+  // but writing it must not warn that it 'governs itself'.
+  const orphan = {
+    name: "control_after_generate",
+    type: "combo",
+    value: "randomize",
+    options: { values: [...CONTROL_AFTER_GENERATE_MODES], serialize: false, canvasOnly: true },
+  };
+  const node = { id: 12, type: "Weird", widgets: [orphan] }; // control is the FIRST widget
+  assert.equal(controlEntryForWidget(node, "control_after_generate"), null);
+  assert.equal(controlAfterGenerateWarning(node, "control_after_generate"), null);
+});
+
+test("two seed widgets (seed + noise_seed) each get their own association", () => {
+  const seed = { name: "seed", type: "INT", value: 1 };
+  const c1 = { name: "control_after_generate", type: "combo", value: "randomize", options: { values: [...CONTROL_AFTER_GENERATE_MODES], serialize: false, canvasOnly: true } };
+  const noise = { name: "noise_seed", type: "INT", value: 2 };
+  const c2 = { name: "control_after_generate", type: "combo", value: "fixed", options: { values: [...CONTROL_AFTER_GENERATE_MODES], serialize: false, canvasOnly: true } };
+  seed.linkedWidgets = [c1];
+  noise.linkedWidgets = [c2];
+  const node = { id: 9, type: "SamplerCustom", widgets: [seed, c1, noise, c2] };
+  assert.deepEqual(controlAfterGenerateModes(node), { seed: "randomize", noise_seed: "fixed" });
+});
+
+test("a node with no control widget yields no entries", () => {
+  const node = { id: 5, type: "CLIPTextEncode", widgets: [{ name: "text", value: "hi" }] };
+  assert.deepEqual(controlAfterGenerateModes(node), {});
+  assert.deepEqual(controlAfterGenerateEntries(node), []);
+});

--- a/browser_tests/unit/set-widget-composite-control.test.mjs
+++ b/browser_tests/unit/set-widget-composite-control.test.mjs
@@ -1,0 +1,189 @@
+/**
+ * End-to-end unit tests for runSetWidget (web/js/lib/set-widget.js), the SAME async
+ * unit GRAPH_TOOL_EXECUTORS.graph_set_widget delegates to — run with `node --test`.
+ *
+ * Covers the two set_widget honesty fixes wired at the runSetWidget layer:
+ *   #560 — `widget:"lora_1.on"` is parsed into a base-widget + sub-field and MERGED
+ *          (preserving lora/strength/strengthTwo); a bare scalar to a composite is
+ *          refused upstream (see widget-write.test.mjs).
+ *   #558 — a write to a value governed by a NON-fixed control_after_generate returns
+ *          a `warning` (the value will be overwritten next run); a 'fixed' one does not.
+ *
+ * Driven with the fresh-oracle capability wired exactly as the panel wires it, so the
+ * dotted-path parsing, promotion resolution, and warning all run their real path.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runSetWidget } from "../../web/js/lib/set-widget.js";
+import { CONTROL_AFTER_GENERATE_MODES } from "../../web/js/lib/control-after-generate.js";
+
+const HOOKS = { beforeChange() {}, afterChange() {}, setDirty() {} };
+
+// A genuinely-resolved node instance (its constructor carries a live def) so the
+// registry/placeholder guards pass and ONLY the intended behavior is under test.
+function regNode(type, widgets, extra = {}) {
+  return { id: 3, type, widgets, constructor: { nodeData: { input: { required: {} } } }, ...extra };
+}
+const reg = () => ({ KSampler: mkCtor(), "Power Lora Loader (rgthree)": mkCtor() });
+function mkCtor() {
+  const c = function NodeCtor() {};
+  c.nodeData = { input: { required: {} } };
+  return c;
+}
+const oracle = async () => ({ KSampler: {}, "Power Lora Loader (rgthree)": {} });
+
+function wired(extra = {}) {
+  const r = reg();
+  return { registry: r, getRegistry: () => r, getFreshObjectInfo: oracle, ...HOOKS, ...extra };
+}
+
+// ---- #560: dotted sub-field parsing at the runSetWidget layer ----------------
+
+test("#560 e2e: runSetWidget parses 'lora_1.on' and merges, preserving other fields", async () => {
+  const node = regNode("Power Lora Loader (rgthree)", [
+    { name: "lora_1", value: { on: true, lora: "motion.safetensors", strength: 1, strengthTwo: null } },
+  ]);
+  const res = await runSetWidget(node, "lora_1.on", false, wired());
+  assert.equal(res.set.value.on, false);
+  assert.equal(node.widgets[0].value.lora, "motion.safetensors");
+  assert.equal(node.widgets[0].value.strength, 1);
+  assert.equal(node.widgets[0].value.strengthTwo, null);
+  assert.equal(res.warning, undefined); // no control_after_generate here
+});
+
+test("#560 e2e: a bare scalar to the composite base is refused, value untouched", async () => {
+  const node = regNode("Power Lora Loader (rgthree)", [
+    { name: "lora_1", value: { on: true, lora: "keep.safetensors", strength: 1, strengthTwo: null } },
+  ]);
+  await assert.rejects(
+    () => runSetWidget(node, "lora_1", false, wired()),
+    /composite object widget|bare scalar would corrupt/,
+  );
+  assert.deepEqual(node.widgets[0].value, {
+    on: true,
+    lora: "keep.safetensors",
+    strength: 1,
+    strengthTwo: null,
+  });
+});
+
+// ---- #558: control_after_generate warning on write --------------------------
+
+function ksamplerWithSeedControl(mode) {
+  const seed = { name: "seed", type: "INT", value: 111 };
+  const control = {
+    name: "control_after_generate",
+    type: "combo",
+    value: mode,
+    options: { values: [...CONTROL_AFTER_GENERATE_MODES], serialize: false, canvasOnly: true },
+  };
+  seed.linkedWidgets = [control];
+  return regNode("KSampler", [seed, control, { name: "steps", type: "INT", value: 20 }]);
+}
+
+test("#558 e2e: writing a seed governed by 'randomize' SUCCEEDS but returns a warning", async () => {
+  const node = ksamplerWithSeedControl("randomize");
+  const res = await runSetWidget(node, "seed", 777777, wired());
+  assert.equal(res.set.value, 777777); // the write took
+  assert.match(res.warning, /control_after_generate='randomize'/);
+  assert.match(res.warning, /will NOT persist/);
+  assert.match(res.warning, /'fixed'/);
+});
+
+test("#558 e2e: writing a seed with 'fixed' control returns NO warning", async () => {
+  const node = ksamplerWithSeedControl("fixed");
+  const res = await runSetWidget(node, "seed", 777777, wired());
+  assert.equal(res.set.value, 777777);
+  assert.equal(res.warning, undefined);
+});
+
+test("#558 e2e: writing an unrelated widget (steps) returns NO warning even under randomize", async () => {
+  const node = ksamplerWithSeedControl("randomize");
+  const res = await runSetWidget(node, "steps", 30, wired());
+  assert.equal(res.set.value, 30);
+  assert.equal(res.warning, undefined);
+});
+
+test("#558 e2e: setting control_after_generate itself to 'fixed' is the fix — no warning", async () => {
+  const node = ksamplerWithSeedControl("randomize");
+  const res = await runSetWidget(node, "control_after_generate", "fixed", wired());
+  assert.equal(res.set.value, "fixed");
+  assert.equal(res.warning, undefined);
+});
+
+// A TWO-LEVEL nested promotion A→B→KSampler where control_after_generate lives on the
+// CONCRETE KSampler (not the intermediate virtual B). The warning MUST be computed on
+// the concrete node reached by following the promotion chain, not the immediate virtual
+// target — otherwise a nested seed write reports no warning despite randomize (P1 in
+// review). Mirrors makeNestedSubgraphFixture from set-widget-fresh-backend.test.mjs.
+function nestedSeedControl(r, mode) {
+  const seedW = { name: "seed", type: "INT", value: 111 };
+  const controlW = {
+    name: "control_after_generate",
+    type: "combo",
+    value: mode,
+    options: { values: [...CONTROL_AFTER_GENERATE_MODES], serialize: false, canvasOnly: true },
+  };
+  seedW.linkedWidgets = [controlW];
+  const concrete = {
+    id: 90,
+    type: "KSampler",
+    widgets: [seedW, controlW],
+    constructor: { nodeData: { input: { required: {} } } },
+  };
+  const b = {
+    id: 80,
+    type: "SubgraphB",
+    widgets: [{ name: "seed", type: "INT", value: 111 }],
+    subgraph: { _nodes: [concrete], getNodeById: (id) => (String(id) === "90" ? concrete : null) },
+    inputs: [{ name: "seed", _subgraphSlot: { name: "seed" } }],
+  };
+  const aRail = { name: "seed", type: "INT", value: 111 };
+  const a = {
+    id: 70,
+    type: "SubgraphA",
+    widgets: [aRail],
+    subgraph: { _nodes: [b], getNodeById: (id) => (String(id) === "80" ? b : null) },
+    inputs: [{ name: "seed", _widget: aRail, widget: { name: "seed" }, _subgraphSlot: { name: "seed" } }],
+  };
+  r.SubgraphA = function SubgraphA() {};
+  r.SubgraphB = function SubgraphB() {};
+  const resolveSource = (sn, si) => {
+    if (sn === a && si?.name === "seed") return { sourceNodeId: "80", sourceWidgetName: "seed" };
+    if (sn === b && si?.name === "seed") return { sourceNodeId: "90", sourceWidgetName: "seed" };
+    return null;
+  };
+  return { a, b, concrete, resolveSource };
+}
+
+test("#558 e2e NESTED: the warning is computed on the CONCRETE node's control (A→B→KSampler)", async () => {
+  const r = reg();
+  const { a, b, resolveSource } = nestedSeedControl(r, "randomize");
+  const res = await runSetWidget(a, "seed", 777777, {
+    registry: r,
+    getRegistry: () => r,
+    getFreshObjectInfo: async () => ({ KSampler: {} }), // SubgraphA/B are virtual, absent
+    resolveSource,
+    ...HOOKS,
+  });
+  assert.equal(res.set.value, 777777, "nested promoted seed write succeeds");
+  assert.equal(b.widgets.find((w) => w.name === "seed").value, 777777);
+  // The control lives on KSampler, reached by following the chain — warning must fire.
+  assert.match(res.warning, /control_after_generate='randomize'/);
+  assert.match(res.warning, /will NOT persist/);
+});
+
+test("#558 e2e NESTED: a 'fixed' concrete control yields NO warning", async () => {
+  const r = reg();
+  const { a, resolveSource } = nestedSeedControl(r, "fixed");
+  const res = await runSetWidget(a, "seed", 777777, {
+    registry: r,
+    getRegistry: () => r,
+    getFreshObjectInfo: async () => ({ KSampler: {} }),
+    resolveSource,
+    ...HOOKS,
+  });
+  assert.equal(res.set.value, 777777);
+  assert.equal(res.warning, undefined);
+});

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -142,6 +142,364 @@ test("#179: a non-JSON string for a composite widget is refused, not written raw
   assert.throws(() => applyWidgetWrite(node, "lora_2", "not-json", {}), /not valid JSON/);
 });
 
+// ---- #560: scalar-to-composite corruption is REFUSED; sub-field writes MERGE -----
+
+test("#560: a BARE SCALAR to a composite slot is REFUSED, leaving every field intact", () => {
+  const node = {
+    id: 128,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [
+      { name: "lora_1", value: { on: true, lora: "motion.safetensors", strength: 1, strengthTwo: null } },
+    ],
+  };
+  // The exact #560 repro: value=false must NOT null the lora / clobber the row.
+  assert.throws(
+    () => applyWidgetWrite(node, "lora_1", false, {}),
+    (err) =>
+      err instanceof WidgetWriteError &&
+      /composite object widget/.test(err.message) &&
+      /bare scalar would corrupt it/.test(err.message) &&
+      /"lora_1\.on"/.test(err.message), // points at the sub-field syntax
+  );
+  // The ORIGINAL value survives verbatim — no partial write happened.
+  assert.deepEqual(node.widgets[0].value, {
+    on: true,
+    lora: "motion.safetensors",
+    strength: 1,
+    strengthTwo: null,
+  });
+});
+
+test("#560: a sub-field write (lora_1.on=false) MERGES only that field; lora/strength/strengthTwo SURVIVE", () => {
+  const node = {
+    id: 128,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [
+      { name: "lora_1", value: { on: true, lora: "motion.safetensors", strength: 1, strengthTwo: 0.5 } },
+    ],
+  };
+  const set = applyWidgetWrite(node, "lora_1.on", false, {});
+  assert.equal(set.value.on, false);
+  // Every OTHER field is preserved — the core anti-corruption assertion.
+  assert.equal(node.widgets[0].value.lora, "motion.safetensors");
+  assert.equal(node.widgets[0].value.strength, 1);
+  assert.equal(node.widgets[0].value.strengthTwo, 0.5);
+});
+
+test("#560: a numeric sub-field write (lora_1.strength=0.8) preserves the filename + toggle", () => {
+  const node = {
+    id: 128,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [{ name: "lora_1", value: { on: true, lora: "x.safetensors", strength: 1, strengthTwo: null } }],
+  };
+  const set = applyWidgetWrite(node, "lora_1.strength", 0.8, {});
+  assert.equal(set.value.strength, 0.8);
+  assert.equal(node.widgets[0].value.lora, "x.safetensors");
+  assert.equal(node.widgets[0].value.on, true);
+  assert.equal(node.widgets[0].value.strengthTwo, null);
+});
+
+test("#560: a string sub-field write (lora_1.lora=name) preserves on/strength", () => {
+  const node = {
+    id: 128,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [{ name: "lora_1", value: { on: true, lora: "old.safetensors", strength: 0.7, strengthTwo: null } }],
+  };
+  const set = applyWidgetWrite(node, "lora_1.lora", "new.safetensors", {});
+  assert.equal(set.value.lora, "new.safetensors");
+  assert.equal(node.widgets[0].value.on, true);
+  assert.equal(node.widgets[0].value.strength, 0.7);
+});
+
+test("#560: sub-field addressing on a NON-composite widget FAILS LOUDLY (never a wrong write)", () => {
+  const node = { id: 40, type: "KSampler", widgets: [{ name: "seed", type: "INT", value: 5 }] };
+  assert.throws(
+    () => applyWidgetWrite(node, "seed.on", 9, {}),
+    (err) => err instanceof WidgetWriteError && /not a composite object widget/.test(err.message),
+  );
+  assert.equal(node.widgets[0].value, 5, "the scalar widget must be untouched");
+});
+
+test("#560 EXACT-FIRST: a widget whose OWN name contains a dot is targeted exactly, never split", () => {
+  // A (contrived) widget literally named "lora.on" must win over a base "lora" split.
+  const node = {
+    id: 41,
+    type: "CustomNode",
+    widgets: [
+      { name: "lora", value: { on: true, lora: "keep.safetensors", strength: 1 } },
+      { name: "lora.on", type: "text", value: "literal" },
+    ],
+  };
+  const set = applyWidgetWrite(node, "lora.on", "written", {});
+  assert.equal(set.value, "written");
+  assert.equal(node.widgets[1].value, "written");
+  // The composite base was NOT touched.
+  assert.deepEqual(node.widgets[0].value, { on: true, lora: "keep.safetensors", strength: 1 });
+});
+
+test("#560 EMPTY SUFFIX: 'lora_1.' is refused loudly, base is NOT silently written", () => {
+  const node = {
+    id: 42,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [{ name: "lora_1", value: { on: true, lora: "a.safetensors", strength: 1 } }],
+  };
+  assert.throws(
+    () => applyWidgetWrite(node, "lora_1.", false, {}),
+    (err) => err instanceof WidgetWriteError && /empty sub-field/.test(err.message),
+  );
+  assert.deepEqual(node.widgets[0].value, { on: true, lora: "a.safetensors", strength: 1 });
+});
+
+test("#560: coerceWidgetValue merges a sub-field onto the CURRENT object", () => {
+  const w = { name: "lora_1", value: { on: true, lora: "a.safetensors", strength: 1, strengthTwo: null } };
+  const merged = coerceWidgetValue(w, false, w, "on");
+  assert.deepEqual(merged, { on: false, lora: "a.safetensors", strength: 1, strengthTwo: null });
+});
+
+test("#560: a nested sub-field path is refused (no per-node schema to shape it)", () => {
+  const w = { name: "lora_1", value: { on: true, lora: "a", strength: 1 } };
+  assert.throws(() => coerceWidgetValue(w, 1, w, "a.b"), /Nested sub-field path/);
+});
+
+test("#560 HARDEN: a sub-field write to an UNKNOWN field is refused, never ADDED", () => {
+  const node = {
+    id: 43,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [{ name: "lora_1", value: { on: true, lora: "a.safetensors", strength: 1, strengthTwo: null } }],
+  };
+  assert.throws(
+    () => applyWidgetWrite(node, "lora_1.strenght", 1, {}), // typo
+    (err) => err instanceof WidgetWriteError && /has no field "strenght"/.test(err.message),
+  );
+  // No junk member was added and the row is unchanged.
+  assert.deepEqual(node.widgets[0].value, { on: true, lora: "a.safetensors", strength: 1, strengthTwo: null });
+});
+
+test("#560 HARDEN: a boolean-string ('false') for a boolean field COERCES to boolean, not a string", () => {
+  const node = {
+    id: 44,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [{ name: "lora_1", value: { on: true, lora: "a.safetensors", strength: 1 } }],
+  };
+  const set = applyWidgetWrite(node, "lora_1.on", "false", {});
+  assert.strictEqual(set.value.on, false); // boolean false, NOT the string "false"
+  assert.equal(node.widgets[0].value.lora, "a.safetensors");
+});
+
+test("#560 HARDEN: a non-numeric value for a numeric field is refused", () => {
+  const node = {
+    id: 45,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [{ name: "lora_1", value: { on: true, lora: "a.safetensors", strength: 1 } }],
+  };
+  assert.throws(
+    () => applyWidgetWrite(node, "lora_1.strength", "loud", {}),
+    (err) => err instanceof WidgetWriteError && /is numeric but value/.test(err.message),
+  );
+  assert.equal(node.widgets[0].value.strength, 1, "unchanged on reject");
+});
+
+test("#560 HARDEN: a number into a STRING field (lora filename) is refused", () => {
+  const node = {
+    id: 46,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [{ name: "lora_1", value: { on: true, lora: "a.safetensors", strength: 1 } }],
+  };
+  assert.throws(
+    () => applyWidgetWrite(node, "lora_1.lora", 5, {}),
+    (err) => err instanceof WidgetWriteError && /is a string but value/.test(err.message),
+  );
+});
+
+test("#560 HARDEN: a FULL JSON-object write also rejects unknown fields + mistypes (not just dotted)", () => {
+  const node = {
+    id: 48,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [{ name: "lora_1", value: { on: true, lora: "a.safetensors", strength: 1, strengthTwo: null } }],
+  };
+  // Unknown field in the object payload is refused (no junk added).
+  assert.throws(
+    () => applyWidgetWrite(node, "lora_1", '{"strenght":2}', {}),
+    (err) => err instanceof WidgetWriteError && /has no field "strenght"/.test(err.message),
+  );
+  // A mistyped known field (string into boolean) COERCES rather than storing "false".
+  const set = applyWidgetWrite(node, "lora_1", '{"on":"false"}', {});
+  assert.strictEqual(set.value.on, false);
+  assert.equal(node.widgets[0].value.lora, "a.safetensors");
+  assert.equal(node.widgets[0].value.strength, 1);
+});
+
+test("#560 P0: a null-valued field ENFORCES its DECLARED type — number into a null `lora` is refused", () => {
+  // Empty rgthree row: lora/strengthTwo are null. Type must come from the schema, NOT
+  // the (null) current value — otherwise a wrong-typed scalar is silently accepted.
+  const node = {
+    id: 50,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [{ name: "lora_1", value: { on: true, lora: null, strength: 1, strengthTwo: null } }],
+  };
+  assert.throws(
+    () => applyWidgetWrite(node, "lora_1.lora", 5, {}), // number into string|null field
+    (err) => err instanceof WidgetWriteError && /is a string but value/.test(err.message),
+  );
+  assert.throws(
+    () => applyWidgetWrite(node, "lora_1", '{"strengthTwo":"bad"}', {}), // string into number|null
+    (err) => err instanceof WidgetWriteError && /is numeric but value/.test(err.message),
+  );
+  assert.deepEqual(node.widgets[0].value, { on: true, lora: null, strength: 1, strengthTwo: null });
+});
+
+test("#560 P0: a null-valued field still ACCEPTS a correctly-typed value", () => {
+  const node = {
+    id: 51,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [{ name: "lora_1", value: { on: true, lora: null, strength: 1, strengthTwo: null } }],
+  };
+  const set = applyWidgetWrite(node, "lora_1.lora", "face.safetensors", {});
+  assert.equal(set.value.lora, "face.safetensors");
+  const set2 = applyWidgetWrite(node, "lora_1.strengthTwo", 0.5, {});
+  assert.equal(set2.value.strengthTwo, 0.5);
+});
+
+test("#560 P2: clearing a NULLABLE field to null is accepted (lora, strengthTwo)", () => {
+  const node = {
+    id: 52,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [{ name: "lora_1", value: { on: true, lora: "x.safetensors", strength: 1, strengthTwo: 0.5 } }],
+  };
+  const set = applyWidgetWrite(node, "lora_1", '{"lora":null}', {});
+  assert.equal(set.value.lora, null);
+  assert.equal(node.widgets[0].value.strength, 1); // sibling preserved
+  const set2 = applyWidgetWrite(node, "lora_1", '{"strengthTwo":null}', {});
+  assert.equal(set2.value.strengthTwo, null);
+});
+
+test("#560 P0: an rgthree-KEY-SHAPED row enforces the schema even when a current value is CORRUPT (repair-forward)", () => {
+  // The key set is rgthree's, but `on` currently holds a wrong-typed string (from a prior
+  // bad write). Classification is by KEY SHAPE, not value validity, so the schema is still
+  // ENFORCED: a further wrong-type write to `on` is refused, and a valid boolean REPAIRS it.
+  const node = {
+    id: 54,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [{ name: "lora_1", value: { on: "yes", lora: "x.safetensors", strength: 1 } }],
+  };
+  assert.throws(
+    () => applyWidgetWrite(node, "lora_1.on", "active", {}), // still a string → refused
+    (err) => err instanceof WidgetWriteError && /is boolean but value/.test(err.message),
+  );
+  const set = applyWidgetWrite(node, "lora_1.on", true, {}); // valid boolean repairs it
+  assert.strictEqual(set.value.on, true);
+  assert.equal(node.widgets[0].value.lora, "x.safetensors");
+});
+
+test("#560 P0: a partially-corrupt row rejects a further wrong-type FULL-OBJECT write, repairs a valid one", () => {
+  // `lora` is corruptly numeric (5). The schema (string) must still be enforced from the
+  // KEY SHAPE — a further numeric write is refused (would deepen corruption), a string repairs.
+  const node = {
+    id: 58,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [{ name: "lora_1", value: { on: true, lora: 5, strength: 1, strengthTwo: null } }],
+  };
+  assert.throws(
+    () => applyWidgetWrite(node, "lora_1", '{"lora":6}', {}),
+    (err) => err instanceof WidgetWriteError && /is a string but value/.test(err.message),
+  );
+  const set = applyWidgetWrite(node, "lora_1", '{"lora":"real.safetensors"}', {});
+  assert.equal(set.value.lora, "real.safetensors");
+});
+
+test("#560 P1: a foreign composite's UNTYPED (null) field is REFUSED, not accepted with a guessed type", () => {
+  const node = {
+    id: 56,
+    type: "SomeOtherNode",
+    widgets: [{ name: "cfg", value: { on: true, lora: null, strength: 1, extra: "x" } }],
+  };
+  // `extra` is not an rgthree key → schema NOT applied → lora is null → type unknowable →
+  // refuse LOUDLY (no silent wrong-typed write).
+  assert.throws(
+    () => applyWidgetWrite(node, "cfg.lora", "anything", {}),
+    (err) => err instanceof WidgetWriteError && /cannot validate the value/.test(err.message),
+  );
+  // A NON-null field of the same foreign composite is still writable (type inferred).
+  const set = applyWidgetWrite(node, "cfg.strength", 0.5, {});
+  assert.equal(set.value.strength, 0.5);
+});
+
+test("#560 P0: an rgthree-key-shaped row with an undefined field is REPAIRED-FORWARD by the schema", () => {
+  // `on: undefined` — the key shape is still rgthree's, so the boolean schema is enforced:
+  // a boolean-string 'false' coerces to boolean false (repairing the field), and a foreign
+  // value would be refused. Classification never depends on the current value's validity.
+  const node = {
+    id: 57,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [{ name: "lora_1", value: { on: undefined, lora: null, strength: 1 } }],
+  };
+  const set = applyWidgetWrite(node, "lora_1.on", "false", {});
+  assert.strictEqual(set.value.on, false); // coerced to boolean, not the string "false"
+});
+
+test("#560 P2: a DOTTED null clears a nullable field (lora); non-nullable (on) is still refused", () => {
+  const node = {
+    id: 55,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [{ name: "lora_1", value: { on: true, lora: "x.safetensors", strength: 1, strengthTwo: 0.5 } }],
+  };
+  const set = applyWidgetWrite(node, "lora_1.lora", null, {});
+  assert.equal(set.value.lora, null);
+  assert.equal(node.widgets[0].value.strength, 1);
+  assert.throws(
+    () => applyWidgetWrite(node, "lora_1.on", null, {}),
+    (err) => err instanceof WidgetWriteError && /not nullable/.test(err.message),
+  );
+});
+
+test("#560 P2: clearing a NON-nullable field to null is refused (on, strength)", () => {
+  const node = {
+    id: 53,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [{ name: "lora_1", value: { on: true, lora: "x.safetensors", strength: 1, strengthTwo: null } }],
+  };
+  assert.throws(
+    () => applyWidgetWrite(node, "lora_1", '{"on":null}', {}),
+    (err) => err instanceof WidgetWriteError && /not nullable/.test(err.message),
+  );
+  assert.throws(
+    () => applyWidgetWrite(node, "lora_1", '{"strength":null}', {}),
+    (err) => err instanceof WidgetWriteError && /not nullable/.test(err.message),
+  );
+  assert.equal(node.widgets[0].value.on, true);
+  assert.equal(node.widgets[0].value.strength, 1);
+});
+
+test("#179 REGRESSION: a valid full-object write still merges + preserves unspecified fields", () => {
+  const node = {
+    id: 49,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [{ name: "lora_1", value: { on: false, lora: null, strength: 1, strengthTwo: null } }],
+  };
+  const set = applyWidgetWrite(node, "lora_1", '{"on":true,"lora":"x.safetensors","strength":0.6}', {});
+  assert.equal(set.value.on, true);
+  assert.equal(set.value.lora, "x.safetensors");
+  assert.equal(set.value.strength, 0.6);
+  assert.equal(set.value.strengthTwo, null); // preserved
+});
+
+test("#560 SAFETY: dotted addressing on a SUBGRAPH parent is refused (never a rail-only write)", () => {
+  // A subgraph-shaped node whose "lora_1" is NOT resolvable as a promotion alias here:
+  // the dotted form must fail closed rather than write the parent rail directly (#366).
+  const node = {
+    id: 47,
+    type: "MySubgraph",
+    subgraph: {},
+    inputs: [],
+    widgets: [{ name: "lora_1", value: { on: true, lora: "a.safetensors", strength: 1 } }],
+  };
+  assert.throws(
+    () => applyWidgetWrite(node, "lora_1.on", false, { resolveSource: () => null }),
+    (err) => err instanceof WidgetWriteError && /not supported on subgraph node/.test(err.message),
+  );
+  assert.deepEqual(node.widgets[0].value, { on: true, lora: "a.safetensors", strength: 1 });
+});
+
 // ---- combo classification + exact-value writes (#240) ---------------------
 
 test("combo widget is classified by its option list", () => {
@@ -1169,4 +1527,36 @@ test("#366×#179: a promoted COMPOSITE write merges onto the RAIL's current obje
   assert.equal(inner.widgets[0].value.lora, "current.safetensors");
   assert.equal(inner.widgets[0].value.strength, 0.6);
   assert.equal(set.promoted_from.parent_widget_synced, true);
+});
+
+test("#560 P1: a promoted composite whose INNER value went STALE-SCALAR is still detected via the RAIL (no raw-string clobber)", () => {
+  // The inner widget value is a stale SCALAR while the authoritative rail still holds the
+  // composite object. A JSON payload must be recognized as composite via the rail and
+  // MERGED onto it — never fall through as a raw string that clobbers the rail (#179/#366).
+  const inner = {
+    id: 301,
+    type: "Power Lora Loader (rgthree)",
+    widgets: [{ name: "lora_1", value: "STALE" }], // scalar, not an object
+  };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "301" ? inner : null) };
+  const railWidget = { name: "lora_1", value: { on: true, lora: "current.safetensors", strength: 0.8, strengthTwo: null } };
+  const parent = {
+    id: 268,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [{ name: "lora_1", _widget: railWidget, _subgraphSlot: { name: "lora_1" } }],
+    widgets: [railWidget],
+  };
+  const resolveSource = (_n, si) =>
+    si?.name === "lora_1" ? { sourceNodeId: "301", sourceWidgetName: "lora_1" } : null;
+
+  const set = applyWidgetWrite(parent, "lora_1", '{"strength":0.6}', { resolveSource });
+
+  // Rail merged onto its object — NOT overwritten by the raw string "{\"strength\":0.6}".
+  assert.equal(typeof railWidget.value, "object");
+  assert.equal(railWidget.value.strength, 0.6);
+  assert.equal(railWidget.value.lora, "current.safetensors");
+  assert.equal(railWidget.value.on, true);
+  assert.equal(railWidget.value.strengthTwo, null);
+  assert.equal(inner.widgets[0].value.strength, 0.6);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -120,6 +120,10 @@ import {
   computeOrphanedBoundaries,
 } from "./lib/subgraph-scope.js";
 import { runSetWidget } from "./lib/set-widget.js";
+import {
+  controlAfterGenerateModes,
+  controlAfterGenerateEntries,
+} from "./lib/control-after-generate.js";
 import { autoMatchSlots, slotDiagnostic } from "./lib/connect-match.js";
 import { coerceMessageText, isDroppedAgentReplay, serializeContext } from "./lib/chat-serialize.js";
 import {
@@ -3931,6 +3935,13 @@ function summarizeNode(node) {
   if (fullHeight == null && node.size) {
     fullHeight = node.flags && node.flags.collapsed ? 30 : Math.round(node.size[1] + 30);
   }
+  // #558: control_after_generate governs seed/INT/COMBO widgets and SILENTLY rewrites
+  // their value after each generation — a value the agent explicitly set will not hold.
+  // The ComfyUI frontend adds it as a serialize:false/canvasOnly widget that renders
+  // unassociated from the seed it controls, so it is easy to miss. Surface it as an
+  // EXPLICIT, seed-associated map (governed-widget → mode) so the mode is visible and
+  // an agent can verify a "fixed" seed actually holds.
+  const controlAfterGenerate = controlAfterGenerateModes(node);
   const summary = {
     id: node.id,
     type: node.type,
@@ -3947,6 +3958,9 @@ function summarizeNode(node) {
     // OUTPUT nodes (SaveImage/PreviewImage/SaveVideo/…) are the only valid
     // targets for panel_run's to_node_id ("run to node" partial execution).
     ...(node.constructor?.nodeData?.output_node ? { is_output: true } : {}),
+    ...(Object.keys(controlAfterGenerate).length
+      ? { control_after_generate: controlAfterGenerate }
+      : {}),
     widgets,
     inputs,
     outputs,
@@ -4480,9 +4494,22 @@ const GRAPH_TOOL_EXECUTORS = {
       const title = n.title && n.title !== n.type ? ` "${n.title}"` : "";
       const grps = groupOf.get(n.id);
       const groupTag = grps?.length ? ` · group:${grps.join("/")}` : "";
+      // #558: MARK the seed/value widget with its control_after_generate mode
+      // (`seed=… [after_gen=randomize]`) — visible like [bypass]/[mute] so a silently-
+      // rewritten value is obvious. The control combo token is NOT hidden (folding could
+      // hide a real combo that merely shares the mode option set), only annotated.
+      const cagMode = new Map(
+        controlAfterGenerateEntries(n)
+          .filter((e) => e.widget !== e.control)
+          .map((e) => [e.widget, e.mode]),
+      );
       const widgets = (n.widgets ?? [])
         .filter((w) => w && typeof w.name === "string")
-        .map((w) => `${w.name}=${fmtVal(w.value)}`)
+        .map((w) => {
+          const base = `${w.name}=${fmtVal(w.value)}`;
+          const mode = cagMode.get(w.name);
+          return mode ? `${base} [after_gen=${mode}]` : base;
+        })
         .join(" ");
       lines.push(
         `${n.id}  ${n.type}${title}${modeTag(n)}${outTag(n)}${groupTag}${widgets ? "  " + widgets : ""}`,

--- a/web/js/lib/control-after-generate.js
+++ b/web/js/lib/control-after-generate.js
@@ -1,0 +1,151 @@
+// control_after_generate detection for graph reads + set_widget honesty (#558).
+//
+// A seed/noise_seed (and any INT/COMBO) widget can carry a companion combo widget
+// named "control_after_generate" whose value ("fixed" | "increment" | "decrement" |
+// "randomize") makes ComfyUI SILENTLY rewrite the governed value AFTER each
+// generation. The ComfyUI frontend adds this control widget to `node.widgets` with
+// `serialize:false, canvasOnly:true`, so it renders as an unassociated widget entry
+// that is easy to miss — a value the agent explicitly set (e.g. a fixed seed for a
+// controlled A/B run) will not hold, with nothing in the tool surface revealing it.
+//
+// This module is EXTRACTED so the detection is unit-tested against the SAME code the
+// panel's summarizeNode / graph_outline / runSetWidget run — a regression fails a
+// test instead of silently re-hiding the mode.
+
+export const CONTROL_AFTER_GENERATE_MODES = ["fixed", "increment", "decrement", "randomize"];
+
+/**
+ * True for a control_after_generate combo widget. Detected by OPTION SHAPE — an option
+ * list containing every control mode — NOT by the literal widget name. ComfyUI lets a
+ * node def name the control widget arbitrarily (a `seed` may be governed by a control
+ * widget named e.g. `seed_behavior`), so a name-substring test misses renamed controls
+ * and drops the #558 warning. The mode option list is the reliable, name-independent
+ * signal — nothing else in a graph carries options [fixed, increment, decrement,
+ * randomize] — and a value-only match (a text widget merely holding "fixed") is still
+ * refused as too weak.
+ */
+export function isControlAfterGenerateWidget(w) {
+  const opts = w?.options;
+  if (!opts) return false;
+  // AUTHORITATIVE control marker: ComfyUI creates the value-control combo with BOTH
+  // `serialize:false` AND `canvasOnly:true`. Requiring BOTH (the real frontend shape)
+  // distinguishes a genuine control from an unrelated hidden combo that merely happens to
+  // be non-serialized and share the mode strings — so no false outline annotation/warning.
+  if (opts.serialize !== false || opts.canvasOnly !== true) return false;
+  // SIDE-EFFECT-FREE detection: a real control combo always carries a STATIC option array,
+  // so we require an array and NEVER invoke a dynamic `values()` function. Detection runs
+  // during reads AND after a write has been verified; invoking a side-effecting callback
+  // here could mutate the graph AFTER verification and silently change the reported value.
+  const vals = opts.values;
+  if (!Array.isArray(vals)) return false;
+  // SUPERSET test: the option list must CONTAIN every base control mode. Not exact-set —
+  // ComfyUI appends a 5th option, "increment-wrap", when the governed widget is itself a
+  // COMBO, so an exact-4 check would MISS combo-governed controls (a real false negative).
+  const set = new Set(vals.map((v) => String(v)));
+  return CONTROL_AFTER_GENERATE_MODES.every((m) => set.has(m));
+}
+
+// A widget that control_after_generate plausibly GOVERNS: a numeric value, a combo, or a
+// seed-named widget. Used to gate the POSITIONAL predecessor fallback so a coincidental
+// mode-option combo does not attach its mode to an unrelated preceding widget.
+function isEligibleGovernedWidget(w) {
+  if (!w || typeof w.name !== "string") return false;
+  const t = String(w.type ?? "").toLowerCase();
+  if (["int", "float", "number", "slider", "combo"].includes(t)) return true;
+  if (Array.isArray(w?.options?.values) || typeof w?.options?.values === "function") return true;
+  return /(^|_)seed$/i.test(w.name) || /noise_seed/i.test(w.name);
+}
+
+/**
+ * The control_after_generate relationships on a node, as
+ * `{ widget: <governed name>, control: <control widget name>, mode }[]`.
+ *
+ * The governed value widget is identified by the AUTHORITATIVE frontend link first
+ * (a value widget whose `linkedWidgets` array includes the control widget), then by
+ * POSITION (the control widget is inserted immediately after the value widget it
+ * governs) as a fallback. When neither yields a distinct governed widget, the entry
+ * is keyed on the control widget itself so the mode is never dropped.
+ */
+export function controlAfterGenerateEntries(node) {
+  const widgets = Array.isArray(node?.widgets) ? node.widgets : [];
+  const entries = [];
+  widgets.forEach((w, i) => {
+    if (!isControlAfterGenerateWidget(w)) return;
+    const mode = typeof w.value === "string" ? w.value : String(w.value);
+    let governed = null;
+    // 1) Authoritative: a value widget that links to THIS control widget.
+    for (const v of widgets) {
+      if (v !== w && Array.isArray(v.linkedWidgets) && v.linkedWidgets.includes(w)) {
+        governed = v;
+        break;
+      }
+    }
+    // 2) Fallback: the IMMEDIATELY preceding widget, and ONLY when it is an ELIGIBLE
+    //    control target (a numeric/combo value or a seed-named widget — what
+    //    control_after_generate actually governs). ComfyUI inserts the control combo
+    //    directly after the value widget it governs, so the predecessor at i-1 is the
+    //    right one; restricting it to eligible widgets avoids attaching a spurious mode
+    //    to an unrelated predecessor if some combo happens to share the mode option set.
+    if (!governed && i > 0) {
+      const cand = widgets[i - 1];
+      if (
+        cand &&
+        typeof cand.name === "string" &&
+        !isControlAfterGenerateWidget(cand) &&
+        isEligibleGovernedWidget(cand)
+      ) {
+        governed = cand;
+      }
+    }
+    entries.push({
+      widget: governed && typeof governed.name === "string" ? governed.name : w.name,
+      control: w.name,
+      mode,
+    });
+  });
+  return entries;
+}
+
+/** Map of governed-widget-name → mode, e.g. `{ seed: "randomize" }`. */
+export function controlAfterGenerateModes(node) {
+  const out = {};
+  for (const e of controlAfterGenerateEntries(node)) out[e.widget] = e.mode;
+  return out;
+}
+
+/**
+ * The control entry whose GOVERNED VALUE widget is `widgetName` (case-insensitive), or
+ * null. Self-keyed fallback entries (an orphan control widget with no distinct governed
+ * widget, keyed on the control itself) are EXCLUDED: writing `control_after_generate`
+ * changes the MODE, it is not a value governed by that mode, so it must never warn.
+ */
+export function controlEntryForWidget(node, widgetName) {
+  if (widgetName == null) return null;
+  const wanted = String(widgetName).toLowerCase();
+  return (
+    controlAfterGenerateEntries(node).find(
+      (e) => e.widget !== e.control && String(e.widget).toLowerCase() === wanted,
+    ) ?? null
+  );
+}
+
+/**
+ * A warning string when writing `widgetName` on `node` targets a value governed by a
+ * NON-fixed control_after_generate (the write will not hold), else null. Points at
+ * the exact control widget + value to make it stick, so the agent can self-correct.
+ */
+export function controlAfterGenerateWarning(node, widgetName) {
+  const entry = controlEntryForWidget(node, widgetName);
+  if (!entry || entry.mode === "fixed") return null;
+  const behavior = {
+    randomize: "a new random value each run",
+    increment: "increased by 1 each run",
+    decrement: "decreased by 1 each run",
+  }[entry.mode] ?? "automatically changed each run";
+  return (
+    `control_after_generate='${entry.mode}' governs widget "${entry.widget}" on node ${node?.id}: ` +
+    `ComfyUI automatically CHANGES this value on subsequent runs (${behavior}), so the value you set ` +
+    `will NOT persist. Set "${entry.control}" to 'fixed' to hold it — e.g. ` +
+    `panel_set_widget(node_id=${node?.id}, widget='${entry.control}', value='fixed').`
+  );
+}

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -28,6 +28,7 @@ import {
   assertResolvedTargetRegistered,
   assertTypeAgainstFreshBackend,
 } from "./node-resolve.js";
+import { controlAfterGenerateWarning } from "./control-after-generate.js";
 
 export async function runSetWidget(
   node,
@@ -184,6 +185,11 @@ export async function runSetWidget(
   // runs on the RESOLVED target BEFORE coercion/mutation, so a placeholder is
   // refused before any side effect (#458). promotedResolution is reused so the
   // write lands on the exact inner node the fresh oracle authorized.
+  // The full (possibly dotted) widgetName is passed through UNCHANGED (#560): sub-field
+  // addressing ("lora_1.on") is resolved EXACT-NAME-FIRST inside applyWidgetWrite /
+  // resolveWidgetWrite — a real widget whose own name contains a dot still wins, and a
+  // dotted form is only interpreted when no exact widget matches — so the split can
+  // never silently misroute to a different widget.
   const write = () =>
     applyWidgetWrite(node, widgetName, value, {
       resolveSource,
@@ -195,8 +201,23 @@ export async function runSetWidget(
       promotedResolution,
     });
 
+  // #558: the value widget being written may be governed by a non-`fixed`
+  // control_after_generate (seed randomize/increment/…), which SILENTLY overwrites
+  // it after the next generation. Warn HONESTLY on success — the write "took", but it
+  // will not hold — pointing at the exact control widget to make it stick. Computed on
+  // the ULTIMATE CONCRETE node + its concrete widget name (where control_after_generate
+  // actually lives): a nested promotion A→B→KSampler exposes `seed` on B virtually, but
+  // the control combo is on KSampler — `authTarget`/`concreteWidgetName` follow the
+  // promotion chain to it (both are the node itself for a direct write).
+  const withWarning = (result) => {
+    const warnNode = authTarget ?? resolvedTargetNode;
+    const warnWidget = concreteWidgetName ?? writeTargetWidgetName ?? widgetName;
+    const warning = controlAfterGenerateWarning(warnNode, warnWidget);
+    return warning ? { ...result, warning } : result;
+  };
+
   try {
-    return { set: write() };
+    return withWarning({ set: write() });
   } catch (err) {
     // STALE-COMBO RECOVERY (#338/#317/#299/#288/#284/#304): the ONLY retryable
     // failure is a COMBO value rejected against the widget's CURRENT option list
@@ -229,7 +250,7 @@ export async function runSetWidget(
         /* refresh best-effort; fall through to re-raise the original rejection */
       }
       try {
-        return { set: write(), refreshed: true };
+        return withWarning({ set: write(), refreshed: true });
       } catch (retryErr) {
         if (retryErr instanceof WidgetWriteError) {
           throw new Error(

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -91,12 +91,131 @@ export function isCompositeObjectWidget(widget) {
   return v != null && typeof v === "object" && !Array.isArray(v);
 }
 
+// DECLARED field schema for known composite widgets. Types are enforced from THIS
+// schema, never inferred from the current value — a field whose current value is `null`
+// still enforces the correct type, so a scalar of the wrong type (e.g. a number into a
+// `lora` filename) can never be written on an EMPTY/cleared row (#560 P0). `nullable`
+// marks fields that legitimately hold `null` (an empty slot), so clearing them is
+// allowed (#560 P2). rgthree Power Lora Loader slot: {on, lora, strength, strengthTwo}.
+const RGTHREE_LORA_SLOT_SCHEMA = {
+  on: { type: "boolean", nullable: false },
+  lora: { type: "string", nullable: true },
+  strength: { type: "number", nullable: false },
+  strengthTwo: { type: "number", nullable: true },
+};
+
+// True for an rgthree Power Lora Loader slot object. Identified by its KEY-SET SHAPE
+// ONLY — the keys are a SUBSET of the rgthree slot keys {on, lora, strength, strengthTwo}
+// and include the core {on, lora, strength}. The classification does NOT depend on the
+// current VALUES being well-formed: a PARTIALLY-CORRUPT row (e.g. lora already holding a
+// number from a prior bad write) must STILL be recognized so the schema is ENFORCED and
+// the row is repaired-forward — never fall back to inferring a type from a corrupt value,
+// which would accept a further wrong-type write and deepen the corruption.
+const RGTHREE_LORA_SLOT_KEYS = new Set(["on", "lora", "strength", "strengthTwo"]);
+function isLoraSlotObject(obj) {
+  if (obj == null || typeof obj !== "object" || Array.isArray(obj)) return false;
+  const keys = Object.keys(obj);
+  if (keys.length === 0) return false;
+  if (!keys.every((k) => RGTHREE_LORA_SLOT_KEYS.has(k))) return false; // no foreign/extra keys
+  for (const core of ["on", "lora", "strength"]) {
+    if (!Object.prototype.hasOwnProperty.call(obj, core)) return false;
+  }
+  return true;
+}
+
+// The declared {type, nullable} schema for `field` of composite `base`, or null when the
+// composite is unknown (no declared schema).
+function compositeFieldSchema(base, field) {
+  if (isLoraSlotObject(base) && Object.prototype.hasOwnProperty.call(RGTHREE_LORA_SLOT_SCHEMA, field)) {
+    return RGTHREE_LORA_SLOT_SCHEMA[field];
+  }
+  return null;
+}
+
+// STRICT type coercion to a declared primitive type. Mirrors the whole-widget #240
+// strictness. Throws WidgetWriteError on mismatch.
+function coerceByType(type, value, where) {
+  if (type === "boolean") {
+    if (typeof value === "boolean") return value;
+    const s = String(value).toLowerCase();
+    if (s === "true" || s === "1") return true;
+    if (s === "false" || s === "0") return false;
+    throw new WidgetWriteError(`${where} is boolean but value ${JSON.stringify(value)} is not a boolean.`);
+  }
+  if (type === "number") {
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "string" && value.trim() !== "" && Number.isFinite(Number(value))) return Number(value);
+    throw new WidgetWriteError(`${where} is numeric but value ${JSON.stringify(value)} is not a number.`);
+  }
+  if (type === "string") {
+    if (typeof value === "string") return value;
+    throw new WidgetWriteError(`${where} is a string but value ${JSON.stringify(value)} is not a string.`);
+  }
+  return value;
+}
+
+/**
+ * Validate + coerce a composite field value. The expected type comes FIRST from the
+ * declared schema (so a null current field still enforces the right type, #560 P0), and
+ * `null` is accepted only for a nullable field (#560 P2). For an UNKNOWN composite with
+ * no schema, fall back to the existing NON-null value's type; a null/undefined current
+ * value with no schema is genuinely untyped, so only a primitive is accepted verbatim.
+ * Throws WidgetWriteError on a mismatch.
+ */
+function coerceCompositeFieldValue(widgetName, base, field, value) {
+  const where = `sub-field "${widgetName}.${field}"`;
+  const schema = compositeFieldSchema(base, field);
+  if (schema) {
+    if (value === null) {
+      if (schema.nullable) return null;
+      throw new WidgetWriteError(`${where} is not nullable (expected ${schema.type}).`);
+    }
+    return coerceByType(schema.type, value, where);
+  }
+  // Unknown composite: infer the expected type from the EXISTING non-null value.
+  const existing = base?.[field];
+  if (typeof existing === "boolean") return coerceByType("boolean", value, where);
+  if (typeof existing === "number") return coerceByType("number", value, where);
+  if (typeof existing === "string") return coerceByType("string", value, where);
+  // No schema AND an untyped current value (null/undefined/object): the field's type is
+  // genuinely unknowable, so we REFUSE rather than write a possibly-wrong-typed value —
+  // #560's principle is a loud, safe failure over silent corruption. (A KNOWN composite,
+  // e.g. rgthree, is handled by the schema above and its nullable fields still clear.)
+  throw new WidgetWriteError(
+    `${where}: cannot validate the value — this composite is not a recognized type and the ` +
+      `field's current value is ${existing === undefined ? "undefined" : JSON.stringify(existing)}, ` +
+      `so its expected type is unknown. Set a correctly-typed value only if the field already ` +
+      `holds one, or edit this widget from the node UI.`,
+  );
+}
+
+/**
+ * Merge `incoming` fields onto composite `base`, FAILING CLOSED on any field that does
+ * not already exist (never ADD a member) and validating each value against the field's
+ * DECLARED type / an unknown composite's existing type (#560 hardening). Used by BOTH
+ * the dotted single-field path and the #179 full-JSON-object path so neither can silently
+ * mistype or junk-up a composite row.
+ */
+function mergeCompositeFields(widgetName, base, incoming) {
+  const out = { ...base };
+  for (const key of Object.keys(incoming)) {
+    if (!Object.prototype.hasOwnProperty.call(base, key)) {
+      throw new WidgetWriteError(
+        `Composite widget "${widgetName}" has no field "${key}" ` +
+          `(fields: ${Object.keys(base).join(", ") || "none"}). Refusing to add an unknown field.`,
+      );
+    }
+    out[key] = coerceCompositeFieldValue(widgetName, base, key, incoming[key]);
+  }
+  return out;
+}
+
 /**
  * Validate + coerce `value` for `widget`, returning the value to write. Throws
  * WidgetWriteError (never silently coerces to a wrong value) when the value is
  * incompatible with the widget's declared type.
  */
-export function coerceWidgetValue(widget, value, mergeBaseWidget = widget) {
+export function coerceWidgetValue(widget, value, mergeBaseWidget = widget, subFieldPath = null) {
   const name = widget?.name ?? "(widget)";
 
   // #347: distinguish "clear to empty" from "missing value". An EXPLICIT empty
@@ -105,11 +224,63 @@ export function coerceWidgetValue(widget, value, mergeBaseWidget = widget) {
   // or dropped arg) is not, and must fail loudly instead of silently writing
   // `undefined`. The combo/numeric/boolean branches below still reject "" on
   // their own terms, so #240 strictness is untouched.
-  if (value === undefined || value === null) {
+  // A MISSING value (undefined) is always refused. An explicit `null` for a WHOLE-widget
+  // write is also refused (#347: clear a text widget with ""); but for a SUB-FIELD write
+  // `null` is a legitimate CLEAR of a nullable composite field (e.g. `lora_1.lora=null`),
+  // so it is allowed through to coerceCompositeFieldValue, which enforces the schema's
+  // nullability (a non-nullable field still rejects null).
+  if (value === undefined || (value === null && subFieldPath == null)) {
     throw new WidgetWriteError(
-      `No value provided for widget "${name}". To clear a text widget, pass an ` +
-        `explicit empty string ("").`,
+      subFieldPath != null
+        ? `No value provided for sub-field "${name}.${subFieldPath}".`
+        : `No value provided for widget "${name}". To clear a text widget, pass an ` +
+            `explicit empty string ("").`,
     );
+  }
+
+  // #560: EXPLICIT sub-field addressing (widget "lora_1.on" / "lora_1.strength").
+  // Writing a bare scalar to a COMPOSITE object widget (rgthree Power Lora Loader's
+  // `lora_N` rows: {on, lora, strength, strengthTwo}) previously corrupted the row —
+  // a scalar toggled one field and nulled the rest. Addressing ONE field merges that
+  // field onto the CURRENT object and PRESERVES every other field. This runs BEFORE
+  // the combo/numeric/boolean branches so a sub-field write is never reinterpreted by
+  // the base widget's declared type.
+  if (subFieldPath != null && subFieldPath !== "") {
+    // Only single-level fields are supported; a nested path needs a per-node schema
+    // we do not have — refuse LOUDLY rather than write a wrongly-shaped object.
+    if (subFieldPath.includes(".")) {
+      throw new WidgetWriteError(
+        `Nested sub-field path "${name}.${subFieldPath}" is not supported. Address ONE ` +
+          `top-level field (e.g. "${name}.on", "${name}.strength") or pass a full JSON object.`,
+      );
+    }
+    // The AUTHORITATIVE base object to merge onto: the promoted rail's current object
+    // when present (#366×#179), else the target widget's own value. The field is only
+    // addressable when that base is a real (non-array) object.
+    const railBase =
+      mergeBaseWidget &&
+      mergeBaseWidget.value != null &&
+      typeof mergeBaseWidget.value === "object" &&
+      !Array.isArray(mergeBaseWidget.value)
+        ? mergeBaseWidget.value
+        : null;
+    const ownBase =
+      widget?.value != null && typeof widget.value === "object" && !Array.isArray(widget.value)
+        ? widget.value
+        : null;
+    const base = railBase ?? ownBase;
+    if (base == null) {
+      throw new WidgetWriteError(
+        `Widget "${name}" is not a composite object widget, so its sub-field ` +
+          `"${subFieldPath}" cannot be addressed. Sub-field writes (e.g. "lora_1.on") are ` +
+          `only valid on widgets whose current value is an object.`,
+      );
+    }
+    // Merge ONLY the addressed field: FAIL CLOSED on an unknown field (a typo like
+    // "lora_1.strenght" must not create junk) and validate the value against the
+    // existing field's type (no silent mistyping — "false" into a boolean, a number
+    // into a filename), mirroring #240 whole-widget strictness. All other fields survive.
+    return mergeCompositeFields(name, base, { [subFieldPath]: value });
   }
 
   if (isComboWidget(widget)) {
@@ -173,7 +344,13 @@ export function coerceWidgetValue(widget, value, mergeBaseWidget = widget) {
   // lora=null and drops strength). Parse a JSON-string payload (or accept an
   // object directly) and MERGE onto the current value so fields the caller did
   // not specify (e.g. strengthTwo) are preserved.
-  if (isCompositeObjectWidget(widget)) {
+  //
+  // Detect the composite from the inner widget OR the AUTHORITATIVE promoted RAIL widget
+  // (mergeBaseWidget): the value that SERIALIZES is the rail's, so if the rail still holds
+  // a composite object while the inner value has gone stale/scalar, the write must STILL
+  // be treated as composite — otherwise the JSON payload would fall through as a raw
+  // string and clobber the rail (#179/#366 rail-authoritative guarantee).
+  if (isCompositeObjectWidget(widget) || isCompositeObjectWidget(mergeBaseWidget)) {
     let incoming = value;
     if (typeof value === "string") {
       try {
@@ -181,15 +358,19 @@ export function coerceWidgetValue(widget, value, mergeBaseWidget = widget) {
       } catch {
         throw new WidgetWriteError(
           `Widget "${name}" holds a composite object value; the string ` +
-            `${JSON.stringify(value)} is not valid JSON for it.`,
+            `${JSON.stringify(value)} is not valid JSON for it. To change ONE field, ` +
+            `address it directly (e.g. "${name}.on" or "${name}.strength"), or pass a full ` +
+            `JSON object like {"on":false}.`,
         );
       }
     }
     if (incoming == null || typeof incoming !== "object" || Array.isArray(incoming)) {
       throw new WidgetWriteError(
-        `Widget "${name}" is a composite object widget; value ${JSON.stringify(value)} ` +
-          `must be an object (or a JSON object string), e.g. ` +
-          `{"on":true,"lora":"name.safetensors","strength":1}.`,
+        `Widget "${name}" is a composite object widget; a bare scalar would corrupt it. ` +
+          `Value ${JSON.stringify(value)} must be an object (or JSON object string), e.g. ` +
+          `{"on":true,"lora":"name.safetensors","strength":1}. To change ONE field and keep ` +
+          `the rest, address it directly: "${name}.on"=false, "${name}.strength"=0.8, or pass ` +
+          `a JSON object {"on":false}.`,
       );
     }
     // #366×#179: for a PROMOTED composite, the AUTHORITATIVE base is the RAIL
@@ -201,7 +382,12 @@ export function coerceWidgetValue(widget, value, mergeBaseWidget = widget) {
       mergeBaseWidget && mergeBaseWidget.value != null && typeof mergeBaseWidget.value === "object" && !Array.isArray(mergeBaseWidget.value)
         ? mergeBaseWidget.value
         : widget.value;
-    return { ...base, ...incoming };
+    // Validate EACH incoming key against the existing row (fail closed on an unknown
+    // field, type-check each value) so a full-object write cannot silently mistype `on`
+    // or add junk members either — the same strictness the dotted path enforces (#560).
+    const mergeBase =
+      base != null && typeof base === "object" && !Array.isArray(base) ? base : {};
+    return mergeCompositeFields(name, mergeBase, incoming);
   }
 
   // STRING / text / unknown widget: pass through unchanged (an explicit "" clears
@@ -417,6 +603,10 @@ export function resolveWidgetWrite(
   let promotedFrom = null;
   let promotedParentWidget = null;
   let promotedHostInput = null;
+  // #560: sub-field addressing ("lora_1.on") is derived AFTER an exact-name lookup
+  // fails — never by pre-splitting the caller's name — so a real widget whose own
+  // name contains a dot is never hijacked.
+  let subFieldPath = null;
 
   if (node?.subgraph) {
     // Reuse a promotion resolution the caller already computed (graph_set_widget
@@ -463,9 +653,61 @@ export function resolveWidgetWrite(
   }
 
   if (!widget) {
+    // EXACT-NAME FIRST: a widget whose own name is literally `widgetName` (dots and
+    // all) always wins — the split is never taken when an exact match exists.
     widget = (targetNode.widgets ?? []).find(
       (cand) => cand?.name?.toLowerCase() === String(widgetName).toLowerCase(),
     );
+  }
+  if (!widget && node?.subgraph) {
+    // #560 SAFETY: on a SUBGRAPH parent, a dotted name that did not resolve as a
+    // promotion alias must NOT fall through to the base-name dotted fallback below —
+    // that would write the parent's projected RAIL widget DIRECTLY, bypassing the
+    // atomic inner+rail #366 path (inner left stale, silent partial). A promoted
+    // composite is driven with a FULL JSON object on the promoted widget instead,
+    // which goes through the #366 merge. Refuse the dotted form loudly here.
+    const nameStr = String(widgetName);
+    if (nameStr.indexOf(".") > 0) {
+      const baseName = nameStr.slice(0, nameStr.indexOf("."));
+      throw new WidgetWriteError(
+        `Dotted sub-field addressing ("${widgetName}") is not supported on subgraph node ` +
+          `${node.id}. If "${baseName}" is a promoted composite widget, set it with a full JSON ` +
+          `object (e.g. {"on":false}) so the promoted inner + rail update atomically (#366); ` +
+          `otherwise address it from the node that owns the widget.`,
+      );
+    }
+  }
+  if (!widget) {
+    // #560: no exact widget — try DOTTED sub-field addressing ("lora_1.on") on a DIRECT
+    // node. Resolve the BASE widget (before the first dot); the field is only
+    // addressable when the base is a COMPOSITE object widget. An empty suffix ("foo.")
+    // is rejected LOUDLY rather than silently degrading to a bare write on the base.
+    const nameStr = String(widgetName);
+    const dot = nameStr.indexOf(".");
+    if (dot > 0) {
+      const baseName = nameStr.slice(0, dot);
+      const sub = nameStr.slice(dot + 1);
+      const baseWidget = (targetNode.widgets ?? []).find(
+        (cand) => cand?.name?.toLowerCase() === baseName.toLowerCase(),
+      );
+      if (baseWidget) {
+        if (sub === "") {
+          throw new WidgetWriteError(
+            `Widget "${widgetName}" has an empty sub-field after the dot. Address a field, ` +
+              `e.g. "${baseName}.on" or "${baseName}.strength".`,
+          );
+        }
+        if (!isCompositeObjectWidget(baseWidget)) {
+          throw new WidgetWriteError(
+            `Widget "${baseName}" is not a composite object widget, so its sub-field ` +
+              `"${sub}" cannot be addressed. Sub-field writes are only valid on widgets ` +
+              `whose current value is an object (e.g. an rgthree Power Lora Loader row).`,
+          );
+        }
+        widget = baseWidget;
+        subFieldPath = sub;
+      }
+    }
   }
   if (!widget) {
     const names = (targetNode.widgets ?? []).map((cand) => cand?.name).join(", ");
@@ -486,7 +728,7 @@ export function resolveWidgetWrite(
   // unaffected (they don't merge). Non-promoted writes merge onto their own value.
   // (A promoted write with no authoritative rail already threw above, BEFORE this
   // possibly side-effecting coercion — so `promotedParentWidget` is non-null here.)
-  const coerced = coerceWidgetValue(widget, value, promotedParentWidget ?? widget);
+  const coerced = coerceWidgetValue(widget, value, promotedParentWidget ?? widget, subFieldPath);
 
   return { targetNode, widget, coerced, promotedFrom, promotedParentWidget, promotedHostInput };
 }


### PR DESCRIPTION
## Summary

Fixes two `panel_set_widget` honesty bugs on composite widgets and seed-control widgets. Both filed against the same root cause: **`panel_set_widget` reported success without the value actually holding.**

### #560 — scalar-to-composite corruption (data loss)

rgthree's **Power Lora Loader** stores each slot as a composite object `{on, lora, strength, strengthTwo}`. Writing a bare scalar to `lora_1` used to overwrite one field and null the rest, reporting success.

- The silent corruption itself was already refused by #179's composite branch on `origin/main` (a bare scalar now throws), but the node was **not drivable**: dotted addressing errored and the refuse message did not explain the fix.
- This PR adds explicit **sub-field addressing** — `panel_set_widget(node_id, 'lora_1.on', false)` merges **only** that field and preserves `lora`/`strength`/`strengthTwo`. Resolution is **exact-name-first** (a real widget whose own name contains a dot always wins; an empty suffix like `lora_1.` is refused).
- Both the dotted path **and** the existing full-JSON-object path now go through one `mergeCompositeFields()` that **fails closed on an unknown field** (no junk members added) and **validates each value against the existing field's type** (no storing the string `"false"` where a boolean is expected).
- On a **subgraph parent**, a dotted sub-field is refused rather than writing the projected rail directly (which would bypass the #366 atomic inner+rail path) — promoted composites are driven with a full JSON object instead.

### #558 — `control_after_generate` is invisible (silent failure)

A seed governed by a non-`fixed` `control_after_generate` is silently overwritten after each run. The control combo (`serialize:false`/`canvasOnly`) rendered unassociated from the seed it governs, with no write-time signal.

- `panel_query_graph {fields:'detail'}` now surfaces an explicit, seed-associated `control_after_generate` map (e.g. `{ "seed": "randomize" }`); `panel_graph_outline` marks the governed widget (`seed=… [after_gen=randomize]`).
- `panel_set_widget` returns a **`warning`** when the written value will not persist, pointing at the exact control widget to set to `fixed`. Wording is mode-accurate (randomize = new random value; increment/decrement = ±1 each run). Warnings are computed on the **concrete** node/widget through nested promotions, only for genuinely governed value widgets (never the control widget itself).

## Verification

- Detection extracted to `web/js/lib/control-after-generate.js` (unit-tested); composite sub-field merge + type validation + warning tested end-to-end through `runSetWidget`, including a nested `A→B→KSampler` promotion.
- **795 unit tests pass** (`node --test browser_tests/unit/*.test.mjs`); panel module + libs parse clean as ES modules.
- Preserves #423 fail-closed, #347 empty-string-clear, #240 strictness, and #179/#366 composite-merge/promoted-rail behavior.
- Passed an adversarial Codex self-review (5 rounds; each of 6 findings fixed and re-verified).

Closes artokun/comfyui-mcp#560
Closes artokun/comfyui-mcp#558

🤖 Generated with [Claude Code](https://claude.com/claude-code)
