### PR TITLE
release: 0.11.25 — resize_node/LTXDirector (#530/#314), subgraph scope safety (#412/#411/#405/#409), soft-reload no-wedge (#379), PLAN-box spinner (#492), copy warn (#286), connect/search (#406/#417/#426)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,17 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.25] - 2026-08-01
+
+### Added
+- **`panel_resize_node` resizes a node on the live canvas, and `set_widget` can drive the LTXDirector timeline (#530, #314).** Resize prefers `setSize()` so a Note/MarkdownNote reflows to a readable size (undo-enveloped). LTXDirector's timeline is driven through the node's own `_applyLoadedTimeline` re-hydration, keyed strictly to the `LTXDirector` node type and merged onto the current snapshot (never a general widget-replay), so omitted tracks are preserved and derived widgets are refused loudly.
+
 ### Fixed
-- **`panel_copy_nodes` no longer reports a clean copy that can't round-trip (#286).** When a workflow's custom-node packs aren't installed, copying those nodes used to return a bare `copied: N` even though a later paste silently drops every unregistered type (the packs aren't registered on this frontend, so `LiteGraph.createNode` returns null). `graph_copy_nodes` now checks the copied selection against the frontend's registered node types up front and returns `unregistered_types` + a `warning` naming exactly which types won't paste — so an agent knows before it builds an incomplete graph, complementing the paste-side drop report shipped in #261.
+- **Subgraph exit/run/unpack are scope-aware and safe (#412, #411, #405, #409).** Exiting a nested subgraph pops to the immediate parent (not the workflow root); `panel_run` can target an output node inside a nested subgraph; `panel_unpack_subgraph` is atomic (fully unpacks or rolls back on error instead of leaving a half-unpacked graph); and an unsafe positional bypass of a multi-input subgraph is refused unless `force:true`.
+- **`softReload()` no longer wedges the bridge (#379).** The by-design `503` from `/comfyui_mcp_panel/reload` always hit the failure branch and returned after stopping the client without restarting it (permanent connected-chip/dead-bridge). It now reconnects on every path (bounded), with bridge-lifecycle hardening (instance-guarded listeners, async-reply guard, handshake-timer guard).
+- **The PLAN box spinner stops when the agent is idle (#492).** A plan step left `active` when a turn ended kept spinning forever; the glyph now spins only while the agent is actually working and reverts to a static dot on turn-end/interrupt/disconnect.
+- **`panel_copy_nodes` warns at copy time when copied nodes can't round-trip (#286)** — an unregistered/uninstalled pack type is surfaced as `unregistered_types` + a warning instead of a bare `copied:N` that then silently drops on paste.
+- **Type-name slot addressing, CivitAI search timeout, legacy-Manager node search (#406, #417, #426).** `panel_connect` resolves `from_output="IMAGE"` (a type name) against slot types instead of refusing it (ambiguous type → refuse, not guess); the CivitAI workflow search has a 15s timeout (no more infinite `loading`); and `panel_search_nodes` falls back to an `/object_info` search when a legacy Manager is unreachable.
 
 ## [0.11.24] - 2026-08-01
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.24"
+version = "0.11.25"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -328,7 +328,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.24";
+const PANEL_VERSION = "0.11.25";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Six codex-gated clusters since 0.11.24. Registry publish fires on the pyproject change. Companion to mcp 0.48.25 (published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)