### PR TITLE
fix(readiness): resolve provider CLI under ComfyUI Desktop's minimal GUI PATH (#434)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -137,9 +137,38 @@ def _antigravity_installed():
     return os.path.isfile(os.path.join(os.path.expanduser("~"), ".local", "bin", "agy"))
 
 
+def _gui_fallback_bin_dirs():
+    """Well-known user/local bin dirs a GUI launcher's minimal PATH omits (#434).
+
+    ComfyUI Desktop launches its Python server with a restricted GUI PATH
+    (``/usr/bin:/bin:/usr/sbin:/sbin`` on macOS), so ``shutil.which()`` misses a
+    CLI the user installed under ``~/.local/bin`` (the official installer's
+    target), Homebrew, or an npm global prefix — and the panel then falsely
+    reports the provider's CLI absent and silently falls back to another backend.
+    Windows resolves via PATHEXT and has no equivalent GUI-PATH gap, so keep the
+    fallback non-Windows only (mirrors ``_ollama_installed`` / ``_antigravity_installed``)."""
+    if sys.platform == "win32":
+        return ()
+    home = os.path.expanduser("~")
+    return (
+        os.path.join(home, ".local", "bin"),
+        "/usr/local/bin",
+        "/opt/homebrew/bin",
+    )
+
+
 def _provider_cli(provider):
-    """True if the provider's CLI binary is resolvable on PATH."""
-    return any(shutil.which(name) for name in _PROVIDER_CLIS.get(provider, ()))
+    """True if the provider's CLI binary is resolvable — on PATH, or in a
+    well-known user/local bin dir a GUI launcher's minimal PATH omits (#434)."""
+    names = _PROVIDER_CLIS.get(provider, ())
+    if any(shutil.which(name) for name in names):
+        return True
+    for directory in _gui_fallback_bin_dirs():
+        for name in names:
+            candidate = os.path.join(directory, name)
+            if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                return True
+    return False
 
 
 def _provider_auth(provider):

