### PR TITLE
fix(panel): fence async widget writes to their workflow (#718)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.35] - 2026-08-02
+
+### Added
+- stamp the session epoch from any epoch-carrying frame (#694) (#549)
+- add atomic node editor
+
+### Fixed
+- recheck graph_set_widget workflow targeting at the post-await write boundary (#718)
+- recover dirty graph reads
+- bind restart readiness to browser tab identity
+- scope command retries to session epoch (#550)
+- prevent dirty graph-binding false positives (#545) (#546)
+- reject mismatched retry tokens (#547)
+- retry identity via retry_of + session-epoch replay gating (#694) (#543)
+- validate legacy color and mode targets
+- normalize legacy numeric node ids
+- retain legacy rail aliases
+- validate consolidated node targets
+- validate consolidated title input
+- validate legacy presentation inputs
+- preserve legacy motion compatibility
+- preserve legacy color behavior
+- preserve legacy title and color nulls
+- preserve atomic edit rollback and legacy commands
+- fence stale nonempty workflow graph (#349)
+- centralize stale outline cleanup
+- retain missing-node-type outlines
+- clear stale root outlines after subgraph conversion (#516)
+- restore CivitAI keyword search results
+
+
 ## [0.11.34] - 2026-08-02
 
 ### Added

--- a/browser_tests/unit/session-rebind.test.mjs
+++ b/browser_tests/unit/session-rebind.test.mjs
@@ -257,13 +257,18 @@ test("#296: resume rides the hello only when present", () => {
   assert.equal(buildHelloPayload({ tabId: "t", resume: "sess-1" }).resume, "sess-1");
 });
 
-test("#570 P0c: hello ALWAYS advertises enforces_workflow_stamp so the orchestrator won't gate this build's graph edits", () => {
-  // A current build unconditionally enforces the per-command workflow stamp; the flag must
-  // ride every hello (not gated behind any optional field) so the server never fails closed
-  // on our mutating graph commands.
+test("#570/#718: hello ALWAYS advertises both workflow-stamp fences so the orchestrator can safely allow graph edits", () => {
+  // A current build fences at dispatch AND immediately before an async graph write.
+  // Both flags must ride every hello (not gated behind optional fields), so the
+  // server never treats this build like an older unsafe bundle.
   assert.equal(buildHelloPayload({ tabId: "t" }).enforces_workflow_stamp, true);
+  assert.equal(buildHelloPayload({ tabId: "t" }).enforces_workflow_stamp_at_write, true);
   assert.equal(
     buildHelloPayload({ tabId: "wf:x.json", title: "x", backend: "codex" }).enforces_workflow_stamp,
+    true,
+  );
+  assert.equal(
+    buildHelloPayload({ tabId: "wf:x.json", title: "x", backend: "codex" }).enforces_workflow_stamp_at_write,
     true,
   );
 });

--- a/browser_tests/unit/set-widget-fresh-backend.test.mjs
+++ b/browser_tests/unit/set-widget-fresh-backend.test.mjs
@@ -33,9 +33,14 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import { runSetWidget } from "../../web/js/lib/set-widget.js";
 import { refreshComboOptionsFromDefs } from "../../web/js/lib/asset-staleness.js";
+import { commandTargetsActiveWorkflow } from "../../web/js/lib/workflow-chat-identity.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 
 // A registry shaped like LG.registered_node_types once /object_info loaded. Each
 // entry carries a `.nodeData` def (registerNodesFromDefs stamps one per class), so
@@ -93,6 +98,141 @@ function regNode(type, widgets, extra = {}) {
 }
 
 const HOOKS = { beforeChange() {}, afterChange() {}, setDirty() {} };
+
+test("#718 graph_set_widget: a workflow switch during fresh-object-info wait refuses before the write", async () => {
+  const reg = loadedRegistry();
+  const node = regNode("KSampler", [{ name: "steps", type: "INT", value: 20 }]);
+  let activeUuid = "workflow-A";
+  let releaseFetch;
+  let markFetchStarted;
+  const fetchStarted = new Promise((resolve) => {
+    markFetchStarted = resolve;
+  });
+
+  const pending = runSetWidget(node, "steps", 30, {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: () => {
+      markFetchStarted();
+      return new Promise((resolve) => {
+        releaseFetch = () => resolve(objectInfo());
+      });
+    },
+    assertTargetStillCurrent: () => {
+      if (!commandTargetsActiveWorkflow({
+        cmd: "graph_set_widget",
+        commandUuid: "workflow-A",
+        activeUuid,
+      })) {
+        throw new Error("workflow instance mismatch");
+      }
+    },
+    ...HOOKS,
+  });
+
+  await fetchStarted;
+  // The command was fenced for A at dispatch, then the user changed the active
+  // canvas while graph_set_widget awaited its required fresh backend oracle.
+  activeUuid = "workflow-B";
+  releaseFetch();
+
+  await assert.rejects(pending, /workflow instance mismatch/);
+  assert.equal(node.widgets[0].value, 20, "the stale command must not mutate workflow B");
+});
+
+test("#718 graph_set_widget: a switch during fresh-object-info wait cannot reconcile stale widget names", async () => {
+  const reg = loadedRegistry();
+  const node = regNode("KSampler", [{ name: "UNKNOWN", type: "INT", value: 20 }]);
+  node.constructor.nodeData = { input: { required: { steps: ["INT"] } } };
+  let activeUuid = "workflow-A";
+  let releaseFetch;
+  let markFetchStarted;
+  const fetchStarted = new Promise((resolve) => {
+    markFetchStarted = resolve;
+  });
+
+  const pending = runSetWidget(node, "steps", 30, {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: () => {
+      markFetchStarted();
+      return new Promise((resolve) => {
+        releaseFetch = () => resolve(objectInfo());
+      });
+    },
+    assertTargetStillCurrent: () => {
+      if (!commandTargetsActiveWorkflow({
+        cmd: "graph_set_widget",
+        commandUuid: "workflow-A",
+        activeUuid,
+      })) {
+        throw new Error("workflow instance mismatch");
+      }
+    },
+    ...HOOKS,
+  });
+
+  await fetchStarted;
+  activeUuid = "workflow-B";
+  releaseFetch();
+
+  await assert.rejects(pending, /workflow instance mismatch/);
+  assert.equal(node.widgets[0].name, "UNKNOWN", "the stale command must not repair workflow B's widget metadata");
+  assert.equal(node.widgets[0].value, 20);
+});
+
+for (const commandUuid of [undefined, "   "]) {
+  test(`#718 graph_set_widget: ${commandUuid === undefined ? "missing" : "blank"} stamp refuses at the post-await write boundary`, async () => {
+    const reg = loadedRegistry();
+    const node = regNode("KSampler", [{ name: "steps", type: "INT", value: 20 }]);
+    let releaseFetch;
+    let markFetchStarted;
+    const fetchStarted = new Promise((resolve) => {
+      markFetchStarted = resolve;
+    });
+
+    const pending = runSetWidget(node, "steps", 30, {
+      registry: reg,
+      getRegistry: () => reg,
+      getFreshObjectInfo: () => {
+        markFetchStarted();
+        return new Promise((resolve) => {
+          releaseFetch = () => resolve(objectInfo());
+        });
+      },
+      assertTargetStillCurrent: () => {
+        if (!commandTargetsActiveWorkflow({
+          cmd: "graph_set_widget",
+          commandUuid,
+          activeUuid: "workflow-A",
+        })) {
+          throw new Error("workflow instance mismatch");
+        }
+      },
+      ...HOOKS,
+    });
+
+    await fetchStarted;
+    releaseFetch();
+
+    await assert.rejects(pending, /workflow instance mismatch/);
+    assert.equal(node.widgets[0].value, 20, "an unstamped command must not mutate after its await");
+  });
+}
+
+test("#718 wiring: graph_set_widget passes the execution-time workflow fence into runSetWidget", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const start = src.indexOf("async graph_set_widget({ node_id, widget, value, workflow_uuid })");
+  const end = src.indexOf("\n  graph_set_node_property(", start);
+  assert.notEqual(start, -1, "graph_set_widget executor must accept the bridge-owned stamp");
+  assert.notEqual(end, -1, "graph_set_widget executor boundary must exist");
+  const body = src.slice(start, end);
+  assert.match(
+    body,
+    /assertTargetStillCurrent:\s*\(\)\s*=>\s*assertActiveWorkflowCommandTarget\([\s\S]*workflow_uuid/,
+    "the post-await write boundary must recheck the exact command stamp",
+  );
+});
 
 test("#458 set_widget: REMOVED type (stale registry positive, absent from fresh object_info) ⇒ FAIL CLOSED, no mutation", async () => {
   // GoneNode's pack was uninstalled + ComfyUI restarted WITHOUT a tab reload: the

--- a/browser_tests/unit/set-widget-upload-asset.test.mjs
+++ b/browser_tests/unit/set-widget-upload-asset.test.mjs
@@ -60,6 +60,40 @@ test("nested LoadImage upload the combo never lists is accepted when the server 
   assert.ok(widget.options.values.includes("xyr_canvas/boswellia_source.png"));
 });
 
+test("#718: a workflow switch during upload confirmation cannot add an option or write", async () => {
+  const widget = { name: "image", type: "combo", options: { values: ["example.png"] }, value: "example.png" };
+  const node = { id: 191, type: "LoadImage", widgets: [widget] };
+  let current = true;
+  let releaseProbe;
+  let markProbeStarted;
+  const probeStarted = new Promise((resolve) => {
+    markProbeStarted = resolve;
+  });
+
+  const pending = runSetWidget(node, "image", "xyr_canvas/boswellia_source.png", {
+    registry: REGISTRY,
+    ...freshOracle,
+    refreshCombos: refreshFromFreshDefs,
+    confirmServerAsset: () => {
+      markProbeStarted();
+      return new Promise((resolve) => {
+        releaseProbe = () => resolve(true);
+      });
+    },
+    assertTargetStillCurrent: () => {
+      if (!current) throw new Error("workflow instance mismatch");
+    },
+  });
+
+  await probeStarted;
+  current = false;
+  releaseProbe();
+
+  await assert.rejects(pending, /workflow instance mismatch/);
+  assert.equal(widget.value, "example.png");
+  assert.deepEqual(widget.options.values, ["example.png"], "the stale command must not add its uploaded asset");
+});
+
 test("a plain model combo is NOT rescued by confirmServerAsset (gated to upload inputs)", async () => {
   const widget = {
     name: "ckpt_name",

--- a/browser_tests/unit/subgraph-stale-outline.test.mjs
+++ b/browser_tests/unit/subgraph-stale-outline.test.mjs
@@ -21,7 +21,7 @@ function methodSource(name, args) {
 
 const createSource = methodSource("graph_create_subgraph", "\\{ node_ids \\}");
 const groupSource = methodSource("graph_subgraph_group", "\\{ group \\}");
-const setWidgetSource = methodSource("async graph_set_widget", "\\{ node_id, widget, value \\}");
+const setWidgetSource = methodSource("async graph_set_widget", "\\{ node_id, widget, value, workflow_uuid \\}");
 // Extract the actual helper through its unindented closing brace. Do not depend on
 // the following doc comment or on checkout line endings: Windows worktrees retain
 // CRLF, while the test runner reads the source verbatim.

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -102,11 +102,11 @@ test('#570 fence: stamped uuid but active is UNRESOLVABLE → REJECT (fail close
   assert.equal(commandWorkflowMismatch({ commandUuid: 'uuid-A', activeUuid: null }), true)
 })
 
-test('#570 fence: NO stamp (old orchestrator / identity-less tab) → never fenced', () => {
-  assert.equal(commandWorkflowMismatch({ commandUuid: undefined, activeUuid: 'uuid-B' }), false)
-  assert.equal(commandWorkflowMismatch({ commandUuid: '', activeUuid: 'uuid-B' }), false)
-  assert.equal(commandWorkflowMismatch({ commandUuid: '   ', activeUuid: 'uuid-B' }), false)
-  assert.equal(commandWorkflowMismatch({}), false)
+test('#718 fence: missing or blank stamp is a protected-command mismatch (fail closed)', () => {
+  assert.equal(commandWorkflowMismatch({ commandUuid: undefined, activeUuid: 'uuid-B' }), true)
+  assert.equal(commandWorkflowMismatch({ commandUuid: '', activeUuid: 'uuid-B' }), true)
+  assert.equal(commandWorkflowMismatch({ commandUuid: '   ', activeUuid: 'uuid-B' }), true)
+  assert.equal(commandWorkflowMismatch({}), true)
 })
 
 // #570 — FAIL-CLOSED durability carrier. The embedded graph.extra uuid is only trustworthy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.34"
+version = "0.11.35"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -95,9 +95,8 @@ import {
   updateMetadataEntry,
 } from "./lib/chat-history-store.js";
 import {
-  activeWorkflowFenceApplies,
   classifyPinnedTarget,
-  commandWorkflowMismatch,
+  commandTargetsActiveWorkflow,
   selectorSearchIncludesListed,
   selectorTargetsNonActiveWorkflow,
   isNewWorkflowLoad,
@@ -667,7 +666,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.34";
+const PANEL_VERSION = "0.11.35";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;
@@ -1654,6 +1653,28 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
     }
   }
   return id;
+}
+
+/** Refuse a command whose bridge-owned stamp no longer names this active canvas.
+ * This runs at dispatch and can be injected into an async graph executor's
+ * mutation boundary after that executor has awaited external state (#718). */
+function assertActiveWorkflowCommandTarget(msg, targetsNonActive = false) {
+  const commandUuid = msg?.[WORKFLOW_UUID_FIELD];
+  if (
+    !commandTargetsActiveWorkflow({
+      cmd: msg?.cmd,
+      commandUuid,
+      activeUuid: workflowStableUuid(),
+      targetsNonActive,
+    })
+  ) {
+    throw new Error(
+      `workflow instance mismatch: this command targets a different workflow than the ` +
+        `active canvas â€” the workflow was switched or replaced after it was issued. ` +
+        `Re-select the intended workflow (panel_open_workflow) or re-target with ` +
+        `panel_set_workflow_target({mode:"current"}), then retry.`,
+    );
+  }
 }
 
 function workflowStorageKey({ embed = false } = {}) {
@@ -6788,7 +6809,7 @@ const GRAPH_TOOL_EXECUTORS = {
     };
   },
 
-  async graph_set_widget({ node_id, widget, value }) {
+  async graph_set_widget({ node_id, widget, value, workflow_uuid }) {
     const { app, graph, LG, rootGraph } = getGraphCtx();
     const node = resolveNode(graph, node_id);
     // #314: the LTXDirector custom node owns its timeline widgets through an in-browser
@@ -6874,6 +6895,15 @@ const GRAPH_TOOL_EXECUTORS = {
       beforeChange: () => graph.beforeChange(),
       afterChange: () => graph.afterChange(),
       setDirty: () => graph.setDirtyCanvas(true, true),
+      // #718: the first command-handler fence ran before awaitObjectInfoHistorySeed()
+      // and the fresh /object_info request. A user can switch workflows while either
+      // promise is pending, so re-read the ACTIVE uuid at the exact shared write
+      // boundary. runSetWidget calls this synchronously before every write path.
+      assertTargetStillCurrent: () =>
+        assertActiveWorkflowCommandTarget({
+          cmd: "graph_set_widget",
+          [WORKFLOW_UUID_FIELD]: workflow_uuid,
+        }),
       // Stale-combo retry: reuse the /object_info already fetched for authorization
       // (passed by runSetWidget) to refresh THIS target's combo option lists in place
       // — a single fetch total (#458 P2). When a payload IS present we NEVER re-fetch,
@@ -11083,7 +11113,6 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // (openWorkflows.find) and exempt ONLY when it lands on a real open workflow that is
             // NOT the active one — a path that resolves to the ACTIVE workflow (e.g. replaced in
             // place at the same path) still hits the active canvas, so it is fenced.
-            const commandUuid = msg?.[WORKFLOW_UUID_FIELD];
             let targetsNonActive = false;
             if (msg.cmd === "workflow_rename" || msg.cmd === "workflow_close") {
               const pathArg = typeof msg?.path === "string" ? msg.path.trim() : "";
@@ -11101,8 +11130,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
               }
             }
             if (
-              activeWorkflowFenceApplies({ cmd: msg.cmd, targetsNonActive }) &&
-              commandWorkflowMismatch({ commandUuid, activeUuid: workflowStableUuid() })
+              !commandTargetsActiveWorkflow({
+                cmd: msg.cmd,
+                commandUuid: msg?.[WORKFLOW_UUID_FIELD],
+                activeUuid: workflowStableUuid(),
+                targetsNonActive,
+              })
             ) {
               throw new Error(
                 `workflow instance mismatch: this command targets a different workflow than the ` +

--- a/web/js/lib/session-rebind.js
+++ b/web/js/lib/session-rebind.js
@@ -319,6 +319,11 @@ export function buildHelloPayload({
     // boundary — the flag is self-asserted, so a modified panel can spoof it, but that only
     // leaks the user's own workflow into their own workflow (self-attack). No attestation.
     enforces_workflow_stamp: true,
+    // #718: graph_set_widget awaits fresh backend metadata before its write and
+    // must recheck the stamp after that await. This separate capability lets a
+    // newer orchestrator fail closed for an older bundle that only fences at
+    // initial dispatch.
+    enforces_workflow_stamp_at_write: true,
   };
   // #709 — a browser-tab-scoped identity, deliberately separate from the
   // workflow routing id. `tab_id` is normally a workflow path and can therefore

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -52,6 +52,12 @@ export async function runSetWidget(
     beforeChange,
     afterChange,
     setDirty,
+    // The graph command handler captures its bridge-owned workflow stamp at
+    // dispatch. `runSetWidget` awaits fresh backend metadata before writing, so
+    // it rechecks that stamp immediately before every possible write. This is
+    // injected so the shared body stays browser-independent and its unit tests
+    // exercise the exact production write boundary.
+    assertTargetStillCurrent,
     refreshCombos,
     confirmServerAsset,
   } = {},
@@ -236,9 +242,19 @@ export async function runSetWidget(
   // (1) Preflight the OUTER node before ANY mutation; decide whether reconcile
   //     may run (never on a placeholder; skipped for subgraph parents).
   const { reconcile } = preflightSetWidgetTarget(liveRegistry(), node);
+  // Every mutation below belongs to the captured command's target. The fresh
+  // backend oracle above can yield to a workflow switch, so do not let helper
+  // repairs or recovery option changes mutate the stale graph before the main
+  // widget write gets its own fence check (#718).
+  const assertTargetStillCurrentNow = () => {
+    if (typeof assertTargetStillCurrent === "function") assertTargetStillCurrent();
+  };
   // (2) Repair positional UNKNOWN/UNKNOWN_n widget names against the live def so
   //     the caller's real widget name resolves (#199) — resolved direct node only.
-  if (reconcile) reconcileUnknownWidgetNames(node);
+  if (reconcile) {
+    assertTargetStillCurrentNow();
+    reconcileUnknownWidgetNames(node);
+  }
 
   // (3) applyWidgetWrite owns the whole write: for a PARENT SubgraphNode it
   // resolves a PROMOTED widget to its ACTUAL inner (node, widget) and writes
@@ -252,8 +268,13 @@ export async function runSetWidget(
   // resolveWidgetWrite — a real widget whose own name contains a dot still wins, and a
   // dotted form is only interpreted when no exact widget matches — so the split can
   // never silently misroute to a different widget.
-  const write = (extra = {}) =>
-    applyWidgetWrite(node, widgetName, value, {
+  const write = (extra = {}) => {
+    // No await follows this check before applyWidgetWrite, whose mutation is
+    // synchronous. A workflow switch while the fresh-object-info fetch was in
+    // flight therefore refuses before touching either canvas; retry and upload
+    // recovery use this same boundary too.
+    assertTargetStillCurrentNow();
+    return applyWidgetWrite(node, widgetName, value, {
       resolveSource,
       canvas,
       beforeChange,
@@ -263,6 +284,7 @@ export async function runSetWidget(
       promotedResolution,
       ...extra,
     });
+  };
 
   // #558: the value widget being written may be governed by a non-`fixed`
   // control_after_generate (seed randomize/increment/…), which SILENTLY overwrites
@@ -312,6 +334,9 @@ export async function runSetWidget(
       exists = false;
     }
     if (!exists) return false;
+    // confirmServerAsset may have yielded while the user changed canvases; do
+    // not add an option to the captured widget after that switch (#718).
+    assertTargetStillCurrentNow();
     return addComboOption(uploadWidget, value);
   };
 

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -131,10 +131,29 @@ export function activeWorkflowFenceApplies({ cmd, targetsNonActive = false } = {
  *  server can no longer retract), applying it would silently mutate the WRONG graph. Reject
  *  when the command carries a non-empty uuid that does NOT equal the active workflow's uuid —
  *  including when the active uuid is unresolvable (fail closed, #186). A command with no
- *  stamp (old orchestrator / identity-less tab) is never fenced here. */
+ *  stamp is also a mismatch for an active-workflow mutation: this panel advertises the
+ *  workflow-stamp capability, so accepting an unstamped protected command would make that
+ *  advertised fence fail open (#718). */
 export function commandWorkflowMismatch({ commandUuid, activeUuid } = {}) {
-  if (typeof commandUuid !== 'string' || !commandUuid.trim()) return false;
+  if (typeof commandUuid !== 'string' || !commandUuid.trim()) return true;
   return activeUuid !== commandUuid;
+}
+
+/**
+ * Does this command still name the active workflow at the instant it is about
+ * to mutate it? Most graph executors are synchronous, so their dispatch-time
+ * fence is sufficient. An executor that awaits an external oracle before its
+ * write must ask this again after that await: a user can switch canvases while
+ * the promise is pending. Keeping the rule pure makes both checks identical.
+ */
+export function commandTargetsActiveWorkflow({
+  cmd,
+  commandUuid,
+  activeUuid,
+  targetsNonActive = false,
+} = {}) {
+  return !activeWorkflowFenceApplies({ cmd, targetsNonActive }) ||
+    !commandWorkflowMismatch({ commandUuid, activeUuid });
 }
 
 /** #570 — resolve the per-instance uuid for an UNSAVED workflow, failing CLOSED on the


### PR DESCRIPTION
Companion for artokun/comfyui-mcp#718.\n\n- Rechecks the command's captured workflow UUID immediately before each graph_set_widget write after its fresh backend await.\n- Advertises enforces_workflow_stamp_at_write and bumps the panel capability version to 0.11.35.\n- Includes an A-to-B interleaving regression test.\n\nMust ship lockstep with the MCP companion; no merge/release from this draft.