### PR TITLE
fix(session): emit durable per-instance workflow_uuid in hello (#570)

### DIFF
--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -257,6 +257,19 @@ test("#296: resume rides the hello only when present", () => {
   assert.equal(buildHelloPayload({ tabId: "t", resume: "sess-1" }).resume, "sess-1");
 });
 
+test("#570: the durable per-instance workflow uuid rides the hello when present", () => {
+  // Lets the orchestrator key an UNSAVED workflow's resume on a globally-unique id
+  // that survives the tmp:<uuid> tab-id churn — so a same-title sibling can't
+  // cross-resume its conversation (the reopened #570 residual).
+  const frame = buildHelloPayload({ tabId: "tmp:abc", title: "Unsaved Workflow", workflowUuid: "wf-uuid-1" });
+  assert.equal(frame.workflow_uuid, "wf-uuid-1");
+});
+
+test("#570: workflow_uuid is omitted (never blank) when unknown, so old behavior stands", () => {
+  assert.equal("workflow_uuid" in buildHelloPayload({ tabId: "t" }), false);
+  assert.equal("workflow_uuid" in buildHelloPayload({ tabId: "t", workflowUuid: "   " }), false);
+});
+
 // ---- #379 soft-reload recovery: never leave the bridge dead -----------------
 
 test("#379: a REFUSED reload (by-design 503) still reconnects, dropping the interlock", () => {

--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -257,6 +257,17 @@ test("#296: resume rides the hello only when present", () => {
   assert.equal(buildHelloPayload({ tabId: "t", resume: "sess-1" }).resume, "sess-1");
 });
 
+test("#570 P0c: hello ALWAYS advertises enforces_workflow_stamp so the orchestrator won't gate this build's graph edits", () => {
+  // A current build unconditionally enforces the per-command workflow stamp; the flag must
+  // ride every hello (not gated behind any optional field) so the server never fails closed
+  // on our mutating graph commands.
+  assert.equal(buildHelloPayload({ tabId: "t" }).enforces_workflow_stamp, true);
+  assert.equal(
+    buildHelloPayload({ tabId: "wf:x.json", title: "x", backend: "codex" }).enforces_workflow_stamp,
+    true,
+  );
+});
+
 test("#570: the durable per-instance workflow uuid rides the hello when present", () => {
   // Lets the orchestrator key an UNSAVED workflow's resume on a globally-unique id
   // that survives the tmp:<uuid> tab-id churn — so a same-title sibling can't

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -6,8 +6,23 @@ import {
   isWorkflowCreationLoad,
   normalizedWorkflowPath,
   shouldForkEmbeddedWorkflowUuid,
+  trustedUnsavedEmbeddedUuid,
   workflowAliasForPath
 } from '../../web/js/lib/workflow-chat-identity.js'
+
+// #570 P0b — trust an unsaved workflow's embedded uuid ONLY when it carries the fork marker.
+test('#570 P0b a MARKED embedded uuid is trusted (fork-minted → unique per-instance)', () => {
+  assert.equal(trustedUnsavedEmbeddedUuid({ embeddedId: 'uuid-A', embeddedOwned: true }), 'uuid-A')
+})
+
+test('#570 P0b a LEGACY unmarked embedded uuid is NOT trusted → fork (null)', () => {
+  // A pre-rollout copy carries the source uuid with no marker → must not be adopted.
+  assert.equal(trustedUnsavedEmbeddedUuid({ embeddedId: 'uuid-A', embeddedOwned: false }), null)
+  assert.equal(trustedUnsavedEmbeddedUuid({ embeddedId: 'uuid-A' }), null)
+  // No embedded id at all → null (mint fresh).
+  assert.equal(trustedUnsavedEmbeddedUuid({ embeddedOwned: true }), null)
+  assert.equal(trustedUnsavedEmbeddedUuid({}), null)
+})
 
 // Fakes for the ComfyWorkflow 4th arg: a REUSE passes a ComfyWorkflow OBJECT; a CREATION
 // passes null/undefined/string.

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -42,16 +42,30 @@ test('#570 fence applies to every graph_* op and all four workflow mutators (act
   assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_close', targetsNonActive: false }), true)
 })
 
-test('#570 fence does NOT apply to pinned / navigation / resolved-non-active workflow ops', () => {
-  // Pinned → the #349 workflow_path guard is the authority.
-  assert.equal(activeWorkflowFenceApplies({ cmd: 'graph_add_node', hasPin: true }), false)
-  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_close', hasPin: true }), false)
+test('#570 fence ALSO applies to PINNED commands (the pin guard authorizes by path, not uuid)', () => {
+  // A pinned command (workflow_path present) is NOT exempt: after an in-place replacement at the
+  // SAME saved path the pin still matches but the uuid does not, and only the uuid fence catches
+  // it. activeWorkflowFenceApplies no longer takes a pin — the fence fires for pinned ops too.
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'graph_add_node' }), true)
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_save' }), true)
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'graph_set_widget' }), true)
+})
+
+test('#570 fence does NOT apply to navigation / resolved-non-active workflow ops', () => {
   // Navigation / creation.
   assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_open' }), false)
   assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_new' }), false)
   // Selector RESOLVED to a genuinely non-active open workflow → deterministic target → runs.
   assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_close', targetsNonActive: true }), false)
   assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_rename', targetsNonActive: true }), false)
+})
+
+test('#570 pinned command after in-place replacement at the same path: uuid mismatch ⇒ REFUSED', () => {
+  // A pinned graph write stamped for A (uuid-A) whose workflow_path still matches the active
+  // canvas — but the workflow at that path was replaced in place by B (uuid-B). The fence APPLIES
+  // (pinned no longer exempt) and the uuid mismatch refuses it, protecting B.
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'graph_add_node' }), true)
+  assert.equal(commandWorkflowMismatch({ commandUuid: 'uuid-A', activeUuid: 'uuid-B' }), true)
 })
 
 // #570 — WORKFLOW-INSTANCE FENCE. A command stamped for workflow A must not execute against

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -7,7 +7,7 @@ import {
   selectorTargetsNonActiveWorkflow,
   commandWorkflowMismatch,
   isThreadInScope,
-  isWorkflowCreationLoad,
+  isNewWorkflowLoad,
   normalizedWorkflowPath,
   resolveUnsavedInstanceUuid,
   shouldForkEmbeddedWorkflowUuid,
@@ -171,36 +171,36 @@ class FakeComfyWorkflow { constructor (path) { this.path = path } }
 // #570 P0 — fork the per-instance identity at the workflow CREATION boundary.
 test('#570 a CREATION (non-object 4th arg) is forked so a copy cannot inherit the source uuid', () => {
   // paste/new-blank pass null; open-file/duplicate/template pass a string filename.
-  assert.equal(isWorkflowCreationLoad({ workflowArg: null }), true)
-  assert.equal(isWorkflowCreationLoad({ workflowArg: undefined }), true)
-  assert.equal(isWorkflowCreationLoad({ workflowArg: 'workflows/Unsaved Workflow.json' }), true)
+  assert.equal(isNewWorkflowLoad({ workflowArg: null }), true)
+  assert.equal(isNewWorkflowLoad({ workflowArg: undefined }), true)
+  assert.equal(isNewWorkflowLoad({ workflowArg: 'workflows/Unsaved Workflow.json' }), true)
 })
 
 test('#570 an external import with an openSource is a creation', () => {
-  assert.equal(isWorkflowCreationLoad({ workflowArg: 'x.json', openSource: 'file_button' }), true)
+  assert.equal(isNewWorkflowLoad({ workflowArg: 'x.json', openSource: 'file_button' }), true)
   // Even if some future path passed an object, an explicit openSource still forks.
-  assert.equal(isWorkflowCreationLoad({ workflowArg: new FakeComfyWorkflow('a'), openSource: 'file_drop' }), true)
+  assert.equal(isNewWorkflowLoad({ workflowArg: new FakeComfyWorkflow('a'), openSource: 'file_drop' }), true)
 })
 
 test('#570 a REUSE (ComfyWorkflow object 4th arg, no openSource) is NOT forked — durable reload', () => {
   // reload-restore / tab-switch / undo / reroute-migration all pass the workflow OBJECT.
-  assert.equal(isWorkflowCreationLoad({ workflowArg: new FakeComfyWorkflow('workflows/Unsaved Workflow.json') }), false)
+  assert.equal(isNewWorkflowLoad({ workflowArg: new FakeComfyWorkflow('workflows/Unsaved Workflow.json') }), false)
 })
 
 test('#570 the panel\'s own same-workflow reload opts out via noFork (snapshot revert)', () => {
-  assert.equal(isWorkflowCreationLoad({ workflowArg: null, noFork: true }), false)
-  assert.equal(isWorkflowCreationLoad({ workflowArg: 'x.json', openSource: 'file_button', noFork: true }), false)
+  assert.equal(isNewWorkflowLoad({ workflowArg: null, noFork: true }), false)
+  assert.equal(isNewWorkflowLoad({ workflowArg: 'x.json', openSource: 'file_button', noFork: true }), false)
 })
 
 test('#570 FAIL-SAFE: an unrecognized/mis-shaped object 4th arg is forked (bias to fork)', () => {
   // A real reuse passes a ComfyWorkflow with a string `path`; anything else — an object
   // WITHOUT a path, or an array — is ambiguous and must fork rather than risk inheriting.
-  assert.equal(isWorkflowCreationLoad({ workflowArg: {} }), true)
-  assert.equal(isWorkflowCreationLoad({ workflowArg: { notAPath: 1 } }), true)
-  assert.equal(isWorkflowCreationLoad({ workflowArg: { path: 123 } }), true) // path not a string
-  assert.equal(isWorkflowCreationLoad({ workflowArg: [] }), true)
+  assert.equal(isNewWorkflowLoad({ workflowArg: {} }), true)
+  assert.equal(isNewWorkflowLoad({ workflowArg: { notAPath: 1 } }), true)
+  assert.equal(isNewWorkflowLoad({ workflowArg: { path: 123 } }), true) // path not a string
+  assert.equal(isNewWorkflowLoad({ workflowArg: [] }), true)
   // Only a ComfyWorkflow-shaped object (string path) is trusted as a reuse.
-  assert.equal(isWorkflowCreationLoad({ workflowArg: { path: 'workflows/x.json' } }), false)
+  assert.equal(isNewWorkflowLoad({ workflowArg: { path: 'workflows/x.json' } }), false)
 })
 
 test('normalizes Windows paths for stable identity comparisons', () => {

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -3,47 +3,38 @@ import test from 'node:test'
 
 import {
   isThreadInScope,
+  isWorkflowCreationLoad,
   normalizedWorkflowPath,
-  resolveUnsavedWorkflowUuid,
   shouldForkEmbeddedWorkflowUuid,
   workflowAliasForPath
 } from '../../web/js/lib/workflow-chat-identity.js'
 
-// #570 P0b/P1 — unsaved-workflow durable uuid keyed on (path, graph-id).
-test('#570 reload of the same unsaved workflow reuses its stored uuid (P1 durability)', () => {
-  const stored = { u: 'uuid-A', g: 'gid-A' }
-  const r = resolveUnsavedWorkflowUuid({ stored, gid: 'gid-A', mint: 'fresh' })
-  assert.equal(r.uuid, 'uuid-A') // same path + same graph id → continuity
-  assert.equal(r.changed, false)
+// Fakes for the ComfyWorkflow 4th arg: a REUSE passes a ComfyWorkflow OBJECT; a CREATION
+// passes null/undefined/string.
+class FakeComfyWorkflow { constructor (path) { this.path = path } }
+
+// #570 P0 — fork the per-instance identity at the workflow CREATION boundary.
+test('#570 a CREATION (non-object 4th arg) is forked so a copy cannot inherit the source uuid', () => {
+  // paste/new-blank pass null; open-file/duplicate/template pass a string filename.
+  assert.equal(isWorkflowCreationLoad({ workflowArg: null }), true)
+  assert.equal(isWorkflowCreationLoad({ workflowArg: undefined }), true)
+  assert.equal(isWorkflowCreationLoad({ workflowArg: 'workflows/Unsaved Workflow.json' }), true)
 })
 
-test('#570 a cold import (no stored entry for its deduped path) mints fresh (P0b)', () => {
-  // The imported copy carries the SOURCE embedded uuid, but it lands on a brand-new
-  // deduped path with no stored alias → it must NOT inherit the source identity.
-  const r = resolveUnsavedWorkflowUuid({ stored: null, gid: 'gid-A', mint: 'fresh' })
-  assert.equal(r.uuid, 'fresh')
-  assert.equal(r.changed, true)
+test('#570 an external import with an openSource is a creation', () => {
+  assert.equal(isWorkflowCreationLoad({ workflowArg: 'x.json', openSource: 'file_button' }), true)
+  // Even if some future path passed an object, an explicit openSource still forks.
+  assert.equal(isWorkflowCreationLoad({ workflowArg: new FakeComfyWorkflow('a'), openSource: 'file_drop' }), true)
 })
 
-test('#570 a new workflow reusing a freed path slot does NOT inherit the old uuid (graph-id guard)', () => {
-  const stored = { u: 'uuid-old', g: 'gid-old' }
-  const r = resolveUnsavedWorkflowUuid({ stored, gid: 'gid-new', mint: 'fresh' })
-  assert.equal(r.uuid, 'fresh') // same path, DIFFERENT graph id → different workflow
-  assert.equal(r.changed, true)
+test('#570 a REUSE (ComfyWorkflow object 4th arg, no openSource) is NOT forked — durable reload', () => {
+  // reload-restore / tab-switch / undo / reroute-migration all pass the workflow OBJECT.
+  assert.equal(isWorkflowCreationLoad({ workflowArg: new FakeComfyWorkflow('workflows/Unsaved Workflow.json') }), false)
 })
 
-test('#570 FAILS CLOSED when a graph id is unavailable (mints fresh, never path-only reuse)', () => {
-  // A missing gid on either side can't prove continuity — reusing by path alone would
-  // let a new workflow inherit a closed one that reused the path slot. Mint fresh.
-  assert.equal(resolveUnsavedWorkflowUuid({ stored: { u: 'u', g: '' }, gid: 'g', mint: 'm' }).uuid, 'm')
-  assert.equal(resolveUnsavedWorkflowUuid({ stored: { u: 'u', g: 'g' }, gid: '', mint: 'm' }).uuid, 'm')
-})
-
-test('#570 a read-only probe (no mint) returns null unless BOTH graph ids match', () => {
-  assert.equal(resolveUnsavedWorkflowUuid({ stored: null, gid: 'g' }).uuid, null)
-  assert.equal(resolveUnsavedWorkflowUuid({ stored: { u: 'u', g: 'gid-old' }, gid: 'gid-new' }).uuid, null)
-  assert.equal(resolveUnsavedWorkflowUuid({ stored: { u: 'u', g: '' }, gid: 'g' }).uuid, null)
-  assert.equal(resolveUnsavedWorkflowUuid({ stored: { u: 'u', g: 'g' }, gid: 'g' }).uuid, 'u')
+test('#570 the panel\'s own same-workflow reload opts out via noFork (snapshot revert)', () => {
+  assert.equal(isWorkflowCreationLoad({ workflowArg: null, noFork: true }), false)
+  assert.equal(isWorkflowCreationLoad({ workflowArg: 'x.json', openSource: 'file_button', noFork: true }), false)
 })
 
 test('normalizes Windows paths for stable identity comparisons', () => {

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -4,9 +4,45 @@ import test from 'node:test'
 import {
   isThreadInScope,
   normalizedWorkflowPath,
+  resolveUnsavedWorkflowUuid,
   shouldForkEmbeddedWorkflowUuid,
   workflowAliasForPath
 } from '../../web/js/lib/workflow-chat-identity.js'
+
+// #570 P0b/P1 — unsaved-workflow durable uuid keyed on (path, graph-id).
+test('#570 reload of the same unsaved workflow reuses its stored uuid (P1 durability)', () => {
+  const stored = { u: 'uuid-A', g: 'gid-A' }
+  const r = resolveUnsavedWorkflowUuid({ stored, gid: 'gid-A', mint: 'fresh' })
+  assert.equal(r.uuid, 'uuid-A') // same path + same graph id → continuity
+  assert.equal(r.changed, false)
+})
+
+test('#570 a cold import (no stored entry for its deduped path) mints fresh (P0b)', () => {
+  // The imported copy carries the SOURCE embedded uuid, but it lands on a brand-new
+  // deduped path with no stored alias → it must NOT inherit the source identity.
+  const r = resolveUnsavedWorkflowUuid({ stored: null, gid: 'gid-A', mint: 'fresh' })
+  assert.equal(r.uuid, 'fresh')
+  assert.equal(r.changed, true)
+})
+
+test('#570 a new workflow reusing a freed path slot does NOT inherit the old uuid (graph-id guard)', () => {
+  const stored = { u: 'uuid-old', g: 'gid-old' }
+  const r = resolveUnsavedWorkflowUuid({ stored, gid: 'gid-new', mint: 'fresh' })
+  assert.equal(r.uuid, 'fresh') // same path, DIFFERENT graph id → different workflow
+  assert.equal(r.changed, true)
+})
+
+test('#570 lenient path-only fallback when a graph id is unavailable', () => {
+  // gid unknown on either side → key on the path alone (best-effort durability).
+  assert.equal(resolveUnsavedWorkflowUuid({ stored: { u: 'u', g: '' }, gid: 'g', mint: 'm' }).uuid, 'u')
+  assert.equal(resolveUnsavedWorkflowUuid({ stored: { u: 'u', g: 'g' }, gid: '', mint: 'm' }).uuid, 'u')
+})
+
+test('#570 a read-only probe (no mint) returns null on a miss/mismatch', () => {
+  assert.equal(resolveUnsavedWorkflowUuid({ stored: null, gid: 'g' }).uuid, null)
+  assert.equal(resolveUnsavedWorkflowUuid({ stored: { u: 'u', g: 'gid-old' }, gid: 'gid-new' }).uuid, null)
+  assert.equal(resolveUnsavedWorkflowUuid({ stored: { u: 'u', g: 'g' }, gid: 'g' }).uuid, 'u')
+})
 
 test('normalizes Windows paths for stable identity comparisons', () => {
   assert.equal(

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -5,10 +5,48 @@ import {
   isThreadInScope,
   isWorkflowCreationLoad,
   normalizedWorkflowPath,
+  resolveUnsavedInstanceUuid,
   shouldForkEmbeddedWorkflowUuid,
   shouldForkInPlaceReload,
   workflowAliasForPath
 } from '../../web/js/lib/workflow-chat-identity.js'
+
+// #570 — FAIL-CLOSED durability carrier. The embedded graph.extra uuid is only trustworthy
+// when the creation-boundary wrapper (the sanitizer that re-mints graph.extra on every copy)
+// is provably installed. If it is NOT, a pasted/imported unsaved graph could still carry the
+// SOURCE uuid, so it must be ignored and a fresh per-instance uuid minted.
+test('#570 unsaved uuid: live-object WeakMap value always wins (copy-safe)', () => {
+  assert.equal(
+    resolveUnsavedInstanceUuid({ objectUuid: 'live-A', embeddedId: 'copied-src', forkActive: true, mint: () => 'FRESH' }),
+    'live-A'
+  )
+  // Even with the sanitizer off, the live object is authoritative.
+  assert.equal(
+    resolveUnsavedInstanceUuid({ objectUuid: 'live-A', embeddedId: 'copied-src', forkActive: false, mint: () => 'FRESH' }),
+    'live-A'
+  )
+})
+
+test('#570 unsaved uuid: embedded uuid trusted ONLY when the fork wrapper is installed (durable reload)', () => {
+  assert.equal(
+    resolveUnsavedInstanceUuid({ objectUuid: undefined, embeddedId: 'wf-uuid', forkActive: true, mint: () => 'FRESH' }),
+    'wf-uuid'
+  )
+})
+
+test('#570 unsaved uuid: fork wrapper NOT installed → embedded uuid ignored, mint fresh (no cross-resume)', () => {
+  // The critical regression: loadGraphData unavailable / wrapping threw → a copied graph must
+  // NOT adopt its source graph.extra uuid.
+  assert.equal(
+    resolveUnsavedInstanceUuid({ objectUuid: undefined, embeddedId: 'copied-src-uuid', forkActive: false, mint: () => 'FRESH' }),
+    'FRESH'
+  )
+})
+
+test('#570 unsaved uuid: no live object and no embedded → mint fresh regardless of fork state', () => {
+  assert.equal(resolveUnsavedInstanceUuid({ forkActive: true, mint: () => 'FRESH' }), 'FRESH')
+  assert.equal(resolveUnsavedInstanceUuid({ forkActive: false, mint: () => 'FRESH' }), 'FRESH')
+})
 
 // #570 P0b — an in-place load into an existing object must FORK when the content identity
 // changed; a stale object-cache must never override the newly-loaded graph identity.

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test'
 
 import {
   activeWorkflowFenceApplies,
+  selectorTargetsNonActiveWorkflow,
   commandWorkflowMismatch,
   isThreadInScope,
   isWorkflowCreationLoad,
@@ -13,6 +14,20 @@ import {
   workflowAliasForPath
 } from '../../web/js/lib/workflow-chat-identity.js'
 
+// #570 P0c — the exemption is decided by the RESOLVED TARGET, not raw path presence.
+test('#570 selectorTargetsNonActiveWorkflow: exempt ONLY when the selector resolves to a NON-active open workflow', () => {
+  const active = { path: 'workflows/foo.json' }
+  const other = { path: 'workflows/bar.json' }
+  // Resolves to a DIFFERENT open workflow → non-active → exempt (true).
+  assert.equal(selectorTargetsNonActiveWorkflow({ resolved: other, active }), true)
+  // Resolves to the ACTIVE workflow (incl. after an in-place replacement at the same path: the
+  // active object is what the selector lands on) → NOT exempt (false) → will be fenced.
+  assert.equal(selectorTargetsNonActiveWorkflow({ resolved: active, active }), false)
+  // Resolves to NOTHING → can't prove non-active → NOT exempt (false) → fenced (fail-closed).
+  assert.equal(selectorTargetsNonActiveWorkflow({ resolved: null, active }), false)
+  assert.equal(selectorTargetsNonActiveWorkflow({ resolved: undefined, active }), false)
+})
+
 // #570 P0c — the panel fence must cover ALL four active-workflow mutators, not just graph_*,
 // so a panel advertising enforces_workflow_stamp honestly fences everything the server admits.
 test('#570 fence applies to every graph_* op and all four workflow mutators (active-workflow ops)', () => {
@@ -20,22 +35,23 @@ test('#570 fence applies to every graph_* op and all four workflow mutators (act
   assert.equal(activeWorkflowFenceApplies({ cmd: 'graph_get_state' }), true) // reads harmlessly fenced too
   assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_save' }), true)
   assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_save_as' }), true)
-  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_rename' }), true) // no explicit path
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_rename' }), true) // path-less ⇒ active
   assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_close' }), true)
-  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_close', pathArg: '' }), true) // empty ⇒ active
-  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_close', pathArg: '  ' }), true) // whitespace ⇒ active
+  // A rename/close whose selector RESOLVED to the active workflow is fenced (the P0: an explicit
+  // path that, after in-place replacement, names the active workflow).
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_close', targetsNonActive: false }), true)
 })
 
-test('#570 fence does NOT apply to pinned / navigation / explicit-path workflow ops', () => {
+test('#570 fence does NOT apply to pinned / navigation / resolved-non-active workflow ops', () => {
   // Pinned → the #349 workflow_path guard is the authority.
   assert.equal(activeWorkflowFenceApplies({ cmd: 'graph_add_node', hasPin: true }), false)
   assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_close', hasPin: true }), false)
   // Navigation / creation.
   assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_open' }), false)
   assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_new' }), false)
-  // Explicit non-empty path arg names a deterministic non-active target (must not be fenced to active).
-  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_close', pathArg: 'workflows/other.json' }), false)
-  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_rename', pathArg: 'workflows/a.json' }), false)
+  // Selector RESOLVED to a genuinely non-active open workflow → deterministic target → runs.
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_close', targetsNonActive: true }), false)
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_rename', targetsNonActive: true }), false)
 })
 
 // #570 — WORKFLOW-INSTANCE FENCE. A command stamped for workflow A must not execute against

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test'
 
 import {
   activeWorkflowFenceApplies,
+  selectorSearchIncludesListed,
   selectorTargetsNonActiveWorkflow,
   commandWorkflowMismatch,
   isThreadInScope,
@@ -26,6 +27,23 @@ test('#570 selectorTargetsNonActiveWorkflow: exempt ONLY when the selector resol
   // Resolves to NOTHING → can't prove non-active → NOT exempt (false) → fenced (fail-closed).
   assert.equal(selectorTargetsNonActiveWorkflow({ resolved: null, active }), false)
   assert.equal(selectorTargetsNonActiveWorkflow({ resolved: undefined, active }), false)
+})
+
+test('#570 P1: the fence/executor selector scope includes CLOSED-but-listed workflows for rename, open-only for close', () => {
+  // The shared resolver keys the search collection on this, so the fence resolves over EXACTLY
+  // what the executor searches — rename over [...openWorkflows, ...workflows], close over open only.
+  assert.equal(selectorSearchIncludesListed('workflow_rename'), true)
+  assert.equal(selectorSearchIncludesListed('workflow_close'), false)
+})
+
+test('#570 P1: a CLOSED-but-listed rename target (resolved via the executor collection) is exempt (not over-fenced)', () => {
+  // workflow_rename resolves over [...openWorkflows, ...workflows], so a target present only in
+  // `workflows` (closed but listed) DOES resolve to a genuine non-active workflow — the executor
+  // would rename it — so the fence must exempt it. Models the resolved record the shared helper
+  // returns for that selector (a real record distinct from the active object).
+  const active = { path: 'workflows/foo.json' } // active canvas
+  const closedButListed = { path: 'workflows/archived.json' } // only in s.workflows, not openWorkflows
+  assert.equal(selectorTargetsNonActiveWorkflow({ resolved: closedButListed, active }), true)
 })
 
 // #570 P0c — the panel fence must cover ALL four active-workflow mutators, not just graph_*,

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  commandWorkflowMismatch,
   isThreadInScope,
   isWorkflowCreationLoad,
   normalizedWorkflowPath,
@@ -10,6 +11,29 @@ import {
   shouldForkInPlaceReload,
   workflowAliasForPath
 } from '../../web/js/lib/workflow-chat-identity.js'
+
+// #570 — WORKFLOW-INSTANCE FENCE. A command stamped for workflow A must not execute against
+// a canvas the user has since switched to (B). The generation-bound-command leak: the server
+// cannot retract a delivered frame, so the panel declines to apply a stale one.
+test('#570 fence: stamped uuid matches the active workflow → execute', () => {
+  assert.equal(commandWorkflowMismatch({ commandUuid: 'uuid-A', activeUuid: 'uuid-A' }), false)
+})
+
+test('#570 fence: stamped uuid differs from active (post-switch) → REJECT (no cross-apply)', () => {
+  assert.equal(commandWorkflowMismatch({ commandUuid: 'uuid-A', activeUuid: 'uuid-B' }), true)
+})
+
+test('#570 fence: stamped uuid but active is UNRESOLVABLE → REJECT (fail closed, #186)', () => {
+  assert.equal(commandWorkflowMismatch({ commandUuid: 'uuid-A', activeUuid: undefined }), true)
+  assert.equal(commandWorkflowMismatch({ commandUuid: 'uuid-A', activeUuid: null }), true)
+})
+
+test('#570 fence: NO stamp (old orchestrator / identity-less tab) → never fenced', () => {
+  assert.equal(commandWorkflowMismatch({ commandUuid: undefined, activeUuid: 'uuid-B' }), false)
+  assert.equal(commandWorkflowMismatch({ commandUuid: '', activeUuid: 'uuid-B' }), false)
+  assert.equal(commandWorkflowMismatch({ commandUuid: '   ', activeUuid: 'uuid-B' }), false)
+  assert.equal(commandWorkflowMismatch({}), false)
+})
 
 // #570 — FAIL-CLOSED durability carrier. The embedded graph.extra uuid is only trustworthy
 // when the creation-boundary wrapper (the sanitizer that re-mints graph.extra on every copy)

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -6,22 +6,26 @@ import {
   isWorkflowCreationLoad,
   normalizedWorkflowPath,
   shouldForkEmbeddedWorkflowUuid,
-  trustedUnsavedEmbeddedUuid,
+  shouldForkInPlaceReload,
   workflowAliasForPath
 } from '../../web/js/lib/workflow-chat-identity.js'
 
-// #570 P0b — trust an unsaved workflow's embedded uuid ONLY when it carries the fork marker.
-test('#570 P0b a MARKED embedded uuid is trusted (fork-minted → unique per-instance)', () => {
-  assert.equal(trustedUnsavedEmbeddedUuid({ embeddedId: 'uuid-A', embeddedOwned: true }), 'uuid-A')
+// #570 P0b — an in-place load into an existing object must FORK when the content identity
+// changed; a stale object-cache must never override the newly-loaded graph identity.
+test('#570 P0b in-place replace (cached uuid, DIFFERENT incoming) → fork', () => {
+  assert.equal(shouldForkInPlaceReload({ cachedUuid: 'uuid-A', incomingUuid: 'uuid-B' }), true)
+  // Incoming has no embedded uuid at all → still fork (can't prove same content).
+  assert.equal(shouldForkInPlaceReload({ cachedUuid: 'uuid-A', incomingUuid: undefined }), true)
 })
 
-test('#570 P0b a LEGACY unmarked embedded uuid is NOT trusted → fork (null)', () => {
-  // A pre-rollout copy carries the source uuid with no marker → must not be adopted.
-  assert.equal(trustedUnsavedEmbeddedUuid({ embeddedId: 'uuid-A', embeddedOwned: false }), null)
-  assert.equal(trustedUnsavedEmbeddedUuid({ embeddedId: 'uuid-A' }), null)
-  // No embedded id at all → null (mint fresh).
-  assert.equal(trustedUnsavedEmbeddedUuid({ embeddedOwned: true }), null)
-  assert.equal(trustedUnsavedEmbeddedUuid({}), null)
+test('#570 P0b same content reloaded/undone (cached === incoming) → keep', () => {
+  assert.equal(shouldForkInPlaceReload({ cachedUuid: 'uuid-A', incomingUuid: 'uuid-A' }), false)
+})
+
+test('#570 P0b a fresh object (no cache) is NOT an in-place replace here → false', () => {
+  // A brand-new object (reload-restore/copy) has no cache; creation/embedded handling covers it.
+  assert.equal(shouldForkInPlaceReload({ cachedUuid: undefined, incomingUuid: 'uuid-A' }), false)
+  assert.equal(shouldForkInPlaceReload({}), false)
 })
 
 // Fakes for the ComfyWorkflow 4th arg: a REUSE passes a ComfyWorkflow OBJECT; a CREATION

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  activeWorkflowFenceApplies,
   commandWorkflowMismatch,
   isThreadInScope,
   isWorkflowCreationLoad,
@@ -11,6 +12,31 @@ import {
   shouldForkInPlaceReload,
   workflowAliasForPath
 } from '../../web/js/lib/workflow-chat-identity.js'
+
+// #570 P0c — the panel fence must cover ALL four active-workflow mutators, not just graph_*,
+// so a panel advertising enforces_workflow_stamp honestly fences everything the server admits.
+test('#570 fence applies to every graph_* op and all four workflow mutators (active-workflow ops)', () => {
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'graph_add_node' }), true)
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'graph_get_state' }), true) // reads harmlessly fenced too
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_save' }), true)
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_save_as' }), true)
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_rename' }), true) // no explicit path
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_close' }), true)
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_close', pathArg: '' }), true) // empty ⇒ active
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_close', pathArg: '  ' }), true) // whitespace ⇒ active
+})
+
+test('#570 fence does NOT apply to pinned / navigation / explicit-path workflow ops', () => {
+  // Pinned → the #349 workflow_path guard is the authority.
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'graph_add_node', hasPin: true }), false)
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_close', hasPin: true }), false)
+  // Navigation / creation.
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_open' }), false)
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_new' }), false)
+  // Explicit non-empty path arg names a deterministic non-active target (must not be fenced to active).
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_close', pathArg: 'workflows/other.json' }), false)
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_rename', pathArg: 'workflows/a.json' }), false)
+})
 
 // #570 — WORKFLOW-INSTANCE FENCE. A command stamped for workflow A must not execute against
 // a canvas the user has since switched to (B). The generation-bound-command leak: the server

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -37,6 +37,17 @@ test('#570 the panel\'s own same-workflow reload opts out via noFork (snapshot r
   assert.equal(isWorkflowCreationLoad({ workflowArg: 'x.json', openSource: 'file_button', noFork: true }), false)
 })
 
+test('#570 FAIL-SAFE: an unrecognized/mis-shaped object 4th arg is forked (bias to fork)', () => {
+  // A real reuse passes a ComfyWorkflow with a string `path`; anything else — an object
+  // WITHOUT a path, or an array — is ambiguous and must fork rather than risk inheriting.
+  assert.equal(isWorkflowCreationLoad({ workflowArg: {} }), true)
+  assert.equal(isWorkflowCreationLoad({ workflowArg: { notAPath: 1 } }), true)
+  assert.equal(isWorkflowCreationLoad({ workflowArg: { path: 123 } }), true) // path not a string
+  assert.equal(isWorkflowCreationLoad({ workflowArg: [] }), true)
+  // Only a ComfyWorkflow-shaped object (string path) is trusted as a reuse.
+  assert.equal(isWorkflowCreationLoad({ workflowArg: { path: 'workflows/x.json' } }), false)
+})
+
 test('normalizes Windows paths for stable identity comparisons', () => {
   assert.equal(
     normalizedWorkflowPath('Workflows\\Portrait.JSON'),

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -32,15 +32,17 @@ test('#570 a new workflow reusing a freed path slot does NOT inherit the old uui
   assert.equal(r.changed, true)
 })
 
-test('#570 lenient path-only fallback when a graph id is unavailable', () => {
-  // gid unknown on either side → key on the path alone (best-effort durability).
-  assert.equal(resolveUnsavedWorkflowUuid({ stored: { u: 'u', g: '' }, gid: 'g', mint: 'm' }).uuid, 'u')
-  assert.equal(resolveUnsavedWorkflowUuid({ stored: { u: 'u', g: 'g' }, gid: '', mint: 'm' }).uuid, 'u')
+test('#570 FAILS CLOSED when a graph id is unavailable (mints fresh, never path-only reuse)', () => {
+  // A missing gid on either side can't prove continuity — reusing by path alone would
+  // let a new workflow inherit a closed one that reused the path slot. Mint fresh.
+  assert.equal(resolveUnsavedWorkflowUuid({ stored: { u: 'u', g: '' }, gid: 'g', mint: 'm' }).uuid, 'm')
+  assert.equal(resolveUnsavedWorkflowUuid({ stored: { u: 'u', g: 'g' }, gid: '', mint: 'm' }).uuid, 'm')
 })
 
-test('#570 a read-only probe (no mint) returns null on a miss/mismatch', () => {
+test('#570 a read-only probe (no mint) returns null unless BOTH graph ids match', () => {
   assert.equal(resolveUnsavedWorkflowUuid({ stored: null, gid: 'g' }).uuid, null)
   assert.equal(resolveUnsavedWorkflowUuid({ stored: { u: 'u', g: 'gid-old' }, gid: 'gid-new' }).uuid, null)
+  assert.equal(resolveUnsavedWorkflowUuid({ stored: { u: 'u', g: '' }, gid: 'g' }).uuid, null)
   assert.equal(resolveUnsavedWorkflowUuid({ stored: { u: 'u', g: 'g' }, gid: 'g' }).uuid, 'u')
 })
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9401,19 +9401,22 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // match the active workflow's uuid (fail closed when unresolvable, #186). This covers
             // EVERY active-canvas op — graph_* AND the four workflow mutators — matching the
             // server's enforcement contract (a panel advertising enforces_workflow_stamp fences
-            // all of them, not only graph commands). activeWorkflowFenceApplies() scopes OUT the
-            // NON-active-workflow ops: a pinned command (workflow_path → #349 guard below),
-            // navigation/creation (workflow_open/new), and a path-selectored workflow_rename/close
-            // whose selector RESOLVES to a genuinely non-active OPEN workflow.
+            // all of them, not only graph commands).
             //
-            // Decide the rename/close exemption by the RESOLVED TARGET, never by raw path presence:
-            // resolve the selector the same way the executor will (openWorkflows.find) and exempt
-            // ONLY when it lands on a real open workflow that is NOT the active one. A non-empty
-            // path that resolves to the ACTIVE workflow — e.g. its file was replaced IN PLACE with
-            // a different workflow at the same path — still hits the active canvas, so it is fenced.
+            // PINNED commands are fenced TOO (codex): the #349 pin guard below authorizes by
+            // PATH, which can't tell workflow A from a different B saved to the SAME path after an
+            // in-place replacement — the stale command's workflow_path still matches but its uuid
+            // does not, and only this uuid fence catches it. The pin guard stays as an ADDITIONAL
+            // check (it catches a switch to a different PATH); both must pass.
+            //
+            // activeWorkflowFenceApplies() exempts only the genuinely-non-active ops: navigation/
+            // creation (workflow_open/new) and a path-selectored workflow_rename/close whose
+            // selector RESOLVES to a non-active OPEN workflow. Decide that by the RESOLVED TARGET,
+            // never raw path presence: resolve the selector the same way the executor will
+            // (openWorkflows.find) and exempt ONLY when it lands on a real open workflow that is
+            // NOT the active one — a path that resolves to the ACTIVE workflow (e.g. replaced in
+            // place at the same path) still hits the active canvas, so it is fenced.
             const commandUuid = msg?.[WORKFLOW_UUID_FIELD];
-            const explicitTargetPath = msg?.[WORKFLOW_PATH_FIELD];
-            const hasPin = typeof explicitTargetPath === "string" && explicitTargetPath.trim();
             let targetsNonActive = false;
             if (msg.cmd === "workflow_rename" || msg.cmd === "workflow_close") {
               const pathArg = typeof msg?.path === "string" ? msg.path.trim() : "";
@@ -9425,7 +9428,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
               }
             }
             if (
-              activeWorkflowFenceApplies({ cmd: msg.cmd, hasPin: Boolean(hasPin), targetsNonActive }) &&
+              activeWorkflowFenceApplies({ cmd: msg.cmd, targetsNonActive }) &&
               commandWorkflowMismatch({ commandUuid, activeUuid: workflowStableUuid() })
             ) {
               throw new Error(

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -99,7 +99,7 @@ import {
   isWorkflowCreationLoad,
   normalizedWorkflowPath,
   shouldForkEmbeddedWorkflowUuid,
-  trustedUnsavedEmbeddedUuid,
+  shouldForkInPlaceReload,
   workflowAliasForPath,
   workflowIdentityForms,
 } from "./lib/workflow-chat-identity.js";
@@ -969,13 +969,6 @@ const _workflowUuidOwners = new Map();
 const WORKFLOW_UUID_ALIASES_KEY = "comfyui-mcp.panel.workflowUuidAliases";
 const WORKFLOW_META_NAMESPACE = "comfyui_mcp";
 const WORKFLOW_UUID_FIELD = "workflow_uuid";
-// #570 P0b — marker proving the embedded uuid was MINTED by our fork mechanism (the
-// create-boundary loadGraphData wrapper, or the unsaved-branch fork), so it is a UNIQUE
-// per-instance identity. A pre-rollout/legacy embedded uuid (written by the old transcript
-// recorder, which never set this) may be a DUPLICATE carried by a copied/imported graph —
-// a creation-time-only fork can't repair those, so on load of an UNSAVED graph we trust the
-// embedded uuid ONLY when this marker is present, and otherwise FORK to a fresh identity.
-const WORKFLOW_UUID_OWNED_FIELD = "workflow_uuid_forked";
 const WORKFLOW_PATH_FIELD = "workflow_path";
 let _workflowUuidAliases = (() => {
   try {
@@ -1066,14 +1059,6 @@ function embeddedWorkflowUuid(wf = activeWorkflowRef()) {
   return typeof id === "string" && id ? id : null;
 }
 
-// #570 P0b — true only when the embedded uuid carries our fork-ownership marker (minted by
-// the create-boundary wrapper or the unsaved-branch fork). A legacy/pre-rollout embed lacks
-// it, so it must not be trusted as a unique per-instance identity.
-function embeddedWorkflowUuidOwned(wf = activeWorkflowRef()) {
-  const ns = activeWorkflowExtra(wf)?.[WORKFLOW_META_NAMESPACE];
-  return ns?.[WORKFLOW_UUID_OWNED_FIELD] === true;
-}
-
 function embeddedWorkflowPath(wf = activeWorkflowRef()) {
   const ns = activeWorkflowExtra(wf)?.[WORKFLOW_META_NAMESPACE];
   const path = ns?.[WORKFLOW_PATH_FIELD];
@@ -1107,20 +1092,39 @@ function installCreateBoundaryFork(appRef) {
     const orig = appRef.loadGraphData.bind(appRef);
     appRef.loadGraphData = function (graphData, clean, restoreView, workflow, options = {}) {
       try {
-        const creation = isWorkflowCreationLoad({
-          workflowArg: workflow,
-          openSource: options ? options.openSource : undefined,
-          noFork: Boolean(options && options.__cmcpNoFork),
-        });
-        if (creation && graphData && typeof graphData === "object" && !Array.isArray(graphData)) {
-          const extra =
-            graphData.extra && typeof graphData.extra === "object" ? graphData.extra : (graphData.extra = {});
-          const prev = extra[WORKFLOW_META_NAMESPACE];
-          extra[WORKFLOW_META_NAMESPACE] = {
-            ...(prev && typeof prev === "object" ? prev : {}),
-            [WORKFLOW_UUID_FIELD]: crypto.randomUUID(),
-            [WORKFLOW_UUID_OWNED_FIELD]: true, // fork-minted → a unique per-instance identity
-          };
+        if (graphData && typeof graphData === "object" && !Array.isArray(graphData)) {
+          const noFork = Boolean(options && options.__cmcpNoFork);
+          const creation =
+            !noFork &&
+            isWorkflowCreationLoad({ workflowArg: workflow, openSource: options ? options.openSource : undefined });
+          // #570 P0b — a stale PER-OBJECT uuid cache must NEVER override the identity of the
+          // newly-loaded content, and we KEEP nothing derived from the copyable graph.extra.
+          //  • CREATION (import/paste/duplicate/new) → mint a fresh identity.
+          //  • IN-PLACE load into an EXISTING object whose cached uuid DIFFERS from the incoming
+          //    graph's embedded uuid (or the incoming has none) → the workflow was REPLACED in
+          //    place: INVALIDATE the object cache and mint fresh, so the replacement can't keep
+          //    the prior instance's identity. The embedded value is used ONLY to DETECT the
+          //    change; the minted uuid is fresh (never adopted from graph.extra).
+          let fork = false;
+          if (creation) {
+            fork = true;
+          } else if (!noFork && workflow && typeof workflow === "object") {
+            const cached = _workflowObjectUuids.get(workflow);
+            const incoming = graphData.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD];
+            if (shouldForkInPlaceReload({ cachedUuid: cached, incomingUuid: incoming })) {
+              _workflowObjectUuids.delete(workflow); // content replaced in place → drop stale cache
+              fork = true;
+            }
+          }
+          if (fork) {
+            const extra =
+              graphData.extra && typeof graphData.extra === "object" ? graphData.extra : (graphData.extra = {});
+            const prev = extra[WORKFLOW_META_NAMESPACE];
+            extra[WORKFLOW_META_NAMESPACE] = {
+              ...(prev && typeof prev === "object" ? prev : {}),
+              [WORKFLOW_UUID_FIELD]: crypto.randomUUID(),
+            };
+          }
         }
       } catch {
         // Never let identity bookkeeping break a graph load.
@@ -1163,30 +1167,24 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
   const path = savedWorkflowPath(wf);
   const objectUuid = _workflowObjectUuids.get(identityObject);
 
-  // #570 P0/P1 — UNSAVED workflow: the durable per-instance identity is the EMBEDDED
-  // graph.extra uuid, which installCreateBoundaryFork REGENERATES at every creation
-  // (import/paste/duplicate/new) — so it is fresh for a copy yet round-tripped verbatim by
-  // ComfyUI's draft persistence across a reload (durable regardless of chat scope). Prefer
-  // the in-session objectUuid, then the embedded uuid — but TRUST the embedded uuid ONLY
-  // when it carries our fork-ownership marker (WORKFLOW_UUID_OWNED_FIELD). A pre-rollout /
-  // legacy embedded uuid (no marker) may be a DUPLICATE carried by a graph copied/imported
-  // BEFORE the create-boundary fork existed — a creation-time-only fork can't repair those,
-  // so FORK it here (mint fresh) rather than adopt the source's identity (#570 P0b). This is
-  // a one-time strip on the first unsaved load post-upgrade: a lost resume, never a
-  // cross-workflow leak. We then STAMP uuid + marker so a reload trusts it thereafter, and
-  // it stays distinct per live object so two concurrently-open copies never collide.
+  // #570 P0/P1 — UNSAVED workflow: the per-instance identity is the in-session objectUuid
+  // (the LIVE-object WeakMap — a copy/import does NOT share it), else the EMBEDDED graph.extra
+  // uuid for DURABILITY across a reload. Ownership/KEEP is anchored on the live object: the
+  // loadGraphData wrapper INVALIDATES a stale object-cache and re-mints whenever the content
+  // loaded into an existing instance changes (in-place replace), and forks every creation —
+  // so the embedded uuid can only survive as a genuine reload of the SAME content, never a
+  // copy or an in-place replacement. We therefore read the embedded uuid ONLY when the object
+  // cache is empty (a fresh reload), and never let it override a live cache.
   const isUnsaved = !path && wf && wf.isPersisted !== true;
   if (isUnsaved) {
     const embeddedId = embeddedWorkflowUuid(wf);
-    const embeddedOwned = embeddedWorkflowUuidOwned(wf);
-    const trustedEmbedded = trustedUnsavedEmbeddedUuid({ embeddedId, embeddedOwned }); // legacy/unmarked → null → fork
-    const id = objectUuid || trustedEmbedded || crypto.randomUUID();
+    const id = objectUuid || embeddedId || crypto.randomUUID();
     _workflowObjectUuids.set(identityObject, id);
     rememberWorkflowUuidOwner(id, identityObject);
-    if (embeddedId !== id || !embeddedOwned) {
-      // Persist the identity + ownership marker into extra (so a reload keeps + trusts it,
-      // AND a later SAVE carries it into the saved file across the tmp:→wf: transition).
-      // Never dirties the graph.
+    if (embeddedId !== id) {
+      // Persist the identity into extra (so a reload of the SAME content keeps it, AND a later
+      // SAVE carries it into the saved file across the tmp:→wf: transition). Never dirties the
+      // graph. Not a KEEP authority — the wrapper's live-object invalidation is.
       try {
         const extra = activeWorkflowExtra(wf, { create: true });
         const previous = extra?.[WORKFLOW_META_NAMESPACE];
@@ -1194,7 +1192,6 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
           extra[WORKFLOW_META_NAMESPACE] = {
             ...(previous && typeof previous === "object" ? previous : {}),
             [WORKFLOW_UUID_FIELD]: id,
-            [WORKFLOW_UUID_OWNED_FIELD]: true,
           };
         }
       } catch {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -96,6 +96,7 @@ import {
 } from "./lib/chat-history-store.js";
 import {
   classifyPinnedTarget,
+  commandWorkflowMismatch,
   isWorkflowCreationLoad,
   normalizedWorkflowPath,
   resolveUnsavedInstanceUuid,
@@ -9352,6 +9353,25 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           } else {
             const executor = GRAPH_TOOL_EXECUTORS[msg.cmd];
             if (!executor) throw new Error(`Unknown command "${msg.cmd}"`);
+            // WORKFLOW-INSTANCE FENCE (#570): the orchestrator stamps each command with the
+            // trusted per-instance workflow_uuid it was ISSUED FOR. Every executor runs
+            // against the ACTIVE canvas, so a command that arrives AFTER the user switched or
+            // replaced the workflow (a frame the server already delivered and cannot retract)
+            // would silently mutate the WRONG graph. Refuse when the stamped uuid does not
+            // match the active workflow's uuid (fail closed when unresolvable, #186). This
+            // catches the CURRENT-mode leak that the workflow_path pin guard below cannot —
+            // a default (unpinned) session carries no path but still must not cross-apply.
+            const commandUuid = msg?.[WORKFLOW_UUID_FIELD];
+            if (
+              commandWorkflowMismatch({ commandUuid, activeUuid: workflowStableUuid() })
+            ) {
+              throw new Error(
+                `workflow instance mismatch: this command targets a different workflow than the ` +
+                  `active canvas — the workflow was switched or replaced after it was issued. ` +
+                  `Re-select the intended workflow (panel_open_workflow) or re-target with ` +
+                  `panel_set_workflow_target({mode:"current"}), then retry.`,
+              );
+            }
             // PINNED-TARGET GUARD (#349): a `workflow_path` on the command means the
             // agent's session is pinned to a SPECIFIC workflow. But every executor
             // runs against the ACTIVE canvas (getGraphCtx = app.canvas.graph) — the

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -97,6 +97,7 @@ import {
 import {
   classifyPinnedTarget,
   normalizedWorkflowPath,
+  resolveUnsavedWorkflowUuid,
   shouldForkEmbeddedWorkflowUuid,
   workflowAliasForPath,
   workflowIdentityForms,
@@ -965,6 +966,26 @@ const _priorTempWorkflowIds = new WeakMap();
 const _workflowObjectUuids = new WeakMap();
 const _workflowUuidOwners = new Map();
 const WORKFLOW_UUID_ALIASES_KEY = "comfyui-mcp.panel.workflowUuidAliases";
+// #570 P0b/P1 — durable per-instance uuid for an UNSAVED workflow, keyed on the pair
+// (ComfyUI tab path, reload-stable graph id). An unsaved workflow's `path`
+// ("workflows/Unsaved Workflow.json") is reused verbatim when ITS tab is restored on a
+// reload, but DEDUPED ("... (2).json") for a fresh import/duplicate — so keying on the
+// path both keeps the identity across a reload (P1) and mints a fresh one for a cold
+// import that merely carries a SOURCE workflow's embedded uuid (P0b). The graph id
+// (activeState.id, reload-stable but import-PRESERVED) is a second guard: a DIFFERENT
+// new unsaved workflow that later REUSES a freed path slot has a different graph id, so
+// it can't inherit the closed workflow's identity. Persisted in localStorage; graph
+// `extra` is deliberately NOT the source of truth for unsaved tabs (a copy carries it).
+const WORKFLOW_UNSAVED_IDS_KEY = "comfyui-mcp.panel.unsavedWorkflowIds";
+const WORKFLOW_UNSAVED_IDS_CAP = 200; // bound growth (keyed by transient unsaved paths)
+let _unsavedWorkflowIds = (() => {
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(WORKFLOW_UNSAVED_IDS_KEY) || "{}");
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+})();
 const WORKFLOW_META_NAMESPACE = "comfyui_mcp";
 const WORKFLOW_UUID_FIELD = "workflow_uuid";
 const WORKFLOW_PATH_FIELD = "workflow_path";
@@ -1071,6 +1092,62 @@ function persistWorkflowAliases() {
   }
 }
 
+// #570 P0b/P1 — the ComfyUI tab path of an UNSAVED (never-saved) workflow, e.g.
+// "workflows/Unsaved Workflow.json". Reload-stable (restored to the SAME path) and
+// import-distinct (a fresh open/duplicate is deduped to "... (2).json"). null for a
+// saved tab (which uses savedWorkflowPath) or when no path is exposed.
+function unsavedWorkflowPath(wf) {
+  if (!wf || wf.isPersisted === true) return null;
+  return typeof wf.path === "string" && wf.path ? wf.path : null;
+}
+
+// The reload-stable, per-workflow graph id ComfyUI mints (activeState.id via
+// ensureWorkflowId). It is PRESERVED across an import/copy (so it can't tell a copy
+// from the original by itself), but it DOES differ between two genuinely different
+// unsaved workflows — the guard that stops a new workflow reusing a freed path slot
+// from inheriting the closed workflow's uuid. "" when unavailable (older format).
+function unsavedWorkflowGraphId(wf) {
+  try {
+    const id = wf?.activeState?.id ?? wf?.initialState?.id ?? wf?.workflow?.id ?? null;
+    return typeof id === "string" && id ? id : "";
+  } catch {
+    return "";
+  }
+}
+
+function persistUnsavedWorkflowIds() {
+  try {
+    // Bound growth: unsaved paths are transient, so evict arbitrary old entries when
+    // over the cap (a dropped entry only costs a lost resume for a long-idle tab).
+    const keys = Object.keys(_unsavedWorkflowIds);
+    if (keys.length > WORKFLOW_UNSAVED_IDS_CAP) {
+      for (const k of keys.slice(0, keys.length - WORKFLOW_UNSAVED_IDS_CAP)) delete _unsavedWorkflowIds[k];
+    }
+    window.localStorage.setItem(WORKFLOW_UNSAVED_IDS_KEY, JSON.stringify(_unsavedWorkflowIds));
+  } catch {
+    // In-memory identity still holds for this session.
+  }
+}
+
+// Resolve (and optionally persist) the durable uuid for an unsaved workflow at
+// (path, gid) via the pure resolveUnsavedWorkflowUuid. A read-only probe (no `assign`)
+// returns the stored uuid only when it names the SAME instance, else null; with
+// `assign` it adopts that fresh uuid on a miss and persists the (path,gid) entry.
+function unsavedWorkflowUuid(path, gid, assign) {
+  if (!path) return assign ?? null;
+  const stored = _unsavedWorkflowIds[path] || null;
+  const { uuid, changed } = resolveUnsavedWorkflowUuid({
+    stored,
+    gid,
+    mint: assign === undefined ? null : assign,
+  });
+  if (assign !== undefined && changed && uuid) {
+    _unsavedWorkflowIds[path] = { u: uuid, g: gid || "" };
+    persistUnsavedWorkflowIds();
+  }
+  return uuid;
+}
+
 function workflowUuidOwner(id) {
   const stored = _workflowUuidOwners.get(id);
   const owner = stored && typeof stored.deref === "function" ? stored.deref() ?? null : stored ?? null;
@@ -1099,6 +1176,39 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
   if (!identityObject || typeof identityObject !== "object") return getTabId();
   const path = savedWorkflowPath(wf);
   const objectUuid = _workflowObjectUuids.get(identityObject);
+
+  // #570 P0b/P1 — UNSAVED workflow: the DURABLE, import-distinct identity is the panel's
+  // own (path, graph-id) alias, NOT the embedded graph.extra uuid (which a COPIED graph
+  // carries verbatim → cross-resume). Resolve from that alias; a cold import (new deduped
+  // path) or a path-slot reuse (different graph id) misses → mint fresh; a reload (same
+  // path + graph id) hits → same uuid. The embedded uuid is deliberately ignored here.
+  const unsavedPath = path ? null : unsavedWorkflowPath(wf);
+  if (unsavedPath) {
+    const gid = unsavedWorkflowGraphId(wf);
+    const resolved = objectUuid || unsavedWorkflowUuid(unsavedPath, gid) || crypto.randomUUID();
+    const id = unsavedWorkflowUuid(unsavedPath, gid, resolved); // persist/refresh the alias
+    _workflowObjectUuids.set(identityObject, id);
+    rememberWorkflowUuidOwner(id, identityObject);
+    if (embed) {
+      // Keep writing the in-graph metadata (harmless — not authoritative for an unsaved
+      // tab) so a subsequent user-initiated SAVE carries the identity into the saved
+      // file and the conversation survives the tmp:→wf: transition.
+      try {
+        const extra = activeWorkflowExtra(wf, { create: true });
+        const previous = extra?.[WORKFLOW_META_NAMESPACE];
+        if (extra && previous?.[WORKFLOW_UUID_FIELD] !== id) {
+          extra[WORKFLOW_META_NAMESPACE] = {
+            ...(previous && typeof previous === "object" ? previous : {}),
+            [WORKFLOW_UUID_FIELD]: id,
+          };
+        }
+      } catch {
+        // The (path, graph-id) alias still makes the identity durable in this browser.
+      }
+    }
+    return id;
+  }
+
   const embedded = embeddedWorkflowUuid(wf);
   const embeddedPath = embeddedWorkflowPath(wf);
   const pathAlias = workflowAliasForPath(_workflowUuidAliases, path);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9391,15 +9391,26 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             const executor = GRAPH_TOOL_EXECUTORS[msg.cmd];
             if (!executor) throw new Error(`Unknown command "${msg.cmd}"`);
             // WORKFLOW-INSTANCE FENCE (#570): the orchestrator stamps each command with the
-            // trusted per-instance workflow_uuid it was ISSUED FOR. Every executor runs
-            // against the ACTIVE canvas, so a command that arrives AFTER the user switched or
-            // replaced the workflow (a frame the server already delivered and cannot retract)
-            // would silently mutate the WRONG graph. Refuse when the stamped uuid does not
-            // match the active workflow's uuid (fail closed when unresolvable, #186). This
-            // catches the CURRENT-mode leak that the workflow_path pin guard below cannot —
-            // a default (unpinned) session carries no path but still must not cross-apply.
+            // trusted per-instance workflow_uuid it was ISSUED FOR. A command that mutates the
+            // ACTIVE workflow but arrives AFTER the user switched or replaced it (a frame the
+            // server already delivered and cannot retract) would hit the WRONG workflow —
+            // including workflow_close discarding the new workflow's unsaved work. Refuse when
+            // the stamped uuid does not match the active workflow's uuid (fail closed when
+            // unresolvable, #186). Scope, so navigation and pinned edits are not falsely fenced:
+            //  • an explicit workflow_path names a SPECIFIC target → the #349 pin guard below is
+            //    its authority (covers pinned graph_* and path-targeted workflow_* ops);
+            //  • workflow_open / workflow_new are navigation/creation with their OWN explicit or
+            //    new target, not an active-content mutation, so the stamp must not gate them.
+            // Everything else (unpinned graph_* + path-less workflow_save/save_as/rename/close +
+            // reads) runs against the active canvas and IS fenced.
             const commandUuid = msg?.[WORKFLOW_UUID_FIELD];
+            const explicitTargetPath = msg?.[WORKFLOW_PATH_FIELD];
+            const hasExplicitTarget =
+              typeof explicitTargetPath === "string" && explicitTargetPath.trim();
+            const isNavigationOrCreate = msg.cmd === "workflow_open" || msg.cmd === "workflow_new";
             if (
+              !hasExplicitTarget &&
+              !isNavigationOrCreate &&
               commandWorkflowMismatch({ commandUuid, activeUuid: workflowStableUuid() })
             ) {
               throw new Error(

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -100,7 +100,7 @@ import {
   commandWorkflowMismatch,
   selectorSearchIncludesListed,
   selectorTargetsNonActiveWorkflow,
-  isWorkflowCreationLoad,
+  isNewWorkflowLoad,
   normalizedWorkflowPath,
   resolveUnsavedInstanceUuid,
   shouldForkEmbeddedWorkflowUuid,
@@ -1101,7 +1101,7 @@ function persistWorkflowAliases() {
 // "Unsaved Workflow.json" path, so without this a copy would present the source's identity
 // and inherit its session (the reopened cross-resume). Regenerating at creation makes the
 // embedded uuid a trustworthy per-instance identity: fresh for a copy, and round-tripped
-// verbatim by ComfyUI's draft persistence across a reload (durable — P1). isWorkflowCreationLoad
+// verbatim by ComfyUI's draft persistence across a reload (durable — P1). isNewWorkflowLoad
 // reads the discriminators (loadGraphData's 4th `workflow` arg is a ComfyWorkflow object only
 // on a REUSE; creations pass null/undefined/string; external imports also set openSource).
 // loadGraphData clones graphData internally AFTER we mutate, so our stamp flows into configure.
@@ -1127,7 +1127,7 @@ function installCreateBoundaryFork(appRef) {
           const creation =
             !noFork &&
             !keepInstance &&
-            isWorkflowCreationLoad({ workflowArg: workflow, openSource: options ? options.openSource : undefined });
+            isNewWorkflowLoad({ workflowArg: workflow, openSource: options ? options.openSource : undefined });
           // #570 P0b — a stale PER-OBJECT uuid cache must NEVER override the identity of the
           // newly-loaded content, and we KEEP nothing derived from the copyable graph.extra.
           //  • CREATION (import/paste/duplicate/new) → mint a fresh identity.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1096,8 +1096,19 @@ function installCreateBoundaryFork(appRef) {
       try {
         if (graphData && typeof graphData === "object" && !Array.isArray(graphData)) {
           const noFork = Boolean(options && options.__cmcpNoFork);
+          // #570 P0b — an UNTRUSTED in-place replacement: the agent's graph_load drops
+          // ARBITRARY external JSON onto the ACTIVE workflow object. That JSON's graph.extra
+          // uuid is forgeable/copyable (a copied/exported graph can carry ANY workflow's uuid),
+          // so it must NEVER be adopted as identity — but the load is still an agent tool
+          // running INSIDE the live session on this tab, so changing the tab's identity would
+          // reset the very conversation the agent is executing in. We therefore KEEP the LIVE
+          // OBJECT's identity (the WeakMap value — the only non-forgeable ownership source) and
+          // OVERWRITE the incoming graph.extra uuid with it, stripping the copied value so it
+          // can neither be adopted now nor resurface via the embedded fallback or a later save.
+          const keepInstance = Boolean(options && options.__cmcpKeepInstance);
           const creation =
             !noFork &&
+            !keepInstance &&
             isWorkflowCreationLoad({ workflowArg: workflow, openSource: options ? options.openSource : undefined });
           // #570 P0b — a stale PER-OBJECT uuid cache must NEVER override the identity of the
           // newly-loaded content, and we KEEP nothing derived from the copyable graph.extra.
@@ -1108,7 +1119,20 @@ function installCreateBoundaryFork(appRef) {
           //    the prior instance's identity. The embedded value is used ONLY to DETECT the
           //    change; the minted uuid is fresh (never adopted from graph.extra).
           let fork = false;
-          if (creation) {
+          if (keepInstance && workflow && typeof workflow === "object") {
+            // Authoritative identity = the live object's cached uuid (mint one only if this
+            // object has never been seen). Stamp it over the incoming value; do NOT fork.
+            const cached = _workflowObjectUuids.get(workflow);
+            const authoritative = cached || crypto.randomUUID();
+            if (!cached) _workflowObjectUuids.set(workflow, authoritative);
+            const extra =
+              graphData.extra && typeof graphData.extra === "object" ? graphData.extra : (graphData.extra = {});
+            const prev = extra[WORKFLOW_META_NAMESPACE];
+            extra[WORKFLOW_META_NAMESPACE] = {
+              ...(prev && typeof prev === "object" ? prev : {}),
+              [WORKFLOW_UUID_FIELD]: authoritative,
+            };
+          } else if (creation) {
             fork = true;
           } else if (!noFork && workflow && typeof workflow === "object") {
             const cached = _workflowObjectUuids.get(workflow);
@@ -5856,7 +5880,20 @@ const GRAPH_TOOL_EXECUTORS = {
     // same active tab twice, and a later save 409'd), and a soft-reload-then-
     // reload left graph routing stranded on a frozen Unsaved tab.
     const activeWorkflow = app?.extensionManager?.workflow?.activeWorkflow || null;
-    await app.loadGraphData(...resolveLoadGraphArgs(clone, activeWorkflow));
+    // #570 P0b — this replaces the ACTIVE canvas with UNTRUSTED external JSON in place. Keep
+    // the live workflow instance's identity (so the agent's live session/fence stays intact —
+    // re-minting here would reject the agent's own follow-up commands and reset the very
+    // conversation running this tool) and STRIP the incoming graph.extra uuid so a copied
+    // source uuid is never adopted as this instance's identity. The __cmcpKeepInstance option
+    // only rides the IN-PLACE (active-workflow) load — resolveLoadGraphArgs returns a 4-arg
+    // form then, so options lands in its proper 5th slot; a blank-canvas load (single arg) is
+    // a genuine creation and takes the normal fresh-mint path.
+    const loadArgs = resolveLoadGraphArgs(clone, activeWorkflow);
+    if (activeWorkflow && typeof activeWorkflow === "object") {
+      await app.loadGraphData(...loadArgs, { __cmcpKeepInstance: true });
+    } else {
+      await app.loadGraphData(...loadArgs);
+    }
     return {
       loaded: true,
       node_count: clone.nodes.length,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -98,6 +98,7 @@ import {
   classifyPinnedTarget,
   isWorkflowCreationLoad,
   normalizedWorkflowPath,
+  resolveUnsavedInstanceUuid,
   shouldForkEmbeddedWorkflowUuid,
   shouldForkInPlaceReload,
   workflowAliasForPath,
@@ -1132,9 +1133,18 @@ function installCreateBoundaryFork(appRef) {
       return orig(graphData, clean, restoreView, workflow, options);
     };
     _loadGraphDataForkInstalled = true;
-  } catch {
-    // If wrapping fails, workflowStableUuid's lazy per-object stamping still keeps two
-    // concurrently-open copies distinct — the fork is a durability/robustness upgrade.
+  } catch (err) {
+    // Surface the failure: with the sanitizer inactive, workflowStableUuid fails CLOSED for
+    // unsaved workflows (ignores the copyable embedded uuid, mints fresh per instance). Two
+    // concurrently-open copies stay distinct, but durable resume across a reload is disabled
+    // — a deliberate lost-resume, never a wrong-resume.
+    _loadGraphDataForkInstalled = false;
+    try {
+      console.warn(
+        "[comfyui-mcp] creation-boundary fork failed to install; unsaved-workflow resume disabled (fail-closed)",
+        err,
+      );
+    } catch {}
   }
 }
 
@@ -1177,8 +1187,21 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
   // cache is empty (a fresh reload), and never let it override a live cache.
   const isUnsaved = !path && wf && wf.isPersisted !== true;
   if (isUnsaved) {
+    // FAIL CLOSED on the durability carrier: the embedded graph.extra uuid is trustworthy
+    // ONLY because the creation-boundary wrapper re-mints it on every copy/import/in-place
+    // replace — that sanitizer is what makes a persisted uuid a faithful projection of the
+    // live-object identity rather than a copyable source uuid. If the wrapper is not provably
+    // installed, that guarantee is void, so a pasted/imported graph could still be carrying
+    // the SOURCE's graph.extra uuid; adopting it would cross-resume the source's conversation
+    // (#570). When the sanitizer is inactive we therefore ignore the embedded value entirely
+    // and mint a fresh per-instance uuid — durable resume is disabled (lost-resume), never a
+    // wrong-resume. The live-object WeakMap (objectUuid) is always safe: a copy never shares it.
     const embeddedId = embeddedWorkflowUuid(wf);
-    const id = objectUuid || embeddedId || crypto.randomUUID();
+    const id = resolveUnsavedInstanceUuid({
+      objectUuid,
+      embeddedId,
+      forkActive: _loadGraphDataForkInstalled,
+    });
     _workflowObjectUuids.set(identityObject, id);
     rememberWorkflowUuidOwner(id, identityObject);
     if (embeddedId !== id) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -98,6 +98,7 @@ import {
   activeWorkflowFenceApplies,
   classifyPinnedTarget,
   commandWorkflowMismatch,
+  selectorSearchIncludesListed,
   selectorTargetsNonActiveWorkflow,
   isWorkflowCreationLoad,
   normalizedWorkflowPath,
@@ -1038,6 +1039,21 @@ function workflowRecordMatchesSelector(w, sel) {
     w.key === sel ||
     (typeof w.filename === "string" && w.filename.replace(/\.json$/i, "") === sel)
   );
+}
+
+// #570 — resolve a path/selector to the workflow record a path-selectored active-workflow mutator
+// (workflow_rename / workflow_close) will act on, over the EXACT collection that command's
+// executor searches — so the #570 fence's "does this resolve to the active workflow?" decision
+// matches execution EXACTLY (no over- or under-fencing). workflow_rename can target a
+// closed-but-listed workflow, so it searches openWorkflows + workflows; workflow_close can only
+// close an OPEN workflow, so it searches openWorkflows alone. Selector semantics are unchanged
+// (workflowRecordMatchesSelector). Returns the matched record or null.
+function resolveWorkflowSelectorTarget(cmd, s, selector) {
+  if (typeof selector !== "string" || !selector) return null;
+  const list = selectorSearchIncludesListed(cmd)
+    ? [...(s?.openWorkflows ?? []), ...(s?.workflows ?? [])]
+    : (s?.openWorkflows ?? []);
+  return list.find((w) => workflowRecordMatchesSelector(w, selector)) || null;
 }
 
 function activeWorkflowExtra(wf = activeWorkflowRef(), { create = false } = {}) {
@@ -7358,10 +7374,8 @@ const GRAPH_TOOL_EXECUTORS = {
     const s = app?.extensionManager?.workflow;
     if (!s?.renameWorkflow) throw new Error("rename unavailable on this frontend");
     if (!name) throw new Error("name is required");
-    const all = [...(s.openWorkflows ?? []), ...(s.workflows ?? [])];
-    const target = path
-      ? all.find((w) => workflowRecordMatchesSelector(w, path))
-      : s.activeWorkflow;
+    // Resolve via the shared helper so the #570 fence sees the SAME target this executor will.
+    const target = path ? resolveWorkflowSelectorTarget("workflow_rename", s, path) : s.activeWorkflow;
     if (!target) throw new Error("no target workflow");
     const clean = name.replace(/\.json$/i, "");
     const slash = target.path ? target.path.lastIndexOf("/") : -1;
@@ -7373,9 +7387,8 @@ const GRAPH_TOOL_EXECUTORS = {
   async workflow_close({ path, force }) {
     const s = app?.extensionManager?.workflow;
     if (!s?.closeWorkflow) throw new Error("close unavailable on this frontend");
-    const target = path
-      ? (s.openWorkflows ?? []).find((w) => workflowRecordMatchesSelector(w, path))
-      : s.activeWorkflow;
+    // Resolve via the shared helper so the #570 fence sees the SAME target this executor will.
+    const target = path ? resolveWorkflowSelectorTarget("workflow_close", s, path) : s.activeWorkflow;
     if (!target) throw new Error("no target workflow");
     // Guard against data loss: don't silently close a workflow with unsaved
     // changes (closeWorkflow bypasses the UI's save prompt). Save first.
@@ -9422,8 +9435,14 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
               const pathArg = typeof msg?.path === "string" ? msg.path.trim() : "";
               if (pathArg) {
                 const active = activeWorkflowRef();
-                const open = app?.extensionManager?.workflow?.openWorkflows ?? [];
-                const resolved = open.find((w) => workflowRecordMatchesSelector(w, pathArg)) || null;
+                // Resolve over the SAME collection the executor will (rename: open+listed;
+                // close: open only) so the fence's target decision matches execution exactly —
+                // a closed-but-listed rename target resolves here too and is correctly exempted.
+                const resolved = resolveWorkflowSelectorTarget(
+                  msg.cmd,
+                  app?.extensionManager?.workflow,
+                  pathArg,
+                );
                 targetsNonActive = selectorTargetsNonActiveWorkflow({ resolved, active });
               }
             }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -95,6 +95,7 @@ import {
   updateMetadataEntry,
 } from "./lib/chat-history-store.js";
 import {
+  activeWorkflowFenceApplies,
   classifyPinnedTarget,
   commandWorkflowMismatch,
   isWorkflowCreationLoad,
@@ -9391,26 +9392,23 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             const executor = GRAPH_TOOL_EXECUTORS[msg.cmd];
             if (!executor) throw new Error(`Unknown command "${msg.cmd}"`);
             // WORKFLOW-INSTANCE FENCE (#570): the orchestrator stamps each command with the
-            // trusted per-instance workflow_uuid it was ISSUED FOR. A command that mutates the
-            // ACTIVE workflow but arrives AFTER the user switched or replaced it (a frame the
+            // trusted per-instance workflow_uuid it was ISSUED FOR. A command that runs against
+            // the ACTIVE workflow but arrives AFTER the user switched or replaced it (a frame the
             // server already delivered and cannot retract) would hit the WRONG workflow —
-            // including workflow_close discarding the new workflow's unsaved work. Refuse when
-            // the stamped uuid does not match the active workflow's uuid (fail closed when
-            // unresolvable, #186). Scope, so navigation and pinned edits are not falsely fenced:
-            //  • an explicit workflow_path names a SPECIFIC target → the #349 pin guard below is
-            //    its authority (covers pinned graph_* and path-targeted workflow_* ops);
-            //  • workflow_open / workflow_new are navigation/creation with their OWN explicit or
-            //    new target, not an active-content mutation, so the stamp must not gate them.
-            // Everything else (unpinned graph_* + path-less workflow_save/save_as/rename/close +
-            // reads) runs against the active canvas and IS fenced.
+            // including workflow_close discarding the new workflow's unsaved work, or
+            // workflow_save/save_as/rename overwriting it. Refuse when the stamped uuid does not
+            // match the active workflow's uuid (fail closed when unresolvable, #186). This covers
+            // EVERY active-canvas op — graph_* AND the four workflow mutators — so it matches the
+            // server's enforcement contract (a panel advertising enforces_workflow_stamp fences
+            // all of them, not only graph commands). activeWorkflowFenceApplies() scopes OUT the
+            // cases that are NOT active-workflow ops: a pinned command (workflow_path → #349 guard
+            // below), navigation/creation (workflow_open/new), and a path-targeted
+            // workflow_rename/close (explicit path arg names a deterministic non-active target).
             const commandUuid = msg?.[WORKFLOW_UUID_FIELD];
             const explicitTargetPath = msg?.[WORKFLOW_PATH_FIELD];
-            const hasExplicitTarget =
-              typeof explicitTargetPath === "string" && explicitTargetPath.trim();
-            const isNavigationOrCreate = msg.cmd === "workflow_open" || msg.cmd === "workflow_new";
+            const hasPin = typeof explicitTargetPath === "string" && explicitTargetPath.trim();
             if (
-              !hasExplicitTarget &&
-              !isNavigationOrCreate &&
+              activeWorkflowFenceApplies({ cmd: msg.cmd, hasPin: Boolean(hasPin), pathArg: msg?.path }) &&
               commandWorkflowMismatch({ commandUuid, activeUuid: workflowStableUuid() })
             ) {
               throw new Error(

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -98,6 +98,7 @@ import {
   activeWorkflowFenceApplies,
   classifyPinnedTarget,
   commandWorkflowMismatch,
+  selectorTargetsNonActiveWorkflow,
   isWorkflowCreationLoad,
   normalizedWorkflowPath,
   resolveUnsavedInstanceUuid,
@@ -9398,17 +9399,33 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // including workflow_close discarding the new workflow's unsaved work, or
             // workflow_save/save_as/rename overwriting it. Refuse when the stamped uuid does not
             // match the active workflow's uuid (fail closed when unresolvable, #186). This covers
-            // EVERY active-canvas op — graph_* AND the four workflow mutators — so it matches the
+            // EVERY active-canvas op — graph_* AND the four workflow mutators — matching the
             // server's enforcement contract (a panel advertising enforces_workflow_stamp fences
             // all of them, not only graph commands). activeWorkflowFenceApplies() scopes OUT the
-            // cases that are NOT active-workflow ops: a pinned command (workflow_path → #349 guard
-            // below), navigation/creation (workflow_open/new), and a path-targeted
-            // workflow_rename/close (explicit path arg names a deterministic non-active target).
+            // NON-active-workflow ops: a pinned command (workflow_path → #349 guard below),
+            // navigation/creation (workflow_open/new), and a path-selectored workflow_rename/close
+            // whose selector RESOLVES to a genuinely non-active OPEN workflow.
+            //
+            // Decide the rename/close exemption by the RESOLVED TARGET, never by raw path presence:
+            // resolve the selector the same way the executor will (openWorkflows.find) and exempt
+            // ONLY when it lands on a real open workflow that is NOT the active one. A non-empty
+            // path that resolves to the ACTIVE workflow — e.g. its file was replaced IN PLACE with
+            // a different workflow at the same path — still hits the active canvas, so it is fenced.
             const commandUuid = msg?.[WORKFLOW_UUID_FIELD];
             const explicitTargetPath = msg?.[WORKFLOW_PATH_FIELD];
             const hasPin = typeof explicitTargetPath === "string" && explicitTargetPath.trim();
+            let targetsNonActive = false;
+            if (msg.cmd === "workflow_rename" || msg.cmd === "workflow_close") {
+              const pathArg = typeof msg?.path === "string" ? msg.path.trim() : "";
+              if (pathArg) {
+                const active = activeWorkflowRef();
+                const open = app?.extensionManager?.workflow?.openWorkflows ?? [];
+                const resolved = open.find((w) => workflowRecordMatchesSelector(w, pathArg)) || null;
+                targetsNonActive = selectorTargetsNonActiveWorkflow({ resolved, active });
+              }
+            }
             if (
-              activeWorkflowFenceApplies({ cmd: msg.cmd, hasPin: Boolean(hasPin), pathArg: msg?.path }) &&
+              activeWorkflowFenceApplies({ cmd: msg.cmd, hasPin: Boolean(hasPin), targetsNonActive }) &&
               commandWorkflowMismatch({ commandUuid, activeUuid: workflowStableUuid() })
             ) {
               throw new Error(

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -99,6 +99,7 @@ import {
   isWorkflowCreationLoad,
   normalizedWorkflowPath,
   shouldForkEmbeddedWorkflowUuid,
+  trustedUnsavedEmbeddedUuid,
   workflowAliasForPath,
   workflowIdentityForms,
 } from "./lib/workflow-chat-identity.js";
@@ -968,6 +969,13 @@ const _workflowUuidOwners = new Map();
 const WORKFLOW_UUID_ALIASES_KEY = "comfyui-mcp.panel.workflowUuidAliases";
 const WORKFLOW_META_NAMESPACE = "comfyui_mcp";
 const WORKFLOW_UUID_FIELD = "workflow_uuid";
+// #570 P0b — marker proving the embedded uuid was MINTED by our fork mechanism (the
+// create-boundary loadGraphData wrapper, or the unsaved-branch fork), so it is a UNIQUE
+// per-instance identity. A pre-rollout/legacy embedded uuid (written by the old transcript
+// recorder, which never set this) may be a DUPLICATE carried by a copied/imported graph —
+// a creation-time-only fork can't repair those, so on load of an UNSAVED graph we trust the
+// embedded uuid ONLY when this marker is present, and otherwise FORK to a fresh identity.
+const WORKFLOW_UUID_OWNED_FIELD = "workflow_uuid_forked";
 const WORKFLOW_PATH_FIELD = "workflow_path";
 let _workflowUuidAliases = (() => {
   try {
@@ -1058,6 +1066,14 @@ function embeddedWorkflowUuid(wf = activeWorkflowRef()) {
   return typeof id === "string" && id ? id : null;
 }
 
+// #570 P0b — true only when the embedded uuid carries our fork-ownership marker (minted by
+// the create-boundary wrapper or the unsaved-branch fork). A legacy/pre-rollout embed lacks
+// it, so it must not be trusted as a unique per-instance identity.
+function embeddedWorkflowUuidOwned(wf = activeWorkflowRef()) {
+  const ns = activeWorkflowExtra(wf)?.[WORKFLOW_META_NAMESPACE];
+  return ns?.[WORKFLOW_UUID_OWNED_FIELD] === true;
+}
+
 function embeddedWorkflowPath(wf = activeWorkflowRef()) {
   const ns = activeWorkflowExtra(wf)?.[WORKFLOW_META_NAMESPACE];
   const path = ns?.[WORKFLOW_PATH_FIELD];
@@ -1103,6 +1119,7 @@ function installCreateBoundaryFork(appRef) {
           extra[WORKFLOW_META_NAMESPACE] = {
             ...(prev && typeof prev === "object" ? prev : {}),
             [WORKFLOW_UUID_FIELD]: crypto.randomUUID(),
+            [WORKFLOW_UUID_OWNED_FIELD]: true, // fork-minted → a unique per-instance identity
           };
         }
       } catch {
@@ -1150,19 +1167,26 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
   // graph.extra uuid, which installCreateBoundaryFork REGENERATES at every creation
   // (import/paste/duplicate/new) — so it is fresh for a copy yet round-tripped verbatim by
   // ComfyUI's draft persistence across a reload (durable regardless of chat scope). Prefer
-  // the in-session objectUuid, then the embedded uuid; if neither (a workflow that predates
-  // the wrapper, or a fresh blank created before it installed), mint one and STAMP it into
-  // extra so it is durable — and distinct per live object, so two concurrently-open copies
-  // never collide.
+  // the in-session objectUuid, then the embedded uuid — but TRUST the embedded uuid ONLY
+  // when it carries our fork-ownership marker (WORKFLOW_UUID_OWNED_FIELD). A pre-rollout /
+  // legacy embedded uuid (no marker) may be a DUPLICATE carried by a graph copied/imported
+  // BEFORE the create-boundary fork existed — a creation-time-only fork can't repair those,
+  // so FORK it here (mint fresh) rather than adopt the source's identity (#570 P0b). This is
+  // a one-time strip on the first unsaved load post-upgrade: a lost resume, never a
+  // cross-workflow leak. We then STAMP uuid + marker so a reload trusts it thereafter, and
+  // it stays distinct per live object so two concurrently-open copies never collide.
   const isUnsaved = !path && wf && wf.isPersisted !== true;
   if (isUnsaved) {
     const embeddedId = embeddedWorkflowUuid(wf);
-    const id = objectUuid || embeddedId || crypto.randomUUID();
+    const embeddedOwned = embeddedWorkflowUuidOwned(wf);
+    const trustedEmbedded = trustedUnsavedEmbeddedUuid({ embeddedId, embeddedOwned }); // legacy/unmarked → null → fork
+    const id = objectUuid || trustedEmbedded || crypto.randomUUID();
     _workflowObjectUuids.set(identityObject, id);
     rememberWorkflowUuidOwner(id, identityObject);
-    if (embeddedId !== id) {
-      // Persist the identity into extra (so a reload keeps it AND a later SAVE carries it
-      // into the saved file across the tmp:→wf: transition). Never dirties the graph.
+    if (embeddedId !== id || !embeddedOwned) {
+      // Persist the identity + ownership marker into extra (so a reload keeps + trusts it,
+      // AND a later SAVE carries it into the saved file across the tmp:→wf: transition).
+      // Never dirties the graph.
       try {
         const extra = activeWorkflowExtra(wf, { create: true });
         const previous = extra?.[WORKFLOW_META_NAMESPACE];
@@ -1170,6 +1194,7 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
           extra[WORKFLOW_META_NAMESPACE] = {
             ...(previous && typeof previous === "object" ? previous : {}),
             [WORKFLOW_UUID_FIELD]: id,
+            [WORKFLOW_UUID_OWNED_FIELD]: true,
           };
         }
       } catch {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -96,8 +96,8 @@ import {
 } from "./lib/chat-history-store.js";
 import {
   classifyPinnedTarget,
+  isWorkflowCreationLoad,
   normalizedWorkflowPath,
-  resolveUnsavedWorkflowUuid,
   shouldForkEmbeddedWorkflowUuid,
   workflowAliasForPath,
   workflowIdentityForms,
@@ -966,26 +966,6 @@ const _priorTempWorkflowIds = new WeakMap();
 const _workflowObjectUuids = new WeakMap();
 const _workflowUuidOwners = new Map();
 const WORKFLOW_UUID_ALIASES_KEY = "comfyui-mcp.panel.workflowUuidAliases";
-// #570 P0b/P1 — durable per-instance uuid for an UNSAVED workflow, keyed on the pair
-// (ComfyUI tab path, reload-stable graph id). An unsaved workflow's `path`
-// ("workflows/Unsaved Workflow.json") is reused verbatim when ITS tab is restored on a
-// reload, but DEDUPED ("... (2).json") for a fresh import/duplicate — so keying on the
-// path both keeps the identity across a reload (P1) and mints a fresh one for a cold
-// import that merely carries a SOURCE workflow's embedded uuid (P0b). The graph id
-// (activeState.id, reload-stable but import-PRESERVED) is a second guard: a DIFFERENT
-// new unsaved workflow that later REUSES a freed path slot has a different graph id, so
-// it can't inherit the closed workflow's identity. Persisted in localStorage; graph
-// `extra` is deliberately NOT the source of truth for unsaved tabs (a copy carries it).
-const WORKFLOW_UNSAVED_IDS_KEY = "comfyui-mcp.panel.unsavedWorkflowIds";
-const WORKFLOW_UNSAVED_IDS_CAP = 200; // bound growth (keyed by transient unsaved paths)
-let _unsavedWorkflowIds = (() => {
-  try {
-    const parsed = JSON.parse(window.localStorage.getItem(WORKFLOW_UNSAVED_IDS_KEY) || "{}");
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
-  } catch {
-    return {};
-  }
-})();
 const WORKFLOW_META_NAMESPACE = "comfyui_mcp";
 const WORKFLOW_UUID_FIELD = "workflow_uuid";
 const WORKFLOW_PATH_FIELD = "workflow_path";
@@ -1092,60 +1072,49 @@ function persistWorkflowAliases() {
   }
 }
 
-// #570 P0b/P1 — the ComfyUI tab path of an UNSAVED (never-saved) workflow, e.g.
-// "workflows/Unsaved Workflow.json". Reload-stable (restored to the SAME path) and
-// import-distinct (a fresh open/duplicate is deduped to "... (2).json"). null for a
-// saved tab (which uses savedWorkflowPath) or when no path is exposed.
-function unsavedWorkflowPath(wf) {
-  if (!wf || wf.isPersisted === true) return null;
-  return typeof wf.path === "string" && wf.path ? wf.path : null;
-}
-
-// The reload-stable, per-workflow graph id ComfyUI mints (activeState.id via
-// ensureWorkflowId). It is PRESERVED across an import/copy (so it can't tell a copy
-// from the original by itself), but it DOES differ between two genuinely different
-// unsaved workflows — the guard that stops a new workflow reusing a freed path slot
-// from inheriting the closed workflow's uuid. "" when unavailable (older format).
-function unsavedWorkflowGraphId(wf) {
+// #570 P0 — CREATE-BOUNDARY FORK. Wrap app.loadGraphData so that at every workflow
+// CREATION (import / open-file / drag-drop / template / shared-url / DUPLICATE / PASTE /
+// new-blank) — but NOT a reload-restore / tab-switch / undo / in-place repaint — we mint
+// a FRESH embedded per-instance uuid into the incoming graph BEFORE it goes live. Paste
+// and duplicate keep the SOURCE graph's embedded uuid AND can land on the same synthesized
+// "Unsaved Workflow.json" path, so without this a copy would present the source's identity
+// and inherit its session (the reopened cross-resume). Regenerating at creation makes the
+// embedded uuid a trustworthy per-instance identity: fresh for a copy, and round-tripped
+// verbatim by ComfyUI's draft persistence across a reload (durable — P1). isWorkflowCreationLoad
+// reads the discriminators (loadGraphData's 4th `workflow` arg is a ComfyWorkflow object only
+// on a REUSE; creations pass null/undefined/string; external imports also set openSource).
+// loadGraphData clones graphData internally AFTER we mutate, so our stamp flows into configure.
+let _loadGraphDataForkInstalled = false;
+function installCreateBoundaryFork(appRef) {
   try {
-    const id = wf?.activeState?.id ?? wf?.initialState?.id ?? wf?.workflow?.id ?? null;
-    return typeof id === "string" && id ? id : "";
+    if (_loadGraphDataForkInstalled || !appRef || typeof appRef.loadGraphData !== "function") return;
+    const orig = appRef.loadGraphData.bind(appRef);
+    appRef.loadGraphData = function (graphData, clean, restoreView, workflow, options = {}) {
+      try {
+        const creation = isWorkflowCreationLoad({
+          workflowArg: workflow,
+          openSource: options ? options.openSource : undefined,
+          noFork: Boolean(options && options.__cmcpNoFork),
+        });
+        if (creation && graphData && typeof graphData === "object" && !Array.isArray(graphData)) {
+          const extra =
+            graphData.extra && typeof graphData.extra === "object" ? graphData.extra : (graphData.extra = {});
+          const prev = extra[WORKFLOW_META_NAMESPACE];
+          extra[WORKFLOW_META_NAMESPACE] = {
+            ...(prev && typeof prev === "object" ? prev : {}),
+            [WORKFLOW_UUID_FIELD]: crypto.randomUUID(),
+          };
+        }
+      } catch {
+        // Never let identity bookkeeping break a graph load.
+      }
+      return orig(graphData, clean, restoreView, workflow, options);
+    };
+    _loadGraphDataForkInstalled = true;
   } catch {
-    return "";
+    // If wrapping fails, workflowStableUuid's lazy per-object stamping still keeps two
+    // concurrently-open copies distinct — the fork is a durability/robustness upgrade.
   }
-}
-
-function persistUnsavedWorkflowIds() {
-  try {
-    // Bound growth: unsaved paths are transient, so evict arbitrary old entries when
-    // over the cap (a dropped entry only costs a lost resume for a long-idle tab).
-    const keys = Object.keys(_unsavedWorkflowIds);
-    if (keys.length > WORKFLOW_UNSAVED_IDS_CAP) {
-      for (const k of keys.slice(0, keys.length - WORKFLOW_UNSAVED_IDS_CAP)) delete _unsavedWorkflowIds[k];
-    }
-    window.localStorage.setItem(WORKFLOW_UNSAVED_IDS_KEY, JSON.stringify(_unsavedWorkflowIds));
-  } catch {
-    // In-memory identity still holds for this session.
-  }
-}
-
-// Resolve (and optionally persist) the durable uuid for an unsaved workflow at
-// (path, gid) via the pure resolveUnsavedWorkflowUuid. A read-only probe (no `assign`)
-// returns the stored uuid only when it names the SAME instance, else null; with
-// `assign` it adopts that fresh uuid on a miss and persists the (path,gid) entry.
-function unsavedWorkflowUuid(path, gid, assign) {
-  if (!path) return assign ?? null;
-  const stored = _unsavedWorkflowIds[path] || null;
-  const { uuid, changed } = resolveUnsavedWorkflowUuid({
-    stored,
-    gid,
-    mint: assign === undefined ? null : assign,
-  });
-  if (assign !== undefined && changed && uuid) {
-    _unsavedWorkflowIds[path] = { u: uuid, g: gid || "" };
-    persistUnsavedWorkflowIds();
-  }
-  return uuid;
 }
 
 function workflowUuidOwner(id) {
@@ -1177,33 +1146,34 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
   const path = savedWorkflowPath(wf);
   const objectUuid = _workflowObjectUuids.get(identityObject);
 
-  // #570 P0b/P1 — UNSAVED workflow: the DURABLE, import-distinct identity is the panel's
-  // own (path, graph-id) alias, NOT the embedded graph.extra uuid (which a COPIED graph
-  // carries verbatim → cross-resume). Resolve from that alias; a cold import (new deduped
-  // path) or a path-slot reuse (different graph id) misses → mint fresh; a reload (same
-  // path + graph id) hits → same uuid. The embedded uuid is deliberately ignored here.
-  const unsavedPath = path ? null : unsavedWorkflowPath(wf);
-  if (unsavedPath) {
-    const gid = unsavedWorkflowGraphId(wf);
-    const resolved = objectUuid || unsavedWorkflowUuid(unsavedPath, gid) || crypto.randomUUID();
-    const id = unsavedWorkflowUuid(unsavedPath, gid, resolved); // persist/refresh the alias
+  // #570 P0/P1 — UNSAVED workflow: the durable per-instance identity is the EMBEDDED
+  // graph.extra uuid, which installCreateBoundaryFork REGENERATES at every creation
+  // (import/paste/duplicate/new) — so it is fresh for a copy yet round-tripped verbatim by
+  // ComfyUI's draft persistence across a reload (durable regardless of chat scope). Prefer
+  // the in-session objectUuid, then the embedded uuid; if neither (a workflow that predates
+  // the wrapper, or a fresh blank created before it installed), mint one and STAMP it into
+  // extra so it is durable — and distinct per live object, so two concurrently-open copies
+  // never collide.
+  const isUnsaved = !path && wf && wf.isPersisted !== true;
+  if (isUnsaved) {
+    const embeddedId = embeddedWorkflowUuid(wf);
+    const id = objectUuid || embeddedId || crypto.randomUUID();
     _workflowObjectUuids.set(identityObject, id);
     rememberWorkflowUuidOwner(id, identityObject);
-    if (embed) {
-      // Keep writing the in-graph metadata (harmless — not authoritative for an unsaved
-      // tab) so a subsequent user-initiated SAVE carries the identity into the saved
-      // file and the conversation survives the tmp:→wf: transition.
+    if (embeddedId !== id) {
+      // Persist the identity into extra (so a reload keeps it AND a later SAVE carries it
+      // into the saved file across the tmp:→wf: transition). Never dirties the graph.
       try {
         const extra = activeWorkflowExtra(wf, { create: true });
         const previous = extra?.[WORKFLOW_META_NAMESPACE];
-        if (extra && previous?.[WORKFLOW_UUID_FIELD] !== id) {
+        if (extra) {
           extra[WORKFLOW_META_NAMESPACE] = {
             ...(previous && typeof previous === "object" ? previous : {}),
             [WORKFLOW_UUID_FIELD]: id,
           };
         }
       } catch {
-        // The (path, graph-id) alias still makes the identity durable in this browser.
+        // In-memory objectUuid still keeps this instance stable for the session.
       }
     }
     return id;
@@ -3805,7 +3775,11 @@ function restoreSnapshot(snap) {
   if (!snap) return null;
   try {
     // Deep-clone so the stored snapshot isn't mutated by the live graph after load.
-    getGraphCtx().app.loadGraphData(JSON.parse(JSON.stringify(snap.data)));
+    // __cmcpNoFork: this reloads the SAME active workflow (a revert), so the create-
+    // boundary fork must NOT re-mint its per-instance identity (#570 P0).
+    getGraphCtx().app.loadGraphData(JSON.parse(JSON.stringify(snap.data)), true, true, activeWorkflowRef(), {
+      __cmcpNoFork: true,
+    });
     return snap;
   } catch {
     return null;
@@ -19604,6 +19578,9 @@ function registerExtensionWhenReady(tries = 0) {
   }
   app = comfyApp;
   api = window.comfyAPI?.api?.api || window.api || null;
+  // #570 P0 — wrap app.loadGraphData so every workflow CREATION (import/paste/duplicate/
+  // new) mints a fresh per-instance uuid, so a copy can't inherit the source's session.
+  installCreateBoundaryFork(app);
   setupListeners();
 
   // TODO(v2): replace with `defineExtension({ name, setup() {...} })`.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9538,6 +9538,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // orchestrator registers panel_* tools + local panel management.
             comfyuiPath: localComfyuiPathForAgent(),
             resume,
+            // #570 — the durable per-instance workflow uuid (the SAME identity that
+            // keys the durable chat transcript). Unlike workflowTabId()'s ephemeral
+            // tmp:<uuid> and the non-unique default title, it survives a reload, so
+            // the orchestrator can resume an UNSAVED workflow's conversation without
+            // cross-resuming a DIFFERENT same-title unsaved workflow.
+            workflowUuid: workflowStableUuid(),
           }),
         ),
       );

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -306,10 +306,13 @@ export function buildHelloPayload({
     backend: backend || "claude",
     blind: Boolean(blind),
     // #570 P0c — advertise that THIS panel build enforces the per-command workflow-instance
-    // stamp (it refuses to run a graph command whose stamped workflow_uuid does not match the
-    // active canvas). The orchestrator FAILS CLOSED for mutating graph commands unless a
-    // connected panel confirms this, so an OLD panel that would silently ignore the stamp and
-    // apply a stale write to the wrong canvas gets read-only graph access until updated.
+    // stamp: it refuses to run ANY active-workflow op whose stamped workflow_uuid does not match
+    // the active canvas — every graph_* command AND the four active-workflow mutators
+    // (workflow_save / workflow_save_as / workflow_rename / workflow_close). The fence is in the
+    // command handler (activeWorkflowFenceApplies), before every executor, so it spans all of
+    // them. The orchestrator FAILS CLOSED for those mutations unless a connected panel confirms
+    // this, so an OLD panel that would silently ignore the stamp and apply a stale write to the
+    // wrong workflow gets read-only graph access until updated.
     // SCOPE: this is ACCIDENTAL version-skew protection for an honest user, NOT a security
     // boundary — the flag is self-asserted, so a modified panel can spoof it, but that only
     // leaks the user's own workflow into their own workflow (self-attack). No attestation.

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -310,6 +310,9 @@ export function buildHelloPayload({
     // active canvas). The orchestrator FAILS CLOSED for mutating graph commands unless a
     // connected panel confirms this, so an OLD panel that would silently ignore the stamp and
     // apply a stale write to the wrong canvas gets read-only graph access until updated.
+    // SCOPE: this is ACCIDENTAL version-skew protection for an honest user, NOT a security
+    // boundary — the flag is self-asserted, so a modified panel can spoof it, but that only
+    // leaks the user's own workflow into their own workflow (self-attack). No attestation.
     enforces_workflow_stamp: true,
   };
   if (comfyuiUrl) frame.comfyui_url = comfyuiUrl;

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -305,6 +305,12 @@ export function buildHelloPayload({
     panel_version: panelVersion,
     backend: backend || "claude",
     blind: Boolean(blind),
+    // #570 P0c — advertise that THIS panel build enforces the per-command workflow-instance
+    // stamp (it refuses to run a graph command whose stamped workflow_uuid does not match the
+    // active canvas). The orchestrator FAILS CLOSED for mutating graph commands unless a
+    // connected panel confirms this, so an OLD panel that would silently ignore the stamp and
+    // apply a stale write to the wrong canvas gets read-only graph access until updated.
+    enforces_workflow_stamp: true,
   };
   if (comfyuiUrl) frame.comfyui_url = comfyuiUrl;
   if (typeof comfyuiPath === "string" && comfyuiPath.trim()) {

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -296,6 +296,7 @@ export function buildHelloPayload({
   comfyuiUrl,
   comfyuiPath,
   resume,
+  workflowUuid,
 } = {}) {
   const frame = {
     type: "hello",
@@ -310,5 +311,13 @@ export function buildHelloPayload({
     frame.comfyui_path = comfyuiPath.trim();
   }
   if (resume) frame.resume = resume;
+  // #570 — the durable, globally-unique per-instance workflow uuid (survives the
+  // tmp:<uuid> tab-id churn across a reload, unlike the tab id and the default
+  // title). Lets the orchestrator key an UNSAVED workflow's resume on a stable
+  // identity that never collides with a DIFFERENT unsaved workflow of the same
+  // title (the reopened cross-resume). Omitted when unknown so old behavior stands.
+  if (typeof workflowUuid === "string" && workflowUuid.trim()) {
+    frame.workflow_uuid = workflowUuid.trim();
+  }
   return frame;
 }

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -75,6 +75,16 @@ export function shouldForkInPlaceReload({ cachedUuid, incomingUuid } = {}) {
   return Boolean(cachedUuid) && incomingUuid !== cachedUuid;
 }
 
+/** #570 P1 — does the path-selector search scope for `cmd` include CLOSED-but-LISTED workflows
+ *  (s.workflows) in addition to the OPEN ones (s.openWorkflows)? workflow_rename can rename a
+ *  closed-but-listed workflow, so it searches both; workflow_close can only close an OPEN one, so
+ *  it searches openWorkflows alone. The fence and the executor share the ONE resolver keyed on
+ *  this so their target decision matches exactly (a closed-but-listed rename target resolves in
+ *  BOTH → correctly exempted, never over-fenced). */
+export function selectorSearchIncludesListed(cmd) {
+  return cmd !== 'workflow_close';
+}
+
 /** #570 — a path-selectored active-targeting mutator (workflow_rename / workflow_close) is exempt
  *  from the active-workflow uuid fence ONLY when its selector resolves to a REAL open workflow
  *  that is NOT the active one. Decide by the RESOLVED TARGET, never by raw path presence: the

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -75,6 +75,18 @@ export function shouldForkInPlaceReload({ cachedUuid, incomingUuid } = {}) {
   return Boolean(cachedUuid) && incomingUuid !== cachedUuid;
 }
 
+/** #570 — a path-selectored active-targeting mutator (workflow_rename / workflow_close) is exempt
+ *  from the active-workflow uuid fence ONLY when its selector resolves to a REAL open workflow
+ *  that is NOT the active one. Decide by the RESOLVED TARGET, never by raw path presence: the
+ *  executor does openWorkflows.find(selector), so a non-empty path that resolves to the ACTIVE
+ *  workflow — including after that path was replaced IN PLACE with a different workflow (same
+ *  path/tab, new uuid) — still hits the active canvas and MUST be fenced. Resolves to the active
+ *  object, or to nothing (can't prove non-active), ⇒ NOT exempt (fenced). `resolved` is the open
+ *  workflow the selector matched (or null); `active` is the active workflow object. */
+export function selectorTargetsNonActiveWorkflow({ resolved, active } = {}) {
+  return Boolean(resolved) && resolved !== active;
+}
+
 /** #570 — does the per-command workflow-instance uuid fence APPLY to this command? The fence
  *  refuses a command whose stamped workflow_uuid ≠ the ACTIVE workflow's uuid, so it must cover
  *  everything that runs against the active canvas — every graph_* op AND the active-workflow
@@ -83,22 +95,16 @@ export function shouldForkInPlaceReload({ cachedUuid, incomingUuid } = {}) {
  *   • a PINNED command (`hasPin` — a workflow_path is present): the #349 pin guard is its
  *     authority (covers pinned graph_* and path-targeted workflow_* ops);
  *   • workflow_open / workflow_new: navigation/creation with their own explicit/new target;
- *   • workflow_rename / workflow_close carrying an EXPLICIT non-empty `path` ARG: that names a
- *     DETERMINISTIC open workflow to rename/close (the executor does openWorkflows.find(path)),
- *     not the active one, so fencing it against the active uuid would wrongly reject a valid
- *     close/rename of a non-active workflow.
+ *   • workflow_rename / workflow_close whose selector resolves to a genuinely NON-active open
+ *     workflow (`targetsNonActive` — computed via selectorTargetsNonActiveWorkflow): a
+ *     deterministic close/rename of a DIFFERENT workflow must run. A non-empty path that resolves
+ *     to the ACTIVE workflow (incl. after an in-place replacement) is NOT exempt — it is fenced.
  *  Reads (graph_get_state, …) still return true here — harmlessly fenced (fail-closed); their
  *  reply is server-fenced anyway, and a read can only run against the active canvas regardless. */
-export function activeWorkflowFenceApplies({ cmd, hasPin = false, pathArg } = {}) {
+export function activeWorkflowFenceApplies({ cmd, hasPin = false, targetsNonActive = false } = {}) {
   if (hasPin) return false;
   if (cmd === 'workflow_open' || cmd === 'workflow_new') return false;
-  if (
-    (cmd === 'workflow_rename' || cmd === 'workflow_close') &&
-    typeof pathArg === 'string' &&
-    pathArg.trim().length > 0
-  ) {
-    return false;
-  }
+  if ((cmd === 'workflow_rename' || cmd === 'workflow_close') && targetsNonActive) return false;
   return true;
 }
 

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -75,6 +75,19 @@ export function shouldForkInPlaceReload({ cachedUuid, incomingUuid } = {}) {
   return Boolean(cachedUuid) && incomingUuid !== cachedUuid;
 }
 
+/** #570 — should the panel REFUSE to execute a command stamped for a specific workflow
+ *  instance? The orchestrator stamps each dispatched command with the trusted per-instance
+ *  `workflow_uuid` it was ISSUED FOR. Every graph executor runs against the ACTIVE canvas, so
+ *  if the user switched/replaced the workflow after the command was dispatched (a frame the
+ *  server can no longer retract), applying it would silently mutate the WRONG graph. Reject
+ *  when the command carries a non-empty uuid that does NOT equal the active workflow's uuid —
+ *  including when the active uuid is unresolvable (fail closed, #186). A command with no
+ *  stamp (old orchestrator / identity-less tab) is never fenced here. */
+export function commandWorkflowMismatch({ commandUuid, activeUuid } = {}) {
+  if (typeof commandUuid !== 'string' || !commandUuid.trim()) return false;
+  return activeUuid !== commandUuid;
+}
+
 /** #570 — resolve the per-instance uuid for an UNSAVED workflow, failing CLOSED on the
  *  copyable durability carrier. Precedence:
  *   1. `objectUuid` — the LIVE-object WeakMap value. A copy/import never shares the live

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -40,6 +40,24 @@ export function shouldForkEmbeddedWorkflowUuid({
   );
 }
 
+/** #570 P0b/P1 — resolve an UNSAVED workflow's durable per-instance uuid from its
+ *  stored (path,graph-id) alias. `stored` is the localStorage entry for this ComfyUI
+ *  tab path ({ u: uuid, g: graphId } | null); `gid` is the workflow's current
+ *  reload-stable graph id; `mint` is a fresh uuid to adopt on a miss (null in a
+ *  read-only probe). Reuse the stored uuid ONLY when it names the SAME instance — the
+ *  graph ids match, or either is unknown (a lenient path-only fallback). A stored
+ *  entry with a DIFFERENT graph id is a different workflow that REUSED a freed path
+ *  slot, so it must NOT inherit the uuid → adopt `mint`. A cold import lands on a
+ *  brand-new (deduped) path with no stored entry → also `mint`. Returns { uuid,
+ *  changed } where `changed` asks the caller to (re)persist the entry. */
+export function resolveUnsavedWorkflowUuid({ stored, gid, mint = null } = {}) {
+  const valid = stored && typeof stored.u === "string" && stored.u ? stored : null;
+  const gidMatches = valid ? !valid.g || !gid || valid.g === gid : false;
+  const uuid = valid && gidMatches ? valid.u : mint;
+  const changed = uuid ? !valid || valid.u !== uuid || (valid.g || "") !== (gid || "") : false;
+  return { uuid, changed };
+}
+
 /** Every identity string the ACTIVE workflow answers to, for pinned-target
  *  matching (#186/#349). `routingKey` is the per-instance opaque id — "wf:<path>"
  *  for a saved tab, "tmp:<uuid>" for an unsaved one — and ALWAYS authorizes.

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -75,6 +75,33 @@ export function shouldForkInPlaceReload({ cachedUuid, incomingUuid } = {}) {
   return Boolean(cachedUuid) && incomingUuid !== cachedUuid;
 }
 
+/** #570 — does the per-command workflow-instance uuid fence APPLY to this command? The fence
+ *  refuses a command whose stamped workflow_uuid ≠ the ACTIVE workflow's uuid, so it must cover
+ *  everything that runs against the active canvas — every graph_* op AND the active-workflow
+ *  mutators workflow_save / workflow_save_as / workflow_rename / workflow_close (workflow_save*
+ *  ignore any path, so they are ALWAYS active). It must NOT fire for:
+ *   • a PINNED command (`hasPin` — a workflow_path is present): the #349 pin guard is its
+ *     authority (covers pinned graph_* and path-targeted workflow_* ops);
+ *   • workflow_open / workflow_new: navigation/creation with their own explicit/new target;
+ *   • workflow_rename / workflow_close carrying an EXPLICIT non-empty `path` ARG: that names a
+ *     DETERMINISTIC open workflow to rename/close (the executor does openWorkflows.find(path)),
+ *     not the active one, so fencing it against the active uuid would wrongly reject a valid
+ *     close/rename of a non-active workflow.
+ *  Reads (graph_get_state, …) still return true here — harmlessly fenced (fail-closed); their
+ *  reply is server-fenced anyway, and a read can only run against the active canvas regardless. */
+export function activeWorkflowFenceApplies({ cmd, hasPin = false, pathArg } = {}) {
+  if (hasPin) return false;
+  if (cmd === 'workflow_open' || cmd === 'workflow_new') return false;
+  if (
+    (cmd === 'workflow_rename' || cmd === 'workflow_close') &&
+    typeof pathArg === 'string' &&
+    pathArg.trim().length > 0
+  ) {
+    return false;
+  }
+  return true;
+}
+
 /** #570 — should the panel REFUSE to execute a command stamped for a specific workflow
  *  instance? The orchestrator stamps each dispatched command with the trusted per-instance
  *  `workflow_uuid` it was ISSUED FOR. Every graph executor runs against the ACTIVE canvas, so

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -44,15 +44,17 @@ export function shouldForkEmbeddedWorkflowUuid({
  *  stored (path,graph-id) alias. `stored` is the localStorage entry for this ComfyUI
  *  tab path ({ u: uuid, g: graphId } | null); `gid` is the workflow's current
  *  reload-stable graph id; `mint` is a fresh uuid to adopt on a miss (null in a
- *  read-only probe). Reuse the stored uuid ONLY when it names the SAME instance — the
- *  graph ids match, or either is unknown (a lenient path-only fallback). A stored
- *  entry with a DIFFERENT graph id is a different workflow that REUSED a freed path
- *  slot, so it must NOT inherit the uuid → adopt `mint`. A cold import lands on a
- *  brand-new (deduped) path with no stored entry → also `mint`. Returns { uuid,
- *  changed } where `changed` asks the caller to (re)persist the entry. */
+ *  read-only probe). Reuse the stored uuid ONLY when it names the SAME instance —
+ *  BOTH graph ids present AND equal. This FAILS CLOSED: a stored entry with a DIFFERENT
+ *  graph id (a different workflow that REUSED a freed path slot), OR a missing graph id
+ *  on either side (can't prove continuity), mints fresh rather than risk inheriting a
+ *  closed workflow's session. A cold import also lands on a brand-new (deduped) path
+ *  with no stored entry → `mint`. Returns { uuid, changed } where `changed` asks the
+ *  caller to (re)persist the entry. (Trade-off: an unsaved workflow whose graph id is
+ *  ever unavailable forgoes durable disk resume — a lost resume, never a wrong one.) */
 export function resolveUnsavedWorkflowUuid({ stored, gid, mint = null } = {}) {
   const valid = stored && typeof stored.u === "string" && stored.u ? stored : null;
-  const gidMatches = valid ? !valid.g || !gid || valid.g === gid : false;
+  const gidMatches = Boolean(valid && valid.g && gid && valid.g === gid);
   const uuid = valid && gidMatches ? valid.u : mint;
   const changed = uuid ? !valid || valid.u !== uuid || (valid.g || "") !== (gid || "") : false;
   return { uuid, changed };

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -64,13 +64,15 @@ export function shouldForkEmbeddedWorkflowUuid({
  *  A mis-classified reuse only loses durability (P1, a fresh session); a mis-classified
  *  creation that INHERITED the source identity would be a wrong-resume (P0) — so, faced
  *  with an ambiguous arg, fork. */
-/** #570 P0b — the embedded unsaved-workflow uuid to TRUST as this instance's identity, or
- *  null to FORK. Trust the embedded uuid ONLY when it carries the fork-ownership marker
- *  (`embeddedOwned` — minted by the create-boundary wrapper or a prior fork). A legacy /
- *  pre-rollout embed (no marker) may be a DUPLICATE carried by a copy/import made before the
- *  fork existed, so it is NOT trusted → null → the caller mints a fresh identity. */
-export function trustedUnsavedEmbeddedUuid({ embeddedId, embeddedOwned } = {}) {
-  return embeddedOwned && typeof embeddedId === "string" && embeddedId ? embeddedId : null;
+/** #570 P0b — should an IN-PLACE graph load (loadGraphData into an EXISTING workflow object)
+ *  FORK the per-instance identity? A stale object-cache must NEVER override the identity of
+ *  newly-loaded content, and ownership is anchored on the LIVE object (not copyable
+ *  graph.extra). Fork when the object already has a cached uuid AND the incoming graph's
+ *  embedded uuid DIFFERS from it (a workflow REPLACED in place) — or the incoming has none.
+ *  Same uuid → the same content reloaded/undone → keep. The embedded value is used only to
+ *  DETECT the change; the caller mints a FRESH uuid (never adopts the copyable embedded one). */
+export function shouldForkInPlaceReload({ cachedUuid, incomingUuid } = {}) {
+  return Boolean(cachedUuid) && incomingUuid !== cachedUuid;
 }
 
 export function isWorkflowCreationLoad({ workflowArg, openSource, noFork = false } = {}) {

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -55,11 +55,24 @@ export function shouldForkEmbeddedWorkflowUuid({
  *
  *  A rare legacy single-tab restore (a string 4th arg, no openSource) is treated as a
  *  creation and re-mints — harmless: it already forks into a fresh temporary, and the
- *  common multi-tab reload passes an object so it is never misclassified. */
+ *  common multi-tab reload passes an object so it is never misclassified.
+ *
+ *  FAIL SAFE (bias to fork): a REUSE is recognized ONLY when the 4th arg is genuinely a
+ *  ComfyWorkflow — a non-array object exposing a string `path` (every open workflow,
+ *  including a temporary "workflows/Unsaved Workflow.json", has one). Anything else — a
+ *  primitive, an array, or an unrecognized/mis-shaped object — is treated as a CREATION.
+ *  A mis-classified reuse only loses durability (P1, a fresh session); a mis-classified
+ *  creation that INHERITED the source identity would be a wrong-resume (P0) — so, faced
+ *  with an ambiguous arg, fork. */
 export function isWorkflowCreationLoad({ workflowArg, openSource, noFork = false } = {}) {
   if (noFork) return false;
   if (openSource != null) return true;
-  return !(workflowArg !== null && typeof workflowArg === "object");
+  const looksLikeWorkflow =
+    workflowArg !== null &&
+    typeof workflowArg === "object" &&
+    !Array.isArray(workflowArg) &&
+    typeof workflowArg.path === "string";
+  return !looksLikeWorkflow;
 }
 
 /** Every identity string the ACTIVE workflow answers to, for pinned-target

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -64,6 +64,15 @@ export function shouldForkEmbeddedWorkflowUuid({
  *  A mis-classified reuse only loses durability (P1, a fresh session); a mis-classified
  *  creation that INHERITED the source identity would be a wrong-resume (P0) — so, faced
  *  with an ambiguous arg, fork. */
+/** #570 P0b — the embedded unsaved-workflow uuid to TRUST as this instance's identity, or
+ *  null to FORK. Trust the embedded uuid ONLY when it carries the fork-ownership marker
+ *  (`embeddedOwned` — minted by the create-boundary wrapper or a prior fork). A legacy /
+ *  pre-rollout embed (no marker) may be a DUPLICATE carried by a copy/import made before the
+ *  fork existed, so it is NOT trusted → null → the caller mints a fresh identity. */
+export function trustedUnsavedEmbeddedUuid({ embeddedId, embeddedOwned } = {}) {
+  return embeddedOwned && typeof embeddedId === "string" && embeddedId ? embeddedId : null;
+}
+
 export function isWorkflowCreationLoad({ workflowArg, openSource, noFork = false } = {}) {
   if (noFork) return false;
   if (openSource != null) return true;

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -40,24 +40,26 @@ export function shouldForkEmbeddedWorkflowUuid({
   );
 }
 
-/** #570 P0b/P1 — resolve an UNSAVED workflow's durable per-instance uuid from its
- *  stored (path,graph-id) alias. `stored` is the localStorage entry for this ComfyUI
- *  tab path ({ u: uuid, g: graphId } | null); `gid` is the workflow's current
- *  reload-stable graph id; `mint` is a fresh uuid to adopt on a miss (null in a
- *  read-only probe). Reuse the stored uuid ONLY when it names the SAME instance —
- *  BOTH graph ids present AND equal. This FAILS CLOSED: a stored entry with a DIFFERENT
- *  graph id (a different workflow that REUSED a freed path slot), OR a missing graph id
- *  on either side (can't prove continuity), mints fresh rather than risk inheriting a
- *  closed workflow's session. A cold import also lands on a brand-new (deduped) path
- *  with no stored entry → `mint`. Returns { uuid, changed } where `changed` asks the
- *  caller to (re)persist the entry. (Trade-off: an unsaved workflow whose graph id is
- *  ever unavailable forgoes durable disk resume — a lost resume, never a wrong one.) */
-export function resolveUnsavedWorkflowUuid({ stored, gid, mint = null } = {}) {
-  const valid = stored && typeof stored.u === "string" && stored.u ? stored : null;
-  const gidMatches = Boolean(valid && valid.g && gid && valid.g === gid);
-  const uuid = valid && gidMatches ? valid.u : mint;
-  const changed = uuid ? !valid || valid.u !== uuid || (valid.g || "") !== (gid || "") : false;
-  return { uuid, changed };
+/** #570 P0 — classify an `app.loadGraphData` call as a workflow CREATION (import,
+ *  open-file, drag-drop, template, shared-url, DUPLICATE, PASTE, new-blank) versus a
+ *  reuse (reload-restore, tab-switch, undo/redo, reroute-migration, in-place repaint).
+ *
+ *  ComfyUI passes the open ComfyWorkflow OBJECT as the 4th `loadGraphData` arg for every
+ *  REUSE, and a non-object (null / undefined / string filename) for every CREATION; the
+ *  external imports additionally carry an `openSource`. Paste and duplicate keep the
+ *  SOURCE graph's embedded per-instance uuid, so a creation must MINT A FRESH identity
+ *  before the graph goes live — otherwise a copy that preserved the source's uuid AND
+ *  its synthesized "Unsaved Workflow.json" path inherits the source's session (the
+ *  reopened cross-resume that a (path,graph-id) key can't catch). `noFork` lets the
+ *  panel's OWN same-workflow reloads (snapshot revert) opt out.
+ *
+ *  A rare legacy single-tab restore (a string 4th arg, no openSource) is treated as a
+ *  creation and re-mints — harmless: it already forks into a fresh temporary, and the
+ *  common multi-tab reload passes an object so it is never misclassified. */
+export function isWorkflowCreationLoad({ workflowArg, openSource, noFork = false } = {}) {
+  if (noFork) return false;
+  if (openSource != null) return true;
+  return !(workflowArg !== null && typeof workflowArg === "object");
 }
 
 /** Every identity string the ACTIVE workflow answers to, for pinned-target

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -75,6 +75,28 @@ export function shouldForkInPlaceReload({ cachedUuid, incomingUuid } = {}) {
   return Boolean(cachedUuid) && incomingUuid !== cachedUuid;
 }
 
+/** #570 — resolve the per-instance uuid for an UNSAVED workflow, failing CLOSED on the
+ *  copyable durability carrier. Precedence:
+ *   1. `objectUuid` — the LIVE-object WeakMap value. A copy/import never shares the live
+ *      object, so this is always a safe per-instance identity.
+ *   2. `embeddedId` — the graph.extra uuid. Trustworthy ONLY when `forkActive` is true,
+ *      because the creation-boundary wrapper is what re-mints graph.extra on every
+ *      copy/import/in-place replace. If the sanitizer is not provably installed
+ *      (`forkActive` false), a pasted graph could still carry the SOURCE's uuid, so the
+ *      embedded value is IGNORED and a fresh uuid is minted (lost-resume, never wrong-resume).
+ *   3. a freshly minted uuid.
+ *  `mint` is injected for deterministic tests; defaults to crypto.randomUUID. */
+export function resolveUnsavedInstanceUuid({
+  objectUuid,
+  embeddedId,
+  forkActive,
+  mint = () => crypto.randomUUID(),
+} = {}) {
+  if (objectUuid) return objectUuid;
+  if (forkActive && embeddedId) return embeddedId;
+  return mint();
+}
+
 export function isWorkflowCreationLoad({ workflowArg, openSource, noFork = false } = {}) {
   if (noFork) return false;
   if (openSource != null) return true;

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -91,18 +91,24 @@ export function selectorTargetsNonActiveWorkflow({ resolved, active } = {}) {
  *  refuses a command whose stamped workflow_uuid ≠ the ACTIVE workflow's uuid, so it must cover
  *  everything that runs against the active canvas — every graph_* op AND the active-workflow
  *  mutators workflow_save / workflow_save_as / workflow_rename / workflow_close (workflow_save*
- *  ignore any path, so they are ALWAYS active). It must NOT fire for:
- *   • a PINNED command (`hasPin` — a workflow_path is present): the #349 pin guard is its
- *     authority (covers pinned graph_* and path-targeted workflow_* ops);
+ *  ignore any path, so they are ALWAYS active).
+ *
+ *  A PINNED command (workflow_path present) is NOT exempt (codex): the #349 pin guard authorizes
+ *  by PATH/key/filename, which cannot distinguish workflow A from a DIFFERENT workflow B saved to
+ *  the SAME path after an in-place replacement — a stale command stamped for A still carries a
+ *  matching workflow_path but a mismatching uuid, and only the uuid fence catches it. The pin
+ *  guard runs as an ADDITIONAL check (it catches a switch to a DIFFERENT path the uuid alone
+ *  can't); both must pass. The fence fires for pinned ops too.
+ *
+ *  It must NOT fire only for:
  *   • workflow_open / workflow_new: navigation/creation with their own explicit/new target;
  *   • workflow_rename / workflow_close whose selector resolves to a genuinely NON-active open
- *     workflow (`targetsNonActive` — computed via selectorTargetsNonActiveWorkflow): a
- *     deterministic close/rename of a DIFFERENT workflow must run. A non-empty path that resolves
- *     to the ACTIVE workflow (incl. after an in-place replacement) is NOT exempt — it is fenced.
+ *     workflow (`targetsNonActive` — via selectorTargetsNonActiveWorkflow): a deterministic
+ *     close/rename of a DIFFERENT workflow must run. A path that resolves to the ACTIVE workflow
+ *     (incl. after an in-place replacement) is NOT exempt — it is fenced.
  *  Reads (graph_get_state, …) still return true here — harmlessly fenced (fail-closed); their
  *  reply is server-fenced anyway, and a read can only run against the active canvas regardless. */
-export function activeWorkflowFenceApplies({ cmd, hasPin = false, targetsNonActive = false } = {}) {
-  if (hasPin) return false;
+export function activeWorkflowFenceApplies({ cmd, targetsNonActive = false } = {}) {
   if (cmd === 'workflow_open' || cmd === 'workflow_new') return false;
   if ((cmd === 'workflow_rename' || cmd === 'workflow_close') && targetsNonActive) return false;
   return true;

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -159,7 +159,7 @@ export function resolveUnsavedInstanceUuid({
   return mint();
 }
 
-export function isWorkflowCreationLoad({ workflowArg, openSource, noFork = false } = {}) {
+export function isNewWorkflowLoad({ workflowArg, openSource, noFork = false } = {}) {
   if (noFork) return false;
   if (openSource != null) return true;
   const looksLikeWorkflow =


### PR DESCRIPTION
Paired producer for **artokun/comfyui-mcp#570** (orchestrator PR: artokun/comfyui-mcp#614).

## Why

#587 keyed an unsaved workflow's durable resume on `origin + title + backend`. That is not unique — every unsaved workflow shares the default `"Unsaved Workflow"` title — so after a reset/restart the orchestrator resumed an **unrelated same-title workflow's conversation** (the reopened #570).

## What

Advertise the panel's durable, reload-surviving, globally-unique **per-instance workflow uuid** — `workflowStableUuid()`, the same id that already keys the durable chat transcript and is forked on clone/import (#186/#386) — as `workflow_uuid` on **every** hello. The orchestrator now keys the stable resume index on that uuid instead of the non-unique title, so two distinct unsaved workflows can never cross-resume, and the id survives the `tmp:<uuid>` tab-id churn a reload causes.

- `buildHelloPayload()` gains a `workflowUuid` field -> emits `frame.workflow_uuid`, **omitted when blank** so old orchestrators are unaffected.
- `sendHello()` passes `workflowUuid: workflowStableUuid()`.

`workflowStableUuid()` returns `crypto.randomUUID()`-format ids in every branch, which the orchestrator validates against a strict uuid regex (and folds together with the server-observed trusted origin).

## Tests

`session-rebind.test.mjs`: `workflow_uuid` rides the hello when present; omitted when blank/unknown. Full panel unit suite green.

Draft — do not merge; land together with the orchestrator PR after human re-review (session-loss is high-stakes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
