### PR TITLE
fix(panel): materialize V3 custom widgets before add

### DIFF
--- a/browser_tests/unit/graph-mutation-context.test.mjs
+++ b/browser_tests/unit/graph-mutation-context.test.mjs
@@ -1,0 +1,30 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { sameGraphMutationContext } from "../../web/js/lib/graph-mutation-context.js";
+
+function context(overrides = {}) {
+  return {
+    app: {},
+    graph: {},
+    rootGraph: {},
+    canvas: {},
+    workflow: {},
+    ...overrides,
+  };
+}
+
+test("an async graph preflight may commit only to its original graph context", () => {
+  const original = context();
+  assert.equal(sameGraphMutationContext(original, original), true);
+  assert.equal(sameGraphMutationContext(original, { ...original, graph: {} }), false);
+  assert.equal(sameGraphMutationContext(original, { ...original, rootGraph: {} }), false);
+  assert.equal(sameGraphMutationContext(original, { ...original, workflow: {} }), false);
+});
+
+test("the caller can treat a raw workflow and its proxy as the same owner", () => {
+  const raw = {};
+  const proxy = { __v_raw: raw };
+  const original = context({ workflow: raw });
+  const after = { ...original, workflow: proxy };
+  assert.equal(sameGraphMutationContext(original, after, (a, b) => a === b?.__v_raw), true);
+});

--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -1,6 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { missingRequiredWidgetMaterializations } from "../../web/js/lib/node-widget-materialization.js";
+import {
+  missingRequiredWidgetMaterializations,
+  requiredWidgetInputTypes,
+  unavailableDeclaredCustomWidgetTypes,
+} from "../../web/js/lib/node-widget-materialization.js";
 
 const widgetConstructors = { ZIPN_STYLE_GALLERY: () => {}, ZIPN_SPACER: () => {}, COMBO: () => {} };
 
@@ -36,13 +40,32 @@ test("missing V3 custom widget is reported while a socket datatype remains wirea
   assert.deepEqual(missingRequiredWidgetMaterializations(node, widgetConstructors), ["gallery", "spacer"]);
 });
 
+test("declared custom widgets stay unavailable until the frontend registry contains them", () => {
+  const node = v3Node([{ name: "style" }]);
+  const declared = new Set(["ZIPN_STYLE_GALLERY", "ZIPN_SPACER"]);
+  assert.deepEqual(unavailableDeclaredCustomWidgetTypes(node, declared, {}), [
+    "ZIPN_STYLE_GALLERY",
+    "ZIPN_SPACER",
+  ]);
+  assert.deepEqual(unavailableDeclaredCustomWidgetTypes(node, declared, widgetConstructors), []);
+});
+
 test("canvas-only control cannot satisfy a required custom input", () => {
   const node = v3Node([
-    { name: "gallery", serialize: false },
+    { name: "gallery", options: { serialize: false } },
     { name: "spacer", serialize: true },
     { name: "style" },
   ]);
   assert.deepEqual(missingRequiredWidgetMaterializations(node, widgetConstructors), ["gallery"]);
+});
+
+test("a widget serialize property does not override ComfyUI options.serialize", () => {
+  const node = v3Node([
+    { name: "gallery", serialize: false, options: { serialize: true } },
+    { name: "spacer", options: { serialize: true } },
+    { name: "style" },
+  ]);
+  assert.deepEqual(missingRequiredWidgetMaterializations(node, widgetConstructors), []);
 });
 
 test("a forceInput declaration remains a wireable socket", () => {
@@ -52,4 +75,5 @@ test("a forceInput declaration remains a wireable socket", () => {
   ]);
   node.constructor.nodeData.input.required.style = ["STRING", { forceInput: true }];
   assert.deepEqual(missingRequiredWidgetMaterializations(node, { ...widgetConstructors, STRING: () => {} }), []);
+  assert.deepEqual(requiredWidgetInputTypes(node), ["ZIPN_STYLE_GALLERY", "ZIPN_SPACER", "CLIP"]);
 });

