### PR TITLE
fix(panel #809): truncated results name their own remedy — and one that works from where the caller is

### DIFF
--- a/browser_tests/unit/graph-read.test.mjs
+++ b/browser_tests/unit/graph-read.test.mjs
@@ -19,6 +19,20 @@ import {
   fitDetailLine,
   isLineProtected,
   truncationTail,
+  // #809
+  clipCompactValue,
+  compactClipNote,
+  OUTLINE_DETAIL_LEVELS,
+  OUTLINE_MAX_CHARS_DEFAULT,
+  OUTLINE_MAX_CHARS_FLOOR,
+  OUTLINE_MAX_CHARS_CEILING,
+  clampOutlineMaxChars,
+  outlineDegradeBanner,
+  outlineFloorRefusal,
+  outlineValueClipNote,
+  clipOutlineTitle,
+  OUTLINE_TITLE_CAP,
+  MAX_CHARS_CEILING,
 } from "../../web/js/lib/graph-read.js";
 
 // ---- #607: link-driven widget detection -----------------------------------
@@ -100,7 +114,7 @@ test("capWidgetValue clips an oversized string and reports the drop (#609)", () 
   const out = capWidgetValue(blob);
   assert.ok(out.length < blob.length, "clipped shorter than original");
   assert.ok(out.startsWith("x".repeat(1000)), "keeps the head");
-  assert.match(out, /…\(\+\d+ chars, truncated\)$/, "reports how much was dropped");
+  assert.match(out, /…\(\+\d+ chars cut at the 2048-char per-widget cap, which `max_chars` does not raise\)$/, "#809: reports how much was dropped AND that max_chars cannot raise this cap");
   assert.ok(JSON.stringify(out).length <= WIDGET_VALUE_CAP, "ESCAPED size within the cap");
 });
 
