### PR TITLE
fix(panel): dedupe bridge command rids so a replayed mutation can't double-apply (#517)

### DIFF
--- a/browser_tests/unit/command-dedupe.test.mjs
+++ b/browser_tests/unit/command-dedupe.test.mjs
@@ -217,3 +217,23 @@ test("a different bridge-stamped workflow_uuid is a DIFFERENT command even with 
   assert.equal(ran, 2);
   assert.equal(warnings.length, 1);
 });
+
+test("a past-cap in-flight burst is swept back to the cap as entries settle (#517 re-gate)", async () => {
+  const ledger = createCommandDedupeLedger(200);
+  // 202 commands concurrently in flight — nothing is evictable at begin time,
+  // so the ledger grows past cap (safe direction).
+  const settles = [];
+  for (let i = 0; i <= 200; i += 1) settles.push(ledger.begin(`r${i}`, `fp${i}`));
+  const settleLive = ledger.begin("r-live", "fp-live"); // pinned in flight
+
+  // All 201 settle: the settle-time sweep must re-apply the bound, dropping the
+  // oldest SETTLED entries while the in-flight one is never touched.
+  settles.forEach((s, i) => s({ rid: `r${i}`, ok: true, result: {} }));
+
+  assert.equal(ledger.get("r0", "fp0"), undefined, "oldest settled entry swept on settle");
+  assert.equal(ledger.get("r1", "fp1"), undefined, "swept down to the cap, not one past it");
+  assert.notEqual(ledger.get("r2", "fp2"), undefined, "settled entries within the cap are kept");
+  assert.notEqual(ledger.get("r200", "fp200"), undefined, "newest settled entry is kept");
+  assert.notEqual(ledger.get("r-live", "fp-live"), undefined, "the in-flight entry is never evicted");
+  settleLive({ rid: "r-live", ok: true, result: {} });
+});

--- a/browser_tests/unit/command-dedupe.test.mjs
+++ b/browser_tests/unit/command-dedupe.test.mjs
@@ -7,18 +7,22 @@
 // duplicate / orphaned nodes. The ledger makes every rid-correlated command
 // idempotent at the point of application: the first delivery executes, any
 // later delivery of the same rid is answered with the ORIGINAL reply.
