### PR TITLE
release: 0.11.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.38] - 2026-08-03
+
+### Fixed
+- missing_media no longer false-positives on [output]/[input]/[temp]-annotated paths (annotation parsed per folder_paths.annotated_filepath exactly, unspaced and clamp cases included) (#743) (#568)
+- the binding guard heals proven drift after a reconnect/multi-tab switch and only ever re-stamps a stale root tag on a proven-clean, proven-empty canvas; non-empty surfaces stay strict both ways (#560, #565) (#570)
+- phantom missing_model clears when the node's CURRENT widgets resolve a real asset (widget-shift repair); annotated values are classified before combo membership so [output]/[temp] can never be combo-cleared (#569) (#574)
+- a first save consumes the temporary Unsaved tab via its proven produced record — no more duplicate modified Unsaved tabs, and the save-swap identity carry fires correctly (#566) (#575)
+
 ## [0.11.37] - 2026-08-03
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.37"
+version = "0.11.38"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -675,7 +675,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.37";
+const PANEL_VERSION = "0.11.38";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Version bump + changelog for 0.11.38: #568 (annotation parity), #570 (binding heal), #574 (phantom missing_model + annotation ordering), #575 (first-save ghost tabs + carry proof). All codex-gated SHIP + CI-green.