### PR TITLE
binding wedged after reconnect or restart, with no path back — including a brand-new empty tab

### DIFF
--- a/browser_tests/unit/binding-recovery.test.mjs
+++ b/browser_tests/unit/binding-recovery.test.mjs
@@ -1,0 +1,506 @@
+/**
+ * Unit tests for the binding-wedged-no-recovery cluster (panel #606 / #607, on the
+ * tree that absorbed #621):
+ *
+ *   #606 — a panel-created blank tab could wedge behind the binding guard after a
+ *     reconnect: ComfyUI reuses app.graph across tabs and clear/configure does NOT
+ *     reset graph.extra, so the new tab inherited the PREVIOUS workflow's root tag;
+ *     with its ChangeTracker not yet PROVEN empty the both-empty heal could not fire,
+ *     and nothing re-stamped the root. workflow_new now stamps the root at creation
+ *     (only when the root is PROVEN content-free), and workflow_open's repaint proof
+ *     re-stamps the tag directly once the content is proven (the tag riding
+ *     loadGraphData/configure is a serializer DIALECT, not workflow content).
+ *
+ *   #607 — a fence refusal ("workflow instance mismatch") meant the orchestrator's
+ *     cached stamp was stale relative to the panel's LIVE identity, yet the advertised
+ *     recovery never reached that cache: the panel re-hellos (the frame the
+ *     orchestrator re-stamps from) when the refusal fires.
+ *
+ * The harnesses extract the SHIPPING code from the panel monolith and drive it with
+ * injected doubles, so the tests are about the code that actually runs (delete the
+ * stamp / the re-stamp / the hook call and the matching test fails).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  graphRootProvenEmpty,
+  graphRootWorkflowUuidMatches,
+  graphRootMatchesState,
+} from "../../web/js/lib/graph-binding.js";
+import { commandTargetsActiveWorkflow } from "../../web/js/lib/workflow-chat-identity.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+const SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+/** Balanced extraction starting at a marker's first "{", ignoring nothing fancy
+ *  (the extracted regions contain no template braces outside code). `openAt` skips
+ *  ahead when the marker itself contains braces (e.g. a `({ rid } = {})` param). */
+function balancedFrom(src, marker, openAt = null) {
+  const start = src.indexOf(marker);
+  assert.notEqual(start, -1, `missing marker: ${marker}`);
+  const open = openAt ?? src.indexOf("{", start + marker.length);
+  let depth = 0;
+  for (let i = open; i < src.length; i += 1) {
+    const ch = src[i];
+    if (ch === "/" && src[i + 1] === "/") {
+      i = src.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === "/" && src[i + 1] === "*") {
+      i = src.indexOf("*/", i + 2);
+      if (i < 0) break;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < src.length; i += 1) {
+        if (src[i] === "\\") {
+          i += 1;
+          continue;
+        }
+        if (src[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error(`unterminated block: ${marker}`);
+}
+
+// ---------------------------------------------------------------------------
+// #606 fix 1 — workflow_new stamps the root tag at creation (proven-empty gate)
+// ---------------------------------------------------------------------------
+
+function buildWorkflowNew({
+  rootGraph,
+  activeWorkflow,
+  stableUuid = "uuid-new-tab",
+  onStamp = () => {},
+} = {}) {
+  // The extracted method source, converted from object-method to standalone form.
+  // The body brace is located via ") {" because the signature itself carries
+  // braces ("{ rid } = {}").
+  const sigStart = SRC.indexOf("async workflow_new({");
+  assert.notEqual(sigStart, -1, "workflow_new not found");
+  const bodyBrace = SRC.indexOf(") {", sigStart) + 1;
+  const methodSource = balancedFrom(SRC, "async workflow_new({", bodyBrace).replace(
+    /^async workflow_new\(/,
+    "async function workflow_new(",
+  );
+  const factory = new Function(
+    "app",
+    "activeWorkflowRef",
+    "workflowTabId",
+    "workflowStableUuid",
+    "noteOpenAttempt",
+    "coerceMessageText",
+    "getWorkflowTitle",
+    "graphRootProvenEmpty",
+    "stampGraphRootWorkflowUuid",
+    "backendReconnectEpoch",
+    "activeWorkflowResyncEpoch",
+    `${methodSource}\nreturn workflow_new;`,
+  );
+  return factory(
+    { graph: rootGraph, extensionManager: { command: { execute: async () => {} } } },
+    () => activeWorkflow,
+    () => "tmp:new-tab",
+    () => stableUuid,
+    () => ({ seq: 1 }),
+    (e) => String(e),
+    () => "Unsaved Workflow",
+    graphRootProvenEmpty,
+    onStamp,
+    1,
+    0,
+  );
+}
+
+const EMPTY_SERIALIZE = () => ({ nodes: [], links: [], extra: { ds: { offset: [0, 0], scale: 1 } } });
+
+test("#606 workflow_new stamps the fresh tab's identity onto a proven-empty root", async () => {
+  const rootGraph = { _nodes: [], extra: {}, serialize: EMPTY_SERIALIZE };
+  const wf = { isPersisted: false, isModified: false, changeTracker: { activeState: { nodes: [] } } };
+  const stamps = [];
+  const workflow_new = buildWorkflowNew({
+    rootGraph,
+    activeWorkflow: wf,
+    onStamp: (root, uuid, owner) => stamps.push([root, uuid, owner]),
+  });
+  const out = await workflow_new({ rid: "r1" });
+  assert.equal(out.created, true);
+  assert.equal(out.routing_key, "tmp:new-tab");
+  assert.equal(stamps.length, 1, "the creation stamp must fire exactly once");
+  assert.equal(stamps[0][0], rootGraph, "stamps the LIVE root");
+  assert.equal(stamps[0][1], "uuid-new-tab", "stamps the NEW tab's identity");
+  assert.equal(stamps[0][2], wf, "records the new workflow as the tag owner");
+});
+
+test("#606 workflow_new does NOT stamp a root that still holds content (fail closed)", async () => {
+  const rootGraph = {
+    _nodes: [{ id: 1, type: "KSampler" }],
+    extra: { comfyui_mcp: { workflow_uuid: "uuid-OLD-tab" } },
+    serialize: () => ({ nodes: [{ id: 1, type: "KSampler" }] }),
+  };
+  const wf = { isPersisted: false, isModified: false, changeTracker: { activeState: { nodes: [] } } };
+  const stamps = [];
+  const workflow_new = buildWorkflowNew({
+    rootGraph,
+    activeWorkflow: wf,
+    onStamp: (...args) => stamps.push(args),
+  });
+  const out = await workflow_new({ rid: "r1" });
+  assert.equal(out.created, true, "creation itself still succeeds");
+  assert.equal(stamps.length, 0, "no re-tagging a root with foreign content");
+});
+
+test("#606 workflow_new does NOT stamp an unserializable root, and a throwing stamp never breaks creation", async () => {
+  const wf = { isPersisted: false, isModified: false, changeTracker: { activeState: { nodes: [] } } };
+  // Unserializable root: proven-empty fails closed → no stamp.
+  const noSerializer = { _nodes: [], extra: {} };
+  const stamps = [];
+  const workflow_new = buildWorkflowNew({
+    rootGraph: noSerializer,
+    activeWorkflow: wf,
+    onStamp: (...args) => stamps.push(args),
+  });
+  assert.equal((await workflow_new({ rid: "r1" })).created, true);
+  assert.equal(stamps.length, 0);
+  // A stamp that throws: creation still reports success (the guard simply keeps its say).
+  const rootGraph = { _nodes: [], extra: {}, serialize: EMPTY_SERIALIZE };
+  const workflow_new_throwing = buildWorkflowNew({
+    rootGraph,
+    activeWorkflow: wf,
+    onStamp: () => {
+      throw new Error("root refuses the tag");
+    },
+  });
+  assert.equal((await workflow_new_throwing({ rid: "r2" })).created, true);
+});
+
+// ---------------------------------------------------------------------------
+// #606/#560 fix 2 — workflow_open's repaint proof: content first, then the tag.
+// A tag that did not ride loadGraphData/configure is re-stamped directly ONLY
+// under BOTH positive proofs: the load observably TRANSITIONED the root into the
+// loaded state (it did not match before), and no foreign tag is present.
+// ---------------------------------------------------------------------------
+
+/**
+ * Drive the SHIPPING repaint-proof block (from the pre-load transition capture
+ * through the proof chain, verbatim from the monolith) with a fake `app` whose
+ * loadGraphData either applies the state to the live root or leaves a stale root
+ * mounted. `preState` is what the root serializes to BEFORE the load; `postState`
+ * what it serializes to after (when the load applies); `postTag` the identity tag
+ * the root carries afterwards (absent / foreign / the target's own).
+ */
+function buildOpenProofBlock({ preState, postState, postTag, loadApplies = true, active, target, targetUuid, repaintState, onStamp }) {
+  const marker = "const rootMatchedBeforeLoad = (() => {";
+  const start = SRC.indexOf(marker);
+  assert.notEqual(start, -1, "pre-load transition capture not found");
+  const endMarker = "\n          }\n        } catch (err) {";
+  const end = SRC.indexOf(endMarker, start);
+  assert.notEqual(end, -1, "repaint proof block end not found");
+  const block = SRC.slice(start, end);
+  const rootGraph = {
+    _nodes: [],
+    extra: {},
+    serialize: () => preState,
+  };
+  const app = {
+    graph: rootGraph,
+    loadGraphData: async () => {
+      if (!loadApplies) return; // stale root stays mounted (old/partial frontend)
+      rootGraph.serialize = () => postState;
+      rootGraph.extra = postTag ? { comfyui_mcp: { workflow_uuid: postTag } } : {};
+    },
+  };
+  const factory = new Function(
+    "app",
+    "getGraphCtx",
+    "activeWorkflowRef",
+    "graphRootMatchesState",
+    "graphRootWorkflowUuidMatches",
+    "stampGraphRootWorkflowUuid",
+    "WORKFLOW_META_NAMESPACE",
+    "WORKFLOW_UUID_FIELD",
+    "target",
+    "targetUuid",
+    "repaintState",
+    `let rebindFailed = null;\nreturn (async () => {\n${block}\nreturn { rebindFailed, rootGraph };\n})();`,
+  );
+  return factory(
+    app,
+    () => ({ rootGraph: app.graph }),
+    () => active,
+    graphRootMatchesState,
+    graphRootWorkflowUuidMatches,
+    onStamp,
+    "comfyui_mcp",
+    "workflow_uuid",
+    target,
+    targetUuid,
+    repaintState,
+  );
+}
+
+const TARGET_UUID = "22222222-2222-4222-8222-222222222222";
+// The state workflow_open loads (tag stamped into extra, as the monolith does).
+const REPAINT_STATE = {
+  nodes: [{ id: 1, type: "KSampler" }],
+  extra: { comfyui_mcp: { workflow_uuid: TARGET_UUID } },
+};
+// What the root serializes to after a faithful load: the repaint CONTENT (the
+// shape comparison excludes the tag, so this carries just the nodes).
+const LOADED_STATE = { nodes: [{ id: 1, type: "KSampler" }] };
+// A genuinely different prior canvas (the drifted-binding case).
+const STALE_STATE = { nodes: [{ id: 7, type: "VAELoader" }, { id: 8, type: "KSampler" }] };
+
+test("#606 workflow_open: load transitioned the root, tag did not ride, none present → direct re-stamp heals", async () => {
+  // The dialect this fixes: loadGraphData installed the exact repaint content
+  // (a PROVEN transition — the root held a different canvas before), but this
+  // frontend left the root's extra without the tag. Before the fix this was an
+  // unrecoverable "could not prove that the active canvas was rebound" — the
+  // dead-end remedy of #606.
+  const target = { path: "workflows/a.json" };
+  const stamps = [];
+  const { rebindFailed, rootGraph } = await buildOpenProofBlock({
+    preState: STALE_STATE,
+    postState: LOADED_STATE,
+    postTag: null,
+    active: target,
+    target,
+    targetUuid: TARGET_UUID,
+    repaintState: REPAINT_STATE,
+    onStamp: (root, uuid, owner) => {
+      stamps.push([root, uuid, owner]);
+      root.extra = { comfyui_mcp: { workflow_uuid: uuid } };
+    },
+  });
+  assert.equal(rebindFailed, null, "the rebind must succeed on a proven transition");
+  assert.equal(stamps.length, 1, "exactly one direct re-stamp");
+  assert.equal(stamps[0][1], TARGET_UUID);
+  assert.equal(stamps[0][2], target);
+  assert.equal(rootGraph.extra.comfyui_mcp.workflow_uuid, TARGET_UUID);
+});
+
+test("#606 workflow_open: tag already present after a faithful repaint → no extra stamp", async () => {
+  const target = { path: "workflows/a.json" };
+  const stamps = [];
+  const { rebindFailed } = await buildOpenProofBlock({
+    preState: STALE_STATE,
+    postState: LOADED_STATE,
+    postTag: TARGET_UUID,
+    active: target,
+    target,
+    targetUuid: TARGET_UUID,
+    repaintState: REPAINT_STATE,
+    onStamp: (...args) => stamps.push(args),
+  });
+  assert.equal(rebindFailed, null);
+  assert.equal(stamps.length, 0, "a tag that rode through needs no repair");
+});
+
+test("#606 workflow_open: a content mismatch NEVER reaches the re-stamp (the #349 fence stands)", async () => {
+  // The root holds a DIFFERENT graph than the state we loaded — the wrong-canvas
+  // case. The stamp must not fire: re-tagging a foreign canvas is exactly what
+  // the binding guard exists to prevent.
+  const target = { path: "workflows/a.json" };
+  const stamps = [];
+  const { rebindFailed, rootGraph } = await buildOpenProofBlock({
+    preState: STALE_STATE,
+    postState: STALE_STATE, // the load left the different-content root mounted
+    postTag: "uuid-foreign",
+    active: target,
+    target,
+    targetUuid: TARGET_UUID,
+    repaintState: REPAINT_STATE,
+    onStamp: (...args) => stamps.push(args),
+  });
+  assert.ok(rebindFailed instanceof Error, "content mismatch still refuses");
+  assert.match(rebindFailed.message, /could not prove that the active canvas was rebound/);
+  assert.equal(stamps.length, 0, "no re-stamp on unproven content");
+  assert.equal(rootGraph.extra.comfyui_mcp.workflow_uuid, "uuid-foreign", "the foreign tag is untouched");
+});
+
+test("#606 workflow_open: another tab winning the active slot refuses WITHOUT a stamp", async () => {
+  const target = { path: "workflows/a.json" };
+  const usurper = { path: "workflows/b.json" };
+  const stamps = [];
+  const { rebindFailed } = await buildOpenProofBlock({
+    preState: STALE_STATE,
+    postState: LOADED_STATE,
+    postTag: null,
+    active: usurper, // a switch interleaved with the open's awaits (#716)
+    target,
+    targetUuid: TARGET_UUID,
+    repaintState: REPAINT_STATE,
+    onStamp: (...args) => stamps.push(args),
+  });
+  assert.ok(rebindFailed instanceof Error);
+  assert.equal(stamps.length, 0);
+});
+
+test("#606 workflow_open: a root that will not hold the tag fails with the honest reason", async () => {
+  const target = { path: "workflows/a.json" };
+  const { rebindFailed } = await buildOpenProofBlock({
+    preState: STALE_STATE,
+    postState: LOADED_STATE,
+    postTag: null,
+    active: target,
+    target,
+    targetUuid: TARGET_UUID,
+    repaintState: REPAINT_STATE,
+    // Real-stamp semantics against a refusing root: the write throws in the
+    // browser's strict mode; model it as a throw here.
+    onStamp: () => {
+      throw new TypeError("Cannot add property, object is not extensible");
+    },
+  });
+  assert.ok(rebindFailed instanceof Error);
+  assert.match(rebindFailed.message, /would not take the workflow's identity tag/);
+});
+
+test("#606 workflow_open: a PRESENT foreign tag is NEVER re-stamped, even on a proven transition (codex P0)", async () => {
+  // The load applied, but the root carries a DIFFERENT workflow's tag. Claims
+  // cannot distinguish an open identical-content copy whose registration is
+  // missing from a closed tab's residue, and the binding guard's own doctrine
+  // refuses unclaimed tags — so any present foreign tag fails closed.
+  const target = { path: "workflows/a.json" };
+  const stamps = [];
+  const { rebindFailed, rootGraph } = await buildOpenProofBlock({
+    preState: STALE_STATE,
+    postState: LOADED_STATE,
+    postTag: "uuid-copy",
+    active: target,
+    target,
+    targetUuid: TARGET_UUID,
+    repaintState: REPAINT_STATE,
+    onStamp: (...args) => stamps.push(args),
+  });
+  assert.ok(rebindFailed instanceof Error, "a present foreign tag must fail closed");
+  assert.match(rebindFailed.message, /carries a different workflow's identity tag/);
+  assert.match(rebindFailed.message, /Reload the panel/);
+  assert.equal(stamps.length, 0, "no re-stamp over a foreign tag");
+  assert.equal(rootGraph.extra.comfyui_mcp.workflow_uuid, "uuid-copy", "the foreign tag survives");
+});
+
+test("#606 workflow_open: tag absent but NO transition (identical copy still mounted) fails closed (codex P0)", async () => {
+  // The root already matched the target's content BEFORE the load and the load
+  // left it untouched: no observable transition, so "our load applied" cannot be
+  // told apart from "a stale root holding an identical copy's canvas". Even with
+  // no tag present, the re-stamp must not fire.
+  const target = { path: "workflows/a.json" };
+  const stamps = [];
+  const { rebindFailed } = await buildOpenProofBlock({
+    preState: LOADED_STATE, // already identical BEFORE the load
+    postState: LOADED_STATE,
+    postTag: null,
+    loadApplies: false, // old/partial frontend: the load resolved but did nothing
+    active: target,
+    target,
+    targetUuid: TARGET_UUID,
+    repaintState: REPAINT_STATE,
+    onStamp: (...args) => stamps.push(args),
+  });
+  assert.ok(rebindFailed instanceof Error, "no transition ⇒ no proof the rebind happened");
+  assert.match(rebindFailed.message, /already held content identical/);
+  assert.match(rebindFailed.message, /Reload the panel/);
+  assert.equal(stamps.length, 0, "no re-stamp without a proven transition");
+});
+
+// ---------------------------------------------------------------------------
+// #607 fix 3 — a fence refusal re-advertises the panel's live identity (re-hello)
+// ---------------------------------------------------------------------------
+
+function buildMismatchFence() {
+  // The module-level hook + note + the assert function, verbatim from the monolith.
+  const sliceStart = SRC.indexOf("let workflowInstanceMismatchRehello = null;");
+  assert.notEqual(sliceStart, -1, "hook declaration not found");
+  const fnSource = balancedFrom(SRC, "function assertActiveWorkflowCommandTarget(");
+  const fnStart = SRC.indexOf("function assertActiveWorkflowCommandTarget(");
+  const slice = SRC.slice(sliceStart, fnStart + fnSource.length);
+  const factory = new Function(
+    "commandTargetsActiveWorkflow",
+    "workflowStableUuid",
+    "WORKFLOW_UUID_FIELD",
+    `${slice}\nreturn {\n` +
+      `  assert: assertActiveWorkflowCommandTarget,\n` +
+      `  setHook: (fn) => { workflowInstanceMismatchRehello = fn; },\n` +
+      `};`,
+  );
+  return factory(commandTargetsActiveWorkflow, () => "uuid-ACTIVE", "workflow_uuid");
+}
+
+test("#607 a refused stamp fires the re-hello hook exactly once, then throws", () => {
+  const fence = buildMismatchFence();
+  let hellos = 0;
+  fence.setHook(() => {
+    hellos += 1;
+  });
+  assert.throws(
+    () =>
+      fence.assert({
+        cmd: "graph_add_node",
+        workflow_uuid: "uuid-STALE",
+      }),
+    /workflow instance mismatch/,
+  );
+  assert.equal(hellos, 1, "the refusal re-advertises the panel's current identity");
+});
+
+test("#607 a matching stamp does NOT fire the hook and does not throw", () => {
+  const fence = buildMismatchFence();
+  let hellos = 0;
+  fence.setHook(() => {
+    hellos += 1;
+  });
+  fence.assert({ cmd: "graph_add_node", workflow_uuid: "uuid-ACTIVE" });
+  assert.equal(hellos, 0);
+});
+
+test("#607 a throwing hook never masks or replaces the refusal", () => {
+  const fence = buildMismatchFence();
+  fence.setHook(() => {
+    throw new Error("socket exploded");
+  });
+  assert.throws(
+    () => fence.assert({ cmd: "graph_add_node", workflow_uuid: "uuid-STALE" }),
+    /workflow instance mismatch/,
+    "the refusal itself must stand",
+  );
+});
+
+test("#607 the dispatch-time fence also re-advertises before refusing", () => {
+  // Structural: the command-handler fence (separate from the assert helper used at
+  // mutation boundaries) must fire the same hook before its throw.
+  const marker = "const executor = GRAPH_TOOL_EXECUTORS[msg.cmd];";
+  const start = SRC.indexOf(marker);
+  assert.notEqual(start, -1);
+  const end = SRC.indexOf("workflow instance mismatch:", start);
+  assert.notEqual(end, -1);
+  const fenceRegion = SRC.slice(start, end);
+  const noteAt = fenceRegion.indexOf("noteWorkflowInstanceMismatch();");
+  assert.notEqual(noteAt, -1, "the dispatch fence must re-advertise on refusal");
+  const throwAt = fenceRegion.indexOf("throw new Error(", noteAt);
+  assert.ok(throwAt > noteAt, "the re-advertise fires BEFORE the refusal throw");
+});
+
+test("#607 the client registers a THROTTLED re-hello as the hook", () => {
+  // A full hello re-greets the user ("agent ready"), so a retry loop against a
+  // genuinely-switched canvas must not storm greetings — the registration is
+  // time-throttled.
+  const marker = "workflowInstanceMismatchRehello = () => {";
+  const start = SRC.indexOf(marker);
+  assert.notEqual(start, -1, "the bridge client must register the re-hello hook");
+  const region = SRC.slice(start, start + 400);
+  assert.match(region, /lastMismatchRehelloAt/);
+  assert.match(region, /sendHello\(\)/);
+});

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -2711,3 +2711,46 @@ test("#560 r2: mutations are fenced against the false-empty window exactly like 
     "graph_add_node on a mid-population canvas is refused, not applied to a false-empty graph",
   );
 });
+
+// #606 — the refusal text must name the firing predicate honestly: a 0-node
+// expectation phrased as "the workflow reports 0 node(s), but the canvas is bound to
+// a different graph" reads as nonsense on a genuinely-empty tab, and the remedy must
+// name the reload as the certain fallback rather than sending the agent to
+// panel_open_workflow with no hint about which recovery actually works.
+test("#606 refusal message: uuid-mismatch names the identity tag, not a 0-node different-graph claim", () => {
+  const msg = graphBindingRefusalMessage({ reason: "root-workflow-uuid-mismatch", expected: 0 });
+  assert.match(msg, /^\[root-workflow-uuid-mismatch\]/);
+  assert.match(msg, /identity tag/);
+  assert.ok(!msg.includes("reports 0 node(s)"), "no nonsense 0-node clause");
+  assert.match(msg, /NOT applied/);
+  assert.match(msg, /panel_open_workflow/);
+  assert.match(msg, /panel_reload/);
+});
+
+test("#606 refusal message: a 0-expected shape mismatch drops the node-count clause", () => {
+  const msg = graphBindingRefusalMessage({ reason: "root-shape-mismatch", expected: 0 });
+  assert.match(msg, /^\[root-shape-mismatch\]/);
+  assert.ok(!msg.includes("reports 0 node(s)"));
+  assert.match(msg, /NOT applied/);
+});
+
+test("#606 refusal message: a positive-count desync keeps the count", () => {
+  const msg = graphBindingRefusalMessage({ reason: "root-node-count-desync", expected: 164 });
+  assert.match(msg, /^\[root-node-count-desync\]/);
+  assert.match(msg, /reports 164 node\(s\)/);
+  assert.match(msg, /NOT applied/);
+});
+
+test("#606 refusal message: dirty-mutation-binding-unproven names the unproven binding", () => {
+  const msg = graphBindingRefusalMessage({ reason: "dirty-mutation-binding-unproven", expected: 0 });
+  assert.match(msg, /^\[dirty-mutation-binding-unproven\]/);
+  assert.match(msg, /NOT applied/);
+  assert.match(msg, /panel_reload/);
+});
+
+test("#606 refusal message: empty-binding-unproven keeps its false-empty warning", () => {
+  const msg = graphBindingRefusalMessage({ reason: "empty-binding-unproven", expected: 0 });
+  assert.match(msg, /^\[empty-binding-unproven\]/);
+  assert.match(msg, /FALSE-EMPTY/);
+  assert.match(msg, /NOT applied/);
+});

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -473,3 +473,44 @@ test('scope guard authorizes only an exact workflow UUID key', () => {
   assert.equal(isThreadInScope(thread, 'workflow:abc-123-copy'), false)
   assert.equal(isThreadInScope(thread, ''), false)
 })
+
+// #607 — server/Manager-scoped commands never read or mutate app.graph, so the
+// per-instance workflow stamp says nothing about whether they may run. Fencing them
+// wedged panel_restart_comfyui itself behind "workflow instance mismatch" — the very
+// command the mismatch error's situation calls for — leaving no in-band recovery.
+test('#607 non-canvas commands are exempt from the workflow-instance fence', () => {
+  for (const cmd of [
+    'comfy_reboot',
+    'free_vram',
+    'nodes_search',
+    'nodes_list',
+    'nodes_install',
+    'nodes_queue_status',
+    'workflow_list'
+  ]) {
+    assert.equal(activeWorkflowFenceApplies({ cmd }), false, `${cmd} must not be fenced`)
+  }
+})
+
+test('#607 canvas and workflow commands stay fenced; unknown commands fail closed', () => {
+  for (const cmd of [
+    'graph_add_node',
+    'graph_outline',
+    'graph_run',
+    'graph_set_widget',
+    // refresh_nodes re-applies defs to LIVE node instances and rewrites combo
+    // lists on the active graph (refreshComfyNodeDefs → reapplyDefsToLiveNodes) —
+    // a canvas mutation, so the stamp must be proven before it runs (codex gate).
+    'refresh_nodes',
+    'workflow_save',
+    'workflow_save_as',
+    'workflow_rename',
+    'workflow_close'
+  ]) {
+    assert.equal(activeWorkflowFenceApplies({ cmd }), true, `${cmd} must stay fenced`)
+  }
+  // Fail closed: a command nobody classified is treated as canvas-bound.
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'some_future_command' }), true)
+  assert.equal(activeWorkflowFenceApplies({ cmd: undefined }), true)
+  assert.equal(activeWorkflowFenceApplies({}), true)
+})

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1832,6 +1832,25 @@ function workflowStableUuid(wf = activeWorkflowRef(), { embed = false } = {}) {
 /** Refuse a command whose bridge-owned stamp no longer names this active canvas.
  * This runs at dispatch and can be injected into an async graph executor's
  * mutation boundary after that executor has awaited external state (#718). */
+// #607 — a refusal here means the orchestrator's cached stamp and the panel's
+// LIVE identity disagree, and the panel's side is computed fresh at refusal
+// time, so the stale half is the orchestrator's cache. The documented recovery
+// (re-target with panel_set_workflow_target({mode:"current"}), then retry) only
+// works if the panel's current identity actually REACHES the orchestrator —
+// which re-stamps from the hello's workflow_uuid on every (re)hello. The bridge
+// client registers its re-hello below so a refusal re-advertises the current
+// identity instead of leaving the advertised recovery a no-op (#607's wedge:
+// every command refused, the recovery command returning success while changing
+// nothing). Best-effort and edge-triggered (only on an actual refusal): a hook
+// throw must never mask or replace the refusal itself.
+let workflowInstanceMismatchRehello = null;
+function noteWorkflowInstanceMismatch() {
+  try {
+    workflowInstanceMismatchRehello?.();
+  } catch {
+    // best-effort — the refusal stands regardless
+  }
+}
 function assertActiveWorkflowCommandTarget(msg, targetsNonActive = false) {
   const commandUuid = msg?.[WORKFLOW_UUID_FIELD];
   if (
@@ -1842,6 +1861,7 @@ function assertActiveWorkflowCommandTarget(msg, targetsNonActive = false) {
       targetsNonActive,
     })
   ) {
+    noteWorkflowInstanceMismatch();
     throw new Error(
       `workflow instance mismatch: this command targets a different workflow than the ` +
         `active canvas â€” the workflow was switched or replaced after it was issued. ` +
@@ -4480,14 +4500,7 @@ function assertGraphBoundToActiveWorkflow(
       resolveGraphRootUuidRebind({ rootGraph, activeWorkflowUuid, rootTagClaimedByActiveWorkflow, staleTagOnEmptyCanvas }) === "rebind"
     ) {
       try {
-        const extra =
-          rootGraph.extra && typeof rootGraph.extra === "object" ? rootGraph.extra : (rootGraph.extra = {});
-        const priorMeta = extra[WORKFLOW_META_NAMESPACE];
-        extra[WORKFLOW_META_NAMESPACE] = {
-          ...(priorMeta && typeof priorMeta === "object" ? priorMeta : {}),
-          [WORKFLOW_UUID_FIELD]: activeWorkflowUuid,
-        };
-        rememberWorkflowUuidOwner(activeWorkflowUuid, activeWorkflow);
+        stampGraphRootWorkflowUuid(rootGraph, activeWorkflowUuid, activeWorkflow);
         rootUuidMismatch = false;
       } catch {
         // A root that refuses the re-stamp stays mismatched and throws below.
@@ -4513,6 +4526,25 @@ function assertGraphBoundToActiveWorkflow(
     requireDirtyMutationBinding,
   });
   if (verdict) throw new Error(graphBindingRefusalMessage(verdict));
+}
+
+/**
+ * Write the panel-owned workflow-identity tag onto a root graph and record its
+ * owner. One shared writer so the binding guard's rebind heal (#545/#557/#565),
+ * the workflow_new creation stamp (#606), and workflow_open's proven repaint
+ * re-stamp (#560) can never drift into three different tag shapes. Callers
+ * decide the EVIDENCE that justifies the stamp (a proven-empty canvas, a proven
+ * repaint, an ownership claim); this only performs the write they settled on.
+ */
+function stampGraphRootWorkflowUuid(rootGraph, uuid, ownerWorkflow) {
+  const extra =
+    rootGraph.extra && typeof rootGraph.extra === "object" ? rootGraph.extra : (rootGraph.extra = {});
+  const priorMeta = extra[WORKFLOW_META_NAMESPACE];
+  extra[WORKFLOW_META_NAMESPACE] = {
+    ...(priorMeta && typeof priorMeta === "object" ? priorMeta : {}),
+    [WORKFLOW_UUID_FIELD]: uuid,
+  };
+  if (ownerWorkflow) rememberWorkflowUuidOwner(uuid, ownerWorkflow);
 }
 
 /** Reach a Pinia store by id. Pinia attaches itself as `$pinia` on the Vue app's
@@ -9703,7 +9735,29 @@ const GRAPH_TOOL_EXECUTORS = {
     // Mint the per-instance tmp: routing id (and seed the transcript uuid) eagerly so
     // the key exists BEFORE the first edit and is returned for pinning.
     const key = workflowTabId(wf);
-    workflowStableUuid(wf);
+    const newWorkflowUuid = workflowStableUuid(wf);
+    // #606 — stamp the live root with the NEW tab's identity NOW, at creation.
+    // ComfyUI reuses the app.graph object across tabs and its clear/configure does
+    // NOT reset graph.extra, so a brand-new blank tab can inherit the PREVIOUS
+    // workflow's root tag while minting its own identity. If a reconnect then
+    // lands before the new tab's ChangeTracker is PROVEN empty, the binding
+    // guard reads the leftover tag as a foreign-canvas conflict and nothing in
+    // the normal command path re-stamps the root — the tab wedges behind the
+    // guard until a frontend reload. The panel itself just created this tab and
+    // its canvas, so stamp the tag at the source instead. Evidence bar: only
+    // when the root is PROVEN content-free on every serialized surface — if the
+    // frontend did not actually hand the new tab an empty canvas, the stamp is
+    // skipped (fail closed) rather than re-tagging a root that still holds the
+    // previous workflow's content. Best-effort: a stamp failure leaves the
+    // pre-existing guard behavior, never a broken creation.
+    try {
+      const rootGraph = app?.graph;
+      if (rootGraph && graphRootProvenEmpty(rootGraph)) {
+        stampGraphRootWorkflowUuid(rootGraph, newWorkflowUuid, wf);
+      }
+    } catch {
+      // Identity bookkeeping must never break workflow creation.
+    }
     // #433: an explicit new-tab authoritatively re-points `active` — record it
     // against the epoch we STARTED on, but only if no reconnect intervened during
     // the async work (else its tab-restore may have overridden us — leave armed).
@@ -9946,21 +10000,85 @@ const GRAPH_TOOL_EXECUTORS = {
                 ...(target.path ? { [WORKFLOW_PATH_FIELD]: target.path } : {}),
               },
             };
+            // Capture whether the root ALREADY matches the state we are about to
+            // load, BEFORE loading it (codex-gate round 4): a root that did not
+            // match before and does match after is a PROVEN transition — positive
+            // evidence loadGraphData actually applied our state. Without the
+            // before-reading, "content matches + tag absent" cannot be told apart
+            // from "the load left a stale root mounted whose content was already
+            // identical to the target's" (an open COPY of the same workflow), and
+            // re-stamping there would certify a canvas the load never touched.
+            const rootMatchedBeforeLoad = (() => {
+              try {
+                return graphRootMatchesState({ rootGraph: app?.graph, state: repaintState });
+              } catch {
+                return false;
+              }
+            })();
             await app.loadGraphData(repaintState, true, true, target);
             // A successful promise alone is not a binding receipt: old/partial frontend
             // implementations can resolve while leaving app.canvas on the previous root.
             // Demand the positive, target-specific marker even for dirty workflows —
             // read-only graph comparisons intentionally cannot prove that case.
             const { rootGraph } = getGraphCtx();
+            // CONTENT proof FIRST, identity tag SECOND (#606): whether the stamped
+            // extra rides loadGraphData onto the live root is a serializer/configure
+            // DIALECT (clear/configure does not reset graph.extra on every frontend),
+            // not workflow content — graphRootMatchesState already excludes the tag
+            // from the comparison for exactly that reason. A content mismatch (or a
+            // different active workflow) NEVER reaches the re-stamp — that is the
+            // #349 wrong-canvas case and stays a hard refusal. A tag that did not
+            // ride is repaired ONLY under the two positive proofs below (a proven
+            // load transition AND no present foreign tag).
             if (
               activeWorkflowRef() !== target ||
-              !graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid: targetUuid }) ||
               !graphRootMatchesState({ rootGraph, state: repaintState })
             ) {
               rebindFailed = new Error(
                 "workflow_open could not prove that the active canvas was rebound to the requested workflow. " +
                   "The open may have switched the active workflow; reload the panel before graph edits.",
               );
+            } else if (!graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid: targetUuid })) {
+              // codex-gate (four rounds) — the direct re-stamp repairs the tag ONLY
+              // under BOTH positive proofs:
+              //   1. the load TRANSITIONED the root: it did not match the loaded
+              //      state before loadGraphData and does now, so the root
+              //      observably became the state we loaded (a stale root with
+              //      already-identical content — an open COPY — shows no
+              //      transition and must fail closed); and
+              //   2. the root carries NO current identity tag: a present foreign
+              //      tag fails closed exactly like the binding guard's own
+              //      unclaimed-tag doctrine (r4/r5) — claims cannot distinguish a
+              //      copy whose registration is missing from a closed tab's
+              //      residue, and re-stamping either could certify a canvas that
+              //      belongs to another workflow.
+              // Anything unprovable keeps the honest refusal with the reload
+              // remedy — a repair we cannot prove safe is not a repair.
+              const currentTag = rootGraph?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD];
+              const tagAbsent = typeof currentTag !== "string" || !currentTag;
+              const loadTransitionProven = !rootMatchedBeforeLoad;
+              if (tagAbsent && loadTransitionProven) {
+                try {
+                  stampGraphRootWorkflowUuid(rootGraph, targetUuid, target);
+                } catch {
+                  // A root that refuses the stamp falls through to the re-check below.
+                }
+              }
+              if (!graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid: targetUuid })) {
+                rebindFailed = new Error(
+                  "workflow_open could not prove that the active canvas was rebound to the requested workflow" +
+                    (!tagAbsent
+                      ? " — the canvas still carries a different workflow's identity tag, and the repaint " +
+                        "could not be told apart from that workflow's own canvas. "
+                      : !loadTransitionProven
+                        ? " — the canvas already held content identical to the requested workflow before " +
+                          "the repaint, so the rebind cannot be proven (an identical copy may still be " +
+                          "mounted). "
+                        : " — the repainted canvas would not take the workflow's identity tag, so graph " +
+                          "commands would still refuse it. ") +
+                    "Reload the panel before graph edits.",
+                );
+              }
             }
           }
         } catch (err) {
@@ -12974,8 +13092,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // does not, and only this uuid fence catches it. The pin guard stays as an ADDITIONAL
             // check (it catches a switch to a different PATH); both must pass.
             //
-            // activeWorkflowFenceApplies() exempts only the genuinely-non-active ops: navigation/
-            // creation (workflow_open/new) and a path-selectored workflow_rename/close whose
+            // activeWorkflowFenceApplies() exempts only the genuinely-non-active ops: server/
+            // Manager-scoped commands that never touch app.graph (NON_CANVAS_COMMANDS, #607),
+            // navigation/creation (workflow_open/new) and a path-selectored workflow_rename/close whose
             // selector RESOLVES to a non-active OPEN workflow. Decide that by the RESOLVED TARGET,
             // never raw path presence: resolve the selector the same way the executor will
             // (openWorkflows.find) and exempt ONLY when it lands on a real open workflow that is
@@ -13005,6 +13124,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
                 targetsNonActive,
               })
             ) {
+              // #607 — re-advertise the panel's CURRENT identity (re-hello) so the
+              // recovery this message advertises actually reaches the orchestrator's
+              // cached stamp; see noteWorkflowInstanceMismatch.
+              noteWorkflowInstanceMismatch();
               throw new Error(
                 `workflow instance mismatch: this command targets a different workflow than the ` +
                   `active canvas — the workflow was switched or replaced after it was issued. ` +
@@ -13398,6 +13521,21 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // Reconnect path will retry.
     });
   }
+
+  // #607 — the workflow-instance fence fires this (via noteWorkflowInstanceMismatch)
+  // when it refuses a command whose stamp no longer names the active canvas: the
+  // panel's live identity is authoritative, so re-hello to push it to the
+  // orchestrator (which re-stamps from hello.workflow_uuid), making the refusal's
+  // advertised recovery (re-target, then retry) able to succeed. Throttled: a
+  // retry loop against a genuinely-switched canvas must not become a greeting
+  // storm — a full hello re-greets the user ("agent ready").
+  let lastMismatchRehelloAt = 0;
+  workflowInstanceMismatchRehello = () => {
+    const now = Date.now();
+    if (now - lastMismatchRehelloAt < 5000) return;
+    lastMismatchRehelloAt = now;
+    sendHello();
+  };
 
   // When the workflow title changes (rename / open a different file / progress
   // ticks during a run / each graph edit toggling the modified "*"), send a

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -596,7 +596,7 @@ export function resolveGraphBindingVerdict({
  * The caller-facing refusal text for a `resolveGraphBindingVerdict` result. Kept
  * next to the predicates so the claim and the evidence cannot drift apart.
  *
- * Both messages state that the command was NOT applied. That claim is only ever
+ * Every message states that the command was NOT applied. That claim is only ever
  * TRUE because every caller asserts BEFORE doing any work — a caller that has
  * already mutated something must disclose, not refuse (a refusal for work that
  * landed invites a destructive retry, which is #603's duplicate-node cascade).
@@ -612,11 +612,40 @@ export function graphBindingRefusalMessage(verdict) {
       `persists, re-open the workflow tab (panel_open_workflow) or reload the panel.`
     );
   }
+  // #606 — name the firing predicate honestly and order the remedies by what
+  // actually recovers. panel_open_workflow rebinds in place (its repaint proof
+  // re-stamps the root's identity tag from the workflow's own state); a panel
+  // reload ALWAYS re-establishes the binding from scratch, so it is the certain
+  // fallback — earlier text sent the agent to open_workflow with no hint that
+  // reload is the reliable one, and phrased a 0-node expectation as "the
+  // workflow reports 0 node(s), but the canvas is bound to a different graph",
+  // which reads as nonsense for a genuinely-empty tab.
+  const remedy =
+    `Re-open the active workflow tab (panel_open_workflow) to rebind the graph in place; if that ` +
+    `does not clear it, reload the panel (panel_reload scope:frontend) — a reload always ` +
+    `re-establishes the binding — then retry.`;
+  if (verdict.reason === "root-workflow-uuid-mismatch") {
+    return (
+      `[root-workflow-uuid-mismatch] The live canvas carries a different workflow's identity tag ` +
+      `than the active workflow — a load, tab switch, or reconnect left a stale tag behind, so ` +
+      `this command was NOT applied. ${remedy}`
+    );
+  }
+  if (verdict.reason === "dirty-mutation-binding-unproven") {
+    return (
+      `[dirty-mutation-binding-unproven] The active workflow has unsaved edits and the live canvas ` +
+      `carries no identity tag proving it belongs to that workflow, so this mutation was NOT ` +
+      `applied — a change-tracker lag cannot be told apart from a wrong canvas here. ${remedy}`
+    );
+  }
+  const expectation =
+    Number(verdict.expected) > 0
+      ? `the workflow reports ${verdict.expected} node(s), but the canvas is bound to a different graph`
+      : `the canvas's content does not match the active workflow's own state`;
   return (
-    `[${verdict.reason}] The live graph is out of sync with the active workflow: the workflow reports ` +
-    `${verdict.expected} node(s), but the canvas is bound to a different graph. A load, tab switch, ` +
-    `or reconnect left this command pointed at the wrong canvas, so it was NOT applied. Re-open the ` +
-    `active workflow tab (panel_open_workflow) or reload the panel to rebind the graph, then retry.`
+    `[${verdict.reason}] The live graph is out of sync with the active workflow: ${expectation}. ` +
+    `A load, tab switch, or reconnect left this command pointed at the wrong canvas, so it was ` +
+    `NOT applied. ${remedy}`
   );
 }
 

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -237,6 +237,30 @@ export function selectorTargetsNonActiveWorkflow({ resolved, active } = {}) {
   return Boolean(resolved) && resolved !== active;
 }
 
+/** #607 — commands that never touch the active canvas. They target the SERVER
+ *  (comfy_reboot, free_vram), the Manager backend (nodes_*), or the workflow
+ *  SERVICE's tab list (workflow_list — also the diagnostic every recovery remedy
+ *  points at, and the probe the orchestrator refreshes its stamp from) — none of
+ *  them read or mutate `app.graph`, so a stale per-instance workflow stamp says
+ *  nothing about whether they may run. Fencing them was strictly harmful: once
+ *  the stamp drifted, `panel_restart_comfyui` — the very recovery the mismatch
+ *  error's situation calls for — was itself refused with "workflow instance
+ *  mismatch", leaving no in-band way out. `refresh_nodes` is deliberately NOT
+ *  here: refreshComfyNodeDefs re-applies defs to LIVE node instances and
+ *  rewrites combo lists on the active graph, so it is a canvas mutation and
+ *  stays fenced. Keep the list explicit and default unknown/new commands to
+ *  FENCED (fail closed), so adding a graph tool can never accidentally weaken
+ *  the wrong-workflow fence. */
+const NON_CANVAS_COMMANDS = new Set([
+  "comfy_reboot",
+  "free_vram",
+  "nodes_search",
+  "nodes_list",
+  "nodes_install",
+  "nodes_queue_status",
+  "workflow_list",
+]);
+
 /** #570 — does the per-command workflow-instance uuid fence APPLY to this command? The fence
  *  refuses a command whose stamped workflow_uuid ≠ the ACTIVE workflow's uuid, so it must cover
  *  everything that runs against the active canvas — every graph_* op AND the active-workflow
@@ -251,6 +275,8 @@ export function selectorTargetsNonActiveWorkflow({ resolved, active } = {}) {
  *  can't); both must pass. The fence fires for pinned ops too.
  *
  *  It must NOT fire only for:
+ *   • non-canvas commands (NON_CANVAS_COMMANDS, #607): server/Manager/registry-scoped
+ *     ops whose outcome does not depend on which workflow is active;
  *   • workflow_open / workflow_new: navigation/creation with their own explicit/new target;
  *   • workflow_rename / workflow_close whose selector resolves to a genuinely NON-active open
  *     workflow (`targetsNonActive` — via selectorTargetsNonActiveWorkflow): a deterministic
@@ -259,6 +285,7 @@ export function selectorTargetsNonActiveWorkflow({ resolved, active } = {}) {
  *  Reads (graph_get_state, …) still return true here — harmlessly fenced (fail-closed); their
  *  reply is server-fenced anyway, and a read can only run against the active canvas regardless. */
 export function activeWorkflowFenceApplies({ cmd, targetsNonActive = false } = {}) {
+  if (NON_CANVAS_COMMANDS.has(cmd)) return false;
   if (cmd === 'workflow_open' || cmd === 'workflow_new') return false;
   if ((cmd === 'workflow_rename' || cmd === 'workflow_close') && targetsNonActive) return false;
   return true;


### PR DESCRIPTION
## Issues in this cluster

- #607
- #606
- #560
- #436
- #178

Grouped because they share a codepath: once the panel's binding evidence drifts (a stale root identity tag after a reconnect, or the orchestrator's cached workflow-uuid stamp going stale), every recovery the errors advertised was a dead end and the session wedged until a manual browser refresh.

Rebased onto `main` twice: after #621 merged, and again after #623/#625–#629/#632 merged. Each report re-verified against the merged tree before changing anything.

## What this PR changes

**#606 — brand-new empty tab wedged after a reconnect**
- `workflow_new` stamps the live root with the NEW tab's identity at creation, but only when the root is PROVEN content-free on every serialized surface (`graphRootProvenEmpty`). ComfyUI reuses `app.graph` across tabs and clear/configure does not reset `graph.extra`, so a fresh tab otherwise inherits the previous workflow's tag and wedges behind the binding guard while its ChangeTracker is not yet proven empty. A root with content is never re-tagged (fail closed).
- `workflow_open`'s side of this cluster is now owned by **#623's attempt-scoped `open_proof` marker** (merged into main and adopted wholesale in the integration merge): a single-use marker minted per open and written into the load payload proves THIS load landed — strictly stronger than this branch's original transition-proof re-stamp, which was dropped as superseded. The per-cause honest refusal is preserved (and improved) by `describeOpenRebindOutcome`.
- The binding refusal messages no longer say "the workflow reports 0 node(s), but the canvas is bound to a different graph" for a 0-node expectation, name the identity tag for what it is, keep the `[reason]` prefix, and name the panel reload as the certain fallback. (Coexists with #623's `root-mid-population` verdict, which merged cleanly alongside.)

**#607 — "workflow instance mismatch" with no path back**
- Server/Manager-scoped commands (`comfy_reboot`, `free_vram`, `nodes_search/list/install/queue_status`, `workflow_list`) no longer pass the workflow-instance fence at all — they never touch `app.graph`, and fencing them made `panel_restart_comfyui` itself refuse with the mismatch it was called to recover from. `refresh_nodes` is deliberately NOT exempt (it re-applies defs to live node instances — codex gate). Unknown commands still fail closed.
- A fence refusal now fires a throttled (5s) re-hello, re-advertising the panel's CURRENT workflow identity — the frame the orchestrator re-stamps its per-tab command cache from — so the advertised recovery (re-target, then retry) actually reaches the stale stamp instead of being a no-op.

## Already fixed upstream (verified, not re-fixed)

- **#560** (closed): the false-empty read guard, the dialect-normalized `graphRootMatchesState`, the both-empty heal (#560/#565/#621), and now the attempt-scoped open-rebind proof (#623).
- **#178** (closed): `tmp:` ids are WeakMap-stable per workflow object, the panel re-hellos with the fresh tab id on reconnect, and the current orchestrator rebinds on `panel_set_workflow_target({mode:"current"})`. Not reproducible panel-side on the merged tree.
- **#436**: the read-ok/write-refused flap was fixed orchestrator-side (`carryWorkflowCommandStamp`, which cites #436) — the command stamp is carried across the tab-id migration instead of being retired. The panel side (re-register via reconnect→hello) already exists. The two error strings quoted in the issue are orchestrator-side; nothing panel-side left that I could evidence.

## Deliberately NOT fixed

- **#607's "set_workflow_target({mode:'current'}) does not invalidate the cached stamp"** is orchestrator-side (comfyui-mcp). The current orchestrator already rebinds the tab and re-stamps from every hello's `workflow_uuid`; this PR's re-hello-on-refusal closes the panel half of the remaining hole (identity drift with no reconnect). No orchestrator change was made from this repo.
- **#606's "[reason] tag stripped before reaching the agent"**: the tag is present in the panel's thrown message (verified); if it does not reach the agent, the stripping is orchestrator-side and out of this repo.

## What only a live browser can confirm

- The end-to-end un-wedge: fresh `tmp:` tab + reconnect → `graph_outline` succeeds without a reload.

## Verification

- 2309/2309 unit tests pass (`npm run test:unit`) on the final integrated tree (this branch + #623/#624/#625–#629/#632); `node --check` as ES module clean; `tsc --noEmit` clean; CI lint green; GitHub reports MERGEABLE/CLEAN.
- Every test covering this branch's changes mutation-verified against the code it covers — on the integrated tree after the merge: stamp uuid, proven-empty gate, hook exactly-once/no-mask, fence exemption and its fail-closed default, refresh_nodes fenced, uuid-message branch — each break fails the matching test.
- Post-state grep confirms the new forms and the absence of the old ones; committed blobs scanned for control bytes (0).
- Adversarial self-gate (codex) on the branch's own diff: 5 rounds — refresh_nodes exemption (fixed), foreign-claimed re-stamp (fixed), unclaimed-copy hole (fixed), absent-tag/no-transition hole (fixed) — final round **PASS**. (The re-stamp those rounds hardened was later superseded by #623's marker proof in the integration merge; the gate findings are why dropping it for the stronger mechanism was safe.)
- Merge integrations: (1) #623/#625–#629/#632 — conflicts in `web/js/comfyui-mcp-panel.js` (workflow_open proof — resolved by adopting #623's marker proof) and `browser_tests/unit/graph-binding.test.mjs` (both appended suites kept). (2) #624 — conflicts in `web/js/lib/workflow-chat-identity.js` (this branch's NON_CANVAS_COMMANDS vs #624's CANVAS_INDEPENDENT_COMMANDS: adopted #624's set wholesale — `graph_update_node` exempt, `workflow_list` fenced under its sharper criterion; the #607 `comfy_reboot` deadlock case is preserved identically) and `web/js/lib/graph-binding.js` (kept this branch's #606 uuid-mismatch message, adopted #624's #601 dirty-mutation message; #624's `sealProvenRootBinding` sits complementarily after this branch's rebind heal). Lib auto-merges re-checked semantically (mid-population verdict + #606 messages coexist).
