### PR TITLE
feat(pi): add pi.dev provider chip across the panel (#491)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -260,15 +260,10 @@ def _provider_auth(provider):
         # without the CLI there is nothing to be signed in to.
         return None if _antigravity_installed() else False
     if provider == "pi":
-        # pi keeps provider credentials in ~/.pi/agent/auth.json (API keys +
-        # `/login` subscriptions) or provider env vars. A present auth.json is a
-        # definite login; otherwise report unknown when the CLI is installed (pi
-        # may be configured via env we can't cheaply see — the orchestrator's
-        # readiness/connect verifies), and not-signed-in when it isn't.
-        if not _pi_installed():
-            return False
-        auth_json = os.path.join(home, ".pi", "agent", "auth.json")
-        return True if os.path.isfile(auth_json) else None
+        # Do not infer a credential from auth.json: it can be empty, malformed,
+        # stale, or name a provider that cannot run. The MCP's pi probe is the
+        # sole positive readiness authority; this local check is only advisory.
+        return None if _pi_installed() else False
     if provider == "ollama":
         # No login concept — a local daemon. Installed = usable; a stopped daemon
         # surfaces at connect time (the orchestrator's model probe).
@@ -281,7 +276,8 @@ def _provider_state(provider):
     PATH AND a login exists; `cli`/`auth` are reported separately so the panel
     can tell 'install the CLI' apart from 'sign in'; `auth` is null when unknown
     (macOS Keychain). Unknown-with-cli normally counts as ready, except pi: its
-    multi-provider credential sources need the orchestrator's authoritative probe."""
+    multi-provider credential sources are ready only after the orchestrator's
+    authoritative probe."""
     if provider == "ollama":
         cli = _ollama_installed()
     elif provider == "antigravity":
@@ -291,12 +287,9 @@ def _provider_state(provider):
     else:
         cli = _provider_cli(provider)
     auth = _provider_auth(provider)
-    # Unlike Keychain-backed subscriptions, pi's local `auth is None` means no
-    # credential source was positively observed. Do not preempt the MCP's stricter
-    # auth.json/models.json/env validation with a green panel state; a later bridge
-    # readiness frame remains authoritative. A present local auth record can still
-    # provide an optimistic ready state until that frame arrives.
-    ready = bool(cli and (auth is True if provider == "pi" else auth is not False))
+    # Pi's local state intentionally has no positive-ready path. Its bridge frame
+    # applies the MCP's provider-aware credential verdict after connection.
+    ready = False if provider == "pi" else bool(cli and auth is not False)
     return {"cli": cli, "auth": auth, "ready": ready}
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -98,8 +98,8 @@ def _backend_port(backend):
     return _BACKEND_PORTS.get((backend or _DEFAULT_BACKEND).lower(), _BRIDGE_PORT)
 
 
-# Provider-CLI binary names per backend (Windows resolves .cmd/.exe via PATHEXT,
-# but probe the variants too).
+# Provider-CLI binary names per backend. Most Windows CLIs can use a .cmd shim;
+# pi is the exception because the MCP starts it with shell-less spawn.
 _PROVIDER_CLIS = {
     "claude": ("claude", "claude.cmd", "claude.exe"),
     "codex": ("codex", "codex.cmd", "codex.exe"),
@@ -148,15 +148,30 @@ def _pi_installed():
     override mirrors the orchestrator's resolvePiBin so an env-var-only install
     doesn't read "not installed" in onboarding until the orchestrator's readiness
     frame corrects it)."""
+    def spawnable(path):
+        # Python's shutil.which("pi") can resolve pi.cmd through PATHEXT, but
+        # Node's shell-less spawn cannot execute batch shims. Keep the panel's
+        # optimistic discovery aligned with the MCP resolver: only a real binary
+        # (extensionless pi or pi.exe) can advertise this backend as installed.
+        return bool(path) and not str(path).strip().lower().endswith((".cmd", ".bat"))
+
     override = (environ.get("COMFYUI_MCP_PI_PATH") or "").strip()
-    if override and os.path.isfile(override):
+    if spawnable(override) and os.path.isfile(override):
         return True
-    if _provider_cli("pi"):
-        return True
+    for name in _PROVIDER_CLIS["pi"]:
+        if spawnable(shutil.which(name)):
+            return True
+    for directory in _gui_fallback_bin_dirs():
+        for name in _PROVIDER_CLIS["pi"]:
+            candidate = os.path.join(directory, name)
+            if spawnable(candidate) and os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                return True
     if sys.platform == "win32":
         local = environ.get("LOCALAPPDATA") or os.path.join(os.path.expanduser("~"), "AppData", "Local")
-        return os.path.isfile(os.path.join(local, "pi", "bin", "pi.exe"))
-    return os.path.isfile(os.path.join(os.path.expanduser("~"), ".local", "bin", "pi"))
+        candidate = os.path.join(local, "pi", "bin", "pi.exe")
+    else:
+        candidate = os.path.join(os.path.expanduser("~"), ".local", "bin", "pi")
+    return spawnable(candidate) and os.path.isfile(candidate)
 
 
 def _gui_fallback_bin_dirs():

--- a/__init__.py
+++ b/__init__.py
@@ -105,7 +105,9 @@ _PROVIDER_CLIS = {
     "codex": ("codex", "codex.cmd", "codex.exe"),
     "gemini": ("gemini", "gemini.cmd", "gemini.exe"),
     "antigravity": ("agy", "agy.exe"),
-    "pi": ("pi", "pi.cmd", "pi.exe"),
+    # The MCP spawns pi without a shell, so a Windows .cmd shim is not runnable.
+    # Keep this probe aligned with its executable-only resolver (#491).
+    "pi": ("pi", "pi.exe"),
     "grok": ("grok", "grok.cmd", "grok.exe"),
     "kimi": ("kimi", "kimi.cmd", "kimi.exe"),
     "ollama": ("ollama", "ollama.exe"),

--- a/__init__.py
+++ b/__init__.py
@@ -70,6 +70,7 @@ _BACKEND_PORTS = {
     "codex": 9181,
     "gemini": 9182,
     "antigravity": _BRIDGE_PORT,  # Google Antigravity (agy) — single-port multi-provider
+    "pi": _BRIDGE_PORT,  # pi.dev (pi) — single-port multi-provider, same orchestrator (#491)
     "grok": _BRIDGE_PORT,  # single-port multi-provider — same orchestrator
     "kimi": _BRIDGE_PORT,  # single-port multi-provider — same orchestrator
     "moonshot": _BRIDGE_PORT,  # hosted (Moonshot / Kimi K3) — same orchestrator, key-gated
@@ -104,6 +105,7 @@ _PROVIDER_CLIS = {
     "codex": ("codex", "codex.cmd", "codex.exe"),
     "gemini": ("gemini", "gemini.cmd", "gemini.exe"),
     "antigravity": ("agy", "agy.exe"),
+    "pi": ("pi", "pi.cmd", "pi.exe"),
     "grok": ("grok", "grok.cmd", "grok.exe"),
     "kimi": ("kimi", "kimi.cmd", "kimi.exe"),
     "ollama": ("ollama", "ollama.exe"),
@@ -136,6 +138,23 @@ def _antigravity_installed():
         local = environ.get("LOCALAPPDATA") or os.path.join(os.path.expanduser("~"), "AppData", "Local")
         return os.path.isfile(os.path.join(local, "agy", "bin", "agy.exe"))
     return os.path.isfile(os.path.join(os.path.expanduser("~"), ".local", "bin", "agy"))
+
+
+def _pi_installed():
+    """pi.dev CLI (pi) at COMFYUI_MCP_PI_PATH, on PATH, or in its well-known
+    install locations (the official installer targets ~/.local/bin; the env
+    override mirrors the orchestrator's resolvePiBin so an env-var-only install
+    doesn't read "not installed" in onboarding until the orchestrator's readiness
+    frame corrects it)."""
+    override = (environ.get("COMFYUI_MCP_PI_PATH") or "").strip()
+    if override and os.path.isfile(override):
+        return True
+    if _provider_cli("pi"):
+        return True
+    if sys.platform == "win32":
+        local = environ.get("LOCALAPPDATA") or os.path.join(os.path.expanduser("~"), "AppData", "Local")
+        return os.path.isfile(os.path.join(local, "pi", "bin", "pi.exe"))
+    return os.path.isfile(os.path.join(os.path.expanduser("~"), ".local", "bin", "pi"))
 
 
 def _gui_fallback_bin_dirs():
@@ -223,6 +242,16 @@ def _provider_auth(provider):
         # installed (the orchestrator's model probe verifies auth at connect);
         # without the CLI there is nothing to be signed in to.
         return None if _antigravity_installed() else False
+    if provider == "pi":
+        # pi keeps provider credentials in ~/.pi/agent/auth.json (API keys +
+        # `/login` subscriptions) or provider env vars. A present auth.json is a
+        # definite login; otherwise report unknown when the CLI is installed (pi
+        # may be configured via env we can't cheaply see — the orchestrator's
+        # readiness/connect verifies), and not-signed-in when it isn't.
+        if not _pi_installed():
+            return False
+        auth_json = os.path.join(home, ".pi", "agent", "auth.json")
+        return True if os.path.isfile(auth_json) else None
     if provider == "ollama":
         # No login concept — a local daemon. Installed = usable; a stopped daemon
         # surfaces at connect time (the orchestrator's model probe).
@@ -239,6 +268,8 @@ def _provider_state(provider):
         cli = _ollama_installed()
     elif provider == "antigravity":
         cli = _antigravity_installed()
+    elif provider == "pi":
+        cli = _pi_installed()
     else:
         cli = _provider_cli(provider)
     auth = _provider_auth(provider)

--- a/__init__.py
+++ b/__init__.py
@@ -280,7 +280,8 @@ def _provider_state(provider):
     """Per-provider readiness for the panel onboarding flow. `ready` = CLI on
     PATH AND a login exists; `cli`/`auth` are reported separately so the panel
     can tell 'install the CLI' apart from 'sign in'; `auth` is null when unknown
-    (macOS Keychain), and unknown-with-cli still counts as ready."""
+    (macOS Keychain). Unknown-with-cli normally counts as ready, except pi: its
+    multi-provider credential sources need the orchestrator's authoritative probe."""
     if provider == "ollama":
         cli = _ollama_installed()
     elif provider == "antigravity":
@@ -290,7 +291,12 @@ def _provider_state(provider):
     else:
         cli = _provider_cli(provider)
     auth = _provider_auth(provider)
-    ready = bool(cli and auth is not False)
+    # Unlike Keychain-backed subscriptions, pi's local `auth is None` means no
+    # credential source was positively observed. Do not preempt the MCP's stricter
+    # auth.json/models.json/env validation with a green panel state; a later bridge
+    # readiness frame remains authoritative. A present local auth record can still
+    # provide an optimistic ready state until that frame arrives.
+    ready = bool(cli and (auth is True if provider == "pi" else auth is not False))
     return {"cli": cli, "auth": auth, "ready": ready}
 
 

--- a/browser_tests/unit/pi-readiness-ordering.test.mjs
+++ b/browser_tests/unit/pi-readiness-ordering.test.mjs
@@ -1,0 +1,43 @@
+// #505: a generic bridge ready ack can be dispatched before the MCP's `backends`
+// readiness frame. Pi must not become ready from that ack alone.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { readyAckCanPromoteBackend } from "../../web/js/lib/pi-readiness.js";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+
+test("#505 Pi ready ack before backends stays unready; authoritative frame unlocks promotion", () => {
+  let piBackendsReadinessReceived = false;
+  assert.equal(readyAckCanPromoteBackend("pi", piBackendsReadinessReceived), false);
+
+  // The subsequent MCP `backends` frame is the readiness authority.
+  piBackendsReadinessReceived = true;
+  assert.equal(readyAckCanPromoteBackend("pi", piBackendsReadinessReceived), true);
+  assert.equal(readyAckCanPromoteBackend("codex", false), true, "other backends retain ready-ack behavior");
+});
+
+test("#505 panel wiring records the backends frame before allowing Pi ack promotion", () => {
+  const source = readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
+  const backendsStart = source.indexOf("    onBackends(data) {");
+  const ackStart = source.indexOf("    onAck(ack) {");
+  assert.ok(backendsStart >= 0 && ackStart > backendsStart, "could not locate bridge callbacks");
+  const backends = source.slice(backendsStart, ackStart);
+  const ack = source.slice(ackStart, source.indexOf("    getResume:", ackStart));
+  const statusStart = source.indexOf("    onStatus(state) {");
+  const status = source.slice(statusStart, source.indexOf("    onSay(", statusStart));
+
+  assert.match(backends, /piBackendsReadinessReceived = true/, "backends frame must unlock Pi ack promotion");
+  assert.match(
+    ack,
+    /readyAckCanPromoteBackend\(b, piBackendsReadinessReceived\)/,
+    "generic ready ack must use the Pi ordering guard",
+  );
+  assert.match(
+    status,
+    /if \(!connected\) \{\n\s*piBackendsReadinessReceived = false/,
+    "a reconnect must require a fresh authoritative backends frame",
+  );
+});

--- a/browser_tests/unit/test_provider_cli.py
+++ b/browser_tests/unit/test_provider_cli.py
@@ -127,28 +127,28 @@ class ProviderCliGuiPath(unittest.TestCase):
             else:
                 mod.environ["COMFYUI_MCP_PI_PATH"] = old_override
 
-    def test_pi_requires_positive_auth_before_reporting_ready(self):
-        # #491: a found pi binary with no locally observed credential must stay
-        # unready until the MCP's authoritative provider probe arrives. This is a
-        # state-policy test, not a duplicate parser for pi's auth/models files.
+    def test_pi_auth_json_presence_never_sets_local_ready(self):
+        # #491: auth.json may be empty, malformed, or stale. The panel does not
+        # parse it or treat its mere presence as a credential; the MCP is the only
+        # positive readiness authority after the bridge connects.
         old_pi_installed = mod._pi_installed
-        old_provider_auth = mod._provider_auth
+        old_expanduser = mod.os.path.expanduser
         mod._pi_installed = lambda: True
         try:
-            mod._provider_auth = lambda provider: None
-            self.assertEqual(
-                mod._provider_state("pi"),
-                {"cli": True, "auth": None, "ready": False},
-            )
-            # Preserve the positive path for an observed local auth record.
-            mod._provider_auth = lambda provider: True
-            self.assertEqual(
-                mod._provider_state("pi"),
-                {"cli": True, "auth": True, "ready": True},
-            )
+            with tempfile.TemporaryDirectory(prefix="cmcp-pi-home-") as home:
+                mod.os.path.expanduser = lambda p: home if p == "~" else old_expanduser(p)
+                auth_json = os.path.join(home, ".pi", "agent", "auth.json")
+                os.makedirs(os.path.dirname(auth_json), exist_ok=True)
+                for contents in ("", "{ malformed"):
+                    with open(auth_json, "w", encoding="utf-8") as fh:
+                        fh.write(contents)
+                    self.assertEqual(
+                        mod._provider_state("pi"),
+                        {"cli": True, "auth": None, "ready": False},
+                    )
         finally:
             mod._pi_installed = old_pi_installed
-            mod._provider_auth = old_provider_auth
+            mod.os.path.expanduser = old_expanduser
 
     def test_provider_state_ready_when_cli_in_fallback_and_auth_present(self):
         # End-to-end: cli found via fallback + ~/.codex/auth.json present => ready.

--- a/browser_tests/unit/test_provider_cli.py
+++ b/browser_tests/unit/test_provider_cli.py
@@ -85,10 +85,47 @@ class ProviderCliGuiPath(unittest.TestCase):
         self.assertTrue(mod._provider_cli("codex"))
 
     def test_pi_cmd_shim_is_not_reported_as_runnable(self):
-        # #491: the MCP uses shell-less spawn for pi, so `pi.cmd` cannot run.
-        # The panel must not show pi as installed from that Windows shim alone.
-        mod.shutil.which = lambda name: "C:/bin/pi.cmd" if name == "pi.cmd" else None
-        self.assertFalse(mod._provider_cli("pi"))
+        # #491: `which("pi")` may resolve pi.cmd through PATHEXT, but the MCP
+        # uses shell-less spawn and cannot execute that shim. A real pi.exe remains
+        # valid, proving this isn't merely a false-negative test.
+        old_override = mod.environ.get("COMFYUI_MCP_PI_PATH")
+        old_isfile = mod.os.path.isfile
+        mod._gui_fallback_bin_dirs = lambda: ()
+        mod.os.path.isfile = lambda path: False
+        mod.environ.pop("COMFYUI_MCP_PI_PATH", None)
+        try:
+            mod.shutil.which = lambda name: "C:/bin/pi.cmd" if name == "pi" else None
+            self.assertFalse(mod._pi_installed())
+            mod.shutil.which = lambda name: "C:/bin/pi.exe" if name == "pi" else None
+            self.assertTrue(mod._pi_installed())
+        finally:
+            mod.os.path.isfile = old_isfile
+            if old_override is None:
+                mod.environ.pop("COMFYUI_MCP_PI_PATH", None)
+            else:
+                mod.environ["COMFYUI_MCP_PI_PATH"] = old_override
+
+    def test_pi_cmd_override_is_not_reported_as_runnable(self):
+        # The explicit override is passed straight to shell-less spawn too, so it
+        # needs the same .cmd rejection as PATH/PATHEXT discovery.
+        old_override = mod.environ.get("COMFYUI_MCP_PI_PATH")
+        old_isfile = mod.os.path.isfile
+        mod._gui_fallback_bin_dirs = lambda: ()
+        mod.shutil.which = lambda name: None
+        mod.os.path.isfile = lambda path: path in {"C:/bin/pi.cmd", "C:/bin/pi.exe"}
+        try:
+            mod.environ["COMFYUI_MCP_PI_PATH"] = "C:/bin/pi.cmd"
+            self.assertFalse(mod._pi_installed())
+            mod.environ["COMFYUI_MCP_PI_PATH"] = "C:/bin/pi.bat"
+            self.assertFalse(mod._pi_installed())
+            mod.environ["COMFYUI_MCP_PI_PATH"] = "C:/bin/pi.exe"
+            self.assertTrue(mod._pi_installed())
+        finally:
+            mod.os.path.isfile = old_isfile
+            if old_override is None:
+                mod.environ.pop("COMFYUI_MCP_PI_PATH", None)
+            else:
+                mod.environ["COMFYUI_MCP_PI_PATH"] = old_override
 
     def test_provider_state_ready_when_cli_in_fallback_and_auth_present(self):
         # End-to-end: cli found via fallback + ~/.codex/auth.json present => ready.

--- a/browser_tests/unit/test_provider_cli.py
+++ b/browser_tests/unit/test_provider_cli.py
@@ -84,6 +84,12 @@ class ProviderCliGuiPath(unittest.TestCase):
         mod.shutil.which = lambda name: "/somewhere/on/path/" + name
         self.assertTrue(mod._provider_cli("codex"))
 
+    def test_pi_cmd_shim_is_not_reported_as_runnable(self):
+        # #491: the MCP uses shell-less spawn for pi, so `pi.cmd` cannot run.
+        # The panel must not show pi as installed from that Windows shim alone.
+        mod.shutil.which = lambda name: "C:/bin/pi.cmd" if name == "pi.cmd" else None
+        self.assertFalse(mod._provider_cli("pi"))
+
     def test_provider_state_ready_when_cli_in_fallback_and_auth_present(self):
         # End-to-end: cli found via fallback + ~/.codex/auth.json present => ready.
         self._install("codex")

--- a/browser_tests/unit/test_provider_cli.py
+++ b/browser_tests/unit/test_provider_cli.py
@@ -127,6 +127,29 @@ class ProviderCliGuiPath(unittest.TestCase):
             else:
                 mod.environ["COMFYUI_MCP_PI_PATH"] = old_override
 
+    def test_pi_requires_positive_auth_before_reporting_ready(self):
+        # #491: a found pi binary with no locally observed credential must stay
+        # unready until the MCP's authoritative provider probe arrives. This is a
+        # state-policy test, not a duplicate parser for pi's auth/models files.
+        old_pi_installed = mod._pi_installed
+        old_provider_auth = mod._provider_auth
+        mod._pi_installed = lambda: True
+        try:
+            mod._provider_auth = lambda provider: None
+            self.assertEqual(
+                mod._provider_state("pi"),
+                {"cli": True, "auth": None, "ready": False},
+            )
+            # Preserve the positive path for an observed local auth record.
+            mod._provider_auth = lambda provider: True
+            self.assertEqual(
+                mod._provider_state("pi"),
+                {"cli": True, "auth": True, "ready": True},
+            )
+        finally:
+            mod._pi_installed = old_pi_installed
+            mod._provider_auth = old_provider_auth
+
     def test_provider_state_ready_when_cli_in_fallback_and_auth_present(self):
         # End-to-end: cli found via fallback + ~/.codex/auth.json present => ready.
         self._install("codex")

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1142,6 +1142,7 @@ const DEFAULT_BRIDGE_URL_BY_BACKEND = {
   codex: DEFAULT_BRIDGE_URL,
   gemini: DEFAULT_BRIDGE_URL,
   antigravity: DEFAULT_BRIDGE_URL,
+  pi: DEFAULT_BRIDGE_URL,
   grok: DEFAULT_BRIDGE_URL,
   kimi: DEFAULT_BRIDGE_URL,
   moonshot: DEFAULT_BRIDGE_URL,
@@ -1883,6 +1884,7 @@ const SETTING_MODEL = {
   codex: "comfyui-mcp.defaultModel.codex",
   gemini: "comfyui-mcp.defaultModel.gemini",
   antigravity: "comfyui-mcp.defaultModel.antigravity",
+  pi: "comfyui-mcp.defaultModel.pi",
   grok: "comfyui-mcp.defaultModel.grok",
   kimi: "comfyui-mcp.defaultModel.kimi",
   moonshot: "comfyui-mcp.defaultModel.moonshot",
@@ -1899,6 +1901,7 @@ const SETTING_EFFORT = {
   codex: "comfyui-mcp.defaultEffort.codex",
   gemini: "comfyui-mcp.defaultEffort.gemini",
   antigravity: "comfyui-mcp.defaultEffort.antigravity",
+  pi: "comfyui-mcp.defaultEffort.pi",
   grok: "comfyui-mcp.defaultEffort.grok",
   kimi: "comfyui-mcp.defaultEffort.kimi",
   moonshot: "comfyui-mcp.defaultEffort.moonshot",
@@ -1923,6 +1926,7 @@ const SETTING_BRIDGE_URL = {
   codex: "comfyui-mcp.bridgeUrl.codex",
   gemini: "comfyui-mcp.bridgeUrl.gemini",
   antigravity: "comfyui-mcp.bridgeUrl.antigravity",
+  pi: "comfyui-mcp.bridgeUrl.pi",
   grok: "comfyui-mcp.bridgeUrl.grok",
   kimi: "comfyui-mcp.bridgeUrl.kimi",
   moonshot: "comfyui-mcp.bridgeUrl.moonshot",
@@ -1997,10 +2001,10 @@ const SETTINGS_SEEDED_KEY = "comfyui-mcp.panel.settingsSeeded";
 // per-backend groups (runs independently of SETTINGS_SEEDED_KEY).
 const SETTINGS_GROUPS_MIGRATED_KEY = "comfyui-mcp.panel.settingsGroupsMigrated";
 // Section (sub-category) labels for the grouped Settings dialog, per backend.
-const BACKEND_SECTION = { claude: "Claude", codex: "ChatGPT (Codex)", gemini: "Gemini", antigravity: "Antigravity (Google)", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama (local)", openrouter: "OpenRouter", lmstudio: "LM Studio (local)", llamacpp: "llama.cpp (local)", custom: "Custom endpoint" };
+const BACKEND_SECTION = { claude: "Claude", codex: "ChatGPT (Codex)", gemini: "Gemini", antigravity: "Antigravity (Google)", pi: "Pi (pi.dev)", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama (local)", openrouter: "OpenRouter", lmstudio: "LM Studio (local)", llamacpp: "llama.cpp (local)", custom: "Custom endpoint" };
 // Backend display names at module scope (the Settings dialog's render-fns live
 // outside buildPanel's closure, so they need their own copy).
-const BACKEND_TEXT = { claude: "Claude", codex: "ChatGPT", gemini: "Gemini", antigravity: "Antigravity", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint" };
+const BACKEND_TEXT = { claude: "Claude", codex: "ChatGPT", gemini: "Gemini", antigravity: "Antigravity", pi: "Pi", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint" };
 // The allowlisted secure-store keys (mirrors the orchestrator's #59 allowlist).
 const SECRET_SET_AT_PREFIX = "comfyui-mcp.panel.secretSetAt.";
 
@@ -2051,7 +2055,7 @@ const settingsBackendState = {
 // render-fns when the dialog opens, so a freshly-arrived catalog can repaint the
 // matching backend's dropdown in place (a render-fn setting has no static options
 // to re-key). Keyed by backend; null when that group isn't mounted.
-const settingsModelSelectEls = { claude: null, codex: null, gemini: null, antigravity: null, grok: null, kimi: null, moonshot: null, glm: null, minimax: null, ollama: null, openrouter: null, lmstudio: null, llamacpp: null, custom: null };
+const settingsModelSelectEls = { claude: null, codex: null, gemini: null, antigravity: null, pi: null, grok: null, kimi: null, moonshot: null, glm: null, minimax: null, ollama: null, openrouter: null, lmstudio: null, llamacpp: null, custom: null };
 // Disabled placeholder <option> value — mapped to "" (Auto) if ever selected so
 // it can never persist as a bogus model id.
 const SETTINGS_PLACEHOLDER = "__cmcp_placeholder__";
@@ -2063,7 +2067,7 @@ function currentSettingsBackend() {
   const b = getSetting(SETTING_BACKEND);
   // Every selectable backend counts — this list lagging a provider addition
   // silently stops that provider's Settings edits from driving the live panel.
-  return ["codex", "gemini", "antigravity", "grok", "kimi", "moonshot", "glm", "minimax", "ollama", "openrouter", "lmstudio", "llamacpp", "custom"].includes(b) ? b : "claude";
+  return ["codex", "gemini", "antigravity", "pi", "grok", "kimi", "moonshot", "glm", "minimax", "ollama", "openrouter", "lmstudio", "llamacpp", "custom"].includes(b) ? b : "claude";
 }
 /** Fetched model rows for `backend` (the same presentable catalog the composer
  *  picker uses), or null when none is cached (backend never connected this session). */
@@ -2536,6 +2540,7 @@ function panelSettingsList() {
         { value: "codex", text: "ChatGPT" },
         { value: "gemini", text: "Gemini" },
         { value: "antigravity", text: "Antigravity (Google subscription)" },
+        { value: "pi", text: "Pi (pi.dev · multi-provider CLI)" },
         { value: "grok", text: "Grok" },
         { value: "kimi", text: "Kimi" },
         { value: "moonshot", text: "Kimi K3" },
@@ -2788,6 +2793,9 @@ function panelSettingsList() {
     // ---- Antigravity (Google) (Default model; no effort scale, like Gemini) ----
     modelSetting("antigravity", 84),
     effortSetting("antigravity", 82),
+    // ---- Pi (pi.dev) (Default model; no effort scale, like Antigravity) ----
+    modelSetting("pi", 83),
+    effortSetting("pi", 81),
     // ---- Grok (Default model, Default reasoning effort) ----
     modelSetting("grok", 80),
     effortSetting("grok", 75),
@@ -2934,6 +2942,9 @@ const BACKEND_EFFORTS = {
   // Antigravity drives Google's agy CLI like gemini — no user-facing
   // reasoning-effort scale; the orchestrator maps effort server-side.
   antigravity: [],
+  // pi (pi.dev) expresses reasoning effort as a model:<level> suffix, not a
+  // separate flag — no user-facing effort scale here.
+  pi: [],
   // Grok rides the ACP CLI like gemini — no user-facing reasoning-effort scale.
   grok: [],
   kimi: [],
@@ -10173,13 +10184,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
   // `codex app-server` cold-starts much slower than Claude's Agent SDK, so it gets
   // ~3x the window. This is the escalation THRESHOLD only — the respawn/reclaim
   // BOUNDS (MAX_AUTO_RESPAWNS / MAX_AUTO_RECLAIMS) are untouched.
-  const RESPAWN_AFTER_BY_BACKEND = { codex: 6, gemini: 6, antigravity: 6, grok: 6, kimi: 6, moonshot: 6, glm: 6, minimax: 6, ollama: 6, claude: 2 };
+  const RESPAWN_AFTER_BY_BACKEND = { codex: 6, gemini: 6, antigravity: 6, pi: 6, grok: 6, kimi: 6, moonshot: 6, glm: 6, minimax: 6, ollama: 6, claude: 2 };
   function respawnAfterAttempts() {
     return RESPAWN_AFTER_BY_BACKEND[backendNow()] ?? 2;
   }
   // Failed (re)connect attempts ridden out as a steady "connecting" before a
   // terminal "disconnected". Backend-aware, ~3x for Codex's slower cold start.
-  const CONNECT_PATIENCE_BY_BACKEND = { codex: 12, gemini: 12, antigravity: 12, grok: 12, kimi: 12, moonshot: 12, glm: 12, minimax: 12, ollama: 12, claude: 4 };
+  const CONNECT_PATIENCE_BY_BACKEND = { codex: 12, gemini: 12, antigravity: 12, pi: 12, grok: 12, kimi: 12, moonshot: 12, glm: 12, minimax: 12, ollama: 12, claude: 4 };
   function connectPatienceAttempts() {
     return CONNECT_PATIENCE_BY_BACKEND[backendNow()] ?? 4;
   }
@@ -10199,7 +10210,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
   // so it gets a wider window before we treat the open socket as wedged (FIX 2).
   // Ollama gets the long handshake too: a cold model load into VRAM can take
   // tens of seconds before the first token.
-  const HANDSHAKE_MS_BY_BACKEND = { codex: 45000, gemini: 45000, antigravity: 45000, grok: 45000, kimi: 45000, moonshot: 45000, glm: 45000, minimax: 45000, ollama: 45000, claude: 20000 };
+  const HANDSHAKE_MS_BY_BACKEND = { codex: 45000, gemini: 45000, antigravity: 45000, pi: 45000, grok: 45000, kimi: 45000, moonshot: 45000, glm: 45000, minimax: 45000, ollama: 45000, claude: 20000 };
   function handshakeMs() {
     return HANDSHAKE_MS_BY_BACKEND[backendNow()] ?? 20000;
   }
@@ -12687,7 +12698,7 @@ function buildPanel() {
   // ChatGPT). Clicking one asks the pack to ensure that backend's orchestrator is
   // running and returns the bridge URL to connect to — the user never types a
   // port. Populated from GET /comfyui_mcp_panel/backends when settings open.
-  const BACKEND_LABELS = { claude: "Claude", codex: "ChatGPT", gemini: "Gemini", antigravity: "Antigravity", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint", copilot: "GitHub Copilot" };
+  const BACKEND_LABELS = { claude: "Claude", codex: "ChatGPT", gemini: "Gemini", antigravity: "Antigravity", pi: "Pi", grok: "Grok", kimi: "Kimi", moonshot: "Kimi K3", glm: "GLM (z.ai)", minimax: "MiniMax", ollama: "Ollama", openrouter: "OpenRouter", lmstudio: "LM Studio", llamacpp: "llama.cpp", custom: "Custom endpoint", copilot: "GitHub Copilot" };
   // Appends a visible "(experimental)" marker to a backend's display label when
   // the readiness data flags it (b.experimental, e.g. Copilot — device-code,
   // GitHub ToS risk). Keeps picking it a deliberate, informed act everywhere a
@@ -12731,7 +12742,7 @@ function buildPanel() {
   // (GET /backends, blind to the laptop behind a remote pod) must not override it.
   let readinessFromOrchestrator = false;
   // Short per-provider hint shown under each provider row in the popup.
-  const BACKEND_HINTS = { claude: "Fable · Opus · Sonnet · Haiku", codex: "GPT-5 (Codex)", gemini: "Gemini 2.5 Pro · Flash", antigravity: "Gemini 3 · Google subscription", grok: "Grok Composer · Build", kimi: "Kimi (Moonshot)", moonshot: "Kimi K3 · Moonshot", glm: "GLM · z.ai coding plan", minimax: "MiniMax M3 · 1M context", ollama: "Local LLMs", openrouter: "MiMo · MiniMax (1M · SOTA)", lmstudio: "Local LLMs · no account", llamacpp: "Local LLMs · no account", custom: "DeepSeek · vLLM · any OpenAI-compatible API" };
+  const BACKEND_HINTS = { claude: "Fable · Opus · Sonnet · Haiku", codex: "GPT-5 (Codex)", gemini: "Gemini 2.5 Pro · Flash", antigravity: "Gemini 3 · Google subscription", pi: "pi.dev · multi-provider CLI · no ComfyUI tools", grok: "Grok Composer · Build", kimi: "Kimi (Moonshot)", moonshot: "Kimi K3 · Moonshot", glm: "GLM · z.ai coding plan", minimax: "MiniMax M3 · 1M context", ollama: "Local LLMs", openrouter: "MiMo · MiniMax (1M · SOTA)", lmstudio: "Local LLMs · no account", llamacpp: "Local LLMs · no account", custom: "DeepSeek · vLLM · any OpenAI-compatible API" };
 
   // Hint for a provider that exists but isn't usable yet — distinguishes
   // "install the CLI" from "sign in". Empty when ready or readiness is unknown.
@@ -12753,11 +12764,13 @@ function buildPanel() {
       if (b.backend === "lmstudio") return "LM Studio not installed — get it at lmstudio.ai";
       if (b.backend === "llamacpp") return "llama.cpp not found on PATH — github.com/ggml-org/llama.cpp/releases (a reachable server still works)";
       if (b.backend === "antigravity") return "Install the Antigravity CLI (agy) and run `agy` once to sign in with your Google account.";
+      if (b.backend === "pi") return "Install the pi CLI (pi.dev) and configure a provider (set a provider API key, or run `pi` once and `/login`).";
       return `${BACKEND_LABELS[b.backend] || b.backend} CLI not installed`;
     }
     if (b.backend === "codex") return "Not signed in — Sign in via API Keys (▾ menu) or run: codex login";
     if (b.backend === "gemini") return "Not signed in — run: gemini (then sign in with Google)";
     if (b.backend === "antigravity") return "Install the Antigravity CLI (agy) and run `agy` once to sign in with your Google account.";
+    if (b.backend === "pi") return "No provider configured — set a provider API key (e.g. ANTHROPIC_API_KEY) or run `pi` once and `/login`.";
     if (b.backend === "grok") return "Not signed in — Sign in with Grok via API Keys (▾ menu) or run: grok";
     if (b.backend === "kimi") return "Not signed in — add a Kimi key via API Keys (▾ menu) or run: kimi";
     if (b.backend === "ollama") return "Ollama not running — run: ollama serve";
@@ -13015,6 +13028,10 @@ function buildPanel() {
     // Google's Antigravity CLI (agy) — the individual-tier Google-subscription
     // path; auth lives in the OS keyring (no in-panel OAuth, no API-key slot).
     antigravity: { label: "Antigravity (Google subscription)", install: "install the Antigravity CLI (agy)", login: "agy" },
+    // pi.dev — a multi-provider coding CLI. "install" is the official installer;
+    // "login" is configuring any provider (env key or `/login`). NOTE: pi has no
+    // MCP, so a pi agent has no ComfyUI panel tools (see the ready banner).
+    pi: { label: "Pi (pi.dev, multi-provider CLI)", install: "curl -fsSL https://pi.dev/install.sh | sh", login: "set a provider API key, or run `pi` then /login" },
     grok: { label: "Grok", install: "install the Grok CLI (Grok Build / xAI)", login: "grok" },
     kimi: { label: "Kimi", install: "install the Kimi CLI (Moonshot)", login: "kimi" },
     // No CLI — "setup" is pasting a Moonshot platform API key (Kimi K3).
@@ -13065,7 +13082,7 @@ function buildPanel() {
     sub.textContent =
       "The agent runs on YOUR machine on your own AI subscription (Claude, ChatGPT, Gemini, …) or a local model (Ollama, LM Studio, llama.cpp) — no API keys. Set up a provider (Node ≥ 22), start the agent with the command below, then click Connect.";
     onboard.append(title, sub);
-    for (const id of ["claude", "codex", "gemini", "antigravity", "grok", "kimi", "moonshot", "glm", "minimax", "ollama", "openrouter", "lmstudio", "llamacpp", "custom"]) {
+    for (const id of ["claude", "codex", "gemini", "antigravity", "pi", "grok", "kimi", "moonshot", "glm", "minimax", "ollama", "openrouter", "lmstudio", "llamacpp", "custom"]) {
       const meta = PROVIDER_SETUP[id];
       const st = list.find((b) => b.backend === id) || {};
       const col = document.createElement("div");
@@ -18428,7 +18445,7 @@ function buildPanel() {
   // backend's handshake window (handshakeMs()) so a healthy slow reload completes
   // on its own backoff before the guard releases — Codex's app-server handshake is
   // 45s, so its guard is ~50s; Claude keeps 28s (still > its 20s handshake).
-  const SOFT_RELOAD_GUARD_MS_BY_BACKEND = { codex: 50000, gemini: 50000, antigravity: 50000, grok: 50000, kimi: 50000, moonshot: 50000, glm: 50000, minimax: 50000, ollama: 50000, claude: 28000 };
+  const SOFT_RELOAD_GUARD_MS_BY_BACKEND = { codex: 50000, gemini: 50000, antigravity: 50000, pi: 50000, grok: 50000, kimi: 50000, moonshot: 50000, glm: 50000, minimax: 50000, ollama: 50000, claude: 28000 };
   function softReloadGuardMs() {
     return SOFT_RELOAD_GUARD_MS_BY_BACKEND[selectedBackend] ?? 28000;
   }
@@ -18445,7 +18462,7 @@ function buildPanel() {
   // normal cold-start handshake (handshakeMs()) so a healthy-but-slow reload is
   // never pre-empted — Codex (45s handshake) escalates at ~40s, comfortably under
   // its ~50s guard; Claude keeps 11s (under its 28s guard and > its 20s handshake).
-  const SOFT_RELOAD_ESCALATE_MS_BY_BACKEND = { codex: 40000, gemini: 40000, antigravity: 40000, grok: 40000, kimi: 40000, moonshot: 40000, glm: 40000, minimax: 40000, ollama: 40000, claude: 11000 };
+  const SOFT_RELOAD_ESCALATE_MS_BY_BACKEND = { codex: 40000, gemini: 40000, antigravity: 40000, pi: 40000, grok: 40000, kimi: 40000, moonshot: 40000, glm: 40000, minimax: 40000, ollama: 40000, claude: 11000 };
   function softReloadEscalateMs() {
     return SOFT_RELOAD_ESCALATE_MS_BY_BACKEND[selectedBackend] ?? 11000;
   }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -243,6 +243,7 @@ import {
 } from "./lib/workflow-save.js";
 import { createRunCompletionTracker } from "./lib/run-completion.js";
 import { composeRunCompletionFrame } from "./lib/run-completion-frame.js";
+import { readyAckCanPromoteBackend } from "./lib/pi-readiness.js";
 import { createRunReconcileSweep } from "./lib/run-reconcile-sweep.js";
 import {
   activeWorkflowNodeCount,
@@ -12741,6 +12742,9 @@ function buildPanel() {
   // that actually RUNS the agents — authoritative), the ComfyUI-side Python probe
   // (GET /backends, blind to the laptop behind a remote pod) must not override it.
   let readinessFromOrchestrator = false;
+  // A generic `ready` ack can arrive before the authoritative `backends` snapshot.
+  // Pi must stay conservative until that snapshot has landed for this connection.
+  let piBackendsReadinessReceived = false;
   // Short per-provider hint shown under each provider row in the popup.
   const BACKEND_HINTS = { claude: "Fable · Opus · Sonnet · Haiku", codex: "GPT-5 (Codex)", gemini: "Gemini 2.5 Pro · Flash", antigravity: "Gemini 3 · Google subscription", pi: "pi.dev · multi-provider CLI · no ComfyUI tools", grok: "Grok Composer · Build", kimi: "Kimi (Moonshot)", moonshot: "Kimi K3 · Moonshot", glm: "GLM · z.ai coding plan", minimax: "MiniMax M3 · 1M context", ollama: "Local LLMs", openrouter: "MiMo · MiniMax (1M · SOTA)", lmstudio: "Local LLMs · no account", llamacpp: "Local LLMs · no account", custom: "DeepSeek · vLLM · any OpenAI-compatible API" };
 
@@ -17377,6 +17381,7 @@ function buildPanel() {
       // here falsely reads as "turn finished", so keep it up (with a reconnecting
       // banner) while a turn is live; only hide when nothing is in flight.
       if (!connected) {
+        piBackendsReadinessReceived = false;
         // Remember the drop so the next "connected" reconciles pending runs (#370).
         bridgeWasDown = true;
         if (agentWorking) {
@@ -17807,6 +17812,9 @@ function buildPanel() {
       // cmcpOpenCredentialsFrame) — sent alongside backends/any_ready.
       if (data && typeof data.console_url === "string") cmcpConsoleUrl = data.console_url;
       if (data && typeof data.console_token === "string") cmcpConsoleToken = data.console_token;
+      // This callback runs only for a real bridge `backends` frame with an array
+      // payload. From now on a ready ack may refine that authoritative Pi state.
+      piBackendsReadinessReceived = true;
       // Authoritative readiness from the connected orchestrator — the machine that
       // runs the agents. Wins over the ComfyUI-side probe (which false-flags "CLI
       // not installed" behind a remote pod). Repaint the chips so hints refresh.
@@ -17851,7 +17859,7 @@ function buildPanel() {
       // below still need to run on this same ack.
       if (ack?.kind === "ready") {
         const b = typeof ack.backend === "string" ? ack.backend : connectedBackend;
-        if (b) {
+        if (b && readyAckCanPromoteBackend(b, piBackendsReadinessReceived)) {
           backendReady[b] = { cli: true, auth: true, ready: true };
           readinessFromOrchestrator = true;
           anyReady = true;

--- a/web/js/lib/pi-readiness.js
+++ b/web/js/lib/pi-readiness.js
@@ -1,0 +1,7 @@
+// Pi credentials have provider-specific validation in the MCP. A generic bridge
+// `ready` acknowledgement only proves its dispatcher progressed; before the MCP
+// has sent its authoritative `backends` snapshot it must not override Pi's
+// conservative panel-local state.
+export function readyAckCanPromoteBackend(backend, piBackendsReadinessReceived) {
+  return backend !== "pi" || piBackendsReadinessReceived === true;
+}


### PR DESCRIPTION
Panel-side companion to comfyui-mcp#643 — wires the **pi.dev** (`pi`) provider chip across the panel so pi is selectable, has correct readiness/onboarding, and drives Settings.

pi is a **CLI provider** (mirrors antigravity/grok), not a hosted-key or in-panel-OAuth provider — so it is deliberately **not** added to `CMCP_OAUTH_PROVIDERS` and has no API-key slot.

## Sites touched (~21)
- `__init__.py`: `_BACKEND_PORTS`, `_PROVIDER_CLIS` (pi/pi.exe — no `.cmd`, matching orchestrator spawnability), `_pi_installed()`, and the `_provider_auth` / `_provider_state` pi branches (auth via `~/.pi/agent/auth.json`).
- `comfyui-mcp-panel.js`: bridge-url + default-model/effort/bridgeUrl setting-key maps; `BACKEND_SECTION` / `BACKEND_TEXT` / `BACKEND_LABELS` / `BACKEND_HINTS`; `settingsModelSelectEls`; the `currentSettingsBackend` allowlist; the default-backend `<option>` + model/effort setting rows; effort-scale map (`pi: []`); respawn / connect-patience / handshake / soft-reload-guard / soft-reload-escalate timing maps; signed-out hints; `PROVIDER_SETUP`; and the onboarding iteration list.

Hints note pi's **no-ComfyUI-tools** limitation (pi has no MCP).

## Gates
- `node --check` (ES module) + `python -c ast.parse` clean. No spawn literals / svg+onload.
- **Rebased on current `main`** (after MiniMax #504) — the ~20 adjacent chip-insert conflicts were re-resolved to keep BOTH `minimax` and `pi` at every site.

Refs #491 (closed by comfyui-mcp#643). Kept **draft** — provider-auth is gated by the maintainer's independent codex before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
