### PR TITLE
fix(panel): replace literal NUL map-key sentinels with printable form (#510)

### DIFF
--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -12905,7 +12905,7 @@ function buildPanel() {
       if (!bk || !Array.isArray(list)) return;
       const plabel = BACKEND_LABELS[bk] || bk;
       for (const m of list) {
-        const key = bk + " " + m.id;
+        const key = bk + "\x00" + m.id;
         if (seen.has(key)) continue;
         seen.add(key);
         rows.push({ ...m, provider: bk, providerLabel: plabel });
@@ -12956,7 +12956,7 @@ function buildPanel() {
     const out = [];
     const pushed = new Set();
     const take = (m) => {
-      const key = m.provider + " " + m.id;
+      const key = m.provider + "\x00" + m.id;
       if (pushed.has(key)) return;
       pushed.add(key);
       out.push(m);


### PR DESCRIPTION
Refs #510

## What

`web/js/comfyui-mcp-panel.js` carried two literal NUL bytes (`\0`) as composite map-key separators:

- `aggregatedModels()` — dedupe key `bk + "\0" + m.id`
- `recommendedModels()` — dedupe key `m.provider + "\0" + m.id`

Git treats any file with a NUL in its sample window as binary; today the sentinels sit ~630 KB in so the file still diffs as text by luck. If they ever fall inside the window the whole panel file diffs as `Bin X -> Y bytes` and becomes unreviewable.

## Fix

Both string literals now spell the same sentinel as the printable escape sequence `"\x00"` (6 ASCII bytes in source) instead of a raw NUL byte. The runtime value is byte-identical — a single NUL character — so dedupe semantics are provably unchanged. No other edits.

## Verification

- `tr -dc '\000' < web/js/comfyui-mcp-panel.js | wc -c` → `0` (was `2`)
- `git show HEAD:web/js/comfyui-mcp-panel.js | grep -acP '\x00'` → `0` matches
- node buffer scan for `0x00` → `0`
- `node --check web/js/comfyui-mcp-panel.js` → OK
- `npm run test:unit` (`node --test browser_tests/unit/*.test.mjs`) → **1245 pass, 0 fail**

Note: `grep -c $'\x00'` is not a usable check in bash — `$'\x00'` expands to the empty string so grep matches every line. Use `grep -cP '\x00'` or the `tr` form above.

Follow-up idea from the issue (not in this PR, kept minimal): wire a NUL-free assertion for this file into the existing lint gate so the pattern can't regress.