--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import {
   missingRequiredWidgetMaterializations,
   requiredWidgetInputTypes,
-  unavailableDeclaredCustomWidgetTypes,
+  unavailableRequiredCustomWidgetTypes,
 } from "../../web/js/lib/node-widget-materialization.js";
 
 const widgetConstructors = { ZIPN_STYLE_GALLERY: () => {}, ZIPN_SPACER: () => {}, COMBO: () => {} };
@@ -40,14 +40,28 @@ test("missing V3 custom widget is reported while a socket datatype remains wirea
   assert.deepEqual(missingRequiredWidgetMaterializations(node, widgetConstructors), ["gallery", "spacer"]);
 });
 
-test("declared custom widgets stay unavailable until the frontend registry contains them", () => {
+test("an unknown custom type stays unavailable until the frontend registry contains it", () => {
   const node = v3Node([{ name: "style" }]);
-  const declared = new Set(["ZIPN_STYLE_GALLERY", "ZIPN_SPACER"]);
-  assert.deepEqual(unavailableDeclaredCustomWidgetTypes(node, declared, {}), [
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(node, {}), [
+    "ZIPN_STYLE_GALLERY",
+    "ZIPN_SPACER",
+    "COMBO",
+  ]);
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(node, widgetConstructors), []);
+});
+
+test("known core connections and forced inputs remain safe sockets", () => {
+  const node = v3Node([]);
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(node, {}), [
+    "ZIPN_STYLE_GALLERY",
+    "ZIPN_SPACER",
+    "COMBO",
+  ]);
+  node.constructor.nodeData.input.required.style = ["STRING", { forceInput: true }];
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(node, {}), [
     "ZIPN_STYLE_GALLERY",
     "ZIPN_SPACER",
   ]);
-  assert.deepEqual(unavailableDeclaredCustomWidgetTypes(node, declared, widgetConstructors), []);
 });
 
 test("canvas-only control cannot satisfy a required custom input", () => {

--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -1,0 +1,55 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { missingRequiredWidgetMaterializations } from "../../web/js/lib/node-widget-materialization.js";
+
+const widgetConstructors = { ZIPN_STYLE_GALLERY: () => {}, ZIPN_SPACER: () => {}, COMBO: () => {} };
+
+function v3Node(widgets) {
+  return {
+    widgets,
+    constructor: {
+      nodeData: {
+        input: {
+          required: {
+            gallery: ["ZIPN_STYLE_GALLERY", {}],
+            spacer: ["ZIPN_SPACER", {}],
+            style: [["none", "film"], {}],
+            clip: ["CLIP", {}],
+          },
+        },
+      },
+    },
+  };
+}
+
+test("required registered V3 custom widgets must materialize and serialize", () => {
+  const node = v3Node([
+    { name: "gallery", serialize: true },
+    { name: "spacer", serialize: true },
+    { name: "style" },
+  ]);
+  assert.deepEqual(missingRequiredWidgetMaterializations(node, widgetConstructors), []);
+});
+
+test("missing V3 custom widget is reported while a socket datatype remains wireable", () => {
+  const node = v3Node([{ name: "style" }]);
+  assert.deepEqual(missingRequiredWidgetMaterializations(node, widgetConstructors), ["gallery", "spacer"]);
+});
+
+test("canvas-only control cannot satisfy a required custom input", () => {
+  const node = v3Node([
+    { name: "gallery", serialize: false },
+    { name: "spacer", serialize: true },
+    { name: "style" },
+  ]);
+  assert.deepEqual(missingRequiredWidgetMaterializations(node, widgetConstructors), ["gallery"]);
+});
+
+test("a forceInput declaration remains a wireable socket", () => {
+  const node = v3Node([
+    { name: "gallery", serialize: true },
+    { name: "spacer", serialize: true },
+  ]);
+  node.constructor.nodeData.input.required.style = ["STRING", { forceInput: true }];
+  assert.deepEqual(missingRequiredWidgetMaterializations(node, { ...widgetConstructors, STRING: () => {} }), []);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -180,9 +180,9 @@ import { isLinkPersisted, removePhantomLink, isWidgetBackedInput } from "./lib/c
 import { coerceMessageText, isDroppedAgentReplay, serializeContext } from "./lib/chat-serialize.js";
 import {
   missingRequiredWidgetMaterializations,
-  requiredWidgetInputTypes,
-  unavailableDeclaredCustomWidgetTypes,
+  unavailableRequiredCustomWidgetTypes,
 } from "./lib/node-widget-materialization.js";
+import { sameGraphMutationContext } from "./lib/graph-mutation-context.js";
 import { isImeComposing } from "./lib/ime.js";
 import { installGraphToPromptNullSafety } from "./lib/widget-null-safety.js";
 import {
@@ -5882,69 +5882,46 @@ function placementFor(graph, pos) {
 }
 
 // getCustomWidgets is deliberately fire-and-forget in the ComfyUI frontend.
-// The graph can therefore be ready while a V3 node's widget constructor is
-// still pending. A microtask/frame only happens to cover fast extensions; it
-// cannot prove registration. Resolve the actual extension declarations, then
-// wait for the public widget registry to contain the required constructors.
+// An unrecognised required V3 input is therefore unsafe until the *live*
+// widget registry either contains a constructor or the type is proven to be a
+// built-in socket. Do not call extension hooks here: they are registration
+// callbacks, not repeatable queries, and ComfyUI does not expose their promise.
 const CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS = 5000;
 const CUSTOM_WIDGET_REGISTRATION_POLL_MS = 25;
-const customWidgetTypePromises = new WeakMap();
-
-function customWidgetTypesDeclaredByExtensions(comfyApp) {
-  if (!comfyApp || !Array.isArray(comfyApp.extensions)) {
-    return Promise.reject(new Error("ComfyUI extension registry is unavailable"));
-  }
-  const cached = customWidgetTypePromises.get(comfyApp);
-  if (cached) return cached;
-  const pending = Promise.all(
-    comfyApp.extensions.map(async (extension) => {
-      if (typeof extension?.getCustomWidgets !== "function") return [];
-      const widgets = await extension.getCustomWidgets(comfyApp);
-      return Object.keys(widgets && typeof widgets === "object" ? widgets : {});
-    }),
-  ).then((sets) => new Set(sets.flat()));
-  customWidgetTypePromises.set(comfyApp, pending);
-  return pending;
-}
-
-function rejectAfter(ms, message) {
-  return new Promise((_, reject) => setTimeout(() => reject(new Error(message)), ms));
-}
 
 async function awaitRequiredCustomWidgetRegistration(nodeData, comfyApp) {
-  const requiredTypes = requiredWidgetInputTypes(nodeData);
-  if (!requiredTypes.length) return;
-
-  let declaredTypes;
-  try {
-    declaredTypes = await Promise.race([
-      customWidgetTypesDeclaredByExtensions(comfyApp),
-      rejectAfter(
-        CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS,
-        "ComfyUI custom-widget registry is still initializing",
-      ),
-    ]);
-  } catch (error) {
-    throw new Error(
-      `Cannot add node until ComfyUI custom widgets are available; retry shortly. ${error?.message ?? ""}`.trim(),
-    );
-  }
-
-  const expectedTypes = requiredTypes.filter((type) => declaredTypes.has(type));
-  if (!expectedTypes.length) return;
-
   const deadline = Date.now() + CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS;
-  let unavailable = expectedTypes;
+  let unavailable = unavailableRequiredCustomWidgetTypes(nodeData, comfyApp?.widgets);
   while (Date.now() < deadline) {
-    unavailable = unavailableDeclaredCustomWidgetTypes(nodeData, declaredTypes, comfyApp?.widgets);
     if (!unavailable.length) return;
     await new Promise((resolve) => setTimeout(resolve, CUSTOM_WIDGET_REGISTRATION_POLL_MS));
+    unavailable = unavailableRequiredCustomWidgetTypes(nodeData, comfyApp?.widgets);
   }
+  if (!unavailable.length) return;
   throw new Error(
     `Required custom widget${unavailable.length === 1 ? "" : "s"} ` +
-      `${unavailable.map((type) => `"${type}"`).join(", ")} are unavailable for this node. ` +
-      "ComfyUI is still loading its extension; retry shortly.",
+      `${unavailable.map((type) => `"${type}"`).join(", ")} have not registered. ` +
+      "They may be custom widgets still loading; retry shortly.",
   );
+}
+
+function captureGraphMutationContext() {
+  const context = getGraphCtx();
+  return { ...context, workflow: activeWorkflowRef() };
+}
+
+function revalidateGraphMutationContext(captured) {
+  const current = { ...getGraphCtx(), workflow: activeWorkflowRef() };
+  if (!sameGraphMutationContext(captured, current, sameWorkflowObject)) {
+    throw new Error(
+      "The active workflow or graph view changed while this node was preparing; nothing was added. Retry on the intended tab.",
+    );
+  }
+  assertGraphBoundToActiveWorkflow(current.graph, current.rootGraph, {
+    includeBaselineReadGuard: false,
+    requireDirtyMutationBinding: true,
+  });
+  return current;
 }
 
 // The currently-mounted panel root (set by buildPanel). Used by canvas "fit" to
@@ -6821,7 +6798,8 @@ const GRAPH_TOOL_EXECUTORS = {
   },
 
   async graph_add_node({ class_type, pos, title }) {
-    const { app: comfyApp, graph, LG } = getGraphCtx();
+    const capturedContext = captureGraphMutationContext();
+    const { app: comfyApp, LG } = capturedContext;
     if (!class_type || typeof class_type !== "string") {
       throw new Error("class_type (string) is required");
     }
@@ -6873,6 +6851,10 @@ const GRAPH_TOOL_EXECUTORS = {
           `"${class_type}". Reload ComfyUI so its node extension can register, then retry.`,
       );
     }
+    // No await follows this validation. Re-read the graph/workflow now so a
+    // tab or subgraph switch during the async preflight cannot commit to the
+    // graph captured at command start.
+    const { graph } = revalidateGraphMutationContext(capturedContext);
     graph.beforeChange();
     try {
       node.pos = placementFor(graph, pos);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -178,7 +178,11 @@ import {
 import { autoMatchSlots, slotDiagnostic } from "./lib/connect-match.js";
 import { isLinkPersisted, removePhantomLink, isWidgetBackedInput } from "./lib/connect-verify.js";
 import { coerceMessageText, isDroppedAgentReplay, serializeContext } from "./lib/chat-serialize.js";
-import { missingRequiredWidgetMaterializations } from "./lib/node-widget-materialization.js";
+import {
+  missingRequiredWidgetMaterializations,
+  requiredWidgetInputTypes,
+  unavailableDeclaredCustomWidgetTypes,
+} from "./lib/node-widget-materialization.js";
 import { isImeComposing } from "./lib/ime.js";
 import { installGraphToPromptNullSafety } from "./lib/widget-null-safety.js";
 import {
@@ -5877,18 +5881,70 @@ function placementFor(graph, pos) {
   return [100, 100];
 }
 
-// A custom extension's getCustomWidgets hook is allowed to resolve
-// asynchronously. Node defs can therefore be available one task before the
-// corresponding widget constructors. Yield before creating a node so the
-// constructors are installed before LiteGraph runs onNodeCreated; otherwise a
-// V3 node can be added with bare required sockets that graphToPrompt omits.
-async function settleFrontendWidgetRegistry() {
-  await Promise.resolve();
-  if (typeof requestAnimationFrame === "function") {
-    await new Promise((resolve) => requestAnimationFrame(resolve));
-  } else {
-    await new Promise((resolve) => setTimeout(resolve, 0));
+// getCustomWidgets is deliberately fire-and-forget in the ComfyUI frontend.
+// The graph can therefore be ready while a V3 node's widget constructor is
+// still pending. A microtask/frame only happens to cover fast extensions; it
+// cannot prove registration. Resolve the actual extension declarations, then
+// wait for the public widget registry to contain the required constructors.
+const CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS = 5000;
+const CUSTOM_WIDGET_REGISTRATION_POLL_MS = 25;
+const customWidgetTypePromises = new WeakMap();
+
+function customWidgetTypesDeclaredByExtensions(comfyApp) {
+  if (!comfyApp || !Array.isArray(comfyApp.extensions)) {
+    return Promise.reject(new Error("ComfyUI extension registry is unavailable"));
   }
+  const cached = customWidgetTypePromises.get(comfyApp);
+  if (cached) return cached;
+  const pending = Promise.all(
+    comfyApp.extensions.map(async (extension) => {
+      if (typeof extension?.getCustomWidgets !== "function") return [];
+      const widgets = await extension.getCustomWidgets(comfyApp);
+      return Object.keys(widgets && typeof widgets === "object" ? widgets : {});
+    }),
+  ).then((sets) => new Set(sets.flat()));
+  customWidgetTypePromises.set(comfyApp, pending);
+  return pending;
+}
+
+function rejectAfter(ms, message) {
+  return new Promise((_, reject) => setTimeout(() => reject(new Error(message)), ms));
+}
+
+async function awaitRequiredCustomWidgetRegistration(nodeData, comfyApp) {
+  const requiredTypes = requiredWidgetInputTypes(nodeData);
+  if (!requiredTypes.length) return;
+
+  let declaredTypes;
+  try {
+    declaredTypes = await Promise.race([
+      customWidgetTypesDeclaredByExtensions(comfyApp),
+      rejectAfter(
+        CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS,
+        "ComfyUI custom-widget registry is still initializing",
+      ),
+    ]);
+  } catch (error) {
+    throw new Error(
+      `Cannot add node until ComfyUI custom widgets are available; retry shortly. ${error?.message ?? ""}`.trim(),
+    );
+  }
+
+  const expectedTypes = requiredTypes.filter((type) => declaredTypes.has(type));
+  if (!expectedTypes.length) return;
+
+  const deadline = Date.now() + CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS;
+  let unavailable = expectedTypes;
+  while (Date.now() < deadline) {
+    unavailable = unavailableDeclaredCustomWidgetTypes(nodeData, declaredTypes, comfyApp?.widgets);
+    if (!unavailable.length) return;
+    await new Promise((resolve) => setTimeout(resolve, CUSTOM_WIDGET_REGISTRATION_POLL_MS));
+  }
+  throw new Error(
+    `Required custom widget${unavailable.length === 1 ? "" : "s"} ` +
+      `${unavailable.map((type) => `"${type}"`).join(", ")} are unavailable for this node. ` +
+      "ComfyUI is still loading its extension; retry shortly.",
+  );
 }
 
 // The currently-mounted panel root (set by buildPanel). Used by canvas "fit" to
@@ -6765,7 +6821,7 @@ const GRAPH_TOOL_EXECUTORS = {
   },
 
   async graph_add_node({ class_type, pos, title }) {
-    const { graph, LG } = getGraphCtx();
+    const { app: comfyApp, graph, LG } = getGraphCtx();
     if (!class_type || typeof class_type !== "string") {
       throw new Error("class_type (string) is required");
     }
@@ -6796,16 +6852,20 @@ const GRAPH_TOOL_EXECUTORS = {
       wasTypeEverDefined: (t) => objectInfoHistory.wasTypeEverDefined(t),
     });
     // registerNodesFromDefs can expose a newly installed V3 class before its
-    // extension's asynchronous custom-widget registry settles. Do not
-    // construct in that transient state (#580).
-    await settleFrontendWidgetRegistry();
+    // extension's asynchronous custom-widget registry settles. Resolve the
+    // required constructors before creating anything, or fail retryably before
+    // mutating the graph (#580).
+    await awaitRequiredCustomWidgetRegistration(
+      LG?.registered_node_types?.[class_type]?.nodeData,
+      comfyApp,
+    );
     const node = LG.createNode(class_type);
     if (!node) {
       throw new Error(
         `Unknown node type "${class_type}" — check the exact class_type via get_node_info`,
       );
     }
-    const missingWidgets = missingRequiredWidgetMaterializations(node, app?.widgets);
+    const missingWidgets = missingRequiredWidgetMaterializations(node, comfyApp?.widgets);
     if (missingWidgets.length) {
       throw new Error(
         `Required custom widget${missingWidgets.length === 1 ? "" : "s"} ` +

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -178,6 +178,7 @@ import {
 import { autoMatchSlots, slotDiagnostic } from "./lib/connect-match.js";
 import { isLinkPersisted, removePhantomLink, isWidgetBackedInput } from "./lib/connect-verify.js";
 import { coerceMessageText, isDroppedAgentReplay, serializeContext } from "./lib/chat-serialize.js";
+import { missingRequiredWidgetMaterializations } from "./lib/node-widget-materialization.js";
 import { isImeComposing } from "./lib/ime.js";
 import { installGraphToPromptNullSafety } from "./lib/widget-null-safety.js";
 import {
@@ -5876,6 +5877,20 @@ function placementFor(graph, pos) {
   return [100, 100];
 }
 
+// A custom extension's getCustomWidgets hook is allowed to resolve
+// asynchronously. Node defs can therefore be available one task before the
+// corresponding widget constructors. Yield before creating a node so the
+// constructors are installed before LiteGraph runs onNodeCreated; otherwise a
+// V3 node can be added with bare required sockets that graphToPrompt omits.
+async function settleFrontendWidgetRegistry() {
+  await Promise.resolve();
+  if (typeof requestAnimationFrame === "function") {
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+  } else {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
 // The currently-mounted panel root (set by buildPanel). Used by canvas "fit" to
 // measure how much of the canvas the open sidebar panel overlays.
 let activePanelRoot = null;
@@ -6780,10 +6795,22 @@ const GRAPH_TOOL_EXECUTORS = {
       // #458 OBSERVED-BACKEND-HISTORY trust root, identical to graph_set_widget's.
       wasTypeEverDefined: (t) => objectInfoHistory.wasTypeEverDefined(t),
     });
+    // registerNodesFromDefs can expose a newly installed V3 class before its
+    // extension's asynchronous custom-widget registry settles. Do not
+    // construct in that transient state (#580).
+    await settleFrontendWidgetRegistry();
     const node = LG.createNode(class_type);
     if (!node) {
       throw new Error(
         `Unknown node type "${class_type}" — check the exact class_type via get_node_info`,
+      );
+    }
+    const missingWidgets = missingRequiredWidgetMaterializations(node, app?.widgets);
+    if (missingWidgets.length) {
+      throw new Error(
+        `Required custom widget${missingWidgets.length === 1 ? "" : "s"} ` +
+          `${missingWidgets.map((name) => `"${name}"`).join(", ")} did not initialize for ` +
+          `"${class_type}". Reload ComfyUI so its node extension can register, then retry.`,
       );
     }
     graph.beforeChange();

--- a/web/js/lib/graph-mutation-context.js
+++ b/web/js/lib/graph-mutation-context.js
@@ -1,0 +1,13 @@
+/**
+ * Async preflights must not commit into a graph selected before a tab/subgraph
+ * switch. The caller supplies the workflow comparator because ComfyUI can
+ * expose the same workflow through a Vue proxy and its raw object.
+ */
+export function sameGraphMutationContext(before, after, sameWorkflow = (a, b) => a === b) {
+  return !!before && !!after &&
+    before.app === after.app &&
+    before.graph === after.graph &&
+    before.rootGraph === after.rootGraph &&
+    before.canvas === after.canvas &&
+    sameWorkflow(before.workflow, after.workflow);
+}

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -18,14 +18,42 @@ function inputWidgetType(spec) {
   return Array.isArray(declared) ? "COMBO" : typeof declared === "string" ? declared : null;
 }
 
+function requiredInputs(nodeOrNodeData) {
+  const nodeData = nodeOrNodeData?.constructor?.nodeData ?? nodeOrNodeData;
+  const required = nodeData?.input?.required;
+  return required && typeof required === "object" ? required : null;
+}
+
+/**
+ * The distinct required input types that are eligible to be frontend widgets.
+ * `forceInput` / `widget:false` are sockets even if a custom widget constructor
+ * happens to share their declared type.
+ */
+export function requiredWidgetInputTypes(nodeOrNodeData) {
+  const required = requiredInputs(nodeOrNodeData);
+  if (!required) return [];
+  return [...new Set(Object.values(required).map(inputWidgetType).filter(Boolean))];
+}
+
+/**
+ * Custom widget hooks declare their types before ComfyUI copies them into the
+ * public widget registry. This detects that transient state without treating
+ * unrelated custom socket datatypes as widgets.
+ */
+export function unavailableDeclaredCustomWidgetTypes(nodeOrNodeData, declaredTypes, widgetConstructors) {
+  return requiredWidgetInputTypes(nodeOrNodeData).filter(
+    (type) => declaredTypes?.has(type) && typeof widgetConstructors?.[type] !== "function",
+  );
+}
+
 /**
  * Return required inputs whose registered frontend widget did not materialize
  * on `node`.  A socket-only custom datatype is deliberately not reported: it
  * has no registered widget constructor and is valid to wire later.
  */
 export function missingRequiredWidgetMaterializations(node, widgetConstructors) {
-  const required = node?.constructor?.nodeData?.input?.required;
-  if (!required || typeof required !== "object") return [];
+  const required = requiredInputs(node);
+  if (!required) return [];
 
   const widgets = Array.isArray(node.widgets) ? node.widgets : [];
   const missing = [];
@@ -33,9 +61,10 @@ export function missingRequiredWidgetMaterializations(node, widgetConstructors) 
     const type = inputWidgetType(spec);
     if (!type || typeof widgetConstructors?.[type] !== "function") continue;
     const widget = widgets.find((candidate) => candidate?.name === name);
-    // serialize:false controls must never stand in for a required prompt
-    // value: they are canvas-only and graphToPrompt omits them.
-    if (!widget || widget.serialize === false) missing.push(name);
+    // ComfyUI's prompt serializer reads the widget *options* flag. A widget
+    // property named `serialize` is not authoritative and must not allow a
+    // canvas-only control to satisfy a required prompt value.
+    if (!widget || widget.options?.serialize === false) missing.push(name);
   }
   return missing;
 }

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -35,14 +35,26 @@ export function requiredWidgetInputTypes(nodeOrNodeData) {
   return [...new Set(Object.values(required).map(inputWidgetType).filter(Boolean))];
 }
 
+// These are ComfyUI's built-in connection datatypes. A required input carrying
+// one is safe to leave as a socket when no widget constructor exists. An
+// unrecognised type is NOT assumed safe: it may be a custom V3 widget whose
+// extension is still registering.
+const SAFE_SOCKET_TYPES = new Set([
+  "*", "ANY", "AUDIO", "BBOX", "CLIP", "CLIP_VISION", "CLIP_VISION_OUTPUT",
+  "CONDITIONING", "CONTROL_NET", "GLIGEN", "GUIDER", "IMAGE", "IPADAPTER",
+  "LATENT", "MODEL", "NOISE", "SAMPLER", "SCHEDULER", "SIGMAS", "STYLE_MODEL",
+  "UNET", "UPSCALE_MODEL", "VAE",
+]);
+
 /**
- * Custom widget hooks declare their types before ComfyUI copies them into the
- * public widget registry. This detects that transient state without treating
- * unrelated custom socket datatypes as widgets.
+ * Required input types that might be custom widgets but have not entered the
+ * live ComfyUI registry yet. Unknown custom socket types deliberately remain
+ * unavailable: their schema is indistinguishable from a widget pending its
+ * extension hook, so admitting one would reintroduce #580's bad prompt.
  */
-export function unavailableDeclaredCustomWidgetTypes(nodeOrNodeData, declaredTypes, widgetConstructors) {
-  return requiredWidgetInputTypes(nodeOrNodeData).filter(
-    (type) => declaredTypes?.has(type) && typeof widgetConstructors?.[type] !== "function",
+export function unavailableRequiredCustomWidgetTypes(nodeOrNodeData, widgetConstructors) {
+  return requiredWidgetInputTypes(nodeOrNodeData).filter((type) =>
+    typeof widgetConstructors?.[type] !== "function" && !SAFE_SOCKET_TYPES.has(type),
   );
 }
 

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -1,0 +1,41 @@
+/**
+ * The frontend's node definition retains the V1-shaped input data even for
+ * V3-schema nodes.  A registered widget constructor is the authoritative
+ * signal that an input must be represented by a node widget rather than an
+ * unconnected socket.
+ */
+function inputWidgetType(spec) {
+  if (!Array.isArray(spec)) return null;
+  const config = spec[1];
+  // A forced socket is intentionally not materialized as a widget even when
+  // its type also has a widget constructor.
+  if (config && typeof config === "object" && (config.forceInput || config.widget === false)) {
+    return null;
+  }
+  const declared = spec[0];
+  // Legacy combo specs store their choices as the first tuple item; ComfyUI
+  // materializes those through the COMBO constructor.
+  return Array.isArray(declared) ? "COMBO" : typeof declared === "string" ? declared : null;
+}
+
+/**
+ * Return required inputs whose registered frontend widget did not materialize
+ * on `node`.  A socket-only custom datatype is deliberately not reported: it
+ * has no registered widget constructor and is valid to wire later.
+ */
+export function missingRequiredWidgetMaterializations(node, widgetConstructors) {
+  const required = node?.constructor?.nodeData?.input?.required;
+  if (!required || typeof required !== "object") return [];
+
+  const widgets = Array.isArray(node.widgets) ? node.widgets : [];
+  const missing = [];
+  for (const [name, spec] of Object.entries(required)) {
+    const type = inputWidgetType(spec);
+    if (!type || typeof widgetConstructors?.[type] !== "function") continue;
+    const widget = widgets.find((candidate) => candidate?.name === name);
+    // serialize:false controls must never stand in for a required prompt
+    // value: they are canvas-only and graphToPrompt omits them.
+    if (!widget || widget.serialize === false) missing.push(name);
+  }
+  return missing;
+}


### PR DESCRIPTION
## Summary

- wait for ComfyUI's asynchronous custom-widget registry before `panel_add_node` constructs a freshly registered V3 node
- reject the add before graph mutation when a required registered widget was not materialized or is canvas-only
- cover V3 custom widgets, socket-only datatypes, and forced-input compatibility

## Root cause

`registerNodesFromDefs` can expose a newly installed V3 class before the frontend has completed its `getCustomWidgets` hook. Constructing in that window leaves required custom inputs as bare sockets, so `graphToPrompt` omits their values and backend validation fails.

## Validation

- `npm.cmd run test:unit` (1706 passing)
- `npm.cmd run typecheck`