+//
+// The dedupe identity is rid + payload fingerprint: the bridge's re-dispatch of
+// the SAME logical command dedupes, but a rid reused for DIFFERENT work must
+// execute fresh (never answered from the ledger) and is logged once.
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { createCommandDedupeLedger } from "../../web/js/lib/command-dedupe.js";
+import { commandFingerprint, createCommandDedupeLedger } from "../../web/js/lib/command-dedupe.js";
 
 // Minimal stand-in for the panel's bridge message handler: the same
 // get → (replay | begin → execute → settle) flow the real dispatch runs.
 function makeDispatch(ledger, executor) {
   return async function deliver(msg) {
-    const prior = ledger.get(msg.rid);
+    const prior = ledger.get(msg.rid, commandFingerprint(msg));
     if (prior !== undefined) return { reply: await prior, executed: false };
-    const settle = ledger.begin(msg.rid);
+    const settle = ledger.begin(msg.rid, commandFingerprint(msg));
     let reply;
     try {
       reply = { rid: msg.rid, ok: true, result: await executor(msg) };
@@ -94,21 +98,22 @@ test("distinct rids execute independently", async () => {
 
 test("the ledger forgets rids beyond its cap (bounded, fail-open)", async () => {
   const ledger = createCommandDedupeLedger(3);
+  const fp = commandFingerprint({ cmd: "graph_add_node" });
   const deliver = makeDispatch(ledger, async () => ({ ok: true }));
   for (const rid of ["r1", "r2", "r3", "r4"]) await deliver({ rid, cmd: "graph_add_node" });
-  assert.equal(ledger.get("r1"), undefined, "oldest rid is evicted once over cap");
-  assert.notEqual(ledger.get("r4"), undefined, "recent rids are still remembered");
+  assert.equal(ledger.get("r1", fp), undefined, "oldest rid is evicted once over cap");
+  assert.notEqual(ledger.get("r4", fp), undefined, "recent rids are still remembered");
   // Fail-open: an evicted replay would simply re-execute — the pre-ledger
   // behaviour, never a new failure mode.
 });
 
 test("settle is idempotent — a second settle cannot rewrite the recorded reply", async () => {
   const ledger = createCommandDedupeLedger();
-  const settle = ledger.begin("r1");
+  const settle = ledger.begin("r1", "fp");
   const reply = { rid: "r1", ok: true, result: { added: { id: 1 } } };
   settle(reply);
   settle({ rid: "r1", ok: false, error: "bogus" });
-  assert.equal(await ledger.get("r1"), reply);
+  assert.equal(await ledger.get("r1", "fp"), reply);
 });
 
 test("an in-flight entry is NEVER evicted past cap — its replay is still deduped (#517 re-gate)", async () => {
@@ -137,12 +142,78 @@ test("an in-flight entry is NEVER evicted past cap — its replay is still dedup
 
 test("settled entries still evict oldest-first while an in-flight one is kept", async () => {
   const ledger = createCommandDedupeLedger(3);
+  const fp = commandFingerprint({ cmd: "graph_add_node" });
   const deliver = makeDispatch(ledger, async () => ({ ok: true }));
-  const settleLive = ledger.begin("r-live"); // stays in flight
+  const settleLive = ledger.begin("r-live", "fp-live"); // stays in flight
   for (const rid of ["r1", "r2", "r3"]) await deliver({ rid, cmd: "graph_add_node" });
   // 4 entries > cap 3 → the oldest SETTLED (r1) evicts; in-flight r-live survives.
-  assert.notEqual(ledger.get("r-live"), undefined, "in-flight entry is kept past cap");
-  assert.equal(ledger.get("r1"), undefined, "oldest settled entry still evicts — memory stays bounded");
-  assert.notEqual(ledger.get("r3"), undefined, "newer settled entries are still remembered");
+  assert.notEqual(ledger.get("r-live", "fp-live"), undefined, "in-flight entry is kept past cap");
+  assert.equal(ledger.get("r1", fp), undefined, "oldest settled entry still evicts — memory stays bounded");
+  assert.notEqual(ledger.get("r3", fp), undefined, "newer settled entries are still remembered");
   settleLive({ rid: "r-live", ok: true, result: {} });
+});
+
+test("same rid + DIFFERENT payload is NOT answered from the ledger — it executes fresh (#517 re-gate)", async () => {
+  const warnings = [];
+  const ledger = createCommandDedupeLedger(200, (m) => warnings.push(m));
+  let applied = 0;
+  const deliver = makeDispatch(ledger, async (msg) => ({ added: { id: ++applied, pos: msg.pos } }));
+
+  const a = await deliver({ rid: "r1", cmd: "graph_add_node", pos: [0, 0] });
+  const b = await deliver({ rid: "r1", cmd: "graph_add_node", pos: [9, 9] });
+  assert.equal(a.executed, true);
+  assert.equal(b.executed, true, "a reused rid with a different payload must execute, not replay the old reply");
+  assert.equal(applied, 2, "the new command was NOT lost to the ledger");
+  assert.notEqual(b.reply, a.reply, "each command gets its OWN truthful reply");
+  assert.equal(warnings.length, 1, "rid reuse for different work logs a warning");
+
+  // …and each payload still dedupes its OWN replays against its own reply.
+  const aReplay = await deliver({ rid: "r1", cmd: "graph_add_node", pos: [0, 0] });
+  const bReplay = await deliver({ rid: "r1", cmd: "graph_add_node", pos: [9, 9] });
+  assert.equal(aReplay.executed, false);
+  assert.equal(bReplay.executed, false);
+  assert.equal(applied, 2, "neither payload's replay re-executes");
+  assert.equal(aReplay.reply, a.reply);
+  assert.equal(bReplay.reply, b.reply);
+});
+
+test("fingerprint mismatch logs ONCE — the new payload's own replays dedupe silently", async () => {
+  const warnings = [];
+  const ledger = createCommandDedupeLedger(200, (m) => warnings.push(m));
+  const deliver = makeDispatch(ledger, async () => ({ ok: true }));
+
+  await deliver({ rid: "r1", cmd: "graph_add_node" });
+  const fresh = await deliver({ rid: "r1", cmd: "graph_remove_node", node_id: 7 }); // mismatch → warn
+  const replay = await deliver({ rid: "r1", cmd: "graph_remove_node", node_id: 7 }); // replay of new → dedupe
+  assert.equal(fresh.executed, true);
+  assert.equal(replay.executed, false);
+  assert.equal(warnings.length, 1, "one warning per rid-reuse event, not per retry");
+});
+
+test("fingerprint is key-order independent — the same payload re-serialized still dedupes", async () => {
+  const ledger = createCommandDedupeLedger();
+  let applied = 0;
+  const deliver = makeDispatch(ledger, async () => ({ added: { id: ++applied } }));
+
+  const first = await deliver({ rid: "r1", cmd: "graph_add_node", class_type: "LoraLoaderModelOnly", pos: [1, 2] });
+  // Same logical command, fields in a different insertion order (a re-serialized
+  // re-dispatch): identical fingerprint, so it dedupes.
+  const replay = await deliver({ pos: [1, 2], class_type: "LoraLoaderModelOnly", cmd: "graph_add_node", rid: "r1" });
+  assert.equal(replay.executed, false);
+  assert.equal(applied, 1);
+  assert.equal(replay.reply, first.reply);
+});
+
+test("a different bridge-stamped workflow_uuid is a DIFFERENT command even with identical args", async () => {
+  const warnings = [];
+  const ledger = createCommandDedupeLedger(200, (m) => warnings.push(m));
+  let ran = 0;
+  const deliver = makeDispatch(ledger, async () => ++ran);
+
+  const a = await deliver({ rid: "r1", cmd: "graph_add_node", class_type: "X", workflow_uuid: "wfA" });
+  const b = await deliver({ rid: "r1", cmd: "graph_add_node", class_type: "X", workflow_uuid: "wfB" });
+  assert.equal(a.executed, true);
+  assert.equal(b.executed, true, "same rid+args on another workflow must execute, not replay");
+  assert.equal(ran, 2);
+  assert.equal(warnings.length, 1);
 });

--- a/browser_tests/unit/command-dedupe.test.mjs
+++ b/browser_tests/unit/command-dedupe.test.mjs
@@ -1,0 +1,112 @@
+// Unit tests for the bridge-command rid dedupe ledger (web/js/lib/command-dedupe.js).
+//
+// Regression coverage for #517: a graph mutation that timed out bridge-side can
+// still apply panel-side, and re-delivering the SAME command frame (a replay
+// after reconnect, or a retry that reuses the request id) must NOT execute the
+// mutation a second time — the timed-out apply plus the retry is what produced
+// duplicate / orphaned nodes. The ledger makes every rid-correlated command
+// idempotent at the point of application: the first delivery executes, any
+// later delivery of the same rid is answered with the ORIGINAL reply.
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createCommandDedupeLedger } from "../../web/js/lib/command-dedupe.js";
+
+// Minimal stand-in for the panel's bridge message handler: the same
+// get → (replay | begin → execute → settle) flow the real dispatch runs.
+function makeDispatch(ledger, executor) {
+  return async function deliver(msg) {
+    const prior = ledger.get(msg.rid);
+    if (prior !== undefined) return { reply: await prior, executed: false };
+    const settle = ledger.begin(msg.rid);
+    let reply;
+    try {
+      reply = { rid: msg.rid, ok: true, result: await executor(msg) };
+    } catch (err) {
+      reply = { rid: msg.rid, ok: false, error: String(err?.message ?? err) };
+    }
+    settle(reply);
+    return { reply, executed: true };
+  };
+}
+
+test("a replayed rid is answered with the ORIGINAL reply and never re-executes (#517)", async () => {
+  const ledger = createCommandDedupeLedger();
+  let applied = 0;
+  const deliver = makeDispatch(ledger, async () => ({ added: { id: ++applied } }));
+
+  const first = await deliver({ rid: "r1", cmd: "graph_add_node" });
+  assert.equal(first.executed, true);
+  assert.equal(applied, 1, "first delivery applies the mutation once");
+
+  const replay = await deliver({ rid: "r1", cmd: "graph_add_node" });
+  assert.equal(replay.executed, false, "second delivery of the same rid is a no-op");
+  assert.equal(applied, 1, "the mutation is still applied exactly once — no duplicate node");
+  assert.equal(replay.reply, first.reply, "the replay gets the ORIGINAL reply verbatim");
+});
+
+test("an in-flight duplicate waits for the first execution and shares its reply", async () => {
+  const ledger = createCommandDedupeLedger();
+  let applied = 0;
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  const deliver = makeDispatch(ledger, async () => {
+    await gate; // still applying when the replay arrives (the #517 slow-tab window)
+    return { added: { id: ++applied } };
+  });
+
+  const p1 = deliver({ rid: "r1", cmd: "graph_add_node" });
+  const p2 = deliver({ rid: "r1", cmd: "graph_add_node" });
+  release();
+  const [first, replay] = await Promise.all([p1, p2]);
+  assert.equal(applied, 1, "one execution even when the replay lands mid-apply");
+  assert.equal(replay.executed, false);
+  assert.equal(replay.reply, first.reply, "both deliveries resolve to the same reply");
+});
+
+test("a failed command's replay re-sends the same error reply without re-executing", async () => {
+  const ledger = createCommandDedupeLedger();
+  let attempts = 0;
+  const deliver = makeDispatch(ledger, async () => {
+    attempts += 1;
+    throw new Error("workflow instance mismatch");
+  });
+
+  const first = await deliver({ rid: "r1", cmd: "graph_remove_node" });
+  assert.equal(first.reply.ok, false);
+  const replay = await deliver({ rid: "r1", cmd: "graph_remove_node" });
+  assert.equal(replay.executed, false);
+  assert.equal(attempts, 1);
+  assert.equal(replay.reply, first.reply);
+});
+
+test("distinct rids execute independently", async () => {
+  const ledger = createCommandDedupeLedger();
+  let applied = 0;
+  const deliver = makeDispatch(ledger, async () => ({ added: { id: ++applied } }));
+  const a = await deliver({ rid: "r1", cmd: "graph_add_node" });
+  const b = await deliver({ rid: "r2", cmd: "graph_add_node" });
+  assert.equal(a.executed, true);
+  assert.equal(b.executed, true);
+  assert.equal(applied, 2);
+  assert.notEqual(a.reply, b.reply);
+});
+
+test("the ledger forgets rids beyond its cap (bounded, fail-open)", async () => {
+  const ledger = createCommandDedupeLedger(3);
+  const deliver = makeDispatch(ledger, async () => ({ ok: true }));
+  for (const rid of ["r1", "r2", "r3", "r4"]) await deliver({ rid, cmd: "graph_add_node" });
+  assert.equal(ledger.get("r1"), undefined, "oldest rid is evicted once over cap");
+  assert.notEqual(ledger.get("r4"), undefined, "recent rids are still remembered");
+  // Fail-open: an evicted replay would simply re-execute — the pre-ledger
+  // behaviour, never a new failure mode.
+});
+
+test("settle is idempotent — a second settle cannot rewrite the recorded reply", async () => {
+  const ledger = createCommandDedupeLedger();
+  const settle = ledger.begin("r1");
+  const reply = { rid: "r1", ok: true, result: { added: { id: 1 } } };
+  settle(reply);
+  settle({ rid: "r1", ok: false, error: "bogus" });
+  assert.equal(await ledger.get("r1"), reply);
+});

--- a/browser_tests/unit/command-dedupe.test.mjs
+++ b/browser_tests/unit/command-dedupe.test.mjs
@@ -110,3 +110,39 @@ test("settle is idempotent — a second settle cannot rewrite the recorded reply
   settle({ rid: "r1", ok: false, error: "bogus" });
   assert.equal(await ledger.get("r1"), reply);
 });
+
+test("an in-flight entry is NEVER evicted past cap — its replay is still deduped (#517 re-gate)", async () => {
+  const ledger = createCommandDedupeLedger(200);
+  let applied = 0;
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  const deliver = makeDispatch(ledger, async (msg) => {
+    if (msg.rid === "r-first") await gate; // the first command stays in flight
+    return { added: { id: ++applied } };
+  });
+
+  const first = deliver({ rid: "r-first", cmd: "graph_add_node" }); // in-flight
+  // 200 more commands complete while the first is still applying → 201 entries,
+  // over cap. Eviction must skip the in-flight first entry, not drop it.
+  for (let i = 1; i <= 200; i += 1) {
+    await deliver({ rid: `r${i}`, cmd: "graph_add_node" });
+  }
+  const replayP = deliver({ rid: "r-first", cmd: "graph_add_node" });
+  release();
+  const [orig, replay] = await Promise.all([first, replayP]);
+  assert.equal(replay.executed, false, "the 201st command did not evict the in-flight first");
+  assert.equal(applied, 201, "the replay added nothing — executor count stays at one per rid");
+  assert.equal(replay.reply, orig.reply);
+});
+
+test("settled entries still evict oldest-first while an in-flight one is kept", async () => {
+  const ledger = createCommandDedupeLedger(3);
+  const deliver = makeDispatch(ledger, async () => ({ ok: true }));
+  const settleLive = ledger.begin("r-live"); // stays in flight
+  for (const rid of ["r1", "r2", "r3"]) await deliver({ rid, cmd: "graph_add_node" });
+  // 4 entries > cap 3 → the oldest SETTLED (r1) evicts; in-flight r-live survives.
+  assert.notEqual(ledger.get("r-live"), undefined, "in-flight entry is kept past cap");
+  assert.equal(ledger.get("r1"), undefined, "oldest settled entry still evicts — memory stays bounded");
+  assert.notEqual(ledger.get("r3"), undefined, "newer settled entries are still remembered");
+  settleLive({ rid: "r-live", ok: true, result: {} });
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -205,7 +205,7 @@ import {
   activeStaleHint,
 } from "./lib/reconnect-staleness.js";
 import { pickRevertSnapshot } from "./lib/graph-revert.js";
-import { createCommandDedupeLedger } from "./lib/command-dedupe.js";
+import { commandFingerprint, createCommandDedupeLedger } from "./lib/command-dedupe.js";
 import { decideOpenStaleness } from "./lib/workflow-open-staleness.js";
 import {
   OPEN_DISK_READ_BUDGET_MS,
@@ -10075,10 +10075,14 @@ function redactBridgeUrl(u) {
 // rid (a replay after reconnect, or an orchestrator retry that reuses the
 // request id) is answered with the ORIGINAL reply instead of being executed
 // again — a re-applied graph_add_node / graph_remove_node is how a timed-out
-// mutation plus its retry lands twice (duplicate / orphan nodes). Module-scoped
-// so the ledger survives a socket supersede: the replay can arrive on the
-// REPLACEMENT socket while the first execution was still in flight on the old.
-const commandRidLedger = createCommandDedupeLedger();
+// mutation plus its retry lands twice (duplicate / orphan nodes). Dedupe keys
+// on rid + PAYLOAD FINGERPRINT: the bridge's re-dispatch of the SAME logical
+// command reproduces the frame exactly, while a rid reused for DIFFERENT work
+// (anomalous — logged once via onRidReuse) executes fresh instead of receiving
+// the old reply. Module-scoped so the ledger survives a socket supersede: the
+// replay can arrive on the REPLACEMENT socket while the first execution was
+// still in flight on the old.
+const commandRidLedger = createCommandDedupeLedger(200, (m) => console.warn(m));
 
 function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCommandReceived, onAsk, onSecret, onSecretSaved, onReload, onTodo, onShowMedia, onOpenCivitai, onCivitaiCmd, onTrainingCmd, onUiRender, onUiUpdate, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onBackends, onAck, onTurn, onAction, onTurnAnchor, getResume, getBackend, onHandshakeTimeout, onBridgeClosed, onPairUrl, onPairError, onRunpodStatus, onComfyuiTarget, onRunpodAlert }) {
   let sock = null;
@@ -10484,12 +10488,15 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             err?.message ?? err,
           );
         }
-        // #517 — refuse to APPLY the same rid twice. A duplicate delivery of an
-        // already-seen command frame is answered with the ORIGINAL reply
-        // (awaited first if the first execution is still in flight) on THIS
-        // socket — no second executor run, no second activity card — so a
-        // replayed mutation can never double-apply.
-        const priorRidReply = commandRidLedger.get(msg.rid);
+        // #517 — refuse to APPLY the same command twice. Dedupe keys on rid +
+        // payload fingerprint: the bridge's re-dispatch of the SAME logical
+        // command reproduces the frame exactly, so a duplicate delivery is
+        // answered with the ORIGINAL reply (awaited first if the first
+        // execution is still in flight) on THIS socket — no second executor
+        // run, no second activity card — while a rid reused for DIFFERENT work
+        // falls through and executes fresh (logged once by the ledger).
+        const fingerprint = commandFingerprint(msg);
+        const priorRidReply = commandRidLedger.get(msg.rid, fingerprint);
         if (priorRidReply !== undefined) {
           let dupReply;
           try {
@@ -10505,7 +10512,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           }
           return;
         }
-        const settleRid = commandRidLedger.begin(msg.rid);
+        const settleRid = commandRidLedger.begin(msg.rid, fingerprint);
         let reply;
         try {
           let result;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -205,6 +205,7 @@ import {
   activeStaleHint,
 } from "./lib/reconnect-staleness.js";
 import { pickRevertSnapshot } from "./lib/graph-revert.js";
+import { createCommandDedupeLedger } from "./lib/command-dedupe.js";
 import { decideOpenStaleness } from "./lib/workflow-open-staleness.js";
 import {
   OPEN_DISK_READ_BUDGET_MS,
@@ -10069,6 +10070,16 @@ function redactBridgeUrl(u) {
   }
 }
 
+// #517 — rid dedupe ledger for inbound agent commands. The bridge correlates
+// every command frame by `rid`, so a frame re-delivered with an ALREADY-SEEN
+// rid (a replay after reconnect, or an orchestrator retry that reuses the
+// request id) is answered with the ORIGINAL reply instead of being executed
+// again — a re-applied graph_add_node / graph_remove_node is how a timed-out
+// mutation plus its retry lands twice (duplicate / orphan nodes). Module-scoped
+// so the ledger survives a socket supersede: the replay can arrive on the
+// REPLACEMENT socket while the first execution was still in flight on the old.
+const commandRidLedger = createCommandDedupeLedger();
+
 function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCommandReceived, onAsk, onSecret, onSecretSaved, onReload, onTodo, onShowMedia, onOpenCivitai, onCivitaiCmd, onTrainingCmd, onUiRender, onUiUpdate, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onBackends, onAck, onTurn, onAction, onTurnAnchor, getResume, getBackend, onHandshakeTimeout, onBridgeClosed, onPairUrl, onPairError, onRunpodStatus, onComfyuiTarget, onRunpodAlert }) {
   let sock = null;
   let url = loadBridgeUrl();
@@ -10473,6 +10484,28 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             err?.message ?? err,
           );
         }
+        // #517 — refuse to APPLY the same rid twice. A duplicate delivery of an
+        // already-seen command frame is answered with the ORIGINAL reply
+        // (awaited first if the first execution is still in flight) on THIS
+        // socket — no second executor run, no second activity card — so a
+        // replayed mutation can never double-apply.
+        const priorRidReply = commandRidLedger.get(msg.rid);
+        if (priorRidReply !== undefined) {
+          let dupReply;
+          try {
+            dupReply = await priorRidReply;
+          } catch {
+            return; // ledger promises never reject — defensive only
+          }
+          if (!isActive()) return; // superseded socket — ignore its late frames
+          try {
+            if (thisSock.readyState === WebSocket.OPEN) thisSock.send(JSON.stringify(dupReply));
+          } catch {
+            // Socket died between receive and reply — agent side times out.
+          }
+          return;
+        }
+        const settleRid = commandRidLedger.begin(msg.rid);
         let reply;
         try {
           let result;
@@ -10694,6 +10727,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             error: coerceMessageText(err?.message ?? err),
           };
         }
+        // Settle the rid ledger BEFORE the dead-socket drop below (#517): even
+        // when this reply can no longer be delivered on THIS socket, a replay of
+        // the same rid on a fresh socket learns the true outcome instead of
+        // re-executing the command.
+        settleRid(reply);
         // A command executor can be ASYNC (ask_user/request_secret block on the user;
         // graph run/save await). If a soft-reload/restart swapped this socket out while
         // we were suspended, this reply belongs to the DEAD session A — it must NOT be

--- a/web/js/lib/command-dedupe.js
+++ b/web/js/lib/command-dedupe.js
@@ -2,16 +2,26 @@
 //
 // The bridge correlates every command frame by `rid`. A mutation that times out
 // bridge-side may STILL apply here, and when the apparently-failed command is
-// retried under the SAME request id (a replayed frame after a reconnect, or an
-// orchestrator that reuses the rid on re-dispatch) the panel must not execute it
-// a second time — a re-applied graph_add_node / graph_remove_node is how a
-// timed-out mutation plus its retry lands twice (duplicate / orphan nodes).
+// retried under the SAME request id (a replayed frame after a reconnect, or the
+// orchestrator deliberately re-dispatching the SAME logical command under its
+// original rid after a timeout) the panel must not execute it a second time —
+// a re-applied graph_add_node / graph_remove_node is how a timed-out mutation
+// plus its retry lands twice (duplicate / orphan nodes).
 //
 // This ledger makes every rid-correlated command IDEMPOTENT at the point of
 // application: the FIRST delivery of a rid executes and its reply is recorded;
 // any later delivery of the same rid is answered with that ORIGINAL reply —
 // awaited first if the first execution is still in flight — and never runs the
 // executor again (so no second mutation and no duplicate activity card).
+//
+// The dedupe identity is rid + PAYLOAD FINGERPRINT (commandFingerprint below:
+// the frame minus `rid`, canonical-stringified). The bridge's re-dispatch of
+// the SAME logical command reproduces the frame exactly, so it dedupes — but a
+// rid arriving with a MISMATCHED fingerprint is NOT the same command (a
+// genuinely new command that happens to reuse a prior rid: re-targeted or
+// replaced socket, different workflow). It is never answered from the ledger:
+// it executes fresh, and the reuse is logged once via onRidReuse (the bridge
+// should only ever re-dispatch the SAME command under a reused rid).
 //
 // Bounded: oldest-first eviction of SETTLED entries keeps a long session from
 // growing it without limit. An IN-FLIGHT entry is NEVER evicted — dropping an
@@ -23,41 +33,82 @@
 //
 // Dependency-free (no LiteGraph, no DOM). Unit-testable with plain fixtures.
 
+/** Recursively key-sorted JSON so equality is independent of key insertion order. */
+function stableStringify(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const keys = Object.keys(value).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(value[k])}`).join(",")}}`;
+}
+
 /**
- * @param {number} cap  max remembered SETTLED rids (oldest evicted first)
- * @returns {{
- *   get(rid: string): object | Promise<object> | undefined,
- *   begin(rid: string): (reply: object) => void,
- * }} get() returns undefined for a fresh rid, the settled reply object once the
- *    command completed, or a promise of it while the first execution is still
- *    in flight. begin() records a fresh rid as in-flight and returns its
- *    settle(reply) function.
+ * Fingerprint of a command frame's IDENTITY: every field except the transport
+ * `rid` (cmd + all args + the bridge-stamped workflow_uuid), canonicalized so
+ * key insertion order doesn't matter. The bridge's re-dispatch of the SAME
+ * logical command yields an identical fingerprint; any genuinely different
+ * command — even one differing only in workflow_uuid — differs here too.
  */
-export function createCommandDedupeLedger(cap = 200) {
-  // rid → { inflight: true, promise } | { inflight: false, reply }. Map preserves
-  // insertion order, so the oldest rid is always the first key.
+export function commandFingerprint(msg) {
+  const identity = { ...msg };
+  delete identity.rid; // transport correlation only — NOT part of command identity
+  return stableStringify(identity);
+}
+
+/**
+ * @param {number} cap  max remembered SETTLED entries (oldest evicted first)
+ * @param {(message: string) => void} [onRidReuse]  called once when a rid
+ *    arrives under a DIFFERENT fingerprint than a remembered entry — i.e. the
+ *    bridge reused a request id for different work (anomalous; worth a log).
+ * @returns {{
+ *   get(rid: string, fingerprint: string): object | Promise<object> | undefined,
+ *   begin(rid: string, fingerprint: string): (reply: object) => void,
+ * }} get() returns undefined for a fresh rid+fingerprint, the settled reply
+ *    object once the command completed, or a promise of it while the first
+ *    execution is still in flight. begin() records a fresh rid+fingerprint as
+ *    in-flight and returns its settle(reply) function.
+ */
+export function createCommandDedupeLedger(cap = 200, onRidReuse) {
+  // `${rid}\n${fingerprint}` → { rid, inflight: true, promise } in-flight |
+  // { rid, inflight: false, reply } settled. Map preserves insertion order, so
+  // the oldest entry is always the first key. (The \n separator is safe: rids
+  // are UUIDs and canonical JSON never contains a raw newline.)
   const entries = new Map();
 
   return {
-    get(rid) {
-      const entry = entries.get(rid);
+    get(rid, fingerprint) {
+      const key = `${rid}\n${fingerprint}`;
+      const entry = entries.get(key);
       if (entry === undefined) return undefined;
-      // LRU touch: a replayed rid is by definition still relevant — keep it
+      // LRU touch: a replayed entry is by definition still relevant — keep it
       // from ageing out while the bridge may still re-deliver it.
-      entries.delete(rid);
-      entries.set(rid, entry);
+      entries.delete(key);
+      entries.set(key, entry);
       return entry.inflight ? entry.promise : entry.reply;
     },
-    begin(rid) {
+    begin(rid, fingerprint) {
+      // begin() only runs after get() missed, so any same-rid entry exists
+      // under a DIFFERENT fingerprint — the bridge reused a request id for
+      // different work. Warn ONCE: this new entry dedupes its own replays, so
+      // a retry of THIS command can't re-fire the warning.
+      for (const e of entries.values()) {
+        if (e.rid === rid) {
+          onRidReuse?.(
+            `[comfyui-mcp-panel] bridge rid "${rid}" reused for a DIFFERENT command payload — ` +
+              `treating it as a new command (the original reply stays bound to its own payload)`,
+          );
+          break;
+        }
+      }
+      const key = `${rid}\n${fingerprint}`;
       let settle;
-      entries.set(rid, { inflight: true, promise: new Promise((resolve) => { settle = resolve; }) });
+      entries.set(key, { rid, inflight: true, promise: new Promise((resolve) => { settle = resolve; }) });
       // Evict oldest-first while over cap, but NEVER an in-flight entry (see
       // header): with every entry in flight this grows the ledger past cap
       // instead of evicting, which is the safe direction.
-      for (const [key, entry] of entries) {
+      for (const [k, entry] of entries) {
         if (entries.size <= cap) break;
         if (entry.inflight) continue;
-        entries.delete(key);
+        entries.delete(k);
       }
       let settled = false;
       return (reply) => {
@@ -67,7 +118,7 @@ export function createCommandDedupeLedger(cap = 200) {
         // Collapse to the settled reply itself so later replays read it
         // synchronously (and `await` on either form is the same). The entry is
         // provably still present — in-flight entries are never evicted.
-        const entry = entries.get(rid);
+        const entry = entries.get(key);
         if (entry !== undefined) {
           entry.inflight = false;
           entry.reply = reply;

--- a/web/js/lib/command-dedupe.js
+++ b/web/js/lib/command-dedupe.js
@@ -13,14 +13,18 @@
 // awaited first if the first execution is still in flight — and never runs the
 // executor again (so no second mutation and no duplicate activity card).
 //
-// Bounded (oldest-first eviction) so a long session can't grow it without
-// limit. Eviction fails OPEN: a replay older than the cap re-executes, which is
-// exactly today's pre-ledger behaviour — never a new failure mode.
+// Bounded: oldest-first eviction of SETTLED entries keeps a long session from
+// growing it without limit. An IN-FLIGHT entry is NEVER evicted — dropping an
+// unsettled command would let its replay re-execute and double-apply a mutation
+// — so past `cap` CONCURRENT in-flight commands the ledger simply grows (bounded
+// by real concurrency, which is tiny); the settled cap still applies. Settled
+// eviction fails OPEN: a replay older than the cap re-executes, which is exactly
+// the pre-ledger behaviour — never a new failure mode.
 //
 // Dependency-free (no LiteGraph, no DOM). Unit-testable with plain fixtures.
 
 /**
- * @param {number} cap  max remembered rids (oldest evicted first)
+ * @param {number} cap  max remembered SETTLED rids (oldest evicted first)
  * @returns {{
  *   get(rid: string): object | Promise<object> | undefined,
  *   begin(rid: string): (reply: object) => void,
@@ -30,32 +34,45 @@
  *    settle(reply) function.
  */
 export function createCommandDedupeLedger(cap = 200) {
-  // rid → settled reply object | in-flight promise of the reply. Map preserves
+  // rid → { inflight: true, promise } | { inflight: false, reply }. Map preserves
   // insertion order, so the oldest rid is always the first key.
   const entries = new Map();
 
   return {
     get(rid) {
-      if (!entries.has(rid)) return undefined;
-      const value = entries.get(rid);
+      const entry = entries.get(rid);
+      if (entry === undefined) return undefined;
       // LRU touch: a replayed rid is by definition still relevant — keep it
       // from ageing out while the bridge may still re-deliver it.
       entries.delete(rid);
-      entries.set(rid, value);
-      return value;
+      entries.set(rid, entry);
+      return entry.inflight ? entry.promise : entry.reply;
     },
     begin(rid) {
       let settle;
-      entries.set(rid, new Promise((resolve) => { settle = resolve; }));
-      while (entries.size > cap) entries.delete(entries.keys().next().value);
+      entries.set(rid, { inflight: true, promise: new Promise((resolve) => { settle = resolve; }) });
+      // Evict oldest-first while over cap, but NEVER an in-flight entry (see
+      // header): with every entry in flight this grows the ledger past cap
+      // instead of evicting, which is the safe direction.
+      for (const [key, entry] of entries) {
+        if (entries.size <= cap) break;
+        if (entry.inflight) continue;
+        entries.delete(key);
+      }
       let settled = false;
       return (reply) => {
         if (settled) return; // settle exactly once — later calls can't rewrite history
         settled = true;
         settle(reply);
-        // Collapse the in-flight promise to the settled reply itself so later
-        // replays read it synchronously (and `await` on either form is the same).
-        if (entries.get(rid) !== undefined) entries.set(rid, reply);
+        // Collapse to the settled reply itself so later replays read it
+        // synchronously (and `await` on either form is the same). The entry is
+        // provably still present — in-flight entries are never evicted.
+        const entry = entries.get(rid);
+        if (entry !== undefined) {
+          entry.inflight = false;
+          entry.reply = reply;
+          delete entry.promise;
+        }
       };
     },
   };

--- a/web/js/lib/command-dedupe.js
+++ b/web/js/lib/command-dedupe.js
@@ -1,0 +1,62 @@
+// Rid dedupe ledger for inbound agent commands (#517).
+//
+// The bridge correlates every command frame by `rid`. A mutation that times out
+// bridge-side may STILL apply here, and when the apparently-failed command is
+// retried under the SAME request id (a replayed frame after a reconnect, or an
+// orchestrator that reuses the rid on re-dispatch) the panel must not execute it
+// a second time — a re-applied graph_add_node / graph_remove_node is how a
+// timed-out mutation plus its retry lands twice (duplicate / orphan nodes).
+//
+// This ledger makes every rid-correlated command IDEMPOTENT at the point of
+// application: the FIRST delivery of a rid executes and its reply is recorded;
+// any later delivery of the same rid is answered with that ORIGINAL reply —
+// awaited first if the first execution is still in flight — and never runs the
+// executor again (so no second mutation and no duplicate activity card).
+//
+// Bounded (oldest-first eviction) so a long session can't grow it without
+// limit. Eviction fails OPEN: a replay older than the cap re-executes, which is
+// exactly today's pre-ledger behaviour — never a new failure mode.
+//
+// Dependency-free (no LiteGraph, no DOM). Unit-testable with plain fixtures.
+
+/**
+ * @param {number} cap  max remembered rids (oldest evicted first)
+ * @returns {{
+ *   get(rid: string): object | Promise<object> | undefined,
+ *   begin(rid: string): (reply: object) => void,
+ * }} get() returns undefined for a fresh rid, the settled reply object once the
+ *    command completed, or a promise of it while the first execution is still
+ *    in flight. begin() records a fresh rid as in-flight and returns its
+ *    settle(reply) function.
+ */
+export function createCommandDedupeLedger(cap = 200) {
+  // rid → settled reply object | in-flight promise of the reply. Map preserves
+  // insertion order, so the oldest rid is always the first key.
+  const entries = new Map();
+
+  return {
+    get(rid) {
+      if (!entries.has(rid)) return undefined;
+      const value = entries.get(rid);
+      // LRU touch: a replayed rid is by definition still relevant — keep it
+      // from ageing out while the bridge may still re-deliver it.
+      entries.delete(rid);
+      entries.set(rid, value);
+      return value;
+    },
+    begin(rid) {
+      let settle;
+      entries.set(rid, new Promise((resolve) => { settle = resolve; }));
+      while (entries.size > cap) entries.delete(entries.keys().next().value);
+      let settled = false;
+      return (reply) => {
+        if (settled) return; // settle exactly once — later calls can't rewrite history
+        settled = true;
+        settle(reply);
+        // Collapse the in-flight promise to the settled reply itself so later
+        // replays read it synchronously (and `await` on either form is the same).
+        if (entries.get(rid) !== undefined) entries.set(rid, reply);
+      };
+    },
+  };
+}

--- a/web/js/lib/command-dedupe.js
+++ b/web/js/lib/command-dedupe.js
@@ -23,13 +23,16 @@
 // it executes fresh, and the reuse is logged once via onRidReuse (the bridge
 // should only ever re-dispatch the SAME command under a reused rid).
 //
-// Bounded: oldest-first eviction of SETTLED entries keeps a long session from
-// growing it without limit. An IN-FLIGHT entry is NEVER evicted — dropping an
-// unsettled command would let its replay re-execute and double-apply a mutation
-// — so past `cap` CONCURRENT in-flight commands the ledger simply grows (bounded
-// by real concurrency, which is tiny); the settled cap still applies. Settled
-// eviction fails OPEN: a replay older than the cap re-executes, which is exactly
-// the pre-ledger behaviour — never a new failure mode.
+// Bounded: oldest-first eviction of SETTLED entries — swept on every begin AND
+// every settle (a past-cap burst of concurrent in-flight commands has nothing
+// evictable at begin; only a settle-time sweep re-applies the bound as those
+// entries complete) — keeps a long session from growing it without limit. An
+// IN-FLIGHT entry is NEVER evicted — dropping an unsettled command would let
+// its replay re-execute and double-apply a mutation — so past `cap` CONCURRENT
+// in-flight commands the ledger simply grows (bounded by real concurrency,
+// which is tiny); the settled cap still applies. Settled eviction fails OPEN: a
+// replay older than the cap re-executes, which is exactly the pre-ledger
+// behaviour — never a new failure mode.
 //
 // Dependency-free (no LiteGraph, no DOM). Unit-testable with plain fixtures.
 
@@ -55,7 +58,8 @@ export function commandFingerprint(msg) {
 }
 
 /**
- * @param {number} cap  max remembered SETTLED entries (oldest evicted first)
+ * @param {number} cap  max remembered SETTLED entries (oldest evicted first;
+ *    swept on begin and on settle)
  * @param {(message: string) => void} [onRidReuse]  called once when a rid
  *    arrives under a DIFFERENT fingerprint than a remembered entry — i.e. the
  *    bridge reused a request id for different work (anomalous; worth a log).
@@ -73,6 +77,19 @@ export function createCommandDedupeLedger(cap = 200, onRidReuse) {
   // the oldest entry is always the first key. (The \n separator is safe: rids
   // are UUIDs and canonical JSON never contains a raw newline.)
   const entries = new Map();
+
+  // Evict oldest-first while over cap, but NEVER an in-flight entry (see
+  // header): with every entry in flight this grows the ledger past cap
+  // instead of evicting, which is the safe direction. Called on begin AND on
+  // settle — a burst of >cap concurrent in-flight commands is only trimmable
+  // once its entries start settling.
+  const evictSettled = () => {
+    for (const [k, entry] of entries) {
+      if (entries.size <= cap) break;
+      if (entry.inflight) continue;
+      entries.delete(k);
+    }
+  };
 
   return {
     get(rid, fingerprint) {
@@ -102,14 +119,7 @@ export function createCommandDedupeLedger(cap = 200, onRidReuse) {
       const key = `${rid}\n${fingerprint}`;
       let settle;
       entries.set(key, { rid, inflight: true, promise: new Promise((resolve) => { settle = resolve; }) });
-      // Evict oldest-first while over cap, but NEVER an in-flight entry (see
-      // header): with every entry in flight this grows the ledger past cap
-      // instead of evicting, which is the safe direction.
-      for (const [k, entry] of entries) {
-        if (entries.size <= cap) break;
-        if (entry.inflight) continue;
-        entries.delete(k);
-      }
+      evictSettled();
       let settled = false;
       return (reply) => {
         if (settled) return; // settle exactly once — later calls can't rewrite history
@@ -124,6 +134,9 @@ export function createCommandDedupeLedger(cap = 200, onRidReuse) {
           entry.reply = reply;
           delete entry.promise;
         }
+        // A past-cap burst of concurrent in-flight commands grows the ledger
+        // (nothing evictable at begin) — re-apply the bound as entries settle.
+        evictSettled();
       };
     },
   };


### PR DESCRIPTION
## Problem (#517)

A panel graph mutation (`graph_add_node`, `graph_remove_node`, …) that timed out bridge-side ("Panel tab … did not reply within 6000 ms") can still apply panel-side. When the apparently-failed command is then re-delivered under the **same** request id — a replayed frame after a reconnect, or an orchestrator retry that reuses the rid — the panel executed it **again**. The timed-out apply plus the retry both landed, producing duplicate/orphaned nodes (in the report, inside a native subgraph); the cleanup `graph_remove_node` then timed out too, leaving its applied state ambiguous.

## Fix shape

Shape **(a)** from the issue: mutations carry a rid and the panel refuses to apply the same rid twice. The panel-side half of the request-ID/idempotency fix the issue asks for.

A bounded **rid dedupe ledger** (`web/js/lib/command-dedupe.js`) makes every rid-correlated command idempotent at the point of application:

- **First delivery** of a rid executes and records its reply.
- **Any later delivery of the same rid** is answered with the ORIGINAL reply — awaited first if the first execution is still in flight (the exact slow-tab window from the report) — with **no second executor run and no second activity card**, so a replayed mutation can never double-apply.
- The ledger is **module-scoped** so it survives a socket supersede (the replay can arrive on the replacement socket), and it **settles before the dead-socket reply drop**, so a replay on a fresh socket learns the true outcome instead of re-executing.
- **Bounded, fail-open**: oldest-first eviction; a replay older than the cap simply re-executes — the pre-ledger behaviour, never a new failure mode. Failed commands dedupe the same way (the original error reply is re-sent, not re-attempted).

This matches the orchestrator-side prior art in the ui-bridge (idempotent-read resume re-dispatches the same command rather than erroring); it extends that idempotency to the point of application for *all* commands, reads included.

### Why not shape (b) here

"Applied after timeout" truthful reporting is bridge-side: the panel never learns that the orchestrator's 6 s reply timer fired, so it cannot mark anything. The ui-bridge already tags that case with typed `reply-timeout`/`dispatched:true` markers (comfyui-mcp #509); reconciling late completions of timed-out rids (and reusing rids on mutation re-dispatch, which this ledger then makes safe) belongs to the comfyui-mcp repo.

## Changes

- `web/js/lib/command-dedupe.js` (new): `createCommandDedupeLedger(cap)` — `get(rid)` returns the settled reply or the in-flight reply promise (LRU-touched); `begin(rid)` records in-flight and returns an idempotent `settle(reply)`.
- `web/js/comfyui-mcp-panel.js`: bridge message handler checks the ledger before executing (+38 lines incl. comments); duplicate rids short-circuit to re-sending the original reply on the live socket.
- `browser_tests/unit/command-dedupe.test.mjs` (new): 6 tests — the key one proves a duplicate-rid delivery is a no-op answered with the original reply (executor call count stays 1), plus in-flight dedupe, error-reply dedupe, distinct-rid independence, bounded fail-open eviction, and idempotent settle.

## Verification

- `npm run test:unit` — 1308/1308 pass (was 1302 before this change).
- `npm run typecheck` — clean.

Refs #517