### PR TITLE
fix(errors): verify nested input media before reporting missing

### DIFF
--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -11,12 +11,18 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 
 import {
   activeWorkflowNodeCount,
   graphReadDesynced,
   graphReadBindingChanged,
 } from "../../web/js/lib/graph-binding.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
 
 // A ComfyUI ChangeTracker-shaped workflow: serialized graph states hang off
 // `changeTracker.activeState` / `.initialState` (and some builds hang them flat).
@@ -168,5 +174,48 @@ test("graphReadBindingChanged: FALSE — both snapshots unresolvable never manuf
       afterRootGraph: null,
     }),
     false,
+  );
+});
+
+// ── panel wiring: validationBanner's probe is fenced by the correlation ─────
+
+test("#513 review wiring: validationBanner fences its server probe against a mid-await workflow switch", () => {
+  // The proactive turn-start banner captures node errors / exec failure / missing
+  // assets from workflow A, then AWAITS the nested-input server probe. A tab
+  // switch in that window used to inject A's banner into B's session. The panel
+  // source must snapshot the binding BEFORE the await and silently skip (the
+  // banner is best-effort — no recoverable retry) when it provably changed.
+  // (the panel file is CRLF — normalize so the column-0 `}` anchor matches)
+  const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+  const start = src.indexOf("async function validationBanner()");
+  assert.notEqual(start, -1, "validationBanner must exist in the panel");
+  const end = src.indexOf("\n}\n", start); // top-level function closes at column 0
+  assert.notEqual(end, -1);
+  const body = src.slice(start, end);
+
+  const snapAt = body.indexOf("const preProbeWorkflow = activeWorkflowRef();");
+  const probeAt = body.indexOf("await filterServerConfirmedInputSubfolderMedia");
+  assert.notEqual(snapAt, -1, "banner must snapshot the active workflow before probing");
+  assert.notEqual(probeAt, -1, "banner must await the nested-input probe");
+  assert.ok(
+    snapAt < probeAt,
+    `workflow snapshot must precede the probe await (snap@${snapAt} vs probe@${probeAt})`,
+  );
+
+  const fenceAt = body.indexOf("graphReadBindingChanged({");
+  assert.notEqual(fenceAt, -1, "banner must re-check the binding after the probe");
+  assert.ok(fenceAt > probeAt, "the binding re-check must follow the probe await");
+  assert.match(
+    body.slice(fenceAt),
+    /afterWorkflow: activeWorkflowRef\(\)/,
+    "the fence must re-read the NOW-active workflow",
+  );
+  const discardAt = body.indexOf('return "";', fenceAt);
+  assert.notEqual(discardAt, -1, "a binding change must silently skip the banner (best-effort)");
+  const sigAt = body.indexOf("lastInjectedValidationSig = sig");
+  assert.notEqual(sigAt, -1, "banner must stamp the dedupe signature");
+  assert.ok(
+    discardAt < sigAt,
+    "the mismatch discard must precede the dedupe-sig stamp — A's state must not poison B's dedupe",
   );
 });

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -12,7 +12,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { activeWorkflowNodeCount, graphReadDesynced } from "../../web/js/lib/graph-binding.js";
+import {
+  activeWorkflowNodeCount,
+  graphReadDesynced,
+  graphReadBindingChanged,
+} from "../../web/js/lib/graph-binding.js";
 
 // A ComfyUI ChangeTracker-shaped workflow: serialized graph states hang off
 // `changeTracker.activeState` / `.initialState` (and some builds hang them flat).
@@ -118,4 +122,51 @@ test("graphReadDesynced: FALSE — descended into an empty subgraph (legitimatel
 test("graphReadDesynced: defensive — missing args never throw, default to not-desynced", () => {
   assert.equal(graphReadDesynced(), false);
   assert.equal(graphReadDesynced({}), false);
+});
+
+test("graphReadBindingChanged: FALSE — same workflow instance and root graph across the await", () => {
+  const w = wf();
+  const g = {};
+  assert.equal(
+    graphReadBindingChanged({ beforeWorkflow: w, afterWorkflow: w, beforeRootGraph: g, afterRootGraph: g }),
+    false,
+  );
+});
+
+test("graphReadBindingChanged: TRUE — a tab switch swapped the active workflow instance mid-probe (#513 review)", () => {
+  const g = {};
+  assert.equal(
+    graphReadBindingChanged({ beforeWorkflow: wf(), afterWorkflow: wf(), beforeRootGraph: g, afterRootGraph: g }),
+    true,
+  );
+});
+
+test("graphReadBindingChanged: TRUE — the root graph was rebound across the await", () => {
+  const w = wf();
+  assert.equal(
+    graphReadBindingChanged({ beforeWorkflow: w, afterWorkflow: w, beforeRootGraph: {}, afterRootGraph: {} }),
+    true,
+  );
+});
+
+test("graphReadBindingChanged: TRUE — the binding went unresolvable mid-read (one side null)", () => {
+  const w = wf();
+  const g = {};
+  assert.equal(
+    graphReadBindingChanged({ beforeWorkflow: w, afterWorkflow: null, beforeRootGraph: g, afterRootGraph: g }),
+    true,
+  );
+});
+
+test("graphReadBindingChanged: FALSE — both snapshots unresolvable never manufactures a mismatch", () => {
+  assert.equal(graphReadBindingChanged(), false);
+  assert.equal(
+    graphReadBindingChanged({
+      beforeWorkflow: null,
+      afterWorkflow: null,
+      beforeRootGraph: null,
+      afterRootGraph: null,
+    }),
+    false,
+  );
 });

--- a/browser_tests/unit/input-asset.test.mjs
+++ b/browser_tests/unit/input-asset.test.mjs
@@ -145,9 +145,23 @@ test("splitInputAssetRef: POSIX semantics keep a backslash literal (#513 review)
   });
 });
 
