### PR TITLE
fix(panel): prevent dirty graph-binding false positives (#545)

### DIFF
--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -26,6 +26,14 @@ import {
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
 
+function panelFunctionSource(src, name, nextName) {
+  const start = src.indexOf(`function ${name}(`);
+  const end = src.indexOf(`function ${nextName}(`, start);
+  assert.notEqual(start, -1, `could not locate ${name} in panel source`);
+  assert.notEqual(end, -1, `could not locate ${nextName} after ${name}`);
+  return src.slice(start, end);
+}
+
 // A ComfyUI ChangeTracker-shaped workflow: serialized graph states hang off
 // `changeTracker.activeState` / `.initialState` (and some builds hang them flat).
 const wf = (over = {}) => ({ changeTracker: {}, ...over });
@@ -361,6 +369,72 @@ test("#545 wiring: dirty tracker state is inconclusive, but an established workf
     body,
     /currentStateTrustworthy &&\s*includeBaselineReadGuard &&\s*graphReadDesynced/,
     "the old node-count baseline guard must not reject a dirty canvas from stale tracker state",
+  );
+});
+
+test("#545 P1: command identity resolution cannot adopt a stale dirty root before the binding fence", () => {
+  // This drives the actual panel resolver followed by the actual panel fence in
+  // the same order bridge dispatch uses. It reproduces the P1: active dirty A
+  // has not been seen yet, while app.graph still holds B. If workflowStableUuid
+  // reads or rewrites that root, the fence sees A as B and graph mutation passes.
+  const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+  const stableSource = panelFunctionSource(src, "workflowStableUuid", "workflowStorageKey");
+  const fenceSource = panelFunctionSource(src, "assertGraphBoundToActiveWorkflow", "getPiniaStore");
+  const workflowA = { isPersisted: false, isModified: true, changeTracker: { activeState: state(27) } };
+  const rootB = {
+    _nodes: Array.from({ length: 30 }, (_, i) => ({ id: i + 1, type: "KSampler" })),
+    extra: { comfyui_mcp: { workflow_uuid: "workflow-B" } },
+  };
+  const objectUuids = new WeakMap();
+  let minted = 0;
+  const stableUuid = new Function(
+    "app",
+    "getTabId",
+    "savedWorkflowPath",
+    "_workflowObjectUuids",
+    "embeddedWorkflowUuid",
+    "resolveUnsavedInstanceUuid",
+    "_loadGraphDataForkInstalled",
+    "rememberWorkflowUuidOwner",
+    "workflowOwnedExtra",
+    "crypto",
+    `${stableSource}\nreturn workflowStableUuid;`,
+  )(
+    { graph: rootB },
+    () => "fallback-tab",
+    () => null,
+    objectUuids,
+    (_wf, { allowGraph }) => (allowGraph ? rootB.extra.comfyui_mcp.workflow_uuid : null),
+    ({ objectUuid, embeddedId, forkActive }) => objectUuid || (forkActive && embeddedId) || `workflow-A-${++minted}`,
+    true,
+    () => {},
+    () => null,
+    { randomUUID: () => `workflow-A-${++minted}` },
+  );
+  const assertBound = new Function(
+    "activeWorkflowRef",
+    "_workflowObjectUuids",
+    "graphRootWorkflowUuidMismatches",
+    "graphRootMismatchesActiveWorkflow",
+    "graphReadDesynced",
+    "activeWorkflowNodeCount",
+    `${fenceSource}\nreturn assertGraphBoundToActiveWorkflow;`,
+  )(
+    () => workflowA,
+    objectUuids,
+    graphRootWorkflowUuidMismatches,
+    graphRootMismatchesActiveWorkflow,
+    graphReadDesynced,
+    activeWorkflowNodeCount,
+  );
+
+  const activeUuid = stableUuid(workflowA);
+  assert.notEqual(activeUuid, "workflow-B", "the stale root must not establish A's identity");
+  assert.equal(rootB.extra.comfyui_mcp.workflow_uuid, "workflow-B", "identity resolution must not rewrite the foreign root");
+  assert.throws(
+    () => assertBound(rootB, rootB, { includeBaselineReadGuard: false }),
+    /NOT applied/,
+    "the positive B-vs-A UUID mismatch must stop the graph command after resolution",
   );
 });
 

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -19,6 +19,7 @@ import {
   activeWorkflowNodeCount,
   graphReadDesynced,
   graphRootMismatchesActiveWorkflow,
+  graphRootWorkflowUuidMismatches,
   graphReadBindingChanged,
 } from "../../web/js/lib/graph-binding.js";
 
@@ -301,6 +302,65 @@ test("graphRootMismatchesActiveWorkflow: FALSE - initialState is a baseline, not
       activeWorkflow,
     }),
     false,
