### PR TITLE
fix(workflow-files): stale-tab detection on open + in-place save 409 (#442 defects 2,3)

### DIFF
--- a/browser_tests/unit/workflow-inplace-overwrite.test.mjs
+++ b/browser_tests/unit/workflow-inplace-overwrite.test.mjs
@@ -1,0 +1,102 @@
+// #442 defect 3 — panel_save_workflow must not 409 when saving IN PLACE over the
+// workflow's OWN name. ComfyUI's UserFile.save() writes with `overwrite: isPersisted`,
+// and `isPersisted`/`isTemporary` are getters derived from `size` (isTemporary =
+// size === -1). After a panel_open_workflow open-ack race the loaded workflow's `size`
+// drifts to -1, so `isPersisted` reads false → overwrite:false → the server 409s on the
+// existing own file.
+//
+// The fix splits the async PROBE (inPlaceOverwriteAuthorized — no mutation) from the
+// synchronous MUTATION (markPersistedForOverwrite), so the coercion runs only AFTER the
+// caller re-asserts the expected tab (codex P2: a probe-then-mutate that mutated before
+// the second assertExpect leaked overwrite authorization onto an aborted tab).
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  inPlaceOverwriteAuthorized,
+  markPersistedForOverwrite,
+} from "../../web/js/lib/workflow-save.js";
+
+/** A workflow object mirroring ComfyUI's real UserFile: isPersisted/isTemporary are
+ *  GETTERS over `size` (a plain, settable field), so the only way to flip persistence
+ *  is to change `size` — exactly what the fix must do. */
+function makeWorkflow({ path = "workflows/Krea2 Studio v3.json", size = -1 } = {}) {
+  return {
+    path,
+    size,
+    get isTemporary() {
+      return this.size === -1;
+    },
+    get isPersisted() {
+      return this.size !== -1;
+    },
+    // What ComfyUI's save() would send as the /userdata `overwrite` query param.
+    get overwriteParam() {
+      return this.isPersisted;
+    },
+  };
+}
+
+const CONFIRM = async () => true; // disk oracle: file exists (200)
+const ABSENT = async () => false; // disk oracle: 404
+const UNKNOWN = async () => null; // disk oracle: inconclusive
+const THROWS = async () => {
+  throw new Error("probe failed");
+};
+
+test("drifted-persisted own file (size -1) + disk-confirmed ⇒ authorized, and coercion enables overwrite", async () => {
+  const wf = makeWorkflow({ size: -1 });
+  assert.equal(wf.overwriteParam, false, "precondition: drift makes overwrite false (the 409 cause)");
+  const allow = await inPlaceOverwriteAuthorized(wf, wf.path, CONFIRM);
+  assert.equal(allow, true);
+  assert.equal(wf.overwriteParam, false, "PROBE must not mutate (still false until the sync coercion)");
+  markPersistedForOverwrite(wf);
+  assert.equal(wf.isPersisted, true);
+  assert.equal(wf.overwriteParam, true, "in-place save now overwrites the own file — no 409");
+  assert.notEqual(wf.size, -1);
+});
+
+test("already-persisted workflow ⇒ not authorized (overwrite already true)", async () => {
+  const wf = makeWorkflow({ size: 4096 });
+  assert.equal(await inPlaceOverwriteAuthorized(wf, wf.path, CONFIRM), false);
+  assert.equal(wf.overwriteParam, true);
+});
+
+test("disk says ABSENT (404) ⇒ not authorized — a genuine first save keeps overwrite:false", async () => {
+  const wf = makeWorkflow({ size: -1 });
+  assert.equal(await inPlaceOverwriteAuthorized(wf, wf.path, ABSENT), false);
+});
+
+test("disk UNKNOWN ⇒ not authorized (fail safe — a real collision still 409s honestly)", async () => {
+  const wf = makeWorkflow({ size: -1 });
+  assert.equal(await inPlaceOverwriteAuthorized(wf, wf.path, UNKNOWN), false);
+});
+
+test("oracle THROWS ⇒ not authorized", async () => {
+  const wf = makeWorkflow({ size: -1 });
+  assert.equal(await inPlaceOverwriteAuthorized(wf, wf.path, THROWS), false);
+});
+
+test("no oracle / no path ⇒ not authorized", async () => {
+  const wf1 = makeWorkflow({ size: -1 });
+  assert.equal(await inPlaceOverwriteAuthorized(wf1, wf1.path, undefined), false);
+  const wf2 = makeWorkflow({ size: -1 });
+  assert.equal(await inPlaceOverwriteAuthorized(wf2, "", CONFIRM), false);
+});
+
+test("PROBE never mutates (P2): a positive probe leaves the workflow untouched until coercion", async () => {
+  const wf = makeWorkflow({ size: -1 });
+  await inPlaceOverwriteAuthorized(wf, wf.path, CONFIRM);
+  // The caller aborts here (e.g. assertExpect throws because the tab switched) and
+  // MUST NOT call markPersistedForOverwrite — the tab is left exactly as it was.
+  assert.equal(wf.size, -1);
+  assert.equal(wf.isPersisted, false);
+  assert.equal(wf.overwriteParam, false);
+});
+
+test("markPersistedForOverwrite corrects plain-object doubles (no getters) too", () => {
+  const wf = { path: "workflows/Foo.json", size: -1, isTemporary: true, isPersisted: false };
+  markPersistedForOverwrite(wf);
+  assert.equal(wf.isPersisted, true);
+  assert.equal(wf.isTemporary, false);
+  assert.notEqual(wf.size, -1);
+});

--- a/browser_tests/unit/workflow-inplace-overwrite.test.mjs
+++ b/browser_tests/unit/workflow-inplace-overwrite.test.mjs
@@ -1,28 +1,36 @@
 // #442 defect 3 — panel_save_workflow must not 409 when saving IN PLACE over the
-// workflow's OWN name. ComfyUI's UserFile.save() writes with `overwrite: isPersisted`,
-// and `isPersisted`/`isTemporary` are getters derived from `size` (isTemporary =
-// size === -1). After a panel_open_workflow open-ack race the loaded workflow's `size`
-// drifts to -1, so `isPersisted` reads false → overwrite:false → the server 409s on the
-// existing own file.
+// workflow's OWN name, but MUST NOT turn that fix into a destructive overwrite.
 //
-// The fix splits the async PROBE (inPlaceOverwriteAuthorized — no mutation) from the
-// synchronous MUTATION (markPersistedForOverwrite), so the coercion runs only AFTER the
-// caller re-asserts the expected tab (codex P2: a probe-then-mutate that mutated before
-// the second assertExpect leaked overwrite authorization onto an aborted tab).
+// ComfyUI's UserFile.save() writes with `overwrite: isPersisted`, and isPersisted
+// derives from `size` (isTemporary = size === -1). After a panel_open_workflow
+// open-ack race the loaded workflow's `size` drifts to -1 → overwrite:false → the
+// server 409s on the existing own file. The fix forces overwrite:true for the drifted
+// tab — but ONLY when the on-disk bytes STILL MATCH what the tab loaded
+// (wf.originalContent). If the file changed under us (another tab/agent/process wrote
+// B), forcing the overwrite would CLOBBER B — the 409 was protective there — so the
+// classifier returns "conflict" and the caller refuses (codex P0 data-loss guard).
+//
+// classifyInPlaceOverwrite is a PURE async probe (no mutation); markPersistedForOverwrite
+// is the synchronous coercion the caller applies only on "authorize", after re-asserting
+// the tab (codex P2 TOCTOU).
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
-  inPlaceOverwriteAuthorized,
+  classifyInPlaceOverwrite,
   markPersistedForOverwrite,
 } from "../../web/js/lib/workflow-save.js";
 
