### PR TITLE
fix(panel): PLAN box shows false activity when the agent is idle (#492)

### DIFF
--- a/browser_tests/unit/plan-glyph.test.mjs
+++ b/browser_tests/unit/plan-glyph.test.mjs
@@ -1,0 +1,42 @@
+// Unit tests for the "PLAN" box false-activity fix (issue #492).
+//
+// The reporter loaded a workflow, went off to download models by hand, and the
+// agent's PLAN box "showed activity when none was happening" — a circle widget
+// that kept turning after the agent had stopped. Root cause: the plan is pushed
+// via `set_todo` and PERSISTED on the thread, so the step that was "active" when
+// a turn ended stayed "active", and the tray unconditionally painted an "active"
+// step with the SPINNING glyph. The spinner must instead reflect whether the
+// agent is actually working right now.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { todoItemGlyph } from "../../web/js/lib/plan-glyph.js";
+
+const SPINNER = "pi-spin pi-spinner";
+const IDLE_ACTIVE = "pi-circle-fill";
+
+test("active step spins ONLY while the agent is working", () => {
+  assert.equal(todoItemGlyph("active", true), SPINNER);
+});
+
+test("active step does NOT spin when the agent is idle (the #492 false-activity bug)", () => {
+  // This is the core regression: a persisted 'active' step, agent stopped.
+  assert.equal(todoItemGlyph("active", false), IDLE_ACTIVE);
+  assert.notEqual(todoItemGlyph("active", false), SPINNER);
+});
+
+test("done and pending steps never spin, regardless of working state", () => {
+  for (const working of [true, false]) {
+    assert.equal(todoItemGlyph("done", working), "pi-check-circle");
+    assert.equal(todoItemGlyph("pending", working), "pi-circle");
+    // Unknown/blank status falls back to the hollow (pending) circle — never a spinner.
+    assert.equal(todoItemGlyph(undefined, working), "pi-circle");
+    assert.equal(todoItemGlyph("", working), "pi-circle");
+  }
+});
+
+test("no status ever yields a spinner while idle — the whole box is quiet", () => {
+  for (const status of ["active", "done", "pending", undefined, "weird"]) {
+    assert.notEqual(todoItemGlyph(status, false), SPINNER);
+  }
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -111,6 +111,7 @@ import {
 import { assertAddNodeResolvableRefreshing } from "./lib/node-resolve.js";
 import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
 import { reconcileCompletedDownloads } from "./lib/download-refresh.js";
+import { todoItemGlyph } from "./lib/plan-glyph.js";
 import {
   resolveScope,
   describeScope,
@@ -10934,8 +10935,12 @@ function buildPanel() {
         const row = document.createElement("div");
         row.className = "cmcp-todo-item " + status;
         const icon = document.createElement("i");
-        icon.className =
-          "pi " + (status === "done" ? "pi-check-circle" : status === "active" ? "pi-spin pi-spinner" : "pi-circle");
+        // #492: the "active" step only SPINS while the agent is actually working.
+        // set_todo persists the plan on the thread, so a step left "active" when a
+        // turn ends (or is stopped) would otherwise keep its spinner turning forever
+        // — the box "shows activity when none is happening". Between turns / on idle
+        // the current step is a static filled dot ("you are here"), not motion.
+        icon.className = "pi " + todoItemGlyph(status, agentWorking);
         const txt = document.createElement("span");
         txt.textContent = (it && it.text) || "";
         row.append(icon, txt);
@@ -14492,6 +14497,9 @@ function buildPanel() {
     thinkingTokens = 0; // reset so the next turn doesn't show a stale count
     thinkingAction = null;
     thinkingReconnecting = false;
+    // #492: the plan tray's "active" spinner mirrors real agent activity — the
+    // turn just stopped (done / interrupt / disconnect), so repaint it static.
+    renderTray();
   }
 
   // A user-initiated local stop (Esc / Ctrl+C, or discarding the last turn).
@@ -14523,6 +14531,8 @@ function buildPanel() {
     cycleWord();
     if (!workWordTimer) workWordTimer = setInterval(cycleWord, 2600);
     ensureSafety(); // DOM rebuild — don't postpone the budget check
+    // #492: a turn is now live → let the plan tray's "active" step spin.
+    renderTray();
     scrollLog();
   }
 

--- a/web/js/lib/plan-glyph.js
+++ b/web/js/lib/plan-glyph.js
@@ -1,0 +1,21 @@
+// Plan-tray ("PLAN" box) icon selection — extracted as a pure function so the
+// false-activity fix (issue #492) is unit-testable without a DOM.
+//
+// The agent's live plan is pushed via `set_todo` and PERSISTED on the thread, so
+// whatever step was "active" when a turn ended stays "active" in the stored data.
+// The tray must not paint that as a spinning ("working") glyph once the turn is
+// over — the reporter saw the "PLAN" box "show activity when none is happening"
+// (a circle widget that "continues turning") after the agent had stopped.
+//
+// Rule: a step only SPINS while the agent is actually working (`agentWorking`).
+//   - done            → check    (pi-check-circle)
+//   - active + working → spinner  (pi-spin pi-spinner)  ← real, live motion
+//   - active + idle    → filled dot (pi-circle-fill)    ← "you are here", static
+//   - pending          → hollow circle (pi-circle)
+//
+// Returns the PrimeIcons class string for the leading <i> of a todo row.
+export function todoItemGlyph(status, agentWorking) {
+  if (status === "done") return "pi-check-circle";
+  if (status === "active") return agentWorking ? "pi-spin pi-spinner" : "pi-circle-fill";
+  return "pi-circle";
+}


### PR DESCRIPTION
Closes artokun/comfyui-mcp#492

## The bug
The agent's **"PLAN"** box (the todo/plan checklist tray) showed a spinning "circle widget" that kept turning even when the agent was idle. Real repro from the reporter: they loaded a workflow, went off to download models by hand, asked the agent to stop — it did — but the PLAN box kept showing a turning download-looking spinner "so it looks like it's downloading."

**Root cause:** the plan is pushed by the agent via `set_todo` and **persisted on the conversation thread**. A step with status `active` renders the spinning glyph (`pi-spin pi-spinner`). Because the persisted plan keeps its last `active` step after a turn ends, the spinner kept turning forever — decoupled from whether the agent is actually running. Switching workflows/threads just repaints that same stale `active` step.

## The fix
Make the spinner reflect **real** agent activity (`agentWorking`), not the persisted plan state:

- Extracted the tray glyph selection into a pure, unit-testable module `web/js/lib/plan-glyph.js` — `todoItemGlyph(status, agentWorking)`:
  - `active` **+ working** → `pi-spin pi-spinner` (real live motion)
  - `active` **+ idle** → `pi-circle-fill` (static "you are here" dot, no motion)
  - `done` → `pi-check-circle`, `pending`/unknown → `pi-circle`
- `renderTray()` now uses that helper, and repaints at the working↔idle transitions (inside `showThinking()` / `hideThinking()`), so the spinner stops the instant a turn ends (`turn:done`, local interrupt, or disconnect) and starts when a turn begins.
- Added `browser_tests/unit/plan-glyph.test.mjs` (the core regression: a persisted `active` step with the agent idle must NOT spin).

## Design note (left for the maintainer)
The issue's other half — *"the PLAN box takes up valuable real estate"* — is a **layout/collapsibility preference**, not a bug, so I did **not** restructure the layout. The tray already auto-hides entirely when there's no plan/downloads/pending. Whether to further collapse/relocate it when non-empty is a maintainer design decision.

## Verification
- `node --check` clean on all three files.
- `npm run test:unit` → **913 passing** (4 new).
- Codex adversarial self-gate (gpt-5.6-terra / high): **VERDICT: PASS** — confirmed no idle-spin path remains, both transitions repaint, no TDZ/ordering hazard from calling `renderTray()` inside `show/hideThinking()`, and done/pending behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)