### PR TITLE
fix(panel): live-geometry group reads + post-reconnect active-stale signal (#429, #433)

### DIFF
--- a/browser_tests/unit/group-geometry.test.mjs
+++ b/browser_tests/unit/group-geometry.test.mjs
@@ -378,3 +378,50 @@ test("membership overlap is edge-inclusive (matches LiteGraph overlapBounding)",
     "edge contact counts as membership",
   );
 });
+
+// ---------------------------------------------------------------------------
+// #429: group-membership READ paths must resync live rects before computing
+// membership. A node moved by a path the panel didn't own (paste/load/manual
+// drag, or an older move that never refreshed the rect) leaves a STALE cached
+// boundingRect; because nodeFocusBounds prefers boundingRect, a bounds-derived
+// read (graph_outline / graph_query / edit_group / auto_layout) would report the
+// PRE-move membership. syncGraphNodeAreas(graph) — which every membership read
+// handler now runs first — makes the read reflect the CURRENT layout.
+// ---------------------------------------------------------------------------
+test("stale cached rect yields wrong members; syncGraphNodeAreas repairs the read (#429)", () => {
+  // Five nodes were moved DOWN into a vertical column (pos updated), but their
+  // cached rects still describe the pre-move positions — three of them stale
+  // OUTSIDE the box the caller now wants, exactly the "reported only two" symptom.
+  const mk = (id, x, y, staleY) => ({
+    id,
+    pos: [x, y],
+    size: [200, 100],
+    boundingRect: [x, staleY - 30, 200, 130], // rect frozen at the OLD y (staleY)
+  });
+  const a = mk(299, 100, 100, 100); // already correct (rect matches pos)
+  const b = mk(300, 100, 260, 260); // already correct
+  const c = mk(301, 100, 420, -900); // rect stale far above the box
+  const d = mk(302, 100, 580, -900); // rect stale far above the box
+  const e = mk(303, 100, 740, -900); // rect stale far above the box
+  const graph = graphOf(a, b, c, d, e);
+
+  // The box the caller built (boundsAroundNodes uses live pos/size) wraps all five.
+  const box = boundsAroundNodes([a, b, c, d, e]);
+  const g = groupBox(box);
+
+  // BEFORE syncing: membership is computed against stale rects → only the two
+  // whose rects already matched are inside. This is the reported bug.
+  assert.deepEqual(
+    groupMemberNodes(graph, g).map((n) => n.id).sort((x, y) => x - y),
+    [299, 300],
+    "stale rects report only the two un-moved members (the #429 symptom)",
+  );
+
+  // AFTER the resync every read handler now performs: all five are members.
+  syncGraphNodeAreas(graph);
+  assert.deepEqual(
+    groupMemberNodes(graph, g).map((n) => n.id).sort((x, y) => x - y),
+    [299, 300, 301, 302, 303],
+    "post-sync membership reflects the live column layout — all five wrapped",
+  );
+});