-test("inputPathsUseWindowsSeparators: only os.name 'nt' enables Windows semantics", () => {
+test("inputPathsUseWindowsSeparators: sys.platform 'win32' AND legacy os.name 'nt' enable Windows semantics", () => {
+  // ComfyUI ≥ 0.4.0 reports Python's sys.platform ("win32" on Windows) in
+  // /system_stats; older servers reported os.name ("nt"). BOTH must read as
+  // Windows — the nt-only check sent EVERY modern Windows server down the POSIX
+  // branch, so an existing `dir\file.png` stayed falsely reported missing on the
+  // platform this PR exists for (#513 review regression).
+  assert.equal(inputPathsUseWindowsSeparators({ system: { os: "win32" } }), true);
   assert.equal(inputPathsUseWindowsSeparators({ system: { os: "nt" } }), true);
+  // POSIX servers keep POSIX semantics — including Cygwin/MSYS2 Pythons
+  // (sys.platform "cygwin"/"msys"), whose os.path is posixpath, so a backslash
+  // is a literal filename character there.
   assert.equal(inputPathsUseWindowsSeparators({ system: { os: "posix" } }), false);
+  assert.equal(inputPathsUseWindowsSeparators({ system: { os: "linux" } }), false);
+  assert.equal(inputPathsUseWindowsSeparators({ system: { os: "darwin" } }), false);
+  assert.equal(inputPathsUseWindowsSeparators({ system: { os: "cygwin" } }), false);
+  assert.equal(inputPathsUseWindowsSeparators({ system: { os: "msys" } }), false);
+  // Unknown / malformed payloads fail CLOSED to POSIX semantics.
   assert.equal(inputPathsUseWindowsSeparators({ system: {} }), false);
   assert.equal(inputPathsUseWindowsSeparators({}), false);
   assert.equal(inputPathsUseWindowsSeparators(null), false);

--- a/browser_tests/unit/input-asset.test.mjs
+++ b/browser_tests/unit/input-asset.test.mjs
@@ -9,6 +9,7 @@ import {
   uploadInputConfig,
   uploadInputAccepts,
   splitInputAssetRef,
+  filterServerConfirmedInputSubfolderCandidates,
   addComboOption,
 } from "../../web/js/lib/input-asset.js";
 
@@ -103,6 +104,30 @@ test("splitInputAssetRef: Windows backslashes normalized to forward slashes", ()
     subfolder: "xyr_canvas",
     filename: "foo.png",
   });
+});
+
+test("#513: server-confirmed nested input media is not reported missing", async () => {
+  const candidates = [
+    { node_id: 11, file: "root.png" },
+    { node_id: 12, file: "codex_stage\\mask.png" },
+    { node_id: 13, file: "codex_stage/missing.png" },
+    { node_id: 14, file: "codex_stage/mask.png" },
+  ];
+  const probes = [];
+  const result = await filterServerConfirmedInputSubfolderCandidates(candidates, async (file) => {
+    probes.push(file);
+    return file.includes("mask.png");
+  });
+  assert.deepEqual(result, [candidates[0], candidates[2]]);
+  assert.deepEqual(probes, ["codex_stage\\mask.png", "codex_stage/missing.png"]);
+});
+
+test("#513: nested input media stays missing when the server probe fails", async () => {
+  const candidate = { node_id: 12, file: "codex_stage/mask.png" };
+  const result = await filterServerConfirmedInputSubfolderCandidates([candidate], async () => {
+    throw new Error("offline");
+  });
+  assert.deepEqual(result, [candidate]);
 });
 
 test("addComboOption adds a value to an array-backed combo in place", () => {

--- a/browser_tests/unit/input-asset.test.mjs
+++ b/browser_tests/unit/input-asset.test.mjs
@@ -10,6 +10,7 @@ import {
   uploadInputAccepts,
   splitInputAssetRef,
   filterServerConfirmedInputSubfolderCandidates,
+  inputPathsUseWindowsSeparators,
   addComboOption,
 } from "../../web/js/lib/input-asset.js";
 
@@ -128,6 +129,73 @@ test("#513: nested input media stays missing when the server probe fails", async
     throw new Error("offline");
   });
   assert.deepEqual(result, [candidate]);
+});
+
+test("splitInputAssetRef: POSIX semantics keep a backslash literal (#513 review)", () => {
+  // On a POSIX server ComfyUI resolves `dir\file.png` as a LITERAL filename, not
+  // a nested path — the split must NOT invent a subfolder the server won't use.
+  assert.deepEqual(splitInputAssetRef("dir\\missing.png", { backslashIsSeparator: false }), {
+    subfolder: "",
+    filename: "dir\\missing.png",
+  });
+  // A forward slash still splits on POSIX.
+  assert.deepEqual(splitInputAssetRef("dir/missing.png", { backslashIsSeparator: false }), {
+    subfolder: "dir",
+    filename: "missing.png",
+  });
+});
+
+test("inputPathsUseWindowsSeparators: only os.name 'nt' enables Windows semantics", () => {
+  assert.equal(inputPathsUseWindowsSeparators({ system: { os: "nt" } }), true);
+  assert.equal(inputPathsUseWindowsSeparators({ system: { os: "posix" } }), false);
+  assert.equal(inputPathsUseWindowsSeparators({ system: {} }), false);
+  assert.equal(inputPathsUseWindowsSeparators({}), false);
+  assert.equal(inputPathsUseWindowsSeparators(null), false);
+});
+
+test("#513 review: POSIX server — a backslash value is NEVER probed as a nested path", async () => {
+  // The false-PASS from the review: `dir\missing.png` is genuinely missing on a
+  // POSIX server (LoadImage looks for the literal name), while `dir/missing.png`
+  // EXISTS. Splitting the backslash away would probe the existing file and
+  // suppress a real miss. POSIX semantics must leave the value un-probed and the
+  // candidate reported.
+  const candidate = { node_id: 12, file: "dir\\missing.png" };
+  let probed = 0;
+  const result = await filterServerConfirmedInputSubfolderCandidates(
+    [candidate],
+    async () => {
+      probed += 1;
+      return true; // would confirm dir/missing.png — must never be consulted
+    },
+    { backslashIsSeparator: false },
+  );
+  assert.equal(probed, 0);
+  assert.deepEqual(result, [candidate]);
+});
+
+test("#513 review: POSIX server — a forward-slash nested value is still probed and cleared", async () => {
+  const candidate = { node_id: 12, file: "dir/mask.png" };
+  const result = await filterServerConfirmedInputSubfolderCandidates(
+    [candidate],
+    async () => true,
+    { backslashIsSeparator: false },
+  );
+  assert.deepEqual(result, []);
+});
+
+test("#513 review: Windows server — a backslash value splits and probes as nested", async () => {
+  const candidate = { node_id: 12, file: "dir\\mask.png" };
+  const probes = [];
+  const result = await filterServerConfirmedInputSubfolderCandidates(
+    [candidate],
+    async (file) => {
+      probes.push(file);
+      return true;
+    },
+    { backslashIsSeparator: true },
+  );
+  assert.deepEqual(probes, ["dir\\mask.png"]);
+  assert.deepEqual(result, []);
 });
 
 test("addComboOption adds a value to an array-backed combo in place", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7324,9 +7324,9 @@ const GRAPH_TOOL_EXECUTORS = {
       })
     ) {
       throw new Error(
-        "The active workflow changed while graph_get_errors was verifying nested input media " +
+        "The active workflow changed while panel_get_errors was verifying nested input media " +
           "with the server, so this read's graph snapshot and asset verdicts now belong to " +
-          "DIFFERENT workflows. Retry graph_get_errors — it re-reads the now-active workflow.",
+          "DIFFERENT workflows. Retry panel_get_errors — it re-reads the now-active workflow.",
       );
     }
     assets.any = !!(assets.models.length || assets.media.length || assets.nodeTypes.length || assets.nodeCount);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -140,6 +140,7 @@ import { runSetWidget } from "./lib/set-widget.js";
 import {
   splitInputAssetRef,
   filterServerConfirmedInputSubfolderCandidates,
+  inputPathsUseWindowsSeparators,
 } from "./lib/input-asset.js";
 import {
   drivenWidgetsFor,
@@ -217,7 +218,11 @@ import {
 import { createRunCompletionTracker } from "./lib/run-completion.js";
 import { composeRunCompletionFrame } from "./lib/run-completion-frame.js";
 import { createRunReconcileSweep } from "./lib/run-reconcile-sweep.js";
-import { activeWorkflowNodeCount, graphReadDesynced } from "./lib/graph-binding.js";
+import {
+  activeWorkflowNodeCount,
+  graphReadDesynced,
+  graphReadBindingChanged,
+} from "./lib/graph-binding.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
 import { queueMembership, historyEntryFor } from "./lib/history-reconcile.js";
 import {
@@ -4366,31 +4371,65 @@ function collectMissingAssets(trustComboOverride) {
   return { models, media, nodeTypes, nodeCount, any: !!(models.length || media.length || nodeTypes.length || nodeCount) };
 }
 
+// ComfyUI resolves an input-asset value on the SERVER's platform (os.path.join):
+// a backslash is a path separator ONLY on Windows; on POSIX it is a literal
+// filename character. The /view probe must split the value exactly the way the
+// server will, or an existing `dir/file.png` falsely clears a genuinely missing
+// `dir\file.png` on a POSIX server (#513 review). The verdict comes from
+// /system_stats (`system.os` is Python's os.name) and is fetched once and cached —
+// the backend's OS cannot change within a page session. An UNKNOWN platform fails
+// CLOSED: POSIX semantics keep a backslash literal, so a value is never
+// re-interpreted into a path the server would not resolve (over-report, never
+// suppress — the same fail direction as the probe itself).
+let serverInputPathsAreWindows = null;
+async function inputAssetServerUsesWindowsPaths() {
+  if (serverInputPathsAreWindows !== null) return serverInputPathsAreWindows;
+  try {
+    if (typeof api?.fetchApi !== "function") return false;
+    const res = await api.fetchApi("/system_stats", {
+      cache: "no-store",
+      signal: AbortSignal.timeout(GET_ERRORS_REFRESH_TIMEOUT_MS),
+    });
+    const stats = res && res.ok ? await res.json() : null;
+    serverInputPathsAreWindows = inputPathsUseWindowsSeparators(stats);
+  } catch {
+    return false; // unknown platform → POSIX semantics (never suppress a genuine miss)
+  }
+  return serverInputPathsAreWindows;
+}
+
 /**
  * `/object_info` cannot list LoadImage input files below the input root, although
  * `/view?type=input` and LoadImage's validator can resolve them. Confirm only
  * those nested missing-media candidates against the server before telling the
  * agent that the user must re-upload an asset (#513). A failed probe deliberately
- * leaves the candidate in place, preserving the prior fail-closed warning.
+ * leaves the candidate in place, preserving the prior fail-closed warning. The
+ * subfolder/filename split follows the SERVER's path semantics so a backslash is
+ * treated as a separator only where ComfyUI itself would treat it as one.
  */
 async function filterServerConfirmedInputSubfolderMedia(media) {
-  return filterServerConfirmedInputSubfolderCandidates(media, async (assetValue) => {
-    try {
-      if (typeof api?.fetchApi !== "function") return false;
-      const { subfolder, filename } = splitInputAssetRef(assetValue);
-      if (!subfolder || !filename) return false;
-      const qs = new URLSearchParams({ filename, subfolder, type: "input" }).toString();
-      const res = await api.fetchApi(`/view?${qs}`, {
-        method: "GET",
-        cache: "no-store",
-        headers: { Range: "bytes=0-0" },
-        signal: AbortSignal.timeout(GET_ERRORS_REFRESH_TIMEOUT_MS),
-      });
-      return !!res && (res.ok || res.status === 206);
-    } catch {
-      return false;
-    }
-  });
+  const backslashIsSeparator = await inputAssetServerUsesWindowsPaths();
+  return filterServerConfirmedInputSubfolderCandidates(
+    media,
+    async (assetValue) => {
+      try {
+        if (typeof api?.fetchApi !== "function") return false;
+        const { subfolder, filename } = splitInputAssetRef(assetValue, { backslashIsSeparator });
+        if (!subfolder || !filename) return false;
+        const qs = new URLSearchParams({ filename, subfolder, type: "input" }).toString();
+        const res = await api.fetchApi(`/view?${qs}`, {
+          method: "GET",
+          cache: "no-store",
+          headers: { Range: "bytes=0-0" },
+          signal: AbortSignal.timeout(GET_ERRORS_REFRESH_TIMEOUT_MS),
+        });
+        return !!res && (res.ok || res.status === 206);
+      } catch {
+        return false;
+      }
+    },
+    { backslashIsSeparator },
+  );
 }
 
 /** True when EITHER missing-asset store holds a RAW candidate (isMissing !== false),
@@ -7227,7 +7266,38 @@ const GRAPH_TOOL_EXECUTORS = {
     //    LOAD, which is why they explain a red canvas long before anything is
     //    queued (see collectMissingAssets).
     const assets = collectMissingAssets(comboTrustedForQuery);
+    // The nested-input probe AWAITS the server AFTER the graph, node map and asset
+    // snapshot above are already captured — a workflow-tab switch in that window
+    // would join the PRE-switch workflow's missing-media verdicts onto the
+    // now-active one, returning workflow A's result while B is active (#513 review).
+    // Correlate on the active-workflow INSTANCE (the identity a rename/Save-As
+    // leaves intact) and the bound root graph across the await; on a provable
+    // change, discard the mixed read with a recoverable error so the caller retries
+    // against the now-current workflow — the same fail-loudly discipline as
+    // assertGraphBoundToActiveWorkflow above, never a cross-workflow result.
+    const preProbeWorkflow = activeWorkflowRef();
+    const preProbeRootGraph = rootGraph;
     assets.media = await filterServerConfirmedInputSubfolderMedia(assets.media);
+    let postProbeRootGraph = null;
+    try {
+      postProbeRootGraph = getGraphCtx().rootGraph ?? null;
+    } catch {
+      postProbeRootGraph = null; // binding gone mid-read → treated as changed below
+    }
+    if (
+      graphReadBindingChanged({
+        beforeWorkflow: preProbeWorkflow,
+        afterWorkflow: activeWorkflowRef(),
+        beforeRootGraph: preProbeRootGraph,
+        afterRootGraph: postProbeRootGraph,
+      })
+    ) {
+      throw new Error(
+        "The active workflow changed while graph_get_errors was verifying nested input media " +
+          "with the server, so this read's graph snapshot and asset verdicts now belong to " +
+          "DIFFERENT workflows. Retry graph_get_errors — it re-reads the now-active workflow.",
+      );
+    }
     assets.any = !!(assets.models.length || assets.media.length || assets.nodeTypes.length || assets.nodeCount);
     const missingModels = assets.models.map((m) => ({ ...m, kind: "missing_model" }));
     const missingMedia = assets.media.map((m) => ({ ...m, kind: "missing_media" }));

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -138,6 +138,10 @@ import {
 } from "./lib/subgraph-scope.js";
 import { runSetWidget } from "./lib/set-widget.js";
 import {
+  splitInputAssetRef,
+  filterServerConfirmedInputSubfolderCandidates,
+} from "./lib/input-asset.js";
+import {
   drivenWidgetsFor,
   drivenTag,
   capSummaryWidgets,
@@ -4362,6 +4366,33 @@ function collectMissingAssets(trustComboOverride) {
   return { models, media, nodeTypes, nodeCount, any: !!(models.length || media.length || nodeTypes.length || nodeCount) };
 }
 
+/**
+ * `/object_info` cannot list LoadImage input files below the input root, although
+ * `/view?type=input` and LoadImage's validator can resolve them. Confirm only
+ * those nested missing-media candidates against the server before telling the
+ * agent that the user must re-upload an asset (#513). A failed probe deliberately
+ * leaves the candidate in place, preserving the prior fail-closed warning.
+ */
+async function filterServerConfirmedInputSubfolderMedia(media) {
+  return filterServerConfirmedInputSubfolderCandidates(media, async (assetValue) => {
+    try {
+      if (typeof api?.fetchApi !== "function") return false;
+      const { subfolder, filename } = splitInputAssetRef(assetValue);
+      if (!subfolder || !filename) return false;
+      const qs = new URLSearchParams({ filename, subfolder, type: "input" }).toString();
+      const res = await api.fetchApi(`/view?${qs}`, {
+        method: "GET",
+        cache: "no-store",
+        headers: { Range: "bytes=0-0" },
+        signal: AbortSignal.timeout(GET_ERRORS_REFRESH_TIMEOUT_MS),
+      });
+      return !!res && (res.ok || res.status === 206);
+    } catch {
+      return false;
+    }
+  });
+}
+
 /** True when EITHER missing-asset store holds a RAW candidate (isMissing !== false),
  *  BEFORE the live cross-check filters it. get_errors keys its authoritative refresh
  *  on THIS, not on collectMissingAssets() — the collector already trusts a possibly-
@@ -4410,7 +4441,7 @@ function withRefreshTimeout(promise) {
   ]);
 }
 
-function validationBanner() {
+async function validationBanner() {
   let nodeErrors = null;
   try {
     nodeErrors =
@@ -4426,6 +4457,8 @@ function validationBanner() {
   // canvas is already red. Bailing on those two alone left the agent blind
   // exactly when the user could see the problem — reported from the field.
   const missing = collectMissingAssets();
+  missing.media = await filterServerConfirmedInputSubfolderMedia(missing.media);
+  missing.any = !!(missing.models.length || missing.media.length || missing.nodeTypes.length || missing.nodeCount);
   // #415: the ⚠️ MISSING ASSETS block reads as authoritative at turn start, but the
   // stores are LOAD-TIME only and the live combo can drift BOTH ways — a since-uploaded
   // asset the banner still calls missing, OR a since-deleted asset a prior-confirmed
@@ -7194,6 +7227,8 @@ const GRAPH_TOOL_EXECUTORS = {
     //    LOAD, which is why they explain a red canvas long before anything is
     //    queued (see collectMissingAssets).
     const assets = collectMissingAssets(comboTrustedForQuery);
+    assets.media = await filterServerConfirmedInputSubfolderMedia(assets.media);
+    assets.any = !!(assets.models.length || assets.media.length || assets.nodeTypes.length || assets.nodeCount);
     const missingModels = assets.models.map((m) => ({ ...m, kind: "missing_model" }));
     const missingMedia = assets.media.map((m) => ({ ...m, kind: "missing_media" }));
     const missingNodeTypes = assets.nodeTypes;
@@ -19330,7 +19365,7 @@ function buildPanel() {
     // value_not_in_list, broken links) the instant they appear — the same data the
     // user sees in the frontend's error panel — so the agent isn't blind to a broken
     // graph until it independently re-runs. Conditional + deduped (event-driven).
-    const valBanner = validationBanner();
+    const valBanner = await validationBanner();
     if (valBanner) sendText = valBanner + sendText;
     // Track delivery: trackSend marks "Sending…", then the working ack flips it
     // to "✓ Seen" (or a timeout / closed socket flips it to "Not delivered").

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -4376,11 +4376,12 @@ function collectMissingAssets(trustComboOverride) {
 // filename character. The /view probe must split the value exactly the way the
 // server will, or an existing `dir/file.png` falsely clears a genuinely missing
 // `dir\file.png` on a POSIX server (#513 review). The verdict comes from
-// /system_stats (`system.os` is Python's os.name) and is fetched once and cached —
-// the backend's OS cannot change within a page session. An UNKNOWN platform fails
-// CLOSED: POSIX semantics keep a backslash literal, so a value is never
-// re-interpreted into a path the server would not resolve (over-report, never
-// suppress — the same fail direction as the probe itself).
+// /system_stats (`system.os` is Python's sys.platform on ComfyUI ≥ 0.4.0 —
+// "win32" on Windows — os.name "nt" on older servers) and is fetched once and
+// cached — the backend's OS cannot change within a page session. An UNKNOWN
+// platform fails CLOSED: POSIX semantics keep a backslash literal, so a value
+// is never re-interpreted into a path the server would not resolve
+// (over-report, never suppress — the same fail direction as the probe itself).
 let serverInputPathsAreWindows = null;
 async function inputAssetServerUsesWindowsPaths() {
   if (serverInputPathsAreWindows !== null) return serverInputPathsAreWindows;
@@ -4496,7 +4497,37 @@ async function validationBanner() {
   // canvas is already red. Bailing on those two alone left the agent blind
   // exactly when the user could see the problem — reported from the field.
   const missing = collectMissingAssets();
+  // The probe below awaits SERVER state while everything above was captured from
+  // the PRE-await workflow. A workflow-tab switch during the await would join A's
+  // missing/validation banner onto B's turn and send it into B's session (#513
+  // review). Same correlation as graph_get_errors: snapshot the active-workflow
+  // instance and the bound root graph before the await, re-read after, discard on
+  // a provable change. The banner is best-effort, so a mismatch skips it SILENTLY
+  // (no recoverable-error retry) — B's next turn recomputes from B's own state.
+  let preProbeRootGraph = null;
+  try {
+    preProbeRootGraph = getGraphCtx().rootGraph ?? null;
+  } catch {
+    preProbeRootGraph = null; // unresolvable now → correlate on the workflow alone
+  }
+  const preProbeWorkflow = activeWorkflowRef();
   missing.media = await filterServerConfirmedInputSubfolderMedia(missing.media);
+  let postProbeRootGraph = null;
+  try {
+    postProbeRootGraph = getGraphCtx().rootGraph ?? null;
+  } catch {
+    postProbeRootGraph = null; // binding gone mid-read → treated as changed below
+  }
+  if (
+    graphReadBindingChanged({
+      beforeWorkflow: preProbeWorkflow,
+      afterWorkflow: activeWorkflowRef(),
+      beforeRootGraph: preProbeRootGraph,
+      afterRootGraph: postProbeRootGraph,
+    })
+  ) {
+    return "";
+  }
   missing.any = !!(missing.models.length || missing.media.length || missing.nodeTypes.length || missing.nodeCount);
   // #415: the ⚠️ MISSING ASSETS block reads as authoritative at turn start, but the
   // stores are LOAD-TIME only and the live combo can drift BOTH ways — a since-uploaded

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -75,3 +75,26 @@ export function graphReadDesynced({ liveNodeCount, activeWorkflow, inSubgraph = 
   if (Number(liveNodeCount) !== 0) return false;
   return activeWorkflowNodeCount(activeWorkflow) > 0;
 }
+
+/**
+ * True when the graph READ's binding changed across an AWAIT: the active-workflow
+ * instance or the bound root-graph object captured before the await no longer
+ * matches after it. Used to detect a workflow-tab SWITCH that interleaved with a
+ * server probe mid-read (graph_get_errors' nested-input /view probe, #513 review)
+ * — without it, the read would join the PRE-switch workflow's asset verdicts onto
+ * the now-active workflow and return workflow A's result while B is active.
+ *
+ * Identity-based, not value-based: ComfyUI mutates a workflow instance's path in
+ * place on rename/Save-As, so the INSTANCE is the only stable identity (a rename
+ * alone leaves it intact and correctly reads as NO switch). Fires only on a
+ * provable change — both snapshots unresolvable (null/null) compares equal and
+ * never manufactures a mismatch.
+ */
+export function graphReadBindingChanged({
+  beforeWorkflow,
+  afterWorkflow,
+  beforeRootGraph,
+  afterRootGraph,
+} = {}) {
+  return beforeWorkflow !== afterWorkflow || beforeRootGraph !== afterRootGraph;
+}

--- a/web/js/lib/input-asset.js
+++ b/web/js/lib/input-asset.js
@@ -154,14 +154,22 @@ export function splitInputAssetRef(value, { backslashIsSeparator = true } = {}) 
 }
 
 /**
- * Interpret a ComfyUI `/system_stats` payload for the input-path split above:
- * `system.os` is Python's `os.name` — "nt" on Windows, "posix" elsewhere. Any
- * missing/malformed shape returns false (POSIX semantics), so an unreadable
- * stats payload can never enable a split the server would not perform.
+ * Interpret a ComfyUI `/system_stats` payload for the input-path split above.
+ * `system.os` is Python's `sys.platform` on ComfyUI ≥ 0.4.0 — "win32" on
+ * Windows — while older servers report `os.name` ("nt" on Windows); BOTH
+ * Windows spellings are accepted, or every modern Windows server falls
+ * through to the POSIX branch and a genuinely-present `dir\file.png` stays
+ * falsely reported missing (#513 review). Cygwin/MSYS2 Pythons report
+ * sys.platform "cygwin"/"msys" but their os.path is posixpath — a backslash
+ * is NOT a separator there — so they correctly fall through to POSIX
+ * semantics, as do "linux"/"darwin". Any missing/malformed shape returns
+ * false (POSIX semantics), so an unreadable stats payload can never enable a
+ * split the server would not perform.
  */
 export function inputPathsUseWindowsSeparators(systemStats) {
   try {
-    return String(systemStats?.system?.os ?? "").toLowerCase() === "nt";
+    const os = String(systemStats?.system?.os ?? "").toLowerCase();
+    return os === "win32" || os === "nt";
   } catch {
     return false;
   }

--- a/web/js/lib/input-asset.js
+++ b/web/js/lib/input-asset.js
@@ -134,14 +134,37 @@ export function uploadInputAccepts(config, value) {
  * ComfyUI `/view?type=input` existence probe. ComfyUI stores uploaded inputs at
  * `input/<subfolder>/<filename>` and the widget value is the POSIX-joined
  * `subfolder/filename` (or a bare `filename` at the root). Splits on the LAST slash;
- * a value with no slash is a root-level filename. Backslashes are normalized to
- * forward slashes so a Windows-style path still probes correctly.
+ * a value with no slash is a root-level filename.
+ *
+ * `backslashIsSeparator` (default true) mirrors how the SERVER resolves the value:
+ * ComfyUI joins it with `os.path`, where a backslash is a path separator ONLY on
+ * Windows — on a POSIX server it is a literal filename character. Normalizing it
+ * away unconditionally would probe a DIFFERENT path than LoadImage resolves, so an
+ * existing `dir/file.png` could falsely clear a genuinely missing `dir\file.png`
+ * on a POSIX server (#513 review). Pass the server platform's verdict; when the
+ * platform is unknown, pass false (POSIX semantics) so a backslash value is never
+ * re-interpreted into a path the server would not resolve.
  */
-export function splitInputAssetRef(value) {
-  const v = String(value ?? "").replace(/\\/g, "/");
+export function splitInputAssetRef(value, { backslashIsSeparator = true } = {}) {
+  const raw = String(value ?? "");
+  const v = backslashIsSeparator ? raw.replace(/\\/g, "/") : raw;
   const i = v.lastIndexOf("/");
   if (i < 0) return { subfolder: "", filename: v };
   return { subfolder: v.slice(0, i), filename: v.slice(i + 1) };
+}
+
+/**
+ * Interpret a ComfyUI `/system_stats` payload for the input-path split above:
+ * `system.os` is Python's `os.name` — "nt" on Windows, "posix" elsewhere. Any
+ * missing/malformed shape returns false (POSIX semantics), so an unreadable
+ * stats payload can never enable a split the server would not perform.
+ */
+export function inputPathsUseWindowsSeparators(systemStats) {
+  try {
+    return String(systemStats?.system?.os ?? "").toLowerCase() === "nt";
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -154,8 +177,17 @@ export function splitInputAssetRef(value) {
  * must not own a ComfyUI API client. The helper fails CLOSED: an unavailable,
  * rejected, or throwing probe keeps the original candidate reported. Root-level
  * values are not probed because the live combo is already authoritative there.
+ *
+ * `backslashIsSeparator` must match the SERVER's platform (see splitInputAssetRef):
+ * on a POSIX server a `dir\file.png` value is a literal filename, NOT a nested
+ * path, so it is left un-split and un-probed — the candidate stays reported,
+ * which is the truthful verdict for a file LoadImage cannot resolve there.
  */
-export async function filterServerConfirmedInputSubfolderCandidates(candidates, confirmServerAsset) {
+export async function filterServerConfirmedInputSubfolderCandidates(
+  candidates,
+  confirmServerAsset,
+  { backslashIsSeparator = true } = {},
+) {
   if (!Array.isArray(candidates)) return [];
   if (typeof confirmServerAsset !== "function") return candidates;
   const probes = new Map();
@@ -163,7 +195,7 @@ export async function filterServerConfirmedInputSubfolderCandidates(candidates, 
     candidates.map(async (candidate) => {
       const file = candidate?.file;
       if (typeof file !== "string") return candidate;
-      const { subfolder, filename } = splitInputAssetRef(file);
+      const { subfolder, filename } = splitInputAssetRef(file, { backslashIsSeparator });
       if (!subfolder || !filename) return candidate;
       const key = `${subfolder}/${filename}`;
       let probe = probes.get(key);

--- a/web/js/lib/input-asset.js
+++ b/web/js/lib/input-asset.js
@@ -145,6 +145,41 @@ export function splitInputAssetRef(value) {
 }
 
 /**
+ * Remove missing-media candidates for NESTED input files the server confirms are
+ * present. ComfyUI's LoadImage combo only lists files at the input root, while
+ * its validator can load `subfolder/file.png`; exact combo membership therefore
+ * cannot adjudicate these candidates (#513).
+ *
+ * `confirmServerAsset(value)` is injected by the panel because this pure module
+ * must not own a ComfyUI API client. The helper fails CLOSED: an unavailable,
+ * rejected, or throwing probe keeps the original candidate reported. Root-level
+ * values are not probed because the live combo is already authoritative there.
+ */
+export async function filterServerConfirmedInputSubfolderCandidates(candidates, confirmServerAsset) {
+  if (!Array.isArray(candidates)) return [];
+  if (typeof confirmServerAsset !== "function") return candidates;
+  const probes = new Map();
+  const filtered = await Promise.all(
+    candidates.map(async (candidate) => {
+      const file = candidate?.file;
+      if (typeof file !== "string") return candidate;
+      const { subfolder, filename } = splitInputAssetRef(file);
+      if (!subfolder || !filename) return candidate;
+      const key = `${subfolder}/${filename}`;
+      let probe = probes.get(key);
+      if (!probe) {
+        probe = Promise.resolve()
+          .then(() => confirmServerAsset(file))
+          .then((present) => present === true, () => false);
+        probes.set(key, probe);
+      }
+      return (await probe) ? null : candidate;
+    }),
+  );
+  return filtered.filter(Boolean);
+}
+
+/**
  * Add `value` to a combo widget's option list in place (so a following revalidation
  * accepts it) WITHOUT clobbering a dynamic function-valued option source. Returns
  * true if the option list now contains the value. Defensive; no-op on a bad widget.


### PR DESCRIPTION
Closes #513.\n\nComfyUI LoadImage can resolve input/subfolder/file values even though /object_info lists only input-root files. Before panel_get_errors or the turn-start missing-assets banner reports a nested media candidate as missing, the panel performs the existing bounded /view?type=input range probe. A confirmed file is excluded; unavailable, failed, and non-successful probes retain the existing warning. Duplicate candidate paths share one probe.\n\nValidation:\n- npm.cmd run test:unit (1,221 passing)\n- npm.cmd run typecheck\n- node --check web/js/comfyui-mcp-panel.js\n- npm.cmd run test:e2e:list\n- git diff --check\n\nLive rig: not run; the focused regression uses an injected server-confirmation probe, while a live ComfyUI fixture with a nested input upload was not available in this worktree.