### PR TITLE
fix(#556): panel_run refuses scopeless full-graph execution (strict to_node_id)

### DIFF
--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -28,6 +28,7 @@ import {
   scopeUnverifiedError,
   createRunFetchInterceptor,
   createScopedRunGuard,
+  cancelPendingScopedQueueItem,
 } from "../../web/js/lib/run-scope-guard.js";
 import { resolveRunToNodeTarget } from "../../web/js/lib/subgraph-scope.js";
 
@@ -125,12 +126,15 @@ test("#556 scopeDroppedError: names the node and states NOTHING was queued", () 
 });
 
 test("#556 scopeUnverifiedError: truthful — nothing CONFIRMED queued, never claims a scoped run happened", () => {
-  const msg = scopeUnverifiedError({ toNodeId: 14, timeoutMs: 5000 });
-  assert.match(msg, /node 14/);
-  assert.match(msg, /could not be verified/);
-  assert.match(msg, /CONFIRMED queued/i);
-  assert.doesNotMatch(msg, /queued:\s*true/);
-  assert.doesNotMatch(msg, /Nothing was queued/, "a deferred post may still land — must not claim otherwise");
+  const lingering = scopeUnverifiedError({ toNodeId: 14, timeoutMs: 5000, cancelled: false, lingerMs: 600000 });
+  assert.match(lingering, /node 14/);
+  assert.match(lingering, /could not be verified/);
+  assert.match(lingering, /CONFIRMED queued/i);
+  assert.match(lingering, /sentinel/, "says the guard stays installed when cancellation was impossible");
+  assert.doesNotMatch(lingering, /Nothing was queued/, "a deferred post may still land — must not claim otherwise");
+  const cancelled = scopeUnverifiedError({ toNodeId: 14, timeoutMs: 5000, cancelled: true });
+  assert.match(cancelled, /REMOVED/);
+  assert.match(cancelled, /nothing was queued/i, "after a successful cancel, 'nothing was queued' is literally true");
 });
 
 // ---------------------------------------------------------------------------
@@ -230,19 +234,60 @@ test("#556 P1: an UNRELATED full run (different signature) during the window pas
   assert.equal(guard.state.dropped, null);
 });
 
-test("#556 P1: an unrelated SCOPED run (someone else's targets) passes through untouched", async () => {
+test("#556 P1: an unrelated SCOPED run (foreign signature, its own targets) passes through untouched", async () => {
   const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "other-scoped" }));
   let captured = null;
   const guard = createScopedRunGuard({
     origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
     onPromptId: (p) => (captured = p),
   });
-  const body = { prompt: OUR_OUTPUT, client_id: "x", partial_execution_targets: ["9"] };
+  const body = { prompt: { "1": { class_type: "LoadImage" }, "2": { class_type: "PreviewImage" } }, client_id: "x", partial_execution_targets: ["2"] };
   const res = await guard(...promptPost(body));
   assert.equal(spy.calls.length, 1);
   assert.equal(res.status, 200);
   assert.equal(captured, null, "another scope's prompt_id is never claimed as ours");
   assert.equal(guard.state.observed, 0);
+});
+
+test("#556 r2 P0-1: OUR signature with WRONG/EXTRA/PARTIAL targets is OUR corrupted dispatch — REFUSED with zero dispatch (not forwarded as 'someone else's')", async () => {
+  for (const badTargets of [["14", "9"], ["9"], ["14", "76:34"]]) {
+    const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "must-never-happen" }));
+    let dropped = null;
+    const guard = createScopedRunGuard({
+      origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
+      onScopeDropped: (m) => (dropped = m),
+    });
+    const body = { prompt: OUR_OUTPUT, client_id: "x", partial_execution_targets: badTargets };
+    const res = await guard(...promptPost(body));
+    assert.equal(spy.calls.length, 0, `targets ${JSON.stringify(badTargets)} must never leave the tab`);
+    assert.equal(res.status, 400);
+    assert.match(dropped, /node 14/);
+    assert.match(dropped, /instead of/, "scope_mismatch names what the body carried");
+    assert.equal(guard.state.observed, 0, "a corrupted dispatch never counts as observed");
+  }
+});
+
+test("#556 r2 P0-2: a FOREIGN post carrying the SAME targets does NOT satisfy observation — our deferred corrupted post is still refused afterwards", async () => {
+  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "foreign-pid" }));
+  let captured = null;
+  const guard = createScopedRunGuard({
+    origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
+    onPromptId: (p) => (captured = p),
+  });
+  // Another workflow whose prompt ALSO carries ["14"] but has a different node set.
+  const foreign = { prompt: { "14": { class_type: "SaveImage" }, "2": { class_type: "LoadImage" } }, client_id: "x", partial_execution_targets: ["14"] };
+  const foreignRes = await guard(...promptPost(foreign));
+  assert.equal(spy.calls.length, 1, "the foreign scoped run passes through");
+  assert.equal(foreignRes.status, 200);
+  assert.equal(guard.state.observed, 0, "same targets + different signature is NOT our dispatch");
+  assert.equal(captured, null, "its prompt_id is never claimed as ours");
+  // graph_run would still be waiting (observed==0) — and when OUR deferred
+  // corrupted post finally surfaces, the guard is still there to refuse it.
+  assert.equal(guard.state.dropped, null);
+  const spy2 = spy;
+  const res = await guard(...promptPost(OUR_FULL_BODY));
+  assert.equal(res.status, 400, "our scope-dropped dispatch is still refused");
+  assert.equal(spy2.calls.length, 1, "and never dispatches");
 });
 
 test("#556 P1: refusal is bounded by the batch — a same-signature full body BEYOND our batch count passes through", async () => {
@@ -308,10 +353,46 @@ test("#556 P0 TIMEOUT: nothing surfaces within the window ⇒ waitForVerdict fal
   assert.equal(guard.state.observed, 0);
   assert.equal(guard.state.dropped, null);
   assert.equal(spy.calls.length, 0);
-  // This is exactly the condition graph_run maps to scopeUnverifiedError:
-  // a truthful "could not verify — nothing confirmed queued", not queued:true.
-  const msg = scopeUnverifiedError({ toNodeId: 14, timeoutMs: 5000 });
-  assert.match(msg, /could not be verified/);
+});
+
+test("#556 r2 P0-3: timeout CANCELS our still-pending queue item — the deferred scope-dropped dispatch can never execute", () => {
+  // The frontend's pending list holds OUR deferred item (targets stored in
+  // either shape) plus a user's targetless full-run item and a foreign scoped
+  // item — only ours may be removed.
+  const ourItemArray = { number: 0, batchCount: 1, queueNodeIds: ["14"] };
+  const ourItemOptions = { number: 0, batchCount: 1, queueNodeIds: { queueNodeIds: ["14"] } };
+  const userFullRun = { number: 0, batchCount: 1, queueNodeIds: undefined };
+  const foreignScoped = { number: 0, batchCount: 1, queueNodeIds: ["9"] };
+  const app = { queueItems: [userFullRun, ourItemArray, foreignScoped, ourItemOptions] };
+  const res = cancelPendingScopedQueueItem(app, ["14"]);
+  assert.equal(res.accessible, true);
+  assert.equal(res.removed, 2, "both of our pending items are removed, in either stored shape");
+  assert.deepEqual(app.queueItems, [userFullRun, foreignScoped], "foreign items are never touched");
+});
+
+test("#556 r2 P0-3: cancellation is impossible on builds that hard-privatize queueItems ⇒ reported inaccessible (caller keeps the sentinel guard)", () => {
+  const res = cancelPendingScopedQueueItem({}, ["14"]);
+  assert.deepEqual(res, { accessible: false, removed: 0 });
+  assert.deepEqual(cancelPendingScopedQueueItem(null, ["14"]), { accessible: false, removed: 0 });
+});
+
+test("#556 r2 P0-3 SENTINEL: when cancellation failed, the guard (never restored) still refuses the late scope-dropped dispatch — zero dispatch post-timeout", async () => {
+  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "must-never-happen" }));
+  let dropped = null;
+  const guard = createScopedRunGuard({
+    origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
+    onScopeDropped: (m) => (dropped = m),
+  });
+  // The give-up path: timeout expired, cancelPendingScopedQueueItem removed
+  // nothing, so graph_run leaves THIS guard installed and returns unverified.
+  const seen = await guard.waitForVerdict(50);
+  assert.equal(seen, false, "timed out unverified");
+  // …the deferred item finally posts, well after the run returned.
+  await sleep(20);
+  const res = await guard(...promptPost(OUR_FULL_BODY));
+  assert.equal(res.status, 400, "the sentinel still refuses the scope-dropped dispatch");
+  assert.equal(spy.calls.length, 0, "no full-graph dispatch ever escapes — even after the timeout");
+  assert.match(dropped, /node 14/);
 });
 
 // ---------------------------------------------------------------------------

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -20,7 +20,7 @@ import {
   queuePromptScopeArgs,
   promptContentHash,
   promptContentHashFromBody,
-  collectSelfMutatingInputNames,
+  collectVolatileInputs,
   verifyScopedPromptBody,
   scopeDroppedError,
   scopeUnverifiedError,
@@ -177,26 +177,30 @@ test("#556 r7 promptContentHash: full CONTENT covered (ids, class types, links, 
   assert.notEqual(promptContentHash({ "9": { class_type: "B", inputs: { steps: 20, model: ["4", 0] } }, "3": { class_type: "A", inputs: {} } }), a,
     "a changed LINK changes the hash");
   assert.notEqual(promptContentHash({ "3": { class_type: "A" } }), a, "a changed node set changes the hash");
-  // The ONLY tolerance: inputs whose widgets self-mutate at queue time.
-  const withSeed = (seed) => promptContentHash(
-    { "3": { class_type: "KSampler", inputs: { seed, steps: 20 } } },
-    new Set(["seed"]),
+  // The ONLY tolerance: inputs whose OWNING widget self-mutates at queue
+  // time — PER-NODE pairs (r8), never a global input name.
+  const withSeed = (seed, node = "3") => promptContentHash(
+    { "3": { class_type: "KSampler", inputs: { seed, steps: 20 } }, "5": { class_type: "KSampler", inputs: { seed: 222, steps: 20 } } },
+    new Set([`${node} seed`]),
   );
-  assert.equal(withSeed(1), withSeed(999), "a self-mutating (beforeQueued) input is excluded — our own dispatch isn't refused over a rerolled seed");
+  assert.equal(withSeed(1), withSeed(999), "the hook node's rerolled seed is excluded");
+  assert.notEqual(withSeed(1, "3"), withSeed(999, "5"),
+    "excluding node 3's 'seed' does NOT hide an edit to node 5's same-named input");
   assert.equal(promptContentHashFromBody(JSON.stringify({ prompt: OUR_OUTPUT })), OUR_HASH);
   assert.equal(promptContentHashFromBody("not-json{"), null);
 });
 
-test("#556 r7 collectSelfMutatingInputNames: finds beforeQueued widgets across the root graph and nested subgraphs", () => {
+test("#556 r8 collectVolatileInputs: per-NODE pairs (execId + input name) across the root graph and nested subgraphs", () => {
   const root = {
     _nodes: [
       { id: 1, widgets: [{ name: "seed", beforeQueued() {} }, { name: "steps" }] },
       { id: 2, widgets: null, subgraph: { _nodes: [{ id: 3, widgets: [{ name: "noise_seed", beforeQueued() {} }] }] } },
     ],
   };
-  const names = collectSelfMutatingInputNames(root);
-  assert.deepEqual([...names].sort(), ["noise_seed", "seed"]);
-  assert.equal(collectSelfMutatingInputNames(null).size, 0);
+  const pairs = collectVolatileInputs(root);
+  assert.deepEqual([...pairs].sort(), ["1 seed", "2:3 noise_seed"],
+    "root node ⇒ String(id); nested node ⇒ colon-joined subgraph-instance path");
+  assert.equal(collectVolatileInputs(null).size, 0);
 });
 
 test("#556 verifyScopedPromptBody: exact scope passes; missing/empty/wrong/extra/unparseable all refuse", () => {
@@ -559,8 +563,9 @@ test("#556 r7 integration: a deferred post differing ONLY in a self-mutating (be
     };
     // The live graph has a beforeQueued seed widget — its value is excluded
     // from the content hash, so a rerolled seed can't refuse our own dispatch.
+    // app.graph is the panel's live root (production shape, r8).
     const app = makeFrontend({ shape: "shim", defer: true, apiTarget, output: outputAtQueue });
-    app.rootGraph = { _nodes: [{ id: 3, widgets: [{ name: "seed", beforeQueued() {} }, { name: "steps" }] }] };
+    app.graph = { _nodes: [{ id: 3, widgets: [{ name: "seed", beforeQueued() {} }, { name: "steps" }] }] };
     const ids = [];
     const promise = dispatchScopedRun({
       app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
@@ -583,6 +588,56 @@ test("#556 r7 integration: a deferred post differing ONLY in a self-mutating (be
     assert.equal(result.outcome, "dispatched", "a rerolled seed does not refuse our own dispatch");
     assert.deepEqual(ids, ["srv-1"]);
     assert.equal(server.calls.length, 1);
+  } finally {
+    stop();
+  }
+});
+
+test("#556 r8 integration: an edit to a NON-hook node's same-named input is STILL detected as drift (per-node exclusions) — while the hook node's reroll is tolerated", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const outputAtQueue = {
+      "3": { class_type: "KSampler", inputs: { seed: 111, steps: 20 } }, // hook node
+      "5": { class_type: "KSampler", inputs: { seed: 222, steps: 20 } }, // NON-hook node, same input name
+      "14": { class_type: "PreviewAny", inputs: {} },
+    };
+    const app = makeFrontend({ shape: "shim", defer: true, apiTarget, output: outputAtQueue });
+    // app.graph is the panel's live root (production shape): only node 3 has the hook.
+    app.graph = {
+      _nodes: [
+        { id: 3, widgets: [{ name: "seed", beforeQueued() {} }, { name: "steps" }] },
+        { id: 5, widgets: [{ name: "seed" }, { name: "steps" }] },
+      ],
+    };
+    const promise = dispatchScopedRun({
+      app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
+      verifyTimeoutMs: 500,
+    });
+    await sleep(20);
+    // The deferred post: node 3's seed rerolled (legitimate beforeQueued) AND
+    // node 5's seed edited (a real user edit — must NOT hide behind node 3's
+    // exclusion).
+    app.postDeferred = async (item) => {
+      const body = frontendBody({
+        output: {
+          ...outputAtQueue,
+          "3": { class_type: "KSampler", inputs: { seed: 999999, steps: 20 } },
+          "5": { class_type: "KSampler", inputs: { seed: 777, steps: 20 } },
+        },
+        number: item.number,
+        targets: ["14"],
+      });
+      app.posted.push(body);
+      return apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
+    };
+    const res = await app.postDeferred(app.deferredItem);
+    const result = await promise;
+    assert.equal(res.status, 400, "the edit to the NON-hook node's seed is drift — refused");
+    assert.equal(result.outcome, "refused");
+    assert.match(result.error, /graph CHANGED/i);
+    assert.equal(server.calls.length, 0, "the edited workflow never left the tab");
   } finally {
     stop();
   }

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -15,7 +15,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
-  SCOPED_QUEUE_MARK,
+  newScopedQueueMark,
   QUEUE_ITEM_TAG,
   queuePromptScopeArgs,
   promptSignature,
@@ -84,8 +84,12 @@ function keepAlive() {
   return () => clearInterval(ka);
 }
 
+// Two run marks for the tests (what newScopedQueueMark hands out per run).
+const MARK_A = 2 ** 30 - 1 - 1;
+const MARK_B = 2 ** 30 - 1 - 2;
+
 // Bodies the way the frontend's api.queuePrompt builds them.
-function frontendBody({ output = OUR_OUTPUT, number = SCOPED_QUEUE_MARK, targets = null }) {
+function frontendBody({ output = OUR_OUTPUT, number = MARK_A, targets = null }) {
   const body = { prompt: output, client_id: "x" };
   if (targets) body.partial_execution_targets = targets;
   if (number === -1) body.front = true;
@@ -187,7 +191,7 @@ test("#556 error messages: dropped names the node + nothing queued; unverified d
   const cancelled = scopeUnverifiedError({ toNodeId: 14, timeoutMs: 5000, cancelled: true });
   assert.match(cancelled, /REMOVED/);
   assert.match(cancelled, /nothing was queued/i);
-  const sentinel = scopeUnverifiedError({ toNodeId: 14, timeoutMs: 5000, cancelled: false, lingerMs: 600000 });
+  const sentinel = scopeUnverifiedError({ toNodeId: 14, timeoutMs: 5000, cancelled: false });
   assert.match(sentinel, /sentinel/);
   assert.match(sentinel, /CONFIRMED queued/i);
   const unattributable = scopeUnattributableError({ toNodeId: 14 });
@@ -223,7 +227,7 @@ test("#556 unscoped interceptor: captures top-level rejection and prompt_id, lea
 test("#556 guard: OUR marked post with signature+exact targets ⇒ observed, dispatched verbatim, prompt_id captured", async () => {
   const spy = makeServer();
   const ids = [];
-  const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14, onPromptId: (p) => ids.push(p) });
+  const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14, queueMark: MARK_A, onPromptId: (p) => ids.push(p) });
   const [route, options] = promptPost(frontendBody({ targets: ["14"] }));
   const res = await guard(route, options);
   assert.equal(spy.calls.length, 1);
@@ -237,7 +241,7 @@ test("#556 guard: OUR marked post with MISSING or WRONG/EXTRA targets ⇒ refuse
   for (const bad of [null, ["9"], ["14", "9"]]) {
     const spy = makeServer();
     let dropped = null;
-    const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14, onScopeDropped: (m) => (dropped = m) });
+    const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14, queueMark: MARK_A, onScopeDropped: (m) => (dropped = m) });
     const res = await guard(...promptPost(frontendBody({ targets: bad })));
     assert.equal(spy.calls.length, 0, `targets ${JSON.stringify(bad)} must never leave the tab`);
     assert.equal(res.status, 400);
@@ -269,7 +273,7 @@ test("#556 r3 P0-3: an UNMARKED post is FOREIGN even with our node set AND our t
 
 test("#556 guard: a marked post whose graph CHANGED under the deferred item (signature mismatch) is corrupted ⇒ refused", async () => {
   const spy = makeServer();
-  const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14 });
+  const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14, queueMark: MARK_A });
   const changedOutput = { "3": { class_type: "KSampler" }, "20": { class_type: "SaveImage" } };
   const res = await guard(...promptPost(frontendBody({ output: changedOutput, targets: ["14"] })));
   assert.equal(res.status, 400, "scope is unverifiable against the changed graph — refuse");
@@ -280,23 +284,37 @@ test("#556 guard: a marked post whose graph CHANGED under the deferred item (sig
 // cancelPendingScopedQueueItem — ownership-tagged removal
 // ---------------------------------------------------------------------------
 
-test("#556 r3 P0-3: cancellation removes ONLY the ownership-tagged item — an identical-scope foreign item stays", () => {
+test("#556 r3/r4: cancellation removes ONLY the ownership-tagged item with THIS run's mark — tag without the mark, and foreign items, stay", () => {
   const runTag = Symbol("t");
   const ourArray = ["14"];
   Object.defineProperty(ourArray, QUEUE_ITEM_TAG, { value: runTag, enumerable: false });
-  const ourOptionsItem = { number: 1, batchCount: 1, queueNodeIds: { queueNodeIds: ourArray } };
-  const ourDirectItem = { number: 1, batchCount: 1, queueNodeIds: ourArray };
+  const ourOptionsItem = { number: MARK_A, batchCount: 1, queueNodeIds: { queueNodeIds: ourArray } };
+  const ourDirectItem = { number: MARK_A, batchCount: 1, queueNodeIds: ourArray };
+  // Same tag but a DIFFERENT run's mark — never ours (paranoia; can't happen
+  // in practice since tag and mark are minted together).
+  const wrongMarkItem = { number: MARK_B, batchCount: 1, queueNodeIds: ourArray };
   const foreignSameScope = { number: 0, batchCount: 1, queueNodeIds: ["14"] };
   const userFullRun = { number: 0, batchCount: 1, queueNodeIds: undefined };
-  const app = { queueItems: [userFullRun, foreignSameScope, ourDirectItem, ourOptionsItem] };
-  const res = cancelPendingScopedQueueItem(app, runTag);
+  const app = { queueItems: [userFullRun, wrongMarkItem, foreignSameScope, ourDirectItem, ourOptionsItem] };
+  const res = cancelPendingScopedQueueItem(app, { runTag, queueMark: MARK_A });
   assert.equal(res.accessible, true);
   assert.equal(res.removed, 2, "our item removed in either stored shape");
-  assert.deepEqual(app.queueItems, [userFullRun, foreignSameScope], "identical-scope foreign item and user run stay");
+  assert.deepEqual(app.queueItems, [userFullRun, wrongMarkItem, foreignSameScope], "mark-mismatched and foreign items stay");
 });
 
 test("#556 r3 P0-3: hard-private queueItems builds ⇒ inaccessible (caller keeps the sentinel)", () => {
-  assert.deepEqual(cancelPendingScopedQueueItem({}, Symbol("t")), { accessible: false, removed: 0 });
+  assert.deepEqual(cancelPendingScopedQueueItem({}, { runTag: Symbol("t"), queueMark: MARK_A }), { accessible: false, removed: 0 });
+});
+
+test("#556 r4 P0-2: newScopedQueueMark is unique per run, nonzero, a safe integer near 2^30 (sorts to the queue end)", () => {
+  const a = newScopedQueueMark();
+  const b = newScopedQueueMark();
+  assert.notEqual(a, b, "two runs never share a mark — a sentinel can't claim a later run's traffic");
+  for (const m of [a, b]) {
+    assert.ok(Number.isSafeInteger(m));
+    assert.ok(m > 0);
+    assert.ok(m <= 2 ** 30 - 1 && m > 2 ** 29, "large enough to always append at the priority-queue end");
+  }
 });
 
 // ---------------------------------------------------------------------------
@@ -318,7 +336,7 @@ test("#556 integration: happy path — marked scoped dispatch observed, prompt_i
     assert.deepEqual(ids, ["srv-1"]);
     assert.equal(apiTarget.fetchApi, prev, "guard restored after observation");
     assert.equal(app.posted.length, 1, "first arg shape worked — no retry");
-    assert.equal(app.posted[0].number, SCOPED_QUEUE_MARK, "our posts carry the queue mark");
+    assert.equal(app.posted[0].number, result.queueMark, "our posts carry THIS run's queue mark");
     assert.deepEqual(app.posted[0].partial_execution_targets, ["14"]);
   } finally {
     stop();
@@ -363,7 +381,7 @@ test("#556 integration: a build honoring NEITHER shape ⇒ truthful refusal, ZER
   }
 });
 
-test("#556 r3 P0-1 integration: THE SENTINEL ACTUALLY INSTALLS — after a give-up timeout, api.fetchApi is STILL the guard and refuses the late scope-dropped post with zero dispatch", async () => {
+test("#556 r4 P0-1 integration: THE SENTINEL INSTALLS AND NEVER EXPIRES — still installed past the old linger bound, still refusing the late scope-dropped post with zero dispatch", async () => {
   const stop = keepAlive();
   try {
     const apiTarget = { fetchApi: makeServer() };
@@ -374,18 +392,61 @@ test("#556 r3 P0-1 integration: THE SENTINEL ACTUALLY INSTALLS — after a give-
     delete app.queueItems;
     const result = await dispatchScopedRun({
       app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
-      verifyTimeoutMs: 50, lingerMs: 120,
+      verifyTimeoutMs: 50,
     });
     assert.equal(result.outcome, "unverified");
     assert.match(result.error, /sentinel/);
+    assert.match(result.error, /page session/);
     assert.notEqual(apiTarget.fetchApi, prev, "the sentinel guard is STILL installed after the run returned");
+    // Well past where the r3 linger timer would have restored fetchApi (120ms).
+    await sleep(200);
+    assert.notEqual(apiTarget.fetchApi, prev, "NO expiry — an expiring sentinel re-opens the hole: the uncancellable item can post whenever the stalled processor resumes");
     // The deferred item finally posts — through the sentinel — scope dropped.
     const res = await app.postDeferred(app.deferredItem);
-    assert.equal(res.status, 400, "the sentinel refuses the late scope-dropped dispatch");
-    assert.equal(prev.calls.length, 0, "no full-graph dispatch escapes — even after the timeout");
-    // …and the sentinel self-removes at the long bound.
-    await sleep(160);
-    assert.equal(apiTarget.fetchApi, prev, "sentinel self-removes at the linger bound");
+    assert.equal(res.status, 400, "the sentinel STILL refuses the late scope-dropped dispatch");
+    assert.equal(prev.calls.length, 0, "no full-graph dispatch escapes — ever");
+    assert.notEqual(apiTarget.fetchApi, prev, "installed for the rest of the page session");
+  } finally {
+    stop();
+  }
+});
+
+test("#556 r4 P0-2 integration: two overlapping scoped runs — B's traffic passes A's sentinel untouched, B is observed by its own guard, A's sentinel still only constrains A's items, guards chain without clobbering", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const prev = apiTarget.fetchApi;
+    // RUN A: busy shim-less frontend, deferred, uncancellable ⇒ sentinel.
+    const appA = makeFrontend({ shape: "shimless", defer: true, apiTarget });
+    delete appA.queueItems;
+    const resultA = await dispatchScopedRun({
+      app: appA, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
+      verifyTimeoutMs: 50,
+    });
+    assert.equal(resultA.outcome, "unverified");
+    const sentinelA = apiTarget.fetchApi;
+    assert.notEqual(sentinelA, prev, "run A left its sentinel installed");
+
+    // RUN B: a normal retry to a DIFFERENT node through the SAME apiTarget.
+    // B's posts carry B's OWN unique mark — foreign to A's sentinel.
+    const appB = makeFrontend({ shape: "shim", apiTarget });
+    const idsB = [];
+    const resultB = await dispatchScopedRun({
+      app: appB, apiTarget, execIds: ["15"], batch: 1, toNodeId: 15,
+      onPromptId: (p) => idsB.push(p),
+    });
+    assert.equal(resultB.outcome, "dispatched", "B runs normally behind A's sentinel");
+    assert.notEqual(resultB.queueMark, resultA.queueMark, "each run has its own mark");
+    assert.deepEqual(idsB, ["srv-1"], "B's prompt_id captured by B's guard, never by A's sentinel");
+    assert.equal(server.calls.length, 1, "B's scoped dispatch reached the server THROUGH A's sentinel, untouched");
+    assert.deepEqual(JSON.parse(server.calls[0].options.body).partial_execution_targets, ["15"]);
+    // Chaining: B restored the wrap that was current when IT installed — A's sentinel.
+    assert.equal(apiTarget.fetchApi, sentinelA, "B's cleanup did not clobber A's sentinel");
+    // A's late scope-dropped post is STILL refused by A's sentinel.
+    const resA = await appA.postDeferred(appA.deferredItem);
+    assert.equal(resA.status, 400, "A's sentinel still constrains exactly A's items");
+    assert.equal(server.calls.length, 1, "A's corrupted dispatch never escapes");
   } finally {
     stop();
   }
@@ -401,7 +462,7 @@ test("#556 r3 P0-3 integration: timeout CANCELS our tagged pending item (assert 
     app.queueItems.push({ number: 0, batchCount: 1, queueNodeIds: ["14"] });
     const result = await dispatchScopedRun({
       app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
-      verifyTimeoutMs: 50, lingerMs: 1000,
+      verifyTimeoutMs: 50,
     });
     assert.equal(result.outcome, "unverified");
     assert.match(result.error, /REMOVED/);
@@ -441,7 +502,7 @@ test("#556 r3 P0-3 integration: foreign traffic during our window is untouched �
     const ids = [];
     const promise = dispatchScopedRun({
       app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
-      verifyTimeoutMs: 500, lingerMs: 1000,
+      verifyTimeoutMs: 500,
       onPromptId: (p) => ids.push(p),
     });
     await sleep(20); // guard is installed, waiting for observation

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -452,6 +452,106 @@ test("#556 r4 P0-2 integration: two overlapping scoped runs — B's traffic pass
   }
 });
 
+test("#556 r5 integration: batch=2 with the first post verified and the second scope-dropped ⇒ REFUSED with truthful counts, NO escape, never 'dispatched'", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const app = makeFrontend({ shape: "shim", apiTarget });
+    // The frontend's batch loop: post 1 keeps its scope, post 2 loses it, and
+    // the loop breaks on the refusal (so nothing further posts).
+    app.queuePrompt = async (number, batch, arg) => {
+      for (let i = 0; i < batch; i++) {
+        const targets = i === 0 ? ["14"] : null;
+        const body = frontendBody({ output: OUR_OUTPUT, number, targets });
+        app.posted.push(body);
+        const res = await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
+        if (res.status !== 200) return true;
+      }
+      return true;
+    };
+    const ids = [];
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["14"], batch: 2, toNodeId: 14,
+      onPromptId: (p) => ids.push(p),
+    });
+    assert.notEqual(result.outcome, "dispatched", "never dispatched on a partially-verified batch");
+    assert.equal(result.outcome, "refused");
+    assert.equal(result.verified, 1);
+    assert.match(result.error, /1 of 2/);
+    assert.match(result.error, /did NOT execute/);
+    assert.equal(server.calls.length, 1, "only the verified scoped post left the tab — the scope-dropped one was refused");
+    assert.deepEqual(ids, ["srv-1"], "the verified prompt_id was captured (ledger-eligible)");
+  } finally {
+    stop();
+  }
+});
+
+test("#556 r5 integration: batch=2 FULLY verified ⇒ dispatched (guard held until BOTH posts verify)", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const prev = apiTarget.fetchApi;
+    const app = makeFrontend({ shape: "shim", apiTarget });
+    app.queuePrompt = async (number, batch, arg) => {
+      for (let i = 0; i < batch; i++) {
+        const body = frontendBody({ output: OUR_OUTPUT, number, targets: ["14"] });
+        app.posted.push(body);
+        await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
+      }
+      return true;
+    };
+    const ids = [];
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["14"], batch: 2, toNodeId: 14,
+      onPromptId: (p) => ids.push(p),
+    });
+    assert.equal(result.outcome, "dispatched");
+    assert.equal(result.verified, 2);
+    assert.deepEqual(ids, ["srv-1", "srv-2"], "every batch prompt_id captured");
+    assert.equal(server.calls.length, 2);
+    assert.equal(apiTarget.fetchApi, prev, "guard restored once the whole batch verified");
+  } finally {
+    stop();
+  }
+});
+
+test("#556 r5 integration: batch=2 where the second post NEVER arrives ⇒ unverified naming the verified count, sentinel guards the rest", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const app = makeFrontend({ shape: "shim", apiTarget });
+    // Posts only the FIRST of the batch, then the processor stalls silently.
+    app.queuePrompt = async (number, batch, arg) => {
+      const body = frontendBody({ output: OUR_OUTPUT, number, targets: ["14"] });
+      app.posted.push(body);
+      await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
+      return true;
+    };
+    const ids = [];
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["14"], batch: 2, toNodeId: 14,
+      verifyTimeoutMs: 60,
+      onPromptId: (p) => ids.push(p),
+    });
+    assert.equal(result.outcome, "unverified");
+    assert.equal(result.verified, 1);
+    assert.match(result.error, /1 of 2/, "the error names how many of the batch were verified");
+    assert.match(result.error, /sentinel/);
+    // The stalled second post finally arrives, scope-dropped ⇒ sentinel refuses it.
+    const res = await apiTarget.fetchApi("/prompt", {
+      method: "POST",
+      body: JSON.stringify(frontendBody({ output: OUR_OUTPUT, number: result.queueMark, targets: null })),
+    });
+    assert.equal(res.status, 400, "the sentinel refuses the late scope-dropped batch post");
+    assert.equal(server.calls.length, 1, "only the one verified scoped post ever left the tab");
+  } finally {
+    stop();
+  }
+});
+
 test("#556 r3 P0-3 integration: timeout CANCELS our tagged pending item (assert the removal) — guard restored, no sentinel", async () => {
   const stop = keepAlive();
   try {

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -72,6 +72,18 @@ const OUR_SIGNATURE = promptSignature(OUR_OUTPUT);
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+// Node 22's test runner exits the process early — cancelling every pending
+// test with "Promise resolution is still pending but the event loop has
+// already resolved" — when a test's pending promise depends SOLELY on UNREF'd
+// timers (the guard's verify-timeout and sentinel linger are unref'd BY DESIGN
+// so they never hold a real process's event loop; that production behavior
+// must not change). A REF'd interval keeps the loop alive for the duration of
+// an integration test; cleared in finally so it never leaks past the test.
+function keepAlive() {
+  const ka = setInterval(() => {}, 25);
+  return () => clearInterval(ka);
+}
+
 // Bodies the way the frontend's api.queuePrompt builds them.
 function frontendBody({ output = OUR_OUTPUT, number = SCOPED_QUEUE_MARK, targets = null }) {
   const body = { prompt: output, client_id: "x" };
@@ -292,128 +304,163 @@ test("#556 r3 P0-3: hard-private queueItems builds ⇒ inaccessible (caller keep
 // ---------------------------------------------------------------------------
 
 test("#556 integration: happy path — marked scoped dispatch observed, prompt_id captured, fetchApi restored", async () => {
-  const apiTarget = { fetchApi: makeServer() };
-  const prev = apiTarget.fetchApi;
-  const app = makeFrontend({ shape: "shim", apiTarget });
-  const ids = [];
-  const result = await dispatchScopedRun({
-    app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
-    onPromptId: (p) => ids.push(p),
-  });
-  assert.equal(result.outcome, "dispatched");
-  assert.deepEqual(ids, ["srv-1"]);
-  assert.equal(apiTarget.fetchApi, prev, "guard restored after observation");
-  assert.equal(app.posted.length, 1, "first arg shape worked — no retry");
-  assert.equal(app.posted[0].number, SCOPED_QUEUE_MARK, "our posts carry the queue mark");
-  assert.deepEqual(app.posted[0].partial_execution_targets, ["14"]);
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const prev = apiTarget.fetchApi;
+    const app = makeFrontend({ shape: "shim", apiTarget });
+    const ids = [];
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
+      onPromptId: (p) => ids.push(p),
+    });
+    assert.equal(result.outcome, "dispatched");
+    assert.deepEqual(ids, ["srv-1"]);
+    assert.equal(apiTarget.fetchApi, prev, "guard restored after observation");
+    assert.equal(app.posted.length, 1, "first arg shape worked — no retry");
+    assert.equal(app.posted[0].number, SCOPED_QUEUE_MARK, "our posts carry the queue mark");
+    assert.deepEqual(app.posted[0].partial_execution_targets, ["14"]);
+  } finally {
+    stop();
+  }
 });
 
 test("#556 integration: a shim-less options build drops the legacy array — attempt 1 refused with ZERO dispatch, attempt 2 delivers", async () => {
-  const apiTarget = { fetchApi: makeServer() };
-  const app = makeFrontend({ shape: "shimless", apiTarget });
-  const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
-  assert.equal(result.outcome, "dispatched");
-  assert.equal(app.posted.length, 2, "both shapes attempted");
-  assert.equal(app.posted[0].partial_execution_targets, undefined, "attempt 1 (array) dropped by this build");
-  assert.equal(apiTarget.fetchApi.calls.length, 1, "only the correctly-shaped dispatch reached the server");
-  assert.deepEqual(apiTarget.fetchApi.calls[0].options.body && JSON.parse(apiTarget.fetchApi.calls[0].options.body).partial_execution_targets, ["14"]);
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeFrontend({ shape: "shimless", apiTarget });
+    const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
+    assert.equal(result.outcome, "dispatched");
+    assert.equal(app.posted.length, 2, "both shapes attempted");
+    assert.equal(app.posted[0].partial_execution_targets, undefined, "attempt 1 (array) dropped by this build");
+    assert.equal(apiTarget.fetchApi.calls.length, 1, "only the correctly-shaped dispatch reached the server");
+    assert.deepEqual(apiTarget.fetchApi.calls[0].options.body && JSON.parse(apiTarget.fetchApi.calls[0].options.body).partial_execution_targets, ["14"]);
+  } finally {
+    stop();
+  }
 });
 
 test("#556 integration: a build honoring NEITHER shape ⇒ truthful refusal, ZERO dispatches", async () => {
-  const apiTarget = { fetchApi: makeServer() };
-  const app = makeFrontend({ shape: "positional", apiTarget });
-  // positional honors the array… force neither by overriding queuePrompt to always drop targets
-  app.queuePrompt = async (number, batch) => {
-    const body = frontendBody({ output: OUR_OUTPUT, number, targets: null });
-    app.posted.push(body);
-    await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
-    return true;
-  };
-  const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
-  assert.equal(result.outcome, "refused");
-  assert.match(result.error, /node 14/);
-  assert.match(result.error, /Nothing was queued/);
-  assert.equal(apiTarget.fetchApi.calls.length, 0, "no full-graph prompt ever left the tab");
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeFrontend({ shape: "positional", apiTarget });
+    // positional honors the array… force neither by overriding queuePrompt to always drop targets
+    app.queuePrompt = async (number, batch) => {
+      const body = frontendBody({ output: OUR_OUTPUT, number, targets: null });
+      app.posted.push(body);
+      await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
+      return true;
+    };
+    const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
+    assert.equal(result.outcome, "refused");
+    assert.match(result.error, /node 14/);
+    assert.match(result.error, /Nothing was queued/);
+    assert.equal(apiTarget.fetchApi.calls.length, 0, "no full-graph prompt ever left the tab");
+  } finally {
+    stop();
+  }
 });
 
 test("#556 r3 P0-1 integration: THE SENTINEL ACTUALLY INSTALLS — after a give-up timeout, api.fetchApi is STILL the guard and refuses the late scope-dropped post with zero dispatch", async () => {
-  const apiTarget = { fetchApi: makeServer() };
-  const prev = apiTarget.fetchApi;
-  // Busy SHIM-LESS frontend (drops the legacy array ⇒ the deferred item has no
-  // scope), and queueItems NOT accessible (hard-private build) ⇒ cancel impossible.
-  const app = makeFrontend({ shape: "shimless", defer: true, apiTarget });
-  delete app.queueItems;
-  const result = await dispatchScopedRun({
-    app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
-    verifyTimeoutMs: 50, lingerMs: 120,
-  });
-  assert.equal(result.outcome, "unverified");
-  assert.match(result.error, /sentinel/);
-  assert.notEqual(apiTarget.fetchApi, prev, "the sentinel guard is STILL installed after the run returned");
-  // The deferred item finally posts — through the sentinel — scope dropped.
-  const res = await app.postDeferred(app.deferredItem);
-  assert.equal(res.status, 400, "the sentinel refuses the late scope-dropped dispatch");
-  assert.equal(prev.calls.length, 0, "no full-graph dispatch escapes — even after the timeout");
-  // …and the sentinel self-removes at the long bound.
-  await sleep(160);
-  assert.equal(apiTarget.fetchApi, prev, "sentinel self-removes at the linger bound");
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const prev = apiTarget.fetchApi;
+    // Busy SHIM-LESS frontend (drops the legacy array ⇒ the deferred item has no
+    // scope), and queueItems NOT accessible (hard-private build) ⇒ cancel impossible.
+    const app = makeFrontend({ shape: "shimless", defer: true, apiTarget });
+    delete app.queueItems;
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
+      verifyTimeoutMs: 50, lingerMs: 120,
+    });
+    assert.equal(result.outcome, "unverified");
+    assert.match(result.error, /sentinel/);
+    assert.notEqual(apiTarget.fetchApi, prev, "the sentinel guard is STILL installed after the run returned");
+    // The deferred item finally posts — through the sentinel — scope dropped.
+    const res = await app.postDeferred(app.deferredItem);
+    assert.equal(res.status, 400, "the sentinel refuses the late scope-dropped dispatch");
+    assert.equal(prev.calls.length, 0, "no full-graph dispatch escapes — even after the timeout");
+    // …and the sentinel self-removes at the long bound.
+    await sleep(160);
+    assert.equal(apiTarget.fetchApi, prev, "sentinel self-removes at the linger bound");
+  } finally {
+    stop();
+  }
 });
 
 test("#556 r3 P0-3 integration: timeout CANCELS our tagged pending item (assert the removal) — guard restored, no sentinel", async () => {
-  const apiTarget = { fetchApi: makeServer() };
-  const prev = apiTarget.fetchApi;
-  const app = makeFrontend({ shape: "shim", defer: true, apiTarget });
-  // A foreign identical-scope item also pending — must survive.
-  app.queueItems.push({ number: 0, batchCount: 1, queueNodeIds: ["14"] });
-  const result = await dispatchScopedRun({
-    app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
-    verifyTimeoutMs: 50, lingerMs: 1000,
-  });
-  assert.equal(result.outcome, "unverified");
-  assert.match(result.error, /REMOVED/);
-  assert.equal(app.queueItems.length, 1, "ONLY our tagged item was removed");
-  assert.deepEqual(app.queueItems[0].queueNodeIds, ["14"]);
-  assert.equal(apiTarget.fetchApi, prev, "guard restored — no sentinel needed after a successful cancel");
-  assert.equal(apiTarget.fetchApi.calls.length, 0, "nothing was ever dispatched");
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const prev = apiTarget.fetchApi;
+    const app = makeFrontend({ shape: "shim", defer: true, apiTarget });
+    // A foreign identical-scope item also pending — must survive.
+    app.queueItems.push({ number: 0, batchCount: 1, queueNodeIds: ["14"] });
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
+      verifyTimeoutMs: 50, lingerMs: 1000,
+    });
+    assert.equal(result.outcome, "unverified");
+    assert.match(result.error, /REMOVED/);
+    assert.equal(app.queueItems.length, 1, "ONLY our tagged item was removed");
+    assert.deepEqual(app.queueItems[0].queueNodeIds, ["14"]);
+    assert.equal(apiTarget.fetchApi, prev, "guard restored — no sentinel needed after a successful cancel");
+    assert.equal(apiTarget.fetchApi.calls.length, 0, "nothing was ever dispatched");
+  } finally {
+    stop();
+  }
 });
 
 test("#556 r3 P0-2 integration: degraded mode FAILS CLOSED — graphToPrompt failure refuses BEFORE queuePrompt (never 'dispatch and hope')", async () => {
-  const apiTarget = { fetchApi: makeServer() };
-  const app = makeFrontend({ shape: "shim", apiTarget, failGraphToPrompt: true });
-  let queuePromptCalled = false;
-  const origQP = app.queuePrompt;
-  app.queuePrompt = async (...a) => { queuePromptCalled = true; return origQP(...a); };
-  const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
-  assert.equal(result.outcome, "unverifiable");
-  assert.match(result.error, /cannot be dispatched safely/);
-  assert.equal(queuePromptCalled, false, "queuePrompt is never called without a signature");
-  assert.equal(apiTarget.fetchApi.calls.length, 0, "nothing dispatched — the failure is closed, not open");
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeFrontend({ shape: "shim", apiTarget, failGraphToPrompt: true });
+    let queuePromptCalled = false;
+    const origQP = app.queuePrompt;
+    app.queuePrompt = async (...a) => { queuePromptCalled = true; return origQP(...a); };
+    const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
+    assert.equal(result.outcome, "unverifiable");
+    assert.match(result.error, /cannot be dispatched safely/);
+    assert.equal(queuePromptCalled, false, "queuePrompt is never called without a signature");
+    assert.equal(apiTarget.fetchApi.calls.length, 0, "nothing dispatched — the failure is closed, not open");
+  } finally {
+    stop();
+  }
 });
 
 test("#556 r3 P0-3 integration: foreign traffic during our window is untouched — same-graph user full run + identical-scope foreign scoped run; only OUR marked post is observed and captured", async () => {
-  const server = makeServer();
-  const apiTarget = { fetchApi: server };
-  const app = makeFrontend({ shape: "shim", defer: true, apiTarget });
-  const ids = [];
-  const promise = dispatchScopedRun({
-    app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
-    verifyTimeoutMs: 500, lingerMs: 1000,
-    onPromptId: (p) => ids.push(p),
-  });
-  await sleep(20); // guard is installed, waiting for observation
-  // A user queues a full run of the SAME graph (UI: number=0 ⇒ unmarked).
-  const userRes = await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(frontendBody({ number: 0, targets: null })) });
-  assert.equal(userRes.status, 200, "the user's run is dispatched normally");
-  // A foreign scoped run with the SAME targets (also unmarked).
-  const foreignRes = await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(frontendBody({ number: 0, targets: ["14"] })) });
-  assert.equal(foreignRes.status, 200);
-  assert.equal(server.calls.length, 2, "both foreign posts dispatched untouched");
-  // Now OUR deferred item posts (marked, scoped) — observed.
-  await app.postDeferred(app.deferredItem);
-  const result = await promise;
-  assert.equal(result.outcome, "dispatched");
-  assert.deepEqual(ids, ["srv-3"], "only OUR prompt_id was captured (srv-1/2 were the foreign posts)");
-  assert.equal(server.calls.length, 3);
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const app = makeFrontend({ shape: "shim", defer: true, apiTarget });
+    const ids = [];
+    const promise = dispatchScopedRun({
+      app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
+      verifyTimeoutMs: 500, lingerMs: 1000,
+      onPromptId: (p) => ids.push(p),
+    });
+    await sleep(20); // guard is installed, waiting for observation
+    // A user queues a full run of the SAME graph (UI: number=0 ⇒ unmarked).
+    const userRes = await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(frontendBody({ number: 0, targets: null })) });
+    assert.equal(userRes.status, 200, "the user's run is dispatched normally");
+    // A foreign scoped run with the SAME targets (also unmarked).
+    const foreignRes = await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(frontendBody({ number: 0, targets: ["14"] })) });
+    assert.equal(foreignRes.status, 200);
+    assert.equal(server.calls.length, 2, "both foreign posts dispatched untouched");
+    // Now OUR deferred item posts (marked, scoped) — observed.
+    await app.postDeferred(app.deferredItem);
+    const result = await promise;
+    assert.equal(result.outcome, "dispatched");
+    assert.deepEqual(ids, ["srv-3"], "only OUR prompt_id was captured (srv-1/2 were the foreign posts)");
+    assert.equal(server.calls.length, 3);
+  } finally {
+    stop();
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -1,0 +1,373 @@
+/**
+ * Unit tests for web/js/lib/run-scope-guard.js — run with `node --test`.
+ *
+ * Guards #556: a scoped panel_run (to_node_id, "run to node") must NEVER
+ * silently fall through to a FULL-graph execution. The queuePrompt 3rd-argument
+ * shape differs across frontend builds (positional NodeExecutionId[] vs
+ * QueuePromptOptions { queueNodeIds }); a build that accepts only one shape
+ * silently IGNORES the other, so the scope never reaches POST /prompt and the
+ * full graph queues while panel_run reports ran_to_node. The guard inspects the
+ * outgoing /prompt body and REFUSES a scopeless dispatch before it leaves —
+ * these tests pin that refusal (no full-graph dispatch) and that a verifiably
+ * scoped run still runs scoped on both frontend build shapes.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  queuePromptScopeArgs,
+  verifyScopedPromptBody,
+  scopeDroppedError,
+  createRunFetchInterceptor,
+} from "../../web/js/lib/run-scope-guard.js";
+import { resolveRunToNodeTarget } from "../../web/js/lib/subgraph-scope.js";
+
+// A Response double with the surface the interceptor + frontend rejection path
+// use (status, clone().json(), text()).
+function jsonResponse(status, obj) {
+  return {
+    status,
+    clone() {
+      return { json: async () => JSON.parse(JSON.stringify(obj)) };
+    },
+    text: async () => JSON.stringify(obj),
+  };
+}
+
+// A recording origFetchApi double. `responder(route, options)` produces the
+// response; every call is logged so tests can prove a dispatch did/didn't happen.
+function makeFetchSpy(responder) {
+  const calls = [];
+  const fetchApi = async (route, options) => {
+    calls.push({ route, options });
+    return responder(route, options);
+  };
+  fetchApi.calls = calls;
+  return fetchApi;
+}
+
+const promptPost = (body) => [
+  "/prompt",
+  {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  },
+];
+
+// ---------------------------------------------------------------------------
+// queuePromptScopeArgs — the shapes graph_run tries, in order.
+// ---------------------------------------------------------------------------
+
+test("#556 queuePromptScopeArgs: no scope ⇒ a single undefined arg (plain full run, historical call shape)", () => {
+  assert.deepEqual(queuePromptScopeArgs(undefined), [undefined]);
+  assert.deepEqual(queuePromptScopeArgs(null), [undefined]);
+  assert.deepEqual(queuePromptScopeArgs([]), [undefined]);
+});
+
+test("#556 queuePromptScopeArgs: a scope ⇒ positional array FIRST, then the options object", () => {
+  const [first, second] = queuePromptScopeArgs(["76:34"]);
+  assert.deepEqual(first, ["76:34"]);
+  assert.deepEqual(second, { queueNodeIds: ["76:34"] });
+});
+
+// ---------------------------------------------------------------------------
+// verifyScopedPromptBody — the pure verdict.
+// ---------------------------------------------------------------------------
+
+test("#556 verify: body carrying EXACTLY the requested scope passes (incl. colon-path exec ids)", () => {
+  assert.deepEqual(verifyScopedPromptBody(JSON.stringify({ partial_execution_targets: ["14"] }), ["14"]), {
+    ok: true,
+  });
+  assert.deepEqual(
+    verifyScopedPromptBody(JSON.stringify({ partial_execution_targets: ["10:15:359"] }), ["10:15:359"]),
+    { ok: true },
+  );
+});
+
+test("#556 verify: NO partial_execution_targets in the body ⇒ scope_missing refusal", () => {
+  const v = verifyScopedPromptBody(JSON.stringify({ prompt: {}, client_id: "x" }), ["14"]);
+  assert.equal(v.ok, false);
+  assert.equal(v.reason, "scope_missing");
+  assert.deepEqual(v.expected, ["14"]);
+});
+
+test("#556 verify: an EMPTY targets list is a dropped scope, not a scoped run", () => {
+  const v = verifyScopedPromptBody(JSON.stringify({ partial_execution_targets: [] }), ["14"]);
+  assert.equal(v.ok, false);
+  assert.equal(v.reason, "scope_missing");
+});
+
+test("#556 verify: WRONG or EXTRA targets ⇒ scope_mismatch refusal", () => {
+  const wrong = verifyScopedPromptBody(JSON.stringify({ partial_execution_targets: ["9"] }), ["14"]);
+  assert.equal(wrong.ok, false);
+  assert.equal(wrong.reason, "scope_mismatch");
+  assert.deepEqual(wrong.got, ["9"]);
+  const extra = verifyScopedPromptBody(JSON.stringify({ partial_execution_targets: ["14", "9"] }), ["14"]);
+  assert.equal(extra.ok, false);
+  assert.equal(extra.reason, "scope_mismatch");
+});
+
+test("#556 verify: an unparseable body is UNVERIFIABLE ⇒ refuse (never fail open)", () => {
+  const v = verifyScopedPromptBody("not-json{", ["14"]);
+  assert.equal(v.ok, false);
+  assert.equal(v.reason, "scope_missing");
+  const u = verifyScopedPromptBody(undefined, ["14"]);
+  assert.equal(u.ok, false);
+});
+
+test("#556 verify: numeric targets normalize to strings; no scope requested ⇒ always ok", () => {
+  assert.deepEqual(verifyScopedPromptBody(JSON.stringify({ partial_execution_targets: [14] }), ["14"]), {
+    ok: true,
+  });
+  assert.deepEqual(verifyScopedPromptBody("garbage", null), { ok: true });
+  assert.deepEqual(verifyScopedPromptBody("garbage", []), { ok: true });
+});
+
+test("#556 scopeDroppedError: names the node and states NOTHING was queued", () => {
+  const msg = scopeDroppedError({
+    toNodeId: 14,
+    verdict: { ok: false, reason: "scope_missing", expected: ["14"], got: null },
+  });
+  assert.match(msg, /node 14/);
+  assert.match(msg, /NOT applied/);
+  assert.match(msg, /Nothing was queued/);
+  assert.match(msg, /full-graph/);
+});
+
+// ---------------------------------------------------------------------------
+// createRunFetchInterceptor — the guard graph_run installs.
+// ---------------------------------------------------------------------------
+
+test("#556 REGRESSION: a scoped run whose scope the frontend dropped is REFUSED — origFetchApi is NEVER called (no full-graph dispatch)", async () => {
+  // Simulates the #556 frontend: queuePrompt accepted the call but the POST
+  // /prompt body carries NO partial_execution_targets.
+  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "should-never-happen" }));
+  let dropped = null;
+  const intercepted = createRunFetchInterceptor({
+    origFetchApi: spy,
+    partialTargets: ["14"],
+    toNodeId: 14,
+    onScopeDropped: (m) => (dropped = m),
+  });
+  const [route, options] = promptPost({ prompt: {}, client_id: "x" });
+  const res = await intercepted(route, options);
+  assert.equal(spy.calls.length, 0, "the scopeless prompt must NEVER be dispatched");
+  assert.equal(res.status, 400, "the refusal is shaped like a server rejection");
+  assert.match(dropped, /node 14/);
+  assert.match(dropped, /Nothing was queued/);
+});
+
+test("#556: a scoped run whose body carries the scope is DISPATCHED verbatim and the prompt_id captured", async () => {
+  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: 123 }));
+  const ids = [];
+  const intercepted = createRunFetchInterceptor({
+    origFetchApi: spy,
+    partialTargets: ["76:34"],
+    toNodeId: 34,
+    onPromptId: (pid) => ids.push(pid),
+  });
+  const [route, options] = promptPost({ prompt: {}, partial_execution_targets: ["76:34"] });
+  const res = await intercepted(route, options);
+  assert.equal(spy.calls.length, 1, "scoped prompt dispatched");
+  assert.equal(spy.calls[0].options, options, "request passed through untouched");
+  assert.equal(res.status, 200);
+  assert.deepEqual(ids, ["123"], "prompt_id normalized to a string at capture");
+});
+
+test("#556: response capture preserved — a top-level server rejection (non-200) is reported (#358 channel)", async () => {
+  const rejectionBody = { error: { type: "missing_node_type", message: "no class_type" } };
+  const spy = makeFetchSpy(async () => jsonResponse(400, rejectionBody));
+  let rejection = null;
+  const intercepted = createRunFetchInterceptor({
+    origFetchApi: spy,
+    partialTargets: ["14"],
+    toNodeId: 14,
+    onRejection: (r) => (rejection = r),
+  });
+  const [route, options] = promptPost({ prompt: {}, partial_execution_targets: ["14"] });
+  await intercepted(route, options);
+  assert.equal(spy.calls.length, 1, "a verifiably scoped prompt IS dispatched (and may be refused by the server)");
+  assert.deepEqual(rejection, { error: rejectionBody.error, node_errors: null });
+});
+
+test("#556: non-/prompt routes and non-POST methods pass through UNINSPECTED even when scoped", async () => {
+  const spy = makeFetchSpy(async () => jsonResponse(200, {}));
+  let dropped = null;
+  const intercepted = createRunFetchInterceptor({
+    origFetchApi: spy,
+    partialTargets: ["14"],
+    toNodeId: 14,
+    onScopeDropped: () => (dropped = true),
+  });
+  await intercepted("/history", { method: "GET" });
+  await intercepted("/prompt", { method: "GET" });
+  await intercepted("/upload/image", { method: "POST", body: "..." });
+  assert.equal(spy.calls.length, 3);
+  assert.equal(dropped, null);
+});
+
+test("#556: an UNSCOPED run (partialTargets null) is never scope-checked — the normal full-run path is preserved", async () => {
+  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "p1" }));
+  let dropped = null;
+  const intercepted = createRunFetchInterceptor({
+    origFetchApi: spy,
+    partialTargets: null,
+    onScopeDropped: () => (dropped = true),
+  });
+  const [route, options] = promptPost({ prompt: {}, client_id: "x" });
+  const res = await intercepted(route, options);
+  assert.equal(spy.calls.length, 1, "full run dispatched");
+  assert.equal(res.status, 200);
+  assert.equal(dropped, null);
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end across the two frontend build shapes, driving the interceptor the
+// way graph_run's retry loop does (array first, then { queueNodeIds }).
+// ---------------------------------------------------------------------------
+
+// A fake app.queuePrompt for a build that ONLY honors the QueuePromptOptions
+// object — the legacy positional array is silently ignored (#556's build).
+function makeOptionsOnlyQueuePrompt(fetchApi, posted) {
+  return async (number, batch, arg) => {
+    const queueNodeIds = Array.isArray(arg) ? undefined : arg?.queueNodeIds;
+    const body = { prompt: {}, client_id: "x" };
+    if (queueNodeIds) body.partial_execution_targets = queueNodeIds;
+    await fetchApi("/prompt", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    posted.push(body);
+  };
+}
+
+// A fake app.queuePrompt for a build that ONLY honors the positional array.
+function makePositionalOnlyQueuePrompt(fetchApi, posted) {
+  return async (number, batch, arg) => {
+    const queueNodeIds = Array.isArray(arg) ? arg : undefined;
+    const body = { prompt: {}, client_id: "x" };
+    if (queueNodeIds) body.partial_execution_targets = queueNodeIds;
+    await fetchApi("/prompt", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    posted.push(body);
+  };
+}
+
+test("#556 e2e: an options-only frontend (drops the legacy array) still runs SCOPED — the blocked attempt never dispatched, the retry delivers", async () => {
+  const posted = [];
+  const dispatched = [];
+  const origFetchApi = makeFetchSpy(async () => {
+    dispatched.push(true);
+    return jsonResponse(200, { prompt_id: "p1" });
+  });
+  let scopeDropped = null;
+  for (const scopeArg of queuePromptScopeArgs(["14"])) {
+    scopeDropped = null;
+    const intercepted = createRunFetchInterceptor({
+      origFetchApi,
+      partialTargets: ["14"],
+      toNodeId: 14,
+      onScopeDropped: (m) => (scopeDropped = m),
+    });
+    const queuePrompt = makeOptionsOnlyQueuePrompt(intercepted, posted);
+    await queuePrompt(0, 1, scopeArg);
+    if (!scopeDropped) break;
+  }
+  assert.equal(scopeDropped, null, "the retry shape delivered the scope");
+  assert.equal(dispatched.length, 1, "exactly ONE prompt actually dispatched (no double-queue)");
+  assert.equal(posted.length, 2, "both shapes were attempted");
+  assert.deepEqual(posted[0].partial_execution_targets, undefined, "attempt 1 (array) dropped by this build");
+  assert.deepEqual(posted[1].partial_execution_targets, ["14"], "attempt 2 (options object) delivered the scope");
+});
+
+test("#556 e2e: a positional-only frontend runs SCOPED on the FIRST shape (no retry needed)", async () => {
+  const posted = [];
+  const dispatched = [];
+  const origFetchApi = makeFetchSpy(async () => {
+    dispatched.push(true);
+    return jsonResponse(200, { prompt_id: "p1" });
+  });
+  let scopeDropped = null;
+  let attempts = 0;
+  for (const scopeArg of queuePromptScopeArgs(["14"])) {
+    attempts++;
+    scopeDropped = null;
+    const intercepted = createRunFetchInterceptor({
+      origFetchApi,
+      partialTargets: ["14"],
+      toNodeId: 14,
+      onScopeDropped: (m) => (scopeDropped = m),
+    });
+    const queuePrompt = makePositionalOnlyQueuePrompt(intercepted, posted);
+    await queuePrompt(0, 1, scopeArg);
+    if (!scopeDropped) break;
+  }
+  assert.equal(scopeDropped, null);
+  assert.equal(attempts, 1, "array first ⇒ no retry on positional builds");
+  assert.equal(dispatched.length, 1);
+  assert.deepEqual(posted[0].partial_execution_targets, ["14"]);
+});
+
+test("#556 e2e: a build that honors NEITHER shape ⇒ truthful refusal, ZERO dispatches", async () => {
+  const dispatched = [];
+  const origFetchApi = makeFetchSpy(async () => {
+    dispatched.push(true);
+    return jsonResponse(200, { prompt_id: "p1" });
+  });
+  let scopeDropped = null;
+  for (const scopeArg of queuePromptScopeArgs(["14"])) {
+    scopeDropped = null;
+    const intercepted = createRunFetchInterceptor({
+      origFetchApi,
+      partialTargets: ["14"],
+      toNodeId: 14,
+      onScopeDropped: (m) => (scopeDropped = m),
+    });
+    // This build posts a body with NO targets regardless of the arg shape.
+    await intercepted("/prompt", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: {}, client_id: "x" }),
+    });
+    if (!scopeDropped) break;
+  }
+  assert.match(scopeDropped, /node 14/);
+  assert.match(scopeDropped, /Nothing was queued/);
+  assert.equal(dispatched.length, 0, "no full-graph prompt ever left the tab");
+});
+
+// ---------------------------------------------------------------------------
+// The RESOLUTION half of the refusal: a stale/unknown to_node_id never reaches
+// dispatch at all (graph_run returns queued:false before queuePrompt).
+// ---------------------------------------------------------------------------
+
+const outputNode = (id) => ({
+  id,
+  type: "PreviewImage",
+  constructor: { nodeData: { output_node: true } },
+});
+
+test("#556: a to_node_id that went STALE (graph changed after the id was captured) resolves not_found ⇒ refused before any dispatch", () => {
+  // The id was valid against the graph the agent last saw…
+  const staleRoot = { _nodes: [outputNode(14)], getNodeById(id) { return this._nodes.find((n) => Number(n.id) === Number(id)) ?? null; } };
+  assert.equal(resolveRunToNodeTarget(staleRoot, null, 14).ok, true);
+  // …but the live root no longer has it (node deleted / workflow reloaded).
+  const liveRoot = { _nodes: [outputNode(15)], getNodeById(id) { return this._nodes.find((n) => Number(n.id) === Number(id)) ?? null; } };
+  const res = resolveRunToNodeTarget(liveRoot, null, 14);
+  assert.deepEqual(res, { ok: false, code: "not_found", node: null });
+  // graph_run maps this verdict to { queued:false, error: "node 14 was not found…" }
+  // and returns BEFORE queuePrompt — no full-graph dispatch is possible.
+});
+
+test("#556: a NON-output target is refused (not_output) — it can never be an execution root", () => {
+  const ksampler = { id: 3, type: "KSampler", constructor: { nodeData: { output_node: false } } };
+  const root = { _nodes: [ksampler], getNodeById(id) { return this._nodes.find((n) => Number(n.id) === Number(id)) ?? null; } };
+  const res = resolveRunToNodeTarget(root, null, 3);
+  assert.equal(res.ok, false);
+  assert.equal(res.code, "not_output");
+});

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -2,33 +2,32 @@
  * Unit tests for web/js/lib/run-scope-guard.js — run with `node --test`.
  *
  * Guards #556: a scoped panel_run (to_node_id, "run to node") must NEVER
- * silently fall through to a FULL-graph execution — and (codex gate) must do so
- * without breaking the tab around it:
- *
- *  P0 — a busy app.queuePrompt returns early and posts the item LATER; a guard
- *       restored at queuePrompt's return never sees that deferred dispatch. The
- *       scoped guard stays installed until our dispatch is OBSERVED or a
- *       bounded timeout, and a run whose dispatch never surfaces reports a
- *       truthful "unverified — nothing confirmed queued", never queued:true.
- *
- *  P1 — while installed, the guard sees EVERY POST /prompt in the tab. It only
- *       refuses a targetless body matching THIS run's prompt signature (and
- *       only within the batch count); unrelated full runs and other scoped runs
- *       pass through untouched and are never captured as ours.
+ * silently fall through to a FULL-graph execution — and must never collateral-
+ * damage unrelated queue traffic while preventing that. The integration tests
+ * below drive dispatchScopedRun — the SAME orchestration graph_run runs —
+ * through mock frontends, including the real guard-install/try/finally/restore
+ * control flow (codex gate r3: the sentinel must ACTUALLY be installed after a
+ * timeout, degraded mode must fail closed BEFORE dispatch, and run identity —
+ * queue-position mark + queue-item tag — must separate our work from every
+ * stranger's).
  */
 import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  SCOPED_QUEUE_MARK,
+  QUEUE_ITEM_TAG,
   queuePromptScopeArgs,
   promptSignature,
   promptSignatureFromBody,
   verifyScopedPromptBody,
   scopeDroppedError,
   scopeUnverifiedError,
+  scopeUnattributableError,
   createRunFetchInterceptor,
   createScopedRunGuard,
   cancelPendingScopedQueueItem,
+  dispatchScopedRun,
 } from "../../web/js/lib/run-scope-guard.js";
 import { resolveRunToNodeTarget } from "../../web/js/lib/subgraph-scope.js";
 
