### PR TITLE
fix(panel): soft-reload no longer wedges the bridge; harden the reconnect race (#379)

### DIFF
--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -8,6 +8,7 @@ import assert from "node:assert/strict";
 import {
   shouldResumeAfterComfyReconnect,
   shouldRehelloAfterCommand,
+  planSoftReloadRecovery,
   isTransientReconnectError,
   retryDuringReconnect,
   workflowTabKey,
@@ -253,4 +254,42 @@ test("#296: comfyui_path is omitted (never blank) when unknown", () => {
 test("#296: resume rides the hello only when present", () => {
   assert.equal("resume" in buildHelloPayload({ tabId: "t" }), false);
   assert.equal(buildHelloPayload({ tabId: "t", resume: "sess-1" }).resume, "sess-1");
+});
+
+// ---- #379 soft-reload recovery: never leave the bridge dead -----------------
+
+test("#379: a REFUSED reload (by-design 503) still reconnects, dropping the interlock", () => {
+  // This pack's /reload returns { ok:false } — the orchestrator never stops.
+  const plan = planSoftReloadRecovery({ ok: false, reachable: true });
+  assert.equal(plan.accepted, false);
+  assert.equal(plan.reconnect, true); // bridge MUST be restored — no wedge
+  assert.equal(plan.keepResumeInterlock, false); // no respawn to interlock
+});
+
+test("#379: an unreachable reload POST still reconnects the dropped bridge", () => {
+  const plan = planSoftReloadRecovery({ ok: true, reachable: false });
+  assert.equal(plan.accepted, false);
+  assert.equal(plan.reconnect, true);
+  assert.equal(plan.keepResumeInterlock, false);
+});
+
+test("#379: an ACCEPTED reload keeps the resume interlock and reconnects", () => {
+  // A pack that DOES own the orchestrator: reload accepted → keep SOFT_RELOAD_KEY
+  // + guard so the fresh orchestrator binds and onAck resumes the conversation.
+  const plan = planSoftReloadRecovery({ ok: true, reachable: true });
+  assert.equal(plan.accepted, true);
+  assert.equal(plan.reconnect, true);
+  assert.equal(plan.keepResumeInterlock, true);
+});
+
+test("#379: reconnect is unconditional across every outcome (no dead-bridge path)", () => {
+  for (const ok of [true, false]) {
+    for (const reachable of [true, false]) {
+      assert.equal(planSoftReloadRecovery({ ok, reachable }).reconnect, true);
+    }
+  }
+  // Defaults are the safe path: refused + reconnect.
+  const d = planSoftReloadRecovery();
+  assert.equal(d.reconnect, true);
+  assert.equal(d.keepResumeInterlock, false);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -164,6 +164,7 @@ import { queueMembership, historyEntryFor } from "./lib/history-reconcile.js";
 import {
   shouldResumeAfterComfyReconnect,
   shouldRehelloAfterCommand,
+  planSoftReloadRecovery,
   retryDuringReconnect,
   dedupeWorkflowTabRecords,
   resolveLoadGraphArgs,
@@ -1094,6 +1095,9 @@ const REBOOT_KEY = "comfyui-mcp.panel.rebootResume";
 // agent-triggered reload mid-task — nudge it to continue. Survives the bridge
 // drop via sessionStorage.
 const SOFT_RELOAD_KEY = "comfyui-mcp.panel.softReloadResume";
+// Upper bound on the soft-reload POST so a hung /reload handler can't wedge the
+// reconnect (the await must always settle → client.start() always runs). #379.
+const RELOAD_POST_TIMEOUT_MS = 10000;
 // Set while the agent is mid-turn (working), cleared when the turn finishes. If
 // the connection drops while it's set — an UNEXPECTED bounce (another agent
 // rebooting ComfyUI, a crash, an SDK self-heal) — the reconnect nudges the
@@ -8178,8 +8182,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     // on each background retry — that latched "disconnected" is what stops the
     // connecting↔disconnected flicker.
     if (!gaveUp) emitStatus("connecting");
+    let thisSock;
     try {
-      sock = new WebSocket(url);
+      thisSock = new WebSocket(url);
     } catch (err) {
       // Constructor threw before a socket exists → no open/close will fire, so we
       // drive the retry directly. Keep the status steady (scheduleReconnect decides
@@ -8187,8 +8192,21 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       scheduleReconnect();
       return;
     }
+    sock = thisSock;
 
-    sock.addEventListener("open", () => {
+    // INSTANCE GUARD (panel #379 race): every listener below is bound to THIS socket
+    // instance and no-ops unless it is still the active `sock`. A soft-reload / restart
+    // does stop()→start() (drop the old socket, open a new one); the OLD socket's
+    // asynchronous `close`/`open`/`message` can arrive AFTER the new socket is assigned.
+    // Without this guard the stale `close` handler would `sock = null` the FRESH socket
+    // (and scheduleReconnect), leaving the new socket unable to send its hello — an
+    // unhandshaken, untracked connection plus a duplicate reconnect. Now on the hot
+    // path because this pack's /reload is a by-design 503, so every soft reload
+    // reconnects. Guarding by instance makes a superseded socket's events inert.
+    const isActive = () => sock === thisSock;
+
+    thisSock.addEventListener("open", () => {
+      if (!isActive()) return; // superseded socket — ignore its late open
       handshakeDone = false;
       // A bare WS open is NOT progress — the orchestrator handshake (`models`)
       // hasn't arrived yet. Do NOT reset attempt/gaveUp here (only markConnected
@@ -8207,6 +8225,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       clearHandshake();
       handshakeTimer = setTimeout(() => {
         if (handshakeDone) return;
+        // A SUPERSEDED socket's stale handshake timer must not drive recovery against
+        // the replacement connection (onHandshakeTimeout can setUrl/redial or trigger
+        // a reclaim). Only the still-active socket's timeout is real. (stop() also
+        // clears this timer now, but a socket replaced by a fast reconnect can leave a
+        // timer armed between stop and the next open.)
+        if (!isActive()) return;
         // The WS is OPEN but no orchestrator handshake (models frame) arrived
         // within the generous cold-start window. Two causes: (1) a WEDGED
         // orchestrator — alive, bridge up, agent dead — or (2) some non-orchestrator
@@ -8223,7 +8247,8 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       }, handshakeMs());
     });
 
-    sock.addEventListener("message", async (ev) => {
+    thisSock.addEventListener("message", async (ev) => {
+      if (!isActive()) return; // superseded socket — ignore its late frames
       let msg;
       try {
         msg = JSON.parse(typeof ev.data === "string" ? ev.data : "");
@@ -8394,8 +8419,15 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             error: coerceMessageText(err?.message ?? err),
           };
         }
+        // A command executor can be ASYNC (ask_user/request_secret block on the user;
+        // graph run/save await). If a soft-reload/restart swapped this socket out while
+        // we were suspended, this reply belongs to the DEAD session A — it must NOT be
+        // injected into the fresh session B (whose sock the global now points at), and
+        // its activity card must not paint. Drop the whole continuation, and always send
+        // the reply on THIS socket (never the mutable global), only while it's open.
+        if (!isActive()) return;
         try {
-          sock.send(JSON.stringify(reply));
+          if (thisSock.readyState === WebSocket.OPEN) thisSock.send(JSON.stringify(reply));
         } catch {
           // Socket died between receive and reply — agent side times out.
         }
@@ -8556,7 +8588,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // "echo" frames are ignored — we render the user bubble locally on send.
     });
 
-    sock.addEventListener("close", () => {
+    thisSock.addEventListener("close", () => {
+      // A SUPERSEDED socket closing must NOT touch the fresh connection: don't null
+      // the active `sock`, don't reject its pending calls, don't scheduleReconnect
+      // (that would orphan the new socket and spawn a duplicate). Just let it die.
+      if (!isActive()) return;
       sock = null;
       handshakeDone = false;
       // Fail any in-flight direct tool calls — the reply can never arrive now.
@@ -8575,7 +8611,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       }
     });
 
-    sock.addEventListener("error", () => {
+    thisSock.addEventListener("error", () => {
       // close fires after error; reconnect handled there.
     });
   }
@@ -8858,6 +8894,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         clearTimeout(reconnectTimer);
         reconnectTimer = null;
       }
+      // Cancel the shared handshake timer so a stopped-before-handshake socket can't
+      // fire onHandshakeTimeout against a later reconnect (#379 race hardening).
+      clearHandshake();
       try {
         sock?.close();
       } catch {}
@@ -16098,24 +16137,51 @@ function buildPanel() {
     appendSystem("Soft-reloading the agent (new code, no ComfyUI restart)…");
     try {
       client.stop(); // drop the bridge so the old orchestrator can release the port
-      const res = await api.fetchApi("/comfyui_mcp_panel/reload", { method: "POST" });
+      // Bound the POST: a hung ComfyUI handler / stalled network would otherwise never
+      // settle, so the await never returns, `reloading` stays true, and client.start()
+      // below is never reached — a permanent wedge (codex). On timeout we reject into
+      // the catch, which clears the interlock and reconnects the dropped bridge.
+      const res = await Promise.race([
+        api.fetchApi("/comfyui_mcp_panel/reload", { method: "POST" }),
+        new Promise((_resolve, reject) =>
+          setTimeout(() => reject(new Error("reload request timed out")), RELOAD_POST_TIMEOUT_MS),
+        ),
+      ]);
       const data = await res.json().catch(() => ({}));
-      if (!data?.ok) {
+      const plan = planSoftReloadRecovery({ ok: data?.ok, reachable: true });
+      if (!plan.keepResumeInterlock) {
+        // Reload REFUSED. This pack's /reload route is a by-design 503: the
+        // orchestrator runs out-of-band and never stopped — only our bridge socket
+        // did (client.stop above). We do NOT own a respawn, so stand the interlock
+        // down and reconnect the dropped bridge (below) instead of leaving the
+        // panel wedged "connected chip / dead bridge" (#379). The old code told the
+        // user to restart a healthy orchestrator; surface that only as an OPTIONAL
+        // "load new code" hint, not a required recovery step.
         ssSet(SOFT_RELOAD_KEY, null);
-        clearSoftReloadGuard(); // never started respawning → re-enable auto-respawn
-        appendSystem(data?.message || "Soft reload failed — try Disconnect then Connect.");
-        return;
+        clearSoftReloadGuard();
+        const cmd = typeof data?.start_command === "string" ? data.start_command.trim() : "";
+        appendSystem(
+          "Reconnecting the panel bridge…" +
+            (cmd ? `\n(To load new orchestrator code, restart it manually: ${cmd})` : ""),
+        );
       }
     } catch (err) {
+      // Couldn't even reach the reload route. The orchestrator may still be alive,
+      // so stand the interlock down and reconnect the dropped bridge (below) rather
+      // than leaving it dead (#379).
       ssSet(SOFT_RELOAD_KEY, null);
-      clearSoftReloadGuard(); // POST failed → re-enable auto-respawn
-      appendSystem(`Couldn't reach ComfyUI to reload the agent: ${coerceMessageText(err?.message ?? err)}`);
-      return;
+      clearSoftReloadGuard();
+      appendSystem(
+        `Couldn't reach ComfyUI to reload the agent — reconnecting the bridge: ${coerceMessageText(err?.message ?? err)}`,
+      );
     } finally {
       reloading = false;
     }
-    // Reconnect with backoff until the fresh orchestrator binds; onAck resumes. The
-    // soft-reload guard keeps auto-respawn from racing this backoff window.
+    // Reconnect EITHER WAY (mirrors hardRestart, #379): on an accepted reload the
+    // guard/SOFT_RELOAD_KEY are still set so the fresh orchestrator binds and onAck
+    // resumes; on a refused/failed reload the interlock was cleared above and this
+    // restores the bridge we dropped against the still-running orchestrator — the
+    // panel never wedges "connected but dead".
     client.start();
   }
 

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -91,6 +91,25 @@ export async function retryDuringReconnect(
   throw lastErr;
 }
 
+// #379 — softReload() drops the bridge (client.stop) BEFORE the /reload POST so
+// the old orchestrator can free the port, then OWNS the respawn (client.start →
+// onAck resumes the conversation). But this published pack's /reload route is a
+// by-design 503 (the orchestrator runs out-of-band and never stops), so the POST
+// is ALWAYS refused — and the old code `return`ed on that path with the bridge
+// still stopped, wedging the panel "connected chip / dead bridge" with no
+// auto-recovery, every time. This decides the recovery from the POST outcome:
+//   - reconnect is ALWAYS true — the dropped bridge must be restored on every
+//     path (accepted → the fresh orchestrator binds; refused/unreachable → the
+//     orchestrator never stopped, so reconnecting restores the live bridge).
+//   - keepResumeInterlock (SOFT_RELOAD_KEY + soft-reload guard) is kept ONLY for
+//     an accepted respawn we own; a refused reload has no respawn to interlock,
+//     so it is cleared and the normal reconnect + hello.resume restores the
+//     session against the still-running orchestrator.
+export function planSoftReloadRecovery({ ok = false, reachable = true } = {}) {
+  const accepted = Boolean(reachable && ok);
+  return { accepted, reconnect: true, keepResumeInterlock: accepted };
+}
+
 // #207 / #334 — Stable identity for a workflow tab record. A load that replaces
 // the active canvas can flip the tab id (tmp: → wf:) or re-add the same file, so
 // dedupe on the rename-stable identity. Strip the tmp:/wf: scheme prefix so the


### PR DESCRIPTION
## What

**`Closes artokun/comfyui-mcp-panel#379`**

This published pack's `/comfyui_mcp_panel/reload` route is a **by-design 503** (the orchestrator runs out-of-band and is never stopped from here), so `softReload()` **always** hit the failure branch — and the old code returned there after `client.stop()` **without ever calling `client.start()`**, permanently wedging the panel "connected chip / dead bridge" with no auto-recovery, on every soft reload.

### Fix
- `softReload()` now **reconnects on every path** (mirrors `hardRestart`). A new testable pure helper `planSoftReloadRecovery()` keeps the `SOFT_RELOAD_KEY` resume interlock only for an **accepted** (owned-orchestrator) reload; a refused/failed reload clears it and reconnects the dropped bridge against the still-running orchestrator. The misleading "restart the orchestrator" directive is reframed as an optional hint.
- The reload POST is bounded by a **10s timeout race** — a hung `/reload` handler can no longer leave `reloading` true / skip `client.start()`.

### Bridge-lifecycle hardening
The reconnect is now on the hot path (every soft reload), so a stale socket event must not corrupt the fresh connection:
- Socket listeners (open/message/close/error) are **instance-guarded**: each captures its own `WebSocket` and no-ops via `isActive()` unless it's still the active `sock`. A superseded socket's late `close` can no longer null the fresh sock / reject its pending calls / `scheduleReconnect` (which orphaned the new socket).
- After awaiting an **async** command executor (ask_user/request_secret/graph run/save), the handler re-checks `isActive()` and **drops** the continuation if superseded, and sends the reply via the captured `thisSock` (only when OPEN) — never the mutable global `sock` — so a dead session A's reply can't be injected into fresh session B.
- The handshake-timeout callback returns unless `isActive()`, and `stop()` clears the handshake timer, so a superseded socket can't drive `onHandshakeTimeout` against the live connection.

## Related
The orchestrator-side half of this cluster (tab-binding recovery after restart/reload for #400/#402/#474) is in **artokun/comfyui-mcp** PR #595.

## Tests
`browser_tests/unit/session-rebind.test.mjs` — `planSoftReloadRecovery`: refused / unreachable / accepted always reconnect; interlock kept only on accept; reconnect unconditional across every outcome. Full unit suite green (831). Monolith verified to parse as an ES module. The socket-lifecycle guards are covered by reasoning + the codex gate; a live-WebSocket regression test is deferred (the pure-function `node --test` harness can't mount a socket).

Adversarial self-gate: codex (gpt-5.6-terra) — **approve, no material findings** (after fixing the stale-close race, async-continuation reply injection, handshake-timer leak, and hung-POST wedge across several review cycles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)