### PR TITLE
feat(panel): stamp the session epoch from any epoch-carrying frame (#694)

### DIFF
--- a/browser_tests/unit/command-liveness.test.mjs
+++ b/browser_tests/unit/command-liveness.test.mjs
@@ -211,6 +211,20 @@ test("#694: the journal records the session epoch and summaries filter by it ide
   assert.equal(j.summaries().length, 3);
 });
 
+test("#694 wiring: the epoch stamps from ANY epoch-carrying frame, before the models branch", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const genericAt = src.indexOf('typeof msg.epoch === "string"');
+  const modelsAt = src.indexOf('msg.type === "models"');
+  assert.notEqual(genericAt, -1, "the generic epoch stamp must exist (epoch-first session frame)");
+  assert.notEqual(modelsAt, -1);
+  assert.ok(
+    genericAt < modelsAt,
+    "the generic stamp must run BEFORE the models branch so an early session frame advances the epoch",
+  );
+  const branch = src.slice(genericAt, genericAt + 400);
+  assert.match(branch, /thisSock\.__cmcpBridgeEpoch = msg\.epoch;/, "it stamps the socket's epoch from the frame");
+});
+
 test("#694 wiring: the models handshake stamps the socket's session epoch BEFORE the replay fires", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   const modelsAt = src.indexOf('msg.type === "models"');

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11266,8 +11266,8 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         onTurnAnchor?.(msg.uuid);
       }
       // #694 (epoch-first) — stamp the session epoch from ANY frame that
-      // carries it: the orchestrator now sends a tiny `session` frame the
-      // instant a hello lands (before async model discovery), so the epoch
+      // carries it: the orchestrator now sends a tiny "session_epoch" frame
+      // the instant a hello lands (before async model discovery), so the epoch
       // advances immediately instead of only when the `models` frame arrives.
       // A legacy orchestrator sends no epoch on those early frames — the
       // models-frame stamp below still covers them.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11265,6 +11265,19 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       if (msg && msg.type === "turn_anchor" && typeof msg.uuid === "string") {
         onTurnAnchor?.(msg.uuid);
       }
+      // #694 (epoch-first) — stamp the session epoch from ANY frame that
+      // carries it: the orchestrator now sends a tiny `session` frame the
+      // instant a hello lands (before async model discovery), so the epoch
+      // advances immediately instead of only when the `models` frame arrives.
+      // A legacy orchestrator sends no epoch on those early frames — the
+      // models-frame stamp below still covers them.
+      if (msg && typeof msg.epoch === "string") {
+        try {
+          thisSock.__cmcpBridgeEpoch = msg.epoch;
+        } catch {
+          /* exotic WebSocket impl — epoch matching stays absent/absent */
+        }
+      }
       // Live model catalog from the orchestrator (SDK-probed). This is also the
       // orchestrator HANDSHAKE — receiving it proves a real panel agent is behind
       // the socket, so it's the moment we truthfully flip to "connected".


### PR DESCRIPTION
Sibling of comfyui-mcp#713 (epoch-first session frame). Stamps the socket's session epoch from ANY frame carrying one — the orchestrator's new immediate `session` frame now advances the epoch on hello, before async model discovery. Models-frame stamp kept as belt. Unit: 1536/1536.