### PR TITLE
panel_add_node rejects nodes whose widgets it cannot register — link-only custom types, VIDEO, V3 required values

### DIFF
--- a/browser_tests/unit/connect-match.test.mjs
+++ b/browser_tests/unit/connect-match.test.mjs
@@ -280,3 +280,105 @@ test("#406: a slot literally NAMED like a type still wins by name first", () => 
   const m = autoMatchSlots(origin, target, "IMAGE", "mask");
   assert.equal(m.outIdx, 0); // resolved by NAME to the MASK slot, not by type
 });
+
+// ---- #651: a WILDCARD socket accepts the type it is addressed by ------------
+//
+// Reported: `panel_connect(ImageCrop.IMAGE -> SetNode."IMAGE")` was refused with
+// "No input on node 225 accepts type IMAGE", while node 225's only input was a
+// wildcard `*` — a socket whose declaration is a POSITIVE statement that it accepts
+// anything, and which had carried an IMAGE from VHS_LoadVideo moments earlier.
+// The type-ref resolver compared type strings naively while the auto-matcher scored
+// with isTypeCompatible, so the two answered "does this slot accept IMAGE?"
+// differently. Reading `*` as "not IMAGE" is reading an unknown as a definite
+// negative — the mirror of the add path's over-permissive output-side inference,
+// and the reason both now go through ONE predicate.
+
+// Set/Get bus node: a single wildcard input, named "*" and typed "*".
+function setNodeWildcard() {
+  return { id: 225, type: "SetNode", inputs: [{ name: "*", type: "*", link: null }] };
+}
+function imageCrop() {
+  return { id: 324, type: "ImageCrop", outputs: [{ name: "IMAGE", type: "IMAGE" }] };
+}
+
+test("#651: a wildcard input is matched when addressed by a concrete TYPE name", () => {
+  assert.deepEqual(typeMatchedIndices(setNodeWildcard().inputs, "IMAGE"), [0]);
+  assert.deepEqual(typeMatchedIndices(setNodeWildcard().inputs, "LATENT"), [0]);
+});
+
+test("#651: the reported call now connects (IMAGE output -> existing SetNode wildcard)", () => {
+  const m = autoMatchSlots(imageCrop(), setNodeWildcard(), "IMAGE", "IMAGE");
+  assert.equal(m.outIdx, 0);
+  assert.equal(m.inIdx, 0);
+});
+
+test("#651: an EXACT type match still outranks a wildcard — the tiers never mix", () => {
+  // The wildcard tier exists to stop a false refusal, not to start a wrong guess.
+  // With both an IMAGE input and a `*` input present, "IMAGE" must land on IMAGE.
+  const target = {
+    id: 2,
+    inputs: [
+      { name: "*", type: "*", link: null },
+      { name: "image", type: "IMAGE", link: null },
+    ],
+  };
+  const m = autoMatchSlots(imageCrop(), target, "IMAGE", "IMAGE");
+  assert.equal(m.inIdx, 1, "the concrete IMAGE input wins outright");
+});
+
+test('#651: addressing "*" literally still lands on the wildcard, not on every slot', () => {
+  // isTypeCompatible ranks `*` against anything as a WILDCARD match, so a purely
+  // rank-based resolver would make `to_input:"*"` tie with every string-typed slot
+  // and refuse as ambiguous. Literal identity of the addressed name is checked first.
+  const target = {
+    id: 2,
+    inputs: [
+      { name: "image", type: "IMAGE", link: null },
+      { name: "any", type: "*", link: null },
+    ],
+  };
+  const m = autoMatchSlots(imageCrop(), target, "IMAGE", "*");
+  assert.equal(m.inIdx, 1);
+});
+
+test("#651: TWO wildcard inputs stay AMBIGUOUS — a wildcard does not license guessing", () => {
+  // The whole point of matching `*` is that it accepts anything; that says nothing
+  // about WHICH of two it should be. Silently picking one is the wrong-negative bug
+  // this cluster's other half is about, inverted.
+  const target = {
+    id: 2,
+    inputs: [
+      { name: "a", type: "*", link: null },
+      { name: "b", type: "*", link: null },
+    ],
+  };
+  assert.throws(() => autoMatchSlots(imageCrop(), target, "IMAGE", "IMAGE"), /ambiguous/i);
+});
+
+test("#651: a node with NO wildcard still refuses an unmatched type — the refusal is not blanket-loosened", () => {
+  const target = { id: 2, inputs: [{ name: "samples", type: "LATENT", link: null }] };
+  assert.throws(() => autoMatchSlots(imageCrop(), target, "IMAGE", "IMAGE"), /No input|accepts type/i);
+});
+
+test("#651: a COMBO input is never matched by a type name, wildcard tier or not", () => {
+  // isTypeCompatible refuses combo/non-combo pairings outright, and the resolver only
+  // considers string-typed slots — so an enum cannot be addressed as "IMAGE".
+  const target = {
+    id: 2,
+    inputs: [{ name: "mode", type: ["a", "b"], link: null }],
+  };
+  assert.deepEqual(typeMatchedIndices(target.inputs, "IMAGE"), []);
+});
+
+test("#651: a comma multi-type input is matched by ANY of its declared segments (exact tier)", () => {
+  const target = {
+    id: 2,
+    inputs: [
+      { name: "either", type: "IMAGE,MASK", link: null },
+      { name: "any", type: "*", link: null },
+    ],
+  };
+  // Exact-tier hit on the multi-type slot means the wildcard is never consulted.
+  assert.deepEqual(typeMatchedIndices(target.inputs, "MASK"), [0]);
+  assert.deepEqual(typeMatchedIndices(target.inputs, "IMAGE"), [0]);
+});

--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  driftedRequiredInputNames,
   missingRequiredWidgetMaterializations,
   registeredSocketTypes,
   requiredWidgetInputTypes,
@@ -167,19 +168,20 @@ test("frontend-injected upload input is not guarded once the backend proves it n
     },
   };
   // Live /object_info for LoadImage reports required = image only: `upload`
-  // is 100% frontend-injected, so it can never be a missing prompt value and
-  // neither guard may reject over it.
-  const backendRequired = new Set(["image"]);
+  // is 100% frontend-injected, so it can never be a missing prompt value.
+  // Scanning the FRESH def instead of the frontend nodeData means neither
+  // guard ever sees it.
+  const currentDef = { input: { required: { image: [["a.png", "b.png"], {}] } } };
   assert.deepEqual(
     missingRequiredWidgetMaterializations(
       node,
       { COMBO: () => {}, IMAGEUPLOAD: () => {} },
-      backendRequired,
+      currentDef,
     ),
     [],
   );
   assert.deepEqual(
-    unavailableRequiredCustomWidgetTypes(node, { COMBO: () => {} }, undefined, backendRequired),
+    unavailableRequiredCustomWidgetTypes(node, { COMBO: () => {} }, undefined, currentDef),
     [],
   );
 });
@@ -197,9 +199,68 @@ test("a canvasOnly serialize:false widget for a BACKEND-required input is still 
       },
     },
   };
+  const currentDef = { input: { required: { gallery: ["ZIPN_STYLE_GALLERY", {}] } } };
   assert.deepEqual(
-    missingRequiredWidgetMaterializations(node, widgetConstructors, new Set(["gallery"])),
+    missingRequiredWidgetMaterializations(node, widgetConstructors, currentDef),
     ["gallery"],
+  );
+});
+
+test("a backend def present with no input requirements enforces nothing", () => {
+  // The class IS in fresh /object_info but requires no inputs — distinct from
+  // a frontend-only type (no def at all), which falls back to the node data.
+  const node = v3Node([{ name: "style" }]);
+  assert.deepEqual(missingRequiredWidgetMaterializations(node, widgetConstructors, {}), []);
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(node, {}, undefined, {}), []);
+});
+
+test("a required input added to an already-registered class is seen via the fresh def", () => {
+  // Pack upgraded mid-session: the registered nodeData predates the schema
+  // change. The guards must still catch the NEW required custom-widget input.
+  const staleNode = {
+    widgets: [],
+    constructor: {
+      nodeData: {
+        input: { required: { clip: ["CLIP", {}] } },
+      },
+    },
+  };
+  const currentDef = {
+    input: {
+      required: {
+        clip: ["CLIP", {}],
+        gallery: ["ZIPN_STYLE_GALLERY", {}],
+      },
+    },
+  };
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(staleNode, {}, undefined, currentDef),
+    ["ZIPN_STYLE_GALLERY"],
+  );
+  // Constructor registered, but the stale-shaped node never built the widget.
+  assert.deepEqual(
+    missingRequiredWidgetMaterializations(staleNode, widgetConstructors, currentDef),
+    ["gallery"],
+  );
+  assert.deepEqual(driftedRequiredInputNames(currentDef, staleNode), ["gallery"]);
+  assert.deepEqual(driftedRequiredInputNames(currentDef, { input: currentDef.input }), []);
+  assert.deepEqual(driftedRequiredInputNames(undefined, staleNode), []);
+});
+
+test("raw /object_info snake_case force_input remains a wireable socket", () => {
+  const node = {
+    constructor: {
+      nodeData: {
+        input: {
+          required: { text: ["STRING", { force_input: true }] },
+        },
+      },
+    },
+  };
+  assert.deepEqual(requiredWidgetInputTypes(node), []);
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(node, {}, undefined, node.constructor.nodeData),
+    [],
   );
 });
 

--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -247,6 +247,34 @@ test("a required input added to an already-registered class is seen via the fres
   assert.deepEqual(driftedRequiredInputNames(undefined, staleNode), []);
 });
 
