### PR TITLE
fix(#560,#565): heal blank-canvas stale root tags; dialect-tolerant binding proof

### DIFF
--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -17,14 +17,17 @@ import { dirname, join } from "node:path";
 
 import {
   activeWorkflowNodeCount,
+  activeWorkflowProvenEmpty,
   graphReadDesynced,
   graphRootMismatchesActiveWorkflow,
+  graphRootProvenEmpty,
   graphRootWorkflowUuidMismatches,
   graphRootWorkflowUuidMatches,
   graphRootMatchesState,
   graphCommandMayMutateWorkflow,
   graphReadBindingChanged,
   resolveGraphRootUuidRebind,
+  serializedStateProvenEmpty,
 } from "../../web/js/lib/graph-binding.js";
 import {
   commandWorkflowMismatch,
@@ -104,7 +107,8 @@ function buildDirtyStaleRouteHarness({
   activeNodeCount = 27,
   rootNodeCount = 30,
   activeModified = true,
-  activeTracker = null,
+  activeTracker,
+  rootSerializer = null,
 } = {}) {
   const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
   const stableSource = panelFunctionSource(src, "workflowStableUuid", "workflowStorageKey");
@@ -118,7 +122,10 @@ function buildDirtyStaleRouteHarness({
     : {
         isPersisted: false,
         isModified: activeModified,
-        changeTracker: activeTracker ?? {
+        // activeTracker is deliberately NOT `??`-defaulted: an explicit null
+        // models a workflow whose tracker is entirely unreadable, which the
+        // proven-empty relaxation must treat as fail-closed (#565 gate).
+        changeTracker: activeTracker !== undefined ? activeTracker : {
           activeState: {
             ...state(activeNodeCount),
             // "stale-lineage" (r6 P0): the active object's tracker state is
@@ -154,6 +161,10 @@ function buildDirtyStaleRouteHarness({
   const rootB = {
     _nodes: Array.from({ length: rootNodeCount }, (_, i) => ({ id: i + 1, type: "KSampler" })),
     ...(rootUuid ? { extra: { comfyui_mcp: { workflow_uuid: rootUuid } } } : {}),
+    // The proven-empty relaxation requires a SERIALIZABLE root whose full
+    // non-identity surfaces are all empty (#565 gate): a bare empty _nodes
+    // array is node-level evidence only and must not relax the guard.
+    ...(rootSerializer ? { serialize: rootSerializer } : {}),
   };
   const openWorkflows =
     foreignClaim === "none" || foreignClaim === "active-lineage" || foreignClaim === "stale-lineage"
@@ -240,6 +251,8 @@ function buildDirtyStaleRouteHarness({
     "graphRootMismatchesActiveWorkflow",
     "graphReadDesynced",
     "activeWorkflowNodeCount",
+    "activeWorkflowProvenEmpty",
+    "graphRootProvenEmpty",
     "workflowOwnsRootUuidTag",
     "rememberWorkflowUuidOwner",
     "resolveGraphRootUuidRebind",
@@ -255,6 +268,8 @@ function buildDirtyStaleRouteHarness({
     graphRootMismatchesActiveWorkflow,
     graphReadDesynced,
     activeWorkflowNodeCount,
+    activeWorkflowProvenEmpty,
+    graphRootProvenEmpty,
     ownsTag,
     () => {},
     resolveGraphRootUuidRebind,
@@ -1965,6 +1980,105 @@ test("#565: graphRootMismatchesActiveWorkflow is inconclusive when BOTH node arr
   );
 });
 
+// ── #565 gate: the proven-empty evidence bar ─────────────────────────────────
+
+test("serializedStateProvenEmpty: TRUE only for a well-formed, fully content-free state", () => {
+  assert.equal(serializedStateProvenEmpty({ nodes: [] }), true, "the minimal blank state");
+  assert.equal(
+    serializedStateProvenEmpty({
+      id: "g",
+      revision: 3,
+      version: 0.4,
+      last_node_id: 12,
+      last_link_id: 8,
+      nodes: [],
+      links: [],
+      groups: [],
+      config: {},
+      extra: { ds: { scale: 2 }, comfyui_mcp: { workflow_uuid: "u" }, linkExtensions: [] },
+    }),
+    true,
+    "format metadata, viewport, the panel identity tag, and empty surfaces are not content",
+  );
+});
+
+test("serializedStateProvenEmpty: FALSE for missing/malformed nodes or ANY non-empty surface", () => {
+  for (const state of [
+    null,
+    undefined,
+    42,
+    [],
+    {},
+    { nodes: "bad" }, // malformed read — not an empty-array proof
+    { nodes: [{ id: 1 }] }, // a node is content
+    { nodes: [], subgraphs: [{ id: "s", nodes: [{ id: 9 }] }] },
+    { nodes: [], groups: [{ id: 1, title: "g" }] },
+    { nodes: [], reroutes: [{ id: "r" }] },
+    { nodes: [], links: [[1, 1, 0, 2, 0, "MODEL"]] },
+    { nodes: [], config: { setting: 1 } },
+    { nodes: [], definitions: { subgraphs: [{ id: "def" }] } },
+    { nodes: [], extra: { workflow_meta: { owner: "artist" } } }, // real extra content
+    { nodes: [], extra: 5 }, // malformed scalar extra
+    { nodes: [], unknownSurface: { nested: "content" } }, // unknown non-empty surface
+  ]) {
+    assert.equal(serializedStateProvenEmpty(state), false, JSON.stringify(state));
+  }
+});
+
+test("activeWorkflowProvenEmpty: requires a CLEAN, well-formed, zero-node CURRENT state", () => {
+  assert.equal(
+    activeWorkflowProvenEmpty(wf({ changeTracker: { activeState: { nodes: [] } } })),
+    true,
+    "the genuine #565 blank tab",
+  );
+  assert.equal(
+    activeWorkflowProvenEmpty(wf({ activeState: { nodes: [] } })),
+    true,
+    "flat activeState shapes count too",
+  );
+  // A DIRTY tab's tracker can lag the real canvas (#545) — never proof.
+  assert.equal(
+    activeWorkflowProvenEmpty(wf({ changeTracker: { activeState: { nodes: [] } }, isModified: true })),
+    false,
+  );
+  // Absent / malformed / baseline-only reads fail closed — a 0 from
+  // activeWorkflowNodeCount is not evidence.
+  assert.equal(activeWorkflowProvenEmpty(null), false);
+  assert.equal(activeWorkflowProvenEmpty(wf({ changeTracker: {} })), false);
+  assert.equal(activeWorkflowProvenEmpty(wf({ changeTracker: { activeState: { nodes: "bad" } } })), false);
+  assert.equal(activeWorkflowProvenEmpty(wf({ changeTracker: { initialState: state(0) } })), false);
+  // Surface content defeats the proof even at zero nodes.
+  assert.equal(
+    activeWorkflowProvenEmpty(wf({ changeTracker: { activeState: { nodes: [], subgraphs: [{ id: "s" }] } } })),
+    false,
+  );
+});
+
+test("graphRootProvenEmpty: requires a present empty _nodes array AND a serializable content-free state", () => {
+  assert.equal(
+    graphRootProvenEmpty(serializedRoot({ nodes: [], links: [], extra: { comfyui_mcp: { workflow_uuid: "u" } } })),
+    true,
+    "the genuine reused blank canvas (identity tag is not content)",
+  );
+  assert.equal(
+    graphRootProvenEmpty({ _nodes: [] }),
+    false,
+    "a bare empty node array without serialize() proves nothing about surfaces",
+  );
+  assert.equal(
+    graphRootProvenEmpty(serializedRoot({ nodes: [], groups: [{ id: 1, title: "g" }] })),
+    false,
+    "non-node surface content defeats the proof",
+  );
+  assert.equal(
+    graphRootProvenEmpty(serializedRoot({ nodes: [{ id: 1, type: "KSampler" }] })),
+    false,
+    "a populated root is not empty",
+  );
+  assert.equal(graphRootProvenEmpty(null), false);
+  assert.equal(graphRootProvenEmpty({}), false);
+});
+
 test("#560: a tracker state omitting optional surfaces does NOT false-mismatch the live canvas it was loaded from", () => {
   // The reconnect / multi-tab recurrence: the canvas IS the active workflow's
   // own graph, but ChangeTracker's state omits surfaces LiteGraph's
@@ -2058,8 +2172,10 @@ test("#560: graphRootMatchesState proves a faithful repaint despite serializer d
 test("#565: a NEW blank workflow after a tagged workflow heals the stale root tag instead of throwing", () => {
   // ComfyUI reuses app.graph across tabs and its clear/configure does not
   // reset graph.extra: a brand-new blank tab inherits the PREVIOUS workflow's
-  // root tag while minting its own identity. Both sides hold ZERO nodes, so no
-  // foreign content can be confused — the guard must re-stamp, not hard-block.
+  // root tag while minting its own identity. Both sides are PROVEN empty — a
+  // clean, well-formed zero-node active state and a serializable root whose
+  // every non-identity surface is empty — so no foreign content can be
+  // confused and the guard re-stamps instead of hard-blocking.
   for (const foreignClaim of ["identity", "none"]) {
     const h = buildDirtyStaleRouteHarness({
       rootUuid: "workflow-prev",
@@ -2067,10 +2183,17 @@ test("#565: a NEW blank workflow after a tagged workflow heals the stale root ta
       activeNodeCount: 0,
       rootNodeCount: 0,
       activeModified: false,
+      rootSerializer: () => ({
+        nodes: [],
+        links: [],
+        groups: [],
+        config: {},
+        extra: { ds: { scale: 1 }, comfyui_mcp: { workflow_uuid: "workflow-prev" } },
+      }),
     });
     assert.doesNotThrow(
       () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: true }),
-      `blank active tab + empty tagged root (${foreignClaim}) must not be rejected`,
+      `blank active tab + provably empty tagged root (${foreignClaim}) must not be rejected`,
     );
     assert.equal(
       h.rootB.extra.comfyui_mcp.workflow_uuid,
@@ -2078,6 +2201,174 @@ test("#565: a NEW blank workflow after a tagged workflow heals the stale root ta
       "the stale tag is re-stamped with the ACTIVE blank workflow's identity",
     );
   }
+});
+
+test("#565 gate: counters/version metadata on a blank canvas does not defeat the proven-empty heal", () => {
+  // LiteGraph rebuilds can leave format metadata (ids/counters/version) on an
+  // otherwise content-free canvas. That metadata is not workflow content, so
+  // the relaxation still fires — real surface CONTENT (next tests) is what
+  // keeps the guard strict.
+  const h = buildDirtyStaleRouteHarness({
+    rootUuid: "workflow-prev",
+    foreignClaim: "none",
+    activeNodeCount: 0,
+    rootNodeCount: 0,
+    activeModified: false,
+    activeTracker: { activeState: { nodes: [], version: 0.4, last_node_id: 7, last_link_id: 3 } },
+    rootSerializer: () => ({
+      id: "graph-uuid",
+      revision: 12,
+      version: 0.4,
+      last_node_id: 7,
+      last_link_id: 3,
+      nodes: [],
+      links: [],
+      extra: { ds: { scale: 1 }, comfyui_mcp: { workflow_uuid: "workflow-prev" }, linkExtensions: [] },
+    }),
+  });
+  assert.doesNotThrow(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: true }),
+    "format metadata must not be mistaken for canvas content",
+  );
+  assert.equal(h.rootB.extra.comfyui_mcp.workflow_uuid, h.stableUuid(h.workflowA));
+});
+
+test("#565 gate: malformed or absent tracker state does NOT prove the active workflow empty — the relaxation fails closed", () => {
+  // activeWorkflowNodeCount() deliberately returns 0 for absent/malformed
+  // state — that is NOT proof of an empty workflow. Without an explicit clean,
+  // well-formed zero-node active state there is no relaxation: the tag
+  // conflict fails closed and the root is never re-stamped.
+  for (const activeTracker of [
+    null, // tracker entirely unreadable
+    {}, // no readable states
+    { activeState: { nodes: "bad" } }, // malformed nodes
+    { activeState: {} }, // state without a nodes array
+    { initialState: state(0) }, // load baseline only — NOT a current-state proof
+  ]) {
+    const h = buildDirtyStaleRouteHarness({
+      rootUuid: "workflow-prev",
+      foreignClaim: "none",
+      activeNodeCount: 0,
+      rootNodeCount: 0,
+      activeModified: false,
+      activeTracker,
+      rootSerializer: () => ({ nodes: [], extra: { comfyui_mcp: { workflow_uuid: "workflow-prev" } } }),
+    });
+    assert.throws(
+      () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: true }),
+      /\[root-workflow-uuid-mismatch\]/,
+      `absent/malformed current state must fail closed: ${JSON.stringify(activeTracker)}`,
+    );
+    assert.equal(
+      h.rootB.extra.comfyui_mcp.workflow_uuid,
+      "workflow-prev",
+      "no re-stamp without a proven-empty active workflow",
+    );
+  }
+});
+
+test("#565 gate: a DIRTY zero-node workflow is not proven empty — a lagging tracker is not evidence", () => {
+  // #545: a dirty workflow's ChangeTracker state can lag the user's real
+  // canvas, so a dirty tab can never prove its canvas is content-free.
+  const h = buildDirtyStaleRouteHarness({
+    rootUuid: "workflow-prev",
+    foreignClaim: "none",
+    activeNodeCount: 0,
+    rootNodeCount: 0,
+    activeModified: true,
+    rootSerializer: () => ({ nodes: [], extra: { comfyui_mcp: { workflow_uuid: "workflow-prev" } } }),
+  });
+  assert.throws(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: true }),
+    /\[root-workflow-uuid-mismatch\]/,
+    "a dirty tab's zero-node tracker read is not an empty-canvas proof",
+  );
+  assert.equal(h.rootB.extra.comfyui_mcp.workflow_uuid, "workflow-prev", "no re-stamp for a dirty tab");
+});
+
+test("#565 gate: an UNSERIALIZABLE empty root is not proven empty — node-level evidence only fails closed", () => {
+  // A bare empty `_nodes` array says nothing about non-node surfaces. Without
+  // serialize() there is no proof the root holds no subgraphs/groups/links,
+  // so the relaxation must not fire (the pre-gate harness root had exactly
+  // this shape and the guard re-stamped it).
+  const h = buildDirtyStaleRouteHarness({
+    rootUuid: "workflow-prev",
+    foreignClaim: "none",
+    activeNodeCount: 0,
+    rootNodeCount: 0,
+    activeModified: false,
+  });
+  assert.throws(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: true }),
+    /\[root-workflow-uuid-mismatch\]/,
+  );
+  assert.equal(h.rootB.extra.comfyui_mcp.workflow_uuid, "workflow-prev", "no re-stamp without full-surface proof");
+});
+
+test("#565 gate: zero nodes with NON-EMPTY surfaces is content — the shape check stays strict", () => {
+  // Removing the blanket zero-node skip: a state with zero nodes but real
+  // surface content (subgraphs, groups, reroutes, links) versus an empty
+  // canvas is a genuine desync and must still mismatch — in BOTH directions.
+  const contentByField = {
+    subgraphs: [{ id: "subgraph-a", nodes: [{ id: 9, type: "SaveImage" }] }],
+    groups: [{ id: 1, title: "kept-group" }],
+    reroutes: [{ id: "reroute-a", pos: [30, 40] }],
+    floatingLinks: [{ id: "floating-a", pos: [10, 20] }],
+    links: [[1, 1, 0, 2, 0, "MODEL"]],
+  };
+  for (const [field, content] of Object.entries(contentByField)) {
+    const activeWorkflow = wf({ changeTracker: { activeState: { nodes: [], [field]: content } } });
+    assert.equal(
+      graphRootMismatchesActiveWorkflow({ rootGraph: serializedRoot({ nodes: [] }), activeWorkflow }),
+      true,
+      `${field}: workflow content missing from the live canvas is a desync even at zero nodes`,
+    );
+    const reverseWorkflow = wf({ changeTracker: { activeState: { nodes: [] } } });
+    assert.equal(
+      graphRootMismatchesActiveWorkflow({ rootGraph: serializedRoot({ nodes: [], [field]: content }), activeWorkflow: reverseWorkflow }),
+      true,
+      `${field}: foreign content on the live canvas is a mismatch even at zero nodes`,
+    );
+  }
+});
+
+test("#565 gate: a zero-node root bearing foreign surface content is never re-stamped through the relaxation", () => {
+  const h = buildDirtyStaleRouteHarness({
+    rootUuid: "workflow-prev",
+    foreignClaim: "none",
+    activeNodeCount: 0,
+    rootNodeCount: 0,
+    activeModified: false,
+    rootSerializer: () => ({
+      nodes: [],
+      subgraphs: [{ id: "subgraph-a", nodes: [{ id: 9, type: "SaveImage" }] }],
+      extra: { comfyui_mcp: { workflow_uuid: "workflow-prev" } },
+    }),
+  });
+  assert.throws(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: true }),
+    /\[root-workflow-uuid-mismatch\]/,
+    "a content-bearing root must stay strict even at zero nodes",
+  );
+  assert.equal(h.rootB.extra.comfyui_mcp.workflow_uuid, "workflow-prev", "foreign content is never re-stamped");
+});
+
+test("#565 gate: a zero-node active STATE bearing surface content does not relax the guard", () => {
+  const h = buildDirtyStaleRouteHarness({
+    rootUuid: "workflow-prev",
+    foreignClaim: "none",
+    activeNodeCount: 0,
+    rootNodeCount: 0,
+    activeModified: false,
+    activeTracker: { activeState: { nodes: [], groups: [{ id: 1, title: "kept-group" }] } },
+    rootSerializer: () => ({ nodes: [], extra: { comfyui_mcp: { workflow_uuid: "workflow-prev" } } }),
+  });
+  assert.throws(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: true }),
+    /\[root-workflow-uuid-mismatch\]/,
+    "surface content in the active state defeats the empty-canvas relaxation",
+  );
+  assert.equal(h.rootB.extra.comfyui_mcp.workflow_uuid, "workflow-prev", "no re-stamp when the workflow still holds content");
 });
 
 test("#565 boundary: the both-empty heal never fires while content exists on EITHER side", () => {

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -91,12 +91,20 @@ const rawKeyedUuidStore = (map) => ({
 //                             canvas, r5): the guard must keep throwing.
 // foreignTab overrides the B object (e.g. a creation-lifecycle product), and
 // registeredOwners/objectUuids override the identity stores the harness wires in.
+// activeNodeCount/rootNodeCount/activeModified parameterize A and the root so
+// the #560 (drifted tag on a matching clean canvas) and #565 (both sides
+// empty) recurrence scenarios can reuse this wiring; defaults preserve the
+// original dirty-A (27) / foreign-root-B (30) setup exactly.
 function buildDirtyStaleRouteHarness({
   rootUuid = "workflow-B",
   foreignClaim = "identity",
   foreignTab = null,
   registeredOwners = null,
   objectUuids: objectUuidsOpt = null,
+  activeNodeCount = 27,
+  rootNodeCount = 30,
+  activeModified = true,
+  activeTracker = null,
 } = {}) {
   const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
   const stableSource = panelFunctionSource(src, "workflowStableUuid", "workflowStorageKey");
@@ -106,13 +114,13 @@ function buildDirtyStaleRouteHarness({
   const lineage = foreignClaim === "active-lineage";
   const staleLineage = foreignClaim === "stale-lineage";
   const workflowA = overlap
-    ? { isPersisted: true, path: "workflows/a.json", isModified: true, changeTracker: { activeState: state(27) } }
+    ? { isPersisted: true, path: "workflows/a.json", isModified: activeModified, changeTracker: { activeState: state(activeNodeCount) } }
     : {
         isPersisted: false,
-        isModified: true,
-        changeTracker: {
+        isModified: activeModified,
+        changeTracker: activeTracker ?? {
           activeState: {
-            ...state(27),
+            ...state(activeNodeCount),
             // "stale-lineage" (r6 P0): the active object's tracker state is
             // LAGGING — it still carries an OLD uuid (a replaced predecessor's
             // residue). Serialized-state evidence is not object-keyed, so this
@@ -131,7 +139,7 @@ function buildDirtyStaleRouteHarness({
           ? null // a live tab whose serialized state is NOT loaded
           : {
               activeState: {
-                ...state(30),
+                ...state(rootNodeCount),
                 // A creation-stamped graph carries the tag in the tab's own
                 // serialized state even when no resolver/owner record observed it.
                 ...(foreignClaim === "tracker-stamp" && rootUuid
@@ -144,7 +152,7 @@ function buildDirtyStaleRouteHarness({
   // PROXIES while the identity stores key on RAW objects.
   const proxyB = vueProxyOf(rawB);
   const rootB = {
-    _nodes: Array.from({ length: 30 }, (_, i) => ({ id: i + 1, type: "KSampler" })),
+    _nodes: Array.from({ length: rootNodeCount }, (_, i) => ({ id: i + 1, type: "KSampler" })),
     ...(rootUuid ? { extra: { comfyui_mcp: { workflow_uuid: rootUuid } } } : {}),
   };
   const openWorkflows =
@@ -505,7 +513,12 @@ test("graphRootMismatchesActiveWorkflow: TRUE - ChangeTracker-relevant non-node 
   }
 });
 
-test("graphRootMismatchesActiveWorkflow: TRUE - missing and explicitly empty/null tracker surfaces differ", () => {
+test("graphRootMismatchesActiveWorkflow: FALSE - omitted vs present-but-empty/null tracker surfaces are serializer dialect (#560/#565)", () => {
+  // ChangeTracker states routinely OMIT optional surfaces that a live
+  // graph.serialize() re-emits as present-but-empty (or null). Presence
+  // strictness turned that dialect into a false binding refusal on the
+  // legitimately-active canvas — the #560 recurrence and the #565 latent
+  // instance. Empty/null now compares EQUAL to absent…
   const activeState = { nodes: [{ id: 1, type: "KSampler" }] };
   const activeWorkflow = wf({ changeTracker: { activeState } });
   for (const [field, replacement] of [
@@ -517,11 +530,28 @@ test("graphRootMismatchesActiveWorkflow: TRUE - missing and explicitly empty/nul
     ["subgraphs", []],
     ["definitions", null],
   ]) {
+    const dialectState = { ...activeState, [field]: replacement };
+    assert.equal(
+      graphRootMismatchesActiveWorkflow({ rootGraph: serializedRoot(dialectState), activeWorkflow }),
+      false,
+      `${field}: present-but-empty must not be confused with workflow content`,
+    );
+  }
+  // …but a PRESENT, NON-empty surface remains content: a canvas that genuinely
+  // has reroutes / links / groups the workflow's state lacks still mismatches
+  // (the #349 wrong-canvas fence is not weakened).
+  for (const [field, replacement] of [
+    ["links", [[1, 1, 0, 2, 0, "MODEL"]]],
+    ["floatingLinks", [{ id: "floating-a", pos: [10, 20] }]],
+    ["reroutes", [{ id: "reroute-a", pos: [30, 40] }]],
+    ["groups", [{ id: 1, title: "group-a" }]],
+    ["subgraphs", [{ id: "subgraph-a", nodes: [{ id: 9, type: "SaveImage" }] }]],
+  ]) {
     const staleState = { ...activeState, [field]: replacement };
     assert.equal(
       graphRootMismatchesActiveWorkflow({ rootGraph: serializedRoot(staleState), activeWorkflow }),
       true,
-      `${field}: missing must not collapse into an explicit value`,
+      `${field}: a non-empty surface the state lacks remains a real mismatch`,
     );
   }
 });
@@ -1889,5 +1919,254 @@ test("#349 snapshots: capture is bound and restore rejects a snapshot from anoth
     revertBody,
     /pickRevertSnapshot\(scopedSnapshots, current\)/,
     "a foreign newer snapshot must not hide an older same-workflow revert",
+  );
+});
+
+// ── #560/#565: reconnect / multi-tab + blank-canvas binding recurrence ──────
+
+test("resolveGraphRootUuidRebind: a stale tag on a BOTH-EMPTY canvas rebinds (#565); anything else stays closed", () => {
+  const tagged = { _nodes: [], extra: { comfyui_mcp: { workflow_uuid: "workflow-prev" } } };
+  assert.equal(
+    resolveGraphRootUuidRebind({
+      rootGraph: tagged,
+      activeWorkflowUuid: "workflow-new",
+      rootTagClaimedByActiveWorkflow: false,
+      staleTagOnEmptyCanvas: true,
+    }),
+    "rebind",
+    "zero content on both sides: the leftover tag is stale metadata, not a foreign canvas",
+  );
+  assert.equal(
+    resolveGraphRootUuidRebind({ rootGraph: tagged, activeWorkflowUuid: "workflow-new", staleTagOnEmptyCanvas: false }),
+    "conflict",
+    "without the both-empty proof the same tag still fails closed (r4/r5)",
+  );
+  assert.equal(
+    resolveGraphRootUuidRebind({ rootGraph: tagged, activeWorkflowUuid: "workflow-prev", staleTagOnEmptyCanvas: true }),
+    "none",
+    "no conflict stays inconclusive, flag or not",
+  );
+});
+
+test("#565: graphRootMismatchesActiveWorkflow is inconclusive when BOTH node arrays are empty", () => {
+  const activeWorkflow = wf({ changeTracker: { activeState: { nodes: [] } } });
+  const liveState = {
+    nodes: [],
+    links: [],
+    groups: [],
+    reroutes: [],
+    config: {},
+    extra: { ds: { scale: 1 }, comfyui_mcp: { workflow_uuid: "workflow-prev" } },
+  };
+  assert.equal(
+    graphRootMismatchesActiveWorkflow({ rootGraph: serializedRoot(liveState), activeWorkflow }),
+    false,
+    "zero content on both sides can never be a confused canvas",
+  );
+});
+
+test("#560: a tracker state omitting optional surfaces does NOT false-mismatch the live canvas it was loaded from", () => {
+  // The reconnect / multi-tab recurrence: the canvas IS the active workflow's
+  // own graph, but ChangeTracker's state omits surfaces LiteGraph's
+  // serialize() emits present-but-empty, and the panel tag lives only on the
+  // live side. That serializer dialect is not a binding mismatch.
+  const trackerState = {
+    nodes: [
+      { id: 1, type: "CheckpointLoader", widgets_values: ["model.safetensors"] },
+      { id: 2, type: "KSampler", widgets_values: [20] },
+      { id: 3, type: "SaveImage" },
+    ],
+    links: [[1, 1, 0, 2, 0, "MODEL"]],
+  };
+  const liveState = {
+    ...structuredClone(trackerState),
+    floatingLinks: [],
+    reroutes: [],
+    groups: [],
+    config: {},
+    subgraphs: [],
+    extra: { ds: { scale: 1.4, offset: [12, -8] }, comfyui_mcp: { workflow_uuid: "drifted-tag" } },
+  };
+  const activeWorkflow = wf({ changeTracker: { activeState: trackerState } });
+  assert.equal(
+    graphRootMismatchesActiveWorkflow({ rootGraph: serializedRoot(liveState), activeWorkflow }),
+    false,
+  );
+});
+
+test("#560: the panel identity tag inside extra is NOT workflow content — tag drift alone is no shape mismatch", () => {
+  // The guard's rebind heal re-stamps the root with the active identity; if the
+  // tag participated in the shape comparison, a tracker capture holding the
+  // PRIOR tag would instantly re-throw after the heal, so a clean tab could
+  // never heal. Tag conflicts are owned by the UUID predicates, not by shape.
+  const trackerState = {
+    nodes: [{ id: 1, type: "KSampler", widgets_values: [20] }],
+    links: [],
+    extra: { comfyui_mcp: { workflow_uuid: "workflow-old" } },
+  };
+  const liveState = {
+    ...structuredClone(trackerState),
+    extra: { comfyui_mcp: { workflow_uuid: "workflow-new" } },
+  };
+  const activeWorkflow = wf({ changeTracker: { activeState: trackerState } });
+  assert.equal(
+    graphRootMismatchesActiveWorkflow({ rootGraph: serializedRoot(liveState), activeWorkflow }),
+    false,
+    "tag drift is judged by the UUID branch with claim/heal semantics, not by content shape",
+  );
+});
+
+test("#560: graphRootMatchesState proves a faithful repaint despite serializer dialect — the recovery that failed", () => {
+  // panel_open_workflow's repaint proof: the just-loaded root serializes with
+  // present-but-empty surfaces and a viewport, while the loaded state (a
+  // ChangeTracker clone) omits them. That asymmetry false-failed the proof and
+  // left a drifted binding with no recovery short of a panel reload.
+  const repaintState = {
+    nodes: [
+      { id: 1, type: "CheckpointLoader", widgets_values: ["model.safetensors"] },
+      { id: 2, type: "KSampler", widgets_values: [20] },
+    ],
+    links: [[1, 1, 0, 2, 0, "MODEL"]],
+    extra: { comfyui_mcp: { workflow_uuid: "workflow-A", workflow_path: "workflows/a.json" } },
+  };
+  const liveAfterRepaint = {
+    ...structuredClone(repaintState),
+    floatingLinks: [],
+    reroutes: [],
+    groups: [],
+    config: {},
+    extra: {
+      ds: { scale: 0.9, offset: [1, 2] },
+      comfyui_mcp: { workflow_uuid: "workflow-A", workflow_path: "workflows/a.json" },
+    },
+  };
+  assert.equal(
+    graphRootMatchesState({ rootGraph: serializedRoot(liveAfterRepaint), state: repaintState }),
+    true,
+    "the proven repaint is accepted even when serialize() re-emits omitted surfaces as empty",
+  );
+  assert.equal(
+    graphRootMatchesState({
+      rootGraph: serializedRoot({ ...structuredClone(repaintState), reroutes: [{ id: "reroute-a", pos: [1, 2] }] }),
+      state: repaintState,
+    }),
+    false,
+    "content strictness is unchanged: a genuinely different canvas still fails the proof",
+  );
+});
+
+test("#565: a NEW blank workflow after a tagged workflow heals the stale root tag instead of throwing", () => {
+  // ComfyUI reuses app.graph across tabs and its clear/configure does not
+  // reset graph.extra: a brand-new blank tab inherits the PREVIOUS workflow's
+  // root tag while minting its own identity. Both sides hold ZERO nodes, so no
+  // foreign content can be confused — the guard must re-stamp, not hard-block.
+  for (const foreignClaim of ["identity", "none"]) {
+    const h = buildDirtyStaleRouteHarness({
+      rootUuid: "workflow-prev",
+      foreignClaim, // previous tab still OPEN and claiming the tag / nobody claims it
+      activeNodeCount: 0,
+      rootNodeCount: 0,
+      activeModified: false,
+    });
+    assert.doesNotThrow(
+      () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: true }),
+      `blank active tab + empty tagged root (${foreignClaim}) must not be rejected`,
+    );
+    assert.equal(
+      h.rootB.extra.comfyui_mcp.workflow_uuid,
+      h.stableUuid(h.workflowA),
+      "the stale tag is re-stamped with the ACTIVE blank workflow's identity",
+    );
+  }
+});
+
+test("#565 boundary: the both-empty heal never fires while content exists on EITHER side", () => {
+  // #389 preserved: an EMPTY root against a workflow that reports nodes still
+  // fails closed — the tag conflict is real and the tag is not rewritten.
+  const readDesync = buildDirtyStaleRouteHarness({
+    rootUuid: "workflow-prev",
+    foreignClaim: "identity",
+    activeNodeCount: 5,
+    rootNodeCount: 0,
+    activeModified: false,
+  });
+  assert.throws(
+    () => readDesync.assertBound(readDesync.rootB, readDesync.rootB, { includeBaselineReadGuard: true }),
+    /\[root-workflow-uuid-mismatch\]/,
+    "empty root + populated workflow still fails closed",
+  );
+  assert.equal(readDesync.rootB.extra.comfyui_mcp.workflow_uuid, "workflow-prev", "no re-stamp on a real conflict");
+
+  // #349 preserved: a FOREIGN NONEMPTY canvas is never re-stamped for a blank
+  // active tab — the wrong-canvas fence protects content exactly as before.
+  const foreignContent = buildDirtyStaleRouteHarness({
+    rootUuid: "workflow-B",
+    foreignClaim: "identity",
+    activeNodeCount: 0,
+    rootNodeCount: 30,
+    activeModified: false,
+  });
+  assert.throws(
+    () => foreignContent.assertBound(foreignContent.rootB, foreignContent.rootB, { includeBaselineReadGuard: true }),
+    /\[root-workflow-uuid-mismatch\]/,
+    "a foreign canvas with content keeps the #349 fence",
+  );
+  assert.equal(foreignContent.rootB.extra.comfyui_mcp.workflow_uuid, "workflow-B", "foreign content is never re-stamped");
+});
+
+test("#560: after reconnect + multi-tab switch the drifted-tag canvas fails closed with a reason code, and the proven re-stamp restores agreement", () => {
+  // panel_list_workflows reports X active (and active_confirmed — a reconnect
+  // -epoch concept independent of this guard) while the root tag drifted to an
+  // unclaimed pre-reconnect identity. The canvas CONTENT is X's own graph, so
+  // the shape branch stays silent; the UUID branch fails closed (the drift is
+  // unprovable inline) and now NAMES the firing predicate. The sanctioned
+  // recovery — panel_open_workflow's proven repaint re-stamp, modeled here —
+  // then restores active/binding agreement.
+  const h = buildDirtyStaleRouteHarness({
+    rootUuid: "workflow-old",
+    foreignClaim: "none", // the tag's owner record is a dead predecessor — nobody live claims it
+    activeNodeCount: 11,
+    rootNodeCount: 11,
+    activeModified: false,
+  });
+  assert.throws(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: true }),
+    /\[root-workflow-uuid-mismatch\]/,
+    "an unprovable drift still fails closed — and is now diagnosable",
+  );
+  assert.equal(h.rootB.extra.comfyui_mcp.workflow_uuid, "workflow-old", "a failed-closed root is never rewritten");
+  h.rootB.extra.comfyui_mcp.workflow_uuid = h.stableUuid(h.workflowA); // the proven repaint re-stamp
+  assert.doesNotThrow(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: true }),
+    "after the proven re-stamp the legitimately-active workflow reads normally",
+  );
+});
+
+test("#565: the guard names the root-shape-mismatch predicate when a genuinely different canvas is mounted", () => {
+  const h = buildDirtyStaleRouteHarness({
+    rootUuid: null,
+    foreignClaim: "none",
+    activeNodeCount: 27,
+    rootNodeCount: 30,
+    activeModified: false,
+  });
+  assert.throws(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: true }),
+    /\[root-shape-mismatch\]/,
+  );
+});
+
+test("#389: the guard names the root-node-count-desync predicate when the canvas reads empty against a populated workflow", () => {
+  const h = buildDirtyStaleRouteHarness({
+    rootUuid: null,
+    foreignClaim: "none",
+    rootNodeCount: 0,
+    activeModified: false,
+    activeTracker: { activeState: { nodes: "bad" }, initialState: state(5) },
+  });
+  assert.throws(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: true }),
+    /\[root-node-count-desync\]/,
+    "the #389 baseline read guard still fires, and now says so",
   );
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -4321,14 +4321,30 @@ function assertGraphBoundToActiveWorkflow(
   // tab's stale canvas — re-stamping either would authorize writes to a graph
   // that is not the active workflow's (r4/r5 P0). The remedy for a genuinely
   // drifted binding the tracker cannot prove is panel_open_workflow's proven
-  // repaint re-stamp.
+  // repaint re-stamp. The ONE exception is the both-empty stale tag below
+  // (#565): with zero nodes on either side there is no content to protect.
   let rootUuidMismatch = graphRootWorkflowUuidMismatches({ rootGraph, activeWorkflowUuid });
   if (rootUuidMismatch) {
     const rootUuid = rootGraph?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD];
     const rootTagClaimedByActiveWorkflow =
       !!activeWorkflow && workflowOwnsRootUuidTag(activeWorkflow, rootUuid);
+    // #565 — a leftover tag on a SHARED, reused app.graph is stale metadata
+    // when NEITHER side holds any nodes: ComfyUI's clear/configure does not
+    // reset graph.extra, so a brand-new blank tab inherits the PREVIOUS
+    // workflow's root tag while minting its own identity. With zero content
+    // on both sides there is no foreign canvas to protect (the #349 fence
+    // protects CONTENT), so the tag is re-stamped with the active identity
+    // instead of hard-blocking every graph tool on an empty canvas. The
+    // root's node array must be a PRESENT empty array (a partial frontend
+    // that hides _nodes stays fail-closed), and the both-empty requirement
+    // keeps the #389 case (empty root while the workflow reports N>0 nodes)
+    // failing closed via the baseline read guard below.
+    const staleTagOnEmptyCanvas =
+      Array.isArray(rootGraph?._nodes) &&
+      rootGraph._nodes.length === 0 &&
+      activeWorkflowNodeCount(activeWorkflow) === 0;
     if (
-      resolveGraphRootUuidRebind({ rootGraph, activeWorkflowUuid, rootTagClaimedByActiveWorkflow }) === "rebind"
+      resolveGraphRootUuidRebind({ rootGraph, activeWorkflowUuid, rootTagClaimedByActiveWorkflow, staleTagOnEmptyCanvas }) === "rebind"
     ) {
       try {
         const extra =
@@ -4354,17 +4370,30 @@ function assertGraphBoundToActiveWorkflow(
     requireDirtyMutationBinding &&
     activeWorkflow?.isModified === true &&
     !graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid });
+  const rootShapeMismatch = graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow });
+  const baselineReadDesync =
+    currentStateTrustworthy &&
+    includeBaselineReadGuard &&
+    graphReadDesynced({ liveNodeCount, activeWorkflow, inSubgraph });
   if (
     rootUuidMismatch ||
     dirtyMutationBindingUnproven ||
-    graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow }) ||
-    (currentStateTrustworthy &&
-      includeBaselineReadGuard &&
-      graphReadDesynced({ liveNodeCount, activeWorkflow, inSubgraph }))
+    rootShapeMismatch ||
+    baselineReadDesync
   ) {
+    // #565 — name the firing predicate. All four branches used to throw the
+    // identical text, so a misfiring guard was undiagnosable and the only
+    // available response was a blind reload/re-open retry loop.
+    const reason = rootUuidMismatch
+      ? "root-workflow-uuid-mismatch"
+      : dirtyMutationBindingUnproven
+        ? "dirty-mutation-binding-unproven"
+        : rootShapeMismatch
+          ? "root-shape-mismatch"
+          : "root-node-count-desync";
     const expected = activeWorkflowNodeCount(activeWorkflow);
     throw new Error(
-      `The live graph is out of sync with the active workflow: the workflow reports ${expected} node(s), ` +
+      `[${reason}] The live graph is out of sync with the active workflow: the workflow reports ${expected} node(s), ` +
         `but the canvas is bound to a different graph. A load, tab switch, or reconnect left this command ` +
         `pointed at the wrong canvas, so it was NOT applied. Re-open the active workflow tab ` +
         `(panel_open_workflow) or reload the panel to rebind the graph, then retry.`,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -252,8 +252,10 @@ import { readyAckCanPromoteBackend } from "./lib/pi-readiness.js";
 import { createRunReconcileSweep } from "./lib/run-reconcile-sweep.js";
 import {
   activeWorkflowNodeCount,
+  activeWorkflowProvenEmpty,
   graphReadDesynced,
   graphRootMismatchesActiveWorkflow,
+  graphRootProvenEmpty,
   graphRootWorkflowUuidMismatches,
   graphRootWorkflowUuidMatches,
   graphRootMatchesState,
@@ -4329,20 +4331,26 @@ function assertGraphBoundToActiveWorkflow(
     const rootTagClaimedByActiveWorkflow =
       !!activeWorkflow && workflowOwnsRootUuidTag(activeWorkflow, rootUuid);
     // #565 — a leftover tag on a SHARED, reused app.graph is stale metadata
-    // when NEITHER side holds any nodes: ComfyUI's clear/configure does not
-    // reset graph.extra, so a brand-new blank tab inherits the PREVIOUS
-    // workflow's root tag while minting its own identity. With zero content
-    // on both sides there is no foreign canvas to protect (the #349 fence
-    // protects CONTENT), so the tag is re-stamped with the active identity
-    // instead of hard-blocking every graph tool on an empty canvas. The
-    // root's node array must be a PRESENT empty array (a partial frontend
-    // that hides _nodes stays fail-closed), and the both-empty requirement
-    // keeps the #389 case (empty root while the workflow reports N>0 nodes)
-    // failing closed via the baseline read guard below.
+    // ONLY when BOTH sides are PROVEN content-free: ComfyUI's clear/configure
+    // does not reset graph.extra, so a brand-new blank tab inherits the
+    // PREVIOUS workflow's root tag while minting its own identity. With
+    // provably zero content anywhere there is no foreign canvas to protect
+    // (the #349 fence protects CONTENT), so the tag is re-stamped with the
+    // active identity instead of hard-blocking every graph tool on an empty
+    // canvas. The proof bar is deliberately high (gate):
+    //   - the root must expose a present empty _nodes array AND serialize()
+    //     to a state whose every non-identity surface is empty (a bare empty
+    //     node array proves nothing about subgraphs/groups/links);
+    //   - the active workflow must be CLEAN (a dirty tracker can lag the
+    //     real canvas, #545) with a well-formed CURRENT serialized state
+    //     whose nodes array is present and empty and whose surfaces are all
+    //     empty — activeWorkflowNodeCount()===0 is NOT proof, since that
+    //     helper returns 0 for absent/malformed reads.
+    // Anything unprovable fails closed, and the #389 case (empty root while
+    // the workflow reports N>0 nodes) still fires via the baseline read
+    // guard below.
     const staleTagOnEmptyCanvas =
-      Array.isArray(rootGraph?._nodes) &&
-      rootGraph._nodes.length === 0 &&
-      activeWorkflowNodeCount(activeWorkflow) === 0;
+      graphRootProvenEmpty(rootGraph) && activeWorkflowProvenEmpty(activeWorkflow);
     if (
       resolveGraphRootUuidRebind({ rootGraph, activeWorkflowUuid, rootTagClaimedByActiveWorkflow, staleTagOnEmptyCanvas }) === "rebind"
     ) {

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -96,6 +96,104 @@ function activeWorkflowCurrentState(activeWorkflow) {
   }
 }
 
+/**
+ * A serialized-surface value holding no content: null/undefined, an empty
+ * array, or a plain object with no own keys. Scalars and non-empty values are
+ * significant (malformed or real content — never silently tolerated).
+ */
+const isEmptySurfaceValue = (value) =>
+  value == null ||
+  (Array.isArray(value) && value.length === 0) ||
+  (typeof value === "object" && Object.keys(value).length === 0);
+
+/**
+ * Serialized-graph FORMAT metadata that is not workflow content: graph ids,
+ * revision/version stamps, and the id counters LiteGraph leaves on a rebuilt
+ * or cleared canvas. Everything else a serialized state carries is compared as
+ * (potential) content by serializedStateProvenEmpty below.
+ */
+const SERIALIZED_FORMAT_METADATA_KEYS = new Set([
+  "id",
+  "revision",
+  "version",
+  "last_node_id",
+  "last_link_id",
+  "last_group_id",
+  "lastGroupId",
+  "last_reroute_id",
+]);
+
+/**
+ * POSITIVE proof that a serialized graph state holds NO workflow content at
+ * all — the empty-canvas relaxation's evidence bar (#565 gate). True only
+ * when `state` is a well-formed serialized graph whose `nodes` is a PRESENT
+ * empty array (a missing/malformed read proves nothing) AND every own
+ * surface outside the format-metadata allowlist is absent-or-empty. Inside
+ * `extra`, `ds` (viewport) and `comfyui_mcp` (the panel's own identity tag)
+ * are not content; any other key must hold an empty value. A single
+ * non-empty subgraphs/groups/reroutes/links surface — or any unknown
+ * non-empty surface — defeats the proof, so a foreign content-bearing canvas
+ * can never be re-stamped through the relaxation.
+ */
+export function serializedStateProvenEmpty(state) {
+  try {
+    if (!state || typeof state !== "object" || Array.isArray(state)) return false;
+    if (!Array.isArray(state.nodes) || state.nodes.length !== 0) return false;
+    for (const [key, value] of Object.entries(state)) {
+      if (key === "nodes" || SERIALIZED_FORMAT_METADATA_KEYS.has(key)) continue;
+      if (key === "extra") {
+        if (value == null) continue;
+        if (typeof value !== "object" || Array.isArray(value)) return false;
+        const { ds: viewport, comfyui_mcp: panelTag, ...workflowExtra } = value;
+        for (const extraValue of Object.values(workflowExtra)) {
+          if (!isEmptySurfaceValue(extraValue)) return false;
+        }
+        continue;
+      }
+      if (!isEmptySurfaceValue(value)) return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * POSITIVE proof that the ACTIVE workflow's own canvas is content-free
+ * (#565 gate). Requires ALL of:
+ *   - the workflow is CLEAN — a dirty tracker state can lag the user's real
+ *     canvas (#545), so a dirty tab can never prove emptiness;
+ *   - the workflow's OWN serialized CURRENT state exists and is well-formed
+ *     (activeWorkflowCurrentState — a missing/malformed read proves nothing,
+ *     and a node COUNT of 0 from a failed read is not evidence either);
+ *   - that state holds no content on any non-identity surface.
+ * Absent or malformed state fails closed: false.
+ */
+export function activeWorkflowProvenEmpty(activeWorkflow) {
+  try {
+    if (activeWorkflow?.isModified === true) return false;
+    return serializedStateProvenEmpty(activeWorkflowCurrentState(activeWorkflow));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * POSITIVE proof that the live ROOT graph is content-free (#565 gate). A bare
+ * empty `_nodes` array is node-level evidence only: without serialize() there
+ * is no way to prove the root holds no non-node content (subgraphs, groups,
+ * links), so an unserializable root fails closed.
+ */
+export function graphRootProvenEmpty(rootGraph) {
+  try {
+    if (!Array.isArray(rootGraph?._nodes) || rootGraph._nodes.length !== 0) return false;
+    if (typeof rootGraph?.serialize !== "function") return false;
+    return serializedStateProvenEmpty(rootGraph.serialize());
+  } catch {
+    return false;
+  }
+}
+
 function graphShape(state) {
   if (!state || !Array.isArray(state.nodes)) return null;
   // Omit counters/version metadata that can legitimately differ after LiteGraph
@@ -115,10 +213,6 @@ function graphShape(state) {
   // canvas that genuinely differs in reroutes / floating links / groups /
   // subgraphs still mismatches (#349 unchanged).
   const EMPTY_SURFACE = { present: false };
-  const isEmptySurfaceValue = (value) =>
-    value == null ||
-    (Array.isArray(value) && value.length === 0) ||
-    (typeof value === "object" && Object.keys(value).length === 0);
   const own = (key) => Object.prototype.hasOwnProperty.call(state, key);
   const surface = (key) => {
     if (!own(key)) return EMPTY_SURFACE;
@@ -138,8 +232,15 @@ function graphShape(state) {
     // false-mismatch a tracker capture that still holds the prior tag (#560).
     // Tag CONFLICTS are owned by the dedicated UUID predicates above, with
     // their claim/heal semantics (#545/#557) — not by this content shape.
+    // The same dialect rule applies INSIDE extra: a key one side emits with an
+    // empty value (e.g. LiteGraph's linkExtensions: []) is not content, so
+    // empty-valued keys are dropped before comparing; a non-empty value stays
+    // significant, and only what remains is compared.
     const { ds: viewport, comfyui_mcp: panelTag, ...workflowExtra } = state.extra;
-    return isEmptySurfaceValue(workflowExtra) ? EMPTY_SURFACE : { present: true, value: workflowExtra };
+    const contentExtra = Object.fromEntries(
+      Object.entries(workflowExtra).filter(([, extraValue]) => !isEmptySurfaceValue(extraValue)),
+    );
+    return Object.keys(contentExtra).length === 0 ? EMPTY_SURFACE : { present: true, value: contentExtra };
   })();
   const shape = {
     // LiteGraph preserves node array order opportunistically, but it does not
@@ -212,10 +313,10 @@ export function graphRootMatchesState({ rootGraph, state } = {}) {
  * is also unavailable, equal counts remain inconclusive and return false. The
  * guard never manufactures a mismatch from partial state.
  *
- * #565 — with ZERO nodes on BOTH sides there is no workflow content that could
- * possibly be confused, so the serializer-dialect surface comparison below is
- * skipped as inconclusive: a brand-new / just-cleared canvas must never be
- * rejected as "bound to a different graph".
+ * #565 — there is deliberately NO blanket zero-node skip: a state with zero
+ * nodes can still carry real content (subgraphs, groups, reroutes, links), and
+ * a genuinely-empty canvas compares equal through the serializer-dialect
+ * normalization above anyway. Zero nodes relaxes nothing.
  */
 export function graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow } = {}) {
   // #545 — ChangeTracker's activeState is a useful *clean-tab* binding witness,
@@ -231,11 +332,6 @@ export function graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow } 
   const live = rootGraph?._nodes;
   if (!Array.isArray(expected) || !Array.isArray(live)) return false;
   if (live.length !== expected.length) return true;
-  // #565 — zero nodes on BOTH sides: no content exists that could be confused,
-  // so the surface comparison below can only manufacture a false mismatch from
-  // serializer dialect (a tracker state omitting what serialize() emits as
-  // present-but-empty). Inconclusive.
-  if (live.length === 0) return false;
 
   // Current LiteGraph can serialize its live ROOT graph. When both sides can be
   // represented, compare the complete semantic shape so equal id:type node sets

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -102,17 +102,44 @@ function graphShape(state) {
   // rebuilds; retain every serialized graph surface ChangeTracker treats as
   // workflow state, so the binding guard cannot accept a different canvas that
   // only differs in reroutes, floating links, or top-level subgraphs.
-  // ChangeTracker distinguishes a missing surface from an explicitly empty or
-  // null one. Preserve that distinction rather than `??`-normalizing it away.
+  //
+  // #560/#565 — a surface ChangeTracker OMITS but LiteGraph's serialize() emits
+  // as present-but-empty (or null) is a serializer DIALECT, not workflow
+  // content: a ChangeTracker state routinely lacks `links`/`groups`/`config`/
+  // `reroutes`/`subgraphs`/`definitions`/`extra` keys that the live root's
+  // serialize() re-emits as `[]`/`{}`/`null`. Comparing presence strictly made
+  // a canvas false-mismatch the very state it was just loaded from — which
+  // broke the workflow_open repaint proof on a drifted binding (#560) and the
+  // empty-canvas read guard (#565). Present-empty therefore compares EQUAL to
+  // absent. NON-empty values keep the full present-vs-absent strictness, so a
+  // canvas that genuinely differs in reroutes / floating links / groups /
+  // subgraphs still mismatches (#349 unchanged).
+  const EMPTY_SURFACE = { present: false };
+  const isEmptySurfaceValue = (value) =>
+    value == null ||
+    (Array.isArray(value) && value.length === 0) ||
+    (typeof value === "object" && Object.keys(value).length === 0);
   const own = (key) => Object.prototype.hasOwnProperty.call(state, key);
-  const surface = (key) => ({ present: own(key), value: state[key] });
+  const surface = (key) => {
+    if (!own(key)) return EMPTY_SURFACE;
+    const value = state[key];
+    return isEmptySurfaceValue(value) ? EMPTY_SURFACE : { present: true, value };
+  };
   const extra = (() => {
-    if (!own("extra")) return { present: false };
-    if (!state.extra || typeof state.extra !== "object") return { present: true, value: state.extra };
-    const { ds: viewport, ...workflowExtra } = state.extra;
-    // A sole `extra.ds` is viewport-only, so it compares like no extra field.
-    if (viewport !== undefined && Object.keys(workflowExtra).length === 0) return { present: false };
-    return { present: true, value: workflowExtra };
+    if (!own("extra")) return EMPTY_SURFACE;
+    if (!state.extra || typeof state.extra !== "object") {
+      // A scalar extra is malformed, not a dialect — keep it significant.
+      return isEmptySurfaceValue(state.extra) ? EMPTY_SURFACE : { present: true, value: state.extra };
+    }
+    // `ds` is the viewport transform and `comfyui_mcp` is the panel's own
+    // identity tag — neither is workflow content. Panning/zooming or an
+    // identity (re)stamp must never manufacture a binding mismatch: a root
+    // re-tagged by the guard's rebind heal would otherwise instantly
+    // false-mismatch a tracker capture that still holds the prior tag (#560).
+    // Tag CONFLICTS are owned by the dedicated UUID predicates above, with
+    // their claim/heal semantics (#545/#557) — not by this content shape.
+    const { ds: viewport, comfyui_mcp: panelTag, ...workflowExtra } = state.extra;
+    return isEmptySurfaceValue(workflowExtra) ? EMPTY_SURFACE : { present: true, value: workflowExtra };
   })();
   const shape = {
     // LiteGraph preserves node array order opportunistically, but it does not
@@ -154,7 +181,12 @@ function graphShape(state) {
  * state. Unlike the ordinary read guard, this does NOT treat missing serializer
  * data or a dirty workflow as inconclusive: callers use it only after they have
  * just asked `loadGraphData` to install `state`, so an absent proof must not turn
- * into a fabricated success.
+ * into a fabricated success. Strictness is about CONTENT: every node and every
+ * non-empty surface must match. Serializer dialect — an optional surface the
+ * state omits but LiteGraph re-emits as present-but-empty, or the panel's own
+ * `extra.comfyui_mcp` identity tag — is NOT content and can never make a
+ * faithful repaint fail this proof (#560: that false negative is what left a
+ * drifted binding with no recovery short of a panel reload).
  */
 export function graphRootMatchesState({ rootGraph, state } = {}) {
   try {
@@ -179,6 +211,11 @@ export function graphRootMatchesState({ rootGraph, state } = {}) {
  * Older/partial frontends fall back to an unordered `id` + `type` shape; if that
  * is also unavailable, equal counts remain inconclusive and return false. The
  * guard never manufactures a mismatch from partial state.
+ *
+ * #565 — with ZERO nodes on BOTH sides there is no workflow content that could
+ * possibly be confused, so the serializer-dialect surface comparison below is
+ * skipped as inconclusive: a brand-new / just-cleared canvas must never be
+ * rejected as "bound to a different graph".
  */
 export function graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow } = {}) {
   // #545 — ChangeTracker's activeState is a useful *clean-tab* binding witness,
@@ -194,6 +231,11 @@ export function graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow } 
   const live = rootGraph?._nodes;
   if (!Array.isArray(expected) || !Array.isArray(live)) return false;
   if (live.length !== expected.length) return true;
+  // #565 — zero nodes on BOTH sides: no content exists that could be confused,
+  // so the surface comparison below can only manufacture a false mismatch from
+  // serializer dialect (a tracker state omitting what serialize() emits as
+  // present-but-empty). Inconclusive.
+  if (live.length === 0) return false;
 
   // Current LiteGraph can serialize its live ROOT graph. When both sides can be
   // represented, compare the complete semantic shape so equal id:type node sets
@@ -265,7 +307,14 @@ export function graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid } =
  *                identity, its own serialized state, or its registered owner
  *                record ties it to the tag): the tag is the active tab's own
  *                lineage, stale relative to its current identity, so the root
- *                is provably its own canvas — re-stamp and proceed;
+ *                is provably its own canvas — re-stamp and proceed. Also when
+ *                `staleTagOnEmptyCanvas` is set (#565): ComfyUI reuses the
+ *                app.graph object across tabs and its clear/configure does NOT
+ *                reset graph.extra, so a brand-new blank tab inherits the
+ *                PREVIOUS workflow's tag while minting its own identity. With
+ *                zero nodes on BOTH sides there is no workflow content that
+ *                could be confused — the #349 fence protects CONTENT — so the
+ *                leftover tag is stale metadata: re-stamp and proceed;
  *   "conflict" — anything else. A tag claimed by a FOREIGN open workflow is the
  *                #349 wrong-canvas case, and a tag NOBODY claims may be a
  *                closed tab's stale canvas — re-stamping either would authorize
@@ -277,9 +326,10 @@ export function resolveGraphRootUuidRebind({
   rootGraph,
   activeWorkflowUuid,
   rootTagClaimedByActiveWorkflow = false,
+  staleTagOnEmptyCanvas = false,
 } = {}) {
   if (!graphRootWorkflowUuidMismatches({ rootGraph, activeWorkflowUuid })) return "none";
-  return rootTagClaimedByActiveWorkflow ? "rebind" : "conflict";
+  return rootTagClaimedByActiveWorkflow || staleTagOnEmptyCanvas ? "rebind" : "conflict";
 }
 
 /**


### PR DESCRIPTION
## Root causes

### #565 — false "live graph is out of sync" on every NEW blank workflow
ComfyUI reuses the `app.graph` object across workflow tabs and its clear/configure does **not** reset `graph.extra`. A brand-new blank tab therefore inherits the PREVIOUS workflow's `extra.comfyui_mcp.workflow_uuid` root tag while `workflowStableUuid()` (deliberately root-blind, #545) mints a fresh identity for it. The guard's UUID branch saw `rootUuid !== activeWorkflowUuid`, the blank tab could not claim the stale tag (its resolver identity differs; the owner record points at the *previous* tab), and `resolveGraphRootUuidRebind` returned `conflict` — so every graph command threw on a canvas with **zero nodes on both sides**, where no foreign content exists that could be confused.

A second, latent instance: `graphRootMismatchesActiveWorkflow()` fell through to the `graphShape()\) surface comparison with both node arrays empty, where ChangeTracker states omitting optional surfaces (`links`/`groups`/`config`/`reroutes`/…) that live `serialize()\) re-emits as present-but-empty — plus the panel's own `extra.comfyui_mcp` tag only existing on the live side — manufactured a false mismatch on any empty canvas.

### #560 — reconnect + multi-tab: list says active + `active_confirmed`, guard says bound-to-different
`active_confirmed` is a reconnect-epoch concept (workflow-open-staleness), independent of the binding guard — hence the disagreement. The post-reconnect identity drift itself (successor object re-resolved while the root tag / owner record still carry the pre-reconnect identity) is the *designed* #558 fail-closed fork; the bug was that nothing could heal it:

1. `graphShape()\) counted the panel-owned `comfyui_mcp` identity tag **and** the present-vs-absent optional-surface dialect as workflow content, so a legitimately-active canvas could false-mismatch its own tracker state — and the #558 rebind heal was self-defeating on clean tabs (re-stamp the root, then the shape branch immediately re-threw because the tracker's captured extra still held the prior tag).
2. The sanctioned recovery, `panel_open_workflow`'s proven repaint, uses `graphRootMatchesState()\) with the same strict comparison — a tracker state omitting surfaces LiteGraph re-emits empty false-failed the proof ("could not prove that the active canvas was rebound"), leaving no remedy short of a panel reload.

## What changed (`web/js/lib/graph-binding.js`, `web/js/comfyui-mcp-panel.js`)

- **Both-empty stale-tag heal (#565):** `resolveGraphRootUuidRebind` gains `staleTagOnEmptyCanvas`; the guard sets it only when the root exposes a **present, empty** `_nodes` array AND the active workflow's own node count is 0 — then re-stamps the root with the active identity and proceeds. Any content on either side behaves exactly as before (#349 foreign-claimed tag still throws; #389 empty-root-vs-populated-workflow still throws).
- **Serializer-dialect tolerance (#560/#565):** `graphShape()\) strips the `comfyui_mcp` namespace from `extra` (identity bookkeeping, not content — tag conflicts remain with the dedicated UUID predicates and their claim/heal semantics) and compares present-but-empty/null **equal to absent** for the optional surfaces. NON-empty surface differences keep full present-vs-absent strictness, so a genuinely different canvas (reroutes, floating links, groups, subgraphs) still mismatches — the #349 wrong-canvas fence is not weakened.
- **Empty-canvas inconclusive (#565):** `graphRootMismatchesActiveWorkflow()` returns false before the surface comparison when both node arrays are empty.
- **Reason codes (#565):** the guard's thrown error is now prefixed with the firing predicate — `[root-workflow-uuid-mismatch]` / `[dirty-mutation-binding-unproven]` / `[root-shape-mismatch]` / `[root-node-count-desync]` — so a misfiring guard is diagnosable instead of forcing blind reload/re-open loops. (The message body, including "so it was NOT applied", is unchanged.)

Net effect on the #560 recurrence: the drifted-but-legitimate canvas no longer false-fires the shape branch; the UUID branch still fails closed on an unprovable drift (now with a reason code), and the documented recovery — `panel_open_workflow`'s proven repaint — actually proves and rebinds, after which active and binding agree.

## Tests

`browser_tests/unit/graph-binding.test.mjs`: **+11 tests** (82 total in file), following the existing pure-lib + source-extraction harness style:

- #565: new blank workflow after a tagged workflow heals (both a foreign-claimed and an unclaimed stale tag); the both-empty heal never fires with content on either side (#389/#349 boundaries); both-empty inconclusiveness.
- #560: reconnect + multi-tab drift — clean active canvas + unclaimed drifted tag fails closed with `[root-workflow-uuid-mismatch]`, root not rewritten, then agrees after the modeled proven-repaint re-stamp; tracker-state-vs-serialize dialect is no mismatch; tag-in-extra asymmetry is no mismatch; `graphRootMatchesState` accepts a faithful repaint despite dialect while still rejecting genuine content differences.
- Reason codes asserted for uuid / shape / baseline branches.
- The pre-existing "missing vs explicitly empty/null surfaces" test was rewritten to the new dialect semantics, with a new counterpart proving non-empty surface differences still mismatch.

`npm run test:unit`: **1648 pass, 0 fail**. `npx -y node@22 --test browser_tests/unit/*.test.mjs` (CI runs node 22): **1648 pass, 0 fail**. `npm run typecheck`: clean.

Fixes #560
Fixes #565