### PR TITLE
test+refactor: lock scope-aware run-to-node + promoted-widget inner callback (#438/#439/#435)

### DIFF
--- a/browser_tests/unit/subgraph-scope.test.mjs
+++ b/browser_tests/unit/subgraph-scope.test.mjs
@@ -259,6 +259,34 @@ test("#411 e2e: viewing a nested subgraph, an inner output node yields its full 
   assert.equal(buildNodeExecutionId(root, hit.ownerGraph, hit.node.id), "10:15:359");
 });
 
+test("#438/#439 e2e: viewing the ACTIVE first-level subgraph, an inner output node yields the owner:leaf path (not 'not on the root graph')", () => {
+  // Reporter scenario (dup of #411, verified fixed in 0.11.25): the user ENTERED a
+  // first-level subgraph (owner instance id 76) containing an output node — a
+  // PreviewImage (#438, id 34) / MaskPreview (#439, id 74). graph_run passes the
+  // ACTIVE viewing graph as preferGraph, so findNodeInScopes resolves the inner
+  // output in that scope and buildNodeExecutionId produces the "76:34" path used as
+  // partial_execution_targets — instead of the OLD root-only rejection
+  // ("node 34 is not on the root graph"). This locks the ACTIVE first-level case the
+  // #411 e2e (a NESTED subgraph) did not exercise directly.
+  const preview = { id: 34, type: "PreviewImage" };
+  const active = makeSubgraph({ name: "LAB 07 — ANIMA INPAINT", nodes: [preview] });
+  const root = { _nodes: [{ id: 76, subgraph: active }] };
+  // preferGraph = the active first-level subgraph (graph !== rootGraph).
+  const hit = findNodeInScopes(root, 34, active);
+  assert.equal(hit.node, preview, "inner output resolves in the ACTIVE viewing scope");
+  assert.equal(hit.ownerGraph, active);
+  assert.equal(
+    buildNodeExecutionId(root, hit.ownerGraph, hit.node.id),
+    "76:34",
+    "first-level active-subgraph output → owner:leaf partial_execution_target",
+  );
+  // Same for the #439 MaskPreview id shape.
+  const maskPreview = { id: 74, type: "MaskPreview" };
+  active._nodes.push(maskPreview);
+  const hit2 = findNodeInScopes(root, 74, active);
+  assert.equal(buildNodeExecutionId(root, hit2.ownerGraph, hit2.node.id), "76:74");
+});
+
 // ---- #409: reject unsafe bypass on a multi-input subgraph ------------------
 
 test("#409 unsafeBypassMappings: reorder that forwards a wrong-type input is flagged", () => {

--- a/browser_tests/unit/subgraph-scope.test.mjs
+++ b/browser_tests/unit/subgraph-scope.test.mjs
@@ -32,6 +32,7 @@ import {
   subgraphInstancePath,
   buildNodeExecutionId,
   findNodeInScopes,
+  resolveRunToNodeTarget,
   unsafeBypassMappings,
 } from "../../web/js/lib/subgraph-scope.js";
 
@@ -259,32 +260,65 @@ test("#411 e2e: viewing a nested subgraph, an inner output node yields its full 
   assert.equal(buildNodeExecutionId(root, hit.ownerGraph, hit.node.id), "10:15:359");
 });
 
-test("#438/#439 e2e: viewing the ACTIVE first-level subgraph, an inner output node yields the owner:leaf path (not 'not on the root graph')", () => {
+// An output node as ComfyUI tags it: node.constructor.nodeData.output_node === true.
+// resolveRunToNodeTarget gates on this exactly like graph_run does.
+function makeOutputNode(id, type) {
+  return { id, type, constructor: { nodeData: { output_node: true } } };
+}
+
+test("#438/#439 resolveRunToNodeTarget: an output node in the ACTIVE first-level subgraph yields the owner:leaf path (the exact graph_run resolution)", () => {
   // Reporter scenario (dup of #411, verified fixed in 0.11.25): the user ENTERED a
   // first-level subgraph (owner instance id 76) containing an output node — a
-  // PreviewImage (#438, id 34) / MaskPreview (#439, id 74). graph_run passes the
-  // ACTIVE viewing graph as preferGraph, so findNodeInScopes resolves the inner
-  // output in that scope and buildNodeExecutionId produces the "76:34" path used as
-  // partial_execution_targets — instead of the OLD root-only rejection
-  // ("node 34 is not on the root graph"). This locks the ACTIVE first-level case the
-  // #411 e2e (a NESTED subgraph) did not exercise directly.
-  const preview = { id: 34, type: "PreviewImage" };
-  const active = makeSubgraph({ name: "LAB 07 — ANIMA INPAINT", nodes: [preview] });
+  // PreviewImage (#438, id 34) / MaskPreview (#439, id 74). graph_run passes the ACTIVE
+  // viewing graph so the inner output resolves IN THAT SCOPE and the "76:34" colon path
+  // is used as partial_execution_targets — instead of the OLD root-only rejection
+  // ("node 34 is not on the root graph"). Drives the SAME helper graph_run calls,
+  // through the real output-eligibility + colon-path build, not just findNodeInScopes.
+  const preview = makeOutputNode(34, "PreviewImage");
+  const maskPreview = makeOutputNode(74, "MaskPreview");
+  const active = makeSubgraph({ name: "LAB 07 — ANIMA INPAINT", nodes: [preview, maskPreview] });
   const root = { _nodes: [{ id: 76, subgraph: active }] };
-  // preferGraph = the active first-level subgraph (graph !== rootGraph).
-  const hit = findNodeInScopes(root, 34, active);
-  assert.equal(hit.node, preview, "inner output resolves in the ACTIVE viewing scope");
-  assert.equal(hit.ownerGraph, active);
-  assert.equal(
-    buildNodeExecutionId(root, hit.ownerGraph, hit.node.id),
-    "76:34",
-    "first-level active-subgraph output → owner:leaf partial_execution_target",
-  );
-  // Same for the #439 MaskPreview id shape.
-  const maskPreview = { id: 74, type: "MaskPreview" };
-  active._nodes.push(maskPreview);
-  const hit2 = findNodeInScopes(root, 74, active);
-  assert.equal(buildNodeExecutionId(root, hit2.ownerGraph, hit2.node.id), "76:74");
+
+  const r34 = resolveRunToNodeTarget(root, active, 34);
+  assert.equal(r34.ok, true, "an output node in the active subgraph is runnable");
+  assert.equal(r34.node, preview);
+  assert.equal(r34.execId, "76:34", "#438: first-level active-subgraph output → owner:leaf target");
+
+  const r74 = resolveRunToNodeTarget(root, active, 74);
+  assert.equal(r74.execId, "76:74", "#439: MaskPreview inside the active subgraph resolves too");
+});
+
+test("#438/#439 NON-VACUOUS: the ACTIVE-scope PREFERENCE is what reaches the inner output — dropping it targets the wrong (root) node", () => {
+  // The SAME id 34 exists at BOTH the root AND inside the active subgraph, and both are
+  // output nodes. This is the case that only the viewing-scope preference disambiguates:
+  //  - viewing the active subgraph → the INNER output, target "76:34" (correct branch).
+  //  - NO viewing scope (as if graph_run stopped passing the active graph) → the ROOT
+  //    node, target "34" — a DIFFERENT branch. So this test FAILS if the fix is reverted.
+  const innerOut = makeOutputNode(34, "PreviewImage");
+  const active = makeSubgraph({ name: "LAB", nodes: [innerOut] });
+  const rootOut = makeOutputNode(34, "SaveImage");
+  const root = { _nodes: [{ id: 76, subgraph: active }, rootOut] };
+
+  const viewing = resolveRunToNodeTarget(root, active, 34);
+  assert.equal(viewing.node, innerOut, "viewing the active subgraph resolves the INNER output");
+  assert.equal(viewing.execId, "76:34", "the active-scope preference targets the inner branch");
+
+  const noScope = resolveRunToNodeTarget(root, root, 34);
+  assert.equal(noScope.node, rootOut, "without the active scope the ROOT node wins");
+  assert.equal(noScope.execId, "34", "→ a DIFFERENT (root) target: the preference is load-bearing");
+});
+
+test("#438/#439: a NON-output node in the active subgraph is refused with the not_output code (never queued as a bad root)", () => {
+  const notOutput = { id: 34, type: "CLIPTextEncode", constructor: { nodeData: { output_node: false } } };
+  const active = makeSubgraph({ name: "LAB", nodes: [notOutput] });
+  const root = { _nodes: [{ id: 76, subgraph: active }] };
+  const res = resolveRunToNodeTarget(root, active, 34);
+  assert.equal(res.ok, false);
+  assert.equal(res.code, "not_output");
+  assert.equal(res.node, notOutput, "carries the node so graph_run can name its type in the error");
+
+  // Unknown id → not_found (graph_run's first guard).
+  assert.deepEqual(resolveRunToNodeTarget(root, active, 999), { ok: false, code: "not_found", node: null });
 });
 
 // ---- #409: reject unsafe bypass on a multi-input subgraph ------------------

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -901,6 +901,63 @@ test("#366: the rail widget is resolved by the promotion's own NAME — a DIFFER
   assert.equal(set.promoted_from.parent_widget_synced, true);
 });
 
+// ---- #435: a promoted write must FIRE the INNER node's own widget callback so
+//            callback-driven side effects (LoadImage showImage → node.imgs) run,
+//            not merely propagate the value (verified fixed in 0.11.25) ----------
+
+test("#435: a promoted LoadImage 'image' write FIRES the INNER widget's callback (showImage side effect runs; node.imgs no longer stale)", () => {
+  // Reporter scenario: subgraph node 76 promotes inner LoadImage (id 68) 'image'.
+  // The pre-0.11.25 inline handler fired the PROMOTED VIEW's callback — forwarding the
+  // value down but NEVER invoking the inner widget's OWN callback — so showImage() was
+  // skipped, node.imgs stayed stale, and MaskEditor opened the OLD image (silent).
+  // The extracted applyWidgetWrite resolves to the inner (node, widget) and fires the
+  // INNER callback (#244) while syncing the authoritative rail (#366). This locks that
+  // the SIDE EFFECT runs — the exact thing #435 needed — not just the value landing.
+  const OLD = "clipspace/clipspace-painted-masked-A.png";
+  const NEW = "SHOWCASE_11a_cinematic_grade_00012_.png";
+  const fired = [];
+  const innerImageWidget = {
+    name: "image",
+    type: "combo",
+    options: { values: [OLD, NEW] },
+    value: OLD,
+    // Models LoadImage's image-widget callback: showImage(this.value) repopulates node.imgs.
+    callback(v, _canvas, node) {
+      fired.push(v);
+      node.imgs = [{ src: v }]; // showImage() side effect MaskEditor reads
+    },
+  };
+  const inner = { id: 68, type: "LoadImage", imgs: [{ src: OLD }], widgets: [innerImageWidget] };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "68" ? inner : null) };
+  // The parent's OWN promoted rail projection (identity-linked from the host input).
+  const railWidget = { name: "image", type: "combo", options: { values: [OLD, NEW] }, value: OLD };
+  const parent = {
+    id: 76,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [{ name: "image", _widget: railWidget, widget: { name: "image" }, _subgraphSlot: { name: "image" } }],
+    widgets: [railWidget],
+  };
+  const resolveSource = (_n, si) =>
+    si?.name === "image" ? { sourceNodeId: "68", sourceWidgetName: "image" } : null;
+
+  const set = applyWidgetWrite(parent, "image", NEW, { resolveSource });
+
+  // Value landed on the inner widget AND the authoritative rail (no stale render, #366).
+  assert.equal(innerImageWidget.value, NEW, "inner LoadImage image widget holds the new value");
+  assert.equal(railWidget.value, NEW, "authoritative rail synced (#366)");
+  assert.equal(set.promoted_from.inner_node_id, 68);
+  assert.equal(set.promoted_from.parent_widget_synced, true);
+  // THE #435 FIX: the INNER widget's OWN callback fired EXACTLY ONCE with the new value…
+  assert.deepEqual(fired, [NEW], "inner LoadImage callback fires once with the new value");
+  // …and its SIDE EFFECT ran — node.imgs repopulated, so MaskEditor reads the NEW image.
+  assert.deepEqual(
+    inner.imgs,
+    [{ src: NEW }],
+    "showImage side effect repopulated node.imgs (MaskEditor no longer opens the stale image)",
+  );
+});
+
 test("#366 FAIL CLOSED runs BEFORE any side-effecting coercion — a dynamic-combo inner is never invoked when the rail is refused", () => {
   // The inner is a DYNAMIC combo whose options.values() has a side effect. With a
   // linked (non-authoritative) host input the write must fail closed BEFORE

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -122,8 +122,7 @@ import {
   resolveRailNode,
   railKindFor,
   computeOrphanedBoundaries,
-  findNodeInScopes,
-  buildNodeExecutionId,
+  resolveRunToNodeTarget,
   unsafeBypassMappings,
 } from "./lib/subgraph-scope.js";
 import { runSetWidget } from "./lib/set-widget.js";
@@ -6118,31 +6117,32 @@ const GRAPH_TOOL_EXECUTORS = {
     // a root-level target yields String(id), the same value as before).
     let partialTargets;
     if (to_node_id != null) {
+      // Resolve the run-to-node target in the CURRENT viewing scope first (the reporter
+      // added / is targeting the output node INSIDE the subgraph they are viewing —
+      // active first-level #438/#439, nested #411). resolveRunToNodeTarget encapsulates
+      // the SAME find→output-eligibility→colon-path resolution the tests drive.
       const viewing = graph !== rootGraph ? graph : null;
-      const hit = findNodeInScopes(rootGraph, to_node_id, viewing);
-      if (!hit) {
-        return {
-          queued: false,
-          error:
-            `node ${to_node_id} was not found on the root graph or in any subgraph — ` +
-            `run-to-node targets an output node in the current workflow (check the id in panel_query_graph)`,
-        };
-      }
-      const node = hit.node;
-      // isOutputNode mirrors ComfyUI's util: node.constructor.nodeData.output_node.
-      if (!node.constructor?.nodeData?.output_node) {
-        return {
-          queued: false,
-          error:
-            `node ${to_node_id} (${node.type}) is not an output node — "run to node" can ` +
-            `only target an output node such as SaveImage, PreviewImage, or SaveVideo. Pick the ` +
-            `output node at the end of the branch you want to render (is_output:true in panel_query_graph).`,
-        };
-      }
-      // Colon path for a nested node ("10:15:359"), or String(id) at root. null
-      // means the owning subgraph is unreachable from the live root (stale view).
-      const execId = buildNodeExecutionId(rootGraph, hit.ownerGraph, node.id);
-      if (execId == null) {
+      const res = resolveRunToNodeTarget(rootGraph, viewing, to_node_id);
+      if (!res.ok) {
+        if (res.code === "not_found") {
+          return {
+            queued: false,
+            error:
+              `node ${to_node_id} was not found on the root graph or in any subgraph — ` +
+              `run-to-node targets an output node in the current workflow (check the id in panel_query_graph)`,
+          };
+        }
+        // isOutputNode mirrors ComfyUI's util: node.constructor.nodeData.output_node.
+        if (res.code === "not_output") {
+          return {
+            queued: false,
+            error:
+              `node ${to_node_id} (${res.node.type}) is not an output node — "run to node" can ` +
+              `only target an output node such as SaveImage, PreviewImage, or SaveVideo. Pick the ` +
+              `output node at the end of the branch you want to render (is_output:true in panel_query_graph).`,
+          };
+        }
+        // "unreachable": the owning subgraph isn't reachable from the live root (stale view).
         return {
           queued: false,
           error:
@@ -6150,7 +6150,9 @@ const GRAPH_TOOL_EXECUTORS = {
             `workflow root (stale view) — re-open the workflow and try again`,
         };
       }
-      partialTargets = [execId];
+      // Colon path for a nested node ("10:15:359") / first-level ("76:34"), or
+      // String(id) at root.
+      partialTargets = [res.execId];
     }
 
     // app.queuePrompt(number, batchCount, queueNodeIds) — the 3rd arg becomes the

--- a/web/js/lib/subgraph-scope.js
+++ b/web/js/lib/subgraph-scope.js
@@ -181,6 +181,43 @@ export function findNodeInScopes(rootGraph, id, preferGraph = null) {
   return null;
 }
 
+/** Resolve panel_run's `to_node_id` ("run to node") to a runnable partial-execution
+ *  target, in the CURRENT viewing scope FIRST. This is the exact resolution graph_run
+ *  performs, extracted so the SAME logic the tool runs is unit-testable headlessly (the
+ *  live app.queuePrompt path can't be driven from `node --test`) — the test path IS the
+ *  production path.
+ *
+ *  `viewingGraph` is the graph the user is LOOKING at (an entered subgraph, or the root).
+ *  It is searched FIRST so an output node the user added INSIDE the subgraph they are
+ *  viewing resolves to THAT node — not a same-id node elsewhere — which is what makes
+ *  run-to-node reach an output inside the ACTIVE subgraph (#438/#439) and a nested one
+ *  (#411). Dropping this preference would resolve a colliding root id instead and target
+ *  the WRONG branch.
+ *
+ *  Returns a discriminated result (never throws):
+ *   - { ok: true,  execId, node, ownerGraph }        → runnable; execId is the colon
+ *       path ("76:34" for a first-level subgraph output, "10:15:359" nested, "34" at
+ *       root) to pass in partial_execution_targets.
+ *   - { ok: false, code: "not_found", node: null }   → id resolves to no node in any scope
+ *   - { ok: false, code: "not_output", node }        → resolved, but not an OUTPUT node
+ *       (only SaveImage/PreviewImage/SaveVideo/… can be a partial-execution root)
+ *   - { ok: false, code: "unreachable", node }        → owning subgraph is unreachable
+ *       from the live root (stale view) so no execution path exists
+ *
+ *  Output-node eligibility mirrors ComfyUI's util: node.constructor.nodeData.output_node. */
+export function resolveRunToNodeTarget(rootGraph, viewingGraph, toNodeId) {
+  const viewing = viewingGraph && viewingGraph !== rootGraph ? viewingGraph : null;
+  const hit = findNodeInScopes(rootGraph, toNodeId, viewing);
+  if (!hit) return { ok: false, code: "not_found", node: null };
+  const node = hit.node;
+  if (!node?.constructor?.nodeData?.output_node) {
+    return { ok: false, code: "not_output", node };
+  }
+  const execId = buildNodeExecutionId(rootGraph, hit.ownerGraph, node.id);
+  if (execId == null) return { ok: false, code: "unreachable", node };
+  return { ok: true, execId, node, ownerGraph: hit.ownerGraph };
+}
+
 /** Types are compatible for a BYPASS forward when equal (case-insensitive) or either
  *  side is a wildcard ('*' or ''). */
 function bypassTypeCompatible(a, b) {


### PR DESCRIPTION
## Verify-first outcome: all three are FIXED-IN-0.11.25 (dups of shipped work)

The subgraph scope/run cluster (#411 / #366 / #244) shipped in **panel 0.11.25 / mcp 0.48.25**. Verifying #438/#439/#435 against current `origin/main` shows all three are already covered. This PR adds **regression tests** locking that behavior, plus one small **no-behavior-change refactor** to make the run-to-node path unit-testable.

### #438 / #439 — panel_run cannot target an output node inside the ACTIVE/live subgraph
**Fixed by #411 (shipped 0.11.25).** `graph_run` passes the active viewing graph as `preferGraph` to the scope search, resolves the inner output in that scope, and builds the colon path (`"76:34"`) used as `partial_execution_targets` — the old `"node N is not on the root graph"` rejection is gone. #411's e2e only covered a *nested* subgraph; these tests add the **active first-level** case the reporters hit.

- Extracted `graph_run`'s resolution into `resolveRunToNodeTarget(rootGraph, viewingGraph, toNodeId)` in `subgraph-scope.js` (find in viewing scope first → `output_node` eligibility → colon path → discriminated result). `graph_run` now delegates to it; error strings byte-identical. Matches the repo's "test path IS the production path" extraction philosophy.
- Tests drive that helper through faithful output-node fixtures, including a **non-vacuous ambiguity case**: the same output-node id at BOTH root and the active subgraph, so the active-scope preference resolves `"76:34"` while dropping it resolves the root `"34"` — the test fails if the preference regresses. Plus `not_output` / `not_found` guards.

### #435 — panel_set_widget on a promoted subgraph widget doesn't fire the inner node's callback
**Fixed by #244 (inner-callback fire) + #366 (rail sync), both shipped 0.11.25.** The inline handler the report quoted (`w.value = value; w.callback?.(...)` on the *promoted view*) is gone; `graph_set_widget` now delegates to `applyWidgetWrite`, which resolves to the inner `(node, widget)`, syncs the authoritative rail, and fires the **inner** widget's own callback with the new value. That inner-callback fire is exactly the `LoadImage.showImage()` side effect #435 needed (repopulates `node.imgs`, so MaskEditor no longer opens the stale image).

- New test asserts the inner callback fires **once** with the new value AND its **side effect runs** (`node.imgs` repopulated) — not merely that the value lands — while the rail stays synced.

### mcp side
No change needed: `panel_run` / `panel_set_widget` are thin proxies, and `panel_run`'s tool description already documents the shipped scope-aware nested targeting.

## Testing
- Full panel unit suite green: **1007 tests, 0 fail**.
- Codex adversarial self-gate (gpt-5.6-terra / high): **PASS** (round 1 flagged the initial #438/#439 test as vacuous → strengthened via the extraction + ambiguity case; round 2 PASS, no blocking findings).

## Reopen clause
If, on 0.11.25+, `panel_run` still rejects an output node inside the active subgraph, or MaskEditor still opens the stale image after a promoted `image` write (compare the saved clipspace PNG's pixel dimensions to the newly-set source), please reopen with the scope/ids and on-disk dimensions.

Closes artokun/comfyui-mcp-panel#438
Closes artokun/comfyui-mcp-panel#439
Closes artokun/comfyui-mcp-panel#435

🤖 Generated with [Claude Code](https://claude.com/claude-code)