### PR TITLE
fix(panel): reconcile local_prompts when timeline_data updates on PromptRelayEncodeTimeline (#506)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- `panel_set_widget` on `PromptRelayEncodeTimeline.timeline_data` no longer leaves the node rendering the PREVIOUS prompts. That node's Python `execute()` reads only `local_prompts` + `segment_lengths` — never `timeline_data` — and both are derived by the in-browser timeline editor, so a raw `timeline_data` write reported success while the render silently kept the old prompts (and was reverted on the next UI touch). The write now regenerates both derived widgets from the new timeline and applies all three atomically, re-hydrates the live editor so its next commit is a no-op, merges onto the node's current timeline so unmentioned fields are preserved, and REFUSES any value the node would silently coerce or reset to a blank default. Direct writes to the derived widgets are refused with a redirect, and a node found already out of sync returns its previous prompt text rather than dropping it silently (#506)
+
 ## [0.11.32] - 2026-08-01
 
 ### Fixed

--- a/browser_tests/unit/prompt-relay-timeline.test.mjs
+++ b/browser_tests/unit/prompt-relay-timeline.test.mjs
@@ -287,6 +287,36 @@ test("MID-TYPING: the live editor wins over a timeline_data widget lagging by th
   assert.equal(res.replaced_out_of_band, undefined);
 });
 
+test("MID-TYPING: an explicit segments write that DISCARDS in-flight text says so", () => {
+  // Replacing `segments` is the caller's stated intent, so it is applied — but the prompt text
+  // the user had typed and not yet committed is handed back rather than vanishing silently.
+  const { node, widgets, editor } = makeRelayNode();
+  editor.timeline.segments[0].prompt = "user was typing this";
+  widgets.local_prompts.value = derivePromptRelayWidgets(editor.timeline.segments).local_prompts;
+
+  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("agent set", 20)] }));
+  assert.equal(res.merge_base, "editor");
+  assert.equal(res.overwrote_uncommitted_edit, "user was typing this | b");
+  assert.ok(res.warnings.some((w) => w.includes("UNCOMMITTED prompt edit")));
+  assert.equal(widgets.local_prompts.value, "agent set");
+});
+
+test("MID-TYPING: a write that PRESERVES the in-flight text reports no overwrite", () => {
+  const { node, widgets, editor } = makeRelayNode();
+  editor.timeline.segments[0].prompt = "user was typing this";
+  widgets.local_prompts.value = derivePromptRelayWidgets(editor.timeline.segments).local_prompts;
+  const res = relay(applyPromptRelayTimelineWrite(node, { zoom: 4 }));
+  assert.equal(res.overwrote_uncommitted_edit, undefined);
+  assert.equal(widgets.local_prompts.value, "user was typing this | b");
+});
+
+test("a normal (non-debounce) write never reports overwrote_uncommitted_edit", () => {
+  const { node } = makeRelayNode();
+  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("totally different", 3)] }));
+  assert.equal(res.merge_base, "timeline_data");
+  assert.equal(res.overwrote_uncommitted_edit, undefined);
+});
+
 test("MID-TYPING: a pending debounce commit AFTER our write is a no-op (no rollback)", () => {
   const { node, widgets, editor } = makeRelayNode();
   editor.timeline.segments[0].prompt = "in flight";

--- a/browser_tests/unit/prompt-relay-timeline.test.mjs
+++ b/browser_tests/unit/prompt-relay-timeline.test.mjs
@@ -299,6 +299,25 @@ test("MID-TYPING: a pending debounce commit AFTER our write is a no-op (no rollb
   assert.ok(before);
 });
 
+test("POST-LOAD: a stale editor is rejected even when its derived strings COLLIDE with the widgets", () => {
+  // The dangerous near-miss: after a load the restored widgets agree with each other, but the
+  // old editor's timeline happens to derive the SAME prompt join and length list while
+  // differing in per-segment data. Preferring the widget whenever it is self-consistent means
+  // the stale editor can never win, so its timeline is not resurrected.
+  const { node, widgets, editor } = makeRelayNode({
+    timelineSegments: [seg("a", 24, { color: "#new" }), seg("b", 36, { color: "#new2" })],
+  });
+  editor.timeline = {
+    stalePreviousWorkflow: true,
+    segments: [seg("a", 24, { color: "#old" }), seg("b", 36, { color: "#old2" })],
+  };
+  const res = relay(applyPromptRelayTimelineWrite(node, {}));
+  assert.equal(res.merge_base, "timeline_data");
+  const written = JSON.parse(widgets.timeline_data.value);
+  assert.equal(written.stalePreviousWorkflow, undefined);
+  assert.deepEqual(written.segments.map((s) => s.color), ["#new", "#new2"]);
+});
+
 test("POST-LOAD: the timeline_data widget wins over an editor still holding the OLD workflow", () => {
   // onConfigure restores the widgets first and re-parses the editor ~10ms later. Merging onto
   // the editor in that window would resurrect the previous workflow's timeline.
@@ -476,6 +495,25 @@ test("WARNS about leading/trailing whitespace — the python side strips each en
   // A fully-blank prompt is reported by the stronger blank-prompt warning, not this one.
   const clean = relay(applyPromptRelayTimelineWrite(makeRelayNode().node, { segments: [seg("   ", 24)] }));
   assert.equal(clean.warnings.filter((w) => w.includes("leading/trailing whitespace")).length, 0);
+});
+
+test("the whitespace notice covers characters PYTHON strips but JS trim() does not", () => {
+  // python's str.strip() also removes U+001C…U+001F and U+0085; JS trim() does not. A prompt
+  // padded with one of those is dropped/shifted by the encoder, so it must still be reported.
+  for (const pad of ["\u001c", "\u001d", "\u001e", "\u001f", "\u0085", "\ufeff"]) {
+    const res = relay(
+      applyPromptRelayTimelineWrite(makeRelayNode().node, { segments: [seg(pad + "fox" + pad, 24)] }),
+    );
+    assert.ok(
+      res.warnings?.some((w) => w.includes("leading/trailing whitespace")),
+      `no whitespace warning for U+${pad.codePointAt(0).toString(16)}`,
+    );
+  }
+  // A prompt made only of those characters counts as BLANK (python drops it entirely).
+  const blank = relay(
+    applyPromptRelayTimelineWrite(makeRelayNode().node, { segments: [seg("\u001c\u0085", 24), seg("b")] }),
+  );
+  assert.ok(blank.warnings.some((w) => w.includes("EMPTY prompt")));
 });
 
 test("a UI-refresh failure does NOT fail the write, and is reported", () => {

--- a/browser_tests/unit/prompt-relay-timeline.test.mjs
+++ b/browser_tests/unit/prompt-relay-timeline.test.mjs
@@ -317,6 +317,30 @@ test("a normal (non-debounce) write never reports overwrote_uncommitted_edit", (
   assert.equal(res.overwrote_uncommitted_edit, undefined);
 });
 
+test("a PERSISTED #506 stale-master state discloses the timeline_data prompts it sets aside", () => {
+  // timeline_data holds prompts a raw write put there that never reached the editor (the #506
+  // state). The editor + derived widgets still hold the previous prompts, so the editor is what
+  // the node would execute and it wins — but the prompts in timeline_data are handed back.
+  const { node, widgets, editor } = makeRelayNode();
+  widgets.timeline_data.value = JSON.stringify({ segments: [seg("raw write never applied", 24)] });
+  assert.equal(widgets.local_prompts.value, "a | b"); // editor + derived still the old pair
+
+  const res = relay(applyPromptRelayTimelineWrite(node, { zoom: 4 }));
+  assert.equal(res.merge_base, "editor");
+  assert.equal(res.superseded_timeline_data, "raw write never applied");
+  assert.ok(res.warnings.some((w) => w.includes("superseded_timeline_data")));
+  assert.equal(widgets.local_prompts.value, "a | b");
+  assert.equal(editor.timeline.zoom, 4);
+});
+
+test("a write that reproduces the timeline_data prompts reports no supersede", () => {
+  const { node, widgets } = makeRelayNode();
+  widgets.timeline_data.value = JSON.stringify({ segments: [seg("wanted", 24)] });
+  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("wanted", 24)] }));
+  assert.equal(res.superseded_timeline_data, undefined);
+  assert.equal(widgets.local_prompts.value, "wanted");
+});
+
 test("MID-TYPING: a pending debounce commit AFTER our write is a no-op (no rollback)", () => {
   const { node, widgets, editor } = makeRelayNode();
   editor.timeline.segments[0].prompt = "in flight";

--- a/browser_tests/unit/prompt-relay-timeline.test.mjs
+++ b/browser_tests/unit/prompt-relay-timeline.test.mjs
@@ -461,6 +461,16 @@ test("sameSegmentContent compares structurally, never through the join", () => {
   assert.equal(sameSegmentContent([{ prompt: "p", length: null }], [{ prompt: "p", length: "null" }]), false);
   assert.equal(sameSegmentContent([{ prompt: "p", length: NaN }], [{ prompt: "p", length: 24 }]), false);
   assert.equal(sameSegmentContent([{ prompt: "p" }], [{ prompt: "p" }]), true);
+  // …nor by a plain Number() coercion. The pack's parseInt reads "2e3" as 2, so calling it equal
+  // to 2000 would suppress the disclosure while a 2000-frame segment was replaced by a 2-frame
+  // one. Only the LOSSLESS forms the write path accepts count as equal.
+  const len = (x, y) => sameSegmentContent([{ prompt: "p", length: x }], [{ prompt: "p", length: y }]);
+  assert.equal(len("2e3", 2000), false);
+  assert.equal(len("0x10", 16), false);
+  assert.equal(len("24.7", 24), false);
+  assert.equal(len("24.0", 24), true);
+  assert.equal(len("+24", 24), true);
+  assert.equal(len(" 24 ", 24), true);
   // Prompts are compared strictly — no coercion, and an empty prompt is distinct from absent.
   assert.equal(sameSegmentContent([{ prompt: "", length: 1 }], [{ length: 1 }]), false);
 });

--- a/browser_tests/unit/prompt-relay-timeline.test.mjs
+++ b/browser_tests/unit/prompt-relay-timeline.test.mjs
@@ -201,6 +201,65 @@ test("selectedIndex past the end of a shrunken timeline is clamped, and anim sta
   assert.equal(editor._settling, false);
 });
 
+test("a SHRINK push during an ACTIVE reorder/drag invalidates it — no stale-index splice, no throw", () => {
+  // The pack's editor keys its in-flight pointer interactions on segment INDICES: an active
+  // reorder splices `sourceIdx`→`targetIdx` on pointer-up and a boundary drag resizes from
+  // `dragStart.initialLengths[handle]` on pointer-move. A push that SHRINKS the timeline
+  // between pointer-down and pointer-up leaves those indices pointing past the end of the new
+  // list: the release would splice `undefined` into segments and the editor's own commit()
+  // would throw on `s.prompt` BEFORE the derived widgets update — timeline_data corrupted and
+  // desynced. Rehydration must end the interaction instead.
+  const { node, widgets, editor } = makeRelayNode({
+    timelineSegments: [seg("a"), seg("b", 36), seg("c", 48)],
+  });
+  // Mid-reorder of block 2 toward slot 0, AND mid boundary-drag — both index-keyed.
+  editor.reorder = {
+    sourceIdx: 2,
+    targetIdx: 0,
+    startX: 0,
+    startY: 0,
+    cursorX: 5,
+    dragOffsetPx: 2,
+    active: true,
+  };
+  editor.dragHandle = 1;
+  editor.dragStart = { x: 0, initialLengths: [24, 36, 48] };
+
+  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("only one", 5)] }));
+
+  assert.equal(res.editor_synced, true);
+  // The interaction is over, at exactly the pack's idle values.
+  assert.equal(editor.reorder, null);
+  assert.equal(editor.dragHandle, -1);
+  assert.equal(editor.dragStart, null);
+
+  // Replay the pack's onPointerUp VERBATIM against the released pointer: with no drag state
+  // it is a no-op. (Mirrors prompt_relay_timeline.js — splice(sourceIdx,1)[0] then
+  // splice(targetIdx,0,seg), then commit()'s segments.map(s => s.prompt), which is what threw.)
+  const packPointerUp = (ed) => {
+    if (ed.dragHandle >= 0) {
+      ed.dragHandle = -1;
+      ed.dragStart = null;
+    }
+    if (ed.reorder) {
+      if (ed.reorder.active && ed.reorder.sourceIdx !== ed.reorder.targetIdx) {
+        const segm = ed.timeline.segments.splice(ed.reorder.sourceIdx, 1)[0];
+        ed.timeline.segments.splice(ed.reorder.targetIdx, 0, segm);
+        ed.committedPrompts = ed.timeline.segments.map((s) => s.prompt).join(" | ");
+      }
+      ed.reorder = null;
+    }
+  };
+  assert.doesNotThrow(() => packPointerUp(editor));
+  // No splice happened: the pushed list is untouched, no undefined was inserted.
+  assert.deepEqual(editor.timeline.segments.map((s) => s.prompt), ["only one"]);
+  assert.equal(editor.committedPrompts, undefined);
+  // …and timeline_data still re-derives to exactly the derived widgets (consistent triplet).
+  const back = derivePromptRelayWidgets(JSON.parse(widgets.timeline_data.value).segments);
+  assert.equal(back.local_prompts, widgets.local_prompts.value);
+  assert.equal(back.segment_lengths, widgets.segment_lengths.value);
+});
+
 // ─── Merge: omitted fields preserved, never defaulted away ───
 
 test("a partial write MERGES onto the current timeline (unmentioned fields preserved)", () => {

--- a/browser_tests/unit/prompt-relay-timeline.test.mjs
+++ b/browser_tests/unit/prompt-relay-timeline.test.mjs
@@ -420,6 +420,119 @@ test("MID-TYPING with a REALISTIC partial editor: fields the editor does not mod
   assert.equal(res.replaced_out_of_band, undefined);
 });
 
+/**
+ * Seed a REALISTIC partial editor (the pack's parser keeps only prompt/length/color) holding
+ * `editorSegments` — the un-committed state mid-debounce — over a persisted timeline_data whose
+ * segments carry per-segment fields the editor does not model. local_prompts is refreshed to
+ * the editor's content, timeline_data lags, so the editor is authoritative on reconciliation.
+ */
+function makeMidEditNode(editorSegments, persistedSegments, extraTimelineFields = {}) {
+  const n = makeRelayNode({ timelineSegments: persistedSegments, extraTimelineFields });
+  n.editor.timeline = { segments: editorSegments };
+  n.widgets.local_prompts.value = derivePromptRelayWidgets(editorSegments).local_prompts;
+  n.widgets.segment_lengths.value = derivePromptRelayWidgets(editorSegments).segment_lengths;
+  return n;
+}
+
+test("MID-TYPING REORDER: unmodelled per-segment fields follow their PROMPT, never their old index", () => {
+  // Before the debounce commits, the user swaps the two blocks. The persisted widget still
+  // holds [A, B] with per-segment metadata; carrying BY INDEX would attach A's metadata to B
+  // and B's to A — writing fields onto segments they were never authored for.
+  const n = makeMidEditNode(
+    [
+      { prompt: "b", length: 36, color: "#222222" },
+      { prompt: "a", length: 24, color: "#111111" },
+    ],
+    [
+      seg("a", 24, { color: "#111111", legacyMeta: "keep-A" }),
+      seg("b", 36, { color: "#222222", legacyMeta: "keep-B" }),
+    ],
+    { zoom: 3 },
+  );
+
+  const res = relay(applyPromptRelayTimelineWrite(n.node, { fps: 24 }));
+
+  assert.equal(res.merge_base, "editor");
+  const written = JSON.parse(n.widgets.timeline_data.value);
+  assert.deepEqual(written.segments.map((s) => s.prompt), ["b", "a"]);
+  // Keyed by the unique prompt: each segment keeps ITS OWN metadata.
+  assert.equal(written.segments[0].legacyMeta, "keep-B");
+  assert.equal(written.segments[1].legacyMeta, "keep-A");
+  assert.equal(written.zoom, 3);
+});
+
+test("MID-TYPING SHRINK: deleting the FIRST block does not shift its metadata onto the survivor", () => {
+  // The user deletes block A; the editor now holds only [B]. Index carry would stamp A's
+  // metadata onto B (index 0) and drop B's entirely — the exact misattachment the carry keys
+  // on content to prevent.
+  const n = makeMidEditNode(
+    [{ prompt: "b", length: 36, color: "#222222" }],
+    [
+      seg("a", 24, { color: "#111111", legacyMeta: "keep-A" }),
+      seg("b", 36, { color: "#222222", legacyMeta: "keep-B" }),
+    ],
+  );
+
+  const res = relay(applyPromptRelayTimelineWrite(n.node, { fps: 24 }));
+
+  assert.equal(res.merge_base, "editor");
+  const written = JSON.parse(n.widgets.timeline_data.value);
+  assert.equal(written.segments.length, 1);
+  assert.equal(written.segments[0].prompt, "b");
+  assert.equal(written.segments[0].legacyMeta, "keep-B");
+});
+
+test("MID-TYPING with an AMBIGUOUS mapping: the carry is DROPPED, never guessed", () => {
+  // The user shrank the list AND retyped the survivor, so no prompt matches anything in the
+  // persisted record. Index carry would attach A's metadata to the retyped segment; content
+  // matching finds no pair. Ambiguous → no carry: losing an unmodelled field beats writing it
+  // onto the WRONG segment.
+  const n = makeMidEditNode(
+    [{ prompt: "retyped from scratch", length: 24, color: "#111111" }],
+    [
+      seg("a", 24, { color: "#111111", legacyMeta: "keep-A" }),
+      seg("b", 36, { color: "#222222", legacyMeta: "keep-B" }),
+    ],
+  );
+
+  const res = relay(applyPromptRelayTimelineWrite(n.node, { fps: 24 }));
+
+  const written = JSON.parse(n.widgets.timeline_data.value);
+  assert.equal(res.merge_base, "editor");
+  assert.equal(written.segments.length, 1);
+  assert.equal(written.segments[0].legacyMeta, undefined);
+  // The persisted record's own fields still survive where they belong: top level.
+  assert.equal(typeof written.segments[0].color, "string");
+});
+
+test("MID-TYPING with DUPLICATED prompts: a non-1:1 content match carries nothing", () => {
+  // The user duplicated block A while also keeping B (list grew, so positional alignment is
+  // already broken). Both editor copies of "a" match the SAME persisted segment, so neither
+  // pairing is provably the original — carrying "keep-A" onto either would be a guess. The
+  // 1:1 match for "b" is unaffected and still carries.
+  const n = makeMidEditNode(
+    [
+      { prompt: "a", length: 24, color: "#111111" },
+      { prompt: "b", length: 36, color: "#222222" },
+      { prompt: "a", length: 24, color: "#111111" },
+    ],
+    [
+      seg("a", 24, { color: "#111111", legacyMeta: "keep-A" }),
+      seg("b", 36, { color: "#222222", legacyMeta: "keep-B" }),
+    ],
+  );
+
+  const res = relay(applyPromptRelayTimelineWrite(n.node, { fps: 24 }));
+
+  const written = JSON.parse(n.widgets.timeline_data.value);
+  assert.equal(res.merge_base, "editor");
+  // "a" is not unique on the editor's side → no carry for either copy…
+  assert.equal(written.segments[0].legacyMeta, undefined);
+  assert.equal(written.segments[2].legacyMeta, undefined);
+  // …while the unique "b" still matches its own persisted segment 1:1.
+  assert.equal(written.segments[1].legacyMeta, "keep-B");
+});
+
 test("a normal (non-debounce) write never reports overwrote_uncommitted_edit", () => {
   const { node } = makeRelayNode();
   const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("totally different", 3)] }));
@@ -625,27 +738,40 @@ test("PIPE COLLISION: a metadata-only overlay on an unresolvable tie FAILS CLOSE
   assert.deepEqual(order, []);
 });
 
-test("an unresolvable tie is flagged; an ordinary write is not", () => {
+test("an unresolvable tie FAILS CLOSED even with explicit segments; an ordinary write has no tie", () => {
   // Neither record matches the derived widgets (a genuinely desynced node) and they differ
-  // structurally: unresolvable. Explicit segments replace BOTH records outright, so the write
-  // may proceed — declared ambiguous, merging onto the PERSISTED record for everything else,
-  // with the set-aside editor copy handed back rather than written.
-  const { node, widgets } = makeRelayNode({ localPrompts: "hand written | text" });
+  // structurally: unresolvable. Explicit segments used to replace BOTH records outright here —
+  // but that still permanently destroys whichever copy they do not reproduce behind a
+  // "reconciled" report, and the filter just said it cannot prove which copy is current. No
+  // resolved base, no write: refused with both copies disclosed, nothing mutated.
+  const { node, widgets, editor } = makeRelayNode({ localPrompts: "hand written | text" });
   widgets.timeline_data.value = JSON.stringify({ segments: [seg("master only", 24)] });
-  const tied = relay(
-    applyPromptRelayTimelineWrite(node, { segments: [seg("caller decides", 5)] }),
+  const timelineBefore = widgets.timeline_data.value;
+  const order = [];
+  assert.throws(
+    () =>
+      applyPromptRelayTimelineWrite(node, { segments: [seg("caller decides", 5)] }, {
+        beforeChange: () => order.push("before"),
+        afterChange: () => order.push("after"),
+        setDirty: () => order.push("dirty"),
+      }),
+    (err) => {
+      assert.ok(err instanceof PromptRelayTimelineWriteError);
+      assert.match(err.message, /CANNOT tell which is current/);
+      // BOTH copies are handed back PER SEGMENT, so the caller knows exactly what is at stake.
+      assert.ok(err.message.includes('"a","b"'), "editor copy missing from the refusal");
+      assert.ok(err.message.includes('"master only"'), "timeline_data copy missing from the refusal");
+      return true;
+    },
   );
-  assert.equal(tied.merge_base, "timeline_data");
-  assert.equal(tied.merge_base_reason, "unresolved-tie");
-  assert.equal(tied.merge_base_ambiguous, true);
-  // The out-of-band derived text is still reported before being replaced…
-  assert.equal(tied.replaced_out_of_band.local_prompts, "hand written | text");
-  // …and the ambiguous editor copy is disclosed per segment, never written back.
-  assert.deepEqual(tied.discarded_unverified_editor_copy, { prompts: ["a", "b"], lengths: [24, 36] });
-  assert.ok(tied.warnings.some((w) => w.includes("could not tell which was current")));
-  assert.equal(widgets.local_prompts.value, "caller decides");
+  // ZERO mutation — not the widgets, not the editor, not the undo history.
+  assert.equal(widgets.timeline_data.value, timelineBefore);
+  assert.equal(widgets.local_prompts.value, "hand written | text");
+  assert.deepEqual(editor.timeline.segments.map((s) => s.prompt), ["a", "b"]);
+  assert.deepEqual(order, []);
 
-  // A node whose two records agree has no tie to declare.
+  // A node whose two records agree has no tie to declare, and a successful write carries no
+  // ambiguity flag.
   const plain = relay(applyPromptRelayTimelineWrite(makeRelayNode().node, { segments: [seg("x", 3)] }));
   assert.equal(plain.merge_base, "timeline_data");
   assert.equal(plain.merge_base_ambiguous, undefined);
@@ -841,33 +967,45 @@ test("POST-LOAD TIE: a stale editor colliding on BOTH joins fails CLOSED — the
   assert.deepEqual(n.editor.timeline.segments.map((s) => s.prompt), ["x", "y | z"]);
 });
 
-test("TIE with explicit segments: the caller's list replaces BOTH copies — no ambiguous data is written", () => {
-  // The same unresolvable collision, but the write supplies the segment list outright — the one
-  // resolution that cannot resurrect ambiguous data: the segments come from the caller, and
-  // everything else from the PERSISTED widget (never the editor copy, whose unmodeled
-  // top-level fields — the old workflow's zoom here — belong to the previous workflow).
+test("TIE with explicit segments FAILS CLOSED too — no copy is destroyed behind a reconciled report", () => {
+  // The same unresolvable collision, with the write supplying the segment list outright. That
+  // used to be the escape hatch — the caller's list replaced BOTH records — but the filter
+  // just proved it cannot tell which record is current, and the supplied list still
+  // permanently destroys whichever copy it does not reproduce: exactly the live edit
+  // ["x","y | z"] here, discarded while the call reported success. No resolved base, no write.
   const { node, widgets, editor } = makeRelayNode({
     timelineSegments: [seg("x | y", 50), seg("z", 10)],
     extraTimelineFields: { zoom: 3 },
   });
   // The editor still holds the PREVIOUS workflow, colliding on both derived joins.
   editor.timeline = { zoom: 9, segments: [seg("x", 50), seg("y | z", 10)] };
+  const timelineBefore = widgets.timeline_data.value;
 
+  assert.throws(
+    () => applyPromptRelayTimelineWrite(node, { segments: [seg("caller decides", 7)] }),
+    (err) => {
+      assert.ok(err instanceof PromptRelayTimelineWriteError);
+      assert.match(err.message, /CANNOT tell which is current/);
+      // BOTH copies disclosed PER SEGMENT — the live edit and the persisted record.
+      assert.ok(err.message.includes('"x","y | z"'), "editor copy missing from the refusal");
+      assert.ok(err.message.includes('"x | y","z"'), "timeline_data copy missing from the refusal");
+      return true;
+    },
+  );
+  // NOTHING mutated: both copies survive byte-for-byte.
+  assert.equal(widgets.timeline_data.value, timelineBefore);
+  assert.equal(widgets.local_prompts.value, "x | y | z");
+  assert.equal(widgets.segment_lengths.value, "50, 10");
+  assert.deepEqual(editor.timeline.segments.map((s) => s.prompt), ["x", "y | z"]);
+
+  // The documented remedy: the tie is transient. Once the editor's pending commit lands (the
+  // records converge on the editor's copy), the very same write succeeds as an ordinary one.
+  widgets.timeline_data.value = JSON.stringify(editor.timeline);
   const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("caller decides", 7)] }));
-
   assert.equal(res.reconciled, true);
   assert.equal(res.merge_base, "timeline_data");
-  assert.equal(res.merge_base_reason, "unresolved-tie");
-  assert.equal(res.merge_base_ambiguous, true);
-  const written = JSON.parse(widgets.timeline_data.value);
-  assert.deepEqual(written.segments.map((s) => s.prompt), ["caller decides"]);
-  // The persisted record's fields — never the ambiguous editor copy's.
-  assert.equal(written.zoom, 3);
   assert.equal(widgets.local_prompts.value, "caller decides");
-  // The set-aside editor copy is disclosed per segment, with warnings — not silently kept.
-  assert.deepEqual(res.discarded_unverified_editor_copy, { prompts: ["x", "y | z"], lengths: [50, 10] });
-  assert.ok(res.warnings.some((w) => w.includes("could not tell which was current")));
-  assert.ok(res.warnings.some((w) => w.includes("could NOT be determined")));
+  assert.equal(JSON.parse(widgets.timeline_data.value).zoom, 9);
 });
 
 // ─── The filter cannot tell a stale editor from an uncommitted edit; only the load can ───

--- a/browser_tests/unit/prompt-relay-timeline.test.mjs
+++ b/browser_tests/unit/prompt-relay-timeline.test.mjs
@@ -536,10 +536,10 @@ test("WARNS about leading/trailing whitespace — the python side strips each en
   assert.equal(clean.warnings.filter((w) => w.includes("leading/trailing whitespace")).length, 0);
 });
 
-test("the whitespace notice covers characters PYTHON strips but JS trim() does not", () => {
-  // python's str.strip() also removes U+001C…U+001F and U+0085; JS trim() does not. A prompt
-  // padded with one of those is dropped/shifted by the encoder, so it must still be reported.
-  for (const pad of ["\u001c", "\u001d", "\u001e", "\u001f", "\u0085", "\ufeff"]) {
+test("the whitespace notice tracks PYTHON str.strip(), not JS trim()", () => {
+  // python's str.strip() also removes U+001C…U+001F and U+0085, which JS trim() keeps. A
+  // prompt padded with one of those IS dropped/shifted by the encoder, so it must be reported.
+  for (const pad of ["\u001c", "\u001d", "\u001e", "\u001f", "\u0085", "\u00a0", "\u3000"]) {
     const res = relay(
       applyPromptRelayTimelineWrite(makeRelayNode().node, { segments: [seg(pad + "fox" + pad, 24)] }),
     );
@@ -548,7 +548,13 @@ test("the whitespace notice covers characters PYTHON strips but JS trim() does n
       `no whitespace warning for U+${pad.codePointAt(0).toString(16)}`,
     );
   }
-  // A prompt made only of those characters counts as BLANK (python drops it entirely).
+  // U+FEFF goes the OTHER way: JS trim() strips it but python does NOT, so the render keeps it
+  // verbatim and warning would be a lie.
+  const bom = relay(
+    applyPromptRelayTimelineWrite(makeRelayNode().node, { segments: [seg("\ufefffox\ufeff", 24)] }),
+  );
+  assert.equal(bom.warnings, undefined);
+  // A prompt made only of python-whitespace counts as BLANK (python drops it entirely).
   const blank = relay(
     applyPromptRelayTimelineWrite(makeRelayNode().node, { segments: [seg("\u001c\u0085", 24), seg("b")] }),
   );

--- a/browser_tests/unit/prompt-relay-timeline.test.mjs
+++ b/browser_tests/unit/prompt-relay-timeline.test.mjs
@@ -573,6 +573,50 @@ test("POST-LOAD: the timeline_data widget wins over an editor still holding the 
   assert.equal(widgets.segment_lengths.value, "50");
 });
 
+test("POST-LOAD: a stale editor is NOT reported as an overwritten uncommitted edit", () => {
+  // The routine post-load window: onConfigure restores the widgets ~10ms before it re-parses the
+  // editor, so the editor still holds the PREVIOUS workflow. An ordinary metadata-only write
+  // arrives. Case 3 rejects the editor on positive evidence (it could not have produced what the
+  // node executes), so calling its content an overwritten uncommitted edit would cry wolf on a
+  // routine write — and this disclosure is the safety net for the genuine collision case, so it
+  // must not become noise. The content is still returned, just classified honestly.
+  const { node, widgets, editor } = makeRelayNode({ timelineSegments: [seg("restored", 50)] });
+  editor.timeline = { segments: [seg("previous workflow", 99)] };
+
+  const res = relay(applyPromptRelayTimelineWrite(node, { zoom: 4 }));
+
+  assert.equal(res.merge_base, "timeline_data");
+  assert.equal(res.merge_base_reason, "filter-rejected-editor");
+  // NO data-loss claim, and no warning at all — nothing was typed and nothing was lost.
+  assert.equal(res.overwrote_uncommitted_edit, undefined);
+  assert.equal(res.warnings, undefined);
+  // The payload is still handed back, under a name that says what it actually is.
+  assert.deepEqual(res.discarded_stale_editor, { prompts: ["previous workflow"], lengths: [99] });
+  assert.equal(widgets.local_prompts.value, "restored");
+  assert.equal(widgets.segment_lengths.value, "50");
+});
+
+test("POST-LOAD: an explicit segments write does not claim the master was superseded", () => {
+  // Case 3 selected the master; replacing its segments is the caller's plain intent, not a copy
+  // set aside behind their back.
+  const { node, widgets, editor } = makeRelayNode({ timelineSegments: [seg("restored", 50)] });
+  editor.timeline = { segments: [seg("previous workflow", 99)] };
+  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("caller wrote this", 10)] }));
+  assert.equal(res.merge_base, "timeline_data");
+  assert.equal(res.superseded_timeline_data, undefined);
+  assert.equal(res.overwrote_uncommitted_edit, undefined);
+  assert.deepEqual(res.discarded_stale_editor, { prompts: ["previous workflow"], lengths: [99] });
+  assert.equal(widgets.local_prompts.value, "caller wrote this");
+});
+
+test("a stale editor whose content the write happens to reproduce reports nothing", () => {
+  const { node, editor } = makeRelayNode({ timelineSegments: [seg("restored", 50)] });
+  editor.timeline = { segments: [seg("previous workflow", 99)] };
+  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("previous workflow", 99)] }));
+  assert.equal(res.discarded_stale_editor, undefined);
+  assert.equal(res.overwrote_uncommitted_edit, undefined);
+});
+
 test("the live editor never has its segment objects aliased into the written timeline", () => {
   const { node, widgets, editor } = makeRelayNode();
   const originalSeg = editor.timeline.segments[0];

--- a/browser_tests/unit/prompt-relay-timeline.test.mjs
+++ b/browser_tests/unit/prompt-relay-timeline.test.mjs
@@ -394,6 +394,30 @@ test("an overlay with NO segments key is an idempotent RE-RECONCILE, not a wipe"
   assert.deepEqual(res.replaced_out_of_band, { local_prompts: "stale text" });
 });
 
+test("with NO readable base at all, an existing derived value is still reported before replacement", () => {
+  // No editor yet (it is built in a setTimeout(0)) and no readable timeline_data, but the node
+  // carries hand-written local_prompts. Nothing could have derived that, so it is out-of-band
+  // by definition and must not be overwritten silently.
+  const { node, widgets } = makeRelayNode({ timelineSegments: null, withEditor: false });
+  widgets.local_prompts.value = "hand written | prompts";
+  widgets.segment_lengths.value = "10, 10";
+  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("from the agent", 7)] }));
+  assert.equal(res.merge_base, "none");
+  assert.deepEqual(res.replaced_out_of_band, {
+    local_prompts: "hand written | prompts",
+    segment_lengths: "10, 10",
+  });
+  assert.ok(res.warnings.some((w) => w.includes("ALREADY desynced")));
+  assert.equal(widgets.local_prompts.value, "from the agent");
+});
+
+test("a first write onto a truly EMPTY node reports nothing replaced", () => {
+  const { node } = makeRelayNode({ timelineSegments: null, withEditor: false });
+  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("first", 5)] }));
+  assert.equal(res.replaced_out_of_band, undefined);
+  assert.equal(res.warnings, undefined);
+});
+
 test("an overlay with no segments AND no readable current timeline is REFUSED", () => {
   const { node } = makeRelayNode({ timelineSegments: null });
   assert.throws(() => applyPromptRelayTimelineWrite(node, {}), PromptRelayTimelineWriteError);

--- a/browser_tests/unit/prompt-relay-timeline.test.mjs
+++ b/browser_tests/unit/prompt-relay-timeline.test.mjs
@@ -19,6 +19,7 @@ import {
   normalizePromptRelayTimelineValue,
   parsePromptRelayTimeline,
   derivePromptRelayWidgets,
+  sameSegmentContent,
   promptRelayDerivedRefusal,
   applyPromptRelayTimelineWrite,
   PromptRelayTimelineWriteError,
@@ -296,8 +297,12 @@ test("MID-TYPING: an explicit segments write that DISCARDS in-flight text says s
 
   const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("agent set", 20)] }));
   assert.equal(res.merge_base, "editor");
