### PR TITLE
release: 0.11.23 — create_group correctness (#566/#388/#391), chat composer paste/IME/replay (#384/#385/#393), fresh-asset selectability (#396/#394)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.23] - 2026-08-01
+
+### Fixed
+- **`panel_create_group` correctly builds a group from the requested nodes (#566, #388, #391).** Requested `node_ids` (numbers) were compared against live LiteGraph member ids (strings) with raw sets, so `9 !== "9"` — every member was reported as *both* extra and missing (#566), a spurious "membership is geometric" warning fired on every call (#388), and a stale cached bounding rect made the group come up empty (#391). Membership is now compared on a normalized key, and each node's cached rect is resynced to its live position/size before the group box is computed — so the requested nodes are provably enclosed and the warning fires only on a genuine difference.
+- **Chat composer no longer leaks pastes to the canvas, sends early on a CJK IME, or renders legacy `[object Object]` (#384, #385, #393).** Pasting an image into the composer now stops the event from bubbling to ComfyUI's canvas paste-to-node handler (no more duplicate `LoadImage` per paste); a new IME guard (`isImeComposing`) is applied across every composition-context keydown (composer, slash/mention menu, model + side-panel search, `panel_ask`, secret input, RunPod pod-id, and the document-level interrupt/Escape handlers) so a Korean/CJK commit-Enter no longer sends early and leaks a trailing syllable; and legacy persisted `"[object Object]"` chat artifacts are dropped on replay.
+- **Freshly downloaded models are selectable on the live canvas without a reload (#396), and a Manager search result installs by its id (#394).** After `download_model` completes, the loader combos now get a guaranteed trailing re-registration of node defs (coalesced, with a completion-race guard) so the new file appears immediately; `panel_install_node` derives the installable id from the pack's repo URL/reference instead of the human title, so a titled search result no longer becomes a silent no-op.
+
+
 ## [0.11.22] - 2026-08-01
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.22"
+version = "0.11.23"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -303,7 +303,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.22";
+const PANEL_VERSION = "0.11.23";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
## Release 0.11.23

Version bump (`pyproject.toml` + `PANEL_VERSION`) + changelog. Registry publish fires on the pyproject change to main.

Three codex-gated (gpt-5.6-terra/high) correctness clusters merged since 0.11.22:
- **#444** — `panel_create_group` number-vs-string id compare + stale bounding rect (#566/#388/#391)
- **#446** — chat composer: paste-to-canvas leak, CJK IME early-send, legacy `[object Object]` replay (#384/#385/#393)
- **#447** — fresh model selectable-after-download + installable Manager search id (#396/#394)

Panel verified loading clean on the merged code on the rig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)