### PR TITLE
CRITICAL: mutations reach the WRONG graph — nodes deleted from another workflow, writes reported not-applied that were applied

### DIFF
--- a/browser_tests/unit/canvas-graph-divergence.test.mjs
+++ b/browser_tests/unit/canvas-graph-divergence.test.mjs
@@ -1,0 +1,419 @@
+/**
+ * Unit tests for the "mutations reach the wrong graph" family — #604 / #603 /
+ * #616 / #374 — run with `node --test`.
+ *
+ * THE SHARED INVARIANT
+ * --------------------
+ * A graph command may only run on a canvas whose identity the panel can PROVE,
+ * and a MUTATION may never run on evidence that would not satisfy a READ.
+ *
+ * The panel broke that invariant in the two places where a graph command picks
+ * its target and checks it, and both breaks read a value computed for one
+ * purpose as the answer to a different question:
+ *
+ *  1. `resolveScope` / `getGraphCtx` MANUFACTURED a binding. "The canvas graph is
+ *     not reachable from app.graph" was computed to mean "the canvas still points
+ *     at a SUBGRAPH the rebuilt root no longer owns" (#220/#308) — a ghost that
+ *     holds none of the workflow, so reconciling the view to root loses nothing.
+ *     It was then read as "the canvas graph is garbage, replace it", and the
+ *     repair (`app.canvas.setGraph(app.graph)`) ran for the ROOT-LEVEL case too.
+ *     #604's follow-up report is exactly that: after a backend restart with no
+ *     page reload, `app.graph` was empty while the canvas held the user's unsaved
+ *     ~31-node graph; the panel pointed the canvas at the empty root, the 31-node
+ *     graph became unreferenced ("the memory-only graph was unrecoverable"), and
+ *     every downstream guard was then handed a self-consistent
+ *     (app.graph, activeWorkflow) pair that said nothing about the canvas the
+ *     command was issued for. The evidence was destroyed before it could be
+ *     reported.
+ *
+ *  2. The binding EVIDENCE BAR was lower for mutations than for reads. The bridge
+ *     dispatch fence hard-coded `includeBaselineReadGuard: false` for every
+ *     command and only the read executors re-asserted with it on. So the exact
+ *     evidence that made `graph_outline` refuse — "the active workflow reports
+ *     N>0 nodes but the live root reads empty" — let `graph_remove_node` through.
+ *     That is #604's title verbatim: reads blocked, mutations still routed to the
+ *     wrong workflow tab and deleted nodes from it.
+ *
+ * FAIL-before / PASS-after: with the old resolveScope the divergence test below
+ * sees `stale: true`, getGraphCtx repaints the canvas and returns normally, so
+ * both the refusal and the "user's graph still mounted" assertions fail. With the
+ * old dispatch bar the mutation-symmetry test sees a `null` verdict for every
+ * mutating command on evidence a read refuses.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  graphIsSubgraphLike,
+  resolveScope,
+  SUBGRAPH_INPUT_RAIL_ID,
+  SUBGRAPH_OUTPUT_RAIL_ID,
+} from "../../web/js/lib/subgraph-scope.js";
+import {
+  graphBindingRefusalMessage,
+  graphCommandBindingBar,
+  graphCommandMayMutateWorkflow,
+  resolveGraphBindingVerdict,
+  MUTATION_BINDING_BAR,
+} from "../../web/js/lib/graph-binding.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+function panelFunctionSource(src, name, nextName) {
+  const start = src.indexOf(`function ${name}(`);
+  const end = src.indexOf(`function ${nextName}(`, start);
+  assert.notEqual(start, -1, `could not locate ${name} in panel source`);
+  assert.notEqual(end, -1, `could not locate ${nextName} after ${name}`);
+  return src.slice(start, end);
+}
+
+/** The panel's REAL getGraphCtx, with only its ambient globals injected, so the
+ *  refusal AND the absence of the destructive repaint are both observable. */
+function buildGetGraphCtx(app) {
+  const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+  const source = panelFunctionSource(src, "getGraphCtx", "workflowOwnsRootUuidTag");
+  return new Function(
+    "app",
+    "window",
+    "resolveScope",
+    `${source}\nreturn getGraphCtx;`,
+  )(app, { LiteGraph: {} }, resolveScope);
+}
+
+function nodes(n, offset = 0) {
+  return Array.from({ length: n }, (_, i) => ({ id: i + 1 + offset, type: "Node" }));
+}
+
+/** A LiteGraph SUBGRAPH as this codebase already identifies one: boundary rails
+ *  (the same members resolveRailNode reads). */
+function subgraphObject({ nodes: inner = [] } = {}) {
+  return {
+    name: "sub",
+    inputNode: { id: SUBGRAPH_INPUT_RAIL_ID },
+    outputNode: { id: SUBGRAPH_OUTPUT_RAIL_ID },
+    inputs: [],
+    outputs: [],
+    _nodes: inner,
+  };
+}
+
+/** An `app` whose canvas points at `canvasGraph`; setGraph is COUNTED because
+ *  calling it at all is the destructive act under test. */
+function makeApp({ rootGraph, canvasGraph }) {
+  const app = {
+    graph: rootGraph,
+    canvas: {
+      graph: canvasGraph ?? rootGraph,
+      setGraphCalls: 0,
+      setGraph(g) {
+        this.setGraphCalls += 1;
+        this.graph = g;
+      },
+      setDirty() {},
+    },
+  };
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// graphIsSubgraphLike — the predicate that separates the two questions
+// ---------------------------------------------------------------------------
+
+test("graphIsSubgraphLike: POSITIVE subgraph evidence only (rails, or a foreign rootGraph back-pointer)", () => {
+  assert.equal(graphIsSubgraphLike(subgraphObject()), true, "boundary rails are subgraph evidence");
+  assert.equal(
+    graphIsSubgraphLike({ _nodes: [], _inputNode: { id: SUBGRAPH_INPUT_RAIL_ID } }),
+    true,
+    "the private rail members count too (resolveRailNode reads both forms)",
+  );
+  const root = { _nodes: [] };
+  assert.equal(
+    graphIsSubgraphLike({ _nodes: [], rootGraph: root }),
+    true,
+    "a rootGraph back-pointer naming a DIFFERENT graph is subgraph evidence",
+  );
+
+  const selfRooted = { _nodes: [] };
+  selfRooted.rootGraph = selfRooted;
+  assert.equal(
+    graphIsSubgraphLike(selfRooted),
+    false,
+    "a root LGraph is its own rootGraph — that is NOT subgraph evidence",
+  );
+  assert.equal(graphIsSubgraphLike({ _nodes: nodes(31) }), false, "a bare root-level graph");
+  assert.equal(graphIsSubgraphLike(null), false);
+  assert.equal(graphIsSubgraphLike("graph"), false);
+});
+
+// ---------------------------------------------------------------------------
+// resolveScope — divergence is its own verdict, and must NOT arm the repaint
+// ---------------------------------------------------------------------------
+
+test("#604: canvas and app.graph hold two different ROOT graphs ⇒ diverged, and stale stays FALSE", () => {
+  // The reported post-backend-restart state: app.graph empty, the canvas still
+  // holding the user's unsaved 31-node workflow.
+  const rootGraph = { _nodes: [] };
+  const canvasGraph = { _nodes: nodes(31) };
+  const scope = resolveScope(makeApp({ rootGraph, canvasGraph }));
+
+  assert.equal(scope.diverged, true, "a root-level canvas unreachable from app.graph is a DIVERGENCE");
+  assert.equal(
+    scope.stale,
+    false,
+    "stale is the caller's REPAINT trigger — arming it here is what discarded the user's graph",
+  );
+  assert.equal(
+    scope.graph,
+    canvasGraph,
+    "the reported graph is the one the user is looking at, not the one we could reach",
+  );
+  assert.equal(scope.rootGraph, rootGraph);
+});
+
+test("#220/#308 regression fence: a ghost SUBGRAPH still reconciles to root (stale, not diverged)", () => {
+  // A subgraph the REBUILT root neither owns via an owner node nor registers.
+  const rootGraph = { _nodes: [{ id: 1, type: "Node" }] };
+  const ghost = subgraphObject({ nodes: nodes(2, 100) });
+  const scope = resolveScope(makeApp({ rootGraph, canvasGraph: ghost }));
+
+  assert.equal(scope.stale, true, "the #220/#308 ghost must still reconcile to root");
+  assert.equal(scope.diverged, false, "a ghost subgraph is NOT the #604 root divergence");
+  assert.equal(scope.graph, rootGraph, "reads and edits both land on the live root");
+});
+
+test("resolveScope: an EMPTY diverged canvas is still a divergence — 'no content' is not proof of a good binding", () => {
+  // Both sides empty. There is no content to lose, but there is also no proof of
+  // which graph the command names — and "could not determine" must not become a
+  // verdict in either direction.
+  const scope = resolveScope(makeApp({ rootGraph: { _nodes: [] }, canvasGraph: { _nodes: [] } }));
+  assert.equal(scope.diverged, true);
+  assert.equal(scope.stale, false);
+});
+
+// ---------------------------------------------------------------------------
+// getGraphCtx — refuse the divergence; never repaint the user's canvas away
+// ---------------------------------------------------------------------------
+
+test("#604: getGraphCtx REFUSES a diverged canvas and leaves the user's live graph mounted", () => {
+  const rootGraph = { _nodes: [] };
+  const canvasGraph = { _nodes: nodes(31) };
+  const app = makeApp({ rootGraph, canvasGraph });
+  const getGraphCtx = buildGetGraphCtx(app);
+
+  assert.throws(
+    () => getGraphCtx(),
+    /\[canvas-root-divergence\][\s\S]*was NOT applied/,
+    "the divergence must be a loud, reasoned refusal — not a silently-picked graph",
+  );
+  assert.equal(
+    app.canvas.setGraphCalls,
+    0,
+    "the user's canvas must NOT be repainted: setGraph(app.graph) is what made the 31-node graph unrecoverable",
+  );
+  assert.equal(app.canvas.graph, canvasGraph, "the graph the user was editing is still mounted");
+});
+
+test("#604: the divergence refusal states BOTH candidate graphs and a remedy that actually rebinds", () => {
+  const app = makeApp({ rootGraph: { _nodes: nodes(4) }, canvasGraph: { _nodes: nodes(31) } });
+  const getGraphCtx = buildGetGraphCtx(app);
+  let message = "";
+  try {
+    getGraphCtx();
+  } catch (err) {
+    message = err.message;
+  }
+  assert.match(message, /31 node\(s\)/, "the canvas the user is looking at must be named");
+  assert.match(message, /4 node\(s\)/, "the bound root must be named");
+  assert.match(message, /reload the ComfyUI page/, "the remedy must be the one that rebuilds the binding");
+  assert.doesNotMatch(
+    message,
+    /panel_open_workflow/,
+    "open_workflow cannot rebuild this binding — recommending it produces the #603/#604 retry churn",
+  );
+});
+
+test("#220/#308 regression fence: getGraphCtx still reconciles a GHOST subgraph to root", () => {
+  const rootGraph = { _nodes: [{ id: 1, type: "Node" }] };
+  const ghost = subgraphObject({ nodes: nodes(2, 100) });
+  const app = makeApp({ rootGraph, canvasGraph: ghost });
+  const ctx = buildGetGraphCtx(app)();
+
+  assert.equal(ctx.graph, rootGraph);
+  assert.equal(app.canvas.setGraphCalls, 1, "the ghost view is reconciled so reads and edits stay in lockstep");
+  assert.equal(app.canvas.graph, rootGraph);
+});
+
+test("getGraphCtx: an ordinary root-bound canvas is untouched (no false refusal)", () => {
+  const rootGraph = { _nodes: nodes(3) };
+  const app = makeApp({ rootGraph, canvasGraph: rootGraph });
+  const ctx = buildGetGraphCtx(app)();
+  assert.equal(ctx.graph, rootGraph);
+  assert.equal(ctx.rootGraph, rootGraph);
+  assert.equal(app.canvas.setGraphCalls, 0);
+});
+
+test("getGraphCtx: a VALID open subgraph keeps subgraph scope (no false refusal)", () => {
+  const sub = subgraphObject({ nodes: nodes(2, 100) });
+  const rootGraph = { _nodes: [{ id: 7, type: "SubgraphNode", subgraph: sub }] };
+  const app = makeApp({ rootGraph, canvasGraph: sub });
+  const ctx = buildGetGraphCtx(app)();
+  assert.equal(ctx.graph, sub, "the user is inside the subgraph; reads and edits target it");
+  assert.equal(ctx.rootGraph, rootGraph);
+  assert.equal(app.canvas.setGraphCalls, 0);
+});
+
+// ---------------------------------------------------------------------------
+// The evidence bar: a mutation may never clear a LOWER bar than a read
+// ---------------------------------------------------------------------------
+
+/**
+ * The evidence in which ONLY the baseline read guard can fire, which is what
+ * made the read/mutation asymmetry reachable rather than theoretical: a live
+ * root that exposes no `_nodes` ARRAY at all (a half-rebuilt root after a
+ * backend restart). `graphRootMismatchesActiveWorkflow` and
+ * `graphEmptyBindingUnproven` both bail out as inconclusive by design when the
+ * live node array is unreadable, so `graphReadDesynced` is the only predicate
+ * left — and gating it off for mutations left them with no fence at all.
+ */
+function halfRebuiltRootEvidence(expectedNodeCount = 3) {
+  return {
+    graph: {},
+    rootGraph: {}, // no _nodes array: unreadable, not "empty"
+    activeWorkflow: {
+      isModified: false,
+      changeTracker: { activeState: { nodes: nodes(expectedNodeCount) } },
+    },
+    activeWorkflowUuid: "workflow-A",
+    liveNodeCount: 0,
+    inSubgraph: false,
+    rootUuidMismatch: false,
+  };
+}
+
+// What a READ tool asks for inside its own executor (graph_outline, graph_get_errors).
+const READ_EXECUTOR_BAR = { includeBaselineReadGuard: true, requireDirtyMutationBinding: false };
+
+const MUTATING_GRAPH_COMMANDS = [
+  "graph_add_node",
+  "graph_remove_node",
+  "graph_connect",
+  "graph_set_widget",
+  "graph_edit_node",
+  "graph_move_node",
+  "graph_clear",
+  "graph_load",
+  "graph_run",
+  "graph_future_command", // unknown commands fail closed as mutations
+];
+
+test("#604: a mutation may never clear a LOWER binding bar than a read", () => {
+  const evidence = halfRebuiltRootEvidence(3);
+
+  const readVerdict = resolveGraphBindingVerdict({ ...evidence, ...READ_EXECUTOR_BAR });
+  assert.ok(readVerdict, "graph_outline refuses this canvas — that is the #389/#604 read guard");
+  assert.equal(readVerdict.reason, "root-node-count-desync");
+
+  for (const cmd of MUTATING_GRAPH_COMMANDS) {
+    const verdict = resolveGraphBindingVerdict({ ...evidence, ...graphCommandBindingBar(cmd) });
+    assert.ok(
+      verdict,
+      `${cmd} must be refused on evidence a read refuses — this is #604: reads blocked, ` +
+        `mutations still routed to the wrong canvas and deleted nodes from it`,
+    );
+    assert.equal(verdict.reason, "root-node-count-desync", `${cmd} must refuse for the READ guard's reason`);
+    assert.equal(verdict.expected, 3, `${cmd} must report the workflow's own expected node count`);
+  }
+});
+
+test("#604: every DIRECT mutation path (run, CivitAI load, snapshot capture/restore) uses the same full bar", () => {
+  // Paths that skip bridge dispatch must not thereby skip evidence.
+  assert.deepEqual(
+    { ...MUTATION_BINDING_BAR },
+    graphCommandBindingBar("graph_add_node"),
+    "the shared constant must BE the dispatch mutation bar, not a weaker copy",
+  );
+  const verdict = resolveGraphBindingVerdict({ ...halfRebuiltRootEvidence(3), ...MUTATION_BINDING_BAR });
+  assert.ok(verdict, "a direct mutation path must refuse the same evidence bridge dispatch refuses");
+  assert.equal(verdict.reason, "root-node-count-desync");
+});
+
+test("graphCommandBindingBar: reads get the reduced DISPATCH bar (they re-assert with the full one)", () => {
+  for (const cmd of ["graph_outline", "graph_query", "graph_get_state", "graph_screenshot"]) {
+    assert.equal(graphCommandMayMutateWorkflow(cmd), false, `${cmd} must stay classified read-only`);
+    assert.deepEqual(graphCommandBindingBar(cmd), {
+      includeBaselineReadGuard: false,
+      requireDirtyMutationBinding: false,
+    });
+  }
+});
+
+test("availability: the raised mutation bar never refuses a genuinely EMPTY workflow", () => {
+  // Same unreadable root, but the workflow's own current state reports zero nodes:
+  // there is nothing to be out of sync WITH, so no command may be refused.
+  const evidence = {
+    ...halfRebuiltRootEvidence(0),
+    activeWorkflow: { isModified: false, changeTracker: { activeState: { nodes: [] } } },
+  };
+  assert.equal(resolveGraphBindingVerdict({ ...evidence, ...READ_EXECUTOR_BAR }), null);
+  for (const cmd of MUTATING_GRAPH_COMMANDS) {
+    assert.equal(
+      resolveGraphBindingVerdict({ ...evidence, ...graphCommandBindingBar(cmd) }),
+      null,
+      `${cmd} must stay available on a genuinely empty workflow`,
+    );
+  }
+});
+
+test("availability: the raised mutation bar never refuses a DIRTY canvas whose root is positively tagged", () => {
+  // The #545 case: ChangeTracker lags the user's real canvas, so its node count is
+  // not evidence — a positive root/active UUID match is what authorizes the edit.
+  const rootGraph = { _nodes: nodes(5), extra: { comfyui_mcp: { workflow_uuid: "workflow-A" } } };
+  const evidence = {
+    graph: rootGraph,
+    rootGraph,
+    activeWorkflow: { isModified: true, changeTracker: { activeState: { nodes: nodes(9) } } },
+    activeWorkflowUuid: "workflow-A",
+    liveNodeCount: 5,
+    inSubgraph: false,
+    rootUuidMismatch: false,
+  };
+  for (const cmd of MUTATING_GRAPH_COMMANDS) {
+    assert.equal(
+      resolveGraphBindingVerdict({ ...evidence, ...graphCommandBindingBar(cmd) }),
+      null,
+      `${cmd} must remain available on a proven dirty canvas (#545)`,
+    );
+  }
+});
+
+test("availability: the raised mutation bar never fires inside a SUBGRAPH scope", () => {
+  const evidence = { ...halfRebuiltRootEvidence(3), inSubgraph: true };
+  for (const cmd of MUTATING_GRAPH_COMMANDS) {
+    assert.equal(
+      resolveGraphBindingVerdict({ ...evidence, ...graphCommandBindingBar(cmd) }),
+      null,
+      `${cmd} inside a descended subgraph must not be refused by a ROOT node-count comparison`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// The refusal TEXT must state the reason and must not overclaim
+// ---------------------------------------------------------------------------
+
+test("the refusal message names the firing predicate and claims only 'NOT applied'", () => {
+  const msg = graphBindingRefusalMessage({ reason: "root-node-count-desync", expected: 3 });
+  assert.match(msg, /^\[root-node-count-desync\]/, "a verdict with a cause must state the cause (#565)");
+  assert.match(msg, /the workflow reports 3 node\(s\)/);
+  assert.match(msg, /was NOT applied/, "callers assert BEFORE any work — that is what makes this claim true");
+
+  const empty = graphBindingRefusalMessage({ reason: "empty-binding-unproven", expected: 0 });
+  assert.match(empty, /^\[empty-binding-unproven\]/);
+  assert.match(empty, /FALSE-EMPTY/, "an unproven empty read must not become a definite 'empty' verdict");
+
+  assert.equal(graphBindingRefusalMessage(null), null, "no verdict ⇒ no message");
+});

--- a/browser_tests/unit/canvas-graph-divergence.test.mjs
+++ b/browser_tests/unit/canvas-graph-divergence.test.mjs
@@ -56,18 +56,41 @@ import {
   graphBindingRefusalMessage,
   graphCommandBindingBar,
   graphCommandMayMutateWorkflow,
+  graphRootMatchesState,
+  graphRootWorkflowUuidMatches,
   resolveGraphBindingVerdict,
   MUTATION_BINDING_BAR,
 } from "../../web/js/lib/graph-binding.js";
+import { describeRevertOutcome } from "../../web/js/lib/graph-revert.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
 
+/** Index of `function <name>(`, INCLUDING a preceding `async ` when present —
+ *  without it an extracted async function loses its keyword and its `await`
+ *  becomes a syntax error inside `new Function`. */
+function panelFunctionStart(src, name, from = 0) {
+  const bare = src.indexOf(`function ${name}(`, from);
+  assert.notEqual(bare, -1, `could not locate ${name} in panel source`);
+  const asyncAt = bare - "async ".length;
+  return asyncAt >= 0 && src.startsWith("async ", asyncAt) ? asyncAt : bare;
+}
+
 function panelFunctionSource(src, name, nextName) {
-  const start = src.indexOf(`function ${name}(`);
-  const end = src.indexOf(`function ${nextName}(`, start);
-  assert.notEqual(start, -1, `could not locate ${name} in panel source`);
-  assert.notEqual(end, -1, `could not locate ${nextName} after ${name}`);
+  const start = panelFunctionStart(src, name);
+  const end = panelFunctionStart(src, nextName, start + 1);
+  assert.ok(end > start, `could not locate ${nextName} after ${name}`);
+  return src.slice(start, end);
+}
+
+/** restoreSnapshot PLUS the canvas-interaction lock and load-deadline machinery it
+ *  closes over, so both fences under test are the REAL ones rather than stubs that
+ *  could drift from them. */
+function restoreSnapshotSource(src) {
+  const start = src.indexOf("// ---- the canvas interaction lock, as a fence with an OWNER");
+  assert.notEqual(start, -1, "could not locate the canvas interaction lock");
+  const end = panelFunctionStart(src, "revertGraphToLastSnapshot", start + 1);
+  assert.ok(end > start);
   return src.slice(start, end);
 }
 
@@ -114,6 +137,12 @@ function makeApp({ rootGraph, canvasGraph, setGraph = "ok" }) {
     graph: canvasGraph ?? rootGraph,
     setGraphCalls: 0,
     setDirty() {},
+    /** A hand edit, gated the way LiteGraph gates one. Returns whether it landed. */
+    userEdit(node) {
+      if (!this.allow_interaction) return false;
+      this.graph?._nodes?.push(node);
+      return true;
+    },
   };
   if (setGraph !== "missing") {
     canvas.setGraph = function (g) {
@@ -123,6 +152,26 @@ function makeApp({ rootGraph, canvasGraph, setGraph = "ok" }) {
       this.graph = g;
     };
   }
+  // LiteGraph's own gate for hand editing. workflow_open freezes it across its
+  // destructive await; the restore must too, or a hand edit landing mid-load is
+  // overwritten when the load settles. Backed by an accessor that RECORDS every
+  // write: asserting the end value alone cannot tell "froze then restored" from
+  // "never touched it", so a deleted freeze would satisfy it.
+  let interaction = true;
+  canvas.interactionWrites = [];
+  // `lockWrites: "throw"` models a read-only property or a throwing setter — the
+  // case where the freeze does NOT happen even though the property reads boolean.
+  canvas.lockWrites = "ok";
+  Object.defineProperty(canvas, "allow_interaction", {
+    get: () => interaction,
+    set(value) {
+      if (canvas.lockWrites === "throw") throw new TypeError("allow_interaction is read-only");
+      canvas.interactionWrites.push(value);
+      interaction = value;
+    },
+    configurable: true,
+    enumerable: true,
+  });
   return { graph: rootGraph, canvas };
 }
 
@@ -433,7 +482,7 @@ test("#604: EVERY direct mutation path clears the same full bar bridge dispatch 
     ["async graph_run({ batch_count, to_node_id })", "app.queuePrompt"],
     ["async graph_load({ graph: incoming } = {})", 'captureGraphSnapshot(null, "before graph_load")'],
     ["function captureGraphSnapshot(mid, label)", "const data = rootGraph.serialize();"],
-    ["function restoreSnapshot(snap)", "app.loadGraphData(JSON.parse(JSON.stringify(snap.data))"],
+    ["function restoreSnapshot(snap)", "payload = JSON.parse(JSON.stringify(snap.data))"],
     ["function revalidateGraphMutationContext(captured)", "return current;"],
   ];
   for (const [startNeedle, beforeNeedle] of DIRECT_MUTATION_PATHS) {
@@ -452,6 +501,870 @@ test("#604: EVERY direct mutation path clears the same full bar bridge dispatch 
       `${startNeedle} bypasses bridge dispatch, so it must name the full mutation bar itself`,
     );
   }
+});
+
+// ---------------------------------------------------------------------------
+// The recovery path: the refusal must reach the user who is trying to recover
+// ---------------------------------------------------------------------------
+
+test("#604: /revert during a divergence REFUSES with the remedy — it must not claim there was no snapshot", async () => {
+  // The whole timeline, end to end: a snapshot was captured while the binding was
+  // sound → a backend restart leaves the canvas on the unsaved 31-node graph while
+  // app.graph is empty → the user reaches for /revert. getGraphCtx refuses BEFORE
+  // loadGraphData, which is correct; what must not happen is that refusal being
+  // swallowed into "Nothing to revert — no graph snapshot captured in this session
+  // yet." That is false, drops the remedy, and ends the recovery attempt.
+  const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+  const restoreSource = restoreSnapshotSource(src);
+
+  const rootGraph = { _nodes: [] };
+  const canvasGraph = { _nodes: nodes(31) };
+  const app = makeApp({ rootGraph, canvasGraph });
+  const workflow = { isModified: false, changeTracker: { activeState: { nodes: nodes(31) } } };
+  let loads = 0;
+
+  const guard = makeReloadGuardStub();
+  app.loadGraphData = () => {
+    loads += 1; // never reached: getGraphCtx refuses first
+  };
+  const restoreSnapshot = buildRestoreSnapshot({
+    restoreSource,
+    app, // buildGetGraphCtx over it is the REAL resolver — it refuses the divergence
+    activeWorkflowRef: () => workflow,
+    guard,
+  });
+
+  const outcome = await restoreSnapshot({ workflowRef: workflow, data: { nodes: nodes(12) } });
+
+  assert.equal(outcome.status, "refused", "a snapshot EXISTS — the answer is 'refused', never 'none'");
+  assert.match(outcome.reason, /canvas-root-divergence/, "the refusal must carry the reason code");
+  assert.equal(loads, 0, "and nothing may be loaded onto a canvas the panel cannot identify");
+  assert.equal(app.canvas.setGraphCalls, 0, "nor may the user's 31-node canvas be repainted away");
+
+  // What the user actually sees.
+  const line = describeRevertOutcome(outcome, {
+    action: "revert",
+    restoredText: "Reverted.",
+    noneText: "Nothing to revert — no graph snapshot captured in this session yet.",
+  });
+  assert.doesNotMatch(line, /Nothing to revert/, "the exact regression this guards");
+  assert.match(line, /reload the ComfyUI page/, "the remedy survives to the person who needs it");
+});
+
+/** A faithful stand-in for the panel's #442 reload-guard section: the real one is
+ *  module state, and the restore now takes it so a bridge command cannot land
+ *  mid-load. `held` lets a test pretend a workflow switch already owns it. */
+function makeReloadGuardStub({ held = null } = {}) {
+  let guard = held;
+  let seq = 0;
+  return {
+    calls: [],
+    activeWorkflowReloadGuard: () => guard,
+    acquireWorkflowReloadGuard(key) {
+      const token = ++seq;
+      guard = { token, key, since: Date.now(), pending: 0 };
+      this.calls.push(`acquire:${key}`);
+      return token;
+    },
+    beginWorkflowReloadStep(token) {
+      if (!guard || guard.token !== token) return false;
+      guard.pending += 1;
+      this.calls.push("begin");
+      return true;
+    },
+    endWorkflowReloadStep(token) {
+      if (guard && guard.token === token && guard.pending > 0) guard.pending -= 1;
+      this.calls.push("end");
+    },
+    releaseWorkflowReloadGuard(token) {
+      if (guard && guard.token === token) guard = null;
+      this.calls.push("release");
+    },
+    get current() {
+      return guard;
+    },
+    /** Model another operation TAKING OVER the section. acquireWorkflowReloadGuard
+     *  overwrites unconditionally — workflow_open does exactly that — so a holder
+     *  can lose its section without its own release ever running. */
+    takeOver() {
+      guard = null;
+    },
+  };
+}
+
+/** The real restoreSnapshot over a sound binding, with an injectable loader.
+ *  `applies` models whether the frontend's load ACTUALLY lands the payload on the
+ *  root — the default is a faithful frontend that does; pass false for one that
+ *  resolves without applying (which resolution alone can never rule out). */
+function buildSoundRestoreSnapshot(
+  loadGraphData,
+  { guard = makeReloadGuardStub(), applies = true, deadlineMs = 5000 } = {},
+) {
+  const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+  const restoreSource = restoreSnapshotSource(src);
+  // A live root that serializes to whatever was last loaded into it, which is what
+  // the post-load proof reads. Starts as the pre-revert canvas.
+  let live = { nodes: nodes(12), links: [] };
+  const rootGraph = {
+    _nodes: nodes(12),
+    extra: {},
+    serialize: () => JSON.parse(JSON.stringify(live)),
+  };
+  const app = makeApp({ rootGraph, canvasGraph: rootGraph });
+  const workflow = { isModified: false, changeTracker: { activeState: { nodes: nodes(12) } } };
+  // `undefined` models a frontend that never exposed loadGraphData at all — the
+  // wrapper must not paper over that, since it is one of the pre-load refusals.
+  if (loadGraphData) {
+    app.loadGraphData = (payload, ...rest) => {
+      const result = loadGraphData(payload, ...rest);
+      // A real load lands `extra` (including the panel's identity stamp) on the live
+      // root, which is where graphRootWorkflowUuidMatches reads it, AND lands the
+      // content. "identity-only" models a frontend that takes the stamp but does not
+      // faithfully install the graph, so the CONTENT check is what has to catch it.
+      if (applies === true || applies === "identity-only") {
+        rootGraph.extra = JSON.parse(JSON.stringify(payload.extra ?? {}));
+      }
+      if (applies === true || applies === "content-only") live = JSON.parse(JSON.stringify(payload));
+      // "content-only" models the A->B->A window: the canvas ends up holding a graph
+      // whose CONTENT matches the snapshot, but it is not carrying the identity this
+      // restore stamped — a different tab's same-shaped canvas.
+      if (applies === "content-only") rootGraph.extra = { comfyui_mcp: { workflow_uuid: "some-other-tab" } };
+      return result;
+    };
+  }
+  const restoreSnapshot = buildRestoreSnapshot({
+    restoreSource,
+    app,
+    activeWorkflowRef: () => workflow,
+    guard,
+    deadlineMs,
+  });
+  return { restoreSnapshot, workflow, guard, app, rootGraph };
+}
+
+/** Wire the extracted restoreSnapshot to its collaborators. Identity is modelled
+ *  the way the panel does it: a stable per-instance uuid the stamp/read pair agree
+ *  on, so the post-load identity proof is exercised rather than stubbed out. */
+function buildRestoreSnapshot({ restoreSource, app, activeWorkflowRef, guard, deadlineMs = 5000 }) {
+  const uuids = new WeakMap();
+  const uuidCalls = [];
+  let seq = 0;
+  // Models the real workflowStableUuid's `embed` STEP — the option whose job is to
+  // write the uuid into the workflow's own `extra`, where it rides the next save.
+  // It deliberately does NOT model the real helper's unsaved branch, which persists
+  // a freshly-minted id even without the option (#570 durability); that is
+  // pre-existing behaviour shared with every graph command and is not what these
+  // tests are about. Calls are recorded so a test can assert the call HAPPENED and
+  // with what options, rather than inferring it from an absence.
+  const stableUuid = (wf, { embed = false } = {}) => {
+    uuidCalls.push({ wf, embed });
+    if (!wf || typeof wf !== "object") return null;
+    if (!uuids.has(wf)) uuids.set(wf, `wf-uuid-${++seq}`);
+    const id = uuids.get(wf);
+    if (embed) {
+      wf.extra = { ...(wf.extra ?? {}), comfyui_mcp: { workflow_uuid: id } };
+    }
+    return id;
+  };
+  const built = new Function(
+    "getGraphCtx",
+    "activeWorkflowRef",
+    "assertGraphBoundToActiveWorkflow",
+    "MUTATION_BINDING_BAR",
+    "coerceMessageText",
+    "activeWorkflowReloadGuard",
+    "acquireWorkflowReloadGuard",
+    "beginWorkflowReloadStep",
+    "endWorkflowReloadStep",
+    "releaseWorkflowReloadGuard",
+    "graphRootMatchesState",
+    "graphRootWorkflowUuidMatches",
+    "workflowStableUuid",
+    "WORKFLOW_META_NAMESPACE",
+    "WORKFLOW_UUID_FIELD",
+    // The ONLY consumer of setTimeout inside the extracted slice is the load
+    // deadline, so shadowing it here rescales just that — the tests drive the real
+    // bounded-load code instead of sleeping out its 15s production budget.
+    "setTimeout",
+    // The lock helpers ride out too, so a test can model a CONCURRENT holder
+    // (workflow_open) taking the canvas while a timed-out revert is still live.
+    `${restoreSource}\nreturn { restoreSnapshot, acquireCanvasInteractionLock, releaseCanvasInteractionLock };`,
+  )(
+    buildGetGraphCtx(app),
+    activeWorkflowRef,
+    () => {},
+    MUTATION_BINDING_BAR,
+    (v) => String(v ?? ""),
+    () => guard.activeWorkflowReloadGuard(),
+    (key) => guard.acquireWorkflowReloadGuard(key),
+    (token) => guard.beginWorkflowReloadStep(token),
+    (token) => guard.endWorkflowReloadStep(token),
+    (token) => guard.releaseWorkflowReloadGuard(token),
+    graphRootMatchesState,
+    graphRootWorkflowUuidMatches,
+    stableUuid,
+    "comfyui_mcp",
+    "workflow_uuid",
+    (fn) => setTimeout(fn, deadlineMs),
+  );
+  const { restoreSnapshot } = built;
+  restoreSnapshot.uuidCalls = uuidCalls;
+  restoreSnapshot.acquireCanvasInteractionLock = built.acquireCanvasInteractionLock;
+  restoreSnapshot.releaseCanvasInteractionLock = built.releaseCanvasInteractionLock;
+  return restoreSnapshot;
+}
+
+test("#604: a sound binding still reverts — the recovery path is not simply disabled", async () => {
+  let loaded = null;
+  const { restoreSnapshot, workflow } = buildSoundRestoreSnapshot((data) => {
+    loaded = data;
+  });
+
+  const snap = { workflowRef: workflow, data: { nodes: nodes(3) }, label: "before your last message" };
+  const outcome = await restoreSnapshot(snap);
+  assert.equal(outcome.status, "restored");
+  assert.equal(outcome.snapshot, snap);
+  assert.deepEqual(loaded?.nodes, snap.data.nodes, "the snapshot actually reached loadGraphData");
+  assert.ok(
+    loaded?.extra?.comfyui_mcp?.workflow_uuid,
+    "and it carries the identity stamp the post-load proof will demand back",
+  );
+  assert.equal(snap.data.extra, undefined, "the STORED snapshot is not mutated by the stamp");
+});
+
+test("#604: a load that THROWS is disclosed as failed — never as 'nothing to revert'", async () => {
+  // The binding was sound and loadGraphData was CALLED, so the canvas may be
+  // partly changed. This is the disclose case, not the refuse case: reporting
+  // "nothing happened" would invite a retry on top of a half-applied load.
+  const { restoreSnapshot, workflow } = buildSoundRestoreSnapshot(() => {
+    throw new Error("loadGraphData blew up mid-configure");
+  });
+
+  const outcome = await restoreSnapshot({ workflowRef: workflow, data: { nodes: nodes(3) } });
+  assert.equal(outcome.status, "failed", "the action was STARTED — that is not 'none'");
+  assert.match(outcome.reason, /blew up mid-configure/, "carry what went wrong");
+
+  const line = describeRevertOutcome(outcome, {
+    action: "revert",
+    restoredText: "Reverted.",
+    noneText: "Nothing to revert — no graph snapshot captured in this session yet.",
+  });
+  assert.doesNotMatch(line, /Nothing to revert/);
+  assert.match(line, /canvas may have changed/, "tell the user to check the canvas before retrying");
+});
+
+test("#604: a load that REJECTS is disclosed as failed too — loadGraphData is ASYNC", async () => {
+  // The reachable form of the case above on current frontends: loadGraphData
+  // returns a promise, and the panel's own creation-boundary wrapper preserves it.
+  // Un-awaited, a load that started, changed the canvas in part, and then rejected
+  // returned "restored" — every consumer reported success (rewind even said "canvas
+  // reverted") over a half-applied load, and the rejection escaped unhandled.
+  const { restoreSnapshot, workflow } = buildSoundRestoreSnapshot(
+    () => Promise.reject(new Error("configure rejected after partial apply")),
+  );
+
+  const outcome = await restoreSnapshot({ workflowRef: workflow, data: { nodes: nodes(3) } });
+  assert.equal(
+    outcome.status,
+    "failed",
+    "an async rejection must reach the failed branch, not be reported as a successful revert",
+  );
+  assert.match(outcome.reason, /partial apply/);
+});
+
+test("#604: the restore HOLDS the reload section across its await", async () => {
+  // The restore is an async destructive load, and the bridge refuses graph commands
+  // while the #442 section is held. Without it an agent command arriving during the
+  // await is accepted and ACKNOWLEDGED, then erased when the load settles — the
+  // data-loss shape that section exists to close.
+  // Sampled INSIDE the load — the guard object is mutated in place, so a saved
+  // reference would read post-settle values.
+  let keyDuringLoad = null;
+  let pendingDuringLoad = null;
+  const guard = makeReloadGuardStub();
+  const { restoreSnapshot, workflow } = buildSoundRestoreSnapshot(
+    () =>
+      new Promise((resolve) => {
+        keyDuringLoad = guard.current?.key ?? null;
+        pendingDuringLoad = guard.current?.pending ?? null;
+        setTimeout(resolve, 1);
+      }),
+    { guard },
+  );
+
+  const outcome = await restoreSnapshot({ workflowRef: workflow, data: { nodes: nodes(3) } });
+  assert.equal(outcome.status, "restored");
+  assert.equal(keyDuringLoad, "graph-revert", "the section must be HELD while loadGraphData is in flight");
+  assert.equal(pendingDuringLoad, 1, "and marked in-flight so it cannot age out mid-load");
+  assert.equal(guard.current, null, "and released once the load settles");
+});
+
+test("#604: a HAND edit cannot land during the restore's destructive await", async () => {
+  // The section fences the BRIDGE; this fences the USER. Both halves of the same
+  // window: an edit made while loadGraphData is in flight is silently overwritten
+  // when the load settles, which is the unsaved-work loss this whole change exists
+  // to stop — arriving through the window that making the path async opened.
+  // workflow_open already freezes allow_interaction for exactly this reason.
+  let editLanded = null;
+  let frozenDuringLoad = null;
+  const guard = makeReloadGuardStub();
+  const { restoreSnapshot, workflow, app } = buildSoundRestoreSnapshot(
+    () =>
+      new Promise((resolve) => {
+        frozenDuringLoad = app.canvas.allow_interaction;
+        editLanded = app.canvas.userEdit({ id: 999, type: "HandAdded" });
+        setTimeout(resolve, 1);
+      }),
+    { guard },
+  );
+
+  const outcome = await restoreSnapshot({ workflowRef: workflow, data: { nodes: nodes(3), links: [] } });
+  assert.equal(outcome.status, "restored");
+  assert.equal(frozenDuringLoad, false, "canvas interaction must be FROZEN across the await");
+  assert.equal(editLanded, false, "so a hand edit is refused rather than silently clobbered");
+  assert.equal(app.canvas.allow_interaction, true, "and the freeze is lifted once the load settles");
+});
+
+test("#604: the canvas freeze is lifted even when the load FAILS", async () => {
+  // A throw must never leave the user unable to touch their own canvas. The freeze
+  // is sampled INSIDE the load, so this fails both if the freeze never happens and
+  // if it is never lifted — asserting the end state alone would pass with the whole
+  // freeze deleted, since the canvas starts unfrozen.
+  let frozenDuringLoad = null;
+  const failing = buildSoundRestoreSnapshot(() => {
+    frozenDuringLoad = failing.app.canvas.allow_interaction;
+    return Promise.reject(new Error("nope"));
+  });
+  const failed = await failing.restoreSnapshot({ workflowRef: failing.workflow, data: { nodes: nodes(3) } });
+  assert.equal(failed.status, "failed");
+  assert.equal(frozenDuringLoad, false, "the load ran inside the freeze");
+  assert.equal(failing.app.canvas.allow_interaction, true, "and a failed load must not wedge the canvas");
+});
+
+// An explicit timeout so REMOVING the bounded load fails this test instead of
+// hanging the suite: an unbounded restore never resolves, and a hang is a much
+// worse signal than a failure.
+test(
+  "#604: a load past its deadline KEEPS the fences — releasing one while the writer is live cannot be made safe",
+  { timeout: 5000 },
+  async () => {
+    // The panel cannot cancel a loadGraphData once it is running. The deadline
+    // therefore bounds how long the CALLER waits, never how long the canvas is
+    // protected: releasing the freeze here would hand the canvas back, let a hand
+    // edit land, and then let the original load overwrite it — the silent loss this
+    // whole change exists to stop, introduced by the deadline meant to help.
+    let releaseHungLoad;
+    const hung = new Promise((resolve) => {
+      releaseHungLoad = resolve;
+    });
+    const guard = makeReloadGuardStub();
+    const { restoreSnapshot, workflow, app } = buildSoundRestoreSnapshot(() => hung, {
+      guard,
+      deadlineMs: 5,
+    });
+    app.canvas.interactionWrites.length = 0;
+
+    const outcome = await restoreSnapshot({ workflowRef: workflow, data: { nodes: nodes(3), links: [] } });
+
+    assert.equal(outcome.status, "failed", "unfinished ⇒ disclose; never 'restored', never 'none'");
+    assert.match(outcome.reason, /did not finish within/);
+    assert.match(outcome.reason, /has NOT been cancelled/, "say the writer is still live");
+    assert.match(outcome.reason, /canvas stays locked/, "and that the fences are deliberately held");
+    assert.match(outcome.reason, /unlock by themselves the moment it finishes/, "and when they lift");
+    assert.match(outcome.reason, /reload the ComfyUI page/, "with a remedy if it never does");
+
+    // THE POINT: the caller has its answer, and the fences are still up.
+    assert.deepEqual(app.canvas.interactionWrites, [false], "frozen, and NOT released while the load lives");
+    assert.equal(app.canvas.allow_interaction, false);
+    assert.equal(app.canvas.userEdit({ id: 42, type: "HandAdded" }), false, "so a hand edit still cannot land");
+    assert.ok(guard.current, "and graph commands stay fenced too");
+
+    // …and they lift by themselves once the writer finally finishes.
+    releaseHungLoad();
+    await hung;
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.deepEqual(app.canvas.interactionWrites, [false, true], "released when the load settles, not before");
+    assert.equal(guard.current, null, "and the section with it");
+  },
+);
+
+test(
+  "#604: a late-settling revert must not unlock the canvas under a workflow_open that is still loading",
+  { timeout: 5000 },
+  async () => {
+    // The reason the still-running tracker is not dead code is the same reason this
+    // matters: acquireWorkflowReloadGuard OVERWRITES, so a timed-out revert can lose
+    // its section to a workflow_open while its own load is still live. If the revert
+    // then settles FIRST and restores its saved `true`, it unlocks the canvas in the
+    // middle of the open's reload — a hand edit lands and the newer load overwrites
+    // it. A fence may only be released by its current owner.
+    let releaseHungLoad;
+    const hung = new Promise((resolve) => {
+      releaseHungLoad = resolve;
+    });
+    const guard = makeReloadGuardStub();
+    const { restoreSnapshot, workflow, app } = buildSoundRestoreSnapshot(() => hung, {
+      guard,
+      deadlineMs: 5,
+    });
+    app.canvas.interactionWrites.length = 0;
+
+    const timedOut = await restoreSnapshot({ workflowRef: workflow, data: { nodes: nodes(3), links: [] } });
+    assert.equal(timedOut.status, "failed");
+    assert.equal(app.canvas.allow_interaction, false, "the revert's freeze is holding");
+
+    // A workflow_open now takes over: it overwrites the section and takes the canvas
+    // lock through the SAME owned helper the panel uses.
+    guard.takeOver();
+    const openToken = restoreSnapshot.acquireCanvasInteractionLock(app.canvas);
+    assert.ok(openToken, "the open takes the lock too");
+
+    // …and the revert's load finally lands, releasing what IT thinks it owns.
+    releaseHungLoad();
+    await hung;
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.equal(
+      app.canvas.allow_interaction,
+      false,
+      "THE POINT: the canvas stays locked — the open is still loading and did not release it",
+    );
+    assert.equal(
+      app.canvas.userEdit({ id: 77, type: "HandAdded" }),
+      false,
+      "so a hand edit still cannot land into the open's load",
+    );
+
+    // Only when the open itself releases does the canvas reopen, to the value from
+    // before the FIRST freeze.
+    restoreSnapshot.releaseCanvasInteractionLock(openToken, app.canvas);
+    assert.equal(app.canvas.allow_interaction, true, "the last holder out reopens it");
+  },
+);
+
+test("#604: a freeze that THROWS registers no holder — the lock cannot be owned forever", async () => {
+  // The rule that killed boxWritten: do not record that you did something before
+  // you did it. Registering the holder before the write is a CLAIM that the freeze
+  // happened; if the write then throws, nobody holds the token and nobody ever
+  // releases it, so the orphan keeps the count nonzero and the NEXT canvas is
+  // permanently locked with nothing running. Giving the lock an owner is exactly
+  // what created a way to own it forever.
+  let loads = 0;
+  const { restoreSnapshot, workflow, app } = buildSoundRestoreSnapshot(() => {
+    loads += 1;
+  });
+  app.canvas.lockWrites = "throw";
+
+  const outcome = await restoreSnapshot({ workflowRef: workflow, data: { nodes: nodes(3), links: [] } });
+  assert.equal(outcome.status, "refused", "a freeze that did not happen is no fence at all");
+  assert.match(outcome.reason, /does not expose a canvas interaction lock/);
+  assert.equal(loads, 0, "and the destructive load never ran");
+
+  // THE POINT: no orphan holder survived. Prove it through a FRESH canvas — a
+  // leaked holder would keep the count nonzero and make this release a no-op.
+  const fresh = makeApp({ rootGraph: { _nodes: [] } }).canvas;
+  const token = restoreSnapshot.acquireCanvasInteractionLock(fresh);
+  assert.ok(token, "a healthy canvas can still be frozen");
+  assert.equal(fresh.allow_interaction, false);
+  assert.equal(
+    restoreSnapshot.releaseCanvasInteractionLock(token, fresh),
+    true,
+    "and its release is the LAST one out — no stale holder is still counted",
+  );
+  assert.equal(fresh.allow_interaction, true, "so the new canvas returns to interactive");
+});
+
+test("#604: a release whose restore write throws still drops the claim", async () => {
+  // The mirror case. A dead canvas staying frozen is unavoidable; keeping its holder
+  // registered would be strictly worse — it would lock out every later canvas too.
+  const { restoreSnapshot } = buildSoundRestoreSnapshot(() => {});
+  const dying = makeApp({ rootGraph: { _nodes: [] } }).canvas;
+  const token = restoreSnapshot.acquireCanvasInteractionLock(dying);
+  assert.ok(token);
+  dying.lockWrites = "throw"; // the canvas goes away mid-section
+  assert.equal(restoreSnapshot.releaseCanvasInteractionLock(token, dying), true);
+
+  const fresh = makeApp({ rootGraph: { _nodes: [] } }).canvas;
+  const next = restoreSnapshot.acquireCanvasInteractionLock(fresh);
+  assert.equal(restoreSnapshot.releaseCanvasInteractionLock(next, fresh), true);
+  assert.equal(fresh.allow_interaction, true, "the dead canvas's claim did not outlive it");
+});
+
+test("#604: a frontend with no interaction lock is REFUSED, not run unfenced", async () => {
+  // Without allow_interaction there is no way to stop a hand edit landing mid-load,
+  // and the load would overwrite it. Claiming the fence is there when it cannot be
+  // established is the fabrication; workflow_open sets the precedent by gating its
+  // own destructive re-read on the same condition.
+  let loads = 0;
+  const { restoreSnapshot, workflow, app } = buildSoundRestoreSnapshot(() => {
+    loads += 1;
+  });
+  delete app.canvas.allow_interaction; // frontend without the lock
+
+  const outcome = await restoreSnapshot({ workflowRef: workflow, data: { nodes: nodes(3), links: [] } });
+  assert.equal(outcome.status, "refused", "no fence ⇒ do not run the destructive await at all");
+  assert.match(outcome.reason, /does not expose a canvas interaction lock/);
+  assert.match(outcome.reason, /silently overwritten/, "say what the missing fence would cost");
+  assert.equal(loads, 0, "and nothing was loaded");
+});
+
+test("#604: a restore is REFUSED while an earlier load is still running past its deadline", async () => {
+  // Belt and braces alongside the held section: the tracker is what still refuses a
+  // second restore if the section were ever released first, so a load that outran
+  // its deadline can never be the one that lands last.
+  // ONE builder: the still-running load is module state in the real panel, so all
+  // three attempts must share a single extracted scope. The loader switches
+  // behaviour between calls instead.
+  let releaseHungLoad;
+  const hung = new Promise((resolve) => {
+    releaseHungLoad = resolve;
+  });
+  let hang = true;
+  let laterLoads = 0;
+  const { restoreSnapshot, workflow, guard } = buildSoundRestoreSnapshot(
+    () => {
+      if (hang) return hung;
+      laterLoads += 1;
+      return undefined;
+    },
+    { deadlineMs: 5 },
+  );
+  const snapshot = { workflowRef: workflow, data: { nodes: nodes(3), links: [] } };
+
+  const timedOut = await restoreSnapshot(snapshot);
+  assert.equal(timedOut.status, "failed");
+  hang = false;
+
+  // While the timed-out load holds the section, that alone refuses a second restore.
+  const bySection = await restoreSnapshot(snapshot);
+  assert.equal(bySection.status, "refused");
+  assert.match(bySection.reason, /switching or reloading/);
+
+  // The tracker is the backstop for when the section is NOT enough:
+  // acquireWorkflowReloadGuard overwrites unconditionally (workflow_open does that),
+  // so a holder can lose its section while its load is still live. Then only the
+  // tracker stands between "the earlier load lands last" and a silent overwrite.
+  guard.takeOver();
+  const byTracker = await restoreSnapshot(snapshot);
+  assert.equal(byTracker.status, "refused", "the earlier load could still land last");
+  assert.match(byTracker.reason, /STILL running/);
+  assert.equal(laterLoads, 0, "and nothing was loaded on top of it");
+
+  // …and once the abandoned load finally settles, restores work again.
+  releaseHungLoad();
+  await hung;
+  await Promise.resolve();
+  const ok = await restoreSnapshot(snapshot);
+  assert.equal(ok.status, "restored", "the block is released when the load finishes, not permanent");
+  assert.equal(laterLoads, 1);
+});
+
+test("#604: a refusal does not touch canvas interaction at all", async () => {
+  // Asserted from the WRITE LOG, not the end value: "unchanged" is also what a
+  // deleted freeze looks like. Paired with a SUCCESSFUL restore in the same test,
+  // because an empty log on its own is satisfied by having no freeze at all.
+  const guard = makeReloadGuardStub({ held: { token: 9, key: "wf:other.json", since: Date.now(), pending: 1 } });
+  const refusedCase = buildSoundRestoreSnapshot(() => {}, { guard });
+  refusedCase.app.canvas.interactionWrites.length = 0;
+  const refused = await refusedCase.restoreSnapshot({
+    workflowRef: refusedCase.workflow,
+    data: { nodes: nodes(3) },
+  });
+  assert.equal(refused.status, "refused");
+  assert.deepEqual(
+    refusedCase.app.canvas.interactionWrites,
+    [],
+    "a refusal never froze, so it must not write to the flag at all — including un-freezing someone else's freeze",
+  );
+
+  // …and the freeze DOES exist, so the emptiness above means something.
+  const ok = buildSoundRestoreSnapshot(() => {});
+  ok.app.canvas.interactionWrites.length = 0;
+  await ok.restoreSnapshot({ workflowRef: ok.workflow, data: { nodes: nodes(3), links: [] } });
+  assert.deepEqual(ok.app.canvas.interactionWrites, [false, true], "a restore that RUNS does freeze");
+});
+
+test("#604: a successful restore returns interaction to its PRIOR value, not to true", async () => {
+  let frozenDuringLoad = null;
+  const held = buildSoundRestoreSnapshot(() => {
+    frozenDuringLoad = held.app.canvas.allow_interaction;
+  });
+  held.app.canvas.allow_interaction = false; // already frozen by something else
+  held.app.canvas.interactionWrites.length = 0;
+  const outcome = await held.restoreSnapshot({
+    workflowRef: held.workflow,
+    data: { nodes: nodes(3), links: [] },
+  });
+  assert.equal(outcome.status, "restored");
+  assert.equal(frozenDuringLoad, false);
+  assert.deepEqual(
+    held.app.canvas.interactionWrites,
+    [false, false],
+    "froze, then restored the PRIOR value — never assumed true",
+  );
+});
+
+test("#604: a successful restore on an unfrozen canvas freezes and unfreezes exactly once", async () => {
+  const open = buildSoundRestoreSnapshot(() => {});
+  open.app.canvas.interactionWrites.length = 0;
+  const outcome = await open.restoreSnapshot({
+    workflowRef: open.workflow,
+    data: { nodes: nodes(3), links: [] },
+  });
+  assert.equal(outcome.status, "restored");
+  assert.deepEqual(open.app.canvas.interactionWrites, [false, true]);
+});
+
+test("#604: a restore is REFUSED while another switch/reload owns the section (single-flight)", async () => {
+  // Covers both a workflow_open switch in progress AND a second /revert landing on
+  // top of a first: racing two loads settles them out of user-action order.
+  let loads = 0;
+  const guard = makeReloadGuardStub({ held: { token: 99, key: "wf:other.json", since: Date.now(), pending: 1 } });
+  const { restoreSnapshot, workflow } = buildSoundRestoreSnapshot(() => {
+    loads += 1;
+  }, { guard });
+
+  const outcome = await restoreSnapshot({ workflowRef: workflow, data: { nodes: nodes(3) } });
+  assert.equal(outcome.status, "refused", "nothing was loaded — safe to retry");
+  assert.match(outcome.reason, /wf:other\.json/, "name what is holding the section");
+  assert.equal(loads, 0, "and do not race it");
+});
+
+test("#604: the section is released even when the load FAILS", async () => {
+  const guard = makeReloadGuardStub();
+  const { restoreSnapshot, workflow } = buildSoundRestoreSnapshot(
+    () => Promise.reject(new Error("nope")),
+    { guard },
+  );
+  const outcome = await restoreSnapshot({ workflowRef: workflow, data: { nodes: nodes(3) } });
+  assert.equal(outcome.status, "failed");
+  // The section must have been TAKEN and then let go. Asserting only that nothing
+  // is held would also be satisfied by never taking it — the stub starts empty.
+  assert.deepEqual(
+    guard.calls,
+    ["acquire:graph-revert", "begin", "end", "release"],
+    "the section is taken across the load and released on the failure path",
+  );
+  assert.equal(guard.current, null, "a failed load must not wedge the section and block every graph command");
+});
+
+test("#604: a PRE-load failure is refused, not falsely disclosed as a partial apply", async () => {
+  // loadGraphData missing on this frontend: the action never started, so claiming it
+  // "was STARTED and did not finish" — and telling the user their canvas may be
+  // partly changed — would be fabricated.
+  const { restoreSnapshot, workflow } = buildSoundRestoreSnapshot(undefined);
+  const outcome = await restoreSnapshot({ workflowRef: workflow, data: { nodes: nodes(3) } });
+  assert.equal(outcome.status, "refused", "nothing ran ⇒ refused, never failed");
+  assert.match(outcome.reason, /does not expose loadGraphData/);
+});
+
+test("#604: an unserializable snapshot is refused, not falsely disclosed as a partial apply", async () => {
+  let loads = 0;
+  const { restoreSnapshot, workflow } = buildSoundRestoreSnapshot(() => {
+    loads += 1;
+  });
+  const circular = { nodes: [] };
+  circular.self = circular; // JSON.parse(JSON.stringify(...)) throws
+  const outcome = await restoreSnapshot({ workflowRef: workflow, data: circular });
+  assert.equal(outcome.status, "refused", "the clone failed BEFORE the load — nothing was applied");
+  assert.equal(loads, 0);
+});
+
+test("#604: an unreadable active workflow is REFUSED, not reported as 'no snapshot'", async () => {
+  // There may well be snapshots in the ring — the panel just cannot read the active
+  // workflow, so it cannot tell which of them belong to this canvas. Answering
+  // "none" would be the same could-not-determine-becomes-a-verdict defect one level
+  // up, and it is the answer that ends the user's recovery attempt.
+  const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+  const source = panelFunctionSource(src, "revertGraphToLastSnapshot", "manualChangeBanner");
+  const ring = [{ workflowRef: {}, data: { nodes: nodes(3) } }];
+  let restores = 0;
+
+  const revertGraphToLastSnapshot = new Function(
+    "activeWorkflowRef",
+    "graphSnapshots",
+    "getGraphCtx",
+    "pickRevertSnapshot",
+    "restoreSnapshot",
+    `${source}\nreturn revertGraphToLastSnapshot;`,
+  )(
+    () => null, // the workflow service cannot be read right now
+    ring,
+    () => ({ rootGraph: { serialize: () => ({ nodes: [] }) } }),
+    (snaps) => snaps[snaps.length - 1],
+    async () => {
+      restores += 1;
+      return { status: "restored" };
+    },
+  );
+
+  const outcome = await revertGraphToLastSnapshot();
+  assert.equal(outcome.status, "refused", "unknown scope ⇒ refused, never a definite 'none'");
+  assert.match(outcome.reason, /cannot read the active workflow/);
+  assert.match(outcome.reason, /Retry in a moment/, "and it clears on retry, so say so");
+  assert.equal(restores, 0, "nothing may be loaded when the panel cannot scope the ring");
+});
+
+test("#604: a load that RESOLVES WITHOUT APPLYING is not reported as a successful revert", async () => {
+  // The panel's own workflow_open code says it outright: a resolved load promise is
+  // not a binding receipt — an old or partial frontend can resolve while leaving the
+  // canvas on the previous root. Calling that "restored" would tell the user their
+  // canvas was reverted when it was not, and the rollback modal would then rewind
+  // the conversation and resend against it.
+  let calls = 0;
+  const { restoreSnapshot, workflow } = buildSoundRestoreSnapshot(
+    () => {
+      calls += 1;
+    },
+    { applies: false }, // resolves, changes nothing
+  );
+
+  const outcome = await restoreSnapshot({ workflowRef: workflow, data: { nodes: nodes(3) } });
+  assert.equal(calls, 1, "the load really was attempted");
+  assert.equal(outcome.status, "failed", "unverifiable ⇒ disclose; never 'restored', never 'none'");
+  assert.match(outcome.reason, /cannot confirm/);
+  assert.match(outcome.reason, /Check the canvas/, "and tell them what to do about it");
+});
+
+test("#604: matching CONTENT on a canvas carrying another tab's identity is not a successful revert", async () => {
+  // The A->B->A window the active-instance pointer cannot see: the user switches to
+  // a same-shaped tab B and back to A while the load completes, so the pointer reads
+  // A again and graphRootMatchesState (which deliberately ignores identity) also
+  // passes. The stamped-identity round-trip is the only part that catches it.
+  const { restoreSnapshot, workflow } = buildSoundRestoreSnapshot(() => {}, {
+    applies: "content-only",
+  });
+
+  const outcome = await restoreSnapshot({ workflowRef: workflow, data: { nodes: nodes(3), links: [] } });
+  assert.equal(outcome.status, "failed", "content equality is not proof of WHICH canvas");
+  assert.match(outcome.reason, /not carrying the identity/, "the IDENTITY round-trip is what fires here");
+});
+
+test("#604: a load that takes the identity but NOT the graph is caught by the CONTENT check", async () => {
+  // Isolates the third part of the proof: identity alone cannot tell a faithful
+  // install from a partial one, so content is checked as well as the stamp.
+  const { restoreSnapshot, workflow } = buildSoundRestoreSnapshot(() => {}, {
+    applies: "identity-only",
+  });
+
+  const outcome = await restoreSnapshot({ workflowRef: workflow, data: { nodes: nodes(3), links: [] } });
+  assert.equal(outcome.status, "failed");
+  assert.match(outcome.reason, /does not match the snapshot/, "the CONTENT check is what fires here");
+});
+
+// An AVAILABILITY test, and deliberately deletion-INSENSITIVE: an ordinary revert
+// reports "restored" whether or not any proof exists, so this names no production
+// symbol and claims to cover none. Its job is the opposite direction — catching a
+// proof that has become a blanket refusal, warning on every working /revert.
+// Deletion-sensitivity for each proof part lives in the three tests above.
+test("availability: an ordinary revert on a faithful frontend still reports restored", async () => {
+  const { restoreSnapshot, workflow } = buildSoundRestoreSnapshot(() => {});
+  const snap = { workflowRef: workflow, data: { nodes: nodes(3), links: [] } };
+  const outcome = await restoreSnapshot(snap);
+  assert.equal(outcome.status, "restored");
+  assert.equal(outcome.snapshot, snap);
+});
+
+test("#604: the restore asks for its identity WITHOUT the embed step", async () => {
+  // Scope, precisely: restoreSnapshot's own identity call must not pass
+  // `{embed:true}`, whose job is to write the uuid (and path) into the workflow's own
+  // `extra`, where it rides the user's next save. The restore needs a value, not a
+  // write.
+  //
+  // What this does NOT claim: that resolving an identity is side-effect free in
+  // general. The real helper's UNSAVED branch persists a freshly-minted id even
+  // without the option (#570 durability), and the binding assert above short-circuits
+  // on a cached object uuid so it does not necessarily get there first. Both are
+  // pre-existing behaviour shared with every graph command and are stubbed here.
+  //
+  // Both halves live in ONE test on purpose: the ordering half asserts an ABSENCE,
+  // which on its own is also what a deleted call looks like. Paired with the success
+  // half, deleting the call fails this test.
+  const { restoreSnapshot, workflow } = buildSoundRestoreSnapshot(() => {});
+  workflow.extra = { existing: true };
+
+  const outcome = await restoreSnapshot({ workflowRef: workflow, data: { nodes: nodes(3), links: [] } });
+  assert.equal(outcome.status, "restored", "the restore must reach its identity call");
+  // Asserted from the CALL, not from an absence of writes: "no write" is also what a
+  // deleted call looks like.
+  const own = restoreSnapshot.uuidCalls.filter((c) => c.wf === workflow);
+  assert.equal(own.length, 1, "the restore resolves the snapshot's workflow identity exactly once");
+  assert.equal(own[0].embed, false, "and never asks for the embed step");
+  assert.deepEqual(workflow.extra, { existing: true }, "so nothing is written to the workflow here");
+
+  // …and a restore refused before the section never reaches that call at all.
+  const guard = makeReloadGuardStub({ held: { token: 7, key: "wf:other.json", since: Date.now(), pending: 1 } });
+  const refusedCase = buildSoundRestoreSnapshot(() => {}, { guard });
+  refusedCase.workflow.extra = { existing: true };
+  const refused = await refusedCase.restoreSnapshot({
+    workflowRef: refusedCase.workflow,
+    data: { nodes: nodes(3) },
+  });
+  assert.equal(refused.status, "refused");
+  assert.deepEqual(
+    refusedCase.restoreSnapshot.uuidCalls.filter((c) => c.wf === refusedCase.workflow),
+    [],
+    "a refusal must short-circuit before the identity call, whatever that call does",
+  );
+  assert.deepEqual(refusedCase.workflow.extra, { existing: true });
+});
+
+test("#604: a workflow SWITCH during the load is not certified by matching content", async () => {
+  // Content equality cannot tell tab A from a same-shaped tab B, and
+  // graphRootMatchesState deliberately excludes the identity tag. Without an
+  // identity re-check the restore would report "restored" for a canvas it cannot
+  // prove is the one it was asked about — and the modal would rewind and resend
+  // against it.
+  const other = { isModified: false, changeTracker: { activeState: { nodes: nodes(12) } } };
+  let active = null;
+  const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+  const restoreSource = restoreSnapshotSource(src);
+  const snapWorkflow = { isModified: false, changeTracker: { activeState: { nodes: nodes(12) } } };
+  active = snapWorkflow;
+
+  let live = { nodes: nodes(12), links: [] };
+  const rootGraph = { _nodes: nodes(12), extra: {}, serialize: () => JSON.parse(JSON.stringify(live)) };
+  const app = makeApp({ rootGraph, canvasGraph: rootGraph });
+  app.loadGraphData = (payload) => {
+    live = JSON.parse(JSON.stringify(payload)); // the load DOES apply…
+    rootGraph.extra = JSON.parse(JSON.stringify(payload.extra ?? {}));
+    active = other; // …but the user switched tabs while it was in flight
+  };
+  const guard = makeReloadGuardStub();
+  const restoreSnapshot = buildRestoreSnapshot({
+    restoreSource,
+    app,
+    activeWorkflowRef: () => active,
+    guard,
+  });
+
+  // Content matches perfectly — only the INSTANCE moved.
+  const outcome = await restoreSnapshot({ workflowRef: snapWorkflow, data: { nodes: nodes(3), links: [] } });
+  assert.equal(outcome.status, "failed", "matching content is not proof it is the right canvas");
+  assert.match(outcome.reason, /active workflow changed/);
+  assert.equal(guard.current, null, "and the section is still released");
+});
+
+test("#604: the restore RESOLVES only after the async load settles", async () => {
+  // Ordering matters for the per-message rollback, which resends the edited
+  // message after the revert: resolving early would resend against a canvas whose
+  // load is still in flight.
+  let settled = false;
+  const { restoreSnapshot, workflow } = buildSoundRestoreSnapshot(
+    () =>
+      new Promise((resolve) =>
+        setTimeout(() => {
+          settled = true;
+          resolve();
+        }, 5),
+      ),
+  );
+
+  const outcome = await restoreSnapshot({ workflowRef: workflow, data: { nodes: nodes(3) } });
+  assert.equal(settled, true, "the outcome must not be reported before the load completes");
+  assert.equal(outcome.status, "restored");
 });
 
 test("graphCommandBindingBar: reads get the reduced DISPATCH bar (they re-assert with the full one)", () => {

--- a/browser_tests/unit/canvas-graph-divergence.test.mjs
+++ b/browser_tests/unit/canvas-graph-divergence.test.mjs
@@ -106,21 +106,24 @@ function subgraphObject({ nodes: inner = [] } = {}) {
 }
 
 /** An `app` whose canvas points at `canvasGraph`; setGraph is COUNTED because
- *  calling it at all is the destructive act under test. */
-function makeApp({ rootGraph, canvasGraph }) {
-  const app = {
-    graph: rootGraph,
-    canvas: {
-      graph: canvasGraph ?? rootGraph,
-      setGraphCalls: 0,
-      setGraph(g) {
-        this.setGraphCalls += 1;
-        this.graph = g;
-      },
-      setDirty() {},
-    },
+ *  calling it at all is the destructive act under test. `setGraph` models the three
+ *  real outcomes: "ok" (rebinds), "throw" (a reconnect-time failure), "missing"
+ *  (older frontends that never exposed it), and "noop" (accepts and does nothing). */
+function makeApp({ rootGraph, canvasGraph, setGraph = "ok" }) {
+  const canvas = {
+    graph: canvasGraph ?? rootGraph,
+    setGraphCalls: 0,
+    setDirty() {},
   };
-  return app;
+  if (setGraph !== "missing") {
+    canvas.setGraph = function (g) {
+      this.setGraphCalls += 1;
+      if (setGraph === "throw") throw new Error("canvas is mid-reconnect");
+      if (setGraph === "noop") return;
+      this.graph = g;
+    };
+  }
+  return { graph: rootGraph, canvas };
 }
 
 // ---------------------------------------------------------------------------
@@ -301,6 +304,30 @@ test("#220/#308 regression fence: getGraphCtx still reconciles a PROVABLY EMPTY 
   assert.equal(app.canvas.setGraphCalls, 1, "the ghost view is reconciled so reads and edits stay in lockstep");
   assert.equal(app.canvas.graph, rootGraph);
 });
+
+// An ATTEMPTED repaint is not a repaint. setGraph is optional on older frontends and
+// can throw during a reconnect; swallowing that and returning the root anyway
+// resolved commands onto a graph the user is provably NOT looking at — the same
+// wrong-canvas outcome by a different route (e.g. graph_clear emptying the bound
+// root while the user still sees the ghost).
+for (const [label, setGraph] of [
+  ["throws", "throw"],
+  ["is unavailable on this frontend", "missing"],
+  ["accepts but does not rebind", "noop"],
+]) {
+  test(`#604: an empty ghost whose canvas rebind ${label} is REFUSED, not silently resolved to root`, () => {
+    const rootGraph = { _nodes: [{ id: 1, type: "Node" }] };
+    const ghost = subgraphObject();
+    const app = makeApp({ rootGraph, canvasGraph: ghost, setGraph });
+
+    assert.throws(
+      () => buildGetGraphCtx(app)(),
+      /\[canvas-root-divergence\][\s\S]*could not confirm it/,
+      "an unconfirmed rebind leaves the divergence in place and must be refused like one",
+    );
+    assert.equal(app.canvas.graph, ghost, "the user is still looking at the ghost — say so, don't act");
+  });
+}
 
 test("getGraphCtx: an ordinary root-bound canvas is untouched (no false refusal)", () => {
   const rootGraph = { _nodes: nodes(3) };

--- a/browser_tests/unit/canvas-graph-divergence.test.mjs
+++ b/browser_tests/unit/canvas-graph-divergence.test.mjs
@@ -89,9 +89,11 @@ function nodes(n, offset = 0) {
 }
 
 /** A LiteGraph SUBGRAPH as this codebase already identifies one: boundary rails
- *  (the same members resolveRailNode reads). */
+ *  (the same members resolveRailNode reads). `serialize` is present so the
+ *  content-free proof can actually be evaluated — without it the graph is
+ *  unprovable and fails closed, which is asserted separately. */
 function subgraphObject({ nodes: inner = [] } = {}) {
-  return {
+  const sub = {
     name: "sub",
     inputNode: { id: SUBGRAPH_INPUT_RAIL_ID },
     outputNode: { id: SUBGRAPH_OUTPUT_RAIL_ID },
@@ -99,6 +101,8 @@ function subgraphObject({ nodes: inner = [] } = {}) {
     outputs: [],
     _nodes: inner,
   };
+  sub.serialize = () => ({ nodes: inner.map((n) => ({ ...n })) });
+  return sub;
 }
 
 /** An `app` whose canvas points at `canvasGraph`; setGraph is COUNTED because
@@ -174,15 +178,66 @@ test("#604: canvas and app.graph hold two different ROOT graphs ⇒ diverged, an
   assert.equal(scope.rootGraph, rootGraph);
 });
 
-test("#220/#308 regression fence: a ghost SUBGRAPH still reconciles to root (stale, not diverged)", () => {
-  // A subgraph the REBUILT root neither owns via an owner node nor registers.
+test("#220/#308 regression fence: a PROVABLY EMPTY ghost subgraph still reconciles to root", () => {
+  // A subgraph the REBUILT root neither owns via an owner node nor registers, and
+  // which provably holds nothing — the one case a repaint can lose nothing.
   const rootGraph = { _nodes: [{ id: 1, type: "Node" }] };
-  const ghost = subgraphObject({ nodes: nodes(2, 100) });
+  const ghost = subgraphObject();
   const scope = resolveScope(makeApp({ rootGraph, canvasGraph: ghost }));
 
-  assert.equal(scope.stale, true, "the #220/#308 ghost must still reconcile to root");
-  assert.equal(scope.diverged, false, "a ghost subgraph is NOT the #604 root divergence");
+  assert.equal(scope.stale, true, "the #220/#308 reconcile must survive for an empty ghost");
+  assert.equal(scope.diverged, false);
   assert.equal(scope.graph, rootGraph, "reads and edits both land on the live root");
+});
+
+test("#604: a ghost SUBGRAPH holding content is a divergence too — kind never overrides content", () => {
+  // The P0 the first cut of this fix missed: "unreachable from the live root"
+  // proves only that the root does not own the graph — never that it is
+  // disposable. A stranded subgraph can hold the user's unsaved work exactly like
+  // a stranded root, and repainting it away is the same unrecoverable loss.
+  const rootGraph = { _nodes: [{ id: 1, type: "Node" }] };
+  const ghost = subgraphObject({ nodes: nodes(2, 100) });
+  const app = makeApp({ rootGraph, canvasGraph: ghost });
+  const scope = resolveScope(app);
+
+  assert.equal(scope.diverged, true, "a content-bearing ghost is unresolvable, not disposable");
+  assert.equal(scope.stale, false, "the repaint trigger must stay disarmed");
+  assert.equal(scope.divergedKind, "subgraph");
+  assert.equal(scope.graph, ghost, "the graph the user is looking at is what gets reported");
+
+  assert.throws(() => buildGetGraphCtx(app)(), /\[canvas-root-divergence\]/);
+  assert.equal(app.canvas.setGraphCalls, 0, "the ghost's contents must remain reachable to the user");
+  assert.equal(app.canvas.graph, ghost);
+});
+
+test("#604: the subgraph divergence offers the escape that actually applies to it", () => {
+  const app = makeApp({
+    rootGraph: { _nodes: nodes(1) },
+    canvasGraph: subgraphObject({ nodes: nodes(2, 100) }),
+  });
+  let message = "";
+  try {
+    buildGetGraphCtx(app)();
+  } catch (err) {
+    message = err.message;
+  }
+  assert.match(message, /Leave the open subgraph/, "a stranded subgraph is escaped by leaving it");
+  assert.match(message, /reload the ComfyUI page/, "with the page reload as the fallback");
+});
+
+test("#604: an unserializable ghost is NOT proven empty — unprovable fails closed", () => {
+  const ghost = {
+    inputNode: { id: SUBGRAPH_INPUT_RAIL_ID },
+    outputNode: { id: SUBGRAPH_OUTPUT_RAIL_ID },
+    _nodes: [],
+  };
+  const scope = resolveScope(makeApp({ rootGraph: { _nodes: nodes(1) }, canvasGraph: ghost }));
+  assert.equal(
+    scope.diverged,
+    true,
+    "a bare empty _nodes array is node-level evidence only — groups/links/nested subgraphs are unproven",
+  );
+  assert.equal(scope.stale, false);
 });
 
 test("resolveScope: an EMPTY diverged canvas is still a divergence — 'no content' is not proof of a good binding", () => {
@@ -236,9 +291,9 @@ test("#604: the divergence refusal states BOTH candidate graphs and a remedy tha
   );
 });
 
-test("#220/#308 regression fence: getGraphCtx still reconciles a GHOST subgraph to root", () => {
+test("#220/#308 regression fence: getGraphCtx still reconciles a PROVABLY EMPTY ghost to root", () => {
   const rootGraph = { _nodes: [{ id: 1, type: "Node" }] };
-  const ghost = subgraphObject({ nodes: nodes(2, 100) });
+  const ghost = subgraphObject();
   const app = makeApp({ rootGraph, canvasGraph: ghost });
   const ctx = buildGetGraphCtx(app)();
 
@@ -329,16 +384,47 @@ test("#604: a mutation may never clear a LOWER binding bar than a read", () => {
   }
 });
 
-test("#604: every DIRECT mutation path (run, CivitAI load, snapshot capture/restore) uses the same full bar", () => {
-  // Paths that skip bridge dispatch must not thereby skip evidence.
+test("#604: EVERY direct mutation path clears the same full bar bridge dispatch demands", () => {
+  // The shared constant must BE the dispatch mutation bar, not a weaker copy…
   assert.deepEqual(
     { ...MUTATION_BINDING_BAR },
     graphCommandBindingBar("graph_add_node"),
-    "the shared constant must BE the dispatch mutation bar, not a weaker copy",
+    "a direct path must not get a different bar from a dispatched mutation",
   );
   const verdict = resolveGraphBindingVerdict({ ...halfRebuiltRootEvidence(3), ...MUTATION_BINDING_BAR });
-  assert.ok(verdict, "a direct mutation path must refuse the same evidence bridge dispatch refuses");
+  assert.ok(verdict, "…and it must refuse the same evidence bridge dispatch refuses");
   assert.equal(verdict.reason, "root-node-count-desync");
+
+  // …and every path that bypasses bridge dispatch must actually USE it. Each of
+  // these invokes a graph mutation without going through the dispatch fence: the
+  // panel's Run button (/run), the CivitAI workflow picker's graph_load, the
+  // per-turn snapshot capture and its revert, and the deferred add-node
+  // revalidation after an awaited node-definition fetch. Skipping dispatch must
+  // not mean skipping evidence, so each is checked at its own call site.
+  const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+  const DIRECT_MUTATION_PATHS = [
+    ["async graph_run({ batch_count, to_node_id })", "app.queuePrompt"],
+    ["async graph_load({ graph: incoming } = {})", 'captureGraphSnapshot(null, "before graph_load")'],
+    ["function captureGraphSnapshot(mid, label)", "const data = rootGraph.serialize();"],
+    ["function restoreSnapshot(snap)", "app.loadGraphData(JSON.parse(JSON.stringify(snap.data))"],
+    ["function revalidateGraphMutationContext(captured)", "return current;"],
+  ];
+  for (const [startNeedle, beforeNeedle] of DIRECT_MUTATION_PATHS) {
+    const start = src.indexOf(startNeedle);
+    assert.notEqual(start, -1, `${startNeedle} must exist`);
+    const before = src.indexOf(beforeNeedle, start);
+    assert.notEqual(before, -1, `${beforeNeedle} must follow ${startNeedle}`);
+    const fence = src.indexOf("assertGraphBoundToActiveWorkflow(", start);
+    assert.ok(
+      fence > start && fence < before,
+      `${startNeedle} must assert the binding BEFORE it acts`,
+    );
+    assert.match(
+      src.slice(fence, before),
+      /\.\.\.MUTATION_BINDING_BAR/,
+      `${startNeedle} bypasses bridge dispatch, so it must name the full mutation bar itself`,
+    );
+  }
 });
 
 test("graphCommandBindingBar: reads get the reduced DISPATCH bar (they re-assert with the full one)", () => {

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -50,11 +50,20 @@ import {
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
 
+/** Index of `function <name>(`, INCLUDING a preceding `async ` when present —
+ *  without it an extracted async function loses its keyword and its `await`
+ *  becomes a syntax error inside `new Function`. */
+function panelFunctionStart(src, name, from = 0) {
+  const bare = src.indexOf(`function ${name}(`, from);
+  assert.notEqual(bare, -1, `could not locate ${name} in panel source`);
+  const asyncAt = bare - "async ".length;
+  return asyncAt >= 0 && src.startsWith("async ", asyncAt) ? asyncAt : bare;
+}
+
 function panelFunctionSource(src, name, nextName) {
-  const start = src.indexOf(`function ${name}(`);
-  const end = src.indexOf(`function ${nextName}(`, start);
-  assert.notEqual(start, -1, `could not locate ${name} in panel source`);
-  assert.notEqual(end, -1, `could not locate ${nextName} after ${name}`);
+  const start = panelFunctionStart(src, name);
+  const end = panelFunctionStart(src, nextName, start + 1);
+  assert.ok(end > start, `could not locate ${nextName} after ${name}`);
   return src.slice(start, end);
 }
 
@@ -1759,27 +1768,51 @@ test("#545 P1: command identity resolution cannot adopt a stale dirty root befor
   );
 });
 
-test("#545 P1: direct snapshot restore refuses an untagged stale B for dirty A", () => {
+test("#545 P1: direct snapshot restore refuses an untagged stale B for dirty A", async () => {
   const { src, workflowA, rootB, objectUuids, assertBound } = buildDirtyStaleRouteHarness({ rootUuid: null });
   let loads = 0;
-  const restoreSource = panelFunctionSource(src, "restoreSnapshot", "revertGraphToLastSnapshot");
+  // restoreSnapshot PLUS the load-deadline machinery it closes over.
+  const restoreStart = src.indexOf("/** How long a snapshot restore's " + String.fromCharCode(96) + "loadGraphData" + String.fromCharCode(96));
+  assert.notEqual(restoreStart, -1, "could not locate the restore load budget");
+  const restoreSource = src.slice(restoreStart, panelFunctionStart(src, "revertGraphToLastSnapshot", restoreStart + 1));
   const restoreSnapshot = new Function(
     "getGraphCtx",
     "activeWorkflowRef",
     "assertGraphBoundToActiveWorkflow",
     "MUTATION_BINDING_BAR",
+    "coerceMessageText",
+    "activeWorkflowReloadGuard",
+    "acquireWorkflowReloadGuard",
+    "beginWorkflowReloadStep",
+    "endWorkflowReloadStep",
+    "releaseWorkflowReloadGuard",
     `${restoreSource}\nreturn restoreSnapshot;`,
   )(
     () => ({ app: { loadGraphData: () => { loads += 1; } }, graph: rootB, rootGraph: rootB }),
     () => workflowA,
     assertBound,
     MUTATION_BINDING_BAR,
+    (v) => String(v ?? ""),
+    () => null,
+    () => 1,
+    () => true,
+    () => {},
+    () => {},
   );
 
+  const outcome = await restoreSnapshot({ workflowRef: workflowA, data: { nodes: [] } });
   assert.equal(
-    restoreSnapshot({ workflowRef: workflowA, data: { nodes: [] } }),
-    null,
-    "the local restore path catches the binding refusal instead of loading B into A",
+    outcome.status,
+    "refused",
+    "the local restore path must REFUSE the binding rather than load B into A",
+  );
+  // …and it must PRESERVE the reason rather than collapse it to a bare null: the
+  // callers render an absent outcome as "nothing to revert", which would tell the
+  // user there was never a snapshot at the exact moment they are trying to recover.
+  assert.match(
+    outcome.reason,
+    /NOT applied/,
+    "the refusal must carry the panel's own reason for the caller to surface",
   );
   assert.ok(objectUuids.get(workflowA), "the direct guard must root-blindly establish A");
   assert.equal(rootB.extra?.comfyui_mcp?.workflow_uuid, undefined, "the untagged stale root remains untouched");
@@ -1936,7 +1969,7 @@ test("#349 direct paths: run, CivitAI load, and snapshot restore fence the live 
 
   orderedFence("async graph_run({ batch_count, to_node_id })", "app.queuePrompt");
   orderedFence("async graph_load({ graph: incoming } = {})", "captureGraphSnapshot(null, \"before graph_load\")");
-  orderedFence("function restoreSnapshot(snap)", "app.loadGraphData(JSON.parse(JSON.stringify(snap.data))");
+  orderedFence("function restoreSnapshot(snap)", "payload = JSON.parse(JSON.stringify(snap.data))");
 });
 
 test("#349 snapshots: capture is bound and restore rejects a snapshot from another workflow", () => {
@@ -1962,7 +1995,7 @@ test("#349 snapshots: capture is bound and restore rejects a snapshot from anoth
   );
 
   const restoreStart = src.indexOf("function restoreSnapshot(snap)");
-  const restoreLoad = src.indexOf("app.loadGraphData(JSON.parse(JSON.stringify(snap.data))", restoreStart);
+  const restoreLoad = src.indexOf("payload = JSON.parse(JSON.stringify(snap.data))", restoreStart);
   const restoreBody = src.slice(restoreStart, restoreLoad);
   assert.match(
     restoreBody,

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -26,6 +26,10 @@ import {
   graphRootWorkflowUuidMatches,
   graphRootMatchesState,
   graphCommandMayMutateWorkflow,
+  graphCommandBindingBar,
+  graphBindingRefusalMessage,
+  resolveGraphBindingVerdict,
+  MUTATION_BINDING_BAR,
   graphReadBindingChanged,
   resolveGraphRootUuidRebind,
   serializedStateProvenEmpty,
@@ -248,11 +252,8 @@ function buildDirtyStaleRouteHarness({
     "workflowObjectUuid",
     "workflowStableUuid",
     "graphRootWorkflowUuidMismatches",
-    "graphRootWorkflowUuidMatches",
-    "graphRootMismatchesActiveWorkflow",
-    "graphReadDesynced",
-    "graphEmptyBindingUnproven",
-    "activeWorkflowNodeCount",
+    "resolveGraphBindingVerdict",
+    "graphBindingRefusalMessage",
     "activeWorkflowProvenEmpty",
     "graphRootProvenEmpty",
     "workflowOwnsRootUuidTag",
@@ -266,11 +267,8 @@ function buildDirtyStaleRouteHarness({
     uuidStore.workflowObjectUuid,
     stableUuid,
     graphRootWorkflowUuidMismatches,
-    graphRootWorkflowUuidMatches,
-    graphRootMismatchesActiveWorkflow,
-    graphReadDesynced,
-    graphEmptyBindingUnproven,
-    activeWorkflowNodeCount,
+    resolveGraphBindingVerdict,
+    graphBindingRefusalMessage,
     activeWorkflowProvenEmpty,
     graphRootProvenEmpty,
     ownsTag,
@@ -723,18 +721,33 @@ test("#545 wiring: dirty tracker state is inconclusive, but an established workf
     /graphRootWorkflowUuidMismatches\(\{ rootGraph, activeWorkflowUuid \}\)/,
     "a dirty tab retains the positive foreign-root identity fence",
   );
+  // The predicate composition itself now lives in lib/graph-binding.js
+  // (resolveGraphBindingVerdict) so the read-vs-mutation bar is observable in
+  // tests; the panel fence only resolves the evidence and delegates the verdict.
   assert.match(
     body,
+    /const verdict = resolveGraphBindingVerdict\(\{/,
+    "the fence must delegate its verdict to the pure resolver",
+  );
+  const bindingSrc = readFileSync(
+    join(HERE, "../../web/js/lib/graph-binding.js"),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
+  const verdictStart = bindingSrc.indexOf("export function resolveGraphBindingVerdict(");
+  assert.notEqual(verdictStart, -1);
+  const verdictBody = bindingSrc.slice(verdictStart, bindingSrc.indexOf("\n}\n", verdictStart));
+  assert.match(
+    verdictBody,
     /requireDirtyMutationBinding[\s\S]*!graphRootWorkflowUuidMatches\(\{ rootGraph, activeWorkflowUuid \}\)/,
     "a dirty mutation must require a positive root-to-active UUID match, not merely no mismatch",
   );
   assert.match(
-    body,
+    verdictBody,
     /const currentStateTrustworthy = activeWorkflow\?\.isModified !== true;/,
     "a dirty ChangeTracker snapshot is not trustworthy as a binding proof",
   );
   assert.match(
-    body,
+    verdictBody,
     /currentStateTrustworthy &&\s*includeBaselineReadGuard &&\s*graphReadDesynced/,
     "the old node-count baseline guard must not reject a dirty canvas from stale tracker state",
   );
@@ -1754,11 +1767,13 @@ test("#545 P1: direct snapshot restore refuses an untagged stale B for dirty A",
     "getGraphCtx",
     "activeWorkflowRef",
     "assertGraphBoundToActiveWorkflow",
+    "MUTATION_BINDING_BAR",
     `${restoreSource}\nreturn restoreSnapshot;`,
   )(
     () => ({ app: { loadGraphData: () => { loads += 1; } }, graph: rootB, rootGraph: rootB }),
     () => workflowA,
     assertBound,
+    MUTATION_BINDING_BAR,
   );
 
   assert.equal(
@@ -1782,10 +1797,12 @@ test("#545 P1: direct CivitAI graph_load refuses an untagged stale B for dirty A
   const graphLoad = new Function(
     "getGraphCtx",
     "assertGraphBoundToActiveWorkflow",
+    "MUTATION_BINDING_BAR",
     `const GRAPH_TOOL_EXECUTORS = {${graphLoadSource}\n}; return GRAPH_TOOL_EXECUTORS.graph_load;`,
   )(
     () => ({ app: { loadGraphData: async () => { loads += 1; } }, graph: rootB, rootGraph: rootB }),
     assertBound,
+    MUTATION_BINDING_BAR,
   );
 
   await assert.rejects(
@@ -1896,8 +1913,8 @@ test("#349 wiring: every graph command verifies LiteGraph is bound, with positiv
   assert.match(handler, /msg\.cmd\.startsWith\("graph_"\)/, "graph commands must have a root-binding fence");
   assert.match(
     handler,
-    /assertGraphBoundToActiveWorkflow\(graph, rootGraph, \{[\s\S]*requireDirtyMutationBinding: graphCommandMayMutateWorkflow\(msg\.cmd\)[\s\S]*\}\)/,
-    "the fence must inspect the executor graph and demand positive dirty binding only for mutations",
+    /assertGraphBoundToActiveWorkflow\(graph, rootGraph, graphCommandBindingBar\(msg\.cmd\)\)/,
+    "the fence must inspect the executor graph and derive its bar from the command's mutability",
   );
 });
 
@@ -1912,8 +1929,8 @@ test("#349 direct paths: run, CivitAI load, and snapshot restore fence the live 
     assert.ok(fence > start && fence < before, `${startNeedle} must fence before ${beforeNeedle}`);
     assert.match(
       src.slice(fence, before),
-      /requireDirtyMutationBinding: true/,
-      `${startNeedle} must require a positive binding for dirty mutation`,
+      /\.\.\.MUTATION_BINDING_BAR/,
+      `${startNeedle} must clear the full MUTATION binding bar, not a reduced one`,
     );
   };
 
@@ -1930,7 +1947,7 @@ test("#349 snapshots: capture is bound and restore rejects a snapshot from anoth
   assert.ok(captureStart >= 0 && captureFence > captureStart && captureFence < captureSerialize);
   assert.match(
     src.slice(captureFence, captureSerialize),
-    /requireDirtyMutationBinding: true/,
+    /\.\.\.MUTATION_BINDING_BAR/,
     "snapshot capture must not record an unbound dirty root for later restore",
   );
   assert.match(

--- a/browser_tests/unit/graph-revert.test.mjs
+++ b/browser_tests/unit/graph-revert.test.mjs
@@ -6,8 +6,16 @@
 // the current canvas and reverting to it recovered nothing (silent no-op).
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 
-import { pickRevertSnapshot } from "../../web/js/lib/graph-revert.js";
+import {
+  pickRevertSnapshot,
+  describeRevertOutcome,
+  revertDidRestore,
+  REVERT_STATUS,
+} from "../../web/js/lib/graph-revert.js";
 
 const snap = (data) => ({ mid: null, ts: 0, data });
 // Distinct serialized-graph shapes standing in for rootGraph.serialize() output.
@@ -70,4 +78,626 @@ test("treats key-reordered but structurally-equal graphs as identical (no false 
   assert.equal(pickRevertSnapshot(ring, currentReordered).data, GRAPH_A);
   // And when the ONLY snapshot equals current (reordered), nothing to revert.
   assert.equal(pickRevertSnapshot([snap(newest)], currentReordered), null);
+});
+
+// ---------------------------------------------------------------------------
+// Revert OUTCOMES (#604 follow-up) — a refusal must never render as "nothing"
+// ---------------------------------------------------------------------------
+//
+// The restore path answered with `snapshot | null`, and all three consumers
+// (/revert, double-Esc rewind, the per-message rollback modal) rendered `null`
+// as "no snapshot". That collapsed a REFUSAL into the one answer that ends the
+// user's attempt — and the refusal fires at the worst possible moment: a backend
+// restart leaves the canvas on a graph the panel cannot identify, getGraphCtx
+// refuses [canvas-root-divergence] before loadGraphData, and the user is told
+// there was never a snapshot, with the save/export/reload remedy dropped.
+//
+// FAIL-before / PASS-after: with the old `null` collapse there is no outcome to
+// describe, and describeRevertOutcome / revertDidRestore do not exist.
+
+const DIVERGENCE =
+  "[canvas-root-divergence] The canvas you are looking at (31 node(s)) and the panel's bound " +
+  "root graph (0 node(s)) are two DIFFERENT graphs, so this command was NOT applied — save or " +
+  "export the canvas you want to keep, then reload the ComfyUI page.";
+
+const WORDING = {
+  action: "revert",
+  restoredText: "Reverted the canvas to before your last message.",
+  noneText: "Nothing to revert — no graph snapshot captured in this session yet.",
+};
+
+test("#604: a REFUSED restore never renders as 'nothing to revert', and keeps the remedy", () => {
+  const line = describeRevertOutcome({ status: "refused", reason: DIVERGENCE }, WORDING);
+
+  assert.doesNotMatch(
+    line,
+    /Nothing to revert/,
+    "the exact defect: a snapshot EXISTS and was refused — claiming none ends the recovery attempt",
+  );
+  assert.match(line, /Could not revert/, "say what did not happen");
+  // Precisely "no graph edits were applied", NOT "nothing was changed": getGraphCtx
+  // may legitimately have reconciled the VIEW first (the proven-content-free
+  // stranded-canvas repaint) before the binding assert refused. Retrying is safe
+  // because no workflow data was touched — but a blanket "nothing changed" would
+  // overstate a call whose view effect is real.
+  assert.match(line, /no graph edits were applied/, "the safe-to-retry fact, stated exactly");
+  assert.doesNotMatch(line, /nothing was changed/, "do not overclaim a side-effect-free path");
+  // Nor may it assert a snapshot EXISTS: the no-active-workflow branches refuse
+  // without ever consulting the ring, so "the snapshot is still here" would
+  // fabricate one for exactly the caller least able to check.
+  assert.doesNotMatch(line, /snapshot is still here/, "a refusal must not claim a snapshot exists");
+  assert.match(line, /canvas-root-divergence/, "carry the reason code the panel refused with");
+  assert.match(line, /reload the ComfyUI page/, "and the remedy it was carrying — that is the point");
+});
+
+test("#604: a refusal raised before any snapshot was selected must not claim one exists", () => {
+  // revertGraphToLastSnapshot / revertGraphSnapshotByMid refuse on an unreadable
+  // active workflow WITHOUT consulting the ring — which may well be empty.
+  const line = describeRevertOutcome(
+    {
+      status: "refused",
+      reason: "The panel cannot read the active workflow right now, so it cannot tell which snapshots belong to this canvas. Retry in a moment.",
+    },
+    WORDING,
+  );
+  assert.doesNotMatch(line, /snapshot is still here/);
+  assert.match(line, /nothing was loaded/, "what IS true of every refusal");
+  assert.match(line, /cannot read the active workflow/, "with the specifics carried by the reason");
+});
+
+test("#604: a FAILED restore is DISCLOSED, not reported as nothing-happened", () => {
+  // loadGraphData was already called, so the canvas may be partly changed. Saying
+  // "nothing to revert" here would invite a retry on top of a half-applied load.
+  const line = describeRevertOutcome({ status: "failed", reason: "boom" }, WORDING);
+  assert.doesNotMatch(line, /Nothing to revert/);
+  assert.match(line, /RAN but the panel could not confirm/, "the action happened — disclose, never refuse after the fact");
+  assert.match(line, /canvas may have changed/);
+  assert.match(line, /boom/);
+});
+
+test("a genuine NONE still says nothing-to-revert, and a restore still reports success", () => {
+  assert.equal(describeRevertOutcome({ status: "none" }, WORDING), WORDING.noneText);
+  assert.equal(describeRevertOutcome({ status: "restored", snapshot: {} }, WORDING), WORDING.restoredText);
+});
+
+test("an UNRECOGNIZED outcome is indeterminate — it must not become a definite 'no snapshot'", () => {
+  // Only a broken producer can get here, and the honest answer is "I don't know",
+  // not the caller's "none" wording: rendering an unknown as "no graph snapshot
+  // captured" is the same could-not-determine-becomes-a-verdict defect this whole
+  // vocabulary exists to remove, one level up.
+  for (const outcome of [null, undefined, {}, { status: "who-knows" }, "restored"]) {
+    const line = describeRevertOutcome(outcome, WORDING);
+    assert.notEqual(line, WORDING.noneText, `${JSON.stringify(outcome)} must not render as "none"`);
+    assert.notEqual(line, WORDING.restoredText, `${JSON.stringify(outcome)} must not render as success`);
+    assert.match(line, /Could not tell whether the revert happened/);
+    assert.match(line, /check the canvas/);
+  }
+});
+
+test("a refusal with no reason still refuses — it never degrades into 'nothing to revert'", () => {
+  const line = describeRevertOutcome({ status: "refused" }, WORDING);
+  assert.doesNotMatch(line, /Nothing to revert/);
+  assert.match(line, /No reason was reported/, "an unexplained refusal is still a refusal, stated as one");
+});
+
+test("revertDidRestore: only a RESTORED outcome counts as success", () => {
+  // Every outcome object is truthy, so a caller's bare `if (outcome)` would read a
+  // refusal as a successful revert — which is how the rewind path would otherwise
+  // have claimed "canvas reverted" over a refused one.
+  assert.equal(revertDidRestore({ status: "restored", snapshot: {} }), true);
+  for (const status of ["none", "refused", "failed", undefined]) {
+    assert.equal(revertDidRestore({ status }), false, `${status} is not a restore`);
+  }
+  assert.equal(revertDidRestore(null), false);
+});
+
+test("REVERT_STATUS names exactly the four distinguishable answers", () => {
+  assert.deepEqual(Object.values(REVERT_STATUS).sort(), ["failed", "none", "refused", "restored"]);
+});
+
+// The suppression was in the SHARED path, so the fix has to be there too — not at
+// /revert. These bind all three entry points to it: none may re-derive its own
+// verdict from a truthiness test, which is how the refusal was being lost.
+test("#604 wiring: /revert, double-Esc rewind and per-message rollback all render via the shared path", () => {
+  const src = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js"),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
+
+  // Every producer answers with an OUTCOME. A bare `return null` on these paths is
+  // what collapsed "refused" into "no snapshot".
+  for (const producer of ["restoreSnapshot", "revertGraphToLastSnapshot", "revertGraphSnapshotByMid"]) {
+    const start = src.indexOf(`function ${producer}(`);
+    assert.notEqual(start, -1, `${producer} must exist`);
+    const body = src.slice(start, src.indexOf("\n}\n", start));
+    assert.doesNotMatch(
+      body,
+      /return null;/,
+      `${producer} must return a status outcome, never a bare null the caller reads as "no snapshot"`,
+    );
+    assert.match(body, /status: "none"/, `${producer} must say "none" explicitly when it means none`);
+  }
+
+  // Each consumer renders through describeRevertOutcome, so a refusal cannot be
+  // dropped by one of them wording its own message.
+  const consumers = [
+    ['cmd: "/revert"', "restoredText"],
+    ["function rewindLastTurn()", "restoredText"],
+    ["const wantCode = ", "restoredText"],
+  ];
+  for (const [needle, expected] of consumers) {
+    const at = src.indexOf(needle);
+    assert.notEqual(at, -1, `${needle} must exist`);
+    const region = src.slice(at, at + 2400);
+    assert.match(
+      region,
+      /describeRevertOutcome\(/,
+      `${needle} must render the outcome through the shared describer`,
+    );
+    assert.ok(region.includes(expected));
+  }
+
+  // The rewind path in particular must not treat the (always-truthy) outcome
+  // object as success.
+  const rewindAt = src.indexOf("function rewindLastTurn()");
+  const rewind = src.slice(rewindAt, src.indexOf("\n  }\n", rewindAt));
+  assert.match(
+    rewind,
+    /revertDidRestore\(outcome\)/,
+    "an outcome object is always truthy — success must be tested explicitly",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The rollback modal, driven for real
+// ---------------------------------------------------------------------------
+//
+// The canvas rollback is an async load, so this modal outlives a tick: the
+// primary action can be clicked twice, and the user can Cancel while the restore
+// is in flight. Both were reachable ways to rewind the conversation and RESEND
+// the user's message when they had not asked for it. Source-scanning the handler
+// cannot show that, so the real function is extracted and driven over a minimal
+// DOM.
+//
+// SCOPE, stated honestly: this exercises the handler's LOGIC, not the browser. The
+// fake `fire()` calls registered listeners directly, so it models neither real
+// event dispatch/bubbling, nor hit-testing, nor the browser's own suppression of
+// clicks on a disabled button. A wiring mistake that stops the overlay receiving
+// mousedown at all would not be caught here — only in a live browser.
+
+const PANEL_SRC = () =>
+  readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js"),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
+
+/** Just enough DOM for openRollbackModal: element creation, class/text/value,
+ *  append, listeners, remove, focus. Listeners are recorded so a test can click. */
+function fakeDom() {
+  const make = (tag) => {
+    const el = {
+      tag,
+      children: [],
+      listeners: new Map(),
+      className: "",
+      textContent: "",
+      value: "",
+      checked: false,
+      disabled: false,
+      removed: false,
+      append(...kids) {
+        this.children.push(...kids);
+      },
+      appendChild(kid) {
+        this.children.push(kid);
+        return kid;
+      },
+      addEventListener(ev, fn) {
+        if (!this.listeners.has(ev)) this.listeners.set(ev, []);
+        this.listeners.get(ev).push(fn);
+      },
+      remove() {
+        this.removed = true;
+      },
+      focus() {},
+      fire(ev, arg) {
+        return Promise.all((this.listeners.get(ev) ?? []).map((fn) => fn(arg)));
+      },
+    };
+    return el;
+  };
+  return {
+    createElement: make,
+    createTextNode: (text) => {
+      const node = make("#text");
+      node.textContent = text;
+      return node;
+    },
+  };
+}
+
+/** Find the descendant whose textContent matches, breadth-first. */
+function findByText(el, text) {
+  const queue = [el];
+  while (queue.length) {
+    const node = queue.shift();
+    if (node?.textContent === text) return node;
+    queue.push(...(node?.children ?? []));
+  }
+  return null;
+}
+
+/** The REAL openRollbackModal over a fake DOM, with every collaborator recorded. */
+function buildRollbackModal({ revert }) {
+  const src = PANEL_SRC();
+  const start = src.indexOf("  function openRollbackModal({ mid, text, anchor }) {");
+  assert.notEqual(start, -1, "openRollbackModal must exist");
+  const end = src.indexOf("  function drawQrToCanvas(", start);
+  assert.ok(end > start, "could not bound openRollbackModal");
+  const source = src.slice(start, end);
+
+  const calls = { systems: [], frames: [], composer: [], submits: 0 };
+  const root = fakeDom().createElement("div");
+  const openRollbackModal = new Function(
+    "document",
+    "root",
+    "client",
+    "appendSystem",
+    "setComposerValue",
+    "form",
+    "revertGraphSnapshotByMid",
+    "describeRevertOutcome",
+    "revertDidRestore",
+    "setTimeout",
+    `${source}\nreturn openRollbackModal;`,
+  )(
+    fakeDom(),
+    root,
+    { sendFrame: (f) => calls.frames.push(f) },
+    (msg) => calls.systems.push(msg),
+    (v) => calls.composer.push(v),
+    {
+      requestSubmit() {
+        calls.submits += 1;
+      },
+    },
+    revert,
+    describeRevertOutcome,
+    revertDidRestore,
+    () => {},
+  );
+
+  openRollbackModal({ mid: "m1", text: "do the thing", anchor: "a1" });
+  const overlay = root.children[0];
+  const go = findByText(overlay, "Roll back & resend");
+  const cancel = findByText(overlay, "Cancel");
+  assert.ok(go && cancel, "the modal must render both buttons");
+  return { calls, overlay, go, cancel };
+}
+
+test("#604: cancelling DURING an in-flight rollback must not rewind or resend", () => {
+  // The reachable repro: choose Code+conversation (the default), click "Roll back &
+  // resend", then Cancel while the restore is still awaiting. The user backed out —
+  // resending their message afterwards is acting on their behalf.
+  let release;
+  const pending = new Promise((resolve) => {
+    release = resolve;
+  });
+  const { calls, go, cancel } = buildRollbackModal({ revert: () => pending });
+
+  const done = go.fire("click");
+  cancel.fire("click"); // user backs out while the load is in flight
+  release({ status: "restored", snapshot: {} });
+
+  return done.then(() => {
+    assert.deepEqual(calls.frames, [], "a cancelled rollback must NOT rewind the conversation");
+    assert.equal(calls.submits, 0, "and must NOT resend the user's message");
+    assert.ok(
+      calls.systems.some((m) => /Cancelled/.test(m)),
+      "say that it stopped, rather than silently doing nothing",
+    );
+    assert.deepEqual(calls.composer, ["do the thing"], "the edit stays with the user");
+  });
+});
+
+test("#604: BACKDROP dismissal during an in-flight rollback stops the rewind and resend too", () => {
+  // Cancel and the backdrop are two separate wirings; covering only the button
+  // would leave a deleted/mis-wired backdrop handler green while it silently
+  // resends on the user's behalf.
+  let release;
+  const pending = new Promise((resolve) => {
+    release = resolve;
+  });
+  const { calls, overlay, go } = buildRollbackModal({ revert: () => pending });
+
+  const done = go.fire("click");
+  overlay.fire("mousedown", { target: overlay }); // click outside the modal body
+  release({ status: "restored", snapshot: {} });
+
+  return done.then(() => {
+    assert.deepEqual(calls.frames, [], "a backdrop dismissal must NOT rewind the conversation");
+    assert.equal(calls.submits, 0, "and must NOT resend the user's message");
+    assert.ok(calls.systems.some((m) => /Cancelled/.test(m)));
+  });
+});
+
+test("#604: a click INSIDE the modal body is not a dismissal", () => {
+  // The backdrop handler fires for every mousedown on the overlay; only a hit on
+  // the overlay ITSELF is a dismissal. Treating an inner click as one would abort
+  // rollbacks the user never cancelled.
+  let release;
+  const pending = new Promise((resolve) => {
+    release = resolve;
+  });
+  const { calls, overlay, go } = buildRollbackModal({ revert: () => pending });
+  // Assert the wiring EXISTS as well as its behaviour: without this the test would
+  // also pass with the whole backdrop handler deleted (no handler ⇒ no dismissal
+  // ⇒ the same expected rewind/resend).
+  assert.equal(
+    (overlay.listeners.get("mousedown") ?? []).length,
+    1,
+    "the overlay must have exactly one backdrop handler",
+  );
+
+  const done = go.fire("click");
+  overlay.fire("mousedown", { target: { not: "the overlay" } });
+  release({ status: "restored", snapshot: {} });
+
+  return done.then(() => {
+    assert.deepEqual(calls.frames, [{ type: "rewind", anchor: "a1" }], "this rollback was never cancelled");
+    assert.equal(calls.submits, 1);
+  });
+});
+
+test("#604: an uncancelled rollback still rewinds and resends (the modal is not simply disabled)", () => {
+  const { calls, go } = buildRollbackModal({
+    revert: async () => ({ status: "restored", snapshot: {} }),
+  });
+  return go.fire("click").then(() => {
+    assert.deepEqual(calls.frames, [{ type: "rewind", anchor: "a1" }]);
+    assert.equal(calls.submits, 1);
+    assert.deepEqual(calls.composer, ["do the thing"]);
+  });
+});
+
+test("#604: 'no snapshot for this message' also stops the resend — it is not proof the canvas is right", () => {
+  // The 25-entry ring evicts, so rolling back an OLD message reports "canvas left
+  // as-is" while the canvas actually carries every later turn's edits. Treating
+  // that as permission to resend is the same unknown-as-verdict mistake one level
+  // up, and it was the pre-existing behaviour.
+  const { calls, go } = buildRollbackModal({ revert: async () => ({ status: "none" }) });
+  return go.fire("click").then(() => {
+    assert.deepEqual(calls.frames, [], "no rollback happened, so do not rewind the conversation");
+    assert.equal(calls.submits, 0, "and do not resend against a canvas nobody verified");
+    assert.ok(calls.systems.some((m) => /No graph snapshot for this message/.test(m)), "say what happened");
+    assert.ok(calls.systems.some((m) => /Not resending/.test(m)), "and that it stopped short of resending");
+    assert.deepEqual(calls.composer, ["do the thing"], "the edit stays with the user");
+  });
+});
+
+test("#604: a REFUSED rollback stops the resend and hands the edit back", () => {
+  const { calls, go } = buildRollbackModal({
+    revert: async () => ({ status: "refused", reason: "[canvas-root-divergence] two different graphs" }),
+  });
+  return go.fire("click").then(() => {
+    assert.deepEqual(calls.frames, [], "do not rewind the conversation over a canvas that was not rolled back");
+    assert.equal(calls.submits, 0, "and do not resend against it — that is the destructive retry");
+    assert.ok(calls.systems.some((m) => /canvas-root-divergence/.test(m)), "surface the refusal's reason");
+    assert.ok(calls.systems.some((m) => /Not resending/.test(m)));
+    assert.deepEqual(calls.composer, ["do the thing"]);
+  });
+});
+
+test("#604: double-clicking the primary action starts ONE rollback and sends ONE message", () => {
+  let restores = 0;
+  let release;
+  const pending = new Promise((resolve) => {
+    release = resolve;
+  });
+  const { calls, go } = buildRollbackModal({
+    revert: () => {
+      restores += 1;
+      return pending;
+    },
+  });
+
+  const first = go.fire("click");
+  const second = go.fire("click"); // impatient double click
+  release({ status: "restored", snapshot: {} });
+
+  return Promise.all([first, second]).then(() => {
+    assert.equal(restores, 1, "two restores would race and settle out of order");
+    assert.equal(calls.frames.length, 1, "and both continuations would rewind the conversation");
+    assert.equal(calls.submits, 1, "and resend the message twice");
+    assert.equal(go.disabled, true, "the button is visibly disabled while it runs");
+  });
+});
+
+test("#604 wiring: the rollback modal does NOT resend when the canvas was not rolled back", () => {
+  // The user asked to roll the canvas back AND resend against it. Resending after a
+  // refused or half-applied rollback aims the next turn at a graph they did not
+  // choose — the destructive retry this cluster is about. Awaiting the load fixes
+  // "still in flight"; it does not fix "did not happen".
+  const src = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js"),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
+  const at = src.indexOf('go.addEventListener("click", async () => {');
+  assert.notEqual(at, -1, "the primary action handler must exist and be async");
+  const handler = src.slice(at, src.indexOf("btnRow.append(cancel, go);", at));
+
+  const gateAt = handler.indexOf("if (!revertDidRestore(outcome))");
+  const rewindAt = handler.indexOf('type: "rewind"');
+  const resendAt = handler.indexOf("form.requestSubmit()");
+  assert.ok(gateAt !== -1, "the handler must decide whether the rollback actually happened");
+  assert.ok(gateAt < rewindAt && gateAt < resendAt, "and decide BEFORE rewinding and resending");
+  assert.match(
+    handler.slice(gateAt),
+    /if \(!revertDidRestore\(outcome\)\) \{[\s\S]*?return;/,
+    "a rollback that is not PROVEN to have happened must stop the resend",
+  );
+  // "none" must NOT be an exemption: it means only that this message has no
+  // snapshot (the ring evicts at 25), so the canvas may carry every later turn's
+  // edits — an unknown state read as permission to resend.
+  assert.doesNotMatch(
+    handler.slice(gateAt, gateAt + 300),
+    /status === "none"/,
+    '"no snapshot for this message" is not proof the canvas is what the user asked for',
+  );
+
+  // The cancellation gate must sit BEFORE the rewind and the resend. (Its
+  // behaviour is covered for real by the driven-modal tests above; what only a
+  // source check can add is the ORDER, since a gate placed after the resend would
+  // still satisfy a behavioural test that never cancels.)
+  const cancelAt = handler.indexOf("if (cancelled)");
+  assert.ok(cancelAt !== -1, "a cancellation during the await must be gated");
+  assert.ok(cancelAt < rewindAt && cancelAt < resendAt, "and gated BEFORE rewinding and resending");
+  assert.match(handler.slice(cancelAt, cancelAt + 400), /return;/, "and it must stop the handler");
+});
+
+/** The REAL rewindLastTurn over stubbed collaborators, so the reply it produces can
+ *  be read rather than inferred from the source. */
+function buildRewindLastTurn({ outcome, recalled }) {
+  const src = PANEL_SRC();
+  const start = src.indexOf("  async function rewindLastTurn() {");
+  assert.notEqual(start, -1, "rewindLastTurn must exist");
+  const end = src.indexOf("  function openRollbackModal(", start);
+  assert.ok(end > start, "could not bound rewindLastTurn");
+
+  const systems = [];
+  const rewindLastTurn = new Function(
+    "recallPrev",
+    "input",
+    "revertGraphToLastSnapshot",
+    "revertDidRestore",
+    "describeRevertOutcome",
+    "appendSystem",
+    `${src.slice(start, end)}\nreturn rewindLastTurn;`,
+  )(
+    () => recalled,
+    { focus() {} },
+    async () => outcome,
+    revertDidRestore,
+    describeRevertOutcome,
+    (msg) => systems.push(msg),
+  );
+  return { rewindLastTurn, systems };
+}
+
+test("#604: a rewind over an EVICTED ring must say the canvas was not restored", async () => {
+  // The ring holds 25 and evicts, so an old turn's snapshot is simply gone. The
+  // composer half still succeeds, and "Rewound your last turn; your message is back
+  // in the composer to edit & resend" reads as a completed rewind — after which the
+  // user resends against a graph that still holds the very edits they meant to undo.
+  // Same unknown-canvas-as-permission-to-resend chain as the rollback modal.
+  const { rewindLastTurn, systems } = buildRewindLastTurn({ outcome: { status: "none" }, recalled: true });
+  await rewindLastTurn();
+
+  const reply = systems.join("\n");
+  assert.match(reply, /back in the composer/, "the composer half genuinely happened — still say so");
+  assert.doesNotMatch(reply, /canvas reverted/, "but never claim the canvas half did");
+  assert.match(reply, /canvas was NOT reverted/, "state the canvas half explicitly");
+  assert.match(reply, /still holds that turn's edits/, "and what that means for a resend");
+});
+
+test("#604: a rewind with nothing at all to rewind still says so", async () => {
+  const { rewindLastTurn, systems } = buildRewindLastTurn({ outcome: { status: "none" }, recalled: false });
+  await rewindLastTurn();
+  assert.match(systems.join("\n"), /Nothing to rewind yet/);
+});
+
+test("#604: a rewind over a REFUSED revert carries the refusal, not a rewound claim", async () => {
+  const { rewindLastTurn, systems } = buildRewindLastTurn({
+    outcome: { status: "refused", reason: "[canvas-root-divergence] two different graphs" },
+    recalled: true,
+  });
+  await rewindLastTurn();
+  const reply = systems.join("\n");
+  assert.doesNotMatch(reply, /canvas reverted/);
+  assert.match(reply, /canvas-root-divergence/, "the reason and its remedy must survive to the user");
+});
+
+test("#604: a successful rewind still reports the canvas revert once, with no correction", async () => {
+  const { rewindLastTurn, systems } = buildRewindLastTurn({
+    outcome: { status: "restored", snapshot: {} },
+    recalled: true,
+  });
+  await rewindLastTurn();
+  const reply = systems.join("\n");
+  assert.match(reply, /canvas reverted/);
+  assert.doesNotMatch(reply, /NOT reverted/, "a working rewind must not be followed by a warning");
+  assert.equal(systems.length, 1, "and says it once");
+});
+
+test("#604: describeRevertOutcome will not let a caller SUPPRESS the none variant", async () => {
+  // The mechanism-level half of the same defect: an entry point that passes empty
+  // text words the variant away by omission, and a variant that renders as nothing
+  // is indistinguishable from one that never fired.
+  //
+  // INVISIBLES count as empty. Notices render through textContent, so a zero-width
+  // space is a perfectly good suppression that survives trim() — "technically
+  // supplied text" that puts nothing on screen.
+  // Escapes, never literal invisibles: a test that carries them is unreviewable
+  // and an editor or copy/paste can silently change what it asserts.
+  //
+  // Each of these defeated an EARLIER version of the check, which is why the
+  // filter is now an allowlist of meaning-bearing characters rather than a list
+  // of invisible ones.
+  const invisible = [
+    "\u200b", // zero-width space - survives trim()
+    "\ufeff", // byte-order mark
+    "\u00ad", // soft hyphen
+    "\u2060", // word joiner
+    "\u200e\u200f", // bidi marks
+    "\u202d\u202c", // bidi override + pop
+    "\u2066", // LEFT-TO-RIGHT ISOLATE - outside the hand-listed ranges
+    "\u2067",
+    "\u2068",
+    "\u2069", // POP DIRECTIONAL ISOLATE
+    "\u2800", // BRAILLE PATTERN BLANK - a SYMBOL that draws nothing, so it
+                // is neither whitespace nor Cf/Cc/Default_Ignorable
+    "\u3164", // HANGUL FILLER - category Lo, a LETTER that draws nothing, so
+                // a bare letter/digit allowlist admits it too
+    "\u115f\u1160", // Hangul choseong/jungseong fillers, same shape
+    "\uffa0", // halfwidth Hangul filler
+    "\ufe0f", // variation selector
+    "\u2028", // line separator
+    "\u0000", // NUL - a control character renders as nothing too
+    "-> ...", // punctuation only: not a statement of the verdict either
+    " \u200b \ufeff \u2066 \u2800 ", // mixed with ordinary whitespace
+  ];
+  for (const noneText of ["", "   ", "\t\n", undefined, null, 42, {}, ...invisible]) {
+    const line = describeRevertOutcome({ status: "none" }, { restoredText: "ok", noneText });
+    assert.ok(line && line.trim(), `none must still be stated for noneText=${JSON.stringify(noneText)}`);
+    assert.match(line, /canvas was NOT restored/);
+  }
+  // …while a caller whose wording merely CONTAINS an invisible is left alone.
+  const worded = "No\u200bthing to revert.";
+  assert.equal(describeRevertOutcome({ status: "none" }, { noneText: worded }), worded);
+  // A caller's real wording is still honoured.
+  assert.equal(
+    describeRevertOutcome({ status: "none" }, { noneText: "Nothing to revert." }),
+    "Nothing to revert.",
+  );
+  // RESTORED may be blank: a caller whose own summary states the restore has nothing
+  // to add, and an unstated success misleads no one.
+  assert.equal(describeRevertOutcome({ status: "restored" }, { restoredText: "", noneText: "n" }), "");
+});
+
+test("#604 wiring: async slash commands cannot leave a floating promise", () => {
+  const src = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js"),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
+  // /revert's run() is async now. Both entry points (the slash menu and typing the
+  // command) must go through the normalizing runner rather than calling run()
+  // bare, or a rejection surfaces as an unhandled promise from a sync UI handler.
+  assert.match(src, /function runSlashCommand\(entry\) \{[\s\S]*?Promise\.resolve\(entry\.run\(\)\)\.catch\(/);
+  // POSITIVE assertions: forbidding the bare form alone would also pass if a call
+  // site were deleted, or replaced with some other unguarded invocation.
+  assert.match(src, /\n\s*runSlashCommand\(item\.ref\);/, "the slash menu must route through the runner");
+  assert.match(src, /\n\s*runSlashCommand\(c\);/, "so must the typed-command path");
+  assert.doesNotMatch(src, /\n\s*item\.ref\.run\(\);/, "and neither may call run() bare");
+  assert.doesNotMatch(src, /\n\s*c\.run\(\);/);
+  assert.match(src, /rewindLastTurn\(\)\.catch\(/, "the double-Esc rewind is fire-and-forget with a catch");
 });

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -524,11 +524,11 @@ test("#442 codex P1: the destructive re-read freezes canvas interaction and ALWA
   const body = handlerBody(src, "async workflow_open({");
   // The clean sample authorizes the load, but loadGraphData is awaited — an edit made
   // while it yields would be destroyed by a reload nobody asked for.
-  const lockAt = body.indexOf("canvasView.allow_interaction = false;");
+  const lockAt = body.indexOf("acquireCanvasInteractionLock(canvasView)");
   const firstRebaselineAt = body.indexOf("await clearSpuriousOpenModified(target, {");
   const loadAt = body.indexOf("await app.loadGraphData(diskGraph");
   const rebaselineAt = body.indexOf("await clearSpuriousOpenModified(target, {", loadAt);
-  const restoreAt = body.indexOf("canvasView.allow_interaction = priorInteraction;");
+  const restoreAt = body.indexOf("releaseCanvasInteractionLock(priorInteraction, canvasView);");
   assert.ok(lockAt !== -1 && loadAt !== -1 && restoreAt !== -1, "the load must be bracketed by an interaction lock");
   // clearSpuriousOpenModified awaits a frame and then RE-BASELINES the change tracker, so
   // an edit made during it is absorbed as the new CLEAN baseline — which would make the
@@ -550,8 +550,20 @@ test("#442 codex P1: the destructive re-read freezes canvas interaction and ALWA
   assert.ok(lockAt < dirtySampleAt && dirtySampleAt < restoreAt, "the dirty sample must be taken under the freeze");
   // The restore must live in a `finally`, so a throwing load can never strand a frozen canvas.
   const tail = body.slice(loadAt, restoreAt + 200);
-  assert.match(tail, /\} finally \{[\s\S]*allow_interaction = priorInteraction;/, "the restore must be in a finally");
-  assert.match(body, /typeof canvasView\?\.allow_interaction === "boolean"/);
+  assert.match(
+    tail,
+    /\} finally \{[\s\S]*releaseCanvasInteractionLock\(priorInteraction, canvasView\);/,
+    "the release must be in a finally",
+  );
+  // The boolean probe lives in the lock helper now. What matters HERE is that the
+  // release is OWNER-CHECKED: `allow_interaction` is a bare boolean, so restoring a
+  // saved value unconditionally would let this section unlock the canvas out from
+  // under a concurrent snapshot restore that is still loading (and vice versa).
+  assert.doesNotMatch(
+    body,
+    /canvasView\.allow_interaction = /,
+    "the freeze must go through the owned lock, never a bare assignment",
+  );
   // The local must NOT be named so that it ends in "s": the #268 contract scanner
   // captures `s\.<member>` unanchored, so `canvas.allow_interaction` reads as a new
   // workflow-SERVICE dependency and fails that gate.
@@ -598,7 +610,10 @@ test("#442 codex R9: the switch+reload holds a critical section that REFUSES con
   // Release must be in the SAME finally as the canvas restore — a throw must never leave
   // the tab refusing every command.
   const tail = body.slice(body.indexOf("} finally {", openAt));
-  assert.match(tail, /releaseWorkflowReloadGuard\(reloadGuardToken\);[\s\S]{0,200}allow_interaction = priorInteraction;/);
+  assert.match(
+    tail,
+    /releaseWorkflowReloadGuard\(reloadGuardToken\);[\s\S]{0,300}releaseCanvasInteractionLock\(/,
+  );
   // codex R10 — token-scoped: an expired-then-superseded holder must not release a NEWER
   // holder's section, and must not keep mutating once it has lost it.
   assert.match(src, /if \(workflowReloadGuard && workflowReloadGuard\.token === token\) workflowReloadGuard = null;/);
@@ -780,7 +795,7 @@ test("#442 round-3: a FIRST-TIME open never re-baselines without the freeze (edi
   // allow_interaction — exactly the case where the freeze below is actually applied.
   assert.match(
     body,
-    /const priorInteraction =\s*wasOpen && typeof canvasView\?\.allow_interaction === "boolean"/,
+    /const priorInteraction = wasOpen \? acquireCanvasInteractionLock\(canvasView\) : null;/,
     "priorInteraction !== null ⟺ the freeze is held",
   );
   // clearSpuriousOpenModified awaits a frame, then captures the canvas as the CLEAN

--- a/browser_tests/unit/subgraph-scope.test.mjs
+++ b/browser_tests/unit/subgraph-scope.test.mjs
@@ -424,18 +424,26 @@ test("resolveScope: at root ⇒ scope 'root'", () => {
 
 // THE #220 lockstep test: after a reconnect the root graph is REBUILT (new owner
 // instance whose .subgraph is a NEW object), but the canvas still references the OLD
-// subgraph. The old canvas subgraph is unreachable from the live root ⇒ STALE.
-test("#220/#308: stale canvas subgraph (rebuilt root) ⇒ reconcile to root, read+edit in lockstep", () => {
-  const staleSub = makeSubgraph({ name: "old", nodes: [{ id: 87 }, { id: 88 }] });
-  // Rebuilt root: a fresh owner node whose subgraph is a DIFFERENT object.
+// subgraph. The old canvas subgraph is unreachable from the live root.
+//
+// #604 UPDATE — what happens next is decided by CONTENT, not by the graph's kind.
+// A PROVABLY content-free ghost is reconciled to root exactly as before (nothing can
+// be lost). A ghost that still HOLDS nodes is NOT reconciled: "unreachable" proves
+// only that the rebuilt root does not own it, never that it is disposable, and
+// repainting it away destroyed a user's unsaved graph in the root-level form of this
+// same bug. Both branches keep #220's actual guarantee — a read and an edit issued
+// back-to-back can never target two different graphs — the second by refusing both.
+test("#220/#308: a PROVABLY EMPTY ghost subgraph still reconciles to root, read+edit in lockstep", () => {
+  const emptyGhost = makeSubgraph({ name: "old" });
+  emptyGhost.serialize = () => ({ nodes: [] });
   const freshSub = makeSubgraph({ name: "new", nodes: [{ id: 87 }, { id: 88 }] });
-  const freshOwner = { id: 128, subgraph: freshSub };
-  const app = makeApp({ rootNodes: [freshOwner], canvasGraph: staleSub });
+  const app = makeApp({ rootNodes: [{ id: 128, subgraph: freshSub }], canvasGraph: emptyGhost });
 
   const scope = resolveScope(app);
-  // The read scope resolves to ROOT (not a phantom subgraph) because staleSub is
+  // The read scope resolves to ROOT (not a phantom subgraph) because emptyGhost is
   // unreachable from the rebuilt root — so it AGREES with where writes would land.
-  assert.equal(scope.stale, true, "unreachable canvas subgraph must be flagged stale");
+  assert.equal(scope.stale, true, "an unreachable, provably-empty canvas subgraph is reconcilable");
+  assert.equal(scope.diverged, false);
   assert.equal(scope.scope, "root");
   assert.equal(scope.graph, app.graph, "reads reconcile to the live root");
   assert.equal(scope.rootGraph, app.graph);
@@ -450,6 +458,37 @@ test("#220/#308: stale canvas subgraph (rebuilt root) ⇒ reconcile to root, rea
   assert.equal(app.canvas.graph, app.graph);
   // Re-resolving is now cleanly at root (no residual subgraph claim).
   assert.equal(resolveScope(app).scope, "root");
+});
+
+test("#604: a ghost subgraph that still HOLDS NODES is a divergence — never repainted away", () => {
+  const staleSub = makeSubgraph({ name: "old", nodes: [{ id: 87 }, { id: 88 }] });
+  staleSub.serialize = () => ({ nodes: [{ id: 87 }, { id: 88 }] });
+  const freshSub = makeSubgraph({ name: "new", nodes: [{ id: 87 }, { id: 88 }] });
+  const app = makeApp({ rootNodes: [{ id: 128, subgraph: freshSub }], canvasGraph: staleSub });
+
+  const scope = resolveScope(app);
+  assert.equal(scope.diverged, true, "a content-bearing unreachable canvas graph is unresolvable");
+  assert.equal(
+    scope.stale,
+    false,
+    "stale is the caller's REPAINT trigger — arming it would discard whatever the ghost holds",
+  );
+  assert.equal(scope.divergedKind, "subgraph", "the kind only selects the remedy wording");
+  assert.equal(scope.graph, staleSub, "the reported graph is the one the user is looking at");
+
+  // The caller's repaint is keyed on `stale`, so it cannot fire here.
+  if (scope.stale) app.canvas.setGraph(scope.rootGraph);
+  assert.equal(app.canvas.graph, staleSub, "the ghost's contents are still reachable to the user");
+});
+
+test("#604: an UNSERIALIZABLE empty ghost is not PROVEN empty — it fails closed to a divergence", () => {
+  // A bare empty `_nodes` array is node-level evidence only: without serialize()
+  // there is no way to prove the ghost holds no groups/links/nested subgraphs.
+  const ghost = makeSubgraph({ name: "unprovable" });
+  const app = makeApp({ rootNodes: [], canvasGraph: ghost });
+  const scope = resolveScope(app);
+  assert.equal(scope.diverged, true);
+  assert.equal(scope.stale, false);
 });
 
 // #308 specifically: query and exit must AGREE. A valid subgraph → both see it; a
@@ -489,10 +528,22 @@ test("#308: query scope and exit scope derive from the SAME resolver (cannot dis
   assert.equal(q.scope, "subgraph");
   assert.notEqual(q.graph, q.rootGraph, "exit_subgraph would proceed, not report 'already at root'");
 
-  // Stale subgraph: query reconciles to root, so a following exit reporting root is
-  // consistent — no 'subgraph then already-at-root' contradiction.
-  const app2 = makeApp({ rootNodes: [{ id: 130, subgraph: makeSubgraph({ name: "fresh" }) }], canvasGraph: makeSubgraph({ name: "stale" }) });
+  // Provably-empty stale subgraph: query reconciles to root, so a following exit
+  // reporting root is consistent — no 'subgraph then already-at-root' contradiction.
+  const emptyStale = makeSubgraph({ name: "stale" });
+  emptyStale.serialize = () => ({ nodes: [] });
+  const app2 = makeApp({ rootNodes: [{ id: 130, subgraph: makeSubgraph({ name: "fresh" }) }], canvasGraph: emptyStale });
   const q2 = resolveScope(app2);
   assert.equal(q2.scope, "root");
   assert.equal(q2.graph, q2.rootGraph, "exit truthfully reports root; query already said root too");
+
+  // #604 — a stale subgraph the resolver CANNOT resolve (content-bearing) is reported
+  // as diverged to BOTH tools from the same resolver, so query and exit still cannot
+  // disagree: neither proceeds, and neither claims a scope it did not verify.
+  const heldStale = makeSubgraph({ name: "held", nodes: [{ id: 5 }] });
+  heldStale.serialize = () => ({ nodes: [{ id: 5 }] });
+  const app3 = makeApp({ rootNodes: [{ id: 130, subgraph: makeSubgraph({ name: "fresh" }) }], canvasGraph: heldStale });
+  const q3 = resolveScope(app3);
+  assert.equal(q3.diverged, true, "query refuses");
+  assert.equal(resolveScope(app3).diverged, true, "exit, deriving from the same resolver, refuses identically");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -259,16 +259,15 @@ import { composeRunCompletionFrame } from "./lib/run-completion-frame.js";
 import { readyAckCanPromoteBackend } from "./lib/pi-readiness.js";
 import { createRunReconcileSweep } from "./lib/run-reconcile-sweep.js";
 import {
-  activeWorkflowNodeCount,
   activeWorkflowProvenEmpty,
-  graphEmptyBindingUnproven,
-  graphReadDesynced,
-  graphRootMismatchesActiveWorkflow,
   graphRootProvenEmpty,
   graphRootWorkflowUuidMismatches,
   graphRootWorkflowUuidMatches,
   graphRootMatchesState,
-  graphCommandMayMutateWorkflow,
+  graphCommandBindingBar,
+  MUTATION_BINDING_BAR,
+  graphBindingRefusalMessage,
+  resolveGraphBindingVerdict,
   graphReadBindingChanged,
   resolveGraphRootUuidRebind,
 } from "./lib/graph-binding.js";
@@ -4252,8 +4251,37 @@ function getGraphCtx() {
     throw new Error("ComfyUI graph is not available (app.graph / LiteGraph missing)");
   }
   const scope = resolveScope(app);
-  // When the scope was stale, rebind the CANVAS to root too, so the physical view
-  // matches the graph reads/edits now target (keeps read + edit in lockstep).
+  // #604 — CANVAS/ROOT DIVERGENCE. `app.graph` and `app.canvas.graph` hold two
+  // different ROOT-LEVEL graphs (reported after a backend restart with no page
+  // reload: `app.graph` was empty while the canvas still held the user's unsaved
+  // 31-node workflow). This used to be lumped in with the #220/#308 stale-SUBGRAPH
+  // case and "repaired" by `canvas.setGraph(app.graph)` — which pointed the user's
+  // canvas at the empty root, left the graph they were actually editing
+  // unreferenced ("the memory-only graph was unrecoverable"), and then handed every
+  // downstream guard a self-consistent (app.graph, activeWorkflow) pair that no
+  // longer said anything about the canvas the command was issued for. The evidence
+  // of the divergence was destroyed before anything could report it.
+  //
+  // There is no safe way to pick one: the canvas graph is what the user sees, the
+  // root graph is what the workflow service and every save path use, and nothing
+  // here can prove which one this command names. So REFUSE, before any work and
+  // before touching the view. A destroyed graph cannot be retried; a refusal can.
+  if (scope.diverged) {
+    const canvasNodes = scope.graph?._nodes?.length ?? "unknown";
+    const rootNodes = scope.rootGraph?._nodes?.length ?? "unknown";
+    throw new Error(
+      `[canvas-root-divergence] The canvas you are looking at (${canvasNodes} node(s)) and the ` +
+        `panel's bound root graph (${rootNodes} node(s)) are two DIFFERENT graphs, so this command ` +
+        `was NOT applied — the panel cannot tell which one it was meant for, and picking either ` +
+        `could edit a graph you are not looking at. This usually follows a ComfyUI backend restart ` +
+        `without a page reload. Save or export the canvas you want to keep, then reload the ComfyUI ` +
+        `page (a panel-only reload does not rebuild this binding).`,
+    );
+  }
+  // When the scope was a stale SUBGRAPH, rebind the CANVAS to root too, so the
+  // physical view matches the graph reads/edits now target (keeps read + edit in
+  // lockstep). Safe only because a ghost subgraph the live root neither owns nor
+  // registers holds none of the workflow — unlike the diverged root above.
   if (scope.stale && typeof app.canvas?.setGraph === "function") {
     try {
       app.canvas.setGraph(scope.rootGraph);
@@ -4389,65 +4417,25 @@ function assertGraphBoundToActiveWorkflow(
       }
     }
   }
-  const currentStateTrustworthy = activeWorkflow?.isModified !== true;
-  // On a dirty tab, ChangeTracker's activeState can lag the live canvas (#545),
-  // so it cannot prove the root belongs to this workflow. Reads remain
-  // availability-oriented, but mutations need a positive UUID match: otherwise
-  // a stale, untagged root B is indistinguishable from A and could be changed.
-  const dirtyMutationBindingUnproven =
-    requireDirtyMutationBinding &&
-    activeWorkflow?.isModified === true &&
-    !graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid });
-  const rootShapeMismatch = graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow });
-  const baselineReadDesync =
-    currentStateTrustworthy &&
-    includeBaselineReadGuard &&
-    graphReadDesynced({ liveNodeCount, activeWorkflow, inSubgraph });
-  if (
-    rootUuidMismatch ||
-    dirtyMutationBindingUnproven ||
-    rootShapeMismatch ||
-    baselineReadDesync
-  ) {
-    // #565 — name the firing predicate. All four branches used to throw the
-    // identical text, so a misfiring guard was undiagnosable and the only
-    // available response was a blind reload/re-open retry loop.
-    const reason = rootUuidMismatch
-      ? "root-workflow-uuid-mismatch"
-      : dirtyMutationBindingUnproven
-        ? "dirty-mutation-binding-unproven"
-        : rootShapeMismatch
-          ? "root-shape-mismatch"
-          : "root-node-count-desync";
-    const expected = activeWorkflowNodeCount(activeWorkflow);
-    throw new Error(
-      `[${reason}] The live graph is out of sync with the active workflow: the workflow reports ${expected} node(s), ` +
-        `but the canvas is bound to a different graph. A load, tab switch, or reconnect left this command ` +
-        `pointed at the wrong canvas, so it was NOT applied. Re-open the active workflow tab ` +
-        `(panel_open_workflow) or reload the panel to rebind the graph, then retry.`,
-    );
-  }
-  // #560 (2nd reopen) — the FALSE-EMPTY read hole. Every predicate above is
-  // inconclusive in the mid-population window (empty root, no root tag,
-  // tracker unreadable/unsettled after a reconnect + tab switch or a failed
-  // repaint), so an empty ROOT read slipped through as an AUTHORITATIVE
-  // node_count 0 for a populated workflow — and the agent built on it (#349-
-  // class). An empty read is now authoritative ONLY when the empty state is
-  // PROVEN (clean, well-formed, all-empty tracker state) or the canvas is
-  // POSITIVELY bound (root tag matches). Otherwise the state is INCONCLUSIVE:
-  // refuse with a retryable error — never a false-empty read, never a build
-  // on one. Reads AND mutations are fenced alike; the legacy verdicts above
-  // stay more specific and keep winning. Gated LAST so it can never mask a
-  // positive desync/mismatch verdict.
-  if (graphEmptyBindingUnproven({ graph, rootGraph, activeWorkflow, activeWorkflowUuid })) {
-    throw new Error(
-      `[empty-binding-unproven] The live root canvas reads EMPTY, but the active workflow's own ` +
-        `state cannot prove it is genuinely empty — the tab may still be loading after a switch, ` +
-        `reconnect, or a failed open, and node_count 0 could be a FALSE-EMPTY reading, so this ` +
-        `command was NOT applied as authoritative. Retry in a moment once the tab settles; if it ` +
-        `persists, re-open the workflow tab (panel_open_workflow) or reload the panel.`,
-    );
-  }
+  // The verdict itself is a PURE function of the resolved evidence, lifted into
+  // lib/graph-binding.js (#604) so the read-vs-mutation evidence bar is observable
+  // in unit tests. It names the firing predicate (#565) — all branches used to
+  // throw the identical text, so a misfiring guard was undiagnosable and the only
+  // available response was a blind reload/re-open retry loop. Every caller runs
+  // this BEFORE doing any work, which is what makes its "was NOT applied" claim
+  // true rather than a fabrication.
+  const verdict = resolveGraphBindingVerdict({
+    graph,
+    rootGraph,
+    activeWorkflow,
+    activeWorkflowUuid,
+    liveNodeCount,
+    inSubgraph,
+    rootUuidMismatch,
+    includeBaselineReadGuard,
+    requireDirtyMutationBinding,
+  });
+  if (verdict) throw new Error(graphBindingRefusalMessage(verdict));
 }
 
 /** Reach a Pinia store by id. Pinia attaches itself as `$pinia` on the Vue app's
@@ -4687,8 +4675,7 @@ function captureGraphSnapshot(mid, label) {
     );
     if (!currentState) return null;
     assertGraphBoundToActiveWorkflow(graph, rootGraph, {
-      includeBaselineReadGuard: false,
-      requireDirtyMutationBinding: true,
+      ...MUTATION_BINDING_BAR,
     });
     const data = rootGraph.serialize();
     graphSnapshots.push({ mid, ts: Date.now(), label: (label || "").slice(0, 80), data, workflowRef });
@@ -4711,8 +4698,7 @@ function restoreSnapshot(snap) {
     // Revert is a direct local load, not a bridge command. Do not restore a
     // snapshot into a canvas proven to belong to a different active workflow.
     assertGraphBoundToActiveWorkflow(graph, rootGraph, {
-      includeBaselineReadGuard: false,
-      requireDirtyMutationBinding: true,
+      ...MUTATION_BINDING_BAR,
     });
     // Deep-clone so the stored snapshot isn't mutated by the live graph after load.
     // __cmcpNoFork: this reloads the SAME active workflow (a revert), so the create-
@@ -5930,8 +5916,7 @@ function revalidateGraphMutationContext(captured) {
     );
   }
   assertGraphBoundToActiveWorkflow(current.graph, current.rootGraph, {
-    includeBaselineReadGuard: false,
-    requireDirtyMutationBinding: true,
+    ...MUTATION_BINDING_BAR,
   });
   return current;
 }
@@ -6953,8 +6938,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // bypassing bridge dispatch. Refuse before snapshot/load so that path cannot
     // report a successful load into a stale prior tab (#349).
     assertGraphBoundToActiveWorkflow(graph, rootGraph, {
-      includeBaselineReadGuard: false,
-      requireDirtyMutationBinding: true,
+      ...MUTATION_BINDING_BAR,
     });
     // Accept a JSON string or an object.
     let data = incoming;
@@ -8105,8 +8089,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // mutation occurs, so enforce the same current-state binding before prompt
     // construction or queuePrompt can report success (#349).
     assertGraphBoundToActiveWorkflow(graph, rootGraph, {
-      includeBaselineReadGuard: false,
-      requireDirtyMutationBinding: true,
+      ...MUTATION_BINDING_BAR,
     });
     if (typeof app.queuePrompt !== "function") {
       throw new Error("app.queuePrompt is unavailable on this frontend");
@@ -11808,12 +11791,18 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // can lag ordinary unsaved canvas edits (#545).  Keep the strict
             // positive-binding requirement for mutations only, so read tools can
             // report the live graph and give the user a recovery path.
+            //
+            // #604 — the bar comes from graphCommandBindingBar so a MUTATION can
+            // never clear a LOWER bar than a READ. This line used to hard-code
+            // `includeBaselineReadGuard: false` for EVERY command, and only the read
+            // executors re-asserted with it on: the very evidence that made
+            // graph_outline refuse ("the workflow reports N>0 nodes but the live root
+            // reads empty") let graph_remove_node through and delete nodes from the
+            // wrong canvas. Reads still get the lower bar HERE — they re-assert with
+            // the full one inside their own executors.
             if (msg.cmd.startsWith("graph_")) {
               const { graph, rootGraph } = getGraphCtx();
-              assertGraphBoundToActiveWorkflow(graph, rootGraph, {
-                includeBaselineReadGuard: false,
-                requireDirtyMutationBinding: graphCommandMayMutateWorkflow(msg.cmd),
-              });
+              assertGraphBoundToActiveWorkflow(graph, rootGraph, graphCommandBindingBar(msg.cmd));
             }
             // PINNED-TARGET GUARD (#349): a `workflow_path` on the command means the
             // agent's session is pinned to a SPECIFIC workflow. But every executor

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -4242,25 +4242,27 @@ const MAX_STATE_NODES = 100;
 function getGraphCtx() {
   // app.canvas.graph is the graph the user is LOOKING at — the root graph or an
   // opened subgraph — so reads and edits target what's on screen. But after a
-  // reconnect/tab-switch the canvas can still point at a subgraph object that the
-  // REBUILT root graph no longer owns; resolveScope detects that STALE reference
-  // and reconciles to root so graph READS and graph WRITES can never diverge
-  // (#220/#308). It is the ONE authoritative viewing-scope source.
+  // reconnect/tab-switch/backend restart the canvas can point at a graph the
+  // REBUILT root no longer owns; resolveScope classifies that, reconciling to root
+  // ONLY when the stranded graph is provably content-free and otherwise reporting
+  // a divergence this function refuses (#220/#308 preserved, #604 fixed). It is the
+  // ONE authoritative viewing-scope source, and therefore the one place that can
+  // decide whether the graph a command is about to touch is knowable at all.
   const LG = window.LiteGraph ?? globalThis.LiteGraph;
   if (!app || !app.graph || !LG) {
     throw new Error("ComfyUI graph is not available (app.graph / LiteGraph missing)");
   }
   const scope = resolveScope(app);
-  // #604 — CANVAS/ROOT DIVERGENCE. `app.graph` and `app.canvas.graph` hold two
-  // different ROOT-LEVEL graphs (reported after a backend restart with no page
-  // reload: `app.graph` was empty while the canvas still held the user's unsaved
-  // 31-node workflow). This used to be lumped in with the #220/#308 stale-SUBGRAPH
-  // case and "repaired" by `canvas.setGraph(app.graph)` — which pointed the user's
-  // canvas at the empty root, left the graph they were actually editing
-  // unreferenced ("the memory-only graph was unrecoverable"), and then handed every
-  // downstream guard a self-consistent (app.graph, activeWorkflow) pair that no
-  // longer said anything about the canvas the command was issued for. The evidence
-  // of the divergence was destroyed before anything could report it.
+  // #604 — CANVAS/ROOT DIVERGENCE. The canvas holds a graph the live root neither
+  // owns nor registers, and that graph is NOT provably content-free. Reported after
+  // a backend restart with no page reload: `app.graph` was empty while the canvas
+  // still held the user's unsaved 31-node workflow. This used to be treated as the
+  // #220/#308 stale-SUBGRAPH case and "repaired" by `canvas.setGraph(app.graph)` —
+  // which pointed the user's canvas at the empty root, left the graph they were
+  // actually editing unreferenced ("the memory-only graph was unrecoverable"), and
+  // then handed every downstream guard a self-consistent (app.graph, activeWorkflow)
+  // pair that no longer said anything about the canvas the command was issued for.
+  // The evidence of the divergence was destroyed before anything could report it.
   //
   // There is no safe way to pick one: the canvas graph is what the user sees, the
   // root graph is what the workflow service and every save path use, and nothing
@@ -4269,19 +4271,32 @@ function getGraphCtx() {
   if (scope.diverged) {
     const canvasNodes = scope.graph?._nodes?.length ?? "unknown";
     const rootNodes = scope.rootGraph?._nodes?.length ?? "unknown";
+    // The remedy differs by WHERE the canvas is stranded, and only the remedy does.
+    // A canvas left inside a subgraph the rebuilt root no longer owns is escaped by
+    // leaving that subgraph in ComfyUI's own breadcrumb; two different root graphs
+    // can only be reconciled by reloading the page. Both are stated, cheapest first.
+    const remedy =
+      scope.divergedKind === "subgraph"
+        ? `Leave the open subgraph on the ComfyUI canvas (its breadcrumb, or double-click out) ` +
+          `to get back to a graph the panel can identify; if that does not clear it, save or ` +
+          `export anything you need from this view and reload the ComfyUI page.`
+        : `This usually follows a ComfyUI backend restart without a page reload. Save or export ` +
+          `the canvas you want to keep, then reload the ComfyUI page (a panel-only reload does ` +
+          `not rebuild this binding).`;
     throw new Error(
       `[canvas-root-divergence] The canvas you are looking at (${canvasNodes} node(s)) and the ` +
         `panel's bound root graph (${rootNodes} node(s)) are two DIFFERENT graphs, so this command ` +
         `was NOT applied — the panel cannot tell which one it was meant for, and picking either ` +
-        `could edit a graph you are not looking at. This usually follows a ComfyUI backend restart ` +
-        `without a page reload. Save or export the canvas you want to keep, then reload the ComfyUI ` +
-        `page (a panel-only reload does not rebuild this binding).`,
+        `could edit a graph you are not looking at. ${remedy}`,
     );
   }
-  // When the scope was a stale SUBGRAPH, rebind the CANVAS to root too, so the
-  // physical view matches the graph reads/edits now target (keeps read + edit in
-  // lockstep). Safe only because a ghost subgraph the live root neither owns nor
-  // registers holds none of the workflow — unlike the diverged root above.
+  // The canvas graph is unreachable from the live root but PROVABLY content-free, so
+  // rebind the CANVAS to root: the physical view then matches the graph reads/edits
+  // target, keeping read + edit in lockstep (#220/#308). This is the ONLY case the
+  // repaint is allowed, and it is allowed because the proof — a present-empty
+  // `_nodes` plus a serialize() with every non-identity surface empty — establishes
+  // that there is nothing in it to lose. It also keeps the binding guard's later
+  // "was NOT applied" claim honest: nothing of the workflow changed here either.
   if (scope.stale && typeof app.canvas?.setGraph === "function") {
     try {
       app.canvas.setGraph(scope.rootGraph);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -4268,8 +4268,8 @@ function getGraphCtx() {
   // root graph is what the workflow service and every save path use, and nothing
   // here can prove which one this command names. So REFUSE, before any work and
   // before touching the view. A destroyed graph cannot be retried; a refusal can.
-  if (scope.diverged) {
-    const canvasNodes = scope.graph?._nodes?.length ?? "unknown";
+  const refuseDivergence = (canvasGraph, detail = "") => {
+    const canvasNodes = canvasGraph?._nodes?.length ?? "unknown";
     const rootNodes = scope.rootGraph?._nodes?.length ?? "unknown";
     // The remedy differs by WHERE the canvas is stranded, and only the remedy does.
     // A canvas left inside a subgraph the rebuilt root no longer owns is escaped by
@@ -4283,13 +4283,14 @@ function getGraphCtx() {
         : `This usually follows a ComfyUI backend restart without a page reload. Save or export ` +
           `the canvas you want to keep, then reload the ComfyUI page (a panel-only reload does ` +
           `not rebuild this binding).`;
-    throw new Error(
+    return new Error(
       `[canvas-root-divergence] The canvas you are looking at (${canvasNodes} node(s)) and the ` +
         `panel's bound root graph (${rootNodes} node(s)) are two DIFFERENT graphs, so this command ` +
         `was NOT applied — the panel cannot tell which one it was meant for, and picking either ` +
-        `could edit a graph you are not looking at. ${remedy}`,
+        `could edit a graph you are not looking at.${detail} ${remedy}`,
     );
-  }
+  };
+  if (scope.diverged) throw refuseDivergence(scope.graph);
   // The canvas graph is unreachable from the live root but PROVABLY content-free, so
   // rebind the CANVAS to root: the physical view then matches the graph reads/edits
   // target, keeping read + edit in lockstep (#220/#308). This is the ONLY case the
@@ -4297,12 +4298,27 @@ function getGraphCtx() {
   // `_nodes` plus a serialize() with every non-identity surface empty — establishes
   // that there is nothing in it to lose. It also keeps the binding guard's later
   // "was NOT applied" claim honest: nothing of the workflow changed here either.
-  if (scope.stale && typeof app.canvas?.setGraph === "function") {
+  //
+  // The repaint must be VERIFIED, not attempted (codex r2 P0). setGraph is optional
+  // on older frontends and can throw during a reconnect; swallowing that and
+  // returning the root anyway resolved commands onto a graph the user is provably
+  // NOT looking at — the same wrong-canvas outcome by a different route, and it
+  // would have made "the physical view matches" a claim about a best-effort call.
+  // An unconfirmed rebind leaves the divergence in place, so it is refused like one.
+  if (scope.stale) {
     try {
-      app.canvas.setGraph(scope.rootGraph);
-      app.canvas.setDirty?.(true, true);
+      if (typeof app.canvas?.setGraph === "function") {
+        app.canvas.setGraph(scope.rootGraph);
+        app.canvas.setDirty?.(true, true);
+      }
     } catch {
-      // best-effort — the resolved `graph` below is still the reconciled root
+      // fall through to the confirmation below — a throw is just one way to fail
+    }
+    if (app.canvas?.graph !== scope.rootGraph) {
+      throw refuseDivergence(
+        app.canvas?.graph,
+        ` The panel tried to move the view back to the graph it is bound to and could not confirm it.`,
+      );
     }
   }
   const graph = scope.graph ?? app.graph;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -223,7 +223,7 @@ import {
   activeWorkflowPossiblyStale,
   activeStaleHint,
 } from "./lib/reconnect-staleness.js";
-import { pickRevertSnapshot } from "./lib/graph-revert.js";
+import { pickRevertSnapshot, describeRevertOutcome, revertDidRestore } from "./lib/graph-revert.js";
 import { commandFingerprint, createCommandDedupeLedger } from "./lib/command-dedupe.js";
 import { decideOpenStaleness } from "./lib/workflow-open-staleness.js";
 import {
@@ -4717,54 +4717,469 @@ function captureGraphSnapshot(mid, label) {
   }
 }
 
-// Restore the canvas to a given snapshot. Returns the snapshot, or null on fail.
-function restoreSnapshot(snap) {
-  if (!snap) return null;
+// Restore the canvas to a given snapshot. Returns a REVERT_STATUS outcome, never a
+// bare snapshot-or-null: `null` used to mean all of "no snapshot", "a snapshot
+// exists but loading it was REFUSED", and "the load failed part-way", and every
+// caller rendered it as "nothing to revert". That is the wrong answer at the worst
+// moment — the binding refusal fires exactly when a backend restart has left the
+// canvas unidentifiable, which is when someone reaches for /revert, and the reason
+// it was carrying IS the remedy. Preserve the reason and let the caller show it.
+// ASYNC because `loadGraphData` is async on current frontends and the panel's own
+// creation-boundary wrapper preserves its promise (see graph_load, which awaits it
+// for the same reason). Calling it without awaiting made the "failed" branch below
+// unreachable: a load that STARTED, changed the canvas in part, and then REJECTED
+// returned `restored`, so every consumer reported success — including rewind's
+// "canvas reverted" — over a half-applied load. That is the fabricated-outcome case
+// this whole path exists to prevent, so the promise has to be awaited.
+// ---- the canvas interaction lock, as a fence with an OWNER -----------------
+//
+// `canvas.allow_interaction` is a bare boolean, so "restore the value I saved" is
+// only correct while nobody else has frozen it since. Two overlapping destructive
+// sections break that, and they overlap for a reason already established here:
+// acquireWorkflowReloadGuard OVERWRITES, so a timed-out revert can lose its section
+// to a workflow_open while its own load is still live. If that revert then settles
+// first, restoring its stale `true` UNLOCKS the canvas in the middle of
+// workflow_open's reload — a hand edit lands and the newer load overwrites it. The
+// exact clobber the freeze exists to prevent, reopened by a lock released by
+// someone who no longer owns it.
+//
+// So the lock is reference-counted with per-holder tokens: the value to restore is
+// captured when the FIRST holder freezes, a release by a non-owner is a no-op, and
+// the canvas only reopens when the LAST holder leaves. That is order-independent —
+// whichever of two overlapping sections finishes first, the canvas stays locked
+// until both are done.
+let canvasInteractionHolders = new Set();
+let canvasInteractionPrior = null;
+let canvasInteractionSeq = 0;
+
+/** Freeze `canvasView` and return an ownership token, or null when the freeze did
+ *  NOT happen — this frontend exposes no boolean lock, or the write was refused.
+ *  Callers must treat null as "no user fence available", never as "frozen". */
+function acquireCanvasInteractionLock(canvasView) {
+  if (typeof canvasView?.allow_interaction !== "boolean") return null;
+  const firstHolder = canvasInteractionHolders.size === 0;
+  const prior = firstHolder ? canvasView.allow_interaction : canvasInteractionPrior;
+  // FREEZE FIRST, register second. `allow_interaction` can be a read-only property
+  // or a throwing setter, and registering the holder before the write is a claim
+  // that the freeze happened. If the write then threw, nobody would hold the token
+  // — the caller gets null and never releases — so the orphan would sit in the set
+  // forever, keeping the count nonzero and leaving the NEXT canvas permanently
+  // locked with nothing running. A guard is itself an operation that can fail:
+  // record it only once it has.
   try {
-    const { app, graph, rootGraph } = getGraphCtx();
+    canvasView.allow_interaction = false;
+  } catch {
+    return null; // no freeze, no holder — the caller sees "no user fence available"
+  }
+  if (firstHolder) canvasInteractionPrior = prior;
+  const token = ++canvasInteractionSeq;
+  canvasInteractionHolders.add(token);
+  return token;
+}
+
+/** Drop `token`'s claim. The canvas reopens only when no holder is left, and only
+ *  to the value captured before the FIRST freeze — never to a stale snapshot a
+ *  later holder has since superseded. Returns whether the canvas was reopened. */
+function releaseCanvasInteractionLock(token, canvasView) {
+  if (token == null || !canvasInteractionHolders.delete(token)) return false;
+  if (canvasInteractionHolders.size > 0) return false; // a newer section still holds it
+  try {
+    if (canvasView && typeof canvasInteractionPrior === "boolean") {
+      canvasView.allow_interaction = canvasInteractionPrior;
+    }
+  } catch {
+    // A canvas that refuses the write is already gone. Drop the bookkeeping anyway:
+    // keeping the holder registered would leave the count nonzero forever and lock
+    // out every later canvas, which is strictly worse than a dead canvas staying
+    // frozen. The claim is released either way — only the write is best-effort.
+  }
+  canvasInteractionPrior = null;
+  return true;
+}
+
+/** How long a snapshot restore's `loadGraphData` may run before the panel gives the
+ *  user their canvas back. Generous — a large workflow legitimately takes seconds —
+ *  but finite, because the freeze around this await locks the user out of their own
+ *  graph and a hung load would do so forever, silently. */
+const RESTORE_LOAD_BUDGET_MS = 15000;
+/** Distinguishes "the deadline won" from a resolved load and from a rejection. */
+const RESTORE_LOAD_TIMED_OUT = { timedOut: true };
+
+/** A snapshot load that outran its deadline and is STILL RUNNING. Releasing the
+ *  fences on timeout hands the canvas back, but it does NOT stop that load — so it
+ *  is tracked here and no further restore may start until it settles. Without this
+ *  the deadline would trade a silent lockout for a silent overwrite: a second
+ *  restore could complete and then be clobbered by the first one landing late. It
+ *  cannot fence ordinary graph commands as well — that is precisely the wedge the
+ *  deadline exists to avoid — which is why the timeout message says outright that a
+ *  late completion may overwrite the canvas. */
+let restoreLoadStillRunning = null;
+
+/**
+ * Resolve to `{ outcome, settled }`. `outcome` is `null` (settled), an Error
+ * (rejected), or RESTORE_LOAD_TIMED_OUT. `settled` is the never-rejecting promise
+ * for the load itself, so a caller that gave up on the deadline can still observe
+ * when it finally finishes — and so a rejection arriving after the deadline is
+ * never an unhandled one.
+ * `setTimer`/`clearTimer` are injectable so tests drive the deadline deterministically
+ * instead of sleeping.
+ */
+function raceRestoreLoadDeadline(
+  load,
+  { budgetMs = RESTORE_LOAD_BUDGET_MS, setTimer = setTimeout, clearTimer = clearTimeout } = {},
+) {
+  let timer = null;
+  const settled = Promise.resolve(load).then(
+    () => null,
+    (err) => (err instanceof Error ? err : new Error(coerceMessageText(err))),
+  );
+  const deadline = new Promise((resolve) => {
+    timer = setTimer(() => resolve(RESTORE_LOAD_TIMED_OUT), budgetMs);
+  });
+  return Promise.race([settled, deadline]).then((outcome) => {
+    if (timer !== null) clearTimer(timer);
+    return { outcome, settled };
+  });
+}
+
+/** Remember an abandoned-but-live load, and forget it once it finally settles. */
+function noteRestoreLoadStillRunning(settled) {
+  restoreLoadStillRunning = settled;
+  settled.then(
+    () => {
+      if (restoreLoadStillRunning === settled) restoreLoadStillRunning = null;
+    },
+    () => {
+      if (restoreLoadStillRunning === settled) restoreLoadStillRunning = null;
+    },
+  );
+}
+
+async function restoreSnapshot(snap) {
+  if (!snap) return { status: "none" };
+  // EVERYTHING that can fail before the load starts belongs in this region, because
+  // its verdict is "refused" — nothing applied, safe to retry. Only the awaited
+  // load itself may report "failed" (may be partly applied). Leaving the clone or
+  // the loadGraphData availability check inside the load's try made those failures
+  // claim the action had STARTED, which is fabricated for a call that never
+  // happened.
+  let app;
+  let payload;
+  let token = null;
+  let restoredUuid = null;
+  // Bound to a local whose name does NOT end in "s": the #268 frontend-contract
+  // scanner captures members off the workflow-service alias `s` with an unanchored
+  // `s\.` pattern, so `canvas.<member>` would be misread as a new workflow-SERVICE
+  // dependency. This is a LiteGraph canvas flag, not a workflow-service member.
+  let canvasView = null;
+  let interactionToken = null;
+  // Set when a timed-out load has taken ownership of the fences: they must NOT be
+  // released by the finally below, only by the load settling.
+  let deferredRelease = false;
+  // Release BOTH fences on EVERY path — including the bounded-load timeout, which
+  // exists precisely so a hung load cannot hold them forever. A throw anywhere must
+  // never leave the user with a frozen canvas or a tab refusing every graph command.
+  const releaseSection = () => {
+    if (token !== null) {
+      endWorkflowReloadStep(token);
+      releaseWorkflowReloadGuard(token);
+      token = null;
+    }
+    // OWNER-CHECKED: a release by a section that has since been superseded is a
+    // no-op, so a late-settling revert cannot unlock the canvas out from under a
+    // workflow_open that is still loading.
+    if (interactionToken !== null) {
+      releaseCanvasInteractionLock(interactionToken, canvasView);
+      interactionToken = null;
+    }
+  };
+  try {
+    let graph;
+    let rootGraph;
+    ({ app, graph, rootGraph } = getGraphCtx());
     // Snapshots are workflow-instance scoped. A snapshot captured from tab B
     // must never become a valid load merely because the canvas later rebinds to
     // tab A; missing provenance is rejected too (old in-memory snapshots).
-    if (!snap.workflowRef || snap.workflowRef !== activeWorkflowRef()) return null;
+    if (!snap.workflowRef || snap.workflowRef !== activeWorkflowRef()) {
+      return {
+        status: "refused",
+        reason:
+          "That snapshot was captured from a different workflow tab (or has no recorded " +
+          "workflow), so loading it here would overwrite this canvas with another " +
+          "workflow's graph. Switch back to the tab it came from and retry.",
+      };
+    }
     // Revert is a direct local load, not a bridge command. Do not restore a
     // snapshot into a canvas proven to belong to a different active workflow.
     assertGraphBoundToActiveWorkflow(graph, rootGraph, {
       ...MUTATION_BINDING_BAR,
     });
+    if (typeof app?.loadGraphData !== "function") {
+      return {
+        status: "refused",
+        reason: "This ComfyUI frontend does not expose loadGraphData, so the panel cannot restore a snapshot.",
+      };
+    }
     // Deep-clone so the stored snapshot isn't mutated by the live graph after load.
+    payload = JSON.parse(JSON.stringify(snap.data));
+    // #442's section guard, taken for the SAME reason workflow_open takes it: the
+    // restore is now an ASYNC destructive load, and the bridge refuses graph
+    // commands while the guard is held. Without it an agent command arriving during
+    // the await is accepted and acknowledged, then silently erased when the load
+    // settles — the data-loss shape that guard exists to close. It doubles as the
+    // single-flight lock: a second /revert (or a rewind, or a rollback click)
+    // landing mid-load is refused instead of racing the first to settle out of
+    // order. A guard already held by a workflow switch/reload refuses us likewise.
+    const held = activeWorkflowReloadGuard();
+    if (held) {
+      return {
+        status: "refused",
+        reason:
+          `The panel is switching or reloading "${held.key}" right now, so restoring a snapshot ` +
+          `into that canvas would race it. Retry in a moment.`,
+      };
+    }
+    // …and the section alone is not enough once a load can outrun its deadline: an
+    // abandoned-but-live load still holds no fence, so a second restore could finish
+    // and then be overwritten by the first one landing late.
+    if (restoreLoadStillRunning) {
+      return {
+        status: "refused",
+        reason:
+          "An earlier snapshot restore passed its deadline and is STILL running, so starting " +
+          "another would race it — and the earlier one could land last. Wait for it to finish, " +
+          "or reload the ComfyUI page.",
+      };
+    }
+    token = acquireWorkflowReloadGuard("graph-revert");
+    if (!beginWorkflowReloadStep(token)) {
+      releaseWorkflowReloadGuard(token);
+      token = null;
+      return { status: "refused", reason: "The panel could not take the graph-reload section. Retry in a moment." };
+    }
+    // FREEZE canvas interaction across the destructive await, exactly as
+    // workflow_open does for its own repaint: the section above keeps the BRIDGE
+    // out, and this keeps the USER out. Without it a hand edit landing while
+    // loadGraphData is in flight is silently overwritten when the load settles —
+    // the same unsaved-work loss this whole change exists to stop, arriving through
+    // the window that making the path async opened. Restored on every path by
+    // releaseSection().
+    canvasView = app?.canvas ?? null;
+    interactionToken = acquireCanvasInteractionLock(canvasView);
+    if (interactionToken === null) {
+      // No user-side fence available on this frontend. REFUSE rather than run a
+      // destructive await unfenced and describe it as though the fence were there —
+      // the write would land on whatever the user did in the meantime, which is the
+      // loss this path exists to prevent. workflow_open sets the same precedent: it
+      // gates its destructive re-read on `priorInteraction !== null` and skips it
+      // when the canvas cannot be frozen.
+      return {
+        status: "refused",
+        reason:
+          "This ComfyUI frontend does not expose a canvas interaction lock, so the panel cannot " +
+          "stop you editing while the snapshot loads — and an edit made in that window would be " +
+          "silently overwritten when it lands. Reload the ComfyUI page and retry, or undo with " +
+          "Ctrl+Z on the canvas instead.",
+      };
+    }
+    // STAMP the target workflow's identity into the exact payload about to be
+    // loaded, so the post-load check can demand that marker back — the same
+    // technique, for the same reason, as workflow_open's repaint. Without it the
+    // post-load proof rests on the active-instance pointer plus content, and neither
+    // survives an A->B->A switch across the load: the pointer reads A again, and
+    // graphRootMatchesState deliberately ignores the identity tag, so a same-shaped
+    // B could be certified as a successful revert of A.
+    //
+    // Ask for the identity WITHOUT `{ embed: true }`: that option's job is to write
+    // the uuid (and path) into the workflow's own `extra`, and this needs no such
+    // step — only a value to stamp into its own clone and demand back.
+    //
+    // Being precise, because it is easy to overclaim here: this is NOT a claim that
+    // resolving an identity is side-effect free. `workflowStableUuid`'s UNSAVED
+    // branch persists the id into `extra` by design, so a reload of the same tab
+    // keeps its identity (#570) — and the binding assert above does not necessarily
+    // beat us to it, since it short-circuits on a cached object uuid without calling
+    // the resolver at all. What this does guarantee is narrower and is the part
+    // within this path's gift: no `{embed:true}` step of its own, and the call taken
+    // only after the section, so a refusal never reaches it.
+    //
+    // The stamp does land in the restored graph's `extra.comfyui_mcp`, which is where
+    // the panel already keeps this tag on a live root; it is panel-owned bookkeeping,
+    // excluded from every content comparison, and identical to what a normal binding
+    // stamp would have written.
+    restoredUuid = workflowStableUuid(snap.workflowRef);
+    if (restoredUuid) {
+      const priorExtra =
+        payload.extra && typeof payload.extra === "object" && !Array.isArray(payload.extra)
+          ? payload.extra
+          : {};
+      const priorMeta =
+        priorExtra[WORKFLOW_META_NAMESPACE] &&
+        typeof priorExtra[WORKFLOW_META_NAMESPACE] === "object" &&
+        !Array.isArray(priorExtra[WORKFLOW_META_NAMESPACE])
+          ? priorExtra[WORKFLOW_META_NAMESPACE]
+          : {};
+      payload.extra = {
+        ...priorExtra,
+        [WORKFLOW_META_NAMESPACE]: { ...priorMeta, [WORKFLOW_UUID_FIELD]: restoredUuid },
+      };
+    }
+  } catch (err) {
+    // No graph data has been loaded, so this is a clean REFUSAL: safe to retry once
+    // the binding is sound. Carry the panel's own text — it names the predicate
+    // that fired and the remedy that clears it.
+    releaseSection();
+    return { status: "refused", reason: coerceMessageText(err?.message ?? err) };
+  }
+  try {
     // __cmcpNoFork: this reloads the SAME active workflow (a revert), so the create-
     // boundary fork must NOT re-mint its per-instance identity (#570 P0).
-    app.loadGraphData(JSON.parse(JSON.stringify(snap.data)), true, true, activeWorkflowRef(), {
-      __cmcpNoFork: true,
-    });
-    return snap;
-  } catch {
-    return null;
+    // AWAIT: a rejection after a partial apply must reach the catch below, not
+    // escape as an unhandled rejection while we report success.
+    //
+    // …with a deadline on the REPLY, never on the fences. The panel cannot cancel a
+    // loadGraphData once it is running, so the writer stays live regardless. That
+    // leaves exactly two honest options, and releasing the fences while the writer
+    // is live is not one of them: it would hand the canvas back, let the user (or
+    // any graph_* mutation) edit, and then let the original load land on top — the
+    // silent overwrite this whole change exists to prevent, introduced by the very
+    // deadline that was meant to help.
+    //
+    // So the deadline bounds how long the CALLER waits, not how long the canvas is
+    // protected. On expiry we answer — loudly, saying the canvas stays locked and
+    // why — and the fences come off only when the load actually settles. A load that
+    // never settles therefore wedges the tab, which is the same trade
+    // beginWorkflowReloadStep already documents for the bridge: a loud, recoverable
+    // wedge beats silently eating work the user was never told about. The difference
+    // from the first cut is that it is now LOUD.
+    const { outcome: loadOutcome, settled: loadSettled } = await raceRestoreLoadDeadline(
+      app.loadGraphData(payload, true, true, activeWorkflowRef(), { __cmcpNoFork: true }),
+    );
+    if (loadOutcome === RESTORE_LOAD_TIMED_OUT) {
+      // Hand the fences to the load itself: they drop when it settles, not now.
+      // `deferredRelease` stops the finally below from releasing them early.
+      deferredRelease = true;
+      noteRestoreLoadStillRunning(loadSettled);
+      const handOff = releaseSection;
+      loadSettled.then(handOff, handOff);
+      return {
+        status: "failed",
+        reason:
+          `The graph load did not finish within ${Math.round(RESTORE_LOAD_BUDGET_MS / 1000)}s. It ` +
+          `has NOT been cancelled and the panel cannot cancel it, so the canvas stays locked and ` +
+          `graph commands stay refused until it lands — releasing them now would let an edit be ` +
+          `silently overwritten when it does. They unlock by themselves the moment it finishes; ` +
+          `if it never does, reload the ComfyUI page.`,
+      };
+    }
+    if (loadOutcome instanceof Error) throw loadOutcome;
+    // A RESOLVED PROMISE IS NOT A RECEIPT — the same thing workflow_open's repaint
+    // says about its own load: an old or partial frontend can resolve while leaving
+    // the canvas on the previous root. Treating resolution as proof would report
+    // "canvas reverted" for a canvas that never changed, and the rollback modal
+    // would then rewind the conversation and resend against it.
+    //
+    // The same three-part proof workflow_open demands of its own repaint, because
+    // no one part answers the others' question:
+    //   1. the ACTIVE INSTANCE is still the workflow this snapshot belongs to
+    //      (it was only validated before the await, and a tab switch during the
+    //      load would make everything below describe a different canvas);
+    //   2. the live root carries the identity we STAMPED into this payload — the
+    //      part that survives an A->B->A switch, which the pointer in (1) does not
+    //      and which the content check in (3) deliberately ignores;
+    //   3. the CONTENT matches the exact payload loaded.
+    let liveRoot = null;
+    try {
+      ({ rootGraph: liveRoot } = getGraphCtx());
+    } catch {
+      liveRoot = null; // binding unreadable right after the load — unverifiable
+    }
+    if (activeWorkflowRef() !== snap.workflowRef) {
+      return {
+        status: "failed",
+        reason:
+          "The active workflow changed while the snapshot was loading, so the panel cannot " +
+          "confirm which canvas it landed on. Check both tabs before editing or running them.",
+      };
+    }
+    if (restoredUuid && !graphRootWorkflowUuidMatches({ rootGraph: liveRoot, activeWorkflowUuid: restoredUuid })) {
+      return {
+        status: "failed",
+        reason:
+          "The load reported success, but the canvas is not carrying the identity this snapshot " +
+          "was loaded with, so the panel cannot confirm it landed on the right graph. Check the " +
+          "canvas before editing or running it.",
+      };
+    }
+    // (3) is a SEMANTIC match, not byte equality: graphRootMatchesState normalizes
+    // serializer dialect, node order, counters and viewport (#560), which is what
+    // keeps a faithful repaint from false-failing. It is NOT claimed to be immune:
+    // loadGraphData validates, runs extensions and normalizes widget values before
+    // it resolves, so a frontend transformation could in principle make a genuinely
+    // successful revert unverifiable. That direction is the safe one — the outcome
+    // is "started, cannot confirm", which discloses rather than fabricating and
+    // stops the modal's resend — but it is the thing to watch for in a live session.
+    if (!graphRootMatchesState({ rootGraph: liveRoot, state: payload })) {
+      return {
+        status: "failed",
+        reason:
+          "The load reported success, but the canvas does not match the snapshot that was " +
+          "loaded, so the panel cannot confirm the revert landed. Check the canvas before " +
+          "editing or running it.",
+      };
+    }
+  } catch (err) {
+    // The load was STARTED. It may have applied in part, so this is a disclosure,
+    // not a refusal — reporting "nothing happened" here would invite a retry on
+    // top of a half-changed canvas.
+    return { status: "failed", reason: coerceMessageText(err?.message ?? err) };
+  } finally {
+    // NOT when a timed-out load owns them: the writer is still live, and releasing a
+    // fence while the writer is live is the one combination that cannot be made safe.
+    if (!deferredRelease) releaseSection();
   }
+  return { status: "restored", snapshot: snap };
 }
 
 // Restore the canvas to the most recent pre-turn snapshot that ACTUALLY DIFFERS
 // from the current graph (undo the last turn's edits). Skipping an identical
 // latest snapshot fixes the no-op revert (#327): after a turn replaced/cleared
 // the graph, the next message snapshots the already-changed graph, so the newest
-// snapshot equals the canvas and reverting to it recovers nothing. Returns null
-// when nothing genuinely differs — the caller surfaces "nothing to revert".
-function revertGraphToLastSnapshot() {
+// snapshot equals the canvas and reverting to it recovers nothing. Returns a
+// REVERT_STATUS outcome; "none" only when nothing genuinely differs.
+async function revertGraphToLastSnapshot() {
   const workflowRef = activeWorkflowRef();
-  if (!workflowRef) return null;
+  // NOT "none": there may well be snapshots — the panel just cannot read the active
+  // workflow, so it cannot tell which of them belong to this canvas. Saying "no
+  // snapshot captured" would be the same could-not-determine-becomes-a-verdict
+  // defect this vocabulary exists to remove. Nothing was applied, so it is a
+  // refusal, and a transient null active workflow clears on retry.
+  if (!workflowRef) {
+    return {
+      status: "refused",
+      reason:
+        "The panel cannot read the active workflow right now, so it cannot tell which snapshots " +
+        "belong to this canvas. Retry in a moment.",
+    };
+  }
   // The snapshot ring spans tabs, but a revert belongs only to the CURRENT
   // workflow instance. Filter before choosing the newest differing snapshot:
   // otherwise a newer B snapshot wins selection, is rightly rejected by
   // restoreSnapshot, and hides an older valid A snapshot (#349).
   const scopedSnapshots = graphSnapshots.filter((snap) => snap?.workflowRef === workflowRef);
-  if (!scopedSnapshots.length) return null;
+  // The ONLY truthful "none" on this path: this workflow has no snapshot at all.
+  if (!scopedSnapshots.length) return { status: "none" };
   try {
     const current = getGraphCtx().rootGraph.serialize();
+    // Every snapshot equals the live graph ⇒ genuinely nothing to revert (#327).
     const snap = pickRevertSnapshot(scopedSnapshots, current);
-    return snap ? restoreSnapshot(snap) : null;
+    return snap ? restoreSnapshot(snap) : { status: "none" };
   } catch {
-    // graph unavailable (can't serialize current state) — fall back to the
-    // legacy newest-snapshot behavior rather than silently doing nothing.
+    // The current graph can't be serialized to compare against — which now
+    // includes the canvas/root divergence refusal. Fall back to the legacy
+    // newest-snapshot behavior rather than silently doing nothing: restoreSnapshot
+    // re-checks the binding and returns a REFUSED outcome carrying the reason, so
+    // a divergence surfaces as itself instead of as "nothing to revert".
     return restoreSnapshot(scopedSnapshots[scopedSnapshots.length - 1]);
   }
 }
@@ -5458,16 +5873,27 @@ async function validationBanner() {
 }
 
 // Restore the canvas to the snapshot captured before the message with this mid
-// (the per-message rollback). Returns the snapshot or null.
-function revertGraphSnapshotByMid(mid) {
+// (the per-message rollback). Returns a REVERT_STATUS outcome — "none" ONLY when
+// this message truly has no snapshot for the active workflow, never as a stand-in
+// for a refusal (see restoreSnapshot).
+async function revertGraphSnapshotByMid(mid) {
   const workflowRef = activeWorkflowRef();
-  if (!workflowRef) return null;
+  // Same as revertGraphToLastSnapshot: unreadable active workflow is a refusal, not
+  // a claim that this message has no snapshot.
+  if (!workflowRef) {
+    return {
+      status: "refused",
+      reason:
+        "The panel cannot read the active workflow right now, so it cannot tell which snapshots " +
+        "belong to this canvas. Retry in a moment.",
+    };
+  }
   for (let i = graphSnapshots.length - 1; i >= 0; i--) {
     if (graphSnapshots[i].mid === mid && graphSnapshots[i].workflowRef === workflowRef) {
       return restoreSnapshot(graphSnapshots[i]);
     }
   }
-  return null;
+  return { status: "none" };
 }
 
 /** Summarize one LiteGraph node for the agent — id, type, title, widget
@@ -8986,10 +9412,14 @@ const GRAPH_TOOL_EXECUTORS = {
     // in a window whose dirty signal we are about to overwrite. Scoped to `wasOpen` (the
     // only case that can reload) so a plain first-time open never freezes, and restored in
     // a finally on every path.
-    const priorInteraction =
-      wasOpen && typeof canvasView?.allow_interaction === "boolean"
-        ? canvasView.allow_interaction
-        : null;
+    // Taken through the OWNED lock so this and a concurrent snapshot restore cannot
+    // release each other's freeze: `allow_interaction` is a bare boolean, and a
+    // section that saved `true` before the other one froze would otherwise unlock
+    // the canvas mid-load for whoever is still going. `priorInteraction` keeps its
+    // meaning here — non-null means "the freeze is holding", which the re-baseline
+    // and disk-reload steps below gate on — it is now a token rather than the saved
+    // boolean, and the saved boolean lives inside the lock.
+    const priorInteraction = wasOpen ? acquireCanvasInteractionLock(canvasView) : null;
     let onDiskContent = null;
     let dirtyNow = false;
     let staleInfo = { stale: false, reload: false };
@@ -8997,7 +9427,6 @@ const GRAPH_TOOL_EXECUTORS = {
     let reloadError = null;
     let openFailed = null;
     let rebindFailed = null;
-    if (priorInteraction !== null) canvasView.allow_interaction = false;
     // Hold the switch+reload critical section across the WHOLE mutating sequence. The canvas
     // freeze keeps the USER out; this keeps the BRIDGE out, so a concurrent graph_* command
     // can neither be overwritten by the reload nor be silently re-baselined as clean.
@@ -9317,9 +9746,11 @@ const GRAPH_TOOL_EXECUTORS = {
       console.warn("[comfyui-mcp-panel] workflow_open disk re-read failed:", reloadError);
     } finally {
       // Release BOTH on EVERY path — a throw anywhere above must never leave the user with
-      // a frozen graph or the tab refusing every command.
+      // a frozen graph or the tab refusing every command. The canvas lock is owner-checked:
+      // if a concurrent section still holds it, this release leaves it alone and the last
+      // holder reopens the canvas.
       releaseWorkflowReloadGuard(reloadGuardToken);
-      if (priorInteraction !== null) canvasView.allow_interaction = priorInteraction;
+      releaseCanvasInteractionLock(priorInteraction, canvasView);
     }
     if (openFailed) throw failOpen(openFailed);
     if (rebindFailed) throw failOpenRebindUnknown(rebindFailed);
@@ -21029,6 +21460,20 @@ function buildPanel() {
     }
   }
 
+  /** Run a slash command from a SYNCHRONOUS UI handler. Most `run()`s are sync, but
+   *  /revert now awaits an async graph load — normalizing through Promise.resolve
+   *  keeps a rejection from escaping as an unhandled promise, and surfaces it in the
+   *  transcript instead of only the console. */
+  function runSlashCommand(entry) {
+    try {
+      Promise.resolve(entry.run()).catch((err) => {
+        appendSystem(`${entry.cmd} failed: ${coerceMessageText(err?.message ?? err)}`);
+      });
+    } catch (err) {
+      appendSystem(`${entry.cmd} failed: ${coerceMessageText(err?.message ?? err)}`);
+    }
+  }
+
   const SLASH_COMMANDS = [
     { cmd: "/new", icon: "pi-plus", hint: "start a new chat", run: () => newChat() },
     {
@@ -21060,15 +21505,16 @@ function buildPanel() {
       cmd: "/revert",
       icon: "pi-undo",
       hint: "undo the last turn's graph edits — revert the canvas to before your last message",
-      run: () => {
-        const snap = revertGraphToLastSnapshot();
-        if (snap) {
-          appendSystem(
-            `↩ Reverted the canvas to before${snap.label ? ` “${snap.label}”` : " your last message"}.`,
-          );
-        } else {
-          appendSystem("Nothing to revert — no graph snapshot captured in this session yet.");
-        }
+      run: async () => {
+        const outcome = await revertGraphToLastSnapshot();
+        const label = outcome?.snapshot?.label;
+        appendSystem(
+          describeRevertOutcome(outcome, {
+            action: "revert",
+            restoredText: `↩ Reverted the canvas to before${label ? ` “${label}”` : " your last message"}.`,
+            noneText: "Nothing to revert — no graph snapshot captured in this session yet.",
+          }),
+        );
       },
     },
     {
@@ -21147,7 +21593,9 @@ function buildPanel() {
       input.value = "";
       input.style.height = "auto";
       appendUser(item.ref.cmd);
-      item.ref.run();
+      // Some slash commands (/revert) are async now. Normalize so a rejection can
+      // never surface as an unhandled promise from a sync UI handler.
+      runSlashCommand(item.ref);
       return;
     }
     const { start, end } = menuToken ?? { start: input.value.length, end: input.value.length };
@@ -21850,17 +22298,41 @@ function buildPanel() {
   // before your last message AND bring that message back into the composer to
   // edit & resend. (Graph + edit scope; conversation-fork is a follow-up.)
   let lastEscAt = 0;
-  function rewindLastTurn() {
-    const snap = revertGraphToLastSnapshot();
+  async function rewindLastTurn() {
+    // Recall FIRST and synchronously: the canvas revert now awaits an async
+    // loadGraphData, and the composer must not sit empty for the length of a graph
+    // load. The two halves are independent, so only the summary line below needs
+    // both results.
     const recalled = recallPrev(); // pulls your last message into the composer to edit
-    if (snap || recalled) {
+    if (recalled) input.focus();
+    const outcome = await revertGraphToLastSnapshot();
+    const reverted = revertDidRestore(outcome); // an outcome object is ALWAYS truthy
+    if (reverted || recalled) {
       appendSystem(
-        `↩ Rewound your last turn${snap ? " — canvas reverted" : ""}` +
+        `↩ Rewound your last turn${reverted ? " — canvas reverted" : ""}` +
           `${recalled ? "; your message is back in the composer to edit & resend" : ""}.`,
       );
       input.focus();
-    } else {
-      appendSystem("Nothing to rewind yet — no message/graph snapshot from this session.");
+    }
+    // The canvas half is ALWAYS stated when it did not happen — refused, failed, or
+    // simply no eligible snapshot. "Rewound your last turn; your message is back in
+    // the composer" is otherwise read as a completed rewind, and the user resends
+    // against a graph that still holds the very edits they meant to undo. `none` is
+    // as dangerous as a refusal here: the ring holds 25 and EVICTS, so an old turn's
+    // snapshot is simply gone. Only `restoredText` may be blank, because the line
+    // above already said "canvas reverted".
+    if (!reverted) {
+      appendSystem(
+        describeRevertOutcome(outcome, {
+          action: "rewind the canvas",
+          restoredText: "",
+          noneText: recalled
+            ? "The canvas was NOT reverted — no graph snapshot for that turn (they are kept for the " +
+              "last 25 and then evicted). Your message is back in the composer, but the canvas still " +
+              "holds that turn's edits."
+            : "Nothing to rewind yet — no message or graph snapshot from this session.",
+        }),
+      );
     }
   }
 
@@ -21915,22 +22387,77 @@ function buildPanel() {
     go.type = "button";
     go.className = "cmcp-btn cmcp-btn-primary";
     go.textContent = "Roll back & resend";
+    // The canvas rollback is an ASYNC load, so this modal outlives a single tick and
+    // needs explicit lifecycle state: `settled` makes the primary action single-shot
+    // (a double-click would otherwise start two restores and BOTH continuations
+    // would rewind the conversation and resubmit the message), and `cancelled` marks
+    // an explicit Cancel / backdrop dismissal so the continuation stops instead of
+    // acting on the user's behalf after they backed out.
+    let settled = false;
+    let cancelled = false;
+    // `close` is used BOTH for dismissal and for the handler's own teardown, so it
+    // must not itself set `cancelled` — doing that made every successful path look
+    // cancelled, which is why the gate below had to be written backwards to work at
+    // all. Dismissal is its own function.
     const close = () => overlay.remove();
-    cancel.addEventListener("click", close);
+    const dismiss = () => {
+      cancelled = true;
+      close();
+    };
+    cancel.addEventListener("click", dismiss);
     overlay.addEventListener("mousedown", (e) => {
-      if (e.target === overlay) close();
+      if (e.target === overlay) dismiss();
     });
-    go.addEventListener("click", () => {
+    go.addEventListener("click", async () => {
+      if (settled) return;
+      settled = true;
+      go.disabled = true;
       const edited = ta.value.trim();
       const wantCode = chosen === "code" || chosen === "both";
       const wantConvo = chosen === "conversation" || chosen === "both";
       if (wantCode) {
-        const snap = revertGraphSnapshotByMid(mid);
+        // AWAITED before the conversation rewind and the resend below: resending
+        // against a canvas whose load is still in flight is the race this whole
+        // path is about.
+        const outcome = await revertGraphSnapshotByMid(mid);
         appendSystem(
-          snap
-            ? "↩ Canvas reverted to before this message."
-            : "No graph snapshot for this message — canvas left as-is.",
+          describeRevertOutcome(outcome, {
+            action: "roll back the canvas",
+            restoredText: "↩ Canvas reverted to before this message.",
+            noneText: "No graph snapshot for this message — canvas left as-is.",
+          }),
         );
+        // The user asked to roll the canvas back AND resend against it. Unless the
+        // rollback is PROVEN to have happened, resending aims the next turn at a
+        // graph that is not the one they chose — the destructive retry this whole
+        // cluster is about. STOP and leave the edited text in the composer so the
+        // decision stays theirs.
+        //
+        // "none" is NOT an exemption. It means only that this message has no
+        // snapshot — the ring holds 25 and evicts, so rolling back an old message
+        // reports "canvas left as-is" while the canvas actually carries every later
+        // turn's edits. That is an unknown state being read as permission to
+        // resend, which is the same mistake one level up.
+        if (!revertDidRestore(outcome)) {
+          close();
+          if (edited) setComposerValue(edited);
+          appendSystem(
+            "Not resending — the canvas was not rolled back to the state you asked for. Your edited " +
+              "message is in the composer; send it once the canvas is what you want.",
+          );
+          return;
+        }
+      }
+      // The user hit Cancel (or the backdrop) while the rollback was still in
+      // flight. The canvas work already happened and was reported above — but
+      // rewinding the conversation and RESENDING their message afterwards is acting
+      // on their behalf after they backed out. Stop, and leave the edit with them.
+      if (cancelled) {
+        if (edited) setComposerValue(edited);
+        appendSystem(
+          "Cancelled — not rewinding the conversation or resending. Your edited message is in the composer.",
+        );
+        return;
       }
       if (wantConvo) {
         client.sendFrame?.({ type: "rewind", anchor });
@@ -22114,7 +22641,7 @@ function buildPanel() {
         appendUser(text);
         input.value = "";
         input.style.height = "auto";
-        c.run();
+        runSlashCommand(c);
         return;
       }
     }
@@ -22283,7 +22810,10 @@ function buildPanel() {
       if (now - lastEscAt < 600) {
         lastEscAt = 0;
         ev.preventDefault();
-        rewindLastTurn();
+        // Fire-and-forget from a sync key handler: rewindLastTurn resolves to an
+        // outcome rather than rejecting, but a stray throw must not surface as an
+        // unhandled rejection.
+        rewindLastTurn().catch(() => {});
         return;
       }
       lastEscAt = now;

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -504,6 +504,123 @@ export function graphCommandMayMutateWorkflow(command) {
 }
 
 /**
+ * THE binding evidence bar a bridge graph command must clear (#604 family).
+ *
+ * The invariant this encodes: **a MUTATION may never run on binding evidence that
+ * a READ would refuse.** It was the other way round. The bridge dispatch fence
+ * asked for `includeBaselineReadGuard: false` for EVERY command, and only the
+ * read executors (graph_outline, graph_get_errors) re-asserted with it switched
+ * on. So the exact evidence that made `graph_outline` refuse — "the active
+ * workflow reports N>0 nodes but the live root reads empty" — let
+ * `graph_remove_node` through, which is #604's title verbatim: reads blocked,
+ * mutations still routed to the wrong canvas and deleted nodes from it.
+ *
+ * The hole is not hypothetical-only in the both-empty case: when the live root
+ * exposes no `_nodes` ARRAY at all (a half-rebuilt root after a backend restart),
+ * `graphRootMismatchesActiveWorkflow` and `graphEmptyBindingUnproven` BOTH bail
+ * out as inconclusive by design, and `graphReadDesynced` is the only predicate
+ * that still fires. Gating it off for mutations left them with no fence at all.
+ *
+ * Reads keep the LOWER bar at dispatch on purpose (they re-assert with the full
+ * bar inside their own executors, where they can also offer a recovery path);
+ * mutations get the full bar here, before their executor ever runs.
+ */
+export const MUTATION_BINDING_BAR = Object.freeze({
+  includeBaselineReadGuard: true,
+  requireDirtyMutationBinding: true,
+});
+
+export function graphCommandBindingBar(command) {
+  return graphCommandMayMutateWorkflow(command)
+    ? { ...MUTATION_BINDING_BAR }
+    : { includeBaselineReadGuard: false, requireDirtyMutationBinding: false };
+}
+
+/**
+ * The binding refusal VERDICT for a graph command, or `null` when the binding
+ * clears the bar. Pure — every input is passed in — so the read/mutation symmetry
+ * above is unit-testable without a browser (it previously lived inline in the
+ * panel monolith, where nothing could observe it).
+ *
+ * Returns `{ reason, expected }`; `reason` names the firing predicate so a
+ * misfiring guard is diagnosable instead of driving a blind reload/retry loop
+ * (#565). Order is significant: the first four verdicts are POSITIVE mismatches
+ * and stay more specific than the inconclusive-empty verdict, which is evaluated
+ * LAST so it can never mask them.
+ */
+export function resolveGraphBindingVerdict({
+  graph,
+  rootGraph,
+  activeWorkflow,
+  activeWorkflowUuid,
+  liveNodeCount,
+  inSubgraph = false,
+  rootUuidMismatch = false,
+  includeBaselineReadGuard = true,
+  requireDirtyMutationBinding = false,
+} = {}) {
+  const nodeCount = Number.isFinite(Number(liveNodeCount))
+    ? Number(liveNodeCount)
+    : (rootGraph?._nodes?.length ?? 0);
+  // On a dirty tab, ChangeTracker's activeState can lag the live canvas (#545),
+  // so it cannot prove the root belongs to this workflow. Reads remain
+  // availability-oriented, but mutations need a positive UUID match: otherwise
+  // a stale, untagged root B is indistinguishable from A and could be changed.
+  const dirtyMutationBindingUnproven =
+    requireDirtyMutationBinding &&
+    activeWorkflow?.isModified === true &&
+    !graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid });
+  const rootShapeMismatch = graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow });
+  const currentStateTrustworthy = activeWorkflow?.isModified !== true;
+  const baselineReadDesync =
+    currentStateTrustworthy &&
+    includeBaselineReadGuard &&
+    graphReadDesynced({ liveNodeCount: nodeCount, activeWorkflow, inSubgraph });
+  if (rootUuidMismatch || dirtyMutationBindingUnproven || rootShapeMismatch || baselineReadDesync) {
+    const reason = rootUuidMismatch
+      ? "root-workflow-uuid-mismatch"
+      : dirtyMutationBindingUnproven
+        ? "dirty-mutation-binding-unproven"
+        : rootShapeMismatch
+          ? "root-shape-mismatch"
+          : "root-node-count-desync";
+    return { reason, expected: activeWorkflowNodeCount(activeWorkflow) };
+  }
+  if (graphEmptyBindingUnproven({ graph, rootGraph, activeWorkflow, activeWorkflowUuid })) {
+    return { reason: "empty-binding-unproven", expected: activeWorkflowNodeCount(activeWorkflow) };
+  }
+  return null;
+}
+
+/**
+ * The caller-facing refusal text for a `resolveGraphBindingVerdict` result. Kept
+ * next to the predicates so the claim and the evidence cannot drift apart.
+ *
+ * Both messages state that the command was NOT applied. That claim is only ever
+ * TRUE because every caller asserts BEFORE doing any work — a caller that has
+ * already mutated something must disclose, not refuse (a refusal for work that
+ * landed invites a destructive retry, which is #603's duplicate-node cascade).
+ */
+export function graphBindingRefusalMessage(verdict) {
+  if (!verdict) return null;
+  if (verdict.reason === "empty-binding-unproven") {
+    return (
+      `[empty-binding-unproven] The live root canvas reads EMPTY, but the active workflow's own ` +
+      `state cannot prove it is genuinely empty — the tab may still be loading after a switch, ` +
+      `reconnect, or a failed open, and node_count 0 could be a FALSE-EMPTY reading, so this ` +
+      `command was NOT applied as authoritative. Retry in a moment once the tab settles; if it ` +
+      `persists, re-open the workflow tab (panel_open_workflow) or reload the panel.`
+    );
+  }
+  return (
+    `[${verdict.reason}] The live graph is out of sync with the active workflow: the workflow reports ` +
+    `${verdict.expected} node(s), but the canvas is bound to a different graph. A load, tab switch, ` +
+    `or reconnect left this command pointed at the wrong canvas, so it was NOT applied. Re-open the ` +
+    `active workflow tab (panel_open_workflow) or reload the panel to rebind the graph, then retry.`
+  );
+}
+
+/**
  * True when the graph READ's binding changed across an AWAIT: the active-workflow
  * instance or the bound root-graph object captured before the await no longer
  * matches after it. Used to detect a workflow-tab SWITCH that interleaved with a

--- a/web/js/lib/graph-revert.js
+++ b/web/js/lib/graph-revert.js
@@ -62,3 +62,138 @@ export function pickRevertSnapshot(snapshots, currentSerialized) {
   }
   return null;
 }
+
+// ---- revert OUTCOMES (#604 follow-up) --------------------------------------
+//
+// The restore path used to answer with `snapshot | null`, and every consumer
+// (/revert, double-Esc rewind, the per-message rollback modal) rendered `null`
+// as "nothing to revert / no snapshot for this message". That collapsed FOUR
+// different answers into the one that ends the user's attempt:
+//
+//   • there genuinely is no eligible snapshot            ("none" — truthful)
+//   • a snapshot EXISTS but the panel REFUSED to load it ("refused")
+//   • the load was attempted and did not complete        ("failed")
+//
+// The refusal case is the damaging one, and it fires at exactly the worst
+// moment: `getGraphCtx()` now refuses `[canvas-root-divergence]` when a backend
+// restart leaves the canvas on a graph the panel cannot identify — which is
+// precisely when someone reaches for /revert. Telling them "no graph snapshot
+// captured in this session yet" is false, drops the save/export/reload remedy
+// the refusal was carrying, and ends the recovery attempt. The refusal is
+// right; converting it to `null` is what is wrong.
+//
+// "failed" is separate on purpose: a load that threw MAY have partially applied,
+// so it must be DISCLOSED, never reported as "nothing happened" (which would
+// invite a retry on top of a half-changed canvas).
+
+export const REVERT_STATUS = Object.freeze({
+  RESTORED: "restored",
+  NONE: "none",
+  REFUSED: "refused",
+  FAILED: "failed",
+});
+
+/** What `none` says when the caller supplies nothing usable. A caller may WORD
+ *  this variant, never SUPPRESS it: `none` means the canvas was not restored, and
+ *  an entry point that renders it as an empty string words it away by omission —
+ *  a variant that renders as nothing is indistinguishable from one that never
+ *  fired. That is exactly how the rewind path went on reporting "Rewound your last
+ *  turn" over an evicted ring, without ever saying the canvas still held that
+ *  turn's edits — which is an unknown canvas read as permission to resend. */
+const DEFAULT_NONE_TEXT =
+  "The canvas was NOT restored — there is no graph snapshot available for this, so it still " +
+  "holds the edits you were trying to undo.";
+
+/** Does this string SAY anything? At least one letter or digit that a renderer
+ *  is actually obliged to draw.
+ *
+ *  An ALLOWLIST plus one principled subtraction, after four escalations of the
+ *  opposite approach: trim() missed the zero-width space; a hand-listed range set
+ *  missed the bidi isolates; excluding Cf/Cc/Default_Ignorable missed U+2800
+ *  BRAILLE PATTERN BLANK (a Symbol that draws nothing); and a bare letter/digit
+ *  allowlist still admits U+3164 HANGUL FILLER, which is category Lo and also
+ *  draws nothing. There is no Unicode property for "draws ink", so:
+ *    - name what carries MEANING (\p{L} across every script, \p{N}) rather than
+ *      chasing an open-ended list of invisibles, and
+ *    - subtract Default_Ignorable_Code_Point, the property that exists precisely
+ *      to say "a renderer may show nothing here" — which is what the Hangul
+ *      fillers are.
+ *  Punctuation- and symbol-only text falls back to the default too: an arrow or
+ *  an emoji is not a statement that the canvas was not restored. */
+const IGNORABLE = /\p{Default_Ignorable_Code_Point}/gu;
+const SAYS_SOMETHING = /[\p{L}\p{N}]/u;
+
+/** Does this value put a readable statement on screen? */
+function hasReadableText(value) {
+  return typeof value === "string" && SAYS_SOMETHING.test(value.replace(IGNORABLE, ""));
+}
+
+/**
+ * The system line for a revert-family outcome. `restoredText` / `noneText` are
+ * the caller's own wording (each entry point says something different); the
+ * REFUSED and FAILED lines are shared and ALWAYS carry the panel's own reason,
+ * because that reason is the recovery instruction.
+ *
+ * `noneText` is the caller's WORDING, not an opt-out: a missing or blank one falls
+ * back to DEFAULT_NONE_TEXT rather than rendering nothing. `restoredText` may be
+ * blank — a caller whose own summary already states the restore has nothing to add,
+ * and an unstated SUCCESS misleads no one.
+ *
+ * An UNRECOGNIZED or absent outcome is its own answer, NOT `noneText`. Rendering
+ * it as "no snapshot" would be the same defect this vocabulary exists to remove:
+ * turning "could not determine" into a definite verdict. It can only arise from a
+ * producer that broke the contract, and the truthful thing to say then is that the
+ * panel does not know what happened.
+ *
+ * REFUSED deliberately says "no graph edits were applied" — the narrowest true
+ * statement — rather than "nothing was changed". Reaching a refusal is not
+ * side-effect free: `getGraphCtx()` may legitimately have reconciled the VIEW (the
+ * proven-content-free stranded-canvas repaint), and the binding assert resolves the
+ * active workflow's identity, which for an unsaved tab can mint and embed one
+ * (pre-existing #570 behaviour on every graph command). Neither touches the user's
+ * GRAPH, so retrying is safe and that is what the message promises; a blanket
+ * "nothing changed" would be claiming more than the path delivers.
+ */
+export function describeRevertOutcome(outcome, { restoredText, noneText, action = "revert" } = {}) {
+  const status = outcome?.status;
+  const statedNone = hasReadableText(noneText) ? noneText : DEFAULT_NONE_TEXT;
+  if (status === REVERT_STATUS.RESTORED) return restoredText;
+  if (status === REVERT_STATUS.NONE) return statedNone;
+  const reason = typeof outcome?.reason === "string" ? outcome.reason.trim() : "";
+  if (status === REVERT_STATUS.REFUSED) {
+    // Says nothing about a snapshot EXISTING. A refusal can happen before one is
+    // ever selected — the no-active-workflow branches refuse without consulting the
+    // ring at all — so "the snapshot is still here" would fabricate its existence
+    // for exactly the caller least able to check. What is true of every refusal is
+    // that nothing was loaded; the specifics ride in `reason`.
+    return (
+      `⚠️ Could not ${action} — nothing was loaded, so no graph edits were applied and retrying ` +
+      `is safe. ${reason || "No reason was reported."}`
+    );
+  }
+  if (status === REVERT_STATUS.FAILED) {
+    // "RAN but could not be confirmed", never "did not finish". FAILED covers three
+    // shapes and only one of them stopped early: a rejected load (may be partly
+    // applied), a load still running past its deadline, and a load that RESOLVED but
+    // failed the post-load proof. Asserting it did not finish contradicts that last
+    // one's own reason ("The load reported success, but…") — a fabricated detail
+    // inside a disclosure, which is the thing this vocabulary exists to remove.
+    // What holds for all three: it ran, the result is unconfirmed, the canvas may
+    // have changed.
+    return (
+      `⚠️ The ${action} RAN but the panel could not confirm the result, so the canvas may have ` +
+      `changed — check it before doing anything else. ${reason || "No reason was reported."}`
+    );
+  }
+  return (
+    `⚠️ Could not tell whether the ${action} happened — the panel got back an outcome it does ` +
+    `not recognize, so check the canvas before doing anything else.`
+  );
+}
+
+/** Did this outcome actually put the snapshot back on the canvas? The ONLY
+ *  condition a caller may treat as success — an outcome object is always truthy,
+ *  so a bare `if (outcome)` would read every refusal as a restore. */
+export function revertDidRestore(outcome) {
+  return outcome?.status === REVERT_STATUS.RESTORED;
+}

--- a/web/js/lib/subgraph-scope.js
+++ b/web/js/lib/subgraph-scope.js
@@ -297,38 +297,82 @@ export function isSubgraphInRoot(rootGraph, subgraph) {
   return false;
 }
 
+/** POSITIVE structural evidence that a graph object is a SUBGRAPH rather than a
+ *  root-level graph (#604 family). A LiteGraph subgraph is defined by its boundary
+ *  rails (`inputNode`/`outputNode`, or the private `_inputNode`/`_outputNode` this
+ *  file's resolveRailNode already reads) and by a `rootGraph` back-pointer that
+ *  names a DIFFERENT graph; a root graph has no rails and is its own root.
+ *
+ *  This exists because "the canvas graph is not reachable from app.graph" answers
+ *  TWO different questions, and resolveScope used to read one as the other:
+ *    (a) "the canvas still points at a subgraph the REBUILT root no longer owns"
+ *        (#220/#308) — a ghost with no workflow standing; reconciling the view to
+ *        root loses nothing, and
+ *    (b) "app.graph and the canvas hold two different ROOT graphs" (#604) — the
+ *        canvas is the user's real, live workflow and `app.graph` is the stale or
+ *        half-rebuilt one. Treating (b) as (a) repainted the user's canvas away
+ *        and left the graph they were editing unreferenced and unrecoverable.
+ *
+ *  Fail-safe direction: only POSITIVE subgraph evidence returns true. A graph with
+ *  no rails and no foreign root back-pointer is treated as root-level, so an
+ *  unrecognized divergence is refused (loudly) instead of silently "healed". */
+export function graphIsSubgraphLike(graph) {
+  if (!graph || typeof graph !== "object") return false;
+  if (graph.inputNode ?? graph._inputNode ?? graph.outputNode ?? graph._outputNode) return true;
+  // LiteGraph's `rootGraph` is the graph itself on a root LGraph and the enclosing
+  // root on a Subgraph — a back-pointer to a DIFFERENT graph is subgraph evidence.
+  const claimedRoot = graph.rootGraph;
+  if (claimedRoot && typeof claimedRoot === "object" && claimedRoot !== graph) return true;
+  return false;
+}
+
 /** THE authoritative viewing-scope resolver. Both graph reads and graph mutations
  *  derive their target graph from this, so they can never diverge (#220 / #308).
  *
- *  Returns { graph, rootGraph, scope, owner, stale }:
+ *  Returns { graph, rootGraph, scope, owner, stale, diverged }:
  *   - root             → { graph: root,     scope: "root" }
  *   - a valid subgraph → { graph: subgraph, scope: "subgraph", owner? } — valid when
  *     the live root reaches it via an owner NODE or its `subgraphs` registry.
- *   - a STALE subgraph (the canvas still points at a subgraph the rebuilt root
+ *   - a STALE subgraph (the canvas still points at a SUBGRAPH the rebuilt root
  *     neither owns nor registers — e.g. after a reconnect) → reconcile to root:
  *     { graph: root, scope: "root", stale: true }. The caller rebinds the canvas
- *     so the physical view matches, keeping read + edit in lockstep. */
+ *     so the physical view matches, keeping read + edit in lockstep.
+ *   - a DIVERGED root (the canvas holds a ROOT-LEVEL graph that is not `app.graph`
+ *     — #604: after a backend restart `app.graph` was empty while the canvas still
+ *     held the user's unsaved 31-node workflow) → { graph: canvasGraph, scope:
+ *     "root", stale: FALSE, diverged: true }. `stale` stays false ON PURPOSE: it is
+ *     the caller's repaint trigger, and repainting here is what discarded the
+ *     user's live graph. The caller must REFUSE the command instead — the panel
+ *     cannot prove which of the two graphs the command was issued for, and
+ *     "could not determine" must not become a verdict in either direction. */
 export function resolveScope(app) {
   const rootGraph = app?.graph ?? null;
   const canvasGraph = app?.canvas?.graph ?? null;
   if (!rootGraph) {
-    return { graph: canvasGraph ?? null, rootGraph: null, scope: "root", owner: null, stale: false };
+    return { graph: canvasGraph ?? null, rootGraph: null, scope: "root", owner: null, stale: false, diverged: false };
   }
   if (!canvasGraph || canvasGraph === rootGraph) {
-    return { graph: rootGraph, rootGraph, scope: "root", owner: null, stale: false };
+    return { graph: rootGraph, rootGraph, scope: "root", owner: null, stale: false, diverged: false };
   }
   const owner = findSubgraphOwner(rootGraph, canvasGraph);
   if (owner) {
-    return { graph: canvasGraph, rootGraph, scope: "subgraph", owner, stale: false };
+    return { graph: canvasGraph, rootGraph, scope: "subgraph", owner, stale: false, diverged: false };
   }
   // No presentation-owner node — but the subgraph may still be authoritative via the
   // root's uuid→Subgraph registry (a registered definition without a live instance
   // node). Only when it is NEITHER owned NOR registered is it a genuine post-reconnect
   // ghost; then fall back to root so reads AND writes agree rather than target a ghost.
   if (isSubgraphInRoot(rootGraph, canvasGraph)) {
-    return { graph: canvasGraph, rootGraph, scope: "subgraph", owner: null, stale: false };
+    return { graph: canvasGraph, rootGraph, scope: "subgraph", owner: null, stale: false, diverged: false };
   }
-  return { graph: rootGraph, rootGraph, scope: "root", owner: null, stale: true };
+  // Unreachable from the live root. A SUBGRAPH here is the #220/#308 ghost —
+  // reconcile to root (nothing of the workflow lives in it). Anything ROOT-LEVEL is
+  // the #604 divergence: two candidate workflows, no proof of which one the command
+  // names, and the canvas one is the user's. Report it; never resolve it silently.
+  if (graphIsSubgraphLike(canvasGraph)) {
+    return { graph: rootGraph, rootGraph, scope: "root", owner: null, stale: true, diverged: false };
+  }
+  return { graph: canvasGraph, rootGraph, scope: "root", owner: null, stale: false, diverged: true };
 }
 
 /** Compact JSON scope descriptor for tool responses (the `viewing` field). Derived

--- a/web/js/lib/subgraph-scope.js
+++ b/web/js/lib/subgraph-scope.js
@@ -16,9 +16,22 @@
 //    the now-orphaned slot behind on the parent SubgraphNode.
 //
 // The unifying idea is ONE authoritative scope resolver (`resolveScope`) that BOTH
-// reads and writes derive their target graph from, and that treats a canvas graph
-// unreachable from the LIVE root as stale — reconciling to root so a read and an
-// edit issued back-to-back can never target two different graphs.
+// reads and writes derive their target graph from, so a read and an edit issued
+// back-to-back can never target two different graphs.
+//
+//  - #604: a canvas graph unreachable from the LIVE root used to be reconciled to
+//    root unconditionally, by REPAINTING the canvas. "Unreachable" proves only that
+//    the live root does not own that graph, never that it is disposable — and the
+//    repaint destroyed a user's unsaved 31-node workflow after a backend restart.
+//    The reconcile is now gated on POSITIVE proof that the graph holds no content;
+//    everything else is reported as a divergence for the caller to refuse.
+
+// The SAME content-free proof the binding guard uses (#565): a present-empty
+// `_nodes` array is node-level evidence only, so a graph that cannot serialize —
+// and therefore cannot prove it holds no subgraphs / groups / links — fails
+// closed. resolveScope needs exactly that bar before it may repaint a canvas
+// away, so it borrows the proof rather than inventing a weaker one.
+import { graphRootProvenEmpty as graphProvenContentFree } from "./graph-binding.js";
 
 export const SUBGRAPH_INPUT_RAIL_ID = -10;
 export const SUBGRAPH_OUTPUT_RAIL_ID = -20;
@@ -303,19 +316,15 @@ export function isSubgraphInRoot(rootGraph, subgraph) {
  *  file's resolveRailNode already reads) and by a `rootGraph` back-pointer that
  *  names a DIFFERENT graph; a root graph has no rails and is its own root.
  *
- *  This exists because "the canvas graph is not reachable from app.graph" answers
- *  TWO different questions, and resolveScope used to read one as the other:
- *    (a) "the canvas still points at a subgraph the REBUILT root no longer owns"
- *        (#220/#308) — a ghost with no workflow standing; reconciling the view to
- *        root loses nothing, and
- *    (b) "app.graph and the canvas hold two different ROOT graphs" (#604) — the
- *        canvas is the user's real, live workflow and `app.graph` is the stale or
- *        half-rebuilt one. Treating (b) as (a) repainted the user's canvas away
- *        and left the graph they were editing unreferenced and unrecoverable.
+ *  This does NOT decide whether the view may be repainted — CONTENT does (see
+ *  resolveScope). It only names WHICH divergence happened, so the refusal can
+ *  state a remedy the user can actually act on: a canvas stranded inside a ghost
+ *  SUBGRAPH is escaped by leaving the subgraph, whereas two different ROOT graphs
+ *  can only be reconciled by reloading the page.
  *
- *  Fail-safe direction: only POSITIVE subgraph evidence returns true. A graph with
- *  no rails and no foreign root back-pointer is treated as root-level, so an
- *  unrecognized divergence is refused (loudly) instead of silently "healed". */
+ *  Fail-safe direction: only POSITIVE subgraph evidence returns true, so an
+ *  unrecognized shape is described as the root-level divergence, whose remedy
+ *  (a full page reload) also resolves the subgraph case. */
 export function graphIsSubgraphLike(graph) {
   if (!graph || typeof graph !== "object") return false;
   if (graph.inputNode ?? graph._inputNode ?? graph.outputNode ?? graph._outputNode) return true;
@@ -333,18 +342,27 @@ export function graphIsSubgraphLike(graph) {
  *   - root             → { graph: root,     scope: "root" }
  *   - a valid subgraph → { graph: subgraph, scope: "subgraph", owner? } — valid when
  *     the live root reaches it via an owner NODE or its `subgraphs` registry.
- *   - a STALE subgraph (the canvas still points at a SUBGRAPH the rebuilt root
- *     neither owns nor registers — e.g. after a reconnect) → reconcile to root:
- *     { graph: root, scope: "root", stale: true }. The caller rebinds the canvas
- *     so the physical view matches, keeping read + edit in lockstep.
- *   - a DIVERGED root (the canvas holds a ROOT-LEVEL graph that is not `app.graph`
- *     — #604: after a backend restart `app.graph` was empty while the canvas still
- *     held the user's unsaved 31-node workflow) → { graph: canvasGraph, scope:
- *     "root", stale: FALSE, diverged: true }. `stale` stays false ON PURPOSE: it is
- *     the caller's repaint trigger, and repainting here is what discarded the
- *     user's live graph. The caller must REFUSE the command instead — the panel
- *     cannot prove which of the two graphs the command was issued for, and
- *     "could not determine" must not become a verdict in either direction. */
+ *   - an UNREACHABLE canvas graph (the canvas points at a graph the live root
+ *     neither owns nor registers — after a reconnect, a rebuild, or a backend
+ *     restart). CONTENT decides what happens, never the graph's KIND:
+ *       · PROVABLY content-free (graphRootProvenEmpty: a present-empty `_nodes`
+ *         AND a serialize() whose every non-identity surface is empty) → reconcile
+ *         to root: { graph: root, scope: "root", stale: true }. The caller rebinds
+ *         the canvas so the physical view matches, keeping read + edit in lockstep
+ *         (#220/#308). Nothing can be lost: there is provably nothing in it.
+ *       · anything else → { graph: canvasGraph, scope: "root", stale: FALSE,
+ *         diverged: true, divergedKind }. `stale` stays false ON PURPOSE: it is the
+ *         caller's REPAINT trigger, and repainting is what destroyed work. The
+ *         caller must REFUSE.
+ *
+ *  The kind-blind content rule is the point. This used to reconcile ANY unreachable
+ *  canvas graph by repainting it away, on the premise that an unreachable graph
+ *  "holds none of the workflow". That premise is not proven by unreachability — it
+ *  is proven by CONTENT — and acting on it destroyed a user's unsaved 31-node graph
+ *  (#604) and would equally destroy unsaved work inside a stranded subgraph. Where
+ *  the panel cannot prove which graph a command names, "could not determine" must
+ *  not become a verdict in either direction: refuse, and say which two graphs are
+ *  in play. `divergedKind` ("subgraph" | "root") only selects the remedy wording. */
 export function resolveScope(app) {
   const rootGraph = app?.graph ?? null;
   const canvasGraph = app?.canvas?.graph ?? null;
@@ -365,14 +383,19 @@ export function resolveScope(app) {
   if (isSubgraphInRoot(rootGraph, canvasGraph)) {
     return { graph: canvasGraph, rootGraph, scope: "subgraph", owner: null, stale: false, diverged: false };
   }
-  // Unreachable from the live root. A SUBGRAPH here is the #220/#308 ghost —
-  // reconcile to root (nothing of the workflow lives in it). Anything ROOT-LEVEL is
-  // the #604 divergence: two candidate workflows, no proof of which one the command
-  // names, and the canvas one is the user's. Report it; never resolve it silently.
-  if (graphIsSubgraphLike(canvasGraph)) {
+  // Unreachable from the live root. Repaint ONLY what is provably content-free.
+  if (graphProvenContentFree(canvasGraph)) {
     return { graph: rootGraph, rootGraph, scope: "root", owner: null, stale: true, diverged: false };
   }
-  return { graph: canvasGraph, rootGraph, scope: "root", owner: null, stale: false, diverged: true };
+  return {
+    graph: canvasGraph,
+    rootGraph,
+    scope: "root",
+    owner: null,
+    stale: false,
+    diverged: true,
+    divergedKind: graphIsSubgraphLike(canvasGraph) ? "subgraph" : "root",
+  };
 }
 
 /** Compact JSON scope descriptor for tool responses (the `viewing` field). Derived

--- a/web/js/lib/subgraph-scope.js
+++ b/web/js/lib/subgraph-scope.js
@@ -384,18 +384,14 @@ export function resolveScope(app) {
     return { graph: canvasGraph, rootGraph, scope: "subgraph", owner: null, stale: false, diverged: false };
   }
   // Unreachable from the live root. Repaint ONLY what is provably content-free.
+  // `divergedKind` rides BOTH branches: the caller's repaint can fail (setGraph is
+  // optional and can throw), and an unconfirmed repaint leaves the same divergence,
+  // so it needs the same remedy wording even on the reconcilable branch.
+  const divergedKind = graphIsSubgraphLike(canvasGraph) ? "subgraph" : "root";
   if (graphProvenContentFree(canvasGraph)) {
-    return { graph: rootGraph, rootGraph, scope: "root", owner: null, stale: true, diverged: false };
+    return { graph: rootGraph, rootGraph, scope: "root", owner: null, stale: true, diverged: false, divergedKind };
   }
-  return {
-    graph: canvasGraph,
-    rootGraph,
-    scope: "root",
-    owner: null,
-    stale: false,
-    diverged: true,
-    divergedKind: graphIsSubgraphLike(canvasGraph) ? "subgraph" : "root",
-  };
+  return { graph: canvasGraph, rootGraph, scope: "root", owner: null, stale: false, diverged: true, divergedKind };
 }
 
 /** Compact JSON scope descriptor for tool responses (the `viewing` field). Derived


### PR DESCRIPTION
Fixes the wrong-graph family — #604, #603, #616, and the still-open half of #374 — as one defect rather than four symptoms.

## The shared invariant

> **A graph command may only run on a canvas whose identity the panel can PROVE, and a MUTATION may never run on evidence that would not satisfy a READ.**

Both violations lived at the single point where a graph command picks its target and checks it, and both read a value computed for one purpose as the answer to a different question.

### 1. `getGraphCtx` / `resolveScope` manufactured a binding

"The canvas graph is not reachable from `app.graph`" was computed to mean *"the canvas still points at a stale subgraph the rebuilt root no longer owns"* (#220/#308). It was then read as *"the canvas graph is garbage, replace it"* — and the repair, `app.canvas.setGraph(app.graph)`, ran for **every** unreachable canvas graph.

#604's follow-up report is exactly that: after a backend restart with no page reload, `app.graph` was empty while the canvas still held the user's unsaved ~31-node graph. The panel pointed the canvas at the empty root, the 31-node graph became unreferenced (*"the memory-only graph was unrecoverable"*), and every downstream guard was then handed a self-consistent `(app.graph, activeWorkflow)` pair that no longer said anything about the canvas the command was issued for. **The evidence of the divergence was destroyed before anything could report it** — and the binding guard then threw *"it was NOT applied — nothing changed"* after having changed the view.

The reconcile is now gated on **positive proof of emptiness** (`graphRootProvenEmpty`: a present-empty `_nodes` **and** a `serialize()` whose every non-identity surface is empty); unserializable ⇒ unproven ⇒ refuse. Anything else returns `diverged: true` with `stale: false` — `stale` is the caller's repaint trigger, and arming it is what destroyed work — and `getGraphCtx` refuses `[canvas-root-divergence]` naming both candidate graphs and a remedy that applies. The surviving reconcile is **verified**, not attempted: `setGraph` is optional and can throw during a reconnect, so an unconfirmed rebind is refused like the divergence it leaves in place.

The decision is **content-based, never kind-based**. A stranded *subgraph* can hold unsaved work exactly like a stranded root; "unreachable" proves only that the live root doesn't own it. `graphIsSubgraphLike` decides nothing destructive — only which remedy the refusal states.

### 2. The binding evidence bar was LOWER for mutations than for reads

The bridge dispatch fence hard-coded `includeBaselineReadGuard: false` for **every** command, and only the read executors re-asserted with it on. So the exact evidence that makes `graph_outline` refuse — *"the active workflow reports N>0 nodes but the live root reads empty"* — let `graph_remove_node` through. **That is #604's title verbatim.**

Reachable, not theoretical: when the live root exposes no `_nodes` **array** at all (a half-rebuilt root after a backend restart), `graphRootMismatchesActiveWorkflow` and `graphEmptyBindingUnproven` both bail out as inconclusive *by design*, leaving `graphReadDesynced` as the only predicate — and it was switched off for writes.

The bar now comes from `graphCommandBindingBar(cmd)`, and all five direct-invocation paths that skip dispatch (`graph_run`'s `/run` entry, the CivitAI `graph_load`, per-turn snapshot capture/restore, deferred add-node revalidation) name the shared `MUTATION_BINDING_BAR`.

### 3. The refusal has to survive to the person who needs it

`getGraphCtx` refuses correctly, but `restoreSnapshot()` caught that broadly and returned `null` — the *same value* as "there is no snapshot". All three consumers (`/revert`, double-Esc rewind, the per-message rollback modal) rendered it as **"Nothing to revert — no graph snapshot captured in this session yet."**

Timeline: a snapshot exists → a backend restart leaves the canvas on the unsaved 31-node graph → the user runs `/revert` → `getGraphCtx` correctly refuses before `loadGraphData` → the refusal is discarded → the UI says there was never a snapshot and drops the remedy. It fires *precisely* when someone is recovering from the restart this PR is about.

Fixed in the shared path. The three producers now answer with a discriminated outcome — `restored` (proven on the canvas) / `none` (genuinely no eligible snapshot) / `refused` (nothing loaded; the panel's own reason and remedy attached) / `failed` (the load *ran* and the result is unconfirmed) / unknown (says so rather than borrowing `none`'s wording).

Making that path honest surfaced a chain of related defects, every one found by a gate:

- `loadGraphData` was never **awaited**, so the `failed` branch was unreachable and a partly-applied rejected load reported success.
- A **resolved promise is not a receipt** — `workflow_open` says so about its own load. The restore now demands the same three-part proof: active instance, a stamped identity round-trip (content equality cannot tell tab A from a same-shaped B), and content.
- Pre-load failures were classified as partial applies.
- The async load held **no section**, so an agent command could land mid-load and be silently erased. It now takes the #442 guard.
- The await had **no canvas freeze**, so a *hand* edit during the load was overwritten when it settled. `workflow_open` already freezes `allow_interaction` for this window; the restore now does too — the section fences the bridge, the freeze fences the user.
- Freezing then made a **never-settling load** a silent permanent lockout. The load is now bounded at 15s — but the deadline bounds how long the **caller waits**, not how long the canvas is protected. The panel cannot cancel a `loadGraphData`, so on expiry the fences are *handed to the load* and drop when it settles. **Releasing a fence while the writer is still live is the one combination that cannot be made safe**: it hands the canvas back, lets an edit land, and lets the original load overwrite it. A never-settling load therefore wedges the tab — the same trade `beginWorkflowReloadStep` already documents for the bridge — but now *loudly*: the reply says the load was not cancelled, that the canvas stays locked and why, that it unlocks itself when the load lands, and to reload the page if it never does.
- The interaction lock then needed an **owner**. `allow_interaction` is a bare boolean, so "restore the value I saved" is only correct while nobody else has frozen it since — and two destructive sections do overlap, for the reason already established here: `acquireWorkflowReloadGuard` overwrites, so a timed-out revert can lose its section to a `workflow_open` while its own load is still live. If that revert settled first and restored its stale `true`, it unlocked the canvas mid-reload. It is now reference-counted with per-holder tokens (release by a non-owner is a no-op; the canvas reopens only when the last holder leaves, to the value from before the *first* freeze), and `workflow_open` uses the same pair — a fence only has an owner if every holder goes through it.
- …and the holder is registered **after** the freeze write returns. Registering first is a *claim* that the freeze happened, and `allow_interaction` can be a read-only property or a throwing setter: on a throw nobody holds the token, nobody ever releases it, and the orphan keeps the count nonzero — the next canvas permanently locked with nothing running. **Giving the lock an owner is precisely what created a way to own it forever.** That is the third time in this cluster a guard turned out to be the thing that needed guarding, and it is the strongest argument for the rule the whole PR rests on: every guard is itself an operation that can fail.
- A frontend with no boolean `canvas.allow_interaction` is **refused** rather than run unfenced — there is no way to stop a hand edit there, and claiming a fence that cannot be established is the fabrication. `workflow_open` gates its own destructive re-read on the same condition.
- The rollback modal would rewind the conversation and **resend the user's message** after a rollback that was refused, half-applied, cancelled mid-flight, double-clicked, or simply had no snapshot (the ring holds 25 and evicts).
- `describeRevertOutcome` let a caller pass empty `noneText` and **word a must-state variant away by omission** — which is how the rewind path kept reporting "Rewound your last turn" over an evicted ring. `none` now falls back to text the caller cannot suppress. After four escalations on that axis the emptiness test is **inverted**: an allowlist of what carries meaning (a letter or digit, any script) minus `Default_Ignorable_Code_Point`, not a blocklist of invisibles. `trim()` missed the zero-width space; hand-listed ranges missed the bidi isolates; excluding `Cf`/`Cc`/`Default_Ignorable` missed U+2800 BRAILLE PATTERN BLANK (a *Symbol* that draws nothing); a bare letter/digit allowlist still admits U+3164 HANGUL FILLER (a *Letter* that draws nothing). There is no Unicode property for "draws ink", so a blocklist can always be walked around — the meaning-bearing set is finite.

### 4. The verdict is now observable

The predicate composition was lifted verbatim out of the monolith into a pure `resolveGraphBindingVerdict()` + `graphBindingRefusalMessage()`. The read-vs-mutation bar was previously invisible to every test.

## Availability

Explicitly fenced by tests: no refusal for a genuinely empty workflow, a proven dirty canvas (#545), a descended subgraph, an ordinary root-bound canvas, or a valid open subgraph. The new refusals only fire in the already-broken state.

## Verification

- **1849 unit tests pass**; `tsc --noEmit`, `node --check` as an ES module, and the tool-vocabulary gate clean; committed blobs contain zero control bytes.
- **~47 mutants**, each broken in turn with the matching tests failing — covering the divergence branch, the refusal, the mutation bar, the content proof, the identity stamp and its `{embed}` mode, the reload section, the canvas lock's ownership check, reference count and claim-after-write ordering, releasing the fences while the writer is live, proceeding with no interaction lock, the load deadline, the still-running tracker, the modal's resend/single-shot/cancellation/backdrop gates, and the outcome vocabulary's suppression guard.
- **Codex self-gate to PASS, plus independent review rounds.** The substantive findings, in order: a stranded subgraph was still repainted away on an unproven premise; the permitted reconcile called `setGraph` best-effort and returned root even when it threw; `loadGraphData` was never awaited; a resolved promise was treated as a receipt; the post-load proof could certify the wrong workflow; the modal resent after a rollback that did not happen; the destructive await had no canvas freeze; freezing made a hung load a permanent lockout; the deadline then traded that lockout for a late-write race against a live writer; the destructive path ran unfenced on a frontend without an interaction lock; the canvas lock was released by holders that no longer owned it; and the lock's own holder was registered before the freeze it claimed. Plus a long tail of claims in comments and commit messages narrowed to what the code actually delivers.

## What only a live browser can settle

- **`workflow_open`'s "could not prove that the active canvas was rebound"** (#604 item 3, #603 item 4, #616's recovery path, #374's reopen) is **not fixed here.** My hypothesis is that its proof compares two different dialects — `rootGraph.serialize()` against a `changeTracker.activeState` — which would make it fail *systematically*, matching "on EVERY call". I deliberately did not relax that content proof: guessing wrong re-opens the #349 wrong-canvas hole, and `applied: "unknown"` is at least honest today. One session diffing the two objects settles it.
- Whether `[canvas-root-divergence]` ever fires on a healthy panel. Codex checked the current frontend sources and found no path where `app.canvas.graph` is a root-level graph other than `app.graph`; only a live run proves it.
- #616's vanishing node was seen once, never reproduced. The removed repaint is a mechanism that fits — not proven to be *the* mechanism.
- The restore's post-load **content** proof is a semantic match. `loadGraphData` validates, runs extensions and normalizes widget values before resolving, so a frontend transformation could in principle make a successful revert unverifiable. That direction is safe (it discloses) but if `/revert` starts warning on every working revert, that is where to look.
- The rollback-modal tests drive the real handler over a fake DOM: that is handler *logic*, not event dispatch or hit-testing.
- Deliberate behaviour changes users will notice: the modal no longer resends when a rollback was not proven (including an evicted snapshot); a revert is refused while an earlier timed-out load is still running; a `loadGraphData` that outruns its 15s deadline leaves the canvas locked and graph commands refused **until it lands** (loudly, with a page-reload remedy) rather than handing the canvas back to a live writer; and a frontend without `canvas.allow_interaction` cannot revert at all.

Refs artokun/comfyui-mcp-panel#604, artokun/comfyui-mcp-panel#603, artokun/comfyui-mcp-panel#616, artokun/comfyui-mcp-panel#374

🤖 Generated with [Claude Code](https://claude.com/claude-code)
