### PR TITLE
fix(copy): warn at copy time when copied nodes can't round-trip (#286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- **`panel_copy_nodes` no longer reports a clean copy that can't round-trip (#286).** When a workflow's custom-node packs aren't installed, copying those nodes used to return a bare `copied: N` even though a later paste silently drops every unregistered type (the packs aren't registered on this frontend, so `LiteGraph.createNode` returns null). `graph_copy_nodes` now checks the copied selection against the frontend's registered node types up front and returns `unregistered_types` + a `warning` naming exactly which types won't paste — so an agent knows before it builds an incomplete graph, complementing the paste-side drop report shipped in #261.
+
 ## [0.11.24] - 2026-08-01
 
 ### Added

--- a/browser_tests/unit/paste-report.test.mjs
+++ b/browser_tests/unit/paste-report.test.mjs
@@ -21,6 +21,9 @@ import {
   parseClipboardNodes,
   diffCopiedVsPasted,
   formatDroppedWarning,
+  unregisteredCopiedTypes,
+  registryTypePredicate,
+  formatUnpasteableCopyWarning,
 } from "../../web/js/lib/paste-report.js";
 
 // A trimmed but realistic slice of the wan-multitalk clipboard: live LiteGraph
@@ -219,4 +222,93 @@ test("stale snapshot + native copy of a DIFFERENT selection does NOT fabricate d
   const pastedB = [pastedNode(50, "SaveImage"), pastedNode(51, "CLIPTextEncode")];
   const { dropped_count } = diffCopiedVsPasted(staleSnapshotA, pastedB, isRegistered);
   assert.equal(dropped_count, 0);
+});
+
+// ---- #286: copy-time round-trip check ------------------------------------
+// graph_copy_nodes must not report a clean copy when some copied nodes can't
+// round-trip. On the SAME frontend, an unregistered type (uninstalled custom
+// pack) is exactly what a later paste silently drops — so copy warns up front.
+
+test("unregisteredCopiedTypes flags copied types missing from the frontend registry", () => {
+  // #286 shape: a workflow with uninstalled packs — KSampler is registered,
+  // WanVideoSampler / AudioCrop are not (packs not installed).
+  const registered = new Set(["KSampler", "VAEDecode"]);
+  const isRegistered = (t) => registered.has(t);
+  const copied = new Set([
+    liveNode(1, "KSampler"),
+    liveNode(2, "WanVideoSampler"),
+    liveNode(3, "AudioCrop"),
+    liveNode(4, "VAEDecode"),
+  ]);
+  assert.deepEqual(unregisteredCopiedTypes(copied, isRegistered), [
+    "WanVideoSampler",
+    "AudioCrop",
+  ]);
+});
+
+test("unregisteredCopiedTypes de-dupes per type and returns [] when all round-trip", () => {
+  const registered = new Set(["KSampler"]);
+  const isRegistered = (t) => registered.has(t);
+  // All registered → empty.
+  assert.deepEqual(
+    unregisteredCopiedTypes([liveNode(1, "KSampler"), liveNode(2, "KSampler")], isRegistered),
+    [],
+  );
+  // Two nodes of the same unregistered type collapse to one entry.
+  assert.deepEqual(
+    unregisteredCopiedTypes(
+      [liveNode(1, "AudioCrop"), liveNode(2, "AudioCrop"), liveNode(3, "KSampler")],
+      isRegistered,
+    ),
+    ["AudioCrop"],
+  );
+});
+
+test("unregisteredCopiedTypes ignores groups/typeless items and a missing predicate", () => {
+  const isRegistered = () => false;
+  const items = new Set([liveNode(1, "AudioCrop"), { id: null, title: "grp" }, { id: 9 }]);
+  assert.deepEqual(unregisteredCopiedTypes(items, isRegistered), ["AudioCrop"]);
+  // No predicate → we can't prove anything unregistered → empty (never a false warning).
+  assert.deepEqual(unregisteredCopiedTypes(items, undefined), []);
+});
+
+test("registryTypePredicate returns undefined for a missing/empty registry, a working predicate otherwise", () => {
+  // Missing / non-object → undefined (no usable registry, never fabricate drops).
+  assert.equal(registryTypePredicate(undefined), undefined);
+  assert.equal(registryTypePredicate(null), undefined);
+  assert.equal(registryTypePredicate("nope"), undefined);
+  // EMPTY registry (frontend not loaded) → undefined. This is the #286 P2: the
+  // executor must NOT flag every copied node as "will be dropped" when the
+  // registry didn't load. Feeding the result into unregisteredCopiedTypes yields [].
+  assert.equal(registryTypePredicate({}), undefined);
+  assert.deepEqual(
+    unregisteredCopiedTypes(
+      [liveNode(1, "KSampler"), liveNode(2, "AudioCrop")],
+      registryTypePredicate({}),
+    ),
+    [],
+  );
+  // Populated registry → predicate that reports only genuinely-unregistered types.
+  const pred = registryTypePredicate({ KSampler: {}, VAEDecode: {} });
+  assert.equal(typeof pred, "function");
+  assert.equal(pred("KSampler"), true);
+  assert.equal(pred("AudioCrop"), false);
+  assert.deepEqual(
+    unregisteredCopiedTypes(
+      [liveNode(1, "KSampler"), liveNode(2, "AudioCrop")],
+      registryTypePredicate({ KSampler: {}, VAEDecode: {} }),
+    ),
+    ["AudioCrop"],
+  );
+});
+
+test("formatUnpasteableCopyWarning summarizes the un-round-trippable types (or null)", () => {
+  assert.equal(formatUnpasteableCopyWarning([]), null);
+  assert.equal(formatUnpasteableCopyWarning(null), null);
+  const one = formatUnpasteableCopyWarning(["AudioCrop"]);
+  assert.match(one, /1 copied node type is not registered/);
+  assert.match(one, /AudioCrop/);
+  const many = formatUnpasteableCopyWarning(["AudioCrop", "AudioSeparation"]);
+  assert.match(many, /2 copied node types are not registered/);
+  assert.match(many, /AudioCrop, AudioSeparation/);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -146,6 +146,9 @@ import {
   parseClipboardNodes,
   diffCopiedVsPasted,
   formatDroppedWarning,
+  unregisteredCopiedTypes,
+  registryTypePredicate,
+  formatUnpasteableCopyWarning,
 } from "./lib/paste-report.js";
 import { createMediaRecorder } from "./lib/chat-media.js";
 import { createLightboxModel } from "./lib/lightbox-gallery.js";
@@ -6920,7 +6923,7 @@ const GRAPH_TOOL_EXECUTORS = {
   // no ids: copy the current canvas selection. The clipboard survives a workflow
   // switch, so the next graph_paste_nodes can drop them into a DIFFERENT workflow.
   graph_copy_nodes({ node_ids } = {}) {
-    const { graph, canvas } = getGraphCtx();
+    const { graph, canvas, LG } = getGraphCtx();
     if (!canvas) throw new Error("canvas unavailable");
     if (typeof canvas.copyToClipboard !== "function") {
       throw new Error("copyToClipboard unavailable on this frontend");
@@ -6954,7 +6957,22 @@ const GRAPH_TOOL_EXECUTORS = {
       /* localStorage unavailable — snapshot stays unverifiable, never trusted */
     }
     recordCopiedNodes(selected, fingerprint);
-    return { copied: count };
+    // #286: never report a clean copy that can't round-trip. Any copied node
+    // whose type is unregistered on THIS frontend (uninstalled custom-node pack)
+    // will be silently dropped by a later paste — the destination is the same
+    // frontend, so that's knowable now. Surface it here instead of only warning
+    // after the paste has already produced an incomplete graph.
+    // Only judge round-trippability when a USABLE registry exists — if it's
+    // missing/empty (frontend not fully loaded) registryTypePredicate returns
+    // undefined and we report nothing rather than falsely flagging every node.
+    const isRegisteredType = registryTypePredicate(LG?.registered_node_types);
+    const unregistered = unregisteredCopiedTypes(selected, isRegisteredType);
+    const result = { copied: count };
+    if (unregistered.length) {
+      result.unregistered_types = unregistered;
+      result.warning = formatUnpasteableCopyWarning(unregistered);
+    }
+    return result;
   },
 
   // Paste the litegraph clipboard onto the CURRENT graph. Snapshots node ids

--- a/web/js/lib/paste-report.js
+++ b/web/js/lib/paste-report.js
@@ -139,6 +139,65 @@ export function diffCopiedVsPasted(copied, pasted, isRegisteredType) {
   return { dropped, dropped_count: dropped.length, dropped_types };
 }
 
+/**
+ * The DISTINCT node types among the copied items that are NOT registered on the
+ * current frontend — i.e. exactly the types a subsequent paste will silently
+ * DROP (LiteGraph.createNode returns null for an unregistered type). Empty array
+ * when every copied type round-trips.
+ *
+ * #286: a workflow loaded with uninstalled custom-node packs can be copied whole
+ * (`graph_copy_nodes` reports `copied: 47`), but paste later drops the 25 nodes
+ * whose packs aren't installed. Because the destination frontend is the SAME one
+ * doing the copy, the round-trip-ability is knowable AT COPY TIME — so copy can
+ * warn instead of silently promising a clean copy that can't round-trip. Order
+ * is first-seen; each type appears once.
+ *
+ * @param {Iterable<{id?:any,type?:string}>|Set} items  copied selection
+ * @param {(type:string)=>boolean} isRegisteredType  true if type is a known node class
+ * @returns {string[]} distinct unregistered node types (empty if all round-trip)
+ */
+export function unregisteredCopiedTypes(items, isRegisteredType) {
+  if (typeof isRegisteredType !== "function") return [];
+  const seen = new Set();
+  const out = [];
+  for (const it of normalizeCopiedItems(items)) {
+    if (!isRegisteredType(it.type) && !seen.has(it.type)) {
+      seen.add(it.type);
+      out.push(it.type);
+    }
+  }
+  return out;
+}
+
+/**
+ * Build the `isRegisteredType` predicate for {@link unregisteredCopiedTypes} from
+ * a LiteGraph registry object (`LiteGraph.registered_node_types`), or `undefined`
+ * when no USABLE registry exists — missing, not an object, or EMPTY.
+ *
+ * The empty/missing case is the important one (#286): if the frontend's registry
+ * hasn't loaded, a bare `{}` predicate would report EVERY copied type as
+ * unregistered and warn it "will be DROPPED" — a false alarm on a copy that may
+ * paste back fine. Returning `undefined` makes unregisteredCopiedTypes fall back
+ * to its no-predicate safety (it reports nothing), so we only ever warn when we
+ * have a real registry to prove a type genuinely isn't registered.
+ */
+export function registryTypePredicate(registry) {
+  if (!registry || typeof registry !== "object") return undefined;
+  if (Object.keys(registry).length === 0) return undefined;
+  return (t) => Object.prototype.hasOwnProperty.call(registry, t);
+}
+
+/** Human-readable one-liner warning for copied node types that cannot round-trip
+ *  (they'll be dropped on paste), or null when the list is empty. */
+export function formatUnpasteableCopyWarning(types) {
+  if (!types || !types.length) return null;
+  return (
+    `${types.length} copied node type${types.length > 1 ? "s are" : " is"} not registered on ` +
+    `this ComfyUI frontend and will be DROPPED on paste (install the pack that provides ` +
+    `${types.length > 1 ? "them" : "it"}, then re-copy): ${types.join(", ")}`
+  );
+}
+
 /** Human-readable one-liner for a dropped-node report, or null if none. */
 export function formatDroppedWarning(dropped) {
   if (!dropped || !dropped.length) return null;


### PR DESCRIPTION
## #286 — `panel_copy_nodes` reports all nodes copied but paste silently drops unavailable custom nodes

Closes artokun/comfyui-mcp-panel#286

### Root cause
`graph_copy_nodes` returned a bare `{copied: N}` even when the workflow contained custom-node types whose packs aren't installed. A later `graph_paste_nodes` then silently **drops** every unregistered type (`LiteGraph.createNode` returns null for a type that isn't a registered node class), leaving an incomplete graph with broken connections — exactly the reported "copied 47, pasted 22" scenario.

The **paste-side** drop report already exists (#261, ships `dropped_nodes`/`warning`). The residual gap #286 calls out is the **copy side**: *"Never report a successful copy that cannot round-trip."* Because the paste destination is the SAME frontend, un-round-trippability is knowable at copy time.

### Fix
`graph_copy_nodes` now checks the copied selection against the frontend's `registered_node_types` and, when any copied type is unregistered, returns `unregistered_types` + a human-readable `warning` naming exactly which types won't paste — so an agent knows *before* it builds an incomplete graph. Complements the paste-side report.

Registry safety (caught in adversarial review): the round-trip check only runs when a **usable** registry exists. New exported `registryTypePredicate(registry)` returns `undefined` for a missing / non-object / **empty** registry (frontend not fully loaded), so a copy on a stub/unloaded frontend can never falsely flag every node as "will be dropped".

### Tests / verification
- New pure-helper unit tests in `browser_tests/unit/paste-report.test.mjs` (18 pass): `unregisteredCopiedTypes` (flagging, de-dup, typeless/missing-predicate safety), `registryTypePredicate` (missing/empty → undefined; populated → genuine misses only), `formatUnpasteableCopyWarning`.
- Full panel unit suite green (831); `tsc --noEmit` clean.
- Adversarial codex review (gpt-5.6-terra/high): **PASS** (the round-1 P2 on empty-registry false-flagging is fixed by `registryTypePredicate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)