### PR TITLE
fix(widget): resolve case-colliding names exactly (#524)

### DIFF
--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -58,6 +58,38 @@ test("#347: clearing to '' does NOT weaken combo/numeric strictness (#240)", () 
   assert.throws(() => coerceWidgetValue(num, ""), /not a number/);
 });
 
+test("#524: exact case wins when two widgets differ only by case", () => {
+  const backgroundToggle = { name: "Background", type: "BOOLEAN", value: false };
+  const backgroundMode = { name: "background", type: "COMBO", options: { values: ["Alpha", "Color"] }, value: "Alpha" };
+  const node = { id: 26, type: "ClothesSegment", widgets: [backgroundToggle, backgroundMode] };
+
+  const set = applyWidgetWrite(node, "background", "Color", HOOKS);
+
+  assert.equal(set.widget, "background");
+  assert.equal(backgroundMode.value, "Color");
+  assert.equal(backgroundToggle.value, false, "must not write the first case-insensitive match");
+});
+
+test("#524: ambiguous case-insensitive widget name refuses before mutation", () => {
+  const backgroundToggle = { name: "Background", type: "BOOLEAN", value: false };
+  const backgroundMode = { name: "background", type: "COMBO", options: { values: ["Alpha", "Color"] }, value: "Alpha" };
+  const node = { id: 26, type: "ClothesSegment", widgets: [backgroundToggle, backgroundMode] };
+
+  assert.throws(
+    () => applyWidgetWrite(node, "BACKGROUND", "Color", HOOKS),
+    /case-insensitively.*Background, background.*exact widget name/i,
+  );
+  assert.equal(backgroundToggle.value, false);
+  assert.equal(backgroundMode.value, "Alpha");
+});
+
+test("#524: a unique case-insensitive widget name remains supported", () => {
+  const node = { id: 27, type: "Any", widgets: [{ name: "Prompt", type: "STRING", value: "old" }] };
+  const set = applyWidgetWrite(node, "prompt", "new", HOOKS);
+  assert.equal(set.widget, "Prompt");
+  assert.equal(node.widgets[0].value, "new");
+});
+
 // ---- #179: rgthree Power Lora Loader composite widget ----------------------
 
 test("#179: a composite lora_N widget is detected by its object value", () => {

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -96,6 +96,29 @@ export function isCompositeObjectWidget(widget) {
   return v != null && typeof v === "object" && !Array.isArray(v);
 }
 
+/**
+ * Resolve a widget name without silently choosing between case-colliding
+ * widgets. Exact spelling always wins; a case-insensitive fallback remains for
+ * older callers, but only when it names exactly one widget (#524).
+ */
+function resolveWidgetByName(node, widgetName) {
+  const wanted = String(widgetName);
+  const widgets = node?.widgets ?? [];
+  const exact = widgets.find((cand) => cand?.name === wanted);
+  if (exact) return exact;
+
+  const matches = widgets.filter(
+    (cand) => typeof cand?.name === "string" && cand.name.toLowerCase() === wanted.toLowerCase(),
+  );
+  if (matches.length > 1) {
+    throw new WidgetWriteError(
+      `Node ${node?.id} (${node?.type}) has ${matches.length} widgets matching "${wanted}" ` +
+        `case-insensitively (${matches.map((cand) => cand.name).join(", ")}); pass the exact widget name.`,
+    );
+  }
+  return matches[0] ?? null;
+}
+
 // DECLARED field schema for known composite widgets. Types are enforced from THIS
 // schema, never inferred from the current value — a field whose current value is `null`
 // still enforces the correct type, so a scalar of the wrong type (e.g. a number into a
@@ -779,9 +802,7 @@ export function resolveWidgetWrite(
   if (!widget) {
     // EXACT-NAME FIRST: a widget whose own name is literally `widgetName` (dots and
     // all) always wins — the split is never taken when an exact match exists.
-    widget = (targetNode.widgets ?? []).find(
-      (cand) => cand?.name?.toLowerCase() === String(widgetName).toLowerCase(),
-    );
+    widget = resolveWidgetByName(targetNode, widgetName);
   }
   if (!widget && node?.subgraph) {
     // #560 SAFETY: on a SUBGRAPH parent, a dotted name that did not resolve as a
@@ -811,9 +832,7 @@ export function resolveWidgetWrite(
     if (dot > 0) {
       const baseName = nameStr.slice(0, dot);
       const sub = nameStr.slice(dot + 1);
-      const baseWidget = (targetNode.widgets ?? []).find(
-        (cand) => cand?.name?.toLowerCase() === baseName.toLowerCase(),
-      );
+      const baseWidget = resolveWidgetByName(targetNode, baseName);
       if (baseWidget) {
         if (sub === "") {
           throw new WidgetWriteError(


### PR DESCRIPTION
Fixes #524.\n\npanel_set_widget now prefers an exact widget name and rejects ambiguous case-insensitive fallback matches before any mutation. This prevents Background and ackground from silently targeting the wrong control.\n\nValidation:\n- node --test browser_tests/unit/widget-write.test.mjs\n- node --check web/js/lib/widget-write.js\n- git diff --check