### PR TITLE
fix(panel): separate stale red outlines from errors (#579)

### DIFF
--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -777,7 +777,7 @@ test("#579 source-free LiteGraph outlines are warnings, not graph errors", () =>
   const reasons = new Map([["2", [{ kind: "missing_model" }]]]);
 
   assert.deepEqual(
-    collectUnexplainedRedOutlines(nodes, reasons, { nodeErrors: null, lastExecutionError: null }).map((n) => n.id),
+    collectUnexplainedRedOutlines(nodes, reasons, { nodeErrors: null, lastExecFailure: null }).map((n) => n.id),
     [1],
     "only an unexplained red outline with no run error source is stale",
   );
@@ -787,7 +787,7 @@ test("#579 source-free LiteGraph outlines are warnings, not graph errors", () =>
     "a live validation source retains conservative error classification",
   );
   assert.deepEqual(
-    collectUnexplainedRedOutlines(nodes, reasons, { lastExecutionError: { node_id: 9 } }),
+    collectUnexplainedRedOutlines(nodes, reasons, { lastExecFailure: { node_id: 9 } }),
     [],
     "a live execution source retains conservative error classification",
   );

--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -10,6 +10,7 @@ import assert from "node:assert/strict";
 
 import {
   findNodeByScopedId,
+  findVisibleNodeByScopedId,
   findSubgraphByUuid,
   assetCandidateStillReferenced,
   assetCandidateResolvesLive,
@@ -22,6 +23,7 @@ import {
   reapplyDefsToLiveNodes,
   collectMissingNodeTypeReasons,
   collectUnexplainedRedOutlines,
+  combineNodeErrorMaps,
   graphErrorsResultIsClean,
   nodeRedFlagIsStale,
   collectLinkedNeighborNodeIds,
@@ -100,6 +102,27 @@ test("findNodeByScopedId resolves a REAL locator '<subgraphUuid>:<localId>' (#24
   const sub = subgraphOf(SG_UUID, [inner]);
   const root = rootWithSubgraphs([], [sub]);
   assert.equal(findNodeByScopedId(root, `${SG_UUID}:1913`), inner);
+});
+
+test("findVisibleNodeByScopedId maps a scoped missing asset only onto its displayed subgraph node (#579 P1)", () => {
+  const inner = { id: 6077, has_errors: true, widgets: [{ name: "ckpt_name", value: "gone.safetensors" }] };
+  const sameLocalIdElsewhere = { id: 6077, has_errors: true, widgets: [] };
+  const sub = subgraphOf(SG_UUID, [inner]);
+  const root = rootWithSubgraphs([{ id: 100, subgraph: sub }, sameLocalIdElsewhere], [sub]);
+  const locator = `${SG_UUID}:6077`;
+
+  assert.equal(findVisibleNodeByScopedId(root, [inner], locator), inner);
+  assert.equal(
+    findVisibleNodeByScopedId(root, [sameLocalIdElsewhere], locator),
+    null,
+    "a local-id collision in another scope must not receive the missing-asset reason",
+  );
+  const reasons = new Map([[String(inner.id), [{ kind: "missing_model", file: "gone.safetensors" }]]]);
+  assert.deepEqual(
+    collectUnexplainedRedOutlines([inner], reasons, {}).map((node) => node.id),
+    [],
+    "the real scoped missing asset stays a per-node error, never a stale outline",
+  );
 });
 
 test("findNodeByScopedId returns null when the subgraph UUID is unknown (fails open)", () => {
@@ -790,6 +813,25 @@ test("#579 source-free LiteGraph outlines are warnings, not graph errors", () =>
     collectUnexplainedRedOutlines(nodes, reasons, { lastExecFailure: { node_id: 9 } }),
     [],
     "a live execution source retains conservative error classification",
+  );
+});
+
+test("combineNodeErrorMaps: an empty app map never masks a live execution-store validation error (#579 P1)", () => {
+  const storeError = { message: "checkpoint is not installed" };
+  const combined = combineNodeErrorMaps([
+    {}, // app.lastNodeErrors may be reset immediately after the rejection
+    { 41: { errors: [storeError] } },
+  ]);
+  assert.deepEqual(combined, { 41: { errors: [storeError] } });
+  assert.deepEqual(
+    combineNodeErrorMaps([{ 41: { errors: [] } }, { 41: { errors: [storeError] } }]),
+    { 41: { errors: [storeError] } },
+    "an empty entry for the same node also cannot overwrite the store's live error",
+  );
+  assert.deepEqual(
+    collectUnexplainedRedOutlines([{ id: 8, has_errors: true }], new Map(), { nodeErrors: combined }),
+    [],
+    "a live store validation source keeps a red outline conservatively classified as an error",
   );
 });
 

--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -21,6 +21,7 @@ import {
   collectAllGraphs,
   reapplyDefsToLiveNodes,
   collectMissingNodeTypeReasons,
+  collectUnexplainedRedOutlines,
   graphErrorsResultIsClean,
   nodeRedFlagIsStale,
   collectLinkedNeighborNodeIds,
@@ -674,6 +675,16 @@ test("collectMissingNodeTypeReasons: defensive against malformed inputs (never t
 
 test("graphErrorsResultIsClean: TRUE only for a truly empty result", () => {
   assert.equal(graphErrorsResultIsClean({ errored_count: 0, node_errors: null, last_execution_error: null }), true);
+  assert.equal(
+    graphErrorsResultIsClean({
+      errored_count: 0,
+      node_errors: null,
+      last_execution_error: null,
+      stale_flags: [{ id: 5, red_outline: true }],
+    }),
+    true,
+    "a source-free visual outline is an informational stale flag, not an error",
+  );
   assert.equal(graphErrorsResultIsClean({}), true);
   assert.equal(graphErrorsResultIsClean(null), true);
 });
@@ -755,6 +766,31 @@ test("nodeRedFlagIsStale: FALSE while the node still has a live validation error
 test("nodeRedFlagIsStale: fails toward KEEPING the flag on a null/absent node id", () => {
   assert.equal(nodeRedFlagIsStale(null, {}), false);
   assert.equal(nodeRedFlagIsStale(undefined, {}), false);
+});
+
+test("#579 source-free LiteGraph outlines are warnings, not graph errors", () => {
+  const nodes = [
+    { id: 1, has_errors: true, type: "FastFilmGrain" },
+    { id: 2, has_errors: true, type: "KSampler" },
+    { id: 3, has_errors: false, type: "VAEDecode" },
+  ];
+  const reasons = new Map([["2", [{ kind: "missing_model" }]]]);
+
+  assert.deepEqual(
+    collectUnexplainedRedOutlines(nodes, reasons, { nodeErrors: null, lastExecutionError: null }).map((n) => n.id),
+    [1],
+    "only an unexplained red outline with no run error source is stale",
+  );
+  assert.deepEqual(
+    collectUnexplainedRedOutlines(nodes, reasons, { nodeErrors: { 9: { errors: [{ message: "bad" }] } } }),
+    [],
+    "a live validation source retains conservative error classification",
+  );
+  assert.deepEqual(
+    collectUnexplainedRedOutlines(nodes, reasons, { lastExecutionError: { node_id: 9 } }),
+    [],
+    "a live execution source retains conservative error classification",
+  );
 });
 
 test("nodeRedFlagIsStale: a NESTED still-missing asset (scoped locator) keeps the flag via resolvesToNode (#418 codex round-3 P0)", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -8483,7 +8483,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // downgrade an unexplained red outline.
     const staleRedFlags = collectUnexplainedRedOutlines(nodes, reasons, {
       nodeErrors,
-      lastExecutionError: execFailure,
+      lastExecFailure: execFailure,
     });
     const staleRedFlagIds = new Set(staleRedFlags.map((n) => String(n.id)));
     const flagged = new Set(

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -119,6 +119,7 @@ import {
   reapplyDefsToLiveNodes,
   refreshComboOptionsFromDefs,
   collectMissingNodeTypeReasons,
+  collectUnexplainedRedOutlines,
   graphErrorsResultIsClean,
   nodeRedFlagIsStale,
   collectLinkedNeighborNodeIds,
@@ -8475,7 +8476,19 @@ const GRAPH_TOOL_EXECUTORS = {
 
     // Red-outlined (has_errors) UNIONed with anything a source blamed — a source
     // can name a node LiteGraph never flagged (every runtime failure is one).
-    const flagged = new Set(nodes.filter((n) => n.has_errors).map((n) => String(n.id)));
+    // A source-free red outline can survive workflow loading even though the
+    // execution and validation sources have both cleared (#579). Surface those
+    // separately as stale visual flags instead of calling them errors. When an
+    // execution source exists, retain the conservative legacy behavior: do not
+    // downgrade an unexplained red outline.
+    const staleRedFlags = collectUnexplainedRedOutlines(nodes, reasons, {
+      nodeErrors,
+      lastExecutionError: execFailure,
+    });
+    const staleRedFlagIds = new Set(staleRedFlags.map((n) => String(n.id)));
+    const flagged = new Set(
+      nodes.filter((n) => n.has_errors && !staleRedFlagIds.has(String(n.id))).map((n) => String(n.id)),
+    );
     for (const id of reasons.keys()) if (byId.has(id)) flagged.add(id);
     const erroredNodes = [...flagged]
       .map((id) => byId.get(id))
@@ -8509,6 +8522,17 @@ const GRAPH_TOOL_EXECUTORS = {
       errored_count: erroredNodes.length,
       nodes: erroredNodes.slice(0, MAX_STATE_NODES),
       ...(erroredNodes.length > MAX_STATE_NODES ? { truncated: true } : {}),
+      ...(staleRedFlags.length
+        ? {
+            stale_flags: staleRedFlags.slice(0, MAX_STATE_NODES).map((n) => ({
+              ...summarizeNode(n),
+              red_outline: true,
+              reasons: [],
+              note: "LiteGraph still shows this red outline, but no current execution, validation, or asset source confirms an error.",
+            })),
+            ...(staleRedFlags.length > MAX_STATE_NODES ? { stale_flags_truncated: true } : {}),
+          }
+        : {}),
       ...(missingModels.length ? { missing_models: missingModels } : {}),
       ...(missingMedia.length ? { missing_media: missingMedia } : {}),
       ...(missingNodeTypes.length ? { missing_node_types: missingNodeTypes } : {}),

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -120,10 +120,12 @@ import {
   refreshComboOptionsFromDefs,
   collectMissingNodeTypeReasons,
   collectUnexplainedRedOutlines,
+  combineNodeErrorMaps,
   graphErrorsResultIsClean,
   nodeRedFlagIsStale,
   collectLinkedNeighborNodeIds,
   findNodeByScopedId,
+  findVisibleNodeByScopedId,
   resolveMissingModelDirectory,
 } from "./lib/asset-staleness.js";
 import { assertAddNodeResolvableRefreshing } from "./lib/node-resolve.js";
@@ -8385,15 +8387,21 @@ const GRAPH_TOOL_EXECUTORS = {
     const missingMedia = assets.media.map((m) => ({ ...m, kind: "missing_media" }));
     const missingNodeTypes = assets.nodeTypes;
     const missingNodeCount = assets.nodeCount;
+    // Missing-asset stores identify nested nodes with a scoped locator, while
+    // the currently viewed subgraph indexes its nodes by their local id. Resolve
+    // only to the exact visible node; otherwise retain the locator so a same-id
+    // node in another subgraph can never receive this error by accident.
+    const reasonNodeId = (locator) =>
+      findVisibleNodeByScopedId(rootGraph, nodes, locator)?.id ?? locator;
     for (const m of assets.models) {
       if (m.node_id == null) continue;
       const { node_id, ...rest } = m;
-      addReason(node_id, { kind: "missing_model", ...rest });
+      addReason(reasonNodeId(node_id), { kind: "missing_model", ...rest });
     }
     for (const m of assets.media) {
       if (m.node_id == null) continue;
       const { node_id, ...rest } = m;
-      addReason(node_id, { kind: "missing_media", ...rest });
+      addReason(reasonNodeId(node_id), { kind: "missing_media", ...rest });
     }
 
     // 2) Uninstalled node TYPES, attached PER NODE (#399). collectMissingAssets only
@@ -8423,8 +8431,10 @@ const GRAPH_TOOL_EXECUTORS = {
     } catch {
       /* optional */
     }
-    const rawNodeErrors = comfy?.lastNodeErrors ?? storeNodeErrors ?? null;
-    const nodeErrors = rawNodeErrors && Object.keys(rawNodeErrors).length ? rawNodeErrors : null;
+    // These are independent live stores. The app map can be an empty object
+    // after a reset while the execution store still retains the actual rejected
+    // prompt, so never let nullish selection make an empty app map mask it.
+    const nodeErrors = combineNodeErrorMaps([comfy?.lastNodeErrors ?? null, storeNodeErrors]);
     if (nodeErrors) {
       for (const [id, entry] of Object.entries(nodeErrors)) {
         for (const e of entry?.errors ?? []) {

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -290,6 +290,30 @@ export function nodeRedFlagIsStale(
 }
 
 /**
+ * Return visual LiteGraph red outlines that have no current source-confirmed
+ * explanation. A saved workflow can retain `has_errors` from an older run even
+ * though both error sources have since been cleared. Those outlines are useful
+ * diagnostic hints, but must not inflate `graph_get_errors.errored_count`.
+ *
+ * This intentionally only classifies when BOTH raw execution sources are
+ * absent. If either source exists, keep the old conservative behavior: an
+ * unexplained outline remains an error rather than being silently downgraded.
+ * `reasons` may be the command's Map or a plain id-keyed object for tests.
+ */
+export function collectUnexplainedRedOutlines(
+  nodes,
+  reasons,
+  { nodeErrors = null, lastExecutionError = null } = {},
+) {
+  if (nodeErrors || lastExecutionError || !Array.isArray(nodes)) return [];
+  const reasonsFor = (nodeId) => {
+    const key = String(nodeId);
+    return reasons instanceof Map ? reasons.get(key) : reasons?.[key];
+  };
+  return nodes.filter((node) => node?.has_errors && !(reasonsFor(node.id)?.length));
+}
+
+/**
  * Return the direct graph neighbours connected to `node`. Native
  * `convertToSubgraph()` rewires precisely these surviving root-graph nodes to
  * the new wrapper, but does not re-adjudicate LiteGraph's sticky `has_errors`

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -303,9 +303,9 @@ export function nodeRedFlagIsStale(
 export function collectUnexplainedRedOutlines(
   nodes,
   reasons,
-  { nodeErrors = null, lastExecutionError = null } = {},
+  { nodeErrors = null, lastExecFailure = null } = {},
 ) {
-  if (nodeErrors || lastExecutionError || !Array.isArray(nodes)) return [];
+  if (nodeErrors || lastExecFailure || !Array.isArray(nodes)) return [];
   const reasonsFor = (nodeId) => {
     const key = String(nodeId);
     return reasons instanceof Map ? reasons.get(key) : reasons?.[key];

--- a/web/js/lib/asset-staleness.js
+++ b/web/js/lib/asset-staleness.js
@@ -118,6 +118,22 @@ export function findNodeByScopedId(rootGraph, scopedId) {
 }
 
 /**
+ * Resolve a store locator only when its node is part of the graph currently
+ * being reported. A nested node id is local to its subgraph, so attaching a
+ * `<subgraphUuid>:<localId>` reason directly by string leaves the visible node
+ * looking source-free and can incorrectly classify its red outline as stale.
+ *
+ * Identity (rather than just a matching local id) matters here: different
+ * subgraphs may both contain node `7`. Returning null for a node outside the
+ * visible graph deliberately leaves the caller's original locator untouched,
+ * avoiding a false attribution in the wrong scope.
+ */
+export function findVisibleNodeByScopedId(rootGraph, visibleNodes, scopedId) {
+  const node = findNodeByScopedId(rootGraph, scopedId);
+  return node && Array.isArray(visibleNodes) && visibleNodes.includes(node) ? node : null;
+}
+
+/**
  * True when `scopedId` is a RECOGNIZED locator shape — exactly the shapes
  * `findNodeByScopedId` knows how to resolve:
  *   - a single non-empty segment (plain local id / UUID-like);
@@ -287,6 +303,48 @@ export function nodeRedFlagIsStale(
   } catch {
     return false;
   }
+}
+
+/**
+ * Conservatively union independent frontend validation maps. ComfyUI can clear
+ * `app.lastNodeErrors` while the execution-error store still holds the live
+ * rejection, so choosing the app map with `??` can falsely report a clean
+ * graph. Entries for the same node retain errors from both sources; malformed
+ * entries are preserved rather than used as evidence that no error exists.
+ */
+export function combineNodeErrorMaps(nodeErrorsMaps) {
+  const combined = {};
+  const maps = Array.isArray(nodeErrorsMaps) ? nodeErrorsMaps : [];
+  for (const map of maps) {
+    if (!map || typeof map !== "object" || Array.isArray(map)) continue;
+    for (const [id, entry] of Object.entries(map)) {
+      if (!Object.hasOwn(combined, id)) {
+        combined[id] = entry;
+        continue;
+      }
+      const previous = combined[id];
+      if (previous === entry) continue;
+      const previousObject = previous && typeof previous === "object" && !Array.isArray(previous);
+      const entryObject = entry && typeof entry === "object" && !Array.isArray(entry);
+      if (!previousObject || !entryObject) {
+        // An unexpected entry shape cannot prove the earlier source is clear.
+        // Keep the first one; the map remains non-empty and thus conservative.
+        continue;
+      }
+      const previousErrors = Array.isArray(previous.errors) ? previous.errors : [];
+      const entryErrors = Array.isArray(entry.errors) ? entry.errors : [];
+      const errors = [...previousErrors];
+      for (const error of entryErrors) {
+        if (!errors.includes(error)) errors.push(error);
+      }
+      combined[id] = {
+        ...previous,
+        ...entry,
+        ...(Array.isArray(previous.errors) || Array.isArray(entry.errors) ? { errors } : {}),
+      };
+    }
+  }
+  return Object.keys(combined).length ? combined : null;
 }
 
 /**


### PR DESCRIPTION
Closes #579.\n\nWhen LiteGraph retains red outlines but panel_get_errors has no current validation, execution, or asset reason, report them under stale_flags and keep errored_count at zero. Real source-confirmed failures keep their existing error classification.\n\nValidation:\n- npm.cmd run test:unit\n- npm.cmd run typecheck\n- git diff --check