### PR TITLE
fix(panel): share one frontend-only-node allowlist between the sibling widget guards (#496) + writable empty dynamic combo (#507)

### DIFF
--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -29,8 +29,10 @@ import {
   isAuthorizedFrontendOnlyType,
   isRemovedBackendType,
   HISTORY_UNSEEDED,
+  HISTORY_PENDING,
   backendHistoryVerdict,
 } from "../../web/js/lib/node-resolve.js";
+import { createObjectInfoHistory } from "../../web/js/lib/object-info-history.js";
 // The PRODUCTION graph_set_widget handler body — the executor and these tests
 // call it verbatim, so the tested ordering IS the shipped ordering (#458).
 import { runSetWidget } from "../../web/js/lib/set-widget.js";
@@ -1477,4 +1479,123 @@ test("#496: backendHistoryVerdict — the one classifier all three guards share"
   // refusal, but it is not a claim that the pack was removed.
   assert.equal(isRemovedBackendType("X", () => HISTORY_UNSEEDED), false);
   assert.equal(isRemovedBackendType("X", () => true), true);
+});
+
+// ---- #496 REGRESSION (coordinator review): a merely SLOW /object_info must not burn the
+//      session. A caller's bounded wait can expire while the fetch is still in flight;
+//      that is the ABSENCE of evidence, not evidence, so it yields a TEMPORARY refusal
+//      and a late-arriving seed restores normal operation with no tab reload. Latching
+//      there would make ordinary latency a permanent false refusal — the same bug class
+//      as #496 and #507 themselves. -----------------------------------------------------
+
+test("#496 REGRESSION: a seed that resolves AFTER the bound ⇒ the next MarkdownNote add SUCCEEDS", async () => {
+  // Drives the REAL history object through the real guard, so the state machine and the
+  // guard's reading of it are exercised together.
+  const history = createObjectInfoHistory();
+  const reg = registryWithNatives();
+  const fresh = objectInfo(); // healthy backend; never lists MarkdownNote (by design)
+  const opts = ADD_OPTS(fresh, (t) => history.wasTypeEverDefined(t));
+
+  // t = 0..bound — the startup getNodeDefs() is still in flight and the tool gave up
+  // waiting. Refused, but TEMPORARILY: the message must say "retry in a moment" and must
+  // NOT blame a removed pack or tell the user to reload.
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => reg, "MarkdownNote", opts),
+    (err) =>
+      /still loading|retry in a moment/i.test(err.message) &&
+      !/pack uninstalled|its backend was removed/i.test(err.message) &&
+      !/Reload the ComfyUI tab/i.test(err.message),
+  );
+  assert.equal(history.baselineLost, false, "a bounded wait must not latch the session");
+
+  // t = bound+ε — the slow response lands and seeds the baseline (this is what
+  // seedObjectInfoHistory does when its in-flight fetch finally returns).
+  history.recordTypes(fresh);
+  assert.equal(history.markSeeded(), true);
+
+  // The very SAME add now succeeds. No tab reload, nothing burned.
+  await assert.doesNotReject(
+    () => assertAddNodeResolvableRefreshing(() => reg, "MarkdownNote", opts),
+    "a late seed must restore normal operation",
+  );
+  // …and so does the write path, on the same recovered baseline.
+  const node = { id: 11, type: "MarkdownNote", widgets: [{ name: "text", type: "string", value: "" }], constructor: reg["MarkdownNote"] };
+  const { set } = await runSetWidget(node, "text", "# README", {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: async () => fresh,
+    wasTypeEverDefined: (t) => history.wasTypeEverDefined(t),
+    ...HOOKS,
+  });
+  assert.equal(set.value, "# README");
+  // The recovered baseline is a REAL one, not a blanket allow: a type it DID observe is
+  // still refused once it disappears from /object_info.
+  const gone = objectInfo(); // KSampler is in `fresh` (observed) but we drop it here
+  delete gone["KSampler"];
+  assert.throws(
+    () =>
+      assertTypeAgainstFreshBackend(gone, "KSampler", 12, {
+        registry: reg,
+        wasTypeEverDefined: (t) => history.wasTypeEverDefined(t),
+      }),
+    /its backend was removed|pack uninstalled/i,
+  );
+});
+
+test("#496 REGRESSION: PENDING and LATCHED are reported DIFFERENTLY by all three guards", async () => {
+  // "hasn't loaded yet, retry" and "never loaded, reload the tab" are different problems
+  // with different user actions. Both refuse; only the diagnosis differs.
+  const reg = registryWithNatives();
+  const fresh = objectInfo();
+  const node = { id: 11, type: "MarkdownNote", widgets: [{ name: "text", type: "string", value: "" }], constructor: reg["MarkdownNote"] };
+  const PENDING = () => HISTORY_PENDING;
+  const LATCHED = () => HISTORY_UNSEEDED;
+  const temporary = (m) => /still loading|retry in a moment/i.test(m) && !/Reload the ComfyUI tab/i.test(m);
+  const permanent = (m) => /Reload the ComfyUI tab/i.test(m) && !/retry in a moment/i.test(m);
+
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => reg, "MarkdownNote", ADD_OPTS(fresh, PENDING)),
+    (err) => temporary(err.message),
+  );
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => reg, "MarkdownNote", ADD_OPTS(fresh, LATCHED)),
+    (err) => permanent(err.message),
+  );
+  assert.throws(
+    () => assertTypeAgainstFreshBackend(fresh, "MarkdownNote", 11, { registry: reg, node, wasTypeEverDefined: PENDING }),
+    (err) => temporary(err.message),
+  );
+  assert.throws(
+    () => assertTypeAgainstFreshBackend(fresh, "MarkdownNote", 11, { registry: reg, node, wasTypeEverDefined: LATCHED }),
+    (err) => permanent(err.message),
+  );
+  assert.throws(
+    () => assertMutatedNodeAuthorized(fresh, reg, node, "target", PENDING),
+    (err) => temporary(err.message),
+  );
+  assert.throws(
+    () => assertMutatedNodeAuthorized(fresh, reg, node, "target", LATCHED),
+    (err) => permanent(err.message),
+  );
+});
+
+test("#496 REGRESSION: the PENDING sentinel still FAILS CLOSED — it never authorizes anything", async () => {
+  // The recoverable state must not become a hole: while pending, NOTHING is exempted.
+  const reg = registryWithNatives();
+  const fresh = objectInfo();
+  const node = { id: 11, type: "MarkdownNote", widgets: [{ name: "text", type: "string", value: "" }], constructor: reg["MarkdownNote"] };
+  assert.equal(backendHistoryVerdict("MarkdownNote", () => HISTORY_PENDING), "pending");
+  assert.notEqual(backendHistoryVerdict("MarkdownNote", () => HISTORY_PENDING), "never-seen");
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "text", "# README", {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => fresh,
+        wasTypeEverDefined: () => HISTORY_PENDING,
+        ...HOOKS,
+      }),
+    /still loading|retry in a moment/i,
+  );
+  assert.equal(node.widgets[0].value, "", "no write while the baseline is pending");
 });

--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -1112,9 +1112,151 @@ test("#496 SINGLE SOURCE OF TRUTH: all three guards read the SAME allowlist Set 
   assert.deepEqual(await guardVerdicts(reg, fresh, SYNTHETIC, node), [false, false, false]);
 });
 
+test("#496 add_node (codex SEVERE): the frontend-only exemption REQUIRES the ever-seen oracle — without it, nothing absent from object_info is exempted", async () => {
+  // Client-side name + provenance markers are FORGEABLE: a removed pack whose frontend
+  // class had .nodeData/.comfyClass stripped and which squats a reserved allowlisted
+  // name is indistinguishable from a genuine native by those signals alone. Only the
+  // non-forgeable observed-backend-history gate can rule it out, so with NO history
+  // oracle wired there is no exemption at all — pre-#496 fail-closed behaviour.
+  const reg = registryWithNatives();
+  const fresh = objectInfo();
+  for (const t of ["Note", "MarkdownNote", "Reroute", "PrimitiveNode"]) {
+    await assert.rejects(
+      () =>
+        assertAddNodeResolvableRefreshing(() => reg, t, {
+          getFreshObjectInfo: async () => fresh,
+          refresh: async () => {},
+          // wasTypeEverDefined deliberately OMITTED
+        }),
+      /Unknown node type|does not provide/i,
+      `#496: "${t}" must NOT be exempted without the observed-backend-history oracle`,
+    );
+  }
+  // Wiring the oracle (and only then) enables the exemption.
+  await assert.doesNotReject(() =>
+    assertAddNodeResolvableRefreshing(() => reg, "MarkdownNote", ADD_OPTS(fresh)),
+  );
+});
+
 test("#496: isRemovedBackendType — the shared ever-seen gate is inert without an injected oracle and never guesses", () => {
   assert.equal(isRemovedBackendType("KSampler", () => true), true);
   assert.equal(isRemovedBackendType("KSampler", () => false), false);
   assert.equal(isRemovedBackendType("KSampler", undefined), false, "no oracle wired ⇒ no removal claim");
   assert.equal(isRemovedBackendType(undefined, () => true), false, "a non-string type is never 'removed'");
+});
+
+// ---- #507 END-TO-END through the PRODUCTION graph_set_widget body: a dynamic
+//      client-populated combo (empty server option list) must become writable, and the
+//      empty-list acceptance must be the LAST resort — the authoritative /object_info
+//      refresh gets first refusal, so a merely-STALE empty list is refreshed and then
+//      validated strictly. ------------------------------------------------------------
+
+// StarNodes' StarOllamaPromptHelper: `"model": ((), {...})` ⇒ /object_info reports
+// `[[], {...}]`, and the node's own "Refresh Models" button fills the dropdown.
+function starNodesFixture(liveOptions = []) {
+  const reg = loadedRegistry(["StarOllamaPromptHelper"]);
+  const widget = { name: "model", type: "combo", options: { values: liveOptions }, value: "" };
+  const node = { id: 9, type: "StarOllamaPromptHelper", widgets: [widget], constructor: reg["StarOllamaPromptHelper"] };
+  return { reg, node, widget };
+}
+// /object_info in which StarOllamaPromptHelper's `model` input carries `serverOptions`.
+function starObjectInfo(serverOptions = []) {
+  const info = objectInfo();
+  info["StarOllamaPromptHelper"] = { input: { required: { model: [serverOptions, {}] } } };
+  return info;
+}
+// A refreshCombos that does what the panel's does: overwrite the live option list with
+// the server's, from the ALREADY-FETCHED /object_info payload.
+const refreshFromServer = (fresh, targetNode) => {
+  const def = fresh?.[targetNode?.type]?.input?.required;
+  for (const w of targetNode?.widgets ?? []) {
+    const spec = def?.[w.name];
+    if (Array.isArray(spec?.[0])) w.options.values = spec[0];
+  }
+};
+
+test("#507 e2e: a combo whose SERVER option list is empty becomes writable (the StarNodes repro)", async () => {
+  const { reg, node, widget } = starNodesFixture([]);
+  const res = await runSetWidget(node, "model", "qwen3-vl:8b", {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: async () => starObjectInfo([]), // server publishes ZERO options
+    wasTypeEverDefined: () => true, // a real backend node, present in object_info
+    refreshCombos: refreshFromServer,
+    ...HOOKS,
+  });
+  assert.equal(res.set.value, "qwen3-vl:8b");
+  assert.equal(widget.value, "qwen3-vl:8b");
+  assert.equal(res.empty_option_list, true, "reported honestly as an unvalidatable empty list");
+});
+
+test("#507 e2e: a merely-STALE empty list is REFRESHED first, then validated STRICTLY (not blindly accepted)", async () => {
+  // The live widget is empty only because the frontend combo snapshot is stale; the
+  // SERVER does publish a real list. The refresh must run and decide — a member is
+  // accepted through the normal path (no empty-list fallback), a NON-member is refused.
+  const ok = starNodesFixture([]);
+  const res = await runSetWidget(ok.node, "model", "llama3.2:3b", {
+    registry: ok.reg,
+    getRegistry: () => ok.reg,
+    getFreshObjectInfo: async () => starObjectInfo(["qwen3-vl:8b", "llama3.2:3b"]),
+    wasTypeEverDefined: () => true,
+    refreshCombos: refreshFromServer,
+    ...HOOKS,
+  });
+  assert.equal(res.set.value, "llama3.2:3b");
+  assert.equal(res.refreshed, true, "the authoritative refresh is what accepted it");
+  assert.equal(res.empty_option_list, undefined, "NOT the empty-list path — a real list existed");
+
+  const bad = starNodesFixture([]);
+  await assert.rejects(
+    () =>
+      runSetWidget(bad.node, "model", "not-installed:70b", {
+        registry: bad.reg,
+        getRegistry: () => bad.reg,
+        getFreshObjectInfo: async () => starObjectInfo(["qwen3-vl:8b", "llama3.2:3b"]),
+        wasTypeEverDefined: () => true,
+        refreshCombos: refreshFromServer,
+        ...HOOKS,
+      }),
+    /not a valid option/i,
+    "#240: once the server publishes a real list, an off-list value is still refused",
+  );
+  assert.equal(bad.widget.value, "", "must not have mutated on reject");
+});
+
+test("#507 e2e: an object value into an empty combo still fails closed (no fabricated success)", async () => {
+  const { reg, node, widget } = starNodesFixture([]);
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "model", { model: "qwen3-vl:8b" }, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => starObjectInfo([]),
+        wasTypeEverDefined: () => true,
+        refreshCombos: refreshFromServer,
+        ...HOOKS,
+      }),
+    /refused|only a scalar/i,
+  );
+  assert.equal(widget.value, "", "must not have mutated on reject");
+});
+
+test("#507 e2e: the empty-list fallback does NOT bypass the #458 type authorization", async () => {
+  // A since-REMOVED backend node that happens to expose an empty combo must still be
+  // refused BEFORE any write — the empty-list path is inside the write, downstream of
+  // the fresh-backend gate, and must not become a way around it.
+  const { reg, node, widget } = starNodesFixture([]);
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "model", "qwen3-vl:8b", {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => objectInfo(), // backend no longer provides the type
+        wasTypeEverDefined: (t) => t === "StarOllamaPromptHelper", // …but it did earlier
+        refreshCombos: refreshFromServer,
+        ...HOOKS,
+      }),
+    /removed|since-removed/i,
+  );
+  assert.equal(widget.value, "", "no write behind a refused authorization");
 });

--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -21,7 +21,13 @@ import {
   assertAddNodeResolvableRefreshing,
   assertResolvedTargetRegistered,
   assertTypeAgainstFreshBackend,
+  assertMutatedNodeAuthorized,
   isFrontendOnlyRegisteredType,
+  // #496: the ONE shared frontend-only allowlist + the predicates every
+  // /object_info-oracle guard decides with.
+  FRONTEND_ONLY_NODE_TYPES,
+  isAuthorizedFrontendOnlyType,
+  isRemovedBackendType,
 } from "../../web/js/lib/node-resolve.js";
 // The PRODUCTION graph_set_widget handler body — the executor and these tests
 // call it verbatim, so the tested ordering IS the shipped ordering (#458).
@@ -896,4 +902,219 @@ test("#458 EVER-SEEN: a frontend-only rgthree node NEVER in object_info ⇒ stil
     ...HOOKS,
   });
   assert.equal(set.value, false);
+});
+
+// ---- #496: ONE shared frontend-only allowlist across the WHOLE /object_info-oracle
+//      guard family. The set_widget guards exempted genuine frontend-only types
+//      (Note/MarkdownNote/Reroute/…); assertAddNodeResolvableRefreshing did NOT, so a
+//      MarkdownNote was writable but not ADDABLE on a perfectly healthy backend — the
+//      exact drift #496 reports. All three now decide via isAuthorizedFrontendOnlyType.
+//      These lock BOTH halves: the frontend-only types succeed, and every
+//      graph-corruption case the guards reject today is still rejected. ---------------
+
+// A live registry in which the frontend-only natives are registered by LiteGraph
+// (defless / provenance-clean), exactly as ComfyUI's frontend registers them.
+function registryWithNatives(natives = ["Note", "MarkdownNote", "Reroute", "PrimitiveNode"]) {
+  return loadedRegistry([], natives);
+}
+const ADD_OPTS = (fresh, wasTypeEverDefined = () => false) => ({
+  getFreshObjectInfo: async () => fresh,
+  refresh: async () => {},
+  wasTypeEverDefined,
+});
+
+test("#496 add_node: frontend-only natives (Note/MarkdownNote/Reroute/PrimitiveNode) are ADDABLE on a healthy backend that does not list them", async () => {
+  const reg = registryWithNatives();
+  const fresh = objectInfo(); // healthy backend — genuinely never lists these types
+  for (const t of ["Note", "MarkdownNote", "Reroute", "PrimitiveNode"]) {
+    await assert.doesNotReject(
+      () => assertAddNodeResolvableRefreshing(() => reg, t, ADD_OPTS(fresh)),
+      `#496: "${t}" is frontend-only and must be addable`,
+    );
+  }
+  // The rgthree frontend control nodes are on the same shared allowlist.
+  const reg2 = loadedRegistry([], ["Fast Bypasser (rgthree)"]);
+  await assert.doesNotReject(() =>
+    assertAddNodeResolvableRefreshing(() => reg2, "Fast Bypasser (rgthree)", ADD_OPTS(fresh)),
+  );
+});
+
+test("#496 add_node: a genuinely INVALID target still fails closed (unknown type, defless husk, provenance-bearing allowlisted name)", async () => {
+  const fresh = objectInfo();
+  // (a) never installed / typo — not on the allowlist.
+  const reg = registryWithNatives();
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => reg, "TotallyMadeUpNode", ADD_OPTS(fresh)),
+    /Unknown node type|does not provide/i,
+  );
+  // (b) a REMOVED pack that left a DEFLESS husk registered: defless is NOT the signal —
+  //     it is not on the allowlist, so it stays refused (the #458 hole stays closed).
+  const reg2 = loadedRegistry([], ["RemovedBackendNode"]);
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => reg2, "RemovedBackendNode", ADD_OPTS(fresh)),
+    /Unknown node type|does not provide/i,
+  );
+  // (c) a class squatting an ALLOWLISTED name but carrying backend provenance
+  //     (nodeData/comfyClass) is NOT frontend-only — refuse.
+  const reg3 = loadedRegistry(["MarkdownNote"]); // registered WITH nodeData
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => reg3, "MarkdownNote", ADD_OPTS(fresh)),
+    /Unknown node type|does not provide/i,
+  );
+  // (d) an allowlisted name that is NOT registered in the live registry at all — the
+  //     exemption requires registry membership (which is also what createNode needs).
+  const reg4 = loadedRegistry();
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => reg4, "MarkdownNote", ADD_OPTS(fresh)),
+    /Unknown node type|does not provide/i,
+  );
+});
+
+test("#496 add_node: the EVER-SEEN gate still wins — an allowlisted name whose backend was REMOVED this session fails closed", async () => {
+  // A pack registered a backend node literally named "MarkdownNote" and was then
+  // uninstalled, leaving a provenance-clean husk. The observed-backend-history trust
+  // root refuses it: a client husk cannot un-see what the backend already reported.
+  const reg = registryWithNatives();
+  const fresh = objectInfo(); // current object_info no longer lists it
+  await assert.rejects(
+    () =>
+      assertAddNodeResolvableRefreshing(
+        () => reg,
+        "MarkdownNote",
+        ADD_OPTS(fresh, (t) => t === "MarkdownNote"),
+      ),
+    /defined this node type earlier this session|removed/i,
+  );
+  // …and the gate does NOT over-reach: a sibling native never reported stays addable.
+  await assert.doesNotReject(() =>
+    assertAddNodeResolvableRefreshing(() => reg, "Note", ADD_OPTS(fresh, (t) => t === "MarkdownNote")),
+  );
+});
+
+test("#496 add_node: object_info UNAVAILABLE still fails closed, even for a frontend-only type", async () => {
+  // The exemption is scoped to "object_info WAS fetched but lacks the type". An
+  // unverifiable backend must never authorize anything (#458).
+  const reg = registryWithNatives();
+  await assert.rejects(
+    () =>
+      assertAddNodeResolvableRefreshing(() => reg, "MarkdownNote", {
+        getFreshObjectInfo: async () => null,
+        refresh: async () => {},
+        wasTypeEverDefined: () => false,
+      }),
+    /cannot verify|object_info is unavailable/i,
+  );
+});
+
+test("#496 set_widget: MarkdownNote's text widget is writable end-to-end (the reported repro)", async () => {
+  const reg = registryWithNatives();
+  const node = {
+    id: 11,
+    type: "MarkdownNote",
+    widgets: [{ name: "text", type: "string", value: "" }],
+    constructor: reg["MarkdownNote"],
+  };
+  const { set } = await runSetWidget(node, "text", "# README", {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: async () => objectInfo(), // healthy backend, no MarkdownNote
+    wasTypeEverDefined: () => false,
+    ...HOOKS,
+  });
+  assert.equal(set.value, "# README");
+  assert.equal(node.widgets[0].value, "# README");
+});
+
+// The three guards whose oracle is /object_info. Each is reduced to a boolean
+// "would this LEAF node type be authorized?" so they can be compared directly.
+// (Container-shaped nodes are excluded on purpose: assertMutatedNodeAuthorized has an
+// ADDITIONAL virtual-subgraph-container branch the other two must not have, so parity
+// is asserted over LEAF nodes, where the frontend-only allowlist is the only exemption.)
+function guardVerdicts(reg, fresh, type, node, wasTypeEverDefined = () => false) {
+  const ok = async (fn) => {
+    try {
+      await fn();
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  return Promise.all([
+    ok(() => assertAddNodeResolvableRefreshing(() => reg, type, ADD_OPTS(fresh, wasTypeEverDefined))),
+    ok(() => assertTypeAgainstFreshBackend(fresh, type, node?.id, { registry: reg, node, wasTypeEverDefined })),
+    ok(() => assertMutatedNodeAuthorized(fresh, reg, node, "target", wasTypeEverDefined)),
+  ]);
+}
+
+test("#496 PARITY: all three /object_info-oracle guards reach the SAME verdict for the same leaf node type", async () => {
+  const fresh = objectInfo();
+  const leaf = (type, ctor) => ({
+    id: 42,
+    type,
+    widgets: [{ name: "text", type: "string", value: "" }],
+    constructor: ctor,
+  });
+  const natives = registryWithNatives();
+  const husk = loadedRegistry([], ["RemovedBackendNode"]);
+  const squat = loadedRegistry(["MarkdownNote"]); // allowlisted NAME, backend provenance
+  const cases = [
+    // [label, registry, type, expected verdict, wasTypeEverDefined]
+    ["MarkdownNote (frontend-only)", natives, "MarkdownNote", true, () => false],
+    ["Note (frontend-only)", natives, "Note", true, () => false],
+    ["Reroute (frontend-only)", natives, "Reroute", true, () => false],
+    ["KSampler (live backend node)", natives, "KSampler", true, () => false],
+    ["TotallyMadeUpNode (unknown)", natives, "TotallyMadeUpNode", false, () => false],
+    ["RemovedBackendNode (defless husk, not allowlisted)", husk, "RemovedBackendNode", false, () => false],
+    ["MarkdownNote (squatted, backend provenance)", squat, "MarkdownNote", false, () => false],
+    ["MarkdownNote (backend REMOVED this session)", natives, "MarkdownNote", false, (t) => t === "MarkdownNote"],
+  ];
+  for (const [label, reg, type, expected, everSeen] of cases) {
+    const [add, freshAuth, mutated] = await guardVerdicts(reg, fresh, type, leaf(type, reg[type]), everSeen);
+    assert.deepEqual(
+      { add, freshAuth, mutated },
+      { add: expected, freshAuth: expected, mutated: expected },
+      `#496 guard drift on ${label}: all three guards must agree (expected ${expected})`,
+    );
+  }
+});
+
+test("#496 SINGLE SOURCE OF TRUTH: all three guards read the SAME allowlist Set (no second copy)", async () => {
+  // Mutating the ONE exported allowlist must move all three guards together. If a guard
+  // ever hard-codes its own copy of the list, its verdict stops tracking this Set and
+  // this test fails — which is precisely the regression #496 was.
+  const SYNTHETIC = "ZZFrontendOnlyProbe (test)";
+  const reg = loadedRegistry([], [SYNTHETIC]);
+  const fresh = objectInfo();
+  const node = {
+    id: 77,
+    type: SYNTHETIC,
+    widgets: [{ name: "text", type: "string", value: "" }],
+    constructor: reg[SYNTHETIC],
+  };
+  // Not on the allowlist yet ⇒ every guard refuses.
+  assert.deepEqual(
+    await guardVerdicts(reg, fresh, SYNTHETIC, node),
+    [false, false, false],
+    "a defless, non-allowlisted type must be refused by all three guards",
+  );
+  FRONTEND_ONLY_NODE_TYPES.add(SYNTHETIC);
+  try {
+    assert.deepEqual(
+      await guardVerdicts(reg, fresh, SYNTHETIC, node),
+      [true, true, true],
+      "adding to the ONE allowlist must authorize all three guards — they share it",
+    );
+    assert.equal(isAuthorizedFrontendOnlyType(reg, SYNTHETIC, node), true);
+  } finally {
+    FRONTEND_ONLY_NODE_TYPES.delete(SYNTHETIC);
+  }
+  // Removed again ⇒ back to refused everywhere (no guard cached the membership).
+  assert.deepEqual(await guardVerdicts(reg, fresh, SYNTHETIC, node), [false, false, false]);
+});
+
+test("#496: isRemovedBackendType — the shared ever-seen gate is inert without an injected oracle and never guesses", () => {
+  assert.equal(isRemovedBackendType("KSampler", () => true), true);
+  assert.equal(isRemovedBackendType("KSampler", () => false), false);
+  assert.equal(isRemovedBackendType("KSampler", undefined), false, "no oracle wired ⇒ no removal claim");
+  assert.equal(isRemovedBackendType(undefined, () => true), false, "a non-string type is never 'removed'");
 });

--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -28,6 +28,8 @@ import {
   FRONTEND_ONLY_NODE_TYPES,
   isAuthorizedFrontendOnlyType,
   isRemovedBackendType,
+  HISTORY_UNSEEDED,
+  backendHistoryVerdict,
 } from "../../web/js/lib/node-resolve.js";
 // The PRODUCTION graph_set_widget handler body — the executor and these tests
 // call it verbatim, so the tested ordering IS the shipped ordering (#458).
@@ -1395,4 +1397,84 @@ test("#507 codex round-2 (MODERATE): a real failure on the FINAL attempt propaga
       }),
     /did not retain the requested value/i,
   );
