### PR TITLE
fix: type-name slot addressing (#406), CivitAI search timeout (#417), legacy-Manager node search (#426)

### DIFF
--- a/browser_tests/unit/civitai-upstream-error.test.mjs
+++ b/browser_tests/unit/civitai-upstream-error.test.mjs
@@ -5,9 +5,9 @@
 // upstream `status` — so the UI's fetch catch can record a distinct error state
 // and panel_civitai_results can report it instead of an indistinguishable
 // empty grid (total:0).
-import { test } from "node:test";
+import { test, mock } from "node:test";
 import assert from "node:assert/strict";
-import { CivitaiClient } from "../../web/js/cmcp-civitai.js";
+import { CivitaiClient, CIVITAI_REQUEST_TIMEOUT_MS } from "../../web/js/cmcp-civitai.js";
 
 function clientWith(response) {
   return new CivitaiClient({
@@ -41,4 +41,58 @@ test("_request returns the normalized body on success", async () => {
   });
   const out = await client._request({ url: "https://civitai.com/api/v1/models" });
   assert.deepEqual(out, { items: [1, 2, 3] });
+});
+
+// ---- #417: a hung proxy request is aborted so _loadMore can recover ----------
+// Before the fix, _request awaited fetchApi with NO timeout/AbortSignal, so a
+// proxy/upstream that never settled left the fetch pending forever — _loadMore
+// never reached its catch/finally and panel_civitai_results stayed
+// {loading:true, total:0, error:null} indefinitely. The client-side abort budget
+// converts that hang into a thrown timeout the existing catch surfaces.
+
+test("#417: _request throws a timeout error when the proxy never settles", async () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+  try {
+    let aborted = false;
+    const client = new CivitaiClient({
+      fetchApi: (_path, opts) =>
+        new Promise((_resolve, reject) => {
+          // Real fetch rejects with an AbortError when its signal fires.
+          opts.signal.addEventListener("abort", () => {
+            aborted = true;
+            const e = new Error("The operation was aborted");
+            e.name = "AbortError";
+            reject(e);
+          });
+        }),
+      apiURL: (p) => p,
+    });
+    const pending = client._request({ url: "https://civitai.com/api/v1/models" });
+    // Advance past the abort budget — fires the timeout → controller.abort().
+    mock.timers.tick(CIVITAI_REQUEST_TIMEOUT_MS + 1);
+    await assert.rejects(
+      () => pending,
+      (err) => {
+        assert.match(err.message, /timed out after \d+ seconds/i);
+        assert.notEqual(err.name, "AbortError"); // AbortError is converted, not leaked
+        return true;
+      },
+    );
+    assert.equal(aborted, true);
+  } finally {
+    mock.timers.reset();
+  }
+});
+
+test("#417: a non-abort fetch rejection still propagates unchanged", async () => {
+  const client = new CivitaiClient({
+    fetchApi: async () => {
+      throw new TypeError("Failed to fetch");
+    },
+    apiURL: (p) => p,
+  });
+  await assert.rejects(
+    () => client._request({ url: "https://civitai.com/api/v1/models" }),
+    /Failed to fetch/,
+  );
 });

--- a/browser_tests/unit/connect-match.test.mjs
+++ b/browser_tests/unit/connect-match.test.mjs
@@ -20,6 +20,7 @@ import assert from "node:assert/strict";
 import {
   autoMatchSlots,
   resolveExplicitSlot,
+  typeMatchedIndices,
   isTypeCompatible,
   isWildcardSlotType,
   slotDiagnostic,
@@ -192,4 +193,90 @@ test("#169: a typed occupied input (reconnect) is NOT blocked by the wildcard gu
   };
   const m = autoMatchSlots(sourceNode(), target, "0", null);
   assert.equal(m.inIdx, 0);
+});
+
+// ---- #406: a token that names a TYPE (not a slot name) resolves by type ------
+// The reporter addressed the output as "IMAGE" though its slot is NAMED
+// "output_0" (type IMAGE). resolveExplicitSlot alone name-misses; autoMatchSlots
+// must re-resolve it against slot TYPES instead of throwing the generic "no
+// compatible pair" diagnostic.
+
+// ProPostApplyLUT-shaped: sole output NAMED "output_0" but TYPED IMAGE.
+function lutNode() {
+  return { id: 54, type: "ProPostApplyLUT", outputs: [{ name: "output_0", type: "IMAGE" }] };
+}
+// SaveImageNoMetaNode-shaped: input named "image" (type IMAGE).
+function saveNode() {
+  return { id: 222, type: "SaveImageNoMetaNode", inputs: [{ name: "image", type: "IMAGE", link: null }] };
+}
+
+test("#406: typeMatchedIndices finds slots by TYPE when no name matches", () => {
+  assert.deepEqual(typeMatchedIndices(lutNode().outputs, "IMAGE"), [0]);
+  assert.deepEqual(typeMatchedIndices(lutNode().outputs, "image"), [0]); // case-insensitive
+  assert.deepEqual(typeMatchedIndices(lutNode().outputs, "LATENT"), []); // no such type
+  assert.deepEqual(typeMatchedIndices(lutNode().outputs, 0), []); // numbers are indices, not types
+});
+
+test("#406: from_output addressed by TYPE name connects (was: no compatible pair)", () => {
+  const m = autoMatchSlots(lutNode(), saveNode(), "IMAGE", "image");
+  assert.equal(m.outIdx, 0);
+  assert.equal(m.inIdx, 0);
+});
+
+test("#406: BOTH sides addressed by type name resolve", () => {
+  const origin = { id: 1, outputs: [{ name: "out", type: "IMAGE" }] };
+  const target = { id: 2, inputs: [{ name: "in", type: "IMAGE", link: null }] };
+  const m = autoMatchSlots(origin, target, "IMAGE", "IMAGE");
+  assert.equal(m.outIdx, 0);
+  assert.equal(m.inIdx, 0);
+});
+
+test("#406: a token that matches NEITHER a name NOR a type still refuses", () => {
+  assert.throws(
+    () => autoMatchSlots(lutNode(), saveNode(), "MODEL", "image"),
+    /no compatible|MODEL/i,
+  );
+});
+
+test("#406: an ambiguous type token (2 inputs of that type) is refused, not guessed", () => {
+  const origin = { id: 1, outputs: [{ name: "out", type: "IMAGE" }] };
+  const target = {
+    id: 2,
+    inputs: [
+      { name: "a", type: "IMAGE", link: null },
+      { name: "b", type: "IMAGE", link: null },
+    ],
+  };
+  assert.throws(() => autoMatchSlots(origin, target, "IMAGE", "IMAGE"), /ambiguous/i);
+});
+
+test("#406: an ambiguous OUTPUT type token (2 IMAGE outputs) is refused even with an explicit input", () => {
+  // Two IMAGE outputs + an explicit IMAGE input: the scorer would have silently
+  // picked output 0, wiring a possibly-wrong same-typed branch. Refuse instead.
+  const origin = {
+    id: 1,
+    outputs: [
+      { name: "sharp", type: "IMAGE" },
+      { name: "blurred", type: "IMAGE" },
+    ],
+  };
+  const target = { id: 2, inputs: [{ name: "image", type: "IMAGE", link: null }] };
+  assert.throws(
+    () => autoMatchSlots(origin, target, "IMAGE", "image"),
+    /ambiguous.*IMAGE outputs.*sharp.*blurred/is,
+  );
+});
+
+test("#406: a slot literally NAMED like a type still wins by name first", () => {
+  // Output 0 is NAMED "IMAGE" (type MASK); output 1 is TYPED IMAGE. Name wins.
+  const origin = {
+    id: 1,
+    outputs: [
+      { name: "IMAGE", type: "MASK" },
+      { name: "pixels", type: "IMAGE" },
+    ],
+  };
+  const target = { id: 2, inputs: [{ name: "mask", type: "MASK", link: null }] };
+  const m = autoMatchSlots(origin, target, "IMAGE", "mask");
+  assert.equal(m.outIdx, 0); // resolved by NAME to the MASK slot, not by type
 });

