### PR TITLE
release: 0.11.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.36] - 2026-08-03
+
+### Fixed
+- panel_run scoped dispatch guard: per-run queue marks, content-hash drift detection, refusal before any scope-dropped/corrupted/drifted dispatch leaves the browser (deferred posts included via cancel-or-page-lifetime-sentinel), verified = completed 200+prompt_id, terminal-truthful partial batches — never a silent full-graph run (#556) (#559)
+- graph-binding identity system rebuilt: the desync guard self-heals proven active-lineage drift and fails closed on foreign/untracked/unclaimed tags; identity transfers uniformly require object-keyed evidence (raw-canonical stores with conflict vetoes) or API/event-threaded succession proof across all four paths — carry, creation registration, guard rebind, lazy backstop (#545, #557) (#558)
+
 ## [0.11.35] - 2026-08-02
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.35"
+version = "0.11.36"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -674,7 +674,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.35";
+const PANEL_VERSION = "0.11.36";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Version bump + changelog for 0.11.36: the #559 panel_run scope guard and the #558 graph-binding identity rebuild — both through 9 and 12 adversarial codex rounds respectively, 1600+ unit tests on node 22 + 24.