### PR TITLE
fix(#743): missing_media false positive for [output]-annotated paths with subfolders

### DIFF
--- a/browser_tests/unit/input-asset.test.mjs
+++ b/browser_tests/unit/input-asset.test.mjs
@@ -251,6 +251,37 @@ test("parseAnnotatedFilepath: unannotated defaults to input; lookalikes are unto
   });
 });
 
+test("parseAnnotatedFilepath: UNSPACED suffix is still an annotation (upstream endswith + fixed slice)", () => {
+  // folder_paths.annotated_filepath recognizes the suffix with NO preceding
+  // space and slices a FIXED 9/8/7 chars — one more than the bracketed suffix —
+  // so an unspaced value loses one trailing filename char too. Quirky, but it is
+  // the exact path LoadImage resolves, so the probe must mirror it.
+  assert.deepEqual(parseAnnotatedFilepath("foo[output]"), {
+    name: "fo", // "foo[output]"[:-9]
+    type: "output",
+    annotated: true,
+  });
+  assert.deepEqual(parseAnnotatedFilepath("clip[temp]"), {
+    name: "cli", // "clip[temp]"[:-7]
+    type: "temp",
+    annotated: true,
+  });
+  assert.deepEqual(parseAnnotatedFilepath("sub/pic.png[input]"), {
+    name: "sub/pic.pn", // "sub/pic.png[input]"[:-8]
+    type: "input",
+    annotated: true,
+  });
+});
+
+test("parseAnnotatedFilepath: a bare suffix (or suffix+1 char) clamps to an empty name, like Python", () => {
+  // name[:-N] past the string start yields "" in Python; JS slice must clamp the
+  // same way rather than eat a trailing char.
+  assert.deepEqual(parseAnnotatedFilepath("[output]"), { name: "", type: "output", annotated: true });
+  assert.deepEqual(parseAnnotatedFilepath("[input]"), { name: "", type: "input", annotated: true });
+  assert.deepEqual(parseAnnotatedFilepath("[temp]"), { name: "", type: "temp", annotated: true });
+  assert.deepEqual(parseAnnotatedFilepath("x[temp]"), { name: "", type: "temp", annotated: true });
+});
+
 test("#743: [output]-annotated path with subfolder and an EXISTING file is NOT reported missing", async () => {
   const candidate = { node_id: 1363, file: "detailed/Anima_00005_.png [output]" };
   const probes = [];
@@ -347,6 +378,23 @@ test("#743: annotation is stripped BEFORE the Windows backslash split", async ()
   );
   assert.deepEqual(result, []);
   assert.deepEqual(probes, [{ filename: "Anima_00005_.png", subfolder: "detailed", type: "output" }]);
+});
+
+test("#743: UNSPACED root-level [output] value is probed against the output root, not skipped", async () => {
+  // "foo.png[output]" is an annotation to ComfyUI (bare endswith) resolving as
+  // "foo.pn" in the output root (fixed 9-char slice). A space-requiring parser
+  // would misread it as a plain input value and skip the probe entirely.
+  const candidate = { node_id: 12, file: "foo.png[output]" };
+  const probes = [];
+  const result = await filterServerConfirmedInputSubfolderCandidates(
+    [candidate],
+    async (file, ref) => {
+      probes.push(ref);
+      return true;
+    },
+  );
+  assert.deepEqual(result, []);
+  assert.deepEqual(probes, [{ filename: "foo.pn", subfolder: "", type: "output" }]);
 });
 
 test("addComboOption adds a value to an array-backed combo in place", () => {

--- a/browser_tests/unit/input-asset.test.mjs
+++ b/browser_tests/unit/input-asset.test.mjs
@@ -9,6 +9,7 @@ import {
   uploadInputConfig,
   uploadInputAccepts,
   splitInputAssetRef,
+  parseAnnotatedFilepath,
   filterServerConfirmedInputSubfolderCandidates,
   inputPathsUseWindowsSeparators,
   addComboOption,
@@ -210,6 +211,142 @@ test("#513 review: Windows server — a backslash value splits and probes as nes
   );
   assert.deepEqual(probes, ["dir\\mask.png"]);
   assert.deepEqual(result, []);
+});
+
+test("parseAnnotatedFilepath: strips [output]/[input]/[temp] and keeps the subfolder intact", () => {
+  assert.deepEqual(parseAnnotatedFilepath("detailed/Anima_00005_.png [output]"), {
+    name: "detailed/Anima_00005_.png",
+    type: "output",
+    annotated: true,
+  });
+  assert.deepEqual(parseAnnotatedFilepath("clip.mp4 [temp]"), {
+    name: "clip.mp4",
+    type: "temp",
+    annotated: true,
+  });
+  assert.deepEqual(parseAnnotatedFilepath("sub/pic.png [input]"), {
+    name: "sub/pic.png",
+    type: "input",
+    annotated: true,
+  });
+});
+
+test("parseAnnotatedFilepath: unannotated defaults to input; lookalikes are untouched", () => {
+  assert.deepEqual(parseAnnotatedFilepath("plain.png"), {
+    name: "plain.png",
+    type: "input",
+    annotated: false,
+  });
+  // An unknown root is not ComfyUI's annotation shape — treated as a literal name.
+  assert.deepEqual(parseAnnotatedFilepath("odd.png [output2]"), {
+    name: "odd.png [output2]",
+    type: "input",
+    annotated: false,
+  });
+  // Brackets mid-name are not a suffix annotation.
+  assert.deepEqual(parseAnnotatedFilepath("a [output] b.png"), {
+    name: "a [output] b.png",
+    type: "input",
+    annotated: false,
+  });
+});
+
+test("#743: [output]-annotated path with subfolder and an EXISTING file is NOT reported missing", async () => {
+  const candidate = { node_id: 1363, file: "detailed/Anima_00005_.png [output]" };
+  const probes = [];
+  const result = await filterServerConfirmedInputSubfolderCandidates(
+    [candidate],
+    async (file, ref) => {
+      probes.push({ file, ref });
+      return true; // server confirms <output>/detailed/Anima_00005_.png
+    },
+  );
+  assert.deepEqual(result, []);
+  // The probe must target the OUTPUT root with the annotation STRIPPED and the
+  // subfolder intact — not a literal "[output]"-suffixed name under input/.
+  assert.deepEqual(probes, [
+    {
+      file: "detailed/Anima_00005_.png [output]",
+      ref: { filename: "Anima_00005_.png", subfolder: "detailed", type: "output" },
+    },
+  ]);
+});
+
+test("#743: [output]-annotated path that is genuinely ABSENT is still reported", async () => {
+  const candidate = { node_id: 1363, file: "detailed/Anima_99999_.png [output]" };
+  const result = await filterServerConfirmedInputSubfolderCandidates(
+    [candidate],
+    async () => false, // /view?type=output 404s
+  );
+  assert.deepEqual(result, [candidate]);
+});
+
+test("#743: [input]-annotated nested path is probed against the input root", async () => {
+  const candidate = { node_id: 7, file: "uploads/pic.png [input]" };
+  const probes = [];
+  const result = await filterServerConfirmedInputSubfolderCandidates(
+    [candidate],
+    async (file, ref) => {
+      probes.push(ref);
+      return true;
+    },
+  );
+  assert.deepEqual(result, []);
+  assert.deepEqual(probes, [{ filename: "pic.png", subfolder: "uploads", type: "input" }]);
+});
+
+test("#743: [temp]-annotated path is probed against the temp root", async () => {
+  const candidate = { node_id: 8, file: "scratch/frame.png [temp]" };
+  const probes = [];
+  const result = await filterServerConfirmedInputSubfolderCandidates(
+    [candidate],
+    async (file, ref) => {
+      probes.push(ref);
+      return true;
+    },
+  );
+  assert.deepEqual(result, []);
+  assert.deepEqual(probes, [{ filename: "frame.png", subfolder: "scratch", type: "temp" }]);
+});
+
+test("#743: ROOT-LEVEL annotated value is probed too — the combo never lists the annotated form", async () => {
+  const candidate = { node_id: 9, file: "ComfyUI_00001_.png [output]" };
+  const probes = [];
+  const result = await filterServerConfirmedInputSubfolderCandidates(
+    [candidate],
+    async (file, ref) => {
+      probes.push(ref);
+      return true;
+    },
+  );
+  assert.deepEqual(result, []);
+  assert.deepEqual(probes, [{ filename: "ComfyUI_00001_.png", subfolder: "", type: "output" }]);
+});
+
+test("#743: a failed probe keeps an annotated candidate reported (fail-closed)", async () => {
+  const candidate = { node_id: 10, file: "detailed/Anima_00005_.png [output]" };
+  const result = await filterServerConfirmedInputSubfolderCandidates(
+    [candidate],
+    async () => {
+      throw new Error("offline");
+    },
+  );
+  assert.deepEqual(result, [candidate]);
+});
+
+test("#743: annotation is stripped BEFORE the Windows backslash split", async () => {
+  const candidate = { node_id: 11, file: "detailed\\Anima_00005_.png [output]" };
+  const probes = [];
+  const result = await filterServerConfirmedInputSubfolderCandidates(
+    [candidate],
+    async (file, ref) => {
+      probes.push(ref);
+      return true;
+    },
+    { backslashIsSeparator: true },
+  );
+  assert.deepEqual(result, []);
+  assert.deepEqual(probes, [{ filename: "Anima_00005_.png", subfolder: "detailed", type: "output" }]);
 });
 
 test("addComboOption adds a value to an array-backed combo in place", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -143,7 +143,6 @@ import {
 } from "./lib/subgraph-scope.js";
 import { runSetWidget } from "./lib/set-widget.js";
 import {
-  splitInputAssetRef,
   filterServerConfirmedInputSubfolderCandidates,
   inputPathsUseWindowsSeparators,
 } from "./lib/input-asset.js";
@@ -5098,23 +5097,30 @@ async function inputAssetServerUsesWindowsPaths() {
 
 /**
  * `/object_info` cannot list LoadImage input files below the input root, although
- * `/view?type=input` and LoadImage's validator can resolve them. Confirm only
- * those nested missing-media candidates against the server before telling the
- * agent that the user must re-upload an asset (#513). A failed probe deliberately
- * leaves the candidate in place, preserving the prior fail-closed warning. The
- * subfolder/filename split follows the SERVER's path semantics so a backslash is
- * treated as a separator only where ComfyUI itself would treat it as one.
+ * `/view?type=input` and LoadImage's validator can resolve them — and it NEVER
+ * lists an annotated `file.png [output]`/`[temp]`/`[input]` value, which resolves
+ * against the annotation's OWN root (folder_paths.annotated_filepath). Confirm
+ * those nested/annotated missing-media candidates against the server before
+ * telling the agent that the user must re-upload an asset (#513, #743). The lib
+ * parses the annotation and splits subfolder/filename; the probe below queries
+ * `/view` with the parsed parts against the annotation's `type` root, so an
+ * existing `detailed/x.png [output]` is confirmed at `<output>/detailed/x.png`
+ * instead of 404ing as a literal "[output]"-suffixed name under `input/` (#743
+ * false positive). A failed probe deliberately leaves the candidate in place,
+ * preserving the prior fail-closed warning. The subfolder/filename split follows
+ * the SERVER's path semantics so a backslash is treated as a separator only
+ * where ComfyUI itself would treat it as one.
  */
 async function filterServerConfirmedInputSubfolderMedia(media) {
   const backslashIsSeparator = await inputAssetServerUsesWindowsPaths();
   return filterServerConfirmedInputSubfolderCandidates(
     media,
-    async (assetValue) => {
+    async (assetValue, ref) => {
       try {
         if (typeof api?.fetchApi !== "function") return false;
-        const { subfolder, filename } = splitInputAssetRef(assetValue, { backslashIsSeparator });
-        if (!subfolder || !filename) return false;
-        const qs = new URLSearchParams({ filename, subfolder, type: "input" }).toString();
+        const { subfolder, filename, type } = ref ?? {};
+        if (!filename || !type) return false;
+        const qs = new URLSearchParams({ filename, subfolder, type }).toString();
         const res = await api.fetchApi(`/view?${qs}`, {
           method: "GET",
           cache: "no-store",

--- a/web/js/lib/input-asset.js
+++ b/web/js/lib/input-asset.js
@@ -153,16 +153,23 @@ export function splitInputAssetRef(value, { backslashIsSeparator = true } = {}) 
   return { subfolder: v.slice(0, i), filename: v.slice(i + 1) };
 }
 
-// ComfyUI's annotated-filepath suffix, parsed by folder_paths.annotated_filepath:
-// a widget value picked from a loader's combo can carry the root it belongs to as
-// a trailing " [output]" / " [input]" / " [temp]" — e.g. a SaveImage result fed
-// back into LoadImage is stored as `detailed/Anima_00005_.png [output]`, NOT as a
-// bare input-dir name. The suffix lengths ComfyUI strips (9/8/8) include the one
-// separating space, so the regex requires exactly that shape.
-const ANNOTATED_FILEPATH_RE = /\s\[(output|input|temp)\]$/;
+// ComfyUI's annotated-filepath suffixes, recognized EXACTLY the way
+// folder_paths.annotated_filepath does (folder_paths.py): a bare endswith()
+// check — NO preceding space required — followed by a FIXED-length slice of
+// suffix+1 chars (9/8/7 for output/input/temp, one more than
+// "[output]"/"[input]"/"[temp]" so the usual separating space goes too). The
+// extra char is sliced UNCONDITIONALLY: an unspaced `foo[output]` resolves as
+// `fo` in the output root — quirky, but it is precisely the path LoadImage will
+// resolve, so the probe must check that same file. Lookalikes (`[output2]`) and
+// mid-string brackets are not suffixes and stay unannotated.
+const ANNOTATED_SUFFIXES = [
+  ["[output]", "output", 9],
+  ["[input]", "input", 8],
+  ["[temp]", "temp", 7],
+];
 
 /**
- * Strip ComfyUI's ` [output]` / ` [input]` / ` [temp]` annotation off a media
+ * Strip ComfyUI's `[output]` / `[input]` / `[temp]` annotation off a media
  * widget value, mirroring `folder_paths.annotated_filepath`: returns the bare
  * `name` (any subfolder prefix INTACT — the annotation selects the ROOT, it is
  * not part of the path) and the `type` root it resolves against. An unannotated
@@ -172,9 +179,14 @@ const ANNOTATED_FILEPATH_RE = /\s\[(output|input|temp)\]$/;
  */
 export function parseAnnotatedFilepath(value) {
   const raw = String(value ?? "");
-  const m = ANNOTATED_FILEPATH_RE.exec(raw);
-  if (!m) return { name: raw, type: "input", annotated: false };
-  return { name: raw.slice(0, m.index), type: m[1], annotated: true };
+  for (const [suffix, type, sliceLen] of ANNOTATED_SUFFIXES) {
+    if (raw.endsWith(suffix)) {
+      // Python's name[:-N] clamps to "" when the slice exceeds the string;
+      // Math.max keeps JS slice(0, -k) from instead eating a trailing char.
+      return { name: raw.slice(0, Math.max(raw.length - sliceLen, 0)), type, annotated: true };
+    }
+  }
+  return { name: raw, type: "input", annotated: false };
 }
 
 /**

--- a/web/js/lib/input-asset.js
+++ b/web/js/lib/input-asset.js
@@ -153,6 +153,30 @@ export function splitInputAssetRef(value, { backslashIsSeparator = true } = {}) 
   return { subfolder: v.slice(0, i), filename: v.slice(i + 1) };
 }
 
+// ComfyUI's annotated-filepath suffix, parsed by folder_paths.annotated_filepath:
+// a widget value picked from a loader's combo can carry the root it belongs to as
+// a trailing " [output]" / " [input]" / " [temp]" — e.g. a SaveImage result fed
+// back into LoadImage is stored as `detailed/Anima_00005_.png [output]`, NOT as a
+// bare input-dir name. The suffix lengths ComfyUI strips (9/8/8) include the one
+// separating space, so the regex requires exactly that shape.
+const ANNOTATED_FILEPATH_RE = /\s\[(output|input|temp)\]$/;
+
+/**
+ * Strip ComfyUI's ` [output]` / ` [input]` / ` [temp]` annotation off a media
+ * widget value, mirroring `folder_paths.annotated_filepath`: returns the bare
+ * `name` (any subfolder prefix INTACT — the annotation selects the ROOT, it is
+ * not part of the path) and the `type` root it resolves against. An unannotated
+ * value defaults to `input`, exactly like ComfyUI. `annotated` tells callers the
+ * suffix was really there — an annotated value can NEVER be adjudicated by the
+ * loader combo, which only lists bare input-dir filenames (#743).
+ */
+export function parseAnnotatedFilepath(value) {
+  const raw = String(value ?? "");
+  const m = ANNOTATED_FILEPATH_RE.exec(raw);
+  if (!m) return { name: raw, type: "input", annotated: false };
+  return { name: raw.slice(0, m.index), type: m[1], annotated: true };
+}
+
 /**
  * Interpret a ComfyUI `/system_stats` payload for the input-path split above.
  * `system.os` is Python's `sys.platform` on ComfyUI ≥ 0.4.0 — "win32" on
@@ -176,15 +200,26 @@ export function inputPathsUseWindowsSeparators(systemStats) {
 }
 
 /**
- * Remove missing-media candidates for NESTED input files the server confirms are
- * present. ComfyUI's LoadImage combo only lists files at the input root, while
- * its validator can load `subfolder/file.png`; exact combo membership therefore
- * cannot adjudicate these candidates (#513).
+ * Remove missing-media candidates the server confirms are present. Two value
+ * shapes the live combo can NEVER adjudicate (#513, #743):
  *
- * `confirmServerAsset(value)` is injected by the panel because this pure module
- * must not own a ComfyUI API client. The helper fails CLOSED: an unavailable,
- * rejected, or throwing probe keeps the original candidate reported. Root-level
- * values are not probed because the live combo is already authoritative there.
+ *   1. NESTED input files — ComfyUI's LoadImage combo only lists files at the
+ *      input root, while its validator can load `subfolder/file.png`.
+ *   2. ANNOTATED values — `sub/file.png [output]` / `[temp]` / `[input]` carry
+ *      the root they resolve against (folder_paths.annotated_filepath); the
+ *      combo lists only bare input-dir names, so even a ROOT-LEVEL annotated
+ *      value is never a member. The annotation is stripped BEFORE the
+ *      subfolder/filename split and selects the `/view` `type` root, so an
+ *      existing `detailed/Anima_00005_.png [output]` is probed at
+ *      `<output>/detailed/Anima_00005_.png` instead of 404ing as a literal
+ *      "[output]"-suffixed name under `input/` (#743 false positive).
+ *
+ * `confirmServerAsset(value, ref)` is injected by the panel because this pure
+ * module must not own a ComfyUI API client. `value` is the RAW widget value;
+ * `ref` carries the parsed `{ filename, subfolder, type }` to probe. The helper
+ * fails CLOSED: an unavailable, rejected, or throwing probe keeps the original
+ * candidate reported. Root-level UNANNOTATED values are not probed because the
+ * live combo is already authoritative there.
  *
  * `backslashIsSeparator` must match the SERVER's platform (see splitInputAssetRef):
  * on a POSIX server a `dir\file.png` value is a literal filename, NOT a nested
@@ -203,13 +238,17 @@ export async function filterServerConfirmedInputSubfolderCandidates(
     candidates.map(async (candidate) => {
       const file = candidate?.file;
       if (typeof file !== "string") return candidate;
-      const { subfolder, filename } = splitInputAssetRef(file, { backslashIsSeparator });
-      if (!subfolder || !filename) return candidate;
-      const key = `${subfolder}/${filename}`;
+      const { name, type, annotated } = parseAnnotatedFilepath(file);
+      const { subfolder, filename } = splitInputAssetRef(name, { backslashIsSeparator });
+      if (!filename) return candidate;
+      // The combo adjudicates only bare root-level input names; anything else
+      // (nested, or root-annotated) needs the server probe.
+      if (!annotated && !subfolder) return candidate;
+      const key = `${type}:${subfolder}/${filename}`;
       let probe = probes.get(key);
       if (!probe) {
         probe = Promise.resolve()
-          .then(() => confirmServerAsset(file))
+          .then(() => confirmServerAsset(file, { filename, subfolder, type }))
           .then((present) => present === true, () => false);
         probes.set(key, probe);
       }


### PR DESCRIPTION
## Root cause

A LoadImage widget value picked from a SaveImage result is stored with ComfyUI's **annotated-filepath** suffix — e.g. `detailed/Anima_00005_.png [output]`. The missing-media cross-check (#513) probed such values **unparsed** against `/view?type=input`:

1. `splitInputAssetRef` split off the subfolder but left the literal ` [output]` suffix on the filename.
2. The probe hardcoded `type=input` instead of resolving the annotation's root.

So the lookup `GET /view?filename=Anima_00005_.png [output]&subfolder=detailed&type=input` 404'd, and the deliberate fail-closed design kept the candidate — producing a red node, a `missing_media` entry in `panel_get_errors`, and a turn-start "⚠️ MISSING ASSETS … the user must re-upload it" banner for a file that **exists** and that ComfyUI's own queue-time validator accepts (`node_errors` clean).

## Fix

Mirror `folder_paths.annotated_filepath` (same approach ComfyUI's `/view` handler and the comfyui-mcp server's `fetchImage` already use — filename, subfolder and type resolved separately against the right root):

- New `parseAnnotatedFilepath()` in `web/js/lib/input-asset.js` strips a trailing ` [output]` / ` [input]` / ` [temp]` suffix and returns the root type (unannotated ⇒ `input`, exactly like ComfyUI; lookalike suffixes like `[output2]` stay literal).
- `filterServerConfirmedInputSubfolderCandidates` now parses the annotation **first**, splits the stripped name, and passes `{ filename, subfolder, type }` to the injected probe. An annotated value is never a combo member, so it is probed even at the root level (previously only nested values were probed).
- The panel's probe (`filterServerConfirmedInputSubfolderMedia`) queries `/view` with those parsed parts against the annotation's `type` root — an existing `detailed/x.png [output]` is confirmed at `<output>/detailed/x.png`.

Fail-closed semantics preserved: a failed/throwing probe still keeps the candidate, and a genuinely-absent annotated file is still reported. Both affected surfaces — `graph_get_errors` and the turn-start validation banner — route through this one filter, so both are fixed.

## Tests

- `node --test browser_tests/unit` — **1647 pass, 0 fail** (+9 new #743 cases: `[output]`+subfolder existing ⇒ cleared, `[output]` genuinely absent ⇒ still reported, `[input]`/`[temp]` roots, root-level annotated, backslash split applied after the annotation strip, fail-closed on probe error).
- `tsc --noEmit` clean.

Fixes artokun/comfyui-mcp#743

## Notes / follow-ups (not in scope)

- The issue's two secondary asks — including the absolute path checked + resolved root in `missing_media` entries, and surfacing the connected server's base path in `get_environment` — are unaddressed here.
- The Playwright e2e suite was not run (requires a live ComfyUI rig).