### PR TITLE
fix(panel): report active workflow UUID after open

### DIFF
--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -110,6 +110,19 @@ function codeBlockAt(src, marker) {
   throw new Error(`unterminated block: ${marker}`);
 }
 
+/** Extract one simple top-level function for a behavioral panel-source test. */
+function namedFunctionSource(src, name) {
+  const start = src.indexOf(`function ${name}(`);
+  if (start === -1) return null;
+  const open = src.indexOf("{", start);
+  let depth = 0;
+  for (let i = open; i < src.length; i += 1) {
+    if (src[i] === "{") depth += 1;
+    if (src[i] === "}" && --depth === 0) return src.slice(start, i + 1);
+  }
+  return null;
+}
+
 const receiptFor = (requested, extra = {}) =>
   makeOpenReceipt({
     seq: 1,
@@ -865,4 +878,169 @@ test("#402 wiring: workflow_list exposes the receipt + the POSITIVE trust flag",
   assert.match(body, /interpretation:/, "last_open must state how it may be read");
   assert.match(body, /answers ONLY for the command/);
   assert.match(body, /do not infer success from `active` matching your target/);
+});
+
+test("#716 wiring: post-open and active workflow responses carry the live instance UUID", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const list = handlerBody(src, "workflow_list()");
+  const open = handlerBody(src, "async workflow_open({");
+  assert.ok(list && open, "workflow_list and workflow_open must exist");
+  // The response source must be the live workflow object, not a path alias or
+  // a stale mounted graph. The MCP only adopts a separately validated UUID.
+  assert.match(list, /const \{ active, activeIdentity \} = liveWorkflowListActive\(\);/);
+  assert.doesNotMatch(list, /const active = s\.activeWorkflow;/, "workflow_list must not publish a pre-reconnect service binding");
+  assert.match(list, /activeIdentity \? \{ workflow_uuid: activeIdentity\.uuid \} : \{\}/);
+  assert.match(open, /activeWorkflowUuidForOpenReply\(target\)/);
+  assert.doesNotMatch(open, /activeWorkflowUuidForOpenReply\(target, s\.activeWorkflow\)/);
+  assert.match(open, /activeWorkflowUuid \? \{ workflow_uuid: activeWorkflowUuid \} : \{\}/);
+});
+
+test("#716 P1: service rebind during workflow_open omits the former target UUID", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const pathSource = namedFunctionSource(src, "savedWorkflowPath");
+  const canonicalUuidSource = namedFunctionSource(src, "isCanonicalWorkflowInstanceUuid");
+  const identitySource = namedFunctionSource(src, "establishedWorkflowReplyIdentity");
+  const helperSource = namedFunctionSource(src, "activeWorkflowUuidForOpenReply");
+  assert.ok(pathSource && canonicalUuidSource && identitySource && helperSource, "the reply identity check must live in the shipped panel source");
+
+  const openedTarget = { isPersisted: true, isTemporary: false, path: "workflows/a.json" };
+  const otherActive = { isPersisted: true, isTemporary: false, path: "workflows/b.json" };
+  const workflowUuids = new WeakMap([
+    [openedTarget, "11111111-1111-4111-8111-111111111111"],
+    [otherActive, "22222222-2222-4222-8222-222222222222"],
+  ]);
+  // This is the actual final-reply input: activeWorkflowRef observes whatever
+  // workflow service is live at emission, not the service workflow_open held
+  // before its repaint/disk awaits.
+  let currentService = { activeWorkflow: openedTarget };
+  const replyUuid = new Function(
+    "activeWorkflowRef",
+    "_workflowObjectUuids",
+    `${pathSource}; ${canonicalUuidSource}; ${identitySource}; ${helperSource}; return activeWorkflowUuidForOpenReply;`,
+  )(
+    () => currentService.activeWorkflow,
+    workflowUuids,
+  );
+
+  assert.equal(replyUuid(openedTarget), "11111111-1111-4111-8111-111111111111", "the normal completed open reports its actual active tab");
+  // workflow_open has retained its old local `s`, but a reconnect/rebind has
+  // replaced the service before the final reply. The old service could still
+  // report A; the actual binding now says B. Returning target.uuid here would
+  // stamp the NEXT graph command for the wrong live canvas.
+  const staleService = currentService;
+  currentService = { activeWorkflow: otherActive };
+  assert.equal(staleService.activeWorkflow, openedTarget, "the pre-await service still looks like the opened target");
+  assert.equal(replyUuid(openedTarget), null, "the re-bound live service omits the stale reply UUID and leaves the MCP fence unchanged");
+  assert.equal(replyUuid(otherActive), "22222222-2222-4222-8222-222222222222", "the same helper still reports the actual active tab");
+});
+
+test("#716 P1: service rebind during workflow_list reports only the current active UUID", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const pathSource = namedFunctionSource(src, "savedWorkflowPath");
+  const canonicalUuidSource = namedFunctionSource(src, "isCanonicalWorkflowInstanceUuid");
+  const identitySource = namedFunctionSource(src, "establishedWorkflowReplyIdentity");
+  const listActiveSource = namedFunctionSource(src, "liveWorkflowListActive");
+  assert.ok(pathSource && canonicalUuidSource && identitySource && listActiveSource, "workflow_list must obtain its active identity through the shipped live-binding helper");
+
+  const staleActive = { isPersisted: true, isTemporary: false, path: "workflows/a/foo.json" };
+  const currentActive = { isPersisted: true, isTemporary: false, path: "workflows/b/foo.json" };
+  const workflowUuids = new WeakMap([
+    [staleActive, "11111111-1111-4111-8111-111111111111"],
+    [currentActive, "22222222-2222-4222-8222-222222222222"],
+  ]);
+  let currentService = { activeWorkflow: staleActive };
+  const listActive = new Function(
+    "activeWorkflowRef",
+    "_workflowObjectUuids",
+    `${pathSource}; ${canonicalUuidSource}; ${identitySource}; ${listActiveSource}; return liveWorkflowListActive;`,
+  )(
+    () => currentService.activeWorkflow,
+    workflowUuids,
+  );
+
+  assert.equal(listActive().activeIdentity?.uuid, "11111111-1111-4111-8111-111111111111");
+  const staleService = currentService;
+  currentService = { activeWorkflow: currentActive };
+  assert.equal(staleService.activeWorkflow, staleActive, "the old executor service still points at A");
+  const reply = listActive();
+  assert.equal(reply.active, currentActive, "workflow_list observes the re-bound live service, not its captured service");
+  assert.equal(reply.activeIdentity?.uuid, "22222222-2222-4222-8222-222222222222", "only B's current UUID is eligible for the list response");
+  assert.notEqual(reply.activeIdentity?.uuid, "11111111-1111-4111-8111-111111111111");
+});
+
+test("#716 P1: a malformed truthy active binding cannot mint reply identity", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const pathSource = namedFunctionSource(src, "savedWorkflowPath");
+  const canonicalUuidSource = namedFunctionSource(src, "isCanonicalWorkflowInstanceUuid");
+  const identitySource = namedFunctionSource(src, "establishedWorkflowReplyIdentity");
+  const helperSource = namedFunctionSource(src, "activeWorkflowUuidForOpenReply");
+  const malformedActive = {};
+  const workflowUuids = new WeakMap();
+  const replyUuid = new Function(
+    "activeWorkflowRef",
+    "_workflowObjectUuids",
+    `${pathSource}; ${canonicalUuidSource}; ${identitySource}; ${helperSource}; return activeWorkflowUuidForOpenReply;`,
+  )(
+    () => malformedActive,
+    workflowUuids,
+  );
+
+  // Execute the actual shipped reply helper against a truthy but malformed
+  // binding. It must be an observation only: no tmp routing id and no UUID can
+  // be initialized while deciding whether to publish the response field.
+  assert.equal(replyUuid(malformedActive), null);
+  assert.equal(workflowUuids.has(malformedActive), false, "must not mint an ephemeral workflow UUID");
+});
+
+test("#716 P1: a temporary workflow UUID is never published as a durable refresh source", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const pathSource = namedFunctionSource(src, "savedWorkflowPath");
+  const canonicalUuidSource = namedFunctionSource(src, "isCanonicalWorkflowInstanceUuid");
+  const identitySource = namedFunctionSource(src, "establishedWorkflowReplyIdentity");
+  const helperSource = namedFunctionSource(src, "activeWorkflowUuidForOpenReply");
+  const temporaryActive = { isPersisted: false, isTemporary: true };
+  const workflowUuids = new WeakMap([[temporaryActive, "33333333-3333-4333-8333-333333333333"]]);
+  const replyUuid = new Function(
+    "activeWorkflowRef",
+    "_workflowObjectUuids",
+    `${pathSource}; ${canonicalUuidSource}; ${identitySource}; ${helperSource}; return activeWorkflowUuidForOpenReply;`,
+  )(
+    () => temporaryActive,
+    workflowUuids,
+  );
+
+  // Even an existing object-map UUID is insufficient for a temporary tab:
+  // its tmp routing identity is ephemeral, so it cannot refresh the MCP's
+  // durable command fence.
+  assert.equal(replyUuid(temporaryActive), null);
+});
+
+test("#716 P1: existing mapped UUIDs still omit when noncanonical", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const pathSource = namedFunctionSource(src, "savedWorkflowPath");
+  const canonicalUuidSource = namedFunctionSource(src, "isCanonicalWorkflowInstanceUuid");
+  const identitySource = namedFunctionSource(src, "establishedWorkflowReplyIdentity");
+  const helperSource = namedFunctionSource(src, "activeWorkflowUuidForOpenReply");
+  const invalidVersion = { isPersisted: true, isTemporary: false, path: "workflows/invalid-version.json" };
+  const invalidVariant = { isPersisted: true, isTemporary: false, path: "workflows/invalid-variant.json" };
+  const uppercase = { isPersisted: true, isTemporary: false, path: "workflows/uppercase.json" };
+  const workflowUuids = new WeakMap([
+    [invalidVersion, "44444444-4444-0444-8444-444444444444"],
+    [invalidVariant, "55555555-5555-4555-7555-555555555555"],
+    [uppercase, "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA"],
+  ]);
+  let active = invalidVersion;
+  const replyUuid = new Function(
+    "activeWorkflowRef",
+    "_workflowObjectUuids",
+    `${pathSource}; ${canonicalUuidSource}; ${identitySource}; ${helperSource}; return activeWorkflowUuidForOpenReply;`,
+  )(
+    () => active,
+    workflowUuids,
+  );
+
+  for (const workflow of [invalidVersion, invalidVariant, uppercase]) {
+    active = workflow;
+    assert.equal(replyUuid(workflow), null, `mapped ${workflow.path} must not publish a noncanonical UUID`);
+  }
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1703,6 +1703,61 @@ function workflowTabId(wf = activeWorkflowRef()) {
   return id;
 }
 
+// `workflow_open` does most of its work asynchronously.  Its `target` remains a
+// valid workflow object even if another tab becomes active while repainting or
+// re-reading the file, so it must never be used by itself as proof of the
+// workflow that is active when the reply leaves the panel.  The command-fence
+// UUID is useful only for that live canvas; omit it rather than hand the MCP a
+// contradictory stamp when the active routing object changed mid-open (#716).
+function isCanonicalWorkflowInstanceUuid(value) {
+  return (
+    typeof value === "string" &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(value)
+  );
+}
+
+// A reply is an observation, never an identity-initialization point. In
+// particular, workflowTabId() and workflowStableUuid() mint values for an
+// unfamiliar object; doing that after a malformed/rebound active binding would
+// manufacture a plausible stamp for something the panel has not established as
+// a real workflow. Accept only an already-established UUID on a persisted,
+// canonical workflow. A tmp: routing handle is intentionally not durable enough
+// to publish as a command-fence refresh source.
+function establishedWorkflowReplyIdentity(wf) {
+  if (!wf || typeof wf !== "object") return null;
+  const uuid = _workflowObjectUuids.get(wf);
+  if (!isCanonicalWorkflowInstanceUuid(uuid)) return null;
+  const savedPath = savedWorkflowPath(wf);
+  return savedPath ? { routingKey: `wf:${savedPath}`, uuid } : null;
+}
+
+function activeWorkflowUuidForOpenReply(target) {
+  // Do not accept a workflow-service reference captured before workflow_open's
+  // awaits: a reconnect can replace/rebind that service while the old instance
+  // still reports `target` as active. Read the panel's CURRENT binding at reply
+  // emission, then require object and routing identity to agree.
+  const active = activeWorkflowRef();
+  if (!target || active !== target) return null;
+  const activeIdentity = establishedWorkflowReplyIdentity(active);
+  const targetIdentity = establishedWorkflowReplyIdentity(target);
+  if (!activeIdentity || !targetIdentity || activeIdentity.routingKey !== targetIdentity.routingKey) return null;
+  return activeIdentity.uuid;
+}
+
+// Like the post-open reply, workflow_list must observe the CURRENT workflow
+// service at response time.  The executor's captured `s` is still useful for
+// enumerating tabs, but after a reconnect it can be an old service that points
+// at a different workflow.  Keep the object and its established identity from
+// the same live read so a list reply cannot pair a stale active tab with a UUID
+// for the panel's current canvas (#716).
+function liveWorkflowListActive() {
+  const active = activeWorkflowRef();
+  return {
+    active,
+    activeIdentity: active ? establishedWorkflowReplyIdentity(active) : null,
+  };
+}
+
 // Per-tab agent session id + which thread this tab is showing. sessionStorage
 // is tab-scoped and survives reload — exactly what "restore the last session on
 // reload" needs, without two tabs clobbering each other.
@@ -8117,8 +8172,13 @@ const GRAPH_TOOL_EXECUTORS = {
   workflow_list() {
     const s = app?.extensionManager?.workflow;
     if (!s) throw new Error("workflow service unavailable on this frontend");
-    const active = s.activeWorkflow;
-    const activeRoutingKey = active ? workflowTabId(active) : null;
+    // `s` may be a pre-reconnect service.  Read the live binding rather than
+    // publishing its stale active object/UUID pair (#716 P1).
+    const { active, activeIdentity } = liveWorkflowListActive();
+    // #716 — the `active` reply's fence identity observes an already established
+    // workflow; it must not mint a UUID merely because a malformed/rebound
+    // object is truthy.
+    const activeRoutingKey = activeIdentity?.routingKey ?? null;
     // Every tab gets its per-instance routing id ("wf:<path>" saved, "tmp:<uuid>"
     // unsaved). For an UNSAVED tab this is the ONLY unique, matchable handle —
     // native ComfyUI reuses the "Unsaved Workflow" title/key/filename across unsaved
@@ -8186,6 +8246,10 @@ const GRAPH_TOOL_EXECUTORS = {
             title: active.filename || getWorkflowTitle(),
             key: activeDiskPath ? active.key : activeRoutingKey,
             routing_key: activeRoutingKey,
+            // #716 — only a previously established live identity can re-stamp
+            // the next command. Missing proof is omitted so the MCP keeps its
+            // existing workflow fence fail-closed.
+            ...(activeIdentity ? { workflow_uuid: activeIdentity.uuid } : {}),
           }
         : null,
       // Guard against nullish entries in openWorkflows: a tab mid-open/close can
@@ -8770,9 +8834,16 @@ const GRAPH_TOOL_EXECUTORS = {
       },
       applied: true,
     });
+    // #716 — only return a command-fence UUID after a FINAL synchronous check
+    // against the actual active workflow. `target` can remain a valid object
+    // after another tab wins the active slot during any await above; publishing
+    // its UUID then would let the MCP stamp a command for a different canvas.
+    // Omission is deliberate: the MCP keeps its existing fence fail-closed.
+    const activeWorkflowUuid = activeWorkflowUuidForOpenReply(target);
     return {
       opened: { path: target.path, filename: target.filename },
       routing_key: workflowTabId(target),
+      ...(activeWorkflowUuid ? { workflow_uuid: activeWorkflowUuid } : {}),
       modified: !!target.isModified,
       // #402 — the receipt id for THIS open. Journaled in the panel, so if this reply
       // never reaches the caller the outcome is still recoverable from workflow_list's


### PR DESCRIPTION
Lockstep companion for comfyui-mcp issue #716.\n\nAdds workflow_uuid only to workflow_list.active and successful workflow_open results, sourced from the actual active/target workflow object. It deliberately does not mutate all listed workflow records.\n\nTests: npm.cmd run test:unit (1540 passed); npm.cmd run typecheck.