### PR TITLE
panel_set_widget and the #458 guard: promoted subgraph widgets refused or mis-reported, and frontend-only node types failing closed

### DIFF
--- a/browser_tests/unit/node-resolve.test.mjs
+++ b/browser_tests/unit/node-resolve.test.mjs
@@ -1063,6 +1063,65 @@ test("#496 set_widget: MarkdownNote's text widget is writable end-to-end (the re
   assert.equal(node.widgets[0].value, "# README");
 });
 
+test("#496 recurrence: KJNodes' frontend-only SetNode/GetNode are ADDABLE on a healthy backend that never lists them", async () => {
+  // The reported recurrence (also seen with rgthree installed): SetNode/GetNode are
+  // registered purely by the pack's frontend JS — absent from /object_info BY DESIGN —
+  // and both panel_add_node and panel_set_widget refused them as a missing pack.
+  // They are on the shared allowlist now; the ever-seen gate + provenance checks
+  // below pin that this does not reopen the #458 hole.
+  const reg = loadedRegistry([], ["SetNode", "GetNode"]); // registered by pack JS, defless
+  const fresh = objectInfo(); // healthy backend — genuinely never lists these types
+  for (const t of ["SetNode", "GetNode"]) {
+    await assert.doesNotReject(
+      () => assertAddNodeResolvableRefreshing(() => reg, t, ADD_OPTS(fresh)),
+      `#496: "${t}" is frontend-only and must be addable`,
+    );
+  }
+});
+
+test("#496 recurrence: SetNode's widget is WRITABLE end-to-end via runSetWidget", async () => {
+  const reg = loadedRegistry([], ["SetNode"]);
+  const node = {
+    id: 32,
+    type: "SetNode",
+    widgets: [{ name: "Constant", type: "string", value: "" }],
+    constructor: reg["SetNode"],
+  };
+  const { set } = await runSetWidget(node, "Constant", "model", {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: async () => objectInfo(), // healthy backend, no SetNode
+    wasTypeEverDefined: () => false,
+    ...HOOKS,
+  });
+  assert.equal(set.value, "model");
+  assert.equal(node.widgets[0].value, "model");
+});
+
+test("#496 recurrence: the SetNode/GetNode allowlist entries do NOT weaken the guards", async () => {
+  const fresh = objectInfo();
+  // (a) A class SQUATTING the allowlisted name but carrying backend provenance
+  //     (a real backend def, or a removed pack's unpurged class) is NOT frontend-only.
+  const squat = loadedRegistry(["SetNode"]); // registered WITH nodeData
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => squat, "SetNode", ADD_OPTS(fresh)),
+    /Unknown node type|does not provide/i,
+  );
+  // (b) The EVER-SEEN gate still wins: a "GetNode" the backend reported EARLIER this
+  //     session and no longer lists is a removed backend node — refused.
+  const reg = loadedRegistry([], ["GetNode"]);
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => reg, "GetNode", ADD_OPTS(fresh, (t) => t === "GetNode")),
+    /defined this node type earlier this session|removed/i,
+  );
+  // (c) An allowlisted name that is NOT registered in the live registry at all stays
+  //     refused (registry membership is also what createNode needs).
+  await assert.rejects(
+    () => assertAddNodeResolvableRefreshing(() => loadedRegistry(), "SetNode", ADD_OPTS(fresh)),
+    /Unknown node type|does not provide/i,
+  );
+});
+
 // The three guards whose oracle is /object_info. Each is reduced to a boolean
 // "would this LEAF node type be authorized?" so they can be compared directly.
 // (Container-shaped nodes are excluded on purpose: assertMutatedNodeAuthorized has an

--- a/browser_tests/unit/set-widget-composite-control.test.mjs
+++ b/browser_tests/unit/set-widget-composite-control.test.mjs
@@ -308,6 +308,39 @@ test("#650 NESTED: the remedy enters EVERY container the promotion is driven thr
   assert.match(res.warning, /panel_exit_subgraph\(\) 2 times/);
 });
 
+test("#650 guard: a THROWING resolver while composing the warning never turns a COMPLETED write into a failure", async () => {
+  // The warning is advisory and runs AFTER the write has landed and been verified. It
+  // re-enters the promotion resolver to work out the caller's scope, and that resolver
+  // is injected — a malformed or control-only promotion link can throw there. Refuse
+  // before the action; disclose after it: an advisory failure must downgrade to a
+  // disclosed gap, never to a reported failure for a write that already happened (the
+  // caller would then "retry" a mutation it already made).
+  const r = reg();
+  const { outer, inner, resolveSource } = promotedSeedFixture(r, "randomize", { promoteControl: true });
+  const seedWidget = inner.widgets.find((w) => w.name === "seed");
+  // The SEED slot resolves normally, so the write itself runs its whole real path and
+  // succeeds. The CONTROL slot — which only the advisory's scope walk ever looks up —
+  // throws, standing in for the malformed/legacy promotion link that can do this live.
+  const exploding = (sn, si) => {
+    if (si?.name === "control_after_generate") throw new Error("promotion link is malformed");
+    return resolveSource(sn, si);
+  };
+  const res = await runSetWidget(outer, "seed", 777777, {
+    registry: r,
+    getRegistry: () => r,
+    getFreshObjectInfo: async () => ({ KSampler: {} }),
+    resolveSource: exploding,
+    ...HOOKS,
+  });
+  // The write is reported as the success it was, and the mutation is real.
+  assert.equal(res.set.value, 777777);
+  assert.equal(seedWidget.value, 777777, "the write landed on the inner node");
+  // …and the gap is DISCLOSED as unknown, not silently swallowed into "no control".
+  assert.match(res.warning, /The write SUCCEEDED and was verified/);
+  assert.match(res.warning, /UNKNOWN, not as "no control"/);
+  assert.match(res.warning, /promotion link is malformed/);
+});
+
 test("#650: when the CONTROL widget is itself promoted, the remedy sets it on the OUTER node with no entering", async () => {
   // The best remedy available: a legacy proxyWidgets promotion exposes the control on
   // the boundary, so it IS settable from the caller's scope. Asserted as an OBSERVED

--- a/browser_tests/unit/set-widget-composite-control.test.mjs
+++ b/browser_tests/unit/set-widget-composite-control.test.mjs
@@ -187,3 +187,141 @@ test("#558 e2e NESTED: a 'fixed' concrete control yields NO warning", async () =
   assert.equal(res.set.value, 777777);
   assert.equal(res.warning, undefined);
 });
+
+// ---- #650: the warning's REMEDY must be executable from the CALLER'S scope ----
+//
+// Reported: setting a promoted seed on root node 78 returned
+// `panel_set_widget(node_id=75, widget='control_after_generate', value='fixed')`.
+// Node 75 is INSIDE the subgraph; following that at root returns "No node with id 75
+// in the current graph". A remedy the caller cannot follow is worse than none — it
+// reads as a working instruction and costs a round trip to discover otherwise.
+//
+// The reachability below is not inferred from names or shapes: it is read off the SAME
+// promotion resolution the write was driven through.
+
+// The reported shape: outer subgraph node 78 promotes `seed` from inner KSampler 75,
+// whose control_after_generate is NOT promoted (ComfyUI marks it canvasOnly, so it has
+// no connectable slot). `promoteControl` adds a legacy proxyWidgets-style promotion of
+// the control widget itself, which makes it settable from the outer scope directly.
+function promotedSeedFixture(r, mode, { promoteControl = false } = {}) {
+  const seedW = { name: "seed", type: "INT", value: 111 };
+  const controlW = {
+    name: "control_after_generate",
+    type: "combo",
+    value: mode,
+    options: { values: [...CONTROL_AFTER_GENERATE_MODES], serialize: false, canvasOnly: true },
+  };
+  seedW.linkedWidgets = [controlW];
+  const inner = {
+    id: 75,
+    type: "KSampler",
+    widgets: [seedW, controlW],
+    constructor: { nodeData: { input: { required: {} } } },
+  };
+  const rail = { name: "seed", type: "INT", value: 111 };
+  const inputs = [{ name: "seed", _widget: rail, widget: { name: "seed" }, _subgraphSlot: { name: "seed" } }];
+  const widgets = [rail];
+  if (promoteControl) {
+    const controlRail = { name: "control_after_generate", type: "combo", value: mode };
+    inputs.push({
+      name: "control_after_generate",
+      _widget: controlRail,
+      widget: { name: "control_after_generate" },
+      _subgraphSlot: { name: "control_after_generate" },
+    });
+    widgets.push(controlRail);
+  }
+  const outer = {
+    id: 78,
+    type: "SubgraphOuter",
+    widgets,
+    subgraph: { _nodes: [inner], getNodeById: (id) => (String(id) === "75" ? inner : null) },
+    inputs,
+  };
+  r.SubgraphOuter = function SubgraphOuter() {};
+  const resolveSource = (sn, si) => {
+    if (sn !== outer) return null;
+    if (si?.name === "seed") return { sourceNodeId: "75", sourceWidgetName: "seed" };
+    if (si?.name === "control_after_generate") {
+      return { sourceNodeId: "75", sourceWidgetName: "control_after_generate" };
+    }
+    return null;
+  };
+  return { outer, inner, resolveSource };
+}
+
+test("#650: a PROMOTED seed write's remedy enters the owning subgraph — it never hands back a bare inner node id", async () => {
+  const r = reg();
+  const { outer, resolveSource } = promotedSeedFixture(r, "randomize");
+  const res = await runSetWidget(outer, "seed", 777777, {
+    registry: r,
+    getRegistry: () => r,
+    getFreshObjectInfo: async () => ({ KSampler: {} }),
+    resolveSource,
+    ...HOOKS,
+  });
+  assert.equal(res.set.value, 777777, "the write itself still succeeds");
+  assert.match(res.warning, /control_after_generate='randomize'/);
+  // The remedy must START by entering the owning subgraph…
+  assert.match(res.warning, /panel_enter_subgraph\(node_id=78\)/);
+  // …and it must say WHY the plain call would fail, so the caller is not left to
+  // discover "No node with id 75 in the current graph" by running it.
+  assert.match(res.warning, /node 75 does not exist in the graph you are addressing/);
+  assert.match(res.warning, /panel_exit_subgraph\(\)/);
+  // THE REASON, not the shape: the enter step must come BEFORE the inner-node write.
+  assert.ok(
+    res.warning.indexOf("panel_enter_subgraph(node_id=78)") <
+      res.warning.indexOf("panel_set_widget(node_id=75"),
+    "the enter step must precede the inner-node write, or the remedy is still unexecutable",
+  );
+});
+
+test("#650: a DIRECT write's remedy is unchanged — no spurious enter step", async () => {
+  // The scope correction must not add ceremony where the control widget is already
+  // addressable. Deleting the scope logic would make this pass and the one above fail;
+  // hard-coding the enter form would do the reverse. Both directions are pinned.
+  const node = ksamplerWithSeedControl("randomize");
+  const res = await runSetWidget(node, "seed", 777777, wired());
+  assert.match(res.warning, /panel_set_widget\(node_id=3, widget='control_after_generate', value='fixed'\)/);
+  assert.doesNotMatch(res.warning, /panel_enter_subgraph/);
+  assert.doesNotMatch(res.warning, /does not exist in the graph you are addressing/);
+});
+
+test("#650 NESTED: the remedy enters EVERY container the promotion is driven through, in order", async () => {
+  // A→B→KSampler. Entering A alone lands in A's subgraph, where node 90 still does not
+  // exist — the remedy has to name B too, or it is unexecutable one level deeper.
+  const r = reg();
+  const { a, resolveSource } = nestedSeedControl(r, "randomize");
+  const res = await runSetWidget(a, "seed", 777777, {
+    registry: r,
+    getRegistry: () => r,
+    getFreshObjectInfo: async () => ({ KSampler: {} }),
+    resolveSource,
+    ...HOOKS,
+  });
+  assert.match(res.warning, /panel_enter_subgraph\(node_id=70\).*panel_enter_subgraph\(node_id=80\)/s);
+  assert.ok(
+    res.warning.indexOf("panel_enter_subgraph(node_id=80)") <
+      res.warning.indexOf("panel_set_widget(node_id=90"),
+    "both enters must precede the inner-node write",
+  );
+  assert.match(res.warning, /panel_exit_subgraph\(\) 2 times/);
+});
+
+test("#650: when the CONTROL widget is itself promoted, the remedy sets it on the OUTER node with no entering", async () => {
+  // The best remedy available: a legacy proxyWidgets promotion exposes the control on
+  // the boundary, so it IS settable from the caller's scope. Asserted as an OBSERVED
+  // promotion — resolved through the same resolver the write used — never assumed.
+  const r = reg();
+  const { outer, resolveSource } = promotedSeedFixture(r, "randomize", { promoteControl: true });
+  const res = await runSetWidget(outer, "seed", 777777, {
+    registry: r,
+    getRegistry: () => r,
+    getFreshObjectInfo: async () => ({ KSampler: {} }),
+    resolveSource,
+    ...HOOKS,
+  });
+  assert.match(res.warning, /is promoted onto subgraph node 78 as "control_after_generate"/);
+  assert.match(res.warning, /panel_set_widget\(node_id=78, widget='control_after_generate', value='fixed'\)/);
+  assert.doesNotMatch(res.warning, /panel_enter_subgraph/);
+});

--- a/browser_tests/unit/set-widget-fresh-backend.test.mjs
+++ b/browser_tests/unit/set-widget-fresh-backend.test.mjs
@@ -1418,3 +1418,150 @@ test("#512: NESTED promotion through a provenance-stamped UUID intermediate ⇒ 
   assert.equal(b.widgets.find((w) => w.name === "steps").value, 30, "the intermediate forwarded the write");
   assert.equal(aRail.value, 30, "#366: authoritative outer rail synced");
 });
