### PR TITLE
fix(create-group): panel_create_group correctness cluster (#566, #388, #391)

### DIFF
--- a/browser_tests/unit/group-geometry.test.mjs
+++ b/browser_tests/unit/group-geometry.test.mjs
@@ -19,6 +19,7 @@ import {
   groupMemberNodes,
   classifyRequestedMembership,
   refreshNodeArea,
+  syncNodeArea,
 } from "../../web/js/lib/group-geometry.js";
 
 // Minimal fixtures. No boundingRect => nodeFocusBounds falls back to pos/size
@@ -114,6 +115,59 @@ test("classifyRequestedMembership reports missing requested nodes", () => {
   const cls = classifyRequestedMembership([1, 2, 3], [1, 3]);
   assert.deepEqual(cls.missing, [2]);
   assert.deepEqual(cls.extra, []);
+});
+
+test("classifyRequestedMembership matches number requests to string live ids (#566/#388)", () => {
+  // Tool schema sends node_ids as numbers; live LiteGraph ids are strings. A raw
+  // Set compare (9 !== "9") would put every id in BOTH extra and missing and fire
+  // the geometric warning on every clean grouping. Type-normalized compare = clean.
+  const cls = classifyRequestedMembership([9, 10], ["9", "10"]);
+  assert.deepEqual(cls.extra, [], "no member is spuriously 'extra'");
+  assert.deepEqual(cls.missing, [], "no requested id is spuriously 'missing'");
+});
+
+test("classifyRequestedMembership still flags genuine extra/missing across id types", () => {
+  // Requested numbers; live string ids: one requested node absent, one neighbor captured.
+  const cls = classifyRequestedMembership([9, 10, 11], ["9", "10", "999"]);
+  assert.deepEqual(cls.extra, ["999"], "captured neighbor reported once, original string form");
+  assert.deepEqual(cls.missing, [11], "absent requested node reported once, original number form");
+});
+
+test("syncNodeArea makes create-group membership include nodes with a stale rect (#391)", () => {
+  // Node lives at [3400,0] but its cached boundingRect is stale at the origin
+  // (loaded/rendered elsewhere). boundsAroundNodes uses pos/size → correct box,
+  // but groupMemberNodes tests boundingRect-first → misses the node → empty group.
+  const n = { id: 278, pos: [3400, 0], size: [300, 120], boundingRect: [0, -30, 300, 150] };
+  const graph = graphOf(n);
+  const bbox = boundsAroundNodes([n]); // box wraps the LIVE pos, far from origin
+  const g = groupBox(bbox);
+
+  // FAIL-BEFORE: stale rect (preferred by nodeFocusBounds) sits at the origin,
+  // outside the box → node is wrongly excluded and the group looks empty.
+  assert.deepEqual(
+    groupMemberNodes(graph, g).map((x) => x.id),
+    [],
+    "stale boundingRect wrongly yields an empty group",
+  );
+
+  // PASS-AFTER: the create path syncs the cached rect to live pos/size first.
+  syncNodeArea(n);
+  assert.deepEqual(n.boundingRect, [3400, -30, 300, 150], "rect resynced to live pos/size");
+  assert.deepEqual(
+    groupMemberNodes(graph, g).map((x) => x.id),
+    [278],
+    "requested node is now a geometric member of its own box",
+  );
+});
+
+test("syncNodeArea is a no-op without a cached rect and supports typed arrays", () => {
+  const fresh = { id: 1, pos: [10, 10], size: [200, 100] };
+  syncNodeArea(fresh);
+  assert.equal(fresh.boundingRect, undefined, "nothing to sync when nodeFocusBounds uses live pos/size");
+  syncNodeArea(null); // must not throw
+  const typed = { id: 2, pos: [50, 60], size: [80, 40], boundingRect: Float32Array.from([0, 0, 1, 1]) };
+  syncNodeArea(typed);
+  assert.deepEqual([...typed.boundingRect], [50, 30, 80, 70], "typed-array rect resynced in place");
 });
 
 test("groupBoundsOf handles _bounding and pos/size, rejects garbage", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -146,6 +146,7 @@ import {
   groupMemberNodes,
   classifyRequestedMembership,
   refreshNodeArea,
+  syncNodeArea,
 } from "./lib/group-geometry.js";
 import { pickRevertSnapshot } from "./lib/graph-revert.js";
 import {
@@ -6956,6 +6957,12 @@ const GRAPH_TOOL_EXECUTORS = {
       requestedIds = node_ids.map(Number).filter(Number.isFinite);
       const ns = node_ids.map((id) => graph.getNodeById(Number(id))).filter(Boolean);
       if (!ns.length) throw new Error("none of the given node_ids exist in the current graph");
+      // Sync each node's cached boundingRect to its live pos/size BEFORE we build
+      // the box and recompute membership. The box is derived from pos/size but
+      // membership is tested boundingRect-first, so a stale cached rect (from a
+      // prior render, or never rendered at this position) would make geometry miss
+      // nodes the box plainly wraps → an empty group despite valid node_ids (#391).
+      ns.forEach(syncNodeArea);
       // Tight box around exactly the requested nodes that exist (title height + padding).
       bbox = boundsAroundNodes(ns);
     } else if (Array.isArray(bounds) && bounds.length === 4) {

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -119,18 +119,52 @@ export function groupMemberNodes(graph, g) {
 }
 
 /**
+ * Rewrite a node's cached boundingRect to match its CURRENT pos/size so a
+ * geometric membership test taken RIGHT AFTER a programmatic group create
+ * doesn't miss the node because its cached rect is stale from a previous render
+ * or was never rendered at its live position (#391).
+ *
+ * The group box is built from pos/size (boundsAroundNodes) but membership is
+ * tested against boundingRect-first (nodeFocusBounds); when the two disagree the
+ * box visually wraps the node yet geometry excludes it, yielding an empty group.
+ * Syncing the cached rect to the pos-based footprint (title band included, exactly
+ * matching nodeFocusBounds' fallback) makes the two bases agree. No-op when there
+ * is no cached rect — nodeFocusBounds already uses live pos/size in that case.
+ * Mutates in place so it works on plain arrays AND typed-array rects (ComfyUI
+ * Rectangle). Dependency-free for unit testing with plain object fixtures.
+ */
+export function syncNodeArea(node) {
+  const br = node?.boundingRect;
+  if (!br || br.length !== 4) return;
+  const w = node.size?.[0] ?? 200;
+  const h = node.size?.[1] ?? 100;
+  br[0] = node.pos?.[0] ?? 0;
+  br[1] = (node.pos?.[1] ?? 0) - 30; // title bar renders above pos
+  br[2] = w;
+  br[3] = h + 30;
+}
+
+/**
  * Compare the node ids actually enclosed (geometric) against the ids the caller
  * asked to group. Returns { requested, members, extra, missing } so a create
  * handler can warn honestly in dense layouts (#297) instead of reporting a
  * misleading success.
+ *
+ * Ids are compared by their STRING form: requested ids arrive as numbers (the
+ * tool schema is number[]) while live LiteGraph ids are strings ("9"), so a raw
+ * Set/SameValueZero compare (9 !== "9") would put every id in BOTH extra and
+ * missing on every call — the honest-reporting feature inverted (#566, #388).
+ * Normalizing to a common key fixes that; the returned arrays keep each id's
+ * ORIGINAL representation so callers see the ids in their native form.
  */
 export function classifyRequestedMembership(requestedIds, memberIds) {
-  const req = new Set(requestedIds);
-  const members = new Set(memberIds);
+  const key = (id) => String(id);
+  const reqKeys = new Set(requestedIds.map(key));
+  const memberKeys = new Set(memberIds.map(key));
   return {
     requested: [...requestedIds],
     members: [...memberIds],
-    extra: memberIds.filter((id) => !req.has(id)),
-    missing: requestedIds.filter((id) => !members.has(id)),
+    extra: memberIds.filter((id) => !reqKeys.has(key(id))),
+    missing: requestedIds.filter((id) => !memberKeys.has(key(id))),
   };
 }


### PR DESCRIPTION
## Summary

`panel_create_group` had three layered defects, all in the group-membership reconciliation path. This fixes all three.

### #566 / #388 — same ids reported as BOTH extra and missing; warning on every call
`classifyRequestedMembership` compared requested ids (numbers, per the tool schema `node_ids: number[]`) against live LiteGraph member ids (strings, e.g. `"9"`) using raw `Set`s. `Set.prototype.has` uses SameValueZero, so `9 !== "9"` — the sets never intersect, so **every** member became `extra` and **every** requested id became `missing`, and the geometric-membership warning fired on 100% of calls. The honest-reporting feature from #297 was effectively inverted (cried wolf on clean groupings).

**Fix:** compare by normalized `String` key; the returned `extra`/`missing` arrays keep each id's original representation.

### #391 — node_ids ignored, empty group created
The group box is built from `pos/size` (`boundsAroundNodes`) but membership is tested `boundingRect`-first (`nodeFocusBounds`). When a node's cached `boundingRect` is stale (rendered elsewhere, or never rendered at its live position), the box visually wraps the node yet the overlap test excludes it → `node_count: 0`, `node_ids: []` despite valid `node_ids`.

**Fix:** new `syncNodeArea()` resyncs each requested node's cached rect to its live `pos/size` (title band included, matching `nodeFocusBounds`' fallback) *before* the box and membership are computed, so both bases agree and the requested nodes are provably enclosed.

The warning now fires **only** when membership genuinely differs from the requested set.

## Root cause
Two independent bugs in `web/js/lib/group-geometry.js`, surfacing through `graph_create_group` in `web/js/comfyui-mcp-panel.js`: (1) number-vs-string id comparison in `classifyRequestedMembership`; (2) box-vs-membership geometry-basis mismatch when a cached `boundingRect` is stale.

The mcp side (`src/orchestrator/panel-tools.ts`) is a pure pass-through and needed no change.

## Tests
Regression coverage added to `browser_tests/unit/group-geometry.test.mjs`:
- number-request vs string-live-id classify (clean grouping ⇒ no extra/missing), plus a genuine-difference case across id types.
- stale-`boundingRect` empty-group scenario (fail-before / pass-after `syncNodeArea`), plus no-op/typed-array coverage.

**Verify-first on origin/main** confirmed both bugs: `classify([9,10],["9","10"])` → `extra:["9","10"] missing:[9,10]`; stale-rect membership → `[]`. `npm run test:unit` green (831 tests).

## Codex self-gate
Built-in reviewer, branch diff vs `origin/main`, single blocking wait — **PASS**: "No actionable regressions were identified in the diff."

Closes artokun/comfyui-mcp#566
Closes #388
Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)