### PR TITLE
fix(tests): make the clearStaleRedFlag extraction line-ending tolerant

### DIFF
--- a/browser_tests/unit/subgraph-stale-outline.test.mjs
+++ b/browser_tests/unit/subgraph-stale-outline.test.mjs
@@ -22,7 +22,7 @@ function methodSource(name, args) {
 const createSource = methodSource("graph_create_subgraph", "\\{ node_ids \\}");
 const groupSource = methodSource("graph_subgraph_group", "\\{ group \\}");
 const setWidgetSource = methodSource("async graph_set_widget", "\\{ node_id, widget, value \\}");
-const cleanupMatch = panelSrc.match(/function clearStaleRedFlag\(node, \{ app, graph, rootGraph \}\) \{[\s\S]*?\n\}\n\n\/\*\*/);
+const cleanupMatch = panelSrc.match(/function clearStaleRedFlag\(node, \{ app, graph, rootGraph \}\) \{[\s\S]*?\n\}\r?\n\r?\n\/\*\*/);
 assert.ok(cleanupMatch, "could not locate clearStaleRedFlag in panel source");
 const cleanupSource = cleanupMatch[0].replace(/\n\/\*\*$/, "");
 


### PR DESCRIPTION
The #536 test suite extracts clearStaleRedFlag from the panel source with an LF-only regex; the file is CRLF on Windows (core.autocrlf), failing every Windows run. One regex, now \r?-tolerant.