-  assert.equal(res.overwrote_uncommitted_edit, "user was typing this | b");
-  assert.ok(res.warnings.some((w) => w.includes("UNCOMMITTED prompt edit")));
+  // Handed back PER SEGMENT, not as the lossy join, so the caller can actually restore it.
+  assert.deepEqual(res.overwrote_uncommitted_edit, {
+    prompts: ["user was typing this", "b"],
+    lengths: [24, 36],
+  });
+  assert.ok(res.warnings.some((w) => w.includes("UNCOMMITTED timeline edit")));
   assert.equal(widgets.local_prompts.value, "agent set");
 });
 
@@ -327,7 +332,10 @@ test("a PERSISTED #506 stale-master state discloses the timeline_data prompts it
 
   const res = relay(applyPromptRelayTimelineWrite(node, { zoom: 4 }));
   assert.equal(res.merge_base, "editor");
-  assert.equal(res.superseded_timeline_data, "raw write never applied");
+  assert.deepEqual(res.superseded_timeline_data, {
+    prompts: ["raw write never applied"],
+    lengths: [24],
+  });
   assert.ok(res.warnings.some((w) => w.includes("superseded_timeline_data")));
   assert.equal(widgets.local_prompts.value, "a | b");
   assert.equal(editor.timeline.zoom, 4);
@@ -338,7 +346,88 @@ test("a write that reproduces the timeline_data prompts reports no supersede", (
   widgets.timeline_data.value = JSON.stringify({ segments: [seg("wanted", 24)] });
   const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("wanted", 24)] }));
   assert.equal(res.superseded_timeline_data, undefined);
+  // The editor's own copy IS discarded by this write, and that is still disclosed.
+  assert.deepEqual(res.overwrote_uncommitted_edit, { prompts: ["a", "b"], lengths: [24, 36] });
   assert.equal(widgets.local_prompts.value, "wanted");
+});
+
+// ─── The lossy " | " join must never gate a data-loss disclosure ───
+
+test("PIPE COLLISION: an overwrite is disclosed even when the joined local_prompts is IDENTICAL", () => {
+  // The exact hazard the join hides. Persisted timeline is ["old", "c"]. During the 120ms
+  // debounce the user types segment 0 as the perfectly valid prompt "a | b", so the live editor
+  // holds ["a | b", "c"] and local_prompts is already "a | b | c". An incoming write supplies
+  // ["a", "b | c"] with the same lengths — a COMPLETELY different segmentation that joins to the
+  // SAME string. Gating on the join would report a clean success while the user's single
+  // authored prompt "a | b" was silently split into two different segment prompts.
+  const { node, widgets, editor } = makeRelayNode({
+    timelineSegments: [seg("old", 24), seg("c", 36)],
+  });
+  editor.timeline.segments[0].prompt = "a | b";
+  widgets.local_prompts.value = "a | b | c";
+  widgets.segment_lengths.value = "24, 36";
+
+  const res = relay(
+    applyPromptRelayTimelineWrite(node, { segments: [seg("a", 24), seg("b | c", 36)] }),
+  );
+
+  // Same join on both sides — the ONLY thing that distinguishes them is the segment structure.
+  assert.equal(res.local_prompts, "a | b | c");
+  assert.equal(derivePromptRelayWidgets(editor.timeline.segments).local_prompts, res.local_prompts);
+  assert.deepEqual(res.overwrote_uncommitted_edit, { prompts: ["a | b", "c"], lengths: [24, 36] });
+  assert.ok(res.warnings.some((w) => w.includes("UNCOMMITTED timeline edit")));
+});
+
+test("PIPE COLLISION mirror: genuinely identical segments report NO overwrite", () => {
+  // Same starting state, but the write reproduces the in-flight segments exactly. Nothing is
+  // lost, so the disclosure must stay silent — a structural compare, not a join compare, is the
+  // only thing that can tell these two cases apart.
+  const { node, widgets, editor } = makeRelayNode({
+    timelineSegments: [seg("old", 24), seg("c", 36)],
+  });
+  editor.timeline.segments[0].prompt = "a | b";
+  widgets.local_prompts.value = "a | b | c";
+  widgets.segment_lengths.value = "24, 36";
+
+  const res = relay(
+    applyPromptRelayTimelineWrite(node, { segments: [seg("a | b", 24), seg("c", 36)] }),
+  );
+  assert.equal(res.overwrote_uncommitted_edit, undefined);
+  // The stale timeline_data copy (["old","c"]) IS still set aside, and that is disclosed.
+  assert.deepEqual(res.superseded_timeline_data, { prompts: ["old", "c"], lengths: [24, 36] });
+});
+
+test("PIPE COLLISION: a length-only change is disclosed despite identical prompt joins", () => {
+  const { node, widgets, editor } = makeRelayNode({
+    timelineSegments: [seg("old", 24), seg("c", 36)],
+  });
+  editor.timeline.segments[0].prompt = "a | b";
+  widgets.local_prompts.value = "a | b | c";
+  widgets.segment_lengths.value = "24, 36";
+
+  const res = relay(
+    applyPromptRelayTimelineWrite(node, { segments: [seg("a | b", 90), seg("c", 36)] }),
+  );
+  assert.equal(res.local_prompts, "a | b | c");
+  assert.deepEqual(res.overwrote_uncommitted_edit, { prompts: ["a | b", "c"], lengths: [24, 36] });
+});
+
+test("sameSegmentContent compares structurally, never through the join", () => {
+  const A = [seg("a | b", 24), seg("c", 36)];
+  const B = [seg("a", 24), seg("b | c", 36)];
+  // Identical derived strings…
+  assert.equal(
+    derivePromptRelayWidgets(A).local_prompts,
+    derivePromptRelayWidgets(B).local_prompts,
+  );
+  // …but not the same content.
+  assert.equal(sameSegmentContent(A, B), false);
+  assert.equal(sameSegmentContent(A, [seg("a | b", 24), seg("c", 36)]), true);
+  // A numeric-string length matches its normalized number; a real change does not.
+  assert.equal(sameSegmentContent([{ prompt: "p", length: "24" }], [{ prompt: "p", length: 24 }]), true);
+  assert.equal(sameSegmentContent([{ prompt: "p", length: 24 }], [{ prompt: "p", length: 25 }]), false);
+  assert.equal(sameSegmentContent(A, A.slice(0, 1)), false);
+  assert.equal(sameSegmentContent(A, null), false);
 });
 
 test("MID-TYPING: a pending debounce commit AFTER our write is a no-op (no rollback)", () => {

--- a/browser_tests/unit/prompt-relay-timeline.test.mjs
+++ b/browser_tests/unit/prompt-relay-timeline.test.mjs
@@ -20,6 +20,7 @@ import {
   parsePromptRelayTimeline,
   derivePromptRelayWidgets,
   sameSegmentContent,
+  recordPreLoadPromptRelayEditors,
   promptRelayDerivedRefusal,
   applyPromptRelayTimelineWrite,
   PromptRelayTimelineWriteError,
@@ -573,48 +574,120 @@ test("POST-LOAD: the timeline_data widget wins over an editor still holding the 
   assert.equal(widgets.segment_lengths.value, "50");
 });
 
-test("POST-LOAD: a stale editor is NOT reported as an overwritten uncommitted edit", () => {
-  // The routine post-load window: onConfigure restores the widgets ~10ms before it re-parses the
-  // editor, so the editor still holds the PREVIOUS workflow. An ordinary metadata-only write
-  // arrives. Case 3 rejects the editor on positive evidence (it could not have produced what the
-  // node executes), so calling its content an overwritten uncommitted edit would cry wolf on a
-  // routine write — and this disclosure is the safety net for the genuine collision case, so it
-  // must not become noise. The content is still returned, just classified honestly.
-  const { node, widgets, editor } = makeRelayNode({ timelineSegments: [seg("restored", 50)] });
-  editor.timeline = { segments: [seg("previous workflow", 99)] };
+/**
+ * Model a real workflow load: the panel's app.loadGraphData fork snapshots what every
+ * PromptRelay editor holds RIGHT NOW (still the previous workflow), then the load restores the
+ * widgets to the new workflow's values. The editor's own re-parse is ~10ms later, so between
+ * those two points it still holds the old timeline.
+ */
+function simulateWorkflowLoad({ node, widgets, editor }, restoredSegments) {
+  recordPreLoadPromptRelayEditors([node]); // the fork, firing before the graph is replaced
+  const timeline = { segments: restoredSegments };
+  widgets.timeline_data.value = JSON.stringify(timeline);
+  const derived = derivePromptRelayWidgets(restoredSegments);
+  widgets.local_prompts.value = derived.local_prompts;
+  widgets.segment_lengths.value = derived.segment_lengths;
+  return { node, widgets, editor };
+}
 
-  const res = relay(applyPromptRelayTimelineWrite(node, { zoom: 4 }));
+test("POST-LOAD: an editor PROVEN to predate the load is not reported as an overwritten edit", () => {
+  // The routine post-load window. The pre-load snapshot proves the editor still holds exactly
+  // what it held before the load — it has not been re-parsed OR typed into — so calling its
+  // content an overwritten uncommitted edit would cry wolf on a routine write, and this
+  // disclosure is the safety net for the genuine collision case.
+  const n = makeRelayNode({ timelineSegments: [seg("previous workflow", 99)] });
+  simulateWorkflowLoad(n, [seg("restored", 50)]);
+
+  const res = relay(applyPromptRelayTimelineWrite(n.node, { zoom: 4 }));
 
   assert.equal(res.merge_base, "timeline_data");
   assert.equal(res.merge_base_reason, "filter-rejected-editor");
-  // NO data-loss claim, and no warning at all — nothing was typed and nothing was lost.
+  // NO data-loss claim, and no warning at all — staleness is PROVEN, not assumed.
   assert.equal(res.overwrote_uncommitted_edit, undefined);
+  assert.equal(res.discarded_unverified_editor_copy, undefined);
   assert.equal(res.warnings, undefined);
   // The payload is still handed back, under a name that says what it actually is.
   assert.deepEqual(res.discarded_stale_editor, { prompts: ["previous workflow"], lengths: [99] });
-  assert.equal(widgets.local_prompts.value, "restored");
-  assert.equal(widgets.segment_lengths.value, "50");
+  assert.equal(n.widgets.local_prompts.value, "restored");
+  assert.equal(n.widgets.segment_lengths.value, "50");
 });
 
 test("POST-LOAD: an explicit segments write does not claim the master was superseded", () => {
   // Case 3 selected the master; replacing its segments is the caller's plain intent, not a copy
   // set aside behind their back.
-  const { node, widgets, editor } = makeRelayNode({ timelineSegments: [seg("restored", 50)] });
-  editor.timeline = { segments: [seg("previous workflow", 99)] };
-  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("caller wrote this", 10)] }));
+  const n = makeRelayNode({ timelineSegments: [seg("previous workflow", 99)] });
+  simulateWorkflowLoad(n, [seg("restored", 50)]);
+  const res = relay(applyPromptRelayTimelineWrite(n.node, { segments: [seg("caller wrote this", 10)] }));
   assert.equal(res.merge_base, "timeline_data");
   assert.equal(res.superseded_timeline_data, undefined);
   assert.equal(res.overwrote_uncommitted_edit, undefined);
   assert.deepEqual(res.discarded_stale_editor, { prompts: ["previous workflow"], lengths: [99] });
-  assert.equal(widgets.local_prompts.value, "caller wrote this");
+  assert.equal(n.widgets.local_prompts.value, "caller wrote this");
 });
 
 test("a stale editor whose content the write happens to reproduce reports nothing", () => {
-  const { node, editor } = makeRelayNode({ timelineSegments: [seg("restored", 50)] });
-  editor.timeline = { segments: [seg("previous workflow", 99)] };
-  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("previous workflow", 99)] }));
+  const n = makeRelayNode({ timelineSegments: [seg("previous workflow", 99)] });
+  simulateWorkflowLoad(n, [seg("restored", 50)]);
+  const res = relay(applyPromptRelayTimelineWrite(n.node, { segments: [seg("previous workflow", 99)] }));
   assert.equal(res.discarded_stale_editor, undefined);
   assert.equal(res.overwrote_uncommitted_edit, undefined);
+  assert.equal(res.discarded_unverified_editor_copy, undefined);
+});
+
+// ─── The filter cannot tell a stale editor from an uncommitted edit; only the load can ───
+
+test("UNCOMMITTED TEXT whose derived widgets were refreshed back to the master is NOT suppressed", () => {
+  // The mirror of the post-load case, and indistinguishable from it by the derived widgets: the
+  // master and both derived widgets describe ["old","b"], while the editor holds text the user
+  // typed. The filter rejects the editor exactly as it does for a stale one — but the pre-load
+  // snapshot does NOT match, so the editor changed after the load and this is a real edit.
+  const n = makeRelayNode({ timelineSegments: [seg("before the load", 24), seg("b", 36)] });
+  simulateWorkflowLoad(n, [seg("old", 24), seg("b", 36)]);
+  // …the load settles, the editor re-parses, the user types, and the derived widgets end up back
+  // at the master's values (a refresh, or a commit that did not survive).
+  n.editor.timeline = { segments: [seg("user typed this", 24), seg("b", 36)] };
+
+  const res = relay(applyPromptRelayTimelineWrite(n.node, { zoom: 4 }));
+
+  assert.equal(res.merge_base_reason, "filter-rejected-editor");
+  // NOT silently dropped: the content comes back AND the caller is warned.
+  assert.equal(res.discarded_stale_editor, undefined);
+  assert.deepEqual(res.discarded_unverified_editor_copy, {
+    prompts: ["user typed this", "b"],
+    lengths: [24, 36],
+  });
+  assert.ok(res.warnings.some((w) => w.includes("could NOT be determined")));
+});
+
+test("with NO load ever observed, a discarded editor copy WARNS (unknown is never treated as safe)", () => {
+  // No pre-load snapshot exists (the fork never ran, or the load recreated the node). Staleness
+  // is unproven, so the fail-safe direction is to warn and return the content.
+  const { node } = makeRelayNode({ timelineSegments: [seg("restored", 50)] });
+  node._timelineEditor.timeline = { segments: [seg("unknown provenance", 99)] };
+  const res = relay(applyPromptRelayTimelineWrite(node, { zoom: 4 }));
+  assert.equal(res.merge_base_reason, "filter-rejected-editor");
+  assert.equal(res.discarded_stale_editor, undefined);
+  assert.deepEqual(res.discarded_unverified_editor_copy, {
+    prompts: ["unknown provenance"],
+    lengths: [99],
+  });
+  assert.ok(res.warnings.some((w) => w.includes("could NOT be determined")));
+});
+
+test("recordPreLoadPromptRelayEditors only touches PromptRelay nodes, and tolerates junk", () => {
+  const { node } = makeRelayNode();
+  const other = { id: 2, type: "KSampler", widgets: [], _timelineEditor: { timeline: { segments: [seg("x", 1)] } } };
+  const noEditor = { id: 3, type: PROMPT_RELAY_TIMELINE_NODE_TYPE, widgets: [] };
+  assert.equal(recordPreLoadPromptRelayEditors([node, other, noEditor]), 2);
+  assert.equal(other.__cmcpPromptRelayPreLoadSegments, undefined);
+  // A PromptRelay node with no live editor records an explicit "nothing was there".
+  assert.equal(noEditor.__cmcpPromptRelayPreLoadSegments, null);
+  assert.deepEqual(node.__cmcpPromptRelayPreLoadSegments, [
+    { prompt: "a", length: 24 },
+    { prompt: "b", length: 36 },
+  ]);
+  assert.equal(recordPreLoadPromptRelayEditors(null), 0);
+  assert.equal(recordPreLoadPromptRelayEditors([null, undefined, 5]), 0);
 });
 
 test("the live editor never has its segment objects aliased into the written timeline", () => {
@@ -911,6 +984,20 @@ test("graph_set_widget's PromptRelay branch exists and is ordered before the gen
   // Must intercept BEFORE the generic raw write, and must not displace the LTXDirector route.
   assert.ok(relayAt < genericAt, "PromptRelay branch must run before runSetWidget");
   assert.ok(ltxAt < relayAt, "the LTXDirector route (#314) must keep its position");
+});
+
+test("the pre-load snapshot is taken inside the app.loadGraphData fork, BEFORE the load runs", () => {
+  // The signal only works if it is recorded before the graph is replaced. Pin both the call and
+  // its position relative to the original loadGraphData, and that it cannot break a load.
+  assert.match(panelSrc, /recordPreLoadPromptRelayEditors,\n\} from "\.\/lib\/prompt-relay-timeline\.js";/);
+  const callAt = panelSrc.indexOf("recordPreLoadPromptRelayEditors(appRef?.graph?._nodes");
+  const origAt = panelSrc.indexOf("return orig(graphData, clean, restoreView, workflow, options);");
+  assert.ok(callAt > 0, "recorder is not called from the loadGraphData fork");
+  assert.ok(origAt > 0);
+  assert.ok(callAt < origAt, "the snapshot must be taken BEFORE the load is delegated");
+  // Wrapped so bookkeeping can never break a graph load.
+  const between = panelSrc.slice(callAt - 400, origAt);
+  assert.ok(/try \{\s*\n\s*recordPreLoadPromptRelayEditors\(/.test(between));
 });
 
 test("graph_set_widget routes master → apply, derived → refusal, everything else → fall through", () => {

--- a/browser_tests/unit/prompt-relay-timeline.test.mjs
+++ b/browser_tests/unit/prompt-relay-timeline.test.mjs
@@ -8,6 +8,8 @@
 // derived writes. These tests drive the REAL shipped lib.
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import {
   PROMPT_RELAY_TIMELINE_NODE_TYPE,
   PROMPT_RELAY_MASTER_WIDGET,
@@ -394,8 +396,15 @@ test("REFUSES a missing/non-string prompt — the node would coerce it to \"\" (
 });
 
 test("REFUSES a length the node would clamp/truncate; accepts every LOSSLESS integer form", () => {
-  // "24.7" is the important one: parseInt TRUNCATES it to 24, silently shortening the segment.
-  for (const bad of [undefined, null, 0, -5, 12.5, "24px", "24.7", "", NaN, Infinity, {}]) {
+  // "24.7"  — parseInt TRUNCATES it to 24, silently shortening the segment.
+  // "2e3"   — parseInt stops at the "e" and yields 2, so a caller meaning 2000 would get 2.
+  //           "24e0" is refused with it: allowing the harmless form would open the lossy one.
+  // 1e21    — String() renders it as "1e+21", which python's int() rejects outright and the
+  //           pack's own parseInt reads back as 1. Anything past MAX_SAFE_INTEGER is refused.
+  for (const bad of [
+    undefined, null, 0, -5, 12.5, "24px", "24.7", "2e3", "24e0", "", NaN, Infinity,
+    1e21, Number.MAX_SAFE_INTEGER + 2, {},
+  ]) {
     const { node, widgets } = makeRelayNode();
     assert.throws(
       () => applyPromptRelayTimelineWrite(node, { segments: [{ prompt: "p", length: bad }] }),
@@ -556,6 +565,77 @@ test("fires NO undo hooks when a refusal happens (no empty undo step)", () => {
     () => applyPromptRelayTimelineWrite(makeRelayNode({ omitWidgets: ["local_prompts"] }).node, { segments: [seg("p")] }, hooks),
   );
   assert.deepEqual(order, []);
+});
+
+// ─── The route is actually WIRED into graph_set_widget ───
+//
+// The lib is only reached through the branch inside graph_set_widget in
+// comfyui-mcp-panel.js. That method references browser/ComfyUI globals, so (following the
+// graph-resize-node.test.mjs convention) the PromptRelay branch is extracted from the REAL
+// panel source and evaluated with injected stubs — a deleted or misordered route fails here
+// rather than shipping a panel that silently falls through to the raw widget write (#506).
+
+// Normalized to LF: the working copy is checked out CRLF on Windows.
+const panelSrc = readFileSync(
+  fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+  "utf8",
+).replace(/\r\n/g, "\n");
+
+const relayBranch = panelSrc.match(
+  /const relayKind = classifyPromptRelayTimelineWrite\(node, widget\);[\s\S]*?\n {6}\}\);\n {4}\}/,
+);
+
+test("graph_set_widget's PromptRelay branch exists and is ordered before the generic write", () => {
+  assert.ok(relayBranch, "PromptRelay branch not found in graph_set_widget");
+  assert.match(panelSrc, /import \{[\s\S]*?\} from "\.\/lib\/prompt-relay-timeline\.js";/);
+  const relayAt = panelSrc.indexOf("const relayKind = classifyPromptRelayTimelineWrite");
+  const genericAt = panelSrc.indexOf("await runSetWidget(node, widget, value");
+  const ltxAt = panelSrc.indexOf("const ltxKind = classifyLtxTimelineWrite");
+  assert.ok(relayAt > 0 && genericAt > 0 && ltxAt > 0);
+  // Must intercept BEFORE the generic raw write, and must not displace the LTXDirector route.
+  assert.ok(relayAt < genericAt, "PromptRelay branch must run before runSetWidget");
+  assert.ok(ltxAt < relayAt, "the LTXDirector route (#314) must keep its position");
+});
+
+test("graph_set_widget routes master → apply, derived → refusal, everything else → fall through", () => {
+  const run = (kind) => {
+    const calls = [];
+    const factory = new Function(
+      "classifyPromptRelayTimelineWrite",
+      "promptRelayDerivedRefusal",
+      "applyPromptRelayTimelineWrite",
+      "node",
+      "widget",
+      "value",
+      "graph",
+      `return () => { ${relayBranch[0]}\n return "fell-through"; };`,
+    );
+    const fn = factory(
+      () => kind,
+      (w, id) => `refused ${w} on ${id}`,
+      (n, v, hooks) => {
+        calls.push({ n: n.id, v, hooks: Object.keys(hooks).sort() });
+        return { applied: true };
+      },
+      { id: 3 },
+      "timeline_data",
+      { segments: [] },
+      { beforeChange() {}, afterChange() {}, setDirtyCanvas() {} },
+    );
+    return { fn, calls };
+  };
+
+  const master = run("master");
+  assert.deepEqual(master.fn(), { applied: true });
+  assert.deepEqual(master.calls[0].hooks, ["afterChange", "beforeChange", "setDirty"]);
+
+  const derived = run("derived");
+  assert.throws(() => derived.fn(), /refused timeline_data on 3/);
+  assert.equal(derived.calls.length, 0);
+
+  const other = run(null);
+  assert.equal(other.fn(), "fell-through");
+  assert.equal(other.calls.length, 0);
 });
 
 test("honors an injected getEditor", () => {

--- a/browser_tests/unit/prompt-relay-timeline.test.mjs
+++ b/browser_tests/unit/prompt-relay-timeline.test.mjs
@@ -345,6 +345,48 @@ test("MID-TYPING: a write that PRESERVES the in-flight text reports no overwrite
   assert.equal(widgets.local_prompts.value, "user was typing this | b");
 });
 
+test("MID-TYPING with a REALISTIC partial editor: fields the editor does not model are NOT dropped", () => {
+  // The shipped editor's parser retains ONLY prompt/length/color per segment and nothing
+  // top-level, so a real editor's this.timeline is NOT a full copy of timeline_data. Merging
+  // FROM it would silently drop every field the parser does not model — the fixture never
+  // caught that because it seeds the editor with the COMPLETE timeline. This seeds it the way
+  // the pack's parser actually leaves it, then proves the merge loses nothing.
+  const { node, widgets, editor } = makeRelayNode({
+    timelineSegments: [
+      seg("a", 24, { legacyMeta: "keep-0" }),
+      seg("b", 36, { legacyMeta: "keep-1" }),
+    ],
+    extraTimelineFields: { zoom: 3, note: "keep me" },
+  });
+  editor.timeline = {
+    segments: JSON.parse(widgets.timeline_data.value).segments.map(({ prompt, length, color }) => ({
+      prompt,
+      length,
+      color,
+    })),
+  };
+  // Mid-typing: the user edits segment 0; local_prompts updates immediately, timeline_data lags.
+  editor.timeline.segments[0].prompt = "typed just now";
+  widgets.local_prompts.value = derivePromptRelayWidgets(editor.timeline.segments).local_prompts;
+
+  const res = relay(applyPromptRelayTimelineWrite(node, { fps: 24 }));
+
+  assert.equal(res.merge_base, "editor");
+  const written = JSON.parse(widgets.timeline_data.value);
+  // Unmentioned TOP-LEVEL fields survive from the persisted widget, and the overlay applied.
+  assert.equal(written.zoom, 3);
+  assert.equal(written.note, "keep me");
+  assert.equal(written.fps, 24);
+  // The editor's typed text wins — it is authoritative mid-typing…
+  assert.deepEqual(written.segments.map((s) => s.prompt), ["typed just now", "b"]);
+  // …while PER-SEGMENT fields the editor does not model survive by index.
+  assert.equal(written.segments[0].legacyMeta, "keep-0");
+  assert.equal(written.segments[1].legacyMeta, "keep-1");
+  // The in-flight text is current, not a loss — no bogus disclosures.
+  assert.equal(res.overwrote_uncommitted_edit, undefined);
+  assert.equal(res.replaced_out_of_band, undefined);
+});
+
 test("a normal (non-debounce) write never reports overwrote_uncommitted_edit", () => {
   const { node } = makeRelayNode();
   const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("totally different", 3)] }));
@@ -442,13 +484,16 @@ test("PIPE COLLISION: a length-only change is disclosed despite identical prompt
   assert.deepEqual(res.overwrote_uncommitted_edit, { prompts: ["a | b", "c"], lengths: [24, 36] });
 });
 
-test("PIPE COLLISION: a metadata-only overlay must NOT rebuild from a stale master", () => {
-  // The join cannot decide AUTHORITY either. Persisted timeline_data + widgets are
+test("PIPE COLLISION: a metadata-only overlay on an unresolvable tie FAILS CLOSED", () => {
+  // The join cannot decide AUTHORITY. Persisted timeline_data + widgets are
   // ["a", "b | c"] / [24, 36]. Within one debounce interval the user edits BOTH prompt boxes,
   // leaving the live editor at ["a | b", "c"] with the same lengths — which derives the SAME
   // "a | b | c" and "24, 36", so the stale master still looks perfectly consistent. A caller
-  // then writes a metadata-only overlay that asks for no segment change at all. Choosing the
-  // master on join equality would rebuild the node from ["a", "b | c"] and destroy the edit.
+  // then writes a metadata-only overlay that asks for no segment change at all. Neither copy
+  // is provably current, so the write must REFUSE: guessing the editor could destroy the
+  // persisted timeline (the post-load wrong-workflow loss), guessing the master could destroy
+  // the in-flight edit — and a refusal mutates NOTHING, so both survive and the caller can
+  // retry once the debounce settles, or supply the segments outright.
   const { node, widgets, editor } = makeRelayNode({
     timelineSegments: [seg("a", 24), seg("b | c", 36)],
   });
@@ -464,31 +509,51 @@ test("PIPE COLLISION: a metadata-only overlay must NOT rebuild from a stale mast
     widgets.segment_lengths.value,
   );
 
-  const res = relay(applyPromptRelayTimelineWrite(node, { zoom: 4 }));
-
-  // The live edit SURVIVES — the whole point.
-  assert.deepEqual(JSON.parse(widgets.timeline_data.value).segments.map((s) => s.prompt), ["a | b", "c"]);
-  assert.deepEqual(editor.timeline.segments.map((s) => s.prompt), ["a | b", "c"]);
-  assert.equal(JSON.parse(widgets.timeline_data.value).zoom, 4);
-  // Nothing was overwritten, and the tie is declared rather than resolved silently.
-  assert.equal(res.merge_base, "editor");
-  assert.equal(res.merge_base_ambiguous, true);
-  assert.equal(res.overwrote_uncommitted_edit, undefined);
-  assert.deepEqual(res.superseded_timeline_data, { prompts: ["a", "b | c"], lengths: [24, 36] });
-  assert.ok(res.warnings.some((w) => w.includes("could not tell which is current")));
-  // The derived join is unchanged by all of this — proof it could never have detected the case.
+  const timelineBefore = widgets.timeline_data.value;
+  const order = [];
+  assert.throws(
+    () =>
+      applyPromptRelayTimelineWrite(node, { zoom: 4 }, {
+        beforeChange: () => order.push("before"),
+        afterChange: () => order.push("after"),
+        setDirty: () => order.push("dirty"),
+      }),
+    (err) => {
+      assert.ok(err instanceof PromptRelayTimelineWriteError);
+      assert.match(err.message, /CANNOT tell which is current/);
+      // Both copies are handed back PER SEGMENT, so the caller can resolve the tie explicitly.
+      assert.ok(err.message.includes('"a | b","c"'), "editor copy missing from the refusal");
+      assert.ok(err.message.includes('"a","b | c"'), "timeline_data copy missing from the refusal");
+      return true;
+    },
+  );
+  // NOTHING was mutated — not the widgets, not the editor, not the undo history. The live
+  // edit SURVIVES precisely because nothing was written over it.
+  assert.equal(widgets.timeline_data.value, timelineBefore);
   assert.equal(widgets.local_prompts.value, "a | b | c");
+  assert.deepEqual(editor.timeline.segments.map((s) => s.prompt), ["a | b", "c"]);
+  assert.deepEqual(order, []);
 });
 
 test("an unresolvable tie is flagged; an ordinary write is not", () => {
   // Neither record matches the derived widgets (a genuinely desynced node) and they differ
-  // structurally: still unresolvable, so the live editor wins and the tie is flagged.
+  // structurally: unresolvable. Explicit segments replace BOTH records outright, so the write
+  // may proceed — declared ambiguous, merging onto the PERSISTED record for everything else,
+  // with the set-aside editor copy handed back rather than written.
   const { node, widgets } = makeRelayNode({ localPrompts: "hand written | text" });
   widgets.timeline_data.value = JSON.stringify({ segments: [seg("master only", 24)] });
-  const tied = relay(applyPromptRelayTimelineWrite(node, { zoom: 1 }));
-  assert.equal(tied.merge_base, "editor");
+  const tied = relay(
+    applyPromptRelayTimelineWrite(node, { segments: [seg("caller decides", 5)] }),
+  );
+  assert.equal(tied.merge_base, "timeline_data");
+  assert.equal(tied.merge_base_reason, "unresolved-tie");
   assert.equal(tied.merge_base_ambiguous, true);
-  assert.deepEqual(tied.replaced_out_of_band, { local_prompts: "hand written | text" });
+  // The out-of-band derived text is still reported before being replaced…
+  assert.equal(tied.replaced_out_of_band.local_prompts, "hand written | text");
+  // …and the ambiguous editor copy is disclosed per segment, never written back.
+  assert.deepEqual(tied.discarded_unverified_editor_copy, { prompts: ["a", "b"], lengths: [24, 36] });
+  assert.ok(tied.warnings.some((w) => w.includes("could not tell which was current")));
+  assert.equal(widgets.local_prompts.value, "caller decides");
 
   // A node whose two records agree has no tie to declare.
   const plain = relay(applyPromptRelayTimelineWrite(makeRelayNode().node, { segments: [seg("x", 3)] }));
@@ -634,6 +699,74 @@ test("a stale editor whose content the write happens to reproduce reports nothin
   assert.equal(res.discarded_unverified_editor_copy, undefined);
 });
 
+test("POST-LOAD TIE: a stale editor colliding on BOTH joins fails CLOSED — the restored workflow is never overwritten", () => {
+  // The review's wrong-workflow loss. The load restores ["x | y", "z"] / [50, 10], but the
+  // editor still holds the PREVIOUS workflow's ["x", "y | z"] / [50, 10] — structurally
+  // different, yet byte-identical local_prompts AND segment_lengths, so the derived widgets
+  // cannot separate the two copies. Choosing the editor (the old tie behaviour) wrote the OLD
+  // workflow's timeline back over the restored one and still reported success. A tie must
+  // REFUSE instead: nothing is written, and both copies come back in the error.
+  const n = makeRelayNode({ timelineSegments: [seg("x", 50), seg("y | z", 10)] });
+  simulateWorkflowLoad(n, [seg("x | y", 50), seg("z", 10)]);
+  // The collision is exact — the filter genuinely cannot tell the copies apart.
+  assert.equal(n.widgets.local_prompts.value, "x | y | z");
+  assert.equal(
+    derivePromptRelayWidgets(n.editor.timeline.segments).local_prompts,
+    n.widgets.local_prompts.value,
+  );
+  assert.equal(
+    derivePromptRelayWidgets(n.editor.timeline.segments).segment_lengths,
+    n.widgets.segment_lengths.value,
+  );
+
+  const timelineBefore = n.widgets.timeline_data.value;
+  assert.throws(
+    () => applyPromptRelayTimelineWrite(n.node, { zoom: 4 }),
+    (err) => {
+      assert.ok(err instanceof PromptRelayTimelineWriteError);
+      assert.match(err.message, /CANNOT tell which is current/);
+      assert.ok(err.message.includes('"x","y | z"'), "old-workflow editor copy missing from the refusal");
+      assert.ok(err.message.includes('"x | y","z"'), "restored-workflow copy missing from the refusal");
+      return true;
+    },
+  );
+  // NOTHING was written: the restored workflow's timeline survives byte-for-byte, and the old
+  // workflow's editor copy is left alone too — the caller resolves the tie explicitly.
+  assert.equal(n.widgets.timeline_data.value, timelineBefore);
+  assert.equal(n.widgets.local_prompts.value, "x | y | z");
+  assert.equal(n.widgets.segment_lengths.value, "50, 10");
+  assert.deepEqual(n.editor.timeline.segments.map((s) => s.prompt), ["x", "y | z"]);
+});
+
+test("TIE with explicit segments: the caller's list replaces BOTH copies — no ambiguous data is written", () => {
+  // The same unresolvable collision, but the write supplies the segment list outright — the one
+  // resolution that cannot resurrect ambiguous data: the segments come from the caller, and
+  // everything else from the PERSISTED widget (never the editor copy, whose unmodeled
+  // top-level fields — the old workflow's zoom here — belong to the previous workflow).
+  const { node, widgets, editor } = makeRelayNode({
+    timelineSegments: [seg("x | y", 50), seg("z", 10)],
+    extraTimelineFields: { zoom: 3 },
+  });
+  // The editor still holds the PREVIOUS workflow, colliding on both derived joins.
+  editor.timeline = { zoom: 9, segments: [seg("x", 50), seg("y | z", 10)] };
+
+  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("caller decides", 7)] }));
+
+  assert.equal(res.reconciled, true);
+  assert.equal(res.merge_base, "timeline_data");
+  assert.equal(res.merge_base_reason, "unresolved-tie");
+  assert.equal(res.merge_base_ambiguous, true);
+  const written = JSON.parse(widgets.timeline_data.value);
+  assert.deepEqual(written.segments.map((s) => s.prompt), ["caller decides"]);
+  // The persisted record's fields — never the ambiguous editor copy's.
+  assert.equal(written.zoom, 3);
+  assert.equal(widgets.local_prompts.value, "caller decides");
+  // The set-aside editor copy is disclosed per segment, with warnings — not silently kept.
+  assert.deepEqual(res.discarded_unverified_editor_copy, { prompts: ["x", "y | z"], lengths: [50, 10] });
+  assert.ok(res.warnings.some((w) => w.includes("could not tell which was current")));
+  assert.ok(res.warnings.some((w) => w.includes("could NOT be determined")));
+});
+
 // ─── The filter cannot tell a stale editor from an uncommitted edit; only the load can ───
 
 test("UNCOMMITTED TEXT whose derived widgets were refreshed back to the master is NOT suppressed", () => {
@@ -678,16 +811,97 @@ test("recordPreLoadPromptRelayEditors only touches PromptRelay nodes, and tolera
   const { node } = makeRelayNode();
   const other = { id: 2, type: "KSampler", widgets: [], _timelineEditor: { timeline: { segments: [seg("x", 1)] } } };
   const noEditor = { id: 3, type: PROMPT_RELAY_TIMELINE_NODE_TYPE, widgets: [] };
-  assert.equal(recordPreLoadPromptRelayEditors([node, other, noEditor]), 2);
+  assert.equal(recordPreLoadPromptRelayEditors([node, other, noEditor], { now: () => 1000 }), 2);
   assert.equal(other.__cmcpPromptRelayPreLoadSegments, undefined);
   // A PromptRelay node with no live editor records an explicit "nothing was there".
-  assert.equal(noEditor.__cmcpPromptRelayPreLoadSegments, null);
-  assert.deepEqual(node.__cmcpPromptRelayPreLoadSegments, [
+  assert.deepEqual(noEditor.__cmcpPromptRelayPreLoadSegments, { at: 1000, segments: null });
+  assert.deepEqual(node.__cmcpPromptRelayPreLoadSegments, {
+    at: 1000,
+    segments: [
+      { prompt: "a", length: 24 },
+      { prompt: "b", length: 36 },
+    ],
+  });
+  assert.equal(recordPreLoadPromptRelayEditors(null), 0);
+  assert.equal(recordPreLoadPromptRelayEditors([null, undefined, 5]), 0);
+});
+
+test("recordPreLoadPromptRelayEditors descends into subgraphs and survives a cycle", () => {
+  // A write can target a node inside the viewed subgraph, so those editors need the signal too —
+  // otherwise every routine post-load write on them would warn.
+  const inner = makeRelayNode({ id: 9 }).node;
+  const container = { id: 1, type: "Subgraph", widgets: [], subgraph: { _nodes: [inner] } };
+  // A cycle: the subgraph lists a node whose own subgraph points back at the container.
+  const looper = { id: 2, type: "Subgraph", widgets: [], subgraph: { _nodes: [container] } };
+  container.subgraph._nodes.push(looper);
+  assert.equal(recordPreLoadPromptRelayEditors([container], { now: () => 5 }), 1);
+  assert.deepEqual(inner.__cmcpPromptRelayPreLoadSegments.segments, [
     { prompt: "a", length: 24 },
     { prompt: "b", length: 36 },
   ]);
-  assert.equal(recordPreLoadPromptRelayEditors(null), 0);
-  assert.equal(recordPreLoadPromptRelayEditors([null, undefined, 5]), 0);
+});
+
+test("a nested PromptRelay node gets the quiet post-load path, not a spurious warning", () => {
+  const n = makeRelayNode({ id: 9, timelineSegments: [seg("previous workflow", 99)] });
+  const container = { id: 1, type: "Subgraph", widgets: [], subgraph: { _nodes: [n.node] } };
+  recordPreLoadPromptRelayEditors([container], { now: () => 0 });
+  const timeline = { segments: [seg("restored", 50)] };
+  n.widgets.timeline_data.value = JSON.stringify(timeline);
+  const d = derivePromptRelayWidgets(timeline.segments);
+  n.widgets.local_prompts.value = d.local_prompts;
+  n.widgets.segment_lengths.value = d.segment_lengths;
+
+  const res = relay(applyPromptRelayTimelineWrite(n.node, { zoom: 4 }, { now: () => 10 }));
+  assert.deepEqual(res.discarded_stale_editor, { prompts: ["previous workflow"], lengths: [99] });
+  assert.equal(res.warnings, undefined);
+});
+
+// ─── Content equality alone is not proof of history ───
+
+test("RETYPING the exact pre-load text after the re-parse is NOT quietly discarded", () => {
+  // The collision the snapshot cannot see on its own: the editor's content equals the pre-load
+  // content, but only because the user re-authored it long after the load's re-parse. Time is
+  // what separates the two — nobody retypes a timeline within the re-parse window.
+  const n = makeRelayNode({ timelineSegments: [seg("the same text", 24)] });
+  recordPreLoadPromptRelayEditors([n.node], { now: () => 0 });
+  const timeline = { segments: [seg("restored", 50)] };
+  n.widgets.timeline_data.value = JSON.stringify(timeline);
+  const d = derivePromptRelayWidgets(timeline.segments);
+  n.widgets.local_prompts.value = d.local_prompts;
+  n.widgets.segment_lengths.value = d.segment_lengths;
+  // …the load settles, the editor re-parses, and the user types the old text back in.
+  n.editor.timeline = { segments: [seg("the same text", 24)] };
+
+  const res = relay(applyPromptRelayTimelineWrite(n.node, { zoom: 4 }, { now: () => 60_000 }));
+  assert.equal(res.discarded_stale_editor, undefined);
+  assert.deepEqual(res.discarded_unverified_editor_copy, {
+    prompts: ["the same text"],
+    lengths: [24],
+  });
+  assert.ok(res.warnings.some((w) => w.includes("could NOT be determined")));
+});
+
+test("the stale window is bounded, and a stale clock never proves staleness", () => {
+  const build = () => {
+    const n = makeRelayNode({ timelineSegments: [seg("previous workflow", 99)] });
+    recordPreLoadPromptRelayEditors([n.node], { now: () => 1_000 });
+    const timeline = { segments: [seg("restored", 50)] };
+    n.widgets.timeline_data.value = JSON.stringify(timeline);
+    const d = derivePromptRelayWidgets(timeline.segments);
+    n.widgets.local_prompts.value = d.local_prompts;
+    n.widgets.segment_lengths.value = d.segment_lengths;
+    return n;
+  };
+  const at = (t) => relay(applyPromptRelayTimelineWrite(build().node, { zoom: 4 }, { now: () => t }));
+  // Inside the re-parse window: proven stale, quiet.
+  assert.ok(at(1_000).discarded_stale_editor);
+  assert.ok(at(1_250).discarded_stale_editor);
+  // Outside it: the editor has certainly re-parsed, so equal content means re-authored → warn.
+  assert.equal(at(1_251).discarded_stale_editor, undefined);
+  assert.ok(at(1_251).discarded_unverified_editor_copy);
+  // A clock that went backwards proves nothing.
+  assert.equal(at(999).discarded_stale_editor, undefined);
+  assert.ok(at(999).discarded_unverified_editor_copy);
 });
 
 test("the live editor never has its segment objects aliased into the written timeline", () => {

--- a/browser_tests/unit/prompt-relay-timeline.test.mjs
+++ b/browser_tests/unit/prompt-relay-timeline.test.mjs
@@ -265,6 +265,35 @@ test("an unreadable current timeline_data still merges from the LIVE editor", ()
   assert.equal(JSON.parse(widgets.timeline_data.value).zoom, 2);
 });
 
+test("CORRUPT MASTER: discarding the editor copy is disclosed when timeline_data is unreadable", () => {
+  // With timeline_data unreadable the editor holds the ONLY record of that content, so a write
+  // that does not reproduce it must hand it back — there is no second copy to recover it from.
+  const { node, widgets } = makeRelayNode();
+  widgets.timeline_data.value = "corrupt {{{";
+  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("replacement", 11)] }));
+  assert.equal(res.merge_base, "editor");
+  assert.deepEqual(res.overwrote_uncommitted_edit, { prompts: ["a", "b"], lengths: [24, 36] });
+  assert.ok(res.warnings.some((w) => w.includes("UNCOMMITTED timeline edit")));
+  // Nothing to supersede: there was no readable timeline_data copy.
+  assert.equal(res.superseded_timeline_data, undefined);
+});
+
+test("CORRUPT MASTER: a write that reproduces the editor copy stays quiet", () => {
+  const { node, widgets } = makeRelayNode();
+  widgets.timeline_data.value = "corrupt {{{";
+  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("a", 24), seg("b", 36)] }));
+  assert.equal(res.overwrote_uncommitted_edit, undefined);
+});
+
+test("HEADLESS: an ordinary write with no editor never fires an overwrite disclosure", () => {
+  // Not an anomaly — the widget is the single normal record and the caller read it.
+  const { node } = makeRelayNode({ withEditor: false });
+  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("brand new", 5)] }));
+  assert.equal(res.overwrote_uncommitted_edit, undefined);
+  assert.equal(res.superseded_timeline_data, undefined);
+  assert.equal(res.warnings, undefined);
+});
+
 // ─── The merge base: whichever copy of the timeline is actually current ───
 
 test("MID-TYPING: the live editor wins over a timeline_data widget lagging by the 120ms debounce", () => {
@@ -428,6 +457,12 @@ test("sameSegmentContent compares structurally, never through the join", () => {
   assert.equal(sameSegmentContent([{ prompt: "p", length: 24 }], [{ prompt: "p", length: 25 }]), false);
   assert.equal(sameSegmentContent(A, A.slice(0, 1)), false);
   assert.equal(sameSegmentContent(A, null), false);
+  // Lengths are NOT compared by stringifying — that would make null equal "null".
+  assert.equal(sameSegmentContent([{ prompt: "p", length: null }], [{ prompt: "p", length: "null" }]), false);
+  assert.equal(sameSegmentContent([{ prompt: "p", length: NaN }], [{ prompt: "p", length: 24 }]), false);
+  assert.equal(sameSegmentContent([{ prompt: "p" }], [{ prompt: "p" }]), true);
+  // Prompts are compared strictly — no coercion, and an empty prompt is distinct from absent.
+  assert.equal(sameSegmentContent([{ prompt: "", length: 1 }], [{ length: 1 }]), false);
 });
 
 test("MID-TYPING: a pending debounce commit AFTER our write is a no-op (no rollback)", () => {

--- a/browser_tests/unit/prompt-relay-timeline.test.mjs
+++ b/browser_tests/unit/prompt-relay-timeline.test.mjs
@@ -318,21 +318,54 @@ test("MID-TYPING: the live editor wins over a timeline_data widget lagging by th
   assert.equal(res.replaced_out_of_band, undefined);
 });
 
-test("MID-TYPING: an explicit segments write that DISCARDS in-flight text says so", () => {
-  // Replacing `segments` is the caller's stated intent, so it is applied — but the prompt text
-  // the user had typed and not yet committed is handed back rather than vanishing silently.
+test("MID-TYPING: an explicit segments write that would DISCARD in-flight text FAILS CLOSED", () => {
+  // The review finding: a push with explicit segments landing inside the 120 ms debounce
+  // DETECTED the newer editor text (the filter makes the editor authoritative), then reported
+  // success anyway and overwrote every widget AND the editor — the user's in-progress edit
+  // survived only as a result-envelope disclosure. Silent loss is the bug; a loud conflict is
+  // the contract. No non-guessing merge of two conflicting segment lists exists, so the write
+  // is REFUSED with both states disclosed per segment and NOTHING mutated.
   const { node, widgets, editor } = makeRelayNode();
   editor.timeline.segments[0].prompt = "user was typing this";
   widgets.local_prompts.value = derivePromptRelayWidgets(editor.timeline.segments).local_prompts;
+  const timelineBefore = widgets.timeline_data.value;
+  const editorTimelineBefore = editor.timeline;
 
+  const order = [];
+  assert.throws(
+    () =>
+      applyPromptRelayTimelineWrite(node, { segments: [seg("agent set", 20)] }, {
+        beforeChange: () => order.push("before"),
+        afterChange: () => order.push("after"),
+        setDirty: () => order.push("dirty"),
+      }),
+    (err) => {
+      assert.ok(err instanceof PromptRelayTimelineWriteError);
+      assert.match(err.message, /UNCOMMITTED timeline edit/);
+      // BOTH states are disclosed PER SEGMENT — the in-flight edit and the supplied segments.
+      assert.ok(
+        err.message.includes('"user was typing this","b"'),
+        "editor copy missing from the refusal",
+      );
+      assert.ok(err.message.includes('"agent set"'), "supplied segments missing from the refusal");
+      return true;
+    },
+  );
+  // ZERO mutation — not the widgets, not the editor, not the undo history. The edit SURVIVES.
+  assert.equal(widgets.timeline_data.value, timelineBefore);
+  assert.equal(widgets.local_prompts.value, "user was typing this | b");
+  assert.equal(widgets.segment_lengths.value, "24, 36");
+  assert.equal(editor.timeline, editorTimelineBefore);
+  assert.deepEqual(editor.timeline.segments.map((s) => s.prompt), ["user was typing this", "b"]);
+  assert.deepEqual(order, []);
+
+  // The remedy the refusal documents: once the debounce has settled (the editor's commit has
+  // reached timeline_data, so the node's two records agree), the very same write succeeds as
+  // an ordinary one — no livelock.
+  widgets.timeline_data.value = JSON.stringify(editor.timeline);
   const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("agent set", 20)] }));
-  assert.equal(res.merge_base, "editor");
-  // Handed back PER SEGMENT, not as the lossy join, so the caller can actually restore it.
-  assert.deepEqual(res.overwrote_uncommitted_edit, {
-    prompts: ["user was typing this", "b"],
-    lengths: [24, 36],
-  });
-  assert.ok(res.warnings.some((w) => w.includes("UNCOMMITTED timeline edit")));
+  assert.equal(res.reconciled, true);
+  assert.equal(res.overwrote_uncommitted_edit, undefined);
   assert.equal(widgets.local_prompts.value, "agent set");
 });
 
@@ -413,41 +446,85 @@ test("a PERSISTED #506 stale-master state discloses the timeline_data prompts it
   assert.equal(editor.timeline.zoom, 4);
 });
 
