### PR TITLE
fix(panel): fresh-asset install cluster — selectable-after-download (#396) + installable search id (#394)

### DIFF
--- a/browser_tests/unit/download-refresh.test.mjs
+++ b/browser_tests/unit/download-refresh.test.mjs
@@ -1,0 +1,71 @@
+// Unit tests for the download-completion combo-refresh transition (issue #396):
+// a freshly downloaded model must become SELECTABLE on the live canvas without a
+// manual reload. reconcileCompletedDownloads decides WHEN to fire the refresh —
+// once per completed download, never on an error, never twice for a lingering
+// done row.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { reconcileCompletedDownloads } from "../../web/js/lib/download-refresh.js";
+
+test("a download reaching done fires exactly once", () => {
+  let seen = new Set();
+  // Still downloading — nothing to refresh yet.
+  let r = reconcileCompletedDownloads([{ id: "d1", name: "vae.safetensors", status: "downloading" }], seen);
+  assert.deepEqual(r.newlyDone, []);
+  seen = r.nextSeen;
+  // Transitions to done — fire once.
+  r = reconcileCompletedDownloads([{ id: "d1", name: "vae.safetensors", status: "done" }], seen);
+  assert.deepEqual(r.newlyDone, ["d1"]);
+  seen = r.nextSeen;
+  // The done row LINGERS in the tray on subsequent frames — must NOT re-fire.
+  r = reconcileCompletedDownloads([{ id: "d1", name: "vae.safetensors", status: "done" }], seen);
+  assert.deepEqual(r.newlyDone, []);
+});
+
+test("an error row never triggers a refresh", () => {
+  const r = reconcileCompletedDownloads([{ id: "e1", name: "bad", status: "error" }], new Set());
+  assert.deepEqual(r.newlyDone, []);
+  assert.equal(r.nextSeen.has("e1"), false);
+});
+
+test("many files completing on one frame all count as newly done (caller coalesces the refresh)", () => {
+  const rows = [
+    { id: "a", status: "done" },
+    { id: "b", status: "done" },
+    { id: "c", status: "downloading" },
+  ];
+  const r = reconcileCompletedDownloads(rows, new Set());
+  assert.deepEqual(r.newlyDone.sort(), ["a", "b"]);
+  assert.equal(r.nextSeen.has("c"), false);
+});
+
+test("a pruned-then-re-downloaded id can fire again", () => {
+  let seen = new Set();
+  seen = reconcileCompletedDownloads([{ id: "d1", status: "done" }], seen).nextSeen;
+  // Row pruned from the tray (disappears) — id drops from the tracked set.
+  seen = reconcileCompletedDownloads([], seen).nextSeen;
+  assert.equal(seen.has("d1"), false);
+  // Same target re-downloaded and completed again — fires anew.
+  const r = reconcileCompletedDownloads([{ id: "d1", status: "done" }], seen);
+  assert.deepEqual(r.newlyDone, ["d1"]);
+});
+
+test("rows are keyed by id, falling back to name; shapeless rows are ignored", () => {
+  const r = reconcileCompletedDownloads(
+    [
+      { name: "only-name.ckpt", status: "done" },
+      { status: "done" }, // no id/name → ignored
+      null,
+      "junk",
+    ],
+    new Set(),
+  );
+  assert.deepEqual(r.newlyDone, ["only-name.ckpt"]);
+});
+
+test("non-array / undefined frame is a no-op", () => {
+  const r = reconcileCompletedDownloads(undefined, new Set());
+  assert.deepEqual(r.newlyDone, []);
+  assert.equal(r.nextSeen.size, 0);
+});

--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -776,6 +776,47 @@ test("parseNodeMappings handles array + map shapes and caps the limit", () => {
   assert.equal(parseNodeMappings(many, "").results.length, 15);
 });
 
+test("#394 parseNodeMappings MAP-shape id is INSTALLABLE (repo URL), never the display title", () => {
+  const res = parseNodeMappings(GETMAPPINGS_MAP, "", 15);
+  // The meta objects carry only { title, description } — no installable id — so
+  // the id MUST fall through to the repo-URL KEY, not the human title.
+  const byTitle = Object.fromEntries(res.results.map((r) => [r.title, r]));
+  const impactish = byTitle["ComfyUI-RMBG"];
+  assert.ok(impactish, "expected a result keyed by its display title");
+  assert.equal(impactish.id, "https://github.com/1038lab/ComfyUI-RMBG");
+  // A title with a space ("ComfyUI Frame Interpolation") is the exact shape that
+  // used to leak into `id` and defeat install (no slash/protocol). Assert it does
+  // NOT: the id is the repo URL and the title stays separate for display.
+  const fi = byTitle["ComfyUI Frame Interpolation"];
+  assert.ok(fi);
+  assert.equal(fi.id, "https://github.com/Fannovel16/ComfyUI-Frame-Interpolation");
+  assert.notEqual(fi.id, fi.title);
+  // Every derived id must be consumable by panel_install_node — routed as a git
+  // install and matched on disk under the repo name.
+  for (const r of res.results) {
+    assert.equal(looksLikeGitUrl(r.id), true, `id ${r.id} must be git-routable`);
+    assert.equal(installGitUrl({ id: r.id }), r.id, `installGitUrl must resolve ${r.id}`);
+    const req = buildInstallRequest("v2", { id: r.id, version: "latest" });
+    assert.equal(req.params.id, gitRepoName(r.id), "v2 install routes by the repo name");
+  }
+});
+
+test("#394 parseNodeMappings prefers an explicit cnr/reference id over the title/key", () => {
+  // A Manager build that DOES carry a cnr id in meta must keep it (installable),
+  // and a `reference` repo URL wins over the human title too.
+  const withCnr = {
+    "https://github.com/ltdrdata/ComfyUI-Impact-Pack": [
+      ["ImpactWildcardProcessor"],
+      { id: "comfyui-impact-pack", title: "Impact Pack", description: "detailer" },
+    ],
+  };
+  assert.equal(parseNodeMappings(withCnr, "", 15).results[0].id, "comfyui-impact-pack");
+  const arrWithRef = [
+    { reference: "https://github.com/foo/bar", title: "Foo Bar", description: "x" },
+  ];
+  assert.equal(parseNodeMappings(arrWithRef, "", 15).results[0].id, "https://github.com/foo/bar");
+});
+
 test("managerUnavailableResult is a safe, actionable structured payload", () => {
   const r = managerUnavailableResult(undefined, UNREACHABLE);
   assert.equal(r.supported, false);

--- a/browser_tests/unit/refresh-coalesce.test.mjs
+++ b/browser_tests/unit/refresh-coalesce.test.mjs
@@ -77,6 +77,48 @@ test("a single call registers its payload and clears the in-flight slot", async 
   assert.equal(getInFlight(), null, "in-flight slot cleared after settle");
 });
 
+test("#396 a FORCED payload-less call while a refresh is in flight runs a TRAILING fresh run", async () => {
+  // The download-completion case: an unrelated refresh (e.g. reconnect) is in
+  // flight when a model finishes; its /object_info fetch predates the new file, so
+  // a plain join would miss it. force:true must guarantee a second (trailing) run.
+  const gate = deferred();
+  const { coalescer, registered } = makeHarness(async () => {
+    if (registered.length === 1) await gate.promise; // hold ONLY the first run in flight
+  });
+
+  const inflight = coalescer(); // unrelated refresh, now in flight (held by gate)
+  const forced = coalescer(undefined, { force: true }); // download completion
+
+  gate.resolve();
+  await Promise.all([inflight, forced]);
+
+  assert.equal(registered.length, 2, "the forced call ran its OWN trailing refresh, not just a join");
+});
+
+test("#396 many FORCED calls during one in-flight run coalesce into ONE trailing run", async () => {
+  const gate = deferred();
+  const { coalescer, registered } = makeHarness(async () => {
+    if (registered.length === 1) await gate.promise;
+  });
+
+  const inflight = coalescer(); // held in flight
+  const f1 = coalescer(undefined, { force: true });
+  const f2 = coalescer(undefined, { force: true });
+  const f3 = coalescer(undefined, { force: true });
+
+  gate.resolve();
+  await Promise.all([inflight, f1, f2, f3]);
+
+  assert.equal(registered.length, 2, "three forced calls collapsed to a single trailing run");
+});
+
+test("#396 a FORCED call with NO refresh in flight runs immediately (leading edge)", async () => {
+  const { coalescer, registered, getInFlight } = makeHarness();
+  await coalescer(undefined, { force: true });
+  assert.equal(registered.length, 1, "forced call ran once");
+  assert.equal(getInFlight(), null, "in-flight slot cleared after settle");
+});
+
 test("a payload call still runs even if the in-flight refresh REJECTS", async () => {
   const gate = deferred();
   let first = true;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -110,6 +110,7 @@ import {
 } from "./lib/asset-staleness.js";
 import { assertAddNodeResolvableRefreshing } from "./lib/node-resolve.js";
 import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
+import { reconcileCompletedDownloads } from "./lib/download-refresh.js";
 import {
   resolveScope,
   describeScope,
@@ -258,6 +259,12 @@ const refreshComfyNodeDefs = makeRefreshCoalescer({
   },
   runRegister: registerComfyNodeDefs,
 });
+
+// #396: download ids already counted as done, so each COMPLETED model download
+// triggers a live-combo refresh exactly once (a lingering done row won't re-fire;
+// a pruned-then-re-downloaded id can). Fed by the download_progress frame in
+// onDownloads.
+let seenDoneDownloads = new Set();
 
 function setupListeners() {
   if (!api) return;
@@ -14710,6 +14717,19 @@ function buildPanel() {
     // Orchestrator pushed live download progress → render rows in the tray.
     onDownloads(list) {
       renderDownloads(list);
+      // #396: when a model download COMPLETES, its file has landed in models/…
+      // but the live-canvas loader combos (vae_name, lora_name, ckpt_name, …)
+      // were populated from /object_info at page-load and stay stale — so the
+      // freshly downloaded file reads as "not a valid option" until a manual
+      // reload / ComfyUI restart. Re-pull fresh /object_info and re-register the
+      // node defs + refreshComboInNodes so the new file is immediately SELECTABLE.
+      // Fire ONCE per completed download (reconcileCompletedDownloads dedupes the
+      // lingering done rows); refreshComfyNodeDefs is coalesced single-flight and
+      // fully defensive (no-op when no canvas / on any frontend-API gap — worst
+      // case is today's stale behaviour, never a throw).
+      const { nextSeen, newlyDone } = reconcileCompletedDownloads(list, seenDoneDownloads);
+      seenDoneDownloads = nextSeen;
+      if (newlyDone.length) void refreshComfyNodeDefs();
     },
     // Live RunPod pod status → the host pill + open control modal.
     onRunpodStatus(frame) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14726,10 +14726,13 @@ function buildPanel() {
       // Fire ONCE per completed download (reconcileCompletedDownloads dedupes the
       // lingering done rows); refreshComfyNodeDefs is coalesced single-flight and
       // fully defensive (no-op when no canvas / on any frontend-API gap — worst
-      // case is today's stale behaviour, never a throw).
+      // case is today's stale behaviour, never a throw). force:true so a completion
+      // arriving while an UNRELATED refresh is already in flight is not silently
+      // dropped by joining that older /object_info fetch — it guarantees a trailing
+      // fresh fetch that reflects the just-landed file (#396 completion race).
       const { nextSeen, newlyDone } = reconcileCompletedDownloads(list, seenDoneDownloads);
       seenDoneDownloads = nextSeen;
-      if (newlyDone.length) void refreshComfyNodeDefs();
+      if (newlyDone.length) void refreshComfyNodeDefs(undefined, { force: true });
     },
     // Live RunPod pod status → the host pill + open control modal.
     onRunpodStatus(frame) {

--- a/web/js/lib/download-refresh.js
+++ b/web/js/lib/download-refresh.js
@@ -1,0 +1,56 @@
+// Pure helper for issue #396 — freshly downloaded models must become SELECTABLE
+// on the live canvas without a manual reload / ComfyUI restart.
+//
+// The orchestrator broadcasts a `download_progress` frame to the panel: an array
+// of rows, each { id?, name?, status } where status is "downloading" | "done" |
+// "error" (src/orchestrator/index.ts pollDownloads). When a model download
+// COMPLETES its file lands in models/<type>/…, but the live loader combo option
+// lists (VAELoader.vae_name, LoraLoaderModelOnly.lora_name, …) were populated
+// from /object_info at page-load and stay stale until something re-registers the
+// node defs — so a just-downloaded file looks "not a valid option" until reload.
+//
+// This helper detects the once-per-download moment a row transitions into the
+// terminal DONE state, so the panel can trigger a non-destructive object_info
+// re-register + refreshComboInNodes exactly once per completed download. Kept
+// standalone (no browser globals) so the transition logic is unit-testable under
+// `node --test`.
+
+/** A stable identity for a download row: prefer `id` (the orchestrator keys rows
+ *  off `row.id ?? full`), else the `name`. Undefined for a shapeless row. */
+function rowKey(row) {
+  if (!row || typeof row !== "object") return undefined;
+  if (typeof row.id === "string" && row.id) return row.id;
+  if (typeof row.name === "string" && row.name) return row.name;
+  return undefined;
+}
+
+/**
+ * Reconcile a fresh `download_progress` rows array against the set of download
+ * ids ALREADY counted as done, to find newly-completed downloads. Pure — does not
+ * mutate `seen`. Returns:
+ *   - nextSeen: the reconciled Set the caller should keep — every id present on
+ *     THIS frame with status "done" (a lingering done row stays tracked so it
+ *     never re-fires; an id that has disappeared is dropped, so a later
+ *     RE-download of the same target can fire again); and
+ *   - newlyDone: the ids that reached status "done" on this frame and were not in
+ *     `seen` — non-empty ⇒ the caller should refresh combos ONCE (regardless of
+ *     how many ids: the refresh itself is coalesced single-flight).
+ *
+ * Only "done" is a model-landed terminal — an "error" row produced no new file,
+ * so it never appears in nextSeen and never triggers a refresh.
+ */
+export function reconcileCompletedDownloads(rows, seen) {
+  const prev = seen instanceof Set ? seen : new Set();
+  const nextSeen = new Set();
+  const newlyDone = [];
+  if (Array.isArray(rows)) {
+    for (const row of rows) {
+      if (!row || row.status !== "done") continue;
+      const key = rowKey(row);
+      if (!key) continue;
+      nextSeen.add(key);
+      if (!prev.has(key)) newlyDone.push(key);
+    }
+  }
+  return { nextSeen, newlyDone };
+}

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -412,6 +412,17 @@ export function legacyUpdateBody({ ui_id, id, version } = {}) {
  * parse/filter is unit-testable away from the browser Manager client. Handles
  * both wire shapes: an ARRAY of pack objects, or the documented MAP keyed by
  * repo/url → [ [classNames…], { title, description, … } ]. Issues #251/#255.
+ *
+ * The `id` MUST be a value panel_install_node can actually consume (#394): a
+ * cnr/registry id or a git-routable repo URL. In the MAP shape the meta object
+ * carries only { title, description } — NO installable id — while the object KEY
+ * is the pack's repo URL (git-routable via buildInstallRequest). Deriving the id
+ * from the human `title` (e.g. "Impact Pack") produced a display name with a
+ * space and no slash/protocol that looksLikeGitUrl rejects → it was sent verbatim
+ * to Manager, which silently no-ops on v4 (queue drains "done", nothing installs).
+ * So the id is taken from an explicit cnr/reference id when present, else the
+ * repo-URL KEY — NEVER the title. The title is still returned separately for
+ * display.
  */
 export function parseNodeMappings(data, query, limit) {
   const q = String(query ?? "").toLowerCase();
@@ -424,11 +435,15 @@ export function parseNodeMappings(data, query, limit) {
     }
   };
   if (Array.isArray(data)) {
+    // Array shape: an explicit cnr `id` or a repo-URL `reference` are both
+    // installable; only fall back to `title` when neither is present (#394).
     for (const p of data) push(p?.id ?? p?.reference ?? p?.title, p?.title, p?.description);
   } else if (data && typeof data === "object") {
     for (const [key, val] of Object.entries(data)) {
       const meta = Array.isArray(val) ? val[1] : val;
-      push(meta?.id ?? meta?.title ?? key, meta?.title, meta?.description);
+      // #394: prefer an installable id (cnr/reference), else the repo-URL KEY.
+      // NEVER the display title — that is not resolvable by panel_install_node.
+      push(meta?.id ?? meta?.reference ?? key, meta?.title, meta?.description);
     }
   }
   const max = Math.min(Number(limit) || 15, 40);

--- a/web/js/lib/refresh-coalesce.js
+++ b/web/js/lib/refresh-coalesce.js
@@ -13,25 +13,25 @@
 // enough. With a payload, it WAITS for the in-flight refresh to settle, THEN runs a
 // fresh refresh that registers the newer payload — so the payload is never dropped.
 //
+// A payload-less `force:true` refresh (#396) is the third case. A no-payload
+// refresh triggered by a state change that JUST happened — e.g. a model download
+// completing — cannot simply join an in-flight run, because that run's
+// /object_info FETCH may have started BEFORE the change and so won't reflect it.
+// Joining it would report success while the new file is still absent from the
+// combos. So a forced call GUARANTEES a fresh registration whose fetch begins
+// AFTER the current run settles. Multiple forced calls that arrive during one
+// in-flight run coalesce into a SINGLE trailing run (no /object_info stampede).
+//
 //   getInFlight / setInFlight : accessors for the shared single-flight promise slot
 //                               (module-level in the panel).
 //   runRegister(preloadedDefs) : performs the actual (idempotent) registration; its
 //                                own cleanup must NOT clear the slot — the coalescer
 //                                owns the slot lifecycle.
 export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister }) {
-  return async function refresh(preloadedDefs) {
-    const current = getInFlight();
-    if (current) {
-      try {
-        await current;
-      } catch {
-        /* the in-flight refresh failed — fall through and run our own */
-      }
-      // No specific payload to guarantee ⇒ joining the settled refresh is enough.
-      if (preloadedDefs == null) return;
-      // Otherwise fall through: register the NEWER payload now the older run settled,
-      // so a freshly-installed node's defs are not dropped (#289 P2).
-    }
+  // The single queued trailing (forced, no-payload) run, or null when none is
+  // pending. Coalesces any number of forced calls arriving during one in-flight run.
+  let trailing = null;
+  const startRun = (preloadedDefs) => {
     const p = (async () => {
       try {
         return await runRegister(preloadedDefs);
@@ -43,5 +43,45 @@ export function makeRefreshCoalescer({ getInFlight, setInFlight, runRegister }) 
     })();
     setInFlight(p);
     return p;
+  };
+  return async function refresh(preloadedDefs, opts) {
+    const force = !!(opts && opts.force);
+    const current = getInFlight();
+    if (current) {
+      // No payload, not forced ⇒ joining the settled refresh is enough.
+      if (preloadedDefs == null && !force) {
+        try {
+          await current;
+        } catch {
+          /* the in-flight refresh failed — a plain join still just returns */
+        }
+        return;
+      }
+      // Payload present ⇒ wait for the in-flight run, then register the NEWER
+      // payload so a freshly-installed node's defs are not dropped (#289 P2).
+      if (preloadedDefs != null) {
+        try {
+          await current;
+        } catch {
+          /* fall through and run our own */
+        }
+        return startRun(preloadedDefs);
+      }
+      // Forced, no payload ⇒ guarantee a fresh fetch AFTER the current run
+      // settles; coalesce concurrent forced calls into ONE trailing run (#396).
+      if (!trailing) {
+        trailing = (async () => {
+          try {
+            await current;
+          } catch {
+            /* the in-flight refresh failed — run our own anyway */
+          }
+          trailing = null;
+          return startRun(undefined);
+        })();
+      }
+      return trailing;
+    }
+    return startRun(preloadedDefs);
   };
 }


### PR DESCRIPTION
## Fresh-asset-not-usable cluster

Two independent panel bugs that both leave a freshly-added asset unusable. Both fixes are panel-only — the orchestrator (comfyui-mcp) already does the right thing for each (it broadcasts `download_progress` frames, and `search_custom_nodes` already returns installable CNR ids from registry.comfy.org).

### #396 — freshly downloaded models not selectable on the live canvas until reload
Root cause: after `download_model` lands a file in `models/…`, the live-canvas loader combo option lists (`vae_name`, `lora_name`, `ckpt_name`, …) were populated from `/object_info` at page-load and stayed stale. Nothing re-registered the node defs after a download — combos only refreshed on a socket reconnect, a `graph_add_node`, or a `graph_set_widget` retry — so the new file read as "not a valid option" until a manual reload / ComfyUI restart.

Fix: the orchestrator already pushes `download_progress` frames to the panel. The new pure helper `reconcileCompletedDownloads` (`web/js/lib/download-refresh.js`) detects the once-per-download `done` transition, and `onDownloads` then fires the coalesced, defensive `refreshComfyNodeDefs()` (re-pull fresh `/object_info` → re-register defs → `refreshComboInNodes`) so the new file is immediately SELECTABLE without a reload.

Completion-race hardening (caught by the codex self-gate): a completion arriving while an unrelated refresh was already in flight would join that older `/object_info` fetch (predating the new file) and get marked seen, staying invisible. The refresh coalescer now has an opt-in `force` flag: a forced no-payload refresh guarantees a TRAILING fresh registration that begins after the in-flight run settles, with multiple forced calls coalesced into one trailing run (no `/object_info` stampede). Non-forced paths (reconnect join, #289 P2 payload) are unchanged.

### #394 — `panel_install_node` cannot install a `panel_search_nodes` result by its returned id
Root cause: `parseNodeMappings` derived the search-result `id` from the human `title` (e.g. "Impact Pack"). The ComfyUI-Manager `/customnode/getmappings` MAP is keyed by the pack's repo URL, and the meta value carries only `{ title, description }` — no installable id. A title with a space and no protocol/slash is rejected by `looksLikeGitUrl`, so it was sent verbatim to Manager, which silently no-ops on v4 (queue drains "done", nothing installs).

Fix: derive the id from an installable identifier — an explicit cnr/`reference` id when present, else the repo-URL KEY (which `buildInstallRequest` routes as a git install) — NEVER the display title. The title is still returned separately for display, so search filtering/output is unchanged.

## Tests
- `browser_tests/unit/download-refresh.test.mjs` — completion transition lifecycle (fire-once, error rows ignored, lingering-done dedup, prune-then-redownload, keying, no-op frames).
- `browser_tests/unit/refresh-coalesce.test.mjs` — new forced trailing-run + coalescing + leading-edge cases for the #396 race; existing #289 P2 / plain-join cases still green.
- `browser_tests/unit/manager-install.test.mjs` — #394 installable-id regression (repo-URL / cnr-id derivation, never the title).
- Full suite: 838 passing; `tsc --noEmit` clean; panel parses as ESM.

## Codex self-gate
gpt-5.6-terra / high, embedded-diff, single blocking wait. Round 1 flagged the completion race (P1) → fixed. Re-review: **VERDICT: PASS**.

Closes artokun/comfyui-mcp-panel#396
Closes artokun/comfyui-mcp-panel#394

🤖 Generated with [Claude Code](https://claude.com/claude-code)