### PR TITLE
fix(panel): reject mismatched retry tokens

### DIFF
--- a/browser_tests/unit/command-dedupe.test.mjs
+++ b/browser_tests/unit/command-dedupe.test.mjs
@@ -56,7 +56,7 @@ function makeRetryDispatch(ledger, executor) {
     const fingerprint = commandFingerprint(msg);
     let prior = ledger.get(msg.rid, fingerprint);
     let retryOfHit = false;
-    if (prior === undefined && typeof msg.retry_of === "string") {
+    if (typeof msg.retry_of === "string") {
       const retryLookup = ledger.lookupRetry(msg.retry_of, fingerprint);
       if (retryLookup.status === "mismatch") {
         return {
@@ -68,7 +68,7 @@ function makeRetryDispatch(ledger, executor) {
           executed: false,
         };
       }
-      if (retryLookup.status === "match") {
+      if (prior === undefined && retryLookup.status === "match") {
         prior = retryLookup.reply;
         retryOfHit = true;
       }
@@ -393,6 +393,37 @@ test("a retained retry_of with another workflow fingerprint is rejected before i
   assert.deepEqual(executedWorkflows, ["wfA"], "workflow B never receives r2");
 });
 
+test("a later-retained original rejects a duplicate retry that first failed open (#543 P1)", async () => {
+  const ledger = createCommandDedupeLedger(2);
+  const executions = [];
+  const deliver = makeRetryDispatch(ledger, async (msg) => {
+    executions.push(`${msg.rid}:${msg.workflow_uuid}`);
+    return { appliedTo: msg.workflow_uuid };
+  });
+  const originalA = { rid: "r1", cmd: "graph_set_title", title: "A", workflow_uuid: "wfA" };
+  const retryB = { rid: "r2", retry_of: "r1", cmd: "graph_set_title", title: "B", workflow_uuid: "wfB" };
+
+  // Evict r1/A. r2/B can then fail open, as designed, because r1 is absent.
+  await deliver(originalA);
+  await deliver({ rid: "fill-1", cmd: "graph_set_title", title: "fill", workflow_uuid: "wfA" });
+  await deliver({ rid: "fill-2", cmd: "graph_set_title", title: "fill", workflow_uuid: "wfA" });
+  const firstRetry = await deliver(retryB);
+  assert.equal(firstRetry.executed, true, "the evicted retry token fails open once");
+
+  // A delayed delivery of r1/A is now retained again while r2/B remains in the
+  // ledger. The duplicate r2/B must validate retry_of before replaying its own
+  // prior reply, otherwise it hides the now-known cross-workflow mismatch.
+  await deliver(originalA);
+  const beforeDuplicate = [...executions];
+  const duplicateRetry = await deliver(retryB);
+
+  assert.equal(duplicateRetry.executed, false);
+  assert.equal(duplicateRetry.reply.ok, false);
+  assert.match(duplicateRetry.reply.error, /retry_of.*different command or workflow/i);
+  assert.deepEqual(executions, beforeDuplicate, "the duplicate r2/B neither replays success nor executes again");
+  assert.equal(executions.filter((entry) => entry === "r2:wfB").length, 1, "workflow B ran only during the permitted fail-open delivery");
+});
+
 test("a genuinely FRESH command with identical args after a settled one EXECUTES again (#694)", async () => {
   const ledger = createCommandDedupeLedger();
   let applied = 0;
@@ -424,7 +455,7 @@ test("#694 wiring: the panel handler falls back to retry_of and REWRITES the rid
   // falling through to begin + execute.
   const fpAt = src.indexOf("const fingerprint = commandFingerprint(msg);");
   assert.notEqual(fpAt, -1, "the command handler must fingerprint the frame");
-  const block = src.slice(fpAt, fpAt + 2400);
+  const block = src.slice(fpAt, fpAt + 3600);
   assert.match(
     block,
     /let priorRidReply = commandRidLedger\.get\(msg\.rid, fingerprint\);/,
@@ -449,6 +480,8 @@ test("#694 wiring: the panel handler falls back to retry_of and REWRITES the rid
   // begin() must still key the retry's OWN rid when the token was unknown/evicted (fail-open).
   assert.match(block, /commandRidLedger\.begin\(msg\.rid, fingerprint\);/);
   const rejectAt = block.indexOf('retryLookup.status === "mismatch"');
+  const ownReplyAt = block.indexOf("if (priorRidReply !== undefined)");
   const beginAt = block.indexOf("commandRidLedger.begin(msg.rid, fingerprint)");
+  assert.ok(rejectAt !== -1 && ownReplyAt !== -1 && rejectAt < ownReplyAt, "mismatched retries return before their own-rid reply can replay");
   assert.ok(rejectAt !== -1 && beginAt !== -1 && rejectAt < beginAt, "mismatched retries return before begin + execute");
 });

--- a/browser_tests/unit/command-dedupe.test.mjs
+++ b/browser_tests/unit/command-dedupe.test.mjs
@@ -57,8 +57,21 @@ function makeRetryDispatch(ledger, executor) {
     let prior = ledger.get(msg.rid, fingerprint);
     let retryOfHit = false;
     if (prior === undefined && typeof msg.retry_of === "string") {
-      prior = ledger.get(msg.retry_of, fingerprint);
-      retryOfHit = prior !== undefined;
+      const retryLookup = ledger.lookupRetry(msg.retry_of, fingerprint);
+      if (retryLookup.status === "mismatch") {
+        return {
+          reply: {
+            rid: msg.rid,
+            ok: false,
+            error: "Retry rejected: retry_of refers to a different command or workflow.",
+          },
+          executed: false,
+        };
+      }
+      if (retryLookup.status === "match") {
+        prior = retryLookup.reply;
+        retryOfHit = true;
+      }
     }
     if (prior !== undefined) {
       const reply = await prior;
@@ -343,6 +356,43 @@ test("a retry naming an UNKNOWN retry_of executes fresh — the ledger fails ope
   assert.equal(applied, 1);
 });
 
+test("a retry naming an EVICTED retry_of also executes fresh (#543)", async () => {
+  const ledger = createCommandDedupeLedger(1);
+  const executedRids = [];
+  const deliver = makeRetryDispatch(ledger, async (msg) => {
+    executedRids.push(msg.rid);
+    return { appliedTo: msg.workflow_uuid };
+  });
+
+  await deliver({ rid: "r1", cmd: "graph_set_title", title: "A", workflow_uuid: "wfA" });
+  await deliver({ rid: "r-fill", cmd: "graph_set_title", title: "fill", workflow_uuid: "wfA" });
+  const retry = await deliver({ rid: "r2", retry_of: "r1", cmd: "graph_set_title", title: "B", workflow_uuid: "wfB" });
+
+  assert.equal(retry.executed, true, "an evicted retry token retains fail-open behaviour");
+  assert.deepEqual(executedRids, ["r1", "r-fill", "r2"]);
+});
+
+test("a retained retry_of with another workflow fingerprint is rejected before it executes (#543)", async () => {
+  const ledger = createCommandDedupeLedger();
+  const executedWorkflows = [];
+  const deliver = makeRetryDispatch(ledger, async (msg) => {
+    executedWorkflows.push(msg.workflow_uuid);
+    return { appliedTo: msg.workflow_uuid };
+  });
+
+  // r1 applied to workflow A, but the orchestrator timed out before seeing its
+  // reply. It switches to workflow B, then retries r1 under r2. The retained
+  // token proves this is not an unknown/evicted fail-open case.
+  const first = await deliver({ rid: "r1", cmd: "graph_set_title", title: "A", workflow_uuid: "wfA" });
+  assert.equal(first.executed, true);
+  const retry = await deliver({ rid: "r2", retry_of: "r1", cmd: "graph_set_title", title: "B", workflow_uuid: "wfB" });
+
+  assert.equal(retry.executed, false, "the cross-workflow retry is stopped before the executor");
+  assert.equal(retry.reply.ok, false);
+  assert.match(retry.reply.error, /retry_of.*different command or workflow/i);
+  assert.deepEqual(executedWorkflows, ["wfA"], "workflow B never receives r2");
+});
+
 test("a genuinely FRESH command with identical args after a settled one EXECUTES again (#694)", async () => {
   const ledger = createCommandDedupeLedger();
   let applied = 0;
@@ -382,9 +432,11 @@ test("#694 wiring: the panel handler falls back to retry_of and REWRITES the rid
   );
   assert.match(
     block,
-    /if \(priorRidReply === undefined && typeof msg\.retry_of === "string"\) \{\s*priorRidReply = commandRidLedger\.get\(msg\.retry_of, fingerprint\);/,
-    "a retry misses on its fresh rid, then looks up the ORIGINAL rid it names",
+    /const retryLookup = commandRidLedger\.lookupRetry\(msg\.retry_of, fingerprint\);/,
+    "a retry misses on its fresh rid, then distinguishes the ORIGINAL token's state",
   );
+  assert.match(block, /if \(retryLookup\.status === "mismatch"\)/, "a retained mismatched retry token is rejected");
+  assert.match(block, /error: "Retry rejected: retry_of refers to a different command or workflow\."/, "the mismatch produces a truthful retry error");
   assert.match(
     block,
     /\{ \.\.\.dupReply, rid: msg\.rid \}/,
@@ -392,8 +444,11 @@ test("#694 wiring: the panel handler falls back to retry_of and REWRITES the rid
   );
   // The rewrite must sit on the dedupe-reply path, BEFORE the reply is sent.
   const rewriteAt = block.indexOf("{ ...dupReply, rid: msg.rid }");
-  const sendAt = block.indexOf("thisSock.send(");
+  const sendAt = block.indexOf("thisSock.send(", rewriteAt);
   assert.ok(rewriteAt !== -1 && sendAt !== -1 && rewriteAt < sendAt, "the rewrite precedes the reply write");
-  // begin() must still key the retry's OWN rid when every lookup missed (fail-open).
+  // begin() must still key the retry's OWN rid when the token was unknown/evicted (fail-open).
   assert.match(block, /commandRidLedger\.begin\(msg\.rid, fingerprint\);/);
+  const rejectAt = block.indexOf('retryLookup.status === "mismatch"');
+  const beginAt = block.indexOf("commandRidLedger.begin(msg.rid, fingerprint)");
+  assert.ok(rejectAt !== -1 && beginAt !== -1 && rejectAt < beginAt, "mismatched retries return before begin + execute");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10807,13 +10807,34 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         // fingerprints identically and is answered from the ORIGINAL's ledger
         // entry (settled reply or in-flight promise — the await below handles
         // both). An unknown/evicted retry_of misses and falls through to
-        // begin + execute fresh — the ledger fails open, never closed.
+        // begin + execute fresh — the ledger fails open. A RETAINED retry_of
+        // for a different fingerprint, however, is rejected before execution:
+        // executing it would apply the old command's retry to the active,
+        // wrong workflow.
         const fingerprint = commandFingerprint(msg);
         let priorRidReply = commandRidLedger.get(msg.rid, fingerprint);
         let retryOfHit = false;
         if (priorRidReply === undefined && typeof msg.retry_of === "string") {
-          priorRidReply = commandRidLedger.get(msg.retry_of, fingerprint);
-          retryOfHit = priorRidReply !== undefined;
+          const retryLookup = commandRidLedger.lookupRetry(msg.retry_of, fingerprint);
+          if (retryLookup.status === "mismatch") {
+            if (!isActive()) return; // superseded socket — ignore its late frames
+            try {
+              if (thisSock.readyState === WebSocket.OPEN) {
+                thisSock.send(JSON.stringify({
+                  rid: msg.rid,
+                  ok: false,
+                  error: "Retry rejected: retry_of refers to a different command or workflow.",
+                }));
+              }
+            } catch {
+              // Socket died between receive and reply — agent side times out.
+            }
+            return;
+          }
+          if (retryLookup.status === "match") {
+            priorRidReply = retryLookup.reply;
+            retryOfHit = true;
+          }
         }
         if (priorRidReply !== undefined) {
           let dupReply;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10814,7 +10814,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         const fingerprint = commandFingerprint(msg);
         let priorRidReply = commandRidLedger.get(msg.rid, fingerprint);
         let retryOfHit = false;
-        if (priorRidReply === undefined && typeof msg.retry_of === "string") {
+        // Validate retry_of even when this retry rid is already remembered. A
+        // token may have failed open while its original was evicted, then the
+        // delayed original can re-enter the ledger before this retry is
+        // duplicated. Replaying the retry's own old reply must not bypass the
+        // newly-known cross-workflow mismatch.
+        if (typeof msg.retry_of === "string") {
           const retryLookup = commandRidLedger.lookupRetry(msg.retry_of, fingerprint);
           if (retryLookup.status === "mismatch") {
             if (!isActive()) return; // superseded socket — ignore its late frames
@@ -10831,7 +10836,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             }
             return;
           }
-          if (retryLookup.status === "match") {
+          if (priorRidReply === undefined && retryLookup.status === "match") {
             priorRidReply = retryLookup.reply;
             retryOfHit = true;
           }

--- a/web/js/lib/command-dedupe.js
+++ b/web/js/lib/command-dedupe.js
@@ -80,11 +80,14 @@ export function commandFingerprint(msg) {
  *    bridge reused a request id for different work (anomalous; worth a log).
  * @returns {{
  *   get(rid: string, fingerprint: string): object | Promise<object> | undefined,
+ *   lookupRetry(rid: string, fingerprint: string): { status: "match", reply: object | Promise<object> } | { status: "mismatch" } | { status: "unknown" },
  *   begin(rid: string, fingerprint: string): (reply: object) => void,
  * }} get() returns undefined for a fresh rid+fingerprint, the settled reply
  *    object once the command completed, or a promise of it while the first
- *    execution is still in flight. begin() records a fresh rid+fingerprint as
- *    in-flight and returns its settle(reply) function.
+ *    execution is still in flight. lookupRetry() additionally distinguishes an
+ *    unknown/evicted token from a remembered token for different work. begin()
+ *    records a fresh rid+fingerprint as in-flight and returns its settle(reply)
+ *    function.
  */
 export function createCommandDedupeLedger(cap = 200, onRidReuse) {
   // `${rid}\n${fingerprint}` → { rid, inflight: true, promise } in-flight |
@@ -116,6 +119,18 @@ export function createCommandDedupeLedger(cap = 200, onRidReuse) {
       entries.delete(key);
       entries.set(key, entry);
       return entry.inflight ? entry.promise : entry.reply;
+    },
+    lookupRetry(rid, fingerprint) {
+      const reply = this.get(rid, fingerprint);
+      if (reply !== undefined) return { status: "match", reply };
+      // A retry token that is still retained but has no entry for this
+      // fingerprint names different work. It must not fail open onto whichever
+      // workflow is active now. In contrast, an unknown or evicted token has no
+      // entry at all and intentionally retains the ledger's fail-open behaviour.
+      for (const entry of entries.values()) {
+        if (entry.rid === rid) return { status: "mismatch" };
+      }
+      return { status: "unknown" };
     },
     begin(rid, fingerprint) {
       // begin() only runs after get() missed, so any same-rid entry exists


### PR DESCRIPTION
## What changed

Retry-ledger lookup distinguishes a matching original reply, an unknown or evicted retry token, and a retained token whose command fingerprint differs. Every retry delivery now validates etry_of, including an own-rid replay.

## Why

A timed-out command on workflow A could be retried after switching to workflow B. The retained etry_of token formerly looked identical to an unknown token and fell through to fresh execution on B. A later A delivery could then re-enter the ledger, letting a duplicate B retry replay its own stale success without validating the now-known mismatch.

## Impact

Known mismatches now return an explicit error before replay, egin, or the executor. Unknown and evicted tokens intentionally retain the established fail-open behavior.

## Validation

- node --test browser_tests/unit/command-dedupe.test.mjs (23 passing)
- npm run test:unit (1,528 passing)
- npm run typecheck
- git diff --check