### PR TITLE
fix: advertise browser-tab identity for restart readiness

### DIFF
--- a/browser_tests/unit/restart-tab-identity.test.mjs
+++ b/browser_tests/unit/restart-tab-identity.test.mjs
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { buildHelloPayload } from "../../web/js/lib/session-rebind.js";
+import { createRestartTabIdentity, sendBridgeHello } from "../../web/js/lib/restart-tab-identity.js";
+
+class FakeLocks {
+  held = new Set();
+
+  request(name, _options, callback) {
+    if (this.held.has(name)) return Promise.resolve(callback(null));
+    this.held.add(name);
+    return Promise.resolve(callback({ name })).finally(() => this.held.delete(name));
+  }
+}
+
+class DelayedDenyThenGrantLocks extends FakeLocks {
+  calls = 0;
+  denyFirst;
+
+  request(name, options, callback) {
+    this.calls++;
+    if (this.calls === 1) {
+      return new Promise((resolve) => {
+        this.denyFirst = () => resolve(callback(null));
+      });
+    }
+    return super.request(name, options, callback);
+  }
+}
+
+function copiedStorage(value) {
+  let stored = value;
+  return {
+    getItem: () => stored,
+    setItem: (_key, next) => { stored = next; },
+  };
+}
+
+test("#709: storage failure keeps one in-memory identity across actual hello reconnects", async () => {
+  const locks = new FakeLocks();
+  const storage = {
+    getItem: () => { throw new Error("storage disabled"); },
+    setItem: () => { throw new Error("storage disabled"); },
+  };
+  const identity = createRestartTabIdentity({ storage, locks, randomUUID: () => "memory-tab" });
+  const sent = [];
+  const socket = { send: (frame) => sent.push(JSON.parse(frame)) };
+  const makePayload = (tabSessionId) => buildHelloPayload({ tabId: "wf:shared.json", tabSessionId });
+
+  await sendBridgeHello({ socket, isCurrent: () => true, resolveTabIdentity: identity.resolve, makePayload });
+  await sendBridgeHello({ socket, isCurrent: () => true, resolveTabIdentity: identity.resolve, makePayload });
+  assert.deepEqual(sent.map((frame) => frame.tab_session_id), ["memory-tab", "memory-tab"]);
+  identity.releaseForTests();
+});
+
+test("#709: a duplicated sessionStorage candidate rotates under an exclusive lease before hello", async () => {
+  const locks = new FakeLocks();
+  const original = createRestartTabIdentity({
+    storage: copiedStorage("copied-browser-tab"),
+    locks,
+    randomUUID: () => "original-rotation",
+  });
+  const duplicate = createRestartTabIdentity({
+    storage: copiedStorage("copied-browser-tab"),
+    locks,
+    randomUUID: () => "duplicate-rotation",
+  });
+  const [originalId, duplicateId] = await Promise.all([original.resolve(), duplicate.resolve()]);
+  assert.equal(originalId, "copied-browser-tab");
+  assert.equal(duplicateId, "duplicate-rotation");
+  assert.notEqual(originalId, duplicateId);
+  original.releaseForTests();
+  duplicate.releaseForTests();
+});
+
+test("#709: actual hello sender waits for a definitive delayed lock verdict; no timeout can certify the copy", async () => {
+  const locks = new DelayedDenyThenGrantLocks();
+  const identity = createRestartTabIdentity({
+    storage: copiedStorage("copied-browser-tab"),
+    locks,
+    randomUUID: () => "rotated-after-denial",
+  });
+  const sent = [];
+  const socket = { send: (frame) => sent.push(JSON.parse(frame)) };
+  const pending = sendBridgeHello({
+    socket,
+    isCurrent: () => true,
+    resolveTabIdentity: identity.resolve,
+    makePayload: (tabSessionId) => buildHelloPayload({ tabId: "wf:shared.json", tabSessionId }),
+  });
+  await new Promise((resolve) => setTimeout(resolve, 40));
+  assert.equal(sent.length, 0, "no hello before the lock manager gives a positive lease");
+  locks.denyFirst();
+  await pending;
+  assert.equal(sent[0].tab_session_id, "rotated-after-denial");
+  identity.releaseForTests();
+});
+
+test("#709: absent Web Locks omits identity and the sender cannot fabricate restart readiness", async () => {
+  const identity = createRestartTabIdentity({
+    storage: copiedStorage("possibly-copied"),
+    locks: null,
+    randomUUID: () => "unused",
+  });
+  const sent = [];
+  await sendBridgeHello({
+    socket: { send: (frame) => sent.push(JSON.parse(frame)) },
+    isCurrent: () => true,
+    resolveTabIdentity: identity.resolve,
+    makePayload: (tabSessionId) => buildHelloPayload({ tabId: "wf:shared.json", tabSessionId }),
+  });
+  assert.equal("tab_session_id" in sent[0], false);
+});
+
+test("#709: a rejected Web Locks request also omits identity instead of hanging or trusting storage", async () => {
+  const identity = createRestartTabIdentity({
+    storage: copiedStorage("possibly-copied"),
+    locks: { request: () => Promise.reject(new Error("locks unavailable")) },
+    randomUUID: () => "unused",
+  });
+  assert.equal(await identity.resolve(), undefined);
+});
+
+test("#709: the live bridge sender awaits the leased identity helper, never getTabId directly", () => {
+  const source = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const start = source.indexOf("function sendHello() {");
+  const body = source.slice(start, source.indexOf("\n  }", start));
+  assert.match(body, /sendBridgeHello\(/);
+  assert.match(body, /resolveTabIdentity: \(\) => restartTabIdentity\.resolve\(\)/);
+  assert.match(body, /tabSessionId,/);
+  assert.doesNotMatch(body, /tabSessionId:\s*getTabId\(\)/);
+});

--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -268,6 +268,14 @@ test("#570 P0c: hello ALWAYS advertises enforces_workflow_stamp so the orchestra
   );
 });
 
