### PR TITLE
the write fence blocking legitimate writes: unknown bundle version, a stale JS reload, one mutation per page load

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -493,6 +493,26 @@ def _register_routes():
     except Exception as _e:  # pragma: no cover - never block panel load
         _log("apps routes not registered: {}".format(_e))
 
+    @routes.get("/comfyui_mcp_panel/version")
+    async def _pack_version(_request):
+        # #584/#611 — the INSTALLED pack version, read from pyproject.toml at
+        # request time. The panel JS compares this against its running
+        # PANEL_VERSION: a mismatch proves the browser is running a CACHED stale
+        # bundle (a restart reconnects the tab but never re-downloads the
+        # extension JS), which is what leaves the tab advertising old/unknown
+        # capabilities to the orchestrator's write fence. no-store so the probe
+        # itself can never be served stale.
+        try:
+            from .py.pack_version import installed_pack_version
+
+            version = installed_pack_version()
+        except Exception:
+            version = None
+        return web.json_response(
+            {"version": version},
+            headers={"Cache-Control": "no-store"},
+        )
+
     @routes.get("/comfyui_mcp_panel/status")
     async def _status(_request):
         detected = _detect_comfyui_url()

--- a/browser_tests/unit/bundle-version.test.mjs
+++ b/browser_tests/unit/bundle-version.test.mjs
@@ -1,0 +1,206 @@
+/**
+ * Unit tests for #584/#611 — stale panel bundle detection + module-cache priming.
+ *
+ * The pack on disk can be current while a browser tab keeps running a CACHED
+ * older bundle (heuristic static-file caching survives restarts and plain
+ * reloads); the stale bundle then advertises old/unknown capabilities and the
+ * orchestrator's write fence refuses every mutation. These lock the verdict
+ * (never reload on an unreadable probe) and the cache priming crawl (visits the
+ * pack's whole static module graph with cache:"reload", stays inside the pack
+ * dir, bounded and cycle-safe).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  collectRelativeImportSpecifiers,
+  primeModuleCache,
+  resolveBundleStaleness,
+} from "../../web/js/lib/bundle-version.js";
+
+test("resolveBundleStaleness: equal versions are current", () => {
+  assert.equal(resolveBundleStaleness({ running: "0.11.39", installed: "0.11.39" }), "current");
+});
+
+test("resolveBundleStaleness: different versions are stale — upgrade AND downgrade", () => {
+  assert.equal(resolveBundleStaleness({ running: "0.11.34", installed: "0.11.39" }), "stale");
+  assert.equal(resolveBundleStaleness({ running: "0.11.39", installed: "0.11.34" }), "stale");
+});
+
+test("resolveBundleStaleness: a missing/malformed probe is UNKNOWN — never evidence for a reload", () => {
+  assert.equal(resolveBundleStaleness({ running: "0.11.39", installed: null }), "unknown");
+  assert.equal(resolveBundleStaleness({ running: "0.11.39", installed: undefined }), "unknown");
+  assert.equal(resolveBundleStaleness({ running: "0.11.39", installed: "" }), "unknown");
+  assert.equal(resolveBundleStaleness({ running: "0.11.39", installed: "   " }), "unknown");
+  assert.equal(resolveBundleStaleness({ running: "0.11.39", installed: 123 }), "unknown");
+  assert.equal(resolveBundleStaleness({ running: "", installed: "0.11.39" }), "unknown");
+  assert.equal(resolveBundleStaleness({}), "unknown");
+});
+
+test("collectRelativeImportSpecifiers: static imports/exports, relative only", () => {
+  const src = [
+    `import { app } from "../../scripts/app.js";`, // relative but OUT of the pack dir: the CRAWLER excludes it, the collector reports it
+    `import { marked } from "./vendor/marked.esm.js";`,
+    `import { a } from "./lib/a.js";`,
+    `import "./lib/side-effect.js";`,
+    `export { b } from "../lib/b.js";`,
+    `const lit = await import("./vendor/a2ui-lit.bundle.js");`, // literal dynamic import (the #584 mixed-bundle hole)
+    `import(dynamicName);`, // non-literal: unparseable, skipped
+    `import lit from "lit";`, // bare specifier: not ours, never reported
+    `import{min}from"./minified.js";`, // minified static import — no whitespace (codex gate round 4)
+    `export{re}from"./reexport.js";`, // minified re-export
+    `const x = 1; // import { fake } from "./not-real.js" — inside a comment`,
+  ].join("\n");
+  const specs = collectRelativeImportSpecifiers(src);
+  assert.deepEqual(
+    specs.sort(),
+    [
+      "../../scripts/app.js",
+      "../lib/b.js",
+      "./lib/a.js",
+      "./lib/side-effect.js",
+      "./minified.js",
+      "./reexport.js",
+      "./vendor/a2ui-lit.bundle.js",
+      "./vendor/marked.esm.js",
+    ].sort(),
+  );
+  assert.deepEqual(collectRelativeImportSpecifiers(""), []);
+  assert.deepEqual(collectRelativeImportSpecifiers(null), []);
+});
+
+// A fake module graph for the crawl: entry → lib/a → lib/b (+cycle back to a),
+// entry → vendor/v, a DYNAMIC import of vendor/dyn, and an out-of-pack import
+// that must NOT be fetched.
+const GRAPH = {
+  "https://host/extensions/pack/panel.js":
+    `import { a } from "./lib/a.js";\nimport { v } from "./vendor/v.js";\nimport { app } from "../../scripts/app.js";\nconst d = await import("./vendor/dyn.js");`,
+  "https://host/extensions/pack/lib/a.js":
+    `import { b } from "./b.js";`,
+  "https://host/extensions/pack/lib/b.js":
+    `import { a } from "./a.js";`, // cycle
+  "https://host/extensions/pack/vendor/v.js": `export const v = 1;`,
+  "https://host/extensions/pack/vendor/dyn.js": `export const d = 1;`,
+};
+
+const fakeFetch =
+  (graph, record, failUrls = new Set()) =>
+  async (url, opts) => {
+    record.push({ url, opts });
+    if (failUrls.has(url) || !(url in graph)) return { ok: false, text: async () => "" };
+    return { ok: true, text: async () => graph[url] };
+  };
+
+test("primeModuleCache: revalidates the whole in-pack module graph with cache:reload, cycle-safe", async () => {
+  const calls = [];
+  const result = await primeModuleCache({
+    entryUrl: "https://host/extensions/pack/panel.js",
+    fetchImpl: fakeFetch(GRAPH, calls),
+  });
+  assert.deepEqual(
+    result.primed.sort(),
+    [
+      "https://host/extensions/pack/panel.js",
+      "https://host/extensions/pack/lib/a.js",
+      "https://host/extensions/pack/lib/b.js",
+      "https://host/extensions/pack/vendor/v.js",
+      "https://host/extensions/pack/vendor/dyn.js", // literal dynamic import — primed too
+    ].sort(),
+  );
+  assert.deepEqual(result.failed, []);
+  assert.equal(result.truncated, false);
+  // Every fetch forced revalidation (the whole point — a normal reload reuses the stale cache entries).
+  for (const c of calls) assert.equal(c.opts?.cache, "reload", `no cache:reload on ${c.url}`);
+  // The out-of-pack core script is never fetched.
+  assert.ok(
+    !calls.some((c) => c.url.includes("/scripts/app.js")),
+    "the crawl must stay inside the pack's web dir",
+  );
+  // Cycle: each module fetched exactly once.
+  assert.equal(calls.length, 5);
+});
+
+test("primeModuleCache: a failed module is collected, not thrown — the caller decides", async () => {
+  const calls = [];
+  const result = await primeModuleCache({
+    entryUrl: "https://host/extensions/pack/panel.js",
+    fetchImpl: fakeFetch(GRAPH, calls, new Set(["https://host/extensions/pack/lib/a.js"])),
+  });
+  assert.deepEqual(result.failed, ["https://host/extensions/pack/lib/a.js"]);
+  assert.ok(result.primed.includes("https://host/extensions/pack/panel.js"));
+});
+
+test("primeModuleCache: maxModules bounds the crawl and reports truncation", async () => {
+  const calls = [];
+  const result = await primeModuleCache({
+    entryUrl: "https://host/extensions/pack/panel.js",
+    fetchImpl: fakeFetch(GRAPH, calls),
+    maxModules: 2,
+  });
+  assert.equal(result.truncated, true);
+  assert.ok(calls.length <= 2);
+});
+
+test("primeModuleCache: a throwing fetch is collected as failed, never propagated", async () => {
+  const result = await primeModuleCache({
+    entryUrl: "https://host/extensions/pack/panel.js",
+    fetchImpl: async () => {
+      throw new Error("network down");
+    },
+  });
+  assert.deepEqual(result.primed, []);
+  assert.deepEqual(result.failed, ["https://host/extensions/pack/panel.js"]);
+});
+
+test("primeModuleCache: degenerate inputs are a no-op", async () => {
+  assert.deepEqual(await primeModuleCache({}), { primed: [], failed: [], truncated: false });
+  assert.deepEqual(await primeModuleCache({ entryUrl: "", fetchImpl: async () => null }), {
+    primed: [],
+    failed: [],
+    truncated: false,
+  });
+});
+
+// The healer itself is browser wiring (api/sessionStorage/location), so its
+// safety INVARIANTS are pinned at source level (codex gate rounds 2-3):
+//   - the reload-loop guard marker must be read back after ssSet — sessionStorage
+//     can be unavailable, and reloading without the persisted marker loops forever;
+//   - the automatic prime must be time-bounded — a hung module fetch must not
+//     strand the guarded reload.
+test("#584 healer invariants: loop-guard read-back and bounded prime are present in the panel source", () => {
+  const src = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "../../web/js/comfyui-mcp-panel.js"),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
+  const arm = src.indexOf("ssSet(BUNDLE_HEAL_KEY, marker);");
+  assert.notEqual(arm, -1, "the healer arms the loop guard");
+  const readback = src.indexOf("ssGet(BUNDLE_HEAL_KEY) !== marker", arm);
+  assert.ok(readback > arm, "the marker is read back after ssSet — no reload when the guard cannot persist");
+  const healPrime = src.indexOf("primeModuleCache({", arm);
+  assert.ok(healPrime > arm, "the healer primes the module cache");
+  const race = src.lastIndexOf("Promise.race([", healPrime);
+  assert.ok(race !== -1 && healPrime - race < 400, "the healer's prime is raced against a timeout");
+  // Round 5: the probe deadline covers the BODY parse too — a response whose
+  // json() never settles must not wedge setup() before registration. The pin
+  // requires the timeout ENTRY, not just the race shape.
+  const probeRace = src.match(
+    /Promise\.race\(\[\s*probe,\s*new Promise\(\(resolve\) => setTimeout\(\(\) => resolve\(null\), \d+\)\)/,
+  );
+  assert.ok(probeRace, "the version probe (fetch AND body parse) is raced against a timeout entry");
+  assert.ok(
+    src.indexOf("return await res.json().catch(() => null);") < src.indexOf("Promise.race([\n      probe,"),
+    "the body parse lives INSIDE the raced probe",
+  );
+  // Round 4: setup() must AWAIT the bounded probe BEFORE the panel becomes
+  // available — a stale bundle that connects first would advertise its stale
+  // capabilities and get fenced again inside the probe window.
+  const healCall = src.indexOf("await healStaleBundleIfNeeded();");
+  assert.ok(healCall !== -1, "setup awaits the staleness probe");
+  assert.ok(
+    healCall < src.indexOf("registerSidebarTab(tabSpec)"),
+    "the probe settles before the sidebar tab registers (no stale-capability window)",
+  );
+});

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -32,6 +32,7 @@ import {
   MUTATION_BINDING_BAR,
   graphReadBindingChanged,
   resolveGraphRootUuidRebind,
+  sealProvenRootBinding,
   serializedStateProvenEmpty,
 } from "../../web/js/lib/graph-binding.js";
 import {
@@ -268,6 +269,10 @@ function buildDirtyStaleRouteHarness({
     "workflowOwnsRootUuidTag",
     "rememberWorkflowUuidOwner",
     "resolveGraphRootUuidRebind",
+    "sealProvenRootBinding",
+    "graphRootMatchesState",
+    "sameWorkflowObject",
+    "app",
     "WORKFLOW_META_NAMESPACE",
     "WORKFLOW_UUID_FIELD",
     `${fenceSource}\nreturn assertGraphBoundToActiveWorkflow;`,
@@ -283,6 +288,10 @@ function buildDirtyStaleRouteHarness({
     ownsTag,
     () => {},
     resolveGraphRootUuidRebind,
+    sealProvenRootBinding,
+    graphRootMatchesState,
+    sameWorkflowObject,
+    { graph: rootB, extensionManager: { workflow: { openWorkflows } } },
     "comfyui_mcp",
     "workflow_uuid",
   );
@@ -781,6 +790,192 @@ test("#545 P1: an untagged stale root is refused for dirty mutations but a prove
     }),
     "the #545 dirty-edit case remains available once the live root positively matches A",
   );
+});
+
+// ── #601: the seal — a proven-CLEAN binding is stamped onto the root ─────────
+//
+// The one-mutation-per-page-load deadlock: a reload rebuilds app.graph from
+// saved JSON with NO root stamp, and the first mutation is itself what dirties
+// the tab — so every mutation after the first hit dirty-mutation-binding-
+// unproven. The seal stamps the active workflow's uuid onto the root at the one
+// moment it is provably correct: clean tab + root serializes EQUAL to the
+// workflow's own current state.
+
+test("sealProvenRootBinding: clean tab + proven-equal root gets stamped (and preserves other extra keys)", () => {
+  const workflow = { isModified: false, changeTracker: { activeState: state(5) } };
+  const root = { _nodes: [], extra: { ds: { scale: 1 } }, serialize: () => state(5) };
+  assert.equal(
+    sealProvenRootBinding({ rootGraph: root, activeWorkflow: workflow, activeWorkflowUuid: "uuid-A" }),
+    true,
+  );
+  assert.equal(root.extra.comfyui_mcp.workflow_uuid, "uuid-A");
+  assert.deepEqual(root.extra.ds, { scale: 1 }, "the stamp must not clobber unrelated extra keys");
+});
+
+test("sealProvenRootBinding: fails CLOSED — dirty tab, subgraph scope, foreign stamp, unproven root, missing identity", () => {
+  const clean = { isModified: false, changeTracker: { activeState: state(5) } };
+  const dirty = { isModified: true, changeTracker: { activeState: state(5) } };
+  const root = () => ({ _nodes: [], serialize: () => state(5) });
+  // Dirty tab: the tracker can lag the real canvas (#545) — no seal.
+  {
+    const r = root();
+    assert.equal(sealProvenRootBinding({ rootGraph: r, activeWorkflow: dirty, activeWorkflowUuid: "uuid-A" }), false);
+    assert.equal(r.extra, undefined);
+  }
+  // Subgraph scope: the stamp belongs on the root only — the caller passes the root, but the flag is defense in depth.
+  {
+    const r = root();
+    assert.equal(
+      sealProvenRootBinding({ rootGraph: r, activeWorkflow: clean, activeWorkflowUuid: "uuid-A", inSubgraph: true }),
+      false,
+    );
+    assert.equal(r.extra, undefined);
+  }
+  // An EXISTING stamp — even a conflicting one — is the rebind path's decision, never overwritten here.
+  {
+    const r = { _nodes: [], extra: { comfyui_mcp: { workflow_uuid: "uuid-B" } }, serialize: () => state(5) };
+    assert.equal(sealProvenRootBinding({ rootGraph: r, activeWorkflow: clean, activeWorkflowUuid: "uuid-A" }), false);
+    assert.equal(r.extra.comfyui_mcp.workflow_uuid, "uuid-B");
+  }
+  // A root that does NOT serialize equal to the workflow's current state stays unstamped (stale/foreign canvas).
+  {
+    const r = { _nodes: [], serialize: () => state(9) };
+    assert.equal(sealProvenRootBinding({ rootGraph: r, activeWorkflow: clean, activeWorkflowUuid: "uuid-A" }), false);
+    assert.equal(r.extra, undefined);
+  }
+  // An unserializable root / missing identity / missing sides: no stamp, no throw.
+  {
+    const r = { _nodes: [] };
+    assert.equal(sealProvenRootBinding({ rootGraph: r, activeWorkflow: clean, activeWorkflowUuid: "uuid-A" }), false);
+    assert.equal(sealProvenRootBinding({ rootGraph: root(), activeWorkflow: clean, activeWorkflowUuid: "" }), false);
+    assert.equal(sealProvenRootBinding({ rootGraph: root(), activeWorkflow: clean, activeWorkflowUuid: null }), false);
+    assert.equal(sealProvenRootBinding({}), false);
+  }
+  // A NON-EXCLUSIVE content proof (an identical-twin open tab, or an
+  // exclusivity check that could not run) never seals (codex gate).
+  {
+    const r = root();
+    assert.equal(
+      sealProvenRootBinding({ rootGraph: r, activeWorkflow: clean, activeWorkflowUuid: "uuid-A", proofExclusive: false }),
+      false,
+    );
+    assert.equal(r.extra, undefined);
+  }
+});
+
+test("#601: the FIRST post-reload mutation seals the proven-clean root, so the SECOND (dirty-tab) mutation passes", () => {
+  // Post-reload state: CLEAN tab, unstamped root that provably carries the
+  // workflow's own content (rootSerializer emits exactly the tracker state).
+  const h = buildDirtyStaleRouteHarness({
+    rootUuid: null,
+    foreignClaim: "none",
+    activeNodeCount: 5,
+    rootNodeCount: 5,
+    activeModified: false,
+    rootSerializer: () => state(5),
+  });
+  // First mutation on the clean tab: passes AND seals the root with A's identity.
+  assert.doesNotThrow(() =>
+    h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: true, requireDirtyMutationBinding: true }),
+  );
+  assert.equal(
+    h.rootB.extra?.comfyui_mcp?.workflow_uuid,
+    "workflow-A-1",
+    "the seal stamps the active workflow's own resolved identity onto the proven root",
+  );
+  // That first mutation is what dirties the tab. Before the seal, every
+  // mutation from here was refused (one mutation per page load); now the
+  // stamped root positively matches A, so the mutation bar clears.
+  h.workflowA.isModified = true;
+  assert.doesNotThrow(
+    () => h.assertBound(h.rootB, h.rootB, { includeBaselineReadGuard: true, requireDirtyMutationBinding: true }),
+    "a dirty tab whose root carries its own sealed identity must stay editable",
+  );
+});
+
+test("#601: without a clean proof the seal does not fire — the #545 P1 fence semantics are unchanged", () => {
+  // Dirty tab + unstamped root: refused as before, and the root stays UNSTAMPED
+  // (a refused command must leave no authorization residue behind).
+  const dirty = buildDirtyStaleRouteHarness({ rootUuid: null });
+  assert.throws(
+    () =>
+      dirty.assertBound(dirty.rootB, dirty.rootB, {
+        includeBaselineReadGuard: false,
+        requireDirtyMutationBinding: true,
+      }),
+    /NOT applied/,
+  );
+  assert.equal(dirty.rootB.extra, undefined, "a dirty unproven root must never receive the stamp");
+  // Clean tab whose root does NOT carry the workflow's content: refused, unstamped.
+  const diverged = buildDirtyStaleRouteHarness({
+    rootUuid: null,
+    foreignClaim: "none",
+    activeNodeCount: 5,
+    rootNodeCount: 5,
+    activeModified: false,
+    rootSerializer: () => state(9), // root content ≠ tracker state — a genuinely diverged canvas
+  });
+  assert.throws(
+    () =>
+      diverged.assertBound(diverged.rootB, diverged.rootB, {
+        includeBaselineReadGuard: true,
+        requireDirtyMutationBinding: true,
+      }),
+    /NOT applied/,
+  );
+  assert.equal(diverged.rootB.extra, undefined, "a diverged root must never receive the stamp");
+});
+
+test("#601 (codex gate): an identical-TWIN open tab makes the content proof ambiguous — no seal, fail closed", () => {
+  // Two clean, separately open DUPLICATE workflows carry byte-identical state, so
+  // content equality cannot tell the active tab's canvas from its twin's. The seal
+  // must stay off: stamping here could authorize later dirty writes to the wrong
+  // canvas.
+  const twin = buildDirtyStaleRouteHarness({
+    rootUuid: null,
+    foreignClaim: "identity", // B sits in openWorkflows alongside A
+    foreignTab: {
+      isPersisted: true,
+      path: "workflows/twin.json",
+      changeTracker: { activeState: state(5) }, // the twin's OWN copy of the identical content
+    },
+    activeNodeCount: 5,
+    rootNodeCount: 5,
+    activeModified: false,
+    rootSerializer: () => state(5),
+  });
+  // The clean-tab command itself still passes (the binding verdict is null either
+  // way) — but it must NOT leave a stamp behind.
+  assert.doesNotThrow(() =>
+    twin.assertBound(twin.rootB, twin.rootB, { includeBaselineReadGuard: true, requireDirtyMutationBinding: true }),
+  );
+  assert.equal(twin.rootB.extra, undefined, "an ambiguous (twin) content proof must never seal the root");
+  // …and once the tab is dirty, the ambiguous binding still refuses mutations,
+  // exactly as before the seal existed.
+  twin.workflowA.isModified = true;
+  assert.throws(
+    () =>
+      twin.assertBound(twin.rootB, twin.rootB, { includeBaselineReadGuard: true, requireDirtyMutationBinding: true }),
+    /NOT applied/,
+    "a dirty tab with an ambiguous binding stays fenced (#545 P1)",
+  );
+});
+
+test("#601: the dirty-mutation-binding-unproven refusal names the real cause and remedy — not a node count", () => {
+  const msg = graphBindingRefusalMessage({ reason: "dirty-mutation-binding-unproven", expected: 339 });
+  assert.match(msg, /\[dirty-mutation-binding-unproven\]/, "the reason tag stays observable");
+  assert.match(msg, /NOT applied/, "the refusal claim stays truthful");
+  assert.doesNotMatch(
+    msg,
+    /reports 339 node\(s\)/,
+    "reporting a node count for a UUID-binding failure is what sent two real diagnoses down wrong paths",
+  );
+  assert.match(msg, /identity stamp/, "names the actual failing predicate (no proven stamp on a dirty tab)");
+  assert.match(msg, /panel_open_workflow/, "names a working remedy");
+  assert.match(msg, /multiple_active_tabs/, "disambiguates the confusable sibling guard");
+  // The other verdicts keep their existing wording.
+  const generic = graphBindingRefusalMessage({ reason: "root-shape-mismatch", expected: 27 });
+  assert.match(generic, /reports 27 node\(s\)/);
 });
 
 test("#545: read-only graph commands recover from an untagged dirty root, while workflow mutations remain fenced", () => {

--- a/browser_tests/unit/module-graph-link.test.mjs
+++ b/browser_tests/unit/module-graph-link.test.mjs
@@ -22,6 +22,24 @@ import {
 } from "../../web/js/lib/asset-staleness.js";
 import { assertAddNodeResolvableRefreshing } from "../../web/js/lib/node-resolve.js";
 import { runSetWidget } from "../../web/js/lib/set-widget.js";
+import {
+  primeModuleCache,
+  resolveBundleStaleness,
+  collectRelativeImportSpecifiers,
+} from "../../web/js/lib/bundle-version.js";
+import { commandIsCanvasIndependent } from "../../web/js/lib/workflow-chat-identity.js";
+import { sealProvenRootBinding } from "../../web/js/lib/graph-binding.js";
+
+test("panel ↔ bundle-version.js module edge links (#584/#611)", () => {
+  assert.equal(typeof resolveBundleStaleness, "function");
+  assert.equal(typeof primeModuleCache, "function");
+  assert.equal(typeof collectRelativeImportSpecifiers, "function");
+});
+
+test("panel ↔ workflow-chat-identity.js / graph-binding.js new edges link (#601/#602)", () => {
+  assert.equal(typeof commandIsCanvasIndependent, "function");
+  assert.equal(typeof sealProvenRootBinding, "function");
+});
 
 // --- Mirror set-widget.js imports (the fix's internal module edges) -----------------
 import {

--- a/browser_tests/unit/test_pack_version.py
+++ b/browser_tests/unit/test_pack_version.py
@@ -1,0 +1,100 @@
+"""Unit tests for py/pack_version.py (#584/#611).
+
+The /comfyui_mcp_panel/version route answers with the INSTALLED pack's version,
+read from pyproject.toml at request time, so a browser tab running a cached
+stale bundle can prove it and self-heal. An unreadable/malformed file must
+yield None (the panel treats the probe as UNKNOWN and never reloads on it).
+
+Dev-only. Run from the repo root:
+
+    python -m unittest browser_tests.unit.test_pack_version
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "py"))
+
+import pack_version as pv  # noqa: E402
+
+
+class ReadPackVersion(unittest.TestCase):
+    def _write(self, text):
+        fd, path = tempfile.mkstemp(suffix=".toml")
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        self.addCleanup(os.unlink, path)
+        return path
+
+    def test_reads_project_version(self):
+        path = self._write('[project]\nname = "comfyui-mcp-panel"\nversion = "0.11.39"\n')
+        self.assertEqual(pv.read_pack_version(path), "0.11.39")
+
+    def test_missing_file_is_none_not_raise(self):
+        self.assertIsNone(pv.read_pack_version(os.path.join(tempfile.gettempdir(), "no-such-pyproject.toml")))
+
+    def test_malformed_or_versionless_is_none(self):
+        self.assertIsNone(pv.read_pack_version(self._write("not toml at all = = =\n")))
+        self.assertIsNone(pv.read_pack_version(self._write('[project]\nname = "x"\n')))
+        self.assertIsNone(pv.read_pack_version(self._write("")))
+
+    def test_malformed_toml_with_a_version_line_is_none_not_scraped(self):
+        # codex gate round 2: a CORRUPT pyproject that happens to contain a
+        # version-looking line must report UNKNOWN (no reload), not a version
+        # scraped out of unparseable content — the regex fallback exists only
+        # for Pythons WITHOUT tomllib.
+        try:
+            import tomllib  # noqa: F401
+        except ImportError:
+            self.skipTest("on Python < 3.11 the line-regex fallback is the intended behavior")
+        path = self._write('[project\nversion = "9.9.9"\n')
+        self.assertIsNone(pv.read_pack_version(path))
+
+    def test_invalid_utf8_is_none(self):
+        # codex gate round 3: non-UTF-8 bytes must not be "repaired" into a
+        # parseable file — a corrupt pyproject is UNKNOWN.
+        fd, path = tempfile.mkstemp(suffix=".toml")
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(b'[project]\nversion = "1.2.3"\n# comment \xff\xfe\n')
+        self.addCleanup(os.unlink, path)
+        self.assertIsNone(pv.read_pack_version(path))
+
+    def test_schema_invalid_project_field_is_none_not_raise(self):
+        # codex gate round 4: valid TOML whose [project] is not a table must
+        # yield None per the function contract, never AttributeError.
+        self.assertIsNone(pv.read_pack_version(self._write('project = "not-a-table"\n')))
+
+    def test_regex_fallback_when_tomllib_unavailable(self):
+        # Older Pythons have no tomllib; the section-aware line fallback must
+        # still resolve the [project] version this repo ships.
+        path = self._write('[project]\nversion = "1.2.3"\n')
+        saved = sys.modules.get("tomllib")
+        sys.modules["tomllib"] = None  # importing a None entry raises ImportError
+        try:
+            self.assertEqual(pv.read_pack_version(path), "1.2.3")
+            # …but must NOT scrape a version from outside [project] or from a
+            # schema-invalid project field (codex gate round 5).
+            self.assertIsNone(pv.read_pack_version(self._write('version = "9.9.9"\n')))
+            self.assertIsNone(
+                pv.read_pack_version(self._write('[tool.x]\nversion = "9.9.9"\n'))
+            )
+            self.assertIsNone(
+                pv.read_pack_version(self._write('project = "not-a-table"\nversion = "9.9.9"\n'))
+            )
+        finally:
+            if saved is None:
+                sys.modules.pop("tomllib", None)
+            else:
+                sys.modules["tomllib"] = saved
+
+    def test_installed_pack_version_matches_repo_pyproject(self):
+        # The pack root's own pyproject.toml resolves, and to a non-empty string.
+        version = pv.installed_pack_version()
+        self.assertIsInstance(version, str)
+        self.assertTrue(version.strip())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -1,8 +1,12 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
 
 import {
   activeWorkflowFenceApplies,
+  commandIsCanvasIndependent,
   commandWorkflowMismatch,
   hasEmbeddedUuidSuccessionEvidence,
   selectorSearchIncludesListed,
@@ -81,6 +85,71 @@ test('#570 fence does NOT apply to navigation / resolved-non-active workflow ops
   // Selector RESOLVED to a genuinely non-active open workflow → deterministic target → runs.
   assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_close', targetsNonActive: true }), false)
   assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_rename', targetsNonActive: true }), false)
+})
+
+// #602 — a command whose execution AND reply never reference the active canvas
+// (Manager registry/server ops, ComfyUI server controls) must not be fenced to the
+// active workflow's uuid: a tab switch after issue manufactured a false refusal for
+// panel_search_nodes before it ever reached the registry search.
+test('#602 fence does NOT apply to canvas-independent Manager/server commands', () => {
+  for (const cmd of [
+    'nodes_search',
+    'nodes_list',
+    'nodes_install',
+    'nodes_queue_status',
+    'graph_update_node', // a Manager PACK update misnamed with a graph_ prefix
+    'comfy_reboot',
+    'free_vram',
+  ]) {
+    assert.equal(activeWorkflowFenceApplies({ cmd }), false, `${cmd} never touches a canvas`)
+    assert.equal(commandIsCanvasIndependent(cmd), true, `${cmd} is canvas-independent`)
+  }
+  // codex gate round 5 — refresh_nodes is NOT canvas-independent: its executor
+  // re-applies fresh defs to LIVE node objects and renames UNKNOWN widget
+  // placeholders on the active canvas, so a stale-stamped call must stay fenced.
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'refresh_nodes' }), true)
+  assert.equal(commandIsCanvasIndependent('refresh_nodes'), false)
+})
+
+test('#602 the exemption stays EXPLICIT — canvas ops, workflow mutators, and unknown commands stay fenced (fail closed)', () => {
+  // Canvas mutators and reads.
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'graph_add_node' }), true)
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'graph_get_state' }), true)
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'graph_run' }), true)
+  // Active-workflow mutators.
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_save' }), true)
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_close' }), true)
+  // workflow_list's reply DESCRIBES the active workflow — a stale-stamped call
+  // must not answer for the wrong tab, so it is NOT canvas-independent.
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_list' }), true)
+  assert.equal(commandIsCanvasIndependent('workflow_list'), false)
+  // An unknown/new command fails closed: coverage is lost only by an explicit opt-out.
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'graph_future_command' }), true)
+  assert.equal(commandIsCanvasIndependent('graph_future_command'), false)
+})
+
+test('#602 wiring: dispatch skips the graph-binding assert for canvas-independent graph_ commands, and the fence message is clean UTF-8', () => {
+  const HERE = dirname(fileURLToPath(import.meta.url))
+  const src = readFileSync(join(HERE, '../../web/js/comfyui-mcp-panel.js'), 'utf8')
+  // graph_update_node is canvas-independent but named graph_*: the dispatch-time
+  // binding assert (which requires a canvas binding proof) must not gate it.
+  assert.match(
+    src,
+    /msg\.cmd\.startsWith\("graph_"\)\s*&&\s*!commandIsCanvasIndependent\(msg\.cmd\)/,
+    'the dispatch binding assert must skip commands that never touch a canvas',
+  )
+  // Same for the PIN guard (codex gate round 2): a pin exists to stop a CANVAS
+  // write landing on the wrong workflow — canvas-independent commands must not
+  // be refused by it either.
+  assert.match(
+    src,
+    /pinnedPath\.trim\(\)\s*&&\s*!commandIsCanvasIndependent\(msg\.cmd\)/,
+    'the pinned-target guard must skip commands that never touch a canvas',
+  )
+  // The workflow-instance-mismatch refusal renders for real users; it once shipped
+  // with a mojibake em dash ("â€”"). Pin the clean form.
+  assert.ok(src.includes('active canvas — the workflow was switched or replaced'), 'fence message keeps its em dash')
+  assert.ok(!src.includes('â€'), 'no mojibake anywhere in the panel source')
 })
 
 test('#570 pinned command after in-place replacement at the same path: uuid mismatch ⇒ REFUSED', () => {

--- a/py/pack_version.py
+++ b/py/pack_version.py
@@ -1,0 +1,89 @@
+"""Read the INSTALLED pack's own version from its pyproject.toml.
+
+Backs ``GET /comfyui_mcp_panel/version`` (#584/#611): the panel JS compares its
+running ``PANEL_VERSION`` against this on-disk value to detect that the browser
+is still running a CACHED older bundle after a pack update (ComfyUI serves the
+extension web dir with plain aiohttp static semantics, so heuristic freshness
+lets a stale module graph survive restarts and plain reloads). The comparison
+only works if this value is read from disk at request time — never cached at
+import — so an updated pack reports its NEW version without waiting for a
+Python-level reload of this module.
+
+Read-only: this module never writes pyproject.toml (a version change publishes
+to the Comfy Registry), and any unreadable/malformed file yields None rather
+than raising — the route then reports ``{"version": None}`` and the panel
+treats the probe as UNKNOWN (no self-heal reload), never as "mismatch".
+"""
+
+import os
+import re
+
+_VERSION_LINE_RE = re.compile(r'^version\s*=\s*"([^"]+)"\s*(?:#.*)?$')
+
+
+def _version_from_project_section(text):
+    """The ``version`` string from the ``[project]`` table only, or None.
+
+    Used on Pythons WITHOUT tomllib. Section-aware (codex gate round 5): a
+    bare top-level ``version`` line, a ``version`` under any OTHER table, or a
+    schema-invalid ``project = "..."`` assignment all yield None rather than a
+    scraped guess — a malformed probe must be UNKNOWN, never a false stale
+    verdict.
+    """
+    in_project = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("["):
+            in_project = stripped == "[project]"
+            continue
+        if in_project:
+            match = _VERSION_LINE_RE.match(stripped)
+            if match:
+                return match.group(1)
+    return None
+
+
+def read_pack_version(pyproject_path):
+    """Return the ``[project] version`` string from pyproject_path, or None.
+
+    Uses tomllib when available (Python 3.11+); falls back to a line regex ONLY
+    when tomllib is absent (older Python), so a MALFORMED pyproject on a modern
+    Python yields None — a corrupt file must report "unknown" (the panel then
+    never reloads), never a version scraped out of unparseable content (codex
+    gate round 2). None on any failure — a missing/unparseable version must
+    never break the route.
+    """
+    try:
+        with open(pyproject_path, "rb") as fh:
+            raw = fh.read()
+    except OSError:
+        return None
+    try:
+        # Strict on purpose (codex gate round 3): a corrupt byte decoded with
+        # "replace" could let tomllib parse a damaged file and report a version
+        # from it — a malformed file must be UNKNOWN (no reload), never a guess.
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+    try:
+        import tomllib  # Python 3.11+
+    except ImportError:
+        tomllib = None
+    if tomllib is not None:
+        try:
+            data = tomllib.loads(text)
+        except Exception:
+            return None  # present but unparseable — unknown, never guess
+        project = data.get("project")
+        if not isinstance(project, dict):
+            return None  # schema-invalid (e.g. project = "x") — unknown, never raise
+        version = project.get("version")
+        return version if isinstance(version, str) and version else None
+    match = _version_from_project_section(text)
+    return match
+
+
+def installed_pack_version():
+    """Version of the pack this module ships in (pyproject.toml at pack root)."""
+    pack_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    return read_pack_version(os.path.join(pack_root, "pyproject.toml"))

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -96,6 +96,7 @@ import {
 } from "./lib/chat-history-store.js";
 import {
   classifyPinnedTarget,
+  commandIsCanvasIndependent,
   commandTargetsActiveWorkflow,
   hasEmbeddedUuidSuccessionEvidence,
   selectorSearchIncludesListed,
@@ -290,6 +291,7 @@ import {
   resolveGraphBindingVerdict,
   graphReadBindingChanged,
   resolveGraphRootUuidRebind,
+  sealProvenRootBinding,
 } from "./lib/graph-binding.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
 import { createRunFetchInterceptor, dispatchScopedRun } from "./lib/run-scope-guard.js";
@@ -310,6 +312,7 @@ import {
   buildHelloPayload,
 } from "./lib/session-rebind.js";
 import { createRestartTabIdentity, sendBridgeHello } from "./lib/restart-tab-identity.js";
+import { primeModuleCache, resolveBundleStaleness } from "./lib/bundle-version.js";
 import {
   adoptRebootRuns,
   decodeRebootMarker,
@@ -1844,7 +1847,7 @@ function assertActiveWorkflowCommandTarget(msg, targetsNonActive = false) {
   ) {
     throw new Error(
       `workflow instance mismatch: this command targets a different workflow than the ` +
-        `active canvas â€” the workflow was switched or replaced after it was issued. ` +
+        `active canvas — the workflow was switched or replaced after it was issued. ` +
         `Re-select the intended workflow (panel_open_workflow) or re-target with ` +
         `panel_set_workflow_target({mode:"current"}), then retry.`,
     );
@@ -4494,6 +4497,50 @@ function assertGraphBoundToActiveWorkflow(
       }
     }
   }
+  // #601 — SEAL A PROVEN-CLEAN BINDING ONTO THE UNSTAMPED ROOT. After a page
+  // reload rebuilds app.graph from saved JSON, the live root carries no identity
+  // stamp, and the FIRST mutation is itself what dirties the tab — so every
+  // mutation after the first hit dirty-mutation-binding-unproven: one mutation
+  // per page load. Seal the active workflow's uuid onto the root at the one
+  // moment it is provably correct (clean tab + the root serializes EQUAL to the
+  // workflow's own current state) so the first mutation no longer strands the
+  // rest. Strictly additive: a stale or foreign root fails the content proof,
+  // stays unstamped, and still fails closed exactly as #545 P1 intends; a
+  // CONFLICTING stamp is the rebind path's decision above, never overwritten
+  // here.
+  //
+  // The content proof must also be EXCLUSIVE (codex gate): two clean, separately
+  // open DUPLICATE tabs can carry byte-identical state, and equality alone cannot
+  // tell the active tab's canvas from its twin's. If any OTHER open workflow
+  // provably (clean, well-formed state) matches this same root — or the
+  // exclusivity check itself cannot run — the seal stays off and the command
+  // keeps the pre-seal fail-closed behaviour. A DIRTY twin cannot prove a match
+  // (its tracker may lag) and does not block the seal.
+  let sealProofExclusive = false;
+  try {
+    const others = app?.extensionManager?.workflow?.openWorkflows;
+    if (Array.isArray(others)) {
+      sealProofExclusive = true;
+      for (const other of others) {
+        if (!other || sameWorkflowObject(other, activeWorkflow)) continue;
+        if (other.isModified === true) continue; // unprovable — not evidence of ambiguity
+        const otherState = other.changeTracker?.activeState ?? other.activeState;
+        if (graphRootMatchesState({ rootGraph, state: otherState })) {
+          sealProofExclusive = false; // a proven identical twin — binding is ambiguous
+          break;
+        }
+      }
+    }
+  } catch {
+    sealProofExclusive = false; // enumeration failed → exclusivity unproven → no seal
+  }
+  sealProvenRootBinding({
+    rootGraph,
+    activeWorkflow,
+    activeWorkflowUuid,
+    inSubgraph,
+    proofExclusive: sealProofExclusive,
+  });
   // The verdict itself is a PURE function of the resolved evidence, lifted into
   // lib/graph-binding.js (#604) so the read-vs-mutation evidence bar is observable
   // in unit tests. It names the firing predicate (#565) — all branches used to
@@ -13031,7 +13078,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // reads empty") let graph_remove_node through and delete nodes from the
             // wrong canvas. Reads still get the lower bar HERE — they re-assert with
             // the full one inside their own executors.
-            if (msg.cmd.startsWith("graph_")) {
+            //
+            // #602 — a command that never touches a canvas (graph_update_node is a
+            // Manager PACK update misnamed with a graph_ prefix) clears no canvas
+            // fence at all: requiring a binding proof for it only false-blocks a
+            // server-side operation when the canvas binding is broken.
+            if (msg.cmd.startsWith("graph_") && !commandIsCanvasIndependent(msg.cmd)) {
               const { graph, rootGraph } = getGraphCtx();
               assertGraphBoundToActiveWorkflow(graph, rootGraph, graphCommandBindingBar(msg.cmd));
             }
@@ -13047,7 +13099,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // #186). Current-mode sessions never carry workflow_path, so they never
             // reach this branch.
             const pinnedPath = msg?.[WORKFLOW_PATH_FIELD];
-            if (typeof pinnedPath === "string" && pinnedPath.trim()) {
+            // #602 (codex gate round 2) — a canvas-independent command (nodes_search
+            // and family) is also exempt from the PIN guard: the pin exists to stop
+            // a CANVAS write landing on the wrong workflow, and these commands write
+            // to no canvas. Fencing them anyway re-creates the false refusal one
+            // guard further down whenever a pinned session's active tab changed.
+            if (typeof pinnedPath === "string" && pinnedPath.trim() && !commandIsCanvasIndependent(msg.cmd)) {
               const wf = activeWorkflowRef();
               // A pin identifier from panel_list_workflows / panel_new_workflow /
               // panel_set_workflow_target may be a path, a native key, a filename, OR
@@ -22066,6 +22123,23 @@ function buildPanel() {
       // (ComfyUI won't, since our tab isn't registered yet when it restores).
       ssSet(SIDEBAR_REOPEN_KEY, "1");
       appendSystem("Reloading the panel UI (new frontend code)…");
+      // #584 — the cmcpReload page-URL param busts only the top document; the
+      // panel's JS MODULES can still come straight out of heuristic cache,
+      // which is exactly how a stale bundle survived this very reload. Prime
+      // the pack's module graph with cache:"reload" first. Best-effort and
+      // time-bounded: a commanded reload must never hang on a slow server,
+      // and a failed prime must not cancel it.
+      try {
+        await Promise.race([
+          primeModuleCache({
+            entryUrl: import.meta.url,
+            fetchImpl: (url, opts) => fetch(url, { credentials: "same-origin", ...opts }),
+          }),
+          new Promise((resolve) => setTimeout(resolve, 5000)),
+        ]);
+      } catch {
+        /* reload regardless — worst case is the pre-#584 behaviour */
+      }
       try {
         const u = new URL(window.location.href);
         u.searchParams.set("cmcpReload", String(Date.now()));
@@ -24227,6 +24301,118 @@ function installSidebarTabGuard(tabId, getRoot) {
   start();
 }
 
+// #584/#611 — STALE BUNDLE SELF-HEAL. The pack on disk can be current while
+// this tab keeps running a CACHED older bundle: ComfyUI serves the extension
+// web dir as plain static files, so heuristic freshness lets old module JS
+// survive a backend restart, a reconnect, AND a plain page reload. The stale
+// bundle then advertises old/unknown capabilities in its hello and the
+// orchestrator's write fence refuses every mutation ("does not enforce
+// per-command workflow targeting … version unknown"). Only the running bundle
+// can fix its own cache, so on startup we compare PANEL_VERSION against the
+// INSTALLED pack version the backend reads off pyproject.toml; on a provable
+// mismatch we force-revalidate the pack's module graph (cache:"reload") and
+// reload ONCE. The sessionStorage marker is armed BEFORE the reload so a heal
+// that didn't take can never loop; an unreadable probe is "unknown" and never
+// reloads at all (fail-open, no evidence no action).
+//
+// SCOPE LIMIT (codex gate): this heals upgrades FROM a bundle that contains
+// this code. A bundle OLDER than this change runs no probe and cannot heal
+// itself — for those tabs the remedy remains a hard refresh, which the
+// orchestrator's fence message (#709) already names. There is no panel-side
+// channel that can retrofit self-healing into already-shipped JS.
+const BUNDLE_HEAL_KEY = "comfyui-mcp.panel.bundleHealAttempted";
+
+async function healStaleBundleIfNeeded() {
+  try {
+    if (typeof api?.fetchApi !== "function") return;
+    // Bounded (codex gate round 4): setup() AWAITS this probe so a stale bundle
+    // is reloaded BEFORE it can register/connect and advertise its stale
+    // capabilities — but a hung local server must not delay a healthy panel's
+    // startup, so the WHOLE probe (headers AND body — a response whose json()
+    // never settles must not wedge registration either, codex gate round 5) is
+    // raced against one deadline, and a timeout is simply "unknown" (fail-open
+    // to registration, no reload).
+    const probe = (async () => {
+      const res = await api.fetchApi("/comfyui_mcp_panel/version", { cache: "no-store" });
+      if (!res || !res.ok) return null;
+      return await res.json().catch(() => null);
+    })();
+    const body = await Promise.race([
+      probe,
+      new Promise((resolve) => setTimeout(() => resolve(null), 2000)),
+    ]);
+    const installed = body?.version;
+    const staleness = resolveBundleStaleness({ running: PANEL_VERSION, installed });
+    if (staleness === "current") {
+      // A previous heal took — clear the marker so the NEXT update heals too.
+      if (ssGet(BUNDLE_HEAL_KEY)) ssSet(BUNDLE_HEAL_KEY, null);
+      return;
+    }
+    if (staleness !== "stale") return;
+    const marker = `${PANEL_VERSION}->${String(installed)}`;
+    if (ssGet(BUNDLE_HEAL_KEY) === marker) {
+      // We already reloaded for exactly this version pair and the bundle is
+      // STILL the old one — another reload would loop without fixing it. The
+      // one remedy left bypasses the cache entirely, and only the user can do
+      // it. (The orchestrator's fence message names the same remedy to the
+      // agent, so this console line is for the human reading DevTools.)
+      console.warn(
+        `[comfyui-mcp-panel] this tab is running a STALE panel bundle (running ${PANEL_VERSION}, ` +
+          `installed ${installed}) and an automatic cache refresh did not pick up the new one. ` +
+          `Hard-refresh this tab (Ctrl+Shift+R) to load panel ${installed}.`,
+      );
+      return;
+    }
+    ssSet(BUNDLE_HEAL_KEY, marker);
+    if (ssGet(BUNDLE_HEAL_KEY) !== marker) {
+      // codex gate round 3 — the loop guard is itself an operation that can
+      // fail: sessionStorage can be unavailable or full, and ssSet swallows
+      // that silently. Reloading WITHOUT the marker would loop this heal
+      // forever, so a guard that did not persist means no automatic reload —
+      // name the manual remedy instead.
+      console.warn(
+        `[comfyui-mcp-panel] this tab is running a STALE panel bundle (running ${PANEL_VERSION}, ` +
+          `installed ${installed}) but sessionStorage is unavailable, so the panel cannot reload ` +
+          `itself safely (the reload-loop guard cannot persist). Hard-refresh this tab ` +
+          `(Ctrl+Shift+R) to load panel ${installed}.`,
+      );
+      return;
+    }
+    console.warn(
+      `[comfyui-mcp-panel] this tab is running a STALE panel bundle (running ${PANEL_VERSION}, ` +
+        `installed ${installed}) — refreshing the cached module graph and reloading once.`,
+    );
+    // Bound the prime (codex gate round 2): a module fetch that never settles
+    // must not strand the guarded reload — worst case the reload serves the
+    // stale bundle again and the marker above prevents a loop.
+    const { failed } = await Promise.race([
+      primeModuleCache({
+        entryUrl: import.meta.url,
+        fetchImpl: (url, opts) => fetch(url, { credentials: "same-origin", ...opts }),
+      }),
+      new Promise((resolve) => setTimeout(() => resolve({ failed: [] }), 5000)),
+    ]);
+    if (failed.length) {
+      console.warn(
+        `[comfyui-mcp-panel] could not refresh ${failed.length} module(s); reloading anyway — if the ` +
+          `panel still reports ${PANEL_VERSION} afterwards, hard-refresh (Ctrl+Shift+R).`,
+      );
+    }
+    // Arm the sidebar reopen exactly like the frontend soft reload, then swap
+    // the page URL so the reload also re-fetches the document itself.
+    ssSet(SIDEBAR_REOPEN_KEY, "1");
+    try {
+      const u = new URL(window.location.href);
+      u.searchParams.set("cmcpReload", String(Date.now()));
+      window.location.replace(u.toString());
+    } catch {
+      window.location.reload();
+    }
+  } catch (err) {
+    console.warn("[comfyui-mcp-panel] bundle staleness check failed (non-fatal):", err);
+  }
+}
+
 function registerExtensionWhenReady(tries = 0) {
   const comfyApp = window.comfyAPI?.app?.app || window.app;
   if (!comfyApp || typeof comfyApp.registerExtension !== "function") {
@@ -24263,6 +24449,13 @@ function registerExtensionWhenReady(tries = 0) {
       // and its since-removed node could be written. graph_set_widget AWAITS the seed
       // (objectInfoHistorySeed) before authorizing, so no write decides against an empty
       // history; the reconnect / refresh_nodes / fresh-oracle paths keep it current after.
+      //
+      // #584/#611 — but FIRST: if this tab is running a cached STALE bundle, heal
+      // it BEFORE anything here registers/connects and advertises the stale
+      // bundle's capabilities to the orchestrator (codex gate round 4). The probe
+      // is bounded (2s) and every failure mode fails OPEN to a normal startup, so
+      // a healthy panel pays at most one fast loopback fetch.
+      await healStaleBundleIfNeeded();
       seedObjectInfoHistory();
       const tabId = "comfyui-mcp.agent";
       let mounted = null; // { root, destroy }

--- a/web/js/lib/bundle-version.js
+++ b/web/js/lib/bundle-version.js
@@ -1,0 +1,132 @@
+/**
+ * #584/#611 — detect and heal a STALE PANEL BUNDLE.
+ *
+ * The pack on disk can be current while the browser tab keeps running a CACHED
+ * older bundle: ComfyUI serves the extension web dir with plain static-file
+ * semantics, so heuristic freshness lets an old module graph survive a backend
+ * restart, a reconnect, and even a plain page reload. The stale bundle then
+ * advertises its old (or no) capabilities in the bridge hello, and the
+ * orchestrator's write fence refuses every mutation with "does not enforce
+ * per-command workflow targeting (detected panel version unknown)".
+ *
+ * The only actor that can fix a cached bundle is the bundle itself: probe the
+ * backend for the INSTALLED pack version, and when it provably differs from
+ * the running PANEL_VERSION, force-revalidate the pack's whole module graph
+ * (fetch with cache:"reload" walks the static import graph) and reload the
+ * page once, guarded against reload loops by the caller's sessionStorage
+ * marker.
+ *
+ * These helpers are PURE / dependency-injected (no DOM, no ComfyUI globals) so
+ * the verdict and the crawl are unit-testable without a browser.
+ */
+
+/**
+ * The staleness verdict for the running bundle versus the installed pack.
+ *
+ *   "current" — both versions are well-formed and EQUAL: nothing to do.
+ *   "stale"   — both versions are well-formed and DIFFER: the browser is
+ *               provably running a different bundle than the pack on disk
+ *               (upgrade OR downgrade — the heal is the same reload).
+ *   "unknown" — either side is missing/malformed (old backend without the
+ *               version route, unreadable pyproject, non-string payload).
+ *               Fail-open: NEVER trigger a reload on an unreadable probe —
+ *               a reload decided on absent evidence is a reload loop waiting
+ *               for one failed fetch.
+ */
+export function resolveBundleStaleness({ running, installed } = {}) {
+  const ok = (v) => typeof v === "string" && v.trim().length > 0;
+  if (!ok(running) || !ok(installed)) return "unknown";
+  return running.trim() === installed.trim() ? "current" : "stale";
+}
+
+/**
+ * Extract RELATIVE module specifiers ("./x.js", "../y.js") from a module's
+ * static import/export statements AND its literal dynamic import("...") calls
+ * (e.g. cmcp-a2ui-lit-adapter.js's lazily-loaded vendor bundle — omitting it
+ * would leave a real module stale after an update, a mixed bundle). A dynamic
+ * import with a computed (non-literal) specifier is not parseable by this
+ * syntax scan. Bare specifiers ("/scripts/app.js", "lit", …) are skipped —
+ * they resolve outside the pack's web dir and are not this pack's cache
+ * problem.
+ */
+export function collectRelativeImportSpecifiers(source) {
+  if (typeof source !== "string" || !source) return [];
+  const out = [];
+  const push = (spec) => {
+    if (spec.startsWith("./") || spec.startsWith("../")) out.push(spec);
+  };
+  // import ... from "spec" | import "spec" | export ... from "spec" — including
+  // MINIFIED forms with no whitespace around the braces/from (import{x}from"./a";
+  // codex gate round 4): the crawl must find dependencies in any legal spelling,
+  // or a minified module's children stay stale through the one-shot heal.
+  const staticRe = /(?:^|[;\n\r])\s*(?:import(?:[^'";]*?from)?|export[^'";]*?from)\s*["']([^"']+)["']/g;
+  // import("spec") — literal dynamic imports only
+  const dynamicRe = /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g;
+  let m;
+  while ((m = staticRe.exec(source)) !== null) push(m[1]);
+  while ((m = dynamicRe.exec(source)) !== null) push(m[1]);
+  return out;
+}
+
+/**
+ * Force-revalidate the pack's ENTIRE static module graph in the browser HTTP
+ * cache, starting at `entryUrl` (the panel's import.meta.url). Each module is
+ * fetched THROUGH `fetchImpl` with `{ cache: "reload" }` as the second
+ * argument — bypassing the cached copy and storing the fresh response — so
+ * the page reload that follows re-imports the NEW modules instead of the
+ * stale ones a normal reload would keep. The cache mode is fixed HERE, not
+ * left to the caller, because forced revalidation is the entire point of the
+ * prime; `fetchImpl` may layer its own options (credentials) on top.
+ *
+ * The crawl stays INSIDE the pack's web dir (the entry's own directory): a
+ * root-relative or bare import belongs to ComfyUI core, not this pack. Cyclic
+ * imports are visited once; `maxModules` bounds the work.
+ *
+ * Returns { primed, failed, truncated }. A module that fails to fetch is
+ * collected in `failed` rather than thrown: the caller decides whether a
+ * partial prime is worth reloading over (a half-refreshed module graph is no
+ * worse than the fully stale one it replaces, but the caller may prefer to
+ * keep the old graph and tell the user to hard-refresh).
+ */
+export async function primeModuleCache({ entryUrl, fetchImpl, maxModules = 400 } = {}) {
+  const primed = [];
+  const failed = [];
+  if (typeof entryUrl !== "string" || !entryUrl || typeof fetchImpl !== "function") {
+    return { primed, failed, truncated: false };
+  }
+  const entryDir = new URL(".", entryUrl).toString();
+  const seen = new Set();
+  const queue = [entryUrl];
+  let truncated = false;
+  while (queue.length) {
+    if (seen.size >= maxModules) {
+      truncated = true;
+      break;
+    }
+    const url = queue.shift();
+    if (seen.has(url)) continue;
+    seen.add(url);
+    let text;
+    try {
+      const res = await fetchImpl(url, { cache: "reload" });
+      if (!res || res.ok === false || typeof res.text !== "function") {
+        failed.push(url);
+        continue;
+      }
+      text = await res.text();
+    } catch {
+      failed.push(url);
+      continue;
+    }
+    primed.push(url);
+    for (const spec of collectRelativeImportSpecifiers(text)) {
+      try {
+        const child = new URL(spec, url).toString();
+        if (child.startsWith(entryDir) && !seen.has(child)) queue.push(child);
+      } catch {
+        // An unparseable specifier contributes nothing — skip it.
+      }
+    }
+  }
+  return { primed, failed, truncated };
+}

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -504,6 +504,70 @@ export function graphCommandMayMutateWorkflow(command) {
 }
 
 /**
+ * #601 — seal a PROVEN binding onto the live root while the tab is still CLEAN.
+ *
+ * The dirty-mutation fence (#545 P1) requires a POSITIVE uuid match on the live
+ * root once the tab is dirty. But the first successful mutation is itself what
+ * dirties the tab, and a page reload rebuilds `app.graph` from saved JSON with
+ * NO stamp on the live root (the stamp lives on the workflow's saved state, not
+ * the rebuilt canvas). So after each reload exactly ONE mutation passed and
+ * every later one was refused as `dirty-mutation-binding-unproven` — one
+ * mutation per page load, with reloads as the only recovery.
+ *
+ * The seal closes that: while the workflow is CLEAN, its tracker's current state
+ * is trustworthy (#545's caveat is dirty-lag only), so a root that serializes
+ * EQUAL to that state (graphRootMatchesState — a strict full-surface proof that
+ * never passes on a partial/unavailable serializer) is provably this workflow's
+ * own canvas, and stamping it with the active uuid is a statement of fact, not
+ * an authorization guess. Strictly additive and fail-closed:
+ *   - subgraph scope, missing identity, or a DIRTY tab → no stamp;
+ *   - an EXISTING stamp (matching or conflicting) is never touched here — a
+ *     conflict is the rebind path's decision (#545/#557), with its claim
+ *     analysis this proof deliberately does not redo;
+ *   - a stale or foreign root fails graphRootMatchesState and stays unstamped,
+ *     so the fence below still refuses exactly as before;
+ *   - content equality proves BINDING only when it is EXCLUSIVE: two clean,
+ *     separately open DUPLICATE workflows can carry byte-identical state, and
+ *     equality alone cannot tell the active tab's canvas from its twin's
+ *     (codex gate). `proofExclusive: false` (the caller found another open
+ *     workflow provably carrying the same state, or could not prove
+ *     exclusivity at all) therefore also refuses the stamp and the command
+ *     keeps the pre-seal fail-closed behaviour.
+ * Returns true only when it actually wrote the stamp.
+ */
+export function sealProvenRootBinding({
+  rootGraph,
+  activeWorkflow,
+  activeWorkflowUuid,
+  inSubgraph = false,
+  proofExclusive = true,
+} = {}) {
+  try {
+    if (inSubgraph) return false;
+    if (proofExclusive !== true) return false;
+    if (!rootGraph || !activeWorkflow) return false;
+    if (typeof activeWorkflowUuid !== "string" || !activeWorkflowUuid) return false;
+    if (activeWorkflow.isModified === true) return false;
+    const existing = rootGraph?.extra?.comfyui_mcp?.workflow_uuid;
+    if (typeof existing === "string" && existing) return false;
+    if (!graphRootMatchesState({ rootGraph, state: activeWorkflowCurrentState(activeWorkflow) })) {
+      return false;
+    }
+    const extra =
+      rootGraph.extra && typeof rootGraph.extra === "object" ? rootGraph.extra : (rootGraph.extra = {});
+    const prior = extra.comfyui_mcp;
+    extra.comfyui_mcp = {
+      ...(prior && typeof prior === "object" ? prior : {}),
+      workflow_uuid: activeWorkflowUuid,
+    };
+    return true;
+  } catch {
+    // A root that refuses the stamp keeps the pre-seal fail-closed behaviour.
+    return false;
+  }
+}
+
+/**
  * THE binding evidence bar a bridge graph command must clear (#604 family).
  *
  * The invariant this encodes: **a MUTATION may never run on binding evidence that
@@ -610,6 +674,26 @@ export function graphBindingRefusalMessage(verdict) {
       `reconnect, or a failed open, and node_count 0 could be a FALSE-EMPTY reading, so this ` +
       `command was NOT applied as authoritative. Retry in a moment once the tab settles; if it ` +
       `persists, re-open the workflow tab (panel_open_workflow) or reload the panel.`
+    );
+  }
+  // #601 — name the ACTUAL failing predicate. This verdict is not a node-count
+  // or wrong-canvas finding: the tab is dirty and the live canvas carries no
+  // identity stamp (a page reload rebuilds the canvas WITHOUT the stamp the
+  // saved file carries), so binding is UNPROVEN, not disproven. Reporting the
+  // generic "reports N node(s)" text here sent two real diagnoses down wrong
+  // paths. The remedy that works from here: reload the tab / re-open the
+  // workflow — while the tab is CLEAN the panel now seals the proven binding
+  // onto the canvas (sealProvenRootBinding), so the retried mutation clears.
+  if (verdict.reason === "dirty-mutation-binding-unproven") {
+    return (
+      `[dirty-mutation-binding-unproven] The active tab has unsaved changes and the live canvas ` +
+      `carries no identity stamp proving it belongs to this workflow (a page reload rebuilds the ` +
+      `canvas without the stamp the saved file carries), so the canvas COULD be a stale graph from ` +
+      `another tab and this mutation was NOT applied. Reload the ComfyUI browser tab or re-open the ` +
+      `workflow (panel_open_workflow) — while the tab is clean the panel re-seals the proven ` +
+      `binding onto the canvas — then retry. If the refusal instead says "multiple_active_tabs", ` +
+      `that is a different guard (two browser tabs share one agent session) with a different ` +
+      `remedy: close the extra tab.`
     );
   }
   return (

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -237,6 +237,44 @@ export function selectorTargetsNonActiveWorkflow({ resolved, active } = {}) {
   return Boolean(resolved) && resolved !== active;
 }
 
+/** #602 — commands whose execution AND result never reference the active canvas:
+ *  Manager registry/server operations (node-pack discovery, install/update, queue
+ *  status) and ComfyUI-server controls (reboot, VRAM free). Fencing these to the
+ *  active workflow's uuid only manufactures false refusals when the user switches
+ *  or replaces a tab after the command was issued — a Manager registry search was
+ *  refused before it ever reached searchNodesVia because the stamped uuid no
+ *  longer matched the now-active canvas.
+ *
+ *  refresh_nodes is deliberately NOT here (codex gate round 5): its executor
+ *  re-applies fresh defs to LIVE node objects and renames UNKNOWN widget
+ *  placeholders on the ACTIVE canvas — a real mutation of whichever workflow is
+ *  mounted, so a stale-stamped call must stay fenced.
+ *
+ *  The set is EXPLICIT and everything unlisted stays fenced (fail closed): a new
+ *  command must opt out here on purpose, so the #570 fence cannot silently lose
+ *  coverage of a future canvas op. Membership criterion: the command neither
+ *  reads nor mutates any workflow canvas and its reply does not describe the
+ *  active one (workflow_list, by contrast, reports the ACTIVE workflow — a
+ *  stale-stamped call must not answer for the wrong tab, so it stays fenced).
+ *  graph_update_node is a Manager PACK update misnamed with a graph_ prefix; it
+ *  touches no graph. */
+const CANVAS_INDEPENDENT_COMMANDS = new Set([
+  'nodes_search',
+  'nodes_list',
+  'nodes_install',
+  'nodes_queue_status',
+  'graph_update_node',
+  'comfy_reboot',
+  'free_vram',
+]);
+
+/** #602 — true when a command never reads or mutates a canvas (see the set above).
+ *  Callers use this to skip canvas-targeting fences that would otherwise refuse a
+ *  server-side operation for an irrelevant workflow-binding reason. */
+export function commandIsCanvasIndependent(cmd) {
+  return CANVAS_INDEPENDENT_COMMANDS.has(cmd);
+}
+
 /** #570 — does the per-command workflow-instance uuid fence APPLY to this command? The fence
  *  refuses a command whose stamped workflow_uuid ≠ the ACTIVE workflow's uuid, so it must cover
  *  everything that runs against the active canvas — every graph_* op AND the active-workflow
@@ -251,6 +289,8 @@ export function selectorTargetsNonActiveWorkflow({ resolved, active } = {}) {
  *  can't); both must pass. The fence fires for pinned ops too.
  *
  *  It must NOT fire only for:
+ *   • canvas-independent Manager/server commands (CANVAS_INDEPENDENT_COMMANDS, #602): their
+ *     execution and reply never reference the active canvas, so a stale stamp is irrelevant;
  *   • workflow_open / workflow_new: navigation/creation with their own explicit/new target;
  *   • workflow_rename / workflow_close whose selector resolves to a genuinely NON-active open
  *     workflow (`targetsNonActive` — via selectorTargetsNonActiveWorkflow): a deterministic
@@ -259,6 +299,7 @@ export function selectorTargetsNonActiveWorkflow({ resolved, active } = {}) {
  *  Reads (graph_get_state, …) still return true here — harmlessly fenced (fail-closed); their
  *  reply is server-fenced anyway, and a read can only run against the active canvas regardless. */
 export function activeWorkflowFenceApplies({ cmd, targetsNonActive = false } = {}) {
+  if (commandIsCanvasIndependent(cmd)) return false;
   if (cmd === 'workflow_open' || cmd === 'workflow_new') return false;
   if ((cmd === 'workflow_rename' || cmd === 'workflow_close') && targetsNonActive) return false;
   return true;


### PR DESCRIPTION
## Issues in this cluster

- #611 — panel_run rejected: active tab bundle version unknown → **fixed** (stale-bundle self-heal, see below)
- #600 — mutations blocked by unknown panel version (+ sync lock timeout) → version side **fixed** here; the `panel-op.lock` timeout side is orchestrator-owned and landed separately
- #584 — frontend reload keeps stale panel JS → **fixed** (module-cache prime on reload paths)
- #601 — one mutation per page load behind a misleading node-count error → **fixed** (proven-clean binding seal + truthful message)
- #602 — panel_search_nodes fenced to the active workflow UUID → **fixed** (canvas-independent exemption)
- #537 — panel 0.8.0 lacks per-command targeting → **not reproducible on current panel**: the hello advertises `enforces_workflow_stamp` + `enforces_workflow_stamp_at_write`; the reporter was on panel 0.8.0 and the orchestrator's refusal already names the upgrade path (#709)

## What changed

**#601 — the dirty-tab deadlock.** After a reload, `app.graph` is rebuilt without the saved file's identity stamp; the first mutation dirties the tab, and every later mutation was refused as `dirty-mutation-binding-unproven` — one mutation per page load. `sealProvenRootBinding()` (lib/graph-binding.js) now stamps the active workflow's uuid onto an *unstamped* root only when the tab is clean, the root serializes **equal** to the workflow's own current state, *and* that proof is **exclusive** (no other clean open tab — an identical duplicate — carries the same state; codex gate). The `dirty-mutation-binding-unproven` refusal message now names the real cause and a working remedy instead of a misleading node count, and disambiguates the `multiple_active_tabs` sibling guard.

**#602 — canvas-independent commands.** The workflow-uuid fence, the dispatch-time graph-binding assert, and the pinned-target guard all exist to stop *canvas* writes landing on the wrong workflow. They now skip an explicit set of commands that never touch a canvas: `nodes_search`, `nodes_list`, `nodes_install`, `nodes_queue_status`, `graph_update_node` (a Manager pack update misnamed `graph_*`), `comfy_reboot`, `free_vram`. Everything unlisted stays fenced, fail-closed. (`refresh_nodes` was considered and deliberately kept fenced — it rewrites live node objects.) Also repaired a mojibake em dash in the workflow-instance-mismatch refusal.

**#584/#611 — stale-bundle self-heal.** A tab can run a cached older bundle after the pack updates (heuristic static caching survives restarts and plain reloads), so its hello advertises old/unknown capabilities and the orchestrator refuses every write. New `GET /comfyui_mcp_panel/version` answers the installed pack version (pyproject read at request time, strict UTF-8 + `[project]`-section parsing, `no-store`). At setup the panel awaits a bounded (2s) probe; only on a **proven** mismatch does it prime the pack's whole module graph (static *and* literal dynamic imports, `cache:"reload"`, in-pack scope, cycle-safe, bounded) and reload **once** — the sessionStorage loop guard is armed before the reload and read back (if it can't persist, no reload; hard-refresh remedy logged). Unreadable probe = "unknown" = never reload. The frontend-scope `panel_reload` primes the module cache too, time-bounded. Scope limit: this heals upgrades *from* a bundle containing this code; already-stale older bundles keep the hard-refresh remedy the orchestrator message names.

## Verification

- `npm run test:unit`: **1999 tests, 0 fail** (incl. new seal/twin/message/exemption/crawl/staleness tests; the seal is exercised through the real extracted `assertGraphBoundToActiveWorkflow`)
- `python -m unittest browser_tests.unit.test_pack_version`: 8 tests OK
- Every fix mutation-verified (seal removal, twin-exclusivity removal, message-branch removal, fence exemption/dispatch/pinned-guard skip removal, staleness verdict / cache-mode / crawl-scope / dynamic-import / minified-import mutants, version-reader + malformed-TOML + invalid-UTF-8 mutants, probe/prime timeout pins — each fails its matching test)
- Committed blobs scanned for control bytes: clean; pre-existing mojibake in the fence message repaired
- ES-module check (`node --check` as `.mjs`) passes
- Codex adversarial gate: 6 rounds, **PASS** (r1: twin-ambiguous seal, self-heal scope, dynamic imports; r2: pinned-guard skip, malformed-TOML scrape, unbounded prime; r3: sessionStorage-failure reload loop, non-strict UTF-8; r4: registration-before-probe race, minified imports, schema-invalid `project`; r5: hung `json()` body, `refresh_nodes` over-exemption, regex fallback section awareness — all addressed and re-verified)

Only a live browser can confirm: the end-to-end heal reload against a real ComfyUI cache, and that ComfyUI's session-restore path leaves the root unstamped in the #601 scenario (the seal is additive either way — it only ever fires on a strict, exclusive content proof).
