### PR TITLE
fix(civitai): drop model-level nsfw:true entries under SFW browsing masks (#515)

### DIFF
--- a/browser_tests/unit/civitai-creator.test.mjs
+++ b/browser_tests/unit/civitai-creator.test.mjs
@@ -121,6 +121,21 @@ test("fetchModels keyword×creator chase is capped (initial + 4 hops)", async ()
   assert.equal(page.nextCursor, "again"); // caller can keep going explicitly
 });
 
+// #515: /v1/models returns nsfw:true entries even with nsfw=false — SFW
+// browsing masks must drop them client-side, not just filter their covers.
+test("fetchModels SFW mask [1,2] drops model-level nsfw:true, keeps clean models", async () => {
+  const nsfwItem = { ...modelItem("Adult Pack"), id: 1932929, nsfw: true };
+  const sfwItem = modelItem("Camera Motion");
+  const { client } = stub({ items: [nsfwItem, sfwItem], metadata: {} });
+  const page = await client.fetchModels({ type: "LORA", levels: [1, 2] });
+  assert.deepEqual(page.models.map((m) => m.name), ["Camera Motion"]);
+
+  // an adult-inclusive mask must NOT apply the model-level rejection
+  const { client: adult } = stub({ items: [{ ...nsfwItem, modelVersions: [{ baseModel: "Wan Video", images: [{ url: "u9", nsfwLevel: 8 }], files: [] }] }], metadata: {} });
+  const grown = await adult.fetchModels({ type: "LORA", levels: [1, 2, 8] });
+  assert.deepEqual(grown.models.map((m) => m.name), ["Adult Pack"]);
+});
+
 test("fetchTopCreators parses the leaderboard tRPC shape", async () => {
   const entry = (username, position, extra = {}) => ({
     position, score: position * 100,

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -422,6 +422,11 @@ export class CivitaiClient {
   // pick the highest-level cover image whose level is in the selected set (mask);
   // drop the model entirely if none qualify (no NSFW cover leaking into an SFW view)
   _modelFromJson(j, levels) {
+    // #515: /v1/models gates nsfw=false loosely — entries explicitly flagged
+    // nsfw:true still come back. When the selected levels are SFW-only
+    // (mask ⊆ {PG, PG-13}), drop such models outright; cover-level filtering
+    // below alone isn't enough because a PG cover can front an NSFW model.
+    if (bitmask(levels) <= 3 && j.nsfw === true) return null;
     const mask = bitmask(levels);
     let best = null, bestLvl = -1;
     for (const v of j.modelVersions || []) {


### PR DESCRIPTION
Panel-side fix for #515 (sibling of orchestrator fix artokun/comfyui-mcp#674 / mcp#664 — this PR does not reimplement that one).

## Where the leak was
`CivitaiClient.fetchModels` already sends `nsfw=false` to CivitAI's `/v1/models` when the browsing mask is SFW-only, and `_modelFromJson` already filtered cover-image `nsfwLevel` against the selected levels. But `/v1/models` returns entries explicitly flagged `nsfw: true` even with `nsfw=false`, and `_modelFromJson` never checked the **model-level** flag — a model with a PG cover image (e.g. id 1932929) passed through into the LoRA grid and `panel_civitai_results` with adult mode off.

## Fix
In `_modelFromJson`, when the selected browsing levels are SFW-only (bitmask ⊆ {1,2}), reject items whose payload carries `nsfw: true`. Adult-inclusive masks (any level ≥ 4 selected — the panel's adult-mode consent is expressed via browsing levels, already server-clamped by mcp) are untouched.

## Tests
- New unit test in `browser_tests/unit/civitai-creator.test.mjs`: SFW mask `[1,2]` drops a model-level `nsfw:true` item while retaining a clean one; an adult-inclusive mask `[1,2,8]` does not apply the rejection.
- `node --test --test-name-pattern=fetchModels browser_tests/unit/civitai-creator.test.mjs` → 5 passed.
- `npm run test:unit` → 1246 passed, 0 failed.