### PR TITLE
fix(panel): restore CivitAI keyword search results

### DIFF
--- a/browser_tests/unit/civitai-creator.test.mjs
+++ b/browser_tests/unit/civitai-creator.test.mjs
@@ -76,25 +76,27 @@ test("fetchModels QUIRK: query+username sends only username, filters keyword cli
   assert.equal(calls.length, 1); // matched on page one — no chase
 });
 
-test("fetchModels default path is ONE request — even on an empty page with a cursor", async () => {
-  // no creator filter → no page-chasing, identical to pre-creator behavior
+test("fetchModels chases continuable empty pages on every path", async () => {
   const empty = { items: [], metadata: { nextCursor: "c2" } };
   {
-    const { client, calls } = stub(empty);
+    const { client, calls } = stub([empty, { items: [modelItem("Found")], metadata: {} }]);
     const page = await client.fetchModels({ type: "LORA" });
-    assert.equal(calls.length, 1);
-    assert.equal(page.nextCursor, "c2");
+    assert.equal(calls.length, 2);
+    assert.equal(new URL(calls[1].url).searchParams.get("cursor"), "c2");
+    assert.deepEqual(page.models.map((m) => m.name), ["Found"]);
   }
   {
-    const { client, calls } = stub(empty);
-    await client.fetchModels({ type: "LORA", query: "anime" }); // keyword only
-    assert.equal(calls.length, 1);
+    const { client, calls } = stub([empty, { items: [modelItem("Anime Style")], metadata: {} }]);
+    const page = await client.fetchModels({ type: "LORA", query: "anime" });
+    assert.equal(calls.length, 2);
     assert.equal(new URL(calls[0].url).searchParams.get("query"), "anime");
+    assert.deepEqual(page.models.map((m) => m.name), ["Anime Style"]);
   }
   {
-    const { client, calls } = stub(empty);
-    await client.fetchModels({ type: "LORA", username: "artist" }); // creator only
-    assert.equal(calls.length, 1);
+    const { client, calls } = stub([empty, { items: [modelItem("Found")], metadata: {} }]);
+    const page = await client.fetchModels({ type: "LORA", username: "artist" });
+    assert.equal(calls.length, 2);
+    assert.deepEqual(page.models.map((m) => m.name), ["Found"]);
   }
 });
 
@@ -110,12 +112,12 @@ test("fetchModels keyword×creator chases past client-side-emptied pages", async
   assert.equal(page.nextCursor, "c3"); // resumes AFTER the matched page
 });
 
-test("fetchModels keyword×creator chase is capped (initial + 4 hops)", async () => {
+test("fetchModels empty-page chase is capped (initial + 4 hops)", async () => {
   const { client, calls } = stub({
-    items: [modelItem("Realism Pack")], // never matches "anime"
+    items: [],
     metadata: { nextCursor: "again" },
   });
-  const page = await client.fetchModels({ type: "LORA", query: "anime", username: "artist" });
+  const page = await client.fetchModels({ type: "LORA", query: "anime" });
   assert.equal(calls.length, 5);
   assert.deepEqual(page.models, []);
   assert.equal(page.nextCursor, "again"); // caller can keep going explicitly

--- a/browser_tests/unit/civitai-filter-normalize.test.mjs
+++ b/browser_tests/unit/civitai-filter-normalize.test.mjs
@@ -69,6 +69,20 @@ test("fetchModels never dispatches an invalid model sort/period (the #459 400)",
   assert.equal(u.searchParams.get("period"), "Week"); // clamped, not "Forever"
 });
 
+test("fetchModels defaults a keyword search to AllTime but honors an explicit period", async () => {
+  const { client, calls } = captureClient();
+  await client.fetchModels({ type: "LORA", query: "game asset" });
+  assert.equal(new URL(calls[0]).searchParams.get("period"), "AllTime");
+
+  calls.length = 0;
+  await client.fetchModels({ type: "LORA", query: "game asset", period: "Month" });
+  assert.equal(new URL(calls[0]).searchParams.get("period"), "Month");
+
+  calls.length = 0;
+  await client.fetchModels({ type: "LORA" });
+  assert.equal(new URL(calls[0]).searchParams.get("period"), "Week");
+});
+
 test("fetchFeed never dispatches an invalid image sort/period", async () => {
   const { client, calls } = captureClient();
   await client.fetchFeed({ type: "image", sort: "Most Downloaded", period: "Nope" });

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -605,10 +605,13 @@ export class CivitaiClient {
     return { items, nextCursor: useIdCursor ? String(lastRawId) : String(next) };
   }
 
-  async fetchModels({ type, sort = "Most Downloaded", period = "Week", baseModels = [], levels = [1], limit = 100, cursor, query, username } = {}) {
+  async fetchModels({ type, sort = "Most Downloaded", period = null, baseModels = [], levels = [1], limit = 100, cursor, query, username } = {}) {
     const base = new URLSearchParams({
       limit: String(limit), types: type,
-      sort: normalizeModelSort(sort), period: normalizePeriod(period), // #459: clamp to enum
+      // A keyword search must not silently narrow itself to the last week:
+      // CivitAI intersects query with period, so use AllTime unless the caller
+      // explicitly selected a period in the UI.
+      sort: normalizeModelSort(sort), period: normalizePeriod(period || (query ? "AllTime" : "Week")), // #459: clamp to enum
       nsfw: bitmask(levels) > 2 ? "true" : "false",
     });
     for (const b of baseModels) base.append("baseModels", b);
@@ -621,9 +624,9 @@ export class CivitaiClient {
     const kw = clientFilter ? String(query).toLowerCase() : null;
     let next = cursor || null;
     let models = [];
-    // Exactly ONE request on every path except keyword×creator, whose
-    // client-side matching can empty a page — that combo (and ONLY that
-    // combo) chases a few more pages so a thinned page isn't a dead end.
+    // An empty page with a cursor is not the end of a search: /v1/models can
+    // thin pages server-side, and keyword×creator additionally filters them
+    // client-side. Chase a bounded number of continuable empty pages.
     for (let hop = 0; ; hop++) {
       const q = new URLSearchParams(base);
       if (next) q.set("cursor", next);
@@ -633,7 +636,7 @@ export class CivitaiClient {
         .filter(Boolean);
       if (kw) models = models.filter((m) => (m.name || "").toLowerCase().includes(kw));
       next = data.metadata?.nextCursor || null;
-      if (!clientFilter || models.length || !next || hop >= 4) break;
+      if (models.length || !next || hop >= 4) break;
     }
     return { models, nextCursor: next };
   }


### PR DESCRIPTION
Fixes #530. Keyword model searches now default to AllTime unless the caller explicitly selects a period, and fetchModels follows an empty page with a nextCursor for up to five total requests. Focused coverage verifies both behaviors and the bounded loop. Validation: npm.cmd run test:unit (1485 passed); npm.cmd run typecheck.