### PR TITLE
fix(#572): scoped run-to-node false "graph CHANGED" refusal from linked value-control widgets

### DIFF
--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -203,6 +203,72 @@ test("#556 r8 collectVolatileInputs: per-NODE pairs (execId + input name) across
   assert.equal(collectVolatileInputs(null).size, 0);
 });
 
+test("#572 collectVolatileInputs: a linked value-control TARGET is excluded — the stock control_after_generate shape", () => {
+  // The frontend hangs beforeQueued on the UNSERIALIZED control combo and the
+  // hook mutates the LINKED, serialized seed (target.linkedWidgets = [control]).
+  // Excluding only the carrier's name covered nothing: the seed re-roll between
+  // our pre-dispatch hash and the deferred serialization false-refused every
+  // scoped run as "graph CHANGED" (WidgetControlMode "before" / pre-#8774 builds).
+  const control = { name: "control_after_generate", value: "randomize", beforeQueued() {}, afterQueued() {} };
+  const seed = { name: "seed", value: 42, linkedWidgets: [control] };
+  const root = { _nodes: [{ id: 3, widgets: [seed, control, { name: "steps", value: 20 }] }] };
+  const pairs = collectVolatileInputs(root);
+  assert.ok(pairs.has("3 seed"), "the serialized re-roll target is volatile");
+  assert.ok(pairs.has("3 control_after_generate"), "the hook carrier's own name stays excluded");
+  assert.ok(!pairs.has("3 steps"), "unrelated inputs stay covered for drift detection");
+});
+
+test("#572 collectVolatileInputs: a FIXED control never mutates, so its target stays drift-covered", () => {
+  const control = { name: "control_after_generate", value: "fixed", beforeQueued() {}, afterQueued() {} };
+  const seed = { name: "seed", value: 42, linkedWidgets: [control] };
+  const pairs = collectVolatileInputs({ _nodes: [{ id: 3, widgets: [seed, control] }] });
+  assert.ok(!pairs.has("3 seed"), "fixed ⇒ no queue-time mutation ⇒ a mid-window edit must still read as drift");
+  assert.ok(pairs.has("3 control_after_generate"), "the carrier self-exclusion is unchanged");
+});
+
+test("#572 collectVolatileInputs: the linked-target exclusion reaches nested subgraphs with the colon-path execId", () => {
+  const control = { name: "control_after_generate", value: "increment", beforeQueued() {} };
+  const noiseSeed = { name: "noise_seed", value: 7, linkedWidgets: [control] };
+  const root = {
+    _nodes: [
+      { id: 10, widgets: [], subgraph: { _nodes: [{ id: 15, widgets: [noiseSeed, control] }] } },
+    ],
+  };
+  const pairs = collectVolatileInputs(root);
+  assert.ok(pairs.has("10:15 noise_seed"), "nested target pairs line up with the flattened prompt keys");
+});
+
+test("#572 promptContentHash: a queue-time re-roll of a linked seed no longer reads as graph drift; a real edit still does", () => {
+  const control = { name: "control_after_generate", value: "randomize", beforeQueued() {} };
+  const seed = { name: "seed", value: 111, linkedWidgets: [control] };
+  const graph = { _nodes: [{ id: 3, widgets: [seed, control, { name: "steps", value: 20 }] }] };
+  const volatileInputs = collectVolatileInputs(graph);
+  // Pre-dispatch fingerprint (seed value as serialized at hash time)…
+  const atHash = promptContentHash(
+    { "3": { class_type: "KSampler", inputs: { seed: 111, steps: 20 } }, "9": { class_type: "SaveImage", inputs: {} } },
+    volatileInputs,
+  );
+  // …the deferred serialization after the queue-time hook re-rolled the seed.
+  const atPost = promptContentHashFromBody(
+    JSON.stringify({ prompt: { "3": { class_type: "KSampler", inputs: { seed: 999983, steps: 20 } }, "9": { class_type: "SaveImage", inputs: {} } } }),
+    volatileInputs,
+  );
+  assert.equal(atPost, atHash, "the hook's own mutation is not drift");
+  const userEdit = promptContentHashFromBody(
+    JSON.stringify({ prompt: { "3": { class_type: "KSampler", inputs: { seed: 999983, steps: 25 } }, "9": { class_type: "SaveImage", inputs: {} } } }),
+    volatileInputs,
+  );
+  assert.notEqual(userEdit, atHash, "a genuine mid-window edit to a non-volatile input is still caught");
+});
+
+test("#572 scopeDroppedError: graph_changed guidance names the retry safety and the queue-time hook cause", () => {
+  const msg = scopeDroppedError({ toNodeId: 116, verdict: { ok: false, reason: "graph_changed" } });
+  assert.match(msg, /node 116/);
+  assert.match(msg, /Retrying is safe \(nothing was queued\)/);
+  assert.match(msg, /queue-time widget hook/);
+  assert.match(msg, /Nothing was queued/);
+});
+
 test("#556 verifyScopedPromptBody: exact scope passes; missing/empty/wrong/extra/unparseable all refuse", () => {
   assert.deepEqual(verifyScopedPromptBody(JSON.stringify({ partial_execution_targets: ["10:15:359"] }), ["10:15:359"]), { ok: true });
   assert.equal(verifyScopedPromptBody(JSON.stringify({ prompt: {} }), ["14"]).reason, "scope_missing");

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -238,27 +238,40 @@ test("#572 collectVolatileInputs: the linked-target exclusion reaches nested sub
   assert.ok(pairs.has("10:15 noise_seed"), "nested target pairs line up with the flattened prompt keys");
 });
 
-test("#572 promptContentHash: a queue-time re-roll of a linked seed no longer reads as graph drift; a real edit still does", () => {
+test("#572 promptContentHash: the narrowed exclusion tolerates ONLY the hook's own input — a seed edit is the documented residual, an edit to any OTHER input of the same node refuses", () => {
   const control = { name: "control_after_generate", value: "randomize", beforeQueued() {} };
   const seed = { name: "seed", value: 111, linkedWidgets: [control] };
   const graph = { _nodes: [{ id: 3, widgets: [seed, control, { name: "steps", value: 20 }] }] };
   const volatileInputs = collectVolatileInputs(graph);
+  // Only the hook-mutated input itself is excluded — never a sibling.
+  assert.deepEqual([...volatileInputs].sort(), ["3 control_after_generate", "3 seed"]);
   // Pre-dispatch fingerprint (seed value as serialized at hash time)…
   const atHash = promptContentHash(
     { "3": { class_type: "KSampler", inputs: { seed: 111, steps: 20 } }, "9": { class_type: "SaveImage", inputs: {} } },
     volatileInputs,
   );
-  // …the deferred serialization after the queue-time hook re-rolled the seed.
-  const atPost = promptContentHashFromBody(
-    JSON.stringify({ prompt: { "3": { class_type: "KSampler", inputs: { seed: 999983, steps: 20 } }, "9": { class_type: "SaveImage", inputs: {} } } }),
-    volatileInputs,
+  const postBody = (inputs) =>
+    JSON.stringify({ prompt: { "3": { class_type: "KSampler", inputs }, "9": { class_type: "SaveImage", inputs: {} } } });
+  // The hook's OWN reroll between serialization and dispatch is not drift…
+  assert.equal(
+    promptContentHashFromBody(postBody({ seed: 999983, steps: 20 }), volatileInputs),
+    atHash,
+    "the queue-time reroll is the exclusion's purpose",
   );
-  assert.equal(atPost, atHash, "the hook's own mutation is not drift");
-  const userEdit = promptContentHashFromBody(
-    JSON.stringify({ prompt: { "3": { class_type: "KSampler", inputs: { seed: 999983, steps: 25 } }, "9": { class_type: "SaveImage", inputs: {} } } }),
-    volatileInputs,
+  // …and a USER edit to that same excluded input is indistinguishable from it:
+  // TOLERATED — the documented accepted residual (surfaced via the run result's
+  // drift_coverage note; no hash can separate "user set 777" from "hook rerolled").
+  assert.equal(
+    promptContentHashFromBody(postBody({ seed: 777, steps: 20 }), volatileInputs),
+    atHash,
+    "accepted residual: a user edit to the hook-mutated input rides the exclusion",
   );
-  assert.notEqual(userEdit, atHash, "a genuine mid-window edit to a non-volatile input is still caught");
+  // A user edit to ANY OTHER input of the SAME node is still caught as drift.
+  assert.notEqual(
+    promptContentHashFromBody(postBody({ seed: 999983, steps: 25 }), volatileInputs),
+    atHash,
+    "a genuine mid-window edit to a non-excluded input of the same node refuses",
+  );
 });
 
 test("#572 scopeDroppedError: graph_changed guidance names the retry safety and the queue-time hook cause", () => {
@@ -467,6 +480,43 @@ test("#556 integration: happy path — marked scoped dispatch observed, prompt_i
     assert.equal(app.posted.length, 1, "first arg shape worked — no retry");
     assert.equal(app.posted[0].number, result.queueMark, "our posts carry THIS run's queue mark");
     assert.deepEqual(app.posted[0].partial_execution_targets, ["14"]);
+  } finally {
+    stop();
+  }
+});
+
+test("#572 integration: the scoped-run result SURFACES the drift-uncovered inputs (hook-mutated inputs are not drift-covered)", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeFrontend({ shape: "shim", apiTarget });
+    // The live graph carries a seed whose linked control re-rolls it at queue time:
+    // that input (and the unserialized carrier) is excluded from the drift hash, so
+    // the run must REPORT the coverage gap rather than claim full-graph drift proof.
+    const control = { name: "control_after_generate", value: "randomize", beforeQueued() {} };
+    const seed = { name: "seed", value: 111, linkedWidgets: [control] };
+    app.graph = { _nodes: [{ id: 3, widgets: [seed, control, { name: "steps", value: 20 }] }] };
+    const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
+    assert.equal(result.outcome, "dispatched");
+    assert.deepEqual(
+      [...(result.volatileInputs ?? [])].sort(),
+      ["3 control_after_generate", "3 seed"],
+      "the run reports exactly which inputs were NOT drift-covered for this run",
+    );
+  } finally {
+    stop();
+  }
+});
+
+test("#572 integration: a graph with NO queue-time hooks reports full drift coverage (no uncovered inputs)", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeFrontend({ shape: "shim", apiTarget });
+    app.graph = { _nodes: [{ id: 3, widgets: [{ name: "seed", value: 111 }, { name: "steps", value: 20 }] }] };
+    const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
+    assert.equal(result.outcome, "dispatched");
+    assert.deepEqual(result.volatileInputs ?? [], [], "nothing excluded ⇒ the whole prompt was drift-covered");
   } finally {
     stop();
   }

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -218,12 +218,29 @@ test("#572 collectVolatileInputs: a linked value-control TARGET is excluded — 
   assert.ok(!pairs.has("3 steps"), "unrelated inputs stay covered for drift detection");
 });
 
-test("#572 collectVolatileInputs: a FIXED control never mutates, so its target stays drift-covered", () => {
+test("#572 collectVolatileInputs: a FIXED carrier never mutates, so NOTHING is excluded — a mid-window edit to its target refuses as drift", () => {
+  // A "fixed" value-control no-ops at queue time: its linked target's input is
+  // NOT volatile, and neither is the carrier's own. Excluding either would mask
+  // a genuine mid-window user edit (codex r2 — the fixed-ness check must GATE
+  // the exclusion, not follow it).
   const control = { name: "control_after_generate", value: "fixed", beforeQueued() {}, afterQueued() {} };
   const seed = { name: "seed", value: 42, linkedWidgets: [control] };
-  const pairs = collectVolatileInputs({ _nodes: [{ id: 3, widgets: [seed, control] }] });
-  assert.ok(!pairs.has("3 seed"), "fixed ⇒ no queue-time mutation ⇒ a mid-window edit must still read as drift");
-  assert.ok(pairs.has("3 control_after_generate"), "the carrier self-exclusion is unchanged");
+  const graph = { _nodes: [{ id: 3, widgets: [seed, control, { name: "steps", value: 20 }] }] };
+  const pairs = collectVolatileInputs(graph);
+  assert.ok(!pairs.has("3 seed"), "fixed ⇒ the target input stays drift-covered");
+  assert.ok(!pairs.has("3 control_after_generate"), "fixed ⇒ the carrier's own input stays drift-covered too");
+  // Hash level: a user edit to the fixed target's serialized input during the
+  // deferred window MUST mismatch — exactly like any other genuine edit.
+  const volatileInputs = collectVolatileInputs(graph);
+  const atHash = promptContentHash(
+    { "3": { class_type: "KSampler", inputs: { seed: 42, steps: 20 } }, "9": { class_type: "SaveImage", inputs: {} } },
+    volatileInputs,
+  );
+  const edited = promptContentHashFromBody(
+    JSON.stringify({ prompt: { "3": { class_type: "KSampler", inputs: { seed: 777, steps: 20 } }, "9": { class_type: "SaveImage", inputs: {} } } }),
+    volatileInputs,
+  );
+  assert.notEqual(edited, atHash, "a mid-window edit to a FIXED control's target refuses as drift");
 });
 
 test("#572 collectVolatileInputs: the linked-target exclusion reaches nested subgraphs with the colon-path execId", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -8206,11 +8206,31 @@ const GRAPH_TOOL_EXECUTORS = {
     // Surface the queued prompt_id(s) so the agent can correlate/track the run —
     // #370 reconciliation and mcp#531 (panel_run must return the prompt_id even
     // when a render is already running) both depend on this being reported.
-    return buildQueueAcceptResult({
+    const accept = buildQueueAcceptResult({
       batchCount: batch,
       promptIds: queuedPromptIds,
       ranToNode: partialTargets ? Number(to_node_id) : null,
     });
+    // #572 — TRUTHFUL drift-coverage note for a scoped run: the drift hash
+    // excluded queue-time hook inputs (beforeQueued carriers + their linked,
+    // serialized targets — e.g. a control_after_generate seed reroll). A user
+    // edit to exactly THOSE inputs during the queue window is indistinguishable
+    // from the hook's own mutation (accepted residual), so the result names the
+    // uncovered inputs instead of implying full-graph drift proof. Every other
+    // input was covered.
+    const uncovered = runScopeResult?.volatileInputs;
+    if (partialTargets && Array.isArray(uncovered) && uncovered.length) {
+      accept.drift_coverage = {
+        covered: "partial",
+        uncovered_inputs: uncovered,
+        note:
+          "These queue-time hook inputs (beforeQueued, e.g. a control_after_generate seed " +
+          "reroll) were excluded from this run's graph-drift check: a user edit to exactly " +
+          "these inputs during the queue window is indistinguishable from the hook's own " +
+          "mutation and would NOT have been caught. Every other input was drift-covered.",
+      };
+    }
+    return accept;
   },
 
   // WHY IS THAT NODE RED? — the single error surface. LiteGraph only sets a

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -65,16 +65,19 @@
 //
 //  - The prompt CONTENT HASH (r7) must be computable BEFORE dispatch: a
 //    stable hash of the full queued prompt — node ids, class types, links,
-//    every input/widget value — excluding ONLY the inputs of widgets that
-//    self-mutate at queue time (beforeQueued seeds and the like), which
-//    change between any two serializations of the SAME graph by design. A
-//    topology-only fingerprint is insufficient: a busy queue defers
-//    serialization to post time, and a user edit in between (a changed
-//    widget value, a rewired link) leaves node ids/types untouched while
-//    rendering a DIFFERENT workflow — the guard refuses that drifted post
-//    and the run ends with a truthful "the graph changed" error. If the
-//    hash can't be computed at all (graphToPrompt failed), the run FAILS
-//    CLOSED: it refuses upfront and never calls queuePrompt.
+//    every input/widget value — excluding ONLY the inputs that self-mutate at
+//    queue time (beforeQueued hooks: seed widgets re-rolled by their linked
+//    control_after_generate, and the hook widgets themselves), which change
+//    between any two serializations of the SAME graph by design (#572: the
+//    exclusion must reach the hook's serialized TARGET, not just the
+//    unserialized control the hook hangs on). A topology-only fingerprint is
+//    insufficient: a busy queue defers serialization to post time, and a user
+//    edit in between (a changed widget value, a rewired link) leaves node
+//    ids/types untouched while rendering a DIFFERENT workflow — the guard
+//    refuses that drifted post and the run ends with a truthful "the graph
+//    changed" error. If the hash can't be computed at all (graphToPrompt
+//    failed), the run FAILS CLOSED: it refuses upfront and never calls
+//    queuePrompt.
 //
 // Extracted as a pure module so the SAME orchestration graph_run runs is
 // drivable from `node --test` (the live app.queuePrompt path can't be).
@@ -139,14 +142,17 @@ const fnv1aHex = (s) =>
  * in between (a changed widget value, a rewired link) leaves the topology
  * untouched while rendering a DIFFERENT workflow.
  *
- * The ONLY values excluded are inputs whose OWNING widget self-mutates at
- * queue time (a `beforeQueued` hook — stock seed widgets with
- * control_after_generate, etc.): those change between any two serializations
- * of the SAME graph by design, so hashing them would refuse our own dispatch.
- * Exclusions are PER-NODE pairs (prompt node id + input name, r8): an edit to
- * a NON-hook node's same-named input is still detected as drift, and a prompt
- * node that can't be resolved to a live node carrying the hook gets NO
- * exclusions (fail toward detecting drift).
+ * The ONLY values excluded are inputs that self-mutate at queue time (a
+ * `beforeQueued` hook — stock seed widgets re-rolled by their linked
+ * control_after_generate, third-party hook widgets, etc.): those change
+ * between any two serializations of the SAME graph by design, so hashing them
+ * would refuse our own dispatch. Exclusions are PER-NODE pairs (prompt node id
+ * + input name, r8): an edit to a NON-hook node's same-named input is still
+ * detected as drift, and a prompt node that can't be resolved to a live node
+ * carrying the hook gets NO exclusions (fail toward detecting drift). #572:
+ * the stock hook rides on the unserialized control widget and mutates its
+ * LINKED target, so the exclusion follows the linkedWidgets convention to the
+ * serialized target (see collectVolatileInputs).
  */
 export function promptContentHash(output, volatileInputs = null) {
   if (!output || typeof output !== "object") return null;
@@ -182,19 +188,48 @@ export function promptContentHashFromBody(bodyText, volatileInputs = null) {
  * same path buildNodeExecutionId produces, so pairs line up with the keys of
  * the API prompt. These are the ONLY values the content hash excludes —
  * everything a user can edit, on any other node, is covered.
+ *
+ * #572 — the stock control_after_generate hook is NOT on the serialized
+ * widget: the frontend hangs `beforeQueued` on the control combo (serialize:
+ * false — it never even reaches the prompt) and the hook mutates the LINKED
+ * TARGET (the seed / noise_seed / cycled combo), which IS serialized
+ * (ComfyUI_frontend widgets.ts: `targetWidget.linkedWidgets = [controlWidget]`;
+ * the queue processor fires the hook before serializing the post body).
+ * Excluding only the carrier's own name therefore covered nothing, and any
+ * frontend/mode where the mutation lands between our pre-dispatch hash and the
+ * deferred serialization (WidgetControlMode "before"; pre-#8774 frontends on a
+ * partial execution; third-party hooks following the same linkedWidgets
+ * convention) false-refused EVERY scoped run as "graph CHANGED" — nothing
+ * queued, no concurrent edit. So for each carrier `w` we ALSO exclude every
+ * sibling target `t` with `t.linkedWidgets` containing `w` — unless the
+ * carrier's mode is the string "fixed", which never mutates (a fixed control
+ * leaves the target fully covered, so a genuine mid-window user edit to it is
+ * still detected as drift).
  */
 export function collectVolatileInputs(rootGraph) {
   const pairs = new Set();
   const seen = new Set();
+  const addPair = (execId, name) => {
+    if (name != null) pairs.add(`${execId} ${String(name)}`);
+  };
   const walk = (graph, prefix) => {
     if (!graph || seen.has(graph)) return;
     seen.add(graph);
     for (const node of graph._nodes ?? []) {
       if (!node || node.id == null) continue;
       const execId = prefix ? `${prefix}:${node.id}` : String(node.id);
-      for (const w of node.widgets ?? []) {
-        if (typeof w?.beforeQueued === "function" && w.name != null) {
-          pairs.add(`${execId} ${String(w.name)}`);
+      const widgets = node.widgets ?? [];
+      for (const w of widgets) {
+        if (typeof w?.beforeQueued !== "function") continue;
+        // The carrier's own input (third-party hooks that mutate their own
+        // serialized value; a no-op for the serialize:false stock control).
+        addPair(execId, w.name);
+        // #572 — the serialized TARGET(s) of a linked value-control hook.
+        if (w.value === "fixed") continue;
+        for (const t of widgets) {
+          if (Array.isArray(t?.linkedWidgets) && t.linkedWidgets.includes(w)) {
+            addPair(execId, t.name);
+          }
         }
       }
       if (node.subgraph) walk(node.subgraph, execId);
@@ -263,7 +298,11 @@ export function scopeDroppedError({ toNodeId, verdict }) {
   const detail =
     verdict?.reason === "graph_changed"
       ? `the workflow graph CHANGED after the run was queued — the deferred ` +
-        `dispatch would render a modified workflow, not the one that was scoped`
+        `dispatch would render a modified workflow, not the one that was scoped. ` +
+        `Retrying is safe (nothing was queued); if this recurs without any edit in ` +
+        `between, a queue-time widget hook is mutating values between serialization ` +
+        `and dispatch (e.g. a control_after_generate widget with WidgetControlMode ` +
+        `"before" — switch it to "after" or fix the target widget's value)`
       : verdict?.reason === "scope_mismatch"
         ? `the POST /prompt body carried partial_execution_targets ` +
           `${JSON.stringify(verdict.got)} instead of ${JSON.stringify(verdict.expected)}`

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -201,10 +201,11 @@ export function promptContentHashFromBody(bodyText, volatileInputs = null) {
  * partial execution; third-party hooks following the same linkedWidgets
  * convention) false-refused EVERY scoped run as "graph CHANGED" — nothing
  * queued, no concurrent edit. So for each carrier `w` we ALSO exclude every
- * sibling target `t` with `t.linkedWidgets` containing `w` — unless the
- * carrier's mode is the string "fixed", which never mutates (a fixed control
- * leaves the target fully covered, so a genuine mid-window user edit to it is
- * still detected as drift).
+ * sibling target `t` with `t.linkedWidgets` containing `w`. A carrier whose
+ * value is the string "fixed" never mutates anything, so the fixed-ness check
+ * GATES the exclusion (codex r2): a fixed carrier excludes NOTHING — not its
+ * own input, not its target's — and a mid-window user edit to either still
+ * refuses as drift.
  *
  * ACCEPTED RESIDUAL (codex gate, documented deliberately): the exclusion is
  * narrowed to exactly the input(s) the hook mutates — each linked target's own
@@ -233,11 +234,15 @@ export function collectVolatileInputs(rootGraph) {
       const widgets = node.widgets ?? [];
       for (const w of widgets) {
         if (typeof w?.beforeQueued !== "function") continue;
+        // A "fixed" value-control no-ops at queue time: NEITHER its own input
+        // NOR its linked target is volatile. The fixed-ness check must GATE the
+        // exclusion, not follow it — excluding anything for a fixed carrier
+        // would mask a genuine mid-window user edit as drift-blind (codex r2).
+        if (w.value === "fixed") continue;
         // The carrier's own input (third-party hooks that mutate their own
         // serialized value; a no-op for the serialize:false stock control).
         addPair(execId, w.name);
         // #572 — the serialized TARGET(s) of a linked value-control hook.
-        if (w.value === "fixed") continue;
         for (const t of widgets) {
           if (Array.isArray(t?.linkedWidgets) && t.linkedWidgets.includes(w)) {
             addPair(execId, t.name);

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -205,6 +205,18 @@ export function promptContentHashFromBody(bodyText, volatileInputs = null) {
  * carrier's mode is the string "fixed", which never mutates (a fixed control
  * leaves the target fully covered, so a genuine mid-window user edit to it is
  * still detected as drift).
+ *
+ * ACCEPTED RESIDUAL (codex gate, documented deliberately): the exclusion is
+ * narrowed to exactly the input(s) the hook mutates — each linked target's own
+ * serialized input — but a USER edit to one of THOSE SAME inputs inside the
+ * deferred window (e.g. seed 111 → 777 while the post is pending) is
+ * inherently indistinguishable from the hook's own reroll and is therefore
+ * TOLERATED, not refused. This is the narrowest possible gap: an edit to ANY
+ * OTHER input of the same node (or any input anywhere else) still mismatches
+ * the hash and refuses the dispatch. The gap is never silent: dispatchScopedRun
+ * returns these pairs as `volatileInputs`, and graph_run surfaces them in the
+ * run result's `drift_coverage` note so the caller knows which inputs were not
+ * drift-covered for that run.
  */
 export function collectVolatileInputs(rootGraph) {
   const pairs = new Set();
@@ -662,7 +674,10 @@ export function cancelPendingScopedQueueItem(app, { runTag, queueMark } = {}) {
  * sentinel decision, and the finally-restore) is what the unit tests drive.
  *
  * Returns a discriminated result (never throws for queue outcomes), always
- * carrying the run's unique `queueMark`:
+ * carrying the run's unique `queueMark` and — once the prompt was fingerprinted
+ * — `volatileInputs`: the sorted "execId inputName" pairs this run did NOT
+ * drift-cover (queue-time hook inputs; see collectVolatileInputs' ACCEPTED
+ * RESIDUAL note), so the caller can state the coverage gap honestly:
  *  - { outcome: "dispatched",   queueMark }  our scoped dispatch was OBSERVED
  *    (prompt_ids / a server rejection captured via the callbacks);
  *  - { outcome: "refused",      queueMark, error }  every argument shape
@@ -718,6 +733,12 @@ export async function dispatchScopedRun({
   if (!contentHash) {
     return { outcome: "unverifiable", queueMark: mark, error: scopeUnattributableError({ toNodeId }) };
   }
+  // #572 — the inputs this run does NOT drift-cover (queue-time hook inputs:
+  // hook carriers plus their linked, serialized targets). Surfaced on every
+  // post-hash outcome so the caller can report the coverage gap truthfully
+  // instead of implying full-graph drift proof (see collectVolatileInputs'
+  // ACCEPTED RESIDUAL note).
+  const volatileList = volatileInputs ? [...volatileInputs].sort() : [];
   // Ownership tag for the timeout cancellation (see QUEUE_ITEM_TAG).
   const runTag = Symbol("cmcp-scoped-run");
   try {
@@ -766,6 +787,7 @@ export async function dispatchScopedRun({
             outcome: "unverified",
             queueMark: mark,
             verified,
+            volatileInputs: volatileList,
             error: scopeUnverifiedError({ toNodeId, timeoutMs: verifyTimeoutMs, cancelled: true, verified, batch }),
           };
         }
@@ -774,6 +796,7 @@ export async function dispatchScopedRun({
           outcome: "unverified",
           queueMark: mark,
           verified,
+          volatileInputs: volatileList,
           error: scopeUnverifiedError({ toNodeId, timeoutMs: verifyTimeoutMs, cancelled: false, verified, batch }),
         };
       }
@@ -798,6 +821,7 @@ export async function dispatchScopedRun({
         outcome: "failed",
         queueMark: mark,
         verified: guard.state.observed,
+        volatileInputs: volatileList,
         error: guard.state.failed +
           (keepGuardInstalled
             ? " The scope guard stays installed as a sentinel for the rest of this page session."
@@ -808,17 +832,17 @@ export async function dispatchScopedRun({
     // established rejection channel — the run "dispatched" and ComfyUI said
     // no; graph_run's summarizePromptRejection surfaces it, never queued:true.
     if (guard.state.rejected > 0) {
-      return { outcome: "dispatched", queueMark: mark, verified: guard.state.observed };
+      return { outcome: "dispatched", queueMark: mark, verified: guard.state.observed, volatileInputs: volatileList };
     }
     // The FULL batch verified — genuinely dispatched (r5: never on a partial).
     if (guard.state.observed >= batch) {
-      return { outcome: "dispatched", queueMark: mark, verified: guard.state.observed };
+      return { outcome: "dispatched", queueMark: mark, verified: guard.state.observed, volatileInputs: volatileList };
     }
     // r7 CONTENT DRIFT with ZERO verified posts is NOT an argument-shape
     // problem — retrying the other shape would produce the same drifted post.
     // Terminal refusal naming that the graph changed under the deferred item.
     if (guard.state.observed === 0 && guard.state.droppedReason === "graph_changed") {
-      return { outcome: "refused", queueMark: mark, verified: 0, error: guard.state.dropped };
+      return { outcome: "refused", queueMark: mark, verified: 0, volatileInputs: volatileList, error: guard.state.dropped };
     }
     // A corrupted post with ZERO verified posts means this argument SHAPE was
     // dropped by the frontend — nothing was queued, so retrying the other
@@ -836,6 +860,7 @@ export async function dispatchScopedRun({
       outcome: "refused",
       queueMark: mark,
       verified: guard.state.observed,
+      volatileInputs: volatileList,
       error: scopePartialBatchError({
         toNodeId,
         verified: guard.state.observed,
@@ -845,5 +870,5 @@ export async function dispatchScopedRun({
       }),
     };
   }
-  return { outcome: "refused", queueMark: mark, verified: 0, error: dropped };
+  return { outcome: "refused", queueMark: mark, verified: 0, volatileInputs: volatileList, error: dropped };
 }


### PR DESCRIPTION
## Summary

Fixes artokun/comfyui-mcp-panel#572

- `collectVolatileInputs` excluded only inputs whose **own** widget carries `beforeQueued`. The stock `control_after_generate` hook lives on the **unserialized** control combo (`serialize: false`) and mutates its **linked, serialized target** (seed / noise_seed / cycled combo) — `targetWidget.linkedWidgets = [controlWidget]` in ComfyUI_frontend, fired by the queue processor between the panel's pre-dispatch hash and the deferred serialization. The exclusion therefore covered nothing, and any frontend/mode where the mutation lands in that window false-refused **every** scoped run as `graph CHANGED` — nothing queued, no concurrent edit.
- The exclusion now follows the `linkedWidgets` convention to the serialized target (root and nested-subgraph colon paths), unless the control's mode is `"fixed"` — a fixed control never mutates, so a genuine mid-window user edit to the target is still detected as drift.
- The `graph_changed` refusal now guides correctly: retrying is safe (nothing was queued), and it names the queue-time-hook cause with the `WidgetControlMode` remedy.

## Root cause

`panel_run({to_node_id})` fingerprints the prompt before dispatch and re-hashes the actual POST /prompt body (`#556`/`#559` guard). On the reporter's frontend (ComfyUI 0.27.0 era, predating Comfy-Org/ComfyUI_frontend#8774 which skipped control-after-generate for partial executions) with a queue-time control hook, the seed re-roll landed exactly between those two serializations: the hash mismatched, the guard correctly refused its own "drifted" dispatch — but the drift was the hook's own intended per-run mutation, not a user edit. The guard was misfiring (false drift), and the error gave no recovery path.

## Invariants preserved

- `#556`: a scope-dropped/corrupted/drifted dispatch is still refused before it leaves the browser — only inputs that self-mutate at queue time by design are excluded, per-node, and `fixed`-mode targets stay covered.
- No change to run-target resolution, the queue-mark/sentinel identity model, or the unscoped run path.

## Validation

- `browser_tests/unit/run-scope-guard.test.mjs` +5 (linked-target exclusion, fixed-mode boundary, nested-subgraph path, re-roll-vs-real-edit hash, refusal guidance)
- `npm run test:unit` — 1676 pass; `npx -y node@22 --test browser_tests/unit/*.test.mjs` — 1676 pass; `npm run typecheck` clean

## Note on #573

Also investigated artokun/comfyui-mcp-panel#573 (canvas binding stale after save): that shape is **already fixed on main by #570** (merged, unreleased) — the serializer-dialect false mismatch in `graphRootMismatchesActiveWorkflow`, the `graphRootMatchesState` repaint proof that left `workflow_open` unable to prove a rebind, and the `comfyui_mcp` tag counted as content. Both #573 repros predate the merge (0.11.35/0.11.36). Closing evidence is in the issue; it just needs the next release.