@@ -43,13 +42,12 @@ function jsonResponse(status, obj) {
   };
 }
 
-// A recording origFetchApi double; every call is logged so tests can prove a
-// dispatch did/didn't happen.
-function makeFetchSpy(responder) {
+// The "server" — a recording fetchApi double standing in for the real one.
+function makeServer(responder) {
   const calls = [];
   const fetchApi = async (route, options) => {
     calls.push({ route, options });
-    return responder(route, options);
+    return responder ? responder(route, options) : jsonResponse(200, { prompt_id: `srv-${calls.length}` });
   };
   fetchApi.calls = calls;
   return fetchApi;
@@ -64,30 +62,90 @@ const promptPost = (body) => [
   },
 ];
 
-// The graphToPrompt output OUR scoped run queued (two branches: a KSampler
-// trunk, a SaveImage branch, and the PreviewAny we scope to).
+// The graphToPrompt output OUR scoped run queued.
 const OUR_OUTPUT = {
   "3": { class_type: "KSampler", inputs: {} },
   "9": { class_type: "SaveImage", inputs: {} },
   "14": { class_type: "PreviewAny", inputs: {} },
 };
 const OUR_SIGNATURE = promptSignature(OUR_OUTPUT);
-const OUR_FULL_BODY = { prompt: OUR_OUTPUT, client_id: "x" };
-const OUR_SCOPED_BODY = { prompt: OUR_OUTPUT, client_id: "x", partial_execution_targets: ["14"] };
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+// Bodies the way the frontend's api.queuePrompt builds them.
+function frontendBody({ output = OUR_OUTPUT, number = SCOPED_QUEUE_MARK, targets = null }) {
+  const body = { prompt: output, client_id: "x" };
+  if (targets) body.partial_execution_targets = targets;
+  if (number === -1) body.front = true;
+  else if (number != 0) body.number = number;
+  return body;
+}
+
+/**
+ * A mock frontend. `shape`: "shim" (options object AND legacy array both
+ * honored), "positional" (array only), "shimless" (options object only — the
+ * #556 build). `defer`: queuePrompt pushes the item and returns early (busy
+ * processor); the TEST then drives the deferred post manually through
+ * apiTarget.fetchApi, exactly like the in-flight processor would.
+ */
+function makeFrontend({ shape = "shim", defer = false, apiTarget, output = OUR_OUTPUT, failGraphToPrompt = false } = {}) {
+  const app = {
+    queueItems: [],
+    posted: [],
+    graphToPrompt: async () => {
+      if (failGraphToPrompt) throw new Error("serialization exploded");
+      return { output, workflow: {} };
+    },
+    queuePrompt: async (number, batch, arg) => {
+      const queueNodeIds =
+        shape === "shim"
+          ? Array.isArray(arg)
+            ? arg
+            : arg?.queueNodeIds
+          : shape === "positional"
+            ? Array.isArray(arg)
+              ? arg
+              : undefined
+            : Array.isArray(arg)
+              ? undefined
+              : arg?.queueNodeIds;
+      const item = { number, batchCount: batch, queueNodeIds };
+      if (defer) {
+        app.queueItems?.push(item); // hard-private builds hide the array from us
+        app.deferredItem = item;
+        return false; // busy — the processor posts it LATER
+      }
+      // Synchronous processing: post now, through whatever fetchApi is installed.
+      const body = frontendBody({ output, number, targets: queueNodeIds?.length ? queueNodeIds : null });
+      app.posted.push(body);
+      await apiTarget.fetchApi("/prompt", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      return true;
+    },
+    // Simulate the in-flight processor eventually posting a deferred item.
+    postDeferred: async (item) => {
+      const body = frontendBody({ output, number: item.number, targets: item.queueNodeIds?.length ? item.queueNodeIds : null });
+      app.posted.push(body);
+      return apiTarget.fetchApi("/prompt", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+    },
+  };
+  return app;
+}
+
 // ---------------------------------------------------------------------------
-// queuePromptScopeArgs / signatures / pure verdicts
+// Pure helpers
 // ---------------------------------------------------------------------------
 
-test("#556 queuePromptScopeArgs: no scope ⇒ a single undefined arg (plain full run, historical call shape)", () => {
+test("#556 queuePromptScopeArgs: no scope ⇒ [undefined]; scope ⇒ array first, then options object", () => {
   assert.deepEqual(queuePromptScopeArgs(undefined), [undefined]);
-  assert.deepEqual(queuePromptScopeArgs(null), [undefined]);
   assert.deepEqual(queuePromptScopeArgs([]), [undefined]);
-});
-
-test("#556 queuePromptScopeArgs: a scope ⇒ positional array FIRST, then the options object", () => {
   const [first, second] = queuePromptScopeArgs(["76:34"]);
   assert.deepEqual(first, ["76:34"]);
   assert.deepEqual(second, { queueNodeIds: ["76:34"] });
@@ -96,45 +154,33 @@ test("#556 queuePromptScopeArgs: a scope ⇒ positional array FIRST, then the op
 test("#556 promptSignature: node-id|class_type set, widget values excluded, order-insensitive", () => {
   const a = promptSignature({ "9": { class_type: "B", inputs: { seed: 1 } }, "3": { class_type: "A" } });
   const b = promptSignature({ "3": { class_type: "A" }, "9": { class_type: "B", inputs: { seed: 999 } } });
-  assert.equal(a, b, "same node set with different widget values ⇒ same signature");
-  assert.notEqual(promptSignature({ "3": { class_type: "A" } }), a, "different node set ⇒ different signature");
-  assert.equal(promptSignature(null), null);
-  assert.equal(promptSignature({}), null);
-});
-
-test("#556 promptSignatureFromBody: reads body.prompt; unparseable ⇒ null", () => {
+  assert.equal(a, b);
+  assert.notEqual(promptSignature({ "3": { class_type: "A" } }), a);
   assert.equal(promptSignatureFromBody(JSON.stringify({ prompt: OUR_OUTPUT })), OUR_SIGNATURE);
   assert.equal(promptSignatureFromBody("not-json{"), null);
-  assert.equal(promptSignatureFromBody(undefined), null);
 });
 
 test("#556 verifyScopedPromptBody: exact scope passes; missing/empty/wrong/extra/unparseable all refuse", () => {
   assert.deepEqual(verifyScopedPromptBody(JSON.stringify({ partial_execution_targets: ["10:15:359"] }), ["10:15:359"]), { ok: true });
   assert.equal(verifyScopedPromptBody(JSON.stringify({ prompt: {} }), ["14"]).reason, "scope_missing");
-  assert.equal(verifyScopedPromptBody(JSON.stringify({ partial_execution_targets: [] }), ["14"]).reason, "scope_missing");
-  assert.equal(verifyScopedPromptBody(JSON.stringify({ partial_execution_targets: ["9"] }), ["14"]).reason, "scope_mismatch");
   assert.equal(verifyScopedPromptBody(JSON.stringify({ partial_execution_targets: ["14", "9"] }), ["14"]).reason, "scope_mismatch");
   assert.equal(verifyScopedPromptBody("garbage{", ["14"]).ok, false);
   assert.deepEqual(verifyScopedPromptBody("garbage", null), { ok: true });
 });
 
-test("#556 scopeDroppedError: names the node and states NOTHING was queued", () => {
-  const msg = scopeDroppedError({ toNodeId: 14, verdict: { ok: false, reason: "scope_missing", expected: ["14"], got: null } });
-  assert.match(msg, /node 14/);
-  assert.match(msg, /NOT applied/);
-  assert.match(msg, /Nothing was queued/);
-});
-
-test("#556 scopeUnverifiedError: truthful — nothing CONFIRMED queued, never claims a scoped run happened", () => {
-  const lingering = scopeUnverifiedError({ toNodeId: 14, timeoutMs: 5000, cancelled: false, lingerMs: 600000 });
-  assert.match(lingering, /node 14/);
-  assert.match(lingering, /could not be verified/);
-  assert.match(lingering, /CONFIRMED queued/i);
-  assert.match(lingering, /sentinel/, "says the guard stays installed when cancellation was impossible");
-  assert.doesNotMatch(lingering, /Nothing was queued/, "a deferred post may still land — must not claim otherwise");
+test("#556 error messages: dropped names the node + nothing queued; unverified distinguishes cancelled vs sentinel; unattributable fails closed", () => {
+  const dropped = scopeDroppedError({ toNodeId: 14, verdict: { ok: false, reason: "scope_missing", expected: ["14"], got: null } });
+  assert.match(dropped, /node 14/);
+  assert.match(dropped, /Nothing was queued/);
   const cancelled = scopeUnverifiedError({ toNodeId: 14, timeoutMs: 5000, cancelled: true });
   assert.match(cancelled, /REMOVED/);
-  assert.match(cancelled, /nothing was queued/i, "after a successful cancel, 'nothing was queued' is literally true");
+  assert.match(cancelled, /nothing was queued/i);
+  const sentinel = scopeUnverifiedError({ toNodeId: 14, timeoutMs: 5000, cancelled: false, lingerMs: 600000 });
+  assert.match(sentinel, /sentinel/);
+  assert.match(sentinel, /CONFIRMED queued/i);
+  const unattributable = scopeUnattributableError({ toNodeId: 14 });
+  assert.match(unattributable, /cannot be dispatched safely/);
+  assert.match(unattributable, /Nothing was queued/);
 });
 
 // ---------------------------------------------------------------------------
@@ -142,7 +188,7 @@ test("#556 scopeUnverifiedError: truthful — nothing CONFIRMED queued, never cl
 // ---------------------------------------------------------------------------
 
 test("#556 unscoped interceptor: captures top-level rejection and prompt_id, leaves the request untouched", async () => {
-  const spy = makeFetchSpy(async () => jsonResponse(400, { error: { type: "missing_node_type" } }));
+  const spy = makeServer(async () => jsonResponse(400, { error: { type: "missing_node_type" } }));
   let rejection = null;
   const intercepted = createRunFetchInterceptor({ origFetchApi: spy, onRejection: (r) => (rejection = r) });
   const [route, options] = promptPost({ prompt: {} });
@@ -152,333 +198,222 @@ test("#556 unscoped interceptor: captures top-level rejection and prompt_id, lea
   assert.equal(res.status, 400);
   assert.deepEqual(rejection, { error: { type: "missing_node_type" }, node_errors: null });
 
-  const spy2 = makeFetchSpy(async () => jsonResponse(200, { prompt_id: 0 }));
   const ids = [];
-  const intercepted2 = createRunFetchInterceptor({ origFetchApi: spy2, onPromptId: (p) => ids.push(p) });
+  const intercepted2 = createRunFetchInterceptor({ origFetchApi: makeServer(async () => jsonResponse(200, { prompt_id: 0 })), onPromptId: (p) => ids.push(p) });
   await intercepted2(...promptPost({ prompt: {} }));
-  assert.deepEqual(ids, ["0"], "falsy-but-valid id 0 is captured, string-normalized");
-});
-
-test("#556 unscoped interceptor: non-/prompt routes are not inspected", async () => {
-  const spy = makeFetchSpy(async () => jsonResponse(200, {}));
-  const intercepted = createRunFetchInterceptor({ origFetchApi: spy, onRejection: () => assert.fail("no capture") });
-  await intercepted("/history", { method: "GET" });
-  assert.equal(spy.calls.length, 1);
+  assert.deepEqual(ids, ["0"], "falsy-but-valid id 0 captured, string-normalized");
 });
 
 // ---------------------------------------------------------------------------
-// createScopedRunGuard — the SCOPED path
+// createScopedRunGuard — mark-based attribution (unit level)
 // ---------------------------------------------------------------------------
 
-test("#556 guard: OUR scoped dispatch (body carries exactly our targets) is observed, dispatched verbatim, prompt_id captured", async () => {
-  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "p1" }));
+test("#556 guard: OUR marked post with signature+exact targets ⇒ observed, dispatched verbatim, prompt_id captured", async () => {
+  const spy = makeServer();
   const ids = [];
-  const guard = createScopedRunGuard({
-    origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
-    onPromptId: (p) => ids.push(p),
-  });
-  const [route, options] = promptPost(OUR_SCOPED_BODY);
+  const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14, onPromptId: (p) => ids.push(p) });
+  const [route, options] = promptPost(frontendBody({ targets: ["14"] }));
   const res = await guard(route, options);
-  assert.equal(spy.calls.length, 1, "scoped prompt dispatched");
-  assert.equal(spy.calls[0].options, options, "request passed through untouched");
-  assert.equal(res.status, 200);
-  assert.equal(guard.state.observed, 1);
-  assert.equal(guard.state.dropped, null);
-  assert.deepEqual(ids, ["p1"]);
-});
-
-test("#556 guard: a server rejection of OUR scoped dispatch is captured (#358 channel preserved)", async () => {
-  const spy = makeFetchSpy(async () => jsonResponse(400, { error: { type: "prompt_outputs_failed_validation" } }));
-  let rejection = null;
-  const guard = createScopedRunGuard({
-    origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
-    onRejection: (r) => (rejection = r),
-  });
-  await guard(...promptPost(OUR_SCOPED_BODY));
-  assert.equal(spy.calls.length, 1, "a verifiably scoped prompt IS dispatched (and may be refused by the server)");
-  assert.equal(rejection?.error?.type, "prompt_outputs_failed_validation");
-});
-
-test("#556 REGRESSION: OUR dispatch gone wrong (targetless body with OUR signature) is REFUSED — origFetchApi NEVER called (no full-graph dispatch)", async () => {
-  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "must-never-happen" }));
-  let dropped = null;
-  const guard = createScopedRunGuard({
-    origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
-    onScopeDropped: (m) => (dropped = m),
-  });
-  const res = await guard(...promptPost(OUR_FULL_BODY));
-  assert.equal(spy.calls.length, 0, "the scopeless prompt must NEVER be dispatched");
-  assert.equal(res.status, 400, "refusal shaped like a server rejection");
-  assert.equal(guard.state.observed, 0);
-  assert.match(guard.state.dropped, /node 14/);
-  assert.match(dropped, /Nothing was queued/);
-});
-
-test("#556 P1: an UNRELATED full run (different signature) during the window passes through untouched and is NOT captured", async () => {
-  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "user-run" }));
-  let dropped = null, captured = null;
-  const guard = createScopedRunGuard({
-    origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
-    onScopeDropped: (m) => (dropped = m),
-    onPromptId: (p) => (captured = p),
-  });
-  const otherGraph = { prompt: { "1": { class_type: "LoadImage" }, "2": { class_type: "SaveImage" } }, client_id: "x" };
-  const [route, options] = promptPost(otherGraph);
-  const res = await guard(route, options);
-  assert.equal(spy.calls.length, 1, "the user's run is dispatched");
+  assert.equal(spy.calls.length, 1);
   assert.equal(spy.calls[0].options, options);
   assert.equal(res.status, 200);
-  assert.equal(dropped, null, "no refusal");
-  assert.equal(captured, null, "not captured as ours");
-  assert.equal(guard.state.observed, 0);
-  assert.equal(guard.state.dropped, null);
+  assert.equal(guard.state.observed, 1);
+  assert.deepEqual(ids, ["srv-1"]);
 });
 
-test("#556 P1: an unrelated SCOPED run (foreign signature, its own targets) passes through untouched", async () => {
-  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "other-scoped" }));
-  let captured = null;
-  const guard = createScopedRunGuard({
-    origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
-    onPromptId: (p) => (captured = p),
-  });
-  const body = { prompt: { "1": { class_type: "LoadImage" }, "2": { class_type: "PreviewImage" } }, client_id: "x", partial_execution_targets: ["2"] };
-  const res = await guard(...promptPost(body));
-  assert.equal(spy.calls.length, 1);
-  assert.equal(res.status, 200);
-  assert.equal(captured, null, "another scope's prompt_id is never claimed as ours");
-  assert.equal(guard.state.observed, 0);
-});
-
-test("#556 r2 P0-1: OUR signature with WRONG/EXTRA/PARTIAL targets is OUR corrupted dispatch — REFUSED with zero dispatch (not forwarded as 'someone else's')", async () => {
-  for (const badTargets of [["14", "9"], ["9"], ["14", "76:34"]]) {
-    const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "must-never-happen" }));
+test("#556 guard: OUR marked post with MISSING or WRONG/EXTRA targets ⇒ refused with zero dispatch", async () => {
+  for (const bad of [null, ["9"], ["14", "9"]]) {
+    const spy = makeServer();
     let dropped = null;
-    const guard = createScopedRunGuard({
-      origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
-      onScopeDropped: (m) => (dropped = m),
-    });
-    const body = { prompt: OUR_OUTPUT, client_id: "x", partial_execution_targets: badTargets };
-    const res = await guard(...promptPost(body));
-    assert.equal(spy.calls.length, 0, `targets ${JSON.stringify(badTargets)} must never leave the tab`);
+    const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14, onScopeDropped: (m) => (dropped = m) });
+    const res = await guard(...promptPost(frontendBody({ targets: bad })));
+    assert.equal(spy.calls.length, 0, `targets ${JSON.stringify(bad)} must never leave the tab`);
     assert.equal(res.status, 400);
     assert.match(dropped, /node 14/);
-    assert.match(dropped, /instead of/, "scope_mismatch names what the body carried");
-    assert.equal(guard.state.observed, 0, "a corrupted dispatch never counts as observed");
+    assert.equal(guard.state.observed, 0);
   }
 });
 
