### PR TITLE
fix: report outer previous value for promoted widgets

### DIFF
--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -771,6 +771,23 @@ test("writing a RENAMED promoted widget hits the inner target + syncs the rail, 
   });
 });
 
+test("#583: promoted write reports the requested OUTER widget's previous value, not the inner implementation value", () => {
+  const { parent, inner, railWidget, resolveSource } = makeSubgraphFixture();
+  const innerWidget = inner.widgets.find((w) => w.name === "scheduler");
+  // A stale/migrated subgraph can expose a different outer rail value from its
+  // implementation widget. The tool was addressed to `sched_alias` on `parent`,
+  // so this is the value its response must call `previous`.
+  railWidget.value = "karras";
+  innerWidget.value = "simple";
+
+  const set = applyWidgetWrite(parent, "sched_alias", "simple", { resolveSource });
+
+  assert.equal(set.previous, "karras");
+  assert.equal(set.inner_previous, "simple");
+  assert.equal(set.value, "simple");
+  assert.equal(railWidget.value, "simple", "the visible outer rail is still synchronized");
+});
+
 test("promoted numeric slot REJECTS a non-numeric value (silent-corruption signature)", () => {
   const { parent, inner, resolveSource } = makeSubgraphFixture();
   // Re-point the promotion at inner numeric "steps", WITH a valid authoritative

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1004,6 +1004,12 @@ export function applyWidgetWrite(
   // that object IN PLACE (e.g. `inner.value.strength = …`), so an identity compare
   // (Object.is) would pass while the restored object holds corrupted fields. We
   // verify rollback STRUCTURALLY against the pre-mutation deep clone instead.
+  // `panel_set_widget` is addressed to the OUTER subgraph widget, even though a
+  // promoted write mutates its inner implementation widget too. Its result must
+  // therefore report the prior value the caller could observe on the requested
+  // outer rail, not the (potentially divergent) inner widget's prior value (#583).
+  // Keep the latter separately for diagnostics; it is not the API-level
+  // `previous` for a promoted request.
   const previous = w.value;
   const previousParent = parentWidget ? parentWidget.value : undefined;
   const deepClone = (v) => (v !== null && typeof v === "object" ? JSON.parse(JSON.stringify(v)) : v);
@@ -1383,10 +1389,11 @@ export function applyWidgetWrite(
   return {
     node_id: targetNode.id,
     widget: w.name,
-    previous,
+    previous: parentWidget ? previousParent : previous,
     value: w.value,
     ...(promotedFrom
       ? {
+          inner_previous: previous,
           promoted_from: {
             ...promotedFrom,
             parent_widget_synced: parentWidget != null,


### PR DESCRIPTION
## What changed

For promoted subgraph widgets, `panel_set_widget` now reports `previous` from the requested outer rail widget. The inner implementation widget's old value is preserved as `inner_previous` for diagnostics.

## Why

The write target is an inner node, but callers address the outer exposed widget. When those values had diverged, the response claimed the inner prior value instead of the value visible to the caller.

## Validation

- Added a regression where the exposed outer rail and inner widget intentionally start with different values.
- `npm.cmd run test:unit` (1699 passing)
- `npm.cmd run typecheck`
