### PR TITLE
feat(panel): refresh_nodes executor — force /object_info re-register on demand (#608)

### DIFF
--- a/browser_tests/unit/refresh-coalesce.test.mjs
+++ b/browser_tests/unit/refresh-coalesce.test.mjs
@@ -140,3 +140,59 @@ test("a payload call still runs even if the in-flight refresh REJECTS", async ()
 
   assert.ok(registered.includes(NEW_DEFS), "the payload was registered despite the older refresh failing");
 });
+
+// #608: panel_refresh_nodes' frontend executor (refresh_nodes) awaits a FORCED
+// no-payload refresh and reports its freshness verdict back to the tool. The
+// executor is `refreshComfyNodeDefs(undefined, { force:true })` -> `{ refreshed:
+// !!verdict }`, so the coalescer MUST resolve a forced refresh to runRegister's
+// OWN return value (registerComfyNodeDefs returns true only when it authoritatively
+// fetched /object_info AND refreshed combos). If the coalescer swallowed that
+// value, panel_refresh_nodes would always report refreshed:false and an agent
+// couldn't tell a real refresh from a no-op after stage_output_as_input.
+test("#608: a forced (no-payload) refresh resolves to runRegister's freshness verdict", async () => {
+  let verdict = true;
+  const { coalescer } = makeHarnessReturning(() => verdict);
+
+  assert.equal(await coalescer(undefined, { force: true }), true, "forced refresh forwards a true verdict");
+
+  verdict = false;
+  assert.equal(await coalescer(undefined, { force: true }), false, "forced refresh forwards a false verdict");
+});
+
+test("#608: a forced refresh queued BEHIND an in-flight run resolves to the trailing run's verdict", async () => {
+  const gate = deferred();
+  let verdict = false;
+  const { coalescer } = makeHarnessReturning(async (defs) => {
+    if (defs == null) {
+      // First (in-flight) run blocks; its stale verdict must NOT be what the
+      // trailing forced call reports.
+      await gate.promise;
+    }
+    return verdict;
+  });
+
+  const inflight = coalescer(); // holds the slot
+  const forced = coalescer(undefined, { force: true }); // must run its OWN trailing pass
+  verdict = true; // the authoritative post-change fetch now sees the new asset
+  gate.resolve();
+
+  await inflight;
+  assert.equal(await forced, true, "the trailing forced refresh reports its own fresh verdict, not the stale join");
+});
+
+// Harness variant whose runRegister RETURNS a value (the freshness verdict), so a
+// test can assert what a caller (refresh_nodes) receives from the coalescer.
+function makeHarnessReturning(verdictImpl) {
+  let inFlight = null;
+  const coalescer = makeRefreshCoalescer({
+    getInFlight: () => inFlight,
+    setInFlight: (p) => {
+      inFlight = p;
+    },
+    runRegister: async (defs) => {
+      const v = verdictImpl(defs);
+      return v && typeof v.then === "function" ? await v : v;
+    },
+  });
+  return { coalescer };
+}

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -4570,6 +4570,20 @@ function placementFor(graph, pos) {
 let activePanelRoot = null;
 
 const GRAPH_TOOL_EXECUTORS = {
+  // #608: force a fresh /object_info re-register + combo refresh so an asset that
+  // appeared server-side AFTER page-load — a stage_output_as_input input, a freshly
+  // downloaded model/LoRA/VAE, a newly installed node pack — becomes selectable in
+  // loaders/combos WITHOUT a manual reload (press-R) or restart. Reuses the #396
+  // forced re-register (refreshComfyNodeDefs force), the SAME non-destructive path a
+  // completed download already triggers automatically. GLOBAL (not tied to the active
+  // graph, so it carries no workflow_path and skips the pinned-target guard),
+  // undo-neutral, idempotent. Resolves to the refresh's OWN freshness verdict —
+  // refreshComfyNodeDefs returns true only when it authoritatively fetched /object_info
+  // AND refreshed combos — so the tool reply reflects a real fetch, not just a no-op.
+  async refresh_nodes() {
+    const refreshed = await refreshComfyNodeDefs(undefined, { force: true });
+    return { ok: true, refreshed: !!refreshed };
+  },
   // Full-fidelity capture of the live canvas — the ROOT graph's serialized UI
   // JSON (the same shape ComfyUI writes to disk on save), so the orchestrator
   // can strip/slice/save what the user ACTUALLY has open without asking them to


### PR DESCRIPTION
Companion to artokun/comfyui-mcp#611 (`panel_refresh_nodes`).

Adds a `refresh_nodes` bridge executor to `GRAPH_TOOL_EXECUTORS` that runs a forced `refreshComfyNodeDefs(undefined, { force: true })` — the same non-destructive #396 re-register a completed download already triggers automatically — so a server-side asset that appeared **after** page-load becomes selectable in loaders/combos without a manual reload (press-R) or restart:

- a `stage_output_as_input` input (the #608 chaining dead-end),
- a freshly downloaded model / LoRA / VAE ("the loader can't see it"),
- a newly installed node pack.

### Properties
- **Global** — carries no `workflow_path`, so it skips the pinned-target guard and refreshes the live registry regardless of the pinned session's target.
- **Undo-neutral / idempotent** — only re-registers node defs and rebuilds combo option lists; never changes graph content.
- Resolves to the refresh's **own freshness verdict** (`refreshComfyNodeDefs` returns true only when it authoritatively fetched `/object_info` AND refreshed combos), so the tool reply reflects a real fetch, not a no-op.

### Tests
`refresh-coalesce.test.mjs`: a forced no-payload refresh resolves to `runRegister`'s freshness verdict — including when queued behind an in-flight run (the trailing run's verdict, not a stale join). Full panel unit suite green (1086 tests); panel file parses clean as an ES module.

Refs artokun/comfyui-mcp#608

🤖 Generated with [Claude Code](https://claude.com/claude-code)
