### PR TITLE
release: 0.11.27 — VHS crash + CivitAI enum (#445/#459), get_errors re-evaluation (#407/#410/#415/#418), Codex readiness under Desktop PATH (#434)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.27] - 2026-08-01
+
+### Fixed
+- **`panel_run` no longer crashes on a VHS node with a null widget value, and the CivitAI browser stops 400ing on reopen (#445, #459).** VHS_VideoCombine's `serializeValue` calls `.replace` directly on a null `filename_prefix` inside ComfyUI's `graphToPrompt`; a serializer-level null-safe wrap on `app.graphToPrompt` coerces null/undefined widget values to a safe default for the serialization window only (live workflow left byte-identical, reference-counted for overlapping serializations). And CivitAI's REST list endpoints reject an out-of-enum `sort`/`period`; those are now clamped to the offered enums at the client dispatch boundary.
+- **`panel_get_errors` re-evaluates missing-asset + red-node state so a stale "missing"/red never persists (#407, #410, #415, #418).** A valid subfolder-registered model is no longer flagged missing (authoritative `/object_info` pull on a flagged candidate), the `missingMedia` store + red flags are recomputed against a freshly-refreshed graph at query time (a fixed/renamed/exposed asset clears), and `set_widget` clears LiteGraph's `has_errors` after a successful write when nothing still blames the node.
+- **Codex readiness resolves the CLI under ComfyUI Desktop's minimal GUI PATH (#434).** Desktop launches with `/usr/bin:/bin:…` only, so `shutil.which` missed a Codex CLI in `~/.local/bin` / `/usr/local/bin` / `/opt/homebrew/bin` and reported it absent (silent Ollama fallback); readiness now probes those well-known bin dirs (exec-bit checked, non-Windows).
+
 ## [0.11.26] - 2026-08-01
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.26"
+version = "0.11.27"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -380,7 +380,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.26";
+const PANEL_VERSION = "0.11.27";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Three codex-gated clusters since 0.11.26. Registry publish fires on the pyproject change. Companion to mcp 0.48.27 (published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)