### PR TITLE
fix(panel): authorize promoted subgraph containers via the resolved concrete inner target (#512)

### DIFF
--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -1599,3 +1599,100 @@ test("#496 REGRESSION: the PENDING sentinel still FAILS CLOSED — it never auth
   );
   assert.equal(node.widgets[0].value, "", "no write while the baseline is pending");
 });
+
+// ---- #512: assertMutatedNodeAuthorized authorizes a genuine UUID SubgraphNode through
+//      its RESOLVED, fresh-authorized concrete inner target
+//      (opts.promotionResolvedToAuthorizedConcrete) — because current ComfyUI_frontend
+//      stamps a synthesized def (nodeData + comfyClass) on every subgraph node's class
+//      BY DESIGN, so the provenance-clean check false-fires on the genuine container.
+//      The ever-seen gate and the container-shape check are NOT relaxed. -------------
+
+const SUBGRAPH_UUID = "2454ad83-157c-40dd-9f19-5daaf4041ce0";
+
+// A SubgraphNode as current ComfyUI_frontend builds it (registerSubgraphNodeDef): type
+// is the subgraph's UUID (never in /object_info); the registered class AND the
+// instance's own constructor carry the synthesized nodeDef (nodeData + comfyClass).
+function uuidSubgraphContainer(reg) {
+  const inner = { id: 301, type: "KSampler", widgets: [{ name: "value_4", type: "INT", value: 20 }] };
+  const node = {
+    id: 320,
+    type: SUBGRAPH_UUID,
+    widgets: [{ name: "value_4", type: "INT", value: 20 }],
+    subgraph: { _nodes: [inner], getNodeById: (id) => (String(id) === "301" ? inner : null) },
+    inputs: [{ name: "value_4", _subgraphSlot: { name: "value_4" } }],
+  };
+  const ctor = function ComfySubgraphNode() {};
+  ctor.nodeData = { input: { required: {} }, name: SUBGRAPH_UUID };
+  ctor.comfyClass = SUBGRAPH_UUID;
+  node.constructor = ctor;
+  reg[SUBGRAPH_UUID] = ctor;
+  return node;
+}
+const RESOLVED = { promotionResolvedToAuthorizedConcrete: true };
+
+test("#512: provenance-stamped UUID container + resolved-authorized promotion ⇒ authorized (the reported false refusal)", () => {
+  const reg = loadedRegistry();
+  const node = uuidSubgraphContainer(reg);
+  const fresh = objectInfo(); // the UUID is never in /object_info
+  assert.doesNotThrow(() =>
+    assertMutatedNodeAuthorized(fresh, reg, node, "outer subgraph", () => false, RESOLVED),
+  );
+});
+
+test("#512: the SAME container WITHOUT the resolved-promotion evidence ⇒ still refused (no general relaxation)", () => {
+  // A bare container whose class carries def markers but whose promotion was NOT
+  // positively resolved + authorized keeps the pre-#512 verdict — the flag is the only
+  // thing that changed, so this pins the exemption's scope.
+  const reg = loadedRegistry();
+  const node = uuidSubgraphContainer(reg);
+  const fresh = objectInfo();
+  assert.throws(
+    () => assertMutatedNodeAuthorized(fresh, reg, node, "outer subgraph", () => false),
+    /not a verifiable frontend-only \/ virtual-subgraph node/i,
+  );
+});
+
+test("#512: the exemption requires POSITIVE never-seen history — an UNWIRED oracle fails closed even with the flag", () => {
+  // "no-oracle" is NOT never-seen: without the observed-backend-history trust root
+  // there is no non-forgeable evidence the type was never backend-defined, so the
+  // resolved-promotion exemption must not engage (the panel always wires the oracle).
+  const reg = loadedRegistry();
+  const node = uuidSubgraphContainer(reg);
+  const fresh = objectInfo();
+  assert.throws(
+    () => assertMutatedNodeAuthorized(fresh, reg, node, "outer subgraph", undefined, RESOLVED),
+    /not a verifiable frontend-only \/ virtual-subgraph node/i,
+  );
+});
+
+test("#512: an EVER-SEEN (removed) container type is refused even with the flag — the trust root is not bypassed", () => {
+  const reg = loadedRegistry();
+  const node = uuidSubgraphContainer(reg);
+  const fresh = objectInfo(); // type ABSENT now…
+  assert.throws(
+    () =>
+      assertMutatedNodeAuthorized(fresh, reg, node, "outer subgraph", (t) => t === SUBGRAPH_UUID, RESOLVED), // …but seen EARLIER
+    /was defined by the ComfyUI backend earlier this session|since-removed/i,
+  );
+});
+
+test("#512: the flag does not authorize a provenance-bearing NON-container leaf", () => {
+  // The exemption is for virtual-subgraph CONTAINERS only: a leaf node whose class
+  // carries def markers and whose type is absent from /object_info is still refused.
+  const reg = loadedRegistry();
+  const ctor = function ComfyNode() {};
+  ctor.nodeData = { input: { required: {} } };
+  ctor.comfyClass = "SomeBackendishType";
+  reg["SomeBackendishType"] = ctor;
+  const leaf = {
+    id: 9,
+    type: "SomeBackendishType",
+    widgets: [{ name: "steps", type: "INT", value: 0 }],
+    constructor: ctor,
+  };
+  const fresh = objectInfo();
+  assert.throws(
+    () => assertMutatedNodeAuthorized(fresh, reg, leaf, "outer subgraph", () => false, RESOLVED),
+    /not a verifiable frontend-only \/ virtual-subgraph node/i,
+  );
+});