-test("#556 r2 P0-2: a FOREIGN post carrying the SAME targets does NOT satisfy observation — our deferred corrupted post is still refused afterwards", async () => {
-  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "foreign-pid" }));
-  let captured = null;
+test("#556 r3 P0-3: an UNMARKED post is FOREIGN even with our node set AND our targets — never refused, never captured, never observed", async () => {
+  const spy = makeServer();
+  let captured = null, dropped = null;
   const guard = createScopedRunGuard({
     origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
-    onPromptId: (p) => (captured = p),
+    onPromptId: (p) => (captured = p), onScopeDropped: (m) => (dropped = m),
   });
-  // Another workflow whose prompt ALSO carries ["14"] but has a different node set.
-  const foreign = { prompt: { "14": { class_type: "SaveImage" }, "2": { class_type: "LoadImage" } }, client_id: "x", partial_execution_targets: ["14"] };
-  const foreignRes = await guard(...promptPost(foreign));
-  assert.equal(spy.calls.length, 1, "the foreign scoped run passes through");
-  assert.equal(foreignRes.status, 200);
-  assert.equal(guard.state.observed, 0, "same targets + different signature is NOT our dispatch");
-  assert.equal(captured, null, "its prompt_id is never claimed as ours");
-  // graph_run would still be waiting (observed==0) — and when OUR deferred
-  // corrupted post finally surfaces, the guard is still there to refuse it.
-  assert.equal(guard.state.dropped, null);
-  const spy2 = spy;
-  const res = await guard(...promptPost(OUR_FULL_BODY));
-  assert.equal(res.status, 400, "our scope-dropped dispatch is still refused");
-  assert.equal(spy2.calls.length, 1, "and never dispatches");
-});
-
-test("#556 P1: refusal is bounded by the batch — a same-signature full body BEYOND our batch count passes through", async () => {
-  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "late-run" }));
-  const guard = createScopedRunGuard({
-    origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
-  });
-  const first = await guard(...promptPost(OUR_FULL_BODY));
-  assert.equal(first.status, 400, "our own dropped dispatch is refused");
-  assert.equal(spy.calls.length, 0);
-  const second = await guard(...promptPost(OUR_FULL_BODY));
-  assert.equal(second.status, 200, "a further same-signature full run is NOT ours to refuse");
-  assert.equal(spy.calls.length, 1, "it passes through");
-});
-
-test("#556 guard: an unparseable body is unattributable ⇒ passed through, never blocked (fail-safe toward strangers)", async () => {
-  const spy = makeFetchSpy(async () => jsonResponse(200, {}));
-  const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14 });
-  await guard("/prompt", { method: "POST", body: "not-json{" });
+  // A foreign scoped run to the same node (number=0 ⇒ no body.number ⇒ unmarked).
+  const foreignScoped = await guard(...promptPost(frontendBody({ number: 0, targets: ["14"] })));
+  assert.equal(foreignScoped.status, 200);
   assert.equal(spy.calls.length, 1);
+  assert.equal(guard.state.observed, 0, "foreign same-targets post never satisfies observation");
+  assert.equal(captured, null);
+  // A user's full run of the SAME graph — never refused as our corrupted dispatch.
+  const userFull = await guard(...promptPost(frontendBody({ number: 0, targets: null })));
+  assert.equal(userFull.status, 200);
+  assert.equal(spy.calls.length, 2);
+  assert.equal(dropped, null);
   assert.equal(guard.state.dropped, null);
 });
 
-test("#556 P0 DEFERRED RACE: queuePrompt returned early (busy) — the guard is STILL installed and refuses the deferred invalid-shape dispatch, zero real posts", async () => {
-  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "must-never-happen" }));
-  let dropped = null;
-  const guard = createScopedRunGuard({
-    origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
-    onScopeDropped: (m) => (dropped = m),
-  });
-  // graph_run awaits queuePrompt (which returned early), then waits on the guard.
-  const verdict = guard.waitForVerdict(1000);
-  // …the in-flight processor serializes and posts OUR item 30ms later, through
-  // the still-installed guard, with the scope dropped (invalid shape).
-  await sleep(30);
-  const res = await guard(...promptPost(OUR_FULL_BODY));
-  assert.equal(await verdict, true, "the deferred dispatch is OBSERVED by the still-installed guard");
-  assert.equal(res.status, 400);
-  assert.equal(spy.calls.length, 0, "the deferred full-graph prompt never left the tab");
-  assert.match(dropped, /node 14/);
+test("#556 guard: a marked post whose graph CHANGED under the deferred item (signature mismatch) is corrupted ⇒ refused", async () => {
+  const spy = makeServer();
+  const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14 });
+  const changedOutput = { "3": { class_type: "KSampler" }, "20": { class_type: "SaveImage" } };
+  const res = await guard(...promptPost(frontendBody({ output: changedOutput, targets: ["14"] })));
+  assert.equal(res.status, 400, "scope is unverifiable against the changed graph — refuse");
+  assert.equal(spy.calls.length, 0);
 });
 
-test("#556 P0 DEFERRED, correct shape: the late scoped post IS observed and its prompt_id captured", async () => {
-  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "deferred-pid" }));
+// ---------------------------------------------------------------------------
+// cancelPendingScopedQueueItem — ownership-tagged removal
+// ---------------------------------------------------------------------------
+
+test("#556 r3 P0-3: cancellation removes ONLY the ownership-tagged item — an identical-scope foreign item stays", () => {
+  const runTag = Symbol("t");
+  const ourArray = ["14"];
+  Object.defineProperty(ourArray, QUEUE_ITEM_TAG, { value: runTag, enumerable: false });
+  const ourOptionsItem = { number: 1, batchCount: 1, queueNodeIds: { queueNodeIds: ourArray } };
+  const ourDirectItem = { number: 1, batchCount: 1, queueNodeIds: ourArray };
+  const foreignSameScope = { number: 0, batchCount: 1, queueNodeIds: ["14"] };
+  const userFullRun = { number: 0, batchCount: 1, queueNodeIds: undefined };
+  const app = { queueItems: [userFullRun, foreignSameScope, ourDirectItem, ourOptionsItem] };
+  const res = cancelPendingScopedQueueItem(app, runTag);
+  assert.equal(res.accessible, true);
+  assert.equal(res.removed, 2, "our item removed in either stored shape");
+  assert.deepEqual(app.queueItems, [userFullRun, foreignSameScope], "identical-scope foreign item and user run stay");
+});
+
+test("#556 r3 P0-3: hard-private queueItems builds ⇒ inaccessible (caller keeps the sentinel)", () => {
+  assert.deepEqual(cancelPendingScopedQueueItem({}, Symbol("t")), { accessible: false, removed: 0 });
+});
+
+// ---------------------------------------------------------------------------
+// dispatchScopedRun — the REAL orchestration graph_run runs (integration)
+// ---------------------------------------------------------------------------
+
+test("#556 integration: happy path — marked scoped dispatch observed, prompt_id captured, fetchApi restored", async () => {
+  const apiTarget = { fetchApi: makeServer() };
+  const prev = apiTarget.fetchApi;
+  const app = makeFrontend({ shape: "shim", apiTarget });
   const ids = [];
-  const guard = createScopedRunGuard({
-    origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
+  const result = await dispatchScopedRun({
+    app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
     onPromptId: (p) => ids.push(p),
   });
-  const verdict = guard.waitForVerdict(1000);
-  await sleep(30);
-  await guard(...promptPost(OUR_SCOPED_BODY));
-  assert.equal(await verdict, true);
-  assert.equal(guard.state.observed, 1);
-  assert.deepEqual(ids, ["deferred-pid"]);
+  assert.equal(result.outcome, "dispatched");
+  assert.deepEqual(ids, ["srv-1"]);
+  assert.equal(apiTarget.fetchApi, prev, "guard restored after observation");
+  assert.equal(app.posted.length, 1, "first arg shape worked — no retry");
+  assert.equal(app.posted[0].number, SCOPED_QUEUE_MARK, "our posts carry the queue mark");
+  assert.deepEqual(app.posted[0].partial_execution_targets, ["14"]);
 });
 
-test("#556 P0 TIMEOUT: nothing surfaces within the window ⇒ waitForVerdict false, state clean ⇒ graph_run reports UNVERIFIED (never queued:true)", async () => {
-  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "nope" }));
-  const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14 });
-  const seen = await guard.waitForVerdict(50);
-  assert.equal(seen, false);
-  assert.equal(guard.state.observed, 0);
-  assert.equal(guard.state.dropped, null);
-  assert.equal(spy.calls.length, 0);
+test("#556 integration: a shim-less options build drops the legacy array — attempt 1 refused with ZERO dispatch, attempt 2 delivers", async () => {
+  const apiTarget = { fetchApi: makeServer() };
+  const app = makeFrontend({ shape: "shimless", apiTarget });
+  const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
+  assert.equal(result.outcome, "dispatched");
+  assert.equal(app.posted.length, 2, "both shapes attempted");
+  assert.equal(app.posted[0].partial_execution_targets, undefined, "attempt 1 (array) dropped by this build");
+  assert.equal(apiTarget.fetchApi.calls.length, 1, "only the correctly-shaped dispatch reached the server");
+  assert.deepEqual(apiTarget.fetchApi.calls[0].options.body && JSON.parse(apiTarget.fetchApi.calls[0].options.body).partial_execution_targets, ["14"]);
 });
 
-test("#556 r2 P0-3: timeout CANCELS our still-pending queue item — the deferred scope-dropped dispatch can never execute", () => {
-  // The frontend's pending list holds OUR deferred item (targets stored in
-  // either shape) plus a user's targetless full-run item and a foreign scoped
-  // item — only ours may be removed.
-  const ourItemArray = { number: 0, batchCount: 1, queueNodeIds: ["14"] };
-  const ourItemOptions = { number: 0, batchCount: 1, queueNodeIds: { queueNodeIds: ["14"] } };
-  const userFullRun = { number: 0, batchCount: 1, queueNodeIds: undefined };
-  const foreignScoped = { number: 0, batchCount: 1, queueNodeIds: ["9"] };
-  const app = { queueItems: [userFullRun, ourItemArray, foreignScoped, ourItemOptions] };
-  const res = cancelPendingScopedQueueItem(app, ["14"]);
-  assert.equal(res.accessible, true);
-  assert.equal(res.removed, 2, "both of our pending items are removed, in either stored shape");
-  assert.deepEqual(app.queueItems, [userFullRun, foreignScoped], "foreign items are never touched");
-});
-
-test("#556 r2 P0-3: cancellation is impossible on builds that hard-privatize queueItems ⇒ reported inaccessible (caller keeps the sentinel guard)", () => {
-  const res = cancelPendingScopedQueueItem({}, ["14"]);
-  assert.deepEqual(res, { accessible: false, removed: 0 });
-  assert.deepEqual(cancelPendingScopedQueueItem(null, ["14"]), { accessible: false, removed: 0 });
-});
-
-test("#556 r2 P0-3 SENTINEL: when cancellation failed, the guard (never restored) still refuses the late scope-dropped dispatch — zero dispatch post-timeout", async () => {
-  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "must-never-happen" }));
-  let dropped = null;
-  const guard = createScopedRunGuard({
-    origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
-    onScopeDropped: (m) => (dropped = m),
-  });
-  // The give-up path: timeout expired, cancelPendingScopedQueueItem removed
-  // nothing, so graph_run leaves THIS guard installed and returns unverified.
-  const seen = await guard.waitForVerdict(50);
-  assert.equal(seen, false, "timed out unverified");
-  // …the deferred item finally posts, well after the run returned.
-  await sleep(20);
-  const res = await guard(...promptPost(OUR_FULL_BODY));
-  assert.equal(res.status, 400, "the sentinel still refuses the scope-dropped dispatch");
-  assert.equal(spy.calls.length, 0, "no full-graph dispatch ever escapes — even after the timeout");
-  assert.match(dropped, /node 14/);
-});
-
-// ---------------------------------------------------------------------------
-// End-to-end across frontend build shapes, driving the guard the way
-// graph_run's loop does (try shape, observe, retry on dropped, else unverified).
-// ---------------------------------------------------------------------------
-
-// A fake app.queuePrompt for a build that ONLY honors the QueuePromptOptions
-// object — the legacy positional array is silently ignored (#556's build).
-function makeOptionsOnlyQueuePrompt(fetchApi, posted) {
-  return async (number, batch, arg) => {
-    const queueNodeIds = Array.isArray(arg) ? undefined : arg?.queueNodeIds;
-    const body = { prompt: OUR_OUTPUT, client_id: "x" };
-    if (queueNodeIds) body.partial_execution_targets = queueNodeIds;
-    await fetchApi("/prompt", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    });
-    posted.push(body);
+test("#556 integration: a build honoring NEITHER shape ⇒ truthful refusal, ZERO dispatches", async () => {
+  const apiTarget = { fetchApi: makeServer() };
+  const app = makeFrontend({ shape: "positional", apiTarget });
+  // positional honors the array… force neither by overriding queuePrompt to always drop targets
+  app.queuePrompt = async (number, batch) => {
+    const body = frontendBody({ output: OUR_OUTPUT, number, targets: null });
+    app.posted.push(body);
+    await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
+    return true;
   };
-}
-
-test("#556 e2e: an options-only frontend (drops the legacy array) still runs SCOPED — the blocked attempt never dispatched, the retry delivers", async () => {
-  const posted = [];
-  const dispatched = [];
-  const origFetchApi = makeFetchSpy(async () => {
-    dispatched.push(true);
-    return jsonResponse(200, { prompt_id: "p1" });
-  });
-  let outcome = null;
-  for (const scopeArg of queuePromptScopeArgs(["14"])) {
-    const guard = createScopedRunGuard({
-      origFetchApi, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
-    });
-    const queuePrompt = makeOptionsOnlyQueuePrompt(guard, posted);
-    await queuePrompt(0, 1, scopeArg);
-    if (guard.state.observed > 0) { outcome = "scoped"; break; }
-    if (guard.state.dropped) { outcome = "dropped"; continue; }
-    outcome = "unverified";
-    break;
-  }
-  assert.equal(outcome, "scoped", "the retry shape delivered the scope");
-  assert.equal(dispatched.length, 1, "exactly ONE prompt actually dispatched (no double-queue)");
-  assert.equal(posted.length, 2, "both shapes were attempted");
-  assert.equal(posted[0].partial_execution_targets, undefined, "attempt 1 (array) dropped by this build");
-  assert.deepEqual(posted[1].partial_execution_targets, ["14"], "attempt 2 (options object) delivered the scope");
+  const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
+  assert.equal(result.outcome, "refused");
+  assert.match(result.error, /node 14/);
+  assert.match(result.error, /Nothing was queued/);
+  assert.equal(apiTarget.fetchApi.calls.length, 0, "no full-graph prompt ever left the tab");
 });
 
-test("#556 e2e: a build that honors NEITHER shape ⇒ truthful refusal, ZERO dispatches", async () => {
-  const dispatched = [];
-  const origFetchApi = makeFetchSpy(async () => {
-    dispatched.push(true);
-    return jsonResponse(200, { prompt_id: "p1" });
+test("#556 r3 P0-1 integration: THE SENTINEL ACTUALLY INSTALLS — after a give-up timeout, api.fetchApi is STILL the guard and refuses the late scope-dropped post with zero dispatch", async () => {
+  const apiTarget = { fetchApi: makeServer() };
+  const prev = apiTarget.fetchApi;
+  // Busy SHIM-LESS frontend (drops the legacy array ⇒ the deferred item has no
+  // scope), and queueItems NOT accessible (hard-private build) ⇒ cancel impossible.
+  const app = makeFrontend({ shape: "shimless", defer: true, apiTarget });
+  delete app.queueItems;
+  const result = await dispatchScopedRun({
+    app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
+    verifyTimeoutMs: 50, lingerMs: 120,
   });
-  let dropped = null;
-  for (const scopeArg of queuePromptScopeArgs(["14"])) {
-    const guard = createScopedRunGuard({
-      origFetchApi, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
-      onScopeDropped: (m) => (dropped = m),
-    });
-    // This build posts OUR prompt with NO targets regardless of the arg shape.
-    await guard("/prompt", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(OUR_FULL_BODY),
-    });
-    if (guard.state.observed > 0) break;
-    if (!guard.state.dropped) break;
-  }
-  assert.match(dropped, /node 14/);
-  assert.match(dropped, /Nothing was queued/);
-  assert.equal(dispatched.length, 0, "no full-graph prompt ever left the tab");
+  assert.equal(result.outcome, "unverified");
+  assert.match(result.error, /sentinel/);
+  assert.notEqual(apiTarget.fetchApi, prev, "the sentinel guard is STILL installed after the run returned");
+  // The deferred item finally posts — through the sentinel — scope dropped.
+  const res = await app.postDeferred(app.deferredItem);
+  assert.equal(res.status, 400, "the sentinel refuses the late scope-dropped dispatch");
+  assert.equal(prev.calls.length, 0, "no full-graph dispatch escapes — even after the timeout");
+  // …and the sentinel self-removes at the long bound.
+  await sleep(160);
+  assert.equal(apiTarget.fetchApi, prev, "sentinel self-removes at the linger bound");
 });
 
-test("#556 e2e: a signature-less run still verifies a post that CARRIES the scope (degraded attribution never blocks, never lies)", async () => {
-  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "p1" }));
-  const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: null, batch: 1, toNodeId: 14 });
-  // Our scoped post is still observed without a signature…
-  await guard(...promptPost(OUR_SCOPED_BODY));
-  assert.equal(guard.state.observed, 1);
-  assert.equal(spy.calls.length, 1);
-  // …and a targetless body CANNOT be attributed ⇒ passed through, not blocked.
-  await guard(...promptPost(OUR_FULL_BODY));
-  assert.equal(spy.calls.length, 2);
-  assert.equal(guard.state.dropped, null);
+test("#556 r3 P0-3 integration: timeout CANCELS our tagged pending item (assert the removal) — guard restored, no sentinel", async () => {
+  const apiTarget = { fetchApi: makeServer() };
+  const prev = apiTarget.fetchApi;
+  const app = makeFrontend({ shape: "shim", defer: true, apiTarget });
+  // A foreign identical-scope item also pending — must survive.
+  app.queueItems.push({ number: 0, batchCount: 1, queueNodeIds: ["14"] });
+  const result = await dispatchScopedRun({
+    app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
+    verifyTimeoutMs: 50, lingerMs: 1000,
+  });
+  assert.equal(result.outcome, "unverified");
+  assert.match(result.error, /REMOVED/);
+  assert.equal(app.queueItems.length, 1, "ONLY our tagged item was removed");
+  assert.deepEqual(app.queueItems[0].queueNodeIds, ["14"]);
+  assert.equal(apiTarget.fetchApi, prev, "guard restored — no sentinel needed after a successful cancel");
+  assert.equal(apiTarget.fetchApi.calls.length, 0, "nothing was ever dispatched");
+});
+
+test("#556 r3 P0-2 integration: degraded mode FAILS CLOSED — graphToPrompt failure refuses BEFORE queuePrompt (never 'dispatch and hope')", async () => {
+  const apiTarget = { fetchApi: makeServer() };
+  const app = makeFrontend({ shape: "shim", apiTarget, failGraphToPrompt: true });
+  let queuePromptCalled = false;
+  const origQP = app.queuePrompt;
+  app.queuePrompt = async (...a) => { queuePromptCalled = true; return origQP(...a); };
+  const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
+  assert.equal(result.outcome, "unverifiable");
+  assert.match(result.error, /cannot be dispatched safely/);
+  assert.equal(queuePromptCalled, false, "queuePrompt is never called without a signature");
+  assert.equal(apiTarget.fetchApi.calls.length, 0, "nothing dispatched — the failure is closed, not open");
+});
+
+test("#556 r3 P0-3 integration: foreign traffic during our window is untouched — same-graph user full run + identical-scope foreign scoped run; only OUR marked post is observed and captured", async () => {
+  const server = makeServer();
+  const apiTarget = { fetchApi: server };
+  const app = makeFrontend({ shape: "shim", defer: true, apiTarget });
+  const ids = [];
+  const promise = dispatchScopedRun({
+    app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
+    verifyTimeoutMs: 500, lingerMs: 1000,
+    onPromptId: (p) => ids.push(p),
+  });
+  await sleep(20); // guard is installed, waiting for observation
+  // A user queues a full run of the SAME graph (UI: number=0 ⇒ unmarked).
+  const userRes = await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(frontendBody({ number: 0, targets: null })) });
+  assert.equal(userRes.status, 200, "the user's run is dispatched normally");
+  // A foreign scoped run with the SAME targets (also unmarked).
+  const foreignRes = await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(frontendBody({ number: 0, targets: ["14"] })) });
+  assert.equal(foreignRes.status, 200);
+  assert.equal(server.calls.length, 2, "both foreign posts dispatched untouched");
+  // Now OUR deferred item posts (marked, scoped) — observed.
+  await app.postDeferred(app.deferredItem);
+  const result = await promise;
+  assert.equal(result.outcome, "dispatched");
+  assert.deepEqual(ids, ["srv-3"], "only OUR prompt_id was captured (srv-1/2 were the foreign posts)");
+  assert.equal(server.calls.length, 3);
 });
 
 // ---------------------------------------------------------------------------
@@ -496,8 +431,7 @@ test("#556: a to_node_id that went STALE (graph changed after the id was capture
   const staleRoot = { _nodes: [outputNode(14)], getNodeById(id) { return this._nodes.find((n) => Number(n.id) === Number(id)) ?? null; } };
   assert.equal(resolveRunToNodeTarget(staleRoot, null, 14).ok, true);
   const liveRoot = { _nodes: [outputNode(15)], getNodeById(id) { return this._nodes.find((n) => Number(n.id) === Number(id)) ?? null; } };
-  const res = resolveRunToNodeTarget(liveRoot, null, 14);
-  assert.deepEqual(res, { ok: false, code: "not_found", node: null });
+  assert.deepEqual(resolveRunToNodeTarget(liveRoot, null, 14), { ok: false, code: "not_found", node: null });
 });
 
 test("#556: a NON-output target is refused (not_output) — it can never be an execution root", () => {

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -2,28 +2,36 @@
  * Unit tests for web/js/lib/run-scope-guard.js — run with `node --test`.
  *
  * Guards #556: a scoped panel_run (to_node_id, "run to node") must NEVER
- * silently fall through to a FULL-graph execution. The queuePrompt 3rd-argument
- * shape differs across frontend builds (positional NodeExecutionId[] vs
- * QueuePromptOptions { queueNodeIds }); a build that accepts only one shape
- * silently IGNORES the other, so the scope never reaches POST /prompt and the
- * full graph queues while panel_run reports ran_to_node. The guard inspects the
- * outgoing /prompt body and REFUSES a scopeless dispatch before it leaves —
- * these tests pin that refusal (no full-graph dispatch) and that a verifiably
- * scoped run still runs scoped on both frontend build shapes.
+ * silently fall through to a FULL-graph execution — and (codex gate) must do so
+ * without breaking the tab around it:
+ *
+ *  P0 — a busy app.queuePrompt returns early and posts the item LATER; a guard
+ *       restored at queuePrompt's return never sees that deferred dispatch. The
+ *       scoped guard stays installed until our dispatch is OBSERVED or a
+ *       bounded timeout, and a run whose dispatch never surfaces reports a
+ *       truthful "unverified — nothing confirmed queued", never queued:true.
+ *
+ *  P1 — while installed, the guard sees EVERY POST /prompt in the tab. It only
+ *       refuses a targetless body matching THIS run's prompt signature (and
+ *       only within the batch count); unrelated full runs and other scoped runs
+ *       pass through untouched and are never captured as ours.
  */
 import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
   queuePromptScopeArgs,
+  promptSignature,
+  promptSignatureFromBody,
   verifyScopedPromptBody,
   scopeDroppedError,
+  scopeUnverifiedError,
   createRunFetchInterceptor,
+  createScopedRunGuard,
 } from "../../web/js/lib/run-scope-guard.js";
 import { resolveRunToNodeTarget } from "../../web/js/lib/subgraph-scope.js";
 