--- a/browser_tests/unit/test_provider_cli.py
+++ b/browser_tests/unit/test_provider_cli.py
@@ -1,0 +1,140 @@
+"""Unit tests for _provider_cli / Codex readiness under a GUI PATH (#434).
+
+Dev-only. Run from the repo root:
+
+    python -m unittest browser_tests.unit.test_provider_cli
+
+Guards #434: ComfyUI Desktop launches its Python server with a minimal GUI PATH
+(``/usr/bin:/bin:/usr/sbin:/sbin``), so ``shutil.which()`` cannot see a CLI the
+user installed under ``~/.local/bin`` (the Codex installer's target). The pre-fix
+``_provider_cli`` used ``shutil.which()`` only, so it reported Codex
+``{"cli":false,"auth":true,"ready":false}`` even though the executable existed —
+and the panel silently fell back to another backend. The fix also probes
+well-known user/local bin dirs that a restricted GUI PATH omits.
+"""
+
+import importlib.util
+import os
+import stat
+import sys
+import tempfile
+import unittest
+
+_REPO = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")
+
+
+def _load_init():
+    spec = importlib.util.spec_from_file_location(
+        "cmcp_panel_init_cli", os.path.join(_REPO, "__init__.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load_init()
+
+
+class ProviderCliGuiPath(unittest.TestCase):
+    def setUp(self):
+        # Simulate the restricted GUI PATH: nothing resolves via which().
+        self._orig_which = mod.shutil.which
+        mod.shutil.which = lambda name: None
+        # Point the GUI fallback at a throwaway bin dir (platform-independent, so
+        # the test exercises the resolution loop on Windows CI too).
+        self._bindir = tempfile.mkdtemp(prefix="cmcp-bin-")
+        self._orig_fallback = mod._gui_fallback_bin_dirs
+        mod._gui_fallback_bin_dirs = lambda: (self._bindir,)
+
+    def tearDown(self):
+        mod.shutil.which = self._orig_which
+        mod._gui_fallback_bin_dirs = self._orig_fallback
+
+    def _install(self, name):
+        path = os.path.join(self._bindir, name)
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write("#!/bin/sh\n")
+        # Make it executable so os.access(..., X_OK) is honest on POSIX (Windows
+        # treats any existing file as executable).
+        os.chmod(path, os.stat(path).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        return path
+
+    def test_absent_everywhere_is_false(self):
+        # which() -> None and nothing in the fallback dir: honestly not present.
+        self.assertFalse(mod._provider_cli("codex"))
+
+    def test_resolved_in_fallback_dir(self):
+        # The #434 repro: which() misses it, but ~/.local/bin/codex exists.
+        self._install("codex")
+        self.assertTrue(mod._provider_cli("codex"))
+
+    def test_non_executable_is_not_resolved(self):
+        # A present-but-not-executable file must not read as an installed CLI on
+        # POSIX (Windows X_OK is loose, so skip the negative there).
+        if sys.platform == "win32":
+            self.skipTest("Windows os.access X_OK does not honor the exec bit")
+        path = os.path.join(self._bindir, "codex")
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write("#!/bin/sh\n")
+        os.chmod(path, stat.S_IRUSR)  # readable, not executable
+        self.assertFalse(mod._provider_cli("codex"))
+
+    def test_which_still_wins_when_on_path(self):
+        # If which() DOES resolve it, no fallback probe is needed.
+        mod.shutil.which = lambda name: "/somewhere/on/path/" + name
+        self.assertTrue(mod._provider_cli("codex"))
+
+    def test_provider_state_ready_when_cli_in_fallback_and_auth_present(self):
+        # End-to-end: cli found via fallback + ~/.codex/auth.json present => ready.
+        self._install("codex")
+        home = tempfile.mkdtemp(prefix="cmcp-home-")
+        orig_expanduser = os.path.expanduser
+        os.path.expanduser = lambda p: home if p == "~" else orig_expanduser(p)
+        try:
+            os.makedirs(os.path.join(home, ".codex"), exist_ok=True)
+            with open(os.path.join(home, ".codex", "auth.json"), "w", encoding="utf-8") as fh:
+                fh.write("{}")
+            state = mod._provider_state("codex")
+            self.assertEqual(state, {"cli": True, "auth": True, "ready": True})
+        finally:
+            os.path.expanduser = orig_expanduser
+
+    def test_provider_state_not_ready_pre_fix_scenario(self):
+        # No fallback resolution (empty bin dir) reproduces the pre-fix defect:
+        # cli:false, ready:false even though auth exists.
+        home = tempfile.mkdtemp(prefix="cmcp-home-")
+        orig_expanduser = os.path.expanduser
+        os.path.expanduser = lambda p: home if p == "~" else orig_expanduser(p)
+        try:
+            os.makedirs(os.path.join(home, ".codex"), exist_ok=True)
+            with open(os.path.join(home, ".codex", "auth.json"), "w", encoding="utf-8") as fh:
+                fh.write("{}")
+            state = mod._provider_state("codex")
+            self.assertEqual(state, {"cli": False, "auth": True, "ready": False})
+        finally:
+            os.path.expanduser = orig_expanduser
+
+
+class GuiFallbackBinDirs(unittest.TestCase):
+    def test_windows_has_no_fallback(self):
+        orig = mod.sys.platform
+        mod.sys.platform = "win32"
+        try:
+            self.assertEqual(mod._gui_fallback_bin_dirs(), ())
+        finally:
+            mod.sys.platform = orig
+
+    def test_non_windows_includes_user_local_bin(self):
+        orig = mod.sys.platform
+        mod.sys.platform = "darwin"
+        try:
+            dirs = mod._gui_fallback_bin_dirs()
+            self.assertIn(os.path.join(os.path.expanduser("~"), ".local", "bin"), dirs)
+            self.assertIn("/usr/local/bin", dirs)
+            self.assertIn("/opt/homebrew/bin", dirs)
+        finally:
+            mod.sys.platform = orig
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem (#434)

ComfyUI Desktop launches its Python server with a restricted GUI PATH (`/usr/bin:/bin:/usr/sbin:/sbin` on macOS), so `shutil.which()` cannot see a provider CLI the user installed under `~/.local/bin` (the Codex installer's target), Homebrew, or an npm global prefix. `_provider_cli` then reported Codex `{"cli":false,"auth":true,"ready":false}` even though `~/.local/bin/codex` existed — and after a frontend reload the panel silently fell back to Ollama (the reported `ollama ... model not found` was secondary; the defect is the unsolicited provider switch).

## Fix

`_provider_cli` now probes well-known user/local bin dirs a GUI launcher's minimal PATH omits — `~/.local/bin`, `/usr/local/bin`, `/opt/homebrew/bin` — with an executable-bit check, **non-Windows only** (Windows resolves via PATHEXT and has no GUI-PATH gap). Mirrors the existing `_ollama_installed` / `_antigravity_installed` well-known-location handling. A present CLI resolves honestly; a genuinely-absent one still degrades to `ready:false`.

## Tests

New `browser_tests/unit/test_provider_cli.py`:
- `which()->None` + a `codex` binary in the fallback dir => `cli`/`ready` true (the #434 repro)
- non-executable file is rejected (POSIX); `which()` still wins when on PATH
- end-to-end `_provider_state("codex")` ready with `~/.codex/auth.json`; pre-fix scenario (empty fallback) stays `ready:false`
- `_gui_fallback_bin_dirs()` is empty on Windows, includes the user/local dirs elsewhere

Verification: `python -m py_compile __init__.py` clean; 18 readiness tests pass (1 POSIX-exec negative skipped on Windows); `node --check` panel JS OK; `npm run test:unit` 1037 pass. Codex adversarial self-gate (gpt-5.6-terra/high): **PASS**.

Closes artokun/comfyui-mcp-panel#434

🤖 Generated with [Claude Code](https://claude.com/claude-code)