### PR TITLE
0.11.31 — set_widget frontend-only nodes writable (#475/#477) + group membership centre-in-rect (#497)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,25 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.31] - 2026-08-01
+
 ### Fixed
 - group membership matches LiteGraph's `containsCentre` rule (group box contains the node's centre point), not box overlap — a node whose centre is moved out of a group is no longer reported as a member by `panel_graph_outline` / `panel_edit_group` (#497)
+
+### Added
+- expose per-item `gated` + cap the media proxy read (supports mcp#623)
+- refresh_nodes executor — force /object_info re-register on demand (#608)
+
+### Fixed
+- frontend-only rgthree nodes (#475) + outer promoted display-proxy sync (#477) (#479)
+- legacy Manager 3.x install — negotiate queue/start method + unreachable fallback (#485, #486)
+- derive Ultralytics bbox/segm dir from combo prefix (#487)
+- in-place-overwrite gate must compare RAW BYTES, not decoded text (#442 defect 3)
+- content-equality gate for in-place save + late stale read (#442 defects 2,3)
+- stale-tab detection on open + in-place save 409 (#442 defects 2,3)
+- report EFFECTIVE widget state + stop blobs starving the node you asked for (#607, #609) (#482)
+- recover run-completion missed on unobserved reconnect (#356) + refuse false-clean empty-graph reads (#389)
+
 
 ## [0.11.30] - 2026-08-01
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.30"
+version = "0.11.31"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -465,7 +465,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.30";
+const PANEL_VERSION = "0.11.31";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Panel 0.11.31.

- **#475/#477** `panel_set_widget`: genuine frontend-only nodes (MarkdownNote/Note/Reroute/rgthree) are writable again — the fresh-backend #458 guard now uses an **observed-backend-history** trust root (a type ever-seen in /object_info this session that's now absent ⇒ removed pack ⇒ refuse; never-seen ⇒ frontend-only ⇒ allow), which is STRICTER than the prior defless-trust while fixing the over-rejection. Promoted subgraph widget writes now update the parent boundary value atomically (no stale outer value fed to execution). Closes #475/#477/#493/#494/#496.
- **#497** group membership uses ComfyUI/litegraph's authoritative **centre-in-rect** containment (was edge-overlap), so a node moved out of a group is no longer reported as a member.

Both version fields bumped (pyproject + PANEL_VERSION = 0.11.31). Merge → Registry publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)