-// A Response double with the surface the interceptor + frontend rejection path
-// use (status, clone().json(), text()).
+// A Response double with the surface the guard + frontend rejection path use.
 function jsonResponse(status, obj) {
   return {
     status,
@@ -34,8 +42,8 @@ function jsonResponse(status, obj) {
   };
 }
 
-// A recording origFetchApi double. `responder(route, options)` produces the
-// response; every call is logged so tests can prove a dispatch did/didn't happen.
+// A recording origFetchApi double; every call is logged so tests can prove a
+// dispatch did/didn't happen.
 function makeFetchSpy(responder) {
   const calls = [];
   const fetchApi = async (route, options) => {
@@ -55,8 +63,21 @@ const promptPost = (body) => [
   },
 ];
 
+// The graphToPrompt output OUR scoped run queued (two branches: a KSampler
+// trunk, a SaveImage branch, and the PreviewAny we scope to).
+const OUR_OUTPUT = {
+  "3": { class_type: "KSampler", inputs: {} },
+  "9": { class_type: "SaveImage", inputs: {} },
+  "14": { class_type: "PreviewAny", inputs: {} },
+};
+const OUR_SIGNATURE = promptSignature(OUR_OUTPUT);
+const OUR_FULL_BODY = { prompt: OUR_OUTPUT, client_id: "x" };
+const OUR_SCOPED_BODY = { prompt: OUR_OUTPUT, client_id: "x", partial_execution_targets: ["14"] };
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
 // ---------------------------------------------------------------------------
-// queuePromptScopeArgs — the shapes graph_run tries, in order.
+// queuePromptScopeArgs / signatures / pure verdicts
 // ---------------------------------------------------------------------------
 
 test("#556 queuePromptScopeArgs: no scope ⇒ a single undefined arg (plain full run, historical call shape)", () => {
@@ -71,160 +92,231 @@ test("#556 queuePromptScopeArgs: a scope ⇒ positional array FIRST, then the op
   assert.deepEqual(second, { queueNodeIds: ["76:34"] });
 });
 
-// ---------------------------------------------------------------------------
-// verifyScopedPromptBody — the pure verdict.
-// ---------------------------------------------------------------------------
-
-test("#556 verify: body carrying EXACTLY the requested scope passes (incl. colon-path exec ids)", () => {
-  assert.deepEqual(verifyScopedPromptBody(JSON.stringify({ partial_execution_targets: ["14"] }), ["14"]), {
-    ok: true,
-  });
-  assert.deepEqual(
-    verifyScopedPromptBody(JSON.stringify({ partial_execution_targets: ["10:15:359"] }), ["10:15:359"]),
-    { ok: true },
-  );
+test("#556 promptSignature: node-id|class_type set, widget values excluded, order-insensitive", () => {
+  const a = promptSignature({ "9": { class_type: "B", inputs: { seed: 1 } }, "3": { class_type: "A" } });
+  const b = promptSignature({ "3": { class_type: "A" }, "9": { class_type: "B", inputs: { seed: 999 } } });
+  assert.equal(a, b, "same node set with different widget values ⇒ same signature");
+  assert.notEqual(promptSignature({ "3": { class_type: "A" } }), a, "different node set ⇒ different signature");
+  assert.equal(promptSignature(null), null);
+  assert.equal(promptSignature({}), null);
 });
 
-test("#556 verify: NO partial_execution_targets in the body ⇒ scope_missing refusal", () => {
-  const v = verifyScopedPromptBody(JSON.stringify({ prompt: {}, client_id: "x" }), ["14"]);
-  assert.equal(v.ok, false);
-  assert.equal(v.reason, "scope_missing");
-  assert.deepEqual(v.expected, ["14"]);
+test("#556 promptSignatureFromBody: reads body.prompt; unparseable ⇒ null", () => {
+  assert.equal(promptSignatureFromBody(JSON.stringify({ prompt: OUR_OUTPUT })), OUR_SIGNATURE);
+  assert.equal(promptSignatureFromBody("not-json{"), null);
+  assert.equal(promptSignatureFromBody(undefined), null);
 });
 
-test("#556 verify: an EMPTY targets list is a dropped scope, not a scoped run", () => {
-  const v = verifyScopedPromptBody(JSON.stringify({ partial_execution_targets: [] }), ["14"]);
-  assert.equal(v.ok, false);
-  assert.equal(v.reason, "scope_missing");
-});
-
-test("#556 verify: WRONG or EXTRA targets ⇒ scope_mismatch refusal", () => {
-  const wrong = verifyScopedPromptBody(JSON.stringify({ partial_execution_targets: ["9"] }), ["14"]);
-  assert.equal(wrong.ok, false);
-  assert.equal(wrong.reason, "scope_mismatch");
-  assert.deepEqual(wrong.got, ["9"]);
-  const extra = verifyScopedPromptBody(JSON.stringify({ partial_execution_targets: ["14", "9"] }), ["14"]);
-  assert.equal(extra.ok, false);
-  assert.equal(extra.reason, "scope_mismatch");
-});
-
-test("#556 verify: an unparseable body is UNVERIFIABLE ⇒ refuse (never fail open)", () => {
-  const v = verifyScopedPromptBody("not-json{", ["14"]);
-  assert.equal(v.ok, false);
-  assert.equal(v.reason, "scope_missing");
-  const u = verifyScopedPromptBody(undefined, ["14"]);
-  assert.equal(u.ok, false);
-});
-
-test("#556 verify: numeric targets normalize to strings; no scope requested ⇒ always ok", () => {
-  assert.deepEqual(verifyScopedPromptBody(JSON.stringify({ partial_execution_targets: [14] }), ["14"]), {
-    ok: true,
-  });
+test("#556 verifyScopedPromptBody: exact scope passes; missing/empty/wrong/extra/unparseable all refuse", () => {
+  assert.deepEqual(verifyScopedPromptBody(JSON.stringify({ partial_execution_targets: ["10:15:359"] }), ["10:15:359"]), { ok: true });
+  assert.equal(verifyScopedPromptBody(JSON.stringify({ prompt: {} }), ["14"]).reason, "scope_missing");
+  assert.equal(verifyScopedPromptBody(JSON.stringify({ partial_execution_targets: [] }), ["14"]).reason, "scope_missing");
+  assert.equal(verifyScopedPromptBody(JSON.stringify({ partial_execution_targets: ["9"] }), ["14"]).reason, "scope_mismatch");
+  assert.equal(verifyScopedPromptBody(JSON.stringify({ partial_execution_targets: ["14", "9"] }), ["14"]).reason, "scope_mismatch");
+  assert.equal(verifyScopedPromptBody("garbage{", ["14"]).ok, false);
   assert.deepEqual(verifyScopedPromptBody("garbage", null), { ok: true });
-  assert.deepEqual(verifyScopedPromptBody("garbage", []), { ok: true });
 });
 
 test("#556 scopeDroppedError: names the node and states NOTHING was queued", () => {
-  const msg = scopeDroppedError({
-    toNodeId: 14,
-    verdict: { ok: false, reason: "scope_missing", expected: ["14"], got: null },
-  });
+  const msg = scopeDroppedError({ toNodeId: 14, verdict: { ok: false, reason: "scope_missing", expected: ["14"], got: null } });
   assert.match(msg, /node 14/);
   assert.match(msg, /NOT applied/);
   assert.match(msg, /Nothing was queued/);
-  assert.match(msg, /full-graph/);
+});
+
+test("#556 scopeUnverifiedError: truthful — nothing CONFIRMED queued, never claims a scoped run happened", () => {
+  const msg = scopeUnverifiedError({ toNodeId: 14, timeoutMs: 5000 });
+  assert.match(msg, /node 14/);
+  assert.match(msg, /could not be verified/);
+  assert.match(msg, /CONFIRMED queued/i);
+  assert.doesNotMatch(msg, /queued:\s*true/);
+  assert.doesNotMatch(msg, /Nothing was queued/, "a deferred post may still land — must not claim otherwise");
 });
 
 // ---------------------------------------------------------------------------
-// createRunFetchInterceptor — the guard graph_run installs.
+// createRunFetchInterceptor — the UNSCOPED path (historical #358/#370 capture)
 // ---------------------------------------------------------------------------
 
-test("#556 REGRESSION: a scoped run whose scope the frontend dropped is REFUSED — origFetchApi is NEVER called (no full-graph dispatch)", async () => {
-  // Simulates the #556 frontend: queuePrompt accepted the call but the POST
-  // /prompt body carries NO partial_execution_targets.
-  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "should-never-happen" }));
-  let dropped = null;
-  const intercepted = createRunFetchInterceptor({
-    origFetchApi: spy,
-    partialTargets: ["14"],
-    toNodeId: 14,
-    onScopeDropped: (m) => (dropped = m),
-  });
-  const [route, options] = promptPost({ prompt: {}, client_id: "x" });
+test("#556 unscoped interceptor: captures top-level rejection and prompt_id, leaves the request untouched", async () => {
+  const spy = makeFetchSpy(async () => jsonResponse(400, { error: { type: "missing_node_type" } }));
+  let rejection = null;
+  const intercepted = createRunFetchInterceptor({ origFetchApi: spy, onRejection: (r) => (rejection = r) });
+  const [route, options] = promptPost({ prompt: {} });
   const res = await intercepted(route, options);
-  assert.equal(spy.calls.length, 0, "the scopeless prompt must NEVER be dispatched");
-  assert.equal(res.status, 400, "the refusal is shaped like a server rejection");
-  assert.match(dropped, /node 14/);
-  assert.match(dropped, /Nothing was queued/);
-});
+  assert.equal(spy.calls.length, 1);
+  assert.equal(spy.calls[0].options, options);
+  assert.equal(res.status, 400);
+  assert.deepEqual(rejection, { error: { type: "missing_node_type" }, node_errors: null });
 
-test("#556: a scoped run whose body carries the scope is DISPATCHED verbatim and the prompt_id captured", async () => {
-  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: 123 }));
+  const spy2 = makeFetchSpy(async () => jsonResponse(200, { prompt_id: 0 }));
   const ids = [];
-  const intercepted = createRunFetchInterceptor({
-    origFetchApi: spy,
-    partialTargets: ["76:34"],
-    toNodeId: 34,
-    onPromptId: (pid) => ids.push(pid),
+  const intercepted2 = createRunFetchInterceptor({ origFetchApi: spy2, onPromptId: (p) => ids.push(p) });
+  await intercepted2(...promptPost({ prompt: {} }));
+  assert.deepEqual(ids, ["0"], "falsy-but-valid id 0 is captured, string-normalized");
+});
+
+test("#556 unscoped interceptor: non-/prompt routes are not inspected", async () => {
+  const spy = makeFetchSpy(async () => jsonResponse(200, {}));
+  const intercepted = createRunFetchInterceptor({ origFetchApi: spy, onRejection: () => assert.fail("no capture") });
+  await intercepted("/history", { method: "GET" });
+  assert.equal(spy.calls.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// createScopedRunGuard — the SCOPED path
+// ---------------------------------------------------------------------------
+
+test("#556 guard: OUR scoped dispatch (body carries exactly our targets) is observed, dispatched verbatim, prompt_id captured", async () => {
+  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "p1" }));
+  const ids = [];
+  const guard = createScopedRunGuard({
+    origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
+    onPromptId: (p) => ids.push(p),
   });
-  const [route, options] = promptPost({ prompt: {}, partial_execution_targets: ["76:34"] });
-  const res = await intercepted(route, options);
+  const [route, options] = promptPost(OUR_SCOPED_BODY);
+  const res = await guard(route, options);
   assert.equal(spy.calls.length, 1, "scoped prompt dispatched");
   assert.equal(spy.calls[0].options, options, "request passed through untouched");
   assert.equal(res.status, 200);
-  assert.deepEqual(ids, ["123"], "prompt_id normalized to a string at capture");
+  assert.equal(guard.state.observed, 1);
+  assert.equal(guard.state.dropped, null);
+  assert.deepEqual(ids, ["p1"]);
 });
 
-test("#556: response capture preserved — a top-level server rejection (non-200) is reported (#358 channel)", async () => {
-  const rejectionBody = { error: { type: "missing_node_type", message: "no class_type" } };
-  const spy = makeFetchSpy(async () => jsonResponse(400, rejectionBody));
+test("#556 guard: a server rejection of OUR scoped dispatch is captured (#358 channel preserved)", async () => {
+  const spy = makeFetchSpy(async () => jsonResponse(400, { error: { type: "prompt_outputs_failed_validation" } }));
   let rejection = null;
-  const intercepted = createRunFetchInterceptor({
-    origFetchApi: spy,
-    partialTargets: ["14"],
-    toNodeId: 14,
+  const guard = createScopedRunGuard({
+    origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
     onRejection: (r) => (rejection = r),
   });
-  const [route, options] = promptPost({ prompt: {}, partial_execution_targets: ["14"] });
-  await intercepted(route, options);
+  await guard(...promptPost(OUR_SCOPED_BODY));
   assert.equal(spy.calls.length, 1, "a verifiably scoped prompt IS dispatched (and may be refused by the server)");
-  assert.deepEqual(rejection, { error: rejectionBody.error, node_errors: null });
+  assert.equal(rejection?.error?.type, "prompt_outputs_failed_validation");
 });
 
-test("#556: non-/prompt routes and non-POST methods pass through UNINSPECTED even when scoped", async () => {
-  const spy = makeFetchSpy(async () => jsonResponse(200, {}));
+test("#556 REGRESSION: OUR dispatch gone wrong (targetless body with OUR signature) is REFUSED — origFetchApi NEVER called (no full-graph dispatch)", async () => {
+  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "must-never-happen" }));
   let dropped = null;
-  const intercepted = createRunFetchInterceptor({
-    origFetchApi: spy,
-    partialTargets: ["14"],
-    toNodeId: 14,
-    onScopeDropped: () => (dropped = true),
+  const guard = createScopedRunGuard({
+    origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
+    onScopeDropped: (m) => (dropped = m),
   });
-  await intercepted("/history", { method: "GET" });
-  await intercepted("/prompt", { method: "GET" });
-  await intercepted("/upload/image", { method: "POST", body: "..." });
-  assert.equal(spy.calls.length, 3);
-  assert.equal(dropped, null);
+  const res = await guard(...promptPost(OUR_FULL_BODY));
+  assert.equal(spy.calls.length, 0, "the scopeless prompt must NEVER be dispatched");
+  assert.equal(res.status, 400, "refusal shaped like a server rejection");
+  assert.equal(guard.state.observed, 0);
+  assert.match(guard.state.dropped, /node 14/);
+  assert.match(dropped, /Nothing was queued/);
 });
 
-test("#556: an UNSCOPED run (partialTargets null) is never scope-checked — the normal full-run path is preserved", async () => {
-  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "p1" }));
-  let dropped = null;
-  const intercepted = createRunFetchInterceptor({
-    origFetchApi: spy,
-    partialTargets: null,
-    onScopeDropped: () => (dropped = true),
+test("#556 P1: an UNRELATED full run (different signature) during the window passes through untouched and is NOT captured", async () => {
+  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "user-run" }));
+  let dropped = null, captured = null;
+  const guard = createScopedRunGuard({
+    origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
+    onScopeDropped: (m) => (dropped = m),
+    onPromptId: (p) => (captured = p),
   });
-  const [route, options] = promptPost({ prompt: {}, client_id: "x" });
-  const res = await intercepted(route, options);
-  assert.equal(spy.calls.length, 1, "full run dispatched");
+  const otherGraph = { prompt: { "1": { class_type: "LoadImage" }, "2": { class_type: "SaveImage" } }, client_id: "x" };
+  const [route, options] = promptPost(otherGraph);
+  const res = await guard(route, options);
+  assert.equal(spy.calls.length, 1, "the user's run is dispatched");
+  assert.equal(spy.calls[0].options, options);
   assert.equal(res.status, 200);
-  assert.equal(dropped, null);
+  assert.equal(dropped, null, "no refusal");
+  assert.equal(captured, null, "not captured as ours");
+  assert.equal(guard.state.observed, 0);
+  assert.equal(guard.state.dropped, null);
+});
+
+test("#556 P1: an unrelated SCOPED run (someone else's targets) passes through untouched", async () => {
+  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "other-scoped" }));
+  let captured = null;
+  const guard = createScopedRunGuard({
+    origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
+    onPromptId: (p) => (captured = p),
+  });
+  const body = { prompt: OUR_OUTPUT, client_id: "x", partial_execution_targets: ["9"] };
+  const res = await guard(...promptPost(body));
+  assert.equal(spy.calls.length, 1);
+  assert.equal(res.status, 200);
+  assert.equal(captured, null, "another scope's prompt_id is never claimed as ours");
+  assert.equal(guard.state.observed, 0);
+});
+
+test("#556 P1: refusal is bounded by the batch — a same-signature full body BEYOND our batch count passes through", async () => {
+  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "late-run" }));
+  const guard = createScopedRunGuard({
+    origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
+  });
+  const first = await guard(...promptPost(OUR_FULL_BODY));
+  assert.equal(first.status, 400, "our own dropped dispatch is refused");
+  assert.equal(spy.calls.length, 0);
+  const second = await guard(...promptPost(OUR_FULL_BODY));
+  assert.equal(second.status, 200, "a further same-signature full run is NOT ours to refuse");
+  assert.equal(spy.calls.length, 1, "it passes through");
+});
+
+test("#556 guard: an unparseable body is unattributable ⇒ passed through, never blocked (fail-safe toward strangers)", async () => {
+  const spy = makeFetchSpy(async () => jsonResponse(200, {}));
+  const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14 });
+  await guard("/prompt", { method: "POST", body: "not-json{" });
+  assert.equal(spy.calls.length, 1);
+  assert.equal(guard.state.dropped, null);
+});
+
+test("#556 P0 DEFERRED RACE: queuePrompt returned early (busy) — the guard is STILL installed and refuses the deferred invalid-shape dispatch, zero real posts", async () => {
+  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "must-never-happen" }));
+  let dropped = null;
+  const guard = createScopedRunGuard({
+    origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
+    onScopeDropped: (m) => (dropped = m),
+  });
+  // graph_run awaits queuePrompt (which returned early), then waits on the guard.
+  const verdict = guard.waitForVerdict(1000);
+  // …the in-flight processor serializes and posts OUR item 30ms later, through
+  // the still-installed guard, with the scope dropped (invalid shape).
+  await sleep(30);
+  const res = await guard(...promptPost(OUR_FULL_BODY));
+  assert.equal(await verdict, true, "the deferred dispatch is OBSERVED by the still-installed guard");
+  assert.equal(res.status, 400);
+  assert.equal(spy.calls.length, 0, "the deferred full-graph prompt never left the tab");
+  assert.match(dropped, /node 14/);
+});
+
+test("#556 P0 DEFERRED, correct shape: the late scoped post IS observed and its prompt_id captured", async () => {
+  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "deferred-pid" }));
+  const ids = [];
+  const guard = createScopedRunGuard({
+    origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
+    onPromptId: (p) => ids.push(p),
+  });
+  const verdict = guard.waitForVerdict(1000);
+  await sleep(30);
+  await guard(...promptPost(OUR_SCOPED_BODY));
+  assert.equal(await verdict, true);
+  assert.equal(guard.state.observed, 1);
+  assert.deepEqual(ids, ["deferred-pid"]);
+});
+
+test("#556 P0 TIMEOUT: nothing surfaces within the window ⇒ waitForVerdict false, state clean ⇒ graph_run reports UNVERIFIED (never queued:true)", async () => {
+  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "nope" }));
+  const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14 });
+  const seen = await guard.waitForVerdict(50);
+  assert.equal(seen, false);
+  assert.equal(guard.state.observed, 0);
+  assert.equal(guard.state.dropped, null);
+  assert.equal(spy.calls.length, 0);
+  // This is exactly the condition graph_run maps to scopeUnverifiedError:
+  // a truthful "could not verify — nothing confirmed queued", not queued:true.
+  const msg = scopeUnverifiedError({ toNodeId: 14, timeoutMs: 5000 });
+  assert.match(msg, /could not be verified/);
 });
 
 // ---------------------------------------------------------------------------
-// End-to-end across the two frontend build shapes, driving the interceptor the
-// way graph_run's retry loop does (array first, then { queueNodeIds }).
+// End-to-end across frontend build shapes, driving the guard the way
+// graph_run's loop does (try shape, observe, retry on dropped, else unverified).
 // ---------------------------------------------------------------------------
 
 // A fake app.queuePrompt for a build that ONLY honors the QueuePromptOptions
@@ -232,22 +324,7 @@ test("#556: an UNSCOPED run (partialTargets null) is never scope-checked — the
 function makeOptionsOnlyQueuePrompt(fetchApi, posted) {
   return async (number, batch, arg) => {
     const queueNodeIds = Array.isArray(arg) ? undefined : arg?.queueNodeIds;
-    const body = { prompt: {}, client_id: "x" };
-    if (queueNodeIds) body.partial_execution_targets = queueNodeIds;
-    await fetchApi("/prompt", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    });
-    posted.push(body);
-  };
-}
-
-// A fake app.queuePrompt for a build that ONLY honors the positional array.
-function makePositionalOnlyQueuePrompt(fetchApi, posted) {
-  return async (number, batch, arg) => {
-    const queueNodeIds = Array.isArray(arg) ? arg : undefined;
-    const body = { prompt: {}, client_id: "x" };
+    const body = { prompt: OUR_OUTPUT, client_id: "x" };
     if (queueNodeIds) body.partial_execution_targets = queueNodeIds;
     await fetchApi("/prompt", {
       method: "POST",
@@ -265,52 +342,23 @@ test("#556 e2e: an options-only frontend (drops the legacy array) still runs SCO
     dispatched.push(true);
     return jsonResponse(200, { prompt_id: "p1" });
   });
-  let scopeDropped = null;
+  let outcome = null;
   for (const scopeArg of queuePromptScopeArgs(["14"])) {
-    scopeDropped = null;
-    const intercepted = createRunFetchInterceptor({
-      origFetchApi,
-      partialTargets: ["14"],
-      toNodeId: 14,
-      onScopeDropped: (m) => (scopeDropped = m),
+    const guard = createScopedRunGuard({
+      origFetchApi, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
     });
-    const queuePrompt = makeOptionsOnlyQueuePrompt(intercepted, posted);
+    const queuePrompt = makeOptionsOnlyQueuePrompt(guard, posted);
     await queuePrompt(0, 1, scopeArg);
-    if (!scopeDropped) break;
+    if (guard.state.observed > 0) { outcome = "scoped"; break; }
+    if (guard.state.dropped) { outcome = "dropped"; continue; }
+    outcome = "unverified";
+    break;
   }
-  assert.equal(scopeDropped, null, "the retry shape delivered the scope");
+  assert.equal(outcome, "scoped", "the retry shape delivered the scope");
   assert.equal(dispatched.length, 1, "exactly ONE prompt actually dispatched (no double-queue)");
   assert.equal(posted.length, 2, "both shapes were attempted");
-  assert.deepEqual(posted[0].partial_execution_targets, undefined, "attempt 1 (array) dropped by this build");
+  assert.equal(posted[0].partial_execution_targets, undefined, "attempt 1 (array) dropped by this build");
   assert.deepEqual(posted[1].partial_execution_targets, ["14"], "attempt 2 (options object) delivered the scope");
-});
-
-test("#556 e2e: a positional-only frontend runs SCOPED on the FIRST shape (no retry needed)", async () => {
-  const posted = [];
-  const dispatched = [];
-  const origFetchApi = makeFetchSpy(async () => {
-    dispatched.push(true);
-    return jsonResponse(200, { prompt_id: "p1" });
-  });
-  let scopeDropped = null;
-  let attempts = 0;
-  for (const scopeArg of queuePromptScopeArgs(["14"])) {
-    attempts++;
-    scopeDropped = null;
-    const intercepted = createRunFetchInterceptor({
-      origFetchApi,
-      partialTargets: ["14"],
-      toNodeId: 14,
-      onScopeDropped: (m) => (scopeDropped = m),
-    });
-    const queuePrompt = makePositionalOnlyQueuePrompt(intercepted, posted);
-    await queuePrompt(0, 1, scopeArg);
-    if (!scopeDropped) break;
-  }
-  assert.equal(scopeDropped, null);
-  assert.equal(attempts, 1, "array first ⇒ no retry on positional builds");
-  assert.equal(dispatched.length, 1);
-  assert.deepEqual(posted[0].partial_execution_targets, ["14"]);
 });
 
 test("#556 e2e: a build that honors NEITHER shape ⇒ truthful refusal, ZERO dispatches", async () => {
@@ -319,26 +367,37 @@ test("#556 e2e: a build that honors NEITHER shape ⇒ truthful refusal, ZERO dis
     dispatched.push(true);
     return jsonResponse(200, { prompt_id: "p1" });
   });
-  let scopeDropped = null;
+  let dropped = null;
   for (const scopeArg of queuePromptScopeArgs(["14"])) {
-    scopeDropped = null;
-    const intercepted = createRunFetchInterceptor({
-      origFetchApi,
-      partialTargets: ["14"],
-      toNodeId: 14,
-      onScopeDropped: (m) => (scopeDropped = m),
+    const guard = createScopedRunGuard({
+      origFetchApi, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
+      onScopeDropped: (m) => (dropped = m),
     });
-    // This build posts a body with NO targets regardless of the arg shape.
-    await intercepted("/prompt", {
+    // This build posts OUR prompt with NO targets regardless of the arg shape.
+    await guard("/prompt", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ prompt: {}, client_id: "x" }),
+      body: JSON.stringify(OUR_FULL_BODY),
     });
-    if (!scopeDropped) break;
+    if (guard.state.observed > 0) break;
+    if (!guard.state.dropped) break;
   }
-  assert.match(scopeDropped, /node 14/);
-  assert.match(scopeDropped, /Nothing was queued/);
+  assert.match(dropped, /node 14/);
+  assert.match(dropped, /Nothing was queued/);
   assert.equal(dispatched.length, 0, "no full-graph prompt ever left the tab");
+});
+
+test("#556 e2e: a signature-less run still verifies a post that CARRIES the scope (degraded attribution never blocks, never lies)", async () => {
+  const spy = makeFetchSpy(async () => jsonResponse(200, { prompt_id: "p1" }));
+  const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: null, batch: 1, toNodeId: 14 });
+  // Our scoped post is still observed without a signature…
+  await guard(...promptPost(OUR_SCOPED_BODY));
+  assert.equal(guard.state.observed, 1);
+  assert.equal(spy.calls.length, 1);
+  // …and a targetless body CANNOT be attributed ⇒ passed through, not blocked.
+  await guard(...promptPost(OUR_FULL_BODY));
+  assert.equal(spy.calls.length, 2);
+  assert.equal(guard.state.dropped, null);
 });
 
 // ---------------------------------------------------------------------------
@@ -353,15 +412,11 @@ const outputNode = (id) => ({
 });
 
 test("#556: a to_node_id that went STALE (graph changed after the id was captured) resolves not_found ⇒ refused before any dispatch", () => {
-  // The id was valid against the graph the agent last saw…
   const staleRoot = { _nodes: [outputNode(14)], getNodeById(id) { return this._nodes.find((n) => Number(n.id) === Number(id)) ?? null; } };
   assert.equal(resolveRunToNodeTarget(staleRoot, null, 14).ok, true);
-  // …but the live root no longer has it (node deleted / workflow reloaded).
   const liveRoot = { _nodes: [outputNode(15)], getNodeById(id) { return this._nodes.find((n) => Number(n.id) === Number(id)) ?? null; } };
   const res = resolveRunToNodeTarget(liveRoot, null, 14);
   assert.deepEqual(res, { ok: false, code: "not_found", node: null });
-  // graph_run maps this verdict to { queued:false, error: "node 14 was not found…" }
-  // and returns BEFORE queuePrompt — no full-graph dispatch is possible.
 });
 
 test("#556: a NON-output target is refused (not_output) — it can never be an execution root", () => {

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -237,6 +237,42 @@ test("#556 guard: OUR marked post with signature+exact targets ⇒ observed, dis
   assert.deepEqual(ids, ["srv-1"]);
 });
 
+test("#556 r6: an attributed post whose fetch THROWS is a dispatch FAILURE — never counted as verified, never captured", async () => {
+  const spy = makeServer(async () => { throw new Error("connection reset"); });
+  let captured = null;
+  const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14, queueMark: MARK_A, onPromptId: (p) => (captured = p) });
+  await assert.rejects(guard(...promptPost(frontendBody({ targets: ["14"] }))), /connection reset/);
+  assert.equal(guard.state.observed, 0, "a thrown fetch never satisfies the batch verdict");
+  assert.match(guard.state.failed, /connection reset/);
+  assert.match(guard.state.failed, /NOT reported as queued/);
+  assert.equal(captured, null, "no prompt_id claimed");
+});
+
+test("#556 r6: an attributed post with a MALFORMED response (200 without prompt_id, or non-200 without a rejection body) is a dispatch FAILURE", async () => {
+  for (const bad of [jsonResponse(200, {}), jsonResponse(500, {}), jsonResponse(200, { prompt_id: null })]) {
+    const spy = makeServer(async () => bad);
+    let captured = null;
+    const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14, queueMark: MARK_A, onPromptId: (p) => (captured = p) });
+    const res = await guard(...promptPost(frontendBody({ targets: ["14"] })));
+    assert.equal(res, bad, "the real response passes back to the frontend");
+    assert.equal(guard.state.observed, 0, `HTTP ${bad.status} malformed ⇒ not verified`);
+    assert.match(guard.state.failed, /malformed/);
+    assert.equal(captured, null);
+  }
+});
+
+test("#556 r6: a GENUINE server rejection still flows through the established #358 rejection channel (not a dispatch failure)", async () => {
+  const rejectionBody = { error: { type: "prompt_outputs_failed_validation", message: "bad input" } };
+  const spy = makeServer(async () => jsonResponse(400, rejectionBody));
+  let rejection = null;
+  const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14, queueMark: MARK_A, onRejection: (r) => (rejection = r) });
+  await guard(...promptPost(frontendBody({ targets: ["14"] })));
+  assert.equal(guard.state.rejected, 1);
+  assert.equal(guard.state.failed, null, "a server rejection is NOT a dispatch failure");
+  assert.equal(guard.state.observed, 0);
+  assert.deepEqual(rejection, { error: rejectionBody.error, node_errors: null });
+});
+
 test("#556 guard: OUR marked post with MISSING or WRONG/EXTRA targets ⇒ refused with zero dispatch", async () => {
   for (const bad of [null, ["9"], ["14", "9"]]) {
     const spy = makeServer();
@@ -254,7 +290,7 @@ test("#556 r3 P0-3: an UNMARKED post is FOREIGN even with our node set AND our t
   const spy = makeServer();
   let captured = null, dropped = null;
   const guard = createScopedRunGuard({
-    origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14,
+    origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14, queueMark: MARK_A,
     onPromptId: (p) => (captured = p), onScopeDropped: (m) => (dropped = m),
   });
   // A foreign scoped run to the same node (number=0 ⇒ no body.number ⇒ unmarked).
@@ -547,6 +583,85 @@ test("#556 r5 integration: batch=2 where the second post NEVER arrives ⇒ unver
     });
     assert.equal(res.status, 400, "the sentinel refuses the late scope-dropped batch post");
     assert.equal(server.calls.length, 1, "only the one verified scoped post ever left the tab");
+  } finally {
+    stop();
+  }
+});
+
+test("#556 r6 integration: batch=1 whose /prompt fetch THROWS ⇒ 'failed' outcome (never dispatched/queued:true), sentinel guards the incomplete batch", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer(async () => { throw new Error("connection reset"); });
+    const apiTarget = { fetchApi: server };
+    const prev = apiTarget.fetchApi;
+    const app = makeFrontend({ shape: "shim", apiTarget });
+    // The frontend catches generic submission failures and returns normally.
+    app.queuePrompt = async (number, batch, arg) => {
+      const body = frontendBody({ output: OUR_OUTPUT, number, targets: ["14"] });
+      app.posted.push(body);
+      try {
+        await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
+      } catch { /* frontend swallows generic submission failures */ }
+      return true;
+    };
+    const ids = [];
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
+      onPromptId: (p) => ids.push(p),
+    });
+    assert.equal(result.outcome, "failed");
+    assert.notEqual(result.outcome, "dispatched");
+    assert.equal(result.verified, 0);
+    assert.match(result.error, /connection reset/);
+    assert.match(result.error, /NOT reported as queued/);
+    assert.deepEqual(ids, [], "no prompt_id claimed");
+    assert.notEqual(apiTarget.fetchApi, prev, "batch unaccounted ⇒ sentinel stays (the frontend may keep looping)");
+    // A late CORRUPTED post of this run is still refused by the sentinel.
+    const res = await apiTarget.fetchApi("/prompt", {
+      method: "POST",
+      body: JSON.stringify(frontendBody({ output: OUR_OUTPUT, number: result.queueMark, targets: null })),
+    });
+    assert.equal(res.status, 400);
+    assert.equal(server.calls.length, 1, "nothing ever dispatched successfully");
+  } finally {
+    stop();
+  }
+});
+
+test("#556 r6 integration: batch=2 where post 1's fetch throws and post 2 verifies (frontend continues its loop) ⇒ still 'failed', post 2 captured for the ledger but the run is not claimed", async () => {
+  const stop = keepAlive();
+  try {
+    let call = 0;
+    const server = makeServer(async () => {
+      call++;
+      if (call === 1) throw new Error("connection reset");
+      return jsonResponse(200, { prompt_id: "srv-2" });
+    });
+    const apiTarget = { fetchApi: server };
+    const prev = apiTarget.fetchApi;
+    const app = makeFrontend({ shape: "shim", apiTarget });
+    app.queuePrompt = async (number, batch, arg) => {
+      for (let i = 0; i < batch; i++) {
+        const body = frontendBody({ output: OUR_OUTPUT, number, targets: ["14"] });
+        app.posted.push(body);
+        try {
+          await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
+        } catch { /* generic failure: the frontend CONTINUES its batch loop */ }
+      }
+      return true;
+    };
+    const ids = [];
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["14"], batch: 2, toNodeId: 14,
+      onPromptId: (p) => ids.push(p),
+    });
+    assert.equal(result.outcome, "failed", "the first post's failure terminates the run truthfully");
+    assert.match(result.error, /connection reset/);
+    assert.match(result.error, /0 of 2/);
+    assert.notEqual(result.outcome, "dispatched");
+    assert.deepEqual(ids, ["srv-2"], "post 2's prompt_id is ledger-captured (it IS queued) but the run is not reported as queued");
+    assert.equal(server.calls.length, 2);
+    assert.notEqual(apiTarget.fetchApi, prev, "batch not fully accounted ⇒ sentinel stays");
   } finally {
     stop();
   }

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -18,8 +18,9 @@ import {
   newScopedQueueMark,
   QUEUE_ITEM_TAG,
   queuePromptScopeArgs,
-  promptSignature,
-  promptSignatureFromBody,
+  promptContentHash,
+  promptContentHashFromBody,
+  collectSelfMutatingInputNames,
   verifyScopedPromptBody,
   scopeDroppedError,
   scopeUnverifiedError,
@@ -68,7 +69,7 @@ const OUR_OUTPUT = {
   "9": { class_type: "SaveImage", inputs: {} },
   "14": { class_type: "PreviewAny", inputs: {} },
 };
-const OUR_SIGNATURE = promptSignature(OUR_OUTPUT);
+const OUR_HASH = promptContentHash(OUR_OUTPUT);
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -167,13 +168,35 @@ test("#556 queuePromptScopeArgs: no scope ⇒ [undefined]; scope ⇒ array first
   assert.deepEqual(second, { queueNodeIds: ["76:34"] });
 });
 
-test("#556 promptSignature: node-id|class_type set, widget values excluded, order-insensitive", () => {
-  const a = promptSignature({ "9": { class_type: "B", inputs: { seed: 1 } }, "3": { class_type: "A" } });
-  const b = promptSignature({ "3": { class_type: "A" }, "9": { class_type: "B", inputs: { seed: 999 } } });
-  assert.equal(a, b);
-  assert.notEqual(promptSignature({ "3": { class_type: "A" } }), a);
-  assert.equal(promptSignatureFromBody(JSON.stringify({ prompt: OUR_OUTPUT })), OUR_SIGNATURE);
-  assert.equal(promptSignatureFromBody("not-json{"), null);
+test("#556 r7 promptContentHash: full CONTENT covered (ids, class types, links, widget values), key-order-insensitive", () => {
+  const a = promptContentHash({ "9": { class_type: "B", inputs: { steps: 20, model: ["3", 0] } }, "3": { class_type: "A", inputs: {} } });
+  const b = promptContentHash({ "3": { class_type: "A", inputs: {} }, "9": { class_type: "B", inputs: { model: ["3", 0], steps: 20 } } });
+  assert.equal(a, b, "same content, any key order ⇒ same hash");
+  assert.notEqual(promptContentHash({ "9": { class_type: "B", inputs: { steps: 25, model: ["3", 0] } }, "3": { class_type: "A", inputs: {} } }), a,
+    "a changed WIDGET VALUE changes the hash");
+  assert.notEqual(promptContentHash({ "9": { class_type: "B", inputs: { steps: 20, model: ["4", 0] } }, "3": { class_type: "A", inputs: {} } }), a,
+    "a changed LINK changes the hash");
+  assert.notEqual(promptContentHash({ "3": { class_type: "A" } }), a, "a changed node set changes the hash");
+  // The ONLY tolerance: inputs whose widgets self-mutate at queue time.
+  const withSeed = (seed) => promptContentHash(
+    { "3": { class_type: "KSampler", inputs: { seed, steps: 20 } } },
+    new Set(["seed"]),
+  );
+  assert.equal(withSeed(1), withSeed(999), "a self-mutating (beforeQueued) input is excluded — our own dispatch isn't refused over a rerolled seed");
+  assert.equal(promptContentHashFromBody(JSON.stringify({ prompt: OUR_OUTPUT })), OUR_HASH);
+  assert.equal(promptContentHashFromBody("not-json{"), null);
+});
+
+test("#556 r7 collectSelfMutatingInputNames: finds beforeQueued widgets across the root graph and nested subgraphs", () => {
+  const root = {
+    _nodes: [
+      { id: 1, widgets: [{ name: "seed", beforeQueued() {} }, { name: "steps" }] },
+      { id: 2, widgets: null, subgraph: { _nodes: [{ id: 3, widgets: [{ name: "noise_seed", beforeQueued() {} }] }] } },
+    ],
+  };
+  const names = collectSelfMutatingInputNames(root);
+  assert.deepEqual([...names].sort(), ["noise_seed", "seed"]);
+  assert.equal(collectSelfMutatingInputNames(null).size, 0);
 });
 
 test("#556 verifyScopedPromptBody: exact scope passes; missing/empty/wrong/extra/unparseable all refuse", () => {
@@ -227,7 +250,7 @@ test("#556 unscoped interceptor: captures top-level rejection and prompt_id, lea
 test("#556 guard: OUR marked post with signature+exact targets ⇒ observed, dispatched verbatim, prompt_id captured", async () => {
   const spy = makeServer();
   const ids = [];
-  const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14, queueMark: MARK_A, onPromptId: (p) => ids.push(p) });
+  const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], contentHash: OUR_HASH, batch: 1, toNodeId: 14, queueMark: MARK_A, onPromptId: (p) => ids.push(p) });
   const [route, options] = promptPost(frontendBody({ targets: ["14"] }));
   const res = await guard(route, options);
   assert.equal(spy.calls.length, 1);
@@ -240,7 +263,7 @@ test("#556 guard: OUR marked post with signature+exact targets ⇒ observed, dis
 test("#556 r6: an attributed post whose fetch THROWS is a dispatch FAILURE — never counted as verified, never captured", async () => {
   const spy = makeServer(async () => { throw new Error("connection reset"); });
   let captured = null;
-  const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14, queueMark: MARK_A, onPromptId: (p) => (captured = p) });
+  const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], contentHash: OUR_HASH, batch: 1, toNodeId: 14, queueMark: MARK_A, onPromptId: (p) => (captured = p) });
   await assert.rejects(guard(...promptPost(frontendBody({ targets: ["14"] }))), /connection reset/);
   assert.equal(guard.state.observed, 0, "a thrown fetch never satisfies the batch verdict");
   assert.match(guard.state.failed, /connection reset/);
@@ -252,7 +275,7 @@ test("#556 r6: an attributed post with a MALFORMED response (200 without prompt_
   for (const bad of [jsonResponse(200, {}), jsonResponse(500, {}), jsonResponse(200, { prompt_id: null })]) {
     const spy = makeServer(async () => bad);
     let captured = null;
-    const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14, queueMark: MARK_A, onPromptId: (p) => (captured = p) });
+    const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], contentHash: OUR_HASH, batch: 1, toNodeId: 14, queueMark: MARK_A, onPromptId: (p) => (captured = p) });
     const res = await guard(...promptPost(frontendBody({ targets: ["14"] })));
     assert.equal(res, bad, "the real response passes back to the frontend");
     assert.equal(guard.state.observed, 0, `HTTP ${bad.status} malformed ⇒ not verified`);
@@ -265,7 +288,7 @@ test("#556 r6: a GENUINE server rejection still flows through the established #3
   const rejectionBody = { error: { type: "prompt_outputs_failed_validation", message: "bad input" } };
   const spy = makeServer(async () => jsonResponse(400, rejectionBody));
   let rejection = null;
-  const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14, queueMark: MARK_A, onRejection: (r) => (rejection = r) });
+  const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], contentHash: OUR_HASH, batch: 1, toNodeId: 14, queueMark: MARK_A, onRejection: (r) => (rejection = r) });
   await guard(...promptPost(frontendBody({ targets: ["14"] })));
   assert.equal(guard.state.rejected, 1);
   assert.equal(guard.state.failed, null, "a server rejection is NOT a dispatch failure");
@@ -277,7 +300,7 @@ test("#556 guard: OUR marked post with MISSING or WRONG/EXTRA targets ⇒ refuse
   for (const bad of [null, ["9"], ["14", "9"]]) {
     const spy = makeServer();
     let dropped = null;
-    const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14, queueMark: MARK_A, onScopeDropped: (m) => (dropped = m) });
+    const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], contentHash: OUR_HASH, batch: 1, toNodeId: 14, queueMark: MARK_A, onScopeDropped: (m) => (dropped = m) });
     const res = await guard(...promptPost(frontendBody({ targets: bad })));
     assert.equal(spy.calls.length, 0, `targets ${JSON.stringify(bad)} must never leave the tab`);
     assert.equal(res.status, 400);
@@ -290,7 +313,7 @@ test("#556 r3 P0-3: an UNMARKED post is FOREIGN even with our node set AND our t
   const spy = makeServer();
   let captured = null, dropped = null;
   const guard = createScopedRunGuard({
-    origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14, queueMark: MARK_A,
+    origFetchApi: spy, execIds: ["14"], contentHash: OUR_HASH, batch: 1, toNodeId: 14, queueMark: MARK_A,
     onPromptId: (p) => (captured = p), onScopeDropped: (m) => (dropped = m),
   });
   // A foreign scoped run to the same node (number=0 ⇒ no body.number ⇒ unmarked).
@@ -309,7 +332,7 @@ test("#556 r3 P0-3: an UNMARKED post is FOREIGN even with our node set AND our t
 
 test("#556 guard: a marked post whose graph CHANGED under the deferred item (signature mismatch) is corrupted ⇒ refused", async () => {
   const spy = makeServer();
-  const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], signature: OUR_SIGNATURE, batch: 1, toNodeId: 14, queueMark: MARK_A });
+  const guard = createScopedRunGuard({ origFetchApi: spy, execIds: ["14"], contentHash: OUR_HASH, batch: 1, toNodeId: 14, queueMark: MARK_A });
   const changedOutput = { "3": { class_type: "KSampler" }, "20": { class_type: "SaveImage" } };
   const res = await guard(...promptPost(frontendBody({ output: changedOutput, targets: ["14"] })));
   assert.equal(res.status, 400, "scope is unverifiable against the changed graph — refuse");
@@ -483,6 +506,83 @@ test("#556 r4 P0-2 integration: two overlapping scoped runs — B's traffic pass
     const resA = await appA.postDeferred(appA.deferredItem);
     assert.equal(resA.status, 400, "A's sentinel still constrains exactly A's items");
     assert.equal(server.calls.length, 1, "A's corrupted dispatch never escapes");
+  } finally {
+    stop();
+  }
+});
+
+test("#556 r7 integration: a deferred item serialized from a DRIFTED graph (same topology + targets, changed widget value or link) is REFUSED — zero dispatch, error names the drift, no shape retry", async () => {
+  const stop = keepAlive();
+  try {
+    for (const drift of [
+      { "3": { class_type: "KSampler", inputs: { steps: 25 } } }, // widget value changed
+      { "9": { class_type: "SaveImage", inputs: { images: ["4", 0] } } }, // link rewired
+    ]) {
+      const server = makeServer();
+      const apiTarget = { fetchApi: server };
+      const driftedOutput = { ...OUR_OUTPUT, ...drift };
+      const app = makeFrontend({ shape: "shim", defer: true, apiTarget });
+      // The deferred item posts with the SAME targets but the DRIFTED content
+      // (same node ids/types — a topology-only fingerprint would accept it).
+      app.postDeferred = async (item) => {
+        const body = frontendBody({ output: driftedOutput, number: item.number, targets: ["14"] });
+        app.posted.push(body);
+        return apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
+      };
+      const promise = dispatchScopedRun({
+        app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
+        verifyTimeoutMs: 500,
+      });
+      await sleep(20);
+      const res = await app.postDeferred(app.deferredItem);
+      const result = await promise;
+      assert.equal(res.status, 400, `drift ${JSON.stringify(drift)} is refused`);
+      assert.equal(result.outcome, "refused");
+      assert.match(result.error, /graph CHANGED/i, "the error names the drift");
+      assert.match(result.error, /Nothing was queued/);
+      assert.equal(server.calls.length, 0, "the drifted prompt never left the tab");
+      assert.equal(app.posted.length, 1, "no shape retry — content drift is not an argument-shape problem");
+    }
+  } finally {
+    stop();
+  }
+});
+
+test("#556 r7 integration: a deferred post differing ONLY in a self-mutating (beforeQueued) input is still OUR dispatch — observed and delivered", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const outputAtQueue = {
+      "3": { class_type: "KSampler", inputs: { seed: 111, steps: 20 } },
+      "14": { class_type: "PreviewAny", inputs: {} },
+    };
+    // The live graph has a beforeQueued seed widget — its value is excluded
+    // from the content hash, so a rerolled seed can't refuse our own dispatch.
+    const app = makeFrontend({ shape: "shim", defer: true, apiTarget, output: outputAtQueue });
+    app.rootGraph = { _nodes: [{ id: 3, widgets: [{ name: "seed", beforeQueued() {} }, { name: "steps" }] }] };
+    const ids = [];
+    const promise = dispatchScopedRun({
+      app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
+      verifyTimeoutMs: 500,
+      onPromptId: (p) => ids.push(p),
+    });
+    await sleep(20);
+    // The deferred serialization rerolled the seed (beforeQueued) — nothing else changed.
+    app.postDeferred = async (item) => {
+      const body = frontendBody({
+        output: { ...outputAtQueue, "3": { class_type: "KSampler", inputs: { seed: 999999, steps: 20 } } },
+        number: item.number,
+        targets: ["14"],
+      });
+      app.posted.push(body);
+      return apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
+    };
+    await app.postDeferred(app.deferredItem);
+    const result = await promise;
+    assert.equal(result.outcome, "dispatched", "a rerolled seed does not refuse our own dispatch");
+    assert.deepEqual(ids, ["srv-1"]);
+    assert.equal(server.calls.length, 1);
   } finally {
     stop();
   }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -256,7 +256,7 @@ import {
   graphReadBindingChanged,
 } from "./lib/graph-binding.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
