### PR TITLE
fix(panel): connect honesty verification (#397) + upload-asset combo fallback (#387)

### DIFF
--- a/browser_tests/unit/connect-verify.test.mjs
+++ b/browser_tests/unit/connect-verify.test.mjs
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for the graph_connect link-persistence verification (#397) —
+ * web/js/lib/connect-verify.js. Run with `node --test`.
+ *
+ * Bug: LiteGraph's origin.connect() returns a TRUTHY link object even when the
+ * target input is a widget-backed pseudo-input (ImpactSwitch "select") that the node
+ * reverts, so panel_connect reported a persisted wire that isn't on the graph. The
+ * same Reroute→select on a real socket (LatentSwitch) DOES persist.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isLinkPersisted,
+  removePhantomLink,
+  isWidgetBackedInput,
+} from "../../web/js/lib/connect-verify.js";
+
+test("persisted link (LatentSwitch real socket): stored + input references it → true", () => {
+  const link = { id: 7 };
+  const target = { id: 20, inputs: [{ name: "select", link: 7 }] };
+  const graph = { links: { 7: { id: 7, origin_id: 3, target_id: 20 } } };
+  assert.equal(isLinkPersisted(graph, target, 0, link), true);
+});
+
+test("phantom link (ImpactSwitch widget input reverted): input.link null → false", () => {
+  const link = { id: 9 };
+  // LiteGraph handed back a link object, but the widget-backed input was reverted:
+  // its `link` is null and the graph never stored the id.
+  const target = { id: 20, inputs: [{ name: "select", widget: { name: "select" }, link: null }] };
+  const graph = { links: {} };
+  assert.equal(isLinkPersisted(graph, target, 0, link), false);
+});
+
+test("phantom link: input still points at a DIFFERENT/absent link id → false", () => {
+  const link = { id: 9 };
+  const target = { id: 20, inputs: [{ name: "select", link: 4 }] };
+  const graph = { links: { 4: { id: 4 } } }; // link 9 never stored
+  assert.equal(isLinkPersisted(graph, target, 0, link), false);
+});
+
+test("stored under graph.links but input.link mismatches → false (re-slotted node)", () => {
+  const link = { id: 9 };
+  const target = { id: 20, inputs: [{ name: "select", link: null }] };
+  const graph = { links: { 9: { id: 9 } } };
+  assert.equal(isLinkPersisted(graph, target, 0, link), false);
+});
+
+test("null link / no id / missing graph.links all fail closed", () => {
+  const target = { inputs: [{ link: 1 }] };
+  assert.equal(isLinkPersisted({ links: { 1: {} } }, target, 0, null), false);
+  assert.equal(isLinkPersisted({ links: { 1: {} } }, target, 0, {}), false);
+  assert.equal(isLinkPersisted({}, target, 0, { id: 1 }), false);
+});
+
+test("Map-backed graph.links is read via .get", () => {
+  const link = { id: 5 };
+  const target = { inputs: [{ link: 5 }] };
+  const graph = { links: new Map([[5, { id: 5 }]]) };
+  assert.equal(isLinkPersisted(graph, target, 0, link), true);
+  const empty = { links: new Map() };
+  assert.equal(isLinkPersisted(empty, target, 0, link), false);
+});
+
+test("removePhantomLink uses graph.removeLink when present", () => {
+  let removed = null;
+  const graph = { removeLink: (id) => (removed = id), links: { 3: {} } };
+  removePhantomLink(graph, { id: 3 });
+  assert.equal(removed, 3);
+});
+
+test("removePhantomLink deletes the stored entry when no removeLink method", () => {
+  const graph = { links: { 3: { id: 3 }, 4: { id: 4 } } };
+  removePhantomLink(graph, { id: 3 });
+  assert.equal(graph.links[3], undefined);
+  assert.equal(graph.links[4].id, 4);
+});
+
+test("removePhantomLink is defensive: null link / no graph never throws", () => {
+  assert.doesNotThrow(() => removePhantomLink(null, { id: 1 }));
+  assert.doesNotThrow(() => removePhantomLink({ links: {} }, null));
+  assert.doesNotThrow(() => removePhantomLink({ links: {} }, {}));
+});
+
+test("isWidgetBackedInput: true only when input carries a widget backlink", () => {
+  assert.equal(isWidgetBackedInput({ name: "select", widget: { name: "select" } }), true);
+  assert.equal(isWidgetBackedInput({ name: "latent" }), false);
+  assert.equal(isWidgetBackedInput(null), false);
+});

--- a/browser_tests/unit/connect-verify.test.mjs
+++ b/browser_tests/unit/connect-verify.test.mjs
@@ -62,24 +62,67 @@ test("Map-backed graph.links is read via .get", () => {
   assert.equal(isLinkPersisted(empty, target, 0, link), false);
 });
 
-test("removePhantomLink uses graph.removeLink when present", () => {
+test("removePhantomLink removes OUR dangling remnant (stored targets our slot, input unref) via removeLink", () => {
   let removed = null;
-  const graph = { removeLink: (id) => (removed = id), links: { 3: {} } };
-  removePhantomLink(graph, { id: 3 });
+  const target = { id: 20, inputs: [{ name: "select", link: null }] };
+  const graph = {
+    removeLink: (id) => (removed = id),
+    links: { 3: { id: 3, target_id: 20, target_slot: 0 } },
+  };
+  removePhantomLink(graph, target, 0, { id: 3 });
   assert.equal(removed, 3);
 });
 
 test("removePhantomLink deletes the stored entry when no removeLink method", () => {
-  const graph = { links: { 3: { id: 3 }, 4: { id: 4 } } };
-  removePhantomLink(graph, { id: 3 });
+  const target = { id: 20, inputs: [{ link: null }] };
+  const graph = { links: { 3: { id: 3, target_id: 20, target_slot: 0 }, 4: { id: 4 } } };
+  removePhantomLink(graph, target, 0, { id: 3 });
   assert.equal(graph.links[3], undefined);
   assert.equal(graph.links[4].id, 4);
 });
 
+test("removePhantomLink KEEPS a link a dynamic node RE-SLOTTED to another input (codex P1)", () => {
+  // The link exists and is a legitimate connection, but on a DIFFERENT input slot than
+  // the one we tried (2, not 0). isLinkPersisted(inIdx=0) is false, yet the link is real
+  // — it must NOT be deleted.
+  let removed = null;
+  const target = {
+    id: 20,
+    inputs: [{ name: "a", link: null }, { name: "b", link: null }, { name: "select", link: 3 }],
+  };
+  const graph = {
+    removeLink: (id) => (removed = id),
+    links: { 3: { id: 3, target_id: 20, target_slot: 2 } },
+  };
+  removePhantomLink(graph, target, 0, { id: 3 });
+  assert.equal(removed, null, "must not delete a re-slotted legitimate link");
+  assert.ok(graph.links[3], "the real link survives");
+});
+
+test("removePhantomLink KEEPS a link whose stored target is a DIFFERENT node", () => {
+  let removed = null;
+  const target = { id: 20, inputs: [{ link: null }] };
+  const graph = {
+    removeLink: (id) => (removed = id),
+    links: { 3: { id: 3, target_id: 99, target_slot: 0 } },
+  };
+  removePhantomLink(graph, target, 0, { id: 3 });
+  assert.equal(removed, null);
+});
+
+test("removePhantomLink no-ops when nothing is stored (connect fully reverted)", () => {
+  let removed = null;
+  const target = { id: 20, inputs: [{ link: null }] };
+  const graph = { removeLink: (id) => (removed = id), links: {} };
+  removePhantomLink(graph, target, 0, { id: 3 });
+  assert.equal(removed, null);
+});
+
 test("removePhantomLink is defensive: null link / no graph never throws", () => {
-  assert.doesNotThrow(() => removePhantomLink(null, { id: 1 }));
-  assert.doesNotThrow(() => removePhantomLink({ links: {} }, null));
-  assert.doesNotThrow(() => removePhantomLink({ links: {} }, {}));
+  const target = { id: 1, inputs: [{ link: null }] };
+  assert.doesNotThrow(() => removePhantomLink(null, target, 0, { id: 1 }));
+  assert.doesNotThrow(() => removePhantomLink({ links: {} }, target, 0, null));
+  assert.doesNotThrow(() => removePhantomLink({ links: {} }, target, 0, {}));
 });
 
 test("isWidgetBackedInput: true only when input carries a widget backlink", () => {

--- a/browser_tests/unit/input-asset.test.mjs
+++ b/browser_tests/unit/input-asset.test.mjs
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for the UPLOAD-input recognition helpers (#387) —
+ * web/js/lib/input-asset.js. Run with `node --test`.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  uploadInputConfig,
+  splitInputAssetRef,
+  addComboOption,
+} from "../../web/js/lib/input-asset.js";
+
+const DEFS = {
+  LoadImage: {
+    input: { required: { image: [["example.png"], { image_upload: true }] } },
+  },
+  LoadImageMask: {
+    input: {
+      required: {
+        image: [["a.png"], { image_upload: true }],
+        channel: [["red", "green", "blue", "alpha"]],
+      },
+    },
+  },
+  VHS_LoadVideo: {
+    input: { optional: { video: [["clip.mp4"], { video_upload: true }] } },
+  },
+  CheckpointLoaderSimple: {
+    input: { required: { ckpt_name: [["sd15.safetensors"]] } },
+  },
+};
+
+test("uploadInputConfig returns the config for an image_upload input", () => {
+  const cfg = uploadInputConfig(DEFS, "LoadImage", "image");
+  assert.ok(cfg);
+  assert.equal(cfg.image_upload, true);
+});
+
+test("uploadInputConfig recognizes a video_upload input in optional inputs", () => {
+  assert.ok(uploadInputConfig(DEFS, "VHS_LoadVideo", "video"));
+});
+
+test("uploadInputConfig is null for a plain combo (model loader) — strictness gate", () => {
+  assert.equal(uploadInputConfig(DEFS, "CheckpointLoaderSimple", "ckpt_name"), null);
+});
+
+test("uploadInputConfig is null for a NON-upload combo on an upload node (LoadImageMask.channel)", () => {
+  assert.equal(uploadInputConfig(DEFS, "LoadImageMask", "channel"), null);
+  assert.ok(uploadInputConfig(DEFS, "LoadImageMask", "image"));
+});
+
+test("uploadInputConfig is defensive: missing defs / type / widget → null", () => {
+  assert.equal(uploadInputConfig(null, "LoadImage", "image"), null);
+  assert.equal(uploadInputConfig(DEFS, "NopeNode", "image"), null);
+  assert.equal(uploadInputConfig(DEFS, "LoadImage", "nope"), null);
+  assert.equal(uploadInputConfig(DEFS, "LoadImage", null), null);
+});
+
+test("splitInputAssetRef: nested subfolder path", () => {
+  assert.deepEqual(splitInputAssetRef("xyr_canvas/foo.png"), {
+    subfolder: "xyr_canvas",
+    filename: "foo.png",
+  });
+});
+
+test("splitInputAssetRef: deep nested path splits on the LAST slash", () => {
+  assert.deepEqual(splitInputAssetRef("a/b/c/img.jpg"), { subfolder: "a/b/c", filename: "img.jpg" });
+});
+
+test("splitInputAssetRef: root-level filename has empty subfolder", () => {
+  assert.deepEqual(splitInputAssetRef("foo.png"), { subfolder: "", filename: "foo.png" });
+});
+
+test("splitInputAssetRef: Windows backslashes normalized to forward slashes", () => {
+  assert.deepEqual(splitInputAssetRef("xyr_canvas\\foo.png"), {
+    subfolder: "xyr_canvas",
+    filename: "foo.png",
+  });
+});
+
+test("addComboOption adds a value to an array-backed combo in place", () => {
+  const w = { options: { values: ["a.png"] } };
+  assert.equal(addComboOption(w, "xyr_canvas/foo.png"), true);
+  assert.deepEqual(w.options.values, ["a.png", "xyr_canvas/foo.png"]);
+});
+
+test("addComboOption is idempotent (no duplicate) and creates options if missing", () => {
+  const w = { options: { values: ["a.png", "b.png"] } };
+  addComboOption(w, "a.png");
+  assert.deepEqual(w.options.values, ["a.png", "b.png"]);
+  const w2 = {};
+  assert.equal(addComboOption(w2, "x.png"), true);
+  assert.deepEqual(w2.options.values, ["x.png"]);
+});
+
+test("addComboOption refuses to clobber a dynamic FUNCTION option source", () => {
+  const fn = () => ["a.png"];
+  const w = { options: { values: fn } };
+  assert.equal(addComboOption(w, "x.png"), false);
+  assert.equal(w.options.values, fn, "function source left untouched");
+});

--- a/browser_tests/unit/input-asset.test.mjs
+++ b/browser_tests/unit/input-asset.test.mjs
@@ -7,6 +7,7 @@ import assert from "node:assert/strict";
 
 import {
   uploadInputConfig,
+  uploadInputAccepts,
   splitInputAssetRef,
   addComboOption,
 } from "../../web/js/lib/input-asset.js";
@@ -55,6 +56,31 @@ test("uploadInputConfig is defensive: missing defs / type / widget → null", ()
   assert.equal(uploadInputConfig(DEFS, "NopeNode", "image"), null);
   assert.equal(uploadInputConfig(DEFS, "LoadImage", "nope"), null);
   assert.equal(uploadInputConfig(DEFS, "LoadImage", null), null);
+});
+
+test("uploadInputAccepts: image_upload accepts image extensions, rejects a .txt (#240 strictness)", () => {
+  const cfg = { image_upload: true };
+  assert.equal(uploadInputAccepts(cfg, "xyr_canvas/foo.png"), true);
+  assert.equal(uploadInputAccepts(cfg, "sub/pic.JPEG"), true);
+  assert.equal(uploadInputAccepts(cfg, "sub/clip.webp"), true);
+  // A server-EXISTING but wrong-kind / non-loadable file must be refused.
+  assert.equal(uploadInputAccepts(cfg, "xyr_canvas/notes.txt"), false);
+  assert.equal(uploadInputAccepts(cfg, "sub/data.json"), false);
+  assert.equal(uploadInputAccepts(cfg, "sub/clip.mp4"), false);
+});
+
+test("uploadInputAccepts: video_upload / audio_upload gate to their own kinds", () => {
+  assert.equal(uploadInputAccepts({ video_upload: true }, "a/clip.mp4"), true);
+  assert.equal(uploadInputAccepts({ video_upload: true }, "a/pic.png"), false);
+  assert.equal(uploadInputAccepts({ audio_upload: true }, "a/song.mp3"), true);
+  assert.equal(uploadInputAccepts({ audio_upload: true }, "a/pic.png"), false);
+});
+
+test("uploadInputAccepts: extensionless / dotfile / null config → false", () => {
+  assert.equal(uploadInputAccepts({ image_upload: true }, "sub/noext"), false);
+  assert.equal(uploadInputAccepts({ image_upload: true }, "sub/.hidden"), false);
+  assert.equal(uploadInputAccepts({ image_upload: true }, "sub/trailingdot."), false);
+  assert.equal(uploadInputAccepts(null, "sub/foo.png"), false);
 });
 
 test("splitInputAssetRef: nested subfolder path", () => {

--- a/browser_tests/unit/set-widget-upload-asset.test.mjs
+++ b/browser_tests/unit/set-widget-upload-asset.test.mjs
@@ -105,6 +105,28 @@ test("an upload value the server does NOT have stays rejected (#240 strictness)"
   assert.equal(widget.value, "example.png", "must not mutate on an unconfirmed value");
 });
 
+test("a server-EXISTING but non-image file (.txt) into an image combo is refused (#240 strictness, codex P1)", async () => {
+  const widget = { name: "image", type: "combo", options: { values: ["example.png"] }, value: "example.png" };
+  const node = { id: 191, type: "LoadImage", widgets: [widget] };
+  let probed = false;
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "image", "xyr_canvas/notes.txt", {
+        registry: REGISTRY,
+        ...freshOracle,
+        refreshCombos: refreshFromFreshDefs,
+        confirmServerAsset: async () => {
+          probed = true;
+          return true; // even though the server HAS the file, the extension is wrong
+        },
+      }),
+    (err) => err instanceof Error && /not a valid option/.test(err.message),
+  );
+  assert.equal(probed, false, "a wrong-kind extension must be rejected BEFORE any server probe");
+  assert.equal(widget.value, "example.png");
+  assert.ok(!widget.options.values.includes("xyr_canvas/notes.txt"));
+});
+
 test("a TOP-LEVEL uploaded file the refresh CAN list is accepted by refresh, never probing the server", async () => {
   const widget = { name: "image", type: "combo", options: { values: [] }, value: "" };
   const node = { id: 191, type: "LoadImage", widgets: [widget] };

--- a/browser_tests/unit/set-widget-upload-asset.test.mjs
+++ b/browser_tests/unit/set-widget-upload-asset.test.mjs
@@ -1,0 +1,129 @@
+/**
+ * Unit tests for the #387 UPLOAD-ASSET fallback in web/js/lib/set-widget.js —
+ * run with `node --test`. These drive runSetWidget(), the SAME async unit
+ * graph_set_widget delegates to, so the production ordering is exercised.
+ *
+ * Bug: an image uploaded under a SUBFOLDER (e.g. "xyr_canvas/foo.png") is a valid,
+ * loadable LoadImage input, but ComfyUI's LoadImage.INPUT_TYPES enumerates only
+ * TOP-LEVEL input files, so the value is NEVER in the /object_info combo — the
+ * #338 stale-combo refresh cannot help. panel_set_widget refused a perfectly good
+ * asset. The fallback: when the widget is an UPLOAD input and the server CONFIRMS
+ * the file exists, accept it.
+ *
+ * Invariants:
+ *   1. A server-CONFIRMED nested upload the refresh can't list is accepted.
+ *   2. Gated to UPLOAD inputs — a plain model combo is NOT rescued by confirmServerAsset.
+ *   3. If the server does NOT confirm the file, it stays rejected (#240 strictness).
+ *   4. The refresh path still wins first for a TOP-LEVEL file (no needless probe).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runSetWidget } from "../../web/js/lib/set-widget.js";
+
+const REGISTRY = { LoadImage: {}, CheckpointLoaderSimple: {} };
+
+// Fresh /object_info: LoadImage's image combo lists ONLY a top-level file (mirrors the
+// backend's top-level-only listing), so a nested value is absent even after refresh.
+const FRESH = {
+  LoadImage: { input: { required: { image: [["example.png"], { image_upload: true }] } } },
+  CheckpointLoaderSimple: { input: { required: { ckpt_name: [["sd15.safetensors"]] } } },
+};
+const freshOracle = { getFreshObjectInfo: async () => FRESH };
+
+// A refreshCombos that mirrors the production refreshComboOptionsFromDefs: it sets the
+// widget's option list to the FRESH def's list — which still lacks the nested path.
+function refreshFromFreshDefs(defs, target) {
+  const def = defs?.[target?.type];
+  const spec = def?.input?.required?.[target?.widgets?.[0]?.name];
+  if (Array.isArray(spec) && Array.isArray(spec[0]) && target.widgets[0]) {
+    target.widgets[0].options.values = spec[0].slice();
+  }
+}
+
+test("nested LoadImage upload the combo never lists is accepted when the server confirms it (#387)", async () => {
+  const widget = { name: "image", type: "combo", options: { values: ["example.png"] }, value: "example.png" };
+  const node = { id: 191, type: "LoadImage", widgets: [widget] };
+  let probed = null;
+  const res = await runSetWidget(node, "image", "xyr_canvas/boswellia_source.png", {
+    registry: REGISTRY,
+    ...freshOracle,
+    refreshCombos: refreshFromFreshDefs,
+    confirmServerAsset: async (v) => {
+      probed = v;
+      return true; // the server has the nested file in its input dir
+    },
+  });
+  assert.equal(res.set.value, "xyr_canvas/boswellia_source.png");
+  assert.equal(res.server_confirmed, true);
+  assert.equal(probed, "xyr_canvas/boswellia_source.png");
+  assert.ok(widget.options.values.includes("xyr_canvas/boswellia_source.png"));
+});
+
+test("a plain model combo is NOT rescued by confirmServerAsset (gated to upload inputs)", async () => {
+  const widget = {
+    name: "ckpt_name",
+    type: "combo",
+    options: { values: ["sd15.safetensors"] },
+    value: "sd15.safetensors",
+  };
+  const node = { id: 5, type: "CheckpointLoaderSimple", widgets: [widget] };
+  let probed = false;
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "ckpt_name", "some_uploaded_input.png", {
+        registry: REGISTRY,
+        ...freshOracle,
+        refreshCombos: refreshFromFreshDefs,
+        confirmServerAsset: async () => {
+          probed = true;
+          return true;
+        },
+      }),
+    (err) => err instanceof Error && /not a valid option/.test(err.message),
+  );
+  assert.equal(probed, false, "a non-upload combo must never probe the input dir");
+});
+
+test("an upload value the server does NOT have stays rejected (#240 strictness)", async () => {
+  const widget = { name: "image", type: "combo", options: { values: ["example.png"] }, value: "example.png" };
+  const node = { id: 191, type: "LoadImage", widgets: [widget] };
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "image", "typo_never_uploaded.png", {
+        registry: REGISTRY,
+        ...freshOracle,
+        refreshCombos: refreshFromFreshDefs,
+        confirmServerAsset: async () => false, // server has no such file
+      }),
+    (err) =>
+      err instanceof Error &&
+      /refused/.test(err.message) &&
+      /after refreshing combo options/.test(err.message) &&
+      /not a valid option/.test(err.message),
+  );
+  assert.equal(widget.value, "example.png", "must not mutate on an unconfirmed value");
+});
+
+test("a TOP-LEVEL uploaded file the refresh CAN list is accepted by refresh, never probing the server", async () => {
+  const widget = { name: "image", type: "combo", options: { values: [] }, value: "" };
+  const node = { id: 191, type: "LoadImage", widgets: [widget] };
+  let probed = false;
+  // Fresh defs that DO list the file (top-level upload visible in /object_info).
+  const fresh = {
+    LoadImage: { input: { required: { image: [["fresh_upload.png"], { image_upload: true }] } } },
+  };
+  const res = await runSetWidget(node, "image", "fresh_upload.png", {
+    registry: REGISTRY,
+    getFreshObjectInfo: async () => fresh,
+    refreshCombos: refreshFromFreshDefs,
+    confirmServerAsset: async () => {
+      probed = true;
+      return true;
+    },
+  });
+  assert.equal(res.set.value, "fresh_upload.png");
+  assert.equal(res.refreshed, true);
+  assert.equal(res.server_confirmed, undefined, "top-level file accepted by refresh, not the probe");
+  assert.equal(probed, false, "no server probe when the refresh already lists the value");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -5543,7 +5543,9 @@ const GRAPH_TOOL_EXECUTORS = {
     // socket like LatentSwitch does persist). Verify the link actually landed on the
     // live graph; if not, clean up the phantom and FAIL HONESTLY.
     if (!isLinkPersisted(graph, target, inIdx, link)) {
-      removePhantomLink(graph, link);
+      // Clean up ONLY the dangling remnant of THIS attempt — never a link a dynamic
+      // node re-slotted to another input (removePhantomLink guards that internally).
+      removePhantomLink(graph, target, inIdx, link);
       graph.setDirtyCanvas(true, true);
       const inputSlot = target.inputs?.[inIdx];
       const widgetHint = isWidgetBackedInput(inputSlot)

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -126,6 +126,7 @@ import {
   controlAfterGenerateEntries,
 } from "./lib/control-after-generate.js";
 import { autoMatchSlots, slotDiagnostic } from "./lib/connect-match.js";
+import { isLinkPersisted, removePhantomLink, isWidgetBackedInput } from "./lib/connect-verify.js";
 import { coerceMessageText, isDroppedAgentReplay, serializeContext } from "./lib/chat-serialize.js";
 import { isImeComposing } from "./lib/ime.js";
 import {
@@ -5533,6 +5534,31 @@ const GRAPH_TOOL_EXECUTORS = {
     if (!link) {
       throw new Error(slotDiagnostic(origin, target, { from_output, to_input }));
     }
+    // #397 CONNECT HONESTY: origin.connect() can return a truthy link that LiteGraph
+    // does NOT persist — a WIDGET-backed target input (rgthree/Impact nodes expose
+    // e.g. ImpactSwitch "select" as an INT widget, not a real socket) accepts the
+    // link momentarily and then reverts/re-slots it away, leaving the live graph
+    // disconnected. Reporting success on the truthy return alone FALSELY claimed a
+    // persisted wire (the exact ImpactSwitch bug; the same Reroute→select on a real
+    // socket like LatentSwitch does persist). Verify the link actually landed on the
+    // live graph; if not, clean up the phantom and FAIL HONESTLY.
+    if (!isLinkPersisted(graph, target, inIdx, link)) {
+      removePhantomLink(graph, link);
+      graph.setDirtyCanvas(true, true);
+      const inputSlot = target.inputs?.[inIdx];
+      const widgetHint = isWidgetBackedInput(inputSlot)
+        ? ` The target input "${inputSlot?.name ?? inIdx}" is a WIDGET-backed input that ` +
+          `did not accept a persistent link — set its value directly with panel_set_widget, ` +
+          `or convert the widget to an input slot in the ComfyUI UI first, then connect.`
+        : "";
+      throw new Error(
+        `panel_connect reported no persisted link: node ${origin.id} output ` +
+          `"${origin.outputs?.[outIdx]?.name ?? outIdx}" (${origin.outputs?.[outIdx]?.type}) → ` +
+          `node ${target.id} input "${target.inputs?.[inIdx]?.name ?? inIdx}". LiteGraph accepted ` +
+          `the connection but the live graph shows no wire, so refusing to report a false success.` +
+          widgetHint,
+      );
+    }
     return {
       connected: {
         from: {
@@ -5614,6 +5640,30 @@ const GRAPH_TOOL_EXECUTORS = {
           return;
         }
         return refreshComfyNodeDefs();
+      },
+      // #387: last-resort probe for an UPLOAD input value the refreshed /object_info
+      // combo still cannot list — a LoadImage image uploaded under a SUBFOLDER (ComfyUI
+      // enumerates only TOP-LEVEL input files in LoadImage.INPUT_TYPES, but load_image
+      // resolves the nested path). Confirm the file EXISTS in the server's input
+      // directory via /view?type=input; a 2xx means it is a valid, loadable asset and
+      // set-widget.js accepts it. Range-limited so we do not download the whole file.
+      confirmServerAsset: async (assetValue) => {
+        try {
+          const v = String(assetValue ?? "").replace(/\\/g, "/");
+          const i = v.lastIndexOf("/");
+          const subfolder = i >= 0 ? v.slice(0, i) : "";
+          const filename = i >= 0 ? v.slice(i + 1) : v;
+          if (!filename) return false;
+          const qs = new URLSearchParams({ filename, subfolder, type: "input" }).toString();
+          const res = await api.fetchApi(`/view?${qs}`, {
+            method: "GET",
+            cache: "no-store",
+            headers: { Range: "bytes=0-0" },
+          });
+          return !!res && (res.ok || res.status === 206);
+        } catch {
+          return false;
+        }
       },
     });
   },

--- a/web/js/lib/connect-verify.js
+++ b/web/js/lib/connect-verify.js
@@ -40,21 +40,39 @@ export function isLinkPersisted(graph, target, inIdx, link) {
 }
 
 /**
- * Best-effort removal of a NON-persisted phantom link so a failed connect leaves the
- * graph clean (no dangling half-link the next serialize would trip over). Fully
- * defensive: tries the graph's own removeLink, else clears a matching stored entry.
- * Never throws.
+ * Best-effort removal of the DANGLING remnant of a FAILED connect attempt so the graph
+ * is left clean (no half-link the next serialize would trip over). Removes the link ID
+ * ONLY when it is the debris of the attempt we just made — the stored link still claims
+ * to target the EXACT (target node, input slot) we tried, yet that input does not
+ * back-reference it. If a dynamic node RE-SLOTTED the link to a DIFFERENT input (the
+ * stored link's target points elsewhere), that is a LEGITIMATE connection and is NEVER
+ * deleted — deleting it would destroy a real wire the node deliberately moved. Fully
+ * defensive; never throws. Takes the same (graph, target, inIdx, link) the persistence
+ * check used so the "is this our debris?" decision is grounded in the live link store.
  */
-export function removePhantomLink(graph, link) {
+export function removePhantomLink(graph, target, inIdx, link) {
   const linkId = link?.id;
   if (linkId == null || !graph) return;
   try {
+    const links = graph.links;
+    if (!links) return;
+    const stored = typeof links.get === "function" ? links.get(linkId) : links[linkId];
+    // Nothing stored under this id ⇒ the connect was fully reverted; nothing to clean up.
+    if (stored == null) return;
+    // The stored link must still point at the SLOT we attempted; only then is an
+    // unreferenced input the signature of our dangling attempt. LLink exposes
+    // target_id/target_slot (array-form links use [3]/[4]).
+    const targetId = stored.target_id ?? stored[3];
+    const targetSlot = stored.target_slot ?? stored[4];
+    const sameSlot =
+      String(targetId) === String(target?.id) && Number(targetSlot) === Number(inIdx);
+    const inputReferencesIt = target?.inputs?.[inIdx]?.link === linkId;
+    // Re-slotted elsewhere (not our slot) OR actually attached ⇒ a real link; keep it.
+    if (!sameSlot || inputReferencesIt) return;
     if (typeof graph.removeLink === "function") {
       graph.removeLink(linkId);
       return;
     }
-    const links = graph.links;
-    if (!links) return;
     if (typeof links.delete === "function") links.delete(linkId);
     else if (Object.prototype.hasOwnProperty.call(links, linkId)) delete links[linkId];
   } catch {

--- a/web/js/lib/connect-verify.js
+++ b/web/js/lib/connect-verify.js
@@ -1,0 +1,74 @@
+// Post-mutation link-persistence verification for graph_connect (#397).
+//
+// LiteGraph's `LGraphNode.connect(outIdx, target, inIdx)` can return a TRUTHY link
+// object at the moment of the call and yet leave NO persisted link on the live
+// graph — e.g. when the target input is a WIDGET-backed pseudo-input (rgthree/Impact
+// nodes like ImpactSwitch expose `select` as an INT widget, not a real socket) that
+// the node reverts or restructures away synchronously, or a dynamic-input node that
+// re-slots on connect and drops the just-created link. The panel used to report a
+// full success (with a `type`) purely on that truthy return, so panel_connect
+// FALSELY claimed a persisted wire that isn't on the graph (ImpactSwitch.select),
+// while an identical Reroute→select on a real socket (LatentSwitch) did persist.
+//
+// This module is the single source of truth for "did the link ACTUALLY land". It is
+// pure (no DOM / no ComfyUI globals — the graph + nodes are passed in) so it drives
+// the SAME check under unit test that production runs.
+
+/**
+ * True only when `link` is a REAL, persisted connection on `graph`:
+ *   - the link object carries an id AND
+ *   - `graph.links[link.id]` still exists (not reverted/removed) AND
+ *   - the target input at `inIdx` actually references THAT link id.
+ *
+ * Fails CLOSED (returns false) on any missing/mismatched piece, so a phantom link is
+ * never reported as connected. `graph.links` may be an array or a plain object keyed
+ * by id in different LiteGraph builds — both are read by index/key access.
+ */
+export function isLinkPersisted(graph, target, inIdx, link) {
+  const linkId = link?.id;
+  if (linkId == null) return false;
+  const links = graph?.links;
+  if (!links) return false;
+  const stored = typeof links.get === "function" ? links.get(linkId) : links[linkId];
+  if (stored == null) return false;
+  const input = target?.inputs?.[inIdx];
+  if (!input) return false;
+  // The input's `link` must reference the SAME link id we just created. (A widget
+  // pseudo-input that was reverted has `link == null`; a re-slotted node points the
+  // slot at a different/absent link.)
+  return input.link === linkId;
+}
+
+/**
+ * Best-effort removal of a NON-persisted phantom link so a failed connect leaves the
+ * graph clean (no dangling half-link the next serialize would trip over). Fully
+ * defensive: tries the graph's own removeLink, else clears a matching stored entry.
+ * Never throws.
+ */
+export function removePhantomLink(graph, link) {
+  const linkId = link?.id;
+  if (linkId == null || !graph) return;
+  try {
+    if (typeof graph.removeLink === "function") {
+      graph.removeLink(linkId);
+      return;
+    }
+    const links = graph.links;
+    if (!links) return;
+    if (typeof links.delete === "function") links.delete(linkId);
+    else if (Object.prototype.hasOwnProperty.call(links, linkId)) delete links[linkId];
+  } catch {
+    /* best-effort cleanup — the honest failure is reported regardless */
+  }
+}
+
+/**
+ * True when `input` is a WIDGET-BACKED input slot (rendered as a widget, not a plain
+ * socket) — the class of target that most often accepts a transient link but does not
+ * persist it. Used only to enrich the honest-failure message so the caller is told
+ * WHY (set the value with panel_set_widget, or convert the widget to a real input in
+ * the UI first). Detection is by LiteGraph's `input.widget` backlink.
+ */
+export function isWidgetBackedInput(input) {
+  return !!(input && input.widget);
+}

--- a/web/js/lib/input-asset.js
+++ b/web/js/lib/input-asset.js
@@ -22,6 +22,30 @@
 // audio / 3d), whose valid values live on DISK, not only in the combo snapshot.
 const UPLOAD_CONFIG_FLAGS = ["image_upload", "video_upload", "audio_upload", "model_upload"];
 
+// Extension allowlist PER upload kind. A successful `/view?type=input` probe proves a
+// file EXISTS, not that it is a LOADABLE asset of the RIGHT kind — `/view` serves any
+// input file regardless of type, so a bare existence check would let a `foo.txt` (or a
+// stray file) be accepted into a LoadImage's image combo and then fail at execution,
+// weakening #240's strict combo validation. Gating the fallback on an extension that
+// matches the input's upload kind keeps the accept tight: only a plausibly-loadable
+// image/video/audio/model file of the correct family is admitted. `gif` intentionally
+// appears under both image and video.
+const UPLOAD_KIND_EXTENSIONS = {
+  image_upload: new Set([
+    "png", "jpg", "jpeg", "webp", "gif", "bmp", "tif", "tiff", "jfif", "ppm",
+    "avif", "ico", "apng", "heic", "heif",
+  ]),
+  video_upload: new Set([
+    "mp4", "webm", "mkv", "mov", "avi", "m4v", "gif", "mpg", "mpeg", "wmv", "flv", "ogv",
+  ]),
+  audio_upload: new Set([
+    "mp3", "wav", "flac", "ogg", "oga", "m4a", "aac", "opus", "wma", "aiff", "aif",
+  ]),
+  model_upload: new Set([
+    "safetensors", "ckpt", "pt", "pth", "bin", "gguf", "sft", "onnx",
+  ]),
+};
+
 /**
  * The config object for `widgetName` on the fresh /object_info def for `type`, when
  * that input is an UPLOAD input; otherwise null. ComfyUI encodes an input spec as
@@ -44,6 +68,31 @@ export function uploadInputConfig(defsByType, type, widgetName) {
     return UPLOAD_CONFIG_FLAGS.some((f) => config[f]) ? config : null;
   } catch {
     return null;
+  }
+}
+
+/**
+ * True when `value`'s file extension is a plausibly-LOADABLE asset for the upload
+ * `config`'s kind (image/video/audio/model). This is the strictness gate on top of a
+ * mere server-existence probe (#240): `/view?type=input` confirms the file is on disk
+ * but NOT that it is a loadable image, so a LoadImage image combo must still refuse a
+ * `.txt`/`.json`/extensionless file even if the server has one. A config may carry
+ * more than one upload flag; the value is accepted if its extension matches ANY of the
+ * present kinds. Defensive: a null config or an extensionless value returns false.
+ */
+export function uploadInputAccepts(config, value) {
+  try {
+    if (!config) return false;
+    const { filename } = splitInputAssetRef(value);
+    const dot = filename.lastIndexOf(".");
+    if (dot <= 0 || dot === filename.length - 1) return false; // no usable extension
+    const ext = filename.slice(dot + 1).toLowerCase();
+    for (const flag of UPLOAD_CONFIG_FLAGS) {
+      if (config[flag] && UPLOAD_KIND_EXTENSIONS[flag]?.has(ext)) return true;
+    }
+    return false;
+  } catch {
+    return false;
   }
 }
 

--- a/web/js/lib/input-asset.js
+++ b/web/js/lib/input-asset.js
@@ -1,0 +1,85 @@
+// UPLOAD-input recognition for the set_widget stale-combo recovery (#387).
+//
+// The #338/#340 stale-combo refresh re-pulls /object_info and revalidates a
+// just-staged value against the AUTHORITATIVE option list. That covers a downloaded
+// model (appears in the loader combo) and a TOP-LEVEL uploaded image (LoadImage's
+// `image` combo lists it). It does NOT cover an image uploaded under a SUBFOLDER:
+// ComfyUI's LoadImage.INPUT_TYPES enumerates only TOP-LEVEL files of the input dir
+// (`os.listdir` + `isfile`), so a `subfolder/name.png` upload is NEVER in the
+// /object_info combo — no refresh can make it a member — even though LoadImage will
+// happily LOAD it (`folder_paths.get_annotated_filepath` resolves the nested path).
+// So panel_set_widget rejected a perfectly loadable, server-confirmed input asset.
+//
+// The recovery: when a combo value is rejected for an UPLOAD input AND the server
+// CONFIRMS the file exists in its input directory, accept it (add it to the live
+// option list). This preserves #240 strictness — it is gated to upload inputs and to
+// files the backend actually has, never a blanket accept-anything.
+//
+// Pure module (no DOM / no fetch): the caller injects the server-existence check.
+
+// Upload-input config flags ComfyUI attaches to an input SPEC's config object. Any
+// truthy one marks the input as one the user uploads a file into (image / video /
+// audio / 3d), whose valid values live on DISK, not only in the combo snapshot.
+const UPLOAD_CONFIG_FLAGS = ["image_upload", "video_upload", "audio_upload", "model_upload"];
+
+/**
+ * The config object for `widgetName` on the fresh /object_info def for `type`, when
+ * that input is an UPLOAD input; otherwise null. ComfyUI encodes an input spec as
+ * `[typeOrOptions, config?]`; an upload input carries e.g. `{ image_upload: true }`.
+ * Reads required THEN optional. Fully defensive — a malformed def yields null (⇒ no
+ * upload fallback ⇒ the value simply stays rejected, same as before).
+ */
+export function uploadInputConfig(defsByType, type, widgetName) {
+  try {
+    if (!defsByType || !type || !widgetName) return null;
+    const def = defsByType[type];
+    const input = def?.input;
+    if (!input) return null;
+    const spec =
+      (input.required && input.required[widgetName]) ??
+      (input.optional && input.optional[widgetName]);
+    if (!Array.isArray(spec)) return null;
+    const config = spec[1];
+    if (!config || typeof config !== "object") return null;
+    return UPLOAD_CONFIG_FLAGS.some((f) => config[f]) ? config : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Split a LoadImage-style asset value into `{ subfolder, filename }` for a
+ * ComfyUI `/view?type=input` existence probe. ComfyUI stores uploaded inputs at
+ * `input/<subfolder>/<filename>` and the widget value is the POSIX-joined
+ * `subfolder/filename` (or a bare `filename` at the root). Splits on the LAST slash;
+ * a value with no slash is a root-level filename. Backslashes are normalized to
+ * forward slashes so a Windows-style path still probes correctly.
+ */
+export function splitInputAssetRef(value) {
+  const v = String(value ?? "").replace(/\\/g, "/");
+  const i = v.lastIndexOf("/");
+  if (i < 0) return { subfolder: "", filename: v };
+  return { subfolder: v.slice(0, i), filename: v.slice(i + 1) };
+}
+
+/**
+ * Add `value` to a combo widget's option list in place (so a following revalidation
+ * accepts it) WITHOUT clobbering a dynamic function-valued option source. Returns
+ * true if the option list now contains the value. Defensive; no-op on a bad widget.
+ */
+export function addComboOption(widget, value) {
+  try {
+    if (!widget) return false;
+    const raw = widget.options?.values;
+    // A dynamic (function) option source computes its own list; do not mutate it.
+    // Its membership is decided by the function, so we cannot force-accept here.
+    if (typeof raw === "function") return false;
+    if (!widget.options || typeof widget.options !== "object") widget.options = {};
+    const list = Array.isArray(widget.options.values) ? widget.options.values : [];
+    if (!list.includes(value)) list.push(value);
+    widget.options.values = list;
+    return list.includes(value);
+  } catch {
+    return false;
+  }
+}

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -29,7 +29,7 @@ import {
   assertTypeAgainstFreshBackend,
 } from "./node-resolve.js";
 import { controlAfterGenerateWarning } from "./control-after-generate.js";
-import { uploadInputConfig, addComboOption } from "./input-asset.js";
+import { uploadInputConfig, uploadInputAccepts, addComboOption } from "./input-asset.js";
 
 export async function runSetWidget(
   node,
@@ -235,6 +235,11 @@ export async function runSetWidget(
       concreteWidgetName ?? writeTargetWidgetName ?? widgetName,
     );
     if (!cfg) return false;
+    // #240 strictness: a server-existence probe alone is too loose — `/view?type=input`
+    // serves ANY input file, so accept ONLY a value whose extension is a loadable asset
+    // of THIS input's upload kind (e.g. an image extension for an image_upload combo),
+    // never a stray `.txt` the LoadImage combo would never list.
+    if (!uploadInputAccepts(cfg, value)) return false;
     const uploadWidget = (resolvedTargetNode?.widgets ?? []).find(
       (w) => w?.name === (writeTargetWidgetName ?? widgetName),
     );

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -29,6 +29,7 @@ import {
   assertTypeAgainstFreshBackend,
 } from "./node-resolve.js";
 import { controlAfterGenerateWarning } from "./control-after-generate.js";
+import { uploadInputConfig, addComboOption } from "./input-asset.js";
 
 export async function runSetWidget(
   node,
@@ -44,6 +45,7 @@ export async function runSetWidget(
     afterChange,
     setDirty,
     refreshCombos,
+    confirmServerAsset,
   } = {},
 ) {
   const liveRegistry = () => (typeof getRegistry === "function" ? getRegistry() : registry);
@@ -216,31 +218,63 @@ export async function runSetWidget(
     return warning ? { ...result, warning } : result;
   };
 
+  // #387 UPLOAD-ASSET fallback: a value rejected by the combo list even AFTER the
+  // authoritative /object_info refresh may still be a VALID, loadable input asset the
+  // server has on disk but /object_info never enumerates — specifically a LoadImage
+  // image uploaded under a SUBFOLDER (ComfyUI's LoadImage.INPUT_TYPES lists only
+  // TOP-LEVEL input files, yet load_image resolves a nested `subfolder/name.png`).
+  // When the mutated widget is an UPLOAD input (per the fresh def's config flags) and
+  // the injected probe CONFIRMS the file exists in the server's input directory, add
+  // it to the live option list and revalidate ONCE. Gated to upload inputs AND to
+  // server-confirmed files, so #240 strictness holds (never a blanket accept).
+  const tryUploadAssetAccept = async () => {
+    if (typeof confirmServerAsset !== "function") return false;
+    const cfg = uploadInputConfig(
+      freshDefs ?? undefined,
+      authTarget?.type,
+      concreteWidgetName ?? writeTargetWidgetName ?? widgetName,
+    );
+    if (!cfg) return false;
+    const uploadWidget = (resolvedTargetNode?.widgets ?? []).find(
+      (w) => w?.name === (writeTargetWidgetName ?? widgetName),
+    );
+    if (!uploadWidget) return false;
+    let exists = false;
+    try {
+      exists = await confirmServerAsset(value);
+    } catch {
+      exists = false;
+    }
+    if (!exists) return false;
+    return addComboOption(uploadWidget, value);
+  };
+
   try {
     return withWarning({ set: write() });
   } catch (err) {
-    // STALE-COMBO RECOVERY (#338/#317/#299/#288/#284/#304): the ONLY retryable
-    // failure is a COMBO value rejected against the widget's CURRENT option list
-    // — a just-downloaded model / uploaded image / staged output / freshly
-    // installed pack that the frontend combo snapshot doesn't list yet. When a
-    // refresh source is injected, pull the AUTHORITATIVE option list from the
-    // connected server (object_info + refreshComboInNodes, in place) and
-    // revalidate EXACTLY ONCE. This keeps #240's strictness intact: the retry
-    // validates against the FRESH list, so a genuinely-invalid value (still
-    // absent after refresh) is rejected, and no other error class is retried.
-    if (err instanceof WidgetWriteError && err.combo && typeof refreshCombos === "function") {
+    // Only a COMBO rejection is EVER retryable — every other WidgetWriteError
+    // (numeric/boolean/promotion/composite/stuck-check) fails closed immediately.
+    if (!(err instanceof WidgetWriteError)) throw err;
+    if (!err.combo) {
+      throw new Error(
+        `panel_set_widget refused "${widgetName}" on node ${node?.id} (${node?.type}): ${err.message}`,
+      );
+    }
+
+    // STALE-COMBO RECOVERY (#338/#317/#299/#288/#284/#304): a just-downloaded model /
+    // TOP-LEVEL uploaded image / staged output / freshly installed pack the frontend
+    // combo snapshot doesn't list yet. Pull the AUTHORITATIVE option list from the
+    // connected server and revalidate EXACTLY ONCE, then fall back to the #387
+    // upload-asset probe for a value the refreshed list still cannot contain.
+    let latest = err;
+    if (typeof refreshCombos === "function") {
       try {
         // Reuse the /object_info payload already fetched for type authorization so a
-        // combo miss does not round-trip /object_info a SECOND time (#458 P2): the
-        // production refreshCombos refreshes THIS target's combo options from the
-        // passed defs instead of calling refreshComboInNodes (which re-fetches). The
-        // resolved WRITE target (the intermediate inner node for a nested promotion) is
-        // the node whose widget is mutated, but its authoritative options must be keyed
-        // on the ULTIMATE CONCRETE type (authTarget) — a virtual intermediate is absent
-        // from /object_info, so keying on it would refresh nothing and reject a valid
-        // just-staged value (#458 nested combo-refresh). A RENAMED nested promotion also
-        // needs the mutated widget's name bridged to the concrete def's input name (#366
-        // rename support). When defs are unavailable it falls back to a full refresh.
+        // combo miss does not round-trip /object_info a SECOND time (#458 P2). Key the
+        // options on the ULTIMATE CONCRETE type (authTarget) — a virtual intermediate is
+        // absent from /object_info — and bridge a RENAMED nested promotion's widget name
+        // to the concrete def input name (#366). A missing payload falls back to a full
+        // refresh inside the injected callback.
         const comboNameMap =
           writeTargetWidgetName && concreteWidgetName
             ? { [writeTargetWidgetName]: concreteWidgetName }
@@ -252,20 +286,39 @@ export async function runSetWidget(
       try {
         return withWarning({ set: write(), refreshed: true });
       } catch (retryErr) {
-        if (retryErr instanceof WidgetWriteError) {
+        if (!(retryErr instanceof WidgetWriteError)) throw retryErr;
+        // A NON-combo failure on the retry is terminal — fail closed loudly.
+        if (!retryErr.combo) {
           throw new Error(
             `panel_set_widget refused "${widgetName}" on node ${node?.id} (${node?.type}) ` +
               `after refreshing combo options: ${retryErr.message}`,
           );
         }
-        throw retryErr;
+        // Still a combo miss after the refresh — keep the freshest reason and try the
+        // upload-asset fallback below.
+        latest = retryErr;
       }
     }
-    if (err instanceof WidgetWriteError) {
-      throw new Error(
-        `panel_set_widget refused "${widgetName}" on node ${node?.id} (${node?.type}): ${err.message}`,
-      );
+
+    // #387: server-confirmed upload asset (e.g. a subfolder-nested LoadImage image).
+    if (await tryUploadAssetAccept()) {
+      try {
+        return withWarning({ set: write(), refreshed: true, server_confirmed: true });
+      } catch (confErr) {
+        if (confErr instanceof WidgetWriteError) {
+          throw new Error(
+            `panel_set_widget refused "${widgetName}" on node ${node?.id} (${node?.type}) ` +
+              `after confirming the uploaded asset exists on the server: ${confErr.message}`,
+          );
+        }
+        throw confErr;
+      }
     }
-    throw err;
+
+    // No recovery succeeded — refuse honestly with the freshest rejection.
+    throw new Error(
+      `panel_set_widget refused "${widgetName}" on node ${node?.id} (${node?.type})` +
+        `${typeof refreshCombos === "function" ? " after refreshing combo options" : ""}: ${latest.message}`,
+    );
   }
 }


### PR DESCRIPTION
## Summary

Fixes a set_widget/connect honesty + stale-asset cluster in the panel. Two genuine residuals fixed here; a third issue (#380) is fixed-in-code by the shipped #560 and closed separately as a duplicate.

Closes artokun/comfyui-mcp-panel#397
Closes artokun/comfyui-mcp-panel#387

### panel#397 — `panel_connect` falsely reports a persisted link (connect honesty)
`graph_connect` decided success purely from LiteGraph's truthy `origin.connect()` return value. A **widget-backed** target input (rgthree/Impact nodes expose e.g. `ImpactSwitch.select` as an INT widget, not a real socket) accepts the link momentarily and then reverts/re-slots it away, leaving the live graph disconnected — so the tool reported a phantom wire (the exact ImpactSwitch bug; the same `Reroute→select` on a real socket like `LatentSwitch` does persist).

Fix: after `connect()`, **verify the link actually landed on the live graph** — its id must be stored in `graph.links` (handles array/object/Map stores) **and** `target.inputs[inIdx].link === link.id`. On non-persistence, clean up only our own dangling remnant (never a link a dynamic node deliberately re-slotted elsewhere) and **fail honestly**, with a hint to use `panel_set_widget` / convert-to-input for widget-backed inputs. Extracted to `web/js/lib/connect-verify.js`.

### panel#387 — stale combo rejects a freshly-uploaded **subfolder-nested** image
The shipped #338/#340 stale-combo refresh already covers downloaded models and **top-level** uploaded images (they appear in a fresh `/object_info`). But an image uploaded under a **subfolder** (`xyr_canvas/foo.png`) is a valid, loadable `LoadImage` input that **never** appears in `/object_info` — `LoadImage.INPUT_TYPES` enumerates only top-level input files — so no refresh can rescue it, and `panel_set_widget` refused a good asset.

Fix: after the refresh retry still misses on a **combo** error, an upload-asset fallback — the widget must be an **upload input** (`image_upload`/`video_upload`/`audio_upload`/`model_upload` per the fresh def), the value's **extension must match that upload kind** (per-kind allowlist, so a server-existing `foo.txt` never enters an image combo), and an injected server probe (`/view?type=input`, Range-limited) must **confirm the file exists** — then it's added to the option list and revalidated once. Gated to upload inputs + right-extension + server-confirmed, so #240 strictness holds. Extracted to `web/js/lib/input-asset.js`.

### panel#380 — closed separately as fixed-in-0.11.22
The rgthree Power Lora Loader composite-widget corruption (`lora → null` on a full-JSON write) is the exact bug fixed by **#560 (PR #441, panel 0.11.22)** — schema-validated composite writes in `web/js/lib/widget-write.js`. `widget-write.test.mjs` already covers the identical scenario (full-JSON write preserves `lora`/`strengthTwo`). Closed as a duplicate with a reopen clause; no code change needed here.

## Tests
- New headless unit tests: `browser_tests/unit/connect-verify.test.mjs`, `input-asset.test.mjs`, `set-widget-upload-asset.test.mjs` (link-persistence across store shapes, phantom-cleanup re-slot safety, upload gating + extension strictness, end-to-end `runSetWidget` upload fallback).
- `node --check` clean on all changed JS; full `npm run test:unit` green (**881 tests**).
- Codex self-gate (gpt-5.6-terra/high, embedded diff): **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)