### PR TITLE
release: 0.11.26 — remove_node/manual-notice (#420/#369), group live-geometry + reconnect stale hint (#429/#433), reload reconnects all tabs (#419), subgraph regression locks (#438/#439/#435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.26] - 2026-08-01
+
+### Fixed
+- **`panel_remove_node` no longer crashes on reroute/subgraph-boundary nodes, and the "manual changes" notice stops contradicting the live graph (#420, #369).** Node removal recovers from the `findInputSlot is not a function` TypeError (severs residual links at the record level, preferring reroute/layout-aware `LLink.disconnect()`), and the manual-change diff runs only when the reconnect epoch + workflow identity both match — so a reload/resume reseeds silently instead of emitting a false per-node delta.
+- **Group read tools use live geometry, and read tools flag a stale "active" workflow briefly after a reconnect (#429, #433).** The group-membership read/consume handlers (`graph_get_state`/`graph_outline`/`graph_query`/`graph_auto_layout`/`graph_edit_group`/…) resync node rects to live pos/size before computing geometric membership (no staleness after a non-panel paste/load/drag), and `panel_list_workflows`/`panel_graph_outline` surface an `active_possibly_stale` hint for a bounded window after a ComfyUI reconnect (epoch-ordered + monotonic-clock-windowed, TOCTOU-guarded).
+- **Every open sidebar tab's bridge reconnects after a soft-reload (#419).** Hardens the #379 fix so `softReload()` guarantees `client.start()` on every path (extracted to a DI-testable `performSoftReloadRecovery()`), with an N-tab independence regression test — no tab left permanently disconnected.
+- **Regression-locked the shipped subgraph run/set_widget behavior (#438, #439, #435).** `panel_run` targeting an output node inside the active/nested subgraph and `set_widget` firing a promoted widget's inner callback were already fixed in 0.11.25; extracted `resolveRunToNodeTarget()` and added non-vacuous regression tests so they can't silently regress.
+
 ## [0.11.25] - 2026-08-01
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.25"
+version = "0.11.26"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -358,7 +358,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.25";
+const PANEL_VERSION = "0.11.26";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Five codex-gated clusters since 0.11.25. Registry publish fires on the pyproject change. Companion to mcp 0.48.26 (published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)