+const A = JSON.stringify({ nodes: [{ id: 1, pos: [0, 0] }] }); // what the tab loaded
+const B = JSON.stringify({ nodes: [{ id: 1, pos: [500, 300] }] }); // changed on disk
+
 /** A workflow object mirroring ComfyUI's real UserFile: isPersisted/isTemporary are
- *  GETTERS over `size` (a plain, settable field), so the only way to flip persistence
- *  is to change `size` — exactly what the fix must do. */
-function makeWorkflow({ path = "workflows/Krea2 Studio v3.json", size = -1 } = {}) {
+ *  GETTERS over `size` (a plain, settable field); `originalContent` is the text the tab
+ *  loaded from disk (the baseline the overwrite gate compares against). */
+function makeWorkflow({ path = "workflows/Krea2 Studio v3.json", size = -1, originalContent = A } = {}) {
   return {
     path,
     size,
+    originalContent,
     get isTemporary() {
       return this.size === -1;
     },
@@ -36,61 +44,65 @@ function makeWorkflow({ path = "workflows/Krea2 Studio v3.json", size = -1 } = {
   };
 }
 
-const CONFIRM = async () => true; // disk oracle: file exists (200)
-const ABSENT = async () => false; // disk oracle: 404
-const UNKNOWN = async () => null; // disk oracle: inconclusive
+const readsDisk = (content) => async () => content; // oracle returns fixed disk content
 const THROWS = async () => {
-  throw new Error("probe failed");
+  throw new Error("read failed");
 };
 
-test("drifted-persisted own file (size -1) + disk-confirmed ⇒ authorized, and coercion enables overwrite", async () => {
-  const wf = makeWorkflow({ size: -1 });
+test("drifted own file + disk STILL MATCHES the loaded baseline ⇒ authorize + overwrite becomes true", async () => {
+  const wf = makeWorkflow({ size: -1, originalContent: A });
   assert.equal(wf.overwriteParam, false, "precondition: drift makes overwrite false (the 409 cause)");
-  const allow = await inPlaceOverwriteAuthorized(wf, wf.path, CONFIRM);
-  assert.equal(allow, true);
-  assert.equal(wf.overwriteParam, false, "PROBE must not mutate (still false until the sync coercion)");
+  const decision = await classifyInPlaceOverwrite(wf, wf.path, readsDisk(A));
+  assert.equal(decision, "authorize");
+  assert.equal(wf.overwriteParam, false, "PROBE must not mutate");
   markPersistedForOverwrite(wf);
-  assert.equal(wf.isPersisted, true);
-  assert.equal(wf.overwriteParam, true, "in-place save now overwrites the own file — no 409");
-  assert.notEqual(wf.size, -1);
+  assert.equal(wf.overwriteParam, true, "in-place save now overwrites the own unchanged file — no 409");
 });
 
-test("already-persisted workflow ⇒ not authorized (overwrite already true)", async () => {
-  const wf = makeWorkflow({ size: 4096 });
-  assert.equal(await inPlaceOverwriteAuthorized(wf, wf.path, CONFIRM), false);
-  assert.equal(wf.overwriteParam, true);
+test("P0 REGRESSION — drifted own file + disk CHANGED (A loaded, B on disk) ⇒ CONFLICT, never a forced overwrite", async () => {
+  const wf = makeWorkflow({ size: -1, originalContent: A });
+  const decision = await classifyInPlaceOverwrite(wf, wf.path, readsDisk(B));
+  assert.equal(decision, "conflict", "must refuse — forcing overwrite would clobber the newer on-disk content");
+  assert.equal(wf.overwriteParam, false, "workflow left untouched (the caller throws a surfaced conflict)");
 });
 
-test("disk says ABSENT (404) ⇒ not authorized — a genuine first save keeps overwrite:false", async () => {
-  const wf = makeWorkflow({ size: -1 });
-  assert.equal(await inPlaceOverwriteAuthorized(wf, wf.path, ABSENT), false);
+test("already-persisted workflow ⇒ skip (ComfyUI's own overwrite:true path runs, unchanged)", async () => {
+  const wf = makeWorkflow({ size: 4096, originalContent: A });
+  assert.equal(await classifyInPlaceOverwrite(wf, wf.path, readsDisk(B)), "skip");
 });
 
-test("disk UNKNOWN ⇒ not authorized (fail safe — a real collision still 409s honestly)", async () => {
-  const wf = makeWorkflow({ size: -1 });
-  assert.equal(await inPlaceOverwriteAuthorized(wf, wf.path, UNKNOWN), false);
+test("disk ABSENT (read returns null) ⇒ skip — overwrite:false safely CREATES the file", async () => {
+  const wf = makeWorkflow({ size: -1, originalContent: A });
+  assert.equal(await classifyInPlaceOverwrite(wf, wf.path, readsDisk(null)), "skip");
 });
 
-test("oracle THROWS ⇒ not authorized", async () => {
-  const wf = makeWorkflow({ size: -1 });
-  assert.equal(await inPlaceOverwriteAuthorized(wf, wf.path, THROWS), false);
+test("read THROWS / no oracle / no path / no baseline ⇒ skip (leave overwrite:false — 409s honestly)", async () => {
+  assert.equal(await classifyInPlaceOverwrite(makeWorkflow(), "workflows/x.json", THROWS), "skip");
+  assert.equal(await classifyInPlaceOverwrite(makeWorkflow(), "workflows/x.json", undefined), "skip");
+  assert.equal(await classifyInPlaceOverwrite(makeWorkflow(), "", readsDisk(A)), "skip");
+  assert.equal(
+    await classifyInPlaceOverwrite(makeWorkflow({ originalContent: null }), "workflows/x.json", readsDisk(A)),
+    "skip",
+    "no loaded baseline ⇒ cannot prove safe ⇒ skip",
+  );
 });
 
-test("no oracle / no path ⇒ not authorized", async () => {
-  const wf1 = makeWorkflow({ size: -1 });
-  assert.equal(await inPlaceOverwriteAuthorized(wf1, wf1.path, undefined), false);
-  const wf2 = makeWorkflow({ size: -1 });
-  assert.equal(await inPlaceOverwriteAuthorized(wf2, "", CONFIRM), false);
+test("byte-exact: a reformat on disk is a CONFLICT, not authorize (safe — never a false-equal overwrite)", async () => {
+  // Exact comparison (not JSON round-trip, which could collapse distinct large-int seeds
+  // and authorize a destructive overwrite — codex P0). A formatting-only change reads as
+  // changed ⇒ conflict: the caller refuses, the user reloads. Over-cautious, never lossy.
+  const pretty = JSON.stringify(JSON.parse(A), null, 2); // identical data, different bytes
+  assert.equal(
+    await classifyInPlaceOverwrite(makeWorkflow({ originalContent: A }), "workflows/x.json", readsDisk(pretty)),
+    "conflict",
+  );
 });
 
-test("PROBE never mutates (P2): a positive probe leaves the workflow untouched until coercion", async () => {
-  const wf = makeWorkflow({ size: -1 });
-  await inPlaceOverwriteAuthorized(wf, wf.path, CONFIRM);
-  // The caller aborts here (e.g. assertExpect throws because the tab switched) and
-  // MUST NOT call markPersistedForOverwrite — the tab is left exactly as it was.
-  assert.equal(wf.size, -1);
-  assert.equal(wf.isPersisted, false);
-  assert.equal(wf.overwriteParam, false);
+test("byte-exact: an IDENTICAL-bytes disk file authorizes (the real defect-3 unchanged-file case)", async () => {
+  assert.equal(
+    await classifyInPlaceOverwrite(makeWorkflow({ originalContent: A }), "workflows/x.json", readsDisk(A)),
+    "authorize",
+  );
 });
 
 test("markPersistedForOverwrite corrects plain-object doubles (no getters) too", () => {

--- a/browser_tests/unit/workflow-inplace-overwrite.test.mjs
+++ b/browser_tests/unit/workflow-inplace-overwrite.test.mjs
@@ -22,6 +22,15 @@ import {
 
 const A = JSON.stringify({ nodes: [{ id: 1, pos: [0, 0] }] }); // what the tab loaded
 const B = JSON.stringify({ nodes: [{ id: 1, pos: [500, 300] }] }); // changed on disk
+const enc = new TextEncoder();
+const bytes = (text) => enc.encode(text); // canonical UTF-8, no BOM (how ComfyUI writes)
+const withBom = (text) => {
+  const body = enc.encode(text);
+  const out = new Uint8Array(body.length + 3);
+  out.set([0xef, 0xbb, 0xbf], 0); // UTF-8 BOM
+  out.set(body, 3);
+  return out;
+};
 
 /** A workflow object mirroring ComfyUI's real UserFile: isPersisted/isTemporary are
  *  GETTERS over `size` (a plain, settable field); `originalContent` is the text the tab
@@ -44,7 +53,8 @@ function makeWorkflow({ path = "workflows/Krea2 Studio v3.json", size = -1, orig
   };
 }
 
-const readsDisk = (content) => async () => content; // oracle returns fixed disk content
+const readsDisk = (content) => async () => (content == null ? null : bytes(content)); // bytes oracle
+const readsRaw = (u8) => async () => u8; // oracle returning a raw Uint8Array (or null) verbatim
 const THROWS = async () => {
   throw new Error("read failed");
 };
@@ -66,6 +76,15 @@ test("P0 REGRESSION — drifted own file + disk CHANGED (A loaded, B on disk) �
   assert.equal(wf.overwriteParam, false, "workflow left untouched (the caller throws a surfaced conflict)");
 });
 
+test("P0 REGRESSION (BOM) — loaded A (no BOM) + disk changed to BOM+A ⇒ CONFLICT, not authorize", async () => {
+  // Response.text() strips a UTF-8 BOM, so a decoded-string compare would treat A and
+  // BOM+A as equal and clobber the external BOM-bearing change. The RAW-BYTE gate must
+  // see the extra 3 BOM bytes and refuse.
+  const wf = makeWorkflow({ size: -1, originalContent: A });
+  assert.equal(await classifyInPlaceOverwrite(wf, wf.path, readsRaw(withBom(A))), "conflict");
+  assert.equal(wf.overwriteParam, false, "untouched — the BOM-bearing on-disk change is not overwritten");
+});
+
 test("already-persisted workflow ⇒ skip (ComfyUI's own overwrite:true path runs, unchanged)", async () => {
   const wf = makeWorkflow({ size: 4096, originalContent: A });
   assert.equal(await classifyInPlaceOverwrite(wf, wf.path, readsDisk(B)), "skip");
@@ -76,7 +95,7 @@ test("disk ABSENT (read returns null) ⇒ skip — overwrite:false safely CREATE
   assert.equal(await classifyInPlaceOverwrite(wf, wf.path, readsDisk(null)), "skip");
 });
 
-test("read THROWS / no oracle / no path / no baseline ⇒ skip (leave overwrite:false — 409s honestly)", async () => {
+test("read THROWS / no oracle / no path / no baseline / non-bytes result ⇒ skip (leave overwrite:false)", async () => {
   assert.equal(await classifyInPlaceOverwrite(makeWorkflow(), "workflows/x.json", THROWS), "skip");
   assert.equal(await classifyInPlaceOverwrite(makeWorkflow(), "workflows/x.json", undefined), "skip");
   assert.equal(await classifyInPlaceOverwrite(makeWorkflow(), "", readsDisk(A)), "skip");
@@ -85,10 +104,15 @@ test("read THROWS / no oracle / no path / no baseline ⇒ skip (leave overwrite:
     "skip",
     "no loaded baseline ⇒ cannot prove safe ⇒ skip",
   );
+  assert.equal(
+    await classifyInPlaceOverwrite(makeWorkflow(), "workflows/x.json", readsRaw("A")),
+    "skip",
+    "a non-bytes (string) result is not trusted ⇒ skip, never a forced overwrite",
+  );
 });
 
 test("byte-exact: a reformat on disk is a CONFLICT, not authorize (safe — never a false-equal overwrite)", async () => {
-  // Exact comparison (not JSON round-trip, which could collapse distinct large-int seeds
+  // Byte comparison (not JSON round-trip, which could collapse distinct large-int seeds
   // and authorize a destructive overwrite — codex P0). A formatting-only change reads as
   // changed ⇒ conflict: the caller refuses, the user reloads. Over-cautious, never lossy.
   const pretty = JSON.stringify(JSON.parse(A), null, 2); // identical data, different bytes

--- a/browser_tests/unit/workflow-open-staleness.test.mjs
+++ b/browser_tests/unit/workflow-open-staleness.test.mjs
@@ -5,7 +5,33 @@
 // is CONTENT-based so it survives the frontend's mtime-only listing sync.
 import test from "node:test";
 import assert from "node:assert/strict";
-import { decideOpenStaleness } from "../../web/js/lib/workflow-open-staleness.js";
+import { decideOpenStaleness, diskBytesEqualText } from "../../web/js/lib/workflow-open-staleness.js";
+
+const enc = new TextEncoder();
+const withBom = (text) => {
+  const body = enc.encode(text);
+  const out = new Uint8Array(body.length + 3);
+  out.set([0xef, 0xbb, 0xbf], 0);
+  out.set(body, 3);
+  return out;
+};
+
+test("diskBytesEqualText: canonical UTF-8 (no BOM) of the baseline ⇒ equal (the ComfyUI-written case)", () => {
+  assert.equal(diskBytesEqualText(enc.encode("hello"), "hello"), true);
+  // Accepts a raw ArrayBuffer too.
+  assert.equal(diskBytesEqualText(enc.encode("hello").buffer, "hello"), true);
+});
+
+test("diskBytesEqualText: a UTF-8 BOM on disk is NOT equal to the (BOM-stripped) baseline text (codex P0)", () => {
+  assert.equal(diskBytesEqualText(withBom("hello"), "hello"), false);
+});
+
+test("diskBytesEqualText: any byte difference ⇒ false; non-bytes / non-string ⇒ false (fail closed)", () => {
+  assert.equal(diskBytesEqualText(enc.encode("hello!"), "hello"), false);
+  assert.equal(diskBytesEqualText(null, "hello"), false);
+  assert.equal(diskBytesEqualText(enc.encode("hello"), null), false);
+  assert.equal(diskBytesEqualText("hello", "hello"), false); // a string is not raw bytes
+});
 
 const A = JSON.stringify({ nodes: [{ id: 1, pos: [0, 0] }] });
 const B = JSON.stringify({ nodes: [{ id: 1, pos: [500, 300] }] }); // edited on disk

--- a/browser_tests/unit/workflow-open-staleness.test.mjs
+++ b/browser_tests/unit/workflow-open-staleness.test.mjs
@@ -38,11 +38,14 @@ test("identical on-disk content ⇒ not stale", () => {
   );
 });
 
-test("pure reformat (whitespace/indent only) is NOT reported as stale", () => {
-  const pretty = JSON.stringify(JSON.parse(A), null, 2); // same data, indented
+test("byte-exact: a reformat (or any byte change) is treated as stale (safe over-caution, never false-fresh)", () => {
+  // Comparison is byte-exact (a JSON round-trip could collapse distinct large-int seeds
+  // and falsely report fresh — codex P0). A pure reformat therefore reads as changed:
+  // an over-cautious stale flag, never a missed change.
+  const pretty = JSON.stringify(JSON.parse(A), null, 2); // same data, different bytes
   assert.deepEqual(
     decideOpenStaleness({ wasOpen: true, isModified: false, onDiskContent: pretty, baselineContent: A }),
-    { stale: false, reload: false },
+    { stale: true, reload: true },
   );
 });
 
@@ -57,7 +60,7 @@ test("non-JSON content falls back to a raw compare (differs ⇒ stale, same ⇒ 
   );
 });
 
-test("unreadable disk / missing baseline fail safe (no false staleness)", () => {
+test("unreadable disk / missing baseline on an OPEN tab ⇒ stale:'unknown' (never false-fresh)", () => {
   for (const [onDiskContent, baselineContent] of [
     [null, A],
     [B, null],
@@ -66,12 +69,19 @@ test("unreadable disk / missing baseline fail safe (no false staleness)", () => 
   ]) {
     assert.deepEqual(
       decideOpenStaleness({ wasOpen: true, isModified: false, onDiskContent, baselineContent }),
-      { stale: false, reload: false },
+      { stale: "unknown", reload: false },
     );
   }
 });
 
-test("no-arg / missing fields do not throw and default to not-stale", () => {
+test("not-open tab is never 'unknown' — it's read fresh regardless", () => {
+  assert.deepEqual(
+    decideOpenStaleness({ wasOpen: false, isModified: false, onDiskContent: null, baselineContent: null }),
+    { stale: false, reload: false },
+  );
+});
+
+test("no-arg / missing fields do not throw and default to not-stale (not open)", () => {
   assert.deepEqual(decideOpenStaleness(), { stale: false, reload: false });
   assert.deepEqual(decideOpenStaleness({}), { stale: false, reload: false });
 });

--- a/browser_tests/unit/workflow-open-staleness.test.mjs
+++ b/browser_tests/unit/workflow-open-staleness.test.mjs
@@ -1,0 +1,77 @@
+// #442 defect 2 — panel_open_workflow must not silently serve a stale cached tab.
+// decideOpenStaleness is the pure staleness decision behind workflow_open: given an
+// already-open tab's on-disk bytes vs its loaded baseline and its unsaved-edits state,
+// it decides whether to flag `stale` and whether a lossless re-read is safe. Detection
+// is CONTENT-based so it survives the frontend's mtime-only listing sync.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { decideOpenStaleness } from "../../web/js/lib/workflow-open-staleness.js";
+
+const A = JSON.stringify({ nodes: [{ id: 1, pos: [0, 0] }] });
+const B = JSON.stringify({ nodes: [{ id: 1, pos: [500, 300] }] }); // edited on disk
+
+test("not-open tab is never stale (openWorkflow reads it fresh from disk)", () => {
+  assert.deepEqual(
+    decideOpenStaleness({ wasOpen: false, isModified: false, onDiskContent: B, baselineContent: A }),
+    { stale: false, reload: false },
+  );
+});
+
+test("already-open + disk differs + no unsaved edits ⇒ stale and safe to reload", () => {
+  assert.deepEqual(
+    decideOpenStaleness({ wasOpen: true, isModified: false, onDiskContent: B, baselineContent: A }),
+    { stale: true, reload: true },
+  );
+});
+
+test("already-open + disk differs + UNSAVED edits ⇒ stale but NOT reloaded (no clobber)", () => {
+  assert.deepEqual(
+    decideOpenStaleness({ wasOpen: true, isModified: true, onDiskContent: B, baselineContent: A }),
+    { stale: true, reload: false },
+  );
+});
+
+test("identical on-disk content ⇒ not stale", () => {
+  assert.deepEqual(
+    decideOpenStaleness({ wasOpen: true, isModified: false, onDiskContent: A, baselineContent: A }),
+    { stale: false, reload: false },
+  );
+});
+
+test("pure reformat (whitespace/indent only) is NOT reported as stale", () => {
+  const pretty = JSON.stringify(JSON.parse(A), null, 2); // same data, indented
+  assert.deepEqual(
+    decideOpenStaleness({ wasOpen: true, isModified: false, onDiskContent: pretty, baselineContent: A }),
+    { stale: false, reload: false },
+  );
+});
+
+test("non-JSON content falls back to a raw compare (differs ⇒ stale, same ⇒ fresh)", () => {
+  assert.deepEqual(
+    decideOpenStaleness({ wasOpen: true, isModified: false, onDiskContent: "not json v2", baselineContent: "not json v1" }),
+    { stale: true, reload: true },
+  );
+  assert.deepEqual(
+    decideOpenStaleness({ wasOpen: true, isModified: false, onDiskContent: "same", baselineContent: "same" }),
+    { stale: false, reload: false },
+  );
+});
+
+test("unreadable disk / missing baseline fail safe (no false staleness)", () => {
+  for (const [onDiskContent, baselineContent] of [
+    [null, A],
+    [B, null],
+    [undefined, undefined],
+    [123, A],
+  ]) {
+    assert.deepEqual(
+      decideOpenStaleness({ wasOpen: true, isModified: false, onDiskContent, baselineContent }),
+      { stale: false, reload: false },
+    );
+  }
+});
+
+test("no-arg / missing fields do not throw and default to not-stale", () => {
+  assert.deepEqual(decideOpenStaleness(), { stale: false, reload: false });
+  assert.deepEqual(decideOpenStaleness({}), { stale: false, reload: false });
+});

--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -176,9 +176,9 @@ test('#442 in-place save of a DRIFTED tab whose disk STILL matches its baseline:
     originalContent: baseline
   }
   const svc = makeService({ files: [active.path], active })
-  const readDiskContent = async () => baseline // disk unchanged since load
+  const readDiskBytes = async () => new TextEncoder().encode(baseline) // disk unchanged since load
 
-  const saved = await saveActiveWorkflow(svc, 'Krea', { readDiskContent })
+  const saved = await saveActiveWorkflow(svc, 'Krea', { readDiskBytes })
 
   assert.deepEqual(svc.calls, [['saveWorkflow', 'workflows/Krea.json']], 'saved in place over its own file')
   assert.equal(active.isPersisted, true, 'drift repaired ⇒ ComfyUI now writes with overwrite:true')
@@ -198,10 +198,10 @@ test('#442 P0 — in-place save of a DRIFTED tab whose disk CHANGED under it is 
     originalContent: loadedA
   }
   const svc = makeService({ files: [active.path], active })
-  const readDiskContent = async () => diskB // file changed on disk since load
+  const readDiskBytes = async () => new TextEncoder().encode(diskB) // file changed on disk since load
 
   await assert.rejects(
-    () => saveActiveWorkflow(svc, 'Krea', { readDiskContent }),
+    () => saveActiveWorkflow(svc, 'Krea', { readDiskBytes }),
     /changed on disk since this tab loaded it/,
     'must surface a conflict rather than clobber the newer on-disk content'
   )

--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -162,6 +162,53 @@ test('save-in-place (same name) overwrites the same file, no copy', async () => 
   assert.equal(saved, 'Foo')
 })
 
+test('#442 in-place save of a DRIFTED tab whose disk STILL matches its baseline: forces overwrite, no 409', async () => {
+  const baseline = JSON.stringify({ nodes: [] })
+  const active = {
+    path: 'workflows/Krea.json',
+    filename: 'Krea.json',
+    directory: 'workflows',
+    // Drifted temporary (open-ack race): size -1 ⇒ isPersisted false ⇒ ComfyUI would
+    // send overwrite:false and 409 on the existing own file.
+    size: -1,
+    isTemporary: true,
+    isPersisted: false,
+    originalContent: baseline
+  }
+  const svc = makeService({ files: [active.path], active })
+  const readDiskContent = async () => baseline // disk unchanged since load
+
+  const saved = await saveActiveWorkflow(svc, 'Krea', { readDiskContent })
+
+  assert.deepEqual(svc.calls, [['saveWorkflow', 'workflows/Krea.json']], 'saved in place over its own file')
+  assert.equal(active.isPersisted, true, 'drift repaired ⇒ ComfyUI now writes with overwrite:true')
+  assert.equal(saved, 'Krea')
+})
+
+test('#442 P0 — in-place save of a DRIFTED tab whose disk CHANGED under it is REFUSED (no destructive overwrite)', async () => {
+  const loadedA = JSON.stringify({ nodes: [{ id: 1 }] }) // what the tab loaded
+  const diskB = JSON.stringify({ nodes: [{ id: 2 }] }) // another process wrote this
+  const active = {
+    path: 'workflows/Krea.json',
+    filename: 'Krea.json',
+    directory: 'workflows',
+    size: -1,
+    isTemporary: true,
+    isPersisted: false,
+    originalContent: loadedA
+  }
+  const svc = makeService({ files: [active.path], active })
+  const readDiskContent = async () => diskB // file changed on disk since load
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, 'Krea', { readDiskContent }),
+    /changed on disk since this tab loaded it/,
+    'must surface a conflict rather than clobber the newer on-disk content'
+  )
+  assert.deepEqual(svc.calls, [], 'NO save performed — the newer on-disk content was not overwritten')
+  assert.equal(active.isPersisted, false, 'the aborted authorization did not mutate the tab')
+})
+
 test('workflow_save with no name saves the current persisted file in place', async () => {
   const active = {
     path: 'workflows/Foo.json',

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2602,11 +2602,11 @@ async function programmaticSave(name) {
   const saved = await saveActiveWorkflow(svc, name, {
     autoWorkflowName,
     existsOnDisk: workflowExistsOnDisk,
-    // #442 — content oracle for the in-place-overwrite gate: authorize a forced
-    // overwrite of a drifted tab's OWN file ONLY when the on-disk bytes still match
-    // what it loaded (else refuse, never clobber an external change). Same reader the
-    // defect-2 staleness check uses — one probe.
-    readDiskContent: workflowDiskContent,
+    // #442 — RAW-BYTE oracle for the in-place-overwrite gate: authorize a forced
+    // overwrite of a drifted tab's OWN file ONLY when the on-disk BYTES still match a
+    // canonical encoding of what it loaded (else refuse, never clobber an external change
+    // — including a BOM a decoded-string compare would miss, codex P0).
+    readDiskBytes: workflowDiskBytes,
     reconcileSavedCopy: reconcileSavedWorkflowCopy,
     details,
     expect: expectWf, // #330: refuse if the user switched tabs during our pre-save HEAD
@@ -2752,6 +2752,28 @@ async function workflowDiskContent(rawPath) {
     return await res.text();
   } catch {
     return null; // unknown ⇒ fail safe (surfaced as stale:"unknown", never false-fresh)
+  }
+}
+
+/** #442 defect 3 — the CURRENT on-disk file as RAW BYTES (Uint8Array), or null when it
+ *  can't be read. The in-place-overwrite gate MUST compare raw bytes, not decoded text:
+ *  Response.text() consumes a UTF-8 BOM, so a decoded compare treats `A` and `BOM+A` as
+ *  equal and would authorize a clobber of the BOM-bearing external change (codex P0).
+ *  arrayBuffer() preserves every byte. Same api.getUserData→fetchApi resolution as the
+ *  text reader; null on any error/absence ⇒ the gate leaves overwrite:false (fails safe). */
+async function workflowDiskBytes(rawPath) {
+  try {
+    if (!api || !rawPath) return null;
+    const res =
+      typeof api.getUserData === "function"
+        ? await api.getUserData(rawPath)
+        : typeof api.fetchApi === "function"
+          ? await api.fetchApi(`/userdata/${encodeURIComponent(rawPath)}`)
+          : null;
+    if (!res || res.status !== 200) return null;
+    return new Uint8Array(await res.arrayBuffer());
+  } catch {
+    return null; // unknown ⇒ fail safe (gate leaves overwrite:false — never a forced clobber)
   }
 }
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -177,6 +177,7 @@ import {
   activeStaleHint,
 } from "./lib/reconnect-staleness.js";
 import { pickRevertSnapshot } from "./lib/graph-revert.js";
+import { decideOpenStaleness } from "./lib/workflow-open-staleness.js";
 import {
   saveActiveWorkflow,
   shouldGroundBeforeTurn,
@@ -2720,6 +2721,23 @@ async function workflowExistsOnDisk(rawPath) {
     return diskExistenceFromStatus(res.status);
   } catch {
     return null; // network/other error ⇒ unknown ⇒ fail safe
+  }
+}
+
+/** #442 — the CURRENT on-disk text of a workflow's /userdata file, or null when it
+ *  can't be read (no api, non-200, or a network error). Used to detect an out-of-band
+ *  edit by comparing against the tab's loaded baseline — CONTENT, not mtime, because
+ *  the frontend's own listing sync advances a workflow's `lastModified` without
+ *  reloading its graph (which would defeat an mtime check) and timestamp-preserving
+ *  writes would evade one. Fails safe (null ⇒ no false staleness). */
+async function workflowDiskContent(rawPath) {
+  try {
+    if (!api || !rawPath || typeof api.getUserData !== "function") return null;
+    const res = await api.getUserData(rawPath);
+    if (!res || res.status !== 200) return null;
+    return await res.text();
+  } catch {
+    return null; // unknown ⇒ fail safe (no false staleness)
   }
 }
 
@@ -6990,7 +7008,28 @@ const GRAPH_TOOL_EXECUTORS = {
           `For a file outside the workflows folder, load it with panel_load_workflow path:<file>.`,
       );
     }
+    // #442 — an ALREADY-OPEN tab is repainted from its OWN in-memory buffer below,
+    // never re-read from disk. If the .json changed on disk out-of-band the canvas
+    // would silently keep the pre-edit graph and this open would report a bland
+    // success. Detect it by comparing the CURRENT on-disk bytes against the bytes the
+    // tab LOADED (its originalContent baseline) — content, not mtime, since the
+    // frontend's listing sync advances lastModified without reloading the graph. A
+    // not-yet-open tab is skipped — openWorkflow reads it fresh from disk.
+    const wasOpen = !!target.changeTracker;
+    const onDiskContent = wasOpen ? await workflowDiskContent(target.path) : null;
+    const staleInfo = decideOpenStaleness({
+      wasOpen,
+      isModified: !!target.isModified,
+      onDiskContent,
+      baselineContent: typeof target.originalContent === "string" ? target.originalContent : null,
+    });
     await s.openWorkflow(target);
+    // We deliberately do NOT auto-reload the canvas from disk here: switching to an
+    // already-open tab must not silently discard the user's in-memory graph, and a
+    // re-read could race a concurrent canvas edit and clobber it. Instead the staleness
+    // is SURFACED (below) so the caller refreshes deliberately with panel_load_workflow
+    // — exactly the recovery the issue reporter uses. The load-bearing fix is turning a
+    // SILENT stale serve into a loud, actionable signal.
     // openWorkflow sets the tab ACTIVE but does NOT repaint the canvas for an
     // ALREADY-OPEN instance — the graph load normally rides the frontend's
     // workflow *service* tab-switch, which the panel can't reach (it's a Vue
@@ -7024,6 +7063,19 @@ const GRAPH_TOOL_EXECUTORS = {
     return {
       opened: { path: target.path, filename: target.filename },
       modified: !!target.isModified,
+      // #442 — surface out-of-band staleness so a caller switching to an already-open
+      // tab is never fooled by a bland success while the canvas shows a pre-edit graph.
+      // `stale` = the on-disk file differs from what this tab loaded; the canvas still
+      // shows the LOADED version (we never auto-reload — see above). `stale_hint`
+      // tells the caller how to refresh, and whether unsaved edits are at stake.
+      ...(staleInfo.stale
+        ? {
+            stale: true,
+            stale_hint: staleInfo.reload
+              ? "The file changed on disk since this tab loaded it; the canvas still shows the loaded version. Call panel_load_workflow to load the on-disk version."
+              : "The file changed on disk since this tab loaded it, AND this tab has unsaved edits. Save first (panel_save_workflow) to keep them, or call panel_load_workflow to discard them and load the on-disk version.",
+          }
+        : {}),
     };
   },
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2602,6 +2602,11 @@ async function programmaticSave(name) {
   const saved = await saveActiveWorkflow(svc, name, {
     autoWorkflowName,
     existsOnDisk: workflowExistsOnDisk,
+    // #442 — content oracle for the in-place-overwrite gate: authorize a forced
+    // overwrite of a drifted tab's OWN file ONLY when the on-disk bytes still match
+    // what it loaded (else refuse, never clobber an external change). Same reader the
+    // defect-2 staleness check uses — one probe.
+    readDiskContent: workflowDiskContent,
     reconcileSavedCopy: reconcileSavedWorkflowCopy,
     details,
     expect: expectWf, // #330: refuse if the user switched tabs during our pre-save HEAD
@@ -2732,12 +2737,21 @@ async function workflowExistsOnDisk(rawPath) {
  *  writes would evade one. Fails safe (null ⇒ no false staleness). */
 async function workflowDiskContent(rawPath) {
   try {
-    if (!api || !rawPath || typeof api.getUserData !== "function") return null;
-    const res = await api.getUserData(rawPath);
+    if (!api || !rawPath) return null;
+    // Prefer getUserData, but FALL BACK to fetchApi (mirrors workflowExistsOnDisk) so a
+    // frontend that exposes only fetchApi — or where getUserData is momentarily absent —
+    // still reads disk. Without this the read returned null and the staleness/overwrite
+    // checks silently degraded (codex P2). null only for a genuinely unavailable api.
+    const res =
+      typeof api.getUserData === "function"
+        ? await api.getUserData(rawPath)
+        : typeof api.fetchApi === "function"
+          ? await api.fetchApi(`/userdata/${encodeURIComponent(rawPath)}`)
+          : null;
     if (!res || res.status !== 200) return null;
     return await res.text();
   } catch {
-    return null; // unknown ⇒ fail safe (no false staleness)
+    return null; // unknown ⇒ fail safe (surfaced as stale:"unknown", never false-fresh)
   }
 }
 
@@ -7011,18 +7025,16 @@ const GRAPH_TOOL_EXECUTORS = {
     // #442 — an ALREADY-OPEN tab is repainted from its OWN in-memory buffer below,
     // never re-read from disk. If the .json changed on disk out-of-band the canvas
     // would silently keep the pre-edit graph and this open would report a bland
-    // success. Detect it by comparing the CURRENT on-disk bytes against the bytes the
-    // tab LOADED (its originalContent baseline) — content, not mtime, since the
-    // frontend's listing sync advances lastModified without reloading the graph. A
-    // not-yet-open tab is skipped — openWorkflow reads it fresh from disk.
+    // success. We detect it by comparing the CURRENT on-disk bytes against the bytes
+    // the tab LOADED (its originalContent baseline). Capture `wasOpen` NOW (before
+    // openWorkflow, which loads a not-yet-open tab and would make changeTracker
+    // non-null); the actual disk read happens LATE (after openWorkflow + repaint) so
+    // an external write during those awaits is still caught (codex — otherwise a read
+    // taken here could baseline against A, the file change to B during openWorkflow,
+    // and the result falsely report fresh). A not-yet-open tab is skipped — openWorkflow
+    // reads it fresh from disk. openWorkflow does NOT mutate originalContent for an
+    // already-open tab (its load() early-returns), so the baseline stays valid.
     const wasOpen = !!target.changeTracker;
-    const onDiskContent = wasOpen ? await workflowDiskContent(target.path) : null;
-    const staleInfo = decideOpenStaleness({
-      wasOpen,
-      isModified: !!target.isModified,
-      onDiskContent,
-      baselineContent: typeof target.originalContent === "string" ? target.originalContent : null,
-    });
     await s.openWorkflow(target);
     // We deliberately do NOT auto-reload the canvas from disk here: switching to an
     // already-open tab must not silently discard the user's in-memory graph, and a
@@ -7060,22 +7072,41 @@ const GRAPH_TOOL_EXECUTORS = {
     // the epoch we STARTED on, but only if no reconnect intervened during the async
     // open (else its tab-restore may have overridden us — leave the window armed).
     if (backendReconnectEpoch === openedForEpoch) activeWorkflowResyncEpoch = openedForEpoch;
+    // #442 — read the on-disk bytes AS LATE AS POSSIBLE (after openWorkflow + repaint),
+    // so an external write during those awaits is still detected. There is NO await
+    // between this read and the return below, so nothing can interleave and turn a
+    // freshly-read stale result into a false-fresh (codex). wasOpen was captured before
+    // openWorkflow; the baseline (originalContent) is unchanged by an already-open open.
+    const onDiskContent = wasOpen ? await workflowDiskContent(target.path) : null;
+    const staleInfo = decideOpenStaleness({
+      wasOpen,
+      isModified: !!target.isModified,
+      onDiskContent,
+      baselineContent: typeof target.originalContent === "string" ? target.originalContent : null,
+    });
     return {
       opened: { path: target.path, filename: target.filename },
       modified: !!target.isModified,
       // #442 — surface out-of-band staleness so a caller switching to an already-open
       // tab is never fooled by a bland success while the canvas shows a pre-edit graph.
-      // `stale` = the on-disk file differs from what this tab loaded; the canvas still
-      // shows the LOADED version (we never auto-reload — see above). `stale_hint`
-      // tells the caller how to refresh, and whether unsaved edits are at stake.
-      ...(staleInfo.stale
+      // `stale:true` = the on-disk file differs from what this tab loaded; `stale:"unknown"`
+      // = we could NOT verify (disk unreadable / no baseline) and must NOT claim fresh
+      // (codex P2). The canvas always shows the LOADED version (we never auto-reload —
+      // see above); `stale_hint` says how to refresh, and whether unsaved edits are at stake.
+      ...(staleInfo.stale === true
         ? {
             stale: true,
             stale_hint: staleInfo.reload
               ? "The file changed on disk since this tab loaded it; the canvas still shows the loaded version. Call panel_load_workflow to load the on-disk version."
               : "The file changed on disk since this tab loaded it, AND this tab has unsaved edits. Save first (panel_save_workflow) to keep them, or call panel_load_workflow to discard them and load the on-disk version.",
           }
-        : {}),
+        : staleInfo.stale === "unknown"
+          ? {
+              stale: "unknown",
+              stale_hint:
+                "Could not verify whether the on-disk file still matches this tab (disk read unavailable). Treat the canvas as possibly stale; call panel_load_workflow to be sure you have the on-disk version.",
+            }
+          : {}),
     };
   },
 

--- a/web/js/lib/workflow-open-staleness.js
+++ b/web/js/lib/workflow-open-staleness.js
@@ -1,0 +1,66 @@
+// #442 — pure decision for how panel_open_workflow should treat an ALREADY-OPEN
+// tab whose backing .json may have changed on disk out-of-band.
+//
+// Background: switching to an already-open workflow tab repaints from the tab's
+// OWN in-memory buffer (changeTracker.activeState), never re-reading the file. So
+// if the file was edited on disk after the tab loaded, the canvas silently keeps
+// the pre-edit graph and the open reports a bland success (issue #442 defect 2).
+//
+// Detection is CONTENT-based, NOT mtime-based: the frontend's own file sync bumps a
+// workflow's `lastModified` from listing metadata WITHOUT reloading the active tab's
+// graph, so an mtime comparison can be silently defeated (and timestamp-preserving
+// out-of-band writes evade it entirely). Comparing the on-disk bytes to the bytes the
+// tab loaded (its baseline) is authoritative and immune to both.
+
+/** Normalize a serialized-workflow string for comparison: trim, and (when it parses)
+ *  round-trip through JSON so a pure reformat (e.g. a Python rewrite with indentation)
+ *  isn't reported as a content change. Falls back to the trimmed raw text when the
+ *  content isn't valid JSON. */
+function normalizeWorkflowContent(text) {
+  const s = String(text).trim();
+  try {
+    return JSON.stringify(JSON.parse(s));
+  } catch {
+    return s;
+  }
+}
+
+/** Decide whether an already-open tab's buffer is stale relative to disk, and whether
+ *  it is SAFE to re-read.
+ *
+ *  Inputs:
+ *   - wasOpen:         the tab was already LOADED (has an in-memory graph) before this
+ *                      open — the only case with a stale-buffer risk. A not-yet-open
+ *                      tab is read fresh from disk by openWorkflow.
+ *   - isModified:      the tab has UNSAVED in-memory edits (a reload would lose them).
+ *   - onDiskContent:   the file's CURRENT on-disk text, or null/undefined if it could
+ *                      not be read.
+ *   - baselineContent: the text the tab LOADED from disk (its `originalContent`
+ *                      baseline — updated on save), or null/undefined if unknown.
+ *
+ *  Returns `{ stale, reload }`:
+ *   - `stale`  is true ONLY when both texts are known and DIFFER (the file on disk is
+ *     no longer what the tab loaded).
+ *   - `reload` is true only when it is stale AND there are no unsaved edits to clobber
+ *     (isModified falsy) — a safe, lossless re-read.
+ *
+ *  Every indeterminate case (not open, either text unknown, identical) returns
+ *  `{ stale:false, reload:false }` — never a false staleness signal and never an
+ *  unsafe reload that could discard the user's unsaved edits. */
+export function decideOpenStaleness({
+  wasOpen,
+  isModified,
+  onDiskContent,
+  baselineContent,
+} = {}) {
+  if (!wasOpen) return { stale: false, reload: false };
+  if (typeof onDiskContent !== "string" || typeof baselineContent !== "string") {
+    return { stale: false, reload: false };
+  }
+  const stale =
+    normalizeWorkflowContent(onDiskContent) !== normalizeWorkflowContent(baselineContent);
+  if (!stale) return { stale: false, reload: false };
+  // Stale. Re-read only when nothing unsaved would be lost; otherwise surface the
+  // flag and let the caller force a fresh read (panel_load_workflow) if they choose.
+  return { stale: true, reload: !isModified };
+}

--- a/web/js/lib/workflow-open-staleness.js
+++ b/web/js/lib/workflow-open-staleness.js
@@ -24,6 +24,38 @@ export function workflowContentEqual(a, b) {
   return typeof a === "string" && typeof b === "string" && a === b;
 }
 
+/** LOSSLESS byte-vs-text equality for the SAVE-side in-place-overwrite gate (#442
+ *  defect 3). `Response.text()` silently CONSUMES a UTF-8 BOM, so a decoded-string
+ *  compare treats `A` and `BOM+A` as equal — which would authorize a forced overwrite
+ *  that clobbers an external BOM-bearing change (codex P0). This compares the disk file's
+ *  RAW BYTES (`diskBytes`, a Uint8Array read via arrayBuffer — BOM preserved) against the
+ *  UTF-8 encoding of the loaded baseline TEXT.
+ *
+ *  Why re-encoding the baseline is the right baseline here: ComfyUI writes workflow files
+ *  as CANONICAL UTF-8 with NO BOM (JSON.stringify → verbatim POST body), so for ANY
+ *  ComfyUI-written file the loaded bytes are exactly `TextEncoder().encode(originalContent)`
+ *  — this reconstruction is EXACT. The only case it can't reconstruct is a file that was
+ *  externally created WITH a BOM and then loaded (originalContent lost the BOM): there this
+ *  returns false → the caller treats it as a CONFLICT and REFUSES, i.e. it FAILS CLOSED
+ *  (never a false authorize). So it authorizes iff the on-disk bytes are byte-identical to
+ *  a canonical encoding of what the tab loaded, and refuses on any deviation. */
+export function diskBytesEqualText(diskBytes, baselineText) {
+  if (typeof baselineText !== "string") return false;
+  const bytes =
+    diskBytes instanceof Uint8Array
+      ? diskBytes
+      : diskBytes && typeof diskBytes.byteLength === "number"
+        ? new Uint8Array(diskBytes) // accept a raw ArrayBuffer too
+        : null;
+  if (!bytes) return false;
+  const enc = new TextEncoder().encode(baselineText); // canonical UTF-8, no BOM
+  if (enc.length !== bytes.length) return false;
+  for (let i = 0; i < enc.length; i++) {
+    if (enc[i] !== bytes[i]) return false;
+  }
+  return true;
+}
+
 /** Decide whether an already-open tab's buffer is stale relative to disk, and whether
  *  it is SAFE to re-read.
  *

--- a/web/js/lib/workflow-open-staleness.js
+++ b/web/js/lib/workflow-open-staleness.js
@@ -12,17 +12,16 @@
 // out-of-band writes evade it entirely). Comparing the on-disk bytes to the bytes the
 // tab loaded (its baseline) is authoritative and immune to both.
 
-/** Normalize a serialized-workflow string for comparison: trim, and (when it parses)
- *  round-trip through JSON so a pure reformat (e.g. a Python rewrite with indentation)
- *  isn't reported as a content change. Falls back to the trimmed raw text when the
- *  content isn't valid JSON. */
-function normalizeWorkflowContent(text) {
-  const s = String(text).trim();
-  try {
-    return JSON.stringify(JSON.parse(s));
-  } catch {
-    return s;
-  }
+/** EXACT text equality of two serialized-workflow strings — the shared content-equality
+ *  primitive for both the open-side staleness check and the save-side in-place-overwrite
+ *  gate (#442). Deliberately NOT a JSON round-trip: `JSON.parse`→`JSON.stringify` collapses
+ *  distinct valid JSON values (e.g. large integer seeds beyond 2^53 round to the same
+ *  IEEE-754 double), which would let a genuinely-changed file compare EQUAL and either be
+ *  reported fresh or authorize a destructive overwrite (codex P0). Byte-exact comparison
+ *  errs only in the SAFE direction: a formatting-only difference is treated as "changed"
+ *  (an over-cautious stale flag / a refused in-place save — never data loss). */
+export function workflowContentEqual(a, b) {
+  return typeof a === "string" && typeof b === "string" && a === b;
 }
 
 /** Decide whether an already-open tab's buffer is stale relative to disk, and whether
@@ -39,14 +38,16 @@ function normalizeWorkflowContent(text) {
  *                      baseline — updated on save), or null/undefined if unknown.
  *
  *  Returns `{ stale, reload }`:
- *   - `stale`  is true ONLY when both texts are known and DIFFER (the file on disk is
- *     no longer what the tab loaded).
- *   - `reload` is true only when it is stale AND there are no unsaved edits to clobber
- *     (isModified falsy) — a safe, lossless re-read.
+ *   - `stale` is `true` when both texts are known and DIFFER (the file on disk is no
+ *     longer what the tab loaded); `false` only when both are known and MATCH; and the
+ *     string `"unknown"` when the tab was open but staleness could NOT be determined
+ *     (disk unreadable / baseline missing). "unknown" must NEVER be reported as fresh —
+ *     a transient read failure or a frontend without a content-read API would otherwise
+ *     mask a genuine out-of-band change (codex P2).
+ *   - `reload` is true only when `stale === true` AND there are no unsaved edits to
+ *     clobber (isModified falsy) — a safe, lossless re-read.
  *
- *  Every indeterminate case (not open, either text unknown, identical) returns
- *  `{ stale:false, reload:false }` — never a false staleness signal and never an
- *  unsafe reload that could discard the user's unsaved edits. */
+ *  A not-open tab is never stale (openWorkflow reads it fresh) ⇒ `{stale:false}`. */
 export function decideOpenStaleness({
   wasOpen,
   isModified,
@@ -55,10 +56,10 @@ export function decideOpenStaleness({
 } = {}) {
   if (!wasOpen) return { stale: false, reload: false };
   if (typeof onDiskContent !== "string" || typeof baselineContent !== "string") {
-    return { stale: false, reload: false };
+    // Open tab but we could not read disk or lack a baseline ⇒ cannot prove fresh.
+    return { stale: "unknown", reload: false };
   }
-  const stale =
-    normalizeWorkflowContent(onDiskContent) !== normalizeWorkflowContent(baselineContent);
+  const stale = !workflowContentEqual(onDiskContent, baselineContent);
   if (!stale) return { stale: false, reload: false };
   // Stale. Re-read only when nothing unsaved would be lost; otherwise surface the
   // flag and let the caller force a fresh read (panel_load_workflow) if they choose.

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -1,9 +1,10 @@
 // Programmatic workflow saving — shared by the panel and unit tests.
 //
-// #442 defect 3 — the in-place-overwrite gate compares the on-disk bytes against the
-// tab's loaded baseline using the SAME byte-exact primitive the open-side staleness
-// check uses, so "did the file change under us?" is judged identically on both paths.
-import { workflowContentEqual } from "./workflow-open-staleness.js";
+// #442 defect 3 — the in-place-overwrite gate compares the on-disk file's RAW BYTES
+// against a canonical UTF-8 encoding of the tab's loaded baseline text, so a BOM (or any
+// byte-level) difference a decoded-string compare would miss cannot authorize a
+// destructive overwrite. See diskBytesEqualText for why raw bytes are required.
+import { diskBytesEqualText } from "./workflow-open-staleness.js";
 
 // The one hard rule here exists because of a silent data-loss bug (issue #226):
 // "save this workflow as X" MUST write a NEW file and leave the original file on
@@ -266,7 +267,7 @@ export async function groundActiveWorkflow(svc, opts = {}) {
 export async function saveActiveWorkflow(
   svc,
   name,
-  { autoWorkflowName, existsOnDisk, readDiskContent, reconcileSavedCopy, expect, details } = {},
+  { autoWorkflowName, existsOnDisk, readDiskBytes, reconcileSavedCopy, expect, details } = {},
 ) {
   const wf = svc?.activeWorkflow;
   if (!wf) throw new Error("no active workflow to save");
@@ -537,7 +538,7 @@ export async function saveActiveWorkflow(
   // assert would leave the FORMER tab marked persisted, and a later save of it would
   // skip the oracle and send overwrite:true from an aborted authorization (codex P2).
   // So: probe → assertExpect → THEN coerce synchronously, after the tab is re-verified.
-  const inPlace = await classifyInPlaceOverwrite(wf, currentPath, readDiskContent);
+  const inPlace = await classifyInPlaceOverwrite(wf, currentPath, readDiskBytes);
   assertExpect(); // the disk read above awaited — re-check the tab didn't switch
   // A same-OBJECT rename during the await keeps object identity (so assertExpect
   // passes) but changes wf.path — the captured currentPath would no longer identify
@@ -575,26 +576,37 @@ export async function saveActiveWorkflow(
  *     runs), no reader / no path / no baseline to compare, or the file is absent
  *     (disk read null ⇒ overwrite:false safely CREATES it). Leaves behaviour unchanged.
  *
- *  PURE async probe: it never mutates `wf`. `readDiskContent(path) => string | null`
- *  is the authoritative on-disk content oracle (null = absent/unreadable). The caller
- *  applies markPersistedForOverwrite ONLY on "authorize", AFTER re-asserting the tab. */
-export async function classifyInPlaceOverwrite(wf, currentPath, readDiskContent) {
+ *  PURE async probe: it never mutates `wf`. `readDiskBytes(path) => Uint8Array | null`
+ *  is the authoritative on-disk RAW-BYTE oracle (null = absent/unreadable). Raw bytes —
+ *  not decoded text — because Response.text() strips a UTF-8 BOM, so a string compare
+ *  would treat `A` and `BOM+A` as equal and authorize a clobber of the BOM-bearing change
+ *  (codex P0). The caller applies markPersistedForOverwrite ONLY on "authorize", AFTER
+ *  re-asserting the tab. */
+export async function classifyInPlaceOverwrite(wf, currentPath, readDiskBytes) {
   if (!wf || wf.isPersisted === true) return "skip"; // already overwrite:true — untouched
-  if (typeof readDiskContent !== "function" || !currentPath) return "skip"; // no oracle ⇒ leave as-is
+  if (typeof readDiskBytes !== "function" || !currentPath) return "skip"; // no oracle ⇒ leave as-is
   const baseline = typeof wf.originalContent === "string" ? wf.originalContent : null;
   if (baseline == null) return "skip"; // no baseline to compare ⇒ cannot prove safe ⇒ leave as-is
   let disk = null;
   try {
-    disk = await readDiskContent(currentPath);
+    disk = await readDiskBytes(currentPath);
   } catch {
     disk = null; // read threw ⇒ unknown ⇒ do not force (server 409s honestly if it exists)
   }
-  if (typeof disk !== "string") return "skip"; // absent (create) / unreadable ⇒ leave as-is
-  // Content-equality gate (BYTE-EXACT): only when disk STILL equals what this tab loaded
-  // is the forced overwrite non-destructive. Any external change — including a change we
-  // can't distinguish by value — ⇒ conflict, never a clobber. Exact (not JSON-normalized)
-  // so a genuinely different file can never compare equal and slip through (codex P0).
-  return workflowContentEqual(disk, baseline) ? "authorize" : "conflict";
+  // Absent (create) / unreadable / not raw bytes ⇒ leave as-is (never a forced overwrite).
+  const bytes =
+    disk instanceof Uint8Array
+      ? disk
+      : disk && typeof disk.byteLength === "number"
+        ? new Uint8Array(disk)
+        : null;
+  if (!bytes) return "skip";
+  // Content-equality gate on RAW BYTES vs a canonical UTF-8 encoding of the baseline:
+  // only when the on-disk bytes are byte-identical to what this tab loaded is the forced
+  // overwrite non-destructive. Any external change — a different graph, or merely an added
+  // BOM / re-encoding a string compare would miss — ⇒ conflict, never a clobber. FAILS
+  // CLOSED (conflict) if it can't be proven byte-identical (diskBytesEqualText, codex P0).
+  return diskBytesEqualText(bytes, baseline) ? "authorize" : "conflict";
 }
 
 /** #442 — SYNCHRONOUS mutation that clears a drifted `isTemporary` so ComfyUI's

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -1,5 +1,10 @@
 // Programmatic workflow saving — shared by the panel and unit tests.
 //
+// #442 defect 3 — the in-place-overwrite gate compares the on-disk bytes against the
+// tab's loaded baseline using the SAME byte-exact primitive the open-side staleness
+// check uses, so "did the file change under us?" is judged identically on both paths.
+import { workflowContentEqual } from "./workflow-open-staleness.js";
+
 // The one hard rule here exists because of a silent data-loss bug (issue #226):
 // "save this workflow as X" MUST write a NEW file and leave the original file on
 // disk untouched (copy / Save-As semantics). Renaming the source — which moves
@@ -261,7 +266,7 @@ export async function groundActiveWorkflow(svc, opts = {}) {
 export async function saveActiveWorkflow(
   svc,
   name,
-  { autoWorkflowName, existsOnDisk, reconcileSavedCopy, expect, details } = {},
+  { autoWorkflowName, existsOnDisk, readDiskContent, reconcileSavedCopy, expect, details } = {},
 ) {
   const wf = svc?.activeWorkflow;
   if (!wf) throw new Error("no active workflow to save");
@@ -504,50 +509,92 @@ export async function saveActiveWorkflow(
   // derived from `size` (`isTemporary = size === -1`). After a panel_open_workflow
   // open-ack race the loaded workflow's `size` DRIFTS to -1 (#215/#226), so
   // `isPersisted` reads false, the write goes out with overwrite:false, and the
-  // server rejects it because the file already exists. Repair the drift so the
-  // overwrite of the tab's OWN file is allowed — but ONLY on POSITIVE disk proof
-  // (existsOnDisk 200) that a file backs this exact path. We are in the
-  // NON-relocating branch (finalTargetPath === currentPath === wf.path), so this
-  // can only ever authorize overwriting the tab's own file, never a different tab's
-  // (a distinct tab has a distinct path). A 404/unknown leaves overwrite:false
-  // untouched, so a genuine first save still creates and a real collision still
-  // 409s honestly.
+  // server rejects it because the file already exists.
+  //
+  // DATA-LOSS GUARD (codex P0): existence alone must NOT authorize the forced
+  // overwrite. If the file changed on disk under us (another tab/agent/process
+  // wrote B while this tab holds A), forcing overwrite:true would silently CLOBBER
+  // B — and the very 409 we're removing was, in that sub-case, correctly protecting
+  // it. ComfyUI's /userdata has no If-Match/ETag conditional write, so the achievable
+  // guarantee is a byte-exact CONTENT-EQUALITY gate: force the overwrite only when the
+  // on-disk bytes STILL MATCH what this tab loaded (wf.originalContent). If disk DIFFERS
+  // from the baseline, REFUSE with a surfaced conflict rather than overwrite (the caller
+  // reloads or saves under a new name). We are in the NON-relocating branch
+  // (finalTargetPath === currentPath === wf.path), so this only ever concerns the
+  // tab's OWN file.
+  //
+  // ACCEPTED RESIDUAL (upstream-only, unchanged from ComfyUI's normal saves): the
+  // read→write is not atomic, so a write that lands in the sub-ms window BETWEEN our
+  // read and saveInPlace's overwrite:true is not caught — but this is EXACTLY the same
+  // non-atomic overwrite:true a normal PERSISTED save already performs on every
+  // Ctrl+S, so the drift-repair introduces no window ComfyUI doesn't already have.
+  // A true guarantee needs a server-side conditional/version token ComfyUI does not
+  // expose; the pre-check closes the realistic "already changed before the save" case.
   assertExpect(); // #330: never in-place-overwrite a workflow the user switched to
-  // Split PROBE (async) from MUTATION (sync): the disk HEAD below awaits, so the
+  // Split PROBE (async) from MUTATION (sync): the disk read below awaits, so the
   // persistence coercion must NOT run inside it. If the active tab switches during
   // the probe, the trailing assertExpect throws — but a coercion applied before that
   // assert would leave the FORMER tab marked persisted, and a later save of it would
   // skip the oracle and send overwrite:true from an aborted authorization (codex P2).
   // So: probe → assertExpect → THEN coerce synchronously, after the tab is re-verified.
-  const overwriteOwnFile = await inPlaceOverwriteAuthorized(wf, currentPath, existsOnDisk);
-  assertExpect(); // the disk probe above awaited — re-check the tab didn't switch
-  if (overwriteOwnFile) markPersistedForOverwrite(wf); // sync (post-assert) ⇒ no leak window
+  const inPlace = await classifyInPlaceOverwrite(wf, currentPath, readDiskContent);
+  assertExpect(); // the disk read above awaited — re-check the tab didn't switch
+  // A same-OBJECT rename during the await keeps object identity (so assertExpect
+  // passes) but changes wf.path — the captured currentPath would no longer identify
+  // this tab's file. Refuse rather than authorize/write against a stale path.
+  if (normalizePath(wf.path) !== currentPath) {
+    throw new Error(
+      `refusing to save: the active workflow's path changed during the save (now "${wf.path}") — retry.`,
+    );
+  }
+  if (inPlace === "conflict") {
+    throw new Error(
+      `refusing to save "${effectiveName}": its file "${currentPath}" changed on disk since this tab ` +
+        `loaded it, so saving in place would OVERWRITE those external changes. ComfyUI has no ` +
+        `conditional (If-Match) write, so this is guarded by a content-equality check. Reload the ` +
+        `on-disk version (panel_load_workflow) to pick it up, or save under a NEW name to keep both ` +
+        `(issue #442).`,
+    );
+  }
+  if (inPlace === "authorize") markPersistedForOverwrite(wf); // sync (post-assert) ⇒ no leak window
   recordOutcome(details, "in-place", { sourcePath: currentPath, targetPath: finalTargetPath });
   await saveInPlace(svc, wf);
   return desired || currentName || null;
 }
 
-/** #442 — PROBE (no mutation) whether an IN-PLACE save should force `overwrite:true`.
- *  ComfyUI's UserFile.save() writes with `overwrite: this.isPersisted`, and
- *  `isPersisted`/`isTemporary` are getters derived from `size` (`isTemporary =
- *  size === -1`). After a panel_open_workflow open-ack race the loaded workflow's
- *  `size` DRIFTS to -1 (#215/#226), so `isPersisted` reads false → overwrite:false →
- *  the server 409s on the workflow's OWN existing file. Returns true ONLY when the
- *  workflow currently reads non-persisted AND the disk oracle POSITIVELY confirms
- *  (200) a file already backs `currentPath` — matching classifySource's "exists ⇒
- *  persisted" stance. 404 / unknown / no oracle ⇒ false (a genuine first save keeps
- *  overwrite:false / create, and a real collision still 409s honestly). PURE async
- *  probe — the caller mutates only AFTER re-asserting the expected tab. */
-export async function inPlaceOverwriteAuthorized(wf, currentPath, existsOnDisk) {
-  if (!wf || wf.isPersisted === true) return false; // already overwrite:true
-  if (typeof existsOnDisk !== "function" || !currentPath) return false; // no proof ⇒ leave as-is
-  let exists = null;
+/** #442 — CLASSIFY (no mutation) an IN-PLACE save against a DRIFTED `isPersisted`,
+ *  content-equality gated to prevent a destructive overwrite (codex P0). Returns:
+ *   - `"authorize"` — the workflow reads non-persisted (drifted) AND the on-disk bytes
+ *     STILL MATCH the tab's loaded baseline (`wf.originalContent`). Forcing
+ *     overwrite:true here re-saves the user's edits over the SAME file they loaded — no
+ *     external content is at risk. This is the case defect 3 fixes.
+ *   - `"conflict"` — drifted AND the on-disk bytes DIFFER from the baseline (the file
+ *     changed under us). Forcing overwrite would clobber the newer content, so the
+ *     caller must refuse and surface a conflict instead.
+ *   - `"skip"` — nothing to do: already persisted (ComfyUI's own overwrite:true path
+ *     runs), no reader / no path / no baseline to compare, or the file is absent
+ *     (disk read null ⇒ overwrite:false safely CREATES it). Leaves behaviour unchanged.
+ *
+ *  PURE async probe: it never mutates `wf`. `readDiskContent(path) => string | null`
+ *  is the authoritative on-disk content oracle (null = absent/unreadable). The caller
+ *  applies markPersistedForOverwrite ONLY on "authorize", AFTER re-asserting the tab. */
+export async function classifyInPlaceOverwrite(wf, currentPath, readDiskContent) {
+  if (!wf || wf.isPersisted === true) return "skip"; // already overwrite:true — untouched
+  if (typeof readDiskContent !== "function" || !currentPath) return "skip"; // no oracle ⇒ leave as-is
+  const baseline = typeof wf.originalContent === "string" ? wf.originalContent : null;
+  if (baseline == null) return "skip"; // no baseline to compare ⇒ cannot prove safe ⇒ leave as-is
+  let disk = null;
   try {
-    exists = await existsOnDisk(currentPath);
+    disk = await readDiskContent(currentPath);
   } catch {
-    exists = null; // probe threw ⇒ unknown ⇒ do not force an overwrite
+    disk = null; // read threw ⇒ unknown ⇒ do not force (server 409s honestly if it exists)
   }
-  return exists === true; // ONLY a CONFIRMED 200 authorizes overwriting the own file
+  if (typeof disk !== "string") return "skip"; // absent (create) / unreadable ⇒ leave as-is
+  // Content-equality gate (BYTE-EXACT): only when disk STILL equals what this tab loaded
+  // is the forced overwrite non-destructive. Any external change — including a change we
+  // can't distinguish by value — ⇒ conflict, never a clobber. Exact (not JSON-normalized)
+  // so a genuinely different file can never compare equal and slip through (codex P0).
+  return workflowContentEqual(disk, baseline) ? "authorize" : "conflict";
 }
 
 /** #442 — SYNCHRONOUS mutation that clears a drifted `isTemporary` so ComfyUI's

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -497,10 +497,75 @@ export async function saveActiveWorkflow(
 
   // No relocation — the target path equals the current on-disk path. Overwriting
   // the same file in place is safe (no move can occur).
+  //
+  // #442 — an in-place save can spuriously 409 ("Error storing user data file
+  // '…': 409 Conflict") over the workflow's OWN name. ComfyUI's UserFile.save()
+  // writes with `overwrite: this.isPersisted`, and `isPersisted` is a getter
+  // derived from `size` (`isTemporary = size === -1`). After a panel_open_workflow
+  // open-ack race the loaded workflow's `size` DRIFTS to -1 (#215/#226), so
+  // `isPersisted` reads false, the write goes out with overwrite:false, and the
+  // server rejects it because the file already exists. Repair the drift so the
+  // overwrite of the tab's OWN file is allowed — but ONLY on POSITIVE disk proof
+  // (existsOnDisk 200) that a file backs this exact path. We are in the
+  // NON-relocating branch (finalTargetPath === currentPath === wf.path), so this
+  // can only ever authorize overwriting the tab's own file, never a different tab's
+  // (a distinct tab has a distinct path). A 404/unknown leaves overwrite:false
+  // untouched, so a genuine first save still creates and a real collision still
+  // 409s honestly.
   assertExpect(); // #330: never in-place-overwrite a workflow the user switched to
+  // Split PROBE (async) from MUTATION (sync): the disk HEAD below awaits, so the
+  // persistence coercion must NOT run inside it. If the active tab switches during
+  // the probe, the trailing assertExpect throws — but a coercion applied before that
+  // assert would leave the FORMER tab marked persisted, and a later save of it would
+  // skip the oracle and send overwrite:true from an aborted authorization (codex P2).
+  // So: probe → assertExpect → THEN coerce synchronously, after the tab is re-verified.
+  const overwriteOwnFile = await inPlaceOverwriteAuthorized(wf, currentPath, existsOnDisk);
+  assertExpect(); // the disk probe above awaited — re-check the tab didn't switch
+  if (overwriteOwnFile) markPersistedForOverwrite(wf); // sync (post-assert) ⇒ no leak window
   recordOutcome(details, "in-place", { sourcePath: currentPath, targetPath: finalTargetPath });
   await saveInPlace(svc, wf);
   return desired || currentName || null;
+}
+
+/** #442 — PROBE (no mutation) whether an IN-PLACE save should force `overwrite:true`.
+ *  ComfyUI's UserFile.save() writes with `overwrite: this.isPersisted`, and
+ *  `isPersisted`/`isTemporary` are getters derived from `size` (`isTemporary =
+ *  size === -1`). After a panel_open_workflow open-ack race the loaded workflow's
+ *  `size` DRIFTS to -1 (#215/#226), so `isPersisted` reads false → overwrite:false →
+ *  the server 409s on the workflow's OWN existing file. Returns true ONLY when the
+ *  workflow currently reads non-persisted AND the disk oracle POSITIVELY confirms
+ *  (200) a file already backs `currentPath` — matching classifySource's "exists ⇒
+ *  persisted" stance. 404 / unknown / no oracle ⇒ false (a genuine first save keeps
+ *  overwrite:false / create, and a real collision still 409s honestly). PURE async
+ *  probe — the caller mutates only AFTER re-asserting the expected tab. */
+export async function inPlaceOverwriteAuthorized(wf, currentPath, existsOnDisk) {
+  if (!wf || wf.isPersisted === true) return false; // already overwrite:true
+  if (typeof existsOnDisk !== "function" || !currentPath) return false; // no proof ⇒ leave as-is
+  let exists = null;
+  try {
+    exists = await existsOnDisk(currentPath);
+  } catch {
+    exists = null; // probe threw ⇒ unknown ⇒ do not force an overwrite
+  }
+  return exists === true; // ONLY a CONFIRMED 200 authorizes overwriting the own file
+}
+
+/** #442 — SYNCHRONOUS mutation that clears a drifted `isTemporary` so ComfyUI's
+ *  save() uses `overwrite:true`. `isPersisted`/`isTemporary` derive from `size`
+ *  (`isTemporary = size === -1`), so the correction sets the REAL backing field
+ *  `size` to a non-(-1) value; the subsequent save() replaces it with the server's
+ *  authoritative size. Must be called ONLY after the caller re-asserted the expected
+ *  tab (it is synchronous, so no tab switch can interleave). Best-effort + getter-safe
+ *  — a frozen/derived `size` is left untouched (the assigns cover plain-object doubles). */
+export function markPersistedForOverwrite(wf) {
+  if (!wf) return;
+  try {
+    if (wf.size === -1 || wf.size == null) wf.size = 1;
+  } catch {
+    /* size not settable ⇒ best-effort */
+  }
+  safeAssign(wf, "isTemporary", false);
+  safeAssign(wf, "isPersisted", true);
 }
 
 /** Authoritative tri-state DISK probe for the post-save backstop — the ONLY evidence


### PR DESCRIPTION
Fixes two independent **workflow-file tool** defects from #442 (defects 2 & 3). Defect 1 is already shipped; defects 4 & 5 are a separate PR.

> **Update after review.** An independent review caught a **data-loss regression** in the first cut of defect 3 (authorizing overwrite on *existence* alone could clobber a file changed on disk under the tab). Reworked to a **byte-exact content-equality gate**. Details below reflect the final design. Codex read-only review is at a clean **PASS**.

## Defect 2 — `panel_open_workflow` served a stale cached tab
**Root cause.** Switching to an ALREADY-OPEN workflow repaints from the tab's in-memory buffer (`changeTracker.activeState`) and never re-reads the file. An out-of-band `.json` edit left the pre-edit graph on the canvas under a bland `{opened, modified:false}` success.

**Fix.** Detect it by **byte-exact content** comparison of the current on-disk bytes (via `api.getUserData`, with an `api.fetchApi` fallback) against the tab's loaded `originalContent` baseline. mtime is unusable — the frontend's listing sync advances `lastModified` without reloading the graph, and timestamp-preserving writes evade it. The disk read happens **as late as possible** (after `openWorkflow` + repaint, no `await` before the return) so an external write during those awaits is still caught. Result carries `stale:true`, or `stale:"unknown"` when it couldn't be verified (**never** false-fresh), plus a `stale_hint`. We deliberately **do not auto-reload** the canvas (a re-read could race a concurrent edit); the caller refreshes with `panel_load_workflow`. Pure decision in `lib/workflow-open-staleness.js`.

## Defect 3 — `panel_save_workflow` 409'd on own-name in-place overwrite
**Root cause.** ComfyUI's `UserFile.save()` writes `/userdata` with `overwrite: this.isPersisted`, and `isPersisted` derives from `size` (`isTemporary = size === -1`). After a `panel_open_workflow` open-ack race the loaded workflow's `size` drifts to `-1`, so `overwrite=false` and the server rejects the write on the existing own file — `409 Conflict`.

**Fix (data-loss-safe).** In the in-place (non-relocating) branch of `saveActiveWorkflow`, `classifyInPlaceOverwrite` reads the on-disk bytes and authorizes the forced `overwrite:true` **only when they still byte-exactly equal the tab's loaded baseline (`wf.originalContent`)**. If they differ (another tab/agent/process wrote newer content), it returns `"conflict"` and the caller **throws a surfaced conflict instead of overwriting** — the 409 was protective in that sub-case. Byte-exact (not JSON-normalized) so distinct files can never compare equal. Split into an async **probe** (no mutation) + a synchronous **mutation** applied only after the `#330` `assertExpect` re-check **and** a `wf.path === currentPath` re-check, so a tab switch/rename during the probe can't leak authorization. Non-relocating branch ⇒ `finalTargetPath === wf.path` — never a different tab's file. ComfyUI has no If-Match conditional write, so the residual write-time TOCTOU is the same non-atomic `overwrite:true` every normal persisted save already performs (documented).

## Not changed
Defect 1 (node-resize) already shipped as `panel_resize_node`/`graph_resize_node` (#530).

## Tests
- `workflow-open-staleness.test.mjs` — byte-exact stale / safe-reload / unsafe / `"unknown"` / fail-safe.
- `workflow-inplace-overwrite.test.mjs` — probe/mutate split; **P0 regression: loaded A + disk B ⇒ conflict, never a forced overwrite**; reformat ⇒ conflict; identical bytes ⇒ authorize.
- `workflow-save.test.mjs` — end-to-end `saveActiveWorkflow`: drifted+unchanged ⇒ saves in place; **drifted+disk-changed ⇒ REFUSED, no write**.
- Full suite green: **1127 passed**. `node --check` clean; `frontend-contract` green.

## Review
Codex read-only self-review across the rework caught and fixed: the existence-only clobber (P0), lossy-normalization false-equal (P0), a TOCTOU authorization leak (P2), a drifted-temporary reload no-op, an edit-clobber race (resolved by flag-only open), and a late-read false-fresh window (P1). **Final verdict: PASS.**

Addresses #442 (defects 1,2,3). Companion MCP PR carries the description update. **Do not merge yet.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
