### PR TITLE
release: 0.11.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.37] - 2026-08-03
+
+### Fixed
+- the published Registry pack ships web/js/vendor/ runtime modules again — a bare `vendor/` line in .comfyignore matched at any depth and excluded them from 0.11.33-0.11.36 packs, breaking the panel for Registry installs (#749) (#567)
+- missing_media no longer false-positives on [output]/[input]/[temp]-annotated paths with subfolders — annotation is parsed before probing, against the annotation's root (#743) (#568)
+
 ### Fixed
 - `panel_add_node` / `panel_set_widget` unknown-type errors now point at `get_node_info` (the live /object_info node-class oracle) instead of `panel_search_nodes`, which searches installable Manager packs and can never resolve an exact class_type (mcp#741)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.36"
+version = "0.11.37"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -674,7 +674,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.36";
+const PANEL_VERSION = "0.11.37";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Urgent republish: #567 restored web/js/vendor/ to the pack (Registry installs of 0.11.33-0.11.36 were missing the runtime modules and the panel failed to load). #568/#570 ride the next release.