### PR TITLE
fix(get_errors): surface missing node types per-node incl. bypassed/muted + honest clean/summary (#399, #356)

### DIFF
--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -20,6 +20,8 @@ import {
   reconcileUnknownWidgetNames,
   collectAllGraphs,
   reapplyDefsToLiveNodes,
+  collectMissingNodeTypeReasons,
+  graphErrorsResultIsClean,
 } from "../../web/js/lib/asset-staleness.js";
 
 /** The REAL LTXICLoRALoaderModelOnly schema: a `model` CONNECTION input plus two
@@ -441,4 +443,90 @@ test("reconcileUnknownWidgetNames is a no-op when there are no placeholders", ()
     constructor: { nodeData: { input: { required: { seed: {} } } } },
   };
   assert.equal(reconcileUnknownWidgetNames(node), false);
+});
+
+// ---------------------------------------------------------------------------
+// collectMissingNodeTypeReasons — per-node missing-node-type blame (#399)
+// ---------------------------------------------------------------------------
+
+test("collectMissingNodeTypeReasons: blames a node whose type is uninstalled (#399)", () => {
+  const nodes = [
+    { id: 5239, type: "RIFEInterpolation" },
+    { id: 3, type: "KSampler" },
+  ];
+  assert.deepEqual(collectMissingNodeTypeReasons(nodes, ["RIFEInterpolation"]), [
+    { nodeId: 5239, type: "RIFEInterpolation" },
+  ]);
+});
+
+test("collectMissingNodeTypeReasons: surfaces a BYPASSED/MUTED missing node (mode never filters) (#399)", () => {
+  // mode 4 = bypass, mode 2 = mute — the exact case the reporter hit. The helper must
+  // still blame it; graph_get_errors' has_errors-based flagging would otherwise miss it.
+  const nodes = [
+    { id: 5239, type: "RIFEInterpolation", mode: 4 },
+    { id: 7, type: "RIFEInterpolation", mode: 2 },
+  ];
+  assert.deepEqual(collectMissingNodeTypeReasons(nodes, ["RIFEInterpolation"]), [
+    { nodeId: 5239, type: "RIFEInterpolation" },
+    { nodeId: 7, type: "RIFEInterpolation" },
+  ]);
+});
+
+test("collectMissingNodeTypeReasons: matches on comfyClass when type is absent", () => {
+  const nodes = [{ id: 9, comfyClass: "SomeMissingNode" }];
+  assert.deepEqual(collectMissingNodeTypeReasons(nodes, ["SomeMissingNode"]), [
+    { nodeId: 9, type: "SomeMissingNode" },
+  ]);
+});
+
+test("collectMissingNodeTypeReasons: empty for no missing types / no nodes / no match", () => {
+  assert.deepEqual(collectMissingNodeTypeReasons([{ id: 1, type: "KSampler" }], []), []);
+  assert.deepEqual(collectMissingNodeTypeReasons([], ["RIFEInterpolation"]), []);
+  assert.deepEqual(
+    collectMissingNodeTypeReasons([{ id: 1, type: "KSampler" }], ["RIFEInterpolation"]),
+    [],
+  );
+});
+
+test("collectMissingNodeTypeReasons: defensive against malformed inputs (never throws)", () => {
+  assert.deepEqual(collectMissingNodeTypeReasons(null, ["X"]), []);
+  assert.deepEqual(collectMissingNodeTypeReasons([{ id: 1, type: "X" }], null), []);
+  // A node with no type/comfyClass is skipped, not blamed.
+  assert.deepEqual(collectMissingNodeTypeReasons([{ id: 1 }], ["X"]), []);
+});
+
+// ---------------------------------------------------------------------------
+// graphErrorsResultIsClean — honest "errors vs none" for the command summary (#399/#356)
+// ---------------------------------------------------------------------------
+
+test("graphErrorsResultIsClean: TRUE only for a truly empty result", () => {
+  assert.equal(graphErrorsResultIsClean({ errored_count: 0, node_errors: null, last_execution_error: null }), true);
+  assert.equal(graphErrorsResultIsClean({}), true);
+  assert.equal(graphErrorsResultIsClean(null), true);
+});
+
+test("graphErrorsResultIsClean: FALSE for a missing-node-type-ONLY result (bypassed node — #399)", () => {
+  // The exact false-clean the summary label produced: no node_errors / exec error, but
+  // a populated missing_node_types (and errored_count from the attached per-node reason).
+  assert.equal(
+    graphErrorsResultIsClean({
+      errored_count: 1,
+      node_errors: null,
+      last_execution_error: null,
+      missing_node_types: ["RIFEInterpolation"],
+    }),
+    false,
+  );
+});
+
+test("graphErrorsResultIsClean: FALSE for missing_models / missing_media / missing_node_count only", () => {
+  assert.equal(graphErrorsResultIsClean({ missing_models: [{ file: "x.safetensors" }] }), false);
+  assert.equal(graphErrorsResultIsClean({ missing_media: [{ file: "in.png" }] }), false);
+  assert.equal(graphErrorsResultIsClean({ missing_node_count: 2 }), false);
+});
+
+test("graphErrorsResultIsClean: FALSE for raw validation / execution errors", () => {
+  assert.equal(graphErrorsResultIsClean({ node_errors: { 3: { errors: [] } } }), false);
+  assert.equal(graphErrorsResultIsClean({ last_execution_error: { node_id: 5 } }), false);
+  assert.equal(graphErrorsResultIsClean({ errored_count: 2 }), false);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -107,6 +107,8 @@ import {
   isStaleAssetCandidate as isStaleAssetCandidateLib,
   reapplyDefsToLiveNodes,
   refreshComboOptionsFromDefs,
+  collectMissingNodeTypeReasons,
+  graphErrorsResultIsClean,
 } from "./lib/asset-staleness.js";
 import { assertAddNodeResolvableRefreshing } from "./lib/node-resolve.js";
 import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
@@ -6150,6 +6152,23 @@ const GRAPH_TOOL_EXECUTORS = {
       addReason(node_id, { kind: "missing_media", ...rest });
     }
 
+    // 2) Uninstalled node TYPES, attached PER NODE (#399). collectMissingAssets only
+    //    reports the type NAMES at the top level (missing_node_types, above); on their
+    //    own they never land on a node, so a red "node type not installed" node —
+    //    especially a BYPASSED or MUTED one, which LiteGraph may not flag has_errors —
+    //    fell through the union below and graph_get_errors returned a clean, empty state
+    //    that CONTRADICTED the sidebar's own load-time MISSING ASSETS warning. Blame
+    //    every node on the CURRENTLY-VIEWED graph whose type is in the missing set, so it
+    //    surfaces with a missing_node_type reason instead of vanishing. Iterating `nodes`
+    //    covers bypass/mute (mode is never filtered) and mirrors the exact scope of the
+    //    missing_model/missing_media per-node join above — a type nested inside an
+    //    un-entered subgraph is still reported BY NAME at the top level (missing_node_types
+    //    lists it), and gets its per-node reason once the user drills into that subgraph,
+    //    identical to how a subgraph-hosted missing model behaves here.
+    for (const { nodeId, type } of collectMissingNodeTypeReasons(nodes, missingNodeTypes)) {
+      addReason(nodeId, { kind: "missing_node_type", type });
+    }
+
     // 3) Per-node VALIDATION errors from the last queue attempt. `app.lastNodeErrors`
     //    is the classic surface; the execution-error store carries the same map and
     //    outlives some app-level resets, so it's the fallback (verified live: both
@@ -6227,7 +6246,20 @@ const GRAPH_TOOL_EXECUTORS = {
           : { note: "Flagged by LiteGraph but no source explained it — it may be stale; re-run to refresh, or check the node's widget values." }),
       }));
 
-    const clean = !nodeErrors && !lastExecFailure && !erroredNodes.length;
+    // "clean" must reflect EVERY surface, not just per-node/exec errors — a workflow
+    // whose only defect is a missing asset (model/media/node-type) that didn't land on
+    // an erroredNode (e.g. a top-level missing-type count with no mappable node) must
+    // NOT emit the "no errors recorded" note alongside a populated missing_* field
+    // (#399/#356 self-contradiction). Fold the asset surfaces in so the note and the
+    // reported misses can never disagree in one payload.
+    const clean =
+      !nodeErrors &&
+      !lastExecFailure &&
+      !erroredNodes.length &&
+      !missingModels.length &&
+      !missingMedia.length &&
+      !missingNodeTypes.length &&
+      !missingNodeCount;
     return {
       viewing: describeActiveGraph(graph),
       node_count: nodes.length,
@@ -9777,11 +9809,27 @@ function describeCommand(cmd, msg, reply) {
         icon: "pi-search",
         text: `Found ${r.count}${r.truncated ? "+" : ""} of ${r.total} node${r.total === 1 ? "" : "s"}`,
       };
-    case "graph_get_errors":
+    case "graph_get_errors": {
+      // Label from the COMPLETE error surface, not just raw validation/exec fields:
+      // a missing-asset-ONLY result (e.g. a bypassed uninstalled node — #399) carries
+      // neither node_errors nor last_execution_error, so the old check mislabelled it
+      // "none" while the payload actually reported missing_node_types/models/media.
+      if (graphErrorsResultIsClean(r)) {
+        return { icon: "pi-info-circle", text: "Checked errors — none" };
+      }
+      const missingAssets =
+        (r.missing_models?.length || 0) +
+        (r.missing_media?.length || 0) +
+        (r.missing_node_types?.length || 0) +
+        (Number(r.missing_node_count) || 0);
+      const parts = [];
+      if (r.errored_count) parts.push(`${r.errored_count} node${r.errored_count === 1 ? "" : "s"}`);
+      if (missingAssets) parts.push(`${missingAssets} missing asset${missingAssets === 1 ? "" : "s"}`);
       return {
-        icon: "pi-info-circle",
-        text: r.node_errors || r.last_execution_error ? "Read execution errors" : "Checked errors — none",
+        icon: "pi-exclamation-triangle",
+        text: parts.length ? `Found errors — ${parts.join(", ")}` : "Read execution errors",
       };
+    }
     case "free_vram":
       return { icon: "pi-bolt", text: "Unloaded models — freed VRAM" };
     case "workflow_save":

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -223,6 +223,58 @@ export function isStaleAssetCandidate(
   return false;
 }
 
+/**
+ * Blame each LIVE node whose type is one of the uninstalled `missingNodeTypes`. The
+ * missing-nodes store only yields type NAMES; on their own they never land on a node,
+ * so a red "node type not installed" node — INCLUDING a bypassed/muted one that
+ * LiteGraph may not flag `has_errors` — otherwise vanishes from graph_get_errors,
+ * which then reports a falsely-clean state that contradicts the sidebar's own
+ * load-time MISSING ASSETS warning (#399). This maps the type names back onto the
+ * actual node ids so each such node surfaces with a `missing_node_type` reason.
+ * Iterates EVERY node regardless of mode (bypass/mute never filtered). Returns
+ * `[{ nodeId, type }, ...]`. Fully defensive — a malformed node/list yields fewer
+ * (never throws).
+ */
+export function collectMissingNodeTypeReasons(nodes, missingNodeTypes) {
+  const out = [];
+  try {
+    if (!Array.isArray(nodes) || !nodes.length) return out;
+    const set = new Set(Array.isArray(missingNodeTypes) ? missingNodeTypes : []);
+    if (!set.size) return out;
+    for (const n of nodes) {
+      const t = n?.type ?? n?.comfyClass;
+      if (t != null && set.has(t)) out.push({ nodeId: n.id, type: t });
+    }
+  } catch {
+    /* best-effort — partial mapping is better than none */
+  }
+  return out;
+}
+
+/**
+ * True when a `graph_get_errors` RESULT payload represents a genuinely CLEAN graph —
+ * no per-node validation errors, no execution failure, no errored nodes, AND no
+ * missing-asset surface of ANY kind (models / media / node-types / node-count). Every
+ * consumer that summarizes the result — the command-summary label, banners, etc. —
+ * must derive "errors vs none" from THIS, so a missing-asset-ONLY result (e.g. a red or
+ * BYPASSED uninstalled node, #399/#356) is never labelled "none" while its own payload
+ * carries a populated missing_* / errored_count field. Fully defensive: an absent or
+ * non-object result is treated as clean.
+ */
+export function graphErrorsResultIsClean(result) {
+  if (!result || typeof result !== "object") return true;
+  const len = (v) => (Array.isArray(v) ? v.length : 0);
+  return (
+    !result.node_errors &&
+    !result.last_execution_error &&
+    !(Number(result.errored_count) > 0) &&
+    !len(result.missing_models) &&
+    !len(result.missing_media) &&
+    !len(result.missing_node_types) &&
+    !(Number(result.missing_node_count) > 0)
+  );
+}
+
 // Input types that ComfyUI renders as a WIDGET rather than a connection socket.
 // A combo (the type spec is an array of option values) is also a widget.
 const WIDGET_INPUT_TYPES = new Set(["INT", "FLOAT", "STRING", "BOOLEAN", "COMBO"]);


### PR DESCRIPTION
## Issue
Fixes **#399** — `panel_get_errors` returned `errored_count:0, nodes:[], "no errors recorded"` for a workflow whose only defect was an uninstalled node type (`RIFEInterpolation`), even though the sidebar load-time MISSING ASSETS warning correctly named it and the node sat red (and bypassed) on the canvas.

## Root cause (verify-first)
Top-level `missing_node_types` was already merged into `graph_get_errors` (#444), but a missing node type never landed **on a node**, so a red "type not installed" node — especially a **bypassed/muted** one LiteGraph doesn't flag `has_errors` — fell through the errored-node union. Worse, the `clean` decision and the `describeCommand` summary label both ignored the missing-asset surfaces, so the payload said "no errors recorded" / "Checked errors — none" **while** carrying a populated `missing_node_types` field — the same self-contradiction class #356 (Bug 1) flags.

## Fix
- **Per-node attribution** (`web/js/lib/asset-staleness.js` → `collectMissingNodeTypeReasons`): blame every node on the currently-viewed graph whose type is uninstalled — **including bypassed/muted** (mode is never filtered) — attaching a `missing_node_type` reason. Mirrors the exact scope of the existing `missing_model`/`missing_media` per-node joins; a type nested in an un-entered subgraph is still reported by name via the top-level `missing_node_types` array.
- **Honest `clean`** (`graph_get_errors`): fold `missing_models`/`media`/`node_types`/`node_count` into the decision so the "no errors recorded" note can never accompany a populated `missing_*` field.
- **Honest summary** (`describeCommand`): new `graphErrorsResultIsClean()` derives errors-vs-none from the **complete** surface, so a missing-asset-only result is no longer labelled "Checked errors — none".

Execution/validation-error **sourcing is intentionally unchanged** from shipped behavior — that pre-existing store-fallback logic is out of scope for these issues.

## On #356
Bug 1 (stale `missing_model` after `set_widget`) was already resolved upstream by the shipped live-recompute (#316/#339/#260) and is covered by existing tests; this PR hardens the adjacent `clean`/summary honesty. **Bug 2** (dropped `panel_run` completion notification) is a separate defect and is **not** addressed here, so #356 is referenced, not closed.

## Tests
`browser_tests/unit/asset-staleness.test.mjs` — +9 unit tests (`collectMissingNodeTypeReasons` incl. bypass/mute + `comfyClass` + defensive; `graphErrorsResultIsClean` across every surface). **Full panel unit suite: 836 passing.**

## Codex self-gate
`gpt-5.6-terra` adversarial review (embed-diff, working-tree): **APPROVE — no material findings**, within the documented viewed-graph scope. Several earlier mediums were found and fixed (per-node/summary honesty) or scoped out (pre-existing exec-error store-fallback sourcing reverted to shipped behavior).

Closes #399
Relates to #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)