### PR TITLE
fix(panel): legacy Manager 3.x install — queue/start method negotiation + unreachable fallback

### DIFF
--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -610,6 +610,137 @@ test("waitForQueueDrain (real panel source) returns a drained status without Ref
 });
 
 // ---------------------------------------------------------------------------
+// #486 / #485 — legacy Manager 3.x install dialect. The install runtime lives in
+// comfyui-mcp-panel.js (managerQueueControl + nodes_install); we extract the real
+// source and assert its wiring so the fixes can't silently regress.
+// ---------------------------------------------------------------------------
+
+function readPanelSource() {
+  const panelPath = fileURLToPath(
+    new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url),
+  );
+  return readFileSync(panelPath, "utf8");
+}
+
+// #486 — queue/start is POST on pip v4 and the released 3.41 build, but GET-only
+// on some older released 3.x builds (ComfyUI 0.27.0 → HTTP 405 on POST). Drive
+// the REAL managerQueueControl source against mock `call`s to prove: POST first;
+// a 405 negotiates a single GET retry on the SAME route; any non-405 propagates
+// with NO GET retry.
+test("#486 managerQueueControl (real panel source): POST, then GET-retry ONLY on 405", async () => {
+  const src = readPanelSource();
+  const fnMatch = src.match(/async function managerQueueControl\([\s\S]*?\n\}/);
+  assert.ok(fnMatch, "could not locate managerQueueControl in panel source");
+
+  const isMethodNotAllowed = (err) => /HTTP\s*405\b/.test(String(err?.message ?? err ?? ""));
+  const MANAGER_FETCH_TIMEOUT_MS = 15000;
+  const factory = new Function(
+    "isMethodNotAllowed",
+    "MANAGER_FETCH_TIMEOUT_MS",
+    "AbortSignal",
+    `${fnMatch[0]}\nreturn managerQueueControl;`,
+  );
+  const managerQueueControl = factory(isMethodNotAllowed, MANAGER_FETCH_TIMEOUT_MS, AbortSignal);
+
+  // (a) POST succeeds ⇒ exactly one POST, no GET retry.
+  {
+    const calls = [];
+    const call = async (route, opts) => {
+      calls.push(opts?.method ?? "GET");
+    };
+    await managerQueueControl(call, "manager/queue/start");
+    assert.deepEqual(calls, ["POST"], "a working POST must NOT trigger a GET retry");
+  }
+
+  // (b) POST 405s (GET-only build) ⇒ negotiate a single GET retry on the SAME route.
+  {
+    const calls = [];
+    const call = async (route, opts) => {
+      const method = opts?.method ?? "GET";
+      calls.push({ route, method });
+      if (method === "POST") throw new Error("Manager manager/queue/start: HTTP 405");
+    };
+    await managerQueueControl(call, "manager/queue/start");
+    assert.deepEqual(
+      calls,
+      [
+        { route: "manager/queue/start", method: "POST" },
+        { route: "manager/queue/start", method: "GET" },
+      ],
+      "a 405 must negotiate POST→GET on the same route",
+    );
+  }
+
+  // (c) A non-405 error (e.g. 404 'not reachable') propagates with NO GET retry —
+  // a 405 is the ONLY method signal we negotiate.
+  {
+    let posts = 0;
+    let gets = 0;
+    const call = async (route, opts) => {
+      if ((opts?.method ?? "GET") === "POST") {
+        posts += 1;
+        throw new Error("ComfyUI-Manager not reachable (is the built-in Manager enabled?)");
+      }
+      gets += 1;
+    };
+    await assert.rejects(() => managerQueueControl(call, "manager/queue/start"), /not reachable/);
+    assert.equal(posts, 1);
+    assert.equal(gets, 0, "a 404/unreachable must NOT be retried as GET");
+  }
+});
+
+// #486 — nodes_install must start the queue through managerQueueControl (which
+// negotiates POST→GET on 405), never a raw POST (the exact HTTP-405 bug). Guard
+// the install block's source.
+test("#486 nodes_install starts the queue via managerQueueControl, never a raw POST", () => {
+  const src = readPanelSource();
+  const fnMatch = src.match(/async nodes_install\(args\)\s*\{[\s\S]*?\n {2}\},/);
+  assert.ok(fnMatch, "could not locate nodes_install in panel source");
+  const body = fnMatch[0];
+  // The start goes through the negotiator, routed to the effective dialect's caller.
+  assert.match(
+    body,
+    /managerQueueControl\(\s*dialect === "legacy" \? managerCall : managerV2,\s*"manager\/queue\/start"\s*\)/,
+  );
+  // No raw start POST survives in the install path (the #486 regression).
+  assert.ok(
+    !/manager(V2|Call)\(\s*"manager\/queue\/start"\s*,\s*post\(\)\s*\)/.test(body),
+    "install must not send a raw POST to manager/queue/start",
+  );
+  // Exactly ONE start is issued (not one per dialect branch) — the submit is
+  // separated from start so the #485 fallback can't double-fire (codex P0).
+  const starts = body.match(/"manager\/queue\/start"/g) ?? [];
+  assert.equal(starts.length, 1, "install must start the queue exactly once");
+});
+
+// #485 — a non-legacy dialect whose /v2 mutation reports the Manager unreachable
+// (404) must fall back to the ABSOLUTE legacy install SUBMIT, exactly as
+// nodes_list already degrades — never surface a false 'not reachable'. The
+// fallback must wrap ONLY the enqueue (submit), never the start, so an already-
+// landed submission can't be re-fired (codex P0). Guard the wiring in source.
+test("#485 nodes_install falls back to the legacy dialect on an unreachable signal", () => {
+  const src = readPanelSource();
+  const fnMatch = src.match(/async nodes_install\(args\)\s*\{[\s\S]*?\n {2}\},/);
+  assert.ok(fnMatch, "could not locate nodes_install in panel source");
+  const body = fnMatch[0];
+  // The submit is attempted, and on an unreachable error from a non-legacy
+  // dialect, retried as legacy (mirrors nodes_list's absolute fallback).
+  assert.match(body, /let dialect = detected;/);
+  assert.match(body, /submitInstall\(dialect\)/);
+  assert.match(body, /submitInstall\("legacy"\)/);
+  assert.match(
+    body,
+    /dialect === "legacy" \|\| !isManagerUnreachable\(err\)/,
+    "must rethrow when already legacy or the error is not an unreachable signal",
+  );
+  // The single queue/start MUST live OUTSIDE the try/catch (after it) so a start
+  // failure never re-runs the submit (codex P0 — no double-fire).
+  const catchIdx = body.indexOf("catch (err)");
+  const startIdx = body.indexOf('managerQueueControl(dialect === "legacy"');
+  assert.ok(catchIdx >= 0 && startIdx > catchIdx, "queue/start must run after the submit try/catch");
+});
+
+// ---------------------------------------------------------------------------
 // 3.x-LEGACY dialect completeness (#423 list / #424 update-self / #425 restart)
 // ---------------------------------------------------------------------------
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2997,6 +2997,30 @@ async function fetchObjectInfo() {
   return txt ? JSON.parse(txt) : null;
 }
 
