### PR TITLE
fix(graph-read): report EFFECTIVE widget state + stop blobs starving the node you asked for (comfyui-mcp#607, #609)

### DIFF
--- a/browser_tests/unit/graph-read.test.mjs
+++ b/browser_tests/unit/graph-read.test.mjs
@@ -1,0 +1,261 @@
+// Unit tests for the graph read helpers (web/js/lib/graph-read.js) backing
+// panel_query_graph / panel_graph_outline.
+//
+//   #607 — link-driven widgets must be flagged so a read never reports a stale
+//          stored value as if it were the value that executes.
+//   #609 — one oversized widget blob (or several nodes) must not blow the whole
+//          max_chars budget and return shown:0 for a node asked for by id.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  WIDGET_VALUE_CAP,
+  linkDrivenWidgets,
+  drivenWidgetsFor,
+  drivenTag,
+  capWidgetValue,
+  capSummaryWidgets,
+  clipLine,
+  fitDetailLine,
+  isLineProtected,
+  truncationTail,
+} from "../../web/js/lib/graph-read.js";
+
+// ---- #607: link-driven widget detection -----------------------------------
+
+// A node whose `steps` input is fed by a link from node 85 slot 0, but whose
+// stored `steps` widget still says 30 (the classic Primitive/switch-rail case).
+function ksamplerDrivenBySteps() {
+  const graph = { links: { 7: { origin_id: 85, origin_slot: 0 } } };
+  return {
+    id: 3,
+    type: "KSampler",
+    graph,
+    widgets: [
+      { name: "steps", value: 30 },
+      { name: "cfg", value: 4 },
+    ],
+    inputs: [
+      { name: "model", type: "MODEL", link: null },
+      { name: "steps", type: "INT", link: 7 }, // converted-to-input, link-driven
+    ],
+  };
+}
+
+test("linkDrivenWidgets names the overridden input and its source (#607)", () => {
+  const map = linkDrivenWidgets(ksamplerDrivenBySteps());
+  assert.deepEqual(map, { steps: { node_id: 85, output_slot: 0 } });
+});
+
+test("linkDrivenWidgets supports array-form links [id, slot, ...] (#607)", () => {
+  const node = {
+    graph: { links: { 9: [9, 42, 1, 3, 0, "INT"] } }, // [id, origin_id, origin_slot, ...]
+    inputs: [{ name: "cfg", link: 9 }],
+  };
+  assert.deepEqual(linkDrivenWidgets(node), { cfg: { node_id: 42, output_slot: 1 } });
+});
+
+test("drivenWidgetsFor keeps only names that are real widgets (#607)", () => {
+  const node = ksamplerDrivenBySteps();
+  // `model` is a link-connected input but NOT a widget — must not appear.
+  node.inputs[0].link = 11;
+  node.graph.links[11] = { origin_id: 2, origin_slot: 0 };
+  const only = drivenWidgetsFor(node, ["steps", "cfg"]);
+  assert.deepEqual(only, { steps: { node_id: 85, output_slot: 0 } });
+});
+
+test("drivenWidgetsFor is empty when no widget input is link-connected", () => {
+  const node = {
+    graph: { links: {} },
+    widgets: [{ name: "steps", value: 30 }],
+    inputs: [{ name: "steps", type: "INT", link: null }],
+  };
+  assert.deepEqual(drivenWidgetsFor(node, ["steps"]), {});
+});
+
+test("linkDrivenWidgets never throws on malformed nodes", () => {
+  assert.deepEqual(linkDrivenWidgets(null), {});
+  assert.deepEqual(linkDrivenWidgets({}), {});
+  assert.deepEqual(linkDrivenWidgets({ inputs: [{ name: "x", link: 5 }] }), {}); // no graph.links
+  assert.deepEqual(linkDrivenWidgets({ graph: { links: {} }, inputs: [{ link: 5 }] }), {}); // no name
+});
+
+test("drivenTag renders a concise, honest annotation", () => {
+  assert.equal(drivenTag({ node_id: 85, output_slot: 0 }), " [⚠ link-driven #85.0]");
+  assert.equal(drivenTag(null), "");
+});
+
+// ---- #609: per-value widget cap -------------------------------------------
+
+test("capWidgetValue leaves small values untouched (identity, any type)", () => {
+  assert.equal(capWidgetValue(30), 30);
+  assert.equal(capWidgetValue("euler"), "euler");
+  assert.equal(capWidgetValue(null), null);
+  const obj = { a: 1 };
+  assert.equal(capWidgetValue(obj), obj, "small objects returned by reference");
+});
+
+test("capWidgetValue clips an oversized string and reports the drop (#609)", () => {
+  const blob = "x".repeat(20000);
+  const out = capWidgetValue(blob);
+  assert.ok(out.length < blob.length, "clipped shorter than original");
+  assert.ok(out.startsWith("x".repeat(1000)), "keeps the head");
+  assert.match(out, /…\(\+\d+ chars, truncated\)$/, "reports how much was dropped");
+  assert.ok(JSON.stringify(out).length <= WIDGET_VALUE_CAP, "ESCAPED size within the cap");
+});
+
+test("capWidgetValue bounds by ESCAPED size for control chars / surrogates (#609)", () => {
+  // NUL escapes to 6 chars each (\\u0000); a raw-length cap would blow the budget.
+  const nuls = String.fromCharCode(0).repeat(5000);
+  const out = capWidgetValue(nuls, 600);
+  assert.ok(JSON.stringify(out).length <= 600, `escaped size within cap, got ${JSON.stringify(out).length}`);
+  assert.match(out, /truncated\)$/);
+});
+
+test("capWidgetValue clips oversized serialized objects (ResolutionMaster presets)", () => {
+  const bigObj = { presets: Array.from({ length: 500 }, (_, i) => ({ i, name: `preset ${i}` })) };
+  const out = capWidgetValue(bigObj);
+  assert.equal(typeof out, "string");
+  assert.ok(JSON.stringify(out).length <= WIDGET_VALUE_CAP, "escaped size within the cap");
+  assert.match(out, /truncated\)$/);
+});
+
+test("capSummaryWidgets bounds every widget value without mutating the input (#609)", () => {
+  const summary = { id: 1, type: "ResolutionMaster", widgets: { auto_detect_presets_json: "y".repeat(9000), steps: 20 } };
+  const capped = capSummaryWidgets(summary);
+  assert.notEqual(capped, summary, "returns a clone when something changed");
+  assert.equal(summary.widgets.auto_detect_presets_json.length, 9000, "original untouched");
+  assert.ok(capped.widgets.auto_detect_presets_json.length <= WIDGET_VALUE_CAP + 40);
+  assert.equal(capped.widgets.steps, 20, "small values preserved");
+});
+
+test("capSummaryWidgets bounds the TOTAL widgets size, keeping valid JSON (#609)", () => {
+  // 40 oversized widgets: per-value capping alone still yields ~40×2KB. The total
+  // cap must drop overflow with an elision marker so one node can't blow the budget.
+  const widgets = {};
+  for (let i = 0; i < 40; i++) widgets[`w${i}`] = "z".repeat(5000);
+  const capped = capSummaryWidgets({ id: 1, widgets }, WIDGET_VALUE_CAP, 3000);
+  const json = JSON.stringify(capped);
+  assert.doesNotThrow(() => JSON.parse(json), "result is still valid JSON");
+  assert.ok(json.length < 3000 * 2, `bounded near totalCap, got ${json.length}`);
+  assert.ok("…" in capped.widgets, "carries the elision marker");
+  assert.ok(Object.keys(capped.widgets).length >= 2, "at least one real widget survives");
+});
+
+test("capSummaryWidgets keeps at least one widget even if it alone exceeds the total cap", () => {
+  const capped = capSummaryWidgets({ id: 1, widgets: { blob: "x".repeat(20000), extra: 1 } }, WIDGET_VALUE_CAP, 500);
+  assert.ok("blob" in capped.widgets, "the single huge widget still renders (per-value capped)");
+  assert.match(capped.widgets.blob, /truncated\)$/);
+});
+
+test("capSummaryWidgets tightens the per-value cap to a SMALL total budget (#609)", () => {
+  // totalCap 600 < WIDGET_VALUE_CAP: the single retained widget must be clipped to the
+  // budget, so the serialized line stays near totalCap, not ~2KB.
+  const capped = capSummaryWidgets({ id: 1, widgets: { blob: "q".repeat(5000) } }, WIDGET_VALUE_CAP, 600);
+  assert.ok(JSON.stringify(capped).length < 600 * 2, "line bounded near the small budget");
+  assert.match(capped.widgets.blob, /truncated\)$/);
+});
+
+test("capSummaryWidgets stays bounded on ESCAPE-HEAVY content at a small budget (#609)", () => {
+  // Every char JSON-escapes to two; halving the effective cap keeps the escaped line
+  // near the budget rather than doubling past it.
+  const capped = capSummaryWidgets({ id: 1, widgets: { blob: '"'.repeat(5000) } }, WIDGET_VALUE_CAP, 600);
+  assert.ok(JSON.stringify(capped).length < 600 * 2, `escaped line bounded, got ${JSON.stringify(capped).length}`);
+});
+
+test("fitDetailLine degrades an over-budget JSON line to a bounded valid-JSON stub (#609)", () => {
+  const stub = { id: 42, type: "Hub", title: "x" };
+  const huge = JSON.stringify({ id: 42, type: "Hub", widgets: {}, inputs: Array.from({ length: 5000 }, (_, i) => i) });
+  const out = fitDetailLine(huge, stub, 800);
+  assert.ok(out.length <= 800, `stub within budget, got ${out.length}`);
+  assert.doesNotThrow(() => JSON.parse(out), "stub is valid JSON");
+  assert.equal(JSON.parse(out).id, 42, "keeps the id so the row still identifies the node");
+  assert.match(out, /detail_omitted/);
+});
+
+test("fitDetailLine leaves a within-budget line untouched (#609)", () => {
+  const line = JSON.stringify({ id: 1, type: "KSampler", widgets: { steps: 20 } });
+  assert.equal(fitDetailLine(line, { id: 1, type: "KSampler" }, 2000), line);
+  assert.equal(fitDetailLine(line, { id: 1 }, Infinity), line, "no cap ⇒ unchanged");
+});
+
+test("fitDetailLine clips its OWN stub fields so the stub is ≤ max_chars (#609)", () => {
+  // A pathologically long node id/type must not blow even the degraded stub.
+  const huge = "y".repeat(20000);
+  const out = fitDetailLine(huge, { id: "n".repeat(5000), type: "T".repeat(5000), title: "x".repeat(5000) }, 600);
+  assert.ok(out.length <= 600, `stub self-bounded, got ${out.length}`);
+  assert.doesNotThrow(() => JSON.parse(out), "still valid JSON");
+});
+
+test("clipLine bounds a plain compact line by length, leaving short lines intact (#609)", () => {
+  assert.equal(clipLine("#1 KSampler · steps=20", 2000), "#1 KSampler · steps=20", "short line untouched");
+  const huge = "#1 Wide · " + "k=v ".repeat(5000);
+  const out = clipLine(huge, 2000);
+  assert.ok(out.length <= 2000, `clipped to <= maxChars, got ${out.length}`);
+  assert.ok(out.endsWith("…"), "carries an ellipsis marker");
+  assert.equal(clipLine(huge, Infinity), huge, "no cap ⇒ unchanged");
+});
+
+test("capSummaryWidgets returns the same object when nothing needed capping", () => {
+  const summary = { id: 1, widgets: { steps: 20, cfg: 4 } };
+  assert.equal(capSummaryWidgets(summary), summary);
+});
+
+// The concrete #609 symptom: a single node with a huge widget blob must render.
+test("a capped detail line for one huge-blob node fits a modest budget (#609)", () => {
+  const summary = { id: 164, type: "ResolutionMaster", widgets: { auto_detect_presets_json: "x".repeat(20000) } };
+  const before = JSON.stringify(summary);
+  const after = JSON.stringify(capSummaryWidgets(summary));
+  assert.ok(before.length > 7000, "raw detail exceeds the default single-node budget (reproduces shown:0)");
+  assert.ok(after.length < 7000, "capped detail fits, so the requested node renders");
+});
+
+// ---- #609: budget protection + truncation message -------------------------
+
+test("isLineProtected protects ONLY the first match (never shown:0), keeping the budget bound (#609)", () => {
+  assert.equal(isLineProtected(0), true, "first line always renders, so matched≥1 ⇒ shown≥1");
+  assert.equal(isLineProtected(1), false, "later lines stay budget-governed — output stays token-bounded");
+  assert.equal(isLineProtected(9), false);
+});
+
+test("truncationTail advises raising max_chars when ids were explicit (#609)", () => {
+  const withIds = truncationTail(1, 3, true);
+  assert.match(withIds, /raise max_chars/);
+  assert.doesNotMatch(withIds, /narrow with/, "no dead-end 'narrow with ids' advice");
+
+  const noIds = truncationTail(5, 40, false);
+  assert.match(noIds, /narrow with types\/where\/ids\/depth/);
+});
+
+// End-to-end shape: mirror the graph_query budget loop with the helpers to prove a
+// single-id query with a pathological blob yields shown:1, not shown:0.
+test("budget loop with helpers: one requested huge-blob node renders (shown:1) (#609)", () => {
+  const matched = [{ id: 164, type: "ResolutionMaster", widgets: { blob: "x".repeat(20000) } }];
+  const maxChars = 7000;
+  let shown = 0, truncated = false, chars = 20;
+  for (const n of matched) {
+    const line = JSON.stringify(capSummaryWidgets({ id: n.id, type: n.type, widgets: n.widgets }));
+    const protectedLine = isLineProtected(shown);
+    if (!protectedLine && chars + line.length + 1 > maxChars) { truncated = true; break; }
+    chars += line.length + 1;
+    shown++;
+  }
+  assert.equal(shown, 1, "the node the caller asked for by id renders");
+  assert.equal(truncated, false);
+});
+
+// The budget stays token-bounded: a large ids list is NOT wholesale-exempted (the
+// codex P1 regression). Only the first over-budget line renders; the rest truncate.
+test("budget loop stays bounded for a large ids list — only the first overflows (#609)", () => {
+  const matched = Array.from({ length: 10 }, (_, i) => ({ id: i, widgets: { note: "y".repeat(1500) } }));
+  const maxChars = 4000;
+  let shown = 0, truncated = false, chars = 20;
+  for (const n of matched) {
+    const line = JSON.stringify(capSummaryWidgets({ id: n.id, widgets: n.widgets }));
+    if (!isLineProtected(shown) && chars + line.length + 1 > maxChars) { truncated = true; break; }
+    chars += line.length + 1;
+    shown++;
+  }
+  assert.ok(shown >= 1 && shown < 10, `bounded: rendered ${shown} of 10, not all`);
+  assert.equal(truncated, true, "the rest are honestly marked truncated");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -128,6 +128,15 @@ import {
   unsafeBypassMappings,
 } from "./lib/subgraph-scope.js";
 import { runSetWidget } from "./lib/set-widget.js";
+import {
+  drivenWidgetsFor,
+  drivenTag,
+  capSummaryWidgets,
+  clipLine,
+  fitDetailLine,
+  isLineProtected,
+  truncationTail,
+} from "./lib/graph-read.js";
 import { classifyManualChangeBaseline } from "./lib/manual-change-gate.js";
 import { safeRemoveNode } from "./lib/safe-remove-node.js";
 import {
@@ -4235,6 +4244,11 @@ function summarizeNode(node) {
   // EXPLICIT, seed-associated map (governed-widget → mode) so the mode is visible and
   // an agent can verify a "fixed" seed actually holds.
   const controlAfterGenerate = controlAfterGenerateModes(node);
+  // #607: a widget whose SAME-NAMED input is link-connected is DRIVEN BY THE LINK at
+  // execution — the stored `w.value` is stale (e.g. a KSampler steps/cfg fed from a
+  // Primitive/switch rail). Surface which widgets are overridden and by whom so the
+  // read flags the stale value rather than reporting it as if it were effective.
+  const drivenByLink = drivenWidgetsFor(node, Object.keys(widgets));
   const summary = {
     id: node.id,
     type: node.type,
@@ -4255,6 +4269,9 @@ function summarizeNode(node) {
       ? { control_after_generate: controlAfterGenerate }
       : {}),
     widgets,
+    // #607: names here are OVERRIDDEN by a link at run time — the value in `widgets`
+    // is the stale stored value, NOT what executes. Each entry names the source.
+    ...(Object.keys(drivenByLink).length ? { driven_by_link: drivenByLink } : {}),
     inputs,
     outputs,
   };
@@ -4807,12 +4824,15 @@ const GRAPH_TOOL_EXECUTORS = {
           .filter((e) => e.widget !== e.control)
           .map((e) => [e.widget, e.mode]),
       );
+      // #607: flag widgets overridden by a link so the stored value isn't read as effective.
+      const driven = drivenWidgetsFor(n, (n.widgets ?? []).map((w) => w?.name).filter(Boolean));
       const widgets = (n.widgets ?? [])
         .filter((w) => w && typeof w.name === "string")
         .map((w) => {
           const base = `${w.name}=${fmtVal(w.value)}`;
           const mode = cagMode.get(w.name);
-          return mode ? `${base} [after_gen=${mode}]` : base;
+          const withMode = mode ? `${base} [after_gen=${mode}]` : base;
+          return driven[w.name] ? `${withMode}${drivenTag(driven[w.name])}` : withMode;
         })
         .join(" ");
       lines.push(
@@ -4928,14 +4948,17 @@ const GRAPH_TOOL_EXECUTORS = {
     // 1) Traversal scope.
     let scope = null;
     const maxDepth = depth != null && depth >= 0 ? Number(depth) : Infinity;
+    // #609: clip caller-supplied values echoed in diagnostics so an oversized seed /
+    // predicate can't flood the read.
+    const clipDiag = (s) => { const x = String(s); return x.length > 120 ? x.slice(0, 120) + "…" : x; };
     if (upstream_of != null) {
       const seed = String(upstream_of);
-      if (!byId.has(seed)) return { total, candidates: 0, matched: 0, shown: 0, truncated: false, text: `upstream_of node ${seed} not found (${total} nodes in view).` };
+      if (!byId.has(seed)) return { total, candidates: 0, matched: 0, shown: 0, truncated: false, text: `upstream_of node ${clipDiag(seed)} not found (${total} nodes in view).` };
       scope = closure(up, seed, maxDepth);
     }
     if (downstream_of != null) {
       const seed = String(downstream_of);
-      if (!byId.has(seed)) return { total, candidates: 0, matched: 0, shown: 0, truncated: false, text: `downstream_of node ${seed} not found (${total} nodes in view).` };
+      if (!byId.has(seed)) return { total, candidates: 0, matched: 0, shown: 0, truncated: false, text: `downstream_of node ${clipDiag(seed)} not found (${total} nodes in view).` };
       const d = closure(down, seed, maxDepth);
       scope = scope ? new Set([...scope].filter((x) => d.has(x))) : d;
     }
@@ -4948,7 +4971,7 @@ const GRAPH_TOOL_EXECUTORS = {
     const preds = (Array.isArray(where) ? where : []).map((w) => {
       const m = /^\s*([A-Za-z0-9_.]+)\s*(>=|<=|!=|=|>|<|~)\s*(.*?)\s*$/.exec(String(w));
       // A value starting with an operator char means a mistyped op ("cfg >> 7").
-      if (!m || /^[=<>~]/.test(m[3])) throw new Error(`Bad predicate "${w}" — expected "name op value" with op one of = != >= <= > < ~`);
+      if (!m || /^[=<>~]/.test(m[3])) throw new Error(`Bad predicate "${clipDiag(w)}" — expected "name op value" with op one of = != >= <= > < ~`);
       return { name: m[1], op: m[2], rhs: m[3] };
     });
     const matchPred = (value, op, rhs) => {
@@ -5007,11 +5030,24 @@ const GRAPH_TOOL_EXECUTORS = {
     if (group_by === "type") {
       const hist = new Map();
       for (const n of matched) hist.set(n.type ?? "?", (hist.get(n.type ?? "?") ?? 0) + 1);
-      const lines = [...hist.entries()].sort((a, b) => b[1] - a[1]).map(([t, c]) => `${c}× ${t}`);
+      // #609: bound the aggregate too — clip each type and char-bound the list so a graph
+      // with thousands of distinct/long node types can't flood the read.
+      const clipType = (t) => { const s = String(t); return s.length > 200 ? s.slice(0, 200) + "…" : s; };
+      const allLines = [...hist.entries()].sort((a, b) => b[1] - a[1]).map(([t, c]) => `${c}× ${clipType(t)}`);
+      const head = `${matched.length} node(s) across ${hist.size} type(s):`;
+      const kept = [];
+      let used = head.length;
+      let aggTruncated = false;
+      for (const l of allLines) {
+        if (used + l.length + 1 > maxChars) { aggTruncated = true; break; }
+        kept.push(l);
+        used += l.length + 1;
+      }
+      const aggTail = aggTruncated ? `\n…(${allLines.length - kept.length} more type(s) omitted; raise max_chars)` : "";
       return {
         ...meta, total, candidates: candidates.length, matched: matched.length,
-        shown: matched.length, truncated: false,
-        text: `${matched.length} node(s) across ${hist.size} type(s):\n${lines.join("\n")}`,
+        shown: matched.length, truncated: aggTruncated,
+        text: `${head}\n${kept.join("\n")}${aggTail}`,
       };
     }
 
@@ -5034,24 +5070,41 @@ const GRAPH_TOOL_EXECUTORS = {
       if (shown >= lim) { truncated = true; break; }
       let line;
       if (proj === "ids") {
-        line = String(n.id);
+        line = clipLine(String(n.id), maxChars); // #609: bound even a pathological long id
       } else if (proj === "detail") {
-        line = JSON.stringify(summarizeNode(n));
+        // #609: bound each widget value AND the total widgets size so a
+        // ResolutionMaster/LTXDirector/VHS blob (or a many-widget node) can't consume
+        // the entire budget in one node's detail — even the protected first line.
+        const summary = capSummaryWidgets(summarizeNode(n), undefined, maxChars);
+        line = JSON.stringify(summary);
+        // Final guard: if the fully-capped detail STILL exceeds max_chars (a node with
+        // very many/large slots, which capSummaryWidgets doesn't touch), degrade the
+        // protected line to a bounded valid-JSON stub so it's never dropped yet can't
+        // flood — every rendered detail line ends up ≤ max_chars.
+        line = fitDetailLine(line, { id: summary.id, type: summary.type, title: summary.title }, maxChars);
       } else {
-        const w = Object.entries(widgetsOf(n)).map(([k, v]) => `${k}=${clip(v)}`).join(" ");
+        // #607: flag link-driven widgets in the compact line too.
+        const driven = drivenWidgetsFor(n, (n.widgets ?? []).map((w) => w?.name).filter(Boolean));
+        const w = Object.entries(widgetsOf(n))
+          .map(([k, v]) => `${k}=${clip(v)}${driven[k] ? drivenTag(driven[k]) : ""}`)
+          .join(" ");
         const ins = [...(up.get(String(n.id)) ?? [])].join(",");
         const outs = [...(down.get(String(n.id)) ?? [])].join(",");
         const t = n.title && n.title !== n.type ? ` "${clip(n.title, 40)}"` : "";
         line = `#${n.id} ${n.type ?? "?"}${t}${modeTag(n)}${outTag(n)}` + (w ? ` · ${w}` : "") + (ins ? `  ← ${ins}` : "") + (outs ? `  → ${outs}` : "");
+        // #609: bound the compact line by widget COUNT too (the protected first line
+        // bypasses the running budget, so a thousands-of-widgets node would else be
+        // unbounded). Plain string ⇒ a tail ellipsis is safe.
+        line = clipLine(line, maxChars);
       }
-      if (chars + line.length + 1 > maxChars) { truncated = true; break; }
+      // #609: protect ONLY the first match from the char budget so a single-id query
+      // never returns shown:0. Later lines stay budget-governed (output stays bounded).
+      if (!isLineProtected(shown) && chars + line.length + 1 > maxChars) { truncated = true; break; }
       chars += line.length + 1;
       lines.push(line);
       shown++;
     }
-    const tail = truncated
-      ? `\n… truncated at ${shown} of ${matched.length} — narrow with types/where/ids/depth, use group_by:"type", or raise limit/max_chars.`
-      : "";
+    const tail = truncated ? truncationTail(shown, matched.length, !!(wantIds && wantIds.length)) : "";
     const body = proj === "ids" ? lines.join(",") : lines.join("\n");
     return {
       ...meta, total, candidates: candidates.length, matched: matched.length, shown, truncated,

--- a/web/js/lib/graph-read.js
+++ b/web/js/lib/graph-read.js
@@ -1,0 +1,185 @@
+// Pure read helpers for the graph query/outline tools (panel_query_graph /
+// panel_graph_outline). Kept side-effect-free and dependency-free so they can be
+// unit-tested in isolation (browser_tests/unit/graph-read.test.mjs) and mirror the
+// orchestrator's headless engine (comfyui-mcp src/services/graph-query.ts).
+//
+// Two correctness fixes live here:
+//   #607 — a widget whose SAME-NAMED input is link-connected is DRIVEN BY THE LINK
+//          at execution; its stored value is stale. linkDrivenWidgets() surfaces
+//          which widgets are overridden (and by whom) so a read can flag the stale
+//          value instead of reporting it as if it were effective.
+//   #609 — one oversized widget blob (ResolutionMaster presets JSON,
+//          LTXDirector.timeline_data, VHS videopreview…) or several nodes can blow
+//          the whole max_chars budget, returning `shown:0` for a node you asked for
+//          by id. capSummaryWidgets() bounds each value; isLineProtected() keeps the
+//          FIRST match and any explicitly-requested id renderable regardless.
+
+/** Per-widget-value character cap for the `detail` projection (#609). Big enough
+ *  to identify a value, small enough that one blob can't starve a whole query. */
+export const WIDGET_VALUE_CAP = 2048;
+
+/** Map of widget-name → { node_id, output_slot } for every input on `node` that is
+ *  connected by a link. A widget whose name matches such an input is driven by that
+ *  link at execution — its stored `w.value` is stale (#607). Never throws. */
+export function linkDrivenWidgets(node) {
+  const links = node?.graph?.links ?? {};
+  const out = {};
+  for (const inp of node?.inputs ?? []) {
+    if (!inp || inp.link == null || typeof inp.name !== "string") continue;
+    const l = links[inp.link];
+    if (!l) continue;
+    // Support both object links ({origin_id,origin_slot}) and array links [id,os,...].
+    const originId = l.origin_id ?? l[1];
+    const originSlot = l.origin_slot ?? l[2];
+    if (originId == null) continue;
+    out[inp.name] = { node_id: originId, output_slot: originSlot ?? 0 };
+  }
+  return out;
+}
+
+/** Restrict a full link-driven map to only the names that are actually WIDGETS on
+ *  the node (a link-connected input with no matching widget is a normal input,
+ *  already shown under `inputs`). `widgetNames` is any iterable of names. */
+export function drivenWidgetsFor(node, widgetNames) {
+  const all = linkDrivenWidgets(node);
+  const names = widgetNames instanceof Set ? widgetNames : new Set(widgetNames ?? []);
+  const out = {};
+  for (const name of Object.keys(all)) if (names.has(name)) out[name] = all[name];
+  return out;
+}
+
+/** A concise, human-readable annotation for a link-driven widget, e.g.
+ *  "[⚠ link-driven #85.0]". `src` is a { node_id, output_slot } entry. */
+export function drivenTag(src) {
+  if (!src) return "";
+  return ` [⚠ link-driven #${src.node_id}.${src.output_slot}]`;
+}
+
+/** Bound a single widget value by its ESCAPED (JSON-serialized) size (#609), so the
+ *  bound holds regardless of content — control chars ( ) and lone surrogates
+ *  escape to 6 chars each, not 2. Returns the value unchanged when it already fits;
+ *  otherwise the longest head prefix whose encoding fits `cap`, with an honest marker
+ *  naming how many raw chars were dropped. */
+export function capWidgetValue(value, cap = WIDGET_VALUE_CAP) {
+  if (value == null) return value;
+  const isString = typeof value === "string";
+  const s = isString ? value : (() => { try { return JSON.stringify(value); } catch { return String(value); } })();
+  if (typeof s !== "string") return value;
+  if (JSON.stringify(s).length <= cap) return value;
+  // Binary-search the longest raw prefix whose ESCAPED length fits, reserving room
+  // for the marker (itself plain ASCII, so its escaped size ≈ its length).
+  const target = Math.max(2, cap - 40);
+  let lo = 0;
+  let hi = s.length;
+  let best = 0;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (JSON.stringify(s.slice(0, mid)).length <= target) { best = mid; lo = mid + 1; }
+    else hi = mid - 1;
+  }
+  return `${s.slice(0, best)}…(+${s.length - best} chars, truncated)`;
+}
+
+/** Clip a KEY/name to a small bound (#609) — node/widget/input names are short
+ *  identifiers, but a pathological graph shouldn't be able to blow the line via a key. */
+function capKey(key, cap = 128) {
+  const k = String(key);
+  return k.length <= cap ? k : `${k.slice(0, cap)}…`;
+}
+
+/** Serialized (JSON-escaped) size of one `"key":value,` widget entry — the ACTUAL
+ *  contribution to the line, so escape-heavy strings (quotes/newlines) don't slip the
+ *  budget. */
+function entrySize(key, value) {
+  let vLen;
+  try { vLen = JSON.stringify(value)?.length ?? 0; } catch { vLen = String(value).length; }
+  return JSON.stringify(String(key)).length + vLen + 2; // "key": value ,
+}
+
+/** Return a shallow clone of a summarizeNode() result whose `widgets` are bounded
+ *  (#609): each value is clipped, AND the total serialized widgets size is kept under
+ *  `totalCap` by DROPPING overflow widgets (keeping valid JSON) with an elision
+ *  marker — so even a node with many oversized widgets can't blow the char budget.
+ *  When a budget is set, the per-value cap is tightened to it so even the single
+ *  retained widget respects `totalCap`. At least one widget always survives. The
+ *  original summary is not mutated. */
+export function capSummaryWidgets(summary, cap = WIDGET_VALUE_CAP, totalCap = Infinity) {
+  if (!summary || typeof summary !== "object" || !summary.widgets) return summary;
+  // capWidgetValue bounds the ESCAPED size exactly, so the per-value cap can be the
+  // budget itself (minus a small reserve for the key + JSON framing).
+  const perValueCap = Number.isFinite(totalCap) ? Math.min(cap, Math.max(1, totalCap - 256)) : cap;
+  const entries = Object.entries(summary.widgets);
+  const widgets = {};
+  let used = 0;
+  let omitted = 0;
+  let changed = false;
+  for (let i = 0; i < entries.length; i++) {
+    const [rawKey, v] = entries[i];
+    const k = capKey(rawKey);
+    if (k !== rawKey) changed = true;
+    const capped = capWidgetValue(v, perValueCap);
+    if (capped !== v) changed = true;
+    const size = entrySize(k, capped);
+    // Keep at least one widget, then stop once the total would exceed the budget.
+    if (Number.isFinite(totalCap) && Object.keys(widgets).length > 0 && used + size > totalCap) {
+      omitted = entries.length - i;
+      changed = true;
+      break;
+    }
+    widgets[k] = capped;
+    used += size;
+  }
+  if (omitted > 0) widgets["…"] = `${omitted} widget(s) omitted (exceeded budget); raise max_chars`;
+  return changed ? { ...summary, widgets } : summary;
+}
+
+/** Hard-clip an assembled COMPACT (plain-string) line to `maxChars` (#609). The
+ *  protected first match bypasses the running budget, so without this a node with
+ *  thousands of small widgets could emit an unbounded first line. Plain string, so a
+ *  tail ellipsis is safe (unlike detail's JSON, which is bounded via capSummaryWidgets). */
+export function clipLine(line, maxChars) {
+  if (!Number.isFinite(maxChars) || line.length <= maxChars) return line;
+  return line.slice(0, Math.max(0, maxChars - 1)) + "…";
+}
+
+/** Final guard for a DETAIL (JSON) line (#609): if a node's fully-capped detail STILL
+ *  exceeds `maxChars` — a high-fan-in / many-slot node whose inputs/outputs the
+ *  per-field caps don't touch — replace it with a bounded, VALID-JSON stub carrying
+ *  the essentials + guidance. The row is never dropped (shown stays ≥ 1) but can't
+ *  flood: every rendered line is ≤ maxChars. `stub` is a small object {id, type, …}. */
+export function fitDetailLine(line, stub, maxChars) {
+  if (!Number.isFinite(maxChars) || line.length <= maxChars) return line;
+  // Clip the stub's OWN fields too — a graph may carry an arbitrarily long node id or
+  // type, which would otherwise blow even the stub past the budget.
+  const clipF = (v) => (typeof v === "string" && v.length > 60 ? `${v.slice(0, 60)}…` : v);
+  const safe = {
+    id: clipF(stub?.id),
+    type: clipF(stub?.type),
+    ...(stub?.title != null ? { title: clipF(stub.title) } : {}),
+  };
+  const s = JSON.stringify({
+    ...safe,
+    detail_omitted: `full detail is ${line.length} chars > max_chars ${maxChars}; raise max_chars to read this node`,
+  });
+  if (s.length <= maxChars) return s;
+  // Absurdly small budget: a minimal fixed-shape row (id clipped hard) that still identifies the node.
+  return JSON.stringify({ id: typeof safe.id === "string" ? safe.id.slice(0, 40) : safe.id, detail_omitted: "raise max_chars" });
+}
+
+/** Whether a line must render regardless of the remaining char budget (#609): ONLY
+ *  the FIRST match, so a non-empty match never yields `shown:0` (the reported
+ *  single-id failure). Deliberately does NOT exempt every requested id — that would
+ *  disable the max_chars token bound for a large `ids` list. At most one line (the
+ *  first, itself per-value capped) can exceed the budget, keeping output bounded. */
+export function isLineProtected(shownSoFar) {
+  return shownSoFar === 0;
+}
+
+/** Build the truncation-tail advice (#609). When the caller passed explicit `ids`,
+ *  "narrow with ids" is a dead end — advise raising max_chars / fewer ids instead. */
+export function truncationTail(shown, matchedCount, hasExplicitIds) {
+  if (hasExplicitIds) {
+    return `\n… truncated at ${shown} of ${matchedCount} — requested nodes exceed max_chars (per-field values are already capped); raise max_chars or request fewer ids at once.`;
+  }
+  return `\n… truncated at ${shown} of ${matchedCount} — narrow with types/where/ids/depth, use group_by:"type", or raise limit/max_chars.`;
+}


### PR DESCRIPTION
Companion to **artokun/comfyui-mcp#617** — the user-facing half of the `panel_query_graph` / `panel_graph_outline` read-correctness cluster. Fixes artokun/comfyui-mcp#607 and artokun/comfyui-mcp#609 on the live-graph engine (the mcp PR carries the lockstep headless change and the `Closes` keywords).

## Root causes & fixes

**#607 — reads reported DECLARED widget values, not EFFECTIVE ones.** When a widget's same-named input is link-connected (a Primitive/switch rail driving a KSampler's `steps`/`cfg`), the stored widget value is stale — the link wins at execution — so the read printed numbers the graph won't use (a KSampler reported 30 steps / cfg 4 while actually running 8 steps / cfg 1 via the turbo rail).
Fix: `summarizeNode` now emits a `driven_by_link` map (`widget → {node_id, output_slot}`) for any widget whose same-named input is link-connected; `graph_outline` and `graph_query` compact lines append a `[⚠ link-driven #id.slot]` tag. Widgets that are NOT link-driven are untouched and `widgets` values stay scalar (predicate filtering / `graph_find_nodes` / `view_selected` unaffected).

**#609 — one node's detail could starve the budget, returning ZERO for the node you asked for.** A single oversized widget blob (ResolutionMaster presets JSON, `LTXDirector.timeline_data`, VHS videopreview) made one node's `detail` exceed `max_chars`, so `panel_query_graph {ids:[164], fields:'detail'}` returned `matched:1, shown:0, truncated:true` — and the advice "narrow with ids" was a dead end for someone who already gave one id. (`groups[]` rides in a separate meta field and was never charged to the text budget — the node's own blob was the starver.)
Fix: per-value widget cap (exact JSON-escaped size), per-node total-widgets cap (drop overflow keeping valid JSON + elision marker), **first-match-only** budget protection so a matched query never yields `shown:0`, and a `fitDetailLine` guard that degrades an over-budget row to a self-bounded valid-JSON stub. `ids`/`compact` lines are hard-clipped, the `group_by` aggregate and seed/predicate diagnostics are char-bounded, so every rendered row is ≤ ~`max_chars`. Explicit-`ids` truncation advice now says raise `max_chars`.

New pure helpers live in `web/js/lib/graph-read.js` (`linkDrivenWidgets`, `capWidgetValue`, `capSummaryWidgets`, `clipLine`, `fitDetailLine`, `isLineProtected`, `truncationTail`).

## Tests / verification

- `browser_tests/unit/graph-read.test.mjs`: 25 unit tests (link-driven detection incl. array/object links; exact-escaped + total caps; control-char/NUL bound; `fitDetailLine` self-bounding; `clipLine`; first-line protection; truncation advice). `node --test` green; full panel unit suite green; panel ESM syntax-checked.
- Mirrors the orchestrator headless engine (comfyui-mcp#617). Adversarial `codex` self-review (gpt-5.6-terra, high) over both diffs: **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