+test("a same-name required input whose TYPE changed mid-session is drift", () => {
+  const staleNode = {
+    constructor: {
+      nodeData: {
+        input: {
+          required: {
+            mode: ["STRING", { default: "legacy" }],
+            style: [["none", "film"], {}],
+            quality: ["INT", { default: 5 }],
+          },
+        },
+      },
+    },
+  };
+  // mode retyped STRING -> COMBO, style's combo VALUES changed, quality only
+  // gained a benign default change.
+  const currentDef = {
+    input: {
+      required: {
+        mode: [["modern"], {}],
+        style: [["noir", "film"], {}],
+        quality: ["INT", { default: 7 }],
+      },
+    },
+  };
+  assert.deepEqual(driftedRequiredInputNames(currentDef, staleNode), ["mode", "style"]);
+});
+
 test("raw /object_info snake_case force_input remains a wireable socket", () => {
   const node = {
     constructor: {

--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -1,12 +1,17 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import {
+  applyCurrentDefWidgetValues,
   driftedRequiredInputNames,
   missingRequiredWidgetMaterializations,
   registeredSocketTypes,
   requiredWidgetInputTypes,
   unavailableRequiredCustomWidgetTypes,
 } from "../../web/js/lib/node-widget-materialization.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 
 const widgetConstructors = { ZIPN_STYLE_GALLERY: () => {}, ZIPN_SPACER: () => {}, COMBO: () => {} };
 
@@ -342,4 +347,188 @@ test("registeredSocketTypes derives link datatypes from fresh /object_info outpu
   assert.ok(types.has("VIDEO"));
   assert.ok(types.has("MASK"));
   assert.equal(types.size, 5);
+});
+
+// ---- #626 P0-1: output-type compatibility is not proof an input is LINK-ONLY -------
+//
+// `knownSocketTypes` waived registration for any input whose type appears as SOME fresh
+// definition's OUTPUT. That is evidence about the TYPE; the question is about the INPUT.
+// ComfyUI's frontend supports converting widget inputs to links, so widget-bearing
+// inputs are link-compatible too — a custom ACME_VALUE can be a widget on one node and
+// an output on another. Waiving on the output side alone meant a required custom widget
+// whose constructor NEVER registers passed the guard, and `panel_add_node` added a node
+// with NEITHER the required widget value NOR a link — invalid, and rejected only later
+// at queue time. The later materialization guard could not report it either: with no
+// constructor there is nothing for it to look for.
+
+const ACME_OUTPUT_PROOF = new Set(["ACME_VALUE"]);
+
+test("#626: a required input that DECLARES a value is not waived just because some node OUTPUTS its type", () => {
+  // The V3 custom-widget shape: the input declares a `default`, which only a widget can
+  // carry. Another node outputs ACME_VALUE, so the type IS a proven link datatype — and
+  // that still does not make THIS input link-only.
+  const node = {
+    constructor: {
+      nodeData: { input: { required: { amount: ["ACME_VALUE", { default: 3, min: 0, max: 10 }] } } },
+    },
+  };
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(node, {}, ACME_OUTPUT_PROOF),
+    ["ACME_VALUE"],
+    "output-side proof alone must not waive a value-declaring input",
+  );
+  // …and it clears the moment the widget constructor actually registers, which is the
+  // only thing that makes the node valid.
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(node, { ACME_VALUE: () => {} }, ACME_OUTPUT_PROOF),
+    [],
+  );
+});
+
+test("#626: a socket-SHAPED input of a proven link type is still waived (#620/#608 preserved)", () => {
+  // The discriminating half. Identical type, identical output-side proof — the ONLY
+  // difference is that this input declares no value config, i.e. it is asking for a
+  // link. Without this the guard would fail closed forever on third-party socket
+  // datatypes again, which is the regression #620/#608 were about.
+  const node = {
+    constructor: { nodeData: { input: { required: { thing: ["ACME_VALUE", {}] } } } },
+  };
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(node, {}, ACME_OUTPUT_PROOF), []);
+  // A null/absent config is the same statement.
+  const bare = {
+    constructor: { nodeData: { input: { required: { thing: ["ACME_VALUE"] } } } },
+  };
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(bare, {}, ACME_OUTPUT_PROOF), []);
+  // `tooltip` and `lazy` say nothing about widget-vs-socket and must not flip it.
+  const annotated = {
+    constructor: {
+      nodeData: { input: { required: { thing: ["ACME_VALUE", { tooltip: "hi", lazy: true }] } } },
+    },
+  };
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(annotated, {}, ACME_OUTPUT_PROOF), []);
+});
+
+test("#626: one socket-shaped input does NOT waive a SIBLING of the same type that declares a value", () => {
+  // A def can require the same datatype twice, once as a link and once as a widget.
+  // Waiving the widget one because its sibling is a socket reproduces the same error a
+  // level down, so the waiver needs EVERY required input of the type to be socket-shaped.
+  const node = {
+    constructor: {
+      nodeData: {
+        input: {
+          required: {
+            wired: ["ACME_VALUE", {}],
+            typed: ["ACME_VALUE", { default: 1 }],
+          },
+        },
+      },
+    },
+  };
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(node, {}, ACME_OUTPUT_PROOF), ["ACME_VALUE"]);
+});
+
+test("#626: an explicit forceInput/widget:false still reads as a socket even with value config", () => {
+  // An explicit socket flag is the strongest input-level statement there is and settles
+  // it outright — inputWidgetType already drops these, so they never reach the guard.
+  const node = {
+    constructor: {
+      nodeData: {
+        input: { required: { amount: ["ACME_VALUE", { default: 3, forceInput: true }] } },
+      },
+    },
+  };
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(node, {}, new Set()), []);
+});
+
+// ---- #626 P0-2: the node is built from STALE nodeData, not the current definition ----
+
+function intWidget(value, options) {
+  return { name: "steps", type: "number", value, options: { ...options } };
+}
+
+test("#626: a required INT whose range moved takes the CURRENT default, not the stale one", () => {
+  // The reported fold: {default:1,min:0,max:10} -> {default:20,min:20,max:100}. Both
+  // signatures are `INT`, so drift does not fire, and LG.createNode builds from the
+  // registered nodeData — producing `1`, which the backend rejects at QUEUE time, far
+  // from its cause.
+  const node = { widgets: [intWidget(1, { min: 0, max: 10 })] };
+  const currentDef = { input: { required: { steps: ["INT", { default: 20, min: 20, max: 100 }] } } };
+  const corrections = applyCurrentDefWidgetValues(node, currentDef);
+  assert.equal(node.widgets[0].value, 20, "the value comes from the CURRENT definition");
+  assert.equal(node.widgets[0].options.min, 20, "bounds come from the current definition too");
+  assert.equal(node.widgets[0].options.max, 100);
+  // The correction is DISCLOSED, not applied silently — it is a value the caller did
+  // not ask for, even though it is the right one.
+  assert.deepEqual(corrections, [{ name: "steps", from: 1, to: 20 }]);
+});
+
+test("#626: bounds are written BEFORE the value, so a raised default is not clamped by the stale max", () => {
+  // Order is load-bearing: applying the value first against a stale max of 10 would
+  // clamp 20 back to 10 and ship an out-of-range value while reporting a correction.
+  const node = { widgets: [intWidget(1, { min: 0, max: 10 })] };
+  applyCurrentDefWidgetValues(node, {
+    input: { required: { steps: ["INT", { default: 20, min: 20, max: 100 }] } },
+  });
+  assert.equal(node.widgets[0].value, 20);
+});
+
+test("#626: a value outside the CURRENT range with no declared default is clamped and reported", () => {
+  const node = { widgets: [intWidget(1, { min: 0, max: 10 })] };
+  const corrections = applyCurrentDefWidgetValues(node, {
+    input: { required: { steps: ["INT", { min: 20, max: 100 }] } },
+  });
+  assert.equal(node.widgets[0].value, 20, "clamped up to the current minimum");
+  assert.deepEqual(corrections, [{ name: "steps", from: 1, to: 20 }]);
+});
+
+test("#626: an UNCHANGED definition produces NO corrections, so nothing is disclosed", () => {
+  // Keeps the ordinary add byte-identical to before: an empty list means the payload
+  // carries no correction key and no warning at all.
+  const node = { widgets: [intWidget(20, { min: 20, max: 100 })] };
+  assert.deepEqual(
+    applyCurrentDefWidgetValues(node, {
+      input: { required: { steps: ["INT", { default: 20, min: 20, max: 100 }] } },
+    }),
+    [],
+  );
+  assert.equal(node.widgets[0].value, 20);
+});
+
+test("#626: no current definition (a frontend-only type) leaves the node untouched", () => {
+  const node = { widgets: [intWidget(1, { min: 0, max: 10 })] };
+  assert.deepEqual(applyCurrentDefWidgetValues(node, undefined), []);
+  assert.deepEqual(applyCurrentDefWidgetValues(node, {}), []);
+  assert.equal(node.widgets[0].value, 1);
+});
+
+test("#626: an input with NO materialized widget is not invented into one", () => {
+  // A socket input has no widget, and reconciliation must not create one — that would
+  // put a value on a slot the user is expected to wire.
+  const node = { widgets: [] };
+  assert.deepEqual(
+    applyCurrentDefWidgetValues(node, {
+      input: { required: { model: ["MODEL", {}], steps: ["INT", { default: 20 }] } },
+    }),
+    [],
+  );
+  assert.equal(node.widgets.length, 0);
+});
+
+test("#626: graph_add_node actually CONSUMES the reconciliation and discloses it", () => {
+  // Without this the helper could be perfectly correct and entirely unwired.
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /applyCurrentDefWidgetValues,/, "imported");
+  assert.match(
+    src,
+    /const valueCorrections = applyCurrentDefWidgetValues\(node, currentDef\);/,
+    "called on the created node with the CURRENT def",
+  );
+  assert.match(src, /added\.schema_value_corrections = valueCorrections;/, "disclosed on the result");
+  // …and it must run BEFORE the node is added to the graph, or the graph briefly holds
+  // the stale value and an undo step captures it.
+  assert.ok(
+    src.indexOf("const valueCorrections = applyCurrentDefWidgetValues(node, currentDef);") <
+      src.indexOf("      graph.add(node);"),
+    "reconciliation must precede graph.add",
+  );
 });

--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   missingRequiredWidgetMaterializations,
+  registeredSocketTypes,
   requiredWidgetInputTypes,
   unavailableRequiredCustomWidgetTypes,
 } from "../../web/js/lib/node-widget-materialization.js";
