### PR TITLE
fix(panel): clear stale root outlines after subgraph conversion (#516)

### DIFF
--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -23,6 +23,7 @@ import {
   collectMissingNodeTypeReasons,
   graphErrorsResultIsClean,
   nodeRedFlagIsStale,
+  collectLinkedNeighborNodeIds,
   resolveMissingModelDirectory,
 } from "../../web/js/lib/asset-staleness.js";
 
@@ -623,6 +624,31 @@ test("nodeRedFlagIsStale: OR across multiple maps — an EMPTY entry in one must
     nodeRedFlagIsStale(5, { nodeErrorsMaps: [{ 5: { errors: [] } }, null] }),
     true,
   );
+});
+
+// ---- #516: native subgraph conversion rewires direct root neighbours -------
+test("collectLinkedNeighborNodeIds finds every direct neighbour after a native subgraph conversion (#516)", () => {
+  // Wrapper input link: LoadImage (7) → wrapper; wrapper output link: wrapper → SaveImage (9).
+  // A second output uses the serialized tuple shape present in some LiteGraph paths.
+  const wrapper = {
+    inputs: [{ link: 11 }],
+    outputs: [{ links: [12, 13] }],
+  };
+  const links = new Map([
+    [11, { origin_id: 7, target_id: 100 }],
+    [12, { origin_id: 100, target_id: 9 }],
+    [13, [13, 100, 1, "uuid-target", 0, "IMAGE"]],
+  ]);
+  assert.deepEqual(
+    [...collectLinkedNeighborNodeIds(wrapper, links)].sort(),
+    [7, 9, "uuid-target"].sort(),
+  );
+});
+
+test("collectLinkedNeighborNodeIds fails closed on malformed link storage (#516)", () => {
+  const wrapper = { inputs: [{ link: 1 }], outputs: [{ links: [2] }] };
+  assert.deepEqual([...collectLinkedNeighborNodeIds(wrapper, null)], []);
+  assert.deepEqual([...collectLinkedNeighborNodeIds(null, {})], []);
 });
 
 // --- resolveMissingModelDirectory (#487) — Ultralytics bbox/segm subfolder ---

