### PR TITLE
turn lifecycle told untruthfully: a stall reported as a user rejection, an unmatched result, reconnect flood, and blind mode asking for a verdict on withheld images

### DIFF
--- a/browser_tests/unit/bridge-reconnect-transcript.test.mjs
+++ b/browser_tests/unit/bridge-reconnect-transcript.test.mjs
@@ -1,0 +1,81 @@
+// Regression guard for #588: every successful bridge reconnect used to append
+// "Connected to ws://… — waiting for the panel agent…" to the DURABLE chat
+// transcript (onLog → appendSystem), because markConnected()/start()/setUrl()
+// reset the `loggedWaiting` throttle. During a ComfyUI/orchestrator restart the
+// same transient line flooded the chat once per reconnect cycle, even though
+// connection recovery was working normally and the status pill already shows
+// the transient state.
+//
+// The load-bearing invariants locked here:
+//   * the socket-open handler never writes the transient "waiting for the
+//     panel agent" line to the transcript (the pill owns that state);
+//   * the pill still flips to "connecting" on open (the state is not hidden);
+//   * a genuinely WEDGED open socket (no agent handshake inside the window)
+//     still surfaces its distinct warning — the transient-line removal must
+//     not silence real wedge reporting;
+//   * the `loggedWaiting` throttle bookkeeping is gone entirely (a resettable
+//     throttle IS the flood — every reset re-arms exactly one transcript line).
+//
+// The callback depends on the real browser/ComfyUI environment, so inspect the
+// shipped handler source directly (the panel's established wiring test
+// pattern, cf. bridge-disconnect.test.mjs) rather than substitute a different
+// implementation.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+
+function panelSource() {
+  return readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
+}
+
+function socketOpenHandler() {
+  const source = panelSource();
+  const start = source.indexOf('thisSock.addEventListener("open", () => {');
+  assert.notEqual(start, -1, "could not locate the bridge socket open handler");
+  const end = source.indexOf("\n    });", start);
+  assert.notEqual(end, -1, "could not locate the end of the open handler");
+  return source.slice(start, end);
+}
+
+test("#588: a socket (re)open never writes the transient waiting line to the transcript", () => {
+  const handler = socketOpenHandler();
+  assert.doesNotMatch(
+    handler,
+    /onLog\(\s*[`"'][\s\S]{0,300}?waiting for the panel agent/,
+    "the transient waiting state must not be appended to the durable chat transcript",
+  );
+  assert.doesNotMatch(
+    handler,
+    /appendSystem\([^)]*waiting for the panel agent/s,
+    "the transient waiting state must not reach the transcript by any other path",
+  );
+});
+
+test("#588: the status pill still communicates the transient connecting state", () => {
+  const handler = socketOpenHandler();
+  assert.match(
+    handler,
+    /emitStatus\("connecting"\)/,
+    "removing the transcript line must not hide the state from the status pill",
+  );
+});
+
+test("#588: a wedged open socket still warns (transient-line removal ≠ silence)", () => {
+  const handler = socketOpenHandler();
+  assert.match(
+    handler,
+    /no panel agent responded/,
+    "the handshake-timeout wedge warning is a REAL state and must survive",
+  );
+});
+
+test("#588: the resettable loggedWaiting throttle is gone (a reset re-arms the flood)", () => {
+  assert.doesNotMatch(
+    panelSource(),
+    /\bloggedWaiting\b/,
+    "the throttle that let every reconnect cycle re-log the line must be removed, not re-tuned",
+  );
+});

--- a/browser_tests/unit/run-completion.test.mjs
+++ b/browser_tests/unit/run-completion.test.mjs
@@ -12,6 +12,8 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import {
   createRunCompletionTracker,
@@ -467,4 +469,167 @@ test("presentation: a STALLED storyboard upload still yields ONE frame (never we
   assert.match(frame.note, /timed out/, "each stalled video degrades to a note-only fallback");
   assert.match(frame.note, /a\.mp4/);
   assert.match(frame.note, /b\.mp4/);
+});
+
+// ── #609: blind mode must not be asked for a visual verdict ────────────────
+// With Blind ON, the sendFrame gate strips `images` from the agent_event — but
+// the storyboard note still ordered the agent to "Review motion, sharpness, and
+// temporal consistency", and the (vision-capable) agent confabulated a verdict
+// on a sheet it never received. The review request is lawful ONLY when the
+// pixels actually ride the frame; when withheld, the note must say so
+// AFFIRMATIVELY (an explicit prohibition — a merely-absent request is not
+// reliable) and name blind mode as the cause.
+
+test("#609: blind mode (images withheld) — no review request, an explicit prohibition instead", async () => {
+  const { deps, frames } = makeFrameDeps({ agentReceivesImages: () => false });
+  const frame = await composeRunCompletionFrame(
+    {
+      promptId: "p-blind",
+      images: [],
+      videos: [{ m: { filename: "clip.mp4", type: "output" }, nodeId: "7" }],
+      durationMs: 5000,
+    },
+    deps,
+  );
+  assert.equal(frames.length, 1);
+  assert.doesNotMatch(
+    frame.note,
+    /Review motion, sharpness/,
+    "must not order a visual review of a storyboard the agent never received",
+  );
+  // Assert the REASON, not just the absence: the note names blind mode as the
+  // cause and prohibits the visual verdict outright.
+  assert.match(frame.note, /Blind mode is ON/, "the withhold is disclosed, naming the cause");
+  assert.match(frame.note, /NOT sent to you/, "the withhold itself is stated");
+  assert.match(frame.note, /Do not comment on motion, sharpness, or visual quality/);
+  // The factual half survives: the agent can still name the file and metadata.
+  assert.match(frame.note, /clip\.mp4/, "the factual summary (file, metadata) still reaches the agent");
+  // The storyboard is still produced for the USER (blind blinds the agent, not
+  // the panel) — the ref rides the frame; the sendFrame gate strips it.
+  assert.ok(
+    frame.images.some((m) => m.filename === "storyboard_clip.png"),
+    "the storyboard is still built for the user; only the agent-facing pixels are gated",
+  );
+});
+
+test("#609: sighted mode (default) — the review request is unchanged", async () => {
+  const { deps, frames } = makeFrameDeps();
+  const frame = await composeRunCompletionFrame(
+    {
+      promptId: "p-sighted",
+      images: [],
+      videos: [{ m: { filename: "clip.mp4", type: "output" }, nodeId: "7" }],
+      durationMs: 5000,
+    },
+    deps,
+  );
+  assert.match(
+    frames[0].note,
+    /frames run top-left→bottom-right = start→end\. Review motion, sharpness, and temporal consistency\./,
+    "when the pixels DO reach the agent, the review request must survive verbatim",
+  );
+  assert.doesNotMatch(frame.note, /Blind mode is ON/);
+});
+
+test("#609: the sighted/blind decision is made NEAR SEND TIME (a mid-flush toggle is honored)", async () => {
+  let sighted = true;
+  const { deps, frames } = makeFrameDeps({
+    agentReceivesImages: () => sighted,
+    // Flip blind ON only once the storyboard upload is in flight — the decision
+    // is made after every segment resolves, so a flush-start snapshot would
+    // read the stale value.
+    uploadBlobToInput: async (_blob, name, opts) => {
+      sighted = false;
+      return { filename: name, type: opts?.type || "input" };
+    },
+  });
+  const frame = await composeRunCompletionFrame(
+    {
+      promptId: "p-toggle",
+      images: [],
+      videos: [{ m: { filename: "t.mp4", type: "output" }, nodeId: "7" }],
+      durationMs: 5000,
+    },
+    deps,
+  );
+  assert.equal(frames.length, 1);
+  assert.doesNotMatch(
+    frame.note,
+    /Review motion, sharpness/,
+    "a flush-start snapshot would still ask for the review — the decision must be made after the segments resolve",
+  );
+  assert.match(frame.note, /Blind mode is ON/);
+});
+
+test("#609: ONE decision per frame — parallel segments can never disagree with each other or the gate", async () => {
+  // codex gate finding: with a PER-SEGMENT read, a fast storyboard whose note
+  // was already composed stays "Review…" while a slow one, still in flight when
+  // Blind flips ON, says "NOT sent" — two segments of the SAME frame
+  // contradicting each other, and the fast one contradicting the sendFrame gate
+  // (which strips BOTH images at send time). The decision must be single and
+  // made after the slowest segment, immediately before send.
+  let sighted = true;
+  const { deps, frames } = makeFrameDeps({
+    agentReceivesImages: () => sighted,
+    // fast.mp4's storyboard resolves immediately; slow.mp4's takes a real 20ms.
+    buildVideoStoryboard: async (url) => {
+      if (/slow/.test(url)) await new Promise((r) => setTimeout(r, 20));
+      return { fake: "blob" };
+    },
+    // Blind flips ON during slow.mp4's upload — AFTER fast.mp4's whole segment
+    // (including its note) was already built.
+    uploadBlobToInput: async (_blob, name, opts) => {
+      if (/slow/.test(name)) sighted = false;
+      return { filename: name, type: opts?.type || "input" };
+    },
+  });
+  const frame = await composeRunCompletionFrame(
+    {
+      promptId: "p-interleave",
+      images: [],
+      videos: [
+        { m: { filename: "fast.mp4", type: "output" }, nodeId: "1" },
+        { m: { filename: "slow.mp4", type: "output" }, nodeId: "2" },
+      ],
+      durationMs: 5000,
+    },
+    deps,
+  );
+  assert.equal(frames.length, 1);
+  // The single decision was made after slow.mp4 resolved — Blind was ON by
+  // then, so BOTH segments disclose, and NEITHER requests a review.
+  assert.equal(
+    frame.note.match(/Blind mode is ON/g)?.length,
+    2,
+    "both video segments must follow the SAME per-frame decision",
+  );
+  assert.doesNotMatch(
+    frame.note,
+    /Review motion, sharpness/,
+    "the fast segment's pre-flip composition must not survive into the sent note",
+  );
+  assert.match(frame.note, /fast\.mp4/);
+  assert.match(frame.note, /slow\.mp4/);
+});
+
+// #609 wiring: the behavioral tests above inject `agentReceivesImages` by hand,
+// so they cannot catch the panel's REAL call site dropping the dep (the composer
+// then defaults to always-sighted while the sendFrame gate still strips the
+// pixels — the exact #609 hole). Pin the wiring by source inspection, the
+// panel's established pattern for the giant module (cf. bridge-disconnect).
+test("#609 wiring: the panel call site feeds the composer the gate's own blind predicate", () => {
+  const src = readFileSync(
+    fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
+  const start = src.indexOf("composeRunCompletionFrame(");
+  assert.notEqual(start, -1, "could not locate the composeRunCompletionFrame call site");
+  const end = src.indexOf(".then((frame)", start);
+  assert.notEqual(end, -1, "could not locate the end of the call site");
+  const callSite = src.slice(start, end);
+  assert.match(
+    callSite,
+    /agentReceivesImages:\s*\(\)\s*=>\s*!AGENT_BLIND/,
+    "the note's review request must be conditioned on the SAME blind flag the sendFrame gate strips by",
+  );
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -49,9 +49,9 @@
     } catch {
       // crypto is a frozen host object — leave it alone rather than re-clobber
       // it (re-binding getRandomValues / subtle by hand has already proven
-      // fragile). Behavior reverts to pre-polyfill: the panel hangs in
-      // 'waiting for the panel agent…' on a non-secure LAN host, exactly as
-      // before this fix.
+      // fragile). Behavior reverts to pre-polyfill: the panel hangs on the
+      // "connecting" pill awaiting the agent handshake on a non-secure LAN
+      // host, exactly as before this fix.
     }
   }
 })();
@@ -11169,7 +11169,6 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
   // trying underneath either way — `gaveUp` just latches the terminal display so
   // later background retries don't re-pulse the pill connecting↔disconnected.
   let gaveUp = false;
-  let loggedWaiting = false; // FIX 3 — throttle the "waiting for the panel agent" log
   function backendNow() {
     try {
       return window.localStorage.getItem(STORAGE_KEY_BACKEND) || "claude";
@@ -11233,7 +11232,6 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     // "connecting" forever, masking a genuine terminal failure.
     attempt = 0;
     gaveUp = false;
-    loggedWaiting = false;
     // #508/#402 — replay the outcomes the previous socket could not deliver, so a command
     // that genuinely ran is never silently swallowed by the reconnect. Deliberately HERE,
     // on the real handshake, and not at bare socket-open (codex): an open socket only proves
@@ -11446,12 +11444,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // gaveUp is latched, a mere open must NOT clear it back to "connecting" —
       // only a real `models` handshake (markConnected) does.
       if (!gaveUp) emitStatus("connecting");
-      // FIX 3 — log the "waiting for the panel agent" line ONCE per connect
-      // sequence instead of on every (re)open during a cold-start flicker.
-      if (!loggedWaiting) {
-        loggedWaiting = true;
-        onLog(`Connected to ${redactBridgeUrl(url)} — waiting for the panel agent…`);
-      }
+      // #588 — the transient "waiting for the panel agent" state is the status
+      // pill's job (emitStatus above); it must NOT also be written into the
+      // durable chat transcript, where every reconnect cycle during a ComfyUI /
+      // orchestrator restart appended the same line again. A genuinely wedged
+      // open socket is still surfaced by the handshake-timeout warning below.
       sendHello();
       clearHandshake();
       handshakeTimer = setTimeout(() => {
@@ -12239,10 +12236,8 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       closed = false;
       // A fresh connect intent (user Connect / sticky reconnect / respawn handoff)
       // restarts the patient cold-start window: clear the terminal latch and the
-      // attempt count so we ride out the slow boot again as a steady "connecting"
-      // (and the "waiting for the panel agent" line logs once more). FIX 1/2/3.
+      // attempt count so we ride out the slow boot again as a steady "connecting".
       gaveUp = false;
-      loggedWaiting = false;
       attempt = 0;
       connect();
     },
@@ -12395,7 +12390,6 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       attempt = 0;
       // Pointing at a new bridge is a fresh connect → restart the patience window.
       gaveUp = false;
-      loggedWaiting = false;
       if (reconnectTimer) {
         clearTimeout(reconnectTimer);
         reconnectTimer = null;
@@ -19252,6 +19246,11 @@ function buildPanel() {
           storyboardFrameCount,
           paintImage,
           videoStoryboardEnabled: prefs.videoStoryboard !== false,
+          // #609 — Blind mode strips images at the sendFrame gate below; the
+          // storyboard note must not ask for a visual review of pixels the
+          // agent never received. A function, so the composer makes its single
+          // per-frame decision after the storyboards resolve, near send time.
+          agentReceivesImages: () => !AGENT_BLIND,
           warn: (...a) => console.warn(...a),
         },
       )
@@ -20330,8 +20329,8 @@ function buildPanel() {
   // the port yet its AGENT handshake (the `models` frame → "connected") never lands,
   // the WS is OPEN — so there's no close event to drive scheduleReconnect, and
   // tryAutoRespawn is standing down for the guard window. The panel then sits in the
-  // "Connected … waiting for the panel agent" stuck state until the user manually
-  // clicks Reconnect. So: if the handshake hasn't landed within this window,
+  // stuck open-but-unhandshook state (steady "connecting" pill) until the user
+  // manually clicks Reconnect. So: if the handshake hasn't landed within this window,
   // AUTO-ESCALATE once to exactly what Reconnect does — a single clean
   // connectAgent(). One-shot (never a loop) so it can't reintroduce the storm the
   // interlock prevents. BACKEND-AWARE: the escalation must sit BEYOND the backend's
@@ -20373,8 +20372,8 @@ function buildPanel() {
     }
   }
   // The soft-reload's WS is open (or reconnecting) but the agent handshake hasn't
-  // landed within the short window — the "connected … waiting for the panel agent"
-  // stuck state. Escalate ONCE to exactly what the user's manual Reconnect does:
+  // landed within the short window — the stuck open-but-unhandshook state.
+  // Escalate ONCE to exactly what the user's manual Reconnect does:
   // drop the stale (open-but-unhandshook) socket — necessary because connect()
   // early-returns on an already-OPEN socket, so a bare connectAgent()/client.start()
   // alone would NOT replace it — then run a single clean connectAgent(). connectAgent
@@ -20770,7 +20769,7 @@ function buildPanel() {
     // Switching to a DIFFERENT backend than we're connected to: agent sessions are
     // NOT shareable across providers, so start FRESH for the new one (fix #2).
     // Sending the saved (foreign) session id on hello makes the new orchestrator
-    // try to resume a session it doesn't own ("waiting for the panel agent…" +
+    // try to resume a session it doesn't own (stuck awaiting handshake +
     // a spurious re-send). Mirror newChat()'s session-clear so getResume() → null;
     // the visible chat log stays, only the agent session resets.
     const switching = connectedBackend !== null && connectedBackend !== id;

--- a/web/js/lib/run-completion-frame.js
+++ b/web/js/lib/run-completion-frame.js
@@ -44,6 +44,15 @@ export async function composeRunCompletionFrame(
     storyboardFrameCount,
     paintImage,
     videoStoryboardEnabled = true,
+    // Will the agent actually RECEIVE the pixels on this frame? Blind mode
+    // (#90/#174) strips `images` at the sendFrame gate — the note must not
+    // request a visual review of a storyboard that was withheld, or a
+    // vision-capable agent will confabulate a verdict (#609). Evaluated ONCE,
+    // after every segment has resolved (see the video fold below): a per-segment
+    // read would let two videos of the SAME frame disagree when the toggle
+    // flips mid-composition, and a flush-start snapshot would decide on a stale
+    // flag. One decision per frame, taken at the last moment before send.
+    agentReceivesImages = () => true,
     now = () => new Date(),
     warn = () => {},
     // Per-video wall-clock cap. The single completion frame awaits every video
@@ -118,10 +127,17 @@ export async function composeRunCompletionFrame(
       }),
     ),
   );
+  // #609 — ONE sighted/blind decision for the whole frame, made HERE: after the
+  // slowest segment resolved and immediately before send (nothing below awaits
+  // until sendFrame, so the toggle cannot interleave). A per-segment read would
+  // let a fast storyboard say "Review…" while a slow one says "NOT sent" when
+  // Blind flips mid-composition — and both could contradict the sendFrame gate.
+  const sighted = agentReceivesImages();
   for (const seg of videoSegs) {
     if (!seg) continue;
     if (seg.ref) outImages.push(seg.ref);
-    if (seg.note) noteSections.push(seg.note);
+    const note = sighted ? seg.note : (seg.noteWhenBlind ?? seg.note);
+    if (note) noteSections.push(note);
   }
 
   if (!outImages.length && !noteSections.length) return null;
@@ -266,8 +282,11 @@ async function buildStillsSegment(bufImages, deps) {
 
 /**
  * One video's portion: build a storyboard contact sheet (or a note-only fallback
- * when the storyboard can't be produced) and return { ref, note }. `ref` is the
- * uploaded storyboard ImageRef (or null); it never sends a frame itself.
+ * when the storyboard can't be produced) and return { ref, note, noteWhenBlind? }.
+ * `ref` is the uploaded storyboard ImageRef (or null); it never sends a frame
+ * itself. `noteWhenBlind` is set only on the storyboard-success path (#609): the
+ * sighted note requests a visual review, which is lawful only if the pixels ride
+ * the frame — the composer picks the variant ONCE per frame, right before send.
  */
 async function buildVideoSegment(v, deps) {
   const {
@@ -353,12 +372,27 @@ async function buildVideoSegment(v, deps) {
       const sizeStr = humanizeBytes(await fetchImageBytes(imageViewUrl(m)));
       // Show the user the contact sheet next to the <video> player.
       paintImage(imageViewUrl(ref), `Storyboard · ${n} frames`);
+      // #609 — the review request is lawful ONLY when the storyboard pixels
+      // actually reach the agent. Blind mode strips them at the sendFrame gate;
+      // asking for a visual verdict on a withheld sheet makes a vision-capable
+      // agent confabulate one. Both note variants are built here; the COMPOSER
+      // picks one per FRAME (never per segment) right before send, so parallel
+      // segments can never disagree with each other or with the gate. The blind
+      // variant says so AFFIRMATIVELY (an explicit prohibition is reliable; a
+      // merely-absent request is not) — the sheet is still painted for the user
+      // above, so only the agent is blind.
+      const header = `📽️ ${n}-frame storyboard (contact sheet) of ${videoKind} — `;
       const note =
-        `📽️ ${n}-frame storyboard (contact sheet) of ${videoKind} — ` +
+        header +
         `frames run top-left→bottom-right = start→end. ` +
         `Review motion, sharpness, and temporal consistency.` +
         metaSuffix(sizeStr, n);
-      return { ref, note };
+      const noteWhenBlind =
+        header +
+        `Blind mode is ON, so the storyboard was NOT sent to you (it is shown to the user). ` +
+        `Do not comment on motion, sharpness, or visual quality — acknowledge completion and the metadata below only.` +
+        metaSuffix(sizeStr, n);
+      return { ref, note, noteWhenBlind };
     } catch (err) {
       warn("[cmcp] storyboard pipeline failed:", err);
       return { ref: null, note: noteOnly("its storyboard preview failed to build") };


### PR DESCRIPTION
## Issues in this cluster

- artokun/comfyui-mcp#886
- artokun/comfyui-mcp#885
- artokun/comfyui-mcp-panel#588
- artokun/comfyui-mcp-panel#609

Grouped because they share a codepath or are variations of one defect. An agent takes the whole cluster, so a fix for one is checked against the others rather than landing several times with several different shapes.

## Outcome per issue

**#588 (reconnect flood) — FIXED here.** Every successful bridge reconnect reset the `loggedWaiting` throttle (`markConnected`/`start()`/`setUrl()`), so the transient `Connected to … — waiting for the panel agent…` line was appended to the **durable** chat transcript once per reconnect cycle. The transcript write and the throttle bookkeeping are removed; the status pill still shows the transient `connecting` state, and a genuinely wedged open socket keeps its distinct handshake-timeout warning (`⚠ Bridge open … no panel agent responded`).

**#609 (blind mode asked for a visual verdict) — FIXED here.** The video-storyboard note hardcoded `Review motion, sharpness, and temporal consistency.` even when Blind mode strips the storyboard pixels at the `sendFrame` gate. `buildVideoSegment` now returns both note variants and `composeRunCompletionFrame` picks **one per frame** via an injected `agentReceivesImages()` (wired at the call site to `() => !AGENT_BLIND`), evaluated after every segment resolves and immediately before send — so parallel video segments can never disagree with each other or with the gate when the toggle flips mid-composition. When withheld, the note says so affirmatively (`Blind mode is ON, so the storyboard was NOT sent to you … Do not comment on motion, sharpness, or visual quality`) and keeps the factual metadata. The storyboard is still built and painted for the user.

**#587 (stall reported to the agent as a USER REJECTION) — orchestrator-side; partially fixed upstream, NOT in this repo.** The stall watchdog and the agent-visible tool result live in comfyui-mcp (`src/orchestrator/panel-agent.ts`, backends). Upstream fix `8bc668a` (comfyui-mcp PR #782, released in **v0.49.4** — the issue was filed against 0.49.3) sends a Codex turn an explicit harness-stall notice (`turn/steer`: "The user did NOT reject or cancel this tool call …") before falling back to interrupt. **Residual gap:** `recoverStalledTurn` is implemented only by the Codex backend; a stalled **Claude** turn still goes straight to `interrupt()`, and the issue's exact repro was a Claude turn. Closing the Claude half requires an orchestrator change, which is out of this repo's scope — flagged here so it isn't lost.

**#590 (result matched no submitted turn) — orchestrator-side; working as designed upstream, NOT in this repo.** The quoted message is emitted by comfyui-mcp `claude-backend.ts` (`The result could not be matched to any submitted turn — reporting the turn as unverifiable rather than a success`, plus the `Nothing was lost — try again …` wrapper from `panel-agent.ts`). That fail-closed guard (the #740/#745 work) was already present in the reported version 0.49.3 — the message the user saw IS that guard firing. The issue's enhancement asks (turn registry surviving reconnects, reconciliation by stable turn id, surfacing "completed but unverified" with tool activity) are all orchestrator-state changes with no panel-side component. One upstream nit worth noting: `Nothing was lost` is questionable when the unmatched turn had in fact done real work.

## Verification

- `npm run test:unit` — 1783 passed, 0 failed (includes new `browser_tests/unit/bridge-reconnect-transcript.test.mjs` and +5 tests in `run-completion.test.mjs`).
- Both edited panel files pass `node --check` as `.mjs` (ES-module check).
- Mutation-verified: restoring the transcript write, snapshotting the blind decision at flush start, always picking the sighted note, and dropping the call-site `agentReceivesImages` dep each turn the matching test red.
- Committed blobs scanned for control bytes: 0. Post-state grepped on the committed blobs (old forms absent, new forms present).
- Rendered both note variants end to end against the issue's exact scenario text.
- Codex adversarial self-gate: **PASS** (round 1 found a real per-segment race — fixed and regression-tested; round 2 finding was shown to be a false positive with line-cited evidence and withdrawn by the gate itself in round 3).

## What only a live browser can confirm

- The transcript staying quiet across a real ComfyUI/orchestrator restart while the pill cycles (the unit tests pin the wiring by source inspection, per the repo's established pattern for the giant module).
- A real Blind-mode video completion delivering the prohibitive note variant to the agent.