-test("a write that reproduces the timeline_data prompts reports no supersede", () => {
+test("a write reproducing timeline_data while the editor holds the current text FAILS CLOSED — then converges", () => {
+  // The persisted #506 state: a raw write put "wanted" into timeline_data but it never reached
+  // the editor, so the editor still holds (and the node still executes) "a | b". Re-asserting
+  // the master's prompts through this route would DISCARD the text the node would run right
+  // now — structurally identical to a mid-debounce edit, so the same fail-closed rule applies:
+  // the filter cannot tell "editor holds an in-flight edit" from "master holds an out-of-band
+  // raw write", and unknown is never treated as safe. The documented remedy then converges the
+  // node deterministically: first write the editor's disclosed segments verbatim (nothing is
+  // discarded, so it applies), after which the intended write is an ordinary one.
   const { node, widgets } = makeRelayNode();
   widgets.timeline_data.value = JSON.stringify({ segments: [seg("wanted", 24)] });
+  const timelineBefore = widgets.timeline_data.value;
+
+  assert.throws(
+    () => applyPromptRelayTimelineWrite(node, { segments: [seg("wanted", 24)] }),
+    (err) => {
+      assert.ok(err instanceof PromptRelayTimelineWriteError);
+      assert.match(err.message, /UNCOMMITTED timeline edit/);
+      assert.ok(err.message.includes('"a","b"'), "editor copy missing from the refusal");
+      assert.ok(err.message.includes('"wanted"'), "supplied segments missing from the refusal");
+      return true;
+    },
+  );
+  // Nothing moved: the master still holds the raw write, the editor still holds what executes.
+  assert.equal(widgets.timeline_data.value, timelineBefore);
+  assert.equal(widgets.local_prompts.value, "a | b");
+
+  // Remedy, step 1: converge the node's two records onto the editor's current text. The write
+  // reproduces the editor's segments, so nothing is discarded and it applies — disclosing the
+  // out-of-band master copy it sets aside.
+  const converge = relay(
+    applyPromptRelayTimelineWrite(node, { segments: [seg("a", 24), seg("b", 36)] }),
+  );
+  assert.equal(converge.reconciled, true);
+  assert.deepEqual(converge.superseded_timeline_data, { prompts: ["wanted"], lengths: [24] });
+  // Remedy, step 2: with the records agreeing, the intended write is ordinary — no conflict,
+  // no disclosures.
   const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("wanted", 24)] }));
+  assert.equal(res.merge_base, "timeline_data");
   assert.equal(res.superseded_timeline_data, undefined);
-  // The editor's own copy IS discarded by this write, and that is still disclosed.
-  assert.deepEqual(res.overwrote_uncommitted_edit, { prompts: ["a", "b"], lengths: [24, 36] });
+  assert.equal(res.overwrote_uncommitted_edit, undefined);
   assert.equal(widgets.local_prompts.value, "wanted");
 });
 
 // ─── The lossy " | " join must never gate a data-loss disclosure ───
 
-test("PIPE COLLISION: an overwrite is disclosed even when the joined local_prompts is IDENTICAL", () => {
+test("PIPE COLLISION: an overwrite is REFUSED even when the joined local_prompts is IDENTICAL", () => {
   // The exact hazard the join hides. Persisted timeline is ["old", "c"]. During the 120ms
   // debounce the user types segment 0 as the perfectly valid prompt "a | b", so the live editor
   // holds ["a | b", "c"] and local_prompts is already "a | b | c". An incoming write supplies
   // ["a", "b | c"] with the same lengths — a COMPLETELY different segmentation that joins to the
-  // SAME string. Gating on the join would report a clean success while the user's single
-  // authored prompt "a | b" was silently split into two different segment prompts.
+  // SAME string. The detection is STRUCTURAL, never the join: the editor is provably current
+  // and the supplied segments do not reproduce it, so the write is REFUSED and the user's
+  // single authored prompt "a | b" is not silently split into two different segment prompts.
   const { node, widgets, editor } = makeRelayNode({
     timelineSegments: [seg("old", 24), seg("c", 36)],
   });
   editor.timeline.segments[0].prompt = "a | b";
   widgets.local_prompts.value = "a | b | c";
   widgets.segment_lengths.value = "24, 36";
+  const timelineBefore = widgets.timeline_data.value;
 
-  const res = relay(
-    applyPromptRelayTimelineWrite(node, { segments: [seg("a", 24), seg("b | c", 36)] }),
+  assert.throws(
+    () => applyPromptRelayTimelineWrite(node, { segments: [seg("a", 24), seg("b | c", 36)] }),
+    (err) => {
+      assert.ok(err instanceof PromptRelayTimelineWriteError);
+      assert.match(err.message, /UNCOMMITTED timeline edit/);
+      // Same join on both sides — the ONLY thing that distinguishes them is the segment
+      // structure, and BOTH structures are disclosed per segment.
+      assert.ok(err.message.includes('"a | b","c"'), "editor copy missing from the refusal");
+      assert.ok(err.message.includes('"a","b | c"'), "supplied segments missing from the refusal");
+      return true;
+    },
   );
-
-  // Same join on both sides — the ONLY thing that distinguishes them is the segment structure.
-  assert.equal(res.local_prompts, "a | b | c");
-  assert.equal(derivePromptRelayWidgets(editor.timeline.segments).local_prompts, res.local_prompts);
-  assert.deepEqual(res.overwrote_uncommitted_edit, { prompts: ["a | b", "c"], lengths: [24, 36] });
-  assert.ok(res.warnings.some((w) => w.includes("UNCOMMITTED timeline edit")));
+  // Nothing mutated: the in-flight edit survives byte-for-byte.
+  assert.equal(widgets.timeline_data.value, timelineBefore);
+  assert.equal(widgets.local_prompts.value, "a | b | c");
+  assert.equal(widgets.segment_lengths.value, "24, 36");
+  assert.deepEqual(editor.timeline.segments.map((s) => s.prompt), ["a | b", "c"]);
 });
 
 test("PIPE COLLISION mirror: genuinely identical segments report NO overwrite", () => {
@@ -469,19 +546,32 @@ test("PIPE COLLISION mirror: genuinely identical segments report NO overwrite", 
   assert.deepEqual(res.superseded_timeline_data, { prompts: ["old", "c"], lengths: [24, 36] });
 });
 
-test("PIPE COLLISION: a length-only change is disclosed despite identical prompt joins", () => {
+test("PIPE COLLISION: a length-only change to in-flight text is REFUSED despite identical prompt joins", () => {
+  // Reproducing the in-flight PROMPTS is not reproducing the in-flight CONTENT: the supplied
+  // segments change the user's first segment from 24 to 90 frames, so the write still discards
+  // the editor's current content and fails closed.
   const { node, widgets, editor } = makeRelayNode({
     timelineSegments: [seg("old", 24), seg("c", 36)],
   });
   editor.timeline.segments[0].prompt = "a | b";
   widgets.local_prompts.value = "a | b | c";
   widgets.segment_lengths.value = "24, 36";
+  const timelineBefore = widgets.timeline_data.value;
 
-  const res = relay(
-    applyPromptRelayTimelineWrite(node, { segments: [seg("a | b", 90), seg("c", 36)] }),
+  assert.throws(
+    () => applyPromptRelayTimelineWrite(node, { segments: [seg("a | b", 90), seg("c", 36)] }),
+    (err) => {
+      assert.ok(err instanceof PromptRelayTimelineWriteError);
+      assert.match(err.message, /UNCOMMITTED timeline edit/);
+      // Prompts match on both sides; the LENGTHS are what conflicts — and both lists disclose them.
+      assert.ok(err.message.includes('"a | b","c"'));
+      assert.ok(err.message.includes("(lengths [24,36])"), "editor lengths missing from the refusal");
+      assert.ok(err.message.includes("(lengths [90,36])"), "supplied lengths missing from the refusal");
+      return true;
+    },
   );
-  assert.equal(res.local_prompts, "a | b | c");
-  assert.deepEqual(res.overwrote_uncommitted_edit, { prompts: ["a | b", "c"], lengths: [24, 36] });
+  assert.equal(widgets.timeline_data.value, timelineBefore);
+  assert.deepEqual(editor.timeline.segments.map((s) => s.length), [24, 36]);
 });
 
 test("PIPE COLLISION: a metadata-only overlay on an unresolvable tie FAILS CLOSED", () => {
@@ -595,18 +685,31 @@ test("sameSegmentContent compares structurally, never through the join", () => {
   assert.equal(sameSegmentContent([{ prompt: "", length: 1 }], [{ length: 1 }]), false);
 });
 
-test("MID-TYPING: a pending debounce commit AFTER our write is a no-op (no rollback)", () => {
+test("MID-TYPING: after a REFUSED push, the editor's pending debounce commit lands normally", () => {
+  // The old contract applied the push and re-hydrated the editor so its pending commit became
+  // a no-op — at the cost of the in-flight text. The new contract refuses the push, so the
+  // pending commit is not a no-op: it is the whole point. The user's text commits to
+  // timeline_data exactly as if the push had never arrived.
   const { node, widgets, editor } = makeRelayNode();
   editor.timeline.segments[0].prompt = "in flight";
   widgets.local_prompts.value = derivePromptRelayWidgets(editor.timeline.segments).local_prompts;
-  applyPromptRelayTimelineWrite(node, { segments: [seg("agent set", 20)] });
-  // Replay the pack's commit() → syncWidgetsFromTimeline against the re-hydrated editor.
-  const before = { ...widgets.timeline_data, ...widgets.local_prompts };
-  const segs = editor.timeline.segments;
-  assert.equal(JSON.stringify(editor.timeline), widgets.timeline_data.value);
-  assert.equal(segs.map((s) => s.prompt).join(" | "), widgets.local_prompts.value);
-  assert.equal(segs.map((s) => s.length).join(", "), widgets.segment_lengths.value);
-  assert.ok(before);
+  assert.throws(
+    () => applyPromptRelayTimelineWrite(node, { segments: [seg("agent set", 20)] }),
+    PromptRelayTimelineWriteError,
+  );
+  // Replay the pack's commit() → syncWidgetsFromTimeline against the UNTOUCHED editor: the
+  // in-flight text becomes the persisted state, undisturbed by the refused write.
+  widgets.timeline_data.value = JSON.stringify(editor.timeline);
+  const d = derivePromptRelayWidgets(editor.timeline.segments);
+  widgets.local_prompts.value = d.local_prompts;
+  widgets.segment_lengths.value = d.segment_lengths;
+  assert.equal(widgets.local_prompts.value, "in flight | b");
+  assert.deepEqual(JSON.parse(widgets.timeline_data.value).segments.map((s) => s.prompt), [
+    "in flight",
+    "b",
+  ]);
+  // …and the same push, re-issued after the settle, is an ordinary write (see the FAILS CLOSED
+  // test above for the full remedy path).
 });
 
 test("POST-LOAD: a stale editor is rejected even when its derived strings COLLIDE with the widgets", () => {

--- a/browser_tests/unit/prompt-relay-timeline.test.mjs
+++ b/browser_tests/unit/prompt-relay-timeline.test.mjs
@@ -1,0 +1,413 @@
+// #506: driving the ComfyUI-PromptRelay "PromptRelayEncodeTimeline" node via panel_set_widget.
+//
+// The node's python execute() reads ONLY local_prompts + segment_lengths, both DERIVED by the
+// in-browser editor from timeline_data. A raw timeline_data write therefore reports success
+// while the RENDER still uses the previous prompts. The lib reconciles: it regenerates the
+// derived widgets from the new timeline and writes all three atomically, re-hydrates the live
+// editor, refuses every value the node would silently coerce or reset, and refuses direct
+// derived writes. These tests drive the REAL shipped lib.
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  PROMPT_RELAY_TIMELINE_NODE_TYPE,
+  PROMPT_RELAY_MASTER_WIDGET,
+  PROMPT_RELAY_DERIVED_WIDGETS,
+  isPromptRelayTimelineNode,
+  classifyPromptRelayTimelineWrite,
+  normalizePromptRelayTimelineValue,
+  parsePromptRelayTimeline,
+  derivePromptRelayWidgets,
+  promptRelayDerivedRefusal,
+  applyPromptRelayTimelineWrite,
+  PromptRelayTimelineWriteError,
+} from "../../web/js/lib/prompt-relay-timeline.js";
+
+const seg = (prompt, length = 24, extra = {}) => ({ prompt, length, color: "#4f8edc", ...extra });
+
+/**
+ * A fake node matching the real one's widget layout. `timelineSegments` seeds timeline_data
+ * AND (unless overridden) the two derived widgets, i.e. a node that starts in sync.
+ */
+function makeRelayNode({
+  id = 7,
+  timelineSegments = [seg("a"), seg("b", 36)],
+  extraTimelineFields = {},
+  localPrompts,
+  segmentLengths,
+  withEditor = true,
+  omitWidgets = [],
+} = {}) {
+  const timeline = timelineSegments ? { ...extraTimelineFields, segments: timelineSegments } : null;
+  const derived = derivePromptRelayWidgets(timelineSegments ?? []);
+  const all = {
+    timeline_data: { name: "timeline_data", value: timeline ? JSON.stringify(timeline) : "" },
+    local_prompts: { name: "local_prompts", value: localPrompts ?? derived.local_prompts },
+    segment_lengths: { name: "segment_lengths", value: segmentLengths ?? derived.segment_lengths },
+  };
+  const widgets = Object.values(all).filter((w) => !omitWidgets.includes(w.name));
+  const editor = withEditor
+    ? {
+        timeline: timeline ? JSON.parse(JSON.stringify(timeline)) : { segments: [] },
+        selectedIndex: 0,
+        _displayedX: new Map([[0, 5]]),
+        _targetX: new Map([[0, 5]]),
+        _settling: true,
+        uiCalls: [],
+        updateUIFromSelection() {
+          this.uiCalls.push("updateUIFromSelection");
+        },
+        render() {
+          this.uiCalls.push("render");
+        },
+      }
+    : null;
+  const node = { id, type: PROMPT_RELAY_TIMELINE_NODE_TYPE, widgets, _timelineEditor: editor };
+  return { node, widgets: all, editor };
+}
+
+const relay = (r) => r.prompt_relay_timeline;
+
+test("isPromptRelayTimelineNode matches on type or comfyClass, nothing else", () => {
+  assert.equal(isPromptRelayTimelineNode({ type: PROMPT_RELAY_TIMELINE_NODE_TYPE }), true);
+  assert.equal(isPromptRelayTimelineNode({ comfyClass: PROMPT_RELAY_TIMELINE_NODE_TYPE }), true);
+  // A non-matching `type` must NOT mask a matching `comfyClass` (the `type ?? comfyClass` trap).
+  assert.equal(
+    isPromptRelayTimelineNode({ type: "SomeVirtualType", comfyClass: PROMPT_RELAY_TIMELINE_NODE_TYPE }),
+    true,
+  );
+  // The NON-timeline sibling in the same pack has no editor and no timeline_data — never match it.
+  assert.equal(isPromptRelayTimelineNode({ type: "PromptRelayEncode" }), false);
+  assert.equal(isPromptRelayTimelineNode({ type: "LTXDirector" }), false);
+  assert.equal(isPromptRelayTimelineNode(null), false);
+  assert.equal(isPromptRelayTimelineNode({}), false);
+});
+
+test("classifyPromptRelayTimelineWrite: master / derived / null", () => {
+  const node = { type: PROMPT_RELAY_TIMELINE_NODE_TYPE };
+  assert.equal(classifyPromptRelayTimelineWrite(node, PROMPT_RELAY_MASTER_WIDGET), "master");
+  for (const w of PROMPT_RELAY_DERIVED_WIDGETS) {
+    assert.equal(classifyPromptRelayTimelineWrite(node, w), "derived");
+  }
+  // Ordinary widgets on the SAME node take the normal write path.
+  for (const w of ["global_prompt", "max_frames", "epsilon", "fps", "time_units"]) {
+    assert.equal(classifyPromptRelayTimelineWrite(node, w), null);
+  }
+  // Other node types are never perturbed — including LTXDirector, which owns its own route.
+  assert.equal(classifyPromptRelayTimelineWrite({ type: "LTXDirector" }, "timeline_data"), null);
+  assert.equal(classifyPromptRelayTimelineWrite({ type: "KSampler" }, "local_prompts"), null);
+});
+
+test("derivePromptRelayWidgets mirrors the node's syncWidgetsFromTimeline joins", () => {
+  const d = derivePromptRelayWidgets([seg("a cat", 10), seg("a dog", 20), seg("a bird", 30)]);
+  assert.equal(d.local_prompts, "a cat | a dog | a bird");
+  assert.equal(d.segment_lengths, "10, 20, 30");
+});
+
+test("parsePromptRelayTimeline: object / empty / invalid / non-object", () => {
+  assert.deepEqual(parsePromptRelayTimeline('{"segments":[]}'), { segments: [] });
+  assert.equal(parsePromptRelayTimeline(""), null);
+  assert.equal(parsePromptRelayTimeline("   "), null);
+  assert.equal(parsePromptRelayTimeline("not json"), null);
+  assert.equal(parsePromptRelayTimeline("[1,2]"), null);
+  assert.equal(parsePromptRelayTimeline(null), null);
+});
+
+test("normalizePromptRelayTimelineValue accepts an object or a JSON string, refuses the rest", () => {
+  assert.deepEqual(normalizePromptRelayTimelineValue({ segments: [] }), { segments: [] });
+  assert.deepEqual(normalizePromptRelayTimelineValue('{"segments":[]}'), { segments: [] });
+  assert.throws(() => normalizePromptRelayTimelineValue("nope"), PromptRelayTimelineWriteError);
+  assert.throws(() => normalizePromptRelayTimelineValue("[]"), PromptRelayTimelineWriteError);
+  assert.throws(() => normalizePromptRelayTimelineValue(42), PromptRelayTimelineWriteError);
+  assert.throws(() => normalizePromptRelayTimelineValue(null), PromptRelayTimelineWriteError);
+});
+
+// ─── The #506 core: the derived widgets never stay stale ───
+
+test("a timeline_data write REGENERATES local_prompts and segment_lengths (#506)", () => {
+  const { node, widgets, editor } = makeRelayNode();
+  assert.equal(widgets.local_prompts.value, "a | b");
+
+  const res = relay(
+    applyPromptRelayTimelineWrite(node, JSON.stringify({ segments: [seg("new one", 40), seg("b", 36)] })),
+  );
+
+  assert.equal(widgets.local_prompts.value, "new one | b");
+  assert.equal(widgets.segment_lengths.value, "40, 36");
+  assert.deepEqual(JSON.parse(widgets.timeline_data.value).segments.map((s) => s.prompt), ["new one", "b"]);
+  assert.equal(res.reconciled, true);
+  assert.equal(res.segments, 2);
+  assert.equal(res.local_prompts, "new one | b");
+  assert.equal(res.segment_lengths, "40, 36");
+  // The live editor is re-hydrated so its next commit re-derives the SAME values instead of
+  // reverting to the stale in-memory timeline.
+  assert.equal(res.editor_synced, true);
+  assert.deepEqual(editor.timeline.segments.map((s) => s.prompt), ["new one", "b"]);
+  assert.deepEqual(editor.uiCalls, ["updateUIFromSelection", "render"]);
+});
+
+test("the three widgets always agree — timeline_data JSON re-derives to the written values", () => {
+  const { node, widgets } = makeRelayNode();
+  applyPromptRelayTimelineWrite(node, { segments: [seg("x", 1), seg("y", 2), seg("z", 3)] });
+  const back = derivePromptRelayWidgets(JSON.parse(widgets.timeline_data.value).segments);
+  assert.equal(back.local_prompts, widgets.local_prompts.value);
+  assert.equal(back.segment_lengths, widgets.segment_lengths.value);
+});
+
+test("the editor's own commit after our write is a NO-OP (no silent revert)", () => {
+  const { node, widgets, editor } = makeRelayNode();
+  applyPromptRelayTimelineWrite(node, { segments: [seg("driven", 12)] });
+  // Replay the node's syncWidgetsFromTimeline against the re-hydrated editor.
+  const segs = editor.timeline.segments;
+  assert.equal(JSON.stringify(editor.timeline), widgets.timeline_data.value);
+  assert.equal(segs.map((s) => s.prompt).join(" | "), widgets.local_prompts.value);
+  assert.equal(segs.map((s) => s.length).join(", "), widgets.segment_lengths.value);
+});
+
+test("a write with NO live editor still leaves all three widgets consistent", () => {
+  const { node, widgets } = makeRelayNode({ withEditor: false });
+  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("headless", 9)] }));
+  assert.equal(res.editor_synced, false);
+  assert.equal(res.reconciled, true);
+  assert.equal(widgets.local_prompts.value, "headless");
+  assert.equal(widgets.segment_lengths.value, "9");
+});
+
+test("segment count SHRINKS and GROWS cleanly (derived lists track exactly)", () => {
+  const { node, widgets, editor } = makeRelayNode({
+    timelineSegments: [seg("a"), seg("b"), seg("c")],
+  });
+  applyPromptRelayTimelineWrite(node, { segments: [seg("only", 5)] });
+  assert.equal(widgets.local_prompts.value, "only");
+  assert.equal(widgets.segment_lengths.value, "5");
+  // selectedIndex is clamped into the shrunken list rather than dangling past the end.
+  assert.equal(editor.selectedIndex, 0);
+
+  applyPromptRelayTimelineWrite(node, { segments: [seg("p", 1), seg("q", 2), seg("r", 3), seg("s", 4)] });
+  assert.equal(widgets.local_prompts.value, "p | q | r | s");
+  assert.equal(widgets.segment_lengths.value, "1, 2, 3, 4");
+});
+
+test("selectedIndex past the end of a shrunken timeline is clamped, and anim state is reset", () => {
+  const { node, editor } = makeRelayNode({ timelineSegments: [seg("a"), seg("b"), seg("c")] });
+  editor.selectedIndex = 2;
+  applyPromptRelayTimelineWrite(node, { segments: [seg("a"), seg("b")] });
+  assert.equal(editor.selectedIndex, 1);
+  assert.equal(editor._displayedX.size, 0);
+  assert.equal(editor._targetX.size, 0);
+  assert.equal(editor._settling, false);
+});
+
+// ─── Merge: omitted fields preserved, never defaulted away ───
+
+test("a partial write MERGES onto the current timeline (unmentioned fields preserved)", () => {
+  const { node, widgets } = makeRelayNode({ extraTimelineFields: { zoom: 3, note: "keep me" } });
+  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("changed", 7)] }));
+  const written = JSON.parse(widgets.timeline_data.value);
+  assert.equal(written.zoom, 3);
+  assert.equal(written.note, "keep me");
+  assert.equal(res.merged_onto_current, true);
+});
+
+test("per-segment fields the caller does not know about survive the round-trip", () => {
+  const { node, widgets } = makeRelayNode();
+  applyPromptRelayTimelineWrite(node, {
+    segments: [{ prompt: "p", length: 8, color: "#abcdef", futureField: { a: 1 } }],
+  });
+  const s = JSON.parse(widgets.timeline_data.value).segments[0];
+  assert.equal(s.color, "#abcdef");
+  assert.deepEqual(s.futureField, { a: 1 });
+});
+
+test("a segment without a color inherits the same-index color, else a stable fallback", () => {
+  const { node, widgets } = makeRelayNode({
+    timelineSegments: [seg("a", 24, { color: "#111111" }), seg("b", 24, { color: "#222222" })],
+  });
+  applyPromptRelayTimelineWrite(node, {
+    segments: [{ prompt: "a2", length: 24 }, { prompt: "b2", length: 24 }, { prompt: "c2", length: 24 }],
+  });
+  const colors = JSON.parse(widgets.timeline_data.value).segments.map((s) => s.color);
+  assert.equal(colors[0], "#111111");
+  assert.equal(colors[1], "#222222");
+  assert.equal(typeof colors[2], "string");
+  assert.ok(colors[2].length > 0);
+});
+
+test("an unreadable current timeline_data falls back to a pure replace", () => {
+  const { node, widgets } = makeRelayNode();
+  widgets.timeline_data.value = "corrupt {{{";
+  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("fresh", 11)] }));
+  assert.equal(res.merged_onto_current, false);
+  assert.equal(widgets.local_prompts.value, "fresh");
+});
+
+// ─── Refusals: everything the node would silently coerce or reset ───
+
+test("REFUSES an empty / non-array segments list (node resets to a blank default)", () => {
+  for (const bad of [{ segments: [] }, { segments: null }, { segments: "a|b" }, { segments: {} }]) {
+    const { node, widgets } = makeRelayNode();
+    assert.throws(() => applyPromptRelayTimelineWrite(node, bad), PromptRelayTimelineWriteError);
+    // Nothing was touched — a refusal never half-writes.
+    assert.equal(widgets.local_prompts.value, "a | b");
+    assert.equal(widgets.segment_lengths.value, "24, 36");
+    assert.equal(JSON.parse(widgets.timeline_data.value).segments.length, 2);
+  }
+});
+
+test("an overlay with NO segments key is an idempotent RE-RECONCILE, not a wipe", () => {
+  // `segments` is merged from the node's current timeline, so nothing is defaulted away. This
+  // doubles as the repair path for a node that is already desynced.
+  const { node, widgets } = makeRelayNode({ localPrompts: "stale text" });
+  const res = relay(applyPromptRelayTimelineWrite(node, {}));
+  assert.equal(res.segments, 2);
+  assert.equal(widgets.local_prompts.value, "a | b");
+  assert.deepEqual(res.replaced_out_of_band, { local_prompts: "stale text" });
+});
+
+test("an overlay with no segments AND no readable current timeline is REFUSED", () => {
+  const { node } = makeRelayNode({ timelineSegments: null });
+  assert.throws(() => applyPromptRelayTimelineWrite(node, {}), PromptRelayTimelineWriteError);
+});
+
+test("REFUSES a non-object segment (node falls back to a blank timeline, wiping prompts)", () => {
+  for (const bad of [null, undefined, "a prompt", 5, ["x"]]) {
+    const { node, widgets } = makeRelayNode();
+    assert.throws(
+      () => applyPromptRelayTimelineWrite(node, { segments: [seg("ok"), bad] }),
+      PromptRelayTimelineWriteError,
+    );
+    assert.equal(widgets.local_prompts.value, "a | b");
+  }
+});
+
+test("REFUSES a missing/non-string prompt — the node would coerce it to \"\" (data loss)", () => {
+  for (const bad of [undefined, null, 42, { text: "hi" }, ["hi"]]) {
+    const { node, widgets } = makeRelayNode();
+    assert.throws(
+      () => applyPromptRelayTimelineWrite(node, { segments: [{ prompt: bad, length: 24 }] }),
+      PromptRelayTimelineWriteError,
+    );
+    assert.equal(widgets.local_prompts.value, "a | b");
+  }
+  // An EXPLICIT empty string is a legitimate value and is accepted.
+  const { node, widgets } = makeRelayNode();
+  applyPromptRelayTimelineWrite(node, { segments: [{ prompt: "", length: 24 }, seg("b")] });
+  assert.equal(widgets.local_prompts.value, " | b");
+});
+
+test("REFUSES a length the node would clamp/truncate; accepts integers and integer strings", () => {
+  for (const bad of [undefined, null, 0, -5, 12.5, "24px", "", NaN, Infinity, {}]) {
+    const { node, widgets } = makeRelayNode();
+    assert.throws(
+      () => applyPromptRelayTimelineWrite(node, { segments: [{ prompt: "p", length: bad }] }),
+      PromptRelayTimelineWriteError,
+    );
+    assert.equal(widgets.segment_lengths.value, "24, 36");
+  }
+  const { node, widgets } = makeRelayNode();
+  applyPromptRelayTimelineWrite(node, { segments: [{ prompt: "p", length: "30" }, seg("q", 1)] });
+  assert.equal(widgets.segment_lengths.value, "30, 1");
+  assert.equal(typeof JSON.parse(widgets.timeline_data.value).segments[0].length, "number");
+});
+
+test("REFUSES when any of the three widgets is missing (a reconcile would be impossible)", () => {
+  for (const missing of ["timeline_data", "local_prompts", "segment_lengths"]) {
+    const { node } = makeRelayNode({ omitWidgets: [missing] });
+    assert.throws(
+      () => applyPromptRelayTimelineWrite(node, { segments: [seg("p")] }),
+      (err) => err instanceof PromptRelayTimelineWriteError && err.message.includes(missing),
+    );
+  }
+});
+
+test("REFUSES a direct write to a derived widget and redirects to timeline_data", () => {
+  for (const w of PROMPT_RELAY_DERIVED_WIDGETS) {
+    const msg = promptRelayDerivedRefusal(w, 7);
+    assert.ok(msg.includes(w));
+    assert.ok(msg.includes(PROMPT_RELAY_MASTER_WIDGET));
+    assert.ok(msg.includes("#506"));
+  }
+});
+
+// ─── Honesty: nothing diverges silently ───
+
+test("a PRE-EXISTING desync is reported, not silently overwritten (#506 workaround recovery)", () => {
+  // A node whose local_prompts was written directly (the issue's workaround): that text exists
+  // ONLY there and the node would revert it anyway. Our reconcile replaces it — and says so.
+  const { node, widgets } = makeRelayNode({ localPrompts: "hand written | prompts" });
+  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("timeline says", 24)] }));
+  assert.deepEqual(res.replaced_out_of_band, { local_prompts: "hand written | prompts" });
+  assert.ok(res.warnings.some((w) => w.includes("ALREADY desynced")));
+  assert.equal(widgets.local_prompts.value, "timeline says");
+});
+
+test("an IN-SYNC node reports no replaced_out_of_band and no desync warning", () => {
+  const { node } = makeRelayNode();
+  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("a"), seg("b", 36)] }));
+  assert.equal(res.replaced_out_of_band, undefined);
+  assert.equal(res.warnings, undefined);
+});
+
+test("WARNS about an empty prompt — the python side drops blanks and shifts every later segment", () => {
+  const { node } = makeRelayNode();
+  const res = relay(
+    applyPromptRelayTimelineWrite(node, { segments: [seg("a"), seg("   ", 12), seg("c")] }),
+  );
+  assert.ok(res.warnings.some((w) => w.includes("EMPTY prompt")));
+  assert.equal(res.local_prompts, "a |     | c");
+});
+
+test("WARNS about a literal | inside a prompt — the python side splits on it", () => {
+  const { node } = makeRelayNode();
+  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("a cat | a dog", 24)] }));
+  assert.ok(res.warnings.some((w) => w.includes('literal "|"')));
+});
+
+test("a UI-refresh failure does NOT fail the write, and is reported", () => {
+  const { node, widgets, editor } = makeRelayNode();
+  editor.render = () => {
+    throw new Error("canvas gone");
+  };
+  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("still applied", 15)] }));
+  // The values the node EXECUTES are correct; only the repaint failed.
+  assert.equal(widgets.local_prompts.value, "still applied");
+  assert.equal(widgets.segment_lengths.value, "15");
+  assert.equal(res.editor_synced, true);
+  assert.equal(res.ui_refresh_error, "canvas gone");
+});
+
+// ─── Undo envelope ───
+
+test("wraps the mutation in one undo envelope: before → write → after → dirty", () => {
+  const { node } = makeRelayNode();
+  const order = [];
+  applyPromptRelayTimelineWrite(node, { segments: [seg("p")] }, {
+    beforeChange: () => order.push("before"),
+    afterChange: () => order.push("after"),
+    setDirty: () => order.push("dirty"),
+  });
+  assert.deepEqual(order, ["before", "after", "dirty"]);
+});
+
+test("fires NO undo hooks when a refusal happens (no empty undo step)", () => {
+  const order = [];
+  const hooks = {
+    beforeChange: () => order.push("before"),
+    afterChange: () => order.push("after"),
+    setDirty: () => order.push("dirty"),
+  };
+  const { node } = makeRelayNode();
+  assert.throws(() => applyPromptRelayTimelineWrite(node, "not json", hooks));
+  assert.throws(() => applyPromptRelayTimelineWrite(node, { segments: [] }, hooks));
+  assert.throws(
+    () => applyPromptRelayTimelineWrite(makeRelayNode({ omitWidgets: ["local_prompts"] }).node, { segments: [seg("p")] }, hooks),
+  );
+  assert.deepEqual(order, []);
+});
+
+test("honors an injected getEditor", () => {
+  const { node } = makeRelayNode({ withEditor: false });
+  const editor = { timeline: null, selectedIndex: 0, uiCalls: [], render() { this.uiCalls.push("render"); } };
+  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("p")] }, { getEditor: () => editor }));
+  assert.equal(res.editor_synced, true);
+  assert.deepEqual(editor.timeline.segments.map((s) => s.prompt), ["p"]);
+});

