### PR TITLE
fix(#566): consume the never-persisted predecessor tab on a first save

### DIFF
--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -1501,6 +1501,34 @@ test("#557 r4 control: a GENUINE save-swap successor still carries the pre-save 
   assert.equal(owners.get("uuid-A"), successor, "the successor becomes the uuid's registered owner");
 });
 
+test("#566: a FIRST-SAVE swap (temp tab saved under a real name) carries the identity to the saved successor", async () => {
+  // The #566 first-save shape: a never-persisted "Unsaved Workflow" tab is saved
+  // under a real name — the successor lives at a DIFFERENT path, and the save
+  // CONSUMED the temp predecessor (no ghost tab). The temp tab's identity must
+  // continue onto the saved successor, not die with the consumed tab.
+  const successor = {
+    isPersisted: true,
+    path: "workflows/XYR_SH01_v001.json", // the first save's real file — a NEW path
+    changeTracker: {
+      activeState: { ...state(27), extra: { comfyui_mcp: { workflow_uuid: "uuid-A" } } },
+    },
+  };
+  const { save, svc, objectUuids, owners } = buildProgrammaticSaveHarness({
+    onSave: ({ svc }) => {
+      svc.openWorkflows = [successor]; // the first save CONSUMED the temp predecessor (#566)
+      svc.activeWorkflow = successor;
+      return { producedRecord: successor }; // the trio's produced record IS the successor (r10)
+    },
+  });
+  await save();
+  assert.equal(
+    objectUuids.get(successor),
+    "uuid-A",
+    "the saved successor inherits the temp tab's pre-save identity",
+  );
+  assert.equal(owners.get("uuid-A"), successor, "the successor becomes the uuid's registered owner");
+});
+
 test("#349 r7 P0: a successor with an established CONFLICTING identity is not overwritten by the carry", async () => {
   // The successor proves continuity (its tracker carries the pre-save uuid),
   // but it ALREADY has an established, different WeakMap identity — a

--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -788,16 +788,21 @@ function makeStore147Service({ files = [], active, graph = SAMPLE_GRAPH } = {}) 
   for (const f of files) disk.set(f, JSON.stringify({ seeded: f }))
   const calls = []
   const store = new Map() // path -> in-memory workflow object
+  const openWorkflows = [] // the open tab strip (1.47 openWorkflows)
   // The active source tab is LOADED (the user is editing it): model its live
   // graph via a changeTracker, exactly what save()/saveAs read.
   if (active && active.changeTracker === undefined) {
     active.changeTracker = { activeState: graph, prepareForSave() {} }
   }
-  if (active) store.set(active.path, active)
+  if (active) {
+    store.set(active.path, active)
+    openWorkflows.push(active)
+  }
   const svc = {
     activeWorkflow: active,
     calls,
     disk,
+    openWorkflows,
     // In-memory oracle: returns whatever object the store holds at `path`,
     // INCLUDING the open temporary tab. Never consults disk. Mirrors 1.47's
     // `getWorkflowByPath = e => n.value[e] ?? null`.
@@ -831,8 +836,20 @@ function makeStore147Service({ files = [], active, graph = SAMPLE_GRAPH } = {}) 
       if (wf.changeTracker === null) {
         wf.changeTracker = { activeState: wf._pendingState, prepareForSave() {} }
       }
+      if (!openWorkflows.includes(wf)) openWorkflows.push(wf)
       svc.activeWorkflow = wf
       return wf
+    },
+    // Mirrors 1.47 store `closeWorkflow`: the tab leaves the open strip, and the
+    // path-keyed lookup entry is deleted ONLY for a TEMPORARY workflow — a
+    // persisted one is merely unload()ed and its record STAYS in the lookup.
+    // Never touches disk.
+    async closeWorkflow(wf) {
+      calls.push(['closeWorkflow', wf.path])
+      const i = openWorkflows.indexOf(wf)
+      if (i >= 0) openWorkflows.splice(i, 1)
+      if (wf.isTemporary === true || wf.size === -1) store.delete(wf.path)
+      if (svc.activeWorkflow === wf) svc.activeWorkflow = openWorkflows[0] ?? null
     },
     async saveWorkflow(wf) {
       calls.push(['saveWorkflow', wf.path])
@@ -2249,6 +2266,137 @@ test('panel#363: naming a workflow created by panel_new_workflow (temp tab) SUCC
   assert.ok(svc.calls.some((c) => c[0] === 'saveAs'), 'used the atomic low-level saveAs copy')
   assert.ok(!svc.calls.some((c) => c[0] === 'renameWorkflow'), 'no source file to move — never renamed')
   assert.equal(saved, 'Video Face Detail - Second Stage')
+})
+
+// ---------------------------------------------------------------------------
+// #566 — saving then closing a NEW (never-persisted) workflow must leave NO
+// duplicate modified "Unsaved Workflow" tab. The atomic copy trio activates the
+// saved copy; the first save must CONSUME the never-persisted predecessor tab.
+
+test("#566: a temp tab's first save CONSUMES the temp tab — save-then-close leaves NO ghost Unsaved Workflow", async () => {
+  // The exact #566 repro: a new (never-persisted) tab populated with nodes is saved
+  // under a real name (panel_save_workflow) and then closed (panel_close_workflow).
+  // The atomic copy path activates the SAVED copy but used to leave the original
+  // temporary tab open — a modified, persisted:false "Unsaved Workflow (N)" ghost
+  // that survived the close (the report accumulated 34 of them).
+  const active = {
+    path: 'workflows/Unsaved Workflow (2).json',
+    filename: 'Unsaved Workflow (2).json',
+    directory: 'workflows',
+    isPersisted: false,
+    isTemporary: true,
+    isModified: true // the user populated the canvas
+  }
+  const { svc, existsOnDisk } = makeStore147Service({ active }) // disk EMPTY ⇒ temp 404s
+
+  const details = {}
+  const saved = await saveActiveWorkflow(svc, 'XYR_SH01_v001', { existsOnDisk, details })
+
+  assert.equal(details.mode, 'first-save', 'a never-persisted temp tab is a first save')
+  assert.ok(svc.disk.has('workflows/XYR_SH01_v001.json'), 'saved file persisted')
+  // The predecessor temp tab is CONSUMED: lookup purged and off the open-tab strip.
+  assert.equal(
+    svc.getWorkflowByPath('workflows/Unsaved Workflow (2).json'),
+    null,
+    'the consumed temp tab is purged from the store lookup'
+  )
+  assert.ok(!svc.openWorkflows.includes(active), 'the temp tab left the open-tab strip')
+  const successor = svc.activeWorkflow
+  assert.equal(successor?.path, 'workflows/XYR_SH01_v001.json', 'the saved copy is the active tab')
+  assert.deepEqual(
+    svc.openWorkflows,
+    [successor],
+    'exactly ONE tab remains — the saved successor (no duplicate unsaved tab)'
+  )
+  // r10 wiring for the #557 save-swap identity carry: the save threads its OWN
+  // produced record, so the temp tab's identity can continue onto the successor.
+  assert.equal(details.savedRecord, successor, 'save-produced record threaded for the identity carry')
+  // Closing the saved workflow (panel_close_workflow) then leaves NOTHING behind.
+  await svc.closeWorkflow(successor)
+  assert.deepEqual(svc.openWorkflows, [], 'save-then-close leaves zero tabs — no ghost unsaved tab (#566)')
+  assert.equal(saved, 'XYR_SH01_v001')
+})
+
+test('#566: an auto-named grounding first save also consumes the temp predecessor', async () => {
+  // Same consumption on the no-name grounding path (#330): the ghost must not
+  // linger there either.
+  const active = {
+    path: 'workflows/Unsaved Workflow (3).json',
+    filename: 'Unsaved Workflow (3).json',
+    directory: 'workflows',
+    isPersisted: false,
+    isTemporary: true,
+    isModified: true
+  }
+  const { svc, existsOnDisk } = makeStore147Service({ active })
+
+  await saveActiveWorkflow(svc, undefined, {
+    autoWorkflowName: () => 'Untitled 2026-08-03',
+    existsOnDisk
+  })
+
+  assert.ok(svc.disk.has('workflows/Untitled 2026-08-03.json'), 'auto-named file persisted')
+  assert.equal(
+    svc.getWorkflowByPath('workflows/Unsaved Workflow (3).json'),
+    null,
+    'temp lookup purged after the grounding save'
+  )
+  assert.deepEqual(
+    svc.openWorkflows,
+    [svc.activeWorkflow],
+    'only the grounded successor remains open'
+  )
+})
+
+test("#566: a PERSISTED workflow's Save-As COPY keeps the source tab open (only a first save consumes)", async () => {
+  // The consumption must NEVER touch a real Save-As: copying an already-persisted
+  // workflow deliberately leaves the original tab open (standard Save-As UX).
+  const active = {
+    path: 'workflows/Foo.json',
+    filename: 'Foo.json',
+    directory: 'workflows',
+    isPersisted: true,
+    isTemporary: false
+  }
+  const { svc, existsOnDisk } = makeStore147Service({ files: [active.path], active })
+
+  await saveActiveWorkflow(svc, 'Bar', { existsOnDisk })
+
+  assert.ok(svc.disk.has('workflows/Foo.json'), 'source file preserved')
+  assert.equal(svc.getWorkflowByPath('workflows/Foo.json'), active, 'source lookup untouched')
+  assert.equal(svc.openWorkflows.length, 2, 'BOTH tabs remain — a Save-As copy never consumes the original tab')
+  assert.ok(svc.openWorkflows.includes(active), 'the original tab stays open')
+  assert.equal(svc.activeWorkflow?.path, 'workflows/Bar.json', 'the copy is the active tab')
+})
+
+test('#566: the temp predecessor is NOT consumed when openWorkflow leaves the SOURCE active (no swap occurred)', async () => {
+  // Guard: on an unfaithful frontend whose openWorkflow never activates the copy,
+  // the swap never happened — the visible source tab must stay (and no succession
+  // proof is threaded).
+  const active = {
+    path: 'workflows/Unsaved Workflow.json',
+    filename: 'Unsaved Workflow.json',
+    directory: 'workflows',
+    isPersisted: false,
+    isTemporary: true
+  }
+  const { svc, existsOnDisk } = makeStore147Service({ active })
+  svc.openWorkflow = async (copy) => {
+    svc.calls.push(['openWorkflow', copy.path])
+    // UNFAITHFUL: loads nothing and never activates — the source stays active.
+  }
+
+  const details = {}
+  await saveActiveWorkflow(svc, 'Named', { existsOnDisk, details })
+
+  assert.equal(svc.activeWorkflow, active, 'the source is still the active tab')
+  assert.equal(
+    svc.getWorkflowByPath('workflows/Unsaved Workflow.json'),
+    active,
+    'the source tab was NOT consumed (the swap never happened)'
+  )
+  assert.ok(svc.openWorkflows.includes(active), 'the source tab stays open')
+  assert.equal(details.savedRecord, undefined, 'no succession proof threaded without a swap')
 })
 
 // ---------------------------------------------------------------------------

--- a/browser_tests/unit/workflow-save.test.mjs
+++ b/browser_tests/unit/workflow-save.test.mjs
@@ -2399,6 +2399,57 @@ test('#566: the temp predecessor is NOT consumed when openWorkflow leaves the SO
   assert.equal(details.savedRecord, undefined, 'no succession proof threaded without a swap')
 })
 
+test('#566 P0: a MID-TRIO switch to a DISTINCT tab consumes NOTHING and threads NOTHING (fail safe)', async () => {
+  // Codex-gate regression: the user/reconnect switches to a distinct tab B DURING
+  // the awaited saveWorkflow(copy). The post-trio active tab is then B — NOT the
+  // copy the trio produced. "Whatever is active after the await" is not succession
+  // evidence (the #557 r4/r10 class): without PROOF the active tab IS the produced
+  // copy, the predecessor must NOT be consumed (the cosmetic ghost may stay — never
+  // the data-loss) and details.savedRecord must NOT be threaded to B. Threading B
+  // would arm the #557 carry gate: the forced removal makes the predecessor appear
+  // gone, the threaded record matches the post-save active (B), and B is seeded
+  // with A's uuid — the #349 wrong-canvas bypass the r4 round hardened against.
+  const active = {
+    path: 'workflows/Unsaved Workflow (2).json',
+    filename: 'Unsaved Workflow (2).json',
+    directory: 'workflows',
+    isPersisted: false,
+    isTemporary: true,
+    isModified: true
+  }
+  const { svc, existsOnDisk } = makeStore147Service({ active })
+  const B = {
+    path: 'workflows/Other.json',
+    filename: 'Other.json',
+    directory: 'workflows',
+    isPersisted: true,
+    isTemporary: false,
+    isModified: true,
+    changeTracker: { activeState: { other: true }, prepareForSave() {} }
+  }
+  svc.openWorkflows.push(B) // a DISTINCT open tab the user can switch to
+  // MID-TRIO SWITCH: while the copy's persist awaits, the active tab becomes B.
+  const origSaveWorkflow = svc.saveWorkflow
+  svc.saveWorkflow = async (w) => {
+    await origSaveWorkflow(w)
+    svc.activeWorkflow = B // user/reconnect switch during the awaited persist
+  }
+
+  const details = {}
+  await saveActiveWorkflow(svc, 'XYR_SH01_v001', { existsOnDisk, details })
+
+  assert.ok(svc.disk.has('workflows/XYR_SH01_v001.json'), 'the copy itself still persisted')
+  assert.equal(svc.activeWorkflow, B, 'B is the post-save active tab')
+  assert.equal(
+    svc.getWorkflowByPath('workflows/Unsaved Workflow (2).json'),
+    active,
+    'predecessor NOT consumed on a mid-trio switch (fail safe — the cosmetic ghost stays)'
+  )
+  assert.ok(svc.openWorkflows.includes(active), 'the temp tab remains open')
+  assert.equal(details.savedRecord, undefined, 'savedRecord NOT threaded to the foreign tab B')
+  assert.ok(svc.openWorkflows.includes(B), 'B is untouched')
+})
+
 // ---------------------------------------------------------------------------
 // describeSaveOutcome — the pure mapper from saveActiveWorkflow's AUTHORITATIVE
 // `details.mode` to the tool-result fields, so panel_save_workflow reports what a

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -442,7 +442,12 @@ export async function saveActiveWorkflow(
     // touched. The residual (a concurrent save to the identical brand-new name within
     // that sub-second window, which cannot occur in a single-user session, and cannot
     // retroactively protect a victim file the server already replaced) is upstream-only.
-    const atomicCopy = resolveSaveAsCopy(svc, { reconcileSavedCopy });
+    // Out-param the adapter fills with its PROVEN produced record: the post-trio
+    // active tab, ONLY when token-proof shows it IS the copy the trio just wrote
+    // (#566 codex P0 — "whatever is active after the await" is NOT succession
+    // evidence; a mid-trio switch to a foreign tab must thread/consume NOTHING).
+    const producedRecord = {};
+    const atomicCopy = resolveSaveAsCopy(svc, { reconcileSavedCopy, producedRecord });
     if (atomicCopy) {
       assertExpect(); // #330: still the workflow we probed?
       // Authoritative outcome: a "never-persisted" source (a temp / new_workflow tab
@@ -495,22 +500,26 @@ export async function saveActiveWorkflow(
       // copy's successful persist + post-write clobber check above: a failed save
       // keeps the user's unsaved tab. A PERSISTED source is never consumed — a Save-As
       // copy deliberately leaves the original tab open.
+      //
+      // PROOF GATE (codex P0): consumption requires the adapter's own PROOF that the
+      // post-trio active tab IS the copy the trio produced (producedRecord.record,
+      // token-matched — the same succession-proof class as the #557 r10 carry: the
+      // save's own produced record, never post-await active-tab occupancy). A
+      // user/reconnect switch to a DISTINCT tab during the awaited persist fails that
+      // proof ⇒ consume NOTHING and thread NOTHING (fail safe: the cosmetic ghost
+      // stays — never the #349 wrong-canvas seeding of a foreign tab).
       if (cls === "never-persisted") {
-        // Stamp BEFORE any identity comparison so the source is recognizable through
-        // the store's reactive proxies (the token reflects through a Vue proxy) —
-        // the same mechanism the copy's own cleanup relies on.
-        stampCopyToken(wf);
-        const produced = svc?.activeWorkflow;
-        // Guard: consume the predecessor ONLY when the copy actually took over the
-        // active slot. If openWorkflow left the SOURCE active (an unfaithful
-        // frontend), the swap never happened and the visible tab must stay.
-        if (produced && !isSameCopy(wf, produced)) {
+        const produced = producedRecord.record ?? null;
+        if (produced) {
+          // Stamp BEFORE the identity-safe removal so the source is recognizable
+          // through the store's reactive proxies (the token reflects through a Vue
+          // proxy) — the same mechanism the copy's own cleanup relies on.
+          stampCopyToken(wf);
           removeInMemoryWorkflow(svc, wf);
-          // r10 thread for the #557 save-swap identity carry: the post-save ACTIVE
-          // object IS the record the trio produced (saveAs built it, openWorkflow
-          // activated it, saveWorkflow persisted it) — the ONLY succession proof the
-          // carry accepts. With the predecessor gone, the temp tab's identity can now
-          // continue onto its saved successor instead of dying with the ghost.
+          // r10 thread for the #557 save-swap identity carry: the PROVEN produced
+          // record is the ONLY succession proof the carry accepts. With the
+          // predecessor gone, the temp tab's identity can now continue onto its
+          // saved successor instead of dying with the ghost.
           if (details) details.savedRecord = produced;
         }
       }
@@ -707,8 +716,17 @@ async function probeSourceOnDisk(existsOnDisk, normPath) {
  *   - POST-WRITE CLOBBER DETECTION (P0): after a "successful" persist, verify the
  *     target still holds OUR content; a concurrent save in the server's body-read
  *     window can silently overwrite it (200, not 409) → surface a detected error
- *     instead of a false success. */
-function resolveSaveAsCopy(svc, { reconcileSavedCopy } = {}) {
+ *     instead of a false success.
+ *
+ *  `producedRecord` is an OPTIONAL out-param object the adapter fills with its
+ *  PROVEN produced record (`producedRecord.record = <active tab>`) at a success
+ *  point — ONLY when token-proof shows the post-trio ACTIVE tab IS the copy this
+ *  trio just wrote (#566 codex P0). "Whatever is active after the awaited persist"
+ *  is NOT succession evidence (a user/reconnect switch during saveWorkflow lands
+ *  on a foreign tab); this is the same proof class the #557 r10 carry demands —
+ *  the save's own produced record, never post-await active-tab occupancy. A proof
+ *  failure threads NOTHING (fail safe). */
+function resolveSaveAsCopy(svc, { reconcileSavedCopy, producedRecord } = {}) {
   // `openWorkflow` is MANDATORY for this path, not optional. The object saveAs
   // returns is UNLOADED (no changeTracker → activeState === null), and
   // ComfyWorkflow.save() serializes `activeState ?? null` — so persisting a copy
@@ -777,6 +795,28 @@ function resolveSaveAsCopy(svc, { reconcileSavedCopy } = {}) {
       const prevActive = svc.activeWorkflow;
       const resolvedName = () =>
         baseName(svc.activeWorkflow?.filename) || baseName(copy.filename) || effectiveName;
+      // #566 codex P0 — success exit: thread the trio's PRODUCED record into the
+      // caller's out-param ONLY with PROOF the post-trio active tab IS the copy
+      // this trio just wrote (its proxy-safe token reflects through the store's
+      // reactive proxies). A user/reconnect switch to a DISTINCT tab during the
+      // awaited persist fails the token match ⇒ thread NOTHING (fail safe), so the
+      // caller consumes no predecessor and arms no identity carry for a foreign tab.
+      const finish = () => {
+        try {
+          const activeNow = svc.activeWorkflow;
+          if (
+            activeNow &&
+            isSameCopy(copy, activeNow) &&
+            producedRecord &&
+            typeof producedRecord === "object"
+          ) {
+            producedRecord.record = activeNow;
+          }
+        } catch {
+          /* active unreadable ⇒ no proof ⇒ no thread (fail safe) */
+        }
+        return resolvedName();
+      };
       try {
         await svc.openWorkflow(copy);
         copy.changeTracker?.prepareForSave?.();
@@ -806,7 +846,7 @@ function resolveSaveAsCopy(svc, { reconcileSavedCopy } = {}) {
             // saved copy). markCopyPersisted sets size + resyncs originalContent so the
             // store treats it as a normal saved, unmodified workflow. Report success.
             markCopyPersisted(copy);
-            return resolvedName();
+            return finish();
           }
           if (state === "foreign") {
             // The target holds SOMEONE ELSE's content — our write was clobbered or
@@ -870,7 +910,7 @@ function resolveSaveAsCopy(svc, { reconcileSavedCopy } = {}) {
           );
         }
       }
-      return resolvedName();
+      return finish();
     };
   }
   return null;

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -245,8 +245,10 @@ export async function groundActiveWorkflow(svc, opts = {}) {
  *     source's containing folder, and leaves the original file on disk). NEVER
  *     renameWorkflow() here — that would move/destroy the source (issue #226).
  *   - a never-saved (temporary) workflow that needs a name → also Save-As, which
- *     for a temporary safely renames the in-memory tab to a real file (there is
- *     no source file to consume).
+ *     for a temporary copies the graph into a real file and then CONSUMES the
+ *     never-persisted source tab (its in-memory record only — there is
+ *     provably no source file to destroy), so no modified "Unsaved Workflow"
+ *     ghost tab outlives the save (issue #566).
  *   - otherwise → save in place under the current name (`svc.saveWorkflow`).
  *
  *  `autoWorkflowName` mints a grounding name for a placeholder temporary
@@ -478,6 +480,38 @@ export async function saveActiveWorkflow(
             `save moved the original workflow "${sourcePath}" instead of copying it — ` +
               `the source no longer exists on disk (issue #226)`,
           );
+        }
+      }
+      // #566 FIRST-SAVE PREDECESSOR CONSUMPTION (cls === "never-persisted"). The atomic
+      // trio saves by COPYING: saveAs builds a NEW object at the target, openWorkflow
+      // activates it, saveWorkflow persists it. ComfyUI's own temporary Save-As instead
+      // RENAMES the temp tab (one tab, rekeyed) — so our move-free copy leaves the
+      // never-persisted SOURCE tab open: a modified "Unsaved Workflow (N)" ghost that
+      // outlives both the save AND the later close of the saved tab (the exact #566
+      // repro: panel_save_workflow + panel_close_workflow left 34 modified unsaved
+      // tabs). The save conceptually CONSUMED that tab — its graph now lives in the
+      // persisted copy, and the classifier PROVED no on-disk file backs it — so purge
+      // its IN-MEMORY record (identity-safe, disk untouched). Runs ONLY after the
+      // copy's successful persist + post-write clobber check above: a failed save
+      // keeps the user's unsaved tab. A PERSISTED source is never consumed — a Save-As
+      // copy deliberately leaves the original tab open.
+      if (cls === "never-persisted") {
+        // Stamp BEFORE any identity comparison so the source is recognizable through
+        // the store's reactive proxies (the token reflects through a Vue proxy) —
+        // the same mechanism the copy's own cleanup relies on.
+        stampCopyToken(wf);
+        const produced = svc?.activeWorkflow;
+        // Guard: consume the predecessor ONLY when the copy actually took over the
+        // active slot. If openWorkflow left the SOURCE active (an unfaithful
+        // frontend), the swap never happened and the visible tab must stay.
+        if (produced && !isSameCopy(wf, produced)) {
+          removeInMemoryWorkflow(svc, wf);
+          // r10 thread for the #557 save-swap identity carry: the post-save ACTIVE
+          // object IS the record the trio produced (saveAs built it, openWorkflow
+          // activated it, saveWorkflow persisted it) — the ONLY succession proof the
+          // carry accepts. With the predecessor gone, the temp tab's identity can now
+          // continue onto its saved successor instead of dying with the ghost.
+          if (details) details.savedRecord = produced;
         }
       }
       return activeName;


### PR DESCRIPTION
## Root cause

Fixes #566.

Saving a new (never-persisted) workflow routes through the atomic copy trio in `saveActiveWorkflow` (`saveAs` + `openWorkflow` + `saveWorkflow`, chosen over `renameWorkflow` for #226/#309 atomicity). The **saved copy** becomes the active tab, but nothing ever removed the **original temporary tab** (`workflows/Unsaved Workflow (N).json`) from the store — it stayed in `openWorkflows`, modified and `persisted:false`. ComfyUI's own temporary Save-As renames the temp tab (one tab, rekeyed); the panel's move-free copy left a second tab behind. `panel_close_workflow` then closed only the saved tab, leaving the modified unsaved ghost — 34 of them accumulated in the report (`Unsaved Workflow (3)` … `(36)`).

The #557/#558 save-swap identity carry even assumes this invariant (`preWfStillOpen === false`: "a genuine swap REMOVES the predecessor") — it was never actually performed on the first-save path, so the carry also silently aborted there.

## Fix (`web/js/lib/workflow-save.js`)

When the source classifier proves `never-persisted` (a genuine first save), after the copy's successful persist **and** its post-write clobber check, the predecessor temp tab is consumed:

- identity-safe removal via the existing token-stamped `removeInMemoryWorkflow` (in-memory only — the classifier proved there is no on-disk file; a failed save keeps the user's unsaved tab);
- guarded: skipped if `openWorkflow` never actually swapped the active tab (unfaithful frontend ⇒ the visible tab stays);
- never applied to a **persisted** source — a Save-As copy deliberately keeps the original tab open;
- threads the save-produced record into `details.savedRecord`, so the #557 save-swap identity carry can prove the predecessor→successor swap from the save's own replacement event (its r10 requirement) and the temp tab's identity continues onto its saved successor.

## Tests

- `browser_tests/unit/workflow-save.test.mjs`: the 1.47 store double gains faithful `openWorkflows`/`closeWorkflow` modeling; new tests pin that save-then-close of a first-saved temp tab leaves **zero** tabs (no ghost), the auto-named grounding first save consumes too, a persisted Save-As keeps **both** tabs, and the predecessor survives when no swap occurred.
- `browser_tests/unit/graph-binding.test.mjs`: harness test pinning the first-save identity carry onto the saved successor at its new path.
- `npm run test:unit`: **1676 pass / 0 fail**; `npx -y node@22 --test browser_tests/unit/*.test.mjs`: 1676/0; `npm run typecheck`: clean.