### PR TITLE
docs(panel): correct an overclaimed guarantee in the restart-resume warning (#585)

### DIFF
--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -19713,12 +19713,22 @@ function buildPanel() {
     // WRITE-AHEAD, and VERIFY. The attempt is recorded BEFORE it can happen, and the
     // write is read back. `ssSet` returning is not evidence it persisted — quota,
     // private mode and eviction all fail silently — and an increment that didn't
-    // stick reads back as "no attempt yet", so a retry after a reload would go out
-    // as a first attempt with no warning. This is the same shape as sent-vs-received
-    // one layer down: written is not persisted. A failed record therefore ALSO
-    // raises the warning, on this attempt and every later one, because if storage
-    // cannot count attempts we must assume there may have been one. A warning
-    // wrongly present is harmless; its absence is not.
+    // stick reads back as "no attempt yet", so a retry would go out as a first
+    // attempt with no warning. This is the same shape as sent-vs-received one layer
+    // down: written is not persisted. A failed record therefore ALSO raises the
+    // warning, because if storage cannot count attempts we must assume there may
+    // have been one. A warning wrongly present is harmless; its absence is not.
+    //
+    // SCOPE OF THAT GUARANTEE — it holds for the LIFE OF THIS MOUNT, not forever.
+    // If the record fails, the message nonetheless reaches the orchestrator, storage
+    // then recovers, and the frontend reloads, the new mount reads a real (merely
+    // stale) zero and cannot know a nudge already went out — so its next attempt is
+    // an undisclosed duplicate continuation. Doing better would mean durably
+    // recording "a write failed" at the exact moment storage is refusing to durably
+    // record anything; the only alternative is to warn on every post-reload resume,
+    // which trains the agent to ignore the warning. Accepted and documented in the
+    // PR as a sessionStorage-class residual — the outcome is a duplicate NUDGE, not
+    // a duplicate render.
     const retained = rebootMarkerAfterSend(step, false);
     let attemptRecorded = true;
     if (retained) {

--- a/web/js/lib/restart-resume.js
+++ b/web/js/lib/restart-resume.js
@@ -265,6 +265,14 @@ export function planRebootResume(state = {}) {
  * one redundant sentence; a warning wrongly absent is an undisclosed duplicate
  * "continue", which is the hazard this whole fix exists to prevent.
  *
+ * The caller supplies `attemptRecorded`, and that evidence is MOUNT-LOCAL: a count
+ * whose write failed, whose message landed anyway, and whose storage later
+ * recovered reads back after a reload as a real — merely stale — zero, and this
+ * returns false for it. That residual is accepted and documented in the PR rather
+ * than fixed, because closing it means durably recording a failure at the moment
+ * storage refuses to record durably, and the only alternative is warning on every
+ * post-reload resume.
+ *
  * @param {{totalAttempts?:unknown, attemptRecorded?:boolean, sentThisMount?:number}} state
  * @returns {boolean}
  */


### PR DESCRIPTION
Comment-only. No behaviour change.

#597 merged with a source comment (and a doc comment on the function implementing the guard) claiming
the duplicate-nudge warning is raised "on this attempt and every later one". That is not what the code
provides, and the gap was found by review after the merge landed:

> marker at `t:0, ts:0` → attempt A's count write fails but its message reaches the orchestrator →
> storage recovers and the panel reloads → the new mount resets its broken-storage flag, reads the
> stale zero counts, records attempt B successfully, and computes `repeat === false`.

Attempt B is then an undisclosed duplicate continuation nudge. The guarantee holds for the life of the
mount, not indefinitely.

This corrects the wording at both implementation sites to match. The behaviour itself is a **documented
residual** (see #597's body): fixing it would require durably recording "a write failed" at the moment
storage is refusing to durably record anything, and the only alternative — warning on every
reboot-resume after any reload — is the cry-wolf outcome the design deliberately avoids.

Worth stating explicitly, because it is the likeliest thing for a future reader to get wrong: this is
**not** the unknown-vs-zero fold fixed elsewhere in #597. No value is absent here. The stored zero is
real and merely stale, so pattern-matching it to the already-fixed defect and "fixing" it again would
be a mistake.

Follows #585, #597.
