### PR TITLE
fix(panel): recover dirty graph reads

### DIFF
--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -21,6 +21,7 @@ import {
   graphRootMismatchesActiveWorkflow,
   graphRootWorkflowUuidMismatches,
   graphRootWorkflowUuidMatches,
+  graphCommandMayMutateWorkflow,
   graphReadBindingChanged,
 } from "../../web/js/lib/graph-binding.js";
 
@@ -460,6 +461,42 @@ test("#545 P1: an untagged stale root is refused for dirty mutations but a prove
   );
 });
 
+test("#545: read-only graph commands recover from an untagged dirty root, while workflow mutations remain fenced", () => {
+  const unbound = buildDirtyStaleRouteHarness({ rootUuid: null });
+  assert.equal(graphCommandMayMutateWorkflow("graph_outline"), false);
+  assert.equal(graphCommandMayMutateWorkflow("graph_query"), false);
+  assert.equal(graphCommandMayMutateWorkflow("graph_set_node_property"), true);
+  assert.equal(graphCommandMayMutateWorkflow("graph_future_command"), true, "unknown commands fail closed");
+
+  assert.doesNotThrow(
+    () => unbound.assertBound(unbound.rootB, unbound.rootB, {
+      includeBaselineReadGuard: false,
+      requireDirtyMutationBinding: graphCommandMayMutateWorkflow("graph_outline"),
+    }),
+    "a read must remain available when a dirty canvas lacks UUID metadata",
+  );
+  assert.throws(
+    () => unbound.assertBound(unbound.rootB, unbound.rootB, {
+      includeBaselineReadGuard: false,
+      requireDirtyMutationBinding: graphCommandMayMutateWorkflow("graph_set_node_property"),
+    }),
+    /NOT applied/,
+    "the same unproven dirty root must not accept a workflow mutation",
+  );
+});
+
+test("#545: a positively identified wrong root remains rejected even for a read", () => {
+  const stale = buildDirtyStaleRouteHarness({ rootUuid: "workflow-B" });
+  assert.throws(
+    () => stale.assertBound(stale.rootB, stale.rootB, {
+      includeBaselineReadGuard: false,
+      requireDirtyMutationBinding: graphCommandMayMutateWorkflow("graph_outline"),
+    }),
+    /NOT applied/,
+    "availability for an unproven dirty root must not turn a known wrong workflow into a read result",
+  );
+});
+
 test("#545 P1: command identity resolution cannot adopt a stale dirty root before the binding fence", () => {
   // This drives the actual panel resolver followed by the actual panel fence in
   // the same order bridge dispatch uses. It reproduces the P1: active dirty A
@@ -619,7 +656,7 @@ test("#513 review wiring: validationBanner fences its server probe against a mid
   );
 });
 
-test("#349 wiring: every graph command verifies LiteGraph is bound to the active workflow before execution", () => {
+test("#349 wiring: every graph command verifies LiteGraph is bound, with positive dirty binding limited to mutations", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   const handlerStart = src.indexOf("const executor = GRAPH_TOOL_EXECUTORS[msg.cmd];");
   assert.notEqual(handlerStart, -1, "bridge graph-command handler must exist");
@@ -627,8 +664,8 @@ test("#349 wiring: every graph command verifies LiteGraph is bound to the active
   assert.match(handler, /msg\.cmd\.startsWith\("graph_"\)/, "graph commands must have a root-binding fence");
   assert.match(
     handler,
-    /assertGraphBoundToActiveWorkflow\(graph, rootGraph, \{[\s\S]*requireDirtyMutationBinding: true[\s\S]*\}\)/,
-    "the fence must inspect the graph the executor will use",
+    /assertGraphBoundToActiveWorkflow\(graph, rootGraph, \{[\s\S]*requireDirtyMutationBinding: graphCommandMayMutateWorkflow\(msg\.cmd\)[\s\S]*\}\)/,
+    "the fence must inspect the executor graph and demand positive dirty binding only for mutations",
   );
 });
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -252,6 +252,7 @@ import {
   graphRootMismatchesActiveWorkflow,
   graphRootWorkflowUuidMismatches,
   graphRootWorkflowUuidMatches,
+  graphCommandMayMutateWorkflow,
   graphReadBindingChanged,
 } from "./lib/graph-binding.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
@@ -11102,11 +11103,16 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // separate app.graph. A stale nonempty app.graph can therefore pass the
             // UUID check and still edit a previous tab. Fence every graph command
             // against the active workflow's serialized root before its executor.
+            // A dirty root without its UUID is unsafe for a workflow mutation, but
+            // it is not proof that a read targets another workflow: ChangeTracker
+            // can lag ordinary unsaved canvas edits (#545).  Keep the strict
+            // positive-binding requirement for mutations only, so read tools can
+            // report the live graph and give the user a recovery path.
             if (msg.cmd.startsWith("graph_")) {
               const { graph, rootGraph } = getGraphCtx();
               assertGraphBoundToActiveWorkflow(graph, rootGraph, {
                 includeBaselineReadGuard: false,
-                requireDirtyMutationBinding: true,
+                requireDirtyMutationBinding: graphCommandMayMutateWorkflow(msg.cmd),
               });
             }
             // PINNED-TARGET GUARD (#349): a `workflow_path` on the command means the

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -234,6 +234,38 @@ export function graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid } =
 }
 
 /**
+ * Whether a bridge graph command can change durable workflow state.
+ *
+ * A dirty workflow without a root UUID is not sufficiently proven for a graph
+ * mutation: ChangeTracker can lag the canvas, so a stale untagged root must
+ * stay fail-closed (#545 P1).  That proof requirement must not, however,
+ * prevent the read-only tools from inspecting the live canvas and recovering
+ * from a stale tracker snapshot.  In particular, an unsaved local edit may
+ * legitimately make the root differ from ChangeTracker until the next state
+ * capture.
+ *
+ * Keep the small read-only list explicit and default unknown/new graph commands
+ * to mutating.  Adding a graph tool therefore cannot accidentally weaken the
+ * wrong-workflow mutation fence.
+ */
+const READ_ONLY_GRAPH_COMMANDS = new Set([
+  "graph_serialize",
+  "graph_get_state",
+  "graph_view_selected",
+  "graph_view_nodes_in_viewport",
+  "graph_outline",
+  "graph_query",
+  "graph_find_nodes",
+  "graph_get_subgraph",
+  "graph_list_subgraphs",
+  "graph_screenshot",
+]);
+
+export function graphCommandMayMutateWorkflow(command) {
+  return !READ_ONLY_GRAPH_COMMANDS.has(command);
+}
+
+/**
  * True when the graph READ's binding changed across an AWAIT: the active-workflow
  * instance or the bound root-graph object captured before the await no longer
  * matches after it. Used to detect a workflow-tab SWITCH that interleaved with a


### PR DESCRIPTION
## What changed

- Classifies the small, explicit set of read-only graph bridge commands.
- Lets those reads pass the dirty-root UUID proof requirement when identity is unavailable, so a legitimate unsaved canvas can be inspected again.
- Keeps the positive UUID requirement for all graph mutations by default; unknown future graph commands remain fail-closed.
- Retains rejection for a root positively identified as another workflow.

## Why

The #545 dirty-root repair correctly made ChangeTracker differences inconclusive, but bridge dispatch still applied the mutation-only positive UUID requirement to every graph command. That blocked graph_outline/query/find along with mutations when a legitimate dirty canvas had no root UUID.

## Validation

- node --test browser_tests/unit/graph-binding.test.mjs
- npm.cmd run test:unit (1541 passed)
- npm.cmd run typecheck