+/** Start (or POST another control on) the Manager queue, negotiating the HTTP
+ *  method on a 405. Some released 3.x Manager builds register `queue/start` (and
+ *  peer control routes) as GET-only, so our POST comes back HTTP 405 (#486 —
+ *  reproduced on ComfyUI 0.27.0). On a Manager route a 405 means "wrong method
+ *  for THIS route on THIS build" — NEVER "the Manager is unreachable" and NEVER a
+ *  different Manager generation — so retry the SAME route once as GET. The pip v4
+ *  Manager and the released 3.41 build register `queue/start` as POST and keep
+ *  answering it (no 405, no GET retry); a GET-only build then starts its queue
+ *  instead of failing the whole install. Mirrors the orchestrator's
+ *  managerQueueControl (src/services/node-management.ts, #551). `call` is
+ *  managerV2 (adds the /v2 prefix) or managerCall (absolute legacy route). */
+async function managerQueueControl(call, route) {
+  try {
+    await call(route, { method: "POST", signal: AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS) });
+  } catch (err) {
+    // Only a 405 is a method signal we can negotiate; a 404 ("not reachable") or
+    // any other error means the route/POST genuinely failed — surface it. A 405
+    // leaves the route REGISTERED, so the GET retry hits the real GET handler
+    // (not ComfyUI's frontend catchall, which only serves UNREGISTERED GETs).
+    if (!isMethodNotAllowed(err)) throw err;
+    await call(route, { signal: AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS) });
+  }
+}
+
 /** Throw if a /v2/manager/queue/batch response reported the target id as failed.
  *  The batch runs synchronously and surfaces failures as {failed:[id,...]} — a
  *  silent success on a failed op is exactly the #184 no-op bug. */
