### PR TITLE
fix(panel): graph_connect reply before graph snapshot (#581)

### DIFF
--- a/browser_tests/unit/change-tracker-snapshot.test.mjs
+++ b/browser_tests/unit/change-tracker-snapshot.test.mjs
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { deferChangeTrackerSnapshot } from "../../web/js/lib/change-tracker-snapshot.js";
+
+test("#581 defers the captured tracker snapshot and preserves its receiver", () => {
+  let queued = null;
+  let delay = null;
+  let calls = 0;
+  const tracker = {
+    checkState() {
+      assert.equal(this, tracker, "checkState must run on the tracker from the completed edit");
+      calls += 1;
+    },
+  };
+
+  assert.equal(
+    deferChangeTrackerSnapshot(tracker, (callback, ms) => {
+      queued = callback;
+      delay = ms;
+    }),
+    true,
+  );
+  assert.equal(calls, 0, "the expensive serialization cannot run before the reply path returns");
+  assert.equal(delay, 0);
+  queued();
+  assert.equal(calls, 1);
+});
+
+test("#581 ignores unavailable trackers and swallows a deferred teardown failure", () => {
+  assert.equal(deferChangeTrackerSnapshot(null), false);
+  let queued = null;
+  assert.equal(
+    deferChangeTrackerSnapshot({ checkState() { throw new Error("workflow disposed"); } }, (callback) => {
+      queued = callback;
+    }),
+    true,
+  );
+  assert.doesNotThrow(() => queued());
+});
+
+test("#581 wires the deferred snapshot after delivering a successful command reply", () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const source = readFileSync(join(here, "../../web/js/comfyui-mcp-panel.js"), "utf8").replace(/\r\n/g, "\n");
+  const capture = source.indexOf("changeTrackerToSnapshot =");
+  const deliver = source.indexOf("if (deliverReply(reply, msg.cmd, superseded))", capture);
+  const defer = source.indexOf("deferChangeTrackerSnapshot(changeTrackerToSnapshot)", deliver);
+  assert.ok(capture >= 0, "successful executor path captures its tracker");
+  assert.ok(deliver > capture, "reply delivery follows the successful executor");
+  assert.ok(defer > deliver, "snapshot is scheduled only after the reply is delivered");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -177,6 +177,7 @@ import {
 } from "./lib/control-after-generate.js";
 import { autoMatchSlots, slotDiagnostic } from "./lib/connect-match.js";
 import { isLinkPersisted, removePhantomLink, isWidgetBackedInput } from "./lib/connect-verify.js";
+import { deferChangeTrackerSnapshot } from "./lib/change-tracker-snapshot.js";
 import { coerceMessageText, isDroppedAgentReplay, serializeContext } from "./lib/chat-serialize.js";
 import { isImeComposing } from "./lib/ime.js";
 import { installGraphToPromptNullSafety } from "./lib/widget-null-safety.js";
@@ -11578,6 +11579,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         }
         const settleRid = commandRidLedger.begin(msg.rid, fingerprint, commandEpoch);
         let reply;
+        // #581 — retain the tracker belonging to the command's completed edit.
+        // We schedule its full-graph serialization only after the bridge reply
+        // has been handed to the socket below, so a large nested subgraph cannot
+        // turn an already-applied graph_connect into a false timeout.
+        let changeTrackerToSnapshot = null;
         try {
           let result;
           if (msg.cmd === "ask_user") {
@@ -11800,12 +11806,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // mutations were invisible to undo (Ctrl+Z did nothing). An explicit
             // checkState() after each successful command pushes the pre-command
             // state onto the undo queue; it diffs first, so read-only commands
-            // (get_state, screenshot, dry_run) are free no-ops.
-            try {
-              app.extensionManager?.workflow?.activeWorkflow?.changeTracker?.checkState?.();
-            } catch {
-              /* tracker unavailable (older frontend) — undo stays best-effort */
-            }
+            // (get_state, screenshot, dry_run) are free no-ops. The snapshot can
+            // serialize a whole nested graph, so capture it now but defer the work
+            // until after the correlated reply is delivered (#581).
+            changeTrackerToSnapshot = app.extensionManager?.workflow?.activeWorkflow?.changeTracker ?? null;
           }
           reply = { rid: msg.rid, ok: true, result };
         } catch (err) {
@@ -11841,6 +11845,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           // becomes a claim about what the caller received — only `applied` is that.
           markOpenReceiptReplySent(openReceipts, msg.rid);
         }
+        deferChangeTrackerSnapshot(changeTrackerToSnapshot);
         if (superseded) return;
         // ask_user / request_secret paint their OWN cards and their replies carry
         // user input (a choice, or a SECRET) — never echo them as an activity card

--- a/web/js/lib/change-tracker-snapshot.js
+++ b/web/js/lib/change-tracker-snapshot.js
@@ -1,0 +1,25 @@
+// Schedule ComfyUI's expensive ChangeTracker serialization after a bridge reply.
+//
+// Bridge graph edits must still enter the native undo history, but serializing a
+// large nested subgraph synchronously in the command handler delays the rid reply
+// long enough for the orchestrator's panel timeout to fire (#581). Capture the
+// tracker that owned the completed edit, then yield one UI turn before asking it
+// to snapshot. Capturing it matters: looking up activeWorkflow in the callback
+// could snapshot a tab the user selected after the edit instead.
+
+/**
+ * Queue a best-effort ChangeTracker snapshot without blocking the current command
+ * reply. Returns whether a snapshot was queued. `schedule` is injectable for the
+ * no-DOM unit test; production uses the browser timer.
+ */
+export function deferChangeTrackerSnapshot(changeTracker, schedule = setTimeout) {
+  if (typeof changeTracker?.checkState !== "function") return false;
+  schedule(() => {
+    try {
+      changeTracker.checkState();
+    } catch {
+      // Older frontends and transient workflow teardown keep undo best-effort.
+    }
+  }, 0);
+  return true;
+}


### PR DESCRIPTION
## Summary
- deliver the correlated command reply before scheduling ChangeTracker's expensive full-graph snapshot
- retain the ChangeTracker captured from the completed edit so a later tab switch cannot snapshot a different workflow
- add unit coverage for asynchronous scheduling, receiver preservation, unavailable/teardown trackers, and reply-before-snapshot wiring

## Validation
- npm.cmd run test:unit (1705 passed)
- npm.cmd run typecheck
- git diff --cached --check