### PR TITLE
feat(panel): in-app media lightbox for inline chat media (#163)

### DIFF
--- a/browser_tests/unit/lightbox-gallery.test.mjs
+++ b/browser_tests/unit/lightbox-gallery.test.mjs
@@ -1,0 +1,118 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  stepIndex,
+  mediaKindFromUrl,
+  normalizeMediaItem,
+  createLightboxModel,
+} from "../../web/js/lib/lightbox-gallery.js";
+
+// In-panel media lightbox (#163). The overlay DOM lives in the main panel and
+// is covered by e2e; these tests pin the pure core it drives: index math,
+// url→kind inference, descriptor normalization, and the stateful model.
+
+test("stepIndex wraps in both directions", () => {
+  assert.equal(stepIndex(0, 1, 3), 1);
+  assert.equal(stepIndex(2, 1, 3), 0, "next past the end wraps to first");
+  assert.equal(stepIndex(0, -1, 3), 2, "prev before the start wraps to last");
+  assert.equal(stepIndex(1, -1, 3), 0);
+});
+
+test("stepIndex clamps when wrap:false", () => {
+  assert.equal(stepIndex(2, 1, 3, { wrap: false }), 2, "clamps at the end");
+  assert.equal(stepIndex(0, -1, 3, { wrap: false }), 0, "clamps at the start");
+  assert.equal(stepIndex(1, 5, 3, { wrap: false }), 2);
+});
+
+test("stepIndex is out-of-bounds safe for degenerate inputs", () => {
+  assert.equal(stepIndex(0, 1, 0), 0, "empty list");
+  assert.equal(stepIndex(5, -2, NaN), 0, "non-finite length");
+  assert.equal(stepIndex(NaN, NaN, 4), 0, "non-finite cur/delta collapse to 0-step");
+});
+
+test("stepIndex stays in range for huge finite operands (no Infinity%n NaN)", () => {
+  const r1 = stepIndex(Number.MAX_VALUE, Number.MAX_VALUE, 3);
+  assert.ok(Number.isInteger(r1) && r1 >= 0 && r1 < 3, `wrap result ${r1} in [0,3)`);
+  const r2 = stepIndex(Number.MAX_VALUE, 1, 3, { wrap: false });
+  assert.equal(r2, 2, "clamp path handles Infinity sum");
+  // Lengths beyond Number.MAX_SAFE_INTEGER (where integer indices aren't
+  // representable and float rounding could push a result to exactly n) collapse
+  // to 0 — never NaN, Infinity, or an out-of-range value.
+  for (const [c, d, len] of [
+    [Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE],
+    [Number.MAX_VALUE / 2, 0, Number.MAX_VALUE],
+    [2 ** 99 - 2 ** 46, 2 ** 99, 2 ** 100], // codex round-4 counterexample
+  ]) {
+    assert.equal(stepIndex(c, d, len), 0, `huge-n (${len}) collapses to 0`);
+  }
+  // Within the safe-integer range the wrap contract [0,n) is exact.
+  const big = Number.MAX_SAFE_INTEGER; // n <= this ⇒ all arithmetic exact
+  const rb = stepIndex(big - 1, 5, big);
+  assert.ok(Number.isInteger(rb) && rb >= 0 && rb < big, `safe-max wrap ${rb} in [0,n)`);
+  assert.equal(rb, 4, "wraps past the end of a max-safe-length gallery");
+});
+
+test("mediaKindFromUrl honours data: MIME then extension", () => {
+  assert.equal(mediaKindFromUrl("data:video/mp4;base64,AAAA"), "video");
+  assert.equal(mediaKindFromUrl("data:image/png;base64,AAAA"), "image");
+  assert.equal(mediaKindFromUrl("data:image/gif;base64,AAAA"), "image", "animated gif stays <img>");
+  assert.equal(mediaKindFromUrl("/view?filename=clip.webm&type=output"), "video");
+  assert.equal(mediaKindFromUrl("/view?filename=pic.png&type=output"), "image");
+  assert.equal(mediaKindFromUrl("https://host/a/b/render.MP4"), "video", "case-insensitive ext");
+  assert.equal(mediaKindFromUrl(""), "image", "empty → default image");
+});
+
+test("normalizeMediaItem coerces strings, objects, and captions", () => {
+  assert.deepEqual(normalizeMediaItem("http://x/y.png"), {
+    url: "http://x/y.png",
+    type: "image",
+    caption: "",
+  });
+  assert.deepEqual(normalizeMediaItem({ url: "http://x/y.mp4", caption: "a clip" }), {
+    url: "http://x/y.mp4",
+    type: "video",
+    caption: "a clip",
+  });
+  // Explicit type wins even if the extension disagrees.
+  assert.equal(normalizeMediaItem({ url: "http://x/y.png", type: "video" }).type, "video");
+  // Non-string caption is coerced to a string (never leaks an object).
+  assert.equal(normalizeMediaItem({ url: "http://x/y.png", caption: 42 }).caption, "42");
+  assert.equal(normalizeMediaItem({}), null, "no url → null");
+  assert.equal(normalizeMediaItem(null), null);
+});
+
+test("createLightboxModel drops url-less items and clamps the start index", () => {
+  const m = createLightboxModel(
+    [{ url: "a.png" }, { caption: "no url" }, "b.mp4"],
+    9, // out of range → clamped
+  );
+  assert.equal(m.length, 2, "the url-less descriptor is filtered out");
+  assert.equal(m.index, 1, "start index clamps to the last valid item");
+  assert.deepEqual(m.current(), { url: "b.mp4", type: "video", caption: "" });
+  assert.equal(m.hasMultiple(), true);
+});
+
+test("createLightboxModel.step wraps and returns the new current", () => {
+  const m = createLightboxModel(["a.png", "b.png", "c.png"], 0);
+  assert.equal(m.step(1).url, "b.png");
+  assert.equal(m.step(1).url, "c.png");
+  assert.equal(m.step(1).url, "a.png", "wraps past the end");
+  assert.equal(m.step(-1).url, "c.png", "wraps before the start");
+  assert.equal(m.index, 2);
+});
+
+test("createLightboxModel handles an empty gallery without throwing", () => {
+  const m = createLightboxModel([], 0);
+  assert.equal(m.length, 0);
+  assert.equal(m.current(), null);
+  assert.equal(m.step(1), null);
+  assert.equal(m.hasMultiple(), false);
+});
+
+test("createLightboxModel.goto clamps to range", () => {
+  const m = createLightboxModel(["a.png", "b.png", "c.png"], 0);
+  assert.equal(m.goto(1).url, "b.png");
+  assert.equal(m.goto(99).url, "c.png", "clamps high");
+  assert.equal(m.goto(-5).url, "a.png", "clamps low");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -135,6 +135,7 @@ import {
   formatDroppedWarning,
 } from "./lib/paste-report.js";
 import { createMediaRecorder } from "./lib/chat-media.js";
+import { createLightboxModel } from "./lib/lightbox-gallery.js";
 import {
   vueNodesActive,
   computeFitTransform,
@@ -9115,6 +9116,70 @@ const PANEL_CSS = `
 .cmcp-modal-scope input { margin-top: 0.15rem; }
 .cmcp-modal-btns { display: flex; justify-content: flex-end; gap: 0.4rem; }
 .cmcp-btn-primary { background: var(--p-primary-color, #3a7bd5); color: #fff; border: none; }
+/* In-panel media lightbox (#163): clicking a chat image (or a video card's
+   expand button) opens this full-window overlay instead of a raw new tab. It is
+   body-mounted (covers the whole ComfyUI window for a true "full size" view) and
+   theme-aware via the inherited PrimeVue --p-* tokens. Every pointer event is
+   stopped inside it so nothing leaks to the ComfyUI canvas underneath. */
+.cmcp-lightbox {
+  position: fixed; inset: 0; z-index: 10040; display: flex; flex-direction: column;
+  background: rgba(0,0,0,0.82); outline: none;
+}
+.cmcp-lightbox-stage {
+  position: relative; flex: 1 1 auto; min-height: 0;
+  display: flex; align-items: center; justify-content: center; padding: 2.5rem;
+}
+.cmcp-lightbox-media { display: flex; align-items: center; justify-content: center; max-width: 100%; max-height: 100%; }
+.cmcp-lightbox-el {
+  max-width: 100%; max-height: calc(100vh - 6rem); width: auto; height: auto;
+  display: block; border-radius: 6px; box-shadow: 0 8px 40px rgba(0,0,0,0.6);
+  background: var(--p-surface-950, #111113);
+}
+.cmcp-lightbox-nav {
+  position: absolute; top: 50%; transform: translateY(-50%);
+  width: 2.6rem; height: 2.6rem; border-radius: 50%; cursor: pointer;
+  font-size: 1.6rem; line-height: 1; display: flex; align-items: center; justify-content: center;
+  color: var(--p-text-color, #fafafa);
+  background: rgba(0,0,0,0.45); border: 1px solid var(--p-content-border-color, #3f3f46);
+}
+.cmcp-lightbox-nav:hover { background: var(--p-primary-color, #3a7bd5); color: #fff; }
+.cmcp-lightbox-prev { left: 0.75rem; }
+.cmcp-lightbox-next { right: 0.75rem; }
+.cmcp-lightbox-close {
+  position: absolute; top: 0.75rem; right: 0.75rem;
+  width: 2.2rem; height: 2.2rem; border-radius: 50%; cursor: pointer;
+  font-size: 1.1rem; line-height: 1; display: flex; align-items: center; justify-content: center;
+  color: var(--p-text-color, #fafafa);
+  background: rgba(0,0,0,0.45); border: 1px solid var(--p-content-border-color, #3f3f46);
+}
+.cmcp-lightbox-close:hover { background: var(--p-red-400, #f87171); color: #fff; }
+.cmcp-lightbox-bar {
+  flex: 0 0 auto; display: flex; align-items: center; justify-content: space-between; gap: 0.75rem;
+  padding: 0.6rem 0.9rem; background: var(--p-surface-900, #18181b);
+  border-top: 1px solid var(--p-content-border-color, #3f3f46);
+}
+.cmcp-lightbox-caption {
+  font-size: 0.75rem; color: var(--p-text-muted-color, #a1a1aa);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.cmcp-lightbox-open {
+  flex: 0 0 auto; cursor: pointer; font-size: 0.72rem; padding: 0.3rem 0.6rem; border-radius: 6px;
+  color: var(--p-text-color, #fafafa);
+  background: var(--p-surface-800, #27272a); border: 1px solid var(--p-content-border-color, #3f3f46);
+}
+.cmcp-lightbox-open:hover { border-color: var(--p-primary-color, #60a5fa); color: var(--p-primary-color, #60a5fa); }
+/* Expand affordance on video cards — images open on click, but a video's own
+   surface is owned by its native controls, so it gets a dedicated button. */
+.cmcp-imgcard { position: relative; }
+.cmcp-media-expand {
+  position: absolute; top: 0.4rem; right: 0.4rem; z-index: 2;
+  width: 1.8rem; height: 1.8rem; border-radius: 6px; cursor: pointer;
+  font-size: 0.95rem; line-height: 1; display: flex; align-items: center; justify-content: center;
+  color: #fff; background: rgba(0,0,0,0.5); border: 1px solid rgba(255,255,255,0.25);
+  opacity: 0; transition: opacity 0.12s ease;
+}
+.cmcp-imgcard:hover .cmcp-media-expand, .cmcp-media-expand:focus-visible { opacity: 1; }
+.cmcp-media-expand:hover { background: var(--p-primary-color, #3a7bd5); }
 /* Agent text flows freely — no card/bubble. Only user messages are boxed. */
 .cmcp-bubble.agent {
   align-self: stretch; max-width: 100%;
@@ -12780,6 +12845,153 @@ function buildPanel() {
     scrollLog();
   }
 
+  // ── In-panel media lightbox (#163) ────────────────────────────────────────
+  // Chat media cards (images + videos) used to open in a raw new browser tab on
+  // click. #163 opens them in an in-app overlay viewer: full-size, prev/next
+  // across ALL media in the log, Esc / backdrop / button close, image+video,
+  // theme-aware. window.open (openMediaUrl) stays as an explicit "Open original"
+  // fallback. Only one lightbox is ever live; a second open tears down the first.
+  let _activeLightboxClose = null; // teardown of the live lightbox (owns its doc keydown)
+
+  // Every media card stashes its {url,type,caption} on `card._cmcpMedia` at paint
+  // time. Collect them all, in visual order, so a click opens the lightbox at the
+  // clicked card with prev/next reaching every other image/video in the chat.
+  function collectChatGallery(clickedCard) {
+    const items = [];
+    let index = 0;
+    for (const card of log.querySelectorAll(".cmcp-imgcard")) {
+      const m = card._cmcpMedia;
+      if (!m || !m.url) continue;
+      if (card === clickedCard) index = items.length;
+      items.push(m);
+    }
+    return { items, index };
+  }
+
+  function openMediaLightbox(items, startIndex) {
+    // At-most-one lightbox: tear down any prior one (and its doc keydown listener)
+    // before opening, so a second open can't strand the older listener.
+    if (_activeLightboxClose) {
+      try { _activeLightboxClose(); } catch { /* already gone */ }
+      _activeLightboxClose = null;
+    }
+    const model = createLightboxModel(items, startIndex);
+    if (!model.length) return; // nothing renderable
+
+    const overlay = document.createElement("div");
+    overlay.className = "cmcp-lightbox";
+    overlay.tabIndex = -1; // focusable → receives key events immediately
+    const stage = document.createElement("div");
+    stage.className = "cmcp-lightbox-stage";
+    const mediaWrap = document.createElement("div");
+    mediaWrap.className = "cmcp-lightbox-media";
+    const mkBtn = (cls, html, title) => {
+      const b = document.createElement("button");
+      b.type = "button"; b.className = cls; b.innerHTML = html; if (title) b.title = title;
+      return b;
+    };
+    const prevBtn = mkBtn("cmcp-lightbox-nav cmcp-lightbox-prev", "‹", "Previous");
+    const nextBtn = mkBtn("cmcp-lightbox-nav cmcp-lightbox-next", "›", "Next");
+    const closeBtn = mkBtn("cmcp-lightbox-close", "✕", "Close (Esc)");
+    const caption = document.createElement("div");
+    caption.className = "cmcp-lightbox-caption";
+    const openBtn = document.createElement("button");
+    openBtn.type = "button"; openBtn.className = "cmcp-lightbox-open";
+    openBtn.textContent = "Open original"; openBtn.title = "Open in a new browser tab";
+
+    // Release any decoded <video> before it leaves the DOM (memory + stop audio).
+    const releaseVideo = () => {
+      try {
+        const v = mediaWrap.querySelector("video");
+        if (v) { v.pause(); v.removeAttribute("src"); v.load(); }
+      } catch { /* best-effort */ }
+    };
+
+    const closeLb = () => {
+      releaseVideo();
+      overlay.remove();
+      window.removeEventListener("keydown", onKey, true);
+      if (_activeLightboxClose === closeLb) _activeLightboxClose = null;
+    };
+    _activeLightboxClose = closeLb;
+
+    const render = () => {
+      const it = model.current();
+      if (!it) { closeLb(); return; }
+      releaseVideo();
+      mediaWrap.innerHTML = "";
+      if (it.type === "video") {
+        const v = document.createElement("video");
+        v.src = it.url; v.controls = true; v.autoplay = true; v.loop = true;
+        v.playsInline = true; v.className = "cmcp-lightbox-el";
+        mediaWrap.appendChild(v);
+        v.play?.().catch(() => {}); // opened by a user gesture; ignore if blocked
+      } else {
+        const img = document.createElement("img");
+        img.src = it.url; img.alt = it.caption || "media"; img.className = "cmcp-lightbox-el";
+        mediaWrap.appendChild(img);
+      }
+      caption.textContent = it.caption || "";
+      caption.style.display = it.caption ? "" : "none";
+      const multi = model.hasMultiple();
+      prevBtn.style.display = multi ? "" : "none";
+      nextBtn.style.display = multi ? "" : "none";
+      openBtn._url = it.url;
+    };
+    const step = (d) => { model.step(d); render(); };
+
+    const onKey = (e) => {
+      // Respect IME composition: an Enter/Escape mid-CJK-compose commits a
+      // candidate — it must NOT close the viewer (mirror lib/ime.js, #385). We
+      // return WITHOUT stopping so the keystroke still reaches the IME/composer.
+      if (isImeComposing(e)) return;
+      // Registered on WINDOW capture so it runs before any document-level panel
+      // handler (the turn-interrupt Esc, ComfyUI's own Esc) — for keys we own,
+      // stopImmediatePropagation prevents those from also firing (e.g. Escape
+      // aborting a running agent turn instead of just closing the viewer).
+      let handled = true;
+      if (e.key === "Escape") closeLb();
+      else if (e.key === "ArrowRight" || e.key === "ArrowDown") step(1);
+      else if (e.key === "ArrowLeft" || e.key === "ArrowUp") step(-1);
+      else handled = false;
+      if (handled) { e.preventDefault(); e.stopPropagation(); e.stopImmediatePropagation(); }
+    };
+
+    prevBtn.addEventListener("click", (e) => { e.stopPropagation(); step(-1); });
+    nextBtn.addEventListener("click", (e) => { e.stopPropagation(); step(1); });
+    closeBtn.addEventListener("click", (e) => { e.stopPropagation(); closeLb(); });
+    openBtn.addEventListener("click", (e) => { e.stopPropagation(); openMediaUrl(openBtn._url); });
+    // Keep every interaction inside the overlay — never leak a click/scroll to the
+    // ComfyUI canvas underneath (#163). Swallow the WHOLE pointer gesture
+    // (mousedown+mouseup+click); close the viewer on the fully-consumed CLICK, not
+    // on mousedown — removing the overlay mid-gesture would let the trailing
+    // mouseup/click hit-test against (and reach) the canvas now exposed beneath it.
+    overlay.addEventListener("mousedown", (e) => { e.stopPropagation(); });
+    overlay.addEventListener("mouseup", (e) => { e.stopPropagation(); });
+    overlay.addEventListener("click", (e) => {
+      e.stopPropagation();
+      if (e.target === overlay || e.target === stage || e.target === mediaWrap) closeLb();
+    });
+    overlay.addEventListener("wheel", (e) => { e.stopPropagation(); }, { passive: true });
+
+    stage.append(mediaWrap, prevBtn, nextBtn, closeBtn);
+    const bar = document.createElement("div");
+    bar.className = "cmcp-lightbox-bar";
+    bar.append(caption, openBtn);
+    overlay.append(stage, bar);
+    document.body.appendChild(overlay);
+    window.addEventListener("keydown", onKey, true);
+    overlay.focus();
+    render();
+  }
+
+  // Open the lightbox from a media card, gathering the whole chat gallery so
+  // prev/next span every image/video in the log.
+  function openLightboxFromCard(card) {
+    const { items, index } = collectChatGallery(card);
+    openMediaLightbox(items, index);
+  }
+
   function paintImage(url, name) {
     // Coerce the caption at the painter boundary — a structured/persisted caption
     // must never render (or re-persist) as "[object Object]", live OR on replay (#276).
@@ -12787,12 +12999,13 @@ function buildPanel() {
     clearEmpty();
     const card = document.createElement("div");
     card.className = "cmcp-bubble agent cmcp-imgcard";
+    card._cmcpMedia = { url, type: "image", caption: name || "" };
     const img = document.createElement("img");
     img.src = url;
     img.alt = name || "output";
     img.loading = "lazy";
     img.style.cssText = "max-width:100%;border-radius:6px;display:block;cursor:zoom-in;";
-    img.addEventListener("click", () => openMediaUrl(url));
+    img.addEventListener("click", (e) => { e.stopPropagation(); openLightboxFromCard(card); });
     card.appendChild(img);
     if (name) {
       const cap = document.createElement("div");
@@ -12865,6 +13078,7 @@ function buildPanel() {
     clearEmpty();
     const card = document.createElement("div");
     card.className = "cmcp-bubble agent cmcp-imgcard";
+    card._cmcpMedia = { url, type: "video", caption: name || "" };
     // Self-sizing holder: a live <video> when on-screen, a gray aspect-ratio box
     // when off-screen. Defaults to 16/9 until the first mount learns real dimensions.
     const holder = document.createElement("div");
@@ -12873,6 +13087,17 @@ function buildPanel() {
     holder.style.cssText =
       "width:100%;aspect-ratio:16 / 9;border-radius:6px;background:var(--p-content-hover-background,#2a2a2e);";
     card.appendChild(holder);
+    // A video's own surface is owned by its native controls, so it can't be
+    // "click to zoom" like an image — give it a dedicated expand button that opens
+    // the same in-panel lightbox (#163). The video still plays inline in the chat.
+    const expandBtn = document.createElement("button");
+    expandBtn.type = "button";
+    expandBtn.className = "cmcp-media-expand";
+    expandBtn.title = "View full size";
+    expandBtn.setAttribute("aria-label", "View full size");
+    expandBtn.innerHTML = "⛶";
+    expandBtn.addEventListener("click", (e) => { e.stopPropagation(); openLightboxFromCard(card); });
+    card.appendChild(expandBtn);
     if (name) {
       const cap = document.createElement("div");
       cap.style.cssText = "font-size:0.625rem;color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
@@ -18012,6 +18237,14 @@ function buildPanel() {
       if (workWordTimer) { clearInterval(workWordTimer); workWordTimer = null; }
       if (thinkingSafety) { clearTimeout(thinkingSafety); thinkingSafety = null; }
       document.removeEventListener("keydown", onInterruptKeydown, true);
+      // Tear down a live media lightbox (#163): it's body-mounted with its own
+      // window keydown listener, so without this an unmount/remount would strand
+      // the overlay + listener (and a remount's fresh _activeLightboxClose tracker
+      // could never dismiss the old one).
+      if (_activeLightboxClose) {
+        try { _activeLightboxClose(); } catch { /* already gone */ }
+        _activeLightboxClose = null;
+      }
       document.removeEventListener("visibilitychange", onVisibilityChange);
       window.removeEventListener("pagehide", onPageHide);
       unsubscribeHistorySync();

--- a/web/js/lib/lightbox-gallery.js
+++ b/web/js/lib/lightbox-gallery.js
@@ -1,0 +1,144 @@
+// In-panel media lightbox — pure, DOM-free core (issue #163).
+//
+// Inline chat media (images/videos painted by panel_show_media / a finished
+// run) used to open in a raw new browser tab on click. #163 replaces that with
+// an in-app lightbox: a full-size overlay viewer with prev/next across the
+// chat's media, Esc / backdrop close, and image+video support.
+//
+// This module holds ONLY the logic that can be tested without a DOM:
+//   - index math for prev/next (wrap or clamp),
+//   - normalizing a media descriptor into { url, type, caption },
+//   - deciding image-vs-video from a url when the caller didn't say,
+//   - a tiny stateful model the DOM lightbox drives (index + current + step).
+// The overlay DOM itself lives in comfyui-mcp-panel.js and is covered by e2e —
+// mirroring how chat-media.js factors the testable core out of the paint code.
+
+/**
+ * Step an index by `delta` over a list of `len` items.
+ *
+ * A gallery wraps by default (prev on the first item lands on the last, and
+ * vice-versa) so browsing a run of renders never dead-ends. Pass
+ * `{ wrap:false }` to clamp at the ends instead. Non-finite / empty inputs
+ * collapse to 0 so a caller can never index out of bounds.
+ *
+ * @param {number} cur   current index
+ * @param {number} delta step (usually +1 / -1)
+ * @param {number} len   number of items
+ * @param {{wrap?:boolean}} [opts]
+ * @returns {number} the next in-range index
+ */
+export function stepIndex(cur, delta, len, { wrap = true } = {}) {
+  const n = Math.trunc(Number(len));
+  if (!Number.isFinite(n) || n <= 0) return 0;
+  // Indices are array positions, so a real gallery's length is a small integer.
+  // Above Number.MAX_SAFE_INTEGER (2^53-1) distinct integer indices aren't even
+  // representable in a JS number, and float rounding on such magnitudes could
+  // nudge a result to exactly n (out of range). There's no meaningful index to
+  // land on, so collapse to 0. BELOW this bound every operation below is EXACT:
+  // the residues cm,dm are in [0,n), the `cm < room` branch guarantees cm+dm < n
+  // < 2^53 (representable exactly), and the else branch subtracts two values each
+  // < 2^53 — so no rounding can ever push the result to n. The contract [0,n)
+  // therefore holds for every finite input.
+  if (n > Number.MAX_SAFE_INTEGER) return 0;
+  const start = Number.isFinite(cur) ? Math.trunc(cur) : 0;
+  const d = Number.isFinite(delta) ? Math.trunc(delta) : 0;
+  if (wrap) {
+    // Reduce BOTH operands into [0,n). Normalize WITHOUT an unconditional `+ n`
+    // (that overflows when `v % n` is already near Number.MAX_VALUE): add n only
+    // when the residue is negative. Then combine with conditional subtraction
+    // rather than a second `% n`: room = n - dm; cm < room ⇒ sum < n, else fold
+    // via cm - room (= cm + dm - n).
+    const mod = (v) => { const r = v % n; return r < 0 ? r + n : r; };
+    const cm = mod(start);
+    const dm = mod(d);
+    const room = n - dm;
+    return cm < room ? cm + dm : cm - room;
+  }
+  // Clamp path: start+d may be ±Infinity, which Math.min/Math.max clamp cleanly.
+  return Math.max(0, Math.min(n - 1, start + d));
+}
+
+/**
+ * Best-effort image-vs-video decision from a media URL when the descriptor
+ * didn't carry an explicit `type`. Mirrors the panel's isVideoOutput: honour a
+ * `data:video/…` / `data:image/…` MIME first, else fall back to the file
+ * extension. `data:image/gif` stays an image (animated gifs render in <img>).
+ *
+ * @param {string} url
+ * @returns {"image"|"video"}
+ */
+export function mediaKindFromUrl(url) {
+  const s = String(url || "");
+  const dm = /^data:([a-z]+)\//i.exec(s);
+  if (dm) return dm[1].toLowerCase() === "video" ? "video" : "image";
+  // A video extension anywhere, bounded by end-of-string or a query/fragment
+  // separator. ComfyUI serves media as /view?filename=clip.webm&type=output, so
+  // the extension lives in the QUERY, not at the end — don't anchor on `$` only.
+  return /\.(mp4|webm|mov|mkv|m4v|avi)(?:$|[?&#])/i.test(s) ? "video" : "image";
+}
+
+/**
+ * Normalize a loose media descriptor into a stable lightbox item.
+ * Accepts a bare url string or `{ url, type, caption }`. An explicit `type` of
+ * "video" wins; anything else (including a missing type) is resolved from the
+ * url. Returns null when there is no usable url, so callers can filter.
+ *
+ * @param {string|{url?:string,type?:string,caption?:string}} item
+ * @returns {{url:string,type:"image"|"video",caption:string}|null}
+ */
+export function normalizeMediaItem(item) {
+  const raw = typeof item === "string" ? { url: item } : (item || {});
+  const url = typeof raw.url === "string" ? raw.url : "";
+  if (!url) return null;
+  const declared = String(raw.type || "").toLowerCase();
+  const type =
+    declared === "video" ? "video" : declared === "image" ? "image" : mediaKindFromUrl(url);
+  const caption = raw.caption == null ? "" : String(raw.caption);
+  return { url, type, caption };
+}
+
+/**
+ * A stateful, DOM-free lightbox model the overlay drives. Holds the normalized
+ * gallery and the current index; `step(±1)` moves (wrapping) and returns the
+ * new current item. Filters out descriptors with no url up front, so `current()`
+ * always yields a renderable item (or null when the gallery is empty).
+ *
+ * @param {Array} items       raw descriptors
+ * @param {number} [startIndex]
+ * @param {{wrap?:boolean}} [opts]
+ */
+export function createLightboxModel(items, startIndex = 0, { wrap = true } = {}) {
+  const list = (Array.isArray(items) ? items : [])
+    .map(normalizeMediaItem)
+    .filter(Boolean);
+  let idx = list.length ? stepIndex(startIndex, 0, list.length, { wrap: false }) : 0;
+  return {
+    get length() {
+      return list.length;
+    },
+    get index() {
+      return idx;
+    },
+    items() {
+      return list.slice();
+    },
+    current() {
+      return list[idx] || null;
+    },
+    hasMultiple() {
+      return list.length > 1;
+    },
+    /** Move by `delta` (wrapping unless the model was built with wrap:false). */
+    step(delta) {
+      if (!list.length) return null;
+      idx = stepIndex(idx, delta, list.length, { wrap });
+      return list[idx] || null;
+    },
+    /** Jump to an absolute index (clamped). */
+    goto(i) {
+      if (!list.length) return null;
+      idx = stepIndex(i, 0, list.length, { wrap: false });
+      return list[idx] || null;
+    },
+  };
+}


### PR DESCRIPTION
## #163 — In-app media lightbox (implemented)

Clicking an inline chat image (or a video card's new expand button) now opens a **self-contained, theme-aware overlay viewer** instead of a raw new browser tab.

- **Full-size media** centered over the whole ComfyUI window.
- **Prev/next** across *every* image + video currently in the chat log (wrapping), with ‹ / › buttons and Arrow keys.
- **Close** on the ✕ button, backdrop click, or **Esc**.
- **Image AND video** support (`<video controls autoplay loop>` in the viewer).
- **`window.open` kept only** as an explicit "Open original" fallback button (still handles the desktop bridge + `data:` path via the existing `openMediaUrl`).

### How it's built
- `web/js/lib/lightbox-gallery.js` — pure, DOM-free core: `stepIndex` (wrap/clamp index math), `mediaKindFromUrl`, `normalizeMediaItem`, and `createLightboxModel` (the stateful model the overlay drives). Unit-tested in `browser_tests/unit/lightbox-gallery.test.mjs` (10 tests).
- `web/js/comfyui-mcp-panel.js` — `openMediaLightbox` + gallery collection (each media card stashes `{url,type,caption}`); `paintImage` click and `paintVideo` expand-button wiring; overlay CSS in `PANEL_CSS` using inherited PrimeVue `--p-*` tokens with dark fallbacks (auto light/dark).

### Isolation / lifecycle (hardened over 4 codex review rounds)
- **Keys don't leak to the agent:** the key handler is on **`window` capture** with `stopImmediatePropagation` on handled keys, so Esc closes the viewer instead of reaching the panel's document-capture turn-interrupt handler (which would abort a running turn). **IME-safe** — bails on `isImeComposing` (mirrors `lib/ime.js`, #385) so an Enter/Escape mid-CJK-compose is left to the composer.
- **Clicks don't leak to the canvas:** the whole pointer gesture is swallowed and backdrop-close fires on the **fully-consumed `click`** (not `mousedown`), so removing the overlay can't expose the ComfyUI canvas to the trailing mouseup/click.
- **No stranded state:** at most one live lightbox (a second open tears down the first); `destroy()` tears down a live overlay + its `window` keydown listener on unmount/remount; `<video>` is released (`pause` / `removeAttribute src` / `load`) on navigation and close.
- `stepIndex` is out-of-bounds- and overflow-safe for **all** finite inputs (domain bounded to safe-integer lengths; wrap arithmetic proven exact below `Number.MAX_SAFE_INTEGER`).

### Verification
- `node --check` clean on both changed JS files.
- `npm run test:unit` — **847 pass, 0 fail** (10 new lightbox tests).
- Codex self-gate (`gpt-5.6-terra`, high): **VERDICT: PASS** after fixing 3× P1 (Esc→interrupt leak, mousedown-close canvas leak, destroy() strand) + numeric edge-cases it raised.

Closes #163

---

## #390 — adult-consent-survives-idle (investigated; **not** panel-side)

I did **not** change anything for #390, because the fix cannot live in this repo. A thorough sweep (`grep -a`, incl. past the null byte that truncates ripgrep in `comfyui-mcp-panel.js`) of all of `web/js` found **no adult-consent state in the panel at all**:

- No `panel_request_adult_consent` / `panel_get_content_mode` handler, no consent card UI, and **no consent storage** (`localStorage`/`sessionStorage`) — the CivitAI UI explicitly notes "the client has no NSFW gate; mcp strips adult levels without consent." A2UI has no consent references either.
- The only content-mode mechanism the panel owns is the unrelated **"Blind agents"** toggle (`AGENT_BLIND`, `localStorage cmcp.blindAgents`, re-advertised via `hello`).
- Issue #390 itself is filed **`upstream-only: yes`** and its root cause is the orchestrator's 300s `tools/call` timeout on a blocking consent prompt — i.e. the consent state and its lifetime live in the **orchestrator (`comfyui-mcp`)**, not the panel.

So there is no "existing consent storage mechanism" in the panel to persist. Making the panel a durable consent mirror would require a matching orchestrator protocol change to be honored (otherwise it's dead code on a security-sensitive gate). Flagging for a scope decision — I'd rather not fabricate that here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)