@@ -146,27 +147,73 @@ test("native VIDEO socket resolves via registry proof (#608 SaveVideo)", () => {
   );
 });
 
-test("canvasOnly upload control counts as materialized while a plain serialize:false widget stays missing (#620 LoadImage)", () => {
+test("frontend-injected upload input is not guarded once the backend proves it never requires it (#620 LoadImage)", () => {
   const node = {
     widgets: [
       // ComfyUI's own IMAGEUPLOAD button: deliberately serialize:false,
       // canvasOnly:true — a canvas control paired with the real value widget.
       { name: "upload", options: { serialize: false, canvasOnly: true } },
-      { name: "gallery", options: { serialize: false } },
+      { name: "image" },
     ],
     constructor: {
       nodeData: {
         input: {
           required: {
+            image: [["a.png", "b.png"], {}],
             upload: ["IMAGEUPLOAD", {}],
-            gallery: ["ZIPN_STYLE_GALLERY", {}],
           },
         },
       },
     },
   };
+  // Live /object_info for LoadImage reports required = image only: `upload`
+  // is 100% frontend-injected, so it can never be a missing prompt value and
+  // neither guard may reject over it.
+  const backendRequired = new Set(["image"]);
   assert.deepEqual(
-    missingRequiredWidgetMaterializations(node, { ...widgetConstructors, IMAGEUPLOAD: () => {} }),
+    missingRequiredWidgetMaterializations(
+      node,
+      { COMBO: () => {}, IMAGEUPLOAD: () => {} },
+      backendRequired,
+    ),
+    [],
+  );
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(node, { COMBO: () => {} }, undefined, backendRequired),
+    [],
+  );
+});
+
+test("a canvasOnly serialize:false widget for a BACKEND-required input is still reported missing", () => {
+  // canvasOnly is a Vue-renderer display flag, not proof of non-prompt state;
+  // only the backend not requiring the input excuses a non-serializing widget.
+  const node = {
+    widgets: [{ name: "gallery", options: { serialize: false, canvasOnly: true } }],
+    constructor: {
+      nodeData: {
+        input: {
+          required: { gallery: ["ZIPN_STYLE_GALLERY", {}] },
+        },
+      },
+    },
+  };
+  assert.deepEqual(
+    missingRequiredWidgetMaterializations(node, widgetConstructors, new Set(["gallery"])),
     ["gallery"],
   );
+});
+
+test("registeredSocketTypes derives link datatypes from registered node outputs", () => {
+  const registry = {
+    InpaintCropImproved: { nodeData: { output: ["IMAGE", "MASK", "STITCHER"] } },
+    LoadVideo: { nodeData: { output: ["VIDEO", "AUDIO"] } },
+    Broken: { nodeData: { output: "NOT_AN_ARRAY" } },
+    Empty: {},
+  };
+  const types = registeredSocketTypes(registry);
+  assert.deepEqual(registeredSocketTypes(undefined), new Set());
+  assert.ok(types.has("STITCHER"));
+  assert.ok(types.has("VIDEO"));
+  assert.ok(types.has("MASK"));
+  assert.equal(types.size, 5);
 });

--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -203,14 +203,14 @@ test("a canvasOnly serialize:false widget for a BACKEND-required input is still 
   );
 });
 
-test("registeredSocketTypes derives link datatypes from registered node outputs", () => {
-  const registry = {
-    InpaintCropImproved: { nodeData: { output: ["IMAGE", "MASK", "STITCHER"] } },
-    LoadVideo: { nodeData: { output: ["VIDEO", "AUDIO"] } },
-    Broken: { nodeData: { output: "NOT_AN_ARRAY" } },
+test("registeredSocketTypes derives link datatypes from fresh /object_info outputs", () => {
+  const objectInfoDefs = {
+    InpaintCropImproved: { output: ["IMAGE", "MASK", "STITCHER"] },
+    LoadVideo: { output: ["VIDEO", "AUDIO"] },
+    Broken: { output: "NOT_AN_ARRAY" },
     Empty: {},
   };
-  const types = registeredSocketTypes(registry);
+  const types = registeredSocketTypes(objectInfoDefs);
   assert.deepEqual(registeredSocketTypes(undefined), new Set());
   assert.ok(types.has("STITCHER"));
   assert.ok(types.has("VIDEO"));

--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -91,3 +91,82 @@ test("a forceInput declaration remains a wireable socket", () => {
   assert.deepEqual(missingRequiredWidgetMaterializations(node, { ...widgetConstructors, STRING: () => {} }), []);
   assert.deepEqual(requiredWidgetInputTypes(node), ["ZIPN_STYLE_GALLERY", "ZIPN_SPACER", "CLIP"]);
 });
+
+test("core MASK required input is a safe socket (#620 SetLatentNoiseMask)", () => {
+  const node = {
+    constructor: {
+      nodeData: {
+        input: {
+          required: {
+            samples: ["LATENT", {}],
+            mask: ["MASK", {}],
+          },
+        },
+      },
+    },
+  };
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(node, {}), []);
+});
+
+test("third-party socket type is available only once the live registry proves it (#620 STITCHER)", () => {
+  const node = {
+    constructor: {
+      nodeData: {
+        input: {
+          required: { stitcher: ["STITCHER", {}] },
+        },
+      },
+    },
+  };
+  // No registry proof: indistinguishable from a widget pending its extension
+  // hook — still fails closed, exactly as #580 requires.
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(node, {}), ["STITCHER"]);
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(node, {}, new Set()), ["STITCHER"]);
+  // Some registered node declaring STITCHER as an OUTPUT proves it is a link
+  // datatype no widget constructor will ever appear for.
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(node, {}, new Set(["STITCHER"])), []);
+});
+
+test("native VIDEO socket resolves via registry proof (#608 SaveVideo)", () => {
+  const node = {
+    constructor: {
+      nodeData: {
+        input: {
+          required: {
+            video: ["VIDEO", {}],
+            filename_prefix: ["STRING", {}],
+          },
+        },
+      },
+    },
+  };
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(node, { STRING: () => {} }, new Set(["VIDEO"])),
+    [],
+  );
+});
+
+test("canvasOnly upload control counts as materialized while a plain serialize:false widget stays missing (#620 LoadImage)", () => {
+  const node = {
+    widgets: [
+      // ComfyUI's own IMAGEUPLOAD button: deliberately serialize:false,
+      // canvasOnly:true — a canvas control paired with the real value widget.
+      { name: "upload", options: { serialize: false, canvasOnly: true } },
+      { name: "gallery", options: { serialize: false } },
+    ],
+    constructor: {
+      nodeData: {
+        input: {
+          required: {
+            upload: ["IMAGEUPLOAD", {}],
+            gallery: ["ZIPN_STYLE_GALLERY", {}],
+          },
+        },
+      },
+    },
+  };
+  assert.deepEqual(
+    missingRequiredWidgetMaterializations(node, { ...widgetConstructors, IMAGEUPLOAD: () => {} }),
+    ["gallery"],
+  );
+});

--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -275,6 +275,43 @@ test("a same-name required input whose TYPE changed mid-session is drift", () =>
   assert.deepEqual(driftedRequiredInputNames(currentDef, staleNode), ["mode", "style"]);
 });
 