-import { queuePromptScopeArgs, createRunFetchInterceptor, createScopedRunGuard, promptSignature, scopeUnverifiedError, cancelPendingScopedQueueItem } from "./lib/run-scope-guard.js";
+import { createRunFetchInterceptor, dispatchScopedRun } from "./lib/run-scope-guard.js";
 import { queueMembership, historyEntryFor } from "./lib/history-reconcile.js";
 import {
   normalizeModels,
@@ -7782,18 +7782,23 @@ const GRAPH_TOOL_EXECUTORS = {
     // Array.isArray compat shim for the legacy array). A build that accepts only
     // ONE shape SILENTLY IGNORES the other — the scope never reaches the request
     // and the FULL graph queues while panel_run reports ran_to_node (#556). A
-    // scoped run must NEVER fall through to a full-graph execution, so:
-    //   1. try each arg shape in turn (queuePromptScopeArgs), and
-    //   2. a scoped fetch GUARD verifies the scope actually lands in the POST
-    //      /prompt body before that request leaves — and stays installed until
-    //      our dispatch is OBSERVED or a bounded timeout, because a busy
-    //      queuePrompt returns early and posts the item LATER (a guard restored
-    //      at return never sees the deferred dispatch). The guard is surgical:
-    //      it only refuses a targetless body matching THIS run's prompt
-    //      signature (the node-id|class_type set we queued), so an unrelated
-    //      prompt posting during the window passes through untouched. If no
-    //      scoped dispatch surfaces, the run reports "unverified — nothing
-    //      confirmed queued" rather than a lying queued:true.
+    // scoped run must NEVER fall through to a full-graph execution, so
+    // dispatchScopedRun (lib, the same code the tests drive):
+    //   1. fingerprints the prompt (node-id|class_type signature) BEFORE
+    //      dispatch — no signature ⇒ no attribution ⇒ fail closed, never queued;
+    //   2. queues with a sentinel queue-position MARK and an ownership tag on
+    //      the targets array, so this run's posts/items are distinguishable
+    //      from ALL unrelated queue traffic (a user full run of the same
+    //      graph, a foreign scoped run with the same targets);
+    //   3. tries each arg shape in turn while a surgical fetch GUARD observes
+    //      every POST /prompt: our marked post with signature+exact targets ⇒
+    //      dispatched; our marked post without them ⇒ refused before it
+    //      leaves; anything unmarked ⇒ not ours, passed through untouched;
+    //   4. stays installed until our dispatch is OBSERVED or a bounded timeout
+    //      (a busy queuePrompt returns early and posts LATER), then cancels
+    //      the still-pending tagged item — or, when cancellation is
+    //      impossible, keeps the guard as a long-bound sentinel — and reports
+    //      a truthful "unverified", never a lying queued:true.
     //
     // #358: app.queuePrompt SWALLOWS a synchronous rejection. It stores per-node
     // validation errors on `lastNodeErrors`, but a TOP-LEVEL rejection (e.g.
@@ -7855,116 +7860,27 @@ const GRAPH_TOOL_EXECUTORS = {
         if (origFetchApi) api.fetchApi = prevFetchApi;
       }
     } else {
-      if (!origFetchApi) {
-        // A scoped run we can't VERIFY (no fetchApi to inspect the outgoing prompt)
-        // is a scoped run we can't guarantee — refuse rather than risk a silent
-        // full-graph execution (#556).
-        return {
-          queued: false,
-          error:
-            `run-to-node scope for node ${to_node_id} cannot be verified — api.fetchApi is ` +
-            `unavailable on this frontend, so there is no way to confirm the scope reaches the ` +
-            `prompt. Nothing was queued rather than risk a full-graph execution (#556).`,
-        };
+      // SCOPED run — the whole dispatch (guard install, arg-shape retry,
+      // observation wait, timeout cancel/sentinel, fetchApi restore) lives in
+      // dispatchScopedRun so the REAL control flow is what the unit tests
+      // drive (#556). It marks every one of this run's posts with a queue
+      // position sentinel and tags the pending queue item, so a scoped run
+      // can never be confused with unrelated queue traffic.
+      const result = await dispatchScopedRun({
+        app,
+        apiTarget: api,
+        execIds: partialTargets,
+        batch,
+        toNodeId: to_node_id,
+        onRejection: captureRejection,
+        onPromptId: capturePromptId,
+      });
+      // "refused" / "unverified" / "unverifiable" all carry a truthful error
+      // naming what couldn't be resolved — and guarantee no scopeless
+      // full-graph dispatch left the tab.
+      if (result.outcome !== "dispatched") {
+        return { queued: false, error: result.error };
       }
-      // The signature that attributes a POST /prompt body to THIS run (see the
-      // guard). Best-effort: if graphToPrompt can't give us one, the guard
-      // still verifies posts that CARRY our targets, and anything else is
-      // reported unverified rather than blocked or lied about.
-      let signature = null;
-      try {
-        if (typeof app.graphToPrompt === "function") {
-          signature = promptSignature((await app.graphToPrompt())?.output);
-        }
-      } catch {
-        signature = null;
-      }
-      // A busy queuePrompt defers the post past its own return; bound how long
-      // we keep the guard installed waiting for OUR dispatch to surface. The
-      // pending item is popped LIFO, so it normally surfaces in well under this.
-      const SCOPED_DISPATCH_VERIFY_TIMEOUT_MS = 5000;
-      // When the pending item can't be cancelled on timeout, the guard stays
-      // installed this much longer as a sentinel — a late scope-dropped
-      // dispatch is still refused whenever it posts.
-      const SCOPED_DISPATCH_LINGER_MS = 10 * 60 * 1000;
-      let scopeDropped = null;
-      for (const scopeArg of queuePromptScopeArgs(partialTargets)) {
-        scopeDropped = null;
-        promptRejection = null;
-        queuedPromptIds.length = 0;
-        let keepGuardInstalled = false;
-        const guard = createScopedRunGuard({
-          origFetchApi,
-          execIds: partialTargets,
-          signature,
-          batch,
-          toNodeId: to_node_id,
-          onRejection: captureRejection,
-          onPromptId: capturePromptId,
-        });
-        api.fetchApi = guard;
-        try {
-          await app.queuePrompt(0, batch, scopeArg);
-          if (!(guard.state.observed > 0 || guard.state.dropped)) {
-            // queuePrompt returned without our dispatch surfacing — the
-            // frontend's processor was busy and will serialize/post the item
-            // LATER. Keep the guard installed and wait for our scoped dispatch
-            // to be OBSERVED, or the bounded timeout.
-            await guard.waitForVerdict(SCOPED_DISPATCH_VERIFY_TIMEOUT_MS);
-          }
-        } finally {
-          if (!keepGuardInstalled) api.fetchApi = prevFetchApi;
-        }
-        // Verifiably dispatched with our scope — proceed to the ledger/verdict.
-        if (guard.state.observed > 0) {
-          scopeDropped = null;
-          break;
-        }
-        // OUR dispatch surfaced WITHOUT the scope and was refused before it
-        // left the tab — nothing was queued, so retrying the other arg shape
-        // can never double-queue.
-        if (guard.state.dropped) {
-          scopeDropped = guard.state.dropped;
-          continue;
-        }
-        // Nothing surfaced — but the deferred item may STILL be live in the
-        // frontend's pending queue, and restoring the guard would let its
-        // scope-dropped dispatch escape later. Try to REMOVE the pending item
-        // (the server-side /queue never saw it — it never posted). When that's
-        // impossible (some builds hard-privatize queueItems, and a
-        // scope-dropped item may carry no attributable targets to match), keep
-        // the surgical guard installed as a sentinel until the long bound
-        // expires, then report the truthful unverified outcome — never
-        // queued:true (#556).
-        const cancel = cancelPendingScopedQueueItem(app, partialTargets);
-        if (cancel.removed > 0) {
-          return {
-            queued: false,
-            error: scopeUnverifiedError({
-              toNodeId: to_node_id,
-              timeoutMs: SCOPED_DISPATCH_VERIFY_TIMEOUT_MS,
-              cancelled: true,
-            }),
-          };
-        }
-        keepGuardInstalled = true;
-        setTimeout(() => {
-          // Self-remove only if nothing newer has wrapped over the sentinel —
-          // a guard left underneath a newer wrap is inert (surgical + budgeted)
-          // and simply remains in the chain.
-          if (api.fetchApi === guard) api.fetchApi = prevFetchApi;
-        }, SCOPED_DISPATCH_LINGER_MS);
-        return {
-          queued: false,
-          error: scopeUnverifiedError({
-            toNodeId: to_node_id,
-            timeoutMs: SCOPED_DISPATCH_VERIFY_TIMEOUT_MS,
-            cancelled: false,
-            lingerMs: SCOPED_DISPATCH_LINGER_MS,
-          }),
-        };
-      }
-      if (scopeDropped) return { queued: false, error: scopeDropped };
     }
     // Register EVERY accepted prompt_id for reconnect reconciliation (#370) —
     // BEFORE the rejection check. With batch>1, app.queuePrompt breaks its loop on

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -256,6 +256,7 @@ import {
   graphReadBindingChanged,
 } from "./lib/graph-binding.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
+import { queuePromptScopeArgs, createRunFetchInterceptor } from "./lib/run-scope-guard.js";
 import { queueMembership, historyEntryFor } from "./lib/history-reconcile.js";
 import {
   normalizeModels,
@@ -7774,8 +7775,19 @@ const GRAPH_TOOL_EXECUTORS = {
       partialTargets = [res.execId];
     }
 
-    // app.queuePrompt(number, batchCount, queueNodeIds) — the 3rd arg becomes the
-    // request's partial_execution_targets (queue-service signature; ComfyUI 0.26.2).
+    // app.queuePrompt(number, batchCount, queueNodeIds | QueuePromptOptions) —
+    // the 3rd arg becomes the request's partial_execution_targets, but its SHAPE
+    // differs across frontend builds: a positional NodeExecutionId[] on some, a
+    // { queueNodeIds } options object on others (options builds carry an
+    // Array.isArray compat shim for the legacy array). A build that accepts only
+    // ONE shape SILENTLY IGNORES the other — the scope never reaches the request
+    // and the FULL graph queues while panel_run reports ran_to_node (#556). A
+    // scoped run must NEVER fall through to a full-graph execution, so:
+    //   1. try each arg shape in turn (queuePromptScopeArgs), and
+    //   2. let the fetch interceptor VERIFY the scope actually landed in the
+    //      POST /prompt body BEFORE the request leaves — a dropped scope blocks
+    //      the dispatch (nothing is queued), and if no shape delivers, REFUSE
+    //      with a truthful error instead of lying about a scoped run.
     //
     // #358: app.queuePrompt SWALLOWS a synchronous rejection. It stores per-node
     // validation errors on `lastNodeErrors`, but a TOP-LEVEL rejection (e.g.
@@ -7783,53 +7795,24 @@ const GRAPH_TOOL_EXECUTORS = {
     // outputs failed validation") is shown in a dialog and then DISCARDED — it
     // never reaches `lastNodeErrors` (which stays `{}`). Inspecting only
     // `lastNodeErrors` therefore reports a false `queued:true` for a prompt
-    // ComfyUI refused ~1ms after "got prompt". Capture the raw non-200 /prompt
-    // body — the only place the top-level `error` exists — by wrapping fetchApi
-    // for the duration of THIS queue call, then let summarizePromptRejection turn
-    // it into a real failure. All queue paths POST /prompt through fetchApi, so
-    // this is version-robust regardless of app.queuePrompt's internal plumbing.
-    // Capture the FIRST top-level rejection (app.queuePrompt breaks its batch loop
-    // on the first rejected prompt, so there is at most one) plus EVERY accepted
-    // prompt_id — a batch>1 run queues N separate prompts, each of which needs its
-    // own #370 recovery-ledger entry. The panel dispatches agent commands serially
-    // (each command is replied to before the next tool runs), so graph_run's queue
-    // call does not overlap another graph_run; we save + restore the exact prior
-    // api.fetchApi so even a hypothetical nested wrap unwinds cleanly.
+    // ComfyUI refused ~1ms after "got prompt". The interceptor captures the raw
+    // non-200 /prompt body — the only place the top-level `error` exists — and
+    // summarizePromptRejection turns it into a real failure. All queue paths
+    // POST /prompt through fetchApi, so this is version-robust regardless of
+    // app.queuePrompt's internal plumbing. Capture the FIRST top-level rejection
+    // (app.queuePrompt breaks its batch loop on the first rejected prompt, so
+    // there is at most one) plus EVERY accepted prompt_id — a batch>1 run queues
+    // N separate prompts, each of which needs its own #370 recovery-ledger
+    // entry. The panel dispatches agent commands serially (each command is
+    // replied to before the next tool runs), so graph_run's queue call does not
+    // overlap another graph_run; we save + restore the exact prior api.fetchApi
+    // around EACH attempt so even a hypothetical nested wrap unwinds cleanly.
     let promptRejection = null;
     const queuedPromptIds = [];
+    let scopeDropped = null;
     const prevFetchApi =
       typeof api?.fetchApi === "function" ? api.fetchApi : null;
     const origFetchApi = prevFetchApi ? prevFetchApi.bind(api) : null;
-    if (origFetchApi) {
-      api.fetchApi = async (route, options) => {
-        const res = await origFetchApi(route, options);
-        try {
-          const method = String(options?.method || "GET").toUpperCase();
-          const path = typeof route === "string" ? route.split("?")[0] : "";
-          if (method === "POST" && path.endsWith("/prompt") && res) {
-            const body = await res.clone().json();
-            if (res.status !== 200) {
-              if (promptRejection == null && body && (body.error || body.node_errors)) {
-                promptRejection = { error: body.error ?? null, node_errors: body.node_errors ?? null };
-              }
-            } else if (body && body.prompt_id != null) {
-              // Accepted — remember EACH prompt_id so #370 reconcile can recover a
-              // run that starts AND finishes entirely inside a connection drop. Use a
-              // NULLISH presence check (!= null), NOT truthiness — a falsy-but-valid
-              // id like 0 must flow through ingestion, or a drop before lifecycle
-              // frames would lose the completion (#370). Normalize to a STRING AT
-              // CAPTURE so dedupe is canonical (0 and "0" are the same run) and
-              // everything downstream stays string-vs-string.
-              const pid = String(body.prompt_id);
-              if (!queuedPromptIds.includes(pid)) queuedPromptIds.push(pid);
-            }
-          }
-        } catch {
-          // non-JSON body / clone unsupported — fall back to lastNodeErrors below.
-        }
-        return res;
-      };
-    }
     // #445: guard the VHS null-widget serialization crash. ComfyUI core / node
     // extensions (notably VHS_VideoCombine) serialize EVERY node's widgets when
     // building the prompt — even unused branches, even under "run to node" — and
@@ -7842,11 +7825,52 @@ const GRAPH_TOOL_EXECUTORS = {
     // the deferred serialization queuePrompt runs when its processor is already
     // busy) without permanently altering the live workflow.
     installGraphToPromptNullSafety(app);
-    try {
-      await app.queuePrompt(0, batch, partialTargets);
-    } finally {
-      if (origFetchApi) api.fetchApi = prevFetchApi;
+    if (partialTargets && !origFetchApi) {
+      // A scoped run we can't VERIFY (no fetchApi to inspect the outgoing prompt)
+      // is a scoped run we can't guarantee — refuse rather than risk a silent
+      // full-graph execution (#556).
+      return {
+        queued: false,
+        error:
+          `run-to-node scope for node ${to_node_id} cannot be verified — api.fetchApi is ` +
+          `unavailable on this frontend, so there is no way to confirm the scope reaches the ` +
+          `prompt. Nothing was queued rather than risk a full-graph execution (#556).`,
+      };
     }
+    for (const scopeArg of queuePromptScopeArgs(partialTargets)) {
+      scopeDropped = null;
+      promptRejection = null;
+      queuedPromptIds.length = 0;
+      if (origFetchApi) {
+        api.fetchApi = createRunFetchInterceptor({
+          origFetchApi,
+          partialTargets: partialTargets ?? null,
+          toNodeId: to_node_id,
+          onRejection: (r) => {
+            // Capture the FIRST top-level rejection only (see above).
+            if (promptRejection == null) promptRejection = r;
+          },
+          onPromptId: (pid) => {
+            // EVERY accepted prompt_id, string-normalized at capture (0 and "0"
+            // are the same run) so #370 reconcile stays string-vs-string.
+            if (!queuedPromptIds.includes(pid)) queuedPromptIds.push(pid);
+          },
+          onScopeDropped: (msg) => {
+            if (scopeDropped == null) scopeDropped = msg;
+          },
+        });
+      }
+      try {
+        await app.queuePrompt(0, batch, scopeArg);
+      } finally {
+        if (origFetchApi) api.fetchApi = prevFetchApi;
+      }
+      // The scope verifiably reached /prompt (or none was requested) — proceed.
+      // A DROPPED scope means the unscoped POST was blocked BEFORE dispatch, so
+      // retrying the other arg shape can never double-queue.
+      if (!scopeDropped) break;
+    }
+    if (scopeDropped) return { queued: false, error: scopeDropped };
     // Register EVERY accepted prompt_id for reconnect reconciliation (#370) —
     // BEFORE the rejection check. With batch>1, app.queuePrompt breaks its loop on
     // the first rejection, so an EARLIER repetition can be accepted (already

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7819,6 +7819,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // overlap another graph_run; we save + restore the exact prior api.fetchApi
     // around EACH attempt so even a hypothetical nested wrap unwinds cleanly.
     let promptRejection = null;
+    let runScopeResult = null;
     const queuedPromptIds = [];
     const prevFetchApi =
       typeof api?.fetchApi === "function" ? api.fetchApi : null;
@@ -7866,7 +7867,7 @@ const GRAPH_TOOL_EXECUTORS = {
       // drive (#556). It marks every one of this run's posts with a queue
       // position sentinel and tags the pending queue item, so a scoped run
       // can never be confused with unrelated queue traffic.
-      const result = await dispatchScopedRun({
+      runScopeResult = await dispatchScopedRun({
         app,
         apiTarget: api,
         execIds: partialTargets,
@@ -7875,12 +7876,6 @@ const GRAPH_TOOL_EXECUTORS = {
         onRejection: captureRejection,
         onPromptId: capturePromptId,
       });
-      // "refused" / "unverified" / "unverifiable" all carry a truthful error
-      // naming what couldn't be resolved — and guarantee no scopeless
-      // full-graph dispatch left the tab.
-      if (result.outcome !== "dispatched") {
-        return { queued: false, error: result.error };
-      }
     }
     // Register EVERY accepted prompt_id for reconnect reconciliation (#370) —
     // BEFORE the rejection check. With batch>1, app.queuePrompt breaks its loop on
@@ -7901,6 +7896,14 @@ const GRAPH_TOOL_EXECUTORS = {
       try {
         armRunReconcileSweepRef?.();
       } catch {}
+    }
+    // A scoped run that did NOT fully verify (r5: refused / unverified /
+    // unverifiable) carries a truthful error naming what couldn't be resolved —
+    // and guarantees no scopeless full-graph dispatch left the tab. The return
+    // comes AFTER the ledger registration above so any partially-verified
+    // prompts (which ARE queued, scoped) stay reconcilable (#370).
+    if (runScopeResult && runScopeResult.outcome !== "dispatched") {
+      return { queued: false, error: runScopeResult.error };
     }
     // Verdict from BOTH channels: the captured top-level rejection (#358) and the
     // per-node errors the frontend stashed. null ⇒ genuinely accepted.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -256,7 +256,7 @@ import {
   graphReadBindingChanged,
 } from "./lib/graph-binding.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
-import { queuePromptScopeArgs, createRunFetchInterceptor, createScopedRunGuard, promptSignature, scopeUnverifiedError } from "./lib/run-scope-guard.js";
+import { queuePromptScopeArgs, createRunFetchInterceptor, createScopedRunGuard, promptSignature, scopeUnverifiedError, cancelPendingScopedQueueItem } from "./lib/run-scope-guard.js";
 import { queueMembership, historyEntryFor } from "./lib/history-reconcile.js";
 import {
   normalizeModels,
@@ -7883,11 +7883,16 @@ const GRAPH_TOOL_EXECUTORS = {
       // we keep the guard installed waiting for OUR dispatch to surface. The
       // pending item is popped LIFO, so it normally surfaces in well under this.
       const SCOPED_DISPATCH_VERIFY_TIMEOUT_MS = 5000;
+      // When the pending item can't be cancelled on timeout, the guard stays
+      // installed this much longer as a sentinel — a late scope-dropped
+      // dispatch is still refused whenever it posts.
+      const SCOPED_DISPATCH_LINGER_MS = 10 * 60 * 1000;
       let scopeDropped = null;
       for (const scopeArg of queuePromptScopeArgs(partialTargets)) {
         scopeDropped = null;
         promptRejection = null;
         queuedPromptIds.length = 0;
+        let keepGuardInstalled = false;
         const guard = createScopedRunGuard({
           origFetchApi,
           execIds: partialTargets,
@@ -7908,7 +7913,7 @@ const GRAPH_TOOL_EXECUTORS = {
             await guard.waitForVerdict(SCOPED_DISPATCH_VERIFY_TIMEOUT_MS);
           }
         } finally {
-          api.fetchApi = prevFetchApi;
+          if (!keepGuardInstalled) api.fetchApi = prevFetchApi;
         }
         // Verifiably dispatched with our scope — proceed to the ledger/verdict.
         if (guard.state.observed > 0) {
@@ -7922,14 +7927,40 @@ const GRAPH_TOOL_EXECUTORS = {
           scopeDropped = guard.state.dropped;
           continue;
         }
-        // Nothing surfaced. A deferred dispatch may still land later but can
-        // no longer be attributed/verified — report a truthful UNVERIFIED
-        // outcome, never queued:true (#556).
+        // Nothing surfaced — but the deferred item may STILL be live in the
+        // frontend's pending queue, and restoring the guard would let its
+        // scope-dropped dispatch escape later. Try to REMOVE the pending item
+        // (the server-side /queue never saw it — it never posted). When that's
+        // impossible (some builds hard-privatize queueItems, and a
+        // scope-dropped item may carry no attributable targets to match), keep
+        // the surgical guard installed as a sentinel until the long bound
+        // expires, then report the truthful unverified outcome — never
+        // queued:true (#556).
+        const cancel = cancelPendingScopedQueueItem(app, partialTargets);
+        if (cancel.removed > 0) {
+          return {
+            queued: false,
+            error: scopeUnverifiedError({
+              toNodeId: to_node_id,
+              timeoutMs: SCOPED_DISPATCH_VERIFY_TIMEOUT_MS,
+              cancelled: true,
+            }),
+          };
+        }
+        keepGuardInstalled = true;
+        setTimeout(() => {
+          // Self-remove only if nothing newer has wrapped over the sentinel —
+          // a guard left underneath a newer wrap is inert (surgical + budgeted)
+          // and simply remains in the chain.
+          if (api.fetchApi === guard) api.fetchApi = prevFetchApi;
+        }, SCOPED_DISPATCH_LINGER_MS);
         return {
           queued: false,
           error: scopeUnverifiedError({
             toNodeId: to_node_id,
             timeoutMs: SCOPED_DISPATCH_VERIFY_TIMEOUT_MS,
+            cancelled: false,
+            lingerMs: SCOPED_DISPATCH_LINGER_MS,
           }),
         };
       }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -256,7 +256,7 @@ import {
   graphReadBindingChanged,
 } from "./lib/graph-binding.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
-import { queuePromptScopeArgs, createRunFetchInterceptor } from "./lib/run-scope-guard.js";
+import { queuePromptScopeArgs, createRunFetchInterceptor, createScopedRunGuard, promptSignature, scopeUnverifiedError } from "./lib/run-scope-guard.js";
 import { queueMembership, historyEntryFor } from "./lib/history-reconcile.js";
 import {
   normalizeModels,
@@ -7784,10 +7784,16 @@ const GRAPH_TOOL_EXECUTORS = {
     // and the FULL graph queues while panel_run reports ran_to_node (#556). A
     // scoped run must NEVER fall through to a full-graph execution, so:
     //   1. try each arg shape in turn (queuePromptScopeArgs), and
-    //   2. let the fetch interceptor VERIFY the scope actually landed in the
-    //      POST /prompt body BEFORE the request leaves — a dropped scope blocks
-    //      the dispatch (nothing is queued), and if no shape delivers, REFUSE
-    //      with a truthful error instead of lying about a scoped run.
+    //   2. a scoped fetch GUARD verifies the scope actually lands in the POST
+    //      /prompt body before that request leaves — and stays installed until
+    //      our dispatch is OBSERVED or a bounded timeout, because a busy
+    //      queuePrompt returns early and posts the item LATER (a guard restored
+    //      at return never sees the deferred dispatch). The guard is surgical:
+    //      it only refuses a targetless body matching THIS run's prompt
+    //      signature (the node-id|class_type set we queued), so an unrelated
+    //      prompt posting during the window passes through untouched. If no
+    //      scoped dispatch surfaces, the run reports "unverified — nothing
+    //      confirmed queued" rather than a lying queued:true.
     //
     // #358: app.queuePrompt SWALLOWS a synchronous rejection. It stores per-node
     // validation errors on `lastNodeErrors`, but a TOP-LEVEL rejection (e.g.
@@ -7795,7 +7801,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // outputs failed validation") is shown in a dialog and then DISCARDED — it
     // never reaches `lastNodeErrors` (which stays `{}`). Inspecting only
     // `lastNodeErrors` therefore reports a false `queued:true` for a prompt
-    // ComfyUI refused ~1ms after "got prompt". The interceptor captures the raw
+    // ComfyUI refused ~1ms after "got prompt". The capture below records the raw
     // non-200 /prompt body — the only place the top-level `error` exists — and
     // summarizePromptRejection turns it into a real failure. All queue paths
     // POST /prompt through fetchApi, so this is version-robust regardless of
@@ -7809,10 +7815,18 @@ const GRAPH_TOOL_EXECUTORS = {
     // around EACH attempt so even a hypothetical nested wrap unwinds cleanly.
     let promptRejection = null;
     const queuedPromptIds = [];
-    let scopeDropped = null;
     const prevFetchApi =
       typeof api?.fetchApi === "function" ? api.fetchApi : null;
     const origFetchApi = prevFetchApi ? prevFetchApi.bind(api) : null;
+    const captureRejection = (r) => {
+      // Capture the FIRST top-level rejection only (see above).
+      if (promptRejection == null) promptRejection = r;
+    };
+    const capturePromptId = (pid) => {
+      // EVERY accepted prompt_id, string-normalized at capture (0 and "0"
+      // are the same run) so #370 reconcile stays string-vs-string.
+      if (!queuedPromptIds.includes(pid)) queuedPromptIds.push(pid);
+    };
     // #445: guard the VHS null-widget serialization crash. ComfyUI core / node
     // extensions (notably VHS_VideoCombine) serialize EVERY node's widgets when
     // building the prompt — even unused branches, even under "run to node" — and
@@ -7825,52 +7839,102 @@ const GRAPH_TOOL_EXECUTORS = {
     // the deferred serialization queuePrompt runs when its processor is already
     // busy) without permanently altering the live workflow.
     installGraphToPromptNullSafety(app);
-    if (partialTargets && !origFetchApi) {
-      // A scoped run we can't VERIFY (no fetchApi to inspect the outgoing prompt)
-      // is a scoped run we can't guarantee — refuse rather than risk a silent
-      // full-graph execution (#556).
-      return {
-        queued: false,
-        error:
-          `run-to-node scope for node ${to_node_id} cannot be verified — api.fetchApi is ` +
-          `unavailable on this frontend, so there is no way to confirm the scope reaches the ` +
-          `prompt. Nothing was queued rather than risk a full-graph execution (#556).`,
-      };
-    }
-    for (const scopeArg of queuePromptScopeArgs(partialTargets)) {
-      scopeDropped = null;
-      promptRejection = null;
-      queuedPromptIds.length = 0;
+    if (!partialTargets) {
+      // UNSCOPED full run — the historical single-shot path: capture wrap for
+      // exactly the duration of the queuePrompt call, then restore.
       if (origFetchApi) {
         api.fetchApi = createRunFetchInterceptor({
           origFetchApi,
-          partialTargets: partialTargets ?? null,
-          toNodeId: to_node_id,
-          onRejection: (r) => {
-            // Capture the FIRST top-level rejection only (see above).
-            if (promptRejection == null) promptRejection = r;
-          },
-          onPromptId: (pid) => {
-            // EVERY accepted prompt_id, string-normalized at capture (0 and "0"
-            // are the same run) so #370 reconcile stays string-vs-string.
-            if (!queuedPromptIds.includes(pid)) queuedPromptIds.push(pid);
-          },
-          onScopeDropped: (msg) => {
-            if (scopeDropped == null) scopeDropped = msg;
-          },
+          onRejection: captureRejection,
+          onPromptId: capturePromptId,
         });
       }
       try {
-        await app.queuePrompt(0, batch, scopeArg);
+        await app.queuePrompt(0, batch, undefined);
       } finally {
         if (origFetchApi) api.fetchApi = prevFetchApi;
       }
-      // The scope verifiably reached /prompt (or none was requested) — proceed.
-      // A DROPPED scope means the unscoped POST was blocked BEFORE dispatch, so
-      // retrying the other arg shape can never double-queue.
-      if (!scopeDropped) break;
+    } else {
+      if (!origFetchApi) {
+        // A scoped run we can't VERIFY (no fetchApi to inspect the outgoing prompt)
+        // is a scoped run we can't guarantee — refuse rather than risk a silent
+        // full-graph execution (#556).
+        return {
+          queued: false,
+          error:
+            `run-to-node scope for node ${to_node_id} cannot be verified — api.fetchApi is ` +
+            `unavailable on this frontend, so there is no way to confirm the scope reaches the ` +
+            `prompt. Nothing was queued rather than risk a full-graph execution (#556).`,
+        };
+      }
+      // The signature that attributes a POST /prompt body to THIS run (see the
+      // guard). Best-effort: if graphToPrompt can't give us one, the guard
+      // still verifies posts that CARRY our targets, and anything else is
+      // reported unverified rather than blocked or lied about.
+      let signature = null;
+      try {
+        if (typeof app.graphToPrompt === "function") {
+          signature = promptSignature((await app.graphToPrompt())?.output);
+        }
+      } catch {
+        signature = null;
+      }
+      // A busy queuePrompt defers the post past its own return; bound how long
+      // we keep the guard installed waiting for OUR dispatch to surface. The
+      // pending item is popped LIFO, so it normally surfaces in well under this.
+      const SCOPED_DISPATCH_VERIFY_TIMEOUT_MS = 5000;
+      let scopeDropped = null;
+      for (const scopeArg of queuePromptScopeArgs(partialTargets)) {
+        scopeDropped = null;
+        promptRejection = null;
+        queuedPromptIds.length = 0;
+        const guard = createScopedRunGuard({
+          origFetchApi,
+          execIds: partialTargets,
+          signature,
+          batch,
+          toNodeId: to_node_id,
+          onRejection: captureRejection,
+          onPromptId: capturePromptId,
+        });
+        api.fetchApi = guard;
+        try {
+          await app.queuePrompt(0, batch, scopeArg);
+          if (!(guard.state.observed > 0 || guard.state.dropped)) {
+            // queuePrompt returned without our dispatch surfacing — the
+            // frontend's processor was busy and will serialize/post the item
+            // LATER. Keep the guard installed and wait for our scoped dispatch
+            // to be OBSERVED, or the bounded timeout.
+            await guard.waitForVerdict(SCOPED_DISPATCH_VERIFY_TIMEOUT_MS);
+          }
+        } finally {
+          api.fetchApi = prevFetchApi;
+        }
+        // Verifiably dispatched with our scope — proceed to the ledger/verdict.
+        if (guard.state.observed > 0) {
+          scopeDropped = null;
+          break;
+        }
+        // OUR dispatch surfaced WITHOUT the scope and was refused before it
+        // left the tab — nothing was queued, so retrying the other arg shape
+        // can never double-queue.
+        if (guard.state.dropped) {
+          scopeDropped = guard.state.dropped;
+          continue;
+        }
+        // Nothing surfaced. A deferred dispatch may still land later but can
+        // no longer be attributed/verified — report a truthful UNVERIFIED
+        // outcome, never queued:true (#556).
+        return {
+          queued: false,
+          error: scopeUnverifiedError({
+            toNodeId: to_node_id,
+            timeoutMs: SCOPED_DISPATCH_VERIFY_TIMEOUT_MS,
+          }),
+        };
+      }
+      if (scopeDropped) return { queued: false, error: scopeDropped };
     }
-    if (scopeDropped) return { queued: false, error: scopeDropped };
     // Register EVERY accepted prompt_id for reconnect reconciliation (#370) —
     // BEFORE the rejection check. With batch>1, app.queuePrompt breaks its loop on
     // the first rejection, so an EARLIER repetition can be accepted (already

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -13,55 +13,66 @@
 //     { queueNodeIds } object on others (options builds carry an Array.isArray
 //     compat shim for the legacy array). A build that accepts only ONE shape
 //     silently IGNORES the other — the scope never reaches the request, the FULL
-//     graph queues, and panel_run still reports ran_to_node (#556: an unrelated
-//     SaveImage branch rendered and wrote a file nobody asked for). A minified
+//     graph queues, and panel_run still reports ran_to_node (#556). A minified
 //     queuePrompt signature can't be sniffed reliably, so the guarantee is
 //     enforced at the one place every build must pass through: the POST /prompt
 //     request body.
 //
-// Three dispatch realities shape the design (codex gate, rounds 1–2):
+// RUN IDENTITY (codex gate r3). Content alone cannot always tell our dispatch
+// from a stranger's: an identical-node-set foreign post is indistinguishable
+// from ours, and a user's full run of the same graph looks exactly like our
+// scope-dropped dispatch. So this run MARKS its own work end to end:
 //
-//  - app.queuePrompt is NOT synchronous with the POST. When its processor is
-//    already busy it pushes the item and RETURNS EARLY — the prompt is
-//    serialized and posted LATER by the in-flight processor. A guard restored
-//    when queuePrompt returns never sees that deferred dispatch. So the scoped
-//    guard stays installed until our dispatch is actually OBSERVED (a POST
-//    carrying exactly our targets, attributed to our prompt, has passed
-//    through) or a bounded timeout — and a run whose dispatch never surfaces
-//    reports a truthful "could not verify", never queued:true.
+//  - QUEUE POSITION MARK: graph_run queues with number = SCOPED_QUEUE_MARK.
+//    Every frontend build's api.queuePrompt copies a nonzero `number` into the
+//    POST body verbatim (`body.number = number` — present since at least the
+//    1.28-era frontend), and the server treats it as a priority that with
+//    2^30-1 always sorts to the END of the pending queue — the same append
+//    position today's number=0 produces. A body WITHOUT our mark is FOREIGN:
+//    passed through untouched, never captured, never refused, never counted
+//    as our observation — even with an identical node set and identical
+//    targets. A body WITH our mark is this run: signature+targets exact ⇒
+//    observed; anything else (scope missing/wrong/extra, or a graph that
+//    changed under a deferred item) ⇒ OUR corrupted dispatch, refused before
+//    it leaves (batch-bounded).
 //
-//  - While installed, the guard sees EVERY POST /prompt in the tab (a user
-//    queue, another processor's item). Attribution is by PROMPT SIGNATURE
-//    FIRST (the sorted node-id|class_type set of the graphToPrompt output we
-//    queued — widget values excluded so beforeQueued seed randomization can't
-//    blur it), targets second:
-//      · signature matches, targets exactly ours → OUR scoped dispatch:
-//        observed, passed through, response captured.
-//      · signature matches, targets MISSING/WRONG/EXTRA/PARTIAL → OUR dispatch
-//        CORRUPTED (the frontend dropped/mangled the scope argument): refused
-//        before it leaves, bounded by this batch's post count. A body with
-//        ["14","9"] is NOT "someone else's" — it's our scope with an unwanted
-//        branch attached, and letting it out would run that work.
-//      · signature does NOT match → FOREIGN: passed through untouched, never
-//        captured, never refused, and NEVER counts as our observation — even
-//        if it carries the same targets (a foreign same-targets post must not
-//        satisfy `observed` and let our own deferred corrupted post escape).
-//    Known limit: a concurrent full run of the byte-identical node set inside
-//    the window is indistinguishable from our own corrupted dispatch and is
-//    treated as ours (bounded by batch).
+//  - QUEUE ITEM TAG: the targets array carries a non-enumerable per-run Symbol
+//    tag. Frontend builds store the array by reference in queueItems (either
+//    directly or inside the options object), so on timeout the still-pending
+//    item can be found and REMOVED with exact ownership — an identical-scope
+//    item from another run is never touched. When the item can't be found
+//    (hard-private #queueItems builds, or a build that copied the array), the
+//    surgical guard stays installed as a long-bound sentinel instead, so the
+//    late corrupted dispatch is still refused whenever it posts.
 //
-//  - On timeout the deferred queue item may STILL be live in the frontend's
-//    pending list; restoring the guard then would let a scope-dropped dispatch
-//    escape later. graph_run therefore tries to REMOVE the pending item
-//    (cancelPendingScopedQueueItem — the frontend keeps its queueItems array
-//    runtime-accessible on TS-`private` builds; older builds hard-privatize it
-//    as #queueItems, and a scope-dropped item may carry no attributable
-//    targets). When removal is impossible the guard stays installed as a
-//    sentinel — still surgical, still batch-bounded — until a much longer
-//    bound expires, so the corrupted dispatch is refused whenever it posts.
+// OTHER DISPATCH REALITIES (gate rounds 1–2):
 //
-// Extracted as a pure module so the SAME guard graph_run installs is drivable
-// from `node --test` (the live app.queuePrompt path can't be).
+//  - app.queuePrompt is NOT synchronous with the POST: a busy processor makes
+//    it return early and post LATER. The guard therefore stays installed until
+//    our dispatch is OBSERVED or a bounded timeout — and the timeout path
+//    decides cancel-vs-sentinel BEFORE the finally restores fetchApi.
+//
+//  - The prompt SIGNATURE (sorted node-id|class_type set of the graphToPrompt
+//    output, widget values excluded so beforeQueued seed randomization can't
+//    blur it) must be computable BEFORE dispatch. If it isn't, attribution is
+//    impossible, so the run FAILS CLOSED: it refuses upfront with a truthful
+//    error and never calls queuePrompt — "cannot safely dispatch", never
+//    "dispatch and hope".
+//
+// Extracted as a pure module so the SAME orchestration graph_run runs is
+// drivable from `node --test` (the live app.queuePrompt path can't be).
+
+/**
+ * The queue-position number every scoped panel_run dispatches with. Copied
+ * into the POST body as `number` by every frontend build's api.queuePrompt,
+ * making OUR posts identifiable among every /prompt in the tab. 2^30-1 sorts
+ * to the END of the server's priority queue (lower number = earlier), which
+ * matches the append behavior of the historical number=0.
+ */
+export const SCOPED_QUEUE_MARK = 2 ** 30 - 1;
+
+/** Property key for the per-run ownership tag on the targets array (non-enumerable). */
+export const QUEUE_ITEM_TAG = Symbol("cmcp-scoped-run-tag");
 
 /**
  * The ordered list of 3rd-argument shapes to try for app.queuePrompt when a
@@ -84,8 +95,8 @@ export function queuePromptScopeArgs(partialTargets) {
  * sorted node-id|class_type pairs of a graphToPrompt output (the API workflow).
  * Widget values are EXCLUDED — queuePrompt randomizes seeds via beforeQueued
  * between serialization calls, so a value-level fingerprint would miss our own
- * dispatch. Two runs of the same unedited graph share a signature; the batch
- * bound in the guard limits what that ambiguity can mis-attribute.
+ * dispatch. Two runs of the same unedited graph share a signature; the queue
+ * mark (module header) is what actually separates them.
  */
 export function promptSignature(output) {
   if (!output || typeof output !== "object") return null;
@@ -106,6 +117,18 @@ export function promptSignatureFromBody(bodyText) {
     return null;
   }
   return promptSignature(body?.prompt);
+}
+
+/** The body's queue-position `number` as a Number, or null when absent/unparseable. */
+function bodyQueueMark(bodyText) {
+  let body;
+  try {
+    body = JSON.parse(bodyText);
+  } catch {
+    return null;
+  }
+  const n = Number(body?.number);
+  return Number.isFinite(n) ? n : null;
 }
 
 /** The body's partial_execution_targets as strings, or null when absent/empty/unparseable. */
@@ -165,11 +188,26 @@ export function scopeDroppedError({ toNodeId, verdict }) {
 }
 
 /**
+ * The truthful UPFRONT refusal when the prompt can't be fingerprinted
+ * (graphToPrompt failed before dispatch). Without a signature our dispatch
+ * can't be told apart from a stranger's, so a scoped run must NOT dispatch at
+ * all — fail closed, nothing queued.
+ */
+export function scopeUnattributableError({ toNodeId }) {
+  return (
+    `run-to-node scope for node ${toNodeId} cannot be dispatched safely: the ` +
+    `prompt could not be fingerprinted (graphToPrompt failed), so the panel ` +
+    `cannot distinguish its own dispatch from unrelated queue traffic. ` +
+    `Nothing was queued rather than risk a full-graph execution (#556).`
+  );
+}
+
+/**
  * The truthful UNVERIFIED outcome when no scoped dispatch surfaced within the
  * observation window (a busy queuePrompt deferred the post past its return, or
  * the prompt build failed silently).
- *  - cancelled:  the still-pending frontend queue item was located and REMOVED
- *    — "nothing was queued" is then literally true.
+ *  - cancelled:  the still-pending frontend queue item was located by its
+ *    ownership tag and REMOVED — "nothing was queued" is then literally true.
  *  - lingering:  removal was impossible, so the surgical guard stays installed
  *    for lingerMs as a sentinel — a late scope-dropped dispatch is still
  *    refused whenever it posts. Only "nothing CONFIRMED queued" is claimed.
@@ -190,7 +228,7 @@ export function scopeUnverifiedError({ toNodeId, timeoutMs, cancelled = false, l
     base +
     `The pending queue item could not be removed on this frontend, so the scope ` +
     `guard stays installed for up to ${Math.round(lingerMs / 60000)}min as a sentinel — ` +
-    `any late dispatch of this prompt WITHOUT the scope will still be refused. ` +
+    `any late dispatch of this run WITHOUT the scope will still be refused. ` +
     `Nothing is CONFIRMED queued — check the ComfyUI queue before retrying (#556).`
   );
 }
@@ -249,26 +287,26 @@ export function createRunFetchInterceptor({ origFetchApi, onRejection = null, on
 }
 
 /**
- * The api.fetchApi replacement graph_run installs for a SCOPED run — see the
- * module header for the attribution rules this enforces. The guard stays
- * installed until the caller restores it (on observation, on a successful
- * pending-item cancellation, or via the long-bound sentinel timer); it does
- * not restore itself. state = { observed, dropped } is live; waitForVerdict(ms)
- * resolves true as soon as either is set, false on timeout.
- *
- * @param {object}   args
- * @param {Function} args.origFetchApi
- * @param {string[]} args.execIds        This run's resolved partial-execution targets.
- * @param {string|null} [args.signature] promptSignature of the graphToPrompt output we queued.
- * @param {number} [args.batch]          Bound on how many corrupted posts are attributable to us.
- * @param {*}        [args.toNodeId]
+ * The api.fetchApi replacement dispatchScopedRun installs for a SCOPED run —
+ * see the module header for the run-identity model. Per POST /prompt body:
+ *  - NO queue mark           → FOREIGN: passed through untouched, never
+ *                              captured, never refused, never observed — even
+ *                              with our node set and our targets.
+ *  - mark + signature + exact targets → OUR scoped dispatch: passed through,
+ *                              counted OBSERVED, response captured.
+ *  - mark + anything else    → OUR corrupted dispatch (scope dropped/mangled,
+ *                              or the graph changed under a deferred item):
+ *                              refused before it leaves, batch-bounded.
+ * state = { observed, dropped } is live; waitForVerdict(ms) resolves true as
+ * soon as either is set, false on timeout.
  */
 export function createScopedRunGuard({
   origFetchApi,
   execIds,
-  signature = null,
+  signature,
   batch = 1,
   toNodeId = null,
+  queueMark = SCOPED_QUEUE_MARK,
   onRejection = null,
   onPromptId = null,
   onScopeDropped = null,
@@ -284,19 +322,15 @@ export function createScopedRunGuard({
 
   const guard = async (route, options) => {
     if (!isPromptPost(route, options)) return origFetchApi(route, options);
+    // RUN IDENTITY FIRST: no mark ⇒ not ours ⇒ never touch it. This is what
+    // keeps a user's full run of the SAME graph, or another scoped run with
+    // the SAME targets, safe from our refusals and our capture.
+    if (bodyQueueMark(options?.body) !== queueMark) {
+      return origFetchApi(route, options);
+    }
     const targets = targetsFromBody(options?.body);
-    // SIGNATURE FIRST: only a body whose node set is exactly the prompt we
-    // queued can be this run — matched or corrupted. Everything else is
-    // foreign: passed through untouched, never captured, never observed,
-    // never refused (even a foreign post carrying the SAME targets).
-    // Degraded mode: with NO signature (graphToPrompt failed at queue time) we
-    // can only attribute a post carrying EXACTLY our targets — enough to still
-    // verify a delivered scope, never enough to refuse (never blocks strangers).
-    const attributable = signature
-      ? promptSignatureFromBody(options?.body) === signature
-      : targets != null && sameSet(targets, expected);
-    if (!attributable) return origFetchApi(route, options);
-    if (targets && sameSet(targets, expected)) {
+    const sigOk = signature && promptSignatureFromBody(options?.body) === signature;
+    if (sigOk && targets && sameSet(targets, expected)) {
       // OUR scoped dispatch, verifiably delivered.
       state.observed++;
       const res = await origFetchApi(route, options);
@@ -304,10 +338,9 @@ export function createScopedRunGuard({
       notify();
       return res;
     }
-    // OUR dispatch CORRUPTED — scope missing, or wrong/extra/partial targets
-    // (["14","9"] would run an unwanted branch; "9" would run the wrong one).
-    // Only reachable with a signature; the batch bound caps the documented
-    // same-node-set ambiguity.
+    // OUR dispatch CORRUPTED — scope missing, wrong/extra/partial targets
+    // (["14","9"] would run an unwanted branch), or the graph changed while
+    // our item sat deferred (scope unverifiable against the new graph).
     if (refused < maxBatch) {
       refused++;
       state.dropped = scopeDroppedError({
@@ -320,8 +353,8 @@ export function createScopedRunGuard({
       notify();
       return SCOPE_DROPPED_RESPONSE();
     }
-    // Refusal budget for this batch is exhausted — beyond this point a
-    // same-signature body is not ours to judge (documented ambiguity bound).
+    // Refusal budget for this batch is exhausted (paranoia bound; normally the
+    // frontend's batch loop breaks on the first refusal).
     return origFetchApi(route, options);
   };
   guard.state = state;
@@ -337,6 +370,7 @@ export function createScopedRunGuard({
         waiters.delete(fire);
         resolve(false);
       }, ms);
+      if (typeof timer.unref === "function") timer.unref();
       waiters.add(fire);
     });
   return guard;
@@ -345,35 +379,150 @@ export function createScopedRunGuard({
 /**
  * Best-effort removal of THIS run's still-pending item(s) from the frontend's
  * in-memory queueItems (the not-yet-posted deferred dispatch — the server-side
- * /queue never saw it, so server queue control can't help). The frontend keeps
- * the array runtime-accessible as app.queueItems on TS-`private` builds; older
- * builds hard-privatize it (#queueItems) and then this is impossible — the
- * caller keeps the guard installed as a sentinel instead (module header).
- *
- * An item is only removed when its stored targets NORMALIZE to exactly this
- * run's scope (either the raw array or the {queueNodeIds} options shape a
- * positional build stored verbatim) — a user's pending full-run item carries
- * no targets and is never touched, and a scope-dropped item whose build stored
- * no attributable targets can't be identified (left for the sentinel).
+ * /queue never saw it, so server queue control can't help). Ownership is by
+ * the non-enumerable QUEUE_ITEM_TAG dispatchScopedRun stamped on the targets
+ * array (frontend builds store the array by reference, either directly or
+ * inside the options object), so an identical-scope item from ANOTHER run is
+ * never removed. The array is runtime-accessible as app.queueItems on
+ * TS-`private` builds; older builds hard-privatize it (#queueItems), and a
+ * build that COPIED the array loses the tag — then this reports 0 removed and
+ * the caller keeps the guard installed as a sentinel instead (module header).
  *
  * @returns {{accessible: boolean, removed: number}}
  */
-export function cancelPendingScopedQueueItem(app, expectedExecIds) {
+export function cancelPendingScopedQueueItem(app, runTag) {
   const items = app?.queueItems;
   if (!Array.isArray(items)) return { accessible: false, removed: 0 };
-  const expected = (expectedExecIds ?? []).map(String);
   let removed = 0;
   for (let i = items.length - 1; i >= 0; i--) {
     const raw = items[i]?.queueNodeIds;
-    const ids = Array.isArray(raw) && raw.length
-      ? raw.map(String)
-      : raw && Array.isArray(raw.queueNodeIds) && raw.queueNodeIds.length
-        ? raw.queueNodeIds.map(String)
-        : null;
-    if (ids && sameSet(ids, expected)) {
+    const arr = Array.isArray(raw) ? raw : raw && Array.isArray(raw.queueNodeIds) ? raw.queueNodeIds : null;
+    if (arr && arr[QUEUE_ITEM_TAG] === runTag) {
       items.splice(i, 1);
       removed++;
     }
   }
   return { accessible: true, removed };
+}
+
+/**
+ * The scoped-dispatch orchestration graph_run runs — extracted whole so the
+ * REAL control flow (guard install, queuePrompt, observation wait, cancel/
+ * sentinel decision, and the finally-restore) is what the unit tests drive.
+ *
+ * Returns a discriminated result (never throws for queue outcomes):
+ *  - { outcome: "dispatched" }              our scoped dispatch was OBSERVED
+ *    (prompt_ids / a server rejection captured via the callbacks);
+ *  - { outcome: "refused",   error }        every argument shape produced OUR
+ *    corrupted dispatch, all blocked — nothing was queued;
+ *  - { outcome: "unverified", error }       no scoped dispatch surfaced in
+ *    time; our pending item was cancelled, or a sentinel guard remains for
+ *    lingerMs (the error says which);
+ *  - { outcome: "unverifiable", error }     no attribution possible (no
+ *    fetchApi to observe through, or no prompt signature) — refused BEFORE
+ *    dispatch, nothing queued.
+ */
+export async function dispatchScopedRun({
+  app,
+  apiTarget,
+  execIds,
+  batch = 1,
+  toNodeId = null,
+  verifyTimeoutMs = 5000,
+  lingerMs = 10 * 60 * 1000,
+  onRejection = null,
+  onPromptId = null,
+} = {}) {
+  const prevFetchApi = typeof apiTarget?.fetchApi === "function" ? apiTarget.fetchApi : null;
+  const origFetchApi = prevFetchApi ? prevFetchApi.bind(apiTarget) : null;
+  if (!origFetchApi) {
+    return {
+      outcome: "unverifiable",
+      error:
+        `run-to-node scope for node ${toNodeId} cannot be verified — api.fetchApi is ` +
+        `unavailable on this frontend, so there is no way to confirm the scope reaches the ` +
+        `prompt. Nothing was queued rather than risk a full-graph execution (#556).`,
+    };
+  }
+  // The signature that (with the queue mark) attributes a POST /prompt body to
+  // THIS run. No signature ⇒ no attribution ⇒ fail closed BEFORE dispatch.
+  let signature = null;
+  try {
+    if (typeof app.graphToPrompt === "function") {
+      signature = promptSignature((await app.graphToPrompt())?.output);
+    }
+  } catch {
+    signature = null;
+  }
+  if (!signature) {
+    return { outcome: "unverifiable", error: scopeUnattributableError({ toNodeId }) };
+  }
+  // Ownership tag for the timeout cancellation (see QUEUE_ITEM_TAG).
+  const runTag = Symbol("cmcp-scoped-run");
+  try {
+    Object.defineProperty(execIds, QUEUE_ITEM_TAG, { value: runTag, enumerable: false, configurable: true });
+  } catch {
+    // non-extensible array — cancellation will report 0 and the sentinel covers it.
+  }
+  let dropped = null;
+  for (const scopeArg of queuePromptScopeArgs(execIds)) {
+    dropped = null;
+    let keepGuardInstalled = false;
+    const guard = createScopedRunGuard({
+      origFetchApi,
+      execIds,
+      signature,
+      batch,
+      toNodeId,
+      queueMark: SCOPED_QUEUE_MARK,
+      onRejection,
+      onPromptId,
+    });
+    apiTarget.fetchApi = guard;
+    try {
+      await app.queuePrompt(SCOPED_QUEUE_MARK, batch, scopeArg);
+      if (!(guard.state.observed > 0 || guard.state.dropped)) {
+        // queuePrompt returned without our dispatch surfacing — the
+        // frontend's processor was busy and will serialize/post the item
+        // LATER. Keep the guard installed and wait for our scoped dispatch
+        // to be OBSERVED, or the bounded timeout.
+        await guard.waitForVerdict(verifyTimeoutMs);
+      }
+      if (!(guard.state.observed > 0 || guard.state.dropped)) {
+        // GIVE-UP — decided HERE, inside the try, so the finally below honors
+        // keepGuardInstalled. The deferred item may still be live in the
+        // frontend's pending queue: try to REMOVE it (ownership-tagged), and
+        // only when that's impossible keep the surgical guard installed as a
+        // sentinel so the late scope-dropped dispatch is still refused.
+        const cancel = cancelPendingScopedQueueItem(app, runTag);
+        if (cancel.removed > 0) {
+          return {
+            outcome: "unverified",
+            error: scopeUnverifiedError({ toNodeId, timeoutMs: verifyTimeoutMs, cancelled: true }),
+          };
+        }
+        keepGuardInstalled = true;
+        const timer = setTimeout(() => {
+          // Self-remove only if nothing newer has wrapped over the sentinel —
+          // a guard left underneath a newer wrap is inert (mark-scoped +
+          // batch-bounded) and simply remains in the chain.
+          if (apiTarget.fetchApi === guard) apiTarget.fetchApi = prevFetchApi;
+        }, lingerMs);
+        if (typeof timer.unref === "function") timer.unref();
+        return {
+          outcome: "unverified",
+          error: scopeUnverifiedError({ toNodeId, timeoutMs: verifyTimeoutMs, cancelled: false, lingerMs }),
+        };
+      }
+    } finally {
+      if (!keepGuardInstalled) apiTarget.fetchApi = prevFetchApi;
+    }
+    // Verifiably dispatched with our scope.
+    if (guard.state.observed > 0) return { outcome: "dispatched" };
+    // OUR dispatch surfaced WITHOUT the scope and was refused before it left
+    // the tab — nothing was queued, so retrying the other arg shape can never
+    // double-queue.
+    dropped = guard.state.dropped;
+  }
+  return { outcome: "refused", error: dropped };
 }

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -15,12 +15,33 @@
 //     silently IGNORES the other — the scope never reaches the request, the FULL
 //     graph queues, and panel_run still reports ran_to_node (#556: an unrelated
 //     SaveImage branch rendered and wrote a file nobody asked for). A minified
-//     queuePrompt signature can't be sniffed reliably, so this module enforces
-//     the guarantee at the one place every build must pass through: the POST
-//     /prompt request body. When a scope was requested, any /prompt body that
-//     doesn't carry EXACTLY that scope is REFUSED BEFORE origFetchApi runs —
-//     nothing is dispatched unscoped — and the caller retries the OTHER
-//     argument shape once, then refuses truthfully if neither shape delivers.
+//     queuePrompt signature can't be sniffed reliably, so the guarantee is
+//     enforced at the one place every build must pass through: the POST /prompt
+//     request body.
+//
+// Two dispatch realities shape the design (codex gate on the first cut):
+//
+//  - app.queuePrompt is NOT synchronous with the POST. When its processor is
+//    already busy it pushes the item and RETURNS EARLY — the prompt is
+//    serialized and posted LATER by the in-flight processor. A guard restored
+//    when queuePrompt returns never sees that deferred dispatch (P0). So the
+//    scoped guard stays installed until our dispatch is actually OBSERVED (a
+//    POST carrying exactly our targets has passed through) or a bounded
+//    timeout — and a run whose dispatch never surfaces reports a truthful
+//    "could not verify — nothing confirmed queued", never queued:true.
+//
+//  - While installed, the guard sees EVERY POST /prompt in the tab, including
+//    unrelated ones (a user queue, another processor's item). Refusing any
+//    body that merely lacks our targets would 400 a stranger's legitimate full
+//    run (P1). So the guard is SURGICAL: it only refuses a targetless body
+//    that matches THIS run's prompt signature (the sorted node-id|class_type
+//    set of the graphToPrompt output we queued — widget values excluded so
+//    beforeQueued seed randomization can't blur it), and only for as many
+//    posts as this batch still has unattributed. Everything else — unrelated
+//    full runs, other scoped runs, unparseable bodies — passes through
+//    untouched and is never captured as ours. Known limit: a concurrent full
+//    run of the byte-identical node set inside the window is indistinguishable
+//    from our own dropped dispatch and is treated as ours (bounded by batch).
 //
 // Extracted as a pure module so the SAME guard graph_run installs is drivable
 // from `node --test` (the live app.queuePrompt path can't be).
@@ -42,6 +63,52 @@ export function queuePromptScopeArgs(partialTargets) {
 }
 
 /**
+ * The prompt signature used to attribute a POST /prompt body to THIS run: the
+ * sorted node-id|class_type pairs of a graphToPrompt output (the API workflow).
+ * Widget values are EXCLUDED — queuePrompt randomizes seeds via beforeQueued
+ * between serialization calls, so a value-level fingerprint would miss our own
+ * dispatch. Two runs of the same unedited graph share a signature; the batch
+ * bound in the guard limits what that ambiguity can mis-attribute.
+ */
+export function promptSignature(output) {
+  if (!output || typeof output !== "object") return null;
+  const keys = Object.keys(output);
+  if (!keys.length) return null;
+  return keys
+    .sort()
+    .map((k) => `${k}${output[k]?.class_type ?? ""}`)
+    .join("|");
+}
+
+/** Signature of a raw POST /prompt body, or null when unparseable/odd. */
+export function promptSignatureFromBody(bodyText) {
+  let body;
+  try {
+    body = JSON.parse(bodyText);
+  } catch {
+    return null;
+  }
+  return promptSignature(body?.prompt);
+}
+
+/** The body body's partial_execution_targets as strings, or null when absent/empty/unparseable. */
+function targetsFromBody(bodyText) {
+  let body;
+  try {
+    body = JSON.parse(bodyText);
+  } catch {
+    return null;
+  }
+  const t = body?.partial_execution_targets;
+  if (!Array.isArray(t) || !t.length) return null;
+  return t.map(String);
+}
+
+function sameSet(a, b) {
+  return a.length === b.length && b.every((x) => a.includes(x));
+}
+
+/**
  * Verify a POST /prompt request body carries EXACTLY the requested
  * partial-execution scope. Compared as string sets (server exec ids are strings;
  * a colon path like "76:34" for a subgraph-nested output must survive verbatim).
@@ -55,29 +122,17 @@ export function queuePromptScopeArgs(partialTargets) {
 export function verifyScopedPromptBody(bodyText, expectedExecIds) {
   const expected = (expectedExecIds ?? []).map(String);
   if (!expected.length) return { ok: true }; // no scope requested — nothing to verify
-  let body;
-  try {
-    body = JSON.parse(bodyText);
-  } catch {
-    body = null;
-  }
-  const targets = Array.isArray(body?.partial_execution_targets)
-    ? body.partial_execution_targets.map(String)
-    : null;
-  if (!targets || !targets.length) {
-    return { ok: false, reason: "scope_missing", expected, got: targets };
-  }
-  const same =
-    targets.length === expected.length && expected.every((e) => targets.includes(e));
-  if (!same) return { ok: false, reason: "scope_mismatch", expected, got: targets };
+  const got = targetsFromBody(bodyText);
+  if (!got) return { ok: false, reason: "scope_missing", expected, got: null };
+  if (!sameSet(got, expected)) return { ok: false, reason: "scope_mismatch", expected, got };
   return { ok: true };
 }
 
 /**
- * The truthful refusal message when the scope didn't reach the request. Names
- * the node that couldn't be scoped and states plainly that NOTHING was queued —
- * never a false `queued:true`/`ran_to_node` for what would have been a
- * full-graph run.
+ * The truthful refusal message when our own dispatch surfaced WITHOUT the
+ * scope. Names the node that couldn't be scoped and states plainly that
+ * NOTHING was queued — never a false `queued:true`/`ran_to_node` for what
+ * would have been a full-graph run.
  */
 export function scopeDroppedError({ toNodeId, verdict }) {
   const detail =
@@ -93,80 +148,160 @@ export function scopeDroppedError({ toNodeId, verdict }) {
 }
 
 /**
- * The api.fetchApi replacement graph_run installs for the duration of ONE queue
- * attempt. Two jobs:
- *
- *  - SCOPE GUARD (#556, above): for a scoped run, inspect every POST /prompt
- *    body BEFORE it leaves and refuse any that dropped the scope — the blocked
- *    call NEVER reaches origFetchApi, so no unscoped prompt is dispatched. The
- *    refusal is shaped like a server 400 so the frontend walks its normal
- *    rejection path (the same dialog a real refused prompt shows), while the
- *    onScopeDropped callback hands graph_run the truthful error to return.
- *
- *  - RESPONSE CAPTURE (#358/#370, moved verbatim from graph_run): app.queuePrompt
- *    SWALLOWS a synchronous top-level rejection (dialog, then discarded — it
- *    never lands on lastNodeErrors), so the raw non-200 /prompt body is the only
- *    place that error exists; and EVERY accepted prompt_id must be captured for
- *    the recovery ledger. onPromptId receives the id NORMALIZED TO A STRING at
- *    capture (0 and "0" are the same run).
- *
- * @param {object}   args
- * @param {Function} args.origFetchApi      The real api.fetchApi (bound).
- * @param {string[]|null} [args.partialTargets]  Resolved scope, or null for a full run.
- * @param {*}        [args.toNodeId]        The requested to_node_id (for the refusal message).
- * @param {Function} [args.onRejection]     ({error, node_errors}) for a non-200 /prompt.
- * @param {Function} [args.onPromptId]      (promptId:string) for each accepted prompt.
- * @param {Function} [args.onScopeDropped]  (message:string) when the guard refuses.
+ * The truthful UNVERIFIED outcome when no scoped dispatch surfaced within the
+ * observation window (a busy queuePrompt deferred the post past its return, or
+ * the prompt build failed silently). Deliberately does NOT say "nothing was
+ * queued" — a deferred post may still land later, unverifiably — only that
+ * nothing is CONFIRMED queued, so the caller must check the ComfyUI queue
+ * rather than assume a scoped run happened.
  */
-export function createRunFetchInterceptor({
+export function scopeUnverifiedError({ toNodeId, timeoutMs }) {
+  return (
+    `run-to-node scope for node ${toNodeId} could not be verified: no scoped ` +
+    `dispatch was observed within ${Math.round(timeoutMs / 1000)}s of queueing ` +
+    `(the frontend deferred or silently dropped the request). Nothing is ` +
+    `CONFIRMED queued — check the ComfyUI queue, and retry the run; the panel ` +
+    `did not report this as a scoped execution (#556).`
+  );
+}
+
+const SCOPE_DROPPED_RESPONSE = () =>
+  new Response(
+    JSON.stringify({
+      error: {
+        type: "partial_execution_scope_dropped",
+        message: "run-to-node scope was not applied; nothing was queued",
+      },
+    }),
+    { status: 400, headers: { "Content-Type": "application/json" } },
+  );
+
+function isPromptPost(route, options) {
+  const method = String(options?.method || "GET").toUpperCase();
+  const path = typeof route === "string" ? route.split("?")[0] : "";
+  return method === "POST" && path.endsWith("/prompt");
+}
+
+// Capture the #358 top-level rejection / #370 prompt_id out of a /prompt
+// response that is ATTRIBUTED to this run. prompt_id is normalized to a string
+// at capture (0 and "0" are the same run).
+async function captureRunResponse(res, { onRejection, onPromptId }) {
+  try {
+    const body = await res.clone().json();
+    if (res.status !== 200) {
+      if (body && (body.error || body.node_errors)) {
+        onRejection?.({ error: body.error ?? null, node_errors: body.node_errors ?? null });
+      }
+    } else if (body && body.prompt_id != null) {
+      onPromptId?.(String(body.prompt_id));
+    }
+  } catch {
+    // non-JSON body / clone unsupported — the caller falls back to lastNodeErrors.
+  }
+}
+
+/**
+ * The api.fetchApi replacement graph_run installs around an UNSCOPED run — the
+ * historical #358/#370 capture wrap, byte-identical in behavior: app.queuePrompt
+ * SWALLOWS a synchronous top-level rejection (dialog, then discarded — it never
+ * lands on lastNodeErrors), so the raw non-200 /prompt body is the only place
+ * that error exists; and EVERY accepted prompt_id is captured for the recovery
+ * ledger. Installed only for the duration of the queuePrompt call.
+ */
+export function createRunFetchInterceptor({ origFetchApi, onRejection = null, onPromptId = null } = {}) {
+  return async function runFetchInterceptor(route, options) {
+    const res = await origFetchApi(route, options);
+    if (isPromptPost(route, options) && res) {
+      await captureRunResponse(res, { onRejection, onPromptId });
+    }
+    return res;
+  };
+}
+
+/**
+ * The api.fetchApi replacement graph_run installs for a SCOPED run — see the
+ * module header for the two dispatch realities this is shaped by.
+ *
+ * Attribution, per POST /prompt body:
+ *  - carries exactly our targets       → OUR scoped dispatch: pass through,
+ *    count it OBSERVED, capture its response (rejection / prompt_id).
+ *  - carries someone else's targets    → unrelated scoped run: untouched,
+ *    never captured.
+ *  - carries NO targets, matches our prompt signature, and this batch still
+ *    has unattributed posts           → OUR dispatch gone wrong (the frontend
+ *    ignored the scope argument): REFUSE before origFetchApi runs — the
+ *    unscoped prompt never leaves the tab — and record state.dropped so the
+ *    caller can retry the other argument shape.
+ *  - anything else (other signature, batch already accounted, unparseable)
+ *                                      → unrelated: untouched, never captured.
+ *
+ * The guard stays installed until the caller has observed a verdict; it does
+ * not restore itself. state = { observed, dropped } is live;
+ * waitForVerdict(ms) resolves true as soon as either is set, false on timeout.
+ */
+export function createScopedRunGuard({
   origFetchApi,
-  partialTargets = null,
+  execIds,
+  signature = null,
+  batch = 1,
   toNodeId = null,
   onRejection = null,
   onPromptId = null,
   onScopeDropped = null,
 } = {}) {
-  const scoped = Array.isArray(partialTargets) && partialTargets.length > 0;
-  return async function runFetchInterceptor(route, options) {
-    const method = String(options?.method || "GET").toUpperCase();
-    const path = typeof route === "string" ? route.split("?")[0] : "";
-    const isPromptPost = method === "POST" && path.endsWith("/prompt");
-    if (isPromptPost && scoped) {
-      const verdict = verifyScopedPromptBody(options?.body, partialTargets);
-      if (!verdict.ok) {
-        onScopeDropped?.(scopeDroppedError({ toNodeId, verdict }));
-        // Refuse WITHOUT touching origFetchApi — the unscoped prompt must never
-        // leave the tab. 400 mirrors a server-side rejection so app.queuePrompt
-        // handles it through its existing refused-prompt path.
-        return new Response(
-          JSON.stringify({
-            error: {
-              type: "partial_execution_scope_dropped",
-              message: "run-to-node scope was not applied; nothing was queued",
-            },
-          }),
-          { status: 400, headers: { "Content-Type": "application/json" } },
-        );
-      }
-    }
-    const res = await origFetchApi(route, options);
-    if (isPromptPost && res) {
-      try {
-        const body = await res.clone().json();
-        if (res.status !== 200) {
-          if (body && (body.error || body.node_errors)) {
-            onRejection?.({
-              error: body.error ?? null,
-              node_errors: body.node_errors ?? null,
-            });
-          }
-        } else if (body && body.prompt_id != null) {
-          onPromptId?.(String(body.prompt_id));
-        }
-      } catch {
-        // non-JSON body / clone unsupported — the caller falls back to lastNodeErrors.
-      }
-    }
-    return res;
+  const expected = (execIds ?? []).map(String);
+  const maxBatch = Math.max(1, Math.floor(Number(batch)) || 1);
+  let oursAccounted = 0; // verified + refused posts attributable to THIS batch
+  const state = { observed: 0, dropped: null };
+  const waiters = new Set();
+  const notify = () => {
+    for (const fire of [...waiters]) fire();
   };
+
+  const guard = async (route, options) => {
+    if (!isPromptPost(route, options)) return origFetchApi(route, options);
+    const targets = targetsFromBody(options?.body);
+    if (targets) {
+      if (!sameSet(targets, expected)) {
+        // A scoped run for SOMEONE ELSE — never touch it.
+        return origFetchApi(route, options);
+      }
+      oursAccounted++;
+      state.observed++;
+      const res = await origFetchApi(route, options);
+      if (res) await captureRunResponse(res, { onRejection, onPromptId });
+      notify();
+      return res;
+    }
+    // Targetless body. Ours-gone-wrong only while it matches our signature and
+    // we still have unattributed batch posts outstanding.
+    if (signature && promptSignatureFromBody(options?.body) === signature && oursAccounted < maxBatch) {
+      oursAccounted++;
+      state.dropped = scopeDroppedError({
+        toNodeId,
+        verdict: { ok: false, reason: "scope_missing", expected, got: null },
+      });
+      onScopeDropped?.(state.dropped);
+      notify();
+      return SCOPE_DROPPED_RESPONSE();
+    }
+    // Unrelated full run (or unattributable) — untouched, never captured.
+    return origFetchApi(route, options);
+  };
+  guard.state = state;
+  guard.waitForVerdict = (ms) =>
+    new Promise((resolve) => {
+      if (state.observed > 0 || state.dropped) return resolve(true);
+      const fire = () => {
+        clearTimeout(timer);
+        waiters.delete(fire);
+        resolve(true);
+      };
+      const timer = setTimeout(() => {
+        waiters.delete(fire);
+        resolve(false);
+      }, ms);
+      waiters.add(fire);
+    });
+  return guard;
 }

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -297,6 +297,22 @@ function isPromptPost(route, options) {
   return method === "POST" && path.endsWith("/prompt");
 }
 
+/**
+ * The truthful DISPATCH-FAILURE outcome (r6): an ATTRIBUTED /prompt post (our
+ * mark, our signature, our exact targets) whose fetch threw or whose response
+ * was malformed (no parseable prompt_id, no rejection body). That post is NOT
+ * verified and NOT a server rejection — the run must never report queued:true
+ * for it. Names what failed and how much of the batch was confirmed first.
+ */
+export function scopeDispatchError({ toNodeId, detail, verified, batch }) {
+  return (
+    `run-to-node scope for node ${toNodeId}: a verified-scoped /prompt request ` +
+    `FAILED to complete — ${detail}. ${verified} of ${batch} batch prompts were ` +
+    `confirmed queued before the failure. The run is NOT reported as queued: ` +
+    `this prompt did not reach ComfyUI, and no full-graph dispatch occurred (#556).`
+  );
+}
+
 // Capture the #358 top-level rejection / #370 prompt_id out of a /prompt
 // response that is ATTRIBUTED to this run. prompt_id is normalized to a string
 // at capture (0 and "0" are the same run).
@@ -312,6 +328,33 @@ async function captureRunResponse(res, { onRejection, onPromptId }) {
     }
   } catch {
     // non-JSON body / clone unsupported — the caller falls back to lastNodeErrors.
+  }
+}
+
+// Classify the response to an ATTRIBUTED scoped post (r6): "accepted" ONLY
+// when it is a real 200 with a parseable prompt_id (captured); "rejected" when
+// it is a genuine server rejection (non-200 with an error / node_errors body —
+// captured through the established #358 channel); "malformed" for anything
+// else (2xx without a prompt_id, non-200 without a rejection body, unparseable
+// body, missing response). Only "accepted" may ever count as verified.
+async function classifyRunResponse(res, { onRejection, onPromptId }) {
+  if (!res) return "malformed";
+  try {
+    const body = await res.clone().json();
+    if (res.status === 200) {
+      if (body && body.prompt_id != null) {
+        onPromptId?.(String(body.prompt_id));
+        return "accepted";
+      }
+      return "malformed";
+    }
+    if (body && (body.error || body.node_errors)) {
+      onRejection?.({ error: body.error ?? null, node_errors: body.node_errors ?? null });
+      return "rejected";
+    }
+    return "malformed";
+  } catch {
+    return "malformed";
   }
 }
 
@@ -360,7 +403,7 @@ export function createScopedRunGuard({
 } = {}) {
   const expected = (execIds ?? []).map(String);
   const maxBatch = Math.max(1, Math.floor(Number(batch)) || 1);
-  const state = { observed: 0, refused: 0, dropped: null };
+  const state = { observed: 0, rejected: 0, refused: 0, dropped: null, failed: null };
   const waiters = new Set();
   const notify = () => {
     for (const fire of [...waiters]) fire();
@@ -377,12 +420,38 @@ export function createScopedRunGuard({
     const targets = targetsFromBody(options?.body);
     const sigOk = signature && promptSignatureFromBody(options?.body) === signature;
     if (sigOk && targets && sameSet(targets, expected)) {
-      // OUR scoped dispatch, verifiably delivered. The run is only
-      // "dispatched" when ALL `batch` posts verify — a batch is never
-      // declared complete on a partial count (r5).
-      state.observed++;
-      const res = await origFetchApi(route, options);
-      if (res) await captureRunResponse(res, { onRejection, onPromptId });
+      // OUR scoped dispatch. It counts as VERIFIED only when the fetch itself
+      // completes with a real 200 + prompt_id (r6) — a thrown fetch or a
+      // malformed response is a terminal dispatch FAILURE, never a success;
+      // a genuine server rejection flows through the established #358 channel.
+      let res;
+      try {
+        res = await origFetchApi(route, options);
+      } catch (err) {
+        if (state.failed == null) {
+          state.failed = scopeDispatchError({
+            toNodeId,
+            detail: `the /prompt request itself threw (${String(err?.message ?? err)})`,
+            verified: state.observed,
+            batch: maxBatch,
+          });
+        }
+        notify();
+        throw err; // the frontend sees exactly the failure it would have seen
+      }
+      const verdict = await classifyRunResponse(res, { onRejection, onPromptId });
+      if (verdict === "accepted") {
+        state.observed++;
+      } else if (verdict === "rejected") {
+        state.rejected++;
+      } else if (state.failed == null) {
+        state.failed = scopeDispatchError({
+          toNodeId,
+          detail: `the /prompt response was malformed (HTTP ${res?.status ?? "?"}, no prompt_id and no rejection body)`,
+          verified: state.observed,
+          batch: maxBatch,
+        });
+      }
       notify();
       return res;
     }
@@ -408,11 +477,16 @@ export function createScopedRunGuard({
     return origFetchApi(route, options);
   };
   guard.state = state;
-  // Verdict = the FULL batch verified, or ANY corrupted post (which ends the
-  // attempt: the frontend's batch loop breaks on the first refusal — the
-  // caller distinguishes shape-drop (0 verified ⇒ retry shape) from mid-batch
-  // corruption (some verified ⇒ terminal partial, r5)).
-  const verdictReached = () => state.observed >= maxBatch || state.dropped != null;
+  // Verdict = the run reached a TERMINAL state: the whole batch verified, a
+  // genuine server rejection arrived, a dispatch failure occurred (r6), or a
+  // corrupted post ended the attempt (the frontend's batch loop breaks on the
+  // first refusal — the caller distinguishes shape-drop (0 verified ⇒ retry
+  // shape) from mid-batch corruption (some verified ⇒ terminal partial, r5)).
+  const verdictReached = () =>
+    state.failed != null ||
+    state.rejected > 0 ||
+    state.observed >= maxBatch ||
+    state.dropped != null;
   guard.verdictReached = verdictReached;
   guard.waitForVerdict = (ms) =>
     new Promise((resolve) => {
@@ -575,8 +649,38 @@ export async function dispatchScopedRun({
           error: scopeUnverifiedError({ toNodeId, timeoutMs: verifyTimeoutMs, cancelled: false, verified, batch }),
         };
       }
+      // r6: a dispatch FAILURE with the batch not fully accounted — the
+      // frontend CONTINUES its queue loop on generic submission failures, so
+      // later posts of this batch can still come. Keep the guard installed as
+      // a page-session sentinel so a later CORRUPTED post is still refused
+      // (decided HERE so the finally below honors it).
+      if (
+        guard.state.failed != null &&
+        guard.state.observed + guard.state.rejected + guard.state.refused < batch
+      ) {
+        keepGuardInstalled = true;
+      }
     } finally {
       if (!keepGuardInstalled) apiTarget.fetchApi = prevFetchApi;
+    }
+    // r6: the dispatch itself failed (fetch threw / malformed response) —
+    // terminal, truthful, NEVER queued:true.
+    if (guard.state.failed != null) {
+      return {
+        outcome: "failed",
+        queueMark: mark,
+        verified: guard.state.observed,
+        error: guard.state.failed +
+          (keepGuardInstalled
+            ? " The scope guard stays installed as a sentinel for the rest of this page session."
+            : ""),
+      };
+    }
+    // A genuine SERVER rejection (#358) is terminal and flows through the
+    // established rejection channel — the run "dispatched" and ComfyUI said
+    // no; graph_run's summarizePromptRejection surfaces it, never queued:true.
+    if (guard.state.rejected > 0) {
+      return { outcome: "dispatched", queueMark: mark, verified: guard.state.observed };
     }
     // The FULL batch verified — genuinely dispatched (r5: never on a partial).
     if (guard.state.observed >= batch) {

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -1,0 +1,172 @@
+// #556 — panel_run's to_node_id ("run to node") must NEVER silently fall through
+// to a FULL-graph execution. A scoped run can fail open on two channels:
+//
+//  1. SCOPE RESOLUTION — the id is stale/unknown, names a non-output node, or
+//     lives in a subgraph the live root can't reach. graph_run resolves strictly
+//     via resolveRunToNodeTarget and REFUSES before dispatch (queued:false,
+//     naming what couldn't be resolved). Covered by subgraph-scope.test.mjs.
+//
+//  2. SCOPE DELIVERY — a VALID target must survive the trip through
+//     app.queuePrompt into the POST /prompt body as partial_execution_targets.
+//     The queuePrompt 3rd-argument SHAPE differs across frontend builds:
+//     a positional NodeExecutionId[] on some, a QueuePromptOptions
+//     { queueNodeIds } object on others (options builds carry an Array.isArray
+//     compat shim for the legacy array). A build that accepts only ONE shape
+//     silently IGNORES the other — the scope never reaches the request, the FULL
+//     graph queues, and panel_run still reports ran_to_node (#556: an unrelated
+//     SaveImage branch rendered and wrote a file nobody asked for). A minified
+//     queuePrompt signature can't be sniffed reliably, so this module enforces
+//     the guarantee at the one place every build must pass through: the POST
+//     /prompt request body. When a scope was requested, any /prompt body that
+//     doesn't carry EXACTLY that scope is REFUSED BEFORE origFetchApi runs —
+//     nothing is dispatched unscoped — and the caller retries the OTHER
+//     argument shape once, then refuses truthfully if neither shape delivers.
+//
+// Extracted as a pure module so the SAME guard graph_run installs is drivable
+// from `node --test` (the live app.queuePrompt path can't be).
+
+/**
+ * The ordered list of 3rd-argument shapes to try for app.queuePrompt when a
+ * run-to-node scope is requested. The positional array comes first (native on
+ * positional builds, normalized by the Array.isArray shim on options builds);
+ * the QueuePromptOptions object is the fallback for builds that dropped the
+ * shim. `[undefined]` when no scope was requested — a plain full run, exactly
+ * the historical call shape.
+ *
+ * @param {string[]|undefined} partialTargets
+ * @returns {(string[]|{queueNodeIds:string[]}|undefined)[]}
+ */
+export function queuePromptScopeArgs(partialTargets) {
+  if (!Array.isArray(partialTargets) || !partialTargets.length) return [undefined];
+  return [partialTargets, { queueNodeIds: partialTargets }];
+}
+
+/**
+ * Verify a POST /prompt request body carries EXACTLY the requested
+ * partial-execution scope. Compared as string sets (server exec ids are strings;
+ * a colon path like "76:34" for a subgraph-nested output must survive verbatim).
+ * Any deviation — missing key, empty list, wrong/extra targets, an unparseable
+ * body — is a refusal: an unverifiable scope is treated as a dropped scope.
+ *
+ * @param {string|undefined} bodyText        Raw request body (JSON string).
+ * @param {string[]|null} expectedExecIds    The scope graph_run resolved, or null.
+ * @returns {{ok:true}|{ok:false, reason:"scope_missing"|"scope_mismatch", expected:string[], got:string[]|null}}
+ */
+export function verifyScopedPromptBody(bodyText, expectedExecIds) {
+  const expected = (expectedExecIds ?? []).map(String);
+  if (!expected.length) return { ok: true }; // no scope requested — nothing to verify
+  let body;
+  try {
+    body = JSON.parse(bodyText);
+  } catch {
+    body = null;
+  }
+  const targets = Array.isArray(body?.partial_execution_targets)
+    ? body.partial_execution_targets.map(String)
+    : null;
+  if (!targets || !targets.length) {
+    return { ok: false, reason: "scope_missing", expected, got: targets };
+  }
+  const same =
+    targets.length === expected.length && expected.every((e) => targets.includes(e));
+  if (!same) return { ok: false, reason: "scope_mismatch", expected, got: targets };
+  return { ok: true };
+}
+
+/**
+ * The truthful refusal message when the scope didn't reach the request. Names
+ * the node that couldn't be scoped and states plainly that NOTHING was queued —
+ * never a false `queued:true`/`ran_to_node` for what would have been a
+ * full-graph run.
+ */
+export function scopeDroppedError({ toNodeId, verdict }) {
+  const detail =
+    verdict?.reason === "scope_mismatch"
+      ? `the POST /prompt body carried partial_execution_targets ` +
+        `${JSON.stringify(verdict.got)} instead of ${JSON.stringify(verdict.expected)}`
+      : `the POST /prompt body carried no partial_execution_targets — this ` +
+        `frontend build ignored the run-to-node argument`;
+  return (
+    `run-to-node scope for node ${toNodeId} was NOT applied: ${detail}. ` +
+    `Nothing was queued — refusing to fall through to a full-graph execution (#556).`
+  );
+}
+
+/**
+ * The api.fetchApi replacement graph_run installs for the duration of ONE queue
+ * attempt. Two jobs:
+ *
+ *  - SCOPE GUARD (#556, above): for a scoped run, inspect every POST /prompt
+ *    body BEFORE it leaves and refuse any that dropped the scope — the blocked
+ *    call NEVER reaches origFetchApi, so no unscoped prompt is dispatched. The
+ *    refusal is shaped like a server 400 so the frontend walks its normal
+ *    rejection path (the same dialog a real refused prompt shows), while the
+ *    onScopeDropped callback hands graph_run the truthful error to return.
+ *
+ *  - RESPONSE CAPTURE (#358/#370, moved verbatim from graph_run): app.queuePrompt
+ *    SWALLOWS a synchronous top-level rejection (dialog, then discarded — it
+ *    never lands on lastNodeErrors), so the raw non-200 /prompt body is the only
+ *    place that error exists; and EVERY accepted prompt_id must be captured for
+ *    the recovery ledger. onPromptId receives the id NORMALIZED TO A STRING at
+ *    capture (0 and "0" are the same run).
+ *
+ * @param {object}   args
+ * @param {Function} args.origFetchApi      The real api.fetchApi (bound).
+ * @param {string[]|null} [args.partialTargets]  Resolved scope, or null for a full run.
+ * @param {*}        [args.toNodeId]        The requested to_node_id (for the refusal message).
+ * @param {Function} [args.onRejection]     ({error, node_errors}) for a non-200 /prompt.
+ * @param {Function} [args.onPromptId]      (promptId:string) for each accepted prompt.
+ * @param {Function} [args.onScopeDropped]  (message:string) when the guard refuses.
+ */
+export function createRunFetchInterceptor({
+  origFetchApi,
+  partialTargets = null,
+  toNodeId = null,
+  onRejection = null,
+  onPromptId = null,
+  onScopeDropped = null,
+} = {}) {
+  const scoped = Array.isArray(partialTargets) && partialTargets.length > 0;
+  return async function runFetchInterceptor(route, options) {
+    const method = String(options?.method || "GET").toUpperCase();
+    const path = typeof route === "string" ? route.split("?")[0] : "";
+    const isPromptPost = method === "POST" && path.endsWith("/prompt");
+    if (isPromptPost && scoped) {
+      const verdict = verifyScopedPromptBody(options?.body, partialTargets);
+      if (!verdict.ok) {
+        onScopeDropped?.(scopeDroppedError({ toNodeId, verdict }));
+        // Refuse WITHOUT touching origFetchApi — the unscoped prompt must never
+        // leave the tab. 400 mirrors a server-side rejection so app.queuePrompt
+        // handles it through its existing refused-prompt path.
+        return new Response(
+          JSON.stringify({
+            error: {
+              type: "partial_execution_scope_dropped",
+              message: "run-to-node scope was not applied; nothing was queued",
+            },
+          }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        );
+      }
+    }
+    const res = await origFetchApi(route, options);
+    if (isPromptPost && res) {
+      try {
+        const body = await res.clone().json();
+        if (res.status !== 200) {
+          if (body && (body.error || body.node_errors)) {
+            onRejection?.({
+              error: body.error ?? null,
+              node_errors: body.node_errors ?? null,
+            });
+          }
+        } else if (body && body.prompt_id != null) {
+          onPromptId?.(String(body.prompt_id));
+        }
+      } catch {
+        // non-JSON body / clone unsupported — the caller falls back to lastNodeErrors.
+      }
+    }
+    return res;
+  };
+}

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -19,29 +19,46 @@
 //     enforced at the one place every build must pass through: the POST /prompt
 //     request body.
 //
-// Two dispatch realities shape the design (codex gate on the first cut):
+// Three dispatch realities shape the design (codex gate, rounds 1–2):
 //
 //  - app.queuePrompt is NOT synchronous with the POST. When its processor is
 //    already busy it pushes the item and RETURNS EARLY — the prompt is
 //    serialized and posted LATER by the in-flight processor. A guard restored
-//    when queuePrompt returns never sees that deferred dispatch (P0). So the
-//    scoped guard stays installed until our dispatch is actually OBSERVED (a
-//    POST carrying exactly our targets has passed through) or a bounded
-//    timeout — and a run whose dispatch never surfaces reports a truthful
-//    "could not verify — nothing confirmed queued", never queued:true.
+//    when queuePrompt returns never sees that deferred dispatch. So the scoped
+//    guard stays installed until our dispatch is actually OBSERVED (a POST
+//    carrying exactly our targets, attributed to our prompt, has passed
+//    through) or a bounded timeout — and a run whose dispatch never surfaces
+//    reports a truthful "could not verify", never queued:true.
 //
-//  - While installed, the guard sees EVERY POST /prompt in the tab, including
-//    unrelated ones (a user queue, another processor's item). Refusing any
-//    body that merely lacks our targets would 400 a stranger's legitimate full
-//    run (P1). So the guard is SURGICAL: it only refuses a targetless body
-//    that matches THIS run's prompt signature (the sorted node-id|class_type
-//    set of the graphToPrompt output we queued — widget values excluded so
-//    beforeQueued seed randomization can't blur it), and only for as many
-//    posts as this batch still has unattributed. Everything else — unrelated
-//    full runs, other scoped runs, unparseable bodies — passes through
-//    untouched and is never captured as ours. Known limit: a concurrent full
-//    run of the byte-identical node set inside the window is indistinguishable
-//    from our own dropped dispatch and is treated as ours (bounded by batch).
+//  - While installed, the guard sees EVERY POST /prompt in the tab (a user
+//    queue, another processor's item). Attribution is by PROMPT SIGNATURE
+//    FIRST (the sorted node-id|class_type set of the graphToPrompt output we
+//    queued — widget values excluded so beforeQueued seed randomization can't
+//    blur it), targets second:
+//      · signature matches, targets exactly ours → OUR scoped dispatch:
+//        observed, passed through, response captured.
+//      · signature matches, targets MISSING/WRONG/EXTRA/PARTIAL → OUR dispatch
+//        CORRUPTED (the frontend dropped/mangled the scope argument): refused
+//        before it leaves, bounded by this batch's post count. A body with
+//        ["14","9"] is NOT "someone else's" — it's our scope with an unwanted
+//        branch attached, and letting it out would run that work.
+//      · signature does NOT match → FOREIGN: passed through untouched, never
+//        captured, never refused, and NEVER counts as our observation — even
+//        if it carries the same targets (a foreign same-targets post must not
+//        satisfy `observed` and let our own deferred corrupted post escape).
+//    Known limit: a concurrent full run of the byte-identical node set inside
+//    the window is indistinguishable from our own corrupted dispatch and is
+//    treated as ours (bounded by batch).
+//
+//  - On timeout the deferred queue item may STILL be live in the frontend's
+//    pending list; restoring the guard then would let a scope-dropped dispatch
+//    escape later. graph_run therefore tries to REMOVE the pending item
+//    (cancelPendingScopedQueueItem — the frontend keeps its queueItems array
+//    runtime-accessible on TS-`private` builds; older builds hard-privatize it
+//    as #queueItems, and a scope-dropped item may carry no attributable
+//    targets). When removal is impossible the guard stays installed as a
+//    sentinel — still surgical, still batch-bounded — until a much longer
+//    bound expires, so the corrupted dispatch is refused whenever it posts.
 //
 // Extracted as a pure module so the SAME guard graph_run installs is drivable
 // from `node --test` (the live app.queuePrompt path can't be).
@@ -76,7 +93,7 @@ export function promptSignature(output) {
   if (!keys.length) return null;
   return keys
     .sort()
-    .map((k) => `${k}${output[k]?.class_type ?? ""}`)
+    .map((k) => `${k}${output[k]?.class_type ?? ""}`)
     .join("|");
 }
 
@@ -91,7 +108,7 @@ export function promptSignatureFromBody(bodyText) {
   return promptSignature(body?.prompt);
 }
 
-/** The body body's partial_execution_targets as strings, or null when absent/empty/unparseable. */
+/** The body's partial_execution_targets as strings, or null when absent/empty/unparseable. */
 function targetsFromBody(bodyText) {
   let body;
   try {
@@ -150,18 +167,31 @@ export function scopeDroppedError({ toNodeId, verdict }) {
 /**
  * The truthful UNVERIFIED outcome when no scoped dispatch surfaced within the
  * observation window (a busy queuePrompt deferred the post past its return, or
- * the prompt build failed silently). Deliberately does NOT say "nothing was
- * queued" — a deferred post may still land later, unverifiably — only that
- * nothing is CONFIRMED queued, so the caller must check the ComfyUI queue
- * rather than assume a scoped run happened.
+ * the prompt build failed silently).
+ *  - cancelled:  the still-pending frontend queue item was located and REMOVED
+ *    — "nothing was queued" is then literally true.
+ *  - lingering:  removal was impossible, so the surgical guard stays installed
+ *    for lingerMs as a sentinel — a late scope-dropped dispatch is still
+ *    refused whenever it posts. Only "nothing CONFIRMED queued" is claimed.
  */
-export function scopeUnverifiedError({ toNodeId, timeoutMs }) {
-  return (
+export function scopeUnverifiedError({ toNodeId, timeoutMs, cancelled = false, lingerMs = 0 }) {
+  const base =
     `run-to-node scope for node ${toNodeId} could not be verified: no scoped ` +
     `dispatch was observed within ${Math.round(timeoutMs / 1000)}s of queueing ` +
-    `(the frontend deferred or silently dropped the request). Nothing is ` +
-    `CONFIRMED queued — check the ComfyUI queue, and retry the run; the panel ` +
-    `did not report this as a scoped execution (#556).`
+    `(the frontend deferred or silently dropped the request). `;
+  if (cancelled) {
+    return (
+      base +
+      `The still-pending queue item was located and REMOVED, so nothing was ` +
+      `queued and no scope-dropped full-graph dispatch can execute — retry the run (#556).`
+    );
+  }
+  return (
+    base +
+    `The pending queue item could not be removed on this frontend, so the scope ` +
+    `guard stays installed for up to ${Math.round(lingerMs / 60000)}min as a sentinel — ` +
+    `any late dispatch of this prompt WITHOUT the scope will still be refused. ` +
+    `Nothing is CONFIRMED queued — check the ComfyUI queue before retrying (#556).`
   );
 }
 
@@ -220,24 +250,18 @@ export function createRunFetchInterceptor({ origFetchApi, onRejection = null, on
 
 /**
  * The api.fetchApi replacement graph_run installs for a SCOPED run — see the
- * module header for the two dispatch realities this is shaped by.
+ * module header for the attribution rules this enforces. The guard stays
+ * installed until the caller restores it (on observation, on a successful
+ * pending-item cancellation, or via the long-bound sentinel timer); it does
+ * not restore itself. state = { observed, dropped } is live; waitForVerdict(ms)
+ * resolves true as soon as either is set, false on timeout.
  *
- * Attribution, per POST /prompt body:
- *  - carries exactly our targets       → OUR scoped dispatch: pass through,
- *    count it OBSERVED, capture its response (rejection / prompt_id).
- *  - carries someone else's targets    → unrelated scoped run: untouched,
- *    never captured.
- *  - carries NO targets, matches our prompt signature, and this batch still
- *    has unattributed posts           → OUR dispatch gone wrong (the frontend
- *    ignored the scope argument): REFUSE before origFetchApi runs — the
- *    unscoped prompt never leaves the tab — and record state.dropped so the
- *    caller can retry the other argument shape.
- *  - anything else (other signature, batch already accounted, unparseable)
- *                                      → unrelated: untouched, never captured.
- *
- * The guard stays installed until the caller has observed a verdict; it does
- * not restore itself. state = { observed, dropped } is live;
- * waitForVerdict(ms) resolves true as soon as either is set, false on timeout.
+ * @param {object}   args
+ * @param {Function} args.origFetchApi
+ * @param {string[]} args.execIds        This run's resolved partial-execution targets.
+ * @param {string|null} [args.signature] promptSignature of the graphToPrompt output we queued.
+ * @param {number} [args.batch]          Bound on how many corrupted posts are attributable to us.
+ * @param {*}        [args.toNodeId]
  */
 export function createScopedRunGuard({
   origFetchApi,
@@ -251,7 +275,7 @@ export function createScopedRunGuard({
 } = {}) {
   const expected = (execIds ?? []).map(String);
   const maxBatch = Math.max(1, Math.floor(Number(batch)) || 1);
-  let oursAccounted = 0; // verified + refused posts attributable to THIS batch
+  let refused = 0; // corrupted posts refused so far (batch-bounded)
   const state = { observed: 0, dropped: null };
   const waiters = new Set();
   const notify = () => {
@@ -261,31 +285,43 @@ export function createScopedRunGuard({
   const guard = async (route, options) => {
     if (!isPromptPost(route, options)) return origFetchApi(route, options);
     const targets = targetsFromBody(options?.body);
-    if (targets) {
-      if (!sameSet(targets, expected)) {
-        // A scoped run for SOMEONE ELSE — never touch it.
-        return origFetchApi(route, options);
-      }
-      oursAccounted++;
+    // SIGNATURE FIRST: only a body whose node set is exactly the prompt we
+    // queued can be this run — matched or corrupted. Everything else is
+    // foreign: passed through untouched, never captured, never observed,
+    // never refused (even a foreign post carrying the SAME targets).
+    // Degraded mode: with NO signature (graphToPrompt failed at queue time) we
+    // can only attribute a post carrying EXACTLY our targets — enough to still
+    // verify a delivered scope, never enough to refuse (never blocks strangers).
+    const attributable = signature
+      ? promptSignatureFromBody(options?.body) === signature
+      : targets != null && sameSet(targets, expected);
+    if (!attributable) return origFetchApi(route, options);
+    if (targets && sameSet(targets, expected)) {
+      // OUR scoped dispatch, verifiably delivered.
       state.observed++;
       const res = await origFetchApi(route, options);
       if (res) await captureRunResponse(res, { onRejection, onPromptId });
       notify();
       return res;
     }
-    // Targetless body. Ours-gone-wrong only while it matches our signature and
-    // we still have unattributed batch posts outstanding.
-    if (signature && promptSignatureFromBody(options?.body) === signature && oursAccounted < maxBatch) {
-      oursAccounted++;
+    // OUR dispatch CORRUPTED — scope missing, or wrong/extra/partial targets
+    // (["14","9"] would run an unwanted branch; "9" would run the wrong one).
+    // Only reachable with a signature; the batch bound caps the documented
+    // same-node-set ambiguity.
+    if (refused < maxBatch) {
+      refused++;
       state.dropped = scopeDroppedError({
         toNodeId,
-        verdict: { ok: false, reason: "scope_missing", expected, got: null },
+        verdict: targets
+          ? { ok: false, reason: "scope_mismatch", expected, got: targets }
+          : { ok: false, reason: "scope_missing", expected, got: null },
       });
       onScopeDropped?.(state.dropped);
       notify();
       return SCOPE_DROPPED_RESPONSE();
     }
-    // Unrelated full run (or unattributable) — untouched, never captured.
+    // Refusal budget for this batch is exhausted — beyond this point a
+    // same-signature body is not ours to judge (documented ambiguity bound).
     return origFetchApi(route, options);
   };
   guard.state = state;
@@ -304,4 +340,40 @@ export function createScopedRunGuard({
       waiters.add(fire);
     });
   return guard;
+}
+
+/**
+ * Best-effort removal of THIS run's still-pending item(s) from the frontend's
+ * in-memory queueItems (the not-yet-posted deferred dispatch — the server-side
+ * /queue never saw it, so server queue control can't help). The frontend keeps
+ * the array runtime-accessible as app.queueItems on TS-`private` builds; older
+ * builds hard-privatize it (#queueItems) and then this is impossible — the
+ * caller keeps the guard installed as a sentinel instead (module header).
+ *
+ * An item is only removed when its stored targets NORMALIZE to exactly this
+ * run's scope (either the raw array or the {queueNodeIds} options shape a
+ * positional build stored verbatim) — a user's pending full-run item carries
+ * no targets and is never touched, and a scope-dropped item whose build stored
+ * no attributable targets can't be identified (left for the sentinel).
+ *
+ * @returns {{accessible: boolean, removed: number}}
+ */
+export function cancelPendingScopedQueueItem(app, expectedExecIds) {
+  const items = app?.queueItems;
+  if (!Array.isArray(items)) return { accessible: false, removed: 0 };
+  const expected = (expectedExecIds ?? []).map(String);
+  let removed = 0;
+  for (let i = items.length - 1; i >= 0; i--) {
+    const raw = items[i]?.queueNodeIds;
+    const ids = Array.isArray(raw) && raw.length
+      ? raw.map(String)
+      : raw && Array.isArray(raw.queueNodeIds) && raw.queueNodeIds.length
+        ? raw.queueNodeIds.map(String)
+        : null;
+    if (ids && sameSet(ids, expected)) {
+      items.splice(i, 1);
+      removed++;
+    }
+  }
+  return { accessible: true, removed };
 }

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -34,10 +34,10 @@
 //    was never its own. A body WITHOUT this run's mark is FOREIGN: passed
 //    through untouched, never captured, never refused, never counted as our
 //    observation — even with an identical node set and identical targets. A
-//    body WITH this run's mark is this run: signature+targets exact ⇒
-//    observed; anything else (scope missing/wrong/extra, or a graph that
-//    changed under a deferred item) ⇒ OUR corrupted dispatch, refused before
-//    it leaves (batch-bounded).
+//    body WITH this run's mark is this run: content-hash + targets exact ⇒
+//    observed; anything else (scope missing/wrong/extra, or CONTENT DRIFT —
+//    the graph changed under a deferred item) ⇒ OUR corrupted dispatch,
+//    refused before it leaves (batch-bounded).
 //
 //  - QUEUE ITEM TAG: the targets array carries a non-enumerable per-run Symbol
 //    tag. Frontend builds store the array by reference in queueItems (either
@@ -63,12 +63,18 @@
 //    our dispatch is OBSERVED or a bounded timeout — and the timeout path
 //    decides cancel-vs-sentinel BEFORE the finally restores fetchApi.
 //
-//  - The prompt SIGNATURE (sorted node-id|class_type set of the graphToPrompt
-//    output, widget values excluded so beforeQueued seed randomization can't
-//    blur it) must be computable BEFORE dispatch. If it isn't, attribution is
-//    impossible, so the run FAILS CLOSED: it refuses upfront with a truthful
-//    error and never calls queuePrompt — "cannot safely dispatch", never
-//    "dispatch and hope".
+//  - The prompt CONTENT HASH (r7) must be computable BEFORE dispatch: a
+//    stable hash of the full queued prompt — node ids, class types, links,
+//    every input/widget value — excluding ONLY the inputs of widgets that
+//    self-mutate at queue time (beforeQueued seeds and the like), which
+//    change between any two serializations of the SAME graph by design. A
+//    topology-only fingerprint is insufficient: a busy queue defers
+//    serialization to post time, and a user edit in between (a changed
+//    widget value, a rewired link) leaves node ids/types untouched while
+//    rendering a DIFFERENT workflow — the guard refuses that drifted post
+//    and the run ends with a truthful "the graph changed" error. If the
+//    hash can't be computed at all (graphToPrompt failed), the run FAILS
+//    CLOSED: it refuses upfront and never calls queuePrompt.
 //
 // Extracted as a pure module so the SAME orchestration graph_run runs is
 // drivable from `node --test` (the live app.queuePrompt path can't be).
@@ -109,33 +115,86 @@ export function queuePromptScopeArgs(partialTargets) {
   return [partialTargets, { queueNodeIds: partialTargets }];
 }
 
+// Two-seed 32-bit FNV-1a, concatenated — change-detection hashing only (no
+// security requirement): stable across key order (canonicalized before
+// hashing) and cheap enough to run once at queue time + once per observed post.
+function fnv1a32(str, seed) {
+  let h = seed >>> 0;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h >>> 0;
+}
+const fnv1aHex = (s) =>
+  fnv1a32(s, 0x811c9dc5).toString(16).padStart(8, "0") +
+  fnv1a32(s, 0x9e3779b9).toString(16).padStart(8, "0");
+
 /**
- * The prompt signature used to attribute a POST /prompt body to THIS run: the
- * sorted node-id|class_type pairs of a graphToPrompt output (the API workflow).
- * Widget values are EXCLUDED — queuePrompt randomizes seeds via beforeQueued
- * between serialization calls, so a value-level fingerprint would miss our own
- * dispatch. Two runs of the same unedited graph share a signature; the queue
- * mark (module header) is what actually separates them.
+ * The CONTENT fingerprint attributing a POST /prompt body to THIS run (r7):
+ * a stable hash of the full queued prompt — node ids, class types, links, and
+ * every input/widget value — canonicalized (sorted keys) so serialization
+ * order can't blur it. A topology-only fingerprint (node-id|class_type) is
+ * NOT enough: a busy queue defers serialization to post time, and a user edit
+ * in between (a changed widget value, a rewired link) leaves the topology
+ * untouched while rendering a DIFFERENT workflow.
+ *
+ * The ONLY values excluded are the inputs of widgets that SELF-MUTATE at
+ * queue time (a `beforeQueued` hook — stock seed widgets with
+ * control_after_generate, etc.): those change between any two serializations
+ * of the SAME graph by design, so hashing them would refuse our own dispatch.
+ * collectSelfMutatingInputNames derives the exclusion set from the live
+ * graph; name-level exclusion (not per-node) trades a little precision for
+ * not having to map flattened colon-path prompt ids back to live nodes.
  */
-export function promptSignature(output) {
+export function promptContentHash(output, excludeInputNames = null) {
   if (!output || typeof output !== "object") return null;
-  const keys = Object.keys(output);
+  const keys = Object.keys(output).sort();
   if (!keys.length) return null;
-  return keys
-    .sort()
-    .map((k) => `${k}${output[k]?.class_type ?? ""}`)
-    .join("|");
+  const canon = keys.map((k) => {
+    const node = output[k] ?? {};
+    const inputs = node.inputs && typeof node.inputs === "object" ? node.inputs : {};
+    const names = Object.keys(inputs)
+      .filter((n) => !excludeInputNames?.has(n))
+      .sort();
+    return [k, node.class_type ?? null, names.map((n) => [n, inputs[n]])];
+  });
+  return fnv1aHex(JSON.stringify(canon));
 }
 
-/** Signature of a raw POST /prompt body, or null when unparseable/odd. */
-export function promptSignatureFromBody(bodyText) {
+/** Content hash of a raw POST /prompt body, or null when unparseable/odd. */
+export function promptContentHashFromBody(bodyText, excludeInputNames = null) {
   let body;
   try {
     body = JSON.parse(bodyText);
   } catch {
     return null;
   }
-  return promptSignature(body?.prompt);
+  return promptContentHash(body?.prompt, excludeInputNames);
+}
+
+/**
+ * Names of inputs whose owning widgets SELF-MUTATE at queue time (a
+ * `beforeQueued` hook), collected from the live root graph and every nested
+ * subgraph. These are the ONLY values the content hash excludes — everything
+ * a user can edit is covered.
+ */
+export function collectSelfMutatingInputNames(rootGraph) {
+  const names = new Set();
+  const seen = new Set();
+  const walk = (g) => {
+    if (!g || seen.has(g)) return;
+    seen.add(g);
+    for (const node of g._nodes ?? []) {
+      if (!node) continue;
+      for (const w of node.widgets ?? []) {
+        if (typeof w?.beforeQueued === "function" && w.name != null) names.add(String(w.name));
+      }
+      if (node.subgraph) walk(node.subgraph);
+    }
+  };
+  walk(rootGraph);
+  return names;
 }
 
 /** The body's queue-position `number` as a Number, or null when absent/unparseable. */
@@ -195,11 +254,14 @@ export function verifyScopedPromptBody(bodyText, expectedExecIds) {
  */
 export function scopeDroppedError({ toNodeId, verdict }) {
   const detail =
-    verdict?.reason === "scope_mismatch"
-      ? `the POST /prompt body carried partial_execution_targets ` +
-        `${JSON.stringify(verdict.got)} instead of ${JSON.stringify(verdict.expected)}`
-      : `the POST /prompt body carried no partial_execution_targets — this ` +
-        `frontend build ignored the run-to-node argument`;
+    verdict?.reason === "graph_changed"
+      ? `the workflow graph CHANGED after the run was queued — the deferred ` +
+        `dispatch would render a modified workflow, not the one that was scoped`
+      : verdict?.reason === "scope_mismatch"
+        ? `the POST /prompt body carried partial_execution_targets ` +
+          `${JSON.stringify(verdict.got)} instead of ${JSON.stringify(verdict.expected)}`
+        : `the POST /prompt body carried no partial_execution_targets — this ` +
+          `frontend build ignored the run-to-node argument`;
   return (
     `run-to-node scope for node ${toNodeId} was NOT applied: ${detail}. ` +
     `Nothing was queued — refusing to fall through to a full-graph execution (#556).`
@@ -268,12 +330,15 @@ export function scopeUnverifiedError({ toNodeId, timeoutMs, cancelled = false, v
  * refusal, so the attempt is terminal: `verified` prompts are queued (scoped),
  * one was refused, and the rest never posted. Never reported as dispatched.
  */
-export function scopePartialBatchError({ toNodeId, verified, refused, batch }) {
+export function scopePartialBatchError({ toNodeId, verified, refused, batch, graphChanged = false }) {
   const unposted = Math.max(0, batch - verified - refused);
+  const cause = graphChanged
+    ? `was refused after the graph changed mid-batch`
+    : `was refused after its scope was lost mid-batch`;
   return (
     `run-to-node scope for node ${toNodeId}: batch incomplete — ${verified} of ` +
     `${batch} prompts were verified and are queued WITH the scope, ${refused} ` +
-    `was refused after its scope was lost mid-batch (it did NOT execute, and no ` +
+    `${cause} (it did NOT execute, and no ` +
     `full-graph dispatch left the tab)` +
     (unposted ? `, and ${unposted} never posted` : "") +
     `. Re-run for the remaining prompts (#556).`
@@ -379,21 +444,28 @@ export function createRunFetchInterceptor({ origFetchApi, onRejection = null, on
 /**
  * The api.fetchApi replacement dispatchScopedRun installs for a SCOPED run —
  * see the module header for the run-identity model. Per POST /prompt body:
- *  - NO queue mark           → FOREIGN: passed through untouched, never
- *                              captured, never refused, never observed — even
- *                              with our node set and our targets.
- *  - mark + signature + exact targets → OUR scoped dispatch: passed through,
- *                              counted OBSERVED, response captured.
- *  - mark + anything else    → OUR corrupted dispatch (scope dropped/mangled,
- *                              or the graph changed under a deferred item):
- *                              refused before it leaves, batch-bounded.
- * state = { observed, dropped } is live; waitForVerdict(ms) resolves true as
- * soon as either is set, false on timeout.
+ *  - NO queue mark                → FOREIGN: passed through untouched, never
+ *                                   captured, never refused, never observed —
+ *                                   even with our node set and our targets.
+ *  - mark + content hash + exact targets → OUR scoped dispatch: passed
+ *                                   through, counted OBSERVED once its fetch
+ *                                   completes (r6), response captured.
+ *  - mark + anything else         → OUR corrupted dispatch: scope missing or
+ *                                   wrong/extra/partial targets, or the
+ *                                   CONTENT HASH mismatched (r7: the graph
+ *                                   changed under a deferred item — a user
+ *                                   edit, or the deferred serialization
+ *                                   picking up a modified graph): refused
+ *                                   before it leaves, batch-bounded.
+ * state = { observed, rejected, refused, dropped, droppedReason, failed } is
+ * live; waitForVerdict(ms) resolves true at any terminal state, false on
+ * timeout.
  */
 export function createScopedRunGuard({
   origFetchApi,
   execIds,
-  signature,
+  contentHash,
+  volatileNames = null,
   batch = 1,
   toNodeId = null,
   queueMark,
@@ -403,7 +475,7 @@ export function createScopedRunGuard({
 } = {}) {
   const expected = (execIds ?? []).map(String);
   const maxBatch = Math.max(1, Math.floor(Number(batch)) || 1);
-  const state = { observed: 0, rejected: 0, refused: 0, dropped: null, failed: null };
+  const state = { observed: 0, rejected: 0, refused: 0, dropped: null, droppedReason: null, failed: null };
   const waiters = new Set();
   const notify = () => {
     for (const fire of [...waiters]) fire();
@@ -418,8 +490,9 @@ export function createScopedRunGuard({
       return origFetchApi(route, options);
     }
     const targets = targetsFromBody(options?.body);
-    const sigOk = signature && promptSignatureFromBody(options?.body) === signature;
-    if (sigOk && targets && sameSet(targets, expected)) {
+    const contentOk =
+      contentHash && promptContentHashFromBody(options?.body, volatileNames) === contentHash;
+    if (contentOk && targets && sameSet(targets, expected)) {
       // OUR scoped dispatch. It counts as VERIFIED only when the fetch itself
       // completes with a real 200 + prompt_id (r6) — a thrown fetch or a
       // malformed response is a terminal dispatch FAILURE, never a success;
@@ -455,18 +528,19 @@ export function createScopedRunGuard({
       notify();
       return res;
     }
-    // OUR dispatch CORRUPTED — scope missing, wrong/extra/partial targets
-    // (["14","9"] would run an unwanted branch), or the graph changed while
-    // our item sat deferred (scope unverifiable against the new graph).
+    // OUR dispatch CORRUPTED. Content drift (r7) takes naming precedence: a
+    // changed graph would render the wrong workflow even with the scope
+    // intact. Then the scope itself: missing, or wrong/extra/partial targets.
     if (state.refused < maxBatch) {
       state.refused++;
       if (state.dropped == null) {
-        state.dropped = scopeDroppedError({
-          toNodeId,
-          verdict: targets
+        const verdict = !contentOk
+          ? { ok: false, reason: "graph_changed" }
+          : targets
             ? { ok: false, reason: "scope_mismatch", expected, got: targets }
-            : { ok: false, reason: "scope_missing", expected, got: null },
-        });
+            : { ok: false, reason: "scope_missing", expected, got: null };
+        state.droppedReason = verdict.reason;
+        state.dropped = scopeDroppedError({ toNodeId, verdict });
         onScopeDropped?.(state.dropped);
       }
       notify();
@@ -578,17 +652,22 @@ export async function dispatchScopedRun({
         `prompt. Nothing was queued rather than risk a full-graph execution (#556).`,
     };
   }
-  // The signature that (with the queue mark) attributes a POST /prompt body to
-  // THIS run. No signature ⇒ no attribution ⇒ fail closed BEFORE dispatch.
-  let signature = null;
+  // The CONTENT HASH that (with the queue mark) attributes a POST /prompt
+  // body to THIS run: the full prompt we are about to queue — ids, class
+  // types, links, widget values — minus only the self-mutating (beforeQueued)
+  // inputs that change between any two serializations by design. No hash ⇒
+  // no attribution ⇒ fail closed BEFORE dispatch.
+  let contentHash = null;
+  let volatileNames = null;
   try {
     if (typeof app.graphToPrompt === "function") {
-      signature = promptSignature((await app.graphToPrompt())?.output);
+      volatileNames = collectSelfMutatingInputNames(app?.rootGraph);
+      contentHash = promptContentHash((await app.graphToPrompt())?.output, volatileNames);
     }
   } catch {
-    signature = null;
+    contentHash = null;
   }
-  if (!signature) {
+  if (!contentHash) {
     return { outcome: "unverifiable", queueMark: mark, error: scopeUnattributableError({ toNodeId }) };
   }
   // Ownership tag for the timeout cancellation (see QUEUE_ITEM_TAG).
@@ -605,7 +684,8 @@ export async function dispatchScopedRun({
     const guard = createScopedRunGuard({
       origFetchApi,
       execIds,
-      signature,
+      contentHash,
+      volatileNames,
       batch,
       toNodeId,
       queueMark: mark,
@@ -686,6 +766,12 @@ export async function dispatchScopedRun({
     if (guard.state.observed >= batch) {
       return { outcome: "dispatched", queueMark: mark, verified: guard.state.observed };
     }
+    // r7 CONTENT DRIFT with ZERO verified posts is NOT an argument-shape
+    // problem — retrying the other shape would produce the same drifted post.
+    // Terminal refusal naming that the graph changed under the deferred item.
+    if (guard.state.observed === 0 && guard.state.droppedReason === "graph_changed") {
+      return { outcome: "refused", queueMark: mark, verified: 0, error: guard.state.dropped };
+    }
     // A corrupted post with ZERO verified posts means this argument SHAPE was
     // dropped by the frontend — nothing was queued, so retrying the other
     // shape can never double-queue.
@@ -694,9 +780,10 @@ export async function dispatchScopedRun({
       continue;
     }
     // r5 TERMINAL PARTIAL: the shape works (≥1 verified), then a later batch
-    // post lost its scope and was refused — the frontend's batch loop breaks
-    // on that refusal, so no more posts of this attempt will come. Report the
-    // truthful counts; never "dispatched"; no shape retry (the shape works).
+    // post lost its scope (or the graph drifted) and was refused — the
+    // frontend's batch loop breaks on that refusal, so no more posts of this
+    // attempt will come. Report the truthful counts; never "dispatched"; no
+    // shape retry (the shape works).
     return {
       outcome: "refused",
       queueMark: mark,
@@ -706,6 +793,7 @@ export async function dispatchScopedRun({
         verified: guard.state.observed,
         refused: guard.state.refused,
         batch,
+        graphChanged: guard.state.droppedReason === "graph_changed",
       }),
     };
   }

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -18,20 +18,23 @@
 //     enforced at the one place every build must pass through: the POST /prompt
 //     request body.
 //
-// RUN IDENTITY (codex gate r3). Content alone cannot always tell our dispatch
+// RUN IDENTITY (codex gate r3/r4). Content alone cannot always tell our dispatch
 // from a stranger's: an identical-node-set foreign post is indistinguishable
 // from ours, and a user's full run of the same graph looks exactly like our
-// scope-dropped dispatch. So this run MARKS its own work end to end:
+// scope-dropped dispatch. So each run MARKS its own work end to end:
 //
-//  - QUEUE POSITION MARK: graph_run queues with number = SCOPED_QUEUE_MARK.
-//    Every frontend build's api.queuePrompt copies a nonzero `number` into the
-//    POST body verbatim (`body.number = number` — present since at least the
-//    1.28-era frontend), and the server treats it as a priority that with
-//    2^30-1 always sorts to the END of the pending queue — the same append
-//    position today's number=0 produces. A body WITHOUT our mark is FOREIGN:
-//    passed through untouched, never captured, never refused, never counted
-//    as our observation — even with an identical node set and identical
-//    targets. A body WITH our mark is this run: signature+targets exact ⇒
+//  - QUEUE POSITION MARK: each scoped run queues with its OWN unique number
+//    (newScopedQueueMark). Every frontend build's api.queuePrompt copies a
+//    nonzero `number` into the POST body verbatim (`body.number = number` —
+//    present since at least the 1.28-era frontend), and the server treats it
+//    as a priority that near 2^30 always sorts to the END of the pending
+//    queue — the same append position today's number=0 produces. The mark is
+//    UNIQUE PER RUN (r4): a fixed mark would let one run's leftover guard
+//    attribute a LATER run's posts to itself — refusing/capturing traffic that
+//    was never its own. A body WITHOUT this run's mark is FOREIGN: passed
+//    through untouched, never captured, never refused, never counted as our
+//    observation — even with an identical node set and identical targets. A
+//    body WITH this run's mark is this run: signature+targets exact ⇒
 //    observed; anything else (scope missing/wrong/extra, or a graph that
 //    changed under a deferred item) ⇒ OUR corrupted dispatch, refused before
 //    it leaves (batch-bounded).
@@ -39,11 +42,19 @@
 //  - QUEUE ITEM TAG: the targets array carries a non-enumerable per-run Symbol
 //    tag. Frontend builds store the array by reference in queueItems (either
 //    directly or inside the options object), so on timeout the still-pending
-//    item can be found and REMOVED with exact ownership — an identical-scope
-//    item from another run is never touched. When the item can't be found
-//    (hard-private #queueItems builds, or a build that copied the array), the
-//    surgical guard stays installed as a long-bound sentinel instead, so the
-//    late corrupted dispatch is still refused whenever it posts.
+//    item can be found and REMOVED with exact ownership (tag AND this run's
+//    mark both checked) — an identical-scope item from another run is never
+//    touched. When the item can't be found (hard-private #queueItems builds,
+//    or a build that copied the array), the surgical guard stays installed
+//    for the PAGE LIFETIME as a sentinel — NO expiry timer (r4: an expiring
+//    sentinel re-opens the hole, because the uncancellable item can post its
+//    scope-dropped full graph whenever the stalled processor resumes). A
+//    permanent install is safe BY CONSTRUCTION: the guard only ever acts on
+//    its own run's unique mark, which no future run (or user, or UI) will
+//    ever carry, so foreign traffic passes through untouched forever. Multiple
+//    sentinels simply CHAIN through whatever wrap is current — each restores
+//    only inside its own synchronous dispatch, and an old sentinel has no
+//    cleanup that could clobber a newer run's guard.
 //
 // OTHER DISPATCH REALITIES (gate rounds 1–2):
 //
@@ -62,14 +73,22 @@
 // Extracted as a pure module so the SAME orchestration graph_run runs is
 // drivable from `node --test` (the live app.queuePrompt path can't be).
 
+let queueMarkCounter = 0;
+
 /**
- * The queue-position number every scoped panel_run dispatches with. Copied
+ * A UNIQUE queue-position number for one scoped run (module header). Copied
  * into the POST body as `number` by every frontend build's api.queuePrompt,
- * making OUR posts identifiable among every /prompt in the tab. 2^30-1 sorts
- * to the END of the server's priority queue (lower number = earlier), which
- * matches the append behavior of the historical number=0.
+ * making THIS run's posts identifiable among every /prompt in the tab. Near
+ * 2^30 so the server's priority queue (lower number = earlier) always sorts
+ * it to the END — the append behavior of the historical number=0 — and
+ * decremented per run so no two runs in the page session share a mark (a
+ * leftover sentinel can then never attribute a later run's traffic). Safe
+ * integer, nonzero, copied verbatim by the frontend.
  */
-export const SCOPED_QUEUE_MARK = 2 ** 30 - 1;
+export function newScopedQueueMark() {
+  queueMarkCounter++;
+  return 2 ** 30 - 1 - queueMarkCounter;
+}
 
 /** Property key for the per-run ownership tag on the targets array (non-enumerable). */
 export const QUEUE_ITEM_TAG = Symbol("cmcp-scoped-run-tag");
@@ -208,11 +227,12 @@ export function scopeUnattributableError({ toNodeId }) {
  * the prompt build failed silently).
  *  - cancelled:  the still-pending frontend queue item was located by its
  *    ownership tag and REMOVED — "nothing was queued" is then literally true.
- *  - lingering:  removal was impossible, so the surgical guard stays installed
- *    for lingerMs as a sentinel — a late scope-dropped dispatch is still
+ *  - sentinel:   removal was impossible, so the surgical guard stays installed
+ *    for the REST OF THE PAGE SESSION (no expiry — an expiring sentinel would
+ *    re-open the hole) — a late scope-dropped dispatch of THIS run is still
  *    refused whenever it posts. Only "nothing CONFIRMED queued" is claimed.
  */
-export function scopeUnverifiedError({ toNodeId, timeoutMs, cancelled = false, lingerMs = 0 }) {
+export function scopeUnverifiedError({ toNodeId, timeoutMs, cancelled = false }) {
   const base =
     `run-to-node scope for node ${toNodeId} could not be verified: no scoped ` +
     `dispatch was observed within ${Math.round(timeoutMs / 1000)}s of queueing ` +
@@ -227,8 +247,9 @@ export function scopeUnverifiedError({ toNodeId, timeoutMs, cancelled = false, l
   return (
     base +
     `The pending queue item could not be removed on this frontend, so the scope ` +
-    `guard stays installed for up to ${Math.round(lingerMs / 60000)}min as a sentinel — ` +
-    `any late dispatch of this run WITHOUT the scope will still be refused. ` +
+    `guard stays installed for the rest of this page session as a sentinel — ` +
+    `any late dispatch of THIS run WITHOUT the scope will still be refused (it ` +
+    `cannot touch any other run's traffic). ` +
     `Nothing is CONFIRMED queued — check the ComfyUI queue before retrying (#556).`
   );
 }
@@ -306,7 +327,7 @@ export function createScopedRunGuard({
   signature,
   batch = 1,
   toNodeId = null,
-  queueMark = SCOPED_QUEUE_MARK,
+  queueMark,
   onRejection = null,
   onPromptId = null,
   onScopeDropped = null,
@@ -379,25 +400,26 @@ export function createScopedRunGuard({
 /**
  * Best-effort removal of THIS run's still-pending item(s) from the frontend's
  * in-memory queueItems (the not-yet-posted deferred dispatch — the server-side
- * /queue never saw it, so server queue control can't help). Ownership is by
- * the non-enumerable QUEUE_ITEM_TAG dispatchScopedRun stamped on the targets
- * array (frontend builds store the array by reference, either directly or
- * inside the options object), so an identical-scope item from ANOTHER run is
- * never removed. The array is runtime-accessible as app.queueItems on
- * TS-`private` builds; older builds hard-privatize it (#queueItems), and a
- * build that COPIED the array loses the tag — then this reports 0 removed and
- * the caller keeps the guard installed as a sentinel instead (module header).
+ * /queue never saw it, so server queue control can't help). Ownership requires
+ * BOTH: the non-enumerable QUEUE_ITEM_TAG dispatchScopedRun stamped on the
+ * targets array (frontend builds store the array by reference, either directly
+ * or inside the options object) AND the item's queue-position number equal to
+ * THIS run's unique mark — an identical-scope item from ANOTHER run is never
+ * removed. The array is runtime-accessible as app.queueItems on TS-`private`
+ * builds; older builds hard-privatize it (#queueItems), and a build that
+ * COPIED the array loses the tag — then this reports 0 removed and the caller
+ * keeps the guard installed as a sentinel instead (module header).
  *
  * @returns {{accessible: boolean, removed: number}}
  */
-export function cancelPendingScopedQueueItem(app, runTag) {
+export function cancelPendingScopedQueueItem(app, { runTag, queueMark } = {}) {
   const items = app?.queueItems;
   if (!Array.isArray(items)) return { accessible: false, removed: 0 };
   let removed = 0;
   for (let i = items.length - 1; i >= 0; i--) {
     const raw = items[i]?.queueNodeIds;
     const arr = Array.isArray(raw) ? raw : raw && Array.isArray(raw.queueNodeIds) ? raw.queueNodeIds : null;
-    if (arr && arr[QUEUE_ITEM_TAG] === runTag) {
+    if (arr && arr[QUEUE_ITEM_TAG] === runTag && Number(items[i]?.number) === queueMark) {
       items.splice(i, 1);
       removed++;
     }
@@ -410,17 +432,18 @@ export function cancelPendingScopedQueueItem(app, runTag) {
  * REAL control flow (guard install, queuePrompt, observation wait, cancel/
  * sentinel decision, and the finally-restore) is what the unit tests drive.
  *
- * Returns a discriminated result (never throws for queue outcomes):
- *  - { outcome: "dispatched" }              our scoped dispatch was OBSERVED
+ * Returns a discriminated result (never throws for queue outcomes), always
+ * carrying the run's unique `queueMark`:
+ *  - { outcome: "dispatched",   queueMark }  our scoped dispatch was OBSERVED
  *    (prompt_ids / a server rejection captured via the callbacks);
- *  - { outcome: "refused",   error }        every argument shape produced OUR
- *    corrupted dispatch, all blocked — nothing was queued;
- *  - { outcome: "unverified", error }       no scoped dispatch surfaced in
- *    time; our pending item was cancelled, or a sentinel guard remains for
- *    lingerMs (the error says which);
- *  - { outcome: "unverifiable", error }     no attribution possible (no
- *    fetchApi to observe through, or no prompt signature) — refused BEFORE
- *    dispatch, nothing queued.
+ *  - { outcome: "refused",      queueMark, error }  every argument shape
+ *    produced OUR corrupted dispatch, all blocked — nothing was queued;
+ *  - { outcome: "unverified",   queueMark, error }  no scoped dispatch
+ *    surfaced in time; our pending item was cancelled, or a sentinel guard
+ *    remains installed for the page session (the error says which);
+ *  - { outcome: "unverifiable", queueMark?, error }  no attribution possible
+ *    (no fetchApi to observe through, or no prompt signature) — refused
+ *    BEFORE dispatch, nothing queued.
  */
 export async function dispatchScopedRun({
   app,
@@ -429,15 +452,17 @@ export async function dispatchScopedRun({
   batch = 1,
   toNodeId = null,
   verifyTimeoutMs = 5000,
-  lingerMs = 10 * 60 * 1000,
+  queueMark = null,
   onRejection = null,
   onPromptId = null,
 } = {}) {
+  const mark = queueMark ?? newScopedQueueMark();
   const prevFetchApi = typeof apiTarget?.fetchApi === "function" ? apiTarget.fetchApi : null;
   const origFetchApi = prevFetchApi ? prevFetchApi.bind(apiTarget) : null;
   if (!origFetchApi) {
     return {
       outcome: "unverifiable",
+      queueMark: mark,
       error:
         `run-to-node scope for node ${toNodeId} cannot be verified — api.fetchApi is ` +
         `unavailable on this frontend, so there is no way to confirm the scope reaches the ` +
@@ -455,7 +480,7 @@ export async function dispatchScopedRun({
     signature = null;
   }
   if (!signature) {
-    return { outcome: "unverifiable", error: scopeUnattributableError({ toNodeId }) };
+    return { outcome: "unverifiable", queueMark: mark, error: scopeUnattributableError({ toNodeId }) };
   }
   // Ownership tag for the timeout cancellation (see QUEUE_ITEM_TAG).
   const runTag = Symbol("cmcp-scoped-run");
@@ -474,13 +499,13 @@ export async function dispatchScopedRun({
       signature,
       batch,
       toNodeId,
-      queueMark: SCOPED_QUEUE_MARK,
+      queueMark: mark,
       onRejection,
       onPromptId,
     });
     apiTarget.fetchApi = guard;
     try {
-      await app.queuePrompt(SCOPED_QUEUE_MARK, batch, scopeArg);
+      await app.queuePrompt(mark, batch, scopeArg);
       if (!(guard.state.observed > 0 || guard.state.dropped)) {
         // queuePrompt returned without our dispatch surfacing — the
         // frontend's processor was busy and will serialize/post the item
@@ -491,38 +516,36 @@ export async function dispatchScopedRun({
       if (!(guard.state.observed > 0 || guard.state.dropped)) {
         // GIVE-UP — decided HERE, inside the try, so the finally below honors
         // keepGuardInstalled. The deferred item may still be live in the
-        // frontend's pending queue: try to REMOVE it (ownership-tagged), and
-        // only when that's impossible keep the surgical guard installed as a
-        // sentinel so the late scope-dropped dispatch is still refused.
-        const cancel = cancelPendingScopedQueueItem(app, runTag);
+        // frontend's pending queue: try to REMOVE it (ownership tag AND this
+        // run's mark both checked), and only when that's impossible keep the
+        // surgical guard installed for the PAGE SESSION as a sentinel — NO
+        // expiry timer (r4): the uncancellable item can post whenever the
+        // stalled processor resumes, so the refusal must not go away. Safe by
+        // construction: the sentinel only ever acts on THIS run's unique mark.
+        const cancel = cancelPendingScopedQueueItem(app, { runTag, queueMark: mark });
         if (cancel.removed > 0) {
           return {
             outcome: "unverified",
+            queueMark: mark,
             error: scopeUnverifiedError({ toNodeId, timeoutMs: verifyTimeoutMs, cancelled: true }),
           };
         }
         keepGuardInstalled = true;
-        const timer = setTimeout(() => {
-          // Self-remove only if nothing newer has wrapped over the sentinel —
-          // a guard left underneath a newer wrap is inert (mark-scoped +
-          // batch-bounded) and simply remains in the chain.
-          if (apiTarget.fetchApi === guard) apiTarget.fetchApi = prevFetchApi;
-        }, lingerMs);
-        if (typeof timer.unref === "function") timer.unref();
         return {
           outcome: "unverified",
-          error: scopeUnverifiedError({ toNodeId, timeoutMs: verifyTimeoutMs, cancelled: false, lingerMs }),
+          queueMark: mark,
+          error: scopeUnverifiedError({ toNodeId, timeoutMs: verifyTimeoutMs, cancelled: false }),
         };
       }
     } finally {
       if (!keepGuardInstalled) apiTarget.fetchApi = prevFetchApi;
     }
     // Verifiably dispatched with our scope.
-    if (guard.state.observed > 0) return { outcome: "dispatched" };
+    if (guard.state.observed > 0) return { outcome: "dispatched", queueMark: mark };
     // OUR dispatch surfaced WITHOUT the scope and was refused before it left
     // the tab — nothing was queued, so retrying the other arg shape can never
     // double-queue.
     dropped = guard.state.dropped;
   }
-  return { outcome: "refused", error: dropped };
+  return { outcome: "refused", queueMark: mark, error: dropped };
 }

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -231,17 +231,24 @@ export function scopeUnattributableError({ toNodeId }) {
  *    for the REST OF THE PAGE SESSION (no expiry — an expiring sentinel would
  *    re-open the hole) — a late scope-dropped dispatch of THIS run is still
  *    refused whenever it posts. Only "nothing CONFIRMED queued" is claimed.
+ *  - verified/batch (r5): a partially-verified batch names its count — the
+ *    verified prompts DID queue (scoped); only the unverified remainder is
+ *    in doubt.
  */
-export function scopeUnverifiedError({ toNodeId, timeoutMs, cancelled = false }) {
+export function scopeUnverifiedError({ toNodeId, timeoutMs, cancelled = false, verified = 0, batch = 1 }) {
+  const count =
+    verified > 0
+      ? ` (${verified} of ${batch} batch prompts WERE verified and are queued with the scope)`
+      : "";
   const base =
     `run-to-node scope for node ${toNodeId} could not be verified: no scoped ` +
     `dispatch was observed within ${Math.round(timeoutMs / 1000)}s of queueing ` +
-    `(the frontend deferred or silently dropped the request). `;
+    `(the frontend deferred or silently dropped the request)${count}. `;
   if (cancelled) {
     return (
       base +
-      `The still-pending queue item was located and REMOVED, so nothing was ` +
-      `queued and no scope-dropped full-graph dispatch can execute — retry the run (#556).`
+      `The still-pending queue item was located and REMOVED, so nothing ` +
+      `${verified > 0 ? "more " : ""}was queued and no scope-dropped full-graph dispatch can execute — retry the run (#556).`
     );
   }
   return (
@@ -250,7 +257,26 @@ export function scopeUnverifiedError({ toNodeId, timeoutMs, cancelled = false })
     `guard stays installed for the rest of this page session as a sentinel — ` +
     `any late dispatch of THIS run WITHOUT the scope will still be refused (it ` +
     `cannot touch any other run's traffic). ` +
-    `Nothing is CONFIRMED queued — check the ComfyUI queue before retrying (#556).`
+    `Nothing is CONFIRMED queued beyond the verified count — check the ComfyUI queue before retrying (#556).`
+  );
+}
+
+/**
+ * The truthful PARTIAL-BATCH outcome (r5): the argument shape demonstrably
+ * works (at least one post verified), then a LATER post in the same batch lost
+ * its scope and was refused — the frontend's batch loop breaks on that first
+ * refusal, so the attempt is terminal: `verified` prompts are queued (scoped),
+ * one was refused, and the rest never posted. Never reported as dispatched.
+ */
+export function scopePartialBatchError({ toNodeId, verified, refused, batch }) {
+  const unposted = Math.max(0, batch - verified - refused);
+  return (
+    `run-to-node scope for node ${toNodeId}: batch incomplete — ${verified} of ` +
+    `${batch} prompts were verified and are queued WITH the scope, ${refused} ` +
+    `was refused after its scope was lost mid-batch (it did NOT execute, and no ` +
+    `full-graph dispatch left the tab)` +
+    (unposted ? `, and ${unposted} never posted` : "") +
+    `. Re-run for the remaining prompts (#556).`
   );
 }
 
@@ -334,8 +360,7 @@ export function createScopedRunGuard({
 } = {}) {
   const expected = (execIds ?? []).map(String);
   const maxBatch = Math.max(1, Math.floor(Number(batch)) || 1);
-  let refused = 0; // corrupted posts refused so far (batch-bounded)
-  const state = { observed: 0, dropped: null };
+  const state = { observed: 0, refused: 0, dropped: null };
   const waiters = new Set();
   const notify = () => {
     for (const fire of [...waiters]) fire();
@@ -352,7 +377,9 @@ export function createScopedRunGuard({
     const targets = targetsFromBody(options?.body);
     const sigOk = signature && promptSignatureFromBody(options?.body) === signature;
     if (sigOk && targets && sameSet(targets, expected)) {
-      // OUR scoped dispatch, verifiably delivered.
+      // OUR scoped dispatch, verifiably delivered. The run is only
+      // "dispatched" when ALL `batch` posts verify — a batch is never
+      // declared complete on a partial count (r5).
       state.observed++;
       const res = await origFetchApi(route, options);
       if (res) await captureRunResponse(res, { onRejection, onPromptId });
@@ -362,15 +389,17 @@ export function createScopedRunGuard({
     // OUR dispatch CORRUPTED — scope missing, wrong/extra/partial targets
     // (["14","9"] would run an unwanted branch), or the graph changed while
     // our item sat deferred (scope unverifiable against the new graph).
-    if (refused < maxBatch) {
-      refused++;
-      state.dropped = scopeDroppedError({
-        toNodeId,
-        verdict: targets
-          ? { ok: false, reason: "scope_mismatch", expected, got: targets }
-          : { ok: false, reason: "scope_missing", expected, got: null },
-      });
-      onScopeDropped?.(state.dropped);
+    if (state.refused < maxBatch) {
+      state.refused++;
+      if (state.dropped == null) {
+        state.dropped = scopeDroppedError({
+          toNodeId,
+          verdict: targets
+            ? { ok: false, reason: "scope_mismatch", expected, got: targets }
+            : { ok: false, reason: "scope_missing", expected, got: null },
+        });
+        onScopeDropped?.(state.dropped);
+      }
       notify();
       return SCOPE_DROPPED_RESPONSE();
     }
@@ -379,9 +408,15 @@ export function createScopedRunGuard({
     return origFetchApi(route, options);
   };
   guard.state = state;
+  // Verdict = the FULL batch verified, or ANY corrupted post (which ends the
+  // attempt: the frontend's batch loop breaks on the first refusal — the
+  // caller distinguishes shape-drop (0 verified ⇒ retry shape) from mid-batch
+  // corruption (some verified ⇒ terminal partial, r5)).
+  const verdictReached = () => state.observed >= maxBatch || state.dropped != null;
+  guard.verdictReached = verdictReached;
   guard.waitForVerdict = (ms) =>
     new Promise((resolve) => {
-      if (state.observed > 0 || state.dropped) return resolve(true);
+      if (verdictReached()) return resolve(true);
       const fire = () => {
         clearTimeout(timer);
         waiters.delete(fire);
@@ -506,14 +541,14 @@ export async function dispatchScopedRun({
     apiTarget.fetchApi = guard;
     try {
       await app.queuePrompt(mark, batch, scopeArg);
-      if (!(guard.state.observed > 0 || guard.state.dropped)) {
+      if (!guard.verdictReached()) {
         // queuePrompt returned without our dispatch surfacing — the
         // frontend's processor was busy and will serialize/post the item
-        // LATER. Keep the guard installed and wait for our scoped dispatch
-        // to be OBSERVED, or the bounded timeout.
+        // LATER. Keep the guard installed and wait for the WHOLE batch to be
+        // accounted (r5: never dispatched on a partial count), or the timeout.
         await guard.waitForVerdict(verifyTimeoutMs);
       }
-      if (!(guard.state.observed > 0 || guard.state.dropped)) {
+      if (!guard.verdictReached()) {
         // GIVE-UP — decided HERE, inside the try, so the finally below honors
         // keepGuardInstalled. The deferred item may still be live in the
         // frontend's pending queue: try to REMOVE it (ownership tag AND this
@@ -522,30 +557,53 @@ export async function dispatchScopedRun({
         // expiry timer (r4): the uncancellable item can post whenever the
         // stalled processor resumes, so the refusal must not go away. Safe by
         // construction: the sentinel only ever acts on THIS run's unique mark.
+        const verified = guard.state.observed;
         const cancel = cancelPendingScopedQueueItem(app, { runTag, queueMark: mark });
         if (cancel.removed > 0) {
           return {
             outcome: "unverified",
             queueMark: mark,
-            error: scopeUnverifiedError({ toNodeId, timeoutMs: verifyTimeoutMs, cancelled: true }),
+            verified,
+            error: scopeUnverifiedError({ toNodeId, timeoutMs: verifyTimeoutMs, cancelled: true, verified, batch }),
           };
         }
         keepGuardInstalled = true;
         return {
           outcome: "unverified",
           queueMark: mark,
-          error: scopeUnverifiedError({ toNodeId, timeoutMs: verifyTimeoutMs, cancelled: false }),
+          verified,
+          error: scopeUnverifiedError({ toNodeId, timeoutMs: verifyTimeoutMs, cancelled: false, verified, batch }),
         };
       }
     } finally {
       if (!keepGuardInstalled) apiTarget.fetchApi = prevFetchApi;
     }
-    // Verifiably dispatched with our scope.
-    if (guard.state.observed > 0) return { outcome: "dispatched", queueMark: mark };
-    // OUR dispatch surfaced WITHOUT the scope and was refused before it left
-    // the tab — nothing was queued, so retrying the other arg shape can never
-    // double-queue.
-    dropped = guard.state.dropped;
+    // The FULL batch verified — genuinely dispatched (r5: never on a partial).
+    if (guard.state.observed >= batch) {
+      return { outcome: "dispatched", queueMark: mark, verified: guard.state.observed };
+    }
+    // A corrupted post with ZERO verified posts means this argument SHAPE was
+    // dropped by the frontend — nothing was queued, so retrying the other
+    // shape can never double-queue.
+    if (guard.state.observed === 0) {
+      dropped = guard.state.dropped;
+      continue;
+    }
+    // r5 TERMINAL PARTIAL: the shape works (≥1 verified), then a later batch
+    // post lost its scope and was refused — the frontend's batch loop breaks
+    // on that refusal, so no more posts of this attempt will come. Report the
+    // truthful counts; never "dispatched"; no shape retry (the shape works).
+    return {
+      outcome: "refused",
+      queueMark: mark,
+      verified: guard.state.observed,
+      error: scopePartialBatchError({
+        toNodeId,
+        verified: guard.state.observed,
+        refused: guard.state.refused,
+        batch,
+      }),
+    };
   }
-  return { outcome: "refused", queueMark: mark, error: dropped };
+  return { outcome: "refused", queueMark: mark, verified: 0, error: dropped };
 }

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -139,15 +139,16 @@ const fnv1aHex = (s) =>
  * in between (a changed widget value, a rewired link) leaves the topology
  * untouched while rendering a DIFFERENT workflow.
  *
- * The ONLY values excluded are the inputs of widgets that SELF-MUTATE at
+ * The ONLY values excluded are inputs whose OWNING widget self-mutates at
  * queue time (a `beforeQueued` hook — stock seed widgets with
  * control_after_generate, etc.): those change between any two serializations
  * of the SAME graph by design, so hashing them would refuse our own dispatch.
- * collectSelfMutatingInputNames derives the exclusion set from the live
- * graph; name-level exclusion (not per-node) trades a little precision for
- * not having to map flattened colon-path prompt ids back to live nodes.
+ * Exclusions are PER-NODE pairs (prompt node id + input name, r8): an edit to
+ * a NON-hook node's same-named input is still detected as drift, and a prompt
+ * node that can't be resolved to a live node carrying the hook gets NO
+ * exclusions (fail toward detecting drift).
  */
-export function promptContentHash(output, excludeInputNames = null) {
+export function promptContentHash(output, volatileInputs = null) {
   if (!output || typeof output !== "object") return null;
   const keys = Object.keys(output).sort();
   if (!keys.length) return null;
@@ -155,7 +156,7 @@ export function promptContentHash(output, excludeInputNames = null) {
     const node = output[k] ?? {};
     const inputs = node.inputs && typeof node.inputs === "object" ? node.inputs : {};
     const names = Object.keys(inputs)
-      .filter((n) => !excludeInputNames?.has(n))
+      .filter((n) => !volatileInputs?.has(`${k} ${n}`))
       .sort();
     return [k, node.class_type ?? null, names.map((n) => [n, inputs[n]])];
   });
@@ -163,38 +164,44 @@ export function promptContentHash(output, excludeInputNames = null) {
 }
 
 /** Content hash of a raw POST /prompt body, or null when unparseable/odd. */
-export function promptContentHashFromBody(bodyText, excludeInputNames = null) {
+export function promptContentHashFromBody(bodyText, volatileInputs = null) {
   let body;
   try {
     body = JSON.parse(bodyText);
   } catch {
     return null;
   }
-  return promptContentHash(body?.prompt, excludeInputNames);
+  return promptContentHash(body?.prompt, volatileInputs);
 }
 
 /**
- * Names of inputs whose owning widgets SELF-MUTATE at queue time (a
- * `beforeQueued` hook), collected from the live root graph and every nested
- * subgraph. These are the ONLY values the content hash excludes — everything
- * a user can edit is covered.
+ * The "execId inputName" pairs whose owning widgets SELF-MUTATE at queue time
+ * (a `beforeQueued` hook), collected from the live root graph and every nested
+ * subgraph. execId is the flattened prompt id: String(node.id) at root, the
+ * colon-joined subgraph-instance path for nested nodes ("10:15:359") — the
+ * same path buildNodeExecutionId produces, so pairs line up with the keys of
+ * the API prompt. These are the ONLY values the content hash excludes —
+ * everything a user can edit, on any other node, is covered.
  */
-export function collectSelfMutatingInputNames(rootGraph) {
-  const names = new Set();
+export function collectVolatileInputs(rootGraph) {
+  const pairs = new Set();
   const seen = new Set();
-  const walk = (g) => {
-    if (!g || seen.has(g)) return;
-    seen.add(g);
-    for (const node of g._nodes ?? []) {
-      if (!node) continue;
+  const walk = (graph, prefix) => {
+    if (!graph || seen.has(graph)) return;
+    seen.add(graph);
+    for (const node of graph._nodes ?? []) {
+      if (!node || node.id == null) continue;
+      const execId = prefix ? `${prefix}:${node.id}` : String(node.id);
       for (const w of node.widgets ?? []) {
-        if (typeof w?.beforeQueued === "function" && w.name != null) names.add(String(w.name));
+        if (typeof w?.beforeQueued === "function" && w.name != null) {
+          pairs.add(`${execId} ${String(w.name)}`);
+        }
       }
-      if (node.subgraph) walk(node.subgraph);
+      if (node.subgraph) walk(node.subgraph, execId);
     }
   };
-  walk(rootGraph);
-  return names;
+  walk(rootGraph, "");
+  return pairs;
 }
 
 /** The body's queue-position `number` as a Number, or null when absent/unparseable. */
@@ -465,7 +472,7 @@ export function createScopedRunGuard({
   origFetchApi,
   execIds,
   contentHash,
-  volatileNames = null,
+  volatileInputs = null,
   batch = 1,
   toNodeId = null,
   queueMark,
@@ -491,7 +498,7 @@ export function createScopedRunGuard({
     }
     const targets = targetsFromBody(options?.body);
     const contentOk =
-      contentHash && promptContentHashFromBody(options?.body, volatileNames) === contentHash;
+      contentHash && promptContentHashFromBody(options?.body, volatileInputs) === contentHash;
     if (contentOk && targets && sameSet(targets, expected)) {
       // OUR scoped dispatch. It counts as VERIFIED only when the fetch itself
       // completes with a real 200 + prompt_id (r6) — a thrown fetch or a
@@ -658,11 +665,13 @@ export async function dispatchScopedRun({
   // inputs that change between any two serializations by design. No hash ⇒
   // no attribution ⇒ fail closed BEFORE dispatch.
   let contentHash = null;
-  let volatileNames = null;
+  let volatileInputs = null;
   try {
     if (typeof app.graphToPrompt === "function") {
-      volatileNames = collectSelfMutatingInputNames(app?.rootGraph);
-      contentHash = promptContentHash((await app.graphToPrompt())?.output, volatileNames);
+      // This panel's live root is app.graph (r8) — app.rootGraph only as a
+      // fallback for frontends that expose it instead.
+      volatileInputs = collectVolatileInputs(app?.graph ?? app?.rootGraph ?? null);
+      contentHash = promptContentHash((await app.graphToPrompt())?.output, volatileInputs);
     }
   } catch {
     contentHash = null;
@@ -685,7 +694,7 @@ export async function dispatchScopedRun({
       origFetchApi,
       execIds,
       contentHash,
-      volatileNames,
+      volatileInputs,
       batch,
       toNodeId,
       queueMark: mark,


### PR DESCRIPTION
Fixes #556.

## Root cause

`panel_run` with `to_node_id` scopes execution via ComfyUI partial execution: the resolved target must reach the `POST /prompt` body as `partial_execution_targets`. The panel passed it as a **bare array** in the 3rd `app.queuePrompt` argument — but that argument's shape differs across frontend builds:

- positional `NodeExecutionId[]` (e.g. frontend ≤1.46, the 1.48.x line)
- `QueuePromptOptions { queueNodeIds }` (1.47.x, current main — these carry an `Array.isArray` compat shim)

A build that accepts only ONE shape **silently ignores the other**: the scope never reaches the request, the FULL graph queues, and `panel_run` still returns `queued:true, ran_to_node:X` — in #556 an unrelated SaveImage branch rendered and wrote a file nobody asked for. (The issue's local patch, passing only `{queueNodeIds}`, fixes the shim-less builds but would break the positional-only ones — neither single shape is universally safe.)

Note: the resolution half (stale/unknown/non-output/`unreachable` `to_node_id`) was already strict on main — `resolveRunToNodeTarget` refuses with `queued:false` before dispatch (#411/#438/#439). The silent fall-through lived at **dispatch**.

## Fix

- **`web/js/lib/run-scope-guard.js` (new)** — `createRunFetchInterceptor`, the `api.fetchApi` wrap `graph_run` already installs for #358/#370 response capture, now also inspects every outgoing `POST /prompt` body **before** it leaves: when a scope was requested and the body doesn't carry exactly that scope, the call is refused **without touching the real fetchApi** — no unscoped prompt is ever dispatched. `graph_run` then retries the other argument shape once (a blocked attempt queued nothing, so a retry can't double-queue) and, if no shape delivers, returns `queued:false` with a truthful error naming the node and stating nothing was queued. A scoped run with no `fetchApi` to verify against is refused up front. Unscoped (full) runs are byte-identical to before; the #358 first-rejection and #370 prompt_id capture move into the interceptor unchanged.
- **`web/js/comfyui-mcp-panel.js`** — `graph_run` drives the shape-retry loop (`queuePromptScopeArgs`) and returns the truthful refusal.

## Tests

19 new unit tests in `browser_tests/unit/run-scope-guard.test.mjs`:
- dropped-scope `POST /prompt` is refused and the real fetch is **never called** (the #556 regression);
- body verification: missing / empty / wrong / extra targets and unparseable bodies all refuse (never fail open);
- both frontend build shapes end-to-end: options-only build runs scoped on the retry, positional-only on the first attempt, neither-shape build ⇒ truthful refusal with zero dispatches;
- stale `to_node_id` (graph changed after id capture) resolves `not_found` ⇒ refused before any dispatch;
- normal full run and server-rejection (#358) paths preserved.

`npm run test:unit`: **1583/1583 pass**. `tsc --noEmit` clean. Playwright e2e not run (live rig occupied).

## Overlap note

The binding/desync-guard cluster (#545/#557) is being worked concurrently on `fix/graph-binding-cluster`; this PR touches only the run-scope path and does not modify the binding guard. One shared surface: `graph_run` still calls `assertGraphBoundToActiveWorkflow` before scope resolution — unchanged. Residual limitation worth knowing: if `app.queuePrompt` defers processing (queue already busy), the deferred `POST /prompt` can happen after the interceptor is restored; the scope argument is still delivered correctly by argument normalization, but that one asynchronous path can't be body-verified. Closing it would require patching `queuePrompt` itself — out of scope here.