### PR TITLE
fix(panel): label cancelled reconnect runs truthfully (#582)

### DIFF
--- a/browser_tests/unit/run-reconcile.test.mjs
+++ b/browser_tests/unit/run-reconcile.test.mjs
@@ -29,10 +29,12 @@ function makeHarness(opts = {}) {
   let seq = 0;
   const flushes = [];
   const errors = [];
+  const interruptions = [];
   const giveUps = [];
   const tracker = createRunCompletionTracker({
     onFlush: (p) => flushes.push(p),
     onReconcileError: (e) => errors.push(e),
+    onReconcileInterrupted: (e) => interruptions.push(e),
     onReconcileGiveUp: (e) => giveUps.push(e),
     now: () => clock,
     setTimer: (fn, ms) => {
@@ -48,6 +50,7 @@ function makeHarness(opts = {}) {
     tracker,
     flushes,
     errors,
+    interruptions,
     giveUps,
     advance: (ms) => {
       clock += ms;
@@ -95,6 +98,38 @@ test("parseHistoryEntry: terminal success classifies stills vs videos", () => {
 test("parseHistoryEntry: an errored run is terminal with status error and no batch delivered", () => {
   const parsed = parseHistoryEntry(
     { outputs: {}, status: { status_str: "error", completed: false } },
+    { isVideo },
+  );
+  assert.equal(parsed.terminal, true);
+  assert.equal(parsed.status, "error");
+});
+
+test("parseHistoryEntry: ComfyUI's raw error plus execution_interrupted is a terminal cancellation", () => {
+  const parsed = parseHistoryEntry(
+    {
+      outputs: {},
+      status: {
+        status_str: "error",
+        completed: false,
+        messages: [["execution_interrupted", { prompt_id: "cancelled" }]],
+      },
+    },
+    { isVideo },
+  );
+  assert.equal(parsed.terminal, true);
+  assert.equal(parsed.status, "interrupted");
+});
+
+test("parseHistoryEntry: a real execution_error wins over an interrupted marker", () => {
+  const parsed = parseHistoryEntry(
+    {
+      outputs: {},
+      status: {
+        status_str: "error",
+        completed: false,
+        messages: [["execution_interrupted", {}], ["execution_error", { exception_message: "boom" }]],
+      },
+    },
     { isVideo },
   );
   assert.equal(parsed.terminal, true);
@@ -235,6 +270,29 @@ test("#370 errored run recovered from history: no batch delivered, status error 
   const summary = await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
   assert.equal(flushes.length, 0, "no completion batch for a failed run");
   assert.deepEqual(summary, [{ promptId: "pE", status: "error" }]);
+});
+
+test("#582 interrupted run recovered from history emits only the neutral cancellation hook", async () => {
+  const { tracker, flushes, errors, interruptions } = makeHarness();
+  tracker.onExecutionStart("pCancel");
+  tracker.onExecuted("pCancel", { images: [{ filename: "partial.png", type: "output" }] });
+  const history = {
+    pCancel: {
+      outputs: {},
+      status: {
+        status_str: "error",
+        completed: false,
+        messages: [["execution_interrupted", { prompt_id: "pCancel" }]],
+      },
+    },
+  };
+  const summary = await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
+  assert.deepEqual(summary, [{ promptId: "pCancel", status: "interrupted" }]);
+  assert.equal(flushes.length, 0, "a cancelled run never delivers a partial batch");
+  assert.deepEqual(errors, [], "a cancelled run never enters the error hook");
+  assert.deepEqual(interruptions, [{ promptId: "pCancel" }], "neutral hook fires exactly once");
+  await tracker.reconcile({ fetchHistory: async (id) => history[id] ?? null, isVideo });
+  assert.deepEqual(interruptions, [{ promptId: "pCancel" }], "a second reconnect does not repeat the event");
 });
 
 test("#370 codex P1 (idempotency): a LATE executed+execution_success after reconcile does NOT double-deliver", async () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -19134,6 +19134,21 @@ function buildPanel() {
       // transport failure re-pends so the next reconnect/retry re-delivers it.
       else if (!AGENT_MUTED) runCompletion.markUndelivered(promptId);
     },
+    // #582: ComfyUI writes a manually stopped run to history with raw
+    // status_str:"error" plus execution_interrupted. Deliver a neutral event,
+    // not run_error: the orchestrator treats run_error as urgent and tells the
+    // agent to diagnose/panel_get_errors. `executed` with a note is the existing
+    // non-urgent event protocol, and does not claim an output was produced.
+    onReconcileInterrupted: ({ promptId }) => {
+      const note =
+        `The workflow run you queued was cancelled while the connection was down (prompt ${promptId}). ` +
+        `It did not crash; no action is required unless the cancellation was unintended.`;
+      const sent = client.sendFrame({ type: "agent_event", kind: "executed", note });
+      if (sent) appendSystem(`Queued render was cancelled while disconnected (prompt ${promptId}).`);
+      // Match terminal-error recovery: only a transport drop re-pends the
+      // cancellation notice; an intentionally muted agent stays silent.
+      else if (!AGENT_MUTED) runCompletion.markUndelivered(promptId);
+    },
     // #370 (P1 memory-leak): the tracker GAVE UP on a prompt whose outcome it
     // couldn't confirm after the bounded retries (its /history stayed absent —
     // cancelled/disconnected). It's been evicted from the ledger; surface a

--- a/web/js/lib/history-reconcile.js
+++ b/web/js/lib/history-reconcile.js
@@ -20,7 +20,7 @@
  * @param {object}   [opts]
  * @param {(m:object)=>boolean} [opts.isVideo]  Classifies an output ref as video
  *   (else still image), matching the live path's classification.
- * @returns {null | { terminal:boolean, status:("success"|"error"|"unknown"),
+ * @returns {null | { terminal:boolean, status:("success"|"error"|"interrupted"|"unknown"),
  *   images:object[], videos:{m:object,nodeId:string}[] }}
  *   `null` when there's no usable entry.
  */
@@ -30,14 +30,25 @@ export function parseHistoryEntry(entry, { isVideo } = {}) {
   const status = entry.status && typeof entry.status === "object" ? entry.status : {};
   const statusStr = typeof status.status_str === "string" ? status.status_str : null;
   const completedFlag = status.completed === true;
+  const messages = Array.isArray(status.messages) ? status.messages : [];
+
+  // ComfyUI records a manually stopped render as status_str:"error" plus an
+  // execution_interrupted lifecycle message. That is a terminal cancellation,
+  // not an execution failure: diagnose_run makes the same distinction. An actual
+  // execution_error wins if an unusual record carries both markers.
+  const hasMessage = (name) => messages.some((message) => Array.isArray(message) && message[0] === name);
+  const hasExecutionError = hasMessage("execution_error");
+  const isInterrupted =
+    !hasExecutionError &&
+    (hasMessage("execution_interrupted") || statusStr === "interrupted" || statusStr === "cancelled" || statusStr === "canceled");
 
   // Terminal ONLY when ComfyUI marks the prompt done. `status_str:"error"` is a
   // terminal failure; `status_str:"success"` or `completed:true` is a terminal
   // success. Anything else (still running, or an entry without a terminal status)
   // is NOT reconcilable yet — leave it pending so a later reconnect retries.
-  const isError = statusStr === "error";
-  const isSuccess = !isError && (statusStr === "success" || completedFlag);
-  const terminal = isError || isSuccess;
+  const isError = !isInterrupted && statusStr === "error";
+  const isSuccess = !isError && !isInterrupted && (statusStr === "success" || completedFlag);
+  const terminal = isError || isSuccess || isInterrupted;
 
   const images = [];
   const videos = [];
@@ -58,7 +69,7 @@ export function parseHistoryEntry(entry, { isVideo } = {}) {
 
   return {
     terminal,
-    status: isError ? "error" : isSuccess ? "success" : "unknown",
+    status: isError ? "error" : isInterrupted ? "interrupted" : isSuccess ? "success" : "unknown",
     images,
     videos,
   };

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -64,6 +64,7 @@ export const NO_PROMPT_KEY = "__no_prompt__";
 export function createRunCompletionTracker({
   onFlush,
   onReconcileError,
+  onReconcileInterrupted,
   onReconcileGiveUp,
   now = () => Date.now(),
   setTimer = (fn, ms) => setTimeout(fn, ms),
@@ -376,6 +377,19 @@ export function createRunCompletionTracker({
         }
       }
       return { promptId, status: "error" };
+    }
+    if (parsed.status === "interrupted") {
+      // A manual stop is terminal, but it is not a failed run. Keep it on a
+      // distinct hook so reconnect never routes it through the urgent
+      // run_error/panel_get_errors path (#582).
+      if (typeof onReconcileInterrupted === "function") {
+        try {
+          onReconcileInterrupted({ promptId });
+        } catch {
+          /* presentation error must never wedge reconciliation */
+        }
+      }
+      return { promptId, status: "interrupted" };
     }
     const hasBatch = parsed.images.length > 0 || parsed.videos.length > 0;
     if (hasBatch) {


### PR DESCRIPTION
Fixes #582.\n\nComfyUI records a manually interrupted render as raw \status_str: error\ with an \execution_interrupted\ history message. Reconnect reconciliation now classifies that record as a terminal cancellation, emits a neutral non-urgent note, and preserves \un_error\ only for genuine \execution_error\ records.\n\nValidation:\n- \
pm.cmd run test:unit\ (1708 passing)\n- \
pm.cmd run typecheck\\n- focused #582 reconcile regressions