+  );
+});
+
+test("#545: a DIRTY workflow's tracker state may lag legitimate canvas edits, so it is never a binding refusal", () => {
+  const staleTrackerState = {
+    nodes: Array.from({ length: 27 }, (_, i) => ({ id: i + 1, type: "KSampler" })),
+    links: [],
+  };
+  const actualDirtyCanvas = {
+    nodes: Array.from({ length: 30 }, (_, i) => ({ id: i + 1, type: "KSampler" })),
+    links: [],
+  };
+  const activeWorkflow = wf({ changeTracker: { activeState: staleTrackerState }, isModified: true });
+  assert.equal(
+    graphRootMismatchesActiveWorkflow({ rootGraph: serializedRoot(actualDirtyCanvas), activeWorkflow }),
+    false,
+    "a dirty tab's cached ChangeTracker state is not proof that its live canvas is another workflow",
+  );
+});
+
+test("#545: a DIRTY workflow still rejects a root positively identified as another workflow", () => {
+  const rootGraph = {
+    _nodes: [{ id: 1, type: "KSampler" }],
+    extra: { comfyui_mcp: { workflow_uuid: "workflow-B" } },
+  };
+  assert.equal(
+    graphRootWorkflowUuidMismatches({ rootGraph, activeWorkflowUuid: "workflow-A" }),
+    true,
+    "a durable root UUID disagreement remains a real wrong-canvas proof even while dirty",
+  );
+  assert.equal(graphRootWorkflowUuidMismatches({ rootGraph, activeWorkflowUuid: "workflow-B" }), false);
+  assert.equal(graphRootWorkflowUuidMismatches({ rootGraph, activeWorkflowUuid: null }), false);
+  assert.equal(graphRootWorkflowUuidMismatches({ rootGraph: {}, activeWorkflowUuid: "workflow-A" }), false);
+});
+
+test("#545 wiring: dirty tracker state is inconclusive, but an established workflow UUID still fences a foreign root", () => {
+  const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+  const start = src.indexOf("function assertGraphBoundToActiveWorkflow(");
+  assert.notEqual(start, -1);
+  const body = src.slice(start, src.indexOf("\n}\n", start));
+  assert.match(
+    body,
+    /const activeWorkflowUuid = activeWorkflow \? _workflowObjectUuids\.get\(activeWorkflow\) : null;/,
+    "the fence must use only the already-established object UUID, never derive one from a possibly stale root",
+  );
+  assert.match(
+    body,
+    /graphRootWorkflowUuidMismatches\(\{ rootGraph, activeWorkflowUuid \}\)/,
+    "a dirty tab retains the positive foreign-root identity fence",
+  );
+  assert.match(
+    body,
+    /const currentStateTrustworthy = activeWorkflow\?\.isModified !== true;/,
+    "a dirty ChangeTracker snapshot is not trustworthy as a binding proof",
+  );
+  assert.match(
+    body,
+    /currentStateTrustworthy &&\s*includeBaselineReadGuard &&\s*graphReadDesynced/,
+    "the old node-count baseline guard must not reject a dirty canvas from stale tracker state",
   );
 });
 

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -20,6 +20,7 @@ import {
   graphReadDesynced,
   graphRootMismatchesActiveWorkflow,
   graphRootWorkflowUuidMismatches,
+  graphRootWorkflowUuidMatches,
   graphReadBindingChanged,
 } from "../../web/js/lib/graph-binding.js";
 
@@ -34,14 +35,14 @@ function panelFunctionSource(src, name, nextName) {
   return src.slice(start, end);
 }
 
-function buildDirtyStaleRouteHarness() {
+function buildDirtyStaleRouteHarness({ rootUuid = "workflow-B" } = {}) {
   const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
   const stableSource = panelFunctionSource(src, "workflowStableUuid", "workflowStorageKey");
   const fenceSource = panelFunctionSource(src, "assertGraphBoundToActiveWorkflow", "getPiniaStore");
   const workflowA = { isPersisted: false, isModified: true, changeTracker: { activeState: state(27) } };
   const rootB = {
     _nodes: Array.from({ length: 30 }, (_, i) => ({ id: i + 1, type: "KSampler" })),
-    extra: { comfyui_mcp: { workflow_uuid: "workflow-B" } },
+    ...(rootUuid ? { extra: { comfyui_mcp: { workflow_uuid: rootUuid } } } : {}),
   };
   const objectUuids = new WeakMap();
   let minted = 0;
@@ -62,7 +63,7 @@ function buildDirtyStaleRouteHarness() {
     () => "fallback-tab",
     () => null,
     objectUuids,
-    (_wf, { allowGraph }) => (allowGraph ? rootB.extra.comfyui_mcp.workflow_uuid : null),
+    (_wf, { allowGraph }) => (allowGraph ? rootB.extra?.comfyui_mcp?.workflow_uuid : null),
     ({ objectUuid, embeddedId, forkActive }) => objectUuid || (forkActive && embeddedId) || `workflow-A-${++minted}`,
     true,
     () => {},
@@ -74,6 +75,7 @@ function buildDirtyStaleRouteHarness() {
     "_workflowObjectUuids",
     "workflowStableUuid",
     "graphRootWorkflowUuidMismatches",
+    "graphRootWorkflowUuidMatches",
     "graphRootMismatchesActiveWorkflow",
     "graphReadDesynced",
     "activeWorkflowNodeCount",
@@ -83,6 +85,7 @@ function buildDirtyStaleRouteHarness() {
     objectUuids,
     stableUuid,
     graphRootWorkflowUuidMismatches,
+    graphRootWorkflowUuidMatches,
     graphRootMismatchesActiveWorkflow,
     graphReadDesynced,
     activeWorkflowNodeCount,
@@ -399,6 +402,9 @@ test("#545: a DIRTY workflow still rejects a root positively identified as anoth
   assert.equal(graphRootWorkflowUuidMismatches({ rootGraph, activeWorkflowUuid: "workflow-B" }), false);
   assert.equal(graphRootWorkflowUuidMismatches({ rootGraph, activeWorkflowUuid: null }), false);
   assert.equal(graphRootWorkflowUuidMismatches({ rootGraph: {}, activeWorkflowUuid: "workflow-A" }), false);
+  assert.equal(graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid: "workflow-A" }), false);
+  assert.equal(graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid: "workflow-B" }), true);
+  assert.equal(graphRootWorkflowUuidMatches({ rootGraph: {}, activeWorkflowUuid: "workflow-A" }), false);
 });
 
 test("#545 wiring: dirty tracker state is inconclusive, but an established workflow UUID still fences a foreign root", () => {
@@ -418,6 +424,11 @@ test("#545 wiring: dirty tracker state is inconclusive, but an established workf
   );
   assert.match(
     body,
+    /requireDirtyMutationBinding[\s\S]*!graphRootWorkflowUuidMatches\(\{ rootGraph, activeWorkflowUuid \}\)/,
+    "a dirty mutation must require a positive root-to-active UUID match, not merely no mismatch",
+  );
+  assert.match(
+    body,
     /const currentStateTrustworthy = activeWorkflow\?\.isModified !== true;/,
     "a dirty ChangeTracker snapshot is not trustworthy as a binding proof",
   );
@@ -425,6 +436,27 @@ test("#545 wiring: dirty tracker state is inconclusive, but an established workf
     body,
     /currentStateTrustworthy &&\s*includeBaselineReadGuard &&\s*graphReadDesynced/,
     "the old node-count baseline guard must not reject a dirty canvas from stale tracker state",
+  );
+});
+
+test("#545 P1: an untagged stale root is refused for dirty mutations but a proven dirty root remains editable", () => {
+  const unbound = buildDirtyStaleRouteHarness({ rootUuid: null });
+  assert.throws(
+    () => unbound.assertBound(unbound.rootB, unbound.rootB, {
+      includeBaselineReadGuard: false,
+      requireDirtyMutationBinding: true,
+    }),
+    /NOT applied/,
+    "dirty A must not mutate an untagged stale B just because tracker comparison is unavailable",
+  );
+  const bound = buildDirtyStaleRouteHarness({ rootUuid: "workflow-A" });
+  bound.objectUuids.set(bound.workflowA, "workflow-A");
+  assert.doesNotThrow(
+    () => bound.assertBound(bound.rootB, bound.rootB, {
+      includeBaselineReadGuard: false,
+      requireDirtyMutationBinding: true,
+    }),
+    "the #545 dirty-edit case remains available once the live root positively matches A",
   );
 });
 
