### PR TITLE
fix(#545,#557): rebindable graph binding after save/open (desync guard recovery)

### DIFF
--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -70,9 +70,11 @@ const vueProxyOf = (raw) => new Proxy(raw, { get: (t, k) => (k === "__v_raw" ? t
 //   "same-path-overlap"     — A and B are DISTINCT live objects at the SAME path
 //                             (a closed→reopened overlap, #558 r3): path equality
 //                             must NOT exempt B from the foreign-claim check;
-//   "none"                  — NO live open tab claims the tag (a closed/replaced
-//                             tab's leftover): genuine stale bookkeeping — the
-//                             guard rebinds.
+//   "active-lineage"        — the ACTIVE tab's own serialized state carries the
+//                             tag (the #545/#557 drifted-successor heal case):
+//                             the guard rebinds the root to the active identity;
+//   "none"                  — NOBODY claims the tag (a closed tab's leftover
+//                             canvas, r5): the guard must keep throwing.
 // foreignTab overrides the B object (e.g. a creation-lifecycle product), and
 // registeredOwners/objectUuids override the identity stores the harness wires in.
 function buildDirtyStaleRouteHarness({
@@ -87,9 +89,22 @@ function buildDirtyStaleRouteHarness({
   const fenceSource = panelFunctionSource(src, "assertGraphBoundToActiveWorkflow", "getPiniaStore");
   const ownsTagSource = panelFunctionSource(src, "workflowOwnsRootUuidTag", "assertGraphBoundToActiveWorkflow");
   const overlap = foreignClaim === "same-path-overlap";
+  const lineage = foreignClaim === "active-lineage";
   const workflowA = overlap
     ? { isPersisted: true, path: "workflows/a.json", isModified: true, changeTracker: { activeState: state(27) } }
-    : { isPersisted: false, isModified: true, changeTracker: { activeState: state(27) } };
+    : {
+        isPersisted: false,
+        isModified: true,
+        changeTracker: {
+          activeState: {
+            ...state(27),
+            // "active-lineage": the ACTIVE tab's own serialized state carries the
+            // tag — the drifted-successor heal case (#545/#557): the tag is its
+            // own lineage, stale relative to its resolved identity.
+            ...(lineage && rootUuid ? { extra: { comfyui_mcp: { workflow_uuid: rootUuid } } } : {}),
+          },
+        },
+      };
   const rawB =
     foreignTab ??
     {
@@ -117,7 +132,7 @@ function buildDirtyStaleRouteHarness({
     ...(rootUuid ? { extra: { comfyui_mcp: { workflow_uuid: rootUuid } } } : {}),
   };
   const openWorkflows =
-    foreignClaim === "none"
+    foreignClaim === "none" || foreignClaim === "active-lineage"
       ? [workflowA]
       : foreignClaim === "unloaded-proxy-owner"
         ? [workflowA, proxyB]
@@ -192,13 +207,11 @@ function buildDirtyStaleRouteHarness({
     "graphRootMismatchesActiveWorkflow",
     "graphReadDesynced",
     "activeWorkflowNodeCount",
-    "sameWorkflowObject",
     "workflowOwnsRootUuidTag",
     "rememberWorkflowUuidOwner",
     "resolveGraphRootUuidRebind",
     "WORKFLOW_META_NAMESPACE",
     "WORKFLOW_UUID_FIELD",
-    "app",
     `${fenceSource}\nreturn assertGraphBoundToActiveWorkflow;`,
   )(
     () => workflowA,
@@ -209,13 +222,11 @@ function buildDirtyStaleRouteHarness({
     graphRootMismatchesActiveWorkflow,
     graphReadDesynced,
     activeWorkflowNodeCount,
-    sameWorkflowObject,
     ownsTag,
     () => {},
     resolveGraphRootUuidRebind,
     "comfyui_mcp",
     "workflow_uuid",
-    { graph: rootB, extensionManager: { workflow: { openWorkflows } } },
   );
   return { src, workflowA, rawB, proxyB, rootB, objectUuids, stableUuid, assertBound };
 }
@@ -715,21 +726,21 @@ test("#545: a positively identified wrong root remains rejected even for a read"
 
 // ── #545/#557: recoverable desync — orphaned root tags rebind ────────────────
 
-test("resolveGraphRootUuidRebind: none without a conflict, conflict for a foreign open owner, rebind otherwise", () => {
+test("resolveGraphRootUuidRebind: none without a conflict, rebind only when the ACTIVE workflow claims the tag", () => {
   const tagged = { extra: { comfyui_mcp: { workflow_uuid: "workflow-B" } } };
-  assert.equal(
-    resolveGraphRootUuidRebind({ rootGraph: tagged, activeWorkflowUuid: "workflow-A" }),
-    "rebind",
-    "a tag no LIVE OPEN workflow claims is stale bookkeeping, not a wrong canvas",
-  );
   assert.equal(
     resolveGraphRootUuidRebind({
       rootGraph: tagged,
       activeWorkflowUuid: "workflow-A",
-      rootTagOwnedByForeignOpenWorkflow: true,
+      rootTagClaimedByActiveWorkflow: true,
     }),
+    "rebind",
+    "the active tab's own lineage tag is stale bookkeeping — heal it",
+  );
+  assert.equal(
+    resolveGraphRootUuidRebind({ rootGraph: tagged, activeWorkflowUuid: "workflow-A" }),
     "conflict",
-    "a tag owned by another LIVE OPEN workflow keeps the #349 data-loss fence",
+    "a tag the active workflow does NOT claim fails closed — foreign claim OR closed-tab leftover (r5)",
   );
   assert.equal(
     resolveGraphRootUuidRebind({ rootGraph: tagged, activeWorkflowUuid: "workflow-B" }), "none");
@@ -741,12 +752,12 @@ test("resolveGraphRootUuidRebind: none without a conflict, conflict for a foreig
   assert.equal(resolveGraphRootUuidRebind({ rootGraph: tagged, activeWorkflowUuid: null }), "none");
 });
 
-test("#545: a root tag NO LIVE OPEN workflow claims (closed/replaced tab's leftover) rebinds instead of blocking every tool", () => {
-  const h = buildDirtyStaleRouteHarness({ rootUuid: "workflow-B", foreignClaim: "none" });
+test("#545: a root tag the ACTIVE workflow itself claims (its own drifted lineage) rebinds instead of blocking every tool", () => {
+  const h = buildDirtyStaleRouteHarness({ rootUuid: "workflow-B", foreignClaim: "active-lineage" });
   h.objectUuids.set(h.workflowA, "workflow-A");
   assert.doesNotThrow(
     () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: false }),
-    "a leftover tag no open tab claims must not hard-block reads",
+    "a tag the active tab's own tracker state carries is its own lineage — heal, don't block",
   );
   assert.equal(
     h.rootB.extra.comfyui_mcp.workflow_uuid,
@@ -760,6 +771,34 @@ test("#545: a root tag NO LIVE OPEN workflow claims (closed/replaced tab's lefto
         requireDirtyMutationBinding: graphCommandMayMutateWorkflow("graph_set_node_property"),
       }),
     "after the rebind the root positively matches, so a dirty-tab mutation proceeds",
+  );
+});
+
+test("#349 r5: a root tag NOBODY claims (a closed tab's leftover canvas) must throw, never re-stamp", () => {
+  // A closed workflow's stale graph left mounted: the active tab does not claim
+  // the tag, and no live open tab does either. Re-stamping it with the active
+  // identity would authorize writes to that dead graph as if it were the active
+  // one (r5 P0) — fail closed; panel_open_workflow's proven repaint is the remedy.
+  const h = buildDirtyStaleRouteHarness({ rootUuid: "workflow-B", foreignClaim: "none" });
+  h.objectUuids.set(h.workflowA, "workflow-A");
+  assert.throws(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: false }),
+    /NOT applied/,
+    "an unclaimed tag is not proof the root belongs to the active workflow",
+  );
+  assert.throws(
+    () =>
+      h.assertBound(h.rootB, h.rootB, {
+        includeBaselineReadGuard: false,
+        requireDirtyMutationBinding: graphCommandMayMutateWorkflow("graph_set_node_property"),
+      }),
+    /NOT applied/,
+    "an unclaimed tag must refuse a dirty mutation",
+  );
+  assert.equal(
+    h.rootB.extra.comfyui_mcp.workflow_uuid,
+    "workflow-B",
+    "an unclaimed tag must NOT be rewritten",
   );
 });
 
@@ -959,8 +998,13 @@ test("#557 r3/r4 wiring: programmaticSave threads the pre-save identity across a
   );
   assert.match(
     body,
-    /shouldCarryIdentityAcrossSaveSwap\(\{\s*preWf: expectWf,\s*postWf: postSwapWf,\s*savedAs: outcome\.saved_as,\s*preWfStillOpen,\s*successorCarriesPreUuid,\s*successorInPreSlot,\s*\}\)/,
+    /shouldCarryIdentityAcrossSaveSwap\(\{\s*preWf: expectWf,\s*postWf: postSwapWf,\s*savedAs: outcome\.saved_as,\s*preWfStillOpen,\s*successorCarriesPreUuid,\s*\}\)/,
     "the carry must pass ALL continuity evidence to the pure rule (never a Save-As copy, never a mid-save switch)",
+  );
+  assert.doesNotMatch(
+    body,
+    /successorInPreSlot|preSwapSlotIndex/,
+    "tab-slot occupancy is NOT continuity evidence (r5 P0) — it must not appear in the carry",
   );
   assert.match(
     body,
@@ -1048,15 +1092,15 @@ function buildProgrammaticSaveHarness({ onSave } = {}) {
     "comfyui_mcp",
     "workflow_uuid",
   );
-  // The #349 fence input, computed the same way the guard does: does any OTHER
-  // live open tab claim this root tag?
-  const foreignClaimOn = (rootUuid) =>
-    svc.openWorkflows.some((w) => !sameWorkflowObject(w, svc.activeWorkflow) && ownsTag(w, rootUuid));
-  return { save, svc, A, B, objectUuids, owners, foreignClaimOn };
+  // The #349 fence input, computed the same way the guard does: does the ACTIVE
+  // workflow itself claim this root tag (its own lineage → heal) or not (→
+  // fail closed)?
+  const activeClaims = (rootUuid) => ownsTag(svc.activeWorkflow, rootUuid);
+  return { save, svc, A, B, objectUuids, owners, activeClaims };
 }
 
 test("#349 r4 P0: a tab SWITCH during the awaited save aborts the identity carry — B is never seeded with A's uuid", async () => {
-  const { save, svc, A, B, objectUuids, owners, foreignClaimOn } = buildProgrammaticSaveHarness({
+  const { save, svc, A, B, objectUuids, owners, activeClaims } = buildProgrammaticSaveHarness({
     onSave: ({ svc }) => {
       svc.activeWorkflow = B; // user switched to a distinct dirty B while the save awaited
     },
@@ -1065,18 +1109,18 @@ test("#349 r4 P0: a tab SWITCH during the awaited save aborts the identity carry
   assert.equal(objectUuids.get(B), undefined, "B must NOT be seeded with A's uuid");
   assert.notEqual(owners.get("uuid-A"), B, "A's uuid must not be re-registered to B");
   assert.equal(
-    foreignClaimOn("uuid-A"),
-    true,
-    "A is still open and claims its tag — the #349 fence input holds while B is active",
+    activeClaims("uuid-A"),
+    false,
+    "B must not claim A's tag — the guard cannot heal an A-tagged root onto B",
   );
   assert.equal(
     resolveGraphRootUuidRebind({
       rootGraph: { extra: { comfyui_mcp: { workflow_uuid: "uuid-A" } } },
       activeWorkflowUuid: "uuid-B",
-      rootTagOwnedByForeignOpenWorkflow: foreignClaimOn("uuid-A"),
+      rootTagClaimedByActiveWorkflow: activeClaims("uuid-A"),
     }),
     "conflict",
-    "with the carry aborted, an A-tagged root stays foreign to B-active — writes are fenced",
+    "with the carry aborted, an A-tagged root stays fenced while B is active",
   );
 });
 
@@ -1095,6 +1139,36 @@ test("#349 r4 P0: a RECONNECT-shaped mid-save switch (tab list rebuilt with new 
   await save();
   assert.equal(objectUuids.get(B), undefined, "B must NOT be seeded with A's uuid");
   assert.notEqual(owners.get("uuid-A"), B, "A's uuid must not be re-registered to B");
+});
+
+test("#349 r5 P0: a CLOSE mid-await that compacts the tab list (B lands in A's old slot) aborts the carry", async () => {
+  // The r5 hole: A is CLOSED while its save awaits and the open-tab list
+  // compacts to [B], seating B in A's former slot. Slot occupancy is NOT
+  // succession — B carries NO A lineage, so the carry must abort and B must
+  // keep its own identity.
+  const { save, svc, B, objectUuids, owners, activeClaims } = buildProgrammaticSaveHarness({
+    onSave: ({ svc }) => {
+      svc.openWorkflows = [B]; // A closed; the list compacted — B now occupies A's slot
+      svc.activeWorkflow = B;
+    },
+  });
+  await save();
+  assert.equal(objectUuids.get(B), undefined, "B must NOT be seeded with A's uuid via A's vacated slot");
+  assert.notEqual(owners.get("uuid-A"), B, "A's uuid must not be re-registered to B");
+  assert.equal(
+    activeClaims("uuid-A"),
+    false,
+    "B must not claim A's tag — the guard cannot heal an A-tagged stale canvas onto B",
+  );
+  assert.equal(
+    resolveGraphRootUuidRebind({
+      rootGraph: { extra: { comfyui_mcp: { workflow_uuid: "uuid-A" } } },
+      activeWorkflowUuid: "uuid-B",
+      rootTagClaimedByActiveWorkflow: activeClaims("uuid-A"),
+    }),
+    "conflict",
+    "with the carry aborted, writes to A's stale root stay fenced while B is active",
+  );
 });
 
 test("#557 r4 control: a GENUINE save-swap successor still carries the pre-save identity", async () => {

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -27,6 +27,8 @@ import {
   resolveGraphRootUuidRebind,
 } from "../../web/js/lib/graph-binding.js";
 import {
+  rawWorkflowObject,
+  sameWorkflowObject,
   shouldForkEmbeddedUuidForLiveOwner,
   shouldForkEmbeddedWorkflowUuid,
   workflowAliasForPath,
@@ -45,40 +47,59 @@ function panelFunctionSource(src, name, nextName) {
 
 // foreignClaim models WHETHER a live open tab claims the root tag when it
 // conflicts with the active workflow's identity (#349/#545/#557):
-//   "identity"      — tab B is OPEN and the root-blind resolver returns the tag
-//                     for it: the guard must keep throwing;
-//   "tracker-stamp" — tab B is OPEN, the resolver mints a DIFFERENT identity for
-//                     it, but B's OWN serialized state still carries the tag (a
-//                     creation stamp no resolver run or owner record observed —
-//                     creation loadGraphData passes no workflow object, so the
-//                     stamp was never registered): the guard must keep throwing;
-//   "none"          — NO live open tab claims the tag (a closed/replaced tab's
-//                     leftover): genuine stale bookkeeping — the guard rebinds.
+//   "identity"              — tab B is OPEN and the root-blind resolver returns
+//                             the tag for it: the guard must keep throwing;
+//   "tracker-stamp"         — tab B is OPEN, the resolver mints a DIFFERENT
+//                             identity for it, but B's OWN serialized state still
+//                             carries the tag (an unregistered creation stamp):
+//                             the guard must keep throwing;
+//   "unloaded-proxy-owner"  — tab B is OPEN but only as a Vue-style PROXY, its
+//                             serialized state is NOT populated (unloaded), and
+//                             the resolver mints a different identity; only the
+//                             registered owner map ties it to the tag (#558 r2):
+//                             the guard must keep throwing;
+//   "none"                  — NO live open tab claims the tag (a closed/replaced
+//                             tab's leftover): genuine stale bookkeeping — the
+//                             guard rebinds.
 function buildDirtyStaleRouteHarness({ rootUuid = "workflow-B", foreignClaim = "identity" } = {}) {
   const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
   const stableSource = panelFunctionSource(src, "workflowStableUuid", "workflowStorageKey");
   const fenceSource = panelFunctionSource(src, "assertGraphBoundToActiveWorkflow", "getPiniaStore");
   const ownsTagSource = panelFunctionSource(src, "workflowOwnsRootUuidTag", "assertGraphBoundToActiveWorkflow");
   const workflowA = { isPersisted: false, isModified: true, changeTracker: { activeState: state(27) } };
-  const workflowB = {
+  const rawB = {
     isPersisted: true,
     path: "workflows/b.json",
-    changeTracker: {
-      activeState: {
-        ...state(30),
-        // A creation-stamped graph carries the tag in the tab's own serialized
-        // state even when no resolver/owner record ever observed it.
-        ...(foreignClaim === "tracker-stamp" && rootUuid
-          ? { extra: { comfyui_mcp: { workflow_uuid: rootUuid } } }
-          : {}),
-      },
-    },
+    changeTracker:
+      foreignClaim === "unloaded-proxy-owner"
+        ? null // a live tab whose serialized state is NOT loaded
+        : {
+            activeState: {
+              ...state(30),
+              // A creation-stamped graph carries the tag in the tab's own
+              // serialized state even when no resolver/owner record observed it.
+              ...(foreignClaim === "tracker-stamp" && rootUuid
+                ? { extra: { comfyui_mcp: { workflow_uuid: rootUuid } } }
+                : {}),
+            },
+          },
   };
+  // The repo's store-double idiom (workflow-save.test.mjs): openWorkflows holds
+  // PROXIES while the identity stores key on RAW objects.
+  const proxyB = new Proxy(rawB, {});
   const rootB = {
     _nodes: Array.from({ length: 30 }, (_, i) => ({ id: i + 1, type: "KSampler" })),
     ...(rootUuid ? { extra: { comfyui_mcp: { workflow_uuid: rootUuid } } } : {}),
   };
-  const openWorkflows = foreignClaim === "none" ? [workflowA] : [workflowA, workflowB];
+  const openWorkflows =
+    foreignClaim === "none"
+      ? [workflowA]
+      : foreignClaim === "unloaded-proxy-owner"
+        ? [workflowA, proxyB]
+        : [workflowA, rawB];
+  const registeredOwners = new Map(
+    foreignClaim === "unloaded-proxy-owner" && rootUuid ? [[rootUuid, rawB]] : [],
+  );
   const objectUuids = new WeakMap();
   let minted = 0;
   const stableUuidA = new Function(
@@ -92,6 +113,7 @@ function buildDirtyStaleRouteHarness({ rootUuid = "workflow-B", foreignClaim = "
     "rememberWorkflowUuidOwner",
     "workflowOwnedExtra",
     "crypto",
+    "sameWorkflowObject",
     `${stableSource}\nreturn workflowStableUuid;`,
   )(
     { graph: rootB },
@@ -104,19 +126,34 @@ function buildDirtyStaleRouteHarness({ rootUuid = "workflow-B", foreignClaim = "
     () => {},
     () => null,
     { randomUUID: () => `workflow-A-${++minted}` },
+    sameWorkflowObject,
   );
   // Per-tab established identities as the real resolver would produce them: A
   // through the real (unsaved-branch) source; B returns its recorded identity —
-  // under "identity" that IS the root tag; under "tracker-stamp" the resolver
-  // minted a different identity and never observed B's graph stamp.
+  // under "identity" that IS the root tag; otherwise the resolver minted a
+  // different identity and never observed B's stamp.
   const stableUuid = (wf) =>
-    wf === workflowB ? (foreignClaim === "identity" ? rootUuid : "workflow-B-minted") : stableUuidA(wf);
+    wf === rawB || wf === proxyB
+      ? foreignClaim === "identity"
+        ? rootUuid
+        : "workflow-B-minted"
+      : stableUuidA(wf);
   const ownsTag = new Function(
     "workflowStableUuid",
+    "rawWorkflowObject",
+    "sameWorkflowObject",
+    "workflowUuidOwner",
     "WORKFLOW_META_NAMESPACE",
     "WORKFLOW_UUID_FIELD",
     `${ownsTagSource}\nreturn workflowOwnsRootUuidTag;`,
-  )(stableUuid, "comfyui_mcp", "workflow_uuid");
+  )(
+    stableUuid,
+    rawWorkflowObject,
+    sameWorkflowObject,
+    (id) => registeredOwners.get(id) ?? null,
+    "comfyui_mcp",
+    "workflow_uuid",
+  );
   const assertBound = new Function(
     "activeWorkflowRef",
     "_workflowObjectUuids",
@@ -126,6 +163,7 @@ function buildDirtyStaleRouteHarness({ rootUuid = "workflow-B", foreignClaim = "
     "graphRootMismatchesActiveWorkflow",
     "graphReadDesynced",
     "activeWorkflowNodeCount",
+    "sameWorkflowObject",
     "workflowOwnsRootUuidTag",
     "rememberWorkflowUuidOwner",
     "resolveGraphRootUuidRebind",
@@ -142,6 +180,7 @@ function buildDirtyStaleRouteHarness({ rootUuid = "workflow-B", foreignClaim = "
     graphRootMismatchesActiveWorkflow,
     graphReadDesynced,
     activeWorkflowNodeCount,
+    sameWorkflowObject,
     ownsTag,
     () => {},
     resolveGraphRootUuidRebind,
@@ -149,21 +188,35 @@ function buildDirtyStaleRouteHarness({ rootUuid = "workflow-B", foreignClaim = "
     "workflow_uuid",
     { graph: rootB, extensionManager: { workflow: { openWorkflows } } },
   );
-  return { src, workflowA, workflowB, rootB, objectUuids, stableUuid, assertBound };
+  return { src, workflowA, rawB, proxyB, rootB, objectUuids, stableUuid, assertBound };
 }
 
 // #557 — the SAVED branch of workflowStableUuid after a save replaced the active
 // ComfyWorkflow object: the successor parses the pre-save embedded uuid from the
 // just-saved file while the replaced object is still its registered owner.
-function buildSavedSuccessorHarness({ ownerOpen = false } = {}) {
+// currentPath/embeddedPath/aliases are parameterizable so a genuine co-open COPY
+// (different path, same embedded uuid) can be distinguished from a same-path
+// save-swap successor. ownerOpen: false | true | "proxy" — "proxy" models the
+// live owner appearing in openWorkflows only as a Vue-style proxy (#558 r2).
+function buildSavedSuccessorHarness({
+  ownerOpen = false,
+  currentPath = "workflows/x.json",
+  embeddedPath = "workflows/x.json",
+  aliases = { "workflows/x.json": "11111111-1111-4111-8111-111111111111" },
+} = {}) {
   const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
   const stableSource = panelFunctionSource(src, "workflowStableUuid", "workflowStorageKey");
   const U1 = "11111111-1111-4111-8111-111111111111";
   const replaced = { isPersisted: true, path: "workflows/x.json" };
-  const successor = { isPersisted: true, path: "workflows/x.json" };
-  const aliases = { "workflows/x.json": U1 };
+  const successor = { isPersisted: true, path: currentPath };
   const owners = new Map([[U1, replaced]]);
   let minted = 0;
+  const openWorkflows =
+    ownerOpen === true
+      ? [replaced, successor]
+      : ownerOpen === "proxy"
+        ? [new Proxy(replaced, {}), successor]
+        : [successor];
   const stableUuid = new Function(
     "app",
     "getTabId",
@@ -184,14 +237,15 @@ function buildSavedSuccessorHarness({ ownerOpen = false } = {}) {
     "persistWorkflowAliases",
     "workflowAliasMutationSink",
     "crypto",
+    "sameWorkflowObject",
     `${stableSource}\nreturn workflowStableUuid;`,
   )(
-    { extensionManager: { workflow: { openWorkflows: ownerOpen ? [replaced, successor] : [successor] } } },
+    { extensionManager: { workflow: { openWorkflows } } },
     () => "fallback-tab",
     (wf) => (wf?.isPersisted === true && wf?.isTemporary !== true && typeof wf?.path === "string" ? wf.path : null),
     new WeakMap(),
     () => U1, // the just-saved file carries the pre-save embedded uuid
-    () => "workflows/x.json",
+    () => embeddedPath,
     workflowAliasForPath,
     (id) => owners.get(id) ?? null,
     (id, owner) => owners.set(id, owner),
@@ -205,6 +259,7 @@ function buildSavedSuccessorHarness({ ownerOpen = false } = {}) {
     () => {},
     null,
     { randomUUID: () => `fresh-${++minted}` },
+    sameWorkflowObject,
   );
   return { stableUuid, successor, replaced, owners, U1 };
 }
@@ -719,6 +774,36 @@ test("#349 P0: a root tag claimed ONLY by a live open tab's serialized state (un
   );
 });
 
+test("#349 P0 r2: a live UNLOADED foreign tab present only as a proxy must throw — the registered owner map still claims the tag", () => {
+  // The codex r2 hole: B is LIVE in openWorkflows but only as a Vue-style proxy
+  // (raw `!==` misses the registered raw owner), its serialized state is NOT
+  // populated (unloaded → the tracker claim can't fire), and the resolver mints
+  // a different identity for it. Only the owner map ties B to the tag — and the
+  // rebind must honor that claim rather than re-stamping B's live root as A's
+  // and permitting dirty writes to B.
+  const h = buildDirtyStaleRouteHarness({ rootUuid: "workflow-B", foreignClaim: "unloaded-proxy-owner" });
+  h.objectUuids.set(h.workflowA, "workflow-A");
+  assert.throws(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: false }),
+    /NOT applied/,
+    "a live foreign claim registered only in the owner map must stay fail-closed (#349)",
+  );
+  assert.throws(
+    () =>
+      h.assertBound(h.rootB, h.rootB, {
+        includeBaselineReadGuard: false,
+        requireDirtyMutationBinding: graphCommandMayMutateWorkflow("graph_set_node_property"),
+      }),
+    /NOT applied/,
+    "the unloaded foreign proxy root must refuse a dirty mutation",
+  );
+  assert.equal(
+    h.rootB.extra.comfyui_mcp.workflow_uuid,
+    "workflow-B",
+    "a live foreign proxy's tag must NOT be rewritten",
+  );
+});
+
 // ── #557: save replaces the active workflow object — identity must follow ────
 
 test("#557: a save's successor object INHERITS the embedded uuid when the replaced owner is gone", () => {
@@ -734,10 +819,35 @@ test("#557: a save's successor object INHERITS the embedded uuid when the replac
 });
 
 test("#557: a genuinely co-open copy still FORKS away from the live owner's embedded uuid (#570)", () => {
-  const { stableUuid, successor, U1 } = buildSavedSuccessorHarness({ ownerOpen: true });
+  // A real copy lives at a DIFFERENT path while carrying the source's embedded
+  // uuid; the source (owner) is live in openWorkflows.
+  const { stableUuid, successor, U1 } = buildSavedSuccessorHarness({
+    ownerOpen: true,
+    currentPath: "workflows/y.json",
+    embeddedPath: "workflows/x.json",
+    aliases: {},
+  });
   const id = stableUuid(successor);
   assert.notEqual(id, U1, "two simultaneously-open objects must never share one identity");
   assert.match(id, /^fresh-/, "the copy gets a fresh per-instance identity");
+});
+
+test("#570 r2: a co-open copy FORKS even when the live owner appears in openWorkflows only as a proxy", () => {
+  // The codex r2 hole: openWorkflows holds a PROXY of the raw registered owner,
+  // so a raw `includes` reads the live foreign owner as closed and the copy
+  // INHERITS the source identity (shared uuid → cross-resume, and the desync
+  // guard can no longer tell the two canvases apart). No path evidence saves us
+  // here (the file carries no embedded path and the browser has no aliases), so
+  // the proxy-safe owner check is the ONLY fork signal.
+  const { stableUuid, successor, U1 } = buildSavedSuccessorHarness({
+    ownerOpen: "proxy",
+    currentPath: "workflows/y.json",
+    embeddedPath: null,
+    aliases: {},
+  });
+  const id = stableUuid(successor);
+  assert.notEqual(id, U1, "a proxy-wrapped live owner is still a live foreign owner — the copy must fork");
+  assert.match(id, /^fresh-/);
 });
 
 test("#557 regression: after the save-swap, the guard sees no mismatch (root tag and object stay aligned)", () => {

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -1070,6 +1070,55 @@ test("#349 r6 P0: a mid-load switch to a tab whose tracker is unreadable registe
   assert.equal(h.rootB.extra.comfyui_mcp.workflow_uuid, "creation-uuid-1", "the ownerless tag is not rewritten");
 });
 
+test("#349 r7 P0: a positive tracker match must NOT promote the stamp over an established CONFLICTING identity", async () => {
+  // The r7 hole: the mid-load active tab B ALREADY has an established WeakMap
+  // identity "uuid-B" and its (stale) tracker happens to carry the minted
+  // stamp. Recording stampUuid → B anyway creates an owner-map claim that the
+  // guard's lineage check then accepts — re-stamping C's foreign root with B's
+  // identity. A conflicting established identity must veto the registration.
+  const foreignB = {
+    isPersisted: true,
+    path: "workflows/b.json",
+    changeTracker: { activeState: { extra: { comfyui_mcp: { workflow_uuid: "creation-uuid-1" } } } },
+  };
+  const { fakeApp, objectUuids, owners } = buildCreationForkHarness({
+    onLoad: ({ app }) => {
+      app.extensionManager.workflow.activeWorkflow = foreignB;
+      app.extensionManager.workflow.openWorkflows.push(foreignB);
+    },
+  });
+  objectUuids.set(foreignB, "uuid-B"); // B's identity is ALREADY established — and differs
+  await fakeApp.loadGraphData({ nodes: [{ id: 1, type: "KSampler" }] });
+  assert.equal(
+    owners.get("creation-uuid-1"),
+    undefined,
+    "a conflicting established identity must veto the owner-map registration",
+  );
+  assert.equal(
+    objectUuids.get(foreignB),
+    "uuid-B",
+    "B's established identity must NOT be overwritten by the creation stamp",
+  );
+
+  // …and the guard fences C's tagged canvas while B is active: with no
+  // registration, B does not claim the tag — nothing to heal, the stale
+  // canvas throws.
+  const h = buildDirtyStaleRouteHarness({
+    rootUuid: "creation-uuid-1",
+    foreignClaim: "unloaded-proxy-owner",
+    foreignTab: foreignB,
+    registeredOwners: owners,
+    objectUuids,
+  });
+  h.objectUuids.set(h.workflowA, "workflow-A");
+  assert.throws(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: false }),
+    /NOT applied/,
+    "with the registration vetoed, C's tagged canvas stays fenced (#349)",
+  );
+  assert.equal(h.rootB.extra.comfyui_mcp.workflow_uuid, "creation-uuid-1", "the foreign tag is not rewritten");
+});
+
 test("#557 r3/r4 wiring: programmaticSave threads the pre-save identity across a PROVEN in-place object swap", () => {
   const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
   const start = src.indexOf("async function programmaticSave(name)");
@@ -1092,13 +1141,18 @@ test("#557 r3/r4 wiring: programmaticSave threads the pre-save identity across a
   );
   assert.match(
     body,
-    /shouldCarryIdentityAcrossSaveSwap\(\{\s*preWf: expectWf,\s*postWf: postSwapWf,\s*savedAs: outcome\.saved_as,\s*preWfStillOpen,\s*successorCarriesPreUuid,\s*\}\)/,
-    "the carry must pass ALL continuity evidence to the pure rule (never a Save-As copy, never a mid-save switch)",
+    /shouldCarryIdentityAcrossSaveSwap\(\{\s*preWf: expectWf,\s*postWf: postSwapWf,\s*savedAs: outcome\.saved_as,\s*preWfStillOpen,\s*successorCarriesPreUuid,\s*postWfHasConflictingEstablishedIdentity,\s*\}\)/,
+    "the carry must pass ALL continuity evidence to the pure rule (never a Save-As copy, never a mid-save switch, never over an established conflict)",
   );
   assert.doesNotMatch(
     body,
     /successorInPreSlot|preSwapSlotIndex/,
     "tab-slot occupancy is NOT continuity evidence (r5 P0) — it must not appear in the carry",
+  );
+  assert.match(
+    body,
+    /postWfHasConflictingEstablishedIdentity = Boolean\(\s*postSwapWf && _workflowObjectUuids\.get\(postSwapWf\) && _workflowObjectUuids\.get\(postSwapWf\) !== preSwapUuid,?\s*\)/,
+    "an established conflicting WeakMap identity on the successor must veto the carry (r7 P0)",
   );
   assert.match(
     body,
@@ -1286,6 +1340,34 @@ test("#557 r4 control: a GENUINE save-swap successor still carries the pre-save 
     "the proven successor is seeded with the pre-save uuid (#557)",
   );
   assert.equal(owners.get("uuid-A"), successor, "the successor becomes the uuid's registered owner");
+});
+
+test("#349 r7 P0: a successor with an established CONFLICTING identity is not overwritten by the carry", async () => {
+  // The successor proves continuity (its tracker carries the pre-save uuid),
+  // but it ALREADY has an established, different WeakMap identity — a
+  // conflicting tab, not A's continuation. Overwriting would promote the stamp
+  // over the object's own identity and poison the owner map.
+  const successor = {
+    isPersisted: true,
+    path: "workflows/a.json",
+    changeTracker: {
+      activeState: { ...state(27), extra: { comfyui_mcp: { workflow_uuid: "uuid-A" } } },
+    },
+  };
+  const { save, svc, objectUuids, owners } = buildProgrammaticSaveHarness({
+    onSave: ({ svc }) => {
+      svc.openWorkflows = [successor];
+      svc.activeWorkflow = successor;
+    },
+  });
+  objectUuids.set(successor, "uuid-X"); // established BEFORE the seed — and conflicting
+  await save();
+  assert.equal(
+    objectUuids.get(successor),
+    "uuid-X",
+    "the carry must not overwrite an established conflicting identity",
+  );
+  assert.notEqual(owners.get("uuid-A"), successor, "A's uuid must not be re-registered over the conflict");
 });
 
 // ── #557: save replaces the active workflow object — identity must follow ────

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -70,9 +70,13 @@ const vueProxyOf = (raw) => new Proxy(raw, { get: (t, k) => (k === "__v_raw" ? t
 //   "same-path-overlap"     — A and B are DISTINCT live objects at the SAME path
 //                             (a closed→reopened overlap, #558 r3): path equality
 //                             must NOT exempt B from the foreign-claim check;
-//   "active-lineage"        — the ACTIVE tab's own serialized state carries the
-//                             tag (the #545/#557 drifted-successor heal case):
-//                             the guard rebinds the root to the active identity;
+//   "active-lineage"        — the tag's REGISTERED OWNER is the active object
+//                             itself (object-keyed lineage, the #545/#557
+//                             drifted-identity heal case): the guard rebinds;
+//   "stale-lineage"         — the active object's LAGGING tracker state still
+//                             carries the tag (replaced-predecessor residue,
+//                             r6 P0): NOT object-keyed, must NOT count — the
+//                             guard must keep throwing;
 //   "none"                  — NOBODY claims the tag (a closed tab's leftover
 //                             canvas, r5): the guard must keep throwing.
 // foreignTab overrides the B object (e.g. a creation-lifecycle product), and
@@ -90,6 +94,7 @@ function buildDirtyStaleRouteHarness({
   const ownsTagSource = panelFunctionSource(src, "workflowOwnsRootUuidTag", "assertGraphBoundToActiveWorkflow");
   const overlap = foreignClaim === "same-path-overlap";
   const lineage = foreignClaim === "active-lineage";
+  const staleLineage = foreignClaim === "stale-lineage";
   const workflowA = overlap
     ? { isPersisted: true, path: "workflows/a.json", isModified: true, changeTracker: { activeState: state(27) } }
     : {
@@ -98,10 +103,11 @@ function buildDirtyStaleRouteHarness({
         changeTracker: {
           activeState: {
             ...state(27),
-            // "active-lineage": the ACTIVE tab's own serialized state carries the
-            // tag — the drifted-successor heal case (#545/#557): the tag is its
-            // own lineage, stale relative to its resolved identity.
-            ...(lineage && rootUuid ? { extra: { comfyui_mcp: { workflow_uuid: rootUuid } } } : {}),
+            // "stale-lineage" (r6 P0): the active object's tracker state is
+            // LAGGING — it still carries an OLD uuid (a replaced predecessor's
+            // residue). Serialized-state evidence is not object-keyed, so this
+            // must NOT count as an active-lineage claim.
+            ...(staleLineage && rootUuid ? { extra: { comfyui_mcp: { workflow_uuid: rootUuid } } } : {}),
           },
         },
       };
@@ -132,14 +138,20 @@ function buildDirtyStaleRouteHarness({
     ...(rootUuid ? { extra: { comfyui_mcp: { workflow_uuid: rootUuid } } } : {}),
   };
   const openWorkflows =
-    foreignClaim === "none" || foreignClaim === "active-lineage"
+    foreignClaim === "none" || foreignClaim === "active-lineage" || foreignClaim === "stale-lineage"
       ? [workflowA]
       : foreignClaim === "unloaded-proxy-owner"
         ? [workflowA, proxyB]
         : [workflowA, rawB];
   const registeredOwnersMap =
     registeredOwners ??
-    new Map(foreignClaim === "unloaded-proxy-owner" && rootUuid ? [[rootUuid, rawB]] : []);
+    new Map(
+      foreignClaim === "unloaded-proxy-owner" && rootUuid
+        ? [[rootUuid, rawB]]
+        : foreignClaim === "active-lineage" && rootUuid
+          ? [[rootUuid, workflowA]] // the tag's registered owner IS the active object
+          : [],
+    );
   const objectUuids = objectUuidsOpt ?? new WeakMap();
   let minted = 0;
   const stableUuidA = new Function(
@@ -752,12 +764,12 @@ test("resolveGraphRootUuidRebind: none without a conflict, rebind only when the 
   assert.equal(resolveGraphRootUuidRebind({ rootGraph: tagged, activeWorkflowUuid: null }), "none");
 });
 
-test("#545: a root tag the ACTIVE workflow itself claims (its own drifted lineage) rebinds instead of blocking every tool", () => {
+test("#545: a root tag whose REGISTERED OWNER is the active object itself rebinds instead of blocking every tool", () => {
   const h = buildDirtyStaleRouteHarness({ rootUuid: "workflow-B", foreignClaim: "active-lineage" });
   h.objectUuids.set(h.workflowA, "workflow-A");
   assert.doesNotThrow(
     () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: false }),
-    "a tag the active tab's own tracker state carries is its own lineage — heal, don't block",
+    "a tag registered to the active object is its own lineage — heal, don't block",
   );
   assert.equal(
     h.rootB.extra.comfyui_mcp.workflow_uuid,
@@ -771,6 +783,34 @@ test("#545: a root tag the ACTIVE workflow itself claims (its own drifted lineag
         requireDirtyMutationBinding: graphCommandMayMutateWorkflow("graph_set_node_property"),
       }),
     "after the rebind the root positively matches, so a dirty-tab mutation proceeds",
+  );
+});
+
+test("#349 r6 P0: a LAGGING tracker state carrying the tag (replaced-predecessor residue) must NOT prove active lineage", () => {
+  // The r6 spoof: the active object resolved identity B ("workflow-A" here),
+  // but its stale serialized state still carries the tag "workflow-B" — while
+  // the root is a FOREIGN canvas genuinely tagged "workflow-B". Serialized
+  // state is not object-keyed, so this must fail closed: no re-stamp, throw.
+  const h = buildDirtyStaleRouteHarness({ rootUuid: "workflow-B", foreignClaim: "stale-lineage" });
+  h.objectUuids.set(h.workflowA, "workflow-A");
+  assert.throws(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: false }),
+    /NOT applied/,
+    "a lagging tracker stamp must not re-stamp a foreign root with the active identity",
+  );
+  assert.throws(
+    () =>
+      h.assertBound(h.rootB, h.rootB, {
+        includeBaselineReadGuard: false,
+        requireDirtyMutationBinding: graphCommandMayMutateWorkflow("graph_set_node_property"),
+      }),
+    /NOT applied/,
+    "the same spoofed lineage must refuse a dirty mutation",
+  );
+  assert.equal(
+    h.rootB.extra.comfyui_mcp.workflow_uuid,
+    "workflow-B",
+    "the foreign root must NOT be rewritten on serialized-state evidence",
   );
 });
 
@@ -896,25 +936,22 @@ test("#349 P0 r3: a same-path OVERLAP (closed→reopened object) is NOT self —
   assert.equal(h.rootB.extra.comfyui_mcp.workflow_uuid, "workflow-B", "the foreign root keeps its tag");
 });
 
-test("#349 P0 r3: a CREATION-minted tag is registered to the tab the load activates (lifecycle, no manual seeding)", async () => {
-  // Drive the REAL creation path: installCreateBoundaryFork wraps
-  // app.loadGraphData; a creation (non-object workflow arg) stamps a fresh uuid
-  // and — after the load — must register it against the tab the load activated.
-  // Without that registration a live, unloaded, never-resolved creation carries
-  // a tag nothing claims, and the guard rebinds over its foreign root (r3 P0).
+// Drives the REAL installCreateBoundaryFork source against a fake app whose
+// loadGraphData simulates ComfyUI's creation behavior (the graph goes live in a
+// NEW active tab). onLoad customizes what the load leaves active — e.g. a
+// mid-load switch to an unrelated tab with an unreadable tracker (r6 P0).
+function buildCreationForkHarness({ onLoad } = {}) {
   const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
   const forkSource = panelFunctionSource(src, "installCreateBoundaryFork", "workflowUuidOwner");
   const objectUuids = new WeakMap();
   const owners = new Map();
-  const createdTab = { isPersisted: false, changeTracker: null }; // live, unloaded, never resolved
+  const createdTab = { isPersisted: false, changeTracker: null };
   const fakeApp = {
     graph: null,
     extensionManager: { workflow: { activeWorkflow: null, openWorkflows: [] } },
     loadGraphData(graphData) {
-      // ComfyUI's creation behavior: the graph goes live in a NEW active tab.
       this.graph = { _nodes: graphData.nodes ?? [], extra: graphData.extra };
-      this.extensionManager.workflow.activeWorkflow = createdTab;
-      this.extensionManager.workflow.openWorkflows.push(createdTab);
+      onLoad?.({ app: this, graphData, createdTab });
     },
   };
   const install = new Function(
@@ -940,6 +977,19 @@ test("#349 P0 r3: a CREATION-minted tag is registered to the tab the load activa
     "workflow_uuid",
   );
   install(fakeApp);
+  return { fakeApp, createdTab, objectUuids, owners };
+}
+
+test("#349 P0 r3: a CREATION-minted tag is registered to the tab the load activates (lifecycle, no manual seeding)", async () => {
+  const { fakeApp, createdTab, objectUuids, owners } = buildCreationForkHarness({
+    onLoad: ({ app, graphData, createdTab }) => {
+      // ComfyUI's creation behavior: the graph goes live in a NEW active tab,
+      // and the tab's tracker captures the configured state (stamp included).
+      createdTab.changeTracker = { activeState: { extra: graphData.extra } };
+      app.extensionManager.workflow.activeWorkflow = createdTab;
+      app.extensionManager.workflow.openWorkflows.push(createdTab);
+    },
+  });
   await fakeApp.loadGraphData({ nodes: [{ id: 1, type: "KSampler" }] });
   assert.equal(
     fakeApp.graph.extra.comfyui_mcp.workflow_uuid,
@@ -957,9 +1007,8 @@ test("#349 P0 r3: a CREATION-minted tag is registered to the tab the load activa
     "the receiving tab's identity cache carries its stamp",
   );
 
-  // …so the desync guard refuses to rebind over that live, unloaded,
-  // never-resolved creation while ANOTHER workflow is active: the resolver
-  // claim fires straight from the registration (no manual owner-map seeding).
+  // …so the desync guard refuses to rebind over that live creation while
+  // ANOTHER workflow is active: the active tab does not claim the tag.
   const h = buildDirtyStaleRouteHarness({
     rootUuid: "creation-uuid-1",
     foreignClaim: "unloaded-proxy-owner",
@@ -974,6 +1023,51 @@ test("#349 P0 r3: a CREATION-minted tag is registered to the tab the load activa
     "a live creation-registered tab keeps its root — never rebound (#349)",
   );
   assert.equal(h.rootB.extra.comfyui_mcp.workflow_uuid, "creation-uuid-1", "the created tab's tag survives");
+});
+
+test("#349 r6 P0: a mid-load switch to a tab whose tracker is unreadable registers NOTHING (no guessing)", async () => {
+  // The r6 hole: an async creation settles while a DIFFERENT tab B is active
+  // and B's tracker can't be read. Registering the minted uuid against B
+  // anyway would let C's tagged canvas match B through the guard's lineage
+  // claim — a fail-open misattribution. With no positive stamp match the
+  // registration must be skipped entirely (the tag floats ownerless, which can
+  // only fail CLOSED).
+  const foreignB = { isPersisted: true, path: "workflows/b.json", changeTracker: null };
+  const { fakeApp, objectUuids, owners } = buildCreationForkHarness({
+    onLoad: ({ app }) => {
+      app.extensionManager.workflow.activeWorkflow = foreignB; // mid-load switch
+      app.extensionManager.workflow.openWorkflows.push(foreignB);
+    },
+  });
+  await fakeApp.loadGraphData({ nodes: [{ id: 1, type: "KSampler" }] });
+  assert.equal(
+    fakeApp.graph.extra.comfyui_mcp.workflow_uuid,
+    "creation-uuid-1",
+    "the creation still stamps the graph before it goes live",
+  );
+  assert.equal(
+    owners.get("creation-uuid-1"),
+    undefined,
+    "no positive stamp match → NO registration (fail safe, never a guess)",
+  );
+  assert.equal(objectUuids.get(foreignB), undefined, "B's identity is untouched");
+
+  // …and the guard fences C's tagged canvas while B is active: B does not
+  // claim the tag, so there is nothing to heal — the stale canvas throws.
+  const h = buildDirtyStaleRouteHarness({
+    rootUuid: "creation-uuid-1",
+    foreignClaim: "unloaded-proxy-owner",
+    foreignTab: foreignB,
+    registeredOwners: owners,
+    objectUuids,
+  });
+  h.objectUuids.set(h.workflowA, "workflow-A");
+  assert.throws(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: false }),
+    /NOT applied/,
+    "an ownerless creation tag on a stale canvas stays fenced (#349)",
+  );
+  assert.equal(h.rootB.extra.comfyui_mcp.workflow_uuid, "creation-uuid-1", "the ownerless tag is not rewritten");
 });
 
 test("#557 r3/r4 wiring: programmaticSave threads the pre-save identity across a PROVEN in-place object swap", () => {

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -24,7 +24,13 @@ import {
   graphRootMatchesState,
   graphCommandMayMutateWorkflow,
   graphReadBindingChanged,
+  resolveGraphRootUuidRebind,
 } from "../../web/js/lib/graph-binding.js";
+import {
+  shouldForkEmbeddedUuidForLiveOwner,
+  shouldForkEmbeddedWorkflowUuid,
+  workflowAliasForPath,
+} from "../../web/js/lib/workflow-chat-identity.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
@@ -37,15 +43,27 @@ function panelFunctionSource(src, name, nextName) {
   return src.slice(start, end);
 }
 
-function buildDirtyStaleRouteHarness({ rootUuid = "workflow-B" } = {}) {
+// tagOwnerKind models WHO owns the root graph's stamped uuid when it conflicts
+// with the active workflow's identity (#545/#557):
+//   "foreign-open" — another LIVE OPEN workflow tab (the genuine #349 wrong
+//                    canvas): the guard must keep throwing;
+//   "orphaned"     — an object that is no longer an open tab (a save/reconnect
+//                    replaced it): stale bookkeeping — the guard must rebind;
+//   "untracked"    — no owner record at all: also stale bookkeeping — rebind.
+function buildDirtyStaleRouteHarness({ rootUuid = "workflow-B", tagOwnerKind = "foreign-open" } = {}) {
   const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
   const stableSource = panelFunctionSource(src, "workflowStableUuid", "workflowStorageKey");
   const fenceSource = panelFunctionSource(src, "assertGraphBoundToActiveWorkflow", "getPiniaStore");
   const workflowA = { isPersisted: false, isModified: true, changeTracker: { activeState: state(27) } };
+  const workflowB = { isPersisted: true, path: "workflows/b.json", changeTracker: { activeState: state(30) } };
+  const replacedPredecessor = { isPersisted: true, path: "workflows/a.json" };
   const rootB = {
     _nodes: Array.from({ length: 30 }, (_, i) => ({ id: i + 1, type: "KSampler" })),
     ...(rootUuid ? { extra: { comfyui_mcp: { workflow_uuid: rootUuid } } } : {}),
   };
+  const tagOwner =
+    tagOwnerKind === "foreign-open" ? workflowB : tagOwnerKind === "orphaned" ? replacedPredecessor : null;
+  const openWorkflows = tagOwnerKind === "foreign-open" ? [workflowA, workflowB] : [workflowA];
   const objectUuids = new WeakMap();
   let minted = 0;
   const stableUuid = new Function(
@@ -81,6 +99,12 @@ function buildDirtyStaleRouteHarness({ rootUuid = "workflow-B" } = {}) {
     "graphRootMismatchesActiveWorkflow",
     "graphReadDesynced",
     "activeWorkflowNodeCount",
+    "workflowUuidOwner",
+    "rememberWorkflowUuidOwner",
+    "resolveGraphRootUuidRebind",
+    "WORKFLOW_META_NAMESPACE",
+    "WORKFLOW_UUID_FIELD",
+    "app",
     `${fenceSource}\nreturn assertGraphBoundToActiveWorkflow;`,
   )(
     () => workflowA,
@@ -91,8 +115,71 @@ function buildDirtyStaleRouteHarness({ rootUuid = "workflow-B" } = {}) {
     graphRootMismatchesActiveWorkflow,
     graphReadDesynced,
     activeWorkflowNodeCount,
+    (id) => (id && id === rootUuid ? tagOwner : null),
+    () => {},
+    resolveGraphRootUuidRebind,
+    "comfyui_mcp",
+    "workflow_uuid",
+    { graph: rootB, extensionManager: { workflow: { openWorkflows } } },
   );
-  return { src, workflowA, rootB, objectUuids, stableUuid, assertBound };
+  return { src, workflowA, workflowB, rootB, objectUuids, stableUuid, assertBound };
+}
+
+// #557 — the SAVED branch of workflowStableUuid after a save replaced the active
+// ComfyWorkflow object: the successor parses the pre-save embedded uuid from the
+// just-saved file while the replaced object is still its registered owner.
+function buildSavedSuccessorHarness({ ownerOpen = false } = {}) {
+  const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+  const stableSource = panelFunctionSource(src, "workflowStableUuid", "workflowStorageKey");
+  const U1 = "11111111-1111-4111-8111-111111111111";
+  const replaced = { isPersisted: true, path: "workflows/x.json" };
+  const successor = { isPersisted: true, path: "workflows/x.json" };
+  const aliases = { "workflows/x.json": U1 };
+  const owners = new Map([[U1, replaced]]);
+  let minted = 0;
+  const stableUuid = new Function(
+    "app",
+    "getTabId",
+    "savedWorkflowPath",
+    "_workflowObjectUuids",
+    "embeddedWorkflowUuid",
+    "embeddedWorkflowPath",
+    "workflowAliasForPath",
+    "workflowUuidOwner",
+    "rememberWorkflowUuidOwner",
+    "shouldForkEmbeddedWorkflowUuid",
+    "shouldForkEmbeddedUuidForLiveOwner",
+    "resolveUnsavedInstanceUuid",
+    "_loadGraphDataForkInstalled",
+    "workflowOwnedExtra",
+    "currentWorkflowRef",
+    "_workflowUuidAliases",
+    "persistWorkflowAliases",
+    "workflowAliasMutationSink",
+    "crypto",
+    `${stableSource}\nreturn workflowStableUuid;`,
+  )(
+    { extensionManager: { workflow: { openWorkflows: ownerOpen ? [replaced, successor] : [successor] } } },
+    () => "fallback-tab",
+    (wf) => (wf?.isPersisted === true && wf?.isTemporary !== true && typeof wf?.path === "string" ? wf.path : null),
+    new WeakMap(),
+    () => U1, // the just-saved file carries the pre-save embedded uuid
+    () => "workflows/x.json",
+    workflowAliasForPath,
+    (id) => owners.get(id) ?? null,
+    (id, owner) => owners.set(id, owner),
+    shouldForkEmbeddedWorkflowUuid,
+    shouldForkEmbeddedUuidForLiveOwner,
+    ({ objectUuid, embeddedId, forkActive }) => objectUuid || (forkActive && embeddedId) || `fresh-${++minted}`,
+    true,
+    () => null,
+    replaced, // currentWorkflowRef still points at the pre-save object (600ms poll hasn't run)
+    aliases,
+    () => {},
+    null,
+    { randomUUID: () => `fresh-${++minted}` },
+  );
+  return { stableUuid, successor, replaced, owners, U1 };
 }
 
 // A ComfyUI ChangeTracker-shaped workflow: serialized graph states hang off
@@ -508,6 +595,99 @@ test("#545: a positively identified wrong root remains rejected even for a read"
     /NOT applied/,
     "availability for an unproven dirty root must not turn a known wrong workflow into a read result",
   );
+  assert.equal(
+    stale.rootB.extra.comfyui_mcp.workflow_uuid,
+    "workflow-B",
+    "a foreign-owned live tag must NOT be rewritten — the wrong-canvas fence stays intact",
+  );
+});
+
+// ── #545/#557: recoverable desync — orphaned root tags rebind ────────────────
+
+test("resolveGraphRootUuidRebind: none without a conflict, conflict for a foreign open owner, rebind otherwise", () => {
+  const tagged = { extra: { comfyui_mcp: { workflow_uuid: "workflow-B" } } };
+  assert.equal(
+    resolveGraphRootUuidRebind({ rootGraph: tagged, activeWorkflowUuid: "workflow-A" }),
+    "rebind",
+    "an orphaned/untracked tag is stale bookkeeping, not a wrong canvas",
+  );
+  assert.equal(
+    resolveGraphRootUuidRebind({
+      rootGraph: tagged,
+      activeWorkflowUuid: "workflow-A",
+      rootTagOwnedByForeignOpenWorkflow: true,
+    }),
+    "conflict",
+    "a tag owned by another LIVE OPEN workflow keeps the #349 data-loss fence",
+  );
+  assert.equal(
+    resolveGraphRootUuidRebind({ rootGraph: tagged, activeWorkflowUuid: "workflow-B" }), "none");
+  assert.equal(
+    resolveGraphRootUuidRebind({ rootGraph: {}, activeWorkflowUuid: "workflow-A" }),
+    "none",
+    "a missing tag stays inconclusive, exactly like the mismatch predicate",
+  );
+  assert.equal(resolveGraphRootUuidRebind({ rootGraph: tagged, activeWorkflowUuid: null }), "none");
+});
+
+test("#545: an ORPHANED root tag (owner replaced, no longer open) rebinds instead of blocking every tool", () => {
+  const h = buildDirtyStaleRouteHarness({ rootUuid: "workflow-B", tagOwnerKind: "orphaned" });
+  h.objectUuids.set(h.workflowA, "workflow-A");
+  assert.doesNotThrow(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: false }),
+    "a stale tag whose owner is no longer an open workflow must not hard-block reads",
+  );
+  assert.equal(
+    h.rootB.extra.comfyui_mcp.workflow_uuid,
+    "workflow-A",
+    "the rebind re-stamps the root with the ACTIVE workflow's identity",
+  );
+  assert.doesNotThrow(
+    () =>
+      h.assertBound(h.rootB, h.rootB, {
+        includeBaselineReadGuard: false,
+        requireDirtyMutationBinding: graphCommandMayMutateWorkflow("graph_set_node_property"),
+      }),
+    "after the rebind the root positively matches, so a dirty-tab mutation proceeds",
+  );
+});
+
+test("#545: an UNTRACKED root tag (no owner record) also rebinds rather than blocking forever", () => {
+  const h = buildDirtyStaleRouteHarness({ rootUuid: "workflow-B", tagOwnerKind: "untracked" });
+  h.objectUuids.set(h.workflowA, "workflow-A");
+  assert.doesNotThrow(() => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: false }));
+  assert.equal(h.rootB.extra.comfyui_mcp.workflow_uuid, "workflow-A");
+});
+
+// ── #557: save replaces the active workflow object — identity must follow ────
+
+test("#557: a save's successor object INHERITS the embedded uuid when the replaced owner is gone", () => {
+  const { stableUuid, successor, replaced, owners, U1 } = buildSavedSuccessorHarness({ ownerOpen: false });
+  const id = stableUuid(successor);
+  assert.equal(
+    id,
+    U1,
+    "the successor must keep the pre-save identity — minting fresh desyncs it from the root tag",
+  );
+  assert.equal(owners.get(U1), successor, "ownership moves to the successor object");
+  assert.notEqual(owners.get(U1), replaced);
+});
+
+test("#557: a genuinely co-open copy still FORKS away from the live owner's embedded uuid (#570)", () => {
+  const { stableUuid, successor, U1 } = buildSavedSuccessorHarness({ ownerOpen: true });
+  const id = stableUuid(successor);
+  assert.notEqual(id, U1, "two simultaneously-open objects must never share one identity");
+  assert.match(id, /^fresh-/, "the copy gets a fresh per-instance identity");
+});
+
+test("#557 regression: after the save-swap, the guard sees no mismatch (root tag and object stay aligned)", () => {
+  // The pre-save root tag equals the embedded uuid the successor inherits — the
+  // exact alignment panel_save_workflow broke before this fix.
+  const { stableUuid, successor, U1 } = buildSavedSuccessorHarness({ ownerOpen: false });
+  const activeWorkflowUuid = stableUuid(successor);
+  const rootGraph = { extra: { comfyui_mcp: { workflow_uuid: U1 } } };
+  assert.equal(graphRootWorkflowUuidMismatches({ rootGraph, activeWorkflowUuid }), false);
+  assert.equal(graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid }), true);
 });
 
 test("#545 P1: command identity resolution cannot adopt a stale dirty root before the binding fence", () => {

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -27,6 +27,8 @@ import {
   resolveGraphRootUuidRebind,
 } from "../../web/js/lib/graph-binding.js";
 import {
+  commandWorkflowMismatch,
+  hasEmbeddedUuidSuccessionEvidence,
   isNewWorkflowLoad,
   rawWorkflowObject,
   sameWorkflowObject,
@@ -281,6 +283,7 @@ function buildSavedSuccessorHarness({
     "rememberWorkflowUuidOwner",
     "shouldForkEmbeddedWorkflowUuid",
     "shouldForkEmbeddedUuidForLiveOwner",
+    "hasEmbeddedUuidSuccessionEvidence",
     "resolveUnsavedInstanceUuid",
     "_loadGraphDataForkInstalled",
     "workflowOwnedExtra",
@@ -303,6 +306,7 @@ function buildSavedSuccessorHarness({
     (id, owner) => owners.set(id, owner),
     shouldForkEmbeddedWorkflowUuid,
     shouldForkEmbeddedUuidForLiveOwner,
+    hasEmbeddedUuidSuccessionEvidence,
     ({ objectUuid, embeddedId, forkActive }) => objectUuid || (forkActive && embeddedId) || `fresh-${++minted}`,
     true,
     () => null,
@@ -1461,6 +1465,43 @@ test("#570 r2: a co-open copy FORKS even when the live owner appears in openWork
   const id = stableUuid(successor);
   assert.notEqual(id, U1, "a proxy-wrapped live owner is still a live foreign owner — the copy must fork");
   assert.match(id, /^fresh-/);
+});
+
+test("#349 r9 P0: a CLOSED owner + different-path copy + no alias/embedded-path FORKS — never inherits", () => {
+  // The r9 hole: "the owner is closed" alone qualified as succession, so a copy
+  // of a file that carries ONLY workflow_uuid (saved from an unsaved tab, whose
+  // embed omitted workflow_path) inherited A's identity once A closed — then
+  // overwrote A's owner record, letting stale A-scoped commands pass the fence
+  // against the copy. Without positive succession evidence the copy must fork.
+  const { stableUuid, successor, replaced, owners, U1 } = buildSavedSuccessorHarness({
+    ownerOpen: false, // the owner is CLOSED
+    currentPath: "workflows/y.json", // the COPY lives at a different path
+    embeddedPath: null, // the file carries only workflow_uuid — no path record
+    aliases: {}, // and no alias exists
+  });
+  const id = stableUuid(successor);
+  assert.notEqual(id, U1, "a different-path copy with no succession evidence must FORK");
+  assert.match(id, /^fresh-/, "the copy gets a fresh per-instance identity");
+  assert.equal(owners.get(U1), replaced, "A's owner record stays intact — never re-keyed to the copy");
+  assert.equal(
+    commandWorkflowMismatch({ commandUuid: U1, activeUuid: id }),
+    true,
+    "stale A-scoped commands stay fenced against the copy (#349)",
+  );
+});
+
+test("#557 r9 control: a same-file successor still INHERITS through the closed owner's lineage", () => {
+  // The genuine continuation: the closed owner's unique on-disk file IS this
+  // object's file (save-swap / close→reopen of the same file) — positive
+  // succession evidence, so the identity (and its root tag) carries over.
+  const { stableUuid, successor, U1 } = buildSavedSuccessorHarness({
+    ownerOpen: false,
+    currentPath: "workflows/x.json", // same file as the closed owner
+    embeddedPath: null, // even without a path record or…
+    aliases: {}, // …an alias — the owner's own file is the evidence
+  });
+  const id = stableUuid(successor);
+  assert.equal(id, U1, "the same-file successor inherits the closed owner's identity");
 });
 
 test("#557 regression: after the save-swap, the guard sees no mismatch (root tag and object stay aligned)", () => {

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -1140,18 +1140,18 @@ test("#557 r3/r4 wiring: programmaticSave threads the pre-save identity across a
   );
   assert.match(
     body,
-    /postWfIsSaveTargetRecord = Boolean\(targetRecord\) && sameWorkflowObject\(targetRecord, postSwapWf\)/,
-    "continuity must be threaded from the save's own replacement event — the service's record for the file this save wrote (r8 P0)",
+    /postWfIsSaveProducedRecord = Boolean\(details\?\.savedRecord\) && sameWorkflowObject\(details\.savedRecord, postSwapWf\)/,
+    "continuity must be threaded from the save API's own PRODUCED record — never path occupancy (r10 P0)",
   );
   assert.doesNotMatch(
     body,
-    /successorCarriesPreUuid/,
-    "static tracker/serialized-state evidence is NOT continuity (r8 P0) — it must not appear in the carry",
+    /successorCarriesPreUuid|postWfIsSaveTargetRecord|targetRecord/,
+    "static evidence (tracker state, path occupancy) is NOT continuity (r8/r10 P0) — it must not appear in the carry",
   );
   assert.match(
     body,
-    /shouldCarryIdentityAcrossSaveSwap\(\{\s*preWf: expectWf,\s*postWf: postSwapWf,\s*savedAs: outcome\.saved_as,\s*preWfStillOpen,\s*postWfHasConflictingEstablishedIdentity,\s*postWfIsSaveTargetRecord,\s*\}\)/,
-    "the carry must pass ALL continuity evidence to the pure rule (never a Save-As copy, never a mid-save switch, never over an established conflict, never on stale residue)",
+    /shouldCarryIdentityAcrossSaveSwap\(\{\s*preWf: expectWf,\s*postWf: postSwapWf,\s*savedAs: outcome\.saved_as,\s*preWfStillOpen,\s*postWfHasConflictingEstablishedIdentity,\s*postWfIsSaveProducedRecord,\s*\}\)/,
+    "the carry must pass ALL continuity evidence to the pure rule (never a Save-As copy, never a mid-save switch, never over an established conflict, never on static evidence)",
   );
   assert.doesNotMatch(
     body,
@@ -1229,9 +1229,11 @@ function buildProgrammaticSaveHarness({ onSave } = {}) {
   )(
     { extensionManager: { workflow: svc } },
     async (svcArg, _name, opts) => {
-      onSave?.({ svc: svcArg, A, B }); // the mid-await switch / swap / reconnect
+      const outcome = onSave?.({ svc: svcArg, A, B }) ?? {}; // the mid-await switch / swap / reconnect
       opts.details.mode = "in-place";
       opts.details.targetPath = "workflows/a.json"; // the save wrote A's file (mirrors recordOutcome)
+      // Mirrors the save lib's r10 thread: the save API's own produced record.
+      if (outcome.producedRecord) opts.details.savedRecord = outcome.producedRecord;
       return "a.json";
     },
     () => "Untitled",
@@ -1370,6 +1372,46 @@ test("#349 r8 P0: a foreign tab whose LAGGING tracker carries the pre-save uuid 
   );
 });
 
+test("#349 r10 P0: a same-path close→reopen during the awaited save aborts the carry (reopened = new identity)", async () => {
+  // The r10 hole: A's tab CLOSES while the save awaits and a DISTINCT object B
+  // reopens the SAME path. Path occupancy (r8's target record) is satisfied by
+  // B — but B is not what the save PRODUCED, so the carry must abort: a
+  // closed→reopened object is a NEW identity (r5's rule), never a successor.
+  const reopenedB = {
+    isPersisted: true,
+    path: "workflows/a.json", // SAME path — but a DISTINCT object
+    isModified: true,
+    changeTracker: {
+      activeState: { ...state(27), extra: { comfyui_mcp: { workflow_uuid: "uuid-A" } } },
+    },
+  };
+  const saveProducedRecord = {
+    isPersisted: true,
+    path: "workflows/a.json", // what the save API itself produced — NOT reopenedB
+    changeTracker: { activeState: state(27) },
+  };
+  const { save, svc, objectUuids, owners, activeClaims } = buildProgrammaticSaveHarness({
+    onSave: ({ svc }) => {
+      svc.openWorkflows = [reopenedB]; // A closed; B reopened the same path and is its record
+      svc.activeWorkflow = reopenedB;
+      return { producedRecord: saveProducedRecord };
+    },
+  });
+  await save();
+  assert.equal(objectUuids.get(reopenedB), undefined, "a reopened object must NOT be seeded — it is a NEW identity");
+  assert.notEqual(owners.get("uuid-A"), reopenedB, "A's owner record stays intact");
+  assert.equal(
+    activeClaims("uuid-A"),
+    false,
+    "the reopened object must not claim A's tag — the guard cannot heal onto it",
+  );
+  assert.equal(
+    commandWorkflowMismatch({ commandUuid: "uuid-A", activeUuid: "uuid-B" }),
+    true,
+    "stale A-scoped commands stay fenced against the reopened object (#349)",
+  );
+});
+
 test("#557 r4 control: a GENUINE save-swap successor still carries the pre-save identity", async () => {
   const successor = {
     isPersisted: true,
@@ -1382,13 +1424,14 @@ test("#557 r4 control: a GENUINE save-swap successor still carries the pre-save 
     onSave: ({ svc }) => {
       svc.openWorkflows = [successor]; // a genuine swap REMOVES the predecessor
       svc.activeWorkflow = successor;
+      return { producedRecord: successor }; // the save API's own result IS the successor
     },
   });
   await save();
   assert.equal(
     objectUuids.get(successor),
     "uuid-A",
-    "the proven successor is seeded with the pre-save uuid (#557)",
+    "the save-produced successor is seeded with the pre-save uuid (#557)",
   );
   assert.equal(owners.get("uuid-A"), successor, "the successor becomes the uuid's registered owner");
 });
@@ -1490,18 +1533,36 @@ test("#349 r9 P0: a CLOSED owner + different-path copy + no alias/embedded-path 
   );
 });
 
-test("#557 r9 control: a same-file successor still INHERITS through the closed owner's lineage", () => {
-  // The genuine continuation: the closed owner's unique on-disk file IS this
-  // object's file (save-swap / close→reopen of the same file) — positive
-  // succession evidence, so the identity (and its root tag) carries over.
-  const { stableUuid, successor, U1 } = buildSavedSuccessorHarness({
+test("#349 r10: a same-path successor of a PATH-LESS file FORKS — reopened object, new identity", () => {
+  // The file carries only workflow_uuid (no workflow_path record) and no alias
+  // exists, so the only "evidence" would be the closed owner's file matching —
+  // which r10 excludes: a closed→reopened object at the same path is a NEW
+  // identity. (The durable-resume heal belongs to the UNREGISTERED-embedded
+  // path, not to registered-owner inheritance.)
+  const { stableUuid, successor, replaced, owners, U1 } = buildSavedSuccessorHarness({
     ownerOpen: false,
-    currentPath: "workflows/x.json", // same file as the closed owner
-    embeddedPath: null, // even without a path record or…
-    aliases: {}, // …an alias — the owner's own file is the evidence
+    currentPath: "workflows/x.json", // same path as the closed owner, but a distinct object
+    embeddedPath: null,
+    aliases: {},
   });
   const id = stableUuid(successor);
-  assert.equal(id, U1, "the same-file successor inherits the closed owner's identity");
+  assert.notEqual(id, U1, "owner-file match alone is NOT succession evidence (r10)");
+  assert.match(id, /^fresh-/, "the reopened object gets a fresh per-instance identity");
+  assert.equal(owners.get(U1), replaced, "A's owner record stays intact");
+});
+
+test("#557 r9 control: a same-file successor still INHERITS via the file's own path record", () => {
+  // Positive succession evidence layer 1: the file's recorded workflow_path
+  // ties the uuid to this object's file — the genuine #557 save-swap / same-file
+  // reload of a properly-stamped file.
+  const { stableUuid, successor, U1 } = buildSavedSuccessorHarness({
+    ownerOpen: false,
+    currentPath: "workflows/x.json",
+    embeddedPath: "workflows/x.json",
+    aliases: {},
+  });
+  const id = stableUuid(successor);
+  assert.equal(id, U1, "the file's own path record proves succession — the successor inherits");
 });
 
 test("#557 regression: after the save-swap, the guard sees no mismatch (root tag and object stay aligned)", () => {

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -27,10 +27,12 @@ import {
   resolveGraphRootUuidRebind,
 } from "../../web/js/lib/graph-binding.js";
 import {
+  isNewWorkflowLoad,
   rawWorkflowObject,
   sameWorkflowObject,
   shouldForkEmbeddedUuidForLiveOwner,
   shouldForkEmbeddedWorkflowUuid,
+  shouldForkInPlaceReload,
   workflowAliasForPath,
 } from "../../web/js/lib/workflow-chat-identity.js";
 
@@ -45,6 +47,12 @@ function panelFunctionSource(src, name, nextName) {
   return src.slice(start, end);
 }
 
+// Vue-faithful reactive proxy: real Vue proxies expose the raw target as
+// __v_raw. A purely transparent Proxy has no raw back-pointer, so an
+// inspection-based identity check could never match it to a carrier-less object
+// — that combination is a test artifact, not a Vue behavior (r3).
+const vueProxyOf = (raw) => new Proxy(raw, { get: (t, k) => (k === "__v_raw" ? t : t[k]) });
+
 // foreignClaim models WHETHER a live open tab claims the root tag when it
 // conflicts with the active workflow's identity (#349/#545/#557):
 //   "identity"              — tab B is OPEN and the root-blind resolver returns
@@ -58,35 +66,51 @@ function panelFunctionSource(src, name, nextName) {
 //                             the resolver mints a different identity; only the
 //                             registered owner map ties it to the tag (#558 r2):
 //                             the guard must keep throwing;
+//   "same-path-overlap"     — A and B are DISTINCT live objects at the SAME path
+//                             (a closed→reopened overlap, #558 r3): path equality
+//                             must NOT exempt B from the foreign-claim check;
 //   "none"                  — NO live open tab claims the tag (a closed/replaced
 //                             tab's leftover): genuine stale bookkeeping — the
 //                             guard rebinds.
-function buildDirtyStaleRouteHarness({ rootUuid = "workflow-B", foreignClaim = "identity" } = {}) {
+// foreignTab overrides the B object (e.g. a creation-lifecycle product), and
+// registeredOwners/objectUuids override the identity stores the harness wires in.
+function buildDirtyStaleRouteHarness({
+  rootUuid = "workflow-B",
+  foreignClaim = "identity",
+  foreignTab = null,
+  registeredOwners = null,
+  objectUuids: objectUuidsOpt = null,
+} = {}) {
   const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
   const stableSource = panelFunctionSource(src, "workflowStableUuid", "workflowStorageKey");
   const fenceSource = panelFunctionSource(src, "assertGraphBoundToActiveWorkflow", "getPiniaStore");
   const ownsTagSource = panelFunctionSource(src, "workflowOwnsRootUuidTag", "assertGraphBoundToActiveWorkflow");
-  const workflowA = { isPersisted: false, isModified: true, changeTracker: { activeState: state(27) } };
-  const rawB = {
-    isPersisted: true,
-    path: "workflows/b.json",
-    changeTracker:
-      foreignClaim === "unloaded-proxy-owner"
-        ? null // a live tab whose serialized state is NOT loaded
-        : {
-            activeState: {
-              ...state(30),
-              // A creation-stamped graph carries the tag in the tab's own
-              // serialized state even when no resolver/owner record observed it.
-              ...(foreignClaim === "tracker-stamp" && rootUuid
-                ? { extra: { comfyui_mcp: { workflow_uuid: rootUuid } } }
-                : {}),
+  const overlap = foreignClaim === "same-path-overlap";
+  const workflowA = overlap
+    ? { isPersisted: true, path: "workflows/a.json", isModified: true, changeTracker: { activeState: state(27) } }
+    : { isPersisted: false, isModified: true, changeTracker: { activeState: state(27) } };
+  const rawB =
+    foreignTab ??
+    {
+      isPersisted: true,
+      path: overlap ? "workflows/a.json" : "workflows/b.json", // overlap: same file, NEW object
+      changeTracker:
+        foreignClaim === "unloaded-proxy-owner"
+          ? null // a live tab whose serialized state is NOT loaded
+          : {
+              activeState: {
+                ...state(30),
+                // A creation-stamped graph carries the tag in the tab's own
+                // serialized state even when no resolver/owner record observed it.
+                ...(foreignClaim === "tracker-stamp" && rootUuid
+                  ? { extra: { comfyui_mcp: { workflow_uuid: rootUuid } } }
+                  : {}),
+              },
             },
-          },
-  };
+    };
   // The repo's store-double idiom (workflow-save.test.mjs): openWorkflows holds
   // PROXIES while the identity stores key on RAW objects.
-  const proxyB = new Proxy(rawB, {});
+  const proxyB = vueProxyOf(rawB);
   const rootB = {
     _nodes: Array.from({ length: 30 }, (_, i) => ({ id: i + 1, type: "KSampler" })),
     ...(rootUuid ? { extra: { comfyui_mcp: { workflow_uuid: rootUuid } } } : {}),
@@ -97,10 +121,10 @@ function buildDirtyStaleRouteHarness({ rootUuid = "workflow-B", foreignClaim = "
       : foreignClaim === "unloaded-proxy-owner"
         ? [workflowA, proxyB]
         : [workflowA, rawB];
-  const registeredOwners = new Map(
-    foreignClaim === "unloaded-proxy-owner" && rootUuid ? [[rootUuid, rawB]] : [],
-  );
-  const objectUuids = new WeakMap();
+  const registeredOwnersMap =
+    registeredOwners ??
+    new Map(foreignClaim === "unloaded-proxy-owner" && rootUuid ? [[rootUuid, rawB]] : []);
+  const objectUuids = objectUuidsOpt ?? new WeakMap();
   let minted = 0;
   const stableUuidA = new Function(
     "app",
@@ -130,14 +154,18 @@ function buildDirtyStaleRouteHarness({ rootUuid = "workflow-B", foreignClaim = "
   );
   // Per-tab established identities as the real resolver would produce them: A
   // through the real (unsaved-branch) source; B returns its recorded identity —
-  // under "identity" that IS the root tag; otherwise the resolver minted a
-  // different identity and never observed B's stamp.
-  const stableUuid = (wf) =>
-    wf === rawB || wf === proxyB
-      ? foreignClaim === "identity"
-        ? rootUuid
-        : "workflow-B-minted"
-      : stableUuidA(wf);
+  // under "identity"/"same-path-overlap" that IS the root tag; otherwise the
+  // resolver mints a different identity and never observed B's stamp. The real
+  // resolver consults the per-object cache FIRST, so a creation-registered tab
+  // (its cache seeded at load, r3) resolves to its stamp even here.
+  const stableUuid = (wf) => {
+    if (wf === rawB || wf === proxyB) {
+      const cached = objectUuids.get(wf) ?? objectUuids.get(rawB);
+      if (cached) return cached;
+      return foreignClaim === "identity" || foreignClaim === "same-path-overlap" ? rootUuid : "workflow-B-minted";
+    }
+    return stableUuidA(wf);
+  };
   const ownsTag = new Function(
     "workflowStableUuid",
     "rawWorkflowObject",
@@ -150,7 +178,7 @@ function buildDirtyStaleRouteHarness({ rootUuid = "workflow-B", foreignClaim = "
     stableUuid,
     rawWorkflowObject,
     sameWorkflowObject,
-    (id) => registeredOwners.get(id) ?? null,
+    (id) => registeredOwnersMap.get(id) ?? null,
     "comfyui_mcp",
     "workflow_uuid",
   );
@@ -215,7 +243,7 @@ function buildSavedSuccessorHarness({
     ownerOpen === true
       ? [replaced, successor]
       : ownerOpen === "proxy"
-        ? [new Proxy(replaced, {}), successor]
+        ? [vueProxyOf(replaced), successor]
         : [successor];
   const stableUuid = new Function(
     "app",
@@ -801,6 +829,137 @@ test("#349 P0 r2: a live UNLOADED foreign tab present only as a proxy must throw
     h.rootB.extra.comfyui_mcp.workflow_uuid,
     "workflow-B",
     "a live foreign proxy's tag must NOT be rewritten",
+  );
+});
+
+test("#349 P0 r3: a same-path OVERLAP (closed→reopened object) is NOT self — the foreign claim still throws", () => {
+  // A and B are DISTINCT live objects at the SAME path (a closed→reopened
+  // overlap). Path equality must not classify B as the active workflow and
+  // exempt it from the foreign-claim check — the reopened object is a NEW
+  // identity (r3 P0), so B's claim on the root tag stays a hard refusal.
+  const h = buildDirtyStaleRouteHarness({ rootUuid: "workflow-B", foreignClaim: "same-path-overlap" });
+  h.objectUuids.set(h.workflowA, "workflow-A");
+  assert.throws(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: false }),
+    /NOT applied/,
+    "a same-path foreign object must not be exempted as self (#349)",
+  );
+  assert.throws(
+    () =>
+      h.assertBound(h.rootB, h.rootB, {
+        includeBaselineReadGuard: false,
+        requireDirtyMutationBinding: graphCommandMayMutateWorkflow("graph_set_node_property"),
+      }),
+    /NOT applied/,
+    "the same-path foreign root must refuse a dirty mutation",
+  );
+  assert.equal(h.rootB.extra.comfyui_mcp.workflow_uuid, "workflow-B", "the foreign root keeps its tag");
+});
+
+test("#349 P0 r3: a CREATION-minted tag is registered to the tab the load activates (lifecycle, no manual seeding)", async () => {
+  // Drive the REAL creation path: installCreateBoundaryFork wraps
+  // app.loadGraphData; a creation (non-object workflow arg) stamps a fresh uuid
+  // and — after the load — must register it against the tab the load activated.
+  // Without that registration a live, unloaded, never-resolved creation carries
+  // a tag nothing claims, and the guard rebinds over its foreign root (r3 P0).
+  const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+  const forkSource = panelFunctionSource(src, "installCreateBoundaryFork", "workflowUuidOwner");
+  const objectUuids = new WeakMap();
+  const owners = new Map();
+  const createdTab = { isPersisted: false, changeTracker: null }; // live, unloaded, never resolved
+  const fakeApp = {
+    graph: null,
+    extensionManager: { workflow: { activeWorkflow: null, openWorkflows: [] } },
+    loadGraphData(graphData) {
+      // ComfyUI's creation behavior: the graph goes live in a NEW active tab.
+      this.graph = { _nodes: graphData.nodes ?? [], extra: graphData.extra };
+      this.extensionManager.workflow.activeWorkflow = createdTab;
+      this.extensionManager.workflow.openWorkflows.push(createdTab);
+    },
+  };
+  const install = new Function(
+    "_loadGraphDataForkInstalled",
+    "_workflowObjectUuids",
+    "rememberWorkflowUuidOwner",
+    "isNewWorkflowLoad",
+    "shouldForkInPlaceReload",
+    "recordPreLoadPromptRelayEditors",
+    "crypto",
+    "WORKFLOW_META_NAMESPACE",
+    "WORKFLOW_UUID_FIELD",
+    `${forkSource}\nreturn installCreateBoundaryFork;`,
+  )(
+    false,
+    objectUuids,
+    (id, owner) => owners.set(id, owner),
+    isNewWorkflowLoad,
+    shouldForkInPlaceReload,
+    () => {},
+    { randomUUID: () => "creation-uuid-1" },
+    "comfyui_mcp",
+    "workflow_uuid",
+  );
+  install(fakeApp);
+  await fakeApp.loadGraphData({ nodes: [{ id: 1, type: "KSampler" }] });
+  assert.equal(
+    fakeApp.graph.extra.comfyui_mcp.workflow_uuid,
+    "creation-uuid-1",
+    "the creation stamps the graph before it goes live",
+  );
+  assert.equal(
+    owners.get("creation-uuid-1"),
+    createdTab,
+    "the creation stamp is registered to the tab the load activated — no ownerless tags",
+  );
+  assert.equal(
+    objectUuids.get(createdTab),
+    "creation-uuid-1",
+    "the receiving tab's identity cache carries its stamp",
+  );
+
+  // …so the desync guard refuses to rebind over that live, unloaded,
+  // never-resolved creation while ANOTHER workflow is active: the resolver
+  // claim fires straight from the registration (no manual owner-map seeding).
+  const h = buildDirtyStaleRouteHarness({
+    rootUuid: "creation-uuid-1",
+    foreignClaim: "unloaded-proxy-owner",
+    foreignTab: createdTab,
+    registeredOwners: owners,
+    objectUuids,
+  });
+  h.objectUuids.set(h.workflowA, "workflow-A");
+  assert.throws(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: false }),
+    /NOT applied/,
+    "a live creation-registered tab keeps its root — never rebound (#349)",
+  );
+  assert.equal(h.rootB.extra.comfyui_mcp.workflow_uuid, "creation-uuid-1", "the created tab's tag survives");
+});
+
+test("#557 r3 wiring: programmaticSave threads the pre-save identity across an in-place object swap", () => {
+  const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+  const start = src.indexOf("async function programmaticSave(name)");
+  assert.notEqual(start, -1, "programmaticSave must exist");
+  const body = src.slice(start, src.indexOf("\n}\n", start));
+  assert.match(
+    body,
+    /preSwapUuid = expectWf \? _workflowObjectUuids\.get\(expectWf\) \|\| workflowStableUuid\(expectWf\) : null/,
+    "the pre-save identity must be captured from the pre-save object BEFORE the save",
+  );
+  assert.match(
+    body,
+    /shouldCarryIdentityAcrossSaveSwap\(\{ preWf: expectWf, postWf: postSwapWf, savedAs: outcome\.saved_as \}\)/,
+    "the carry must be gated by the pure continuous-lifetime rule (never a Save-As copy)",
+  );
+  assert.match(
+    body,
+    /_workflowObjectUuids\.set\(postSwapWf, preSwapUuid\)/,
+    "the successor object cache must be seeded with the pre-save uuid",
+  );
+  assert.match(
+    body,
+    /rememberWorkflowUuidOwner\(preSwapUuid, postSwapWf\)/,
+    "the successor must be registered as the pre-save uuid's owner",
   );
 });
 

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -43,30 +43,45 @@ function panelFunctionSource(src, name, nextName) {
   return src.slice(start, end);
 }
 
-// tagOwnerKind models WHO owns the root graph's stamped uuid when it conflicts
-// with the active workflow's identity (#545/#557):
-//   "foreign-open" — another LIVE OPEN workflow tab (the genuine #349 wrong
-//                    canvas): the guard must keep throwing;
-//   "orphaned"     — an object that is no longer an open tab (a save/reconnect
-//                    replaced it): stale bookkeeping — the guard must rebind;
-//   "untracked"    — no owner record at all: also stale bookkeeping — rebind.
-function buildDirtyStaleRouteHarness({ rootUuid = "workflow-B", tagOwnerKind = "foreign-open" } = {}) {
+// foreignClaim models WHETHER a live open tab claims the root tag when it
+// conflicts with the active workflow's identity (#349/#545/#557):
+//   "identity"      — tab B is OPEN and the root-blind resolver returns the tag
+//                     for it: the guard must keep throwing;
+//   "tracker-stamp" — tab B is OPEN, the resolver mints a DIFFERENT identity for
+//                     it, but B's OWN serialized state still carries the tag (a
+//                     creation stamp no resolver run or owner record observed —
+//                     creation loadGraphData passes no workflow object, so the
+//                     stamp was never registered): the guard must keep throwing;
+//   "none"          — NO live open tab claims the tag (a closed/replaced tab's
+//                     leftover): genuine stale bookkeeping — the guard rebinds.
+function buildDirtyStaleRouteHarness({ rootUuid = "workflow-B", foreignClaim = "identity" } = {}) {
   const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
   const stableSource = panelFunctionSource(src, "workflowStableUuid", "workflowStorageKey");
   const fenceSource = panelFunctionSource(src, "assertGraphBoundToActiveWorkflow", "getPiniaStore");
+  const ownsTagSource = panelFunctionSource(src, "workflowOwnsRootUuidTag", "assertGraphBoundToActiveWorkflow");
   const workflowA = { isPersisted: false, isModified: true, changeTracker: { activeState: state(27) } };
-  const workflowB = { isPersisted: true, path: "workflows/b.json", changeTracker: { activeState: state(30) } };
-  const replacedPredecessor = { isPersisted: true, path: "workflows/a.json" };
+  const workflowB = {
+    isPersisted: true,
+    path: "workflows/b.json",
+    changeTracker: {
+      activeState: {
+        ...state(30),
+        // A creation-stamped graph carries the tag in the tab's own serialized
+        // state even when no resolver/owner record ever observed it.
+        ...(foreignClaim === "tracker-stamp" && rootUuid
+          ? { extra: { comfyui_mcp: { workflow_uuid: rootUuid } } }
+          : {}),
+      },
+    },
+  };
   const rootB = {
     _nodes: Array.from({ length: 30 }, (_, i) => ({ id: i + 1, type: "KSampler" })),
     ...(rootUuid ? { extra: { comfyui_mcp: { workflow_uuid: rootUuid } } } : {}),
   };
-  const tagOwner =
-    tagOwnerKind === "foreign-open" ? workflowB : tagOwnerKind === "orphaned" ? replacedPredecessor : null;
-  const openWorkflows = tagOwnerKind === "foreign-open" ? [workflowA, workflowB] : [workflowA];
+  const openWorkflows = foreignClaim === "none" ? [workflowA] : [workflowA, workflowB];
   const objectUuids = new WeakMap();
   let minted = 0;
-  const stableUuid = new Function(
+  const stableUuidA = new Function(
     "app",
     "getTabId",
     "savedWorkflowPath",
@@ -90,6 +105,18 @@ function buildDirtyStaleRouteHarness({ rootUuid = "workflow-B", tagOwnerKind = "
     () => null,
     { randomUUID: () => `workflow-A-${++minted}` },
   );
+  // Per-tab established identities as the real resolver would produce them: A
+  // through the real (unsaved-branch) source; B returns its recorded identity —
+  // under "identity" that IS the root tag; under "tracker-stamp" the resolver
+  // minted a different identity and never observed B's graph stamp.
+  const stableUuid = (wf) =>
+    wf === workflowB ? (foreignClaim === "identity" ? rootUuid : "workflow-B-minted") : stableUuidA(wf);
+  const ownsTag = new Function(
+    "workflowStableUuid",
+    "WORKFLOW_META_NAMESPACE",
+    "WORKFLOW_UUID_FIELD",
+    `${ownsTagSource}\nreturn workflowOwnsRootUuidTag;`,
+  )(stableUuid, "comfyui_mcp", "workflow_uuid");
   const assertBound = new Function(
     "activeWorkflowRef",
     "_workflowObjectUuids",
@@ -99,7 +126,7 @@ function buildDirtyStaleRouteHarness({ rootUuid = "workflow-B", tagOwnerKind = "
     "graphRootMismatchesActiveWorkflow",
     "graphReadDesynced",
     "activeWorkflowNodeCount",
-    "workflowUuidOwner",
+    "workflowOwnsRootUuidTag",
     "rememberWorkflowUuidOwner",
     "resolveGraphRootUuidRebind",
     "WORKFLOW_META_NAMESPACE",
@@ -115,7 +142,7 @@ function buildDirtyStaleRouteHarness({ rootUuid = "workflow-B", tagOwnerKind = "
     graphRootMismatchesActiveWorkflow,
     graphReadDesynced,
     activeWorkflowNodeCount,
-    (id) => (id && id === rootUuid ? tagOwner : null),
+    ownsTag,
     () => {},
     resolveGraphRootUuidRebind,
     "comfyui_mcp",
@@ -609,7 +636,7 @@ test("resolveGraphRootUuidRebind: none without a conflict, conflict for a foreig
   assert.equal(
     resolveGraphRootUuidRebind({ rootGraph: tagged, activeWorkflowUuid: "workflow-A" }),
     "rebind",
-    "an orphaned/untracked tag is stale bookkeeping, not a wrong canvas",
+    "a tag no LIVE OPEN workflow claims is stale bookkeeping, not a wrong canvas",
   );
   assert.equal(
     resolveGraphRootUuidRebind({
@@ -630,12 +657,12 @@ test("resolveGraphRootUuidRebind: none without a conflict, conflict for a foreig
   assert.equal(resolveGraphRootUuidRebind({ rootGraph: tagged, activeWorkflowUuid: null }), "none");
 });
 
-test("#545: an ORPHANED root tag (owner replaced, no longer open) rebinds instead of blocking every tool", () => {
-  const h = buildDirtyStaleRouteHarness({ rootUuid: "workflow-B", tagOwnerKind: "orphaned" });
+test("#545: a root tag NO LIVE OPEN workflow claims (closed/replaced tab's leftover) rebinds instead of blocking every tool", () => {
+  const h = buildDirtyStaleRouteHarness({ rootUuid: "workflow-B", foreignClaim: "none" });
   h.objectUuids.set(h.workflowA, "workflow-A");
   assert.doesNotThrow(
     () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: false }),
-    "a stale tag whose owner is no longer an open workflow must not hard-block reads",
+    "a leftover tag no open tab claims must not hard-block reads",
   );
   assert.equal(
     h.rootB.extra.comfyui_mcp.workflow_uuid,
@@ -652,11 +679,44 @@ test("#545: an ORPHANED root tag (owner replaced, no longer open) rebinds instea
   );
 });
 
-test("#545: an UNTRACKED root tag (no owner record) also rebinds rather than blocking forever", () => {
-  const h = buildDirtyStaleRouteHarness({ rootUuid: "workflow-B", tagOwnerKind: "untracked" });
+test("#349: a root tag a LIVE OPEN workflow claims through the resolver must throw", () => {
+  const h = buildDirtyStaleRouteHarness({ rootUuid: "workflow-B", foreignClaim: "identity" });
   h.objectUuids.set(h.workflowA, "workflow-A");
-  assert.doesNotThrow(() => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: false }));
-  assert.equal(h.rootB.extra.comfyui_mcp.workflow_uuid, "workflow-A");
+  assert.throws(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: false }),
+    /NOT applied/,
+    "B's live open tab claims the tag — rebinding over it would authorize mutating B (#349)",
+  );
+  assert.equal(h.rootB.extra.comfyui_mcp.workflow_uuid, "workflow-B", "the foreign tag must NOT be rewritten");
+});
+
+test("#349 P0: a root tag claimed ONLY by a live open tab's serialized state (unregistered creation stamp) must throw", () => {
+  // The codex-gate hole: a CREATION stamps the graph uuid without any owner/
+  // object-cache record (creation loadGraphData passes no workflow object), so
+  // the owner map says nothing while B is LIVE in openWorkflows. The rebind must
+  // treat B's own serialized-state stamp as a foreign claim — never re-stamp B's
+  // canvas as A's.
+  const h = buildDirtyStaleRouteHarness({ rootUuid: "workflow-B", foreignClaim: "tracker-stamp" });
+  h.objectUuids.set(h.workflowA, "workflow-A");
+  assert.throws(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: false }),
+    /NOT applied/,
+    "a live but UNTRACKED foreign owner must stay fail-closed (#349)",
+  );
+  assert.throws(
+    () =>
+      h.assertBound(h.rootB, h.rootB, {
+        includeBaselineReadGuard: false,
+        requireDirtyMutationBinding: graphCommandMayMutateWorkflow("graph_set_node_property"),
+      }),
+    /NOT applied/,
+    "the same live-untracked foreign root must refuse a dirty mutation",
+  );
+  assert.equal(
+    h.rootB.extra.comfyui_mcp.workflow_uuid,
+    "workflow-B",
+    "an unregistered live creation stamp must NOT be rewritten",
+  );
 });
 
 // ── #557: save replaces the active workflow object — identity must follow ────

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -1136,13 +1136,18 @@ test("#557 r3/r4 wiring: programmaticSave threads the pre-save identity across a
   );
   assert.match(
     body,
-    /successorCarriesPreUuid =\s*successorState\?\.extra\?\.\[WORKFLOW_META_NAMESPACE\]\?\.\[WORKFLOW_UUID_FIELD\] === preSwapUuid/,
-    "the successor must prove continuity via the pre-save uuid in its serialized state",
+    /postWfIsSaveTargetRecord = Boolean\(targetRecord\) && sameWorkflowObject\(targetRecord, postSwapWf\)/,
+    "continuity must be threaded from the save's own replacement event — the service's record for the file this save wrote (r8 P0)",
+  );
+  assert.doesNotMatch(
+    body,
+    /successorCarriesPreUuid/,
+    "static tracker/serialized-state evidence is NOT continuity (r8 P0) — it must not appear in the carry",
   );
   assert.match(
     body,
-    /shouldCarryIdentityAcrossSaveSwap\(\{\s*preWf: expectWf,\s*postWf: postSwapWf,\s*savedAs: outcome\.saved_as,\s*preWfStillOpen,\s*successorCarriesPreUuid,\s*postWfHasConflictingEstablishedIdentity,\s*\}\)/,
-    "the carry must pass ALL continuity evidence to the pure rule (never a Save-As copy, never a mid-save switch, never over an established conflict)",
+    /shouldCarryIdentityAcrossSaveSwap\(\{\s*preWf: expectWf,\s*postWf: postSwapWf,\s*savedAs: outcome\.saved_as,\s*preWfStillOpen,\s*postWfHasConflictingEstablishedIdentity,\s*postWfIsSaveTargetRecord,\s*\}\)/,
+    "the carry must pass ALL continuity evidence to the pure rule (never a Save-As copy, never a mid-save switch, never over an established conflict, never on stale residue)",
   );
   assert.doesNotMatch(
     body,
@@ -1222,6 +1227,7 @@ function buildProgrammaticSaveHarness({ onSave } = {}) {
     async (svcArg, _name, opts) => {
       onSave?.({ svc: svcArg, A, B }); // the mid-await switch / swap / reconnect
       opts.details.mode = "in-place";
+      opts.details.targetPath = "workflows/a.json"; // the save wrote A's file (mirrors recordOutcome)
       return "a.json";
     },
     () => "Untitled",
@@ -1316,6 +1322,47 @@ test("#349 r5 P0: a CLOSE mid-await that compacts the tab list (B lands in A's o
     }),
     "conflict",
     "with the carry aborted, writes to A's stale root stay fenced while B is active",
+  );
+});
+
+test("#349 r8 P0: a foreign tab whose LAGGING tracker carries the pre-save uuid must not inherit the carry", async () => {
+  // The r8 spoof: A closed mid-await; B — a FOREIGN tab (different file), with
+  // no WeakMap cache (so the r7 conflict veto cannot fire) — becomes active,
+  // and its lagging activeState still carries A's uuid as residue. Static
+  // tracker evidence is indistinguishable from "the successor parsed the
+  // just-saved file" (the r6 evidence class, one layer up), so the carry must
+  // require event-threaded continuity instead: the post-save ACTIVE object
+  // must be the service's current record for the file THIS save wrote.
+  const foreignB = {
+    isPersisted: true,
+    path: "workflows/b.json",
+    isModified: true,
+    changeTracker: {
+      activeState: { ...state(5), extra: { comfyui_mcp: { workflow_uuid: "uuid-A" } } }, // stale residue
+    },
+  };
+  const { save, svc, A, objectUuids, owners, activeClaims } = buildProgrammaticSaveHarness({
+    onSave: ({ svc }) => {
+      svc.openWorkflows = [foreignB]; // A closed; foreign B activated
+      svc.activeWorkflow = foreignB;
+    },
+  });
+  await save();
+  assert.equal(objectUuids.get(foreignB), undefined, "B must NOT be seeded with A's uuid on stale residue");
+  assert.notEqual(owners.get("uuid-A"), foreignB, "A's owner record must stay intact");
+  assert.equal(
+    activeClaims("uuid-A"),
+    false,
+    "B must not claim A's tag — the guard cannot heal an A-tagged stale canvas onto B",
+  );
+  assert.equal(
+    resolveGraphRootUuidRebind({
+      rootGraph: { extra: { comfyui_mcp: { workflow_uuid: "uuid-A" } } },
+      activeWorkflowUuid: "uuid-B",
+      rootTagClaimedByActiveWorkflow: activeClaims("uuid-A"),
+    }),
+    "conflict",
+    "with the carry vetoed, writes to A's stale canvas stay fenced while B is active",
   );
 });
 

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -56,6 +56,14 @@ function panelFunctionSource(src, name, nextName) {
 // — that combination is a test artifact, not a Vue behavior (r3).
 const vueProxyOf = (raw) => new Proxy(raw, { get: (t, k) => (k === "__v_raw" ? t : t[k]) });
 
+// r11 — the panel's per-object identity store is accessed ONLY through
+// raw-keyed helpers; harnesses inject equivalents backed by their own WeakMap.
+const rawKeyedUuidStore = (map) => ({
+  workflowObjectUuid: (wf) => map.get(rawWorkflowObject(wf)),
+  setWorkflowObjectUuid: (wf, id) => map.set(rawWorkflowObject(wf), id),
+  deleteWorkflowObjectUuid: (wf) => map.delete(rawWorkflowObject(wf)),
+});
+
 // foreignClaim models WHETHER a live open tab claims the root tag when it
 // conflicts with the active workflow's identity (#349/#545/#557):
 //   "identity"              — tab B is OPEN and the root-blind resolver returns
@@ -155,12 +163,14 @@ function buildDirtyStaleRouteHarness({
           : [],
     );
   const objectUuids = objectUuidsOpt ?? new WeakMap();
+  const uuidStore = rawKeyedUuidStore(objectUuids);
   let minted = 0;
   const stableUuidA = new Function(
     "app",
     "getTabId",
     "savedWorkflowPath",
-    "_workflowObjectUuids",
+    "workflowObjectUuid",
+    "setWorkflowObjectUuid",
     "embeddedWorkflowUuid",
     "resolveUnsavedInstanceUuid",
     "_loadGraphDataForkInstalled",
@@ -173,7 +183,8 @@ function buildDirtyStaleRouteHarness({
     { graph: rootB },
     () => "fallback-tab",
     () => null,
-    objectUuids,
+    uuidStore.workflowObjectUuid,
+    uuidStore.setWorkflowObjectUuid,
     (_wf, { allowGraph }) => (allowGraph ? rootB.extra?.comfyui_mcp?.workflow_uuid : null),
     ({ objectUuid, embeddedId, forkActive }) => objectUuid || (forkActive && embeddedId) || `workflow-A-${++minted}`,
     true,
@@ -214,7 +225,7 @@ function buildDirtyStaleRouteHarness({
   );
   const assertBound = new Function(
     "activeWorkflowRef",
-    "_workflowObjectUuids",
+    "workflowObjectUuid",
     "workflowStableUuid",
     "graphRootWorkflowUuidMismatches",
     "graphRootWorkflowUuidMatches",
@@ -229,7 +240,7 @@ function buildDirtyStaleRouteHarness({
     `${fenceSource}\nreturn assertGraphBoundToActiveWorkflow;`,
   )(
     () => workflowA,
-    objectUuids,
+    uuidStore.workflowObjectUuid,
     stableUuid,
     graphRootWorkflowUuidMismatches,
     graphRootWorkflowUuidMatches,
@@ -264,6 +275,7 @@ function buildSavedSuccessorHarness({
   const replaced = { isPersisted: true, path: "workflows/x.json" };
   const successor = { isPersisted: true, path: currentPath };
   const owners = new Map([[U1, replaced]]);
+  const objectUuids = new WeakMap();
   let minted = 0;
   const openWorkflows =
     ownerOpen === true
@@ -275,7 +287,8 @@ function buildSavedSuccessorHarness({
     "app",
     "getTabId",
     "savedWorkflowPath",
-    "_workflowObjectUuids",
+    "workflowObjectUuid",
+    "setWorkflowObjectUuid",
     "embeddedWorkflowUuid",
     "embeddedWorkflowPath",
     "workflowAliasForPath",
@@ -298,7 +311,8 @@ function buildSavedSuccessorHarness({
     { extensionManager: { workflow: { openWorkflows } } },
     () => "fallback-tab",
     (wf) => (wf?.isPersisted === true && wf?.isTemporary !== true && typeof wf?.path === "string" ? wf.path : null),
-    new WeakMap(),
+    rawKeyedUuidStore(objectUuids).workflowObjectUuid,
+    rawKeyedUuidStore(objectUuids).setWorkflowObjectUuid,
     () => U1, // the just-saved file carries the pre-save embedded uuid
     () => embeddedPath,
     workflowAliasForPath,
@@ -317,7 +331,7 @@ function buildSavedSuccessorHarness({
     { randomUUID: () => `fresh-${++minted}` },
     sameWorkflowObject,
   );
-  return { stableUuid, successor, replaced, owners, U1 };
+  return { stableUuid, successor, replaced, owners, objectUuids, U1 };
 }
 
 // A ComfyUI ChangeTracker-shaped workflow: serialized graph states hang off
@@ -653,7 +667,7 @@ test("#545 wiring: dirty tracker state is inconclusive, but an established workf
   const body = src.slice(start, src.indexOf("\n}\n", start));
   assert.match(
     body,
-    /const activeWorkflowUuid = activeWorkflow\s*\? \(_workflowObjectUuids\.get\(activeWorkflow\) \|\| workflowStableUuid\(activeWorkflow\)\)\s*: null;/,
+    /const activeWorkflowUuid = activeWorkflow\s*\? \(workflowObjectUuid\(activeWorkflow\) \|\| workflowStableUuid\(activeWorkflow\)\)\s*: null;/,
     "the fence must establish a missing object UUID through the root-blind resolver, never from a stale root",
   );
   assert.match(
@@ -960,7 +974,9 @@ function buildCreationForkHarness({ onLoad } = {}) {
   };
   const install = new Function(
     "_loadGraphDataForkInstalled",
-    "_workflowObjectUuids",
+    "workflowObjectUuid",
+    "setWorkflowObjectUuid",
+    "deleteWorkflowObjectUuid",
     "rememberWorkflowUuidOwner",
     "isNewWorkflowLoad",
     "shouldForkInPlaceReload",
@@ -971,7 +987,9 @@ function buildCreationForkHarness({ onLoad } = {}) {
     `${forkSource}\nreturn installCreateBoundaryFork;`,
   )(
     false,
-    objectUuids,
+    rawKeyedUuidStore(objectUuids).workflowObjectUuid,
+    rawKeyedUuidStore(objectUuids).setWorkflowObjectUuid,
+    rawKeyedUuidStore(objectUuids).deleteWorkflowObjectUuid,
     (id, owner) => owners.set(id, owner),
     isNewWorkflowLoad,
     shouldForkInPlaceReload,
@@ -1130,7 +1148,7 @@ test("#557 r3/r4 wiring: programmaticSave threads the pre-save identity across a
   const body = src.slice(start, src.indexOf("\n}\n", start));
   assert.match(
     body,
-    /preSwapUuid = expectWf \? _workflowObjectUuids\.get\(expectWf\) \|\| workflowStableUuid\(expectWf\) : null/,
+    /preSwapUuid = expectWf \? workflowObjectUuid\(expectWf\) \|\| workflowStableUuid\(expectWf\) : null/,
     "the pre-save identity must be captured from the pre-save object BEFORE the save",
   );
   assert.match(
@@ -1160,12 +1178,12 @@ test("#557 r3/r4 wiring: programmaticSave threads the pre-save identity across a
   );
   assert.match(
     body,
-    /postWfHasConflictingEstablishedIdentity = Boolean\(\s*postSwapWf && _workflowObjectUuids\.get\(postSwapWf\) && _workflowObjectUuids\.get\(postSwapWf\) !== preSwapUuid,?\s*\)/,
+    /postWfHasConflictingEstablishedIdentity = Boolean\(\s*postSwapWf && workflowObjectUuid\(postSwapWf\) && workflowObjectUuid\(postSwapWf\) !== preSwapUuid,?\s*\)/,
     "an established conflicting WeakMap identity on the successor must veto the carry (r7 P0)",
   );
   assert.match(
     body,
-    /_workflowObjectUuids\.set\(postSwapWf, preSwapUuid\)/,
+    /setWorkflowObjectUuid\(postSwapWf, preSwapUuid\)/,
     "the successor object cache must be seeded with the pre-save uuid",
   );
   assert.match(
@@ -1218,7 +1236,8 @@ function buildProgrammaticSaveHarness({ onSave } = {}) {
     "classifyOriginalOnDisk",
     "normalizePath",
     "getWorkflowTitle",
-    "_workflowObjectUuids",
+    "workflowObjectUuid",
+    "setWorkflowObjectUuid",
     "workflowStableUuid",
     "rememberWorkflowUuidOwner",
     "sameWorkflowObject",
@@ -1244,7 +1263,8 @@ function buildProgrammaticSaveHarness({ onSave } = {}) {
     () => "unknown",
     (p) => p,
     () => "title",
-    objectUuids,
+    rawKeyedUuidStore(objectUuids).workflowObjectUuid,
+    rawKeyedUuidStore(objectUuids).setWorkflowObjectUuid,
     identityOf,
     (id, owner) => owners.set(id, owner),
     sameWorkflowObject,
@@ -1462,6 +1482,64 @@ test("#349 r7 P0: a successor with an established CONFLICTING identity is not ov
     "the carry must not overwrite an established conflicting identity",
   );
   assert.notEqual(owners.get("uuid-A"), successor, "A's uuid must not be re-registered over the conflict");
+});
+
+test("#349 r11 P0: the carry veto sees a RAW-keyed established identity when the active successor arrives as a PROXY", async () => {
+  // The r2 proxy/raw duality inside the veto itself: the established identity
+  // "uuid-X" is keyed by the RAW successor, but the post-save ACTIVE object
+  // arrives as a Vue proxy. A proxy-keyed WeakMap lookup misses the raw-keyed
+  // conflict, and the seed then writes a proxy-keyed foreign identity.
+  const successor = {
+    isPersisted: true,
+    path: "workflows/a.json",
+    changeTracker: {
+      activeState: { ...state(27), extra: { comfyui_mcp: { workflow_uuid: "uuid-A" } } },
+    },
+  };
+  const successorProxy = vueProxyOf(successor);
+  const { save, svc, objectUuids, owners } = buildProgrammaticSaveHarness({
+    onSave: ({ svc }) => {
+      svc.openWorkflows = [successorProxy];
+      svc.activeWorkflow = successorProxy;
+      return { producedRecord: successor }; // the save produced the RAW record; active holds the PROXY
+    },
+  });
+  objectUuids.set(successor, "uuid-X"); // established BEFORE the seed, keyed by the RAW object
+  await save();
+  assert.equal(objectUuids.get(successor), "uuid-X", "the veto must see the raw-keyed conflict — no overwrite");
+  assert.notEqual(owners.get("uuid-A"), successor, "no owner registration over the conflict");
+  assert.notEqual(owners.get("uuid-A"), successorProxy, "no proxy-keyed registration either");
+});
+
+test("#349 r11 P0: the creation-registration veto sees a RAW-keyed established identity when the active tab is a PROXY", async () => {
+  const foreignB = {
+    isPersisted: true,
+    path: "workflows/b.json",
+    changeTracker: { activeState: { extra: { comfyui_mcp: { workflow_uuid: "creation-uuid-1" } } } },
+  };
+  const foreignBProxy = vueProxyOf(foreignB);
+  const { fakeApp, objectUuids, owners } = buildCreationForkHarness({
+    onLoad: ({ app }) => {
+      app.extensionManager.workflow.activeWorkflow = foreignBProxy; // mid-load switch, PROXY form
+      app.extensionManager.workflow.openWorkflows.push(foreignBProxy);
+    },
+  });
+  objectUuids.set(foreignB, "uuid-B"); // established BEFORE, keyed by the RAW object
+  await fakeApp.loadGraphData({ nodes: [{ id: 1, type: "KSampler" }] });
+  assert.equal(
+    owners.get("creation-uuid-1"),
+    undefined,
+    "the veto must see the raw-keyed conflict — no owner-map registration",
+  );
+  assert.equal(objectUuids.get(foreignB), "uuid-B", "the raw-keyed identity is untouched");
+  assert.equal(objectUuids.get(foreignBProxy), undefined, "nothing was keyed by the proxy");
+});
+
+test("#557 r11: workflowStableUuid finds a RAW-keyed established identity when handed the PROXY", () => {
+  const { stableUuid, successor, objectUuids } = buildSavedSuccessorHarness({ ownerOpen: false });
+  objectUuids.set(successor, "uuid-R"); // established, keyed by the RAW object
+  const id = stableUuid(vueProxyOf(successor)); // the lookup side holds the PROXY
+  assert.equal(id, "uuid-R", "the resolver unwraps the proxy and finds the raw-keyed identity");
 });
 
 // ── #557: save replaces the active workflow object — identity must follow ────

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -30,6 +30,7 @@ import {
   isNewWorkflowLoad,
   rawWorkflowObject,
   sameWorkflowObject,
+  shouldCarryIdentityAcrossSaveSwap,
   shouldForkEmbeddedUuidForLiveOwner,
   shouldForkEmbeddedWorkflowUuid,
   shouldForkInPlaceReload,
@@ -936,7 +937,7 @@ test("#349 P0 r3: a CREATION-minted tag is registered to the tab the load activa
   assert.equal(h.rootB.extra.comfyui_mcp.workflow_uuid, "creation-uuid-1", "the created tab's tag survives");
 });
 
-test("#557 r3 wiring: programmaticSave threads the pre-save identity across an in-place object swap", () => {
+test("#557 r3/r4 wiring: programmaticSave threads the pre-save identity across a PROVEN in-place object swap", () => {
   const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
   const start = src.indexOf("async function programmaticSave(name)");
   assert.notEqual(start, -1, "programmaticSave must exist");
@@ -948,8 +949,18 @@ test("#557 r3 wiring: programmaticSave threads the pre-save identity across an i
   );
   assert.match(
     body,
-    /shouldCarryIdentityAcrossSaveSwap\(\{ preWf: expectWf, postWf: postSwapWf, savedAs: outcome\.saved_as \}\)/,
-    "the carry must be gated by the pure continuous-lifetime rule (never a Save-As copy)",
+    /preWfStillOpen =\s*!Array\.isArray\(openList\) \|\| openList\.some\(\(w\) => sameWorkflowObject\(w, expectWf\)\)/,
+    "a predecessor still present in the open tabs (a mid-save switch) must be detected",
+  );
+  assert.match(
+    body,
+    /successorCarriesPreUuid =\s*successorState\?\.extra\?\.\[WORKFLOW_META_NAMESPACE\]\?\.\[WORKFLOW_UUID_FIELD\] === preSwapUuid/,
+    "the successor must prove continuity via the pre-save uuid in its serialized state",
+  );
+  assert.match(
+    body,
+    /shouldCarryIdentityAcrossSaveSwap\(\{\s*preWf: expectWf,\s*postWf: postSwapWf,\s*savedAs: outcome\.saved_as,\s*preWfStillOpen,\s*successorCarriesPreUuid,\s*successorInPreSlot,\s*\}\)/,
+    "the carry must pass ALL continuity evidence to the pure rule (never a Save-As copy, never a mid-save switch)",
   );
   assert.match(
     body,
@@ -961,6 +972,152 @@ test("#557 r3 wiring: programmaticSave threads the pre-save identity across an i
     /rememberWorkflowUuidOwner\(preSwapUuid, postSwapWf\)/,
     "the successor must be registered as the pre-save uuid's owner",
   );
+});
+
+// Drives the REAL programmaticSave source with a fake saveActiveWorkflow that
+// switches the active workflow mid-await — the r4 P0 shape (user switch or
+// reconnect during the save). onSave performs the mid-save mutation of svc.
+function buildProgrammaticSaveHarness({ onSave } = {}) {
+  const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+  const start = src.indexOf("async function programmaticSave(");
+  const end = src.indexOf("async function reconcileSavedWorkflowCopy(", start);
+  assert.notEqual(start, -1, "programmaticSave must exist");
+  assert.notEqual(end, -1, "programmaticSave boundary must exist");
+  const saveSource = src.slice(start, end);
+  const ownsTagSource = panelFunctionSource(src, "workflowOwnsRootUuidTag", "assertGraphBoundToActiveWorkflow");
+  const A = { isPersisted: true, path: "workflows/a.json", changeTracker: { activeState: state(27) } };
+  const B = {
+    isPersisted: true,
+    path: "workflows/b.json",
+    isModified: true, // a DISTINCT dirty tab — the r4 switch target
+    changeTracker: { activeState: state(5) },
+  };
+  const svc = { activeWorkflow: A, openWorkflows: [A, B] };
+  const objectUuids = new WeakMap();
+  const owners = new Map();
+  const identityOf = (wf) =>
+    objectUuids.get(wf) ?? (wf === A ? "uuid-A" : wf === B ? "uuid-B" : null);
+  const ownsTag = new Function(
+    "workflowStableUuid",
+    "rawWorkflowObject",
+    "sameWorkflowObject",
+    "workflowUuidOwner",
+    "WORKFLOW_META_NAMESPACE",
+    "WORKFLOW_UUID_FIELD",
+    `${ownsTagSource}\nreturn workflowOwnsRootUuidTag;`,
+  )(identityOf, rawWorkflowObject, sameWorkflowObject, (id) => owners.get(id) ?? null, "comfyui_mcp", "workflow_uuid");
+  const save = new Function(
+    "app",
+    "saveActiveWorkflow",
+    "autoWorkflowName",
+    "workflowExistsOnDisk",
+    "workflowDiskBytes",
+    "reconcileSavedWorkflowCopy",
+    "describeSaveOutcome",
+    "classifyOriginalOnDisk",
+    "normalizePath",
+    "getWorkflowTitle",
+    "_workflowObjectUuids",
+    "workflowStableUuid",
+    "rememberWorkflowUuidOwner",
+    "sameWorkflowObject",
+    "shouldCarryIdentityAcrossSaveSwap",
+    "WORKFLOW_META_NAMESPACE",
+    "WORKFLOW_UUID_FIELD",
+    `${saveSource}\nreturn programmaticSave;`,
+  )(
+    { extensionManager: { workflow: svc } },
+    async (svcArg, _name, opts) => {
+      onSave?.({ svc: svcArg, A, B }); // the mid-await switch / swap / reconnect
+      opts.details.mode = "in-place";
+      return "a.json";
+    },
+    () => "Untitled",
+    async () => true,
+    async () => null,
+    async () => "unknown",
+    () => ({ saved_as: false }),
+    () => "unknown",
+    (p) => p,
+    () => "title",
+    objectUuids,
+    identityOf,
+    (id, owner) => owners.set(id, owner),
+    sameWorkflowObject,
+    shouldCarryIdentityAcrossSaveSwap,
+    "comfyui_mcp",
+    "workflow_uuid",
+  );
+  // The #349 fence input, computed the same way the guard does: does any OTHER
+  // live open tab claim this root tag?
+  const foreignClaimOn = (rootUuid) =>
+    svc.openWorkflows.some((w) => !sameWorkflowObject(w, svc.activeWorkflow) && ownsTag(w, rootUuid));
+  return { save, svc, A, B, objectUuids, owners, foreignClaimOn };
+}
+
+test("#349 r4 P0: a tab SWITCH during the awaited save aborts the identity carry — B is never seeded with A's uuid", async () => {
+  const { save, svc, A, B, objectUuids, owners, foreignClaimOn } = buildProgrammaticSaveHarness({
+    onSave: ({ svc }) => {
+      svc.activeWorkflow = B; // user switched to a distinct dirty B while the save awaited
+    },
+  });
+  await save();
+  assert.equal(objectUuids.get(B), undefined, "B must NOT be seeded with A's uuid");
+  assert.notEqual(owners.get("uuid-A"), B, "A's uuid must not be re-registered to B");
+  assert.equal(
+    foreignClaimOn("uuid-A"),
+    true,
+    "A is still open and claims its tag — the #349 fence input holds while B is active",
+  );
+  assert.equal(
+    resolveGraphRootUuidRebind({
+      rootGraph: { extra: { comfyui_mcp: { workflow_uuid: "uuid-A" } } },
+      activeWorkflowUuid: "uuid-B",
+      rootTagOwnedByForeignOpenWorkflow: foreignClaimOn("uuid-A"),
+    }),
+    "conflict",
+    "with the carry aborted, an A-tagged root stays foreign to B-active — writes are fenced",
+  );
+});
+
+test("#349 r4 P0: a RECONNECT-shaped mid-save switch (tab list rebuilt with new objects) aborts the carry", async () => {
+  const aRebuilt = {
+    isPersisted: true,
+    path: "workflows/a.json", // A's file, NEW object after a reconnect — NOT A
+    changeTracker: { activeState: state(27) },
+  };
+  const { save, svc, B, objectUuids, owners } = buildProgrammaticSaveHarness({
+    onSave: ({ svc }) => {
+      svc.openWorkflows = [aRebuilt, B]; // reconnect rebuilt the tab list
+      svc.activeWorkflow = B;
+    },
+  });
+  await save();
+  assert.equal(objectUuids.get(B), undefined, "B must NOT be seeded with A's uuid");
+  assert.notEqual(owners.get("uuid-A"), B, "A's uuid must not be re-registered to B");
+});
+
+test("#557 r4 control: a GENUINE save-swap successor still carries the pre-save identity", async () => {
+  const successor = {
+    isPersisted: true,
+    path: "workflows/a.json", // A's successor: same file, NEW object, predecessor GONE
+    changeTracker: {
+      activeState: { ...state(27), extra: { comfyui_mcp: { workflow_uuid: "uuid-A" } } },
+    },
+  };
+  const { save, svc, objectUuids, owners } = buildProgrammaticSaveHarness({
+    onSave: ({ svc }) => {
+      svc.openWorkflows = [successor]; // a genuine swap REMOVES the predecessor
+      svc.activeWorkflow = successor;
+    },
+  });
+  await save();
+  assert.equal(
+    objectUuids.get(successor),
+    "uuid-A",
+    "the proven successor is seeded with the pre-save uuid (#557)",
+  );
+  assert.equal(owners.get("uuid-A"), successor, "the successor becomes the uuid's registered owner");
 });
 
 // ── #557: save replaces the active workflow object — identity must follow ────

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -915,11 +915,11 @@ test("#716 P1: service rebind during workflow_open omits the former target UUID"
   let currentService = { activeWorkflow: openedTarget };
   const replyUuid = new Function(
     "activeWorkflowRef",
-    "_workflowObjectUuids",
+    "workflowObjectUuid",
     `${pathSource}; ${canonicalUuidSource}; ${identitySource}; ${helperSource}; return activeWorkflowUuidForOpenReply;`,
   )(
     () => currentService.activeWorkflow,
-    workflowUuids,
+    (wf) => workflowUuids.get(wf),
   );
 
   assert.equal(replyUuid(openedTarget), "11111111-1111-4111-8111-111111111111", "the normal completed open reports its actual active tab");
@@ -951,11 +951,11 @@ test("#716 P1: service rebind during workflow_list reports only the current acti
   let currentService = { activeWorkflow: staleActive };
   const listActive = new Function(
     "activeWorkflowRef",
-    "_workflowObjectUuids",
+    "workflowObjectUuid",
     `${pathSource}; ${canonicalUuidSource}; ${identitySource}; ${listActiveSource}; return liveWorkflowListActive;`,
   )(
     () => currentService.activeWorkflow,
-    workflowUuids,
+    (wf) => workflowUuids.get(wf),
   );
 
   assert.equal(listActive().activeIdentity?.uuid, "11111111-1111-4111-8111-111111111111");
@@ -978,11 +978,11 @@ test("#716 P1: a malformed truthy active binding cannot mint reply identity", ()
   const workflowUuids = new WeakMap();
   const replyUuid = new Function(
     "activeWorkflowRef",
-    "_workflowObjectUuids",
+    "workflowObjectUuid",
     `${pathSource}; ${canonicalUuidSource}; ${identitySource}; ${helperSource}; return activeWorkflowUuidForOpenReply;`,
   )(
     () => malformedActive,
-    workflowUuids,
+    (wf) => workflowUuids.get(wf),
   );
 
   // Execute the actual shipped reply helper against a truthy but malformed
@@ -1002,11 +1002,11 @@ test("#716 P1: a temporary workflow UUID is never published as a durable refresh
   const workflowUuids = new WeakMap([[temporaryActive, "33333333-3333-4333-8333-333333333333"]]);
   const replyUuid = new Function(
     "activeWorkflowRef",
-    "_workflowObjectUuids",
+    "workflowObjectUuid",
     `${pathSource}; ${canonicalUuidSource}; ${identitySource}; ${helperSource}; return activeWorkflowUuidForOpenReply;`,
   )(
     () => temporaryActive,
-    workflowUuids,
+    (wf) => workflowUuids.get(wf),
   );
 
   // Even an existing object-map UUID is insufficient for a temporary tab:
@@ -1032,11 +1032,11 @@ test("#716 P1: existing mapped UUIDs still omit when noncanonical", () => {
   let active = invalidVersion;
   const replyUuid = new Function(
     "activeWorkflowRef",
-    "_workflowObjectUuids",
+    "workflowObjectUuid",
     `${pathSource}; ${canonicalUuidSource}; ${identitySource}; ${helperSource}; return activeWorkflowUuidForOpenReply;`,
   )(
     () => active,
-    workflowUuids,
+    (wf) => workflowUuids.get(wf),
   );
 
   for (const workflow of [invalidVersion, invalidVariant, uppercase]) {

--- a/browser_tests/unit/prompt-relay-timeline.test.mjs
+++ b/browser_tests/unit/prompt-relay-timeline.test.mjs
@@ -1505,7 +1505,9 @@ test("the pre-load snapshot is taken inside the app.loadGraphData fork, BEFORE t
   // its position relative to the original loadGraphData, and that it cannot break a load.
   assert.match(panelSrc, /recordPreLoadPromptRelayEditors,\n\} from "\.\/lib\/prompt-relay-timeline\.js";/);
   const callAt = panelSrc.indexOf("recordPreLoadPromptRelayEditors(appRef?.graph?._nodes");
-  const origAt = panelSrc.indexOf("return orig(graphData, clean, restoreView, workflow, options);");
+  // The delegation itself (its result may be captured so post-load identity
+  // bookkeeping can run before returning).
+  const origAt = panelSrc.indexOf("orig(graphData, clean, restoreView, workflow, options)");
   assert.ok(callAt > 0, "recorder is not called from the loadGraphData fork");
   assert.ok(origAt > 0);
   assert.ok(callAt < origAt, "the snapshot must be taken BEFORE the load is delegated");

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -3,9 +3,10 @@ import test from 'node:test'
 
 import {
   activeWorkflowFenceApplies,
+  commandWorkflowMismatch,
+  hasEmbeddedUuidSuccessionEvidence,
   selectorSearchIncludesListed,
   selectorTargetsNonActiveWorkflow,
-  commandWorkflowMismatch,
   isThreadInScope,
   isNewWorkflowLoad,
   normalizedWorkflowPath,
@@ -174,11 +175,12 @@ test('#570 P0b a fresh object (no cache) is NOT an in-place replace here → fal
 test('#557 fork away from an owned embedded uuid ONLY while the owner is still open', () => {
   const owner = { path: 'workflows/x.json' }
   const successor = { path: 'workflows/x.json' }
-  // Owner replaced (no longer an open workflow) → successor INHERITS, no fork —
-  // minting fresh here desynced the object from the root tag and blocked every
-  // graph tool until a frontend reload.
+  // Owner replaced (no longer an open workflow) AND succession proven →
+  // successor INHERITS, no fork — minting fresh here desynced the object from
+  // the root tag and blocked every graph tool until a frontend reload.
   assert.equal(shouldForkEmbeddedUuidForLiveOwner({
-    embeddedUuid: 'uuid-A', embeddedOwner: owner, identityObject: successor, ownerIsOpenWorkflow: false
+    embeddedUuid: 'uuid-A', embeddedOwner: owner, identityObject: successor,
+    ownerIsOpenWorkflow: false, successionProven: true
   }), false)
   // Owner still open alongside → a genuine co-open copy → fork (#570).
   assert.equal(shouldForkEmbeddedUuidForLiveOwner({
@@ -196,6 +198,59 @@ test('#557 fork away from an owned embedded uuid ONLY while the owner is still o
     embeddedUuid: 'uuid-A', embeddedOwner: null, identityObject: successor, ownerIsOpenWorkflow: true
   }), false)
   assert.equal(shouldForkEmbeddedUuidForLiveOwner(), false)
+})
+
+// #558 r9 P0 — a CLOSED owner is not succession: without positive evidence this
+// object continues the owner's FILE, a different-path copy must FORK, never
+// inherit (inheriting re-keys the uuid's owner record to the copy and lets
+// stale uuid-scoped commands for the old workflow pass the fence against it).
+test('#557 r9: closed-owner inheritance requires positive succession evidence', () => {
+  const owner = { isPersisted: true, path: 'workflows/x.json' }
+  const copy = { isPersisted: true, path: 'workflows/y.json' }
+  // Closed owner + NO succession evidence (default fails safe) → FORK.
+  assert.equal(shouldForkEmbeddedUuidForLiveOwner({
+    embeddedUuid: 'uuid-A', embeddedOwner: owner, identityObject: copy, ownerIsOpenWorkflow: false
+  }), true)
+  assert.equal(shouldForkEmbeddedUuidForLiveOwner({
+    embeddedUuid: 'uuid-A', embeddedOwner: owner, identityObject: copy,
+    ownerIsOpenWorkflow: false, successionProven: false
+  }), true)
+  // Closed owner + proven succession (same-file successor) → INHERIT.
+  assert.equal(shouldForkEmbeddedUuidForLiveOwner({
+    embeddedUuid: 'uuid-A', embeddedOwner: owner, identityObject: copy,
+    ownerIsOpenWorkflow: false, successionProven: true
+  }), false)
+})
+
+test('#557 r9: hasEmbeddedUuidSuccessionEvidence — file path record, alias, or owner lineage', () => {
+  const owner = { isPersisted: true, path: 'workflows/x.json' }
+  // 1. The file's own recorded workflow_path ties the uuid to this object's file.
+  assert.equal(hasEmbeddedUuidSuccessionEvidence({
+    embeddedUuid: 'uuid-A', embeddedPath: 'workflows/x.json', currentPath: 'workflows/x.json'
+  }), true)
+  assert.equal(hasEmbeddedUuidSuccessionEvidence({
+    embeddedUuid: 'uuid-A', embeddedPath: 'workflows\\x.json', currentPath: 'workflows/x.json'
+  }), true, 'separator normalization still ties the same file')
+  // 2. The canonical path alias ties this object's path to the uuid.
+  assert.equal(hasEmbeddedUuidSuccessionEvidence({
+    embeddedUuid: 'uuid-A', currentPath: 'workflows/y.json', pathAlias: 'uuid-A'
+  }), true)
+  // 3. The closed owner's unique on-disk file IS this object's file.
+  assert.equal(hasEmbeddedUuidSuccessionEvidence({
+    embeddedUuid: 'uuid-A', currentPath: 'workflows/x.json', embeddedOwner: owner
+  }), true)
+  // The r9 hole: different-path copy, file carries ONLY workflow_uuid (no
+  // workflow_path), no alias → NO evidence → fork.
+  assert.equal(hasEmbeddedUuidSuccessionEvidence({
+    embeddedUuid: 'uuid-A', embeddedPath: null, currentPath: 'workflows/y.json',
+    pathAlias: null, embeddedOwner: owner
+  }), false)
+  // An UNSAVED owner has no unique path (#186) — never evidence.
+  assert.equal(hasEmbeddedUuidSuccessionEvidence({
+    embeddedUuid: 'uuid-A', currentPath: 'workflows/Unsaved Workflow.json',
+    embeddedOwner: { isPersisted: false, path: 'workflows/Unsaved Workflow.json' }
+  }), false)
+  assert.equal(hasEmbeddedUuidSuccessionEvidence(), false)
 })
 
 // #558 r2 — openWorkflows holds Vue PROXIES while the owner/uuid WeakMaps can hold

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -271,6 +271,13 @@ test('#557 r3/r4: identity carries across a save object-swap ONLY with positive 
   assert.equal(shouldCarryIdentityAcrossSaveSwap({
     preWf: pre, postWf: successor, savedAs: false, preWfStillOpen: false, successorInPreSlot: true
   }), false)
+  // r7 P0: an established, DIFFERENT identity on the successor vetoes the carry —
+  // overwriting it would promote the stamp over the object's own identity and
+  // poison the owner map (the r6 stale-lineage bypass via registration).
+  assert.equal(shouldCarryIdentityAcrossSaveSwap({
+    preWf: pre, postWf: successor, savedAs: false, preWfStillOpen: false,
+    successorCarriesPreUuid: true, postWfHasConflictingEstablishedIdentity: true
+  }), false)
   // r4 P0: the predecessor is STILL OPEN — a user/reconnect tab switch during the
   // awaited save lands on a DISTINCT workflow; seeding it with A's uuid would
   // bypass the #349 wrong-canvas fence → never carry.

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -12,6 +12,7 @@ import {
   rawWorkflowObject,
   resolveUnsavedInstanceUuid,
   sameWorkflowObject,
+  shouldCarryIdentityAcrossSaveSwap,
   shouldForkEmbeddedUuidForLiveOwner,
   shouldForkEmbeddedWorkflowUuid,
   shouldForkInPlaceReload,
@@ -236,6 +237,42 @@ test('sameWorkflowObject: distinct workflows never match — incl. same-path uns
   assert.equal(sameWorkflowObject(null, raw), false)
   assert.equal(sameWorkflowObject(raw, null), false)
   assert.equal(sameWorkflowObject(null, null), false)
+})
+
+// #558 r3 P0 — path equality alone must NOT prove object identity: two distinct
+// objects sharing a path are the same identity ONLY across a continuous-lifetime
+// replacement (the save-swap, threaded via the replacement event). A
+// closed→reopened object at the same path is a NEW workflow.
+test('sameWorkflowObject r3: same-path distinct objects are NOT one identity (closed→reopened is new)', () => {
+  assert.equal(sameWorkflowObject(
+    { isPersisted: true, path: 'workflows/b.json', changeTracker: { activeState: null } },
+    { isPersisted: true, path: 'workflows/b.json', changeTracker: { activeState: null } }
+  ), false)
+  assert.equal(sameWorkflowObject(
+    { isPersisted: true, path: 'workflows/b.json', changeTracker: {} },
+    { isPersisted: true, path: 'workflows/b.json', changeTracker: null }
+  ), false)
+  assert.equal(sameWorkflowObject(
+    { isPersisted: true, path: 'workflows/b.json' },
+    { isPersisted: true, path: 'workflows/b.json' }
+  ), false)
+})
+
+test('#557 r3: identity carries across a save object-swap ONLY as a continuous-lifetime replacement', () => {
+  const pre = { isPersisted: true, path: 'workflows/x.json', changeTracker: {} }
+  const successor = { isPersisted: true, path: 'workflows/x.json', changeTracker: {} }
+  // In-place / first save that swapped the active object → carry.
+  assert.equal(shouldCarryIdentityAcrossSaveSwap({ preWf: pre, postWf: successor, savedAs: false }), true)
+  // A Save-As COPY starts a new workflow → never carry (#226/#570).
+  assert.equal(shouldCarryIdentityAcrossSaveSwap({ preWf: pre, postWf: successor, savedAs: true }), false)
+  // Same object (no swap) → nothing to carry.
+  assert.equal(shouldCarryIdentityAcrossSaveSwap({ preWf: pre, postWf: pre, savedAs: false }), false)
+  // A proxy/raw form of the SAME object is no swap either.
+  assert.equal(shouldCarryIdentityAcrossSaveSwap({ preWf: pre, postWf: { __v_raw: pre }, savedAs: false }), false)
+  // Missing sides → no carry.
+  assert.equal(shouldCarryIdentityAcrossSaveSwap({ preWf: null, postWf: successor, savedAs: false }), false)
+  assert.equal(shouldCarryIdentityAcrossSaveSwap({ preWf: pre, postWf: null, savedAs: false }), false)
+  assert.equal(shouldCarryIdentityAcrossSaveSwap(), false)
 })
 
 // Fakes for the ComfyWorkflow 4th arg: a REUSE passes a ComfyWorkflow OBJECT; a CREATION

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -262,14 +262,15 @@ test('#557 r3/r4: identity carries across a save object-swap ONLY with positive 
   const pre = { isPersisted: true, path: 'workflows/x.json', changeTracker: {} }
   const successor = { isPersisted: true, path: 'workflows/x.json', changeTracker: {} }
   // In-place / first save that swapped the object, predecessor GONE from the open
-  // tabs, successor showing continuity (carries the pre-save uuid, or occupies
-  // the predecessor's tab slot) → carry.
+  // tabs, successor carrying the pre-save uuid in its serialized state → carry.
   assert.equal(shouldCarryIdentityAcrossSaveSwap({
     preWf: pre, postWf: successor, savedAs: false, preWfStillOpen: false, successorCarriesPreUuid: true
   }), true)
+  // r5 P0: tab-slot occupancy is NOT continuity — a closed-then-compacted list
+  // can seat a foreign B in A's old slot with zero A lineage.
   assert.equal(shouldCarryIdentityAcrossSaveSwap({
     preWf: pre, postWf: successor, savedAs: false, preWfStillOpen: false, successorInPreSlot: true
-  }), true)
+  }), false)
   // r4 P0: the predecessor is STILL OPEN — a user/reconnect tab switch during the
   // awaited save lands on a DISTINCT workflow; seeding it with A's uuid would
   // bypass the #349 wrong-canvas fence → never carry.

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -258,14 +258,21 @@ test('sameWorkflowObject r3: same-path distinct objects are NOT one identity (cl
   ), false)
 })
 
-test('#557 r3/r4: identity carries across a save object-swap ONLY with positive continuity', () => {
+test('#557 r3/r4/r8: identity carries across a save object-swap ONLY with event-threaded continuity', () => {
   const pre = { isPersisted: true, path: 'workflows/x.json', changeTracker: {} }
   const successor = { isPersisted: true, path: 'workflows/x.json', changeTracker: {} }
   // In-place / first save that swapped the object, predecessor GONE from the open
-  // tabs, successor carrying the pre-save uuid in its serialized state → carry.
+  // tabs, and the post-save active object IS the service's record for the file
+  // this save wrote (event-threaded continuity) → carry.
+  assert.equal(shouldCarryIdentityAcrossSaveSwap({
+    preWf: pre, postWf: successor, savedAs: false, preWfStillOpen: false, postWfIsSaveTargetRecord: true
+  }), true)
+  // r8 P0: static tracker/state evidence is NOT continuity — a lagging
+  // activeState carrying the pre-save uuid can be a closed/reopened tab's
+  // residue. Without the target-record thread, never carry.
   assert.equal(shouldCarryIdentityAcrossSaveSwap({
     preWf: pre, postWf: successor, savedAs: false, preWfStillOpen: false, successorCarriesPreUuid: true
-  }), true)
+  }), false)
   // r5 P0: tab-slot occupancy is NOT continuity — a closed-then-compacted list
   // can seat a foreign B in A's old slot with zero A lineage.
   assert.equal(shouldCarryIdentityAcrossSaveSwap({
@@ -276,13 +283,13 @@ test('#557 r3/r4: identity carries across a save object-swap ONLY with positive 
   // poison the owner map (the r6 stale-lineage bypass via registration).
   assert.equal(shouldCarryIdentityAcrossSaveSwap({
     preWf: pre, postWf: successor, savedAs: false, preWfStillOpen: false,
-    successorCarriesPreUuid: true, postWfHasConflictingEstablishedIdentity: true
+    postWfIsSaveTargetRecord: true, postWfHasConflictingEstablishedIdentity: true
   }), false)
   // r4 P0: the predecessor is STILL OPEN — a user/reconnect tab switch during the
   // awaited save lands on a DISTINCT workflow; seeding it with A's uuid would
   // bypass the #349 wrong-canvas fence → never carry.
   assert.equal(shouldCarryIdentityAcrossSaveSwap({
-    preWf: pre, postWf: successor, savedAs: false, preWfStillOpen: true, successorCarriesPreUuid: true
+    preWf: pre, postWf: successor, savedAs: false, preWfStillOpen: true, postWfIsSaveTargetRecord: true
   }), false)
   // No continuity evidence → never carry (an unknown predecessor state defaults
   // to still-open, fail-safe).
@@ -292,18 +299,18 @@ test('#557 r3/r4: identity carries across a save object-swap ONLY with positive 
   }), false)
   // A Save-As COPY starts a new workflow → never carry (#226/#570).
   assert.equal(shouldCarryIdentityAcrossSaveSwap({
-    preWf: pre, postWf: successor, savedAs: true, preWfStillOpen: false, successorCarriesPreUuid: true
+    preWf: pre, postWf: successor, savedAs: true, preWfStillOpen: false, postWfIsSaveTargetRecord: true
   }), false)
   // Same object (no swap) / a proxy form of the same object → nothing to carry.
   assert.equal(shouldCarryIdentityAcrossSaveSwap({
-    preWf: pre, postWf: pre, savedAs: false, preWfStillOpen: false, successorCarriesPreUuid: true
+    preWf: pre, postWf: pre, savedAs: false, preWfStillOpen: false, postWfIsSaveTargetRecord: true
   }), false)
   assert.equal(shouldCarryIdentityAcrossSaveSwap({
-    preWf: pre, postWf: { __v_raw: pre }, savedAs: false, preWfStillOpen: false, successorCarriesPreUuid: true
+    preWf: pre, postWf: { __v_raw: pre }, savedAs: false, preWfStillOpen: false, postWfIsSaveTargetRecord: true
   }), false)
   // Missing sides → no carry.
   assert.equal(shouldCarryIdentityAcrossSaveSwap({
-    preWf: null, postWf: successor, savedAs: false, preWfStillOpen: false, successorCarriesPreUuid: true
+    preWf: null, postWf: successor, savedAs: false, preWfStillOpen: false, postWfIsSaveTargetRecord: true
   }), false)
   assert.equal(shouldCarryIdentityAcrossSaveSwap(), false)
 })

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -222,7 +222,7 @@ test('#557 r9: closed-owner inheritance requires positive succession evidence', 
   }), false)
 })
 
-test('#557 r9: hasEmbeddedUuidSuccessionEvidence — file path record, alias, or owner lineage', () => {
+test('#557 r9/r10: hasEmbeddedUuidSuccessionEvidence — file path record or alias ONLY', () => {
   const owner = { isPersisted: true, path: 'workflows/x.json' }
   // 1. The file's own recorded workflow_path ties the uuid to this object's file.
   assert.equal(hasEmbeddedUuidSuccessionEvidence({
@@ -235,10 +235,14 @@ test('#557 r9: hasEmbeddedUuidSuccessionEvidence — file path record, alias, or
   assert.equal(hasEmbeddedUuidSuccessionEvidence({
     embeddedUuid: 'uuid-A', currentPath: 'workflows/y.json', pathAlias: 'uuid-A'
   }), true)
-  // 3. The closed owner's unique on-disk file IS this object's file.
+  // r10 P0: the owner's file MATCHING this object's path is NOT evidence — a
+  // closed→reopened object at the same path is a NEW identity, and its resume
+  // heal belongs to the unregistered-embedded path, not registered-owner
+  // inheritance.
   assert.equal(hasEmbeddedUuidSuccessionEvidence({
-    embeddedUuid: 'uuid-A', currentPath: 'workflows/x.json', embeddedOwner: owner
-  }), true)
+    embeddedUuid: 'uuid-A', embeddedPath: null, currentPath: 'workflows/x.json',
+    pathAlias: null, embeddedOwner: owner
+  }), false)
   // The r9 hole: different-path copy, file carries ONLY workflow_uuid (no
   // workflow_path), no alias → NO evidence → fork.
   assert.equal(hasEmbeddedUuidSuccessionEvidence({
@@ -313,14 +317,14 @@ test('sameWorkflowObject r3: same-path distinct objects are NOT one identity (cl
   ), false)
 })
 
-test('#557 r3/r4/r8: identity carries across a save object-swap ONLY with event-threaded continuity', () => {
+test('#557 r3/r4/r8: identity carries across a save object-swap ONLY with save-produced-record continuity', () => {
   const pre = { isPersisted: true, path: 'workflows/x.json', changeTracker: {} }
   const successor = { isPersisted: true, path: 'workflows/x.json', changeTracker: {} }
   // In-place / first save that swapped the object, predecessor GONE from the open
   // tabs, and the post-save active object IS the service's record for the file
-  // this save wrote (event-threaded continuity) → carry.
+  // this save wrote (save-produced-record continuity) → carry.
   assert.equal(shouldCarryIdentityAcrossSaveSwap({
-    preWf: pre, postWf: successor, savedAs: false, preWfStillOpen: false, postWfIsSaveTargetRecord: true
+    preWf: pre, postWf: successor, savedAs: false, preWfStillOpen: false, postWfIsSaveProducedRecord: true
   }), true)
   // r8 P0: static tracker/state evidence is NOT continuity — a lagging
   // activeState carrying the pre-save uuid can be a closed/reopened tab's
@@ -338,13 +342,13 @@ test('#557 r3/r4/r8: identity carries across a save object-swap ONLY with event-
   // poison the owner map (the r6 stale-lineage bypass via registration).
   assert.equal(shouldCarryIdentityAcrossSaveSwap({
     preWf: pre, postWf: successor, savedAs: false, preWfStillOpen: false,
-    postWfIsSaveTargetRecord: true, postWfHasConflictingEstablishedIdentity: true
+    postWfIsSaveProducedRecord: true, postWfHasConflictingEstablishedIdentity: true
   }), false)
   // r4 P0: the predecessor is STILL OPEN — a user/reconnect tab switch during the
   // awaited save lands on a DISTINCT workflow; seeding it with A's uuid would
   // bypass the #349 wrong-canvas fence → never carry.
   assert.equal(shouldCarryIdentityAcrossSaveSwap({
-    preWf: pre, postWf: successor, savedAs: false, preWfStillOpen: true, postWfIsSaveTargetRecord: true
+    preWf: pre, postWf: successor, savedAs: false, preWfStillOpen: true, postWfIsSaveProducedRecord: true
   }), false)
   // No continuity evidence → never carry (an unknown predecessor state defaults
   // to still-open, fail-safe).
@@ -354,18 +358,18 @@ test('#557 r3/r4/r8: identity carries across a save object-swap ONLY with event-
   }), false)
   // A Save-As COPY starts a new workflow → never carry (#226/#570).
   assert.equal(shouldCarryIdentityAcrossSaveSwap({
-    preWf: pre, postWf: successor, savedAs: true, preWfStillOpen: false, postWfIsSaveTargetRecord: true
+    preWf: pre, postWf: successor, savedAs: true, preWfStillOpen: false, postWfIsSaveProducedRecord: true
   }), false)
   // Same object (no swap) / a proxy form of the same object → nothing to carry.
   assert.equal(shouldCarryIdentityAcrossSaveSwap({
-    preWf: pre, postWf: pre, savedAs: false, preWfStillOpen: false, postWfIsSaveTargetRecord: true
+    preWf: pre, postWf: pre, savedAs: false, preWfStillOpen: false, postWfIsSaveProducedRecord: true
   }), false)
   assert.equal(shouldCarryIdentityAcrossSaveSwap({
-    preWf: pre, postWf: { __v_raw: pre }, savedAs: false, preWfStillOpen: false, postWfIsSaveTargetRecord: true
+    preWf: pre, postWf: { __v_raw: pre }, savedAs: false, preWfStillOpen: false, postWfIsSaveProducedRecord: true
   }), false)
   // Missing sides → no carry.
   assert.equal(shouldCarryIdentityAcrossSaveSwap({
-    preWf: null, postWf: successor, savedAs: false, preWfStillOpen: false, postWfIsSaveTargetRecord: true
+    preWf: null, postWf: successor, savedAs: false, preWfStillOpen: false, postWfIsSaveProducedRecord: true
   }), false)
   assert.equal(shouldCarryIdentityAcrossSaveSwap(), false)
 })

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -9,7 +9,9 @@ import {
   isThreadInScope,
   isNewWorkflowLoad,
   normalizedWorkflowPath,
+  rawWorkflowObject,
   resolveUnsavedInstanceUuid,
+  sameWorkflowObject,
   shouldForkEmbeddedUuidForLiveOwner,
   shouldForkEmbeddedWorkflowUuid,
   shouldForkInPlaceReload,
@@ -193,6 +195,47 @@ test('#557 fork away from an owned embedded uuid ONLY while the owner is still o
     embeddedUuid: 'uuid-A', embeddedOwner: null, identityObject: successor, ownerIsOpenWorkflow: true
   }), false)
   assert.equal(shouldForkEmbeddedUuidForLiveOwner(), false)
+})
+
+// #558 r2 — openWorkflows holds Vue PROXIES while the owner/uuid WeakMaps can hold
+// RAW objects (the workflow-save.test.mjs store double models exactly this), so
+// identity across those carriers must be proxy-safe.
+test('rawWorkflowObject: unwraps __v_raw, passes raw objects and transparent proxies through', () => {
+  const raw = { path: 'workflows/x.json' }
+  assert.equal(rawWorkflowObject(raw), raw)
+  const proxy = new Proxy(raw, {})
+  assert.equal(rawWorkflowObject(proxy), proxy, 'a transparent proxy has no raw back-pointer')
+  assert.equal(rawWorkflowObject({ __v_raw: raw }), raw)
+  assert.equal(rawWorkflowObject(null), null)
+  assert.equal(rawWorkflowObject(undefined), null)
+})
+
+test('sameWorkflowObject: a Vue proxy and its raw target are the SAME workflow', () => {
+  const raw = { isPersisted: true, path: 'workflows/b.json', changeTracker: { activeState: null } }
+  const proxy = new Proxy(raw, {}) // transparent proxy — the repo's store-double idiom
+  assert.equal(sameWorkflowObject(raw, proxy), true)
+  assert.equal(sameWorkflowObject(proxy, raw), true)
+  assert.equal(sameWorkflowObject(proxy, proxy), true)
+  // A Vue-style proxy exposing the raw target as __v_raw.
+  const vueProxy = { __v_raw: raw }
+  assert.equal(sameWorkflowObject(vueProxy, raw), true)
+  assert.equal(sameWorkflowObject(raw, vueProxy), true)
+})
+
+test('sameWorkflowObject: distinct workflows never match — incl. same-path unsaved tabs (#186)', () => {
+  const raw = { isPersisted: true, path: 'workflows/b.json', changeTracker: {} }
+  assert.equal(sameWorkflowObject(raw, { isPersisted: true, path: 'workflows/c.json' }), false)
+  // Two UNSAVED tabs share the synthetic path; identity falls to the per-instance
+  // changeTracker object, which differs.
+  const unsavedA = { isPersisted: false, path: 'workflows/Unsaved Workflow.json', changeTracker: {} }
+  const unsavedB = { isPersisted: false, path: 'workflows/Unsaved Workflow.json', changeTracker: {} }
+  assert.equal(sameWorkflowObject(unsavedA, unsavedB), false)
+  assert.equal(sameWorkflowObject(unsavedA, new Proxy(unsavedA, {})), true)
+  // Two not-yet-loaded unsaved tabs (no tracker) can never be proven same.
+  assert.equal(sameWorkflowObject({ isPersisted: false }, { isPersisted: false }), false)
+  assert.equal(sameWorkflowObject(null, raw), false)
+  assert.equal(sameWorkflowObject(raw, null), false)
+  assert.equal(sameWorkflowObject(null, null), false)
 })
 
 // Fakes for the ComfyWorkflow 4th arg: a REUSE passes a ComfyWorkflow OBJECT; a CREATION

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -10,6 +10,7 @@ import {
   isNewWorkflowLoad,
   normalizedWorkflowPath,
   resolveUnsavedInstanceUuid,
+  shouldForkEmbeddedUuidForLiveOwner,
   shouldForkEmbeddedWorkflowUuid,
   shouldForkInPlaceReload,
   workflowAliasForPath
@@ -162,6 +163,36 @@ test('#570 P0b a fresh object (no cache) is NOT an in-place replace here → fal
   // A brand-new object (reload-restore/copy) has no cache; creation/embedded handling covers it.
   assert.equal(shouldForkInPlaceReload({ cachedUuid: undefined, incomingUuid: 'uuid-A' }), false)
   assert.equal(shouldForkInPlaceReload({}), false)
+})
+
+// #557 — a save replaces the active ComfyWorkflow object. The successor parses the
+// same embedded uuid from the just-saved file while the REPLACED object is still the
+// registered owner: fork ONLY while that owner is still a live OPEN tab.
+test('#557 fork away from an owned embedded uuid ONLY while the owner is still open', () => {
+  const owner = { path: 'workflows/x.json' }
+  const successor = { path: 'workflows/x.json' }
+  // Owner replaced (no longer an open workflow) → successor INHERITS, no fork —
+  // minting fresh here desynced the object from the root tag and blocked every
+  // graph tool until a frontend reload.
+  assert.equal(shouldForkEmbeddedUuidForLiveOwner({
+    embeddedUuid: 'uuid-A', embeddedOwner: owner, identityObject: successor, ownerIsOpenWorkflow: false
+  }), false)
+  // Owner still open alongside → a genuine co-open copy → fork (#570).
+  assert.equal(shouldForkEmbeddedUuidForLiveOwner({
+    embeddedUuid: 'uuid-A', embeddedOwner: owner, identityObject: successor, ownerIsOpenWorkflow: true
+  }), true)
+  // The owner IS this object (rename/Save-As continuity) → never fork.
+  assert.equal(shouldForkEmbeddedUuidForLiveOwner({
+    embeddedUuid: 'uuid-A', embeddedOwner: owner, identityObject: owner, ownerIsOpenWorkflow: true
+  }), false)
+  // Missing identity/owner data is inconclusive → never fork.
+  assert.equal(shouldForkEmbeddedUuidForLiveOwner({
+    embeddedUuid: null, embeddedOwner: owner, identityObject: successor, ownerIsOpenWorkflow: true
+  }), false)
+  assert.equal(shouldForkEmbeddedUuidForLiveOwner({
+    embeddedUuid: 'uuid-A', embeddedOwner: null, identityObject: successor, ownerIsOpenWorkflow: true
+  }), false)
+  assert.equal(shouldForkEmbeddedUuidForLiveOwner(), false)
 })
 
 // Fakes for the ComfyWorkflow 4th arg: a REUSE passes a ComfyWorkflow OBJECT; a CREATION

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -258,20 +258,45 @@ test('sameWorkflowObject r3: same-path distinct objects are NOT one identity (cl
   ), false)
 })
 
-test('#557 r3: identity carries across a save object-swap ONLY as a continuous-lifetime replacement', () => {
+test('#557 r3/r4: identity carries across a save object-swap ONLY with positive continuity', () => {
   const pre = { isPersisted: true, path: 'workflows/x.json', changeTracker: {} }
   const successor = { isPersisted: true, path: 'workflows/x.json', changeTracker: {} }
-  // In-place / first save that swapped the active object → carry.
-  assert.equal(shouldCarryIdentityAcrossSaveSwap({ preWf: pre, postWf: successor, savedAs: false }), true)
+  // In-place / first save that swapped the object, predecessor GONE from the open
+  // tabs, successor showing continuity (carries the pre-save uuid, or occupies
+  // the predecessor's tab slot) → carry.
+  assert.equal(shouldCarryIdentityAcrossSaveSwap({
+    preWf: pre, postWf: successor, savedAs: false, preWfStillOpen: false, successorCarriesPreUuid: true
+  }), true)
+  assert.equal(shouldCarryIdentityAcrossSaveSwap({
+    preWf: pre, postWf: successor, savedAs: false, preWfStillOpen: false, successorInPreSlot: true
+  }), true)
+  // r4 P0: the predecessor is STILL OPEN — a user/reconnect tab switch during the
+  // awaited save lands on a DISTINCT workflow; seeding it with A's uuid would
+  // bypass the #349 wrong-canvas fence → never carry.
+  assert.equal(shouldCarryIdentityAcrossSaveSwap({
+    preWf: pre, postWf: successor, savedAs: false, preWfStillOpen: true, successorCarriesPreUuid: true
+  }), false)
+  // No continuity evidence → never carry (an unknown predecessor state defaults
+  // to still-open, fail-safe).
+  assert.equal(shouldCarryIdentityAcrossSaveSwap({ preWf: pre, postWf: successor, savedAs: false }), false)
+  assert.equal(shouldCarryIdentityAcrossSaveSwap({
+    preWf: pre, postWf: successor, savedAs: false, preWfStillOpen: false
+  }), false)
   // A Save-As COPY starts a new workflow → never carry (#226/#570).
-  assert.equal(shouldCarryIdentityAcrossSaveSwap({ preWf: pre, postWf: successor, savedAs: true }), false)
-  // Same object (no swap) → nothing to carry.
-  assert.equal(shouldCarryIdentityAcrossSaveSwap({ preWf: pre, postWf: pre, savedAs: false }), false)
-  // A proxy/raw form of the SAME object is no swap either.
-  assert.equal(shouldCarryIdentityAcrossSaveSwap({ preWf: pre, postWf: { __v_raw: pre }, savedAs: false }), false)
+  assert.equal(shouldCarryIdentityAcrossSaveSwap({
+    preWf: pre, postWf: successor, savedAs: true, preWfStillOpen: false, successorCarriesPreUuid: true
+  }), false)
+  // Same object (no swap) / a proxy form of the same object → nothing to carry.
+  assert.equal(shouldCarryIdentityAcrossSaveSwap({
+    preWf: pre, postWf: pre, savedAs: false, preWfStillOpen: false, successorCarriesPreUuid: true
+  }), false)
+  assert.equal(shouldCarryIdentityAcrossSaveSwap({
+    preWf: pre, postWf: { __v_raw: pre }, savedAs: false, preWfStillOpen: false, successorCarriesPreUuid: true
+  }), false)
   // Missing sides → no carry.
-  assert.equal(shouldCarryIdentityAcrossSaveSwap({ preWf: null, postWf: successor, savedAs: false }), false)
-  assert.equal(shouldCarryIdentityAcrossSaveSwap({ preWf: pre, postWf: null, savedAs: false }), false)
+  assert.equal(shouldCarryIdentityAcrossSaveSwap({
+    preWf: null, postWf: successor, savedAs: false, preWfStillOpen: false, successorCarriesPreUuid: true
+  }), false)
   assert.equal(shouldCarryIdentityAcrossSaveSwap(), false)
 })
 

--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -162,6 +162,51 @@ test('save-in-place (same name) overwrites the same file, no copy', async () => 
   assert.equal(saved, 'Foo')
 })
 
+test('r10: an in-place save threads the save API\'s returned record into details.savedRecord', async () => {
+  const active = {
+    path: 'workflows/Foo.json',
+    filename: 'Foo.json',
+    directory: 'workflows',
+    isPersisted: true,
+    isTemporary: false
+  }
+  const svc = makeService({ files: [active.path], active })
+  // A frontend whose saveWorkflow re-registers and RETURNS the successor record.
+  const produced = { isPersisted: true, path: 'workflows/Foo.json', changeTracker: {} }
+  const origSave = svc.saveWorkflow.bind(svc)
+  svc.saveWorkflow = async (wf) => {
+    await origSave(wf)
+    return produced
+  }
+
+  const details = {}
+  await saveActiveWorkflow(svc, 'Foo', { details })
+
+  assert.equal(
+    details.savedRecord,
+    produced,
+    'the save API\'s own produced record is threaded through details (the r10 succession event)',
+  )
+})
+
+test('r10: a save API that returns nothing useful leaves details.savedRecord unset (fail safe)', async () => {
+  const active = {
+    path: 'workflows/Foo.json',
+    filename: 'Foo.json',
+    directory: 'workflows',
+    isPersisted: true,
+    isTemporary: false
+  }
+  const svc = makeService({ files: [active.path], active }) // its saveWorkflow returns undefined
+  const details = {}
+  await saveActiveWorkflow(svc, 'Foo', { details })
+  assert.equal(
+    details.savedRecord,
+    undefined,
+    'no produced record ⇒ no thread ⇒ the identity carry must fail safe (no carry)',
+  )
+})
+
 test('#442 in-place save of a DRIFTED tab whose disk STILL matches its baseline: forces overwrite, no 409', async () => {
   const baseline = JSON.stringify({ nodes: [] })
   const active = {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3260,11 +3260,6 @@ async function programmaticSave(name) {
   // closed→reopened object at the same path is a NEW workflow (r3 P0), while a
   // swapped successor is the same continuous tab and must keep its identity.
   const preSwapUuid = expectWf ? _workflowObjectUuids.get(expectWf) || workflowStableUuid(expectWf) : null;
-  // The predecessor's tab slot BEFORE the save — half of the continuity proof
-  // below (a genuine swap lands the successor in the same slot).
-  const preSwapSlotIndex = Array.isArray(svc?.openWorkflows)
-    ? svc.openWorkflows.findIndex((w) => sameWorkflowObject(w, expectWf))
-    : -1;
   // Capture POSITIVE pre-save evidence of the source file's existence: a confirmed 200
   // is the ONLY basis on which a post-save 404 may be treated as a real move/deletion
   // of a persisted original. Without it, a source that 404s afterward simply never
@@ -3293,15 +3288,18 @@ async function programmaticSave(name) {
     expect: expectWf, // #330: refuse if the user switched tabs during our pre-save HEAD
   });
   const outcome = describeSaveOutcome(details);
-  // #557 r3/r4 — thread the identity across the swap ONLY with positive
+  // #557 r3/r4/r5 — thread the identity across the swap ONLY with positive
   // CONTINUITY, verified at the seed point (postWf is read from the service
   // HERE, after the awaited save): the predecessor must be GONE from the open
   // tabs — a user/reconnect tab switch during the await keeps it open and must
   // abort the carry entirely, or a distinct foreign tab gets seeded with A's
   // uuid and the #349 wrong-canvas fence aligns on the wrong identity — and
-  // the successor must show it continues the same tab lifetime (its
-  // serialized state carries the pre-save uuid, or it occupies the
-  // predecessor's slot).
+  // the successor must CARRY the pre-save uuid in its serialized state (the
+  // genuine #557 successor parses the just-saved file, which embeds it). Tab
+  // SLOT occupancy is NOT evidence: a closed-then-compacted list can seat a
+  // foreign tab in the predecessor's old slot with zero lineage (r5 P0). A
+  // successor whose tracker is lagging/unreadable fails SAFE (no carry); the
+  // lazy owner-not-open inheritance heals that case on next resolve.
   const postSwapWf = svc?.activeWorkflow;
   if (preSwapUuid) {
     const openList = svc?.openWorkflows;
@@ -3310,8 +3308,6 @@ async function programmaticSave(name) {
     const successorState = postSwapWf?.changeTracker?.activeState ?? postSwapWf?.activeState;
     const successorCarriesPreUuid =
       successorState?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD] === preSwapUuid;
-    const successorInPreSlot =
-      Array.isArray(openList) && preSwapSlotIndex >= 0 && sameWorkflowObject(openList[preSwapSlotIndex], postSwapWf);
     if (
       shouldCarryIdentityAcrossSaveSwap({
         preWf: expectWf,
@@ -3319,7 +3315,6 @@ async function programmaticSave(name) {
         savedAs: outcome.saved_as,
         preWfStillOpen,
         successorCarriesPreUuid,
-        successorInPreSlot,
       })
     ) {
       _workflowObjectUuids.set(postSwapWf, preSwapUuid);
@@ -4259,33 +4254,26 @@ function assertGraphBoundToActiveWorkflow(
     ? (_workflowObjectUuids.get(activeWorkflow) || workflowStableUuid(activeWorkflow))
     : null;
   // #545/#557 — a root-tag UUID conflict is not self-healing: a save or reconnect
-  // can REPLACE the live ComfyWorkflow object, leaving the root stamped with an
-  // identity no live open tab claims. Such an orphaned tag is stale bookkeeping
-  // rather than a foreign canvas — re-stamp the root with the active identity
-  // and proceed, instead of hard-blocking every graph tool until a frontend
-  // reload. A tag claimed by another LIVE OPEN workflow is the genuine #349
-  // wrong-canvas case: it still throws below, preserving the data-loss
-  // protection.
+  // can drift the root stamp from the ACTIVE workflow's resolved identity while
+  // the root is still that workflow's own canvas. Rebind ONLY when the active
+  // workflow ITSELF claims the tag — its own serialized state carries it, or
+  // its registered owner record ties it to the tag — because then the tag is
+  // the active tab's own lineage and the root is provably its own canvas; in
+  // that case re-stamp the root with the active identity and proceed instead of
+  // hard-blocking every graph tool until a frontend reload. A tag the active
+  // workflow does NOT claim fails closed: a FOREIGN open tab's claim is the
+  // genuine #349 wrong-canvas case, and a tag NOBODY claims may be a closed
+  // tab's stale canvas — re-stamping either would authorize writes to a graph
+  // that is not the active workflow's (r4/r5 P0). The remedy for a genuinely
+  // drifted binding the tracker cannot prove is panel_open_workflow's proven
+  // repaint re-stamp.
   let rootUuidMismatch = graphRootWorkflowUuidMismatches({ rootGraph, activeWorkflowUuid });
   if (rootUuidMismatch) {
     const rootUuid = rootGraph?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD];
-    // The tag stays a hard wrong-canvas refusal whenever ANY OTHER LIVE OPEN
-    // workflow claims it (#349). Decide by ENUMERATING the open tabs, never the
-    // owner map alone: a creation stamps the graph without any owner/uuid-cache
-    // record (creation loadGraphData passes no workflow object), and a save can
-    // leave the owner map pointing at the replaced predecessor — so a missing or
-    // stale owner record must never be what authorizes a rebind over a live
-    // tab's canvas (codex P0). Fail closed when the open-tab list itself is
-    // unavailable: an unverifiable claim is a claim.
-    const openWorkflows = app?.extensionManager?.workflow?.openWorkflows;
-    const rootTagOwnedByForeignOpenWorkflow =
-      !Array.isArray(openWorkflows) ||
-      openWorkflows.some(
-        (w) => w && !sameWorkflowObject(w, activeWorkflow) && workflowOwnsRootUuidTag(w, rootUuid),
-      );
+    const rootTagClaimedByActiveWorkflow =
+      !!activeWorkflow && workflowOwnsRootUuidTag(activeWorkflow, rootUuid);
     if (
-      resolveGraphRootUuidRebind({ rootGraph, activeWorkflowUuid, rootTagOwnedByForeignOpenWorkflow }) ===
-      "rebind"
+      resolveGraphRootUuidRebind({ rootGraph, activeWorkflowUuid, rootTagClaimedByActiveWorkflow }) === "rebind"
     ) {
       try {
         const extra =

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -102,6 +102,7 @@ import {
   isNewWorkflowLoad,
   normalizedWorkflowPath,
   resolveUnsavedInstanceUuid,
+  shouldForkEmbeddedUuidForLiveOwner,
   shouldForkEmbeddedWorkflowUuid,
   shouldForkInPlaceReload,
   workflowAliasForPath,
@@ -254,6 +255,7 @@ import {
   graphRootMatchesState,
   graphCommandMayMutateWorkflow,
   graphReadBindingChanged,
+  resolveGraphRootUuidRebind,
 } from "./lib/graph-binding.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
 import { queueMembership, historyEntryFor } from "./lib/history-reconcile.js";
@@ -1424,6 +1426,10 @@ function installCreateBoundaryFork(appRef) {
             const cached = _workflowObjectUuids.get(workflow);
             const authoritative = cached || crypto.randomUUID();
             if (!cached) _workflowObjectUuids.set(workflow, authoritative);
+            // Record ownership too: every root tag must have a resolvable owner or
+            // the desync guard's orphaned-tag rebind (#545/#557) cannot tell this
+            // live tag apart from stale bookkeeping.
+            rememberWorkflowUuidOwner(authoritative, workflow);
             const extra =
               graphData.extra && typeof graphData.extra === "object" ? graphData.extra : (graphData.extra = {});
             const prev = extra[WORKFLOW_META_NAMESPACE];
@@ -1596,7 +1602,28 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
   let id = objectUuid || embedded || pathAlias || crypto.randomUUID();
 
   const embeddedOwner = embedded ? workflowUuidOwner(embedded) : null;
-  if (!objectUuid && embeddedOwner && embeddedOwner !== identityObject) id = crypto.randomUUID();
+  // #557 — fork away from a live owner's embedded uuid ONLY while that owner is
+  // still an OPEN workflow tab (a genuine co-open copy, #570). A save (or a
+  // reconnect) can REPLACE the active ComfyWorkflow object: the successor parses
+  // the same embedded uuid from the just-saved file while the replaced object is
+  // still the registered owner. Minting a fresh identity here desyncs the object
+  // from the root graph tag the desync guard compares, and every graph tool then
+  // hard-fails until a frontend reload. An owner that is no longer open was
+  // replaced — this object is its successor and INHERITS the identity, which
+  // keeps the WeakMap cache and the root tag aligned.
+  const openWorkflowsForOwnerCheck = app?.extensionManager?.workflow?.openWorkflows;
+  if (
+    !objectUuid &&
+    shouldForkEmbeddedUuidForLiveOwner({
+      embeddedUuid: embedded,
+      embeddedOwner,
+      identityObject,
+      ownerIsOpenWorkflow:
+        Array.isArray(openWorkflowsForOwnerCheck) && openWorkflowsForOwnerCheck.includes(embeddedOwner),
+    })
+  ) {
+    id = crypto.randomUUID();
+  }
   if (
     wf !== currentWorkflowRef &&
     shouldForkEmbeddedWorkflowUuid({
@@ -4096,6 +4123,43 @@ function assertGraphBoundToActiveWorkflow(
   const activeWorkflowUuid = activeWorkflow
     ? (_workflowObjectUuids.get(activeWorkflow) || workflowStableUuid(activeWorkflow))
     : null;
+  // #545/#557 — a root-tag UUID conflict is not self-healing: a save or reconnect
+  // can REPLACE the live ComfyWorkflow object, leaving the root stamped with an
+  // identity whose owner no longer exists as an open tab. Unless another LIVE
+  // open workflow owns the tag, the mismatch is stale bookkeeping rather than a
+  // foreign canvas — re-stamp the root with the active identity and proceed,
+  // instead of hard-blocking every graph tool until a frontend reload. A tag
+  // owned by another OPEN workflow is the genuine #349 wrong-canvas case: it
+  // still throws below, preserving the data-loss protection.
+  let rootUuidMismatch = graphRootWorkflowUuidMismatches({ rootGraph, activeWorkflowUuid });
+  if (rootUuidMismatch) {
+    const rootUuid = rootGraph?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD];
+    const tagOwner = workflowUuidOwner(rootUuid);
+    const openWorkflows = app?.extensionManager?.workflow?.openWorkflows;
+    const rootTagOwnedByForeignOpenWorkflow =
+      !!tagOwner &&
+      tagOwner !== activeWorkflow &&
+      Array.isArray(openWorkflows) &&
+      openWorkflows.includes(tagOwner);
+    if (
+      resolveGraphRootUuidRebind({ rootGraph, activeWorkflowUuid, rootTagOwnedByForeignOpenWorkflow }) ===
+      "rebind"
+    ) {
+      try {
+        const extra =
+          rootGraph.extra && typeof rootGraph.extra === "object" ? rootGraph.extra : (rootGraph.extra = {});
+        const priorMeta = extra[WORKFLOW_META_NAMESPACE];
+        extra[WORKFLOW_META_NAMESPACE] = {
+          ...(priorMeta && typeof priorMeta === "object" ? priorMeta : {}),
+          [WORKFLOW_UUID_FIELD]: activeWorkflowUuid,
+        };
+        rememberWorkflowUuidOwner(activeWorkflowUuid, activeWorkflow);
+        rootUuidMismatch = false;
+      } catch {
+        // A root that refuses the re-stamp stays mismatched and throws below.
+      }
+    }
+  }
   const currentStateTrustworthy = activeWorkflow?.isModified !== true;
   // On a dirty tab, ChangeTracker's activeState can lag the live canvas (#545),
   // so it cannot prove the root belongs to this workflow. Reads remain
@@ -4106,7 +4170,7 @@ function assertGraphBoundToActiveWorkflow(
     activeWorkflow?.isModified === true &&
     !graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid });
   if (
-    graphRootWorkflowUuidMismatches({ rootGraph, activeWorkflowUuid }) ||
+    rootUuidMismatch ||
     dirtyMutationBindingUnproven ||
     graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow }) ||
     (currentStateTrustworthy &&

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -101,7 +101,9 @@ import {
   selectorTargetsNonActiveWorkflow,
   isNewWorkflowLoad,
   normalizedWorkflowPath,
+  rawWorkflowObject,
   resolveUnsavedInstanceUuid,
+  sameWorkflowObject,
   shouldForkEmbeddedUuidForLiveOwner,
   shouldForkEmbeddedWorkflowUuid,
   shouldForkInPlaceReload,
@@ -1612,14 +1614,22 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
   // replaced — this object is its successor and INHERITS the identity, which
   // keeps the WeakMap cache and the root tag aligned.
   const openWorkflowsForOwnerCheck = app?.extensionManager?.workflow?.openWorkflows;
+  // Proxy-safe owner checks (#558 r2): openWorkflows holds Vue proxies while the
+  // owner map can hold raw objects, so raw `includes`/`!==` would misread a live
+  // foreign owner as closed (fork suppressed → a co-open copy INHERITS the source
+  // identity) or this object's own predecessor as foreign. Normalize through
+  // sameWorkflowObject at the comparison boundary.
+  const embeddedOwnerIsSelf = embeddedOwner != null && sameWorkflowObject(embeddedOwner, identityObject);
   if (
     !objectUuid &&
+    !embeddedOwnerIsSelf &&
     shouldForkEmbeddedUuidForLiveOwner({
       embeddedUuid: embedded,
       embeddedOwner,
       identityObject,
       ownerIsOpenWorkflow:
-        Array.isArray(openWorkflowsForOwnerCheck) && openWorkflowsForOwnerCheck.includes(embeddedOwner),
+        Array.isArray(openWorkflowsForOwnerCheck) &&
+        openWorkflowsForOwnerCheck.some((w) => sameWorkflowObject(w, embeddedOwner)),
     })
   ) {
     id = crypto.randomUUID();
@@ -4107,28 +4117,48 @@ function getGraphCtx() {
 // than return empty". Fail-safe: fires ONLY when the workflow reports N>0 nodes at
 // ROOT scope while the live root graph is empty, so a genuinely-empty / brand-new
 // workflow (and any descended-into empty subgraph) reads `node_count: 0` as before.
-// #349 — does OPEN workflow `w` claim rootUuid as its identity? Checked two ways,
-// because the identity carriers can lag: (1) the root-blind resolver — the same
-// identity the command fence uses for that tab; (2) the tab's OWN serialized
-// state, which still carries the graph stamp a CREATION made before any resolver
-// or owner record existed for it (creation loadGraphData calls pass no workflow
-// object, so nothing is registered in _workflowObjectUuids/_workflowUuidOwners at
-// stamp time). Either claim makes the tag that tab's live identity — never stale
-// bookkeeping the desync guard may rebind over.
+// #349 — does OPEN workflow `w` claim rootUuid as its identity? Checked three
+// ways, because the identity carriers can lag or disagree: (1) the root-blind
+// resolver — the same identity the command fence uses for that tab; (2) the
+// tab's OWN serialized state, which still carries the graph stamp a CREATION
+// made before any resolver or owner record existed for it (creation
+// loadGraphData calls pass no workflow object, so nothing is registered in
+// _workflowObjectUuids/_workflowUuidOwners at stamp time); (3) the registered
+// owner map, which still ties the tag to the tab even when its serialized state
+// is NOT loaded yet (an unloaded tab presents neither carrier). Any claim makes
+// the tag that tab's live identity — never stale bookkeeping the desync guard
+// may rebind over.
+//
+// The proxy/raw duality is normalized FIRST (#558 r2): openWorkflows holds Vue
+// proxies while the identity stores key on raw objects, so every lookup below
+// must work for either form — a raw `!==` would read a live proxy owner as a
+// different object and let the guard re-stamp that tab's live root.
 function workflowOwnsRootUuidTag(w, rootUuid) {
   if (!w || typeof rootUuid !== "string" || !rootUuid) return false;
+  const rawW = rawWorkflowObject(w);
   try {
-    if (workflowStableUuid(w) === rootUuid) return true;
+    if (workflowStableUuid(rawW) === rootUuid) return true;
   } catch {
     // Fall through to the serialized-state claim.
   }
   try {
-    const state = w?.changeTracker?.activeState ?? w?.activeState;
+    const state =
+      rawW?.changeTracker?.activeState ??
+      w?.changeTracker?.activeState ??
+      rawW?.activeState ??
+      w?.activeState;
     const stamped = state?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD];
-    return typeof stamped === "string" && stamped === rootUuid;
+    if (typeof stamped === "string" && stamped === rootUuid) return true;
   } catch {
-    return false;
+    // Fall through to the registered-owner claim.
   }
+  try {
+    const owner = workflowUuidOwner(rootUuid);
+    if (owner && sameWorkflowObject(owner, w)) return true;
+  } catch {
+    // No registered claim either.
+  }
+  return false;
 }
 
 function assertGraphBoundToActiveWorkflow(
@@ -4169,7 +4199,9 @@ function assertGraphBoundToActiveWorkflow(
     const openWorkflows = app?.extensionManager?.workflow?.openWorkflows;
     const rootTagOwnedByForeignOpenWorkflow =
       !Array.isArray(openWorkflows) ||
-      openWorkflows.some((w) => w && w !== activeWorkflow && workflowOwnsRootUuidTag(w, rootUuid));
+      openWorkflows.some(
+        (w) => w && !sameWorkflowObject(w, activeWorkflow) && workflowOwnsRootUuidTag(w, rootUuid),
+      );
     if (
       resolveGraphRootUuidRebind({ rootGraph, activeWorkflowUuid, rootTagOwnedByForeignOpenWorkflow }) ===
       "rebind"

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -4107,6 +4107,30 @@ function getGraphCtx() {
 // than return empty". Fail-safe: fires ONLY when the workflow reports N>0 nodes at
 // ROOT scope while the live root graph is empty, so a genuinely-empty / brand-new
 // workflow (and any descended-into empty subgraph) reads `node_count: 0` as before.
+// #349 — does OPEN workflow `w` claim rootUuid as its identity? Checked two ways,
+// because the identity carriers can lag: (1) the root-blind resolver — the same
+// identity the command fence uses for that tab; (2) the tab's OWN serialized
+// state, which still carries the graph stamp a CREATION made before any resolver
+// or owner record existed for it (creation loadGraphData calls pass no workflow
+// object, so nothing is registered in _workflowObjectUuids/_workflowUuidOwners at
+// stamp time). Either claim makes the tag that tab's live identity — never stale
+// bookkeeping the desync guard may rebind over.
+function workflowOwnsRootUuidTag(w, rootUuid) {
+  if (!w || typeof rootUuid !== "string" || !rootUuid) return false;
+  try {
+    if (workflowStableUuid(w) === rootUuid) return true;
+  } catch {
+    // Fall through to the serialized-state claim.
+  }
+  try {
+    const state = w?.changeTracker?.activeState ?? w?.activeState;
+    const stamped = state?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD];
+    return typeof stamped === "string" && stamped === rootUuid;
+  } catch {
+    return false;
+  }
+}
+
 function assertGraphBoundToActiveWorkflow(
   graph,
   rootGraph,
@@ -4125,22 +4149,27 @@ function assertGraphBoundToActiveWorkflow(
     : null;
   // #545/#557 — a root-tag UUID conflict is not self-healing: a save or reconnect
   // can REPLACE the live ComfyWorkflow object, leaving the root stamped with an
-  // identity whose owner no longer exists as an open tab. Unless another LIVE
-  // open workflow owns the tag, the mismatch is stale bookkeeping rather than a
-  // foreign canvas — re-stamp the root with the active identity and proceed,
-  // instead of hard-blocking every graph tool until a frontend reload. A tag
-  // owned by another OPEN workflow is the genuine #349 wrong-canvas case: it
-  // still throws below, preserving the data-loss protection.
+  // identity no live open tab claims. Such an orphaned tag is stale bookkeeping
+  // rather than a foreign canvas — re-stamp the root with the active identity
+  // and proceed, instead of hard-blocking every graph tool until a frontend
+  // reload. A tag claimed by another LIVE OPEN workflow is the genuine #349
+  // wrong-canvas case: it still throws below, preserving the data-loss
+  // protection.
   let rootUuidMismatch = graphRootWorkflowUuidMismatches({ rootGraph, activeWorkflowUuid });
   if (rootUuidMismatch) {
     const rootUuid = rootGraph?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD];
-    const tagOwner = workflowUuidOwner(rootUuid);
+    // The tag stays a hard wrong-canvas refusal whenever ANY OTHER LIVE OPEN
+    // workflow claims it (#349). Decide by ENUMERATING the open tabs, never the
+    // owner map alone: a creation stamps the graph without any owner/uuid-cache
+    // record (creation loadGraphData passes no workflow object), and a save can
+    // leave the owner map pointing at the replaced predecessor — so a missing or
+    // stale owner record must never be what authorizes a rebind over a live
+    // tab's canvas (codex P0). Fail closed when the open-tab list itself is
+    // unavailable: an unverifiable claim is a claim.
     const openWorkflows = app?.extensionManager?.workflow?.openWorkflows;
     const rootTagOwnedByForeignOpenWorkflow =
-      !!tagOwner &&
-      tagOwner !== activeWorkflow &&
-      Array.isArray(openWorkflows) &&
-      openWorkflows.includes(tagOwner);
+      !Array.isArray(openWorkflows) ||
+      openWorkflows.some((w) => w && w !== activeWorkflow && workflowOwnsRootUuidTag(w, rootUuid));
     if (
       resolveGraphRootUuidRebind({ rootGraph, activeWorkflowUuid, rootTagOwnedByForeignOpenWorkflow }) ===
       "rebind"

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3260,6 +3260,11 @@ async function programmaticSave(name) {
   // closed→reopened object at the same path is a NEW workflow (r3 P0), while a
   // swapped successor is the same continuous tab and must keep its identity.
   const preSwapUuid = expectWf ? _workflowObjectUuids.get(expectWf) || workflowStableUuid(expectWf) : null;
+  // The predecessor's tab slot BEFORE the save — half of the continuity proof
+  // below (a genuine swap lands the successor in the same slot).
+  const preSwapSlotIndex = Array.isArray(svc?.openWorkflows)
+    ? svc.openWorkflows.findIndex((w) => sameWorkflowObject(w, expectWf))
+    : -1;
   // Capture POSITIVE pre-save evidence of the source file's existence: a confirmed 200
   // is the ONLY basis on which a post-save 404 may be treated as a real move/deletion
   // of a persisted original. Without it, a source that 404s afterward simply never
@@ -3288,17 +3293,38 @@ async function programmaticSave(name) {
     expect: expectWf, // #330: refuse if the user switched tabs during our pre-save HEAD
   });
   const outcome = describeSaveOutcome(details);
-  // #557 r3 — thread the identity across the swap for an in-place/first save
-  // (never a Save-As copy, which is a NEW workflow): seed the successor object
-  // with the pre-save uuid so the desync guard and the command fence keep
-  // agreeing with the root tag without waiting for the lazy resolver path.
+  // #557 r3/r4 — thread the identity across the swap ONLY with positive
+  // CONTINUITY, verified at the seed point (postWf is read from the service
+  // HERE, after the awaited save): the predecessor must be GONE from the open
+  // tabs — a user/reconnect tab switch during the await keeps it open and must
+  // abort the carry entirely, or a distinct foreign tab gets seeded with A's
+  // uuid and the #349 wrong-canvas fence aligns on the wrong identity — and
+  // the successor must show it continues the same tab lifetime (its
+  // serialized state carries the pre-save uuid, or it occupies the
+  // predecessor's slot).
   const postSwapWf = svc?.activeWorkflow;
-  if (
-    preSwapUuid &&
-    shouldCarryIdentityAcrossSaveSwap({ preWf: expectWf, postWf: postSwapWf, savedAs: outcome.saved_as })
-  ) {
-    _workflowObjectUuids.set(postSwapWf, preSwapUuid);
-    rememberWorkflowUuidOwner(preSwapUuid, postSwapWf);
+  if (preSwapUuid) {
+    const openList = svc?.openWorkflows;
+    const preWfStillOpen =
+      !Array.isArray(openList) || openList.some((w) => sameWorkflowObject(w, expectWf));
+    const successorState = postSwapWf?.changeTracker?.activeState ?? postSwapWf?.activeState;
+    const successorCarriesPreUuid =
+      successorState?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD] === preSwapUuid;
+    const successorInPreSlot =
+      Array.isArray(openList) && preSwapSlotIndex >= 0 && sameWorkflowObject(openList[preSwapSlotIndex], postSwapWf);
+    if (
+      shouldCarryIdentityAcrossSaveSwap({
+        preWf: expectWf,
+        postWf: postSwapWf,
+        savedAs: outcome.saved_as,
+        preWfStillOpen,
+        successorCarriesPreUuid,
+        successorInPreSlot,
+      })
+    ) {
+      _workflowObjectUuids.set(postSwapWf, preSwapUuid);
+      rememberWorkflowUuidOwner(preSwapUuid, postSwapWf);
+    }
   }
   // INDEPENDENT post-save verification (a second backstop, at the tool layer) for a
   // Save-As COPY: attest whether the REAL source file is still on disk. This reports

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3298,40 +3298,47 @@ async function programmaticSave(name) {
     expect: expectWf, // #330: refuse if the user switched tabs during our pre-save HEAD
   });
   const outcome = describeSaveOutcome(details);
-  // #557 r3/r4/r5 — thread the identity across the swap ONLY with positive
-  // CONTINUITY, verified at the seed point (postWf is read from the service
-  // HERE, after the awaited save): the predecessor must be GONE from the open
-  // tabs — a user/reconnect tab switch during the await keeps it open and must
-  // abort the carry entirely, or a distinct foreign tab gets seeded with A's
-  // uuid and the #349 wrong-canvas fence aligns on the wrong identity — and
-  // the successor must CARRY the pre-save uuid in its serialized state (the
-  // genuine #557 successor parses the just-saved file, which embeds it). Tab
-  // SLOT occupancy is NOT evidence: a closed-then-compacted list can seat a
-  // foreign tab in the predecessor's old slot with zero lineage (r5 P0). A
-  // successor whose tracker is lagging/unreadable fails SAFE (no carry); the
-  // lazy owner-not-open inheritance heals that case on next resolve.
+  // #557 r3/r4/r5/r7/r8 — thread the identity across the swap ONLY with
+  // CONTINUITY PROVEN FROM THE SAVE'S OWN REPLACEMENT EVENT, verified at the
+  // seed point (postWf is read from the service HERE, after the awaited save):
+  // the predecessor must be GONE from the open tabs — a user/reconnect tab
+  // switch during the await keeps it open and must abort the carry entirely —
+  // and the post-save ACTIVE object must be the service's current record for
+  // the file THIS save wrote (details.targetPath, the lib's authoritative
+  // record of what was written). STATIC evidence is never accepted: tab-slot
+  // occupancy can seat a foreign tab in the predecessor's old slot (r5), and a
+  // lagging tracker state carrying the pre-save uuid can be a closed/reopened
+  // tab's residue (r8). A successor the event thread can't prove fails SAFE
+  // (no carry); the lazy owner-not-open inheritance heals it on next resolve.
   const postSwapWf = svc?.activeWorkflow;
   if (preSwapUuid) {
     const openList = svc?.openWorkflows;
     const preWfStillOpen =
       !Array.isArray(openList) || openList.some((w) => sameWorkflowObject(w, expectWf));
-    const successorState = postSwapWf?.changeTracker?.activeState ?? postSwapWf?.activeState;
-    const successorCarriesPreUuid =
-      successorState?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD] === preSwapUuid;
     // r7 P0 — even with continuity proven, never overwrite an established,
     // DIFFERENT identity on the successor: that is a conflicting tab, not A's
     // continuation, and seeding it would poison the owner map.
     const postWfHasConflictingEstablishedIdentity = Boolean(
       postSwapWf && _workflowObjectUuids.get(postSwapWf) && _workflowObjectUuids.get(postSwapWf) !== preSwapUuid
     );
+    // r8 P0 — ask the SERVICE which record now owns the file the save wrote,
+    // and require the post-save active object to BE that record.
+    const saveTargetPath =
+      typeof details?.targetPath === "string" && details.targetPath ? details.targetPath : null;
+    const targetRecord = saveTargetPath
+      ? ((typeof svc?.getWorkflowByPath === "function" && svc.getWorkflowByPath(saveTargetPath)) ||
+          (Array.isArray(openList) ? openList.find((w) => w && w.path === saveTargetPath) : null) ||
+          null)
+      : null;
+    const postWfIsSaveTargetRecord = Boolean(targetRecord) && sameWorkflowObject(targetRecord, postSwapWf);
     if (
       shouldCarryIdentityAcrossSaveSwap({
         preWf: expectWf,
         postWf: postSwapWf,
         savedAs: outcome.saved_as,
         preWfStillOpen,
-        successorCarriesPreUuid,
         postWfHasConflictingEstablishedIdentity,
+        postWfIsSaveTargetRecord,
       })
     ) {
       if (!_workflowObjectUuids.get(postSwapWf)) _workflowObjectUuids.set(postSwapWf, preSwapUuid);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3312,18 +3312,19 @@ async function programmaticSave(name) {
     expect: expectWf, // #330: refuse if the user switched tabs during our pre-save HEAD
   });
   const outcome = describeSaveOutcome(details);
-  // #557 r3/r4/r5/r7/r8 — thread the identity across the swap ONLY with
+  // #557 r3/r4/r5/r7/r8/r10 — thread the identity across the swap ONLY with
   // CONTINUITY PROVEN FROM THE SAVE'S OWN REPLACEMENT EVENT, verified at the
   // seed point (postWf is read from the service HERE, after the awaited save):
   // the predecessor must be GONE from the open tabs — a user/reconnect tab
   // switch during the await keeps it open and must abort the carry entirely —
-  // and the post-save ACTIVE object must be the service's current record for
-  // the file THIS save wrote (details.targetPath, the lib's authoritative
-  // record of what was written). STATIC evidence is never accepted: tab-slot
-  // occupancy can seat a foreign tab in the predecessor's old slot (r5), and a
-  // lagging tracker state carrying the pre-save uuid can be a closed/reopened
-  // tab's residue (r8). A successor the event thread can't prove fails SAFE
-  // (no carry); the lazy owner-not-open inheritance heals it on next resolve.
+  // and the post-save ACTIVE object must be the record the save API itself
+  // PRODUCED (details.savedRecord, threaded by the save lib). STATIC evidence
+  // is never accepted: tab-slot occupancy can seat a foreign tab in the
+  // predecessor's old slot (r5), a lagging tracker state carrying the pre-save
+  // uuid can be residue (r8), and path occupancy is satisfied by any
+  // close→reopen of the same file — which is a NEW identity, not a successor
+  // (r10). A successor the event thread can't prove fails SAFE (no carry); the
+  // lazy backstop / proven repaint heals the genuine case afterward.
   const postSwapWf = svc?.activeWorkflow;
   if (preSwapUuid) {
     const openList = svc?.openWorkflows;
@@ -3335,16 +3336,9 @@ async function programmaticSave(name) {
     const postWfHasConflictingEstablishedIdentity = Boolean(
       postSwapWf && _workflowObjectUuids.get(postSwapWf) && _workflowObjectUuids.get(postSwapWf) !== preSwapUuid
     );
-    // r8 P0 — ask the SERVICE which record now owns the file the save wrote,
-    // and require the post-save active object to BE that record.
-    const saveTargetPath =
-      typeof details?.targetPath === "string" && details.targetPath ? details.targetPath : null;
-    const targetRecord = saveTargetPath
-      ? ((typeof svc?.getWorkflowByPath === "function" && svc.getWorkflowByPath(saveTargetPath)) ||
-          (Array.isArray(openList) ? openList.find((w) => w && w.path === saveTargetPath) : null) ||
-          null)
-      : null;
-    const postWfIsSaveTargetRecord = Boolean(targetRecord) && sameWorkflowObject(targetRecord, postSwapWf);
+    // r10 P0 — the save API's own produced record is the ONLY succession proof:
+    // a close→reopen of the same path is not what the save produced.
+    const postWfIsSaveProducedRecord = Boolean(details?.savedRecord) && sameWorkflowObject(details.savedRecord, postSwapWf);
     if (
       shouldCarryIdentityAcrossSaveSwap({
         preWf: expectWf,
@@ -3352,7 +3346,7 @@ async function programmaticSave(name) {
         savedAs: outcome.saved_as,
         preWfStillOpen,
         postWfHasConflictingEstablishedIdentity,
-        postWfIsSaveTargetRecord,
+        postWfIsSaveProducedRecord,
       })
     ) {
       if (!_workflowObjectUuids.get(postSwapWf)) _workflowObjectUuids.set(postSwapWf, preSwapUuid);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1245,6 +1245,36 @@ const _tempWorkflowInstanceIds = new WeakMap(); // wf object -> "tmp:<uuid>"
 const _priorTempWorkflowIds = new WeakMap();
 const _workflowObjectUuids = new WeakMap();
 const _workflowUuidOwners = new Map();
+
+// r11 P0 — every access to the per-object identity store keys on the RAW
+// workflow object. Service lists and reads hand out Vue proxies, and a WeakMap
+// keyed by whichever carrier arrives splits the store: a proxy-keyed write
+// would hide the raw-keyed established identity from the conflict vetoes (and
+// vice versa), and the resolver would mint over an established identity it
+// could not see. Never key by the arriving carrier.
+function workflowObjectUuid(wf) {
+  try {
+    return _workflowObjectUuids.get(rawWorkflowObject(wf));
+  } catch {
+    return undefined;
+  }
+}
+
+function setWorkflowObjectUuid(wf, uuid) {
+  try {
+    _workflowObjectUuids.set(rawWorkflowObject(wf), uuid);
+  } catch {
+    // Never let identity bookkeeping break the caller.
+  }
+}
+
+function deleteWorkflowObjectUuid(wf) {
+  try {
+    _workflowObjectUuids.delete(rawWorkflowObject(wf));
+  } catch {
+    // Never let identity bookkeeping break the caller.
+  }
+}
 const WORKFLOW_UUID_ALIASES_KEY = "comfyui-mcp.panel.workflowUuidAliases";
 const WORKFLOW_META_NAMESPACE = "comfyui_mcp";
 const WORKFLOW_UUID_FIELD = "workflow_uuid";
@@ -1430,9 +1460,9 @@ function installCreateBoundaryFork(appRef) {
           if (keepInstance && workflow && typeof workflow === "object") {
             // Authoritative identity = the live object's cached uuid (mint one only if this
             // object has never been seen). Stamp it over the incoming value; do NOT fork.
-            const cached = _workflowObjectUuids.get(workflow);
+            const cached = workflowObjectUuid(workflow);
             const authoritative = cached || crypto.randomUUID();
-            if (!cached) _workflowObjectUuids.set(workflow, authoritative);
+            if (!cached) setWorkflowObjectUuid(workflow, authoritative);
             // Record ownership too: every root tag must have a resolvable owner or
             // the desync guard's orphaned-tag rebind (#545/#557) cannot tell this
             // live tag apart from stale bookkeeping.
@@ -1447,10 +1477,10 @@ function installCreateBoundaryFork(appRef) {
           } else if (creation) {
             fork = true;
           } else if (!noFork && workflow && typeof workflow === "object") {
-            const cached = _workflowObjectUuids.get(workflow);
+            const cached = workflowObjectUuid(workflow);
             const incoming = graphData.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD];
             if (shouldForkInPlaceReload({ cachedUuid: cached, incomingUuid: incoming })) {
-              _workflowObjectUuids.delete(workflow); // content replaced in place → drop stale cache
+              deleteWorkflowObjectUuid(workflow); // content replaced in place → drop stale cache
               fork = true;
             } else if (!cached) {
               // The load call itself binds this serialized graph to `workflow`.
@@ -1478,7 +1508,7 @@ function installCreateBoundaryFork(appRef) {
               [WORKFLOW_UUID_FIELD]: freshUuid,
             };
             if (workflow && typeof workflow === "object") {
-              _workflowObjectUuids.set(workflow, freshUuid);
+              setWorkflowObjectUuid(workflow, freshUuid);
               rememberWorkflowUuidOwner(freshUuid, workflow);
             } else {
               // A creation passes no workflow object — the receiving tab only
@@ -1487,7 +1517,7 @@ function installCreateBoundaryFork(appRef) {
               ownerlessStampUuid = freshUuid;
             }
           } else if (cacheIncomingUuid) {
-            _workflowObjectUuids.set(workflow, cacheIncomingUuid);
+            setWorkflowObjectUuid(workflow, cacheIncomingUuid);
             rememberWorkflowUuidOwner(cacheIncomingUuid, workflow);
           }
         }
@@ -1534,9 +1564,9 @@ function installCreateBoundaryFork(appRef) {
             // guard's lineage check re-stamp a foreign root with this object's
             // identity — the r6 stale-lineage bypass via registration. Fail
             // closed: an established conflicting identity vetoes registration.
-            const established = _workflowObjectUuids.get(active);
+            const established = workflowObjectUuid(active);
             if (established && established !== stampUuid) return;
-            if (!established) _workflowObjectUuids.set(active, stampUuid);
+            if (!established) setWorkflowObjectUuid(active, stampUuid);
             rememberWorkflowUuidOwner(stampUuid, active);
           } catch {
             // Identity bookkeeping must never break a graph load.
@@ -1571,7 +1601,10 @@ function workflowUuidOwner(id) {
 }
 
 function rememberWorkflowUuidOwner(id, owner) {
-  _workflowUuidOwners.set(id, typeof WeakRef === "function" ? new WeakRef(owner) : owner);
+  // Owner records key on the RAW object too (r11): later sameWorkflowObject
+  // comparisons unwrap, but the store stays canonical.
+  const rawOwner = rawWorkflowObject(owner) ?? owner;
+  _workflowUuidOwners.set(id, typeof WeakRef === "function" ? new WeakRef(rawOwner) : rawOwner);
   // WeakRef is unavailable only on older embedded browsers. Keep that fallback
   // bounded rather than retaining every workflow object for the life of the page.
   if (typeof WeakRef !== "function" && _workflowUuidOwners.size > 64) {
@@ -1590,7 +1623,7 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
   const identityObject = wf || app?.graph;
   if (!identityObject || typeof identityObject !== "object") return getTabId();
   const path = savedWorkflowPath(wf);
-  const objectUuid = _workflowObjectUuids.get(identityObject);
+  const objectUuid = workflowObjectUuid(identityObject);
 
   // #570 P0/P1 — UNSAVED workflow: the per-instance identity is the in-session objectUuid
   // (the LIVE-object WeakMap — a copy/import does NOT share it), else the EMBEDDED graph.extra
@@ -1622,7 +1655,7 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
       embeddedId,
       forkActive: _loadGraphDataForkInstalled,
     });
-    _workflowObjectUuids.set(identityObject, id);
+    setWorkflowObjectUuid(identityObject, id);
     rememberWorkflowUuidOwner(id, identityObject);
     if (embeddedId !== id) {
       // Persist the identity into extra (so a reload of the SAME content keeps it, AND a later
@@ -1711,7 +1744,7 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
     id = pathAlias && pathAlias !== embedded ? pathAlias : crypto.randomUUID();
   }
 
-  _workflowObjectUuids.set(identityObject, id);
+  setWorkflowObjectUuid(identityObject, id);
   rememberWorkflowUuidOwner(id, identityObject);
   const aliasMutations = [];
   if (objectUuid && path) {
@@ -1823,7 +1856,7 @@ function isCanonicalWorkflowInstanceUuid(value) {
 // to publish as a command-fence refresh source.
 function establishedWorkflowReplyIdentity(wf) {
   if (!wf || typeof wf !== "object") return null;
-  const uuid = _workflowObjectUuids.get(wf);
+  const uuid = workflowObjectUuid(wf);
   if (!isCanonicalWorkflowInstanceUuid(uuid)) return null;
   const savedPath = savedWorkflowPath(wf);
   return savedPath ? { routingKey: `wf:${savedPath}`, uuid } : null;
@@ -3283,7 +3316,7 @@ async function programmaticSave(name) {
   // only known for certain here. Static path equality cannot decide it — a
   // closed→reopened object at the same path is a NEW workflow (r3 P0), while a
   // swapped successor is the same continuous tab and must keep its identity.
-  const preSwapUuid = expectWf ? _workflowObjectUuids.get(expectWf) || workflowStableUuid(expectWf) : null;
+  const preSwapUuid = expectWf ? workflowObjectUuid(expectWf) || workflowStableUuid(expectWf) : null;
   // Capture POSITIVE pre-save evidence of the source file's existence: a confirmed 200
   // is the ONLY basis on which a post-save 404 may be treated as a real move/deletion
   // of a persisted original. Without it, a source that 404s afterward simply never
@@ -3334,7 +3367,7 @@ async function programmaticSave(name) {
     // DIFFERENT identity on the successor: that is a conflicting tab, not A's
     // continuation, and seeding it would poison the owner map.
     const postWfHasConflictingEstablishedIdentity = Boolean(
-      postSwapWf && _workflowObjectUuids.get(postSwapWf) && _workflowObjectUuids.get(postSwapWf) !== preSwapUuid
+      postSwapWf && workflowObjectUuid(postSwapWf) && workflowObjectUuid(postSwapWf) !== preSwapUuid
     );
     // r10 P0 — the save API's own produced record is the ONLY succession proof:
     // a close→reopen of the same path is not what the save produced.
@@ -3349,7 +3382,7 @@ async function programmaticSave(name) {
         postWfIsSaveProducedRecord,
       })
     ) {
-      if (!_workflowObjectUuids.get(postSwapWf)) _workflowObjectUuids.set(postSwapWf, preSwapUuid);
+      if (!workflowObjectUuid(postSwapWf)) setWorkflowObjectUuid(postSwapWf, preSwapUuid);
       rememberWorkflowUuidOwner(preSwapUuid, postSwapWf);
     }
   }
@@ -4272,7 +4305,7 @@ function assertGraphBoundToActiveWorkflow(
   // it can use workflow-owned/load-bound metadata or mint a fresh id, but can
   // never adopt the stale app.graph.extra we are trying to detect (#545 P1).
   const activeWorkflowUuid = activeWorkflow
-    ? (_workflowObjectUuids.get(activeWorkflow) || workflowStableUuid(activeWorkflow))
+    ? (workflowObjectUuid(activeWorkflow) || workflowStableUuid(activeWorkflow))
     : null;
   // #545/#557 — a root-tag UUID conflict is not self-healing: a save or reconnect
   // can drift the root stamp from the ACTIVE workflow's resolved identity while

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1508,15 +1508,16 @@ function installCreateBoundaryFork(appRef) {
       }
       const result = orig(graphData, clean, restoreView, workflow, options);
       if (ownerlessStampUuid) {
-        // #349 r3 P0 — a creation-minted tag must NEVER float ownerless: with no
-        // registered claim, a live-but-never-resolved created tab looks like
-        // stale bookkeeping to the desync guard's orphaned-tag rebind and its
-        // foreign root can be re-stamped over. Creations switch to the tab they
-        // create, so register against the post-load ACTIVE workflow — verified,
-        // when its tracker already exposes the stamp, by that stamp; when the
-        // tracker is absent or lagging, register anyway: a mis-attributed claim
-        // fails CLOSED (a spurious desync refusal), where an ownerless tag fails
-        // OPEN (a wrong-canvas write).
+        // #349 r3/r6 P0 — a creation-minted tag must NEVER float ownerless when
+        // its receiving tab can be PROVEN — but registration must never guess.
+        // Creations switch to the tab they create, so check the post-load ACTIVE
+        // workflow's tracker for the minted stamp: a positive match proves the
+        // load landed there and registration is safe. An absent, lagging, or
+        // unreadable stamp proves NOTHING (a mid-load switch would otherwise
+        // misattribute the minted uuid to a foreign tab — fail-OPEN through the
+        // guard's lineage claim), and a mismatch means the load landed
+        // elsewhere. In both cases the tag floats ownerless, which can only
+        // ever fail CLOSED.
         const stampUuid = ownerlessStampUuid;
         const register = () => {
           try {
@@ -1524,7 +1525,7 @@ function installCreateBoundaryFork(appRef) {
             if (!active || typeof active !== "object") return;
             const stamped =
               active?.changeTracker?.activeState?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD];
-            if (stamped && stamped !== stampUuid) return; // the load landed in a different tab
+            if (stamped !== stampUuid) return; // no positive match — do NOT register
             if (!_workflowObjectUuids.get(active)) _workflowObjectUuids.set(active, stampUuid);
             rememberWorkflowUuidOwner(stampUuid, active);
           } catch {
@@ -4193,17 +4194,17 @@ function getGraphCtx() {
 // than return empty". Fail-safe: fires ONLY when the workflow reports N>0 nodes at
 // ROOT scope while the live root graph is empty, so a genuinely-empty / brand-new
 // workflow (and any descended-into empty subgraph) reads `node_count: 0` as before.
-// #349 — does OPEN workflow `w` claim rootUuid as its identity? Checked three
-// ways, because the identity carriers can lag or disagree: (1) the root-blind
-// resolver — the same identity the command fence uses for that tab; (2) the
-// tab's OWN serialized state, which still carries the graph stamp a CREATION
-// made before any resolver or owner record existed for it (creation
-// loadGraphData calls pass no workflow object, so nothing is registered in
-// _workflowObjectUuids/_workflowUuidOwners at stamp time); (3) the registered
-// owner map, which still ties the tag to the tab even when its serialized state
-// is NOT loaded yet (an unloaded tab presents neither carrier). Any claim makes
-// the tag that tab's live identity — never stale bookkeeping the desync guard
-// may rebind over.
+// #349 — does OPEN workflow `w` claim rootUuid as its identity? Only OBJECT-KEYED
+// evidence counts: (1) the root-blind resolver — the same identity the command
+// fence uses for that tab (WeakMap-keyed on the object, falling back to
+// workflow-owned metadata); (2) the registered owner map — recorded, proxy-safely
+// compared, when the tag was minted for an object. A tab's SERIALIZED STATE is
+// deliberately NOT evidence (r6 P0): a lagging changeTracker.activeState can
+// carry a replaced predecessor's uuid residue, which is indistinguishable from
+// the genuine lineage stamp — accepting it let a stale-state object re-stamp a
+// foreign root with the active identity. Dropping it is fail-safe: a genuine
+// drift the object-keyed claims can't prove heals via panel_open_workflow's
+// proven repaint re-stamp instead of inline.
 //
 // The proxy/raw duality is normalized FIRST (#558 r2): openWorkflows holds Vue
 // proxies while the identity stores key on raw objects, so every lookup below
@@ -4214,17 +4215,6 @@ function workflowOwnsRootUuidTag(w, rootUuid) {
   const rawW = rawWorkflowObject(w);
   try {
     if (workflowStableUuid(rawW) === rootUuid) return true;
-  } catch {
-    // Fall through to the serialized-state claim.
-  }
-  try {
-    const state =
-      rawW?.changeTracker?.activeState ??
-      w?.changeTracker?.activeState ??
-      rawW?.activeState ??
-      w?.activeState;
-    const stamped = state?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD];
-    if (typeof stamped === "string" && stamped === rootUuid) return true;
   } catch {
     // Fall through to the registered-owner claim.
   }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1526,7 +1526,16 @@ function installCreateBoundaryFork(appRef) {
             const stamped =
               active?.changeTracker?.activeState?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD];
             if (stamped !== stampUuid) return; // no positive match — do NOT register
-            if (!_workflowObjectUuids.get(active)) _workflowObjectUuids.set(active, stampUuid);
+            // r7 P0 — a positive tracker match is still not enough when the
+            // active object ALREADY has an established, DIFFERENT identity: the
+            // load landed on a tab with its own uuid (or the tracker is stale
+            // residue). Promoting the stamp into an owner claim would let the
+            // guard's lineage check re-stamp a foreign root with this object's
+            // identity — the r6 stale-lineage bypass via registration. Fail
+            // closed: an established conflicting identity vetoes registration.
+            const established = _workflowObjectUuids.get(active);
+            if (established && established !== stampUuid) return;
+            if (!established) _workflowObjectUuids.set(active, stampUuid);
             rememberWorkflowUuidOwner(stampUuid, active);
           } catch {
             // Identity bookkeeping must never break a graph load.
@@ -3309,6 +3318,12 @@ async function programmaticSave(name) {
     const successorState = postSwapWf?.changeTracker?.activeState ?? postSwapWf?.activeState;
     const successorCarriesPreUuid =
       successorState?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD] === preSwapUuid;
+    // r7 P0 — even with continuity proven, never overwrite an established,
+    // DIFFERENT identity on the successor: that is a conflicting tab, not A's
+    // continuation, and seeding it would poison the owner map.
+    const postWfHasConflictingEstablishedIdentity = Boolean(
+      postSwapWf && _workflowObjectUuids.get(postSwapWf) && _workflowObjectUuids.get(postSwapWf) !== preSwapUuid
+    );
     if (
       shouldCarryIdentityAcrossSaveSwap({
         preWf: expectWf,
@@ -3316,9 +3331,10 @@ async function programmaticSave(name) {
         savedAs: outcome.saved_as,
         preWfStillOpen,
         successorCarriesPreUuid,
+        postWfHasConflictingEstablishedIdentity,
       })
     ) {
-      _workflowObjectUuids.set(postSwapWf, preSwapUuid);
+      if (!_workflowObjectUuids.get(postSwapWf)) _workflowObjectUuids.set(postSwapWf, preSwapUuid);
       rememberWorkflowUuidOwner(preSwapUuid, postSwapWf);
     }
   }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -97,6 +97,7 @@ import {
 import {
   classifyPinnedTarget,
   commandTargetsActiveWorkflow,
+  hasEmbeddedUuidSuccessionEvidence,
   selectorSearchIncludesListed,
   selectorTargetsNonActiveWorkflow,
   isNewWorkflowLoad,
@@ -1677,6 +1678,19 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
       ownerIsOpenWorkflow:
         Array.isArray(openWorkflowsForOwnerCheck) &&
         openWorkflowsForOwnerCheck.some((w) => sameWorkflowObject(w, embeddedOwner)),
+      // r9 P0 — a CLOSED owner is not succession by itself: require positive
+      // evidence this object continues the owner's FILE (the file's recorded
+      // workflow_path ties the uuid here, an explicit alias, or the owner's own
+      // file matching this object's), or a different-path copy of a file that
+      // carries only workflow_uuid would inherit A's identity and re-key its
+      // owner record — letting stale A-scoped commands fence-pass against it.
+      successionProven: hasEmbeddedUuidSuccessionEvidence({
+        embeddedUuid: embedded,
+        embeddedPath,
+        currentPath: path,
+        pathAlias,
+        embeddedOwner,
+      }),
     })
   ) {
     id = crypto.randomUUID();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -104,6 +104,7 @@ import {
   rawWorkflowObject,
   resolveUnsavedInstanceUuid,
   sameWorkflowObject,
+  shouldCarryIdentityAcrossSaveSwap,
   shouldForkEmbeddedUuidForLiveOwner,
   shouldForkEmbeddedWorkflowUuid,
   shouldForkInPlaceReload,
@@ -1395,6 +1396,9 @@ function installCreateBoundaryFork(appRef) {
     if (_loadGraphDataForkInstalled || !appRef || typeof appRef.loadGraphData !== "function") return;
     const orig = appRef.loadGraphData.bind(appRef);
     appRef.loadGraphData = function (graphData, clean, restoreView, workflow, options = {}) {
+      // Set when a CREATION mints a stamp without a workflow object to key on —
+      // registered against the tab the load activates, after orig (below).
+      let ownerlessStampUuid = null;
       try {
         if (graphData && typeof graphData === "object" && !Array.isArray(graphData)) {
           const noFork = Boolean(options && options.__cmcpNoFork);
@@ -1475,6 +1479,11 @@ function installCreateBoundaryFork(appRef) {
             if (workflow && typeof workflow === "object") {
               _workflowObjectUuids.set(workflow, freshUuid);
               rememberWorkflowUuidOwner(freshUuid, workflow);
+            } else {
+              // A creation passes no workflow object — the receiving tab only
+              // exists AFTER the load. Register the stamp against it post-orig
+              // (below), or the tag floats ownerless (#349 r3 P0).
+              ownerlessStampUuid = freshUuid;
             }
           } else if (cacheIncomingUuid) {
             _workflowObjectUuids.set(workflow, cacheIncomingUuid);
@@ -1497,7 +1506,35 @@ function installCreateBoundaryFork(appRef) {
       } catch {
         // Never let disclosure bookkeeping break a graph load either.
       }
-      return orig(graphData, clean, restoreView, workflow, options);
+      const result = orig(graphData, clean, restoreView, workflow, options);
+      if (ownerlessStampUuid) {
+        // #349 r3 P0 — a creation-minted tag must NEVER float ownerless: with no
+        // registered claim, a live-but-never-resolved created tab looks like
+        // stale bookkeeping to the desync guard's orphaned-tag rebind and its
+        // foreign root can be re-stamped over. Creations switch to the tab they
+        // create, so register against the post-load ACTIVE workflow — verified,
+        // when its tracker already exposes the stamp, by that stamp; when the
+        // tracker is absent or lagging, register anyway: a mis-attributed claim
+        // fails CLOSED (a spurious desync refusal), where an ownerless tag fails
+        // OPEN (a wrong-canvas write).
+        const stampUuid = ownerlessStampUuid;
+        const register = () => {
+          try {
+            const active = appRef?.extensionManager?.workflow?.activeWorkflow;
+            if (!active || typeof active !== "object") return;
+            const stamped =
+              active?.changeTracker?.activeState?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD];
+            if (stamped && stamped !== stampUuid) return; // the load landed in a different tab
+            if (!_workflowObjectUuids.get(active)) _workflowObjectUuids.set(active, stampUuid);
+            rememberWorkflowUuidOwner(stampUuid, active);
+          } catch {
+            // Identity bookkeeping must never break a graph load.
+          }
+        };
+        if (result && typeof result.then === "function") result.then(register, register);
+        else register();
+      }
+      return result;
     };
     _loadGraphDataForkInstalled = true;
   } catch (err) {
@@ -3217,6 +3254,12 @@ async function programmaticSave(name) {
   // workflow changed during our pre-probe — restoring the "capture A before the first
   // await" guarantee the pre-probe would otherwise have widened into a wrong-tab window.
   const expectWf = svc?.activeWorkflow;
+  // #557 r3 — capture the pre-save identity NOW so a save's object SWAP can be
+  // threaded through the replacement event: the predecessor/successor pair is
+  // only known for certain here. Static path equality cannot decide it — a
+  // closed→reopened object at the same path is a NEW workflow (r3 P0), while a
+  // swapped successor is the same continuous tab and must keep its identity.
+  const preSwapUuid = expectWf ? _workflowObjectUuids.get(expectWf) || workflowStableUuid(expectWf) : null;
   // Capture POSITIVE pre-save evidence of the source file's existence: a confirmed 200
   // is the ONLY basis on which a post-save 404 may be treated as a real move/deletion
   // of a persisted original. Without it, a source that 404s afterward simply never
@@ -3245,6 +3288,18 @@ async function programmaticSave(name) {
     expect: expectWf, // #330: refuse if the user switched tabs during our pre-save HEAD
   });
   const outcome = describeSaveOutcome(details);
+  // #557 r3 — thread the identity across the swap for an in-place/first save
+  // (never a Save-As copy, which is a NEW workflow): seed the successor object
+  // with the pre-save uuid so the desync guard and the command fence keep
+  // agreeing with the root tag without waiting for the lazy resolver path.
+  const postSwapWf = svc?.activeWorkflow;
+  if (
+    preSwapUuid &&
+    shouldCarryIdentityAcrossSaveSwap({ preWf: expectWf, postWf: postSwapWf, savedAs: outcome.saved_as })
+  ) {
+    _workflowObjectUuids.set(postSwapWf, preSwapUuid);
+    rememberWorkflowUuidOwner(preSwapUuid, postSwapWf);
+  }
   // INDEPENDENT post-save verification (a second backstop, at the tool layer) for a
   // Save-As COPY: attest whether the REAL source file is still on disk. This reports
   // PATH PRESENCE (`original_on_disk`), not content identity — an honest, disk-checked

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -262,13 +262,16 @@ export function graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid } =
  * Returns:
  *   "none"     — no UUID conflict (missing identity on either side stays
  *                inconclusive, exactly like graphRootWorkflowUuidMismatches);
- *   "conflict" — the tag is positively owned by ANOTHER currently-open
+ *   "conflict" — the tag is positively claimed by ANOTHER currently-open
  *                workflow: the live root may genuinely be that tab's canvas
- *                (#349), so the data-loss protection stays fail-closed;
- *   "rebind"   — the tag is orphaned (dead/replaced/untracked owner) or names
- *                the active object itself under a former identity: the caller
- *                should re-stamp the root with the active workflow's uuid and
- *                proceed instead of throwing.
+ *                (#349), so the data-loss protection stays fail-closed. The
+ *                CALLER must establish this by enumerating the live open tabs —
+ *                a missing owner/uuid-cache record is NOT proof of orphanhood
+ *                (a creation stamps the graph before any record exists);
+ *   "rebind"   — no live open workflow claims the tag (a closed/replaced tab's
+ *                leftover, or the active object's own former identity): the
+ *                caller should re-stamp the root with the active workflow's
+ *                uuid and proceed instead of throwing.
  */
 export function resolveGraphRootUuidRebind({
   rootGraph,

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -252,34 +252,34 @@ export function graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid } =
 
 /**
  * #545/#557 — a root-tag/active-identity UUID conflict is not always a wrong
- * canvas. The tag is panel-owned bookkeeping, and a save or reconnect can
- * REPLACE the live ComfyWorkflow object: the root then keeps a stamp whose
- * owning object no longer exists as an open tab, while the successor object
- * resolves a different identity. That orphan is stale bookkeeping, not a live
- * foreign canvas — and a guard that can only throw on it blocks every graph
- * tool until a frontend reload, with no working remedy.
+ * canvas. The tag is panel-owned bookkeeping, and a save or reconnect can drift
+ * it from the ACTIVE workflow's resolved identity while the root is still that
+ * workflow's own canvas. For that case the guard must be RECOVERABLE: re-stamp
+ * the root with the active identity instead of hard-blocking every graph tool
+ * until a frontend reload.
  *
  * Returns:
  *   "none"     — no UUID conflict (missing identity on either side stays
  *                inconclusive, exactly like graphRootWorkflowUuidMismatches);
- *   "conflict" — the tag is positively claimed by ANOTHER currently-open
- *                workflow: the live root may genuinely be that tab's canvas
- *                (#349), so the data-loss protection stays fail-closed. The
- *                CALLER must establish this by enumerating the live open tabs —
- *                a missing owner/uuid-cache record is NOT proof of orphanhood
- *                (a creation stamps the graph before any record exists);
- *   "rebind"   — no live open workflow claims the tag (a closed/replaced tab's
- *                leftover, or the active object's own former identity): the
- *                caller should re-stamp the root with the active workflow's
- *                uuid and proceed instead of throwing.
+ *   "rebind"   — the ACTIVE workflow ITSELF claims the tag (its resolver
+ *                identity, its own serialized state, or its registered owner
+ *                record ties it to the tag): the tag is the active tab's own
+ *                lineage, stale relative to its current identity, so the root
+ *                is provably its own canvas — re-stamp and proceed;
+ *   "conflict" — anything else. A tag claimed by a FOREIGN open workflow is the
+ *                #349 wrong-canvas case, and a tag NOBODY claims may be a
+ *                closed tab's stale canvas — re-stamping either would authorize
+ *                writes to a graph that is not the active workflow's (r4/r5
+ *                P0). Both fail closed; the remedy for a genuinely drifted
+ *                binding is panel_open_workflow's proven repaint re-stamp.
  */
 export function resolveGraphRootUuidRebind({
   rootGraph,
   activeWorkflowUuid,
-  rootTagOwnedByForeignOpenWorkflow = false,
+  rootTagClaimedByActiveWorkflow = false,
 } = {}) {
   if (!graphRootWorkflowUuidMismatches({ rootGraph, activeWorkflowUuid })) return "none";
-  return rootTagOwnedByForeignOpenWorkflow ? "conflict" : "rebind";
+  return rootTagClaimedByActiveWorkflow ? "rebind" : "conflict";
 }
 
 /**

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -251,6 +251,35 @@ export function graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid } =
 }
 
 /**
+ * #545/#557 — a root-tag/active-identity UUID conflict is not always a wrong
+ * canvas. The tag is panel-owned bookkeeping, and a save or reconnect can
+ * REPLACE the live ComfyWorkflow object: the root then keeps a stamp whose
+ * owning object no longer exists as an open tab, while the successor object
+ * resolves a different identity. That orphan is stale bookkeeping, not a live
+ * foreign canvas — and a guard that can only throw on it blocks every graph
+ * tool until a frontend reload, with no working remedy.
+ *
+ * Returns:
+ *   "none"     — no UUID conflict (missing identity on either side stays
+ *                inconclusive, exactly like graphRootWorkflowUuidMismatches);
+ *   "conflict" — the tag is positively owned by ANOTHER currently-open
+ *                workflow: the live root may genuinely be that tab's canvas
+ *                (#349), so the data-loss protection stays fail-closed;
+ *   "rebind"   — the tag is orphaned (dead/replaced/untracked owner) or names
+ *                the active object itself under a former identity: the caller
+ *                should re-stamp the root with the active workflow's uuid and
+ *                proceed instead of throwing.
+ */
+export function resolveGraphRootUuidRebind({
+  rootGraph,
+  activeWorkflowUuid,
+  rootTagOwnedByForeignOpenWorkflow = false,
+} = {}) {
+  if (!graphRootWorkflowUuidMismatches({ rootGraph, activeWorkflowUuid })) return "none";
+  return rootTagOwnedByForeignOpenWorkflow ? "conflict" : "rebind";
+}
+
+/**
  * Whether a bridge graph command can change durable workflow state.
  *
  * A dirty workflow without a root UUID is not sufficiently proven for a graph

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -50,18 +50,37 @@ export function sameWorkflowObject(a, b) {
   return Boolean(ctA) && ctA === ctB;
 }
 
-/** #557 r3 — should the pre-save identity be carried onto the post-save active
+/** #557 r3/r4 — should the pre-save identity be carried onto the post-save active
  *  object? True ONLY for a continuous-lifetime replacement: an in-place or
  *  first save (NOT a Save-As copy — that starts a new workflow) that swapped
  *  the active ComfyWorkflow object. The swap is provable ONLY at the
  *  replacement event, where the predecessor and successor objects are both
  *  known; static path equality cannot decide it — a closed→reopened object at
  *  the same path is a NEW workflow (r3 P0), while a swapped successor is the
- *  same tab. A proxy/raw form of the SAME object is no swap at all. */
-export function shouldCarryIdentityAcrossSaveSwap({ preWf, postWf, savedAs = false } = {}) {
+ *  same tab. A proxy/raw form of the SAME object is no swap at all.
+ *
+ *  CONTINUITY (r4 P0): "whatever is active after the awaited save" is not
+ *  enough — a user/reconnect tab switch DURING the await lands on a DISTINCT
+ *  workflow, and seeding it with the pre-save uuid would align that foreign tab
+ *  with the old root tag, bypassing the #349 wrong-canvas fence. The carry
+ *  therefore also requires the predecessor to be GONE from the open tabs (a
+ *  genuine swap removes it; a switch keeps it open) AND the successor to show
+ *  it continues the same tab lifetime: its serialized state carries the
+ *  pre-save uuid, or it occupies the predecessor's tab slot. Unknown
+ *  predecessor state defaults to still-open (fail-safe: no carry). */
+export function shouldCarryIdentityAcrossSaveSwap({
+  preWf,
+  postWf,
+  savedAs = false,
+  preWfStillOpen = true,
+  successorCarriesPreUuid = false,
+  successorInPreSlot = false,
+} = {}) {
   if (savedAs) return false;
   if (!preWf || !postWf || typeof postWf !== "object") return false;
-  return preWf !== postWf && !sameWorkflowObject(preWf, postWf);
+  if (preWf === postWf || sameWorkflowObject(preWf, postWf)) return false;
+  if (preWfStillOpen) return false;
+  return successorCarriesPreUuid || successorInPreSlot;
 }
 
 /** Return true when an embedded UUID belongs to a different workflow file.

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -59,20 +59,20 @@ export function sameWorkflowObject(a, b) {
  *  the same path is a NEW workflow (r3 P0), while a swapped successor is the
  *  same tab. A proxy/raw form of the SAME object is no swap at all.
  *
- *  CONTINUITY (r4/r5/r8 P0): "whatever is active after the awaited save" is not
- *  enough — a user/reconnect tab switch DURING the await lands on a DISTINCT
+ *  CONTINUITY (r4/r5/r8/r10 P0): "whatever is active after the awaited save" is
+ *  not enough — a user/reconnect tab switch DURING the await lands on a DISTINCT
  *  workflow, and seeding it with the pre-save uuid would align that foreign tab
  *  with the old root tag, bypassing the #349 wrong-canvas fence. The carry
  *  therefore requires the predecessor to be GONE from the open tabs (a genuine
  *  swap removes it; a switch keeps it open) AND continuity threaded from the
- *  save's own replacement EVENT: the post-save active object must be the
- *  service's current record for the file THIS save wrote. STATIC evidence is
- *  deliberately excluded: tab-slot occupancy can seat a foreign tab in the
- *  predecessor's old slot (r5), and a lagging tracker state carrying the
- *  pre-save uuid can be a closed/reopened tab's residue (r8) — neither proves
- *  succession. A successor the event thread can't prove fails SAFE (no carry);
- *  the lazy owner-not-open inheritance in workflowStableUuid heals the genuine
- *  case on next resolve. Unknown predecessor state defaults to still-open
+ *  save's own replacement EVENT: the post-save active object must be the record
+ *  the save API itself PRODUCED. STATIC evidence is deliberately excluded:
+ *  tab-slot occupancy can seat a foreign tab in the predecessor's old slot
+ *  (r5), a lagging tracker state carrying the pre-save uuid can be residue
+ *  (r8), and path occupancy is satisfied by any close→reopen of the same file —
+ *  which is a NEW identity, not a successor (r10). A successor the event thread
+ *  can't prove fails SAFE (no carry); the lazy backstop / proven repaint heals
+ *  the genuine case afterward. Unknown predecessor state defaults to still-open
  *  (fail-safe: no carry). */
 export function shouldCarryIdentityAcrossSaveSwap({
   preWf,
@@ -80,7 +80,7 @@ export function shouldCarryIdentityAcrossSaveSwap({
   savedAs = false,
   preWfStillOpen = true,
   postWfHasConflictingEstablishedIdentity = false,
-  postWfIsSaveTargetRecord = false,
+  postWfIsSaveProducedRecord = false,
 } = {}) {
   if (savedAs) return false;
   if (!preWf || !postWf || typeof postWf !== "object") return false;
@@ -91,7 +91,7 @@ export function shouldCarryIdentityAcrossSaveSwap({
   // identity and poison the owner map (the r6 stale-lineage bypass, via
   // registration this time). Fail closed; the proven-repaint remedy heals.
   if (postWfHasConflictingEstablishedIdentity) return false;
-  return postWfIsSaveTargetRecord === true;
+  return postWfIsSaveProducedRecord === true;
 }
 
 /** Return true when an embedded UUID belongs to a different workflow file.
@@ -172,25 +172,26 @@ export function shouldForkEmbeddedUuidForLiveOwner({
   return successionProven !== true;
 }
 
-/** #557 r9 — POSITIVE succession evidence for inheriting a CLOSED owner's
+/** #557 r9/r10 — POSITIVE succession evidence for inheriting a CLOSED owner's
  *  embedded uuid. "The owner is gone" alone does not make this object the
  *  successor — a different-path COPY of the file qualifies just as well, and
  *  inheriting would re-key the uuid's owner record to the copy, letting stale
  *  uuid-scoped commands for the old workflow pass the command fence against it
- *  (r9 P0). Evidence, strongest first:
+ *  (r9 P0). Evidence:
  *   1. the file's OWN recorded workflow_path ties the uuid to THIS object's file;
- *   2. the canonical path alias ties THIS object's path to the uuid;
- *   3. the closed owner's unique on-disk file IS this object's file (same
- *      lineage — the save-swap / reload successor). An UNSAVED owner has no
- *      unique path (#186), so it can never serve here.
- *  Absent ALL of these — notably a file carrying only workflow_uuid, saved from
- *  an unsaved tab whose embed omitted workflow_path — fail toward FORKING. */
+ *   2. the canonical path alias ties THIS object's path to the uuid.
+ *  The owner's file MATCHING this object's path is deliberately NOT evidence
+ *  (r10 P0): a closed→reopened object at the same path is a NEW identity, not a
+ *  successor — the resume heal for that case belongs to the
+ *  UNREGISTERED-embedded path (no owner record), never to registered-owner
+ *  inheritance. Absent both layers — notably a file carrying only
+ *  workflow_uuid, saved from an unsaved tab whose embed omitted workflow_path —
+ *  fail toward FORKING. */
 export function hasEmbeddedUuidSuccessionEvidence({
   embeddedUuid,
   embeddedPath,
   currentPath,
   pathAlias,
-  embeddedOwner,
 } = {}) {
   if (
     embeddedPath &&
@@ -200,11 +201,6 @@ export function hasEmbeddedUuidSuccessionEvidence({
     return true;
   }
   if (typeof pathAlias === "string" && pathAlias && pathAlias === embeddedUuid) return true;
-  const ownerPath =
-    embeddedOwner?.isPersisted === true && typeof embeddedOwner?.path === "string" && embeddedOwner.path
-      ? embeddedOwner.path
-      : null;
-  if (ownerPath && currentPath && ownerPath === currentPath) return true;
   return false;
 }
 

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -64,6 +64,27 @@ export function shouldForkEmbeddedWorkflowUuid({
  *  A mis-classified reuse only loses durability (P1, a fresh session); a mis-classified
  *  creation that INHERITED the source identity would be a wrong-resume (P0) — so, faced
  *  with an ambiguous arg, fork. */
+/** #557 — should a previously-unseen workflow object FORK away from an embedded
+ *  UUID that is still owned by a DIFFERENT live object? Fork ONLY while that
+ *  owner is still an OPEN workflow tab — the genuine co-open copy case (#570).
+ *  A save re-registers/replaces the active ComfyWorkflow object: the successor
+ *  parses the same embedded uuid from the just-saved file while the REPLACED
+ *  object is still the registered owner. Minting a fresh identity for the
+ *  successor desyncs it from the root graph tag the graph-binding guard
+ *  compares against, so every panel_* graph tool hard-fails until a frontend
+ *  reload (#557). An owner that is no longer an open workflow was replaced, so
+ *  this object is its successor and must INHERIT the identity (and with it the
+ *  root tag), keeping the object cache and the root stamp aligned. */
+export function shouldForkEmbeddedUuidForLiveOwner({
+  embeddedUuid,
+  embeddedOwner,
+  identityObject,
+  ownerIsOpenWorkflow = false,
+} = {}) {
+  if (!embeddedUuid || !embeddedOwner || embeddedOwner === identityObject) return false;
+  return ownerIsOpenWorkflow === true;
+}
+
 /** #570 P0b — should an IN-PLACE graph load (loadGraphData into an EXISTING workflow object)
  *  FORK the per-instance identity? A stale object-cache must NEVER override the identity of
  *  newly-loaded content, and ownership is anchored on the LIVE object (not copyable

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -59,18 +59,19 @@ export function sameWorkflowObject(a, b) {
  *  the same path is a NEW workflow (r3 P0), while a swapped successor is the
  *  same tab. A proxy/raw form of the SAME object is no swap at all.
  *
- *  CONTINUITY (r4/r5 P0): "whatever is active after the awaited save" is not
+ *  CONTINUITY (r4/r5/r8 P0): "whatever is active after the awaited save" is not
  *  enough — a user/reconnect tab switch DURING the await lands on a DISTINCT
  *  workflow, and seeding it with the pre-save uuid would align that foreign tab
  *  with the old root tag, bypassing the #349 wrong-canvas fence. The carry
- *  therefore also requires the predecessor to be GONE from the open tabs (a
- *  genuine swap removes it; a switch keeps it open) AND the successor to CARRY
- *  the pre-save uuid in its serialized state — the genuine #557 successor
- *  parses the just-saved file, which embeds the pre-save uuid. Tab-SLOT
- *  occupancy is deliberately NOT evidence: a closed-then-compacted list can
- *  seat a foreign tab in the predecessor's old slot with zero lineage (r5 P0).
- *  A successor whose tracker/state is lagging or unreadable fails SAFE (no
- *  carry); the lazy owner-not-open inheritance in workflowStableUuid heals that
+ *  therefore requires the predecessor to be GONE from the open tabs (a genuine
+ *  swap removes it; a switch keeps it open) AND continuity threaded from the
+ *  save's own replacement EVENT: the post-save active object must be the
+ *  service's current record for the file THIS save wrote. STATIC evidence is
+ *  deliberately excluded: tab-slot occupancy can seat a foreign tab in the
+ *  predecessor's old slot (r5), and a lagging tracker state carrying the
+ *  pre-save uuid can be a closed/reopened tab's residue (r8) — neither proves
+ *  succession. A successor the event thread can't prove fails SAFE (no carry);
+ *  the lazy owner-not-open inheritance in workflowStableUuid heals the genuine
  *  case on next resolve. Unknown predecessor state defaults to still-open
  *  (fail-safe: no carry). */
 export function shouldCarryIdentityAcrossSaveSwap({
@@ -78,8 +79,8 @@ export function shouldCarryIdentityAcrossSaveSwap({
   postWf,
   savedAs = false,
   preWfStillOpen = true,
-  successorCarriesPreUuid = false,
   postWfHasConflictingEstablishedIdentity = false,
+  postWfIsSaveTargetRecord = false,
 } = {}) {
   if (savedAs) return false;
   if (!preWf || !postWf || typeof postWf !== "object") return false;
@@ -90,7 +91,7 @@ export function shouldCarryIdentityAcrossSaveSwap({
   // identity and poison the owner map (the r6 stale-lineage bypass, via
   // registration this time). Fail closed; the proven-repaint remedy heals.
   if (postWfHasConflictingEstablishedIdentity) return false;
-  return successorCarriesPreUuid === true;
+  return postWfIsSaveTargetRecord === true;
 }
 
 /** Return true when an embedded UUID belongs to a different workflow file.

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -145,24 +145,67 @@ export function shouldForkEmbeddedWorkflowUuid({
  *  creation that INHERITED the source identity would be a wrong-resume (P0) — so, faced
  *  with an ambiguous arg, fork. */
 /** #557 — should a previously-unseen workflow object FORK away from an embedded
- *  UUID that is still owned by a DIFFERENT live object? Fork ONLY while that
- *  owner is still an OPEN workflow tab — the genuine co-open copy case (#570).
- *  A save re-registers/replaces the active ComfyWorkflow object: the successor
- *  parses the same embedded uuid from the just-saved file while the REPLACED
- *  object is still the registered owner. Minting a fresh identity for the
- *  successor desyncs it from the root graph tag the graph-binding guard
- *  compares against, so every panel_* graph tool hard-fails until a frontend
- *  reload (#557). An owner that is no longer an open workflow was replaced, so
- *  this object is its successor and must INHERIT the identity (and with it the
- *  root tag), keeping the object cache and the root stamp aligned. */
+ *  UUID that is still owned by a DIFFERENT live object? Fork while that owner
+ *  is still an OPEN workflow tab — the genuine co-open copy case (#570) — and
+ *  ALSO when the owner is closed but succession is NOT proven (r9 P0): "the
+ *  owner is gone" alone does not make this object the successor — a
+ *  different-path copy of the file qualifies just as well, and inheriting
+ *  re-keys the uuid's owner record to the copy so stale uuid-scoped commands
+ *  for the old workflow pass the command fence against it. Only a closed owner
+ *  WITH positive succession evidence (hasEmbeddedUuidSuccessionEvidence) lets
+ *  this object INHERIT — the save re-registers/replaces the active
+ *  ComfyWorkflow object and the successor parses the same embedded uuid from
+ *  the just-saved file while the REPLACED object is still the registered
+ *  owner; minting fresh there desyncs it from the root graph tag the
+ *  graph-binding guard compares against (#557). */
 export function shouldForkEmbeddedUuidForLiveOwner({
   embeddedUuid,
   embeddedOwner,
   identityObject,
   ownerIsOpenWorkflow = false,
+  successionProven = false,
 } = {}) {
   if (!embeddedUuid || !embeddedOwner || embeddedOwner === identityObject) return false;
-  return ownerIsOpenWorkflow === true;
+  if (ownerIsOpenWorkflow === true) return true; // a LIVE co-open owner → genuine copy
+  // r9 P0 — a CLOSED owner is not succession: without positive evidence this
+  // object continues the owner's file, fork rather than inherit.
+  return successionProven !== true;
+}
+
+/** #557 r9 — POSITIVE succession evidence for inheriting a CLOSED owner's
+ *  embedded uuid. "The owner is gone" alone does not make this object the
+ *  successor — a different-path COPY of the file qualifies just as well, and
+ *  inheriting would re-key the uuid's owner record to the copy, letting stale
+ *  uuid-scoped commands for the old workflow pass the command fence against it
+ *  (r9 P0). Evidence, strongest first:
+ *   1. the file's OWN recorded workflow_path ties the uuid to THIS object's file;
+ *   2. the canonical path alias ties THIS object's path to the uuid;
+ *   3. the closed owner's unique on-disk file IS this object's file (same
+ *      lineage — the save-swap / reload successor). An UNSAVED owner has no
+ *      unique path (#186), so it can never serve here.
+ *  Absent ALL of these — notably a file carrying only workflow_uuid, saved from
+ *  an unsaved tab whose embed omitted workflow_path — fail toward FORKING. */
+export function hasEmbeddedUuidSuccessionEvidence({
+  embeddedUuid,
+  embeddedPath,
+  currentPath,
+  pathAlias,
+  embeddedOwner,
+} = {}) {
+  if (
+    embeddedPath &&
+    currentPath &&
+    normalizedWorkflowPath(embeddedPath) === normalizedWorkflowPath(currentPath)
+  ) {
+    return true;
+  }
+  if (typeof pathAlias === "string" && pathAlias && pathAlias === embeddedUuid) return true;
+  const ownerPath =
+    embeddedOwner?.isPersisted === true && typeof embeddedOwner?.path === "string" && embeddedOwner.path
+      ? embeddedOwner.path
+      : null;
+  if (ownerPath && currentPath && ownerPath === currentPath) return true;
+  return false;
 }
 
 /** #570 P0b — should an IN-PLACE graph load (loadGraphData into an EXISTING workflow object)

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -79,11 +79,17 @@ export function shouldCarryIdentityAcrossSaveSwap({
   savedAs = false,
   preWfStillOpen = true,
   successorCarriesPreUuid = false,
+  postWfHasConflictingEstablishedIdentity = false,
 } = {}) {
   if (savedAs) return false;
   if (!preWf || !postWf || typeof postWf !== "object") return false;
   if (preWf === postWf || sameWorkflowObject(preWf, postWf)) return false;
   if (preWfStillOpen) return false;
+  // r7 P0 — an established, DIFFERENT identity on the successor is a conflict:
+  // overwriting it would promote the pre-save stamp over the object's own
+  // identity and poison the owner map (the r6 stale-lineage bypass, via
+  // registration this time). Fail closed; the proven-repaint remedy heals.
+  if (postWfHasConflictingEstablishedIdentity) return false;
   return successorCarriesPreUuid === true;
 }
 

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -14,6 +14,42 @@ export function workflowAliasForPath(aliases, path) {
   return typeof match?.[1] === "string" && match[1] ? match[1] : null;
 }
 
+/** Vue reactive proxies expose their raw target as `__v_raw`; everything else is
+ *  returned as-is. The workflow service hands out reactive PROXIES in computed
+ *  lists (openWorkflows) while RAW objects flow through other paths (store
+ *  returns, the uuid owner/object WeakMaps), so identity comparisons across
+ *  those carriers must normalize first — a raw `===`/`includes` misreads a live
+ *  proxy as a different object (#558 r2). A transparent (non-Vue) proxy has no
+ *  raw back-pointer and passes through; sameWorkflowObject's property identity
+ *  covers that form. */
+export function rawWorkflowObject(w) {
+  try {
+    return w?.__v_raw ?? w ?? null;
+  } catch {
+    return w ?? null;
+  }
+}
+
+/** Proxy-safe identity between two workflow references. Layers, strongest first:
+ *  object identity (after unwrapping Vue proxies), then a SAVED tab's unique
+ *  on-disk path (reflected through any proxy), then the per-instance
+ *  changeTracker OBJECT — the strongest shared identity for an UNSAVED tab,
+ *  whose synthetic path is shared by every unsaved tab (#186). Two references
+ *  that share NONE of these carriers can never be proven same → false. */
+export function sameWorkflowObject(a, b) {
+  if (!a || !b) return false;
+  if (a === b) return true;
+  if (rawWorkflowObject(a) === rawWorkflowObject(b)) return true;
+  const savedPath = (w) =>
+    w?.isPersisted === true && typeof w?.path === "string" && w.path ? w.path : null;
+  const pa = savedPath(a) ?? savedPath(rawWorkflowObject(a));
+  const pb = savedPath(b) ?? savedPath(rawWorkflowObject(b));
+  if (pa && pb) return pa === pb;
+  const ctA = rawWorkflowObject(a)?.changeTracker ?? a?.changeTracker;
+  const ctB = rawWorkflowObject(b)?.changeTracker ?? b?.changeTracker;
+  return Boolean(ctA) && ctA === ctB;
+}
+
 /** Return true when an embedded UUID belongs to a different workflow file.
  *  An existing objectUuid means ComfyUI mutated the same live workflow object
  *  during rename/Save-As, so continuity wins. Otherwise an embedded path or a

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -59,28 +59,32 @@ export function sameWorkflowObject(a, b) {
  *  the same path is a NEW workflow (r3 P0), while a swapped successor is the
  *  same tab. A proxy/raw form of the SAME object is no swap at all.
  *
- *  CONTINUITY (r4 P0): "whatever is active after the awaited save" is not
+ *  CONTINUITY (r4/r5 P0): "whatever is active after the awaited save" is not
  *  enough — a user/reconnect tab switch DURING the await lands on a DISTINCT
  *  workflow, and seeding it with the pre-save uuid would align that foreign tab
  *  with the old root tag, bypassing the #349 wrong-canvas fence. The carry
  *  therefore also requires the predecessor to be GONE from the open tabs (a
- *  genuine swap removes it; a switch keeps it open) AND the successor to show
- *  it continues the same tab lifetime: its serialized state carries the
- *  pre-save uuid, or it occupies the predecessor's tab slot. Unknown
- *  predecessor state defaults to still-open (fail-safe: no carry). */
+ *  genuine swap removes it; a switch keeps it open) AND the successor to CARRY
+ *  the pre-save uuid in its serialized state — the genuine #557 successor
+ *  parses the just-saved file, which embeds the pre-save uuid. Tab-SLOT
+ *  occupancy is deliberately NOT evidence: a closed-then-compacted list can
+ *  seat a foreign tab in the predecessor's old slot with zero lineage (r5 P0).
+ *  A successor whose tracker/state is lagging or unreadable fails SAFE (no
+ *  carry); the lazy owner-not-open inheritance in workflowStableUuid heals that
+ *  case on next resolve. Unknown predecessor state defaults to still-open
+ *  (fail-safe: no carry). */
 export function shouldCarryIdentityAcrossSaveSwap({
   preWf,
   postWf,
   savedAs = false,
   preWfStillOpen = true,
   successorCarriesPreUuid = false,
-  successorInPreSlot = false,
 } = {}) {
   if (savedAs) return false;
   if (!preWf || !postWf || typeof postWf !== "object") return false;
   if (preWf === postWf || sameWorkflowObject(preWf, postWf)) return false;
   if (preWfStillOpen) return false;
-  return successorCarriesPreUuid || successorInPreSlot;
+  return successorCarriesPreUuid === true;
 }
 
 /** Return true when an embedded UUID belongs to a different workflow file.

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -31,23 +31,37 @@ export function rawWorkflowObject(w) {
 }
 
 /** Proxy-safe identity between two workflow references. Layers, strongest first:
- *  object identity (after unwrapping Vue proxies), then a SAVED tab's unique
- *  on-disk path (reflected through any proxy), then the per-instance
- *  changeTracker OBJECT — the strongest shared identity for an UNSAVED tab,
- *  whose synthetic path is shared by every unsaved tab (#186). Two references
- *  that share NONE of these carriers can never be proven same → false. */
+ *  object identity (after unwrapping Vue proxies), then the per-instance
+ *  changeTracker OBJECT — the strongest shared identity a proxy reflects, and
+ *  the only one available for an UNSAVED tab (whose synthetic path is shared by
+ *  every unsaved tab, #186). PATH IS DELIBERATELY NOT EVIDENCE: two distinct
+ *  objects can share a path across a close→reopen, and that reopened object is
+ *  a NEW workflow — treating path as identity let a live foreign owner read as
+ *  self (#558 r3 P0). The one legitimate same-path identity continuation, a
+ *  save swapping the active object, is threaded through the replacement event
+ *  instead (shouldCarryIdentityAcrossSaveSwap). Two references that share NONE
+ *  of these carriers can never be proven same → false. */
 export function sameWorkflowObject(a, b) {
   if (!a || !b) return false;
   if (a === b) return true;
   if (rawWorkflowObject(a) === rawWorkflowObject(b)) return true;
-  const savedPath = (w) =>
-    w?.isPersisted === true && typeof w?.path === "string" && w.path ? w.path : null;
-  const pa = savedPath(a) ?? savedPath(rawWorkflowObject(a));
-  const pb = savedPath(b) ?? savedPath(rawWorkflowObject(b));
-  if (pa && pb) return pa === pb;
   const ctA = rawWorkflowObject(a)?.changeTracker ?? a?.changeTracker;
   const ctB = rawWorkflowObject(b)?.changeTracker ?? b?.changeTracker;
   return Boolean(ctA) && ctA === ctB;
+}
+
+/** #557 r3 — should the pre-save identity be carried onto the post-save active
+ *  object? True ONLY for a continuous-lifetime replacement: an in-place or
+ *  first save (NOT a Save-As copy — that starts a new workflow) that swapped
+ *  the active ComfyWorkflow object. The swap is provable ONLY at the
+ *  replacement event, where the predecessor and successor objects are both
+ *  known; static path equality cannot decide it — a closed→reopened object at
+ *  the same path is a NEW workflow (r3 P0), while a swapped successor is the
+ *  same tab. A proxy/raw form of the SAME object is no swap at all. */
+export function shouldCarryIdentityAcrossSaveSwap({ preWf, postWf, savedAs = false } = {}) {
+  if (savedAs) return false;
+  if (!preWf || !postWf || typeof postWf !== "object") return false;
+  return preWf !== postWf && !sameWorkflowObject(preWf, postWf);
 }
 
 /** Return true when an embedded UUID belongs to a different workflow file.

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -559,7 +559,11 @@ export async function saveActiveWorkflow(
   }
   if (inPlace === "authorize") markPersistedForOverwrite(wf); // sync (post-assert) ⇒ no leak window
   recordOutcome(details, "in-place", { sourcePath: currentPath, targetPath: finalTargetPath });
-  await saveInPlace(svc, wf);
+  const savedRecord = await saveInPlace(svc, wf);
+  // r10 — thread the save API's own produced record (when it returns one) through
+  // details, so the identity carry can prove succession from the replacement
+  // EVENT. An empty/non-object return simply carries no thread (fail safe).
+  if (details && savedRecord && typeof savedRecord === "object") details.savedRecord = savedRecord;
   return desired || currentName || null;
 }
 
@@ -977,9 +981,13 @@ export function normalizePath(path) {
 }
 
 async function saveInPlace(svc, wf) {
-  if (typeof svc.saveWorkflow === "function") await svc.saveWorkflow(wf);
-  else if (typeof wf.save === "function") await wf.save();
-  else throw new Error("workflow save API unavailable on this frontend");
+  // Return the save API's own result: when it yields the workflow record it
+  // PRODUCED (a re-registered successor object), that is the one unambiguous
+  // replacement-event thread the identity carry can use (r10) — path occupancy
+  // proves nothing (a close→reopen occupies the same path with a new identity).
+  if (typeof svc.saveWorkflow === "function") return await svc.saveWorkflow(wf);
+  if (typeof wf.save === "function") return await wf.save();
+  throw new Error("workflow save API unavailable on this frontend");
 }
 
 /** True when `err` is a name-collision (HTTP 409) from the userdata write — the


### PR DESCRIPTION
## Root cause (one, shared by #545 / #557 / mcp#721)

The panel keeps per-workflow identity in **two carriers**:

1. a per-object WeakMap (`_workflowObjectUuids`) keyed on the live ComfyWorkflow object, and
2. the root graph tag `app.graph.extra.comfyui_mcp.workflow_uuid`.

A save (and some reconnect paths) **replaces the live ComfyWorkflow object**. The successor object has no WeakMap entry, and `workflowStableUuid()` minted a **fresh** uuid for it: the file it was just saved from still carries the pre-save embedded uuid, but that uuid was still registered as owned by the *replaced* object, and the anti-copy rule (`embeddedOwner !== identityObject → mint fresh`) fired. The root tag kept the pre-save uuid, so `graphRootWorkflowUuidMismatches()` failed closed on **every** `panel_*` graph tool — and nothing in the panel ever reconciled the two carriers, so no documented remedy (`panel_open_workflow`, `panel_set_workflow_target`, soft reloads) could clear it. Only a real frontend reload rebuilt the binding.

- **#557** — `panel_save_workflow` triggers exactly this object swap → instant, permanent desync.
- **#545** — the same drift on a dirty tab (state comparison already relaxed by #546; the UUID clause was the permanent block).
- **artokun/comfyui-mcp#721** — the same drift observed from the mcp side; the panel-side remedy (`workflow_open` proven rebind repaint) already landed in #554, this PR removes the drift + the non-recoverable guard it ran into.

## Fix (minimal, guard intent preserved)

- **`workflowStableUuid` (#557 root):** fork away from an owned embedded uuid **only while that owner is still an OPEN workflow tab** (the genuine co-open copy, #570). An owner that is no longer open was replaced — this object is its **successor** and *inherits* the identity, keeping the WeakMap cache and the root tag aligned. New pure helper `shouldForkEmbeddedUuidForLiveOwner` (lib/workflow-chat-identity.js).
- **`assertGraphBoundToActiveWorkflow` (#545/#721 recovery):** when the root tag conflicts, resolve the tag's owner. If it is **not another live, open workflow**, the tag is stale bookkeeping, not a foreign canvas — **re-stamp the root with the active identity and proceed** instead of throwing until a frontend reload. New pure helper `resolveGraphRootUuidRebind` (lib/graph-binding.js). A tag **positively owned by another open workflow** still throws — the #349 wrong-canvas data-loss protection is untouched, and the guard also still requires a positive UUID match for mutations on dirty tabs.
- **`loadGraphData` keepInstance branch:** record uuid ownership (one line) so every minted root tag has a resolvable owner and the orphaned-tag check can't misclassify a live tag as orphaned.

Not changed: the throw message (its remedy — `panel_open_workflow` — is now actually effective), the node-count/shape comparison clauses, and the dirty-tab mutation fencing.

## Tests

- `browser_tests/unit/graph-binding.test.mjs` — pure `resolveGraphRootUuidRebind` cases; harness now models tag ownership (`foreign-open` / `orphaned` / `untracked`): foreign-owned live tag still throws **and is not rewritten**; orphaned/untracked tags rebind (read + subsequent dirty mutation succeed, root re-stamped); new #557 saved-successor harness drives the real `workflowStableUuid` source: successor inherits pre-save uuid / genuine co-open copy still forks / post-save guard sees no mismatch.
- `browser_tests/unit/workflow-chat-identity.test.mjs` — pure `shouldForkEmbeddedUuidForLiveOwner` cases.
- `npm run test:unit`: **1590/1590 pass**; `npm run typecheck` (tsc --noEmit): clean. Playwright e2e not run (needs a live rig).

Closes #545
Closes #557
Refs artokun/comfyui-mcp#721