@@ -3023,8 +3047,10 @@ function boundedDelay(ms, deadline) {
  *  respects the remaining budget. Never throws. Returns the LAST status seen (or
  *  null on a stall) — the caller's classifyInstallOutcome re-derives drained
  *  from it via queueDrained, so a null/malformed status is never a false drain
- *  (codex round 2 #1). */
-async function waitForQueueDrain({ timeoutMs = 120000, intervalMs = 1500 } = {}) {
+ *  (codex round 2 #1). `get` defaults to the dialect-routed managerGet; the
+ *  install verifier passes a dialect-PINNED getter so a post-#485-fallback verify
+ *  reads the SAME routes the install actually landed on (codex P1). */
+async function waitForQueueDrain({ timeoutMs = 120000, intervalMs = 1500, get = managerGet } = {}) {
   const deadline = Date.now() + timeoutMs;
   let status = null;
   // Give the queue a beat to register the task before the first poll, so we
@@ -3034,7 +3060,7 @@ async function waitForQueueDrain({ timeoutMs = 120000, intervalMs = 1500 } = {})
     // Cap this individual fetch by whatever budget remains.
     const perFetch = Math.max(1000, Math.min(MANAGER_FETCH_TIMEOUT_MS, deadline - Date.now()));
     try {
-      status = await managerGet("manager/queue/status", {
+      status = await get("manager/queue/status", {
         signal: AbortSignal.timeout(perFetch),
       });
     } catch {
@@ -3056,11 +3082,19 @@ async function waitForQueueDrain({ timeoutMs = 120000, intervalMs = 1500 } = {})
  * tri-state — never an early throw). Returns { state, status, message }.
  */
 async function verifyInstalled(target, dialect, { batchFailed, renameProne } = {}) {
-  const status = await waitForQueueDrain();
+  // Pin the status/list reads to the dialect the install ACTUALLY landed on. In
+  // the normal case this equals managerGet's cached detection; after the #485
+  // legacy fallback the cache still holds the detected v2 dialect, so re-deriving
+  // via managerGet would read the /v2 routes that don't serve on that hybrid
+  // build (→ a false "unverified"). Route by the effective dialect instead
+  // (codex P1).
+  const get = (route, opts) =>
+    dialect === "legacy" ? managerCall(route, opts) : managerV2(route, opts);
+  const status = await waitForQueueDrain({ get });
   let installed = null;
   let listError = false;
   try {
-    installed = await managerGet("customnode/installed", {
+    installed = await get("customnode/installed", {
       signal: AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS),
     });
   } catch {
@@ -8370,19 +8404,9 @@ const GRAPH_TOOL_EXECUTORS = {
     if (!id && !repository) {
       throw new Error("id (registry id or author/repo) or repository (git URL) is required");
     }
-    const dialect = await detectManagerDialect();
+    const detected = await detectManagerDialect();
     const ui_id = crypto.randomUUID();
     const client_id = api.clientId ?? api.initialClientId ?? "comfyui-mcp-panel";
-    // buildInstallRequest (./lib/manager-install.js) derives the repo NAME for a
-    // git URL (arriving via id OR repository, any protocol) and picks the right
-    // per-dialect payload — issues #187/#182/#184. A full URL is never sent as
-    // `id` (v4 would silently mark it "done"; 3.x fails late, past `failed`).
-    const req = buildInstallRequest(dialect, args, ui_id);
-    // The install id we verify against on disk (already the repo NAME for a git
-    // URL). #232: the Manager queue reports every task "done" even when the
-    // clone/resolve fails, so after queueing we resolve the TRUE outcome instead
-    // of claiming success — installed / failed / unverified (see verifyInstalled).
-    const target = dialect === "v2" ? req.params.id : req.body.id;
     // A git URL or an owner/repo id can install under a directory name that
     // differs from the repo name (e.g. TenStrip/10S-Comfy-nodes → 10S_Nodes), so
     // its on-disk presence can't be confirmed OR ruled out by name — absence is
@@ -8391,21 +8415,57 @@ const GRAPH_TOOL_EXECUTORS = {
     const renameProne = !!installGitUrl(args) || String(id ?? "").includes("/");
     // Every Manager mutation is bounded (codex round 2 #5).
     const post = (body) => ({ method: "POST", body, signal: AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS) });
-    let batchFailed; // v2-batch synchronous failed[] — FEEDS the gate as evidence
-    if (dialect === "v2") {
-      await managerV2("manager/queue/task", post({ kind: "install", params: req.params, ui_id, client_id }));
-      await managerV2("manager/queue/start", post());
-    } else if (dialect === "v2-batch") {
-      const res = await managerV2("manager/queue/batch", post({ install: [req.body] }));
-      // Capture the synchronous `failed[]` as failure EVIDENCE — but do NOT throw
-      // early (codex round 2 #4). The final outcome still goes through the
-      // tri-state gate (drained + list-readable + absent) below.
-      batchFailed = Array.isArray(res?.failed) ? res.failed : undefined;
-      await managerV2("manager/queue/start", post());
-    } else {
-      await managerCall("manager/queue/install", post(req.body));
-      await managerCall("manager/queue/start", post());
+    // SUBMIT the install (enqueue only — NOT start) for a given dialect. Kept
+    // separate from queue/start so the #485 unreachable-fallback below can never
+    // re-run a submission that already landed (a start failure must not double-
+    // fire the install — codex P0). Returns the on-disk `target` (already the
+    // repo NAME for a git URL — #232 verifies against it) plus the v2-batch
+    // synchronous `failed[]` (FEEDS the tri-state gate as EVIDENCE — never an
+    // early throw, codex round 2 #4).
+    const submitInstall = async (dialect) => {
+      // buildInstallRequest (./lib/manager-install.js) derives the repo NAME for
+      // a git URL (arriving via id OR repository, any protocol) and picks the
+      // right per-dialect payload — issues #187/#182/#184. A full URL is never
+      // sent as `id` (v4 would silently mark it "done"; 3.x fails late).
+      const req = buildInstallRequest(dialect, args, ui_id);
+      const target = dialect === "v2" ? req.params.id : req.body.id;
+      let batchFailed;
+      if (dialect === "v2") {
+        await managerV2("manager/queue/task", post({ kind: "install", params: req.params, ui_id, client_id }));
+      } else if (dialect === "v2-batch") {
+        const res = await managerV2("manager/queue/batch", post({ install: [req.body] }));
+        batchFailed = Array.isArray(res?.failed) ? res.failed : undefined;
+      } else {
+        await managerCall("manager/queue/install", post(req.body));
+      }
+      return { target, batchFailed };
+    };
+    // #485: a dialect-routed SUBMIT that reports the Manager "unreachable" (a /v2
+    // mutation 404s) can still succeed on the ABSOLUTE released-3.x routes — a
+    // build can answer the /v2 queue-status probe (so detection picks v2 /
+    // v2-batch) yet 404 the /v2 MUTATION routes while /manager/queue/install
+    // serves fine. nodes_list already degrades this way for the installed-node
+    // list; without the same fallback here, install threw a false "not reachable"
+    // even though panel_list_nodes worked. So on an unreachable signal from a
+    // non-legacy dialect, retry the SUBMIT via the legacy dialect before
+    // surfacing the error. The fallback wraps ONLY the enqueue: if the submit
+    // already succeeded, a later queue/start failure must NOT re-submit.
+    let dialect = detected;
+    let submitted;
+    try {
+      submitted = await submitInstall(dialect);
+    } catch (err) {
+      if (dialect === "legacy" || !isManagerUnreachable(err)) throw err;
+      dialect = "legacy";
+      submitted = await submitInstall("legacy");
     }
+    // The submission landed. NOW start the queue on the SAME (possibly
+    // fallen-back) dialect. queue/start goes through managerQueueControl so a
+    // GET-only 3.x build negotiates POST→GET on HTTP 405 instead of failing the
+    // install (#486). A start failure here is surfaced as-is — the install is
+    // already queued, so re-running the submit would double-fire it.
+    await managerQueueControl(dialect === "legacy" ? managerCall : managerV2, "manager/queue/start");
+    const { target, batchFailed } = submitted;
     // Resolve the true outcome. Throw ONLY on positive failure evidence; an
     // inconclusive result returns an honest unverified status (never a silent
     // success, never a false failure). #232 + codex rounds 1-2.


### PR DESCRIPTION
## Problem

`panel_install_node` failed against **ComfyUI-Manager 3.x legacy** two ways, same dialect root:

- **#486** (ComfyUI 0.27.0): install queued then failed `Manager manager/queue/start: HTTP 405`. The install path sent `manager/queue/start` as an unconditional **POST**, but older released 3.x builds register that route **GET-only** → 405.
- **#485** (ComfyUI 0.29.2): install threw a false `ComfyUI-Manager not reachable (is the built-in Manager enabled?)` while `panel_list_nodes` worked. `nodes_install` detected the dialect and hit the dialect-routed mutation with **no fallback**, whereas `nodes_list` already degrades to the absolute legacy route on an unreachable signal.

## Root cause & why the reporter's "always GET" diff is insufficient

Verified against the real ComfyUI-Manager source: **pip v4 and released 3.41 register `queue/start` as POST**; only *older* 3.x builds are GET-only. A blanket "GET on legacy" (the #486 reporter's applied-local diff) would break v4/3.41. The correct fix is **method negotiation** (POST, retry GET only on 405), matching the mcp orchestrator's `managerQueueControl` (#551).

For #485, the real gap is that `nodes_install` lacked the absolute-legacy fallback `nodes_list` already has: a build can answer the `/v2` queue-status probe (so detection picks `v2`/`v2-batch`) yet 404 the `/v2` **mutation** routes while `/manager/queue/install` serves fine.

## Fix

- New `managerQueueControl(call, route)` — POST, and **only on HTTP 405** retry the SAME route as GET. v4/3.41 keep POST (no 405, no retry); GET-only 3.x negotiates. A 405 means the route is registered, so its GET handler is real (not ComfyUI's frontend catchall, which only serves unregistered GETs).
- `nodes_install` split into `submitInstall` (enqueue only) + a single `managerQueueControl(dialect === "legacy" ? managerCall : managerV2, "manager/queue/start")` **after** the try/catch. The #485 unreachable-fallback wraps **only** the submit, so a start failure can never re-fire the install (no double-submit).
- `verifyInstalled` reads status/installed via a **dialect-pinned getter**, so a post-#485-fallback verify hits the routes the install actually landed on instead of the stale cached (`v2`) dialect. `waitForQueueDrain` gained an optional `{ get = managerGet }` (default preserves prior behavior + existing tests).

The modern Manager (v4) path is unchanged: POST start, no GET retry when POST succeeds, no fallback when the v2 mutation works.

## Tests

- Source-extraction test drives the real `managerQueueControl`: POST-only on success; single GET retry only on 405; a 404/unreachable propagates with no GET retry.
- Wiring guards: install starts the queue exactly once via `managerQueueControl` (no raw POST); the #485 legacy fallback wraps only the submit (start runs after the try/catch).
- **1159/1159 panel unit tests pass**; `node --check` + `tsc --noEmit` clean; YARA-clean (no svg+onload/onerror, no process-spawn literals).

Panel-only fix — the mcp orchestrator already negotiates `queue/start` and handles legacy install consistently, so no mcp change.

Closes #485
Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)