--- a/browser_tests/unit/prompt-relay-timeline.test.mjs
+++ b/browser_tests/unit/prompt-relay-timeline.test.mjs
@@ -232,12 +232,92 @@ test("a segment without a color inherits the same-index color, else a stable fal
   assert.ok(colors[2].length > 0);
 });
 
-test("an unreadable current timeline_data falls back to a pure replace", () => {
-  const { node, widgets } = makeRelayNode();
+test("per-segment fields that exist ONLY on the current timeline are NOT index-merged back", () => {
+  // Deliberate: supplying `segments` REPLACES the list, and index-matching unknown metadata
+  // across a reordered/resized list would attach it to the wrong segment. `color` is the one
+  // documented exception (purely cosmetic, and the canvas needs it).
+  const { node, widgets } = makeRelayNode({
+    timelineSegments: [seg("a", 24, { legacyMeta: "old" }), seg("b", 36)],
+  });
+  applyPromptRelayTimelineWrite(node, { segments: [{ prompt: "a2", length: 24 }, seg("b", 36)] });
+  const written = JSON.parse(widgets.timeline_data.value).segments;
+  assert.equal(written[0].legacyMeta, undefined);
+  assert.equal(written[0].color, "#4f8edc"); // colour DID carry over by index
+});
+
+test("an unreadable current timeline_data AND no editor falls back to a pure replace", () => {
+  const { node, widgets } = makeRelayNode({ withEditor: false });
   widgets.timeline_data.value = "corrupt {{{";
   const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("fresh", 11)] }));
   assert.equal(res.merged_onto_current, false);
+  assert.equal(res.merge_base, "none");
   assert.equal(widgets.local_prompts.value, "fresh");
+});
+
+test("an unreadable current timeline_data still merges from the LIVE editor", () => {
+  const { node, widgets } = makeRelayNode({ extraTimelineFields: { zoom: 2 } });
+  widgets.timeline_data.value = "corrupt {{{";
+  const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("fresh", 11)] }));
+  assert.equal(res.merge_base, "editor");
+  assert.equal(JSON.parse(widgets.timeline_data.value).zoom, 2);
+});
+
+// ─── The merge base: whichever copy of the timeline is actually current ───
+
+test("MID-TYPING: the live editor wins over a timeline_data widget lagging by the 120ms debounce", () => {
+  // Reproduces the pack's textarea handler: it writes seg.prompt + local_prompts IMMEDIATELY
+  // and defers the timeline_data JSON by 120ms. Merging onto the stale widget would DESTROY
+  // the text the user just typed.
+  const { node, widgets, editor } = makeRelayNode();
+  editor.timeline.segments[0].prompt = "just typed, not yet committed";
+  widgets.local_prompts.value = derivePromptRelayWidgets(editor.timeline.segments).local_prompts;
+  // timeline_data still holds the pre-keystroke JSON ("a | b").
+
+  // A write that does not mention segments must PRESERVE the in-flight text, not roll it back.
+  const res = relay(applyPromptRelayTimelineWrite(node, {}));
+  assert.equal(res.merge_base, "editor");
+  assert.equal(widgets.local_prompts.value, "just typed, not yet committed | b");
+  assert.deepEqual(JSON.parse(widgets.timeline_data.value).segments.map((s) => s.prompt), [
+    "just typed, not yet committed",
+    "b",
+  ]);
+  // The in-flight text is current, not "out of band" — no bogus data-loss report.
+  assert.equal(res.replaced_out_of_band, undefined);
+});
+
+test("MID-TYPING: a pending debounce commit AFTER our write is a no-op (no rollback)", () => {
+  const { node, widgets, editor } = makeRelayNode();
+  editor.timeline.segments[0].prompt = "in flight";
+  widgets.local_prompts.value = derivePromptRelayWidgets(editor.timeline.segments).local_prompts;
+  applyPromptRelayTimelineWrite(node, { segments: [seg("agent set", 20)] });
+  // Replay the pack's commit() → syncWidgetsFromTimeline against the re-hydrated editor.
+  const before = { ...widgets.timeline_data, ...widgets.local_prompts };
+  const segs = editor.timeline.segments;
+  assert.equal(JSON.stringify(editor.timeline), widgets.timeline_data.value);
+  assert.equal(segs.map((s) => s.prompt).join(" | "), widgets.local_prompts.value);
+  assert.equal(segs.map((s) => s.length).join(", "), widgets.segment_lengths.value);
+  assert.ok(before);
+});
+
+test("POST-LOAD: the timeline_data widget wins over an editor still holding the OLD workflow", () => {
+  // onConfigure restores the widgets first and re-parses the editor ~10ms later. Merging onto
+  // the editor in that window would resurrect the previous workflow's timeline.
+  const { node, widgets, editor } = makeRelayNode({ timelineSegments: [seg("restored", 50)] });
+  editor.timeline = { segments: [seg("previous workflow", 99)] };
+  const res = relay(applyPromptRelayTimelineWrite(node, {}));
+  assert.equal(res.merge_base, "timeline_data");
+  assert.equal(widgets.local_prompts.value, "restored");
+  assert.equal(widgets.segment_lengths.value, "50");
+});
+
+test("the live editor never has its segment objects aliased into the written timeline", () => {
+  const { node, widgets, editor } = makeRelayNode();
+  const originalSeg = editor.timeline.segments[0];
+  applyPromptRelayTimelineWrite(node, {});
+  assert.notEqual(editor.timeline.segments[0], originalSeg);
+  // Mutating the pre-write object must not change what was written.
+  originalSeg.prompt = "mutated after the fact";
+  assert.equal(widgets.local_prompts.value, "a | b");
 });
 
 // ─── Refusals: everything the node would silently coerce or reset ───
@@ -294,8 +374,9 @@ test("REFUSES a missing/non-string prompt — the node would coerce it to \"\" (
   assert.equal(widgets.local_prompts.value, " | b");
 });
 
