### PR TITLE
fix(panel): retry identity via retry_of + session-epoch replay gating (#694)

### DIFF
--- a/browser_tests/unit/command-dedupe.test.mjs
+++ b/browser_tests/unit/command-dedupe.test.mjs
@@ -11,8 +11,19 @@
 // The dedupe identity is rid + payload fingerprint: the bridge's re-dispatch of
 // the SAME logical command dedupes, but a rid reused for DIFFERENT work must
 // execute fresh (never answered from the ledger) and is logged once.
+//
+// #694: the orchestrator never REUSES a rid (#683/#687) — a timed-out command is
+// retried under a FRESH rid plus `retry_of` naming the original. `retry_of` is
+// excluded from the fingerprint, so the retry dedupes against the ORIGINAL's
+// ledger entry (settled or still in flight) and is answered with the rid
+// rewritten to the retry's — never a second execution. An unknown retry_of
+// misses and executes fresh (fail-open), and a genuinely fresh command with
+// identical args (no retry_of) executes again as it should.
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 
 import { commandFingerprint, createCommandDedupeLedger } from "../../web/js/lib/command-dedupe.js";
 
@@ -23,6 +34,37 @@ function makeDispatch(ledger, executor) {
     const prior = ledger.get(msg.rid, commandFingerprint(msg));
     if (prior !== undefined) return { reply: await prior, executed: false };
     const settle = ledger.begin(msg.rid, commandFingerprint(msg));
+    let reply;
+    try {
+      reply = { rid: msg.rid, ok: true, result: await executor(msg) };
+    } catch (err) {
+      reply = { rid: msg.rid, ok: false, error: String(err?.message ?? err) };
+    }
+    settle(reply);
+    return { reply, executed: true };
+  };
+}
+
+// #694 — the SAME stand-in EXTENDED with the panel's retry path: a retry carries
+// a FRESH rid plus `retry_of` naming the original (the orchestrator never reuses
+// rids, #683/#687). A miss on the retry's own rid falls back to the original's
+// ledger entry; a hit there is answered with the rid REWRITTEN to the retry's
+// (the orchestrator's pending map waits on the fresh rid). An unknown retry_of
+// misses too and falls through to begin + execute fresh — the ledger fails open.
+function makeRetryDispatch(ledger, executor) {
+  return async function deliver(msg) {
+    const fingerprint = commandFingerprint(msg);
+    let prior = ledger.get(msg.rid, fingerprint);
+    let retryOfHit = false;
+    if (prior === undefined && typeof msg.retry_of === "string") {
+      prior = ledger.get(msg.retry_of, fingerprint);
+      retryOfHit = prior !== undefined;
+    }
+    if (prior !== undefined) {
+      const reply = await prior;
+      return { reply: retryOfHit ? { ...reply, rid: msg.rid } : reply, executed: false };
+    }
+    const settle = ledger.begin(msg.rid, fingerprint);
     let reply;
     try {
       reply = { rid: msg.rid, ok: true, result: await executor(msg) };
@@ -236,4 +278,122 @@ test("a past-cap in-flight burst is swept back to the cap as entries settle (#51
   assert.notEqual(ledger.get("r200", "fp200"), undefined, "newest settled entry is kept");
   assert.notEqual(ledger.get("r-live", "fp-live"), undefined, "the in-flight entry is never evicted");
   settleLive({ rid: "r-live", ok: true, result: {} });
+});
+
+// --- #694: retry under a FRESH rid + retry_of (the orchestrator never reuses rids) ---
+
+test("the fingerprint excludes retry_of — a retry fingerprints identically to its original (#694)", () => {
+  const original = { rid: "r1", cmd: "graph_add_node", class_type: "X", pos: [1, 2], workflow_uuid: "wfA" };
+  const retry = { rid: "r2", retry_of: "r1", cmd: "graph_add_node", class_type: "X", pos: [1, 2], workflow_uuid: "wfA" };
+  assert.equal(commandFingerprint(retry), commandFingerprint(original));
+  // …and a fresh command with identical args but NO retry_of shares that fingerprint
+  // (it is still distinguished by its rid — see the executes-again test below).
+  const fresh = { rid: "r3", cmd: "graph_add_node", class_type: "X", pos: [1, 2], workflow_uuid: "wfA" };
+  assert.equal(commandFingerprint(fresh), commandFingerprint(original));
+});
+
+test("a retry of a SETTLED command gets the ORIGINAL reply with the rid REWRITTEN — the executor never re-runs (#694)", async () => {
+  const ledger = createCommandDedupeLedger();
+  let applied = 0;
+  const deliver = makeRetryDispatch(ledger, async () => ({ added: { id: ++applied } }));
+
+  const first = await deliver({ rid: "r1", cmd: "graph_add_node", workflow_uuid: "wfA" });
+  assert.equal(first.executed, true);
+  assert.equal(applied, 1);
+
+  const retry = await deliver({ rid: "r2", retry_of: "r1", cmd: "graph_add_node", workflow_uuid: "wfA" });
+  assert.equal(retry.executed, false, "the retry is answered from the ledger, not executed again");
+  assert.equal(applied, 1, "the mutation is still applied exactly once — no duplicate node");
+  assert.equal(retry.reply.rid, "r2", "the reply is correlated to the RETRY's rid, not the original's");
+  assert.deepEqual(
+    { ...retry.reply, rid: "r1" },
+    first.reply,
+    "…and is otherwise the ORIGINAL reply verbatim",
+  );
+});
+
+test("a retry of an IN-FLIGHT command awaits the first execution and shares its result (#694)", async () => {
+  const ledger = createCommandDedupeLedger();
+  let applied = 0;
+  let release;
+  const gate = new Promise((resolve) => { release = resolve; });
+  const deliver = makeRetryDispatch(ledger, async () => {
+    await gate; // still applying when the retry arrives (the timed-out-then-retried window)
+    return { added: { id: ++applied } };
+  });
+
+  const p1 = deliver({ rid: "r1", cmd: "graph_add_node" });
+  const p2 = deliver({ rid: "r2", retry_of: "r1", cmd: "graph_add_node" });
+  release();
+  const [first, retry] = await Promise.all([p1, p2]);
+  assert.equal(applied, 1, "one execution even when the retry lands mid-apply");
+  assert.equal(retry.executed, false);
+  assert.equal(retry.reply.rid, "r2", "the awaited reply is rewritten to the retry's rid");
+  assert.deepEqual({ ...retry.reply, rid: "r1" }, first.reply, "both resolve to the same outcome");
+});
+
+test("a retry naming an UNKNOWN retry_of executes fresh — the ledger fails open (#694)", async () => {
+  const ledger = createCommandDedupeLedger();
+  let applied = 0;
+  const deliver = makeRetryDispatch(ledger, async () => ({ added: { id: ++applied } }));
+
+  const retry = await deliver({ rid: "r2", retry_of: "r-unknown", cmd: "graph_add_node" });
+  assert.equal(retry.executed, true, "an unknown/evicted retry token can never SUPPRESS execution");
+  assert.equal(retry.reply.rid, "r2");
+  assert.equal(applied, 1);
+});
+
+test("a genuinely FRESH command with identical args after a settled one EXECUTES again (#694)", async () => {
+  const ledger = createCommandDedupeLedger();
+  let applied = 0;
+  const deliver = makeRetryDispatch(ledger, async () => ({ added: { id: ++applied } }));
+
+  const first = await deliver({ rid: "r1", cmd: "graph_add_node", pos: [0, 0] });
+  const fresh = await deliver({ rid: "r2", cmd: "graph_add_node", pos: [0, 0] }); // same args, NO retry_of
+  assert.equal(first.executed, true);
+  assert.equal(fresh.executed, true, "identical args without retry_of is a NEW command — it must run");
+  assert.equal(applied, 2, "the user really did ask for two identical nodes");
+});
+
+test("a same-rid verbatim replay is still answered with the UNREWITTEN original reply (#521 unchanged)", async () => {
+  const ledger = createCommandDedupeLedger();
+  let applied = 0;
+  const deliver = makeRetryDispatch(ledger, async () => ({ added: { id: ++applied } }));
+
+  const first = await deliver({ rid: "r1", cmd: "graph_add_node" });
+  const replay = await deliver({ rid: "r1", cmd: "graph_add_node" }); // no retry_of — the #521 replay
+  assert.equal(replay.executed, false);
+  assert.equal(applied, 1);
+  assert.equal(replay.reply, first.reply, "same-rid replay returns the original reply object verbatim");
+});
+
+test("#694 wiring: the panel handler falls back to retry_of and REWRITES the rid on a retry hit", () => {
+  const HERE = dirname(fileURLToPath(import.meta.url));
+  const src = readFileSync(join(HERE, "../../web/js/comfyui-mcp-panel.js"), "utf8");
+  // The dedupe block: a miss on the frame's own rid must consult retry_of BEFORE
+  // falling through to begin + execute.
+  const fpAt = src.indexOf("const fingerprint = commandFingerprint(msg);");
+  assert.notEqual(fpAt, -1, "the command handler must fingerprint the frame");
+  const block = src.slice(fpAt, fpAt + 2400);
+  assert.match(
+    block,
+    /let priorRidReply = commandRidLedger\.get\(msg\.rid, fingerprint\);/,
+    "the frame's own rid is consulted first",
+  );
+  assert.match(
+    block,
+    /if \(priorRidReply === undefined && typeof msg\.retry_of === "string"\) \{\s*priorRidReply = commandRidLedger\.get\(msg\.retry_of, fingerprint\);/,
+    "a retry misses on its fresh rid, then looks up the ORIGINAL rid it names",
+  );
+  assert.match(
+    block,
+    /\{ \.\.\.dupReply, rid: msg\.rid \}/,
+    "a retry hit is answered with the rid REWRITTEN to the retry's fresh rid",
+  );
+  // The rewrite must sit on the dedupe-reply path, BEFORE the reply is sent.
+  const rewriteAt = block.indexOf("{ ...dupReply, rid: msg.rid }");
+  const sendAt = block.indexOf("thisSock.send(");
+  assert.ok(rewriteAt !== -1 && sendAt !== -1 && rewriteAt < sendAt, "the rewrite precedes the reply write");
+  // begin() must still key the retry's OWN rid when every lookup missed (fail-open).
+  assert.match(block, /commandRidLedger\.begin\(msg\.rid, fingerprint\);/);
 });

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -121,8 +121,8 @@ test("codex R8: replay never crosses a bridge change — entries for another bri
   const body = src.slice(start, src.indexOf("\n  }", start));
   assert.match(
     body,
-    /if \(!isReplayable\(entry, \{ now: Date\.now\(\), targetUrl \}\)\) \{\s*\n\s*dropped\+\+;\s*\n\s*continue;/,
-    "an outcome belonging to a previous bridge (or too old) must never be volunteered",
+    /if \(!isReplayable\(entry, \{ now: Date\.now\(\), targetUrl, targetEpoch \}\)\) \{\s*\n\s*dropped\+\+;\s*\n\s*continue;/,
+    "an outcome belonging to a previous bridge, session, or too old must never be volunteered",
   );
   assert.match(body, /lostReplies\.replace\(keep\)/, "only undeliverable-but-still-ours entries are retried");
   assert.match(body, /Discarded \$\{dropped\}/, "the user must be told what was discarded");
@@ -161,6 +161,84 @@ test("codex R10: isReplayable demands the SAME bridge and a recent entry, and fa
   assert.equal(isReplayable({ url: URL_A, at: NaN }, { now, targetUrl: URL_A }), false);
 });
 
+test("#694: isReplayable demands the SAME session epoch — match replays, mismatch drops, both-absent replays (legacy)", () => {
+  const URL_A = "ws://127.0.0.1:9180";
+  const now = 1_000_000;
+  const fresh = { url: URL_A, at: now - 1000, epoch: "epoch-1" };
+  // Same session (the ordinary reconnect within one orchestrator run) — replays.
+  assert.equal(isReplayable(fresh, { now, targetUrl: URL_A, targetEpoch: "epoch-1" }), true);
+  // A RESTARTED orchestrator at the same URL handshakes with a fresh epoch — dropped.
+  assert.equal(
+    isReplayable(fresh, { now, targetUrl: URL_A, targetEpoch: "epoch-2" }),
+    false,
+    "a predecessor session's journal must never replay into the new session",
+  );
+  // Legacy on BOTH sides (an epoch-less orchestrator): absent === absent — exactly
+  // the pre-epoch URL+age behaviour.
+  assert.equal(isReplayable({ url: URL_A, at: now - 1000 }, { now, targetUrl: URL_A }), true);
+  // One-sided presence can never prove session continuity — fail CLOSED.
+  assert.equal(
+    isReplayable(fresh, { now, targetUrl: URL_A }),
+    false,
+    "an epoch'd entry must not replay to an epoch-less target",
+  );
+  assert.equal(
+    isReplayable({ url: URL_A, at: now - 1000 }, { now, targetUrl: URL_A, targetEpoch: "epoch-1" }),
+    false,
+    "an epoch-less entry must not replay to an epoch'd target",
+  );
+});
+
+test("#694: the journal records the session epoch and summaries filter by it identically", () => {
+  const j = createLostReplyJournal();
+  const now = 1_000_000;
+  j.record({ reply: { rid: "same-session", ok: true }, cmd: "graph_outline", at: now - 1000, url: "ws://a", epoch: "e1" });
+  j.record({ reply: { rid: "prior-session", ok: true }, cmd: "graph_outline", at: now - 1000, url: "ws://a", epoch: "e0" });
+  j.record({ reply: { rid: "legacy", ok: true }, cmd: "graph_outline", at: now - 1000, url: "ws://a" });
+  assert.equal(j.list()[0].epoch, "e1", "the entry must carry the session it belongs to");
+  assert.equal(j.list()[2].epoch, undefined, "a legacy socket records no epoch (absent, not null)");
+  assert.deepEqual(
+    j.summaries({ now, targetUrl: "ws://a", targetEpoch: "e1" }).map((e) => e.rid),
+    ["same-session"],
+    "hello.lost_replies must obey the same session rule as the replay",
+  );
+  assert.deepEqual(
+    j.summaries({ now, targetUrl: "ws://a" }).map((e) => e.rid),
+    ["legacy"],
+    "an epoch-less target (legacy orchestrator) sees only epoch-less entries",
+  );
+  // No target ⇒ unfiltered (the journal's own bookkeeping view).
+  assert.equal(j.summaries().length, 3);
+});
+
+test("#694 wiring: the models handshake stamps the socket's session epoch BEFORE the replay fires", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const modelsAt = src.indexOf('msg.type === "models"');
+  assert.notEqual(modelsAt, -1, "the models handshake branch must exist");
+  const branch = src.slice(modelsAt, modelsAt + 1200);
+  const stampAt = branch.indexOf("thisSock.__cmcpBridgeEpoch = msg.epoch;");
+  const markAt = branch.indexOf("markConnected();");
+  assert.notEqual(stampAt, -1, "the handshake must stamp the orchestrator's epoch on the socket");
+  assert.notEqual(markAt, -1);
+  assert.ok(
+    stampAt < markAt,
+    "the epoch must be stamped BEFORE markConnected() fires the lost-reply replay",
+  );
+});
+
+test("#694 wiring: a journaled outcome stamps THIS socket's epoch, and the replay checks it", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /epoch: thisSock\.__cmcpBridgeEpoch,/, "the journal must record the socket's session epoch");
+  const start = src.indexOf("function replayLostReplies(target) {");
+  assert.notEqual(start, -1);
+  const body = src.slice(start, src.indexOf("\n  }", start));
+  assert.match(
+    body,
+    /const targetEpoch = target\?\.__cmcpBridgeEpoch;/,
+    "the replay must compare against the TARGET socket's epoch, like the url check",
+  );
+});
+
 test("codex R11: hello summaries obey the SAME cross-bridge/age rule as the replay", () => {
   // The summaries ride the hello, so an unfiltered list would tell a bridge that never
   // owned these commands their ids, names and outcomes — even though replayLostReplies
@@ -181,8 +259,8 @@ test("codex R11: hello summaries obey the SAME cross-bridge/age rule as the repl
   const src = readFileSync(PANEL_JS, "utf8");
   assert.match(
     src,
-    /lostReplies\.summaries\(\{\s*\n\s*now: Date\.now\(\),\s*\n\s*targetUrl: sock\?\.__cmcpBridgeUrl \?\? url,\s*\n\s*\}\)/,
-    "sendHello must filter the summaries by THIS socket's bridge",
+    /lostReplies\.summaries\(\{\s*\n\s*now: Date\.now\(\),\s*\n\s*targetUrl: sock\?\.__cmcpBridgeUrl \?\? url,\s*\n(?:\s*\/\/[^\n]*\n)*\s*targetEpoch: sock\?\.__cmcpBridgeEpoch,\s*\n\s*\}\)/,
+    "sendHello must filter the summaries by THIS socket's bridge AND session epoch (#694)",
   );
 });
 

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -121,7 +121,7 @@ test("codex R8: replay never crosses a bridge change — entries for another bri
   const body = src.slice(start, src.indexOf("\n  }", start));
   assert.match(
     body,
-    /if \(!isReplayable\(entry, \{ now: Date\.now\(\), targetUrl, targetEpoch \}\)\) \{\s*\n\s*dropped\+\+;\s*\n\s*continue;/,
+    /if \(!isReplayable\(entry, \{ now, targetUrl, targetEpoch \}\)\) \{\s*\n\s*dropped\+\+;\s*\n\s*continue;/,
     "an outcome belonging to a previous bridge, session, or too old must never be volunteered",
   );
   assert.match(body, /lostReplies\.replace\(keep\)/, "only undeliverable-but-still-ours entries are retried");
@@ -276,12 +276,14 @@ test("codex R11 / #694: summaries obey the SAME cross-bridge/session/age rule as
   assert.match(replayBody, /type: "lost_replies",/, "the summaries frame must exist");
   assert.match(
     replayBody,
-    /entries: lostReplies\.summaries\(\{ now: Date\.now\(\), targetUrl, targetEpoch \}\)/,
+    /entries: lostReplies\.summaries\(\{ now, targetUrl, targetEpoch \}\)/,
     "the summaries must be filtered with the SAME url+epoch the replay loop uses",
   );
   const epochAt = replayBody.indexOf("const targetEpoch = target?.__cmcpBridgeEpoch;");
   const summaryAt = replayBody.indexOf('type: "lost_replies"');
   const loopAt = replayBody.indexOf("for (const entry of lost) {");
+  const nowAt = replayBody.indexOf("const now = Date.now();");
+  assert.ok(nowAt !== -1 && nowAt < summaryAt, "one captured instant must serve BOTH the summary frame and the replay checks");
   assert.ok(epochAt !== -1 && summaryAt !== -1 && loopAt !== -1);
   assert.ok(
     epochAt < summaryAt && summaryAt < loopAt,

--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -200,7 +200,7 @@ test("#694: the journal records the session epoch and summaries filter by it ide
   assert.deepEqual(
     j.summaries({ now, targetUrl: "ws://a", targetEpoch: "e1" }).map((e) => e.rid),
     ["same-session"],
-    "hello.lost_replies must obey the same session rule as the replay",
+    "the advertised summaries must obey the same session rule as the replay",
   );
   assert.deepEqual(
     j.summaries({ now, targetUrl: "ws://a" }).map((e) => e.rid),
@@ -239,10 +239,10 @@ test("#694 wiring: a journaled outcome stamps THIS socket's epoch, and the repla
   );
 });
 
-test("codex R11: hello summaries obey the SAME cross-bridge/age rule as the replay", () => {
-  // The summaries ride the hello, so an unfiltered list would tell a bridge that never
-  // owned these commands their ids, names and outcomes — even though replayLostReplies
-  // correctly withholds the replies themselves.
+test("codex R11 / #694: summaries obey the SAME cross-bridge/session/age rule as the replay — and ride the post-handshake frame, never the hello", () => {
+  // The summaries advertise "the tab answered and the reply was lost", so an unfiltered
+  // list would tell a bridge that never owned these commands their ids, names and
+  // outcomes — even though replayLostReplies correctly withholds the replies themselves.
   const j = createLostReplyJournal();
   const now = 1_000_000;
   j.record({ reply: { rid: "mine", ok: true }, cmd: "graph_outline", at: now - 1000, url: "ws://a" });
@@ -257,11 +257,66 @@ test("codex R11: hello summaries obey the SAME cross-bridge/age rule as the repl
   assert.equal(j.summaries().length, 3);
 
   const src = readFileSync(PANEL_JS, "utf8");
-  assert.match(
-    src,
-    /lostReplies\.summaries\(\{\s*\n\s*now: Date\.now\(\),\s*\n\s*targetUrl: sock\?\.__cmcpBridgeUrl \?\? url,\s*\n(?:\s*\/\/[^\n]*\n)*\s*targetEpoch: sock\?\.__cmcpBridgeEpoch,\s*\n\s*\}\)/,
-    "sendHello must filter the summaries by THIS socket's bridge AND session epoch (#694)",
+  // #694 — the hello fires at socket-open, BEFORE the models handshake stamps the
+  // socket's epoch: a summary computed there is filtered with an UNKNOWN epoch and can
+  // contradict the epoch-filtered replay. The hello must therefore carry NO summaries…
+  const helloStart = src.indexOf("function sendHello() {");
+  assert.notEqual(helloStart, -1);
+  const helloBody = src.slice(helloStart, src.indexOf("\n  }", helloStart));
+  assert.equal(
+    /lostReplies|lost_replies/.test(helloBody.replace(/\/\/[^\n]*/g, "")),
+    false,
+    "sendHello must not advertise lost-reply summaries computed before the epoch is known",
   );
+  // …they ride the post-handshake `lost_replies` frame, sent from INSIDE the replay with
+  // the SAME targetUrl/targetEpoch locals the replay loop uses — agreement by construction.
+  const replayStart = src.indexOf("function replayLostReplies(target) {");
+  assert.notEqual(replayStart, -1);
+  const replayBody = src.slice(replayStart, src.indexOf("\n  }", replayStart));
+  assert.match(replayBody, /type: "lost_replies",/, "the summaries frame must exist");
+  assert.match(
+    replayBody,
+    /entries: lostReplies\.summaries\(\{ now: Date\.now\(\), targetUrl, targetEpoch \}\)/,
+    "the summaries must be filtered with the SAME url+epoch the replay loop uses",
+  );
+  const epochAt = replayBody.indexOf("const targetEpoch = target?.__cmcpBridgeEpoch;");
+  const summaryAt = replayBody.indexOf('type: "lost_replies"');
+  const loopAt = replayBody.indexOf("for (const entry of lost) {");
+  assert.ok(epochAt !== -1 && summaryAt !== -1 && loopAt !== -1);
+  assert.ok(
+    epochAt < summaryAt && summaryAt < loopAt,
+    "the epoch must be stamped, THEN the summaries sent, THEN the replay attempted",
+  );
+});
+
+test("#694: the advertised summaries and the replay delivery set can never disagree — four epoch cases", () => {
+  // The replay loop delivers entry.reply for exactly the entries where isReplayable
+  // passes; the summaries frame advertises summaries() over the SAME filter. Lock the
+  // equality across every epoch pairing so a future refactor can't split them.
+  const now = 1_000_000;
+  const URL_A = "ws://a";
+  const build = () => {
+    const j = createLostReplyJournal();
+    j.record({ reply: { rid: "this-session", ok: true }, cmd: "graph_outline", at: now - 1000, url: URL_A, epoch: "e1" });
+    j.record({ reply: { rid: "prior-session", ok: true }, cmd: "graph_outline", at: now - 1000, url: URL_A, epoch: "e0" });
+    j.record({ reply: { rid: "legacy", ok: true }, cmd: "graph_outline", at: now - 1000, url: URL_A });
+    j.record({ reply: { rid: "other-bridge", ok: true }, cmd: "graph_outline", at: now - 1000, url: "ws://b", epoch: "e1" });
+    j.record({ reply: { rid: "stale", ok: true }, cmd: "graph_outline", at: now - REPLAY_MAX_AGE_MS - 1, url: URL_A, epoch: "e1" });
+    return j;
+  };
+  const cases = [
+    ["(a) epoch match — same-session reconnect", { now, targetUrl: URL_A, targetEpoch: "e1" }, ["this-session"]],
+    ["(b) epoch mismatch — restarted orchestrator", { now, targetUrl: URL_A, targetEpoch: "e2" }, []],
+    ["(c) both-absent — legacy orchestrator", { now, targetUrl: URL_A }, ["legacy"]],
+    ["(d) one-sided — epoch'd target, epoch'd entries only", { now, targetUrl: URL_A, targetEpoch: "e0" }, ["prior-session"]],
+  ];
+  for (const [name, filter, expected] of cases) {
+    const j = build();
+    const advertised = j.summaries(filter).map((e) => e.rid);
+    const delivered = j.list().filter((e) => isReplayable(e, filter)).map((e) => e.rid);
+    assert.deepEqual(advertised, delivered, `${name}: advertised set must equal the replayed set`);
+    assert.deepEqual(advertised, expected, `${name}: the filter itself picks the right entries`);
+  }
 });
 
 test("codex R12: replay only ever writes to a socket that PROVED itself with a handshake", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10349,12 +10349,17 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     // advertised set IS the replayable set — the two can never diverge. A legacy
     // (epoch-less) orchestrator gets exactly the pre-epoch URL+age-filtered list,
     // one frame later than the hello used to carry it.
+    // ONE captured `now` for the summary frame AND the per-entry replay checks:
+    // two Date.now() reads let an entry at the age boundary be advertised and
+    // then dropped (or vice versa) — the advertised set and the delivered set
+    // must be computed against the SAME instant (codex).
+    const now = Date.now();
     try {
       target.send(
         JSON.stringify({
           type: "lost_replies",
           tab_id: workflowTabId(),
-          entries: lostReplies.summaries({ now: Date.now(), targetUrl, targetEpoch }),
+          entries: lostReplies.summaries({ now, targetUrl, targetEpoch }),
         }),
       );
     } catch {
@@ -10381,7 +10386,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // the residual bounds below are exactly the pre-epoch ones: sensitive
       // results never enter the journal at all, this runs only AFTER a real
       // handshake, and stale entries age out here.
-      if (!isReplayable(entry, { now: Date.now(), targetUrl, targetEpoch })) {
+      if (!isReplayable(entry, { now, targetUrl, targetEpoch })) {
         dropped++;
         continue;
       }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10340,6 +10340,26 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     // #694 — the orchestrator SESSION this socket belongs to (stamped from its models
     // handshake), so a restart at the same URL never inherits its predecessor's journal.
     const targetEpoch = target?.__cmcpBridgeEpoch;
+    // #694 — the lost-reply SUMMARIES ride THIS post-handshake frame, never the hello:
+    // the hello goes out at socket-open, BEFORE the models handshake stamps this
+    // socket's epoch, so a summary computed there is filtered with an UNKNOWN epoch
+    // and can disagree with the replay below — advertising epoch'd entries to the
+    // wrong session, or omitting same-session entries the replay is about to deliver.
+    // Computed HERE with the SAME targetUrl/targetEpoch the replay loop uses, the
+    // advertised set IS the replayable set — the two can never diverge. A legacy
+    // (epoch-less) orchestrator gets exactly the pre-epoch URL+age-filtered list,
+    // one frame later than the hello used to carry it.
+    try {
+      target.send(
+        JSON.stringify({
+          type: "lost_replies",
+          tab_id: workflowTabId(),
+          entries: lostReplies.summaries({ now: Date.now(), targetUrl, targetEpoch }),
+        }),
+      );
+    } catch {
+      // Advisory only — the replay below is the load-bearing delivery.
+    }
     let sent = 0;
     let dropped = 0;
     const keep = [];
@@ -11096,20 +11116,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // the orchestrator can resume an UNSAVED workflow's conversation without
             // cross-resuming a DIFFERENT same-title unsaved workflow.
             workflowUuid: workflowStableUuid(),
-            // #508 — command outcomes this tab produced but could NOT send back. Advertised
-            // so the other end can say "the tab answered and the reply was lost" instead of
-            // asserting the unestablished "the tab may be backgrounded or frozen".
-            // Same cross-bridge/age rule the replay uses (codex): these summaries ride the
-            // hello, so an unfiltered list would tell a bridge that never owned these
-            // commands their ids, names and outcomes even though the replies are withheld.
-            lostReplies: lostReplies.summaries({
-              now: Date.now(),
-              targetUrl: sock?.__cmcpBridgeUrl ?? url,
-              // #694 — the SAME session rule as the replay: an orchestrator that
-              // restarted (new handshake epoch) learns nothing about its
-              // predecessor's lost outcomes.
-              targetEpoch: sock?.__cmcpBridgeEpoch,
-            }),
+            // #508/#694 — NO lostReplies summaries here: the hello fires at
+            // socket-open, BEFORE the models handshake stamps this socket's session
+            // epoch, so any summary computed now is filtered with an unknown epoch
+            // and can contradict the epoch-filtered replay (the #694 divergence).
+            // The summaries ride the post-handshake `lost_replies` frame sent from
+            // replayLostReplies, computed with the SAME epoch the replay uses.
           }),
         ),
       );

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10337,6 +10337,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     // The bridge THIS socket belongs to (stamped at creation), not the mutable current
     // `url` — after setUrl the two can differ while the old socket is still closing.
     const targetUrl = target?.__cmcpBridgeUrl ?? url;
+    // #694 — the orchestrator SESSION this socket belongs to (stamped from its models
+    // handshake), so a restart at the same URL never inherits its predecessor's journal.
+    const targetEpoch = target?.__cmcpBridgeEpoch;
     let sent = 0;
     let dropped = 0;
     const keep = [];
@@ -10347,14 +10350,18 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // not a recovery. Such an entry is also meaningless there — its rid is unknown — so
       // it is dropped rather than carried forever. (Sensitive results are additionally
       // redacted at journal time and never travel at all.)
-      // Replayable = SAME bridge AND recent enough (codex). A bridge is identified by its
-      // URL, and URL equality is ENDPOINT identity, not SESSION identity — a newly started
-      // orchestrator on the same address looks exactly like the old one reconnecting, which
-      // is the very case replay exists to serve. Proving session continuity needs a
-      // server-issued connection epoch in the handshake (an orchestrator-side follow-up), so
-      // until then the exposure is bounded: sensitive results never enter the journal at
-      // all, this runs only AFTER a real handshake, and stale entries age out here.
-      if (!isReplayable(entry, { now: Date.now(), targetUrl })) {
+      // Replayable = SAME bridge AND SAME session AND recent enough (codex, #694).
+      // A bridge is identified by its URL, and URL equality is ENDPOINT identity,
+      // not SESSION identity — a newly started orchestrator on the same address
+      // looks exactly like the old one reconnecting, which is the very case replay
+      // exists to serve. Session continuity is now PROVEN by the server-issued
+      // epoch on the models handshake (#694): a restart mints a fresh epoch, so a
+      // predecessor session's entry fails the check and is dropped. A legacy
+      // orchestrator sends no epoch — absent on both sides compares equal, and
+      // the residual bounds below are exactly the pre-epoch ones: sensitive
+      // results never enter the journal at all, this runs only AFTER a real
+      // handshake, and stale entries age out here.
+      if (!isReplayable(entry, { now: Date.now(), targetUrl, targetEpoch })) {
         dropped++;
         continue;
       }
@@ -10503,6 +10510,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           // Stamp the bridge this outcome belongs to so a replay can never cross it. THIS
           // socket's url, never the mutable current one (codex).
           url: socketUrl,
+          // #694 — …and the orchestrator SESSION (the models-handshake epoch stamped
+          // on THIS socket), so a replay can never cross a RESTART at the same URL
+          // either. Absent on a legacy orchestrator — recorded as absent, which
+          // compares equal to an epoch-less target and replays exactly as before.
+          epoch: thisSock.__cmcpBridgeEpoch,
         }),
       );
       return false;
@@ -10572,8 +10584,20 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         // execution is still in flight) on THIS socket — no second executor
         // run, no second activity card — while a rid reused for DIFFERENT work
         // falls through and executes fresh (logged once by the ledger).
+        // #694 — the orchestrator never REUSES a rid (#683/#687): a timed-out
+        // command is retried under a FRESH rid plus `retry_of` naming the
+        // original. `retry_of` is excluded from the fingerprint, so the retry
+        // fingerprints identically and is answered from the ORIGINAL's ledger
+        // entry (settled reply or in-flight promise — the await below handles
+        // both). An unknown/evicted retry_of misses and falls through to
+        // begin + execute fresh — the ledger fails open, never closed.
         const fingerprint = commandFingerprint(msg);
-        const priorRidReply = commandRidLedger.get(msg.rid, fingerprint);
+        let priorRidReply = commandRidLedger.get(msg.rid, fingerprint);
+        let retryOfHit = false;
+        if (priorRidReply === undefined && typeof msg.retry_of === "string") {
+          priorRidReply = commandRidLedger.get(msg.retry_of, fingerprint);
+          retryOfHit = priorRidReply !== undefined;
+        }
         if (priorRidReply !== undefined) {
           let dupReply;
           try {
@@ -10582,8 +10606,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             return; // ledger promises never reject — defensive only
           }
           if (!isActive()) return; // superseded socket — ignore its late frames
+          // Rid REWRITE on a retry hit (#694): the ledger reply is correlated
+          // to the ORIGINAL rid, but the orchestrator's pending map is waiting
+          // on the retry's fresh rid — answer under THAT rid or the retry
+          // still times out.
+          const outReply = retryOfHit ? { ...dupReply, rid: msg.rid } : dupReply;
           try {
-            if (thisSock.readyState === WebSocket.OPEN) thisSock.send(JSON.stringify(dupReply));
+            if (thisSock.readyState === WebSocket.OPEN) thisSock.send(JSON.stringify(outReply));
           } catch {
             // Socket died between receive and reply — agent side times out.
           }
@@ -10904,6 +10933,18 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // orchestrator HANDSHAKE — receiving it proves a real panel agent is behind
       // the socket, so it's the moment we truthfully flip to "connected".
       if (msg && msg.type === "models" && Array.isArray(msg.models)) {
+        // #694 — stamp the orchestrator's SESSION epoch BEFORE markConnected()
+        // fires the lost-reply replay: isReplayable compares each journaled
+        // entry's epoch against THIS socket's, so an orchestrator RESTART (which
+        // mints a fresh epoch) drops its predecessor's journal instead of
+        // replaying another session's replies into it. A legacy orchestrator
+        // sends no epoch — undefined on both sides compares equal, preserving
+        // the pre-epoch behaviour exactly.
+        try {
+          thisSock.__cmcpBridgeEpoch = msg.epoch;
+        } catch {
+          /* exotic WebSocket impl — epoch matching stays absent/absent */
+        }
         markConnected();
         onModels?.(
           msg.models,
@@ -11064,6 +11105,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             lostReplies: lostReplies.summaries({
               now: Date.now(),
               targetUrl: sock?.__cmcpBridgeUrl ?? url,
+              // #694 — the SAME session rule as the replay: an orchestrator that
+              // restarted (new handshake epoch) learns nothing about its
+              // predecessor's lost outcomes.
+              targetEpoch: sock?.__cmcpBridgeEpoch,
             }),
           }),
         ),

--- a/web/js/lib/command-dedupe.js
+++ b/web/js/lib/command-dedupe.js
@@ -15,13 +15,24 @@
 // executor again (so no second mutation and no duplicate activity card).
 //
 // The dedupe identity is rid + PAYLOAD FINGERPRINT (commandFingerprint below:
-// the frame minus `rid`, canonical-stringified). The bridge's re-dispatch of
-// the SAME logical command reproduces the frame exactly, so it dedupes — but a
-// rid arriving with a MISMATCHED fingerprint is NOT the same command (a
-// genuinely new command that happens to reuse a prior rid: re-targeted or
-// replaced socket, different workflow). It is never answered from the ledger:
-// it executes fresh, and the reuse is logged once via onRidReuse (the bridge
-// should only ever re-dispatch the SAME command under a reused rid).
+// the frame minus `rid` and `retry_of`, canonical-stringified). The bridge's
+// re-dispatch of the SAME logical command reproduces the frame exactly, so it
+// dedupes — but a rid arriving with a MISMATCHED fingerprint is NOT the same
+// command (a genuinely new command that happens to reuse a prior rid:
+// re-targeted or replaced socket, different workflow). It is never answered
+// from the ledger: it executes fresh, and the reuse is logged once via
+// onRidReuse (the bridge should only ever re-dispatch the SAME command under a
+// reused rid).
+//
+// #694 — the orchestrator NEVER reuses rids (#683/#687): a timed-out command is
+// retried under a FRESH rid plus `retry_of` pointing at the original rid.
+// `retry_of` is correlation metadata, the same class as `rid`, so it is
+// excluded from the fingerprint too — a retry fingerprints IDENTICALLY to the
+// command it retries, and the handler answers it from the original's ledger
+// entry (with the rid rewritten to the retry's, which is what the
+// orchestrator's pending map is waiting on). A genuinely fresh command with
+// identical args carries no `retry_of`: it shares the fingerprint but misses
+// on its new rid, so it executes.
 //
 // Bounded: oldest-first eviction of SETTLED entries — swept on every begin AND
 // every settle (a past-cap burst of concurrent in-flight commands has nothing
@@ -46,14 +57,18 @@ function stableStringify(value) {
 
 /**
  * Fingerprint of a command frame's IDENTITY: every field except the transport
- * `rid` (cmd + all args + the bridge-stamped workflow_uuid), canonicalized so
- * key insertion order doesn't matter. The bridge's re-dispatch of the SAME
- * logical command yields an identical fingerprint; any genuinely different
- * command — even one differing only in workflow_uuid — differs here too.
+ * `rid` and the retry-correlation `retry_of` (#694 — both are metadata, not
+ * command identity), i.e. cmd + all args + the bridge-stamped workflow_uuid,
+ * canonicalized so key insertion order doesn't matter. The bridge's re-dispatch
+ * of the SAME logical command yields an identical fingerprint — including a
+ * retry under a FRESH rid, which differs from the original ONLY in rid +
+ * retry_of — while any genuinely different command, even one differing only in
+ * workflow_uuid, differs here too.
  */
 export function commandFingerprint(msg) {
   const identity = { ...msg };
   delete identity.rid; // transport correlation only — NOT part of command identity
+  delete identity.retry_of; // #694 — retry correlation only — same class as rid
   return stableStringify(identity);
 }
 

--- a/web/js/lib/command-liveness.js
+++ b/web/js/lib/command-liveness.js
@@ -131,7 +131,7 @@ export function createLostReplyJournal({ cap = LOST_REPLY_CAP } = {}) {
      *  it can be re-sent verbatim on the next socket: rids are random UUIDs, so an
      *  orchestrator that no longer knows the rid simply drops it, and one that still has
      *  the command pending resolves it with its TRUE outcome. */
-    record({ reply, cmd, reason, at = 0, url } = {}) {
+    record({ reply, cmd, reason, at = 0, url, epoch } = {}) {
       if (!reply || typeof reply !== "object" || typeof reply.rid !== "string") return null;
       const safe = redactSensitiveReply(reply, cmd);
       const entry = {
@@ -146,6 +146,13 @@ export function createLostReplyJournal({ cap = LOST_REPLY_CAP } = {}) {
         // switch or a Bridge-URL change the next socket is a different orchestrator, and
         // volunteering another session's result to it is a leak, not a recovery (codex).
         url: typeof url === "string" && url ? url : null,
+        // #694 — the orchestrator SESSION this outcome belongs to (the epoch stamped on
+        // the models handshake). URL equality is only ENDPOINT identity: a restarted
+        // orchestrator at the same address mints a fresh epoch, and its predecessor's
+        // journal must never replay into the new session. A legacy orchestrator sends
+        // no epoch — absent here and absent on the target socket compare EQUAL, which
+        // preserves the pre-epoch (URL-only) behaviour exactly.
+        epoch: typeof epoch === "string" || typeof epoch === "number" ? epoch : undefined,
         redacted: safe !== reply,
         reply: safe,
       };
@@ -160,12 +167,14 @@ export function createLostReplyJournal({ cap = LOST_REPLY_CAP } = {}) {
     /** Wire summaries — the raw `reply` payload is NOT included (it can be large, and for
      *  a sensitive command it is exactly what must not travel).
      *
-     *  Pass `{ now, targetUrl }` to apply the SAME cross-bridge/age rule the replay uses
-     *  (codex): the summaries ride the hello, so without this a bridge that never owned
-     *  these commands would still learn their ids, names and outcomes even though the
-     *  replies themselves are correctly withheld. */
-    summaries({ now, targetUrl } = {}) {
-      const visible = targetUrl ? entries.filter((e) => isReplayable(e, { now, targetUrl })) : entries;
+     *  Pass `{ now, targetUrl, targetEpoch }` to apply the SAME cross-bridge/session/age
+     *  rule the replay uses (codex, #694): the summaries ride the hello, so without this
+     *  a bridge that never owned these commands would still learn their ids, names and
+     *  outcomes even though the replies themselves are correctly withheld. */
+    summaries({ now, targetUrl, targetEpoch } = {}) {
+      const visible = targetUrl
+        ? entries.filter((e) => isReplayable(e, { now, targetUrl, targetEpoch }))
+        : entries;
       return visible.map(({ rid, cmd, ok, reason, at }) => ({ rid, cmd, ok, reason, at }));
     },
     /** Take everything and empty the journal (used when replaying onto a new socket, so
@@ -192,35 +201,37 @@ export function createLostReplyJournal({ cap = LOST_REPLY_CAP } = {}) {
  * reconnect happen in seconds; anything older almost certainly belongs to an orchestrator
  * that is gone.
  *
- * This bounds a residual the panel cannot fully close on its own (codex): a bridge is
- * identified by its URL, and URL equality is ENDPOINT identity, not SESSION identity — a
- * newly started orchestrator listening at the same address is indistinguishable from the
- * same one reconnecting, which is precisely the case replay exists to serve. Proving
- * session continuity needs a server-issued connection epoch in the handshake, i.e. an
- * orchestrator-side change (tracked as a follow-up). Until then the exposure is bounded
- * four ways: sensitive results never enter the journal at all; replay goes ONLY to the
- * exact socket instance that completed a handshake; entries age out here; and the window
- * is deliberately tight — a drop, reconnect and handshake take a couple of seconds, so 20s
+ * Session continuity is proven by the server-issued epoch on the models handshake
+ * (#694): an orchestrator RESTART mints a fresh epoch, so a predecessor session's
+ * journal entries fail isReplayable and are dropped rather than replayed into the new
+ * session at the same address. The age bound here remains the backstop for a LEGACY
+ * orchestrator that sends no epoch (absent on both sides compares equal — URL-only
+ * matching, exactly the pre-epoch behaviour), bounding that residual four ways:
+ * sensitive results never enter the journal at all; replay goes ONLY to the exact
+ * socket instance that completed a handshake; entries age out here; and the window is
+ * deliberately tight — a drop, reconnect and handshake take a couple of seconds, so 20s
  * is generous for the case this serves while leaving little room for an orchestrator to
  * restart and re-bind inside it.
- *
- * The residual, stated plainly: if the orchestrator restarts on the SAME address within
- * this window, its successor can receive one non-sensitive result belonging to the previous
- * session. It cannot resolve any of its own commands with it (rids are random UUIDs) and it
- * cannot double-apply anything (a reply is not a command). Closing the residual entirely
- * requires the handshake epoch above; discarding on unprovable continuity instead would
- * discard the ordinary reconnect too, which is the whole case this exists to serve.
  */
 export const REPLAY_MAX_AGE_MS = 20000;
 
 /**
  * May this journaled outcome be replayed onto a socket for `targetUrl` right now?
- * Requires the SAME bridge and a recent enough entry. An entry with no recorded bridge is
- * refused: unattributable outcomes are never volunteered.
+ * Requires the SAME bridge, the SAME orchestrator session (#694 — entry.epoch must
+ * equal the target socket's handshake epoch; both absent compares equal, so a legacy
+ * epoch-less orchestrator keeps the pre-epoch URL-only behaviour) and a recent enough
+ * entry. An entry with no recorded bridge is refused: unattributable outcomes are
+ * never volunteered.
  */
-export function isReplayable(entry, { now = 0, targetUrl = null, maxAgeMs = REPLAY_MAX_AGE_MS } = {}) {
+export function isReplayable(entry, { now = 0, targetUrl = null, targetEpoch, maxAgeMs = REPLAY_MAX_AGE_MS } = {}) {
   if (!entry) return false;
   if (!entry.url || !targetUrl || entry.url !== targetUrl) return false;
+  // #694 — SESSION identity on top of endpoint identity: an orchestrator that
+  // restarted at the same URL handshakes with a FRESH epoch, so its predecessor's
+  // entries must not replay into it. One-sided presence (an epoch'd entry vs an
+  // epoch-less target, or vice versa) fails CLOSED — that pairing can never prove
+  // session continuity.
+  if (entry.epoch !== targetEpoch) return false;
   const age = Number.isFinite(now) && Number.isFinite(entry.at) ? now - entry.at : null;
   if (age === null) return false;
   const limit = Number.isFinite(maxAgeMs) && maxAgeMs > 0 ? maxAgeMs : REPLAY_MAX_AGE_MS;

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -333,10 +333,16 @@ export function buildHelloPayload({
     frame.workflow_uuid = workflowUuid.trim();
   }
   // #508 — command outcomes this tab COMPLETED but could not deliver (the socket closed
-  // or was superseded mid-command). Advertising them at re-registration lets the other
-  // end reconcile "the reply was lost" against its own timed-out commands instead of
-  // asserting the unestablished "the tab may be backgrounded or frozen". Omitted when
-  // empty so the common hello is unchanged.
+  // or was superseded mid-command). Advertising them lets the other end reconcile "the
+  // reply was lost" against its own timed-out commands instead of asserting the
+  // unestablished "the tab may be backgrounded or frozen". Omitted when empty so the
+  // common hello is unchanged.
+  // #694 — the panel no longer passes this on the hello: the hello fires at socket-open,
+  // BEFORE the models handshake stamps the socket's session epoch, so a hello-carried
+  // summary is filtered with an unknown epoch and can contradict the epoch-filtered
+  // replay. The summaries ride the post-handshake `lost_replies` frame (sent from
+  // replayLostReplies with the SAME epoch filter the replay uses). The field remains
+  // supported here for any caller whose timing is already post-handshake.
   if (Array.isArray(lostReplies) && lostReplies.length) {
     frame.lost_replies = lostReplies;
   }


### PR DESCRIPTION
Panel half of artokun/comfyui-mcp#694. The orchestrator half (sibling PR in comfyui-mcp) retries a timed-out command under a FRESH rid plus `retry_of` naming the original — it never reuses rids (#683/#687) — and stamps a session `epoch` on the `models` handshake. This PR teaches the panel both halves of that contract.

## Retry identity (`retry_of`)

- `commandFingerprint` (web/js/lib/command-dedupe.js) now deletes `retry_of` alongside `rid` before canonicalizing — both are correlation metadata, not command identity. A retry therefore fingerprints **identically** to its original.
- The frame handler (web/js/comfyui-mcp-panel.js) keeps the existing `ledger.get(msg.rid, fingerprint)` first; on a miss and `typeof msg.retry_of === "string"` it tries `ledger.get(msg.retry_of, fingerprint)`.
  - **Hit** (settled reply or in-flight promise — the existing await handles both): sends `{ ...dupReply, rid: msg.rid }`. The rid rewrite matters — the orchestrator's pending map is waiting on the retry's fresh rid. Executor never re-runs: no double-applied mutation.
  - **Miss** (unknown/evicted token): falls through to `begin` + execute fresh. The ledger fails open, never closed.
- A genuinely fresh command with identical args (no `retry_of`) shares the fingerprint but misses on its new rid and executes, as it must. Same-rid verbatim replay (#521) is untouched.

## Session epoch (replay gating)

- The `models` branch stamps `thisSock.__cmcpBridgeEpoch = msg.epoch` **before** `markConnected()` fires the lost-reply replay.
- `lostReplies.record` journals the current socket's epoch; `isReplayable` gains `entry.epoch !== targetEpoch → false`, applied identically in `summaries` so `hello.lost_replies` filters the same way.
- Backward compat: epoch absent on both sides compares equal — a legacy orchestrator gets exactly today's URL+age behaviour. A restart mints a new epoch, so the old session's journal is dropped instead of replayed into its successor at the same URL (closes the residual the code comments previously flagged as needing a server-issued epoch).

## Tests

`npm run test:unit` — 1503 pass (11 new, 2 wiring regexes updated); `npm run typecheck` clean.

New coverage:
- fingerprint excludes `retry_of`; retry of a settled command → original reply, rid rewritten, executor not re-run; retry of an in-flight command → awaited, same result; unknown `retry_of` → executes fresh; identical-args fresh command after a settled one → executes again; same-rid verbatim replay (#521) unchanged
- `isReplayable`: epoch match replays, mismatch drops, both-absent replays (legacy), one-sided presence fails closed; journal records epoch and summaries filter by it
- source-wiring: epoch stamped before the replay fires, journal stamps this socket's epoch, replay compares the target socket's epoch, handler falls back to `retry_of` and rewrites the rid