### PR TITLE
fix(#569): phantom missing_model clears when the node's current widgets resolve a real asset

### DIFF
--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -376,13 +376,25 @@ test("assetCandidateResolvesLive: [output]/[temp]-annotated values are NEVER com
     widgets: [{ name: "image", value: "foo.png [temp]", options: { values: ["foo.png"] } }],
   };
   assert.equal(assetCandidateResolvesLive(graphOf([temp]), 10, "foo.png [temp]", "image"), false);
-  // A file on disk LITERALLY named `foo.png [output]` is listed verbatim — an
-  // EXACT combo hit still resolves it.
+  // A combo entry that LITERALLY ends with `[output]` is just a weird input-root
+  // filename — it must NOT clear the annotated candidate: the value resolves as
+  // `foo.png` in the OUTPUT root (folder_paths.annotated_filepath), on which the
+  // input combo has no verdict. The candidate stays flagged for the /view probe.
   const literal = {
     id: 11,
     widgets: [{ name: "image", value: "foo.png [output]", options: { values: ["foo.png [output]"] } }],
   };
-  assert.equal(assetCandidateResolvesLive(graphOf([literal]), 11, "foo.png [output]", "image"), true);
+  assert.equal(assetCandidateResolvesLive(graphOf([literal]), 11, "foo.png [output]", "image"), false);
+});
+
+test("assetCandidateResolvesLive: a combo entry literally ending `[input]` is a weird filename, NOT proof the bare name exists", () => {
+  // The value resolves as `foo.png` in the input root; a combo listing only the
+  // literal `foo.png [input]` says nothing about `foo.png` — no clear.
+  const node = {
+    id: 12,
+    widgets: [{ name: "image", value: "foo.png [input]", options: { values: ["foo.png [input]"] } }],
+  };
+  assert.equal(assetCandidateResolvesLive(graphOf([node]), 12, "foo.png [input]", "image"), false);
 });
 
 test("isStaleAssetCandidate: stale once fixed by set_widget (subgraph-scoped)", () => {

--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -227,6 +227,164 @@ test("assetCandidateResolvesLive supports a function-valued combo and fails CLOS
   assert.equal(assetCandidateResolvesLive(graphOf([node]), 4, "missing", "ckpt_name"), false);
 });
 
+// ---- #569: widget-shift blame — the node's CURRENT model-carrying widget clears ----
+// A save corrupted by a node-signature change recorded the model filename under an
+// unrelated widget (`control_after_generate`, whose fixed/increment/randomize combo
+// can never contain a filename). After repair the file lives in the REAL model
+// widget (`upscale_model_name`) — the same widget that keeps the candidate alive
+// via the node-wide still-referenced scan — so the live-resolution check must
+// consult it too, or a fully-fixed node reports a phantom missing model forever.
+test("assetCandidateResolvesLive: widget-shift blamed widget — file held+resolved by a DIFFERENT widget clears the candidate (#569)", () => {
+  const node = {
+    id: 803,
+    widgets: [
+      { name: "control_after_generate", value: "fixed", options: { values: ["fixed", "increment", "randomize"] } },
+      { name: "upscale_model_name", value: "4x_foolhardy_Remacri.pth", options: { values: ["4x_foolhardy_Remacri.pth", "other.pth"] } },
+    ],
+  };
+  assert.equal(
+    assetCandidateResolvesLive(graphOf([node]), 803, "4x_foolhardy_Remacri.pth", "control_after_generate"),
+    true,
+  );
+});
+
+test("assetCandidateResolvesLive: a genuinely-missing file held by a widget but NOT offered by any fresh combo still flags (#569 fail-closed)", () => {
+  const node = {
+    id: 804,
+    widgets: [
+      { name: "control_after_generate", value: "fixed", options: { values: ["fixed", "increment", "randomize"] } },
+      { name: "upscale_model_name", value: "gone.pth", options: { values: ["other.pth"] } },
+    ],
+  };
+  assert.equal(
+    assetCandidateResolvesLive(graphOf([node]), 804, "gone.pth", "control_after_generate"),
+    false,
+  );
+});
+
+test("assetCandidateResolvesLive: blamed widget has NO usable combo but the model-carrying widget resolves (#569)", () => {
+  // The blamed widget exists but carries no option list at all (a seed/INT-style
+  // widget the shifted save blamed); the file is held + fresh-combo-listed elsewhere.
+  const node = {
+    id: 805,
+    widgets: [
+      { name: "seed", value: 42 },
+      { name: "ckpt_name", value: "model.safetensors", options: { values: ["model.safetensors"] } },
+    ],
+  };
+  assert.equal(
+    assetCandidateResolvesLive(graphOf([node]), 805, "model.safetensors", "seed"),
+    true,
+  );
+  // Same shape, but the model widget's combo does NOT offer the file → kept.
+  const missing = {
+    id: 806,
+    widgets: [
+      { name: "seed", value: 42 },
+      { name: "ckpt_name", value: "gone.safetensors", options: { values: ["model.safetensors"] } },
+    ],
+  };
+  assert.equal(
+    assetCandidateResolvesLive(graphOf([missing]), 806, "gone.safetensors", "seed"),
+    false,
+  );
+});
+
+test("assetCandidateResolvesLive: the widened clear path still needs a REAL file-carrying widget (no value, no clear)", () => {
+  // No widget literally holds the file (still-referenced would have dropped the
+  // candidate before this runs) — the fallback must not invent a clear.
+  const node = {
+    id: 807,
+    widgets: [
+      { name: "control_after_generate", value: "fixed", options: { values: ["fixed", "increment", "randomize"] } },
+      { name: "upscale_model_name", value: "other.pth", options: { values: ["4x_foolhardy_Remacri.pth", "other.pth"] } },
+    ],
+  };
+  assert.equal(
+    assetCandidateResolvesLive(graphOf([node]), 807, "4x_foolhardy_Remacri.pth", "control_after_generate"),
+    false,
+  );
+});
+
+test("isStaleAssetCandidate: the FULL #569 panel_get_errors verdict — fixed widget-shift node unflags only once the combo is trusted", () => {
+  const node = {
+    id: 803,
+    widgets: [
+      { name: "control_after_generate", value: "fixed", options: { values: ["fixed", "increment", "randomize"] } },
+      { name: "upscale_model_name", value: "4x_foolhardy_Remacri.pth", options: { values: ["4x_foolhardy_Remacri.pth", "other.pth"] } },
+    ],
+  };
+  const candidate = { nodeId: 803, name: "4x_foolhardy_Remacri.pth", widgetName: "control_after_generate" };
+  // Before the authoritative /object_info refresh the combo is NOT trusted: the
+  // candidate is kept (fail-closed) — the refresh gate is what makes the verdict.
+  assert.equal(isStaleAssetCandidate(graphOf([node]), candidate, { trustCombo: false }), false);
+  // After the confirmed refresh the node's CURRENT widgets resolve the file → stale.
+  assert.equal(isStaleAssetCandidate(graphOf([node]), candidate, { trustCombo: true }), true);
+});
+
+test("isStaleAssetCandidate: a genuinely-missing model still reports after a widget-shift repair attempt (#569 fail-closed)", () => {
+  const node = {
+    id: 804,
+    widgets: [
+      { name: "control_after_generate", value: "fixed", options: { values: ["fixed", "increment", "randomize"] } },
+      { name: "upscale_model_name", value: "gone.pth", options: { values: ["other.pth"] } },
+    ],
+  };
+  assert.equal(
+    isStaleAssetCandidate(graphOf([node]), { nodeId: 804, name: "gone.pth", widgetName: "control_after_generate" }, { trustCombo: true }),
+    false,
+  );
+});
+
+// ---- #569 × #743: annotated values in the live-resolution check ---------------
+test("assetCandidateResolvesLive: an [input]-annotated value resolves via its stripped bare name in the combo (#743 composition)", () => {
+  // `foo.png [input]` resolves against the INPUT root — exactly the root the
+  // loader combo enumerates — so the stripped bare name is combo-adjudicable.
+  const node = {
+    id: 9,
+    widgets: [
+      { name: "control_after_generate", value: "fixed", options: { values: ["fixed", "increment", "randomize"] } },
+      { name: "image", value: "foo.png [input]", options: { values: ["foo.png", "bar.png"] } },
+    ],
+  };
+  // …both via the widget that currently carries it (fallback path) …
+  assert.equal(
+    assetCandidateResolvesLive(graphOf([node]), 9, "foo.png [input]", "control_after_generate"),
+    true,
+  );
+  // …and when the blame lands on the carrying widget itself (named path).
+  assert.equal(assetCandidateResolvesLive(graphOf([node]), 9, "foo.png [input]", "image"), true);
+});
+
+test("assetCandidateResolvesLive: [output]/[temp]-annotated values are NEVER combo-resolved (left to the #743 server probe)", () => {
+  // These resolve against the OUTPUT/TEMP roots, which the input combo does not
+  // enumerate — a bare-name combo hit proves nothing, so the candidate must stay
+  // flagged for the /view probe even though the bare name IS listed.
+  const node = {
+    id: 9,
+    widgets: [
+      { name: "control_after_generate", value: "fixed", options: { values: ["fixed", "increment", "randomize"] } },
+      { name: "image", value: "foo.png [output]", options: { values: ["foo.png", "bar.png"] } },
+    ],
+  };
+  assert.equal(
+    assetCandidateResolvesLive(graphOf([node]), 9, "foo.png [output]", "control_after_generate"),
+    false,
+  );
+  const temp = {
+    id: 10,
+    widgets: [{ name: "image", value: "foo.png [temp]", options: { values: ["foo.png"] } }],
+  };
+  assert.equal(assetCandidateResolvesLive(graphOf([temp]), 10, "foo.png [temp]", "image"), false);
+  // A file on disk LITERALLY named `foo.png [output]` is listed verbatim — an
+  // EXACT combo hit still resolves it.
+  const literal = {
+    id: 11,
+    widgets: [{ name: "image", value: "foo.png [output]", options: { values: ["foo.png [output]"] } }],
+  };
+  assert.equal(assetCandidateResolvesLive(graphOf([literal]), 11, "foo.png [output]", "image"), true);
+});
+
 test("isStaleAssetCandidate: stale once fixed by set_widget (subgraph-scoped)", () => {
   const inner = { id: 6077, widgets: [{ name: "model", value: "..._fp8_scaled.safetensors" }] };
   const sub = { id: 6105, subgraph: graphOf([inner]) };

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -12,6 +12,8 @@
  *      the class def wasn't matched at load, even though the live def names them. (#199)
  */
 
+import { parseAnnotatedFilepath } from "./input-asset.js";
+
 const UNKNOWN_WIDGET_RE = /^UNKNOWN(_\d+)?$/;
 
 // A canonical RFC-4122-shaped UUID, as ComfyUI mints for subgraph ids. The strict
@@ -161,25 +163,65 @@ export function assetCandidateStillReferenced(rootGraph, nodeId, file) {
  * combo — i.e. the server already knows the file and the store entry is stale.
  * Fails CLOSED (returns false / "keep it") on any unexpected shape, so a genuinely
  * missing model is never silently swallowed.
+ *
+ * The store's `widgetName` can blame the WRONG widget: a save corrupted by a
+ * node-signature change (widget-shift) records the filename under an unrelated
+ * widget like `control_after_generate`, whose combo can never contain a filename.
+ * After the agent/user repairs the node, the file lives in a DIFFERENT widget
+ * (e.g. `upscale_model_name`) — the same widget that keeps the candidate alive
+ * via assetCandidateStillReferenced's node-wide scan. So once the named-widget
+ * check fails, every widget whose CURRENT value literally holds the file is
+ * consulted too: kept by a node-WIDE check must mean clearable by a node-wide
+ * check, or a fully-fixed node reports a phantom missing model until reload
+ * (#569). The widened clear path stays fail-closed — it reads only combos the
+ * caller has gated as TRUSTED (fresh /object_info), and a genuinely-absent file
+ * is never offered by a fresh combo, so no genuine miss can be suppressed.
+ *
+ * Annotated values (`file.png [input]`/`[output]`/`[temp]`, #743) are parsed with
+ * parseAnnotatedFilepath: an `[input]`-annotated (or bare) value resolves against
+ * the INPUT root — the same root the loader combo enumerates — so the combo can
+ * also adjudicate the stripped bare name. An `[output]`/`[temp]` value resolves
+ * against a DIFFERENT root the combo never lists, so the combo has no verdict on
+ * it: it fails CLOSED here and is left to the #743 /view server probe.
  */
 export function assetCandidateResolvesLive(rootGraph, nodeId, file, widgetName) {
   try {
     if (nodeId == null || !file) return false;
     const node = findNodeByScopedId(rootGraph, nodeId);
     if (!node || !Array.isArray(node.widgets)) return false;
-    const w = widgetName
-      ? node.widgets.find((x) => x?.name === widgetName)
-      : node.widgets.find((x) => Array.isArray(x?.options?.values));
-    if (!w) return false;
-    const raw = w.options?.values;
-    const list = typeof raw === "function" ? raw(w, node) : raw;
     // EXACT membership only. A subfolder-registered model (Impact Subpack's
     // `segm/yolov8m-seg.pt`, #407) is listed by /object_info with the SAME separator
     // the widget value carries, so an exact match resolves it once the combo is
     // trusted (the get_errors authoritative refresh) — no separator normalization,
     // which on POSIX could equate a literal-backslash filename with a distinct
-    // forward-slash one and SUPPRESS a genuine miss.
-    return Array.isArray(list) && list.includes(file);
+    // forward-slash one and SUPPRESS a genuine miss. The single extra relaxation:
+    // an `[input]`-annotated value's stripped BARE name (#743), which the combo
+    // enumerates from the very root the annotation resolves against.
+    const parsed = parseAnnotatedFilepath(file);
+    const comboName =
+      parsed.annotated && parsed.type !== "input" ? null : parsed.name;
+    const comboHasFile = (w) => {
+      if (!w) return false;
+      const raw = w.options?.values;
+      const list = typeof raw === "function" ? raw(w, node) : raw;
+      if (!Array.isArray(list)) return false;
+      if (list.includes(file)) return true;
+      return comboName != null && comboName !== file && list.includes(comboName);
+    };
+    const named = widgetName
+      ? node.widgets.find((x) => x?.name === widgetName)
+      : node.widgets.find((x) => Array.isArray(x?.options?.values));
+    if (comboHasFile(named)) return true;
+    // Widget-shift repair (#569): the blamed widget's own combo can never hold
+    // the file, so also consult the widgets whose CURRENT value literally carries
+    // it — exactly the widgets assetCandidateStillReferenced's node-wide scan
+    // keeps this candidate alive for. A widget still referencing a genuinely
+    // missing file is NOT offered by its fresh combo, so it still flags.
+    for (const w of node.widgets) {
+      if (w === named) continue;
+      if (w?.value === file && comboHasFile(w)) return true;
+    }
+    return false;
   } catch {
     return false;
   }

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -177,36 +177,43 @@ export function assetCandidateStillReferenced(rootGraph, nodeId, file) {
  * caller has gated as TRUSTED (fresh /object_info), and a genuinely-absent file
  * is never offered by a fresh combo, so no genuine miss can be suppressed.
  *
- * Annotated values (`file.png [input]`/`[output]`/`[temp]`, #743) are parsed with
- * parseAnnotatedFilepath: an `[input]`-annotated (or bare) value resolves against
- * the INPUT root — the same root the loader combo enumerates — so the combo can
- * also adjudicate the stripped bare name. An `[output]`/`[temp]` value resolves
- * against a DIFFERENT root the combo never lists, so the combo has no verdict on
- * it: it fails CLOSED here and is left to the #743 /view server probe.
+ * Annotated values (`file.png [input]`/`[output]`/`[temp]`, #743) are classified
+ * with parseAnnotatedFilepath BEFORE any combo probing: an `[output]`/`[temp]`
+ * value resolves against a root the input combo NEVER enumerates, so the combo
+ * has no verdict on it at all — it fails CLOSED here and is left to the #743
+ * /view server probe. Only an UNANNOTATED value (exact raw membership) or an
+ * `[input]`-annotated one (its stripped bare name) may be combo-cleared: both
+ * resolve against the very input root the combo enumerates.
  */
 export function assetCandidateResolvesLive(rootGraph, nodeId, file, widgetName) {
   try {
     if (nodeId == null || !file) return false;
     const node = findNodeByScopedId(rootGraph, nodeId);
     if (!node || !Array.isArray(node.widgets)) return false;
+    // Annotation classification comes FIRST (codex P1): a value that parses as
+    // [output]/[temp]-annotated resolves as its STRIPPED name in the output/temp
+    // root via folder_paths.annotated_filepath. A combo entry that literally
+    // ends with "[output]"/"[temp]" is just a weird input-root filename — even
+    // an EXACT-looking hit proves nothing about the annotated value, so it must
+    // never clear the candidate. Those stay flagged for the #743 /view probe.
+    const parsed = parseAnnotatedFilepath(file);
+    if (parsed.annotated && parsed.type !== "input") return false;
     // EXACT membership only. A subfolder-registered model (Impact Subpack's
     // `segm/yolov8m-seg.pt`, #407) is listed by /object_info with the SAME separator
     // the widget value carries, so an exact match resolves it once the combo is
     // trusted (the get_errors authoritative refresh) — no separator normalization,
     // which on POSIX could equate a literal-backslash filename with a distinct
-    // forward-slash one and SUPPRESS a genuine miss. The single extra relaxation:
-    // an `[input]`-annotated value's stripped BARE name (#743), which the combo
-    // enumerates from the very root the annotation resolves against.
-    const parsed = parseAnnotatedFilepath(file);
-    const comboName =
-      parsed.annotated && parsed.type !== "input" ? null : parsed.name;
+    // forward-slash one and SUPPRESS a genuine miss. For an unannotated value
+    // parsed.name === file (the raw exact match); for an [input]-annotated one
+    // the stripped bare name is adjudicable because it resolves against the very
+    // input root the combo enumerates — and the RAW annotated string is NOT
+    // checked: a literal `foo.png [input]` combo entry is a weird filename, not
+    // proof that `foo.png` exists.
     const comboHasFile = (w) => {
       if (!w) return false;
       const raw = w.options?.values;
       const list = typeof raw === "function" ? raw(w, node) : raw;
-      if (!Array.isArray(list)) return false;
-      if (list.includes(file)) return true;
-      return comboName != null && comboName !== file && list.includes(comboName);
+      return Array.isArray(list) && list.includes(parsed.name);
     };
     const named = widgetName
       ? node.widgets.find((x) => x?.name === widgetName)


### PR DESCRIPTION
Fixes #569.

## Root cause

`panel_get_errors` kept reporting a phantom `missing_model` for a node fully repaired after widget-shift corruption, because of an asymmetry in `web/js/lib/asset-staleness.js`:

- `assetCandidateStillReferenced` scans **all** widgets on the node → finds the repaired filename in its new home (e.g. `upscale_model_name`) → **keeps** the candidate.
- `assetCandidateResolvesLive` (the trusted-fresh-combo clear path) inspected **only** the candidate's recorded `widgetName` (`control_after_generate`, whose `fixed/increment/randomize` combo can never contain a filename) → could **never** clear it.

Kept by a node-wide check, clearable only by a single-widget check → a fully-fixed node reported a phantom missing model until a full page reload.

## Fix

`assetCandidateResolvesLive` now, after the named-widget check fails, also consults the widgets whose **current** value literally holds the file — exactly the widgets that keep the candidate alive via the node-wide still-referenced scan — and clears when their (caller-trust-gated, fresh) combo offers it.

Fail-closed intent is preserved:

- The whole check still runs only under `trustCombo` (confirmed fresh `/object_info` refresh); a genuinely-absent file is never offered by a fresh combo, so no genuine miss can be suppressed (regression-tested).
- Exact combo membership is unchanged (no separator normalization, #407 semantics intact).
- #743 composition: annotated values are parsed with `parseAnnotatedFilepath`. An `[input]`-annotated (or bare) value resolves against the input root the combo enumerates, so its stripped bare name is combo-adjudicable; `[output]`/`[temp]` values resolve against a different root the combo never lists, so they are **never** combo-cleared and stay flagged for the #743 `/view` server probe.

## Tests

New regression tests in `browser_tests/unit/asset-staleness.test.mjs`:

- Widget-shift scenario — corrupted-then-fixed node unflags (direct + full `isStaleAssetCandidate` verdict with/without `trustCombo`).
- Genuinely-missing model still flags (held by a widget but not offered by any fresh combo).
- Blamed widget with no usable combo but model-carrying widget valid → resolves; same shape with the file absent from the combo → kept.
- Fallback requires a widget that literally carries the file (no value, no clear).
- `[input]`-annotated value resolves via stripped bare name; `[output]`/`[temp]` never combo-resolve; a literal verbatim-named file still exact-matches.

`npm run test:unit`: **1679 pass / 0 fail**
`npx -y node@22 --test browser_tests/unit/*.test.mjs`: **1679 pass / 0 fail**
`npm run typecheck`: clean