--- a/browser_tests/unit/reconnect-staleness.test.mjs
+++ b/browser_tests/unit/reconnect-staleness.test.mjs
@@ -167,11 +167,21 @@ test("#433 wiring: reconnect bumps the epoch on a MONOTONIC clock; open/new/read
   for (const sig of ["async workflow_new()", "async workflow_open({"]) {
     const body = handlerBody(src, sig);
     assert.ok(body, `${sig} must exist`);
-    assert.match(body, /const openedForEpoch = backendReconnectEpoch;/, `${sig} must snapshot the epoch before awaiting`);
+    const snapAt = body.indexOf("const openedForEpoch = backendReconnectEpoch;");
+    assert.notEqual(snapAt, -1, `${sig} must snapshot the epoch`);
     assert.match(
       body,
       /if \(backendReconnectEpoch === openedForEpoch\) activeWorkflowResyncEpoch = openedForEpoch;/,
       `${sig} must stamp the resync epoch ONLY if unchanged (TOCTOU guard)`,
+    );
+    // The snapshot MUST precede the first `await` — otherwise a reconnect during the
+    // native work would advance the epoch before we capture it, reintroducing the
+    // TOCTOU P1 with the guard still "present". Ordering, not mere presence.
+    const firstAwaitAt = body.indexOf("await ");
+    assert.notEqual(firstAwaitAt, -1, `${sig} is async and must contain an await`);
+    assert.ok(
+      snapAt < firstAwaitAt,
+      `${sig} must snapshot openedForEpoch BEFORE the first await (snap@${snapAt} vs await@${firstAwaitAt})`,
     );
   }
 

--- a/browser_tests/unit/reconnect-staleness.test.mjs
+++ b/browser_tests/unit/reconnect-staleness.test.mjs
@@ -134,9 +134,25 @@ test("activeStaleHint names the risk and the recovery action", () => {
 // --- Wiring guards (close the codex "tests don't exercise the wiring" gap) ------
 // The handlers need the real ComfyUI `app`/canvas to run, so we can't unit-invoke
 // them here. Instead assert on the SOURCE that the wiring is present, so removing
-// any of it fails a test rather than silently reintroducing the bug.
+// any of it fails a test rather than silently reintroducing the bug. To avoid a
+// false-pass from a NEIGHBOUR handler's code (codex P2), each body is extracted up
+// to the NEXT executor-method declaration, and ordering (sync BEFORE the membership
+// read) is asserted explicitly.
 
-test("#433 wiring: reconnect bumps the epoch on a MONOTONIC clock, open/new record it", () => {
+/** Body of an object method from its `sig` up to the next 2-space-indented method
+ *  declaration (executor methods are indented exactly 2 spaces; nested code is 4+),
+ *  so the slice contains ONLY this handler — never a neighbour's. */
+function handlerBody(src, sig) {
+  const start = src.indexOf(sig);
+  if (start === -1) return null;
+  const after = start + sig.length;
+  // Next `\n  name(` / `\n  async name(` — the following executor method.
+  const m = src.slice(after).match(/\n {2}(?:async )?[A-Za-z_][A-Za-z0-9_]*\s*\(/);
+  const end = m ? after + m.index : src.length;
+  return src.slice(start, end);
+}
+
+test("#433 wiring: reconnect bumps the epoch on a MONOTONIC clock; open/new/readers wire it", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   // Epoch bump + monotonic timestamp live inside the `reconnected` listener.
   const reconnectBlock = src.slice(
@@ -145,20 +161,32 @@ test("#433 wiring: reconnect bumps the epoch on a MONOTONIC clock, open/new reco
   );
   assert.match(reconnectBlock, /backendReconnectEpoch \+= 1/, "reconnect must bump the epoch");
   assert.match(reconnectBlock, /backendReconnectedAt = monotonicNow\(\)/, "reconnect must arm the monotonic window");
-  // Both explicit resync sites stamp the CURRENT epoch (not a wall-clock time).
-  const resyncStamps = src.match(/activeWorkflowResyncEpoch = backendReconnectEpoch/g) ?? [];
-  assert.ok(resyncStamps.length >= 2, `open AND new must record the resync epoch (found ${resyncStamps.length})`);
-  // The read tools consult the helper with the epoch pair + monotonic now.
-  const readerCalls = src.match(/activeWorkflowPossiblyStale\(\{/g) ?? [];
-  assert.ok(readerCalls.length >= 2, `workflow_list + graph_outline must both check staleness (found ${readerCalls.length})`);
-  assert.match(src, /reconnectEpoch: backendReconnectEpoch/, "readers pass the epoch for ordering");
-  assert.match(src, /now: monotonicNow\(\)/, "readers use the monotonic clock");
+
+  // Each explicit resync site (open AND new) must stamp the epoch GUARDED by the
+  // TOCTOU check (codex P1): only when no reconnect intervened during the async op.
+  for (const sig of ["async workflow_new()", "async workflow_open({"]) {
+    const body = handlerBody(src, sig);
+    assert.ok(body, `${sig} must exist`);
+    assert.match(body, /const openedForEpoch = backendReconnectEpoch;/, `${sig} must snapshot the epoch before awaiting`);
+    assert.match(
+      body,
+      /if \(backendReconnectEpoch === openedForEpoch\) activeWorkflowResyncEpoch = openedForEpoch;/,
+      `${sig} must stamp the resync epoch ONLY if unchanged (TOCTOU guard)`,
+    );
+  }
+
+  // BOTH readers must consult the helper — checked in their OWN bodies, not globally.
+  for (const sig of ["workflow_list()", "graph_outline()"]) {
+    const body = handlerBody(src, sig);
+    assert.ok(body, `${sig} must exist`);
+    assert.match(body, /activeWorkflowPossiblyStale\(\{/, `${sig} must check post-reconnect staleness`);
+    assert.match(body, /reconnectEpoch: backendReconnectEpoch/, `${sig} must pass the epoch for ordering`);
+    assert.match(body, /now: monotonicNow\(\)/, `${sig} must use the monotonic clock`);
+  }
 });
 
-test("#429 wiring: every group-membership READ handler resyncs live rects first", () => {
+test("#429 wiring: every group-membership READ handler resyncs live rects BEFORE the read", () => {
   const src = readFileSync(PANEL_JS, "utf8");
-  // For each handler, take the slice from its declaration to the next handler and
-  // assert syncGraphNodeAreas appears before the geometric membership read.
   const handlers = [
     "graph_get_state()",
     "graph_outline()",
@@ -169,14 +197,16 @@ test("#429 wiring: every group-membership READ handler resyncs live rects first"
     "graph_remove_group({",
   ];
   for (const sig of handlers) {
-    const start = src.indexOf(sig);
-    assert.notEqual(start, -1, `handler ${sig} must exist`);
-    // Bound the slice to a reasonable handler size so we test THIS handler's body.
-    const body = src.slice(start, start + 2200);
-    assert.match(
-      body,
-      /syncGraphNodeAreas\(graph\)/,
-      `handler ${sig} must resync live rects before reading geometric membership (#429)`,
+    const body = handlerBody(src, sig);
+    assert.ok(body, `handler ${sig} must exist`);
+    const syncAt = body.indexOf("syncGraphNodeAreas(graph)");
+    assert.notEqual(syncAt, -1, `handler ${sig} must resync live rects (#429)`);
+    // The membership read is via summarizeGroup(...) or groupMemberNodes(...).
+    const readMatch = body.match(/summarizeGroup\(graph|groupMemberNodes\(graph/);
+    assert.ok(readMatch, `handler ${sig} must read geometric membership`);
+    assert.ok(
+      syncAt < readMatch.index,
+      `handler ${sig} must resync BEFORE computing membership (sync@${syncAt} vs read@${readMatch.index})`,
     );
   }
 });

--- a/browser_tests/unit/reconnect-staleness.test.mjs
+++ b/browser_tests/unit/reconnect-staleness.test.mjs
@@ -1,0 +1,105 @@
+// Unit tests for web/js/lib/reconnect-staleness.js — run with `node --test`.
+//
+// Regression coverage for #433: after a ComfyUI BACKEND restart the frontend can
+// restore a DIFFERENT active tab than the user was last viewing, so workflow_list /
+// graph_outline must flag `active` as possibly stale for a short window — until an
+// explicit panel_open_workflow / panel_new_workflow re-points it authoritatively.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ACTIVE_STALE_WINDOW_MS,
+  activeWorkflowPossiblyStale,
+  activeStaleHint,
+} from "../../web/js/lib/reconnect-staleness.js";
+
+test("no reconnect recorded → never stale", () => {
+  assert.equal(
+    activeWorkflowPossiblyStale({ reconnectedAt: null, now: 1_000_000 }),
+    false,
+  );
+  assert.equal(activeWorkflowPossiblyStale({ now: 1_000_000 }), false);
+});
+
+test("just reconnected, no resync → stale within the window", () => {
+  const reconnectedAt = 1_000_000;
+  assert.equal(
+    activeWorkflowPossiblyStale({ reconnectedAt, now: reconnectedAt + 1 }),
+    true,
+  );
+  assert.equal(
+    activeWorkflowPossiblyStale({ reconnectedAt, now: reconnectedAt + ACTIVE_STALE_WINDOW_MS - 1 }),
+    true,
+  );
+});
+
+test("window elapsed → no longer stale", () => {
+  const reconnectedAt = 1_000_000;
+  assert.equal(
+    activeWorkflowPossiblyStale({ reconnectedAt, now: reconnectedAt + ACTIVE_STALE_WINDOW_MS }),
+    false,
+  );
+  assert.equal(
+    activeWorkflowPossiblyStale({ reconnectedAt, now: reconnectedAt + ACTIVE_STALE_WINDOW_MS + 5000 }),
+    false,
+  );
+});
+
+test("explicit resync AT/AFTER the reconnect clears staleness immediately (#433 recovery)", () => {
+  const reconnectedAt = 1_000_000;
+  // panel_open_workflow / panel_new_workflow ran right after the reconnect.
+  assert.equal(
+    activeWorkflowPossiblyStale({
+      reconnectedAt,
+      resyncedAt: reconnectedAt + 10,
+      now: reconnectedAt + 20,
+    }),
+    false,
+  );
+  // Resync exactly at the reconnect instant also counts as authoritative.
+  assert.equal(
+    activeWorkflowPossiblyStale({ reconnectedAt, resyncedAt: reconnectedAt, now: reconnectedAt + 5 }),
+    false,
+  );
+});
+
+test("a STALE resync (before the reconnect) does NOT clear the new window", () => {
+  const reconnectedAt = 1_000_000;
+  // The agent opened a tab, THEN the backend restarted — the pre-restart open is
+  // no longer authoritative, so the freshly-reconnected active must still be flagged.
+  assert.equal(
+    activeWorkflowPossiblyStale({
+      reconnectedAt,
+      resyncedAt: reconnectedAt - 5000,
+      now: reconnectedAt + 100,
+    }),
+    true,
+  );
+});
+
+test("fail-safe: non-finite / missing inputs never flag (preserve report-as-is)", () => {
+  assert.equal(activeWorkflowPossiblyStale({ reconnectedAt: NaN, now: 5 }), false);
+  assert.equal(activeWorkflowPossiblyStale({ reconnectedAt: 5, now: NaN }), false);
+  assert.equal(activeWorkflowPossiblyStale({ reconnectedAt: 5 }), false);
+  // A `now` earlier than the reconnect (clock skew) yields a negative elapsed → not stale.
+  assert.equal(activeWorkflowPossiblyStale({ reconnectedAt: 100, now: 50 }), false);
+});
+
+test("custom windowMs is honored", () => {
+  const reconnectedAt = 1_000_000;
+  assert.equal(
+    activeWorkflowPossiblyStale({ reconnectedAt, now: reconnectedAt + 100, windowMs: 50 }),
+    false,
+  );
+  assert.equal(
+    activeWorkflowPossiblyStale({ reconnectedAt, now: reconnectedAt + 40, windowMs: 50 }),
+    true,
+  );
+});
+
+test("activeStaleHint names the risk and the recovery action", () => {
+  const hint = activeStaleHint();
+  assert.match(hint, /reconnect/i);
+  assert.match(hint, /panel_open_workflow/);
+  assert.match(hint, /active/i);
+});

--- a/browser_tests/unit/reconnect-staleness.test.mjs
+++ b/browser_tests/unit/reconnect-staleness.test.mjs
@@ -4,8 +4,16 @@
 // restore a DIFFERENT active tab than the user was last viewing, so workflow_list /
 // graph_outline must flag `active` as possibly stale for a short window — until an
 // explicit panel_open_workflow / panel_new_workflow re-points it authoritatively.
+//
+// The staleness verdict combines an EPOCH (ordering: has a resync happened SINCE
+// the latest reconnect?) with a MONOTONIC elapsed window (recency). Both guard
+// against the two codex P1s: a same-millisecond pre-reconnect resync, and a
+// non-monotonic wall clock.
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 
 import {
   ACTIVE_STALE_WINDOW_MS,
@@ -13,86 +21,105 @@ import {
   activeStaleHint,
 } from "../../web/js/lib/reconnect-staleness.js";
 
-test("no reconnect recorded → never stale", () => {
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+test("no reconnect yet (epoch 0) → never stale", () => {
   assert.equal(
-    activeWorkflowPossiblyStale({ reconnectedAt: null, now: 1_000_000 }),
+    activeWorkflowPossiblyStale({ reconnectEpoch: 0, reconnectedAt: 5, now: 6 }),
     false,
   );
-  assert.equal(activeWorkflowPossiblyStale({ now: 1_000_000 }), false);
+  assert.equal(activeWorkflowPossiblyStale({ reconnectedAt: 5, now: 6 }), false);
 });
 
-test("just reconnected, no resync → stale within the window", () => {
+test("first reconnect, no resync → stale within the window", () => {
   const reconnectedAt = 1_000_000;
+  const base = { reconnectEpoch: 1, resyncEpoch: 0, reconnectedAt };
+  assert.equal(activeWorkflowPossiblyStale({ ...base, now: reconnectedAt + 1 }), true);
   assert.equal(
-    activeWorkflowPossiblyStale({ reconnectedAt, now: reconnectedAt + 1 }),
-    true,
-  );
-  assert.equal(
-    activeWorkflowPossiblyStale({ reconnectedAt, now: reconnectedAt + ACTIVE_STALE_WINDOW_MS - 1 }),
+    activeWorkflowPossiblyStale({ ...base, now: reconnectedAt + ACTIVE_STALE_WINDOW_MS - 1 }),
     true,
   );
 });
 
 test("window elapsed → no longer stale", () => {
   const reconnectedAt = 1_000_000;
+  const base = { reconnectEpoch: 1, resyncEpoch: 0, reconnectedAt };
   assert.equal(
-    activeWorkflowPossiblyStale({ reconnectedAt, now: reconnectedAt + ACTIVE_STALE_WINDOW_MS }),
+    activeWorkflowPossiblyStale({ ...base, now: reconnectedAt + ACTIVE_STALE_WINDOW_MS }),
     false,
   );
   assert.equal(
-    activeWorkflowPossiblyStale({ reconnectedAt, now: reconnectedAt + ACTIVE_STALE_WINDOW_MS + 5000 }),
+    activeWorkflowPossiblyStale({ ...base, now: reconnectedAt + ACTIVE_STALE_WINDOW_MS + 5000 }),
     false,
   );
 });
 
-test("explicit resync AT/AFTER the reconnect clears staleness immediately (#433 recovery)", () => {
+test("resync FOR the current epoch clears staleness immediately (#433 recovery)", () => {
   const reconnectedAt = 1_000_000;
-  // panel_open_workflow / panel_new_workflow ran right after the reconnect.
+  // panel_open_workflow / panel_new_workflow ran after reconnect #1 → resyncEpoch=1.
   assert.equal(
     activeWorkflowPossiblyStale({
+      reconnectEpoch: 1,
+      resyncEpoch: 1,
       reconnectedAt,
-      resyncedAt: reconnectedAt + 10,
       now: reconnectedAt + 20,
     }),
     false,
   );
-  // Resync exactly at the reconnect instant also counts as authoritative.
-  assert.equal(
-    activeWorkflowPossiblyStale({ reconnectedAt, resyncedAt: reconnectedAt, now: reconnectedAt + 5 }),
-    false,
-  );
 });
 
-test("a STALE resync (before the reconnect) does NOT clear the new window", () => {
-  const reconnectedAt = 1_000_000;
-  // The agent opened a tab, THEN the backend restarted — the pre-restart open is
-  // no longer authoritative, so the freshly-reconnected active must still be flagged.
+test("a PRE-reconnect resync (older epoch) does NOT clear the new window (codex P1)", () => {
+  // Open happened during epoch 1 (resyncEpoch=1), THEN the backend restarted →
+  // reconnectEpoch=2. Even if reconnectedAt equals the open instant to the ms, the
+  // older resync epoch (1 < 2) can't clear the epoch-2 window. This is the exact
+  // same-millisecond suppression codex flagged.
+  const t = 1_000_000;
   assert.equal(
     activeWorkflowPossiblyStale({
-      reconnectedAt,
-      resyncedAt: reconnectedAt - 5000,
-      now: reconnectedAt + 100,
+      reconnectEpoch: 2,
+      resyncEpoch: 1,
+      reconnectedAt: t,
+      now: t, // zero elapsed, still inside the window
     }),
     true,
   );
 });
 
-test("fail-safe: non-finite / missing inputs never flag (preserve report-as-is)", () => {
-  assert.equal(activeWorkflowPossiblyStale({ reconnectedAt: NaN, now: 5 }), false);
-  assert.equal(activeWorkflowPossiblyStale({ reconnectedAt: 5, now: NaN }), false);
-  assert.equal(activeWorkflowPossiblyStale({ reconnectedAt: 5 }), false);
-  // A `now` earlier than the reconnect (clock skew) yields a negative elapsed → not stale.
-  assert.equal(activeWorkflowPossiblyStale({ reconnectedAt: 100, now: 50 }), false);
+test("monotonic window: a backwards `now` (should be impossible with performance.now) fails safe, never flags forever", () => {
+  // performance.now() never runs backwards, so now < reconnectedAt cannot occur in
+  // production. If it somehow did, the verdict is a benign `false` (report as-is) —
+  // NOT a stuck-forever warning.
+  assert.equal(
+    activeWorkflowPossiblyStale({ reconnectEpoch: 1, resyncEpoch: 0, reconnectedAt: 100, now: 50 }),
+    false,
+  );
+});
+
+test("fail-safe: non-finite inputs never flag (preserve report-as-is)", () => {
+  assert.equal(
+    activeWorkflowPossiblyStale({ reconnectEpoch: NaN, reconnectedAt: 5, now: 6 }),
+    false,
+  );
+  assert.equal(
+    activeWorkflowPossiblyStale({ reconnectEpoch: 1, reconnectedAt: NaN, now: 6 }),
+    false,
+  );
+  assert.equal(
+    activeWorkflowPossiblyStale({ reconnectEpoch: 1, reconnectedAt: 5, now: NaN }),
+    false,
+  );
 });
 
 test("custom windowMs is honored", () => {
   const reconnectedAt = 1_000_000;
+  const base = { reconnectEpoch: 1, resyncEpoch: 0, reconnectedAt };
   assert.equal(
-    activeWorkflowPossiblyStale({ reconnectedAt, now: reconnectedAt + 100, windowMs: 50 }),
+    activeWorkflowPossiblyStale({ ...base, now: reconnectedAt + 100, windowMs: 50 }),
     false,
   );
   assert.equal(
-    activeWorkflowPossiblyStale({ reconnectedAt, now: reconnectedAt + 40, windowMs: 50 }),
+    activeWorkflowPossiblyStale({ ...base, now: reconnectedAt + 40, windowMs: 50 }),
     true,
   );
 });
@@ -102,4 +129,54 @@ test("activeStaleHint names the risk and the recovery action", () => {
   assert.match(hint, /reconnect/i);
   assert.match(hint, /panel_open_workflow/);
   assert.match(hint, /active/i);
+});
+
+// --- Wiring guards (close the codex "tests don't exercise the wiring" gap) ------
+// The handlers need the real ComfyUI `app`/canvas to run, so we can't unit-invoke
+// them here. Instead assert on the SOURCE that the wiring is present, so removing
+// any of it fails a test rather than silently reintroducing the bug.
+
+test("#433 wiring: reconnect bumps the epoch on a MONOTONIC clock, open/new record it", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  // Epoch bump + monotonic timestamp live inside the `reconnected` listener.
+  const reconnectBlock = src.slice(
+    src.indexOf('api.addEventListener("reconnected"'),
+    src.indexOf('api.addEventListener("reconnected"') + 700,
+  );
+  assert.match(reconnectBlock, /backendReconnectEpoch \+= 1/, "reconnect must bump the epoch");
+  assert.match(reconnectBlock, /backendReconnectedAt = monotonicNow\(\)/, "reconnect must arm the monotonic window");
+  // Both explicit resync sites stamp the CURRENT epoch (not a wall-clock time).
+  const resyncStamps = src.match(/activeWorkflowResyncEpoch = backendReconnectEpoch/g) ?? [];
+  assert.ok(resyncStamps.length >= 2, `open AND new must record the resync epoch (found ${resyncStamps.length})`);
+  // The read tools consult the helper with the epoch pair + monotonic now.
+  const readerCalls = src.match(/activeWorkflowPossiblyStale\(\{/g) ?? [];
+  assert.ok(readerCalls.length >= 2, `workflow_list + graph_outline must both check staleness (found ${readerCalls.length})`);
+  assert.match(src, /reconnectEpoch: backendReconnectEpoch/, "readers pass the epoch for ordering");
+  assert.match(src, /now: monotonicNow\(\)/, "readers use the monotonic clock");
+});
+
+test("#429 wiring: every group-membership READ handler resyncs live rects first", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  // For each handler, take the slice from its declaration to the next handler and
+  // assert syncGraphNodeAreas appears before the geometric membership read.
+  const handlers = [
+    "graph_get_state()",
+    "graph_outline()",
+    "graph_query({",
+    "graph_auto_layout({",
+    "graph_subgraph_group({",
+    "graph_edit_group({",
+    "graph_remove_group({",
+  ];
+  for (const sig of handlers) {
+    const start = src.indexOf(sig);
+    assert.notEqual(start, -1, `handler ${sig} must exist`);
+    // Bound the slice to a reasonable handler size so we test THIS handler's body.
+    const body = src.slice(start, start + 2200);
+    assert.match(
+      body,
+      /syncGraphNodeAreas\(graph\)/,
+      `handler ${sig} must resync live rects before reading geometric membership (#429)`,
+    );
+  }
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -6613,6 +6613,11 @@ const GRAPH_TOOL_EXECUTORS = {
   },
 
   async workflow_new() {
+    // #433 TOCTOU: snapshot the reconnect epoch BEFORE the async native work. If a
+    // reconnect lands mid-operation it advances the epoch, and stamping the NEW
+    // epoch at the end would suppress the warning that reconnect must raise (codex
+    // P1). We only claim authoritative below when the epoch is UNCHANGED.
+    const openedForEpoch = backendReconnectEpoch;
     const mgr = app?.extensionManager;
     if (!mgr?.command?.execute) throw new Error("command service unavailable");
     // Comfy.NewBlankWorkflow opens a fresh TAB — the current workflow is untouched.
@@ -6638,14 +6643,18 @@ const GRAPH_TOOL_EXECUTORS = {
     const key = workflowTabId(wf);
     workflowStableUuid(wf);
     // #433: an explicit new-tab authoritatively re-points `active` — record it
-    // against the CURRENT reconnect epoch so later reads trust `active` again.
-    activeWorkflowResyncEpoch = backendReconnectEpoch;
+    // against the epoch we STARTED on, but only if no reconnect intervened during
+    // the async work (else its tab-restore may have overridden us — leave armed).
+    if (backendReconnectEpoch === openedForEpoch) activeWorkflowResyncEpoch = openedForEpoch;
     // `key`/`routing_key` are the unique handle the agent should pass to
     // panel_set_workflow_target so its session pins to this exact graph.
     return { created: true, active: getWorkflowTitle(), key, routing_key: key };
   },
 
   async workflow_open({ path }) {
+    // #433 TOCTOU: snapshot the reconnect epoch BEFORE the async open (see
+    // workflow_new) so a reconnect landing mid-operation is not masked by our stamp.
+    const openedForEpoch = backendReconnectEpoch;
     const s = app?.extensionManager?.workflow;
     if (!s?.openWorkflow) throw new Error("workflow service unavailable");
     const find = () => {
@@ -6707,8 +6716,9 @@ const GRAPH_TOOL_EXECUTORS = {
     // diff otherwise flips it to modified:true and blocks an unforced close).
     await clearSpuriousOpenModified(target);
     // #433: an explicit open authoritatively re-points `active` — record it against
-    // the CURRENT reconnect epoch so later reads trust `active` again.
-    activeWorkflowResyncEpoch = backendReconnectEpoch;
+    // the epoch we STARTED on, but only if no reconnect intervened during the async
+    // open (else its tab-restore may have overridden us — leave the window armed).
+    if (backendReconnectEpoch === openedForEpoch) activeWorkflowResyncEpoch = openedForEpoch;
     return {
       opened: { path: target.path, filename: target.filename },
       modified: !!target.isModified,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -169,6 +169,10 @@ import {
   syncGraphNodeAreas,
   moveGroupMembers,
 } from "./lib/group-geometry.js";
+import {
+  activeWorkflowPossiblyStale,
+  activeStaleHint,
+} from "./lib/reconnect-staleness.js";
 import { pickRevertSnapshot } from "./lib/graph-revert.js";
 import {
   saveActiveWorkflow,
@@ -237,6 +241,14 @@ let nodeDefRefreshInFlight = null;
 // suppress a genuine miss (codex WS-3 finding #4). Reset to false whenever the
 // backend socket drops, since the combos may be about to change under us.
 let nodeDefsRefreshConfirmed = false;
+// #433: when ComfyUI's own socket last RECONNECTED (backend restart). For a short
+// window after this, the frontend may have restored a DIFFERENT active tab than the
+// user was last viewing, so workflow_list / graph_outline flag `active` as possibly
+// stale until an explicit panel_open_workflow / panel_new_workflow re-points it.
+let backendReconnectedAt = null;
+// When the active tab was last authoritatively (re)bound by an explicit open/new —
+// clears the possibly-stale flag above the moment the agent resyncs.
+let activeWorkflowResyncedAt = null;
 // The actual (idempotent) node-def registration; the coalescer owns the in-flight
 // slot lifecycle, so this MUST NOT clear it. Reuses a caller-supplied /object_info
 // payload when present (graph_add_node passes the fresh defs it just validated
@@ -316,6 +328,9 @@ function setupListeners() {
     // in-tab signal that the server came back after a restart — refresh the
     // stale node registry + combos then (#221/#171/#185/#181).
     api.addEventListener("reconnected", () => {
+      // #433: the frontend may now restore a stale/wrong active tab — arm the
+      // possibly-stale window until an explicit open/new re-points `active`.
+      backendReconnectedAt = Date.now();
       void refreshComfyNodeDefs();
     });
   } catch {
@@ -4454,6 +4469,9 @@ const GRAPH_TOOL_EXECUTORS = {
 
   graph_get_state() {
     const { graph, rootGraph } = getGraphCtx();
+    // #429: resync cached node rects to live geometry before reading geometric
+    // group membership, so a non-panel move (paste/load/drag) can't report stale ids.
+    syncGraphNodeAreas(graph);
     const nodes = (graph._nodes ?? []).slice(0, MAX_STATE_NODES).map(summarizeNode);
     const groups = (graph._groups ?? []).map((g) => summarizeGroup(graph, g));
     const inSubgraph = graph !== rootGraph;
@@ -4586,6 +4604,11 @@ const GRAPH_TOOL_EXECUTORS = {
   // raw node dump makes you reconstruct). Read-only.
   graph_outline() {
     const { graph } = getGraphCtx();
+    // #429: geometric group membership is tested boundingRect-first, so resync every
+    // node's cached rect to its live pos/size BEFORE computing membership — a node
+    // moved by a path the panel didn't own (paste/load/manual drag) otherwise reports
+    // stale group members (mirrors the create/move write paths).
+    syncGraphNodeAreas(graph);
     const nodes = graph._nodes ?? [];
     const byId = new Map(nodes.map((n) => [n.id, n]));
     const links = graph.links ?? {};
@@ -4661,7 +4684,16 @@ const GRAPH_TOOL_EXECUTORS = {
     const va = describeActiveGraph(graph);
     const viewingStr = va && va.scope === "subgraph" ? `subgraph "${va.title ?? ""}"` : (va?.scope ?? "root");
     const header = `${nodes.length} nodes · ${groups.length} group(s) · viewing: ${viewingStr}`;
+    // #433: warn if ComfyUI reconnected recently — `viewing`/`active` may point at a
+    // tab the frontend restored rather than the one the user was last looking at.
+    const activeMaybeStale = activeWorkflowPossiblyStale({
+      reconnectedAt: backendReconnectedAt,
+      resyncedAt: activeWorkflowResyncedAt,
+      now: Date.now(),
+    });
+    const staleBanner = activeMaybeStale ? `⚠ ${activeStaleHint()}\n\n` : "";
     const outline =
+      staleBanner +
       header +
       (groupLines.length ? `\n\nGROUPS (title → member node ids):\n${groupLines.join("\n")}` : "") +
       `\n\nNODES (data flows top→down; ← inputs from, → outputs to):\n${lines.join("\n")}`;
@@ -4671,6 +4703,9 @@ const GRAPH_TOOL_EXECUTORS = {
       group_count: groups.length,
       viewing: describeActiveGraph(graph),
       outline,
+      ...(activeMaybeStale
+        ? { active_possibly_stale: true, stale_hint: activeStaleHint() }
+        : {}),
     };
   },
 
@@ -4686,6 +4721,9 @@ const GRAPH_TOOL_EXECUTORS = {
   // graph_get_state stays registered for BACK-COMPAT with older orchestrators.
   graph_query({ types, title, where, ids, upstream_of, downstream_of, depth, fields, group_by, limit, max_chars }) {
     const { graph, rootGraph } = getGraphCtx();
+    // #429: resync cached node rects to live geometry before the `groups` block
+    // recomputes geometric membership (summarizeGroup), so it never reports stale ids.
+    syncGraphNodeAreas(graph);
     const nodes = graph._nodes ?? [];
     const links = graph.links ?? {};
     const byId = new Map(nodes.map((n) => [String(n.id), n]));
@@ -5825,6 +5863,9 @@ const GRAPH_TOOL_EXECUTORS = {
     dry_run = false,
   } = {}) {
     const { graph } = getGraphCtx();
+    // #429: resync live rects before deriving group membership for clustering, so a
+    // non-panel move can't cluster the wrong nodes (or drop members) during layout.
+    syncGraphNodeAreas(graph);
     const allNodes = (graph._nodes ?? []).filter(
       (n) => n.id !== SUBGRAPH_INPUT_RAIL_ID && n.id !== SUBGRAPH_OUTPUT_RAIL_ID,
     );
@@ -6513,6 +6554,14 @@ const GRAPH_TOOL_EXECUTORS = {
     };
     const openList = dedupeWorkflowTabRecords((s.openWorkflows ?? []).filter(Boolean).map(brief));
     const activeDiskPath = workflowDiskIdentityPath(active);
+    // #433: right after a backend reconnect the frontend may have restored a
+    // DIFFERENT active tab than the user was last viewing — warn the agent so it
+    // double-checks `active` instead of silently reading/editing the wrong graph.
+    const activeMaybeStale = activeWorkflowPossiblyStale({
+      reconnectedAt: backendReconnectedAt,
+      resyncedAt: activeWorkflowResyncedAt,
+      now: Date.now(),
+    });
     return {
       active: active
         ? {
@@ -6541,6 +6590,9 @@ const GRAPH_TOOL_EXECUTORS = {
       // for any existing reader.
       open: openList,
       workflows: openList,
+      ...(activeMaybeStale
+        ? { active_possibly_stale: true, stale_hint: activeStaleHint() }
+        : {}),
     };
   },
 
@@ -6569,6 +6621,9 @@ const GRAPH_TOOL_EXECUTORS = {
     // the key exists BEFORE the first edit and is returned for pinning.
     const key = workflowTabId(wf);
     workflowStableUuid(wf);
+    // #433: an explicit new-tab authoritatively re-points `active` — clear any
+    // post-reconnect possibly-stale window so later reads trust `active` again.
+    activeWorkflowResyncedAt = Date.now();
     // `key`/`routing_key` are the unique handle the agent should pass to
     // panel_set_workflow_target so its session pins to this exact graph.
     return { created: true, active: getWorkflowTitle(), key, routing_key: key };
@@ -6635,6 +6690,9 @@ const GRAPH_TOOL_EXECUTORS = {
     // Opening alone must not dirty the tab (a spurious post-load change-tracker
     // diff otherwise flips it to modified:true and blocks an unforced close).
     await clearSpuriousOpenModified(target);
+    // #433: an explicit open authoritatively re-points `active` — clear any
+    // post-reconnect possibly-stale window so later reads trust `active` again.
+    activeWorkflowResyncedAt = Date.now();
     return {
       opened: { path: target.path, filename: target.filename },
       modified: !!target.isModified,
@@ -6733,6 +6791,9 @@ const GRAPH_TOOL_EXECUTORS = {
         `no group matching "${group}" — list groups via panel_query_graph (each has id, title, node_ids)`,
       );
     }
+    // #429: resync live rects before computing which nodes the box encloses, so a
+    // non-panel move doesn't wrap the WRONG set (or nothing) into the subgraph.
+    syncGraphNodeAreas(graph);
     const ns = groupMemberNodes(graph, g);
     if (!ns.length) {
       throw new Error(`group "${g.title}" has no nodes inside its box to wrap into a subgraph`);
@@ -7321,6 +7382,10 @@ const GRAPH_TOOL_EXECUTORS = {
   graph_edit_group({ group_id, title, color, font_size, bounds }) {
     const { graph } = getGraphCtx();
     const g = resolveGroup(graph, group_id);
+    // #429: resync live rects before re-bounding + recomputing membership so the
+    // returned node_ids reflect the CURRENT layout, not a stale cached rect (the
+    // exact "edit_group still reported the old members" symptom in the report).
+    syncGraphNodeAreas(graph);
     graph.beforeChange();
     try {
       if (typeof title === "string") g.title = title;
@@ -7339,6 +7404,9 @@ const GRAPH_TOOL_EXECUTORS = {
   graph_remove_group({ group_id }) {
     const { graph } = getGraphCtx();
     const g = resolveGroup(graph, group_id);
+    // #429: resync live rects so the removed-group summary reports the members that
+    // were ACTUALLY inside the box, not a stale cached set.
+    syncGraphNodeAreas(graph);
     const summary = summarizeGroup(graph, g);
     graph.beforeChange();
     try {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -241,14 +241,25 @@ let nodeDefRefreshInFlight = null;
 // suppress a genuine miss (codex WS-3 finding #4). Reset to false whenever the
 // backend socket drops, since the combos may be about to change under us.
 let nodeDefsRefreshConfirmed = false;
-// #433: when ComfyUI's own socket last RECONNECTED (backend restart). For a short
-// window after this, the frontend may have restored a DIFFERENT active tab than the
-// user was last viewing, so workflow_list / graph_outline flag `active` as possibly
+// #433: track ComfyUI backend RECONNECTS (backend restart). For a short window
+// after one, the frontend may have restored a DIFFERENT active tab than the user
+// was last viewing, so workflow_list / graph_outline flag `active` as possibly
 // stale until an explicit panel_open_workflow / panel_new_workflow re-points it.
+// Ordering is by EPOCH (a pre-reconnect resync can't clear the new window); the
+// window is measured on a MONOTONIC clock (performance.now) so a wall-clock
+// adjustment can't spuriously suppress or expire the warning (codex P1 x2).
+let backendReconnectEpoch = 0;
 let backendReconnectedAt = null;
-// When the active tab was last authoritatively (re)bound by an explicit open/new —
-// clears the possibly-stale flag above the moment the agent resyncs.
-let activeWorkflowResyncedAt = null;
+// The reconnect epoch value at the last authoritative (re)bind by an explicit
+// open/new; when it's >= backendReconnectEpoch the active pointer is trusted again.
+let activeWorkflowResyncEpoch = 0;
+// Monotonic "now" — performance.now() when available (never runs backwards),
+// falling back to Date.now() only if the environment lacks it.
+function monotonicNow() {
+  return typeof performance !== "undefined" && typeof performance.now === "function"
+    ? performance.now()
+    : Date.now();
+}
 // The actual (idempotent) node-def registration; the coalescer owns the in-flight
 // slot lifecycle, so this MUST NOT clear it. Reuses a caller-supplied /object_info
 // payload when present (graph_add_node passes the fresh defs it just validated
@@ -328,9 +339,12 @@ function setupListeners() {
     // in-tab signal that the server came back after a restart — refresh the
     // stale node registry + combos then (#221/#171/#185/#181).
     api.addEventListener("reconnected", () => {
-      // #433: the frontend may now restore a stale/wrong active tab — arm the
-      // possibly-stale window until an explicit open/new re-points `active`.
-      backendReconnectedAt = Date.now();
+      // #433: the frontend may now restore a stale/wrong active tab — bump the
+      // epoch and arm the monotonic possibly-stale window. Bumping the epoch
+      // invalidates any EARLIER resync so a pre-reconnect open can't clear this
+      // new window (codex P1); only an open/new AFTER this reconnect will.
+      backendReconnectEpoch += 1;
+      backendReconnectedAt = monotonicNow();
       void refreshComfyNodeDefs();
     });
   } catch {
@@ -4687,9 +4701,10 @@ const GRAPH_TOOL_EXECUTORS = {
     // #433: warn if ComfyUI reconnected recently — `viewing`/`active` may point at a
     // tab the frontend restored rather than the one the user was last looking at.
     const activeMaybeStale = activeWorkflowPossiblyStale({
+      reconnectEpoch: backendReconnectEpoch,
+      resyncEpoch: activeWorkflowResyncEpoch,
       reconnectedAt: backendReconnectedAt,
-      resyncedAt: activeWorkflowResyncedAt,
-      now: Date.now(),
+      now: monotonicNow(),
     });
     const staleBanner = activeMaybeStale ? `⚠ ${activeStaleHint()}\n\n` : "";
     const outline =
@@ -6558,9 +6573,10 @@ const GRAPH_TOOL_EXECUTORS = {
     // DIFFERENT active tab than the user was last viewing — warn the agent so it
     // double-checks `active` instead of silently reading/editing the wrong graph.
     const activeMaybeStale = activeWorkflowPossiblyStale({
+      reconnectEpoch: backendReconnectEpoch,
+      resyncEpoch: activeWorkflowResyncEpoch,
       reconnectedAt: backendReconnectedAt,
-      resyncedAt: activeWorkflowResyncedAt,
-      now: Date.now(),
+      now: monotonicNow(),
     });
     return {
       active: active
@@ -6621,9 +6637,9 @@ const GRAPH_TOOL_EXECUTORS = {
     // the key exists BEFORE the first edit and is returned for pinning.
     const key = workflowTabId(wf);
     workflowStableUuid(wf);
-    // #433: an explicit new-tab authoritatively re-points `active` — clear any
-    // post-reconnect possibly-stale window so later reads trust `active` again.
-    activeWorkflowResyncedAt = Date.now();
+    // #433: an explicit new-tab authoritatively re-points `active` — record it
+    // against the CURRENT reconnect epoch so later reads trust `active` again.
+    activeWorkflowResyncEpoch = backendReconnectEpoch;
     // `key`/`routing_key` are the unique handle the agent should pass to
     // panel_set_workflow_target so its session pins to this exact graph.
     return { created: true, active: getWorkflowTitle(), key, routing_key: key };
@@ -6690,9 +6706,9 @@ const GRAPH_TOOL_EXECUTORS = {
     // Opening alone must not dirty the tab (a spurious post-load change-tracker
     // diff otherwise flips it to modified:true and blocks an unforced close).
     await clearSpuriousOpenModified(target);
-    // #433: an explicit open authoritatively re-points `active` — clear any
-    // post-reconnect possibly-stale window so later reads trust `active` again.
-    activeWorkflowResyncedAt = Date.now();
+    // #433: an explicit open authoritatively re-points `active` — record it against
+    // the CURRENT reconnect epoch so later reads trust `active` again.
+    activeWorkflowResyncEpoch = backendReconnectEpoch;
     return {
       opened: { path: target.path, filename: target.filename },
       modified: !!target.isModified,

--- a/web/js/lib/reconnect-staleness.js
+++ b/web/js/lib/reconnect-staleness.js
@@ -7,37 +7,54 @@
 // graph_outline faithfully report whatever the frontend calls `active`, so for a
 // short window after a reconnect the `active` identity an agent reads may not match
 // the tab the user is actually looking at and must be double-checked rather than
-// silently trusted (#433). This just answers "did a reconnect happen recently, and
-// has nothing authoritative re-pointed `active` since?" — the callers add the flag.
+// silently trusted (#433).
 //
-// Dependency-free (no DOM, no app, no timers) so it is unit-testable with plain
-// values and the same logic can't drift between workflow_list and graph_outline.
+// Two independent signals, deliberately NOT collapsed into a wall-clock compare:
+//   * an EPOCH counter (monotonically bumped on every reconnect) decides ORDER —
+//     "has an explicit open/new re-pointed `active` SINCE the latest reconnect?".
+//     A pre-reconnect resync carries an OLDER epoch and can never clear the new
+//     window, even if both events land in the same millisecond (codex P1).
+//   * a MONOTONIC elapsed reading (callers pass performance.now(), which never
+//     runs backwards and is immune to wall-clock adjustments — codex P1) decides
+//     the WINDOW — "was the reconnect recent enough to still warn?".
+//
+// Dependency-free (no DOM, no app, no timers, no clock) so it is unit-testable with
+// plain values and the same logic can't drift between workflow_list and graph_outline.
 
-/** How long after a reconnect the `active` pointer is treated as possibly stale. */
+/** How long after a reconnect the `active` pointer is treated as possibly stale (ms). */
 export const ACTIVE_STALE_WINDOW_MS = 30000;
 
 /**
- * True when a backend reconnect happened within `windowMs` of `now` AND nothing
- * authoritative has re-pointed the active tab since (an explicit panel_open_workflow
- * / panel_new_workflow records `resyncedAt`). Fail-safe: any missing/non-finite
- * input yields `false` (never flag when we can't actually tell), matching the
- * pre-existing "report active as-is" behaviour.
+ * True when the LATEST reconnect (epoch > 0) has NOT been superseded by an explicit
+ * resync for that same epoch AND it happened within `windowMs` of `now` on a
+ * MONOTONIC clock. Fail-safe: any missing/invalid input yields `false` (never flag
+ * when we can't actually tell), preserving the pre-existing "report active as-is".
  *
- * @param {{reconnectedAt?: number|null, resyncedAt?: number|null, now?: number, windowMs?: number}} o
+ * @param {{
+ *   reconnectEpoch?: number,   // bumped on every reconnect; 0/absent = none yet
+ *   resyncEpoch?: number,      // epoch value at the last explicit open/new
+ *   reconnectedAt?: number|null, // monotonic timestamp (performance.now) of latest reconnect
+ *   now?: number,              // monotonic timestamp (performance.now)
+ *   windowMs?: number,
+ * }} o
  */
 export function activeWorkflowPossiblyStale({
+  reconnectEpoch = 0,
+  resyncEpoch = 0,
   reconnectedAt,
-  resyncedAt = null,
   now,
   windowMs = ACTIVE_STALE_WINDOW_MS,
 } = {}) {
+  // No reconnect has happened → nothing to warn about.
+  if (!Number.isFinite(reconnectEpoch) || reconnectEpoch <= 0) return false;
+  // An explicit open/new that ran AT OR AFTER the latest reconnect (same-or-newer
+  // epoch) makes `active` authoritative again — clear immediately. Ordering is by
+  // epoch, so a pre-reconnect resync (older epoch) can't spuriously clear (codex P1).
+  if (Number.isFinite(resyncEpoch) && resyncEpoch >= reconnectEpoch) return false;
+  // Window check on a monotonic clock: negative elapsed (should be impossible with
+  // performance.now) fails safe to "not stale" rather than flag forever.
   if (typeof reconnectedAt !== "number" || !Number.isFinite(reconnectedAt)) return false;
   if (typeof now !== "number" || !Number.isFinite(now)) return false;
-  // An explicit resync (panel_open_workflow / panel_new_workflow) AT OR AFTER the
-  // reconnect makes the active pointer authoritative again — clear immediately.
-  if (typeof resyncedAt === "number" && Number.isFinite(resyncedAt) && resyncedAt >= reconnectedAt) {
-    return false;
-  }
   const elapsed = now - reconnectedAt;
   return elapsed >= 0 && elapsed < windowMs;
 }

--- a/web/js/lib/reconnect-staleness.js
+++ b/web/js/lib/reconnect-staleness.js
@@ -1,0 +1,53 @@
+// Pure helper: is the workflow service's `active` pointer possibly stale right now?
+//
+// After a ComfyUI BACKEND restart the frontend's OWN websocket reconnects and it
+// RESTORES a tab as active — but it can restore a DIFFERENT tab than the one the
+// user was viewing immediately before the drop (a last-SAVED vs last-VIEWED
+// snapshot, or a race where the restore hasn't settled yet). workflow_list /
+// graph_outline faithfully report whatever the frontend calls `active`, so for a
+// short window after a reconnect the `active` identity an agent reads may not match
+// the tab the user is actually looking at and must be double-checked rather than
+// silently trusted (#433). This just answers "did a reconnect happen recently, and
+// has nothing authoritative re-pointed `active` since?" — the callers add the flag.
+//
+// Dependency-free (no DOM, no app, no timers) so it is unit-testable with plain
+// values and the same logic can't drift between workflow_list and graph_outline.
+
+/** How long after a reconnect the `active` pointer is treated as possibly stale. */
+export const ACTIVE_STALE_WINDOW_MS = 30000;
+
+/**
+ * True when a backend reconnect happened within `windowMs` of `now` AND nothing
+ * authoritative has re-pointed the active tab since (an explicit panel_open_workflow
+ * / panel_new_workflow records `resyncedAt`). Fail-safe: any missing/non-finite
+ * input yields `false` (never flag when we can't actually tell), matching the
+ * pre-existing "report active as-is" behaviour.
+ *
+ * @param {{reconnectedAt?: number|null, resyncedAt?: number|null, now?: number, windowMs?: number}} o
+ */
+export function activeWorkflowPossiblyStale({
+  reconnectedAt,
+  resyncedAt = null,
+  now,
+  windowMs = ACTIVE_STALE_WINDOW_MS,
+} = {}) {
+  if (typeof reconnectedAt !== "number" || !Number.isFinite(reconnectedAt)) return false;
+  if (typeof now !== "number" || !Number.isFinite(now)) return false;
+  // An explicit resync (panel_open_workflow / panel_new_workflow) AT OR AFTER the
+  // reconnect makes the active pointer authoritative again — clear immediately.
+  if (typeof resyncedAt === "number" && Number.isFinite(resyncedAt) && resyncedAt >= reconnectedAt) {
+    return false;
+  }
+  const elapsed = now - reconnectedAt;
+  return elapsed >= 0 && elapsed < windowMs;
+}
+
+/** Actionable one-liner surfaced to the agent when `active` may be post-reconnect stale. */
+export function activeStaleHint() {
+  return (
+    "ComfyUI reconnected moments ago (e.g. a backend restart) and its frontend may have " +
+    "restored a DIFFERENT active tab than the one the user was last viewing. Do not trust " +
+    "`active` blindly: confirm the intended workflow from the `open`/`workflows` list, then " +
+    "call panel_open_workflow to bind to it before reading or editing its graph."
+  );
+}


### PR DESCRIPTION
## Summary

Fixes a target/geometry/active-identity **staleness cluster** in the panel. Verify-first: all three issues relate to shipped work, so each was re-checked on current `origin/main` before touching code.

### panel#429 — `panel_create_group` used stale node positions → wrong membership
`Closes artokun/comfyui-mcp-panel#429`

- **Verified:** the exact repro (move via `panel_move_node` → `panel_create_group`/`panel_edit_group`) is **already fixed** on main — `move_node` refreshes each node's cached `boundingRect` (#355) and `create_group`/`move_group` resync live rects (#408/#416/#391).
- **Residual fixed here:** the group-membership **READ/consume** handlers computed geometric membership *without* first resyncing rects, so they still went stale after a move the panel didn't own (paste / graph-load / manual drag). Added `syncGraphNodeAreas(graph)` — mirroring the create/move write paths — to all seven: `graph_get_state`, `graph_outline`, `graph_query`, `graph_auto_layout`, `graph_subgraph_group`, `graph_edit_group`, `graph_remove_group`.

### panel#433 — `panel_list_workflows` / `panel_graph_outline` report a stale `active` after reconnect
`Closes artokun/comfyui-mcp-panel#433`

- **Verified:** the tools faithfully report ComfyUI's own `activeWorkflow`; after a backend restart the frontend can restore a *different* active tab than the user was last viewing (root cause is upstream tab-restore). The real panel-side gap is the issue's suggestion #3: **no signal to the agent** that a reconnect just happened.
- **Fixed here:** a bounded post-reconnect "possibly stale" window (new pure helper `lib/reconnect-staleness.js`). Armed on ComfyUI's `reconnected` event, cleared by an explicit `panel_open_workflow` / `panel_new_workflow`. `panel_list_workflows` and `panel_graph_outline` now surface `active_possibly_stale: true` + a `stale_hint` so an agent double-checks `active` instead of silently editing the wrong graph.
- Ordering uses a **reconnect epoch** (a pre-reconnect resync can't clear a newer window; TOCTOU-guarded across the async open/new); the window is measured on a **monotonic clock** (`performance.now`), so a wall-clock adjustment can't suppress or expire the warning.

### panel#430 — pinned target rejected graph calls unless the tab was active
**Not in this PR — already fixed upstream.** The shipped #556/#571 work (mcp **0.48.23**, PR #585, `resolvePinTarget` in `src/orchestrator/panel-tools.ts`) rejects a background-tab pin **at pin time** — exactly the "don't report successful background routing" option the issue asked for. No residual; closing #430 as fixed-in-0.48.23 with a reopen clause.

## Tests
- New `browser_tests/unit/reconnect-staleness.test.mjs` — epoch/monotonic/TOCTOU semantics + source-level **wiring guards** (verified to fail if any handler's resync or the pre-await snapshot is removed).
- Extended `browser_tests/unit/group-geometry.test.mjs` — read-path stale-rect invariant.
- Full unit suite **1049 pass**, `tsc --noEmit` clean.

## Review
Adversarial codex self-gate (gpt-5.6-terra/high): 3 FAIL rounds caught real issues (same-ms suppression, non-monotonic clock, TOCTOU stamp, test false-passes) — all fixed — then **VERDICT: PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
