### PR TITLE
fix(panel): fence stale nonempty workflow graph (#349)

### DIFF
--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -18,6 +18,7 @@ import { dirname, join } from "node:path";
 import {
   activeWorkflowNodeCount,
   graphReadDesynced,
+  graphRootMismatchesActiveWorkflow,
   graphReadBindingChanged,
 } from "../../web/js/lib/graph-binding.js";
 
@@ -28,6 +29,12 @@ const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
 // `changeTracker.activeState` / `.initialState` (and some builds hang them flat).
 const wf = (over = {}) => ({ changeTracker: {}, ...over });
 const state = (n) => ({ nodes: Array.from({ length: n }, (_, i) => ({ id: i + 1 })) });
+const typedState = (...nodes) => ({ nodes: nodes.map(([id, type]) => ({ id, type })) });
+const liveRoot = (...nodes) => ({ _nodes: nodes.map(([id, type]) => ({ id, type })) });
+const serializedRoot = (serialized) => ({
+  _nodes: serialized.nodes.map(({ id, type }) => ({ id, type })),
+  serialize: () => serialized,
+});
 
 // ── activeWorkflowNodeCount: fail-open ground truth ──────────────────────────
 
@@ -130,6 +137,173 @@ test("graphReadDesynced: defensive — missing args never throw, default to not-
   assert.equal(graphReadDesynced({}), false);
 });
 