+});
+
+// ---- #496 / #458: an UNSEEDED history must refuse with an HONEST diagnosis. Previously
+//      every refusal in that state claimed "its backend was removed (pack uninstalled)",
+//      which for a MarkdownNote is false and misdiagnoses a transient backend problem as
+//      a broken install — the same misleading-error complaint #496 was filed about. -----
+
+// The oracle the panel injects when it has no trustworthy baseline.
+const NO_BASELINE = () => HISTORY_UNSEEDED;
+
+test("#496: all three guards refuse an unseeded history with a RELOAD-THE-TAB diagnosis, never a false 'pack removed'", async () => {
+  const reg = registryWithNatives();
+  const fresh = objectInfo();
+  const node = { id: 11, type: "MarkdownNote", widgets: [{ name: "text", type: "string", value: "" }], constructor: reg["MarkdownNote"] };
+  const honest = /no trustworthy record|Reload the ComfyUI tab/i;
+  const falseClaim = /pack uninstalled|its backend was removed/i;
+
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => reg, "MarkdownNote", ADD_OPTS(fresh, NO_BASELINE)),
+    (err) => honest.test(err.message) && !falseClaim.test(err.message),
+  );
+  assert.throws(
+    () => assertTypeAgainstFreshBackend(fresh, "MarkdownNote", 11, { registry: reg, node, wasTypeEverDefined: NO_BASELINE }),
+    (err) => honest.test(err.message) && !falseClaim.test(err.message),
+  );
+  assert.throws(
+    () => assertMutatedNodeAuthorized(fresh, reg, node, "target", NO_BASELINE),
+    (err) => honest.test(err.message) && !falseClaim.test(err.message),
+  );
+});
+
+test("#496: the unseeded sentinel still FAILS CLOSED — it is truthy and never authorizes", async () => {
+  const reg = registryWithNatives();
+  const fresh = objectInfo();
+  const node = { id: 11, type: "MarkdownNote", widgets: [{ name: "text", type: "string", value: "" }], constructor: reg["MarkdownNote"] };
+  // The SAME fixture succeeds with a real baseline — only the oracle differs, so the
+  // refusal below is attributable to the missing baseline and nothing else.
+  await assert.doesNotReject(() => assertAddNodeResolvableRefreshing(() => reg, "MarkdownNote", ADD_OPTS(fresh)));
+  assert.doesNotThrow(() =>
+    assertTypeAgainstFreshBackend(fresh, "MarkdownNote", 11, { registry: reg, node, wasTypeEverDefined: () => false }),
+  );
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "text", "# README", {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => fresh,
+        wasTypeEverDefined: NO_BASELINE,
+        ...HOOKS,
+      }),
+    /no trustworthy record|Reload the ComfyUI tab/i,
+  );
+  assert.equal(node.widgets[0].value, "", "no write without a baseline");
+});
+
+test("#496: a REAL removed pack still gets the removed-pack diagnosis (the honest message did not replace it)", () => {
+  const reg = registryWithNatives();
+  const fresh = objectInfo();
+  const node = { id: 11, type: "MarkdownNote", widgets: [{ name: "text", type: "string", value: "" }], constructor: reg["MarkdownNote"] };
+  assert.throws(
+    () =>
+      assertTypeAgainstFreshBackend(fresh, "MarkdownNote", 11, {
+        registry: reg,
+        node,
+        wasTypeEverDefined: (t) => t === "MarkdownNote", // a genuine ever-seen positive
+      }),
+    /its backend was removed|pack uninstalled/i,
+  );
+});
+
+test("#496: backendHistoryVerdict — the one classifier all three guards share", () => {
+  assert.equal(backendHistoryVerdict("X", () => HISTORY_UNSEEDED), "unseeded");
+  assert.equal(backendHistoryVerdict("X", () => true), "removed");
+  assert.equal(backendHistoryVerdict("X", () => false), "never-seen");
+  assert.equal(backendHistoryVerdict("X", undefined), "no-oracle", "no oracle wired");
+  assert.equal(backendHistoryVerdict(undefined, () => true), "no-oracle", "a non-string type");
+  // isRemovedBackendType is the NARROW "REMOVED" claim only — an unseeded history is a
+  // refusal, but it is not a claim that the pack was removed.
+  assert.equal(isRemovedBackendType("X", () => HISTORY_UNSEEDED), false);
+  assert.equal(isRemovedBackendType("X", () => true), true);
 });

--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -32,6 +32,10 @@ import {
 // The PRODUCTION graph_set_widget handler body — the executor and these tests
 // call it verbatim, so the tested ordering IS the shipped ordering (#458).
 import { runSetWidget } from "../../web/js/lib/set-widget.js";
+// The PRODUCTION combo refresh + the authoritative "server says this combo is empty"
+// oracle that gates #507's last-resort acceptance.
+import { refreshComboOptionsFromDefs } from "../../web/js/lib/asset-staleness.js";
+import { serverDeclaresEmptyComboOptions } from "../../web/js/lib/input-asset.js";
 
 // A registry shaped like LG.registered_node_types once /object_info loaded:
 // hundreds of classes; we only need the sentinels + a couple of extras here.
@@ -1165,15 +1169,12 @@ function starObjectInfo(serverOptions = []) {
   info["StarOllamaPromptHelper"] = { input: { required: { model: [serverOptions, {}] } } };
   return info;
 }
-// A refreshCombos that does what the panel's does: overwrite the live option list with
-// the server's, from the ALREADY-FETCHED /object_info payload.
-const refreshFromServer = (fresh, targetNode) => {
-  const def = fresh?.[targetNode?.type]?.input?.required;
-  for (const w of targetNode?.widgets ?? []) {
-    const spec = def?.[w.name];
-    if (Array.isArray(spec?.[0])) w.options.values = spec[0];
-  }
-};
+// The PRODUCTION combo refresh (the same function the panel injects as refreshCombos),
+// so these tests inherit its real semantics — notably that it deliberately NEVER clobbers
+// a dynamic (function) option source. A hand-rolled stand-in that overwrote functions
+// would hide exactly the path codex round-2 flagged.
+const refreshFromServer = (fresh, targetNode, defTypeKey, nameMap) =>
+  refreshComboOptionsFromDefs(targetNode, fresh, defTypeKey, nameMap);
 
 test("#507 e2e: a combo whose SERVER option list is empty becomes writable (the StarNodes repro)", async () => {
   const { reg, node, widget } = starNodesFixture([]);
@@ -1259,4 +1260,139 @@ test("#507 e2e: the empty-list fallback does NOT bypass the #458 type authorizat
     /removed|since-removed/i,
   );
   assert.equal(widget.value, "", "no write behind a refused authorization");
+});
+
+// ---- #507 codex round-2 (SEVERE): the last-resort acceptance is gated on the SERVER
+//      declaring the option list empty, never on the LIVE widget alone. -----------------
+
+test("#507 SEVERE: a DYNAMIC (function) source returning [] while the SERVER publishes a real list is still REFUSED", () => {
+  // The exact fail-open codex found: refreshComboOptionsFromDefs deliberately never
+  // clobbers a function option source, so a dynamic combo that currently returns []
+  // stays "empty" through the refresh. If the empty-list fallback keyed on the LIVE
+  // widget it would then write an OFF-LIST value against a real server list (#240).
+  const reg = loadedRegistry(["StarOllamaPromptHelper"]);
+  const widget = { name: "model", type: "combo", options: { values: () => [] }, value: "" };
+  const node = { id: 9, type: "StarOllamaPromptHelper", widgets: [widget], constructor: reg["StarOllamaPromptHelper"] };
+  const fresh = starObjectInfo(["allowed:1b"]); // the SERVER does publish a list
+  // Precondition: the production refresh leaves a function source alone.
+  refreshComboOptionsFromDefs(node, fresh, "StarOllamaPromptHelper");
+  assert.equal(typeof widget.options.values, "function", "production refresh must not clobber a dynamic source");
+  // And the authoritative oracle correctly says the server list is NOT empty.
+  assert.equal(serverDeclaresEmptyComboOptions(fresh, "StarOllamaPromptHelper", "model"), false);
+  return assert.rejects(
+    () =>
+      runSetWidget(node, "model", "off-list:70b", {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => fresh,
+        wasTypeEverDefined: () => true,
+        refreshCombos: refreshFromServer,
+        ...HOOKS,
+      }),
+    /not a valid option|EMPTY option list/i,
+  ).then(() => {
+    assert.equal(widget.value, "", "must not have mutated — the server list is real");
+  });
+});
+
+test("#507: a dynamic source returning [] AND a server-declared empty list DOES write", () => {
+  // The legitimate StarNodes shape, dynamic-source variant: both the live source and
+  // /object_info agree there is nothing to validate against.
+  const reg = loadedRegistry(["StarOllamaPromptHelper"]);
+  const widget = { name: "model", type: "combo", options: { values: () => [] }, value: "" };
+  const node = { id: 9, type: "StarOllamaPromptHelper", widgets: [widget], constructor: reg["StarOllamaPromptHelper"] };
+  return runSetWidget(node, "model", "qwen3-vl:8b", {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: async () => starObjectInfo([]),
+    wasTypeEverDefined: () => true,
+    refreshCombos: refreshFromServer,
+    ...HOOKS,
+  }).then((res) => {
+    assert.equal(res.set.value, "qwen3-vl:8b");
+    assert.equal(res.empty_option_list, true);
+  });
+});
+
+test("#507: with NO server def for the type (or a non-combo input), the empty list is NOT accepted", async () => {
+  const reg = loadedRegistry(["StarOllamaPromptHelper"]);
+  // (a) the type IS in object_info but declares `model` as a plain STRING input.
+  const stringInput = objectInfo();
+  stringInput["StarOllamaPromptHelper"] = { input: { required: { model: ["STRING", {}] } } };
+  const a = starNodesFixture([]);
+  await assert.rejects(
+    () =>
+      runSetWidget(a.node, "model", "qwen3-vl:8b", {
+        registry: a.reg,
+        getRegistry: () => a.reg,
+        getFreshObjectInfo: async () => stringInput,
+        wasTypeEverDefined: () => true,
+        refreshCombos: refreshFromServer,
+        ...HOOKS,
+      }),
+    /EMPTY option list|refused/i,
+  );
+  assert.equal(a.widget.value, "", "no write without an authoritative empty-combo declaration");
+  // (b) the def exists but has no such input at all.
+  const noInput = objectInfo();
+  noInput["StarOllamaPromptHelper"] = { input: { required: {} } };
+  const b = starNodesFixture([]);
+  await assert.rejects(
+    () =>
+      runSetWidget(b.node, "model", "qwen3-vl:8b", {
+        registry: b.reg,
+        getRegistry: () => b.reg,
+        getFreshObjectInfo: async () => noInput,
+        wasTypeEverDefined: () => true,
+        refreshCombos: refreshFromServer,
+        ...HOOKS,
+      }),
+    /EMPTY option list|refused/i,
+  );
+  assert.equal(b.widget.value, "");
+  void reg;
+});
+
+test("#507: serverDeclaresEmptyComboOptions — TRUE only for an explicitly EMPTY declared combo list", () => {
+  const defs = {
+    T: {
+      input: {
+        required: { empty: [[], {}], full: [["a"], {}], str: ["STRING", {}] },
+        optional: { optEmpty: [[], {}] },
+      },
+    },
+  };
+  assert.equal(serverDeclaresEmptyComboOptions(defs, "T", "empty"), true);
+  assert.equal(serverDeclaresEmptyComboOptions(defs, "T", "optEmpty"), true, "optional inputs count too");
+  assert.equal(serverDeclaresEmptyComboOptions(defs, "T", "full"), false);
+  assert.equal(serverDeclaresEmptyComboOptions(defs, "T", "str"), false);
+  assert.equal(serverDeclaresEmptyComboOptions(defs, "T", "nope"), false);
+  assert.equal(serverDeclaresEmptyComboOptions(defs, "Missing", "empty"), false);
+  assert.equal(serverDeclaresEmptyComboOptions(null, "T", "empty"), false);
+  assert.equal(serverDeclaresEmptyComboOptions(defs, "T", undefined), false);
+});
+
+test("#507 codex round-2 (MODERATE): a real failure on the FINAL attempt propagates, not the earlier combo rejection", async () => {
+  // The empty-list attempt is a genuine write. If it fails for a REAL reason (here the
+  // value does not stick), that error must surface — it must not be swallowed and
+  // replaced by the stale "EMPTY option list" rejection.
+  const reg = loadedRegistry(["StarOllamaPromptHelper"]);
+  const widget = Object.defineProperty(
+    { name: "model", type: "combo", options: { values: [] } },
+    "value",
+    { get: () => "frozen", set: () => {}, enumerable: true, configurable: true },
+  );
+  const node = { id: 9, type: "StarOllamaPromptHelper", widgets: [widget], constructor: reg["StarOllamaPromptHelper"] };
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "model", "qwen3-vl:8b", {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => starObjectInfo([]),
+        wasTypeEverDefined: () => true,
+        refreshCombos: refreshFromServer,
+        ...HOOKS,
+      }),
+    /did not retain the requested value/i,
+  );
 });

--- a/browser_tests/unit/object-info-history.test.mjs
+++ b/browser_tests/unit/object-info-history.test.mjs
@@ -20,6 +20,19 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { createObjectInfoHistory } from "../../web/js/lib/object-info-history.js";
+// The guard-side contract this oracle feeds: an unseeded history returns a TRUTHY
+// sentinel, which the shared classifier reports as "unseeded" (refuse, but diagnose it
+// as a missing baseline rather than a removed pack).
+import { HISTORY_UNSEEDED, backendHistoryVerdict, isRemovedBackendType } from "../../web/js/lib/node-resolve.js";
+
+// Assert the FULL fail-closed contract for a type in a no-baseline history.
+const assertUnseededClosed = (h, type, msg) => {
+  const verdict = h.wasTypeEverDefined(type);
+  assert.equal(verdict, HISTORY_UNSEEDED, msg);
+  assert.ok(verdict, "the sentinel must be TRUTHY so a truth-testing consumer still fails closed");
+  assert.equal(backendHistoryVerdict(type, (t) => h.wasTypeEverDefined(t)), "unseeded");
+  assert.equal(isRemovedBackendType(type, (t) => h.wasTypeEverDefined(t)), false, "not a REMOVED claim — it is an unknown-baseline claim");
+};
 
 const defs = (...types) => Object.fromEntries(types.map((t) => [t, { input: { required: {} } }]));
 
