### PR TITLE
fix(#749): root-anchor .comfyignore vendor/ — ship web/js/vendor runtime assets

### DIFF
--- a/.comfyignore
+++ b/.comfyignore
@@ -21,7 +21,11 @@ scripts/
 # Build-time vocabulary artefact vendored from comfyui-mcp. Consumed only by
 # scripts/check-tool-vocabulary.mjs in CI; shipping a list of ~270 tool names in
 # the pack would add nothing for users and give the registry scanner more surface.
-vendor/
+# ROOT-ANCHORED on purpose: the registry applies .comfyignore with gitignore
+# semantics, so a bare `vendor/` matches at ANY depth — it silently dropped
+# web/js/vendor/ (the runtime marked/DOMPurify/qrcode/a2ui-lit imports) from the
+# pack, the browser 404'd on import and the sidebar never registered (#749).
+/vendor/
 .githooks/
 # The Cloudflare registry worker (deploy infra, not part of the custom-node
 # pack; its fetch/crypto calls would only manufacture scanner findings)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,37 @@ jobs:
           sys.exit(1 if bad else 0)
           PY
 
+      # The registry applies .comfyignore with gitignore semantics: a bare
+      # `vendor/` matches a vendor dir at ANY depth, so the exclusion meant for
+      # the root CI artefact also silently dropped web/js/vendor/ (the runtime
+      # marked/DOMPurify/qrcode/a2ui-lit imports) from the pack — the browser
+      # 404'd on import and the sidebar never registered (#749). The parity
+      # scan above reimplements the matching root-anchored and cannot see this
+      # class of loss, so assert with git's OWN ignore engine instead (empty
+      # index: check-ignore skips tracked paths).
+      - name: Pack contents — runtime assets must not be .comfyignore'd
+        shell: bash
+        run: |
+          set -e
+          export GIT_INDEX_FILE="$PWD/.git/pack-contents-empty-index"
+          trap 'rm -f "$GIT_INDEX_FILE"' EXIT
+          for f in \
+            web/js/comfyui-mcp-panel.js \
+            web/js/vendor/marked.esm.js \
+            web/js/vendor/purify.es.js \
+            web/js/vendor/qrcode.esm.js \
+            web/js/vendor/a2ui-lit.bundle.js \
+          ; do
+            if git -c core.excludesFile=.comfyignore check-ignore -q "$f"; then
+              echo "::error file=.comfyignore::$f is exclude-matched but imported at runtime — the published pack would 404 on import and the sidebar would never register (#749)"
+              exit 1
+            fi
+          done
+          # …while the CI-only vocabulary artefact MUST stay excluded.
+          if ! git -c core.excludesFile=.comfyignore check-ignore -q vendor/tool-vocabulary.json; then
+            echo "::error file=.comfyignore::vendor/tool-vocabulary.json must stay .comfyignore'd (CI-only artefact consumed by scripts/check-tool-vocabulary.mjs)"
+            exit 1
+          fi
 
       - name: pyproject.toml is valid + has registry fields + JS version matches
         run: |

--- a/.github/workflows/publish_action.yml
+++ b/.github/workflows/publish_action.yml
@@ -35,6 +35,38 @@ jobs:
           done
           [ "$found" = "1" ] || { echo "::error::no web/js/*.js files found"; exit 1; }
 
+      # The registry applies .comfyignore with gitignore semantics: a bare
+      # `vendor/` matches a vendor dir at ANY depth, so the exclusion meant for
+      # the root CI artefact also silently dropped web/js/vendor/ (the runtime
+      # marked/DOMPurify/qrcode/a2ui-lit imports) from the pack — the browser
+      # 404'd on import and the sidebar never registered (#749). The parity
+      # scan below reimplements the matching root-anchored and cannot see this
+      # class of loss, so assert with git's OWN ignore engine instead (empty
+      # index: check-ignore skips tracked paths). Mirrors ci.yml.
+      - name: Pack contents — runtime assets must not be .comfyignore'd
+        shell: bash
+        run: |
+          set -e
+          export GIT_INDEX_FILE="$PWD/.git/pack-contents-empty-index"
+          trap 'rm -f "$GIT_INDEX_FILE"' EXIT
+          for f in \
+            web/js/comfyui-mcp-panel.js \
+            web/js/vendor/marked.esm.js \
+            web/js/vendor/purify.es.js \
+            web/js/vendor/qrcode.esm.js \
+            web/js/vendor/a2ui-lit.bundle.js \
+          ; do
+            if git -c core.excludesFile=.comfyignore check-ignore -q "$f"; then
+              echo "::error file=.comfyignore::$f is exclude-matched but imported at runtime — the published pack would 404 on import and the sidebar would never register (#749)"
+              exit 1
+            fi
+          done
+          # …while the CI-only vocabulary artefact MUST stay excluded.
+          if ! git -c core.excludesFile=.comfyignore check-ignore -q vendor/tool-vocabulary.json; then
+            echo "::error file=.comfyignore::vendor/tool-vocabulary.json must stay .comfyignore'd (CI-only artefact consumed by scripts/check-tool-vocabulary.mjs)"
+            exit 1
+          fi
+
       # Never publish a version the registry's YARA scan will flag. The rule
       # SUSP_SVG_Onload_Onerror fires on "svg" + ("onload"|"onerror") co-occurring
       # in any file (nocase). Flagged every release 0.1.0→0.6.1. Fix: use


### PR DESCRIPTION
## Problem

Fixes artokun/comfyui-mcp#749.

`.comfyignore` gained a bare `vendor/` line in 7ceeeb87 (2026-08-01, "0.49.0 vocabulary gate") to exclude the root CI-only artefact `vendor/tool-vocabulary.json`. But the Comfy Registry applies .comfyignore with **gitignore semantics**: a bare `vendor/` matches a `vendor` directory at **any depth**, so it also excluded `web/js/vendor/` — the runtime ES-module dependencies imported by the panel:

- `web/js/comfyui-mcp-panel.js:65-67` → `./vendor/marked.esm.js`, `./vendor/purify.es.js`, `./vendor/qrcode.esm.js`
- `web/js/cmcp-a2ui-lit-adapter.js:35` → `./vendor/a2ui-lit.bundle.js`

**Verified against the live registry**: the published `node.zip` for 0.11.36 (https://cdn.comfy.org/artokun/comfyui-agent-panel/0.11.36/node.zip) contains `web/js/comfyui-mcp-panel.js` but **no `web/js/vendor/`**. The browser 404s on each import, the module fails to load, and the sidebar tab never registers — the "agent panel disappeared" report in the issue. Affects packs published 2026-08-01 onward (0.11.33+).

## Fix

One-line: `vendor/` → `/vendor/` (root-anchored), plus a comment explaining why the anchor must stay.

## Guard (regression test)

New **Pack contents** step in both `ci.yml` and `publish_action.yml`. It asserts with git's own ignore engine — not a reimplementation — that:

1. the 5 runtime assets (`comfyui-mcp-panel.js` + 4 vendor bundles) are **not** exclude-matched, and
2. the CI-only `vendor/tool-vocabulary.json` **stays** excluded.

Implementation notes:

- `git -c core.excludesFile=.comfyignore check-ignore` treats .comfyignore as a root-level ignore file — exactly the registry's semantics.
- `GIT_INDEX_FILE` is pointed at an empty temp index because `check-ignore` skips tracked paths (observed on git 2.54); with an empty index the check is purely pattern-based and version-agnostic.
- The existing YARA parity scan reimplements archive matching with root-anchored directory patterns, so it structurally cannot see this class of loss — hence a separate step rather than extending that block.

Verified locally against the real repo: guard **fails** on the old pattern (`web/js/vendor/marked.esm.js is exclude-matched`), **passes** on the fix.

## Notes

- No version bump — leaving the release cadence to you. Users who installed via the registry (ComfyUI extensions button / Manager version channel) need a republished pack; nightly/git-clone installs were never affected.
- No JS/Python code changed; the new CI steps are the test.
