### PR TITLE
fix(panel): guard VHS null-widget run crash (#445) + clamp CivitAI sort/period (#459)

### DIFF
--- a/browser_tests/unit/civitai-filter-normalize.test.mjs
+++ b/browser_tests/unit/civitai-filter-normalize.test.mjs
@@ -1,0 +1,86 @@
+// Unit tests for the #459 sort/period enum clamp in web/js/cmcp-civitai.js.
+//
+// CivitAI's REST list endpoints ZodError-reject any sort/period value outside
+// their enum with a hard `400 Bad Request` that dead-ended the docked browser
+// ("No data: CivitAI API 400"). The trigger class: a stale/renamed/cross-tab
+// value reaching the wrong endpoint — most notably an IMAGE sort ("Most
+// Reactions") landing on /v1/models, which only accepts MODEL sorts. The client
+// now clamps sort+period to a supported value BEFORE dispatch. These tests
+// assert the normalizers AND that fetchModels/fetchFeed actually dispatch a
+// well-formed request no matter what the caller passes.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  CivitaiClient,
+  normalizeModelSort,
+  normalizeImageSort,
+  normalizePeriod,
+  MODEL_SORTS,
+  IMAGE_SORTS,
+  PERIODS,
+} from "../../web/js/cmcp-civitai.js";
+
+test("normalizeModelSort clamps out-of-vocab / cross-tab values to the default", () => {
+  // Cross-tab: an IMAGE sort is NOT a valid model sort → 400 on /v1/models.
+  assert.equal(normalizeModelSort("Most Reactions"), "Most Downloaded");
+  assert.equal(normalizeModelSort("Most Comments"), "Most Downloaded");
+  assert.equal(normalizeModelSort("bogus"), "Most Downloaded");
+  assert.equal(normalizeModelSort(undefined), "Most Downloaded");
+  assert.equal(normalizeModelSort(null), "Most Downloaded");
+  // Valid model sorts pass through untouched.
+  for (const s of MODEL_SORTS) assert.equal(normalizeModelSort(s), s);
+});
+
+test("normalizeImageSort clamps out-of-vocab values to the default", () => {
+  assert.equal(normalizeImageSort("Most Downloaded"), "Most Reactions"); // a MODEL sort on the image path
+  assert.equal(normalizeImageSort("nope"), "Most Reactions");
+  assert.equal(normalizeImageSort(undefined), "Most Reactions");
+  for (const s of IMAGE_SORTS) assert.equal(normalizeImageSort(s), s);
+});
+
+test("normalizePeriod clamps out-of-vocab values to Week", () => {
+  assert.equal(normalizePeriod("Forever"), "Week");
+  assert.equal(normalizePeriod("alltime"), "Week"); // wrong case is not the enum value
+  assert.equal(normalizePeriod(undefined), "Week");
+  for (const p of PERIODS) assert.equal(normalizePeriod(p), p);
+});
+
+// Capture the exact URL the client would dispatch, without a real network call.
+function captureClient() {
+  const calls = [];
+  const client = new CivitaiClient({
+    fetchApi: async (_route, opts) => {
+      const { url } = JSON.parse(opts.body);
+      calls.push(url);
+      return { ok: true, status: 200, json: async () => ({ items: [], metadata: {} }) };
+    },
+    apiURL: (p) => p,
+  });
+  return { client, calls };
+}
+
+test("fetchModels never dispatches an invalid model sort/period (the #459 400)", async () => {
+  const { client, calls } = captureClient();
+  // The exact failing shape: an image sort + a period, on the LoRA (model) tab.
+  await client.fetchModels({ type: "LORA", sort: "Most Reactions", period: "Forever", levels: [1, 2, 4, 8, 16] });
+  const u = new URL(calls[0]);
+  assert.equal(u.searchParams.get("sort"), "Most Downloaded"); // clamped, not "Most Reactions"
+  assert.equal(u.searchParams.get("period"), "Week"); // clamped, not "Forever"
+});
+
+test("fetchFeed never dispatches an invalid image sort/period", async () => {
+  const { client, calls } = captureClient();
+  await client.fetchFeed({ type: "image", sort: "Most Downloaded", period: "Nope" });
+  const u = new URL(calls[0]);
+  assert.equal(u.searchParams.get("sort"), "Most Reactions"); // clamped from the model sort
+  assert.equal(u.searchParams.get("period"), "Week");
+});
+
+test("valid filters are dispatched unchanged", async () => {
+  const { client, calls } = captureClient();
+  await client.fetchModels({ type: "LORA", sort: "Most Liked", period: "AllTime", levels: [1] });
+  const u = new URL(calls[0]);
+  assert.equal(u.searchParams.get("sort"), "Most Liked");
+  assert.equal(u.searchParams.get("period"), "AllTime");
+});