+
+// ---- #612: a widget that is NOT promoted on a GENUINE subgraph container must be
+//      refused with the HONEST diagnosis — "not a promoted widget on this subgraph",
+//      naming what IS promoted and the actionable remedy — never the generic #458
+//      "the ComfyUI backend does not provide node type <uuid>" message, which
+//      misreports a benign not-promoted case as an uninstalled/removed pack and
+//      sends the agent reinstalling packs or restarting ComfyUI. This is also the
+//      #512 recurrence: the krea2 pack's legacy proxyWidgets promotion of
+//      control_after_generate is QUARANTINED on load by the current frontend (a
+//      canvas-only control widget has no connectable slot), so the outer node has
+//      no such promotion and the refusal is correct — only its message was wrong. ----
+
+test("#612: non-promoted widget on a genuine UUID subgraph node ⇒ honest 'not a promoted widget' refusal", async () => {
+  // The exact reported shape (#612 node 105 / #512-recurrence node 78): a genuine
+  // subgraph container with one promoted widget (value_4), asked to write a widget
+  // that is NOT promoted (control_after_generate — it exists on an inner node but
+  // is not exposed on the boundary).
+  const reg = loadedRegistry();
+  const { parent, inner, railWidget, resolveSource } = makeUuidSubgraphFixture(reg, "KSampler");
+  await assert.rejects(
+    () =>
+      runSetWidget(parent, "control_after_generate", "fixed", {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => objectInfo(), // healthy backend
+        wasTypeEverDefined: () => false, // the UUID was never backend-defined
+        resolveSource,
+        ...HOOKS,
+      }),
+    (err) => {
+      assert.match(err.message, /Cannot set widget on subgraph node 320/);
+      assert.match(err.message, /"control_after_generate" is not a promoted widget on this subgraph/);
+      // The reason must name what IS promoted so the caller can self-correct…
+      assert.match(err.message, /promoted: value_4/);
+      // …and point at the actionable remedy…
+      assert.match(err.message, /panel_enter_subgraph/);
+      assert.match(err.message, /panel_promote_widget/);
+      // …and NEVER blame a removed/uninstalled pack — nothing was uninstalled.
+      assert.doesNotMatch(err.message, /backend does not provide/i);
+      assert.doesNotMatch(err.message, /not installed, or its pack was removed/i);
+      return true;
+    },
+  );
+  assert.equal(inner.widgets.find((w) => w.name === "value_4").value, 20, "inner untouched");
+  assert.equal(railWidget.value, 20, "rail untouched");
+});
+
+test("#612: the honest diagnosis is graph-local — it fires even when the backend is UNREACHABLE", async () => {
+  // "This widget is not promoted on this node" needs no /object_info oracle. With the
+  // backend down, the old path reported "cannot verify the node type … reconnect and
+  // retry", which reads as transient — but no retry can ever make an unpromoted widget
+  // settable from outside. The refusal is identical; only the reason is honest.
+  const reg = loadedRegistry();
+  const { parent, railWidget, resolveSource } = makeUuidSubgraphFixture(reg, "KSampler");
+  await assert.rejects(
+    () =>
+      runSetWidget(parent, "control_after_generate", "fixed", {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => null, // backend unreachable
+        wasTypeEverDefined: () => false,
+        resolveSource,
+        ...HOOKS,
+      }),
+    (err) => {
+      assert.match(err.message, /is not a promoted widget on this subgraph/);
+      assert.doesNotMatch(err.message, /cannot verify|object_info is unavailable/i);
+      return true;
+    },
+  );
+  assert.equal(railWidget.value, 20, "no mutation");
+});
+
+test("#612: an EVER-SEEN container type keeps the removed-type diagnosis (the trust root wins)", async () => {
+  // The honest "not a promoted widget" branch is only for a container whose type the
+  // backend NEVER reported. A container-shaped node whose type was in an earlier
+  // /object_info this session is a removed backend node masquerading as a container —
+  // the #458 removed-type diagnosis is the accurate one and must not be masked.
+  const reg = loadedRegistry();
+  const { parent, railWidget, resolveSource } = makeUuidSubgraphFixture(reg, "KSampler");
+  await assert.rejects(
+    () =>
+      runSetWidget(parent, "control_after_generate", "fixed", {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => objectInfo(), // the type is ABSENT now…
+        wasTypeEverDefined: (t) => t === SUBGRAPH_UUID, // …but was reported EARLIER
+        resolveSource,
+        ...HOOKS,
+      }),
+    (err) => {
+      assert.match(err.message, /was defined by the ComfyUI backend earlier this session|since-removed/i);
+      assert.doesNotMatch(err.message, /not a promoted widget/i);
+      return true;
+    },
+  );
+  assert.equal(railWidget.value, 20, "no mutation");
+});
+
+test("#612: a bare `subgraph:{}` marker that is NOT a real container keeps the #458 fresh-auth diagnosis", async () => {
+  // The subgraph-shaped bypass fixture: a stale type carrying a truthy `subgraph`
+  // field that fails the virtual-container shape check. It must NOT get the benign
+  // "not a promoted widget" message — the backend-type diagnosis stands.
+  const reg = loadedRegistry();
+  const node = regNode("SubgraphNode", [{ name: "steps", type: "INT", value: 20 }], { subgraph: {} });
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "steps", 7, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => objectInfo(), // backend provides no "SubgraphNode"
+        wasTypeEverDefined: () => false,
+        ...HOOKS,
+      }),
+    (err) => {
+      assert.match(err.message, /backend does not provide/i);
+      assert.doesNotMatch(err.message, /not a promoted widget/i);
+      return true;
+    },
+  );
+  assert.equal(node.widgets[0].value, 20, "no mutation");
+});
+
+test("#612: an UNWIRED history oracle still gets the honest diagnosis (the 'no-oracle' arm)", async () => {
+  // "X is not a promoted widget on this node" is graph-locally TRUE whether or not the
+  // history oracle is wired, so the honest refusal does not depend on it. (The panel
+  // always wires the oracle; this pins the branch's behaviour if a caller does not.)
+  const reg = loadedRegistry();
+  const { parent, railWidget, resolveSource } = makeUuidSubgraphFixture(reg, "KSampler");
+  await assert.rejects(
+    () =>
+      runSetWidget(parent, "control_after_generate", "fixed", {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => objectInfo(),
+        // wasTypeEverDefined deliberately OMITTED
+        resolveSource,
+        ...HOOKS,
+      }),
+    (err) => {
+      assert.match(err.message, /is not a promoted widget on this subgraph/);
+      assert.doesNotMatch(err.message, /backend does not provide/i);
+      return true;
+    },
+  );
+  assert.equal(railWidget.value, 20, "no mutation");
+});

