### PR TITLE
fix(reload): guarantee every sidebar tab's bridge reconnects after a soft-reload (#419)

### DIFF
--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -9,6 +9,7 @@ import {
   shouldResumeAfterComfyReconnect,
   shouldRehelloAfterCommand,
   planSoftReloadRecovery,
+  performSoftReloadRecovery,
   isTransientReconnectError,
   retryDuringReconnect,
   workflowTabKey,
@@ -292,4 +293,193 @@ test("#379: reconnect is unconditional across every outcome (no dead-bridge path
   const d = planSoftReloadRecovery();
   assert.equal(d.reconnect, true);
   assert.equal(d.keepResumeInterlock, false);
+});
+
+// ---- #419 soft-reload LIFECYCLE: a reload never leaves a bridge dead ---------
+// #419 reported panel_reload leaving open sidebar tabs permanently disconnected.
+// The fix guarantee is at the stop→start level: whatever the reload POST does,
+// the dropped bridge is ALWAYS restarted. The pure planSoftReloadRecovery truth
+// table (above) can't lock this, because softReload() does not branch on
+// `reconnect` — it drives performSoftReloadRecovery(), which owns the sequence.
+// These tests spy on ONE client's stop/start across every outcome, and — since
+// the lifecycle is per-tab, state-free, and shares nothing — that same guarantee
+// holds independently for each of N open tabs (no subset, or all, left dead).
+
+// Drive the lifecycle with a spy client + injected postReload, returning the
+// recorded stop/start order and which interlock branch ran.
+async function runLifecycle(postReload) {
+  const events = [];
+  const client = {
+    stop: () => events.push("stop"),
+    start: () => events.push("start"),
+  };
+  let kept = false;
+  let cleared = false;
+  let noted = null;
+  const result = await performSoftReloadRecovery({
+    client,
+    postReload,
+    onKeepInterlock: () => {
+      kept = true;
+    },
+    onClearInterlock: () => {
+      cleared = true;
+    },
+    note: (outcome) => {
+      noted = outcome;
+    },
+  });
+  return { events, kept, cleared, noted, result };
+}
+
+test("#419: an ACCEPTED reload stops THEN restarts the bridge and keeps the interlock", async () => {
+  const { events, kept, cleared, result } = await runLifecycle(async () => ({
+    ok: true,
+    reachable: true,
+  }));
+  assert.deepEqual(events, ["stop", "start"]); // bridge always restored
+  assert.equal(kept, true);
+  assert.equal(cleared, false);
+  assert.equal(result.accepted, true);
+  assert.equal(result.keepResumeInterlock, true);
+});
+
+test("#419: a REFUSED 503 reload stops THEN restarts the bridge and clears the interlock", async () => {
+  const { events, kept, cleared, noted, result } = await runLifecycle(async () => ({
+    ok: false, // by-design 503: reachable response, not ok
+    reachable: true,
+    startCommand: "node dist/index.js",
+  }));
+  assert.deepEqual(events, ["stop", "start"]); // NEVER left dead (the #379 wedge)
+  assert.equal(kept, false);
+  assert.equal(cleared, true);
+  assert.equal(noted.error, undefined); // refused, not a transport error
+  assert.equal(noted.startCommand, "node dist/index.js"); // manual-restart hint surfaced
+  assert.equal(result.keepResumeInterlock, false);
+});
+
+test("#419: a THROWN/timed-out reload POST still stops THEN restarts the bridge", async () => {
+  const { events, cleared, noted, result } = await runLifecycle(async () => {
+    throw new Error("reload request timed out");
+  });
+  assert.deepEqual(events, ["stop", "start"]); // unreachable → still reconnects
+  assert.equal(cleared, true);
+  assert.equal(noted.error instanceof Error, true);
+  assert.match(noted.error.message, /timed out/);
+  assert.equal(result.accepted, false);
+  assert.equal(result.keepResumeInterlock, false);
+});
+
+test("#419: the bridge is restarted even if the interlock callback throws", async () => {
+  // The hard guarantee: nothing between stop() and start() can strand the bridge.
+  const events = [];
+  const client = {
+    stop: () => events.push("stop"),
+    start: () => events.push("start"),
+  };
+  await performSoftReloadRecovery({
+    client,
+    postReload: async () => ({ ok: false, reachable: true }),
+    onClearInterlock: () => {
+      throw new Error("interlock callback blew up");
+    },
+    note: () => {
+      throw new Error("note blew up (should not be reached — interlock threw first)");
+    },
+  });
+  assert.deepEqual(events, ["stop", "start"]); // start() still fires from the finally
+});
+
+test("#419: the bridge is restarted even if the note callback throws (interlock ran)", async () => {
+  // Distinct from above: onClearInterlock SUCCEEDS, then note throws — start() must
+  // STILL fire (the note is a downstream best-effort effect).
+  const events = [];
+  const client = {
+    stop: () => events.push("stop"),
+    start: () => events.push("start"),
+  };
+  let cleared = false;
+  await performSoftReloadRecovery({
+    client,
+    postReload: async () => ({ ok: false, reachable: true }),
+    onClearInterlock: () => {
+      cleared = true;
+    },
+    note: () => {
+      throw new Error("note blew up");
+    },
+  });
+  assert.equal(cleared, true); // the interlock effect DID run
+  assert.deepEqual(events, ["stop", "start"]); // and the bridge still reconnected
+});
+
+test("#419: a THROWING plan() still stops THEN restarts the bridge (never rejects)", async () => {
+  // The DI contract: nothing between stop() and start() — including a throwing
+  // injected plan — may strand the bridge or reject the reload.
+  const events = [];
+  const client = {
+    stop: () => events.push("stop"),
+    start: () => events.push("start"),
+  };
+  let planCalled = false;
+  const result = await performSoftReloadRecovery({
+    client,
+    postReload: async () => ({ ok: true, reachable: true }),
+    plan: () => {
+      planCalled = true;
+      throw new Error("plan blew up");
+    },
+  });
+  assert.equal(planCalled, true); // the injected plan WAS invoked (not bypassed)
+  assert.deepEqual(events, ["stop", "start"]); // reconnect still guaranteed
+  assert.equal(result.reconnect, true); // contract value survives a thrown plan
+});
+
+test("#419: a stop() that throws does NOT skip the reconnect", async () => {
+  const events = [];
+  const client = {
+    stop: () => {
+      events.push("stop-throw");
+      throw new Error("socket close failed");
+    },
+    start: () => events.push("start"),
+  };
+  await performSoftReloadRecovery({
+    client,
+    postReload: async () => ({ ok: true, reachable: true }),
+  });
+  assert.deepEqual(events, ["stop-throw", "start"]); // start still reached
+});
+
+test("#419: beforeStart runs immediately BEFORE start (pre-extraction ordering)", async () => {
+  // The caller clears its `reloading` re-entrancy flag in beforeStart; it MUST run
+  // before the reconnect so the ordering matches the pre-extraction code.
+  const events = [];
+  const client = {
+    stop: () => events.push("stop"),
+    start: () => events.push("start"),
+  };
+  await performSoftReloadRecovery({
+    client,
+    postReload: async () => ({ ok: true, reachable: true }),
+    beforeStart: () => events.push("beforeStart"),
+  });
+  assert.deepEqual(events, ["stop", "beforeStart", "start"]);
+});
+
+test("#419: N open tabs each independently reconnect — no subset left dead", async () => {
+  // Each tab runs its OWN lifecycle on its OWN spy client with a DIFFERENT POST
+  // outcome; the lifecycle shares no state, so every tab is restarted.
+  const outcomes = [
+    async () => ({ ok: true, reachable: true }), // accepted
+    async () => ({ ok: false, reachable: true }), // by-design 503
+    async () => {
+      throw new Error("unreachable"); // POST never answered
+    },
+  ];
+  const runs = await Promise.all(outcomes.map((p) => runLifecycle(p)));
+  for (const r of runs) {
+    assert.deepEqual(r.events, ["stop", "start"]); // this tab reconnected
+    assert.equal(r.result.reconnect, true);
+  }
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -191,7 +191,7 @@ import {
 import {
   shouldResumeAfterComfyReconnect,
   shouldRehelloAfterCommand,
-  planSoftReloadRecovery,
+  performSoftReloadRecovery,
   retryDuringReconnect,
   dedupeWorkflowTabRecords,
   resolveLoadGraphArgs,
@@ -16816,53 +16816,64 @@ function buildPanel() {
     setSoftReloadGuard();
     appendSystem("Soft-reloading the agent (new code, no ComfyUI restart)…");
     try {
-      client.stop(); // drop the bridge so the old orchestrator can release the port
-      // Bound the POST: a hung ComfyUI handler / stalled network would otherwise never
-      // settle, so the await never returns, `reloading` stays true, and client.start()
-      // below is never reached — a permanent wedge (codex). On timeout we reject into
-      // the catch, which clears the interlock and reconnects the dropped bridge.
-      const res = await Promise.race([
-        api.fetchApi("/comfyui_mcp_panel/reload", { method: "POST" }),
-        new Promise((_resolve, reject) =>
-          setTimeout(() => reject(new Error("reload request timed out")), RELOAD_POST_TIMEOUT_MS),
-        ),
-      ]);
-      const data = await res.json().catch(() => ({}));
-      const plan = planSoftReloadRecovery({ ok: data?.ok, reachable: true });
-      if (!plan.keepResumeInterlock) {
-        // Reload REFUSED. This pack's /reload route is a by-design 503: the
-        // orchestrator runs out-of-band and never stopped — only our bridge socket
-        // did (client.stop above). We do NOT own a respawn, so stand the interlock
-        // down and reconnect the dropped bridge (below) instead of leaving the
-        // panel wedged "connected chip / dead bridge" (#379). The old code told the
-        // user to restart a healthy orchestrator; surface that only as an OPTIONAL
-        // "load new code" hint, not a required recovery step.
-        ssSet(SOFT_RELOAD_KEY, null);
-        clearSoftReloadGuard();
-        const cmd = typeof data?.start_command === "string" ? data.start_command.trim() : "";
-        appendSystem(
-          "Reconnecting the panel bridge…" +
-            (cmd ? `\n(To load new orchestrator code, restart it manually: ${cmd})` : ""),
-        );
-      }
-    } catch (err) {
-      // Couldn't even reach the reload route. The orchestrator may still be alive,
-      // so stand the interlock down and reconnect the dropped bridge (below) rather
-      // than leaving it dead (#379).
-      ssSet(SOFT_RELOAD_KEY, null);
-      clearSoftReloadGuard();
-      appendSystem(
-        `Couldn't reach ComfyUI to reload the agent — reconnecting the bridge: ${coerceMessageText(err?.message ?? err)}`,
-      );
+      // Whole lifecycle (stop → bounded POST → decide interlock → ALWAYS start) lives
+      // in performSoftReloadRecovery so the "reload never leaves the bridge dead"
+      // guarantee is unit-tested at the stop/start level (#379/#419). It reconnects
+      // EITHER WAY (mirrors hardRestart): on an accepted reload the guard/
+      // SOFT_RELOAD_KEY stay set so the fresh orchestrator binds and onAck resumes;
+      // on a refused (by-design 503) or unreachable/timed-out reload the interlock is
+      // cleared and the dropped bridge is restored against the still-running
+      // orchestrator — the panel never wedges "connected chip / dead bridge".
+      await performSoftReloadRecovery({
+        client,
+        // Bound the POST: a hung ComfyUI handler / stalled network would otherwise
+        // never settle. On timeout we reject → treated as unreachable (clear interlock
+        // + reconnect). A real Response (incl. the by-design 503) is REACHABLE.
+        postReload: async () => {
+          const res = await Promise.race([
+            api.fetchApi("/comfyui_mcp_panel/reload", { method: "POST" }),
+            new Promise((_resolve, reject) =>
+              setTimeout(() => reject(new Error("reload request timed out")), RELOAD_POST_TIMEOUT_MS),
+            ),
+          ]);
+          const data = await res.json().catch(() => ({}));
+          return {
+            ok: Boolean(data?.ok),
+            reachable: true,
+            startCommand: typeof data?.start_command === "string" ? data.start_command.trim() : "",
+          };
+        },
+        // Accepted respawn we own — keep SOFT_RELOAD_KEY + guard (already armed above).
+        onKeepInterlock: () => {},
+        // Refused/unreachable — this pack's /reload is a by-design 503 (orchestrator
+        // out-of-band, never stopped); only our socket dropped. Stand the interlock
+        // down so the reconnect + hello.resume restores the session.
+        onClearInterlock: () => {
+          ssSet(SOFT_RELOAD_KEY, null);
+          clearSoftReloadGuard();
+        },
+        note: (outcome) => {
+          if (outcome?.error) {
+            appendSystem(
+              `Couldn't reach ComfyUI to reload the agent — reconnecting the bridge: ${coerceMessageText(outcome.error?.message ?? outcome.error)}`,
+            );
+          } else {
+            const cmd = outcome?.startCommand || "";
+            appendSystem(
+              "Reconnecting the panel bridge…" +
+                (cmd ? `\n(To load new orchestrator code, restart it manually: ${cmd})` : ""),
+            );
+          }
+        },
+        // Clear the re-entrancy flag right BEFORE the reconnect (pre-extraction
+        // ordering); the outer finally is a backstop in case the helper ever throws.
+        beforeStart: () => {
+          reloading = false;
+        },
+      });
     } finally {
       reloading = false;
     }
-    // Reconnect EITHER WAY (mirrors hardRestart, #379): on an accepted reload the
-    // guard/SOFT_RELOAD_KEY are still set so the fresh orchestrator binds and onAck
-    // resumes; on a refused/failed reload the interlock was cleared above and this
-    // restores the bridge we dropped against the still-running orchestrator — the
-    // panel never wedges "connected but dead".
-    client.start();
   }
 
   // Hard restart: recover a wedged/unresponsive agent. Unlike soft reload (which

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -110,6 +110,95 @@ export function planSoftReloadRecovery({ ok = false, reachable = true } = {}) {
   return { accepted, reconnect: true, keepResumeInterlock: accepted };
 }
 
+// #379 / #419 — the soft-reload LIFECYCLE, extracted from softReload() so the
+// "a reload never leaves a bridge dead" guarantee is unit-testable at the
+// stop→start level (the pure planSoftReloadRecovery decision alone can't lock it,
+// because reconnect is unconditional and not branched on). #419 reported a reload
+// leaving open sidebar tabs permanently disconnected; the guarantee that fixes it
+// is exactly this: EVERY tab that runs a reload drops its bridge and is ALWAYS
+// restored, whatever the POST outcome (accepted respawn we own, a by-design 503
+// refusal, an unreachable/timed-out POST, or a throw from the effect callbacks).
+//
+// Pure control-flow over injected effects (so a test drives it with spies, and so
+// each open tab runs the SAME sequence independently on its own bridge — there is
+// no shared state one tab could leave dead for the others):
+//   1. client.stop()      — drop the bridge so the old orchestrator frees the port
+//   2. postReload()       — the bounded reload POST → { ok, reachable } | throws
+//   3. planSoftReloadRecovery(outcome) — keep the resume interlock ONLY for an
+//      accepted respawn we own; otherwise clear it + surface a reconnect note
+//   4. client.start()     — ALWAYS, in a finally, even if a callback throws, so the
+//      bridge can never be stranded stopped (the #419 no-dead-bridge invariant)
+export async function performSoftReloadRecovery({
+  client,
+  postReload,
+  onKeepInterlock,
+  onClearInterlock,
+  note,
+  // Runs immediately BEFORE client.start(), inside the same finally — the caller
+  // uses it to clear its `reloading` re-entrancy flag right before the reconnect,
+  // preserving the pre-extraction ordering (flag cleared, THEN start). Best-effort:
+  // a throw here never blocks the start below.
+  beforeStart,
+  plan = planSoftReloadRecovery,
+} = {}) {
+  // Drop the bridge; a throw here must NOT skip the client.start() below.
+  try {
+    client.stop();
+  } catch {
+    /* stop is best-effort — start() still runs so the bridge is never stranded */
+  }
+  let outcome;
+  try {
+    const res = await postReload();
+    // A response (any HTTP status, incl. the by-design 503) means the route was
+    // REACHABLE; only a throw/timeout is unreachable.
+    outcome = {
+      ok: Boolean(res && res.ok),
+      reachable: !res || res.reachable !== false,
+      startCommand: (res && res.startCommand) || "",
+    };
+  } catch (error) {
+    outcome = { ok: false, reachable: false, startCommand: "", error };
+  }
+  let decision;
+  try {
+    // The recovery DECISION and its best-effort UI/state effects are all inside
+    // this try so that NOTHING between the stop above and the start below — not a
+    // throwing injected `plan`, not a throwing interlock/note callback — can strand
+    // the bridge or surface as a "reload failed". The finally guarantees reconnect.
+    decision = plan({ ok: outcome.ok, reachable: outcome.reachable });
+    if (decision.keepResumeInterlock) {
+      // Accepted respawn we own — keep SOFT_RELOAD_KEY + guard so the fresh
+      // orchestrator binds and onAck resumes; nothing else to do here.
+      onKeepInterlock?.(outcome);
+    } else {
+      // Refused/unreachable — stand the interlock down and reconnect the dropped
+      // bridge against the still-running orchestrator (no wedge).
+      onClearInterlock?.(outcome);
+      note?.(outcome);
+    }
+  } catch {
+    /* decision/effects are best-effort — never block the reconnect below */
+  } finally {
+    // The invariant: reconnect on EVERY path, even if the decision/effects threw.
+    // beforeStart runs first (the caller clears its `reloading` flag here, matching
+    // the pre-extraction "flag cleared THEN start" ordering); both are isolated so
+    // neither can strand the bridge.
+    try {
+      beforeStart?.();
+    } catch {
+      /* best-effort pre-start hook — never block the reconnect */
+    }
+    try {
+      client.start();
+    } catch {
+      /* start scheduling is best-effort; a throw here must not mask the outcome */
+    }
+  }
+  // reconnect is always true by contract; keep it present even if `plan` threw.
+  return { reconnect: true, ...(decision || {}), outcome };
+}
+
 // #207 / #334 — Stable identity for a workflow tab record. A load that replaces
 // the active canvas can flip the tab id (tmp: → wf:) or re-add the same file, so
 // dedupe on the rename-stable identity. Strip the tmp:/wf: scheme prefix so the


### PR DESCRIPTION
Closes artokun/comfyui-mcp-panel#419

## Outcome: already covered by #379 — locked with a lifecycle regression + defense-in-depth

**Verify-first** on current `origin/main` (0.11.25): the reproducible #419 cases are **already fixed**, not open:

- The just-shipped **#379** makes the one dropped (bound) tab's `softReload()` **always reach `client.start()`** via `try/catch/finally` — no more "connected chip / dead bridge" wedge.
- `soft_reload` is delivered **per-tab** by the orchestrator (`ctx.call` → `ctx.tabId`), **never broadcast**; and this pack's `POST /comfyui_mcp_panel/reload` is a by-design **503 no-op** (the orchestrator runs out-of-band and never restarts), so **sibling tabs' WebSockets are never dropped** by a reload.
- Orchestrator **#474** made `panel_set_workflow_target({mode:"current"})` **defer** (bind on reconnect) instead of failing circularly on "Connected: none" — closing the reporter's circular-recovery complaint.

The reporter's "**all** sidebar tabs" (panel **0.11.20**, pre-#379) was the single active-tab wedge generalized.

## What this PR changes

The "a reload never leaves a bridge dead" guarantee lives at the **stop → start** level, which the pure `planSoftReloadRecovery` decision cannot capture (`softReload` never branches on `reconnect`; it calls `client.start()` unconditionally). So a pure-helper test can't lock it.

- **Extract** the soft-reload lifecycle into a dependency-injected, unit-testable helper `performSoftReloadRecovery()` in `web/js/lib/session-rebind.js`, and **rewire** `softReload()` (orchestrator scope) onto it.
- **Behavior-preserving** for accepted / refused-503 / thrown-timeout (interlock retention, `start_command` hint, error wording, and the pre-extraction "clear `reloading` **then** start" ordering via a `beforeStart` hook).
- **Strictly safer:** `client.start()` is now guaranteed on **every** path — `stop()`, `postReload()`, `plan()`, `onKeepInterlock`/`onClearInterlock`/`note`, and `beforeStart` throws all still reconnect. A reload can never strand a bridge.

## Tests

New lifecycle regression tests in `browser_tests/unit/session-rebind.test.mjs` spying on one client's `stop`/`start` across accepted / refused-503 / thrown-timeout / throwing-`plan` / throwing-interlock / throwing-`note` / throwing-`stop` / `beforeStart` ordering, plus an **N-tab independence** test (each open tab runs its own state-free lifecycle → no subset, or all, left dead).

- `node --check` clean on both JS files.
- `npm run test:unit` green — **1012 passing**.

No orchestrator (`comfyui-mcp`) changes.

## Verification
Codex adversarial self-gate (gpt-5.6-terra / high) — **PASS** after 4 rounds (it independently confirmed no behavioral dead-bridge residual, and drove the helper to a guaranteed-`start()`-on-every-path contract with non-vacuous lifecycle tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)