### PR TITLE
release: 0.11.22 — set_widget composite-corruption refusal (#560/#558) + Save-As outcome reporting (#579/#363)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.22] - 2026-08-01
+
+### Fixed
+- **`set_widget` refuses a scalar/wrong-typed write to a composite widget instead of silently corrupting it (#560), and warns when a value is governed by `control_after_generate` (#558).** rgthree Power Lora Loader slots (`{on, lora, strength, strengthTwo}`) are now written via schema-validated sub-field addressing (`lora_1.on`) that fails closed on unknown fields and enforces each field's declared type independent of its current value — a bare scalar or wrong-typed write no longer overwrites part of the object and reports success, and a partially-corrupt row is repaired forward. `set_widget` also detects a governed `control_after_generate` control (side-effect-free) and warns that the written value will be overwritten on the next run; `graph_outline` annotates the widget. Verified by an independent 3-round adversarial codex review.
+- **`panel_save_workflow` reports its Save-As outcome so a rename-vs-copy is never silent, with no false data-loss alarms (#579, #363).** The result now describes what happened (`saved_as` / `copied_from` / `original_on_disk` / `first_save`) instead of a bare `{saved:true}`, and a post-write disk check flags a genuine loss — while never false-throwing on a legitimate first save, a transient probe failure, a non-200 2xx pre-probe, a root-relative external path, or a tab switch during the pre-probe. The Save-As copy semantics themselves (never move/clobber the source) were already in place from #375; this locks the reporting around them. Naming a workflow created by `panel_new_workflow` is accepted as a first save (#363). Verified by an independent 3-round adversarial codex review.
+
+
 ## [0.11.21] - 2026-07-31
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.21"
+version = "0.11.22"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -294,7 +294,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.21";
+const PANEL_VERSION = "0.11.22";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
## Release 0.11.22

Version bump (`pyproject.toml` version + `PANEL_VERSION` together) + changelog. Registry publish fires on the pyproject change to main.

Two **SEVERE data-integrity** fixes, each of which cleared an independent **3-round adversarial codex** (that caught real defects the authors' own multi-round self-gates had passed):

- **#560 / #558** — `set_widget` refuses a scalar/wrong-typed write to a composite widget (rgthree Power Lora slot) instead of silently corrupting siblings; schema-validated sub-field addressing, fail-closed on unknown fields, repair-forward on a partially-corrupt row; plus side-effect-free `control_after_generate` detection with a write warning + `graph_outline` annotation. *(My re-review caught a P0 null-field type-corruption and a partial-corrupt-row fall-through the 5-round self-gate had passed.)*
- **#579 / #363** — `panel_save_workflow` reports its Save-As outcome (`saved_as`/`copied_from`/`original_on_disk`/`first_save`) instead of a bare `{saved:true}`, with a disk check that flags a genuine loss but never false-alarms (transient probe, non-200 2xx, root-relative path, tab-switch race). *(My re-review caught, across 3 rounds, false-throw paths — an in-memory backstop bypassing the disk gate, "confirmed 200" implemented as any-2xx — the self-gate had passed.)* The copy-not-move core was already in place from #375.

**Live-tested on the rig:** merged panel loads clean (extension registered, zero fatal errors); save-as `overwrite:false` → 409-refuse with the original surviving intact, verified against the real `/userdata` backend.

Ships alongside **mcp 0.48.23** (already published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)