### PR TITLE
fix(#560): refuse the false-empty authoritative read (empty-binding-unproven)

### DIFF
--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -18,6 +18,7 @@ import { dirname, join } from "node:path";
 import {
   activeWorkflowNodeCount,
   activeWorkflowProvenEmpty,
+  graphEmptyBindingUnproven,
   graphReadDesynced,
   graphRootMismatchesActiveWorkflow,
   graphRootProvenEmpty,
@@ -250,6 +251,7 @@ function buildDirtyStaleRouteHarness({
     "graphRootWorkflowUuidMatches",
     "graphRootMismatchesActiveWorkflow",
     "graphReadDesynced",
+    "graphEmptyBindingUnproven",
     "activeWorkflowNodeCount",
     "activeWorkflowProvenEmpty",
     "graphRootProvenEmpty",
@@ -267,6 +269,7 @@ function buildDirtyStaleRouteHarness({
     graphRootWorkflowUuidMatches,
     graphRootMismatchesActiveWorkflow,
     graphReadDesynced,
+    graphEmptyBindingUnproven,
     activeWorkflowNodeCount,
     activeWorkflowProvenEmpty,
     graphRootProvenEmpty,
@@ -2487,5 +2490,174 @@ test("#389: the guard names the root-node-count-desync predicate when the canvas
     () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: true }),
     /\[root-node-count-desync\]/,
     "the #389 baseline read guard still fires, and now says so",
+  );
+});
+
+// ── #560 (2nd reopen): the FALSE-EMPTY authoritative read ────────────────────
+// After a reconnect + tab switch (or a failed workflow_open repaint), the
+// shared app.graph object is observed MID-POPULATION: _nodes empty, no root
+// tag, and the tracker unreadable/not yet settled. Every legacy predicate is
+// inconclusive there (desync needs a POSITIVE tracker count; the shape guard
+// skips both-empty; the UUID guards skip a missing tag), so graph_outline
+// returned node_count 0 as authoritative for a canvas known to hold 10 nodes
+// — and the agent built ~70 nodes on the false reading (#349-class). An empty
+// ROOT read must distinguish PROVEN-empty from not-yet-populated.
+
+test("#560 r2 graphEmptyBindingUnproven: truth table — inconclusive only when empty + unproven + unbound", () => {
+  const bareRoot = { _nodes: [] };
+  const taggedRoot = { _nodes: [], extra: { comfyui_mcp: { workflow_uuid: "uuid-A" } } };
+  const noTracker = { isModified: false };
+  const malformedTracker = { isModified: false, changeTracker: { activeState: "garbage" } };
+  const dirtyTracker = { isModified: true, changeTracker: { activeState: { nodes: [{ id: 1 }] } } };
+  const provenEmpty = {
+    isModified: false,
+    changeTracker: { activeState: { nodes: [], links: [], groups: [], config: {} } },
+  };
+  // The mid-load / failed-repaint / post-reconnect window: INCONCLUSIVE.
+  assert.equal(
+    graphEmptyBindingUnproven({ graph: bareRoot, rootGraph: bareRoot, activeWorkflow: noTracker, activeWorkflowUuid: "uuid-A" }),
+    true,
+    "tracker entirely absent — an empty read cannot be authoritative",
+  );
+  assert.equal(
+    graphEmptyBindingUnproven({ graph: bareRoot, rootGraph: bareRoot, activeWorkflow: malformedTracker, activeWorkflowUuid: "uuid-A" }),
+    true,
+    "malformed tracker state — same blind window",
+  );
+  assert.equal(
+    graphEmptyBindingUnproven({ graph: bareRoot, rootGraph: bareRoot, activeWorkflow: dirtyTracker, activeWorkflowUuid: "uuid-A" }),
+    true,
+    "a dirty tracker cannot prove emptiness (#545 lag) and the root is unbound",
+  );
+  // PROVEN genuinely empty: node_count 0 is the TRUTH.
+  assert.equal(
+    graphEmptyBindingUnproven({ graph: bareRoot, rootGraph: bareRoot, activeWorkflow: provenEmpty, activeWorkflowUuid: "uuid-A" }),
+    false,
+    "clean + well-formed all-empty state ⇒ a truthful empty read",
+  );
+  // POSITIVELY bound (root tag matches the active identity): the known #545
+  // availability case — a manual/agent clear on a bound canvas, tracker lagging.
+  assert.equal(
+    graphEmptyBindingUnproven({ graph: taggedRoot, rootGraph: taggedRoot, activeWorkflow: dirtyTracker, activeWorkflowUuid: "uuid-A" }),
+    false,
+    "a positively-bound canvas stays availability-oriented",
+  );
+  // Populated root: self-evidently bound; other guards own it.
+  const populated = { _nodes: [{ id: 1 }] };
+  assert.equal(
+    graphEmptyBindingUnproven({ graph: populated, rootGraph: populated, activeWorkflow: noTracker, activeWorkflowUuid: "uuid-A" }),
+    false,
+    "a populated canvas can never false-read empty",
+  );
+  // Subgraph scope: a descended empty subgraph is legitimate scope content.
+  assert.equal(
+    graphEmptyBindingUnproven({ graph: { _nodes: [] }, rootGraph: bareRoot, activeWorkflow: noTracker, activeWorkflowUuid: "uuid-A" }),
+    false,
+    "descended subgraph scope is exempt (mirrors the baseline desync guard)",
+  );
+  // No workflow service at all: the legacy availability path — this frontend
+  // never had binding fences, so an empty canvas keeps reading as empty.
+  assert.equal(
+    graphEmptyBindingUnproven({ graph: bareRoot, rootGraph: bareRoot, activeWorkflow: null, activeWorkflowUuid: null }),
+    false,
+    "no workflow service ⇒ legacy behavior preserved",
+  );
+  // An UNREADABLE root (no _nodes array) stays with the legacy predicates.
+  assert.equal(
+    graphEmptyBindingUnproven({ graph: {}, rootGraph: {}, activeWorkflow: noTracker, activeWorkflowUuid: "uuid-A" }),
+    false,
+    "an unobservable root is not this predicate's case",
+  );
+});
+
+test("#560 r2: the read guard throws [empty-binding-unproven] for the mid-population window — never a false-empty read", () => {
+  for (const [label, activeTracker] of [
+    ["tracker absent", null],
+    ["tracker malformed", { activeState: "garbage" }],
+  ]) {
+    const h = buildDirtyStaleRouteHarness({
+      rootUuid: null, // no binding tag: the shared root mid-population / failed repaint
+      foreignClaim: "none",
+      activeNodeCount: 10, // (unused — the injected tracker below replaces the default)
+      rootNodeCount: 0,
+      activeModified: false,
+      activeTracker,
+    });
+    assert.throws(
+      () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: true }),
+      (err) => {
+        assert.match(err.message, /\[empty-binding-unproven\]/);
+        assert.match(err.message, /FALSE-EMPTY/i);
+        assert.match(err.message, /Retry in a moment/i);
+        assert.doesNotMatch(err.message, /out of sync/, "this is inconclusive, not a wrong-canvas verdict");
+        return true;
+      },
+      `${label}: the empty root is inconclusive, never authoritative-empty`,
+    );
+  }
+});
+
+test("#560 r2: a populated tracker verdict still wins over the empty-binding check (desync ordering)", () => {
+  // The tracker positively reports 10 nodes against an empty root: the #389
+  // desync is the louder, more specific error and must keep firing FIRST
+  // (malformed activeState so the shape guard stays inconclusive, exactly the
+  // existing #389 naming test's shape).
+  const h = buildDirtyStaleRouteHarness({
+    rootUuid: null,
+    foreignClaim: "none",
+    rootNodeCount: 0,
+    activeModified: false,
+    activeTracker: { activeState: { nodes: "bad" }, initialState: state(10) },
+  });
+  assert.throws(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: true }),
+    /\[root-node-count-desync\]/,
+  );
+});
+
+test("#560 r2: a PROVEN-empty canvas still reads truthfully (no false refusal) — and a bound empty canvas stays editable", () => {
+  const h = buildDirtyStaleRouteHarness({
+    rootUuid: null,
+    foreignClaim: "none",
+    rootNodeCount: 0,
+    activeModified: false,
+    activeTracker: { activeState: { nodes: [], links: [], groups: [], config: {} } },
+    rootSerializer: () => ({ nodes: [], links: [], groups: [], config: {} }),
+  });
+  assert.doesNotThrow(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: true }),
+    "clean tracker + well-formed all-empty state ⇒ the empty read is authoritative",
+  );
+  // The #545 availability case: the root is positively bound to the active
+  // identity (tag match), so even a dirty, lagging tracker keeps the cleared
+  // canvas readable/editable — only UNBOUND emptiness is inconclusive.
+  const bound = buildDirtyStaleRouteHarness({
+    rootUuid: "workflow-A-1", // the harness resolver's first deterministic mint
+    foreignClaim: "none",
+    rootNodeCount: 0,
+    activeModified: true, // dirty tracker — cannot prove, but the binding is positive
+  });
+  assert.doesNotThrow(
+    () => bound.assertBound(bound.rootB, bound.rootB, { includeBaselineReadGuard: true }),
+    "positively-bound empty canvas: reads stay availability-oriented (#545)",
+  );
+  assert.doesNotThrow(
+    () => bound.assertBound(bound.rootB, bound.rootB, { includeBaselineReadGuard: false, requireDirtyMutationBinding: true }),
+    "…and mutations too (the agent's clear-and-rebuild flow)",
+  );
+});
+
+test("#560 r2: mutations are fenced against the false-empty window exactly like reads", () => {
+  const h = buildDirtyStaleRouteHarness({
+    rootUuid: null,
+    foreignClaim: "none",
+    rootNodeCount: 0,
+    activeModified: false,
+    activeTracker: null,
+  });
+  assert.throws(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: false, requireDirtyMutationBinding: true }),
+    /\[empty-binding-unproven\]/,
+    "graph_add_node on a mid-population canvas is refused, not applied to a false-empty graph",
   );
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -252,6 +252,7 @@ import { createRunReconcileSweep } from "./lib/run-reconcile-sweep.js";
 import {
   activeWorkflowNodeCount,
   activeWorkflowProvenEmpty,
+  graphEmptyBindingUnproven,
   graphReadDesynced,
   graphRootMismatchesActiveWorkflow,
   graphRootProvenEmpty,
@@ -4404,6 +4405,27 @@ function assertGraphBoundToActiveWorkflow(
         `but the canvas is bound to a different graph. A load, tab switch, or reconnect left this command ` +
         `pointed at the wrong canvas, so it was NOT applied. Re-open the active workflow tab ` +
         `(panel_open_workflow) or reload the panel to rebind the graph, then retry.`,
+    );
+  }
+  // #560 (2nd reopen) — the FALSE-EMPTY read hole. Every predicate above is
+  // inconclusive in the mid-population window (empty root, no root tag,
+  // tracker unreadable/unsettled after a reconnect + tab switch or a failed
+  // repaint), so an empty ROOT read slipped through as an AUTHORITATIVE
+  // node_count 0 for a populated workflow — and the agent built on it (#349-
+  // class). An empty read is now authoritative ONLY when the empty state is
+  // PROVEN (clean, well-formed, all-empty tracker state) or the canvas is
+  // POSITIVELY bound (root tag matches). Otherwise the state is INCONCLUSIVE:
+  // refuse with a retryable error — never a false-empty read, never a build
+  // on one. Reads AND mutations are fenced alike; the legacy verdicts above
+  // stay more specific and keep winning. Gated LAST so it can never mask a
+  // positive desync/mismatch verdict.
+  if (graphEmptyBindingUnproven({ graph, rootGraph, activeWorkflow, activeWorkflowUuid })) {
+    throw new Error(
+      `[empty-binding-unproven] The live root canvas reads EMPTY, but the active workflow's own ` +
+        `state cannot prove it is genuinely empty — the tab may still be loading after a switch, ` +
+        `reconnect, or a failed open, and node_count 0 could be a FALSE-EMPTY reading, so this ` +
+        `command was NOT applied as authoritative. Retry in a moment once the tab settles; if it ` +
+        `persists, re-open the workflow tab (panel_open_workflow) or reload the panel.`,
     );
   }
 }

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -77,6 +77,49 @@ export function graphReadDesynced({ liveNodeCount, activeWorkflow, inSubgraph = 
 }
 
 /**
+ * #560 (2nd reopen) — the FALSE-EMPTY authoritative read. After a reconnect +
+ * workflow-tab switch (or a failed workflow_open repaint), the shared
+ * app.graph object is observable MID-POPULATION: `_nodes` empty, no root tag,
+ * and the active workflow's tracker unreadable or not yet settled. Every other
+ * binding predicate is inconclusive in that window BY DESIGN: the baseline
+ * desync guard needs a POSITIVE tracker node count (it fails open to 0 on an
+ * absent/malformed read), the shape guard deliberately skips both-empty
+ * comparisons (#565), and the UUID guards treat a missing root tag as
+ * inconclusive. An empty root READ there returned `node_count: 0` as
+ * AUTHORITATIVE for a canvas known to hold 10 nodes — and the agent built ~70
+ * nodes on the false reading (#349-class wrong-canvas work).
+ *
+ * This predicate is the empty-read evidence bar: an empty ROOT read is
+ * authoritative ONLY when it is
+ *   - PROVEN genuinely empty — a CLEAN tracker with a well-formed, all-empty
+ *     CURRENT serialized state (activeWorkflowProvenEmpty; a node COUNT of 0
+ *     from an absent/malformed read is NOT proof), or
+ *   - POSITIVELY bound — the root tag matches the active workflow's identity
+ *     (graphRootWorkflowUuidMatches), the known #545 availability case: a
+ *     manual/agent clear on a bound canvas with the tracker legitimately
+ *     lagging.
+ *
+ * Returns true (INCONCLUSIVE — the caller must refuse rather than treat the
+ * empty read as authoritative) only when the root observably has zero nodes
+ * AND neither proof holds. Availability is preserved where it must be:
+ *   - a POPULATED root (self-evidently bound) and an unreadable root shape
+ *     stay with the legacy predicates;
+ *   - subgraph scope is exempt (a descended empty subgraph is legitimate,
+ *     mirroring graphReadDesynced);
+ *   - with NO active workflow service at all, the legacy availability path
+ *     stands (that frontend never had binding fences).
+ */
+export function graphEmptyBindingUnproven({ graph, rootGraph, activeWorkflow, activeWorkflowUuid } = {}) {
+  if (!!rootGraph && graph && graph !== rootGraph) return false; // subgraph scope
+  const live = rootGraph?._nodes;
+  if (!Array.isArray(live) || live.length !== 0) return false; // populated or unobservable
+  if (!activeWorkflow) return false; // no workflow service — legacy availability
+  if (activeWorkflowProvenEmpty(activeWorkflow)) return false; // PROVEN empty — truthful 0
+  if (graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid })) return false; // positively bound
+  return true; // empty + unproven + unbound ⇒ inconclusive, never authoritative-empty
+}
+
+/**
  * Return the active workflow's serialized CURRENT graph state. `initialState`
  * is deliberately excluded: it is a load/save baseline and can legitimately
  * differ from an active canvas with unsaved edits. `null` means current state is


### PR DESCRIPTION
## Summary

Fixes artokun/comfyui-mcp-panel#560 (2nd reopen, 0.49.2 / 0.11.37)

- **New predicate `graphEmptyBindingUnproven`** (`web/js/lib/graph-binding.js`), wired LAST into `assertGraphBoundToActiveWorkflow` with a distinct, retryable `[empty-binding-unproven]` error: an empty ROOT read/mutation is authoritative ONLY when the empty state is **proven** (`activeWorkflowProvenEmpty` — clean, well-formed, all-empty tracker state) or the canvas is **positively bound** (root tag matches the active identity — the #545 dirty-clear availability case). Every other empty-canvas state is **inconclusive — never authoritative-empty**.
- Reads AND mutations are fenced alike: `panel_graph_outline` can no longer return `node_count: 0` as truth for a mid-population canvas, and `panel_add_node` & co. can no longer build on that false reading (#349-class).

## What 0.11.38 (#570) already covers vs what's new

**#570-covered (upgrade note for the reporter):** the recurrence's first two symptoms are the 0.11.37-era shape #570 fixed — the out-of-sync false positive on a legitimately-active canvas (serializer dialect + `comfyui_mcp` tag counted as content) and `workflow_open could not prove that the active canvas was rebound` (the `graphRootMatchesState` repaint proof false-negative that "left a drifted binding with no recovery short of a panel reload"). Both repros predate the merge.

**NOT #570-covered (this PR):** the false-empty authoritative read. The #570 proven-empty machinery only gates the rebind *relaxation*, never the READ path. In the mid-population window — the shared, reused `app.graph` object cleared/not-yet-repopulated after a tab switch (the #565 root cause), root tag absent, tracker unreadable or not yet settled — every legacy predicate is inconclusive *by design*: the baseline desync guard needs a POSITIVE tracker count (fails open to 0 on absent/malformed reads), the shape guard deliberately skips both-empty comparisons (#565), and the UUID guards treat a missing tag as inconclusive. The empty read returned as truth, and ~70 nodes were built on it.

## Invariants preserved

- Legacy fail-closed verdicts (`root-workflow-uuid-mismatch` / `dirty-mutation-binding-unproven` / `root-shape-mismatch` / `root-node-count-desync`) stay more specific and keep winning — the new check is gated last and can never mask a positive desync (locked by an ordering test).
- Availability: proven-empty canvases read truthful 0; positively-bound empty canvases (manual/agent clear, dirty tracker) stay readable AND editable; populated roots, subgraph scope, unreadable root shapes, and no-workflow-service frontends are untouched. #349 wrong-canvas fence, #545 dirty-read availability, #565 both-empty heal all intact.

## Validation

- `browser_tests/unit/graph-binding.test.mjs` +5: pure truth table (absent/malformed/dirty tracker ⇒ inconclusive; proven-empty / bound / populated / subgraph / no-service / unobservable-root ⇒ available), fence throws `[empty-binding-unproven]` with retry guidance for reads and mutations, desync ordering, no false refusal for proven-empty or bound-empty.
- Red-first: the 3 fence tests failed before the wiring (missing exception / wrong reason), all pass after.
- `npm run test:unit` — **1691 pass**; `npx -y node@22 --test browser_tests/unit/*.test.mjs` — **1691 pass**; `npm run typecheck` clean.