### PR TITLE
fix(groups): match LiteGraph containsCentre rule for group membership (#497)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- group membership matches LiteGraph's `containsCentre` rule (group box contains the node's centre point), not box overlap — a node whose centre is moved out of a group is no longer reported as a member by `panel_graph_outline` / `panel_edit_group` (#497)
+
 ## [0.11.30] - 2026-08-01
 
 ### Added

--- a/browser_tests/unit/group-geometry.test.mjs
+++ b/browser_tests/unit/group-geometry.test.mjs
@@ -367,16 +367,96 @@ test("moveGroupMembers skips nodes without a usable pos and never throws", () =>
   moveGroupMembers(null, 1, 1); // must not throw
 });
 
-test("membership overlap is edge-inclusive (matches LiteGraph overlapBounding)", () => {
-  // Node's right edge exactly touches the group's left edge.
-  const n = { id: 1, boundingRect: [0, 0, 100, 100] }; // spans x:0..100
+// ---------------------------------------------------------------------------
+// #497: membership must match LiteGraph's containsCentre rule (the group box
+// contains the node bounding-box's CENTRE point), NOT a box OVERLAP. A node
+// moved so its centre leaves the group is dropped even if an edge still pokes
+// into the box — the "still reported as a member after moving it out" symptom.
+// LiteGraph never recomputes group._nodes when a MEMBER node moves (only when
+// the GROUP is created/moved/resized), so the panel recomputes live at read.
+// ---------------------------------------------------------------------------
+test("membership is centre-in-rect, not box overlap (#497)", () => {
+  // Node spans x:0..100 (centre x=50). Group starts at x=60, so the two boxes
+  // OVERLAP (x:60..100) but the node's centre (50) is OUTSIDE the box. The old
+  // overlap rule wrongly counted this as a member; containsCentre does not.
+  const n = { id: 1, boundingRect: [0, 0, 100, 100] }; // centre (50,50)
   const graph = graphOf(n);
-  const g = groupBox([100, 0, 200, 200]); // starts exactly at x=100
+  const overlapping = groupBox([60, 0, 200, 200]); // x:60..260 — overlaps but no centre
   assert.deepEqual(
-    groupMemberNodes(graph, g).map((x) => x.id),
-    [1],
-    "edge contact counts as membership",
+    groupMemberNodes(graph, overlapping).map((x) => x.id),
+    [],
+    "a box that only overlaps (centre outside) is NOT a member",
   );
+  // Same node, a box that actually contains its centre → member.
+  const containing = groupBox([0, 0, 200, 200]); // x:0..200 contains centre (50,50)
+  assert.deepEqual(
+    groupMemberNodes(graph, containing).map((x) => x.id),
+    [1],
+    "a box containing the centre IS a member",
+  );
+});
+
+test("centre-in-rect is min-edge inclusive, max-edge exclusive (matches isInRect) (#497)", () => {
+  // Node centre lands EXACTLY on the group's min corner → inclusive (member).
+  const onMin = { id: 1, boundingRect: [0, 0, 200, 200] }; // centre (100,100)
+  assert.deepEqual(
+    groupMemberNodes(graphOf(onMin), groupBox([100, 100, 300, 300])).map((n) => n.id),
+    [1],
+    "centre on the min edge (>=) counts as inside",
+  );
+  // Node centre lands EXACTLY on the group's RIGHT (x-max) edge → exclusive.
+  const onMaxX = { id: 2, boundingRect: [50, 0, 100, 100] }; // centre (100,50)
+  assert.deepEqual(
+    groupMemberNodes(graphOf(onMaxX), groupBox([0, 0, 100, 100])).map((n) => n.id),
+    [],
+    "centre on the x-max edge (<) is excluded",
+  );
+  // Node centre lands EXACTLY on the group's BOTTOM (y-max) edge → exclusive. This
+  // is an INDEPENDENT condition in isInRect; the box overlaps on both axes here, so
+  // the old overlap rule would wrongly include it.
+  const onMaxY = { id: 3, boundingRect: [0, 50, 100, 100] }; // centre (50,100)
+  assert.deepEqual(
+    groupMemberNodes(graphOf(onMaxY), groupBox([0, 0, 100, 100])).map((n) => n.id),
+    [],
+    "centre on the y-max edge (<) is excluded",
+  );
+});
+
+test("a node moved OUT of a group by CENTRE stops being a member (#497)", () => {
+  // The report's shape: a node whose box still OVERLAPS a nearby group but whose
+  // CENTRE has moved out. The old edge-overlap rule reported it in every box its
+  // edge touched (the #497 bug); containsCentre reports it only where its centre is.
+  // Both panel_graph_outline and panel_edit_group (summarizeGroup) funnel through
+  // groupMemberNodes, so this shared recompute keeps the two readers in agreement.
+  const n = node(7, 600, 560, 287, 122); // focus bounds x600..887, centre ≈ (743.5, 606)
+  const g3 = groupBox([560, 265, 360, 460]); // x560..920 — holds the centre
+  // g4 OVERLAPS the node (x800..1100 vs node x600..887 → shared 800..887) but the
+  // centre (743.5) is LEFT of it: old overlap = member (WRONG), containsCentre = no.
+  const g4 = groupBox([800, 500, 300, 300]); // x800..1100 y500..800
+  const graph = graphOf(n);
+  const membersOf = (g) => groupMemberNodes(graph, g).map((x) => x.id);
+
+  assert.deepEqual(membersOf(g4), [], "overlapping box WITHOUT the centre drops the node");
+  assert.deepEqual(membersOf(g3), [7], "the box that holds the centre keeps it");
+
+  // Move the node's centre INTO g4 → member there, and out of g3.
+  n.pos = [850, 550]; // focus x850..1137, centre ≈ (993.5, 596) — inside g4, right of g3
+  assert.deepEqual(membersOf(g4), [7], "moved-in node reported by live centre geometry");
+  assert.deepEqual(membersOf(g3), [], "and no longer reported by the box it left");
+});
+
+test("membership follows a group's OWN moved bounds, not a stale cache (#497)", () => {
+  // The dual of the node-move case: the NODE stays put and the GROUP box moves
+  // (as panel_edit_group(bounds=…) / panel_move_group mutate g._bounding). The
+  // live read must reflect the new box even though groupBox's recomputeInsideNodes
+  // is a no-op that leaves the _nodes cache stale.
+  const n = node(1, 600, 560, 200, 100); // focus bounds x600..800, centre (700, 595)
+  const graph = graphOf(n);
+  const g = groupBox([1000, 0, 300, 300]); // starts far from the node (x1000..1300)
+  assert.deepEqual(groupMemberNodes(graph, g).map((x) => x.id), [], "node outside the group's start bounds");
+  // Reposition the SAME group's box so it now covers the node's centre.
+  g._bounding = [650, 500, 300, 200]; // x650..950 y500..700 — holds centre (700,595)
+  assert.deepEqual(groupMemberNodes(graph, g).map((x) => x.id), [1], "moved group box gains the node by live geometry");
 });
 
 // ---------------------------------------------------------------------------

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7845,8 +7845,9 @@ const GRAPH_TOOL_EXECUTORS = {
     graph.setDirtyCanvas(true, true);
     const summary = summarizeGroup(graph, group);
     // Honesty for dense layouts (#297): group membership is purely GEOMETRIC, so
-    // any unrelated node whose box overlaps the computed rectangle is now a member
-    // — LiteGraph has no per-node ownership to exclude it. When the live members
+    // any unrelated node whose CENTRE falls within the computed rectangle is now a
+    // member (LiteGraph's containsCentre rule, #497) — LiteGraph has no per-node
+    // ownership to exclude it. When the live members
     // differ from what was requested, surface both sets and a warning instead of
     // silently reporting a misleading success.
     if (requestedIds) {
@@ -7857,7 +7858,7 @@ const GRAPH_TOOL_EXECUTORS = {
         summary.missing_node_ids = missing;
         summary.warning =
           "group membership is geometric: the box that wraps the requested nodes " +
-          `also overlaps ${extra.length} unrelated node(s)` +
+          `also captures ${extra.length} unrelated node(s) (their centre falls inside)` +
           (missing.length ? ` and misses ${missing.length} requested node(s)` : "") +
           ". Move the intended nodes into a contiguous region (panel_move_node / " +
           "panel_arrange) before grouping, or edit the group bounds, to get an exact set.";

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -1,11 +1,15 @@
 // Pure geometry helpers for LiteGraph GROUP membership.
 //
 // LiteGraph groups do NOT own their nodes. Membership is purely GEOMETRIC: a
-// node belongs to a group when its bounding box overlaps the group's bounding
-// box. Several ComfyUI frontend builds leave LGraphGroup._nodes stale or empty
-// after programmatic bounds / pos / paste changes, so the panel must recompute
-// membership from LIVE node + group geometry on every read rather than trust the
-// cached _nodes array (issues #287, #305, #311, #312).
+// node belongs to a group when the group's bounding box contains the CENTRE
+// point of the node's bounding box — the exact rule ComfyUI's @comfyorg/litegraph
+// applies in LGraphGroup.recomputeInsideNodes (containsCentre → isInRect), so the
+// panel's reported members match what the user sees on the canvas (issue #497).
+// Several ComfyUI frontend builds leave LGraphGroup._nodes stale or empty after
+// programmatic bounds / pos / paste changes (and never recompute when a MEMBER
+// node moves — only when the GROUP is created/moved/resized), so the panel must
+// recompute membership from LIVE node + group geometry on every read rather than
+// trust the cached _nodes array (issues #287, #305, #311, #312, #497).
 //
 // These functions are intentionally dependency-free (no LiteGraph, no DOM) so
 // they can be unit-tested with plain object fixtures.
@@ -95,15 +99,20 @@ export function groupBoundsOf(g) {
 /**
  * LIVE geometric membership of a LiteGraph group.
  *
- * Recomputes from the CURRENT node + group geometry (overlap test, mirroring
- * LiteGraph's own overlapBounding) instead of trusting the cached g._nodes.
- * Best-effort calls g.recomputeInsideNodes?.() first to keep LiteGraph's own
- * cache (used by convertToSubgraph / canvas selection) in sync, but never
- * depends on its result.
+ * Recomputes from the CURRENT node + group geometry instead of trusting the
+ * cached g._nodes (which LiteGraph only refreshes when the GROUP moves, never
+ * when a member node moves — the #497 stale-membership root cause). Membership
+ * mirrors @comfyorg/litegraph's LGraphGroup.recomputeInsideNodes: a node is IN
+ * the group when the group box contains the node bounding-box's CENTRE point
+ * (containsCentre → isInRect), NOT when the two boxes merely overlap. A node
+ * moved so its centre leaves the box is dropped even if an edge still pokes in —
+ * matching what the user sees on the canvas. Best-effort calls
+ * g.recomputeInsideNodes?.() first to keep LiteGraph's own cache (used by
+ * convertToSubgraph / canvas selection) in sync, but never depends on its result.
  *
- * NOTE (dense-layout limitation, #297): because membership is purely geometric,
- * ANY unrelated node whose box overlaps the group rectangle IS a member — there
- * is no per-node ownership to exclude it. Callers creating a group around a
+ * NOTE (dense-layout limitation, #297): membership is purely geometric, so ANY
+ * unrelated node whose CENTRE falls within the group rectangle IS a member —
+ * there is no per-node ownership to exclude it. Callers creating a group around a
  * specific node set must report requested-vs-actual honestly.
  */
 export function groupMemberNodes(graph, g) {
@@ -113,8 +122,11 @@ export function groupMemberNodes(graph, g) {
   const [gx, gy, gw, gh] = gb;
   return (graph?._nodes ?? []).filter((n) => {
     const [nx, ny, nw, nh] = nodeFocusBounds(n);
-    // Inclusive overlap, matching LiteGraph's overlapBounding (edge contact counts).
-    return nx <= gx + gw && nx + nw >= gx && ny <= gy + gh && ny + nh >= gy;
+    // Centre-in-rect, matching LiteGraph's containsCentre → isInRect: the centre
+    // is inclusive on the min edges (>=) and exclusive on the max edges (<).
+    const cx = nx + nw / 2;
+    const cy = ny + nh / 2;
+    return cx >= gx && cx < gx + gw && cy >= gy && cy < gy + gh;
   });
 }
 


### PR DESCRIPTION
## Problem (#497)

`panel_graph_outline` and `panel_edit_group` reported a node as a member of groups it had been moved out of. The reporter saw node 7 listed in three groups when only one contained it geometrically.

## Root cause

Group membership was recomputed live (via `groupMemberNodes` → `syncGraphNodeAreas`/`refreshNodeArea`, the #355/#408/#416/#429 fixes), but it used an edge-inclusive box **OVERLAP** test. ComfyUI's `@comfyorg/litegraph` decides membership in `LGraphGroup.recomputeInsideNodes` with **`containsCentre` → `isInRect`**: the group box must contain the node bounding-box's **centre point** (min-edge inclusive `>=`, max-edge exclusive `<`), NOT any box overlap. So a node whose centre sits outside a group but whose edge still pokes into the box was reported as a member — diverging from what the user sees on the canvas.

(LiteGraph only recomputes its own `group._nodes` cache when the GROUP is created/moved/resized, never when a MEMBER node moves — which is why the panel must recompute live at read time in the first place. That part was already correct; the rule was not.)

## Fix

`web/js/lib/group-geometry.js` `groupMemberNodes()`: replace the overlap test with the centre-in-rect rule, computing the centre from `nodeFocusBounds` and matching `isInRect` edge semantics exactly. All group-membership readers (`panel_graph_outline`, `panel_edit_group`/`summarizeGroup`, `graph_query`, subgraph-group, auto-layout) funnel through this single helper, so they stay in agreement. The live-geometry recompute and honest requested-vs-actual reporting (#297) are preserved; the create-group warning wording is updated to the centre rule.

## Tests

`browser_tests/unit/group-geometry.test.mjs` — new regression coverage:
- overlap-but-centre-outside is NOT a member (discriminates old rule from new)
- edge inclusivity matches `isInRect` on both x-max and y-max edges
- a node moved out/in flips membership by live centre geometry
- a group whose own bounds move onto a fixed node's centre gains it (edit_group/move_group path)

All 29 group-geometry tests pass; full panel unit suite green (1169). `node --check` clean; YARA/spawn-literal guard unaffected. Self-reviewed with codex.

Closes #497