### PR TITLE
0.11.28 — refresh_nodes executor (#608) + reconnect run-completion recovery (#356, #389)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.28] - 2026-08-01
+
+### Added
+- refresh_nodes executor — force /object_info re-register on demand (#608)
+
+### Fixed
+- recover run-completion missed on unobserved reconnect (#356) + refuse false-clean empty-graph reads (#389)
+
+
 ## [0.11.27] - 2026-08-01
 
 ### Fixed

--- a/browser_tests/unit/refresh-coalesce.test.mjs
+++ b/browser_tests/unit/refresh-coalesce.test.mjs
@@ -140,3 +140,59 @@ test("a payload call still runs even if the in-flight refresh REJECTS", async ()
 
   assert.ok(registered.includes(NEW_DEFS), "the payload was registered despite the older refresh failing");
 });
+
+// #608: panel_refresh_nodes' frontend executor (refresh_nodes) awaits a FORCED
+// no-payload refresh and reports its freshness verdict back to the tool. The
+// executor is `refreshComfyNodeDefs(undefined, { force:true })` -> `{ refreshed:
+// !!verdict }`, so the coalescer MUST resolve a forced refresh to runRegister's
+// OWN return value (registerComfyNodeDefs returns true only when it authoritatively
+// fetched /object_info AND refreshed combos). If the coalescer swallowed that
+// value, panel_refresh_nodes would always report refreshed:false and an agent
+// couldn't tell a real refresh from a no-op after stage_output_as_input.
+test("#608: a forced (no-payload) refresh resolves to runRegister's freshness verdict", async () => {
+  let verdict = true;
+  const { coalescer } = makeHarnessReturning(() => verdict);
+
+  assert.equal(await coalescer(undefined, { force: true }), true, "forced refresh forwards a true verdict");
+
+  verdict = false;
+  assert.equal(await coalescer(undefined, { force: true }), false, "forced refresh forwards a false verdict");
+});
+
+test("#608: a forced refresh queued BEHIND an in-flight run resolves to the trailing run's verdict", async () => {
+  const gate = deferred();
+  let verdict = false;
+  const { coalescer } = makeHarnessReturning(async (defs) => {
+    if (defs == null) {
+      // First (in-flight) run blocks; its stale verdict must NOT be what the
+      // trailing forced call reports.
+      await gate.promise;
+    }
+    return verdict;
+  });
+
+  const inflight = coalescer(); // holds the slot
+  const forced = coalescer(undefined, { force: true }); // must run its OWN trailing pass
+  verdict = true; // the authoritative post-change fetch now sees the new asset
+  gate.resolve();
+
+  await inflight;
+  assert.equal(await forced, true, "the trailing forced refresh reports its own fresh verdict, not the stale join");
+});
+
+// Harness variant whose runRegister RETURNS a value (the freshness verdict), so a
+// test can assert what a caller (refresh_nodes) receives from the coalescer.
+function makeHarnessReturning(verdictImpl) {
+  let inFlight = null;
+  const coalescer = makeRefreshCoalescer({
+    getInFlight: () => inFlight,
+    setInFlight: (p) => {
+      inFlight = p;
+    },
+    runRegister: async (defs) => {
+      const v = verdictImpl(defs);
+      return v && typeof v.then === "function" ? await v : v;
+    },
+  });
+  return { coalescer };
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.27"
+version = "0.11.28"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -396,7 +396,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.27";
+const PANEL_VERSION = "0.11.28";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -4613,6 +4613,20 @@ function placementFor(graph, pos) {
 let activePanelRoot = null;
 
 const GRAPH_TOOL_EXECUTORS = {
+  // #608: force a fresh /object_info re-register + combo refresh so an asset that
+  // appeared server-side AFTER page-load — a stage_output_as_input input, a freshly
+  // downloaded model/LoRA/VAE, a newly installed node pack — becomes selectable in
+  // loaders/combos WITHOUT a manual reload (press-R) or restart. Reuses the #396
+  // forced re-register (refreshComfyNodeDefs force), the SAME non-destructive path a
+  // completed download already triggers automatically. GLOBAL (not tied to the active
+  // graph, so it carries no workflow_path and skips the pinned-target guard),
+  // undo-neutral, idempotent. Resolves to the refresh's OWN freshness verdict —
+  // refreshComfyNodeDefs returns true only when it authoritatively fetched /object_info
+  // AND refreshed combos — so the tool reply reflects a real fetch, not just a no-op.
+  async refresh_nodes() {
+    const refreshed = await refreshComfyNodeDefs(undefined, { force: true });
+    return { ok: true, refreshed: !!refreshed };
+  },
   // Full-fidelity capture of the live canvas — the ROOT graph's serialized UI
   // JSON (the same shape ComfyUI writes to disk on save), so the orchestrator
   // can strip/slice/save what the user ACTUALLY has open without asking them to


### PR DESCRIPTION
Panel 0.11.28.

- **#608** `refresh_nodes` executor — force /object_info re-register on demand.
- **#356** recover run-completion missed on unobserved reconnect.
- **#389** refuse false-clean empty-graph reads.

Both version fields bumped (pyproject 0.11.28 + PANEL_VERSION 0.11.28). Merges → Registry publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)