--- a/browser_tests/unit/widget-null-safety.test.mjs
+++ b/browser_tests/unit/widget-null-safety.test.mjs
@@ -1,0 +1,236 @@
+// Unit tests for web/js/lib/widget-null-safety.js — run with `node --test`.
+//
+// Guards the #445 crash: a workflow with null VHS_VideoCombine widget values
+// (frame_rate:null, filename_prefix:null, pingpong:null, save_output:null) threw
+// `Cannot read properties of null (reading 'replace')` inside app.queuePrompt's
+// graph serialization, killing panel_run BEFORE it queued — even under
+// "run to node" targeting an unrelated valid output. sanitizeNullWidgetValues
+// null-safes the live graph before queueing so serialization can't crash.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  safeWidgetDefault,
+  sanitizeNullWidgetValues,
+  restoreWidgetValues,
+  installGraphToPromptNullSafety,
+} from "../../web/js/lib/widget-null-safety.js";
+
+test("safeWidgetDefault prefers the widget's declared default", () => {
+  assert.equal(safeWidgetDefault({ type: "text", options: { default: "AnimateDiff" } }), "AnimateDiff");
+  assert.equal(safeWidgetDefault({ type: "number", options: { default: 16 } }), 16);
+  assert.equal(safeWidgetDefault({ type: "toggle", options: { default: true } }), true);
+  // A false / 0 default must be honoured (not treated as "missing").
+  assert.equal(safeWidgetDefault({ type: "toggle", options: { default: false } }), false);
+  assert.equal(safeWidgetDefault({ type: "number", options: { default: 0 } }), 0);
+});
+
+test("safeWidgetDefault falls back by widget type when no default is declared", () => {
+  assert.equal(safeWidgetDefault({ type: "toggle" }), false);
+  assert.equal(safeWidgetDefault({ type: "boolean" }), false);
+  assert.equal(safeWidgetDefault({ type: "number" }), 0);
+  assert.equal(safeWidgetDefault({ type: "number", options: { min: 8 } }), 8);
+  assert.equal(safeWidgetDefault({ type: "slider", options: { min: -5 } }), -5);
+  assert.equal(safeWidgetDefault({ type: "combo", options: { values: ["H.264", "H.265"] } }), "H.264");
+  // A dynamic (function) combo provider is NOT invoked (side-effect/context risk).
+  let invoked = false;
+  assert.equal(
+    safeWidgetDefault({ type: "combo", options: { values: () => { invoked = true; return ["a", "b"]; } } }),
+    "",
+  );
+  assert.equal(invoked, false);
+  // text / unknown / missing type → empty string keeps string ops safe.
+  assert.equal(safeWidgetDefault({ type: "text" }), "");
+  assert.equal(safeWidgetDefault({ type: "customtext" }), "");
+  assert.equal(safeWidgetDefault({}), "");
+  assert.equal(safeWidgetDefault(null), "");
+});
+
+// Mirror the reporter's graph: a valid target VHS node plus an UNUSED VHS node
+// whose widgets serialized as null.
+function vhsNode(id, values) {
+  return {
+    id,
+    type: "VHS_VideoCombine",
+    widgets: [
+      { name: "frame_rate", type: "number", options: { default: 8 }, value: values.frame_rate },
+      { name: "filename_prefix", type: "text", options: { default: "AnimateDiff" }, value: values.filename_prefix },
+      { name: "pingpong", type: "toggle", options: { default: false }, value: values.pingpong },
+      { name: "save_output", type: "toggle", options: { default: true }, value: values.save_output },
+    ],
+  };
+}
+
+test("sanitizeNullWidgetValues coerces every null/undefined widget and reports them", () => {
+  const nulled = vhsNode(2, { frame_rate: null, filename_prefix: null, pingpong: null, save_output: undefined });
+  const good = vhsNode(1, { frame_rate: 16, filename_prefix: "hero", pingpong: false, save_output: true });
+  const graph = { _nodes: [good, nulled] };
+
+  const fixed = sanitizeNullWidgetValues(graph);
+
+  // Four repairs, all on the nulled node.
+  assert.equal(fixed.length, 4);
+  assert.ok(fixed.every((f) => f.nodeId === 2 && f.nodeType === "VHS_VideoCombine"));
+
+  // Null values became their declared defaults; the good node is untouched.
+  const byName = Object.fromEntries(nulled.widgets.map((w) => [w.name, w.value]));
+  assert.equal(byName.frame_rate, 8);
+  assert.equal(byName.filename_prefix, "AnimateDiff");
+  assert.equal(byName.pingpong, false);
+  assert.equal(byName.save_output, true);
+  assert.equal(good.widgets.find((w) => w.name === "frame_rate").value, 16);
+
+  // The actual crash: `.replace` on the former-null string widget must not throw.
+  assert.doesNotThrow(() => byName.filename_prefix.replace(/x/g, "y"));
+});
+
+test("sanitizeNullWidgetValues descends into nested subgraphs", () => {
+  const inner = vhsNode(99, { frame_rate: null, filename_prefix: null, pingpong: null, save_output: null });
+  const host = { id: 10, type: "Subgraph", widgets: [], subgraph: { _nodes: [inner] } };
+  const graph = { _nodes: [host] };
+
+  const fixed = sanitizeNullWidgetValues(graph);
+
+  assert.equal(fixed.length, 4);
+  assert.ok(inner.widgets.every((w) => w.value !== null && w.value !== undefined));
+});
+
+test("sanitizeNullWidgetValues is a no-op on a clean graph and tolerates junk", () => {
+  const clean = vhsNode(1, { frame_rate: 8, filename_prefix: "x", pingpong: false, save_output: true });
+  assert.deepEqual(sanitizeNullWidgetValues({ _nodes: [clean] }), []);
+  assert.deepEqual(sanitizeNullWidgetValues(null), []);
+  assert.deepEqual(sanitizeNullWidgetValues({}), []);
+  assert.deepEqual(sanitizeNullWidgetValues({ _nodes: [null, { widgets: null }, {}] }), []);
+});
+
+test("sanitizeNullWidgetValues leaves button widgets (no serializable value) alone", () => {
+  const node = { id: 5, type: "SomeNode", widgets: [{ name: "run", type: "button", value: undefined }] };
+  const fixed = sanitizeNullWidgetValues({ _nodes: [node] });
+  assert.equal(fixed.length, 0);
+  assert.equal(node.widgets[0].value, undefined);
+});
+
+test("restoreWidgetValues puts the exact prior values back (null and undefined preserved)", () => {
+  const node = vhsNode(2, { frame_rate: null, filename_prefix: null, pingpong: null, save_output: undefined });
+  const fixed = sanitizeNullWidgetValues({ _nodes: [node] });
+  // Coerced during the window…
+  assert.equal(node.widgets.find((w) => w.name === "filename_prefix").value, "AnimateDiff");
+  restoreWidgetValues(fixed);
+  // …then restored to the ORIGINAL semantic values, distinguishing null vs undefined.
+  const byName = Object.fromEntries(node.widgets.map((w) => [w.name, w.value]));
+  assert.equal(byName.frame_rate, null);
+  assert.equal(byName.filename_prefix, null);
+  assert.equal(byName.pingpong, null);
+  assert.equal(byName.save_output, undefined);
+});
+
+test("overlapping passes are reference-counted — a value is not restored while another pass is live", () => {
+  const node = vhsNode(2, { frame_rate: null, filename_prefix: null, pingpong: null, save_output: null });
+  const graph = { _nodes: [node] };
+  const fp = () => node.widgets.find((w) => w.name === "filename_prefix").value;
+
+  const a = sanitizeNullWidgetValues(graph); // pass A coerces, count → 1
+  const b = sanitizeNullWidgetValues(graph); // pass B joins, count → 2 (already coerced)
+  assert.equal(a.length, 4);
+  assert.equal(b.length, 4);
+  assert.equal(fp(), "AnimateDiff");
+
+  restoreWidgetValues(a); // count → 1: still coerced (B's serialization is protected)
+  assert.equal(fp(), "AnimateDiff");
+
+  restoreWidgetValues(b); // count → 0: now restored
+  assert.equal(fp(), null);
+});
+
+test("a join RE-ASSERTS coercion if the value drifted back to null between passes", () => {
+  const node = vhsNode(2, { frame_rate: null, filename_prefix: null, pingpong: null, save_output: null });
+  const graph = { _nodes: [node] };
+  const w = node.widgets.find((x) => x.name === "filename_prefix");
+
+  const a = sanitizeNullWidgetValues(graph); // A: null → "AnimateDiff", count 1
+  w.value = null; // a concurrent write drifts it back to null before B starts
+  const b = sanitizeNullWidgetValues(graph); // B joins → must re-coerce so B can't serialize null
+  assert.equal(w.value, "AnimateDiff");
+
+  restoreWidgetValues(a);
+  restoreWidgetValues(b); // count 0 → restored to original null
+  assert.equal(w.value, null);
+});
+
+test("restore never clobbers an edit made during the serialization window", () => {
+  const node = vhsNode(2, { frame_rate: null, filename_prefix: null, pingpong: null, save_output: null });
+  const graph = { _nodes: [node] };
+  const w = node.widgets.find((x) => x.name === "filename_prefix");
+
+  const touched = sanitizeNullWidgetValues(graph); // null → "AnimateDiff"
+  w.value = "user_edit"; // a concurrent edit during the awaited serialize
+  restoreWidgetValues(touched); // value !== our coerced value → leave the edit alone
+
+  assert.equal(w.value, "user_edit");
+});
+
+// A minimal fake `app` whose graphToPrompt mirrors ComfyUI's real one: it reads
+// each widget's value via a VHS-like `serializeValue` that calls `.replace` — the
+// exact operation that throws on null (executionUtil graphToPrompt line ~103).
+function fakeApp(node) {
+  const rootGraph = { _nodes: [node] };
+  return {
+    rootGraph,
+    seenNull: false,
+    async graphToPrompt(graph = this.rootGraph) {
+      const out = {};
+      for (const n of graph._nodes) {
+        for (const w of n.widgets ?? []) {
+          if (w.value === null || w.value === undefined) this.seenNull = true;
+          // VHS_VideoCombine's serializeValue calls `.replace` DIRECTLY on the
+          // filename_prefix value — throwing on null (the exact #445 crash).
+          out[w.name] = w.name === "filename_prefix" ? w.value.replace(/\s+/g, "_") : w.value;
+        }
+      }
+      return { output: out };
+    },
+  };
+}
+
+test("installGraphToPromptNullSafety makes graphToPrompt null-safe, then restores", async () => {
+  const node = vhsNode(2, { frame_rate: null, filename_prefix: null, pingpong: null, save_output: null });
+  const app = fakeApp(node);
+
+  // Before the wrap, serializing the null graph throws exactly the #445 error.
+  await assert.rejects(() => app.graphToPrompt(), /Cannot read properties of null|reading 'replace'/);
+
+  assert.equal(installGraphToPromptNullSafety(app), true);
+  app.seenNull = false; // reset after the pre-wrap throwing call
+
+  // After the wrap: no throw, and the serialized prompt has coerced values.
+  const prompt = await app.graphToPrompt();
+  assert.equal(app.seenNull, false); // serialization never saw a null
+  assert.equal(prompt.output.filename_prefix, "AnimateDiff");
+
+  // The LIVE graph is byte-identical afterwards — the null "unset" is preserved.
+  assert.ok(node.widgets.every((w) => w.value === null));
+});
+
+test("installGraphToPromptNullSafety restores even when the original serializer throws", async () => {
+  const node = vhsNode(2, { frame_rate: null, filename_prefix: null, pingpong: null, save_output: null });
+  const app = {
+    rootGraph: { _nodes: [node] },
+    async graphToPrompt() { throw new Error("serialize boom"); },
+  };
+  installGraphToPromptNullSafety(app);
+  await assert.rejects(() => app.graphToPrompt(), /serialize boom/);
+  assert.ok(node.widgets.every((w) => w.value === null)); // rolled back despite throw
+});
+
+test("installGraphToPromptNullSafety is idempotent and reversible-free", () => {
+  const app = fakeApp(vhsNode(1, { frame_rate: 8, filename_prefix: "x", pingpong: false, save_output: true }));
+  const first = app.graphToPrompt;
+  installGraphToPromptNullSafety(app);
+  const wrapped = app.graphToPrompt;
+  assert.notEqual(wrapped, first); // wrapped once
+  installGraphToPromptNullSafety(app);
+  assert.equal(app.graphToPrompt, wrapped); // not double-wrapped
+  // Nothing to wrap → false.
+  assert.equal(installGraphToPromptNullSafety({}), false);
+  assert.equal(installGraphToPromptNullSafety(null), false);
+});

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -42,6 +42,22 @@ export function levelLabel(n) {
 export const PERIODS = ["Day", "Week", "Month", "Year", "AllTime"];
 export const IMAGE_SORTS = ["Most Reactions", "Most Comments", "Most Collected", "Newest", "Oldest"];
 export const MODEL_SORTS = ["Most Downloaded", "Highest Rated", "Most Liked", "Newest", "Oldest"];
+
+// #459: CivitAI's REST list endpoints (/v1/models, /v1/images) ZodError-reject
+// ANY `sort`/`period` value outside their enum with a hard `400 Bad Request`
+// that dead-ends the docked browser with "No data". A stale, renamed, or
+// CROSS-TAB value — most notably an IMAGE sort such as "Most Reactions" reaching
+// the /v1/models endpoint (which only accepts MODEL sorts) — must be clamped to
+// a supported value BEFORE dispatch instead of surfacing as an opaque 400. These
+// clamp against the panel's own offered sets (the only values its UI produces),
+// falling back to the default at index 0, so the request is always well-formed.
+// NOTE: an agent-supplied sort that is API-valid but NOT in the panel's offered
+// subset (e.g. "Most Collected" for models) is normalized to the default too —
+// a deliberate tradeoff: the docked browser only ever dispatches sorts it also
+// exposes in its dropdown, so the dispatched request and the visible UI agree.
+export const normalizeModelSort = (s) => (MODEL_SORTS.includes(s) ? s : MODEL_SORTS[0]);
+export const normalizeImageSort = (s) => (IMAGE_SORTS.includes(s) ? s : IMAGE_SORTS[0]);
+export const normalizePeriod = (p) => (PERIODS.includes(p) ? p : "Week");
 /**
  * Civitai's full `BaseModel` enum. The site accepts ONLY these strings for
  * `baseModels=` — anything else silently returns nothing, so this list is the
@@ -459,7 +475,7 @@ export class CivitaiClient {
   async fetchFeed({ type = "image", period = "Week", sort = "Most Reactions", levels = [1], limit = 100, cursor, username } = {}) {
     const q = new URLSearchParams({
       limit: String(limit), browsingLevel: String(bitmask(levels)),
-      period, type, sort,
+      period: normalizePeriod(period), type, sort: normalizeImageSort(sort), // #459: clamp to enum
     });
     if (username) q.set("username", username); // narrow to one creator's posts
     if (cursor) q.set("cursor", cursor);
@@ -473,7 +489,7 @@ export class CivitaiClient {
   async fetchModelImages(modelVersionId, { levels = [1], sort = "Most Reactions", limit = 30 } = {}) {
     const q = new URLSearchParams({
       limit: String(limit), modelVersionId: String(modelVersionId),
-      browsingLevel: String(bitmask(levels)), sort,
+      browsingLevel: String(bitmask(levels)), sort: normalizeImageSort(sort), // #459: clamp to enum
       nsfw: bitmask(levels) > 2 ? "X" : "None",
     });
     const data = await this._get(`${API}/v1/images?${q.toString()}`);
@@ -586,7 +602,8 @@ export class CivitaiClient {
 
   async fetchModels({ type, sort = "Most Downloaded", period = "Week", baseModels = [], levels = [1], limit = 100, cursor, query, username } = {}) {
     const base = new URLSearchParams({
-      limit: String(limit), types: type, sort, period,
+      limit: String(limit), types: type,
+      sort: normalizeModelSort(sort), period: normalizePeriod(period), // #459: clamp to enum
       nsfw: bitmask(levels) > 2 ? "true" : "false",
     });
     for (const b of baseModels) base.append("baseModels", b);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -140,6 +140,7 @@ import { autoMatchSlots, slotDiagnostic } from "./lib/connect-match.js";
 import { isLinkPersisted, removePhantomLink, isWidgetBackedInput } from "./lib/connect-verify.js";
 import { coerceMessageText, isDroppedAgentReplay, serializeContext } from "./lib/chat-serialize.js";
 import { isImeComposing } from "./lib/ime.js";
+import { installGraphToPromptNullSafety } from "./lib/widget-null-safety.js";
 import {
   recordCopiedNodes,
   getVerifiedSnapshot,
@@ -6209,6 +6210,18 @@ const GRAPH_TOOL_EXECUTORS = {
         return res;
       };
     }
+    // #445: guard the VHS null-widget serialization crash. ComfyUI core / node
+    // extensions (notably VHS_VideoCombine) serialize EVERY node's widgets when
+    // building the prompt — even unused branches, even under "run to node" — and
+    // call string ops like `.replace()` on those values (in graphToPrompt via the
+    // node's own serializeValue). A null widget value (e.g. VHS
+    // `filename_prefix:null`) throws `Cannot read properties of null (reading
+    // 'replace')` DURING serialization, killing the run before it queues. Install
+    // an idempotent, self-restoring wrap on app.graphToPrompt so every prompt
+    // build is null-safe for exactly its serialization window (which also covers
+    // the deferred serialization queuePrompt runs when its processor is already
+    // busy) without permanently altering the live workflow.
+    installGraphToPromptNullSafety(app);
     try {
       await app.queuePrompt(0, batch, partialTargets);
     } finally {

--- a/web/js/lib/widget-null-safety.js
+++ b/web/js/lib/widget-null-safety.js
@@ -1,0 +1,177 @@
+// Null-widget serialization guard for graph_run (#445).
+//
+// A workflow can carry nodes whose serialized widget values are `null` — most
+// commonly VHS_VideoCombine (VideoHelperSuite) nodes left in the graph with
+// `frame_rate:null`, `filename_prefix:null`, `pingpong:null`, `save_output:null`.
+// When such a graph is queued, ComfyUI's `graphToPrompt` serializes EVERY node's
+// widgets (even unused branches, even under "run to node") — for VHS it calls the
+// node's own `serializeValue`, which does string ops like `.replace()` on the
+// value and throws `Cannot read properties of null (reading 'replace')` DURING
+// serialization, killing the run before it queues.
+//
+// The panel installs no serialize hook, so the fix is a SERIALIZER-LEVEL
+// temporary normalization: we wrap `app.graphToPrompt` (the exact function inside
+// which every prompt build — and the crash — happens). Around each serialize it
+// coerces null/undefined widget values to a safe default, delegates to the
+// original, then RESTORES the prior values.
+//
+// Design constraints learned in review:
+//   • Wrap the SERIALIZER, not `app.queuePrompt`: queuePrompt PUSHES the request
+//     and returns early (`return false`) when its processor is already busy — the
+//     real `graphToPrompt` for that item runs LATER inside the active loop, so a
+//     coerce/restore scoped to our own queuePrompt call would restore the nulls
+//     before that deferred serialization ran.
+//   • RE-ENTRANCY: graphToPrompt is async and can overlap (e.g. a "Save (API
+//     format)" export while a queue serialize is in flight). A refless restore
+//     could revert nulls while another serialize is mid-flight → the crash
+//     returns. So a per-widget REFERENCE COUNT keeps the coercion alive until the
+//     LAST overlapping serialization finishes.
+//   • NEVER PERMANENTLY MUTATE / never clobber a concurrent edit: `null` may be a
+//     meaningful "unset/auto" on an executed or third-party widget. We restore
+//     only when the value is still exactly the one we set — an edit made during
+//     the serialization window is left untouched — and always via `finally`, so
+//     the live workflow is left as the user had it.
+
+/**
+ * A safe, non-null default for a widget whose value is null/undefined. Prefers
+ * the widget's own declared default (from the node def), then falls back by
+ * widget type so downstream string ops (`.replace`, `.trim`, …) can't throw.
+ * Never INVOKES a dynamic combo `values()` provider — those can be context-
+ * dependent or side-effecting (the panel avoids calling them mid-queue); an
+ * empty string is a safe, string-op-friendly fallback for that case.
+ */
+export function safeWidgetDefault(widget) {
+  const def = widget?.options?.default;
+  if (def !== null && def !== undefined) return def;
+  const type = typeof widget?.type === "string" ? widget.type.toLowerCase() : "";
+  if (type === "toggle" || type === "boolean") return false;
+  if (type === "number" || type === "slider" || type === "int" || type === "float") {
+    const min = widget?.options?.min;
+    return typeof min === "number" ? min : 0;
+  }
+  if (type === "combo") {
+    const vals = widget?.options?.values;
+    if (Array.isArray(vals) && vals.length) return vals[0];
+    // A function provider is NOT invoked (side-effect/context risk) — "" is safe.
+    return "";
+  }
+  // text / customtext / string / unknown → empty string keeps string ops safe.
+  return "";
+}
+
+// Per-widget coercion registry: widget object → { original, coerced, count }.
+// A WeakMap so a discarded widget can be GC'd. The count makes overlapping
+// serializations of the same widget safe (restore only when the last one exits).
+const REG = new WeakMap();
+
+/**
+ * Walk `rootGraph` and every nested subgraph, coercing any null/undefined widget
+ * value to `safeWidgetDefault(widget)` IN PLACE (reference-counted). Returns the
+ * list of records touched by THIS pass — `{ ref, original, coerced, nodeId,
+ * nodeType, widget }[]` — to be handed to restoreWidgetValues(). A widget already
+ * coerced by an overlapping pass is joined (its refcount incremented) rather than
+ * re-read, so an in-flight serialization never sees it revert. `button`-type
+ * widgets (no serializable value) are skipped. Idempotent per pass.
+ */
+export function sanitizeNullWidgetValues(rootGraph) {
+  const touched = [];
+  if (!rootGraph) return touched;
+  const stack = [...(rootGraph._nodes ?? rootGraph.nodes ?? [])];
+  const seen = new Set();
+  while (stack.length) {
+    const node = stack.pop();
+    if (!node || seen.has(node)) continue;
+    seen.add(node);
+    const widgets = Array.isArray(node.widgets) ? node.widgets : [];
+    for (const w of widgets) {
+      if (!w) continue;
+      const type = typeof w.type === "string" ? w.type.toLowerCase() : "";
+      if (type === "button") continue; // no serializable value to repair
+      const active = REG.get(w);
+      const record = (entry) => ({
+        ref: w,
+        original: entry.original,
+        coerced: entry.coerced,
+        nodeId: node.id ?? null,
+        nodeType: typeof node.type === "string" ? node.type : null,
+        widget: typeof w.name === "string" ? w.name : null,
+      });
+      if (active) {
+        // Already coerced by an overlapping pass — join its refcount so it can't
+        // be restored out from under the in-flight serialization. Re-assert the
+        // coercion if the value has since drifted BACK to null (a concurrent
+        // write between the first coercion and this pass), so this pass's
+        // serialization can never see null either.
+        active.count++;
+        if (w.value === null || w.value === undefined) w.value = active.coerced;
+        touched.push(record(active));
+      } else if (w.value === null || w.value === undefined) {
+        const entry = { original: w.value, coerced: safeWidgetDefault(w), count: 1 };
+        w.value = entry.coerced;
+        REG.set(w, entry);
+        touched.push(record(entry));
+      }
+    }
+    const sub = node.subgraph?._nodes ?? node.subgraph?.nodes;
+    if (Array.isArray(sub) && sub.length) stack.push(...sub);
+  }
+  return touched;
+}
+
+/**
+ * Undo a sanitizeNullWidgetValues() pass. Decrements each widget's refcount and,
+ * once it reaches zero (the last overlapping pass), restores the ORIGINAL value —
+ * but ONLY if the widget still holds exactly the value we coerced it to, so an
+ * edit made during the serialization window is never clobbered.
+ */
+export function restoreWidgetValues(touched) {
+  if (!Array.isArray(touched)) return;
+  for (const r of touched) {
+    const w = r?.ref;
+    if (!w) continue;
+    const entry = REG.get(w);
+    if (!entry) continue;
+    if (--entry.count <= 0) {
+      if (w.value === entry.coerced) w.value = entry.original; // don't clobber edits
+      REG.delete(w);
+    }
+  }
+}
+
+// Marker so the wrap is installed at most once per app instance.
+const INSTALLED = Symbol.for("comfyui-mcp.graphToPromptNullSafety");
+
+/**
+ * Idempotently wrap `app.graphToPrompt` so EVERY prompt build is null-safe:
+ * before delegating to the original, coerce null/undefined widget values on the
+ * graph being serialized; after it settles (resolve OR throw), restore the prior
+ * values. Because the wrap is on the serializer itself, it protects the deferred
+ * serialization that runs inside an already-active queue loop, and — via the
+ * reference-counted registry — overlapping serializations of the same graph.
+ * Returns true if the wrap is (now or already) installed, false if `app` has no
+ * graphToPrompt to wrap.
+ */
+export function installGraphToPromptNullSafety(app) {
+  if (!app || typeof app.graphToPrompt !== "function") return false;
+  if (app[INSTALLED]) return true;
+  const orig = app.graphToPrompt.bind(app);
+  app.graphToPrompt = async function nullSafeGraphToPrompt(graph, ...rest) {
+    // graphToPrompt defaults its graph arg to the app's root graph; mirror that
+    // so we sanitize exactly what the original is about to serialize.
+    const target = graph ?? app.rootGraph ?? app.graph ?? null;
+    const touched = sanitizeNullWidgetValues(target);
+    if (touched.length) {
+      console.warn(
+        `[comfyui-mcp] null-safed ${touched.length} widget value(s) for prompt ` +
+          `serialization, then restored them (VHS null-widget crash guard, #445)`,
+      );
+    }
+    try {
+      return await orig(graph, ...rest);
+    } finally {
+      restoreWidgetValues(touched);
+    }
+  };
+  app[INSTALLED] = true;
+  return true;
+}


### PR DESCRIPTION
Two independent panel bugs, fixed and tested independently.

## #445 — `panel_run` crashes on null VHS widget values (`Cannot read properties of null (reading 'replace')`)

**Root cause.** When a graph carries `VHS_VideoCombine` nodes whose serialized widgets are null (`frame_rate:null`, `filename_prefix:null`, `pingpong:null`, `save_output:null`), queuing throws *before* the prompt is ever posted. The `.replace` is inside ComfyUI's `graphToPrompt` (`executionUtil.ts`): for a widget with a custom `serializeValue` (VHS defines one for `filename_prefix`) it does `await widget.serializeValue(...)`, and VHS's implementation calls `.replace` directly on the value → dies on `null`. This happens for **every** node's widgets — even unused branches and even under "run to node". The panel registers no serialize/`beforeQueued` hook, so it can't intercept that call.

**Fix.** Guard at the serializer itself. `installGraphToPromptNullSafety(app)` (new `web/js/lib/widget-null-safety.js`) idempotently wraps `app.graphToPrompt` so every prompt build is null-safe for exactly its serialization window, then restores the prior values — the live workflow is left byte-identical (a `null` can be a meaningful "unset" on an executed/third-party widget, so it is never permanently rewritten).

Why the serializer and not `app.queuePrompt`: `queuePrompt` pushes the request and returns early (`return false`) when its processor is already busy — that item's real `graphToPrompt` runs later inside the active loop, so a coerce/restore scoped to our own `queuePrompt` call would restore the nulls too early. Wrapping `graphToPrompt` covers whichever loop drives it.

The coerce/restore is **reference-counted** (per-widget `WeakMap`) so overlapping serializations (e.g. a Save-API-format export concurrent with a queue serialize) stay null-safe until the last one exits; a value that drifts back to `null` between overlapping passes is re-coerced; and restore only reverts a widget still holding exactly the coerced value, so a concurrent edit is never clobbered. `graph_run` calls the installer before queuing.

## #459 — CivitAI browser shows `API 400: Bad Request` after reopening

**Root cause.** CivitAI's REST list endpoints (`/v1/models`, `/v1/images`) `ZodError`-reject any `sort`/`period` value outside their enum with a hard `400` that dead-ends the docked browser ("No data"). Empirically verified against the live API: an **image** sort like `Most Reactions` on `/v1/models` (which only accepts *model* sorts), or a stale/renamed/typo'd value, 400s. The panel already had `MODEL_SORTS`/`IMAGE_SORTS`/`PERIODS` but used them only to render dropdown chips — never to validate the value actually dispatched.

**Fix.** Clamp `sort` + `period` to the panel's offered enums at the client dispatch boundary — `fetchModels`, `fetchFeed`, `fetchModelImages` (`web/js/cmcp-civitai.js`) — so no out-of-vocab value can reach the API. (An agent-supplied, API-valid-but-not-offered sort is normalized to the default too — a deliberate tradeoff so the dispatched request always matches what the dropdown exposes.)

## Tests / verification
- New: `browser_tests/unit/widget-null-safety.test.mjs` (safe defaults, subgraph walk, refcounted overlap, re-coerce-on-drift, no-clobber-on-edit, serializer wrap), `browser_tests/unit/civitai-filter-normalize.test.mjs` (enum clamps + captured-URL dispatch tests).
- `node --check` clean, `npm run test:unit` green (1022), `npm run typecheck` clean.
- Adversarial review via codex (`gpt-5.6-terra`, high) — PASS after iterating through the queue-timing and re-entrancy edge cases.

Closes #445
Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)