--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -28,6 +28,8 @@ const {
   parseNodeMappings,
   managerUnavailableResult,
   searchNodesVia,
+  parseObjectInfoSearch,
+  objectInfoSearchFallback,
 } = ManagerInstall;
 
 test("looksLikeGitUrl recognizes every git protocol, plus author/repo shorthand (#301)", () => {
@@ -822,4 +824,97 @@ test("managerUnavailableResult is a safe, actionable structured payload", () => 
   assert.equal(r.supported, false);
   assert.equal(r.query, "");
   assert.equal(r.reason, UNREACHABLE.message);
+});
+
+// ---- #426: /object_info installed-node fallback when Manager is unreachable ---
+// On a legacy 3.x Manager without the registry search endpoint (or Manager
+// disabled), nodes_search used to return a bare "unavailable" message. Now, when
+// BOTH Manager routes are unreachable, it searches the connected ComfyUI's core
+// /object_info for INSTALLED nodes matching the query so the agent still gets
+// usable results.
+
+const OBJECT_INFO = {
+  ControlNetApplyAdvanced: {
+    display_name: "Apply ControlNet (Advanced)",
+    category: "conditioning/controlnet",
+    description: "Apply a ControlNet to conditioning.",
+  },
+  ControlNetLoader: {
+    display_name: "Load ControlNet Model",
+    category: "loaders",
+    description: "",
+  },
+  KSampler: { display_name: "KSampler", category: "sampling", description: "" },
+};
+
+test("#426 parseObjectInfoSearch filters installed nodes by query across name/display/category/desc", () => {
+  const r = parseObjectInfoSearch(OBJECT_INFO, "controlnet", 15);
+  assert.equal(r.count, 2);
+  const ids = r.results.map((x) => x.id).sort();
+  assert.deepEqual(ids, ["ControlNetApplyAdvanced", "ControlNetLoader"]);
+  assert.equal(r.results[0].installed, true);
+  // A query that only appears in the display name still hits.
+  assert.equal(parseObjectInfoSearch(OBJECT_INFO, "apply", 15).count, 1);
+  // No match → empty.
+  assert.equal(parseObjectInfoSearch(OBJECT_INFO, "flux", 15).count, 0);
+  // Empty query returns all, capped by limit.
+  assert.equal(parseObjectInfoSearch(OBJECT_INFO, "", 2).results.length, 2);
+});
+
+test("#426 parseObjectInfoSearch tolerates junk input", () => {
+  assert.deepEqual(parseObjectInfoSearch(null, "x", 5), { count: 0, results: [] });
+  assert.deepEqual(parseObjectInfoSearch(undefined, "x", 5), { count: 0, results: [] });
+});
+
+test("#426 searchNodesVia falls back to /object_info when BOTH Manager routes are unreachable", async () => {
+  const throwUnreachable = async () => {
+    throw UNREACHABLE;
+  };
+  const objectInfoGet = async () => OBJECT_INFO;
+  const res = await searchNodesVia(throwUnreachable, throwUnreachable, {
+    query: "ControlNet",
+    objectInfoGet,
+  });
+  assert.equal(res.supported, true);
+  assert.equal(res.managerReachable, false);
+  assert.equal(res.installedOnly, true);
+  assert.equal(res.source, "object_info");
+  assert.equal(res.count, 2);
+  assert.match(res.message, /object_info|installed/i);
+});
+
+test("#426 falls back to the structured unavailable result when /object_info has NO match", async () => {
+  const throwUnreachable = async () => {
+    throw UNREACHABLE;
+  };
+  const res = await searchNodesVia(throwUnreachable, throwUnreachable, {
+    query: "no-such-node-xyz",
+    objectInfoGet: async () => OBJECT_INFO,
+  });
+  assert.equal(res.supported, false);
+  assert.equal(res.count, 0);
+});
+
+test("#426 a failing /object_info fetch degrades to the unavailable result, never throws", async () => {
+  const throwUnreachable = async () => {
+    throw UNREACHABLE;
+  };
+  const res = await objectInfoSearchFallback(
+    async () => {
+      throw new Error("object_info 503");
+    },
+    "ControlNet",
+    15,
+    UNREACHABLE,
+  );
+  assert.equal(res.supported, false);
+  assert.equal(res.managerReachable, false);
+});
+
+test("#426 with no objectInfoGet injected, behavior is unchanged (structured unavailable)", async () => {
+  const throwUnreachable = async () => {
+    throw UNREACHABLE;
+  };
+  const res = await searchNodesVia(throwUnreachable, throwUnreachable, { query: "ControlNet" });
+  assert.equal(res.supported, false);
 });

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -10,6 +10,12 @@
 
 import { coerceMessageText } from "./lib/chat-serialize.js";
 
+/** #417 — client-side abort budget for a single proxied CivitAI request. The
+ *  Python proxy already bounds each upstream ATTEMPT at 30s but retries 3× on
+ *  429/503, so a stalled search can outlast the agent's bridge read; this caps
+ *  the whole browser-side call so _loadMore's catch/finally always runs. */
+export const CIVITAI_REQUEST_TIMEOUT_MS = 15000;
+
 // ── constants (mirror civitai_models.dart) ─────────────────────────────────
 export const LEVELS = [
   { label: "PG", level: 1 },
@@ -277,11 +283,32 @@ export class CivitaiClient {
   }
 
   async _request({ url, method = "GET", body, auth = false, headers }) {
-    const res = await this.api.fetchApi("/comfyui_mcp_panel/civitai/api", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ url, method, body, auth, headers }),
-    });
+    // #417: bound EVERY proxied CivitAI call with a client-side abort. Without it,
+    // a proxy/upstream request that never settles leaves this fetch pending
+    // forever, so _loadMore never reaches its catch/finally — the docked browser
+    // and panel_civitai_results stay {loading:true, total:0, error:null} with no
+    // way to recover. On timeout we THROW a plain Error (no AbortError leaking to
+    // callers) so the existing catch sets state.error and clears loading.
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), CIVITAI_REQUEST_TIMEOUT_MS);
+    let res;
+    try {
+      res = await this.api.fetchApi("/comfyui_mcp_panel/civitai/api", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ url, method, body, auth, headers }),
+        signal: controller.signal,
+      });
+    } catch (e) {
+      if (e?.name === "AbortError") {
+        throw new Error(
+          `CivitAI request timed out after ${Math.round(CIVITAI_REQUEST_TIMEOUT_MS / 1000)} seconds`,
+        );
+      }
+      throw e;
+    } finally {
+      clearTimeout(timeout);
+    }
     if (!res.ok) {
       // Carry the upstream status as a property so callers (the UI's fetch
       // catch) can surface a distinct error state instead of an empty grid

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2868,6 +2868,21 @@ async function managerGet(route, { signal } = {}) {
   return dialect === "legacy" ? managerCall(route, opts) : managerV2(route, opts);
 }
 
+/** #426 — fetch the connected ComfyUI's full `/object_info` map (node CLASS →
+ *  metadata). Always present on a running ComfyUI (no Manager needed), so it is
+ *  the installed-node fallback for nodes_search when the Manager registry search
+ *  is unreachable. Bounded by the shared Manager timeout; throws on any non-ok /
+ *  parse failure (searchNodesVia's fallback swallows it and degrades). */
+async function fetchObjectInfo() {
+  const res = await api.fetchApi("/object_info", {
+    method: "GET",
+    signal: AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS),
+  });
+  if (!res || !res.ok) throw new Error(`/object_info HTTP ${res ? res.status : "no response"}`);
+  const txt = await res.text();
+  return txt ? JSON.parse(txt) : null;
+}
+
 /** Throw if a /v2/manager/queue/batch response reported the target id as failed.
  *  The batch runs synchronously and surfaces failures as {failed:[id,...]} — a
  *  silent success on a failed op is exactly the #184 no-op bug. */