@@ -27,12 +40,12 @@ test("#458 rule 1: an UNSEEDED history fails CLOSED — every type reads as ever
   const h = createObjectInfoHistory();
   assert.equal(h.seeded, false);
   // Nothing observed at all.
-  assert.equal(h.wasTypeEverDefined("MarkdownNote"), true, "unseeded ⇒ refuse (treat as removed)");
-  assert.equal(h.wasTypeEverDefined("AnythingAtAll"), true);
+  assertUnseededClosed(h, "MarkdownNote", "unseeded ⇒ refuse");
+  assertUnseededClosed(h, "AnythingAtAll");
   // Even after RECORDING types, an unseeded history still refuses everything: recording
   // is evidence, promoting it to a baseline is a separate, explicit claim.
   h.recordTypes(defs("KSampler"));
-  assert.equal(h.wasTypeEverDefined("MarkdownNote"), true, "recording alone is not a baseline");
+  assertUnseededClosed(h, "MarkdownNote", "recording alone is not a baseline");
 });
 
 test("#458 rule 1: once SEEDED, only genuinely-observed types read as ever-defined", () => {
@@ -54,12 +67,25 @@ test("#458 rule 2 (SEVERE): a LOST baseline is LATCHED — a later successful ob
   assert.equal(h.baselineLost, true);
   // "MarkdownNote" was NEVER in the late payload — but we cannot conclude it never
   // existed, so it must still read as ever-defined and stay refused by the guards.
-  assert.equal(
-    h.wasTypeEverDefined("MarkdownNote"),
-    true,
-    "a post-loss history must never authorize the frontend-only exemption",
-  );
-  assert.equal(h.wasTypeEverDefined("KSampler"), true);
+  assertUnseededClosed(h, "MarkdownNote", "a post-loss history must never authorize the frontend-only exemption");
+  assertUnseededClosed(h, "KSampler");
+});
+
+test("#458 rule 2 (SEVERE, production ordering): a post-gap observation recorded BEFORE any guard runs does not establish a baseline", () => {
+  // The ordering codex round-4 flagged: the startup seed hangs (so nothing has latched
+  // yet), the pack is removed, and a RECONNECT / refresh_nodes / download refresh lands a
+  // current /object_info. That payload is RECORDED — recording only ever adds evidence —
+  // but it must NOT be promoted to a baseline, because it cannot support the claim
+  // "anything absent here was never backend-defined this session".
+  const h = createObjectInfoHistory();
+  h.recordTypes(defs("KSampler", "CLIPTextEncode")); // post-removal payload, no markSeeded
+  assert.equal(h.seeded, false, "recording alone never seeds — only the startup seed may");
+  assertUnseededClosed(h, "MarkdownNote", "with no startup baseline, nothing can be concluded");
+  // The guard that eventually runs latches the loss, and it stays latched afterwards.
+  h.loseBaseline();
+  h.recordTypes(defs("KSampler"));
+  assert.equal(h.markSeeded(), false);
+  assertUnseededClosed(h, "MarkdownNote");
 });
 
 test("#458 rule 2: losing the baseline AFTER it was legitimately established also closes the gate", () => {
@@ -71,7 +97,7 @@ test("#458 rule 2: losing the baseline AFTER it was legitimately established als
   // markSeeded is now inert, so a subsequent re-register cannot re-open the exemption.
   assert.equal(h.markSeeded(), false);
   assert.equal(h.seeded, false);
-  assert.equal(h.wasTypeEverDefined("MarkdownNote"), true, "latched closed for the session");
+  assertUnseededClosed(h, "MarkdownNote", "latched closed for the session");
 });
 
 test("#458: recordTypes is NOT latched — recording can only ever ADD evidence (refuse more)", () => {

--- a/browser_tests/unit/object-info-history.test.mjs
+++ b/browser_tests/unit/object-info-history.test.mjs
@@ -15,6 +15,12 @@
  * a pack is removed → a later fetch succeeds → without the latch that POST-removal map
  * becomes the baseline, the removed type reads "never seen", and a provenance-stripped
  * husk squatting a reserved allowlisted name (MarkdownNote) is exempted.
+ *
+ * SCOPE NOTE: these tests cover this module's POLICY. They do NOT — and cannot — cover the
+ * residual race in which a pack is removed inside the window between page load and the
+ * panel's first successful /object_info response, since the baseline can only ever come
+ * from an asynchronous fetch. See the KNOWN, ACCEPTED RESIDUAL note in
+ * web/js/lib/object-info-history.js for why that is bounded and out of scope.
  */
 import test from "node:test";
 import assert from "node:assert/strict";

--- a/browser_tests/unit/object-info-history.test.mjs
+++ b/browser_tests/unit/object-info-history.test.mjs
@@ -28,7 +28,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { createObjectInfoHistory } from "../../web/js/lib/object-info-history.js";
+import { createObjectInfoHistory, awaitHistoryBaseline } from "../../web/js/lib/object-info-history.js";
 // The guard-side contract this oracle feeds: both no-baseline states return a TRUTHY
 // sentinel (so a truth-testing consumer still fails closed) and the shared classifier
 // turns them into distinct, honest diagnoses.
@@ -163,4 +163,64 @@ test("#458: recordTypes is defensive and returns its argument (so it can wrap a 
   assert.equal(h.wasTypeEverDefined("KSampler"), true);
   // A null payload recorded nothing, so an unobserved type is still 'never seen'.
   assert.equal(h.wasTypeEverDefined("MarkdownNote"), false);
+});
+
+
+// ---- awaitHistoryBaseline: the PRODUCTION bounded wait. These are the load-bearing
+//      tests for the coordinator-found HIGH — reintroducing a loseBaseline() call inside
+//      this helper must FAIL here, not merely be caught by review. ---------------------
+
+const never = () => new Promise(() => {}); // a getNodeDefs() that never settles
+
+test("#496 HIGH: a bounded wait that EXPIRES must not mutate the history (no latch, no seed)", async () => {
+  const h = createObjectInfoHistory();
+  const seeded = await awaitHistoryBaseline(h, never(), 5);
+  assert.equal(seeded, false, "reports 'not seeded' so the caller refuses this one call");
+  assert.equal(h.baselineLost, false, "a TIMEOUT is the absence of evidence — it must never latch");
+  assert.equal(h.seeded, false);
+  // …and the state is the RECOVERABLE one, so the refusal reads as temporary.
+  assert.equal(h.wasTypeEverDefined("MarkdownNote"), HISTORY_PENDING);
+});
+
+test("#496 HIGH: the seed keeps running past the bound — a late response still restores normal operation", async () => {
+  const h = createObjectInfoHistory();
+  // A seed that resolves well AFTER the caller's bound, exactly like an 8.1s getNodeDefs
+  // against an 8s wait.
+  const slowSeed = new Promise((resolve) => setTimeout(resolve, 40)).then(() => {
+    h.recordTypes({ KSampler: {}, CLIPTextEncode: {} });
+    h.markSeeded();
+  });
+  assert.equal(await awaitHistoryBaseline(h, slowSeed, 5), false, "gave up waiting");
+  assert.equal(h.baselineLost, false, "…without burning the session");
+  await slowSeed; // the response lands
+  // The NEXT call sees a real baseline: no reload, and the exemption works again.
+  assert.equal(await awaitHistoryBaseline(h, slowSeed, 5), true);
+  assert.equal(h.wasTypeEverDefined("MarkdownNote"), false, "MarkdownNote addable/writable again");
+  assert.equal(h.wasTypeEverDefined("KSampler"), true, "and the baseline is a REAL one");
+});
+
+test("awaitHistoryBaseline: a seed that RESOLVES within the bound reports seeded immediately", async () => {
+  const h = createObjectInfoHistory();
+  const seed = Promise.resolve().then(() => {
+    h.recordTypes({ KSampler: {} });
+    h.markSeeded();
+  });
+  assert.equal(await awaitHistoryBaseline(h, seed, 1000), true);
+  assert.equal(h.baselineLost, false);
+});
+
+test("awaitHistoryBaseline: a REJECTED seed neither throws nor latches (the seed itself owns that decision)", async () => {
+  const h = createObjectInfoHistory();
+  const rejected = Promise.reject(new Error("network"));
+  assert.equal(await awaitHistoryBaseline(h, rejected, 1000), false, "no unhandled rejection, no throw");
+  assert.equal(h.baselineLost, false, "only seedObjectInfoHistory, after ALL attempts finish, may latch");
+  assert.equal(h.wasTypeEverDefined("MarkdownNote"), HISTORY_PENDING);
+});
+
+test("awaitHistoryBaseline: an ALREADY-LATCHED history is reported as not seeded and stays latched", async () => {
+  const h = createObjectInfoHistory();
+  h.loseBaseline();
+  assert.equal(await awaitHistoryBaseline(h, never(), 5), false);
+  assert.equal(h.baselineLost, true);
+  assert.equal(h.wasTypeEverDefined("MarkdownNote"), HISTORY_UNSEEDED, "still the reload-the-tab state");
 });

--- a/browser_tests/unit/object-info-history.test.mjs
+++ b/browser_tests/unit/object-info-history.test.mjs
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for web/js/lib/object-info-history.js — run with `node --test`.
+ *
+ * This is the OBSERVED-BACKEND-HISTORY trust root the whole #458 guard family rests on
+ * (node-resolve.js's isRemovedBackendType / the frontend-only exemption). Its two
+ * fail-closed rules are what stop a removed backend pack from being written to or added:
+ *
+ *   1. UNSEEDED ⇒ CLOSED — until a trustworthy baseline exists, "never seen" proves
+ *      nothing, so every absent-from-current type reads as removed.
+ *   2. BASELINE LOST ⇒ LATCHED CLOSED — once the startup baseline is missed, no LATER
+ *      observation may re-establish it, because the removal could have happened inside
+ *      the window we never observed.
+ *
+ * Rule 2 is the sequence adversarial review flagged twice: startup fetch hangs/fails →
+ * a pack is removed → a later fetch succeeds → without the latch that POST-removal map
+ * becomes the baseline, the removed type reads "never seen", and a provenance-stripped
+ * husk squatting a reserved allowlisted name (MarkdownNote) is exempted.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createObjectInfoHistory } from "../../web/js/lib/object-info-history.js";
+
+const defs = (...types) => Object.fromEntries(types.map((t) => [t, { input: { required: {} } }]));
+
+test("#458 rule 1: an UNSEEDED history fails CLOSED — every type reads as ever-defined", () => {
+  const h = createObjectInfoHistory();
+  assert.equal(h.seeded, false);
+  // Nothing observed at all.
+  assert.equal(h.wasTypeEverDefined("MarkdownNote"), true, "unseeded ⇒ refuse (treat as removed)");
+  assert.equal(h.wasTypeEverDefined("AnythingAtAll"), true);
+  // Even after RECORDING types, an unseeded history still refuses everything: recording
+  // is evidence, promoting it to a baseline is a separate, explicit claim.
+  h.recordTypes(defs("KSampler"));
+  assert.equal(h.wasTypeEverDefined("MarkdownNote"), true, "recording alone is not a baseline");
+});
+
+test("#458 rule 1: once SEEDED, only genuinely-observed types read as ever-defined", () => {
+  const h = createObjectInfoHistory();
+  h.recordTypes(defs("KSampler", "CLIPTextEncode"));
+  assert.equal(h.markSeeded(), true);
+  assert.equal(h.wasTypeEverDefined("KSampler"), true, "observed ⇒ removed if now absent");
+  assert.equal(h.wasTypeEverDefined("MarkdownNote"), false, "never observed ⇒ genuinely frontend-only");
+});
+
+test("#458 rule 2 (SEVERE): a LOST baseline is LATCHED — a later successful observation cannot restore it", () => {
+  // The exact hole: the startup seed fails / times out, the pack is removed during the
+  // gap, and a later fetch returns the POST-removal /object_info.
+  const h = createObjectInfoHistory();
+  h.loseBaseline(); // a graph tool gave up waiting for the startup seed
+  h.recordTypes(defs("KSampler", "CLIPTextEncode")); // a later, post-removal payload
+  assert.equal(h.markSeeded(), false, "the latch refuses to promote a post-loss observation");
+  assert.equal(h.seeded, false);
+  assert.equal(h.baselineLost, true);
+  // "MarkdownNote" was NEVER in the late payload — but we cannot conclude it never
+  // existed, so it must still read as ever-defined and stay refused by the guards.
+  assert.equal(
+    h.wasTypeEverDefined("MarkdownNote"),
+    true,
+    "a post-loss history must never authorize the frontend-only exemption",
+  );
+  assert.equal(h.wasTypeEverDefined("KSampler"), true);
+});
+
+test("#458 rule 2: losing the baseline AFTER it was legitimately established also closes the gate", () => {
+  const h = createObjectInfoHistory();
+  h.recordTypes(defs("KSampler"));
+  h.markSeeded();
+  assert.equal(h.wasTypeEverDefined("MarkdownNote"), false, "precondition: exemption available");
+  h.loseBaseline();
+  // markSeeded is now inert, so a subsequent re-register cannot re-open the exemption.
+  assert.equal(h.markSeeded(), false);
+  assert.equal(h.seeded, false);
+  assert.equal(h.wasTypeEverDefined("MarkdownNote"), true, "latched closed for the session");
+});
+
+test("#458: recordTypes is NOT latched — recording can only ever ADD evidence (refuse more)", () => {
+  const h = createObjectInfoHistory();
+  h.recordTypes(defs("GoneNode"));
+  h.markSeeded();
+  assert.equal(h.wasTypeEverDefined("GoneNode"), true, "observed ⇒ its later absence means REMOVED");
+  // A brand-new type observed later is likewise remembered, so its later absence is
+  // caught too. This direction can never open a hole.
+  h.recordTypes(defs("LaterPackNode"));
+  assert.equal(h.has("LaterPackNode"), true);
+  assert.equal(h.wasTypeEverDefined("LaterPackNode"), true);
+});
+
+test("#458: recordTypes is defensive and returns its argument (so it can wrap a fetch inline)", () => {
+  const h = createObjectInfoHistory();
+  assert.equal(h.recordTypes(null), null);
+  assert.equal(h.recordTypes(undefined), undefined);
+  const payload = defs("KSampler");
+  assert.equal(h.recordTypes(payload), payload, "returns the payload unchanged");
+  h.markSeeded();
+  assert.equal(h.wasTypeEverDefined("KSampler"), true);
+  // A null payload recorded nothing, so an unobserved type is still 'never seen'.
+  assert.equal(h.wasTypeEverDefined("MarkdownNote"), false);
+});

--- a/browser_tests/unit/object-info-history.test.mjs
+++ b/browser_tests/unit/object-info-history.test.mjs
@@ -2,19 +2,22 @@
  * Unit tests for web/js/lib/object-info-history.js — run with `node --test`.
  *
  * This is the OBSERVED-BACKEND-HISTORY trust root the whole #458 guard family rests on
- * (node-resolve.js's isRemovedBackendType / the frontend-only exemption). Its two
- * fail-closed rules are what stop a removed backend pack from being written to or added:
+ * (node-resolve.js's backendHistoryVerdict / the frontend-only exemption). It has THREE
+ * states, and keeping two of them apart is the whole point of the module:
  *
- *   1. UNSEEDED ⇒ CLOSED — until a trustworthy baseline exists, "never seen" proves
- *      nothing, so every absent-from-current type reads as removed.
- *   2. BASELINE LOST ⇒ LATCHED CLOSED — once the startup baseline is missed, no LATER
- *      observation may re-establish it, because the removal could have happened inside
- *      the window we never observed.
+ *   SEEDED   — a page-load-anchored /object_info was observed. "Never seen" is meaningful,
+ *              so the frontend-only exemption may be considered.
+ *   PENDING  — no baseline YET (the fetch is in flight, or a caller bounded its wait).
+ *              Refuse, but TEMPORARILY and RECOVERABLY: a late response still seeds and
+ *              the next call authorizes normally, with no tab reload.
+ *   LATCHED  — the observation window POSITIVELY closed with no data. Refuse for the whole
+ *              session; no later observation may re-establish a baseline.
  *
- * Rule 2 is the sequence adversarial review flagged twice: startup fetch hangs/fails →
- * a pack is removed → a later fetch succeeds → without the latch that POST-removal map
- * becomes the baseline, the removed type reads "never seen", and a provenance-stripped
- * husk squatting a reserved allowlisted name (MarkdownNote) is exempted.
+ * PENDING vs LATCHED is an evidence distinction, not a convenience. A TIMEOUT is the
+ * ABSENCE of evidence: latching on one turns an /object_info fetch that merely took a
+ * moment too long into a permanent, session-long refusal of every legitimate add and
+ * write — a third false refusal on top of the two (#496, #507) this work fixes. Only a
+ * seed whose attempt sequence has FINISHED empty has the evidence to latch.
  *
  * SCOPE NOTE: these tests cover this module's POLICY. They do NOT — and cannot — cover the
  * residual race in which a pack is removed inside the window between page load and the
@@ -26,32 +29,44 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { createObjectInfoHistory } from "../../web/js/lib/object-info-history.js";
-// The guard-side contract this oracle feeds: an unseeded history returns a TRUTHY
-// sentinel, which the shared classifier reports as "unseeded" (refuse, but diagnose it
-// as a missing baseline rather than a removed pack).
-import { HISTORY_UNSEEDED, backendHistoryVerdict, isRemovedBackendType } from "../../web/js/lib/node-resolve.js";
-
-// Assert the FULL fail-closed contract for a type in a no-baseline history.
-const assertUnseededClosed = (h, type, msg) => {
-  const verdict = h.wasTypeEverDefined(type);
-  assert.equal(verdict, HISTORY_UNSEEDED, msg);
-  assert.ok(verdict, "the sentinel must be TRUTHY so a truth-testing consumer still fails closed");
-  assert.equal(backendHistoryVerdict(type, (t) => h.wasTypeEverDefined(t)), "unseeded");
-  assert.equal(isRemovedBackendType(type, (t) => h.wasTypeEverDefined(t)), false, "not a REMOVED claim — it is an unknown-baseline claim");
-};
+// The guard-side contract this oracle feeds: both no-baseline states return a TRUTHY
+// sentinel (so a truth-testing consumer still fails closed) and the shared classifier
+// turns them into distinct, honest diagnoses.
+import {
+  HISTORY_PENDING,
+  HISTORY_UNSEEDED,
+  backendHistoryVerdict,
+  isRemovedBackendType,
+} from "../../web/js/lib/node-resolve.js";
 
 const defs = (...types) => Object.fromEntries(types.map((t) => [t, { input: { required: {} } }]));
+const oracle = (h) => (t) => h.wasTypeEverDefined(t);
 
-test("#458 rule 1: an UNSEEDED history fails CLOSED — every type reads as ever-defined", () => {
+// Assert the full fail-closed contract for a type in a given no-baseline state.
+const assertClosed = (h, type, sentinel, verdict, msg) => {
+  const answer = h.wasTypeEverDefined(type);
+  assert.equal(answer, sentinel, msg);
+  assert.ok(answer, "the sentinel must be TRUTHY so a truth-testing consumer fails closed");
+  assert.equal(backendHistoryVerdict(type, oracle(h)), verdict);
+  assert.equal(
+    isRemovedBackendType(type, oracle(h)),
+    false,
+    "no baseline is not a REMOVED claim — it is an unknown-baseline claim",
+  );
+};
+const assertPending = (h, type, msg) => assertClosed(h, type, HISTORY_PENDING, "pending", msg);
+const assertLatched = (h, type, msg) => assertClosed(h, type, HISTORY_UNSEEDED, "unseeded", msg);
+
+test("#458 rule 1: a history with no baseline yet is PENDING and fails CLOSED", () => {
   const h = createObjectInfoHistory();
   assert.equal(h.seeded, false);
-  // Nothing observed at all.
-  assertUnseededClosed(h, "MarkdownNote", "unseeded ⇒ refuse");
-  assertUnseededClosed(h, "AnythingAtAll");
-  // Even after RECORDING types, an unseeded history still refuses everything: recording
-  // is evidence, promoting it to a baseline is a separate, explicit claim.
+  assert.equal(h.baselineLost, false);
+  assertPending(h, "MarkdownNote", "no baseline yet ⇒ refuse");
+  assertPending(h, "AnythingAtAll");
+  // Even after RECORDING types, an unseeded history still refuses: recording is evidence,
+  // promoting it to a baseline is a separate, explicit claim.
   h.recordTypes(defs("KSampler"));
-  assertUnseededClosed(h, "MarkdownNote", "recording alone is not a baseline");
+  assertPending(h, "MarkdownNote", "recording alone is not a baseline");
 });
 
 test("#458 rule 1: once SEEDED, only genuinely-observed types read as ever-defined", () => {
@@ -60,38 +75,58 @@ test("#458 rule 1: once SEEDED, only genuinely-observed types read as ever-defin
   assert.equal(h.markSeeded(), true);
   assert.equal(h.wasTypeEverDefined("KSampler"), true, "observed ⇒ removed if now absent");
   assert.equal(h.wasTypeEverDefined("MarkdownNote"), false, "never observed ⇒ genuinely frontend-only");
+  assert.equal(backendHistoryVerdict("MarkdownNote", oracle(h)), "never-seen");
+  assert.equal(backendHistoryVerdict("KSampler", oracle(h)), "removed");
 });
 
-test("#458 rule 2 (SEVERE): a LOST baseline is LATCHED — a later successful observation cannot restore it", () => {
-  // The exact hole: the startup seed fails / times out, the pack is removed during the
-  // gap, and a later fetch returns the POST-removal /object_info.
+test("#496 REGRESSION: a LATE seed (arriving after a caller's bounded wait) restores normal operation", () => {
+  // The exact scenario a bounded wait creates: api.getNodeDefs() takes longer than the
+  // bound, a graph tool gives up waiting and refuses THIS call, and the response then
+  // lands with perfectly healthy definitions. The next call MUST authorize normally.
+  // Latching at the timeout instead would refuse every legitimate add/write for the rest
+  // of the session — ordinary latency causing permanent breakage, which is the very
+  // false-refusal bug class #496/#507 are about.
   const h = createObjectInfoHistory();
-  h.loseBaseline(); // a graph tool gave up waiting for the startup seed
-  h.recordTypes(defs("KSampler", "CLIPTextEncode")); // a later, post-removal payload
+  // t = 0..bound: the tool gives up waiting. It must NOT latch — it learned nothing.
+  assertPending(h, "MarkdownNote", "still loading ⇒ a TEMPORARY refusal");
+  assert.equal(h.baselineLost, false, "a bounded wait must never latch the session");
+  // t = bound+ε: the slow response lands and seeds the baseline.
+  h.recordTypes(defs("KSampler", "CLIPTextEncode"));
+  assert.equal(h.markSeeded(), true, "a late seed is still a valid page-load-anchored baseline");
+  // The very next authorization succeeds — no tab reload, nothing burned.
+  assert.equal(h.seeded, true);
+  assert.equal(h.wasTypeEverDefined("MarkdownNote"), false, "MarkdownNote is addable/writable again");
+  assert.equal(backendHistoryVerdict("MarkdownNote", oracle(h)), "never-seen");
+  // …and the recovered baseline is a REAL one: a type it did observe still reads removed.
+  assert.equal(backendHistoryVerdict("KSampler", oracle(h)), "removed");
+});
+
+test("#458 rule 2 (SEVERE): a LATCHED baseline cannot be restored by a later successful observation", () => {
+  // The evidence case: the seed's whole attempt sequence finished with nothing, so the
+  // page-load-anchored window is positively closed. A later fetch may be POST-removal, so
+  // it must never become the baseline.
+  const h = createObjectInfoHistory();
+  h.loseBaseline(); // the startup seed exhausted every attempt
+  h.recordTypes(defs("KSampler", "CLIPTextEncode")); // a later, possibly post-removal payload
   assert.equal(h.markSeeded(), false, "the latch refuses to promote a post-loss observation");
   assert.equal(h.seeded, false);
   assert.equal(h.baselineLost, true);
-  // "MarkdownNote" was NEVER in the late payload — but we cannot conclude it never
-  // existed, so it must still read as ever-defined and stay refused by the guards.
-  assertUnseededClosed(h, "MarkdownNote", "a post-loss history must never authorize the frontend-only exemption");
-  assertUnseededClosed(h, "KSampler");
+  // "MarkdownNote" was never in the late payload — but we cannot conclude it never
+  // existed, so it stays refused, and with the reload-the-tab diagnosis rather than the
+  // temporary one.
+  assertLatched(h, "MarkdownNote", "a post-loss history must never authorize the exemption");
+  assertLatched(h, "KSampler");
 });
 
 test("#458 rule 2 (SEVERE, production ordering): a post-gap observation recorded BEFORE any guard runs does not establish a baseline", () => {
-  // The ordering codex round-4 flagged: the startup seed hangs (so nothing has latched
-  // yet), the pack is removed, and a RECONNECT / refresh_nodes / download refresh lands a
-  // current /object_info. That payload is RECORDED — recording only ever adds evidence —
-  // but it must NOT be promoted to a baseline, because it cannot support the claim
-  // "anything absent here was never backend-defined this session".
+  // The ordering adversarial review flagged: nothing has latched yet, a pack is removed,
+  // and a RECONNECT / refresh_nodes / download refresh lands a current /object_info. That
+  // payload is RECORDED — recording only ever adds evidence — but it must NOT be promoted
+  // to a baseline, because only the startup seed may call markSeeded().
   const h = createObjectInfoHistory();
   h.recordTypes(defs("KSampler", "CLIPTextEncode")); // post-removal payload, no markSeeded
   assert.equal(h.seeded, false, "recording alone never seeds — only the startup seed may");
-  assertUnseededClosed(h, "MarkdownNote", "with no startup baseline, nothing can be concluded");
-  // The guard that eventually runs latches the loss, and it stays latched afterwards.
-  h.loseBaseline();
-  h.recordTypes(defs("KSampler"));
-  assert.equal(h.markSeeded(), false);
-  assertUnseededClosed(h, "MarkdownNote");
+  assertPending(h, "MarkdownNote", "with no startup baseline, nothing can be concluded");
 });
 
 test("#458 rule 2: losing the baseline AFTER it was legitimately established also closes the gate", () => {
@@ -103,7 +138,7 @@ test("#458 rule 2: losing the baseline AFTER it was legitimately established als
   // markSeeded is now inert, so a subsequent re-register cannot re-open the exemption.
   assert.equal(h.markSeeded(), false);
   assert.equal(h.seeded, false);
-  assertUnseededClosed(h, "MarkdownNote", "latched closed for the session");
+  assertLatched(h, "MarkdownNote", "latched closed for the session");
 });
 
 test("#458: recordTypes is NOT latched — recording can only ever ADD evidence (refuse more)", () => {

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -1883,3 +1883,146 @@ test("#477 P1: a STATEFUL afterChange that RE-ADDS a replacement proxy every fir
   // the extra replacement stays live — surfaced as partial state, never a clean rollback.
   assert.ok(parent.widgets.includes(newProxy), "the stateful afterChange keeps the replacement live — honestly reported, not masked");
 });
+
+// ---- #507: a DYNAMIC, CLIENT-POPULATED combo whose option list is EMPTY.
+//      `comboOptions()` returns `[]`, which is TRUTHY, so the "no readable option list"
+//      guard never fired and `[].includes(value)` rejected EVERY value — the widget was
+//      permanently unwritable. Zero options means the option set is not KNOWABLE, not
+//      that nothing is valid. But an empty LIVE list can also be merely STALE, so
+//      applyWidgetWrite refuses RETRYABLY by default and only accepts once the caller
+//      (runSetWidget, after its authoritative refresh) opts in. -----------------------
+
+// StarNodes' StarOllamaPromptHelper declares `"model": ((), {...})`, so /object_info
+// reports `"model": [[], {...}]` and the node's own "Refresh Models" button fills the
+// dropdown client-side.
+const emptyComboNode = (value = "") => ({
+  id: 9,
+  type: "StarOllamaPromptHelper",
+  widgets: [{ name: "model", type: "combo", options: { values: [] }, value }],
+});
+const ACCEPT_EMPTY = { ...HOOKS, acceptEmptyComboOptions: true };
+
+test("#507: an EMPTY option list is a RETRYABLE combo rejection by default (a stale list must be refreshed first)", () => {
+  const node = emptyComboNode("orig");
+  assert.throws(
+    () => applyWidgetWrite(node, "model", "qwen3-vl:8b", HOOKS),
+    (err) => err instanceof WidgetWriteError && err.combo === true && /EMPTY option list/.test(err.message),
+  );
+  assert.equal(node.widgets[0].value, "orig", "no mutation while the list is still being resolved");
+});
+
+test("#507: once the list is confirmed STILL empty, the write PROCEEDS with the exact value", () => {
+  const node = emptyComboNode();
+  const set = applyWidgetWrite(node, "model", "qwen3-vl:8b", ACCEPT_EMPTY);
+  assert.equal(set.value, "qwen3-vl:8b");
+  assert.equal(node.widgets[0].value, "qwen3-vl:8b", "the exact value is written, uncoerced");
+});
+
+test("#507: an empty DYNAMIC (function) option list behaves exactly like an empty array", () => {
+  const mk = () => ({
+    id: 9,
+    type: "StarOllamaPromptHelper",
+    widgets: [{ name: "model", type: "combo", options: { values: () => [] }, value: "" }],
+  });
+  assert.throws(() => applyWidgetWrite(mk(), "model", "llama3.2:3b", HOOKS), WidgetWriteError);
+  assert.equal(applyWidgetWrite(mk(), "model", "llama3.2:3b", ACCEPT_EMPTY).value, "llama3.2:3b");
+});
+
+test("#507: a NON-EMPTY list still refuses an off-list value even with acceptEmptyComboOptions (#240 intact)", () => {
+  // The opt-in is scoped to the EMPTY case only — it is not a blanket 'skip validation'.
+  const node = {
+    id: 9,
+    type: "StarOllamaPromptHelper",
+    widgets: [{ name: "model", type: "combo", options: { values: ["qwen3-vl:8b", "llama3.2:3b"] }, value: "qwen3-vl:8b" }],
+  };
+  assert.throws(
+    () => applyWidgetWrite(node, "model", "not-installed:70b", ACCEPT_EMPTY),
+    (err) => err instanceof WidgetWriteError && /not a valid option/.test(err.message),
+  );
+  assert.equal(node.widgets[0].value, "qwen3-vl:8b", "must not have mutated on reject");
+  // …and a valid member of that same non-empty list still succeeds.
+  assert.equal(applyWidgetWrite(node, "model", "llama3.2:3b", ACCEPT_EMPTY).value, "llama3.2:3b");
+});
+
+test("#507: the LIVE client-populated list is what gets validated (richer than the server's empty one)", () => {
+  // comboOptions reads the LIVE widget, so once the node's own "Refresh Models" button
+  // has filled the dropdown, that list is authoritative for membership.
+  const node = {
+    id: 9,
+    type: "StarOllamaPromptHelper",
+    widgets: [{ name: "model", type: "combo", options: { values: ["qwen3-vl:8b"] }, value: "" }],
+  };
+  assert.equal(applyWidgetWrite(node, "model", "qwen3-vl:8b", ACCEPT_EMPTY).value, "qwen3-vl:8b");
+  assert.throws(() => applyWidgetWrite(node, "model", "ghost:1b", ACCEPT_EMPTY), WidgetWriteError);
+});
+
+test("#507: an UNREADABLE option list is STILL refused — empty is not the same as unreadable", () => {
+  // The pre-existing fail-closed guard is untouched: a missing options.values and a
+  // throwing dynamic fn both still refuse, even with the opt-in — they may be hiding a
+  // real, non-empty list.
+  const missing = { id: 9, type: "N", widgets: [{ name: "model", type: "combo", value: "x" }] };
+  assert.throws(
+    () => applyWidgetWrite(missing, "model", "anything", ACCEPT_EMPTY),
+    (err) => err instanceof WidgetWriteError && /no readable option list/.test(err.message),
+  );
+  const throwing = {
+    id: 9,
+    type: "N",
+    widgets: [{ name: "model", type: "combo", options: { values: () => { throw new Error("boom"); } }, value: "x" }],
+  };
+  assert.throws(() => applyWidgetWrite(throwing, "model", "anything", ACCEPT_EMPTY), WidgetWriteError);
+});
+
+test("#507: an empty option list accepts only a SCALAR — objects/arrays fail closed and are NOT retryable", () => {
+  for (const bad of [{ a: 1 }, ["a"]]) {
+    const node = emptyComboNode("orig");
+    assert.throws(
+      () => applyWidgetWrite(node, "model", bad, ACCEPT_EMPTY),
+      (err) => err instanceof WidgetWriteError && err.combo !== true,
+      `#507: ${JSON.stringify(bad)} must not be written to a combo, and a refresh cannot help`,
+    );
+    assert.equal(node.widgets[0].value, "orig", "must not have mutated on reject");
+  }
+  // A MISSING value is still refused by the pre-existing #347 guard, before the combo branch.
+  assert.throws(() => applyWidgetWrite(emptyComboNode("orig"), "model", undefined, ACCEPT_EMPTY), WidgetWriteError);
+  // Non-string scalars are fine — a dynamic combo may legitimately hold a number/boolean.
+  assert.equal(applyWidgetWrite(emptyComboNode(), "model", 7, ACCEPT_EMPTY).value, 7);
+  assert.equal(applyWidgetWrite(emptyComboNode(), "model", true, ACCEPT_EMPTY).value, true);
+});
+
+test("#507: an UNRESOLVED widget/node still gets no fabricated success (#281/#458)", () => {
+  // No such widget at all: the empty-list path must never be reached by inventing one.
+  const none = { id: 9, type: "StarOllamaPromptHelper", widgets: [] };
+  assert.throws(
+    () => applyWidgetWrite(none, "model", "qwen3-vl:8b", ACCEPT_EMPTY),
+    (err) => err instanceof WidgetWriteError && /has no widget/.test(err.message),
+  );
+  // The injected #458 target guard still runs before any empty-list handling.
+  assert.throws(
+    () =>
+      applyWidgetWrite(emptyComboNode(), "model", "qwen3-vl:8b", {
+        ...ACCEPT_EMPTY,
+        assertTargetWritable: () => {
+          throw new Error("unresolved placeholder node");
+        },
+      }),
+    /unresolved placeholder node/,
+  );
+  // A write that does not STICK is reported as a failure, never a success.
+  const frozen = {
+    id: 9,
+    type: "StarOllamaPromptHelper",
+    widgets: [
+      Object.defineProperty({ name: "model", type: "combo", options: { values: [] } }, "value", {
+        get: () => "frozen",
+        set: () => {},
+        enumerable: true,
+        configurable: true,
+      }),
+    ],
+  };
+  assert.throws(
+    () => applyWidgetWrite(frozen, "model", "qwen3-vl:8b", ACCEPT_EMPTY),
+    (err) => err instanceof WidgetWriteError && /did not retain the requested value/i.test(err.message),
+  );
+});

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -2165,3 +2165,61 @@ test("#507 round-5: the dynamic-rail refusal is SCOPED to the empty-list path", 
   assert.equal(set.value, "karras");
   assert.equal(inner.widgets[0].value, "karras");
 });
+
+test("#507 final round: when the INNER list validated the value normally, the dynamic-rail refusal does not fire", () => {
+  // A stateful inner options function that was empty for the earlier attempts but holds a
+  // real list containing the value by the final one: ordinary membership validated the
+  // write, so a dynamic parent rail needs no extra scrutiny and must not be refused —
+  // that would be the same "guard rejects a legitimate case" bug #496/#507 are about.
+  const inner = {
+    id: 301,
+    type: "StarOllamaPromptHelper",
+    widgets: [{ name: "model", type: "combo", options: { values: () => ["qwen3-vl:8b"] }, value: "" }],
+  };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "301" ? inner : null) };
+  const railWidget = { name: "model_alias", type: "combo", options: { values: () => ["qwen3-vl:8b"] }, value: "" };
+  const parent = {
+    id: 320,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [{ name: "model_alias", _widget: railWidget, widget: { name: "model_alias" }, _subgraphSlot: { name: "model_alias" } }],
+    widgets: [railWidget],
+  };
+  const resolveSource = (_node, si) =>
+    si?.name === "model_alias" ? { sourceNodeId: "301", sourceWidgetName: "model" } : null;
+  const set = applyWidgetWrite(parent, "model_alias", "qwen3-vl:8b", {
+    ...HOOKS,
+    resolveSource,
+    acceptEmptyComboOptions: true,
+  });
+  assert.equal(set.value, "qwen3-vl:8b");
+  assert.equal(inner.widgets[0].value, "qwen3-vl:8b");
+  assert.equal(railWidget.value, "qwen3-vl:8b");
+});
+
+test("#507 final round: an OFF-list value against a non-empty inner list is still refused with the flag set", () => {
+  // The narrowing must not become an escape hatch: if the inner list is non-empty and
+  // does NOT contain the value, coerceWidgetValue already refuses (before the rail check).
+  const inner = {
+    id: 301,
+    type: "StarOllamaPromptHelper",
+    widgets: [{ name: "model", type: "combo", options: { values: ["qwen3-vl:8b"] }, value: "" }],
+  };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "301" ? inner : null) };
+  const railWidget = { name: "model_alias", type: "combo", options: { values: () => ["anything"] }, value: "" };
+  const parent = {
+    id: 320,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [{ name: "model_alias", _widget: railWidget, widget: { name: "model_alias" }, _subgraphSlot: { name: "model_alias" } }],
+    widgets: [railWidget],
+  };
+  const resolveSource = (_node, si) =>
+    si?.name === "model_alias" ? { sourceNodeId: "301", sourceWidgetName: "model" } : null;
+  assert.throws(
+    () => applyWidgetWrite(parent, "model_alias", "off-list:70b", { ...HOOKS, resolveSource, acceptEmptyComboOptions: true }),
+    (err) => err instanceof WidgetWriteError && /not a valid option/.test(err.message),
+  );
+  assert.equal(inner.widgets[0].value, "");
+  assert.equal(railWidget.value, "");
+});

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -2026,3 +2026,85 @@ test("#507: an UNRESOLVED widget/node still gets no fabricated success (#281/#45
     (err) => err instanceof WidgetWriteError && /did not retain the requested value/i.test(err.message),
   );
 });
+
+// ---- #507 codex round-3 (MODERATE): a PROMOTED write also mutates the parent's rail /
+//      display-proxy combos, whose option lists can DIFFER from the inner's. The
+//      empty-list acceptance must not push an off-list value into one of those. --------
+
+// Same shape as makeSubgraphFixture above (identity-linked rail via input._widget), but
+// the INNER combo is EMPTY — the StarNodes-style dynamic input promoted out of a subgraph.
+function makeEmptyInnerPromotedFixture(railOptions) {
+  const inner = {
+    id: 301,
+    type: "StarOllamaPromptHelper",
+    widgets: [{ name: "model", type: "combo", options: { values: [] }, value: "" }],
+  };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "301" ? inner : null) };
+  const railWidget = { name: "model_alias", type: "combo", options: railOptions, value: "" };
+  const parent = {
+    id: 320,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [
+      { name: "model_alias", _widget: railWidget, widget: { name: "model_alias" }, _subgraphSlot: { name: "model_alias" } },
+    ],
+    widgets: [railWidget],
+  };
+  const resolveSource = (_node, subgraphInput) =>
+    subgraphInput?.name === "model_alias" ? { sourceNodeId: "301", sourceWidgetName: "model" } : null;
+  return { parent, inner, railWidget, resolveSource };
+}
+
+test("#507 round-3: an empty INNER combo must not write an off-list value into a NON-EMPTY parent rail", () => {
+  const { parent, inner, railWidget, resolveSource } = makeEmptyInnerPromotedFixture({
+    values: ["qwen3-vl:8b", "llama3.2:3b"],
+  });
+  assert.throws(
+    () =>
+      applyWidgetWrite(parent, "model_alias", "off-list:70b", {
+        ...HOOKS,
+        resolveSource,
+        acceptEmptyComboOptions: true,
+      }),
+    (err) => err instanceof WidgetWriteError && /not a valid option for the parent subgraph/.test(err.message),
+  );
+  assert.equal(inner.widgets[0].value, "", "inner untouched — refused before any mutation");
+  assert.equal(railWidget.value, "", "rail untouched");
+});
+
+test("#507 round-3: the SAME promoted shape writes fine when the value IS on the parent rail's list", () => {
+  const { parent, inner, railWidget, resolveSource } = makeEmptyInnerPromotedFixture({
+    values: ["qwen3-vl:8b", "llama3.2:3b"],
+  });
+  const set = applyWidgetWrite(parent, "model_alias", "llama3.2:3b", {
+    ...HOOKS,
+    resolveSource,
+    acceptEmptyComboOptions: true,
+  });
+  assert.equal(set.value, "llama3.2:3b");
+  assert.equal(inner.widgets[0].value, "llama3.2:3b");
+  assert.equal(railWidget.value, "llama3.2:3b", "the rail is synced (#366/#477)");
+});
+
+test("#507 round-3: a parent rail whose list is EMPTY or UNREADABLE adds no constraint", () => {
+  for (const railOptions of [{ values: [] }, { values: () => { throw new Error("boom"); } }, {}]) {
+    const { parent, inner, resolveSource } = makeEmptyInnerPromotedFixture(railOptions);
+    const set = applyWidgetWrite(parent, "model_alias", "qwen3-vl:8b", {
+      ...HOOKS,
+      resolveSource,
+      acceptEmptyComboOptions: true,
+    });
+    assert.equal(set.value, "qwen3-vl:8b");
+    assert.equal(inner.widgets[0].value, "qwen3-vl:8b");
+  }
+});
+
+test("#507 round-3: the rail cross-check is SCOPED to the empty-list path (ordinary promoted writes unchanged)", () => {
+  // Pre-existing behaviour: the INNER list is authoritative, so a value on the inner list
+  // but NOT on the rail's still writes. The new cross-check must not tighten this.
+  const { parent, inner, railWidget, resolveSource } = makeSubgraphFixture();
+  railWidget.options.values = ["simple"]; // rail list now EXCLUDES "karras"
+  const set = applyWidgetWrite(parent, "sched_alias", "karras", { ...HOOKS, resolveSource });
+  assert.equal(set.value, "karras");
+  assert.equal(inner.widgets.find((w) => w.name === "scheduler").value, "karras");
+});

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -2167,10 +2167,10 @@ test("#507 round-5: the dynamic-rail refusal is SCOPED to the empty-list path", 
 });
 
 test("#507 final round: when the INNER list validated the value normally, the dynamic-rail refusal does not fire", () => {
-  // A stateful inner options function that was empty for the earlier attempts but holds a
-  // real list containing the value by the final one: ordinary membership validated the
-  // write, so a dynamic parent rail needs no extra scrutiny and must not be refused —
-  // that would be the same "guard rejects a legitimate case" bug #496/#507 are about.
+  // The inner list is non-empty and CONTAINS the value, so ordinary membership admitted it
+  // and the empty-list acceptance was never used — a dynamic parent rail then needs no
+  // extra scrutiny and must not be refused, which would be the same "guard rejects a
+  // legitimate case" bug #496/#507 are about. The flag being set is not itself the trigger.
   const inner = {
     id: 301,
     type: "StarOllamaPromptHelper",
@@ -2222,4 +2222,60 @@ test("#507 final round: an OFF-list value against a non-empty inner list is stil
   );
   assert.equal(inner.widgets[0].value, "");
   assert.equal(railWidget.value, "");
+});
+
+test("#507 confirmation round: a STATEFUL inner options fn cannot be used to skip the parent-rail check", () => {
+  // The escape hatch codex found: if the sibling cross-check decided by RE-READING the
+  // inner list after coercion, a function that returns [] at coercion time (so the
+  // empty-list acceptance is what admitted the value) and a NON-EMPTY list containing the
+  // value on the next read would look "normally validated" — and an off-list value would
+  // then land on a static parent rail and be reported as success. The verdict must come
+  // from COERCION TIME, so this must still be refused.
+  let call = 0;
+  const inner = {
+    id: 301,
+    type: "StarOllamaPromptHelper",
+    // 1st call (coercion): empty ⇒ the empty-list acceptance admits the value.
+    // Every later call: a list that CONTAINS the value, which a re-read would trust.
+    widgets: [{ name: "model", type: "combo", options: { values: () => (call++ === 0 ? [] : ["off-list:70b"]) }, value: "" }],
+  };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "301" ? inner : null) };
+  const railWidget = { name: "model_alias", type: "combo", options: { values: ["allowed:1b"] }, value: "" };
+  const parent = {
+    id: 320,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [{ name: "model_alias", _widget: railWidget, widget: { name: "model_alias" }, _subgraphSlot: { name: "model_alias" } }],
+    widgets: [railWidget],
+  };
+  const resolveSource = (_node, si) =>
+    si?.name === "model_alias" ? { sourceNodeId: "301", sourceWidgetName: "model" } : null;
+  assert.throws(
+    () => applyWidgetWrite(parent, "model_alias", "off-list:70b", { ...HOOKS, resolveSource, acceptEmptyComboOptions: true }),
+    (err) => err instanceof WidgetWriteError && /not a valid option for the parent subgraph/.test(err.message),
+  );
+  assert.equal(inner.widgets[0].value, "", "inner untouched");
+  assert.equal(railWidget.value, "", "the off-list value never reached the rail");
+});
+
+test("#507 confirmation round: coerceWidgetValue reports empty-list acceptance ONLY when it was used", () => {
+  // The signal the cross-check keys on, asserted directly so a future refactor that stops
+  // setting it (silently disabling the rail check) fails here.
+  const empty = { name: "model", type: "combo", options: { values: [] }, value: "" };
+  const outEmpty = {};
+  assert.equal(coerceWidgetValue(empty, "anything", empty, null, { acceptEmptyComboOptions: true, out: outEmpty }), "anything");
+  assert.equal(outEmpty.emptyAcceptanceUsed, true, "the empty-list acceptance admitted it");
+
+  const full = { name: "model", type: "combo", options: { values: ["a", "b"] }, value: "a" };
+  const outFull = {};
+  assert.equal(coerceWidgetValue(full, "b", full, null, { acceptEmptyComboOptions: true, out: outFull }), "b");
+  assert.equal(outFull.emptyAcceptanceUsed, undefined, "ordinary membership admitted it — acceptance unused");
+
+  // And with the flag OFF an empty list is still a retryable refusal, never an acceptance.
+  const outOff = {};
+  assert.throws(
+    () => coerceWidgetValue(empty, "anything", empty, null, { out: outOff }),
+    (err) => err instanceof WidgetWriteError && err.emptyOptions === true && err.combo === true,
+  );
+  assert.equal(outOff.emptyAcceptanceUsed, undefined);
 });

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -2086,8 +2086,8 @@ test("#507 round-3: the SAME promoted shape writes fine when the value IS on the
   assert.equal(railWidget.value, "llama3.2:3b", "the rail is synced (#366/#477)");
 });
 
-test("#507 round-3: a parent rail whose list is EMPTY or UNREADABLE adds no constraint", () => {
-  for (const railOptions of [{ values: [] }, { values: () => { throw new Error("boom"); } }, {}]) {
+test("#507 round-3: a parent rail whose list is EMPTY or ABSENT adds no constraint", () => {
+  for (const railOptions of [{ values: [] }, {}]) {
     const { parent, inner, resolveSource } = makeEmptyInnerPromotedFixture(railOptions);
     const set = applyWidgetWrite(parent, "model_alias", "qwen3-vl:8b", {
       ...HOOKS,
@@ -2107,4 +2107,61 @@ test("#507 round-3: the rail cross-check is SCOPED to the empty-list path (ordin
   const set = applyWidgetWrite(parent, "sched_alias", "karras", { ...HOOKS, resolveSource });
   assert.equal(set.value, "karras");
   assert.equal(inner.widgets.find((w) => w.name === "scheduler").value, "karras");
+});
+
+test("#507 round-5: a DYNAMIC parent-rail option source is UNVERIFIABLE on the empty-list path ⇒ fail closed", () => {
+  // codex round-5: a one-shot read of a function source proves nothing — it can return []
+  // during the cross-check and a real list immediately afterwards, so the off-list value
+  // would still land on the mutated, serializing rail. Refuse instead.
+  let call = 0;
+  const { parent, inner, railWidget, resolveSource } = makeEmptyInnerPromotedFixture({
+    values: () => (call++ === 0 ? [] : ["allowed"]), // [] first, real list after
+  });
+  assert.throws(
+    () =>
+      applyWidgetWrite(parent, "model_alias", "off-list:70b", {
+        ...HOOKS,
+        resolveSource,
+        acceptEmptyComboOptions: true,
+      }),
+    (err) => err instanceof WidgetWriteError && /computed dynamically/.test(err.message),
+  );
+  assert.equal(inner.widgets[0].value, "", "inner untouched");
+  assert.equal(railWidget.value, "", "rail untouched — no value assigned behind an unverifiable list");
+  // A stable dynamic source is refused too: the rule is about verifiability, not about
+  // catching this particular stateful source.
+  const stable = makeEmptyInnerPromotedFixture({ values: () => ["allowed"] });
+  assert.throws(
+    () =>
+      applyWidgetWrite(stable.parent, "model_alias", "allowed", {
+        ...HOOKS,
+        resolveSource: stable.resolveSource,
+        acceptEmptyComboOptions: true,
+      }),
+    (err) => err instanceof WidgetWriteError && /computed dynamically/.test(err.message),
+  );
+});
+
+test("#507 round-5: the dynamic-rail refusal is SCOPED to the empty-list path", () => {
+  // An ordinary promoted write against a dynamic rail is untouched — the inner list is
+  // authoritative there, so nothing about the rail needs verifying.
+  const inner = {
+    id: 301,
+    type: "N",
+    widgets: [{ name: "scheduler", type: "combo", options: { values: ["simple", "karras"] }, value: "simple" }],
+  };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "301" ? inner : null) };
+  const railWidget = { name: "sched_alias", type: "combo", options: { values: () => ["simple", "karras"] }, value: "simple" };
+  const parent = {
+    id: 320,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [{ name: "sched_alias", _widget: railWidget, widget: { name: "sched_alias" }, _subgraphSlot: { name: "sched_alias" } }],
+    widgets: [railWidget],
+  };
+  const resolveSource = (_node, si) =>
+    si?.name === "sched_alias" ? { sourceNodeId: "301", sourceWidgetName: "scheduler" } : null;
+  const set = applyWidgetWrite(parent, "sched_alias", "karras", { ...HOOKS, resolveSource });
+  assert.equal(set.value, "karras");
+  assert.equal(inner.widgets[0].value, "karras");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -121,6 +121,7 @@ import {
   resolveMissingModelDirectory,
 } from "./lib/asset-staleness.js";
 import { assertAddNodeResolvableRefreshing } from "./lib/node-resolve.js";
+import { createObjectInfoHistory } from "./lib/object-info-history.js";
 import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
 import { reconcileCompletedDownloads } from "./lib/download-refresh.js";
 import { todoItemGlyph } from "./lib/plan-glyph.js";
@@ -314,44 +315,28 @@ function monotonicNow() {
 // registerComfyNodeDefs). A write to a type ABSENT from the CURRENT /object_info that
 // was EVER seen here is a REMOVED backend node (refuse, #458) — a client husk cannot
 // un-see what the backend already reported; a type NEVER seen is genuinely frontend-only.
-const seenObjectInfoTypes = new Set();
-function recordObjectInfoTypes(defs) {
-  if (defs && typeof defs === "object") {
-    for (const key of Object.keys(defs)) seenObjectInfoTypes.add(key);
-  }
-  return defs;
-}
-// True once at least ONE authoritative /object_info observation has been recorded as a
-// baseline (the startup seed, or a reconnect/refresh_nodes re-register). Until then the
-// ever-seen history is UNRELIABLE — a write must NOT decide "never seen" against it, so
-// wasTypeEverDefined below FAILS CLOSED (treats every absent-from-current type as
-// removed) while this is false. A seed FAILURE therefore never opens a hole (codex
-// round-10): it leaves this false, so absent types are refused, not allowed.
-let objectInfoHistorySeeded = false;
+// The trust root itself lives in web/js/lib/object-info-history.js so its fail-closed
+// rules (unseeded ⇒ closed; baseline LOST ⇒ latched closed for the session) are
+// unit-testable rather than loose module state in this bundle.
+const objectInfoHistory = createObjectInfoHistory();
+const recordObjectInfoTypes = (defs) => objectInfoHistory.recordTypes(defs);
+const markObjectInfoHistorySeeded = () => objectInfoHistory.markSeeded();
 // Resolves once the STARTUP baseline seed attempt sequence has finished (success or all
-// retries exhausted). graph_set_widget AWAITS this before authorizing.
+// retries exhausted). The graph tools AWAIT this (bounded) before authorizing.
 let objectInfoHistorySeed = Promise.resolve();
-// True once the CURRENT seed attempt sequence has actually FINISHED (settled), as opposed
-// to still being in flight. A bounded waiter must not start a REPLACEMENT seed while the
-// original is still running: a fetch issued after a mid-wait pack removal would observe an
-// /object_info that never contained the removed type and install THAT as the session
-// baseline, making a removed type look "never seen" — exactly the hole the ever-seen gate
-// exists to close (codex round-2, SEVERE).
-let objectInfoHistorySeedSettled = true;
 function seedObjectInfoHistory() {
-  objectInfoHistorySeedSettled = false;
   objectInfoHistorySeed = (async () => {
     // Retry a transient getNodeDefs failure a few times (short backoff) so a flaky
     // startup fetch self-heals BEFORE any pack could be removed mid-session. If the
-    // backend is genuinely down, all attempts fail and objectInfoHistorySeeded stays
-    // false → fail closed (and the write's own oracle also fails closed).
+    // backend is genuinely down, all attempts fail and the history stays UNSEEDED
+    // → fail closed (and the write's own oracle also fails closed).
     for (let attempt = 0; attempt < 5; attempt++) {
       try {
         if (typeof api?.getNodeDefs === "function") {
           const defs = await api.getNodeDefs();
           if (defs && typeof defs === "object" && Object.keys(defs).length > 0) {
             recordObjectInfoTypes(defs);
-            objectInfoHistorySeeded = true;
+            markObjectInfoHistorySeeded();
             return;
           }
         }
@@ -360,9 +345,7 @@ function seedObjectInfoHistory() {
       }
       await new Promise((resolve) => setTimeout(resolve, 150));
     }
-  })().finally(() => {
-    objectInfoHistorySeedSettled = true;
-  });
+  })();
   return objectInfoHistorySeed;
 }
 
@@ -370,8 +353,8 @@ function seedObjectInfoHistory() {
 // The seed's own retry loop only advances once each api.getNodeDefs() SETTLES, so a
 // request that never settles (a hung/half-open connection) would otherwise block the
 // awaiting tool FOREVER (codex round-1, MODERATE). Bounding the wait converts that
-// availability failure into the correct fail-CLOSED outcome: objectInfoHistorySeeded is
-// still false when we stop waiting, so wasTypeEverDefined treats every absent-from-current
+// availability failure into the correct fail-CLOSED outcome: the history is still
+// UNSEEDED when we stop waiting, so wasTypeEverDefined treats every absent-from-current
 // type as removed and the write/add is refused with an honest error instead of hanging.
 const OBJECT_INFO_SEED_WAIT_MS = 8000;
 async function awaitObjectInfoHistorySeed() {
@@ -387,16 +370,16 @@ async function awaitObjectInfoHistorySeed() {
     ]).finally(() => clearTimeout(timer));
   };
   await bounded(objectInfoHistorySeed);
-  if (objectInfoHistorySeeded) return;
-  // Not seeded. Retry ONCE (the backend may have come up since page load) — but ONLY if
-  // the previous attempt has actually FINISHED. If we merely TIMED OUT on an in-flight
-  // request, a replacement fetch could observe an /object_info taken AFTER a pack was
-  // removed during the wait and install it as the session baseline, so the removed type
-  // would read "never seen" and sail through the frontend-only exemption (codex round-2,
-  // SEVERE). Returning here leaves objectInfoHistorySeeded false, which makes
-  // wasTypeEverDefined treat every absent-from-current type as removed — fail CLOSED.
-  if (!objectInfoHistorySeedSettled) return;
-  await bounded(seedObjectInfoHistory());
+  if (objectInfoHistory.seeded) return;
+  // We reached a graph tool WITHOUT a trustworthy startup baseline — the seed failed, or
+  // it is still in flight and we bounded the wait. Either way there is now a window we
+  // never observed, so no later /object_info can prove a type was "never defined earlier
+  // this session". LATCH that permanently (codex round-2 + round-3, SEVERE) instead of
+  // re-seeding: a replacement fetch would happily install a POST-removal map as the
+  // baseline. With the latch set, wasTypeEverDefined treats every absent-from-current
+  // type as removed, so the frontend-only exemption stays OFF and both graph_add_node and
+  // graph_set_widget fail closed for the rest of the session.
+  objectInfoHistory.loseBaseline();
 }
 
 async function registerComfyNodeDefs(preloadedDefs) {
@@ -422,7 +405,11 @@ async function registerComfyNodeDefs(preloadedDefs) {
     // reconnect after a failed startup seed restores the ever-seen gate to normal.
     recordObjectInfoTypes(defs);
     if (defs && typeof defs === "object" && Object.keys(defs).length > 0) {
-      objectInfoHistorySeeded = true;
+      // Honours the baseline-lost LATCH: a reconnect must NOT restore the ever-seen gate
+      // once the startup baseline was missed, because this payload may already be
+      // POST-removal (codex round-3, SEVERE). Recording the types above is still correct
+      // and useful — it can only ever ADD evidence that a type existed.
+      markObjectInfoHistorySeeded();
     }
     // Re-register node definitions so newly installed/updated classes and their
     // current widget schemas are known to LiteGraph (#221/#171).
@@ -5897,7 +5884,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // so a since-REMOVED pack is still refused. WAIT for the startup baseline seed for
     // the same reason set_widget does: an un-seeded history must never let a write/add
     // decide "never seen". If the seed still cannot land (backend down),
-    // objectInfoHistorySeeded stays false and wasTypeEverDefined fails CLOSED.
+    // the history stays UNSEEDED and wasTypeEverDefined fails CLOSED.
     await awaitObjectInfoHistorySeed();
     await assertAddNodeResolvableRefreshing(() => LG?.registered_node_types ?? {}, class_type, {
       getFreshObjectInfo: async () =>
@@ -5906,7 +5893,7 @@ const GRAPH_TOOL_EXECUTORS = {
         ),
       refresh: (defs) => refreshComfyNodeDefs(defs),
       // #458 OBSERVED-BACKEND-HISTORY trust root, identical to graph_set_widget's.
-      wasTypeEverDefined: (t) => !objectInfoHistorySeeded || seenObjectInfoTypes.has(t),
+      wasTypeEverDefined: (t) => objectInfoHistory.wasTypeEverDefined(t),
     });
     const node = LG.createNode(class_type);
     if (!node) {
@@ -6331,7 +6318,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // write can never decide "never seen" against an un-seeded history — a pack present
     // at page load that is removed mid-session is thus recorded before its removal and
     // refused. If the startup seed did NOT establish a baseline (transient failure), try
-    // ONCE more here; if it still can't (backend down), objectInfoHistorySeeded stays
+    // ONCE more here; if it still can't (backend down), the history stays UNSEEDED
     // false and wasTypeEverDefined fails CLOSED (absent types refused) — never allowed
     // against an empty history (codex round-10). A backend that is up now succeeds and
     // establishes the baseline for all currently-present types.
@@ -6366,7 +6353,7 @@ const GRAPH_TOOL_EXECUTORS = {
       // node — refuse (non-forgeable; client shape/name/provenance can't prove this).
       // While the history is NOT reliably seeded, FAIL CLOSED (treat every absent type as
       // ever-seen) so a failed/empty baseline never opens a hole (codex round-10).
-      wasTypeEverDefined: (t) => !objectInfoHistorySeeded || seenObjectInfoTypes.has(t),
+      wasTypeEverDefined: (t) => objectInfoHistory.wasTypeEverDefined(t),
       resolveSource: sourceForSubgraphInput,
       canvas: app.canvas,
       beforeChange: () => graph.beforeChange(),

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -348,22 +348,28 @@ function seedObjectInfoHistory() {
       }
       await new Promise((resolve) => setTimeout(resolve, 150));
     }
-    // Every attempt failed: the STARTUP baseline is definitively missed, and this is the
-    // ONLY function permitted to establish one. Latch the loss now rather than waiting
-    // for a graph tool to notice — otherwise nothing marks the session unsafe and a later
-    // observation could look authoritative (codex round-4, SEVERE).
+    // Every attempt FINISHED and none produced definitions. That is positive EVIDENCE
+    // that the page-load-anchored observation window closed with nothing — not merely an
+    // absence of evidence — so no later fetch can serve as a baseline and the latch is
+    // correctly armed here. This is the ONLY place that arms it: a caller that merely
+    // bounded its WAIT has learned nothing and must not latch (a request still in flight
+    // may return healthy definitions a moment later).
     objectInfoHistory.loseBaseline();
   })();
   return objectInfoHistorySeed;
 }
 
-// How long a graph tool will WAIT for the startup baseline seed before giving up on it.
-// The seed's own retry loop only advances once each api.getNodeDefs() SETTLES, so a
+// How long a graph tool will WAIT for the startup baseline seed before proceeding without
+// it. The seed's own retry loop only advances once each api.getNodeDefs() SETTLES, so a
 // request that never settles (a hung/half-open connection) would otherwise block the
-// awaiting tool FOREVER (codex round-1, MODERATE). Bounding the wait converts that
-// availability failure into the correct fail-CLOSED outcome: the history is still
-// UNSEEDED when we stop waiting, so wasTypeEverDefined treats every absent-from-current
-// type as removed and the write/add is refused with an honest error instead of hanging.
+// awaiting tool FOREVER. Bounding the wait converts that hang into the correct outcome:
+// the history reports PENDING, and the tool refuses THIS call with "retry in a moment".
+//
+// The bound is a patience limit, NOT a verdict. The seed is untouched by it and keeps
+// running, so a response arriving after the bound still establishes the baseline and the
+// very next call succeeds — no tab reload, nothing burned. That is what makes an 8s
+// timeout safe to have at all: without a recoverable pending state it would convert
+// ordinary latency into a permanent, session-long false refusal.
 const OBJECT_INFO_SEED_WAIT_MS = 8000;
 async function awaitObjectInfoHistorySeed() {
   const bounded = (p) => {
@@ -378,16 +384,20 @@ async function awaitObjectInfoHistorySeed() {
     ]).finally(() => clearTimeout(timer));
   };
   await bounded(objectInfoHistorySeed);
-  if (objectInfoHistory.seeded) return;
-  // We reached a graph tool WITHOUT a trustworthy startup baseline — the seed failed, or
-  // it is still in flight and we bounded the wait. Either way there is now a window we
-  // never observed, so no later /object_info can prove a type was "never defined earlier
-  // this session". LATCH that permanently (codex round-2 + round-3, SEVERE) instead of
-  // re-seeding: a replacement fetch would happily install a POST-removal map as the
-  // baseline. With the latch set, wasTypeEverDefined treats every absent-from-current
-  // type as removed, so the frontend-only exemption stays OFF and both graph_add_node and
-  // graph_set_widget fail closed for the rest of the session.
-  objectInfoHistory.loseBaseline();
+  // Deliberately nothing else. If the seed has not landed yet the history reports
+  // PENDING, the guards refuse this ONE call with "retry in a moment", and the seed keeps
+  // running: a response arriving AFTER the bound still calls markSeeded(), so the next
+  // call authorizes normally with no tab reload.
+  //
+  // We must NOT latch here. Timing out is the ABSENCE of evidence, not evidence — an
+  // /object_info fetch that merely took longer than the bound would otherwise burn the
+  // whole session, refusing every legitimate add/write afterwards even though the request
+  // came back with perfectly healthy definitions. That is the same false-refusal bug
+  // (#496/#507) this work exists to fix. Only seedObjectInfoHistory, whose attempt
+  // sequence has actually FINISHED empty, has the evidence to arm the latch.
+  //
+  // We must also NOT start a replacement seed: that fetch would be anchored AFTER an
+  // unobserved window, and installing its map as the baseline is the removed-pack hole.
 }
 
 async function registerComfyNodeDefs(preloadedDefs) {
@@ -5891,10 +5901,11 @@ const GRAPH_TOOL_EXECUTORS = {
     // #496: genuinely FRONTEND-ONLY types (Note/MarkdownNote/Reroute/…) are never in
     // /object_info by design, so the guard exempts them via the SAME shared predicate
     // graph_set_widget uses — but only behind the observed-backend-history gate below,
-    // so a since-REMOVED pack is still refused. WAIT for the startup baseline seed for
-    // the same reason set_widget does: an un-seeded history must never let a write/add
-    // decide "never seen". If the seed still cannot land (backend down),
-    // the history stays UNSEEDED and wasTypeEverDefined fails CLOSED.
+    // so a since-REMOVED pack is still refused. WAIT (bounded) for the startup baseline
+    // seed for the same reason set_widget does: an un-seeded history must never let a
+    // write/add decide "never seen". If it has not landed the history reports PENDING and
+    // this ONE call is refused with a retry-in-a-moment message — a late response still
+    // seeds, so the next call succeeds without a reload.
     await awaitObjectInfoHistorySeed();
     await assertAddNodeResolvableRefreshing(() => LG?.registered_node_types ?? {}, class_type, {
       getFreshObjectInfo: async () =>
@@ -6327,13 +6338,11 @@ const GRAPH_TOOL_EXECUTORS = {
     // #458: WAIT for the startup baseline history seed to land before authorizing, so a
     // write can never decide "never seen" against an un-seeded history — a pack present
     // at page load that is removed mid-session is thus recorded before its removal and
-    // refused. If the startup seed did NOT establish a baseline (transient failure), try
-    // ONCE more here; if it still can't (backend down), the history stays UNSEEDED
-    // false and wasTypeEverDefined fails CLOSED (absent types refused) — never allowed
-    // against an empty history (codex round-10). A backend that is up now succeeds and
-    // establishes the baseline for all currently-present types.
-    // (BOUNDED — a getNodeDefs request that never settles must not hang the tool; the
-    // wait gives up and leaves the history unseeded, which fails CLOSED.)
+    // refused. BOUNDED, so a getNodeDefs request that never settles cannot hang the tool:
+    // if the baseline has not landed the history reports PENDING and wasTypeEverDefined
+    // fails CLOSED for this call only, with a TEMPORARY "retry in a moment" refusal. The
+    // seed keeps running, so a late response still establishes the baseline and the next
+    // call authorizes normally — ordinary latency must never burn the session.
     await awaitObjectInfoHistorySeed();
     // Delegate to the shared handler body (web/js/lib/set-widget.js) so this
     // production path and the unit tests run the IDENTICAL ordering: preflight →

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -121,7 +121,7 @@ import {
   resolveMissingModelDirectory,
 } from "./lib/asset-staleness.js";
 import { assertAddNodeResolvableRefreshing } from "./lib/node-resolve.js";
-import { createObjectInfoHistory } from "./lib/object-info-history.js";
+import { createObjectInfoHistory, awaitHistoryBaseline } from "./lib/object-info-history.js";
 import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
 import { reconcileCompletedDownloads } from "./lib/download-refresh.js";
 import { todoItemGlyph } from "./lib/plan-glyph.js";
@@ -371,34 +371,13 @@ function seedObjectInfoHistory() {
 // timeout safe to have at all: without a recoverable pending state it would convert
 // ordinary latency into a permanent, session-long false refusal.
 const OBJECT_INFO_SEED_WAIT_MS = 8000;
-async function awaitObjectInfoHistorySeed() {
-  const bounded = (p) => {
-    let timer;
-    return Promise.race([
-      Promise.resolve(p).catch(() => {}),
-      new Promise((resolve) => {
-        timer = setTimeout(resolve, OBJECT_INFO_SEED_WAIT_MS);
-      }),
-      // Clear the losing timer either way so a fast seed does not leave an 8s handle
-      // pinned for every graph tool call.
-    ]).finally(() => clearTimeout(timer));
-  };
-  await bounded(objectInfoHistorySeed);
-  // Deliberately nothing else. If the seed has not landed yet the history reports
-  // PENDING, the guards refuse this ONE call with "retry in a moment", and the seed keeps
-  // running: a response arriving AFTER the bound still calls markSeeded(), so the next
-  // call authorizes normally with no tab reload.
-  //
-  // We must NOT latch here. Timing out is the ABSENCE of evidence, not evidence — an
-  // /object_info fetch that merely took longer than the bound would otherwise burn the
-  // whole session, refusing every legitimate add/write afterwards even though the request
-  // came back with perfectly healthy definitions. That is the same false-refusal bug
-  // (#496/#507) this work exists to fix. Only seedObjectInfoHistory, whose attempt
-  // sequence has actually FINISHED empty, has the evidence to arm the latch.
-  //
-  // We must also NOT start a replacement seed: that fetch would be anchored AFTER an
-  // unobserved window, and installing its map as the baseline is the removed-pack hole.
-}
+// Delegates to the extracted, unit-tested helper, whose contract is that it NEVER mutates
+// the history: giving up on the WAIT is the absence of evidence, so it must not latch and
+// must not start a replacement seed. If the baseline has not landed the history reports
+// PENDING and the guards refuse this ONE call with "retry in a moment"; the seed keeps
+// running and a late response still seeds, so the next call succeeds with no tab reload.
+const awaitObjectInfoHistorySeed = () =>
+  awaitHistoryBaseline(objectInfoHistory, objectInfoHistorySeed, OBJECT_INFO_SEED_WAIT_MS);
 
 async function registerComfyNodeDefs(preloadedDefs) {
   // Trust the live combos for suppressing missing-asset candidates ONLY once the

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -5847,12 +5847,28 @@ const GRAPH_TOOL_EXECUTORS = {
     // installed ones (#289). When the backend defines the type but the stale
     // page-load registry lacks it, the defs are refreshed + re-registered so
     // LG.createNode works; a type the live backend does not provide fails closed.
+    //
+    // #496: genuinely FRONTEND-ONLY types (Note/MarkdownNote/Reroute/…) are never in
+    // /object_info by design, so the guard exempts them via the SAME shared predicate
+    // graph_set_widget uses — but only behind the observed-backend-history gate below,
+    // so a since-REMOVED pack is still refused. WAIT for the startup baseline seed for
+    // the same reason set_widget does: an un-seeded history must never let a write/add
+    // decide "never seen". If the seed still cannot land (backend down),
+    // objectInfoHistorySeeded stays false and wasTypeEverDefined fails CLOSED.
+    try {
+      await objectInfoHistorySeed;
+      if (!objectInfoHistorySeeded) await seedObjectInfoHistory();
+    } catch {
+      /* seed is best-effort; an unseeded history makes wasTypeEverDefined fail closed */
+    }
     await assertAddNodeResolvableRefreshing(() => LG?.registered_node_types ?? {}, class_type, {
       getFreshObjectInfo: async () =>
         recordObjectInfoTypes(
           typeof api?.getNodeDefs === "function" ? await api.getNodeDefs() : null,
         ),
       refresh: (defs) => refreshComfyNodeDefs(defs),
+      // #458 OBSERVED-BACKEND-HISTORY trust root, identical to graph_set_widget's.
+      wasTypeEverDefined: (t) => !objectInfoHistorySeeded || seenObjectInfoTypes.has(t),
     });
     const node = LG.createNode(class_type);
     if (!node) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -320,6 +320,9 @@ function monotonicNow() {
 // unit-testable rather than loose module state in this bundle.
 const objectInfoHistory = createObjectInfoHistory();
 const recordObjectInfoTypes = (defs) => objectInfoHistory.recordTypes(defs);
+// ONLY seedObjectInfoHistory() may call this. See the RECORD ONLY note in
+// registerComfyNodeDefs: any observation taken after an unobserved window cannot support
+// the "never backend-defined this session" claim a baseline makes.
 const markObjectInfoHistorySeeded = () => objectInfoHistory.markSeeded();
 // Resolves once the STARTUP baseline seed attempt sequence has finished (success or all
 // retries exhausted). The graph tools AWAIT this (bounded) before authorizing.
@@ -345,6 +348,11 @@ function seedObjectInfoHistory() {
       }
       await new Promise((resolve) => setTimeout(resolve, 150));
     }
+    // Every attempt failed: the STARTUP baseline is definitively missed, and this is the
+    // ONLY function permitted to establish one. Latch the loss now rather than waiting
+    // for a graph tool to notice — otherwise nothing marks the session unsafe and a later
+    // observation could look authoritative (codex round-4, SEVERE).
+    objectInfoHistory.loseBaseline();
   })();
   return objectInfoHistorySeed;
 }
@@ -400,17 +408,19 @@ async function registerComfyNodeDefs(preloadedDefs) {
       defs = await api.getNodeDefs();
     }
     // Record observed backend history (#458 trust root) — covers reconnect, the forced
-    // refresh_nodes path, add_node payloads, and download-triggered refreshes. A valid
-    // payload here also establishes a reliable baseline (marks history seeded), so a
-    // reconnect after a failed startup seed restores the ever-seen gate to normal.
+    // refresh_nodes path, add_node payloads, and download-triggered refreshes.
+    //
+    // RECORD ONLY — this must NEVER establish the baseline (codex round-4, SEVERE).
+    // Recording can only ADD evidence that a type existed, which can only make the gate
+    // refuse MORE, so it is always safe. Claiming a BASELINE is the opposite: it asserts
+    // "anything not in this map was never backend-defined this session", which this
+    // payload cannot support — it may have been fetched AFTER a pack removal we never
+    // observed (startup seed hung, pack removed, then a reconnect/refresh_nodes lands
+    // here). Marking seeded from it would make the removed type read "never seen" and
+    // let a provenance-stripped husk squatting a reserved allowlisted name through the
+    // frontend-only exemption. ONLY seedObjectInfoHistory() — the STARTUP baseline, whose
+    // observation window begins at page load — may call markObjectInfoHistorySeeded().
     recordObjectInfoTypes(defs);
-    if (defs && typeof defs === "object" && Object.keys(defs).length > 0) {
-      // Honours the baseline-lost LATCH: a reconnect must NOT restore the ever-seen gate
-      // once the startup baseline was missed, because this payload may already be
-      // POST-removal (codex round-3, SEVERE). Recording the types above is still correct
-      // and useful — it can only ever ADD evidence that a type existed.
-      markObjectInfoHistorySeeded();
-    }
     // Re-register node definitions so newly installed/updated classes and their
     // current widget schemas are known to LiteGraph (#221/#171).
     if (defs && typeof a.registerNodesFromDefs === "function") {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -331,7 +331,15 @@ let objectInfoHistorySeeded = false;
 // Resolves once the STARTUP baseline seed attempt sequence has finished (success or all
 // retries exhausted). graph_set_widget AWAITS this before authorizing.
 let objectInfoHistorySeed = Promise.resolve();
+// True once the CURRENT seed attempt sequence has actually FINISHED (settled), as opposed
+// to still being in flight. A bounded waiter must not start a REPLACEMENT seed while the
+// original is still running: a fetch issued after a mid-wait pack removal would observe an
+// /object_info that never contained the removed type and install THAT as the session
+// baseline, making a removed type look "never seen" — exactly the hole the ever-seen gate
+// exists to close (codex round-2, SEVERE).
+let objectInfoHistorySeedSettled = true;
 function seedObjectInfoHistory() {
+  objectInfoHistorySeedSettled = false;
   objectInfoHistorySeed = (async () => {
     // Retry a transient getNodeDefs failure a few times (short backoff) so a flaky
     // startup fetch self-heals BEFORE any pack could be removed mid-session. If the
@@ -352,7 +360,9 @@ function seedObjectInfoHistory() {
       }
       await new Promise((resolve) => setTimeout(resolve, 150));
     }
-  })();
+  })().finally(() => {
+    objectInfoHistorySeedSettled = true;
+  });
   return objectInfoHistorySeed;
 }
 
@@ -365,15 +375,28 @@ function seedObjectInfoHistory() {
 // type as removed and the write/add is refused with an honest error instead of hanging.
 const OBJECT_INFO_SEED_WAIT_MS = 8000;
 async function awaitObjectInfoHistorySeed() {
-  const bounded = (p) =>
-    Promise.race([
+  const bounded = (p) => {
+    let timer;
+    return Promise.race([
       Promise.resolve(p).catch(() => {}),
-      new Promise((resolve) => setTimeout(resolve, OBJECT_INFO_SEED_WAIT_MS)),
-    ]);
+      new Promise((resolve) => {
+        timer = setTimeout(resolve, OBJECT_INFO_SEED_WAIT_MS);
+      }),
+      // Clear the losing timer either way so a fast seed does not leave an 8s handle
+      // pinned for every graph tool call.
+    ]).finally(() => clearTimeout(timer));
+  };
   await bounded(objectInfoHistorySeed);
-  // Not seeded by the startup attempt? Try ONCE more here (the backend may have come
-  // up since page load), still bounded. Failure leaves the history unseeded ⇒ closed.
-  if (!objectInfoHistorySeeded) await bounded(seedObjectInfoHistory());
+  if (objectInfoHistorySeeded) return;
+  // Not seeded. Retry ONCE (the backend may have come up since page load) — but ONLY if
+  // the previous attempt has actually FINISHED. If we merely TIMED OUT on an in-flight
+  // request, a replacement fetch could observe an /object_info taken AFTER a pack was
+  // removed during the wait and install it as the session baseline, so the removed type
+  // would read "never seen" and sail through the frontend-only exemption (codex round-2,
+  // SEVERE). Returning here leaves objectInfoHistorySeeded false, which makes
+  // wasTypeEverDefined treat every absent-from-current type as removed — fail CLOSED.
+  if (!objectInfoHistorySeedSettled) return;
+  await bounded(seedObjectInfoHistory());
 }
 
 async function registerComfyNodeDefs(preloadedDefs) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -356,6 +356,26 @@ function seedObjectInfoHistory() {
   return objectInfoHistorySeed;
 }
 
+// How long a graph tool will WAIT for the startup baseline seed before giving up on it.
+// The seed's own retry loop only advances once each api.getNodeDefs() SETTLES, so a
+// request that never settles (a hung/half-open connection) would otherwise block the
+// awaiting tool FOREVER (codex round-1, MODERATE). Bounding the wait converts that
+// availability failure into the correct fail-CLOSED outcome: objectInfoHistorySeeded is
+// still false when we stop waiting, so wasTypeEverDefined treats every absent-from-current
+// type as removed and the write/add is refused with an honest error instead of hanging.
+const OBJECT_INFO_SEED_WAIT_MS = 8000;
+async function awaitObjectInfoHistorySeed() {
+  const bounded = (p) =>
+    Promise.race([
+      Promise.resolve(p).catch(() => {}),
+      new Promise((resolve) => setTimeout(resolve, OBJECT_INFO_SEED_WAIT_MS)),
+    ]);
+  await bounded(objectInfoHistorySeed);
+  // Not seeded by the startup attempt? Try ONCE more here (the backend may have come
+  // up since page load), still bounded. Failure leaves the history unseeded ⇒ closed.
+  if (!objectInfoHistorySeeded) await bounded(seedObjectInfoHistory());
+}
+
 async function registerComfyNodeDefs(preloadedDefs) {
   // Trust the live combos for suppressing missing-asset candidates ONLY once the
   // combo refresh has ACTUALLY RUN and succeeded. If refreshComboInNodes is absent on
@@ -5855,12 +5875,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // the same reason set_widget does: an un-seeded history must never let a write/add
     // decide "never seen". If the seed still cannot land (backend down),
     // objectInfoHistorySeeded stays false and wasTypeEverDefined fails CLOSED.
-    try {
-      await objectInfoHistorySeed;
-      if (!objectInfoHistorySeeded) await seedObjectInfoHistory();
-    } catch {
-      /* seed is best-effort; an unseeded history makes wasTypeEverDefined fail closed */
-    }
+    await awaitObjectInfoHistorySeed();
     await assertAddNodeResolvableRefreshing(() => LG?.registered_node_types ?? {}, class_type, {
       getFreshObjectInfo: async () =>
         recordObjectInfoTypes(
@@ -6297,12 +6312,9 @@ const GRAPH_TOOL_EXECUTORS = {
     // false and wasTypeEverDefined fails CLOSED (absent types refused) — never allowed
     // against an empty history (codex round-10). A backend that is up now succeeds and
     // establishes the baseline for all currently-present types.
-    try {
-      await objectInfoHistorySeed;
-      if (!objectInfoHistorySeeded) await seedObjectInfoHistory();
-    } catch {
-      /* seed is best-effort; an unseeded history makes wasTypeEverDefined fail closed */
-    }
+    // (BOUNDED — a getNodeDefs request that never settles must not hang the tool; the
+    // wait gives up and leaves the history unseeded, which fails CLOSED.)
+    await awaitObjectInfoHistorySeed();
     // Delegate to the shared handler body (web/js/lib/set-widget.js) so this
     // production path and the unit tests run the IDENTICAL ordering: preflight →
     // reconcile-only-a-resolved-node → applyWidgetWrite with the resolved-target

--- a/web/js/lib/input-asset.js
+++ b/web/js/lib/input-asset.js
@@ -72,6 +72,39 @@ export function uploadInputConfig(defsByType, type, widgetName) {
 }
 
 /**
+ * TRUE only when the freshly-fetched /object_info AUTHORITATIVELY declares `widgetName`
+ * on `type` to be a combo whose option list is EMPTY — i.e. the SERVER itself says there
+ * is nothing to validate against (StarNodes' `"model": ((), {...})` ⇒ `[[], {...}]`).
+ *
+ * This is the gate on #507's last-resort "an empty option list is not knowable, so take
+ * the value as written". Reading the LIVE widget alone is NOT sufficient (codex round-2,
+ * SEVERE): a widget whose `options.values` is a FUNCTION is deliberately never clobbered
+ * by the combo refresh (refreshComboOptionsFromDefs skips function sources), so a dynamic
+ * source that happens to return `[]` right now would otherwise look "empty" even while
+ * /object_info publishes a real, non-empty list — and an off-list value would be written,
+ * violating #240. Requiring the SERVER to declare the list empty makes that impossible.
+ *
+ * Fails CLOSED on every uncertainty: no defs, no def for the type, no such input, a
+ * non-combo spec (a type string like "INT"/"STRING"), or a NON-EMPTY declared list all
+ * return false, so the value simply stays rejected exactly as before.
+ */
+export function serverDeclaresEmptyComboOptions(defsByType, type, widgetName) {
+  try {
+    if (!defsByType || !type || !widgetName) return false;
+    const input = defsByType[type]?.input;
+    if (!input) return false;
+    const spec =
+      (input.required && input.required[widgetName]) ??
+      (input.optional && input.optional[widgetName]);
+    if (!Array.isArray(spec)) return false;
+    const options = spec[0];
+    return Array.isArray(options) && options.length === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * True when `value`'s file extension is a plausibly-LOADABLE asset for the upload
  * `config`'s kind (image/video/audio/model). This is the strictness gate on top of a
  * mere server-existence probe (#240): `/view?type=input` confirms the file is on disk

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -117,6 +117,59 @@ export function isFrontendOnlyRegisteredType(registry, type) {
 }
 
 /**
+ * THE single frontend-only authorization predicate for the WHOLE #458 guard family
+ * (#496). Every guard that may exempt a type from the "must be in fresh /object_info"
+ * rule calls THIS — graph_add_node's assertAddNodeResolvableRefreshing, and
+ * graph_set_widget's assertTypeAgainstFreshBackend + assertMutatedNodeAuthorized.
+ *
+ * WHY ONE HELPER: the exemption was previously spelled out inline, clause-for-clause,
+ * in each set_widget guard and OMITTED entirely from the add_node guard — so
+ * MarkdownNote/Note/Reroute were writable but NOT addable, and a future edit to one
+ * copy would silently diverge from the other. #496 is exactly that drift. A single
+ * predicate makes "which types are frontend-only" a one-place decision; a guard either
+ * consults it or does not exempt at all.
+ *
+ * The decision is UNCHANGED from the set_widget spelling — it still requires BOTH
+ * positive signals and fails closed on any doubt:
+ *   1. the type is REGISTERED in the live LiteGraph registry AND on the reserved
+ *      FRONTEND_ONLY_NODE_TYPES allowlist, with no backend provenance on the
+ *      REGISTERED class (isFrontendOnlyRegisteredType); AND
+ *   2. the write-target INSTANCE's own constructor carries no backend provenance
+ *      either — a stale backend instance must not slip through under a bare native
+ *      class of the same name. (`node` is omitted by add_node, where no instance
+ *      exists yet; the class check in (1) still applies.)
+ *
+ * This is NEVER the sole gate: every caller runs the non-forgeable
+ * OBSERVED-BACKEND-HISTORY check (isRemovedBackendType) FIRST, so a since-removed
+ * pack is refused before this predicate is ever consulted.
+ */
+export function isAuthorizedFrontendOnlyType(registry, type, node) {
+  if (!registry) return false;
+  if (!isFrontendOnlyRegisteredType(registry, type)) return false;
+  return !hasBackendProvenance(node?.constructor);
+}
+
+/**
+ * The #458 OBSERVED-BACKEND-HISTORY gate, shared by the whole guard family (#496):
+ * TRUE when the ComfyUI backend reported `type` in some /object_info EARLIER this
+ * session but the CURRENT /object_info no longer lists it — i.e. its backend was
+ * REMOVED (pack uninstalled/disabled), so any write/add must be refused.
+ *
+ * This is the NON-FORGEABLE trust root: a client-side husk cannot un-see what the
+ * backend already reported, so it catches a removed pack even when it masquerades
+ * under a reserved allowlisted name with no provenance markers. Callers apply it
+ * BEFORE the frontend-only exemption. `wasTypeEverDefined` is injected by the panel
+ * and itself fails closed while the session baseline is unseeded.
+ */
+export function isRemovedBackendType(type, wasTypeEverDefined) {
+  return (
+    typeof wasTypeEverDefined === "function" &&
+    typeof type === "string" &&
+    wasTypeEverDefined(type)
+  );
+}
+
+/**
  * Positive signal that `node` is a genuine VIRTUAL SUBGRAPH CONTAINER — a litegraph
  * SubgraphNode. Prefers the UPSTREAM identity markers ComfyUI_frontend's SubgraphNode
  * exposes (`isVirtualNode === true`, `isSubgraphNode()`), falling back to a REAL nested
@@ -179,7 +232,7 @@ export function assertMutatedNodeAuthorized(freshDefs, registry, node, role = "t
   if (typeof type === "string" && Object.prototype.hasOwnProperty.call(freshDefs, type)) return;
   // ABSENT from fresh object_info. EVER-SEEN GATE: if the backend reported this type
   // earlier this session, its backend was REMOVED — refuse (non-forgeable, #458).
-  if (typeof wasTypeEverDefined === "function" && typeof type === "string" && wasTypeEverDefined(type)) {
+  if (isRemovedBackendType(type, wasTypeEverDefined)) {
     throw new Error(
       `Cannot set widget on node ${id}${label}: the ${role} node type was defined by the ComfyUI ` +
         `backend earlier this session but is ABSENT from the current /object_info — its backend was ` +
@@ -192,7 +245,9 @@ export function assertMutatedNodeAuthorized(freshDefs, registry, node, role = "t
     !hasBackendProvenance(typeof type === "string" ? registry?.[type] : undefined) &&
     !hasBackendProvenance(node?.constructor);
   if (provenanceClean && isVirtualSubgraphContainer(node)) return;
-  if (registry && isFrontendOnlyRegisteredType(registry, type) && !hasBackendProvenance(node?.constructor)) return;
+  // SHARED frontend-only predicate (#496) — the identical decision assertTypeAgainstFreshBackend
+  // and assertAddNodeResolvableRefreshing make, so the family cannot drift apart again.
+  if (isAuthorizedFrontendOnlyType(registry, type, node)) return;
   throw new Error(
     `Cannot set widget on node ${id}${label}: the ${role} node is not defined by the ComfyUI ` +
       `backend and is not a verifiable frontend-only / virtual-subgraph node (a removed or ` +
@@ -237,7 +292,11 @@ export function assertAddNodeResolvable(registry, class_type) {
  * So the AUTHORITATIVE oracle is the freshly-fetched /object_info payload:
  *   1. Fetch fresh /object_info via `getFreshObjectInfo`.
  *   2. If the backend does NOT define the type → fail closed (unknown/removed),
- *      regardless of any stale registry entry.
+ *      regardless of any stale registry entry. The ONE exemption (#496) is a genuine
+ *      FRONTEND-ONLY type (Note/MarkdownNote/Reroute/… — never in /object_info by
+ *      design), decided by the SAME shared predicate the graph_set_widget guards use
+ *      (isAuthorizedFrontendOnlyType) and only AFTER the observed-backend-history gate
+ *      (isRemovedBackendType) has ruled out a since-removed pack.
  *   3. If the backend DOES define it → ensure LiteGraph can construct it: if the
  *      page-load registry predates it, `refresh` (re-register the fresh defs) and
  *      re-check; if it still can't be registered, fail closed rather than let
@@ -254,9 +313,15 @@ export function assertAddNodeResolvable(registry, class_type) {
  *   refresh            : optional async (defs?) => re-register node defs into the
  *                        registry; receives the already-fetched defs to avoid a
  *                        second /object_info round-trip.
+ *   wasTypeEverDefined : optional (type) => did any /object_info this session report
+ *                        this type? The #458 observed-backend-history trust root,
+ *                        shared with graph_set_widget. Omitting it does NOT loosen the
+ *                        backend-presence rule — it only removes the extra rejection
+ *                        that distinguishes a since-REMOVED pack from a never-installed
+ *                        one, which matters solely for the frontend-only exemption.
  */
 export async function assertAddNodeResolvableRefreshing(getRegistry, class_type, opts = {}) {
-  const { getFreshObjectInfo, refresh } = opts;
+  const { getFreshObjectInfo, refresh, wasTypeEverDefined } = opts;
   const readRegistry = () =>
     typeof getRegistry === "function" ? getRegistry() : getRegistry;
 
@@ -281,6 +346,27 @@ export async function assertAddNodeResolvableRefreshing(getRegistry, class_type,
     }
     // AUTHORITATIVE: does the LIVE backend provide this type right now?
     if (!Object.prototype.hasOwnProperty.call(freshDefs, class_type)) {
+      // #458 EVER-SEEN GATE (the non-forgeable trust root, applied FIRST — same order
+      // as the set_widget guards): the backend reported this type earlier this session
+      // but no longer does ⇒ its pack was REMOVED. Refuse, even under a reserved
+      // allowlisted name, before the frontend-only exemption below is consulted.
+      if (isRemovedBackendType(class_type, wasTypeEverDefined)) {
+        throw new Error(
+          `Cannot add "${class_type}": the ComfyUI backend defined this node type earlier this ` +
+            `session but it is ABSENT from the current /object_info — its backend was removed ` +
+            `(pack uninstalled/disabled). Refusing to add a since-removed node type (#458).`,
+        );
+      }
+      // #496 FRONTEND-ONLY EXEMPTION: Note / MarkdownNote / Reroute / PrimitiveNode and
+      // the rgthree frontend control nodes are registered PURELY by the LiteGraph
+      // frontend and are NEVER enumerated by /object_info BY DESIGN, so the fresh-backend
+      // oracle can never authorize them and this guard failed CLOSED on a perfectly
+      // healthy backend. graph_set_widget already exempted exactly this class of node;
+      // add_node did not — the drift #496 reports. Both now call the SAME predicate
+      // (isAuthorizedFrontendOnlyType), which requires live-registry membership, reserved
+      // allowlist membership and a provenance-clean registered class. Registry membership
+      // is also precisely what LG.createNode needs, so the caller can construct it.
+      if (isAuthorizedFrontendOnlyType(readRegistry(), class_type)) return;
       // Not defined by the current backend (never installed, or its pack was
       // removed). Fail closed even if a stale registry entry survives (#458/P1-C).
       throw new Error(
@@ -364,7 +450,7 @@ export function assertTypeAgainstFreshBackend(freshDefs, type, nodeId = "(unknow
     // that carries no nodeData/comfyClass is caught here, because a client husk cannot
     // un-see what the backend already reported. This is what the client-side allowlist +
     // provenance markers CANNOT prove on their own.
-    if (typeof wasTypeEverDefined === "function" && typeof type === "string" && wasTypeEverDefined(type)) {
+    if (isRemovedBackendType(type, wasTypeEverDefined)) {
       throw new Error(
         `Cannot set widget on node ${nodeId}${label}: node type "${type}" was defined by the ComfyUI ` +
           `backend earlier this session but is ABSENT from the current /object_info — its backend was ` +
@@ -375,13 +461,9 @@ export function assertTypeAgainstFreshBackend(freshDefs, type, nodeId = "(unknow
     // namespace allowlisted node with NO backend provenance on the registered class OR
     // the write-target INSTANCE's own constructor (defense-in-depth on top of the
     // ever-seen gate). A removed backend node's arbitrary pack name is not allowlisted.
-    if (
-      registry &&
-      isFrontendOnlyRegisteredType(registry, type) &&
-      !hasBackendProvenance(node?.constructor)
-    ) {
-      return;
-    }
+    // SHARED predicate (#496) — the same one assertMutatedNodeAuthorized and
+    // assertAddNodeResolvableRefreshing use, so no copy can drift.
+    if (isAuthorizedFrontendOnlyType(registry, type, node)) return;
     throw new Error(
       `Cannot set widget on node ${nodeId}${label}: the ComfyUI backend does not provide node ` +
         `type "${type}" (not installed, or its pack was removed) — refusing to write to a node ` +
@@ -405,6 +487,15 @@ export function assertTypeAgainstFreshBackend(freshDefs, type, nodeId = "(unknow
  * registered". A REAL subgraph parent is exempted authentically: its promoted
  * widget resolves to a registered inner node, and THAT inner node is what gets
  * passed here and passes the registry check.
+ *
+ * #496 NOTE — this is the one member of the guard family that needs NO frontend-only
+ * allowlist, so do NOT paste one here: its oracle is the LIVE LiteGraph REGISTRY, not
+ * /object_info, and a frontend-only type IS registered there (that is what "frontend-
+ * only" means). Note/MarkdownNote/Reroute therefore pass it already, and the
+ * placeholder check below is explicitly written not to false-negative them. Only the
+ * guards whose oracle is /object_info (assertAddNodeResolvableRefreshing,
+ * assertTypeAgainstFreshBackend, assertMutatedNodeAuthorized) need the exemption, and
+ * all three take it from the single shared isAuthorizedFrontendOnlyType predicate.
  */
 export function assertResolvedTargetRegistered(registry, targetNode) {
   const type = targetNode?.type;

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -313,12 +313,11 @@ export function assertAddNodeResolvable(registry, class_type) {
  *   refresh            : optional async (defs?) => re-register node defs into the
  *                        registry; receives the already-fetched defs to avoid a
  *                        second /object_info round-trip.
- *   wasTypeEverDefined : optional (type) => did any /object_info this session report
- *                        this type? The #458 observed-backend-history trust root,
- *                        shared with graph_set_widget. Omitting it does NOT loosen the
- *                        backend-presence rule — it only removes the extra rejection
- *                        that distinguishes a since-REMOVED pack from a never-installed
- *                        one, which matters solely for the frontend-only exemption.
+ *   wasTypeEverDefined : (type) => did any /object_info this session report this type?
+ *                        The #458 observed-backend-history trust root, shared with
+ *                        graph_set_widget. REQUIRED for the frontend-only exemption:
+ *                        omit it and NOTHING absent from fresh /object_info is ever
+ *                        exempted (fail closed, pre-#496 behaviour).
  */
 export async function assertAddNodeResolvableRefreshing(getRegistry, class_type, opts = {}) {
   const { getFreshObjectInfo, refresh, wasTypeEverDefined } = opts;
@@ -366,7 +365,22 @@ export async function assertAddNodeResolvableRefreshing(getRegistry, class_type,
       // (isAuthorizedFrontendOnlyType), which requires live-registry membership, reserved
       // allowlist membership and a provenance-clean registered class. Registry membership
       // is also precisely what LG.createNode needs, so the caller can construct it.
-      if (isAuthorizedFrontendOnlyType(readRegistry(), class_type)) return;
+      //
+      // The exemption additionally REQUIRES the observed-backend-history oracle to be
+      // WIRED (codex round-1, SEVERE): client-side name + provenance markers alone are
+      // forgeable — a removed pack whose frontend class had its .nodeData/.comfyClass
+      // stripped and which squats a reserved allowlisted name would otherwise be added
+      // as a stale/generic node and reported as success. Only the non-forgeable
+      // ever-seen gate can rule that out, so WITHOUT it there is no exemption at all
+      // and every type absent from fresh /object_info fails closed exactly as before
+      // this change. The panel always wires it; this makes add's exemption strictly
+      // stronger than a bare allowlist check.
+      if (
+        typeof wasTypeEverDefined === "function" &&
+        isAuthorizedFrontendOnlyType(readRegistry(), class_type)
+      ) {
+        return;
+      }
       // Not defined by the current backend (never installed, or its pack was
       // removed). Fail closed even if a stale registry entry survives (#458/P1-C).
       throw new Error(

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -162,10 +162,48 @@ export function isAuthorizedFrontendOnlyType(registry, type, node) {
  * and itself fails closed while the session baseline is unseeded.
  */
 export function isRemovedBackendType(type, wasTypeEverDefined) {
+  return backendHistoryVerdict(type, wasTypeEverDefined) === "removed";
+}
+
+/**
+ * The sentinel an injected `wasTypeEverDefined` returns instead of `true` when it has NO
+ * trustworthy session baseline at all (the panel never established one, or latched it as
+ * lost). It is TRUTHY, so any consumer that merely tests for truth still fails CLOSED —
+ * recognizing it only buys a HONEST error message. Without it every refusal in that state
+ * claims "its backend was removed (pack uninstalled/disabled)", which for a MarkdownNote
+ * is simply false and misdiagnoses a transient backend problem as a broken install —
+ * exactly the misleading-error complaint #496 was filed about.
+ */
+export const HISTORY_UNSEEDED = "history-unseeded";
+
+/**
+ * Classify a type against the observed-backend-history oracle. ONE shared classifier for
+ * the whole guard family (#496), so all three guards agree on both the verdict and the
+ * diagnosis they report:
+ *   "unseeded"   — no trustworthy baseline exists; nothing can be concluded ⇒ refuse, and
+ *                  tell the user to reload the tab rather than blame a missing pack.
+ *   "removed"    — the backend reported this type earlier this session and does not now
+ *                  ⇒ its pack was uninstalled/disabled ⇒ refuse.
+ *   "never-seen" — genuinely never backend-defined this session ⇒ the frontend-only
+ *                  exemption may be considered (it has its own further requirements).
+ *   "no-oracle"  — no history oracle was injected at all. Treated as NOT never-seen, so
+ *                  callers that require positive history evidence fail closed.
+ */
+export function backendHistoryVerdict(type, wasTypeEverDefined) {
+  if (typeof wasTypeEverDefined !== "function" || typeof type !== "string") return "no-oracle";
+  const seen = wasTypeEverDefined(type);
+  if (seen === HISTORY_UNSEEDED) return "unseeded";
+  return seen ? "removed" : "never-seen";
+}
+
+/** The shared, honest refusal for the "no trustworthy baseline" state. */
+function unseededHistoryMessage(what) {
   return (
-    typeof wasTypeEverDefined === "function" &&
-    typeof type === "string" &&
-    wasTypeEverDefined(type)
+    `${what}: the panel has no trustworthy record of what this ComfyUI backend defined ` +
+    `earlier this session (the /object_info baseline never loaded — the backend was ` +
+    `unreachable or too slow at page load), so a genuinely frontend-only node cannot be ` +
+    `told apart from one whose pack was removed. Reload the ComfyUI tab to re-establish ` +
+    `the baseline, then retry. Refusing to write rather than guess (#458).`
   );
 }
 
@@ -232,7 +270,11 @@ export function assertMutatedNodeAuthorized(freshDefs, registry, node, role = "t
   if (typeof type === "string" && Object.prototype.hasOwnProperty.call(freshDefs, type)) return;
   // ABSENT from fresh object_info. EVER-SEEN GATE: if the backend reported this type
   // earlier this session, its backend was REMOVED — refuse (non-forgeable, #458).
-  if (isRemovedBackendType(type, wasTypeEverDefined)) {
+  const verdict = backendHistoryVerdict(type, wasTypeEverDefined);
+  if (verdict === "unseeded") {
+    throw new Error(unseededHistoryMessage(`Cannot set widget on node ${id}${label} (${role} node)`));
+  }
+  if (verdict === "removed") {
     throw new Error(
       `Cannot set widget on node ${id}${label}: the ${role} node type was defined by the ComfyUI ` +
         `backend earlier this session but is ABSENT from the current /object_info — its backend was ` +
@@ -349,7 +391,11 @@ export async function assertAddNodeResolvableRefreshing(getRegistry, class_type,
       // as the set_widget guards): the backend reported this type earlier this session
       // but no longer does ⇒ its pack was REMOVED. Refuse, even under a reserved
       // allowlisted name, before the frontend-only exemption below is consulted.
-      if (isRemovedBackendType(class_type, wasTypeEverDefined)) {
+      const verdict = backendHistoryVerdict(class_type, wasTypeEverDefined);
+      if (verdict === "unseeded") {
+        throw new Error(unseededHistoryMessage(`Cannot add "${class_type}"`));
+      }
+      if (verdict === "removed") {
         throw new Error(
           `Cannot add "${class_type}": the ComfyUI backend defined this node type earlier this ` +
             `session but it is ABSENT from the current /object_info — its backend was removed ` +
@@ -464,7 +510,11 @@ export function assertTypeAgainstFreshBackend(freshDefs, type, nodeId = "(unknow
     // that carries no nodeData/comfyClass is caught here, because a client husk cannot
     // un-see what the backend already reported. This is what the client-side allowlist +
     // provenance markers CANNOT prove on their own.
-    if (isRemovedBackendType(type, wasTypeEverDefined)) {
+    const verdict = backendHistoryVerdict(type, wasTypeEverDefined);
+    if (verdict === "unseeded") {
+      throw new Error(unseededHistoryMessage(`Cannot set widget on node ${nodeId}${label}`));
+    }
+    if (verdict === "removed") {
       throw new Error(
         `Cannot set widget on node ${nodeId}${label}: node type "${type}" was defined by the ComfyUI ` +
           `backend earlier this session but is ABSENT from the current /object_info — its backend was ` +

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -177,33 +177,65 @@ export function isRemovedBackendType(type, wasTypeEverDefined) {
 export const HISTORY_UNSEEDED = "history-unseeded";
 
 /**
+ * The other no-baseline sentinel: the baseline has not ARRIVED yet (the /object_info fetch
+ * is still in flight, or a caller bounded its wait on it). Also TRUTHY, so it fails closed
+ * identically — but it is TEMPORARY and RECOVERABLE, and must be reported that way.
+ *
+ * Keeping it distinct from HISTORY_UNSEEDED is not cosmetic. Treating "hasn't loaded yet"
+ * as "proven untrustworthy" turns ordinary latency into a permanent, session-long refusal
+ * of every legitimate add/write — a THIRD false refusal on top of the two (#496, #507)
+ * this guard family was fixed to stop making. A slow fetch must yield "retry in a moment",
+ * never "reload the tab".
+ */
+export const HISTORY_PENDING = "history-pending";
+
+/**
  * Classify a type against the observed-backend-history oracle. ONE shared classifier for
  * the whole guard family (#496), so all three guards agree on both the verdict and the
  * diagnosis they report:
- *   "unseeded"   — no trustworthy baseline exists; nothing can be concluded ⇒ refuse, and
- *                  tell the user to reload the tab rather than blame a missing pack.
+ *   "pending"    — the baseline has not arrived YET ⇒ refuse, but say it is temporary and
+ *                  to retry; the state clears itself when the fetch lands.
+ *   "unseeded"   — the observation window closed with no data ⇒ refuse, and tell the user
+ *                  to reload the tab rather than blame a missing pack.
  *   "removed"    — the backend reported this type earlier this session and does not now
  *                  ⇒ its pack was uninstalled/disabled ⇒ refuse.
  *   "never-seen" — genuinely never backend-defined this session ⇒ the frontend-only
  *                  exemption may be considered (it has its own further requirements).
  *   "no-oracle"  — no history oracle was injected at all. Treated as NOT never-seen, so
  *                  callers that require positive history evidence fail closed.
+ * Every verdict except "never-seen" refuses, so a consumer that cannot tell them apart is
+ * still safe — the distinction only buys an accurate diagnosis.
  */
 export function backendHistoryVerdict(type, wasTypeEverDefined) {
   if (typeof wasTypeEverDefined !== "function" || typeof type !== "string") return "no-oracle";
   const seen = wasTypeEverDefined(type);
+  if (seen === HISTORY_PENDING) return "pending";
   if (seen === HISTORY_UNSEEDED) return "unseeded";
   return seen ? "removed" : "never-seen";
 }
 
-/** The shared, honest refusal for the "no trustworthy baseline" state. */
+/** The shared refusal for a baseline that simply has not ARRIVED yet — TEMPORARY, so it
+ *  must read as "retry in a moment", never as "this node type can't be verified" or
+ *  "reload the tab". Getting this wrong is what makes ordinary latency look like a broken
+ *  install to the user. */
+function pendingHistoryMessage(what) {
+  return (
+    `${what}: the panel is still loading this ComfyUI's node-type baseline (the ` +
+    `/object_info fetch has not come back yet), so a genuinely frontend-only node cannot ` +
+    `yet be told apart from one whose pack was removed. This is TEMPORARY — retry in a ` +
+    `moment and it will resolve itself; no reload is needed. Refusing to write until the ` +
+    `backend can be verified (#458).`
+  );
+}
+
+/** The shared, honest refusal for a baseline that was never established at all. */
 function unseededHistoryMessage(what) {
   return (
     `${what}: the panel has no trustworthy record of what this ComfyUI backend defined ` +
     `earlier this session (the /object_info baseline never loaded — the backend was ` +
-    `unreachable or too slow at page load), so a genuinely frontend-only node cannot be ` +
-    `told apart from one whose pack was removed. Reload the ComfyUI tab to re-establish ` +
-    `the baseline, then retry. Refusing to write rather than guess (#458).`
+    `unreachable at page load), so a genuinely frontend-only node cannot be told apart ` +
+    `from one whose pack was removed. Reload the ComfyUI tab to re-establish the ` +
+    `baseline, then retry. Refusing to write rather than guess (#458).`
   );
 }
 
@@ -271,6 +303,9 @@ export function assertMutatedNodeAuthorized(freshDefs, registry, node, role = "t
   // ABSENT from fresh object_info. EVER-SEEN GATE: if the backend reported this type
   // earlier this session, its backend was REMOVED — refuse (non-forgeable, #458).
   const verdict = backendHistoryVerdict(type, wasTypeEverDefined);
+  if (verdict === "pending") {
+    throw new Error(pendingHistoryMessage(`Cannot set widget on node ${id}${label} (${role} node)`));
+  }
   if (verdict === "unseeded") {
     throw new Error(unseededHistoryMessage(`Cannot set widget on node ${id}${label} (${role} node)`));
   }
@@ -392,6 +427,9 @@ export async function assertAddNodeResolvableRefreshing(getRegistry, class_type,
       // but no longer does ⇒ its pack was REMOVED. Refuse, even under a reserved
       // allowlisted name, before the frontend-only exemption below is consulted.
       const verdict = backendHistoryVerdict(class_type, wasTypeEverDefined);
+      if (verdict === "pending") {
+        throw new Error(pendingHistoryMessage(`Cannot add "${class_type}"`));
+      }
       if (verdict === "unseeded") {
         throw new Error(unseededHistoryMessage(`Cannot add "${class_type}"`));
       }
@@ -511,6 +549,9 @@ export function assertTypeAgainstFreshBackend(freshDefs, type, nodeId = "(unknow
     // un-see what the backend already reported. This is what the client-side allowlist +
     // provenance markers CANNOT prove on their own.
     const verdict = backendHistoryVerdict(type, wasTypeEverDefined);
+    if (verdict === "pending") {
+      throw new Error(pendingHistoryMessage(`Cannot set widget on node ${nodeId}${label}`));
+    }
     if (verdict === "unseeded") {
       throw new Error(unseededHistoryMessage(`Cannot set widget on node ${nodeId}${label}`));
     }

--- a/web/js/lib/object-info-history.js
+++ b/web/js/lib/object-info-history.js
@@ -31,6 +31,19 @@
 // recordTypes() is deliberately NOT latched: recording can only ever ADD evidence that a
 // type existed, which can only ever make the gate refuse MORE. Only the "this history is
 // trustworthy enough to conclude never-seen" claim is latched.
+//
+// KNOWN, ACCEPTED RESIDUAL — do not "fix" it by weakening the rules above. The baseline
+// can only ever be established from an ASYNCHRONOUS /object_info response, so it is a
+// snapshot as of the fetch, not of page load. A pack removed inside that window (page load
+// → the first successful fetch; the seed's whole retry sequence is sub-second) is never
+// observed, so it would read "never seen". Exploiting that requires a third-party pack to
+// squat a ComfyUI-core-RESERVED name (Note/MarkdownNote/Reroute/PrimitiveNode or a
+// "… (rgthree)" control node), strip its own frontend class's .nodeData/.comfyClass, AND
+// be uninstalled inside that sub-second window — an adversarial construction, not an
+// accidental failure, in a product where the panel, orchestrator and user share one
+// machine and one trust domain. There is no synchronous page-load oracle that would close
+// it. The reserved-name allowlist and the provenance checks are the layered defenses that
+// keep the residual to exactly that construction.
 
 import { HISTORY_UNSEEDED } from "./node-resolve.js";
 

--- a/web/js/lib/object-info-history.js
+++ b/web/js/lib/object-info-history.js
@@ -17,16 +17,26 @@
 //      reports EVERY absent-from-current type as removed. A failed seed therefore never
 //      opens a hole; it only refuses more.
 //
-//   2. BASELINE LOST ⇒ LATCHED CLOSED FOR THE SESSION. Once the STARTUP baseline is
-//      missed — the seed failed, or a tool bounded its wait and gave up — there is a
-//      window we never observed, and NO later observation can prove a type was "never
-//      defined earlier this session": the removal may have happened inside that window.
-//      So after loseBaseline() nothing may mark the history seeded, not even a successful
-//      reconnect/refresh_nodes re-register. Reloading the tab is what re-establishes a
-//      real baseline. (Without this latch: startup fetch hangs → pack removed during the
-//      wait → a later fetch installs the POST-removal map as the baseline → a
-//      provenance-stripped husk squatting a reserved allowlisted name reads "never seen"
-//      and is exempted — the exact hole the ever-seen gate exists to close.)
+//   2. BASELINE LOST ⇒ LATCHED CLOSED FOR THE SESSION. Once the page-load-anchored
+//      observation window has POSITIVELY closed with no data, no later observation can
+//      prove a type was "never defined earlier this session": a removal may have happened
+//      inside the gap. So after loseBaseline() nothing may mark the history seeded, not
+//      even a successful reconnect/refresh_nodes re-register. (Without this latch: the
+//      startup fetch fails → a pack is removed → a later fetch installs the POST-removal
+//      map as the baseline → a provenance-stripped husk squatting a reserved allowlisted
+//      name reads "never seen" and is exempted — the hole the ever-seen gate exists to
+//      close.)
+//
+//      THE LATCH IS ARMED BY EVIDENCE ONLY, NEVER BY A TIMEOUT. "Not seeded yet" and
+//      "proven unanchored" are different states and get different handling, because
+//      conflating them created a third false refusal on top of the two this work fixes:
+//      an /object_info fetch that merely took longer than a tool's bounded wait would
+//      latch the session closed, and every subsequent legitimate add/write was refused
+//      until the user reloaded the tab — even though the request then returned perfectly
+//      healthy definitions. A timeout is the ABSENCE of evidence. The PENDING state
+//      (rule 1, below) covers it and is fully RECOVERABLE: the in-flight seed keeps
+//      running, a late response still calls markSeeded(), and normal operation resumes
+//      on the next call with no reload.
 //
 // recordTypes() is deliberately NOT latched: recording can only ever ADD evidence that a
 // type existed, which can only ever make the gate refuse MORE. Only the "this history is
@@ -45,7 +55,7 @@
 // it. The reserved-name allowlist and the provenance checks are the layered defenses that
 // keep the residual to exactly that construction.
 
-import { HISTORY_UNSEEDED } from "./node-resolve.js";
+import { HISTORY_PENDING, HISTORY_UNSEEDED } from "./node-resolve.js";
 
 export function createObjectInfoHistory() {
   const seen = new Set();
@@ -70,12 +80,17 @@ export function createObjectInfoHistory() {
       return true;
     },
 
-    /** Latch: we reached a guard without a trustworthy baseline. IRREVERSIBLE, and it
-     *  also DEMOTES any existing baseline, so the invariant is the simple one — any
-     *  admitted observation gap closes the gate for the session, no case analysis about
-     *  which side of the gap the baseline fell on. In practice the panel only calls this
-     *  when the history is already unseeded (the waiter returns early when it is seeded),
-     *  so a healthy session never reaches it. */
+    /** Latch: POSITIVE EVIDENCE that the page-load-anchored observation window closed
+     *  WITHOUT data, so no later fetch can serve as a baseline. IRREVERSIBLE, and it
+     *  demotes any existing baseline.
+     *
+     *  ARM THIS ONLY ON EVIDENCE, NEVER ON A TIMEOUT. A timeout is the ABSENCE of
+     *  evidence, not evidence: the request may still be in flight and about to return
+     *  perfectly healthy definitions. Latching on one would turn ordinary latency into a
+     *  permanent, session-long false refusal of every legitimate add/write — the exact
+     *  bug class (#496/#507) this module's consumers exist to fix. Use the recoverable
+     *  PENDING state for "no baseline yet"; the only caller here is the startup seed
+     *  after its whole attempt sequence has finished with nothing. */
     loseBaseline() {
       baselineLost = true;
       seeded = false;
@@ -83,14 +98,19 @@ export function createObjectInfoHistory() {
 
     /** The oracle the #458 guards inject. TRUE ⇒ "treat as defined earlier this session",
      *  which for a type absent from the CURRENT /object_info means REMOVED ⇒ refuse.
-     *  With NO trustworthy baseline it returns the HISTORY_UNSEEDED sentinel instead —
-     *  still TRUTHY, so a consumer that only tests for truth still fails closed, but a
-     *  guard that recognizes it can say "reload the tab" rather than falsely blaming a
-     *  removed pack (which for a MarkdownNote is nonsense and is exactly the misleading
-     *  diagnosis #496 was filed about). */
+     *
+     *  Without a baseline it returns one of two TRUTHY sentinels — truthy so a consumer
+     *  that only tests for truth still fails closed, distinct so the guards can say what
+     *  is actually wrong instead of falsely blaming a removed pack (nonsense for a
+     *  MarkdownNote, and exactly the misleading diagnosis #496 was filed about):
+     *    HISTORY_PENDING  — the baseline has not ARRIVED yet. TEMPORARY and RECOVERABLE:
+     *                       a late /object_info response still calls markSeeded(), after
+     *                       which the very next call authorizes normally, no tab reload.
+     *    HISTORY_UNSEEDED — the observation window closed with nothing (latched). Only a
+     *                       reload can re-establish a baseline. */
     wasTypeEverDefined(type) {
-      if (!seeded) return HISTORY_UNSEEDED;
-      return seen.has(type);
+      if (seeded) return seen.has(type);
+      return baselineLost ? HISTORY_UNSEEDED : HISTORY_PENDING;
     },
 
     get seeded() {

--- a/web/js/lib/object-info-history.js
+++ b/web/js/lib/object-info-history.js
@@ -125,3 +125,42 @@ export function createObjectInfoHistory() {
     },
   };
 }
+
+/**
+ * Wait (BOUNDED) for the startup baseline seed, then return REGARDLESS of whether it
+ * landed. Extracted from the panel so the rule below is directly testable — the bug it
+ * encodes was found in review, not by a test, precisely because this logic had no seam.
+ *
+ * THE RULE, AND THE WHOLE REASON THIS FUNCTION EXISTS: it must NEVER mutate `history`.
+ * The bound exists only so a getNodeDefs() that never settles cannot hang a graph tool
+ * forever; giving up on the WAIT teaches us nothing about the backend. If this called
+ * history.loseBaseline(), a fetch that merely took a moment longer than the bound would
+ * latch the session closed and every subsequent legitimate add/write would be refused
+ * until the user reloaded the tab — ordinary latency causing permanent breakage, the same
+ * false-refusal bug class (#496/#507) this guard family was fixed to stop producing.
+ *
+ * Nor may it start a REPLACEMENT seed: that fetch would be anchored after an unobserved
+ * window, and installing its map as the baseline is exactly the removed-pack hole.
+ *
+ * So: on return the history is either SEEDED (proceed normally) or PENDING (refuse this
+ * one call, temporarily). `seedPromise` keeps running either way, and a late response
+ * still calls markSeeded(), so the next call authorizes with no reload. `history` is
+ * accepted only so callers and tests can state that invariant explicitly.
+ */
+export async function awaitHistoryBaseline(history, seedPromise, timeoutMs) {
+  let timer;
+  try {
+    await Promise.race([
+      // A rejected seed is not an error here — it simply leaves the history unseeded.
+      Promise.resolve(seedPromise).catch(() => {}),
+      new Promise((resolve) => {
+        timer = setTimeout(resolve, timeoutMs);
+      }),
+    ]);
+  } finally {
+    // Clear the losing timer so a fast seed does not pin a handle per graph tool call.
+    clearTimeout(timer);
+  }
+  // Deliberately no state change. See the rule above before adding one.
+  return history?.seeded ?? false;
+}

--- a/web/js/lib/object-info-history.js
+++ b/web/js/lib/object-info-history.js
@@ -1,0 +1,86 @@
+// The OBSERVED-BACKEND-HISTORY trust root for the #458 write/add guards, extracted so
+// the exact fail-closed rules are unit-testable instead of living as loose module state
+// in the 20k-line panel bundle.
+//
+// WHAT IT IS: the session-scoped set of every node class_type that has appeared in ANY
+// backend /object_info response during this session. A type ABSENT from the CURRENT
+// /object_info that was EVER seen here is a REMOVED backend node (pack uninstalled) and
+// must be refused — a client husk cannot un-see what the backend already reported. A type
+// NEVER seen is genuinely frontend-only (Note/MarkdownNote/Reroute/…) and may be exempted.
+// This is the one signal the guards' client-side allowlist and provenance markers cannot
+// forge, so the whole frontend-only exemption in node-resolve.js rests on it.
+//
+// THE TWO FAIL-CLOSED RULES (both learned from adversarial review):
+//
+//   1. UNSEEDED ⇒ CLOSED. Until at least one authoritative /object_info observation has
+//      been recorded as a BASELINE, "never seen" means nothing, so wasTypeEverDefined
+//      reports EVERY absent-from-current type as removed. A failed seed therefore never
+//      opens a hole; it only refuses more.
+//
+//   2. BASELINE LOST ⇒ LATCHED CLOSED FOR THE SESSION. Once the STARTUP baseline is
+//      missed — the seed failed, or a tool bounded its wait and gave up — there is a
+//      window we never observed, and NO later observation can prove a type was "never
+//      defined earlier this session": the removal may have happened inside that window.
+//      So after loseBaseline() nothing may mark the history seeded, not even a successful
+//      reconnect/refresh_nodes re-register. Reloading the tab is what re-establishes a
+//      real baseline. (Without this latch: startup fetch hangs → pack removed during the
+//      wait → a later fetch installs the POST-removal map as the baseline → a
+//      provenance-stripped husk squatting a reserved allowlisted name reads "never seen"
+//      and is exempted — the exact hole the ever-seen gate exists to close.)
+//
+// recordTypes() is deliberately NOT latched: recording can only ever ADD evidence that a
+// type existed, which can only ever make the gate refuse MORE. Only the "this history is
+// trustworthy enough to conclude never-seen" claim is latched.
+
+export function createObjectInfoHistory() {
+  const seen = new Set();
+  let seeded = false;
+  let baselineLost = false;
+
+  return {
+    /** Record every class_type in a real /object_info payload. Returns `defs` unchanged
+     *  so it can wrap a fetch inline. A null/non-object payload records nothing. */
+    recordTypes(defs) {
+      if (defs && typeof defs === "object") {
+        for (const key of Object.keys(defs)) seen.add(key);
+      }
+      return defs;
+    },
+
+    /** Promote the recorded history to a trustworthy BASELINE. A no-op once the baseline
+     *  has been lost — that is rule 2, and it is the whole point of this module. */
+    markSeeded() {
+      if (baselineLost) return false;
+      seeded = true;
+      return true;
+    },
+
+    /** Latch: we reached a guard without a trustworthy baseline. IRREVERSIBLE, and it
+     *  also DEMOTES any existing baseline, so the invariant is the simple one — any
+     *  admitted observation gap closes the gate for the session, no case analysis about
+     *  which side of the gap the baseline fell on. In practice the panel only calls this
+     *  when the history is already unseeded (the waiter returns early when it is seeded),
+     *  so a healthy session never reaches it. */
+    loseBaseline() {
+      baselineLost = true;
+      seeded = false;
+    },
+
+    /** The oracle the #458 guards inject. TRUE ⇒ "treat as defined earlier this session",
+     *  which for a type absent from the CURRENT /object_info means REMOVED ⇒ refuse. */
+    wasTypeEverDefined(type) {
+      return !seeded || seen.has(type);
+    },
+
+    get seeded() {
+      return seeded;
+    },
+    get baselineLost() {
+      return baselineLost;
+    },
+    /** Test/diagnostic view of the recorded set. */
+    has(type) {
+      return seen.has(type);
+    },
+  };
+}

--- a/web/js/lib/object-info-history.js
+++ b/web/js/lib/object-info-history.js
@@ -32,6 +32,8 @@
 // type existed, which can only ever make the gate refuse MORE. Only the "this history is
 // trustworthy enough to conclude never-seen" claim is latched.
 
+import { HISTORY_UNSEEDED } from "./node-resolve.js";
+
 export function createObjectInfoHistory() {
   const seen = new Set();
   let seeded = false;
@@ -67,9 +69,15 @@ export function createObjectInfoHistory() {
     },
 
     /** The oracle the #458 guards inject. TRUE ⇒ "treat as defined earlier this session",
-     *  which for a type absent from the CURRENT /object_info means REMOVED ⇒ refuse. */
+     *  which for a type absent from the CURRENT /object_info means REMOVED ⇒ refuse.
+     *  With NO trustworthy baseline it returns the HISTORY_UNSEEDED sentinel instead —
+     *  still TRUTHY, so a consumer that only tests for truth still fails closed, but a
+     *  guard that recognizes it can say "reload the tab" rather than falsely blaming a
+     *  removed pack (which for a MarkdownNote is nonsense and is exactly the misleading
+     *  diagnosis #496 was filed about). */
     wasTypeEverDefined(type) {
-      return !seeded || seen.has(type);
+      if (!seeded) return HISTORY_UNSEEDED;
+      return seen.has(type);
     },
 
     get seeded() {

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -31,7 +31,12 @@ import {
   assertMutatedNodeAuthorized,
 } from "./node-resolve.js";
 import { controlAfterGenerateWarning } from "./control-after-generate.js";
-import { uploadInputConfig, uploadInputAccepts, addComboOption } from "./input-asset.js";
+import {
+  uploadInputConfig,
+  uploadInputAccepts,
+  addComboOption,
+  serverDeclaresEmptyComboOptions,
+} from "./input-asset.js";
 
 export async function runSetWidget(
   node,
@@ -370,22 +375,40 @@ export async function runSetWidget(
     // option list" guard never fired and `[].includes(value)` rejected EVERY value,
     // making the widget permanently unwritable by the agent.
     //
-    // ZERO options after the authoritative refresh means the option set is genuinely NOT
-    // KNOWABLE, which is not the same as "no value is valid"; and #240's reason for
-    // strict membership (a number being reinterpreted as an INDEX into a real list)
-    // cannot apply when there is no list to index into. So take the value as written.
-    // This runs LAST precisely so a merely-STALE empty list is refreshed first and a
-    // server-confirmable upload asset is confirmed first; a NON-EMPTY list (from either
-    // source) still enforces exact membership, and an object/array value still fails
-    // closed. If the write still cannot land, the freshest rejection is re-raised below.
-    try {
+    // ZERO options means the option set is genuinely NOT KNOWABLE, which is not the same
+    // as "no value is valid"; and #240's reason for strict membership (a number being
+    // reinterpreted as an INDEX into a real list) cannot apply when there is no list to
+    // index into. So take the value as written — but ONLY under two hard conditions:
+    //
+    //   1. The rejection really WAS the empty-list case (err.emptyOptions, set solely by
+    //      that branch) — never a "not a valid option" miss against a real list.
+    //   2. The freshly-fetched /object_info AUTHORITATIVELY declares this input's option
+    //      list EMPTY (serverDeclaresEmptyComboOptions). The LIVE widget alone is not
+    //      enough (codex round-2, SEVERE): a widget whose `options.values` is a FUNCTION
+    //      is deliberately never clobbered by the combo refresh, so a dynamic source that
+    //      returns [] right now would look "empty" even while the server publishes a real
+    //      list — and an off-list value would be written. Keyed on the ULTIMATE CONCRETE
+    //      type + its concrete input name, exactly like the #387 probe above, so a renamed
+    //      nested promotion still looks the right def input up.
+    //
+    // It also runs LAST, so a merely-STALE empty list is refreshed first and a
+    // server-confirmable upload asset is confirmed first. NOT wrapped in a catch: this is
+    // a real write attempt, and a genuine failure from it (a rejected value, a partial/
+    // rolled-back write) must propagate UNCHANGED rather than be masked by the earlier
+    // combo rejection.
+    if (
+      latest?.emptyOptions &&
+      serverDeclaresEmptyComboOptions(
+        freshDefs ?? undefined,
+        authTarget?.type,
+        concreteWidgetName ?? writeTargetWidgetName ?? widgetName,
+      )
+    ) {
       return withWarning({
         set: write({ acceptEmptyComboOptions: true }),
         ...(typeof refreshCombos === "function" ? { refreshed: true } : {}),
         empty_option_list: true,
       });
-    } catch {
-      /* not the empty-combo case (or still invalid) — fall through and refuse honestly */
     }
 
     // No recovery succeeded — refuse honestly with the freshest rejection.

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -233,7 +233,7 @@ export async function runSetWidget(
   // resolveWidgetWrite — a real widget whose own name contains a dot still wins, and a
   // dotted form is only interpreted when no exact widget matches — so the split can
   // never silently misroute to a different widget.
-  const write = () =>
+  const write = (extra = {}) =>
     applyWidgetWrite(node, widgetName, value, {
       resolveSource,
       canvas,
@@ -242,6 +242,7 @@ export async function runSetWidget(
       setDirty,
       assertTargetWritable: (targetNode) => assertResolvedTargetRegistered(liveRegistry(), targetNode),
       promotedResolution,
+      ...extra,
     });
 
   // #558: the value widget being written may be governed by a non-`fixed`
@@ -359,6 +360,32 @@ export async function runSetWidget(
         }
         throw confErr;
       }
+    }
+
+    // #507 DYNAMIC CLIENT-POPULATED COMBO, the LAST resort — deliberately after every
+    // authoritative mechanism above has been tried and failed. Some custom nodes declare
+    // a combo with an EMPTY option list on purpose (StarNodes' `"model": ((), {...})`
+    // ⇒ /object_info reports `[[], {...}]`) and let the node's own frontend JS fill the
+    // dropdown at runtime. `comboOptions()` returns `[]` — TRUTHY — so the "no readable
+    // option list" guard never fired and `[].includes(value)` rejected EVERY value,
+    // making the widget permanently unwritable by the agent.
+    //
+    // ZERO options after the authoritative refresh means the option set is genuinely NOT
+    // KNOWABLE, which is not the same as "no value is valid"; and #240's reason for
+    // strict membership (a number being reinterpreted as an INDEX into a real list)
+    // cannot apply when there is no list to index into. So take the value as written.
+    // This runs LAST precisely so a merely-STALE empty list is refreshed first and a
+    // server-confirmable upload asset is confirmed first; a NON-EMPTY list (from either
+    // source) still enforces exact membership, and an object/array value still fails
+    // closed. If the write still cannot land, the freshest rejection is re-raised below.
+    try {
+      return withWarning({
+        set: write({ acceptEmptyComboOptions: true }),
+        ...(typeof refreshCombos === "function" ? { refreshed: true } : {}),
+        empty_option_list: true,
+      });
+    } catch {
+      /* not the empty-combo case (or still invalid) — fall through and refuse honestly */
     }
 
     // No recovery succeeded — refuse honestly with the freshest rejection.

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -920,6 +920,19 @@ export function applyWidgetWrite(
   if (acceptEmptyComboOptions) {
     for (const other of [parentWidget, ...displayWidgets]) {
       if (!other || !isComboWidget(other)) continue;
+      // A DYNAMIC (function) sibling list is UNVERIFIABLE from here (codex round-5): it
+      // can return [] during this check and a real, non-empty list immediately afterwards
+      // — a one-shot read proves nothing, and the off-list value would still land on the
+      // mutated, serializing rail. Only the value's membership matters, and we cannot
+      // establish it, so fail closed rather than report a success we cannot stand behind.
+      if (typeof other.options?.values === "function") {
+        throw new WidgetWriteError(
+          `Cannot verify value ${JSON.stringify(coerced)} against the parent subgraph's combo ` +
+            `widget "${other.name}", which this promoted write also mutates: its option list is ` +
+            `computed dynamically and the inner widget's list is empty, so nothing authoritative ` +
+            `validates the value. Refusing to write.`,
+        );
+      }
       const otherOptions = comboOptions(other);
       if (!Array.isArray(otherOptions) || otherOptions.length === 0) continue;
       if (otherOptions.includes(coerced)) continue;

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -215,7 +215,13 @@ function mergeCompositeFields(widgetName, base, incoming) {
  * WidgetWriteError (never silently coerces to a wrong value) when the value is
  * incompatible with the widget's declared type.
  */
-export function coerceWidgetValue(widget, value, mergeBaseWidget = widget, subFieldPath = null) {
+export function coerceWidgetValue(
+  widget,
+  value,
+  mergeBaseWidget = widget,
+  subFieldPath = null,
+  { acceptEmptyComboOptions = false } = {},
+) {
   const name = widget?.name ?? "(widget)";
 
   // #347: distinguish "clear to empty" from "missing value". An EXPLICIT empty
@@ -292,6 +298,47 @@ export function coerceWidgetValue(widget, value, mergeBaseWidget = widget, subFi
       throw new WidgetWriteError(
         `Combo widget "${name}" has no readable option list; cannot validate ` +
           `value ${JSON.stringify(value)} — refusing to write.`,
+        { combo: true },
+      );
+    }
+    // #507: a DYNAMIC, CLIENT-POPULATED combo declared with an EMPTY option list —
+    // e.g. StarNodes' `"model": ((), {...})`, which /object_info reports as
+    // `[[], {...}]` and whose dropdown the node's own frontend JS fills at runtime
+    // (a "Refresh Models" button). `comboOptions` returns `[]`, which is TRUTHY, so
+    // the `!options` guard above never fired and `[].includes(value)` rejected EVERY
+    // value — the widget was permanently unwritable by the agent.
+    //
+    // ZERO options means the option set is NOT KNOWABLE from here — the same state
+    // the guard above names, NOT "no value is valid". And the #240 reason for strict
+    // membership does not apply: that rule exists so a numeric value cannot be
+    // silently reinterpreted as an INDEX into a real list, and with an empty list
+    // there is no list to index into. So accept the value as written.
+    //
+    // This does NOT loosen #233/#240. An empty LIVE list is ambiguous — it can also
+    // simply be STALE (never populated yet) while the SERVER publishes a real list —
+    // so acceptance is NOT automatic: by default the empty case throws a RETRYABLE
+    // combo error, which drives runSetWidget's authoritative /object_info refresh
+    // first. Only if the list is STILL empty after that (`acceptEmptyComboOptions`)
+    // is the value taken as written. The moment the list is NON-EMPTY — from the
+    // server or from the node's own client-side refresh, whichever is richer, since
+    // `options` is read from the LIVE widget — strict membership below applies
+    // unchanged and an off-list value is refused.
+    //
+    // Only a SCALAR is ever accepted: an object/array could never be an option under
+    // any list and would corrupt the widget, so it fails closed and is marked
+    // NON-retryable (no refresh can make it valid).
+    if (options.length === 0) {
+      if (typeof value === "object") {
+        throw new WidgetWriteError(
+          `Combo widget "${name}" has an EMPTY option list (a dynamic, client-populated ` +
+            `combo), so ${JSON.stringify(value)} cannot be validated against it — and only a ` +
+            `scalar (string/number/boolean) can be written to a combo. Refusing to write.`,
+        );
+      }
+      if (acceptEmptyComboOptions) return value;
+      throw new WidgetWriteError(
+        `Combo widget "${name}" has an EMPTY option list; the server's option list may ` +
+          `simply be stale — refreshing it before deciding.`,
         { combo: true },
       );
     }
@@ -649,6 +696,7 @@ export function resolveWidgetWrite(
   resolveSource,
   assertTargetWritable,
   promotedResolution,
+  coerceOpts,
 ) {
   let targetNode = node;
   let widget = null;
@@ -791,7 +839,7 @@ export function resolveWidgetWrite(
   // unaffected (they don't merge). Non-promoted writes merge onto their own value.
   // (A promoted write with no authoritative rail already threw above, BEFORE this
   // possibly side-effecting coercion — so `promotedParentWidget` is non-null here.)
-  const coerced = coerceWidgetValue(widget, value, promotedParentWidget ?? widget, subFieldPath);
+  const coerced = coerceWidgetValue(widget, value, promotedParentWidget ?? widget, subFieldPath, coerceOpts);
 
   return { targetNode, widget, coerced, promotedFrom, promotedParentWidget, promotedParentWidgets, promotedHostInput };
 }
@@ -806,7 +854,20 @@ export function applyWidgetWrite(
   node,
   widgetName,
   value,
-  { resolveSource, canvas, beforeChange, afterChange, setDirty, assertTargetWritable, promotedResolution } = {},
+  {
+    resolveSource,
+    canvas,
+    beforeChange,
+    afterChange,
+    setDirty,
+    assertTargetWritable,
+    promotedResolution,
+    // #507: only the FINAL attempt (after the authoritative /object_info combo refresh
+    // has had its chance) may treat a still-EMPTY combo option list as "not knowable"
+    // and take the value as written. Default false ⇒ the empty case is a RETRYABLE
+    // combo rejection, so a merely-stale empty list is refreshed before any decision.
+    acceptEmptyComboOptions = false,
+  } = {},
 ) {
   // resolveWidgetWrite runs assertTargetWritable on the RESOLVED target (inner
   // promoted node for a subgraph write, or the node's own) BEFORE it coerces the
@@ -816,7 +877,9 @@ export function applyWidgetWrite(
   // /object_info gate authorized (#458), and resolveWidgetWrite also fails closed if
   // the AUTHORITATIVE parent rail widget can't be identified (#366).
   const { targetNode, widget: w, coerced, promotedFrom, promotedParentWidget, promotedParentWidgets, promotedHostInput } =
-    resolveWidgetWrite(node, widgetName, value, resolveSource, assertTargetWritable, promotedResolution);
+    resolveWidgetWrite(node, widgetName, value, resolveSource, assertTargetWritable, promotedResolution, {
+      acceptEmptyComboOptions,
+    });
 
   // #366: for a promoted subgraph widget the AUTHORITATIVE value lives on the
   // parent's OWN rail widget (resolved by the promotion RELATIONSHIP in

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -225,7 +225,7 @@ export function coerceWidgetValue(
   value,
   mergeBaseWidget = widget,
   subFieldPath = null,
-  { acceptEmptyComboOptions = false } = {},
+  { acceptEmptyComboOptions = false, out } = {},
 ) {
   const name = widget?.name ?? "(widget)";
 
@@ -340,7 +340,15 @@ export function coerceWidgetValue(
             `scalar (string/number/boolean) can be written to a combo. Refusing to write.`,
         );
       }
-      if (acceptEmptyComboOptions) return value;
+      if (acceptEmptyComboOptions) {
+        // Record that THIS acceptance — not ordinary membership — is what admitted the
+        // value, so applyWidgetWrite can decide the sibling cross-check from the
+        // COERCION-TIME verdict. It must never re-read the list to infer this: a
+        // stateful dynamic source can answer differently on a second call and would
+        // become an escape hatch around the check (codex confirmation round).
+        if (out) out.emptyAcceptanceUsed = true;
+        return value;
+      }
       throw new WidgetWriteError(
         `Combo widget "${name}" has an EMPTY option list; the server's option list may ` +
           `simply be stale — refreshing it before deciding.`,
@@ -881,9 +889,13 @@ export function applyWidgetWrite(
   // promotedResolution is reused so the write targets the EXACT node the fresh
   // /object_info gate authorized (#458), and resolveWidgetWrite also fails closed if
   // the AUTHORITATIVE parent rail widget can't be identified (#366).
+  const coerceOutcome = {};
   const { targetNode, widget: w, coerced, promotedFrom, promotedParentWidget, promotedParentWidgets, promotedHostInput } =
     resolveWidgetWrite(node, widgetName, value, resolveSource, assertTargetWritable, promotedResolution, {
       acceptEmptyComboOptions,
+      // Filled in by coerceWidgetValue when the EMPTY-LIST acceptance (not ordinary
+      // membership) is what admitted the value. Read below — never re-derived.
+      out: coerceOutcome,
     });
 
   // #366: for a promoted subgraph widget the AUTHORITATIVE value lives on the
@@ -917,17 +929,15 @@ export function applyWidgetWrite(
   // NON-EMPTY list must contain the value, or the whole write fails closed BEFORE any
   // mutation. A rail whose own list is unreadable or empty adds no information and is
   // skipped (the inner's server declaration already governs).
-  // …and ONLY when the empty-list acceptance was actually what let `coerced` through.
-  // Keying on the FLAG alone over-reached (codex final round, MINOR): a stateful inner
-  // options function can return [] for the first attempts and a real list containing the
-  // value by the final one, in which case ordinary membership validated the write and the
-  // rail needs no extra scrutiny — refusing there would be the very "guard rejects a
-  // legitimate case" bug this PR exists to fix. Re-reading the inner list decides it, and
-  // an inner list that is (still) empty/unreadable falls into the strict branch.
-  const innerOptions = acceptEmptyComboOptions && isComboWidget(w) ? comboOptions(w) : null;
-  const innerValidatedIt =
-    Array.isArray(innerOptions) && innerOptions.length > 0 && innerOptions.includes(coerced);
-  if (acceptEmptyComboOptions && !innerValidatedIt) {
+  // …and ONLY when the EMPTY-LIST acceptance is what actually admitted the value. Keying
+  // on the caller's FLAG alone over-reached: with a stateful inner options function the
+  // final attempt may have been validated by ordinary membership, and refusing the rail
+  // then would be the very "guard rejects a legitimate case" bug this PR exists to fix.
+  // The verdict is taken from COERCION TIME (coerceOutcome, set inside coerceWidgetValue)
+  // and never re-derived by reading the list again: a second read of a stateful dynamic
+  // source can disagree with the first, which would turn the narrowing into an escape
+  // hatch around this very check (codex confirmation round).
+  if (coerceOutcome.emptyAcceptanceUsed) {
     for (const other of [parentWidget, ...displayWidgets]) {
       if (!other || !isComboWidget(other)) continue;
       // A DYNAMIC (function) sibling list is UNVERIFIABLE from here (codex round-5): it

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -917,7 +917,17 @@ export function applyWidgetWrite(
   // NON-EMPTY list must contain the value, or the whole write fails closed BEFORE any
   // mutation. A rail whose own list is unreadable or empty adds no information and is
   // skipped (the inner's server declaration already governs).
-  if (acceptEmptyComboOptions) {
+  // …and ONLY when the empty-list acceptance was actually what let `coerced` through.
+  // Keying on the FLAG alone over-reached (codex final round, MINOR): a stateful inner
+  // options function can return [] for the first attempts and a real list containing the
+  // value by the final one, in which case ordinary membership validated the write and the
+  // rail needs no extra scrutiny — refusing there would be the very "guard rejects a
+  // legitimate case" bug this PR exists to fix. Re-reading the inner list decides it, and
+  // an inner list that is (still) empty/unreadable falls into the strict branch.
+  const innerOptions = acceptEmptyComboOptions && isComboWidget(w) ? comboOptions(w) : null;
+  const innerValidatedIt =
+    Array.isArray(innerOptions) && innerOptions.length > 0 && innerOptions.includes(coerced);
+  if (acceptEmptyComboOptions && !innerValidatedIt) {
     for (const other of [parentWidget, ...displayWidgets]) {
       if (!other || !isComboWidget(other)) continue;
       // A DYNAMIC (function) sibling list is UNVERIFIABLE from here (codex round-5): it

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -906,6 +906,32 @@ export function applyWidgetWrite(
       ? promotedParentWidgets.filter((dw) => dw && dw !== w && dw !== parentWidget)
       : [];
 
+  // #507 (codex round-3, MODERATE): coerceWidgetValue validated the value against the
+  // IMMEDIATE inner widget's option list only — but a promoted write assigns the SAME
+  // value to the parent's authoritative RAIL widget and to every display proxy, whose
+  // own option lists can DIFFER from the inner's. That is harmless while the inner list
+  // is authoritative, but the empty-list acceptance deliberately writes a value nothing
+  // validated, so an inner combo that is (server-declared) EMPTY could push an OFF-LIST
+  // value into a rail/proxy that DOES have a real list. Scoped strictly to that path:
+  // when acceptEmptyComboOptions is in force, every OTHER mutated combo with a readable
+  // NON-EMPTY list must contain the value, or the whole write fails closed BEFORE any
+  // mutation. A rail whose own list is unreadable or empty adds no information and is
+  // skipped (the inner's server declaration already governs).
+  if (acceptEmptyComboOptions) {
+    for (const other of [parentWidget, ...displayWidgets]) {
+      if (!other || !isComboWidget(other)) continue;
+      const otherOptions = comboOptions(other);
+      if (!Array.isArray(otherOptions) || otherOptions.length === 0) continue;
+      if (otherOptions.includes(coerced)) continue;
+      throw new WidgetWriteError(
+        `Value ${JSON.stringify(coerced)} is not a valid option for the parent subgraph's ` +
+          `combo widget "${other.name}" (${otherOptions.length} options), which this promoted ` +
+          `write also mutates — the inner widget's option list is empty, but this one is not. ` +
+          `Refusing to write.`,
+      );
+    }
+  }
+
   // Snapshot the EXPECTED value BEFORE the callback runs. For a COMPOSITE object
   // write (#179) `w.value` and `coerced` are the SAME reference, so a callback
   // that mutates the object IN PLACE would change our "expected" too — making a

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -31,9 +31,14 @@
 //     is refused, not written blindly).
 
 export class WidgetWriteError extends Error {
-  constructor(message, { combo = false } = {}) {
+  constructor(message, { combo = false, emptyOptions = false } = {}) {
     super(message);
     this.name = "WidgetWriteError";
+    // `emptyOptions` narrows `combo` to the ONE case runSetWidget's #507 last-resort
+    // path may act on: the option list was READ successfully and is EMPTY. It is set
+    // ONLY by that branch, so the caller never has to pattern-match a message, and a
+    // plain "not a valid option" rejection can never be mistaken for it.
+    this.emptyOptions = emptyOptions;
     // `combo` marks the failure as "combo value rejected against the current
     // option list" (unreadable OR not-a-member). runSetWidget uses this as the
     // ONLY signal that a stale-combo refresh + single revalidation may help —
@@ -339,7 +344,7 @@ export function coerceWidgetValue(
       throw new WidgetWriteError(
         `Combo widget "${name}" has an EMPTY option list; the server's option list may ` +
           `simply be stale — refreshing it before deciding.`,
-        { combo: true },
+        { combo: true, emptyOptions: true },
       );
     }
     // STRICT typed membership: no numeric<->string coercion. Numeric options


### PR DESCRIPTION
Two guards that fail CLOSED on a legitimate case, plus the hardening the self-gate demanded.

Closes #496
Closes #507

## #496 — one shared frontend-only allowlist across the whole guard family

The `#458` guard family authorizes a node type against a freshly-fetched `/object_info`. Genuinely **frontend-only** types (`Note`, `MarkdownNote`, `Reroute`, `PrimitiveNode`, the rgthree control nodes) are registered purely by the LiteGraph frontend and are **never enumerated by `/object_info` by design**, so that oracle can never authorize them and the guard refuses them on a perfectly healthy backend.

**State of the issue as filed:** the `panel_set_widget` half was already fixed by #479 — `FRONTEND_ONLY_NODE_TYPES` exists and both set_widget guards consult it. What #479 did **not** do is teach `graph_add_node`'s guard, and each set_widget guard still spelled the exemption out inline, clause for clause. So `MarkdownNote` was **writable but not addable**: `assertAddNodeResolvableRefreshing` had no exemption at all. Verified against this machine's live ComfyUI — `/object_info` does not list `Note`/`MarkdownNote`, so `panel_add_node("MarkdownNote")` fails closed with *"Unknown node type … the ComfyUI backend does not provide it"*. A duplicated predicate is exactly how that drift happened.

Two shared predicates now carry the decision, and every guard whose oracle is `/object_info` routes through them:

- `isAuthorizedFrontendOnlyType(registry, type, node)` — live-registry membership + reserved-allowlist membership + no backend provenance on the registered class *or* the target instance's constructor. Same conjunction as before, one copy.
- `isRemovedBackendType` / `backendHistoryVerdict(type, wasTypeEverDefined)` — the non-forgeable observed-backend-history gate, previously duplicated verbatim in both set_widget guards.

| guard | oracle | consumes the shared allowlist |
|---|---|---|
| `assertAddNodeResolvableRefreshing` | fresh `/object_info` | **yes (new)** |
| `assertTypeAgainstFreshBackend` | fresh `/object_info` | yes |
| `assertMutatedNodeAuthorized` | fresh `/object_info` | yes |
| `assertResolvedTargetRegistered` | live LiteGraph registry | **no, deliberately** |

The fourth family member needs no allowlist: its oracle is the registry, where a frontend-only type *is* present — that is what "frontend-only" means. A comment now says so, so no list gets pasted there.

**The allowlist (unchanged, single copy in `node-resolve.js`):** `Note`, `MarkdownNote`, `Reroute`, `PrimitiveNode`, `Fast Bypasser (rgthree)`, `Fast Muter (rgthree)`, `Fast Groups Bypasser (rgthree)`, `Fast Groups Muter (rgthree)`, `Label (rgthree)`, `Reroute (rgthree)`, `Node Collector (rgthree)`.

**Nothing loosened.** The ever-seen gate runs FIRST in every guard, so a since-removed pack is refused before the exemption is consulted; an unavailable `/object_info` still fails closed for every type; and a defless husk not on the allowlist, a class squatting an allowlisted name with backend provenance, and an allowlisted name absent from the live registry are all still refused. `graph_add_node`'s exemption additionally **requires** the history oracle to be wired — without it nothing absent from fresh `/object_info` is exempted at all.

## #507 — a dynamic combo with an empty option list was permanently unwritable

Some custom nodes declare a client-populated combo — StarNodes' `"model": ((), {...})`, which `/object_info` reports as `[[], {...}]` — and fill the dropdown from their own frontend JS. `comboOptions()` returns `[]`, which is **truthy**, so the "no readable option list" guard never fired and `[].includes(value)` rejected every value.

Zero options means the option set is **not knowable**, not "no value is valid", and #240's reason for strict membership (a number reinterpreted as an *index* into a real list) cannot apply when there is no list to index into. Acceptance is nonetheless not automatic, because an empty *live* list can also be merely stale:

1. `applyWidgetWrite` refuses the empty case **retryably** (`emptyOptions`), driving `runSetWidget`'s authoritative `/object_info` combo refresh.
2. The last-resort attempt runs only after the refresh **and** the #387 server-asset probe have both failed, and only when `serverDeclaresEmptyComboOptions()` confirms the **server itself** declares that concrete input a zero-length combo. The live widget alone is not enough — the production refresh deliberately never clobbers a dynamic `options.values` *function*, so a source returning `[]` right now would otherwise look empty while the server publishes a real list.
3. A non-empty list — server or client-populated, whichever the live widget holds — still enforces exact membership. Object/array values fail closed and are non-retryable. An unreadable list is still refused.
4. On that path every **other** mutated combo (the promoted parent rail and display proxies, whose lists can differ from the inner's) must contain the value, and a *dynamic* sibling source is treated as unverifiable and refused outright.
5. The final attempt is not wrapped in a catch — a genuine failure from it propagates unchanged rather than being masked by the earlier combo rejection.

As a side effect the reported list-wiping goes away: the first attempt now succeeds for this shape, so the refresh that overwrote the user's client-loaded models never runs.

## Self-gate

Eight rounds of `codex exec -m gpt-5.6-terra`, scoped to the graph-corruption / fabricated-success class. Final verdict **PASS** on the #507 flow and on the shared-allowlist work. Findings and resolutions:

| # | severity | finding | resolution |
|---|---|---|---|
| 1 | SEVERE | the add exemption trusted an allowlisted name + marker-free class — both forgeable | exemption now **requires** the observed-backend-history oracle |
| 1 | MODERATE | awaiting the history seed could hang `graph_add_node` forever | bounded `awaitObjectInfoHistorySeed()`; giving up leaves the history unseeded ⇒ fail closed |
| 2 | SEVERE | a dynamic `[]`-returning source vs a real server list wrote an off-list value | gated on `serverDeclaresEmptyComboOptions()`; tests now use the **production** `refreshComboOptionsFromDefs` |
| 2 | SEVERE | a post-timeout re-seed installed a post-removal map as the baseline | retry removed; the loss is latched |
| 3 | SEVERE | a later observation (incl. reconnect) could still erase the only evidence of a removal | trust root extracted to `object-info-history.js` with an irreversible `loseBaseline()` latch |
| 3 | MODERATE | a promoted write mutates rail/proxy combos that were never validated | every mutated combo cross-checked on the empty-list path |
| 4 | SEVERE | `registerComfyNodeDefs` marked the history seeded from a post-gap payload | it now **records only**; the startup seed is the sole caller of `markSeeded` |
| 5 | MODERATE | a stateful dynamic rail source could return `[]` during the check and a real list after | a dynamic sibling source is unverifiable ⇒ refused |
| 6 | MINOR | the rail check keyed on the flag, over-reaching onto normally-validated writes | narrowed to writes the empty-list acceptance actually authorized |
| 7 | SEVERE | …but that narrowing re-read the inner list, which a stateful source could exploit | verdict now taken from **coercion time** (`emptyAcceptanceUsed`), never a re-read |

**Disclosed, not fixed.** The final round flagged that the baseline is established from an *asynchronous* `/object_info` response, so a pack removed between page load and the first successful fetch is never observed. There is no synchronous page-load oracle that would close it; exploiting it needs a pack to squat a ComfyUI-core-reserved name, strip its own frontend class's provenance markers, and be uninstalled inside that sub-second window — an adversarial construction rather than an accidental failure, in a product where panel, orchestrator and user share one machine. The residual is **unchanged from `main`** and is now documented in `object-info-history.js` so nobody "fixes" it by weakening the two fail-closed rules.

## Tests

`browser_tests/unit`, 1292 passing (was 1245). Beyond the per-issue cases:

- **Parity** — all three `/object_info`-oracle guards return the same verdict over a leaf-node matrix (frontend-only, live backend node, unknown, defless husk, squatted name, removed-this-session).
- **Single source of truth** — mutating the one exported `FRONTEND_ONLY_NODE_TYPES` Set at runtime moves all three guards together and removing it moves them back, so a future hard-coded second copy fails here. That is #496 as an executable invariant.
- **Honest diagnosis** — with no baseline the guards say *"the `/object_info` baseline never loaded — reload the ComfyUI tab"* instead of falsely blaming a removed pack, while a genuinely removed pack still gets the removed-pack message. The unseeded sentinel is asserted TRUTHY, so a consumer that only tests for truth still fails closed.

`tsc --noEmit` clean. Every changed file re-checked as an ES module (`node --check` on a `.mjs` copy) — a duplicate top-level declaration would silently break the panel and CJS `node --check` misses it. No version/`pyproject.toml` bump. No NUL sentinels (`git diff --numstat` shows real line counts throughout).

## Needs rig verification

Unit tests cannot drive LiteGraph or a live ComfyUI, so on the rig please confirm:

1. `panel_add_node` with `class_type: "MarkdownNote"` / `"Note"` / `"Reroute"` succeeds and `panel_set_widget` writes its `text` — the exact #496 repro. This is the one behaviour change to `graph_add_node`, and it depends on ComfyUI's real frontend classes being provenance-clean (no `.nodeData`/`.comfyClass`), which only the browser can show.
2. Adding a genuinely unknown type still fails closed, and normal backend nodes still add — `graph_add_node` now awaits the history seed first, so confirm there is no added latency in the steady state.
3. `panel_set_widget` on a StarNodes `StarOllamaPromptHelper` `model` widget with a real Ollama model, and that the node's own client-loaded list is no longer wiped.
4. A promoted subgraph widget still writes and syncs the parent rail (the `#366`/`#477` path the new cross-check sits next to).

Also worth noting: two of the recent comments on #496 report a **different** failure — `panel_set_widget` refused on an *outer UUID subgraph* node's promoted widget (`ltx-2.3-img2vid`, node 320) as an "unverifiable virtual-subgraph node". That is `assertMutatedNodeAuthorized`'s virtual-container branch, not the frontend-only allowlist, and it is not addressed here; it needs the rig to determine whether ComfyUI's `SubgraphNode` class carries backend provenance or fails `isVirtualSubgraphContainer`. Suggest re-filing it separately rather than holding #496 open for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
