### PR TITLE
fix(#741): panel_add_node accepts frontend-only virtual nodes (Note/MarkdownNote)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+### Fixed
+- `panel_add_node` / `panel_set_widget` unknown-type errors now point at `get_node_info` (the live /object_info node-class oracle) instead of `panel_search_nodes`, which searches installable Manager packs and can never resolve an exact class_type (mcp#741)
+
 ## [0.11.36] - 2026-08-03
 
 ### Fixed

--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -133,7 +133,7 @@ test("add_node: unknown type on a REACHABLE server ⇒ ERRORS with unknown-type"
   });
 });
 
-test("add_node: unknown-type error points at a LIVE tool, not the retired panel_get_graph (#318)", () => {
+test("add_node: unknown-type error points at a LIVE class-type oracle, not a retired or pack-only tool (#318, #741)", () => {
   const reg = loadedRegistry();
   try {
     assertAddNodeResolvable(reg, "DefinitelyNotARealNode");
@@ -141,8 +141,11 @@ test("add_node: unknown-type error points at a LIVE tool, not the retired panel_
   } catch (e) {
     // The retired panel_get_graph must never be recommended.
     assert.doesNotMatch(e.message, /panel_get_graph/);
-    // Should steer the caller to the registry-search tool instead.
-    assert.match(e.message, /panel_search_nodes/);
+    // #741: panel_search_nodes searches installable Manager PACKS, not node classes,
+    // so it can never answer "what is the exact class_type" — get_node_info (the live
+    // /object_info) is the oracle that can.
+    assert.doesNotMatch(e.message, /panel_search_nodes/);
+    assert.match(e.message, /get_node_info/);
   }
 });
 
@@ -1011,6 +1014,33 @@ test("#496 add_node: object_info UNAVAILABLE still fails closed, even for a fron
         wasTypeEverDefined: () => false,
       }),
     /cannot verify|object_info is unavailable/i,
+  );
+});
+
+// ---- #741: the annotation repro end-to-end through the add guard — Note and
+//      MarkdownNote (frontend-only virtual types, never in /object_info) must be
+//      ADDABLE on a healthy backend, while a genuinely-bogus type is still refused —
+//      and the refusal must steer the agent at a tool that can actually resolve an
+//      exact class_type (get_node_info, the live /object_info), never
+//      panel_search_nodes (which searches installable Manager PACKS). ---------------
+
+test("#741 add_node: Note/MarkdownNote are accepted; a bogus type is refused and points at get_node_info, not panel_search_nodes", async () => {
+  const reg = registryWithNatives(); // natives registered as LiteGraph registers them
+  const fresh = objectInfo(); // healthy backend — never lists the virtual types
+  for (const t of ["Note", "MarkdownNote"]) {
+    await assert.doesNotReject(
+      () => assertAddNodeResolvableRefreshing(() => reg, t, ADD_OPTS(fresh)),
+      `#741: "${t}" is a frontend-only virtual type and must be addable`,
+    );
+  }
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => reg, "TotallyBogusNode", ADD_OPTS(fresh)),
+    (err) => {
+      assert.match(err.message, /Unknown node type "TotallyBogusNode"/);
+      assert.match(err.message, /get_node_info/);
+      assert.doesNotMatch(err.message, /panel_search_nodes/);
+      return true;
+    },
   );
 });
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -6715,7 +6715,7 @@ const GRAPH_TOOL_EXECUTORS = {
     const node = LG.createNode(class_type);
     if (!node) {
       throw new Error(
-        `Unknown node type "${class_type}" — check the exact class_type via panel_search_nodes`,
+        `Unknown node type "${class_type}" — check the exact class_type via get_node_info`,
       );
     }
     graph.beforeChange();

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -376,7 +376,9 @@ export function assertAddNodeResolvable(registry, class_type) {
     );
   }
   throw new Error(
-    `Unknown node type "${class_type}" — check the exact class_type via panel_search_nodes`,
+    // get_node_info queries the live /object_info (node CLASSES); panel_search_nodes
+    // searches installable Manager PACKS and can never answer this (#741).
+    `Unknown node type "${class_type}" — check the exact class_type via get_node_info`,
   );
 }
 
@@ -493,9 +495,12 @@ export async function assertAddNodeResolvableRefreshing(getRegistry, class_type,
       }
       // Not defined by the current backend (never installed, or its pack was
       // removed). Fail closed even if a stale registry entry survives (#458/P1-C).
+      // #741: the pointer must be a tool that searches node CLASSES (get_node_info,
+      // the live /object_info) — panel_search_nodes searches Manager PACKS, which
+      // structurally cannot resolve an exact class_type.
       throw new Error(
         `Unknown node type "${class_type}" — the ComfyUI backend does not provide it ` +
-          `(not installed, or its pack was removed). Check the exact class_type via panel_search_nodes`,
+          `(not installed, or its pack was removed). Check the exact class_type via get_node_info`,
       );
     }
     // Backend HAS it. Make sure LiteGraph can construct it — refresh to register the
@@ -598,7 +603,7 @@ export function assertTypeAgainstFreshBackend(freshDefs, type, nodeId = "(unknow
     throw new Error(
       `Cannot set widget on node ${nodeId}${label}: the ComfyUI backend does not provide node ` +
         `type "${type}" (not installed, or its pack was removed) — refusing to write to a node ` +
-        `the live backend no longer defines (#458). Check the exact class_type via panel_search_nodes.`,
+        `the live backend no longer defines (#458). Check the exact class_type via get_node_info.`,
     );
   }
 }


### PR DESCRIPTION
## Summary

Closes the panel half of artokun/comfyui-mcp#741.

**Root cause (as filed):** on the reporter's panel 0.11.32, `graph_add_node`'s guard rejected `Note`/`MarkdownNote` because they never appear in `/object_info`. The add-side frontend-only exemption itself already shipped in **0.11.33** (#496 — `assertAddNodeResolvableRefreshing` exempts genuine frontend-only types via the shared `isAuthorizedFrontendOnlyType` predicate, behind the observed-backend-history gate). Verified on current main: the four native virtual types + rgthree control nodes pass the add guard; bogus types still fail closed.

**What this PR fixes — the issue's two remaining follow-ups:**

1. **Dead-end error message.** Every unknown-type refusal told the agent to "check the exact class_type via `panel_search_nodes`" — a tool that searches installable Manager **packs**, not node **classes**, and can never answer that question (its `/object_info` fallback only fires when the Manager is unreachable). All four sites now point at `get_node_info`, the live `/object_info` node-class oracle:
   - `web/js/lib/node-resolve.js` — `assertAddNodeResolvable`, `assertAddNodeResolvableRefreshing`, `assertTypeAgainstFreshBackend`
   - `web/js/comfyui-mcp-panel.js` — `graph_add_node` createNode fallback

2. **Tests** (`browser_tests/unit/node-resolve.test.mjs`):
   - new #741 test: `Note`/`MarkdownNote` accepted through the add guard on a healthy backend; a bogus type still refused — and the refusal names `get_node_info`, never `panel_search_nodes`
   - updated the #318 message test to the new pointer

All binding/targeting guards untouched; the #458 fail-closed invariants (ever-seen gate, provenance checks, unavailable-oracle refusal) are unchanged and still locked by the existing #496/#458 tests.

## Test plan
- `npm run test:unit` — **1638/1638 pass** (node 24)
- `npx -y node@22 --test browser_tests/unit/*.test.mjs` — **1638/1638 pass**
- `npx tsc --noEmit` — clean

Sibling PR in comfyui-mcp documents the annotation path in `panel_add_node`'s tool description.

Refs artokun/comfyui-mcp#741