### PR TITLE
fix(canvas): preserve zoom center (#401) + per-conversation context ring (#381); verify #178

### DIFF
--- a/browser_tests/unit/context-ring-scope.test.mjs
+++ b/browser_tests/unit/context-ring-scope.test.mjs
@@ -1,0 +1,247 @@
+// Regression coverage for panel#381 (+ codex-P2 follow-up): the composer's
+// context ring was persisted under a SINGLE GLOBAL sessionStorage key
+// (comfyui-mcp.panel.ctxPct) while agent conversations are per-conversation
+// (per workflow-tab, and one workflow can hold several saved conversations).
+// Switching conversations left the ring showing the PREVIOUS one's fill until
+// the next agent_status push — a nearly-full context could read as having
+// headroom. The fix keys the persisted value by the ACTIVE THREAD id (falling
+// back to the workflow scope only for the pre-first-message view) and repaints
+// the ring from that conversation on every switch/restore, blanking when it has
+// no stored fill.
+//
+// ctxScopeKey / refreshContextRingForScope / clearAllCtxScopes live inside the
+// panel-builder closure in web/js/comfyui-mcp-panel.js (they close over browser
+// globals + the closure's `thread`), so we follow the established "real panel
+// source" extraction convention (see graph-set-node-collapsed.test.mjs): regex
+// the three function declarations out of the file and evaluate them via
+// `new Function` with their collaborators injected as stubs, driving the ACTUAL
+// shipped logic against a fake sessionStorage.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8");
+
+const CTX_KEY = "comfyui-mcp.panel.ctxPct";
+
+// The three helpers are contiguous in the source. Grab the slice from
+// ctxScopeKey through the closing brace of clearAllCtxScopes (the first
+// two-space-indented `}` after that function opens).
+const sliceMatch = panelSrc.match(
+  /function ctxScopeKey\(\) \{[\s\S]*?function clearAllCtxScopes\(\) \{[\s\S]*?\n {2}\}/,
+);
+assert.ok(sliceMatch, "could not locate the #381 ctx-scope helpers in panel source");
+for (const name of ["ctxScopeKey", "ctxPersistKey", "ctxFrameForActiveView", "refreshContextRingForScope", "clearAllCtxScopes"]) {
+  assert.ok(sliceMatch[0].includes(`function ${name}(`), `extraction missing ${name}`);
+}
+// Lock in that the key is thread-scoped (codex P2), not merely workflow-scoped.
+assert.ok(/thread\?\.id/.test(sliceMatch[0]), "ctxScopeKey must key by the active thread id");
+
+// The turn owner MUST be cleared on a terminal `done` frame, else a later
+// reconnect re-push persists under the completed conversation (codex P2). Assert
+// the onTurn done branch resets it, so the source can't silently drop this.
+const doneBranch = panelSrc.match(/else if \(state === "done"\) \{[\s\S]*?agentWorking = false;[\s\S]*?liveTurnThreadId = null;/);
+assert.ok(doneBranch, "onTurn 'done' must clear liveTurnThreadId (codex P2 turn-owner reset)");
+
+// A sync-driven detach/rebind (another tab deleted/invalidated the active
+// conversation) must repaint the ring, else it keeps the deleted chat's fill
+// (codex P2). Assert the detach helper calls the refresh before returning.
+const detachFn = panelSrc.match(/function detachInvalidCurrentThread\([\s\S]*?refreshContextRingForScope\(\);[\s\S]*?return replacement;/);
+assert.ok(detachFn, "detachInvalidCurrentThread must call refreshContextRingForScope (codex P2)");
+
+// The manual thread switch (loadThread) must also refresh the ring, after it
+// repaints the selected conversation.
+const loadThreadFn = panelSrc.match(/function loadThread\(t\) \{[\s\S]*?\n {2}\}/);
+assert.ok(loadThreadFn, "could not locate loadThread");
+const paintIdx = loadThreadFn[0].indexOf("paintThread(t);");
+const refreshIdx = loadThreadFn[0].indexOf("refreshContextRingForScope();");
+assert.ok(paintIdx >= 0 && refreshIdx > paintIdx, "loadThread must call refreshContextRingForScope after paintThread(t)");
+
+/** A minimal sessionStorage with the enumeration surface clearAllCtxScopes uses. */
+function makeSessionStorage() {
+  const map = new Map();
+  return {
+    get length() { return map.size; },
+    key(i) { return [...map.keys()][i] ?? null; },
+    getItem(k) { return map.has(k) ? map.get(k) : null; },
+    setItem(k, v) { map.set(k, String(v)); },
+    removeItem(k) { map.delete(k); },
+    _dump() { return new Map(map); },
+  };
+}
+
+/** Build the REAL helpers bound to injected collaborators. `thread` is the
+ *  closure's active-conversation object (mutate `thread.id` to simulate a
+ *  conversation switch, or pass null for the pre-first-message view);
+ *  `scopeRef.value` drives the workflow-scope fallback. */
+function buildHelpers({ thread = null, liveTurnThreadId = null, scopeRef = { value: "workflow:none" }, sessionStorage } = {}) {
+  const ss = sessionStorage ?? makeSessionStorage();
+  const setCalls = [];
+  const ctxLabel = { textContent: "" };
+  const factory = new Function(
+    "CTX_KEY",
+    "thread",
+    "liveTurnThreadId",
+    "currentHistoryScopeKey",
+    "ssGet",
+    "ssSet",
+    "setContextPct",
+    "ctxLabel",
+    "window",
+    `${sliceMatch[0]}\nreturn { ctxScopeKey, ctxPersistKey, ctxFrameForActiveView, refreshContextRingForScope, clearAllCtxScopes };`,
+  );
+  const helpers = factory(
+    CTX_KEY,
+    thread,
+    liveTurnThreadId,
+    () => scopeRef.value,
+    (k) => ss.getItem(k),
+    (k, v) => (v == null ? ss.removeItem(k) : ss.setItem(k, v)),
+    (p) => setCalls.push(p),
+    ctxLabel,
+    { sessionStorage: ss },
+  );
+  return { helpers, setCalls, ctxLabel, ss, thread, scopeRef };
+}
+
+test("#381 ctxScopeKey keys by the active thread id", () => {
+  const thread = { id: "t-123" };
+  const { helpers } = buildHelpers({ thread });
+  assert.equal(helpers.ctxScopeKey(), `${CTX_KEY}:t-123`);
+  thread.id = "t-999";
+  assert.equal(helpers.ctxScopeKey(), `${CTX_KEY}:t-999`);
+});
+
+test("codex-P2: ctxScopeKey is null for the pre-first-message view (no workflow-scope fallback)", () => {
+  // A thread-less view has no conversation, so no key — nothing is read,
+  // persisted, or painted against it, and a re-push in that gap cannot leak into
+  // the thread the first message then mints.
+  const { helpers } = buildHelpers({ thread: null });
+  assert.equal(helpers.ctxScopeKey(), null);
+});
+
+test("codex-P2: nothing is persisted or painted against a thread-less view", () => {
+  const empty = buildHelpers({ thread: null, liveTurnThreadId: null });
+  assert.equal(empty.helpers.ctxPersistKey(), null, "no persist target without a conversation");
+  assert.equal(empty.helpers.ctxFrameForActiveView(), false, "a re-push must not paint an empty view");
+});
+
+test("codex-P2: refreshContextRingForScope blanks when no conversation is shown", () => {
+  const { helpers, setCalls, ctxLabel } = buildHelpers({ thread: null });
+  helpers.refreshContextRingForScope();
+  assert.equal(setCalls.at(-1), 0);
+  assert.equal(ctxLabel.textContent, "—");
+});
+
+test("#381 switching conversations never shows the previous one's fill", () => {
+  const thread = { id: "t-A" };
+  const ss = makeSessionStorage();
+  const { helpers, setCalls, ctxLabel } = buildHelpers({ thread, sessionStorage: ss });
+
+  // Conversation A reports a high fill (agent_status writes under A's key).
+  ss.setItem(helpers.ctxScopeKey(), "0.785");
+
+  // Switch to a lightly-used conversation B (no stored fill yet).
+  thread.id = "t-B";
+  helpers.refreshContextRingForScope();
+  assert.equal(setCalls.at(-1), 0, "switching to an unused conversation must blank the ring, not keep A's fill");
+  assert.equal(ctxLabel.textContent, "—");
+
+  // B accrues its own smaller fill.
+  ss.setItem(helpers.ctxScopeKey(), "0.24");
+  helpers.refreshContextRingForScope();
+  assert.equal(setCalls.at(-1), 0.24);
+
+  // Back to A — its own high fill is restored, not B's.
+  thread.id = "t-A";
+  helpers.refreshContextRingForScope();
+  assert.equal(setCalls.at(-1), 0.785, "returning to A must restore A's fill, not leave B's 0.24");
+});
+
+test("codex-P2: two conversations in the SAME workflow keep independent fills", () => {
+  // The scope (workflow) is constant across both threads — proving the key is
+  // thread-scoped, so picking an older history entry in one workflow does not
+  // inherit the other conversation's usage.
+  const thread = { id: "t-A" };
+  const ss = makeSessionStorage();
+  const scopeRef = { value: "workflow:SAME" };
+  const { helpers, setCalls } = buildHelpers({ thread, scopeRef, sessionStorage: ss });
+
+  ss.setItem(helpers.ctxScopeKey(), "0.70"); // A, in workflow:SAME
+  thread.id = "t-B";                          // same workflow, different conversation
+  ss.setItem(helpers.ctxScopeKey(), "0.24"); // B, in workflow:SAME
+  assert.notEqual(`${CTX_KEY}:t-A`, `${CTX_KEY}:t-B`);
+
+  thread.id = "t-A";
+  helpers.refreshContextRingForScope();
+  assert.equal(setCalls.at(-1), 0.70, "A keeps 0.70 even though B is in the same workflow scope");
+  thread.id = "t-B";
+  helpers.refreshContextRingForScope();
+  assert.equal(setCalls.at(-1), 0.24, "B keeps its own 0.24");
+});
+
+test("codex-P2: a status frame persists under the turn's owner, not the switched-to conversation", () => {
+  // The user was chatting in A (a turn is live, so liveTurnThreadId === A), then
+  // switched history to B (thread === B) before A's turn drained. A late
+  // agent_status must persist under A, never B.
+  const { helpers } = buildHelpers({ thread: { id: "t-B" }, liveTurnThreadId: "t-A" });
+  assert.equal(helpers.ctxPersistKey(), `${CTX_KEY}:t-A`, "late frame must attribute to the turn owner A, not the displayed B");
+});
+
+test("codex-P2: outside a live turn, persistence targets the current conversation", () => {
+  // liveTurnThreadId null (between turns / after reload) → the reconnect re-push
+  // belongs to whatever conversation is now shown.
+  const { helpers } = buildHelpers({ thread: { id: "t-B" }, liveTurnThreadId: null });
+  assert.equal(helpers.ctxPersistKey(), `${CTX_KEY}:t-B`);
+});
+
+test("codex-P2: a background turn's frame does NOT repaint the ring of the chat on screen", () => {
+  // Live turn owned by A (liveTurnThreadId=A) while B is displayed (thread=B):
+  // the frame is persisted to A but must not touch B's visible ring.
+  const bg = buildHelpers({ thread: { id: "t-B" }, liveTurnThreadId: "t-A" });
+  assert.equal(bg.helpers.ctxFrameForActiveView(), false, "a background-turn frame must not repaint the active ring");
+
+  // Live turn owned by the displayed chat → repaint.
+  const fg = buildHelpers({ thread: { id: "t-A" }, liveTurnThreadId: "t-A" });
+  assert.equal(fg.helpers.ctxFrameForActiveView(), true);
+
+  // No live turn (reconnect re-push) → repaint the current chat.
+  const idle = buildHelpers({ thread: { id: "t-A" }, liveTurnThreadId: null });
+  assert.equal(idle.helpers.ctxFrameForActiveView(), true);
+});
+
+test("codex-P2: a mid-turn switch cannot corrupt the switched-to conversation's stored fill", () => {
+  // End to end: A has a stored fill; a live turn owned by A drains a late frame
+  // while B is displayed; B's own stored fill must be untouched.
+  const ss = makeSessionStorage();
+  const { helpers } = buildHelpers({ thread: { id: "t-B" }, liveTurnThreadId: "t-A", sessionStorage: ss });
+  ss.setItem(`${CTX_KEY}:t-B`, "0.10"); // B's real, low fill
+  // Simulate onAgentStatus persisting a high A-frame while B is shown.
+  ss.setItem(helpers.ctxPersistKey(), "0.90");
+  assert.equal(ss.getItem(`${CTX_KEY}:t-B`), "0.10", "B's fill must stay 0.10");
+  assert.equal(ss.getItem(`${CTX_KEY}:t-A`), "0.90", "A absorbs its own turn's fill");
+});
+
+test("#381 refreshContextRingForScope blanks the ring when the conversation has no fill", () => {
+  const { helpers, setCalls, ctxLabel } = buildHelpers({ thread: { id: "t-fresh" } });
+  helpers.refreshContextRingForScope();
+  assert.equal(setCalls.at(-1), 0);
+  assert.equal(ctxLabel.textContent, "—");
+});
+
+test("#381 clearAllCtxScopes drops every conversation's fill and the legacy global key", () => {
+  const ss = makeSessionStorage();
+  const { helpers } = buildHelpers({ thread: { id: "t-A" }, sessionStorage: ss });
+
+  ss.setItem(`${CTX_KEY}:t-A`, "0.5");
+  ss.setItem(`${CTX_KEY}:t-B`, "0.6");
+  ss.setItem(`${CTX_KEY}:panel:global`, "0.7");
+  ss.setItem(CTX_KEY, "0.9"); // pre-#381 global key an upgraded tab might carry
+  ss.setItem("unrelated.key", "keep-me");
+
+  helpers.clearAllCtxScopes();
+
+  assert.deepEqual([...ss._dump().keys()], ["unrelated.key"], "only non-ctx keys should survive");
+});

--- a/browser_tests/unit/graph-canvas-zoom-center.test.mjs
+++ b/browser_tests/unit/graph-canvas-zoom-center.test.mjs
@@ -1,0 +1,157 @@
+// Regression coverage for panel#401: panel_canvas "zoom" lost the center set by
+// "center_on_node". The zoom branch wrote ds.scale directly, which keeps the
+// graph ORIGIN (top-left, at -ds.offset) pinned — so changing scale slides the
+// viewport CENTER away, dumping the just-centered node off-screen (reporter saw
+// in_view_count=0). The fix holds the graph-space viewport center constant.
+//
+// graph_canvas lives inline inside the GRAPH_TOOL_EXECUTORS object literal in
+// web/js/comfyui-mcp-panel.js (references browser globals, so it can't be
+// imported under plain Node). Following the same "real panel source" extraction
+// convention as graph-set-node-collapsed.test.mjs, we regex the method's source
+// out of the file and evaluate it via `new Function` with getGraphCtx /
+// resolveNode / activePanelRoot injected as stubs, driving the ACTUAL shipped
+// logic.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8");
+
+const methodMatch = panelSrc.match(/graph_canvas\(\{ action, node_id, dx, dy, scale \}\) \{[\s\S]*?\n {2}\},/);
+assert.ok(methodMatch, "could not locate graph_canvas in panel source");
+
+/** Build a fresh graph_canvas bound to injected stubs, evaluating the REAL
+ *  method source pulled from the panel file. */
+function realGraphCanvas(getGraphCtx, resolveNode, activePanelRoot = null) {
+  const factory = new Function(
+    "getGraphCtx",
+    "resolveNode",
+    "activePanelRoot",
+    `const executors = { ${methodMatch[0]} };\nreturn executors.graph_canvas;`,
+  );
+  return factory(getGraphCtx, resolveNode, activePanelRoot);
+}
+
+/** A canvas stub whose transform mirrors litegraph's DragAndScale: ds.scale +
+ *  ds.offset are CSS pixels, and the element reports its CSS size via
+ *  getBoundingClientRect (dpr=1 so the backing store matches). */
+function makeCanvas({ scale = 1, offset = [0, 0], width = 1000, height = 800, typedOffset = false } = {}) {
+  const calls = { dirty: 0 };
+  const el = {
+    width,
+    height,
+    clientWidth: width,
+    clientHeight: height,
+    getBoundingClientRect: () => ({ width, height, left: 0, top: 0, right: width, bottom: height }),
+  };
+  return {
+    calls,
+    // ComfyUI's LiteGraph DragAndScale stores offset as a Float32Array — exercise
+    // that representation so the fix's guard can't silently skip production.
+    ds: { scale, offset: typedOffset ? Float32Array.from(offset) : [...offset] },
+    canvas: el,
+    setDirty() { calls.dirty += 1; },
+    // native centerOnNode: place the node's center at the viewport center using
+    // the CSS-pixel transform (screenCenter = (graphCenter + offset) * scale).
+    centerOnNode(node) {
+      const cx = node.pos[0] + (node.size?.[0] ?? 0) / 2;
+      const cy = node.pos[1] + (node.size?.[1] ?? 0) / 2;
+      this.ds.offset[0] = width / (2 * this.ds.scale) - cx;
+      this.ds.offset[1] = height / (2 * this.ds.scale) - cy;
+    },
+  };
+}
+
+/** Graph-space point currently at the viewport center — the exact quantity
+ *  graph_view_nodes_in_viewport derives (center = -offset + cssSize/(2*scale)). */
+function viewportCenter(canvas) {
+  const { ds } = canvas;
+  return [
+    -ds.offset[0] + canvas.canvas.width / (2 * ds.scale),
+    -ds.offset[1] + canvas.canvas.height / (2 * ds.scale),
+  ];
+}
+
+test("#401 zoom preserves the graph-space viewport center (real panel source)", () => {
+  const canvas = makeCanvas({ scale: 1, offset: [37, -12], width: 1000, height: 800 });
+  const fn = realGraphCanvas(() => ({ graph: {}, canvas }));
+
+  const before = viewportCenter(canvas);
+  fn({ action: "zoom", scale: 0.35 });
+  const after = viewportCenter(canvas);
+
+  assert.equal(canvas.ds.scale, 0.35, "scale must be applied");
+  assert.ok(Math.abs(after[0] - before[0]) < 1e-6, `center x drifted: ${before[0]} -> ${after[0]}`);
+  assert.ok(Math.abs(after[1] - before[1]) < 1e-6, `center y drifted: ${before[1]} -> ${after[1]}`);
+});
+
+test("#401 FAIL-before demo: pinning the origin (old behavior) would move the center", () => {
+  // The OLD zoom branch left ds.offset untouched. Show that keeping the origin
+  // fixed while changing scale necessarily moves the center — i.e. the fix is
+  // load-bearing, not cosmetic.
+  const canvas = makeCanvas({ scale: 1, offset: [37, -12], width: 1000, height: 800 });
+  const before = viewportCenter(canvas);
+  // simulate the old code: scale only, offset untouched
+  canvas.ds.scale = 0.35;
+  const oldAfter = viewportCenter(canvas);
+  assert.ok(
+    Math.abs(oldAfter[0] - before[0]) > 100,
+    "sanity: origin-pinned zoom should shift the center substantially",
+  );
+});
+
+test("#401 center_on_node then zoom keeps the node framed (the reporter's scenario)", () => {
+  // Node 46 at ~[-4400,-2900] as in the report.
+  const node = { id: 46, pos: [-4400, -2900], size: [200, 100] };
+  const canvas = makeCanvas({ scale: 1, offset: [0, 0], width: 1000, height: 800 });
+  const fn = realGraphCanvas(() => ({ graph: {}, canvas }), () => node);
+
+  fn({ action: "center_on_node", node_id: 46 });
+  const nodeCenter = [node.pos[0] + node.size[0] / 2, node.pos[1] + node.size[1] / 2];
+  const centeredAt = viewportCenter(canvas);
+  assert.ok(Math.abs(centeredAt[0] - nodeCenter[0]) < 1e-6, "center_on_node should center the node");
+  assert.ok(Math.abs(centeredAt[1] - nodeCenter[1]) < 1e-6, "center_on_node should center the node");
+
+  fn({ action: "zoom", scale: 0.35 });
+
+  // After zooming out, the node's center must still sit at the viewport center,
+  // and the node must fall inside the (now larger) viewport rect.
+  const afterZoom = viewportCenter(canvas);
+  assert.ok(Math.abs(afterZoom[0] - nodeCenter[0]) < 1e-6, `zoom moved center x off node: ${afterZoom[0]}`);
+  assert.ok(Math.abs(afterZoom[1] - nodeCenter[1]) < 1e-6, `zoom moved center y off node: ${afterZoom[1]}`);
+
+  const vx = -canvas.ds.offset[0];
+  const vy = -canvas.ds.offset[1];
+  const vw = canvas.canvas.width / canvas.ds.scale;
+  const vh = canvas.canvas.height / canvas.ds.scale;
+  const inView =
+    node.pos[0] < vx + vw && node.pos[0] + node.size[0] > vx &&
+    node.pos[1] < vy + vh && node.pos[1] + node.size[1] > vy;
+  assert.ok(inView, "node 46 must remain inside the viewport after zoom (report saw in_view_count=0)");
+});
+
+test("#401 zoom preserves the center with a Float32Array offset (LiteGraph production repr)", () => {
+  // The old guard used Array.isArray(ds.offset), which is FALSE for a
+  // Float32Array, so the correction was skipped and every real zoom re-pinned
+  // the origin. This locks in typed-offset support.
+  const canvas = makeCanvas({ scale: 1, offset: [37, -12], width: 1000, height: 800, typedOffset: true });
+  assert.ok(canvas.ds.offset instanceof Float32Array, "precondition: offset is typed");
+  const fn = realGraphCanvas(() => ({ graph: {}, canvas }));
+
+  const before = viewportCenter(canvas);
+  fn({ action: "zoom", scale: 0.35 });
+  const after = viewportCenter(canvas);
+
+  assert.equal(canvas.ds.scale, 0.35);
+  assert.ok(Math.abs(after[0] - before[0]) < 1e-3, `center x drifted with typed offset: ${before[0]} -> ${after[0]}`);
+  assert.ok(Math.abs(after[1] - before[1]) < 1e-3, `center y drifted with typed offset: ${before[1]} -> ${after[1]}`);
+});
+
+test("#401 zoom still validates scale bounds (no regression)", () => {
+  const canvas = makeCanvas();
+  const fn = realGraphCanvas(() => ({ graph: {}, canvas }));
+  assert.throws(() => fn({ action: "zoom", scale: 0 }), /scale must be in/);
+  assert.throws(() => fn({ action: "zoom", scale: 5 }), /scale must be in/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -5951,7 +5951,29 @@ const GRAPH_TOOL_EXECUTORS = {
       case "zoom": {
         const s = Number(scale);
         if (!(s > 0.05 && s <= 4)) throw new Error("scale must be in (0.05, 4]");
+        // #401: preserve the graph-space point currently at the viewport CENTER.
+        // Naively writing ds.scale keeps the graph ORIGIN (top-left, at -ds.offset)
+        // pinned, so changing scale slides the center away — silently undoing a
+        // preceding center_on_node. The viewport center in graph space is
+        //   c = -ds.offset + cssSize / (2 * scale)     (see graph_view_nodes_in_viewport)
+        // Holding c constant across the scale change gives
+        //   offset += (cssSize / 2) * (1/newScale - 1/oldScale).
+        // ds.scale/ds.offset are CSS pixels, so measure the element's CSS rect
+        // (matches graph_view_nodes_in_viewport), not the DPR-scaled backing store.
+        const prev = Number(ds.scale);
+        const el = canvas.canvas;
+        const rect = typeof el?.getBoundingClientRect === "function" ? el.getBoundingClientRect() : null;
+        const cssW = rect && rect.width > 0 ? rect.width : Number(el?.clientWidth) || Number(el?.width) || 0;
+        const cssH = rect && rect.height > 0 ? rect.height : Number(el?.clientHeight) || Number(el?.height) || 0;
         ds.scale = s;
+        // ds.offset is a Float32Array on ComfyUI's LiteGraph canvas (not a plain
+        // Array), so gate on "indexable pair" — the other branches index it the
+        // same way — rather than Array.isArray, which would skip typed offsets
+        // and leave every real zoom pinning the origin (codex P1).
+        if (Number.isFinite(prev) && prev > 0 && cssW > 0 && cssH > 0 && Number(ds.offset?.length) >= 2) {
+          ds.offset[0] += (cssW / 2) * (1 / s - 1 / prev);
+          ds.offset[1] += (cssH / 2) * (1 / s - 1 / prev);
+        }
         break;
       }
       default:
@@ -10995,11 +11017,78 @@ function buildPanel() {
     ringTitle.textContent = `Context window ~${pct}% used`;
     ctxLabel.textContent = clamped > 0 ? `${pct}%` : "—";
   }
-  // Restore last % across reloads (orchestrator also re-pushes on connect).
-  {
-    const p0 = Number(ssGet(CTX_KEY));
-    if (p0 > 0) setContextPct(p0);
+  // #381: the ring is persisted PER conversation, not globally. A single global
+  // key showed the PREVIOUS conversation's fill against the newly-switched one
+  // until the next agent_status push (a near-full context could read as having
+  // headroom). The ring describes a CONVERSATION == thread, and one workflow can
+  // hold several saved conversations, so key STRICTLY by the active thread id —
+  // stable across workflow rename/save-as and a follows-panel canvas switch (same
+  // thread), distinct per conversation so neither a workflow switch nor picking an
+  // older history entry in the same workflow leaks a stale fill (codex P2). There
+  // is deliberately NO workflow-scope fallback: the pre-first-message view has no
+  // conversation, so it has no key — the ring stays "—" and nothing is persisted
+  // or painted against it, so a re-push in that gap can't leak into the thread the
+  // first message then mints (codex P2). Returns null when no thread is shown.
+  function ctxScopeKey() {
+    return thread?.id ? `${CTX_KEY}:${thread.id}` : null;
   }
+  // Where an agent_status fill is PERSISTED. Attribute it to the conversation
+  // that owns the live turn (liveTurnThreadId, captured at turn start), not the
+  // currently-displayed `thread` (codex P2): when the user switches history
+  // mid-turn, a late status frame draining from the interrupted agent must land
+  // under ITS conversation, never the newly-selected one. resume_session /
+  // new_session only ARM a switch (no status frame is pushed for the new
+  // conversation until its own turn begins), so a frame arriving in that gap is
+  // always the old turn's. Outside a live turn (e.g. the reconnect re-push)
+  // liveTurnThreadId is null and the current conversation is the right target.
+  function ctxPersistKey() {
+    return liveTurnThreadId ? `${CTX_KEY}:${liveTurnThreadId}` : ctxScopeKey();
+  }
+  // Whether an incoming usage frame should REPAINT the visible ring. It should
+  // only when it belongs to the conversation on screen — either there is no live
+  // turn (reconnect re-push for the shown chat) or the live turn's owner IS the
+  // shown chat. A frame draining from a BACKGROUND turn (owner ≠ shown chat, e.g.
+  // the user switched history mid-turn) is still persisted to its owner but must
+  // NOT overwrite the freshly-restored ring of the chat now on screen (codex P2).
+  function ctxFrameForActiveView() {
+    // No live turn: only the shown conversation's own re-push should paint — and
+    // only if a conversation is actually shown (an empty pre-thread view stays
+    // "—"). During a turn: paint only when its owner is the shown conversation.
+    if (!liveTurnThreadId) return Boolean(thread?.id);
+    return liveTurnThreadId === (thread?.id ?? null);
+  }
+  // Repaint the ring from the shown conversation's persisted value, or blank it
+  // when it has none (or none is shown). Called on a genuine workflow switch,
+  // on a history/thread switch, and after restore so the ring always describes
+  // the conversation currently on screen (#381).
+  function refreshContextRingForScope() {
+    const key = ctxScopeKey();
+    const v = key ? Number(ssGet(key)) : 0;
+    if (v > 0) setContextPct(v);
+    else {
+      setContextPct(0);
+      ctxLabel.textContent = "—";
+    }
+  }
+  // Drop every scope's persisted fill — used when clearing ALL history, which
+  // removes the conversations those values described (also sweeps the pre-#381
+  // global key so an upgraded tab can't restore it).
+  function clearAllCtxScopes() {
+    try {
+      const store = window.sessionStorage;
+      for (let i = store.length - 1; i >= 0; i--) {
+        const k = store.key(i);
+        if (k && (k === CTX_KEY || k.startsWith(`${CTX_KEY}:`))) store.removeItem(k);
+      }
+    } catch {
+      // sessionStorage unavailable — nothing persisted to clear.
+    }
+  }
+  // NOTE: no restore here. No thread is bound during panel construction, so
+  // ctxScopeKey() is null and there is nothing to read; the ring is restored
+  // post-hydration by the history-restore pass (once the durable thread is
+  // selected) and repainted on every history/workflow switch. The orchestrator
+  // also re-pushes the live figure on connect.
 
   // Model + effort picker. The orchestrator forwards these to the Agent SDK,
   // so the chip actually drives the background agent (model live, effort on a
@@ -12412,6 +12501,10 @@ function buildPanel() {
       client?.sendFrame?.({ type: "new_session" });
     }
     persistThreads();
+    // #381 codex-P2: a sync from another tab just replaced or removed the active
+    // conversation — repaint the ring for the replacement (or blank it when the
+    // conversation was cleared) instead of leaving the deleted chat's fill up.
+    refreshContextRingForScope();
     return replacement;
   }
 
@@ -13633,7 +13726,9 @@ function buildPanel() {
     turnAnchors = []; // fresh conversation → no rewind anchors
     ssSet(CURRENT_THREAD_KEY, null);
     ssSet(SESSION_KEY, null);
-    ssSet(CTX_KEY, null);
+    // #381: the ring is keyed per THREAD, and `thread` is already null here, so
+    // there is nothing to clear — the outgoing conversation keeps its own fill
+    // (correct if reopened from history). The fresh empty view just blanks below.
     if (typeof resetAttachments === "function") resetAttachments();
     resetFeed();
     renderTodo([]); // fresh chat → empty plan tray
@@ -13707,6 +13802,10 @@ function buildPanel() {
     setActiveThread(followsPanel ? "panel:global" : (t.workflowKey || scopeKey), t.id);
     persistThreads();
     paintThread(t);
+    // #381/codex-P2: `thread` is now `t`, so repaint the ring from THIS
+    // conversation's own last-known fill (blank if none) — selecting an older
+    // history entry in the same workflow must not keep the prior chat's usage.
+    refreshContextRingForScope();
     // Resume this conversation's agent session (or start fresh if it has none),
     // so typing continues THIS chat rather than whatever was last active.
     ssSet(SESSION_KEY, sessionId);
@@ -13872,6 +13971,10 @@ function buildPanel() {
         );
       } catch { /* armContext unavailable — awareness rides the title instead */ }
     }
+    // #381: a genuine switch changed the conversation scope — repaint the ring
+    // from the newly-active scope's own last-known fill (or blank it) so it never
+    // keeps showing the previous workflow's value.
+    refreshContextRingForScope();
   }
 
   function renderHistory() {
@@ -14164,7 +14267,7 @@ function buildPanel() {
       turnAnchors = [];
       ssSet(CURRENT_THREAD_KEY, null);
       ssSet(SESSION_KEY, null);
-      ssSet(CTX_KEY, null);
+      clearAllCtxScopes(); // #381: clearing ALL history drops every scope's fill
       if (typeof resetAttachments === "function") resetAttachments();
       resetFeed();
       renderTodo([], { persist: false });
@@ -14442,6 +14545,11 @@ function buildPanel() {
   // tray) rather than start immediately. Drives the tray-vs-inline decision so
   // an idle send doesn't briefly flash through the tray.
   let agentWorking = false;
+  // Conversation that owns the in-flight turn, captured at turn start so a status
+  // frame is persisted under it even if the user switches history mid-turn (#381
+  // codex-P2). Null between turns; a page reload resets it. Set on onTurn
+  // "working", overwritten by the next turn's owner.
+  let liveTurnThreadId = null;
 
   // Set by a Settings "Set … token" button just before it asks the agent to open
   // the secure input, so the resolved value can be marked set/not-set (timestamp
@@ -14790,11 +14898,19 @@ function buildPanel() {
         // the NEXT turn, and a human can't end + restart a turn inside the window.
         if (Date.now() - localEndAt < STALE_WORKING_GUARD_MS) return;
         agentWorking = true;
+        // Pin the turn's owner so its usage frames persist under THIS
+        // conversation even if the user switches history before it ends (#381).
+        liveTurnThreadId = thread?.id ?? null;
         showThinking();
         noteActivity(); // turn start = real activity → seed the silence clock
         ssSet(MID_TASK_KEY, "1"); // a turn is in flight — arm the resume nudge
       } else if (state === "done") {
         agentWorking = false;
+        // Turn over: drop the owner so a later reconnect re-push (which has no
+        // live turn) is attributed to the conversation THEN on screen, not this
+        // completed one (#381 codex-P2). `done` is terminal — no more usage
+        // frames trail it — so clearing here cannot orphan a late frame.
+        liveTurnThreadId = null;
         hideThinking(); // authoritative terminal frame — clears the action label too
         ssSet(MID_TASK_KEY, null); // turn finished cleanly — nothing to resume
         // Snapshot the graph the agent is leaving behind; the next user turn diffs
@@ -14858,9 +14974,15 @@ function buildPanel() {
       // Percentage of the context window used (label + ring), persisted so a
       // reload isn't blank. % is what the user wants — not raw token counts.
       if (typeof s.context_pct === "number") {
-        setContextPct(s.context_pct);
-        ssSet(CTX_KEY, String(s.context_pct));
-        if (typeof s.cost_usd === "number") {
+        // Persist under the turn's OWNER always; repaint the ring only when the
+        // frame belongs to the conversation on screen (#381 codex-P2) — a
+        // background turn draining after a history switch must not overwrite the
+        // freshly-restored ring of the chat now displayed.
+        const forActiveView = ctxFrameForActiveView();
+        if (forActiveView) setContextPct(s.context_pct);
+        const persistKey = ctxPersistKey();
+        if (persistKey) ssSet(persistKey, String(s.context_pct)); // skip when no conversation owns it yet
+        if (forActiveView && typeof s.cost_usd === "number") {
           ringTitle.textContent = `Context ~${Math.round(s.context_pct * 100)}% used · $${s.cost_usd.toFixed(3)}`;
         }
       }
@@ -17743,6 +17865,7 @@ function buildPanel() {
       resetFeed();
       renderTodo([]);
       persistThreads();
+      refreshContextRingForScope(); // #381: restore this scope's fill post-hydration (blank if none)
       return;
     }
 
@@ -17765,6 +17888,7 @@ function buildPanel() {
     paintThread(durableActive);
     if (foreignSession) armVisibleTranscriptReplay();
     persistThreads();
+    refreshContextRingForScope(); // #381: restore this scope's fill post-hydration
   })();
 
   // ---- Settings dialog → live panel hooks ----
@@ -17800,6 +17924,7 @@ function buildPanel() {
     else newChat({ notifyBackend: false });
     currentWorkflowId = null;
     onWorkflowMaybeChanged();
+    refreshContextRingForScope(); // #381: the scope mode changed — reflect the target scope's fill
     appendSystem(
       mode === "panel"
         ? "Chat scope → panel-wide conversation."


### PR DESCRIPTION
Fixes a canvas-routing / context-ring / zoom cluster. Verify-first per issue; unit tests added; `node --check` + `npm run test:unit` green (844 pass); codex self-gate (gpt-5.6-terra/high, embed-diff) PASS after resolving 5 successive findings.

## panel#401 — `panel_canvas` zoom loses the center set by `center_on_node`
Root cause: the `zoom` action wrote `ds.scale` directly, which pins the graph **origin** (top-left, at `-ds.offset`). Changing scale then slides the viewport **center** away, undoing a preceding `center_on_node` (reporter saw `in_view_count=0`). Fix: hold the graph-space viewport center constant across the scale change — `offset += (cssSize/2)*(1/newScale − 1/oldScale)` — measuring the element's **CSS** rect (matches `graph_view_nodes_in_viewport`), not the DPR-scaled backing store. Also fixes a latent bug found in review: `ds.offset` is a `Float32Array` on ComfyUI's LiteGraph, so the correction was gated behind `Array.isArray` and skipped in production; it now accepts any indexable offset.

## panel#381 — context ring shows the previous workflow's fill after a tab switch
Root cause: the ring was persisted under a **single global** `sessionStorage` key while agent conversations are per-conversation. A switch showed the previous conversation's fill until the next `agent_status` push (a near-full context could read as having headroom). Fix: key the persisted fill **strictly by the active thread id** (stable across workflow rename/save-as and a follows-panel canvas switch; distinct per conversation) and repaint the ring from the shown conversation on every genuine workflow switch, history/thread switch, scope-mode change, sync-driven detach/rebind, and post-hydration restore — blanking when it has no fill. `clearAllCtxScopes` sweeps every conversation (and the legacy global key) on a full history clear.

Review-driven hardening (all resolved):
- Persist per **thread**, not per workflow scope — picking an older history entry in the same workflow no longer inherits another chat's usage.
- Attribute each `agent_status` to the **turn's owner** (captured at turn start; `resume_session`/`new_session` only *arm* a switch, so a frame in the gap is always the old turn's), so a mid-turn history switch can't corrupt the switched-to conversation. Repaint only when the frame belongs to the shown conversation; clear the owner on the terminal `done` frame.
- No workflow-scope fallback: a thread-less pre-first-message view has no key, so a re-push can't leak into the thread the first message mints.

## panel#178 — stale temporary tab id after ComfyUI restart
**Verified already fixed upstream** — no panel change needed. The fix lives in the `comfyui-mcp` orchestrator (shipped 0.48.23): `ensureReachable` → `rebindToActiveTab` auto-heals a session's `ctx.tabId` before each send when the bound tab is gone, with a direct regression test (`src/__tests__/orchestrator/panel-tools.test.ts`, "stale-tmp-tab" → "reconnected-tab"). "current" mode never pins a tmp id (the store deletes on set); the reported single-tab restart case self-heals. The only remaining `no connected tab` paths (multi-tab / pinned) are deliberate, guarded invariants.

## Tests
- `browser_tests/unit/graph-canvas-zoom-center.test.mjs` — center preserved across zoom (incl. `Float32Array` offset + the reporter's `center_on_node`→zoom scenario), scale-bound validation.
- `browser_tests/unit/context-ring-scope.test.mjs` — per-thread keying, no cross-conversation leak (incl. two conversations in one workflow), turn-owner attribution, active-view repaint gating, thread-less-view no-op, `clearAllCtxScopes`, and source guards for the `done`-clear / detach-refresh / loadThread-refresh wiring.

Closes artokun/comfyui-mcp-panel#401
Closes artokun/comfyui-mcp-panel#381
Closes artokun/comfyui-mcp-panel#178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
