### PR TITLE
fix(panel): derive Ultralytics bbox/segm missing-model dir from combo prefix (#487)

### DIFF
--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -23,6 +23,7 @@ import {
   collectMissingNodeTypeReasons,
   graphErrorsResultIsClean,
   nodeRedFlagIsStale,
+  resolveMissingModelDirectory,
 } from "../../web/js/lib/asset-staleness.js";
 
 /** The REAL LTXICLoRALoaderModelOnly schema: a `model` CONNECTION input plus two
@@ -622,4 +623,47 @@ test("nodeRedFlagIsStale: OR across multiple maps — an EMPTY entry in one must
     nodeRedFlagIsStale(5, { nodeErrorsMaps: [{ 5: { errors: [] } }, null] }),
     true,
   );
+});
+
+// --- resolveMissingModelDirectory (#487) — Ultralytics bbox/segm subfolder ---
+
+test("resolveMissingModelDirectory: segm/ combo value overrides a default ultralytics/bbox directory", () => {
+  assert.equal(
+    resolveMissingModelDirectory("ultralytics/bbox", "segm/ntd11_anime_nsfw_segm_v5.pt"),
+    "ultralytics/segm",
+  );
+});
+
+test("resolveMissingModelDirectory: bbox/ combo value stays in ultralytics/bbox", () => {
+  assert.equal(
+    resolveMissingModelDirectory("ultralytics/bbox", "bbox/face_yolov8m.pt"),
+    "ultralytics/bbox",
+  );
+});
+
+test("resolveMissingModelDirectory: bare `ultralytics` directory gains the prefix subfolder", () => {
+  assert.equal(resolveMissingModelDirectory("ultralytics", "segm/x.pt"), "ultralytics/segm");
+  assert.equal(resolveMissingModelDirectory("ultralytics", "bbox/x.pt"), "ultralytics/bbox");
+});
+
+test("resolveMissingModelDirectory: a store directory already ultralytics/segm is corrected by a bbox/ value", () => {
+  assert.equal(resolveMissingModelDirectory("ultralytics/segm", "bbox/x.pt"), "ultralytics/bbox");
+});
+
+test("resolveMissingModelDirectory: Windows backslashes are normalized before matching", () => {
+  assert.equal(resolveMissingModelDirectory("ultralytics\\bbox", "segm\\x.pt"), "ultralytics/segm");
+});
+
+test("resolveMissingModelDirectory: file WITHOUT a bbox/segm prefix is left unchanged", () => {
+  assert.equal(resolveMissingModelDirectory("ultralytics/bbox", "yolov8m.pt"), "ultralytics/bbox");
+  assert.equal(resolveMissingModelDirectory("ultralytics/bbox", null), "ultralytics/bbox");
+});
+
+test("resolveMissingModelDirectory: NON-ultralytics directories never regress", () => {
+  // A checkpoint/lora subfolder that merely happens to start with bbox/segm-looking text
+  // must be passed through untouched — only ultralytics folders are rewritten.
+  assert.equal(resolveMissingModelDirectory("checkpoints", "segm/x.pt"), "checkpoints");
+  assert.equal(resolveMissingModelDirectory("loras", "bbox/x.pt"), "loras");
+  assert.equal(resolveMissingModelDirectory("ultralytics_extra", "segm/x.pt"), "ultralytics_extra");
+  assert.equal(resolveMissingModelDirectory(null, "segm/x.pt"), null);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -111,6 +111,7 @@ import {
   graphErrorsResultIsClean,
   nodeRedFlagIsStale,
   findNodeByScopedId,
+  resolveMissingModelDirectory,
 } from "./lib/asset-staleness.js";
 import { assertAddNodeResolvableRefreshing } from "./lib/node-resolve.js";
 import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
@@ -4008,7 +4009,9 @@ function collectMissingAssets(trustComboOverride) {
       models.push({
         node_id: c?.nodeId ?? null,
         file: c?.name ?? null,
-        directory: c?.directory ?? null,
+        // The Ultralytics detector combo value's bbox/segm prefix, not the store's
+        // single default folder, authoritatively picks the subfolder (#487).
+        directory: resolveMissingModelDirectory(c?.directory ?? null, c?.name ?? null),
         ...(c?.widgetName ? { widget: c.widgetName } : {}),
         ...(c?.url ? { download_url: c.url } : {}),
       });

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -285,6 +285,39 @@ export function isStaleAssetCandidate(
 }
 
 /**
+ * Correct the missing-model `directory` for an Impact-Subpack UltralyticsDetectorProvider
+ * model so it points at the RIGHT bbox/segm subfolder (#487).
+ *
+ * `UltralyticsDetectorProvider.model_name` draws its combo from TWO separately-registered
+ * folders — `ultralytics/bbox` and `ultralytics/segm` — and the combo VALUE authoritatively
+ * carries the subfolder as a prefix (`bbox/…` or `segm/…`). ComfyUI's missing-model store,
+ * however, reports a SINGLE default directory for the input (observed: `ultralytics/bbox`)
+ * regardless of the value's prefix, so a missing `segm/…` model is mis-reported as belonging
+ * in `models/ultralytics/bbox`; downloading there leaves the node red because the loader
+ * resolves `segm/…` through `models/ultralytics/segm`.
+ *
+ * Given the store's `directory` and the missing `file` (the combo value), return the CORRECTED
+ * directory: when the directory is an ultralytics folder (`ultralytics`, `ultralytics/bbox`,
+ * or `ultralytics/segm`) AND the file carries a `bbox/`/`segm/` prefix, force the subfolder to
+ * match that prefix. Every other case — a non-ultralytics directory (checkpoints, loras, …),
+ * a null directory, or a file with no recognizable prefix — is passed through UNCHANGED, so
+ * non-ultralytics missing-asset resolution never regresses. Pure + fully defensive.
+ */
+export function resolveMissingModelDirectory(directory, file) {
+  try {
+    if (directory == null) return directory;
+    const dir = String(directory).replace(/\\/g, "/").replace(/\/+$/, "");
+    // Only touch the known ultralytics folders so nothing else can be rewritten.
+    if (!/^ultralytics(\/(bbox|segm))?$/i.test(dir)) return directory;
+    const m = /^\s*(bbox|segm)\//i.exec(String(file ?? "").replace(/\\/g, "/"));
+    if (!m) return directory;
+    return `ultralytics/${m[1].toLowerCase()}`;
+  } catch {
+    return directory;
+  }
+}
+
+/**
  * Blame each LIVE node whose type is one of the uninstalled `missingNodeTypes`. The
  * missing-nodes store only yields type NAMES; on their own they never land on a node,
  * so a red "node type not installed" node — INCLUDING a bypassed/muted one that


### PR DESCRIPTION
## Problem (#487)

`panel_get_errors` reported a missing `UltralyticsDetectorProvider` **segmentation** model (widget value `segm/ntd11_anime_nsfw_segm_v5.pt`) as belonging in `models/ultralytics/bbox`. ComfyUI-Impact-Subpack registers separate folders and resolves `segm/*` through `models/ultralytics/segm`, so following the tool's `directory` downloaded the model into the wrong folder and the red node stayed broken.

## Root cause

The missing-model surface passes ComfyUI's `missingModel` Pinia store `directory` straight through in `collectMissingAssets()`. That store reports a **single default folder** for the `model_name` input (observed: `ultralytics/bbox`) regardless of the combo value's prefix. But the `UltralyticsDetectorProvider.model_name` combo values are prefixed `bbox/…` or `segm/…`, which authoritatively determine the subfolder.

## Fix

- New pure helper `resolveMissingModelDirectory(directory, file)` in `web/js/lib/asset-staleness.js`: when the store's directory is an ultralytics folder (`ultralytics`, `ultralytics/bbox`, `ultralytics/segm`) **and** the combo value carries a `bbox/`/`segm/` prefix, force the subfolder to match the prefix. Every other case — a non-ultralytics directory (checkpoints, loras, …), a null directory, or a prefix-less file — is passed through **unchanged**, so non-ultralytics missing-asset resolution never regresses. Fully defensive (try/catch, fails through to the original value).
- Applied at the single `collectMissingAssets()` source consumed by BOTH `graph_get_errors` and the turn-start validation banner, so the two can't drift.

## Tests

Regression tests in `browser_tests/unit/asset-staleness.test.mjs`:
- `segm/x.pt` missing with a default `ultralytics/bbox` store dir -> `ultralytics/segm`
- `bbox/x.pt` -> `ultralytics/bbox` (unchanged)
- bare `ultralytics` dir gains the prefix subfolder; already-`segm` dir corrected by a `bbox/` value
- Windows backslash normalization; prefix-less / null file left unchanged
- non-ultralytics directories (`checkpoints`, `loras`, `ultralytics_extra`, null) never rewritten

Full panel unit suite green (1163 tests). `node --check` clean on both changed JS files. Codex self-gate: PASS, 0 findings.

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)