### PR TITLE
fix(panel): scope command retries to session epoch

### DIFF
--- a/browser_tests/unit/command-dedupe.test.mjs
+++ b/browser_tests/unit/command-dedupe.test.mjs
@@ -51,13 +51,14 @@ function makeDispatch(ledger, executor) {
 // ledger entry; a hit there is answered with the rid REWRITTEN to the retry's
 // (the orchestrator's pending map waits on the fresh rid). An unknown retry_of
 // misses too and falls through to begin + execute fresh — the ledger fails open.
-function makeRetryDispatch(ledger, executor) {
+function makeRetryDispatch(ledger, executor, getScope = () => undefined) {
   return async function deliver(msg) {
     const fingerprint = commandFingerprint(msg);
-    let prior = ledger.get(msg.rid, fingerprint);
+    const scope = getScope();
+    let prior = ledger.get(msg.rid, fingerprint, scope);
     let retryOfHit = false;
     if (typeof msg.retry_of === "string") {
-      const retryLookup = ledger.lookupRetry(msg.retry_of, fingerprint);
+      const retryLookup = ledger.lookupRetry(msg.retry_of, fingerprint, scope);
       if (retryLookup.status === "mismatch") {
         return {
           reply: {
@@ -77,7 +78,7 @@ function makeRetryDispatch(ledger, executor) {
       const reply = await prior;
       return { reply: retryOfHit ? { ...reply, rid: msg.rid } : reply, executed: false };
     }
-    const settle = ledger.begin(msg.rid, fingerprint);
+    const settle = ledger.begin(msg.rid, fingerprint, scope);
     let reply;
     try {
       reply = { rid: msg.rid, ok: true, result: await executor(msg) };
@@ -356,6 +357,75 @@ test("a retry naming an UNKNOWN retry_of executes fresh — the ledger fails ope
   assert.equal(applied, 1);
 });
 
+test("a retained predecessor-epoch retry token is unknown and executes fresh (#713)", async () => {
+  const ledger = createCommandDedupeLedger();
+  let applied = 0;
+  let epoch = "epoch-before-restart";
+  const deliver = makeRetryDispatch(
+    ledger,
+    async (msg) => ({ applied: ++applied, workflow: msg.workflow_uuid }),
+    () => epoch,
+  );
+
+  await deliver({ rid: "original-rid", cmd: "graph_set_title", title: "old", workflow_uuid: "wf-old" });
+  epoch = "epoch-after-restart";
+
+  // The later process can legitimately retry with the old correlation token.
+  // Its retained predecessor entry must be UNKNOWN, never a replay hit.
+  const retry = await deliver({
+    rid: "retry-rid",
+    retry_of: "original-rid",
+    cmd: "graph_set_title",
+    title: "old",
+    workflow_uuid: "wf-old",
+  });
+
+  assert.equal(retry.executed, true, "a prior session's token must fail open in the new epoch");
+  assert.equal(applied, 2, "the new process receives its own fresh execution");
+  assert.equal(retry.reply.result.workflow, "wf-old");
+});
+
+test("a same-rid predecessor-epoch replay also executes fresh (#713)", async () => {
+  const ledger = createCommandDedupeLedger();
+  let epoch = "epoch-before-restart";
+  let applied = 0;
+  const deliver = makeRetryDispatch(ledger, async () => ({ applied: ++applied }), () => epoch);
+
+  await deliver({ rid: "same-rid", cmd: "graph_add_node", workflow_uuid: "wf" });
+  epoch = "epoch-after-restart";
+  const current = await deliver({ rid: "same-rid", cmd: "graph_add_node", workflow_uuid: "wf" });
+
+  assert.equal(current.executed, true, "the old process's exact rid is not an own-rid replay now");
+  assert.equal(applied, 2);
+});
+
+test("a predecessor-epoch retry token cannot reject different current work (#713)", async () => {
+  const ledger = createCommandDedupeLedger();
+  let epoch = "epoch-before-restart";
+  const executed = [];
+  const deliver = makeRetryDispatch(
+    ledger,
+    async (msg) => {
+      executed.push(msg.workflow_uuid);
+      return { workflow: msg.workflow_uuid };
+    },
+    () => epoch,
+  );
+
+  await deliver({ rid: "original-rid", cmd: "graph_set_title", title: "old", workflow_uuid: "wf-old" });
+  epoch = "epoch-after-restart";
+  const retry = await deliver({
+    rid: "retry-rid",
+    retry_of: "original-rid",
+    cmd: "graph_set_title",
+    title: "current",
+    workflow_uuid: "wf-current",
+  });
+
+  assert.equal(retry.executed, true, "old-session mismatch state must not reject current work");
+  assert.deepEqual(executed, ["wf-old", "wf-current"]);
+});
+
 test("a retry naming an EVICTED retry_of also executes fresh (#543)", async () => {
   const ledger = createCommandDedupeLedger(1);
   const executedRids = [];
@@ -456,15 +526,16 @@ test("#694 wiring: the panel handler falls back to retry_of and REWRITES the rid
   const fpAt = src.indexOf("const fingerprint = commandFingerprint(msg);");
   assert.notEqual(fpAt, -1, "the command handler must fingerprint the frame");
   const block = src.slice(fpAt, fpAt + 3600);
+  assert.match(block, /const commandEpoch = thisSock\.__cmcpBridgeEpoch;/, "the command snapshots its socket epoch");
   assert.match(
     block,
-    /let priorRidReply = commandRidLedger\.get\(msg\.rid, fingerprint\);/,
-    "the frame's own rid is consulted first",
+    /let priorRidReply = commandRidLedger\.get\(msg\.rid, fingerprint, commandEpoch\);/,
+    "the frame's own rid is consulted in its session epoch",
   );
   assert.match(
     block,
-    /const retryLookup = commandRidLedger\.lookupRetry\(msg\.retry_of, fingerprint\);/,
-    "a retry misses on its fresh rid, then distinguishes the ORIGINAL token's state",
+    /const retryLookup = commandRidLedger\.lookupRetry\(msg\.retry_of, fingerprint, commandEpoch\);/,
+    "a retry distinguishes the original token only in its current session epoch",
   );
   assert.match(block, /if \(retryLookup\.status === "mismatch"\)/, "a retained mismatched retry token is rejected");
   assert.match(block, /error: "Retry rejected: retry_of refers to a different command or workflow\."/, "the mismatch produces a truthful retry error");
@@ -478,10 +549,10 @@ test("#694 wiring: the panel handler falls back to retry_of and REWRITES the rid
   const sendAt = block.indexOf("thisSock.send(", rewriteAt);
   assert.ok(rewriteAt !== -1 && sendAt !== -1 && rewriteAt < sendAt, "the rewrite precedes the reply write");
   // begin() must still key the retry's OWN rid when the token was unknown/evicted (fail-open).
-  assert.match(block, /commandRidLedger\.begin\(msg\.rid, fingerprint\);/);
+  assert.match(block, /commandRidLedger\.begin\(msg\.rid, fingerprint, commandEpoch\);/);
   const rejectAt = block.indexOf('retryLookup.status === "mismatch"');
   const ownReplyAt = block.indexOf("if (priorRidReply !== undefined)");
-  const beginAt = block.indexOf("commandRidLedger.begin(msg.rid, fingerprint)");
+  const beginAt = block.indexOf("commandRidLedger.begin(msg.rid, fingerprint, commandEpoch)");
   assert.ok(rejectAt !== -1 && ownReplyAt !== -1 && rejectAt < ownReplyAt, "mismatched retries return before their own-rid reply can replay");
   assert.ok(rejectAt !== -1 && beginAt !== -1 && rejectAt < beginAt, "mismatched retries return before begin + execute");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10431,7 +10431,10 @@ function redactBridgeUrl(u) {
 // (anomalous — logged once via onRidReuse) executes fresh instead of receiving
 // the old reply. Module-scoped so the ledger survives a socket supersede: the
 // replay can arrive on the REPLACEMENT socket while the first execution was
-// still in flight on the old.
+// still in flight on the old. Each operation additionally owns the epoch
+// stamped on its receiving socket: a retained predecessor-process rid is
+// unknown in the new epoch and therefore fails open instead of replaying or
+// rejecting a prior session's command.
 const commandRidLedger = createCommandDedupeLedger(200, (m) => console.warn(m));
 
 function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCommandReceived, onAsk, onSecret, onSecretSaved, onReload, onTodo, onShowMedia, onOpenCivitai, onCivitaiCmd, onTrainingCmd, onUiRender, onUiUpdate, onDownloads, onThinking, onAgentStatus, onSession, onModels, onCommands, onBackends, onAck, onTurn, onAction, onTurnAnchor, getResume, getBackend, onHandshakeTimeout, onBridgeClosed, onPairUrl, onPairError, onRunpodStatus, onComfyuiTarget, onRunpodAlert }) {
@@ -10825,6 +10828,19 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       } catch {
         return;
       }
+      // #694/#713 (epoch-first) — stamp every epoch-carrying frame before any
+      // command dedupe work. The orchestrator sends `session_epoch` immediately
+      // after hello, before slow model discovery, so a command received after
+      // that tiny frame is already scoped to the fresh process. This is also
+      // deliberately before isCommandFrame: an epoch-bearing command cannot
+      // accidentally consult a predecessor process's retained ledger state.
+      if (msg && typeof msg.epoch === "string") {
+        try {
+          thisSock.__cmcpBridgeEpoch = msg.epoch;
+        } catch {
+          /* exotic WebSocket impl — epoch matching stays absent/absent */
+        }
+      }
       const isCommandFrame = msg && typeof msg.rid === "string" && typeof msg.cmd === "string";
       if (!isActive()) {
         // Superseded socket — a soft-reload/reconnect replaced it. Its late frames must NOT
@@ -10893,7 +10909,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         // executing it would apply the old command's retry to the active,
         // wrong workflow.
         const fingerprint = commandFingerprint(msg);
-        let priorRidReply = commandRidLedger.get(msg.rid, fingerprint);
+        // Capture THIS frame's session owner before any async executor work.
+        // The ledger remains shared across socket supersedes in one process,
+        // but never crosses a server-issued epoch after an orchestrator restart.
+        // A `session_epoch` frame is stamped generically above (before models),
+        // so the first command after that early frame already gets its new owner.
+        const commandEpoch = thisSock.__cmcpBridgeEpoch;
+        let priorRidReply = commandRidLedger.get(msg.rid, fingerprint, commandEpoch);
         let retryOfHit = false;
         // Validate retry_of even when this retry rid is already remembered. A
         // token may have failed open while its original was evicted, then the
@@ -10901,7 +10923,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         // duplicated. Replaying the retry's own old reply must not bypass the
         // newly-known cross-workflow mismatch.
         if (typeof msg.retry_of === "string") {
-          const retryLookup = commandRidLedger.lookupRetry(msg.retry_of, fingerprint);
+          const retryLookup = commandRidLedger.lookupRetry(msg.retry_of, fingerprint, commandEpoch);
           if (retryLookup.status === "mismatch") {
             if (!isActive()) return; // superseded socket — ignore its late frames
             try {
@@ -10942,7 +10964,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           }
           return;
         }
-        const settleRid = commandRidLedger.begin(msg.rid, fingerprint);
+        const settleRid = commandRidLedger.begin(msg.rid, fingerprint, commandEpoch);
         let reply;
         try {
           let result;
@@ -11264,19 +11286,6 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // later "rewind conversation to here" can fork the session at that point.
       if (msg && msg.type === "turn_anchor" && typeof msg.uuid === "string") {
         onTurnAnchor?.(msg.uuid);
-      }
-      // #694 (epoch-first) — stamp the session epoch from ANY frame that
-      // carries it: the orchestrator now sends a tiny "session_epoch" frame
-      // the instant a hello lands (before async model discovery), so the epoch
-      // advances immediately instead of only when the `models` frame arrives.
-      // A legacy orchestrator sends no epoch on those early frames — the
-      // models-frame stamp below still covers them.
-      if (msg && typeof msg.epoch === "string") {
-        try {
-          thisSock.__cmcpBridgeEpoch = msg.epoch;
-        } catch {
-          /* exotic WebSocket impl — epoch matching stays absent/absent */
-        }
       }
       // Live model catalog from the orchestrator (SDK-probed). This is also the
       // orchestrator HANDSHAKE — receiving it proves a real panel agent is behind

--- a/web/js/lib/command-dedupe.js
+++ b/web/js/lib/command-dedupe.js
@@ -14,11 +14,14 @@
 // awaited first if the first execution is still in flight — and never runs the
 // executor again (so no second mutation and no duplicate activity card).
 //
-// The dedupe identity is rid + PAYLOAD FINGERPRINT (commandFingerprint below:
-// the frame minus `rid` and `retry_of`, canonical-stringified). The bridge's
-// re-dispatch of the SAME logical command reproduces the frame exactly, so it
-// dedupes — but a rid arriving with a MISMATCHED fingerprint is NOT the same
-// command (a genuinely new command that happens to reuse a prior rid:
+// The dedupe identity is optional OWNER SCOPE + rid + PAYLOAD FINGERPRINT
+// (commandFingerprint below: the frame minus `rid` and `retry_of`,
+// canonical-stringified). The panel's owner scope is the server-issued session
+// epoch: the same process can reconnect and dedupe safely, while a retained rid
+// from a restarted process is unknown and fails open. Within a scope, the
+// bridge's re-dispatch of the SAME logical command reproduces the frame exactly,
+// so it dedupes — but a rid arriving with a MISMATCHED fingerprint is NOT the
+// same command (a genuinely new command that happens to reuse a prior rid:
 // re-targeted or replaced socket, different workflow). It is never answered
 // from the ledger: it executes fresh, and the reuse is logged once via
 // onRidReuse (the bridge should only ever re-dispatch the SAME command under a
@@ -79,22 +82,29 @@ export function commandFingerprint(msg) {
  *    arrives under a DIFFERENT fingerprint than a remembered entry — i.e. the
  *    bridge reused a request id for different work (anomalous; worth a log).
  * @returns {{
- *   get(rid: string, fingerprint: string): object | Promise<object> | undefined,
- *   lookupRetry(rid: string, fingerprint: string): { status: "match", reply: object | Promise<object> } | { status: "mismatch" } | { status: "unknown" },
- *   begin(rid: string, fingerprint: string): (reply: object) => void,
+ *   get(rid: string, fingerprint: string, scope?: unknown): object | Promise<object> | undefined,
+ *   lookupRetry(rid: string, fingerprint: string, scope?: unknown): { status: "match", reply: object | Promise<object> } | { status: "mismatch" } | { status: "unknown" },
+ *   begin(rid: string, fingerprint: string, scope?: unknown): (reply: object) => void,
  * }} get() returns undefined for a fresh rid+fingerprint, the settled reply
  *    object once the command completed, or a promise of it while the first
  *    execution is still in flight. lookupRetry() additionally distinguishes an
  *    unknown/evicted token from a remembered token for different work. begin()
  *    records a fresh rid+fingerprint as in-flight and returns its settle(reply)
- *    function.
+ *    function. `scope` is an optional owner dimension. The panel supplies the
+ *    orchestrator session epoch, so a retained rid from a predecessor process
+ *    is unknown (and therefore fails open) rather than replayed or rejected in
+ *    the new process.
  */
 export function createCommandDedupeLedger(cap = 200, onRidReuse) {
-  // `${rid}\n${fingerprint}` → { rid, inflight: true, promise } in-flight |
-  // { rid, inflight: false, reply } settled. Map preserves insertion order, so
-  // the oldest entry is always the first key. (The \n separator is safe: rids
-  // are UUIDs and canonical JSON never contains a raw newline.)
+  // JSON tuple `[scope, rid, fingerprint]` →
+  // { scope, rid, inflight: true, promise } in-flight |
+  // { scope, rid, inflight: false, reply } settled. The scope is deliberately
+  // an owned ledger dimension rather than part of the command fingerprint: a
+  // predecessor session's retry token must be unknown in a new session, not a
+  // retained token with a mismatched fingerprint. Map preserves insertion
+  // order, so the oldest entry is always the first key.
   const entries = new Map();
+  const keyFor = (scope, rid, fingerprint) => JSON.stringify([scope, rid, fingerprint]);
 
   // Evict oldest-first while over cap, but NEVER an in-flight entry (see
   // header): with every entry in flight this grows the ledger past cap
@@ -110,8 +120,8 @@ export function createCommandDedupeLedger(cap = 200, onRidReuse) {
   };
 
   return {
-    get(rid, fingerprint) {
-      const key = `${rid}\n${fingerprint}`;
+    get(rid, fingerprint, scope) {
+      const key = keyFor(scope, rid, fingerprint);
       const entry = entries.get(key);
       if (entry === undefined) return undefined;
       // LRU touch: a replayed entry is by definition still relevant — keep it
@@ -120,25 +130,25 @@ export function createCommandDedupeLedger(cap = 200, onRidReuse) {
       entries.set(key, entry);
       return entry.inflight ? entry.promise : entry.reply;
     },
-    lookupRetry(rid, fingerprint) {
-      const reply = this.get(rid, fingerprint);
+    lookupRetry(rid, fingerprint, scope) {
+      const reply = this.get(rid, fingerprint, scope);
       if (reply !== undefined) return { status: "match", reply };
       // A retry token that is still retained but has no entry for this
       // fingerprint names different work. It must not fail open onto whichever
       // workflow is active now. In contrast, an unknown or evicted token has no
       // entry at all and intentionally retains the ledger's fail-open behaviour.
       for (const entry of entries.values()) {
-        if (entry.rid === rid) return { status: "mismatch" };
+        if (entry.scope === scope && entry.rid === rid) return { status: "mismatch" };
       }
       return { status: "unknown" };
     },
-    begin(rid, fingerprint) {
+    begin(rid, fingerprint, scope) {
       // begin() only runs after get() missed, so any same-rid entry exists
       // under a DIFFERENT fingerprint — the bridge reused a request id for
       // different work. Warn ONCE: this new entry dedupes its own replays, so
       // a retry of THIS command can't re-fire the warning.
       for (const e of entries.values()) {
-        if (e.rid === rid) {
+        if (e.scope === scope && e.rid === rid) {
           onRidReuse?.(
             `[comfyui-mcp-panel] bridge rid "${rid}" reused for a DIFFERENT command payload — ` +
               `treating it as a new command (the original reply stays bound to its own payload)`,
@@ -146,9 +156,9 @@ export function createCommandDedupeLedger(cap = 200, onRidReuse) {
           break;
         }
       }
-      const key = `${rid}\n${fingerprint}`;
+      const key = keyFor(scope, rid, fingerprint);
       let settle;
-      entries.set(key, { rid, inflight: true, promise: new Promise((resolve) => { settle = resolve; }) });
+      entries.set(key, { scope, rid, inflight: true, promise: new Promise((resolve) => { settle = resolve; }) });
       evictSettled();
       let settled = false;
       return (reply) => {


### PR DESCRIPTION
Fixes the post-merge #713/#549 retry-ledger epoch leak.

The module-scoped dedupe ledger now owns each entry by the socket's server-issued session epoch. A retained predecessor-process `rid` or `retry_of` is therefore unknown in the next epoch and executes fresh rather than replaying an old reply or rejecting current work. The generic epoch stamp runs before command handling, covering the early `session_epoch` frame before models arrive.

Tests:
- `npm.cmd run test:unit` (1539 passing)
- `npm.cmd run typecheck`