### PR TITLE
feat(providers): wire MiniMax provider chip across the panel (#355)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -74,6 +74,7 @@ _BACKEND_PORTS = {
     "kimi": _BRIDGE_PORT,  # single-port multi-provider — same orchestrator
     "moonshot": _BRIDGE_PORT,  # hosted (Moonshot / Kimi K3) — same orchestrator, key-gated
     "glm": _BRIDGE_PORT,  # hosted (z.ai coding plan / GLM) — same orchestrator, key-gated
+    "minimax": _BRIDGE_PORT,  # hosted (MiniMax platform) — same orchestrator, key-gated
     "ollama": _BRIDGE_PORT,  # single-port multi-provider — same orchestrator
     "openrouter": _BRIDGE_PORT,  # hosted (OpenRouter) — same orchestrator, key-gated
 }

--- a/browser_tests/minimax-provider.spec.ts
+++ b/browser_tests/minimax-provider.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * Tier 1 — MiniMax provider chip.
+ *
+ * The orchestrator gained a `minimax` backend (the hosted MiniMax platform —
+ * api.minimax.io, model MiniMax-M3, key MINIMAX_API_KEY). This spec connects the
+ * panel to a MockBridge, pushes the orchestrator's authoritative `backends` frame
+ * (claude + minimax, both ready) over the SAME bridge channel the real
+ * orchestrator uses (createBridgeClient's onBackends), and asserts the model
+ * popup's Provider section renders minimax's chip labeled "MiniMax"
+ * (BACKEND_LABELS) with the hint "MiniMax M3 · 1M context" (BACKEND_HINTS) — i.e.
+ * the new backend id is a KNOWN label the panel renders, not an unrecognized id
+ * that would fall through to the raw "minimax" string (or be dropped).
+ *
+ * MiniMax is a hosted API-key provider with no CLI (same shape as GLM / Kimi K3).
+ * The handshake-backend ADOPTION path (selecting the chip connects as minimax
+ * without reverting to claude) is exercised manually against a live orchestrator;
+ * here we pin the deterministic UI wiring.
+ *
+ * HARNESS NOTE: the panel can double-mount under a test harness → a documented
+ * "reconnect storm" (two clients, same tab_id) that resets knownBackends and
+ * detaches the popup after ~1s. connect.spec.ts beats it by being fast; so do we —
+ * connect, advertise, then open + read the row in a single fast pass. Spec-level
+ * retries reload the page to dodge a load that storms early.
+ */
+import { test, expect } from './fixtures/panelTest'
+import { MockBridge } from './fixtures/MockBridge'
+
+test.describe.configure({ retries: 2 })
+
+test('a ready MiniMax backend renders a "MiniMax" provider chip with its hint', async ({
+  panel
+}) => {
+  const bridge = new MockBridge({ greeting: 'Panel agent ready.' })
+  await bridge.start()
+  try {
+    // Standard proven connect path (connect.spec.ts).
+    await panel.goto()
+    await panel.setBridgeUrl(bridge.url)
+    await panel.openSidebar()
+    await panel.connect()
+    await expect(panel.statusPill).toContainText('connected')
+
+    // The authoritative readiness frame: claude (the connected, selected backend —
+    // so no auto-pick/switch fires) + a ready minimax. The Provider section renders
+    // only when >1 provider is known. Same {type:"backends"} frame the real
+    // orchestrator sends post-hello; the panel ingests it via onBackends.
+    bridge.send({
+      type: 'backends',
+      any_ready: true,
+      backends: [
+        { backend: 'claude', running: true, cli: true, auth: true, ready: true },
+        { backend: 'minimax', running: false, cli: true, auth: true, ready: true }
+      ]
+    })
+
+    // Let the frame land (ingested synchronously by the ws onmessage handler), then
+    // open the model popup and read minimax's row FAST — capture label + full text
+    // in a single pass before any reconnect can detach it.
+    await panel.page.waitForTimeout(400)
+    await panel.root.locator('.cmcp-chip').first().click()
+    const minimax = panel.root
+      .locator('.cmcp-popover-item.cmcp-provider')
+      .filter({ hasText: 'MiniMax' })
+    await expect(minimax).toHaveCount(1, { timeout: 8_000 })
+    const [label, rowText] = await Promise.all([
+      minimax.locator('.lbl').textContent(),
+      minimax.textContent()
+    ])
+    // Exact label — reads "MiniMax", never the raw id. Proves minimax is in
+    // BACKEND_LABELS (the render allowlist), not an unknown id.
+    expect(label?.trim()).toBe('MiniMax')
+    // BACKEND_HINTS ("MiniMax M3 · 1M context") wired through to the visible chip.
+    expect(rowText).toContain('MiniMax M3 · 1M context')
+  } finally {
+    await bridge.close()
+  }
+})

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -956,6 +956,7 @@ const DEFAULT_BRIDGE_URL_BY_BACKEND = {
   kimi: DEFAULT_BRIDGE_URL,
   moonshot: DEFAULT_BRIDGE_URL,
   glm: DEFAULT_BRIDGE_URL,
+  minimax: DEFAULT_BRIDGE_URL,
   ollama: DEFAULT_BRIDGE_URL,
 };
 function defaultBridgeUrlFor(backend) {
@@ -1522,6 +1523,7 @@ const SETTING_MODEL = {
   kimi: "comfyui-mcp.defaultModel.kimi",
   moonshot: "comfyui-mcp.defaultModel.moonshot",
   glm: "comfyui-mcp.defaultModel.glm",
+  minimax: "comfyui-mcp.defaultModel.minimax",
   ollama: "comfyui-mcp.defaultModel.ollama",
   openrouter: "comfyui-mcp.defaultModel.openrouter",
   lmstudio: "comfyui-mcp.defaultModel.lmstudio",
@@ -1537,6 +1539,7 @@ const SETTING_EFFORT = {
   kimi: "comfyui-mcp.defaultEffort.kimi",
   moonshot: "comfyui-mcp.defaultEffort.moonshot",
   glm: "comfyui-mcp.defaultEffort.glm",
+  minimax: "comfyui-mcp.defaultEffort.minimax",
   ollama: "comfyui-mcp.defaultEffort.ollama",
   openrouter: "comfyui-mcp.defaultEffort.openrouter",
   lmstudio: "comfyui-mcp.defaultEffort.lmstudio",
@@ -1560,6 +1563,7 @@ const SETTING_BRIDGE_URL = {
   kimi: "comfyui-mcp.bridgeUrl.kimi",
   moonshot: "comfyui-mcp.bridgeUrl.moonshot",
   glm: "comfyui-mcp.bridgeUrl.glm",
+  minimax: "comfyui-mcp.bridgeUrl.minimax",
   ollama: "comfyui-mcp.bridgeUrl.ollama",
   openrouter: "comfyui-mcp.bridgeUrl.openrouter",
   lmstudio: "comfyui-mcp.bridgeUrl.lmstudio",
@@ -1629,10 +1633,10 @@ const SETTINGS_SEEDED_KEY = "comfyui-mcp.panel.settingsSeeded";
 // per-backend groups (runs independently of SETTINGS_SEEDED_KEY).
 const SETTINGS_GROUPS_MIGRATED_KEY = "comfyui-mcp.panel.settingsGroupsMigrated";
 // Section (sub-category) labels for the grouped Settings dialog, per backend.
-const BACKEND_SECTION = { claude: "Claude", codex: "ChatGPT (Codex)", gemini: "Gemini", antigravity: "Antigravity (Google)", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", ollama: "Ollama (local)", openrouter: "OpenRouter", lmstudio: "LM Studio (local)", llamacpp: "llama.cpp (local)", custom: "Custom endpoint" };
+const BACKEND_SECTION = { claude: "Claude", codex: "ChatGPT (Codex)", gemini: "Gemini", antigravity: "Antigravity (Google)", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama (local)", openrouter: "OpenRouter", lmstudio: "LM Studio (local)", llamacpp: "llama.cpp (local)", custom: "Custom endpoint" };
 // Backend display names at module scope (the Settings dialog's render-fns live
 // outside buildPanel's closure, so they need their own copy).
-const BACKEND_TEXT = { claude: "Claude", codex: "ChatGPT", gemini: "Gemini", antigravity: "Antigravity", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint" };
+const BACKEND_TEXT = { claude: "Claude", codex: "ChatGPT", gemini: "Gemini", antigravity: "Antigravity", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint" };
 // The allowlisted secure-store keys (mirrors the orchestrator's #59 allowlist).
 const SECRET_SET_AT_PREFIX = "comfyui-mcp.panel.secretSetAt.";
 
@@ -1683,7 +1687,7 @@ const settingsBackendState = {
 // render-fns when the dialog opens, so a freshly-arrived catalog can repaint the
 // matching backend's dropdown in place (a render-fn setting has no static options
 // to re-key). Keyed by backend; null when that group isn't mounted.
-const settingsModelSelectEls = { claude: null, codex: null, gemini: null, antigravity: null, grok: null, kimi: null, moonshot: null, glm: null, ollama: null, openrouter: null, lmstudio: null, llamacpp: null, custom: null };
+const settingsModelSelectEls = { claude: null, codex: null, gemini: null, antigravity: null, grok: null, kimi: null, moonshot: null, glm: null, minimax: null, ollama: null, openrouter: null, lmstudio: null, llamacpp: null, custom: null };
 // Disabled placeholder <option> value — mapped to "" (Auto) if ever selected so
 // it can never persist as a bogus model id.
 const SETTINGS_PLACEHOLDER = "__cmcp_placeholder__";
@@ -1695,7 +1699,7 @@ function currentSettingsBackend() {
   const b = getSetting(SETTING_BACKEND);
   // Every selectable backend counts — this list lagging a provider addition
   // silently stops that provider's Settings edits from driving the live panel.
-  return ["codex", "gemini", "antigravity", "grok", "kimi", "moonshot", "glm", "ollama", "openrouter", "lmstudio", "llamacpp", "custom"].includes(b) ? b : "claude";
+  return ["codex", "gemini", "antigravity", "grok", "kimi", "moonshot", "glm", "minimax", "ollama", "openrouter", "lmstudio", "llamacpp", "custom"].includes(b) ? b : "claude";
 }
 /** Fetched model rows for `backend` (the same presentable catalog the composer
  *  picker uses), or null when none is cached (backend never connected this session). */
@@ -2172,6 +2176,7 @@ function panelSettingsList() {
         { value: "kimi", text: "Kimi" },
         { value: "moonshot", text: "Kimi K3" },
         { value: "glm", text: "GLM (z.ai)" },
+        { value: "minimax", text: "MiniMax" },
         { value: "ollama", text: "Ollama (local)" },
         { value: "openrouter", text: "OpenRouter (1M · SOTA)" },
         { value: "lmstudio", text: "LM Studio (local)" },
@@ -2430,6 +2435,9 @@ function panelSettingsList() {
     // ---- GLM (z.ai coding plan, hosted API key) (Default model; no effort scale) ----
     modelSetting("glm", 71),
     effortSetting("glm", 71),
+    // ---- MiniMax (MiniMax platform, hosted API key) (Default model; no effort scale) ----
+    modelSetting("minimax", 71),
+    effortSetting("minimax", 71),
     // ---- Ollama (local) (Default model; no effort scale) ----
     modelSetting("ollama", 70),
     {
@@ -2569,6 +2577,8 @@ const BACKEND_EFFORTS = {
   moonshot: [],
   // GLM (z.ai coding plan) is a hosted OpenAI-compatible API — no reasoning-effort scale.
   glm: [],
+  // MiniMax is a hosted OpenAI-compatible API — no reasoning-effort scale.
+  minimax: [],
   // Ollama local models expose no reasoning-effort control — selector hidden.
   ollama: [],
   // OpenRouter rides the same backend as ollama — no effort control either.
@@ -9229,13 +9239,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
   // `codex app-server` cold-starts much slower than Claude's Agent SDK, so it gets
   // ~3x the window. This is the escalation THRESHOLD only — the respawn/reclaim
   // BOUNDS (MAX_AUTO_RESPAWNS / MAX_AUTO_RECLAIMS) are untouched.
-  const RESPAWN_AFTER_BY_BACKEND = { codex: 6, gemini: 6, antigravity: 6, grok: 6, kimi: 6, moonshot: 6, glm: 6, ollama: 6, claude: 2 };
+  const RESPAWN_AFTER_BY_BACKEND = { codex: 6, gemini: 6, antigravity: 6, grok: 6, kimi: 6, moonshot: 6, glm: 6, minimax: 6, ollama: 6, claude: 2 };
   function respawnAfterAttempts() {
     return RESPAWN_AFTER_BY_BACKEND[backendNow()] ?? 2;
   }
   // Failed (re)connect attempts ridden out as a steady "connecting" before a
   // terminal "disconnected". Backend-aware, ~3x for Codex's slower cold start.
-  const CONNECT_PATIENCE_BY_BACKEND = { codex: 12, gemini: 12, antigravity: 12, grok: 12, kimi: 12, moonshot: 12, glm: 12, ollama: 12, claude: 4 };
+  const CONNECT_PATIENCE_BY_BACKEND = { codex: 12, gemini: 12, antigravity: 12, grok: 12, kimi: 12, moonshot: 12, glm: 12, minimax: 12, ollama: 12, claude: 4 };
   function connectPatienceAttempts() {
     return CONNECT_PATIENCE_BY_BACKEND[backendNow()] ?? 4;
   }
@@ -9250,7 +9260,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
   // so it gets a wider window before we treat the open socket as wedged (FIX 2).
   // Ollama gets the long handshake too: a cold model load into VRAM can take
   // tens of seconds before the first token.
-  const HANDSHAKE_MS_BY_BACKEND = { codex: 45000, gemini: 45000, antigravity: 45000, grok: 45000, kimi: 45000, moonshot: 45000, glm: 45000, ollama: 45000, claude: 20000 };
+  const HANDSHAKE_MS_BY_BACKEND = { codex: 45000, gemini: 45000, antigravity: 45000, grok: 45000, kimi: 45000, moonshot: 45000, glm: 45000, minimax: 45000, ollama: 45000, claude: 20000 };
   function handshakeMs() {
     return HANDSHAKE_MS_BY_BACKEND[backendNow()] ?? 20000;
   }
@@ -11418,7 +11428,7 @@ function buildPanel() {
   // ChatGPT). Clicking one asks the pack to ensure that backend's orchestrator is
   // running and returns the bridge URL to connect to — the user never types a
   // port. Populated from GET /comfyui_mcp_panel/backends when settings open.
-  const BACKEND_LABELS = { claude: "Claude", codex: "ChatGPT", gemini: "Gemini", antigravity: "Antigravity", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint", copilot: "GitHub Copilot" };
+  const BACKEND_LABELS = { claude: "Claude", codex: "ChatGPT", gemini: "Gemini", antigravity: "Antigravity", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint", copilot: "GitHub Copilot" };
   // Appends a visible "(experimental)" marker to a backend's display label when
   // the readiness data flags it (b.experimental, e.g. Copilot — device-code,
   // GitHub ToS risk). Keeps picking it a deliberate, informed act everywhere a
@@ -11462,7 +11472,7 @@ function buildPanel() {
   // (GET /backends, blind to the laptop behind a remote pod) must not override it.
   let readinessFromOrchestrator = false;
   // Short per-provider hint shown under each provider row in the popup.
-  const BACKEND_HINTS = { claude: "Fable · Opus · Sonnet · Haiku", codex: "GPT-5 (Codex)", gemini: "Gemini 2.5 Pro · Flash", antigravity: "Gemini 3 · Google subscription", grok: "Grok Composer · Build", kimi: "Kimi (Moonshot)", moonshot: "Kimi K3 · Moonshot", glm: "GLM · z.ai coding plan", ollama: "Local LLMs", openrouter: "MiMo · MiniMax (1M · SOTA)", lmstudio: "Local LLMs · no account", llamacpp: "Local LLMs · no account", custom: "DeepSeek · vLLM · any OpenAI-compatible API" };
+  const BACKEND_HINTS = { claude: "Fable · Opus · Sonnet · Haiku", codex: "GPT-5 (Codex)", gemini: "Gemini 2.5 Pro · Flash", antigravity: "Gemini 3 · Google subscription", grok: "Grok Composer · Build", kimi: "Kimi (Moonshot)", moonshot: "Kimi K3 · Moonshot", glm: "GLM · z.ai coding plan", minimax: "MiniMax M3 · 1M context", ollama: "Local LLMs", openrouter: "MiMo · MiniMax (1M · SOTA)", lmstudio: "Local LLMs · no account", llamacpp: "Local LLMs · no account", custom: "DeepSeek · vLLM · any OpenAI-compatible API" };
 
   // Hint for a provider that exists but isn't usable yet — distinguishes
   // "install the CLI" from "sign in". Empty when ready or readiness is unknown.
@@ -11497,6 +11507,7 @@ function buildPanel() {
     if (b.backend === "openrouter") return "No OpenRouter API key — add it via API Keys (▾ menu by “connected”); takes effect immediately";
     if (b.backend === "moonshot") return "No Moonshot API key — add MOONSHOT_API_KEY via API Keys (▾ menu by “connected”); takes effect immediately";
     if (b.backend === "glm") return "No z.ai API key — add ZAI_API_KEY via API Keys (▾ menu by “connected”); takes effect immediately";
+    if (b.backend === "minimax") return "No MiniMax API key — add MINIMAX_API_KEY via API Keys (▾ menu by “connected”); takes effect immediately";
     if (b.backend === "custom") return "No endpoint URL — Settings › Custom endpoint (works with DeepSeek, vLLM, any OpenAI-compatible API)";
     return "Not signed in — run: claude auth login";
   }
@@ -11751,6 +11762,7 @@ function buildPanel() {
     moonshot: { label: "Kimi K3 (Moonshot, hosted)", install: "", login: "Set MOONSHOT_API_KEY via API Keys (▾ menu by “connected”)" },
     // No CLI — "setup" is pasting a z.ai coding-plan API key (GLM).
     glm: { label: "GLM (z.ai coding plan, hosted)", install: "", login: "Set ZAI_API_KEY via API Keys (▾ menu by “connected”)" },
+    minimax: { label: "MiniMax (hosted)", install: "", login: "Set MINIMAX_API_KEY via API Keys (▾ menu by “connected”)" },
     // No sign-in — "login" is pulling OUR FINE-TUNE: gemma4 QLoRA-trained on
     // 1,055 server-verified comfyui-mcp trajectories (hf.co/artokun/
     // gemma4-comfyui-mcp) — it knows this tool suite natively. :e2b fits
@@ -11794,7 +11806,7 @@ function buildPanel() {
     sub.textContent =
       "The agent runs on YOUR machine on your own AI subscription (Claude, ChatGPT, Gemini, …) or a local model (Ollama, LM Studio, llama.cpp) — no API keys. Set up a provider (Node ≥ 22), start the agent with the command below, then click Connect.";
     onboard.append(title, sub);
-    for (const id of ["claude", "codex", "gemini", "antigravity", "grok", "kimi", "moonshot", "glm", "ollama", "openrouter", "lmstudio", "llamacpp", "custom"]) {
+    for (const id of ["claude", "codex", "gemini", "antigravity", "grok", "kimi", "moonshot", "glm", "minimax", "ollama", "openrouter", "lmstudio", "llamacpp", "custom"]) {
       const meta = PROVIDER_SETUP[id];
       const st = list.find((b) => b.backend === id) || {};
       const col = document.createElement("div");
@@ -11947,6 +11959,20 @@ function buildPanel() {
           `  • Or set the ZAI_API_KEY environment variable and (re)start the orchestrator.
 ` +
           `Then pick GLM (z.ai) here again and Connect.`,
+      );
+      return;
+    }
+    // MiniMax is a hosted API — no CLI, no login flow. Same shape as
+    // GLM/Moonshot/OpenRouter: show the key-setup path inline and stop; no agent chat.
+    if (id === "minimax") {
+      appendSystem(
+        `MiniMax is a hosted API — no CLI, no login flow. Enable it by setting your MiniMax API key (create one at https://platform.minimax.io/console/api-keys):
+` +
+          `  • API Keys (▾ menu next to “connected”) → set MINIMAX_API_KEY — masked input, stored by the orchestrator in ~/.comfyui-mcp (0600), never in ComfyUI settings. Applies immediately.
+` +
+          `  • Or set the MINIMAX_API_KEY environment variable and (re)start the orchestrator.
+` +
+          `Then pick MiniMax here again and Connect.`,
       );
       return;
     }
@@ -17143,7 +17169,7 @@ function buildPanel() {
   // backend's handshake window (handshakeMs()) so a healthy slow reload completes
   // on its own backoff before the guard releases — Codex's app-server handshake is
   // 45s, so its guard is ~50s; Claude keeps 28s (still > its 20s handshake).
-  const SOFT_RELOAD_GUARD_MS_BY_BACKEND = { codex: 50000, gemini: 50000, antigravity: 50000, grok: 50000, kimi: 50000, moonshot: 50000, glm: 50000, ollama: 50000, claude: 28000 };
+  const SOFT_RELOAD_GUARD_MS_BY_BACKEND = { codex: 50000, gemini: 50000, antigravity: 50000, grok: 50000, kimi: 50000, moonshot: 50000, glm: 50000, minimax: 50000, ollama: 50000, claude: 28000 };
   function softReloadGuardMs() {
     return SOFT_RELOAD_GUARD_MS_BY_BACKEND[selectedBackend] ?? 28000;
   }
@@ -17160,7 +17186,7 @@ function buildPanel() {
   // normal cold-start handshake (handshakeMs()) so a healthy-but-slow reload is
   // never pre-empted — Codex (45s handshake) escalates at ~40s, comfortably under
   // its ~50s guard; Claude keeps 11s (under its 28s guard and > its 20s handshake).
-  const SOFT_RELOAD_ESCALATE_MS_BY_BACKEND = { codex: 40000, gemini: 40000, antigravity: 40000, grok: 40000, kimi: 40000, moonshot: 40000, glm: 40000, ollama: 40000, claude: 11000 };
+  const SOFT_RELOAD_ESCALATE_MS_BY_BACKEND = { codex: 40000, gemini: 40000, antigravity: 40000, grok: 40000, kimi: 40000, moonshot: 40000, glm: 40000, minimax: 40000, ollama: 40000, claude: 11000 };
   function softReloadEscalateMs() {
     return SOFT_RELOAD_ESCALATE_MS_BY_BACKEND[selectedBackend] ?? 11000;
   }


### PR DESCRIPTION
## MiniMax provider chip — panel wiring

Companion to **comfyui-mcp #640** (orchestrator registry, `Closes #355`). The orchestrator PR alone renders nothing in the panel — MiniMax has to be wired across every provider site here to be selectable and to drive the live panel. Mirrors the existing **moonshot**/**glm** hosted-API-key providers at each site.

### The 3 silent-failure criticals (all covered)
- **`__init__.py` `_BACKEND_PORTS`** — `"minimax": _BRIDGE_PORT` (single-port multi-provider). Gates `/connect` and the `/backends` discovery list; missing = "unknown backend".
- **`currentSettingsBackend()` allowlist** — add `"minimax"`; missing = Settings edits silently never drive the live panel.
- **~22 `web/js/comfyui-mcp-panel.js` provider-map sites** — every map/array/branch that lists moonshot+glm now lists minimax.

### comfyui-mcp-panel.js sites (mirror moonshot/glm)
`DEFAULT_BRIDGE_URL`, `SETTING_MODEL`, `SETTING_EFFORT`, `SETTING_BRIDGE_URL`, `BACKEND_SECTION`, `BACKEND_TEXT`, `settingsModelSelectEls`, `currentSettingsBackend`, the Default-backend dropdown option, `modelSetting`/`effortSetting` group, `BACKEND_EFFORTS` (`[]` — no effort scale), `RESPAWN_AFTER_BY_BACKEND`, `CONNECT_PATIENCE_BY_BACKEND`, `HANDSHAKE_MS_BY_BACKEND`, `SOFT_RELOAD_GUARD_MS_BY_BACKEND`, `SOFT_RELOAD_ESCALATE_MS_BY_BACKEND`, `BACKEND_LABELS` (`"MiniMax"`), `BACKEND_HINTS` (`"MiniMax M3 · 1M context"`), the no-key onboarding hint, `PROVIDER_SETUP`, the onboarding id loop, and the hosted-API inline key-setup branch (`MINIMAX_API_KEY`, platform.minimax.io).

The credential-slot editor and Python readiness card are server-driven / generic (slots derive from the orchestrator registry; `_provider_auth` returns False for all hosted-key providers, authoritative readiness comes from the orchestrator `backends` frame) — no extra edits needed, matching moonshot/glm.

### Test
- **`browser_tests/minimax-provider.spec.ts`** — Tier-1 provider-chip spec mirroring `moonshot-provider.spec.ts`: a ready `minimax` backend renders a "MiniMax" chip with the "MiniMax M3 · 1M context" hint via the authoritative backends frame.
- `node --check` on the panel JS (loads as an ES module) — clean.

Note: the Playwright e2e wasn't executed in this environment (fresh worktree, no deps; needs the rig + Chrome). The spec is a faithful structural mirror of the passing moonshot spec.

Coordinated with the parallel **pi.dev** provider PR — both touch the same provider-list lines; changes kept localized to adjacent-line insertions, a trial-merge is expected.

Draft — do not merge (lands together with comfyui-mcp #640).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