@@ -7510,9 +7525,12 @@ const GRAPH_TOOL_EXECUTORS = {
     // flow. searchNodesVia tries the dialect-routed GET, retries the ABSOLUTE
     // (no-/v2) legacy route on an unreachable/404 signal (a legacy-UI pip build
     // or real 3.x Manager can serve /customnode/getmappings while the /v2 route
-    // 404s — or detectManagerDialect's /v2 probe fails), and returns a
-    // structured {supported:false,…} capability result when BOTH are unreachable.
-    return searchNodesVia(managerGet, managerCall, { query, limit });
+    // 404s — or detectManagerDialect's /v2 probe fails). When BOTH are
+    // unreachable it falls back to an INSTALLED-node search over the connected
+    // ComfyUI's /object_info (#426) so a legacy/disabled Manager still returns
+    // usable, already-installed matches; on a miss it returns the structured
+    // {supported:false,…} capability result.
+    return searchNodesVia(managerGet, managerCall, { query, limit, objectInfoGet: fetchObjectInfo });
   },
 
   async nodes_list() {

--- a/web/js/lib/connect-match.js
+++ b/web/js/lib/connect-match.js
@@ -215,6 +215,37 @@ export function resolveExplicitSlot(slots, ref) {
   return { error: "name" };
 }
 
+/** #406 — indices of the slots whose TYPE (not name) equals the string `ref`,
+ *  case-insensitively/trimmed. Lets a caller address a port by its displayed type
+ *  ("IMAGE", "LATENT") when no slot bears that literal name. Only string-typed
+ *  slots participate (a combo/enum whose `type` is an array or number is never a
+ *  type-name target). Returns [] when `ref` is not a usable string. */
+export function typeMatchedIndices(slots, ref) {
+  if (ref == null || typeof ref === "number") return [];
+  const want = String(ref).trim().toLowerCase();
+  if (!want) return [];
+  const hits = [];
+  (slots ?? []).forEach((s, i) => {
+    if (typeof s?.type === "string" && s.type.trim().toLowerCase() === want) hits.push(i);
+  });
+  return hits;
+}
+
+/** #406 — resolve a slot ref that matched no NAME against slot TYPES. EXACTLY one
+ *  type match → that { index }; SEVERAL → refuse as ambiguous (never guess a
+ *  same-typed sibling — symmetric with the input auto-match ambiguity guard); ZERO
+ *  → the honest name-miss diagnostic. `side` is "output"/"input" for the message. */
+function resolveTypeRef(slots, ref, origin, target, requested, side) {
+  const ti = typeMatchedIndices(slots, ref);
+  if (ti.length === 1) return { index: ti[0] };
+  if (ti.length === 0) throw new Error(slotDiagnostic(origin, target, requested));
+  const names = ti.map((i) => slots[i]?.name).filter(Boolean);
+  const reason =
+    `ambiguous: ${ti.length} ${renderSlotType(slots[ti[0]]?.type)} ${side}s` +
+    `${names.length ? ` (${names.join(", ")})` : ""} — name one by slot name or index`;
+  throw new Error(slotDiagnostic(origin, target, { ...requested, reason }));
+}
+
 /** Resolve output/input slot indices for graph_connect, auto-matching omitted
  *  sides by type. Returns { outIdx, inIdx, autoMatched: [...] } or throws a
  *  diagnostic Error (range error for a bad index; slotDiagnostic otherwise:
@@ -229,13 +260,24 @@ export function autoMatchSlots(origin, target, fromRef, toRef) {
   const inp = resolveExplicitSlot(inputs, toRef);
   if (out?.error === "range")
     throw new Error(`output slot index ${fromRef} out of range (node has ${outputs.length})`);
-  if (out?.error === "name") throw new Error(slotDiagnostic(origin, target, requested));
   if (inp?.error === "range")
     throw new Error(`input slot index ${toRef} out of range (node has ${inputs.length})`);
-  if (inp?.error === "name") throw new Error(slotDiagnostic(origin, target, requested));
 
-  const outIdxFixed = out ? out.index : null;
-  const inIdxFixed = inp ? inp.index : null;
+  // #406: a string ref that matched no slot NAME may instead name a slot's TYPE —
+  // the caller addressed the port by its displayed type ("IMAGE") rather than its
+  // slot name ("output_0"). Before failing, re-resolve the ref against slot TYPES:
+  // EXACTLY ONE slot of that type → treat it as an explicit index; SEVERAL → refuse
+  // as ambiguous (never guess a same-typed sibling — that could wire the wrong
+  // IMAGE branch); ZERO → a genuine name miss, keep the honest diagnostic.
+  const outFix = out?.error === "name"
+    ? resolveTypeRef(outputs, fromRef, origin, target, requested, "output")
+    : out;
+  const inFix = inp?.error === "name"
+    ? resolveTypeRef(inputs, toRef, origin, target, requested, "input")
+    : inp;
+
+  const outIdxFixed = outFix ? outFix.index : null;
+  const inIdxFixed = inFix ? inFix.index : null;
 
   // Both explicit → straight through, no auto-match.
   if (outIdxFixed != null && inIdxFixed != null) {

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -451,6 +451,70 @@ export function parseNodeMappings(data, query, limit) {
 }
 
 /**
+ * #426 — INSTALLED-node search over ComfyUI's core `/object_info` map, the last
+ * resort when the Manager registry backend is unreachable (legacy 3.x without the
+ * search endpoint, or Manager disabled). `/object_info` is keyed by node CLASS
+ * name → { display_name, category, description, ... } and is ALWAYS present on any
+ * running ComfyUI, so an agent can still discover the nodes it can use RIGHT NOW.
+ * Filters by `query` across class name / display_name / category / description and
+ * caps at `limit` (default 15, max 40). Pure so it is unit-testable off-browser.
+ * `id` is the node class name (usable directly as a node type); these are already
+ * installed, so no registry install id is needed.
+ */
+export function parseObjectInfoSearch(objectInfo, query, limit) {
+  const q = String(query ?? "").toLowerCase();
+  const out = [];
+  if (objectInfo && typeof objectInfo === "object") {
+    for (const [cls, meta] of Object.entries(objectInfo)) {
+      const title = meta?.display_name || cls;
+      const desc = meta?.description ?? "";
+      const category = meta?.category ?? "";
+      const hay = `${cls} ${title} ${category} ${desc}`.toLowerCase();
+      if (!q || hay.includes(q)) {
+        out.push({ id: cls, title, description: String(desc).slice(0, 160), installed: true });
+      }
+    }
+  }
+  const max = Math.min(Number(limit) || 15, 40);
+  return { count: out.length, results: out.slice(0, max) };
+}
+
+/**
+ * #426 — when BOTH Manager registry routes are unreachable, try the installed-node
+ * `/object_info` search before giving up. On a hit, return a supported result the
+ * agent can act on (installed-only); otherwise fall through to the structured
+ * "Manager unavailable" capability result. `objectInfoGet` is dependency-injected
+ * (the panel wires the live /object_info fetch) so this stays unit-testable, and
+ * NEVER throws — any /object_info failure degrades to managerUnavailableResult.
+ */
+export async function objectInfoSearchFallback(objectInfoGet, query, limit, err) {
+  if (typeof objectInfoGet !== "function") return managerUnavailableResult(query, err);
+  let info;
+  try {
+    info = await objectInfoGet();
+  } catch {
+    return managerUnavailableResult(query, err);
+  }
+  const parsed = parseObjectInfoSearch(info, query, limit);
+  if (!parsed.count) return managerUnavailableResult(query, err);
+  return {
+    supported: true,
+    managerReachable: false,
+    source: "object_info",
+    installedOnly: true,
+    count: parsed.count,
+    results: parsed.results,
+    query: query == null ? "" : String(query),
+    message:
+      "ComfyUI-Manager's registry search is unavailable (the built-in Manager is " +
+      "disabled, or a legacy/partial build without the search endpoint), so these are " +
+      "INSTALLED nodes matching your query from the connected ComfyUI's /object_info — " +
+      "already available to use directly (add with panel_add_node). Searching/installing " +
+      "NEW packs from the registry needs the built-in Manager (v4+) enabled.",
+  };
+}
+
+/**
  * Graceful-degradation result for nodes_search when the ComfyUI-Manager search
  * backend can NOT be reached on ANY route (dialect-routed /v2 AND the absolute
  * legacy route both threw "not reachable"). Instead of surfacing a raw throw —
@@ -485,11 +549,17 @@ export function managerUnavailableResult(query, err) {
  *   2. on an unreachable/404 signal, retry the ABSOLUTE legacy route (a legacy-
  *      UI pip build or real 3.x Manager can serve /customnode/getmappings while
  *      the /v2 route 404s, or detectManagerDialect's /v2 probe fails);
- *   3. if the absolute route is ALSO unreachable, return the structured
- *      {supported:false,…} capability result instead of throwing.
+ *   3. if the absolute route is ALSO unreachable, try the installed-node
+ *      /object_info search (#426) via the injected `objectInfoGet`; on a miss,
+ *      return the structured {supported:false,…} capability result instead of
+ *      throwing.
  * Any non-"unreachable" error still propagates.
  */
-export async function searchNodesVia(managerGet, managerCall, { query, limit } = {}) {
+export async function searchNodesVia(
+  managerGet,
+  managerCall,
+  { query, limit, objectInfoGet } = {},
+) {
   const route = "customnode/getmappings?mode=cache";
   let data;
   try {
@@ -499,7 +569,8 @@ export async function searchNodesVia(managerGet, managerCall, { query, limit } =
     try {
       data = await managerCall(route);
     } catch (err2) {
-      if (isManagerUnreachable(err2)) return managerUnavailableResult(query, err2);
+      if (isManagerUnreachable(err2))
+        return objectInfoSearchFallback(objectInfoGet, query, limit, err2);
       throw err2;
     }
   }


### PR DESCRIPTION
Three independent panel-side fixes for the workflow-tooling + search cluster. Verified against `origin/main`.

## #406 — connect rejects a valid typed link addressed by type name
`panel_connect` refused a valid `IMAGE → IMAGE` link when `from_output` was given as the displayed **type** name `"IMAGE"` (the slot is NAMED `output_0`). `resolveExplicitSlot` name-missed and `autoMatchSlots` threw the generic "no compatible pair" diagnostic. **Fix:** `autoMatchSlots` re-resolves a name-miss against slot TYPES (`typeMatchedIndices` + `resolveTypeRef`): exactly one type match resolves to that slot; **several REFUSE as ambiguous** (both output and input sides — never guess a same-typed branch); zero keeps the honest diagnostic. Name-first precedence preserved (a slot literally named like a type still wins).

## #417 — CivitAI workflow search can hang forever
`CivitaiClient._request` awaited the proxy with no timeout/AbortSignal, so a stalled upstream left the docked browser and `panel_civitai_results` stuck at `{loading:true, total:0, error:null}` indefinitely — `_loadMore` never reached its catch/finally. **Fix:** a 15s `AbortController`; `AbortError` is converted to a thrown "timed out" Error so the existing catch/finally clears loading. Timer always cleared in `finally`; non-abort errors propagate unchanged.

## #426 — search_nodes fails generically with legacy ComfyUI-Manager
The raw "Manager not reachable" throw was already resolved by the shipped `#251/#255` graceful degrade (structured `{supported:false}`), but there was no **installed-node fallback**. **Fix:** when BOTH Manager routes are unreachable, `searchNodesVia` now searches the connected ComfyUI's core `/object_info` (`parseObjectInfoSearch`, injected `fetchObjectInfo`) and returns matching **installed** nodes; on a miss it returns the prior structured result. Never throws; the no-injection path is unchanged (preserves `#251/#255`).

## Verification
- Full unit suite green (896 tests, incl. new #406/#417/#426 coverage), `tsc --noEmit` clean, monolith parses as ESM.
- Codex self-gate (gpt-5.6-terra, high): **PASS** (2 rounds — round 1 caught an output-side ambiguity that could silently pick the wrong same-typed branch; fixed with symmetric refusal).

Do not merge — draft for review.

Closes artokun/comfyui-mcp-panel#406
Closes artokun/comfyui-mcp-panel#417
Closes artokun/comfyui-mcp-panel#426

🤖 Generated with [Claude Code](https://claude.com/claude-code)
