### PR TITLE
feat(node-ui): panel_resize_node + drive LTXDirector timeline via set_widget (#530, #314)

### DIFF
--- a/browser_tests/unit/graph-resize-node.test.mjs
+++ b/browser_tests/unit/graph-resize-node.test.mjs
@@ -1,0 +1,112 @@
+// #530: graph_resize_node (web/js/comfyui-mcp-panel.js) sets a node's [width, height]
+// on the live canvas so Note/MarkdownNote nodes (created at LiteGraph's unreadable
+// 140×60 default) can be enlarged — panel_move_node only repositions.
+//
+// graph_resize_node lives inline inside the GRAPH_TOOL_EXECUTORS object literal in
+// comfyui-mcp-panel.js (it references browser/ComfyUI globals, so it can't be imported
+// under plain Node). This follows the same "real panel source" extraction convention as
+// graph-set-node-collapsed.test.mjs: regex the method's source text out of the file and
+// evaluate it via `new Function`, injecting getGraphCtx / resolveNode stubs so the test
+// drives the ACTUAL shipped logic.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8");
+
+const methodMatch = panelSrc.match(/graph_resize_node\(\{ node_id, size \}\) \{[\s\S]*?\n  \},/);
+assert.ok(methodMatch, "could not locate graph_resize_node in panel source");
+
+/** Build a fresh graph_resize_node bound to the given stubs, evaluating the REAL method
+ *  source pulled from the panel file. */
+function realGraphResizeNode(getGraphCtx, resolveNode) {
+  const factory = new Function(
+    "getGraphCtx",
+    "resolveNode",
+    `const executors = { ${methodMatch[0]} };\nreturn executors.graph_resize_node;`,
+  );
+  return factory(getGraphCtx, resolveNode);
+}
+
+/** A node mirroring a real LGraphNode: setSize() clamps width/height to a computed min. */
+function makeNode({ id = 5, size = [140, 60], min = [80, 40] } = {}) {
+  const calls = { setSize: 0 };
+  return {
+    id,
+    size: [...size],
+    setSizeCalledWith: null,
+    setSize(s) {
+      calls.setSize += 1;
+      this.setSizeCalledWith = [...s];
+      this.size = [Math.max(s[0], min[0]), Math.max(s[1], min[1])];
+    },
+    _calls: calls,
+  };
+}
+
+function makeCtx(node) {
+  const events = [];
+  const graph = {
+    beforeChange: () => events.push("before"),
+    afterChange: () => events.push("after"),
+    setDirtyCanvas: () => events.push("dirty"),
+  };
+  return {
+    getGraphCtx: () => ({ graph }),
+    resolveNode: () => node,
+    events,
+  };
+}
+
+test("graph_resize_node uses setSize and reports from/to", () => {
+  const node = makeNode({ size: [140, 60] });
+  const ctx = makeCtx(node);
+  const resize = realGraphResizeNode(ctx.getGraphCtx, ctx.resolveNode);
+
+  const res = resize({ node_id: 5, size: [400, 300] });
+  assert.deepEqual(node.setSizeCalledWith, [400, 300], "setSize preferred over raw node.size");
+  assert.equal(node._calls.setSize, 1);
+  assert.deepEqual(res.resized.from, [140, 60]);
+  assert.deepEqual(res.resized.to, [400, 300]);
+  assert.equal(res.resized.node_id, 5);
+});
+
+test("graph_resize_node reflects a min-size clamp in the reported 'to'", () => {
+  const node = makeNode({ size: [140, 60], min: [200, 100] });
+  const ctx = makeCtx(node);
+  const resize = realGraphResizeNode(ctx.getGraphCtx, ctx.resolveNode);
+
+  const res = resize({ node_id: 5, size: [50, 20] });
+  // The node clamped up to its minimum; the result reports the ACTUAL post-clamp size.
+  assert.deepEqual(res.resized.to, [200, 100]);
+});
+
+test("graph_resize_node wraps the write in a beforeChange/afterChange undo envelope + dirties", () => {
+  const node = makeNode();
+  const ctx = makeCtx(node);
+  const resize = realGraphResizeNode(ctx.getGraphCtx, ctx.resolveNode);
+  resize({ node_id: 5, size: [400, 300] });
+  assert.deepEqual(ctx.events, ["before", "after", "dirty"]);
+});
+
+test("graph_resize_node falls back to node.size when setSize is absent", () => {
+  const node = { id: 9, size: [140, 60] };
+  const ctx = makeCtx(node);
+  const resize = realGraphResizeNode(ctx.getGraphCtx, ctx.resolveNode);
+  const res = resize({ node_id: 9, size: [321, 222] });
+  assert.deepEqual(node.size, [321, 222]);
+  assert.deepEqual(res.resized.to, [321, 222]);
+});
+
+test("graph_resize_node rejects malformed sizes", () => {
+  const node = makeNode();
+  const ctx = makeCtx(node);
+  const resize = realGraphResizeNode(ctx.getGraphCtx, ctx.resolveNode);
+  assert.throws(() => resize({ node_id: 5, size: [400] }), /size must be \[width, height\]/);
+  assert.throws(() => resize({ node_id: 5, size: "big" }), /size must be \[width, height\]/);
+  assert.throws(() => resize({ node_id: 5, size: [0, 300] }), /two positive numbers/);
+  assert.throws(() => resize({ node_id: 5, size: [-10, 300] }), /two positive numbers/);
+  assert.throws(() => resize({ node_id: 5, size: [400, NaN] }), /two positive numbers/);
+});

--- a/browser_tests/unit/ltx-director.test.mjs
+++ b/browser_tests/unit/ltx-director.test.mjs
@@ -1,0 +1,358 @@
+// #314: driving the LTXDirector custom timeline via panel_set_widget.
+//
+// The lib routes a `timeline_data` write through the node's OWN _applyLoadedTimeline
+// re-hydration (which drives the UI and regenerates the derived widgets) and REFUSES the
+// derived widgets (local_prompts / segment_lengths / guide_strength), which are silently
+// reverted if written directly. These tests drive the REAL shipped lib.
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  LTX_DIRECTOR_NODE_TYPE,
+  LTX_TIMELINE_MASTER_WIDGET,
+  LTX_DERIVED_TIMELINE_WIDGETS,
+  isLtxDirectorNode,
+  classifyLtxTimelineWrite,
+  normalizeLtxTimelineValue,
+  currentTimelineSnapshot,
+  derivedTimelineRefusal,
+  applyLtxTimelineWrite,
+  LtxTimelineWriteError,
+} from "../../web/js/lib/ltx-director.js";
+
+/** A fake node whose _timelineEditor records the _applyLoadedTimeline call. */
+function makeLtxNode({
+  id = 42,
+  withEditor = true,
+  method = "_applyLoadedTimeline",
+  withWidget = true,
+  widgetValue = "",
+} = {}) {
+  const calls = [];
+  const editor = withEditor
+    ? {
+        [method]: (jsonStr, fileHandle) => calls.push({ jsonStr, fileHandle }),
+        ...(withWidget ? { timelineDataWidget: { name: "timeline_data", value: widgetValue } } : {}),
+      }
+    : null;
+  return { node: { id, type: LTX_DIRECTOR_NODE_TYPE, _timelineEditor: editor }, calls };
+}
+
+/** The JSON string passed to the node's _applyLoadedTimeline, parsed back. */
+const drivenPayload = (calls) => JSON.parse(calls[0].jsonStr);
+
+/** A minimally-valid segment — finite numeric start + length are REQUIRED (NaN-timing guard). */
+const seg = (extra = {}) => ({ start: 0, length: 24, ...extra });
+
+test("isLtxDirectorNode matches on type or comfyClass, nothing else", () => {
+  assert.equal(isLtxDirectorNode({ type: "LTXDirector" }), true);
+  assert.equal(isLtxDirectorNode({ comfyClass: "LTXDirector" }), true);
+  // EITHER field matching is enough — a non-LTX `type` must NOT mask a matching
+  // `comfyClass` (the `type ?? comfyClass` bug codex flagged; would reproduce #314).
+  assert.equal(isLtxDirectorNode({ type: "SomeVirtualType", comfyClass: "LTXDirector" }), true);
+  assert.equal(isLtxDirectorNode({ type: "LTXDirector", comfyClass: "LTXDirector" }), true);
+  assert.equal(isLtxDirectorNode({ type: "KSampler", comfyClass: "KSampler" }), false);
+  assert.equal(isLtxDirectorNode({ type: "KSampler" }), false);
+  assert.equal(isLtxDirectorNode(null), false);
+  assert.equal(isLtxDirectorNode({}), false);
+});
+
+test("classifyLtxTimelineWrite: master / derived / null", () => {
+  const node = { type: LTX_DIRECTOR_NODE_TYPE };
+  assert.equal(classifyLtxTimelineWrite(node, LTX_TIMELINE_MASTER_WIDGET), "master");
+  for (const w of LTX_DERIVED_TIMELINE_WIDGETS) {
+    assert.equal(classifyLtxTimelineWrite(node, w), "derived");
+  }
+  // A normal widget on the LTX node still uses the normal write path.
+  assert.equal(classifyLtxTimelineWrite(node, "seed"), null);
+  // A NON-LTX node is never intercepted, even for a same-named widget.
+  assert.equal(classifyLtxTimelineWrite({ type: "KSampler" }, "timeline_data"), null);
+  assert.equal(classifyLtxTimelineWrite({ type: "KSampler" }, "local_prompts"), null);
+});
+
+test("normalizeLtxTimelineValue accepts an object and a JSON-object string", () => {
+  const obj = { global_prompt: "hi", segments: [seg({ prompt: "a" }), seg({ prompt: "b" })] };
+  const fromObj = normalizeLtxTimelineValue(obj);
+  assert.equal(fromObj.timeline.segments.length, 2);
+  assert.equal(JSON.parse(fromObj.jsonStr).global_prompt, "hi");
+
+  const fromStr = normalizeLtxTimelineValue(JSON.stringify(obj));
+  assert.deepEqual(fromStr.timeline, obj);
+});
+
+test("normalizeLtxTimelineValue rejects non-JSON strings, arrays, scalars, null", () => {
+  assert.throws(() => normalizeLtxTimelineValue("not json {"), LtxTimelineWriteError);
+  assert.throws(() => normalizeLtxTimelineValue("[1,2,3]"), LtxTimelineWriteError);
+  assert.throws(() => normalizeLtxTimelineValue(42), LtxTimelineWriteError);
+  assert.throws(() => normalizeLtxTimelineValue(""), LtxTimelineWriteError);
+  assert.throws(() => normalizeLtxTimelineValue(null), LtxTimelineWriteError);
+});
+
+test("normalizeLtxTimelineValue REFUSES malformed segment arrays that would silently WIPE the timeline", () => {
+  // A null/undefined/primitive segment makes the node's parseInitial destructure THROW,
+  // then silently fall back to an empty timeline (data loss). Refuse loudly instead.
+  assert.throws(() => normalizeLtxTimelineValue({ segments: [null] }), /segments\[0\] must be a segment OBJECT/);
+  assert.throws(() => normalizeLtxTimelineValue({ segments: [seg({ prompt: "ok" }), null] }), /segments\[1\]/);
+  assert.throws(() => normalizeLtxTimelineValue({ segments: [42] }), /segments\[0\]/);
+  assert.throws(() => normalizeLtxTimelineValue({ segments: ["x"] }), /segments\[0\]/);
+  assert.throws(() => normalizeLtxTimelineValue({ segments: [[]] }), /segments\[0\]/);
+  assert.throws(() => normalizeLtxTimelineValue({ motionSegments: [null] }), /motionSegments\[0\]/);
+  assert.throws(() => normalizeLtxTimelineValue({ audioSegments: [null] }), /audioSegments\[0\]/);
+  assert.throws(() => normalizeLtxTimelineValue({ segments: "not-array" }), /must be an ARRAY/);
+  // Also caught through the WRAPPED { timeline: {…} } shape (data.timeline || data).
+  assert.throws(() => normalizeLtxTimelineValue({ timeline: { segments: [null] } }), /segments\[0\]/);
+});
+
+test("normalizeLtxTimelineValue REFUSES a truthy non-object .timeline wrapper (node's data.timeline||data wipe)", () => {
+  // The node uses `data.timeline || data`, so a truthy array/primitive .timeline is what it
+  // serializes → parses as an empty timeline → WIPE. Reject before it can happen.
+  assert.throws(() => normalizeLtxTimelineValue({ timeline: [null] }), /non-object timeline/);
+  assert.throws(() => normalizeLtxTimelineValue({ timeline: [{ prompt: "x" }] }), /non-object timeline/);
+  assert.throws(() => normalizeLtxTimelineValue({ timeline: 5 }), /non-object timeline/);
+  assert.throws(() => normalizeLtxTimelineValue({ timeline: "str" }), /non-object timeline/);
+  assert.throws(() => normalizeLtxTimelineValue(JSON.stringify({ timeline: [null] })), /non-object timeline/);
+  // A FALSY .timeline falls back to the object itself (node's `|| data`) — valid.
+  assert.doesNotThrow(() => normalizeLtxTimelineValue({ timeline: null, segments: [seg({ prompt: "a" })] }));
+  assert.doesNotThrow(() => normalizeLtxTimelineValue({ timeline: 0, global_prompt: "g" }));
+  assert.doesNotThrow(() => normalizeLtxTimelineValue({ timeline: "", global_prompt: "g" }));
+});
+
+test("normalizeLtxTimelineValue REFUSES a PRESENT null/non-array segment field (node clears the track)", () => {
+  // A present `null` (or any non-array) is NOT the same as absent: the node reloads that
+  // track as [], silently clearing it. Only an ABSENT field is safe.
+  assert.throws(() => normalizeLtxTimelineValue({ segments: null }), /segments.*must be an ARRAY/);
+  assert.throws(() => normalizeLtxTimelineValue({ motionSegments: null }), /motionSegments.*must be an ARRAY/);
+  assert.throws(() => normalizeLtxTimelineValue({ audioSegments: null }), /audioSegments.*must be an ARRAY/);
+  assert.throws(() => normalizeLtxTimelineValue({ segments: {} }), /segments.*must be an ARRAY/);
+  // Absent is fine.
+  assert.doesNotThrow(() => normalizeLtxTimelineValue({ global_prompt: "g" }));
+});
+
+test("applyLtxTimelineWrite REFUSES an editor that lacks the timeline_data widget (false-success guard)", () => {
+  const { node, calls } = makeLtxNode({ withWidget: false });
+  assert.throws(() => applyLtxTimelineWrite(node, "{}"), LtxTimelineWriteError);
+  assert.equal(calls.length, 0, "must not call a load path that would silently no-op");
+});
+
+test("normalizeLtxTimelineValue REFUSES exotic (non-plain) objects that serialize to {} (Map/Date/instance)", () => {
+  // JSON.stringify turns these into "{}" → empty timeline → false 'driven' success.
+  class Foo {}
+  assert.throws(() => normalizeLtxTimelineValue(new Map()), LtxTimelineWriteError);
+  assert.throws(() => normalizeLtxTimelineValue(new Date()), LtxTimelineWriteError);
+  assert.throws(() => normalizeLtxTimelineValue(new Foo()), LtxTimelineWriteError);
+  assert.throws(() => normalizeLtxTimelineValue({ timeline: new Map() }), /non-object timeline/);
+  assert.throws(() => normalizeLtxTimelineValue({ segments: [new Map()] }), /segments\[0\]/);
+  // A plain object with a null prototype is still a valid timeline container.
+  assert.doesNotThrow(() => normalizeLtxTimelineValue(Object.assign(Object.create(null), { global_prompt: "g" })));
+});
+
+test("normalizeLtxTimelineValue ACCEPTS well-formed / empty / absent segment arrays", () => {
+  assert.doesNotThrow(() => normalizeLtxTimelineValue({ segments: [seg({ prompt: "a" }), seg({ prompt: "b" })] }));
+  assert.doesNotThrow(() => normalizeLtxTimelineValue({ segments: [] }));
+  assert.doesNotThrow(() => normalizeLtxTimelineValue({ global_prompt: "only global, no segments" }));
+  assert.doesNotThrow(() => normalizeLtxTimelineValue({})); // explicit clear-to-empty is allowed
+  assert.doesNotThrow(() => normalizeLtxTimelineValue({ timeline: { segments: [seg({ prompt: "a" })] } }));
+});
+
+test("applyLtxTimelineWrite REFUSES a wipe-inducing segment BEFORE opening the undo envelope or calling the node", () => {
+  const { node, calls } = makeLtxNode();
+  const order = [];
+  assert.throws(
+    () =>
+      applyLtxTimelineWrite(node, { segments: [null] }, {
+        beforeChange: () => order.push("before"),
+        afterChange: () => order.push("after"),
+        setDirty: () => order.push("dirty"),
+      }),
+    LtxTimelineWriteError,
+  );
+  assert.equal(calls.length, 0, "must not invoke the node's load path with a wipe-inducing payload");
+  assert.deepEqual(order, [], "must not open an undo envelope for a refused payload");
+});
+
+test("applyLtxTimelineWrite counts segments through the wrapped { timeline: {…} } shape", () => {
+  const { node } = makeLtxNode();
+  const res = applyLtxTimelineWrite(node, { timeline: { segments: [seg(), seg()] } });
+  assert.equal(res.ltx_timeline.segments, 2);
+});
+
+test("applyLtxTimelineWrite drives the node's _applyLoadedTimeline with a JSON string + null handle", () => {
+  const { node, calls } = makeLtxNode();
+  const value = JSON.stringify({ global_prompt: "g", segments: [seg({ prompt: "x" })] });
+  const res = applyLtxTimelineWrite(node, value);
+  assert.equal(calls.length, 1);
+  // The node's load path receives a JSON STRING (re-serialized) and fileHandle=null.
+  assert.equal(typeof calls[0].jsonStr, "string");
+  assert.equal(calls[0].fileHandle, null);
+  assert.equal(JSON.parse(calls[0].jsonStr).global_prompt, "g");
+  // Result envelope reports the drive + derived regeneration for the toast/summary.
+  assert.equal(res.ltx_timeline.driven, true);
+  assert.equal(res.ltx_timeline.node_id, 42);
+  assert.equal(res.ltx_timeline.widget, LTX_TIMELINE_MASTER_WIDGET);
+  assert.equal(res.ltx_timeline.segments, 1);
+  assert.deepEqual(res.ltx_timeline.derived_regenerated, [...LTX_DERIVED_TIMELINE_WIDGETS]);
+});
+
+test("applyLtxTimelineWrite accepts an object value directly (segments counted)", () => {
+  const { node, calls } = makeLtxNode();
+  const res = applyLtxTimelineWrite(node, { segments: [seg(), seg(), seg()] });
+  assert.equal(calls.length, 1);
+  assert.equal(res.ltx_timeline.segments, 3);
+});
+
+test("normalizeLtxTimelineValue REFUSES a segment lacking finite numeric start/length (NaN-timing corruption)", () => {
+  assert.throws(() => normalizeLtxTimelineValue({ segments: [{ prompt: "no timing" }] }), /\.start must be a finite number/);
+  assert.throws(() => normalizeLtxTimelineValue({ segments: [{ start: 0 }] }), /\.length must be a finite number/);
+  assert.throws(() => normalizeLtxTimelineValue({ segments: [{ start: 0, length: "24" }] }), /\.length must be a finite number/);
+  assert.throws(() => normalizeLtxTimelineValue({ segments: [{ start: NaN, length: 24 }] }), /\.start must be a finite number/);
+  assert.throws(() => normalizeLtxTimelineValue({ motionSegments: [{ prompt: "m" }] }), /motionSegments\[0\]\.start/);
+  assert.throws(() => normalizeLtxTimelineValue({ audioSegments: [{ start: 0 }] }), /audioSegments\[0\]\.length/);
+  // A properly-timed segment is accepted; extra fields are fine.
+  assert.doesNotThrow(() => normalizeLtxTimelineValue({ segments: [{ start: 0, length: 24, prompt: "ok", guideStrength: 1 }] }));
+});
+
+test("applyLtxTimelineWrite MERGES a partial write onto the current timeline (omitted tracks/scalars PRESERVED)", () => {
+  // Current timeline has all three tracks + a global prompt.
+  const current = {
+    global_prompt: "old global",
+    segments: [seg({ prompt: "old-seg" })],
+    motionSegments: [seg({ prompt: "keep-motion" })],
+    audioSegments: [seg({ prompt: "keep-audio" })],
+    retakeMode: true,
+  };
+  const { node, calls } = makeLtxNode({ widgetValue: JSON.stringify(current) });
+  // Caller only changes segments — nothing else.
+  const res = applyLtxTimelineWrite(node, { segments: [seg({ prompt: "new-seg" })] });
+  const payload = drivenPayload(calls);
+  assert.deepEqual(payload.segments, [seg({ prompt: "new-seg" })], "provided field overrides");
+  assert.deepEqual(payload.motionSegments, [seg({ prompt: "keep-motion" })], "omitted motion track PRESERVED");
+  assert.deepEqual(payload.audioSegments, [seg({ prompt: "keep-audio" })], "omitted audio track PRESERVED");
+  assert.equal(payload.global_prompt, "old global", "omitted global_prompt PRESERVED (not reset to '')");
+  assert.equal(payload.retakeMode, true, "omitted scalar PRESERVED");
+  assert.equal(res.ltx_timeline.merged_onto_current, true);
+  assert.deepEqual(res.ltx_timeline.preserved_tracks.sort(), ["audioSegments", "motionSegments"]);
+});
+
+test("applyLtxTimelineWrite treats a PRESENT empty array as an explicit clear (not a preserve)", () => {
+  const current = { segments: [seg({ prompt: "a" })], motionSegments: [seg({ prompt: "m" })] };
+  const { node, calls } = makeLtxNode({ widgetValue: JSON.stringify(current) });
+  const res = applyLtxTimelineWrite(node, { motionSegments: [] });
+  const payload = drivenPayload(calls);
+  assert.deepEqual(payload.motionSegments, [], "explicit empty array clears the track");
+  assert.deepEqual(payload.segments, [seg({ prompt: "a" })], "unmentioned segments still preserved");
+  assert.equal(res.ltx_timeline.preserved_tracks.includes("motionSegments"), false, "explicitly-set track is not 'preserved'");
+});
+
+test("applyLtxTimelineWrite falls back to pure replace when no current snapshot is readable", () => {
+  const { node, calls } = makeLtxNode({ widgetValue: "" }); // empty widget → no snapshot
+  const res = applyLtxTimelineWrite(node, { segments: [seg({ prompt: "x" })] });
+  const payload = drivenPayload(calls);
+  assert.deepEqual(payload, { segments: [seg({ prompt: "x" })] });
+  assert.equal(res.ltx_timeline.merged_onto_current, false);
+  assert.deepEqual(res.ltx_timeline.preserved_tracks, []);
+});
+
+test("applyLtxTimelineWrite merges through the wrapped { timeline: {…} } overlay too", () => {
+  const current = { global_prompt: "g", audioSegments: [seg({ prompt: "keep" })] };
+  const { node, calls } = makeLtxNode({ widgetValue: JSON.stringify(current) });
+  applyLtxTimelineWrite(node, { timeline: { segments: [seg({ prompt: "s" })] } });
+  const payload = drivenPayload(calls);
+  assert.deepEqual(payload.segments, [seg({ prompt: "s" })]);
+  assert.deepEqual(payload.audioSegments, [seg({ prompt: "keep" })], "preserved through the wrapper overlay");
+  assert.equal(payload.global_prompt, "g");
+});
+
+test("currentTimelineSnapshot reads the widget JSON, and null on empty/invalid", () => {
+  assert.deepEqual(currentTimelineSnapshot({ timelineDataWidget: { value: '{"a":1}' } }), { a: 1 });
+  assert.equal(currentTimelineSnapshot({ timelineDataWidget: { value: "" } }), null);
+  assert.equal(currentTimelineSnapshot({ timelineDataWidget: { value: "not json" } }), null);
+  assert.equal(currentTimelineSnapshot({ timelineDataWidget: { value: "[1,2]" } }), null, "array snapshot is not a timeline");
+  assert.equal(currentTimelineSnapshot({}), null);
+});
+
+test("applyLtxTimelineWrite fails LOUDLY when the editor / load path is missing", () => {
+  // No editor at all (node UI not initialized).
+  const noEditor = makeLtxNode({ withEditor: false });
+  assert.throws(() => applyLtxTimelineWrite(noEditor.node, "{}"), LtxTimelineWriteError);
+  // Editor present but without the _applyLoadedTimeline method (pack version mismatch).
+  const wrongMethod = makeLtxNode({ method: "_somethingElse" });
+  assert.throws(() => applyLtxTimelineWrite(wrongMethod.node, "{}"), LtxTimelineWriteError);
+});
+
+test("applyLtxTimelineWrite rejects invalid JSON BEFORE calling the node (node swallows parse errors)", () => {
+  const { node, calls } = makeLtxNode();
+  assert.throws(() => applyLtxTimelineWrite(node, "totally not json"), LtxTimelineWriteError);
+  assert.equal(calls.length, 0, "must not invoke the node's load path with un-validated input");
+});
+
+test("applyLtxTimelineWrite honors an injected getEditor", () => {
+  const calls = [];
+  const editor = { _applyLoadedTimeline: (s) => calls.push(s), timelineDataWidget: { name: "timeline_data" } };
+  const node = { id: 7, type: LTX_DIRECTOR_NODE_TYPE };
+  applyLtxTimelineWrite(node, "{}", { getEditor: () => editor });
+  assert.equal(calls.length, 1);
+});
+
+test("applyLtxTimelineWrite wraps the drive in an undo envelope: before → apply → after → dirty", () => {
+  const { node, calls } = makeLtxNode();
+  const order = [];
+  applyLtxTimelineWrite(node, "{}", {
+    beforeChange: () => order.push("before"),
+    afterChange: () => order.push("after"),
+    setDirty: () => order.push("dirty"),
+    getEditor: (n) => ({
+      _applyLoadedTimeline: (s) => order.push("apply") || calls.push(s),
+      timelineDataWidget: { name: "timeline_data" },
+    }),
+  });
+  assert.deepEqual(order, ["before", "apply", "after", "dirty"]);
+});
+
+test("applyLtxTimelineWrite closes the undo envelope (afterChange) even when the load path throws", () => {
+  const order = [];
+  const node = { id: 3, type: LTX_DIRECTOR_NODE_TYPE };
+  assert.throws(
+    () =>
+      applyLtxTimelineWrite(node, "{}", {
+        beforeChange: () => order.push("before"),
+        afterChange: () => order.push("after"),
+        setDirty: () => order.push("dirty"),
+        getEditor: () => ({
+          _applyLoadedTimeline: () => {
+            throw new Error("boom");
+          },
+          timelineDataWidget: { name: "timeline_data" },
+        }),
+      }),
+    /boom/,
+  );
+  // afterChange must still fire; setDirty must NOT (no successful repaint).
+  assert.deepEqual(order, ["before", "after"]);
+});
+
+test("applyLtxTimelineWrite fires NO undo hooks when input/editor validation refuses", () => {
+  const order = [];
+  const hooks = {
+    beforeChange: () => order.push("before"),
+    afterChange: () => order.push("after"),
+    setDirty: () => order.push("dirty"),
+  };
+  // Invalid JSON — refused before any envelope.
+  assert.throws(
+    () => applyLtxTimelineWrite({ id: 1, type: LTX_DIRECTOR_NODE_TYPE }, "nope", hooks),
+    LtxTimelineWriteError,
+  );
+  // Missing editor — refused before any envelope.
+  assert.throws(
+    () => applyLtxTimelineWrite({ id: 1, type: LTX_DIRECTOR_NODE_TYPE }, "{}", { ...hooks, getEditor: () => null }),
+    LtxTimelineWriteError,
+  );
+  assert.deepEqual(order, [], "a refusal must not open an empty undo step");
+});
+
+test("derivedTimelineRefusal names the widget, the node, and points at timeline_data", () => {
+  const msg = derivedTimelineRefusal("local_prompts", 99);
+  assert.match(msg, /local_prompts/);
+  assert.match(msg, /node 99/);
+  assert.match(msg, /timeline_data/);
+  assert.match(msg, /#314/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -121,6 +121,11 @@ import {
 } from "./lib/subgraph-scope.js";
 import { runSetWidget } from "./lib/set-widget.js";
 import {
+  classifyLtxTimelineWrite,
+  applyLtxTimelineWrite,
+  derivedTimelineRefusal,
+} from "./lib/ltx-director.js";
+import {
   controlAfterGenerateModes,
   controlAfterGenerateEntries,
 } from "./lib/control-after-generate.js";
@@ -5563,6 +5568,27 @@ const GRAPH_TOOL_EXECUTORS = {
   graph_set_widget({ node_id, widget, value }) {
     const { app, graph, LG } = getGraphCtx();
     const node = resolveNode(graph, node_id);
+    // #314: the LTXDirector custom node owns its timeline widgets through an in-browser
+    // TimelineEditor whose in-memory `this.timeline` is the source of truth. A raw widget
+    // write "succeeds" (panel_query_graph shows it) but never reaches the editor/UI and is
+    // reverted on the next commit. Route a `timeline_data` write through the node's OWN
+    // _applyLoadedTimeline re-hydration (drives the UI + regenerates the derived widgets),
+    // and REFUSE the derived widgets loudly. Keyed strictly to node.type === "LTXDirector",
+    // so no other node is affected; a general widget-replay is deliberately NOT attempted.
+    const ltxKind = classifyLtxTimelineWrite(node, widget);
+    if (ltxKind === "derived") {
+      throw new Error(derivedTimelineRefusal(widget, node.id));
+    }
+    if (ltxKind === "master") {
+      // Bracket in the SAME undo envelope the normal write path uses so this route
+      // honors panel_set_widget's "Undoable with Ctrl+Z" contract (the node's own
+      // _applyLoadedTimeline only schedules async state capture, no pre-change snapshot).
+      return applyLtxTimelineWrite(node, value, {
+        beforeChange: () => graph.beforeChange(),
+        afterChange: () => graph.afterChange(),
+        setDirty: () => graph.setDirtyCanvas(true, true),
+      });
+    }
     // Delegate to the shared handler body (web/js/lib/set-widget.js) so this
     // production path and the unit tests run the IDENTICAL ordering: preflight →
     // reconcile-only-a-resolved-node → applyWidgetWrite with the resolved-target
@@ -5665,6 +5691,31 @@ const GRAPH_TOOL_EXECUTORS = {
     }
     graph.setDirtyCanvas(true, true);
     return { moved: { node_id: node.id, from: previous, to: [node.pos[0], node.pos[1]] } };
+  },
+
+  // #530: resize a node to [width, height]. Note/MarkdownNote nodes are created at
+  // LiteGraph's 140×60 default and are unreadable until enlarged — panel_move_node
+  // only repositions. setSize() (not a raw node.size assignment) is preferred so a
+  // node that clamps to a computed minimum, and DOM-widget nodes like MarkdownNote,
+  // reflow correctly. Mirrors graph_move_node's beforeChange/afterChange undo envelope.
+  graph_resize_node({ node_id, size }) {
+    const { graph } = getGraphCtx();
+    const node = resolveNode(graph, node_id);
+    if (!Array.isArray(size) || size.length !== 2) throw new Error("size must be [width, height]");
+    const w = Number(size[0]);
+    const h = Number(size[1]);
+    if (!Number.isFinite(w) || !Number.isFinite(h) || w <= 0 || h <= 0)
+      throw new Error("size must be two positive numbers");
+    const previous = [node.size?.[0], node.size?.[1]];
+    graph.beforeChange();
+    try {
+      if (typeof node.setSize === "function") node.setSize([w, h]);
+      else node.size = [w, h];
+    } finally {
+      graph.afterChange();
+    }
+    graph.setDirtyCanvas(true, true);
+    return { resized: { node_id: node.id, from: previous, to: [node.size[0], node.size[1]] } };
   },
 
   // Dependency-aware auto-layout of the active graph (or a `node_ids` subset).
@@ -9698,6 +9749,18 @@ function describeCommand(cmd, msg, reply) {
     case "graph_disconnect":
       return { icon: "pi-times-circle", text: `Disconnected ${r.disconnected?.node_id}.${r.disconnected?.input}` };
     case "graph_set_widget": {
+      // #314: an LTXDirector timeline_data write was routed through the node's own
+      // re-hydration, which also regenerated the derived prompt/length widgets.
+      if (r.ltx_timeline) {
+        const seg = r.ltx_timeline.segments;
+        return {
+          icon: "pi-sliders-h",
+          text:
+            `Drove LTXDirector timeline on node ${r.ltx_timeline.node_id}` +
+            (seg != null ? ` (${seg} segment${seg === 1 ? "" : "s"})` : "") +
+            ` — UI re-synced, derived prompt/length widgets regenerated`,
+        };
+      }
       // #366: a promoted-subgraph write is only truly applied when the parent RAIL
       // widget (what serializes at queue time) was synced. The lib fails closed if
       // it can't, so a success result normally has parent_widget_synced !== false;
@@ -9727,6 +9790,11 @@ function describeCommand(cmd, msg, reply) {
         : { icon: "pi-arrow-up", text: `Promoted “${r.promoted}” to the subgraph node` };
     case "graph_move_node":
       return { icon: "pi-arrows-alt", text: `Moved node ${r.moved?.node_id} to [${r.moved?.to?.map(Math.round)}]` };
+    case "graph_resize_node":
+      return {
+        icon: "pi-arrows-alt",
+        text: `Resized node ${r.resized?.node_id} to [${r.resized?.to?.map(Math.round)}]`,
+      };
     case "graph_auto_layout":
       return {
         icon: "pi-th-large",

--- a/web/js/lib/ltx-director.js
+++ b/web/js/lib/ltx-director.js
@@ -1,0 +1,306 @@
+// Targeted support for driving the LTXDirector (WhatDreamsCost "CSGlide") custom
+// timeline node via panel_set_widget (#314).
+//
+// THE PROBLEM. LTXDirector renders its prompts/segments from a custom JS timeline
+// editor (TimelineEditor). That editor parses the `timeline_data` widget ONCE — in its
+// constructor — into an in-memory `this.timeline`, the ABSOLUTE source of truth for both
+// what the DOM shows AND what serializes. `local_prompts`, `segment_lengths` and
+// `guide_strength` are DERIVED OUTPUTS the editor REGENERATES from `this.timeline` on
+// every commitChanges(). All of these widgets are HIDDEN.
+//
+// A raw panel_set_widget therefore:
+//   * writes the widget.value, so panel_query_graph reflects it (the tool "succeeds"),
+//   * but never re-parses into `this.timeline`, so the DOM UI is unchanged, AND
+//   * is SILENTLY REVERTED the next time commitChanges() runs (any UI touch, a load, or
+//     the post-configure sync), because that rebuilds the widgets from the stale
+//     `this.timeline`.
+// That is exactly issue #314: "Tool returned success ... but the node's custom JS
+// timeline UI still displayed the previous prompts."
+//
+// WHY A GENERAL WIDGET REPLAY IS UNSAFE, AND WHAT IS SAFE. There is no general
+// onConfigure/serialize replay that safely re-hydrates arbitrary custom nodes. But
+// LTXDirector ships its OWN re-hydration entry point: `_applyLoadedTimeline(jsonStr)` —
+// the node's "Load Timeline" file handler — which re-parses the JSON into
+// `this.timeline`, syncs the global-prompt DOM, reloads media, REGENERATES the derived
+// widgets via commitChanges(), and re-renders. Routing a `timeline_data` write through
+// THAT method — keyed strictly to node.type === "LTXDirector" and feature-detected —
+// drives the UI correctly WITHOUT touching any other node. It accepts either the raw
+// `timeline_data` object shape or the wrapped save-file shape ({ timeline: {…} }), so the
+// value the agent already writes to `timeline_data` works verbatim.
+//
+// The DERIVED widgets (local_prompts / segment_lengths / guide_strength) CANNOT be driven
+// independently — a direct write is reverted — so we REFUSE them LOUDLY (mirroring #560's
+// principle of "a loud, safe failure over silent corruption") and redirect the caller to
+// `timeline_data`.
+
+export const LTX_DIRECTOR_NODE_TYPE = "LTXDirector";
+
+// The master widget: the JSON the editor parses into its source-of-truth timeline.
+export const LTX_TIMELINE_MASTER_WIDGET = "timeline_data";
+
+// Derived OUTPUTS of the editor's commitChanges() — regenerated from the timeline, so a
+// direct write is silently reverted. Refuse these and redirect to timeline_data.
+export const LTX_DERIVED_TIMELINE_WIDGETS = Object.freeze([
+  "local_prompts",
+  "segment_lengths",
+  "guide_strength",
+]);
+
+/**
+ * True for an LTXDirector node (matched on the ComfyUI class, never a value shape).
+ * Matches when EITHER `type` OR `comfyClass` is "LTXDirector" — not `type ?? comfyClass`,
+ * which would ignore a matching `comfyClass` whenever `type` is a different non-null value.
+ */
+export function isLtxDirectorNode(node) {
+  return node?.type === LTX_DIRECTOR_NODE_TYPE || node?.comfyClass === LTX_DIRECTOR_NODE_TYPE;
+}
+
+/**
+ * Classify a set_widget request against the LTXDirector timeline widgets:
+ *   "master"  → timeline_data (drive via the node's _applyLoadedTimeline)
+ *   "derived" → local_prompts / segment_lengths / guide_strength (refuse)
+ *   null      → not an LTXDirector timeline widget; use the normal write path
+ * Non-LTXDirector nodes always return null, so this never perturbs any other node.
+ */
+export function classifyLtxTimelineWrite(node, widgetName) {
+  if (!isLtxDirectorNode(node)) return null;
+  if (widgetName === LTX_TIMELINE_MASTER_WIDGET) return "master";
+  if (LTX_DERIVED_TIMELINE_WIDGETS.includes(widgetName)) return "derived";
+  return null;
+}
+
+export class LtxTimelineWriteError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "LtxTimelineWriteError";
+  }
+}
+
+// A PLAIN JSON object (`{}` literal / Object.create(null)) — not an array, not a Map/Set/
+// Date/class instance. The node round-trips the value through JSON.stringify, which turns
+// any exotic object into `{}` (an empty timeline). Requiring a plain object rejects those
+// up front so we never report a "driven" success for a value that would serialize to empty.
+// In production the value is already a JSON.parse result (see normalizeLtxTimelineValue),
+// so this is defense-in-depth for direct-object callers.
+function isPlainObject(v) {
+  if (v === null || typeof v !== "object" || Array.isArray(v)) return false;
+  const proto = Object.getPrototypeOf(v);
+  return proto === Object.prototype || proto === null;
+}
+
+// The segment arrays the node's parseInitial() ingests by DESTRUCTURING each element
+// (`const { …, ...rest } = s`). A null/undefined element makes that destructure THROW,
+// and parseInitial's outer try/catch then silently falls back to an EMPTY timeline —
+// which would WIPE the user's existing timeline while we report success. We reject any
+// non-object element up front (loud, safe failure over silent data loss, per #560).
+const SEGMENT_ARRAY_FIELDS = ["segments", "motionSegments", "audioSegments"];
+
+// The effective timeline object parseInitial reads. Mirrors the node's `data.timeline ||
+// data` EXACTLY (truthy `||`, NOT a type check): a TRUTHY `.timeline` — even an array or a
+// primitive — is what the node serializes and parses; only a FALSY `.timeline`
+// (undefined/null/false/0/""/NaN) falls back to the object itself.
+function effectiveTimeline(obj) {
+  return obj.timeline ? obj.timeline : obj;
+}
+
+function assertTimelineSegments(obj) {
+  const tl = effectiveTimeline(obj);
+  // A truthy non-plain-object `.timeline` wrapper (array / primitive / Map / class instance)
+  // is serialized by the node and parsed as a timeline with no `segments`, RESETTING to empty
+  // (data loss) while the request reports success. Reject it — the effective timeline must be
+  // a plain object.
+  if (!isPlainObject(tl)) {
+    throw new LtxTimelineWriteError(
+      `timeline_data resolves to a non-object timeline (${Array.isArray(tl) ? "an array" : JSON.stringify(tl)}); ` +
+        `the LTXDirector parser would reset to an EMPTY timeline (data loss) — refusing. Pass a timeline ` +
+        `OBJECT, optionally wrapped as {"timeline": { … }}.`,
+    );
+  }
+  for (const field of SEGMENT_ARRAY_FIELDS) {
+    // ABSENT is safe (the node defaults the track to []). But a PRESENT non-array —
+    // including an explicit `null` — makes the node reload THAT track as [], silently
+    // clearing it while reporting success. Only skip a field that is truly absent.
+    if (!Object.prototype.hasOwnProperty.call(tl, field)) continue;
+    const arr = tl[field];
+    if (!Array.isArray(arr)) {
+      throw new LtxTimelineWriteError(
+        `timeline_data.${field}, when present, must be an ARRAY of segment objects, not ` +
+          `${arr === null ? "null" : JSON.stringify(arr)}. The node reloads a non-array track as an ` +
+          `empty list, silently CLEARING it — omit the field to leave it unchanged-by-default, or ` +
+          `pass a proper array.`,
+      );
+    }
+    for (let i = 0; i < arr.length; i++) {
+      const el = arr[i];
+      if (!isPlainObject(el)) {
+        const what =
+          el === null
+            ? "null"
+            : el === undefined
+              ? "undefined"
+              : Array.isArray(el)
+                ? "an array"
+                : JSON.stringify(el);
+        throw new LtxTimelineWriteError(
+          `timeline_data.${field}[${i}] must be a segment OBJECT, not ${what}. The LTXDirector ` +
+            `parser THROWS on a non-object segment and silently falls back to an EMPTY timeline, ` +
+            `which would WIPE the existing timeline while reporting success — refusing.`,
+        );
+      }
+      // Every track computes timing as `seg.start + seg.length` (and the main track derives
+      // an omitted start by accumulating prior lengths). A missing/non-numeric start or
+      // length yields NaN timing that corrupts the whole track's layout — with no throw, so
+      // it would be applied and reported as success. Require finite numbers for both (they
+      // are always present in the shape the node itself saves).
+      for (const key of ["start", "length"]) {
+        if (!Number.isFinite(el[key])) {
+          throw new LtxTimelineWriteError(
+            `timeline_data.${field}[${i}].${key} must be a finite number (frames), not ` +
+              `${el[key] === undefined ? "undefined" : JSON.stringify(el[key])}. A non-numeric ${key} ` +
+              `produces NaN timing that corrupts the track; every segment needs numeric start + ` +
+              `length (as in the value the node saves).`,
+          );
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Normalize the incoming value into a JSON STRING for _applyLoadedTimeline, returning
+ * { jsonStr, timeline } (timeline = the parsed object, used for the result envelope).
+ * Accepts an object OR a JSON-object string (the MCP arg schema carries the timeline as a
+ * string). Throws LtxTimelineWriteError on invalid JSON, a non-object, or a malformed
+ * segment array that would make the node silently wipe the timeline. Pre-validating here
+ * matters: the node's own _applyLoadedTimeline swallows parse errors behind an alert() and
+ * degrades to an empty timeline, so we must reject bad input BEFORE calling it.
+ */
+export function normalizeLtxTimelineValue(value) {
+  let obj = value;
+  if (typeof value === "string") {
+    try {
+      obj = JSON.parse(value);
+    } catch {
+      throw new LtxTimelineWriteError(
+        `timeline_data must be a JSON object (the LTXDirector timeline), but the string is not valid JSON. ` +
+          `Pass the full timeline object, e.g. {"global_prompt":"…","segments":[…]}.`,
+      );
+    }
+  }
+  if (!isPlainObject(obj)) {
+    throw new LtxTimelineWriteError(
+      `timeline_data must be a JSON OBJECT describing the timeline (with segments / global_prompt), ` +
+        `not ${Array.isArray(obj) ? "an array" : JSON.stringify(obj)}.`,
+    );
+  }
+  assertTimelineSegments(obj);
+  return { jsonStr: JSON.stringify(obj), timeline: obj };
+}
+
+/**
+ * The node's CLEAN current-timeline snapshot: the JSON it keeps in the timeline_data widget
+ * (commitChanges maintains it with all runtime-only segment fields — imgObj/videoEl/blobs —
+ * already stripped, so it is safe to JSON round-trip, unlike the live editor.timeline which
+ * holds DOM/Image refs). Returns the parsed plain object, or null when it can't be read.
+ */
+export function currentTimelineSnapshot(editor) {
+  const raw = editor?.timelineDataWidget?.value;
+  if (typeof raw !== "string" || raw.trim() === "") return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return isPlainObject(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** The refusal message for a DERIVED-widget write — explains why + points at timeline_data. */
+export function derivedTimelineRefusal(widgetName, nodeId) {
+  return (
+    `panel_set_widget cannot drive "${widgetName}" on LTXDirector node ${nodeId}: it is a DERIVED ` +
+    `OUTPUT that the node's timeline editor REGENERATES from "${LTX_TIMELINE_MASTER_WIDGET}" on every ` +
+    `commit — a direct write shows in panel_query_graph but is silently reverted and never reaches the ` +
+    `UI (#314). Set the whole timeline instead: panel_set_widget on "${LTX_TIMELINE_MASTER_WIDGET}" with ` +
+    `the full timeline JSON (segments + global_prompt), which drives the editor and regenerates ` +
+    `"${LTX_DERIVED_TIMELINE_WIDGETS.join('", "')}" for you.`
+  );
+}
+
+/**
+ * Drive the LTXDirector timeline through the node's OWN _applyLoadedTimeline re-hydration.
+ * Hooks are injected so this is unit-testable without a browser AND so the lib OWNS the
+ * change ordering (mirroring set-widget.js):
+ *   - `getEditor(node)` returns the live TimelineEditor instance (default node._timelineEditor).
+ *   - `beforeChange` / `afterChange` bracket the mutation in litegraph's undo envelope so
+ *     the route honors panel_set_widget's "Undoable with Ctrl+Z" contract — the node's own
+ *     _applyLoadedTimeline only schedules async dirty/state-capture work and does NOT take a
+ *     pre-change snapshot. afterChange ALWAYS runs (even on throw); beforeChange is only
+ *     fired once the value + editor are validated, so a refusal establishes no empty undo step.
+ *   - `setDirty` repaints the canvas on success.
+ * Returns a result envelope. Throws LtxTimelineWriteError when the value is invalid, or the
+ * editor / load method is unavailable (node UI not initialized, or a pack version without the
+ * load path) — an HONEST failure rather than a raw write that would be silently reverted.
+ *
+ * MERGE, not replace. The node's _applyLoadedTimeline is a whole-timeline REPLACE that
+ * DEFAULTS every omitted field (an absent track loads as [], an absent global_prompt as "").
+ * A partial write would therefore silently WIPE unmentioned tracks / reset scalars. To match
+ * panel_set_widget's "change this" intent — and the #560 composite-widget pattern of merging
+ * onto the CURRENT value — we overlay the caller's provided top-level fields onto the node's
+ * clean current-timeline snapshot, so anything they don't mention is PRESERVED. An explicit
+ * empty array (e.g. `motionSegments: []`) still clears that track; only OMISSION preserves.
+ */
+export function applyLtxTimelineWrite(node, value, { getEditor, beforeChange, afterChange, setDirty } = {}) {
+  const { timeline } = normalizeLtxTimelineValue(value);
+  const editor = typeof getEditor === "function" ? getEditor(node) : node?._timelineEditor;
+  // Require BOTH the load method AND the timeline_data widget it dereferences
+  // UNCONDITIONALLY (`this.timelineDataWidget.value`, not behind a guard). Without the
+  // widget, _applyLoadedTimeline throws internally and swallows it behind its own alert(),
+  // applying nothing — so a method-presence-only check would report a false "driven"
+  // success and dirty the graph for no effect.
+  if (!editor || typeof editor._applyLoadedTimeline !== "function" || !editor.timelineDataWidget) {
+    throw new LtxTimelineWriteError(
+      `LTXDirector node ${node?.id} has no live, ready timeline editor to drive (the node UI has not ` +
+        `initialized, its timeline_data widget is missing, or this pack version does not expose the ` +
+        `timeline load path). Open the node on the canvas, or edit the timeline from the node UI; ` +
+        `panel_set_widget cannot re-sync the custom timeline on this version.`,
+    );
+  }
+  // Merge the caller's fields (the effective timeline — unwrapped from a { timeline: {…} }
+  // wrapper) onto the node's CLEAN current snapshot so omitted fields are preserved. When no
+  // snapshot is readable there is nothing to preserve, so fall back to a pure replace with the
+  // caller's object. The result is always an UNWRAPPED timeline object, which the node accepts
+  // via `data.timeline || data`.
+  const overlay = effectiveTimeline(timeline);
+  const base = currentTimelineSnapshot(editor);
+  const merged = base ? { ...base, ...overlay } : overlay;
+  const preservedTracks = base
+    ? SEGMENT_ARRAY_FIELDS.filter(
+        (f) => !Object.prototype.hasOwnProperty.call(overlay, f) && Array.isArray(base[f]) && base[f].length,
+      )
+    : [];
+
+  // Bracket the mutation in one undo envelope (afterChange in finally so a thrown load path
+  // never leaves the history open). The node's authored load path re-parses into
+  // this.timeline, syncs the global-prompt DOM + media, REGENERATES
+  // local_prompts/segment_lengths/guide_strength via commitChanges(), and re-renders.
+  // fileHandle=null (not loaded from a picked file).
+  beforeChange?.();
+  try {
+    editor._applyLoadedTimeline(JSON.stringify(merged), null);
+  } finally {
+    afterChange?.();
+  }
+  setDirty?.();
+  const segments = Array.isArray(merged.segments) ? merged.segments.length : undefined;
+  return {
+    ltx_timeline: {
+      node_id: node?.id,
+      widget: LTX_TIMELINE_MASTER_WIDGET,
+      driven: true,
+      merged_onto_current: base != null,
+      preserved_tracks: preservedTracks,
+      segments,
+      derived_regenerated: [...LTX_DERIVED_TIMELINE_WIDGETS],
+    },
+  };
+}


### PR DESCRIPTION
Node-UI-manipulation cluster. Paired with artokun/comfyui-mcp#530's branch (same name).

## #530 — `panel_resize_node` (Note/MarkdownNote unreadable at 140×60)
New `graph_resize_node` executor + toast. Mirrors `graph_move_node`: prefers `node.setSize()` (so `MarkdownNote` and min-clamping nodes reflow), wraps in the `beforeChange`/`afterChange` undo envelope, dirties the canvas, reports post-clamp `from`/`to`, validates two positive numbers. The MCP `panel_resize_node` def lives in the paired comfyui-mcp PR.

## #314 — driving the LTXDirector (CSGlide) timeline via `panel_set_widget` — **FEASIBLE, shipped**
**Root cause confirmed in the node source.** `LTXDirector` renders from a custom `TimelineEditor` whose in-memory `this.timeline` (parsed once from `timeline_data` in the constructor) is the source of truth. `local_prompts`/`segment_lengths`/`guide_strength` are **derived outputs** regenerated from `this.timeline` by `commitChanges()`. A raw `panel_set_widget` writes `widget.value` (so `panel_query_graph` shows it) but never re-parses into `this.timeline` and is reverted on the next commit — exactly the issue.

**A safe targeted fix is feasible** (no dangerous general widget-replay): the node exposes its own re-hydration entry point `_applyLoadedTimeline(jsonStr)` (its "Load Timeline" handler) that re-parses into `this.timeline`, syncs the global-prompt DOM + media, regenerates the derived widgets via `commitChanges()`, and re-renders. New `web/js/lib/ltx-director.js` routes a `timeline_data` write through that method, **keyed strictly to `node.type`/`comfyClass === "LTXDirector"`** and feature-detected — no other node is touched. The derived widgets are **refused loudly** (they're silently reverted if written directly), reusing #560's "loud safe failure over silent corruption" principle.

Because `_applyLoadedTimeline` is a whole-timeline **replace** that defaults every omitted field, the lib **merges** the caller's provided fields onto the node's clean current-timeline snapshot (`timelineDataWidget.value`, runtime-stripped) — mirroring #560's composite-merge — so omitted tracks/scalars are **preserved**; a present empty array is an explicit clear; no snapshot ⇒ pure replace. Full pre-mutation validation blocks the node's silent-wipe and NaN-timing failure modes (invalid JSON, non-plain-object root/wrapper, present-null/non-array track, non-object segment, segment missing finite `start`/`length`).

### Tests
27 new unit tests in `browser_tests/unit/ltx-director.test.mjs` + 5 in `graph-resize-node.test.mjs`. Full panel unit suite green (863).

### Codex self-gate: **PASS** (gpt-5.6-terra/high)
9 review rounds; each surfaced a real data-integrity edge (type/comfyClass masking, undo envelope, null/exotic-object/wrapper wipe vectors, replace-vs-merge track loss, NaN-timing). All fixed. Final: "No reachable silent data-loss, false-success, or NaN-timing defect found."

Closes artokun/comfyui-mcp-panel#314

🤖 Generated with [Claude Code](https://claude.com/claude-code)