+test("#709: hello carries the browser-tab identity separately from workflow routing", () => {
+  const frame = buildHelloPayload({ tabId: "wf:shared.json", tabSessionId: "browser-tab-a" });
+  assert.equal(frame.tab_id, "wf:shared.json");
+  assert.equal(frame.tab_session_id, "browser-tab-a");
+  assert.equal("tab_session_id" in buildHelloPayload({ tabId: "wf:shared.json" }), false);
+  assert.equal("tab_session_id" in buildHelloPayload({ tabId: "wf:shared.json", tabSessionId: "   " }), false);
+});
+
 test("#570: the durable per-instance workflow uuid rides the hello when present", () => {
   // Lets the orchestrator key an UNSAVED workflow's resume on a globally-unique id
   // that survives the tmp:<uuid> tab-id churn — so a same-title sibling can't

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -271,6 +271,7 @@ import {
   resolveLoadGraphArgs,
   buildHelloPayload,
 } from "./lib/session-rebind.js";
+import { createRestartTabIdentity, sendBridgeHello } from "./lib/restart-tab-identity.js";
 
 let app = null;
 let api = null;
@@ -1190,6 +1191,8 @@ function saveBridgeUrl(url) {
 // reloads, so each ComfyUI tab keeps a stable identity on the bridge while
 // two tabs never collide. (localStorage would be shared across tabs.)
 const TAB_ID_KEY = "comfyui-mcp.panel.tabSessionId";
+let _memoryTabId;
+const memoryTabId = () => (_memoryTabId ??= crypto.randomUUID());
 function getTabId() {
   try {
     let id = window.sessionStorage.getItem(TAB_ID_KEY);
@@ -1199,9 +1202,19 @@ function getTabId() {
     }
     return id;
   } catch {
-    return crypto.randomUUID();
+    // Storage can be disabled in a browser privacy mode. Never mint a new
+    // value on each hello: preserve a stable page-lifetime routing fallback.
+    return memoryTabId();
   }
 }
+// sessionStorage is persistence, not proof: a duplicated browser tab can copy
+// it. This resolver requires an origin-wide exclusive Web Lock before hello and
+// omits its value if it cannot establish per-browser-tab uniqueness.
+const restartTabIdentity = createRestartTabIdentity({
+  storage: window.sessionStorage,
+  locks: window.navigator?.locks,
+  randomUUID: () => crypto.randomUUID(),
+});
 
 // --- Per-workflow agent identity -----------------------------------------
 // Each ComfyUI workflow gets its OWN agent session. Saved workflows key by file
@@ -11412,7 +11425,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
 
   function sendHello() {
     if (!sock || sock.readyState !== WebSocket.OPEN) return;
-    try {
+    const target = sock;
+    void sendBridgeHello({
+      socket: target,
+      isCurrent: () => sock === target && target.readyState === WebSocket.OPEN,
+      resolveTabIdentity: () => restartTabIdentity.resolve(),
+      makePayload: (tabSessionId) => {
       // Carry the last session id so the orchestrator resumes the agent's
       // memory after a panel reload (only honored before the tab's agent spawns).
       const resume = getResume?.();
@@ -11422,9 +11440,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // Auto-target: the URL the browser was served from (or the manual override),
       // so a bare `--panel-orchestrator` points the agent at whatever ComfyUI is open.
       const comfyuiUrl = comfyuiUrlForAgent();
-      sock.send(
-        JSON.stringify(
-          buildHelloPayload({
+        return buildHelloPayload({
             tabId: workflowTabId(),
             title: getWorkflowTitle(),
             // Our build version, so the orchestrator can auto-stamp it into the
@@ -11438,6 +11454,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // #296/#291 — advertise the embedded local ComfyUI path so the
             // orchestrator registers panel_* tools + local panel management.
             comfyuiPath: localComfyuiPathForAgent(),
+            // #709 — stable for this browser tab across a page reload and
+            // distinct from workflowTabId(), whose saved-workflow path can be
+            // reused by another browser tab.
+            tabSessionId,
             resume,
             // #570 — the durable per-instance workflow uuid (the SAME identity that
             // keys the durable chat transcript). Unlike workflowTabId()'s ephemeral
@@ -11451,12 +11471,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // and can contradict the epoch-filtered replay (the #694 divergence).
             // The summaries ride the post-handshake `lost_replies` frame sent from
             // replayLostReplies, computed with the SAME epoch the replay uses.
-          }),
-        ),
-      );
-    } catch {
+        });
+      },
+    }).catch(() => {
       // Reconnect path will retry.
-    }
+    });
   }
 
   // When the workflow title changes (rename / open a different file / progress

--- a/web/js/lib/restart-tab-identity.js
+++ b/web/js/lib/restart-tab-identity.js
@@ -1,0 +1,105 @@
+// Browser-tab identity for #709 restart readiness. sessionStorage supplies a
+// reload-stable candidate, but duplicated browser tabs can copy it. We therefore
+// require an origin-wide Web Locks lease before ever advertising that candidate.
+
+export const RESTART_TAB_ID_STORAGE_KEY = "comfyui-mcp.panel.tabSessionId";
+const LOCK_PREFIX = "comfyui-mcp.panel.restart-tab-identity.v1:";
+
+function nonBlank(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/**
+ * Resolve an identity suitable for certifying that the browser tab which
+ * received a restart is the one which reconnected. A returned ID is backed by
+ * an exclusive Web Locks lease held for this page's lifetime. If that cannot be
+ * acquired, return undefined so the hello omits the identity and MCP readiness
+ * fails closed. There is intentionally no timeout-as-proof fallback.
+ */
+export function createRestartTabIdentity({
+  storage = globalThis.sessionStorage,
+  locks = globalThis.navigator?.locks,
+  randomUUID = () => globalThis.crypto.randomUUID(),
+} = {}) {
+  let memoryFallback;
+  let resolved;
+  let resolving;
+  let releaseLease;
+
+  const fallback = () => (memoryFallback ??= randomUUID());
+  const read = () => {
+    try {
+      return nonBlank(storage?.getItem(RESTART_TAB_ID_STORAGE_KEY));
+    } catch {
+      return undefined;
+    }
+  };
+  const write = (value) => {
+    try {
+      storage?.setItem(RESTART_TAB_ID_STORAGE_KEY, value);
+    } catch {
+      // Storage-disabled pages may still use their stable in-memory candidate,
+      // but only for this loaded page and only with an acquired lock lease.
+    }
+  };
+
+  async function acquire(candidate) {
+    if (!locks || typeof locks.request !== "function") return false;
+    let settle;
+    const acquired = new Promise((resolve) => { settle = resolve; });
+    try {
+      void locks.request(
+        LOCK_PREFIX + candidate,
+        { mode: "exclusive", ifAvailable: true },
+        async (lock) => {
+          if (!lock) {
+            settle(false);
+            return;
+          }
+          // Keep the lease until the browser page unloads. The resolver does
+          // not expose release: an early release could let a duplicate tab
+          // certify itself with the copied identity while this page is live.
+          await new Promise((resolve) => {
+            releaseLease = resolve;
+            settle(true);
+          });
+        },
+      ).catch(() => settle(false));
+      return await acquired;
+    } catch {
+      return false;
+    }
+  }
+
+  async function resolve() {
+    if (resolved) return resolved;
+    if (resolving) return resolving;
+    resolving = (async () => {
+      let candidate = read() ?? fallback();
+      write(candidate);
+      // The existing storage candidate can be held by a duplicated browser
+      // tab. Rotate only after failed exclusivity, and require a NEW positive
+      // lease before accepting the replacement too.
+      for (let attempt = 0; attempt < 3; attempt++) {
+        if (await acquire(candidate)) {
+          resolved = candidate;
+          return resolved;
+        }
+        candidate = randomUUID();
+        write(candidate);
+      }
+      return undefined;
+    })();
+    return resolving;
+  }
+
+  return { resolve, fallback, releaseForTests: () => releaseLease?.() };
+}
+
+/** Send the real hello only after restart identity exclusivity is complete. */
+export async function sendBridgeHello({ socket, isCurrent, resolveTabIdentity, makePayload }) {
+  const tabSessionId = await resolveTabIdentity();
+  if (!isCurrent()) return false;
+  socket.send(JSON.stringify(makePayload(tabSessionId)));
+  return true;
+}

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -295,6 +295,7 @@ export function buildHelloPayload({
   blind = false,
   comfyuiUrl,
   comfyuiPath,
+  tabSessionId,
   resume,
   workflowUuid,
   lostReplies,
@@ -319,6 +320,15 @@ export function buildHelloPayload({
     // leaks the user's own workflow into their own workflow (self-attack). No attestation.
     enforces_workflow_stamp: true,
   };
+  // #709 — a browser-tab-scoped identity, deliberately separate from the
+  // workflow routing id. `tab_id` is normally a workflow path and can therefore
+  // recur in another browser tab. The orchestrator snapshots this before a
+  // ComfyUI restart and only certifies readiness when the SAME browser tab
+  // reconnects afterwards. It is an honest-local correctness guard, not an
+  // attestation; old panels omit it and are conservatively not restart-ready.
+  if (typeof tabSessionId === "string" && tabSessionId.trim()) {
+    frame.tab_session_id = tabSessionId.trim();
+  }
   if (comfyuiUrl) frame.comfyui_url = comfyuiUrl;
   if (typeof comfyuiPath === "string" && comfyuiPath.trim()) {
     frame.comfyui_path = comfyuiPath.trim();


### PR DESCRIPTION
## Summary\n- include the existing sessionStorage-scoped browser-tab id on bridge hello\n- keep it distinct from workflow-derived tab routing ids\n- allow MCP restart readiness to prove the rebooted browser tab reconnected\n\n## Validation\n- node --test browser_tests/unit/session-rebind.test.mjs\n- npm.cmd run typecheck\n\nLockstep companion to comfyui-mcp #714; no release/merge.