### PR TITLE
fix(panel): robust node removal (#420) + trustworthy manual-change notice (#369)

### DIFF
--- a/browser_tests/unit/manual-change-gate.test.mjs
+++ b/browser_tests/unit/manual-change-gate.test.mjs
@@ -1,0 +1,148 @@
+// Unit tests for the manual-canvas-change baseline gate (web/js/lib/manual-change-gate.js).
+//
+// Regression coverage for #369: after a session reload/resume the tracker injected a
+// "MANUAL CANVAS CHANGES … 100+ nodes removed" notice that the very next live graph
+// read contradicted. Root cause: the baseline (captured before the session boundary)
+// was diffed against a rebound / mid-reload canvas. The gate must discard a baseline
+// from a prior session epoch, and never diff on an unconfirmable workflow identity.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { classifyManualChangeBaseline } from "../../web/js/lib/manual-change-gate.js";
+
+const KEY_A = "uuid-A";
+const KEY_B = "uuid-B";
+
+test("same epoch + same confirmed identity → diff", () => {
+  const d = classifyManualChangeBaseline({
+    hasBaseline: true,
+    baselineKey: KEY_A,
+    baselineEpoch: 3,
+    currentKey: KEY_A,
+    currentEpoch: 3,
+  });
+  assert.equal(d.action, "diff");
+});
+
+test("baseline from a PRIOR session epoch → reseed, never diff (#369 core)", () => {
+  // The reported bug: baseline captured at epoch 2, then a reconnect/resume bumped
+  // the epoch to 3. Even with a matching workflow identity, the baseline is stale.
+  const d = classifyManualChangeBaseline({
+    hasBaseline: true,
+    baselineKey: KEY_A,
+    baselineEpoch: 2,
+    currentKey: KEY_A,
+    currentEpoch: 3,
+  });
+  assert.equal(d.action, "reseed", "a cross-epoch baseline must be discarded, not diffed");
+});
+
+test("provably different identity (same epoch) → workflow-changed notice", () => {
+  const d = classifyManualChangeBaseline({
+    hasBaseline: true,
+    baselineKey: KEY_A,
+    baselineEpoch: 5,
+    currentKey: KEY_B,
+    currentEpoch: 5,
+  });
+  assert.equal(d.action, "workflow-changed");
+});
+
+test("unknown current identity (same epoch) → reseed, never a false delta (#369)", () => {
+  // workflowStableUuid() threw / could not resolve during a mid-reload window.
+  const d = classifyManualChangeBaseline({
+    hasBaseline: true,
+    baselineKey: KEY_A,
+    baselineEpoch: 1,
+    currentKey: null,
+    currentEpoch: 1,
+  });
+  assert.equal(d.action, "reseed");
+});
+
+test("unknown baseline identity (same epoch) → reseed, never a false delta", () => {
+  const d = classifyManualChangeBaseline({
+    hasBaseline: true,
+    baselineKey: null,
+    baselineEpoch: 1,
+    currentKey: KEY_A,
+    currentEpoch: 1,
+  });
+  assert.equal(d.action, "reseed");
+});
+
+test("no baseline yet → reseed (nothing to diff)", () => {
+  const d = classifyManualChangeBaseline({
+    hasBaseline: false,
+    baselineKey: null,
+    baselineEpoch: -1,
+    currentKey: KEY_A,
+    currentEpoch: 0,
+  });
+  assert.equal(d.action, "reseed");
+});
+
+test("epoch precedence: a cross-epoch boundary wins even over a workflow-switch", () => {
+  // Different identity AND different epoch — the stale-epoch reseed takes precedence
+  // (we don't assert a confident "workflow changed" across a session boundary we
+  // can't reason about); either way, no per-node delta is emitted.
+  const d = classifyManualChangeBaseline({
+    hasBaseline: true,
+    baselineKey: KEY_A,
+    baselineEpoch: 2,
+    currentKey: KEY_B,
+    currentEpoch: 4,
+  });
+  assert.equal(d.action, "reseed");
+});
+
+test("non-finite / missing epoch on either side is treated as a boundary → reseed", () => {
+  const nonFinite = [NaN, undefined, null, Infinity, "3"];
+  for (const bad of nonFinite) {
+    assert.equal(
+      classifyManualChangeBaseline({
+        hasBaseline: true,
+        baselineKey: KEY_A,
+        baselineEpoch: bad,
+        currentKey: KEY_A,
+        currentEpoch: 0,
+      }).action,
+      "reseed",
+      `baselineEpoch=${String(bad)} must reseed`,
+    );
+    assert.equal(
+      classifyManualChangeBaseline({
+        hasBaseline: true,
+        baselineKey: KEY_A,
+        baselineEpoch: 0,
+        currentKey: KEY_A,
+        currentEpoch: bad,
+      }).action,
+      "reseed",
+      `currentEpoch=${String(bad)} must reseed`,
+    );
+  }
+  // Both sides non-finite (the Object.is(NaN,NaN)===true trap) must STILL reseed.
+  assert.equal(
+    classifyManualChangeBaseline({
+      hasBaseline: true,
+      baselineKey: KEY_A,
+      baselineEpoch: NaN,
+      currentKey: KEY_A,
+      currentEpoch: NaN,
+    }).action,
+    "reseed",
+    "both-NaN must not diff",
+  );
+  assert.equal(
+    classifyManualChangeBaseline({
+      hasBaseline: true,
+      baselineKey: KEY_A,
+      baselineEpoch: undefined,
+      currentKey: KEY_A,
+      currentEpoch: undefined,
+    }).action,
+    "reseed",
+    "both-undefined must not diff",
+  );
+});

--- a/browser_tests/unit/safe-remove-node.test.mjs
+++ b/browser_tests/unit/safe-remove-node.test.mjs
@@ -1,0 +1,441 @@
+// Unit tests for the robust node-removal wrapper (web/js/lib/safe-remove-node.js).
+//
+// Regression coverage for #420: on rapid batched removals litegraph intermittently
+// throws "t.findInputSlot is not a function" while disconnecting a link whose far end
+// momentarily isn't a proper LGraphNode, aborting the removal (the same call succeeds
+// on retry). safeRemoveNode severs the node's links via the link RECORDS (far-end
+// method-free) and retries once.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  safeRemoveNode,
+  severNodeLinks,
+  isLinkDisconnectCrash,
+} from "../../web/js/lib/safe-remove-node.js";
+
+// Minimal litegraph-shaped mock. `_links` is a Map<id, {id,origin_id,origin_slot,
+// target_id,target_slot}>. graph.remove(node) reproduces litegraph: walk this node's
+// links and touch the far end. A NON-NULL far end that lacks findInputSlot (a
+// non-LGraphNode) reproduces the #420 crash → THROW. A NULL far end (rail / already
+// gone) is SKIPPED — litegraph's `if (target) {...}` guard — and its record deleted,
+// never a throw.
+function makeGraph() {
+  const nodesById = new Map();
+  const graph = {
+    _links: new Map(),
+    inputNode: null,
+    outputNode: null,
+    getNodeById: (id) => nodesById.get(id) ?? null,
+    _register: (n) => nodesById.set(n.id, n),
+    remove(node) {
+      for (const out of node.outputs ?? []) {
+        for (const id of Array.isArray(out.links) ? [...out.links] : []) {
+          const link = this._links.get(id);
+          if (!link) continue;
+          const far = this.getNodeById(link.target_id);
+          if (far != null && typeof far.findInputSlot !== "function") {
+            throw new TypeError("t.findInputSlot is not a function");
+          }
+          if (far) far.inputs[link.target_slot].link = null;
+          this._links.delete(id);
+        }
+        out.links = null;
+      }
+      for (const inp of node.inputs ?? []) {
+        if (inp.link != null) {
+          const link = this._links.get(inp.link);
+          if (link) {
+            const far = this.getNodeById(link.origin_id);
+            if (far != null && typeof far.findInputSlot !== "function") {
+              throw new TypeError("t.findInputSlot is not a function");
+            }
+            this._links.delete(inp.link);
+          }
+          inp.link = null;
+        }
+      }
+      nodesById.delete(node.id);
+      node._removed = true;
+    },
+  };
+  return graph;
+}
+
+// Build a graph: node A (output) → node B (input), where B is optionally a "bad"
+// far end that lacks findInputSlot (the crash trigger).
+function wireAtoB(graph, { bBad }) {
+  const B = bBad
+    ? { id: 2, inputs: [{ name: "in", link: 10 }], outputs: [] } // no findInputSlot
+    : { id: 2, inputs: [{ name: "in", link: 10 }], outputs: [], findInputSlot: () => 0 };
+  const A = {
+    id: 1,
+    inputs: [],
+    outputs: [{ name: "out", links: [10] }],
+    findInputSlot: () => -1,
+  };
+  graph._register(A);
+  graph._register(B);
+  graph._links.set(10, { id: 10, origin_id: 1, origin_slot: 0, target_id: 2, target_slot: 0 });
+  return { A, B };
+}
+
+test("normal removal (no throw) → removed, not recovered, remove() called once", () => {
+  const graph = makeGraph();
+  const { A } = wireAtoB(graph, { bBad: false });
+  let calls = 0;
+  const orig = graph.remove.bind(graph);
+  graph.remove = (n) => { calls++; return orig(n); };
+  const res = safeRemoveNode(graph, A);
+  assert.deepEqual(res, { removed: true, recovered: false });
+  assert.equal(calls, 1);
+  assert.equal(graph.getNodeById(1), null, "node A is gone");
+  assert.equal(graph._links.has(10), false, "the link was removed");
+});
+
+test("bad far end throws on first remove, sever+retry succeeds (#420 core)", () => {
+  const graph = makeGraph();
+  const { A, B } = wireAtoB(graph, { bBad: true }); // B lacks findInputSlot → crash
+  const res = safeRemoveNode(graph, A);
+  assert.deepEqual(res, { removed: true, recovered: true });
+  assert.equal(graph.getNodeById(1), null, "node A was removed on the retry");
+  assert.equal(graph._links.has(10), false, "the dangling link record was severed");
+  // The far end B survives and its stale input ref was cleared by the sever (direct
+  // property write, no findInputSlot call).
+  assert.equal(graph.getNodeById(2), B, "far end B is untouched as a node");
+  assert.equal(B.inputs[0].link, null, "B's stale input link ref was cleared");
+});
+
+test("severNodeLinks clears both this node's slots and reachable far-end refs", () => {
+  const graph = makeGraph();
+  // A.out → B.in (id 10); C.out → A.in (id 11).
+  const A = {
+    id: 1,
+    inputs: [{ name: "cin", link: 11 }],
+    outputs: [{ name: "out", links: [10] }],
+  };
+  const B = { id: 2, inputs: [{ name: "in", link: 10 }], outputs: [] };
+  const C = { id: 3, inputs: [], outputs: [{ name: "cout", links: [11] }] };
+  graph._register(A); graph._register(B); graph._register(C);
+  graph._links.set(10, { id: 10, origin_id: 1, origin_slot: 0, target_id: 2, target_slot: 0 });
+  graph._links.set(11, { id: 11, origin_id: 3, origin_slot: 0, target_id: 1, target_slot: 0 });
+
+  severNodeLinks(graph, A);
+
+  assert.equal(graph._links.has(10), false, "outgoing link record removed");
+  assert.equal(graph._links.has(11), false, "incoming link record removed");
+  assert.equal(A.outputs[0].links, null, "A's output links nulled");
+  assert.equal(A.inputs[0].link, null, "A's input link nulled");
+  assert.equal(B.inputs[0].link, null, "far-end B input ref cleared");
+  assert.deepEqual(C.outputs[0].links, [], "far-end C output ref spliced out");
+});
+
+test("STORE SWEEP: severs a record whose slot ref was already nulled by a partial remove (codex P1)", () => {
+  // Reproduce the partial-mutation failure mode: a mid-disconnect graph.remove nulled
+  // A.outputs[0].links BEFORE throwing, but link record 10 (A→B) still lives in the
+  // store. The slot pass can no longer reach it; the store sweep must still drop it
+  // and clear B's mirror ref, else the retry orphans a dangling link.
+  const graph = makeGraph();
+  const A = { id: 1, inputs: [], outputs: [{ name: "out", links: null }] }; // slot ref lost
+  const B = { id: 2, inputs: [{ name: "in", link: 10 }], outputs: [] };
+  graph._register(A); graph._register(B);
+  graph._links.set(10, { id: 10, origin_id: 1, origin_slot: 0, target_id: 2, target_slot: 0 });
+
+  severNodeLinks(graph, A);
+
+  assert.equal(graph._links.has(10), false, "orphaned record dropped via store sweep");
+  assert.equal(B.inputs[0].link, null, "far-end B mirror ref cleared via store sweep");
+});
+
+test("STORE SWEEP: also severs an INCOMING record orphaned by a partial remove", () => {
+  const graph = makeGraph();
+  // C.out → A.in (id 11); A's input slot ref already nulled by the partial remove.
+  const A = { id: 1, inputs: [{ name: "cin", link: null }], outputs: [] };
+  const C = { id: 3, inputs: [], outputs: [{ name: "cout", links: [11] }] };
+  graph._register(A); graph._register(C);
+  graph._links.set(11, { id: 11, origin_id: 3, origin_slot: 0, target_id: 1, target_slot: 0 });
+
+  severNodeLinks(graph, A);
+
+  assert.equal(graph._links.has(11), false, "incoming orphaned record dropped");
+  assert.deepEqual(C.outputs[0].links, [], "far-end C output ref spliced via store sweep");
+});
+
+test("STORE SWEEP: string-vs-number node id representations still match", () => {
+  const graph = makeGraph();
+  const A = { id: 1, inputs: [], outputs: [{ name: "out", links: null }] };
+  const B = { id: 2, inputs: [{ name: "in", link: 10 }], outputs: [] };
+  graph._register(A); graph._register(B);
+  // Record stores origin_id as a string "1" (subgraph-style id) vs node.id number 1.
+  graph._links.set(10, { id: 10, origin_id: "1", origin_slot: 0, target_id: 2, target_slot: 0 });
+  severNodeLinks(graph, A);
+  assert.equal(graph._links.has(10), false, "string/number id mismatch still swept");
+  assert.equal(B.inputs[0].link, null, "far-end B mirror cleared");
+});
+
+test("RAIL SAFETY: a link to a subgraph boundary rail (-20 / graph.outputNode) is LEFT for litegraph, not dropped", () => {
+  // Codex round-2 P1: dropping a rail-connected record here would strand the rail's
+  // own slot linkIds (rails aren't in getNodeById). Rail links must be left untouched
+  // for litegraph's rail-aware retry and the caller's boundary pruning.
+  const graph = makeGraph();
+  const A = { id: 1, inputs: [], outputs: [{ name: "out", links: [10] }] };
+  graph._register(A);
+  // target_id -20 is the reserved SUBGRAPH_OUTPUT_RAIL_ID.
+  graph._links.set(10, { id: 10, origin_id: 1, origin_slot: 0, target_id: -20, target_slot: 0 });
+  assert.doesNotThrow(() => severNodeLinks(graph, A));
+  assert.equal(graph._links.has(10), true, "rail record is LEFT, not dropped");
+  assert.deepEqual(A.outputs[0].links, [10], "rail slot id kept for litegraph's rail-aware retry");
+});
+
+test("RAIL SAFETY: recognizes a rail by graph.inputNode.id too (not only the reserved id)", () => {
+  const graph = makeGraph();
+  graph.inputNode = { id: 42 }; // this graph's live input rail node
+  const A = { id: 1, inputs: [{ name: "in", link: 11 }], outputs: [] };
+  graph._register(A);
+  graph._links.set(11, { id: 11, origin_id: 42, origin_slot: 0, target_id: 1, target_slot: 0 });
+  severNodeLinks(graph, A);
+  assert.equal(graph._links.has(11), true, "link from the live input rail is left");
+  assert.equal(A.inputs[0].link, 11, "this node's rail input ref is kept");
+});
+
+test("MISSING (non-rail) far end: the orphan record is DROPPED, not left (#420 codex round-3 P1b)", () => {
+  // A missing (already-removed) far-end node is NOT a rail; leaving its record would
+  // orphan a link pointing at the removed node (classic disconnectInput early-returns
+  // without deleting it). Drop it — no orphan, matches modern litegraph self-heal.
+  const graph = makeGraph();
+  const A = { id: 1, inputs: [{ name: "cin", link: 11 }], outputs: [{ name: "out", links: [10] }] };
+  graph._register(A);
+  graph._links.set(10, { id: 10, origin_id: 1, origin_slot: 0, target_id: 77, target_slot: 0 });
+  graph._links.set(11, { id: 11, origin_id: 88, origin_slot: 0, target_id: 1, target_slot: 0 });
+  severNodeLinks(graph, A);
+  assert.equal(graph._links.has(10), false, "outgoing orphan (missing target) dropped");
+  assert.equal(graph._links.has(11), false, "incoming orphan (missing origin) dropped — no P1b orphan");
+  assert.equal(A.outputs[0].links, null);
+  assert.equal(A.inputs[0].link, null);
+});
+
+test("MIXED: severs the broken far-end link but leaves the rail link on the same node", () => {
+  const graph = makeGraph();
+  // A.out slot 0 → B.in (id 10, B is a broken far end → sever). A.out slot 1 → rail
+  // (id 11, target -20 → leave).
+  const A = {
+    id: 1,
+    inputs: [],
+    outputs: [
+      { name: "o0", links: [10] },
+      { name: "o1", links: [11] },
+    ],
+  };
+  const B = { id: 2, inputs: [{ name: "in", link: 10 }], outputs: [] };
+  graph._register(A); graph._register(B);
+  graph._links.set(10, { id: 10, origin_id: 1, origin_slot: 0, target_id: 2, target_slot: 0 });
+  graph._links.set(11, { id: 11, origin_id: 1, origin_slot: 1, target_id: -20, target_slot: 0 });
+
+  severNodeLinks(graph, A);
+
+  assert.equal(graph._links.has(10), false, "resolvable broken link severed");
+  assert.equal(graph._links.has(11), true, "rail link left for litegraph");
+  assert.equal(A.outputs[0].links, null, "severed slot nulled");
+  assert.deepEqual(A.outputs[1].links, [11], "rail slot kept");
+  assert.equal(B.inputs[0].link, null, "broken far-end mirror cleared");
+});
+
+test("a node with no links removes cleanly", () => {
+  const graph = makeGraph();
+  const solo = { id: 5, inputs: [], outputs: [] };
+  graph._register(solo);
+  const res = safeRemoveNode(graph, solo);
+  assert.deepEqual(res, { removed: true, recovered: false });
+  assert.equal(graph.getNodeById(5), null);
+});
+
+test("recovery is HOOK-FREE: it never re-runs litegraph's disconnect, so a far-end onConnectionsChange is NOT re-invoked (codex R6 P1)", () => {
+  // The recovery path must sever links at the record level only — never call the
+  // node's disconnectOutput/disconnectInput — so a far-end disconnect hook that threw
+  // the crash is not invoked a second time.
+  const graph = makeGraph();
+  let disconnectCalls = 0;
+  let farHookCalls = 0;
+  const B = {
+    id: 2,
+    inputs: [{ name: "in", link: 10 }],
+    outputs: [],
+    // The far-end node's disconnect hook (would fire if litegraph re-disconnected).
+    onConnectionsChange() { farHookCalls++; },
+    // Note: no findInputSlot → the mock's remove throws the #420 crash for this link.
+  };
+  const node = {
+    id: 1,
+    inputs: [],
+    outputs: [{ name: "out", links: [10] }],
+    disconnectOutput() { disconnectCalls++; },
+    disconnectInput() { disconnectCalls++; },
+  };
+  graph._register(node); graph._register(B);
+  graph._links.set(10, { id: 10, origin_id: 1, origin_slot: 0, target_id: 2, target_slot: 0 });
+  const res = safeRemoveNode(graph, node);
+  assert.deepEqual(res, { removed: true, recovered: true });
+  assert.equal(disconnectCalls, 0, "node.disconnect* was NOT called on recovery (hook-free)");
+  assert.equal(farHookCalls, 0, "far-end onConnectionsChange was NOT re-invoked");
+  assert.equal(graph.getNodeById(1), null, "node removed on retry");
+  assert.equal(graph._links.has(10), false, "link record severed at the record level");
+  assert.equal(B.inputs[0].link, null, "far-end mirror cleared by a plain write");
+});
+
+test("a genuine persistent failure propagates (retry also throws)", () => {
+  const graph = makeGraph();
+  // Residual link so the disconnect-phase crash is recognized and recovery proceeds.
+  const node = { id: 7, inputs: [{ name: "in", link: 10 }], outputs: [] };
+  const B = { id: 2, inputs: [], outputs: [{ name: "o", links: [10] }] };
+  graph._register(node); graph._register(B);
+  graph._links.set(10, { id: 10, origin_id: 2, origin_slot: 0, target_id: 7, target_slot: 0 });
+  // The recognized crash on first call, then a DIFFERENT hard failure on retry.
+  let first = true;
+  graph.remove = () => {
+    if (first) { first = false; throw new TypeError("t.findInputSlot is not a function"); }
+    throw new Error("boom");
+  };
+  assert.throws(() => safeRemoveNode(graph, node), /boom/);
+});
+
+test("NARROW CATCH: an unrelated first-attempt error is NOT retried and propagates (codex P1a)", () => {
+  // A node onRemoved() throwing (or any non-link-disconnect error) must propagate on
+  // the FIRST attempt — never retried (which could duplicate side effects) or masked.
+  const graph = makeGraph();
+  const node = { id: 8, inputs: [], outputs: [] };
+  graph._register(node);
+  let calls = 0;
+  graph.remove = () => { calls++; throw new Error("onRemoved blew up"); };
+  assert.throws(() => safeRemoveNode(graph, node), /onRemoved blew up/);
+  assert.equal(calls, 1, "unrelated error is not retried");
+});
+
+test("NARROW CATCH: an onRemoved hook throwing the IDENTICAL crash message is NOT retried (no residual links, codex R4/R5 P1a)", () => {
+  // litegraph fully disconnects every link BEFORE firing onRemoved (both modern AND
+  // classic — classic fires onRemoved before splicing the node out, so node-presence
+  // can't discriminate). A hook thrown after full disconnection leaves NO links, so
+  // even with an identical-looking TypeError we must NOT sever+retry (that would
+  // re-run the hook / duplicate side effects) — we must propagate. The node here has
+  // no links (fully disconnected), modeling the post-disconnect state.
+  const graph = makeGraph();
+  const node = { id: 9, inputs: [{ name: "in", link: null }], outputs: [{ name: "o", links: null }] };
+  graph._register(node);
+  let calls = 0;
+  graph.remove = () => {
+    calls++;
+    // Node still in the graph (classic ordering: onRemoved before splice), but its
+    // links are already gone — the crash is from onRemoved, not disconnect.
+    throw new TypeError("t.findInputSlot is not a function");
+  };
+  assert.throws(() => safeRemoveNode(graph, node), /findInputSlot/);
+  assert.equal(calls, 1, "a post-disconnect hook error is not retried");
+});
+
+test("RECOVERY fires for the disconnect-phase crash (RESIDUAL links present)", () => {
+  // The crash happens during disconnect: the node still has links attached → recover.
+  const graph = makeGraph();
+  const A = { id: 1, inputs: [], outputs: [{ name: "out", links: [10] }] };
+  const B = { id: 2, inputs: [{ name: "in", link: 10 }], outputs: [] }; // no findInputSlot
+  graph._register(A); graph._register(B);
+  graph._links.set(10, { id: 10, origin_id: 1, origin_slot: 0, target_id: 2, target_slot: 0 });
+  const res = safeRemoveNode(graph, A);
+  assert.deepEqual(res, { removed: true, recovered: true });
+  assert.equal(graph.getNodeById(1), null);
+});
+
+test("NARROW CATCH: residual links tracked via the STORE even if slot refs were nulled", () => {
+  // If a partial disconnect nulled the slot refs but a record still references the
+  // node, that's still a disconnect-phase crash → recover.
+  const graph = makeGraph();
+  const A = { id: 1, inputs: [{ name: "in", link: null }], outputs: [{ name: "o", links: null }] };
+  const B = { id: 2, inputs: [{ name: "in", link: 10 }], outputs: [] };
+  graph._register(A); graph._register(B);
+  graph._links.set(10, { id: 10, origin_id: 1, origin_slot: 0, target_id: 2, target_slot: 0 });
+  let calls = 0;
+  const realRemove = graph.remove.bind(graph);
+  graph.remove = (n) => {
+    calls++;
+    if (calls === 1) throw new TypeError("t.findInputSlot is not a function");
+    return realRemove(n);
+  };
+  const res = safeRemoveNode(graph, A);
+  assert.deepEqual(res, { removed: true, recovered: true });
+  assert.equal(graph._links.has(10), false, "residual store record swept");
+});
+
+test("RAIL SAFETY: recognizes a rail via the private _inputNode variant (codex R4 P2)", () => {
+  const graph = makeGraph();
+  graph._inputNode = { id: 55 }; // private variant property
+  const A = { id: 1, inputs: [{ name: "in", link: 11 }], outputs: [] };
+  graph._register(A);
+  graph._links.set(11, { id: 11, origin_id: 55, origin_slot: 0, target_id: 1, target_slot: 0 });
+  severNodeLinks(graph, A);
+  assert.equal(graph._links.has(11), true, "link from the private-variant rail is left");
+  assert.equal(A.inputs[0].link, 11, "rail input ref kept");
+});
+
+test("isLinkDisconnectCrash matches only the far-end slot-lookup crash, rejects unrelated errors", () => {
+  assert.equal(isLinkDisconnectCrash(new TypeError("t.findInputSlot is not a function")), true);
+  assert.equal(isLinkDisconnectCrash(new TypeError("e.findOutputSlot is not a function")), true);
+  // Narrowed: other connection methods are NOT accepted (a custom hook throwing them
+  // must not be treated as the litegraph link-traversal crash).
+  assert.equal(isLinkDisconnectCrash(new TypeError("n.disconnectInput is not a function")), false);
+  assert.equal(isLinkDisconnectCrash(new TypeError("x.onConnectionsChange is not a function")), false);
+  // Unrelated shapes must NOT match.
+  assert.equal(isLinkDisconnectCrash(new Error("t.findInputSlot is not a function")), false, "not a TypeError");
+  assert.equal(isLinkDisconnectCrash(new TypeError("Cannot read properties of null")), false);
+  assert.equal(isLinkDisconnectCrash(new TypeError("foo is not a function")), false, "no slot lookup");
+  assert.equal(isLinkDisconnectCrash(undefined), false);
+});
+
+test("prefers LLink.disconnect() so modern reroute/layout cleanup happens (codex R7 P1)", () => {
+  // A modern link record exposes .disconnect(network), which deletes the record AND
+  // clears reroute linkIds + layout state. severNodeLinks must call it (not a raw
+  // store delete) so a rerouted link doesn't leave dangling reroute state.
+  const graph = makeGraph();
+  const reroute = { id: 500, linkIds: new Set([10]) };
+  const A = { id: 1, inputs: [], outputs: [{ name: "out", links: [10] }] };
+  const B = { id: 2, inputs: [{ name: "in", link: 10 }], outputs: [] };
+  graph._register(A); graph._register(B);
+  let disconnectArg;
+  const link = {
+    id: 10, origin_id: 1, origin_slot: 0, target_id: 2, target_slot: 0,
+    disconnect(network) {
+      disconnectArg = network;
+      network._links.delete(this.id); // modern: remove the record
+      reroute.linkIds.delete(this.id); // modern: clean the reroute
+    },
+  };
+  graph._links.set(10, link);
+
+  severNodeLinks(graph, A);
+
+  assert.equal(disconnectArg, graph, "LLink.disconnect was called with the graph as network");
+  assert.equal(graph._links.has(10), false, "record removed via LLink.disconnect");
+  assert.equal(reroute.linkIds.has(10), false, "reroute linkId cleaned (no dangling reroute state)");
+  assert.equal(B.inputs[0].link, null, "far-end mirror still cleared");
+});
+
+test("falls back to raw store deletion when the record has no .disconnect() (legacy)", () => {
+  const graph = makeGraph();
+  const A = { id: 1, inputs: [], outputs: [{ name: "out", links: [10] }] };
+  const B = { id: 2, inputs: [{ name: "in", link: 10 }], outputs: [] };
+  graph._register(A); graph._register(B);
+  graph._links.set(10, { id: 10, origin_id: 1, origin_slot: 0, target_id: 2, target_slot: 0 });
+  severNodeLinks(graph, A);
+  assert.equal(graph._links.has(10), false, "legacy record removed via raw delete");
+});
+
+test("works against the back-compat `links` record store (no _links Map)", () => {
+  // Some builds expose only the legacy record. severNodeLinks must still delete.
+  const records = { 10: { id: 10, origin_id: 1, origin_slot: 0, target_id: 2, target_slot: 0 } };
+  const nodesById = new Map();
+  const A = { id: 1, inputs: [], outputs: [{ name: "out", links: [10] }] };
+  const B = { id: 2, inputs: [{ name: "in", link: 10 }], outputs: [] };
+  nodesById.set(1, A); nodesById.set(2, B);
+  const graph = { links: records, getNodeById: (id) => nodesById.get(id) ?? null };
+  severNodeLinks(graph, A);
+  assert.equal(records[10], undefined, "legacy record deleted");
+  assert.equal(A.outputs[0].links, null);
+  assert.equal(B.inputs[0].link, null);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -121,6 +121,8 @@ import {
   computeOrphanedBoundaries,
 } from "./lib/subgraph-scope.js";
 import { runSetWidget } from "./lib/set-widget.js";
+import { classifyManualChangeBaseline } from "./lib/manual-change-gate.js";
+import { safeRemoveNode } from "./lib/safe-remove-node.js";
 import {
   controlAfterGenerateModes,
   controlAfterGenerateEntries,
@@ -3584,6 +3586,15 @@ let lastAgentGraph = null;
 // same-workflow events and would otherwise drop a real manual edit made across a
 // save/rename as a spurious "different workflow".
 let lastAgentGraphKey = null;
+// #369: the SESSION-BINDING generation the baseline was captured in. sessionEpoch is
+// bumped on every orchestrator socket (re)connect (see the bridge client's "open"
+// handler) — i.e. on a reconnect / session resume / reload. The manual-change diff is
+// trusted ONLY when the baseline's epoch still matches the current one; a baseline
+// captured before a session boundary is discarded (reseeded) rather than diffed
+// against a possibly rebound / mid-reload canvas, which previously produced a false
+// "100+ nodes removed" notice that the very next live graph read contradicted.
+let lastAgentGraphEpoch = -1;
+let sessionEpoch = 0;
 
 const MODE_NAME = { 0: "active", 2: "mute", 4: "bypass" };
 const modeName = (m) => MODE_NAME[m] ?? `mode${m ?? 0}`;
@@ -3724,19 +3735,41 @@ function manualChangeBanner() {
   } catch {
     return "";
   }
-  // If the active workflow is not the one the snapshot came from, the user
-  // switched tabs — do NOT diff two different graphs (that produces a bogus
-  // "manual edits" list, #348/#198). Reseed to the now-active graph and tell the
-  // agent to re-read, rather than asserting a false ground-truth delta.
   let currKey = null;
   try {
     currKey = workflowStableUuid();
   } catch {
     currKey = null;
   }
-  if (lastAgentGraphKey && currKey && currKey !== lastAgentGraphKey) {
+  // Gate the diff (#369, #348/#198): only diff when the baseline was captured in the
+  // SAME session generation (no reconnect / resume / reload since) AND the bound
+  // workflow's identity is confirmed unchanged. Otherwise reseed silently (stale
+  // epoch / unknown identity) or emit a workflow-switch notice — never a bogus
+  // per-node delta between two different or stale-vs-live graphs.
+  const reseed = () => {
     lastAgentGraph = curr;
     lastAgentGraphKey = currKey;
+    lastAgentGraphEpoch = sessionEpoch;
+  };
+  const decision = classifyManualChangeBaseline({
+    hasBaseline: true,
+    baselineKey: lastAgentGraphKey,
+    baselineEpoch: lastAgentGraphEpoch,
+    currentKey: currKey,
+    currentEpoch: sessionEpoch,
+  });
+  if (decision.action === "reseed") {
+    // A session boundary was crossed since the baseline was captured, or the
+    // workflow identity can't be confirmed — adopt the current graph as the new
+    // baseline WITHOUT asserting a (false) delta.
+    reseed();
+    return "";
+  }
+  if (decision.action === "workflow-changed") {
+    // The active workflow is not the one the baseline came from — the user switched
+    // tabs. Reseed and tell the agent to re-read rather than diff two different
+    // graphs (that produced a bogus "manual edits" list, #348/#198).
+    reseed();
     return (
       `⟳ ACTIVE WORKFLOW CHANGED since your last turn. ` +
       `The canvas you're now bound to is a DIFFERENT workflow — your remembered ` +
@@ -3744,8 +3777,7 @@ function manualChangeBanner() {
     );
   }
   const lines = diffGraphsForAgent(lastAgentGraph, curr, live);
-  lastAgentGraph = curr;
-  lastAgentGraphKey = currKey;
+  reseed();
   if (!lines.length) return "";
   const MAX = 40;
   const shown = lines.slice(0, MAX);
@@ -5257,7 +5289,11 @@ const GRAPH_TOOL_EXECUTORS = {
     let removedOk = false;
     graph.beforeChange();
     try {
-      graph.remove(node);
+      // #420: robust against the intermittent litegraph link-disconnect crash
+      // ("t.findInputSlot is not a function") seen on rapid batched removals — on a
+      // first-attempt throw it severs this node's links via the record path and
+      // retries once, instead of aborting the removal.
+      safeRemoveNode(graph, node);
       // graph.remove() is a NO-OP for protected nodes (ignore_remove). Only prune
       // (and report success) once the node has ACTUALLY left the graph — otherwise
       // we would delete boundary slots still connected to a surviving node.
@@ -5289,7 +5325,10 @@ const GRAPH_TOOL_EXECUTORS = {
     // than graph.clear(): the whole wipe becomes a single Ctrl+Z step.
     graph.beforeChange();
     try {
-      for (const node of nodes) graph.remove(node);
+      // #420: same robust removal as graph_remove_node — clearing IS a batch, the
+      // exact condition that intermittently throws "t.findInputSlot is not a
+      // function" mid-disconnect on some litegraph builds.
+      for (const node of nodes) safeRemoveNode(graph, node);
     } finally {
       graph.afterChange();
     }
@@ -8279,6 +8318,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
 
     sock.addEventListener("open", () => {
       handshakeDone = false;
+      // #369: a new orchestrator socket is a (re)connect / session-resume boundary.
+      // Bump the session generation so the manual-change tracker discards any
+      // baseline captured before this boundary instead of diffing it against a
+      // possibly rebound / mid-reload canvas (a false "manual edits" delta).
+      sessionEpoch++;
       // A bare WS open is NOT progress — the orchestrator handshake (`models`)
       // hasn't arrived yet. Do NOT reset attempt/gaveUp here (only markConnected
       // does), so an open-then-close-before-`models` cycle still INCREMENTS toward
@@ -15012,6 +15056,10 @@ function buildPanel() {
           } catch {
             lastAgentGraphKey = null;
           }
+          // Stamp the session generation this baseline belongs to (#369): the next
+          // turn's diff is trusted only if no reconnect/resume/reload has happened
+          // since (sessionEpoch unchanged).
+          lastAgentGraphEpoch = sessionEpoch;
         } catch {}
       }
     },

--- a/web/js/lib/manual-change-gate.js
+++ b/web/js/lib/manual-change-gate.js
@@ -1,0 +1,65 @@
+// Decide how the manual-canvas-change tracker should treat its baseline (the graph
+// the agent left at its last turn end) versus the CURRENT live graph, before it
+// injects a "MANUAL CANVAS CHANGES since your last turn" delta into the agent's
+// input.
+//
+// The baseline is only a trustworthy diff target within ONE continuous session
+// binding for the SAME workflow:
+//
+//   • Session boundary (#369): a reconnect / session resume / reload bumps the
+//     session epoch. Across that boundary the canvas may have been rebound or
+//     reloaded (or the live read is a mid-reload transient), so a baseline captured
+//     in an EARLIER epoch must NOT be diffed — doing so misattributes reload churn
+//     as manual edits (the reported symptom: a "100+ nodes removed" notice that the
+//     very next live graph read contradicts).
+//
+//   • Workflow identity (#348/#198): if the bound workflow's stable identity has
+//     provably CHANGED, a different workflow is on the canvas (tab switch) — emit a
+//     switch notice, never a bogus per-node delta.
+//
+//   • Unknown identity: if either side's identity can't be resolved, we can't
+//     confirm it's the same workflow, so a diff is untrustworthy — reseed silently
+//     rather than assert a false delta.
+//
+// Pure + side-effect-free so the decision is unit-testable in isolation; the caller
+// performs the reseed / banner emission based on the returned action.
+//
+// Returns one of:
+//   { action: "diff" }             — same epoch AND confirmed-same identity → diff.
+//   { action: "reseed" }           — stale epoch or unknown identity → adopt current
+//                                     graph as the new baseline, emit NO banner.
+//   { action: "workflow-changed" } — identity provably differs → emit switch notice
+//                                     and reseed.
+export function classifyManualChangeBaseline({
+  hasBaseline,
+  baselineKey,
+  baselineEpoch,
+  currentKey,
+  currentEpoch,
+}) {
+  // No baseline yet (fresh session, or a prior reseed cleared it) — nothing to diff.
+  if (!hasBaseline) return { action: "reseed" };
+
+  // A session boundary (reconnect / resume / reload) was crossed since the baseline
+  // was captured. The baseline predates the current binding and cannot be trusted as
+  // "the graph at the agent's last turn end" — discard it rather than diff (#369).
+  // A non-finite epoch on EITHER side (missing / NaN — an uninitialized or corrupted
+  // stamp) is itself untrustworthy, so treat it as a boundary too (note Object.is
+  // would wrongly report NaN===NaN and undefined===undefined as a match).
+  if (!Number.isFinite(baselineEpoch) || !Number.isFinite(currentEpoch))
+    return { action: "reseed" };
+  if (baselineEpoch !== currentEpoch) return { action: "reseed" };
+
+  // Identity provably DIFFERENT (both known, and unequal) → a different workflow is
+  // bound (the user switched tabs). Emit the switch notice, never a false per-node
+  // delta between two unrelated graphs (#348/#198).
+  if (baselineKey != null && currentKey != null && currentKey !== baselineKey)
+    return { action: "workflow-changed" };
+
+  // Identity UNKNOWN on either side → we cannot confirm the baseline and the live
+  // graph are the same workflow, so a diff is untrustworthy. Reseed silently (#369).
+  if (baselineKey == null || currentKey == null) return { action: "reseed" };
+
+  // Same epoch AND confirmed-same identity → the diff is meaningful.
+  return { action: "diff" };
+}

--- a/web/js/lib/safe-remove-node.js
+++ b/web/js/lib/safe-remove-node.js
@@ -1,0 +1,270 @@
+// Robust wrapper around litegraph's `graph.remove(node)` (#420).
+//
+// `graph.remove(node)` disconnects the node's links first. On some litegraph builds
+// (older/classic ComfyUI frontends, or classic-litegraph custom nodes such as VHS /
+// rgthree) the disconnect path resolves the FAR END of a link via
+// `graph.getNodeById(link.target_id/origin_id)` and then calls a method on it
+// (`findInputSlot`, etc.). During rapid batched removals (deleting many linked nodes
+// in one turn) that far-end lookup can momentarily return something that is NOT a
+// proper LGraphNode — a half-removed node, a foreign/plain object — so the call
+// throws `t.findInputSlot is not a function` and the whole removal aborts. The same
+// call succeeds on a retry a moment later once the link state settles.
+//
+// Recovery, ONLY for that recognized link-disconnect crash (see isLinkDisconnectCrash
+// — any other error, e.g. a node's own onRemoved() throwing, propagates so we never
+// retry-and-duplicate its side effects or mask it as success):
+//   Sever every non-rail link still referencing this node at the RECORD level
+//   (severNodeLinks) — deleting the store record and clearing the far-end's mirror
+//   slot ref with a plain property write, NEVER a far-end method call and NEVER
+//   litegraph's own disconnect. This is deliberate: re-running litegraph's disconnect
+//   would re-fire the far-end onConnectionsChange hook that may itself have thrown the
+//   crash, invoking it twice. With every non-rail link already gone, the retried
+//   `graph.remove` has nothing left to disconnect, so it cannot re-enter the throwing
+//   far-end path or re-fire any far-end disconnect hook. Rail links (ids -10 / -20, or
+//   graph.inputNode/outputNode) are LEFT for litegraph's rail-aware retry and the
+//   caller's boundary pruning; a real-node far end has its mirror cleared; a
+//   genuinely-missing (non-rail) far end just has its record dropped (no orphan).
+//   Then retry `graph.remove(node)` once; a genuine second failure propagates.
+//
+// Operates only on the passed graph/node, so it is unit-testable with a mock graph
+// that reproduces the throw-then-succeed behavior.
+
+// LiteGraph subgraph boundary rail node ids (mirror of the main panel file). Rails are
+// deliberately absent from graph._nodes_by_id, so getNodeById can't resolve them.
+const SUBGRAPH_INPUT_RAIL_ID = -10;
+const SUBGRAPH_OUTPUT_RAIL_ID = -20;
+
+/** True when two litegraph node ids refer to the same node, tolerant of a
+ *  number-vs-string id representation (subgraph ids can be strings). */
+function sameNodeId(a, b) {
+  return a === b || (a != null && b != null && String(a) === String(b));
+}
+
+/** True when a node id refers to a subgraph boundary rail (by the reserved rail ids
+ *  or by matching this graph's live inputNode/outputNode). Rail links must be left
+ *  for litegraph's rail-aware path + the caller's boundary pruning, never nuked. */
+function isRailId(graph, id) {
+  if (id == null) return false;
+  if (sameNodeId(id, SUBGRAPH_INPUT_RAIL_ID) || sameNodeId(id, SUBGRAPH_OUTPUT_RAIL_ID))
+    return true;
+  // Match the panel's rail-node resolution, which supports both the public
+  // inputNode/outputNode and the private _inputNode/_outputNode variants
+  // (web/js/lib/subgraph-scope.js resolveRailNode).
+  const inId = (graph?.inputNode ?? graph?._inputNode)?.id;
+  const outId = (graph?.outputNode ?? graph?._outputNode)?.id;
+  return (inId != null && sameNodeId(id, inId)) || (outId != null && sameNodeId(id, outId));
+}
+
+/** Read a link record by id from either the modern Map (`_links`) or the
+ *  back-compat record/proxy (`links`). Returns undefined when absent. */
+function getLinkRecord(graph, id) {
+  if (id == null) return undefined;
+  const map = graph?._links;
+  if (map && typeof map.get === "function") return map.get(id);
+  const rec = graph?.links;
+  return rec ? rec[id] : undefined;
+}
+
+/** Delete a link record from whichever store the graph uses. Never throws.
+ *
+ *  Prefers the record's OWN `LLink.disconnect(network)` when present: in modern
+ *  litegraph that primitive not only deletes the store record but also removes the
+ *  link id from every reroute and clears its layout-store entry — and it touches NO
+ *  far-end node method, so it's safe on the crash-recovery path. Raw store deletion
+ *  is the fallback for legacy record stores (and test mocks) with no such method. */
+function dropLinkRecord(graph, id, link) {
+  if (link && typeof link.disconnect === "function") {
+    try {
+      link.disconnect(graph); // deletes the record + cleans reroutes/layout, far-end-free
+      return;
+    } catch {
+      // fall through to raw deletion
+    }
+  }
+  if (id == null) return;
+  try {
+    const map = graph?._links;
+    if (map && typeof map.delete === "function") {
+      map.delete(id); // the back-compat `links` proxy mirrors `_links`
+      return;
+    }
+    const rec = graph?.links;
+    if (rec && typeof rec === "object") delete rec[id];
+  } catch {
+    // Best effort — a link we can't delete just becomes a harmless dangling id that
+    // renders as no wire; the retry still removes the node.
+  }
+}
+
+/** Enumerate [id, record] pairs from either the Map store or the legacy record. */
+function linkEntries(graph) {
+  const map = graph?._links;
+  if (map && typeof map.forEach === "function" && typeof map.get === "function") {
+    return [...map.entries()];
+  }
+  const rec = graph?.links;
+  if (rec && typeof rec === "object") {
+    return Object.keys(rec).map((k) => [rec[k]?.id ?? k, rec[k]]);
+  }
+  return [];
+}
+
+/** Sever one link whose ORIGIN is this node (far end = the link's TARGET input).
+ *  Returns true when severed; false when LEFT because the far end is a rail. */
+function severOutgoing(graph, link, id) {
+  const targetId = link?.target_id;
+  if (isRailId(graph, targetId)) return false; // rail → leave for boundary machinery
+  const far = graph?.getNodeById?.(targetId);
+  if (far != null) {
+    try {
+      const slot = far?.inputs?.[link?.target_slot];
+      if (slot && slot.link === link.id) slot.link = null; // plain write, no far-end method
+    } catch {
+      /* far end unusable — drop the record regardless */
+    }
+  }
+  // Real node (mirror cleared), broken non-node culprit, or genuinely-missing node —
+  // all non-rail: drop the record so the retry can't re-enter the throwing path and
+  // no orphan is left behind.
+  dropLinkRecord(graph, id, link);
+  return true;
+}
+
+/** Sever one link whose TARGET is this node (far end = the link's ORIGIN output).
+ *  Returns true when severed; false when LEFT because the far end is a rail. */
+function severIncoming(graph, link, id) {
+  const originId = link?.origin_id;
+  if (isRailId(graph, originId)) return false; // rail → leave for boundary machinery
+  const far = graph?.getNodeById?.(originId);
+  if (far != null) {
+    try {
+      const links = far?.outputs?.[link?.origin_slot]?.links;
+      if (Array.isArray(links)) {
+        const i = links.indexOf(link.id);
+        if (i !== -1) links.splice(i, 1); // array splice, no far-end method
+      }
+    } catch {
+      /* far end unusable — drop the record regardless */
+    }
+  }
+  dropLinkRecord(graph, id, link);
+  return true;
+}
+
+/**
+ * Sever the non-rail links still touching `node` by manipulating link records
+ * directly, never calling a method on a far-end node. Exported for testing.
+ *
+ * Two passes because this runs AFTER an aborted mid-disconnect `graph.remove`:
+ *  1) SLOT PASS — walk this node's own slot refs; sever each non-rail link and keep
+ *     any rail link id in place for litegraph's rail-aware retry.
+ *  2) STORE SWEEP — enumerate the link store for records whose origin/target is this
+ *     node but whose slot ref the aborted remove already nulled (otherwise
+ *     unreachable), and sever the non-rail ones.
+ */
+export function severNodeLinks(graph, node) {
+  // --- Pass 1: this node's own slot refs ---
+  for (const out of node?.outputs ?? []) {
+    if (!Array.isArray(out?.links)) continue;
+    const kept = [];
+    for (const id of [...out.links]) {
+      const link = getLinkRecord(graph, id);
+      if (!link) continue; // unknown/dangling id → drop from the slot
+      if (!severOutgoing(graph, link, id)) kept.push(id); // rail → keep
+    }
+    out.links = kept.length ? kept : null; // litegraph's empty-output convention
+  }
+  for (const inp of node?.inputs ?? []) {
+    const id = inp?.link;
+    if (id == null) continue;
+    const link = getLinkRecord(graph, id);
+    if (!link) {
+      inp.link = null; // dangling id → clear
+      continue;
+    }
+    if (severIncoming(graph, link, id)) inp.link = null;
+    // else: rail origin — leave inp.link for litegraph's rail-aware retry
+  }
+
+  // --- Pass 2: store sweep for records the slot pass could not reach ---
+  const nodeId = node?.id;
+  if (nodeId == null) return;
+  for (const [id, link] of linkEntries(graph)) {
+    if (!link) continue;
+    if (sameNodeId(link.origin_id, nodeId)) severOutgoing(graph, link, id);
+    else if (sameNodeId(link.target_id, nodeId)) severIncoming(graph, link, id);
+  }
+}
+
+/** True for the recognized #420 link-disconnect crash: a TypeError from litegraph
+ *  resolving a link's far end and calling a SLOT-LOOKUP method on something that
+ *  isn't a proper LGraphNode (minified: "t.findInputSlot is not a function"). The
+ *  match is deliberately narrow — only findInputSlot / findOutputSlot, the far-end
+ *  slot lookups litegraph performs during link disconnection — so an unrelated
+ *  TypeError won't be treated as recoverable. (Recovery never re-runs litegraph's
+ *  disconnect, so even in the extraordinarily rare case a custom hook throws this
+ *  exact internal signature, the retry does not re-invoke it — see safeRemoveNode.) */
+export function isLinkDisconnectCrash(err) {
+  if (!(err instanceof TypeError)) return false;
+  const msg = String(err?.message ?? "");
+  if (!/is not a function/.test(msg)) return false;
+  return /find(Input|Output)Slot/.test(msg);
+}
+
+/** True when `node` still has at least one link attached — via its own slot refs OR a
+ *  record in the store. This is the version-independent discriminator for the #420
+ *  disconnect-phase crash: litegraph fully disconnects every link BEFORE it fires
+ *  onRemoved (in BOTH modern and classic builds — classic calls onRemoved before it
+ *  splices the node out, so node-presence is NOT a reliable discriminator). So a crash
+ *  thrown WHILE links remain is a disconnect-phase crash (safe to sever + retry),
+ *  whereas a crash with NO links left came from a post-disconnect callback such as
+ *  onRemoved (must propagate — retrying would re-run the hook / duplicate side
+ *  effects or mask the failure). A node with no links can't hit the disconnect crash
+ *  at all, so this never suppresses a genuine fix. */
+export function nodeHasResidualLinks(graph, node) {
+  for (const inp of node?.inputs ?? []) if (inp?.link != null) return true;
+  for (const out of node?.outputs ?? [])
+    if (Array.isArray(out?.links) && out.links.length) return true;
+  const nodeId = node?.id;
+  if (nodeId == null) return false;
+  for (const [, link] of linkEntries(graph)) {
+    if (link && (sameNodeId(link.origin_id, nodeId) || sameNodeId(link.target_id, nodeId)))
+      return true;
+  }
+  return false;
+}
+
+/**
+ * Remove `node` from `graph`, recovering from the intermittent litegraph
+ * link-disconnect crash (#420). Returns `{ removed, recovered }`:
+ *   - removed:   true once `graph.remove` completed without throwing.
+ *   - recovered: true when the first attempt threw the recognized link-disconnect
+ *                crash and the disconnect + retry path was used.
+ * Any OTHER first-attempt error propagates unchanged (never retried). A genuine
+ * second failure on the retry propagates too.
+ */
+export function safeRemoveNode(graph, node) {
+  try {
+    graph.remove(node);
+    return { removed: true, recovered: false };
+  } catch (err) {
+    // Recover ONLY from the #420 link-disconnect crash. Two guards, because a node's
+    // own onRemoved()/onConnectionsChange() hook could coincidentally throw the SAME
+    // "…is not a function" TypeError:
+    //   1) message shape (isLinkDisconnectCrash), and
+    //   2) the node still has RESIDUAL LINKS. litegraph fully disconnects every link
+    //      (where the #420 crash occurs) BEFORE firing onRemoved, in both modern and
+    //      classic builds — so a disconnect-phase crash leaves links attached, whereas
+    //      a post-disconnect hook error leaves none. Only the former is safe to sever +
+    //      retry; a hook error with no links left must propagate (retrying would re-run
+    //      the hook / duplicate side effects or mask the failure). Node-presence is NOT
+    //      used: classic litegraph fires onRemoved before splicing the node out.
+    if (!isLinkDisconnectCrash(err) || !nodeHasResidualLinks(graph, node)) throw err;
+    // Sever residual non-rail links at the RECORD level (hook-free) — never re-running
+    // litegraph's own disconnect, so no far-end disconnect hook is re-invoked — then
+    // retry. With no non-rail links left, the retry can't re-enter the throwing path.
+    severNodeLinks(graph, node);
+    graph.remove(node); // a real second failure propagates
+    return { removed: true, recovered: true };
+  }
+}


### PR DESCRIPTION
Two independent panel tool-robustness / false-report bugs. Each is verify-first, unit-tested, and passed a codex self-gate (gpt-5.6-terra/high) after 8 adversarial rounds.

## #420 — `panel_remove_node` intermittently throws `t.findInputSlot is not a function` on rapid batched removals
`graph.remove(node)` disconnects links first. On some litegraph builds (older/classic frontends, or classic-litegraph custom nodes like VHS/rgthree) the disconnect path resolves a link's far end via `getNodeById` and calls a slot-lookup method on it; during rapid batched removals the far end can momentarily be a non-`LGraphNode`, so the call throws mid-disconnect and aborts the removal (the reporter saw 2/11 removals fail then succeed on an identical retry — a transient link-state race).

**Fix** (`web/js/lib/safe-remove-node.js`, wired into `graph_remove_node` + `graph_clear`): recover **only** from the recognized `findInputSlot`/`findOutputSlot` `TypeError` **and** only while the node still has **residual links** — a disconnect-phase crash, never a post-disconnect `onRemoved`/`onConnectionsChange` hook throwing the same shape. Recovery severs the node's non-rail links at the **record level** (hook-free, far-end-method-free):
- prefers the record's own `LLink.disconnect(graph)` (modern, reroute + layout-store aware) with a raw-store-delete fallback for legacy stores;
- clears the far-end mirror slot ref by plain property write;
- **never** re-runs litegraph's own disconnect, so no far-end hook is re-invoked;
- **leaves** subgraph boundary rails (`-10`/`-20`, `inputNode`/`outputNode`/`_inputNode`/`_outputNode`) for the caller's `pruneOrphanedBoundaries`;
- **drops** genuinely-missing (non-rail) far-end records so no orphan is left;

then retries `graph.remove` once. A genuine second failure propagates; any non-recognized first-attempt error propagates unchanged (never retried).

## #369 — Manual-changes notice can contradict the subsequent live graph after reload/resume
The `⟳ MANUAL CANVAS CHANGES since your last turn` block is produced by diffing the live graph against `lastAgentGraph`, a module-global baseline captured at the agent's turn end. After a session reconnect/resume the baseline predates the current binding, so diffing it against a rebound / mid-reload canvas misattributed reload churn as manual edits (reporter: a "100+ nodes removed" notice that the very next `panel_graph_outline` showed still present). The prior guard only caught a provably-different workflow identity; it fell through to diffing on unknown identity or a same-identity-but-stale baseline.

**Fix** (`web/js/lib/manual-change-gate.js` + wiring): a `sessionEpoch` is bumped on every orchestrator socket `open` (reconnect/resume); the baseline is stamped with its capture epoch. `classifyManualChangeBaseline` returns `diff` **only** when epochs match **and** workflow identity is confirmed unchanged — otherwise it reseeds silently (stale epoch / unknown identity) or emits the workflow-switch notice. Never a false per-node delta.

## #403 / #404 — verified already-fixed (no code change here)
Both restart-hang / unbounded-confirmation-wait reports were reproduced against the **current** orchestrator and confirmed fixed in **comfyui-mcp 0.48.22** (`src/orchestrator/panel-tools.ts`): the `panel_restart_comfyui` handler has a 255s whole-handler budget, `ctx.confirm()` is a tri-state with a deadline clamped under the MCP tools/call limit (returns an honest `timeout`, never an unbounded wait), and every path returns a structured result via the concurrent post-write-gated boot-endpoint observer (#360/#376/#536/#509). #403 was filed on 0.48.12, #404 on 0.48.21 — both predate 0.48.22. Being closed as already-fixed with a reopen clause (not part of this PR).

## Tests
- `browser_tests/unit/safe-remove-node.test.mjs` (22 cases: recovery, rail-safety, missing-far-end drop, store sweep for partial-mutation orphans, narrowed signature, residual-links guard, hook-free recovery, `LLink.disconnect` reroute cleanup, legacy fallback).
- `browser_tests/unit/manual-change-gate.test.mjs` (cross-epoch reseed, unknown identity, workflow-switch, non-finite epochs).
- Full panel unit suite **928 pass**, `tsc --noEmit` clean.

Closes artokun/comfyui-mcp-panel#420
Closes artokun/comfyui-mcp-panel#369

🤖 Generated with [Claude Code](https://claude.com/claude-code)