@@ -445,8 +477,8 @@ test("#545 P1: command identity resolution cannot adopt a stale dirty root befor
   );
 });
 
-test("#545 P1: direct snapshot restore establishes identity and refuses dirty A over stale B", () => {
-  const { src, workflowA, rootB, objectUuids, assertBound } = buildDirtyStaleRouteHarness();
+test("#545 P1: direct snapshot restore refuses an untagged stale B for dirty A", () => {
+  const { src, workflowA, rootB, objectUuids, assertBound } = buildDirtyStaleRouteHarness({ rootUuid: null });
   let loads = 0;
   const restoreSource = panelFunctionSource(src, "restoreSnapshot", "revertGraphToLastSnapshot");
   const restoreSnapshot = new Function(
@@ -465,13 +497,13 @@ test("#545 P1: direct snapshot restore establishes identity and refuses dirty A 
     null,
     "the local restore path catches the binding refusal instead of loading B into A",
   );
-  assert.notEqual(objectUuids.get(workflowA), "workflow-B", "the direct guard must root-blindly establish A");
-  assert.equal(rootB.extra.comfyui_mcp.workflow_uuid, "workflow-B", "the stale root remains untouched");
+  assert.ok(objectUuids.get(workflowA), "the direct guard must root-blindly establish A");
+  assert.equal(rootB.extra?.comfyui_mcp?.workflow_uuid, undefined, "the untagged stale root remains untouched");
   assert.equal(loads, 0, "a refused direct restore must not call loadGraphData");
 });
 
-test("#545 P1: direct CivitAI graph_load establishes identity and refuses dirty A over stale B", async () => {
-  const { src, workflowA, rootB, objectUuids, assertBound } = buildDirtyStaleRouteHarness();
+test("#545 P1: direct CivitAI graph_load refuses an untagged stale B for dirty A", async () => {
+  const { src, workflowA, rootB, objectUuids, assertBound } = buildDirtyStaleRouteHarness({ rootUuid: null });
   let loads = 0;
   const start = src.indexOf("  async graph_load({ graph: incoming } = {}) {");
   const end = src.indexOf("\n\n  graph_connect(", start);
@@ -492,8 +524,8 @@ test("#545 P1: direct CivitAI graph_load establishes identity and refuses dirty 
     /NOT applied/,
     "the CivitAI direct path must stop before loading external JSON into stale B",
   );
-  assert.notEqual(objectUuids.get(workflowA), "workflow-B", "the direct guard must root-blindly establish A");
-  assert.equal(rootB.extra.comfyui_mcp.workflow_uuid, "workflow-B", "the stale root remains untouched");
+  assert.ok(objectUuids.get(workflowA), "the direct guard must root-blindly establish A");
+  assert.equal(rootB.extra?.comfyui_mcp?.workflow_uuid, undefined, "the untagged stale root remains untouched");
   assert.equal(loads, 0, "a refused direct graph_load must not call loadGraphData");
 });
 
@@ -595,7 +627,7 @@ test("#349 wiring: every graph command verifies LiteGraph is bound to the active
   assert.match(handler, /msg\.cmd\.startsWith\("graph_"\)/, "graph commands must have a root-binding fence");
   assert.match(
     handler,
-    /assertGraphBoundToActiveWorkflow\(graph, rootGraph(?:, \{ includeBaselineReadGuard: false \})?\)/,
+    /assertGraphBoundToActiveWorkflow\(graph, rootGraph, \{[\s\S]*requireDirtyMutationBinding: true[\s\S]*\}\)/,
     "the fence must inspect the graph the executor will use",
   );
 });
@@ -605,10 +637,15 @@ test("#349 direct paths: run, CivitAI load, and snapshot restore fence the live 
   const orderedFence = (startNeedle, beforeNeedle) => {
     const start = src.indexOf(startNeedle);
     const before = src.indexOf(beforeNeedle, start);
-    const fence = src.indexOf("assertGraphBoundToActiveWorkflow(graph, rootGraph, { includeBaselineReadGuard: false })", start);
+    const fence = src.indexOf("assertGraphBoundToActiveWorkflow(graph, rootGraph, {", start);
     assert.notEqual(start, -1, `${startNeedle} must exist`);
     assert.notEqual(before, -1, `${beforeNeedle} must follow ${startNeedle}`);
     assert.ok(fence > start && fence < before, `${startNeedle} must fence before ${beforeNeedle}`);
+    assert.match(
+      src.slice(fence, before),
+      /requireDirtyMutationBinding: true/,
+      `${startNeedle} must require a positive binding for dirty mutation`,
+    );
   };
 
   orderedFence("async graph_run({ batch_count, to_node_id })", "app.queuePrompt");
@@ -620,8 +657,13 @@ test("#349 snapshots: capture is bound and restore rejects a snapshot from anoth
   const src = readFileSync(PANEL_JS, "utf8");
   const captureStart = src.indexOf("function captureGraphSnapshot(mid, label)");
   const captureSerialize = src.indexOf("const data = rootGraph.serialize();", captureStart);
-  const captureFence = src.indexOf("assertGraphBoundToActiveWorkflow(graph, rootGraph, { includeBaselineReadGuard: false });", captureStart);
+  const captureFence = src.indexOf("assertGraphBoundToActiveWorkflow(graph, rootGraph, {", captureStart);
   assert.ok(captureStart >= 0 && captureFence > captureStart && captureFence < captureSerialize);
+  assert.match(
+    src.slice(captureFence, captureSerialize),
+    /requireDirtyMutationBinding: true/,
+    "snapshot capture must not record an unbound dirty root for later restore",
+  );
   assert.match(
     src.slice(captureStart, captureSerialize),
     /\[workflowRef\?\.changeTracker\?\.activeState, workflowRef\?\.activeState\]\.find\(/,

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -34,6 +34,62 @@ function panelFunctionSource(src, name, nextName) {
   return src.slice(start, end);
 }
 
+function buildDirtyStaleRouteHarness() {
+  const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+  const stableSource = panelFunctionSource(src, "workflowStableUuid", "workflowStorageKey");
+  const fenceSource = panelFunctionSource(src, "assertGraphBoundToActiveWorkflow", "getPiniaStore");
+  const workflowA = { isPersisted: false, isModified: true, changeTracker: { activeState: state(27) } };
+  const rootB = {
+    _nodes: Array.from({ length: 30 }, (_, i) => ({ id: i + 1, type: "KSampler" })),
+    extra: { comfyui_mcp: { workflow_uuid: "workflow-B" } },
+  };
+  const objectUuids = new WeakMap();
+  let minted = 0;
+  const stableUuid = new Function(
+    "app",
+    "getTabId",
+    "savedWorkflowPath",
+    "_workflowObjectUuids",
+    "embeddedWorkflowUuid",
+    "resolveUnsavedInstanceUuid",
+    "_loadGraphDataForkInstalled",
+    "rememberWorkflowUuidOwner",
+    "workflowOwnedExtra",
+    "crypto",
+    `${stableSource}\nreturn workflowStableUuid;`,
+  )(
+    { graph: rootB },
+    () => "fallback-tab",
+    () => null,
+    objectUuids,
+    (_wf, { allowGraph }) => (allowGraph ? rootB.extra.comfyui_mcp.workflow_uuid : null),
+    ({ objectUuid, embeddedId, forkActive }) => objectUuid || (forkActive && embeddedId) || `workflow-A-${++minted}`,
+    true,
+    () => {},
+    () => null,
+    { randomUUID: () => `workflow-A-${++minted}` },
+  );
+  const assertBound = new Function(
+    "activeWorkflowRef",
+    "_workflowObjectUuids",
+    "workflowStableUuid",
+    "graphRootWorkflowUuidMismatches",
+    "graphRootMismatchesActiveWorkflow",
+    "graphReadDesynced",
+    "activeWorkflowNodeCount",
+    `${fenceSource}\nreturn assertGraphBoundToActiveWorkflow;`,
+  )(
+    () => workflowA,
+    objectUuids,
+    stableUuid,
+    graphRootWorkflowUuidMismatches,
+    graphRootMismatchesActiveWorkflow,
+    graphReadDesynced,
+    activeWorkflowNodeCount,
+  );
+  return { src, workflowA, rootB, objectUuids, stableUuid, assertBound };
+}
+
 // A ComfyUI ChangeTracker-shaped workflow: serialized graph states hang off
 // `changeTracker.activeState` / `.initialState` (and some builds hang them flat).
 const wf = (over = {}) => ({ changeTracker: {}, ...over });
@@ -352,8 +408,8 @@ test("#545 wiring: dirty tracker state is inconclusive, but an established workf
   const body = src.slice(start, src.indexOf("\n}\n", start));
   assert.match(
     body,
-    /const activeWorkflowUuid = activeWorkflow \? _workflowObjectUuids\.get\(activeWorkflow\) : null;/,
-    "the fence must use only the already-established object UUID, never derive one from a possibly stale root",
+    /const activeWorkflowUuid = activeWorkflow\s*\? \(_workflowObjectUuids\.get\(activeWorkflow\) \|\| workflowStableUuid\(activeWorkflow\)\)\s*: null;/,
+    "the fence must establish a missing object UUID through the root-blind resolver, never from a stale root",
   );
   assert.match(
     body,
@@ -377,56 +433,7 @@ test("#545 P1: command identity resolution cannot adopt a stale dirty root befor
   // the same order bridge dispatch uses. It reproduces the P1: active dirty A
   // has not been seen yet, while app.graph still holds B. If workflowStableUuid
   // reads or rewrites that root, the fence sees A as B and graph mutation passes.
-  const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
-  const stableSource = panelFunctionSource(src, "workflowStableUuid", "workflowStorageKey");
-  const fenceSource = panelFunctionSource(src, "assertGraphBoundToActiveWorkflow", "getPiniaStore");
-  const workflowA = { isPersisted: false, isModified: true, changeTracker: { activeState: state(27) } };
-  const rootB = {
-    _nodes: Array.from({ length: 30 }, (_, i) => ({ id: i + 1, type: "KSampler" })),
-    extra: { comfyui_mcp: { workflow_uuid: "workflow-B" } },
-  };
-  const objectUuids = new WeakMap();
-  let minted = 0;
-  const stableUuid = new Function(
-    "app",
-    "getTabId",
-    "savedWorkflowPath",
-    "_workflowObjectUuids",
-    "embeddedWorkflowUuid",
-    "resolveUnsavedInstanceUuid",
-    "_loadGraphDataForkInstalled",
-    "rememberWorkflowUuidOwner",
-    "workflowOwnedExtra",
-    "crypto",
-    `${stableSource}\nreturn workflowStableUuid;`,
-  )(
-    { graph: rootB },
-    () => "fallback-tab",
-    () => null,
-    objectUuids,
-    (_wf, { allowGraph }) => (allowGraph ? rootB.extra.comfyui_mcp.workflow_uuid : null),
-    ({ objectUuid, embeddedId, forkActive }) => objectUuid || (forkActive && embeddedId) || `workflow-A-${++minted}`,
-    true,
-    () => {},
-    () => null,
-    { randomUUID: () => `workflow-A-${++minted}` },
-  );
-  const assertBound = new Function(
-    "activeWorkflowRef",
-    "_workflowObjectUuids",
-    "graphRootWorkflowUuidMismatches",
-    "graphRootMismatchesActiveWorkflow",
-    "graphReadDesynced",
-    "activeWorkflowNodeCount",
-    `${fenceSource}\nreturn assertGraphBoundToActiveWorkflow;`,
-  )(
-    () => workflowA,
-    objectUuids,
-    graphRootWorkflowUuidMismatches,
-    graphRootMismatchesActiveWorkflow,
-    graphReadDesynced,
-    activeWorkflowNodeCount,
-  );
+  const { workflowA, rootB, stableUuid, assertBound } = buildDirtyStaleRouteHarness();
 
   const activeUuid = stableUuid(workflowA);
   assert.notEqual(activeUuid, "workflow-B", "the stale root must not establish A's identity");
@@ -436,6 +443,58 @@ test("#545 P1: command identity resolution cannot adopt a stale dirty root befor
     /NOT applied/,
     "the positive B-vs-A UUID mismatch must stop the graph command after resolution",
   );
+});
+
+test("#545 P1: direct snapshot restore establishes identity and refuses dirty A over stale B", () => {
+  const { src, workflowA, rootB, objectUuids, assertBound } = buildDirtyStaleRouteHarness();
+  let loads = 0;
+  const restoreSource = panelFunctionSource(src, "restoreSnapshot", "revertGraphToLastSnapshot");
+  const restoreSnapshot = new Function(
+    "getGraphCtx",
+    "activeWorkflowRef",
+    "assertGraphBoundToActiveWorkflow",
+    `${restoreSource}\nreturn restoreSnapshot;`,
+  )(
+    () => ({ app: { loadGraphData: () => { loads += 1; } }, graph: rootB, rootGraph: rootB }),
+    () => workflowA,
+    assertBound,
+  );
+
+  assert.equal(
+    restoreSnapshot({ workflowRef: workflowA, data: { nodes: [] } }),
+    null,
+    "the local restore path catches the binding refusal instead of loading B into A",
+  );
+  assert.notEqual(objectUuids.get(workflowA), "workflow-B", "the direct guard must root-blindly establish A");
+  assert.equal(rootB.extra.comfyui_mcp.workflow_uuid, "workflow-B", "the stale root remains untouched");
+  assert.equal(loads, 0, "a refused direct restore must not call loadGraphData");
+});
+
+test("#545 P1: direct CivitAI graph_load establishes identity and refuses dirty A over stale B", async () => {
+  const { src, workflowA, rootB, objectUuids, assertBound } = buildDirtyStaleRouteHarness();
+  let loads = 0;
+  const start = src.indexOf("  async graph_load({ graph: incoming } = {}) {");
+  const end = src.indexOf("\n\n  graph_connect(", start);
+  assert.notEqual(start, -1, "could not locate graph_load executor");
+  assert.notEqual(end, -1, "could not locate graph_load executor boundary");
+  const graphLoadSource = src.slice(start, end);
+  const graphLoad = new Function(
+    "getGraphCtx",
+    "assertGraphBoundToActiveWorkflow",
+    `const GRAPH_TOOL_EXECUTORS = {${graphLoadSource}\n}; return GRAPH_TOOL_EXECUTORS.graph_load;`,
+  )(
+    () => ({ app: { loadGraphData: async () => { loads += 1; } }, graph: rootB, rootGraph: rootB }),
+    assertBound,
+  );
+
+  await assert.rejects(
+    graphLoad({ graph: { nodes: [] } }),
+    /NOT applied/,
+    "the CivitAI direct path must stop before loading external JSON into stale B",
+  );
+  assert.notEqual(objectUuids.get(workflowA), "workflow-B", "the direct guard must root-blindly establish A");
+  assert.equal(rootB.extra.comfyui_mcp.workflow_uuid, "workflow-B", "the stale root remains untouched");
+  assert.equal(loads, 0, "a refused direct graph_load must not call loadGraphData");
 });
 
 test("graphReadBindingChanged: FALSE — same workflow instance and root graph across the await", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -251,6 +251,7 @@ import {
   graphReadDesynced,
   graphRootMismatchesActiveWorkflow,
   graphRootWorkflowUuidMismatches,
+  graphRootWorkflowUuidMatches,
   graphReadBindingChanged,
 } from "./lib/graph-binding.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
@@ -1424,11 +1425,20 @@ function installCreateBoundaryFork(appRef) {
             if (shouldForkInPlaceReload({ cachedUuid: cached, incomingUuid: incoming })) {
               _workflowObjectUuids.delete(workflow); // content replaced in place → drop stale cache
               fork = true;
-            } else if (!cached && typeof incoming === "string" && incoming) {
+            } else if (!cached) {
               // The load call itself binds this serialized graph to `workflow`.
               // Seed from that authoritative pairing, never later from whichever
-              // app.graph happens to be mounted when a command arrives.
-              cacheIncomingUuid = incoming;
+              // app.graph happens to be mounted when a command arrives. Legacy
+              // graph data without an embedded UUID gets a fresh one here, while
+              // this load-to-workflow pairing is still known to be valid.
+              cacheIncomingUuid = typeof incoming === "string" && incoming ? incoming : crypto.randomUUID();
+              const extra =
+                graphData.extra && typeof graphData.extra === "object" ? graphData.extra : (graphData.extra = {});
+              const prev = extra[WORKFLOW_META_NAMESPACE];
+              extra[WORKFLOW_META_NAMESPACE] = {
+                ...(prev && typeof prev === "object" ? prev : {}),
+                [WORKFLOW_UUID_FIELD]: cacheIncomingUuid,
+              };
             }
           }
           if (fork) {
@@ -3979,7 +3989,11 @@ function getGraphCtx() {
 // than return empty". Fail-safe: fires ONLY when the workflow reports N>0 nodes at
 // ROOT scope while the live root graph is empty, so a genuinely-empty / brand-new
 // workflow (and any descended-into empty subgraph) reads `node_count: 0` as before.
-function assertGraphBoundToActiveWorkflow(graph, rootGraph, { includeBaselineReadGuard = true } = {}) {
+function assertGraphBoundToActiveWorkflow(
+  graph,
+  rootGraph,
+  { includeBaselineReadGuard = true, requireDirtyMutationBinding = false } = {},
+) {
   const liveNodeCount = rootGraph?._nodes?.length ?? 0;
   const inSubgraph = !!rootGraph && graph !== rootGraph;
   const activeWorkflow = activeWorkflowRef();
@@ -3992,8 +4006,17 @@ function assertGraphBoundToActiveWorkflow(graph, rootGraph, { includeBaselineRea
     ? (_workflowObjectUuids.get(activeWorkflow) || workflowStableUuid(activeWorkflow))
     : null;
   const currentStateTrustworthy = activeWorkflow?.isModified !== true;
+  // On a dirty tab, ChangeTracker's activeState can lag the live canvas (#545),
+  // so it cannot prove the root belongs to this workflow. Reads remain
+  // availability-oriented, but mutations need a positive UUID match: otherwise
+  // a stale, untagged root B is indistinguishable from A and could be changed.
+  const dirtyMutationBindingUnproven =
+    requireDirtyMutationBinding &&
+    activeWorkflow?.isModified === true &&
+    !graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid });
   if (
     graphRootWorkflowUuidMismatches({ rootGraph, activeWorkflowUuid }) ||
+    dirtyMutationBindingUnproven ||
     graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow }) ||
     (currentStateTrustworthy &&
       includeBaselineReadGuard &&
@@ -4245,7 +4268,10 @@ function captureGraphSnapshot(mid, label) {
       (state) => state && Array.isArray(state.nodes),
     );
     if (!currentState) return null;
-    assertGraphBoundToActiveWorkflow(graph, rootGraph, { includeBaselineReadGuard: false });
+    assertGraphBoundToActiveWorkflow(graph, rootGraph, {
+      includeBaselineReadGuard: false,
+      requireDirtyMutationBinding: true,
+    });
     const data = rootGraph.serialize();
     graphSnapshots.push({ mid, ts: Date.now(), label: (label || "").slice(0, 80), data, workflowRef });
     while (graphSnapshots.length > GRAPH_SNAPSHOTS_MAX) graphSnapshots.shift();
@@ -4266,7 +4292,10 @@ function restoreSnapshot(snap) {
     if (!snap.workflowRef || snap.workflowRef !== activeWorkflowRef()) return null;
     // Revert is a direct local load, not a bridge command. Do not restore a
     // snapshot into a canvas proven to belong to a different active workflow.
-    assertGraphBoundToActiveWorkflow(graph, rootGraph, { includeBaselineReadGuard: false });
+    assertGraphBoundToActiveWorkflow(graph, rootGraph, {
+      includeBaselineReadGuard: false,
+      requireDirtyMutationBinding: true,
+    });
     // Deep-clone so the stored snapshot isn't mutated by the live graph after load.
     // __cmcpNoFork: this reloads the SAME active workflow (a revert), so the create-
     // boundary fork must NOT re-mint its per-instance identity (#570 P0).
@@ -6434,7 +6463,10 @@ const GRAPH_TOOL_EXECUTORS = {
     // This executor is also called directly by the CivitAI workflow picker,
     // bypassing bridge dispatch. Refuse before snapshot/load so that path cannot
     // report a successful load into a stale prior tab (#349).
-    assertGraphBoundToActiveWorkflow(graph, rootGraph, { includeBaselineReadGuard: false });
+    assertGraphBoundToActiveWorkflow(graph, rootGraph, {
+      includeBaselineReadGuard: false,
+      requireDirtyMutationBinding: true,
+    });
     // Accept a JSON string or an object.
     let data = incoming;
     if (typeof data === "string") {
@@ -7574,7 +7606,10 @@ const GRAPH_TOOL_EXECUTORS = {
     // Queueing a stale root would render the wrong workflow even though no graph
     // mutation occurs, so enforce the same current-state binding before prompt
     // construction or queuePrompt can report success (#349).
-    assertGraphBoundToActiveWorkflow(graph, rootGraph, { includeBaselineReadGuard: false });
+    assertGraphBoundToActiveWorkflow(graph, rootGraph, {
+      includeBaselineReadGuard: false,
+      requireDirtyMutationBinding: true,
+    });
     if (typeof app.queuePrompt !== "function") {
       throw new Error("app.queuePrompt is unavailable on this frontend");
     }
@@ -11021,7 +11056,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // against the active workflow's serialized root before its executor.
             if (msg.cmd.startsWith("graph_")) {
               const { graph, rootGraph } = getGraphCtx();
-              assertGraphBoundToActiveWorkflow(graph, rootGraph, { includeBaselineReadGuard: false });
+              assertGraphBoundToActiveWorkflow(graph, rootGraph, {
+                includeBaselineReadGuard: false,
+                requireDirtyMutationBinding: true,
+              });
             }
             // PINNED-TARGET GUARD (#349): a `workflow_path` on the command means the
             // agent's session is pinned to a SPECIFIC workflow. But every executor

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3983,11 +3983,14 @@ function assertGraphBoundToActiveWorkflow(graph, rootGraph, { includeBaselineRea
   const liveNodeCount = rootGraph?._nodes?.length ?? 0;
   const inSubgraph = !!rootGraph && graph !== rootGraph;
   const activeWorkflow = activeWorkflowRef();
-  // #545 — the WeakMap value is the only live-object identity we have already
-  // established for this workflow. Do NOT mint/read one here: if a stale root is
-  // currently mounted, deriving from its embedded metadata would adopt exactly
-  // the wrong graph we are trying to detect. Missing identity stays inconclusive.
-  const activeWorkflowUuid = activeWorkflow ? _workflowObjectUuids.get(activeWorkflow) : null;
+  // Every caller, including direct CivitAI graph_load and local snapshot restore,
+  // must establish the active object identity before relying on a dirty-tab
+  // relaxation. workflowStableUuid is root-blind when this object has no cache:
+  // it can use workflow-owned/load-bound metadata or mint a fresh id, but can
+  // never adopt the stale app.graph.extra we are trying to detect (#545 P1).
+  const activeWorkflowUuid = activeWorkflow
+    ? (_workflowObjectUuids.get(activeWorkflow) || workflowStableUuid(activeWorkflow))
+    : null;
   const currentStateTrustworthy = activeWorkflow?.isModified !== true;
   if (
     graphRootWorkflowUuidMismatches({ rootGraph, activeWorkflowUuid }) ||

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1326,14 +1326,26 @@ function activeWorkflowExtra(wf = activeWorkflowRef(), { create = false } = {}) 
   return candidate && typeof candidate === "object" ? candidate : null;
 }
 
-function embeddedWorkflowUuid(wf = activeWorkflowRef()) {
-  const ns = activeWorkflowExtra(wf)?.[WORKFLOW_META_NAMESPACE];
+// Metadata hung directly off the ComfyWorkflow object is safe to use to identify
+// that object. `app.graph.extra` is deliberately NOT included here: during a
+// tab-switch/reconnect race it can still be the prior tab's graph, so letting it
+// establish a previously-unseen workflow object's UUID would adopt that prior
+// tab before the graph-binding fence can reject it (#545 P1).
+function workflowOwnedExtra(wf = activeWorkflowRef()) {
+  const candidate = wf?.extra || wf?.workflow?.extra || wf?.data?.extra;
+  return candidate && typeof candidate === "object" ? candidate : null;
+}
+
+function embeddedWorkflowUuid(wf = activeWorkflowRef(), { allowGraph = true } = {}) {
+  const extra = allowGraph ? activeWorkflowExtra(wf) : workflowOwnedExtra(wf);
+  const ns = extra?.[WORKFLOW_META_NAMESPACE];
   const id = ns?.[WORKFLOW_UUID_FIELD];
   return typeof id === "string" && id ? id : null;
 }
 
-function embeddedWorkflowPath(wf = activeWorkflowRef()) {
-  const ns = activeWorkflowExtra(wf)?.[WORKFLOW_META_NAMESPACE];
+function embeddedWorkflowPath(wf = activeWorkflowRef(), { allowGraph = true } = {}) {
+  const extra = allowGraph ? activeWorkflowExtra(wf) : workflowOwnedExtra(wf);
+  const ns = extra?.[WORKFLOW_META_NAMESPACE];
   const path = ns?.[WORKFLOW_PATH_FIELD];
   return typeof path === "string" && path ? path : null;
 }
@@ -1390,6 +1402,7 @@ function installCreateBoundaryFork(appRef) {
           //    the prior instance's identity. The embedded value is used ONLY to DETECT the
           //    change; the minted uuid is fresh (never adopted from graph.extra).
           let fork = false;
+          let cacheIncomingUuid = null;
           if (keepInstance && workflow && typeof workflow === "object") {
             // Authoritative identity = the live object's cached uuid (mint one only if this
             // object has never been seen). Stamp it over the incoming value; do NOT fork.
@@ -1411,16 +1424,29 @@ function installCreateBoundaryFork(appRef) {
             if (shouldForkInPlaceReload({ cachedUuid: cached, incomingUuid: incoming })) {
               _workflowObjectUuids.delete(workflow); // content replaced in place → drop stale cache
               fork = true;
+            } else if (!cached && typeof incoming === "string" && incoming) {
+              // The load call itself binds this serialized graph to `workflow`.
+              // Seed from that authoritative pairing, never later from whichever
+              // app.graph happens to be mounted when a command arrives.
+              cacheIncomingUuid = incoming;
             }
           }
           if (fork) {
             const extra =
               graphData.extra && typeof graphData.extra === "object" ? graphData.extra : (graphData.extra = {});
             const prev = extra[WORKFLOW_META_NAMESPACE];
+            const freshUuid = crypto.randomUUID();
             extra[WORKFLOW_META_NAMESPACE] = {
               ...(prev && typeof prev === "object" ? prev : {}),
-              [WORKFLOW_UUID_FIELD]: crypto.randomUUID(),
+              [WORKFLOW_UUID_FIELD]: freshUuid,
             };
+            if (workflow && typeof workflow === "object") {
+              _workflowObjectUuids.set(workflow, freshUuid);
+              rememberWorkflowUuidOwner(freshUuid, workflow);
+            }
+          } else if (cacheIncomingUuid) {
+            _workflowObjectUuids.set(workflow, cacheIncomingUuid);
+            rememberWorkflowUuidOwner(cacheIncomingUuid, workflow);
           }
         }
       } catch {
@@ -1505,7 +1531,12 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
     // (#570). When the sanitizer is inactive we therefore ignore the embedded value entirely
     // and mint a fresh per-instance uuid — durable resume is disabled (lost-resume), never a
     // wrong-resume. The live-object WeakMap (objectUuid) is always safe: a copy never shares it.
-    const embeddedId = embeddedWorkflowUuid(wf);
+    // Do not read app.graph.extra here. Command dispatch resolves this identity
+    // before assertGraphBoundToActiveWorkflow(), so a stale root must never get
+    // a chance to define the active workflow's identity. A known loadGraphData
+    // pairing above seeds the object cache; otherwise minting loses continuity
+    // but cannot turn a foreign graph into an authorized target.
+    const embeddedId = embeddedWorkflowUuid(wf, { allowGraph: false });
     const id = resolveUnsavedInstanceUuid({
       objectUuid,
       embeddedId,
@@ -1518,7 +1549,7 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
       // SAVE carries it into the saved file across the tmp:→wf: transition). Never dirties the
       // graph. Not a KEEP authority — the wrapper's live-object invalidation is.
       try {
-        const extra = activeWorkflowExtra(wf, { create: true });
+        const extra = workflowOwnedExtra(wf);
         const previous = extra?.[WORKFLOW_META_NAMESPACE];
         if (extra) {
           extra[WORKFLOW_META_NAMESPACE] = {
@@ -1533,8 +1564,10 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
     return id;
   }
 
-  const embedded = embeddedWorkflowUuid(wf);
-  const embeddedPath = embeddedWorkflowPath(wf);
+  // Same root-blind rule for saved workflows. A path alias or a UUID recorded
+  // on the workflow object is usable; a stale mounted root is not.
+  const embedded = embeddedWorkflowUuid(wf, { allowGraph: false });
+  const embeddedPath = embeddedWorkflowPath(wf, { allowGraph: false });
   const pathAlias = workflowAliasForPath(_workflowUuidAliases, path);
   let id = objectUuid || embedded || pathAlias || crypto.randomUUID();
 
@@ -1580,7 +1613,7 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
   }
   if (embed) {
     try {
-      const extra = activeWorkflowExtra(wf, { create: true });
+      const extra = workflowOwnedExtra(wf);
       const previous = extra?.[WORKFLOW_META_NAMESPACE];
       const pathChanged = path && normalizedWorkflowPath(previous?.[WORKFLOW_PATH_FIELD]) !== normalizedWorkflowPath(path);
       if (extra && (previous?.[WORKFLOW_UUID_FIELD] !== id || pathChanged)) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -250,6 +250,7 @@ import {
   activeWorkflowNodeCount,
   graphReadDesynced,
   graphRootMismatchesActiveWorkflow,
+  graphRootWorkflowUuidMismatches,
   graphReadBindingChanged,
 } from "./lib/graph-binding.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
@@ -3949,9 +3950,18 @@ function assertGraphBoundToActiveWorkflow(graph, rootGraph, { includeBaselineRea
   const liveNodeCount = rootGraph?._nodes?.length ?? 0;
   const inSubgraph = !!rootGraph && graph !== rootGraph;
   const activeWorkflow = activeWorkflowRef();
+  // #545 — the WeakMap value is the only live-object identity we have already
+  // established for this workflow. Do NOT mint/read one here: if a stale root is
+  // currently mounted, deriving from its embedded metadata would adopt exactly
+  // the wrong graph we are trying to detect. Missing identity stays inconclusive.
+  const activeWorkflowUuid = activeWorkflow ? _workflowObjectUuids.get(activeWorkflow) : null;
+  const currentStateTrustworthy = activeWorkflow?.isModified !== true;
   if (
+    graphRootWorkflowUuidMismatches({ rootGraph, activeWorkflowUuid }) ||
     graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow }) ||
-    (includeBaselineReadGuard && graphReadDesynced({ liveNodeCount, activeWorkflow, inSubgraph }))
+    (currentStateTrustworthy &&
+      includeBaselineReadGuard &&
+      graphReadDesynced({ liveNodeCount, activeWorkflow, inSubgraph }))
   ) {
     const expected = activeWorkflowNodeCount(activeWorkflow);
     throw new Error(

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -164,6 +164,14 @@ function graphShape(state) {
  * guard never manufactures a mismatch from partial state.
  */
 export function graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow } = {}) {
+  // #545 — ChangeTracker's activeState is a useful *clean-tab* binding witness,
+  // but it is not a synchronous mirror of every manual LiteGraph edit. A dirty
+  // workflow can therefore legitimately serialize differently from the root it
+  // owns (including a different node count). Treat that comparison as
+  // inconclusive while dirty rather than permanently rejecting every graph tool.
+  // Callers can still use a durable per-workflow identity to prove a dirty root
+  // belongs to a different tab.
+  if (activeWorkflow?.isModified === true) return false;
   const activeState = activeWorkflowCurrentState(activeWorkflow);
   const expected = activeState?.nodes;
   const live = rootGraph?._nodes;
@@ -195,6 +203,22 @@ export function graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow } 
   const expectedSet = new Set(expectedShapes);
   if (expectedSet.size !== expectedShapes.length) return false;
   return liveShapes.some((entry) => !expectedSet.has(entry));
+}
+
+/**
+ * True only when a root graph carries a durable workflow UUID that conflicts
+ * with the active workflow object's already-established UUID. Missing identity
+ * on either side is inconclusive: older frontends and first observation must
+ * never manufacture a false refusal.
+ *
+ * This is deliberately separate from ChangeTracker state comparison. It remains
+ * trustworthy for a dirty workflow, where activeState may lag manual edits but a
+ * root from another tab still carries that other tab's identity.
+ */
+export function graphRootWorkflowUuidMismatches({ rootGraph, activeWorkflowUuid } = {}) {
+  if (typeof activeWorkflowUuid !== "string" || !activeWorkflowUuid) return false;
+  const rootUuid = rootGraph?.extra?.comfyui_mcp?.workflow_uuid;
+  return typeof rootUuid === "string" && rootUuid && rootUuid !== activeWorkflowUuid;
 }
 
 /**

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -222,6 +222,18 @@ export function graphRootWorkflowUuidMismatches({ rootGraph, activeWorkflowUuid 
 }
 
 /**
+ * True only when both sides carry the same established workflow identity. This
+ * is stronger than `graphRootWorkflowUuidMismatches`: missing metadata is
+ * inconclusive for reads, but a dirty graph mutation cannot safely use an
+ * inconclusive root because ChangeTracker may lag the user's real canvas.
+ */
+export function graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid } = {}) {
+  if (typeof activeWorkflowUuid !== "string" || !activeWorkflowUuid) return false;
+  const rootUuid = rootGraph?.extra?.comfyui_mcp?.workflow_uuid;
+  return typeof rootUuid === "string" && rootUuid === activeWorkflowUuid;
+}
+
+/**
  * True when the graph READ's binding changed across an AWAIT: the active-workflow
  * instance or the bound root-graph object captured before the await no longer
  * matches after it. Used to detect a workflow-tab SWITCH that interleaved with a


### PR DESCRIPTION
Fixes #545's permanent graph-tool refusal on legitimately dirty canvases.\n\nChangeTracker activeState is not a synchronous mirror of manual LiteGraph edits, so its state comparison is now inconclusive while a workflow is marked modified. The guard still refuses a dirty root with a positively different, already-established workflow UUID; absent identity fails open rather than fabricating a mismatch. Clean workflows retain #541's full semantic comparison and empty-root guard.\n\nTests:\n- node --test browser_tests/unit/graph-binding.test.mjs (36 pass)\n- npm.cmd run test:unit (1527 pass)\n- npm.cmd run typecheck