--- a/browser_tests/unit/set-widget-fresh-backend.test.mjs
+++ b/browser_tests/unit/set-widget-fresh-backend.test.mjs
@@ -1086,3 +1086,195 @@ test("#458 EVER-SEEN INTERMEDIATE: a genuine virtual container (type NEVER in ob
   assert.equal(set.value, 30);
   assert.equal(mid.widgets.find((w) => w.name === "steps").value, 30);
 });
+
+// ---- #512: outer UUID subgraph node whose class carries the frontend's SYNTHESIZED
+//      def markers. Current ComfyUI_frontend's registerSubgraphNodeDef stamps static
+//      nodeData + comfyClass on EVERY subgraph node's registered class (registered
+//      under the subgraph's UUID), so the #458 provenance heuristic false-fired on the
+//      genuine container and refused a CORRECT promoted write as an "unverifiable
+//      virtual-subgraph node". The container must instead be authorized through its
+//      RESOLVED, fresh-authorized concrete inner target — while a promotion that does
+//      NOT resolve (or an ever-seen/removed container type) must still fail closed. ----
+
+// The bundled ltx-2.3-img2vid repro: outer node 320, type is the subgraph's UUID.
+const SUBGRAPH_UUID = "2454ad83-157c-40dd-9f19-5daaf4041ce0";
+
+// A SubgraphNode shaped the way current ComfyUI_frontend actually builds one: the type
+// is the subgraph's UUID (never in /object_info), and BOTH the registered class and the
+// instance's own constructor carry the synthesized nodeDef (nodeData + comfyClass) that
+// registerSubgraphNodeDef stamps BY DESIGN. `innerType` flips the inner node between a
+// live and a removed backend type. Returns null resolveSource when `resolvable` is
+// false to model a stale/empty promoted link.
+function makeUuidSubgraphFixture(reg, innerType, { resolvable = true } = {}) {
+  const inner = {
+    id: 301,
+    type: innerType,
+    widgets: [{ name: "value_4", type: "INT", value: 20 }],
+    constructor: { nodeData: { input: { required: {} } } },
+  };
+  // #366: the AUTHORITATIVE parent rail projection — identity-linked from the host
+  // input (`_widget`) and a live member of parent.widgets.
+  const railWidget = { name: "value_4", type: "INT", value: 20 };
+  const parent = {
+    id: 320,
+    type: SUBGRAPH_UUID,
+    subgraph: { _nodes: [inner], getNodeById: (id) => (String(id) === "301" ? inner : null) },
+    inputs: [{ name: "value_4", _widget: railWidget, widget: { name: "value_4" }, _subgraphSlot: { name: "value_4" } }],
+    widgets: [railWidget],
+  };
+  // registerSubgraphNodeDef: the synthesized def is stamped on the class, which is
+  // registered under the subgraph's UUID — the "backend provenance" that false-fired.
+  const ctor = function ComfySubgraphNode() {};
+  ctor.nodeData = { input: { required: {} }, name: SUBGRAPH_UUID };
+  ctor.comfyClass = SUBGRAPH_UUID;
+  parent.constructor = ctor;
+  reg[SUBGRAPH_UUID] = ctor;
+  const resolveSource = (_n, si) =>
+    resolvable && si?.name === "value_4" ? { sourceNodeId: "301", sourceWidgetName: "value_4" } : null;
+  return { parent, inner, railWidget, resolveSource };
+}
+
+test("#512: promoted write on an outer UUID subgraph node (synthesized-def provenance) ⇒ SUCCEEDS via the resolved inner target", async () => {
+  // The exact reported repro: the guard refused this as "not a verifiable frontend-only
+  // / virtual-subgraph node" purely because the class carries the frontend-stamped def.
+  // The promotion resolves to a live, fresh-authorized inner node — the write is correct
+  // and must proceed, landing on the inner node + syncing the authoritative rail.
+  const reg = loadedRegistry();
+  const { parent, inner, railWidget, resolveSource } = makeUuidSubgraphFixture(reg, "KSampler");
+  const { set } = await runSetWidget(parent, "value_4", 42, {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: async () => objectInfo(), // KSampler present; the UUID never is
+    wasTypeEverDefined: () => false, // UUID subgraph types are never backend-defined
+    resolveSource,
+    ...HOOKS,
+  });
+  assert.equal(set.value, 42);
+  assert.equal(inner.widgets.find((w) => w.name === "value_4").value, 42, "write landed on the resolved inner node");
+  assert.equal(railWidget.value, 42, "#366: authoritative parent rail synced");
+});
+
+test("#512: promoted write on a UUID subgraph node whose inner type is REMOVED ⇒ still FAIL CLOSED", async () => {
+  // The relaxation authorizes the CONTAINER through the resolved inner target — it says
+  // nothing about the target itself. A removed inner type is still refused by the fresh
+  // oracle, exactly as before.
+  const reg = loadedRegistry(["GoneNode"]);
+  const { parent, inner, railWidget, resolveSource } = makeUuidSubgraphFixture(reg, "GoneNode");
+  await assert.rejects(
+    () =>
+      runSetWidget(parent, "value_4", 42, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => objectInfo(), // backend no longer provides GoneNode
+        wasTypeEverDefined: () => false,
+        resolveSource,
+        ...HOOKS,
+      }),
+    (err) =>
+      err instanceof Error &&
+      /Cannot set widget on node 301 \("GoneNode"\)/.test(err.message) &&
+      /backend does not provide/i.test(err.message),
+  );
+  assert.equal(inner.widgets.find((w) => w.name === "value_4").value, 20, "inner untouched");
+  assert.equal(railWidget.value, 20, "rail untouched");
+});
+
+test("#512: UNRESOLVABLE promotion on a UUID subgraph node ⇒ still REFUSED (no concrete target, no write)", async () => {
+  // The exemption is scoped to a POSITIVELY-resolved, concrete-authorized promotion. A
+  // promoted widget whose inner link is stale/empty never earns it — fail closed.
+  const reg = loadedRegistry();
+  const { parent, inner, railWidget, resolveSource } = makeUuidSubgraphFixture(reg, "KSampler", { resolvable: false });
+  await assert.rejects(
+    () =>
+      runSetWidget(parent, "value_4", 42, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => objectInfo(),
+        wasTypeEverDefined: () => false,
+        resolveSource, // stale/empty linkIds — the promotion cannot be resolved
+        ...HOOKS,
+      }),
+    (err) => err instanceof Error && /refused.*no resolvable inner link|no resolvable inner link/i.test(err.message),
+  );
+  assert.equal(inner.widgets.find((w) => w.name === "value_4").value, 20, "inner untouched");
+  assert.equal(railWidget.value, 20, "rail untouched");
+});
+
+test("#512: the EVER-SEEN gate still REFUSES a container type the backend reported earlier (the flag never bypasses the trust root)", async () => {
+  // If the backend DID report this type earlier this session and it is now absent, the
+  // node is a removed backend node masquerading as a subgraph container — refused before
+  // the resolved-promotion exemption is ever consulted (#458 stays closed).
+  const reg = loadedRegistry();
+  const { parent, inner, railWidget, resolveSource } = makeUuidSubgraphFixture(reg, "KSampler");
+  await assert.rejects(
+    () =>
+      runSetWidget(parent, "value_4", 42, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => objectInfo(), // the type is ABSENT now…
+        wasTypeEverDefined: (t) => t === SUBGRAPH_UUID, // …but was reported EARLIER this session
+        resolveSource,
+        ...HOOKS,
+      }),
+    (err) =>
+      err instanceof Error &&
+      /Cannot set widget on node 320/.test(err.message) &&
+      /was defined by the ComfyUI backend earlier this session|since-removed/i.test(err.message),
+  );
+  assert.equal(inner.widgets.find((w) => w.name === "value_4").value, 20, "inner untouched");
+  assert.equal(railWidget.value, 20, "rail untouched");
+});
+
+test("#512: NESTED promotion through a provenance-stamped UUID intermediate ⇒ SUCCEEDS (every driven-through container authorized via the chain)", async () => {
+  // On current frontends EVERY subgraph node in the chain carries the synthesized def,
+  // not just the outer one — a nested A→B→KSampler promotion must authorize the
+  // intermediate B through the same resolved-chain evidence or it false-refuses too.
+  const reg = loadedRegistry();
+  const INNER_UUID = "bbbbbbbb-1111-4222-8333-cccccccccccc";
+  const concrete = {
+    id: 90,
+    type: "KSampler",
+    widgets: [{ name: "steps", type: "INT", value: 20 }],
+    constructor: { nodeData: { input: { required: {} } } },
+  };
+  const stamp = (node, uuid) => {
+    const ctor = function ComfySubgraphNode() {};
+    ctor.nodeData = { input: { required: {} }, name: uuid };
+    ctor.comfyClass = uuid;
+    node.constructor = ctor;
+    reg[uuid] = ctor;
+  };
+  const b = {
+    id: 80,
+    type: INNER_UUID,
+    widgets: [{ name: "steps", type: "INT", value: 20 }],
+    subgraph: { _nodes: [concrete], getNodeById: (id) => (String(id) === "90" ? concrete : null) },
+    inputs: [{ name: "steps", _subgraphSlot: { name: "steps" } }],
+  };
+  stamp(b, INNER_UUID);
+  const aRail = { name: "steps", type: "INT", value: 20 };
+  const a = {
+    id: 70,
+    type: SUBGRAPH_UUID,
+    widgets: [aRail],
+    subgraph: { _nodes: [b], getNodeById: (id) => (String(id) === "80" ? b : null) },
+    inputs: [{ name: "steps", _widget: aRail, widget: { name: "steps" }, _subgraphSlot: { name: "steps" } }],
+  };
+  stamp(a, SUBGRAPH_UUID);
+  const resolveSource = (subgraphNode, si) => {
+    if (subgraphNode === a && si?.name === "steps") return { sourceNodeId: "80", sourceWidgetName: "steps" };
+    if (subgraphNode === b && si?.name === "steps") return { sourceNodeId: "90", sourceWidgetName: "steps" };
+    return null;
+  };
+  const { set } = await runSetWidget(a, "steps", 30, {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: async () => objectInfo(), // KSampler present; both UUIDs absent
+    wasTypeEverDefined: () => false,
+    resolveSource,
+    ...HOOKS,
+  });
+  assert.equal(set.value, 30, "nested promoted write authorized via the resolved concrete chain");
+  assert.equal(b.widgets.find((w) => w.name === "steps").value, 30, "the intermediate forwarded the write");
+  assert.equal(aRail.value, 30, "#366: authoritative outer rail synced");
+});

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -286,8 +286,22 @@ export function isVirtualSubgraphContainer(node) {
  * name / provenance markers cannot. The provenance + container-shape checks remain as
  * DEFENSE-IN-DEPTH for the never-seen case, never as the sole gate. A null/unavailable
  * fresh map fails closed.
+ *
+ * `opts.promotionResolvedToAuthorizedConcrete` (#512): set by the set_widget caller ONLY
+ * when this exact node's promoted widget was POSITIVELY resolved through the subgraph
+ * promotion mapping to a concrete inner node whose type the caller has ALREADY
+ * fresh-authorized (and whose instance passed the stale-placeholder check) — i.e. the
+ * verifiable oracle is the RESOLVED INNER TARGET, not the container's own markers. This
+ * matters because current ComfyUI_frontend STAMPS a synthesized def (static nodeData +
+ * comfyClass) on every subgraph node's registered class (registerSubgraphNodeDef), so a
+ * genuine outer UUID SubgraphNode carries "backend provenance" BY DESIGN and the
+ * provenance-clean check below false-fires on it, refusing a correct promoted write as
+ * an "unverifiable virtual-subgraph node". The flag relaxes ONLY the provenance signal
+ * for a container on POSITIVE never-seen history evidence — the ever-seen gate above
+ * still refuses a mid-session-removed type first, and an unwired/unseeded/pending
+ * oracle never reaches this branch.
  */
-export function assertMutatedNodeAuthorized(freshDefs, registry, node, role = "target", wasTypeEverDefined) {
+export function assertMutatedNodeAuthorized(freshDefs, registry, node, role = "target", wasTypeEverDefined, opts = {}) {
   const type = node?.type;
   const id = node?.id ?? "(unknown)";
   const label = typeof type === "string" ? ` ("${type}")` : "";
@@ -322,6 +336,18 @@ export function assertMutatedNodeAuthorized(freshDefs, registry, node, role = "t
     !hasBackendProvenance(typeof type === "string" ? registry?.[type] : undefined) &&
     !hasBackendProvenance(node?.constructor);
   if (provenanceClean && isVirtualSubgraphContainer(node)) return;
+  // #512: a genuine UUID SubgraphNode whose class carries the frontend's SYNTHESIZED
+  // def markers (so provenanceClean is false BY DESIGN, see the docblock) is authorized
+  // through its RESOLVED, already-fresh-authorized concrete inner target instead — but
+  // only on POSITIVE never-seen history evidence. An unwired oracle ("no-oracle") fails
+  // closed here exactly as before, and a "removed"/pending/unseeded verdict threw above.
+  if (
+    verdict === "never-seen" &&
+    opts?.promotionResolvedToAuthorizedConcrete === true &&
+    isVirtualSubgraphContainer(node)
+  ) {
+    return;
+  }
   // SHARED frontend-only predicate (#496) — the identical decision assertTypeAgainstFreshBackend
   // and assertAddNodeResolvableRefreshing make, so the family cannot drift apart again.
   if (isAuthorizedFrontendOnlyType(registry, type, node)) return;

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -204,9 +204,21 @@ export async function runSetWidget(
   // mutated node: absent from fresh /object_info is permitted ONLY as a provenance-clean
   // virtual-subgraph container (or frontend-only leaf), never a removed/stale backend
   // node masquerading with a subgraph field.
+  //
+  // #512: every call below passes promotionResolvedToAuthorizedConcrete — an HONEST
+  // statement by control flow, never a guess: reaching this point means the promotion
+  // was positively resolved (isResolvedPromotion) AND followPromotionToConcrete reached
+  // a concrete backend node whose type assertTypeAgainstFreshBackend already authorized
+  // (both throw above otherwise). A genuine UUID SubgraphNode whose class carries the
+  // frontend's synthesized def markers (nodeData/comfyClass, stamped by design) is
+  // therefore authorized through that verified inner target instead of the
+  // provenance heuristic, which no longer discriminates containers; the ever-seen gate
+  // inside the guard still refuses a mid-session-removed container type first.
   if (isResolvedPromotion) {
     // The OUTER subgraph parent (its rail/proxy widgets are mutated).
-    assertMutatedNodeAuthorized(freshDefs, liveRegistry(), node, "outer subgraph", wasTypeEverDefined);
+    assertMutatedNodeAuthorized(freshDefs, liveRegistry(), node, "outer subgraph", wasTypeEverDefined, {
+      promotionResolvedToAuthorizedConcrete: true,
+    });
     // EVERY intermediate virtual container the promotion is driven THROUGH — not just
     // the immediate inner. A deeper intermediate (A→B→C→concrete's C) is otherwise
     // never authorized, so a removed-backend node forwarded-through would be trusted.
@@ -214,7 +226,9 @@ export async function runSetWidget(
     // provenance-clean virtual container; a since-removed (ever-seen) type is refused.
     for (const intermediate of collectPromotionIntermediates(promotedResolution.target, resolveSource)) {
       if (intermediate !== authTarget) {
-        assertMutatedNodeAuthorized(freshDefs, liveRegistry(), intermediate, "intermediate promoted", wasTypeEverDefined);
+        assertMutatedNodeAuthorized(freshDefs, liveRegistry(), intermediate, "intermediate promoted", wasTypeEverDefined, {
+          promotionResolvedToAuthorizedConcrete: true,
+        });
       }
     }
   }


### PR DESCRIPTION
Refs #512.

## Problem

`panel_set_widget` refused promoted widgets on outer UUID subgraph nodes as an "unverifiable virtual-subgraph node" (#458 guard), though the write is demonstrably correct — e.g. bundled `ltx-2.3-img2vid` outer node **320** (`2454ad83-…`), promoted `value_4`/`value`/`value_2`, where the write lands on the inner node and returns `parent_widget_synced: true`.

## Root cause

The refusal came from `assertMutatedNodeAuthorized`'s never-seen branch, which requires a **provenance-clean** virtual-subgraph container. Current ComfyUI_frontend's `registerSubgraphNodeDef` (src/services/litegraphService.ts) stamps a **synthesized def** — static `nodeData` + `comfyClass` — on *every* subgraph node's registered class (registered under the subgraph's UUID, loaded from the workflow JSON). So a genuine `SubgraphNode` carries "backend provenance" **by design**, the provenance heuristic no longer discriminates containers, and the guard failed closed on a legitimate mutation. (The container-shape check was fine: upstream `SubgraphNode` has `isVirtualNode === true` / `isSubgraphNode()`.)

## Fix (per the issue's constraint)

The guard is **not** relaxed generally. The container is authorized through the **resolved inner target**, which is verifiable — exactly the shape the issue prescribes. `runSetWidget` already follows the promotion chain to the ultimate concrete backend node (`followPromotionToConcrete`) and fresh-authorizes that node's type (`assertTypeAgainstFreshBackend`) and instance (`assertResolvedTargetRegistered`) *before* the container checks run, so reaching the container checks with a resolved promotion is positive, control-flow-established evidence. A new `opts.promotionResolvedToAuthorizedConcrete` flag conveys exactly that to `assertMutatedNodeAuthorized` (outer container + every intermediate), which then exempts the container from **only** the provenance signal, and **only** on positive `never-seen` history evidence.

What still fails closed (all covered by tests):

- **Ever-seen gate** — a container type the backend reported earlier this session and no longer lists is still refused first (non-forgeable #458 trust root; the flag never bypasses it).
- **Unwired / pending / unseeded history** — `"no-oracle"` is not `never-seen`; fails closed exactly as before.
- **Unresolvable promotion** — no concrete inner node+widget ⇒ the flag is never set ⇒ refused.
- **Removed inner type** — the resolved target itself is still fresh-authorized; a since-removed inner type is refused.
- **Provenance-bearing non-container leaf** — still refused; the exemption is for virtual-subgraph containers only (`isVirtualSubgraphContainer` still required).

## Tests

- `browser_tests/unit/node-resolve.test.mjs` — 5 new direct guard tests (flag authorizes the stamped container; no flag / no oracle / ever-seen / non-container all still refuse).
- `browser_tests/unit/set-widget-fresh-backend.test.mjs` — 5 new end-to-end `runSetWidget` tests on a fixture mirroring the real frontend (UUID-typed node, synthesized def on class + instance): verifiable promotion ⇒ write proceeds (inner + authoritative rail synced); removed inner / unresolvable promotion / ever-seen container ⇒ still refused; nested A→B→KSampler through a stamped intermediate ⇒ succeeds.
- `npm run test:unit`: **1312 pass, 0 fail**. `npm run typecheck` (`tsc --noEmit`): **clean**.