### PR TITLE
fix(panel): recover run-completion missed on unobserved reconnect (#356) + refuse false-clean empty-graph reads (#389)

### DIFF
--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for panel#389 — detect a graph READ that is out of sync with the
+ * active workflow (empty live root graph while the workflow reports nodes).
+ *
+ * The read tools count nodes off LiteGraph's live `app.graph._nodes`, while
+ * "active / modified / missing-model" come from separate Vue/Pinia stores. When a
+ * load / tab-switch / post-reconnect rebuild leaves the read bound to an empty
+ * graph object, `node_count: 0` is returned while the workflow is still active with
+ * red nodes — a silent false-clean. These lock the pure detection the panel's
+ * read-tool guard throws on, and prove it NEVER fires for a genuinely-empty graph.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { activeWorkflowNodeCount, graphReadDesynced } from "../../web/js/lib/graph-binding.js";
+
+// A ComfyUI ChangeTracker-shaped workflow: serialized graph states hang off
+// `changeTracker.activeState` / `.initialState` (and some builds hang them flat).
+const wf = (over = {}) => ({ changeTracker: {}, ...over });
+const state = (n) => ({ nodes: Array.from({ length: n }, (_, i) => ({ id: i + 1 })) });
+
+// ── activeWorkflowNodeCount: fail-open ground truth ──────────────────────────
+
+test("activeWorkflowNodeCount: reads activeState node count", () => {
+  assert.equal(activeWorkflowNodeCount(wf({ changeTracker: { activeState: state(3) } })), 3);
+});
+
+test("activeWorkflowNodeCount: falls back to initialState when activeState is absent", () => {
+  assert.equal(activeWorkflowNodeCount(wf({ changeTracker: { initialState: state(5) } })), 5);
+});
+
+test("activeWorkflowNodeCount: PREFERS activeState (unsaved-but-populated: empty initial, populated active)", () => {
+  assert.equal(
+    activeWorkflowNodeCount(wf({ changeTracker: { initialState: state(0), activeState: state(2) } })),
+    2,
+  );
+});
+
+test("activeWorkflowNodeCount: honors a well-formed activeState of ZERO — NOT the max (the graph_clear case, codex P1)", () => {
+  // After a legitimate graph_clear, activeState→0 while the load baseline initialState
+  // still holds nodes. A MAX would falsely report an expectation and throw a desync.
+  assert.equal(
+    activeWorkflowNodeCount(wf({ changeTracker: { activeState: state(0), initialState: state(7) } })),
+    0,
+  );
+});
+
+test("activeWorkflowNodeCount: falls back to initialState ONLY when activeState is malformed (not merely zero)", () => {
+  assert.equal(
+    activeWorkflowNodeCount(wf({ changeTracker: { activeState: { nodes: "bad" }, initialState: state(4) } })),
+    4,
+  );
+});
+
+test("activeWorkflowNodeCount: reads flat activeState/initialState on the workflow", () => {
+  assert.equal(activeWorkflowNodeCount({ activeState: state(4) }), 4);
+  assert.equal(activeWorkflowNodeCount({ initialState: state(6) }), 6);
+});
+
+test("activeWorkflowNodeCount: fail-open to 0 on null/garbage/malformed shapes", () => {
+  assert.equal(activeWorkflowNodeCount(null), 0);
+  assert.equal(activeWorkflowNodeCount(undefined), 0);
+  assert.equal(activeWorkflowNodeCount(42), 0);
+  assert.equal(activeWorkflowNodeCount({}), 0);
+  assert.equal(activeWorkflowNodeCount({ changeTracker: { activeState: { nodes: "x" } } }), 0);
+  assert.equal(activeWorkflowNodeCount({ changeTracker: { activeState: {} } }), 0);
+});
+
+// ── graphReadDesynced: the guard predicate ───────────────────────────────────
+
+test("graphReadDesynced: TRUE — empty live root graph while the workflow reports nodes (the bug)", () => {
+  assert.equal(
+    graphReadDesynced({
+      liveNodeCount: 0,
+      activeWorkflow: wf({ changeTracker: { activeState: state(2) } }), // e.g. nodes 345/346
+    }),
+    true,
+  );
+});
+
+test("graphReadDesynced: FALSE — genuinely-empty / brand-new workflow reads node_count:0 as before", () => {
+  assert.equal(
+    graphReadDesynced({ liveNodeCount: 0, activeWorkflow: wf({ changeTracker: { activeState: state(0) } }) }),
+    false,
+  );
+  assert.equal(graphReadDesynced({ liveNodeCount: 0, activeWorkflow: null }), false);
+  assert.equal(graphReadDesynced({ liveNodeCount: 0, activeWorkflow: undefined }), false);
+});
+
+test("graphReadDesynced: FALSE — a genuinely-cleared workflow (activeState 0, initialState populated) does NOT throw", () => {
+  assert.equal(
+    graphReadDesynced({
+      liveNodeCount: 0,
+      activeWorkflow: wf({ changeTracker: { activeState: state(0), initialState: state(9) } }),
+    }),
+    false,
+  );
+});
+
+test("graphReadDesynced: FALSE — live graph already has nodes (self-evidently bound)", () => {
+  assert.equal(
+    graphReadDesynced({ liveNodeCount: 5, activeWorkflow: wf({ changeTracker: { activeState: state(5) } }) }),
+    false,
+  );
+});
+
+test("graphReadDesynced: FALSE — descended into an empty subgraph (legitimately empty at that scope)", () => {
+  assert.equal(
+    graphReadDesynced({
+      liveNodeCount: 0,
+      inSubgraph: true,
+      activeWorkflow: wf({ changeTracker: { activeState: state(10) } }),
+    }),
+    false,
+  );
+});
+
+test("graphReadDesynced: defensive — missing args never throw, default to not-desynced", () => {
+  assert.equal(graphReadDesynced(), false);
+  assert.equal(graphReadDesynced({}), false);
+});

--- a/browser_tests/unit/run-reconcile-sweep.test.mjs
+++ b/browser_tests/unit/run-reconcile-sweep.test.mjs
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for the periodic run-completion SAFETY SWEEP (panel#356 Bug 2).
+ *
+ * The panel's reconnect reconcile is edge-triggered only; if the ComfyUI WS drops
+ * and reopens during an idle gap WITHOUT a `reconnected` edge, the terminal
+ * execution_success is missed and the agent stalls. This sweep re-runs the reconcile
+ * on a timer while any run is pending. These lock: single-flight arming, re-arm only
+ * while pending, self-disarm on drain, and — critically — that a dispose() landing
+ * WHILE an async reconcile is in flight cannot resurrect the timer (the codex P1
+ * unmount-resurrection leak).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createRunReconcileSweep } from "../../web/js/lib/run-reconcile-sweep.js";
+
+// A controllable fake scheduler: timers fire only when we advance() past them.
+function harness({ hasPending, reconcile, intervalMs = 100 } = {}) {
+  let clock = 0;
+  let seq = 0;
+  const timers = new Map();
+  const errors = [];
+  const sweep = createRunReconcileSweep({
+    hasPending,
+    reconcile,
+    onSweepError: (e) => errors.push(e),
+    setTimer: (fn, ms) => {
+      const id = ++seq;
+      timers.set(id, { at: clock + ms, fn });
+      return id;
+    },
+    clearTimer: (id) => timers.delete(id),
+    intervalMs,
+  });
+  return {
+    sweep,
+    errors,
+    timerCount: () => timers.size,
+    // Fire every due timer (a fired timer may re-arm another); await async fns.
+    tick: async () => {
+      clock += intervalMs;
+      const due = [...timers].filter(([, t]) => t.at <= clock);
+      for (const [id, t] of due) {
+        timers.delete(id);
+        await t.fn();
+      }
+    },
+  };
+}
+
+test("sweep: does not arm when nothing is pending", () => {
+  const h = harness({ hasPending: () => false, reconcile: async () => {} });
+  h.sweep.arm();
+  assert.equal(h.sweep._hasTimer(), false);
+  assert.equal(h.timerCount(), 0);
+});
+
+test("sweep: single-flight — repeated arm() schedules at most one timer", () => {
+  const h = harness({ hasPending: () => true, reconcile: async () => {} });
+  h.sweep.arm();
+  h.sweep.arm();
+  h.sweep.arm();
+  assert.equal(h.timerCount(), 1, "only one timer despite three arms");
+});
+
+test("sweep: reconciles while pending, then self-disarms once the ledger drains", async () => {
+  let pending = true;
+  let reconciles = 0;
+  const h = harness({
+    hasPending: () => pending,
+    reconcile: async () => {
+      reconciles += 1;
+      if (reconciles >= 2) pending = false; // recovered on the 2nd sweep
+    },
+  });
+  h.sweep.arm();
+  await h.tick(); // sweep 1 — still pending → re-arms
+  assert.equal(h.sweep._hasTimer(), true, "re-armed while still pending");
+  await h.tick(); // sweep 2 — drains → does NOT re-arm
+  assert.equal(reconciles, 2);
+  assert.equal(h.sweep._hasTimer(), false, "disarmed once pending drained");
+  assert.equal(h.timerCount(), 0);
+});
+
+test("sweep: a reconcile that throws is caught and still re-arms while pending", async () => {
+  let calls = 0;
+  const h = harness({
+    hasPending: () => calls < 2,
+    reconcile: async () => {
+      calls += 1;
+      throw new Error("history 503");
+    },
+  });
+  h.sweep.arm();
+  await h.tick(); // throws → onSweepError → re-arm (still pending)
+  assert.equal(h.errors.length, 1);
+  assert.equal(h.sweep._hasTimer(), true, "re-armed despite the throw");
+  await h.tick(); // calls===2 → hasPending false → disarm
+  assert.equal(h.sweep._hasTimer(), false);
+});
+
+test("sweep: dispose() cancels a pending timer and blocks future arm()", () => {
+  const h = harness({ hasPending: () => true, reconcile: async () => {} });
+  h.sweep.arm();
+  assert.equal(h.timerCount(), 1);
+  h.sweep.dispose();
+  assert.equal(h.timerCount(), 0, "dispose cleared the armed timer");
+  h.sweep.arm();
+  assert.equal(h.timerCount(), 0, "arm() after dispose is a no-op");
+  assert.equal(h.sweep._isDisposed(), true);
+});
+
+test("sweep: dispose() DURING an in-flight reconcile does NOT resurrect the timer (codex P1 leak)", async () => {
+  let releaseReconcile;
+  const reconcileGate = new Promise((res) => {
+    releaseReconcile = res;
+  });
+  let reconciles = 0;
+  const h = harness({
+    hasPending: () => true, // always pending — a naive finally would re-arm forever
+    reconcile: async () => {
+      reconciles += 1;
+      await reconcileGate; // stay in-flight until we release it
+    },
+  });
+  h.sweep.arm();
+  // Fire the timer so the async reconcile starts and parks on the gate.
+  const ticking = h.tick();
+  // Unmount happens WHILE the reconcile await is in flight.
+  h.sweep.dispose();
+  // Let the reconcile finish; its finally must NOT re-arm because disposed is set.
+  releaseReconcile();
+  await ticking;
+  assert.equal(reconciles, 1, "reconcile ran exactly once");
+  assert.equal(h.sweep._hasTimer(), false, "no timer re-armed after dispose mid-await");
+  assert.equal(h.timerCount(), 0, "sweep fully stopped — no resurrection leak");
+});

--- a/browser_tests/unit/run-reconcile.test.mjs
+++ b/browser_tests/unit/run-reconcile.test.mjs
@@ -1114,3 +1114,60 @@ test("#370 still-running: reconcile leaves it pending and delivers nothing", asy
   assert.equal(flushes.length, 1);
   assert.equal(flushes[0].promptId, "pR");
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// panel#356 Bug 2 — hasPending() gate for the periodic SAFETY-SWEEP reconcile
+//
+// The reconnect reconcile is EDGE-triggered only (ComfyUI `reconnected` / bridge
+// back). If the ComfyUI WS silently drops and reopens during an idle gap between
+// agent turns WITHOUT firing `reconnected`, the terminal `execution_success` is
+// missed and NO edge fires — the run finishes but the agent is never notified.
+// The panel arms a periodic sweep that re-runs reconcile WHILE `hasPending()`, so
+// such a completion is recovered even with no reconnect edge. These lock the gate
+// the panel's self-disarming sweep loop depends on.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("panel#356: hasPending() false with no runs, true once a prompt is queued", () => {
+  const { tracker } = makeHarness();
+  assert.equal(tracker.hasPending(), false, "no runs ⇒ nothing to sweep");
+  tracker.onQueued("Q1");
+  assert.equal(tracker.hasPending(), true, "a queued prompt arms the sweep");
+});
+
+test("panel#356: a LIVE, delivered success drains the ledger so the sweep disarms", () => {
+  const { tracker, flushes } = makeHarness();
+  tracker.onQueued("L1");
+  tracker.onExecutionStart("L1");
+  tracker.onExecuted("L1", { images: [{ filename: "a.png", type: "output" }] });
+  assert.equal(tracker.hasPending(), true, "pending until the terminal signal");
+  tracker.onExecutionSuccess("L1"); // observed live ⇒ flush + markDelivered
+  assert.equal(flushes.length, 1, "delivered live");
+  assert.equal(tracker.hasPending(), false, "delivered ⇒ ledger drained ⇒ sweep self-disarms");
+});
+
+test("panel#356: a MISSED terminal success keeps hasPending() true; a sweep reconcile recovers it and drains", async () => {
+  const { tracker, flushes } = makeHarness();
+  // Idle-gap WS drop: the run queues + starts, but its execution_success is NEVER
+  // observed (no reconnect edge fires), so it stays pending — exactly the stall.
+  tracker.onQueued("M1");
+  tracker.onExecutionStart("M1");
+  assert.equal(tracker.hasPending(), true, "still pending — the sweep would stay armed");
+
+  // Simulate the panel's self-disarming sweep loop: reconcile against /history
+  // while anything is pending. The run has since finished on the server.
+  const history = {
+    M1: successEntry({ 1: { images: [{ filename: "m1.png", type: "output" }] } }),
+  };
+  let sweeps = 0;
+  while (tracker.hasPending() && sweeps < 5) {
+    sweeps += 1;
+    await tracker.reconcile({
+      fetchHistory: async (id) => history[id] ?? null,
+      fetchQueued: async () => false,
+      isVideo,
+    });
+  }
+  assert.equal(flushes.filter((f) => f.promptId === "M1").length, 1, "sweep recovered the missed completion exactly once");
+  assert.equal(tracker.hasPending(), false, "recovery drained the ledger ⇒ sweep disarms");
+  assert.equal(sweeps, 1, "one sweep sufficed once /history was terminal");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -188,6 +188,8 @@ import {
 } from "./lib/workflow-save.js";
 import { createRunCompletionTracker } from "./lib/run-completion.js";
 import { composeRunCompletionFrame } from "./lib/run-completion-frame.js";
+import { createRunReconcileSweep } from "./lib/run-reconcile-sweep.js";
+import { activeWorkflowNodeCount, graphReadDesynced } from "./lib/graph-binding.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
 import { queueMembership, historyEntryFor } from "./lib/history-reconcile.js";
 import {
@@ -214,6 +216,20 @@ let api = null;
 // queued prompt_id for #370 reconnect reconciliation, even though the tracker
 // lives in buildPanel's closure.
 let runCompletionRef = null;
+// panel#356 Bug 2: arms the periodic run-completion SAFETY SWEEP. The reconnect
+// reconcile is EDGE-triggered only (ComfyUI `reconnected` / bridge back); if the
+// ComfyUI WS silently drops and reopens during an idle gap between agent turns
+// WITHOUT firing `reconnected`, the terminal `execution_success` is missed and no
+// edge fires — the run finishes, images paint for the user, but the agent is never
+// notified and stalls indefinitely. The graph_run handler calls this the instant a
+// prompt is queued so the sweep re-reconciles pending runs against /history until
+// they drain. Set in buildPanel; null while unmounted.
+let armRunReconcileSweepRef = null;
+// How often the safety sweep re-reconciles while any run is still pending delivery.
+// Only runs while `hasPending()` is true (self-disarming), so an idle panel carries
+// no perpetual timer; a redundant sweep is harmless (reconcile is idempotent — the
+// delivered/terminal fences make double-delivery unreachable).
+const RUN_RECONCILE_SWEEP_MS = 20000;
 
 // Execution-error capture so graph_get_errors can report the most recent failure
 // even if it predates the agent's question. Wired once `api` is ready (via
@@ -3352,6 +3368,33 @@ function getGraphCtx() {
   return { app, graph, rootGraph: app.graph, canvas: app.canvas, LG };
 }
 
+// panel#389: a graph READ can land while the live root graph is bound to a
+// DIFFERENT, empty graph object than the one the active workflow describes (a
+// load / tab-switch / post-reconnect canvas rebuild that left the read on an empty
+// graph). The read then returns `node_count: 0` while the workflow service still
+// reports the workflow active with red missing-model nodes — a silent false-clean
+// that misleads the agent (e.g. into telling the user to ignore genuinely-wired red
+// nodes). Detect that provable desync from the active workflow's OWN serialized
+// node count and THROW an actionable, recoverable error instead of returning the
+// misleading empty graph — mirroring #587's "reads throw on a dead binding rather
+// than return empty". Fail-safe: fires ONLY when the workflow reports N>0 nodes at
+// ROOT scope while the live root graph is empty, so a genuinely-empty / brand-new
+// workflow (and any descended-into empty subgraph) reads `node_count: 0` as before.
+function assertGraphBoundToActiveWorkflow(graph, rootGraph) {
+  const liveNodeCount = rootGraph?._nodes?.length ?? 0;
+  const inSubgraph = !!rootGraph && graph !== rootGraph;
+  const activeWorkflow = activeWorkflowRef();
+  if (graphReadDesynced({ liveNodeCount, activeWorkflow, inSubgraph })) {
+    const expected = activeWorkflowNodeCount(activeWorkflow);
+    throw new Error(
+      `The live graph is out of sync with the active workflow: the workflow reports ${expected} node(s) ` +
+        `but the canvas graph is empty. A load, tab switch, or reconnect left this read bound to an empty ` +
+        `graph, so an empty/clean result here would be WRONG. Re-open the active workflow tab ` +
+        `(panel_open_workflow) or reload the panel to rebind the graph, then retry.`,
+    );
+  }
+}
+
 /** Reach a Pinia store by id. Pinia attaches itself as `$pinia` on the Vue app's
  *  globalProperties; the Vue app instance hangs off its mount element (#vue-app)
  *  as `__vue_app__`; `_s` is pinia's id→store map. Returns null if unavailable. */
@@ -4716,7 +4759,10 @@ const GRAPH_TOOL_EXECUTORS = {
   // Far cheaper to read than the full JSON state, and shows the WIRING (which the
   // raw node dump makes you reconstruct). Read-only.
   graph_outline() {
-    const { graph } = getGraphCtx();
+    const { graph, rootGraph } = getGraphCtx();
+    // panel#389: refuse a false-clean empty read when the live graph is desynced
+    // from the active workflow (empty canvas graph while the workflow reports nodes).
+    assertGraphBoundToActiveWorkflow(graph, rootGraph);
     // #429: geometric group membership is tested boundingRect-first, so resync every
     // node's cached rect to its live pos/size BEFORE computing membership — a node
     // moved by a path the panel didn't own (paste/load/manual drag) otherwise reports
@@ -6500,6 +6546,15 @@ const GRAPH_TOOL_EXECUTORS = {
         runCompletionRef?.onQueued(pid);
       } catch {}
     }
+    // panel#356 Bug 2: kick the periodic safety-sweep reconcile now that a run is
+    // pending, so a completion landing during an UNOBSERVED WS reconnect (idle gap,
+    // no `reconnected` edge) is still recovered. No-op if the sweep is already armed
+    // or the ledger is empty; self-disarms when every pending run drains.
+    if (queuedPromptIds.length) {
+      try {
+        armRunReconcileSweepRef?.();
+      } catch {}
+    }
     // Verdict from BOTH channels: the captured top-level rejection (#358) and the
     // per-node errors the frontend stashed. null ⇒ genuinely accepted.
     const rejection = summarizePromptRejection({
@@ -6588,7 +6643,12 @@ const GRAPH_TOOL_EXECUTORS = {
     // would otherwise mix the pre-await graph's nodes/red flags with the new workflow's
     // asset+validation state, fabricating and omitting per-node errors (codex round-9 P1).
     // Reading it here binds every downstream surface to ONE consistent post-await graph.
-    const { app: comfy, graph } = getGraphCtx();
+    const { app: comfy, graph, rootGraph } = getGraphCtx();
+    // panel#389: refuse a false-clean empty read when the live graph is desynced
+    // from the active workflow (empty canvas graph while the workflow reports nodes)
+    // — otherwise get_errors reports "no errors" for a workflow whose red nodes the
+    // agent then wrongly tells the user to ignore.
+    assertGraphBoundToActiveWorkflow(graph, rootGraph);
     const nodes = graph._nodes ?? [];
     const byId = new Map(nodes.map((n) => [String(n.id), n]));
     const reasons = new Map();
@@ -16389,6 +16449,25 @@ function buildPanel() {
     return reconcileInFlight;
   }
 
+  // panel#356 Bug 2: periodic SAFETY SWEEP. reconcileRunsAfterReconnect only fires
+  // on an OBSERVED reconnect edge (ComfyUI `reconnected` / bridge back). If the
+  // ComfyUI WS silently drops and reopens during an idle gap between agent turns
+  // WITHOUT ComfyUI emitting `reconnected` (background-tab throttling, a socket the
+  // client library swaps on a visibility change), the terminal `execution_success`
+  // is missed and NO edge fires — the run completes, images paint for the user, but
+  // no `agent_event` is ever sent and the agent stalls forever. This sweep re-runs
+  // the SAME /history reconcile on a timer while any run is still pending delivery,
+  // so such a completion is recovered even with no reconnect edge. Self-disarming +
+  // dispose-safe (an unmount landing mid-await can't resurrect it — see the lib).
+  const runReconcileSweep = createRunReconcileSweep({
+    hasPending: () => runCompletion.hasPending(),
+    reconcile: () => reconcileRunsAfterReconnect(),
+    onSweepError: (err) => console.warn("[cmcp] run reconcile sweep failed:", err),
+    intervalMs: RUN_RECONCILE_SWEEP_MS,
+  });
+  const armRunReconcileSweep = () => runReconcileSweep.arm();
+  armRunReconcileSweepRef = armRunReconcileSweep;
+
   function onExecuted(ev) {
     const d = ev?.detail ?? {};
     const out = d.output || {};
@@ -19155,6 +19234,14 @@ function buildPanel() {
       } catch {
         // already detached
       }
+      // panel#356 Bug 2: dispose the run-completion safety sweep and drop the module-
+      // level hooks so a torn-down panel can't keep reconciling. dispose() also stops
+      // an in-flight sweep from re-arming even if the unmount lands DURING its async
+      // reconcile await (codex P1 unmount-resurrection leak). Only null the shared
+      // refs if they still point at THIS instance — a newer mount may already own them.
+      runReconcileSweep.dispose();
+      if (armRunReconcileSweepRef === armRunReconcileSweep) armRunReconcileSweepRef = null;
+      if (runCompletionRef === runCompletion) runCompletionRef = null;
       // Drop the Settings→panel hooks so the dialog can't drive a torn-down panel
       // (a freshly-mounted panel re-registers them).
       panelHooks.applyBackend = null;

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1,0 +1,77 @@
+/**
+ * Detect a graph READ that is out of sync with the ACTIVE workflow (panel#389).
+ *
+ * The panel reads node counts straight off LiteGraph's live `app.graph._nodes`,
+ * while "active / modified / missing-model" come from ENTIRELY separate Vue/Pinia
+ * stores (`extensionManager.workflow.activeWorkflow`, the `missingModel` store).
+ * Nothing reconciles the two. When a load / tab-switch / post-reconnect canvas
+ * rebuild leaves the live root graph bound to a DIFFERENT, empty graph object than
+ * the one the active workflow describes, a read returns `node_count: 0` while the
+ * workflow service still reports the workflow active with red missing-model nodes.
+ * That silent false-clean makes the agent believe the canvas is empty — and e.g.
+ * tell the user to ignore red nodes or re-download a model that IS wired.
+ *
+ * The reliable, version-defensive ground truth is the workflow object's OWN
+ * serialized state, kept by ComfyUI's ChangeTracker: `activeState` (current) and
+ * `initialState` (load baseline), each a serialized graph `{ nodes: [...] }`. For
+ * the desync above the active workflow retains its real node count (its state was
+ * captured when ITS graph was live) while the now-bound `app.graph` is empty.
+ *
+ * These helpers are PURE (no DOM / no ComfyUI globals — every input is passed in)
+ * so the detection can be unit-tested without a browser.
+ */
+
+/**
+ * The active workflow's OWN expected node count, read from its ChangeTracker's
+ * serialized state. `activeState` is the workflow's CURRENT intended node set;
+ * `initialState` is the load/save baseline.
+ *
+ * PREFER `activeState` and honor its count EVEN WHEN ZERO — only fall back to
+ * `initialState` when `activeState` is absent or malformed. Taking the MAX of the
+ * two would falsely report an expectation after a legitimate `graph_clear`
+ * (activeState→0 but the baseline `initialState` still holds the pre-clear nodes),
+ * making the desync guard throw on a genuinely-emptied workflow (codex P1). Some
+ * builds hang the serialized states flat off the workflow rather than off
+ * `changeTracker`, so each source is probed there too.
+ *
+ * Fail-open to 0: any missing/malformed shape yields 0, so an ABSENT expectation
+ * can NEVER manufacture a false desync — the guard only ever fires on a POSITIVE,
+ * well-formed node count from the workflow's own CURRENT state.
+ */
+export function activeWorkflowNodeCount(activeWorkflow) {
+  try {
+    if (!activeWorkflow || typeof activeWorkflow !== "object") return 0;
+    const ct = activeWorkflow.changeTracker;
+    // Well-formed node-array length, or null when the state is absent/malformed.
+    const nodesLen = (st) => (st && Array.isArray(st.nodes) ? st.nodes.length : null);
+    // activeState first (current intent — 0 after a clear is authoritative), from the
+    // change tracker then a flat fallback; only if BOTH are unavailable/malformed do
+    // we drop to the load baseline. `??` keeps a well-formed 0 rather than skipping it.
+    const active = nodesLen(ct?.activeState) ?? nodesLen(activeWorkflow.activeState);
+    if (active != null) return active;
+    const initial = nodesLen(ct?.initialState) ?? nodesLen(activeWorkflow.initialState);
+    return initial ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * True when a graph READ is DESYNCED from the active workflow: the live ROOT graph
+ * is EMPTY (`liveNodeCount === 0`) while the active workflow's own serialized state
+ * carries nodes. Returns false (no desync — never throw) whenever:
+ *   - the read is scoped INTO a subgraph (`inSubgraph`): a descended subgraph can
+ *     legitimately be empty while the root workflow has nodes;
+ *   - the live graph already has nodes (self-evidently bound);
+ *   - there is no active workflow, or its state reports 0 nodes (a genuinely empty
+ *     / brand-new workflow legitimately reads `node_count: 0`).
+ *
+ * Fail-safe by construction: it fires ONLY on a provable "workflow has N>0 nodes
+ * but the live root graph has zero" mismatch, so a genuinely-empty workflow is
+ * never misflagged.
+ */
+export function graphReadDesynced({ liveNodeCount, activeWorkflow, inSubgraph = false } = {}) {
+  if (inSubgraph) return false;
+  if (Number(liveNodeCount) !== 0) return false;
+  return activeWorkflowNodeCount(activeWorkflow) > 0;
+}

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -703,6 +703,19 @@ export function createRunCompletionTracker({
       return starts.get(key(id));
     },
 
+    /**
+     * True while ANY run's completion has not yet been confirmed delivered — i.e.
+     * the recovery ledger is non-empty. Drives the panel's periodic SAFETY-SWEEP
+     * reconcile (panel#356 Bug 2): the reconnect reconcile is EDGE-triggered
+     * (ComfyUI `reconnected` / bridge back), so a completion that lands during an
+     * UNOBSERVED WS reconnect in an idle gap between agent turns is never recovered.
+     * A sweep that re-runs `reconcile()` while this stays true closes that hole, and
+     * self-disarms the instant the ledger drains (so an idle panel keeps no timer).
+     */
+    hasPending() {
+      return pending.size > 0;
+    },
+
     // Introspection for tests / diagnostics.
     _active: active,
     _buffers: buffers,

--- a/web/js/lib/run-reconcile-sweep.js
+++ b/web/js/lib/run-reconcile-sweep.js
@@ -1,0 +1,83 @@
+/**
+ * Periodic run-completion SAFETY SWEEP (panel#356 Bug 2).
+ *
+ * The panel's reconnect reconcile is EDGE-triggered only (ComfyUI `reconnected` /
+ * bridge back). If the ComfyUI WS silently drops and reopens during an idle gap
+ * between agent turns WITHOUT firing `reconnected` (background-tab throttling, a
+ * socket the client library swaps on a visibility change), the terminal
+ * `execution_success` is missed and NO edge fires — the run finishes, images paint
+ * for the user, but the agent is never notified and stalls indefinitely.
+ *
+ * This is a self-disarming timer that re-runs the SAME /history reconcile WHILE any
+ * run is still pending delivery (`hasPending()`), so such a completion is recovered
+ * even with no reconnect edge. It:
+ *   - runs at most ONE timer at a time (single-flight `arm`);
+ *   - only re-arms while `hasPending()` stays true, so an idle panel keeps no timer;
+ *   - is safe to `arm()` repeatedly (each queue kicks it — a redundant arm is a
+ *     no-op);
+ *   - stops cleanly on `dispose()` and, critically, will NOT re-arm even if
+ *     `dispose()` lands WHILE an async reconcile is in flight (the `finally` re-arm
+ *     is guarded by the disposed flag) — closing the unmount-resurrection leak.
+ *
+ * Pure of DOM / ComfyUI globals (timers + callbacks injected) so it is unit-tested
+ * without a browser.
+ *
+ * @param {object} o
+ * @param {() => boolean} o.hasPending   True while a completion is still undelivered.
+ * @param {() => (Promise<any>|any)} o.reconcile  Runs one /history reconcile pass.
+ * @param {(err:any) => void} [o.onSweepError] Reconcile failure sink (never rethrows).
+ * @param {(fn:Function, ms:number) => any} [o.setTimer]
+ * @param {(t:any) => void} [o.clearTimer]
+ * @param {number} [o.intervalMs]        Sweep period (default 20000).
+ */
+export function createRunReconcileSweep({
+  hasPending,
+  reconcile,
+  onSweepError = () => {},
+  setTimer = (fn, ms) => setTimeout(fn, ms),
+  clearTimer = (t) => clearTimeout(t),
+  intervalMs = 20000,
+} = {}) {
+  if (typeof hasPending !== "function" || typeof reconcile !== "function") {
+    throw new TypeError("createRunReconcileSweep requires hasPending + reconcile callbacks");
+  }
+  let timer = null;
+  let disposed = false;
+
+  function arm() {
+    if (disposed) return; // torn down ⇒ never schedule
+    if (timer != null) return; // one sweep armed at a time (single-flight)
+    if (!hasPending()) return; // nothing to recover ⇒ no timer
+    timer = setTimer(async () => {
+      timer = null;
+      // Re-check on fire: disposed, or the ledger drained meanwhile ⇒ disarm.
+      if (disposed || !hasPending()) return;
+      try {
+        await reconcile();
+      } catch (err) {
+        onSweepError(err);
+      } finally {
+        // Re-arm ONLY while still mounted AND something is undelivered. The disposed
+        // guard here is what stops an unmount that landed DURING the await from
+        // resurrecting the sweep against a torn-down panel (codex P1).
+        if (!disposed) arm();
+      }
+    }, intervalMs);
+  }
+
+  function dispose() {
+    disposed = true;
+    if (timer != null) {
+      clearTimer(timer);
+      timer = null;
+    }
+  }
+
+  return {
+    arm,
+    dispose,
+    // Introspection for tests.
+    _isDisposed: () => disposed,
+    _hasTimer: () => timer != null,
+  };
+}


### PR DESCRIPTION
Fixes the last two `get_errors` residuals, built on the just-merged #472 get_errors staleness cluster (base = current `origin/main`).

## panel#356 — `panel_run` completion notification never delivered

**Bug 1 (stale `missing_model` after `panel_set_widget`): already fixed.** The #472 staleness merge (`isStaleAssetCandidate` drops the stale candidate after a widget fix; `nodeRedFlagIsStale` clears the sticky red outline) resolves exactly the self-contradicting payload the issue describes. Verified on current `origin/main` — no code change needed.

**Bug 2 (dropped completion notification): the real residual, fixed here.** The render-completion notification is entirely browser-driven and the reconnect reconcile is EDGE-triggered only (ComfyUI `reconnected` / bridge back). If the ComfyUI WS silently drops and reopens during an idle gap between agent turns WITHOUT firing `reconnected` (background-tab throttling, a socket the client swaps on a visibility change), the terminal `execution_success` is missed and no edge fires — the run finishes, images paint for the user, but the agent is never notified and stalls indefinitely (the reported 12-min silent stall).

Fix: a self-disarming periodic **safety sweep** that re-runs the existing `/history` reconcile while any run is still pending delivery, recovering the completion even with no reconnect edge.
- `run-completion.js`: new `hasPending()`.
- `run-reconcile-sweep.js` (new pure lib): single-flight arm, re-arm only while pending, self-disarm on drain, and **dispose-safe** — an unmount landing DURING an in-flight reconcile can't resurrect the timer.
- panel: armed on `graph_run` queue, disposed on unmount.

## panel#389 — graph read tools return an empty graph while the session reports the workflow active

Reads count `app.graph._nodes` while active/modified/missing-model come from separate Vue/Pinia stores. A load / tab-switch / post-reconnect rebuild can leave the read bound to an empty graph object, so `node_count: 0` is returned as a silent false-clean (the agent then e.g. tells the user to ignore genuinely-wired red nodes). Verified on current `origin/main` that the residual survives (`#587`'s dead-binding throw catches a *missing* `app.graph`, not an empty-but-present one).

Fix: detect the provable desync from the active workflow's OWN serialized node count and THROW an actionable, recoverable error from `graph_outline` / `graph_get_errors` instead — mirroring #587's "reads throw on a dead binding rather than return empty".
- `graph-binding.js` (new pure lib): `activeWorkflowNodeCount` prefers ChangeTracker `activeState` (honoring a well-formed `0` so a legitimate `graph_clear` is NOT misread as a desync), falling back to `initialState` only when activeState is absent/malformed; `graphReadDesynced` fires only at ROOT scope when the live graph is empty while the workflow reports N>0 nodes. Fail-safe: a genuinely-empty/new workflow and any descended empty subgraph read `node_count: 0` as before.

## Tests / gate
- New unit suites: `graph-binding`, `run-reconcile-sweep` (incl. the mid-await dispose regression), `hasPending` + sweep-gate. Full panel unit suite green (1106); `tsc` clean; panel parses as ESM.
- Codex self-gate (gpt-5.6-terra/high): first pass FAIL caught two real P1s (unmount-resurrection leak in the sweep; `MAX(active,initial)` false-throw on `graph_clear`) — both fixed; re-review **PASS**, no remaining P0/P1/P2.

Closes #356
Closes #389