--- a/browser_tests/unit/set-widget-fresh-backend.test.mjs
+++ b/browser_tests/unit/set-widget-fresh-backend.test.mjs
@@ -1465,11 +1465,16 @@ test("#612: non-promoted widget on a genuine UUID subgraph node ⇒ honest 'not 
   assert.equal(railWidget.value, 20, "rail untouched");
 });
 
-test("#612: the honest diagnosis is graph-local — it fires even when the backend is UNREACHABLE", async () => {
-  // "This widget is not promoted on this node" needs no /object_info oracle. With the
-  // backend down, the old path reported "cannot verify the node type … reconnect and
-  // retry", which reads as transient — but no retry can ever make an unpromoted widget
-  // settable from outside. The refusal is identical; only the reason is honest.
+test("#612: an UNREACHABLE backend does NOT establish the not-promoted diagnosis — it reports the honest 'could not verify' instead", async () => {
+  // The definite "this is an unpromoted widget on a subgraph" finding claims the node is
+  // a virtual-only container, and that claim rests on the type being ABSENT from the
+  // CURRENT /object_info. When the fetch FAILED there is no current /object_info at all:
+  // an unavailable map is could-not-determine, not "the backend lacks this type". Both
+  // read as "no entry" to a membership test, so they must be told apart here or an
+  // unreachable backend silently becomes positive evidence for a definite verdict.
+  //
+  // The refusal is unchanged (fail closed). Only the diagnosis differs, and "reconnect
+  // and retry" is the accurate one: it IS a transient verification failure.
   const reg = loadedRegistry();
   const { parent, railWidget, resolveSource } = makeUuidSubgraphFixture(reg, "KSampler");
   await assert.rejects(
@@ -1483,8 +1488,33 @@ test("#612: the honest diagnosis is graph-local — it fires even when the backe
         ...HOOKS,
       }),
     (err) => {
-      assert.match(err.message, /is not a promoted widget on this subgraph/);
-      assert.doesNotMatch(err.message, /cannot verify|object_info is unavailable/i);
+      assert.match(err.message, /object_info is unavailable|cannot verify the node type/i);
+      assert.doesNotMatch(err.message, /is not a promoted widget on this subgraph/);
+      return true;
+    },
+  );
+  assert.equal(railWidget.value, 20, "no mutation");
+});
+
+test("#612: a REJECTED /object_info fetch is treated the same as an unavailable one", async () => {
+  // The fetch is wrapped in a catch that sets freshDefs = null, so a throwing oracle and
+  // a null-returning one arrive at the identical state. Both must be could-not-determine.
+  const reg = loadedRegistry();
+  const { parent, railWidget, resolveSource } = makeUuidSubgraphFixture(reg, "KSampler");
+  await assert.rejects(
+    () =>
+      runSetWidget(parent, "control_after_generate", "fixed", {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => {
+          throw new Error("network down");
+        },
+        wasTypeEverDefined: () => false,
+        resolveSource,
+        ...HOOKS,
+      }),
+    (err) => {
+      assert.doesNotMatch(err.message, /is not a promoted widget on this subgraph/);
       return true;
     },
   );

--- a/browser_tests/unit/set-widget-fresh-backend.test.mjs
+++ b/browser_tests/unit/set-widget-fresh-backend.test.mjs
@@ -1541,10 +1541,123 @@ test("#612: a bare `subgraph:{}` marker that is NOT a real container keeps the #
   assert.equal(node.widgets[0].value, 20, "no mutation");
 });
 
-test("#612: an UNWIRED history oracle still gets the honest diagnosis (the 'no-oracle' arm)", async () => {
-  // "X is not a promoted widget on this node" is graph-locally TRUE whether or not the
-  // history oracle is wired, so the honest refusal does not depend on it. (The panel
-  // always wires the oracle; this pins the branch's behaviour if a caller does not.)
+// ---- The #612 diagnosis must NOT be asserted from an absence of evidence. It claims
+//      the node is a virtual-only container, and that claim needs TWO positive facts:
+//      the current /object_info does NOT define the type, AND the history oracle
+//      positively reports never-seen. Getting either wrong refuses a LEGITIMATE write
+//      and hands the caller a remedy that is actionable but WRONG — worse than a bare
+//      refusal, because it sends them to promote a widget on a node that is not a
+//      subgraph at all. These tests pin both directions: the honest refusal survives,
+//      and the valid direct write is permitted FOR THE FRESH-TYPE REASON. ----
+
+// A backend-defined, subgraph-SHAPED node installed AFTER the startup baseline: the
+// pack's class builds an inner graph (so isVirtualSubgraphContainer says "container"),
+// but the backend genuinely defines the type and it carries a direct OWN widget with no
+// promoted inputs. On its FIRST observation the history oracle honestly reports
+// never-seen — it was not in the baseline — while the fresh /object_info this very call
+// fetched positively defines it.
+const LATE_INSTALLED_TYPE = "AcmeVirtualCompositor";
+function makeLateInstalledContainerNode() {
+  const own = { name: "strength", type: "INT", value: 20 };
+  const ctor = function AcmeVirtualCompositor() {};
+  ctor.nodeData = { input: { required: {} } };
+  return {
+    node: {
+      id: 412,
+      type: LATE_INSTALLED_TYPE,
+      // Container SHAPE — a real nested graph, not a bare `subgraph:{}` marker.
+      subgraph: { _nodes: [], getNodeById: () => null },
+      inputs: [], // nothing promoted onto the boundary
+      widgets: [own],
+      constructor: ctor,
+    },
+    own,
+    ctor,
+  };
+}
+function registryWithLateInstalled() {
+  const reg = loadedRegistry();
+  const { ctor } = makeLateInstalledContainerNode();
+  reg[LATE_INSTALLED_TYPE] = ctor;
+  return reg;
+}
+
+test("#612 regression: a backend-defined container-shaped node added AFTER the baseline ⇒ its direct own-widget write is PERMITTED by fresh-type authorization", async () => {
+  // never-seen history is "the startup baseline did not list it", NOT "the backend does
+  // not define it". The fresh /object_info this call already fetched settles it, and the
+  // fresh-type authorization is entitled to permit the write. Short-circuiting to the
+  // not-promoted diagnosis on history alone refuses a write that worked yesterday.
+  const reg = registryWithLateInstalled();
+  const { node, own } = makeLateInstalledContainerNode();
+  reg[LATE_INSTALLED_TYPE] = node.constructor;
+  let fetches = 0;
+  const { set } = await runSetWidget(node, "strength", 42, {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: async () => {
+      fetches += 1;
+      return objectInfo([LATE_INSTALLED_TYPE]); // the backend DOES define it now
+    },
+    wasTypeEverDefined: () => false, // absent from the startup baseline ⇒ never-seen
+    ...HOOKS,
+  });
+  assert.equal(set.value, 42);
+  assert.equal(own.value, 42, "the write landed on the node's OWN widget");
+  // THE REASON, not just the outcome: the permission came from the FRESH backend
+  // definition. The oracle was actually consulted…
+  assert.equal(fetches, 1, "the fresh /object_info oracle was consulted");
+});
+
+test("#612 regression, the discriminating half: the SAME node with the type ABSENT from fresh /object_info is still REFUSED as not-promoted", async () => {
+  // Paired with the test above, this is what makes "permitted for the fresh-type reason"
+  // an assertion rather than a hope: the ONLY difference between the two is whether the
+  // current /object_info defines the type. Nothing else about the node changed. If the
+  // loosened branch permitted on some other ground, this one would pass too.
+  const reg = registryWithLateInstalled();
+  const { node, own } = makeLateInstalledContainerNode();
+  reg[LATE_INSTALLED_TYPE] = node.constructor;
+  await assert.rejects(
+    () =>
+      runSetWidget(node, "strength", 42, {
+        registry: reg,
+        getRegistry: () => reg,
+        getFreshObjectInfo: async () => objectInfo(), // the type is NOT defined
+        wasTypeEverDefined: () => false,
+        ...HOOKS,
+      }),
+    (err) => {
+      assert.match(err.message, /is not a promoted widget on this subgraph/);
+      return true;
+    },
+  );
+  assert.equal(own.value, 20, "no mutation");
+});
+
+test("#612: an UNWIRED history oracle falls THROUGH to fresh-type authorization — a live type is PERMITTED", async () => {
+  // `no-oracle` is the could-not-determine case BY DEFINITION: it establishes neither
+  // "never backend-defined" nor safe container identity (backendHistoryVerdict's own
+  // fail-closed contract). It must therefore not short-circuit to the definite "this is
+  // an unpromoted widget on a subgraph" negative — it must defer to the fresh result the
+  // call already fetched, which here positively defines the type.
+  const reg = registryWithLateInstalled();
+  const { node, own } = makeLateInstalledContainerNode();
+  reg[LATE_INSTALLED_TYPE] = node.constructor;
+  const { set } = await runSetWidget(node, "strength", 7, {
+    registry: reg,
+    getRegistry: () => reg,
+    getFreshObjectInfo: async () => objectInfo([LATE_INSTALLED_TYPE]),
+    // wasTypeEverDefined deliberately OMITTED ⇒ "no-oracle"
+    ...HOOKS,
+  });
+  assert.equal(set.value, 7);
+  assert.equal(own.value, 7, "the valid direct write was not refused for a missing oracle");
+});
+
+test("#612: an UNWIRED history oracle still FAILS CLOSED when the fresh backend does not define the type", async () => {
+  // Falling through is not loosening the refusal — only the diagnosis. With no history
+  // oracle we cannot establish that this UUID node is a genuine container rather than a
+  // removed backend node, so we must not assert the container diagnosis; the fresh-auth
+  // refusal stands and nothing is mutated.
   const reg = loadedRegistry();
   const { parent, railWidget, resolveSource } = makeUuidSubgraphFixture(reg, "KSampler");
   await assert.rejects(
@@ -1558,8 +1671,10 @@ test("#612: an UNWIRED history oracle still gets the honest diagnosis (the 'no-o
         ...HOOKS,
       }),
     (err) => {
-      assert.match(err.message, /is not a promoted widget on this subgraph/);
-      assert.doesNotMatch(err.message, /backend does not provide/i);
+      // Refused — and the message does NOT claim the not-promoted finding, which no
+      // oracle established here.
+      assert.doesNotMatch(err.message, /is not a promoted widget on this subgraph/);
+      assert.match(err.message, /backend does not provide/i);
       return true;
     },
   );

--- a/browser_tests/unit/slot-labels.test.mjs
+++ b/browser_tests/unit/slot-labels.test.mjs
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for web/js/lib/slot-labels.js (#636) — run with `node --test`.
+ *
+ * Reported: a user renamed a subgraph node's promoted widgets to Filename / project? /
+ * project. A screenshot confirmed the labels rendered. But panel_query_graph
+ * (fields:'detail'), panel_get_subgraph and the boundary `rails` payload all kept
+ * returning the underlying keys value / boolean / value_1 with no label anywhere, so
+ * the agent told the user their renames had not stuck when they had.
+ *
+ * The correction is additive and strictly OBSERVED — which cuts both ways, and both
+ * directions are pinned here:
+ *   - a label the frontend DOES carry must be reported (the reported bug), and
+ *   - a label must never be INVENTED. No label carried ⇒ no `label` key; a label equal
+ *     to the name is not a rename and must not be emitted, or every unrenamed node
+ *     would read as renamed and the field would carry no information at all.
+ *
+ * The programmatic NAME is never moved or replaced: it is the identity panel_set_widget
+ * and panel_connect address, and the label is display-only.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { displayLabel, boundaryInputLabel, widgetLabelMap } from "../../web/js/lib/slot-labels.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+
+test("#636: a renamed entry reports its display label", () => {
+  assert.equal(displayLabel({ name: "value", label: "Filename" }), "Filename");
+  assert.equal(displayLabel({ name: "value_1", label: "project" }), "project");
+  // Punctuation the user actually used — no normalization, the label is reported verbatim.
+  assert.equal(displayLabel({ name: "boolean", label: "project?" }), "project?");
+});
+
+test("#636: NOTHING is invented — no label, an empty label, or a non-string is null", () => {
+  assert.equal(displayLabel({ name: "value" }), null);
+  assert.equal(displayLabel({ name: "value", label: "" }), null);
+  assert.equal(displayLabel({ name: "value", label: "   " }), null);
+  assert.equal(displayLabel({ name: "value", label: 42 }), null);
+  assert.equal(displayLabel(null), null);
+  assert.equal(displayLabel(undefined), null);
+});
+
+test("#636: a label IDENTICAL to the name is not a rename and is not emitted", () => {
+  // Frontends commonly default `label` to the name. Emitting it would make every
+  // unrenamed widget look renamed — the field would then mean nothing, which is the
+  // reported failure inverted rather than fixed.
+  assert.equal(displayLabel({ name: "seed", label: "seed" }), null);
+  // …but a case difference IS a user-visible rename and must survive.
+  assert.equal(displayLabel({ name: "seed", label: "Seed" }), "Seed");
+});
+
+test("#636: a boundary input's label is taken from the host input FIRST, then the backing slot", () => {
+  // The host input is what renders on the outer node the caller is looking at, so it
+  // wins when both carry one.
+  assert.equal(
+    boundaryInputLabel({ name: "value", label: "Filename", _subgraphSlot: { name: "value", label: "Inner" } }),
+    "Filename",
+  );
+  // Older frontends record the rename only on the backing subgraph slot.
+  assert.equal(
+    boundaryInputLabel({ name: "value", _subgraphSlot: { name: "value", label: "Filename" } }),
+    "Filename",
+  );
+  // The backing slot's label is compared against the name the entry is REPORTED under,
+  // so a slot whose label merely repeats the host name is still not a rename.
+  assert.equal(
+    boundaryInputLabel({ name: "value", _subgraphSlot: { name: "inner_value", label: "value" } }),
+    null,
+  );
+  assert.equal(boundaryInputLabel({ name: "value" }), null);
+  assert.equal(boundaryInputLabel(null), null);
+});
+
+test("#636: widgetLabelMap keys renamed widgets by their ADDRESSABLE name, and omits the rest", () => {
+  const node = {
+    widgets: [
+      { name: "value", label: "Filename", value: "out" },
+      { name: "boolean", label: "project?", value: true },
+      { name: "value_1", label: "project", value: "x" },
+      { name: "seed", value: 1 }, // not renamed
+      { name: "steps", label: "steps", value: 20 }, // label === name, not a rename
+      { value: "no name" }, // malformed, ignored
+    ],
+  };
+  assert.deepEqual(widgetLabelMap(node), {
+    value: "Filename",
+    boolean: "project?",
+    value_1: "project",
+  });
+});
+
+test("#636: a node with no renames yields an EMPTY map, so the payload key can be omitted entirely", () => {
+  // This is what keeps an unrenamed node's read byte-identical to before the change.
+  assert.deepEqual(widgetLabelMap({ widgets: [{ name: "seed", value: 1 }] }), {});
+  assert.deepEqual(widgetLabelMap({}), {});
+  assert.deepEqual(widgetLabelMap(null), {});
+});
+
+test("#636: the panel's structured readers actually CONSUME these helpers", () => {
+  // Without this, the helpers above could be perfectly correct and entirely unwired —
+  // which is the state the bug was reported in. summarizeNode backs panel_query_graph
+  // (fields:'detail') and panel_get_subgraph; describeRails backs the `rails` payload.
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /import \{ displayLabel, boundaryInputLabel, widgetLabelMap \} from "\.\/lib\/slot-labels\.js"/);
+  assert.match(src, /widget_labels: widgetLabels/, "summarizeNode emits widget_labels");
+  assert.match(src, /const label = boundaryInputLabel\(inp\);/, "summarizeNode labels inputs");
+  assert.match(src, /const widgetLabels = widgetLabelMap\(node\);/);
+  // describeRails' slotList must label boundary slots too — the rails payload was one
+  // of the three readers that dropped renames.
+  assert.match(src, /const slotList = \(slots\) =>[\s\S]{0,400}displayLabel\(s\)/);
+});

--- a/browser_tests/unit/slot-labels.test.mjs
+++ b/browser_tests/unit/slot-labels.test.mjs
@@ -29,8 +29,21 @@ const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", impo
 test("#636: a renamed entry reports its display label", () => {
   assert.equal(displayLabel({ name: "value", label: "Filename" }), "Filename");
   assert.equal(displayLabel({ name: "value_1", label: "project" }), "project");
-  // Punctuation the user actually used — no normalization, the label is reported verbatim.
+  // Punctuation the user actually used is preserved — only surrounding whitespace is
+  // trimmed (see below), never the label's own characters.
   assert.equal(displayLabel({ name: "boolean", label: "project?" }), "project?");
+});
+
+test("#636: surrounding whitespace is trimmed, and is not by itself a rename", () => {
+  // Trimming is deliberate and stated in the helper's contract. A caller cannot match
+  // " Filename " against anything, and " seed " is not a rename of `seed` — reporting it
+  // as one would be a rename that never happened, which is this bug inverted.
+  assert.equal(displayLabel({ name: "value", label: "  Filename  " }), "Filename");
+  assert.equal(displayLabel({ name: "seed", label: "  seed  " }), null);
+  assert.equal(
+    boundaryInputLabel({ name: "value", _subgraphSlot: { name: "value", label: " Filename " } }),
+    "Filename",
+  );
 });
 
 test("#636: NOTHING is invented — no label, an empty label, or a non-string is null", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -11034,7 +11034,12 @@ const GRAPH_TOOL_EXECUTORS = {
     // clear error instead. The remedy must be actionable from where the caller IS:
     // there is no programmatic delete, so name both real options explicitly rather than
     // leaving "overwrite isn't supported" as a dead end (#636).
-    const collision = blueprintList().find(matchesRequested);
+    // ONE snapshot backs BOTH the collision preflight and the before/after comparison, so
+    // the entry this call ultimately attributes to itself is one this call PROVED was
+    // absent beforehand — not one that merely happens to match the name now.
+    const before = blueprintList();
+    const beforeKeys = new Set(before.map((d) => d?.name));
+    const collision = before.find(matchesRequested);
     if (collision) {
       throw new Error(
         `a subgraph blueprint named "${finalName}" already exists (type "${collision.name}") and this ` +
@@ -11043,41 +11048,51 @@ const GRAPH_TOOL_EXECUTORS = {
           `"${finalName}" from the subgraph library in the ComfyUI UI first and then retry this call.`,
       );
     }
-    const before = blueprintList();
-    const beforeKeys = new Set(before.map((d) => d?.name));
     await store.publishSubgraph(finalName);
     // #636 / rule: never report a save we did not OBSERVE. publishSubgraph resolving is
     // not evidence the blueprint exists — a dismissed dialog, a rejected name, or a
     // frontend that sanitizes the name all resolve without publishing what we asked for.
-    // Read the library BACK and report what is actually there.
-    const after = blueprintList();
-    const published = after.find(matchesRequested) ?? null;
-    if (!published) {
-      // Something may still have been added under a name the frontend chose. Say so
-      // precisely rather than claim the requested save, or claim nothing happened.
-      const added = after.filter((d) => !beforeKeys.has(d?.name));
-      if (added.length === 1) {
-        return {
-          saved: {
-            name: bareName(added[0]),
-            from_node_id: target.id,
-            type: added[0]?.name ?? null,
-            requested_name: finalName,
-            note:
-              `ComfyUI published this blueprint under "${bareName(added[0])}", not the requested ` +
-              `"${finalName}" (it sanitizes or de-duplicates names). Use the reported name with ` +
-              `panel_add_subgraph.`,
-          },
-        };
+    // Read the library BACK and attribute ONLY what this call can bind to itself: an
+    // entry that was ABSENT in `before` and is PRESENT now. A pre-existing entry that
+    // merely matches the name is NOT evidence this publish did anything, and reporting
+    // it would claim a save this call never made.
+    const added = blueprintList().filter((d) => !beforeKeys.has(d?.name));
+    if (added.length === 1) {
+      const entry = added[0];
+      if (matchesRequested(entry)) {
+        return { saved: { name: finalName, from_node_id: target.id, type: entry?.name ?? fullType } };
       }
+      // Published, but under a name the frontend chose (it sanitizes / de-duplicates).
+      // Report the name that actually exists — the requested one would not resolve.
+      return {
+        saved: {
+          name: bareName(entry),
+          from_node_id: target.id,
+          type: entry?.name ?? null,
+          requested_name: finalName,
+          note:
+            `ComfyUI published this blueprint under "${bareName(entry)}", not the requested ` +
+            `"${finalName}" (it sanitizes or de-duplicates names). Use the REPORTED name with ` +
+            `panel_add_subgraph — the requested one will not resolve.`,
+        },
+      };
+    }
+    if (added.length > 1) {
+      // More than one entry appeared while this call was awaiting, so no single entry can
+      // be attributed to this publish. Something WAS added — say exactly that rather than
+      // pick one and call it ours, or claim nothing happened.
       throw new Error(
-        `panel_save_subgraph could not confirm the blueprint "${finalName}" was published: the ` +
-          `subgraph library does not contain it after the publish call` +
-          `${added.length > 1 ? ` (${added.length} entries appeared, none matching the requested name)` : ""}. ` +
-          `Nothing is being reported as saved. Check the ComfyUI subgraph library, then retry.`,
+        `panel_save_subgraph cannot confirm which blueprint this call published: ${added.length} new ` +
+          `entries (${added.map((d) => `"${bareName(d)}"`).join(", ")}) appeared in the subgraph ` +
+          `library while it was saving, so none can be attributed to node ${target.id}. Nothing is ` +
+          `being reported as saved — check the library with panel_list_subgraphs before retrying.`,
       );
     }
-    return { saved: { name: finalName, from_node_id: target.id, type: published.name ?? fullType } };
+    throw new Error(
+      `panel_save_subgraph could not confirm the blueprint "${finalName}" was published: no new entry ` +
+        `appeared in the subgraph library after the publish call. Nothing is being reported as saved. ` +
+        `Check the ComfyUI subgraph library (panel_list_subgraphs), then retry.`,
+    );
   },
 
   // List saved subgraph blueprints. Each is addable via graph_add_subgraph(name)

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -129,6 +129,7 @@ import {
   resolveMissingModelDirectory,
 } from "./lib/asset-staleness.js";
 import { assertAddNodeResolvableRefreshing } from "./lib/node-resolve.js";
+import { displayLabel, boundaryInputLabel, widgetLabelMap } from "./lib/slot-labels.js";
 import { createObjectInfoHistory, awaitHistoryBaseline } from "./lib/object-info-history.js";
 import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
 import { reconcileCompletedDownloads } from "./lib/download-refresh.js";
@@ -6004,20 +6005,40 @@ function summarizeNode(node) {
   for (const w of node.widgets ?? []) {
     if (w && typeof w.name === "string") widgets[w.name] = w.value;
   }
+  // #636: a user-RENAMED slot/widget keeps its programmatic NAME (what panel_set_widget
+  // and panel_connect address) and gains a DISPLAY LABEL. Reporting only the name made
+  // renames invisible, so the agent told the user their renames had not stuck when the
+  // canvas showed them. `label` rides ALONGSIDE `name` and is emitted ONLY when one is
+  // actually carried AND differs — never inferred, never replacing the addressable name.
   const inputs = (node.inputs ?? []).map((inp, i) => {
     let from = null;
     if (inp.link != null) {
       const link = node.graph?.links?.[inp.link];
       if (link) from = { node_id: link.origin_id, output_slot: link.origin_slot };
     }
-    return { slot: i, name: inp.name, type: inp.type, connected_from: from };
+    const label = boundaryInputLabel(inp);
+    return {
+      slot: i,
+      name: inp.name,
+      ...(label != null ? { label } : {}),
+      type: inp.type,
+      connected_from: from,
+    };
   });
-  const outputs = (node.outputs ?? []).map((out, i) => ({
-    slot: i,
-    name: out.name,
-    type: out.type,
-    links: out.links?.length ?? 0,
-  }));
+  const outputs = (node.outputs ?? []).map((out, i) => {
+    const label = displayLabel(out);
+    return {
+      slot: i,
+      name: out.name,
+      ...(label != null ? { label } : {}),
+      type: out.type,
+      links: out.links?.length ?? 0,
+    };
+  });
+  // Renamed widgets only. Keyed by the addressable NAME so the caller can see BOTH the
+  // label the user sees and the name it must use; absent entirely when nothing is
+  // renamed, so an unrenamed node's payload is byte-identical to before.
+  const widgetLabels = widgetLabelMap(node);
   // True RENDERED footprint height for layout. node.size[1] is the BODY only
   // (slots + widgets); the title BAR renders ~30px ABOVE node.pos and isn't in it,
   // so stacking by size[1] overlaps each node by a header. litegraph's getBounding
@@ -6067,6 +6088,10 @@ function summarizeNode(node) {
       ? { control_after_generate: controlAfterGenerate }
       : {}),
     widgets,
+    // #636: widget NAME → the DISPLAY LABEL the user renamed it to, for renamed
+    // widgets only. Address widgets by the KEY (the name); `widget_labels` exists so a
+    // rename is visible instead of looking like it did not stick.
+    ...(Object.keys(widgetLabels).length ? { widget_labels: widgetLabels } : {}),
     // #607: names here are OVERRIDDEN by a link at run time — the value in `widgets`
     // is the stale stored value, NOT what executes. Each entry names the source.
     ...(Object.keys(drivenByLink).length ? { driven_by_link: drivenByLink } : {}),
@@ -6406,8 +6431,18 @@ function describeRails(sub) {
   const wh = (n) => (n?.size ? [Math.round(n.size[0]), Math.round(n.size[1])] : null);
   const inNode = sub.inputNode ?? sub._inputNode ?? null;
   const outNode = sub.outputNode ?? sub._outputNode ?? null;
+  // #636: a RENAMED boundary slot keeps its addressable `name` and reports its display
+  // `label` alongside — only when one is carried and differs (never inferred).
   const slotList = (slots) =>
-    (slots ?? []).map((s, i) => ({ index: i, name: s?.name ?? null, type: s?.type ?? null }));
+    (slots ?? []).map((s, i) => {
+      const label = displayLabel(s);
+      return {
+        index: i,
+        name: s?.name ?? null,
+        ...(label != null ? { label } : {}),
+        type: s?.type ?? null,
+      };
+    });
   return {
     input: inNode
       ? {
@@ -10979,17 +11014,70 @@ const GRAPH_TOOL_EXECUTORS = {
     }
     const finalName =
       typeof name === "string" && name.trim() ? name.trim() : target.title || "Subgraph";
-    const fullType = `${store.typePrefix ?? "SubgraphBlueprint."}${finalName}`;
+    const prefix = store.typePrefix ?? "SubgraphBlueprint.";
+    const fullType = `${prefix}${finalName}`;
+    // #636: the collision preflight must not depend on reconstructing the store's own
+    // key. `typePrefix` is probed with a FALLBACK, so on a frontend that names
+    // blueprints differently the `=== fullType` test silently misses a real collision —
+    // and publishSubgraph() then pops its confirmOverwrite() dialog, which either hangs
+    // this programmatic call on UI or replaces a blueprint the caller never named.
+    // Match on EITHER the full stored key OR its prefix-stripped name, so a collision is
+    // caught whichever way the frontend keys it.
+    const bareName = (d) => {
+      const t = typeof d?.name === "string" ? d.name : "";
+      return t.startsWith(prefix) ? t.slice(prefix.length) : t;
+    };
+    const blueprintList = () => [...(store.subgraphBlueprints ?? [])];
+    const matchesRequested = (d) => d?.name === fullType || bareName(d) === finalName;
     // publishSubgraph() pops a confirmOverwrite() dialog on a name COLLISION — which
     // would hang this programmatic call waiting for UI. Preflight and refuse with a
-    // clear error instead (the agent picks a new name).
-    if ((store.subgraphBlueprints ?? []).some((d) => d?.name === fullType)) {
+    // clear error instead. The remedy must be actionable from where the caller IS:
+    // there is no programmatic delete, so name both real options explicitly rather than
+    // leaving "overwrite isn't supported" as a dead end (#636).
+    const collision = blueprintList().find(matchesRequested);
+    if (collision) {
       throw new Error(
-        `a subgraph blueprint named "${finalName}" already exists — choose a different name (programmatic overwrite isn't supported)`,
+        `a subgraph blueprint named "${finalName}" already exists (type "${collision.name}") and this ` +
+          `tool will not replace it — replacing one programmatically would need ComfyUI's overwrite ` +
+          `dialog, which cannot be answered from here. Either save under a different name, or delete ` +
+          `"${finalName}" from the subgraph library in the ComfyUI UI first and then retry this call.`,
       );
     }
+    const before = blueprintList();
+    const beforeKeys = new Set(before.map((d) => d?.name));
     await store.publishSubgraph(finalName);
-    return { saved: { name: finalName, from_node_id: target.id, type: fullType } };
+    // #636 / rule: never report a save we did not OBSERVE. publishSubgraph resolving is
+    // not evidence the blueprint exists — a dismissed dialog, a rejected name, or a
+    // frontend that sanitizes the name all resolve without publishing what we asked for.
+    // Read the library BACK and report what is actually there.
+    const after = blueprintList();
+    const published = after.find(matchesRequested) ?? null;
+    if (!published) {
+      // Something may still have been added under a name the frontend chose. Say so
+      // precisely rather than claim the requested save, or claim nothing happened.
+      const added = after.filter((d) => !beforeKeys.has(d?.name));
+      if (added.length === 1) {
+        return {
+          saved: {
+            name: bareName(added[0]),
+            from_node_id: target.id,
+            type: added[0]?.name ?? null,
+            requested_name: finalName,
+            note:
+              `ComfyUI published this blueprint under "${bareName(added[0])}", not the requested ` +
+              `"${finalName}" (it sanitizes or de-duplicates names). Use the reported name with ` +
+              `panel_add_subgraph.`,
+          },
+        };
+      }
+      throw new Error(
+        `panel_save_subgraph could not confirm the blueprint "${finalName}" was published: the ` +
+          `subgraph library does not contain it after the publish call` +
+          `${added.length > 1 ? ` (${added.length} entries appeared, none matching the requested name)` : ""}. ` +
+          `Nothing is being reported as saved. Check the ComfyUI subgraph library, then retry.`,
+      );
+    }
+    return { saved: { name: finalName, from_node_id: target.id, type: published.name ?? fullType } };
   },
 
   // List saved subgraph blueprints. Each is addable via graph_add_subgraph(name)

--- a/web/js/lib/control-after-generate.js
+++ b/web/js/lib/control-after-generate.js
@@ -130,11 +130,61 @@ export function controlEntryForWidget(node, widgetName) {
 }
 
 /**
+ * The REMEDY half of the #558 warning, expressed in the CALLER'S OWN SCOPE (#650).
+ *
+ * A remedy must be actionable from where the caller actually is. The control widget
+ * lives on the node that is ULTIMATELY governed — for a PROMOTED subgraph write that is
+ * an INNER node, whose id does not exist in the caller's (root) graph at all. The old
+ * unconditional `panel_set_widget(node_id=<inner id>, …)` therefore returned
+ * "No node with id 75 in the current graph" when followed: a remedy the caller cannot
+ * follow is not better than none, it is worse — it reads as a working instruction.
+ *
+ * `scope` states, as OBSERVED FACT by the caller that resolved the write, how the
+ * control widget is reachable from the addressed scope:
+ *   {}                              — DIRECT write: the control is on the very node the
+ *                                     caller addressed; address it there.
+ *   { outerNodeId, promotedAs }     — the control is ITSELF promoted onto the outer
+ *                                     subgraph node under `promotedAs`; set it there,
+ *                                     without entering anything.
+ *   { outerNodeId, enterPath: [id…] } — the control is only reachable INSIDE; enter each
+ *                                     container in order (each id is addressable in the
+ *                                     scope the previous enter lands in), set it on the
+ *                                     inner node, then exit.
+ * An unrecognised/empty scope falls back to the direct form — the shape it had before —
+ * so a caller that cannot describe the scope is no worse off than today.
+ */
+export function controlAfterGenerateRemedy(entry, node, scope = {}) {
+  const control = entry?.control;
+  const outerId = scope?.outerNodeId;
+  if (outerId != null && typeof scope?.promotedAs === "string") {
+    return (
+      `"${control}" is promoted onto subgraph node ${outerId} as "${scope.promotedAs}", so set it ` +
+      `from here: panel_set_widget(node_id=${outerId}, widget='${scope.promotedAs}', value='fixed').`
+    );
+  }
+  const path = Array.isArray(scope?.enterPath) ? scope.enterPath.filter((id) => id != null) : [];
+  if (outerId != null && path.length) {
+    const enters = path.map((id) => `panel_enter_subgraph(node_id=${id})`).join(", then ");
+    return (
+      `"${control}" is NOT promoted onto subgraph node ${outerId}, so it is not settable from this ` +
+      `scope — node ${node?.id} does not exist in the graph you are addressing. Enter the owning ` +
+      `subgraph first: ${enters}, then ` +
+      `panel_set_widget(node_id=${node?.id}, widget='${control}', value='fixed'), then ` +
+      `panel_exit_subgraph()${path.length > 1 ? ` ${path.length} times` : ""}.`
+    );
+  }
+  return `panel_set_widget(node_id=${node?.id}, widget='${control}', value='fixed').`;
+}
+
+/**
  * A warning string when writing `widgetName` on `node` targets a value governed by a
  * NON-fixed control_after_generate (the write will not hold), else null. Points at
  * the exact control widget + value to make it stick, so the agent can self-correct.
+ *
+ * `scope` (#650) is passed straight to controlAfterGenerateRemedy — see there. Omit it
+ * for a direct read/write where the control widget is on the node the caller addressed.
  */
-export function controlAfterGenerateWarning(node, widgetName) {
+export function controlAfterGenerateWarning(node, widgetName, scope = {}) {
   const entry = controlEntryForWidget(node, widgetName);
   if (!entry || entry.mode === "fixed") return null;
   const behavior = {
@@ -145,7 +195,7 @@ export function controlAfterGenerateWarning(node, widgetName) {
   return (
     `control_after_generate='${entry.mode}' governs widget "${entry.widget}" on node ${node?.id}: ` +
     `ComfyUI automatically CHANGES this value on subsequent runs (${behavior}), so the value you set ` +
-    `will NOT persist. Set "${entry.control}" to 'fixed' to hold it — e.g. ` +
-    `panel_set_widget(node_id=${node?.id}, widget='${entry.control}', value='fixed').`
+    `will NOT persist. Set "${entry.control}" to 'fixed' to hold it — ` +
+    `${controlAfterGenerateRemedy(entry, node, scope)}`
   );
 }

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -214,6 +214,20 @@ export const HISTORY_PENDING = "history-pending";
  * Every verdict except "never-seen" refuses, so a consumer that cannot tell them apart is
  * still safe — the distinction only buys an accurate diagnosis.
  */
+/**
+ * The single membership predicate for "the CURRENT /object_info positively defines this
+ * type". ONE definition so every consumer agrees on what a live backend type is: the two
+ * fresh-auth guards below, and the #612 not-promoted diagnosis in runSetWidget, which must
+ * NOT claim a node is a virtual-only container when the fresh backend positively defines
+ * its type. Returns false for an unavailable/unfetched `freshDefs` — absence of the map is
+ * "could not determine", and every caller already fails closed on that separately.
+ */
+export function freshBackendDefinesType(freshDefs, type) {
+  if (!freshDefs || typeof freshDefs !== "object") return false;
+  if (typeof type !== "string") return false;
+  return Object.prototype.hasOwnProperty.call(freshDefs, type);
+}
+
 export function backendHistoryVerdict(type, wasTypeEverDefined) {
   if (typeof wasTypeEverDefined !== "function" || typeof type !== "string") return "no-oracle";
   const seen = wasTypeEverDefined(type);
@@ -321,7 +335,7 @@ export function assertMutatedNodeAuthorized(freshDefs, registry, node, role = "t
     );
   }
   // PRESENT in the fresh backend → a live node, authorized by presence.
-  if (typeof type === "string" && Object.prototype.hasOwnProperty.call(freshDefs, type)) return;
+  if (freshBackendDefinesType(freshDefs, type)) return;
   // ABSENT from fresh object_info. EVER-SEEN GATE: if the backend reported this type
   // earlier this session, its backend was REMOVED — refuse (non-forgeable, #458).
   const verdict = backendHistoryVerdict(type, wasTypeEverDefined);
@@ -579,7 +593,7 @@ export function assertTypeAgainstFreshBackend(freshDefs, type, nodeId = "(unknow
         `Reconnect ComfyUI and retry.`,
     );
   }
-  if (typeof type !== "string" || !Object.prototype.hasOwnProperty.call(freshDefs, type)) {
+  if (!freshBackendDefinesType(freshDefs, type)) {
     // #458 EVER-SEEN GATE (the non-forgeable trust root): object_info WAS fetched but
     // lacks this type. If the backend reported this type EARLIER this session, its
     // backend was REMOVED (pack uninstalled) → refuse — even a pure-JS frontend class

--- a/web/js/lib/node-resolve.js
+++ b/web/js/lib/node-resolve.js
@@ -73,6 +73,14 @@ export const FRONTEND_ONLY_NODE_TYPES = new Set([
   "Label (rgthree)",
   "Reroute (rgthree)",
   "Node Collector (rgthree)",
+  // KJNodes' frontend-only Get/Set bus nodes (also reported with rgthree installed):
+  // registered purely by the pack's JS, absent from /object_info BY DESIGN (#496
+  // recurrence). These are GENERIC names a backend pack could also use — a live
+  // backend registration carries nodeData/comfyClass provenance and never reaches
+  // this allowlist (hasBackendProvenance), and a mid-session removal is caught by
+  // the ever-seen gate BEFORE the exemption is consulted.
+  "SetNode",
+  "GetNode",
 ]);
 
 /**

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -31,8 +31,9 @@ import {
   assertMutatedNodeAuthorized,
   isVirtualSubgraphContainer,
   backendHistoryVerdict,
+  freshBackendDefinesType,
 } from "./node-resolve.js";
-import { controlAfterGenerateWarning } from "./control-after-generate.js";
+import { controlAfterGenerateWarning, controlEntryForWidget } from "./control-after-generate.js";
 import {
   uploadInputConfig,
   uploadInputAccepts,
@@ -109,11 +110,13 @@ export async function runSetWidget(
   //         bypass): otherwise a removed GoneNode with `subgraph:{}` + its own widget
   //         would skip fresh-auth and the stale registry guard would fabricate success.
   //         One exception, still fail-closed: a GENUINE virtual subgraph container
-  //         (never-seen history) with no promoted match is refused UP FRONT with the
-  //         honest "not a promoted widget on this subgraph" diagnosis (#612) — its
-  //         UUID type is never in /object_info, so the generic fresh-auth message
-  //         ("backend does not provide node type <uuid>") misreports a benign
-  //         not-promoted case as a removed pack.
+  //         (POSITIVELY never-seen history AND absent from the fresh /object_info)
+  //         with no promoted match is refused UP FRONT with the honest "not a promoted
+  //         widget on this subgraph" diagnosis (#612) — its UUID type is never in
+  //         /object_info, so the generic fresh-auth message ("backend does not provide
+  //         node type <uuid>") misreports a benign not-promoted case as a removed pack.
+  //         Both facts must be POSITIVE; see the branch below for why neither may be
+  //         inferred from an absence of evidence.
   let freshDefs = null;
   try {
     freshDefs = await getFreshObjectInfo();
@@ -189,9 +192,32 @@ export async function runSetWidget(
     // node whose type the backend reported earlier this session is a REMOVED backend
     // node masquerading as a container and keeps the removed-type diagnosis below,
     // as does a bare `subgraph:{}` marker that is not a real container.
+    //
+    // TWO POSITIVE facts are required before this definite diagnosis may be asserted,
+    // because "not a promoted widget on this SUBGRAPH" claims the node is a virtual-only
+    // container — and getting that wrong refuses a legitimate write while handing the
+    // caller a remedy that is actionable and WRONG (worse than a bare refusal):
+    //
+    //   1. The CURRENT /object_info does NOT define this type. A backend-defined,
+    //      subgraph-capable node ADDED AFTER the startup baseline is `never-seen` on its
+    //      first observation, yet its type IS in the fresh defs this call already
+    //      fetched — it is a real backend node writing its OWN widget directly, and the
+    //      fresh-type authorization below is entitled to PERMIT it. Short-circuiting on
+    //      history alone would refuse that valid direct write as "unpromoted".
+    //   2. The history oracle POSITIVELY reports never-seen. `no-oracle` is the
+    //      could-not-determine case BY DEFINITION — it establishes neither "never
+    //      backend-defined" nor safe container identity (backendHistoryVerdict's own
+    //      fail-closed contract) — so it must FALL THROUGH to the fresh-type
+    //      authorization rather than short-circuit to a definite negative. That path
+    //      still fails closed for a type the backend does not provide; it just stops
+    //      asserting a container diagnosis nothing established.
+    //
+    // "Could not determine whether this is a promoted widget on a subgraph" is not
+    // "determined it is not" — the same fold this cluster exists to correct.
     if (node?.subgraph && isVirtualSubgraphContainer(node)) {
       const containerVerdict = backendHistoryVerdict(node?.type, wasTypeEverDefined);
-      if (containerVerdict === "never-seen" || containerVerdict === "no-oracle") {
+      const liveBackendType = freshBackendDefinesType(freshDefs, node?.type);
+      if (containerVerdict === "never-seen" && !liveBackendType) {
         const promoted = (node.widgets ?? [])
           .map((w) => w?.name)
           .filter((n) => typeof n === "string");
@@ -332,10 +358,46 @@ export async function runSetWidget(
   // actually lives): a nested promotion A→B→KSampler exposes `seed` on B virtually, but
   // the control combo is on KSampler — `authTarget`/`concreteWidgetName` follow the
   // promotion chain to it (both are the node itself for a direct write).
+  //
+  // #650 SCOPE: the remedy has to be executable from the scope the CALLER is in. When
+  // the write went through a promotion, that concrete node is INSIDE the subgraph and
+  // its id does not exist in the caller's graph — following the old unconditional
+  // `panel_set_widget(node_id=<inner id>, …)` returned "No node with id 75 in the
+  // current graph". The reachability below is not a guess: it is read off the SAME
+  // resolution the write itself was driven through.
+  const controlScopeFor = (entry) => {
+    const warnNode = authTarget ?? resolvedTargetNode;
+    // Direct write (or the concrete node IS the node the caller addressed): the control
+    // widget is right there, and the plain form is already actionable.
+    if (!isResolvedPromotion || warnNode === node) return {};
+    const outerNodeId = node?.id;
+    // Is the CONTROL widget itself promoted onto the outer node? Then it is settable
+    // from this scope with no entering at all. Asked of the same resolver the write
+    // used, so a positive answer is an observed promotion, never an assumption.
+    // (Usually NO: ComfyUI marks control_after_generate canvasOnly, so it has no
+    // connectable slot to promote — but a legacy proxyWidgets promotion can exist.)
+    const controlPromotion = resolvePromotedInnerTarget(node, entry.control, resolveSource);
+    if (controlPromotion?.promoted && controlPromotion.target) {
+      const reached = followPromotionToConcrete(controlPromotion.target, resolveSource);
+      if (reached?.node === warnNode && reached?.widget?.name === entry.control) {
+        return { outerNodeId, promotedAs: entry.control };
+      }
+    }
+    // Otherwise it is only reachable from INSIDE: enter the outer container, then every
+    // nested container the promotion is driven through, in that order. The concrete
+    // terminal is never an entry step (collectPromotionIntermediates excludes it).
+    const enterPath = [
+      outerNodeId,
+      ...collectPromotionIntermediates(promotedResolution.target, resolveSource).map((n) => n?.id),
+    ];
+    return { outerNodeId, enterPath };
+  };
   const withWarning = (result) => {
     const warnNode = authTarget ?? resolvedTargetNode;
     const warnWidget = concreteWidgetName ?? writeTargetWidgetName ?? widgetName;
-    const warning = controlAfterGenerateWarning(warnNode, warnWidget);
+    const entry = controlEntryForWidget(warnNode, warnWidget);
+    if (!entry || entry.mode === "fixed") return result;
+    const warning = controlAfterGenerateWarning(warnNode, warnWidget, controlScopeFor(entry));
     return warning ? { ...result, warning } : result;
   };
 

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -29,6 +29,8 @@ import {
   assertResolvedTargetRegistered,
   assertTypeAgainstFreshBackend,
   assertMutatedNodeAuthorized,
+  isVirtualSubgraphContainer,
+  backendHistoryVerdict,
 } from "./node-resolve.js";
 import { controlAfterGenerateWarning } from "./control-after-generate.js";
 import {
@@ -106,6 +108,12 @@ export async function runSetWidget(
   //         exempted just because it carries a `subgraph` field (#458 subgraph-shaped
   //         bypass): otherwise a removed GoneNode with `subgraph:{}` + its own widget
   //         would skip fresh-auth and the stale registry guard would fabricate success.
+  //         One exception, still fail-closed: a GENUINE virtual subgraph container
+  //         (never-seen history) with no promoted match is refused UP FRONT with the
+  //         honest "not a promoted widget on this subgraph" diagnosis (#612) — its
+  //         UUID type is never in /object_info, so the generic fresh-auth message
+  //         ("backend does not provide node type <uuid>") misreports a benign
+  //         not-promoted case as a removed pack.
   let freshDefs = null;
   try {
     freshDefs = await getFreshObjectInfo();
@@ -166,6 +174,36 @@ export async function runSetWidget(
       );
     }
   } else {
+    // #612: a GENUINE virtual subgraph container whose requested widget matched NO
+    // promoted alias is a distinct, benign branch — the widget simply is not exposed
+    // on the subgraph boundary (an inner node's widget that was never promoted; the
+    // #512 recurrence is exactly this: a legacy proxyWidgets promotion of
+    // control_after_generate that the current frontend QUARANTINED on load because a
+    // canvas-only control widget has no connectable slot). Falling through to the
+    // fresh-backend type check below would misdiagnose it as "the ComfyUI backend
+    // does not provide node type <uuid>" — a subgraph node's type is its subgraph
+    // UUID, NEVER in /object_info by design — sending the agent hunting a phantom
+    // uninstalled pack. The refusal itself is unchanged (fail closed); only the
+    // diagnosis is corrected, and it is a graph-local fact that needs no backend
+    // oracle. The observed-history verdict is consulted FIRST: a container-shaped
+    // node whose type the backend reported earlier this session is a REMOVED backend
+    // node masquerading as a container and keeps the removed-type diagnosis below,
+    // as does a bare `subgraph:{}` marker that is not a real container.
+    if (node?.subgraph && isVirtualSubgraphContainer(node)) {
+      const containerVerdict = backendHistoryVerdict(node?.type, wasTypeEverDefined);
+      if (containerVerdict === "never-seen" || containerVerdict === "no-oracle") {
+        const promoted = (node.widgets ?? [])
+          .map((w) => w?.name)
+          .filter((n) => typeof n === "string");
+        throw new Error(
+          `Cannot set widget on subgraph node ${node.id}: "${widgetName}" is not a promoted ` +
+            `widget on this subgraph (promoted: ${promoted.length ? promoted.join(", ") : "none"}). ` +
+            `Only promoted widgets are settable from outside a subgraph — panel_enter_subgraph ` +
+            `and set it on the inner node directly, or promote it from inside the subgraph with ` +
+            `panel_promote_widget first.`,
+        );
+      }
+    }
     authTarget = node;
   }
 

--- a/web/js/lib/set-widget.js
+++ b/web/js/lib/set-widget.js
@@ -41,6 +41,18 @@ import {
   serverDeclaresEmptyComboOptions,
 } from "./input-asset.js";
 
+/** A never-throwing rendering of an advisory failure. Used on the POST-WRITE path, where
+ *  a second exception (a getter on `message`, a null throw) must not escape either. */
+function coerceAdvisoryMessage(err) {
+  try {
+    const msg = err?.message;
+    if (typeof msg === "string" && msg) return msg;
+    return String(err);
+  } catch {
+    return "the reason could not be rendered";
+  }
+}
+
 export async function runSetWidget(
   node,
   widgetName,
@@ -198,12 +210,16 @@ export async function runSetWidget(
     // container — and getting that wrong refuses a legitimate write while handing the
     // caller a remedy that is actionable and WRONG (worse than a bare refusal):
     //
-    //   1. The CURRENT /object_info does NOT define this type. A backend-defined,
-    //      subgraph-capable node ADDED AFTER the startup baseline is `never-seen` on its
-    //      first observation, yet its type IS in the fresh defs this call already
-    //      fetched — it is a real backend node writing its OWN widget directly, and the
-    //      fresh-type authorization below is entitled to PERMIT it. Short-circuiting on
-    //      history alone would refuse that valid direct write as "unpromoted".
+    //   1. The CURRENT /object_info was FETCHED and does NOT define this type. Two
+    //      distinct facts, and both are needed. A backend-defined, subgraph-capable node
+    //      ADDED AFTER the startup baseline is `never-seen` on its first observation, yet
+    //      its type IS in the fresh defs this call already fetched — it is a real backend
+    //      node writing its OWN widget directly, and the fresh-type authorization below
+    //      is entitled to PERMIT it. And when the fetch FAILED there are no fresh defs at
+    //      all: an unavailable map is not evidence the backend lacks the type, so the
+    //      current-absence fact is simply not established and this diagnosis may not be
+    //      asserted. That case falls through to the fresh-auth guard, which refuses with
+    //      the accurate "object_info is unavailable — reconnect and retry".
     //   2. The history oracle POSITIVELY reports never-seen. `no-oracle` is the
     //      could-not-determine case BY DEFINITION — it establishes neither "never
     //      backend-defined" nor safe container identity (backendHistoryVerdict's own
@@ -216,8 +232,13 @@ export async function runSetWidget(
     // "determined it is not" — the same fold this cluster exists to correct.
     if (node?.subgraph && isVirtualSubgraphContainer(node)) {
       const containerVerdict = backendHistoryVerdict(node?.type, wasTypeEverDefined);
-      const liveBackendType = freshBackendDefinesType(freshDefs, node?.type);
-      if (containerVerdict === "never-seen" && !liveBackendType) {
+      // An UNAVAILABLE map is could-not-determine, NOT "the backend lacks this type" —
+      // freshBackendDefinesType returns false for both, so the two must be told apart
+      // here or an unreachable backend silently becomes positive evidence.
+      const freshDefsUsable = !!freshDefs && typeof freshDefs === "object";
+      const absentFromFreshBackend =
+        freshDefsUsable && !freshBackendDefinesType(freshDefs, node?.type);
+      if (containerVerdict === "never-seen" && absentFromFreshBackend) {
         const promoted = (node.widgets ?? [])
           .map((w) => w?.name)
           .filter((n) => typeof n === "string");
@@ -392,13 +413,33 @@ export async function runSetWidget(
     ];
     return { outerNodeId, enterPath };
   };
+  // The write has ALREADY LANDED and been verified by the time this runs. Everything
+  // here is ADVISORY, and advisory work is still work that can fail: controlScopeFor
+  // re-enters resolvePromotedInnerTarget / collectPromotionIntermediates, which call the
+  // injected `resolveSource` — a malformed or control-only promotion link can throw
+  // there. Letting that escape would report a COMPLETED, verified write as a failure,
+  // and the caller would then "retry" a write that already happened. Refuse before the
+  // action; DISCLOSE after it. So the advisory is computed inside a guard, and its
+  // failure downgrades to a disclosed gap, never to a failed write.
   const withWarning = (result) => {
-    const warnNode = authTarget ?? resolvedTargetNode;
-    const warnWidget = concreteWidgetName ?? writeTargetWidgetName ?? widgetName;
-    const entry = controlEntryForWidget(warnNode, warnWidget);
-    if (!entry || entry.mode === "fixed") return result;
-    const warning = controlAfterGenerateWarning(warnNode, warnWidget, controlScopeFor(entry));
-    return warning ? { ...result, warning } : result;
+    try {
+      const warnNode = authTarget ?? resolvedTargetNode;
+      const warnWidget = concreteWidgetName ?? writeTargetWidgetName ?? widgetName;
+      const entry = controlEntryForWidget(warnNode, warnWidget);
+      if (!entry || entry.mode === "fixed") return result;
+      const warning = controlAfterGenerateWarning(warnNode, warnWidget, controlScopeFor(entry));
+      return warning ? { ...result, warning } : result;
+    } catch (advisoryErr) {
+      return {
+        ...result,
+        warning:
+          `The write SUCCEEDED and was verified. The panel could not finish checking whether a ` +
+          `control_after_generate governs this widget (${coerceAdvisoryMessage(advisoryErr)}), so ` +
+          `treat that as UNKNOWN, not as "no control": if this is a seed or similar, read the node ` +
+          `with panel_query_graph(fields:'detail') and check its control_after_generate before ` +
+          `relying on the value holding across runs.`,
+      };
+    }
   };
 
   // #387 UPLOAD-ASSET fallback: a value rejected by the combo list even AFTER the

--- a/web/js/lib/slot-labels.js
+++ b/web/js/lib/slot-labels.js
@@ -25,6 +25,12 @@
  * `nameOverride` lets a caller supply the name the entry is REPORTED under when that
  * differs from the entry's own `name` (a subgraph boundary slot is reported under the
  * host input's name, while its label may live on the backing slot object).
+ *
+ * The label is TRIMMED before reporting, and the rename test is made on the trimmed
+ * form. Surrounding whitespace is not something a user can see on the canvas or type
+ * into a rename dialog deliberately, so treating " seed " as a rename of `seed` would
+ * report a rename that did not happen — and reporting the untrimmed string would hand
+ * the caller a label it cannot match against anything.
  */
 export function displayLabel(entry, nameOverride) {
   const raw = entry?.label;

--- a/web/js/lib/slot-labels.js
+++ b/web/js/lib/slot-labels.js
@@ -1,0 +1,62 @@
+// DISPLAY LABELS for widgets and slots (#636).
+//
+// A user can RENAME a subgraph's promoted widgets and boundary slots in the ComfyUI UI.
+// The rename sets a DISPLAY LABEL; the programmatic NAME (the key panel_set_widget and
+// panel_connect address) is unchanged. Every structured reader reported only the name,
+// so a rename was invisible to the agent — which then told the user their renames "had
+// not stuck" when the canvas plainly showed them. Only a screenshot resolved it.
+//
+// The correction is purely ADDITIVE and strictly OBSERVED:
+//   * the NAME stays exactly where it was — it is the addressable identity, and moving
+//     or overwriting it would break every caller that addresses widgets/slots by name;
+//   * a `label` is emitted ONLY when the frontend actually carries one AND it DIFFERS
+//     from the name. A label equal to the name is not a rename and carries no
+//     information; emitting it anyway would make every node look renamed.
+//   * nothing is inferred. No label observed ⇒ no `label` key, never a guessed or
+//     prettified one — a fabricated label is exactly the failure this fixes, inverted.
+//
+// Extracted so the label derivation is unit-tested against the SAME code the panel's
+// summarizeNode / describeRails run.
+
+/**
+ * The DISPLAY label carried by a widget or slot, or null when it carries none / when it
+ * is identical to the programmatic name.
+ *
+ * `nameOverride` lets a caller supply the name the entry is REPORTED under when that
+ * differs from the entry's own `name` (a subgraph boundary slot is reported under the
+ * host input's name, while its label may live on the backing slot object).
+ */
+export function displayLabel(entry, nameOverride) {
+  const raw = entry?.label;
+  if (typeof raw !== "string") return null;
+  const label = raw.trim();
+  if (!label) return null;
+  const name = nameOverride != null ? nameOverride : entry?.name;
+  if (typeof name === "string" && label === name) return null;
+  return label;
+}
+
+/**
+ * The label a SUBGRAPH BOUNDARY input carries. The rename may be recorded on the host
+ * input itself or on the backing subgraph slot (`_subgraphSlot`), depending on frontend
+ * version, so both are consulted — host input FIRST, since that is what renders on the
+ * outer node the caller is looking at. Returns null when neither carries a distinct one.
+ */
+export function boundaryInputLabel(input) {
+  return displayLabel(input) ?? displayLabel(input?._subgraphSlot, input?.name);
+}
+
+/**
+ * Map of widget NAME → DISPLAY LABEL for every RENAMED widget on `node`, and only those.
+ * Empty object when nothing is renamed, so a caller can omit the key entirely rather
+ * than emit an empty map on every node.
+ */
+export function widgetLabelMap(node) {
+  const out = {};
+  for (const w of node?.widgets ?? []) {
+    if (!w || typeof w.name !== "string") continue;
+    const label = displayLabel(w);
+    if (label != null) out[w.name] = label;
+  }
+  return out;
+}


### PR DESCRIPTION
## Issues in this cluster

- #612
- #583
- #512
- #496

## What changed

**#612 + the #512 recurrence — `web/js/lib/set-widget.js`.** A `panel_set_widget` call on a genuine subgraph node naming a widget that is **not promoted** no longer falls through to the #458 fresh-backend check on the node's own type (a subgraph UUID that is never in `/object_info`), which produced the misleading *"the ComfyUI backend does not provide node type \<uuid\> (not installed, or its pack was removed)"*. It now refuses up front with the honest diagnosis:

> Cannot set widget on subgraph node 78: "control_after_generate" is not a promoted widget on this subgraph (promoted: width, height, seed, …). Only promoted widgets are settable from outside a subgraph — panel_enter_subgraph and set it on the inner node directly, or promote it from inside the subgraph with panel_promote_widget first.

The refusal itself is unchanged (fail closed) — only the diagnosis. The ever-seen history gate is still consulted first (a container-shaped node whose type the backend reported earlier this session keeps the removed-type diagnosis), and a bare `subgraph:{}` marker that fails the container-shape check keeps the #458 fresh-auth path.

The #512 recurrence (krea2-txt2img-manual node 78: promoted `width` accepted, promoted `control_after_generate` refused with the UUID error) was root-caused against the shipped frontend (1.47.12 source maps): the pack's legacy `properties.proxyWidgets` entry `["75","control_after_generate"]` is **quarantined on load** by `proxyWidgetMigration.repairCreateSubgraphInput` because a canvas-only control widget has no connectable input slot — so the outer node genuinely has no such promotion. The refusal was correct; only its message was wrong. That is exactly this fix.

**#496 recurrence — `web/js/lib/node-resolve.js`.** KJNodes' frontend-only `SetNode`/`GetNode` (also reported with rgthree installed) added to `FRONTEND_ONLY_NODE_TYPES`, so the one shared predicate (`isAuthorizedFrontendOnlyType`) authorizes them for both `panel_add_node` and `panel_set_widget`. The guards are not weakened: live-registry membership, no backend provenance on class AND instance, and the non-forgeable ever-seen gate (applied first by every caller) still refuse squatters and mid-session removals — pinned by new negative tests.

**#583** was already fixed on main by #591 (`previous` now reports the requested outer rail widget's prior value, `inner_previous` exposes the inner value separately) and is covered by its regression test in `widget-write.test.mjs`; this PR closes the issue.

## Verification

- Full unit suite: **1782/1782 pass** (`node --test browser_tests/unit/*.test.mjs`).
- 8 new tests (5 in `set-widget-fresh-backend.test.mjs`, 3 in `node-resolve.test.mjs`).
- Delete-the-code checks: removing the new branch fails exactly the 3 tests about it; removing the allowlist entries fails exactly the 2 positive #496 tests; the negative pins stay green.
- Mutation-verified: dropping the `no-oracle` arm, dropping the container-shape check, dropping the verdict gate, and garbling the message are each caught (one also by the pre-existing #458 subgraph-shaped-bypass test).
- ES-module syntax checked as `.mjs`; committed blobs scanned for control bytes (0).
- Adversarial self-gate (codex, read-only): **PASS**, no findings.

## Deliberately not fixed here

- #612's two "related observations": (a) `panel_promote_widget` reporting `link-only` promotions as ordinary widgets (socket-only controls) — a different tool's reporting path; (b) `control_after_generate` surfaced under its current value as its key in `panel_query_graph` — a read-side/frontend-naming issue. Both are real but separate codepaths from this cluster's guard family.
- Live-browser confirmation that the krea2 node's `control_after_generate` is indeed quarantined (not visible on the boundary) is inferred from the frontend source + pack JSON, not observed on a running instance.
