### PR TITLE
panel_get_errors: stale after a widget change, resolved models still missing, and a timeout on a live tab

### DIFF
--- a/browser_tests/unit/asset-staleness.test.mjs
+++ b/browser_tests/unit/asset-staleness.test.mjs
@@ -229,6 +229,61 @@ test("assetCandidateStillReferenced fails OPEN when the node is gone", () => {
   assert.equal(assetCandidateStillReferenced(graphOf([]), 99, "x.safetensors"), true);
 });
 
+// ---- #586: stale missing_media after a LoadImage widget change ----
+// The missingMedia Pinia store is populated at workflow LOAD; after the user
+// repoints the node's image widget to a different file, the load-time candidate
+// for the OLD value must no longer be reported. The drop must come from the
+// WIDGET-REFERENCE cross-check — so pin it with trustCombo:false (the combo
+// clear path inert) and a node that provably still exists (the scope-drop path
+// inert). Mirroring the issue's repro: node 2129, load-time value
+// 20260707_130607992_iOS.jpg, widget changed to helloe.png.
+test("isStaleAssetCandidate drops a missing-MEDIA candidate whose LoadImage widget moved to a new file (#586)", () => {
+  const node = {
+    id: 2129,
+    type: "LoadImage",
+    widgets: [{ name: "image", value: "helloe.png", options: { values: ["helloe.png"] } }],
+  };
+  const candidate = {
+    nodeId: "2129",
+    name: "20260707_130607992_iOS.jpg",
+    widgetName: "image",
+    mediaType: "image",
+    isMissing: true,
+  };
+  // Assert the REASON, not just the verdict: with no combo trust and the node
+  // present, only the still-referenced check can drop it.
+  assert.equal(
+    assetCandidateStillReferenced(graphOf([node]), "2129", "20260707_130607992_iOS.jpg"),
+    false,
+    "no widget still holds the old file",
+  );
+  assert.equal(
+    isStaleAssetCandidate(graphOf([node]), candidate, { trustCombo: false }),
+    true,
+  );
+});
+
+test("isStaleAssetCandidate KEEPS the media candidate while the widget still holds the missing file (#586 control)", () => {
+  const node = {
+    id: 2129,
+    type: "LoadImage",
+    widgets: [{ name: "image", value: "helloe.png", options: { values: ["helloe.png"] } }],
+  };
+  const candidate = {
+    nodeId: "2129",
+    name: "helloe.png",
+    widgetName: "image",
+    mediaType: "image",
+    isMissing: true,
+  };
+  // trustCombo stays false: a genuinely missing current value must survive even
+  // though the combo lists it (an untrusted combo may be a stale snapshot).
+  assert.equal(
+    isStaleAssetCandidate(graphOf([node]), candidate, { trustCombo: false }),
+    false,
+  );
+});
+
 test("assetCandidateResolvesLive: true when the file is now a live combo value (#223/#185)", () => {
   const node = {
     id: 4,

--- a/browser_tests/unit/get-errors-budget.test.mjs
+++ b/browser_tests/unit/get-errors-budget.test.mjs
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for web/js/lib/get-errors-budget.js — run with `node --test`.
+ *
+ * Covers the #610/#589 budget invariants:
+ *   - the refresh cap covers the observed slow-install /object_info (#610);
+ *   - the TOTAL elective-wait budget stays under the orchestrator's 20 s
+ *     ui-bridge read timeout so graph_get_errors can never go silent past it
+ *     on a live tab (#589);
+ *   - sequential steps consuming the shared budget can never sum past it;
+ *   - an exhausted budget or a broken clock yields 0 ⇒ the step is SKIPPED
+ *     and fails closed (over-report), never a hung call.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  GET_ERRORS_TOTAL_BUDGET_MS,
+  GET_ERRORS_REFRESH_CAP_MS,
+  GET_ERRORS_STEP_CAP_MS,
+  getErrorsStepBudgetMs,
+} from "../../web/js/lib/get-errors-budget.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PANEL_SOURCE = readFileSync(
+  join(__dirname, "..", "..", "web", "js", "comfyui-mcp-panel.js"),
+  "utf8",
+);
+
+// The orchestrator side of this invariant: BRIDGE_READ_DEFAULT_TIMEOUT_MS in
+// comfyui-mcp's services/ui-bridge.ts. Duplicated as a literal on purpose —
+// if EITHER side moves, this test forces the relationship to be re-examined.
+const ORCHESTRATOR_READ_TIMEOUT_MS = 20000;
+
+test("the total budget stays under the orchestrator's 20 s read timeout (#589)", () => {
+  assert.ok(
+    GET_ERRORS_TOTAL_BUDGET_MS < ORCHESTRATOR_READ_TIMEOUT_MS,
+    `total budget ${GET_ERRORS_TOTAL_BUDGET_MS} must leave reply margin under the bridge's ${ORCHESTRATOR_READ_TIMEOUT_MS} ms`,
+  );
+});
+
+test("the refresh cap covers the observed ~14.5 s slow-install /object_info (#610)", () => {
+  // #610 measured ~14.5 s for a forced /object_info + combo refresh on a real
+  // Windows install; the old 4000 ms cap fired first and kept verified models
+  // reporting missing. The cap must exceed that observation.
+  assert.ok(GET_ERRORS_REFRESH_CAP_MS > 14500);
+  // …but can never exceed the total budget it is charged against.
+  assert.ok(GET_ERRORS_REFRESH_CAP_MS <= GET_ERRORS_TOTAL_BUDGET_MS);
+});
+
+test("a first step gets its full cap", () => {
+  assert.equal(getErrorsStepBudgetMs(0, GET_ERRORS_REFRESH_CAP_MS), GET_ERRORS_REFRESH_CAP_MS);
+  assert.equal(getErrorsStepBudgetMs(0, GET_ERRORS_STEP_CAP_MS), GET_ERRORS_STEP_CAP_MS);
+});
+
+test("a step is clamped to the REMAINING budget near the end", () => {
+  // 16 s elapsed of the 18 s total ⇒ only 2 s left for a 4 s-capped probe.
+  assert.equal(getErrorsStepBudgetMs(16000, GET_ERRORS_STEP_CAP_MS), 2000);
+});
+
+test("an exhausted or overrun budget yields 0 (step skipped, fail closed)", () => {
+  assert.equal(getErrorsStepBudgetMs(GET_ERRORS_TOTAL_BUDGET_MS, GET_ERRORS_STEP_CAP_MS), 0);
+  assert.equal(getErrorsStepBudgetMs(GET_ERRORS_TOTAL_BUDGET_MS + 1, GET_ERRORS_STEP_CAP_MS), 0);
+});
+
+test("a broken clock (non-finite / negative elapsed) yields 0, not free budget", () => {
+  assert.equal(getErrorsStepBudgetMs(NaN, GET_ERRORS_STEP_CAP_MS), 0);
+  assert.equal(getErrorsStepBudgetMs(Infinity, GET_ERRORS_STEP_CAP_MS), 0);
+  assert.equal(getErrorsStepBudgetMs(-5, GET_ERRORS_STEP_CAP_MS), 0);
+});
+
+test("a non-positive step cap yields 0", () => {
+  assert.equal(getErrorsStepBudgetMs(0, 0), 0);
+  assert.equal(getErrorsStepBudgetMs(0, NaN), 0);
+});
+
+test("SEQUENTIAL consumption of the shared budget can never sum past it (#610+#589)", () => {
+  // Simulate graph_get_errors' elective steps in order — refresh race, then
+  // /system_stats, then the /view probe batch — each taking its full granted
+  // budget, and assert the total wait never exceeds GET_ERRORS_TOTAL_BUDGET_MS.
+  let elapsed = 0;
+  const take = (cap) => {
+    const granted = getErrorsStepBudgetMs(elapsed, cap);
+    elapsed += granted;
+    return granted;
+  };
+  const refresh = take(GET_ERRORS_REFRESH_CAP_MS);
+  const stats = take(GET_ERRORS_STEP_CAP_MS);
+  const probes = take(GET_ERRORS_STEP_CAP_MS);
+  assert.equal(refresh, GET_ERRORS_REFRESH_CAP_MS, "refresh gets its full raised cap first");
+  assert.equal(
+    stats,
+    GET_ERRORS_TOTAL_BUDGET_MS - GET_ERRORS_REFRESH_CAP_MS,
+    "the stats probe is clamped to the remainder of the shared budget",
+  );
+  assert.equal(probes, 0, "the media probes are skipped once the budget is spent");
+  assert.ok(elapsed <= GET_ERRORS_TOTAL_BUDGET_MS);
+  assert.ok(
+    elapsed < ORCHESTRATOR_READ_TIMEOUT_MS,
+    `worst-case in-panel elective wait ${elapsed} must beat the bridge timeout`,
+  );
+});
+
+// Source guard: the constants above are only meaningful while graph_get_errors
+// actually spends them. A revert to the old flat 4 s constant — or a refresh
+// call that stops passing the budget — must fail the build, not slip through
+// (a fix on one branch was once silently reverted by a later bulk rewrite).
+test("graph_get_errors spends the shared budget and the old 4 s constant is gone (#610/#589)", () => {
+  assert.ok(
+    !PANEL_SOURCE.includes("GET_ERRORS_REFRESH_TIMEOUT_MS"),
+    "the old flat GET_ERRORS_REFRESH_TIMEOUT_MS constant must not reappear",
+  );
+  assert.ok(
+    PANEL_SOURCE.includes("errorsStepBudget(GET_ERRORS_REFRESH_CAP_MS)"),
+    "the forced refresh wait must be charged against the shared budget",
+  );
+  assert.ok(
+    PANEL_SOURCE.includes("errorsStepBudget(GET_ERRORS_STEP_CAP_MS)"),
+    "the nested-media probe wait must be charged against the shared budget",
+  );
+});

--- a/browser_tests/unit/get-errors-budget.test.mjs
+++ b/browser_tests/unit/get-errors-budget.test.mjs
@@ -104,20 +104,28 @@ test("SEQUENTIAL consumption of the shared budget can never sum past it (#610+#5
 });
 
 // Source guard: the constants above are only meaningful while graph_get_errors
-// actually spends them. A revert to the old flat 4 s constant — or a refresh
-// call that stops passing the budget — must fail the build, not slip through
-// (a fix on one branch was once silently reverted by a later bulk rewrite).
+// actually spends them. A revert to the old flat 4 s constant — or a call site
+// that stops PASSING the budget (an unwired constant still greps) — must fail
+// the build, not slip through (a fix on one branch was once silently reverted
+// by a later bulk rewrite; codex gate: token presence ≠ wiring).
 test("graph_get_errors spends the shared budget and the old 4 s constant is gone (#610/#589)", () => {
   assert.ok(
     !PANEL_SOURCE.includes("GET_ERRORS_REFRESH_TIMEOUT_MS"),
     "the old flat GET_ERRORS_REFRESH_TIMEOUT_MS constant must not reappear",
   );
-  assert.ok(
-    PANEL_SOURCE.includes("errorsStepBudget(GET_ERRORS_REFRESH_CAP_MS)"),
-    "the forced refresh wait must be charged against the shared budget",
+  assert.match(
+    PANEL_SOURCE,
+    /errorsStepBudget\(GET_ERRORS_REFRESH_CAP_MS\)/,
+    "the refresh wait must be computed from the shared budget",
   );
-  assert.ok(
-    PANEL_SOURCE.includes("errorsStepBudget(GET_ERRORS_STEP_CAP_MS)"),
-    "the nested-media probe wait must be charged against the shared budget",
+  assert.match(
+    PANEL_SOURCE,
+    /withRefreshTimeout\(\s*refreshComfyNodeDefs\(undefined, \{ force: true \}\),\s*refreshBudgetMs,?\s*\)/,
+    "the forced refresh race must RECEIVE that budget (an unpassed budget silently reverts #610)",
+  );
+  assert.match(
+    PANEL_SOURCE,
+    /filterServerConfirmedInputSubfolderMedia\(\s*assets\.media,\s*\(\)\s*=>/,
+    "the nested-media probe must RECEIVE the remaining-budget thunk (the default thunk ignores the shared budget)",
   );
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -150,6 +150,12 @@ import {
   inputPathsUseWindowsSeparators,
 } from "./lib/input-asset.js";
 import {
+  GET_ERRORS_TOTAL_BUDGET_MS,
+  GET_ERRORS_REFRESH_CAP_MS,
+  GET_ERRORS_STEP_CAP_MS,
+  getErrorsStepBudgetMs,
+} from "./lib/get-errors-budget.js";
+import {
   drivenWidgetsFor,
   drivenTag,
   capSummaryWidgets,
@@ -5158,13 +5164,17 @@ function clearStaleRedFlagsAfterSubgraphConversion(res, { app, graph, rootGraph 
 // is never re-interpreted into a path the server would not resolve
 // (over-report, never suppress — the same fail direction as the probe itself).
 let serverInputPathsAreWindows = null;
-async function inputAssetServerUsesWindowsPaths() {
+// `budgetMs` caps the /system_stats wait (see get-errors-budget.js). A call with
+// no budget left returns UNKNOWN (false → POSIX semantics, fail closed) WITHOUT
+// caching — a budget skip must not poison the session-long platform verdict.
+async function inputAssetServerUsesWindowsPaths(budgetMs = GET_ERRORS_STEP_CAP_MS) {
   if (serverInputPathsAreWindows !== null) return serverInputPathsAreWindows;
+  if (!(budgetMs > 0)) return false;
   try {
     if (typeof api?.fetchApi !== "function") return false;
     const res = await api.fetchApi("/system_stats", {
       cache: "no-store",
-      signal: AbortSignal.timeout(GET_ERRORS_REFRESH_TIMEOUT_MS),
+      signal: AbortSignal.timeout(budgetMs),
     });
     const stats = res && res.ok ? await res.json() : null;
     serverInputPathsAreWindows = inputPathsUseWindowsSeparators(stats);
@@ -5189,9 +5199,22 @@ async function inputAssetServerUsesWindowsPaths() {
  * preserving the prior fail-closed warning. The subfolder/filename split follows
  * the SERVER's path semantics so a backslash is treated as a separator only
  * where ComfyUI itself would treat it as one.
+ *
+ * `remainingBudgetMs` (a thunk read between steps, so an earlier step's spend
+ * shrinks the next step's cap) bounds each await; the default keeps the
+ * historical per-step cap for the best-effort validationBanner caller. When no
+ * budget remains, probing is skipped entirely and every candidate stays
+ * reported — the same fail-closed direction as a failed probe (#589).
  */
-async function filterServerConfirmedInputSubfolderMedia(media) {
-  const backslashIsSeparator = await inputAssetServerUsesWindowsPaths();
+async function filterServerConfirmedInputSubfolderMedia(
+  media,
+  remainingBudgetMs = () => GET_ERRORS_STEP_CAP_MS,
+) {
+  const statsBudget = remainingBudgetMs();
+  if (!(statsBudget > 0)) return media;
+  const backslashIsSeparator = await inputAssetServerUsesWindowsPaths(statsBudget);
+  const probeBudget = remainingBudgetMs();
+  if (!(probeBudget > 0)) return media;
   return filterServerConfirmedInputSubfolderCandidates(
     media,
     async (assetValue, ref) => {
@@ -5204,7 +5227,7 @@ async function filterServerConfirmedInputSubfolderMedia(media) {
           method: "GET",
           cache: "no-store",
           headers: { Range: "bytes=0-0" },
-          signal: AbortSignal.timeout(GET_ERRORS_REFRESH_TIMEOUT_MS),
+          signal: AbortSignal.timeout(probeBudget),
         });
         return !!res && (res.ok || res.status === 206);
       } catch {
@@ -5241,25 +5264,31 @@ function hasRawMissingAssetCandidates() {
   return false;
 }
 
-// Upper bound on the authoritative /object_info refresh get_errors awaits: a stalled
-// or backgrounded ComfyUI must never wedge the error query. On timeout we resolve (not
-// reject) and fall through to the load-time snapshot — worst case is today's staleness,
-// never a hung tool call (codex #5). The refresh promise itself keeps running (the
-// coalescer owns it) and benefits a later call.
-const GET_ERRORS_REFRESH_TIMEOUT_MS = 4000;
+// The elective server-verification waits inside one graph_get_errors call share
+// ONE total budget (GET_ERRORS_TOTAL_BUDGET_MS, see lib/get-errors-budget.js):
+// the orchestrator answers panel_get_errors through the ui-bridge 20 s read
+// default, so the SUM of the refresh race + /system_stats + /view probes must
+// stay under it or the reply loses to a "tab did not reply" timeout on a live
+// tab (#589). The refresh cap itself is 15 s because a real slow-install
+// /object_info runs ~14.5 s (#610) — the old flat 4 s cap fired first and kept
+// verified-on-disk models reporting missing. A step that finds no budget left
+// is SKIPPED and fails closed (distrust the combo / keep the candidate): worst
+// case is today's staleness, never a hung tool call (codex #5). The refresh
+// promise itself keeps running (the coalescer owns it) and benefits a later
+// call.
 // Resolves to the refresh's OWN freshness verdict (registerComfyNodeDefs returns TRUE
 // only when it authoritatively fetched /object_info AND refreshed combos), or FALSE if
 // the refresh errored or the timeout wins first. get_errors trusts the combo on this
 // returned value — NOT the shared nodeDefsRefreshConfirmed global, which a concurrent
 // refresh can overwrite mid-await against a stale combo (codex round-5/6 P0). Never
 // rejects; a timeout or failure falls to FALSE ⇒ distrust ⇒ over-report.
-function withRefreshTimeout(promise) {
+function withRefreshTimeout(promise, timeoutMs) {
   return Promise.race([
     Promise.resolve(promise).then(
       (v) => v === true,
       () => false,
     ),
-    new Promise((resolve) => setTimeout(() => resolve(false), GET_ERRORS_REFRESH_TIMEOUT_MS)),
+    new Promise((resolve) => setTimeout(() => resolve(false), timeoutMs)),
   ]);
 }
 
@@ -8378,9 +8407,22 @@ const GRAPH_TOOL_EXECUTORS = {
     // nodeDefsRefreshConfirmed global, which a concurrent refresh (reconnect / add_node
     // payload / download) can overwrite against a stale combo mid-await (codex round-6
     // P0). Defaults to FALSE (distrust ⇒ over-report) unless MY refresh proves freshness.
+    // One SHARED budget for every elective server wait below (refresh race,
+    // /system_stats, /view probes): the orchestrator's ui-bridge read default is
+    // 20 s, and the sum of these waits must never outlive it — a "did not reply"
+    // timeout on a live tab strands the agent with no error surface at all (#589).
+    // A step that finds no budget left is skipped and fails CLOSED (distrust the
+    // combo / keep the raw candidate), never a hung call. The refresh cap is 15 s
+    // because a slow-install /object_info runs ~14.5 s (#610).
+    const errorsBudgetStart = monotonicNow();
+    const errorsStepBudget = (capMs) =>
+      getErrorsStepBudgetMs(monotonicNow() - errorsBudgetStart, capMs);
     let comboTrustedForQuery = false;
     try {
-      if (hasRawMissingAssetCandidates()) {
+      const refreshBudgetMs = hasRawMissingAssetCandidates()
+        ? errorsStepBudget(GET_ERRORS_REFRESH_CAP_MS)
+        : 0;
+      if (refreshBudgetMs > 0) {
         // force:true so we never JOIN an /object_info fetch that began BEFORE the current
         // asset state (a joined stale run would trust a combo snapshot predating a just-
         // deleted asset and suppress the now-genuine miss). The coalescer guarantees a
@@ -8390,6 +8432,7 @@ const GRAPH_TOOL_EXECUTORS = {
         // triggered, not any concurrent run's global write.
         comboTrustedForQuery = await withRefreshTimeout(
           refreshComfyNodeDefs(undefined, { force: true }),
+          refreshBudgetMs,
         );
         // …AND only if no OTHER refresh is still in flight at this synchronous point. The
         // shared coalescer lets a concurrent PAYLOAD refresh (graph_add_node) run its own
@@ -8442,7 +8485,16 @@ const GRAPH_TOOL_EXECUTORS = {
     // assertGraphBoundToActiveWorkflow above, never a cross-workflow result.
     const preProbeWorkflow = activeWorkflowRef();
     const preProbeRootGraph = rootGraph;
-    assets.media = await filterServerConfirmedInputSubfolderMedia(assets.media);
+    // Skip the probe when the shared budget is already spent (e.g. a slow
+    // /object_info refresh consumed it): every candidate stays reported — the
+    // same fail-closed direction as a failed probe — and the reply still beats
+    // the bridge's 20 s read timeout (#589). No await happened in that case, so
+    // the cross-workflow correlation below trivially holds.
+    if (errorsStepBudget(GET_ERRORS_STEP_CAP_MS) > 0) {
+      assets.media = await filterServerConfirmedInputSubfolderMedia(assets.media, () =>
+        errorsStepBudget(GET_ERRORS_STEP_CAP_MS),
+      );
+    }
     let postProbeRootGraph = null;
     try {
       postProbeRootGraph = getGraphCtx().rootGraph ?? null;

--- a/web/js/lib/get-errors-budget.js
+++ b/web/js/lib/get-errors-budget.js
@@ -1,0 +1,65 @@
+/**
+ * Budget arithmetic for graph_get_errors' ELECTIVE server-verification waits
+ * (#610/#589) — extracted from comfyui-mcp-panel.js so the invariant is
+ * unit-testable without a browser. No DOM / no ComfyUI globals: every input is
+ * passed in.
+ *
+ * The problem these constants balance:
+ *
+ *   - #610: the forced /object_info refresh get_errors awaits before trusting a
+ *     combo to clear a resolved missing-model candidate takes ~14.5 s on a real
+ *     Windows install. The old flat 4000 ms cap fired first, the freshness
+ *     verdict came back FALSE, and two verified-on-disk models kept reporting
+ *     missing. So the REFRESH cap must cover a slow-install /object_info.
+ *
+ *   - #589: the orchestrator answers panel_get_errors through the ui-bridge READ
+ *     default of 20 000 ms (BRIDGE_READ_DEFAULT_TIMEOUT_MS in comfyui-mcp's
+ *     services/ui-bridge.ts). graph_get_errors must NEVER stay silent past that
+ *     — a "tab did not reply" timeout on a live tab strands the agent with no
+ *     error surface at all. So the SUM of every elective wait inside one call
+ *     (refresh race + /system_stats probe + /view media probes) must stay under
+ *     the bridge budget. A single shared TOTAL budget, consumed as each step
+ *     runs, is what guarantees that — independent per-step caps cannot (their
+ *     sum can exceed the bridge budget, which is exactly what a raised refresh
+ *     cap would otherwise cause).
+ *
+ * Every step that finds no budget left is SKIPPED, and every skip fails the way
+ * this codebase always fails: CLOSED. A skipped refresh means the combo is
+ * distrusted and raw missing-asset candidates stay reported; skipped media
+ * probes keep every candidate. The worst outcome of an exhausted budget is
+ * today's over-reporting staleness — never a swallowed genuine miss and never
+ * a wedged tool call.
+ */
+
+/** Total elective-verification budget for ONE graph_get_errors call. Must stay
+ *  below the orchestrator's 20 000 ms read timeout (see the header) with margin
+ *  for reply delivery and for coarse timer granularity in a backgrounded tab. */
+export const GET_ERRORS_TOTAL_BUDGET_MS = 18000;
+
+/** Cap on the forced /object_info refresh wait. Raised from the old 4000 ms:
+ *  the #610 field report measured ~14.5 s on a slow Windows install, so a cap
+ *  below that reintroduces the false "still missing" verdict this fixes. An
+ *  install whose refresh exceeds even this keeps the conservative stale report
+ *  (distrust ⇒ over-report) instead of timing the tool out. */
+export const GET_ERRORS_REFRESH_CAP_MS = 15000;
+
+/** Cap on each smaller elective step (the /system_stats platform probe and the
+ *  /view nested-media probes) — and the per-step cap the best-effort
+ *  validationBanner path keeps using, since it answers to no bridge timeout. */
+export const GET_ERRORS_STEP_CAP_MS = 4000;
+
+/**
+ * Milliseconds the NEXT elective step may consume, given how much of the total
+ * budget is already gone. Returns the step's own cap clamped to the remaining
+ * budget, or 0 when the budget is exhausted — 0 means SKIP the step (fail
+ * closed, per the header). A non-finite or negative `elapsedMs` (a broken
+ * clock) also yields 0: when the guard itself cannot measure, it must not hand
+ * out budget it cannot account for.
+ */
+export function getErrorsStepBudgetMs(elapsedMs, stepCapMs, totalBudgetMs = GET_ERRORS_TOTAL_BUDGET_MS) {
+  if (!Number.isFinite(elapsedMs) || elapsedMs < 0) return 0;
+  if (!Number.isFinite(stepCapMs) || stepCapMs <= 0) return 0;
+  const remaining = totalBudgetMs - elapsedMs;
+  if (!(remaining > 0)) return 0;
+  return Math.min(stepCapMs, remaining);
+}


### PR DESCRIPTION
## Issues in this cluster

- #610
- #589
- #586

Grouped because they share a codepath or are variations of one defect. An agent takes the whole cluster, so a fix for one is checked against the others rather than landing several times with several different shapes.

**Not yet started** — draft until an agent picks it up.