### PR TITLE
fix(panel): keep panel_open_workflow's outcome truthful across the mid-command disconnect (#402, #508, #442 defect 2)

### DIFF
--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -135,8 +135,8 @@ test("#508 wiring: a SUPERSEDED socket still gets its reply — only the UI cont
   const src = readFileSync(PANEL_JS, "utf8");
   const supersededAt = src.indexOf("const superseded = !isActive();");
   assert.notEqual(supersededAt, -1, "the instance guard must be captured, not used as an early return");
-  const block = src.slice(supersededAt, supersededAt + 2200);
-  const sendAt = block.indexOf("thisSock.send(JSON.stringify(reply));");
+  const block = src.slice(supersededAt, supersededAt + 1200);
+  const sendAt = block.indexOf("deliverReply(reply, msg.cmd, superseded)");
   const gateAt = block.indexOf("if (superseded) return;");
   assert.notEqual(sendAt, -1, "the reply must still be written to the socket it arrived on");
   assert.notEqual(gateAt, -1, "the UI continuation must still be gated on the instance guard");
@@ -147,6 +147,28 @@ test("#508 wiring: a SUPERSEDED socket still gets its reply — only the UI cont
     false,
     "the superseded early-return must not precede the reply write again",
   );
+});
+
+test("#508 codex R3: a command arriving on an ALREADY-superseded socket is refused, never dropped", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  // The listener must PARSE first: returning before parsing discards a queued command
+  // frame outright — neither executed, nor replied to, nor journaled — which is the very
+  // "registered tab that never acknowledges anything" wedge this change exists to remove.
+  const listenerAt = src.indexOf('thisSock.addEventListener("message"');
+  const listener = src.slice(listenerAt, listenerAt + 3000);
+  const parseAt = listener.indexOf("msg = JSON.parse(");
+  const guardAt = listener.indexOf("if (!isActive()) {");
+  assert.ok(parseAt !== -1 && guardAt !== -1, "the listener must parse before the instance guard");
+  assert.ok(parseAt < guardAt, "the frame must be parsed BEFORE the superseded early return");
+  // …and the refusal must be rid-correlated, explicitly NOT-APPLIED, and delivered/journaled.
+  const guarded = listener.slice(guardAt, guardAt + 1600);
+  assert.match(guarded, /if \(isCommandFrame\) \{/, "only command frames get a refusal");
+  assert.match(guarded, /rid: msg\.rid/, "the refusal must correlate to the command");
+  assert.match(guarded, /ok: false/, "a stale command is refused, never reported as done");
+  assert.match(guarded, /NOTHING was applied/, "the refusal must say it is safe to re-issue");
+  assert.match(guarded, /deliverReply\(/, "the refusal goes through the same deliver+journal path");
+  // The stale command must NOT be executed.
+  assert.equal(/GRAPH_TOOL_EXECUTORS/.test(guarded), false, "a superseded socket must never execute");
 });
 
 test("#508 wiring: an undelivered reply is journaled, replayed after hello, and self-heals boundedly", () => {

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -27,6 +27,8 @@ import {
   classifyUndeliveredReply,
   describeUndeliveredReply,
   createLostReplyJournal,
+  isReplayable,
+  REPLAY_MAX_AGE_MS,
   SENSITIVE_RESULT_CMDS,
   redactSensitiveReply,
   pruneAttempts,
@@ -119,8 +121,8 @@ test("codex R8: replay never crosses a bridge change — entries for another bri
   const body = src.slice(start, src.indexOf("\n  }", start));
   assert.match(
     body,
-    /if \(entry\.url && entry\.url !== targetUrl\) \{\s*\n\s*dropped\+\+;\s*\n\s*continue;/,
-    "an outcome belonging to a previous bridge must never be volunteered to a different agent",
+    /if \(!isReplayable\(entry, \{ now: Date\.now\(\), targetUrl \}\)\) \{\s*\n\s*dropped\+\+;\s*\n\s*continue;/,
+    "an outcome belonging to a previous bridge (or too old) must never be volunteered",
   );
   assert.match(body, /lostReplies\.replace\(keep\)/, "only undeliverable-but-still-ours entries are retried");
   assert.match(body, /Discarded \$\{dropped\}/, "the user must be told what was discarded");
@@ -137,6 +139,26 @@ test("codex R8: replay never crosses a bridge change — entries for another bri
     false,
     "the mutable current url must not be what gets journaled",
   );
+});
+
+test("codex R10: isReplayable demands the SAME bridge and a recent entry, and fails closed", () => {
+  const URL_A = "ws://127.0.0.1:9180";
+  const now = 1_000_000;
+  const fresh = { url: URL_A, at: now - 1000 };
+  assert.equal(isReplayable(fresh, { now, targetUrl: URL_A }), true);
+  // Different endpoint — never volunteered.
+  assert.equal(isReplayable(fresh, { now, targetUrl: "ws://127.0.0.1:9181" }), false);
+  // Unattributable entries are refused rather than guessed at.
+  assert.equal(isReplayable({ at: now }, { now, targetUrl: URL_A }), false, "no recorded bridge ⇒ refuse");
+  assert.equal(isReplayable(fresh, { now }), false, "no target bridge ⇒ refuse");
+  assert.equal(isReplayable(null, { now, targetUrl: URL_A }), false);
+  // Age bound: a real drop-and-reconnect takes seconds; anything older is very likely a
+  // different orchestrator that happens to share the address.
+  assert.equal(isReplayable({ url: URL_A, at: now - REPLAY_MAX_AGE_MS - 1 }, { now, targetUrl: URL_A }), false);
+  assert.equal(isReplayable({ url: URL_A, at: now - REPLAY_MAX_AGE_MS }, { now, targetUrl: URL_A }), true);
+  // A negative age (clock moved) fails closed rather than replaying.
+  assert.equal(isReplayable({ url: URL_A, at: now + 5000 }, { now, targetUrl: URL_A }), false);
+  assert.equal(isReplayable({ url: URL_A, at: NaN }, { now, targetUrl: URL_A }), false);
 });
 
 test("the journal's replace() keeps only what it is given, still bounded", () => {
@@ -251,13 +273,18 @@ test("#508 wiring: an undelivered reply is journaled, replayed after hello, and 
   assert.match(src, /lostReplies\.record\(\{/, "an undelivered reply must be journaled");
   assert.match(src, /handleUndeliveredReply\(/, "…and routed to the bounded self-heal");
   assert.match(src, /shouldReRegister\(\{/, "self-heal must consult the bounded decision");
-  // Replay must come AFTER sendHello() on the new socket (the tab must be registered
-  // before its late outcomes arrive).
+  // codex R10 — replay must fire on the real HANDSHAKE, not at bare socket-open: an open
+  // socket only proves something is listening on the port, while the `models` frame proves
+  // a real orchestrator is behind it. The hello already went out at open.
   const openHandler = src.slice(src.indexOf('thisSock.addEventListener("open"'));
-  const helloAt = openHandler.indexOf("sendHello();");
-  const replayAt = openHandler.indexOf("replayLostReplies(thisSock);");
-  assert.notEqual(replayAt, -1, "lost outcomes must be replayed on the next socket");
-  assert.ok(helloAt !== -1 && helloAt < replayAt, "replay must follow the hello");
+  assert.match(openHandler.slice(0, 2000), /sendHello\(\);/, "the hello still rides socket-open");
+  assert.equal(
+    /replayLostReplies\(thisSock\);/.test(src),
+    false,
+    "replay must not fire at bare socket-open",
+  );
+  const markConnected = src.slice(src.indexOf("function markConnected() {"));
+  assert.match(markConnected.slice(0, 1600), /replayLostReplies\(sock\);/, "replay rides the handshake");
 });
 
 test("#508 codex R6: an outcome journaled AFTER the replacement socket replayed is delivered anyway", () => {

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -186,6 +186,37 @@ test("codex R11: hello summaries obey the SAME cross-bridge/age rule as the repl
   );
 });
 
+test("codex R12: replay only ever writes to a socket that PROVED itself with a handshake", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const start = src.indexOf("function replayLostReplies(target) {");
+  assert.notEqual(start, -1);
+  const body = src.slice(start, src.indexOf("\n  }", start));
+  // An OPEN socket only proves something is bound to the port — it can be a different
+  // orchestrator session at the same URL, or a non-orchestrator listener, and it can be
+  // open before its `models` frame arrives. The check lives in the function (not only at
+  // the call sites) so no caller can bypass it.
+  assert.match(
+    body,
+    /if \(!target \|\| target !== handshakenSock \|\| target\.readyState !== WebSocket\.OPEN\) return;/,
+    "replay must require the handshaken socket INSTANCE",
+  );
+  const gateAt = body.indexOf("target !== handshakenSock");
+  const sendAt = body.indexOf("target.send(");
+  assert.ok(gateAt !== -1 && sendAt !== -1 && gateAt < sendAt, "the gate must precede any write");
+  // Identity, not a boolean: a replacement socket is a different object, which is what
+  // closes the "open but not yet handshaken" race.
+  assert.match(src, /handshakenSock = sock;/, "markConnected must record the proven instance");
+  const markConnected = src.slice(src.indexOf("function markConnected() {"));
+  const recordAt = markConnected.indexOf("handshakenSock = sock;");
+  const replayAt = markConnected.indexOf("replayLostReplies(sock);");
+  assert.ok(recordAt !== -1 && replayAt !== -1 && recordAt < replayAt, "record the instance, then replay");
+  // Dropping the socket must forget it too.
+  assert.ok(
+    (src.match(/handshakenSock = null;/g) || []).length >= 3,
+    "setUrl/stop/destroy must all forget the proven socket",
+  );
+});
+
 test("codex R11: the tracker re-baseline aborts if exclusivity was lost across its own frame", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   const start = src.indexOf("async function clearSpuriousOpenModified(wf");

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -119,13 +119,24 @@ test("codex R8: replay never crosses a bridge change — entries for another bri
   const body = src.slice(start, src.indexOf("\n  }", start));
   assert.match(
     body,
-    /if \(entry\.url && entry\.url !== url\) \{\s*\n\s*dropped\+\+;\s*\n\s*continue;/,
+    /if \(entry\.url && entry\.url !== targetUrl\) \{\s*\n\s*dropped\+\+;\s*\n\s*continue;/,
     "an outcome belonging to a previous bridge must never be volunteered to a different agent",
   );
   assert.match(body, /lostReplies\.replace\(keep\)/, "only undeliverable-but-still-ours entries are retried");
   assert.match(body, /Discarded \$\{dropped\}/, "the user must be told what was discarded");
-  // And the record site must stamp the bridge.
-  assert.match(src, /reason: classifyUndeliveredReply\(\{ socketOpen, superseded, sendThrew \}\),[\s\S]{0,200}?\n\s*url,/);
+  // codex R9 — the comparison must use the SOCKET's own bridge, not the mutable current
+  // `url`: setUrl swaps `url` before the old socket closes, so a command finishing on the
+  // retired socket would otherwise be stamped with (and compared against) the NEW bridge.
+  assert.match(body, /const targetUrl = target\?\.__cmcpBridgeUrl \?\? url;/);
+  assert.match(src, /const socketUrl = url;/, "each socket must capture the url it dialed");
+  assert.match(src, /thisSock = new WebSocket\(socketUrl\)/, "…and dial exactly that url");
+  assert.match(src, /thisSock\.__cmcpBridgeUrl = socketUrl;/, "…and carry it for the replay check");
+  assert.match(src, /url: socketUrl,/, "the journal must stamp THIS socket's bridge, not the current one");
+  assert.equal(
+    /at: Date\.now\(\),\s*\n(?:\s*\/\/[^\n]*\n)*\s*url,\s*\n/.test(src),
+    false,
+    "the mutable current url must not be what gets journaled",
+  );
 });
 
 test("the journal's replace() keeps only what it is given, still bounded", () => {

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -27,6 +27,8 @@ import {
   classifyUndeliveredReply,
   describeUndeliveredReply,
   createLostReplyJournal,
+  SENSITIVE_RESULT_CMDS,
+  redactSensitiveReply,
   pruneAttempts,
   shouldReRegister,
   reRegisterExhaustedHint,
@@ -72,6 +74,68 @@ test("the journal keeps the EXACT reply frame (replayable verbatim) but omits it
   j.record({ reply, cmd: "workflow_open", reason: "socket_closed", at: 7 });
   assert.deepEqual(j.list()[0].reply, reply, "the frame must survive intact for a verbatim replay");
   assert.deepEqual(j.summaries(), [{ rid: "abc", cmd: "workflow_open", ok: true, reason: "socket_closed", at: 7 }]);
+});
+
+test("codex R8: a SENSITIVE result is never journaled in the clear (it must not survive to a replay)", () => {
+  // request_secret's result IS the pasted secret; ask_user's is whatever the user typed.
+  // A journaled raw frame is replayed on whatever socket is current later — which can be a
+  // DIFFERENT orchestrator after a backend switch — so the payload must not be kept at all.
+  for (const cmd of ["request_secret", "ask_user"]) {
+    assert.ok(SENSITIVE_RESULT_CMDS.has(cmd), `${cmd} must be classified sensitive`);
+    const j = createLostReplyJournal();
+    const entry = j.record({
+      reply: { rid: "r1", ok: true, result: "sk-live-SUPERSECRET" },
+      cmd,
+      at: 1,
+      url: "ws://127.0.0.1:9180",
+    });
+    assert.equal(entry.redacted, true);
+    assert.equal(entry.ok, false, "a redacted entry must not advertise a success it will not deliver");
+    assert.equal(
+      JSON.stringify(j.list()).includes("SUPERSECRET"),
+      false,
+      "the secret must not exist anywhere in the journal",
+    );
+    assert.match(entry.reply.error, /ask again on the current connection/);
+    assert.equal(entry.reply.rid, "r1", "the refusal must still correlate to the command");
+  }
+});
+
+test("codex R8: a NON-sensitive result is journaled verbatim so it can be replayed as-is", () => {
+  const j = createLostReplyJournal();
+  const reply = { rid: "r2", ok: true, result: { opened: { path: "x.json" } } };
+  const entry = j.record({ reply, cmd: "workflow_open", at: 1, url: "ws://127.0.0.1:9180" });
+  assert.equal(entry.redacted, false);
+  assert.deepEqual(entry.reply, reply);
+  assert.equal(entry.ok, true);
+  assert.equal(entry.url, "ws://127.0.0.1:9180", "the owning bridge must be stamped on the entry");
+  assert.equal(redactSensitiveReply(reply, "workflow_open"), reply, "pass-through must be identity");
+});
+
+test("codex R8: replay never crosses a bridge change — entries for another bridge are DROPPED", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const start = src.indexOf("function replayLostReplies(target) {");
+  assert.notEqual(start, -1);
+  const body = src.slice(start, src.indexOf("\n  }", start));
+  assert.match(
+    body,
+    /if \(entry\.url && entry\.url !== url\) \{\s*\n\s*dropped\+\+;\s*\n\s*continue;/,
+    "an outcome belonging to a previous bridge must never be volunteered to a different agent",
+  );
+  assert.match(body, /lostReplies\.replace\(keep\)/, "only undeliverable-but-still-ours entries are retried");
+  assert.match(body, /Discarded \$\{dropped\}/, "the user must be told what was discarded");
+  // And the record site must stamp the bridge.
+  assert.match(src, /reason: classifyUndeliveredReply\(\{ socketOpen, superseded, sendThrew \}\),[\s\S]{0,200}?\n\s*url,/);
+});
+
+test("the journal's replace() keeps only what it is given, still bounded", () => {
+  const j = createLostReplyJournal({ cap: 3 });
+  for (let i = 0; i < 3; i++) j.record({ reply: { rid: `r${i}`, ok: true }, cmd: "graph_outline" });
+  const kept = j.list().slice(0, 1);
+  assert.equal(j.replace(kept), 1);
+  assert.equal(j.size(), 1);
+  assert.equal(j.list()[0].rid, "r0");
+  assert.equal(j.replace(null), 0, "a non-array clears the journal rather than corrupting it");
 });
 
 test("the journal refuses a frame with no rid (nothing could ever correlate it)", () => {
@@ -205,12 +269,15 @@ test("#508 codex R6: an outcome journaled AFTER the replacement socket replayed 
   );
 });
 
-test("#508 wiring: replay is idempotent — it drains only after every entry went out", () => {
+test("#508 wiring: replay keeps what it could not send, so a partial replay is retried not lost", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   const start = src.indexOf("function replayLostReplies(target) {");
   assert.notEqual(start, -1);
   const body = src.slice(start, src.indexOf("\n  }", start));
-  assert.match(body, /if \(sent === lost\.length\) lostReplies\.drain\(\);/, "a partial replay must be retried, not lost");
+  // An entry that could not be written (socket closed / send threw) goes back in `keep`;
+  // only the delivered ones and the cross-bridge drops leave the journal.
+  assert.match(body, /keep\.push\(entry\);/, "an undeliverable entry must be retained for a later attempt");
+  assert.match(body, /if \(sent \|\| dropped\) lostReplies\.replace\(keep\);/, "a partial replay must be retried, not lost");
   assert.match(body, /target\.readyState !== WebSocket\.OPEN/, "never write to a closed socket");
   // It must not re-enter the journal path (which would recurse through handleUndeliveredReply).
   assert.equal(/lostReplies\.record\(/.test(body), false, "replay must not re-journal, or it would recurse");

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -1,0 +1,176 @@
+// Unit tests for web/js/lib/command-liveness.js — run with `node --test`.
+//
+// #508: the sidebar chat stayed CONNECTED and accepted the user's request, yet EVERY
+// frontend command timed out with no reply from the registered tab — set_todo (5000 ms),
+// graph_outline (6000 ms), workflow_list (6000 ms) — while the orchestrator kept
+// targeting the same wf: id. A row of identical timeouts, forever.
+//
+// The load-bearing invariants locked here:
+//   * a command frame ALWAYS produces a reply attempt on the socket it arrived on, and
+//     no host callback can suppress it (the pre-reply throw, and the superseded-socket
+//     early return, were both silent no-reply paths);
+//   * an undelivered reply is journaled with its ACTUAL cause and replayed, rather than
+//     leaving the caller with the orchestrator's guess that the tab is "frozen";
+//   * self-heal re-registration is BOUNDED, and it can only ever re-advertise THIS tab's
+//     own current identity — retargeting to a different workflow's tab is corruption
+//     class and strictly worse than staying wedged.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  LOST_REPLY_CAP,
+  RE_REGISTER_MAX,
+  RE_REGISTER_WINDOW_MS,
+  classifyUndeliveredReply,
+  describeUndeliveredReply,
+  createLostReplyJournal,
+  pruneAttempts,
+  shouldReRegister,
+  reRegisterExhaustedHint,
+} from "../../web/js/lib/command-liveness.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+// --- honest cause reporting ----------------------------------------------
+
+test("#508: the cause is REPORTED, not guessed", () => {
+  assert.equal(classifyUndeliveredReply({ socketOpen: false }), "socket_closed");
+  assert.equal(classifyUndeliveredReply({ socketOpen: false, superseded: true }), "socket_superseded");
+  assert.equal(classifyUndeliveredReply({ socketOpen: true, sendThrew: true }), "send_failed");
+  assert.equal(classifyUndeliveredReply({ socketOpen: true }), null, "a healthy write has nothing to report");
+});
+
+test("#508: the user-facing line separates 'the command ran' from 'the reply was lost'", () => {
+  const line = describeUndeliveredReply({ cmd: "workflow_open", ok: true, reason: "socket_closed" });
+  assert.match(line, /completed "workflow_open"/);
+  assert.match(line, /unknown outcome, not as a failure to act/);
+  const superseded = describeUndeliveredReply({ cmd: "graph_outline", ok: true, reason: "socket_superseded" });
+  assert.match(superseded, /replaced mid-command/);
+  assert.equal(describeUndeliveredReply(null), "");
+});
+
+// --- the journal ----------------------------------------------------------
+
+test("the lost-reply journal is bounded, keeps the newest, and drains exactly once", () => {
+  const j = createLostReplyJournal();
+  for (let i = 0; i < LOST_REPLY_CAP + 4; i++) {
+    j.record({ reply: { rid: `r${i}`, ok: true, result: {} }, cmd: "graph_outline", at: i });
+  }
+  assert.equal(j.size(), LOST_REPLY_CAP);
+  assert.equal(j.list()[j.size() - 1].rid, `r${LOST_REPLY_CAP + 3}`);
+  assert.equal(j.drain().length, LOST_REPLY_CAP);
+  assert.equal(j.size(), 0, "a drained journal must not replay again");
+});
+
+test("the journal keeps the EXACT reply frame (replayable verbatim) but omits it from summaries", () => {
+  const j = createLostReplyJournal();
+  const reply = { rid: "abc", ok: true, result: { opened: { path: "x.json" } } };
+  j.record({ reply, cmd: "workflow_open", reason: "socket_closed", at: 7 });
+  assert.deepEqual(j.list()[0].reply, reply, "the frame must survive intact for a verbatim replay");
+  assert.deepEqual(j.summaries(), [{ rid: "abc", cmd: "workflow_open", ok: true, reason: "socket_closed", at: 7 }]);
+});
+
+test("the journal refuses a frame with no rid (nothing could ever correlate it)", () => {
+  const j = createLostReplyJournal();
+  assert.equal(j.record({ reply: { ok: true }, cmd: "x" }), null);
+  assert.equal(j.record({ cmd: "x" }), null);
+  assert.equal(j.size(), 0);
+});
+
+// --- bounded self-heal ----------------------------------------------------
+
+test("#508: self-heal is BOUNDED — never a re-registration storm", () => {
+  const now = 100000;
+  const base = { socketOpen: true, lostCount: 1, now };
+  assert.equal(shouldReRegister({ ...base, attempts: [] }), true);
+  const spent = Array.from({ length: RE_REGISTER_MAX }, (_, i) => now - i * 100);
+  assert.equal(shouldReRegister({ ...base, attempts: spent }), false, "budget spent inside the window");
+  // …and the budget REFRESHES once the window has rolled past.
+  const old = spent.map((t) => t - RE_REGISTER_WINDOW_MS - 1);
+  assert.equal(shouldReRegister({ ...base, attempts: old }), true);
+});
+
+test("#508: no live socket ⇒ no re-registration (the reconnect path owns that recovery)", () => {
+  assert.equal(shouldReRegister({ socketOpen: false, lostCount: 3, attempts: [], now: 1 }), false);
+});
+
+test("#508: nothing lost ⇒ no re-registration (never hello on speculation)", () => {
+  assert.equal(shouldReRegister({ socketOpen: true, lostCount: 0, attempts: [], now: 1 }), false);
+});
+
+test("pruneAttempts drops only entries outside the window and never mutates the input", () => {
+  const now = 50000;
+  const input = [now - 1, now - RE_REGISTER_WINDOW_MS - 1, now - 10];
+  const out = pruneAttempts(input, now);
+  assert.deepEqual(out, [now - 1, now - 10]);
+  assert.equal(input.length, 3, "input must be untouched");
+  assert.deepEqual(pruneAttempts(null, now), []);
+});
+
+test("#508: the exhausted hint is an ACTIONABLE instruction, not another timeout", () => {
+  const hint = reRegisterExhaustedHint();
+  assert.match(hint, /Reconnect/);
+  assert.match(hint, /reload the ComfyUI page/);
+});
+
+// --- wiring contract in the panel -----------------------------------------
+
+test("#508 wiring: the turn-activity host callback can no longer suppress a reply", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const at = src.indexOf("onCommandReceived?.();");
+  assert.notEqual(at, -1, "the command handler must still mark turn activity");
+  // It must sit inside its OWN try, so a throw is contained rather than aborting the
+  // async listener before the reply is ever built.
+  const before = src.slice(Math.max(0, at - 200), at);
+  assert.match(before, /try \{\s*$/, "onCommandReceived must be wrapped in its own try");
+  const after = src.slice(at, at + 260);
+  assert.match(after, /catch \(err\) \{[\s\S]*onCommandReceived threw/, "the throw must be caught and logged, not swallowed silently");
+});
+
+test("#508 wiring: a SUPERSEDED socket still gets its reply — only the UI continuation is dropped", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const supersededAt = src.indexOf("const superseded = !isActive();");
+  assert.notEqual(supersededAt, -1, "the instance guard must be captured, not used as an early return");
+  const block = src.slice(supersededAt, supersededAt + 2200);
+  const sendAt = block.indexOf("thisSock.send(JSON.stringify(reply));");
+  const gateAt = block.indexOf("if (superseded) return;");
+  assert.notEqual(sendAt, -1, "the reply must still be written to the socket it arrived on");
+  assert.notEqual(gateAt, -1, "the UI continuation must still be gated on the instance guard");
+  assert.ok(sendAt < gateAt, "the reply must be sent BEFORE the superseded early return");
+  // And the pre-#508 shape (returning before the reply) must not come back.
+  assert.equal(
+    /if \(!isActive\(\)\) return;\s*\n\s*try \{\s*\n\s*if \(thisSock\.readyState/.test(src),
+    false,
+    "the superseded early-return must not precede the reply write again",
+  );
+});
+
+test("#508 wiring: an undelivered reply is journaled, replayed after hello, and self-heals boundedly", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /lostReplies\.record\(\{/, "an undelivered reply must be journaled");
+  assert.match(src, /handleUndeliveredReply\(/, "…and routed to the bounded self-heal");
+  assert.match(src, /shouldReRegister\(\{/, "self-heal must consult the bounded decision");
+  // Replay must come AFTER sendHello() on the new socket (the tab must be registered
+  // before its late outcomes arrive).
+  const openHandler = src.slice(src.indexOf('thisSock.addEventListener("open"'));
+  const helloAt = openHandler.indexOf("sendHello();");
+  const replayAt = openHandler.indexOf("replayLostReplies(thisSock);");
+  assert.notEqual(replayAt, -1, "lost outcomes must be replayed on the next socket");
+  assert.ok(helloAt !== -1 && helloAt < replayAt, "replay must follow the hello");
+});
+
+test("#508 wiring: self-heal re-registers via sendHello ONLY — it can never pick another tab", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const start = src.indexOf("function handleUndeliveredReply(entry) {");
+  assert.notEqual(start, -1);
+  const body = src.slice(start, src.indexOf("\n  }", start));
+  assert.match(body, /\bsendHello\(\);/, "re-registration must reuse the existing hello path");
+  // Nothing in this path may reference a tab id it did not derive from the live active
+  // workflow — no id argument, no list lookup, no adoption of another tab.
+  assert.equal(/tab_id|tabMigrations|attach_tab|openWorkflows/.test(body), false, "self-heal must not select a target tab");
+  assert.match(body, /reRegisterExhaustedHint\(\)/, "an exhausted budget must surface a user action");
+});

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -161,6 +161,44 @@ test("codex R10: isReplayable demands the SAME bridge and a recent entry, and fa
   assert.equal(isReplayable({ url: URL_A, at: NaN }, { now, targetUrl: URL_A }), false);
 });
 
+test("codex R11: hello summaries obey the SAME cross-bridge/age rule as the replay", () => {
+  // The summaries ride the hello, so an unfiltered list would tell a bridge that never
+  // owned these commands their ids, names and outcomes — even though replayLostReplies
+  // correctly withholds the replies themselves.
+  const j = createLostReplyJournal();
+  const now = 1_000_000;
+  j.record({ reply: { rid: "mine", ok: true }, cmd: "graph_outline", at: now - 1000, url: "ws://a" });
+  j.record({ reply: { rid: "theirs", ok: true }, cmd: "graph_outline", at: now - 1000, url: "ws://b" });
+  j.record({ reply: { rid: "ancient", ok: true }, cmd: "graph_outline", at: now - REPLAY_MAX_AGE_MS - 1, url: "ws://a" });
+  assert.deepEqual(
+    j.summaries({ now, targetUrl: "ws://a" }).map((e) => e.rid),
+    ["mine"],
+    "only this bridge's recent outcomes may be advertised",
+  );
+  // No target ⇒ unfiltered (the journal's own bookkeeping view).
+  assert.equal(j.summaries().length, 3);
+
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(
+    src,
+    /lostReplies\.summaries\(\{\s*\n\s*now: Date\.now\(\),\s*\n\s*targetUrl: sock\?\.__cmcpBridgeUrl \?\? url,\s*\n\s*\}\)/,
+    "sendHello must filter the summaries by THIS socket's bridge",
+  );
+});
+
+test("codex R11: the tracker re-baseline aborts if exclusivity was lost across its own frame", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const start = src.indexOf("async function clearSpuriousOpenModified(wf");
+  assert.notEqual(start, -1);
+  const body = src.slice(start, start + 1400);
+  const frameAt = body.indexOf("await nextFrame();");
+  const guardAt = body.indexOf('if (typeof stillOwns === "function" && !stillOwns()) return;');
+  const captureAt = body.indexOf("captureCanvasState");
+  assert.ok(frameAt !== -1 && guardAt !== -1 && captureAt !== -1);
+  // Checking before the await is not enough — the frame IS the gap in which an edit lands.
+  assert.ok(frameAt < guardAt && guardAt < captureAt, "the ownership check must sit AFTER the frame");
+});
+
 test("the journal's replace() keeps only what it is given, still bounded", () => {
   const j = createLostReplyJournal({ cap: 3 });
   for (let i = 0; i < 3; i++) j.record({ reply: { rid: `r${i}`, ok: true }, cmd: "graph_outline" });

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -185,6 +185,37 @@ test("#508 wiring: an undelivered reply is journaled, replayed after hello, and 
   assert.ok(helloAt !== -1 && helloAt < replayAt, "replay must follow the hello");
 });
 
+test("#508 codex R6: an outcome journaled AFTER the replacement socket replayed is delivered anyway", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const start = src.indexOf("function handleUndeliveredReply(entry) {");
+  assert.notEqual(start, -1);
+  const body = src.slice(start, src.indexOf("\n  }", start));
+  // The replacement socket replays ONCE, at open. A long command still running on the
+  // retired socket finishes after that, so the journal was empty when the replay fired —
+  // without this the entry would wait for a reconnect that may never come.
+  assert.match(body, /replayLostReplies\(sock\);/, "a live socket must receive the outcome immediately");
+  // …and it must NOT be gated on the re-registration budget: telling the truth is not a retry.
+  const replayAt = body.indexOf("replayLostReplies(sock);");
+  const elseAt = body.indexOf("} else {");
+  assert.ok(elseAt !== -1 && replayAt > body.indexOf("reRegisterExhaustedHint()"), "replay must follow both branches");
+  assert.equal(
+    /\} else \{[\s\S]*replayLostReplies\(sock\);[\s\S]*\}\s*$/.test(body),
+    false,
+    "replay must sit outside the budget branches, not inside one",
+  );
+});
+
+test("#508 wiring: replay is idempotent — it drains only after every entry went out", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const start = src.indexOf("function replayLostReplies(target) {");
+  assert.notEqual(start, -1);
+  const body = src.slice(start, src.indexOf("\n  }", start));
+  assert.match(body, /if \(sent === lost\.length\) lostReplies\.drain\(\);/, "a partial replay must be retried, not lost");
+  assert.match(body, /target\.readyState !== WebSocket\.OPEN/, "never write to a closed socket");
+  // It must not re-enter the journal path (which would recurse through handleUndeliveredReply).
+  assert.equal(/lostReplies\.record\(/.test(body), false, "replay must not re-journal, or it would recurse");
+});
+
 test("#508 wiring: self-heal re-registers via sendHello ONLY — it can never pick another tab", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   const start = src.indexOf("function handleUndeliveredReply(entry) {");

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -407,9 +407,9 @@ test("#442 codex P1: the destructive re-read freezes canvas interaction and ALWA
   // The clean sample authorizes the load, but loadGraphData is awaited — an edit made
   // while it yields would be destroyed by a reload nobody asked for.
   const lockAt = body.indexOf("canvasView.allow_interaction = false;");
-  const firstRebaselineAt = body.indexOf("await clearSpuriousOpenModified(target);");
+  const firstRebaselineAt = body.indexOf("await clearSpuriousOpenModified(target, {");
   const loadAt = body.indexOf("await app.loadGraphData(diskGraph");
-  const rebaselineAt = body.indexOf("await clearSpuriousOpenModified(target);", loadAt);
+  const rebaselineAt = body.indexOf("await clearSpuriousOpenModified(target, {", loadAt);
   const restoreAt = body.indexOf("canvasView.allow_interaction = priorInteraction;");
   assert.ok(lockAt !== -1 && loadAt !== -1 && restoreAt !== -1, "the load must be bracketed by an interaction lock");
   // clearSpuriousOpenModified awaits a frame and then RE-BASELINES the change tracker, so
@@ -453,7 +453,7 @@ test("#442 codex R7: a tab that arrived DIRTY is never re-baselined and never re
   assert.ok(wasDirtyAt < openAt, "…BEFORE any await, since it cannot be recovered afterwards");
   assert.match(
     body,
-    /if \(!wasDirty && ownsWorkflowReloadGuard\(reloadGuardToken\)\) \{[\s\S]{0,80}?await clearSpuriousOpenModified\(target\);/,
+    /if \(!wasDirty && ownsWorkflowReloadGuard\(reloadGuardToken\)\) \{[\s\S]{0,80}?await clearSpuriousOpenModified\(target, \{/,
     "a genuinely dirty tab must never be re-baselined, nor one we no longer hold exclusively",
   );
   // BOTH reload gates must require the pre-open snapshot to be clean too.

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -453,7 +453,7 @@ test("#442 codex R7: a tab that arrived DIRTY is never re-baselined and never re
   assert.ok(wasDirtyAt < openAt, "…BEFORE any await, since it cannot be recovered afterwards");
   assert.match(
     body,
-    /if \(!wasDirty && ownsWorkflowReloadGuard\(reloadGuardToken\)\) \{[\s\S]{0,400}?await clearSpuriousOpenModified\(target, \{/,
+    /if \(\s*!wasDirty &&\s*\(!wasOpen \|\| priorInteraction !== null\) &&\s*ownsWorkflowReloadGuard\(reloadGuardToken\)\s*\) \{[\s\S]{0,400}?await clearSpuriousOpenModified\(target, \{/,
     "a genuinely dirty tab must never be re-baselined, nor one we no longer hold exclusively",
   );
   // BOTH reload gates must require the pre-open snapshot to be clean too.
@@ -622,6 +622,39 @@ test("#442 codex P1: with NO reliable freeze available, the destructive reload i
   assert.match(body, /could not be protected against a concurrent edit and was skipped/);
 });
 
+test("#442 round-2: with NO freeze available the tracker is NOT re-baselined either (no silent clean-slate)", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const body = handlerBody(src, "async workflow_open({");
+  // clearSpuriousOpenModified awaits a frame, then captures the canvas as the CLEAN
+  // baseline and forces isModified=false. The canvas freeze (allow_interaction) is what
+  // makes that frame safe. On a frontend WITHOUT the flag the reload is skipped for
+  // exactly that reason (priorInteraction === null) — so the tracker must not be
+  // re-baselined either: an edit landing in the unprotected frame would be adopted as
+  // clean, erasing unsaved-work protection and inviting later silent loss. (A first-time
+  // open — !wasOpen — can never reload, so its spurious-flag cleanup is unchanged.)
+  const skipGate = body.indexOf("if (staleInfo.reload && !dirtyNow && !wasDirty && priorInteraction === null)");
+  const firstRebaseline = body.indexOf("await clearSpuriousOpenModified(target, {");
+  assert.notEqual(skipGate, -1, "the no-freeze skip gate must exist");
+  assert.notEqual(firstRebaseline, -1, "the post-repaint re-baseline must exist");
+  assert.ok(firstRebaseline < skipGate, "fixture order: the re-baseline precedes the reload decision");
+  assert.match(
+    body,
+    /if \(\s*!wasDirty &&\s*\(!wasOpen \|\| priorInteraction !== null\) &&\s*ownsWorkflowReloadGuard\(reloadGuardToken\)\s*\) \{[\s\S]{0,400}?await clearSpuriousOpenModified\(target, \{/,
+    "the pre-reload re-baseline must be gated on the freeze holding — the same condition whose absence skips the reload",
+  );
+  // The only OTHER re-baseline is the post-reload one, and it stays gated on the reload
+  // actually having run: `reloaded = true` precedes it, under the same exclusive window.
+  const reloadedAt = body.indexOf("reloaded = true;");
+  const secondRebaseline = body.indexOf("await clearSpuriousOpenModified(target, {", firstRebaseline + 1);
+  assert.ok(reloadedAt !== -1 && reloadedAt < secondRebaseline, "the second re-baseline must follow a completed reload");
+  // Two call sites, both gated — no third, ungated re-baseline may creep in.
+  assert.equal(
+    (body.match(/await clearSpuriousOpenModified\(target, \{/g) || []).length,
+    2,
+    "workflow_open re-baselines the tracker exactly twice, each behind a gate",
+  );
+});
+
 test("#402 codex P1: workflow_new records UNKNOWN (never a clean failure) once creation started", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   const body = handlerBody(src, "async workflow_new({");
@@ -643,6 +676,28 @@ test("#402 codex P1: workflow_new records UNKNOWN (never a clean failure) once c
     true,
     "a post-creation failure must be journaled as UNKNOWN",
   );
+});
+
+test("#402 round-2: once NewBlankWorkflow has run, the guidance forbids a retry (no SECOND blank tab)", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const body = handlerBody(src, "async workflow_new({");
+  const created = body.indexOf('await mgr.command.execute("Comfy.NewBlankWorkflow");');
+  assert.notEqual(created, -1);
+  // Retrying workflow_new creates a SECOND blank tab and routes later edits to the wrong
+  // workflow. Once creation has run the receipt truthfully records applied:"unknown" — so
+  // the guidance must match it: do NOT retry, check workflow_list / canvas state first.
+  const afterCreate = stripComments(body.slice(created));
+  const errBlock = afterCreate.match(/const error =\s*\n?([\s\S]*?);/);
+  assert.ok(errBlock, "the post-creation failure must build an explicit message");
+  // Reassemble the concatenated literal so the check reads the message the caller gets.
+  const msg = [...errBlock[1].matchAll(/"([^"\n]*)"/g)].map((m) => m[1]).join("");
+  assert.doesNotMatch(
+    msg,
+    /(^|[.!?]\s+)Retry\b/,
+    `no sentence may open with a blanket Retry once the blank tab exists: "${msg}"`,
+  );
+  assert.match(msg, /Do NOT retry/i, "the guidance must forbid the retry outright");
+  assert.match(msg, /workflow_list/, "…and point at workflow_list / the canvas state instead");
 });
 
 test("#570 P0b: the #442 re-read must KEEP this tab's instance identity (no mid-open fork)", () => {

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -317,9 +317,9 @@ test("#402 wiring: workflow_open journals BOTH outcomes, and every early throw i
 test("#442 defect-2 wiring: the re-read is gated on a FRESH dirty re-check (no silent data loss)", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   const body = handlerBody(src, "async workflow_open({");
-  const dirtyAt = body.indexOf("const dirtyNow = !!target.isModified;");
-  const decideAt = body.indexOf("const staleInfo = decideOpenStaleness({");
-  const reloadAt = body.indexOf("if (staleInfo.reload && !dirtyNow)");
+  const dirtyAt = body.indexOf("dirtyNow = !!target.isModified;");
+  const decideAt = body.indexOf("staleInfo = decideOpenStaleness({");
+  const reloadAt = body.indexOf("if (staleInfo.reload && !dirtyNow");
   assert.notEqual(dirtyAt, -1, "isModified must be re-read after the disk await, not reused from before it");
   assert.notEqual(reloadAt, -1, "the re-read must be gated");
   assert.ok(dirtyAt < decideAt && decideAt < reloadAt, "order: re-check dirty → decide → maybe reload");
@@ -338,18 +338,29 @@ test("#442 codex P1: the destructive re-read freezes canvas interaction and ALWA
   // The clean sample authorizes the load, but loadGraphData is awaited — an edit made
   // while it yields would be destroyed by a reload nobody asked for.
   const lockAt = body.indexOf("canvasView.allow_interaction = false;");
+  const firstRebaselineAt = body.indexOf("await clearSpuriousOpenModified(target);");
   const loadAt = body.indexOf("await app.loadGraphData(diskGraph");
   const rebaselineAt = body.indexOf("await clearSpuriousOpenModified(target);", loadAt);
   const restoreAt = body.indexOf("canvasView.allow_interaction = priorInteraction;");
   assert.ok(lockAt !== -1 && loadAt !== -1 && restoreAt !== -1, "the load must be bracketed by an interaction lock");
   // clearSpuriousOpenModified awaits a frame and then RE-BASELINES the change tracker, so
-  // an edit made during it would be adopted as "not modified" and later dropped silently.
-  // The freeze must therefore cover the re-baseline too, not just the load (codex).
+  // an edit made during it is absorbed as the new CLEAN baseline — which would make the
+  // dirty gate read false and authorize the reload to overwrite that edit. The freeze must
+  // therefore start BEFORE the FIRST (post-switch) re-baseline, not just before the load,
+  // and must still be held across the second one (codex R2 + R4).
+  assert.notEqual(firstRebaselineAt, -1, "the open must re-baseline after its repaint");
   assert.notEqual(rebaselineAt, -1, "the reload must re-baseline the change tracker");
   assert.ok(
-    lockAt < loadAt && loadAt < rebaselineAt && rebaselineAt < restoreAt,
-    "lock → load → re-baseline → restore (the freeze must span the re-baseline)",
+    lockAt < firstRebaselineAt,
+    "the freeze must start before the FIRST re-baseline, whose frame could otherwise absorb an edit",
   );
+  assert.ok(
+    firstRebaselineAt < loadAt && loadAt < rebaselineAt && rebaselineAt < restoreAt,
+    "lock → repaint/re-baseline → disk decision → load → re-baseline → restore",
+  );
+  // The dirty sample must live INSIDE the frozen region.
+  const dirtySampleAt = body.indexOf("dirtyNow = !!target.isModified;");
+  assert.ok(lockAt < dirtySampleAt && dirtySampleAt < restoreAt, "the dirty sample must be taken under the freeze");
   // The restore must live in a `finally`, so a throwing load can never strand a frozen canvas.
   const tail = body.slice(loadAt, restoreAt + 200);
   assert.match(tail, /\} finally \{[\s\S]*allow_interaction = priorInteraction;/, "the restore must be in a finally");
@@ -417,4 +428,10 @@ test("#402 wiring: workflow_list exposes the receipt + the POSITIVE trust flag",
   assert.match(body, /active_confirmed: !activeMaybeStale/, "trust must be reported positively, not inferred from silence");
   assert.match(body, /last_open: lastOpen/, "the last open receipt must be reachable after a lost reply");
   assert.match(body, /summarizeOpenReceipt\(latestOpenReceipt\(openReceipts\)/);
+  // The consumer is in ANOTHER process, so the reading rule ships WITH the data — a
+  // receipt that merely names the right workflow is the most over-readable thing here.
+  assert.match(body, /answers_only_command_rid: lastOpenReceipt\.rid/);
+  assert.match(body, /interpretation:/, "last_open must state how it may be read");
+  assert.match(body, /answers ONLY for the command/);
+  assert.match(body, /do not infer success from `active` matching your target/);
 });

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -453,8 +453,8 @@ test("#442 codex R7: a tab that arrived DIRTY is never re-baselined and never re
   assert.ok(wasDirtyAt < openAt, "…BEFORE any await, since it cannot be recovered afterwards");
   assert.match(
     body,
-    /if \(!wasDirty\) await clearSpuriousOpenModified\(target\);/,
-    "a genuinely dirty tab must never be re-baselined",
+    /if \(!wasDirty && ownsWorkflowReloadGuard\(reloadGuardToken\)\) \{[\s\S]{0,80}?await clearSpuriousOpenModified\(target\);/,
+    "a genuinely dirty tab must never be re-baselined, nor one we no longer hold exclusively",
   );
   // BOTH reload gates must require the pre-open snapshot to be clean too.
   const gates = [...body.matchAll(/if \(staleInfo\.reload && !dirtyNow[^)]*\)/g)].map((m) => m[0]);
@@ -471,16 +471,21 @@ test("#442 codex R9: the switch+reload holds a critical section that REFUSES con
   // A valid graph_* command landing mid-reload is either overwritten by the load or —
   // worse — recorded as CLEAN by the tracker re-baseline, so the next out-of-band disk
   // change discards it with no conflict shown.
-  const acquireAt = body.indexOf("workflowReloadGuard = {");
+  const acquireAt = body.indexOf("acquireWorkflowReloadGuard(");
   const openAt = body.indexOf("await s.openWorkflow(target);");
-  const releaseAt = body.indexOf("workflowReloadGuard = null;");
+  const releaseAt = body.indexOf("releaseWorkflowReloadGuard(reloadGuardToken);");
   assert.ok(acquireAt !== -1 && releaseAt !== -1, "the section must be acquired and released");
   assert.ok(acquireAt < openAt, "held from before the switch, so the whole mutating sequence is covered");
   assert.ok(openAt < releaseAt);
   // Release must be in the SAME finally as the canvas restore — a throw must never leave
   // the tab refusing every command.
   const tail = body.slice(body.indexOf("} finally {", openAt));
-  assert.match(tail, /workflowReloadGuard = null;[\s\S]{0,200}allow_interaction = priorInteraction;/);
+  assert.match(tail, /releaseWorkflowReloadGuard\(reloadGuardToken\);[\s\S]{0,200}allow_interaction = priorInteraction;/);
+  // codex R10 — token-scoped: an expired-then-superseded holder must not release a NEWER
+  // holder's section, and must not keep mutating once it has lost it.
+  assert.match(src, /if \(workflowReloadGuard && workflowReloadGuard\.token === token\) workflowReloadGuard = null;/);
+  assert.match(body, /!ownsWorkflowReloadGuard\(reloadGuardToken\)/, "losing the section must abort the destructive reload");
+  assert.match(body, /lost its exclusive switch\/reload window/);
 
   // The dispatcher must refuse executors while it is held — nothing applied, retryable.
   const guardAt = src.indexOf("const reloadGuard = activeWorkflowReloadGuard();");

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -464,6 +464,35 @@ test("#442 codex R7: a tab that arrived DIRTY is never re-baselined and never re
   assert.match(body, /: dirtyNow \|\| wasDirty/, "a pre-open dirty tab must be reported as a CONFLICT");
 });
 
+test("#442 codex R9: the switch+reload holds a critical section that REFUSES concurrent commands", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const body = handlerBody(src, "async workflow_open({");
+  // Freezing the canvas keeps the USER out of the window; the bridge is a second writer.
+  // A valid graph_* command landing mid-reload is either overwritten by the load or —
+  // worse — recorded as CLEAN by the tracker re-baseline, so the next out-of-band disk
+  // change discards it with no conflict shown.
+  const acquireAt = body.indexOf("workflowReloadGuard = {");
+  const openAt = body.indexOf("await s.openWorkflow(target);");
+  const releaseAt = body.indexOf("workflowReloadGuard = null;");
+  assert.ok(acquireAt !== -1 && releaseAt !== -1, "the section must be acquired and released");
+  assert.ok(acquireAt < openAt, "held from before the switch, so the whole mutating sequence is covered");
+  assert.ok(openAt < releaseAt);
+  // Release must be in the SAME finally as the canvas restore — a throw must never leave
+  // the tab refusing every command.
+  const tail = body.slice(body.indexOf("} finally {", openAt));
+  assert.match(tail, /workflowReloadGuard = null;[\s\S]{0,200}allow_interaction = priorInteraction;/);
+
+  // The dispatcher must refuse executors while it is held — nothing applied, retryable.
+  const guardAt = src.indexOf("const reloadGuard = activeWorkflowReloadGuard();");
+  const execAt = src.indexOf("result = await executor(msg);");
+  assert.notEqual(guardAt, -1, "the command dispatcher must consult the section");
+  assert.ok(guardAt < execAt, "…BEFORE running the executor");
+  const refusal = src.slice(guardAt, execAt);
+  assert.match(refusal, /was NOT applied — nothing changed\. Retry in a moment\./);
+  // A stuck guard must age out rather than wedge the tab forever.
+  assert.match(src, /Date\.now\(\) - workflowReloadGuard\.since > WORKFLOW_RELOAD_GUARD_MAX_MS/);
+});
+
 test("#442 codex P1: with NO reliable freeze available, the destructive reload is SKIPPED", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   const body = handlerBody(src, "async workflow_open({");

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -453,7 +453,7 @@ test("#442 codex R7: a tab that arrived DIRTY is never re-baselined and never re
   assert.ok(wasDirtyAt < openAt, "…BEFORE any await, since it cannot be recovered afterwards");
   assert.match(
     body,
-    /if \(!wasDirty && ownsWorkflowReloadGuard\(reloadGuardToken\)\) \{[\s\S]{0,80}?await clearSpuriousOpenModified\(target, \{/,
+    /if \(!wasDirty && ownsWorkflowReloadGuard\(reloadGuardToken\)\) \{[\s\S]{0,400}?await clearSpuriousOpenModified\(target, \{/,
     "a genuinely dirty tab must never be re-baselined, nor one we no longer hold exclusively",
   );
   // BOTH reload gates must require the pre-open snapshot to be clean too.
@@ -496,6 +496,117 @@ test("#442 codex R9: the switch+reload holds a critical section that REFUSES con
   assert.match(refusal, /was NOT applied — nothing changed\. Retry in a moment\./);
   // A stuck guard must age out rather than wedge the tab forever.
   assert.match(src, /Date\.now\(\) - workflowReloadGuard\.since > WORKFLOW_RELOAD_GUARD_MAX_MS/);
+});
+
+// The reload-guard block (let/const + the five functions) lives inline in
+// comfyui-mcp-panel.js, so — per the "real panel source" extraction convention of
+// graph-resize-node.test.mjs — it is regexed out of the file and evaluated with a FAKE
+// Date injected, letting the tests drive the ACTUAL shipped logic across the 30s ceiling.
+const reloadGuardMatch = readFileSync(PANEL_JS, "utf8").match(
+  /let workflowReloadGuard = null;[\s\S]*?function activeWorkflowReloadGuard\(\) \{[\s\S]*?\n\}/,
+);
+assert.ok(reloadGuardMatch, "could not locate the workflow reload guard block in panel source");
+
+/** Build a fresh guard section from the REAL panel source, with time driven by `now.t`. */
+function realReloadGuard(now) {
+  const factory = new Function(
+    "Date",
+    `${reloadGuardMatch[0]}\nreturn { acquireWorkflowReloadGuard, releaseWorkflowReloadGuard, ` +
+      `beginWorkflowReloadStep, endWorkflowReloadStep, ownsWorkflowReloadGuard, activeWorkflowReloadGuard };`,
+  );
+  return factory({ now: () => now.t });
+}
+
+test("#442 DATA-LOSS: the guard CANNOT expire while a reload is genuinely in flight", () => {
+  const now = { t: 1_000_000 };
+  const g = realReloadGuard(now);
+  const token = g.acquireWorkflowReloadGuard("wf:a.json");
+  // The reload's loadGraphData await starts. Pre-fix, the 30s defensive ceiling fired
+  // DURING this await: activeWorkflowReloadGuard() returned null, the dispatcher's fence
+  // dropped, a graph command ran and was ACKNOWLEDGED — and the late-completing load then
+  // overwrote that edit. The guard is now tied to the step's settle instead.
+  assert.equal(g.beginWorkflowReloadStep(token), true, "the owner may mark a step in flight");
+  now.t += 31_000; // past WORKFLOW_RELOAD_GUARD_MAX_MS, load still awaiting
+  const held = g.activeWorkflowReloadGuard();
+  assert.ok(held, "a step in flight must SUSPEND the ageing ceiling — the fence stays up");
+  assert.equal(held.token, token, "…for the SAME holder");
+  assert.equal(
+    g.ownsWorkflowReloadGuard(token),
+    true,
+    "the reload's post-await ownership re-check still passes, so it may re-baseline",
+  );
+  // The load settles; the idle ceiling runs from the SETTLE, not from acquire, so a long
+  // multi-step section cannot expire in the synchronous gap between two of its steps.
+  g.endWorkflowReloadStep(token);
+  now.t += 29_000;
+  assert.ok(g.activeWorkflowReloadGuard(), "idle time is measured from the last step's settle");
+  // …and the fence comes down ONLY through the open's own finally.
+  g.releaseWorkflowReloadGuard(token);
+  assert.equal(g.activeWorkflowReloadGuard(), null, "released by its owner — commands may run again");
+});
+
+test("#442 DATA-LOSS: the defensive ceiling still ages out a guard stuck BETWEEN steps", () => {
+  const now = { t: 1_000_000 };
+  const g = realReloadGuard(now);
+  const token = g.acquireWorkflowReloadGuard("wf:a.json");
+  g.beginWorkflowReloadStep(token);
+  g.endWorkflowReloadStep(token);
+  // No step in flight and no settle for 30s+ — the holder must have VANISHED without its
+  // finally; age the guard out rather than wedge every command in the tab.
+  now.t += 31_000;
+  assert.equal(g.activeWorkflowReloadGuard(), null, "a guard idle past the ceiling still ages out");
+  assert.equal(g.ownsWorkflowReloadGuard(token), false, "an outlived holder's re-checks fail closed");
+  assert.equal(g.beginWorkflowReloadStep(token), false, "a non-owner must not start a step");
+  // Token scoping is intact: the stale holder must not release a NEWER section.
+  const newer = g.acquireWorkflowReloadGuard("wf:b.json");
+  g.releaseWorkflowReloadGuard(token);
+  assert.equal(g.activeWorkflowReloadGuard()?.token, newer, "a stale holder cannot release the newer section");
+  // A balanced begin/finally-end never strands a pending hold.
+  assert.equal(g.beginWorkflowReloadStep(newer), true);
+  g.endWorkflowReloadStep(newer);
+  g.endWorkflowReloadStep(newer); // over-ending is a no-op, never negative
+  now.t += 31_000;
+  assert.equal(g.activeWorkflowReloadGuard(), null, "balanced begin/end leaves the idle ceiling working");
+});
+
+test("#442 DATA-LOSS: every mutating await of the section is held across its own await", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const body = handlerBody(src, "async workflow_open({");
+  const begins = (body.match(/beginWorkflowReloadStep\(reloadGuardToken\);/g) || []).length;
+  const ends = (body.match(/endWorkflowReloadStep\(reloadGuardToken\);/g) || []).length;
+  assert.ok(begins >= 4, `the switch, repaint, reload and re-baseline awaits must each be held (got ${begins})`);
+  assert.equal(begins, ends, "every held step needs its own end (balanced via finally)");
+  // THE finding's case — the destructive disk reload: begin before the await, end in a
+  // finally after it, so neither a slow load nor a throwing one can drop/strand the fence.
+  const loadAt = body.indexOf("await app.loadGraphData(diskGraph");
+  assert.notEqual(loadAt, -1);
+  const beginAt = body.lastIndexOf("beginWorkflowReloadStep(reloadGuardToken);", loadAt);
+  const endAt = body.indexOf("endWorkflowReloadStep(reloadGuardToken);", loadAt);
+  assert.ok(beginAt !== -1 && beginAt < loadAt, "the reload await must start INSIDE a held step");
+  assert.ok(loadAt < endAt, "…and the step must end only AFTER the load settles");
+  assert.match(
+    body.slice(loadAt, endAt + 60),
+    /\} finally \{\s*endWorkflowReloadStep\(reloadGuardToken\);\s*\}/,
+    "the step must end in a finally, so a throwing load cannot strand the fence",
+  );
+  // The repaint load has the same clobber shape (it overwrites the canvas with the tab's
+  // pre-edit buffer), so it must be held too.
+  const repaintAt = body.indexOf("await app.loadGraphData(JSON.parse(JSON.stringify(st))");
+  assert.notEqual(repaintAt, -1);
+  const repaintBegin = body.lastIndexOf("beginWorkflowReloadStep(reloadGuardToken);", repaintAt);
+  const repaintEnd = body.indexOf("endWorkflowReloadStep(reloadGuardToken);", repaintAt);
+  assert.ok(repaintBegin !== -1 && repaintBegin < repaintAt && repaintAt < repaintEnd, "the repaint await must be held too");
+  // The mechanism: expiry requires NO step in flight, and ending a step rearms the clock.
+  assert.match(
+    src,
+    /workflowReloadGuard\.pending === 0 &&[\s\S]{0,80}?Date\.now\(\) - workflowReloadGuard\.since > WORKFLOW_RELOAD_GUARD_MAX_MS/,
+    "the ageing ceiling must be suspended while any step is in flight",
+  );
+  assert.match(
+    src,
+    /workflowReloadGuard\.pending -= 1;[\s\S]{0,80}?workflowReloadGuard\.since = Date\.now\(\);/,
+    "ending a step must rearm the idle clock",
+  );
 });
 
 test("#442 codex P1: with NO reliable freeze available, the destructive reload is SKIPPED", () => {

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -453,7 +453,7 @@ test("#442 codex R7: a tab that arrived DIRTY is never re-baselined and never re
   assert.ok(wasDirtyAt < openAt, "…BEFORE any await, since it cannot be recovered afterwards");
   assert.match(
     body,
-    /if \(\s*!wasDirty &&\s*\(!wasOpen \|\| priorInteraction !== null\) &&\s*ownsWorkflowReloadGuard\(reloadGuardToken\)\s*\) \{[\s\S]{0,400}?await clearSpuriousOpenModified\(target, \{/,
+    /if \(\s*!wasDirty &&\s*priorInteraction !== null &&\s*ownsWorkflowReloadGuard\(reloadGuardToken\)\s*\) \{[\s\S]{0,400}?await clearSpuriousOpenModified\(target, \{/,
     "a genuinely dirty tab must never be re-baselined, nor one we no longer hold exclusively",
   );
   // BOTH reload gates must require the pre-open snapshot to be clean too.
@@ -630,8 +630,8 @@ test("#442 round-2: with NO freeze available the tracker is NOT re-baselined eit
   // makes that frame safe. On a frontend WITHOUT the flag the reload is skipped for
   // exactly that reason (priorInteraction === null) — so the tracker must not be
   // re-baselined either: an edit landing in the unprotected frame would be adopted as
-  // clean, erasing unsaved-work protection and inviting later silent loss. (A first-time
-  // open — !wasOpen — can never reload, so its spurious-flag cleanup is unchanged.)
+  // clean, erasing unsaved-work protection and inviting later silent loss. (Round 3
+  // extended the same exclusion to the first-time open — see the round-3 test below.)
   const skipGate = body.indexOf("if (staleInfo.reload && !dirtyNow && !wasDirty && priorInteraction === null)");
   const firstRebaseline = body.indexOf("await clearSpuriousOpenModified(target, {");
   assert.notEqual(skipGate, -1, "the no-freeze skip gate must exist");
@@ -639,7 +639,7 @@ test("#442 round-2: with NO freeze available the tracker is NOT re-baselined eit
   assert.ok(firstRebaseline < skipGate, "fixture order: the re-baseline precedes the reload decision");
   assert.match(
     body,
-    /if \(\s*!wasDirty &&\s*\(!wasOpen \|\| priorInteraction !== null\) &&\s*ownsWorkflowReloadGuard\(reloadGuardToken\)\s*\) \{[\s\S]{0,400}?await clearSpuriousOpenModified\(target, \{/,
+    /if \(\s*!wasDirty &&\s*priorInteraction !== null &&\s*ownsWorkflowReloadGuard\(reloadGuardToken\)\s*\) \{[\s\S]{0,400}?await clearSpuriousOpenModified\(target, \{/,
     "the pre-reload re-baseline must be gated on the freeze holding — the same condition whose absence skips the reload",
   );
   // The only OTHER re-baseline is the post-reload one, and it stays gated on the reload
@@ -653,6 +653,39 @@ test("#442 round-2: with NO freeze available the tracker is NOT re-baselined eit
     2,
     "workflow_open re-baselines the tracker exactly twice, each behind a gate",
   );
+});
+
+test("#442 round-3: a FIRST-TIME open never re-baselines without the freeze (edit in the frame stays dirty)", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const body = handlerBody(src, "async workflow_open({");
+  // The freeze handle is non-null ONLY for an already-open tab on a frontend exposing
+  // allow_interaction — exactly the case where the freeze below is actually applied.
+  assert.match(
+    body,
+    /const priorInteraction =\s*wasOpen && typeof canvasView\?\.allow_interaction === "boolean"/,
+    "priorInteraction !== null ⟺ the freeze is held",
+  );
+  // clearSpuriousOpenModified awaits a frame, then captures the canvas as the CLEAN
+  // baseline and forces isModified=false. A first-time open holds NO freeze by design,
+  // so if the cleanup ran there an edit landing in that frame would be adopted as
+  // clean — and a later stale open could then auto-reload the disk file over that
+  // unsaved work (the round-3 DATA-LOSS finding). The gate must require the freeze
+  // with NO !wasOpen exception; the fresh tab keeps a spurious flag (loud, cosmetic)
+  // instead of a silent clean-slate.
+  const gate = body.match(
+    /if \(\s*!wasDirty &&\s*priorInteraction !== null &&\s*ownsWorkflowReloadGuard\(reloadGuardToken\)\s*\) \{[\s\S]{0,400}?await clearSpuriousOpenModified\(target, \{/,
+  );
+  assert.ok(gate, "the pre-reload re-baseline must be gated on the freeze holding");
+  assert.doesNotMatch(
+    gate[0],
+    /!wasOpen/,
+    "no first-time-open exception may re-open the unprotected frame",
+  );
+  // …which means a first-time open (wasOpen false ⇒ priorInteraction null) can NEVER
+  // reach the capture/reset: an in-frame edit keeps the tracker dirty, so BOTH reload
+  // paths below (each requires !dirtyNow && !wasDirty) stay closed over that work.
+  const gates = [...body.matchAll(/if \(staleInfo\.reload && !dirtyNow[^)]*\)/g)].map((m) => m[0]);
+  assert.ok(gates.length >= 2, "both reload paths stay gated on the fresh dirty re-check");
 });
 
 test("#402 codex P1: workflow_new records UNKNOWN (never a clean failure) once creation started", () => {

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -226,6 +226,52 @@ test("the exported receipt summary carries the rid (without it nothing can corre
   assert.equal(s.rid, "rid-1");
 });
 
+test('#402 codex P1: applied:"unknown" ⇒ undetermined + possibly_applied + a do-not-retry warning', () => {
+  // workflow_new created the blank tab but the frontend never surfaced it. Reporting a
+  // clean failure (or nothing) would invite a retry, and workflow_new is NOT idempotent.
+  const receipt = makeOpenReceipt({
+    seq: 3,
+    cmd: "workflow_new",
+    rid: "rid-N",
+    applied: "unknown",
+    error: "frontend did not expose the new workflow",
+    at: 10,
+  });
+  assert.equal(receipt.applied, "unknown", "the tri-state must survive normalization");
+  const v = classifyOpenOutcome({ rid: "rid-N", receipt });
+  assert.equal(v.outcome, "undetermined");
+  assert.equal(v.possibly_applied, true);
+  assert.match(v.detail, /not idempotent/);
+  assert.match(v.detail, /Do NOT blindly retry/);
+});
+
+test('#402 codex P1: "applied" names the workflow it LANDED on, and flags a re-resolved selector', () => {
+  // A selector can resolve differently after a mid-command list refresh, so "applied"
+  // alone would let a reader assume the workflow they named.
+  const receipt = makeOpenReceipt({
+    seq: 4,
+    cmd: "workflow_open",
+    rid: "rid-1",
+    requested: "x",
+    resolved: { path: "workflows/b.json", filename: "b.json", routing_key: "wf:workflows/b.json" },
+    applied: true,
+    at: 5,
+  });
+  const v = classifyOpenOutcome({ requested: "x", rid: "rid-1", receipt });
+  assert.equal(v.outcome, "applied");
+  assert.equal(v.opened.path, "workflows/b.json");
+  assert.match(v.detail, /landed on "workflows\/b\.json"/);
+  assert.match(v.detail, /confirm this is the workflow you meant/);
+  // …and a caller that knows its canonical target can make that check ENFORCEABLE.
+  const strict = classifyOpenOutcome({
+    requested: "x",
+    rid: "rid-1",
+    expectedTarget: "workflows/a.json",
+    receipt,
+  });
+  assert.equal(strict.outcome, "undetermined", "a receipt that landed elsewhere must not answer");
+});
+
 test("receiptMatchesRequest accepts any RESOLVED identity form of the same open", () => {
   const r = receiptFor("workflows/x.json");
   assert.equal(receiptMatchesRequest(r, "workflows/x.json"), true);
@@ -293,18 +339,61 @@ test("#442 codex P1: the destructive re-read freezes canvas interaction and ALWA
   // while it yields would be destroyed by a reload nobody asked for.
   const lockAt = body.indexOf("canvasView.allow_interaction = false;");
   const loadAt = body.indexOf("await app.loadGraphData(diskGraph");
+  const rebaselineAt = body.indexOf("await clearSpuriousOpenModified(target);", loadAt);
   const restoreAt = body.indexOf("canvasView.allow_interaction = priorInteraction;");
   assert.ok(lockAt !== -1 && loadAt !== -1 && restoreAt !== -1, "the load must be bracketed by an interaction lock");
-  assert.ok(lockAt < loadAt && loadAt < restoreAt, "lock → load → restore");
+  // clearSpuriousOpenModified awaits a frame and then RE-BASELINES the change tracker, so
+  // an edit made during it would be adopted as "not modified" and later dropped silently.
+  // The freeze must therefore cover the re-baseline too, not just the load (codex).
+  assert.notEqual(rebaselineAt, -1, "the reload must re-baseline the change tracker");
+  assert.ok(
+    lockAt < loadAt && loadAt < rebaselineAt && rebaselineAt < restoreAt,
+    "lock → load → re-baseline → restore (the freeze must span the re-baseline)",
+  );
   // The restore must live in a `finally`, so a throwing load can never strand a frozen canvas.
   const tail = body.slice(loadAt, restoreAt + 200);
   assert.match(tail, /\} finally \{[\s\S]*allow_interaction = priorInteraction;/, "the restore must be in a finally");
-  // …and only when we actually captured a boolean to restore.
   assert.match(body, /typeof canvasView\?\.allow_interaction === "boolean"/);
   // The local must NOT be named so that it ends in "s": the #268 contract scanner
   // captures `s\.<member>` unanchored, so `canvas.allow_interaction` reads as a new
   // workflow-SERVICE dependency and fails that gate.
   assert.equal(/\bcanvas\.allow_interaction/.test(body), false);
+});
+
+test("#442 codex P1: with NO reliable freeze available, the destructive reload is SKIPPED", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const body = handlerBody(src, "async workflow_open({");
+  // Serving a stale graph behind a loud flag is recoverable; silently eating an edit made
+  // during an unrequested load is not. So an absent allow_interaction must skip the reload.
+  assert.match(
+    body,
+    /if \(staleInfo\.reload && !dirtyNow && priorInteraction === null\) \{/,
+    "no interaction flag ⇒ no automatic reload",
+  );
+  assert.match(body, /could not be protected against a concurrent edit and was skipped/);
+});
+
+test("#402 codex P1: workflow_new records UNKNOWN (never a clean failure) once creation started", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const body = handlerBody(src, "async workflow_new({");
+  assert.ok(body, "workflow_new must exist");
+  // Before the creation command runs, a failure is a clean negative — safe to retry.
+  assert.match(body, /applied: false,\s*\n\s*error: "command service unavailable"/);
+  // After it runs, a blank tab may exist. workflow_new is NOT idempotent, so neither
+  // "no receipt" nor applied:false is acceptable — both read as "nothing happened".
+  const created = body.indexOf('await mgr.command.execute("Comfy.NewBlankWorkflow");');
+  assert.notEqual(created, -1);
+  const afterCreate = body.slice(created);
+  assert.equal(
+    /applied: false/.test(afterCreate),
+    false,
+    "no path after the creation command may record a clean failure",
+  );
+  assert.equal(
+    (afterCreate.match(/applied: "unknown"/g) || []).length >= 1,
+    true,
+    "a post-creation failure must be journaled as UNKNOWN",
+  );
 });
 
 test("#570 P0b: the #442 re-read must KEEP this tab's instance identity (no mid-open fork)", () => {

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -395,7 +395,7 @@ test("#442 defect-2 wiring: the re-read is gated on a FRESH dirty re-check (no s
   // The gate must be the FRESH value, and there must be no await between it and the gate.
   const between = stripComments(body.slice(dirtyAt, reloadAt));
   assert.ok(!/\bawait\b/.test(between), "no await may sit between the dirty re-check and the reload gate");
-  assert.match(body, /isModified: dirtyNow/, "the staleness decision must use the fresh dirty value");
+  assert.match(body, /isModified: dirtyNow \|\| wasDirty/, "the staleness decision must honour BOTH dirty signals");
   assert.match(body, /conflict: true/, "stale + unsaved edits must surface a CONFLICT, not a silent pick");
   assert.match(body, /reloaded,/, "the reply must state whether the canvas was actually re-read");
   assert.match(body, /reloadError = coerceMessageText/, "a failed re-read must never be reported as reloaded");
@@ -440,6 +440,30 @@ test("#442 codex P1: the destructive re-read freezes canvas interaction and ALWA
   assert.equal(/\bcanvas\.allow_interaction/.test(body), false);
 });
 
+test("#442 codex R7: a tab that arrived DIRTY is never re-baselined and never reloaded", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const body = handlerBody(src, "async workflow_open({");
+  // clearSpuriousOpenModified captures the canvas as the new baseline and FORCES
+  // isModified=false. On a tab that already had unsaved edits that does not clear a
+  // spurious flag — it erases a REAL one, after which every later dirty check reads clean
+  // and the destructive reload is authorized over the user's work.
+  const wasDirtyAt = body.indexOf("const wasDirty = !!target.isModified;");
+  const openAt = body.indexOf("await s.openWorkflow(target);");
+  assert.notEqual(wasDirtyAt, -1, "the pre-open dirty state must be snapshotted");
+  assert.ok(wasDirtyAt < openAt, "…BEFORE any await, since it cannot be recovered afterwards");
+  assert.match(
+    body,
+    /if \(!wasDirty\) await clearSpuriousOpenModified\(target\);/,
+    "a genuinely dirty tab must never be re-baselined",
+  );
+  // BOTH reload gates must require the pre-open snapshot to be clean too.
+  const gates = [...body.matchAll(/if \(staleInfo\.reload && !dirtyNow[^)]*\)/g)].map((m) => m[0]);
+  assert.ok(gates.length >= 2, "both the skip and the reload branch must be gated");
+  for (const g of gates) assert.match(g, /!wasDirty/, `gate must honour the pre-open snapshot: ${g}`);
+  // …and the conflict report must fire for either signal.
+  assert.match(body, /: dirtyNow \|\| wasDirty/, "a pre-open dirty tab must be reported as a CONFLICT");
+});
+
 test("#442 codex P1: with NO reliable freeze available, the destructive reload is SKIPPED", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   const body = handlerBody(src, "async workflow_open({");
@@ -447,7 +471,7 @@ test("#442 codex P1: with NO reliable freeze available, the destructive reload i
   // during an unrequested load is not. So an absent allow_interaction must skip the reload.
   assert.match(
     body,
-    /if \(staleInfo\.reload && !dirtyNow && priorInteraction === null\) \{/,
+    /if \(staleInfo\.reload && !dirtyNow && !wasDirty && priorInteraction === null\) \{/,
     "no interaction flag ⇒ no automatic reload",
   );
   assert.match(body, /could not be protected against a concurrent edit and was skipped/);

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -31,6 +31,7 @@ import {
   markOpenReceiptReplySent,
   summarizeOpenReceipt,
   receiptMatchesRequest,
+  createSingleFlight,
   receiptAnswersCommand,
   classifyOpenOutcome,
 } from "../../web/js/lib/open-outcome.js";
@@ -99,6 +100,69 @@ test("withDeadline clears its timer on the fast path (no dangling timer in a lon
 test("withDeadline with a non-positive/absent deadline still neutralizes rejection", async () => {
   assert.equal(await withDeadline(Promise.reject(new Error("x")), 0, "fb"), "fb");
   assert.equal(await withDeadline(Promise.reject(new Error("x")), NaN, "fb"), "fb");
+});
+
+test("codex P2: the deadline CANCELS the work it abandons, and a throwing hook cannot change the outcome", async () => {
+  let cancelled = 0;
+  assert.equal(
+    await withDeadline(new Promise(() => {}), 5, "unknown", { onTimeout: () => cancelled++ }),
+    "unknown",
+  );
+  assert.equal(cancelled, 1, "abandoning a read must cancel it, not leave it running");
+  // A throwing cancel hook must not corrupt the deadline's result.
+  assert.equal(
+    await withDeadline(new Promise(() => {}), 5, "unknown", {
+      onTimeout: () => {
+        throw new Error("abort failed");
+      },
+    }),
+    "unknown",
+  );
+  // …and a read that BEATS the deadline is never cancelled.
+  let late = 0;
+  assert.equal(await withDeadline(Promise.resolve("v"), 10000, null, { onTimeout: () => late++ }), "v");
+  assert.equal(late, 0);
+});
+
+test("codex P2: createSingleFlight caps concurrent reads at one per key and clears on settle", async () => {
+  const flight = createSingleFlight();
+  let starts = 0;
+  let release;
+  const gate = new Promise((r) => (release = r));
+  const start = () => {
+    starts++;
+    return gate;
+  };
+  const a = flight.run("wf.json", start);
+  const b = flight.run("wf.json", start);
+  assert.equal(starts, 1, "a second caller must join the outstanding read, not start another");
+  assert.equal(a, b, "both callers share the same promise");
+  assert.equal(flight.size(), 1);
+  // A DIFFERENT key is independent (its own outstanding read, its own slot).
+  const otherPending = flight.run("other.json", () => {
+    starts++;
+    return new Promise(() => {});
+  });
+  assert.ok(otherPending);
+  assert.equal(starts, 2);
+  assert.equal(flight.size(), 2);
+  release("done");
+  assert.equal(await a, "done");
+  assert.equal(flight.size(), 1, "a settled key must be released so the next open can read again");
+  // A rejected read must also release its slot (and stay rejected for its waiters).
+  await assert.rejects(
+    flight.run("boom.json", () => Promise.reject(new Error("nope"))),
+    /nope/,
+  );
+  assert.equal(flight.size(), 1, "a rejected read must not hold its slot forever");
+  // A synchronously throwing starter must not occupy a slot either.
+  await assert.rejects(
+    flight.run("sync.json", () => {
+      throw new Error("sync boom");
+    }),
+    /sync boom/,
+  );
+  assert.equal(flight.size(), 1);
 });
 
 // --- the receipt journal --------------------------------------------------
@@ -290,9 +354,14 @@ test("#402 wiring: workflow_open BOUNDS the post-open disk read and never claims
   assert.ok(body, "workflow_open must exist");
   assert.match(
     body,
-    /withDeadline\(\s*workflowDiskContent\(target\.path\),\s*OPEN_DISK_READ_BUDGET_MS,\s*null\s*\)/,
+    /withDeadline\(\s*\n?\s*staleReadFlight\.run\(target\.path,[\s\S]{0,200}?OPEN_DISK_READ_BUDGET_MS,/,
     "the #442 staleness read must be bounded — the open already applied, so it must not park the reply",
   );
+  // codex P2: a deadline only stops US waiting. The read must also be cancellable and
+  // single-flighted, or a server that accepts and never answers leaks a request per open.
+  assert.match(body, /onTimeout: \(\) => readAbort\?\.abort\(\)/, "the deadline must cancel the read it abandoned");
+  assert.match(body, /staleReadFlight\.run\(target\.path/, "reads must be single-flighted per workflow path");
+  assert.match(body, /workflowDiskContent\(target\.path, \{ signal: readAbort\?\.signal \}\)/);
   // A null read must still land on the honest "unknown", never on a fresh claim.
   assert.match(body, /stale === "unknown"/, "a timed-out/unreadable disk read must degrade to stale:\"unknown\"");
   assert.ok(OPEN_DISK_READ_BUDGET_MS > 0 && OPEN_DISK_READ_BUDGET_MS <= 10000);

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -31,6 +31,7 @@ import {
   markOpenReceiptReplySent,
   summarizeOpenReceipt,
   receiptMatchesRequest,
+  receiptAnswersCommand,
   classifyOpenOutcome,
 } from "../../web/js/lib/open-outcome.js";
 
@@ -137,6 +138,7 @@ test('#402 CORE: a matching `active` alone is NOT success — verdict stays "und
   // workflow as active, the agent's workflow_open drops mid-command and never ran.
   const v = classifyOpenOutcome({
     requested: "workflows/x.json",
+    rid: "rid-1",
     receipt: null,
     activeMatchesRequest: true,
     activeConfirmed: true,
@@ -145,36 +147,83 @@ test('#402 CORE: a matching `active` alone is NOT success — verdict stays "und
   assert.match(v.detail, /does NOT prove/i);
   assert.match(v.detail, /UNDETERMINED/);
   assert.equal(v.evidence.active_matches_request, true);
+  assert.equal(v.evidence.correlated_by_rid, false);
 });
 
-test("#402: a receipt for THIS request that applied ⇒ applied (authoritative)", () => {
+test("#402: THIS command's receipt, applied ⇒ applied (authoritative)", () => {
   const v = classifyOpenOutcome({
     requested: "workflows/x.json",
+    rid: "rid-1",
     receipt: receiptFor("workflows/x.json"),
     activeMatchesRequest: false,
     activeConfirmed: false,
   });
   assert.equal(v.outcome, "applied");
+  assert.equal(v.evidence.correlated_by_rid, true);
   assert.match(v.detail, /could not deliver the reply/);
 });
 
 test("#402: a receipt that FAILED ⇒ not_applied, carrying the real error (a true negative)", () => {
   const v = classifyOpenOutcome({
     requested: "workflows/x.json",
+    rid: "rid-1",
     receipt: receiptFor("workflows/x.json", { applied: false, error: "workflow service unavailable" }),
   });
   assert.equal(v.outcome, "not_applied");
   assert.match(v.detail, /workflow service unavailable/);
 });
 
-test("#570-class: ANOTHER workflow's receipt can never answer for this request", () => {
+test("#402 codex P1: an EARLIER open of the SAME workflow can never answer for a later command", () => {
+  // Command A opened x.json and succeeded. Command B asks for x.json again and is dropped
+  // BEFORE the executor ran, so it has no receipt of its own. Selector equality alone would
+  // read A's receipt as proof that B applied — the exact fabrication #402 must not produce.
   const v = classifyOpenOutcome({
     requested: "workflows/x.json",
+    rid: "rid-B",
+    receipt: receiptFor("workflows/x.json", { rid: "rid-A" }),
+    activeMatchesRequest: true,
+    activeConfirmed: true,
+  });
+  assert.equal(v.outcome, "undetermined");
+  assert.equal(v.evidence.correlated_by_rid, false);
+  assert.match(v.detail, /belongs to a DIFFERENT command/);
+  assert.equal(v.evidence.latest_receipt.rid, "rid-A", "the receipt is offered as evidence, not as the verdict");
+});
+
+test("#402 codex P1: with NO rid to correlate, the verdict is undetermined — never applied", () => {
+  const v = classifyOpenOutcome({
+    requested: "workflows/x.json",
+    receipt: receiptFor("workflows/x.json"),
+    activeMatchesRequest: true,
+    activeConfirmed: true,
+  });
+  assert.equal(v.outcome, "undetermined");
+});
+
+test("#570-class: ANOTHER workflow's receipt can never answer, even on a rid match", () => {
+  const v = classifyOpenOutcome({
+    requested: "workflows/x.json",
+    rid: "rid-1",
     receipt: receiptFor("workflows/OTHER.json"),
     activeMatchesRequest: true,
     activeConfirmed: true,
   });
-  assert.equal(v.outcome, "undetermined", "a receipt for a different workflow must not count");
+  assert.equal(v.outcome, "undetermined", "a rid match with a mismatched workflow must refuse, not answer");
+  assert.equal(receiptAnswersCommand(receiptFor("workflows/OTHER.json"), { requested: "workflows/x.json", rid: "rid-1" }), false);
+});
+
+test("receiptAnswersCommand demands an exact rid and rejects every weaker form", () => {
+  const r = receiptFor("workflows/x.json");
+  assert.equal(receiptAnswersCommand(r, { requested: "workflows/x.json", rid: "rid-1" }), true);
+  assert.equal(receiptAnswersCommand(r, { requested: "workflows/x.json" }), false, "no rid ⇒ no answer");
+  assert.equal(receiptAnswersCommand(r, { requested: "workflows/x.json", rid: "" }), false);
+  assert.equal(receiptAnswersCommand(r, { rid: "rid-1" }), true, "rid alone answers when no workflow is asserted");
+  assert.equal(receiptAnswersCommand(null, { rid: "rid-1" }), false);
+});
+
+test("the exported receipt summary carries the rid (without it nothing can correlate)", () => {
+  const s = summarizeOpenReceipt(receiptFor("workflows/x.json"), { now: 2000 });
+  assert.equal(s.rid, "rid-1");
 });
 
 test("receiptMatchesRequest accepts any RESOLVED identity form of the same open", () => {
@@ -235,6 +284,27 @@ test("#442 defect-2 wiring: the re-read is gated on a FRESH dirty re-check (no s
   assert.match(body, /conflict: true/, "stale + unsaved edits must surface a CONFLICT, not a silent pick");
   assert.match(body, /reloaded,/, "the reply must state whether the canvas was actually re-read");
   assert.match(body, /reloadError = coerceMessageText/, "a failed re-read must never be reported as reloaded");
+});
+
+test("#442 codex P1: the destructive re-read freezes canvas interaction and ALWAYS restores it", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const body = handlerBody(src, "async workflow_open({");
+  // The clean sample authorizes the load, but loadGraphData is awaited — an edit made
+  // while it yields would be destroyed by a reload nobody asked for.
+  const lockAt = body.indexOf("canvasView.allow_interaction = false;");
+  const loadAt = body.indexOf("await app.loadGraphData(diskGraph");
+  const restoreAt = body.indexOf("canvasView.allow_interaction = priorInteraction;");
+  assert.ok(lockAt !== -1 && loadAt !== -1 && restoreAt !== -1, "the load must be bracketed by an interaction lock");
+  assert.ok(lockAt < loadAt && loadAt < restoreAt, "lock → load → restore");
+  // The restore must live in a `finally`, so a throwing load can never strand a frozen canvas.
+  const tail = body.slice(loadAt, restoreAt + 200);
+  assert.match(tail, /\} finally \{[\s\S]*allow_interaction = priorInteraction;/, "the restore must be in a finally");
+  // …and only when we actually captured a boolean to restore.
+  assert.match(body, /typeof canvasView\?\.allow_interaction === "boolean"/);
+  // The local must NOT be named so that it ends in "s": the #268 contract scanner
+  // captures `s\.<member>` unanchored, so `canvas.allow_interaction` reads as a new
+  // workflow-SERVICE dependency and fails that gate.
+  assert.equal(/\bcanvas\.allow_interaction/.test(body), false);
 });
 
 test("#570 P0b: the #442 re-read must KEEP this tab's instance identity (no mid-open fork)", () => {

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -1,0 +1,261 @@
+// Unit tests for web/js/lib/open-outcome.js — run with `node --test`.
+//
+// #402: `panel_open_workflow` came back "disconnected mid-command … OUTCOME UNKNOWN".
+// Two properties are locked here, because getting either wrong produces the worst
+// possible result for this path — a FABRICATED success:
+//
+//   1. classifyOpenOutcome() reports "applied" ONLY from the panel's own execution
+//      record. A matching `active` pointer is explicitly NOT enough: after a backend
+//      reconnect the frontend restores a tab on its own (#433), and the usual #402
+//      request is "open the workflow that is already active", so a matching `active` is
+//      fully explained without our command ever having run.
+//   2. It can never mistake ANOTHER workflow's receipt for this request — the
+//      wrong-workflow failure mode the #570 identity work exists to prevent.
+//
+// Plus the wiring contract in comfyui-mcp-panel.js: the post-open disk read is BOUNDED
+// (#402), workflow_open journals both the positive and the negative, and the #442
+// defect-2 re-read never runs over unsaved edits.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  OPEN_DISK_READ_BUDGET_MS,
+  OPEN_RECEIPT_CAP,
+  withDeadline,
+  makeOpenReceipt,
+  recordOpenReceipt,
+  latestOpenReceipt,
+  markOpenReceiptReplySent,
+  summarizeOpenReceipt,
+  receiptMatchesRequest,
+  classifyOpenOutcome,
+} from "../../web/js/lib/open-outcome.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+/** Comments in this file DISCUSS `throw` and `await` at length, so any structural
+ *  assertion about control flow must look at CODE only. */
+function stripComments(src) {
+  return src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+/** Body of an object method from its `sig` up to the next 2-space-indented method. */
+function handlerBody(src, sig) {
+  const start = src.indexOf(sig);
+  if (start === -1) return null;
+  const after = start + sig.length;
+  const m = src.slice(after).match(/\n {2}(?:async )?[A-Za-z_][A-Za-z0-9_]*\s*\(/);
+  return src.slice(start, m ? after + m.index : src.length);
+}
+
+const receiptFor = (requested, extra = {}) =>
+  makeOpenReceipt({
+    seq: 1,
+    cmd: "workflow_open",
+    rid: "rid-1",
+    requested,
+    resolved: { path: requested, filename: "a.json", routing_key: `wf:${requested}` },
+    applied: true,
+    at: 1000,
+    ...extra,
+  });
+
+// --- withDeadline ---------------------------------------------------------
+
+test("withDeadline resolves the value when it beats the deadline", async () => {
+  assert.equal(await withDeadline(Promise.resolve("text"), 1000, null), "text");
+});
+
+test("withDeadline yields the fallback on timeout — and NEVER rejects", async () => {
+  const never = new Promise(() => {});
+  assert.equal(await withDeadline(never, 5, "unknown"), "unknown");
+});
+
+test("withDeadline maps a REJECTION to the same fallback (unreadable == too slow)", async () => {
+  assert.equal(await withDeadline(Promise.reject(new Error("Failed to fetch")), 1000, null), null);
+});
+
+test("withDeadline clears its timer on the fast path (no dangling timer in a long-lived tab)", async () => {
+  let cleared = 0;
+  let armed = 0;
+  const setTimer = (fn, ms) => {
+    armed++;
+    return setTimeout(fn, ms);
+  };
+  const clearTimer = (t) => {
+    cleared++;
+    clearTimeout(t);
+  };
+  await withDeadline(Promise.resolve(1), 10000, null, { setTimer, clearTimer });
+  assert.equal(armed, 1);
+  assert.equal(cleared, 1, "the deadline timer must be cleared once the value arrives");
+});
+
+test("withDeadline with a non-positive/absent deadline still neutralizes rejection", async () => {
+  assert.equal(await withDeadline(Promise.reject(new Error("x")), 0, "fb"), "fb");
+  assert.equal(await withDeadline(Promise.reject(new Error("x")), NaN, "fb"), "fb");
+});
+
+// --- the receipt journal --------------------------------------------------
+
+test("the receipt journal is bounded and keeps the NEWEST entries", () => {
+  const journal = [];
+  for (let i = 0; i < OPEN_RECEIPT_CAP + 5; i++) {
+    recordOpenReceipt(journal, makeOpenReceipt({ seq: i, requested: `w${i}.json` }));
+  }
+  assert.equal(journal.length, OPEN_RECEIPT_CAP);
+  assert.equal(latestOpenReceipt(journal).seq, OPEN_RECEIPT_CAP + 4);
+  assert.equal(latestOpenReceipt([]), null);
+});
+
+test("makeOpenReceipt starts reply_sent FALSE; markOpenReceiptReplySent flips it by rid only", () => {
+  const journal = [];
+  recordOpenReceipt(journal, receiptFor("a.json"));
+  assert.equal(latestOpenReceipt(journal).reply_sent, false);
+  assert.equal(markOpenReceiptReplySent(journal, "nope"), false);
+  assert.equal(latestOpenReceipt(journal).reply_sent, false);
+  assert.equal(markOpenReceiptReplySent(journal, "rid-1"), true);
+  assert.equal(latestOpenReceipt(journal).reply_sent, true);
+});
+
+test("summarizeOpenReceipt reports an AGE, never a raw clock the other process can't trust", () => {
+  const s = summarizeOpenReceipt(receiptFor("a.json"), { now: 3500 });
+  assert.equal(s.ms_ago, 2500);
+  assert.equal(s.applied, true);
+  assert.equal(s.requested, "a.json");
+  assert.equal(summarizeOpenReceipt(null), null);
+});
+
+// --- the truth function ---------------------------------------------------
+
+test('#402 CORE: a matching `active` alone is NOT success — verdict stays "undetermined"', () => {
+  // The reported scenario verbatim: ComfyUI restarts, the frontend restores the same
+  // workflow as active, the agent's workflow_open drops mid-command and never ran.
+  const v = classifyOpenOutcome({
+    requested: "workflows/x.json",
+    receipt: null,
+    activeMatchesRequest: true,
+    activeConfirmed: true,
+  });
+  assert.equal(v.outcome, "undetermined");
+  assert.match(v.detail, /does NOT prove/i);
+  assert.match(v.detail, /UNDETERMINED/);
+  assert.equal(v.evidence.active_matches_request, true);
+});
+
+test("#402: a receipt for THIS request that applied ⇒ applied (authoritative)", () => {
+  const v = classifyOpenOutcome({
+    requested: "workflows/x.json",
+    receipt: receiptFor("workflows/x.json"),
+    activeMatchesRequest: false,
+    activeConfirmed: false,
+  });
+  assert.equal(v.outcome, "applied");
+  assert.match(v.detail, /could not deliver the reply/);
+});
+
+test("#402: a receipt that FAILED ⇒ not_applied, carrying the real error (a true negative)", () => {
+  const v = classifyOpenOutcome({
+    requested: "workflows/x.json",
+    receipt: receiptFor("workflows/x.json", { applied: false, error: "workflow service unavailable" }),
+  });
+  assert.equal(v.outcome, "not_applied");
+  assert.match(v.detail, /workflow service unavailable/);
+});
+
+test("#570-class: ANOTHER workflow's receipt can never answer for this request", () => {
+  const v = classifyOpenOutcome({
+    requested: "workflows/x.json",
+    receipt: receiptFor("workflows/OTHER.json"),
+    activeMatchesRequest: true,
+    activeConfirmed: true,
+  });
+  assert.equal(v.outcome, "undetermined", "a receipt for a different workflow must not count");
+});
+
+test("receiptMatchesRequest accepts any RESOLVED identity form of the same open", () => {
+  const r = receiptFor("workflows/x.json");
+  assert.equal(receiptMatchesRequest(r, "workflows/x.json"), true);
+  assert.equal(receiptMatchesRequest(r, "a.json"), true, "resolved filename form");
+  assert.equal(receiptMatchesRequest(r, "wf:workflows/x.json"), true, "resolved routing id");
+  assert.equal(receiptMatchesRequest(r, "workflows/other.json"), false);
+  assert.equal(receiptMatchesRequest(null, "x"), false);
+  assert.equal(receiptMatchesRequest(r, ""), false);
+});
+
+// --- wiring contract in the panel -----------------------------------------
+
+test("#402 wiring: workflow_open BOUNDS the post-open disk read and never claims fresh on timeout", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const body = handlerBody(src, "async workflow_open({");
+  assert.ok(body, "workflow_open must exist");
+  assert.match(
+    body,
+    /withDeadline\(\s*workflowDiskContent\(target\.path\),\s*OPEN_DISK_READ_BUDGET_MS,\s*null\s*\)/,
+    "the #442 staleness read must be bounded — the open already applied, so it must not park the reply",
+  );
+  // A null read must still land on the honest "unknown", never on a fresh claim.
+  assert.match(body, /stale === "unknown"/, "a timed-out/unreadable disk read must degrade to stale:\"unknown\"");
+  assert.ok(OPEN_DISK_READ_BUDGET_MS > 0 && OPEN_DISK_READ_BUDGET_MS <= 10000);
+});
+
+test("#402 wiring: workflow_open journals BOTH outcomes, and every early throw is a negative", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const body = handlerBody(src, "async workflow_open({");
+  assert.match(body, /const failOpen = \(err\) => \{/, "there must be a single negative-journal helper");
+  assert.match(body, /applied: false/, "the failure path must journal applied:false");
+  assert.match(body, /noteOpenAttempt\(\{[\s\S]*?cmd: "workflow_open",[\s\S]*?applied: true,/, "the success path must journal a receipt");
+  // Every `throw` inside workflow_open must go through failOpen — an unjournaled throw
+  // leaves a lost reply with no evidence at all. Code only: the prose discusses throws.
+  const rawThrows = [...stripComments(body).matchAll(/\bthrow (?!failOpen)/g)];
+  assert.equal(
+    rawThrows.length,
+    0,
+    `every throw in workflow_open must be journaled via failOpen (found ${rawThrows.length} raw throws)`,
+  );
+});
+
+test("#442 defect-2 wiring: the re-read is gated on a FRESH dirty re-check (no silent data loss)", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const body = handlerBody(src, "async workflow_open({");
+  const dirtyAt = body.indexOf("const dirtyNow = !!target.isModified;");
+  const decideAt = body.indexOf("const staleInfo = decideOpenStaleness({");
+  const reloadAt = body.indexOf("if (staleInfo.reload && !dirtyNow)");
+  assert.notEqual(dirtyAt, -1, "isModified must be re-read after the disk await, not reused from before it");
+  assert.notEqual(reloadAt, -1, "the re-read must be gated");
+  assert.ok(dirtyAt < decideAt && decideAt < reloadAt, "order: re-check dirty → decide → maybe reload");
+  // The gate must be the FRESH value, and there must be no await between it and the gate.
+  const between = stripComments(body.slice(dirtyAt, reloadAt));
+  assert.ok(!/\bawait\b/.test(between), "no await may sit between the dirty re-check and the reload gate");
+  assert.match(body, /isModified: dirtyNow/, "the staleness decision must use the fresh dirty value");
+  assert.match(body, /conflict: true/, "stale + unsaved edits must surface a CONFLICT, not a silent pick");
+  assert.match(body, /reloaded,/, "the reply must state whether the canvas was actually re-read");
+  assert.match(body, /reloadError = coerceMessageText/, "a failed re-read must never be reported as reloaded");
+});
+
+test("#570 P0b: the #442 re-read must KEEP this tab's instance identity (no mid-open fork)", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const body = handlerBody(src, "async workflow_open({");
+  // The re-read loads a file written OUT OF BAND, so its embedded uuid may be absent or
+  // belong to something else. Without __cmcpKeepInstance the create-boundary fork would
+  // mint a NEW identity for this tab mid-open and the next stamped command would be
+  // refused as a "workflow instance mismatch" against the session that asked for the open.
+  assert.match(
+    body,
+    /await app\.loadGraphData\(diskGraph, true, true, target, \{ __cmcpKeepInstance: true \}\)/,
+    "the disk re-read must pass __cmcpKeepInstance, exactly as graph_load does",
+  );
+});
+
+test("#402 wiring: workflow_list exposes the receipt + the POSITIVE trust flag", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const body = handlerBody(src, "workflow_list()");
+  assert.ok(body, "workflow_list must exist");
+  assert.match(body, /active_confirmed: !activeMaybeStale/, "trust must be reported positively, not inferred from silence");
+  assert.match(body, /last_open: lastOpen/, "the last open receipt must be reachable after a lost reply");
+  assert.match(body, /summarizeOpenReceipt\(latestOpenReceipt\(openReceipts\)/);
+});

--- a/browser_tests/unit/reconnect-staleness.test.mjs
+++ b/browser_tests/unit/reconnect-staleness.test.mjs
@@ -164,7 +164,9 @@ test("#433 wiring: reconnect bumps the epoch on a MONOTONIC clock; open/new/read
 
   // Each explicit resync site (open AND new) must stamp the epoch GUARDED by the
   // TOCTOU check (codex P1): only when no reconnect intervened during the async op.
-  for (const sig of ["async workflow_new()", "async workflow_open({"]) {
+  // Both executors now also take the command `rid` (#402 open receipts), so match on the
+  // signature PREFIX rather than the exact old zero-arg form.
+  for (const sig of ["async workflow_new({", "async workflow_open({"]) {
     const body = handlerBody(src, sig);
     assert.ok(body, `${sig} must exist`);
     const snapAt = body.indexOf("const openedForEpoch = backendReconnectEpoch;");

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -338,25 +338,61 @@ const lostReplies = createLostReplyJournal();
 // overwritten by the load, or — worse — land during the tracker re-baseline and be marked
 // CLEAN, so the next out-of-band disk change silently discards it with no conflict shown.
 // While this guard is held, every graph/workflow executor is REFUSED with a retryable
-// error (nothing applied) rather than queued: refusing cannot reorder or double-apply, and
-// the window is a fraction of a second.
+// error (nothing applied) rather than queued: refusing cannot reorder or double-apply. The
+// window normally lasts a fraction of a second, but it lasts EXACTLY as long as the
+// switch/reload genuinely runs — see begin/endWorkflowReloadStep below.
 let workflowReloadGuard = null;
 let workflowReloadGuardSeq = 0;
 // Defensive ceiling: a guard can only ever be cleared by workflow_open's finally, so if
 // some pathological path ever failed to run it, an un-expiring guard would wedge every
-// command in the tab. Age it out instead.
+// command in the tab. Age it out instead — but ONLY while no step of the section is in
+// flight. The ceiling exists for a guard whose holder VANISHED; it must never cut a
+// genuinely-running step off (that expiry is precisely the DATA-LOSS window this guard
+// exists to close).
 const WORKFLOW_RELOAD_GUARD_MAX_MS = 30000;
 /** Take the section and return an OWNERSHIP TOKEN. Sections are token-scoped (codex): an
  *  expired-then-superseded holder must never release a NEWER holder's section, and a holder
  *  that has lost the section must not go on mutating as though it still had it. */
 function acquireWorkflowReloadGuard(key) {
   const token = ++workflowReloadGuardSeq;
-  workflowReloadGuard = { token, key, since: Date.now() };
+  workflowReloadGuard = { token, key, since: Date.now(), pending: 0 };
   return token;
 }
 /** Release ONLY if `token` still owns the section. */
 function releaseWorkflowReloadGuard(token) {
   if (workflowReloadGuard && workflowReloadGuard.token === token) workflowReloadGuard = null;
+}
+/** Mark one awaited step of the section (the tab switch, a loadGraphData, a tracker
+ *  re-baseline) as IN FLIGHT across its await. While any step is outstanding the guard
+ *  CANNOT age out (activeWorkflowReloadGuard below): expiring mid-await drops the fence,
+ *  a graph command then runs and is ACKNOWLEDGED, and the late-completing load overwrites
+ *  that acknowledged edit — the DATA-LOSS shape (codex). Tying the guard to the step's
+ *  settle means a slow load keeps refusing commands for as long as it genuinely runs. The
+ *  trade is deliberate: a load that NEVER settles wedges the tab with a loud, retryable
+ *  refusal (recoverable — reload the tab) instead of silently eating an edit the caller
+ *  was told succeeded (not recoverable). Returns false — and the caller must not start
+ *  the step — when `token` no longer owns the section. */
+function beginWorkflowReloadStep(token) {
+  const held = activeWorkflowReloadGuard();
+  if (!held || held.token !== token) return false;
+  held.pending += 1;
+  return true;
+}
+/** Counterpart of beginWorkflowReloadStep, called from the step's own finally so a
+ *  throwing step cannot leave the fence up forever. Also REARMS the ageing clock: between
+ *  steps the section runs synchronously (no command frame can interleave), so the idle
+ *  ceiling is measured from the last step's SETTLE — a section of many steps totalling
+ *  over WORKFLOW_RELOAD_GUARD_MAX_MS can never expire in the synchronous gap between two
+ *  of its own steps. */
+function endWorkflowReloadStep(token) {
+  if (
+    workflowReloadGuard &&
+    workflowReloadGuard.token === token &&
+    workflowReloadGuard.pending > 0
+  ) {
+    workflowReloadGuard.pending -= 1;
+    workflowReloadGuard.since = Date.now();
+  }
 }
 /** Does `token` still own the section? Re-checked after every await before any further
  *  mutation, so an operation that outlived its own section stops instead of racing the
@@ -365,10 +401,15 @@ function ownsWorkflowReloadGuard(token) {
   const held = activeWorkflowReloadGuard();
   return !!held && held.token === token;
 }
-/** The guard, or null when none is held (expiring a stuck one on the way). */
+/** The guard, or null when none is held (expiring a stuck one on the way). A guard with a
+ *  step in flight (pending > 0) is NEVER expired here — it is tied to that step's settle,
+ *  so the fence cannot drop while a switch/load is genuinely awaiting. */
 function activeWorkflowReloadGuard() {
   if (!workflowReloadGuard) return null;
-  if (Date.now() - workflowReloadGuard.since > WORKFLOW_RELOAD_GUARD_MAX_MS) {
+  if (
+    workflowReloadGuard.pending === 0 &&
+    Date.now() - workflowReloadGuard.since > WORKFLOW_RELOAD_GUARD_MAX_MS
+  ) {
     workflowReloadGuard = null;
     return null;
   }
@@ -7727,12 +7768,17 @@ const GRAPH_TOOL_EXECUTORS = {
       workflowTabId(target) || target.path || "the active workflow",
     );
     try {
+      // Hold the fence across the switch await itself: a slow switch must not let the
+      // guard age out mid-flight (see begin/endWorkflowReloadStep).
+      beginWorkflowReloadStep(reloadGuardToken);
       try {
         await s.openWorkflow(target);
       } catch (err) {
         // The native switch itself failed — nothing was applied. Recorded, then rethrown
         // through failOpen below (outside the freeze) so the negative is journaled.
         openFailed = err instanceof Error ? err : new Error(coerceMessageText(err));
+      } finally {
+        endWorkflowReloadStep(reloadGuardToken);
       }
       if (!openFailed) {
       // We deliberately do NOT auto-reload the canvas from disk here: switching to an
@@ -7769,6 +7815,7 @@ const GRAPH_TOOL_EXECUTORS = {
       // captures members off the workflow-service alias `s` with an unanchored `s\.` pattern,
       // so `canvas.<member>` would be misread as a new workflow-SERVICE dependency. This is a
       // LiteGraph canvas flag, not a workflow-service member.
+        beginWorkflowReloadStep(reloadGuardToken);
         try {
           const st = target.changeTracker?.activeState;
           if (st && typeof app.loadGraphData === "function") {
@@ -7776,6 +7823,8 @@ const GRAPH_TOOL_EXECUTORS = {
           }
         } catch (err) {
           console.warn("[comfyui-mcp-panel] workflow_open repaint failed:", err?.message ?? err);
+        } finally {
+          endWorkflowReloadStep(reloadGuardToken);
         }
         // Opening alone must not dirty the tab (a spurious post-load change-tracker
         // diff otherwise flips it to modified:true and blocks an unforced close).
@@ -7791,9 +7840,16 @@ const GRAPH_TOOL_EXECUTORS = {
         // still held exclusivity. Leaving the tab spuriously "modified" is cosmetic; racing
         // a concurrent edit is not.
         if (!wasDirty && ownsWorkflowReloadGuard(reloadGuardToken)) {
-          await clearSpuriousOpenModified(target, {
-            stillOwns: () => ownsWorkflowReloadGuard(reloadGuardToken),
-          });
+          // The helper awaits a frame before re-baselining — hold the fence across that
+          // frame too, so the guard cannot age out inside it and let a command through.
+          beginWorkflowReloadStep(reloadGuardToken);
+          try {
+            await clearSpuriousOpenModified(target, {
+              stillOwns: () => ownsWorkflowReloadGuard(reloadGuardToken),
+            });
+          } finally {
+            endWorkflowReloadStep(reloadGuardToken);
+          }
         }
         // #433: an explicit open authoritatively re-points `active` — record it against
         // the epoch we STARTED on, but only if no reconnect intervened during the async
@@ -7889,7 +7945,20 @@ const GRAPH_TOOL_EXECUTORS = {
           // command would be refused as a "workflow instance mismatch" against the session
           // that asked for the open. The flag keeps the LIVE OBJECT's identity (the
           // non-forgeable source) and stamps it over whatever the file carried.
-          await app.loadGraphData(diskGraph, true, true, target, { __cmcpKeepInstance: true });
+          //
+          // HOLD THE SECTION ACROSS THE LOAD ITSELF (codex DATA-LOSS): this await is
+          // unbounded — a huge graph on a busy machine can take past the 30s defensive
+          // ceiling. Expiring here is exactly the reported window: the fence drops, a
+          // graph command runs and is ACKNOWLEDGED, and this late-completing load then
+          // overwrites that edit. With the step held the fence cannot drop mid-load, so
+          // no edit can be acknowledged after the reload started — and the ownership
+          // re-check below still guards the re-baseline against every other loss path.
+          beginWorkflowReloadStep(reloadGuardToken);
+          try {
+            await app.loadGraphData(diskGraph, true, true, target, { __cmcpKeepInstance: true });
+          } finally {
+            endWorkflowReloadStep(reloadGuardToken);
+          }
           // The reload HAPPENED — record that before anything else can fail. Understating a
           // completed destructive act would be its own lie.
           reloaded = true;
@@ -7905,9 +7974,14 @@ const GRAPH_TOOL_EXECUTORS = {
             // A programmatic load dirties the change tracker; clear that so the re-read does
             // not leave the tab looking edited (which would block an unforced close). Still
             // inside the freeze, and ownership-aware across its own frame.
-            await clearSpuriousOpenModified(target, {
-              stillOwns: () => ownsWorkflowReloadGuard(reloadGuardToken),
-            });
+            beginWorkflowReloadStep(reloadGuardToken);
+            try {
+              await clearSpuriousOpenModified(target, {
+                stillOwns: () => ownsWorkflowReloadGuard(reloadGuardToken),
+              });
+            } finally {
+              endWorkflowReloadStep(reloadGuardToken);
+            }
           } else {
             // Lost exclusivity while the load was in flight. The canvas IS the on-disk
             // version, but we must not re-baseline over whatever ran in the meantime.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7445,7 +7445,12 @@ const GRAPH_TOOL_EXECUTORS = {
       // execution fact, `requested`/`resolved` prove WHICH workflow it was, and
       // `reply_sent:false` says the caller never heard the answer. A matching `active`
       // is NOT a substitute — after a reconnect the frontend restores a tab by itself.
-      // NO matching receipt ⇒ the honest verdict is UNDETERMINED, never "opened".
+      //
+      // CORRELATE BY `rid` (codex P1). The receipt's `rid` is the server-minted id of the
+      // command it belongs to; only an EXACT rid match makes it an answer about YOUR
+      // command. Selector equality is not enough — an earlier successful open of the SAME
+      // workflow would otherwise be read as proof that a LATER, dropped open ran.
+      // No correlating receipt ⇒ the honest verdict is UNDETERMINED, never "opened".
       ...(lastOpen ? { last_open: lastOpen } : {}),
       ...(activeMaybeStale
         ? { active_possibly_stale: true, stale_hint: activeStaleHint() }
@@ -7653,7 +7658,23 @@ const GRAPH_TOOL_EXECUTORS = {
     let reloaded = false;
     let reloadError = null;
     if (staleInfo.reload && !dirtyNow) {
+      // The clean sample above authorizes the load, but `loadGraphData` is AWAITED — if it
+      // yields before it replaces the graph, a canvas edit made in that window would be
+      // destroyed by a load the user never asked for (codex P1). Nobody requested this
+      // reload, so it must not be able to take work with it: freeze canvas interaction for
+      // the duration and restore it in a finally, whatever happens. Best-effort by design
+      // (the flag name is a LiteGraph detail that may move), so it NARROWS the window
+      // rather than proving it shut — which is why the last-instant `dirtyNow` re-check
+      // above stays, and why a dirty tab is never reloaded at all.
+      // Bound to a local whose name does NOT end in "s": the #268 frontend-contract
+      // scanner captures members off the workflow-service alias `s` with an unanchored
+      // `s\.` pattern, so `canvas.<member>` would be misread as a new workflow-SERVICE
+      // dependency. This is a LiteGraph canvas flag, not a workflow-service member.
+      const canvasView = app?.canvas;
+      const priorInteraction =
+        typeof canvasView?.allow_interaction === "boolean" ? canvasView.allow_interaction : null;
       try {
+        if (priorInteraction !== null) canvasView.allow_interaction = false;
         const diskGraph = JSON.parse(onDiskContent);
         // 4th arg associates the load with THIS tab (same as the repaint above), so the
         // on-disk graph replaces the tab's buffer in place instead of spawning a new
@@ -7677,16 +7698,21 @@ const GRAPH_TOOL_EXECUTORS = {
         } catch {
           /* getter-only — the stale flag simply re-reports until the next save */
         }
-        // A programmatic load dirties the change tracker; clear that so the re-read does
-        // not leave the tab looking edited (which would block an unforced close).
-        await clearSpuriousOpenModified(target);
         reloaded = true;
       } catch (err) {
         // NEVER claim a reload we did not complete — report the failure and leave the
         // caller with the honest `stale:true, reloaded:false`.
         reloadError = coerceMessageText(err?.message ?? err);
         console.warn("[comfyui-mcp-panel] workflow_open disk re-read failed:", reloadError);
+      } finally {
+        // Hand the canvas back on EVERY path — a throw here must never leave the user
+        // with a frozen graph.
+        if (priorInteraction !== null) canvasView.allow_interaction = priorInteraction;
       }
+      // A programmatic load dirties the change tracker; clear that so the re-read does not
+      // leave the tab looking edited (which would block an unforced close). Outside the
+      // interaction lock: it awaits a frame, and the canvas must be live by then.
+      if (reloaded) await clearSpuriousOpenModified(target);
     }
     const receipt = noteOpenAttempt({
       cmd: "workflow_open",

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9866,19 +9866,39 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     const lost = lostReplies.list();
     if (!lost.length) return;
     let sent = 0;
+    let dropped = 0;
+    const keep = [];
     for (const entry of lost) {
-      if (!target || target.readyState !== WebSocket.OPEN) break;
+      // NEVER replay across a bridge change (codex). An entry belongs to the orchestrator
+      // it was produced for; after a backend switch or a Bridge-URL edit the current socket
+      // is a DIFFERENT process, and volunteering another session's result to it is a leak,
+      // not a recovery. Such an entry is also meaningless there — its rid is unknown — so
+      // it is dropped rather than carried forever. (Sensitive results are additionally
+      // redacted at journal time and never travel at all.)
+      if (entry.url && entry.url !== url) {
+        dropped++;
+        continue;
+      }
+      if (!target || target.readyState !== WebSocket.OPEN) {
+        keep.push(entry);
+        continue;
+      }
       try {
         target.send(JSON.stringify(entry.reply));
         sent++;
       } catch {
-        break;
+        keep.push(entry);
       }
     }
-    if (sent === lost.length) lostReplies.drain();
+    if (sent || dropped) lostReplies.replace(keep);
     if (sent) {
       onLog(
         `Re-sent ${sent} command result${sent === 1 ? "" : "s"} the panel completed but could not deliver while the bridge was down.`,
+      );
+    }
+    if (dropped) {
+      onLog(
+        `Discarded ${dropped} undelivered command result${dropped === 1 ? "" : "s"} belonging to a previous bridge — they are not replayed to a different agent.`,
       );
     }
   }
@@ -9993,6 +10013,8 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           cmd,
           reason: classifyUndeliveredReply({ socketOpen, superseded, sendThrew }),
           at: Date.now(),
+          // Stamp the bridge this outcome belongs to so a replay can never cross it.
+          url,
         }),
       );
       return false;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9869,6 +9869,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
   // so the panel won't lie "connected" when there's no agent behind the socket.
   let handshakeTimer = null;
   let handshakeDone = false;
+  // The exact socket INSTANCE that completed a handshake (codex). A boolean cannot express
+  // this: replays are also triggered off the command path, where the current socket may be
+  // open but not yet handshaken — or may not be an orchestrator at all. Identity closes
+  // that race, because a replacement socket is a different object.
+  let handshakenSock = null;
   // Handshake (models-frame) window AFTER the WS opens. Backend-aware: Codex's
   // app-server can still be booting its agent after the bridge accepts the socket,
   // so it gets a wider window before we treat the open socket as wedged (FIX 2).
@@ -9886,6 +9891,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
   }
   function markConnected() {
     handshakeDone = true;
+    handshakenSock = sock;
     clearHandshake();
     // Remember the user wants the agent connected, so we auto-reconnect after a
     // ComfyUI reboot / panel reopen (until they explicitly Disconnect). Mirror it
@@ -9960,6 +9966,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
    *  pending resolves it with the command's TRUE outcome instead of an OUTCOME-UNKNOWN
    *  guess. Only drained once every entry went out, so a partial replay is retried. */
   function replayLostReplies(target) {
+    // ONLY onto a socket that has proven itself with a real handshake (codex). An OPEN
+    // socket merely proves something is bound to the port — it can be a different
+    // orchestrator session at the same URL, or a non-orchestrator listener, and it can be
+    // open before its `models` frame arrives. This is checked HERE rather than only at the
+    // call sites so no future caller can bypass it; anything still journaled simply waits
+    // for markConnected().
+    if (!target || target !== handshakenSock || target.readyState !== WebSocket.OPEN) return;
     const lost = lostReplies.list();
     if (!lost.length) return;
     // The bridge THIS socket belongs to (stamped at creation), not the mutable current
@@ -10896,6 +10909,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         sock?.close();
       } catch {}
       sock = null;
+      handshakenSock = null;
       connect();
     },
     currentUrl() {
@@ -10919,6 +10933,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         sock?.close();
       } catch {}
       sock = null;
+      handshakenSock = null;
     },
     destroy() {
       closed = true;
@@ -10931,6 +10946,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         sock?.close();
       } catch {}
       sock = null;
+      handshakenSock = null;
     },
   };
 }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3167,12 +3167,17 @@ function nextFrame() {
  *  (changeTracker.reset(); isModified = false), minus the disk write — opening
  *  from disk means the loaded graph already IS the saved state. Best-effort +
  *  feature-detected; never throws. */
-async function clearSpuriousOpenModified(wf) {
+async function clearSpuriousOpenModified(wf, { stillOwns } = {}) {
   if (!wf) return;
   try {
     // Wait for the load's post-render state capture to settle, otherwise we'd
     // re-baseline before the spurious modification is recorded.
     await nextFrame();
+    // codex — the re-baseline below CAPTURES the current canvas and forces isModified=false,
+    // so it must not run once the caller has lost its exclusive window: an edit made in this
+    // very frame would be adopted as the new clean baseline and could later be discarded
+    // with no conflict shown. Checking before the await is not enough — the frame IS the gap.
+    if (typeof stillOwns === "function" && !stillOwns()) return;
     const ct = wf.changeTracker;
     // Bring activeState up to date with the loaded graph, then make that the
     // baseline so initialState === activeState (graphEqual → not modified).
@@ -7786,7 +7791,9 @@ const GRAPH_TOOL_EXECUTORS = {
         // still held exclusivity. Leaving the tab spuriously "modified" is cosmetic; racing
         // a concurrent edit is not.
         if (!wasDirty && ownsWorkflowReloadGuard(reloadGuardToken)) {
-          await clearSpuriousOpenModified(target);
+          await clearSpuriousOpenModified(target, {
+            stillOwns: () => ownsWorkflowReloadGuard(reloadGuardToken),
+          });
         }
         // #433: an explicit open authoritatively re-points `active` — record it against
         // the epoch we STARTED on, but only if no reconnect intervened during the async
@@ -7883,20 +7890,31 @@ const GRAPH_TOOL_EXECUTORS = {
           // that asked for the open. The flag keeps the LIVE OBJECT's identity (the
           // non-forgeable source) and stamps it over whatever the file carried.
           await app.loadGraphData(diskGraph, true, true, target, { __cmcpKeepInstance: true });
-          // The tab now holds exactly the on-disk bytes — re-baseline so this same change
-          // isn't re-reported as stale forever. Best-effort: `originalContent` is a plain
-          // field on current builds but may be getter-only elsewhere.
-          try {
-            target.originalContent = onDiskContent;
-          } catch {
-            /* getter-only — the stale flag simply re-reports until the next save */
-          }
-          // A programmatic load dirties the change tracker; clear that so the re-read does
-          // not leave the tab looking edited (which would block an unforced close). Still
-          // inside the freeze — it re-baselines, so an edit made during its frame would be
-          // adopted as "not modified" and could later be discarded without a prompt.
-          await clearSpuriousOpenModified(target);
+          // The reload HAPPENED — record that before anything else can fail. Understating a
+          // completed destructive act would be its own lie.
           reloaded = true;
+          if (ownsWorkflowReloadGuard(reloadGuardToken)) {
+            // The tab now holds exactly the on-disk bytes — re-baseline so this same change
+            // isn't re-reported as stale forever. Best-effort: `originalContent` is a plain
+            // field on current builds but may be getter-only elsewhere.
+            try {
+              target.originalContent = onDiskContent;
+            } catch {
+              /* getter-only — the stale flag simply re-reports until the next save */
+            }
+            // A programmatic load dirties the change tracker; clear that so the re-read does
+            // not leave the tab looking edited (which would block an unforced close). Still
+            // inside the freeze, and ownership-aware across its own frame.
+            await clearSpuriousOpenModified(target, {
+              stillOwns: () => ownsWorkflowReloadGuard(reloadGuardToken),
+            });
+          } else {
+            // Lost exclusivity while the load was in flight. The canvas IS the on-disk
+            // version, but we must not re-baseline over whatever ran in the meantime.
+            reloadError =
+              "the canvas was reloaded from the on-disk file, but the panel lost its exclusive " +
+              "window before it could re-baseline the tab, so the tab may still show as modified";
+          }
         }
       }
     } catch (err) {
@@ -7945,7 +7963,8 @@ const GRAPH_TOOL_EXECUTORS = {
             ...(reloaded
               ? {
                   stale_hint:
-                    "The file had changed on disk since this tab loaded it, and this tab had no unsaved edits, so the canvas was RELOADED from the on-disk version. Re-read the graph (panel_graph_outline / panel_query_graph) — node ids and geometry may differ from before.",
+                    "The file had changed on disk since this tab loaded it, and this tab had no unsaved edits, so the canvas was RELOADED from the on-disk version. Re-read the graph (panel_graph_outline / panel_query_graph) — node ids and geometry may differ from before." +
+                    (reloadError ? ` NOTE: ${reloadError}.` : ""),
                 }
               : dirtyNow || wasDirty
                 ? {
@@ -10637,7 +10656,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // #508 — command outcomes this tab produced but could NOT send back. Advertised
             // so the other end can say "the tab answered and the reply was lost" instead of
             // asserting the unestablished "the tab may be backgrounded or frozen".
-            lostReplies: lostReplies.summaries(),
+            // Same cross-bridge/age rule the replay uses (codex): these summaries ride the
+            // hello, so an unfiltered list would tell a bridge that never owned these
+            // commands their ids, names and outcomes even though the replies are withheld.
+            lostReplies: lostReplies.summaries({
+              now: Date.now(),
+              targetUrl: sock?.__cmcpBridgeUrl ?? url,
+            }),
           }),
         ),
       );

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7668,8 +7668,9 @@ const GRAPH_TOOL_EXECUTORS = {
       // leaves a SECOND blank workflow behind. Journal it as UNKNOWN instead.
       const error =
         "workflow_new: created a blank workflow but the frontend did not expose it as the " +
-        "active workflow — cannot establish a unique routing target. Retry, or select the new " +
-        "tab before editing.";
+        "active workflow — cannot establish a unique routing target. Do NOT retry — " +
+        "workflow_new is not idempotent, so a retry would create a SECOND blank tab. Check " +
+        "workflow_list / the canvas state first, then select the new tab before editing.";
       noteOpenAttempt({
         cmd: "workflow_new",
         rid,
@@ -7870,12 +7871,24 @@ const GRAPH_TOOL_EXECUTORS = {
         // already HAD unsaved edits does not clear a spurious flag — it erases a REAL one,
         // hiding the user's work from every later check (codex). Leaving a genuinely dirty
         // tab marked dirty is both truthful and what keeps the reload gate below closed.
+        // …and ONLY when either no reload is possible (!wasOpen) or the canvas freeze is
+        // holding (priorInteraction !== null). On a frontend WITHOUT allow_interaction the
+        // helper's awaited frame is unprotected: an edit landing in it would be captured as
+        // the new CLEAN baseline, silently erasing unsaved-work protection — and that same
+        // condition (priorInteraction === null) is what skips the reload below, so the
+        // re-baseline would be a silent clean-slate in service of a reload that never
+        // happens. Leave the tracker alone there: a spurious "modified" flag is cosmetic
+        // and keeps the dirty signal alive for the conflict report below.
         // Ownership re-check before EVERY re-baseline / destructive step: if this open
         // outlived its own section (the 30s safety expiry, or a newer open taking over),
         // other commands have been let through and we must not keep mutating as though we
         // still held exclusivity. Leaving the tab spuriously "modified" is cosmetic; racing
         // a concurrent edit is not.
-        if (!wasDirty && ownsWorkflowReloadGuard(reloadGuardToken)) {
+        if (
+          !wasDirty &&
+          (!wasOpen || priorInteraction !== null) &&
+          ownsWorkflowReloadGuard(reloadGuardToken)
+        ) {
           // The helper awaits a frame before re-baselining — hold the fence across that
           // frame too, so the guard cannot age out inside it and let a command through.
           beginWorkflowReloadStep(reloadGuardToken);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -201,6 +201,23 @@ import {
 import { pickRevertSnapshot } from "./lib/graph-revert.js";
 import { decideOpenStaleness } from "./lib/workflow-open-staleness.js";
 import {
+  OPEN_DISK_READ_BUDGET_MS,
+  withDeadline,
+  makeOpenReceipt,
+  recordOpenReceipt,
+  latestOpenReceipt,
+  markOpenReceiptReplySent,
+  summarizeOpenReceipt,
+} from "./lib/open-outcome.js";
+import {
+  classifyUndeliveredReply,
+  describeUndeliveredReply,
+  createLostReplyJournal,
+  pruneAttempts,
+  shouldReRegister,
+  reRegisterExhaustedHint,
+} from "./lib/command-liveness.js";
+import {
   saveActiveWorkflow,
   shouldGroundBeforeTurn,
   groundActiveWorkflow,
@@ -295,6 +312,35 @@ let backendReconnectedAt = null;
 // The reconnect epoch value at the last authoritative (re)bind by an explicit
 // open/new; when it's >= backendReconnectEpoch the active pointer is trusted again.
 let activeWorkflowResyncEpoch = 0;
+// #402 — OPEN RECEIPTS. Every workflow_open / workflow_new that RAN is journaled here
+// with the selector it was asked for, the identity it resolved to, and whether it
+// applied. When a mid-command drop loses the reply, this is the ONLY non-inferential
+// answer to "did my open actually happen?" — reading `workflow_list.active` instead is
+// not an answer, because after a backend reconnect the frontend restores a tab on its
+// own (#433), which explains a matching `active` without our command ever running.
+const openReceipts = [];
+let openReceiptSeq = 0;
+// #508 — outcomes whose reply could NOT be written back. Replayed on the next socket and
+// summarized to the user, so a command that really ran is never silently swallowed.
+const lostReplies = createLostReplyJournal();
+
+/** Journal one open attempt and return its receipt. `applied:false` (with the error) is
+ *  recorded too — a genuine negative is as load-bearing as a positive here. */
+function noteOpenAttempt({ cmd, rid, requested, resolved, applied, error }) {
+  const receipt = makeOpenReceipt({
+    seq: ++openReceiptSeq,
+    cmd,
+    rid,
+    requested,
+    resolved,
+    applied,
+    error,
+    at: Date.now(),
+    reconnectEpoch: backendReconnectEpoch,
+  });
+  recordOpenReceipt(openReceipts, receipt);
+  return receipt;
+}
 // Monotonic "now" — performance.now() when available (never runs backwards),
 // falling back to Date.now() only if the environment lacks it.
 function monotonicNow() {
@@ -7360,6 +7406,7 @@ const GRAPH_TOOL_EXECUTORS = {
       reconnectedAt: backendReconnectedAt,
       now: monotonicNow(),
     });
+    const lastOpen = summarizeOpenReceipt(latestOpenReceipt(openReceipts), { now: Date.now() });
     return {
       active: active
         ? {
@@ -7388,13 +7435,25 @@ const GRAPH_TOOL_EXECUTORS = {
       // for any existing reader.
       open: openList,
       workflows: openList,
+      // #433/#402 — the POSITIVE form of active_possibly_stale, so a reader never has to
+      // infer trust from the absence of a warning. False means: a backend reconnect has
+      // happened recently and no explicit open/new has re-pointed `active` since, so the
+      // frontend — not the agent — chose whatever is active.
+      active_confirmed: !activeMaybeStale,
+      // #402 — the panel's OWN record of the last workflow_open / workflow_new that ran.
+      // This is what answers "did my dropped open apply?": `applied` is the panel's
+      // execution fact, `requested`/`resolved` prove WHICH workflow it was, and
+      // `reply_sent:false` says the caller never heard the answer. A matching `active`
+      // is NOT a substitute — after a reconnect the frontend restores a tab by itself.
+      // NO matching receipt ⇒ the honest verdict is UNDETERMINED, never "opened".
+      ...(lastOpen ? { last_open: lastOpen } : {}),
       ...(activeMaybeStale
         ? { active_possibly_stale: true, stale_hint: activeStaleHint() }
         : {}),
     };
   },
 
-  async workflow_new() {
+  async workflow_new({ rid } = {}) {
     // #433 TOCTOU: snapshot the reconnect epoch BEFORE the async native work. If a
     // reconnect lands mid-operation it advances the epoch, and stamping the NEW
     // epoch at the end would suppress the warning that reconnect must raise (codex
@@ -7428,17 +7487,42 @@ const GRAPH_TOOL_EXECUTORS = {
     // against the epoch we STARTED on, but only if no reconnect intervened during
     // the async work (else its tab-restore may have overridden us — leave armed).
     if (backendReconnectEpoch === openedForEpoch) activeWorkflowResyncEpoch = openedForEpoch;
+    // #402 — workflow_new ALSO authoritatively re-points `active`, so it gets a receipt
+    // too: a lost reply here leaves the caller unable to tell whether a blank tab was
+    // created (and re-issuing would create a SECOND one, unlike the idempotent open).
+    const receipt = noteOpenAttempt({
+      cmd: "workflow_new",
+      rid,
+      requested: null,
+      resolved: { path: wf.path ?? null, filename: wf.filename ?? null, routing_key: key },
+      applied: true,
+    });
     // `key`/`routing_key` are the unique handle the agent should pass to
     // panel_set_workflow_target so its session pins to this exact graph.
-    return { created: true, active: getWorkflowTitle(), key, routing_key: key };
+    return { created: true, active: getWorkflowTitle(), key, routing_key: key, open_seq: receipt.seq };
   },
 
-  async workflow_open({ path }) {
+  async workflow_open({ path, rid }) {
     // #433 TOCTOU: snapshot the reconnect epoch BEFORE the async open (see
     // workflow_new) so a reconnect landing mid-operation is not masked by our stamp.
     const openedForEpoch = backendReconnectEpoch;
+    // #402 — journal the FAILURE side too. Every early throw below is a real "this open
+    // did NOT apply" fact, and a caller whose reply was lost mid-command needs that
+    // negative just as much as the positive: without it the only remaining evidence is
+    // the post-reconnect `active` pointer, which proves nothing (#433).
+    const failOpen = (err) => {
+      noteOpenAttempt({
+        cmd: "workflow_open",
+        rid,
+        requested: path,
+        resolved: null,
+        applied: false,
+        error: coerceMessageText(err?.message ?? err),
+      });
+      return err;
+    };
     const s = app?.extensionManager?.workflow;
-    if (!s?.openWorkflow) throw new Error("workflow service unavailable");
+    if (!s?.openWorkflow) throw failOpen(new Error("workflow service unavailable"));
     const find = () => {
       const all = [...(s.openWorkflows ?? []), ...(s.workflows ?? [])];
       // getWorkflowByPath resolves a real disk path only (returns null for a
@@ -7465,9 +7549,11 @@ const GRAPH_TOOL_EXECUTORS = {
       target = find();
     }
     if (!target) {
-      throw new Error(
-        `no workflow matching "${path}" — it isn't among the saved/open workflows even after a refresh. ` +
-          `For a file outside the workflows folder, load it with panel_load_workflow path:<file>.`,
+      throw failOpen(
+        new Error(
+          `no workflow matching "${path}" — it isn't among the saved/open workflows even after a refresh. ` +
+            `For a file outside the workflows folder, load it with panel_load_workflow path:<file>.`,
+        ),
       );
     }
     // #442 — an ALREADY-OPEN tab is repainted from its OWN in-memory buffer below,
@@ -7483,7 +7569,13 @@ const GRAPH_TOOL_EXECUTORS = {
     // reads it fresh from disk. openWorkflow does NOT mutate originalContent for an
     // already-open tab (its load() early-returns), so the baseline stays valid.
     const wasOpen = !!target.changeTracker;
-    await s.openWorkflow(target);
+    try {
+      await s.openWorkflow(target);
+    } catch (err) {
+      // The native switch itself failed — nothing was applied. Journal the negative so a
+      // lost reply can still be answered truthfully, then surface the error unchanged.
+      throw failOpen(err instanceof Error ? err : new Error(coerceMessageText(err)));
+    }
     // We deliberately do NOT auto-reload the canvas from disk here: switching to an
     // already-open tab must not silently discard the user's in-memory graph, and a
     // re-read could race a concurrent canvas edit and clobber it. Instead the staleness
@@ -7521,38 +7613,135 @@ const GRAPH_TOOL_EXECUTORS = {
     // open (else its tab-restore may have overridden us — leave the window armed).
     if (backendReconnectEpoch === openedForEpoch) activeWorkflowResyncEpoch = openedForEpoch;
     // #442 — read the on-disk bytes AS LATE AS POSSIBLE (after openWorkflow + repaint),
-    // so an external write during those awaits is still detected. There is NO await
-    // between this read and the return below, so nothing can interleave and turn a
-    // freshly-read stale result into a false-fresh (codex). wasOpen was captured before
-    // openWorkflow; the baseline (originalContent) is unchanged by an already-open open.
-    const onDiskContent = wasOpen ? await workflowDiskContent(target.path) : null;
+    // so an external write during those awaits is still detected. wasOpen was captured
+    // before openWorkflow; the baseline (originalContent) is unchanged by an already-open
+    // open.
+    //
+    // #402 — BOUND this read. The open has ALREADY been applied by the time we get here,
+    // so the only thing still outstanding is a staleness HINT — yet the read is an HTTP
+    // round-trip to ComfyUI, and in the exact #402 window ComfyUI's HTTP layer is what is
+    // flaky (the same report's panel_save_workflow returned "Failed to fetch"). Unbounded,
+    // a server that accepts the connection and never answers parks a known-good outcome
+    // for the whole browser timeout — which is precisely how a routine reconnect blip gets
+    // long enough to turn into "disconnected mid-command … OUTCOME UNKNOWN". withDeadline
+    // never rejects: a timeout degrades to the ALREADY-SUPPORTED honest `stale:"unknown"`,
+    // exactly like an unreadable disk, and never to a false "fresh".
+    const onDiskContent = wasOpen
+      ? await withDeadline(workflowDiskContent(target.path), OPEN_DISK_READ_BUDGET_MS, null)
+      : null;
+    // #442 defect 2 — RE-READ the file when it provably changed and nothing is at stake.
+    // Re-check `isModified` HERE, immediately before deciding, rather than trusting the
+    // value from before the disk read: the user can type into the canvas during that
+    // await, and reloading over their unsaved edits is data-loss class — strictly worse
+    // than serving a stale graph. There is NO await between this re-check and the reload
+    // decision below.
+    const dirtyNow = !!target.isModified;
     const staleInfo = decideOpenStaleness({
       wasOpen,
-      isModified: !!target.isModified,
+      isModified: dirtyNow,
       onDiskContent,
       baselineContent: typeof target.originalContent === "string" ? target.originalContent : null,
     });
+    // `reload` is true only for "the file changed AND this tab has nothing unsaved", so
+    // the re-read is lossless. A stale tab WITH unsaved edits is a genuine conflict: we
+    // refuse and surface both sides rather than picking for the user.
+    //
+    // The earlier no-await-before-return invariant is intact: this block runs ONLY when
+    // staleInfo.stale === true, and it never downgrades that to "fresh" — so the
+    // false-fresh window codex closed (read stale → file changes → report fresh) still
+    // cannot open. The provably-fresh and "unknown" paths reach the return with no await.
+    let reloaded = false;
+    let reloadError = null;
+    if (staleInfo.reload && !dirtyNow) {
+      try {
+        const diskGraph = JSON.parse(onDiskContent);
+        // 4th arg associates the load with THIS tab (same as the repaint above), so the
+        // on-disk graph replaces the tab's buffer in place instead of spawning a new
+        // "Unsaved Workflow" tab.
+        //
+        // #570 P0b — `__cmcpKeepInstance` is MANDATORY here, exactly as on graph_load.
+        // This is an in-place reload of the SAME tab from a file that was written
+        // OUT OF BAND, so its embedded workflow uuid may be absent or belong to
+        // something else. Without the flag the create-boundary fork would see
+        // cached-uuid ≠ incoming-uuid, treat the refresh as an in-place REPLACEMENT and
+        // mint a NEW identity for this tab mid-open — after which the very next stamped
+        // command would be refused as a "workflow instance mismatch" against the session
+        // that asked for the open. The flag keeps the LIVE OBJECT's identity (the
+        // non-forgeable source) and stamps it over whatever the file carried.
+        await app.loadGraphData(diskGraph, true, true, target, { __cmcpKeepInstance: true });
+        // The tab now holds exactly the on-disk bytes — re-baseline so this same change
+        // isn't re-reported as stale forever. Best-effort: `originalContent` is a plain
+        // field on current builds but may be getter-only elsewhere.
+        try {
+          target.originalContent = onDiskContent;
+        } catch {
+          /* getter-only — the stale flag simply re-reports until the next save */
+        }
+        // A programmatic load dirties the change tracker; clear that so the re-read does
+        // not leave the tab looking edited (which would block an unforced close).
+        await clearSpuriousOpenModified(target);
+        reloaded = true;
+      } catch (err) {
+        // NEVER claim a reload we did not complete — report the failure and leave the
+        // caller with the honest `stale:true, reloaded:false`.
+        reloadError = coerceMessageText(err?.message ?? err);
+        console.warn("[comfyui-mcp-panel] workflow_open disk re-read failed:", reloadError);
+      }
+    }
+    const receipt = noteOpenAttempt({
+      cmd: "workflow_open",
+      rid,
+      requested: path,
+      resolved: {
+        path: target.path,
+        filename: target.filename,
+        routing_key: workflowTabId(target),
+      },
+      applied: true,
+    });
     return {
       opened: { path: target.path, filename: target.filename },
+      routing_key: workflowTabId(target),
       modified: !!target.isModified,
+      // #402 — the receipt id for THIS open. Journaled in the panel, so if this reply
+      // never reaches the caller the outcome is still recoverable from workflow_list's
+      // `last_open` instead of being guessed from the `active` pointer.
+      open_seq: receipt.seq,
       // #442 — surface out-of-band staleness so a caller switching to an already-open
       // tab is never fooled by a bland success while the canvas shows a pre-edit graph.
-      // `stale:true` = the on-disk file differs from what this tab loaded; `stale:"unknown"`
-      // = we could NOT verify (disk unreadable / no baseline) and must NOT claim fresh
-      // (codex P2). The canvas always shows the LOADED version (we never auto-reload —
-      // see above); `stale_hint` says how to refresh, and whether unsaved edits are at stake.
+      // `stale:true` = the on-disk file differed from what this tab had loaded;
+      // `stale:"unknown"` = we could NOT verify (disk unreadable / read past its deadline
+      // / no baseline) and must NOT claim fresh (codex P2). `reloaded` says whether this
+      // call actually re-read the file: true = the canvas now shows the on-disk version;
+      // false = it still shows the loaded version and the caller must act.
       ...(staleInfo.stale === true
         ? {
             stale: true,
-            stale_hint: staleInfo.reload
-              ? "The file changed on disk since this tab loaded it; the canvas still shows the loaded version. Call panel_load_workflow to load the on-disk version."
-              : "The file changed on disk since this tab loaded it, AND this tab has unsaved edits. Save first (panel_save_workflow) to keep them, or call panel_load_workflow to discard them and load the on-disk version.",
+            reloaded,
+            ...(reloaded
+              ? {
+                  stale_hint:
+                    "The file had changed on disk since this tab loaded it, and this tab had no unsaved edits, so the canvas was RELOADED from the on-disk version. Re-read the graph (panel_graph_outline / panel_query_graph) — node ids and geometry may differ from before.",
+                }
+              : dirtyNow
+                ? {
+                    conflict: true,
+                    stale_hint:
+                      "CONFLICT: the file changed on disk since this tab loaded it AND this tab has unsaved edits, so nothing was reloaded (discarding the user's in-canvas work silently would be data loss). The canvas still shows the loaded version. Ask the user: save first (panel_save_workflow) to keep the in-canvas version, or call panel_load_workflow to discard it and take the on-disk version.",
+                  }
+                : {
+                    stale_hint:
+                      "The file changed on disk since this tab loaded it and the automatic re-read did not complete" +
+                      (reloadError ? ` (${reloadError})` : "") +
+                      "; the canvas still shows the loaded version. Call panel_load_workflow to load the on-disk version.",
+                  }),
           }
         : staleInfo.stale === "unknown"
           ? {
               stale: "unknown",
+              reloaded: false,
               stale_hint:
-                "Could not verify whether the on-disk file still matches this tab (disk read unavailable). Treat the canvas as possibly stale; call panel_load_workflow to be sure you have the on-disk version.",
+                "Could not verify whether the on-disk file still matches this tab (disk read unavailable or slower than its deadline). Treat the canvas as possibly stale; call panel_load_workflow to be sure you have the on-disk version.",
             }
           : {}),
     };
@@ -9471,6 +9660,70 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     emitStatus("connected");
   }
 
+  // #508 — BOUNDED self-heal for a command whose reply could not be written back.
+  // Timestamps of re-registrations we have already performed; pruned to the rolling
+  // window so a persistently sick bridge can never become a hello storm.
+  let reRegisterAttempts = [];
+  function handleUndeliveredReply(entry) {
+    if (!entry) return;
+    // Tell the user what actually happened, in cause-specific terms.
+    onLog(describeUndeliveredReply(entry));
+    const now = Date.now();
+    const socketLive = !!sock && sock.readyState === WebSocket.OPEN;
+    if (!socketLive) {
+      // No live socket to re-register on. The normal reconnect path owns recovery, and
+      // the journaled outcome is replayed on the next hello — nothing to escalate here.
+      return;
+    }
+    reRegisterAttempts = pruneAttempts(reRegisterAttempts, now);
+    if (
+      shouldReRegister({
+        socketOpen: true,
+        lostCount: lostReplies.size(),
+        attempts: reRegisterAttempts,
+        now,
+      })
+    ) {
+      reRegisterAttempts.push(now);
+      // Re-advertise THIS tab under its CURRENT active workflow's own id — byte-for-byte
+      // the same re-registration the panel already performs on a workflow switch and
+      // after free_vram (#310). sendHello() derives the id from the live active workflow,
+      // so it can never adopt, guess, or steal a DIFFERENT workflow's tab id: retargeting
+      // to the wrong workflow is corruption-class and strictly worse than staying wedged.
+      sendHello();
+      onLog("Re-registered this ComfyUI tab with the agent so the next command reaches a live handler.");
+    } else {
+      // Budget spent with a live socket — stop retrying and hand the user a real action.
+      onLog(reRegisterExhaustedHint());
+    }
+  }
+
+  /** #508/#402 — re-send outcomes we could not deliver, onto a freshly-opened socket.
+   *  `rid`s are random UUIDs (server-minted per command), so an orchestrator that already
+   *  gave up on the command drops the frame harmlessly, while one that still has it
+   *  pending resolves it with the command's TRUE outcome instead of an OUTCOME-UNKNOWN
+   *  guess. Only drained once every entry went out, so a partial replay is retried. */
+  function replayLostReplies(target) {
+    const lost = lostReplies.list();
+    if (!lost.length) return;
+    let sent = 0;
+    for (const entry of lost) {
+      if (!target || target.readyState !== WebSocket.OPEN) break;
+      try {
+        target.send(JSON.stringify(entry.reply));
+        sent++;
+      } catch {
+        break;
+      }
+    }
+    if (sent === lost.length) lostReplies.drain();
+    if (sent) {
+      onLog(
+        `Re-sent ${sent} command result${sent === 1 ? "" : "s"} the panel completed but could not deliver while the bridge was down.`,
+      );
+    }
+  }
+
   function connect() {
     if (closed) return;
     // Re-entrancy guard: never open a second socket while one is already
@@ -9529,6 +9782,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         onLog(`Connected to ${redactBridgeUrl(url)} — waiting for the panel agent…`);
       }
       sendHello();
+      // #508/#402 — AFTER the hello (the orchestrator must know this tab first), replay
+      // any command outcome the previous socket could not deliver, so a command that
+      // genuinely ran is never silently swallowed by the reconnect.
+      replayLostReplies(thisSock);
       clearHandshake();
       handshakeTimer = setTimeout(() => {
         if (handshakeDone) return;
@@ -9569,7 +9826,21 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         // never reach onCommand: set_todo, show_media, ui_render/update,
         // request_secret, the drive cmds) — mark it so the silence backstop can't
         // reap a still-working turn between two silent commands.
-        onCommandReceived?.();
+        // #508 — ISOLATE the host callback. This is the turn-activity marker, and it used
+        // to run OUTSIDE the try below inside an ASYNC listener: a throw here became an
+        // unobserved rejection, so the command got NO reply — silently, deterministically,
+        // for every command — while chat kept working (chat frames never reach this
+        // callback). That is exactly the shape #508 reports, `set_todo` included: set_todo
+        // has no executor that could hang, so only a pre-reply throw explains it timing
+        // out. UI code must never be able to suppress a bridge reply.
+        try {
+          onCommandReceived?.();
+        } catch (err) {
+          console.warn(
+            "[comfyui-mcp-panel] onCommandReceived threw (reply unaffected):",
+            err?.message ?? err,
+          );
+        }
         let reply;
         try {
           let result;
@@ -9782,14 +10053,43 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         // graph run/save await). If a soft-reload/restart swapped this socket out while
         // we were suspended, this reply belongs to the DEAD session A — it must NOT be
         // injected into the fresh session B (whose sock the global now points at), and
-        // its activity card must not paint. Drop the whole continuation, and always send
-        // the reply on THIS socket (never the mutable global), only while it's open.
-        if (!isActive()) return;
-        try {
-          if (thisSock.readyState === WebSocket.OPEN) thisSock.send(JSON.stringify(reply));
-        } catch {
-          // Socket died between receive and reply — agent side times out.
+        // its activity card must not paint.
+        //
+        // #508 — but the REPLY itself is NOT part of that continuation. It goes to
+        // `thisSock`, the socket the command ARRIVED on: it is socket-scoped and
+        // rid-scoped, so it cannot reach session B, while withholding it leaves the
+        // sender with no outcome at all — the "registered tab that never acknowledges
+        // anything" wedge. So: always attempt the reply; gate only the UI continuation.
+        const superseded = !isActive();
+        const socketOpen = thisSock.readyState === WebSocket.OPEN;
+        let sendThrew = false;
+        if (socketOpen) {
+          try {
+            thisSock.send(JSON.stringify(reply));
+          } catch {
+            sendThrew = true;
+          }
         }
+        if (socketOpen && !sendThrew) {
+          // #402 — the open receipt records that its answer was handed to a live socket.
+          // ADVISORY only: a socket can still die before the bytes land, so this never
+          // becomes a claim about what the caller received — only `applied` is that.
+          markOpenReceiptReplySent(openReceipts, msg.rid);
+        } else {
+          // #508/#402 — the command RAN and its result has nowhere to go. Journal the
+          // exact frame (replayed on the next socket) and name the ACTUAL cause instead
+          // of leaving the caller with the orchestrator's guess that the tab "may be
+          // backgrounded or frozen" — it was neither; it answered and we could not send.
+          handleUndeliveredReply(
+            lostReplies.record({
+              reply,
+              cmd: msg.cmd,
+              reason: classifyUndeliveredReply({ socketOpen, superseded, sendThrew }),
+              at: Date.now(),
+            }),
+          );
+        }
+        if (superseded) return;
         // ask_user / request_secret paint their OWN cards and their replies carry
         // user input (a choice, or a SECRET) — never echo them as an activity card
         // (and never record them). The CivitAI/training DRIVE cmds animate the
@@ -10010,6 +10310,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // the orchestrator can resume an UNSAVED workflow's conversation without
             // cross-resuming a DIFFERENT same-title unsaved workflow.
             workflowUuid: workflowStableUuid(),
+            // #508 — command outcomes this tab produced but could NOT send back. Advertised
+            // so the other end can say "the tab answered and the reply was lost" instead of
+            // asserting the unestablished "the tab may be backgrounded or frozen".
+            lostReplies: lostReplies.summaries(),
           }),
         ),
       );
@@ -12905,7 +13209,7 @@ function buildPanel() {
       if (!bk || !Array.isArray(list)) return;
       const plabel = BACKEND_LABELS[bk] || bk;
       for (const m of list) {
-        const key = bk + " " + m.id;
+        const key = bk + "\u0000" + m.id;
         if (seen.has(key)) continue;
         seen.add(key);
         rows.push({ ...m, provider: bk, providerLabel: plabel });
@@ -12956,7 +13260,7 @@ function buildPanel() {
     const out = [];
     const pushed = new Set();
     const take = (m) => {
-      const key = m.provider + " " + m.id;
+      const key = m.provider + "\u0000" + m.id;
       if (pushed.has(key)) return;
       pushed.add(key);
       out.push(m);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -214,6 +214,7 @@ import {
   classifyUndeliveredReply,
   describeUndeliveredReply,
   createLostReplyJournal,
+  isReplayable,
   pruneAttempts,
   shouldReRegister,
   reRegisterExhaustedHint,
@@ -340,10 +341,30 @@ const lostReplies = createLostReplyJournal();
 // error (nothing applied) rather than queued: refusing cannot reorder or double-apply, and
 // the window is a fraction of a second.
 let workflowReloadGuard = null;
+let workflowReloadGuardSeq = 0;
 // Defensive ceiling: a guard can only ever be cleared by workflow_open's finally, so if
 // some pathological path ever failed to run it, an un-expiring guard would wedge every
 // command in the tab. Age it out instead.
 const WORKFLOW_RELOAD_GUARD_MAX_MS = 30000;
+/** Take the section and return an OWNERSHIP TOKEN. Sections are token-scoped (codex): an
+ *  expired-then-superseded holder must never release a NEWER holder's section, and a holder
+ *  that has lost the section must not go on mutating as though it still had it. */
+function acquireWorkflowReloadGuard(key) {
+  const token = ++workflowReloadGuardSeq;
+  workflowReloadGuard = { token, key, since: Date.now() };
+  return token;
+}
+/** Release ONLY if `token` still owns the section. */
+function releaseWorkflowReloadGuard(token) {
+  if (workflowReloadGuard && workflowReloadGuard.token === token) workflowReloadGuard = null;
+}
+/** Does `token` still own the section? Re-checked after every await before any further
+ *  mutation, so an operation that outlived its own section stops instead of racing the
+ *  commands that were let through when it expired. */
+function ownsWorkflowReloadGuard(token) {
+  const held = activeWorkflowReloadGuard();
+  return !!held && held.token === token;
+}
 /** The guard, or null when none is held (expiring a stuck one on the way). */
 function activeWorkflowReloadGuard() {
   if (!workflowReloadGuard) return null;
@@ -7697,10 +7718,9 @@ const GRAPH_TOOL_EXECUTORS = {
     // Hold the switch+reload critical section across the WHOLE mutating sequence. The canvas
     // freeze keeps the USER out; this keeps the BRIDGE out, so a concurrent graph_* command
     // can neither be overwritten by the reload nor be silently re-baselined as clean.
-    workflowReloadGuard = {
-      key: workflowTabId(target) || target.path || "the active workflow",
-      since: Date.now(),
-    };
+    const reloadGuardToken = acquireWorkflowReloadGuard(
+      workflowTabId(target) || target.path || "the active workflow",
+    );
     try {
       try {
         await s.openWorkflow(target);
@@ -7760,7 +7780,14 @@ const GRAPH_TOOL_EXECUTORS = {
         // already HAD unsaved edits does not clear a spurious flag — it erases a REAL one,
         // hiding the user's work from every later check (codex). Leaving a genuinely dirty
         // tab marked dirty is both truthful and what keeps the reload gate below closed.
-        if (!wasDirty) await clearSpuriousOpenModified(target);
+        // Ownership re-check before EVERY re-baseline / destructive step: if this open
+        // outlived its own section (the 30s safety expiry, or a newer open taking over),
+        // other commands have been let through and we must not keep mutating as though we
+        // still held exclusivity. Leaving the tab spuriously "modified" is cosmetic; racing
+        // a concurrent edit is not.
+        if (!wasDirty && ownsWorkflowReloadGuard(reloadGuardToken)) {
+          await clearSpuriousOpenModified(target);
+        }
         // #433: an explicit open authoritatively re-points `active` — record it against
         // the epoch we STARTED on, but only if no reconnect intervened during the async
         // open (else its tab-restore may have overridden us — leave the window armed).
@@ -7827,6 +7854,19 @@ const GRAPH_TOOL_EXECUTORS = {
           reloadError =
             "this frontend does not expose the canvas interaction flag, so an automatic reload " +
             "could not be protected against a concurrent edit and was skipped";
+        } else if (
+          staleInfo.reload &&
+          !dirtyNow &&
+          !wasDirty &&
+          !ownsWorkflowReloadGuard(reloadGuardToken)
+        ) {
+          // Lost the section (expired, or superseded by a newer open) — concurrent commands
+          // may already have run against this canvas, so the "nothing unsaved" evidence is
+          // no longer trustworthy. Refuse the destructive reload and say so.
+          reloadError =
+            "the panel lost its exclusive switch/reload window (it took too long, or another " +
+            "open superseded it), so the automatic reload was skipped rather than risk " +
+            "overwriting work done in the meantime";
         } else if (staleInfo.reload && !dirtyNow && !wasDirty) {
           const diskGraph = JSON.parse(onDiskContent);
           // 4th arg associates the load with THIS tab (same as the repaint above), so the
@@ -7868,7 +7908,7 @@ const GRAPH_TOOL_EXECUTORS = {
     } finally {
       // Release BOTH on EVERY path — a throw anywhere above must never leave the user with
       // a frozen graph or the tab refusing every command.
-      workflowReloadGuard = null;
+      releaseWorkflowReloadGuard(reloadGuardToken);
       if (priorInteraction !== null) canvasView.allow_interaction = priorInteraction;
     }
     if (openFailed) throw failOpen(openFailed);
@@ -9841,6 +9881,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     attempt = 0;
     gaveUp = false;
     loggedWaiting = false;
+    // #508/#402 — replay the outcomes the previous socket could not deliver, so a command
+    // that genuinely ran is never silently swallowed by the reconnect. Deliberately HERE,
+    // on the real handshake, and not at bare socket-open (codex): an open socket only proves
+    // something is listening on the port, while a `models` frame proves a real orchestrator
+    // is behind it. The hello already went out at open, so the tab is registered by now.
+    replayLostReplies(sock);
     emitStatus("connected");
   }
 
@@ -9910,7 +9956,14 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // not a recovery. Such an entry is also meaningless there — its rid is unknown — so
       // it is dropped rather than carried forever. (Sensitive results are additionally
       // redacted at journal time and never travel at all.)
-      if (entry.url && entry.url !== targetUrl) {
+      // Replayable = SAME bridge AND recent enough (codex). A bridge is identified by its
+      // URL, and URL equality is ENDPOINT identity, not SESSION identity — a newly started
+      // orchestrator on the same address looks exactly like the old one reconnecting, which
+      // is the very case replay exists to serve. Proving session continuity needs a
+      // server-issued connection epoch in the handshake (an orchestrator-side follow-up), so
+      // until then the exposure is bounded: sensitive results never enter the journal at
+      // all, this runs only AFTER a real handshake, and stale entries age out here.
+      if (!isReplayable(entry, { now: Date.now(), targetUrl })) {
         dropped++;
         continue;
       }
@@ -9933,7 +9986,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     }
     if (dropped) {
       onLog(
-        `Discarded ${dropped} undelivered command result${dropped === 1 ? "" : "s"} belonging to a previous bridge — they are not replayed to a different agent.`,
+        `Discarded ${dropped} undelivered command result${dropped === 1 ? "" : "s"} that belong to a previous bridge or are too old to replay — they are not offered to a different agent.`,
       );
     }
   }
@@ -10008,10 +10061,6 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         onLog(`Connected to ${redactBridgeUrl(url)} — waiting for the panel agent…`);
       }
       sendHello();
-      // #508/#402 — AFTER the hello (the orchestrator must know this tab first), replay
-      // any command outcome the previous socket could not deliver, so a command that
-      // genuinely ran is never silently swallowed by the reconnect.
-      replayLostReplies(thisSock);
       clearHandshake();
       handshakeTimer = setTimeout(() => {
         if (handshakeDone) return;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9882,15 +9882,70 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       }, handshakeMs());
     });
 
+    /** #508 — write `reply` back on the socket the command ARRIVED on, and if that is
+     *  impossible, journal the outcome (for replay) and run the bounded self-heal.
+     *  Returns true only when the frame was actually handed to an open socket. */
+    const deliverReply = (reply, cmd, superseded) => {
+      const socketOpen = thisSock.readyState === WebSocket.OPEN;
+      let sendThrew = false;
+      if (socketOpen) {
+        try {
+          thisSock.send(JSON.stringify(reply));
+        } catch {
+          sendThrew = true;
+        }
+      }
+      if (socketOpen && !sendThrew) return true;
+      // The command was answered and its answer has nowhere to go. Name the ACTUAL cause
+      // instead of leaving the caller with the orchestrator's guess that the tab "may be
+      // backgrounded or frozen" — it was neither; it answered and we could not send.
+      handleUndeliveredReply(
+        lostReplies.record({
+          reply,
+          cmd,
+          reason: classifyUndeliveredReply({ socketOpen, superseded, sendThrew }),
+          at: Date.now(),
+        }),
+      );
+      return false;
+    };
+
     thisSock.addEventListener("message", async (ev) => {
-      if (!isActive()) return; // superseded socket — ignore its late frames
       let msg;
       try {
         msg = JSON.parse(typeof ev.data === "string" ? ev.data : "");
       } catch {
         return;
       }
-      if (msg && typeof msg.rid === "string" && typeof msg.cmd === "string") {
+      const isCommandFrame = msg && typeof msg.rid === "string" && typeof msg.cmd === "string";
+      if (!isActive()) {
+        // Superseded socket — a soft-reload/reconnect replaced it. Its late frames must NOT
+        // be processed: this belongs to the DEAD session, and running it would drive the
+        // fresh session's canvas and paint into its chat.
+        //
+        // #508 — but SILENCE is not an option either. Dropping a command frame outright is
+        // exactly the "registered tab that never acknowledges anything" wedge: the sender
+        // waits out its whole timeout and reports an unknown outcome for a command that
+        // provably never ran. Refuse it EXPLICITLY instead — nothing was executed, so this
+        // is a clean, safe-to-retry negative — and deliver/journal that refusal like any
+        // other reply.
+        if (isCommandFrame) {
+          deliverReply(
+            {
+              rid: msg.rid,
+              ok: false,
+              error:
+                `panel tab superseded before "${msg.cmd}" ran — this browser tab reconnected ` +
+                `(reload / soft reload / restart) and this command arrived on the retired ` +
+                `connection. NOTHING was applied; it is safe to re-issue on the current connection.`,
+            },
+            msg.cmd,
+            true,
+          );
+        }
+        return;
+      }
+      if (isCommandFrame) {
         // Agent command — execute against the graph, reply with the rid.
         // Executors may be async (run, save) — await uniformly.
         // ANY command frame is real turn activity (incl. the SILENT_CMDS that
@@ -10132,33 +10187,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         // sender with no outcome at all — the "registered tab that never acknowledges
         // anything" wedge. So: always attempt the reply; gate only the UI continuation.
         const superseded = !isActive();
-        const socketOpen = thisSock.readyState === WebSocket.OPEN;
-        let sendThrew = false;
-        if (socketOpen) {
-          try {
-            thisSock.send(JSON.stringify(reply));
-          } catch {
-            sendThrew = true;
-          }
-        }
-        if (socketOpen && !sendThrew) {
+        if (deliverReply(reply, msg.cmd, superseded)) {
           // #402 — the open receipt records that its answer was handed to a live socket.
           // ADVISORY only: a socket can still die before the bytes land, so this never
           // becomes a claim about what the caller received — only `applied` is that.
           markOpenReceiptReplySent(openReceipts, msg.rid);
-        } else {
-          // #508/#402 — the command RAN and its result has nowhere to go. Journal the
-          // exact frame (replayed on the next socket) and name the ACTUAL cause instead
-          // of leaving the caller with the orchestrator's guess that the tab "may be
-          // backgrounded or frozen" — it was neither; it answered and we could not send.
-          handleUndeliveredReply(
-            lostReplies.record({
-              reply,
-              cmd: msg.cmd,
-              reason: classifyUndeliveredReply({ socketOpen, superseded, sendThrew }),
-              at: Date.now(),
-            }),
-          );
         }
         if (superseded) return;
         // ask_user / request_secret paint their OWN cards and their replies carry

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -208,6 +208,7 @@ import {
   latestOpenReceipt,
   markOpenReceiptReplySent,
   summarizeOpenReceipt,
+  createSingleFlight,
 } from "./lib/open-outcome.js";
 import {
   classifyUndeliveredReply,
@@ -320,6 +321,11 @@ let activeWorkflowResyncEpoch = 0;
 // own (#433), which explains a matching `active` without our command ever running.
 const openReceipts = [];
 let openReceiptSeq = 0;
+// #402 / codex P2 — at most ONE outstanding staleness disk-read per workflow path. The
+// read is bounded by a deadline, but a deadline only stops US waiting: one of the two
+// read paths takes no AbortSignal, so without this a server that accepts requests and
+// never answers would leak a live request on every open of the same workflow.
+const staleReadFlight = createSingleFlight();
 // #508 — outcomes whose reply could NOT be written back. Replayed on the next socket and
 // summarized to the user, so a command that really ran is never silently swallowed.
 const lostReplies = createLostReplyJournal();
@@ -3032,18 +3038,22 @@ async function workflowExistsOnDisk(rawPath) {
  *  the frontend's own listing sync advances a workflow's `lastModified` without
  *  reloading its graph (which would defeat an mtime check) and timestamp-preserving
  *  writes would evade one. Fails safe (null ⇒ no false staleness). */
-async function workflowDiskContent(rawPath) {
+async function workflowDiskContent(rawPath, { signal } = {}) {
   try {
     if (!api || !rawPath) return null;
     // Prefer getUserData, but FALL BACK to fetchApi (mirrors workflowExistsOnDisk) so a
     // frontend that exposes only fetchApi — or where getUserData is momentarily absent —
     // still reads disk. Without this the read returned null and the staleness/overwrite
     // checks silently degraded (codex P2). null only for a genuinely unavailable api.
+    //
+    // `signal` (optional) lets a bounded caller CANCEL a read that outlived its deadline
+    // instead of leaving it running. It only reaches the fetchApi path — getUserData takes
+    // no options — which is why the bounded caller ALSO single-flights its reads.
     const res =
       typeof api.getUserData === "function"
         ? await api.getUserData(rawPath)
         : typeof api.fetchApi === "function"
-          ? await api.fetchApi(`/userdata/${encodeURIComponent(rawPath)}`)
+          ? await api.fetchApi(`/userdata/${encodeURIComponent(rawPath)}`, signal ? { signal } : undefined)
           : null;
     if (!res || res.status !== 200) return null;
     return await res.text();
@@ -7715,8 +7725,22 @@ const GRAPH_TOOL_EXECUTORS = {
     // long enough to turn into "disconnected mid-command … OUTCOME UNKNOWN". withDeadline
     // never rejects: a timeout degrades to the ALREADY-SUPPORTED honest `stale:"unknown"`,
     // exactly like an unreadable disk, and never to a false "fresh".
+      // codex P2 — the deadline stops US waiting; it cannot stop the REQUEST. So also
+      // (a) hand the read an AbortSignal and fire it when the budget expires, and
+      // (b) SINGLE-FLIGHT per workflow path, because one of the two read paths
+      // (api.getUserData) takes no signal at all. Together these cap the outstanding
+      // reads at one per workflow instead of leaking one per open against a server that
+      // accepts requests and never answers.
+      const readAbort = typeof AbortController === "function" ? new AbortController() : null;
       onDiskContent = wasOpen
-        ? await withDeadline(workflowDiskContent(target.path), OPEN_DISK_READ_BUDGET_MS, null)
+        ? await withDeadline(
+            staleReadFlight.run(target.path, () =>
+              workflowDiskContent(target.path, { signal: readAbort?.signal }),
+            ),
+            OPEN_DISK_READ_BUDGET_MS,
+            null,
+            { onTimeout: () => readAbort?.abort() },
+          )
         : null;
       // #442 defect 2 — RE-READ the file when it provably changed and nothing is at stake.
       // Re-check `isModified` HERE, immediately before deciding, rather than trusting the

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7643,48 +7643,22 @@ const GRAPH_TOOL_EXECUTORS = {
     // reads it fresh from disk. openWorkflow does NOT mutate originalContent for an
     // already-open tab (its load() early-returns), so the baseline stays valid.
     const wasOpen = !!target.changeTracker;
-    try {
-      await s.openWorkflow(target);
-    } catch (err) {
-      // The native switch itself failed — nothing was applied. Journal the negative so a
-      // lost reply can still be answered truthfully, then surface the error unchanged.
-      throw failOpen(err instanceof Error ? err : new Error(coerceMessageText(err)));
-    }
-    // We deliberately do NOT auto-reload the canvas from disk here: switching to an
-    // already-open tab must not silently discard the user's in-memory graph, and a
-    // re-read could race a concurrent canvas edit and clobber it. Instead the staleness
-    // is SURFACED (below) so the caller refreshes deliberately with panel_load_workflow
-    // — exactly the recovery the issue reporter uses. The load-bearing fix is turning a
-    // SILENT stale serve into a loud, actionable signal.
-    // openWorkflow sets the tab ACTIVE but does NOT repaint the canvas for an
-    // ALREADY-OPEN instance — the graph load normally rides the frontend's
-    // workflow *service* tab-switch, which the panel can't reach (it's a Vue
-    // composable, not on the store or window). So switching to an open tab left
-    // the PREVIOUS tab's graph frozen on the canvas ("all tabs show the same
-    // graph" — issue #65), and the earlier in-place-load attempts corrupted tab
-    // buffers (#63/#64). Force the repaint the way a real tab-click does: load
-    // the target's OWN live buffer (changeTracker.activeState — preserves its
-    // unsaved edits, NOT the on-disk copy) into ITS tab. The 4th arg (the
-    // workflow) associates the load with the target so it does NOT spawn a new
-    // "Unsaved Workflow" tab. Verified live in-browser (2026-07-08): switching
-    // among 12/39-node tabs repaints to the correct graph each time, no dup
-    // tabs, no cross-tab clobber. NOTE: getWorkflowByPath returns the SAME
-    // object as the open instance (verified), so find() needs no reorder — the
-    // #63 find() patch was a no-op that only regressed things.
-    //
-    // #442 / codex — FREEZE canvas interaction from HERE, before the repaint, and hold it
-    // through the staleness decision. `clearSpuriousOpenModified` below awaits a frame and
-    // then RE-BASELINES the change tracker (capture → reset → force isModified=false): an
-    // edit the user makes during that frame is absorbed as the new CLEAN baseline, so the
-    // later dirty gate reads false and would authorize the disk reload to overwrite that
-    // very edit. Sampling the flag later cannot fix that — the signal is already gone — so
-    // the window has to be closed instead. Scoped to `wasOpen` (the only case that can
-    // reload) so a plain first-time open never freezes, and always restored in a finally.
+    // #442 / codex — SNAPSHOT the tab's unsaved-edit state BEFORE any await. It cannot be
+    // recovered later: `clearSpuriousOpenModified` below force-clears `isModified`, so by
+    // the time the reload gate samples the flag, a tab that arrived here WITH unsaved
+    // edits (or was edited during `openWorkflow`) already reads clean. That erased signal
+    // is what would authorize the destructive re-read to discard the user's work.
+    const wasDirty = !!target.isModified;
     // Bound to a local whose name does NOT end in "s": the #268 frontend-contract scanner
     // captures members off the workflow-service alias `s` with an unanchored `s\.` pattern,
     // so `canvas.<member>` would be misread as a new workflow-SERVICE dependency. This is a
     // LiteGraph canvas flag, not a workflow-service member.
     const canvasView = app?.canvas;
+    // FREEZE canvas interaction across the WHOLE mutating sequence — the tab switch, the
+    // repaint, the re-baseline, the bounded disk read and the reload — so no edit can land
+    // in a window whose dirty signal we are about to overwrite. Scoped to `wasOpen` (the
+    // only case that can reload) so a plain first-time open never freezes, and restored in
+    // a finally on every path.
     const priorInteraction =
       wasOpen && typeof canvasView?.allow_interaction === "boolean"
         ? canvasView.allow_interaction
@@ -7694,113 +7668,165 @@ const GRAPH_TOOL_EXECUTORS = {
     let staleInfo = { stale: false, reload: false };
     let reloaded = false;
     let reloadError = null;
+    let openFailed = null;
     if (priorInteraction !== null) canvasView.allow_interaction = false;
     try {
       try {
-        const st = target.changeTracker?.activeState;
-        if (st && typeof app.loadGraphData === "function") {
-          await app.loadGraphData(JSON.parse(JSON.stringify(st)), true, true, target);
-        }
+        await s.openWorkflow(target);
       } catch (err) {
-        console.warn("[comfyui-mcp-panel] workflow_open repaint failed:", err?.message ?? err);
+        // The native switch itself failed — nothing was applied. Recorded, then rethrown
+        // through failOpen below (outside the freeze) so the negative is journaled.
+        openFailed = err instanceof Error ? err : new Error(coerceMessageText(err));
       }
-      // Opening alone must not dirty the tab (a spurious post-load change-tracker
-      // diff otherwise flips it to modified:true and blocks an unforced close).
-      await clearSpuriousOpenModified(target);
-      // #433: an explicit open authoritatively re-points `active` — record it against
-      // the epoch we STARTED on, but only if no reconnect intervened during the async
-      // open (else its tab-restore may have overridden us — leave the window armed).
-      if (backendReconnectEpoch === openedForEpoch) activeWorkflowResyncEpoch = openedForEpoch;
-    // #442 — read the on-disk bytes AS LATE AS POSSIBLE (after openWorkflow + repaint),
-    // so an external write during those awaits is still detected. wasOpen was captured
-    // before openWorkflow; the baseline (originalContent) is unchanged by an already-open
-    // open.
-    //
-    // #402 — BOUND this read. The open has ALREADY been applied by the time we get here,
-    // so the only thing still outstanding is a staleness HINT — yet the read is an HTTP
-    // round-trip to ComfyUI, and in the exact #402 window ComfyUI's HTTP layer is what is
-    // flaky (the same report's panel_save_workflow returned "Failed to fetch"). Unbounded,
-    // a server that accepts the connection and never answers parks a known-good outcome
-    // for the whole browser timeout — which is precisely how a routine reconnect blip gets
-    // long enough to turn into "disconnected mid-command … OUTCOME UNKNOWN". withDeadline
-    // never rejects: a timeout degrades to the ALREADY-SUPPORTED honest `stale:"unknown"`,
-    // exactly like an unreadable disk, and never to a false "fresh".
-      // codex P2 — the deadline stops US waiting; it cannot stop the REQUEST. So also
-      // (a) hand the read an AbortSignal and fire it when the budget expires, and
-      // (b) SINGLE-FLIGHT per workflow path, because one of the two read paths
-      // (api.getUserData) takes no signal at all. Together these cap the outstanding
-      // reads at one per workflow instead of leaking one per open against a server that
-      // accepts requests and never answers.
-      const readAbort = typeof AbortController === "function" ? new AbortController() : null;
-      onDiskContent = wasOpen
-        ? await withDeadline(
-            staleReadFlight.run(target.path, () =>
-              workflowDiskContent(target.path, { signal: readAbort?.signal }),
-            ),
-            OPEN_DISK_READ_BUDGET_MS,
-            null,
-            { onTimeout: () => readAbort?.abort() },
-          )
-        : null;
-      // #442 defect 2 — RE-READ the file when it provably changed and nothing is at stake.
-      // Re-check `isModified` HERE, immediately before deciding, rather than trusting the
-      // value from before the disk read: reloading over unsaved edits is data-loss class —
-      // strictly worse than serving a stale graph. There is NO await between this re-check
-      // and the reload decision below. (Interaction is frozen across this whole block, so
-      // this is a belt-and-braces second line of defence, not the only one.)
-      dirtyNow = !!target.isModified;
-      staleInfo = decideOpenStaleness({
-        wasOpen,
-        isModified: dirtyNow,
-        onDiskContent,
-        baselineContent:
-          typeof target.originalContent === "string" ? target.originalContent : null,
-      });
-      // `reload` is true only for "the file changed AND this tab has nothing unsaved", so
-      // the re-read is lossless. A stale tab WITH unsaved edits is a genuine conflict: we
-      // refuse and surface both sides rather than picking for the user.
+      if (!openFailed) {
+      // We deliberately do NOT auto-reload the canvas from disk here: switching to an
+      // already-open tab must not silently discard the user's in-memory graph, and a
+      // re-read could race a concurrent canvas edit and clobber it. Instead the staleness
+      // is SURFACED (below) so the caller refreshes deliberately with panel_load_workflow
+      // — exactly the recovery the issue reporter uses. The load-bearing fix is turning a
+      // SILENT stale serve into a loud, actionable signal.
+      // openWorkflow sets the tab ACTIVE but does NOT repaint the canvas for an
+      // ALREADY-OPEN instance — the graph load normally rides the frontend's
+      // workflow *service* tab-switch, which the panel can't reach (it's a Vue
+      // composable, not on the store or window). So switching to an open tab left
+      // the PREVIOUS tab's graph frozen on the canvas ("all tabs show the same
+      // graph" — issue #65), and the earlier in-place-load attempts corrupted tab
+      // buffers (#63/#64). Force the repaint the way a real tab-click does: load
+      // the target's OWN live buffer (changeTracker.activeState — preserves its
+      // unsaved edits, NOT the on-disk copy) into ITS tab. The 4th arg (the
+      // workflow) associates the load with the target so it does NOT spawn a new
+      // "Unsaved Workflow" tab. Verified live in-browser (2026-07-08): switching
+      // among 12/39-node tabs repaints to the correct graph each time, no dup
+      // tabs, no cross-tab clobber. NOTE: getWorkflowByPath returns the SAME
+      // object as the open instance (verified), so find() needs no reorder — the
+      // #63 find() patch was a no-op that only regressed things.
       //
-      // The earlier no-await-before-return invariant is intact: this block runs ONLY when
-      // staleInfo.stale === true, and it never downgrades that to "fresh" — so the
-      // false-fresh window codex closed (read stale → file changes → report fresh) still
-      // cannot open. The provably-fresh and "unknown" paths reach the return with no await.
-      if (staleInfo.reload && !dirtyNow && priorInteraction === null) {
-        // NO reliable freeze on this frontend ⇒ do NOT perform the automatic destructive
-        // reload at all (codex). Serving a stale graph with a loud flag is recoverable;
-        // silently eating an edit the user made during an unrequested load is not.
-        reloadError =
-          "this frontend does not expose the canvas interaction flag, so an automatic reload " +
-          "could not be protected against a concurrent edit and was skipped";
-      } else if (staleInfo.reload && !dirtyNow) {
-        const diskGraph = JSON.parse(onDiskContent);
-        // 4th arg associates the load with THIS tab (same as the repaint above), so the
-        // on-disk graph replaces the tab's buffer in place instead of spawning a new
-        // "Unsaved Workflow" tab.
-        //
-        // #570 P0b — `__cmcpKeepInstance` is MANDATORY here, exactly as on graph_load.
-        // This is an in-place reload of the SAME tab from a file that was written
-        // OUT OF BAND, so its embedded workflow uuid may be absent or belong to
-        // something else. Without the flag the create-boundary fork would see
-        // cached-uuid ≠ incoming-uuid, treat the refresh as an in-place REPLACEMENT and
-        // mint a NEW identity for this tab mid-open — after which the very next stamped
-        // command would be refused as a "workflow instance mismatch" against the session
-        // that asked for the open. The flag keeps the LIVE OBJECT's identity (the
-        // non-forgeable source) and stamps it over whatever the file carried.
-        await app.loadGraphData(diskGraph, true, true, target, { __cmcpKeepInstance: true });
-        // The tab now holds exactly the on-disk bytes — re-baseline so this same change
-        // isn't re-reported as stale forever. Best-effort: `originalContent` is a plain
-        // field on current builds but may be getter-only elsewhere.
+      // #442 / codex — FREEZE canvas interaction from HERE, before the repaint, and hold it
+      // through the staleness decision. `clearSpuriousOpenModified` below awaits a frame and
+      // then RE-BASELINES the change tracker (capture → reset → force isModified=false): an
+      // edit the user makes during that frame is absorbed as the new CLEAN baseline, so the
+      // later dirty gate reads false and would authorize the disk reload to overwrite that
+      // very edit. Sampling the flag later cannot fix that — the signal is already gone — so
+      // the window has to be closed instead. Scoped to `wasOpen` (the only case that can
+      // reload) so a plain first-time open never freezes, and always restored in a finally.
+      // Bound to a local whose name does NOT end in "s": the #268 frontend-contract scanner
+      // captures members off the workflow-service alias `s` with an unanchored `s\.` pattern,
+      // so `canvas.<member>` would be misread as a new workflow-SERVICE dependency. This is a
+      // LiteGraph canvas flag, not a workflow-service member.
         try {
-          target.originalContent = onDiskContent;
-        } catch {
-          /* getter-only — the stale flag simply re-reports until the next save */
+          const st = target.changeTracker?.activeState;
+          if (st && typeof app.loadGraphData === "function") {
+            await app.loadGraphData(JSON.parse(JSON.stringify(st)), true, true, target);
+          }
+        } catch (err) {
+          console.warn("[comfyui-mcp-panel] workflow_open repaint failed:", err?.message ?? err);
         }
-        // A programmatic load dirties the change tracker; clear that so the re-read does
-        // not leave the tab looking edited (which would block an unforced close). Still
-        // inside the freeze — it re-baselines, so an edit made during its frame would be
-        // adopted as "not modified" and could later be discarded without a prompt.
-        await clearSpuriousOpenModified(target);
-        reloaded = true;
+        // Opening alone must not dirty the tab (a spurious post-load change-tracker
+        // diff otherwise flips it to modified:true and blocks an unforced close).
+        //
+        // …but ONLY when the tab arrived here CLEAN. This helper captures the current canvas
+        // as the new baseline and forces isModified=false, so running it on a tab that
+        // already HAD unsaved edits does not clear a spurious flag — it erases a REAL one,
+        // hiding the user's work from every later check (codex). Leaving a genuinely dirty
+        // tab marked dirty is both truthful and what keeps the reload gate below closed.
+        if (!wasDirty) await clearSpuriousOpenModified(target);
+        // #433: an explicit open authoritatively re-points `active` — record it against
+        // the epoch we STARTED on, but only if no reconnect intervened during the async
+        // open (else its tab-restore may have overridden us — leave the window armed).
+        if (backendReconnectEpoch === openedForEpoch) activeWorkflowResyncEpoch = openedForEpoch;
+      // #442 — read the on-disk bytes AS LATE AS POSSIBLE (after openWorkflow + repaint),
+      // so an external write during those awaits is still detected. wasOpen was captured
+      // before openWorkflow; the baseline (originalContent) is unchanged by an already-open
+      // open.
+      //
+      // #402 — BOUND this read. The open has ALREADY been applied by the time we get here,
+      // so the only thing still outstanding is a staleness HINT — yet the read is an HTTP
+      // round-trip to ComfyUI, and in the exact #402 window ComfyUI's HTTP layer is what is
+      // flaky (the same report's panel_save_workflow returned "Failed to fetch"). Unbounded,
+      // a server that accepts the connection and never answers parks a known-good outcome
+      // for the whole browser timeout — which is precisely how a routine reconnect blip gets
+      // long enough to turn into "disconnected mid-command … OUTCOME UNKNOWN". withDeadline
+      // never rejects: a timeout degrades to the ALREADY-SUPPORTED honest `stale:"unknown"`,
+      // exactly like an unreadable disk, and never to a false "fresh".
+        // codex P2 — the deadline stops US waiting; it cannot stop the REQUEST. So also
+        // (a) hand the read an AbortSignal and fire it when the budget expires, and
+        // (b) SINGLE-FLIGHT per workflow path, because one of the two read paths
+        // (api.getUserData) takes no signal at all. Together these cap the outstanding
+        // reads at one per workflow instead of leaking one per open against a server that
+        // accepts requests and never answers.
+        const readAbort = typeof AbortController === "function" ? new AbortController() : null;
+        onDiskContent = wasOpen
+          ? await withDeadline(
+              staleReadFlight.run(target.path, () =>
+                workflowDiskContent(target.path, { signal: readAbort?.signal }),
+              ),
+              OPEN_DISK_READ_BUDGET_MS,
+              null,
+              { onTimeout: () => readAbort?.abort() },
+            )
+          : null;
+        // #442 defect 2 — RE-READ the file when it provably changed and nothing is at stake.
+        // Re-check `isModified` HERE, immediately before deciding, rather than trusting the
+        // value from before the disk read: reloading over unsaved edits is data-loss class —
+        // strictly worse than serving a stale graph. There is NO await between this re-check
+        // and the reload decision below. (Interaction is frozen across this whole block, so
+        // this is a belt-and-braces second line of defence, not the only one.)
+        dirtyNow = !!target.isModified;
+        staleInfo = decideOpenStaleness({
+          wasOpen,
+          // EITHER signal counts as unsaved work: the flag as it reads NOW, and the snapshot
+          // taken before any await (which clearSpuriousOpenModified can no longer erase).
+          isModified: dirtyNow || wasDirty,
+          onDiskContent,
+          baselineContent:
+            typeof target.originalContent === "string" ? target.originalContent : null,
+        });
+        // `reload` is true only for "the file changed AND this tab has nothing unsaved", so
+        // the re-read is lossless. A stale tab WITH unsaved edits is a genuine conflict: we
+        // refuse and surface both sides rather than picking for the user.
+        //
+        // The earlier no-await-before-return invariant is intact: this block runs ONLY when
+        // staleInfo.stale === true, and it never downgrades that to "fresh" — so the
+        // false-fresh window codex closed (read stale → file changes → report fresh) still
+        // cannot open. The provably-fresh and "unknown" paths reach the return with no await.
+        if (staleInfo.reload && !dirtyNow && !wasDirty && priorInteraction === null) {
+          // NO reliable freeze on this frontend ⇒ do NOT perform the automatic destructive
+          // reload at all (codex). Serving a stale graph with a loud flag is recoverable;
+          // silently eating an edit the user made during an unrequested load is not.
+          reloadError =
+            "this frontend does not expose the canvas interaction flag, so an automatic reload " +
+            "could not be protected against a concurrent edit and was skipped";
+        } else if (staleInfo.reload && !dirtyNow && !wasDirty) {
+          const diskGraph = JSON.parse(onDiskContent);
+          // 4th arg associates the load with THIS tab (same as the repaint above), so the
+          // on-disk graph replaces the tab's buffer in place instead of spawning a new
+          // "Unsaved Workflow" tab.
+          //
+          // #570 P0b — `__cmcpKeepInstance` is MANDATORY here, exactly as on graph_load.
+          // This is an in-place reload of the SAME tab from a file that was written
+          // OUT OF BAND, so its embedded workflow uuid may be absent or belong to
+          // something else. Without the flag the create-boundary fork would see
+          // cached-uuid ≠ incoming-uuid, treat the refresh as an in-place REPLACEMENT and
+          // mint a NEW identity for this tab mid-open — after which the very next stamped
+          // command would be refused as a "workflow instance mismatch" against the session
+          // that asked for the open. The flag keeps the LIVE OBJECT's identity (the
+          // non-forgeable source) and stamps it over whatever the file carried.
+          await app.loadGraphData(diskGraph, true, true, target, { __cmcpKeepInstance: true });
+          // The tab now holds exactly the on-disk bytes — re-baseline so this same change
+          // isn't re-reported as stale forever. Best-effort: `originalContent` is a plain
+          // field on current builds but may be getter-only elsewhere.
+          try {
+            target.originalContent = onDiskContent;
+          } catch {
+            /* getter-only — the stale flag simply re-reports until the next save */
+          }
+          // A programmatic load dirties the change tracker; clear that so the re-read does
+          // not leave the tab looking edited (which would block an unforced close). Still
+          // inside the freeze — it re-baselines, so an edit made during its frame would be
+          // adopted as "not modified" and could later be discarded without a prompt.
+          await clearSpuriousOpenModified(target);
+          reloaded = true;
+        }
       }
     } catch (err) {
       // NEVER claim a reload we did not complete — report the failure and leave the caller
@@ -7813,6 +7839,7 @@ const GRAPH_TOOL_EXECUTORS = {
       // user with a frozen graph.
       if (priorInteraction !== null) canvasView.allow_interaction = priorInteraction;
     }
+    if (openFailed) throw failOpen(openFailed);
     const receipt = noteOpenAttempt({
       cmd: "workflow_open",
       rid,
@@ -7848,7 +7875,7 @@ const GRAPH_TOOL_EXECUTORS = {
                   stale_hint:
                     "The file had changed on disk since this tab loaded it, and this tab had no unsaved edits, so the canvas was RELOADED from the on-disk version. Re-read the graph (panel_graph_outline / panel_query_graph) — node ids and geometry may differ from before.",
                 }
-              : dirtyNow
+              : dirtyNow || wasDirty
                 ? {
                     conflict: true,
                     stale_hint:

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9821,6 +9821,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // Budget spent with a live socket — stop retrying and hand the user a real action.
       onLog(reRegisterExhaustedHint());
     }
+    // codex — DELIVER IT NOW, on the live socket. The replacement socket runs its replay
+    // once, at open; a long command still running on the retired socket finishes AFTER
+    // that, so the journal was empty when the replay fired and this entry would otherwise
+    // sit there until some future reconnect that may never come — leaving the original
+    // caller with the unknown outcome this whole change exists to remove. Unconditional
+    // (not gated on the re-registration budget): telling the truth is not a retry.
+    replayLostReplies(sock);
   }
 
   /** #508/#402 — re-send outcomes we could not deliver, onto a freshly-opened socket.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -330,6 +330,30 @@ const staleReadFlight = createSingleFlight();
 // summarized to the user, so a command that really ran is never silently swallowed.
 const lostReplies = createLostReplyJournal();
 
+// #442 / codex — WORKFLOW SWITCH+RELOAD CRITICAL SECTION. Freezing the CANVAS keeps the
+// USER out of the window between the dirty check and the destructive re-read, but the
+// bridge is a second writer: the socket listener is async and re-entrant, so a perfectly
+// valid, correctly-stamped graph_* command can land mid-reload. It would either be
+// overwritten by the load, or — worse — land during the tracker re-baseline and be marked
+// CLEAN, so the next out-of-band disk change silently discards it with no conflict shown.
+// While this guard is held, every graph/workflow executor is REFUSED with a retryable
+// error (nothing applied) rather than queued: refusing cannot reorder or double-apply, and
+// the window is a fraction of a second.
+let workflowReloadGuard = null;
+// Defensive ceiling: a guard can only ever be cleared by workflow_open's finally, so if
+// some pathological path ever failed to run it, an un-expiring guard would wedge every
+// command in the tab. Age it out instead.
+const WORKFLOW_RELOAD_GUARD_MAX_MS = 30000;
+/** The guard, or null when none is held (expiring a stuck one on the way). */
+function activeWorkflowReloadGuard() {
+  if (!workflowReloadGuard) return null;
+  if (Date.now() - workflowReloadGuard.since > WORKFLOW_RELOAD_GUARD_MAX_MS) {
+    workflowReloadGuard = null;
+    return null;
+  }
+  return workflowReloadGuard;
+}
+
 /** Journal one open attempt and return its receipt. `applied:false` (with the error) is
  *  recorded too — a genuine negative is as load-bearing as a positive here. */
 function noteOpenAttempt({ cmd, rid, requested, resolved, applied, error }) {
@@ -7670,6 +7694,13 @@ const GRAPH_TOOL_EXECUTORS = {
     let reloadError = null;
     let openFailed = null;
     if (priorInteraction !== null) canvasView.allow_interaction = false;
+    // Hold the switch+reload critical section across the WHOLE mutating sequence. The canvas
+    // freeze keeps the USER out; this keeps the BRIDGE out, so a concurrent graph_* command
+    // can neither be overwritten by the reload nor be silently re-baselined as clean.
+    workflowReloadGuard = {
+      key: workflowTabId(target) || target.path || "the active workflow",
+      since: Date.now(),
+    };
     try {
       try {
         await s.openWorkflow(target);
@@ -7835,8 +7866,9 @@ const GRAPH_TOOL_EXECUTORS = {
       reloadError = coerceMessageText(err?.message ?? err);
       console.warn("[comfyui-mcp-panel] workflow_open disk re-read failed:", reloadError);
     } finally {
-      // Hand the canvas back on EVERY path — a throw anywhere above must never leave the
-      // user with a frozen graph.
+      // Release BOTH on EVERY path — a throw anywhere above must never leave the user with
+      // a frozen graph or the tab refusing every command.
+      workflowReloadGuard = null;
       if (priorInteraction !== null) canvasView.allow_interaction = priorInteraction;
     }
     if (openFailed) throw failOpen(openFailed);
@@ -9865,6 +9897,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
   function replayLostReplies(target) {
     const lost = lostReplies.list();
     if (!lost.length) return;
+    // The bridge THIS socket belongs to (stamped at creation), not the mutable current
+    // `url` — after setUrl the two can differ while the old socket is still closing.
+    const targetUrl = target?.__cmcpBridgeUrl ?? url;
     let sent = 0;
     let dropped = 0;
     const keep = [];
@@ -9875,7 +9910,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // not a recovery. Such an entry is also meaningless there — its rid is unknown — so
       // it is dropped rather than carried forever. (Sensitive results are additionally
       // redacted at journal time and never travel at all.)
-      if (entry.url && entry.url !== url) {
+      if (entry.url && entry.url !== targetUrl) {
         dropped++;
         continue;
       }
@@ -9916,9 +9951,14 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     // on each background retry — that latched "disconnected" is what stops the
     // connecting↔disconnected flicker.
     if (!gaveUp) emitStatus("connecting");
+    // codex — capture the URL THIS socket dials. `url` is mutable (setUrl swaps it before
+    // the old socket closes), so a command still finishing on a retired socket would
+    // otherwise journal its result under the NEW bridge's URL and sail past the
+    // cross-bridge check that exists to stop exactly that.
+    const socketUrl = url;
     let thisSock;
     try {
-      thisSock = new WebSocket(url);
+      thisSock = new WebSocket(socketUrl);
     } catch (err) {
       // Constructor threw before a socket exists → no open/close will fire, so we
       // drive the retry directly. Keep the status steady (scheduleReconnect decides
@@ -9927,6 +9967,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       return;
     }
     sock = thisSock;
+    // Stamp the socket with the bridge it belongs to, so a replay onto it can be checked
+    // against the entry's origin rather than against the mutable current `url`.
+    try {
+      thisSock.__cmcpBridgeUrl = socketUrl;
+    } catch {
+      /* exotic WebSocket impl — replayLostReplies falls back to the current url */
+    }
 
     // INSTANCE GUARD (panel #379 race): every listener below is bound to THIS socket
     // instance and no-ops unless it is still the active `sock`. A soft-reload / restart
@@ -10013,8 +10060,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           cmd,
           reason: classifyUndeliveredReply({ socketOpen, superseded, sendThrew }),
           at: Date.now(),
-          // Stamp the bridge this outcome belongs to so a replay can never cross it.
-          url,
+          // Stamp the bridge this outcome belongs to so a replay can never cross it. THIS
+          // socket's url, never the mutable current one (codex).
+          url: socketUrl,
         }),
       );
       return false;
@@ -10144,6 +10192,19 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           } else {
             const executor = GRAPH_TOOL_EXECUTORS[msg.cmd];
             if (!executor) throw new Error(`Unknown command "${msg.cmd}"`);
+            // #442 / codex — the panel is mid switch-and-reload of a workflow. Running now
+            // would either be overwritten by the incoming graph, or land during the change
+            // tracker's re-baseline and be recorded as CLEAN — after which a later
+            // out-of-band disk change would discard it with no conflict reported. REFUSE
+            // (nothing applied, safe to retry) rather than queue: refusing cannot reorder
+            // or double-apply, and the section lasts a fraction of a second.
+            const reloadGuard = activeWorkflowReloadGuard();
+            if (reloadGuard) {
+              throw new Error(
+                `the panel is switching/refreshing "${reloadGuard.key}" right now, so "${msg.cmd}" ` +
+                  `was NOT applied — nothing changed. Retry in a moment.`,
+              );
+            }
             // WORKFLOW-INSTANCE FENCE (#570): the orchestrator stamps each command with the
             // trusted per-instance workflow_uuid it was ISSUED FOR. A command that runs against
             // the ACTIVE workflow but arrives AFTER the user switched or replaced it (a frame the

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7465,9 +7465,35 @@ const GRAPH_TOOL_EXECUTORS = {
     // P1). We only claim authoritative below when the epoch is UNCHANGED.
     const openedForEpoch = backendReconnectEpoch;
     const mgr = app?.extensionManager;
-    if (!mgr?.command?.execute) throw new Error("command service unavailable");
+    if (!mgr?.command?.execute) {
+      // Nothing ran — a clean negative (#402): safe to retry.
+      noteOpenAttempt({
+        cmd: "workflow_new",
+        rid,
+        requested: null,
+        resolved: null,
+        applied: false,
+        error: "command service unavailable",
+      });
+      throw new Error("command service unavailable");
+    }
     // Comfy.NewBlankWorkflow opens a fresh TAB — the current workflow is untouched.
-    await mgr.command.execute("Comfy.NewBlankWorkflow");
+    try {
+      await mgr.command.execute("Comfy.NewBlankWorkflow");
+    } catch (err) {
+      // The creation command itself threw. It may have got partway, and workflow_new is
+      // NOT idempotent — a blind retry can leave a second blank tab. Journal it as
+      // UNKNOWN, never as a clean failure (#402 / codex).
+      noteOpenAttempt({
+        cmd: "workflow_new",
+        rid,
+        requested: null,
+        resolved: null,
+        applied: "unknown",
+        error: coerceMessageText(err?.message ?? err),
+      });
+      throw err instanceof Error ? err : new Error(coerceMessageText(err));
+    }
     // Bind a UNIQUE, stable routing identity to the just-created tab NOW, at
     // creation, so a session pinned to this key routes subsequent graph_* edits to
     // THIS graph and never a pre-existing "Unsaved Workflow" tab (#186). Native
@@ -7478,11 +7504,23 @@ const GRAPH_TOOL_EXECUTORS = {
     // a title alone would invite the agent to edit whatever unsaved tab is active.
     const wf = activeWorkflowRef();
     if (!wf) {
-      throw new Error(
+      // #402 / codex — the blank tab WAS created; only the routing identity is missing. If
+      // this reply is lost, "no receipt" and "applied:false" would both read as "nothing
+      // happened" and invite a retry — and workflow_new is NOT idempotent, so that retry
+      // leaves a SECOND blank workflow behind. Journal it as UNKNOWN instead.
+      const error =
         "workflow_new: created a blank workflow but the frontend did not expose it as the " +
-          "active workflow — cannot establish a unique routing target. Retry, or select the new " +
-          "tab before editing.",
-      );
+        "active workflow — cannot establish a unique routing target. Retry, or select the new " +
+        "tab before editing.";
+      noteOpenAttempt({
+        cmd: "workflow_new",
+        rid,
+        requested: null,
+        resolved: null,
+        applied: "unknown",
+        error,
+      });
+      throw new Error(error);
     }
     // Mint the per-instance tmp: routing id (and seed the transcript uuid) eagerly so
     // the key exists BEFORE the first edit and is returned for pinning.
@@ -7655,26 +7693,32 @@ const GRAPH_TOOL_EXECUTORS = {
     // staleInfo.stale === true, and it never downgrades that to "fresh" — so the
     // false-fresh window codex closed (read stale → file changes → report fresh) still
     // cannot open. The provably-fresh and "unknown" paths reach the return with no await.
+    // The clean sample above authorizes the load, but everything that follows is AWAITED —
+    // `loadGraphData` may yield before it replaces the graph, and clearSpuriousOpenModified
+    // awaits a frame and then RE-BASELINES the change tracker (capture → reset → force
+    // isModified=false). A canvas edit landing in EITHER window would be destroyed by, or
+    // silently absorbed into, a reload the user never asked for (codex P1 x2). Nobody
+    // requested this reload, so it must not be able to take work with it: freeze canvas
+    // interaction across the WHOLE sequence — load AND re-baseline — and restore it in a
+    // finally. Bound to a local whose name does NOT end in "s": the #268 frontend-contract
+    // scanner captures members off the workflow-service alias `s` with an unanchored `s\.`
+    // pattern, so `canvas.<member>` would be misread as a new workflow-SERVICE dependency.
+    // This is a LiteGraph canvas flag, not a workflow-service member.
+    const canvasView = app?.canvas;
+    const priorInteraction =
+      typeof canvasView?.allow_interaction === "boolean" ? canvasView.allow_interaction : null;
     let reloaded = false;
     let reloadError = null;
-    if (staleInfo.reload && !dirtyNow) {
-      // The clean sample above authorizes the load, but `loadGraphData` is AWAITED — if it
-      // yields before it replaces the graph, a canvas edit made in that window would be
-      // destroyed by a load the user never asked for (codex P1). Nobody requested this
-      // reload, so it must not be able to take work with it: freeze canvas interaction for
-      // the duration and restore it in a finally, whatever happens. Best-effort by design
-      // (the flag name is a LiteGraph detail that may move), so it NARROWS the window
-      // rather than proving it shut — which is why the last-instant `dirtyNow` re-check
-      // above stays, and why a dirty tab is never reloaded at all.
-      // Bound to a local whose name does NOT end in "s": the #268 frontend-contract
-      // scanner captures members off the workflow-service alias `s` with an unanchored
-      // `s\.` pattern, so `canvas.<member>` would be misread as a new workflow-SERVICE
-      // dependency. This is a LiteGraph canvas flag, not a workflow-service member.
-      const canvasView = app?.canvas;
-      const priorInteraction =
-        typeof canvasView?.allow_interaction === "boolean" ? canvasView.allow_interaction : null;
+    if (staleInfo.reload && !dirtyNow && priorInteraction === null) {
+      // NO reliable freeze on this frontend ⇒ do NOT perform the automatic destructive
+      // reload at all (codex). Serving a stale graph with a loud flag is recoverable;
+      // silently eating an edit the user made during an unrequested load is not.
+      reloadError =
+        "this frontend does not expose the canvas interaction flag, so an automatic reload " +
+        "could not be protected against a concurrent edit and was skipped";
+    } else if (staleInfo.reload && !dirtyNow) {
       try {
-        if (priorInteraction !== null) canvasView.allow_interaction = false;
+        canvasView.allow_interaction = false;
         const diskGraph = JSON.parse(onDiskContent);
         // 4th arg associates the load with THIS tab (same as the repaint above), so the
         // on-disk graph replaces the tab's buffer in place instead of spawning a new
@@ -7698,6 +7742,11 @@ const GRAPH_TOOL_EXECUTORS = {
         } catch {
           /* getter-only — the stale flag simply re-reports until the next save */
         }
+        // A programmatic load dirties the change tracker; clear that so the re-read does
+        // not leave the tab looking edited (which would block an unforced close). INSIDE
+        // the freeze on purpose: it re-baselines, so an edit made during its frame would be
+        // adopted as "not modified" and could later be discarded without a prompt.
+        await clearSpuriousOpenModified(target);
         reloaded = true;
       } catch (err) {
         // NEVER claim a reload we did not complete — report the failure and leave the
@@ -7707,12 +7756,8 @@ const GRAPH_TOOL_EXECUTORS = {
       } finally {
         // Hand the canvas back on EVERY path — a throw here must never leave the user
         // with a frozen graph.
-        if (priorInteraction !== null) canvasView.allow_interaction = priorInteraction;
+        canvasView.allow_interaction = priorInteraction;
       }
-      // A programmatic load dirties the change tracker; clear that so the re-read does not
-      // leave the tab looking edited (which would block an unforced close). Outside the
-      // interaction lock: it awaits a frame, and the canvas must be live by then.
-      if (reloaded) await clearSpuriousOpenModified(target);
     }
     const receipt = noteOpenAttempt({
       cmd: "workflow_open",

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3236,7 +3236,13 @@ function nextFrame() {
  *  open stays modified:false. This mirrors what the frontend's own save() does
  *  (changeTracker.reset(); isModified = false), minus the disk write — opening
  *  from disk means the loaded graph already IS the saved state. Best-effort +
- *  feature-detected; never throws. */
+ *  feature-detected; never throws.
+ *
+ *  Callers must hold the canvas interaction freeze around this — the awaited
+ *  frame below is exactly the gap in which an UNPROTECTED edit would be adopted
+ *  as the new clean baseline (a silent clean-slate over real work). A first-time
+ *  open is never frozen by design, so it does not get this cleanup at all: it
+ *  keeps the spurious flag (loud, cosmetic) instead. */
 async function clearSpuriousOpenModified(wf, { stillOwns } = {}) {
   if (!wf) return;
   try {
@@ -7871,14 +7877,16 @@ const GRAPH_TOOL_EXECUTORS = {
         // already HAD unsaved edits does not clear a spurious flag — it erases a REAL one,
         // hiding the user's work from every later check (codex). Leaving a genuinely dirty
         // tab marked dirty is both truthful and what keeps the reload gate below closed.
-        // …and ONLY when either no reload is possible (!wasOpen) or the canvas freeze is
-        // holding (priorInteraction !== null). On a frontend WITHOUT allow_interaction the
-        // helper's awaited frame is unprotected: an edit landing in it would be captured as
-        // the new CLEAN baseline, silently erasing unsaved-work protection — and that same
-        // condition (priorInteraction === null) is what skips the reload below, so the
-        // re-baseline would be a silent clean-slate in service of a reload that never
-        // happens. Leave the tracker alone there: a spurious "modified" flag is cosmetic
-        // and keeps the dirty signal alive for the conflict report below.
+        // …and ONLY while the canvas freeze is holding (priorInteraction !== null). The
+        // helper's awaited frame is otherwise unprotected: an edit landing in it would be
+        // captured as the new CLEAN baseline, silently erasing unsaved-work protection —
+        // and a later stale open could then auto-reload the disk file over that work.
+        // That excludes BOTH the no-freeze frontend (priorInteraction === null, the same
+        // condition that skips the reload below) AND the first-time open, which is never
+        // frozen by design (the freeze stays scoped to wasOpen — see above). A spurious
+        // "modified" flag on a fresh open is cosmetic (it may block an unforced close
+        // until a save) and keeps the dirty signal alive; a silent clean-slate over a
+        // real edit is neither.
         // Ownership re-check before EVERY re-baseline / destructive step: if this open
         // outlived its own section (the 30s safety expiry, or a newer open taking over),
         // other commands have been let through and we must not keep mutating as though we
@@ -7886,7 +7894,7 @@ const GRAPH_TOOL_EXECUTORS = {
         // a concurrent edit is not.
         if (
           !wasDirty &&
-          (!wasOpen || priorInteraction !== null) &&
+          priorInteraction !== null &&
           ownsWorkflowReloadGuard(reloadGuardToken)
         ) {
           // The helper awaits a frame before re-baselining — hold the fence across that

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7406,7 +7406,28 @@ const GRAPH_TOOL_EXECUTORS = {
       reconnectedAt: backendReconnectedAt,
       now: monotonicNow(),
     });
-    const lastOpen = summarizeOpenReceipt(latestOpenReceipt(openReceipts), { now: Date.now() });
+    const lastOpenReceipt = summarizeOpenReceipt(latestOpenReceipt(openReceipts), { now: Date.now() });
+    // #402 — ship the READING RULE with the data. The consumer of this field lives in
+    // another process (the orchestrator's dropped-open recovery), so a receipt that merely
+    // NAMES the right workflow is the single most over-readable thing here: an earlier
+    // successful open of the same file would otherwise be taken as proof that a later,
+    // dropped open ran. Stating the rule inline means a reader cannot reach the wrong
+    // conclusion without ignoring the payload it is reading.
+    const lastOpen = lastOpenReceipt
+      ? {
+          ...lastOpenReceipt,
+          answers_only_command_rid: lastOpenReceipt.rid,
+          interpretation:
+            "This receipt is the panel's own execution record and answers ONLY for the command " +
+            "whose id equals `rid`. For any OTHER command the outcome is UNDETERMINED — do not " +
+            "infer success from it, and do not infer success from `active` matching your target " +
+            "either (after a reconnect the frontend restores a tab by itself, see " +
+            "`active_confirmed`). `applied:true` means the panel completed it; `applied:false` " +
+            "means it failed and nothing was applied; `applied:\"unknown\"` means it may have " +
+            "taken effect and must NOT be blindly retried. `reply_sent:false` means the caller " +
+            "never received the answer.",
+        }
+      : null;
     return {
       active: active
         ? {
@@ -7640,21 +7661,46 @@ const GRAPH_TOOL_EXECUTORS = {
     // tabs, no cross-tab clobber. NOTE: getWorkflowByPath returns the SAME
     // object as the open instance (verified), so find() needs no reorder — the
     // #63 find() patch was a no-op that only regressed things.
+    //
+    // #442 / codex — FREEZE canvas interaction from HERE, before the repaint, and hold it
+    // through the staleness decision. `clearSpuriousOpenModified` below awaits a frame and
+    // then RE-BASELINES the change tracker (capture → reset → force isModified=false): an
+    // edit the user makes during that frame is absorbed as the new CLEAN baseline, so the
+    // later dirty gate reads false and would authorize the disk reload to overwrite that
+    // very edit. Sampling the flag later cannot fix that — the signal is already gone — so
+    // the window has to be closed instead. Scoped to `wasOpen` (the only case that can
+    // reload) so a plain first-time open never freezes, and always restored in a finally.
+    // Bound to a local whose name does NOT end in "s": the #268 frontend-contract scanner
+    // captures members off the workflow-service alias `s` with an unanchored `s\.` pattern,
+    // so `canvas.<member>` would be misread as a new workflow-SERVICE dependency. This is a
+    // LiteGraph canvas flag, not a workflow-service member.
+    const canvasView = app?.canvas;
+    const priorInteraction =
+      wasOpen && typeof canvasView?.allow_interaction === "boolean"
+        ? canvasView.allow_interaction
+        : null;
+    let onDiskContent = null;
+    let dirtyNow = false;
+    let staleInfo = { stale: false, reload: false };
+    let reloaded = false;
+    let reloadError = null;
+    if (priorInteraction !== null) canvasView.allow_interaction = false;
     try {
-      const st = target.changeTracker?.activeState;
-      if (st && typeof app.loadGraphData === "function") {
-        await app.loadGraphData(JSON.parse(JSON.stringify(st)), true, true, target);
+      try {
+        const st = target.changeTracker?.activeState;
+        if (st && typeof app.loadGraphData === "function") {
+          await app.loadGraphData(JSON.parse(JSON.stringify(st)), true, true, target);
+        }
+      } catch (err) {
+        console.warn("[comfyui-mcp-panel] workflow_open repaint failed:", err?.message ?? err);
       }
-    } catch (err) {
-      console.warn("[comfyui-mcp-panel] workflow_open repaint failed:", err?.message ?? err);
-    }
-    // Opening alone must not dirty the tab (a spurious post-load change-tracker
-    // diff otherwise flips it to modified:true and blocks an unforced close).
-    await clearSpuriousOpenModified(target);
-    // #433: an explicit open authoritatively re-points `active` — record it against
-    // the epoch we STARTED on, but only if no reconnect intervened during the async
-    // open (else its tab-restore may have overridden us — leave the window armed).
-    if (backendReconnectEpoch === openedForEpoch) activeWorkflowResyncEpoch = openedForEpoch;
+      // Opening alone must not dirty the tab (a spurious post-load change-tracker
+      // diff otherwise flips it to modified:true and blocks an unforced close).
+      await clearSpuriousOpenModified(target);
+      // #433: an explicit open authoritatively re-points `active` — record it against
+      // the epoch we STARTED on, but only if no reconnect intervened during the async
+      // open (else its tab-restore may have overridden us — leave the window armed).
+      if (backendReconnectEpoch === openedForEpoch) activeWorkflowResyncEpoch = openedForEpoch;
     // #442 — read the on-disk bytes AS LATE AS POSSIBLE (after openWorkflow + repaint),
     // so an external write during those awaits is still detected. wasOpen was captured
     // before openWorkflow; the baseline (originalContent) is unchanged by an already-open
@@ -7669,56 +7715,39 @@ const GRAPH_TOOL_EXECUTORS = {
     // long enough to turn into "disconnected mid-command … OUTCOME UNKNOWN". withDeadline
     // never rejects: a timeout degrades to the ALREADY-SUPPORTED honest `stale:"unknown"`,
     // exactly like an unreadable disk, and never to a false "fresh".
-    const onDiskContent = wasOpen
-      ? await withDeadline(workflowDiskContent(target.path), OPEN_DISK_READ_BUDGET_MS, null)
-      : null;
-    // #442 defect 2 — RE-READ the file when it provably changed and nothing is at stake.
-    // Re-check `isModified` HERE, immediately before deciding, rather than trusting the
-    // value from before the disk read: the user can type into the canvas during that
-    // await, and reloading over their unsaved edits is data-loss class — strictly worse
-    // than serving a stale graph. There is NO await between this re-check and the reload
-    // decision below.
-    const dirtyNow = !!target.isModified;
-    const staleInfo = decideOpenStaleness({
-      wasOpen,
-      isModified: dirtyNow,
-      onDiskContent,
-      baselineContent: typeof target.originalContent === "string" ? target.originalContent : null,
-    });
-    // `reload` is true only for "the file changed AND this tab has nothing unsaved", so
-    // the re-read is lossless. A stale tab WITH unsaved edits is a genuine conflict: we
-    // refuse and surface both sides rather than picking for the user.
-    //
-    // The earlier no-await-before-return invariant is intact: this block runs ONLY when
-    // staleInfo.stale === true, and it never downgrades that to "fresh" — so the
-    // false-fresh window codex closed (read stale → file changes → report fresh) still
-    // cannot open. The provably-fresh and "unknown" paths reach the return with no await.
-    // The clean sample above authorizes the load, but everything that follows is AWAITED —
-    // `loadGraphData` may yield before it replaces the graph, and clearSpuriousOpenModified
-    // awaits a frame and then RE-BASELINES the change tracker (capture → reset → force
-    // isModified=false). A canvas edit landing in EITHER window would be destroyed by, or
-    // silently absorbed into, a reload the user never asked for (codex P1 x2). Nobody
-    // requested this reload, so it must not be able to take work with it: freeze canvas
-    // interaction across the WHOLE sequence — load AND re-baseline — and restore it in a
-    // finally. Bound to a local whose name does NOT end in "s": the #268 frontend-contract
-    // scanner captures members off the workflow-service alias `s` with an unanchored `s\.`
-    // pattern, so `canvas.<member>` would be misread as a new workflow-SERVICE dependency.
-    // This is a LiteGraph canvas flag, not a workflow-service member.
-    const canvasView = app?.canvas;
-    const priorInteraction =
-      typeof canvasView?.allow_interaction === "boolean" ? canvasView.allow_interaction : null;
-    let reloaded = false;
-    let reloadError = null;
-    if (staleInfo.reload && !dirtyNow && priorInteraction === null) {
-      // NO reliable freeze on this frontend ⇒ do NOT perform the automatic destructive
-      // reload at all (codex). Serving a stale graph with a loud flag is recoverable;
-      // silently eating an edit the user made during an unrequested load is not.
-      reloadError =
-        "this frontend does not expose the canvas interaction flag, so an automatic reload " +
-        "could not be protected against a concurrent edit and was skipped";
-    } else if (staleInfo.reload && !dirtyNow) {
-      try {
-        canvasView.allow_interaction = false;
+      onDiskContent = wasOpen
+        ? await withDeadline(workflowDiskContent(target.path), OPEN_DISK_READ_BUDGET_MS, null)
+        : null;
+      // #442 defect 2 — RE-READ the file when it provably changed and nothing is at stake.
+      // Re-check `isModified` HERE, immediately before deciding, rather than trusting the
+      // value from before the disk read: reloading over unsaved edits is data-loss class —
+      // strictly worse than serving a stale graph. There is NO await between this re-check
+      // and the reload decision below. (Interaction is frozen across this whole block, so
+      // this is a belt-and-braces second line of defence, not the only one.)
+      dirtyNow = !!target.isModified;
+      staleInfo = decideOpenStaleness({
+        wasOpen,
+        isModified: dirtyNow,
+        onDiskContent,
+        baselineContent:
+          typeof target.originalContent === "string" ? target.originalContent : null,
+      });
+      // `reload` is true only for "the file changed AND this tab has nothing unsaved", so
+      // the re-read is lossless. A stale tab WITH unsaved edits is a genuine conflict: we
+      // refuse and surface both sides rather than picking for the user.
+      //
+      // The earlier no-await-before-return invariant is intact: this block runs ONLY when
+      // staleInfo.stale === true, and it never downgrades that to "fresh" — so the
+      // false-fresh window codex closed (read stale → file changes → report fresh) still
+      // cannot open. The provably-fresh and "unknown" paths reach the return with no await.
+      if (staleInfo.reload && !dirtyNow && priorInteraction === null) {
+        // NO reliable freeze on this frontend ⇒ do NOT perform the automatic destructive
+        // reload at all (codex). Serving a stale graph with a loud flag is recoverable;
+        // silently eating an edit the user made during an unrequested load is not.
+        reloadError =
+          "this frontend does not expose the canvas interaction flag, so an automatic reload " +
+          "could not be protected against a concurrent edit and was skipped";
+      } else if (staleInfo.reload && !dirtyNow) {
         const diskGraph = JSON.parse(onDiskContent);
         // 4th arg associates the load with THIS tab (same as the repaint above), so the
         // on-disk graph replaces the tab's buffer in place instead of spawning a new
@@ -7743,21 +7772,22 @@ const GRAPH_TOOL_EXECUTORS = {
           /* getter-only — the stale flag simply re-reports until the next save */
         }
         // A programmatic load dirties the change tracker; clear that so the re-read does
-        // not leave the tab looking edited (which would block an unforced close). INSIDE
-        // the freeze on purpose: it re-baselines, so an edit made during its frame would be
+        // not leave the tab looking edited (which would block an unforced close). Still
+        // inside the freeze — it re-baselines, so an edit made during its frame would be
         // adopted as "not modified" and could later be discarded without a prompt.
         await clearSpuriousOpenModified(target);
         reloaded = true;
-      } catch (err) {
-        // NEVER claim a reload we did not complete — report the failure and leave the
-        // caller with the honest `stale:true, reloaded:false`.
-        reloadError = coerceMessageText(err?.message ?? err);
-        console.warn("[comfyui-mcp-panel] workflow_open disk re-read failed:", reloadError);
-      } finally {
-        // Hand the canvas back on EVERY path — a throw here must never leave the user
-        // with a frozen graph.
-        canvasView.allow_interaction = priorInteraction;
       }
+    } catch (err) {
+      // NEVER claim a reload we did not complete — report the failure and leave the caller
+      // with the honest `stale:true, reloaded:false`. (The repaint and the bounded disk
+      // read swallow their own errors, so only the reload can land here.)
+      reloadError = coerceMessageText(err?.message ?? err);
+      console.warn("[comfyui-mcp-panel] workflow_open disk re-read failed:", reloadError);
+    } finally {
+      // Hand the canvas back on EVERY path — a throw anywhere above must never leave the
+      // user with a frozen graph.
+      if (priorInteraction !== null) canvasView.allow_interaction = priorInteraction;
     }
     const receipt = noteOpenAttempt({
       cmd: "workflow_open",

--- a/web/js/lib/command-liveness.js
+++ b/web/js/lib/command-liveness.js
@@ -91,6 +91,37 @@ export function describeUndeliveredReply(entry) {
   );
 }
 
+/**
+ * Commands whose RESULT is the user's own private input, not a description of a graph
+ * operation: `request_secret` returns the pasted secret verbatim, and `ask_user` returns
+ * whatever the user typed. The panel already treats both as unspeakable elsewhere (they
+ * are never echoed as activity cards and never recorded to history).
+ *
+ * They must therefore NEVER be journaled as raw frames for cross-socket replay (codex).
+ * A replay lands on whatever socket is current later — which can be a DIFFERENT
+ * orchestrator entirely after a backend switch or a Bridge-URL change — so replaying the
+ * raw frame would hand one session's secret to another process. Redacted instead: the
+ * outcome is still reported truthfully, and for a secret "you never received it" is
+ * exactly right, because the orchestrator only stores what actually reaches it.
+ */
+export const SENSITIVE_RESULT_CMDS = new Set(["request_secret", "ask_user"]);
+
+/** The frame that is safe to journal for `cmd`. Non-sensitive commands pass through
+ *  unchanged; sensitive ones are replaced by a rid-correlated, payload-free failure that
+ *  tells the caller to re-request on the current connection. */
+export function redactSensitiveReply(reply, cmd) {
+  if (!reply || !SENSITIVE_RESULT_CMDS.has(cmd)) return reply;
+  return {
+    rid: reply.rid,
+    ok: false,
+    error:
+      `the panel collected the "${cmd}" response, but the connection dropped before it could be ` +
+      `returned. Its content is deliberately NOT replayed across a reconnect (it is the user's ` +
+      `own input, and the connection it was meant for is gone). Nothing was applied and nothing ` +
+      `was stored — ask again on the current connection.`,
+  };
+}
+
 /** Bounded journal of command outcomes whose reply could not be delivered. */
 export function createLostReplyJournal({ cap = LOST_REPLY_CAP } = {}) {
   const limit = Number.isFinite(cap) && cap > 0 ? cap : LOST_REPLY_CAP;
@@ -100,15 +131,23 @@ export function createLostReplyJournal({ cap = LOST_REPLY_CAP } = {}) {
      *  it can be re-sent verbatim on the next socket: rids are random UUIDs, so an
      *  orchestrator that no longer knows the rid simply drops it, and one that still has
      *  the command pending resolves it with its TRUE outcome. */
-    record({ reply, cmd, reason, at = 0 } = {}) {
+    record({ reply, cmd, reason, at = 0, url } = {}) {
       if (!reply || typeof reply !== "object" || typeof reply.rid !== "string") return null;
+      const safe = redactSensitiveReply(reply, cmd);
       const entry = {
-        rid: reply.rid,
+        rid: safe.rid,
         cmd: typeof cmd === "string" && cmd ? cmd : "unknown",
-        ok: Boolean(reply.ok),
+        // Report the outcome of what we JOURNALED, so a redacted entry never advertises a
+        // success it will not deliver.
+        ok: Boolean(safe.ok),
         reason: typeof reason === "string" && reason ? reason : "socket_closed",
         at: Number.isFinite(at) ? at : 0,
-        reply,
+        // The bridge this outcome BELONGS to. A replay must never cross it: after a backend
+        // switch or a Bridge-URL change the next socket is a different orchestrator, and
+        // volunteering another session's result to it is a leak, not a recovery (codex).
+        url: typeof url === "string" && url ? url : null,
+        redacted: safe !== reply,
+        reply: safe,
       };
       entries.push(entry);
       while (entries.length > limit) entries.shift();
@@ -118,8 +157,8 @@ export function createLostReplyJournal({ cap = LOST_REPLY_CAP } = {}) {
     list() {
       return entries.slice();
     },
-    /** Wire summaries — the raw `reply` payload is NOT included (it can be large and the
-     *  summary is only meant to say WHICH outcomes were lost). */
+    /** Wire summaries — the raw `reply` payload is NOT included (it can be large, and for
+     *  a sensitive command it is exactly what must not travel). */
     summaries() {
       return entries.map(({ rid, cmd, ok, reason, at }) => ({ rid, cmd, ok, reason, at }));
     },
@@ -129,6 +168,12 @@ export function createLostReplyJournal({ cap = LOST_REPLY_CAP } = {}) {
       const out = entries;
       entries = [];
       return out;
+    },
+    /** Replace the contents wholesale — used by a replay that delivered SOME entries,
+     *  dropped others as un-replayable, and must keep only the rest for a later attempt. */
+    replace(next) {
+      entries = Array.isArray(next) ? next.slice(-limit) : [];
+      return entries.length;
     },
     size() {
       return entries.length;

--- a/web/js/lib/command-liveness.js
+++ b/web/js/lib/command-liveness.js
@@ -181,6 +181,36 @@ export function createLostReplyJournal({ cap = LOST_REPLY_CAP } = {}) {
   };
 }
 
+/**
+ * How long an undelivered outcome stays replayable. A genuine mid-command drop and its
+ * reconnect happen in seconds; anything older almost certainly belongs to an orchestrator
+ * that is gone.
+ *
+ * This bounds a residual the panel cannot fully close on its own (codex): a bridge is
+ * identified by its URL, and URL equality is ENDPOINT identity, not SESSION identity — a
+ * newly started orchestrator listening at the same address is indistinguishable from the
+ * same one reconnecting, which is precisely the case replay exists to serve. Proving
+ * session continuity needs a server-issued connection epoch in the handshake, i.e. an
+ * orchestrator-side change (tracked as a follow-up). Until then the exposure is bounded
+ * three ways: sensitive results never enter the journal at all, replay waits for a real
+ * handshake rather than firing at bare socket-open, and entries age out here.
+ */
+export const REPLAY_MAX_AGE_MS = 60000;
+
+/**
+ * May this journaled outcome be replayed onto a socket for `targetUrl` right now?
+ * Requires the SAME bridge and a recent enough entry. An entry with no recorded bridge is
+ * refused: unattributable outcomes are never volunteered.
+ */
+export function isReplayable(entry, { now = 0, targetUrl = null, maxAgeMs = REPLAY_MAX_AGE_MS } = {}) {
+  if (!entry) return false;
+  if (!entry.url || !targetUrl || entry.url !== targetUrl) return false;
+  const age = Number.isFinite(now) && Number.isFinite(entry.at) ? now - entry.at : null;
+  if (age === null) return false;
+  const limit = Number.isFinite(maxAgeMs) && maxAgeMs > 0 ? maxAgeMs : REPLAY_MAX_AGE_MS;
+  return age >= 0 && age <= limit;
+}
+
 /** Drop attempt timestamps older than `windowMs`. Returns a NEW array. */
 export function pruneAttempts(attempts, now, windowMs = RE_REGISTER_WINDOW_MS) {
   if (!Array.isArray(attempts)) return [];

--- a/web/js/lib/command-liveness.js
+++ b/web/js/lib/command-liveness.js
@@ -1,0 +1,178 @@
+// #508 / #402 — the panel half of "did the agent's command reach a live handler?".
+//
+// Field report (#508): the sidebar chat stayed CONNECTED and accepted the user's
+// request, yet EVERY frontend command timed out with no reply from the registered tab —
+// `set_todo` (5000 ms), `graph_outline` (6000 ms), `workflow_list` (6000 ms) — while the
+// orchestrator kept targeting the same `wf:…` id. A row of identical timeouts, forever.
+//
+// The panel's command handler had two ways to swallow a command silently:
+//
+//   a. A HOST CALLBACK THROWING BEFORE THE REPLY. `onCommandReceived()` (the turn-activity
+//      marker) ran OUTSIDE the try/catch that produces the reply, and the listener is
+//      async, so a throw there became an unobserved rejection: no reply, no error, no
+//      log — for every command, deterministically, while chat kept working (chat frames
+//      never touch that callback). That is exactly the reported shape, `set_todo`
+//      included — `set_todo` has no executor to hang, so only a pre-reply throw explains
+//      it timing out.
+//
+//   b. A SUPERSEDED-SOCKET EARLY RETURN. The #379 instance guard drops a stale socket's
+//      whole continuation, INCLUDING its reply, even though replying on that same socket
+//      is what the command's sender is waiting for. (This guard postdates the reporter's
+//      0.11.20, so it is not their cause — but it is a standing one.)
+//
+// The structural fix in the panel is: a command frame ALWAYS produces a reply attempt on
+// the socket it arrived on, and every host callback around it is isolated so UI code can
+// never suppress a bridge reply. What remains is honesty about the cases where the reply
+// genuinely cannot be written — this module owns that:
+//
+//   * classifyUndeliveredReply() names the ACTUAL reason instead of guessing. The
+//     orchestrator's timeout text ("the ComfyUI tab may be backgrounded or frozen") is a
+//     guess; the panel knows whether the socket was closed, superseded, or the write
+//     threw, and should say so rather than assert a cause nobody established.
+//   * a bounded journal keeps those outcomes so the next connection can report them.
+//   * shouldReRegister() decides whether to re-advertise (re-hello) this tab, with a hard
+//     bound so a wedge can never turn into a re-registration storm.
+//
+// SAFETY NOTE ON RE-REGISTRATION: re-registering here means re-sending THIS tab's own
+// hello for THIS tab's CURRENT active workflow — the same identity the panel already
+// re-advertises on a workflow switch (#310/#570). It never selects, guesses, or adopts
+// another tab's id. Re-targeting to a different workflow's tab would be wrong-workflow
+// corruption, which is strictly worse than staying wedged, so this module deliberately
+// exposes no way to choose a target at all.
+//
+// Dependency-free (no DOM, no sockets, no timers) so it is unit-testable with plain values.
+
+/** How many undelivered command outcomes to retain. Bounded so a tab that spends an hour
+ *  disconnected can't grow the journal without limit. */
+export const LOST_REPLY_CAP = 12;
+
+/** Hard bound on self-heal re-registrations, per window. A wedge must never become a
+ *  hello storm against the orchestrator. */
+export const RE_REGISTER_MAX = 3;
+export const RE_REGISTER_WINDOW_MS = 60000;
+
+/**
+ * Why could this reply not be written? Reports what we OBSERVED, never a guess:
+ *
+ *  - "socket_closed"     — the socket we received the command on is no longer open. The
+ *                          command ran; its answer had nowhere to go.
+ *  - "socket_superseded" — a newer socket replaced this one mid-command (reload /
+ *                          reconnect / soft reload). Same story, different trigger.
+ *  - "send_failed"       — the socket claimed to be open and the write still threw.
+ *  - null                — delivered; nothing to report.
+ */
+export function classifyUndeliveredReply({
+  socketOpen = false,
+  superseded = false,
+  sendThrew = false,
+} = {}) {
+  if (sendThrew) return "send_failed";
+  if (!socketOpen) return superseded ? "socket_superseded" : "socket_closed";
+  if (superseded) return "socket_superseded";
+  return null;
+}
+
+/** Human-readable, cause-specific line for an undelivered reply. Deliberately states
+ *  what happened to the REPLY and what is known about the COMMAND separately — the
+ *  command having run is not in doubt; only the caller hearing about it is. */
+export function describeUndeliveredReply(entry) {
+  if (!entry) return "";
+  const cmd = entry.cmd || "a command";
+  const what = entry.ok ? "completed" : "failed";
+  const why =
+    entry.reason === "socket_superseded"
+      ? "the bridge connection was replaced mid-command (reload/reconnect)"
+      : entry.reason === "send_failed"
+        ? "writing the reply to the bridge failed"
+        : "the bridge connection closed mid-command";
+  return (
+    `The panel ${what} "${cmd}" but could not send the result back — ${why}. ` +
+    `The agent will have seen this as an unknown outcome, not as a failure to act.`
+  );
+}
+
+/** Bounded journal of command outcomes whose reply could not be delivered. */
+export function createLostReplyJournal({ cap = LOST_REPLY_CAP } = {}) {
+  const limit = Number.isFinite(cap) && cap > 0 ? cap : LOST_REPLY_CAP;
+  let entries = [];
+  return {
+    /** Record one undelivered outcome. `reply` is the exact frame we failed to send, so
+     *  it can be re-sent verbatim on the next socket: rids are random UUIDs, so an
+     *  orchestrator that no longer knows the rid simply drops it, and one that still has
+     *  the command pending resolves it with its TRUE outcome. */
+    record({ reply, cmd, reason, at = 0 } = {}) {
+      if (!reply || typeof reply !== "object" || typeof reply.rid !== "string") return null;
+      const entry = {
+        rid: reply.rid,
+        cmd: typeof cmd === "string" && cmd ? cmd : "unknown",
+        ok: Boolean(reply.ok),
+        reason: typeof reason === "string" && reason ? reason : "socket_closed",
+        at: Number.isFinite(at) ? at : 0,
+        reply,
+      };
+      entries.push(entry);
+      while (entries.length > limit) entries.shift();
+      return entry;
+    },
+    /** Non-destructive view (newest last). */
+    list() {
+      return entries.slice();
+    },
+    /** Wire summaries — the raw `reply` payload is NOT included (it can be large and the
+     *  summary is only meant to say WHICH outcomes were lost). */
+    summaries() {
+      return entries.map(({ rid, cmd, ok, reason, at }) => ({ rid, cmd, ok, reason, at }));
+    },
+    /** Take everything and empty the journal (used when replaying onto a new socket, so
+     *  a replay can never loop). */
+    drain() {
+      const out = entries;
+      entries = [];
+      return out;
+    },
+    size() {
+      return entries.length;
+    },
+  };
+}
+
+/** Drop attempt timestamps older than `windowMs`. Returns a NEW array. */
+export function pruneAttempts(attempts, now, windowMs = RE_REGISTER_WINDOW_MS) {
+  if (!Array.isArray(attempts)) return [];
+  if (!Number.isFinite(now)) return attempts.slice();
+  const span = Number.isFinite(windowMs) && windowMs > 0 ? windowMs : RE_REGISTER_WINDOW_MS;
+  return attempts.filter((t) => Number.isFinite(t) && now - t < span);
+}
+
+/**
+ * May the panel re-register (re-hello) this tab right now?
+ *
+ * True only when there is a live socket to hello on AND fewer than `max` re-registrations
+ * have already happened inside `windowMs`. Everything else — no socket, budget spent,
+ * nothing actually lost — is false, so the wedge is surfaced to the user instead of being
+ * papered over with an unbounded retry loop.
+ */
+export function shouldReRegister({
+  socketOpen = false,
+  lostCount = 0,
+  attempts = [],
+  now = 0,
+  max = RE_REGISTER_MAX,
+  windowMs = RE_REGISTER_WINDOW_MS,
+} = {}) {
+  if (!socketOpen) return false;
+  if (!Number.isFinite(lostCount) || lostCount <= 0) return false;
+  const limit = Number.isFinite(max) && max > 0 ? max : RE_REGISTER_MAX;
+  return pruneAttempts(attempts, now, windowMs).length < limit;
+}
+
+/** The user-facing line for when self-heal is EXHAUSTED — an explicit, actionable next
+ *  step, which is the whole point of #508's "a row of identical timeouts is a terrible
+ *  failure mode". */
+export function reRegisterExhaustedHint() {
+  return (
+    "The panel keeps losing command replies even after re-registering this tab with the " +
+    "agent. Its commands will look like they timed out. Click Reconnect in the panel " +
+    "header (or reload the ComfyUI page) to rebuild the bridge for this tab."
+  );
+}

--- a/web/js/lib/command-liveness.js
+++ b/web/js/lib/command-liveness.js
@@ -158,9 +158,15 @@ export function createLostReplyJournal({ cap = LOST_REPLY_CAP } = {}) {
       return entries.slice();
     },
     /** Wire summaries — the raw `reply` payload is NOT included (it can be large, and for
-     *  a sensitive command it is exactly what must not travel). */
-    summaries() {
-      return entries.map(({ rid, cmd, ok, reason, at }) => ({ rid, cmd, ok, reason, at }));
+     *  a sensitive command it is exactly what must not travel).
+     *
+     *  Pass `{ now, targetUrl }` to apply the SAME cross-bridge/age rule the replay uses
+     *  (codex): the summaries ride the hello, so without this a bridge that never owned
+     *  these commands would still learn their ids, names and outcomes even though the
+     *  replies themselves are correctly withheld. */
+    summaries({ now, targetUrl } = {}) {
+      const visible = targetUrl ? entries.filter((e) => isReplayable(e, { now, targetUrl })) : entries;
+      return visible.map(({ rid, cmd, ok, reason, at }) => ({ rid, cmd, ok, reason, at }));
     },
     /** Take everything and empty the journal (used when replaying onto a new socket, so
      *  a replay can never loop). */

--- a/web/js/lib/command-liveness.js
+++ b/web/js/lib/command-liveness.js
@@ -198,10 +198,20 @@ export function createLostReplyJournal({ cap = LOST_REPLY_CAP } = {}) {
  * same one reconnecting, which is precisely the case replay exists to serve. Proving
  * session continuity needs a server-issued connection epoch in the handshake, i.e. an
  * orchestrator-side change (tracked as a follow-up). Until then the exposure is bounded
- * three ways: sensitive results never enter the journal at all, replay waits for a real
- * handshake rather than firing at bare socket-open, and entries age out here.
+ * four ways: sensitive results never enter the journal at all; replay goes ONLY to the
+ * exact socket instance that completed a handshake; entries age out here; and the window
+ * is deliberately tight — a drop, reconnect and handshake take a couple of seconds, so 20s
+ * is generous for the case this serves while leaving little room for an orchestrator to
+ * restart and re-bind inside it.
+ *
+ * The residual, stated plainly: if the orchestrator restarts on the SAME address within
+ * this window, its successor can receive one non-sensitive result belonging to the previous
+ * session. It cannot resolve any of its own commands with it (rids are random UUIDs) and it
+ * cannot double-apply anything (a reply is not a command). Closing the residual entirely
+ * requires the handshake epoch above; discarding on unprovable continuity instead would
+ * discard the ordinary reconnect too, which is the whole case this exists to serve.
  */
-export const REPLAY_MAX_AGE_MS = 60000;
+export const REPLAY_MAX_AGE_MS = 20000;
 
 /**
  * May this journaled outcome be replayed onto a socket for `targetUrl` right now?

--- a/web/js/lib/open-outcome.js
+++ b/web/js/lib/open-outcome.js
@@ -176,6 +176,12 @@ export function summarizeOpenReceipt(receipt, { now = 0 } = {}) {
   return {
     seq: receipt.seq,
     cmd: receipt.cmd,
+    // The SERVER-MINTED command id this receipt belongs to. Exported deliberately: it is
+    // the ONLY thing that ties a receipt to a SPECIFIC dispatch. Selector equality is not
+    // enough — an earlier successful open of the same workflow would otherwise answer for
+    // a later command that never ran (codex P1). A consumer that cannot match this rid
+    // must treat the outcome as undetermined.
+    rid: receipt.rid,
     requested: receipt.requested,
     resolved: receipt.resolved,
     applied: receipt.applied,
@@ -187,7 +193,11 @@ export function summarizeOpenReceipt(receipt, { now = 0 } = {}) {
 
 /** Does `receipt` describe an attempt at `requested`? Matches on the RAW selector first
  *  (the exact string the caller sent), then on any resolved identity form — so a caller
- *  that asked by filename still recognizes a receipt resolved to a full path. */
+ *  that asked by filename still recognizes a receipt resolved to a full path.
+ *
+ *  NOT SUFFICIENT ON ITS OWN for a verdict: two commands can name the SAME workflow, so
+ *  this answers "is this receipt about that workflow?", never "is this receipt MINE?".
+ *  Use receiptAnswersCommand() for the latter. */
 export function receiptMatchesRequest(receipt, requested) {
   const want = textOrNull(requested);
   if (!receipt || !want) return false;
@@ -197,21 +207,48 @@ export function receiptMatchesRequest(receipt, requested) {
 }
 
 /**
- * The honest verdict for "did the open of `requested` happen?", from the panel's OWN
- * execution record. Never upgrades a guess to a success.
+ * Does `receipt` answer for THIS SPECIFIC dispatch? Requires the server-minted `rid` to
+ * match EXACTLY, and (belt and braces) the workflow to match too.
  *
- *  - "applied"      — a receipt for this request completed. Authoritative.
- *  - "not_applied"  — a receipt for this request FAILED. Authoritative; carries the error.
- *  - "undetermined" — no receipt for this request. This is the verdict EVEN WHEN the
- *                     requested workflow is currently active: after a backend reconnect
- *                     the frontend restores a tab by itself (#433), so a matching
- *                     `active` is fully explained without our command ever running.
- *                     The evidence is returned alongside so the caller can decide, but
- *                     the VERDICT stays "undetermined" — reporting "opened" here is the
- *                     fabrication #402 must never produce.
+ * Why the rid is mandatory (codex P1): selector equality alone lets an EARLIER command's
+ * receipt answer for a LATER one. Concretely — command A opens `x.json` and succeeds;
+ * command B asks for `x.json` again, is dropped BEFORE the executor ever runs, and a
+ * verifier reads the journal: A's receipt matches the selector, says `applied:true`, and
+ * B is reported as having opened. That is precisely the fabricated success #402 exists to
+ * prevent. Without a rid to correlate, the only truthful verdict is "undetermined".
+ */
+export function receiptAnswersCommand(receipt, { requested, rid } = {}) {
+  const wantRid = textOrNull(rid);
+  if (!receipt || !wantRid) return false;
+  if (receipt.rid !== wantRid) return false;
+  // A rid match with a MISMATCHED workflow means the journal is inconsistent — refuse
+  // rather than answer, so a mis-stamped receipt can never speak for another workflow.
+  const wantRequested = textOrNull(requested);
+  if (wantRequested && !receiptMatchesRequest(receipt, wantRequested)) return false;
+  return true;
+}
+
+/**
+ * The honest verdict for "did MY open (the dispatch identified by `rid`) happen?", from
+ * the panel's OWN execution record. Never upgrades a guess to a success.
+ *
+ *  - "applied"      — THIS command's receipt completed. Authoritative.
+ *  - "not_applied"  — THIS command's receipt FAILED. Authoritative; carries the error.
+ *  - "undetermined" — no receipt correlates to this command. This is the verdict in TWO
+ *                     important cases, and both would otherwise fabricate success:
+ *                       * the caller cannot supply a `rid`, or the journal's latest
+ *                         receipt belongs to a DIFFERENT dispatch — an earlier open of
+ *                         the SAME workflow must never answer for a later one (codex);
+ *                       * the requested workflow is currently active. After a backend
+ *                         reconnect the frontend restores a tab by itself (#433), so a
+ *                         matching `active` is fully explained without our command ever
+ *                         having run.
+ *                     The evidence is returned alongside so the caller can decide what to
+ *                     do, but the VERDICT stays "undetermined".
  */
 export function classifyOpenOutcome({
   requested,
+  rid,
   receipt,
   activeMatchesRequest = false,
   activeConfirmed = false,
@@ -219,8 +256,10 @@ export function classifyOpenOutcome({
   const evidence = {
     active_matches_request: Boolean(activeMatchesRequest),
     active_confirmed: Boolean(activeConfirmed),
+    correlated_by_rid: false,
   };
-  if (receiptMatchesRequest(receipt, requested)) {
+  if (receiptAnswersCommand(receipt, { requested, rid })) {
+    evidence.correlated_by_rid = true;
     if (receipt.applied) {
       return {
         outcome: "applied",
@@ -238,16 +277,28 @@ export function classifyOpenOutcome({
       evidence: { ...evidence, receipt: summarizeOpenReceipt(receipt) },
     };
   }
+  // Explain WHY it is undetermined, because the two reasons need different follow-ups —
+  // and because "a receipt exists for this workflow" is exactly the evidence a reader
+  // would otherwise over-read into a success.
+  const sameWorkflowOtherCommand = receiptMatchesRequest(receipt, requested);
   return {
     outcome: "undetermined",
     detail:
-      `The panel has no completed open on record for "${textOrNull(requested) ?? requested}". ` +
+      `The panel has no receipt correlating to this open of "${textOrNull(requested) ?? requested}". ` +
+      (sameWorkflowOtherCommand
+        ? "There IS a receipt for that workflow, but it belongs to a DIFFERENT command " +
+          "(or could not be correlated by command id), so it cannot answer for this one — " +
+          "an earlier open of the same workflow says nothing about whether this one ran. "
+        : "") +
       (activeMatchesRequest
         ? "That workflow IS the active canvas right now, but the frontend restores a tab on its " +
           "own after a reconnect, so that does NOT prove the requested open ran. "
         : "") +
       "Treat the outcome as UNDETERMINED and re-issue panel_open_workflow (opening an " +
       "already-open workflow is safe and idempotent) rather than assuming either result.",
-    evidence,
+    evidence: {
+      ...evidence,
+      ...(receipt ? { latest_receipt: summarizeOpenReceipt(receipt) } : {}),
+    },
   };
 }

--- a/web/js/lib/open-outcome.js
+++ b/web/js/lib/open-outcome.js
@@ -98,9 +98,15 @@ function textOrNull(v) {
  * is not the same claim as "MY open, of THAT workflow, happened" (the wrong-workflow
  * failure mode the #570 identity work exists to prevent).
  *
- * `applied` is the load-bearing field: true only when the executor ran to completion.
- * A thrown open records `applied:false` WITH its error — that is a genuine NEGATIVE
- * signal, and it is just as important as the positive one.
+ * `applied` is the load-bearing field, and it is TRI-STATE:
+ *   true        — the executor ran to completion.
+ *   false       — it failed BEFORE changing anything. A genuine negative, just as
+ *                 important as the positive.
+ *   "unknown"   — it got far enough that something MAY have taken effect but the panel
+ *                 cannot confirm it (e.g. workflow_new's blank tab was created and then
+ *                 the frontend would not surface it). Recording `false` there would
+ *                 invite a retry, and workflow_new is NOT idempotent — a retry makes a
+ *                 SECOND blank workflow. Omitting the receipt entirely would do the same.
  */
 export function makeOpenReceipt({
   seq = 0,
@@ -124,7 +130,7 @@ export function makeOpenReceipt({
       filename: textOrNull(r.filename),
       routing_key: textOrNull(r.routing_key ?? r.routingKey),
     },
-    applied: Boolean(applied),
+    applied: applied === "unknown" ? "unknown" : Boolean(applied),
     error: textOrNull(error),
     at: Number.isFinite(at) ? at : 0,
     reconnect_epoch: Number.isFinite(reconnectEpoch) ? reconnectEpoch : 0,
@@ -217,7 +223,7 @@ export function receiptMatchesRequest(receipt, requested) {
  * B is reported as having opened. That is precisely the fabricated success #402 exists to
  * prevent. Without a rid to correlate, the only truthful verdict is "undetermined".
  */
-export function receiptAnswersCommand(receipt, { requested, rid } = {}) {
+export function receiptAnswersCommand(receipt, { requested, rid, expectedTarget } = {}) {
   const wantRid = textOrNull(rid);
   if (!receipt || !wantRid) return false;
   if (receipt.rid !== wantRid) return false;
@@ -225,6 +231,14 @@ export function receiptAnswersCommand(receipt, { requested, rid } = {}) {
   // rather than answer, so a mis-stamped receipt can never speak for another workflow.
   const wantRequested = textOrNull(requested);
   if (wantRequested && !receiptMatchesRequest(receipt, wantRequested)) return false;
+  // OPTIONAL canonical target (codex): a SELECTOR is not an identity. workflow_open may
+  // refresh the frontend's workflow list mid-command and re-resolve an ambiguous selector,
+  // so a caller that knows the canonical target it meant (path / routing key, e.g. from
+  // the dispatch-time pin) can require the receipt to have LANDED there. Without it the
+  // receipt still tells the truth — `resolved` names what was actually opened — but the
+  // caller must read it; this makes the check enforceable instead of advisory.
+  const wantTarget = textOrNull(expectedTarget);
+  if (wantTarget && !receiptMatchesRequest(receipt, wantTarget)) return false;
   return true;
 }
 
@@ -249,6 +263,7 @@ export function receiptAnswersCommand(receipt, { requested, rid } = {}) {
 export function classifyOpenOutcome({
   requested,
   rid,
+  expectedTarget,
   receipt,
   activeMatchesRequest = false,
   activeConfirmed = false,
@@ -258,14 +273,36 @@ export function classifyOpenOutcome({
     active_confirmed: Boolean(activeConfirmed),
     correlated_by_rid: false,
   };
-  if (receiptAnswersCommand(receipt, { requested, rid })) {
+  if (receiptAnswersCommand(receipt, { requested, rid, expectedTarget })) {
     evidence.correlated_by_rid = true;
-    if (receipt.applied) {
+    // WHICH workflow it landed on is part of the verdict, never a footnote: a selector can
+    // resolve differently after a mid-command list refresh, so "applied" alone would let a
+    // reader assume the workflow they named (codex).
+    const landed =
+      receipt.resolved?.path || receipt.resolved?.routing_key || receipt.resolved?.filename || null;
+    if (receipt.applied === "unknown") {
+      return {
+        outcome: "undetermined",
+        possibly_applied: true,
+        opened: receipt.resolved,
+        detail:
+          `The panel STARTED "${receipt.cmd}" and cannot confirm whether it took effect` +
+          (receipt.error ? ` (${receipt.error})` : ".") +
+          ` Do NOT blindly retry: "${receipt.cmd}" is not idempotent, so a retry can leave a ` +
+          `second workflow behind. Read the open workflow list and decide from what is there.`,
+        evidence: { ...evidence, receipt: summarizeOpenReceipt(receipt) },
+      };
+    }
+    if (receipt.applied === true) {
       return {
         outcome: "applied",
+        opened: receipt.resolved,
         detail:
-          `The panel completed "${receipt.cmd}" for "${receipt.requested ?? requested}"` +
-          (receipt.reply_sent ? "." : " but could not deliver the reply."),
+          `The panel completed "${receipt.cmd}" and it landed on ${landed ? `"${landed}"` : "the reported workflow"}` +
+          (receipt.requested && landed && receipt.requested !== landed
+            ? ` (asked for "${receipt.requested}" — confirm this is the workflow you meant)`
+            : "") +
+          (receipt.reply_sent ? "." : ", but could not deliver the reply."),
         evidence: { ...evidence, receipt: summarizeOpenReceipt(receipt) },
       };
     }

--- a/web/js/lib/open-outcome.js
+++ b/web/js/lib/open-outcome.js
@@ -53,7 +53,7 @@ export function withDeadline(
   promise,
   ms,
   fallback,
-  { setTimer = setTimeout, clearTimer = clearTimeout } = {},
+  { setTimer = setTimeout, clearTimer = clearTimeout, onTimeout } = {},
 ) {
   const settleValue = (v) => v;
   if (!Number.isFinite(ms) || ms <= 0) {
@@ -65,6 +65,15 @@ export function withDeadline(
     const timer = setTimer(() => {
       if (settled) return;
       settled = true;
+      // Give the caller a chance to CANCEL the underlying work (codex P2). Resolving the
+      // wrapper only stops US waiting — without this the request itself keeps running, so
+      // repeated opens against a server that accepts and never answers would pile up live
+      // requests behind a deadline that only ever looked like it bounded them.
+      try {
+        onTimeout?.();
+      } catch {
+        /* cancellation is best-effort — it must never change the deadline's outcome */
+      }
       resolve(fallback);
     }, ms);
     Promise.resolve(promise).then(
@@ -82,6 +91,52 @@ export function withDeadline(
       },
     );
   });
+}
+
+/**
+ * Coalesce concurrent work by key: while a call for `key` is outstanding, every further
+ * caller gets THAT promise instead of starting another.
+ *
+ * Why the staleness read needs it (codex P2): `withDeadline` stops us WAITING but cannot
+ * abort work it did not create, and one of the two disk-read paths (`api.getUserData`)
+ * takes no AbortSignal at all. Against a server that accepts requests and never answers,
+ * repeated opens of the same workflow would otherwise leave one live request behind each
+ * time. Single-flighting caps that at ONE outstanding read per workflow, whether or not
+ * cancellation is available.
+ */
+export function createSingleFlight() {
+  const inFlight = new Map();
+  return {
+    run(key, start) {
+      const existing = inFlight.get(key);
+      if (existing) return existing;
+      let tracked;
+      const done = () => {
+        if (inFlight.get(key) === tracked) inFlight.delete(key);
+      };
+      let started;
+      try {
+        started = Promise.resolve(start());
+      } catch (err) {
+        return Promise.reject(err);
+      }
+      tracked = started.then(
+        (v) => {
+          done();
+          return v;
+        },
+        (err) => {
+          done();
+          throw err;
+        },
+      );
+      inFlight.set(key, tracked);
+      return tracked;
+    },
+    size() {
+      return inFlight.size;
+    },
+  };
 }
 
 function textOrNull(v) {

--- a/web/js/lib/open-outcome.js
+++ b/web/js/lib/open-outcome.js
@@ -1,0 +1,253 @@
+// #402 — keep `panel_open_workflow`'s OUTCOME truthful across a mid-command drop.
+//
+// Field report (#402): after a ComfyUI restart, `panel_open_workflow` came back as
+//   `panel tab wf:… disconnected mid-command ("workflow_open") — OUTCOME UNKNOWN`
+// The command had already been written to the socket, so the caller could not tell
+// whether the workflow actually opened. Two independent defects feed that:
+//
+//  1. THE PANEL HOLDS A KNOWN-GOOD ANSWER HOSTAGE. `workflow_open` applies the switch
+//     and then, before replying, reads the workflow file back off ComfyUI over HTTP
+//     purely to compute the #442 out-of-band-staleness hint. In exactly the #402 window
+//     ComfyUI's HTTP layer is what is flaky (the same report's `panel_save_workflow`
+//     returned "Failed to fetch"), and that read had NO deadline — a server that accepts
+//     the connection and never answers parks the reply for the whole browser timeout.
+//     The open ALREADY happened; the only thing still unknown is a cosmetic hint. So the
+//     read is bounded here and degrades to the ALREADY-SUPPORTED `stale:"unknown"`.
+//
+//  2. THE PANEL KEEPS NO RECORD OF WHAT IT DID. Once the reply is lost there is nothing
+//     left to ask. A verifier is then reduced to re-reading `workflow_list.active` — but
+//     right after a backend restart the panel itself declares that pointer NOT
+//     authoritative (`active_possibly_stale`, #433), because the frontend restores a tab
+//     on its own. Since the usual #402 request is "open the workflow that is already
+//     active", a matching `active` proves NOTHING: the restore alone produces it. Calling
+//     that success is a FABRICATION — the single worst outcome for this path.
+//
+// So the panel keeps an OPEN RECEIPT: for every `workflow_open` / `workflow_new` that
+// RAN — succeeded or failed — it records the raw selector it was asked for, the identity
+// it actually resolved to, and whether it applied. `workflow_list` then reports the
+// latest receipt, so "did my dropped open apply?" is answered from the panel's own
+// execution instead of being inferred from an ambiguous pointer. When there is no
+// matching receipt the honest verdict is "undetermined" — never "opened".
+//
+// Dependency-free (no DOM, no app, no globals) so it is unit-testable with plain values.
+
+/** Deadline for the post-open on-disk staleness read (#442) inside `workflow_open`.
+ *  The open has already been applied when this runs, so the ONLY thing at stake is the
+ *  staleness hint — never make the caller wait on ComfyUI's HTTP layer for it. */
+export const OPEN_DISK_READ_BUDGET_MS = 2500;
+
+/** How many open receipts to keep. A handful is plenty: a verifier only ever asks about
+ *  the command it just lost, and an unbounded journal in a long-lived tab is a leak. */
+export const OPEN_RECEIPT_CAP = 8;
+
+/**
+ * Await `promise` but give up after `ms` and resolve `fallback` instead. NEVER rejects:
+ * a rejection ALSO resolves `fallback`, so a caller can treat "could not determine" and
+ * "took too long to determine" identically (both are the same honest `unknown`).
+ *
+ * The timer is cleared on the settle path so a bounded read cannot leave a pending timer
+ * behind in a page that stays open for hours. `setTimer`/`clearTimer` are injectable so
+ * tests drive the deadline deterministically instead of sleeping.
+ */
+export function withDeadline(
+  promise,
+  ms,
+  fallback,
+  { setTimer = setTimeout, clearTimer = clearTimeout } = {},
+) {
+  const settleValue = (v) => v;
+  if (!Number.isFinite(ms) || ms <= 0) {
+    // No usable deadline → just neutralize rejection (same contract, no timer).
+    return Promise.resolve(promise).then(settleValue, () => fallback);
+  }
+  return new Promise((resolve) => {
+    let settled = false;
+    const timer = setTimer(() => {
+      if (settled) return;
+      settled = true;
+      resolve(fallback);
+    }, ms);
+    Promise.resolve(promise).then(
+      (value) => {
+        if (settled) return;
+        settled = true;
+        clearTimer(timer);
+        resolve(value);
+      },
+      () => {
+        if (settled) return;
+        settled = true;
+        clearTimer(timer);
+        resolve(fallback);
+      },
+    );
+  });
+}
+
+function textOrNull(v) {
+  return typeof v === "string" && v.trim() ? v.trim() : null;
+}
+
+/**
+ * Build one open receipt.
+ *
+ * `requested` is the RAW selector the caller passed (a path, filename, native key, or a
+ * per-instance routing id). `resolved` is what the panel actually landed on. Both are
+ * recorded deliberately: a verifier must be able to confirm the receipt is about ITS
+ * request AND that the request resolved to the workflow it meant — "an open happened"
+ * is not the same claim as "MY open, of THAT workflow, happened" (the wrong-workflow
+ * failure mode the #570 identity work exists to prevent).
+ *
+ * `applied` is the load-bearing field: true only when the executor ran to completion.
+ * A thrown open records `applied:false` WITH its error — that is a genuine NEGATIVE
+ * signal, and it is just as important as the positive one.
+ */
+export function makeOpenReceipt({
+  seq = 0,
+  cmd = "workflow_open",
+  rid = null,
+  requested = null,
+  resolved = null,
+  applied = false,
+  error = null,
+  at = 0,
+  reconnectEpoch = 0,
+} = {}) {
+  const r = resolved && typeof resolved === "object" ? resolved : {};
+  return {
+    seq: Number.isFinite(seq) ? seq : 0,
+    cmd: typeof cmd === "string" && cmd ? cmd : "workflow_open",
+    rid: textOrNull(rid),
+    requested: textOrNull(requested),
+    resolved: {
+      path: textOrNull(r.path),
+      filename: textOrNull(r.filename),
+      routing_key: textOrNull(r.routing_key ?? r.routingKey),
+    },
+    applied: Boolean(applied),
+    error: textOrNull(error),
+    at: Number.isFinite(at) ? at : 0,
+    reconnect_epoch: Number.isFinite(reconnectEpoch) ? reconnectEpoch : 0,
+    // Flipped to true ONLY once the reply for this command was handed to an OPEN socket.
+    // It is ADVISORY, never proof of receipt: a socket can die between `send()` and the
+    // bytes landing. `applied` is the claim about the WORKFLOW; this is only about the
+    // reply's delivery attempt, and it exists so a caller can tell "you never heard my
+    // answer" apart from "you heard it and are asking again".
+    reply_sent: false,
+  };
+}
+
+/** Append `receipt` to `journal` (mutating, newest LAST) and trim to `cap`. */
+export function recordOpenReceipt(journal, receipt, cap = OPEN_RECEIPT_CAP) {
+  if (!Array.isArray(journal) || !receipt) return journal;
+  journal.push(receipt);
+  const limit = Number.isFinite(cap) && cap > 0 ? cap : OPEN_RECEIPT_CAP;
+  while (journal.length > limit) journal.shift();
+  return journal;
+}
+
+/** The most recent receipt, or null. */
+export function latestOpenReceipt(journal) {
+  if (!Array.isArray(journal) || !journal.length) return null;
+  return journal[journal.length - 1];
+}
+
+/** Mark the receipt carrying `rid` as having had its reply written to an open socket. */
+export function markOpenReceiptReplySent(journal, rid) {
+  const want = textOrNull(rid);
+  if (!want || !Array.isArray(journal)) return false;
+  for (let i = journal.length - 1; i >= 0; i--) {
+    if (journal[i] && journal[i].rid === want) {
+      journal[i].reply_sent = true;
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Wire form of a receipt: compact, and with an AGE rather than an absolute timestamp
+ *  (the reader is another process on a possibly different clock). */
+export function summarizeOpenReceipt(receipt, { now = 0 } = {}) {
+  if (!receipt) return null;
+  const age =
+    Number.isFinite(now) && Number.isFinite(receipt.at) && receipt.at > 0 && now >= receipt.at
+      ? Math.round(now - receipt.at)
+      : null;
+  return {
+    seq: receipt.seq,
+    cmd: receipt.cmd,
+    requested: receipt.requested,
+    resolved: receipt.resolved,
+    applied: receipt.applied,
+    ...(receipt.error ? { error: receipt.error } : {}),
+    reply_sent: receipt.reply_sent,
+    ...(age === null ? {} : { ms_ago: age }),
+  };
+}
+
+/** Does `receipt` describe an attempt at `requested`? Matches on the RAW selector first
+ *  (the exact string the caller sent), then on any resolved identity form — so a caller
+ *  that asked by filename still recognizes a receipt resolved to a full path. */
+export function receiptMatchesRequest(receipt, requested) {
+  const want = textOrNull(requested);
+  if (!receipt || !want) return false;
+  if (receipt.requested === want) return true;
+  const r = receipt.resolved || {};
+  return r.path === want || r.filename === want || r.routing_key === want;
+}
+
+/**
+ * The honest verdict for "did the open of `requested` happen?", from the panel's OWN
+ * execution record. Never upgrades a guess to a success.
+ *
+ *  - "applied"      — a receipt for this request completed. Authoritative.
+ *  - "not_applied"  — a receipt for this request FAILED. Authoritative; carries the error.
+ *  - "undetermined" — no receipt for this request. This is the verdict EVEN WHEN the
+ *                     requested workflow is currently active: after a backend reconnect
+ *                     the frontend restores a tab by itself (#433), so a matching
+ *                     `active` is fully explained without our command ever running.
+ *                     The evidence is returned alongside so the caller can decide, but
+ *                     the VERDICT stays "undetermined" — reporting "opened" here is the
+ *                     fabrication #402 must never produce.
+ */
+export function classifyOpenOutcome({
+  requested,
+  receipt,
+  activeMatchesRequest = false,
+  activeConfirmed = false,
+} = {}) {
+  const evidence = {
+    active_matches_request: Boolean(activeMatchesRequest),
+    active_confirmed: Boolean(activeConfirmed),
+  };
+  if (receiptMatchesRequest(receipt, requested)) {
+    if (receipt.applied) {
+      return {
+        outcome: "applied",
+        detail:
+          `The panel completed "${receipt.cmd}" for "${receipt.requested ?? requested}"` +
+          (receipt.reply_sent ? "." : " but could not deliver the reply."),
+        evidence: { ...evidence, receipt: summarizeOpenReceipt(receipt) },
+      };
+    }
+    return {
+      outcome: "not_applied",
+      detail:
+        `The panel ran "${receipt.cmd}" for "${receipt.requested ?? requested}" and it FAILED` +
+        (receipt.error ? `: ${receipt.error}` : "."),
+      evidence: { ...evidence, receipt: summarizeOpenReceipt(receipt) },
+    };
+  }
+  return {
+    outcome: "undetermined",
+    detail:
+      `The panel has no completed open on record for "${textOrNull(requested) ?? requested}". ` +
+      (activeMatchesRequest
+        ? "That workflow IS the active canvas right now, but the frontend restores a tab on its " +
+          "own after a reconnect, so that does NOT prove the requested open ran. "
+        : "") +
+      "Treat the outcome as UNDETERMINED and re-issue panel_open_workflow (opening an " +
+      "already-open workflow is safe and idempotent) rather than assuming either result.",
+    evidence,
+  };
+}

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -297,6 +297,7 @@ export function buildHelloPayload({
   comfyuiPath,
   resume,
   workflowUuid,
+  lostReplies,
 } = {}) {
   const frame = {
     type: "hello",
@@ -330,6 +331,14 @@ export function buildHelloPayload({
   // title (the reopened cross-resume). Omitted when unknown so old behavior stands.
   if (typeof workflowUuid === "string" && workflowUuid.trim()) {
     frame.workflow_uuid = workflowUuid.trim();
+  }
+  // #508 — command outcomes this tab COMPLETED but could not deliver (the socket closed
+  // or was superseded mid-command). Advertising them at re-registration lets the other
+  // end reconcile "the reply was lost" against its own timed-out commands instead of
+  // asserting the unestablished "the tab may be backgrounded or frozen". Omitted when
+  // empty so the common hello is unchanged.
+  if (Array.isArray(lostReplies) && lostReplies.length) {
+    frame.lost_replies = lostReplies;
   }
   return frame;
 }


### PR DESCRIPTION
Three reports about the same tool and the same question — *did the thing I asked for actually happen?* — answered with one coherent outcome contract.

Closes #402
Closes #508

## #402 — the open worked, but we said "unknown"

`panel_open_workflow` returned `panel tab wf:… disconnected mid-command ("workflow_open") — OUTCOME UNKNOWN`. Two panel-side defects fed it.

**The panel held a known-good answer hostage.** The open applies, and *then* — before replying — the executor reads the workflow file back off ComfyUI over HTTP, purely to compute the #442 staleness hint. That read had no deadline. In exactly the #402 window ComfyUI's HTTP layer is what is flaky (the same report's `panel_save_workflow` returned `Failed to fetch`), so a server that accepts the connection and never answers parked a finished outcome for the whole browser timeout — which is how a routine reconnect blip gets long enough to become a mid-command drop at all. The read is now bounded, cancelled on timeout, and single-flighted per workflow; it degrades to the already-supported honest `stale:"unknown"`, never to a false "fresh".

**The panel kept no record of what it did.** Once the reply was lost there was nothing left to ask, so a verifier could only re-read `workflow_list.active` — which the panel itself declares non-authoritative right after a reconnect (`active_possibly_stale`, #433), because the frontend restores a tab on its own. Since the usual #402 request is "open the workflow that is *already* active", a matching pointer proves nothing; calling it success is a fabrication, and that is the worst outcome this path can produce.

So `workflow_open` / `workflow_new` now journal an **open receipt**: the raw selector asked for, the identity actually resolved to, `applied` (`true` / `false` / `"unknown"`), and any error. `workflow_list` reports `last_open` and a positive `active_confirmed` flag. The verdict function requires an **exact `rid` match** — an earlier open of the same workflow can never answer for a later one — and names the workflow the open *landed on*, not just the selector requested. No correlating receipt means **undetermined**, never "opened". `last_open` ships its own reading rule so a consumer cannot over-read it.

## #508 — chat alive, every command timing out

The command handler had two ways to swallow a command in silence:

- `onCommandReceived()` (the turn-activity marker) ran **outside** the try that builds the reply, inside an async listener — so a throw there became an unobserved rejection: no reply, no error, no log, for every command, while chat kept working (chat frames never touch that callback). That is the reported shape exactly, `set_todo` included: `set_todo` has no executor that could hang, so only a pre-reply throw explains it timing out. Present in the reporter's 0.11.20 too.
- The #379 superseded-socket guard returned **before** the reply, and the listener returned before even parsing — so a command queued on a retired socket was discarded outright.

Now: a command frame **always** produces a reply attempt on the socket it arrived on, host callbacks are isolated so UI code can never suppress one, and a command on a superseded socket gets an explicit rid-correlated `ok:false` refusal saying nothing was applied (it is still never executed). Undelivered outcomes are journaled with their **actual** cause — `socket_closed` / `socket_superseded` / `send_failed`, never the orchestrator's guess that the tab "may be backgrounded or frozen" — replayed to the caller, and they drive a **bounded** self-heal re-hello that can only ever re-advertise this tab's own live identity. It cannot select, adopt or guess another workflow's tab id; when the budget is spent the user gets an actionable Reconnect instruction instead of another silent timeout.

**Already-merged work does not fix #508.** The reporter is on panel 0.11.20 / mcp 0.48.18 against 0.11.32 / 0.48.32. The #570 identity fences added since then *throw* (and therefore reply) rather than hang, so they neither cause nor cure this. The `isActive()` instance guard postdates their build entirely.

## #442 defect 2 — the stale tab was detected but never refreshed

PR #483 already shipped the *detection* (`decideOpenStaleness`, `stale: true|"unknown"` + hints). What was missing is that `workflow_open` computed `reload` and then ignored it — it never re-read the file. Now, when the file provably changed **and** the tab has nothing unsaved, the canvas is reloaded from disk and the reply says `reloaded: true`. Stale + unsaved edits is an explicit `conflict` — surfaced, never silently resolved.

That reload is destructive and nobody asked for it, so it is fenced hard:

- the tab's dirty state is snapshotted **before any await** (`clearSpuriousOpenModified` force-clears `isModified`, so a tab that arrived dirty would otherwise read clean by the time the gate samples it) — and a tab that arrived dirty is never re-baselined and never reloaded;
- canvas interaction is frozen across the whole sequence — switch, repaint, re-baseline, bounded read, reload — restored in one `finally`; if the frontend exposes no interaction flag, the automatic reload is **skipped** rather than run unprotected;
- a switch/reload **critical section** fences the bridge as well, since the socket listener is async and re-entrant: concurrent graph commands are refused with an explicit *nothing was applied, retry* error. It is ownership-token scoped, re-checked after every await, and ages out so it can never wedge the tab;
- the reload passes `__cmcpKeepInstance` (as `graph_load` does), so an out-of-band file's embedded uuid cannot fork this tab's #570 identity mid-open;
- a failed or partial reload is never reported as `reloaded: true`.

`#442` is **not** closed here: defect 1 (node-resize) is routed to the #572 `panel_edit_node` consolidation and defect 5 needs rig testing. I'll comment there listing what this resolves.

## Also

Two raw NUL bytes used as string separators are replaced with printable `` escapes (identical at runtime). They made ripgrep and grep stop scanning `comfyui-mcp-panel.js` partway through — which cost me real time during this investigation.

## Verification

`browser_tests/unit/open-outcome.test.mjs` and `command-liveness.test.mjs` (new) plus the existing suite: **1301 passing**. Coverage is both behavioural (the pure decision functions) and structural — the orderings that carry the safety properties (freeze before the first re-baseline, dirty sample under the freeze, reply before the superseded return, replay after the handshake) are asserted against the source, because a later refactor can silently undo an ordering without failing any behavioural test. Tool-vocabulary gate, `tsc --noEmit`, YARA/SVG parity and `node --check` as an `.mjs` all pass.

**Not verifiable without a rig** — a human should confirm on live ComfyUI:
1. restart ComfyUI from the panel, then `panel_save_workflow` + `panel_open_workflow` on the active workflow — the outcome should be a real result or an explicit undetermined, never a fabricated success;
2. open workflow X, edit its `.json` out of band, `panel_open_workflow(X)` — the canvas should show the new content with `reloaded: true`;
3. same, but with unsaved edits in the tab — expect `conflict: true` and **no** reload;
4. that a normal tab switch still repaints correctly and does not leave the canvas frozen or the tab refusing commands.

## Review

Self-gated with `codex -m gpt-5.6-terra` over **13 rounds**; 19 findings, all fixed — including several I would not have caught: an earlier open's receipt answering for a later command, the `clearSpuriousOpenModified` re-baseline erasing a genuinely dirty tab's signal, a lost reply journaled after the replacement socket had already replayed, and `request_secret`'s result (the pasted secret itself) being replayable across a bridge change.

One residual is **deliberately not fixed here** and is cross-repo. A bridge is identified by URL, and URL equality is *endpoint* identity, not *session* identity: if the orchestrator restarts on the same address within the replay window, its successor can receive one non-sensitive result belonging to the previous session. It cannot resolve any of its own commands with it (rids are random UUIDs) and cannot double-apply anything (a reply is not a command). Closing it properly needs a server-issued handshake epoch in comfyui-mcp; discarding on unprovable continuity instead would discard the ordinary reconnect too, which is the entire case this serves. Bounded meanwhile by: sensitive results never entering the journal, replay going only to the exact socket instance that completed a handshake, a 20s age limit, and hello summaries filtered by the same rule.

**Follow-up needed in comfyui-mcp** (panel-only PR, so not done here): `openWorkflowWithVerify` currently recovers a dropped open by polling `workflow_list` and treating `active` matching the path as success — the fabrication described above. It should consume `last_open` and correlate by `rid` instead. The panel now emits everything it needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
