### PR TITLE
fix(panel): rebind graph when reopening active workflow (#721)

### DIFF
--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -21,6 +21,7 @@ import {
   graphRootMismatchesActiveWorkflow,
   graphRootWorkflowUuidMismatches,
   graphRootWorkflowUuidMatches,
+  graphRootMatchesState,
   graphCommandMayMutateWorkflow,
   graphReadBindingChanged,
 } from "../../web/js/lib/graph-binding.js";
@@ -297,6 +298,18 @@ test("graphRootMismatchesActiveWorkflow: FALSE - matching serialized semantic st
     graphRootMismatchesActiveWorkflow({ rootGraph: serializedRoot(structuredClone(activeState)), activeWorkflow }),
     false,
   );
+});
+
+test("graphRootMatchesState: strict positive proof rejects a missing serializer and a same-UUID stale shape (#721)", () => {
+  const wanted = state(2);
+  wanted.extra = { comfyui_mcp: { workflow_uuid: "workflow-A" } };
+  assert.equal(graphRootMatchesState({ rootGraph: serializedRoot(structuredClone(wanted)), state: wanted }), true);
+  assert.equal(
+    graphRootMatchesState({ rootGraph: serializedRoot({ ...wanted, nodes: [{ id: 1, type: "Other" }, { id: 2, type: "Other" }] }), state: wanted }),
+    false,
+    "the target UUID alone cannot prove a stale same-workflow root was repainted",
+  );
+  assert.equal(graphRootMatchesState({ rootGraph: { _nodes: [] }, state: wanted }), false, "no serializer is no success proof");
 });
 
 test("graphRootMismatchesActiveWorkflow: FALSE - node array order and viewport drift do not invent a mismatch", () => {

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -367,20 +367,39 @@ test("#402 wiring: workflow_open BOUNDS the post-open disk read and never claims
   assert.ok(OPEN_DISK_READ_BUDGET_MS > 0 && OPEN_DISK_READ_BUDGET_MS <= 10000);
 });
 
-test("#402 wiring: workflow_open journals BOTH outcomes, and every early throw is a negative", () => {
+test("#402/#721 wiring: workflow_open journals clean negatives and partial rebind outcomes", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   const body = handlerBody(src, "async workflow_open({");
   assert.match(body, /const failOpen = \(err\) => \{/, "there must be a single negative-journal helper");
   assert.match(body, /applied: false/, "the failure path must journal applied:false");
   assert.match(body, /noteOpenAttempt\(\{[\s\S]*?cmd: "workflow_open",[\s\S]*?applied: true,/, "the success path must journal a receipt");
-  // Every `throw` inside workflow_open must go through failOpen — an unjournaled throw
-  // leaves a lost reply with no evidence at all. Code only: the prose discusses throws.
-  const rawThrows = [...stripComments(body).matchAll(/\bthrow (?!failOpen)/g)];
+  // A failed post-switch repaint is not a clean negative: the active workflow may
+  // already have changed. It must be journaled UNKNOWN, while every other throw
+  // remains a request that definitely did not apply. Code only: prose discusses throws.
+  assert.match(body, /const failOpenRebindUnknown = \(err\) => \{/);
+  assert.match(body, /applied: "unknown"/);
+  const rawThrows = [...stripComments(body).matchAll(/\bthrow (?!failOpen|failOpenRebindUnknown)/g)];
   assert.equal(
     rawThrows.length,
     0,
-    `every throw in workflow_open must be journaled via failOpen (found ${rawThrows.length} raw throws)`,
+    `every throw in workflow_open must be journaled as a clean negative or unknown partial outcome (found ${rawThrows.length} raw throws)`,
   );
+});
+
+test("#721 wiring: an already-active workflow uses every supported active-state shape and proves the repaint", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const body = handlerBody(src, "async workflow_open({");
+  // graph-binding accepts both shapes; repainting only the tracker form stranded a
+  // legitimate active tab whose state is exposed flat on the workflow object.
+  assert.match(body, /const st = target\.changeTracker\?\.activeState \?\? target\.activeState;/);
+  const repaintAt = body.indexOf("await app.loadGraphData(JSON.parse(JSON.stringify(st))");
+  const proofAt = body.indexOf("assertGraphBoundToActiveWorkflow(graph, rootGraph);", repaintAt);
+  const openedAt = body.indexOf("applied: true", proofAt);
+  assert.ok(repaintAt !== -1 && proofAt > repaintAt && openedAt > proofAt, "must prove the repaint before success");
+  // A failed/missing repaint is an honest unknown after s.openWorkflow may have
+  // switched tabs, never the old fabricated {opened} receipt.
+  assert.match(body, /if \(rebindFailed\) throw failOpenRebindUnknown\(rebindFailed\);/);
+  assert.match(body, /workflow_open could not rebind the active canvas/);
 });
 
 test("#442 defect-2 wiring: the re-read is gated on a FRESH dirty re-check (no silent data loss)", () => {

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -54,6 +54,62 @@ function handlerBody(src, sig) {
   return src.slice(start, m ? after + m.index : src.length);
 }
 
+/** The balanced block starting at an `if (...) {` marker. The source contracts below
+ * need to prove a failure cannot merely skip one statement and then reach a later
+ * re-baseline/disk read. Strip comments and literals first so their prose/braces do
+ * not affect the lightweight structural scan. */
+function blockAt(src, marker) {
+  const start = src.indexOf(marker);
+  assert.notEqual(start, -1, `missing block marker: ${marker}`);
+  const brace = src.indexOf("{", start + marker.length);
+  assert.notEqual(brace, -1, `missing opening brace: ${marker}`);
+  const scan = stripComments(src).replace(/(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*")/g, "");
+  const scanBrace = scan.indexOf("{", start + marker.length);
+  let depth = 0;
+  for (let i = scanBrace; i < scan.length; i += 1) {
+    if (scan[i] === "{") depth += 1;
+    if (scan[i] === "}" && --depth === 0) return src.slice(brace, i + 1);
+  }
+  throw new Error(`unterminated block: ${marker}`);
+}
+
+/** Extract a balanced source block while ignoring braces in comments and strings. */
+function codeBlockAt(src, marker) {
+  const start = src.indexOf(marker);
+  assert.notEqual(start, -1, `missing block marker: ${marker}`);
+  const brace = src.indexOf("{", start + marker.length);
+  assert.notEqual(brace, -1, `missing opening brace: ${marker}`);
+  let depth = 0;
+  for (let i = brace; i < src.length; i += 1) {
+    const ch = src[i];
+    if (ch === "/" && src[i + 1] === "/") {
+      i = src.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === "/" && src[i + 1] === "*") {
+      i = src.indexOf("*/", i + 2);
+      if (i < 0) break;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < src.length; i += 1) {
+        if (src[i] === "\\") {
+          i += 1;
+          continue;
+        }
+        if (src[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return src.slice(brace, i + 1);
+  }
+  throw new Error(`unterminated block: ${marker}`);
+}
+
 const receiptFor = (requested, extra = {}) =>
   makeOpenReceipt({
     seq: 1,
@@ -386,20 +442,50 @@ test("#402/#721 wiring: workflow_open journals clean negatives and partial rebin
   );
 });
 
-test("#721 wiring: an already-active workflow uses every supported active-state shape and proves the repaint", () => {
+test("#721 P1: an already-active workflow requires state even when empty, then proves the repaint", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   const body = handlerBody(src, "async workflow_open({");
   // graph-binding accepts both shapes; repainting only the tracker form stranded a
   // legitimate active tab whose state is exposed flat on the workflow object.
   assert.match(body, /const st = target\.changeTracker\?\.activeState \?\? target\.activeState;/);
-  const repaintAt = body.indexOf("await app.loadGraphData(JSON.parse(JSON.stringify(st))");
-  const proofAt = body.indexOf("assertGraphBoundToActiveWorkflow(graph, rootGraph);", repaintAt);
-  const openedAt = body.indexOf("applied: true", proofAt);
+  assert.match(
+    body,
+    /if \(!st \|\| !Array\.isArray\(st\.nodes\)\) \{[\s\S]{0,500}?rebindFailed = new Error\(/,
+    "a state-less EMPTY target cannot report opened against the prior canvas",
+  );
+  const repaintAt = body.indexOf("await app.loadGraphData(repaintState, true, true, target);");
+  const proofAt = body.indexOf("graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid: targetUuid })", repaintAt);
+  const openedAt = body.lastIndexOf("applied: true");
   assert.ok(repaintAt !== -1 && proofAt > repaintAt && openedAt > proofAt, "must prove the repaint before success");
   // A failed/missing repaint is an honest unknown after s.openWorkflow may have
   // switched tabs, never the old fabricated {opened} receipt.
   assert.match(body, /if \(rebindFailed\) throw failOpenRebindUnknown\(rebindFailed\);/);
   assert.match(body, /workflow_open could not rebind the active canvas/);
+});
+
+test("#721 P1: dirty rebind success requires the target UUID, never only a read-shaped comparison", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const body = handlerBody(src, "async workflow_open({");
+  const repaintStart = body.indexOf("const targetUuid = workflowStableUuid");
+  const repaint = body.slice(repaintStart, body.indexOf("} catch (err)", repaintStart));
+  assert.match(repaint, /const targetUuid = workflowStableUuid\(target, \{ embed: true \}\);/);
+  assert.match(repaint, /\[WORKFLOW_UUID_FIELD\]: targetUuid/);
+  assert.match(repaint, /await app\.loadGraphData\(repaintState, true, true, target\);/);
+  assert.match(repaint, /activeWorkflowRef\(\) !== target/);
+  assert.match(repaint, /graphRootWorkflowUuidMatches\(\{ rootGraph, activeWorkflowUuid: targetUuid \}\)/);
+  assert.match(repaint, /graphRootMatchesState\(\{ rootGraph, state: repaintState \}\)/);
+  assert.doesNotMatch(repaint, /assertGraphBoundToActiveWorkflow\(/, "the read guard is deliberately non-strict for dirty roots");
+});
+
+test("#721 P1: a failed rebind never re-baselines, reads disk, or reloads the stale root", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const body = handlerBody(src, "async workflow_open({");
+  const successOnly = codeBlockAt(body, "if (!rebindFailed)");
+  assert.match(successOnly, /await clearSpuriousOpenModified\(target, \{/);
+  assert.match(successOnly, /await withDeadline\(/);
+  assert.match(successOnly, /await app\.loadGraphData\(diskGraph/);
+  const unknownAt = body.indexOf("if (rebindFailed) throw failOpenRebindUnknown(rebindFailed);");
+  assert.ok(unknownAt > body.indexOf("if (!rebindFailed)"), "the unknown receipt is emitted only after the guarded success-only work");
 });
 
 test("#442 defect-2 wiring: the re-read is gated on a FRESH dirty re-check (no silent data loss)", () => {
@@ -610,7 +696,7 @@ test("#442 DATA-LOSS: every mutating await of the section is held across its own
   );
   // The repaint load has the same clobber shape (it overwrites the canvas with the tab's
   // pre-edit buffer), so it must be held too.
-  const repaintAt = body.indexOf("await app.loadGraphData(JSON.parse(JSON.stringify(st))");
+  const repaintAt = body.indexOf("await app.loadGraphData(repaintState, true, true, target);");
   assert.notEqual(repaintAt, -1);
   const repaintBegin = body.lastIndexOf("beginWorkflowReloadStep(reloadGuardToken);", repaintAt);
   const repaintEnd = body.indexOf("endWorkflowReloadStep(reloadGuardToken);", repaintAt);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -252,6 +252,7 @@ import {
   graphRootMismatchesActiveWorkflow,
   graphRootWorkflowUuidMismatches,
   graphRootWorkflowUuidMatches,
+  graphRootMatchesState,
   graphCommandMayMutateWorkflow,
   graphReadBindingChanged,
 } from "./lib/graph-binding.js";
@@ -8459,33 +8460,69 @@ const GRAPH_TOOL_EXECUTORS = {
       // LiteGraph canvas flag, not a workflow-service member.
         beginWorkflowReloadStep(reloadGuardToken);
         try {
-          // `assertGraphBoundToActiveWorkflow` deliberately accepts both tracker-owned
-          // and flat activeState shapes. Use that SAME state source here: otherwise a
-          // frontend that reports the active workflow's 15 nodes through flat
-          // `target.activeState` skips this repaint, returns `opened`, and leaves every
-          // graph tool behind the desync guard (#721).
+          // `activeWorkflowNodeCount` deliberately accepts both tracker-owned and flat
+          // activeState shapes. Use that SAME state source here: otherwise a frontend
+          // that reports the active workflow's 15 nodes through flat `target.activeState`
+          // skips this repaint, returns `opened`, and leaves every graph tool behind the
+          // desync guard (#721).
           const st = target.changeTracker?.activeState ?? target.activeState;
           if (!st || !Array.isArray(st.nodes)) {
-            if (activeWorkflowNodeCount(target) > 0) {
-              rebindFailed = new Error(
-                "workflow_open could not rebind the active canvas: the workflow has graph state, " +
-                  "but this frontend did not expose it for a safe repaint. The open may have switched " +
-                  "the active workflow; inspect panel_list_workflows, then reload the panel before graph edits.",
-              );
-            }
+            // A zero-node target still needs a POSITIVE binding proof. Otherwise an
+            // unsupported frontend can leave the previous nonempty canvas mounted and
+            // receive a fabricated {opened} just because the target happens to be empty.
+            rebindFailed = new Error(
+              "workflow_open could not rebind the active canvas because this frontend did not expose " +
+                "a complete workflow state for a safe repaint. The open may have switched the active " +
+                "workflow; inspect panel_list_workflows, then reload the panel before graph edits.",
+            );
           } else if (typeof app.loadGraphData !== "function") {
             rebindFailed = new Error(
               "workflow_open could not rebind the active canvas because this frontend does not expose " +
                 "loadGraphData. The open may have switched the active workflow; reload the panel before graph edits.",
             );
           } else {
-            await app.loadGraphData(JSON.parse(JSON.stringify(st)), true, true, target);
+            // A graph shape is not ownership proof: two dirty tabs can have the same
+            // nodes, and the normal read guard intentionally stays inconclusive for a
+            // dirty, un-stamped root. Stamp THIS target's live-object identity into the
+            // exact cloned state that is about to be loaded, then require that marker on
+            // the resulting root. The UUID is panel-owned metadata, not caller input;
+            // this is the same workflow identity used by the command fence.
+            const targetUuid = workflowStableUuid(target, { embed: true });
+            const repaintState = JSON.parse(JSON.stringify(st));
+            const repaintExtra =
+              repaintState.extra && typeof repaintState.extra === "object" && !Array.isArray(repaintState.extra)
+                ? repaintState.extra
+                : {};
+            const repaintMeta =
+              repaintExtra[WORKFLOW_META_NAMESPACE] &&
+              typeof repaintExtra[WORKFLOW_META_NAMESPACE] === "object" &&
+              !Array.isArray(repaintExtra[WORKFLOW_META_NAMESPACE])
+                ? repaintExtra[WORKFLOW_META_NAMESPACE]
+                : {};
+            repaintState.extra = {
+              ...repaintExtra,
+              [WORKFLOW_META_NAMESPACE]: {
+                ...repaintMeta,
+                [WORKFLOW_UUID_FIELD]: targetUuid,
+                ...(target.path ? { [WORKFLOW_PATH_FIELD]: target.path } : {}),
+              },
+            };
+            await app.loadGraphData(repaintState, true, true, target);
             // A successful promise alone is not a binding receipt: old/partial frontend
             // implementations can resolve while leaving app.canvas on the previous root.
-            // Re-run the same fail-closed binding guard graph tools use before reporting
-            // that the recommended recovery completed.
-            const { graph, rootGraph } = getGraphCtx();
-            assertGraphBoundToActiveWorkflow(graph, rootGraph);
+            // Demand the positive, target-specific marker even for dirty workflows —
+            // read-only graph comparisons intentionally cannot prove that case.
+            const { rootGraph } = getGraphCtx();
+            if (
+              activeWorkflowRef() !== target ||
+              !graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid: targetUuid }) ||
+              !graphRootMatchesState({ rootGraph, state: repaintState })
+            ) {
+              rebindFailed = new Error(
+                "workflow_open could not prove that the active canvas was rebound to the requested workflow. " +
+                  "The open may have switched the active workflow; reload the panel before graph edits.",
+              );
+            }
           }
         } catch (err) {
           rebindFailed = err instanceof Error ? err : new Error(coerceMessageText(err));
@@ -8493,6 +8530,11 @@ const GRAPH_TOOL_EXECUTORS = {
         } finally {
           endWorkflowReloadStep(reloadGuardToken);
         }
+        // Do not touch the change tracker, inspect disk state, or re-baseline until
+        // the target-specific repaint proof above succeeds. In particular, capturing a
+        // still-stale root as a clean baseline after a failed repaint would corrupt the
+        // target's in-memory state and make a later save/fence believe it was trustworthy.
+        if (!rebindFailed) {
         // Opening alone must not dirty the tab (a spurious post-load change-tracker
         // diff otherwise flips it to modified:true and blocks an unforced close).
         //
@@ -8670,6 +8712,7 @@ const GRAPH_TOOL_EXECUTORS = {
               "the canvas was reloaded from the on-disk file, but the panel lost its exclusive " +
               "window before it could re-baseline the tab, so the tab may still show as modified";
           }
+        }
         }
       }
     } catch (err) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -8305,6 +8305,28 @@ const GRAPH_TOOL_EXECUTORS = {
       });
       return err;
     };
+    // An open can switch the workflow service before the panel manages to repaint
+    // LiteGraph. That is not a clean negative: retrying is not a harmless assertion
+    // that nothing happened, because the active workflow may already have changed.
+    // Journal the partial result explicitly rather than returning an `opened` receipt
+    // that tells the caller its graph-binding recovery worked when it did not (#721).
+    const failOpenRebindUnknown = (err) => {
+      noteOpenAttempt({
+        cmd: "workflow_open",
+        rid,
+        requested: path,
+        resolved: target
+          ? {
+              path: target.path,
+              filename: target.filename,
+              routing_key: workflowTabId(target),
+            }
+          : null,
+        applied: "unknown",
+        error: coerceMessageText(err?.message ?? err),
+      });
+      return err;
+    };
     const s = app?.extensionManager?.workflow;
     if (!s?.openWorkflow) throw failOpen(new Error("workflow service unavailable"));
     const find = () => {
@@ -8379,6 +8401,7 @@ const GRAPH_TOOL_EXECUTORS = {
     let reloaded = false;
     let reloadError = null;
     let openFailed = null;
+    let rebindFailed = null;
     if (priorInteraction !== null) canvasView.allow_interaction = false;
     // Hold the switch+reload critical section across the WHOLE mutating sequence. The canvas
     // freeze keeps the USER out; this keeps the BRIDGE out, so a concurrent graph_* command
@@ -8436,12 +8459,37 @@ const GRAPH_TOOL_EXECUTORS = {
       // LiteGraph canvas flag, not a workflow-service member.
         beginWorkflowReloadStep(reloadGuardToken);
         try {
-          const st = target.changeTracker?.activeState;
-          if (st && typeof app.loadGraphData === "function") {
+          // `assertGraphBoundToActiveWorkflow` deliberately accepts both tracker-owned
+          // and flat activeState shapes. Use that SAME state source here: otherwise a
+          // frontend that reports the active workflow's 15 nodes through flat
+          // `target.activeState` skips this repaint, returns `opened`, and leaves every
+          // graph tool behind the desync guard (#721).
+          const st = target.changeTracker?.activeState ?? target.activeState;
+          if (!st || !Array.isArray(st.nodes)) {
+            if (activeWorkflowNodeCount(target) > 0) {
+              rebindFailed = new Error(
+                "workflow_open could not rebind the active canvas: the workflow has graph state, " +
+                  "but this frontend did not expose it for a safe repaint. The open may have switched " +
+                  "the active workflow; inspect panel_list_workflows, then reload the panel before graph edits.",
+              );
+            }
+          } else if (typeof app.loadGraphData !== "function") {
+            rebindFailed = new Error(
+              "workflow_open could not rebind the active canvas because this frontend does not expose " +
+                "loadGraphData. The open may have switched the active workflow; reload the panel before graph edits.",
+            );
+          } else {
             await app.loadGraphData(JSON.parse(JSON.stringify(st)), true, true, target);
+            // A successful promise alone is not a binding receipt: old/partial frontend
+            // implementations can resolve while leaving app.canvas on the previous root.
+            // Re-run the same fail-closed binding guard graph tools use before reporting
+            // that the recommended recovery completed.
+            const { graph, rootGraph } = getGraphCtx();
+            assertGraphBoundToActiveWorkflow(graph, rootGraph);
           }
         } catch (err) {
-          console.warn("[comfyui-mcp-panel] workflow_open repaint failed:", err?.message ?? err);
+          rebindFailed = err instanceof Error ? err : new Error(coerceMessageText(err));
+          console.warn("[comfyui-mcp-panel] workflow_open repaint failed:", rebindFailed.message);
         } finally {
           endWorkflowReloadStep(reloadGuardToken);
         }
@@ -8637,6 +8685,7 @@ const GRAPH_TOOL_EXECUTORS = {
       if (priorInteraction !== null) canvasView.allow_interaction = priorInteraction;
     }
     if (openFailed) throw failOpen(openFailed);
+    if (rebindFailed) throw failOpenRebindUnknown(rebindFailed);
     const receipt = noteOpenAttempt({
       cmd: "workflow_open",
       rid,

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -150,6 +150,23 @@ function graphShape(state) {
 }
 
 /**
+ * Strict positive proof that a root graph now represents this exact serialized
+ * state. Unlike the ordinary read guard, this does NOT treat missing serializer
+ * data or a dirty workflow as inconclusive: callers use it only after they have
+ * just asked `loadGraphData` to install `state`, so an absent proof must not turn
+ * into a fabricated success.
+ */
+export function graphRootMatchesState({ rootGraph, state } = {}) {
+  try {
+    const expected = graphShape(state);
+    const actual = graphShape(rootGraph?.serialize?.());
+    return expected != null && actual != null && expected === actual;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * True when the live ROOT graph is demonstrably a different workflow from the
  * active workflow's own serialized state. Unlike graphReadDesynced's original
  * empty-canvas check, this catches a stale *nonempty* canvas (for example an


### PR DESCRIPTION
## What changed

- `workflow_open` now repaints from either supported active-state shape: `changeTracker.activeState` or flat `activeState`.
- It verifies the canvas binding after the repaint before returning an `opened` receipt.
- A missing or failed repaint is recorded as an `applied:unknown` partial outcome, with recovery guidance, rather than a fabricated success.

## Why

The graph desync guard already recognized a real active workflow exposed through flat `activeState`, but `panel_open_workflow` only repainted the tracker form. On that frontend shape, reopening an already-active workflow reported success yet left graph tools blocked by the same desync guard (#721).

## Validation

- `node --test browser_tests/unit/open-outcome.test.mjs`
- `npm.cmd run test:unit` (1549 passed)
- `npm.cmd run typecheck`