### PR TITLE
reconnect shape mismatch: a loop on unsaved workflows, an outline missing its own nodes, and a false "panel not installed"

### DIFF
--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -17,9 +17,11 @@ import { dirname, join } from "node:path";
 
 import {
   activeWorkflowNodeCount,
+  activeWorkflowCurrentNodeCount,
   activeWorkflowProvenEmpty,
   graphEmptyBindingUnproven,
   graphReadDesynced,
+  graphRootMidPopulation,
   graphRootMismatchesActiveWorkflow,
   graphRootProvenEmpty,
   graphRootWorkflowUuidMismatches,
@@ -123,6 +125,7 @@ function buildDirtyStaleRouteHarness({
   activeModified = true,
   activeTracker,
   rootSerializer = null,
+  postReconnectWindow = false,
 } = {}) {
   const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
   const stableSource = panelFunctionSource(src, "workflowStableUuid", "workflowStorageKey");
@@ -268,6 +271,7 @@ function buildDirtyStaleRouteHarness({
     "workflowOwnsRootUuidTag",
     "rememberWorkflowUuidOwner",
     "resolveGraphRootUuidRebind",
+    "postReconnectSettleWindow",
     "WORKFLOW_META_NAMESPACE",
     "WORKFLOW_UUID_FIELD",
     `${fenceSource}\nreturn assertGraphBoundToActiveWorkflow;`,
@@ -283,6 +287,9 @@ function buildDirtyStaleRouteHarness({
     ownsTag,
     () => {},
     resolveGraphRootUuidRebind,
+    // #618 — the extracted fence reads the reconnect window through this hook;
+    // harnesses default to OUTSIDE the window and opt in explicitly.
+    () => postReconnectWindow === true,
     "comfyui_mcp",
     "workflow_uuid",
   );
@@ -2710,4 +2717,243 @@ test("#560 r2: mutations are fenced against the false-empty window exactly like 
     /\[empty-binding-unproven\]/,
     "graph_add_node on a mid-population canvas is refused, not applied to a false-empty graph",
   );
+});
+
+// ---------------------------------------------------------------------------
+// #618 — the MID-POPULATION fence. After a ComfyUI reconnect the frontend
+// restores the active tab's graph incrementally; for a window the live root
+// observably reads FEWER nodes than the active workflow's own current state
+// (the restore source). On a DIRTY tab every pre-existing predicate was blind
+// to that signature (shape guard inconclusive while dirty, #545; baseline
+// desync guard gated on a clean tracker; empty-read guard needs ZERO nodes),
+// so an 8-of-31 restoring canvas was served as an authoritative outline and
+// the agent duplicated nodes it could not see. The fence closes that window —
+// and ONLY that window: outside it the #545 dirty-tab availability stands.
+// ---------------------------------------------------------------------------
+
+// A workflow whose CURRENT serialized state reports `n` nodes (the restore
+// source). `withState:false` models an absent/unreadable tracker — no evidence.
+const midPopWorkflow = (n, { modified = true, withState = true } = {}) => ({
+  isModified: modified,
+  ...(withState ? { changeTracker: { activeState: state(n) } } : {}),
+});
+const midPopRoot = (n, extra) => ({
+  _nodes: state(n).nodes,
+  ...(extra ? { extra } : {}),
+});
+
+test("#618: dirty tab in the reconnect window — a live root BEHIND the workflow's own state refuses as root-mid-population", () => {
+  const verdict = resolveGraphBindingVerdict({
+    graph: midPopRoot(8),
+    rootGraph: midPopRoot(8),
+    activeWorkflow: midPopWorkflow(31),
+    liveNodeCount: 8,
+    postReconnectWindow: true,
+  });
+  assert.equal(verdict?.reason, "root-mid-population");
+  // Assert the EVIDENCE, not just the state: the verdict quotes the current-state
+  // count (31), never a load baseline, and the observed live count (8).
+  assert.equal(verdict?.expected, 31);
+  assert.equal(verdict?.live, 8);
+});
+
+test("#618: the SAME evidence outside the reconnect window stays available (the #545 dirty-tab relaxation is untouched)", () => {
+  const verdict = resolveGraphBindingVerdict({
+    graph: midPopRoot(8),
+    rootGraph: midPopRoot(8),
+    activeWorkflow: midPopWorkflow(31),
+    liveNodeCount: 8,
+    postReconnectWindow: false,
+  });
+  assert.equal(verdict, null, "a dirty tab's live-behind-tracker read is legitimate manual-edit lag outside the window");
+});
+
+test("#618: clean tab in the window — the count-short canvas reads as mid-population, not the heavier wrong-canvas verdict", () => {
+  const verdict = resolveGraphBindingVerdict({
+    graph: midPopRoot(8),
+    rootGraph: midPopRoot(8),
+    activeWorkflow: midPopWorkflow(31, { modified: false }),
+    liveNodeCount: 8,
+    postReconnectWindow: true,
+  });
+  assert.equal(verdict?.reason, "root-mid-population");
+  // Outside the window the same clean-tab evidence keeps its pre-#618 verdict.
+  const settled = resolveGraphBindingVerdict({
+    graph: midPopRoot(8),
+    rootGraph: midPopRoot(8),
+    activeWorkflow: midPopWorkflow(31, { modified: false }),
+    liveNodeCount: 8,
+    postReconnectWindow: false,
+  });
+  assert.equal(settled?.reason, "root-shape-mismatch");
+});
+
+test("#618: a descended SUBGRAPH is exempt — an entered subgraph legitimately reads smaller than the root state", () => {
+  const verdict = resolveGraphBindingVerdict({
+    graph: { _nodes: state(4).nodes },
+    rootGraph: midPopRoot(8),
+    activeWorkflow: midPopWorkflow(31),
+    liveNodeCount: 4,
+    inSubgraph: true,
+    postReconnectWindow: true,
+  });
+  assert.equal(verdict, null);
+});
+
+test("#618: no current-state evidence fails OPEN — an absent/malformed tracker read proves nothing", () => {
+  for (const wf of [midPopWorkflow(31, { withState: false }), null, undefined]) {
+    const verdict = resolveGraphBindingVerdict({
+      graph: midPopRoot(8),
+      rootGraph: midPopRoot(8),
+      activeWorkflow: wf,
+      liveNodeCount: 8,
+      postReconnectWindow: true,
+    });
+    assert.equal(verdict, null, "unreadable current state must never manufacture a mid-population verdict");
+  }
+});
+
+test("#618: equal or AHEAD live counts do not fire — only a canvas BEHIND the workflow's own state is mid-restore evidence", () => {
+  for (const live of [31, 40]) {
+    const verdict = resolveGraphBindingVerdict({
+      graph: midPopRoot(live),
+      rootGraph: midPopRoot(live),
+      activeWorkflow: midPopWorkflow(31),
+      liveNodeCount: live,
+      postReconnectWindow: true,
+    });
+    assert.equal(verdict, null, `live=${live} against a 31-node state is not mid-population evidence`);
+  }
+});
+
+test("#618: a current state of ZERO nodes does not fire — an empty restore target is the empty-read guards' case, not this one's", () => {
+  const verdict = resolveGraphBindingVerdict({
+    graph: midPopRoot(0),
+    rootGraph: midPopRoot(0),
+    activeWorkflow: midPopWorkflow(0),
+    liveNodeCount: 0,
+    postReconnectWindow: true,
+  });
+  assert.equal(verdict, null);
+});
+
+test("#618: reads keep their LOWER bar at dispatch — the fence re-asserts in the read executor, like the baseline desync guard", () => {
+  const verdict = resolveGraphBindingVerdict({
+    graph: midPopRoot(8),
+    rootGraph: midPopRoot(8),
+    activeWorkflow: midPopWorkflow(31),
+    liveNodeCount: 8,
+    postReconnectWindow: true,
+    ...graphCommandBindingBar("graph_outline"),
+  });
+  assert.equal(verdict, null, "dispatch does not refuse reads early; the executor's full bar is where the fence lives");
+});
+
+test("#618: MUTATIONS are fenced in the window too — a proven-bound dirty root still refuses while the canvas is mid-restore", () => {
+  const uuid = "wf-uuid-A";
+  const verdict = resolveGraphBindingVerdict({
+    graph: midPopRoot(8),
+    rootGraph: midPopRoot(8, { comfyui_mcp: { workflow_uuid: uuid } }),
+    activeWorkflow: midPopWorkflow(31),
+    activeWorkflowUuid: uuid,
+    liveNodeCount: 8,
+    postReconnectWindow: true,
+    ...graphCommandBindingBar("graph_remove_node"),
+  });
+  assert.equal(verdict?.reason, "root-mid-population");
+});
+
+test("#618: a positive UUID conflict outranks the mid-population verdict — identity evidence stays first", () => {
+  const verdict = resolveGraphBindingVerdict({
+    graph: midPopRoot(8),
+    rootGraph: midPopRoot(8, { comfyui_mcp: { workflow_uuid: "foreign-tab-B" } }),
+    activeWorkflow: midPopWorkflow(31),
+    activeWorkflowUuid: "wf-uuid-A",
+    liveNodeCount: 8,
+    // rootUuidMismatch is computed by the caller (the monolith fence) from the
+    // tag/identity conflict above; passed in here exactly as it would be live.
+    rootUuidMismatch: true,
+    postReconnectWindow: true,
+    ...MUTATION_BINDING_BAR,
+  });
+  assert.equal(verdict?.reason, "root-workflow-uuid-mismatch");
+});
+
+test("#618: the refusal message discloses the uncertainty and names a remedy that works from where the caller is", () => {
+  const message = graphBindingRefusalMessage({
+    reason: "root-mid-population",
+    expected: 31,
+    live: 8,
+  });
+  assert.match(message, /\[root-mid-population\]/);
+  assert.match(message, /shows 8 node\(s\)/, "the live count is quoted");
+  assert.match(message, /reports 31/, "the workflow's own count is quoted");
+  assert.match(message, /NOT applied/, "the refusal never reads as a partial success");
+  assert.match(message, /Retry in a moment/, "the cheap remedy comes first");
+  assert.match(message, /panel_open_workflow/, "the persistent-case remedy is actionable from here");
+  assert.doesNotMatch(message, /did NOT land|not installed/, "no stale-install blame leaks into a binding verdict");
+});
+
+test("#618: the monolith's fence feeds the verdict the live reconnect window (extracted source, window ON and OFF)", () => {
+  const inWindow = buildDirtyStaleRouteHarness({
+    rootUuid: null,
+    foreignClaim: "none",
+    activeNodeCount: 31,
+    rootNodeCount: 8,
+    postReconnectWindow: true,
+  });
+  assert.throws(
+    () => inWindow.assertBound(inWindow.rootB, inWindow.rootB),
+    /\[root-mid-population\]/,
+    "the real assertGraphBoundToActiveWorkflow refuses the 8-of-31 restoring canvas inside the window",
+  );
+  const settled = buildDirtyStaleRouteHarness({
+    rootUuid: null,
+    foreignClaim: "none",
+    activeNodeCount: 31,
+    rootNodeCount: 8,
+  });
+  assert.doesNotThrow(
+    () => settled.assertBound(settled.rootB, settled.rootB),
+    "the same canvas stays available once the window has closed",
+  );
+});
+
+test("#618: the panel source wires the window from the #433 epoch/monotonic machinery, not a wall-clock guess", () => {
+  const src = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+  const helper = panelFunctionSource(src, "postReconnectSettleWindow", "assertGraphBoundToActiveWorkflow");
+  assert.match(helper, /activeWorkflowPossiblyStale\(\{/, "the window decision is the shared #433 predicate");
+  assert.match(helper, /reconnectEpoch: backendReconnectEpoch/);
+  assert.match(helper, /resyncEpoch: activeWorkflowResyncEpoch/);
+  assert.match(helper, /reconnectedAt: backendReconnectedAt/);
+  assert.match(helper, /now: monotonicNow\(\)/, "the window reads a monotonic clock");
+  const fence = panelFunctionSource(src, "assertGraphBoundToActiveWorkflow", "getPiniaStore");
+  assert.match(
+    fence,
+    /postReconnectWindow: postReconnectSettleWindow\(\)/,
+    "the binding verdict receives the live window on every fenced command",
+  );
+});
+
+test("#618: graphRootMidPopulation unit edges — NaN/negative live counts and subgraph scope never fire", () => {
+  const wf = midPopWorkflow(31);
+  assert.equal(graphRootMidPopulation({ liveNodeCount: NaN, activeWorkflow: wf, postReconnectWindow: true }), false);
+  assert.equal(graphRootMidPopulation({ liveNodeCount: -1, activeWorkflow: wf, postReconnectWindow: true }), false);
+  assert.equal(graphRootMidPopulation({ liveNodeCount: 8, activeWorkflow: wf, inSubgraph: true, postReconnectWindow: true }), false);
+  assert.equal(graphRootMidPopulation({ liveNodeCount: 8, activeWorkflow: wf }), false, "window defaults closed");
+});
+
+test("#618: activeWorkflowCurrentNodeCount reads ONLY the current state — the load baseline is not mid-population evidence", () => {
+  // initialState says 31 (the load baseline) but the current state has legitimately
+  // shrunk to 8: the baseline must NOT accuse the canvas.
+  const wf = {
+    changeTracker: { activeState: state(8), initialState: state(31) },
+  };
+  assert.equal(activeWorkflowCurrentNodeCount(wf), 8);
+  assert.equal(
+    graphRootMidPopulation({ liveNodeCount: 8, activeWorkflow: wf, postReconnectWindow: true }),
+    false,
+    "a canvas matching the CURRENT state is not mid-population, whatever the baseline held",
+  );
+  assert.equal(activeWorkflowCurrentNodeCount({}), null, "no current state → no evidence");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -4419,6 +4419,21 @@ function workflowOwnsRootUuidTag(w, rootUuid) {
   return false;
 }
 
+// #618 — is the panel inside the post-reconnect settling window RIGHT NOW?
+// Reuses the #433 epoch/monotonic machinery verbatim: the window opens on every
+// ComfyUI "reconnected" and closes when an explicit open/new re-proves the tab
+// (or the monotonic window expires). The binding verdict uses it to read a live
+// root that is BEHIND the active workflow's own current state as a tab still
+// restoring — not as an authoritative graph (the mid-population fence).
+function postReconnectSettleWindow() {
+  return activeWorkflowPossiblyStale({
+    reconnectEpoch: backendReconnectEpoch,
+    resyncEpoch: activeWorkflowResyncEpoch,
+    reconnectedAt: backendReconnectedAt,
+    now: monotonicNow(),
+  });
+}
+
 function assertGraphBoundToActiveWorkflow(
   graph,
   rootGraph,
@@ -4511,6 +4526,7 @@ function assertGraphBoundToActiveWorkflow(
     rootUuidMismatch,
     includeBaselineReadGuard,
     requireDirtyMutationBinding,
+    postReconnectWindow: postReconnectSettleWindow(),
   });
   if (verdict) throw new Error(graphBindingRefusalMessage(verdict));
 }

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -77,6 +77,66 @@ export function graphReadDesynced({ liveNodeCount, activeWorkflow, inSubgraph = 
 }
 
 /**
+ * The active workflow's OWN current-state node count, or `null` when that state
+ * is absent/malformed. Unlike activeWorkflowNodeCount this NEVER falls back to
+ * the load/save baseline (`initialState`): a baseline legitimately differs from
+ * an edited canvas, so it is not evidence the live canvas is behind. `null`
+ * lets callers fail OPEN — an unreadable current state proves nothing.
+ */
+export function activeWorkflowCurrentNodeCount(activeWorkflow) {
+  const state = activeWorkflowCurrentState(activeWorkflow);
+  return state ? state.nodes.length : null;
+}
+
+/**
+ * #618 — the MID-POPULATION read. After a ComfyUI backend reconnect the frontend
+ * RESTORES the active tab's graph incrementally, and for a window the live root
+ * canvas observably holds FEWER nodes than the active workflow's own current
+ * serialized state (the restore source). Every pre-existing predicate is blind
+ * to exactly this signature on a DIRTY tab — and the reported tabs are dirty
+ * (the unsaved edits are what the restore re-applies): the shape guard treats a
+ * dirty tracker's state as inconclusive (#545: it can lag manual edits), the
+ * baseline desync guard requires a trustworthy (clean) current state, and the
+ * empty-read guard needs ZERO nodes, not a partial count. So an 8-of-31-node
+ * restoring canvas was returned as an AUTHORITATIVE 8-node outline — and the
+ * agent that trusted it duplicated a node it could not see and ran a
+ * whole-graph layout against an under-reported graph (#618's follow-up; the
+ * first report lost a single LoadImage the same way).
+ *
+ * This predicate is the evidence bar for that window, fired only when ALL of:
+ *   - `postReconnectWindow`: the caller's monotonic/epoch machinery says a
+ *     reconnect just happened and no explicit open/new has re-proven the tab
+ *     since (outside the window the #545 dirty-tab availability is untouched);
+ *   - ROOT scope (a descended subgraph is exempt, mirroring graphReadDesynced);
+ *   - the workflow's CURRENT state is a well-formed read reporting N > 0 nodes
+ *     (an absent/malformed read proves nothing — fail open);
+ *   - the live root reads strictly FEWER nodes than N.
+ *
+ * The one signature it cannot distinguish is a manual node DELETION on a dirty
+ * tab whose tracker has not captured yet, inside the same window. That refusal
+ * is safe and self-clearing: the tracker's event-driven capture closes the gap
+ * and the retry the message names succeeds — whereas a mid-population canvas
+ * returned as authoritative is the fabricated-success outcome this repo treats
+ * as the worst case. Reads and mutations alike are fenced: a mutation on a
+ * canvas that is still being restored is #604's wrong-canvas family wearing a
+ * milder hat.
+ */
+export function graphRootMidPopulation({
+  liveNodeCount,
+  activeWorkflow,
+  inSubgraph = false,
+  postReconnectWindow = false,
+} = {}) {
+  if (!postReconnectWindow) return false;
+  if (inSubgraph) return false;
+  const live = Number(liveNodeCount);
+  if (!Number.isFinite(live) || live < 0) return false;
+  const expected = activeWorkflowCurrentNodeCount(activeWorkflow);
+  if (expected == null || expected <= 0) return false;
+  return live < expected;
+}
+
+/**
  * #560 (2nd reopen) — the FALSE-EMPTY authoritative read. After a reconnect +
  * workflow-tab switch (or a failed workflow_open repaint), the shared
  * app.graph object is observable MID-POPULATION: `_nodes` empty, no root tag,
@@ -542,11 +602,11 @@ export function graphCommandBindingBar(command) {
  * above is unit-testable without a browser (it previously lived inline in the
  * panel monolith, where nothing could observe it).
  *
- * Returns `{ reason, expected }`; `reason` names the firing predicate so a
+ * Returns `{ reason, expected, live }`; `reason` names the firing predicate so a
  * misfiring guard is diagnosable instead of driving a blind reload/retry loop
- * (#565). Order is significant: the first four verdicts are POSITIVE mismatches
- * and stay more specific than the inconclusive-empty verdict, which is evaluated
- * LAST so it can never mask them.
+ * (#565). Order is significant: the positive-mismatch verdicts (identity first,
+ * then the #618 mid-population window, then shape) stay more specific than the
+ * inconclusive-empty verdict, which is evaluated LAST so it can never mask them.
  */
 export function resolveGraphBindingVerdict({
   graph,
@@ -558,6 +618,7 @@ export function resolveGraphBindingVerdict({
   rootUuidMismatch = false,
   includeBaselineReadGuard = true,
   requireDirtyMutationBinding = false,
+  postReconnectWindow = false,
 } = {}) {
   const nodeCount = Number.isFinite(Number(liveNodeCount))
     ? Number(liveNodeCount)
@@ -570,21 +631,49 @@ export function resolveGraphBindingVerdict({
     requireDirtyMutationBinding &&
     activeWorkflow?.isModified === true &&
     !graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid });
+  // #618 — inside the post-reconnect window a live root reading BEHIND the
+  // active workflow's own current state is mid-restore evidence, and it is the
+  // ONLY mismatch a dirty tab can surface (the shape guard below is deliberately
+  // inconclusive while dirty). Ordered ahead of rootShapeMismatch: in the window
+  // a count-short canvas is far more often a still-restoring tab than a wrong
+  // one, and this verdict's remedy (settle, then re-open if it persists)
+  // resolves both — while a genuine wrong canvas still refuses, just with the
+  // cheaper remedy first. Gated on includeBaselineReadGuard so reads keep their
+  // lower bar at dispatch and re-assert here in their executors, exactly like
+  // the baseline desync guard.
+  const midPopulation =
+    includeBaselineReadGuard &&
+    graphRootMidPopulation({
+      liveNodeCount: nodeCount,
+      activeWorkflow,
+      inSubgraph,
+      postReconnectWindow,
+    });
   const rootShapeMismatch = graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow });
   const currentStateTrustworthy = activeWorkflow?.isModified !== true;
   const baselineReadDesync =
     currentStateTrustworthy &&
     includeBaselineReadGuard &&
     graphReadDesynced({ liveNodeCount: nodeCount, activeWorkflow, inSubgraph });
-  if (rootUuidMismatch || dirtyMutationBindingUnproven || rootShapeMismatch || baselineReadDesync) {
+  if (rootUuidMismatch || dirtyMutationBindingUnproven || midPopulation || rootShapeMismatch || baselineReadDesync) {
     const reason = rootUuidMismatch
       ? "root-workflow-uuid-mismatch"
       : dirtyMutationBindingUnproven
         ? "dirty-mutation-binding-unproven"
-        : rootShapeMismatch
-          ? "root-shape-mismatch"
-          : "root-node-count-desync";
-    return { reason, expected: activeWorkflowNodeCount(activeWorkflow) };
+        : midPopulation
+          ? "root-mid-population"
+          : rootShapeMismatch
+            ? "root-shape-mismatch"
+            : "root-node-count-desync";
+    return {
+      reason,
+      // The mid-population count must come from the CURRENT state alone — the
+      // load baseline is not evidence the canvas is behind (#618).
+      expected: midPopulation
+        ? activeWorkflowCurrentNodeCount(activeWorkflow)
+        : activeWorkflowNodeCount(activeWorkflow),
+      live: nodeCount,
+    };
   }
   if (graphEmptyBindingUnproven({ graph, rootGraph, activeWorkflow, activeWorkflowUuid })) {
     return { reason: "empty-binding-unproven", expected: activeWorkflowNodeCount(activeWorkflow) };
@@ -600,9 +689,24 @@ export function resolveGraphBindingVerdict({
  * TRUE because every caller asserts BEFORE doing any work — a caller that has
  * already mutated something must disclose, not refuse (a refusal for work that
  * landed invites a destructive retry, which is #603's duplicate-node cascade).
+ * (#618 later added a third, mid-population, verdict on the same terms.)
  */
 export function graphBindingRefusalMessage(verdict) {
   if (!verdict) return null;
+  if (verdict.reason === "root-mid-population") {
+    // #618 — disclose the uncertainty, don't narrate the bucket as a cause: a
+    // count-short canvas in the reconnect window is USUALLY a tab still
+    // restoring, but it can also be a genuine wrong canvas, so the message
+    // names the settle-and-recheck path that resolves both.
+    return (
+      `[root-mid-population] The live root canvas shows ${verdict.live} node(s), but the active workflow's ` +
+      `own current state reports ${verdict.expected} node(s). ComfyUI reconnected moments ago, so the canvas ` +
+      `may still be restoring the tab — a partial canvas read as complete is how duplicate nodes and ` +
+      `wrong-graph edits happen — so this command was NOT applied as authoritative. Retry in a moment once ` +
+      `the tab finishes settling; if the count never catches up, re-open the active workflow tab ` +
+      `(panel_open_workflow) or reload the panel to rebind the graph, then retry.`
+    );
+  }
   if (verdict.reason === "empty-binding-unproven") {
     return (
       `[empty-binding-unproven] The live root canvas reads EMPTY, but the active workflow's own ` +


### PR DESCRIPTION
## Issues in this cluster

- artokun/comfyui-mcp-panel#619
- artokun/comfyui-mcp-panel#618
- artokun/comfyui-mcp-panel#617
- artokun/comfyui-mcp#888

## What landed

**#618 (and the reconnect half of artokun/comfyui-mcp-panel#617/#619): the mid-population fence.** After a ComfyUI reconnect the frontend restores the active tab's graph incrementally; for a window the live root canvas observably reads FEWER nodes than the active workflow's own current serialized state (the restore source). On a **dirty** tab every pre-existing binding predicate was blind to exactly that signature (shape guard deliberately inconclusive while dirty, artokun/comfyui-mcp-panel#545; baseline desync guard gated on a clean tracker; empty-read guard needs zero nodes, not a partial count) — so `panel_graph_outline` served an 8-of-31 mid-restore canvas as an authoritative outline, and the agent that trusted it duplicated a node it could not see and ran a whole-graph layout against the under-reported graph (#618's follow-up report).

The fix, in `web/js/lib/graph-binding.js` + one wiring point in the monolith:

- `graphRootMidPopulation()` fires only when ALL of: the artokun/comfyui-mcp-panel#433 epoch/monotonic post-reconnect window is open, ROOT scope, the workflow's CURRENT state (never the load baseline) is a well-formed read reporting N>0 nodes, and the live root reads strictly fewer than N.
- Wired into `resolveGraphBindingVerdict` as a new `root-mid-population` reason, gated on `includeBaselineReadGuard` (reads keep their lower bar at dispatch and re-assert in their executors, like the baseline desync guard) and ordered ahead of `root-shape-mismatch` inside the window — where a count-short canvas is far more often a still-restoring tab than a wrong one. UUID-conflict and dirty-mutation-binding verdicts still outrank it.
- The refusal discloses the uncertainty instead of narrating the bucket as a cause, states the command was NOT applied, and names remedies that work from where the caller is (retry once settled; `panel_open_workflow` if it persists).
- Outside the window, no pre-#618 behavior changes (mutation-verified against the existing suite, including the artokun/comfyui-mcp-panel#560 false-empty and artokun/comfyui-mcp-panel#545 dirty-tab tests).

Verification: 1993 unit tests pass (15 new). Delete-the-code check: removing the verdict wiring fails the 4 core tests. Mutation-verified (`<=` vs `<`, window-gate removal, monolith-wiring removal — each caught, two of them also by pre-existing artokun/comfyui-mcp-panel#560/#545 tests). Committed blobs scanned: 0 control bytes. Codex adversarial gate: **PASS**, no findings.

## Deliberately NOT fixed here

- **#613 (false "panel install did NOT land" on reconnect): the message is emitted by the ORCHESTRATOR repo** (`src/orchestrator/index.ts` ~L2715 wrapping `src/services/panel-installer.ts` ~L1986 in comfyui-mcp), not this repo — the panel only displays the orchestrator's `say` push. The suggested fix (re-run the authoritative disk scan before emitting the warning, suppress the stale failure when installed=true and version meets requiredPanelVersion) belongs in an orchestrator PR, adjacent to the artokun/comfyui-mcp-panel#629 manager-dialect-and-sync files. Nothing in this repo can suppress it.
- **#617's recovery loop** (`panel_open_workflow` could not prove the rebind on an unsaved tmp tab and advised a reload that repeated the mismatch): needs a live browser to pin down why the rebind proof fails for the re-minted tmp tab identity; the mid-population fence above removes the false-authoritative reads in the same window but does not claim to fix the loop itself.
- **#619's transient** (root-shape-mismatch immediately after a successful `panel_enter_subgraph`, observed once, not reproducible after recovery): the issue itself marks it intermittent and reconnect-adjacent. The fence converts the window's false-authoritative reads into honest refusals, but whether the specific enter→outline race still fires needs live confirmation.

## What only a live browser can confirm

That the post-reconnect restore of a dirty unsaved tab now surfaces `root-mid-population` refusals (instead of a partial outline) during the hydration window, and that the refusal clears once the tab settles.