+test("defaultInput renders a socket, and a widget<->defaultInput flip mid-session is drift", () => {
+  // defaultInput: the input is a socket BY DEFAULT (no widget materialized),
+  // convertible back by the user — the guards must not demand a widget.
+  const socketByDefault = {
+    constructor: {
+      nodeData: {
+        input: { required: { value: ["INT", { defaultInput: true }] } },
+      },
+    },
+  };
+  assert.deepEqual(requiredWidgetInputTypes(socketByDefault), []);
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(socketByDefault, { INT: () => {} }),
+    [],
+  );
+  assert.deepEqual(
+    missingRequiredWidgetMaterializations(
+      { ...socketByDefault, widgets: [] },
+      { INT: () => {} },
+    ),
+    [],
+  );
+  // Widget -> defaultInput socket: the fresh def wants a socket, the stale
+  // constructor would build a widget — drift must refuse with a reload remedy.
+  const widgetShape = {
+    constructor: {
+      nodeData: { input: { required: { value: ["INT", {}] } } },
+    },
+  };
+  const socketDef = { input: { required: { value: ["INT", { defaultInput: true }] } } };
+  assert.deepEqual(driftedRequiredInputNames(socketDef, widgetShape), ["value"]);
+  // defaultInput socket -> widget: the reverse flip is drift too (otherwise
+  // the stale socket-shaped node would be reported as missing a widget).
+  const widgetDef = { input: { required: { value: ["INT", {}] } } };
+  assert.deepEqual(driftedRequiredInputNames(widgetDef, socketByDefault), ["value"]);
+});
+
 test("raw /object_info snake_case force_input remains a wireable socket", () => {
   const node = {
     constructor: {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -198,6 +198,7 @@ import { deferChangeTrackerSnapshot } from "./lib/change-tracker-snapshot.js";
 import { coerceMessageText, isDroppedAgentReplay, serializeContext } from "./lib/chat-serialize.js";
 import {
   missingRequiredWidgetMaterializations,
+  registeredSocketTypes,
   unavailableRequiredCustomWidgetTypes,
 } from "./lib/node-widget-materialization.js";
 import { sameGraphMutationContext } from "./lib/graph-mutation-context.js";
@@ -6475,27 +6476,15 @@ function placementFor(graph, pos) {
 const CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS = 5000;
 const CUSTOM_WIDGET_REGISTRATION_POLL_MS = 25;
 
-/** Datatypes some REGISTERED node declares as an OUTPUT are link sockets, not
- *  widgets pending registration — a widget constructor will never appear for
- *  them. Derived from the live registry so third-party socket types (#620
- *  STITCHER) and core types the allowlist missed (#608 VIDEO) resolve without
- *  an allowlist that can only ever be incomplete. */
-function registeredSocketTypes(LG) {
-  const types = new Set();
-  for (const ctor of Object.values(LG?.registered_node_types ?? {})) {
-    const outputs = ctor?.nodeData?.output;
-    if (!Array.isArray(outputs)) continue;
-    for (const out of outputs) {
-      if (typeof out === "string" && out) types.add(out);
-    }
-  }
-  return types;
-}
-
-async function awaitRequiredCustomWidgetRegistration(nodeData, comfyApp, LG) {
+async function awaitRequiredCustomWidgetRegistration(nodeData, comfyApp, LG, requiredInputNames) {
   const deadline = Date.now() + CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS;
   const check = () =>
-    unavailableRequiredCustomWidgetTypes(nodeData, comfyApp?.widgets, registeredSocketTypes(LG));
+    unavailableRequiredCustomWidgetTypes(
+      nodeData,
+      comfyApp?.widgets,
+      registeredSocketTypes(LG?.registered_node_types),
+      requiredInputNames,
+    );
   let unavailable = check();
   while (Date.now() < deadline) {
     if (!unavailable.length) return;
@@ -7743,15 +7732,27 @@ const GRAPH_TOOL_EXECUTORS = {
     // this ONE call is refused with a retry-in-a-moment message — a late response still
     // seeds, so the next call succeeds without a reload.
     await awaitObjectInfoHistorySeed();
+    // Captured from the SAME fresh /object_info the resolvability assert just
+    // fetched, so the widget guards below can restrict themselves to the inputs
+    // the BACKEND actually requires (#620: the frontend-injected `upload` input
+    // on LoadImage & friends is never in this set and can never be a missing
+    // prompt value). `undefined` when the type is a frontend-only exemption
+    // (no backend def exists), which preserves the unfiltered guard.
+    let freshDefs = null;
     await assertAddNodeResolvableRefreshing(() => LG?.registered_node_types ?? {}, class_type, {
       getFreshObjectInfo: async () =>
-        recordObjectInfoTypes(
+        (freshDefs = recordObjectInfoTypes(
           typeof api?.getNodeDefs === "function" ? await api.getNodeDefs() : null,
-        ),
+        )),
       refresh: (defs) => refreshComfyNodeDefs(defs),
       // #458 OBSERVED-BACKEND-HISTORY trust root, identical to graph_set_widget's.
       wasTypeEverDefined: (t) => objectInfoHistory.wasTypeEverDefined(t),
     });
+    const backendRequired = freshDefs?.[class_type]?.input?.required;
+    const backendRequiredNames =
+      backendRequired && typeof backendRequired === "object"
+        ? new Set(Object.keys(backendRequired))
+        : undefined;
     // registerNodesFromDefs can expose a newly installed V3 class before its
     // extension's asynchronous custom-widget registry settles. Resolve the
     // required constructors before creating anything, or fail retryably before
@@ -7760,6 +7761,7 @@ const GRAPH_TOOL_EXECUTORS = {
       LG?.registered_node_types?.[class_type]?.nodeData,
       comfyApp,
       LG,
+      backendRequiredNames,
     );
     const node = LG.createNode(class_type);
     if (!node) {
@@ -7767,7 +7769,11 @@ const GRAPH_TOOL_EXECUTORS = {
         `Unknown node type "${class_type}" — check the exact class_type via get_node_info`,
       );
     }
-    const missingWidgets = missingRequiredWidgetMaterializations(node, comfyApp?.widgets);
+    const missingWidgets = missingRequiredWidgetMaterializations(
+      node,
+      comfyApp?.widgets,
+      backendRequiredNames,
+    );
     if (missingWidgets.length) {
       throw new Error(
         `Required custom widget${missingWidgets.length === 1 ? "" : "s"} ` +

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -6475,13 +6475,32 @@ function placementFor(graph, pos) {
 const CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS = 5000;
 const CUSTOM_WIDGET_REGISTRATION_POLL_MS = 25;
 
-async function awaitRequiredCustomWidgetRegistration(nodeData, comfyApp) {
+/** Datatypes some REGISTERED node declares as an OUTPUT are link sockets, not
+ *  widgets pending registration — a widget constructor will never appear for
+ *  them. Derived from the live registry so third-party socket types (#620
+ *  STITCHER) and core types the allowlist missed (#608 VIDEO) resolve without
+ *  an allowlist that can only ever be incomplete. */
+function registeredSocketTypes(LG) {
+  const types = new Set();
+  for (const ctor of Object.values(LG?.registered_node_types ?? {})) {
+    const outputs = ctor?.nodeData?.output;
+    if (!Array.isArray(outputs)) continue;
+    for (const out of outputs) {
+      if (typeof out === "string" && out) types.add(out);
+    }
+  }
+  return types;
+}
+
+async function awaitRequiredCustomWidgetRegistration(nodeData, comfyApp, LG) {
   const deadline = Date.now() + CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS;
-  let unavailable = unavailableRequiredCustomWidgetTypes(nodeData, comfyApp?.widgets);
+  const check = () =>
+    unavailableRequiredCustomWidgetTypes(nodeData, comfyApp?.widgets, registeredSocketTypes(LG));
+  let unavailable = check();
   while (Date.now() < deadline) {
     if (!unavailable.length) return;
     await new Promise((resolve) => setTimeout(resolve, CUSTOM_WIDGET_REGISTRATION_POLL_MS));
-    unavailable = unavailableRequiredCustomWidgetTypes(nodeData, comfyApp?.widgets);
+    unavailable = check();
   }
   if (!unavailable.length) return;
   throw new Error(
@@ -7740,6 +7759,7 @@ const GRAPH_TOOL_EXECUTORS = {
     await awaitRequiredCustomWidgetRegistration(
       LG?.registered_node_types?.[class_type]?.nodeData,
       comfyApp,
+      LG,
     );
     const node = LG.createNode(class_type);
     if (!node) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -6476,13 +6476,18 @@ function placementFor(graph, pos) {
 const CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS = 5000;
 const CUSTOM_WIDGET_REGISTRATION_POLL_MS = 25;
 
-async function awaitRequiredCustomWidgetRegistration(nodeData, comfyApp, LG, requiredInputNames) {
+async function awaitRequiredCustomWidgetRegistration(
+  nodeData,
+  comfyApp,
+  knownSocketTypes,
+  requiredInputNames,
+) {
   const deadline = Date.now() + CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS;
   const check = () =>
     unavailableRequiredCustomWidgetTypes(
       nodeData,
       comfyApp?.widgets,
-      registeredSocketTypes(LG?.registered_node_types),
+      knownSocketTypes,
       requiredInputNames,
     );
   let unavailable = check();
@@ -7753,6 +7758,10 @@ const GRAPH_TOOL_EXECUTORS = {
       backendRequired && typeof backendRequired === "object"
         ? new Set(Object.keys(backendRequired))
         : undefined;
+    // Socket proof comes from the SAME fresh defs — NOT the LiteGraph
+    // registry, whose nodeData.output keeps stale positives for removed or
+    // schema-changed packs and would wrongly waive the guard.
+    const knownSocketTypes = registeredSocketTypes(freshDefs);
     // registerNodesFromDefs can expose a newly installed V3 class before its
     // extension's asynchronous custom-widget registry settles. Resolve the
     // required constructors before creating anything, or fail retryably before
@@ -7760,7 +7769,7 @@ const GRAPH_TOOL_EXECUTORS = {
     await awaitRequiredCustomWidgetRegistration(
       LG?.registered_node_types?.[class_type]?.nodeData,
       comfyApp,
-      LG,
+      knownSocketTypes,
       backendRequiredNames,
     );
     const node = LG.createNode(class_type);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7765,10 +7765,10 @@ const GRAPH_TOOL_EXECUTORS = {
     const drifted = driftedRequiredInputNames(currentDef, nodeData);
     if (drifted.length) {
       throw new Error(
-        `"${class_type}" gained required input${drifted.length === 1 ? "" : "s"} ` +
-          `${drifted.map((name) => `"${name}"`).join(", ")} since this page loaded its node ` +
-          "schema. Reload the ComfyUI tab so the frontend picks up the updated node " +
-          "definition, then retry.",
+        `"${class_type}" required input${drifted.length === 1 ? "" : "s"} ` +
+          `${drifted.map((name) => `"${name}"`).join(", ")} ${drifted.length === 1 ? "was" : "were"} ` +
+          "added or retyped since this page loaded its node schema. Reload the ComfyUI tab so " +
+          "the frontend picks up the updated node definition, then retry.",
       );
     }
     // Socket proof comes from the SAME fresh defs — NOT the LiteGraph

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -197,6 +197,7 @@ import { isLinkPersisted, removePhantomLink, isWidgetBackedInput } from "./lib/c
 import { deferChangeTrackerSnapshot } from "./lib/change-tracker-snapshot.js";
 import { coerceMessageText, isDroppedAgentReplay, serializeContext } from "./lib/chat-serialize.js";
 import {
+  applyCurrentDefWidgetValues,
   driftedRequiredInputNames,
   missingRequiredWidgetMaterializations,
   registeredSocketTypes,
@@ -7803,6 +7804,15 @@ const GRAPH_TOOL_EXECUTORS = {
           `"${class_type}". Reload ComfyUI so its node extension can register, then retry.`,
       );
     }
+    // LG.createNode built this from the REGISTERED nodeData, which is refreshed only for
+    // ABSENT classes — so a pack upgraded mid-session leaves the node holding the OLD
+    // defaults and bounds. Drift refuses a changed SHAPE above; a changed default/min/max
+    // keeps the same shape signature and would sail through, planting a value the current
+    // backend rejects at QUEUE time (or, when it happens to remain valid, an invented
+    // value that is not the current definition's). Reconcile against currentDef BEFORE
+    // the node reaches the graph, and DISCLOSE every correction — a silent fix is still
+    // a value the caller did not ask for.
+    const valueCorrections = applyCurrentDefWidgetValues(node, currentDef);
     // No await follows this validation. Re-read the graph/workflow now so a
     // tab or subgraph switch during the async preflight cannot commit to the
     // graph captured at command start.
@@ -7816,7 +7826,18 @@ const GRAPH_TOOL_EXECUTORS = {
       graph.afterChange();
     }
     graph.setDirtyCanvas(true, true);
-    return { added: summarizeNode(node) };
+    const added = summarizeNode(node);
+    if (valueCorrections.length) {
+      added.schema_value_corrections = valueCorrections;
+      added.warning =
+        `This ComfyUI's registered node schema for "${class_type}" is STALE (its pack changed since ` +
+        `this tab loaded). ${valueCorrections.length} widget value${valueCorrections.length === 1 ? " was" : "s were"} ` +
+        `taken from the backend's CURRENT definition instead of the stale one: ` +
+        `${valueCorrections.map((c) => `"${c.name}" ${JSON.stringify(c.from)} → ${JSON.stringify(c.to)}`).join(", ")}. ` +
+        `The node is valid to queue, but reload the ComfyUI tab to pick up the updated definition ` +
+        `before editing it further.`;
+    }
+    return { added };
   },
 
   graph_remove_node({ node_id }) {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -197,6 +197,7 @@ import { isLinkPersisted, removePhantomLink, isWidgetBackedInput } from "./lib/c
 import { deferChangeTrackerSnapshot } from "./lib/change-tracker-snapshot.js";
 import { coerceMessageText, isDroppedAgentReplay, serializeContext } from "./lib/chat-serialize.js";
 import {
+  driftedRequiredInputNames,
   missingRequiredWidgetMaterializations,
   registeredSocketTypes,
   unavailableRequiredCustomWidgetTypes,
@@ -6480,7 +6481,7 @@ async function awaitRequiredCustomWidgetRegistration(
   nodeData,
   comfyApp,
   knownSocketTypes,
-  requiredInputNames,
+  currentDef,
 ) {
   const deadline = Date.now() + CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS;
   const check = () =>
@@ -6488,7 +6489,7 @@ async function awaitRequiredCustomWidgetRegistration(
       nodeData,
       comfyApp?.widgets,
       knownSocketTypes,
-      requiredInputNames,
+      currentDef,
     );
   let unavailable = check();
   while (Date.now() < deadline) {
@@ -7738,11 +7739,12 @@ const GRAPH_TOOL_EXECUTORS = {
     // seeds, so the next call succeeds without a reload.
     await awaitObjectInfoHistorySeed();
     // Captured from the SAME fresh /object_info the resolvability assert just
-    // fetched, so the widget guards below can restrict themselves to the inputs
-    // the BACKEND actually requires (#620: the frontend-injected `upload` input
-    // on LoadImage & friends is never in this set and can never be a missing
-    // prompt value). `undefined` when the type is a frontend-only exemption
-    // (no backend def exists), which preserves the unfiltered guard.
+    // fetched. The widget guards below scan THIS def — the backend's current
+    // truth — not the possibly-stale registered nodeData: frontend-injected
+    // inputs (#620 LoadImage's `upload`) are absent from it and never
+    // guarded, and inputs the backend added since page load are still seen.
+    // `undefined` when the type is a frontend-only exemption (no backend def
+    // exists), which falls back to scanning the registered node data.
     let freshDefs = null;
     await assertAddNodeResolvableRefreshing(() => LG?.registered_node_types ?? {}, class_type, {
       getFreshObjectInfo: async () =>
@@ -7753,11 +7755,22 @@ const GRAPH_TOOL_EXECUTORS = {
       // #458 OBSERVED-BACKEND-HISTORY trust root, identical to graph_set_widget's.
       wasTypeEverDefined: (t) => objectInfoHistory.wasTypeEverDefined(t),
     });
-    const backendRequired = freshDefs?.[class_type]?.input?.required;
-    const backendRequiredNames =
-      backendRequired && typeof backendRequired === "object"
-        ? new Set(Object.keys(backendRequired))
-        : undefined;
+    const currentDef = freshDefs?.[class_type] ?? undefined;
+    const nodeData = LG?.registered_node_types?.[class_type]?.nodeData;
+    // A pack upgraded mid-session can add required inputs to an ALREADY
+    // registered class; the resolver only refreshes absent classes, so
+    // createNode would build the OLD shape — a new link input would not even
+    // get a slot and the node could never validate. Refuse before creating
+    // anything, with the remedy that actually updates the schema.
+    const drifted = driftedRequiredInputNames(currentDef, nodeData);
+    if (drifted.length) {
+      throw new Error(
+        `"${class_type}" gained required input${drifted.length === 1 ? "" : "s"} ` +
+          `${drifted.map((name) => `"${name}"`).join(", ")} since this page loaded its node ` +
+          "schema. Reload the ComfyUI tab so the frontend picks up the updated node " +
+          "definition, then retry.",
+      );
+    }
     // Socket proof comes from the SAME fresh defs — NOT the LiteGraph
     // registry, whose nodeData.output keeps stale positives for removed or
     // schema-changed packs and would wrongly waive the guard.
@@ -7767,10 +7780,10 @@ const GRAPH_TOOL_EXECUTORS = {
     // required constructors before creating anything, or fail retryably before
     // mutating the graph (#580).
     await awaitRequiredCustomWidgetRegistration(
-      LG?.registered_node_types?.[class_type]?.nodeData,
+      nodeData,
       comfyApp,
       knownSocketTypes,
-      backendRequiredNames,
+      currentDef,
     );
     const node = LG.createNode(class_type);
     if (!node) {
@@ -7781,7 +7794,7 @@ const GRAPH_TOOL_EXECUTORS = {
     const missingWidgets = missingRequiredWidgetMaterializations(
       node,
       comfyApp?.widgets,
-      backendRequiredNames,
+      currentDef,
     );
     if (missingWidgets.length) {
       throw new Error(

--- a/web/js/lib/connect-match.js
+++ b/web/js/lib/connect-match.js
@@ -215,20 +215,50 @@ export function resolveExplicitSlot(slots, ref) {
   return { error: "name" };
 }
 
-/** #406 — indices of the slots whose TYPE (not name) equals the string `ref`,
- *  case-insensitively/trimmed. Lets a caller address a port by its displayed type
- *  ("IMAGE", "LATENT") when no slot bears that literal name. Only string-typed
- *  slots participate (a combo/enum whose `type` is an array or number is never a
- *  type-name target). Returns [] when `ref` is not a usable string. */
+/** #406 — indices of the slots that ACCEPT the type named by the string `ref`, so a
+ *  caller can address a port by its displayed type ("IMAGE", "LATENT") when no slot
+ *  bears that literal name. Only string-typed slots participate (a combo/enum whose
+ *  `type` is an array or number is never a type-name target). Returns [] when `ref` is
+ *  not a usable string.
+ *
+ *  #651 — "accepts" is decided by the SAME isTypeCompatible predicate the auto-matcher
+ *  scores pairings with, NOT by naive string equality. Naive equality made the two
+ *  paths disagree: `panel_connect(ImageCrop.IMAGE -> SetNode."IMAGE")` was refused with
+ *  "No input on node 225 accepts type IMAGE" while the node's only input was a wildcard
+ *  `*` — a socket whose whole declaration is a POSITIVE statement that it accepts any
+ *  type. Reading `*` as "not IMAGE" is reading an unknown as a definite negative, and
+ *  it refused a connection the graph plainly supports (the same SetNode had carried an
+ *  IMAGE moments earlier). Two separate checks answering "does this slot accept IMAGE?"
+ *  will keep drifting apart; there is now one.
+ *
+ *  Ranked, and the tiers never mix: a slot whose declared type LITERALLY names `ref`
+ *  wins outright, and the wildcard tier is consulted ONLY when no such slot exists — so
+ *  a node with both an `IMAGE` and a `*` input still resolves "IMAGE" to the IMAGE
+ *  input, and addressing `"*"` literally still lands on the wildcard rather than tying
+ *  with every other slot. Several slots in the winning tier stay AMBIGUOUS and are
+ *  refused upstream; a wildcard does not license guessing between two of them. */
 export function typeMatchedIndices(slots, ref) {
   if (ref == null || typeof ref === "number") return [];
-  const want = String(ref).trim().toLowerCase();
+  const want = String(ref).trim();
   if (!want) return [];
-  const hits = [];
+  const wantLower = want.toLowerCase();
+  const literal = [];
+  const wildcard = [];
   (slots ?? []).forEach((s, i) => {
-    if (typeof s?.type === "string" && s.type.trim().toLowerCase() === want) hits.push(i);
+    const type = s?.type;
+    if (typeof type !== "string") return;
+    // Literal identity of the addressed name — this is what makes `"*"` address the
+    // wildcard slot itself instead of matching everything, and it covers a comma
+    // multi-type ("IMAGE,MASK") naming the requested type as one of its segments.
+    if (typeSegments(type).some((seg) => seg.toLowerCase() === wantLower)) {
+      literal.push(i);
+      return;
+    }
+    // Not literally this type — but the shared predicate may still say it accepts it,
+    // which for a non-combo slot means exactly one thing: it is a wildcard.
+    if (isTypeCompatible(want, type)) wildcard.push(i);
   });
-  return hits;
+  return literal.length ? literal : wildcard;
 }
 
 /** #406 — resolve a slot ref that matched no NAME against slot TYPES. EXACTLY one

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -111,19 +111,48 @@ export function registeredSocketTypes(objectInfoDefs) {
 }
 
 /**
- * Required input names the CURRENT backend def declares that the registered
- * (possibly stale) node definition does not have at all. A pack upgraded
- * mid-session can add required inputs to an ALREADY-registered class; the
- * registry is refreshed only for absent classes, so createNode would build
- * the OLD shape — a new link input would not even get a slot, and the node
- * could never validate. The caller refuses with a reload remedy instead.
+ * What about a required input declaration determines the SHAPE of the node
+ * createNode builds: the widget/socket type (combo choices included — a
+ * widget created from the old values list can hold a value the backend no
+ * longer accepts) and the forceInput/widget:false flags that decide socket
+ * vs widget. Benign config (default, min/max, tooltip) is deliberately not
+ * compared: a stale default still serializes a valid value.
+ */
+function inputShapeSignature(spec) {
+  if (!Array.isArray(spec)) return null;
+  const declared = spec[0];
+  const type = Array.isArray(declared)
+    ? `COMBO:${JSON.stringify(declared)}`
+    : typeof declared === "string"
+      ? declared
+      : null;
+  if (type === null) return null;
+  const config = spec[1];
+  const forced =
+    config &&
+    typeof config === "object" &&
+    (config.forceInput || config.force_input || config.widget === false);
+  return forced ? `${type}|socket` : type;
+}
+
+/**
+ * Required input names whose declaration in the CURRENT backend def the
+ * registered (possibly stale) node definition does not match. A pack
+ * upgraded mid-session can add required inputs — or CHANGE an existing
+ * one's type — on an ALREADY-registered class; the registry is refreshed
+ * only for absent classes, so createNode would build the OLD shape — a new
+ * link input would not even get a slot, and a retyped widget would hold a
+ * value the backend rejects. The caller refuses with a reload remedy
+ * instead.
  */
 export function driftedRequiredInputNames(currentDef, nodeOrNodeData) {
   const current = currentDef?.input?.required;
   if (!current || typeof current !== "object") return [];
   const stale = requiredInputs(nodeOrNodeData) ?? {};
   return Object.keys(current).filter(
-    (name) => !Object.prototype.hasOwnProperty.call(stale, name),
+    (name) =>
+      !Object.prototype.hasOwnProperty.call(stale, name) ||
+      inputShapeSignature(stale[name]) !== inputShapeSignature(current[name]),
   );
 }
 

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -86,17 +86,18 @@ export function unavailableRequiredCustomWidgetTypes(
 }
 
 /**
- * Datatypes some REGISTERED node declares as an OUTPUT are link sockets, not
- * widgets pending registration — a widget constructor will never appear for
- * them. Derived from the live LiteGraph registry (`registered_node_types`) so
- * third-party socket types (#620 STITCHER) and core types the allowlist
- * missed (#608 VIDEO) resolve without an allowlist that can only ever be
- * incomplete.
+ * Datatypes some CURRENT backend node declares as an OUTPUT are link sockets,
+ * not widgets pending registration — a widget constructor will never appear
+ * for them. Derived from a FRESH /object_info map (NOT the LiteGraph
+ * registry, which keeps stale nodeData.output positives for removed or
+ * schema-changed packs and would wrongly waive the guard) so third-party
+ * socket types (#620 STITCHER) and core types the allowlist missed (#608
+ * VIDEO) resolve without an allowlist that can only ever be incomplete.
  */
-export function registeredSocketTypes(registeredNodeTypes) {
+export function registeredSocketTypes(objectInfoDefs) {
   const types = new Set();
-  for (const ctor of Object.values(registeredNodeTypes ?? {})) {
-    const outputs = ctor?.nodeData?.output;
+  for (const def of Object.values(objectInfoDefs ?? {})) {
+    const outputs = def?.output;
     if (!Array.isArray(outputs)) continue;
     for (const out of outputs) {
       if (typeof out === "string" && out) types.add(out);

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -83,13 +83,84 @@ export function unavailableRequiredCustomWidgetTypes(
   knownSocketTypes,
   currentDef,
 ) {
-  return requiredWidgetInputTypes(currentDef ?? nodeOrNodeData).filter(
+  const source = currentDef ?? nodeOrNodeData;
+  const required = requiredInputs(source) ?? {};
+  // Types for which EVERY required input carrying them declares itself socket-shaped.
+  // "Every", not "some": a def can require the same datatype twice, once as a link and
+  // once as a widget, and waiving the widget one because its sibling is a socket would
+  // reproduce the very error this fixes one level down.
+  const socketDeclared = new Set();
+  const widgetDeclared = new Set();
+  for (const spec of Object.values(required)) {
+    const type = inputWidgetType(spec);
+    if (!type) continue;
+    (inputDeclaredAsSocket(spec) ? socketDeclared : widgetDeclared).add(type);
+  }
+  for (const type of widgetDeclared) socketDeclared.delete(type);
+  return requiredWidgetInputTypes(source).filter(
     (type) =>
       typeof widgetConstructors?.[type] !== "function" &&
       !SAFE_SOCKET_TYPES.has(type) &&
-      knownSocketTypes?.has?.(type) !== true,
+      // #626 P0: "some node OUTPUTS this type" does NOT establish that THIS input is
+      // link-only. ComfyUI's frontend supports converting widget inputs to links, so a
+      // widget-bearing input is link-compatible too — INT and a custom ACME_VALUE are
+      // both output by some node somewhere. The output side is evidence about the TYPE;
+      // the question asked here is about the INPUT. So the waiver now needs the
+      // input-level socket declaration as well: the type must be proven a link datatype
+      // AND every required input carrying it must declare itself socket-shaped.
+      !(knownSocketTypes?.has?.(type) === true && socketDeclared.has(type)),
   );
 }
+
+/**
+ * Whether a required input DECLARES itself as a link socket rather than a prompt value.
+ *
+ * This is the input-level half of the #626 waiver, and it is a POSITIVE reading of the
+ * declaration, not an absence: a widget input exists to carry a VALUE, and ComfyUI's
+ * input config is where that value's presence is declared — `default`, and the numeric/
+ * text/combo shaping (`min`/`max`/`step`/`multiline`/`options`/`control_after_generate`)
+ * that only a widget can honour. An input declaring none of them is asking for a link.
+ *
+ * Deliberately NOT inferred from the type: the same datatype can be a widget on one node
+ * and a socket on another, which is exactly why the output-side evidence was insufficient.
+ */
+export function inputDeclaredAsSocket(spec) {
+  if (!Array.isArray(spec)) return false;
+  // A legacy combo (choices as the first tuple item) is always a widget — it exists to
+  // select one of those choices, and nothing can link a choice in.
+  if (Array.isArray(spec[0])) return false;
+  const config = spec[1];
+  if (config == null) return true;
+  if (typeof config !== "object") return true;
+  // An explicit socket flag settles it outright.
+  if (config.forceInput || config.force_input || config.defaultInput || config.widget === false) {
+    return true;
+  }
+  return !WIDGET_VALUE_CONFIG_KEYS.some((key) =>
+    Object.prototype.hasOwnProperty.call(config, key),
+  );
+}
+
+// Config keys that only a WIDGET can honour — their presence is the input declaring it
+// carries a value. `tooltip`, `lazy`, `rawLink` and friends are deliberately absent:
+// they say nothing about widget-vs-socket and a socket input commonly carries them.
+const WIDGET_VALUE_CONFIG_KEYS = [
+  "default",
+  "min",
+  "max",
+  "step",
+  "round",
+  "precision",
+  "multiline",
+  "dynamicPrompts",
+  "dynamic_prompts",
+  "options",
+  "control_after_generate",
+  "image_upload",
+  "video_upload",
+  "audio_upload",
+  "placeholder",
+];
 
 /**
  * Datatypes some CURRENT backend node declares as an OUTPUT are link sockets,
@@ -156,6 +227,72 @@ export function driftedRequiredInputNames(currentDef, nodeOrNodeData) {
       !Object.prototype.hasOwnProperty.call(stale, name) ||
       inputShapeSignature(stale[name]) !== inputShapeSignature(current[name]),
   );
+}
+
+/** The numeric constraint / default a required input's CURRENT declaration carries. */
+function inputValueConfig(spec) {
+  const config = Array.isArray(spec) ? spec[1] : null;
+  return config && typeof config === "object" ? config : null;
+}
+
+/**
+ * Reconcile a JUST-CREATED node's widget values and numeric bounds against the CURRENT
+ * backend definition, returning the corrections that were applied.
+ *
+ * Why this exists (#626 P0): `LG.createNode` builds from the REGISTERED `nodeData`, and
+ * the registry is only refreshed for classes that are ABSENT. A pack upgraded mid-session
+ * keeps its stale entry, so a required INT that moved from
+ * `{default: 1, min: 0, max: 10}` to `{default: 20, min: 20, max: 100}` still matches on
+ * shape signature — both are `INT` — and the node is created holding `1`. That is out of
+ * range: the backend rejects it at QUEUE time, far from its cause, which is exactly the
+ * confusing-failure outcome an add-time check exists to prevent. And even when the stale
+ * value happens to remain valid it is an INVENTED value in the user's graph rather than
+ * the current definition's.
+ *
+ * Applied to a node the caller has just created and not yet placed, so every widget still
+ * holds the stale DEFAULT — there is no user intent here to overwrite. Bounds are written
+ * BEFORE the value, so a new default outside the old range is not clamped back out by a
+ * stale min/max. A value that is still outside the current range after both (a def that
+ * declares no default) is CLAMPED, and the clamp is reported like any other correction —
+ * silently shipping an out-of-range value is the defect, and silently fixing one without
+ * saying so is the fabrication.
+ *
+ * Pure apart from the node it is handed; returns [] when there is nothing current to
+ * compare against, so a frontend-only type is untouched.
+ */
+export function applyCurrentDefWidgetValues(node, currentDef) {
+  const required = currentDef?.input?.required;
+  if (!required || typeof required !== "object") return [];
+  const widgets = Array.isArray(node?.widgets) ? node.widgets : [];
+  const corrections = [];
+  for (const [name, spec] of Object.entries(required)) {
+    const widget = widgets.find((w) => w?.name === name);
+    if (!widget) continue; // a socket, or a widget that never materialized — not ours
+    const config = inputValueConfig(spec);
+    if (!config) continue;
+    const before = widget.value;
+    // 1) BOUNDS first, so a raised default is not clamped by a stale max.
+    const options = widget.options && typeof widget.options === "object" ? widget.options : null;
+    if (options) {
+      for (const key of ["min", "max", "step", "round", "precision"]) {
+        if (Object.prototype.hasOwnProperty.call(config, key) && options[key] !== config[key]) {
+          options[key] = config[key];
+        }
+      }
+    }
+    // 2) The VALUE comes from the CURRENT definition, never the stale registered one.
+    if (Object.prototype.hasOwnProperty.call(config, "default") && widget.value !== config.default) {
+      widget.value = config.default;
+    }
+    // 3) A numeric value still outside the CURRENT range (no default declared, or a
+    //    default the def itself contradicts) is clamped rather than shipped invalid.
+    if (typeof widget.value === "number" && Number.isFinite(widget.value)) {
+      if (typeof config.min === "number" && widget.value < config.min) widget.value = config.min;
+      if (typeof config.max === "number" && widget.value > config.max) widget.value = config.max;
+    }
+    if (widget.value !== before) corrections.push({ name, from: before, to: widget.value });
+  }
+  return corrections;
 }
 
 /**

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -41,9 +41,10 @@ export function requiredWidgetInputTypes(nodeOrNodeData) {
 // extension is still registering.
 const SAFE_SOCKET_TYPES = new Set([
   "*", "ANY", "AUDIO", "BBOX", "CLIP", "CLIP_VISION", "CLIP_VISION_OUTPUT",
-  "CONDITIONING", "CONTROL_NET", "GLIGEN", "GUIDER", "IMAGE", "IPADAPTER",
-  "LATENT", "MODEL", "NOISE", "SAMPLER", "SCHEDULER", "SIGMAS", "STYLE_MODEL",
-  "UNET", "UPSCALE_MODEL", "VAE",
+  "CONDITIONING", "CONTROL_NET", "GLIGEN", "GUIDER", "HOOKS", "IMAGE",
+  "IPADAPTER", "LATENT", "LATENT_OPERATION", "MASK", "MESH", "MODEL", "NOISE",
+  "SAMPLER", "SCHEDULER", "SIGMAS", "STYLE_MODEL", "UNET", "UPSCALE_MODEL",
+  "VAE", "VOXEL",
 ]);
 
 /**
@@ -51,10 +52,26 @@ const SAFE_SOCKET_TYPES = new Set([
  * live ComfyUI registry yet. Unknown custom socket types deliberately remain
  * unavailable: their schema is indistinguishable from a widget pending its
  * extension hook, so admitting one would reintroduce #580's bad prompt.
+ *
+ * `knownSocketTypes` lifts that ambiguity where the LIVE registry already
+ * proves the type is a link datatype (some registered node declares it as an
+ * OUTPUT — no widget constructor will ever appear for it). Without it the
+ * hardcoded allowlist above fails closed FOREVER on every third-party socket
+ * datatype (#620 STITCHER) and on core types the list missed (#620 MASK,
+ * #608 VIDEO), which no retry/refresh can ever clear. A still-unknown type
+ * with NO registry proof continues to fail closed, so #580's protection is
+ * intact.
  */
-export function unavailableRequiredCustomWidgetTypes(nodeOrNodeData, widgetConstructors) {
-  return requiredWidgetInputTypes(nodeOrNodeData).filter((type) =>
-    typeof widgetConstructors?.[type] !== "function" && !SAFE_SOCKET_TYPES.has(type),
+export function unavailableRequiredCustomWidgetTypes(
+  nodeOrNodeData,
+  widgetConstructors,
+  knownSocketTypes,
+) {
+  return requiredWidgetInputTypes(nodeOrNodeData).filter(
+    (type) =>
+      typeof widgetConstructors?.[type] !== "function" &&
+      !SAFE_SOCKET_TYPES.has(type) &&
+      knownSocketTypes?.has?.(type) !== true,
   );
 }
 
@@ -76,7 +93,16 @@ export function missingRequiredWidgetMaterializations(node, widgetConstructors) 
     // ComfyUI's prompt serializer reads the widget *options* flag. A widget
     // property named `serialize` is not authoritative and must not allow a
     // canvas-only control to satisfy a required prompt value.
-    if (!widget || widget.options?.serialize === false) missing.push(name);
+    //
+    // `options.canvasOnly` is the exception ComfyUI itself declares: the
+    // IMAGEUPLOAD button (frontend-injected `upload` input on LoadImage &
+    // friends) is created as
+    //   addWidget("button", name, "image", …, { serialize: false, canvasOnly: true })
+    // — a control PAIRED with a real value widget (`image`), never a prompt
+    // value of its own. Its presence proves the registered constructor ran,
+    // which is exactly what this guard asks (#620).
+    const canvasControl = widget?.options?.canvasOnly === true;
+    if (!widget || (widget.options?.serialize === false && !canvasControl)) missing.push(name);
   }
   return missing;
 }

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -28,11 +28,20 @@ function requiredInputs(nodeOrNodeData) {
  * The distinct required input types that are eligible to be frontend widgets.
  * `forceInput` / `widget:false` are sockets even if a custom widget constructor
  * happens to share their declared type.
+ *
+ * `requiredInputNames`, when a Set, restricts the scan to the inputs the
+ * BACKEND actually requires (fresh /object_info). Frontend-injected inputs
+ * (LoadImage's `upload` button, #620) are never in that set — the backend
+ * never asks for them, so they can never be a missing prompt value and must
+ * not be guarded.
  */
-export function requiredWidgetInputTypes(nodeOrNodeData) {
+export function requiredWidgetInputTypes(nodeOrNodeData, requiredInputNames) {
   const required = requiredInputs(nodeOrNodeData);
   if (!required) return [];
-  return [...new Set(Object.values(required).map(inputWidgetType).filter(Boolean))];
+  const entries = Object.entries(required).filter(
+    ([name]) => !(requiredInputNames instanceof Set) || requiredInputNames.has(name),
+  );
+  return [...new Set(entries.map(([, spec]) => inputWidgetType(spec)).filter(Boolean))];
 }
 
 // These are ComfyUI's built-in connection datatypes. A required input carrying
@@ -66,8 +75,9 @@ export function unavailableRequiredCustomWidgetTypes(
   nodeOrNodeData,
   widgetConstructors,
   knownSocketTypes,
+  requiredInputNames,
 ) {
-  return requiredWidgetInputTypes(nodeOrNodeData).filter(
+  return requiredWidgetInputTypes(nodeOrNodeData, requiredInputNames).filter(
     (type) =>
       typeof widgetConstructors?.[type] !== "function" &&
       !SAFE_SOCKET_TYPES.has(type) &&
@@ -76,33 +86,50 @@ export function unavailableRequiredCustomWidgetTypes(
 }
 
 /**
+ * Datatypes some REGISTERED node declares as an OUTPUT are link sockets, not
+ * widgets pending registration — a widget constructor will never appear for
+ * them. Derived from the live LiteGraph registry (`registered_node_types`) so
+ * third-party socket types (#620 STITCHER) and core types the allowlist
+ * missed (#608 VIDEO) resolve without an allowlist that can only ever be
+ * incomplete.
+ */
+export function registeredSocketTypes(registeredNodeTypes) {
+  const types = new Set();
+  for (const ctor of Object.values(registeredNodeTypes ?? {})) {
+    const outputs = ctor?.nodeData?.output;
+    if (!Array.isArray(outputs)) continue;
+    for (const out of outputs) {
+      if (typeof out === "string" && out) types.add(out);
+    }
+  }
+  return types;
+}
+
+/**
  * Return required inputs whose registered frontend widget did not materialize
  * on `node`.  A socket-only custom datatype is deliberately not reported: it
  * has no registered widget constructor and is valid to wire later.
  */
-export function missingRequiredWidgetMaterializations(node, widgetConstructors) {
+export function missingRequiredWidgetMaterializations(node, widgetConstructors, requiredInputNames) {
   const required = requiredInputs(node);
   if (!required) return [];
 
   const widgets = Array.isArray(node.widgets) ? node.widgets : [];
   const missing = [];
   for (const [name, spec] of Object.entries(required)) {
+    // Only inputs the BACKEND actually requires can fail prompt validation
+    // (#580). Frontend-injected inputs (LoadImage's `upload` button, #620 —
+    // created serialize:false/canvasOnly:true by ComfyUI's own
+    // Comfy.UploadImage extension) are never asked for by the backend, so
+    // they are skipped here instead of being misread as a missing value.
+    if (requiredInputNames instanceof Set && !requiredInputNames.has(name)) continue;
     const type = inputWidgetType(spec);
     if (!type || typeof widgetConstructors?.[type] !== "function") continue;
     const widget = widgets.find((candidate) => candidate?.name === name);
     // ComfyUI's prompt serializer reads the widget *options* flag. A widget
     // property named `serialize` is not authoritative and must not allow a
     // canvas-only control to satisfy a required prompt value.
-    //
-    // `options.canvasOnly` is the exception ComfyUI itself declares: the
-    // IMAGEUPLOAD button (frontend-injected `upload` input on LoadImage &
-    // friends) is created as
-    //   addWidget("button", name, "image", …, { serialize: false, canvasOnly: true })
-    // — a control PAIRED with a real value widget (`image`), never a prompt
-    // value of its own. Its presence proves the registered constructor ran,
-    // which is exactly what this guard asks (#620).
-    const canvasControl = widget?.options?.canvasOnly === true;
-    if (!widget || (widget.options?.serialize === false && !canvasControl)) missing.push(name);
+    if (!widget || widget.options?.serialize === false) missing.push(name);
   }
   return missing;
 }

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -8,8 +8,13 @@ function inputWidgetType(spec) {
   if (!Array.isArray(spec)) return null;
   const config = spec[1];
   // A forced socket is intentionally not materialized as a widget even when
-  // its type also has a widget constructor.
-  if (config && typeof config === "object" && (config.forceInput || config.widget === false)) {
+  // its type also has a widget constructor. The raw /object_info config keeps
+  // the snake_case spelling; the normalized frontend nodeData uses camelCase.
+  if (
+    config &&
+    typeof config === "object" &&
+    (config.forceInput || config.force_input || config.widget === false)
+  ) {
     return null;
   }
   const declared = spec[0];
@@ -28,20 +33,11 @@ function requiredInputs(nodeOrNodeData) {
  * The distinct required input types that are eligible to be frontend widgets.
  * `forceInput` / `widget:false` are sockets even if a custom widget constructor
  * happens to share their declared type.
- *
- * `requiredInputNames`, when a Set, restricts the scan to the inputs the
- * BACKEND actually requires (fresh /object_info). Frontend-injected inputs
- * (LoadImage's `upload` button, #620) are never in that set — the backend
- * never asks for them, so they can never be a missing prompt value and must
- * not be guarded.
  */
-export function requiredWidgetInputTypes(nodeOrNodeData, requiredInputNames) {
+export function requiredWidgetInputTypes(nodeOrNodeData) {
   const required = requiredInputs(nodeOrNodeData);
   if (!required) return [];
-  const entries = Object.entries(required).filter(
-    ([name]) => !(requiredInputNames instanceof Set) || requiredInputNames.has(name),
-  );
-  return [...new Set(entries.map(([, spec]) => inputWidgetType(spec)).filter(Boolean))];
+  return [...new Set(Object.values(required).map(inputWidgetType).filter(Boolean))];
 }
 
 // These are ComfyUI's built-in connection datatypes. A required input carrying
@@ -62,22 +58,30 @@ const SAFE_SOCKET_TYPES = new Set([
  * unavailable: their schema is indistinguishable from a widget pending its
  * extension hook, so admitting one would reintroduce #580's bad prompt.
  *
- * `knownSocketTypes` lifts that ambiguity where the LIVE registry already
- * proves the type is a link datatype (some registered node declares it as an
- * OUTPUT — no widget constructor will ever appear for it). Without it the
- * hardcoded allowlist above fails closed FOREVER on every third-party socket
- * datatype (#620 STITCHER) and on core types the list missed (#620 MASK,
- * #608 VIDEO), which no retry/refresh can ever clear. A still-unknown type
- * with NO registry proof continues to fail closed, so #580's protection is
- * intact.
+ * `currentDef` is the class's entry in a FRESH /object_info map. When given,
+ * it — not the possibly-stale registered nodeData — is the source of the
+ * required-input scan: frontend-injected inputs (LoadImage's `upload`
+ * button, #620) are absent from it and therefore never guarded, and inputs
+ * the backend ADDED since page load are still seen. A def present with no
+ * `input` means the backend requires nothing, so nothing is guarded. Omit
+ * it (frontend-only types have no backend def) to scan the node data.
+ *
+ * `knownSocketTypes` lifts the unknown-type ambiguity where the CURRENT
+ * backend already proves the type is a link datatype (some node in the same
+ * fresh /object_info declares it as an OUTPUT — no widget constructor will
+ * ever appear for it). Without it the hardcoded allowlist above fails closed
+ * FOREVER on every third-party socket datatype (#620 STITCHER) and on core
+ * types the list missed (#620 MASK, #608 VIDEO), which no retry/refresh can
+ * ever clear. A still-unknown type with NO proof continues to fail closed,
+ * so #580's protection is intact.
  */
 export function unavailableRequiredCustomWidgetTypes(
   nodeOrNodeData,
   widgetConstructors,
   knownSocketTypes,
-  requiredInputNames,
+  currentDef,
 ) {
-  return requiredWidgetInputTypes(nodeOrNodeData, requiredInputNames).filter(
+  return requiredWidgetInputTypes(currentDef ?? nodeOrNodeData).filter(
     (type) =>
       typeof widgetConstructors?.[type] !== "function" &&
       !SAFE_SOCKET_TYPES.has(type) &&
@@ -107,23 +111,40 @@ export function registeredSocketTypes(objectInfoDefs) {
 }
 
 /**
+ * Required input names the CURRENT backend def declares that the registered
+ * (possibly stale) node definition does not have at all. A pack upgraded
+ * mid-session can add required inputs to an ALREADY-registered class; the
+ * registry is refreshed only for absent classes, so createNode would build
+ * the OLD shape — a new link input would not even get a slot, and the node
+ * could never validate. The caller refuses with a reload remedy instead.
+ */
+export function driftedRequiredInputNames(currentDef, nodeOrNodeData) {
+  const current = currentDef?.input?.required;
+  if (!current || typeof current !== "object") return [];
+  const stale = requiredInputs(nodeOrNodeData) ?? {};
+  return Object.keys(current).filter(
+    (name) => !Object.prototype.hasOwnProperty.call(stale, name),
+  );
+}
+
+/**
  * Return required inputs whose registered frontend widget did not materialize
  * on `node`.  A socket-only custom datatype is deliberately not reported: it
  * has no registered widget constructor and is valid to wire later.
+ *
+ * `currentDef` has the same meaning as in unavailableRequiredCustomWidgetTypes:
+ * the fresh backend definition is the source of the required-input scan, so
+ * frontend-injected inputs (LoadImage's `upload`, #620) are never misread as
+ * a missing prompt value, and backend-required inputs the stale registry
+ * does not know yet are still checked.
  */
-export function missingRequiredWidgetMaterializations(node, widgetConstructors, requiredInputNames) {
-  const required = requiredInputs(node);
+export function missingRequiredWidgetMaterializations(node, widgetConstructors, currentDef) {
+  const required = requiredInputs(currentDef ?? node);
   if (!required) return [];
 
   const widgets = Array.isArray(node.widgets) ? node.widgets : [];
   const missing = [];
   for (const [name, spec] of Object.entries(required)) {
-    // Only inputs the BACKEND actually requires can fail prompt validation
-    // (#580). Frontend-injected inputs (LoadImage's `upload` button, #620 —
-    // created serialize:false/canvasOnly:true by ComfyUI's own
-    // Comfy.UploadImage extension) are never asked for by the backend, so
-    // they are skipped here instead of being misread as a missing value.
-    if (requiredInputNames instanceof Set && !requiredInputNames.has(name)) continue;
     const type = inputWidgetType(spec);
     if (!type || typeof widgetConstructors?.[type] !== "function") continue;
     const widget = widgets.find((candidate) => candidate?.name === name);

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -7,13 +7,15 @@
 function inputWidgetType(spec) {
   if (!Array.isArray(spec)) return null;
   const config = spec[1];
-  // A forced socket is intentionally not materialized as a widget even when
-  // its type also has a widget constructor. The raw /object_info config keeps
+  // A forced or default-rendered socket is intentionally not materialized as
+  // a widget even when its type also has a widget constructor: `forceInput` /
+  // `widget:false` are socket-only, and `defaultInput` renders the socket by
+  // default (convertible back by the user). The raw /object_info config keeps
   // the snake_case spelling; the normalized frontend nodeData uses camelCase.
   if (
     config &&
     typeof config === "object" &&
-    (config.forceInput || config.force_input || config.widget === false)
+    (config.forceInput || config.force_input || config.defaultInput || config.widget === false)
   ) {
     return null;
   }
@@ -114,9 +116,9 @@ export function registeredSocketTypes(objectInfoDefs) {
  * What about a required input declaration determines the SHAPE of the node
  * createNode builds: the widget/socket type (combo choices included — a
  * widget created from the old values list can hold a value the backend no
- * longer accepts) and the forceInput/widget:false flags that decide socket
- * vs widget. Benign config (default, min/max, tooltip) is deliberately not
- * compared: a stale default still serializes a valid value.
+ * longer accepts) and the forceInput/defaultInput/widget:false flags that
+ * decide socket vs widget. Benign config (default, min/max, tooltip) is
+ * deliberately not compared: a stale default still serializes a valid value.
  */
 function inputShapeSignature(spec) {
   if (!Array.isArray(spec)) return null;
@@ -131,7 +133,7 @@ function inputShapeSignature(spec) {
   const forced =
     config &&
     typeof config === "object" &&
-    (config.forceInput || config.force_input || config.widget === false);
+    (config.forceInput || config.force_input || config.defaultInput || config.widget === false);
   return forced ? `${type}|socket` : type;
 }
 


### PR DESCRIPTION
## Issues in this cluster

- #620 — panel_add_node falsely rejects nodes whose required inputs are link-only custom/MASK types
- #608 — panel_add_node cannot add native SaveVideo: VIDEO widget not registered
- #580 — panel_add_node omits required custom widget values for V3 nodes (the guard this PR keeps intact)

## What changed

The #580 pre-creation guard failed closed on any required input type absent from a hardcoded allowlist — permanently, since no widget constructor ever registers for a link datatype. Both add-node guards now run off the **fresh /object_info entry** that graph_add_node already fetches for its resolvability assert, instead of the possibly-stale registered nodeData:

- **`unavailableRequiredCustomWidgetTypes`** admits a type when (a) a widget constructor is registered, (b) it is in the (extended) core allowlist — MASK, HOOKS, LATENT_OPERATION, MESH, VOXEL added, or (c) the **fresh backend defs prove it is a link datatype** (some current node declares it as an OUTPUT — STITCHER, VIDEO). A still-unknown type with no proof continues to fail closed, so #580's protection is intact.
- **`missingRequiredWidgetMaterializations`** scans the backend def, so frontend-injected inputs (LoadImage's `upload` button, serialize:false/canvasOnly:true) are never misread as a missing prompt value. A def present with no required inputs enforces nothing; a frontend-only type (no def) falls back to scanning the registered node data.
- **`driftedRequiredInputNames`** (new) refuses the add before createNode — with a reload remedy — when a pack upgraded mid-session added or **retyped** a required input on an already-registered class (shape signature: widget/socket type incl. combo choices + forceInput/force_input/defaultInput/widget:false; benign config like defaults deliberately not compared).
- `inputWidgetType` honours the raw snake_case `force_input` spelling from /object_info and treats `defaultInput` as a socket.

## Verification

- `node --test browser_tests/unit/*.test.mjs` → **1785 pass / 0 fail** (incl. 10 new tests in node-widget-materialization.test.mjs).
- Every clause mutation-verified (each semantic mutant fails exactly its matching test).
- `node --check` on the panel as .mjs passes; committed blobs control-byte-clean.
- 6 codex adversarial gate rounds → PASS.
- Pre-existing timer flake in manager-install.test.mjs (`waitForQueueDrain`, ~1 in 4 on this machine) is unrelated: the extracted function is byte-identical to base and that test file is untouched by this diff.

Live-browser confirmation still open: actually adding LoadImage / SetLatentNoiseMask / SaveVideo / InpaintStitchImproved on a live canvas.