### PR TITLE
0.11.32 — panel_set_property executor (#488) + copy-nodes in-memory clipboard (#500)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,27 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.32] - 2026-08-01
+
 ### Fixed
 - `panel_copy_nodes` no longer throws `QuotaExceededError` ("The quota has been exceeded.") when copying many nodes with large widget payloads — the cross-workflow clipboard is backed by a non-quota in-memory store instead of only `localStorage`, so a big copy survives the workflow switch and `panel_paste_nodes` reconstructs every node and intra-set link (native Ctrl+C still wins when it replaces the clipboard after a tool copy) (#500)
+
+### Added
+- graph_set_node_property — set a node's LiteGraph property live (#488) (#501)
+- expose per-item `gated` + cap the media proxy read (supports mcp#623)
+- refresh_nodes executor — force /object_info re-register on demand (#608)
+
+### Fixed
+- frontend-only rgthree nodes (#475) + outer promoted display-proxy sync (#477) (#479)
+- match LiteGraph containsCentre rule for group membership (#497)
+- legacy Manager 3.x install — negotiate queue/start method + unreachable fallback (#485, #486)
+- derive Ultralytics bbox/segm dir from combo prefix (#487)
+- in-place-overwrite gate must compare RAW BYTES, not decoded text (#442 defect 3)
+- content-equality gate for in-place save + late stale read (#442 defects 2,3)
+- stale-tab detection on open + in-place save 409 (#442 defects 2,3)
+- report EFFECTIVE widget state + stop blobs starving the node you asked for (#607, #609) (#482)
+- recover run-completion missed on unobserved reconnect (#356) + refuse false-clean empty-graph reads (#389)
+
 
 ## [0.11.31] - 2026-08-01
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.31"
+version = "0.11.32"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -470,7 +470,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.31";
+const PANEL_VERSION = "0.11.32";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Panel 0.11.32 — coordinated with mcp 0.48.32.

- **#488** `graph_set_node_property` executor (pairs with the mcp panel_set_property tool) — set node LiteGraph properties (rgthree matchTitle etc.) with onPropertyChanged live-effect, false-revert, __proto__ refusal, undo envelope.
- **#500** `panel_copy_nodes` no longer throws 'The quota has been exceeded.' — the cross-workflow clipboard now uses an in-memory store instead of the quota-limited localStorage; paste reconstructs all nodes.

Both version fields bumped (pyproject + PANEL_VERSION = 0.11.32). Merge → Registry publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)