@@ -109,7 +123,8 @@ test("capWidgetValue bounds by ESCAPED size for control chars / surrogates (#609
   const nuls = String.fromCharCode(0).repeat(5000);
   const out = capWidgetValue(nuls, 600);
   assert.ok(JSON.stringify(out).length <= 600, `escaped size within cap, got ${JSON.stringify(out).length}`);
-  assert.match(out, /truncated\)$/);
+  // #809: the marker names the CAUSE and the lever, not just "truncated".
+  assert.match(out, /chars cut (over the `max_chars` budget|at the \d+-char per-widget cap)/);
 });
 
 test("capWidgetValue clips oversized serialized objects (ResolutionMaster presets)", () => {
@@ -117,7 +132,8 @@ test("capWidgetValue clips oversized serialized objects (ResolutionMaster preset
   const out = capWidgetValue(bigObj);
   assert.equal(typeof out, "string");
   assert.ok(JSON.stringify(out).length <= WIDGET_VALUE_CAP, "escaped size within the cap");
-  assert.match(out, /truncated\)$/);
+  // #809: the marker names the CAUSE and the lever, not just "truncated".
+  assert.match(out, /chars cut (over the `max_chars` budget|at the \d+-char per-widget cap)/);
 });
 
 test("capSummaryWidgets bounds every widget value without mutating the input (#609)", () => {
@@ -145,7 +161,11 @@ test("capSummaryWidgets bounds the TOTAL widgets size, keeping valid JSON (#609)
 test("capSummaryWidgets keeps at least one widget even if it alone exceeds the total cap", () => {
   const capped = capSummaryWidgets({ id: 1, widgets: { blob: "x".repeat(20000), extra: 1 } }, WIDGET_VALUE_CAP, 500);
   assert.ok("blob" in capped.widgets, "the single huge widget still renders (per-value capped)");
-  assert.match(capped.widgets.blob, /truncated\)$/);
+  // #809: these are BUDGET-driven cuts (totalCap < WIDGET_VALUE_CAP), so the marker must
+  // name `max_chars` — the lever that genuinely lifts them.
+  // #809 (codex gate): the raise must state HOW FAR. "raise `max_chars`" with no ceiling
+  // leaves a caller unable to tell whether the retry is even possible.
+  assert.match(capped.widgets.blob, /over the `max_chars` budget; raise `max_chars` \(up to 60000\)\)$/);
 });
 
 test("capSummaryWidgets tightens the per-value cap to a SMALL total budget (#609)", () => {
@@ -153,7 +173,11 @@ test("capSummaryWidgets tightens the per-value cap to a SMALL total budget (#609
   // budget, so the serialized line stays near totalCap, not ~2KB.
   const capped = capSummaryWidgets({ id: 1, widgets: { blob: "q".repeat(5000) } }, WIDGET_VALUE_CAP, 600);
   assert.ok(JSON.stringify(capped).length < 600 * 2, "line bounded near the small budget");
-  assert.match(capped.widgets.blob, /truncated\)$/);
+  // #809: these are BUDGET-driven cuts (totalCap < WIDGET_VALUE_CAP), so the marker must
+  // name `max_chars` — the lever that genuinely lifts them.
+  // #809 (codex gate): the raise must state HOW FAR. "raise `max_chars`" with no ceiling
+  // leaves a caller unable to tell whether the retry is even possible.
+  assert.match(capped.widgets.blob, /over the `max_chars` budget; raise `max_chars` \(up to 60000\)\)$/);
 });
 
 test("capSummaryWidgets stays bounded on ESCAPE-HEAVY content at a small budget (#609)", () => {
@@ -192,7 +216,9 @@ test("clipLine bounds a plain compact line by length, leaving short lines intact
   const huge = "#1 Wide · " + "k=v ".repeat(5000);
   const out = clipLine(huge, 2000);
   assert.ok(out.length <= 2000, `clipped to <= maxChars, got ${out.length}`);
-  assert.ok(out.endsWith("…"), "carries an ellipsis marker");
+  // #809: a bare "…" said only "something was here". The marker now says how much was
+  // cut and which parameter lifts the cut, and STILL fits inside maxChars.
+  assert.match(out, /…\(\+\d+ chars over `max_chars`; raise `max_chars` \(up to 60000\)\)$/);
   assert.equal(clipLine(huge, Infinity), huge, "no cap ⇒ unchanged");
 });
 
@@ -219,12 +245,226 @@ test("isLineProtected protects ONLY the first match (never shown:0), keeping the
 });
 
 test("truncationTail advises raising max_chars when ids were explicit (#609)", () => {
-  const withIds = truncationTail(1, 3, true);
-  assert.match(withIds, /raise max_chars/);
+  const withIds = truncationTail(1, 3, true, "max_chars", { limit: 40, maxChars: 600 });
+  assert.match(withIds, /raise `max_chars`/);
   assert.doesNotMatch(withIds, /narrow with/, "no dead-end 'narrow with ids' advice");
 
-  const noIds = truncationTail(5, 40, false);
-  assert.match(noIds, /narrow with types\/where\/ids\/depth/);
+  const noIds = truncationTail(5, 40, false, "max_chars", { limit: 40, maxChars: 600 });
+  assert.match(noIds, /narrow with `types`\/`where`\/`ids`\/`depth`/);
+});
+
+// #809 — the defect this issue was filed for: the tail used to name ONE remedy for BOTH
+// cuts. `limit` and `max_chars` have opposite fixes, so a tail that names the wrong one
+// costs the caller a retry and then reads to them as proof the tool cannot do the job.
+test("#809 truncationTail names the cap that ACTUALLY fired, and disowns the other", () => {
+  const byChars = truncationTail(5, 690, false, "max_chars", { limit: 200, maxChars: 12000 });
+  assert.match(byChars, /raise `max_chars` up to 60000/, "names the real lever and its real ceiling");
+  assert.doesNotMatch(byChars, /raise `limit`/, "must NOT tell the caller to raise the useless lever");
+  assert.match(byChars, /Raising `limit` will not help/);
+
+  const byLimit = truncationTail(40, 690, false, "limit", { limit: 40, maxChars: 60000 });
+  assert.match(byLimit, /raise `limit` up to 200/);
+  assert.doesNotMatch(byLimit, /raise `max_chars`/);
+  assert.match(byLimit, /`max_chars` is not the constraint here/);
+
+  // Explicit ids get the same split — "request fewer ids" is wrong advice for a limit cut
+  // in exactly the way "raise limit" is wrong advice for a budget cut.
+  const idsByLimit = truncationTail(3, 60, true, "limit", { limit: 3, maxChars: 60000 });
+  assert.match(idsByLimit, /raise `limit` up to 200/);
+  assert.doesNotMatch(idsByLimit, /raise `max_chars`/);
+});
+
+// codex gate: "raise `X` up to N" is ITSELF a dead retry at N. A wasted retry is exactly
+// what teaches an agent the tool cannot do the job, so at the ceiling the remedy must
+// switch to something that can still work.
+test("#809 truncationTail stops offering a raise the caller has already maxed out", () => {
+  const maxedLimit = truncationTail(200, 690, false, "limit", { limit: 200, maxChars: 12000 });
+  assert.match(maxedLimit, /`limit` is already at its ceiling of 200/);
+  assert.doesNotMatch(maxedLimit, /raise `limit` up to/);
+  assert.match(maxedLimit, /narrow with `types`/, "still names what IS left");
+
+  const maxedChars = truncationTail(5, 690, false, "max_chars", { limit: 40, maxChars: 60000 });
+  assert.match(maxedChars, /`max_chars` is already at its ceiling of 60000/);
+  assert.doesNotMatch(maxedChars, /raise `max_chars` up to/);
+
+  // Below the ceiling the raise is still the right first move.
+  const room = truncationTail(40, 690, false, "limit", { limit: 40, maxChars: 12000 });
+  assert.match(room, /raise `limit` up to 200/);
+  assert.doesNotMatch(room, /already at its ceiling/);
+});
+
+// The stronger bar (codex gate): naming a real parameter is necessary and NOT
+// sufficient. A raise with no ceiling leaves the caller unable to tell whether the retry
+// is possible at all; a raise they have already maxed out is a guaranteed wasted round
+// trip. Every marker this module emits is swept for both.
+test("#809 no marker ever says 'raise X' without saying how far", () => {
+  const emitted = [
+    capWidgetValue("z".repeat(20000)),
+    capWidgetValue("z".repeat(20000), 600),
+    capSummaryWidgets({ id: 1, widgets: { blob: "q".repeat(5000) } }, WIDGET_VALUE_CAP, 600).widgets["…"],
+    capSummaryWidgets({ id: 1, widgets: Object.fromEntries(Array.from({ length: 40 }, (_, i) => [`w${i}`, "z".repeat(500)])) }, WIDGET_VALUE_CAP, 3000).widgets["…"],
+    clipLine("#1 Wide · " + "k=v ".repeat(5000), 2000),
+    fitDetailLine("y".repeat(20000), { id: 1, type: "T" }, 800),
+    truncationTail(5, 690, false, "max_chars", { limit: 40, maxChars: 12000 }),
+    truncationTail(40, 690, false, "limit", { limit: 40, maxChars: 12000 }),
+    outlineDegradeBanner({ level: "groups", nodeCount: 690, groupCount: 3, maxChars: 4000 }),
+    outlineFloorRefusal({ nodeCount: 690, groupCount: 3, maxChars: 500, floorChars: 3000 }),
+    outlineValueClipNote(3, 2),
+    compactClipNote(3),
+  ].filter((v) => typeof v === "string");
+
+  assert.ok(emitted.length >= 10, "the sweep must actually cover the markers");
+  for (const text of emitted) {
+    for (const m of text.matchAll(/\braise\s+`([A-Za-z_][A-Za-z0-9_]*)`/gi)) {
+      const name = m[1];
+      const stated = new RegExp(`\`${name}\`[^.]{0,40}?\\(?up to \\d+|\`${name}\` is already at its ceiling`);
+      assert.ok(
+        stated.test(text),
+        `remedy says "raise \`${name}\`" without a ceiling: ${JSON.stringify(text)}`,
+      );
+    }
+  }
+});
+
+test("#809 every marker switches away from a raise the caller has already maxed out", () => {
+  // Same code paths, caller at the ceiling.
+  const atCeiling = [
+    capSummaryWidgets({ id: 1, widgets: { blob: "q".repeat(5000) } }, WIDGET_VALUE_CAP, MAX_CHARS_CEILING).widgets.blob,
+    clipLine("#1 Wide · " + "k=v ".repeat(50000), MAX_CHARS_CEILING),
+    truncationTail(5, 690, false, "max_chars", { limit: 40, maxChars: MAX_CHARS_CEILING }),
+    truncationTail(200, 690, false, "limit", { limit: 200, maxChars: 12000 }),
+  ].filter((v) => typeof v === "string");
+  for (const text of atCeiling) {
+    if (!/already at its ceiling/.test(text)) continue; // marker may not fire at this size
+    assert.doesNotMatch(text, /raise `max_chars` \(up to/, `dead raise alongside the ceiling note: ${text}`);
+  }
+  // And at least one of them must actually have taken the ceiling branch, or this test
+  // is asserting nothing.
+  assert.ok(atCeiling.some((t) => /already at its ceiling/.test(t)), "no ceiling branch exercised");
+});
+
+test("#809 a user-controlled title can never blow the outline budget", () => {
+  const long = "T".repeat(5000);
+  const out = clipOutlineTitle(long);
+  assert.ok(out.text.length <= OUTLINE_TITLE_CAP + 1, `clipped title, got ${out.text.length}`);
+  assert.match(out.text, /…$/);
+  // It REPORTS the clip rather than leaving a bare "…" — the caller counts these and
+  // raises ONE footer, instead of scattering signal-free ellipses through the outline.
+  assert.equal(out.clipped, true);
+  // Short titles pass through untouched — this is a bound, not a reformat.
+  assert.deepEqual(clipOutlineTitle("REPLACEMENT MODE"), { text: "REPLACEMENT MODE", clipped: false });
+  assert.deepEqual(clipOutlineTitle(undefined), { text: "", clipped: false });
+  // Newlines in a title would break the one-line-per-group layout.
+  assert.equal(clipOutlineTitle("a\n\nb").text, "a b");
+});
+
+test("#809 the outline footer covers title clips as well as value clips", () => {
+  assert.equal(outlineValueClipNote(0, 0), "", "silent when nothing was clipped");
+  const titlesOnly = outlineValueClipNote(0, 3);
+  assert.match(titlesOnly, /3 title\(s\) clipped to 120 chars/);
+  assert.doesNotMatch(titlesOnly, /widget value/);
+  const both = outlineValueClipNote(2, 3);
+  assert.match(both, /2 widget value\(s\) clipped to 60 chars and 3 title\(s\) clipped to 120 chars/);
+  assert.match(both, /`max_chars` does not raise/);
+});
+
+test("#809 shown-of-matched is always stated, so 'how much is left' is never guesswork", () => {
+  for (const by of ["limit", "max_chars"]) {
+    for (const ids of [true, false]) {
+      const t = truncationTail(7, 690, ids, by, { limit: 40, maxChars: 12000 });
+      assert.match(t, /truncated at 7 of 690/, `${by}/ids=${ids} must state shown of matched`);
+    }
+  }
+});
+
+test("#809 the compact 60-char clip points at fields:'detail', not at a dead lever", () => {
+  const short = clipCompactValue("hello");
+  assert.equal(short.clipped, false);
+  assert.equal(short.text, "hello");
+
+  const long = clipCompactValue("z".repeat(400));
+  assert.equal(long.clipped, true);
+  assert.ok(long.text.length <= 60);
+
+  const note = compactClipNote(3);
+  assert.match(note, /3 widget value\(s\) clipped to 60 chars/);
+  assert.match(note, /`fields`:"detail"/);
+  // Raising max_chars does NOT lift this clip, so the note must not suggest it.
+  assert.doesNotMatch(note, /raise `max_chars`/);
+  assert.equal(compactClipNote(0), "", "silent when nothing was clipped");
+});
+
+// #809 — panel_graph_outline's budget. The ruling on this tool: degrade by RESOLUTION,
+// never by coverage. Half a map is not a smaller map — an agent handed the first 200 of
+// 690 nodes cannot tell what it is missing and will reason confidently about a graph it
+// has seen a third of.
+test("#809 outline ladder shrinks detail, never coverage", () => {
+  assert.deepEqual(OUTLINE_DETAIL_LEVELS, ["full", "no_values", "no_widgets", "ids_only", "groups"]);
+
+  // The same clamp window as panel_query_graph's max_chars — one budget concept, one
+  // spelling, so a lever learned on one graph read is already known on the other.
+  assert.equal(clampOutlineMaxChars(undefined), OUTLINE_MAX_CHARS_DEFAULT);
+  assert.equal(clampOutlineMaxChars(1), OUTLINE_MAX_CHARS_FLOOR);
+  assert.equal(clampOutlineMaxChars(1e9), OUTLINE_MAX_CHARS_CEILING);
+  assert.equal(clampOutlineMaxChars("nonsense"), OUTLINE_MAX_CHARS_DEFAULT);
+  assert.equal(clampOutlineMaxChars(4000), 4000);
+});
+
+test("#809 every degraded outline still states the TRUE shape and the lever", () => {
+  for (const level of ["no_values", "no_widgets", "ids_only", "groups"]) {
+    const b = outlineDegradeBanner({ level, nodeCount: 690, groupCount: 12, maxChars: 4000 });
+    assert.match(b, /COVERAGE IS COMPLETE/, `${level} must not read as a partial graph`);
+    assert.match(b, /all 690 node\(s\) and 12 group\(s\)/, `${level} must state the real totals`);
+    assert.match(b, /raise `max_chars` up to 60000/i, `${level} must name the lever and its ceiling`);
+  }
+  // "full" is not a degradation, so it must be silent — a banner on an undegraded read
+  // would train the caller to ignore banners.
+  assert.equal(outlineDegradeBanner({ level: "full", nodeCount: 1, groupCount: 0, maxChars: 60000 }), "");
+});
+
+test("#809 the outline's fixed 60-char value clip names a tool, not a dead lever", () => {
+  const note = outlineValueClipNote(7, 0);
+  assert.match(note, /7 widget value\(s\) clipped to 60 chars/);
+  // The clip is fixed. Suggesting max_chars here would be defect 1 in miniature.
+  assert.match(note, /`max_chars` does not raise/);
+  assert.match(note, /panel_query_graph/);
+  // "Read FULL values" would over-promise: detail rows carry their own 2048-char
+  // per-widget cap (codex gate). The note must state that downstream bound.
+  assert.doesNotMatch(note, /full values/);
+  assert.match(note, /caps each value at 2048 chars/);
+});
+
+test("#809 the outline floor REFUSES rather than emitting a partial graph", () => {
+  const r = outlineFloorRefusal({ nodeCount: 690, groupCount: 12, maxChars: 500, floorChars: 3200 });
+  assert.match(r, /CANNOT RENDER/);
+  assert.match(r, /690 node\(s\)/, "a refusal still tells you how big the graph is");
+  assert.match(r, /PARTIAL outline is deliberately NOT returned/);
+  assert.match(r, /raise `max_chars` \(up to 60000\)/i);
+});
+
+test("#809 the refusal stops offering a raise that could never hold the outline", () => {
+  // A graph whose group-level floor exceeds the CEILING cannot be outlined at any budget
+  // this tool accepts, so "raise max_chars up to 60000" is a guaranteed second refusal —
+  // a dead retry inside the message explaining the first one (codex gate).
+  const r = outlineFloorRefusal({
+    nodeCount: 20000,
+    groupCount: 300,
+    maxChars: 500,
+    floorChars: 100_000,
+  });
+  assert.match(r, /Even `max_chars`'s ceiling of 60000 could not hold it/);
+  assert.match(r, /raising it will NOT produce an outline/);
+  assert.doesNotMatch(r, /Raise `max_chars` \(up to/);
+  assert.match(r, /panel_query_graph/);
+
+  // Below the ceiling the raise is still the right first move.
+  const reachable = outlineFloorRefusal({
+    nodeCount: 690,
+    groupCount: 12,
+    maxChars: 500,
+    floorChars: 32_000,
+  });
+  assert.match(reachable, /Raise `max_chars` \(up to 60000\)/);
 });
 
 // End-to-end shape: mirror the graph_query budget loop with the helpers to prove a

--- a/browser_tests/unit/outline-coverage.test.mjs
+++ b/browser_tests/unit/outline-coverage.test.mjs
@@ -1,0 +1,237 @@
+// #809 — panel_graph_outline must never trade COVERAGE for budget.
+//
+// The outline exists so an agent can UNDERSTAND a whole graph. A budget that stopped
+// partway would defeat that outright: half a map is not a smaller map. An agent handed
+// the first 200 of a 690-node graph cannot tell what it is missing, and will reason
+// confidently about a graph it has seen a third of — the fabrication failure mode in a
+// different hat. So the executor is allowed to shed RESOLUTION and never nodes.
+//
+// These are STRUCTURAL assertions over the handler source, because the invariant is
+// about what the code is permitted to do, not about one sampled output. A future edit
+// that "fixes" an over-budget outline by slicing the node list fails here.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+/** The executor method body, from its signature to the next executor method. */
+function handlerBody(src, sig) {
+  const start = src.indexOf(sig);
+  if (start === -1) return null;
+  const after = start + sig.length;
+  const m = src.slice(after).match(/\n {2}(?:async )?[A-Za-z_][A-Za-z0-9_]*\s*\(/);
+  const end = m ? after + m.index : src.length;
+  return src.slice(start, end);
+}
+
+const outline = () => {
+  const body = handlerBody(readFileSync(PANEL_JS, "utf8"), "graph_outline({");
+  assert.ok(body, "graph_outline({ … }) handler must exist");
+  return body;
+};
+
+test("#809 graph_outline takes the SAME max_chars budget as panel_query_graph", () => {
+  const body = outline();
+  assert.match(body, /graph_outline\(\{ max_chars \} = \{\}\)/, "accepts max_chars, still callable with no args");
+  assert.match(body, /clampOutlineMaxChars\(max_chars\)/, "clamps through the shared 500–60000 window");
+  // A differently-named budget for the same concept would force agents to learn the
+  // lever twice, which is how they end up not reaching for it at all.
+  assert.doesNotMatch(body, /max_nodes|node_limit|outline_chars/, "no second spelling of the same budget");
+});
+
+test("#809 graph_outline never truncates the NODE LIST to fit", () => {
+  const body = outline();
+  // The only slicing allowed in this handler is none: every rung renders every node.
+  assert.doesNotMatch(
+    body,
+    /\b(sorted|nodes)\s*\.\s*slice\s*\(/,
+    "the node list must never be sliced — degrade detail, not coverage",
+  );
+  assert.doesNotMatch(body, /MAX_STATE_NODES/, "the outline is not a MAX_STATE_NODES view");
+  // Every rung iterates the FULL topologically-sorted set.
+  assert.match(body, /for \(const n of sorted\)/, "node rows are rendered from the full sorted set");
+});
+
+test("#809 no user-controlled title reaches the outline unbounded", () => {
+  const body = outline();
+  // Group titles ride in the GROUPS index at every node rung, in the group summary at the
+  // floor, and the subgraph title rides in the header the REFUSAL also emits. A single
+  // long title would breach max_chars at every rung, since the ladder sheds detail but
+  // cannot shorten one title (codex gate).
+  assert.doesNotMatch(body, /\$\{g\.title \?\? ""\}/, "raw group title in the outline");
+  assert.doesNotMatch(body, /\$\{va\.title \?\? ""\}/, "raw subgraph title in the header");
+  assert.doesNotMatch(body, /` "\$\{n\.title\}"`/, "raw NODE title in a node row");
+  // Every title site goes through the counting wrapper: the GROUPS index, the group
+  // summary floor, the header (which the REFUSAL path re-emits), and the node rows.
+  // Four direct calls (GROUPS index, group-summary floor, header, node row) plus the
+  // `grps.map(title_)` reference asserted below.
+  const clips = body.match(/title_\(/g) ?? [];
+  assert.ok(clips.length >= 4, `every title site must clip, found ${clips.length}`);
+  assert.match(body, /const title_ = \(t\) => \{/, "the wrapper counts, so one footer can report");
+
+  // The per-node `group:` tag is the sneaky one: groupOf deliberately holds RAW titles so
+  // MEMBERSHIP never depends on a display clip, which means the clip has to happen at the
+  // interpolation site — and one long group title otherwise rides on EVERY member node's
+  // row (codex gate).
+  assert.doesNotMatch(body, /group:\$\{grps\.join\("\/"\)\}/, "raw group title on every member row");
+  assert.match(body, /group:\$\{grps\.map\(title_\)\.join\("\/"\)\}/);
+});
+
+test("#809 the query path fits its tail and footer INSIDE max_chars", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const body = handlerBody(src, "graph_query({");
+  assert.ok(body, "graph_query handler must exist");
+  // Fitting AFTERWARDS, not reserving up front: a reserve would manufacture a truncation
+  // on a result that fitted, which is the false-truncation defect in the other direction.
+  assert.match(body, /while \(text\.length > maxChars && lines\.length > 1\)/);
+  assert.match(body, /lines\.pop\(\);/);
+  assert.doesNotMatch(body, /FOOTER_RESERVE/, "no up-front reserve");
+
+  // The AGGREGATE branch returns earlier and is not covered by that loop — it filled the
+  // budget with rows and then appended its tail, the same defect on a different path.
+  assert.match(body, /while \(aggText\.length > maxChars && kept\.length > 0\)/);
+  assert.match(body, /kept\.pop\(\);/);
+
+  // The clip footer counts only rows actually RETURNED: a running total would include
+  // rows the budget rejected and rows the post-fit loop popped, so the note would claim
+  // clips the reader cannot see.
+  assert.match(body, /lineClips\.push\(rowClips\);/);
+  assert.match(body, /lineClips\.pop\(\);/);
+  assert.match(body, /compactClipNote\(lineClips\.reduce\(/);
+});
+
+// The `groups`/`rails` riders sit OUTSIDE the max_chars accounting (#807 owns that fix).
+// Until it lands they must at least be BOUNDED and MARKED, or the reply exceeds the very
+// budget the tool advertises no matter what the caller sets — and a silently short groups
+// list reads as "this graph has N groups" (codex gate).
+test("#809 the groups rider is bounded and says so", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const body = handlerBody(src, "graph_query({");
+  assert.match(body, /GROUPS_RIDER_CAP/, "the rider itself is capped");
+  assert.match(body, /groups_truncation_hint:/, "and the cut is stated in-band");
+  // A SIBLING field, not an extra array element: injecting a {truncated,hint} object into
+  // groups[] would make the array heterogeneous for any client expecting id/title.
+  assert.doesNotMatch(body, /\.\.\.allGroups\.slice\(0, GROUPS_RIDER_CAP\),\s*\{/);
+  assert.match(body, /#807/, "pointing at the issue that owns the accounting fix");
+
+  const summarize = handlerBody(src, "function summarizeGroup(graph, g) {");
+  assert.ok(summarize, "summarizeGroup must exist");
+  // A user-controlled title and an unbounded member list are the two ways one group can
+  // be arbitrarily large.
+  assert.match(summarize, /clipOutlineTitle\(g\.title\)/);
+  assert.match(summarize, /GROUP_NODE_IDS_CAP/);
+  assert.match(summarize, /node_ids_truncated:/);
+  // node_count stays the TRUE total, so a clipped node_ids can never read as the whole
+  // membership.
+  assert.match(summarize, /node_count: memberIds\.length/);
+});
+
+test("#809 graph_outline walks the detail ladder and reports which rung it used", () => {
+  const body = outline();
+  assert.match(body, /OUTLINE_DETAIL_LEVELS/, "uses the shared ladder");
+  assert.match(body, /detail_level:/, "reports the rung it landed on");
+  assert.match(body, /degraded_reason:/, "says WHY detail was reduced");
+  assert.match(body, /outlineDegradeBanner\(/, "puts the notice ON the outline text, not only in a field");
+});
+
+test("#809 graph_outline REFUSES rather than emitting a partial graph at the floor", () => {
+  const body = outline();
+  assert.match(body, /outlineFloorRefusal\(/, "the floor is a refusal, not a partial dump");
+  assert.match(body, /detail_level: refused \? "refused"/, "a refusal is reported as such");
+
+  // The refusal was assembled AFTER the ladder's fit test, so the stale banner and header
+  // could push it back over the very bound it was explaining (codex gate). It now sheds
+  // the optional parts in order — both are also returned as structured fields, so nothing
+  // is lost — and never truncates the refusal sentence itself.
+  assert.match(body, /const candidates = \[/);
+  assert.match(body, /candidates\.find\(\(c\) => c\.length <= maxChars\) \?\? refusal/);
+});
+
+test("#809 the refusal itself fits the smallest budget the tool accepts", async () => {
+  const m = await import("../../web/js/lib/graph-read.js");
+  // If the message that says "I refused to hand you a partial graph" did not fit, the
+  // tool would have to either truncate it (self-defeating) or breach its own bound.
+  const refusal = m.outlineFloorRefusal({
+    nodeCount: 690,
+    groupCount: 12,
+    maxChars: m.OUTLINE_MAX_CHARS_FLOOR,
+    floorChars: 32000,
+  });
+  assert.ok(
+    refusal.length <= m.OUTLINE_MAX_CHARS_FLOOR,
+    `refusal is ${refusal.length} chars, over the ${m.OUTLINE_MAX_CHARS_FLOOR} floor`,
+  );
+});
+
+test("#809 the MAX_STATE_NODES views state their cap instead of a bare boolean", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  // Each capped view must carry prose the model actually reads, not just `truncated:true`.
+  for (const sig of [
+    "graph_view_selected()",
+    "graph_view_nodes_in_viewport()",
+    "graph_get_subgraph({",
+  ]) {
+    const body = handlerBody(src, sig);
+    assert.ok(body, `${sig} must exist`);
+    assert.match(body, /truncation_hint:/, `${sig} must emit a remedy, not only a boolean`);
+    assert.match(body, /fixedCapNote\(/, `${sig} must use the shared fixed-cap wording`);
+  }
+  // And the shared wording must be honest about there being no lever — inventing one
+  // would be the same defect as naming the wrong one.
+  assert.match(src, /FIXED cap of \$\{MAX_STATE_NODES\} and no parameter raises it/);
+});
+
+test("#809 graph_find_nodes says the scan STOPPED, not that it found everything", () => {
+  const body = handlerBody(readFileSync(PANEL_JS, "utf8"), "graph_find_nodes({");
+  assert.ok(body, "graph_find_nodes handler must exist");
+  assert.match(body, /truncation_hint:/, "a bare `truncated` boolean is not a signal a model reads");
+  assert.match(body, /not evidence a node is absent/, "a capped scan must not read as 'no such node'");
+  // Backticks are escaped in the source template literal.
+  assert.match(body, /Raise \\`limit\\` up to \$\{LIMIT_CEILING\}/, "names the real lever and its real ceiling");
+  assert.match(body, /Math\.min\(Math\.max\(Number\(limit \?\? 40\), 1\), LIMIT_CEILING\)/, "the clamp and the quoted ceiling are the SAME constant");
+});
+
+// A false truncation claim is its own defect: told "there may be more" when there is not,
+// an agent burns a retry and learns the tool is unreliable. `truncated` must be PROVEN by
+// an actually-found (cap+1)-th match, never inferred from reaching the cap.
+test("#809 graph_find_nodes proves truncation with a (cap+1)-th match, never infers it", () => {
+  const body = handlerBody(readFileSync(PANEL_JS, "utf8"), "graph_find_nodes({");
+  assert.match(body, /let overCap = false;/, "truncation is a proven fact, not a count comparison");
+  assert.match(body, /if \(matches\.length > cap\) \{[\s\S]*?matches\.pop\(\);[\s\S]*?overCap = true;/,
+    "takes one past the cap, then drops it");
+  assert.match(body, /truncated: overCap,/, "reports the proven fact");
+  assert.doesNotMatch(body, /truncated: matches\.length >= cap/,
+    "matches.length >= cap is true for an EXACT-cap result that dropped nothing");
+});
+
+test("#809 the outline's own fixed clips are not left silent", () => {
+  const body = outline();
+  assert.match(body, /outlineClipped\+\+/, "the fixed per-value clip is counted");
+  assert.match(body, /outlineTitlesClipped\+\+/, "so is the fixed per-title clip");
+  assert.match(
+    body,
+    /outlineValueClipNote\(outlineClipped, outlineTitlesClipped\)/,
+    "and both are reported on the outline itself",
+  );
+});
+
+// The footer is PART of the rung. Appending it after the fit test could tip a rung over
+// budget and trigger the floor refusal while lower rungs were never tried — and the
+// refusal would then call that oversized full-detail size the "smallest whole-graph
+// form" (codex gate).
+test("#809 each rung is measured WITH its footer, and the counters reset inside", () => {
+  const body = outline();
+  const assembleStart = body.indexOf("const assemble = (level) => {");
+  assert.notEqual(assembleStart, -1, "assemble() must exist");
+  const assembleBody = body.slice(assembleStart, body.indexOf("// Walk DOWN the ladder"));
+  assert.match(assembleBody, /outlineClipped = 0;/, "counters reset per rung, inside assemble");
+  assert.match(assembleBody, /outlineTitlesClipped = 0;/);
+  assert.match(assembleBody, /outlineValueClipNote\(/, "the footer is inside the measured string");
+  // The ladder loop must contain no post-hoc append of the note.
+  const ladder = body.slice(body.indexOf("// Walk DOWN the ladder"));
+  assert.doesNotMatch(ladder, /outline \+= outlineValueClipNote/, "no post-fit append");
+});

--- a/browser_tests/unit/reconnect-staleness.test.mjs
+++ b/browser_tests/unit/reconnect-staleness.test.mjs
@@ -188,7 +188,7 @@ test("#433 wiring: reconnect bumps the epoch on a MONOTONIC clock; open/new/read
   }
 
   // BOTH readers must consult the helper — checked in their OWN bodies, not globally.
-  for (const sig of ["workflow_list()", "graph_outline()"]) {
+  for (const sig of ["workflow_list()", "graph_outline({"]) {
     const body = handlerBody(src, sig);
     assert.ok(body, `${sig} must exist`);
     assert.match(body, /activeWorkflowPossiblyStale\(\{/, `${sig} must check post-reconnect staleness`);
@@ -201,7 +201,7 @@ test("#429 wiring: every group-membership READ handler resyncs live rects BEFORE
   const src = readFileSync(PANEL_JS, "utf8");
   const handlers = [
     "graph_get_state()",
-    "graph_outline()",
+    "graph_outline({",
     "graph_query({",
     "graph_auto_layout({",
     "graph_subgraph_group({",

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -157,6 +157,17 @@ import {
   fitDetailLine,
   isLineProtected,
   truncationTail,
+  // #809: remedy plumbing — every truncation must name the lever that applies.
+  clipCompactValue,
+  compactClipNote,
+  LIMIT_CEILING,
+  MAX_CHARS_CEILING,
+  OUTLINE_DETAIL_LEVELS,
+  clampOutlineMaxChars,
+  outlineDegradeBanner,
+  outlineFloorRefusal,
+  outlineValueClipNote,
+  clipOutlineTitle,
 } from "./lib/graph-read.js";
 import { classifyManualChangeBaseline } from "./lib/manual-change-gate.js";
 import { safeRemoveNode } from "./lib/safe-remove-node.js";
@@ -4229,6 +4240,32 @@ function getWorkflowTitle() {
 
 const MAX_STATE_NODES = 100;
 
+// #809 (codex gate): `groups` (and `rails`) ride ALONGSIDE the bounded `text` and are not
+// counted against `max_chars` — that accounting is artokun/comfyui-mcp#807. Until it
+// lands they must at least be BOUNDED, or a heavily-grouped graph makes the reply exceed
+// the budget the tool advertises no matter what the caller sets. Both cuts are marked
+// in-band, because a silently short list reads as the whole list.
+const GROUPS_RIDER_CAP = 200;
+const GROUP_NODE_IDS_CAP = 200;
+
+/**
+ * #809: the MAX_STATE_NODES views used to report only `truncated: true`. A boolean is
+ * the WORST truncation signal there is — it is a field, not prose, so a model reading
+ * the result gets no instruction from it at all, concludes the TOOL cannot do the thing,
+ * and escalates to the human.
+ *
+ * This cap is deliberately FIXED (no parameter raises it), so the honest remedy is to
+ * say exactly that and name the tool that CAN target the rest. Inventing a lever these
+ * views do not have would be the same defect pointing the other way.
+ */
+function fixedCapNote(what, shown, total, targeted) {
+  const of = Number.isFinite(total) ? `${shown} of ${total}` : `${shown}`;
+  return (
+    `Showing ${of} ${what} — this view has a FIXED cap of ${MAX_STATE_NODES} and no parameter raises it. ` +
+    targeted
+  );
+}
+
 function getGraphCtx() {
   // app.canvas.graph is the graph the user is LOOKING at — the root graph or an
   // opened subgraph — so reads and edits target what's on screen. But after a
@@ -5745,13 +5782,28 @@ function setGroupBounds(group, [x, y, w, h]) {
 function summarizeGroup(graph, g) {
   const b = g._bounding ?? [g.pos?.[0] ?? 0, g.pos?.[1] ?? 0, g.size?.[0] ?? 0, g.size?.[1] ?? 0];
   const memberIds = groupMemberNodes(graph, g).map((n) => n.id);
+  // #809 (codex gate): a group TITLE is user-controlled and `node_ids` grows with the
+  // graph, so this summary could be arbitrarily large — and it rides outside the
+  // `max_chars` accounting (#807). Bound both, and MARK each cut: `node_count` is always
+  // the true total, so a clipped `node_ids` can never be read as the whole membership.
+  const clippedTitle = clipOutlineTitle(g.title);
+  const idsFit = memberIds.length <= GROUP_NODE_IDS_CAP;
   return {
     id: g.id != null ? g.id : (graph._groups ?? []).indexOf(g),
-    title: g.title ?? "",
+    title: clippedTitle.text,
+    ...(clippedTitle.clipped ? { title_clipped: true } : {}),
     color: g.color ?? null,
     bounding: [Math.round(b[0]), Math.round(b[1]), Math.round(b[2]), Math.round(b[3])],
     node_count: memberIds.length,
-    node_ids: memberIds,
+    node_ids: idsFit ? memberIds : memberIds.slice(0, GROUP_NODE_IDS_CAP),
+    ...(idsFit
+      ? {}
+      : {
+          // NOT "panel_graph_outline lists every member" flatly (codex gate): its own
+          // budget can degrade it to the group-SUMMARY rung, which emits counts and no
+          // ids at all — and a big group is exactly when that happens. Name the condition.
+          node_ids_truncated: `Showing ${GROUP_NODE_IDS_CAP} of ${memberIds.length} member id(s) — a fixed cap that no parameter raises. panel_graph_outline's GROUPS index lists every member id, but only while its own max_chars affords a node-level rung; if it reports detail_level:"groups" it shows counts, not ids, so raise its max_chars.`,
+        }),
   };
 }
 
@@ -6003,7 +6055,17 @@ const GRAPH_TOOL_EXECUTORS = {
       selected_count: picked.length,
       node_count: graph._nodes?.length ?? 0,
       nodes: picked.slice(0, MAX_STATE_NODES).map(summarizeNode),
-      ...(picked.length > MAX_STATE_NODES ? { truncated: true } : {}),
+      ...(picked.length > MAX_STATE_NODES
+        ? {
+            truncated: true,
+            truncation_hint: fixedCapNote(
+              "selected node(s)",
+              MAX_STATE_NODES,
+              picked.length,
+              "Ask the user to select fewer nodes, or read the ones you need by id with panel_query_graph {ids:[…], fields:'detail'}, which DOES take limit and max_chars.",
+            ),
+          }
+        : {}),
       // Groups/reroutes can be selected too — report them so "nothing selected"
       // is never misreported when the user actually has a group highlighted.
       ...(others.length ? { other_selected_items: others } : {}),
@@ -6078,6 +6140,16 @@ const GRAPH_TOOL_EXECUTORS = {
       node_count: all.length,
       in_view_count: visible.length,
       truncated: visible.length > MAX_STATE_NODES,
+      ...(visible.length > MAX_STATE_NODES
+        ? {
+            truncation_hint: fixedCapNote(
+              "visible node(s)",
+              MAX_STATE_NODES,
+              visible.length,
+              "Ask the user to zoom in so fewer nodes are on screen, or read the region with panel_query_graph (which DOES take limit and max_chars) / panel_graph_outline for the whole graph.",
+            ),
+          }
+        : {}),
       nodes: visible.slice(0, MAX_STATE_NODES).map(summarizeNode),
     };
   },
@@ -6089,7 +6161,7 @@ const GRAPH_TOOL_EXECUTORS = {
   //      → outputs as target_node.input_name
   // Far cheaper to read than the full JSON state, and shows the WIRING (which the
   // raw node dump makes you reconstruct). Read-only.
-  graph_outline() {
+  graph_outline({ max_chars } = {}) {
     const { graph, rootGraph } = getGraphCtx();
     // panel#389: refuse a false-clean empty read when the live graph is desynced
     // from the active workflow (empty canvas graph while the workflow reports nodes).
@@ -6106,77 +6178,157 @@ const GRAPH_TOOL_EXECUTORS = {
     // Geometric group membership → node id → group titles, plus a title→ids index.
     const groups = graph._groups ?? [];
     const groupOf = new Map();
-    const groupLines = [];
+    const groupMembers = new Map();
     for (const g of groups) {
       const ids = groupMemberNodes(graph, g).map((n) => n.id);
-      const tag = { 2: " [mute]", 4: " [bypass]" }[g.mode] ?? "";
-      groupLines.push(`  "${g.title ?? ""}"${tag} → ${ids.join(",") || "(empty)"}`);
+      groupMembers.set(g, ids);
       for (const id of ids) {
         if (!groupOf.has(id)) groupOf.set(id, []);
+        // Clipped for display only — MEMBERSHIP is keyed by node id above and is
+        // unaffected, and the GROUPS index still lists ids per group, so nothing
+        // downstream resolves a group by this label (codex gate).
         groupOf.get(id).push(g.title ?? "");
       }
     }
 
+    // #809 (codex gate): even the "full" rung clips each widget value at a FIXED 60
+    // chars, and TITLES (group, subgraph, node) are user-controlled and unbounded. A bare
+    // "…" on either quietly contradicts the outline's own coverage claim, so count both
+    // and raise ONE footer naming the tool that carries fuller values. No parameter
+    // raises these clips, so the footer must not pretend one does.
+    let outlineClipped = 0;
+    let outlineTitlesClipped = 0;
+    /** clipOutlineTitle, counting — every title in the outline goes through here. */
+    const title_ = (t) => {
+      const c = clipOutlineTitle(t);
+      if (c.clipped) outlineTitlesClipped++;
+      return c.text;
+    };
+    // Rebuilt per rung (not hoisted) so its title clips are counted against the rung that
+    // actually emits them — a count carried in from outside would claim clips the
+    // rendered text does not contain.
+    const renderGroupLines = () =>
+      groups.map((g) => {
+        const ids = groupMembers.get(g) ?? [];
+        const tag = { 2: " [mute]", 4: " [bypass]" }[g.mode] ?? "";
+        // A user-controlled group title is unbounded, so an un-clipped one would breach
+        // max_chars at EVERY rung — the ladder can shed detail but cannot shorten a
+        // single title.
+        return `  "${title_(g.title)}"${tag} → ${ids.join(",") || "(empty)"}`;
+      });
     const fmtVal = (v) => {
       const s = String(typeof v === "string" ? v : JSON.stringify(v) ?? "").replace(/\s+/g, " ");
-      return s.length > 60 ? s.slice(0, 57) + "…" : s;
+      if (s.length <= 60) return s;
+      outlineClipped++;
+      return s.slice(0, 57) + "…";
     };
     const modeTag = (n) => ({ 2: " [mute]", 4: " [bypass]" }[n.mode] ?? "");
     const outTag = (n) => (n.constructor?.nodeData?.output_node ? " [OUTPUT]" : "");
 
-    const lines = [];
-    for (const n of topoSortNodes(nodes, links)) {
-      const title = n.title && n.title !== n.type ? ` "${n.title}"` : "";
-      const grps = groupOf.get(n.id);
-      const groupTag = grps?.length ? ` · group:${grps.join("/")}` : "";
-      // #558: MARK the seed/value widget with its control_after_generate mode
-      // (`seed=… [after_gen=randomize]`) — visible like [bypass]/[mute] so a silently-
-      // rewritten value is obvious. The control combo token is NOT hidden (folding could
-      // hide a real combo that merely shares the mode option set), only annotated.
-      const cagMode = new Map(
-        controlAfterGenerateEntries(n)
-          .filter((e) => e.widget !== e.control)
-          .map((e) => [e.widget, e.mode]),
-      );
-      // #607: flag widgets overridden by a link so the stored value isn't read as effective.
-      const driven = drivenWidgetsFor(n, (n.widgets ?? []).map((w) => w?.name).filter(Boolean));
-      const widgets = (n.widgets ?? [])
-        .filter((w) => w && typeof w.name === "string")
-        .map((w) => {
-          const base = `${w.name}=${fmtVal(w.value)}`;
-          const mode = cagMode.get(w.name);
-          const withMode = mode ? `${base} [after_gen=${mode}]` : base;
-          return driven[w.name] ? `${withMode}${drivenTag(driven[w.name])}` : withMode;
-        })
-        .join(" ");
-      lines.push(
-        `${n.id}  ${n.type}${title}${modeTag(n)}${outTag(n)}${groupTag}${widgets ? "  " + widgets : ""}`,
-      );
-      const ins = (n.inputs ?? [])
-        .map((inp) => {
-          if (inp.link == null) return null;
-          const l = links[inp.link];
-          if (!l) return null;
-          const src = byId.get(l.origin_id);
-          return `${l.origin_id}.${src?.outputs?.[l.origin_slot]?.name ?? l.origin_slot}`;
-        })
-        .filter(Boolean);
-      if (ins.length) lines.push(`     ← ${ins.join(", ")}`);
-      const outs = [];
-      for (const out of n.outputs ?? []) {
-        for (const lid of out.links ?? []) {
-          const l = links[lid];
-          if (!l) continue;
-          const tgt = byId.get(l.target_id);
-          outs.push(`${l.target_id}.${tgt?.inputs?.[l.target_slot]?.name ?? l.target_slot}`);
+    // #809: render the node block at ONE rung of the detail ladder. Every rung emits a
+    // row for EVERY node — the ladder trades RESOLUTION, never coverage, because half a
+    // map is not a smaller map: an agent handed the first 200 of 690 nodes cannot tell
+    // what it is missing and will reason confidently about a graph it has barely seen.
+    const sorted = topoSortNodes(nodes, links);
+    const renderNodeLines = (level) => {
+      const out = [];
+      for (const n of sorted) {
+        // #809 (codex gate): NODE titles are user-controlled too — an unbounded one
+        // would breach max_chars at every rung, which the ladder cannot fix by shedding
+        // detail elsewhere.
+        const title = level === "ids_only" || !(n.title && n.title !== n.type) ? "" : ` "${title_(n.title)}"`;
+        const grps = groupOf.get(n.id);
+        // #809 (codex gate): groupOf holds RAW titles (membership must not depend on a
+        // display clip), so the per-node `group:` tag has to clip HERE — otherwise one
+        // long group title rides on every member node's row and blows max_chars at every
+        // rung, forcing needless degradation.
+        const groupTag =
+          level === "ids_only" || !grps?.length ? "" : ` · group:${grps.map(title_).join("/")}`;
+        let widgets = "";
+        if (level === "full" || level === "no_values") {
+          // #558: MARK the seed/value widget with its control_after_generate mode
+          // (`seed=… [after_gen=randomize]`) — visible like [bypass]/[mute] so a silently-
+          // rewritten value is obvious. The control combo token is NOT hidden (folding could
+          // hide a real combo that merely shares the mode option set), only annotated.
+          const cagMode = new Map(
+            controlAfterGenerateEntries(n)
+              .filter((e) => e.widget !== e.control)
+              .map((e) => [e.widget, e.mode]),
+          );
+          // #607: flag widgets overridden by a link so the stored value isn't read as effective.
+          const driven = drivenWidgetsFor(n, (n.widgets ?? []).map((w) => w?.name).filter(Boolean));
+          widgets = (n.widgets ?? [])
+            .filter((w) => w && typeof w.name === "string")
+            .map((w) => {
+              // At "no_values" the widget NAMES still tell an agent what is configurable;
+              // the VALUES are the bulk of the bytes, so they go first.
+              const base = level === "full" ? `${w.name}=${fmtVal(w.value)}` : w.name;
+              const mode = cagMode.get(w.name);
+              const withMode = mode ? `${base} [after_gen=${mode}]` : base;
+              return driven[w.name] ? `${withMode}${drivenTag(driven[w.name])}` : withMode;
+            })
+            .join(" ");
         }
+        const modes = level === "ids_only" ? "" : `${modeTag(n)}${outTag(n)}`;
+        out.push(
+          `${n.id}  ${n.type}${title}${modes}${groupTag}${widgets ? "  " + widgets : ""}`,
+        );
+        if (level === "ids_only") continue;
+        const ins = (n.inputs ?? [])
+          .map((inp) => {
+            if (inp.link == null) return null;
+            const l = links[inp.link];
+            if (!l) return null;
+            const src = byId.get(l.origin_id);
+            return `${l.origin_id}.${src?.outputs?.[l.origin_slot]?.name ?? l.origin_slot}`;
+          })
+          .filter(Boolean);
+        if (ins.length) out.push(`     ← ${ins.join(", ")}`);
+        const outs = [];
+        for (const out2 of n.outputs ?? []) {
+          for (const lid of out2.links ?? []) {
+            const l = links[lid];
+            if (!l) continue;
+            const tgt = byId.get(l.target_id);
+            outs.push(`${l.target_id}.${tgt?.inputs?.[l.target_slot]?.name ?? l.target_slot}`);
+          }
+        }
+        if (outs.length) out.push(`     → ${outs.join(", ")}`);
       }
-      if (outs.length) lines.push(`     → ${outs.join(", ")}`);
-    }
+      return out;
+    };
+
+    // The FLOOR rung: per-group counts + the types that actually occur there, plus the
+    // ungrouped remainder. Still answers "how big is this and what's in it" for the
+    // WHOLE graph, which is the one question the outline must never fail to answer.
+    const renderGroupSummary = () => {
+      const out = [];
+      const counted = new Set();
+      const typeHist = (ns) => {
+        const h = new Map();
+        for (const n of ns) h.set(n.type ?? "?", (h.get(n.type ?? "?") ?? 0) + 1);
+        return [...h.entries()].sort((a, b) => b[1] - a[1]).map(([t, c]) => `${c}× ${t}`);
+      };
+      for (const g of groups) {
+        const members = groupMemberNodes(graph, g);
+        for (const n of members) counted.add(n.id);
+        const tag = { 2: " [mute]", 4: " [bypass]" }[g.mode] ?? "";
+        out.push(`  "${title_(g.title)}"${tag} — ${members.length} node(s): ${typeHist(members).join(", ") || "(empty)"}`);
+      }
+      const rest = sorted.filter((n) => !counted.has(n.id));
+      if (rest.length) out.push(`  (ungrouped) — ${rest.length} node(s): ${typeHist(rest).join(", ")}`);
+      return out;
+    };
 
     const va = describeActiveGraph(graph);
-    const viewingStr = va && va.scope === "subgraph" ? `subgraph "${va.title ?? ""}"` : (va?.scope ?? "root");
-    const header = `${nodes.length} nodes · ${groups.length} group(s) · viewing: ${viewingStr}`;
+    // #809: the subgraph title is user-controlled too, and it rides in the header that
+    // even the REFUSAL path emits — so it must be bounded there as well (codex gate).
+    // Built PER RUNG so its clip is counted against the rung that actually emits it.
+    const renderHeader = () => {
+      const viewingStr =
+        va && va.scope === "subgraph" ? `subgraph "${title_(va.title)}"` : (va?.scope ?? "root");
+      return `${nodes.length} nodes · ${groups.length} group(s) · viewing: ${viewingStr}`;
+    };
     // #433: warn if ComfyUI reconnected recently — `viewing`/`active` may point at a
     // tab the frontend restored rather than the one the user was last looking at.
     const activeMaybeStale = activeWorkflowPossiblyStale({
@@ -6186,17 +6338,103 @@ const GRAPH_TOOL_EXECUTORS = {
       now: monotonicNow(),
     });
     const staleBanner = activeMaybeStale ? `⚠ ${activeStaleHint()}\n\n` : "";
-    const outline =
-      staleBanner +
-      header +
-      (groupLines.length ? `\n\nGROUPS (title → member node ids):\n${groupLines.join("\n")}` : "") +
-      `\n\nNODES (data flows top→down; ← inputs from, → outputs to):\n${lines.join("\n")}`;
+
+    const maxChars = clampOutlineMaxChars(max_chars);
+    // #809 (codex gate): the clip footer is PART of the rung, so it must be inside the
+    // measured string. Appending it after the fit test could tip a rung over budget and
+    // trigger the floor refusal while lower rungs were never tried — which then reported
+    // that oversized full-detail size as the "smallest whole-graph form".
+    const assemble = (level) => {
+      outlineClipped = 0;
+      outlineTitlesClipped = 0;
+      const banner = outlineDegradeBanner({
+        level,
+        nodeCount: nodes.length,
+        groupCount: groups.length,
+        maxChars,
+      });
+      // Render BEFORE building the note: rendering is what increments the counters, and
+      // rungs below "no_values" emit no values at all, so a carried-over count would
+      // claim clips this outline does not contain.
+      const head = renderHeader();
+      let bodyText;
+      if (level === "groups") {
+        bodyText = `\n\nGROUP SUMMARY (every node is counted here; per-node detail did not fit):\n${renderGroupSummary().join("\n")}`;
+      } else {
+        // The GROUPS index is membership, not detail — it stays on every node-level rung
+        // so the reader keeps the graph's structure even at "ids_only".
+        const gl = renderGroupLines();
+        bodyText =
+          (gl.length ? `\n\nGROUPS (title → member node ids):\n${gl.join("\n")}` : "") +
+          `\n\nNODES (data flows top→down; ← inputs from, → outputs to):\n${renderNodeLines(level).join("\n")}`;
+      }
+      return (
+        staleBanner +
+        (banner ? `${banner}\n\n` : "") +
+        head +
+        bodyText +
+        outlineValueClipNote(outlineClipped, outlineTitlesClipped)
+      );
+    };
+
+    // Walk DOWN the ladder until one fits. The floor is emitted even when it overflows —
+    // but then it is replaced by an explicit refusal that still states the true shape,
+    // because a partial outline that reads as complete is the failure we are avoiding.
+    let level = OUTLINE_DETAIL_LEVELS[0];
+    let outline = assemble(level);
+    for (const next of OUTLINE_DETAIL_LEVELS.slice(1)) {
+      if (outline.length <= maxChars) break;
+      level = next;
+      outline = assemble(level);
+    }
+    let refused = false;
+    let floorChars = 0;
+    if (outline.length > maxChars) {
+      refused = true;
+      floorChars = outline.length;
+      const refusal = outlineFloorRefusal({
+        nodeCount: nodes.length,
+        groupCount: groups.length,
+        maxChars,
+        floorChars: outline.length,
+      });
+      // #809 (codex gate): the refusal was assembled AFTER the ladder's fit test, so at a
+      // small budget the stale banner + header pushed it back over the bound it was
+      // explaining. Shed the OPTIONAL parts in order of expendability — the header, then
+      // the reconnect banner (both are also returned as structured fields, so nothing is
+      // lost) — and never the refusal sentence itself: truncating the message that says
+      // "I refused to hand you a partial graph" would be self-defeating. That last
+      // resort is the only text allowed past the budget, and it is bounded and fixed.
+      const candidates = [
+        staleBanner + refusal + `\n\n${renderHeader()}`,
+        staleBanner + refusal,
+        refusal,
+      ];
+      outline = candidates.find((c) => c.length <= maxChars) ?? refusal;
+    }
+    const degraded = refused || level !== OUTLINE_DETAIL_LEVELS[0];
 
     return {
       node_count: nodes.length,
       group_count: groups.length,
       viewing: describeActiveGraph(graph),
       outline,
+      // #809: the budget, the rung, and WHY — a caller that reads fields rather than
+      // prose must still learn that detail was traded away and which lever restores it.
+      max_chars: maxChars,
+      detail_level: refused ? "refused" : level,
+      // #809 (codex gate): the size the smallest whole-graph form would need. The
+      // orchestrator rider cannot otherwise tell "raise max_chars and it will fit" from
+      // "no budget this tool accepts can hold it", and would repeat the dead retry.
+      ...(refused ? { floor_chars: floorChars } : {}),
+      ...(degraded
+        ? {
+            degraded: true,
+            degraded_reason: refused
+              ? `Not even a per-group summary fits max_chars=${maxChars}; a partial outline is deliberately not returned.`
+              : `Per-node detail reduced to "${level}" to fit max_chars=${maxChars}; coverage is complete (all ${nodes.length} node(s) represented).`,
+          }
+        : {}),
       ...(activeMaybeStale
         ? { active_possibly_stale: true, stale_hint: activeStaleHint() }
         : {}),
@@ -6264,7 +6502,12 @@ const GRAPH_TOOL_EXECUTORS = {
     const maxDepth = depth != null && depth >= 0 ? Number(depth) : Infinity;
     // #609: clip caller-supplied values echoed in diagnostics so an oversized seed /
     // predicate can't flood the read.
-    const clipDiag = (s) => { const x = String(s); return x.length > 120 ? x.slice(0, 120) + "…" : x; };
+    // #809: SAY when it was clipped — echoing back a shortened value with a bare "…"
+    // reads as "that is what I looked for", so the caller cannot tell a typo from a clip.
+    const clipDiag = (s) => {
+      const x = String(s);
+      return x.length > 120 ? `${x.slice(0, 120)}… (shown clipped to 120 of ${x.length} chars)` : x;
+    };
     if (upstream_of != null) {
       const seed = String(upstream_of);
       if (!byId.has(seed)) return { total, candidates: 0, matched: 0, shown: 0, truncated: false, text: `upstream_of node ${clipDiag(seed)} not found (${total} nodes in view).` };
@@ -6332,10 +6575,27 @@ const GRAPH_TOOL_EXECUTORS = {
 
     // Groups + rails ride on every result (they replaced graph_get_state's role
     // as the structured source of group membership / subgraph boundary slots).
-    const groups = (graph._groups ?? []).map((g) => summarizeGroup(graph, g));
+    // #809 (codex gate): the `groups` rider rides ALONGSIDE `text` and is not counted
+    // against `max_chars` (that accounting is #807). Until #807 lands it must at least be
+    // BOUNDED, or the reply can exceed the very budget this tool advertises no matter
+    // what the caller sets. Cap it, and say so in-band — a silently short groups list
+    // would be read as "this graph has N groups", which is the defect this issue removes.
+    const allGroups = (graph._groups ?? []).map((g) => summarizeGroup(graph, g));
+    const groupsOverCap = allGroups.length > GROUPS_RIDER_CAP;
+    const groups = groupsOverCap ? allGroups.slice(0, GROUPS_RIDER_CAP) : allGroups;
+    // The marker is a SIBLING field, not an extra element (codex gate): injecting a
+    // {truncated,hint} object into `groups[]` would make the array heterogeneous and
+    // break any client that expects every element to carry id/title.
+    const groupsCut = groupsOverCap
+      ? {
+          groups_truncated: true,
+          groups_truncation_hint: `Showing ${GROUPS_RIDER_CAP} of ${allGroups.length} group(s) — a fixed cap on this rider, which \`max_chars\` does not govern (it bounds \`text\`; see artokun/comfyui-mcp#807). panel_graph_outline's GROUPS index covers every group.`,
+        }
+      : {};
     const inSubgraph = graph !== rootGraph;
     const meta = {
       viewing: describeActiveGraph(graph),
+      ...groupsCut,
       ...(groups.length ? { groups } : {}),
       ...(inSubgraph ? { rails: describeRails(graph) } : {}),
     };
@@ -6357,11 +6617,32 @@ const GRAPH_TOOL_EXECUTORS = {
         kept.push(l);
         used += l.length + 1;
       }
-      const aggTail = aggTruncated ? `\n…(${allLines.length - kept.length} more type(s) omitted; raise max_chars)` : "";
+      // #809: the aggregate can ONLY be cut by the char budget (limit is ignored here),
+      // so name that one lever and its real ceiling. The tail is part of the RESULT, so
+      // it is fitted afterwards — the loop above fills the budget with rows and appending
+      // past that breached the bound on exactly the path the row projection already fixed
+      // (codex gate).
+      const aggAssemble = () => {
+        const aggTail = aggTruncated
+          ? `\n…(${allLines.length - kept.length} more type(s) cut by \`max_chars\`=${maxChars}; ${
+              maxChars >= MAX_CHARS_CEILING
+                ? `\`max_chars\` is already at its ceiling of ${MAX_CHARS_CEILING} — narrow the matched set with \`types\`/\`where\`/\`upstream_of\` instead`
+                : `raise \`max_chars\` up to ${MAX_CHARS_CEILING}`
+            })`
+          : "";
+        return `${head}\n${kept.join("\n")}${aggTail}`;
+      };
+      let aggText = aggAssemble();
+      while (aggText.length > maxChars && kept.length > 0) {
+        kept.pop();
+        aggTruncated = true;
+        aggText = aggAssemble();
+      }
       return {
         ...meta, total, candidates: candidates.length, matched: matched.length,
         shown: matched.length, truncated: aggTruncated,
-        text: `${head}\n${kept.join("\n")}${aggTail}`,
+        truncated_by: aggTruncated ? "max_chars" : null,
+        text: aggText,
       };
     }
 
@@ -6379,9 +6660,23 @@ const GRAPH_TOOL_EXECUTORS = {
     const lines = [];
     let shown = 0;
     let truncated = false;
+    // #809: WHICH cap fired. `limit` and `max_chars` are different levers with opposite
+    // remedies — a tail that names the wrong one costs the caller a retry and then reads
+    // to them as proof the tool cannot do the job.
+    let truncatedBy = null;
+    // #809: compact rows clip widget values at a FIXED 60 chars, which no parameter
+    // raises — so ONE footer points at `fields`:"detail" rather than at a dead lever.
+    //
+    // Counted PER ROW and summed over the rows actually RETURNED (codex gate). A running
+    // total would include rows the budget rejected and rows the post-fit loop popped, so
+    // the footer would claim clips the reader cannot see — a false claim inside the very
+    // note that has to be trustworthy.
+    const lineClips = [];
+    let rowClips = 0;
     let chars = header.length;
     for (const n of matched) {
-      if (shown >= lim) { truncated = true; break; }
+      rowClips = 0;
+      if (shown >= lim) { truncated = true; truncatedBy = "limit"; break; }
       let line;
       if (proj === "ids") {
         line = clipLine(String(n.id), maxChars); // #609: bound even a pathological long id
@@ -6400,7 +6695,11 @@ const GRAPH_TOOL_EXECUTORS = {
         // #607: flag link-driven widgets in the compact line too.
         const driven = drivenWidgetsFor(n, (n.widgets ?? []).map((w) => w?.name).filter(Boolean));
         const w = Object.entries(widgetsOf(n))
-          .map(([k, v]) => `${k}=${clip(v)}${driven[k] ? drivenTag(driven[k]) : ""}`)
+          .map(([k, v]) => {
+            const c = clipCompactValue(v);
+            if (c.clipped) rowClips++;
+            return `${k}=${c.text}${driven[k] ? drivenTag(driven[k]) : ""}`;
+          })
           .join(" ");
         const ins = [...(up.get(String(n.id)) ?? [])].join(",");
         const outs = [...(down.get(String(n.id)) ?? [])].join(",");
@@ -6413,16 +6712,46 @@ const GRAPH_TOOL_EXECUTORS = {
       }
       // #609: protect ONLY the first match from the char budget so a single-id query
       // never returns shown:0. Later lines stay budget-governed (output stays bounded).
-      if (!isLineProtected(shown) && chars + line.length + 1 > maxChars) { truncated = true; break; }
+      if (!isLineProtected(shown) && chars + line.length + 1 > maxChars) {
+        truncated = true;
+        truncatedBy = "max_chars";
+        break;
+      }
       chars += line.length + 1;
       lines.push(line);
+      lineClips.push(rowClips);
       shown++;
     }
-    const tail = truncated ? truncationTail(shown, matched.length, !!(wantIds && wantIds.length)) : "";
-    const body = proj === "ids" ? lines.join(",") : lines.join("\n");
+    // #809 (codex gate): the tail and the clip footer are PART of the result and must fit
+    // inside `max_chars`, not be appended past it. Fit afterwards by dropping only as
+    // many rows as needed — reserving their worst case up front would manufacture a
+    // truncation on a result that fitted, which is the false-truncation defect this
+    // issue also exists to remove. The first row is never dropped (#609 protection).
+    const assemble = () => {
+      const tail = truncated
+        ? truncationTail(shown, matched.length, !!(wantIds && wantIds.length), truncatedBy, {
+            limit: lim,
+            maxChars,
+          })
+        : "";
+      const body = proj === "ids" ? lines.join(",") : lines.join("\n");
+      return `${header}\n${body}${tail}${compactClipNote(lineClips.reduce((x, y) => x + y, 0))}`;
+    };
+    let text = assemble();
+    while (text.length > maxChars && lines.length > 1) {
+      lines.pop();
+      lineClips.pop();
+      shown--;
+      truncated = true;
+      truncatedBy = "max_chars";
+      text = assemble();
+    }
     return {
       ...meta, total, candidates: candidates.length, matched: matched.length, shown, truncated,
-      text: `${header}\n${body}${tail}`,
+      // #809: expose the CAUSE structurally too, so a caller that reads fields rather
+      // than prose still learns which lever applies.
+      truncated_by: truncatedBy,
+      text,
     };
   },
 
@@ -6685,7 +7014,9 @@ const GRAPH_TOOL_EXECUTORS = {
     limit,
   } = {}) {
     const { graph } = getGraphCtx();
-    const cap = Math.min(Math.max(Number(limit ?? 40), 1), 200);
+    // #809: the clamp and the remedy's stated ceiling come from ONE constant, so a hint
+    // can never quote a ceiling the runtime does not enforce.
+    const cap = Math.min(Math.max(Number(limit ?? 40), 1), LIMIT_CEILING);
     const lc = (s) => String(s ?? "").toLowerCase();
     // Safe stringify for widget values — a BigInt or circular/custom value would
     // throw in JSON.stringify and fail the whole find call; fall back to String().
@@ -6702,6 +7033,8 @@ const GRAPH_TOOL_EXECUTORS = {
 
     const nodes = graph._nodes ?? [];
     const matches = [];
+    /** #809: true only when a (cap+1)-th match was actually found — the proof of a cut. */
+    let overCap = false;
     for (const node of nodes) {
       const summary = summarizeNode(node);
       const desc = nodeDescription(node);
@@ -6767,19 +7100,44 @@ const GRAPH_TOOL_EXECUTORS = {
         matchedOn.push(...hits);
       }
 
+      // #809 (codex gate): stopping AT the cap cannot distinguish "exactly `limit`
+      // matches" from "capped", so a graph with exactly 40 hits was told there "may be
+      // MORE" — a false instruction in the other direction. Take ONE past the cap and
+      // drop it: the extra match is the proof, and its absence is proof of completeness.
       matches.push({
         ...summary,
         ...(desc ? { description: desc.slice(0, 240) } : {}),
         ...(matchedOn.length ? { matched_on: matchedOn } : {}),
       });
-      if (matches.length >= cap) break;
+      if (matches.length > cap) {
+        matches.pop();
+        overCap = true;
+        break;
+      }
     }
 
     return {
       viewing: describeActiveGraph(graph),
       total: nodes.length,
       count: matches.length,
-      truncated: matches.length >= cap,
+      truncated: overCap,
+      // #809: the scan STOPS once it knows there is more, so `count` is not a match total
+      // and the absent matches are not "no more matches". Say both, and name the real
+      // lever + ceiling — a bare boolean here is what let panel_find_nodes' description
+      // claim it never truncated in the first place.
+      ...(overCap
+        ? {
+            truncation_hint:
+              `The scan stopped at \`limit\`=${cap} after ${matches.length} match(es); ` +
+              `there may be MORE matches it never reached, so this is not evidence a node is absent. ` +
+              // #809 (codex gate): at the ceiling, "raise limit" is itself a dead retry.
+              `${
+                cap >= LIMIT_CEILING
+                  ? `\`limit\` is already at its ceiling of ${LIMIT_CEILING}, so narrow with \`type\`/\`title\`/\`widget_value\` instead`
+                  : `Raise \`limit\` up to ${LIMIT_CEILING}, or narrow with \`type\`/\`title\`/\`widget_value\``
+              }.`,
+          }
+        : {}),
       matches,
     };
   },
@@ -6794,6 +7152,19 @@ const GRAPH_TOOL_EXECUTORS = {
       subgraph_of: { node_id: node.id, title: node.title },
       node_count: inner.length,
       truncated: inner.length > MAX_STATE_NODES,
+      ...(inner.length > MAX_STATE_NODES
+        ? {
+            truncation_hint: fixedCapNote(
+              "inner node(s)",
+              MAX_STATE_NODES,
+              inner.length,
+              // Honest about the follow-up's OWN ceiling (codex gate): panel_query_graph
+              // clamps limit at 200 and has no cursor, so on a >200-node subgraph it is a
+              // way to read MORE, not a way to read all.
+              "panel_enter_subgraph into it, then panel_query_graph — which takes limit (max 200) and max_chars. It has no cursor, so beyond 200 inner nodes use its types/where filters to work through them.",
+            ),
+          }
+        : {}),
       nodes: inner.slice(0, MAX_STATE_NODES).map(summarizeNode),
     };
   },
@@ -8601,7 +8972,17 @@ const GRAPH_TOOL_EXECUTORS = {
       node_count: nodes.length,
       errored_count: erroredNodes.length,
       nodes: erroredNodes.slice(0, MAX_STATE_NODES),
-      ...(erroredNodes.length > MAX_STATE_NODES ? { truncated: true } : {}),
+      ...(erroredNodes.length > MAX_STATE_NODES
+        ? {
+            truncated: true,
+            truncation_hint: fixedCapNote(
+              "errored node(s)",
+              MAX_STATE_NODES,
+              erroredNodes.length,
+              "Fix these first and re-check, or inspect specific ids with panel_query_graph {ids:[…], fields:'detail'}.",
+            ),
+          }
+        : {}),
       ...(staleRedFlags.length
         ? {
             stale_flags: staleRedFlags.slice(0, MAX_STATE_NODES).map((n) => ({
@@ -8610,7 +8991,17 @@ const GRAPH_TOOL_EXECUTORS = {
               reasons: [],
               note: "LiteGraph still shows this red outline, but no current execution, validation, or asset source confirms an error.",
             })),
-            ...(staleRedFlags.length > MAX_STATE_NODES ? { stale_flags_truncated: true } : {}),
+            ...(staleRedFlags.length > MAX_STATE_NODES
+              ? {
+                  stale_flags_truncated: true,
+                  stale_flags_truncation_hint: fixedCapNote(
+                    "stale red-outline node(s)",
+                    MAX_STATE_NODES,
+                    staleRedFlags.length,
+                    "These are cosmetic leftovers, not errors; there is no parameter to page them.",
+                  ),
+                }
+              : {}),
           }
         : {}),
       ...(missingModels.length ? { missing_models: missingModels } : {}),

--- a/web/js/lib/graph-read.js
+++ b/web/js/lib/graph-read.js
@@ -18,6 +18,28 @@
  *  to identify a value, small enough that one blob can't starve a whole query. */
 export const WIDGET_VALUE_CAP = 2048;
 
+// #809: the REAL clamps for panel_query_graph / panel_graph_outline, exported so every
+// remedy string below quotes a ceiling the runtime actually enforces. A hint that names
+// a ceiling nobody honours sends the caller at a value that is silently clamped, which
+// reads back to them as "this tool cannot do it".
+export const LIMIT_CEILING = 200;
+export const MAX_CHARS_CEILING = 60000;
+export const MAX_CHARS_FLOOR = 500;
+/** Widget values are clipped to this in the `compact` projection (a FIXED cap). */
+export const COMPACT_VALUE_CLIP = 60;
+
+/**
+ * #809 (codex gate): "raise `X` up to N" is ITSELF a dead retry when the caller is
+ * already at N, and "raise `X`" with no ceiling leaves them guessing how far. Both cost
+ * the round trip this issue exists to prevent. One helper so every marker — inline or
+ * tail — states the same true thing. Mirrors the orchestrator twin in graph-query.ts.
+ */
+export function raiseOrCeiling(param, inForce, ceiling) {
+  return typeof inForce === "number" && inForce >= ceiling
+    ? `\`${param}\` is already at its ceiling of ${ceiling}`
+    : `raise \`${param}\` (up to ${ceiling})`;
+}
+
 /** Map of widget-name → { node_id, output_slot } for every input on `node` that is
  *  connected by a link. A widget whose name matches such an input is driven by that
  *  link at execution — its stored `w.value` is stale (#607). Never throws. */
@@ -60,15 +82,26 @@ export function drivenTag(src) {
  *  escape to 6 chars each, not 2. Returns the value unchanged when it already fits;
  *  otherwise the longest head prefix whose encoding fits `cap`, with an honest marker
  *  naming how many raw chars were dropped. */
-export function capWidgetValue(value, cap = WIDGET_VALUE_CAP) {
+export function capWidgetValue(value, cap = WIDGET_VALUE_CAP, maxChars = Infinity) {
   if (value == null) return value;
   const isString = typeof value === "string";
   const s = isString ? value : (() => { try { return JSON.stringify(value); } catch { return String(value); } })();
   if (typeof s !== "string") return value;
   if (JSON.stringify(s).length <= cap) return value;
-  // Binary-search the longest raw prefix whose ESCAPED length fits, reserving room
-  // for the marker (itself plain ASCII, so its escaped size ≈ its length).
-  const target = Math.max(2, cap - 40);
+  // #809: name the lever that ACTUALLY applies. capSummaryWidgets() tightens the
+  // per-value cap to the char budget only when the budget is the smaller of the two, so
+  // `cap < WIDGET_VALUE_CAP` ⟺ max_chars is what cut this value and raising it helps. At
+  // the FIXED 2048 cap raising max_chars does nothing, and saying so stops the caller
+  // burning a retry on a parameter that cannot move this.
+  const remedy =
+    cap < WIDGET_VALUE_CAP
+      ? `over the \`max_chars\` budget; ${raiseOrCeiling("max_chars", maxChars, MAX_CHARS_CEILING)}`
+      : `at the ${WIDGET_VALUE_CAP}-char per-widget cap, which \`max_chars\` does not raise`;
+  const marker = (dropped) => `…(+${dropped} chars cut ${remedy})`;
+  // Binary-search the longest raw prefix whose ESCAPED length fits, reserving EXACTLY
+  // the marker's own worst-case size (its digit count is bounded by s.length) rather
+  // than a fixed 40 — a longer, more useful marker must not be able to breach `cap`.
+  const target = Math.max(2, cap - marker(s.length).length);
   let lo = 0;
   let hi = s.length;
   let best = 0;
@@ -77,7 +110,7 @@ export function capWidgetValue(value, cap = WIDGET_VALUE_CAP) {
     if (JSON.stringify(s.slice(0, mid)).length <= target) { best = mid; lo = mid + 1; }
     else hi = mid - 1;
   }
-  return `${s.slice(0, best)}…(+${s.length - best} chars, truncated)`;
+  return `${s.slice(0, best)}${marker(s.length - best)}`;
 }
 
 /** Clip a KEY/name to a small bound (#609) — node/widget/input names are short
@@ -117,7 +150,7 @@ export function capSummaryWidgets(summary, cap = WIDGET_VALUE_CAP, totalCap = In
     const [rawKey, v] = entries[i];
     const k = capKey(rawKey);
     if (k !== rawKey) changed = true;
-    const capped = capWidgetValue(v, perValueCap);
+    const capped = capWidgetValue(v, perValueCap, totalCap);
     if (capped !== v) changed = true;
     const size = entrySize(k, capped);
     // Keep at least one widget, then stop once the total would exceed the budget.
@@ -129,7 +162,12 @@ export function capSummaryWidgets(summary, cap = WIDGET_VALUE_CAP, totalCap = In
     widgets[k] = capped;
     used += size;
   }
-  if (omitted > 0) widgets["…"] = `${omitted} widget(s) omitted (exceeded budget); raise max_chars`;
+  // #809: backtick the lever (so the schema-driven remedy test can see it) and state
+  // how many remain — the caller needs "how much is left", not just "some".
+  if (omitted > 0)
+    widgets["…"] =
+      `${omitted} more widget(s) cut by the \`max_chars\` budget; ` +
+      raiseOrCeiling("max_chars", totalCap, MAX_CHARS_CEILING);
   return changed ? { ...summary, widgets } : summary;
 }
 
@@ -139,7 +177,13 @@ export function capSummaryWidgets(summary, cap = WIDGET_VALUE_CAP, totalCap = In
  *  tail ellipsis is safe (unlike detail's JSON, which is bounded via capSummaryWidgets). */
 export function clipLine(line, maxChars) {
   if (!Number.isFinite(maxChars) || line.length <= maxChars) return line;
-  return line.slice(0, Math.max(0, maxChars - 1)) + "…";
+  // #809: a bare "…" told the caller nothing. Say how much was cut and name the lever
+  // (raising max_chars genuinely lifts THIS cut). The reserve is the marker's own
+  // worst-case size, so the clipped line still respects maxChars.
+  const marker = (dropped) =>
+    `…(+${dropped} chars over \`max_chars\`; ${raiseOrCeiling("max_chars", maxChars, MAX_CHARS_CEILING)})`;
+  const keep = Math.max(0, maxChars - marker(line.length).length);
+  return line.slice(0, keep) + marker(line.length - keep);
 }
 
 /** Final guard for a DETAIL (JSON) line (#609): if a node's fully-capped detail STILL
@@ -159,11 +203,11 @@ export function fitDetailLine(line, stub, maxChars) {
   };
   const s = JSON.stringify({
     ...safe,
-    detail_omitted: `full detail is ${line.length} chars > max_chars ${maxChars}; raise max_chars to read this node`,
+    detail_omitted: `full detail is ${line.length} chars > \`max_chars\` ${maxChars}; ${raiseOrCeiling("max_chars", maxChars, MAX_CHARS_CEILING)} to read this node`,
   });
   if (s.length <= maxChars) return s;
   // Absurdly small budget: a minimal fixed-shape row (id clipped hard) that still identifies the node.
-  return JSON.stringify({ id: typeof safe.id === "string" ? safe.id.slice(0, 40) : safe.id, detail_omitted: "raise max_chars" });
+  return JSON.stringify({ id: typeof safe.id === "string" ? safe.id.slice(0, 40) : safe.id, detail_omitted: "raise `max_chars`" });
 }
 
 /** Whether a line must render regardless of the remaining char budget (#609): ONLY
@@ -175,11 +219,164 @@ export function isLineProtected(shownSoFar) {
   return shownSoFar === 0;
 }
 
-/** Build the truncation-tail advice (#609). When the caller passed explicit `ids`,
- *  "narrow with ids" is a dead end — advise raising max_chars / fewer ids instead. */
-export function truncationTail(shown, matchedCount, hasExplicitIds) {
-  if (hasExplicitIds) {
-    return `\n… truncated at ${shown} of ${matchedCount} — requested nodes exceed max_chars (per-field values are already capped); raise max_chars or request fewer ids at once.`;
-  }
-  return `\n… truncated at ${shown} of ${matchedCount} — narrow with types/where/ids/depth, use group_by:"type", or raise limit/max_chars.`;
+/**
+ * Build the truncation-tail advice (#609, rewritten for #809).
+ *
+ * `limit` and `max_chars` are DIFFERENT cuts with OPPOSITE remedies: raising `limit`
+ * on a char-budget cut only makes the overflow worse. The pre-#809 tail listed both
+ * ("raise limit/max_chars") and left the caller to guess which one applied — and the
+ * orchestrator twin listed only `limit`, which is outright wrong on the budget path.
+ * Name the cap that ACTUALLY fired, with its REAL ceiling, and say plainly that the
+ * other one will not help, so nobody can burn a retry proving "the tool can't do this".
+ *
+ * `truncatedBy` is "limit" | "max_chars"; `caps` carries the values in force.
+ */
+export function truncationTail(shown, matchedCount, hasExplicitIds, truncatedBy, caps = {}) {
+  const at = (v) => (typeof v === "number" && Number.isFinite(v) ? `=${v}` : "");
+  const byLimit = truncatedBy === "limit";
+  const inForce = byLimit ? caps.limit : caps.maxChars;
+  const ceiling = byLimit ? LIMIT_CEILING : MAX_CHARS_CEILING;
+  const param = byLimit ? "limit" : "max_chars";
+  // "raise X up to N" is itself a dead retry at N (codex gate) — at the ceiling the
+  // remedy has to switch to what is actually left.
+  const raise =
+    typeof inForce === "number" && inForce >= ceiling
+      ? `\`${param}\` is already at its ceiling of ${ceiling}, so raising it is not an option`
+      : `raise \`${param}\` up to ${ceiling}`;
+  const other = byLimit
+    ? "`max_chars` is not the constraint here."
+    : "Raising `limit` will not help.";
+  const narrow = hasExplicitIds
+    ? "request fewer `ids` at once"
+    : 'narrow with `types`/`where`/`ids`/`depth`, or count with `group_by`:"type"';
+  const cutBy = `\`${param}\`${at(inForce)}${!byLimit && hasExplicitIds ? " (per-field values are already capped)" : ""}`;
+  const subject = hasExplicitIds ? " requested node(s)" : "";
+  return `\n… truncated at ${shown} of ${matchedCount}${subject} by ${cutBy} — ${raise}, or ${narrow}. ${other}`;
+}
+
+/** #809: clip() for the COMPACT projection, reporting whether it actually cut — so ONE
+ *  footer note can name the lever (`fields`:"detail") instead of leaving a bare "…" on
+ *  every value. The 60-char clip itself is FIXED; no parameter raises it. */
+export function clipCompactValue(v, n = COMPACT_VALUE_CLIP) {
+  const s = String(typeof v === "string" ? v : JSON.stringify(v) ?? "").replace(/\s+/g, " ");
+  return s.length > n ? { text: s.slice(0, n - 1) + "…", clipped: true } : { text: s, clipped: false };
+}
+
+/** #809: the one-line footer for compact rows whose values were clipped. */
+export function compactClipNote(count) {
+  if (!count) return "";
+  return `\n(${count} widget value(s) clipped to ${COMPACT_VALUE_CLIP} chars by \`fields\`:"compact" — read fuller values with \`fields\`:"detail", which caps values at ${WIDGET_VALUE_CAP} chars.)`;
+}
+
+// ---------------------------------------------------------------------------
+// #809: panel_graph_outline's budget — degrade by RESOLUTION, never by coverage.
+// ---------------------------------------------------------------------------
+//
+// The outline exists so an agent can UNDERSTAND a whole graph; a budget that stopped
+// partway would defeat that outright. Half a map is not a smaller map: an agent handed
+// the first 200 of 690 nodes cannot tell what it is missing and will reason confidently
+// about a graph it has seen a third of. So every rung below still describes the WHOLE
+// graph, and the ladder sheds DETAIL:
+//
+//   0 "full"     — every node, widgets + wiring (today's outline)
+//   1 "no_values"— every node, widget NAMES only (values are the bulk of the bytes)
+//   2 "no_widgets" — every node, id/type/title/mode/group + wiring
+//   3 "ids_only" — every node, id + type only, wiring dropped
+//   4 "groups"   — per-group counts and representative types; the floor
+//
+// If even rung 4 does not fit, that is a REFUSAL with a stated reason, not a partial
+// dump — see outlineFloorRefusal().
+export const OUTLINE_MAX_CHARS_FLOOR = MAX_CHARS_FLOOR;
+export const OUTLINE_MAX_CHARS_DEFAULT = 24000;
+export const OUTLINE_MAX_CHARS_CEILING = MAX_CHARS_CEILING;
+
+/** The ladder, most detailed first. Exported for the panel executor and its tests. */
+export const OUTLINE_DETAIL_LEVELS = ["full", "no_values", "no_widgets", "ids_only", "groups"];
+
+/** Clamp an outline budget to the SAME window panel_query_graph uses. */
+export function clampOutlineMaxChars(v) {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return OUTLINE_MAX_CHARS_DEFAULT;
+  return Math.min(Math.max(Math.floor(n), OUTLINE_MAX_CHARS_FLOOR), OUTLINE_MAX_CHARS_CEILING);
+}
+
+/** The banner that rides ON the outline itself when a rung below "full" was used. It
+ *  must state the TRUE shape (counts are always real) and the lever, because the
+ *  outline string is often the only part of the reply a model reads closely. */
+export function outlineDegradeBanner({ level, nodeCount, groupCount, maxChars }) {
+  const why = {
+    no_values: "widget VALUES dropped (names kept)",
+    no_widgets: "widgets dropped entirely (wiring kept)",
+    ids_only: "reduced to id + type per node (wiring dropped)",
+    groups: "collapsed to a per-group summary",
+  }[level];
+  if (!why) return "";
+  return (
+    `⚠ REDUCED DETAIL (${level}): ${why}, to fit \`max_chars\`=${maxChars}. ` +
+    `COVERAGE IS COMPLETE — all ${nodeCount} node(s) and ${groupCount} group(s) are represented and these counts are exact; ` +
+    `nothing was cut off the end. ` +
+    (maxChars >= OUTLINE_MAX_CHARS_CEILING
+      ? `\`max_chars\` is already at its ceiling of ${OUTLINE_MAX_CHARS_CEILING}, so this is the most detail one call can carry — `
+      : `Raise \`max_chars\` up to ${OUTLINE_MAX_CHARS_CEILING} for more detail, or `) +
+    `read specific nodes with panel_query_graph {ids:[…], fields:'detail'}.`
+  );
+}
+
+/** #809: even the FULL outline rung clips each widget value at a fixed 60 chars. That
+ *  clip has no lever, so the note names the tool that carries fuller values instead of
+ *  pretending `max_chars` would help — the outline's coverage claim is about NODES, and
+ *  this keeps it from reading as a claim about VALUES too. */
+/**
+ * #809: ONE footer covering every fixed per-field clip in the outline — widget values
+ * and titles alike. Per-field markers would be noise at 690 nodes; the count plus the
+ * lever belongs here, once.
+ *
+ * "Read FULL values" would over-promise: panel_query_graph's detail projection has its
+ * own fixed 2048-char per-widget cap (codex gate). Say "fuller, up to N".
+ */
+export function outlineValueClipNote(valueCount, titleCount = 0) {
+  if (!valueCount && !titleCount) return "";
+  const parts = [];
+  if (valueCount) parts.push(`${valueCount} widget value(s) clipped to ${COMPACT_VALUE_CLIP} chars`);
+  if (titleCount) parts.push(`${titleCount} title(s) clipped to ${OUTLINE_TITLE_CAP} chars`);
+  return `\n\n(${parts.join(" and ")} — fixed outline caps that \`max_chars\` does not raise. Read fuller values with panel_query_graph {ids:[…], fields:'detail'}, which caps each value at ${WIDGET_VALUE_CAP} chars.)`;
+}
+
+/** Group/subgraph titles are user-controlled and unbounded. */
+export const OUTLINE_TITLE_CAP = 120;
+
+/** #809: group/subgraph/node TITLES are user-controlled and unbounded, so an outline
+ *  built from them could breach `max_chars` no matter which rung the ladder chose (codex
+ *  gate). Every title that reaches the outline goes through here first.
+ *
+ *  Returns `{ text, clipped }` rather than a bare string so the caller can COUNT the
+ *  clips and raise the one footer above — a bare "…" per title would be exactly the
+ *  signal-free marker this issue exists to remove. Two long titles sharing a 120-char
+ *  prefix become indistinguishable in the per-node `group:` tag; group MEMBERSHIP is
+ *  keyed by node id and is unaffected, and the GROUPS index still lists ids per group,
+ *  so nothing downstream resolves a group by its displayed label. */
+export function clipOutlineTitle(title, cap = OUTLINE_TITLE_CAP) {
+  const s = String(title ?? "").replace(/\s+/g, " ");
+  return s.length > cap ? { text: `${s.slice(0, cap)}…`, clipped: true } : { text: s, clipped: false };
+}
+
+/** When not even the group-level floor fits, refuse WITH the true shape rather than
+ *  emitting a partial graph that reads as complete (#809). */
+export function outlineFloorRefusal({ nodeCount, groupCount, maxChars, floorChars }) {
+  // #809 (codex gate): raising to the ceiling is only a remedy if the ceiling could
+  // actually hold the floor. On a graph whose per-group summary alone exceeds 60000,
+  // "raise max_chars up to 60000" is a guaranteed second refusal — a dead retry inside
+  // the message explaining the first one.
+  const unreachable = Number.isFinite(floorChars) && floorChars > OUTLINE_MAX_CHARS_CEILING;
+  const remedy = unreachable
+    ? `Even \`max_chars\`'s ceiling of ${OUTLINE_MAX_CHARS_CEILING} could not hold it, so raising it will NOT produce an outline for this graph — read it in parts with panel_query_graph (filter by types/where, or by group member ids).`
+    : maxChars >= OUTLINE_MAX_CHARS_CEILING
+      ? `\`max_chars\` is already at its ceiling of ${OUTLINE_MAX_CHARS_CEILING}, so query a subset with panel_query_graph instead.`
+      : `Raise \`max_chars\` (up to ${OUTLINE_MAX_CHARS_CEILING}), or query a subset with panel_query_graph.`;
+  return (
+    `⚠ CANNOT RENDER an outline within \`max_chars\`=${maxChars}: the smallest whole-graph ` +
+    `form (a per-group summary) needs ~${floorChars} chars for this graph's ${nodeCount} node(s) ` +
+    `and ${groupCount} group(s). A PARTIAL outline is deliberately NOT returned — it would look ` +
+    `complete and it is not. ${remedy}`
+  );
 }


### PR DESCRIPTION
Panel half of **artokun/comfyui-mcp#809**. Orchestrator PR: **artokun/comfyui-mcp#818**.

> **Land artokun/comfyui-mcp#818 FIRST.** It is the surface that advertises this behaviour, and it degrades honestly against a panel that predates this change (it detects a panel that ignored `max_chars` and says so). This PR without it is inert; the reverse is not.

## Why

A truncation marker is an instruction to a machine. An agent that hits a **silent** cap concludes the *tool* cannot do the thing and escalates to the human instead of retrying wider. Observed live on a 690-node graph.

## `graph_query` — converged with the orchestrator engine

The two engines had **diverged on the exact defect the issue is about**. The twin's tail said "raise limit/max_chars" and left the caller to guess which applied; the orchestrator's said only "limit", which is outright wrong on the char-budget path.

Both now name the cap that **actually fired**, with its real ceiling, and say plainly that the other lever will not help. `truncated_by` exposes the cause structurally. The whole result — rows, tail and footers — is fitted inside `max_chars` **afterwards** rather than appended past it, on the row and aggregate paths alike, so a result that fits is never falsely truncated.

## `graph_outline` — a `max_chars` that degrades by RESOLUTION, never coverage

Per the maintainer's ruling. Half a map is not a smaller map: an agent handed the first 200 of 690 nodes cannot tell what it is missing and will reason confidently about a graph it has seen a third of — the fabrication failure mode wearing a different hat.

So the new budget (same name and 500–60000 clamp as `panel_query_graph`, one lever to learn) walks a ladder that sheds **detail**:

1. `full` — every node, widgets + wiring
2. `no_values` — every node, widget **names** only
3. `no_widgets` — every node, id/type/title/mode/group + wiring
4. `ids_only` — every node, id + type
5. `groups` — per-group counts and representative types

**Every rung describes the whole graph, and the counts it reports are always the real ones.** If not even the floor fits it **REFUSES**, stating the true shape, rather than returning a partial outline that would read as complete. `detail_level` names the rung, `degraded_reason` says why, and `floor_chars` on a refusal lets the orchestrator tell "raise it and it will fit" from "no budget this tool accepts can hold it".

## The silent booleans

The `MAX_STATE_NODES` views (selected / viewport / subgraph / errors) reported only `truncated: true` — a **field, not prose**, so a model reading the result got no instruction at all. They now say they capped, at what number, that the cap is **FIXED** with no parameter to raise it, and name the tool that *can* target the rest.

**No new parameter was added**, per the ruling. A caller told *"you're seeing 100 of 690, this view has no adjustable limit — use `panel_query_graph` with `ids`/`upstream_of`"* is fully served.

## The inverse defect

`graph_find_nodes` inferred truncation from **reaching** the cap, so a graph with exactly `limit` matches was told "there may be more" — a wasted retry that teaches distrust of a complete result. It now takes one past the cap and drops it: the extra match is the proof, and its absence is the proof of completeness.

## Also

- Every user-controlled title (group, subgraph, **node**) is bounded before it reaches the outline — one long title would otherwise breach `max_chars` at every rung, which the ladder cannot fix by shedding detail elsewhere. The clips are counted into **one** footer rather than scattering signal-free ellipses through a 690-node read. Group **membership** is keyed by node id and is unaffected by the display clip.
- The `groups`/`rails` riders sit outside the `max_chars` accounting (**artokun/comfyui-mcp#807** owns folding them in). Until then they are bounded by their own fixed caps and say so in-band, with `node_count` still the true total so a clipped `node_ids` can never read as the whole membership.
- Fixed caps that no parameter raises (per-widget 2048, the 60-char compact/outline value clip) say exactly that, instead of pointing at a lever that cannot move them.

## Verification

- `npm run test:unit` — 1743 passed, 0 failed.
- New coverage in `browser_tests/unit/graph-read.test.mjs` and `browser_tests/unit/outline-coverage.test.mjs`, including a sweep asserting **no marker ever says "raise X" without saying how far**, and a structural guard that the outline handler can never slice the node list.
- 11 codex review rounds (`gpt-5.6-terra`) across both repos.
- No NUL bytes; no binary diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
