### PR TITLE
feat(civitai): expose per-item `gated` + cap the media proxy read (supports mcp#623)

### DIFF
--- a/browser_tests/unit/civitai-drive-results.test.mjs
+++ b/browser_tests/unit/civitai-drive-results.test.mjs
@@ -43,6 +43,7 @@ test("media serialization matches the contract shape", () => {
     baseModel: "FLUX.1-dev", type: "image",
     stats: { reactions: 42 }, prompt: "a cat astronaut",
     urls: ["/proxy/thumb/101.jpeg", "/proxy/full/101.jpeg"],
+    gated: false, // has a thumbnail + not flagged → visible
   });
   assert.equal(b.kind, "video"); // type:"video" → kind:"video"
   assert.equal(b.prompt, null);
@@ -58,7 +59,30 @@ test("model serialization matches the contract shape", () => {
     baseModel: "SDXL 1.0", type: "LORA",
     stats: { downloadCount: 1234, thumbsUp: 88 },
     prompt: null, urls: ["/proxy/cover/5.jpeg"],
+    gated: false, // has a cover + not flagged → visible
   });
+});
+
+test("gated / blurred results are flagged so a vision consumer withholds pixels (mcp#623)", () => {
+  // Media: an item flagged gated (rating outside enabled levels), and one with no
+  // thumbnail at all (also rendered as a blurred placeholder by the grid).
+  const media = [
+    { id: 1, type: "image", author: "a", reactions: 0, gated: true, thumbnailUrl: "/t/1", fullUrl: "/f/1" },
+    { id: 2, type: "image", author: "b", reactions: 0, thumbnailUrl: null, fullUrl: null },
+    { id: 3, type: "image", author: "c", reactions: 0, thumbnailUrl: "/t/3", fullUrl: "/f/3" },
+  ];
+  const out = serializeCivitaiResults(media, { model: false });
+  assert.equal(out.items[0].gated, true); // explicitly gated
+  assert.equal(out.items[1].gated, true); // no thumbnail → blurred placeholder
+  assert.equal(out.items[2].gated, false); // visible
+  // Models: a model with no usable cover is treated as gated too.
+  const models = [
+    { id: 9, name: "No Cover", creator: "d", coverUrl: null },
+    { id: 10, name: "Has Cover", creator: "e", coverUrl: "/c/10" },
+  ];
+  const mout = serializeCivitaiResults(models, { model: true });
+  assert.equal(mout.items[0].gated, true);
+  assert.equal(mout.items[1].gated, false);
 });
 
 test("every serialized url is a string, never image bytes/blobs", () => {

--- a/py/civitai_proxy.py
+++ b/py/civitai_proxy.py
@@ -292,6 +292,10 @@ def register(routes, web):
                         return web.json_response({"error": str(e)}, status=502)
         return web.json_response({"error": "unreachable"}, status=502)
 
+    # Upper bound on a single proxied media body (thumbs + full images). Generous
+    # for any real CivitAI asset; caps memory for a hostile/oversize upstream.
+    _MEDIA_CAP = 32 * 1024 * 1024
+
     @routes.get("/comfyui_mcp_panel/civitai/media")
     async def _civitai_media(request):
         # ?uuid=&transform=&ext=  → stream the CDN bytes with bot-gate headers.
@@ -307,9 +311,21 @@ def register(routes, web):
                     if resp.status != 200:
                         return web.Response(status=resp.status)
                     ctype = resp.headers.get("Content-Type", "application/octet-stream")
-                    payload = await resp.read()
+                    # Bound memory: refuse an over-cap body up front, and read in
+                    # chunks so a length-less/lying upstream can't stream past the
+                    # cap into an unbounded buffer. Media (thumbs + full images) is
+                    # comfortably under _MEDIA_CAP; abuse is truncated to a 413.
+                    if (resp.content_length or 0) > _MEDIA_CAP:
+                        return web.Response(status=413, text="media too large")
+                    chunks = []
+                    total = 0
+                    async for chunk in resp.content.iter_chunked(1 << 16):
+                        total += len(chunk)
+                        if total > _MEDIA_CAP:
+                            return web.Response(status=413, text="media too large")
+                        chunks.append(chunk)
                     return web.Response(
-                        body=payload,
+                        body=b"".join(chunks),
                         content_type=ctype.split(";")[0],
                         headers={"Cache-Control": "public, max-age=86400"},
                     )

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -245,9 +245,12 @@ export function graphDirtyForConfirm(ctx) {
 
 /** Serialize result rows — `state.items` (media) or `state.models` (models) —
  *  to the agent's `civitai_results` contract shape: id, kind, title, creator,
- *  baseModel/type, stats, prompt, and media URL(s). Metadata + URLs ONLY — never
- *  image bytes (the agent reasons from text; the human clicks to view). Pure and
- *  exported for unit tests. `limit` is clamped to [1, 200]. */
+ *  baseModel/type, stats, prompt, media URL(s), and `gated`. Metadata + URLs
+ *  ONLY — never image bytes (the agent reasons from text + can fetch the sample
+ *  thumbnail via the URLs; the human clicks to view). `gated` flags a result the
+ *  grid BLURS (rating outside the enabled browsing levels) so a downstream vision
+ *  consumer withholds its sample pixels — see mcp#623. Pure and exported for unit
+ *  tests. `limit` is clamped to [1, 200]. */
 export const CIVITAI_PROMPT_CAP = 600; // chars — bound the agent's token budget
 function _capPrompt(p) {
   // Coerce a structured prompt so the outbound civitai_results contract never
@@ -265,6 +268,11 @@ export function serializeCivitaiResults(source, { model = false, limit = 20, loa
     baseModel: x.baseModel || null, type: x.type || null,
     stats: { downloadCount: x.downloadCount ?? null, thumbsUp: x.thumbsUp ?? null },
     prompt: null, urls: x.coverUrl ? [x.coverUrl] : [],
+    // `gated` mirrors the grid's blur decision (mediaCard/lightbox: `x.gated ===
+    // true || !<cover/thumb>`), so an agent-vision consumer (mcp#623) can withhold
+    // the sample image for anything the human-facing UI renders as a blurred
+    // placeholder — the NSFW/browsing-level gate is never bypassed downstream.
+    gated: x.gated === true || !x.coverUrl,
   } : {
     id: x.id, kind: x.type === "video" ? "video" : "image",
     title: null, creator: x.author || null,
@@ -272,6 +280,7 @@ export function serializeCivitaiResults(source, { model = false, limit = 20, loa
     stats: { reactions: x.reactions ?? null },
     prompt: _capPrompt(x.prompt), // bounded — token budget (audit item 3)
     urls: [x.thumbnailUrl, x.fullUrl].filter(Boolean),
+    gated: x.gated === true || !x.thumbnailUrl,
   });
   return { items, total: rows.length, loading: !!loading };
 }


### PR DESCRIPTION
## What & why

Supports comfyui-mcp #623 (let the agent SEE CivitAI sample images). Two small, gating-preserving changes:

1. **`serializeCivitaiResults` now emits a per-item `gated` boolean** mirroring the grid's own blur decision (`x.gated === true || !<thumbnail/cover>`). This is the signal the mcp orchestrator uses to decide which results' sample pixels it may show the agent — it **fails closed**, so a result the human-facing UI blurs (rating outside the enabled browsing levels) is never surfaced as pixels downstream. No behavior change to the grid/lightbox.

2. **`/comfyui_mcp_panel/civitai/media` proxy now bounds the body** it buffers (`_MEDIA_CAP = 32 MiB`): rejects an over-`Content-Length` upstream up front and reads in chunks so a length-less/lying upstream can't stream past the cap into an unbounded buffer. Real CivitAI media is comfortably under the cap; this just caps abuse (benefits the browser thumbnail path too).

## Tests

`civitai-drive-results.test.mjs`: contract-shape assertions updated to include `gated`, plus a new case proving gated/blurred/no-thumbnail results (media and models) are flagged so a vision consumer withholds their pixels. Panel unit tests + `test_civitai_proxy.py` green. YARA-clean (ES module, no svg+onload/onerror, no process-spawn literals).

Companion of comfyui-mcp #623 (do not merge before/independently of confirming the mcp side).
