### PR TITLE
test(panel): make stale-outline extraction CRLF-safe

### DIFF
--- a/browser_tests/unit/subgraph-stale-outline.test.mjs
+++ b/browser_tests/unit/subgraph-stale-outline.test.mjs
@@ -22,9 +22,12 @@ function methodSource(name, args) {
 const createSource = methodSource("graph_create_subgraph", "\\{ node_ids \\}");
 const groupSource = methodSource("graph_subgraph_group", "\\{ group \\}");
 const setWidgetSource = methodSource("async graph_set_widget", "\\{ node_id, widget, value \\}");
-const cleanupMatch = panelSrc.match(/function clearStaleRedFlag\(node, \{ app, graph, rootGraph \}\) \{[\s\S]*?\n\}\n\n\/\*\*/);
+// Extract the actual helper through its unindented closing brace. Do not depend on
+// the following doc comment or on checkout line endings: Windows worktrees retain
+// CRLF, while the test runner reads the source verbatim.
+const cleanupMatch = panelSrc.match(/function clearStaleRedFlag\(node, \{ app, graph, rootGraph \}\) \{[\s\S]*?\r?\n\}/);
 assert.ok(cleanupMatch, "could not locate clearStaleRedFlag in panel source");
-const cleanupSource = cleanupMatch[0].replace(/\n\/\*\*$/, "");
+const cleanupSource = cleanupMatch[0];
 
 function realCreate(getGraphCtx, clearStaleRedFlagsAfterSubgraphConversion) {
   return new Function(


### PR DESCRIPTION
## What changed

Made the `clearStaleRedFlag` source extraction in the #516 unit test tolerate CRLF and LF worktrees.

## Why

The prior terminator matched a literal LF immediately after the helper's closing brace. On Windows CRLF checkouts, the test failed before it could execute the shipped helper.

## Impact

The test still locates the exact named helper in `web/js/comfyui-mcp-panel.js` and executes its extracted source; it no longer depends on the following doc comment or a particular line ending.

## Validation

- `node --test browser_tests/unit/subgraph-stale-outline.test.mjs`
- `npm.cmd run test:unit` (1492 passed)
- `npm.cmd run typecheck`
