### PR TITLE
fix(chat): composer paste-to-canvas leak, IME-safe Enter/Escape, drop legacy [object Object] replay

### DIFF
--- a/browser_tests/unit/chat-serialize.test.mjs
+++ b/browser_tests/unit/chat-serialize.test.mjs
@@ -156,6 +156,19 @@ test("a persisted structured object WITH readable text is NOT dropped (#241)", (
   assert.equal(isDroppedAgentReplay({ content: [{ text: "hi" }] }), false);
 });
 
+test("a legacy persisted literal '[object Object]' string IS dropped on replay (#393)", () => {
+  // An older panel build stringified a structured payload via
+  // Object.prototype.toString and persisted the literal string
+  // "[object Object]". Because it IS a string, the coerce-based predicate would
+  // keep it and render a visible "[object Object]" bubble. Drop the exact
+  // legacy artifact.
+  assert.equal(isDroppedAgentReplay("[object Object]"), true);
+  // A normal string that merely CONTAINS those words (or differs by a char) is
+  // real user content and must NOT be dropped.
+  assert.equal(isDroppedAgentReplay("look: [object Object] appeared"), false);
+  assert.equal(isDroppedAgentReplay("[object Array]"), false);
+});
+
 test("null/undefined persisted text is dropped, never rendered as literal 'null' (#241)", () => {
   // These are non-string and carry no content; the pre-fix path rendered the
   // literal "null"/"undefined" via String(). Dropping is strictly better and

--- a/browser_tests/unit/ime.test.mjs
+++ b/browser_tests/unit/ime.test.mjs
@@ -1,0 +1,35 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { isImeComposing } from "../../web/js/lib/ime.js";
+
+// isImeComposing is the guard every chat/menu keydown handler calls FIRST so a
+// CJK IME's commit keystroke (Enter) doesn't submit early and leak the trailing
+// syllable as a stray one-char message (#385).
+
+test("true when event.isComposing is set (the standard signal)", () => {
+  assert.equal(isImeComposing({ key: "Enter", isComposing: true }), true);
+});
+
+test("true on the legacy keyCode === 229 sentinel (isComposing false/absent)", () => {
+  // Some engines report isComposing=false on the first/last keydown of a
+  // composition but still emit keyCode 229 while the IME is processing.
+  assert.equal(isImeComposing({ key: "Enter", keyCode: 229 }), true);
+  assert.equal(isImeComposing({ key: "Enter", isComposing: false, keyCode: 229 }), true);
+});
+
+test("false for an ordinary (non-composing) Enter — submit proceeds", () => {
+  assert.equal(isImeComposing({ key: "Enter", isComposing: false, keyCode: 13 }), false);
+  assert.equal(isImeComposing({ key: "Enter" }), false);
+});
+
+test("false for ordinary navigation keys with no IME state", () => {
+  assert.equal(isImeComposing({ key: "ArrowDown", keyCode: 40 }), false);
+  assert.equal(isImeComposing({ key: "Escape", keyCode: 27 }), false);
+});
+
+test("always returns a boolean, and is null/undefined safe", () => {
+  assert.equal(isImeComposing(null), false);
+  assert.equal(isImeComposing(undefined), false);
+  assert.equal(typeof isImeComposing({ isComposing: true }), "boolean");
+});

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -19,6 +19,7 @@ import { openSidePanel } from "./cmcp-sidepanel-ui.js";
 import { openSubModal as openSubModalBase, toast } from "./cmcp-modal.js";
 import { chipRow as filterChipRow, makeFilterButton } from "./cmcp-filter.js";
 import { coerceMessageText } from "./lib/chat-serialize.js";
+import { isImeComposing } from "./lib/ime.js";
 
 const TABS = [
   { key: "images", label: "Images", icon: "pi-image", media: "image" },
@@ -1617,6 +1618,9 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       bmSearch.addEventListener("input", () => { renderOpts(); dd.classList.add("open"); });
       bmSearch.addEventListener("blur", closeDd);
       bmSearch.addEventListener("keydown", (e) => {
+        // A composing CJK IME owns Enter/arrows/Escape to navigate and commit
+        // its candidate window; don't hijack them to drive the dropdown (#385).
+        if (isImeComposing(e)) return;
         if (e.key === "Escape") {
           // Escape MUST stop here. The sheet is mounted inside ComfyUI's own
           // document, so an un-stopped Escape closes the whole filter sheet

--- a/web/js/cmcp-runpod-ui.js
+++ b/web/js/cmcp-runpod-ui.js
@@ -19,6 +19,8 @@
 // Pod control inspired by gpu-cli.sh (https://gpu-cli.sh) — a cloud-GPU CLI
 // worth checking out; this backend is our own (runs the user's real canvas).
 
+import { isImeComposing } from "./lib/ime.js";
+
 const GPU_CLI_URL = "https://gpu-cli.sh";
 
 let styleInjected = false;
@@ -143,6 +145,7 @@ export function createLocalContent(ctx, shell, opts = {}) {
   manualRow.append(podInput);
   // Enter in the manual-ID field connects, matching the primary button.
   podInput.addEventListener("keydown", (e) => {
+    if (isImeComposing(e)) return; // don't connect on a CJK IME commit Enter (#385)
     if (e.key === "Enter") {
       e.preventDefault();
       connectBtn.click();

--- a/web/js/cmcp-sidepanel-ui.js
+++ b/web/js/cmcp-sidepanel-ui.js
@@ -17,6 +17,7 @@
 // mount(bodyEl), onSearch(v,opts), subnavExtras(), drive, driveKind, update(),
 // onActivate(), onDeactivate(), teardown(), escapeBlocked() }`.
 
+import { isImeComposing } from "./lib/ime.js";
 import { createCivitaiContent } from "./cmcp-civitai-ui.js";
 import { createAppsContent } from "./cmcp-apps-ui.js";
 import { createTrainingContent } from "./cmcp-training-ui.js";
@@ -255,6 +256,10 @@ export function openSidePanel(ctx = {}, opts = {}) {
     if (c && typeof c.onSearch === "function") c.onSearch(searchEl.value, {});
   });
   searchEl.addEventListener("keydown", (e) => {
+    // Don't let a CJK IME's commit Enter trigger the search before the syllable
+    // is actually committed (#385) — this shared row backs the CivitAI header
+    // search whose Enter calls applySearch()/reloads immediately.
+    if (isImeComposing(e)) return;
     if (e.key !== "Enter") return;
     const c = contents.get(activeKey);
     if (c && typeof c.onSearch === "function") c.onSearch(searchEl.value, { enter: true });

--- a/web/js/cmcp-sidepanel-ui.js
+++ b/web/js/cmcp-sidepanel-ui.js
@@ -190,6 +190,12 @@ export function openSidePanel(ctx = {}, opts = {}) {
   overlay.addEventListener("mousedown", (e) => { if (e.target === overlay) close(); });
   closeBtn.addEventListener("click", close);
   _onEscape = (e) => {
+    // A composing CJK IME's Escape CANCELS the candidate window; it bubbles here
+    // from the shared search input, and closing the whole side panel (losing the
+    // browsing/filter session) on that keystroke is wrong (#385). Let the IME
+    // own it — the search-input guard returns without stopPropagation, so this
+    // document-level handler is the one that must yield.
+    if (isImeComposing(e)) return;
     if (e.key !== "Escape") return;
     // Yield to a content-owned stacked layer (the Civitai lightbox / sub-modals).
     const active = contents.get(activeKey);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -126,6 +126,7 @@ import {
 } from "./lib/control-after-generate.js";
 import { autoMatchSlots, slotDiagnostic } from "./lib/connect-match.js";
 import { coerceMessageText, isDroppedAgentReplay, serializeContext } from "./lib/chat-serialize.js";
+import { isImeComposing } from "./lib/ime.js";
 import {
   recordCopiedNodes,
   getVerifiedSnapshot,
@@ -11590,6 +11591,9 @@ function buildPanel() {
     renderModelResults();
   });
   modelSearchInput.addEventListener("keydown", (ev) => {
+    // Let a composing IME drive candidate navigation (arrows/Enter) instead of
+    // hijacking those keys to move the model list / pick a row (#385).
+    if (isImeComposing(ev)) return;
     if (ev.key === "ArrowDown") {
       ev.preventDefault();
       if (modelActiveIdx < modelCurrentRows.length - 1) modelActiveIdx++;
@@ -13057,6 +13061,7 @@ function buildPanel() {
       "flex:1;padding:0.35rem 0.5rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
       "background:var(--p-surface-900,#1e1e1e);color:inherit;font-size:0.8rem;";
     other.addEventListener("keydown", (e) => {
+      if (isImeComposing(e)) return; // don't commit mid-IME-composition (#385)
       if (e.key === "Enter" && other.value.trim()) { e.preventDefault(); finish(other.value.trim()); }
     });
     otherRow.appendChild(other);
@@ -13148,6 +13153,7 @@ function buildPanel() {
     };
 
     input.addEventListener("keydown", (e) => {
+      if (isImeComposing(e)) return; // don't commit mid-IME-composition (#385)
       if (e.key === "Enter") { e.preventDefault(); finish(input.value.trim()); }
     });
     row.appendChild(input);
@@ -16889,6 +16895,13 @@ function buildPanel() {
       const file = fileItem.getAsFile();
       if (file) {
         ev.preventDefault();
+        // Once the composer has claimed a pasted file, stop the event here.
+        // Without stopPropagation it keeps bubbling to `document`, where
+        // ComfyUI core's own global paste-to-canvas listener also inspects the
+        // clipboard and drops a duplicate, unwanted LoadImage node onto the
+        // live graph for every screenshot/image attached to a chat message
+        // (#384).
+        ev.stopPropagation();
         handleFile(file);
         return;
       }
@@ -16896,6 +16909,11 @@ function buildPanel() {
     const text = dt.getData("text/plain");
     if (text && (text.length > PASTE_TEXT_THRESHOLD || (text.match(/\n/g) || []).length >= 12)) {
       ev.preventDefault();
+      // Same rationale as the file branch (#384): the composer has claimed this
+      // large paste as an attachment, so keep it from bubbling to ComfyUI's
+      // document-level paste handler (which would try to paste graph JSON /
+      // nodes onto the canvas).
+      ev.stopPropagation();
       handlePastedText(text);
     }
   });
@@ -17421,6 +17439,11 @@ function buildPanel() {
   });
 
   input.addEventListener("keydown", (ev) => {
+    // While a CJK IME is composing, the commit keystroke also fires this keydown
+    // (Enter with isComposing/keyCode 229). Let the IME own it — otherwise the
+    // Enter below submits early and the trailing syllable leaks as a stray
+    // one-char message, and the slash/mention menu picks the wrong item (#385).
+    if (isImeComposing(ev)) return;
     if (!menuPop.hidden && menuItems.length) {
       if (ev.key === "ArrowDown") {
         ev.preventDefault();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -17516,6 +17516,12 @@ function buildPanel() {
   // editing a node widget). Removed in destroy() so remounts can't stack it.
   function onInterruptKeydown(ev) {
     if (!thinkingEl && !agentWorking) return; // no turn in flight
+    // This is a DOCUMENT CAPTURE listener, so it runs BEFORE the composer's own
+    // target-phase keydown guard. During CJK IME composition the Escape that
+    // CANCELS the candidate window (and the commit Enter) must not be read as
+    // "interrupt the turn" — otherwise cancelling an IME candidate aborts the
+    // agent's in-flight work (#385). Let the IME own the keystroke.
+    if (isImeComposing(ev)) return;
     const isCopy = (ev.ctrlKey || ev.metaKey) && !ev.altKey && (ev.key === "c" || ev.key === "C");
     const isEsc = ev.key === "Escape";
     if (!isCopy && !isEsc) return;

--- a/web/js/lib/chat-serialize.js
+++ b/web/js/lib/chat-serialize.js
@@ -90,6 +90,13 @@ export function serializeContext(context) {
  *  valid stored input (chat-history-store accepts it; imports preserve it) and
  *  must still render its empty bubble, so it is NEVER dropped. */
 export function isDroppedAgentReplay(text) {
+  // Legacy artifact (#393): an OLDER panel build persisted a structured payload
+  // by stringifying it via Object.prototype.toString, storing the literal string
+  // "[object Object]". Because that record IS a string, the structured-payload
+  // check below treats it as valid input and it survives replay as a visible
+  // "[object Object]" bubble. The original object is unrecoverable, so drop the
+  // exact legacy literal before the structured check runs.
+  if (text === "[object Object]") return true;
   return typeof text !== "string" && coerceMessageText(text) === "";
 }
 

--- a/web/js/lib/ime.js
+++ b/web/js/lib/ime.js
@@ -1,0 +1,18 @@
+// Shared IME (Input Method Editor) composition guard for keydown handlers.
+//
+// While a CJK IME (Korean 2-beolsik, Japanese, Chinese, …) is composing a
+// syllable, the keystroke that COMMITS the composition also fires a `keydown`
+// with `key === "Enter"`. A composer/menu handler that treats that Enter as
+// "submit" sends the in-flight text early and then leaks the still-composing
+// final syllable into the now-empty field, which is sent as a stray one-char
+// message on the next Enter (issue #385). Arrow/Tab keys are likewise owned by
+// the IME candidate window during composition and must not be hijacked.
+//
+// `event.isComposing` is the standard signal, but it can be false on the very
+// first/last keydown of a composition in some engines, so we also check the
+// legacy `keyCode === 229` sentinel that every major browser still emits while
+// an IME is processing a key. A handler should call this FIRST and bail out
+// (return early) when it is true, letting the IME own the keystroke.
+export function isImeComposing(ev) {
+  return !!(ev && (ev.isComposing || ev.keyCode === 229));
+}


### PR DESCRIPTION
## Chat-composer cluster

Closes artokun/comfyui-mcp-panel#384
Closes artokun/comfyui-mcp-panel#385
Closes artokun/comfyui-mcp-panel#393

### #384 — pasted image leaks to the ComfyUI canvas
The composer paste handler called `ev.preventDefault()` to claim a pasted file but never `ev.stopPropagation()`, so the event kept bubbling to `document`, where ComfyUI core's own global paste-to-canvas listener also fired and dropped a duplicate `LoadImage` node onto the live graph for every screenshot attached to a chat message.

**Fix:** `ev.stopPropagation()` after `preventDefault()` in the file branch (and the large-text branch, same rationale — a claimed paste must not reach the canvas / paste graph JSON).

### #385 — CJK IME: Enter mid-composition sends early and leaks a stray syllable
No `isComposing` / `keyCode === 229` guard existed anywhere. While an IME composes, the commit keystroke also fires a `keydown` with `key === "Enter"`; the composer treated it as "send", flushing the in-flight text early and leaking the still-composing final syllable into the now-empty field (sent as a stray 1-char message on the next Enter). Arrow/Escape keys were likewise hijacked from the IME candidate window.

**Fix:** new shared `web/js/lib/ime.js` → `isImeComposing(ev)` (`isComposing || keyCode === 229`, null-safe), called first (early-return) in **every** composition-context keydown path:
- main chat composer + slash/mention menu
- model search box
- `panel_ask` "Other…" free-text field
- `panel_request_secret` token input
- CivitAI bookmark-search dropdown
- shared side-panel search row (backs the CivitAI header search)
- RunPod manual pod-ID input

…plus the two **document-level** handlers a composing key bubbles to, which adversarial review flagged (they run before/around the composer's own guard):
- `onInterruptKeydown` (capture-phase) — a composing Escape that cancels an IME candidate must not abort an in-flight agent turn
- side-panel `_onEscape` — a composing Escape must not close the whole side panel and lose the browsing/filter session

### #393 — legacy persisted `[object Object]` artifact rendered on replay
Panel 0.11.10 routes live/replay payloads through `coerceMessageText`, but a record already persisted by an **older** build as the literal string `"[object Object]"` is a valid string, so `isDroppedAgentReplay` kept it and it rendered as a visible bubble. The original object is unrecoverable and the old records carry no version/provenance marker.

**Fix (as prescribed in the issue):** `isDroppedAgentReplay` drops the exact literal `"[object Object]"` before the structured-payload check. Exact-match only — real content that merely *contains* the substring is preserved (covered by tests).

### Tests
- New `browser_tests/unit/ime.test.mjs` — `isImeComposing` incl. the `keyCode === 229` boundary and null-safety.
- `browser_tests/unit/chat-serialize.test.mjs` — asserts `isDroppedAgentReplay("[object Object]") === true` and that near-miss strings (`"look: [object Object] appeared"`, `"[object Array]"`) are **not** dropped.
- `npm run test:unit` → **833 pass / 0 fail**. `node --check` clean on all edited files.
- The unit suite is pure-function (no jsdom in the repo); DOM event dispatch is Playwright e2e territory, so IME/paste behavioral coverage lives at the helper level by design.

### Review
Codex adversarial self-gate (gpt-5.6-terra, embedded branch diff) — final verdict **approve** after 4 rounds that each surfaced and fixed a real additional IME path (capture-phase interrupt, side-panel search Enter, side-panel `_onEscape`, RunPod pod-ID) and ratified the owner-directed #393 exact-string migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)