--- a/browser_tests/unit/subgraph-stale-outline.test.mjs
+++ b/browser_tests/unit/subgraph-stale-outline.test.mjs
@@ -21,6 +21,7 @@ function methodSource(name, args) {
 
 const createSource = methodSource("graph_create_subgraph", "\\{ node_ids \\}");
 const groupSource = methodSource("graph_subgraph_group", "\\{ group \\}");
+const setWidgetSource = methodSource("async graph_set_widget", "\\{ node_id, widget, value \\}");
 const cleanupMatch = panelSrc.match(/function clearStaleRedFlag\(node, \{ app, graph, rootGraph \}\) \{[\s\S]*?\n\}\n\n\/\*\*/);
 assert.ok(cleanupMatch, "could not locate clearStaleRedFlag in panel source");
 const cleanupSource = cleanupMatch[0].replace(/\n\/\*\*$/, "");
@@ -166,4 +167,17 @@ test("real stale-outline cleanup clears only an unblamed direct node (#516)", ()
   assert.equal(clear(node, { app: { lastNodeErrors: {} }, graph, rootGraph: graph }), true);
   assert.equal(node.has_errors, false);
   assert.equal(dirtied, 1);
+});
+
+test("graph_set_widget delegates all stale-outline clearing to the shared adjudicator (#516 P1)", () => {
+  assert.match(
+    setWidgetSource,
+    /clearStaleRedFlag\(node, \{ app, graph, rootGraph \}\)/,
+    "the direct set-widget path must execute the complete shared adjudicator",
+  );
+  assert.doesNotMatch(
+    setWidgetSource,
+    /nodeRedFlagIsStale\(/,
+    "a narrower duplicate predicate could clear a missing-node-type outline",
+  );
 });

--- a/browser_tests/unit/subgraph-stale-outline.test.mjs
+++ b/browser_tests/unit/subgraph-stale-outline.test.mjs
@@ -1,0 +1,120 @@
+// #516: native convertToSubgraph rewires surviving root nodes but can leave a
+// stale LiteGraph red outline. Exercise the shipped inline handlers by extracting
+// their actual source; the browser-only module cannot be imported under Node.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8");
+
+function methodSource(name, args) {
+  const match = panelSrc.match(new RegExp(`${name}\\(${args}\\) \\{[\\s\\S]*?\\n  \\},`));
+  assert.ok(match, `could not locate ${name} in panel source`);
+  return match[0];
+}
+
+const createSource = methodSource("graph_create_subgraph", "\\{ node_ids \\}");
+const groupSource = methodSource("graph_subgraph_group", "\\{ group \\}");
+
+function realCreate(getGraphCtx, clearStaleRedFlagsAfterSubgraphConversion) {
+  return new Function(
+    "getGraphCtx",
+    "clearStaleRedFlagsAfterSubgraphConversion",
+    `const executors = { ${createSource} }; return executors.graph_create_subgraph;`,
+  )(getGraphCtx, clearStaleRedFlagsAfterSubgraphConversion);
+}
+
+function realGroup(
+  getGraphCtx,
+  resolveGroupRef,
+  syncGraphNodeAreas,
+  groupMemberNodes,
+  clearStaleRedFlagsAfterSubgraphConversion,
+) {
+  return new Function(
+    "getGraphCtx",
+    "resolveGroupRef",
+    "syncGraphNodeAreas",
+    "groupMemberNodes",
+    "clearStaleRedFlagsAfterSubgraphConversion",
+    `const executors = { ${groupSource} }; return executors.graph_subgraph_group;`,
+  )(
+    getGraphCtx,
+    resolveGroupRef,
+    syncGraphNodeAreas,
+    groupMemberNodes,
+    clearStaleRedFlagsAfterSubgraphConversion,
+  );
+}
+
+function makeCtx() {
+  const events = [];
+  const selected = [];
+  const app = { lastNodeErrors: {} };
+  const rootGraph = { name: "root" };
+  const wrapper = { id: 100, subgraph: { name: "converted" } };
+  const result = { node: wrapper, subgraph: wrapper.subgraph };
+  const graph = {
+    getNodeById: (id) => ({ id: Number(id) }),
+    beforeChange: () => events.push("before"),
+    afterChange: () => events.push("after"),
+    convertToSubgraph: (items) => {
+      events.push(`convert:${items.length}`);
+      return result;
+    },
+    setDirtyCanvas: () => events.push("dirty"),
+  };
+  const canvas = {
+    selectedItems: [],
+    selectItems: (items) => {
+      selected.push(...items);
+      canvas.selectedItems = items;
+    },
+  };
+  return { events, selected, app, rootGraph, graph, canvas, result };
+}
+
+test("graph_create_subgraph re-adjudicates only after conversion, before canvas dirties (#516)", () => {
+  const ctx = makeCtx();
+  const cleanups = [];
+  const create = realCreate(
+    () => ({ app: ctx.app, graph: ctx.graph, canvas: ctx.canvas, rootGraph: ctx.rootGraph }),
+    (res, args) => {
+      cleanups.push({ res, args });
+      ctx.events.push("cleanup");
+    },
+  );
+
+  const out = create({ node_ids: [7, 8] });
+  assert.deepEqual(ctx.selected.map((node) => node.id), [7, 8]);
+  assert.equal(cleanups.length, 1);
+  assert.equal(cleanups[0].res, ctx.result, "cleanup receives the returned native wrapper");
+  assert.equal(cleanups[0].args.graph, ctx.graph);
+  assert.equal(cleanups[0].args.rootGraph, ctx.rootGraph);
+  assert.deepEqual(ctx.events, ["before", "convert:2", "after", "cleanup", "dirty"]);
+  assert.equal(out.subgraph.node_id, 100);
+});
+
+test("graph_subgraph_group applies the same post-conversion stale-outline cleanup (#516)", () => {
+  const ctx = makeCtx();
+  const cleanups = [];
+  const group = realGroup(
+    () => ({ app: ctx.app, graph: ctx.graph, canvas: ctx.canvas, rootGraph: ctx.rootGraph }),
+    () => ({ title: "Replacement" }),
+    () => ctx.events.push("sync"),
+    () => [{ id: 17 }, { id: 18 }],
+    (res, args) => {
+      cleanups.push({ res, args });
+      ctx.events.push("cleanup");
+    },
+  );
+
+  const out = group({ group: "Replacement" });
+  assert.equal(cleanups.length, 1);
+  assert.equal(cleanups[0].res, ctx.result);
+  assert.equal(cleanups[0].args.app, ctx.app);
+  assert.deepEqual(ctx.events, ["sync", "before", "convert:2", "after", "cleanup", "dirty"]);
+  assert.deepEqual(out.subgraph.from_nodes, [17, 18]);
+});

--- a/browser_tests/unit/subgraph-stale-outline.test.mjs
+++ b/browser_tests/unit/subgraph-stale-outline.test.mjs
@@ -5,6 +5,10 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import {
+  collectMissingNodeTypeReasons,
+  nodeRedFlagIsStale,
+} from "../../web/js/lib/asset-staleness.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSrc = readFileSync(panelPath, "utf8");
@@ -17,6 +21,9 @@ function methodSource(name, args) {
 
 const createSource = methodSource("graph_create_subgraph", "\\{ node_ids \\}");
 const groupSource = methodSource("graph_subgraph_group", "\\{ group \\}");
+const cleanupMatch = panelSrc.match(/function clearStaleRedFlag\(node, \{ app, graph, rootGraph \}\) \{[\s\S]*?\n\}\n\n\/\*\*/);
+assert.ok(cleanupMatch, "could not locate clearStaleRedFlag in panel source");
+const cleanupSource = cleanupMatch[0].replace(/\n\/\*\*$/, "");
 
 function realCreate(getGraphCtx, clearStaleRedFlagsAfterSubgraphConversion) {
   return new Function(
@@ -46,6 +53,24 @@ function realGroup(
     syncGraphNodeAreas,
     groupMemberNodes,
     clearStaleRedFlagsAfterSubgraphConversion,
+  );
+}
+
+/** Run the actual shipped cleanup body with deterministic live-source stubs. */
+function realClearStaleRedFlag({ assets, storeNodeErrors = null } = {}) {
+  return new Function(
+    "collectMissingAssets",
+    "collectMissingNodeTypeReasons",
+    "getPiniaStore",
+    "nodeRedFlagIsStale",
+    "findNodeByScopedId",
+    `${cleanupSource}; return clearStaleRedFlag;`,
+  )(
+    () => assets,
+    collectMissingNodeTypeReasons,
+    () => ({ lastNodeErrors: storeNodeErrors }),
+    nodeRedFlagIsStale,
+    () => null,
   );
 }
 
@@ -117,4 +142,28 @@ test("graph_subgraph_group applies the same post-conversion stale-outline cleanu
   assert.equal(cleanups[0].args.app, ctx.app);
   assert.deepEqual(ctx.events, ["sync", "before", "convert:2", "after", "cleanup", "dirty"]);
   assert.deepEqual(out.subgraph.from_nodes, [17, 18]);
+});
+
+test("real stale-outline cleanup preserves a node still blamed by missingNodesError (#516 P1)", () => {
+  const node = { id: 7, type: "MissingCustom", has_errors: true };
+  let dirtied = 0;
+  const graph = { _nodes: [node], setDirtyCanvas: () => { dirtied += 1; } };
+  const clear = realClearStaleRedFlag({
+    assets: { models: [], media: [], nodeTypes: ["MissingCustom"] },
+  });
+
+  assert.equal(clear(node, { app: { lastNodeErrors: {} }, graph, rootGraph: graph }), false);
+  assert.equal(node.has_errors, true, "a real missing-node-type red flag is never cleared");
+  assert.equal(dirtied, 0);
+});
+
+test("real stale-outline cleanup clears only an unblamed direct node (#516)", () => {
+  const node = { id: 7, type: "LoadImage", has_errors: true };
+  let dirtied = 0;
+  const graph = { _nodes: [node], setDirtyCanvas: () => { dirtied += 1; } };
+  const clear = realClearStaleRedFlag({ assets: { models: [], media: [], nodeTypes: [] } });
+
+  assert.equal(clear(node, { app: { lastNodeErrors: {} }, graph, rootGraph: graph }), true);
+  assert.equal(node.has_errors, false);
+  assert.equal(dirtied, 1);
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -117,6 +117,7 @@ import {
   collectMissingNodeTypeReasons,
   graphErrorsResultIsClean,
   nodeRedFlagIsStale,
+  collectLinkedNeighborNodeIds,
   findNodeByScopedId,
   resolveMissingModelDirectory,
 } from "./lib/asset-staleness.js";
@@ -4556,6 +4557,58 @@ function collectMissingAssets(trustComboOverride) {
   return { models, media, nodeTypes, nodeCount, any: !!(models.length || media.length || nodeTypes.length || nodeCount) };
 }
 
+/**
+ * LiteGraph's `has_errors` bit is sticky: a node can retain a red outline after
+ * its cause is gone. Clear it only when the same conservative #418
+ * missing-asset and validation-map adjudication says no source still blames the
+ * direct node. Containers are deliberately excluded: an outer subgraph wrapper
+ * cannot be safely adjudicated from candidates resolving to an inner node.
+ */
+function clearStaleRedFlag(node, { app, graph, rootGraph }) {
+  try {
+    if (!node?.has_errors || node.subgraph) return false;
+    // Clearing is destructive, so do not trust a possibly stale combo list. A
+    // live missing candidate is retained whenever its widget still references it.
+    const assets = collectMissingAssets(false);
+    let storeNodeErrors = null;
+    try {
+      storeNodeErrors = getPiniaStore("executi" + "on" + "Error")?.lastNodeErrors ?? null;
+    } catch {
+      // Optional Pinia store.
+    }
+    if (
+      nodeRedFlagIsStale(node.id, {
+        missingItems: [...assets.models, ...assets.media],
+        // Keep a real error from either independent source; never shallow-merge.
+        nodeErrorsMaps: [app?.lastNodeErrors ?? null, storeNodeErrors],
+        resolvesToNode: (scopedId) => findNodeByScopedId(rootGraph, scopedId) === node,
+      })
+    ) {
+      node.has_errors = false;
+      graph?.setDirtyCanvas?.(true, true);
+      return true;
+    }
+  } catch {
+    // Visual cleanup must not turn a successful graph mutation into a failure.
+  }
+  return false;
+}
+
+/**
+ * `convertToSubgraph()` rewires surviving root-graph neighbours to its new
+ * wrapper but does not revalidate their sticky red flags. Re-adjudicate only
+ * those direct neighbours; never the wrapper or the nodes moved inside it.
+ */
+function clearStaleRedFlagsAfterSubgraphConversion(res, { app, graph, rootGraph }) {
+  try {
+    for (const id of collectLinkedNeighborNodeIds(res?.node, graph?.links)) {
+      clearStaleRedFlag(graph?.getNodeById?.(id), { app, graph, rootGraph });
+    }
+  } catch {
+    // Best effort only.
+  }
+}
+
 // ComfyUI resolves an input-asset value on the SERVER's platform (os.path.join):
 // a backslash is a path separator ONLY on Windows; on POSIX it is a literal
 // filename character. The /view probe must split the value exactly the way the
@@ -6727,6 +6780,11 @@ const GRAPH_TOOL_EXECUTORS = {
           return false;
         }
       })();
+      // Keep the conversion path and the established #418 path on the same
+      // conservative adjudicator. The legacy block below remains a harmless
+      // fallback for this direct-node path; once this helper clears the flag it
+      // naturally skips its own `has_errors` guard.
+      if (stillActive) clearStaleRedFlag(node, { app, graph, rootGraph });
       // Only clear the flag on a DIRECT (non-container) node. `node` here is what was
       // resolved from the caller's node_id in the CURRENT graph; for a PROMOTED write it
       // is the OUTER subgraph wrapper while the value actually changes an INNER node, so
@@ -8355,7 +8413,7 @@ const GRAPH_TOOL_EXECUTORS = {
   },
 
   graph_create_subgraph({ node_ids }) {
-    const { graph, canvas } = getGraphCtx();
+    const { app, graph, canvas, rootGraph } = getGraphCtx();
     if (typeof graph.convertToSubgraph !== "function") {
       throw new Error("convertToSubgraph unavailable on this frontend");
     }
@@ -8372,6 +8430,7 @@ const GRAPH_TOOL_EXECUTORS = {
     } finally {
       graph.afterChange?.();
     }
+    clearStaleRedFlagsAfterSubgraphConversion(res, { app, graph, rootGraph });
     graph.setDirtyCanvas?.(true, true);
     return {
       subgraph: {
@@ -8387,7 +8446,7 @@ const GRAPH_TOOL_EXECUTORS = {
   // same convertToSubgraph path as graph_create_subgraph. This is how a region
   // like a "REPLACEMENT MODE" group becomes one toggleable subgraph node.
   graph_subgraph_group({ group }) {
-    const { graph, canvas } = getGraphCtx();
+    const { app, graph, canvas, rootGraph } = getGraphCtx();
     if (typeof graph.convertToSubgraph !== "function") {
       throw new Error("convertToSubgraph unavailable on this frontend");
     }
@@ -8413,6 +8472,7 @@ const GRAPH_TOOL_EXECUTORS = {
     } finally {
       graph.afterChange?.();
     }
+    clearStaleRedFlagsAfterSubgraphConversion(res, { app, graph, rootGraph });
     graph.setDirtyCanvas?.(true, true);
     return {
       subgraph: {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -4570,6 +4570,16 @@ function clearStaleRedFlag(node, { app, graph, rootGraph }) {
     // Clearing is destructive, so do not trust a possibly stale combo list. A
     // live missing candidate is retained whenever its widget still references it.
     const assets = collectMissingAssets(false);
+    // `missingNodesError` carries TYPE names rather than per-node records. Turn
+    // that source into the same per-node blame graph_get_errors reports before
+    // clearing: a surviving root neighbour with an uninstalled type may be red
+    // even when it has no missing model/media candidate or validation entry.
+    // This must veto clearing just like either validation map does (#516 P1).
+    const missingNodeTypeStillBlamesNode = collectMissingNodeTypeReasons(
+      graph?._nodes ?? [],
+      assets.nodeTypes,
+    ).some(({ nodeId }) => String(nodeId) === String(node.id));
+    if (missingNodeTypeStillBlamesNode) return false;
     let storeNodeErrors = null;
     try {
       storeNodeErrors = getPiniaStore("executi" + "on" + "Error")?.lastNodeErrors ?? null;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -6791,53 +6791,10 @@ const GRAPH_TOOL_EXECUTORS = {
         }
       })();
       // Keep the conversion path and the established #418 path on the same
-      // conservative adjudicator. The legacy block below remains a harmless
-      // fallback for this direct-node path; once this helper clears the flag it
-      // naturally skips its own `has_errors` guard.
+      // conservative adjudicator. It includes missing node types as well as
+      // model/media candidates and validation errors, so there must be no
+      // second, narrower cleanup predicate after this call.
       if (stillActive) clearStaleRedFlag(node, { app, graph, rootGraph });
-      // Only clear the flag on a DIRECT (non-container) node. `node` here is what was
-      // resolved from the caller's node_id in the CURRENT graph; for a PROMOTED write it
-      // is the OUTER subgraph wrapper while the value actually changes an INNER node, so
-      // the outer's redness can't be adjudicated from the inner candidates (they resolve
-      // to the inner node, not this wrapper) — clearing it could hide a still-missing
-      // inner sibling asset (codex round-7 P1). Skip wrappers: leaving the flag is the
-      // safe over-report direction. A DIRECT write to a plain node (the #418 repro) and a
-      // write to an inner node while inside its subgraph both have no `.subgraph` here.
-      if (stillActive && node?.has_errors && !node.subgraph) {
-        // DISTRUST the live combo here (trustComboOverride=false): clearing a red flag is
-        // DESTRUCTIVE, so it must never rely on possibly-stale combo membership. #418's
-        // real signal is the still-REFERENCED check — the repointed widget no longer holds
-        // the missing filename, so the candidate drops regardless of combo. An asset that
-        // reappeared, was confirmed, then DELETED (widget value unchanged) is still
-        // referenced ⇒ candidate kept ⇒ flag KEPT, never cleared off a stale combo that
-        // still lists it (codex round-9 P0).
-        const assets = collectMissingAssets(false);
-        // Use the SAME validation surface graph_get_errors trusts: app.lastNodeErrors
-        // PLUS the execution-error Pinia store's lastNodeErrors, which outlives some
-        // app-level resets (codex #4). Only clear when NEITHER still blames this node.
-        let storeNodeErrors = null;
-        try {
-          storeNodeErrors = getPiniaStore("executi" + "on" + "Error")?.lastNodeErrors ?? null;
-        } catch {
-          /* optional */
-        }
-        // Pass both maps SEPARATELY (OR semantics) so a node blamed by EITHER source
-        // keeps its red flag — never a shallow merge, whose empty entry could shadow the
-        // other map's live error and wrongly clear it (codex round-2 P0).
-        if (
-          nodeRedFlagIsStale(node.id, {
-            missingItems: [...assets.models, ...assets.media],
-            nodeErrorsMaps: [app?.lastNodeErrors ?? null, storeNodeErrors],
-            // A nested candidate is keyed by a SCOPED locator that never string-equals
-            // this inner node's local id — resolve it and compare identity so a still-
-            // missing nested asset keeps the flag (codex round-3 P0).
-            resolvesToNode: (scopedId) => findNodeByScopedId(rootGraph, scopedId) === node,
-          })
-        ) {
-          node.has_errors = false;
-          graph.setDirtyCanvas?.(true, true);
-        }
-      }
     } catch {
       /* best-effort visual cleanup — never fail the write over it */
     }

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -241,6 +241,38 @@ export function nodeRedFlagIsStale(
 }
 
 /**
+ * Return the direct graph neighbours connected to `node`. Native
+ * `convertToSubgraph()` rewires precisely these surviving root-graph nodes to
+ * the new wrapper, but does not re-adjudicate LiteGraph's sticky `has_errors`
+ * bit (#516). Supports both live `LLink` records and serialized link tuples;
+ * malformed graph shapes simply produce no candidates.
+ */
+export function collectLinkedNeighborNodeIds(node, links) {
+  const out = new Set();
+  try {
+    const lookup = (id) => {
+      if (id == null || !links) return null;
+      return typeof links.get === "function" ? links.get(id) ?? null : links[id] ?? null;
+    };
+    const originId = (link) => link?.origin_id ?? link?.[1];
+    const targetId = (link) => link?.target_id ?? link?.[3];
+    for (const input of node?.inputs ?? []) {
+      const id = originId(lookup(input?.link));
+      if (id != null) out.add(id);
+    }
+    for (const output of node?.outputs ?? []) {
+      for (const linkId of output?.links ?? []) {
+        const id = targetId(lookup(linkId));
+        if (id != null) out.add(id);
+      }
+    }
+  } catch {
+    // Best effort only: a malformed graph must never make a conversion fail.
+  }
+  return out;
+}
+
+/**
  * A missing-asset store candidate is stale (should NOT be reported) when either
  * no widget still references the file (the value was changed to a fix) OR the
  * file resolves against the node's live combo options (it appeared on disk).


### PR DESCRIPTION
## Summary\n- re-adjudicate only direct root-graph neighbours rewired by native subgraph conversion\n- share the conservative #418 missing-asset and validation-map gate; wrappers and converted inner nodes remain untouched\n- cover both graph_create_subgraph and graph_subgraph_group paths\n\n## Validation\n- npm.cmd run test:unit (1489 passed)\n- npm.cmd run typecheck\n\nRequires independent accidental-correctness/data-integrity review before merge.