### PR TITLE
0.11.30 — save-409 content-equality gate (#442) + ultralytics dir (#487) + legacy Manager install (#485/#486) + civitai gated flag (#623)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.30] - 2026-08-01
+
+### Added
+- expose per-item `gated` + cap the media proxy read (supports mcp#623)
+- refresh_nodes executor — force /object_info re-register on demand (#608)
+
+### Fixed
+- legacy Manager 3.x install — negotiate queue/start method + unreachable fallback (#485, #486)
+- derive Ultralytics bbox/segm dir from combo prefix (#487)
+- in-place-overwrite gate must compare RAW BYTES, not decoded text (#442 defect 3)
+- content-equality gate for in-place save + late stale read (#442 defects 2,3)
+- stale-tab detection on open + in-place save 409 (#442 defects 2,3)
+- report EFFECTIVE widget state + stop blobs starving the node you asked for (#607, #609) (#482)
+- recover run-completion missed on unobserved reconnect (#356) + refuse false-clean empty-graph reads (#389)
+
+
 ## [0.11.29] - 2026-08-01
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.29"
+version = "0.11.30"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -407,7 +407,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.29";
+const PANEL_VERSION = "0.11.30";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Panel 0.11.30 — coordinated with mcp 0.48.31.

- **#442 defect 3** in-place save-409 fixed via a byte-exact content-equality gate (fail-closed: authorizes overwrite ONLY when on-disk bytes == the tab's loaded baseline; disk changed out-of-band ⇒ conflict, never a silent clobber) + stale-tab detection (#442 defect 2).
- **#487** panel_get_errors derives Ultralytics bbox/segm dir from the combo-value prefix.
- **#485/#486** legacy Manager 3.x install: POST→GET-on-405 method negotiation + unreachable fallback.
- **#623** per-item `gated` flag + media-proxy read cap (supports mcp#628 civitai agent-vision).

Both version fields bumped (pyproject + PANEL_VERSION = 0.11.30). Merge → Registry publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)