+test("graphRootMismatchesActiveWorkflow: TRUE - a nonempty prior tab remains on the canvas (#349)", () => {
+  const activeWorkflow = wf({ changeTracker: { activeState: typedState([1, "AnimeLoader"], [2, "KSampler"]) } });
+  const rootGraph = liveRoot([1, "FluxLoader"], [2, "KSampler"], [3, "SaveImage"]);
+  assert.equal(graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow }), true);
+});
+
+test("graphRootMismatchesActiveWorkflow: TRUE - same node count but a different graph shape", () => {
+  const activeWorkflow = wf({ changeTracker: { activeState: typedState([1, "CheckpointLoader"], [2, "KSampler"]) } });
+  const rootGraph = liveRoot([1, "FluxLoader"], [2, "KSampler"]);
+  assert.equal(graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow }), true);
+});
+
+test("graphRootMismatchesActiveWorkflow: TRUE - matching id:type nodes but different widgets or links", () => {
+  const activeState = {
+    nodes: [
+      { id: 1, type: "CheckpointLoader", widgets_values: ["anime.safetensors"] },
+      { id: 2, type: "KSampler", widgets_values: [20] },
+    ],
+    links: [[1, 1, 0, 2, 0, "MODEL"]],
+  };
+  const staleState = {
+    nodes: [
+      { id: 1, type: "CheckpointLoader", widgets_values: ["flux.safetensors"] },
+      { id: 2, type: "KSampler", widgets_values: [35] },
+    ],
+    links: [],
+  };
+  const activeWorkflow = wf({ changeTracker: { activeState } });
+  assert.equal(
+    graphRootMismatchesActiveWorkflow({ rootGraph: serializedRoot(staleState), activeWorkflow }),
+    true,
+  );
+});
+
+test("graphRootMismatchesActiveWorkflow: TRUE - ChangeTracker-relevant non-node surfaces differ", () => {
+  const activeState = {
+    nodes: [{ id: 1, type: "KSampler" }],
+    links: [],
+    floatingLinks: [{ id: "floating-a", pos: [10, 20] }],
+    reroutes: [{ id: "reroute-a", pos: [30, 40] }],
+    subgraphs: [{ id: "subgraph-a", nodes: [{ id: 9, type: "SaveImage" }] }],
+  };
+  const activeWorkflow = wf({ changeTracker: { activeState } });
+  const variants = [
+    ["floatingLinks", [{ id: "floating-b", pos: [10, 20] }]],
+    ["reroutes", [{ id: "reroute-b", pos: [30, 40] }]],
+    ["subgraphs", [{ id: "subgraph-b", nodes: [{ id: 9, type: "SaveImage" }] }]],
+  ];
+  for (const [field, replacement] of variants) {
+    const staleState = structuredClone(activeState);
+    staleState[field] = replacement;
+    assert.equal(
+      graphRootMismatchesActiveWorkflow({ rootGraph: serializedRoot(staleState), activeWorkflow }),
+      true,
+      `${field} must participate in the binding comparison`,
+    );
+  }
+});
+
+test("graphRootMismatchesActiveWorkflow: TRUE - missing and explicitly empty/null tracker surfaces differ", () => {
+  const activeState = { nodes: [{ id: 1, type: "KSampler" }] };
+  const activeWorkflow = wf({ changeTracker: { activeState } });
+  for (const [field, replacement] of [
+    ["links", []],
+    ["floatingLinks", []],
+    ["reroutes", []],
+    ["groups", []],
+    ["config", {}],
+    ["subgraphs", []],
+    ["definitions", null],
+  ]) {
+    const staleState = { ...activeState, [field]: replacement };
+    assert.equal(
+      graphRootMismatchesActiveWorkflow({ rootGraph: serializedRoot(staleState), activeWorkflow }),
+      true,
+      `${field}: missing must not collapse into an explicit value`,
+    );
+  }
+});
+
+test("graphRootMismatchesActiveWorkflow: FALSE - matching serialized semantic state is bound", () => {
+  const activeState = {
+    nodes: [{ id: 1, type: "CheckpointLoader", widgets_values: ["anime.safetensors"] }],
+    links: [],
+    extra: { ds: { scale: 1 } },
+  };
+  const activeWorkflow = wf({ changeTracker: { activeState } });
+  assert.equal(
+    graphRootMismatchesActiveWorkflow({ rootGraph: serializedRoot(structuredClone(activeState)), activeWorkflow }),
+    false,
+  );
+});
+
+test("graphRootMismatchesActiveWorkflow: FALSE - node array order and viewport drift do not invent a mismatch", () => {
+  const activeState = {
+    nodes: [
+      { id: 1, type: "CheckpointLoader", widgets_values: ["anime.safetensors"] },
+      { id: 2, type: "KSampler", widgets_values: [20] },
+    ],
+    links: [[1, 1, 0, 2, 0, "MODEL"]],
+    extra: { ds: { scale: 1, offset: [0, 0] }, workflow_meta: { owner: "artist" } },
+  };
+  const sameWorkflowDifferentViewport = {
+    ...structuredClone(activeState),
+    nodes: [...activeState.nodes].reverse(),
+    extra: { ds: { scale: 1.7, offset: [125, -40] }, workflow_meta: { owner: "artist" } },
+  };
+  const activeWorkflow = wf({ changeTracker: { activeState } });
+  assert.equal(
+    graphRootMismatchesActiveWorkflow({
+      rootGraph: serializedRoot(sameWorkflowDifferentViewport),
+      activeWorkflow,
+    }),
+    false,
+  );
+});
+
+test("graphRootMismatchesActiveWorkflow: FALSE - viewport-only extra matches an absent extra field", () => {
+  const activeState = { nodes: [{ id: 1, type: "KSampler", widgets_values: [20] }], links: [] };
+  const liveState = {
+    ...structuredClone(activeState),
+    extra: { ds: { scale: 2, offset: [33, -17] } },
+  };
+  const activeWorkflow = wf({ changeTracker: { activeState } });
+  assert.equal(
+    graphRootMismatchesActiveWorkflow({ rootGraph: serializedRoot(liveState), activeWorkflow }),
+    false,
+  );
+});
+
+test("graphRootMismatchesActiveWorkflow: FALSE - matching root shape is bound, independent of node order", () => {
+  const activeWorkflow = wf({ changeTracker: { activeState: typedState([1, "CheckpointLoader"], [2, "KSampler"]) } });
+  const rootGraph = liveRoot([2, "KSampler"], [1, "CheckpointLoader"]);
+  assert.equal(graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow }), false);
+});
+
+test("graphRootMismatchesActiveWorkflow: FALSE - absent or partial state is inconclusive, never a false refusal", () => {
+  const rootGraph = liveRoot([1, "CheckpointLoader"]);
+  assert.equal(graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow: null }), false);
+  assert.equal(
+    graphRootMismatchesActiveWorkflow({
+      rootGraph: { _nodes: [{ id: 1 }] },
+      activeWorkflow: wf({ changeTracker: { activeState: typedState([1, "CheckpointLoader"]) } }),
+    }),
+    false,
+  );
+});
+
+test("graphRootMismatchesActiveWorkflow: FALSE - initialState is a baseline, not a false stale-current comparison", () => {
+  const baseline = {
+    nodes: [{ id: 1, type: "KSampler", widgets_values: [20] }],
+    links: [],
+  };
+  const legitimateUnsavedLiveState = {
+    nodes: [{ id: 1, type: "KSampler", widgets_values: [30] }],
+    links: [],
+  };
+  const activeWorkflow = wf({ changeTracker: { initialState: baseline } });
+  assert.equal(
+    graphRootMismatchesActiveWorkflow({
+      rootGraph: serializedRoot(legitimateUnsavedLiveState),
+      activeWorkflow,
+    }),
+    false,
+  );
+});
+
 test("graphReadBindingChanged: FALSE — same workflow instance and root graph across the await", () => {
   const w = wf();
   const g = {};
@@ -217,5 +391,75 @@ test("#513 review wiring: validationBanner fences its server probe against a mid
   assert.ok(
     discardAt < sigAt,
     "the mismatch discard must precede the dedupe-sig stamp — A's state must not poison B's dedupe",
+  );
+});
+
+test("#349 wiring: every graph command verifies LiteGraph is bound to the active workflow before execution", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const handlerStart = src.indexOf("const executor = GRAPH_TOOL_EXECUTORS[msg.cmd];");
+  assert.notEqual(handlerStart, -1, "bridge graph-command handler must exist");
+  const handler = src.slice(handlerStart, src.indexOf("result = await executor(msg);", handlerStart));
+  assert.match(handler, /msg\.cmd\.startsWith\("graph_"\)/, "graph commands must have a root-binding fence");
+  assert.match(
+    handler,
+    /assertGraphBoundToActiveWorkflow\(graph, rootGraph(?:, \{ includeBaselineReadGuard: false \})?\)/,
+    "the fence must inspect the graph the executor will use",
+  );
+});
+
+test("#349 direct paths: run, CivitAI load, and snapshot restore fence the live root before success", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const orderedFence = (startNeedle, beforeNeedle) => {
+    const start = src.indexOf(startNeedle);
+    const before = src.indexOf(beforeNeedle, start);
+    const fence = src.indexOf("assertGraphBoundToActiveWorkflow(graph, rootGraph, { includeBaselineReadGuard: false })", start);
+    assert.notEqual(start, -1, `${startNeedle} must exist`);
+    assert.notEqual(before, -1, `${beforeNeedle} must follow ${startNeedle}`);
+    assert.ok(fence > start && fence < before, `${startNeedle} must fence before ${beforeNeedle}`);
+  };
+
+  orderedFence("async graph_run({ batch_count, to_node_id })", "app.queuePrompt");
+  orderedFence("async graph_load({ graph: incoming } = {})", "captureGraphSnapshot(null, \"before graph_load\")");
+  orderedFence("function restoreSnapshot(snap)", "app.loadGraphData(JSON.parse(JSON.stringify(snap.data))");
+});
+
+test("#349 snapshots: capture is bound and restore rejects a snapshot from another workflow", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const captureStart = src.indexOf("function captureGraphSnapshot(mid, label)");
+  const captureSerialize = src.indexOf("const data = rootGraph.serialize();", captureStart);
+  const captureFence = src.indexOf("assertGraphBoundToActiveWorkflow(graph, rootGraph, { includeBaselineReadGuard: false });", captureStart);
+  assert.ok(captureStart >= 0 && captureFence > captureStart && captureFence < captureSerialize);
+  assert.match(
+    src.slice(captureStart, captureSerialize),
+    /\[workflowRef\?\.changeTracker\?\.activeState, workflowRef\?\.activeState\]\.find\(/,
+    "snapshot capture must fall back to a valid flat activeState when tracker state is malformed",
+  );
+  assert.match(
+    src.slice(captureStart, src.indexOf("while (graphSnapshots.length", captureStart)),
+    /graphSnapshots\.push\(\{[^}]*data, workflowRef \}\)/,
+    "a captured snapshot must retain its workflow instance",
+  );
+
+  const restoreStart = src.indexOf("function restoreSnapshot(snap)");
+  const restoreLoad = src.indexOf("app.loadGraphData(JSON.parse(JSON.stringify(snap.data))", restoreStart);
+  const restoreBody = src.slice(restoreStart, restoreLoad);
+  assert.match(
+    restoreBody,
+    /!snap\.workflowRef \|\| snap\.workflowRef !== activeWorkflowRef\(\)/,
+    "restore must reject missing or cross-workflow snapshot provenance",
+  );
+
+  const revertStart = src.indexOf("function revertGraphToLastSnapshot()");
+  const revertEnd = src.indexOf("\n}\n", revertStart);
+  const revertBody = src.slice(revertStart, revertEnd);
+  assert.match(
+    revertBody,
+    /graphSnapshots\.filter\(\(snap\) => snap\?\.workflowRef === workflowRef\)/,
+    "revert must select candidates only from the active workflow instance",
+  );
+  assert.match(
+    revertBody,
+    /pickRevertSnapshot\(scopedSnapshots, current\)/,
+    "a foreign newer snapshot must not hide an older same-workflow revert",
   );
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -249,6 +249,7 @@ import { createRunReconcileSweep } from "./lib/run-reconcile-sweep.js";
 import {
   activeWorkflowNodeCount,
   graphReadDesynced,
+  graphRootMismatchesActiveWorkflow,
   graphReadBindingChanged,
 } from "./lib/graph-binding.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
@@ -3944,16 +3945,19 @@ function getGraphCtx() {
 // than return empty". Fail-safe: fires ONLY when the workflow reports N>0 nodes at
 // ROOT scope while the live root graph is empty, so a genuinely-empty / brand-new
 // workflow (and any descended-into empty subgraph) reads `node_count: 0` as before.
-function assertGraphBoundToActiveWorkflow(graph, rootGraph) {
+function assertGraphBoundToActiveWorkflow(graph, rootGraph, { includeBaselineReadGuard = true } = {}) {
   const liveNodeCount = rootGraph?._nodes?.length ?? 0;
   const inSubgraph = !!rootGraph && graph !== rootGraph;
   const activeWorkflow = activeWorkflowRef();
-  if (graphReadDesynced({ liveNodeCount, activeWorkflow, inSubgraph })) {
+  if (
+    graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow }) ||
+    (includeBaselineReadGuard && graphReadDesynced({ liveNodeCount, activeWorkflow, inSubgraph }))
+  ) {
     const expected = activeWorkflowNodeCount(activeWorkflow);
     throw new Error(
-      `The live graph is out of sync with the active workflow: the workflow reports ${expected} node(s) ` +
-        `but the canvas graph is empty. A load, tab switch, or reconnect left this read bound to an empty ` +
-        `graph, so an empty/clean result here would be WRONG. Re-open the active workflow tab ` +
+      `The live graph is out of sync with the active workflow: the workflow reports ${expected} node(s), ` +
+        `but the canvas is bound to a different graph. A load, tab switch, or reconnect left this command ` +
+        `pointed at the wrong canvas, so it was NOT applied. Re-open the active workflow tab ` +
         `(panel_open_workflow) or reload the panel to rebind the graph, then retry.`,
     );
   }
@@ -4183,9 +4187,23 @@ const graphSnapshots = []; // [{ mid, ts, label, data }], oldest → newest
 
 function captureGraphSnapshot(mid, label) {
   try {
-    const data = getGraphCtx().rootGraph.serialize();
-    graphSnapshots.push({ mid, ts: Date.now(), label: (label || "").slice(0, 80), data });
+    const { graph, rootGraph } = getGraphCtx();
+    const workflowRef = activeWorkflowRef();
+    // A snapshot can later be restored by a local /revert path, so it must be
+    // captured only from a canvas proven to match this workflow's CURRENT state.
+    // Without this, a stale root B could be recorded under active A and later
+    // loaded into A after a rebind (cross-workflow corruption, #349).
+    // Mirror the binding helper's version-defensive resolution: a malformed
+    // tracker state must not hide a valid flat workflow.activeState.
+    const currentState = [workflowRef?.changeTracker?.activeState, workflowRef?.activeState].find(
+      (state) => state && Array.isArray(state.nodes),
+    );
+    if (!currentState) return null;
+    assertGraphBoundToActiveWorkflow(graph, rootGraph, { includeBaselineReadGuard: false });
+    const data = rootGraph.serialize();
+    graphSnapshots.push({ mid, ts: Date.now(), label: (label || "").slice(0, 80), data, workflowRef });
     while (graphSnapshots.length > GRAPH_SNAPSHOTS_MAX) graphSnapshots.shift();
+    return graphSnapshots[graphSnapshots.length - 1];
   } catch {
     // graph unavailable — this turn just won't have a restore point.
   }
@@ -4195,10 +4213,18 @@ function captureGraphSnapshot(mid, label) {
 function restoreSnapshot(snap) {
   if (!snap) return null;
   try {
+    const { app, graph, rootGraph } = getGraphCtx();
+    // Snapshots are workflow-instance scoped. A snapshot captured from tab B
+    // must never become a valid load merely because the canvas later rebinds to
+    // tab A; missing provenance is rejected too (old in-memory snapshots).
+    if (!snap.workflowRef || snap.workflowRef !== activeWorkflowRef()) return null;
+    // Revert is a direct local load, not a bridge command. Do not restore a
+    // snapshot into a canvas proven to belong to a different active workflow.
+    assertGraphBoundToActiveWorkflow(graph, rootGraph, { includeBaselineReadGuard: false });
     // Deep-clone so the stored snapshot isn't mutated by the live graph after load.
     // __cmcpNoFork: this reloads the SAME active workflow (a revert), so the create-
     // boundary fork must NOT re-mint its per-instance identity (#570 P0).
-    getGraphCtx().app.loadGraphData(JSON.parse(JSON.stringify(snap.data)), true, true, activeWorkflowRef(), {
+    app.loadGraphData(JSON.parse(JSON.stringify(snap.data)), true, true, activeWorkflowRef(), {
       __cmcpNoFork: true,
     });
     return snap;
@@ -4214,14 +4240,22 @@ function restoreSnapshot(snap) {
 // snapshot equals the canvas and reverting to it recovers nothing. Returns null
 // when nothing genuinely differs — the caller surfaces "nothing to revert".
 function revertGraphToLastSnapshot() {
+  const workflowRef = activeWorkflowRef();
+  if (!workflowRef) return null;
+  // The snapshot ring spans tabs, but a revert belongs only to the CURRENT
+  // workflow instance. Filter before choosing the newest differing snapshot:
+  // otherwise a newer B snapshot wins selection, is rightly rejected by
+  // restoreSnapshot, and hides an older valid A snapshot (#349).
+  const scopedSnapshots = graphSnapshots.filter((snap) => snap?.workflowRef === workflowRef);
+  if (!scopedSnapshots.length) return null;
   try {
     const current = getGraphCtx().rootGraph.serialize();
-    const snap = pickRevertSnapshot(graphSnapshots, current);
+    const snap = pickRevertSnapshot(scopedSnapshots, current);
     return snap ? restoreSnapshot(snap) : null;
   } catch {
     // graph unavailable (can't serialize current state) — fall back to the
     // legacy newest-snapshot behavior rather than silently doing nothing.
-    return restoreSnapshot(graphSnapshots[graphSnapshots.length - 1]);
+    return restoreSnapshot(scopedSnapshots[scopedSnapshots.length - 1]);
   }
 }
 
@@ -4909,8 +4943,12 @@ async function validationBanner() {
 // Restore the canvas to the snapshot captured before the message with this mid
 // (the per-message rollback). Returns the snapshot or null.
 function revertGraphSnapshotByMid(mid) {
+  const workflowRef = activeWorkflowRef();
+  if (!workflowRef) return null;
   for (let i = graphSnapshots.length - 1; i >= 0; i--) {
-    if (graphSnapshots[i].mid === mid) return restoreSnapshot(graphSnapshots[i]);
+    if (graphSnapshots[i].mid === mid && graphSnapshots[i].workflowRef === workflowRef) {
+      return restoreSnapshot(graphSnapshots[i]);
+    }
   }
   return null;
 }
@@ -6333,7 +6371,11 @@ const GRAPH_TOOL_EXECUTORS = {
   // current graph), so a ready pack/template graph lands without recreating it
   // node-by-node. Mirrors restoreSnapshot's app.loadGraphData(...) path.
   async graph_load({ graph: incoming } = {}) {
-    const { app } = getGraphCtx();
+    const { app, graph, rootGraph } = getGraphCtx();
+    // This executor is also called directly by the CivitAI workflow picker,
+    // bypassing bridge dispatch. Refuse before snapshot/load so that path cannot
+    // report a successful load into a stale prior tab (#349).
+    assertGraphBoundToActiveWorkflow(graph, rootGraph, { includeBaselineReadGuard: false });
     // Accept a JSON string or an object.
     let data = incoming;
     if (typeof data === "string") {
@@ -7260,6 +7302,11 @@ const GRAPH_TOOL_EXECUTORS = {
 
   async graph_run({ batch_count, to_node_id }) {
     const { app, graph, rootGraph } = getGraphCtx();
+    // /run invokes this executor directly rather than through bridge dispatch.
+    // Queueing a stale root would render the wrong workflow even though no graph
+    // mutation occurs, so enforce the same current-state binding before prompt
+    // construction or queuePrompt can report success (#349).
+    assertGraphBoundToActiveWorkflow(graph, rootGraph, { includeBaselineReadGuard: false });
     if (typeof app.queuePrompt !== "function") {
       throw new Error("app.queuePrompt is unavailable on this frontend");
     }
@@ -10721,6 +10768,15 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
                   `Re-select the intended workflow (panel_open_workflow) or re-target with ` +
                   `panel_set_workflow_target({mode:"current"}), then retry.`,
               );
+            }
+            // #349: UUID fencing proves the command was issued for the active
+            // workflow SERVICE object, but graph executors operate on LiteGraph's
+            // separate app.graph. A stale nonempty app.graph can therefore pass the
+            // UUID check and still edit a previous tab. Fence every graph command
+            // against the active workflow's serialized root before its executor.
+            if (msg.cmd.startsWith("graph_")) {
+              const { graph, rootGraph } = getGraphCtx();
+              assertGraphBoundToActiveWorkflow(graph, rootGraph, { includeBaselineReadGuard: false });
             }
             // PINNED-TARGET GUARD (#349): a `workflow_path` on the command means the
             // agent's session is pinned to a SPECIFIC workflow. But every executor

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -77,6 +77,127 @@ export function graphReadDesynced({ liveNodeCount, activeWorkflow, inSubgraph = 
 }
 
 /**
+ * Return the active workflow's serialized CURRENT graph state. `initialState`
+ * is deliberately excluded: it is a load/save baseline and can legitimately
+ * differ from an active canvas with unsaved edits. `null` means current state is
+ * unavailable, so callers must fail open rather than invent a binding mismatch.
+ */
+function activeWorkflowCurrentState(activeWorkflow) {
+  try {
+    if (!activeWorkflow || typeof activeWorkflow !== "object") return null;
+    const ct = activeWorkflow.changeTracker;
+    const state = (st) => (st && Array.isArray(st.nodes) ? st : null);
+    return (
+      state(ct?.activeState) ??
+      state(activeWorkflow.activeState)
+    );
+  } catch {
+    return null;
+  }
+}
+
+function graphShape(state) {
+  if (!state || !Array.isArray(state.nodes)) return null;
+  // Omit counters/version metadata that can legitimately differ after LiteGraph
+  // rebuilds; retain every serialized graph surface ChangeTracker treats as
+  // workflow state, so the binding guard cannot accept a different canvas that
+  // only differs in reroutes, floating links, or top-level subgraphs.
+  // ChangeTracker distinguishes a missing surface from an explicitly empty or
+  // null one. Preserve that distinction rather than `??`-normalizing it away.
+  const own = (key) => Object.prototype.hasOwnProperty.call(state, key);
+  const surface = (key) => ({ present: own(key), value: state[key] });
+  const extra = (() => {
+    if (!own("extra")) return { present: false };
+    if (!state.extra || typeof state.extra !== "object") return { present: true, value: state.extra };
+    const { ds: viewport, ...workflowExtra } = state.extra;
+    // A sole `extra.ds` is viewport-only, so it compares like no extra field.
+    if (viewport !== undefined && Object.keys(workflowExtra).length === 0) return { present: false };
+    return { present: true, value: workflowExtra };
+  })();
+  const shape = {
+    // LiteGraph preserves node array order opportunistically, but it does not
+    // identify a workflow: equivalent loads can emit the same nodes in a
+    // different order. Keep each node's full serialized content and normalize
+    // only their ordering by stable id.
+    nodes: [...state.nodes].sort((a, b) => String(a?.id ?? "").localeCompare(String(b?.id ?? ""))),
+    links: surface("links"),
+    floatingLinks: surface("floatingLinks"),
+    reroutes: surface("reroutes"),
+    groups: surface("groups"),
+    config: surface("config"),
+    subgraphs: surface("subgraphs"),
+    definitions: surface("definitions"),
+    // `extra.ds` is the viewport transform. Panning/zooming changes it without
+    // changing the workflow, so it must not block a valid graph command.
+    extra,
+  };
+  try {
+    const canonicalize = (value) => {
+      if (Array.isArray(value)) return value.map(canonicalize);
+      if (value && typeof value === "object") {
+        return Object.fromEntries(
+          Object.keys(value)
+            .sort()
+            .map((key) => [key, canonicalize(value[key])]),
+        );
+      }
+      return value;
+    };
+    return JSON.stringify(canonicalize(shape));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when the live ROOT graph is demonstrably a different workflow from the
+ * active workflow's own serialized state. Unlike graphReadDesynced's original
+ * empty-canvas check, this catches a stale *nonempty* canvas (for example an
+ * active nine-node tab while app.graph still holds a 63-node prior tab).
+ *
+ * Node count alone catches the common case. Where LiteGraph can serialize its
+ * root, compare the complete semantic graph state (nodes, widgets, links,
+ * groups, reroutes, floating links, top-level subgraphs, definitions, and extra)
+ * so same-sized tabs cannot be silently confused.
+ * Older/partial frontends fall back to an unordered `id` + `type` shape; if that
+ * is also unavailable, equal counts remain inconclusive and return false. The
+ * guard never manufactures a mismatch from partial state.
+ */
+export function graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow } = {}) {
+  const activeState = activeWorkflowCurrentState(activeWorkflow);
+  const expected = activeState?.nodes;
+  const live = rootGraph?._nodes;
+  if (!Array.isArray(expected) || !Array.isArray(live)) return false;
+  if (live.length !== expected.length) return true;
+
+  // Current LiteGraph can serialize its live ROOT graph. When both sides can be
+  // represented, compare the complete semantic shape so equal id:type node sets
+  // with different links, widgets, groups, or subgraphs cannot be confused.
+  // An unavailable/throwing serializer remains inconclusive and falls through to
+  // the older id:type comparison below.
+  try {
+    const liveShape = graphShape(rootGraph?.serialize?.());
+    const expectedShape = graphShape(activeState);
+    if (liveShape != null && expectedShape != null) return liveShape !== expectedShape;
+  } catch {
+    // Old/partial LiteGraph frontends: use the defensive shape fallback below.
+  }
+
+  const shape = (node) => {
+    if (!node || (typeof node.id !== "string" && typeof node.id !== "number") || typeof node.type !== "string") {
+      return null;
+    }
+    return `${typeof node.id}:${node.id}\u0000${node.type}`;
+  };
+  const expectedShapes = expected.map(shape);
+  const liveShapes = live.map(shape);
+  if (expectedShapes.includes(null) || liveShapes.includes(null)) return false;
+  const expectedSet = new Set(expectedShapes);
+  if (expectedSet.size !== expectedShapes.length) return false;
+  return liveShapes.some((entry) => !expectedSet.has(entry));
+}
+
+/**
  * True when the graph READ's binding changed across an AWAIT: the active-workflow
  * instance or the bound root-graph object captured before the await no longer
  * matches after it. Used to detect a workflow-tab SWITCH that interleaved with a


### PR DESCRIPTION
Fixes the #349 stale-canvas path left after workflow UUID fencing: graph executors can no longer run when LiteGraph's root graph differs from the active workflow's current serialized state.\n\n- Compares current activeState against the live root (including nodes, widgets, links, groups, definitions/subgraphs, and extra).\n- Covers every bridge graph_* command before its executor.\n- Keeps baseline-only initialState inconclusive, avoiding false refusal of legitimate unsaved edits.\n\nTests: node --test browser_tests/unit/graph-binding.test.mjs browser_tests/unit/workflow-chat-identity.test.mjs browser_tests/unit/session-rebind.test.mjs (99 pass).\n\nFull unit sweep is blocked only by pre-existing subgraph-stale-outline.test.mjs CRLF/LF static-regex failure (reproduces unchanged on main).