-test("REFUSES a length the node would clamp/truncate; accepts integers and integer strings", () => {
-  for (const bad of [undefined, null, 0, -5, 12.5, "24px", "", NaN, Infinity, {}]) {
+test("REFUSES a length the node would clamp/truncate; accepts every LOSSLESS integer form", () => {
+  // "24.7" is the important one: parseInt TRUNCATES it to 24, silently shortening the segment.
+  for (const bad of [undefined, null, 0, -5, 12.5, "24px", "24.7", "", NaN, Infinity, {}]) {
     const { node, widgets } = makeRelayNode();
     assert.throws(
       () => applyPromptRelayTimelineWrite(node, { segments: [{ prompt: "p", length: bad }] }),
@@ -303,10 +384,32 @@ test("REFUSES a length the node would clamp/truncate; accepts integers and integ
     );
     assert.equal(widgets.segment_lengths.value, "24, 36");
   }
+  // Forms parseInt handles losslessly are accepted and stored as real numbers.
   const { node, widgets } = makeRelayNode();
-  applyPromptRelayTimelineWrite(node, { segments: [{ prompt: "p", length: "30" }, seg("q", 1)] });
-  assert.equal(widgets.segment_lengths.value, "30, 1");
-  assert.equal(typeof JSON.parse(widgets.timeline_data.value).segments[0].length, "number");
+  applyPromptRelayTimelineWrite(node, {
+    segments: [
+      { prompt: "p", length: "30" },
+      { prompt: "q", length: "+12" },
+      { prompt: "r", length: "8.0" },
+      { prompt: "s", length: " 5 " },
+      seg("t", 1),
+    ],
+  });
+  assert.equal(widgets.segment_lengths.value, "30, 12, 8, 5, 1");
+  for (const s of JSON.parse(widgets.timeline_data.value).segments) {
+    assert.equal(typeof s.length, "number");
+  }
+});
+
+test("REFUSES a PRESENT non-string colour (the node would swap in a palette entry)", () => {
+  for (const bad of [42, null, {}, ["#fff"]]) {
+    const { node, widgets } = makeRelayNode();
+    assert.throws(
+      () => applyPromptRelayTimelineWrite(node, { segments: [{ prompt: "p", length: 5, color: bad }] }),
+      PromptRelayTimelineWriteError,
+    );
+    assert.equal(widgets.segment_lengths.value, "24, 36");
+  }
 });
 
 test("REFUSES when any of the three widgets is missing (a reconcile would be impossible)", () => {
@@ -360,6 +463,19 @@ test("WARNS about a literal | inside a prompt — the python side splits on it",
   const { node } = makeRelayNode();
   const res = relay(applyPromptRelayTimelineWrite(node, { segments: [seg("a cat | a dog", 24)] }));
   assert.ok(res.warnings.some((w) => w.includes('literal "|"')));
+});
+
+test("WARNS about leading/trailing whitespace — the python side strips each entry", () => {
+  const { node } = makeRelayNode();
+  const res = relay(
+    applyPromptRelayTimelineWrite(node, { segments: [seg("  red fox  ", 24), seg("clean", 24)] }),
+  );
+  assert.ok(res.warnings.some((w) => w.includes("leading/trailing whitespace")));
+  // The prompt is stored VERBATIM; only the note about what the encoder will do is added.
+  assert.equal(res.local_prompts, "  red fox   | clean");
+  // A fully-blank prompt is reported by the stronger blank-prompt warning, not this one.
+  const clean = relay(applyPromptRelayTimelineWrite(makeRelayNode().node, { segments: [seg("   ", 24)] }));
+  assert.equal(clean.warnings.filter((w) => w.includes("leading/trailing whitespace")).length, 0);
 });
 
 test("a UI-refresh failure does NOT fail the write, and is reported", () => {

--- a/browser_tests/unit/prompt-relay-timeline.test.mjs
+++ b/browser_tests/unit/prompt-relay-timeline.test.mjs
@@ -441,6 +441,60 @@ test("PIPE COLLISION: a length-only change is disclosed despite identical prompt
   assert.deepEqual(res.overwrote_uncommitted_edit, { prompts: ["a | b", "c"], lengths: [24, 36] });
 });
 
+test("PIPE COLLISION: a metadata-only overlay must NOT rebuild from a stale master", () => {
+  // The join cannot decide AUTHORITY either. Persisted timeline_data + widgets are
+  // ["a", "b | c"] / [24, 36]. Within one debounce interval the user edits BOTH prompt boxes,
+  // leaving the live editor at ["a | b", "c"] with the same lengths — which derives the SAME
+  // "a | b | c" and "24, 36", so the stale master still looks perfectly consistent. A caller
+  // then writes a metadata-only overlay that asks for no segment change at all. Choosing the
+  // master on join equality would rebuild the node from ["a", "b | c"] and destroy the edit.
+  const { node, widgets, editor } = makeRelayNode({
+    timelineSegments: [seg("a", 24), seg("b | c", 36)],
+  });
+  editor.timeline.segments = [seg("a | b", 24), seg("c", 36)];
+  // Both candidates serialize to byte-identical derived widget values.
+  assert.equal(widgets.local_prompts.value, "a | b | c");
+  assert.equal(
+    derivePromptRelayWidgets(editor.timeline.segments).local_prompts,
+    widgets.local_prompts.value,
+  );
+  assert.equal(
+    derivePromptRelayWidgets(editor.timeline.segments).segment_lengths,
+    widgets.segment_lengths.value,
+  );
+
+  const res = relay(applyPromptRelayTimelineWrite(node, { zoom: 4 }));
+
+  // The live edit SURVIVES — the whole point.
+  assert.deepEqual(JSON.parse(widgets.timeline_data.value).segments.map((s) => s.prompt), ["a | b", "c"]);
+  assert.deepEqual(editor.timeline.segments.map((s) => s.prompt), ["a | b", "c"]);
+  assert.equal(JSON.parse(widgets.timeline_data.value).zoom, 4);
+  // Nothing was overwritten, and the tie is declared rather than resolved silently.
+  assert.equal(res.merge_base, "editor");
+  assert.equal(res.merge_base_ambiguous, true);
+  assert.equal(res.overwrote_uncommitted_edit, undefined);
+  assert.deepEqual(res.superseded_timeline_data, { prompts: ["a", "b | c"], lengths: [24, 36] });
+  assert.ok(res.warnings.some((w) => w.includes("could not tell which is current")));
+  // The derived join is unchanged by all of this — proof it could never have detected the case.
+  assert.equal(widgets.local_prompts.value, "a | b | c");
+});
+
+test("an unresolvable tie is flagged; an ordinary write is not", () => {
+  // Neither record matches the derived widgets (a genuinely desynced node) and they differ
+  // structurally: still unresolvable, so the live editor wins and the tie is flagged.
+  const { node, widgets } = makeRelayNode({ localPrompts: "hand written | text" });
+  widgets.timeline_data.value = JSON.stringify({ segments: [seg("master only", 24)] });
+  const tied = relay(applyPromptRelayTimelineWrite(node, { zoom: 1 }));
+  assert.equal(tied.merge_base, "editor");
+  assert.equal(tied.merge_base_ambiguous, true);
+  assert.deepEqual(tied.replaced_out_of_band, { local_prompts: "hand written | text" });
+
+  // A node whose two records agree has no tie to declare.
+  const plain = relay(applyPromptRelayTimelineWrite(makeRelayNode().node, { segments: [seg("x", 3)] }));
+  assert.equal(plain.merge_base, "timeline_data");
+  assert.equal(plain.merge_base_ambiguous, undefined);
+});
+
 test("sameSegmentContent compares structurally, never through the join", () => {
   const A = [seg("a | b", 24), seg("c", 36)];
   const B = [seg("a", 24), seg("b | c", 36)];

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -156,6 +156,7 @@ import {
   classifyPromptRelayTimelineWrite,
   applyPromptRelayTimelineWrite,
   promptRelayDerivedRefusal,
+  recordPreLoadPromptRelayEditors,
 } from "./lib/prompt-relay-timeline.js";
 import {
   controlAfterGenerateModes,
@@ -1242,6 +1243,19 @@ function installCreateBoundaryFork(appRef) {
         }
       } catch {
         // Never let identity bookkeeping break a graph load.
+      }
+      // #506 — record what every PromptRelayEncodeTimeline editor holds RIGHT NOW, before the
+      // load replaces the graph. That node's editor is re-parsed from timeline_data ~10ms
+      // AFTER onConfigure restores the widgets, so for a moment it still holds the previous
+      // workflow's timeline. An editor that still matches this snapshot has not been re-parsed
+      // or typed into since the load — the only positive evidence that separates a stale
+      // leftover from an uncommitted edit, which are otherwise identical from the widgets alone
+      // and demand opposite disclosures. Taken here because this fork is the one place that
+      // observes a load BEFORE it happens.
+      try {
+        recordPreLoadPromptRelayEditors(appRef?.graph?._nodes ?? appRef?.graph?.nodes);
+      } catch {
+        // Never let disclosure bookkeeping break a graph load either.
       }
       return orig(graphData, clean, restoreView, workflow, options);
     };

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -153,6 +153,11 @@ import {
   derivedTimelineRefusal,
 } from "./lib/ltx-director.js";
 import {
+  classifyPromptRelayTimelineWrite,
+  applyPromptRelayTimelineWrite,
+  promptRelayDerivedRefusal,
+} from "./lib/prompt-relay-timeline.js";
+import {
   controlAfterGenerateModes,
   controlAfterGenerateEntries,
 } from "./lib/control-after-generate.js";
@@ -6268,6 +6273,25 @@ const GRAPH_TOOL_EXECUTORS = {
       // honors panel_set_widget's "Undoable with Ctrl+Z" contract (the node's own
       // _applyLoadedTimeline only schedules async state capture, no pre-change snapshot).
       return applyLtxTimelineWrite(node, value, {
+        beforeChange: () => graph.beforeChange(),
+        afterChange: () => graph.afterChange(),
+        setDirty: () => graph.setDirtyCanvas(true, true),
+      });
+    }
+    // #506: the ComfyUI-PromptRelay "PromptRelayEncodeTimeline" node has the same shape of
+    // problem but DIFFERENT mechanics, and a worse consequence. Its python execute() reads
+    // ONLY local_prompts + segment_lengths — never timeline_data — and both are DERIVED from
+    // timeline_data by the node's in-browser editor. A raw timeline_data write therefore
+    // "succeeds" while the RENDER still uses the old prompts. This pack exposes no re-hydration
+    // entry point, so the route regenerates the derived widgets itself (the node's own two
+    // join()s) and writes all three atomically, then re-hydrates the live editor. Derived
+    // writes are refused loudly. Keyed strictly to the PromptRelayEncodeTimeline node type.
+    const relayKind = classifyPromptRelayTimelineWrite(node, widget);
+    if (relayKind === "derived") {
+      throw new Error(promptRelayDerivedRefusal(widget, node.id));
+    }
+    if (relayKind === "master") {
+      return applyPromptRelayTimelineWrite(node, value, {
         beforeChange: () => graph.beforeChange(),
         afterChange: () => graph.afterChange(),
         setDirty: () => graph.setDirtyCanvas(true, true),

--- a/web/js/lib/prompt-relay-timeline.js
+++ b/web/js/lib/prompt-relay-timeline.js
@@ -136,20 +136,32 @@ function isPlainObject(v) {
  * the value is one the node's `Math.max(1, parseInt(v, 10) || 1)` would silently MANGLE
  * (missing, fractional, zero/negative, non-numeric).
  * A STRING is accepted only in the forms parseInt handles LOSSLESSLY: optional leading "+",
- * digits, and a zero-valued fraction ("24", "+24", "24.0", "24."). A non-zero fraction
- * ("24.7") is refused because parseInt would TRUNCATE it — silently shortening a segment.
+ * digits, and a zero-valued fraction ("24", "+24", "24.0", "24."). Deliberately refused:
+ *   * a non-zero fraction ("24.7") — parseInt TRUNCATES it, silently shortening a segment;
+ *   * EXPONENT notation ("2e3") — parseInt stops at the "e" and yields 2, i.e. a caller who
+ *     means 2000 frames would get 2. Refusing the whole form (including the harmless "24e0")
+ *     is the only way to make that impossible.
+ * The result must also be a SAFE integer: `String()` switches to exponent notation at 1e21,
+ * and `segment_lengths` is consumed by python's `int()`, which rejects "1e+21" outright while
+ * the pack's own parseInt would read it back as 1.
  */
 const LOSSLESS_INT_STRING = /^\+?\d+(?:\.0*)?$/;
 
 function normalizeSegmentLength(v) {
+  let n;
   if (typeof v === "number") {
-    return Number.isInteger(v) && v >= MIN_SEGMENT_LENGTH ? v : null;
+    n = v;
+  } else if (typeof v === "string") {
+    const trimmed = v.trim();
+    if (!LOSSLESS_INT_STRING.test(trimmed)) return null;
+    n = Number.parseInt(trimmed, 10);
+  } else {
+    return null;
   }
-  if (typeof v !== "string") return null;
-  const trimmed = v.trim();
-  if (!LOSSLESS_INT_STRING.test(trimmed)) return null;
-  const n = Number.parseInt(trimmed, 10);
-  return Number.isInteger(n) && n >= MIN_SEGMENT_LENGTH ? n : null;
+  if (!Number.isSafeInteger(n) || n < MIN_SEGMENT_LENGTH) return null;
+  // Belt-and-braces: only a plain decimal string is round-trippable through the joined
+  // `segment_lengths` value that python's int() parses.
+  return /^\d+$/.test(String(n)) ? n : null;
 }
 
 function describe(v) {

--- a/web/js/lib/prompt-relay-timeline.js
+++ b/web/js/lib/prompt-relay-timeline.js
@@ -40,11 +40,14 @@
 // Anything the node's own parser would COERCE (a missing prompt → "", a bogus length → 1) or
 // that would make it RESET to a blank two-segment default (absent/empty/malformed segments)
 // is REFUSED LOUDLY instead of applied — a loud, safe failure over silent destruction. Fields
-// the caller does not mention are MERGED from the node's current timeline, never defaulted
-// away. And when the node is found ALREADY desynced (out-of-band `local_prompts` text that
-// the current timeline does not produce — e.g. written with the #506 workaround), the
-// pre-existing value is RETURNED in the result envelope before being replaced, so no prompt
-// text ever disappears without the caller being told.
+// the caller does not mention are MERGED from the node's CURRENT timeline — and "current"
+// deliberately means the live editor's copy when the user is mid-keystroke, because the
+// timeline_data widget lags a typed prompt by up to 120 ms (see chooseMergeBase). And when the
+// node is found ALREADY desynced (out-of-band `local_prompts` text that no timeline produces —
+// e.g. written with the #506 workaround), the pre-existing value is RETURNED in the result
+// envelope before being replaced, so no prompt text ever disappears without the caller being
+// told. Anything PromptRelay's python would encode differently from what the timeline shows
+// (a blank prompt, a literal "|", padding whitespace) comes back as a warning.
 
 export const PROMPT_RELAY_TIMELINE_NODE_TYPE = "PromptRelayEncodeTimeline";
 
@@ -131,18 +134,22 @@ function isPlainObject(v) {
 /**
  * The node's segment length, normalized to the integer frame count it stores — or null when
  * the value is one the node's `Math.max(1, parseInt(v, 10) || 1)` would silently MANGLE
- * (missing, fractional, zero/negative, non-numeric). A numeric integer STRING is accepted
- * because parseInt handles it losslessly; everything else is refused rather than coerced.
+ * (missing, fractional, zero/negative, non-numeric).
+ * A STRING is accepted only in the forms parseInt handles LOSSLESSLY: optional leading "+",
+ * digits, and an all-zero fraction ("24", "+24", "24.0"). A non-zero fraction ("24.7") is
+ * refused because parseInt would TRUNCATE it — silently shortening a segment.
  */
+const LOSSLESS_INT_STRING = /^\+?\d+(?:\.0+)?$/;
+
 function normalizeSegmentLength(v) {
   if (typeof v === "number") {
     return Number.isInteger(v) && v >= MIN_SEGMENT_LENGTH ? v : null;
   }
-  if (typeof v === "string" && /^\s*\d+\s*$/.test(v)) {
-    const n = Number(v.trim());
-    return Number.isInteger(n) && n >= MIN_SEGMENT_LENGTH ? n : null;
-  }
-  return null;
+  if (typeof v !== "string") return null;
+  const trimmed = v.trim();
+  if (!LOSSLESS_INT_STRING.test(trimmed)) return null;
+  const n = Number.parseInt(trimmed, 10);
+  return Number.isInteger(n) && n >= MIN_SEGMENT_LENGTH ? n : null;
 }
 
 function describe(v) {
@@ -250,13 +257,30 @@ function normalizeSegments(timeline, baseSegments) {
           `silently corrupting the segment lengths that drive the render — refusing.`,
       );
     }
+    // A PRESENT `color` must be a string. The node would swap a non-string for a
+    // palette entry, so accepting it would mean applying a value the caller did not ask for.
+    if (seg.color !== undefined && typeof seg.color !== "string") {
+      throw new PromptRelayTimelineWriteError(
+        `timeline_data.segments[${i}].color, when present, must be a colour STRING (got ` +
+          `${describe(seg.color)}). The node replaces a non-string colour with a palette entry — ` +
+          `refusing rather than applying a colour you did not ask for. Omit the field to keep the ` +
+          `segment's current colour.`,
+      );
+    }
+    // An OMITTED colour keeps the colour the segment at this position already has, so an edit
+    // that only rewrites prompts does not reshuffle the block colours; with no current
+    // timeline to inherit from, fall back to the palette position (what the node itself would
+    // pick). Either way we WRITE the colour, so the node never has to re-derive it.
     const color =
-      typeof seg.color === "string"
-        ? seg.color
-        : typeof baseSegments?.[i]?.color === "string"
-          ? baseSegments[i].color
-          : FALLBACK_SEGMENT_COLORS[i % FALLBACK_SEGMENT_COLORS.length];
-    // Spread first so any field a future pack version adds survives the round-trip.
+      seg.color ??
+      (typeof baseSegments?.[i]?.color === "string"
+        ? baseSegments[i].color
+        : FALLBACK_SEGMENT_COLORS[i % FALLBACK_SEGMENT_COLORS.length]);
+    // Spread the CALLER's segment first so any field a future pack version adds survives.
+    // Deliberately NOT merged with the same-index segment of the current timeline: supplying
+    // `segments` REPLACES the list, and index-matching unknown per-segment metadata across a
+    // reordered or resized list would attach it to the wrong segment. `color` is the sole
+    // exception because it is purely cosmetic and must be present for the canvas to draw.
     return { ...seg, prompt: seg.prompt, length, color };
   });
 }
@@ -273,9 +297,12 @@ function timelineWarnings(segments) {
   const warnings = [];
   const blank = [];
   const piped = [];
+  const padded = [];
   for (let i = 0; i < segments.length; i++) {
-    if (segments[i].prompt.trim() === "") blank.push(i);
-    if (segments[i].prompt.includes("|")) piped.push(i);
+    const p = segments[i].prompt;
+    if (p.trim() === "") blank.push(i);
+    else if (p.trim() !== p) padded.push(i);
+    if (p.includes("|")) piped.push(i);
   }
   if (blank.length) {
     warnings.push(
@@ -292,6 +319,13 @@ function timelineWarnings(segments) {
         `"|" characters from the prompt text.`,
     );
   }
+  if (padded.length) {
+    warnings.push(
+      `segment(s) ${padded.join(", ")} have leading/trailing whitespace. PromptRelay strips each entry ` +
+        `after splitting local_prompts, so the text it actually encodes is the TRIMMED prompt — the ` +
+        `padding you set is not part of the render.`,
+    );
+  }
   return warnings;
 }
 
@@ -299,6 +333,43 @@ function timelineWarnings(segments) {
 function findWidget(node, name) {
   const widgets = Array.isArray(node?.widgets) ? node.widgets : [];
   return widgets.find((w) => w?.name === name) ?? null;
+}
+
+/** The live editor's in-memory timeline, when it is a usable one; otherwise null. */
+function liveEditorTimeline(editor) {
+  const tl = editor && typeof editor === "object" ? editor.timeline : null;
+  if (!isPlainObject(tl) || !Array.isArray(tl.segments) || tl.segments.length === 0) return null;
+  return tl;
+}
+
+/**
+ * Pick which timeline the write MERGES onto — the single trickiest decision here, because the
+ * two candidates can each be the stale one:
+ *
+ *   * The `timeline_data` WIDGET lags while the user is typing. The editor's textarea handler
+ *     updates `this.timeline` and `local_prompts` IMMEDIATELY but debounces the timeline_data
+ *     JSON write by 120 ms. Merging onto the widget in that window would rebuild from the
+ *     pre-keystroke timeline and DESTROY the text the user just typed.
+ *   * The EDITOR's `this.timeline` lags right after a workflow load: `onConfigure` restores the
+ *     widgets first and re-parses the editor 10 ms later. Merging onto the editor in that
+ *     window would resurrect the PREVIOUS workflow's timeline.
+ *
+ * `local_prompts` breaks the tie: it is the value the node would EXECUTE right now, and both
+ * update paths (the editor's live keystroke handler, and a workflow load restoring the saved
+ * widgets) keep it in step with whichever timeline is current. So prefer the candidate whose
+ * derived prompts match it. If neither matches, the node is genuinely desynced and the
+ * timeline_data widget — the node's master field — wins, with the out-of-band text reported.
+ */
+function chooseMergeBase(editor, widgets) {
+  const currentPrompts = widgets.local_prompts.value;
+  const fromEditor = liveEditorTimeline(editor);
+  const fromWidget = parsePromptRelayTimeline(widgets[PROMPT_RELAY_MASTER_WIDGET].value);
+  if (fromEditor && derivePromptRelayWidgets(fromEditor.segments).local_prompts === currentPrompts) {
+    return { base: fromEditor, baseSource: "editor" };
+  }
+  if (fromWidget) return { base: fromWidget, baseSource: "timeline_data" };
+  if (fromEditor) return { base: fromEditor, baseSource: "editor" };
+  return { base: null, baseSource: "none" };
 }
 
 /** The refusal message for a DERIVED-widget write — explains why + points at timeline_data. */
@@ -321,8 +392,9 @@ export function promptRelayDerivedRefusal(widgetName, nodeId) {
  * interleave between the read of the current timeline and the write of the new one):
  *   1. validate the caller's value,
  *   2. resolve ALL THREE widgets (refuse if any is missing — a reconcile would be impossible),
- *   3. MERGE the caller's top-level fields onto the node's CURRENT timeline so anything they
- *      did not mention is preserved (never defaulted away),
+ *   3. MERGE the caller's top-level fields onto the node's CURRENT timeline — see
+ *      chooseMergeBase for which of the editor / widget copies is the current one — so
+ *      anything they did not mention is preserved (never defaulted away),
  *   4. validate + normalize the merged segments (refusing every coerce/reset case),
  *   5. COMPUTE all three final widget values,
  *   6. only then MUTATE — three plain assignments that cannot throw, so there is no path that
@@ -365,15 +437,16 @@ export function applyPromptRelayTimelineWrite(
   // OMISSION preserves. An overlay that omits `segments` entirely is therefore an idempotent
   // RE-RECONCILE of the node's existing timeline — which is also the repair path for a node
   // that is already desynced — and is refused only when there is no current timeline to keep.
-  const base = parsePromptRelayTimeline(widgets[PROMPT_RELAY_MASTER_WIDGET].value);
+  const editor = typeof getEditor === "function" ? getEditor(node) : node?._timelineEditor;
+  const { base, baseSource } = chooseMergeBase(editor, widgets);
   const merged = base ? { ...base, ...overlay } : { ...overlay };
   const segments = normalizeSegments(merged, Array.isArray(base?.segments) ? base.segments : null);
   const finalTimeline = { ...merged, segments };
 
   // The node is ALREADY out of sync when its current local_prompts / segment_lengths are not
-  // what its current timeline_data produces — e.g. prompt text written straight into
-  // local_prompts with the #506 workaround, which exists ONLY there. That text is about to be
-  // replaced, so hand it back rather than letting it vanish silently.
+  // what the base timeline produces — e.g. prompt text written straight into local_prompts with
+  // the #506 workaround, which exists ONLY there (and which the node's next commit would revert
+  // anyway). That text is about to be replaced, so hand it back rather than let it vanish.
   const baseDerived = base ? derivePromptRelayWidgets(base.segments) : null;
   const replaced = {};
   if (baseDerived) {
@@ -405,9 +478,9 @@ export function applyPromptRelayTimelineWrite(
     widgets.local_prompts.value = derived.local_prompts;
     widgets.segment_lengths.value = derived.segment_lengths;
 
-    // Re-hydrate the live editor from the SAME object so its next commit re-derives exactly
-    // what we just wrote (a no-op) instead of reverting to the stale in-memory timeline.
-    const editor = typeof getEditor === "function" ? getEditor(node) : node?._timelineEditor;
+    // Re-hydrate the live editor from the SAME object so its next commit — including a
+    // still-pending 120 ms textarea debounce — re-derives exactly what we just wrote (a no-op)
+    // instead of reverting to the stale in-memory timeline.
     if (editor && typeof editor === "object") {
       editor.timeline = finalTimeline;
       const last = segments.length - 1;
@@ -444,6 +517,7 @@ export function applyPromptRelayTimelineWrite(
       reconciled: true,
       segments: segments.length,
       merged_onto_current: base != null,
+      merge_base: baseSource,
       editor_synced: editorSynced,
       local_prompts: derived.local_prompts,
       segment_lengths: derived.segment_lengths,

--- a/web/js/lib/prompt-relay-timeline.js
+++ b/web/js/lib/prompt-relay-timeline.js
@@ -380,15 +380,17 @@ function timelineWarnings(segments) {
  * so a prompt containing a literal "|" can never make a real overwrite look like a no-op.
  */
 function sameLength(x, y) {
-  // Identical values (including two absent ones) match outright. Otherwise ONLY numerically:
-  // a numeric-string base ("24") must match a normalized 24, but nothing else is coerced —
-  // stringifying instead would make a `null` length compare equal to a `"null"` one.
+  // Identical values (including two absent ones) match outright. Otherwise the two sides are
+  // equal only when they normalize to the SAME stored frame count through the very rule the
+  // write path uses — so "24" matches 24, while "2e3" does NOT match 2000 (the pack's
+  // parseInt reads "2e3" as 2, so treating them as equal would suppress the disclosure while
+  // a live 2000-frame segment was replaced by a 2-frame one). A plain Number() coercion would
+  // do exactly that; stringifying would make `null` equal `"null"`. Anything this cannot
+  // prove equal counts as DIFFERENT, which errs toward disclosing rather than hiding a loss.
   if (x === y) return true;
-  const num = (v) =>
-    typeof v === "number" ? v : typeof v === "string" && v.trim() !== "" ? Number(v) : NaN;
-  const nx = num(x);
-  const ny = num(y);
-  return Number.isFinite(nx) && Number.isFinite(ny) && nx === ny;
+  const nx = normalizeSegmentLength(x);
+  const ny = normalizeSegmentLength(y);
+  return nx !== null && ny !== null && nx === ny;
 }
 
 export function sameSegmentContent(a, b) {

--- a/web/js/lib/prompt-relay-timeline.js
+++ b/web/js/lib/prompt-relay-timeline.js
@@ -48,7 +48,10 @@
 // envelope before being replaced, so no prompt text ever disappears without the caller being
 // told — as is an UNCOMMITTED edit the user was still typing when the write landed
 // (`overwrote_uncommitted_edit`) and a timeline_data copy that lost to the editor
-// (`superseded_timeline_data`). Anything PromptRelay's python would encode differently from
+// (`superseded_timeline_data`). Both carry the prior prompts PER SEGMENT, and both are decided
+// by comparing segment ARRAYS (sameSegmentContent), never the derived `" | "` join, which is
+// lossy and would hide a real overwrite whenever a prompt contains a literal "|".
+// Anything PromptRelay's python would encode differently from
 // what the timeline shows (a blank prompt, a literal "|", padding whitespace) comes back as a
 // warning. The invariant: the panel never leaves the timeline saying A, the prompts saying B,
 // and the caller told nothing.
@@ -199,6 +202,12 @@ export function parsePromptRelayTimeline(raw) {
  *   segment_lengths = segments.map(s => s.length).join(", ")
  * Keeping this in ONE exported place means the production path and the tests agree, and any
  * drift from the pack is a one-line change here.
+ *
+ * THE JOIN IS LOSSY AND MUST NEVER DECIDE WHETHER CONTENT CHANGED. `" | "` is not an
+ * injection: `["a | b", "c"]` and `["a", "b | c"]` both join to `"a | b | c"`. It is only
+ * valid to compare a derived string against a WIDGET, because the widget itself stores nothing
+ * but the join — asking "is this widget consistent with this timeline?". Asking "did the user's
+ * segments change?" requires the STRUCTURAL comparison in sameSegmentContent().
  */
 export function derivePromptRelayWidgets(segments) {
   const segs = Array.isArray(segments) ? segments : [];
@@ -363,6 +372,37 @@ function timelineWarnings(segments) {
   return warnings;
 }
 
+/**
+ * Do two segment lists carry the SAME user content? Compared element-by-element on the fields
+ * that hold authored data — never through `derivePromptRelayWidgets`, whose `" | "` join is
+ * lossy: `["a | b", "c"]` and `["a", "b | c"]` produce an identical `local_prompts` while being
+ * completely different timelines. Every "did the content change?" decision goes through here,
+ * so a prompt containing a literal "|" can never make a real overwrite look like a no-op.
+ * Lengths are compared as strings so a numeric-string base ("24") matches a normalized 24 and
+ * two NaNs match, without NaN !== NaN reporting a phantom difference.
+ */
+export function sameSegmentContent(a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i]?.prompt !== b[i]?.prompt) return false;
+    if (String(a[i]?.length) !== String(b[i]?.length)) return false;
+  }
+  return true;
+}
+
+/**
+ * A RECOVERABLE snapshot of a segment list for the result envelope: the authored prompt
+ * strings themselves, per segment, plus their lengths. Deliberately NOT the joined
+ * `local_prompts` — handing back `"a | b | c"` for a timeline whose real segments were
+ * `["a | b", "c"]` would tell the caller their text was lost without telling them what it was.
+ */
+function contentSnapshot(segments) {
+  return {
+    prompts: segments.map((s) => (typeof s?.prompt === "string" ? s.prompt : "")),
+    lengths: segments.map((s) => s?.length),
+  };
+}
+
 /** Locate a widget by name on a LiteGraph node. */
 function findWidget(node, name) {
   const widgets = Array.isArray(node?.widgets) ? node.widgets : [];
@@ -488,7 +528,7 @@ export function applyPromptRelayTimelineWrite(
   // RE-RECONCILE of the node's existing timeline — which is also the repair path for a node
   // that is already desynced — and is refused only when there is no current timeline to keep.
   const editor = typeof getEditor === "function" ? getEditor(node) : node?._timelineEditor;
-  const { base, baseSource, fromWidget } = chooseMergeBase(editor, widgets);
+  const { base, baseSource, fromWidget, fromEditor } = chooseMergeBase(editor, widgets);
   const merged = base ? { ...base, ...overlay } : { ...overlay };
   const segments = normalizeSegments(merged, Array.isArray(base?.segments) ? base.segments : null);
   const finalTimeline = { ...merged, segments };
@@ -513,42 +553,43 @@ export function applyPromptRelayTimelineWrite(
   const timelineJson = JSON.stringify(finalTimeline);
   const warnings = timelineWarnings(segments);
 
-  // chooseMergeBase only falls back to the editor when the timeline_data widget has gone
-  // stale, which means a prompt edit was IN FLIGHT (typed into the node's prompt box, not yet
-  // committed). Merging preserves it — but a caller who supplies `segments` REPLACES the list,
-  // and that legitimately discards the in-flight text. That is the caller's stated intent, so
-  // it is applied rather than refused, but it is never left silent.
+  // The node keeps TWO copies of the timeline (the editor's in-memory one and the
+  // timeline_data widget), and either can be the current one — see chooseMergeBase. When they
+  // agree there is nothing hidden: the caller read the node, and discarding the old content is
+  // exactly what they asked for. When they DISAGREE the node is in an anomalous state and one
+  // copy holds content the caller may never have seen — an edit still being typed, or prompts a
+  // raw timeline_data write left behind (the #506 state itself). So whenever the two copies
+  // diverge, any copy this write does not reproduce is handed back.
+  //
+  // Every comparison here is STRUCTURAL (sameSegmentContent), never the derived join. Gating on
+  // the joined local_prompts would miss a real overwrite whenever a prompt contains a literal
+  // "|": the persisted pair ["old","c"], an in-flight edit turning segment 0 into "a | b", and
+  // an incoming write of ["a","b | c"] all reduce to the SAME string "a | b | c" while being
+  // three different timelines.
+  const editorSegs = Array.isArray(fromEditor?.segments) ? fromEditor.segments : null;
+  const widgetSegs = Array.isArray(fromWidget?.segments) ? fromWidget.segments : null;
+  const copiesDiverge = !!editorSegs && !!widgetSegs && !sameSegmentContent(editorSegs, widgetSegs);
+
   const overwroteInFlight =
-    baseSource === "editor" && baseDerived && baseDerived.local_prompts !== derived.local_prompts
-      ? baseDerived.local_prompts
-      : null;
-  if (overwroteInFlight !== null) {
+    copiesDiverge && !sameSegmentContent(editorSegs, segments) ? contentSnapshot(editorSegs) : null;
+  if (overwroteInFlight) {
     warnings.push(
-      `this node had an UNCOMMITTED prompt edit in progress (text typed into the node's prompt box ` +
-        `that had not yet reached timeline_data). The segments you supplied REPLACED it; the text ` +
-        `that was in flight is returned as "overwrote_uncommitted_edit". Re-read the node and write ` +
-        `again if you meant to keep it.`,
+      `this node held an UNCOMMITTED timeline edit — the live editor's segments (what the node ` +
+        `would execute right now) did not match its timeline_data, typically text typed into the ` +
+        `prompt box that had not yet been committed. The segments you supplied REPLACED it. The ` +
+        `prompts that were in flight are returned PER SEGMENT as ` +
+        `"overwrote_uncommitted_edit.prompts" — write those back if you meant to keep them.`,
     );
   }
 
-  // Deferring to the editor also means the timeline_data widget's OWN copy was set aside. Two
-  // states look identical from here: the widget is merely a pre-keystroke snapshot (normal), or
-  // it holds prompts a raw timeline_data write put there that never reached the editor — the
-  // #506 state itself, e.g. a workflow touched by an older panel. The editor copy wins because
-  // it is what the node would EXECUTE right now, but the prompts being set aside are handed
-  // back either way rather than disappearing.
-  const supersededMaster =
-    baseSource === "editor" && fromWidget
-      ? derivePromptRelayWidgets(fromWidget.segments).local_prompts
-      : null;
   const supersededTimelineData =
-    supersededMaster !== null && supersededMaster !== derived.local_prompts ? supersededMaster : null;
-  if (supersededTimelineData !== null) {
+    copiesDiverge && !sameSegmentContent(widgetSegs, segments) ? contentSnapshot(widgetSegs) : null;
+  if (supersededTimelineData) {
     warnings.push(
-      `the node's timeline_data widget held DIFFERENT prompts from the timeline editor, and the ` +
-        `editor's copy was used because it is what the node would execute right now. The prompts ` +
-        `that timeline_data held are returned as "superseded_timeline_data" — if those were the ones ` +
-        `you wanted, write them explicitly as "${PROMPT_RELAY_MASTER_WIDGET}" segments.`,
+      `the node's timeline_data widget held DIFFERENT segments from the timeline editor, and your ` +
+        `write did not reproduce them. They are returned PER SEGMENT as ` +
+        `"superseded_timeline_data.prompts" — if those were the prompts you wanted, write them ` +
+        `explicitly as "${PROMPT_RELAY_MASTER_WIDGET}" segments.`,
     );
   }
   if (Object.keys(replaced).length) {
@@ -614,8 +655,8 @@ export function applyPromptRelayTimelineWrite(
       local_prompts: derived.local_prompts,
       segment_lengths: derived.segment_lengths,
       ...(Object.keys(replaced).length ? { replaced_out_of_band: replaced } : {}),
-      ...(overwroteInFlight !== null ? { overwrote_uncommitted_edit: overwroteInFlight } : {}),
-      ...(supersededTimelineData !== null ? { superseded_timeline_data: supersededTimelineData } : {}),
+      ...(overwroteInFlight ? { overwrote_uncommitted_edit: overwroteInFlight } : {}),
+      ...(supersededTimelineData ? { superseded_timeline_data: supersededTimelineData } : {}),
       ...(uiRefreshError ? { ui_refresh_error: uiRefreshError } : {}),
       ...(warnings.length ? { warnings } : {}),
     },

--- a/web/js/lib/prompt-relay-timeline.js
+++ b/web/js/lib/prompt-relay-timeline.js
@@ -441,16 +441,34 @@ function liveEditorTimeline(editor) {
  *     window would resurrect the PREVIOUS workflow's timeline — including its lengths and any
  *     per-segment metadata, not just its prompts.
  *
- * The DERIVED widgets break the tie, and the rule is "widget first, editor only as the
- * exception". `timeline_data` is the node's master field, so it wins WHENEVER it still agrees
- * with the derived widgets. The debounce window is the one moment it does not: the keystroke
- * handler has already advanced `local_prompts` past the pre-keystroke JSON. Deferring to the
- * editor only in that case means a stale post-load editor can never be chosen — after a load
- * the restored widgets agree with each other, so the widget wins even if the old editor
- * happens to derive the same strings.
+ * The derived widgets narrow the choice, but they can only ever act as a FILTER, never as a
+ * tie-break. A join comparison answers exactly one question — "could this widget hold this
+ * timeline's serialization?" — and it is NOT able to answer "which of two timelines is
+ * current?", because `" | "` is lossy: `["a", "b | c"]` and `["a | b", "c"]` with equal
+ * lengths produce byte-identical `local_prompts` AND `segment_lengths`, so both candidates
+ * look consistent while being different timelines. Settling authority on that equality is how
+ * a metadata-only overlay (say `{ "zoom": 4 }`) could rebuild from a stale master and destroy
+ * a live two-box edit without ever being asked to change a segment.
  *
- * Both derived widgets are compared, not just `local_prompts`: two different timelines can
- * share a prompt join while differing in segment lengths.
+ * So the order is:
+ *   1. only one candidate readable  → it wins;
+ *   2. both readable and STRUCTURALLY identical → no authority question exists; the master
+ *      field is canonical;
+ *   3. they differ and exactly ONE is consistent with the derived widgets → that one is
+ *      current (this is what separates the debounce window from the post-load window);
+ *   4. they differ and the filter CANNOT separate them (both consistent — colliding joins — or
+ *      neither) → prefer the LIVE EDITOR. It is the only copy that can hold text existing
+ *      nowhere else; a superseded master is still on disk, an uncommitted keystroke is not.
+ *      The choice is flagged (`merge_base_ambiguous`) and the losing copy is handed back, so a
+ *      tie is never resolved silently.
+ *
+ * Both derived widgets are compared, not just `local_prompts`: two timelines can share a
+ * prompt join while differing in segment lengths, and that difference is worth catching even
+ * though the reverse collision above is not detectable this way at all.
+ */
+/**
+ * COULD this timeline's serialization be what the derived widgets currently hold? That is the
+ * only question this can answer. It is a FILTER, never a tie-break — see chooseMergeBase.
  */
 function derivedMatchesWidgets(timeline, widgets) {
   if (!timeline) return false;
@@ -464,14 +482,33 @@ function derivedMatchesWidgets(timeline, widgets) {
 function chooseMergeBase(editor, widgets) {
   const fromEditor = liveEditorTimeline(editor);
   const fromWidget = parsePromptRelayTimeline(widgets[PROMPT_RELAY_MASTER_WIDGET].value);
-  const pick = (base, baseSource) => ({ base, baseSource, fromWidget, fromEditor });
-  if (derivedMatchesWidgets(fromWidget, widgets)) return pick(fromWidget, "timeline_data");
-  if (derivedMatchesWidgets(fromEditor, widgets)) return pick(fromEditor, "editor");
-  // Neither agrees with what the node would execute: it is genuinely desynced. The master
-  // field wins and the out-of-band text is reported back to the caller.
-  if (fromWidget) return pick(fromWidget, "timeline_data");
-  if (fromEditor) return pick(fromEditor, "editor");
-  return pick(null, "none");
+  const pick = (base, baseSource, ambiguous = false) => ({
+    base,
+    baseSource,
+    fromWidget,
+    fromEditor,
+    ambiguous,
+  });
+  // 1. Only one record to merge onto (or none).
+  if (!fromEditor && !fromWidget) return pick(null, "none");
+  if (!fromEditor) return pick(fromWidget, "timeline_data");
+  if (!fromWidget) return pick(fromEditor, "editor");
+  // 2. The two records carry the SAME content, so there is no authority to settle. The master
+  //    field is canonical (it also carries the persisted non-segment fields).
+  if (sameSegmentContent(fromEditor.segments, fromWidget.segments)) {
+    return pick(fromWidget, "timeline_data");
+  }
+  // 3. They differ. Use the derived widgets as a FILTER: whichever record could NOT have
+  //    produced what the node would execute right now is the stale one.
+  const editorConsistent = derivedMatchesWidgets(fromEditor, widgets);
+  const widgetConsistent = derivedMatchesWidgets(fromWidget, widgets);
+  if (widgetConsistent && !editorConsistent) return pick(fromWidget, "timeline_data");
+  if (editorConsistent && !widgetConsistent) return pick(fromEditor, "editor");
+  // 4. The filter cannot separate them — either both serialize to the same derived strings
+  //    (the lossy-join collision) or neither matches at all. Prefer the LIVE EDITOR: losing a
+  //    superseded master is recoverable from the saved workflow, losing an uncommitted edit is
+  //    not. Flagged as ambiguous, and the copy that lost is returned to the caller.
+  return pick(fromEditor, "editor", true);
 }
 
 /** The refusal message for a DERIVED-widget write — explains why + points at timeline_data. */
@@ -540,7 +577,13 @@ export function applyPromptRelayTimelineWrite(
   // RE-RECONCILE of the node's existing timeline — which is also the repair path for a node
   // that is already desynced — and is refused only when there is no current timeline to keep.
   const editor = typeof getEditor === "function" ? getEditor(node) : node?._timelineEditor;
-  const { base, baseSource, fromWidget, fromEditor } = chooseMergeBase(editor, widgets);
+  const {
+    base,
+    baseSource,
+    fromWidget,
+    fromEditor,
+    ambiguous: baseAmbiguous,
+  } = chooseMergeBase(editor, widgets);
   const merged = base ? { ...base, ...overlay } : { ...overlay };
   const segments = normalizeSegments(merged, Array.isArray(base?.segments) ? base.segments : null);
   const finalTimeline = { ...merged, segments };
@@ -606,6 +649,15 @@ export function applyPromptRelayTimelineWrite(
     anomalous && widgetSegs && !sameSegmentContent(widgetSegs, segments)
       ? contentSnapshot(widgetSegs)
       : null;
+  if (baseAmbiguous) {
+    warnings.push(
+      `the node's two records of the timeline held DIFFERENT segments and its derived widgets ` +
+        `could not tell which is current (the " | " join is lossy, so different segment splits ` +
+        `serialize identically). The LIVE EDITOR's copy was used, because it is the only one that ` +
+        `can hold text not yet saved anywhere; the timeline_data copy is returned as ` +
+        `"superseded_timeline_data" if this write did not reproduce it.`,
+    );
+  }
   if (supersededTimelineData) {
     warnings.push(
       `the node's timeline_data widget held DIFFERENT segments from the timeline editor, and your ` +
@@ -673,6 +725,7 @@ export function applyPromptRelayTimelineWrite(
       segments: segments.length,
       merged_onto_current: base != null,
       merge_base: baseSource,
+      ...(baseAmbiguous ? { merge_base_ambiguous: true } : {}),
       editor_synced: editorSynced,
       local_prompts: derived.local_prompts,
       segment_lengths: derived.segment_lengths,

--- a/web/js/lib/prompt-relay-timeline.js
+++ b/web/js/lib/prompt-relay-timeline.js
@@ -72,11 +72,13 @@
 // governs WHICH copy is authoritative: a join comparison can only ask "could this widget hold
 // this timeline's serialization?", never "which of two colliding timelines is current?" — so
 // chooseMergeBase uses it as a filter, and when the filter cannot separate the two the write
-// FAILS CLOSED rather than guess: a tie with no explicit `segments` is REFUSED with both copies
-// disclosed and nothing mutated (keeping the editor's copy could write the previous workflow's
-// timeline back over the one a load just restored; keeping the widget's could destroy text still
-// being typed — neither guess is acceptable), and only an explicit `segments` list, which
-// replaces BOTH records outright, may proceed, declared via `merge_base_ambiguous`.
+// FAILS CLOSED rather than guess: a tie is REFUSED with both copies disclosed and nothing
+// mutated. Keeping the editor's copy could write the previous workflow's timeline back over the
+// one a load just restored; keeping the widget's could destroy text still being typed — and
+// explicit `segments` are NO exception, because they still destroy whichever copy they do not
+// reproduce behind a "reconciled" report. Success requires a resolved base; a tie is usually
+// transient (the editor's commit debounce or its post-load re-parse), so the caller re-issues
+// once the records agree.
 // Anything PromptRelay's python would encode differently from
 // what the timeline shows (a blank prompt, a literal "|", padding whitespace) comes back as a
 // warning. The invariant: the panel never leaves the timeline saying A, the prompts saying B,
@@ -582,17 +584,58 @@ function derivedMatchesWidgets(timeline, widgets) {
  * widget's JSON. Instead the editor-KNOWN fields are merged ONTO the widget's timeline object:
  * the widget (the persisted record, which the editor never edits around) supplies everything
  * else, the editor stays authoritative for the segment list and the fields it actually holds.
- * Per segment the same-index widget segment is the only correspondence available (segments
- * carry no ids); a reorder inside the 120 ms debounce window could misattach an unknown field —
- * a narrower loss than dropping every such field outright, which is what replacing did.
+ *
+ * Per segment the correspondence between the two lists is the hazard: segments carry no ids,
+ * and the editor's list can differ from the widget's by MORE than the keystroke that made it
+ * authoritative — a reorder or a shrink inside the 120 ms debounce window. Carrying unmodelled
+ * fields BY INDEX would then attach a removed/old segment's metadata to a surviving prompt it
+ * was never written for. So the carry is keyed, never positional-by-default:
+ *
+ *   * ALIGNED lists — same length and AT MOST one index disagreeing on prompt — are the
+ *     in-place-typing signature: every position is provably the same segment, so the
+ *     same-index widget segment carries (this is what lets a mid-keystroke prompt edit keep
+ *     its segment's unmodelled fields).
+ *   * Anything else (reorder / shrink / grow / several edits in one window) breaks positional
+ *     proof. A segment may still carry from a widget segment with the SAME prompt — but only
+ *     when that prompt is UNIQUE on both sides, making the pairing 1:1. A duplicated prompt or
+ *     no match means the mapping is AMBIGUOUS, and ambiguous means NO carry: losing an
+ *     unmodelled extra field beats writing it onto the WRONG segment, and the write's
+ *     disclosures already hand back anything the node loses.
  */
 function editorTimelineOntoWidget(fromEditor, fromWidget) {
   const widgetSegs = Array.isArray(fromWidget?.segments) ? fromWidget.segments : [];
-  const segments = fromEditor.segments.map((seg, i) => {
+  const editorSegs = fromEditor.segments;
+  let indexAligned = widgetSegs.length === editorSegs.length;
+  if (indexAligned) {
+    let promptDiffs = 0;
+    for (let i = 0; i < editorSegs.length; i++) {
+      if (editorSegs[i]?.prompt !== widgetSegs[i]?.prompt) promptDiffs++;
+    }
+    indexAligned = promptDiffs <= 1;
+  }
+  // Prompt popularity on each side, for the 1:1 content match. Only STRING prompts participate
+  // — anything else can never prove a pairing.
+  const promptCount = (list) => {
+    const counts = new Map();
+    for (const s of list) {
+      if (typeof s?.prompt === "string") counts.set(s.prompt, (counts.get(s.prompt) ?? 0) + 1);
+    }
+    return counts;
+  };
+  const inEditor = promptCount(editorSegs);
+  const inWidget = promptCount(widgetSegs);
+  const carryFor = (seg, i) => {
+    if (indexAligned) return isPlainObject(widgetSegs[i]) ? widgetSegs[i] : {};
+    if (typeof seg.prompt !== "string") return {};
+    if (inEditor.get(seg.prompt) !== 1 || inWidget.get(seg.prompt) !== 1) return {};
+    const match = widgetSegs.find((w) => w?.prompt === seg.prompt);
+    return isPlainObject(match) ? match : {};
+  };
+  const segments = editorSegs.map((seg, i) => {
     // A malformed editor segment is passed through untouched so normalizeSegments refuses it
     // loudly, exactly as it would have on the raw editor copy.
     if (!isPlainObject(seg)) return seg;
-    const base = isPlainObject(widgetSegs[i]) ? widgetSegs[i] : {};
+    const base = carryFor(seg, i);
     // Only fields the editor actually HOLDS may override the widget's; an absent or undefined
     // one keeps the widget's value instead of clobbering it.
     const held = {};
@@ -608,8 +651,8 @@ function chooseMergeBase(editor, widgets) {
   const fromEditor = liveEditorTimeline(editor);
   const fromWidget = parsePromptRelayTimeline(widgets[PROMPT_RELAY_MASTER_WIDGET].value);
   // `reason` records WHICH branch settled authority. That matters downstream: a copy set aside
-  // by the case-3 filter was proven stale, while one set aside by a tie or by being superseded
-  // was not — and the two deserve very different disclosures.
+  // by the case-3 filter was proven stale, while one set aside by being superseded was not —
+  // and the two deserve very different disclosures.
   const pick = (base, baseSource, reason, ambiguous = false) => ({
     base,
     baseSource,
@@ -669,8 +712,9 @@ export function promptRelayDerivedRefusal(widgetName, nodeId) {
  *   3. MERGE the caller's top-level fields onto the node's CURRENT timeline — see
  *      chooseMergeBase for which of the editor / widget copies is the current one — so
  *      anything they did not mention is preserved (never defaulted away). When neither copy
- *      can be PROVEN current (an unresolved tie) this step fails closed: refused outright
- *      unless the caller supplied `segments` explicitly. Symmetrically, when the editor is
+ *      can be PROVEN current (an unresolved tie) this step fails closed: refused outright,
+ *      with or without explicit `segments` — they would still destroy whichever copy they do
+ *      not reproduce behind a "reconciled" report. Symmetrically, when the editor is
  *      PROVEN current (the mid-debounce signature) but the write's explicit `segments` would
  *      not reproduce its text, the write fails closed too — refused with both states
  *      disclosed, because applying it would destroy the in-flight edit while reporting
@@ -725,36 +769,38 @@ export function applyPromptRelayTimelineWrite(
     fromEditor,
     ambiguous: baseAmbiguous,
   } = chosen;
-  let { base, baseSource } = chosen;
+  const { base, baseSource } = chosen;
   if (baseAmbiguous) {
-    // A tie FAILS CLOSED. The filter could not prove which record is current, so reconciling
-    // FROM either copy would be a guess: keeping the editor's segments can write the PREVIOUS
-    // workflow's timeline back over the one a load just restored, keeping the widget's can
-    // destroy text still being typed. Only an explicit `segments` list may proceed — it
-    // replaces BOTH records outright, so the tie cannot resurrect anything. Anything else is
-    // refused with both copies disclosed and NOTHING mutated (a truthful failure, not a
-    // "reconciled" success built on a guess).
-    if (!Object.prototype.hasOwnProperty.call(overlay, "segments")) {
-      const editorCopy = contentSnapshot(Array.isArray(fromEditor?.segments) ? fromEditor.segments : []);
-      const widgetCopy = contentSnapshot(Array.isArray(fromWidget?.segments) ? fromWidget.segments : []);
-      throw new PromptRelayTimelineWriteError(
-        `PromptRelayEncodeTimeline node ${node?.id} holds TWO different timelines — one in its live ` +
-          `timeline editor, one in its timeline_data widget — and its derived widgets CANNOT tell ` +
-          `which is current (the " | " join is lossy, so structurally different timelines can ` +
-          `serialize identically). This write did not supply "segments", so reconciling would mean ` +
-          `GUESSING which copy to keep: one may be the timeline a workflow load just restored, the ` +
-          `other may hold prompt text that exists nowhere else. REFUSED, and nothing was written ` +
-          `(#506). The editor holds prompts ${JSON.stringify(editorCopy.prompts)} (lengths ` +
-          `${JSON.stringify(editorCopy.lengths)}); timeline_data holds prompts ` +
-          `${JSON.stringify(widgetCopy.prompts)} (lengths ${JSON.stringify(widgetCopy.lengths)}). ` +
-          `Re-issue the write with the full "segments" array you intend — explicit segments replace ` +
-          `BOTH copies outright.`,
-      );
-    }
-    // Explicit segments: merge onto the PERSISTED widget for everything else — never the
-    // ambiguous editor copy, whose unmodeled top-level fields may belong to the old workflow.
-    base = fromWidget;
-    baseSource = "timeline_data";
+    // A tie FAILS CLOSED — with or without explicit `segments`. The filter could not prove
+    // which record is current, so reconciling FROM either copy would be a guess: keeping the
+    // editor's segments can write the PREVIOUS workflow's timeline back over the one a load
+    // just restored, keeping the widget's can destroy text still being typed. Explicit
+    // segments are NO exception: they replace the record they are written onto, but the copy
+    // they do not reproduce is still permanently destroyed — and the call would report a
+    // reconciled success for it. There is no resolved base, so there is no write: refused
+    // with both copies disclosed and NOTHING mutated. The tie is usually TRANSIENT (the
+    // editor's ~120 ms commit debounce, or its ~10 ms re-parse after a workflow load), so the
+    // remedy is to re-issue once it settles and the two records agree; a PERSISTENT tie can
+    // only be converged on the canvas, where an explicit edit commits the editor's copy to
+    // timeline_data — a deliberate act, not a guess this route made.
+    const editorCopy = contentSnapshot(Array.isArray(fromEditor?.segments) ? fromEditor.segments : []);
+    const widgetCopy = contentSnapshot(Array.isArray(fromWidget?.segments) ? fromWidget.segments : []);
+    throw new PromptRelayTimelineWriteError(
+      `PromptRelayEncodeTimeline node ${node?.id} holds TWO different timelines — one in its live ` +
+        `timeline editor, one in its timeline_data widget — and its derived widgets CANNOT tell ` +
+        `which is current (the " | " join is lossy, so structurally different timelines can ` +
+        `serialize identically). Reconciling from either copy would mean GUESSING which to keep: ` +
+        `one may be the timeline a workflow load just restored, the other may hold prompt text ` +
+        `that exists nowhere else — and explicit "segments" do NOT settle that, since they would ` +
+        `still permanently destroy whichever copy they do not reproduce behind a "reconciled" ` +
+        `report. REFUSED, and nothing was written (#506). The editor holds prompts ` +
+        `${JSON.stringify(editorCopy.prompts)} (lengths ${JSON.stringify(editorCopy.lengths)}); ` +
+        `timeline_data holds prompts ${JSON.stringify(widgetCopy.prompts)} (lengths ` +
+        `${JSON.stringify(widgetCopy.lengths)}). This state is usually TRANSIENT — the editor's ` +
+        `~120 ms commit debounce or its ~10 ms re-parse after a workflow load — so re-issue once ` +
+        `it settles and the two records agree. If it PERSISTS, converge the records first by ` +
+        `committing the intended copy in the node's timeline editor on the canvas, then re-issue.`,
+    );
   }
   const merged = base ? { ...base, ...overlay } : { ...overlay };
   const segments = normalizeSegments(merged, Array.isArray(base?.segments) ? base.segments : null);
@@ -902,16 +948,6 @@ export function applyPromptRelayTimelineWrite(
     editorWasAuthority && widgetSegs && !sameSegmentContent(widgetSegs, segments)
       ? contentSnapshot(widgetSegs)
       : null;
-  if (baseAmbiguous) {
-    warnings.push(
-      `the node's two records of the timeline held DIFFERENT segments and its derived widgets ` +
-        `could not tell which was current (the " | " join is lossy, so different segment splits ` +
-        `serialize identically). Your explicit "segments" replaced BOTH records, so no ambiguous ` +
-        `copy was written back over the other; the live editor's previous segments are returned ` +
-        `per segment as "discarded_stale_editor" / "discarded_unverified_editor_copy" if this ` +
-        `write did not reproduce them.`,
-    );
-  }
   if (supersededTimelineData) {
     warnings.push(
       `the node's timeline_data widget held DIFFERENT segments from the timeline editor, and your ` +
@@ -980,7 +1016,6 @@ export function applyPromptRelayTimelineWrite(
       merged_onto_current: base != null,
       merge_base: baseSource,
       merge_base_reason: baseReason,
-      ...(baseAmbiguous ? { merge_base_ambiguous: true } : {}),
       editor_synced: editorSynced,
       local_prompts: derived.local_prompts,
       segment_lengths: derived.segment_lengths,

--- a/web/js/lib/prompt-relay-timeline.js
+++ b/web/js/lib/prompt-relay-timeline.js
@@ -1,0 +1,455 @@
+// Targeted support for driving the ComfyUI-PromptRelay `PromptRelayEncodeTimeline` node
+// via panel_set_widget (#506). Sibling of ltx-director.js (#314), but a DIFFERENT node with
+// DIFFERENT mechanics — kept in its own module so neither can regress the other.
+//
+// THE PROBLEM (#506). PromptRelayEncodeTimeline has three HIDDEN widgets:
+//   * `timeline_data`    — JSON `{ segments: [ { prompt, length, color }, … ] }`; the state
+//                          the node's own TimelineEditor parses ONCE (constructor / onConfigure)
+//                          into the in-memory `this.timeline` that the canvas draws.
+//   * `local_prompts`    — DERIVED: `segments.map(s => s.prompt).join(" | ")`
+//   * `segment_lengths`  — DERIVED: `segments.map(s => s.length).join(", ")`
+// The editor regenerates BOTH derived widgets from `this.timeline` on every commit
+// (`syncWidgetsFromTimeline`).
+//
+// The node's PYTHON `execute()` reads ONLY `global_prompt`, `local_prompts` and
+// `segment_lengths`. It NEVER reads `timeline_data`. So a raw panel_set_widget on
+// `timeline_data`:
+//   * writes the widget value, so panel_query_graph reflects it (the tool "succeeds"),
+//   * does NOT reach the editor's `this.timeline`, so the node UI still shows the old blocks,
+//   * leaves `local_prompts` / `segment_lengths` STALE, so the RENDER USES THE OLD PROMPTS, and
+//   * is silently REVERTED on the next commit (any UI touch re-derives timeline_data from the
+//     stale in-memory timeline).
+// That is exactly #506: "timeline_data contains the new prompt while local_prompts still
+// contains the prior prompt", and the executed prompt is the stale one.
+//
+// WHY RECONCILE (regenerate) RATHER THAN REJECT. The derived widgets are a TOTAL, PURE
+// function of `timeline.segments` — the node itself defines them that way. And since
+// execute() never looks at `timeline_data`, rejecting a `timeline_data` write outright would
+// leave NO way to drive this node at all. So a `timeline_data` write regenerates
+// `local_prompts` + `segment_lengths` from the SAME segments and writes all three ATOMICALLY,
+// then re-hydrates the live editor so the UI matches and the next commit is a no-op.
+//
+// UNLIKE LTXDirector, this pack exposes NO re-hydration entry point (`_applyLoadedTimeline`
+// has no equivalent here). We therefore compute the authoritative values ourselves — the
+// derivation is two `join()`s, mirrored verbatim from `syncWidgetsFromTimeline` — and assign
+// them. A consequence is that the write is correct EVEN WHEN NO EDITOR EXISTS (node never
+// rendered, pack JS not loaded): the widgets are consistent, and the editor's constructor
+// re-parses our `timeline_data` when it eventually runs.
+//
+// DATA-LOSS STANCE. User-authored prompt TEXT lives in `timeline_data.segments[].prompt`.
+// Anything the node's own parser would COERCE (a missing prompt → "", a bogus length → 1) or
+// that would make it RESET to a blank two-segment default (absent/empty/malformed segments)
+// is REFUSED LOUDLY instead of applied — a loud, safe failure over silent destruction. Fields
+// the caller does not mention are MERGED from the node's current timeline, never defaulted
+// away. And when the node is found ALREADY desynced (out-of-band `local_prompts` text that
+// the current timeline does not produce — e.g. written with the #506 workaround), the
+// pre-existing value is RETURNED in the result envelope before being replaced, so no prompt
+// text ever disappears without the caller being told.
+
+export const PROMPT_RELAY_TIMELINE_NODE_TYPE = "PromptRelayEncodeTimeline";
+
+// The master widget: the JSON the editor parses into its source-of-truth timeline.
+export const PROMPT_RELAY_MASTER_WIDGET = "timeline_data";
+
+// Derived OUTPUTS of the editor's syncWidgetsFromTimeline(). A direct write shows up in
+// panel_query_graph but is reverted on the next commit AND desyncs the node the other way
+// round ("prompts say A, timeline says B"), so these are refused and redirected.
+export const PROMPT_RELAY_DERIVED_WIDGETS = Object.freeze(["local_prompts", "segment_lengths"]);
+
+// Every widget this route reads or writes. All three must exist for a reconcile to be
+// possible at all.
+const REQUIRED_WIDGETS = Object.freeze([PROMPT_RELAY_MASTER_WIDGET, ...PROMPT_RELAY_DERIVED_WIDGETS]);
+
+// The exact separators the node uses on both sides of the wire: the editor joins with these,
+// and the Python `_encode_relay` splits `local_prompts` on "|" and `segment_lengths` on ",".
+const PROMPT_JOIN = " | ";
+const LENGTH_JOIN = ", ";
+
+// The node clamps every segment to at least one pixel-space frame.
+const MIN_SEGMENT_LENGTH = 1;
+
+// COSMETIC ONLY. Mirrors the pack's block palette so a segment that arrives without a
+// `color` gets a stable one instead of an undefined fill. If the pack's palette ever drifts,
+// the sole effect is a different block colour — no derived value depends on this.
+const FALLBACK_SEGMENT_COLORS = Object.freeze([
+  "#4f8edc",
+  "#e07b3a",
+  "#5cb85c",
+  "#d9534f",
+  "#9b6cd6",
+  "#a07060",
+  "#e377c2",
+  "#7f7f7f",
+  "#c4c447",
+  "#3fbac4",
+]);
+
+/**
+ * True for a PromptRelayEncodeTimeline node (matched on the ComfyUI class, never a value
+ * shape). Matches when EITHER `type` OR `comfyClass` is the class name — not
+ * `type ?? comfyClass`, which would ignore a matching `comfyClass` whenever `type` holds a
+ * different non-null value (the #314 review finding, same trap here).
+ */
+export function isPromptRelayTimelineNode(node) {
+  return (
+    node?.type === PROMPT_RELAY_TIMELINE_NODE_TYPE ||
+    node?.comfyClass === PROMPT_RELAY_TIMELINE_NODE_TYPE
+  );
+}
+
+/**
+ * Classify a set_widget request against the PromptRelay timeline widgets:
+ *   "master"  → timeline_data (reconcile: write all three widgets + re-hydrate the editor)
+ *   "derived" → local_prompts / segment_lengths (refuse, redirect to timeline_data)
+ *   null      → not a PromptRelay timeline widget; use the normal write path
+ * Non-PromptRelayEncodeTimeline nodes always return null, so no other node is perturbed.
+ */
+export function classifyPromptRelayTimelineWrite(node, widgetName) {
+  if (!isPromptRelayTimelineNode(node)) return null;
+  if (widgetName === PROMPT_RELAY_MASTER_WIDGET) return "master";
+  if (PROMPT_RELAY_DERIVED_WIDGETS.includes(widgetName)) return "derived";
+  return null;
+}
+
+export class PromptRelayTimelineWriteError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PromptRelayTimelineWriteError";
+  }
+}
+
+// A PLAIN JSON object (`{}` literal / Object.create(null)) — not an array, not a Map/Set/
+// Date/class instance. The value round-trips through JSON.stringify into the widget, which
+// turns any exotic object into `{}` (an empty timeline the node then resets to its blank
+// default). Rejecting those up front means we never report success for a wipe.
+function isPlainObject(v) {
+  if (v === null || typeof v !== "object" || Array.isArray(v)) return false;
+  const proto = Object.getPrototypeOf(v);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
+ * The node's segment length, normalized to the integer frame count it stores — or null when
+ * the value is one the node's `Math.max(1, parseInt(v, 10) || 1)` would silently MANGLE
+ * (missing, fractional, zero/negative, non-numeric). A numeric integer STRING is accepted
+ * because parseInt handles it losslessly; everything else is refused rather than coerced.
+ */
+function normalizeSegmentLength(v) {
+  if (typeof v === "number") {
+    return Number.isInteger(v) && v >= MIN_SEGMENT_LENGTH ? v : null;
+  }
+  if (typeof v === "string" && /^\s*\d+\s*$/.test(v)) {
+    const n = Number(v.trim());
+    return Number.isInteger(n) && n >= MIN_SEGMENT_LENGTH ? n : null;
+  }
+  return null;
+}
+
+function describe(v) {
+  if (v === undefined) return "undefined";
+  if (v === null) return "null";
+  if (Array.isArray(v)) return "an array";
+  try {
+    return JSON.stringify(v);
+  } catch {
+    return String(v);
+  }
+}
+
+/**
+ * Parse a timeline_data widget string into a plain object, or null when it is empty/invalid.
+ * Used both for the merge base and for detecting a pre-existing desync.
+ */
+export function parsePromptRelayTimeline(raw) {
+  if (typeof raw !== "string" || raw.trim() === "") return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return isPlainObject(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The node's own derivation, mirrored verbatim from `syncWidgetsFromTimeline`:
+ *   local_prompts   = segments.map(s => s.prompt).join(" | ")
+ *   segment_lengths = segments.map(s => s.length).join(", ")
+ * Keeping this in ONE exported place means the production path and the tests agree, and any
+ * drift from the pack is a one-line change here.
+ */
+export function derivePromptRelayWidgets(segments) {
+  const segs = Array.isArray(segments) ? segments : [];
+  return {
+    local_prompts: segs.map((s) => s?.prompt ?? "").join(PROMPT_JOIN),
+    segment_lengths: segs.map((s) => s?.length ?? "").join(LENGTH_JOIN),
+  };
+}
+
+/**
+ * Validate + normalize the caller's value into a plain timeline object.
+ * Accepts an object OR a JSON-object string (the MCP arg schema carries it as a string).
+ * Throws PromptRelayTimelineWriteError on anything the node would silently coerce or reset.
+ */
+export function normalizePromptRelayTimelineValue(value) {
+  let obj = value;
+  if (typeof value === "string") {
+    try {
+      obj = JSON.parse(value);
+    } catch {
+      throw new PromptRelayTimelineWriteError(
+        `timeline_data must be the PromptRelayEncodeTimeline timeline as a JSON object, but the ` +
+          `string is not valid JSON. Pass e.g. {"segments":[{"prompt":"…","length":24}]}.`,
+      );
+    }
+  }
+  if (!isPlainObject(obj)) {
+    throw new PromptRelayTimelineWriteError(
+      `timeline_data must be a JSON OBJECT describing the timeline (with a "segments" array), ` +
+        `not ${describe(obj)}.`,
+    );
+  }
+  return obj;
+}
+
+/**
+ * Validate the EFFECTIVE (post-merge) timeline and return its segments normalized to the
+ * shape the node stores. Every rejection below is a case where the node's own parseInitial
+ * would either RESET to a blank two-segment default (wiping every prompt) or COERCE a field
+ * (destroying that segment's prompt / length) while the tool reported success.
+ */
+function normalizeSegments(timeline, baseSegments) {
+  const segments = timeline.segments;
+  if (!Array.isArray(segments) || segments.length === 0) {
+    throw new PromptRelayTimelineWriteError(
+      `timeline_data.segments must be a NON-EMPTY array of segment objects (got ${describe(segments)}). ` +
+        `The PromptRelayEncodeTimeline editor resets an absent/empty segment list to a blank ` +
+        `two-segment default, which would WIPE every prompt on the node while reporting success — ` +
+        `refusing. Read the node's current timeline_data, edit it, and write the whole object back.`,
+    );
+  }
+  return segments.map((seg, i) => {
+    if (!isPlainObject(seg)) {
+      throw new PromptRelayTimelineWriteError(
+        `timeline_data.segments[${i}] must be a segment OBJECT, not ${describe(seg)}. The node's ` +
+          `parser falls back to a blank two-segment timeline on a malformed segment, WIPING every ` +
+          `prompt — refusing.`,
+      );
+    }
+    if (typeof seg.prompt !== "string") {
+      throw new PromptRelayTimelineWriteError(
+        `timeline_data.segments[${i}].prompt must be a STRING (got ${describe(seg.prompt)}). The node ` +
+          `coerces a missing/non-string prompt to "", which would silently DESTROY that segment's ` +
+          `prompt text — refusing. Pass the prompt explicitly, or "" if you really mean empty.`,
+      );
+    }
+    const length = normalizeSegmentLength(seg.length);
+    if (length === null) {
+      throw new PromptRelayTimelineWriteError(
+        `timeline_data.segments[${i}].length must be a whole number of frames >= ${MIN_SEGMENT_LENGTH} ` +
+          `(got ${describe(seg.length)}). The node clamps anything else to ${MIN_SEGMENT_LENGTH} frame, ` +
+          `silently corrupting the segment lengths that drive the render — refusing.`,
+      );
+    }
+    const color =
+      typeof seg.color === "string"
+        ? seg.color
+        : typeof baseSegments?.[i]?.color === "string"
+          ? baseSegments[i].color
+          : FALLBACK_SEGMENT_COLORS[i % FALLBACK_SEGMENT_COLORS.length];
+    // Spread first so any field a future pack version adds survives the round-trip.
+    return { ...seg, prompt: seg.prompt, length, color };
+  });
+}
+
+/**
+ * Non-fatal notes about states where the node's PYTHON side would execute something other
+ * than what the timeline shows. These are legitimate states the node's own UI can produce, so
+ * they are reported rather than refused — but they are never left silent.
+ *   * `_encode_relay` drops blank entries (`if p.strip()`), so an empty prompt makes the
+ *     prompt count disagree with the length count and shifts every later segment.
+ *   * `local_prompts` is split on "|", so a literal "|" inside a prompt becomes TWO prompts.
+ */
+function timelineWarnings(segments) {
+  const warnings = [];
+  const blank = [];
+  const piped = [];
+  for (let i = 0; i < segments.length; i++) {
+    if (segments[i].prompt.trim() === "") blank.push(i);
+    if (segments[i].prompt.includes("|")) piped.push(i);
+  }
+  if (blank.length) {
+    warnings.push(
+      `segment(s) ${blank.join(", ")} have an EMPTY prompt. PromptRelay drops blank entries when it ` +
+        `splits local_prompts, so the node will run ${segments.length - blank.length} prompt(s) against ` +
+        `${segments.length} segment length(s) and every later segment shifts. Give each segment a prompt, ` +
+        `or delete the empty segments.`,
+    );
+  }
+  if (piped.length) {
+    warnings.push(
+      `segment(s) ${piped.join(", ")} contain a literal "|". PromptRelay splits local_prompts on "|", so ` +
+        `each of those becomes MORE than one prompt at run time and the segments misalign. Remove the ` +
+        `"|" characters from the prompt text.`,
+    );
+  }
+  return warnings;
+}
+
+/** Locate a widget by name on a LiteGraph node. */
+function findWidget(node, name) {
+  const widgets = Array.isArray(node?.widgets) ? node.widgets : [];
+  return widgets.find((w) => w?.name === name) ?? null;
+}
+
+/** The refusal message for a DERIVED-widget write — explains why + points at timeline_data. */
+export function promptRelayDerivedRefusal(widgetName, nodeId) {
+  return (
+    `panel_set_widget cannot drive "${widgetName}" on PromptRelayEncodeTimeline node ${nodeId}: it is a ` +
+    `DERIVED OUTPUT that the node's timeline editor REGENERATES from "${PROMPT_RELAY_MASTER_WIDGET}" on ` +
+    `every commit — a direct write shows in panel_query_graph but never reaches the timeline UI and is ` +
+    `reverted the moment the node is touched, leaving the prompts and the timeline disagreeing (#506). ` +
+    `Set the whole timeline instead: panel_set_widget on "${PROMPT_RELAY_MASTER_WIDGET}" with the timeline ` +
+    `JSON ({"segments":[{"prompt":"…","length":24}, …]}), which drives the editor and regenerates ` +
+    `"${PROMPT_RELAY_DERIVED_WIDGETS.join('", "')}" for you.`
+  );
+}
+
+/**
+ * Reconcile a `timeline_data` write on PromptRelayEncodeTimeline.
+ *
+ * ORDERING (all synchronous — JavaScript is single-threaded, so no concurrent UI edit can
+ * interleave between the read of the current timeline and the write of the new one):
+ *   1. validate the caller's value,
+ *   2. resolve ALL THREE widgets (refuse if any is missing — a reconcile would be impossible),
+ *   3. MERGE the caller's top-level fields onto the node's CURRENT timeline so anything they
+ *      did not mention is preserved (never defaulted away),
+ *   4. validate + normalize the merged segments (refusing every coerce/reset case),
+ *   5. COMPUTE all three final widget values,
+ *   6. only then MUTATE — three plain assignments that cannot throw, so there is no path that
+ *      leaves timeline_data updated with the derived widgets stale,
+ *   7. re-hydrate the live editor (if any) from the same object and repaint.
+ *
+ * Hooks are injected so this is unit-testable without a browser and so the lib owns the
+ * ordering (mirroring ltx-director.js): `getEditor(node)` (default `node._timelineEditor`),
+ * `beforeChange`/`afterChange` bracket the mutation in litegraph's undo envelope so the route
+ * honors panel_set_widget's "Undoable with Ctrl+Z" contract, and `setDirty` repaints.
+ * beforeChange fires only AFTER every refusal has been cleared, so a rejected write leaves no
+ * empty undo step; afterChange always runs.
+ */
+export function applyPromptRelayTimelineWrite(
+  node,
+  value,
+  { getEditor, beforeChange, afterChange, setDirty } = {},
+) {
+  const overlay = normalizePromptRelayTimelineValue(value);
+
+  const widgets = {};
+  const missing = [];
+  for (const name of REQUIRED_WIDGETS) {
+    const w = findWidget(node, name);
+    if (w) widgets[name] = w;
+    else missing.push(name);
+  }
+  if (missing.length) {
+    throw new PromptRelayTimelineWriteError(
+      `PromptRelayEncodeTimeline node ${node?.id} is missing the widget(s) ${missing.join(", ")}, so ` +
+        `"${PROMPT_RELAY_MASTER_WIDGET}" cannot be reconciled with the prompts the node actually ` +
+        `executes. Writing timeline_data alone would leave the render using the OLD prompts (#506) — ` +
+        `refusing. Check that the ComfyUI-PromptRelay pack is installed and this node is up to date.`,
+    );
+  }
+
+  // Merge onto the node's CURRENT timeline: a caller who sends only `segments` keeps every
+  // other field, matching panel_set_widget's "change this" intent. Providing `segments`
+  // explicitly REPLACES the segment list (that is the whole point of the write); only
+  // OMISSION preserves. An overlay that omits `segments` entirely is therefore an idempotent
+  // RE-RECONCILE of the node's existing timeline — which is also the repair path for a node
+  // that is already desynced — and is refused only when there is no current timeline to keep.
+  const base = parsePromptRelayTimeline(widgets[PROMPT_RELAY_MASTER_WIDGET].value);
+  const merged = base ? { ...base, ...overlay } : { ...overlay };
+  const segments = normalizeSegments(merged, Array.isArray(base?.segments) ? base.segments : null);
+  const finalTimeline = { ...merged, segments };
+
+  // The node is ALREADY out of sync when its current local_prompts / segment_lengths are not
+  // what its current timeline_data produces — e.g. prompt text written straight into
+  // local_prompts with the #506 workaround, which exists ONLY there. That text is about to be
+  // replaced, so hand it back rather than letting it vanish silently.
+  const baseDerived = base ? derivePromptRelayWidgets(base.segments) : null;
+  const replaced = {};
+  if (baseDerived) {
+    for (const name of PROMPT_RELAY_DERIVED_WIDGETS) {
+      const current = widgets[name].value;
+      if (typeof current === "string" && current !== baseDerived[name]) replaced[name] = current;
+    }
+  }
+
+  const derived = derivePromptRelayWidgets(segments);
+  const timelineJson = JSON.stringify(finalTimeline);
+  const warnings = timelineWarnings(segments);
+  if (Object.keys(replaced).length) {
+    warnings.push(
+      `this node was ALREADY desynced: its ${Object.keys(replaced).join(" / ")} did not match its ` +
+        `timeline_data (typically a direct write to a derived widget, which the node reverts anyway). ` +
+        `Those values have been REPLACED by the ones derived from the timeline you just set; the ` +
+        `previous text is returned as "replaced_out_of_band" so nothing is lost silently.`,
+    );
+  }
+
+  // ── MUTATE ── Everything above either threw or produced final values, so from here on
+  // there are only assignments; no path can leave the three widgets disagreeing.
+  beforeChange?.();
+  let editorSynced = false;
+  let uiRefreshError = null;
+  try {
+    widgets[PROMPT_RELAY_MASTER_WIDGET].value = timelineJson;
+    widgets.local_prompts.value = derived.local_prompts;
+    widgets.segment_lengths.value = derived.segment_lengths;
+
+    // Re-hydrate the live editor from the SAME object so its next commit re-derives exactly
+    // what we just wrote (a no-op) instead of reverting to the stale in-memory timeline.
+    const editor = typeof getEditor === "function" ? getEditor(node) : node?._timelineEditor;
+    if (editor && typeof editor === "object") {
+      editor.timeline = finalTimeline;
+      const last = segments.length - 1;
+      const sel = Number.isInteger(editor.selectedIndex) ? editor.selectedIndex : 0;
+      editor.selectedIndex = Math.max(0, Math.min(sel, last));
+      // Drop the block-position animation state: it is keyed by segment INDEX, so stale
+      // entries would animate the new blocks from the old layout. render() falls back to the
+      // true position for any index it cannot find, so clearing simply snaps them correct.
+      editor._displayedX?.clear?.();
+      editor._targetX?.clear?.();
+      editor._settling = false;
+      editorSynced = true;
+      try {
+        // updateUIFromSelection refreshes the prompt textarea + length input from the new
+        // timeline (and clears the in-progress length-edit baseline, which refers to the old
+        // lengths); render repaints the blocks.
+        editor.updateUIFromSelection?.();
+        editor.render?.();
+      } catch (err) {
+        // The widgets and editor.timeline are already consistent, so execution is correct;
+        // only the repaint failed. Report it instead of failing the whole write.
+        uiRefreshError = err?.message ? String(err.message) : String(err);
+      }
+    }
+  } finally {
+    afterChange?.();
+  }
+  setDirty?.();
+
+  return {
+    prompt_relay_timeline: {
+      node_id: node?.id,
+      widget: PROMPT_RELAY_MASTER_WIDGET,
+      reconciled: true,
+      segments: segments.length,
+      merged_onto_current: base != null,
+      editor_synced: editorSynced,
+      local_prompts: derived.local_prompts,
+      segment_lengths: derived.segment_lengths,
+      ...(Object.keys(replaced).length ? { replaced_out_of_band: replaced } : {}),
+      ...(uiRefreshError ? { ui_refresh_error: uiRefreshError } : {}),
+      ...(warnings.length ? { warnings } : {}),
+    },
+  };
+}

--- a/web/js/lib/prompt-relay-timeline.js
+++ b/web/js/lib/prompt-relay-timeline.js
@@ -48,10 +48,16 @@
 // envelope before being replaced, so no prompt text ever disappears without the caller being
 // told — as is an UNCOMMITTED edit the user was still typing when the write landed
 // (`overwrote_uncommitted_edit`) and a timeline_data copy that lost to the editor
-// (`superseded_timeline_data`). Which name a discarded copy gets depends on WHICH branch
-// settled authority: a copy the derived-widget filter REJECTED is stale on positive evidence,
-// so it comes back as `discarded_stale_editor` with no warning — the ordinary post-load window
-// must not fire a data-loss alarm, or the alarm stops meaning anything. Both carry the prior prompts PER SEGMENT, and both are decided
+// (`superseded_timeline_data`). Which name a discarded copy gets depends on WHICH branch settled
+// authority and, for a copy the derived-widget filter rejected, on the PRE-LOAD SNAPSHOT: the
+// filter proves only that a copy disagrees with the widgets, never WHY, and a stale post-load
+// editor is indistinguishable from an uncommitted edit whose derived values were refreshed back
+// to the master. So recordPreLoadPromptRelayEditors observes what each editor held before the
+// current load; an editor still holding exactly that is PROVEN stale (`discarded_stale_editor`,
+// no warning — the routine post-load window must not fire a data-loss alarm or the alarm stops
+// meaning anything), and anything else is `discarded_unverified_editor_copy` WITH a warning that
+// says plainly that we could not tell. Unknown is never treated as safe: a false warning costs
+// attention, a suppressed loss costs the user's work. Both carry the prior prompts PER SEGMENT, and both are decided
 // by comparing segment ARRAYS (sameSegmentContent), never the derived `" | "` join, which is
 // lossy and would hide a real overwrite whenever a prompt contains a literal "|". The same limit
 // governs WHICH copy is authoritative: a join comparison can only ask "could this widget hold
@@ -422,6 +428,51 @@ function contentSnapshot(segments) {
   };
 }
 
+// Where the PRE-LOAD editor snapshot lives, stamped on the node itself (never serialized —
+// LiteGraph.serialize() writes only its known fields, so this cannot leak into a workflow).
+const PRE_LOAD_SEGMENTS_KEY = "__cmcpPromptRelayPreLoadSegments";
+
+/**
+ * Snapshot every PromptRelayEncodeTimeline editor's CURRENT segments just BEFORE a workflow
+ * load replaces the graph. Called from the panel's app.loadGraphData fork.
+ *
+ * WHY THIS EXISTS. The derived widgets can prove that an editor copy does not match what the
+ * node executes — they can NEVER prove WHY. A stale editor left over from the previous
+ * workflow (onConfigure restores the widgets ~10ms before it re-parses the editor) and an
+ * uncommitted edit whose derived values were refreshed back to the master are indistinguishable
+ * from the widget values alone, yet they demand opposite disclosures: a warning on the second
+ * would be noise, silence on the first would suppress real loss. No threshold between them can
+ * be right, so this records an OBSERVATION instead: the content the editor held before the
+ * current load began. An editor still holding exactly that content has not been re-parsed or
+ * typed into since — positive evidence of staleness. Anything else changed after the load.
+ */
+export function recordPreLoadPromptRelayEditors(nodes, { getEditor } = {}) {
+  if (!Array.isArray(nodes)) return 0;
+  let stamped = 0;
+  for (const node of nodes) {
+    if (!isPromptRelayTimelineNode(node)) continue;
+    const ed = typeof getEditor === "function" ? getEditor(node) : node?._timelineEditor;
+    const tl = liveEditorTimeline(ed);
+    // Store only the authored fields — the same ones sameSegmentContent compares.
+    node[PRE_LOAD_SEGMENTS_KEY] = tl
+      ? tl.segments.map((seg) => ({ prompt: seg?.prompt, length: seg?.length }))
+      : null;
+    stamped++;
+  }
+  return stamped;
+}
+
+/**
+ * Is this editor copy PROVEN to predate the current workflow load? True only when a pre-load
+ * snapshot was actually recorded AND the editor still holds exactly that content. With no
+ * snapshot (no load observed yet, a node recreated by the load, the fork not installed) the
+ * answer is NOT "stale" but "unknown" — and unknown must never be treated as safe.
+ */
+function editorProvenStale(node, editorSegs) {
+  const preLoad = node?.[PRE_LOAD_SEGMENTS_KEY];
+  return Array.isArray(preLoad) && sameSegmentContent(preLoad, editorSegs);
+}
+
 /** Locate a widget by name on a LiteGraph node. */
 function findWidget(node, name) {
   const widgets = Array.isArray(node?.widgets) ? node.widgets : [];
@@ -657,9 +708,26 @@ export function applyPromptRelayTimelineWrite(
   const editorDiscarded = !!editorSegs && !sameSegmentContent(editorSegs, segments);
 
   const overwroteInFlight = editorWasAuthority && editorDiscarded ? contentSnapshot(editorSegs) : null;
-  // Quiet channel: proven-stale, so payload only.
-  const discardedStaleEditor =
-    !editorWasAuthority && anomalous && editorDiscarded ? contentSnapshot(editorSegs) : null;
+  // The filter rejected this editor copy. That alone does NOT say whether it was a stale
+  // leftover or text the user typed, so the pre-load snapshot decides:
+  //   PROVEN stale (still holds exactly what it held before the current load) → payload only;
+  //   UNPROVEN (no snapshot, or the content changed since the load) → payload AND a warning.
+  // Unknown is never treated as safe: a false warning costs attention, a suppressed loss costs
+  // the user's work.
+  const editorSetAside = !editorWasAuthority && anomalous && editorDiscarded;
+  const staleProven = editorSetAside && editorProvenStale(node, editorSegs);
+  const discardedStaleEditor = staleProven ? contentSnapshot(editorSegs) : null;
+  const discardedUnverifiedEditor =
+    editorSetAside && !staleProven ? contentSnapshot(editorSegs) : null;
+  if (discardedUnverifiedEditor) {
+    warnings.push(
+      `a live editor copy that did not match this node's derived widgets was DISCARDED, and it ` +
+        `could NOT be determined whether it was a stale leftover (an editor not yet re-parsed after ` +
+        `a workflow load) or prompt text typed into the node that had not been committed — the two ` +
+        `look identical from the widget values alone. Its prompts are returned PER SEGMENT as ` +
+        `"discarded_unverified_editor_copy.prompts"; write them back if they were yours.`,
+    );
+  }
   if (overwroteInFlight) {
     warnings.push(
       `this node held an UNCOMMITTED timeline edit — the live editor's segments (what the node ` +
@@ -761,6 +829,9 @@ export function applyPromptRelayTimelineWrite(
       ...(Object.keys(replaced).length ? { replaced_out_of_band: replaced } : {}),
       ...(overwroteInFlight ? { overwrote_uncommitted_edit: overwroteInFlight } : {}),
       ...(discardedStaleEditor ? { discarded_stale_editor: discardedStaleEditor } : {}),
+      ...(discardedUnverifiedEditor
+        ? { discarded_unverified_editor_copy: discardedUnverifiedEditor }
+        : {}),
       ...(supersededTimelineData ? { superseded_timeline_data: supersededTimelineData } : {}),
       ...(uiRefreshError ? { ui_refresh_error: uiRefreshError } : {}),
       ...(warnings.length ? { warnings } : {}),

--- a/web/js/lib/prompt-relay-timeline.js
+++ b/web/js/lib/prompt-relay-timeline.js
@@ -62,8 +62,12 @@
 // lossy and would hide a real overwrite whenever a prompt contains a literal "|". The same limit
 // governs WHICH copy is authoritative: a join comparison can only ask "could this widget hold
 // this timeline's serialization?", never "which of two colliding timelines is current?" — so
-// chooseMergeBase uses it as a filter and, when it cannot separate the two, keeps the live
-// editor's copy (the only one that can hold unsaved text) and says so.
+// chooseMergeBase uses it as a filter, and when the filter cannot separate the two the write
+// FAILS CLOSED rather than guess: a tie with no explicit `segments` is REFUSED with both copies
+// disclosed and nothing mutated (keeping the editor's copy could write the previous workflow's
+// timeline back over the one a load just restored; keeping the widget's could destroy text still
+// being typed — neither guess is acceptable), and only an explicit `segments` list, which
+// replaces BOTH records outright, may proceed, declared via `merge_base_ambiguous`.
 // Anything PromptRelay's python would encode differently from
 // what the timeline shows (a blank prompt, a literal "|", padding whitespace) comes back as a
 // warning. The invariant: the panel never leaves the timeline saying A, the prompts saying B,
@@ -432,9 +436,19 @@ function contentSnapshot(segments) {
 // LiteGraph.serialize() writes only its known fields, so this cannot leak into a workflow).
 const PRE_LOAD_SEGMENTS_KEY = "__cmcpPromptRelayPreLoadSegments";
 
+// How long after a load the node's editor may still be holding pre-load content. The pack
+// re-parses the editor from timeline_data on a `setTimeout(…, 10)` scheduled by onConfigure, so
+// the un-reparsed window is milliseconds; this is generous slack for a loaded machine. It is
+// deliberately SHORT rather than generous, because the window is the only period in which
+// content equality is allowed to mean "stale": outside it the editor has certainly re-parsed,
+// so equal content means a user re-authored it and the write must warn. Erring short costs a
+// spurious warning on a very slow load; erring long would quietly discard authored text.
+const POST_LOAD_REPARSE_WINDOW_MS = 250;
+
 /**
  * Snapshot every PromptRelayEncodeTimeline editor's CURRENT segments just BEFORE a workflow
- * load replaces the graph. Called from the panel's app.loadGraphData fork.
+ * load replaces the graph. Called from the panel's app.loadGraphData fork. Descends into
+ * subgraphs, since a write can target a node inside one.
  *
  * WHY THIS EXISTS. The derived widgets can prove that an editor copy does not match what the
  * node executes — they can NEVER prove WHY. A stale editor left over from the previous
@@ -442,37 +456,50 @@ const PRE_LOAD_SEGMENTS_KEY = "__cmcpPromptRelayPreLoadSegments";
  * uncommitted edit whose derived values were refreshed back to the master are indistinguishable
  * from the widget values alone, yet they demand opposite disclosures: a warning on the second
  * would be noise, silence on the first would suppress real loss. No threshold between them can
- * be right, so this records an OBSERVATION instead: the content the editor held before the
- * current load began. An editor still holding exactly that content has not been re-parsed or
- * typed into since — positive evidence of staleness. Anything else changed after the load.
+ * be right, so this records an OBSERVATION instead — the content the editor held before the
+ * current load, and when that load began.
  */
-export function recordPreLoadPromptRelayEditors(nodes, { getEditor } = {}) {
-  if (!Array.isArray(nodes)) return 0;
+export function recordPreLoadPromptRelayEditors(nodes, { getEditor, now = Date.now } = {}) {
+  const at = now();
+  const seen = new Set();
+  const stack = Array.isArray(nodes) ? nodes.slice() : [];
   let stamped = 0;
-  for (const node of nodes) {
+  while (stack.length) {
+    const node = stack.pop();
+    if (!node || typeof node !== "object" || seen.has(node)) continue;
+    seen.add(node); // identity-keyed, so a cyclic subgraph cannot loop forever
+    const nested = node.subgraph?._nodes ?? node.subgraph?.nodes;
+    if (Array.isArray(nested)) stack.push(...nested);
     if (!isPromptRelayTimelineNode(node)) continue;
-    const ed = typeof getEditor === "function" ? getEditor(node) : node?._timelineEditor;
+    const ed = typeof getEditor === "function" ? getEditor(node) : node._timelineEditor;
     const tl = liveEditorTimeline(ed);
     // Store only the authored fields — the same ones sameSegmentContent compares.
-    node[PRE_LOAD_SEGMENTS_KEY] = tl
-      ? tl.segments.map((seg) => ({ prompt: seg?.prompt, length: seg?.length }))
-      : null;
+    node[PRE_LOAD_SEGMENTS_KEY] = {
+      at,
+      segments: tl ? tl.segments.map((seg) => ({ prompt: seg?.prompt, length: seg?.length })) : null,
+    };
     stamped++;
   }
   return stamped;
 }
 
 /**
- * Is this editor copy PROVEN to predate the current workflow load? True only when a pre-load
- * snapshot was actually recorded AND the editor still holds exactly that content. With no
- * snapshot (no load observed yet, a node recreated by the load, the fork not installed) the
- * answer is NOT "stale" but "unknown" — and unknown must never be treated as safe.
+ * Is this editor copy PROVEN to predate the current workflow load? Requires BOTH:
+ *   * the editor still holds exactly what it held before the load, AND
+ *   * we are still inside the window in which it can not yet have re-parsed.
+ * Content equality ALONE is not proof of history: a user who re-types exactly the pre-load text
+ * after the re-parse would otherwise have that authored text quietly discarded. Nobody re-types
+ * a timeline within a few hundred ms of a load, so the window is what makes equality meaningful.
+ * With no snapshot, a stale clock, or a delta outside the window, the answer is not "stale" but
+ * "unknown" — and unknown must never be treated as safe.
  */
-function editorProvenStale(node, editorSegs) {
-  const preLoad = node?.[PRE_LOAD_SEGMENTS_KEY];
-  return Array.isArray(preLoad) && sameSegmentContent(preLoad, editorSegs);
+function editorProvenStale(node, editorSegs, now = Date.now) {
+  const stamp = node?.[PRE_LOAD_SEGMENTS_KEY];
+  if (!stamp || !Array.isArray(stamp.segments) || !Number.isFinite(stamp.at)) return false;
+  const since = now() - stamp.at;
+  if (!(since >= 0 && since <= POST_LOAD_REPARSE_WINDOW_MS)) return false;
+  return sameSegmentContent(stamp.segments, editorSegs);
 }
-
 /** Locate a widget by name on a LiteGraph node. */
 function findWidget(node, name) {
   const widgets = Array.isArray(node?.widgets) ? node.widgets : [];
@@ -515,10 +542,11 @@ function liveEditorTimeline(editor) {
  *   3. they differ and exactly ONE is consistent with the derived widgets → that one is
  *      current (this is what separates the debounce window from the post-load window);
  *   4. they differ and the filter CANNOT separate them (both consistent — colliding joins — or
- *      neither) → prefer the LIVE EDITOR. It is the only copy that can hold text existing
- *      nowhere else; a superseded master is still on disk, an uncommitted keystroke is not.
- *      The choice is flagged (`merge_base_ambiguous`) and the losing copy is handed back, so a
- *      tie is never resolved silently.
+ *      neither) → UNRESOLVABLE. Choosing a copy here would be a GUESS, and each guess has a
+ *      losing scenario with real loss: keeping the editor's copy can write the PREVIOUS
+ *      workflow's timeline back over the one a load just restored, keeping the widget's can
+ *      destroy text still being typed. So a tie chooses NOTHING — it is returned flagged
+ *      (`ambiguous`) with NO base, and the caller fails closed (see applyPromptRelayTimelineWrite).
  *
  * Both derived widgets are compared, not just `local_prompts`: two timelines can share a
  * prompt join while differing in segment lengths, and that difference is worth catching even
@@ -535,6 +563,36 @@ function derivedMatchesWidgets(timeline, widgets) {
     d.local_prompts === widgets.local_prompts.value &&
     d.segment_lengths === widgets.segment_lengths.value
   );
+}
+
+/**
+ * The merge base for an EDITOR-authoritative write (case 3). The shipped editor's parser
+ * retains ONLY prompt/length/color per segment and no other top-level field, so its
+ * `this.timeline` must NOT be merged from directly: spreading it would DROP every field the
+ * parser does not model (a top-level `zoom`, per-segment metadata, …) that exists only in the
+ * widget's JSON. Instead the editor-KNOWN fields are merged ONTO the widget's timeline object:
+ * the widget (the persisted record, which the editor never edits around) supplies everything
+ * else, the editor stays authoritative for the segment list and the fields it actually holds.
+ * Per segment the same-index widget segment is the only correspondence available (segments
+ * carry no ids); a reorder inside the 120 ms debounce window could misattach an unknown field —
+ * a narrower loss than dropping every such field outright, which is what replacing did.
+ */
+function editorTimelineOntoWidget(fromEditor, fromWidget) {
+  const widgetSegs = Array.isArray(fromWidget?.segments) ? fromWidget.segments : [];
+  const segments = fromEditor.segments.map((seg, i) => {
+    // A malformed editor segment is passed through untouched so normalizeSegments refuses it
+    // loudly, exactly as it would have on the raw editor copy.
+    if (!isPlainObject(seg)) return seg;
+    const base = isPlainObject(widgetSegs[i]) ? widgetSegs[i] : {};
+    // Only fields the editor actually HOLDS may override the widget's; an absent or undefined
+    // one keeps the widget's value instead of clobbering it.
+    const held = {};
+    for (const [key, v] of Object.entries(seg)) {
+      if (v !== undefined) held[key] = v;
+    }
+    return { ...base, ...held };
+  });
+  return { ...fromWidget, segments };
 }
 
 function chooseMergeBase(editor, widgets) {
@@ -566,12 +624,17 @@ function chooseMergeBase(editor, widgets) {
   const editorConsistent = derivedMatchesWidgets(fromEditor, widgets);
   const widgetConsistent = derivedMatchesWidgets(fromWidget, widgets);
   if (widgetConsistent && !editorConsistent) return pick(fromWidget, "timeline_data", "filter-rejected-editor");
-  if (editorConsistent && !widgetConsistent) return pick(fromEditor, "editor", "filter-rejected-master");
+  // The editor won authority, but its copy is PARTIAL (the parser models only
+  // prompt/length/color), so the base is its known fields merged onto the widget's timeline —
+  // never the raw editor copy, which would drop every field it does not model.
+  if (editorConsistent && !widgetConsistent) {
+    return pick(editorTimelineOntoWidget(fromEditor, fromWidget), "editor", "filter-rejected-master");
+  }
   // 4. The filter cannot separate them — either both serialize to the same derived strings
-  //    (the lossy-join collision) or neither matches at all. Prefer the LIVE EDITOR: losing a
-  //    superseded master is recoverable from the saved workflow, losing an uncommitted edit is
-  //    not. Flagged as ambiguous, and the copy that lost is returned to the caller.
-  return pick(fromEditor, "editor", "unresolved-tie", true);
+  //    (the lossy-join collision) or neither matches at all. The tie is UNRESOLVABLE, so no
+  //    copy is chosen: flagged ambiguous with a null base, and the caller fails closed —
+  //    merging onto either copy here could write ambiguous old data over the current one.
+  return pick(null, "none", "unresolved-tie", true);
 }
 
 /** The refusal message for a DERIVED-widget write — explains why + points at timeline_data. */
@@ -596,7 +659,9 @@ export function promptRelayDerivedRefusal(widgetName, nodeId) {
  *   2. resolve ALL THREE widgets (refuse if any is missing — a reconcile would be impossible),
  *   3. MERGE the caller's top-level fields onto the node's CURRENT timeline — see
  *      chooseMergeBase for which of the editor / widget copies is the current one — so
- *      anything they did not mention is preserved (never defaulted away),
+ *      anything they did not mention is preserved (never defaulted away). When neither copy
+ *      can be PROVEN current (an unresolved tie) this step fails closed: refused outright
+ *      unless the caller supplied `segments` explicitly,
  *   4. validate + normalize the merged segments (refusing every coerce/reset case),
  *   5. COMPUTE all three final widget values,
  *   6. only then MUTATE — three plain assignments that cannot throw, so there is no path that
@@ -613,7 +678,7 @@ export function promptRelayDerivedRefusal(widgetName, nodeId) {
 export function applyPromptRelayTimelineWrite(
   node,
   value,
-  { getEditor, beforeChange, afterChange, setDirty } = {},
+  { getEditor, beforeChange, afterChange, setDirty, now = Date.now } = {},
 ) {
   const overlay = normalizePromptRelayTimelineValue(value);
 
@@ -640,14 +705,44 @@ export function applyPromptRelayTimelineWrite(
   // RE-RECONCILE of the node's existing timeline — which is also the repair path for a node
   // that is already desynced — and is refused only when there is no current timeline to keep.
   const editor = typeof getEditor === "function" ? getEditor(node) : node?._timelineEditor;
+  const chosen = chooseMergeBase(editor, widgets);
   const {
-    base,
-    baseSource,
     reason: baseReason,
     fromWidget,
     fromEditor,
     ambiguous: baseAmbiguous,
-  } = chooseMergeBase(editor, widgets);
+  } = chosen;
+  let { base, baseSource } = chosen;
+  if (baseAmbiguous) {
+    // A tie FAILS CLOSED. The filter could not prove which record is current, so reconciling
+    // FROM either copy would be a guess: keeping the editor's segments can write the PREVIOUS
+    // workflow's timeline back over the one a load just restored, keeping the widget's can
+    // destroy text still being typed. Only an explicit `segments` list may proceed — it
+    // replaces BOTH records outright, so the tie cannot resurrect anything. Anything else is
+    // refused with both copies disclosed and NOTHING mutated (a truthful failure, not a
+    // "reconciled" success built on a guess).
+    if (!Object.prototype.hasOwnProperty.call(overlay, "segments")) {
+      const editorCopy = contentSnapshot(Array.isArray(fromEditor?.segments) ? fromEditor.segments : []);
+      const widgetCopy = contentSnapshot(Array.isArray(fromWidget?.segments) ? fromWidget.segments : []);
+      throw new PromptRelayTimelineWriteError(
+        `PromptRelayEncodeTimeline node ${node?.id} holds TWO different timelines — one in its live ` +
+          `timeline editor, one in its timeline_data widget — and its derived widgets CANNOT tell ` +
+          `which is current (the " | " join is lossy, so structurally different timelines can ` +
+          `serialize identically). This write did not supply "segments", so reconciling would mean ` +
+          `GUESSING which copy to keep: one may be the timeline a workflow load just restored, the ` +
+          `other may hold prompt text that exists nowhere else. REFUSED, and nothing was written ` +
+          `(#506). The editor holds prompts ${JSON.stringify(editorCopy.prompts)} (lengths ` +
+          `${JSON.stringify(editorCopy.lengths)}); timeline_data holds prompts ` +
+          `${JSON.stringify(widgetCopy.prompts)} (lengths ${JSON.stringify(widgetCopy.lengths)}). ` +
+          `Re-issue the write with the full "segments" array you intend — explicit segments replace ` +
+          `BOTH copies outright.`,
+      );
+    }
+    // Explicit segments: merge onto the PERSISTED widget for everything else — never the
+    // ambiguous editor copy, whose unmodeled top-level fields may belong to the old workflow.
+    base = fromWidget;
+    baseSource = "timeline_data";
+  }
   const merged = base ? { ...base, ...overlay } : { ...overlay };
   const segments = normalizeSegments(merged, Array.isArray(base?.segments) ? base.segments : null);
   const finalTimeline = { ...merged, segments };
@@ -715,7 +810,7 @@ export function applyPromptRelayTimelineWrite(
   // Unknown is never treated as safe: a false warning costs attention, a suppressed loss costs
   // the user's work.
   const editorSetAside = !editorWasAuthority && anomalous && editorDiscarded;
-  const staleProven = editorSetAside && editorProvenStale(node, editorSegs);
+  const staleProven = editorSetAside && editorProvenStale(node, editorSegs, now);
   const discardedStaleEditor = staleProven ? contentSnapshot(editorSegs) : null;
   const discardedUnverifiedEditor =
     editorSetAside && !staleProven ? contentSnapshot(editorSegs) : null;
@@ -748,10 +843,11 @@ export function applyPromptRelayTimelineWrite(
   if (baseAmbiguous) {
     warnings.push(
       `the node's two records of the timeline held DIFFERENT segments and its derived widgets ` +
-        `could not tell which is current (the " | " join is lossy, so different segment splits ` +
-        `serialize identically). The LIVE EDITOR's copy was used, because it is the only one that ` +
-        `can hold text not yet saved anywhere; the timeline_data copy is returned as ` +
-        `"superseded_timeline_data" if this write did not reproduce it.`,
+        `could not tell which was current (the " | " join is lossy, so different segment splits ` +
+        `serialize identically). Your explicit "segments" replaced BOTH records, so no ambiguous ` +
+        `copy was written back over the other; the live editor's previous segments are returned ` +
+        `per segment as "discarded_stale_editor" / "discarded_unverified_editor_copy" if this ` +
+        `write did not reproduce them.`,
     );
   }
   if (supersededTimelineData) {

--- a/web/js/lib/prompt-relay-timeline.js
+++ b/web/js/lib/prompt-relay-timeline.js
@@ -46,10 +46,19 @@
 // node is found ALREADY desynced (out-of-band `local_prompts` text that no timeline produces —
 // e.g. written with the #506 workaround), the pre-existing value is RETURNED in the result
 // envelope before being replaced, so no prompt text ever disappears without the caller being
-// told — as is an UNCOMMITTED edit the user was still typing when the write landed
-// (`overwrote_uncommitted_edit`) and a timeline_data copy that lost to the editor
-// (`superseded_timeline_data`). Which name a discarded copy gets depends on WHICH branch settled
-// authority and, for a copy the derived-widget filter rejected, on the PRE-LOAD SNAPSHOT: the
+// told — as is a timeline_data copy that lost to the editor (`superseded_timeline_data`) and an
+// editor copy set aside while it was NOT the proven-current record (`overwrote_uncommitted_edit`
+// when timeline_data is unreadable and the editor holds the only copy; `discarded_stale_editor` /
+// `discarded_unverified_editor_copy` when the filter rejected it). The one state that is REFUSED
+// rather than disclosed-after-the-fact is a DETECTED in-flight edit: when the derived-widget
+// filter PROVES the live editor holds the text the node would execute right now (timeline_data
+// could not have produced it — the mid-debounce signature, indistinguishable from an out-of-band
+// master) and the write's explicit `segments` do not reproduce that text, applying them would
+// destroy the edit while reporting success. No non-guessing merge of two conflicting segment
+// lists exists, so the write FAILS CLOSED with both states disclosed per segment and nothing
+// mutated — the same discipline as an unresolved tie. Which name a discarded copy gets depends
+// on WHICH branch settled authority and, for a copy the derived-widget filter rejected, on the
+// PRE-LOAD SNAPSHOT: the
 // filter proves only that a copy disagrees with the widgets, never WHY, and a stale post-load
 // editor is indistinguishable from an uncommitted edit whose derived values were refreshed back
 // to the master. So recordPreLoadPromptRelayEditors observes what each editor held before the
@@ -661,7 +670,11 @@ export function promptRelayDerivedRefusal(widgetName, nodeId) {
  *      chooseMergeBase for which of the editor / widget copies is the current one — so
  *      anything they did not mention is preserved (never defaulted away). When neither copy
  *      can be PROVEN current (an unresolved tie) this step fails closed: refused outright
- *      unless the caller supplied `segments` explicitly,
+ *      unless the caller supplied `segments` explicitly. Symmetrically, when the editor is
+ *      PROVEN current (the mid-debounce signature) but the write's explicit `segments` would
+ *      not reproduce its text, the write fails closed too — refused with both states
+ *      disclosed, because applying it would destroy the in-flight edit while reporting
+ *      success,
  *   4. validate + normalize the merged segments (refusing every coerce/reset case),
  *   5. COMPUTE all three final widget values,
  *   6. only then MUTATE — three plain assignments that cannot throw, so there is no path that
@@ -773,7 +786,9 @@ export function applyPromptRelayTimelineWrite(
   // exactly what they asked for. When they DISAGREE the node is in an anomalous state and one
   // copy holds content the caller may never have seen — an edit still being typed, or prompts a
   // raw timeline_data write left behind (the #506 state itself). So whenever the two copies
-  // diverge, any copy this write does not reproduce is handed back.
+  // diverge, any copy this write does not reproduce is handed back — and when the discarded
+  // copy is the one PROVEN current (the mid-debounce signature below), the write is refused
+  // outright instead, because a disclosure cannot un-destroy text.
   //
   // Every comparison here is STRUCTURAL (sameSegmentContent), never the derived join. Gating on
   // the joined local_prompts would miss a real overwrite whenever a prompt contains a literal
@@ -802,7 +817,54 @@ export function applyPromptRelayTimelineWrite(
   const editorWasAuthority = baseSource === "editor";
   const editorDiscarded = !!editorSegs && !sameSegmentContent(editorSegs, segments);
 
-  const overwroteInFlight = editorWasAuthority && editorDiscarded ? contentSnapshot(editorSegs) : null;
+  // The MIRROR of the post-load case FAILS CLOSED instead of disclosing after the fact. Here
+  // the case-3 filter PROVED the editor is the current record — it matches what the node would
+  // execute right now, and the persisted master could not have produced those derived values.
+  // That is the signature of an edit still inside the editor's ~120 ms commit debounce, but a
+  // timeline_data written out of band (the persisted #506 state) presents identically, and in
+  // BOTH the editor's text is the current one. A write whose explicit `segments` do not
+  // reproduce that text would destroy it while reporting a successful reconcile — the exact
+  // silent loss this route exists to prevent, and handing the text back in the result envelope
+  // does not un-destroy it. There is no non-guessing merge of two conflicting segment lists
+  // (each is a TOTAL claim on the list; zipping or concatenating would invent a timeline
+  // neither party wrote), so — the same discipline as an unresolved tie — the write is REFUSED
+  // with both states disclosed per segment and NOTHING mutated. Every remedy is deterministic:
+  // incorporate the editor's text and re-issue; or wait out the debounce, after which the
+  // editor's commit has converged the node and the write is ordinary; or, when the state
+  // persists — proving no edit is in flight — write the editor's disclosed segments back
+  // verbatim to converge the two records first, then re-issue.
+  if (editorWasAuthority && baseReason === "filter-rejected-master" && editorDiscarded) {
+    const editorCopy = contentSnapshot(editorSegs);
+    const suppliedCopy = contentSnapshot(segments);
+    throw new PromptRelayTimelineWriteError(
+      `PromptRelayEncodeTimeline node ${node?.id} holds an UNCOMMITTED timeline edit: its live ` +
+        `editor's segments are what the node would execute right now, but they differ from its ` +
+        `timeline_data — either text still inside the editor's ~120 ms commit debounce, or a ` +
+        `timeline_data written out of band; the widget values cannot tell which, and either way ` +
+        `the editor's text is the current one. This write's explicit "segments" do not reproduce ` +
+        `that text, so applying them would DESTROY it while reporting success — REFUSED, and ` +
+        `nothing was written (#506). The editor holds prompts ` +
+        `${JSON.stringify(editorCopy.prompts)} (lengths ${JSON.stringify(editorCopy.lengths)}); ` +
+        `the segments you supplied are prompts ${JSON.stringify(suppliedCopy.prompts)} (lengths ` +
+        `${JSON.stringify(suppliedCopy.lengths)}). To keep the editor's text, re-issue with ` +
+        `segments that incorporate it. To overwrite it deliberately: wait ~120 ms for the ` +
+        `editor's pending commit to reach timeline_data and re-issue — or, when no edit is ` +
+        `actually in flight (this state persists), first write the editor's disclosed segments ` +
+        `back verbatim to converge the node's two records, then re-issue your segments as an ` +
+        `ordinary write.`,
+    );
+  }
+
+  // After that throw, this disclosure covers the ONE remaining case where the editor is
+  // authoritative WITHOUT being proven newer than a readable master: an UNREADABLE
+  // timeline_data, where the editor's copy is the only record of that content anywhere.
+  // Refusing there could wedge the node (with no readable master there is nothing to converge
+  // first, and the lossy join cannot reconstruct the editor's segments reliably), so the write
+  // proceeds and hands the replaced copy back.
+  const overwroteInFlight =
+    editorWasAuthority && editorDiscarded && baseReason !== "filter-rejected-master"
+      ? contentSnapshot(editorSegs)
+      : null;
   // The filter rejected this editor copy. That alone does NOT say whether it was a stale
   // leftover or text the user typed, so the pre-load snapshot decides:
   //   PROVEN stale (still holds exactly what it held before the current load) → payload only;
@@ -825,10 +887,10 @@ export function applyPromptRelayTimelineWrite(
   }
   if (overwroteInFlight) {
     warnings.push(
-      `this node held an UNCOMMITTED timeline edit — the live editor's segments (what the node ` +
-        `would execute right now) did not match its timeline_data, typically text typed into the ` +
-        `prompt box that had not yet been committed. The segments you supplied REPLACED it. The ` +
-        `prompts that were in flight are returned PER SEGMENT as ` +
+      `this node's live editor held segments (what the node would execute right now) that exist ` +
+        `in no READABLE timeline_data — an UNCOMMITTED timeline edit, typically text typed into ` +
+        `the prompt box that had not yet been committed. The segments you supplied REPLACED them. ` +
+        `Their prompts are returned PER SEGMENT as ` +
         `"overwrote_uncommitted_edit.prompts" — write those back if you meant to keep them.`,
     );
   }

--- a/web/js/lib/prompt-relay-timeline.js
+++ b/web/js/lib/prompt-relay-timeline.js
@@ -378,14 +378,24 @@ function timelineWarnings(segments) {
  * lossy: `["a | b", "c"]` and `["a", "b | c"]` produce an identical `local_prompts` while being
  * completely different timelines. Every "did the content change?" decision goes through here,
  * so a prompt containing a literal "|" can never make a real overwrite look like a no-op.
- * Lengths are compared as strings so a numeric-string base ("24") matches a normalized 24 and
- * two NaNs match, without NaN !== NaN reporting a phantom difference.
  */
+function sameLength(x, y) {
+  // Identical values (including two absent ones) match outright. Otherwise ONLY numerically:
+  // a numeric-string base ("24") must match a normalized 24, but nothing else is coerced —
+  // stringifying instead would make a `null` length compare equal to a `"null"` one.
+  if (x === y) return true;
+  const num = (v) =>
+    typeof v === "number" ? v : typeof v === "string" && v.trim() !== "" ? Number(v) : NaN;
+  const nx = num(x);
+  const ny = num(y);
+  return Number.isFinite(nx) && Number.isFinite(ny) && nx === ny;
+}
+
 export function sameSegmentContent(a, b) {
   if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
   for (let i = 0; i < a.length; i++) {
     if (a[i]?.prompt !== b[i]?.prompt) return false;
-    if (String(a[i]?.length) !== String(b[i]?.length)) return false;
+    if (!sameLength(a[i]?.length, b[i]?.length)) return false;
   }
   return true;
 }
@@ -568,10 +578,18 @@ export function applyPromptRelayTimelineWrite(
   // three different timelines.
   const editorSegs = Array.isArray(fromEditor?.segments) ? fromEditor.segments : null;
   const widgetSegs = Array.isArray(fromWidget?.segments) ? fromWidget.segments : null;
-  const copiesDiverge = !!editorSegs && !!widgetSegs && !sameSegmentContent(editorSegs, widgetSegs);
+  // ANOMALOUS = the node's records do not corroborate each other:
+  //   * both readable but DIFFERENT — one of them holds content the caller may not have seen;
+  //   * an editor copy with an UNREADABLE timeline_data — the editor is then the only record
+  //     of that content anywhere, so discarding it is exactly the case that must be reported.
+  // A headless node (no editor, readable widget) is NOT anomalous: the widget is the single
+  // normal record and the caller read it, so an ordinary write there stays quiet.
+  const anomalous = editorSegs && widgetSegs ? !sameSegmentContent(editorSegs, widgetSegs) : !!editorSegs;
 
   const overwroteInFlight =
-    copiesDiverge && !sameSegmentContent(editorSegs, segments) ? contentSnapshot(editorSegs) : null;
+    anomalous && editorSegs && !sameSegmentContent(editorSegs, segments)
+      ? contentSnapshot(editorSegs)
+      : null;
   if (overwroteInFlight) {
     warnings.push(
       `this node held an UNCOMMITTED timeline edit — the live editor's segments (what the node ` +
@@ -583,7 +601,9 @@ export function applyPromptRelayTimelineWrite(
   }
 
   const supersededTimelineData =
-    copiesDiverge && !sameSegmentContent(widgetSegs, segments) ? contentSnapshot(widgetSegs) : null;
+    anomalous && widgetSegs && !sameSegmentContent(widgetSegs, segments)
+      ? contentSnapshot(widgetSegs)
+      : null;
   if (supersededTimelineData) {
     warnings.push(
       `the node's timeline_data widget held DIFFERENT segments from the timeline editor, and your ` +

--- a/web/js/lib/prompt-relay-timeline.js
+++ b/web/js/lib/prompt-relay-timeline.js
@@ -48,7 +48,10 @@
 // envelope before being replaced, so no prompt text ever disappears without the caller being
 // told — as is an UNCOMMITTED edit the user was still typing when the write landed
 // (`overwrote_uncommitted_edit`) and a timeline_data copy that lost to the editor
-// (`superseded_timeline_data`). Both carry the prior prompts PER SEGMENT, and both are decided
+// (`superseded_timeline_data`). Which name a discarded copy gets depends on WHICH branch
+// settled authority: a copy the derived-widget filter REJECTED is stale on positive evidence,
+// so it comes back as `discarded_stale_editor` with no warning — the ordinary post-load window
+// must not fire a data-loss alarm, or the alarm stops meaning anything. Both carry the prior prompts PER SEGMENT, and both are decided
 // by comparing segment ARRAYS (sameSegmentContent), never the derived `" | "` join, which is
 // lossy and would hide a real overwrite whenever a prompt contains a literal "|". The same limit
 // governs WHICH copy is authoritative: a join comparison can only ask "could this widget hold
@@ -486,33 +489,38 @@ function derivedMatchesWidgets(timeline, widgets) {
 function chooseMergeBase(editor, widgets) {
   const fromEditor = liveEditorTimeline(editor);
   const fromWidget = parsePromptRelayTimeline(widgets[PROMPT_RELAY_MASTER_WIDGET].value);
-  const pick = (base, baseSource, ambiguous = false) => ({
+  // `reason` records WHICH branch settled authority. That matters downstream: a copy set aside
+  // by the case-3 filter was proven stale, while one set aside by a tie or by being superseded
+  // was not — and the two deserve very different disclosures.
+  const pick = (base, baseSource, reason, ambiguous = false) => ({
     base,
     baseSource,
+    reason,
     fromWidget,
     fromEditor,
     ambiguous,
   });
   // 1. Only one record to merge onto (or none).
-  if (!fromEditor && !fromWidget) return pick(null, "none");
-  if (!fromEditor) return pick(fromWidget, "timeline_data");
-  if (!fromWidget) return pick(fromEditor, "editor");
+  if (!fromEditor && !fromWidget) return pick(null, "none", "no-readable-copy");
+  if (!fromEditor) return pick(fromWidget, "timeline_data", "only-readable-copy");
+  if (!fromWidget) return pick(fromEditor, "editor", "only-readable-copy");
   // 2. The two records carry the SAME content, so there is no authority to settle. The master
   //    field is canonical (it also carries the persisted non-segment fields).
   if (sameSegmentContent(fromEditor.segments, fromWidget.segments)) {
-    return pick(fromWidget, "timeline_data");
+    return pick(fromWidget, "timeline_data", "copies-identical");
   }
   // 3. They differ. Use the derived widgets as a FILTER: whichever record could NOT have
-  //    produced what the node would execute right now is the stale one.
+  //    produced what the node would execute right now is the stale one. A record REJECTED here
+  //    is stale on positive evidence, not merely different.
   const editorConsistent = derivedMatchesWidgets(fromEditor, widgets);
   const widgetConsistent = derivedMatchesWidgets(fromWidget, widgets);
-  if (widgetConsistent && !editorConsistent) return pick(fromWidget, "timeline_data");
-  if (editorConsistent && !widgetConsistent) return pick(fromEditor, "editor");
+  if (widgetConsistent && !editorConsistent) return pick(fromWidget, "timeline_data", "filter-rejected-editor");
+  if (editorConsistent && !widgetConsistent) return pick(fromEditor, "editor", "filter-rejected-master");
   // 4. The filter cannot separate them — either both serialize to the same derived strings
   //    (the lossy-join collision) or neither matches at all. Prefer the LIVE EDITOR: losing a
   //    superseded master is recoverable from the saved workflow, losing an uncommitted edit is
   //    not. Flagged as ambiguous, and the copy that lost is returned to the caller.
-  return pick(fromEditor, "editor", true);
+  return pick(fromEditor, "editor", "unresolved-tie", true);
 }
 
 /** The refusal message for a DERIVED-widget write — explains why + points at timeline_data. */
@@ -584,6 +592,7 @@ export function applyPromptRelayTimelineWrite(
   const {
     base,
     baseSource,
+    reason: baseReason,
     fromWidget,
     fromEditor,
     ambiguous: baseAmbiguous,
@@ -635,10 +644,22 @@ export function applyPromptRelayTimelineWrite(
   // normal record and the caller read it, so an ordinary write there stays quiet.
   const anomalous = editorSegs && widgetSegs ? !sameSegmentContent(editorSegs, widgetSegs) : !!editorSegs;
 
-  const overwroteInFlight =
-    anomalous && editorSegs && !sameSegmentContent(editorSegs, segments)
-      ? contentSnapshot(editorSegs)
-      : null;
+  // HOW a discarded copy is CLASSIFIED depends on WHICH branch settled authority — not merely
+  // on the two copies differing. When the case-3 filter chose the master precisely BECAUSE the
+  // editor could not have produced what the node executes, the editor is stale on positive
+  // evidence: the ordinary post-load window, where onConfigure restores the widgets ~10ms
+  // before it re-parses the editor. Calling that an overwritten uncommitted edit would fire a
+  // data-loss warning on a routine write and train callers to ignore the signal exactly when it
+  // is real — and this disclosure is the safety net for the one residual we accept (a stale
+  // post-load editor whose joins collide with a newer master). So its content is still handed
+  // back, under a name that says what it is and with NO warning attached.
+  const editorWasAuthority = baseSource === "editor";
+  const editorDiscarded = !!editorSegs && !sameSegmentContent(editorSegs, segments);
+
+  const overwroteInFlight = editorWasAuthority && editorDiscarded ? contentSnapshot(editorSegs) : null;
+  // Quiet channel: proven-stale, so payload only.
+  const discardedStaleEditor =
+    !editorWasAuthority && anomalous && editorDiscarded ? contentSnapshot(editorSegs) : null;
   if (overwroteInFlight) {
     warnings.push(
       `this node held an UNCOMMITTED timeline edit — the live editor's segments (what the node ` +
@@ -649,8 +670,11 @@ export function applyPromptRelayTimelineWrite(
     );
   }
 
+  // Symmetrically: the master is only 'superseded' when it did NOT win authority. When case 3
+  // selected it and the caller then replaced its segments, that is the caller's plain intent,
+  // not a copy being set aside behind their back.
   const supersededTimelineData =
-    anomalous && widgetSegs && !sameSegmentContent(widgetSegs, segments)
+    editorWasAuthority && widgetSegs && !sameSegmentContent(widgetSegs, segments)
       ? contentSnapshot(widgetSegs)
       : null;
   if (baseAmbiguous) {
@@ -729,12 +753,14 @@ export function applyPromptRelayTimelineWrite(
       segments: segments.length,
       merged_onto_current: base != null,
       merge_base: baseSource,
+      merge_base_reason: baseReason,
       ...(baseAmbiguous ? { merge_base_ambiguous: true } : {}),
       editor_synced: editorSynced,
       local_prompts: derived.local_prompts,
       segment_lengths: derived.segment_lengths,
       ...(Object.keys(replaced).length ? { replaced_out_of_band: replaced } : {}),
       ...(overwroteInFlight ? { overwrote_uncommitted_edit: overwroteInFlight } : {}),
+      ...(discardedStaleEditor ? { discarded_stale_editor: discardedStaleEditor } : {}),
       ...(supersededTimelineData ? { superseded_timeline_data: supersededTimelineData } : {}),
       ...(uiRefreshError ? { ui_refresh_error: uiRefreshError } : {}),
       ...(warnings.length ? { warnings } : {}),

--- a/web/js/lib/prompt-relay-timeline.js
+++ b/web/js/lib/prompt-relay-timeline.js
@@ -496,12 +496,15 @@ export function applyPromptRelayTimelineWrite(
   // the #506 workaround, which exists ONLY there (and which the node's next commit would revert
   // anyway). That text is about to be replaced, so hand it back rather than let it vanish.
   const baseDerived = base ? derivePromptRelayWidgets(base.segments) : null;
+  // With NO readable base (no editor yet, unreadable timeline_data) there is no timeline that
+  // could have produced the current derived values, so ANY non-empty one is out-of-band by
+  // definition — compare against empty rather than skipping the check, which would let a
+  // hand-written local_prompts be overwritten with no report at all.
+  const expectedDerived = baseDerived ?? { local_prompts: "", segment_lengths: "" };
   const replaced = {};
-  if (baseDerived) {
-    for (const name of PROMPT_RELAY_DERIVED_WIDGETS) {
-      const current = widgets[name].value;
-      if (typeof current === "string" && current !== baseDerived[name]) replaced[name] = current;
-    }
+  for (const name of PROMPT_RELAY_DERIVED_WIDGETS) {
+    const current = widgets[name].value;
+    if (typeof current === "string" && current !== expectedDerived[name]) replaced[name] = current;
   }
 
   const derived = derivePromptRelayWidgets(segments);

--- a/web/js/lib/prompt-relay-timeline.js
+++ b/web/js/lib/prompt-relay-timeline.js
@@ -989,6 +989,19 @@ export function applyPromptRelayTimelineWrite(
       editor._displayedX?.clear?.();
       editor._targetX?.clear?.();
       editor._settling = false;
+      // Invalidate any IN-FLIGHT pointer interaction: the reorder state and the boundary-drag
+      // state both key on segment INDICES into the OLD list. Left intact across this write,
+      // the pointer's release would splice sourceIdx→targetIdx of a list that may no longer
+      // have those positions — splicing `undefined` into a shrunken list and throwing inside
+      // the editor's own commit() BEFORE the derived widgets update — and a boundary drag
+      // would keep resizing at stale indices from its stale length snapshot. With the state
+      // reset to the pack's idle values, the editor's pointer handlers treat the release as a
+      // no-op (pointer capture auto-releases on pointerup), so the drag simply ends. Only the
+      // REHYDRATION path does this: a refused write mutates nothing, so a drag in progress
+      // there continues undisturbed.
+      editor.dragHandle = -1;
+      editor.dragStart = null;
+      editor.reorder = null;
       editorSynced = true;
       try {
         // updateUIFromSelection refreshes the prompt textarea + length input from the new

--- a/web/js/lib/prompt-relay-timeline.js
+++ b/web/js/lib/prompt-relay-timeline.js
@@ -308,15 +308,21 @@ function normalizeSegments(timeline, baseSegments) {
  *     prompt count disagree with the length count and shifts every later segment.
  *   * `local_prompts` is split on "|", so a literal "|" inside a prompt becomes TWO prompts.
  */
-// The edge characters that get stripped before encoding. Python's `str.strip()` and JS's
-// `String.trim()` do NOT agree — python also strips the C1/separator controls U+001C…U+001F
-// and U+0085, while JS also strips U+FEFF — so the UNION is used, and the padding/blank
-// notices fire for anything EITHER side would remove. (Using JS trim() alone would miss a
-// prompt padded with U+001C: python drops it, shifting every later segment, with no warning.)
-const STRIPPED_EDGE_CHARS = /^[\s\u001c-\u001f\u0085\ufeff]+|[\s\u001c-\u001f\u0085\ufeff]+$/g;
+// The edge characters PromptRelay's PYTHON strips before encoding: `str.strip()` with no
+// argument, i.e. exactly the characters `str.isspace()` accepts. Spelled out rather than
+// reusing JS `\s`, because the two sets differ in BOTH directions and these notices describe
+// what PYTHON will do:
+//   * python strips the separator/C1 controls U+001C-U+001F and U+0085; JS trim() does not,
+//     so `\s` alone would MISS a prompt python drops entirely (shifting every later segment)
+//     - the exact silent mismatch this warning exists to catch;
+//   * JS trim() strips U+FEFF; python does NOT, so including it would warn that text will be
+//     trimmed when the render actually keeps it verbatim.
+const PY_STRIP_CLASS =
+  "[\\t\\n\\v\\f\\r \\u001c-\\u001f\\u0085\\u00a0\\u1680\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000]";
+const PY_STRIPPED_EDGE_CHARS = new RegExp(`^${PY_STRIP_CLASS}+|${PY_STRIP_CLASS}+$`, "g");
 
 function edgeTrim(s) {
-  return s.replace(STRIPPED_EDGE_CHARS, "");
+  return s.replace(PY_STRIPPED_EDGE_CHARS, "");
 }
 
 function timelineWarnings(segments) {

--- a/web/js/lib/prompt-relay-timeline.js
+++ b/web/js/lib/prompt-relay-timeline.js
@@ -50,7 +50,11 @@
 // (`overwrote_uncommitted_edit`) and a timeline_data copy that lost to the editor
 // (`superseded_timeline_data`). Both carry the prior prompts PER SEGMENT, and both are decided
 // by comparing segment ARRAYS (sameSegmentContent), never the derived `" | "` join, which is
-// lossy and would hide a real overwrite whenever a prompt contains a literal "|".
+// lossy and would hide a real overwrite whenever a prompt contains a literal "|". The same limit
+// governs WHICH copy is authoritative: a join comparison can only ask "could this widget hold
+// this timeline's serialization?", never "which of two colliding timelines is current?" — so
+// chooseMergeBase uses it as a filter and, when it cannot separate the two, keeps the live
+// editor's copy (the only one that can hold unsaved text) and says so.
 // Anything PromptRelay's python would encode differently from
 // what the timeline shows (a blank prompt, a literal "|", padding whitespace) comes back as a
 // warning. The invariant: the panel never leaves the timeline saying A, the prompts saying B,

--- a/web/js/lib/prompt-relay-timeline.js
+++ b/web/js/lib/prompt-relay-timeline.js
@@ -47,7 +47,8 @@
 // e.g. written with the #506 workaround), the pre-existing value is RETURNED in the result
 // envelope before being replaced, so no prompt text ever disappears without the caller being
 // told — as is an UNCOMMITTED edit the user was still typing when the write landed
-// (`overwrote_uncommitted_edit`). Anything PromptRelay's python would encode differently from
+// (`overwrote_uncommitted_edit`) and a timeline_data copy that lost to the editor
+// (`superseded_timeline_data`). Anything PromptRelay's python would encode differently from
 // what the timeline shows (a blank prompt, a literal "|", padding whitespace) comes back as a
 // warning. The invariant: the panel never leaves the timeline saying A, the prompts saying B,
 // and the caller told nothing.
@@ -411,13 +412,14 @@ function derivedMatchesWidgets(timeline, widgets) {
 function chooseMergeBase(editor, widgets) {
   const fromEditor = liveEditorTimeline(editor);
   const fromWidget = parsePromptRelayTimeline(widgets[PROMPT_RELAY_MASTER_WIDGET].value);
-  if (derivedMatchesWidgets(fromWidget, widgets)) return { base: fromWidget, baseSource: "timeline_data" };
-  if (derivedMatchesWidgets(fromEditor, widgets)) return { base: fromEditor, baseSource: "editor" };
+  const pick = (base, baseSource) => ({ base, baseSource, fromWidget, fromEditor });
+  if (derivedMatchesWidgets(fromWidget, widgets)) return pick(fromWidget, "timeline_data");
+  if (derivedMatchesWidgets(fromEditor, widgets)) return pick(fromEditor, "editor");
   // Neither agrees with what the node would execute: it is genuinely desynced. The master
   // field wins and the out-of-band text is reported back to the caller.
-  if (fromWidget) return { base: fromWidget, baseSource: "timeline_data" };
-  if (fromEditor) return { base: fromEditor, baseSource: "editor" };
-  return { base: null, baseSource: "none" };
+  if (fromWidget) return pick(fromWidget, "timeline_data");
+  if (fromEditor) return pick(fromEditor, "editor");
+  return pick(null, "none");
 }
 
 /** The refusal message for a DERIVED-widget write — explains why + points at timeline_data. */
@@ -486,7 +488,7 @@ export function applyPromptRelayTimelineWrite(
   // RE-RECONCILE of the node's existing timeline — which is also the repair path for a node
   // that is already desynced — and is refused only when there is no current timeline to keep.
   const editor = typeof getEditor === "function" ? getEditor(node) : node?._timelineEditor;
-  const { base, baseSource } = chooseMergeBase(editor, widgets);
+  const { base, baseSource, fromWidget } = chooseMergeBase(editor, widgets);
   const merged = base ? { ...base, ...overlay } : { ...overlay };
   const segments = normalizeSegments(merged, Array.isArray(base?.segments) ? base.segments : null);
   const finalTimeline = { ...merged, segments };
@@ -526,6 +528,27 @@ export function applyPromptRelayTimelineWrite(
         `that had not yet reached timeline_data). The segments you supplied REPLACED it; the text ` +
         `that was in flight is returned as "overwrote_uncommitted_edit". Re-read the node and write ` +
         `again if you meant to keep it.`,
+    );
+  }
+
+  // Deferring to the editor also means the timeline_data widget's OWN copy was set aside. Two
+  // states look identical from here: the widget is merely a pre-keystroke snapshot (normal), or
+  // it holds prompts a raw timeline_data write put there that never reached the editor — the
+  // #506 state itself, e.g. a workflow touched by an older panel. The editor copy wins because
+  // it is what the node would EXECUTE right now, but the prompts being set aside are handed
+  // back either way rather than disappearing.
+  const supersededMaster =
+    baseSource === "editor" && fromWidget
+      ? derivePromptRelayWidgets(fromWidget.segments).local_prompts
+      : null;
+  const supersededTimelineData =
+    supersededMaster !== null && supersededMaster !== derived.local_prompts ? supersededMaster : null;
+  if (supersededTimelineData !== null) {
+    warnings.push(
+      `the node's timeline_data widget held DIFFERENT prompts from the timeline editor, and the ` +
+        `editor's copy was used because it is what the node would execute right now. The prompts ` +
+        `that timeline_data held are returned as "superseded_timeline_data" — if those were the ones ` +
+        `you wanted, write them explicitly as "${PROMPT_RELAY_MASTER_WIDGET}" segments.`,
     );
   }
   if (Object.keys(replaced).length) {
@@ -592,6 +615,7 @@ export function applyPromptRelayTimelineWrite(
       segment_lengths: derived.segment_lengths,
       ...(Object.keys(replaced).length ? { replaced_out_of_band: replaced } : {}),
       ...(overwroteInFlight !== null ? { overwrote_uncommitted_edit: overwroteInFlight } : {}),
+      ...(supersededTimelineData !== null ? { superseded_timeline_data: supersededTimelineData } : {}),
       ...(uiRefreshError ? { ui_refresh_error: uiRefreshError } : {}),
       ...(warnings.length ? { warnings } : {}),
     },

--- a/web/js/lib/prompt-relay-timeline.js
+++ b/web/js/lib/prompt-relay-timeline.js
@@ -46,8 +46,11 @@
 // node is found ALREADY desynced (out-of-band `local_prompts` text that no timeline produces —
 // e.g. written with the #506 workaround), the pre-existing value is RETURNED in the result
 // envelope before being replaced, so no prompt text ever disappears without the caller being
-// told. Anything PromptRelay's python would encode differently from what the timeline shows
-// (a blank prompt, a literal "|", padding whitespace) comes back as a warning.
+// told — as is an UNCOMMITTED edit the user was still typing when the write landed
+// (`overwrote_uncommitted_edit`). Anything PromptRelay's python would encode differently from
+// what the timeline shows (a blank prompt, a literal "|", padding whitespace) comes back as a
+// warning. The invariant: the panel never leaves the timeline saying A, the prompts saying B,
+// and the caller told nothing.
 
 export const PROMPT_RELAY_TIMELINE_NODE_TYPE = "PromptRelayEncodeTimeline";
 
@@ -498,6 +501,24 @@ export function applyPromptRelayTimelineWrite(
   const derived = derivePromptRelayWidgets(segments);
   const timelineJson = JSON.stringify(finalTimeline);
   const warnings = timelineWarnings(segments);
+
+  // chooseMergeBase only falls back to the editor when the timeline_data widget has gone
+  // stale, which means a prompt edit was IN FLIGHT (typed into the node's prompt box, not yet
+  // committed). Merging preserves it — but a caller who supplies `segments` REPLACES the list,
+  // and that legitimately discards the in-flight text. That is the caller's stated intent, so
+  // it is applied rather than refused, but it is never left silent.
+  const overwroteInFlight =
+    baseSource === "editor" && baseDerived && baseDerived.local_prompts !== derived.local_prompts
+      ? baseDerived.local_prompts
+      : null;
+  if (overwroteInFlight !== null) {
+    warnings.push(
+      `this node had an UNCOMMITTED prompt edit in progress (text typed into the node's prompt box ` +
+        `that had not yet reached timeline_data). The segments you supplied REPLACED it; the text ` +
+        `that was in flight is returned as "overwrote_uncommitted_edit". Re-read the node and write ` +
+        `again if you meant to keep it.`,
+    );
+  }
   if (Object.keys(replaced).length) {
     warnings.push(
       `this node was ALREADY desynced: its ${Object.keys(replaced).join(" / ")} did not match its ` +
@@ -561,6 +582,7 @@ export function applyPromptRelayTimelineWrite(
       local_prompts: derived.local_prompts,
       segment_lengths: derived.segment_lengths,
       ...(Object.keys(replaced).length ? { replaced_out_of_band: replaced } : {}),
+      ...(overwroteInFlight !== null ? { overwrote_uncommitted_edit: overwroteInFlight } : {}),
       ...(uiRefreshError ? { ui_refresh_error: uiRefreshError } : {}),
       ...(warnings.length ? { warnings } : {}),
     },

--- a/web/js/lib/prompt-relay-timeline.js
+++ b/web/js/lib/prompt-relay-timeline.js
@@ -136,10 +136,10 @@ function isPlainObject(v) {
  * the value is one the node's `Math.max(1, parseInt(v, 10) || 1)` would silently MANGLE
  * (missing, fractional, zero/negative, non-numeric).
  * A STRING is accepted only in the forms parseInt handles LOSSLESSLY: optional leading "+",
- * digits, and an all-zero fraction ("24", "+24", "24.0"). A non-zero fraction ("24.7") is
- * refused because parseInt would TRUNCATE it — silently shortening a segment.
+ * digits, and a zero-valued fraction ("24", "+24", "24.0", "24."). A non-zero fraction
+ * ("24.7") is refused because parseInt would TRUNCATE it — silently shortening a segment.
  */
-const LOSSLESS_INT_STRING = /^\+?\d+(?:\.0+)?$/;
+const LOSSLESS_INT_STRING = /^\+?\d+(?:\.0*)?$/;
 
 function normalizeSegmentLength(v) {
   if (typeof v === "number") {
@@ -293,6 +293,17 @@ function normalizeSegments(timeline, baseSegments) {
  *     prompt count disagree with the length count and shifts every later segment.
  *   * `local_prompts` is split on "|", so a literal "|" inside a prompt becomes TWO prompts.
  */
+// The edge characters that get stripped before encoding. Python's `str.strip()` and JS's
+// `String.trim()` do NOT agree — python also strips the C1/separator controls U+001C…U+001F
+// and U+0085, while JS also strips U+FEFF — so the UNION is used, and the padding/blank
+// notices fire for anything EITHER side would remove. (Using JS trim() alone would miss a
+// prompt padded with U+001C: python drops it, shifting every later segment, with no warning.)
+const STRIPPED_EDGE_CHARS = /^[\s\u001c-\u001f\u0085\ufeff]+|[\s\u001c-\u001f\u0085\ufeff]+$/g;
+
+function edgeTrim(s) {
+  return s.replace(STRIPPED_EDGE_CHARS, "");
+}
+
 function timelineWarnings(segments) {
   const warnings = [];
   const blank = [];
@@ -300,8 +311,9 @@ function timelineWarnings(segments) {
   const padded = [];
   for (let i = 0; i < segments.length; i++) {
     const p = segments[i].prompt;
-    if (p.trim() === "") blank.push(i);
-    else if (p.trim() !== p) padded.push(i);
+    const trimmed = edgeTrim(p);
+    if (trimmed === "") blank.push(i);
+    else if (trimmed !== p) padded.push(i);
     if (p.includes("|")) piped.push(i);
   }
   if (blank.length) {
@@ -352,21 +364,36 @@ function liveEditorTimeline(editor) {
  *     pre-keystroke timeline and DESTROY the text the user just typed.
  *   * The EDITOR's `this.timeline` lags right after a workflow load: `onConfigure` restores the
  *     widgets first and re-parses the editor 10 ms later. Merging onto the editor in that
- *     window would resurrect the PREVIOUS workflow's timeline.
+ *     window would resurrect the PREVIOUS workflow's timeline — including its lengths and any
+ *     per-segment metadata, not just its prompts.
  *
- * `local_prompts` breaks the tie: it is the value the node would EXECUTE right now, and both
- * update paths (the editor's live keystroke handler, and a workflow load restoring the saved
- * widgets) keep it in step with whichever timeline is current. So prefer the candidate whose
- * derived prompts match it. If neither matches, the node is genuinely desynced and the
- * timeline_data widget — the node's master field — wins, with the out-of-band text reported.
+ * The DERIVED widgets break the tie, and the rule is "widget first, editor only as the
+ * exception". `timeline_data` is the node's master field, so it wins WHENEVER it still agrees
+ * with the derived widgets. The debounce window is the one moment it does not: the keystroke
+ * handler has already advanced `local_prompts` past the pre-keystroke JSON. Deferring to the
+ * editor only in that case means a stale post-load editor can never be chosen — after a load
+ * the restored widgets agree with each other, so the widget wins even if the old editor
+ * happens to derive the same strings.
+ *
+ * Both derived widgets are compared, not just `local_prompts`: two different timelines can
+ * share a prompt join while differing in segment lengths.
  */
+function derivedMatchesWidgets(timeline, widgets) {
+  if (!timeline) return false;
+  const d = derivePromptRelayWidgets(timeline.segments);
+  return (
+    d.local_prompts === widgets.local_prompts.value &&
+    d.segment_lengths === widgets.segment_lengths.value
+  );
+}
+
 function chooseMergeBase(editor, widgets) {
-  const currentPrompts = widgets.local_prompts.value;
   const fromEditor = liveEditorTimeline(editor);
   const fromWidget = parsePromptRelayTimeline(widgets[PROMPT_RELAY_MASTER_WIDGET].value);
-  if (fromEditor && derivePromptRelayWidgets(fromEditor.segments).local_prompts === currentPrompts) {
-    return { base: fromEditor, baseSource: "editor" };
-  }
+  if (derivedMatchesWidgets(fromWidget, widgets)) return { base: fromWidget, baseSource: "timeline_data" };
+  if (derivedMatchesWidgets(fromEditor, widgets)) return { base: fromEditor, baseSource: "editor" };
+  // Neither agrees with what the node would execute: it is genuinely desynced. The master
+  // field wins and the out-of-band text is reported back to the caller.
   if (fromWidget) return { base: fromWidget, baseSource: "timeline_data" };
   if (fromEditor) return { base: fromEditor, baseSource: "editor" };
   return { base: null, baseSource: "none" };


### PR DESCRIPTION
Closes #506

## Root cause

`PromptRelayEncodeTimeline` (pack `ComfyUI-PromptRelay`) has three hidden widgets:

| widget | role |
| --- | --- |
| `timeline_data` | JSON `{"segments":[{prompt,length,color}]}` — the state the node's in-browser `TimelineEditor` parses **once** (constructor / `onConfigure`) into `this.timeline` |
| `local_prompts` | **derived** — `segments.map(s => s.prompt).join(" \| ")` |
| `segment_lengths` | **derived** — `segments.map(s => s.length).join(", ")` |

The editor regenerates both derived widgets from `this.timeline` on every commit
(`syncWidgetsFromTimeline`). And the node's **Python `execute()` reads only `global_prompt`,
`local_prompts` and `segment_lengths` — it never reads `timeline_data`.**

So a raw `panel_set_widget` on `timeline_data` wrote the widget (so `panel_query_graph` showed
the new value and the tool "succeeded"), but never reached the editor, left both derived widgets
stale, and therefore **rendered with the previous prompts** — then got silently reverted on the
next UI touch. This is worse than the sibling #314 (LTXDirector) bug: there the desync was
cosmetic-then-reverted; here it silently produces the wrong image.

## Reconcile semantics chosen, and why

**Regenerate, not reject.** The derived widgets are a total, pure function of `timeline.segments`
— the node defines them that way — and since `execute()` never reads `timeline_data`, rejecting
the write would leave no way to drive this node at all. A `timeline_data` write now recomputes
both derived values from the same segments and applies all three **atomically** (everything is
computed before any mutation, so no path can leave `timeline_data` updated with the prompts
stale), then re-hydrates the live editor so its next commit is a no-op instead of a revert.

Unlike LTXDirector, this pack exposes no re-hydration entry point, so the derivation is mirrored
in `web/js/lib/prompt-relay-timeline.js`. A useful consequence: the write is correct **even with
no live editor** (node never rendered, pack JS not loaded) — the widgets are consistent and the
editor's constructor re-parses what we wrote.

Direct writes to `local_prompts` / `segment_lengths` are now refused with a redirect (they are
reverted on the next commit and desync the node the other way round).

## Can user-authored prompt text be lost?

No path loses it silently. Refused outright (anything the pack would coerce or reset):

- absent / empty / non-array `segments` — the pack resets to a blank two-segment default, wiping every prompt
- a non-object segment — the pack's parser throws and falls back to that same blank default
- a missing or non-string `prompt` — the pack coerces to `""`, destroying that segment's text
- a `length` the pack would clamp or truncate (`0`, `12.5`, `"24.7"`, `"2e3"`, past `MAX_SAFE_INTEGER`)
- a present non-string `color`

Disclosed rather than dropped:

- `replaced_out_of_band` — derived text that no timeline could have produced (e.g. written with #506's own workaround)
- `overwrote_uncommitted_edit` — text the user was typing that an explicit `segments` write replaced
- `superseded_timeline_data` — the `timeline_data` copy that lost the merge-base decision

Plus warnings for every state where PromptRelay's Python would encode something other than what
the timeline shows: a blank prompt (dropped by `if p.strip()`, shifting every later segment), a
literal `|` (splits into extra prompts), and padding whitespace (stripped before encoding — the
check uses Python's exact `str.isspace()` set, not JS `trim()`, which disagrees in both
directions).

**Merge base.** The trickiest part: `timeline_data` lags typed text by the editor's 120 ms
debounce, while the editor's own copy lags a workflow load by `onConfigure`'s 10 ms re-parse —
each candidate can be the stale one. The rule is widget-first: `timeline_data` wins whenever it
is still self-consistent with both derived widgets; the editor is used only when it is not,
which is exactly the debounce window. Either way the losing copy is reported.

## Verification

- 51 new unit tests in `browser_tests/unit/prompt-relay-timeline.test.mjs`; full suite 1295 passing, `tsc --noEmit` clean.
- Two of those extract the real PromptRelay branch out of `graph_set_widget` in `comfyui-mcp-panel.js` and execute it with stubs, pinning master → apply, derived → refusal, other → fall-through, and its ordering (after the LTX route, before `runSetWidget`).
- Self-gated with `codex -m gpt-5.6-terra`, 8 rounds to PASS. Rounds 1–7 each found a real defect: the debounce race (would have destroyed in-flight typed text), a stale-editor merge-base collision, Python-vs-JS whitespace divergence, unsafe-integer lengths serializing as `"1e+21"`, and two undisclosed-overwrite paths. All fixed; the only remaining note is a deliberate over-strict ceiling on absurd segment lengths.

### Still needs rig verification

Everything above is unit-level against a faked editor. On a real rig, with a workflow containing
`PromptRelayEncodeTimeline`: `panel_set_widget` `timeline_data` with a changed segment prompt →
re-read with `panel_query_graph fields=detail` and confirm `local_prompts` **and**
`segment_lengths` match the new timeline; confirm the node's canvas blocks and prompt box show
the new text; touch the timeline in the UI and confirm nothing reverts; then run the workflow and
confirm the render uses the new prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
