### PR TITLE
fix(panel): prevent restart resume from duplicating active render

### DIFF
--- a/browser_tests/unit/restart-resume.test.mjs
+++ b/browser_tests/unit/restart-resume.test.mjs
@@ -607,6 +607,39 @@ test("#585 P1(budget-vs-evidence): a bridge drop refreshes the BUDGET without er
   );
 });
 
+test("#585 P1(unknown-count): an absent or malformed attempt count is UNKNOWN, not a verified zero", () => {
+  // Coercing it to 0 says "no attempt was ever made" on no evidence, and that is
+  // precisely what suppresses the duplicate warning.
+  for (const bad of [{}, { t: "2" }, { t: null }, { ts: {} }, { t: NaN, ts: NaN }]) {
+    const m = decodeRebootMarker(JSON.stringify({ v: 1, at: 1000, runs: [], n: 0, ...bad }));
+    assert.equal(m.totalAttempts, null, JSON.stringify(bad));
+    assert.equal(
+      rebootResumeRepeatWarning({ totalAttempts: m.totalAttempts, attemptRecorded: true, sentThisMount: 0 }),
+      true,
+      `an unknown count must warn (${JSON.stringify(bad)})`,
+    );
+  }
+});
+
+test("#585 P1(unknown-count): re-encoding an unknown count must not launder it into a zero", () => {
+  // A retained marker is re-encoded on every wait tick, so a lossy round-trip would
+  // convert "unknown" to "verified none" within seconds of the uncertainty arising.
+  const unknown = decodeRebootMarker(JSON.stringify({ v: 1, at: 1000, runs: ["P"], n: 1 }));
+  assert.equal(unknown.totalAttempts, null);
+  const round = decodeRebootMarker(encodeRebootMarker({ ...unknown }));
+  assert.equal(round.totalAttempts, null, "still unknown after a round-trip");
+  assert.equal(round.attempts, null);
+
+  // …and the wait path, which rewrites the marker, preserves it too.
+  const held = stepRebootResume({
+    raw: encodeRebootMarker({ ...unknown }),
+    isSettled: () => false,
+    nowMs: 1100,
+  });
+  assert.equal(held.decision, "wait_for_run");
+  assert.equal(decodeRebootMarker(held.nextRaw).totalAttempts, null);
+});
+
 test("#585: a legacy marker with only the per-episode count still reports it as evidence", () => {
   // `ts` absent ⇒ fall back to `t` rather than to zero: an older marker that
   // recorded one attempt must not read as "never attempted".

--- a/browser_tests/unit/restart-resume.test.mjs
+++ b/browser_tests/unit/restart-resume.test.mjs
@@ -1,19 +1,437 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { planRebootResume } from "../../web/js/lib/restart-resume.js";
+import {
+  adoptRebootRuns,
+  decodeRebootMarker,
+  encodeRebootMarker,
+  planRebootResume,
+  pruneRebootMarkerRaw,
+  rebootMarkerAfterSend,
+  stepRebootResume,
+  unsettledRebootRuns,
+  REBOOT_RESUME_MAX_WAIT_MS,
+} from "../../web/js/lib/restart-resume.js";
+import { createRunCompletionTracker } from "../../web/js/lib/run-completion.js";
 
-test("#585: a pre-restart render pending in the completion ledger suppresses the generic resume nudge", () => {
-  // The run may have survived the backend restart. Its terminal completion (or
-  // conservative reconnect reconciliation) is the signal that may wake the
-  // resumed agent; a generic "continue" prompt would invite a duplicate queue.
-  assert.equal(planRebootResume({ rebootPending: true, hasPendingRun: true }), "wait_for_run");
-});
+// A real tracker with manual timers, so these tests exercise the ACTUAL delivery
+// lifecycle rather than a hand-rolled stand-in for it. `fireTimers(ms)` runs the
+// pending timers armed for that exact delay — used to trip the delivery watchdog.
+function makeTracker(onFlush = () => {}) {
+  const timers = new Set();
+  const clock = { t: 1_000_000 };
+  const tracker = createRunCompletionTracker({
+    onFlush,
+    now: () => clock.t,
+    setTimer: (fn, ms) => {
+      const t = { fn, ms };
+      timers.add(t);
+      return t;
+    },
+    clearTimer: (t) => timers.delete(t),
+  });
+  tracker._advance = (ms) => {
+    clock.t += ms;
+  };
+  tracker._fireTimers = (ms) => {
+    for (const t of [...timers]) {
+      if (t.ms !== ms) continue;
+      timers.delete(t);
+      t.fn();
+    }
+  };
+  return tracker;
+}
 
-test("#585: an actual reboot with no pending render retains autonomous resume", () => {
-  assert.equal(planRebootResume({ rebootPending: true, hasPendingRun: false }), "resume");
-});
+const settledBy = (tracker) => (id) => tracker.isSettled(id);
+const unconfirmedBy = (tracker) => (id) => tracker.isDeliveryUnconfirmed(id);
+const DELIVERY_WATCHDOG_MS = 120000;
+
+// ── the planner's own branches ────────────────────────────────────────────────
 
 test("#585: no reboot marker never injects a restart-resume message", () => {
-  assert.equal(planRebootResume({ rebootPending: false, hasPendingRun: true }), "none");
+  assert.equal(planRebootResume({ rebootPending: false, unsettledRuns: ["a"] }), "none");
+});
+
+test("#585: a reboot with nothing owed resumes autonomously", () => {
+  assert.equal(planRebootResume({ rebootPending: true, unsettledRuns: [] }), "resume");
+});
+
+test("#585: a reboot whose watched render is still owed a completion frame waits", () => {
+  assert.equal(planRebootResume({ rebootPending: true, unsettledRuns: ["p1"] }), "wait_for_run");
+});
+
+// ── P1 #1 — the guard must survive a frontend RELOAD ──────────────────────────
+
+test("#585 P1(reload): after a reload the fresh EMPTY ledger must not report the still-running render as finished", () => {
+  // Pre-restart mount: render P is queued and running when the reboot is armed.
+  const armed = makeTracker();
+  armed.onQueued("P");
+  armed.onExecutionStart("P");
+  const raw = encodeRebootMarker({ at: 1000, runs: armed.unsettledPromptIds() });
+  assert.deepEqual(decodeRebootMarker(raw).runs, ["P"], "the marker carries the SPECIFIC run id");
+
+  // …the restart reloads the frontend. New mount ⇒ brand-new, EMPTY tracker; only
+  // sessionStorage (the marker) survived.
+  const fresh = makeTracker();
+  assert.equal(
+    fresh.isSettled("P"),
+    true,
+    "an id the fresh ledger never heard of owes nothing — exactly the trap the first fix fell into",
+  );
+
+  // Reload survival: re-adopt the PERSISTED ids before deciding anything.
+  const adopted = adoptRebootRuns(decodeRebootMarker(raw).runs, fresh);
+  assert.deepEqual(adopted, ["P"]);
+  assert.equal(fresh.isSettled("P"), false);
+
+  const step = stepRebootResume({ raw, isSettled: settledBy(fresh), nowMs: 1100 });
+  assert.equal(step.decision, "wait_for_run", "a render still in flight must not be nudged over");
+  assert.notEqual(step.nextRaw, null, "and the marker must survive the suppression");
+});
+
+test("#585 P1(reload): a still-unconfirmed run is not re-adopted within the SAME mount after its replay fence ages out", () => {
+  // The terminal fence has a 10-minute TTL. Without the unconfirmed flag counting as
+  // "known", a repeated ready ack past that TTL would re-adopt the run and let
+  // reconcile dispatch its completion a second time.
+  const t = makeTracker();
+  t.onQueued("P");
+  t.onExecutionStart("P");
+  t.onExecuted("P", { images: [{ filename: "a.png" }] });
+  t.onExecutionSuccess("P");
+  t._fireTimers(DELIVERY_WATCHDOG_MS); // dispatched, never confirmed
+  t._advance(11 * 60 * 1000);
+  t.onQueued("other");
+  t.markDelivered("other"); // drives a fence prune past the TTL
+  assert.equal(t._terminal.has("P"), false, "the replay fence really did age out");
+  assert.deepEqual(adoptRebootRuns(["P"], t), [], "…but the run is still KNOWN, so it is not re-adopted");
+});
+
+test("#585 P1(reload): adoption never resurrects a run this mount already resolved", () => {
+  const t = makeTracker();
+  t.onQueued("P");
+  t.markDelivered("P"); // already reported to the agent on this mount
+  const adopted = adoptRebootRuns(["P"], t);
+  assert.deepEqual(adopted, [], "re-pending it would make /history deliver its completion a SECOND time");
+  assert.equal(t.isSettled("P"), true);
+});
+
+// ── P1 #2 — correlation, not a global count; never clear while suppressing ─────
+
+test("#585 P1(correlation): an UNRELATED render in flight must not swallow a legitimate resume", () => {
+  const t = makeTracker();
+  t.onQueued("B"); // a different workflow's render, not one we are waiting on
+  // Nothing of ours was in flight when the reboot was armed.
+  const raw = encodeRebootMarker({ at: 1000, runs: [] });
+  assert.equal(t.hasPending(), true, "the GLOBAL predicate the first fix used is TRUE here");
+  const step = stepRebootResume({ raw, isSettled: settledBy(t), nowMs: 1100 });
+  assert.equal(step.decision, "resume", "…but no run WE are waiting on is owed, so the resume must fire");
+  assert.equal(step.nextRaw, null);
+});
+
+test("#585 P1(correlation): suppressing RETAINS the marker, so the resume is reissued once the watched run settles", () => {
+  const t = makeTracker();
+  t.onQueued("P");
+  let raw = encodeRebootMarker({ at: 1000, runs: ["P"] });
+
+  const first = stepRebootResume({ raw, isSettled: settledBy(t), nowMs: 1100 });
+  assert.equal(first.decision, "wait_for_run");
+  assert.notEqual(
+    first.nextRaw,
+    null,
+    "clearing the marker here is the SILENT failure — the user waits forever for a turn that never starts",
+  );
+  raw = first.nextRaw;
+
+  // The watched render finally reports back and its frame reaches the agent.
+  t.markDelivered("P");
+  const second = stepRebootResume({ raw, isSettled: settledBy(t), nowMs: 1200 });
+  assert.equal(second.decision, "resume", "the suppressed resume must be REISSUED, not lost");
+  assert.equal(second.nextRaw, null, "and only now is the marker retired");
+  assert.equal(second.marker.armedRunCount, 1, "the resume knows it waited, so it can say so truthfully");
+});
+
+test("#585 P1(correlation): a run re-pended after a failed send re-opens the wait", () => {
+  const t = makeTracker();
+  t.onQueued("P");
+  t.markDelivered("P");
+  const raw = encodeRebootMarker({ at: 1000, runs: ["P"] });
+  assert.equal(stepRebootResume({ raw, isSettled: settledBy(t), nowMs: 1100 }).decision, "resume");
+  t.markUndelivered("P"); // bridge was down — the agent was NOT told after all
+  assert.equal(stepRebootResume({ raw, isSettled: settledBy(t), nowMs: 1100 }).decision, "wait_for_run");
+});
+
+test("#585: the persisted marker is pruned as watched runs settle, so a reload re-adopts only what is still owed", () => {
+  const t = makeTracker();
+  t.onQueued("A");
+  t.onQueued("B");
+  const raw = encodeRebootMarker({ at: 1000, runs: ["A", "B"] });
+  t.markDelivered("A");
+  const pruned = decodeRebootMarker(pruneRebootMarkerRaw(raw, settledBy(t)));
+  assert.deepEqual(pruned.runs, ["B"]);
+  assert.equal(pruned.armedRunCount, 2, "how many it waited on is not lost by pruning");
+  assert.equal(pruned.at, 1000, "…nor is the arm time, which bounds the wait");
+});
+
+// ── P1 #3 — gate on DELIVERED, not on the pre-delivery optimistic retire ───────
+
+test("#585 P1(delivery): a completion dispatched but not yet delivered still suppresses the resume", () => {
+  const flushed = [];
+  const t = makeTracker((p) => flushed.push(p));
+  t.onQueued("P");
+  t.onExecutionStart("P");
+  t.onExecuted("P", { images: [{ filename: "a.png" }] });
+  const raw = encodeRebootMarker({ at: 1000, runs: ["P"] });
+
+  t.onExecutionSuccess("P");
+  assert.equal(flushed.length, 1, "the batch was handed to the caller…");
+  assert.equal(
+    t.hasPending(),
+    false,
+    "…and the ledger retired it OPTIMISTICALLY, before the caller's async compose+send resolved",
+  );
+  assert.equal(t.isSettled("P"), false, "but NO frame has reached the agent yet");
+  assert.equal(
+    stepRebootResume({ raw, isSettled: settledBy(t), nowMs: 1100 }).decision,
+    "wait_for_run",
+    "a resume sent in this window arrives BEFORE the completion — the agent re-queues the render",
+  );
+
+  // The caller's compose+send finally resolves and confirms delivery.
+  t.markDelivered("P");
+  assert.equal(t.isSettled("P"), true);
+  assert.equal(stepRebootResume({ raw, isSettled: settledBy(t), nowMs: 1200 }).decision, "resume");
+});
+
+test("#585 P1(delivery): a dispatched completion whose send FAILS goes back to owed, not settled", () => {
+  const t = makeTracker();
+  t.onQueued("P");
+  t.onExecutionStart("P");
+  t.onExecuted("P", { images: [{ filename: "a.png" }] });
+  t.onExecutionSuccess("P");
+  t.markUndelivered("P"); // bridge down
+  assert.equal(t.isSettled("P"), false);
+  assert.equal(t.unsettledPromptIds().includes("P"), true);
+});
+
+test("#585: a run mid-delivery is still reported by unsettledPromptIds, so arming a reboot then records it", () => {
+  const t = makeTracker();
+  t.onQueued("P");
+  t.onExecutionStart("P");
+  t.onExecuted("P", { images: [{ filename: "a.png" }] });
+  t.onExecutionSuccess("P"); // dispatched, delivery unconfirmed
+  assert.deepEqual(t.unsettledPromptIds(), ["P"]);
+});
+
+test("#585 P1(delivery): a dispatched completion the caller NEVER confirms must not be resumed over as if it had been delivered", () => {
+  const t = makeTracker();
+  t.onQueued("P");
+  t.onExecutionStart("P");
+  t.onExecuted("P", { images: [{ filename: "a.png" }] });
+  t.onExecutionSuccess("P");
+  const raw = encodeRebootMarker({ at: 1000, runs: ["P"] });
+
+  // The caller's compose/send promise never settles. The watchdog must release the
+  // block (otherwise the session strands) WITHOUT claiming the agent was told.
+  t._fireTimers(DELIVERY_WATCHDOG_MS);
+  assert.equal(t.isSettled("P"), true, "it must stop blocking — an eternal wait is the silent failure");
+  assert.equal(t.isDeliveryUnconfirmed("P"), true, "…but delivery was never confirmed");
+
+  const step = stepRebootResume({
+    raw,
+    isSettled: settledBy(t),
+    isDeliveryUnconfirmed: unconfirmedBy(t),
+    nowMs: 1100,
+  });
+  assert.equal(
+    step.decision,
+    "resume_unconfirmed",
+    'a plain "resume" here tells the agent its result was already delivered — a false reassurance that invites the duplicate',
+  );
+  assert.deepEqual(step.owed, ["P"]);
+});
+
+test("#585 P1(delivery): an unconfirmed run is kept in the persisted marker while a DIFFERENT run is still owed", () => {
+  const t = makeTracker();
+  t.onQueued("A");
+  t.onQueued("B");
+  t.onExecutionStart("B");
+  t.onExecuted("B", { images: [{ filename: "b.png" }] });
+  t.onExecutionSuccess("B");
+  t._fireTimers(DELIVERY_WATCHDOG_MS); // B: dispatched, never confirmed
+  const raw = encodeRebootMarker({ at: 1000, runs: ["A", "B"] });
+
+  const waiting = stepRebootResume({
+    raw,
+    isSettled: settledBy(t),
+    isDeliveryUnconfirmed: unconfirmedBy(t),
+    nowMs: 1100,
+  });
+  assert.equal(waiting.decision, "wait_for_run", "A is still owed");
+  assert.deepEqual(
+    decodeRebootMarker(waiting.nextRaw).runs,
+    ["A", "B"],
+    "dropping B here would erase the only evidence the eventual resume has to disclose",
+  );
+
+  t.markDelivered("A");
+  const done = stepRebootResume({
+    raw: waiting.nextRaw,
+    isSettled: settledBy(t),
+    isDeliveryUnconfirmed: unconfirmedBy(t),
+    nowMs: 1200,
+  });
+  assert.equal(done.decision, "resume_unconfirmed");
+});
+
+test("#585 P1(delivery): a confirmed delivery clears the unconfirmed flag", () => {
+  const t = makeTracker();
+  t.onQueued("P");
+  t.onExecutionStart("P");
+  t.onExecuted("P", { images: [{ filename: "a.png" }] });
+  t.onExecutionSuccess("P");
+  t._fireTimers(DELIVERY_WATCHDOG_MS);
+  t.markDelivered("P"); // the compose finally resolved after all
+  assert.equal(t.isDeliveryUnconfirmed("P"), false);
+  const raw = encodeRebootMarker({ at: 1000, runs: ["P"] });
+  assert.equal(
+    stepRebootResume({ raw, isSettled: settledBy(t), isDeliveryUnconfirmed: unconfirmedBy(t), nowMs: 1100 })
+      .decision,
+    "resume",
+  );
+});
+
+test("#585 P1(delivery): the unconfirmed-delivery flag does not EXPIRE under the restart backstop's window", () => {
+  // The fences age out on a 10-minute TTL; the restart resume may still be waiting
+  // at 15 minutes. If the flag aged with them, a run whose frame never reached the
+  // agent would silently read as delivered and get the reassuring resume.
+  const t = makeTracker();
+  t.onQueued("P");
+  t.onExecutionStart("P");
+  t.onExecuted("P", { images: [{ filename: "a.png" }] });
+  t.onExecutionSuccess("P");
+  t._fireTimers(DELIVERY_WATCHDOG_MS);
+  assert.equal(t.isDeliveryUnconfirmed("P"), true);
+
+  // Age the clock well past the fence TTL and run every age-based sweep the tracker
+  // has: its own self-scheduled prune, plus the prune every terminal marking does.
+  const FENCE_TTL_MS = 10 * 60 * 1000;
+  t._advance(FENCE_TTL_MS * 2);
+  t._fireTimers(FENCE_TTL_MS);
+  t.onQueued("later");
+  t.markDelivered("later"); // markDelivered ⇒ markTerminal ⇒ pruneFences
+  assert.equal(t._terminal.has("P"), false, "the ordinary fences DID age out — the sweep really ran");
+
+  assert.equal(t.isDeliveryUnconfirmed("P"), true, "the evidence must outlive the fence TTL");
+  const raw = encodeRebootMarker({ at: 1000, runs: ["P"] });
+  assert.equal(
+    stepRebootResume({
+      raw,
+      isSettled: settledBy(t),
+      isDeliveryUnconfirmed: unconfirmedBy(t),
+      nowMs: 1000 + REBOOT_RESUME_MAX_WAIT_MS - 1,
+    }).decision,
+    "resume_unconfirmed",
+  );
+});
+
+test("#585 P1(delivery): a give-up notice that never reached the agent is flagged, not treated as told", () => {
+  // The give-up path EVICTS the run from the ledger, so unlike the error path there
+  // is nothing to re-pend when its one frame is dropped.
+  const t = makeTracker();
+  t.onQueued("P");
+  t.markDelivered("P"); // stand-in for the give-up eviction
+  assert.equal(t.isSettled("P"), true);
+  t.markDeliveryUnconfirmed("P"); // …but its notice could not be sent
+  assert.equal(t.isSettled("P"), true, "it must not block — nothing will ever settle it");
+  assert.equal(t.isDeliveryUnconfirmed("P"), true);
+  const raw = encodeRebootMarker({ at: 1000, runs: ["P"] });
+  assert.equal(
+    stepRebootResume({ raw, isSettled: settledBy(t), isDeliveryUnconfirmed: unconfirmedBy(t), nowMs: 1100 })
+      .decision,
+    "resume_unconfirmed",
+  );
+});
+
+// ── a resume the transport refused must not be retired ────────────────────────
+
+test("#585 P1(send): a REFUSED send keeps the marker, so the resume is reissued instead of lost", () => {
+  const step = { decision: "resume", marker: { at: 1000, runs: [], armedRunCount: 1 }, nextRaw: null };
+  const kept = rebootMarkerAfterSend(step, false);
+  assert.notEqual(kept, null, "a closed socket returns false — retiring the marker here strands the session");
+  assert.equal(decodeRebootMarker(kept).armedRunCount, 1, "and the retained marker keeps its context");
+  assert.equal(rebootMarkerAfterSend(step, true), null, "only a CONFIRMED send retires it");
+});
+
+test("#585 P1(send): a wait step's marker is retained regardless of any send outcome", () => {
+  const step = {
+    decision: "wait_for_run",
+    marker: { at: 1000, runs: ["P"], armedRunCount: 1 },
+    nextRaw: encodeRebootMarker({ at: 1000, runs: ["P"], armedRunCount: 1 }),
+  };
+  assert.equal(rebootMarkerAfterSend(step, false), step.nextRaw);
+  assert.equal(rebootMarkerAfterSend(step, true), step.nextRaw);
+});
+
+// ── the bounded backstop: never strand silently ───────────────────────────────
+
+test("#585: an outcome that cannot be determined within the wait budget RESUMES with a disclosure", () => {
+  const t = makeTracker();
+  t.onQueued("P");
+  const raw = encodeRebootMarker({ at: 1000, runs: ["P"] });
+  const step = stepRebootResume({
+    raw,
+    isSettled: settledBy(t),
+    nowMs: 1000 + REBOOT_RESUME_MAX_WAIT_MS,
+  });
+  assert.equal(step.decision, "resume_unconfirmed", "a visible duplicate beats an invisible strand");
+  assert.deepEqual(step.owed, ["P"], "and the resume names the run it could not confirm");
+  assert.equal(step.nextRaw, null);
+});
+
+test("#585: the wait budget is measured from the persisted arm time, so a reload cannot restart it", () => {
+  const t = makeTracker();
+  t.onQueued("P");
+  const raw = encodeRebootMarker({ at: 1000, runs: ["P"] });
+  // A reload lands near the end of the budget; the marker, not the new mount, owns the clock.
+  const reloaded = pruneRebootMarkerRaw(raw, settledBy(t));
+  assert.equal(
+    stepRebootResume({ raw: reloaded, isSettled: settledBy(t), nowMs: 1000 + REBOOT_RESUME_MAX_WAIT_MS })
+      .decision,
+    "resume_unconfirmed",
+  );
+});
+
+// ── degraded markers must never strand ────────────────────────────────────────
+
+test('#585: a legacy "1" marker (no recorded ids) resumes immediately rather than waiting forever', () => {
+  const step = stepRebootResume({ raw: "1", isSettled: () => false, nowMs: 5000 });
+  assert.equal(step.decision, "resume");
+  assert.equal(step.nextRaw, null);
+});
+
+test("#585: a corrupt marker resumes rather than parking the session in silence", () => {
+  for (const raw of ["{not json", "{}", "[]", '{"v":1,"runs":"nope"}']) {
+    assert.equal(stepRebootResume({ raw, isSettled: () => false, nowMs: 5000 }).decision, "resume", raw);
+  }
+});
+
+test("#585: no marker at all is not our ack", () => {
+  assert.equal(stepRebootResume({ raw: null }).decision, "none");
+  assert.equal(stepRebootResume({ raw: "" }).decision, "none");
+});
+
+test("#585: an unavailable tracker reports every watched run as owed — never nudge on a blind guess", () => {
+  assert.deepEqual(unsettledRebootRuns(["a", "b"], undefined), ["a", "b"]);
+  assert.deepEqual(
+    unsettledRebootRuns(["a"], () => {
+      throw new Error("tracker exploded");
+    }),
+    ["a"],
+  );
+});
+
+test("#585: run ids normalize to strings so a numeric prompt_id survives the sessionStorage round-trip", () => {
+  const raw = encodeRebootMarker({ at: 1, runs: [7, "7", null, undefined, 8] });
+  assert.deepEqual(decodeRebootMarker(raw).runs, ["7", "8"]);
 });

--- a/browser_tests/unit/restart-resume.test.mjs
+++ b/browser_tests/unit/restart-resume.test.mjs
@@ -5,6 +5,7 @@ import {
   adoptRebootRuns,
   decodeRebootMarker,
   encodeRebootMarker,
+  isRealBridgeDrop,
   planRebootResume,
   pruneRebootMarkerRaw,
   rebootMarkerAfterSend,
@@ -645,6 +646,18 @@ test("#585: a legacy marker with only the per-episode count still reports it as 
   // recorded one attempt must not read as "never attempted".
   const m = decodeRebootMarker(JSON.stringify({ v: 1, at: 1000, runs: [], n: 0, t: 2 }));
   assert.equal(m.totalAttempts, 2);
+});
+
+test("#585 P1(budget): only a real drop refreshes the budget — a fresh mount's 'connecting' is not one", () => {
+  // A freshly mounted client emits `connecting` before it has ever connected. If
+  // that counted as a drop, a page RELOAD would manufacture one and refill the
+  // persisted budget — so repeated reloads would mint unlimited nudges, defeating
+  // the bound through the very event the persisted budget was meant to survive.
+  assert.equal(isRealBridgeDrop({ everConnected: false, connected: false }), false, "never connected");
+  assert.equal(isRealBridgeDrop({ everConnected: true, connected: false }), true, "a genuine transition");
+  assert.equal(isRealBridgeDrop({ everConnected: true, connected: true }), false, "still up");
+  assert.equal(isRealBridgeDrop({}), false, "absent evidence is not a drop");
+  assert.equal(isRealBridgeDrop(), false);
 });
 
 test("#585: the wait budget is a TRI-STATE — within / spent / unknown", () => {

--- a/browser_tests/unit/restart-resume.test.mjs
+++ b/browser_tests/unit/restart-resume.test.mjs
@@ -656,6 +656,31 @@ test("#585: the wait budget is a TRI-STATE — within / spent / unknown", () => 
   }
 });
 
+test("#585 P1(clock): a NEGATIVE elapsed is an unusable clock, not 'no time has passed'", () => {
+  // A clock rollback (NTP correction, resume from suspend, the user changing the
+  // system time) puts `at` and `now` on different timelines, so their difference
+  // measures nothing. Clamping it to 0 would make the backstop wait for the wall
+  // clock to catch up before it could ever fire — an unbounded, silent hold.
+  assert.equal(rebootWaitBudget(-1, 900000), "unknown");
+  assert.equal(rebootWaitBudget(-900000, 900000), "unknown");
+  assert.equal(rebootWaitBudget(0, 900000), "within", "a real zero is still a real answer");
+
+  // End to end: a marker armed "in the future" relative to now.
+  const raw = encodeRebootMarker({ at: 5000, runs: ["P"] });
+  assert.equal(
+    stepRebootResume({ raw, isSettled: () => false, nowMs: 1000 }).decision,
+    "resume_unconfirmed",
+    "the disclosed exit, not an indefinite wait",
+  );
+});
+
+test("#585 P1(clock): an unusable clock HOLDS a wrong-session marker rather than expiring it", () => {
+  const raw = encodeRebootMarker({ at: 5000, runs: [], threadId: "t-A" });
+  const step = stepRebootResume({ raw, isSettled: () => true, currentThreadId: "t-B", nowMs: 1000 });
+  assert.equal(step.decision, "wait_for_session", "unknown holds on this path — never discards");
+  assert.notEqual(step.nextRaw, null);
+});
+
 test("#585: a KNOWN-spent budget on a wrong-session marker still abandons it visibly", () => {
   const raw = encodeRebootMarker({ at: 1000, runs: [], threadId: "t-A" });
   assert.equal(

--- a/browser_tests/unit/restart-resume.test.mjs
+++ b/browser_tests/unit/restart-resume.test.mjs
@@ -550,25 +550,25 @@ test("#585 P1(persisted-write): an attempt that could not be RECORDED still warn
   // attempt yet", so a retry after a reload would go out as a first attempt with no
   // warning. Written is not persisted, exactly as sent is not received.
   assert.equal(
-    rebootResumeRepeatWarning({ attempts: 0, attemptRecorded: false }),
+    rebootResumeRepeatWarning({ totalAttempts: 0, attemptRecorded: false }),
     true,
     "if storage cannot count attempts, we must assume there may have been one",
   );
-  assert.equal(rebootResumeRepeatWarning({ attempts: 1, attemptRecorded: true }), true);
+  assert.equal(rebootResumeRepeatWarning({ totalAttempts: 1, attemptRecorded: true }), true);
   assert.equal(
-    rebootResumeRepeatWarning({ attempts: 0, attemptRecorded: true, sentThisMount: 1 }),
+    rebootResumeRepeatWarning({ totalAttempts: 0, attemptRecorded: true, sentThisMount: 1 }),
     true,
     "a send we made in this mount is storage-independent evidence",
   );
-  for (const attempts of [undefined, null, NaN, "1"]) {
+  for (const totalAttempts of [undefined, null, NaN, "1"]) {
     assert.equal(
-      rebootResumeRepeatWarning({ attempts, attemptRecorded: true }),
+      rebootResumeRepeatWarning({ totalAttempts, attemptRecorded: true }),
       true,
-      `uncountable attempts (${String(attempts)}) must warn`,
+      `uncountable attempts (${String(totalAttempts)}) must warn`,
     );
   }
   assert.equal(
-    rebootResumeRepeatWarning({ attempts: 0, attemptRecorded: true, sentThisMount: 0 }),
+    rebootResumeRepeatWarning({ totalAttempts: 0, attemptRecorded: true, sentThisMount: 0 }),
     false,
     "a genuine, verified first attempt does not warn",
   );
@@ -577,6 +577,41 @@ test("#585 P1(persisted-write): an attempt that could not be RECORDED still warn
     true,
     "and with no information at all the safe side is to warn — no parameter default may invent one",
   );
+});
+
+test("#585 P1(budget-vs-evidence): a bridge drop refreshes the BUDGET without erasing the duplicate evidence", () => {
+  // These are two different facts and were one field. The retry budget is per
+  // delivery episode and an observed drop legitimately refreshes it; "a nudge may
+  // already be in the agent's queue" is monotonic and must survive every episode.
+  // Conflated, a drop erased the evidence — and a resume that reached the
+  // orchestrator but lost its receipt IN THAT DROP is exactly the case a later
+  // undisclosed retry would duplicate.
+  const afterTwoSends = decodeRebootMarker(
+    encodeRebootMarker({ at: 1000, runs: [], threadId: "t-A", attempts: 2, totalAttempts: 2 }),
+  );
+  assert.equal(afterTwoSends.attempts, 2);
+  assert.equal(afterTwoSends.totalAttempts, 2);
+
+  // The drop-gated refresh zeroes the episode budget only.
+  const afterDrop = decodeRebootMarker(encodeRebootMarker({ ...afterTwoSends, attempts: 0 }));
+  assert.equal(afterDrop.attempts, 0, "the budget is refreshed…");
+  assert.equal(afterDrop.totalAttempts, 2, "…but the evidence is not erased");
+  assert.equal(
+    rebootResumeRepeatWarning({
+      totalAttempts: afterDrop.totalAttempts,
+      attemptRecorded: true,
+      sentThisMount: 0, // a remount cleared the in-memory supplement
+    }),
+    true,
+    "so the next attempt still discloses the possible duplicate",
+  );
+});
+
+test("#585: a legacy marker with only the per-episode count still reports it as evidence", () => {
+  // `ts` absent ⇒ fall back to `t` rather than to zero: an older marker that
+  // recorded one attempt must not read as "never attempted".
+  const m = decodeRebootMarker(JSON.stringify({ v: 1, at: 1000, runs: [], n: 0, t: 2 }));
+  assert.equal(m.totalAttempts, 2);
 });
 
 test("#585: the wait budget is a TRI-STATE — within / spent / unknown", () => {

--- a/browser_tests/unit/restart-resume.test.mjs
+++ b/browser_tests/unit/restart-resume.test.mjs
@@ -8,6 +8,8 @@ import {
   planRebootResume,
   pruneRebootMarkerRaw,
   rebootMarkerAfterSend,
+  rebootResumeRepeatWarning,
+  rebootWaitBudget,
   stepRebootResume,
   unsettledRebootRuns,
   REBOOT_RESUME_MAX_WAIT_MS,
@@ -522,6 +524,82 @@ test("#585 P1(session): switching conversations between arm and ack must not mis
   });
   assert.equal(backOnA.decision, "resume");
   assert.equal(backOnA.marker.threadId, "t-A");
+});
+
+test("#585 P1(unknown-elapsed): a wrong-session marker with NO arm time HOLDS, it is not expired away", () => {
+  // Substituting 0 for an unknown elapsed makes it never expire; substituting
+  // infinity makes it always expire. Both manufacture a definite answer from an
+  // absent one — and here the "always expired" direction DELETES a legitimate
+  // resume that switching back to the arming conversation would have delivered.
+  const raw = JSON.stringify({ v: 1, at: null, runs: [], n: 0, tid: "t-A", sid: null, t: 0 });
+  const step = stepRebootResume({ raw, isSettled: () => true, currentThreadId: "t-B", nowMs: 9_999_999 });
+  assert.equal(step.decision, "wait_for_session", "unknown must hold, not abandon");
+  assert.notEqual(step.nextRaw, null, "and the marker must survive");
+
+  // Switching back still delivers it.
+  assert.equal(
+    stepRebootResume({ raw: step.nextRaw, isSettled: () => true, currentThreadId: "t-A", nowMs: 9_999_999 })
+      .decision,
+    "resume",
+  );
+});
+
+test("#585 P1(persisted-write): an attempt that could not be RECORDED still warns", () => {
+  // `ssSet` returning is not evidence the write stuck — quota, private mode and
+  // eviction fail silently. An increment that didn't persist reads back as "no
+  // attempt yet", so a retry after a reload would go out as a first attempt with no
+  // warning. Written is not persisted, exactly as sent is not received.
+  assert.equal(
+    rebootResumeRepeatWarning({ attempts: 0, attemptRecorded: false }),
+    true,
+    "if storage cannot count attempts, we must assume there may have been one",
+  );
+  assert.equal(rebootResumeRepeatWarning({ attempts: 1, attemptRecorded: true }), true);
+  assert.equal(
+    rebootResumeRepeatWarning({ attempts: 0, attemptRecorded: true, sentThisMount: 1 }),
+    true,
+    "a send we made in this mount is storage-independent evidence",
+  );
+  for (const attempts of [undefined, null, NaN, "1"]) {
+    assert.equal(
+      rebootResumeRepeatWarning({ attempts, attemptRecorded: true }),
+      true,
+      `uncountable attempts (${String(attempts)}) must warn`,
+    );
+  }
+  assert.equal(
+    rebootResumeRepeatWarning({ attempts: 0, attemptRecorded: true, sentThisMount: 0 }),
+    false,
+    "a genuine, verified first attempt does not warn",
+  );
+  assert.equal(
+    rebootResumeRepeatWarning({}),
+    true,
+    "and with no information at all the safe side is to warn — no parameter default may invent one",
+  );
+});
+
+test("#585: the wait budget is a TRI-STATE — within / spent / unknown", () => {
+  assert.equal(rebootWaitBudget(0, 1000), "within");
+  assert.equal(rebootWaitBudget(999, 1000), "within");
+  assert.equal(rebootWaitBudget(1000, 1000), "spent");
+  for (const bad of [null, undefined, NaN, Infinity, -Infinity, "500"]) {
+    assert.equal(rebootWaitBudget(bad, 1000), "unknown", String(bad));
+  }
+});
+
+test("#585: a KNOWN-spent budget on a wrong-session marker still abandons it visibly", () => {
+  const raw = encodeRebootMarker({ at: 1000, runs: [], threadId: "t-A" });
+  assert.equal(
+    stepRebootResume({
+      raw,
+      isSettled: () => true,
+      currentThreadId: "t-B",
+      nowMs: 1000 + REBOOT_RESUME_MAX_WAIT_MS,
+    }).decision,
+    "expired_wrong_session",
+    "only a budget we KNOW is spent may abandon the resume",
+  );
 });
 
 test("#585 P1(session): a resume held for an absent conversation is abandoned VISIBLY, never misdelivered", () => {

--- a/browser_tests/unit/restart-resume.test.mjs
+++ b/browser_tests/unit/restart-resume.test.mjs
@@ -58,7 +58,30 @@ test("#585: a reboot with nothing owed resumes autonomously", () => {
 });
 
 test("#585: a reboot whose watched render is still owed a completion frame waits", () => {
-  assert.equal(planRebootResume({ rebootPending: true, unsettledRuns: ["p1"] }), "wait_for_run");
+  assert.equal(planRebootResume({ rebootPending: true, unsettledRuns: ["p1"], waitedMs: 0 }), "wait_for_run");
+});
+
+test("#585 P1(unknown-elapsed): an UNKNOWN wait duration must not read as zero elapsed", () => {
+  // Substituting 0 is a definite claim that no time has passed — and it is re-made
+  // on every tick, so the 15-minute backstop never advances and the wait becomes
+  // unbounded and silent. The mechanism built to prevent an indefinite wait would
+  // be the thing guaranteeing one.
+  for (const waitedMs of [undefined, null, NaN, Infinity, "0"]) {
+    assert.equal(
+      planRebootResume({ rebootPending: true, unsettledRuns: ["p1"], waitedMs }),
+      "resume_unconfirmed",
+      String(waitedMs),
+    );
+  }
+  // An explicit, known zero is a real answer and still waits.
+  assert.equal(planRebootResume({ rebootPending: true, unsettledRuns: ["p1"], waitedMs: 0 }), "wait_for_run");
+});
+
+test("#585 P1(unknown-elapsed): a marker with owed runs but NO arm time cannot park the session", () => {
+  const raw = JSON.stringify({ v: 1, at: null, runs: ["P"], n: 1 });
+  const step = stepRebootResume({ raw, isSettled: () => false, nowMs: 5000 });
+  assert.equal(step.decision, "resume_unconfirmed", "an unbounded wait is the silent strand");
+  assert.equal(step.nextRaw, null);
 });
 
 // ── P1 #1 — the guard must survive a frontend RELOAD ──────────────────────────
@@ -284,6 +307,39 @@ test("#585 P1(delivery): an unconfirmed run is kept in the persisted marker whil
   assert.equal(done.decision, "resume_unconfirmed");
 });
 
+test("#585 P1(arm): a reboot armed AFTER the delivery watchdog still records the uncertain run", () => {
+  // unsettledPromptIds is the arm-time snapshot, and the planner can only reason
+  // about ids the marker carries. If a run whose delivery was never confirmed were
+  // omitted, a reboot armed after the 120s watchdog would resume with the plain
+  // "your result was already delivered" wording — the false reassurance again.
+  const t = makeTracker();
+  t.onQueued("P");
+  t.onExecutionStart("P");
+  t.onExecuted("P", { images: [{ filename: "a.png" }] });
+  t.onExecutionSuccess("P");
+  t._fireTimers(DELIVERY_WATCHDOG_MS);
+  assert.equal(t.isSettled("P"), true, "it no longer blocks…");
+  assert.deepEqual(t.unsettledPromptIds(), ["P"], "…but it is still not known to have been delivered");
+
+  const raw = encodeRebootMarker({ at: 1000, runs: t.unsettledPromptIds() });
+  assert.equal(
+    stepRebootResume({ raw, isSettled: settledBy(t), isDeliveryUnconfirmed: unconfirmedBy(t), nowMs: 1100 })
+      .decision,
+    "resume_unconfirmed",
+  );
+});
+
+test("#585: unsettledPromptIds never reports the same id twice across its three sources", () => {
+  const t = makeTracker();
+  t.onQueued("P");
+  t.onExecutionStart("P");
+  t.onExecuted("P", { images: [{ filename: "a.png" }] });
+  t.onExecutionSuccess("P"); // pending-retired + awaitingDelivery
+  assert.deepEqual(t.unsettledPromptIds(), ["P"]);
+  t._fireTimers(DELIVERY_WATCHDOG_MS); // now unconfirmedDelivery
+  assert.deepEqual(t.unsettledPromptIds(), ["P"]);
+});
+
 test("#585 P1(delivery): a confirmed delivery clears the unconfirmed flag", () => {
   const t = makeTracker();
   t.onQueued("P");
@@ -414,6 +470,238 @@ test("#585: a corrupt marker resumes rather than parking the session in silence"
   for (const raw of ["{not json", "{}", "[]", '{"v":1,"runs":"nope"}']) {
     assert.equal(stepRebootResume({ raw, isSettled: () => false, nowMs: 5000 }).decision, "resume", raw);
   }
+});
+
+test("#585 P1(version): an UNRECOGNIZED marker version is not interpreted field by field", () => {
+  // A future version — or a partial write that happens to still be valid JSON —
+  // would otherwise have its `runs` trusted while its `at` was absent, and an
+  // absent arm time is exactly what makes the wait unbounded.
+  const future = JSON.stringify({ v: 2, runs: ["P"] });
+  assert.deepEqual(decodeRebootMarker(future).runs, [], "runs from an unknown shape are not trusted");
+  const step = stepRebootResume({ raw: future, isSettled: () => false, nowMs: 5000 });
+  assert.equal(step.decision, "resume", "…and it degrades exactly like the legacy marker");
+  assert.equal(step.nextRaw, null);
+});
+
+test("#585 P1(version): a v1 marker still round-trips every field", () => {
+  const raw = encodeRebootMarker({ at: 1000, runs: ["P"], threadId: "t-A", sessionId: "s-A" });
+  const m = decodeRebootMarker(raw);
+  assert.equal(m.at, 1000);
+  assert.deepEqual(m.runs, ["P"]);
+  assert.equal(m.threadId, "t-A");
+  assert.equal(m.sessionId, "s-A");
+});
+
+// ── the resume must reach the conversation that ASKED for the restart ─────────
+
+test("#585 P1(session): switching conversations between arm and ack must not misdeliver the resume", () => {
+  const t = makeTracker();
+  // Conversation A arms the reboot with nothing in flight — it would resume at once.
+  const raw = encodeRebootMarker({ at: 1000, runs: [], threadId: "t-A", sessionId: "s-A" });
+  assert.equal(
+    stepRebootResume({ raw, isSettled: settledBy(t), currentThreadId: "t-A", nowMs: 1100 }).decision,
+    "resume",
+    "on A, it resumes",
+  );
+
+  // …the user switches to conversation B before the ready ack lands.
+  const onB = stepRebootResume({ raw, isSettled: settledBy(t), currentThreadId: "t-B", nowMs: 1100 });
+  assert.equal(
+    onB.decision,
+    "wait_for_session",
+    "B must NOT receive A's restart nudge — that is the duplicate-render hazard aimed at the wrong workflow",
+  );
+  assert.notEqual(onB.nextRaw, null, "and A's resume must not be lost while B is on screen");
+
+  // Switching back delivers it, to A, intact.
+  const backOnA = stepRebootResume({
+    raw: onB.nextRaw,
+    isSettled: settledBy(t),
+    currentThreadId: "t-A",
+    nowMs: 1200,
+  });
+  assert.equal(backOnA.decision, "resume");
+  assert.equal(backOnA.marker.threadId, "t-A");
+});
+
+test("#585 P1(session): a resume held for an absent conversation is abandoned VISIBLY, never misdelivered", () => {
+  const raw = encodeRebootMarker({ at: 1000, runs: [], threadId: "t-A" });
+  const step = stepRebootResume({
+    raw,
+    isSettled: () => true,
+    currentThreadId: "t-B",
+    nowMs: 1000 + REBOOT_RESUME_MAX_WAIT_MS,
+  });
+  assert.equal(step.decision, "expired_wrong_session", "holding it forever would be the silent strand");
+  assert.notEqual(step.decision, "resume", "…and sending it to B would be misdelivery");
+  assert.equal(step.nextRaw, null);
+});
+
+test("#585 P1(session): the session hold outranks the run wait — a mismatch never sends, however settled", () => {
+  const t = makeTracker();
+  const raw = encodeRebootMarker({ at: 1000, runs: [], threadId: "t-A" });
+  assert.equal(
+    stepRebootResume({ raw, isSettled: settledBy(t), currentThreadId: null, nowMs: 1100 }).decision,
+    "wait_for_session",
+    "no conversation on screen is still not the ARMING conversation",
+  );
+});
+
+test("#585 P1(session): a marker with no recorded conversation carries no constraint (legacy)", () => {
+  const raw = encodeRebootMarker({ at: 1000, runs: [] });
+  assert.equal(
+    stepRebootResume({ raw, isSettled: () => true, currentThreadId: "t-anything", nowMs: 1100 }).decision,
+    "resume",
+  );
+});
+
+test("#585 P1(session): PRUNING a settled run must not drop the delivery target", () => {
+  // Pruning runs on every confirmed delivery, so a field dropped here is dropped
+  // almost immediately and permanently — and losing the arming conversation
+  // silently converts the marker back into "deliver to whoever is on screen".
+  const t = makeTracker();
+  t.onQueued("A1");
+  t.onQueued("B1");
+  const raw = encodeRebootMarker({ at: 1000, runs: ["A1", "B1"], threadId: "t-A", sessionId: "s-A" });
+  t.markDelivered("B1"); // an unrelated run settles and prunes the marker
+  const pruned = pruneRebootMarkerRaw(raw, settledBy(t), unconfirmedBy(t));
+  assert.deepEqual(decodeRebootMarker(pruned).runs, ["A1"]);
+  assert.equal(decodeRebootMarker(pruned).threadId, "t-A", "the arming conversation must survive pruning");
+
+  // …and the surviving marker still refuses to deliver to a different conversation.
+  t.markDelivered("A1");
+  assert.equal(
+    stepRebootResume({ raw: pruned, isSettled: settledBy(t), currentThreadId: "t-B", nowMs: 1200 }).decision,
+    "wait_for_session",
+  );
+});
+
+test("#585 P1(receipt): the attempt count is PERSISTED, so a retry after a reload discloses itself", () => {
+  const raw = encodeRebootMarker({ at: 1000, runs: [], threadId: "t-A", attempts: 1 });
+  assert.equal(decodeRebootMarker(raw).attempts, 1);
+  // …and it survives both round-trips the marker makes.
+  const step = stepRebootResume({ raw, isSettled: () => true, currentThreadId: "t-A", nowMs: 1100 });
+  assert.equal(step.marker.attempts, 1);
+  const held = stepRebootResume({ raw, isSettled: () => true, currentThreadId: "t-B", nowMs: 1100 });
+  assert.equal(decodeRebootMarker(held.nextRaw).attempts, 1, "a wrong-session hold keeps it too");
+});
+
+test("#585 P1(budget): the retry budget lives in the PERSISTED marker, so a reload cannot refill it", () => {
+  // An in-memory counter starts at zero on a fresh mount, so after three
+  // unacknowledged sends a reload would hand back a full budget — and repeated
+  // reloads would mint unlimited duplicate "continue" nudges.
+  const MAX = 3;
+  let raw = encodeRebootMarker({ at: 1000, runs: [], threadId: "t-A", attempts: MAX });
+  const afterReload = stepRebootResume({
+    raw,
+    isSettled: () => true,
+    currentThreadId: "t-A",
+    nowMs: 1100,
+  });
+  assert.equal(
+    afterReload.marker.attempts,
+    MAX,
+    "the count the gate reads must survive the reload that reset every in-memory counter",
+  );
+  // …and it is carried by every rewrite the marker undergoes while waiting.
+  const held = stepRebootResume({ raw, isSettled: () => true, currentThreadId: "t-B", nowMs: 1100 });
+  assert.equal(decodeRebootMarker(held.nextRaw).attempts, MAX);
+});
+
+test("#585: every marker field survives a retain/prune round-trip", () => {
+  const t = makeTracker();
+  t.onQueued("X");
+  t.onQueued("Y");
+  const raw = encodeRebootMarker({
+    at: 4242,
+    runs: ["X", "Y"],
+    armedRunCount: 2,
+    threadId: "t-A",
+    sessionId: "s-A",
+    attempts: 2,
+  });
+  t.markDelivered("Y");
+  const after = decodeRebootMarker(pruneRebootMarkerRaw(raw, settledBy(t), unconfirmedBy(t)));
+  assert.deepEqual(
+    { at: after.at, armedRunCount: after.armedRunCount, threadId: after.threadId, sessionId: after.sessionId, attempts: after.attempts },
+    { at: 4242, armedRunCount: 2, threadId: "t-A", sessionId: "s-A", attempts: 2 },
+  );
+});
+
+test("#585 P1(session): a REPLACED agent session is disclosed, never used to withhold the resume", () => {
+  const raw = encodeRebootMarker({ at: 1000, runs: [], threadId: "t-A", sessionId: "s-old" });
+  const step = stepRebootResume({
+    raw,
+    isSettled: () => true,
+    currentThreadId: "t-A",
+    currentSessionId: "s-new",
+    sessionKnown: true,
+    nowMs: 1100,
+  });
+  assert.equal(step.sessionState, "replaced", "the mismatch is reported…");
+  assert.equal(
+    step.decision,
+    "resume",
+    "…but never withheld: a session id legitimately changes across a resume, so refusing here would strand every ordinary restart",
+  );
+});
+
+test("#585 P1(session): an UNKNOWN session is its own answer — never silently 'same'", () => {
+  const withSid = encodeRebootMarker({ at: 1000, runs: [], threadId: "t-A", sessionId: "s-old" });
+  const base = { isSettled: () => true, currentThreadId: "t-A", nowMs: 1100 };
+  assert.equal(
+    stepRebootResume({ ...base, raw: withSid, currentSessionId: null, sessionKnown: true }).sessionState,
+    "unknown",
+    "no current session id ⇒ cannot compare",
+  );
+  const noSid = encodeRebootMarker({ at: 1000, runs: [], threadId: "t-A" });
+  assert.equal(
+    stepRebootResume({ ...base, raw: noSid, currentSessionId: "s-new", sessionKnown: true }).sessionState,
+    "unknown",
+    "no armed session recorded ⇒ cannot compare",
+  );
+  assert.equal(
+    stepRebootResume({ ...base, raw: withSid, currentSessionId: "s-old", sessionKnown: true }).sessionState,
+    "same",
+  );
+});
+
+test("#585 P1(session): before the orchestrator's session frame lands, the session is UNKNOWN, not 'same'", () => {
+  // The `session` frame is not ordered against the "ready" ack that drives this
+  // decision. If ready lands first, the id on hand is still the one we armed with —
+  // a two-state check would confidently answer "same" for a session about to be
+  // replaced, and send the ordinary undisclosed continuation.
+  const raw = encodeRebootMarker({ at: 1000, runs: [], threadId: "t-A", sessionId: "s-old" });
+  const step = stepRebootResume({
+    raw,
+    isSettled: () => true,
+    currentThreadId: "t-A",
+    currentSessionId: "s-old",
+    sessionKnown: false,
+    nowMs: 1100,
+  });
+  assert.equal(step.sessionState, "unknown");
+  assert.equal(step.decision, "resume", "still delivered — the uncertainty is disclosed, not withheld");
+});
+
+test("#585 P1(send): a wait_for_session step retains its marker regardless of send outcome", () => {
+  const raw = encodeRebootMarker({ at: 1000, runs: [], threadId: "t-A" });
+  const step = stepRebootResume({ raw, isSettled: () => true, currentThreadId: "t-B", nowMs: 1100 });
+  assert.equal(rebootMarkerAfterSend(step, false), step.nextRaw);
+  assert.equal(rebootMarkerAfterSend(step, true), step.nextRaw);
+});
+
+test("#585 P1(receipt): a send the orchestrator never acknowledged must NOT retire the marker", () => {
+  // sendUserMessage returns true the instant WebSocket.send() accepts the bytes;
+  // the socket can close before the orchestrator reads them, and an abandoned
+  // channel cannot testify that it wasn't. Only a receipt ack may retire it — so
+  // the panel passes `false` here for every send and clears on the ack instead.
+  const step = { decision: "resume", marker: { at: 1000, runs: [], armedRunCount: 0 }, nextRaw: null };
+  assert.notEqual(
+    rebootMarkerAfterSend(step, false),
+    null,
+    "handed-to-transport is not receipt — retiring here strands the resume permanently",
+  );
 });
 
 test("#585: no marker at all is not our ack", () => {

--- a/browser_tests/unit/restart-resume.test.mjs
+++ b/browser_tests/unit/restart-resume.test.mjs
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { planRebootResume } from "../../web/js/lib/restart-resume.js";
+
+test("#585: a pre-restart render pending in the completion ledger suppresses the generic resume nudge", () => {
+  // The run may have survived the backend restart. Its terminal completion (or
+  // conservative reconnect reconciliation) is the signal that may wake the
+  // resumed agent; a generic "continue" prompt would invite a duplicate queue.
+  assert.equal(planRebootResume({ rebootPending: true, hasPendingRun: true }), "wait_for_run");
+});
+
+test("#585: an actual reboot with no pending render retains autonomous resume", () => {
+  assert.equal(planRebootResume({ rebootPending: true, hasPendingRun: false }), "resume");
+});
+
+test("#585: no reboot marker never injects a restart-resume message", () => {
+  assert.equal(planRebootResume({ rebootPending: false, hasPendingRun: true }), "none");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -19649,6 +19649,13 @@ function buildPanel() {
     rebootResumeMid = mid;
     rebootResumeMidAt = Date.now();
     rebootResumeMids.add(mid);
+    // A continuation has now been issued for this drop, so the generic mid-task
+    // "you dropped, pick it back up" fallback must not ALSO fire. `ready` repeats on
+    // a live socket, and once the marker is retired those repeats fall through to
+    // that branch — a second, uncorrelated, undisclosed "continue", which is the
+    // duplicate-render hazard again. The soft-reload path clears this for exactly
+    // the same reason; the reboot path never did.
+    ssSet(MID_TASK_KEY, null);
     rebootWaitNoticeShown = false;
     rebootSessionNoticeShown = false;
     appendSystem(

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -286,6 +286,7 @@ import {
   buildHelloPayload,
 } from "./lib/session-rebind.js";
 import { createRestartTabIdentity, sendBridgeHello } from "./lib/restart-tab-identity.js";
+import { planRebootResume } from "./lib/restart-resume.js";
 
 let app = null;
 let api = null;
@@ -18925,7 +18926,23 @@ function buildPanel() {
       // orchestrator armed hello.resume, so resuming the agent is safe now.
       // Clear REBOOT_KEY only here (on actual send) so a drop mid-reconnect
       // retries instead of losing the resume.
-      if (ack?.kind === "ready" && ssGet(REBOOT_KEY)) {
+      const rebootResume = planRebootResume({
+        rebootPending: ack?.kind === "ready" && !!ssGet(REBOOT_KEY),
+        // A prompt recorded before the reboot may still be running when the
+        // backend returns. Its completion/reconcile event is the authoritative
+        // continuation signal; waking the agent generically here caused it to
+        // requeue the same render (#585).
+        // The callback is registered before this mount's tracker is constructed;
+        // the module ref is therefore safe even if a bridge implementation emits
+        // a synchronous initial ready frame.
+        hasPendingRun: runCompletionRef?.hasPending?.() ?? false,
+      });
+      if (rebootResume === "wait_for_run") {
+        ssSet(REBOOT_KEY, null);
+        appendSystem("Reconnected — waiting for the render that was already in flight before the restart.");
+        return;
+      }
+      if (rebootResume === "resume") {
         ssSet(REBOOT_KEY, null);
         appendSystem("Reconnected — resuming where we left off.");
         showThinking();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -19586,7 +19586,8 @@ function buildPanel() {
     if (retained) {
       const withAttempt = encodeRebootMarker({
         ...decodeRebootMarker(retained),
-        attempts: (marker?.attempts ?? 0) + 1,
+        attempts: (marker?.attempts ?? 0) + 1, // episode budget
+        totalAttempts: (marker?.totalAttempts ?? 0) + 1, // monotonic evidence
       });
       ssSet(REBOOT_KEY, withAttempt);
       attemptRecorded = ssGet(REBOOT_KEY) === withAttempt;
@@ -19601,7 +19602,7 @@ function buildPanel() {
       }
     }
     const repeat = rebootResumeRepeatWarning({
-      attempts: marker?.attempts,
+      totalAttempts: marker?.totalAttempts,
       attemptRecorded,
       sentThisMount: rebootResumeMids.size,
     });
@@ -19797,11 +19798,18 @@ function buildPanel() {
       rebootResumeStalledNoticeShown = false;
       // The budget lives in the PERSISTED marker (so a reload can't refill it), so
       // refreshing it means rewriting the marker — not zeroing a local counter.
+      // Refresh ONLY the episode budget. `totalAttempts` is deliberately untouched:
+      // it is the evidence that a nudge may already be in the agent's queue, and a
+      // resume that reached the orchestrator but lost its receipt in this very drop
+      // is exactly the case a later undisclosed retry would duplicate.
       const raw = ssGet(REBOOT_KEY);
       const decoded = raw == null ? null : decodeRebootMarker(raw);
       if (decoded && decoded.attempts > 0) {
         ssSet(REBOOT_KEY, encodeRebootMarker({ ...decoded, attempts: 0 }));
       }
+      // Mids from the dead socket can never be acked on the new connection, so drop
+      // them — this also bounds the set across repeated drops.
+      rebootResumeMids.clear();
     } else if (rebootResumeMid != null) {
       // Same connection, attempt still outstanding — let the watch and the receipt
       // ack resolve it rather than firing a second identical "continue".

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -19586,8 +19586,12 @@ function buildPanel() {
     if (retained) {
       const withAttempt = encodeRebootMarker({
         ...decodeRebootMarker(retained),
-        attempts: (marker?.attempts ?? 0) + 1, // episode budget
-        totalAttempts: (marker?.totalAttempts ?? 0) + 1, // monotonic evidence
+        // An unknown prior count restarts at 1 for the BUDGET (we cannot bound what
+        // we cannot count, and a real number here ends the uncertainty) but must not
+        // pretend the TOTAL was zero — so an unknown total stays unknown, and keeps
+        // forcing the duplicate warning.
+        attempts: (Number.isFinite(marker?.attempts) ? Number(marker.attempts) : 0) + 1,
+        totalAttempts: Number.isFinite(marker?.totalAttempts) ? Number(marker.totalAttempts) + 1 : null,
       });
       ssSet(REBOOT_KEY, withAttempt);
       attemptRecorded = ssGet(REBOOT_KEY) === withAttempt;
@@ -19752,7 +19756,12 @@ function buildPanel() {
     // mount's counter starts at zero, so a reload would hand back a full budget and
     // repeated reloads would mint unlimited nudges — the storm the bound exists to
     // prevent. One source of truth, and it is the one that survives a reload.
-    if ((step?.marker?.attempts ?? 0) >= REBOOT_RESUME_MAX_ATTEMPTS) {
+    // An UNKNOWN count cannot say the budget is spent. Allowing the send is the
+    // recoverable side (the unknown total already forces the duplicate warning), and
+    // the write-ahead below replaces the unknown with a real count — so this resolves
+    // after exactly one attempt instead of looping.
+    const budgetUsed = step?.marker?.attempts;
+    if (Number.isFinite(budgetUsed) && Number(budgetUsed) >= REBOOT_RESUME_MAX_ATTEMPTS) {
       if (!rebootResumeStalledNoticeShown) {
         rebootResumeStalledNoticeShown = true;
         appendSystem(
@@ -19804,7 +19813,10 @@ function buildPanel() {
       // is exactly the case a later undisclosed retry would duplicate.
       const raw = ssGet(REBOOT_KEY);
       const decoded = raw == null ? null : decodeRebootMarker(raw);
-      if (decoded && decoded.attempts > 0) {
+      // `!== 0` rather than `> 0` so an UNKNOWN budget is also resolved here: after an
+      // observed drop, "this episode has made zero attempts" is a true statement we
+      // can now assert. The total is untouched and stays unknown if it was.
+      if (decoded && decoded.attempts !== 0) {
         ssSet(REBOOT_KEY, encodeRebootMarker({ ...decoded, attempts: 0 }));
       }
       // Mids from the dead socket can never be acked on the new connection, so drop

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -292,6 +292,7 @@ import {
   encodeRebootMarker,
   pruneRebootMarkerRaw,
   rebootMarkerAfterSend,
+  rebootResumeRepeatWarning,
   stepRebootResume,
   REBOOT_RESUME_MAX_WAIT_MS,
 } from "./lib/restart-resume.js";
@@ -19397,6 +19398,7 @@ function buildPanel() {
   // delivered, and each retry is another "continue" turn in front of the agent.
   const rebootResumeMids = new Set();
   let rebootResumeStalledNoticeShown = false;
+  let rebootAttemptCountUnreliableNoticeShown = false;
   // True once the orchestrator's `session` frame has landed on THIS connection. The
   // frame is not ordered against the "ready" ack, so before it arrives the session
   // id we hold is simply the one we armed with — not evidence that the session was
@@ -19424,6 +19426,7 @@ function buildPanel() {
     forgetRebootResumeAttempt();
     rebootResumeMids.clear();
     rebootResumeSent = false;
+    rebootAttemptCountUnreliableNoticeShown = false;
     rebootResumeStalledNoticeShown = false;
     rebootWaitNoticeShown = false;
     rebootSessionNoticeShown = false;
@@ -19568,7 +19571,40 @@ function buildPanel() {
     // so it survives a reload). We cannot know whether the orchestrator took it —
     // an unacknowledged send is exactly the state we can't resolve — so say so
     // rather than let a possible second identical "continue" arrive unannounced.
-    const repeat = (marker?.attempts ?? 0) > 0;
+    //
+    // WRITE-AHEAD, and VERIFY. The attempt is recorded BEFORE it can happen, and the
+    // write is read back. `ssSet` returning is not evidence it persisted — quota,
+    // private mode and eviction all fail silently — and an increment that didn't
+    // stick reads back as "no attempt yet", so a retry after a reload would go out
+    // as a first attempt with no warning. This is the same shape as sent-vs-received
+    // one layer down: written is not persisted. A failed record therefore ALSO
+    // raises the warning, on this attempt and every later one, because if storage
+    // cannot count attempts we must assume there may have been one. A warning
+    // wrongly present is harmless; its absence is not.
+    const retained = rebootMarkerAfterSend(step, false);
+    let attemptRecorded = true;
+    if (retained) {
+      const withAttempt = encodeRebootMarker({
+        ...decodeRebootMarker(retained),
+        attempts: (marker?.attempts ?? 0) + 1,
+      });
+      ssSet(REBOOT_KEY, withAttempt);
+      attemptRecorded = ssGet(REBOOT_KEY) === withAttempt;
+      if (!attemptRecorded) {
+        ssSet(REBOOT_KEY, retained); // keep the marker itself, just without the count
+        if (!rebootAttemptCountUnreliableNoticeShown) {
+          rebootAttemptCountUnreliableNoticeShown = true;
+          appendSystem(
+            "Note: this browser wouldn't let me record the restart-nudge attempt, so I can't tell whether one already went out. I'll warn the agent about a possible duplicate.",
+          );
+        }
+      }
+    }
+    const repeat = rebootResumeRepeatWarning({
+      attempts: marker?.attempts,
+      attemptRecorded,
+      sentThisMount: rebootResumeMids.size,
+    });
     const repeatPrefix = repeat
       ? "⚠️ You may have already received this restart notice — an earlier copy was sent but never acknowledged. If you already acted on it, ignore this one and do NOT re-queue anything. "
       : "";
@@ -19598,19 +19634,13 @@ function buildPanel() {
         : "✅ ComfyUI just restarted to load newly-installed custom nodes (now available). Continue what you were doing before the restart — if you were mid-build, pick it back up.");
     const mid = newMid();
     const sent = client.sendUserMessage(text, undefined, undefined, mid);
-    // Marker policy for THIS attempt. `sent` is only "the transport took it", so
-    // rebootMarkerAfterSend is deliberately given `false` here: the marker is
-    // retained either way, and only the receipt ack retires it. The attempt count
-    // is bumped in the PERSISTED marker so a reload still knows a nudge may already
-    // be in the agent's queue.
-    const retained = rebootMarkerAfterSend(step, false);
-    ssSet(
-      REBOOT_KEY,
-      retained && sent
-        ? encodeRebootMarker({ ...decodeRebootMarker(retained), attempts: (marker?.attempts ?? 0) + 1 })
-        : retained,
-    );
-    if (!sent) return false;
+    if (!sent) {
+      // Nothing left the panel, so give the budget its attempt back — but only when
+      // we know the increment persisted. If it didn't, the count is already whatever
+      // storage decided and there is nothing to roll back.
+      if (retained && attemptRecorded) ssSet(REBOOT_KEY, retained);
+      return false;
+    }
     rebootResumeMid = mid;
     rebootResumeMidAt = Date.now();
     rebootResumeMids.add(mid);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -18768,6 +18768,22 @@ function buildPanel() {
         // survives the frontend reload a restart can cause (an in-memory ledger
         // starts empty on the new mount and would report "nothing in flight" for
         // a render that is still executing).
+        //
+        // DO NOT "improve" this into a per-workflow correlation. It looks like an
+        // approximation of one and it is not — arm-time IS the correct set. A
+        // reboot restarts ComfyUI GLOBALLY, so every render in flight at this
+        // instant is exposed to the same hazard: the generic "continue" nudge that
+        // makes the agent conclude its render was aborted and queue it again.
+        // Resuming while another workflow's render is still exposed to that hazard
+        // would be the wrong semantics, not a tighter one. (The tracker also has no
+        // workflow attribution on prompt ids; inventing one to reach a worse rule
+        // would be a large change to a concept this codebase doesn't have, landing
+        // inside a fix for a STRANDING bug — not a trade worth making.)
+        //
+        // The accepted consequence: two workflows rendering when a reboot fires
+        // means the resume waits for both. That is bounded — the set is fixed at
+        // arm time, drains as each run settles, and the 15-minute backstop resumes
+        // WITH a disclosure rather than holding the session in silence.
         const armedRuns = (() => {
           try {
             return runCompletionRef?.unsettledPromptIds?.() ?? [];

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -19422,10 +19422,11 @@ function buildPanel() {
   // `connecting` reads as a drop and a reload refills the retry budget.
   let rebootSeenConnected = false;
   let rebootPruneFailureNoticeShown = false;
-  // Set when a budget RESET write is verified to have failed. The persisted count
-  // is then stale-high forever, so the gate falls back to this in-memory per-episode
-  // count — still bounded, but not a permanent refusal.
-  let rebootBudgetPersistBroken = false;
+  // Set when ANY verified REBOOT_KEY write fails. Persisted counters are then
+  // untrustworthy in BOTH directions — a stale-high budget refuses forever, a
+  // stale-low one bounds nothing — so the gate falls back to an in-memory
+  // per-episode count, which is still bounded and still recoverable.
+  let rebootStoragePersistBroken = false;
   let rebootEpisodeSends = 0;
 
   /** Drop any outstanding attempt — its channel is gone, so it can never be acked. */
@@ -19446,7 +19447,7 @@ function buildPanel() {
     rebootResumeSent = false;
     rebootAttemptCountUnreliableNoticeShown = false;
     rebootPruneFailureNoticeShown = false;
-    rebootBudgetPersistBroken = false;
+    rebootStoragePersistBroken = false;
     rebootEpisodeSends = 0;
     rebootResumeStalledNoticeShown = false;
     rebootWaitNoticeShown = false;
@@ -19477,6 +19478,23 @@ function buildPanel() {
     return ssGet(key) === value;
   }
 
+  /**
+   * Can sessionStorage be written AT ALL right now?
+   *
+   * A storage failure outlives the mount that discovered it, but the in-memory
+   * fallback does not — so a reload inherits a stale-high persisted budget with no
+   * memory of why it cannot be reset, and would refuse to send forever. Rather
+   * than carry that state, re-establish it on demand with a throwaway key: it
+   * touches nothing the resume depends on and answers the only question that
+   * matters — is the persisted number something we can still manage?
+   */
+  function sessionStorageWritable() {
+    const probeKey = "comfyui-mcp.panel.storageProbe";
+    const ok = ssSetVerified(probeKey, String(Date.now()));
+    ssSet(probeKey, null);
+    return ok;
+  }
+
   function readRebootMarker() {
     return decodeRebootMarker(ssGet(REBOOT_KEY));
   }
@@ -19497,12 +19515,22 @@ function buildPanel() {
     // the agent a SECOND time. Nothing further can force the write, so surface it —
     // this path had no disclosure at all, which is what made it worse than the
     // best-effort-storage cases that do.
-    if (!ssSetVerified(REBOOT_KEY, next) && !rebootPruneFailureNoticeShown) {
-      rebootPruneFailureNoticeShown = true;
-      appendSystem(
-        "Note: this browser wouldn't let me update the restart marker. If you reload, a render result that was already delivered may be reported to the agent twice.",
-      );
-    }
+    if (!ssSetVerified(REBOOT_KEY, next)) noteRebootMarkerWriteFailed();
+  }
+
+  /**
+   * A verified marker write did not persist. Persisted counters are now untrustworthy
+   * in BOTH directions, so the budget switches to its in-memory bound, and the user is
+   * told once — this path previously had no disclosure at all, which is what set it
+   * apart from the storage cases that do.
+   */
+  function noteRebootMarkerWriteFailed() {
+    rebootStoragePersistBroken = true;
+    if (rebootPruneFailureNoticeShown) return;
+    rebootPruneFailureNoticeShown = true;
+    appendSystem(
+      "Note: this browser wouldn't let me update the restart marker. If you reload, a render result that was already delivered may be reported to the agent twice.",
+    );
   }
 
   /**
@@ -19555,12 +19583,7 @@ function buildPanel() {
       // Same class as the prune write: this rewrite is what drops already-settled run
       // ids from the marker, so a silent failure leaves a delivered run in it for a
       // reload to re-adopt and re-deliver. Verified, and disclosed once if it fails.
-      if (!ssSetVerified(REBOOT_KEY, step.nextRaw) && !rebootPruneFailureNoticeShown) {
-        rebootPruneFailureNoticeShown = true;
-        appendSystem(
-          "Note: this browser wouldn't let me update the restart marker. If you reload, a render result that was already delivered may be reported to the agent twice.",
-        );
-      }
+      if (!ssSetVerified(REBOOT_KEY, step.nextRaw)) noteRebootMarkerWriteFailed();
     }
     return step;
   }
@@ -19642,6 +19665,10 @@ function buildPanel() {
       ssSet(REBOOT_KEY, withAttempt);
       attemptRecorded = ssGet(REBOOT_KEY) === withAttempt;
       if (!attemptRecorded) {
+        // The persisted count cannot be trusted to BOUND anything either — without
+        // this the gate would keep reading a stale 0 and re-send after every ack
+        // timeout, which is the storm the budget exists to prevent.
+        rebootStoragePersistBroken = true;
         ssSet(REBOOT_KEY, retained); // keep the marker itself, just without the count
         if (!rebootAttemptCountUnreliableNoticeShown) {
           rebootAttemptCountUnreliableNoticeShown = true;
@@ -19817,7 +19844,18 @@ function buildPanel() {
     // When the persisted budget cannot be RESET (a verified-failed write), the
     // persisted number is stale-high forever and gating on it would refuse every
     // tick. Bound this episode in memory instead — still bounded, but recoverable.
-    const budgetUsed = rebootBudgetPersistBroken ? rebootEpisodeSends : step?.marker?.attempts;
+    let budgetUsed = step?.marker?.attempts;
+    if (rebootStoragePersistBroken) {
+      budgetUsed = rebootEpisodeSends;
+    } else if (Number.isFinite(budgetUsed) && Number(budgetUsed) >= REBOOT_RESUME_MAX_ATTEMPTS) {
+      // Spent per the marker — but a budget is only meaningful if it can be RESET.
+      // A mount that inherits a spent count from a mount whose storage was broken
+      // would otherwise refuse forever, so establish writability before refusing.
+      if (!sessionStorageWritable()) {
+        rebootStoragePersistBroken = true;
+        budgetUsed = rebootEpisodeSends;
+      }
+    }
     if (Number.isFinite(budgetUsed) && Number(budgetUsed) >= REBOOT_RESUME_MAX_ATTEMPTS) {
       if (!rebootResumeStalledNoticeShown) {
         rebootResumeStalledNoticeShown = true;
@@ -19878,9 +19916,11 @@ function buildPanel() {
         // the send gate refuses on every tick — a confirmed reconnect turning into a
         // permanent stall. A budget we cannot reset is a budget we cannot manage, so
         // fall back to bounding this episode in memory instead of refusing forever.
-        rebootBudgetPersistBroken = !ssSetVerified(REBOOT_KEY, encodeRebootMarker({ ...decoded, attempts: 0 }));
-      } else {
-        rebootBudgetPersistBroken = false;
+        if (ssSetVerified(REBOOT_KEY, encodeRebootMarker({ ...decoded, attempts: 0 }))) {
+          rebootStoragePersistBroken = false; // it wrote — storage is working again
+        } else {
+          noteRebootMarkerWriteFailed();
+        }
       }
       rebootEpisodeSends = 0; // the in-memory fallback bound, per delivery episode
       // Mids from the dead socket can never be acked on the new connection, so drop

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -18447,6 +18447,13 @@ function buildPanel() {
         piBackendsReadinessReceived = false;
         // Remember the drop so the next "connected" reconciles pending runs (#370).
         bridgeWasDown = true;
+        // #585: only a real drop→reconnect may refresh the restart-resume retry
+        // budget. Without this, a repeated "ready" on a still-live socket would
+        // reset it forever and turn a bounded retry into an unbounded nudge storm.
+        rebootBridgeDroppedSinceAttempt = true;
+        // A new connection re-opens the session question: whatever id we hold was
+        // reported by the connection that just died.
+        rebootSessionFrameSeen = false;
         if (agentWorking) {
           thinkingReconnecting = true;
           // Keep the indicator up with the reconnecting banner, but DON'T re-arm
@@ -18791,8 +18798,21 @@ function buildPanel() {
             return [];
           }
         })();
-        rebootResumeSent = false; // a NEW reboot re-arms the one-resume-per-reboot latch
-        const armedMarker = encodeRebootMarker({ at: Date.now(), runs: armedRuns });
+        // A NEW reboot is a NEW subject. Every piece of delivery state below belongs
+        // to the PREVIOUS one — most dangerously the outstanding message ids, whose
+        // delayed receipt would otherwise be accepted as proof that THIS reboot's
+        // resume was taken and retire its marker unsent.
+        resetRebootResumeDelivery();
+        const armedMarker = encodeRebootMarker({
+          at: Date.now(),
+          runs: armedRuns,
+          // WHICH conversation asked for the restart. The wait set above is global;
+          // the delivery target is not. Recorded here because this is the only
+          // moment we know it — by the time the ready ack lands the user may have
+          // switched workflows, and the resume must still find its way home.
+          threadId: ssGet(CURRENT_THREAD_KEY),
+          sessionId: ssGet(SESSION_KEY),
+        });
         ssSet(REBOOT_KEY, armedMarker);
         appendSystem("Restarting ComfyUI to load new nodes — I'll reconnect and pick up automatically when it's back.");
         // ssSet is best-effort (a full/blocked sessionStorage throws and is
@@ -18843,6 +18863,10 @@ function buildPanel() {
       }
     },
     onSession(sessionId) {
+      // #585: the orchestrator has now TOLD us which session this connection is on.
+      // Until this frame lands, "the id we armed with" is merely the id we have not
+      // been corrected about yet — so the restart resume treats it as unknown.
+      rebootSessionFrameSeen = true;
       bindSession(sessionId);
     },
     onTurnAnchor(uuid) {
@@ -18944,11 +18968,18 @@ function buildPanel() {
       // Receipt: orchestrator got it (not dropped) → cancel the failure timer.
       // The bubble stays QUEUED (muted) until the agent actually reads it.
       if (ack?.kind === "working" && typeof ack.mid === "string") {
+        // #585: this is the orchestrator testifying it TOOK the message. If it's the
+        // restart resume, that receipt — not our own send returning true — is what
+        // retires the reboot marker.
+        onRebootResumeReceipt(ack.mid);
         markReceived(ack.mid);
         return;
       }
       // Read: the agent dequeued this message → flip its bubble to read (normal).
       if (ack?.kind === "seen" && typeof ack.mid === "string") {
+        // A "seen" without a preceding "working" (frame coalescing / a dropped
+        // receipt) is still proof the resume was taken — stronger proof, in fact.
+        onRebootResumeReceipt(ack.mid);
         markRead(ack.mid);
         return;
       }
@@ -19338,12 +19369,66 @@ function buildPanel() {
   const REBOOT_WATCH_TICK_MS = 2000;
   let rebootWatchTimer = null;
   let rebootWaitNoticeShown = false;
+  let rebootSessionNoticeShown = false;
   // One resume per armed reboot, latched in memory. ssSet is best-effort: if the
   // clear-on-send silently fails (full/blocked sessionStorage) the marker would
   // survive and every later "ready" ack would re-send the nudge — a repeated
   // "continue" is exactly what makes the agent re-queue. Reset when a NEW reboot
   // is armed, so a second restart still resumes.
   let rebootResumeSent = false;
+  // The resume is retired on RECEIPT, not on send. client.sendUserMessage returns
+  // true the moment WebSocket.send() accepts the bytes — the socket can close
+  // before the orchestrator ever reads them, and an abandoned channel cannot
+  // testify that it wasn't. So each attempt carries a message id and the marker is
+  // held until a "working"/"seen" ack for THAT id comes back (the same receipt
+  // protocol every typed message uses). An attempt that isn't acked in time is
+  // retried, bounded, so a silent drop can neither strand the resume nor storm the
+  // agent with repeated nudges.
+  // Longer than the outbox's own 7s DELIVERY_TIMEOUT_MS, so anything the
+  // orchestrator was ever going to acknowledge has had more time than the panel's
+  // own standard for calling a message dropped.
+  const REBOOT_RESUME_ACK_TIMEOUT_MS = 12000;
+  const REBOOT_RESUME_MAX_ATTEMPTS = 3;
+  let rebootResumeMid = null; // outstanding attempt, awaiting receipt
+  let rebootResumeMidAt = 0;
+  // EVERY mid attempted for this reboot, not just the latest. A receipt for an
+  // earlier attempt is still proof the orchestrator took the resume — discarding it
+  // because a retry has since been issued would keep retrying something already
+  // delivered, and each retry is another "continue" turn in front of the agent.
+  const rebootResumeMids = new Set();
+  let rebootResumeStalledNoticeShown = false;
+  // True once the orchestrator's `session` frame has landed on THIS connection. The
+  // frame is not ordered against the "ready" ack, so before it arrives the session
+  // id we hold is simply the one we armed with — not evidence that the session was
+  // resumed rather than replaced.
+  let rebootSessionFrameSeen = false;
+  // Set whenever the bridge is observed DOWN; consumed by the next ready ack. The
+  // retry budget may only be reset by a genuine NEW connection — "ready" repeats on
+  // a live socket (backend readiness frames), and resetting on those would let a
+  // long-lived connection mint unlimited attempts and storm the agent.
+  let rebootBridgeDroppedSinceAttempt = false;
+
+  /** Drop any outstanding attempt — its channel is gone, so it can never be acked. */
+  function forgetRebootResumeAttempt() {
+    rebootResumeMid = null;
+    rebootResumeMidAt = 0;
+  }
+
+  /**
+   * Reset ALL per-reboot delivery state. Called when a new reboot is armed: the
+   * message ids, retry budget and one-shot notices below are scoped to a SPECIFIC
+   * reboot, and carrying them across would let a late receipt for the previous
+   * one retire the new one's marker without its resume ever being sent.
+   */
+  function resetRebootResumeDelivery() {
+    forgetRebootResumeAttempt();
+    rebootResumeMids.clear();
+    rebootResumeSent = false;
+    rebootResumeStalledNoticeShown = false;
+    rebootWaitNoticeShown = false;
+    rebootSessionNoticeShown = false;
+    rebootBridgeDroppedSinceAttempt = false;
+  }
 
   // The tracker is the only thing that can answer "is a frame still owed for this
   // run?". No tracker (pre-mount / post-dispose) ⇒ undefined predicate ⇒
@@ -19417,28 +19502,92 @@ function buildPanel() {
       raw: ssGet(REBOOT_KEY),
       isSettled: rebootIsSettled(),
       isDeliveryUnconfirmed: rebootDeliveryUnconfirmed(),
+      // Which conversation is on screen right now — compared against the one that
+      // armed the reboot, so the resume can never land on a different workflow.
+      currentThreadId: ssGet(CURRENT_THREAD_KEY),
+      currentSessionId: ssGet(SESSION_KEY),
+      sessionKnown: rebootSessionFrameSeen,
       nowMs: Date.now(),
       maxWaitMs: REBOOT_RESUME_MAX_WAIT_MS,
     });
-    if (step.decision === "wait_for_run") ssSet(REBOOT_KEY, step.nextRaw);
+    if (step.decision === "wait_for_run" || step.decision === "wait_for_session") {
+      ssSet(REBOOT_KEY, step.nextRaw);
+    }
     return step;
   }
 
+  /** Human label for the conversation that armed the reboot, for the held notice. */
+  function rebootArmingThreadLabel(marker) {
+    const tid = marker?.threadId;
+    if (!tid) return "another conversation";
+    const t = threads.find((candidate) => candidate.id === tid) || null;
+    return t?.title || t?.workflowKey || "another conversation";
+  }
+
+  /** The arming conversation isn't on screen — hold, and tell the user where it went. */
+  function holdRebootResumeForSession(step) {
+    if (!rebootSessionNoticeShown) {
+      rebootSessionNoticeShown = true;
+      appendSystem(
+        `A restart resume is waiting for ${rebootArmingThreadLabel(step.marker)} — switch back to it to pick that work up. ` +
+          `I won't send it here; it belongs to the conversation that asked for the restart.`,
+      );
+    }
+    armRebootWatch();
+  }
+
+  /** Never came back within the budget: abandon it VISIBLY rather than misdeliver. */
+  function abandonRebootResumeWrongSession(step) {
+    stopRebootWatch();
+    forgetRebootResumeAttempt();
+    rebootSessionNoticeShown = false;
+    ssSet(REBOOT_KEY, null);
+    appendSystem(
+      `The restart resume for ${rebootArmingThreadLabel(step.marker)} expired without being delivered — ` +
+        `it was never re-opened. If that conversation was mid-build, tell it to continue.`,
+    );
+  }
+
   /**
-   * Send the restart-resume nudge, and retire the marker ONLY once the send is
-   * confirmed. sendUserMessage returns false for a closed/failed socket — clearing
-   * the marker before checking that would swallow the resume permanently on a
-   * ready-ack/socket race, with nothing left to retry from. On failure we keep the
-   * marker AND the watch, so the next tick (or the next ready ack) reissues it.
+   * Send the restart-resume nudge. The marker is NOT retired here: a successful
+   * `sendUserMessage` only means WebSocket.send() accepted the bytes, and a socket
+   * that closes before the orchestrator reads them cannot tell us so. Retiring on
+   * that would strand the resume permanently. Instead the attempt carries a message
+   * id and the marker is held until the orchestrator's own receipt ack for that id
+   * arrives (onRebootResumeReceipt), which is the first point anything can testify
+   * the resume was actually taken.
    *
-   * @returns {boolean} whether the resume was actually sent.
+   * @returns {boolean} whether the attempt reached the transport at all.
    */
   function sendRebootResume(step) {
     const marker = step?.marker;
     const owed = marker?.runs ?? [];
     const waited = (marker?.armedRunCount ?? 0) > 0;
     const unconfirmed = step?.decision === "resume_unconfirmed";
-    const text = unconfirmed
+    // A previous attempt already went out for THIS reboot (persisted in the marker,
+    // so it survives a reload). We cannot know whether the orchestrator took it —
+    // an unacknowledged send is exactly the state we can't resolve — so say so
+    // rather than let a possible second identical "continue" arrive unannounced.
+    const repeat = (marker?.attempts ?? 0) > 0;
+    const repeatPrefix = repeat
+      ? "⚠️ You may have already received this restart notice — an earlier copy was sent but never acknowledged. If you already acted on it, ignore this one and do NOT re-queue anything. "
+      : "";
+    // The agent session behind this conversation looks REPLACED rather than
+    // resumed, so "continue what you were doing" may be addressed to an instance
+    // with no memory of that work — which is how a fresh session ends up re-reading
+    // the graph and re-queueing. Disclosed, never used to withhold the resume: a
+    // session id legitimately changes across a resume, so refusing on a mismatch
+    // would strand the ordinary restart.
+    const replacedPrefix =
+      step?.sessionState === "replaced"
+        ? "⚠️ Your agent session was replaced (not resumed) across this restart, so you may not have the context you had before. Check the ComfyUI queue/history before starting or re-queueing any render. "
+        : step?.sessionState === "unknown"
+          ? "⚠️ I couldn't confirm whether your agent session was resumed or replaced across this restart. Check the ComfyUI queue/history before starting or re-queueing any render. "
+          : "";
+    const text =
+      repeatPrefix +
+      replacedPrefix +
+      (unconfirmed
       ? `✅ ComfyUI just restarted to load newly-installed custom nodes (now available). ` +
         `⚠️ A render was already in flight when the restart was triggered${
           owed.length ? ` (prompt ${owed.join(", ")})` : ""
@@ -19446,26 +19595,27 @@ function buildPanel() {
         `it may still be running, and re-queueing would duplicate it. Then continue what you were doing before the restart.`
       : waited
         ? "✅ ComfyUI just restarted to load newly-installed custom nodes (now available). The render that was already in flight before the restart has since reported back — its result (or its failure) was already delivered to you, so do NOT re-queue it. Continue what you were doing before the restart."
-        : "✅ ComfyUI just restarted to load newly-installed custom nodes (now available). Continue what you were doing before the restart — if you were mid-build, pick it back up.";
-    const sent = client.sendUserMessage(text);
-    // The ONLY place the marker is retired — and only on a CONFIRMED send. A
-    // refused send (closed socket) writes the marker straight back, leaving the
-    // watch armed to reissue instead of losing the resume to a race.
-    const nextRaw = rebootMarkerAfterSend(step, sent);
-    ssSet(REBOOT_KEY, nextRaw);
+        : "✅ ComfyUI just restarted to load newly-installed custom nodes (now available). Continue what you were doing before the restart — if you were mid-build, pick it back up.");
+    const mid = newMid();
+    const sent = client.sendUserMessage(text, undefined, undefined, mid);
+    // Marker policy for THIS attempt. `sent` is only "the transport took it", so
+    // rebootMarkerAfterSend is deliberately given `false` here: the marker is
+    // retained either way, and only the receipt ack retires it. The attempt count
+    // is bumped in the PERSISTED marker so a reload still knows a nudge may already
+    // be in the agent's queue.
+    const retained = rebootMarkerAfterSend(step, false);
+    ssSet(
+      REBOOT_KEY,
+      retained && sent
+        ? encodeRebootMarker({ ...decodeRebootMarker(retained), attempts: (marker?.attempts ?? 0) + 1 })
+        : retained,
+    );
     if (!sent) return false;
-    rebootResumeSent = true;
-    stopRebootWatch();
-    // A refused CLEAR (best-effort storage again) would leave the marker to be
-    // re-read after a reload, where the per-mount latch is gone — the fresh mount
-    // could re-adopt an already-delivered run and nudge again. Nothing can force
-    // the write, so disclose it instead of pretending the state is clean.
-    if (nextRaw == null && ssGet(REBOOT_KEY) != null) {
-      appendSystem(
-        "Note: this browser wouldn't let me clear the restart marker. If you reload, I may repeat the restart nudge — ignore the second one.",
-      );
-    }
+    rebootResumeMid = mid;
+    rebootResumeMidAt = Date.now();
+    rebootResumeMids.add(mid);
     rebootWaitNoticeShown = false;
+    rebootSessionNoticeShown = false;
     appendSystem(
       unconfirmed
         ? `Reconnected — couldn't confirm the render that was in flight before the restart${
@@ -19474,6 +19624,36 @@ function buildPanel() {
         : "Reconnected — resuming where we left off.",
     );
     showThinking();
+    armRebootWatch(); // keep watching until the orchestrator acknowledges receipt
+    return true;
+  }
+
+  /**
+   * The orchestrator acknowledged receipt of the resume ("working" = it took the
+   * message, "seen" = the agent dequeued it). THIS is the evidence that retires the
+   * marker — the first point at which anything other than our own transport can
+   * testify the resume was not dropped.
+   */
+  function onRebootResumeReceipt(mid) {
+    // Any attempt's receipt counts, not just the newest. A `working` ack for an
+    // earlier retry still proves the orchestrator took the resume; ignoring it
+    // because a newer attempt is outstanding would keep retrying an already
+    // delivered nudge, and every retry is another "continue" turn for the agent.
+    if (!mid || !rebootResumeMids.has(mid)) return false;
+    forgetRebootResumeAttempt();
+    rebootResumeMids.clear();
+    rebootResumeStalledNoticeShown = false;
+    rebootResumeSent = true;
+    stopRebootWatch();
+    ssSet(REBOOT_KEY, null); // retired on RECEIPT, the only place it is cleared
+    // A refused CLEAR (best-effort storage) would leave the marker to be re-read
+    // after a reload, where the per-mount latch is gone. Nothing can force the
+    // write, so disclose it rather than pretend the state is clean.
+    if (ssGet(REBOOT_KEY) != null) {
+      appendSystem(
+        "Note: this browser wouldn't let me clear the restart marker. If you reload, I may repeat the restart nudge — ignore the second one.",
+      );
+    }
     return true;
   }
 
@@ -19493,6 +19673,14 @@ function buildPanel() {
         ssSet(REBOOT_KEY, null);
         return;
       }
+      // An attempt is out and not yet acknowledged. Wait for the receipt rather
+      // than firing a second nudge — repeated "continue" messages are themselves
+      // the duplicate-render hazard. Past the window the attempt is presumed
+      // dropped and becomes retryable.
+      if (rebootResumeMid != null) {
+        if (Date.now() - rebootResumeMidAt < REBOOT_RESUME_ACK_TIMEOUT_MS) return;
+        forgetRebootResumeAttempt();
+      }
       const step = stepRebootResumeHere();
       if (step.decision === "none") {
         stopRebootWatch(); // cleared elsewhere (explicit Disconnect) — stand down
@@ -19500,12 +19688,49 @@ function buildPanel() {
         return;
       }
       if (step.decision === "wait_for_run") return;
-      // The resume is a user message on the agent session — it needs a live
-      // bridge. Not connected yet ⇒ keep the marker and keep watching; the
-      // reconnect's own "ready" ack re-enters this same decision.
-      if (!client.isConnected()) return;
-      sendRebootResume(step); // a refused send keeps the marker AND this watch
+      if (step.decision === "wait_for_session") {
+        holdRebootResumeForSession(step);
+        return;
+      }
+      if (step.decision === "expired_wrong_session") {
+        abandonRebootResumeWrongSession(step);
+        return;
+      }
+      tryRebootResume(step); // a refused send keeps the marker AND this watch
     }, REBOOT_WATCH_TICK_MS);
+  }
+
+  /**
+   * The ONE gate every resume send passes through. Both entry points — the watch
+   * tick and the "ready" ack — must share it: a budget enforced on only one of them
+   * is not a budget, and the ack path is the easier one to trigger repeatedly
+   * (readiness frames repeat on a live socket).
+   *
+   * @returns {boolean} whether a resume was actually handed to the transport.
+   */
+  function tryRebootResume(step) {
+    // The resume is a user message on the agent session — it needs a live bridge.
+    // Not connected yet ⇒ keep the marker and keep watching; the reconnect's own
+    // "ready" ack re-enters this same decision.
+    if (!client.isConnected()) return false;
+    // Bounded retries so an orchestrator that never acks can't be nudged on a loop.
+    // Budget spent ⇒ stop RE-SENDING but KEEP the marker: only an observed drop and
+    // reconnect refreshes it, which is recovery rather than a strand.
+    //
+    // The count comes from the PERSISTED marker, not an in-memory counter. A fresh
+    // mount's counter starts at zero, so a reload would hand back a full budget and
+    // repeated reloads would mint unlimited nudges — the storm the bound exists to
+    // prevent. One source of truth, and it is the one that survives a reload.
+    if ((step?.marker?.attempts ?? 0) >= REBOOT_RESUME_MAX_ATTEMPTS) {
+      if (!rebootResumeStalledNoticeShown) {
+        rebootResumeStalledNoticeShown = true;
+        appendSystem(
+          "Couldn't confirm the restart nudge reached the agent. Keeping it pending — it'll retry when the connection next comes back.",
+        );
+      }
+      return false;
+    }
+    return sendRebootResume(step);
   }
 
   /**
@@ -19530,6 +19755,29 @@ function buildPanel() {
       ssSet(REBOOT_KEY, null);
       return false;
     }
+    // A reconnect is a FRESH delivery episode: the previous attempt's channel is
+    // gone (it can never be acked now) and the retry budget starts over, mirroring
+    // how the /history reconciler treats a reconnect edge. But ONLY a real drop
+    // counts — "ready" repeats on a live socket, and treating those as reconnects
+    // would refresh the budget indefinitely and let one connection mint unlimited
+    // nudges. Elapsed time is not evidence of a new connection; an observed drop is.
+    if (rebootBridgeDroppedSinceAttempt) {
+      rebootBridgeDroppedSinceAttempt = false;
+      forgetRebootResumeAttempt();
+      rebootResumeStalledNoticeShown = false;
+      // The budget lives in the PERSISTED marker (so a reload can't refill it), so
+      // refreshing it means rewriting the marker — not zeroing a local counter.
+      const raw = ssGet(REBOOT_KEY);
+      const decoded = raw == null ? null : decodeRebootMarker(raw);
+      if (decoded && decoded.attempts > 0) {
+        ssSet(REBOOT_KEY, encodeRebootMarker({ ...decoded, attempts: 0 }));
+      }
+    } else if (rebootResumeMid != null) {
+      // Same connection, attempt still outstanding — let the watch and the receipt
+      // ack resolve it rather than firing a second identical "continue".
+      armRebootWatch();
+      return true;
+    }
     adoptRebootRunsHere(); // reload survival: re-pend persisted ids into this mount
     const step = stepRebootResumeHere();
     if (step.decision === "none") return false;
@@ -19543,9 +19791,18 @@ function buildPanel() {
       armRebootWatch(); // marker deliberately RETAINED; the watch reissues the resume
       return true;
     }
-    // A failed send keeps the marker; arm the watch so the resume is retried
-    // instead of being lost to a socket that closed between the ack and the send.
-    if (!sendRebootResume(step)) armRebootWatch();
+    if (step.decision === "wait_for_session") {
+      holdRebootResumeForSession(step); // belongs to a different conversation
+      return true;
+    }
+    if (step.decision === "expired_wrong_session") {
+      abandonRebootResumeWrongSession(step);
+      return true;
+    }
+    // Same gate as the watch tick — budget, connectivity, everything. A send that
+    // doesn't happen keeps the marker; arm the watch so the resume is retried rather
+    // than lost to a socket that closed between the ack and the send.
+    if (!tryRebootResume(step)) armRebootWatch();
     return true;
   }
 
@@ -20488,6 +20745,7 @@ function buildPanel() {
     // …and stop the #585 watch, or it would keep re-evaluating a marker the user
     // just revoked (and could still fire the resume after an explicit Disconnect).
     stopRebootWatch();
+    forgetRebootResumeAttempt();
     client.stop();
     // client.stop() sets closed=true, so the socket onclose suppresses onStatus
     // — end the turn locally so the working indicator can't spin forever against

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -19421,6 +19421,12 @@ function buildPanel() {
   // Has THIS mount ever seen a live bridge? Without it, a fresh client's opening
   // `connecting` reads as a drop and a reload refills the retry budget.
   let rebootSeenConnected = false;
+  let rebootPruneFailureNoticeShown = false;
+  // Set when a budget RESET write is verified to have failed. The persisted count
+  // is then stale-high forever, so the gate falls back to this in-memory per-episode
+  // count — still bounded, but not a permanent refusal.
+  let rebootBudgetPersistBroken = false;
+  let rebootEpisodeSends = 0;
 
   /** Drop any outstanding attempt — its channel is gone, so it can never be acked. */
   function forgetRebootResumeAttempt() {
@@ -19439,6 +19445,9 @@ function buildPanel() {
     rebootResumeMids.clear();
     rebootResumeSent = false;
     rebootAttemptCountUnreliableNoticeShown = false;
+    rebootPruneFailureNoticeShown = false;
+    rebootBudgetPersistBroken = false;
+    rebootEpisodeSends = 0;
     rebootResumeStalledNoticeShown = false;
     rebootWaitNoticeShown = false;
     rebootSessionNoticeShown = false;
@@ -19462,6 +19471,12 @@ function buildPanel() {
     return tracker ? (id) => tracker.isDeliveryUnconfirmed(id) : undefined;
   };
 
+  /** ssSet, then read back. Returns whether the value actually persisted. */
+  function ssSetVerified(key, value) {
+    ssSet(key, value);
+    return ssGet(key) === value;
+  }
+
   function readRebootMarker() {
     return decodeRebootMarker(ssGet(REBOOT_KEY));
   }
@@ -19476,7 +19491,18 @@ function buildPanel() {
     const raw = ssGet(REBOOT_KEY);
     if (raw == null) return;
     const next = pruneRebootMarkerRaw(raw, rebootIsSettled(), rebootDeliveryUnconfirmed());
-    if (next !== raw) ssSet(REBOOT_KEY, next);
+    if (next === raw) return;
+    // VERIFIED. A prune that silently fails leaves an already-delivered run id in the
+    // marker; a reload then re-adopts it and `/history` reconciles its completion to
+    // the agent a SECOND time. Nothing further can force the write, so surface it —
+    // this path had no disclosure at all, which is what made it worse than the
+    // best-effort-storage cases that do.
+    if (!ssSetVerified(REBOOT_KEY, next) && !rebootPruneFailureNoticeShown) {
+      rebootPruneFailureNoticeShown = true;
+      appendSystem(
+        "Note: this browser wouldn't let me update the restart marker. If you reload, a render result that was already delivered may be reported to the agent twice.",
+      );
+    }
   }
 
   /**
@@ -19526,7 +19552,15 @@ function buildPanel() {
       maxWaitMs: REBOOT_RESUME_MAX_WAIT_MS,
     });
     if (step.decision === "wait_for_run" || step.decision === "wait_for_session") {
-      ssSet(REBOOT_KEY, step.nextRaw);
+      // Same class as the prune write: this rewrite is what drops already-settled run
+      // ids from the marker, so a silent failure leaves a delivered run in it for a
+      // reload to re-adopt and re-deliver. Verified, and disclosed once if it fails.
+      if (!ssSetVerified(REBOOT_KEY, step.nextRaw) && !rebootPruneFailureNoticeShown) {
+        rebootPruneFailureNoticeShown = true;
+        appendSystem(
+          "Note: this browser wouldn't let me update the restart marker. If you reload, a render result that was already delivered may be reported to the agent twice.",
+        );
+      }
     }
     return step;
   }
@@ -19661,6 +19695,7 @@ function buildPanel() {
     rebootResumeMid = mid;
     rebootResumeMidAt = Date.now();
     rebootResumeMids.add(mid);
+    rebootEpisodeSends += 1;
     // A continuation has now been issued for this drop, so the generic mid-task
     // "you dropped, pick it back up" fallback must not ALSO fire. `ready` repeats on
     // a live socket, and once the marker is retired those repeats fall through to
@@ -19779,7 +19814,10 @@ function buildPanel() {
     // recoverable side (the unknown total already forces the duplicate warning), and
     // the write-ahead below replaces the unknown with a real count — so this resolves
     // after exactly one attempt instead of looping.
-    const budgetUsed = step?.marker?.attempts;
+    // When the persisted budget cannot be RESET (a verified-failed write), the
+    // persisted number is stale-high forever and gating on it would refuse every
+    // tick. Bound this episode in memory instead — still bounded, but recoverable.
+    const budgetUsed = rebootBudgetPersistBroken ? rebootEpisodeSends : step?.marker?.attempts;
     if (Number.isFinite(budgetUsed) && Number(budgetUsed) >= REBOOT_RESUME_MAX_ATTEMPTS) {
       if (!rebootResumeStalledNoticeShown) {
         rebootResumeStalledNoticeShown = true;
@@ -19836,8 +19874,15 @@ function buildPanel() {
       // observed drop, "this episode has made zero attempts" is a true statement we
       // can now assert. The total is untouched and stays unknown if it was.
       if (decoded && decoded.attempts !== 0) {
-        ssSet(REBOOT_KEY, encodeRebootMarker({ ...decoded, attempts: 0 }));
+        // VERIFIED. If the reset silently fails, the persisted budget stays spent and
+        // the send gate refuses on every tick — a confirmed reconnect turning into a
+        // permanent stall. A budget we cannot reset is a budget we cannot manage, so
+        // fall back to bounding this episode in memory instead of refusing forever.
+        rebootBudgetPersistBroken = !ssSetVerified(REBOOT_KEY, encodeRebootMarker({ ...decoded, attempts: 0 }));
+      } else {
+        rebootBudgetPersistBroken = false;
       }
+      rebootEpisodeSends = 0; // the in-memory fallback bound, per delivery episode
       // Mids from the dead socket can never be acked on the new connection, so drop
       // them — this also bounds the set across repeated drops.
       rebootResumeMids.clear();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -286,7 +286,15 @@ import {
   buildHelloPayload,
 } from "./lib/session-rebind.js";
 import { createRestartTabIdentity, sendBridgeHello } from "./lib/restart-tab-identity.js";
-import { planRebootResume } from "./lib/restart-resume.js";
+import {
+  adoptRebootRuns,
+  decodeRebootMarker,
+  encodeRebootMarker,
+  pruneRebootMarkerRaw,
+  rebootMarkerAfterSend,
+  stepRebootResume,
+  REBOOT_RESUME_MAX_WAIT_MS,
+} from "./lib/restart-resume.js";
 
 let app = null;
 let api = null;
@@ -18752,8 +18760,37 @@ function buildPanel() {
       // arming resume in those cases would leave the panel waiting for a restart
       // that never happens.
       if (cmd === "comfy_reboot" && reply.ok && reply.result?.rebooting === true) {
-        ssSet(REBOOT_KEY, "1");
+        // #585: record WHICH runs are still owed a completion frame at the moment
+        // the reboot is armed. The post-restart resume is suppressed for exactly
+        // those prompt ids — never for a global "something is pending" count,
+        // which an UNRELATED workflow's render would satisfy, swallowing this
+        // resume. The ids go in sessionStorage with the marker so the correlation
+        // survives the frontend reload a restart can cause (an in-memory ledger
+        // starts empty on the new mount and would report "nothing in flight" for
+        // a render that is still executing).
+        const armedRuns = (() => {
+          try {
+            return runCompletionRef?.unsettledPromptIds?.() ?? [];
+          } catch {
+            return [];
+          }
+        })();
+        rebootResumeSent = false; // a NEW reboot re-arms the one-resume-per-reboot latch
+        const armedMarker = encodeRebootMarker({ at: Date.now(), runs: armedRuns });
+        ssSet(REBOOT_KEY, armedMarker);
         appendSystem("Restarting ComfyUI to load new nodes — I'll reconnect and pick up automatically when it's back.");
+        // ssSet is best-effort (a full/blocked sessionStorage throws and is
+        // swallowed). Verify the EXACT value landed, not merely that some marker is
+        // present — a refused overwrite would leave a PREVIOUS reboot's marker,
+        // whose run ids don't describe this restart at all, and the resume would be
+        // decided from stale correlation. Either way, say so rather than let the
+        // user wonder why nothing picked up.
+        if (ssGet(REBOOT_KEY) !== armedMarker) {
+          ssSet(REBOOT_KEY, null); // better no marker than a stale one deciding this restart
+          appendSystem(
+            "Heads up: this browser wouldn't let me save the restart marker, so I can't auto-resume after the restart — reconnect manually if the agent goes quiet.",
+          );
+        }
       }
       // #310 — free_vram unloads models and can BOUNCE the ComfyUI connection,
       // which drops the orchestrator's tab mapping (the next graph tool then
@@ -18924,33 +18961,11 @@ function buildPanel() {
       }
       // Post-restart auto-resume (#3): the "ready" ack is sent after the
       // orchestrator armed hello.resume, so resuming the agent is safe now.
-      // Clear REBOOT_KEY only here (on actual send) so a drop mid-reconnect
-      // retries instead of losing the resume.
-      const rebootResume = planRebootResume({
-        rebootPending: ack?.kind === "ready" && !!ssGet(REBOOT_KEY),
-        // A prompt recorded before the reboot may still be running when the
-        // backend returns. Its completion/reconcile event is the authoritative
-        // continuation signal; waking the agent generically here caused it to
-        // requeue the same render (#585).
-        // The callback is registered before this mount's tracker is constructed;
-        // the module ref is therefore safe even if a bridge implementation emits
-        // a synchronous initial ready frame.
-        hasPendingRun: runCompletionRef?.hasPending?.() ?? false,
-      });
-      if (rebootResume === "wait_for_run") {
-        ssSet(REBOOT_KEY, null);
-        appendSystem("Reconnected — waiting for the render that was already in flight before the restart.");
-        return;
-      }
-      if (rebootResume === "resume") {
-        ssSet(REBOOT_KEY, null);
-        appendSystem("Reconnected — resuming where we left off.");
-        showThinking();
-        client.sendUserMessage(
-          "✅ ComfyUI just restarted to load newly-installed custom nodes (now available). Continue what you were doing before the restart — if you were mid-build, pick it back up.",
-        );
-        return;
-      }
+      // #585 routes this through the correlated restart-resume flow below, which
+      // owns clearing REBOOT_KEY — it clears the marker ONLY when the resume is
+      // actually sent, so neither a drop mid-reconnect NOR a suppression while a
+      // pre-restart render finishes can lose it.
+      if (ack?.kind === "ready" && ssGet(REBOOT_KEY) && handleRebootResumeAck()) return;
       // Soft-reload resume: the fresh orchestrator is up. Resume silently for a
       // user-triggered reload; nudge to continue for an agent-triggered one
       // (it was mid-task and its tool call died with the old process).
@@ -19124,6 +19139,11 @@ function buildPanel() {
           if (frame == null || framePushed) runCompletion.markDelivered(promptId);
           else if (AGENT_MUTED) runCompletion.markDelivered(promptId);
           else runCompletion.markUndelivered(promptId);
+          // #585: this is the moment "the agent was told" becomes true (or is
+          // re-pended). Refresh the persisted reboot marker now so a reload in the
+          // gap before the next watch tick can't re-adopt an already-delivered run
+          // and have /history deliver its completion a second time.
+          pruneRebootMarker();
         })
         .catch((err) => {
           console.warn("[cmcp] composeRunCompletionFrame failed:", err);
@@ -19132,6 +19152,7 @@ function buildPanel() {
           // (but respect an intentional mute, as above).
           if (framePushed || AGENT_MUTED) runCompletion.markDelivered(promptId);
           else runCompletion.markUndelivered(promptId);
+          pruneRebootMarker(); // #585 — see the .then branch above
         });
     },
     // #370: deliver a reconcile-discovered terminal ERROR. Routed through the
@@ -19150,6 +19171,7 @@ function buildPanel() {
       // reconcileKey already marked it delivered, so leave it. Only a genuine
       // transport failure re-pends so the next reconnect/retry re-delivers it.
       else if (!AGENT_MUTED) runCompletion.markUndelivered(promptId);
+      pruneRebootMarker(); // #585 — a terminal error is also "the agent was told"
     },
     // #582: ComfyUI writes a manually stopped run to history with raw
     // status_str:"error" plus execution_interrupted. Deliver a neutral event,
@@ -19165,13 +19187,14 @@ function buildPanel() {
       // Match terminal-error recovery: only a transport drop re-pends the
       // cancellation notice; an intentionally muted agent stays silent.
       else if (!AGENT_MUTED) runCompletion.markUndelivered(promptId);
+      pruneRebootMarker(); // #585 — a cancellation notice is also "the agent was told"
     },
     // #370 (P1 memory-leak): the tracker GAVE UP on a prompt whose outcome it
     // couldn't confirm after the bounded retries (its /history stayed absent —
     // cancelled/disconnected). It's been evicted from the ledger; surface a
     // one-time "status unknown, safe to requeue" notice so the agent stops waiting.
     onReconcileGiveUp: ({ promptId }) => {
-      client.sendFrame({
+      const sent = client.sendFrame({
         type: "agent_event",
         kind: "run_error",
         error:
@@ -19179,6 +19202,17 @@ function buildPanel() {
           `(no history for it) — it was likely cancelled or interrupted. Safe to requeue.`,
       });
       appendSystem(`Render status unknown for prompt ${promptId} — safe to requeue.`);
+      // #585: give-up EVICTS the run from the recovery ledger, so unlike the
+      // error/interrupted paths there is nothing to re-pend if this notice didn't
+      // land. Flag it so the run still reads as unsettled-in-truth: a
+      // delivery-gated restart-resume must disclose rather than tell the agent its
+      // outcome "was already delivered" when the only frame about it was dropped.
+      if (!sent && !AGENT_MUTED) runCompletion.markDeliveryUnconfirmed(promptId);
+      // #585: the tracker gave up on this run, so no completion frame will ever be
+      // owed for it. Drop it from the reboot marker — otherwise a suppressed
+      // restart-resume would wait on a run that can never settle, which is the
+      // SILENT failure (the user waits forever for a turn that never starts).
+      pruneRebootMarker();
     },
   });
   runCompletionRef = runCompletion;
@@ -19270,6 +19304,244 @@ function buildPanel() {
   const armRunReconcileSweep = () => runReconcileSweep.arm();
   armRunReconcileSweepRef = armRunReconcileSweep;
 
+  // ── #585: correlated restart-resume ───────────────────────────────────────
+  // After a ComfyUI restart the panel nudges the agent to continue. If a render
+  // queued BEFORE the restart is still in flight — or finished but its completion
+  // frame has not reached the agent yet — that nudge makes the agent conclude the
+  // render was aborted and queue it again.
+  //
+  // The guard is CORRELATION, not aggression: the reboot marker carries the
+  // specific prompt ids that were still owed a completion frame when the reboot
+  // was armed (lib/restart-resume.js), and every decision below is about THOSE
+  // ids. Two rules make the two opposite failures unreachable:
+  //   • the marker is NEVER cleared while suppressing — only when a resume is
+  //     actually sent — so a suppressed resume is always reissued once the run it
+  //     waited on settles (the alternative silently strands the user forever);
+  //   • "settled" means no frame is still owed to the agent (isSettled), not
+  //     "the tracker retired it" (which fires before the async send resolves).
+  const REBOOT_WATCH_TICK_MS = 2000;
+  let rebootWatchTimer = null;
+  let rebootWaitNoticeShown = false;
+  // One resume per armed reboot, latched in memory. ssSet is best-effort: if the
+  // clear-on-send silently fails (full/blocked sessionStorage) the marker would
+  // survive and every later "ready" ack would re-send the nudge — a repeated
+  // "continue" is exactly what makes the agent re-queue. Reset when a NEW reboot
+  // is armed, so a second restart still resumes.
+  let rebootResumeSent = false;
+
+  // The tracker is the only thing that can answer "is a frame still owed for this
+  // run?". No tracker (pre-mount / post-dispose) ⇒ undefined predicate ⇒
+  // unsettledRebootRuns reports every id as owed, so we wait (and disclose) rather
+  // than nudge on a blind guess.
+  const rebootIsSettled = () => {
+    const tracker = runCompletionRef;
+    return tracker ? (id) => tracker.isSettled(id) : undefined;
+  };
+  // …and whether a watched run's frame was dispatched but never CONFIRMED to have
+  // reached the agent. Such a run no longer blocks the resume (that would strand
+  // the session), but the resume must DISCLOSE it instead of telling the agent its
+  // result was already delivered — a false reassurance would invite the duplicate.
+  const rebootDeliveryUnconfirmed = () => {
+    const tracker = runCompletionRef;
+    return tracker ? (id) => tracker.isDeliveryUnconfirmed(id) : undefined;
+  };
+
+  function readRebootMarker() {
+    return decodeRebootMarker(ssGet(REBOOT_KEY));
+  }
+
+  /**
+   * Drop run ids the tracker now reports as settled from the PERSISTED marker.
+   * Keeps the marker an accurate ledger across a reload: a reload that re-adopted
+   * an already-delivered id would have `/history` reconcile it and deliver its
+   * completion a SECOND time.
+   */
+  function pruneRebootMarker() {
+    const raw = ssGet(REBOOT_KEY);
+    if (raw == null) return;
+    const next = pruneRebootMarkerRaw(raw, rebootIsSettled(), rebootDeliveryUnconfirmed());
+    if (next !== raw) ssSet(REBOOT_KEY, next);
+  }
+
+  /**
+   * Re-adopt the marker's runs into THIS mount's tracker (reload survival — see
+   * lib/restart-resume.js `adoptRebootRuns`), then let the existing `/history` +
+   * `/queue` reconcile decide each one's fate.
+   */
+  function adoptRebootRunsHere() {
+    const tracker = runCompletionRef;
+    if (!tracker) return;
+    const runs = readRebootMarker()?.runs ?? [];
+    if (!runs.length) return;
+    adoptRebootRuns(runs, tracker);
+    // Only start probing once the bridge is up. Reconcile's give-up path fires a
+    // one-time "safe to requeue" frame and then EVICTS the run — firing that at a
+    // disconnected agent burns the run's only outcome on a dropped frame. That
+    // applies to the periodic SWEEP as much as to the immediate call, so neither is
+    // started here while disconnected; this runs again on every "ready" ack, which
+    // by definition means the agent can receive what we find.
+    if (!client.isConnected()) return;
+    void reconcileRunsAfterReconnect();
+    armRunReconcileSweep();
+  }
+
+  function stopRebootWatch() {
+    if (rebootWatchTimer != null) {
+      clearInterval(rebootWatchTimer);
+      rebootWatchTimer = null;
+    }
+  }
+
+  /**
+   * One evaluation + the marker write it implies. `nextRaw` is null ONLY when a
+   * resume is actually being sent; on wait it is the retained (pruned) marker.
+   */
+  function stepRebootResumeHere() {
+    const step = stepRebootResume({
+      raw: ssGet(REBOOT_KEY),
+      isSettled: rebootIsSettled(),
+      isDeliveryUnconfirmed: rebootDeliveryUnconfirmed(),
+      nowMs: Date.now(),
+      maxWaitMs: REBOOT_RESUME_MAX_WAIT_MS,
+    });
+    if (step.decision === "wait_for_run") ssSet(REBOOT_KEY, step.nextRaw);
+    return step;
+  }
+
+  /**
+   * Send the restart-resume nudge, and retire the marker ONLY once the send is
+   * confirmed. sendUserMessage returns false for a closed/failed socket — clearing
+   * the marker before checking that would swallow the resume permanently on a
+   * ready-ack/socket race, with nothing left to retry from. On failure we keep the
+   * marker AND the watch, so the next tick (or the next ready ack) reissues it.
+   *
+   * @returns {boolean} whether the resume was actually sent.
+   */
+  function sendRebootResume(step) {
+    const marker = step?.marker;
+    const owed = marker?.runs ?? [];
+    const waited = (marker?.armedRunCount ?? 0) > 0;
+    const unconfirmed = step?.decision === "resume_unconfirmed";
+    const text = unconfirmed
+      ? `✅ ComfyUI just restarted to load newly-installed custom nodes (now available). ` +
+        `⚠️ A render was already in flight when the restart was triggered${
+          owed.length ? ` (prompt ${owed.join(", ")})` : ""
+        } and I could NOT confirm whether it finished. Check the ComfyUI queue/history for it BEFORE re-queueing anything — ` +
+        `it may still be running, and re-queueing would duplicate it. Then continue what you were doing before the restart.`
+      : waited
+        ? "✅ ComfyUI just restarted to load newly-installed custom nodes (now available). The render that was already in flight before the restart has since reported back — its result (or its failure) was already delivered to you, so do NOT re-queue it. Continue what you were doing before the restart."
+        : "✅ ComfyUI just restarted to load newly-installed custom nodes (now available). Continue what you were doing before the restart — if you were mid-build, pick it back up.";
+    const sent = client.sendUserMessage(text);
+    // The ONLY place the marker is retired — and only on a CONFIRMED send. A
+    // refused send (closed socket) writes the marker straight back, leaving the
+    // watch armed to reissue instead of losing the resume to a race.
+    const nextRaw = rebootMarkerAfterSend(step, sent);
+    ssSet(REBOOT_KEY, nextRaw);
+    if (!sent) return false;
+    rebootResumeSent = true;
+    stopRebootWatch();
+    // A refused CLEAR (best-effort storage again) would leave the marker to be
+    // re-read after a reload, where the per-mount latch is gone — the fresh mount
+    // could re-adopt an already-delivered run and nudge again. Nothing can force
+    // the write, so disclose it instead of pretending the state is clean.
+    if (nextRaw == null && ssGet(REBOOT_KEY) != null) {
+      appendSystem(
+        "Note: this browser wouldn't let me clear the restart marker. If you reload, I may repeat the restart nudge — ignore the second one.",
+      );
+    }
+    rebootWaitNoticeShown = false;
+    appendSystem(
+      unconfirmed
+        ? `Reconnected — couldn't confirm the render that was in flight before the restart${
+            owed.length ? ` (prompt ${owed.join(", ")})` : ""
+          }. Resuming, and telling the agent to check the queue before re-running.`
+        : "Reconnected — resuming where we left off.",
+    );
+    showThinking();
+    return true;
+  }
+
+  /**
+   * Re-evaluate the suppressed resume on a timer. This is what makes suppression
+   * safe: the marker stays set while we wait, and the resume is reissued the
+   * moment the specific run it is waiting on is confirmed delivered (or the
+   * bounded wait expires and we resume WITH a disclosure).
+   */
+  function armRebootWatch() {
+    if (rebootWatchTimer != null) return;
+    rebootWatchTimer = setInterval(() => {
+      // Same two revocations as the ack path: an explicit Disconnect, and a resume
+      // already sent for this reboot whose marker clear didn't stick.
+      if (rebootResumeSent || lsGet(USER_DISCONNECTED_KEY)) {
+        stopRebootWatch();
+        ssSet(REBOOT_KEY, null);
+        return;
+      }
+      const step = stepRebootResumeHere();
+      if (step.decision === "none") {
+        stopRebootWatch(); // cleared elsewhere (explicit Disconnect) — stand down
+        rebootWaitNoticeShown = false;
+        return;
+      }
+      if (step.decision === "wait_for_run") return;
+      // The resume is a user message on the agent session — it needs a live
+      // bridge. Not connected yet ⇒ keep the marker and keep watching; the
+      // reconnect's own "ready" ack re-enters this same decision.
+      if (!client.isConnected()) return;
+      sendRebootResume(step); // a refused send keeps the marker AND this watch
+    }, REBOOT_WATCH_TICK_MS);
+  }
+
+  /**
+   * Handle a "ready" ack while a reboot marker is set.
+   * @returns {boolean} true when this ack was consumed by the restart-resume flow.
+   */
+  function handleRebootResumeAck() {
+    if (!readRebootMarker()) return false;
+    // An explicit Disconnect revokes the resume. It clears REBOOT_KEY, but ssSet is
+    // best-effort — honour the (localStorage, durable) opt-out latch too so a
+    // marker that survived a failed clear can't resurrect a session the user
+    // deliberately walked away from.
+    if (lsGet(USER_DISCONNECTED_KEY)) {
+      stopRebootWatch();
+      ssSet(REBOOT_KEY, null);
+      return false;
+    }
+    // The resume for THIS reboot already went out; a marker still present means the
+    // clear didn't stick. Re-sending would nudge the agent to "continue" twice.
+    if (rebootResumeSent) {
+      stopRebootWatch();
+      ssSet(REBOOT_KEY, null);
+      return false;
+    }
+    adoptRebootRunsHere(); // reload survival: re-pend persisted ids into this mount
+    const step = stepRebootResumeHere();
+    if (step.decision === "none") return false;
+    if (step.decision === "wait_for_run") {
+      if (!rebootWaitNoticeShown) {
+        rebootWaitNoticeShown = true;
+        appendSystem(
+          "Reconnected — holding the restart nudge until the render that was already in flight reports back.",
+        );
+      }
+      armRebootWatch(); // marker deliberately RETAINED; the watch reissues the resume
+      return true;
+    }
+    // A failed send keeps the marker; arm the watch so the resume is retried
+    // instead of being lost to a socket that closed between the ack and the send.
+    if (!sendRebootResume(step)) armRebootWatch();
+    return true;
+  }
+
+  // A restart that reloaded the frontend — or a plain panel remount mid-wait —
+  // lands here with an EMPTY ledger and a surviving marker: adopt its runs now so
+  // `/history` + `/queue` start deciding their fate immediately, and re-arm the
+  // watch so a suppressed resume is still reissued even if this mount never sees
+  // another "ready" ack. Neither can fire the nudge early: the watch only sends
+  // once the specific runs are settled AND the bridge is connected.
+  adoptRebootRunsHere();
+  if (readRebootMarker()?.runs.length) armRebootWatch();
+
   function onExecuted(ev) {
     const d = ev?.detail ?? {};
     const out = d.output || {};
@@ -19346,6 +19618,10 @@ function buildPanel() {
     // this frame (sendFrame also returns false then) — onExecutionFailed already
     // marked it delivered, so leaving it there keeps the mute permanent (codex P1).
     if (!runErrorSent && !AGENT_MUTED) runCompletion.markUndelivered(d.prompt_id);
+    // #585: a live failure is also a terminal outcome the agent has been told
+    // about — retire it from the reboot marker so a reload can't re-adopt it and
+    // have /history deliver the same failure a second time.
+    pruneRebootMarker();
     // 2) Render it immediately as an error widget in the chat, so the user sees it
     //    even before the agent reacts (no waiting on a check-errors call).
     paintCard({
@@ -20193,6 +20469,9 @@ function buildPanel() {
     // Also cancel any pending tool-triggered reboot resume: an explicit Disconnect
     // during a reboot window must not be overridden by a surviving REBOOT_KEY.
     ssSet(REBOOT_KEY, null);
+    // …and stop the #585 watch, or it would keep re-evaluating a marker the user
+    // just revoked (and could still fire the resume after an explicit Disconnect).
+    stopRebootWatch();
     client.stop();
     // client.stop() sets closed=true, so the socket onclose suppresses onStatus
     // — end the turn locally so the working indicator can't spin forever against
@@ -22042,6 +22321,11 @@ function buildPanel() {
       // reconcile await (codex P1 unmount-resurrection leak). Only null the shared
       // refs if they still point at THIS instance — a newer mount may already own them.
       runReconcileSweep.dispose();
+      // #585: the restart-resume watch drives client.sendUserMessage — a torn-down
+      // panel must not keep it alive. The marker itself SURVIVES on purpose: a
+      // remount re-reads it and re-arms the watch, so unmounting never loses the
+      // suppressed resume.
+      stopRebootWatch();
       if (armRunReconcileSweepRef === armRunReconcileSweep) armRunReconcileSweepRef = null;
       if (runCompletionRef === runCompletion) runCompletionRef = null;
       // Drop the Settings→panel hooks so the dialog can't drive a torn-down panel

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -289,6 +289,7 @@ import { createRestartTabIdentity, sendBridgeHello } from "./lib/restart-tab-ide
 import {
   adoptRebootRuns,
   decodeRebootMarker,
+  isRealBridgeDrop,
   encodeRebootMarker,
   pruneRebootMarkerRaw,
   rebootMarkerAfterSend,
@@ -18439,6 +18440,9 @@ function buildPanel() {
         // The drop may have let the backstop hide a still-live turn; repair the
         // indicator on reconnect so the resumed turn stays visible.
         if (agentWorking && !thinkingEl) showThinking();
+        // #585: this mount has now seen a LIVE bridge, so a later non-connected
+        // status is a genuine drop rather than a fresh client's opening `connecting`.
+        rebootSeenConnected = true;
       }
       // A transient drop mid-turn keeps the turn AUTHORITATIVE — the orchestrator
       // still owns it and the bridge will rebind/resume. Clearing the indicator
@@ -18448,10 +18452,15 @@ function buildPanel() {
         piBackendsReadinessReceived = false;
         // Remember the drop so the next "connected" reconciles pending runs (#370).
         bridgeWasDown = true;
-        // #585: only a real drop→reconnect may refresh the restart-resume retry
-        // budget. Without this, a repeated "ready" on a still-live socket would
-        // reset it forever and turn a bounded retry into an unbounded nudge storm.
-        rebootBridgeDroppedSinceAttempt = true;
+        // #585: only a REAL drop→reconnect may refresh the restart-resume retry
+        // budget — a transition out of connected, not merely "not connected". A
+        // freshly mounted client emits `connecting` before it has ever connected, so
+        // counting that would let a page RELOAD manufacture a drop and refill the
+        // budget, and repeated reloads would mint unlimited nudges: the storm the
+        // budget bounds, reached through the very event it was meant to survive.
+        if (isRealBridgeDrop({ everConnected: rebootSeenConnected, connected })) {
+          rebootBridgeDroppedSinceAttempt = true;
+        }
         // A new connection re-opens the session question: whatever id we hold was
         // reported by the connection that just died.
         rebootSessionFrameSeen = false;
@@ -19409,6 +19418,9 @@ function buildPanel() {
   // a live socket (backend readiness frames), and resetting on those would let a
   // long-lived connection mint unlimited attempts and storm the agent.
   let rebootBridgeDroppedSinceAttempt = false;
+  // Has THIS mount ever seen a live bridge? Without it, a fresh client's opening
+  // `connecting` reads as a drop and a reload refills the retry budget.
+  let rebootSeenConnected = false;
 
   /** Drop any outstanding attempt — its channel is gone, so it can never be acked. */
   function forgetRebootResumeAttempt() {

--- a/web/js/lib/restart-resume.js
+++ b/web/js/lib/restart-resume.js
@@ -283,6 +283,26 @@ export function rebootResumeRepeatWarning(state = {}) {
 }
 
 /**
+ * Was this a REAL bridge drop — a live connection that went away?
+ *
+ * Only a real drop may refresh the restart-resume retry budget, and "not connected"
+ * is not the same statement. A freshly mounted client emits an initial
+ * `connecting` status before it has ever been connected, so treating every
+ * non-connected status as a drop lets a page RELOAD manufacture one: reload after
+ * the budget is spent, the budget resets, and repeated reloads mint unlimited
+ * nudges — the storm the budget exists to bound, reached through the one event the
+ * persisted budget was supposed to survive.
+ *
+ * A drop is a TRANSITION out of connected, so it requires having been connected.
+ *
+ * @param {{everConnected?:boolean, connected?:boolean}} state
+ * @returns {boolean}
+ */
+export function isRealBridgeDrop({ everConnected, connected } = {}) {
+  return everConnected === true && connected === false;
+}
+
+/**
  * The wait budget as an explicit tri-state.
  *
  * @param {unknown} waitedMs  Elapsed since the reboot was armed, or a non-finite

--- a/web/js/lib/restart-resume.js
+++ b/web/js/lib/restart-resume.js
@@ -87,6 +87,7 @@ export function encodeRebootMarker({
   threadId = null,
   sessionId = null,
   attempts = 0,
+  totalAttempts,
 } = {}) {
   const ids = normalizeRunIds(runs);
   const armed = Number.isFinite(armedRunCount) ? Math.max(0, Math.trunc(armedRunCount)) : ids.length;
@@ -95,12 +96,21 @@ export function encodeRebootMarker({
     at: Number.isFinite(at) ? at : null,
     runs: ids,
     n: Math.max(armed, ids.length),
-    // How many resume attempts have already gone out for this reboot. Persisted so
-    // it survives a reload: a fresh mount cannot know whether an earlier attempt
-    // was actually taken by the orchestrator, and re-sending silently would put a
-    // second identical "continue" in front of the agent. Non-zero ⇒ the resume
-    // says so, turning a possible duplicate into a disclosed one.
+    // TWO different facts, deliberately two fields — conflating them let a bridge
+    // drop erase the duplicate evidence while refreshing the budget.
+    //
+    // `t` — attempts in the CURRENT delivery episode. This is the retry BUDGET, and
+    // an observed drop legitimately refreshes it (a new connection is a new chance).
     t: Number.isFinite(attempts) ? Math.max(0, Math.trunc(attempts)) : 0,
+    // `ts` — attempts EVER made for this reboot. Monotonic: nothing but retiring the
+    // reboot resets it. This is the cross-mount evidence for "the agent may already
+    // have received a nudge", and it must survive every episode boundary, because a
+    // resume that reached the orchestrator and lost only its receipt is exactly the
+    // case a later undisclosed retry would duplicate.
+    ts: Math.max(
+      Number.isFinite(totalAttempts) ? Math.max(0, Math.trunc(totalAttempts)) : 0,
+      Number.isFinite(attempts) ? Math.max(0, Math.trunc(attempts)) : 0,
+    ),
     // WHICH CONVERSATION asked for this restart. The wait set (`runs`) is global
     // because a reboot is global, but the resume is a message into ONE agent
     // session — delivering it to whatever conversation happens to be on screen
@@ -127,7 +137,15 @@ export function decodeRebootMarker(raw) {
   if (typeof raw !== "string") return null;
   const text = raw.trim();
   if (!text) return null;
-  const empty = { at: null, runs: [], armedRunCount: 0, threadId: null, sessionId: null, attempts: 0 };
+  const empty = {
+    at: null,
+    runs: [],
+    armedRunCount: 0,
+    threadId: null,
+    sessionId: null,
+    attempts: 0,
+    totalAttempts: 0,
+  };
   if (text[0] !== "{") return empty; // legacy "1"
   let parsed = null;
   try {
@@ -155,6 +173,11 @@ export function decodeRebootMarker(raw) {
     threadId: typeof parsed.tid === "string" && parsed.tid ? parsed.tid : null,
     sessionId: typeof parsed.sid === "string" && parsed.sid ? parsed.sid : null,
     attempts: Number.isFinite(parsed.t) ? Math.max(0, Math.trunc(parsed.t)) : 0,
+    totalAttempts: Number.isFinite(parsed.ts)
+      ? Math.max(0, Math.trunc(parsed.ts))
+      : Number.isFinite(parsed.t)
+        ? Math.max(0, Math.trunc(parsed.t))
+        : 0,
   };
 }
 
@@ -226,18 +249,21 @@ export function planRebootResume(state = {}) {
  * one redundant sentence; a warning wrongly absent is an undisclosed duplicate
  * "continue", which is the hazard this whole fix exists to prevent.
  *
- * @param {{attempts?:unknown, attemptRecorded?:boolean, sentThisMount?:number}} state
+ * @param {{totalAttempts?:unknown, attemptRecorded?:boolean, sentThisMount?:number}} state
  * @returns {boolean}
  */
 export function rebootResumeRepeatWarning(state = {}) {
   // NO parameter defaults here on purpose. A default would substitute a definite
   // value ("0 attempts", "recorded fine") for an absent one — which is the very
   // mistake this helper exists to prevent. Absent means unknown, and unknown warns.
-  const { attempts, attemptRecorded, sentThisMount } = state;
+  const { totalAttempts, attemptRecorded, sentThisMount } = state;
   if (attemptRecorded !== true) return true; // not recorded, or not known to be
   if (Number.isFinite(sentThisMount) && Number(sentThisMount) > 0) return true; // storage-independent
-  if (!Number.isFinite(attempts)) return true; // uncountable / absent ⇒ assume
-  return Number(attempts) > 0;
+  // The MONOTONIC total, never the per-episode budget: a bridge drop refreshes the
+  // budget, and reading the budget here would let a drop erase the evidence that an
+  // earlier attempt may already be sitting in the agent's queue.
+  if (!Number.isFinite(totalAttempts)) return true; // uncountable / absent ⇒ assume
+  return Number(totalAttempts) > 0;
 }
 
 /**
@@ -337,6 +363,7 @@ function markerFields(marker) {
     threadId: marker.threadId,
     sessionId: marker.sessionId,
     attempts: marker.attempts,
+    totalAttempts: marker.totalAttempts,
   };
 }
 

--- a/web/js/lib/restart-resume.js
+++ b/web/js/lib/restart-resume.js
@@ -28,6 +28,10 @@
 //     runs still owed a completion frame at the moment the reboot was armed. The
 //     marker is retained while waiting and cleared only when the resume is
 //     actually sent.
+//     ARM-TIME is the correct set, not an approximation of a per-workflow one — a
+//     reboot restarts ComfyUI globally, so every render in flight at that instant
+//     is exposed to the same nudge. See the comment at the arm site in
+//     comfyui-mcp-panel.js (`cmd === "comfy_reboot"`) before narrowing this.
 //
 //  3. It completes ASYNCHRONOUSLY. "The tracker retired the run" is not "the agent
 //     was told" — the run tracker retires a run optimistically, before the caller's

--- a/web/js/lib/restart-resume.js
+++ b/web/js/lib/restart-resume.js
@@ -200,17 +200,58 @@ export function planRebootResume(state = {}) {
   if (!state.rebootPending) return "none";
   const unsettled = normalizeRunIds(state.unsettledRuns);
   if (!unsettled.length) return "resume";
-  const maxWaitMs = Number.isFinite(state.maxWaitMs) ? state.maxWaitMs : REBOOT_RESUME_MAX_WAIT_MS;
-  // "How long have we been waiting?" can be UNKNOWN — a marker with no usable arm
-  // time. Substituting 0 would be a definite claim that no time has passed, and it
-  // would be re-made on every tick, so the backstop could never advance and the
-  // wait would be unbounded and silent — the mechanism built to prevent an
-  // indefinite wait becoming the thing that guarantees one. Unknown means the wait
-  // cannot be bounded AT ALL, so take the visible, disclosed exit now.
-  if (!Number.isFinite(state.waitedMs)) return "resume_unconfirmed";
-  const waitedMs = Math.max(0, state.waitedMs);
-  if (waitedMs >= maxWaitMs) return "resume_unconfirmed";
+  // "Has the wait budget run out?" has THREE answers, and `unknown` is one of them.
+  // Whichever definite answer you substitute for it, you are wrong in one direction:
+  // 0 elapsed never expires (the wait becomes unbounded and silent), infinite
+  // elapsed always expires (a legitimate resume is discarded). Picking a default IS
+  // the bug — so every consumer takes the tri-state and decides deliberately.
+  const budget = rebootWaitBudget(state.waitedMs, state.maxWaitMs);
+  // Here, unknown means the wait cannot be bounded at all, so take the visible,
+  // DISCLOSED exit rather than hold the session indefinitely.
+  if (budget === "unknown" || budget === "spent") return "resume_unconfirmed";
   return "wait_for_run";
+}
+
+/**
+ * Should this resume warn the agent that it may ALREADY have received one?
+ *
+ * The attempt count is persisted so it survives a reload, but persisting it can
+ * fail silently (quota, private mode, eviction) — and `ssSet` returning is not
+ * evidence that it stuck. An increment that didn't persist reads back as "no
+ * attempt yet", so the next try would go out as a first attempt with no warning:
+ * the same shape as trusting a send to mean receipt, one layer down. Written is
+ * not persisted.
+ *
+ * So an unrecorded or uncountable attempt WARNS. A warning wrongly present costs
+ * one redundant sentence; a warning wrongly absent is an undisclosed duplicate
+ * "continue", which is the hazard this whole fix exists to prevent.
+ *
+ * @param {{attempts?:unknown, attemptRecorded?:boolean, sentThisMount?:number}} state
+ * @returns {boolean}
+ */
+export function rebootResumeRepeatWarning(state = {}) {
+  // NO parameter defaults here on purpose. A default would substitute a definite
+  // value ("0 attempts", "recorded fine") for an absent one — which is the very
+  // mistake this helper exists to prevent. Absent means unknown, and unknown warns.
+  const { attempts, attemptRecorded, sentThisMount } = state;
+  if (attemptRecorded !== true) return true; // not recorded, or not known to be
+  if (Number.isFinite(sentThisMount) && Number(sentThisMount) > 0) return true; // storage-independent
+  if (!Number.isFinite(attempts)) return true; // uncountable / absent ⇒ assume
+  return Number(attempts) > 0;
+}
+
+/**
+ * The wait budget as an explicit tri-state.
+ *
+ * @param {unknown} waitedMs  Elapsed since the reboot was armed, or a non-finite
+ *   value when the marker carries no usable arm time.
+ * @param {unknown} maxWaitMs
+ * @returns {"within"|"spent"|"unknown"}
+ */
+export function rebootWaitBudget(waitedMs, maxWaitMs) {
+  if (!Number.isFinite(waitedMs)) return "unknown";
+  const cap = Number.isFinite(maxWaitMs) ? maxWaitMs : REBOOT_RESUME_MAX_WAIT_MS;
+  return Math.max(0, /** @type {number} */ (waitedMs)) >= cap ? "spent" : "within";
 }
 
 /**
@@ -359,7 +400,7 @@ export function stepRebootResume({
   // Elapsed since the reboot was ARMED, read from the persisted marker so a reload
   // cannot reset the backstop. `null` = unknown, and stays unknown.
   const waitedMs = marker.at == null ? null : Math.max(0, nowMs - marker.at);
-  const outOfTime = waitedMs == null || waitedMs >= maxWaitMs;
+  const budget = rebootWaitBudget(waitedMs, maxWaitMs);
   const retain = () => encodeRebootMarker({ ...markerFields(marker) });
 
   // DELIVERY TARGET. The wait set above is global on purpose — a reboot restarts
@@ -371,7 +412,12 @@ export function stepRebootResume({
   // switching back delivers it. A marker with no recorded thread (legacy/degraded)
   // carries no constraint and delivers to the current session as before.
   if (marker.threadId != null && String(currentThreadId ?? "") !== marker.threadId) {
-    const decision = outOfTime ? "expired_wrong_session" : "wait_for_session";
+    // Only a budget we know to be SPENT may abandon the resume. `unknown` must
+    // hold: expiring on it deletes a legitimate resume that switching back to the
+    // arming conversation would have delivered — silently, which is the worse
+    // failure. Holding is not silent here, because the hold prints a notice naming
+    // the conversation the resume belongs to, so the user can act on it.
+    const decision = budget === "spent" ? "expired_wrong_session" : "wait_for_session";
     return {
       decision,
       marker: { ...markerFields(marker), runs: marker.runs },

--- a/web/js/lib/restart-resume.js
+++ b/web/js/lib/restart-resume.js
@@ -1,0 +1,15 @@
+// Decide whether a completed ComfyUI reboot should immediately wake the resumed
+// agent turn. A graph_run prompt recorded before the reboot is authoritative
+// evidence that work is still in flight: its completion/reconciliation event is
+// the only safe continuation signal. Sending a generic "continue" nudge first
+// makes the agent reasonably assume the render was aborted and queue it again
+// (#585).
+
+/**
+ * @param {{ rebootPending?: boolean, hasPendingRun?: boolean }} state
+ * @returns {"none"|"wait_for_run"|"resume"}
+ */
+export function planRebootResume(state = {}) {
+  if (!state.rebootPending) return "none";
+  return state.hasPendingRun ? "wait_for_run" : "resume";
+}

--- a/web/js/lib/restart-resume.js
+++ b/web/js/lib/restart-resume.js
@@ -80,7 +80,14 @@ function normalizeRunIds(runs) {
  *   after `runs` drains so the resume can say truthfully whether it waited for one.
  * @returns {string}
  */
-export function encodeRebootMarker({ at = null, runs = [], armedRunCount } = {}) {
+export function encodeRebootMarker({
+  at = null,
+  runs = [],
+  armedRunCount,
+  threadId = null,
+  sessionId = null,
+  attempts = 0,
+} = {}) {
   const ids = normalizeRunIds(runs);
   const armed = Number.isFinite(armedRunCount) ? Math.max(0, Math.trunc(armedRunCount)) : ids.length;
   return JSON.stringify({
@@ -88,6 +95,19 @@ export function encodeRebootMarker({ at = null, runs = [], armedRunCount } = {})
     at: Number.isFinite(at) ? at : null,
     runs: ids,
     n: Math.max(armed, ids.length),
+    // How many resume attempts have already gone out for this reboot. Persisted so
+    // it survives a reload: a fresh mount cannot know whether an earlier attempt
+    // was actually taken by the orchestrator, and re-sending silently would put a
+    // second identical "continue" in front of the agent. Non-zero ⇒ the resume
+    // says so, turning a possible duplicate into a disclosed one.
+    t: Number.isFinite(attempts) ? Math.max(0, Math.trunc(attempts)) : 0,
+    // WHICH CONVERSATION asked for this restart. The wait set (`runs`) is global
+    // because a reboot is global, but the resume is a message into ONE agent
+    // session — delivering it to whatever conversation happens to be on screen
+    // when the ready ack lands would nudge a workflow that never asked for a
+    // restart while stranding the one that did.
+    tid: threadId == null ? null : String(threadId),
+    sid: sessionId == null ? null : String(sessionId),
   });
 }
 
@@ -107,7 +127,7 @@ export function decodeRebootMarker(raw) {
   if (typeof raw !== "string") return null;
   const text = raw.trim();
   if (!text) return null;
-  const empty = { at: null, runs: [], armedRunCount: 0 };
+  const empty = { at: null, runs: [], armedRunCount: 0, threadId: null, sessionId: null, attempts: 0 };
   if (text[0] !== "{") return empty; // legacy "1"
   let parsed = null;
   try {
@@ -116,12 +136,25 @@ export function decodeRebootMarker(raw) {
     return empty;
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return empty;
+  // VERSION-GATE. A marker whose shape we don't understand — a future version, or
+  // a partial write that happens to still be valid JSON — must not be interpreted
+  // field by field. Its `runs` would be trusted while its `at` was absent, and an
+  // absent arm time is what makes the wait unbounded. Treat an unrecognized
+  // version exactly like the legacy marker: a reboot is pending, nothing is known
+  // to be in flight, resume immediately.
+  if (parsed.v !== REBOOT_MARKER_VERSION) return empty;
   const runs = normalizeRunIds(parsed.runs);
   const armed = Number.isFinite(parsed.n) ? Math.max(0, Math.trunc(parsed.n)) : runs.length;
   return {
+    // `null` means UNKNOWN, and stays null — it is never defaulted to a number.
+    // Reading an unknown arm time as 0 would be a definite claim that no time has
+    // passed, re-made on every tick, so the backstop would never advance.
     at: Number.isFinite(parsed.at) ? parsed.at : null,
     runs,
     armedRunCount: Math.max(armed, runs.length),
+    threadId: typeof parsed.tid === "string" && parsed.tid ? parsed.tid : null,
+    sessionId: typeof parsed.sid === "string" && parsed.sid ? parsed.sid : null,
+    attempts: Number.isFinite(parsed.t) ? Math.max(0, Math.trunc(parsed.t)) : 0,
   };
 }
 
@@ -168,7 +201,14 @@ export function planRebootResume(state = {}) {
   const unsettled = normalizeRunIds(state.unsettledRuns);
   if (!unsettled.length) return "resume";
   const maxWaitMs = Number.isFinite(state.maxWaitMs) ? state.maxWaitMs : REBOOT_RESUME_MAX_WAIT_MS;
-  const waitedMs = Number.isFinite(state.waitedMs) ? Math.max(0, state.waitedMs) : 0;
+  // "How long have we been waiting?" can be UNKNOWN — a marker with no usable arm
+  // time. Substituting 0 would be a definite claim that no time has passed, and it
+  // would be re-made on every tick, so the backstop could never advance and the
+  // wait would be unbounded and silent — the mechanism built to prevent an
+  // indefinite wait becoming the thing that guarantees one. Unknown means the wait
+  // cannot be bounded AT ALL, so take the visible, disclosed exit now.
+  if (!Number.isFinite(state.waitedMs)) return "resume_unconfirmed";
+  const waitedMs = Math.max(0, state.waitedMs);
   if (waitedMs >= maxWaitMs) return "resume_unconfirmed";
   return "wait_for_run";
 }
@@ -194,7 +234,12 @@ export function pruneRebootMarkerRaw(raw, isSettled, isDeliveryUnconfirmed) {
   const keep = new Set([...owed, ...pickUnconfirmed(marker.runs, isDeliveryUnconfirmed)]);
   const runs = marker.runs.filter((id) => keep.has(id));
   if (runs.length === marker.runs.length) return typeof raw === "string" ? raw : null;
-  return encodeRebootMarker({ at: marker.at, runs, armedRunCount: marker.armedRunCount });
+  // Re-encode through markerFields, NOT a hand-written subset. Pruning is a
+  // routine, frequently-called operation (every confirmed delivery), so a field
+  // dropped here is dropped almost immediately and permanently — and the field
+  // most easily forgotten is the delivery target, whose absence silently converts
+  // the marker back into "deliver to whoever is on screen".
+  return encodeRebootMarker({ ...markerFields(marker), runs });
 }
 
 /** Ids the caller flags as dispatched-but-never-confirmed. */
@@ -242,36 +287,107 @@ export function adoptRebootRuns(runs, tracker) {
   return adopted;
 }
 
+/** The marker's own fields, so a retained marker round-trips without losing any. */
+function markerFields(marker) {
+  return {
+    at: marker.at,
+    runs: marker.runs,
+    armedRunCount: marker.armedRunCount,
+    threadId: marker.threadId,
+    sessionId: marker.sessionId,
+    attempts: marker.attempts,
+  };
+}
+
 /**
  * One evaluation of the restart-resume state machine: decide, and produce the
  * marker value that must be persisted as a result.
  *
- * The `nextRaw` half is the whole safety property. On `wait_for_run` it is the
- * marker, RETAINED (pruned to the runs still owed) — clearing it there is what
- * loses the resume forever. It is null only when a resume is actually being sent.
+ * The `nextRaw` half is the whole safety property. On either WAIT it is the
+ * marker, RETAINED — clearing it there is what loses the resume forever. It is
+ * null only when the resume is being sent, or deliberately abandoned with a
+ * visible notice.
  *
- * @param {{raw?:unknown, isSettled?:(id:string)=>boolean, nowMs?:number, maxWaitMs?:number}} args
- * @returns {{decision:"none"|"resume"|"wait_for_run"|"resume_unconfirmed",
- *            marker:{at:number|null, runs:string[], armedRunCount:number}|null,
- *            owed:string[], nextRaw:string|null}}
+ * @param {{raw?:unknown, isSettled?:(id:string)=>boolean,
+ *          isDeliveryUnconfirmed?:(id:string)=>boolean, currentThreadId?:string|null,
+ *          nowMs?:number, maxWaitMs?:number}} args
+ * @returns {{decision:"none"|"resume"|"wait_for_run"|"resume_unconfirmed"|"wait_for_session"|"expired_wrong_session",
+ *            marker:object|null, owed:string[], unconfirmed:string[], nextRaw:string|null}}
+ *   `wait_for_session` — the conversation that armed the reboot is not the one on
+ *     screen. Hold; the marker survives so switching back delivers it.
+ *   `expired_wrong_session` — it never came back within the wait budget. Abandon
+ *     the resume with a VISIBLE notice rather than misdeliver it to whoever is on
+ *     screen, and rather than hold it silently forever.
  */
 export function stepRebootResume({
   raw,
   isSettled,
   isDeliveryUnconfirmed,
+  currentThreadId = null,
+  currentSessionId = null,
+  sessionKnown = false,
   nowMs = Date.now(),
   maxWaitMs = REBOOT_RESUME_MAX_WAIT_MS,
 } = {}) {
   const marker = decodeRebootMarker(raw);
-  if (!marker) return { decision: "none", marker: null, owed: [], nextRaw: null };
+  if (!marker) {
+    return { decision: "none", marker: null, owed: [], unconfirmed: [], sessionState: "unknown", nextRaw: null };
+  }
+  // The agent SESSION behind this conversation may have been replaced rather than
+  // resumed (a provider rejected the saved id, a reset, a fresh session hydrated
+  // with a transcript replay). Such a session never asked for this restart and may
+  // have no memory of the work, so "continue what you were doing" can send it
+  // re-reading the graph and re-queueing.
+  //
+  // This is DISCLOSED, never gated on. A session id legitimately CHANGES across a
+  // resume — that is what resuming does — so refusing to deliver on a mismatch
+  // would strand the ordinary restart, which is the worse failure.
+  //
+  // THREE states, not two. The orchestrator reports the post-resume session id in
+  // its own `session` frame, which is NOT ordered against the "ready" ack that
+  // triggers this decision: when ready lands first, the id on hand is still the one
+  // we armed with and a two-state check would confidently answer "same" for a
+  // session that is about to be replaced. That is the benign-default trap again, so
+  // "we have not been told yet" is its own answer and it discloses.
+  const sessionState = !sessionKnown
+    ? "unknown"
+    : marker.sessionId == null || currentSessionId == null
+      ? "unknown"
+      : String(currentSessionId) === marker.sessionId
+        ? "same"
+        : "replaced";
+  // Elapsed since the reboot was ARMED, read from the persisted marker so a reload
+  // cannot reset the backstop. `null` = unknown, and stays unknown.
+  const waitedMs = marker.at == null ? null : Math.max(0, nowMs - marker.at);
+  const outOfTime = waitedMs == null || waitedMs >= maxWaitMs;
+  const retain = () => encodeRebootMarker({ ...markerFields(marker) });
+
+  // DELIVERY TARGET. The wait set above is global on purpose — a reboot restarts
+  // ComfyUI globally, so every in-flight render is exposed — but the resume is a
+  // message into ONE agent session. If the conversation on screen is not the one
+  // that armed the reboot, sending now would nudge a workflow that never asked for
+  // a restart (the duplicate-render hazard, aimed at the wrong target) while the
+  // conversation that did ask gets nothing. Hold instead; the marker survives, so
+  // switching back delivers it. A marker with no recorded thread (legacy/degraded)
+  // carries no constraint and delivers to the current session as before.
+  if (marker.threadId != null && String(currentThreadId ?? "") !== marker.threadId) {
+    const decision = outOfTime ? "expired_wrong_session" : "wait_for_session";
+    return {
+      decision,
+      marker: { ...markerFields(marker), runs: marker.runs },
+      owed: unsettledRebootRuns(marker.runs, isSettled),
+      unconfirmed: pickUnconfirmed(marker.runs, isDeliveryUnconfirmed),
+      sessionState,
+      nextRaw: decision === "wait_for_session" ? retain() : null,
+    };
+  }
+
   const owed = unsettledRebootRuns(marker.runs, isSettled);
   const unconfirmed = pickUnconfirmed(marker.runs, isDeliveryUnconfirmed);
   let decision = planRebootResume({
     rebootPending: true,
     unsettledRuns: owed,
-    // Elapsed since the reboot was ARMED, read from the persisted marker, so a
-    // reload cannot reset the backstop and park the session indefinitely.
-    waitedMs: marker.at == null ? 0 : Math.max(0, nowMs - marker.at),
+    waitedMs,
     maxWaitMs,
   });
   if (unconfirmed.length && decision === "resume") {
@@ -286,11 +402,18 @@ export function stepRebootResume({
   // pruning an unconfirmed id away while still waiting on a different run would
   // erase the only evidence that the eventual resume must disclose.
   const reported = [...new Set([...owed, ...unconfirmed])];
-  const next = { at: marker.at, runs: reported, armedRunCount: marker.armedRunCount };
+  const next = { ...markerFields(marker), runs: reported };
   if (decision === "wait_for_run") {
-    return { decision, marker: next, owed: reported, unconfirmed, nextRaw: encodeRebootMarker(next) };
+    return {
+      decision,
+      marker: next,
+      owed: reported,
+      unconfirmed,
+      sessionState,
+      nextRaw: encodeRebootMarker(next),
+    };
   }
-  return { decision, marker: next, owed: reported, unconfirmed, nextRaw: null };
+  return { decision, marker: next, owed: reported, unconfirmed, sessionState, nextRaw: null };
 }
 
 /**
@@ -308,7 +431,13 @@ export function stepRebootResume({
  */
 export function rebootMarkerAfterSend(step, sent) {
   if (!step || step.decision === "none") return null;
-  if (step.decision === "wait_for_run") return step.nextRaw;
+  if (step.decision === "wait_for_run" || step.decision === "wait_for_session") return step.nextRaw;
+  if (step.decision === "expired_wrong_session") return null; // abandoned, with a notice
+  // `sent` must mean the ORCHESTRATOR TOOK IT (a receipt ack), not that the socket
+  // accepted the bytes. A WebSocket send resolves true the instant it is handed to
+  // the transport; the socket can close before the frame is ever read, and there is
+  // no way for an abandoned channel to testify that it wasn't. Retiring on that
+  // would strand the resume permanently, so an unacknowledged send RETAINS.
   if (sent) return null;
   return step.marker ? encodeRebootMarker(step.marker) : null;
 }

--- a/web/js/lib/restart-resume.js
+++ b/web/js/lib/restart-resume.js
@@ -91,26 +91,32 @@ export function encodeRebootMarker({
 } = {}) {
   const ids = normalizeRunIds(runs);
   const armed = Number.isFinite(armedRunCount) ? Math.max(0, Math.trunc(armedRunCount)) : ids.length;
-  return JSON.stringify({
+  // TWO different facts, deliberately two fields — conflating them let a bridge drop
+  // erase the duplicate evidence while refreshing the budget.
+  //
+  // `t`  — attempts in the CURRENT delivery episode: the retry BUDGET, which an
+  //        observed drop legitimately refreshes (a new connection is a new chance).
+  // `ts` — attempts EVER made for this reboot: monotonic, and the cross-mount
+  //        evidence for "the agent may already have received a nudge". A resume that
+  //        reached the orchestrator and lost only its receipt is exactly the case a
+  //        later undisclosed retry would duplicate.
+  //
+  // Either may be UNKNOWN, and unknown is written by OMITTING the field, never by
+  // writing 0. A zero would launder "we have no idea" into "verified none" — and
+  // since a retained marker is re-encoded on every wait tick, that laundering would
+  // happen within seconds of the uncertainty arising.
+  const t = Number.isFinite(attempts) ? Math.max(0, Math.trunc(Number(attempts))) : null;
+  const ts =
+    totalAttempts === undefined
+      ? t // not supplied ⇒ mirrors the episode count (the fresh-arm case)
+      : Number.isFinite(totalAttempts)
+        ? Math.max(0, Math.trunc(Number(totalAttempts)), t ?? 0)
+        : null; // explicitly unknown
+  const out = {
     v: REBOOT_MARKER_VERSION,
     at: Number.isFinite(at) ? at : null,
     runs: ids,
     n: Math.max(armed, ids.length),
-    // TWO different facts, deliberately two fields — conflating them let a bridge
-    // drop erase the duplicate evidence while refreshing the budget.
-    //
-    // `t` — attempts in the CURRENT delivery episode. This is the retry BUDGET, and
-    // an observed drop legitimately refreshes it (a new connection is a new chance).
-    t: Number.isFinite(attempts) ? Math.max(0, Math.trunc(attempts)) : 0,
-    // `ts` — attempts EVER made for this reboot. Monotonic: nothing but retiring the
-    // reboot resets it. This is the cross-mount evidence for "the agent may already
-    // have received a nudge", and it must survive every episode boundary, because a
-    // resume that reached the orchestrator and lost only its receipt is exactly the
-    // case a later undisclosed retry would duplicate.
-    ts: Math.max(
-      Number.isFinite(totalAttempts) ? Math.max(0, Math.trunc(totalAttempts)) : 0,
-      Number.isFinite(attempts) ? Math.max(0, Math.trunc(attempts)) : 0,
-    ),
     // WHICH CONVERSATION asked for this restart. The wait set (`runs`) is global
     // because a reboot is global, but the resume is a message into ONE agent
     // session — delivering it to whatever conversation happens to be on screen
@@ -118,7 +124,10 @@ export function encodeRebootMarker({
     // restart while stranding the one that did.
     tid: threadId == null ? null : String(threadId),
     sid: sessionId == null ? null : String(sessionId),
-  });
+  };
+  if (t != null) out.t = t;
+  if (ts != null) out.ts = ts;
+  return JSON.stringify(out);
 }
 
 /**
@@ -143,8 +152,10 @@ export function decodeRebootMarker(raw) {
     armedRunCount: 0,
     threadId: null,
     sessionId: null,
-    attempts: 0,
-    totalAttempts: 0,
+    // Unknown, not zero: a legacy/corrupt marker carries no attempt history, and
+    // claiming "none were made" would suppress the duplicate warning on a guess.
+    attempts: null,
+    totalAttempts: null,
   };
   if (text[0] !== "{") return empty; // legacy "1"
   let parsed = null;
@@ -172,12 +183,15 @@ export function decodeRebootMarker(raw) {
     armedRunCount: Math.max(armed, runs.length),
     threadId: typeof parsed.tid === "string" && parsed.tid ? parsed.tid : null,
     sessionId: typeof parsed.sid === "string" && parsed.sid ? parsed.sid : null,
-    attempts: Number.isFinite(parsed.t) ? Math.max(0, Math.trunc(parsed.t)) : 0,
+    // `null` = UNKNOWN, never 0. An absent or malformed count is not evidence that
+    // no attempt was made, and coercing it to a verified zero is exactly what lets
+    // an undisclosed duplicate nudge through.
+    attempts: Number.isFinite(parsed.t) ? Math.max(0, Math.trunc(parsed.t)) : null,
     totalAttempts: Number.isFinite(parsed.ts)
       ? Math.max(0, Math.trunc(parsed.ts))
       : Number.isFinite(parsed.t)
-        ? Math.max(0, Math.trunc(parsed.t))
-        : 0,
+        ? Math.max(0, Math.trunc(parsed.t)) // older marker: the episode count is all we have
+        : null,
   };
 }
 

--- a/web/js/lib/restart-resume.js
+++ b/web/js/lib/restart-resume.js
@@ -1,15 +1,310 @@
-// Decide whether a completed ComfyUI reboot should immediately wake the resumed
-// agent turn. A graph_run prompt recorded before the reboot is authoritative
-// evidence that work is still in flight: its completion/reconciliation event is
-// the only safe continuation signal. Sending a generic "continue" nudge first
-// makes the agent reasonably assume the render was aborted and queue it again
-// (#585).
+// Restart-resume decision + the PERSISTENT marker that carries it across a
+// frontend reload.
+//
+// #585: after a ComfyUI restart the panel nudges the agent to "continue what you
+// were doing before the restart". If a render queued BEFORE the restart is still
+// in flight — or has already finished but its completion frame has not yet
+// reached the agent — that generic nudge makes the agent reasonably conclude the
+// render was aborted and queue it again. The reporter saw exactly that: the
+// duplicate landed behind "1 running" render.
+//
+// Suppressing the nudge is only half the problem, and the other half is worse.
+// Three properties of the thing being guarded against decide the shape of this
+// module, because a guard that misses any one of them is not a guard:
+//
+//  1. It SURVIVES A RELOAD. A restart can reload the frontend, which gives the
+//     panel a brand-new, EMPTY run ledger while the reboot marker (sessionStorage)
+//     lives on. A guard that consults only in-memory state sees "nothing pending"
+//     on the new mount and nudges — reproducing the exact bug one reload later.
+//     So the ids being waited on are stored IN the marker.
+//
+//  2. It SPANS WORKFLOWS. A global "is anything pending" count is not a statement
+//     about the render this reboot is waiting on: an unrelated workflow's render
+//     makes it true. Suppressing on that — and, worse, clearing the reboot marker
+//     while doing so — swallows a legitimate resume permanently, with no error.
+//     The user then waits forever for a turn that will never start. That silent
+//     failure is worse than the duplicate render it was trying to prevent, so
+//     every decision here is made about a SPECIFIC, fixed set of prompt ids: the
+//     runs still owed a completion frame at the moment the reboot was armed. The
+//     marker is retained while waiting and cleared only when the resume is
+//     actually sent.
+//
+//  3. It completes ASYNCHRONOUSLY. "The tracker retired the run" is not "the agent
+//     was told" — the run tracker retires a run optimistically, before the caller's
+//     async compose+send resolves. The caller therefore passes an `isSettled`
+//     predicate that is true only once no frame is still owed (see
+//     run-completion.js `isSettled`), never a pre-delivery signal.
+//
+// Because both failure directions are real harm, the tie-break is explicit: when
+// the runs cannot be confirmed settled within a bounded wait we RESUME rather than
+// keep waiting, and the resume discloses the uncertainty and tells the agent to
+// check the queue before re-queueing. A duplicate render is visible and
+// cancellable; a swallowed resume is silent.
+
+/** Marker schema version — bump only on an incompatible shape change. */
+export const REBOOT_MARKER_VERSION = 1;
 
 /**
- * @param {{ rebootPending?: boolean, hasPendingRun?: boolean }} state
- * @returns {"none"|"wait_for_run"|"resume"}
+ * Absolute backstop on suppression. A render legitimately in flight is normally
+ * resolved long before this by its own completion / the `/history` reconcile, so
+ * this only fires when the outcome genuinely cannot be determined — and then it
+ * resumes with a disclosure rather than stranding the user in silence.
+ */
+export const REBOOT_RESUME_MAX_WAIT_MS = 15 * 60 * 1000;
+
+/** Normalize a run-id list to unique, non-empty strings (ids are strings everywhere). */
+function normalizeRunIds(runs) {
+  const out = [];
+  const seen = new Set();
+  for (const raw of Array.isArray(runs) ? runs : []) {
+    if (raw == null) continue;
+    const id = String(raw);
+    if (!id || id === "null" || id === "undefined") continue;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}
+
+/**
+ * Serialize the reboot marker for sessionStorage.
+ *
+ * @param {{at?:number|null, runs?:Array<string|number>, armedRunCount?:number}} state
+ *   `runs` — the ids still owed a completion frame (pruned as they settle).
+ *   `armedRunCount` — how many runs were in flight when the reboot was ARMED; kept
+ *   after `runs` drains so the resume can say truthfully whether it waited for one.
+ * @returns {string}
+ */
+export function encodeRebootMarker({ at = null, runs = [], armedRunCount } = {}) {
+  const ids = normalizeRunIds(runs);
+  const armed = Number.isFinite(armedRunCount) ? Math.max(0, Math.trunc(armedRunCount)) : ids.length;
+  return JSON.stringify({
+    v: REBOOT_MARKER_VERSION,
+    at: Number.isFinite(at) ? at : null,
+    runs: ids,
+    n: Math.max(armed, ids.length),
+  });
+}
+
+/**
+ * Parse a reboot marker. Returns null only when NO marker is present.
+ *
+ * A legacy `"1"` marker (armed by a build that recorded no ids) and a corrupt
+ * marker both decode to a marker with an EMPTY run list — i.e. "a reboot is
+ * pending, but nothing is known to be in flight". That deliberately degrades to
+ * the pre-#585 behavior (resume immediately) rather than to an indefinite wait:
+ * an unknown marker must never be able to strand the session silently.
+ *
+ * @param {unknown} raw
+ * @returns {{at:number|null, runs:string[], armedRunCount:number}|null}
+ */
+export function decodeRebootMarker(raw) {
+  if (typeof raw !== "string") return null;
+  const text = raw.trim();
+  if (!text) return null;
+  const empty = { at: null, runs: [], armedRunCount: 0 };
+  if (text[0] !== "{") return empty; // legacy "1"
+  let parsed = null;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return empty;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return empty;
+  const runs = normalizeRunIds(parsed.runs);
+  const armed = Number.isFinite(parsed.n) ? Math.max(0, Math.trunc(parsed.n)) : runs.length;
+  return {
+    at: Number.isFinite(parsed.at) ? parsed.at : null,
+    runs,
+    armedRunCount: Math.max(armed, runs.length),
+  };
+}
+
+/**
+ * Which of `runs` are still owed a completion frame.
+ *
+ * `isSettled` must answer "no completion frame for this prompt is still owed to
+ * the agent" — NOT "the tracker retired it" (that fires before delivery). A
+ * missing or throwing predicate means we cannot determine the state, and an
+ * undetermined run is reported as UNSETTLED so the bounded-wait path (which
+ * discloses) owns the outcome instead of an unguarded nudge.
+ *
+ * @param {string[]} runs
+ * @param {(id:string)=>boolean} [isSettled]
+ * @returns {string[]}
+ */
+export function unsettledRebootRuns(runs, isSettled) {
+  const ids = normalizeRunIds(runs);
+  if (!ids.length) return [];
+  if (typeof isSettled !== "function") return ids;
+  return ids.filter((id) => {
+    try {
+      return !isSettled(id);
+    } catch {
+      return true;
+    }
+  });
+}
+
+/**
+ * Decide what the post-restart "ready" ack should do.
+ *
+ * @param {{rebootPending?:boolean, unsettledRuns?:string[], waitedMs?:number, maxWaitMs?:number}} state
+ * @returns {"none"|"resume"|"wait_for_run"|"resume_unconfirmed"}
+ *   `none` — no reboot marker; this ack is not ours.
+ *   `resume` — nothing is owed; send the resume nudge and clear the marker.
+ *   `wait_for_run` — a SPECIFIC pre-restart run is still owed a completion frame;
+ *     stay quiet and KEEP the marker so the resume is reissued when it settles.
+ *   `resume_unconfirmed` — the wait budget is spent without a verdict; resume, but
+ *     disclose that a render may still be running so the agent checks first.
  */
 export function planRebootResume(state = {}) {
   if (!state.rebootPending) return "none";
-  return state.hasPendingRun ? "wait_for_run" : "resume";
+  const unsettled = normalizeRunIds(state.unsettledRuns);
+  if (!unsettled.length) return "resume";
+  const maxWaitMs = Number.isFinite(state.maxWaitMs) ? state.maxWaitMs : REBOOT_RESUME_MAX_WAIT_MS;
+  const waitedMs = Number.isFinite(state.waitedMs) ? Math.max(0, state.waitedMs) : 0;
+  if (waitedMs >= maxWaitMs) return "resume_unconfirmed";
+  return "wait_for_run";
+}
+
+/**
+ * Rewrite a stored marker with the settled runs removed, leaving everything else
+ * intact. Keeping the persisted list accurate is what stops a later reload from
+ * re-adopting an already-delivered run and having `/history` deliver its
+ * completion a second time. Returns `raw` unchanged when nothing moved.
+ *
+ * @param {unknown} raw
+ * @param {(id:string)=>boolean} [isSettled]
+ * @returns {string|null}
+ */
+export function pruneRebootMarkerRaw(raw, isSettled, isDeliveryUnconfirmed) {
+  const marker = decodeRebootMarker(raw);
+  if (!marker) return typeof raw === "string" ? raw : null;
+  if (!marker.runs.length) return typeof raw === "string" ? raw : null;
+  const owed = unsettledRebootRuns(marker.runs, isSettled);
+  // A run whose delivery was never CONFIRMED is settled (it must not block) but is
+  // deliberately NOT pruned away: dropping it here would erase the only evidence
+  // that the resume has to disclose rather than assert "your result was delivered".
+  const keep = new Set([...owed, ...pickUnconfirmed(marker.runs, isDeliveryUnconfirmed)]);
+  const runs = marker.runs.filter((id) => keep.has(id));
+  if (runs.length === marker.runs.length) return typeof raw === "string" ? raw : null;
+  return encodeRebootMarker({ at: marker.at, runs, armedRunCount: marker.armedRunCount });
+}
+
+/** Ids the caller flags as dispatched-but-never-confirmed. */
+function pickUnconfirmed(runs, isDeliveryUnconfirmed) {
+  if (typeof isDeliveryUnconfirmed !== "function") return [];
+  return normalizeRunIds(runs).filter((id) => {
+    try {
+      return !!isDeliveryUnconfirmed(id);
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
+ * Re-adopt persisted run ids into a run-completion tracker.
+ *
+ * A ComfyUI restart can reload the frontend, which gives the panel a brand-new,
+ * EMPTY completion ledger. The tracker answers "settled" for any id it has never
+ * heard of — correctly, since it owes no frame for it — so a marker read on the
+ * new mount would decide "nothing is in flight" for a render that is still
+ * executing, and nudge the agent into re-queueing it. Adoption is what closes
+ * that: re-pending the ids hands the question to the `/history` + `/queue`
+ * reconcile, which is the only thing that actually knows. Ids this tracker
+ * already knows (pending, mid-delivery, or terminal) are skipped so a run it has
+ * already resolved is never resurrected.
+ *
+ * @param {string[]} runs
+ * @param {{isKnown?:(id:string)=>boolean, onQueued?:(id:string)=>void}} tracker
+ * @returns {string[]} the ids newly adopted (empty ⇒ nothing to reconcile)
+ */
+export function adoptRebootRuns(runs, tracker) {
+  const adopted = [];
+  const ids = normalizeRunIds(runs);
+  if (!ids.length || !tracker || typeof tracker.onQueued !== "function") return adopted;
+  for (const id of ids) {
+    try {
+      if (typeof tracker.isKnown === "function" && tracker.isKnown(id)) continue;
+      tracker.onQueued(id);
+      adopted.push(id);
+    } catch {
+      /* a malformed id must never wedge the resume flow */
+    }
+  }
+  return adopted;
+}
+
+/**
+ * One evaluation of the restart-resume state machine: decide, and produce the
+ * marker value that must be persisted as a result.
+ *
+ * The `nextRaw` half is the whole safety property. On `wait_for_run` it is the
+ * marker, RETAINED (pruned to the runs still owed) — clearing it there is what
+ * loses the resume forever. It is null only when a resume is actually being sent.
+ *
+ * @param {{raw?:unknown, isSettled?:(id:string)=>boolean, nowMs?:number, maxWaitMs?:number}} args
+ * @returns {{decision:"none"|"resume"|"wait_for_run"|"resume_unconfirmed",
+ *            marker:{at:number|null, runs:string[], armedRunCount:number}|null,
+ *            owed:string[], nextRaw:string|null}}
+ */
+export function stepRebootResume({
+  raw,
+  isSettled,
+  isDeliveryUnconfirmed,
+  nowMs = Date.now(),
+  maxWaitMs = REBOOT_RESUME_MAX_WAIT_MS,
+} = {}) {
+  const marker = decodeRebootMarker(raw);
+  if (!marker) return { decision: "none", marker: null, owed: [], nextRaw: null };
+  const owed = unsettledRebootRuns(marker.runs, isSettled);
+  const unconfirmed = pickUnconfirmed(marker.runs, isDeliveryUnconfirmed);
+  let decision = planRebootResume({
+    rebootPending: true,
+    unsettledRuns: owed,
+    // Elapsed since the reboot was ARMED, read from the persisted marker, so a
+    // reload cannot reset the backstop and park the session indefinitely.
+    waitedMs: marker.at == null ? 0 : Math.max(0, nowMs - marker.at),
+    maxWaitMs,
+  });
+  if (unconfirmed.length && decision === "resume") {
+    // Nothing is BLOCKING any more, but a watched run's completion frame was never
+    // confirmed to have reached the agent. Resuming with the plain "your result was
+    // already delivered" wording would be a false reassurance that invites exactly
+    // the duplicate render this exists to prevent — so downgrade to the disclosing
+    // resume, which tells the agent to check the queue first.
+    decision = "resume_unconfirmed";
+  }
+  // Carry BOTH the still-owed and the never-confirmed ids in the persisted marker:
+  // pruning an unconfirmed id away while still waiting on a different run would
+  // erase the only evidence that the eventual resume must disclose.
+  const reported = [...new Set([...owed, ...unconfirmed])];
+  const next = { at: marker.at, runs: reported, armedRunCount: marker.armedRunCount };
+  if (decision === "wait_for_run") {
+    return { decision, marker: next, owed: reported, unconfirmed, nextRaw: encodeRebootMarker(next) };
+  }
+  return { decision, marker: next, owed: reported, unconfirmed, nextRaw: null };
+}
+
+/**
+ * The marker value to persist after ATTEMPTING to send the resume.
+ *
+ * The transport can refuse (a closed socket returns false), and a resume that was
+ * never actually sent must not retire its marker — that is the same silent strand
+ * as clearing it while suppressing, just reached through a race instead of a
+ * branch. So the marker is retired ONLY on a confirmed send; a refused send keeps
+ * it so the watch (or the next ready ack) reissues the resume.
+ *
+ * @param {{decision:string, marker:{at:number|null,runs:string[],armedRunCount:number}|null, nextRaw:string|null}} step
+ * @param {boolean} sent
+ * @returns {string|null}
+ */
+export function rebootMarkerAfterSend(step, sent) {
+  if (!step || step.decision === "none") return null;
+  if (step.decision === "wait_for_run") return step.nextRaw;
+  if (sent) return null;
+  return step.marker ? encodeRebootMarker(step.marker) : null;
 }

--- a/web/js/lib/restart-resume.js
+++ b/web/js/lib/restart-resume.js
@@ -247,6 +247,8 @@ export function planRebootResume(state = {}) {
   // DISCLOSED exit rather than hold the session indefinitely.
   if (budget === "unknown" || budget === "spent") return "resume_unconfirmed";
   return "wait_for_run";
+  // NB: `waitedMs` is intentionally not normalized before the helper — clamping a
+  // negative elapsed here would hide the unusable-clock case from it.
 }
 
 /**
@@ -290,8 +292,15 @@ export function rebootResumeRepeatWarning(state = {}) {
  */
 export function rebootWaitBudget(waitedMs, maxWaitMs) {
   if (!Number.isFinite(waitedMs)) return "unknown";
+  // NEGATIVE elapsed means the clock moved backwards (NTP correction, a suspended
+  // laptop, a user changing the system time) — so the arm time and "now" are not on
+  // the same timeline and the difference measures nothing. Clamping it to 0 would
+  // launder that into "no time has passed yet", and the backstop would then wait for
+  // the wall clock to catch up before it could ever fire: an unbounded, silent hold.
+  // An unusable measurement is an unknown one.
+  if (Number(waitedMs) < 0) return "unknown";
   const cap = Number.isFinite(maxWaitMs) ? maxWaitMs : REBOOT_RESUME_MAX_WAIT_MS;
-  return Math.max(0, /** @type {number} */ (waitedMs)) >= cap ? "spent" : "within";
+  return Number(waitedMs) >= cap ? "spent" : "within";
 }
 
 /**
@@ -440,7 +449,9 @@ export function stepRebootResume({
         : "replaced";
   // Elapsed since the reboot was ARMED, read from the persisted marker so a reload
   // cannot reset the backstop. `null` = unknown, and stays unknown.
-  const waitedMs = marker.at == null ? null : Math.max(0, nowMs - marker.at);
+  // Deliberately NOT clamped to 0 — a negative difference is evidence the clock is
+  // not usable here, and rebootWaitBudget must see it to report "unknown".
+  const waitedMs = marker.at == null ? null : nowMs - marker.at;
   const budget = rebootWaitBudget(waitedMs, maxWaitMs);
   const retain = () => encodeRebootMarker({ ...markerFields(marker) });
 

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -173,6 +173,9 @@ export function createRunCompletionTracker({
     // normally; a `delivered` entry is never in `pending`, so it needs no guard.
     pruneFence(terminal, cutoff, (k) => pending.has(k));
     pruneFence(delivered, cutoff);
+    // `unconfirmedDelivery` is deliberately NOT pruned here — see its declaration:
+    // ageing the flag out would turn "we don't know whether the agent was told"
+    // back into a claim that it was. It is size-capped instead.
   }
 
   // Age fences out even when NO further completion arrives (idle): a single
@@ -218,6 +221,74 @@ export function createRunCompletionTracker({
     touchFence(delivered, k);
     pending.delete(k);
     clearReconcileRetry(k); // a delivery (any path) cancels a scheduled /history retry
+    // NB: this deliberately does NOT clear the delivery hold below. It is called
+    // from the tracker's own lifecycle (flush, execution_success, reconcile) where
+    // "delivered" is OPTIMISTIC — only the caller can confirm the frame actually
+    // reached the agent, so only the PUBLIC markDelivered/markUndelivered release
+    // the hold.
+  }
+
+  // ── "Has the agent actually been told?" (#585) ────────────────────────────
+  // `pending` answers "not yet confirmed delivered" ONLY in the reconcile sense:
+  // flush() calls markDelivered OPTIMISTICALLY, *before* the caller's async
+  // compose+send resolves, purely so a racing reconcile can't double-deliver. So
+  // there is a real window in which a run is out of `pending` while no frame has
+  // reached the agent yet — and a restart-resume nudge sent in that window arrives
+  // BEFORE the completion, which is precisely what makes the agent re-queue the
+  // render (#585). Track the dispatched-but-unconfirmed runs separately so
+  // `isSettled()` can answer the delivery question honestly.
+  const awaitingDelivery = new Map(); // key -> self-clear timer
+  // …and the runs whose delivery was never confirmed at all: the caller's
+  // compose/send promise never settled within the watchdog below. Keeping them
+  // pinned as "in flight" forever would suppress a restart-resume for good — the
+  // SILENT failure. But quietly reclassifying them as DELIVERED would be a lie
+  // that reopens the duplicate render (the resume would tell the agent its result
+  // "was already delivered" when no frame ever reached it). So they graduate to an
+  // explicit third state: settled enough not to block, flagged so the caller can
+  // resume with a DISCLOSURE instead of a false reassurance.
+  //
+  // This map is deliberately NOT aged out on the fence TTL. The flag is EVIDENCE
+  // that a consumer uses to choose an honest message, and its consumers hold open
+  // decision windows longer than that TTL (the restart-resume backstop is 15
+  // minutes vs. the 10-minute fence TTL) — expiring it would silently convert
+  // "we don't know whether the agent was told" back into "it was delivered",
+  // which is the false reassurance that invites the duplicate render (codex P1).
+  // It is not size-capped either, for the same reason: evicting the oldest entry
+  // to save bytes would silently restore the false "it was delivered" answer for
+  // exactly the run whose evidence is oldest, i.e. the one most likely to still be
+  // under a consumer's decision window (codex R3-P1). An entry is created ONLY by
+  // an abandoned compose/send promise — a leak orders of magnitude larger than the
+  // ~40-byte record of it — and is removed the moment the caller confirms, denies,
+  // or re-dispatches. So the map's growth is bounded by the same pathology that
+  // would already be the real problem, and trading a correctness property for that
+  // is a bad trade.
+  const unconfirmedDelivery = new Map(); // key -> ts
+  // Bound the in-flight window well past any realistic compose (metadata HEADs +
+  // video storyboard sampling).
+  const deliveryConfirmTimeoutMs = 120000;
+  function clearAwaitingDelivery(k) {
+    const t = awaitingDelivery.get(k);
+    if (t != null) clearTimer(t);
+    awaitingDelivery.delete(k);
+    unconfirmedDelivery.delete(k);
+  }
+  function flagUnconfirmedDelivery(k) {
+    if (k === NO_PROMPT_KEY) return;
+    unconfirmedDelivery.delete(k);
+    unconfirmedDelivery.set(k, now());
+  }
+  /** A completion frame for `k` has been handed to the caller; delivery unconfirmed. */
+  function markDispatched(k) {
+    if (k === NO_PROMPT_KEY) return; // id-less runs are never gated on
+    clearAwaitingDelivery(k);
+    awaitingDelivery.set(
+      k,
+      setTimer(() => {
+        awaitingDelivery.delete(k);
+        // Never confirmed, never re-pended ⇒ we do NOT know the agent was told.
+        flagUnconfirmedDelivery(k);
+      }, deliveryConfirmTimeoutMs),
+    );
   }
 
   function clearReconcileRetry(k) {
@@ -279,6 +350,12 @@ export function createRunCompletionTracker({
     // this flush can't double-deliver the same prompt. If the caller reports the
     // send FAILED (bridge down), it calls markUndelivered() to re-pend it (#370).
     markDelivered(k);
+    // …but that optimism is NOT proof the agent was told: the caller composes and
+    // sends asynchronously. Hold the run as "delivery in flight" until the caller
+    // confirms via markDelivered()/markUndelivered(), so isSettled() can't report
+    // it settled mid-window (#585). Set synchronously, before onFlush, so no
+    // observer can sample the gap.
+    markDispatched(k);
     onFlush({
       key: k,
       promptId: promptIdOf(k),
@@ -394,6 +471,9 @@ export function createRunCompletionTracker({
     const hasBatch = parsed.images.length > 0 || parsed.videos.length > 0;
     if (hasBatch) {
       const durationMs = startTs != null ? now() - startTs : null;
+      // Same async-delivery hold as flush(): the reconciled batch is composed and
+      // sent by the caller, so it is not "delivered" until the caller says so.
+      markDispatched(k);
       onFlush({
         key: k,
         promptId,
@@ -646,6 +726,10 @@ export function createRunCompletionTracker({
      * agent (sendFrame succeeded / batch was empty). Retires it from pending.
      */
     markDelivered(id) {
+      // The CALLER confirming delivery is the only proof the agent was told, so
+      // this — not the tracker's own optimistic retire — is what releases the
+      // delivery hold isSettled() reports on (#585).
+      clearAwaitingDelivery(key(id));
       markDelivered(id);
     },
 
@@ -665,7 +749,79 @@ export function createRunCompletionTracker({
       // cancel any in-flight retry so the re-pend restarts cleanly on the next edge.
       delivered.delete(k);
       clearReconcileRetry(k);
+      // It is back to being OWED, not in-flight — drop the delivery hold so the
+      // 120s backstop can't be what decides isSettled() for it (#585).
+      clearAwaitingDelivery(k);
       if (!pending.has(k)) pending.set(k, { promptId: k, at: now() }); // normalized string id
+    },
+
+    /**
+     * True when NO completion frame is still owed to the agent for `id` — the run
+     * is neither pending recovery NOR mid-delivery. This is the honest answer to
+     * "has the agent been told?", as opposed to `hasPending()`/`_pending`, which
+     * go false the instant flush() optimistically retires a run, before the
+     * caller's async compose+send has resolved. #585 gates the post-restart resume
+     * nudge on this so the nudge can never overtake the completion it is waiting
+     * for. An id the tracker has never heard of is settled (nothing is owed).
+     */
+    isSettled(id) {
+      const k = key(id);
+      return !pending.has(k) && !awaitingDelivery.has(k);
+    },
+
+    /**
+     * True when this run's completion frame was dispatched to the caller and the
+     * caller NEVER confirmed (or denied) delivery within the watchdog window. The
+     * run no longer blocks — isSettled() is true for it, so it can't strand a
+     * restart-resume — but the agent may never have been told, so a caller that
+     * gates on delivery must DISCLOSE the uncertainty rather than assert that the
+     * result was delivered (#585).
+     */
+    isDeliveryUnconfirmed(id) {
+      return unconfirmedDelivery.has(key(id));
+    },
+
+    /**
+     * Caller reports that a run's ONLY agent-facing outcome could not be sent, and
+     * there is nothing left to re-pend — the give-up path, which evicts the run
+     * from the recovery ledger before firing its one-time notice. Without this the
+     * run would read as cleanly settled and a delivery-gated caller would assert
+     * the agent had been told (#585). Flagging it keeps it non-blocking but makes
+     * the uncertainty visible.
+     */
+    markDeliveryUnconfirmed(id) {
+      if (id == null) return;
+      flagUnconfirmedDelivery(key(id));
+    },
+
+    /**
+     * True when this tracker has any record of `id` — pending, mid-delivery, or
+     * already terminal. Lets a caller re-adopt a run id recovered from persistent
+     * state (e.g. the #585 reboot marker after a frontend reload) WITHOUT
+     * resurrecting one this mount has already resolved.
+     */
+    isKnown(id) {
+      const k = key(id);
+      // `unconfirmedDelivery` is included deliberately: the `terminal` replay fence
+      // ages out after its TTL, and without this a still-flagged run could be
+      // re-adopted later in the SAME mount and have its completion dispatched a
+      // second time. A new mount (fresh tracker) knows none of these and re-adopts
+      // it — which is the intended RECOVERY of an unconfirmed frame.
+      return pending.has(k) || awaitingDelivery.has(k) || unconfirmedDelivery.has(k) || terminal.has(k);
+    },
+
+    /**
+     * Every real prompt_id that is still owed a completion frame. Snapshotted when
+     * a reboot is armed so the post-restart resume can be correlated to THOSE runs
+     * specifically, never to a global "is anything pending" count — which an
+     * unrelated workflow's render would make true, swallowing a legitimate resume
+     * (#585).
+     */
+    unsettledPromptIds() {
+      const ids = [];
+      for (const k of pending.keys()) if (k !== NO_PROMPT_KEY) ids.push(k);
+      for (const k of awaitingDelivery.keys()) if (k !== NO_PROMPT_KEY && !pending.has(k)) ids.push(k);
+      return ids;
     },
 
     /**
@@ -737,5 +893,7 @@ export function createRunCompletionTracker({
     _pending: pending,
     _delivered: delivered,
     _terminal: terminal,
+    _awaitingDelivery: awaitingDelivery,
+    _unconfirmedDelivery: unconfirmedDelivery,
   };
 }

--- a/web/js/lib/run-completion.js
+++ b/web/js/lib/run-completion.js
@@ -819,8 +819,21 @@ export function createRunCompletionTracker({
      */
     unsettledPromptIds() {
       const ids = [];
-      for (const k of pending.keys()) if (k !== NO_PROMPT_KEY) ids.push(k);
-      for (const k of awaitingDelivery.keys()) if (k !== NO_PROMPT_KEY && !pending.has(k)) ids.push(k);
+      const seen = new Set();
+      const add = (k) => {
+        if (k === NO_PROMPT_KEY || seen.has(k)) return;
+        seen.add(k);
+        ids.push(k);
+      };
+      for (const k of pending.keys()) add(k);
+      for (const k of awaitingDelivery.keys()) add(k);
+      // Runs whose delivery was never confirmed belong here too. They are "settled"
+      // only in the sense that they no longer BLOCK — we still do not know the agent
+      // was told. Omitting them would leave a reboot armed after the 120s watchdog
+      // with no id to reason about, and the resume would fall back to the plain
+      // "your result was already delivered" wording: the exact false reassurance the
+      // unconfirmed state exists to prevent.
+      for (const k of unconfirmedDelivery.keys()) add(k);
       return ids;
     },
 


### PR DESCRIPTION
Fixes #585.

## The bug

After a ComfyUI restart the panel nudges the agent to "continue what you were doing". The reporter's render was **still in flight** when that notice fired, so the agent reasonably concluded it had been aborted and queued the same branch again — `panel_run` then reported the new prompt queued behind "1 running" render.

## The through-line

Suppression was decided from an **in-memory, global, pre-delivery** signal, while the thing it guards against **survives reloads, spans workflows, and completes asynchronously**. Every fix below is that mismatch on a different axis.

Two failure directions are in play and they pull opposite ways. A duplicate render wastes GPU but is **visible and cancellable**; a swallowed resume leaves the user waiting forever for a turn that will never start, **silently**. Where the code genuinely cannot determine which case it is in, it takes the visible, recoverable outcome and **discloses** it.

## What changed

**Correlation, not aggression.** The reboot marker is now a versioned JSON blob in sessionStorage carrying the prompt ids that were still owed a completion frame when the reboot was armed, plus the arm time, the arming conversation, and the attempt counts. Every decision is about *those* ids — never a global "is anything pending" count, which an unrelated workflow's render would satisfy.

**Reload survival.** A restart can reload the frontend, which hands the panel an empty ledger. Persisted ids are re-adopted into the fresh tracker *before* any decision, handing the question to the existing `/history` + `/queue` reconcile. (A fresh tracker answers "settled" for an id it has never heard of — correctly, it owes nothing — so the marker alone would have reproduced the bug while looking like a fix.)

**The marker is never cleared while suppressing.** It is retired only when a resume is actually sent *and* the orchestrator acknowledges receipt. `sendUserMessage` returning true only means the socket accepted the bytes; a socket that closes before the orchestrator reads them cannot say so.

**Delivery gated on "the agent was told".** The run tracker retires a run optimistically, before the caller's async compose+send resolves. `isSettled()` now answers the delivery question honestly, and a dispatched frame that is never confirmed graduates to an explicit *unconfirmed* state — non-blocking, but flagged, so the resume discloses rather than falsely reassuring.

**Delivery targeted at the arming conversation.** The wait set stays global — a reboot restarts ComfyUI globally, so every in-flight render is exposed; this is the correct set, not an approximation of a per-workflow one (see the comment at the arm site before narrowing it). But the resume is a message into *one* agent session, so a mismatch holds the marker with a visible notice, or past the backstop is abandoned visibly — never misdelivered.

**Unknown stays unknown.** An absent arm time, a negative elapsed (clock rollback), an unrecognized marker version, an absent attempt count — each is its own answer, never substituted with a benign definite one. A 15-minute backstop resumes with an explicit "check the queue for prompt N before re-queueing" instead of holding in silence.

## Known residual — sessionStorage write failures

**A documented, deliberate stopping point, not an oversight.**

The panel's whole resume subsystem is built on best-effort `sessionStorage` (`SESSION_KEY`, `MID_TASK_KEY`, `SOFT_RELOAD_KEY`, `AUTOCONNECT_KEY` all share it). A browser that *accepts reads but refuses writes* — quota exhausted, private mode, eviction — cannot be made reliable by writing more.

**What such a user would experience:** after a frontend reload, they may see one extra restart nudge, and one render result may be reported to the agent twice. Both are visible and recoverable; neither loses work.

**What protects them:** every marker write is verified by read-back, and the attempt record is written **ahead** of the send. A failed record raises the duplicate warning — the agent is explicitly told "you may have already received this restart notice; ignore the duplicate and do NOT re-queue anything" — instead of a silent duplicate. The failures are also surfaced to the user directly: at arm, at clear, and on any failed marker update.

**The precise limit of that guarantee.** It holds for the **life of the mount**, not indefinitely. One timeline escapes it:

> the marker holds a real `0` count → an attempt's count write **fails** but its message **does** reach the orchestrator → storage later **recovers** → the frontend **reloads**.

The new mount resets its in-memory "storage was broken" state, reads a count that is a genuine zero merely gone stale, records its own attempt successfully, and computes *no prior attempt*. The next nudge is therefore an **undisclosed duplicate continuation nudge** — not a duplicate render. The agent is told to continue twice with nothing flagging it; whether that produces a re-queue depends on what it does next, and every other guard in this PR (run correlation, delivery gating, session targeting) still applies to it.

**Why this one is accepted rather than fixed.** Note what it is *not*: it is not the unknown-vs-zero fold fixed elsewhere in this PR, because no value is absent — the stored zero is real, just stale. Closing it would mean **durably recording "a write failed" at exactly the moment storage is refusing to durably record anything.** The only remaining option is to warn on *every* reboot-resume that follows *any* reload, which is the cry-wolf outcome: a warning that fires on the ordinary path trains the agent to ignore it, including in the `replaced`-session case where it genuinely matters. We took the narrow, disclosed duplicate nudge over the broad, self-defeating warning.

**Why we stopped here rather than hardening further:** each additional fix in this class *adds state to a persistence path*, and the thing being defended against is that persistence being unreliable. That is self-defeating, and it bit us once during review — a persistent storage failure was answered with a mount-local flag, which fixed the discovering mount and left the reload broken: a new bug created by adding state to work around missing state. The fix was to stop remembering and re-ask (probe writability on demand). We chose **disclosure over further state**.

Further findings in this class belong in this residual. Findings in the core class — a duplicate render reaching a live job, a swallowed resume, a misdelivered resume, or fabricated reassurance that a result was delivered — are bugs and get fixed.

## Verification

- 1765 unit tests passing; `typecheck` clean; tool-vocabulary gate clean; all three changed modules `node --check` clean **as ESM**; `git diff --check` clean; zero NUL bytes in every changed file.
- **34 mutation runs, all killed** — each fix was broken deliberately and the corresponding test confirmed to fail. Includes both directions of the unknown-elapsed error (0 never expires / infinity always expires), one that re-conflates the retry budget with the duplicate evidence, one that re-coerces an absent count to zero, one that treats any non-connected status as a bridge drop, and one that reintroduces masking parameter defaults.
- Gated independently with codex (`gpt-5.6-terra`, read-only) across nine rounds. The original three P1s plus fourteen further findings were fixed. Two proposed fixes were **declined with reasoning and upheld on re-review** — most notably a strict session-id delivery gate, which would have stranded every ordinary restart, since a session id legitimately changes across a resume.

## Still owed — live verification on the rig

Unit tests fake reload-survival and delivery-ordering most convincingly, so these are flagged rather than claimed:

1. **A real F5 mid-render** — the highest-value check. Tests simulate a reload as "a new tracker instance"; only a live reload proves the marker survives, adoption runs before the ready ack, and reconcile finds the run in `/queue`.
2. **The wait actually ends** — slow render → `comfy_reboot` → the panel holds, stays quiet, and sends the resume *after* the completion frame lands.
3. **The 15-minute backstop** end to end (the decision function is tested; the panel timer path is not).
4. **Message ordering as the agent sees it** — tests assert the decision, not that the completion precedes the nudge on the wire.
5. **Multi-workflow** — B rendering while A reboots; A's resume must not be swallowed, and must arrive once.
6. **Whether `SESSION_KEY` is stable across a real reboot+resume, and whether the `ready` ack precedes the `session` frame.** Together these decide whether the session-state disclosure reads `same` (rare) or `unknown` (routine). The tri-state logic is correct either way; if `unknown` turns out to be routine, the *wording* must not read as a warning, or it trains people to ignore the `replaced` case that actually matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
