### PR TITLE
Manager dialect cache stale after a backend upgrade, and sync no-oping on incoherent queue counts

### DIFF
--- a/browser_tests/unit/manager-dialect.test.mjs
+++ b/browser_tests/unit/manager-dialect.test.mjs
@@ -14,6 +14,7 @@ import { fileURLToPath } from "node:url";
 import * as ManagerInstall from "../../web/js/lib/manager-install.js";
 const {
   dialectRetryTarget,
+  isManagerRouteMissing,
   isManagerUnreachable,
   isMethodNotAllowed,
   legacyUpdateBody,
@@ -23,6 +24,11 @@ const {
 
 const UNREACHABLE = "ComfyUI-Manager not reachable (is the built-in Manager enabled?)";
 const QUEUE_STATUS = { total_count: 0, done_count: 0, is_processing: false };
+
+/** The error managerCall/managerV2 throw for a PROVEN route-level rejection
+ *  (HTTP 404): the same message, tagged managerRouteMissing. Mutations may be
+ *  re-sent on this and ONLY this (codex P0). */
+const routeMissing = () => Object.assign(new Error(UNREACHABLE), { managerRouteMissing: true });
 
 function readPanelSource() {
   const panelPath = fileURLToPath(
@@ -61,6 +67,50 @@ test("dialectRetryTarget: re-probe agrees (or Manager silent) → legacy last re
 test("dialectRetryTarget: legacy-on-legacy has no fallback left (null → surface the original error)", () => {
   assert.equal(dialectRetryTarget("legacy", "legacy"), null);
   assert.equal(dialectRetryTarget("legacy", null), null);
+});
+
+test("isManagerRouteMissing: ONLY the proven-404 marker qualifies a mutation retry (codex P0)", () => {
+  assert.equal(isManagerRouteMissing(routeMissing()), true, "the tagged 404");
+  // The SAME message without the marker is the ambiguous no-response case —
+  // it must NOT authorize re-sending a mutation.
+  assert.equal(isManagerRouteMissing(new Error(UNREACHABLE)), false);
+  assert.equal(isManagerRouteMissing(new Error("Manager manager/queue/install: HTTP 404")), false);
+  assert.equal(isManagerRouteMissing(new Error("Manager x: HTTP 405")), false);
+  assert.equal(isManagerRouteMissing(null), false);
+  assert.equal(isManagerRouteMissing(undefined), false);
+  // ...while the broad GET-fallback predicate still matches the message shape.
+  assert.equal(isManagerUnreachable(new Error(UNREACHABLE)), true);
+});
+
+// The marker itself is minted by the REAL transports — extract them and prove:
+// a 404 response tags the error; a no-response (null) failure does NOT.
+test("managerV2/managerCall tag a 404 as managerRouteMissing, never the no-response case", async () => {
+  const src = readPanelSource();
+  const factory = new Function(
+    "api",
+    `${pick(src, /async function managerV2\(route, \{ method = "GET", body, signal \} = \{\}\) \{[\s\S]*?\n\}/, "managerV2")}
+${pick(src, /async function managerCall\(route, \{ method = "GET", body, signal \} = \{\}\) \{[\s\S]*?\n\}/, "managerCall")}
+return { managerV2, managerCall };`,
+  );
+  for (const res of [
+    { status: 404, ok: false }, // route not registered → proven rejection
+    null, // no response → ambiguous
+  ]) {
+    const { managerV2: mv2, managerCall: mcall } = factory({ fetchApi: async () => res });
+    for (const call of [mv2, mcall]) {
+      const err = await call("manager/queue/status").then(
+        () => null,
+        (e) => e,
+      );
+      assert.ok(err, "must throw");
+      assert.match(err.message, /not reachable/);
+      assert.equal(
+        isManagerRouteMissing(err),
+        res !== null && res.status === 404,
+        `marker only for the proven 404 (res=${JSON.stringify(res)})`,
+      );
+    }
+  }
 });
 
 // ---------------------------------------------------------------------------
@@ -294,6 +344,7 @@ function graphUpdateDeps(overrides) {
     isMethodNotAllowed,
     assertBatchOk,
     isManagerUnreachable,
+    isManagerRouteMissing,
     dialectRetryTarget,
     reProbeManagerDialect: async () => "v2",
     waitForUpdateResult: async () => ({
@@ -311,7 +362,7 @@ test("#605: graph_update_node with a stale 'legacy' cache re-probes and updates 
     graphUpdateDeps({
       managerCall: async (route) => {
         calls.push(["legacy", route]);
-        throw new Error(UNREACHABLE); // the restarted v4 backend dropped the 3.x routes
+        throw routeMissing(); // the restarted v4 backend dropped the 3.x routes (proven 404)
       },
       managerV2: async (route) => {
         calls.push(["v2", route]);
@@ -334,6 +385,29 @@ test("#605: graph_update_node with a stale 'legacy' cache re-probes and updates 
   );
 });
 
+test("codex P0: an AMBIGUOUS enqueue failure (no response) never re-sends the update", async () => {
+  const calls = [];
+  let reprobes = 0;
+  const update = buildGraphUpdateNode(
+    graphUpdateDeps({
+      detectManagerDialect: async () => "legacy",
+      managerCall: async (route) => {
+        calls.push(route);
+        // Same "not reachable" TEXT as a 404 but NO marker: a lost response
+        // says nothing about whether the POST landed.
+        throw new Error(UNREACHABLE);
+      },
+      reProbeManagerDialect: async () => {
+        reprobes += 1;
+        return "v2";
+      },
+    }),
+  );
+  await assert.rejects(() => update({ id: "some-pack" }), /not reachable/);
+  assert.deepEqual(calls, ["manager/queue/update"], "the ambiguous POST is not re-sent anywhere");
+  assert.equal(reprobes, 0, "no re-probe, no retry, no second dialect");
+});
+
 test("#605: graph_update_node never re-enqueues after the task POST landed (start failure surfaces)", async () => {
   const calls = [];
   let reprobes = 0;
@@ -342,7 +416,7 @@ test("#605: graph_update_node never re-enqueues after the task POST landed (star
       detectManagerDialect: async () => "v2",
       managerV2: async (route) => {
         calls.push(route);
-        if (route === "manager/queue/start") throw new Error(UNREACHABLE);
+        if (route === "manager/queue/start") throw routeMissing();
         return {};
       },
       reProbeManagerDialect: async () => {
@@ -364,7 +438,7 @@ test("#605: the legacy update POST landing is tracked too — a start failure af
       detectManagerDialect: async () => "legacy",
       managerCall: async (route) => {
         calls.push(route);
-        if (route === "manager/queue/start") throw new Error(UNREACHABLE);
+        if (route === "manager/queue/start") throw routeMissing();
         return {};
       },
       reProbeManagerDialect: async () => {
@@ -384,13 +458,17 @@ test("#605: the legacy update POST landing is tracked too — a start failure af
 
 test("#605: graph_update_node legacy-on-legacy unreachable surfaces the original error (no retry left)", async () => {
   const calls = [];
+  let reprobes = 0;
   const update = buildGraphUpdateNode(
     graphUpdateDeps({
       detectManagerDialect: async () => "legacy",
-      reProbeManagerDialect: async () => "legacy", // the probe AGREES
+      reProbeManagerDialect: async () => {
+        reprobes += 1;
+        return "legacy"; // the probe AGREES
+      },
       managerCall: async (route) => {
         calls.push(route);
-        throw new Error(UNREACHABLE);
+        throw routeMissing();
       },
     }),
   );
@@ -402,6 +480,7 @@ test("#605: graph_update_node legacy-on-legacy unreachable surfaces the original
     },
   );
   assert.deepEqual(calls, ["manager/queue/update"], "the rejected enqueue is not repeated");
+  assert.equal(reprobes, 1, "one re-probe, then the ladder gives up");
 });
 
 // ---------------------------------------------------------------------------
@@ -430,6 +509,7 @@ function nodesInstallDeps(overrides) {
     managerV2: async () => ({}),
     managerCall: async () => ({}),
     isManagerUnreachable,
+    isManagerRouteMissing,
     dialectRetryTarget,
     reProbeManagerDialect: async () => "v2",
     managerQueueControl: async () => {},
@@ -444,7 +524,7 @@ test("#605: nodes_install with a stale 'legacy' cache re-probes and installs thr
     nodesInstallDeps({
       managerCall: async (route) => {
         calls.push(["legacy", route]);
-        throw new Error(UNREACHABLE); // the restarted v4 backend dropped the 3.x routes
+        throw routeMissing(); // the restarted v4 backend dropped the 3.x routes (proven 404)
       },
       managerV2: async (route) => {
         calls.push(["v2", route]);
@@ -466,6 +546,27 @@ test("#605: nodes_install with a stale 'legacy' cache re-probes and installs thr
   );
 });
 
+test("codex P0: nodes_install never re-submits on an AMBIGUOUS (no-response) failure", async () => {
+  const calls = [];
+  let reprobes = 0;
+  const install = buildNodesInstall(
+    nodesInstallDeps({
+      detectManagerDialect: async () => "legacy",
+      managerCall: async (route) => {
+        calls.push(route);
+        throw new Error(UNREACHABLE); // unmarked: the POST may have landed
+      },
+      reProbeManagerDialect: async () => {
+        reprobes += 1;
+        return "v2";
+      },
+    }),
+  );
+  await assert.rejects(() => install({ id: "some-pack" }), /not reachable/);
+  assert.deepEqual(calls, ["manager/queue/install"], "the ambiguous POST is not re-sent anywhere");
+  assert.equal(reprobes, 0, "no re-probe, no retry, no second dialect");
+});
+
 test("#485 regression: a v2-batch unreachable submit still falls back to legacy when the re-probe agrees", async () => {
   const calls = [];
   const install = buildNodesInstall(
@@ -474,7 +575,7 @@ test("#485 regression: a v2-batch unreachable submit still falls back to legacy 
       reProbeManagerDialect: async () => "v2-batch", // the probe AGREES (hybrid build)
       managerV2: async (route) => {
         calls.push(["v2", route]);
-        throw new Error(UNREACHABLE); // hybrid: /v2 mutation routes not registered
+        throw routeMissing(); // hybrid: /v2 mutation routes not registered (proven 404)
       },
       managerCall: async (route) => {
         calls.push(["legacy", route]);
@@ -503,7 +604,7 @@ test("#605: nodes_install legacy-on-legacy unreachable surfaces the original err
       reProbeManagerDialect: async () => "legacy",
       managerCall: async (route) => {
         calls.push(route);
-        throw new Error(UNREACHABLE);
+        throw routeMissing();
       },
     }),
   );

--- a/browser_tests/unit/manager-dialect.test.mjs
+++ b/browser_tests/unit/manager-dialect.test.mjs
@@ -129,10 +129,10 @@ function buildDialectHarness({ fetchApi, managerCall, managerV2 }) {
     "AbortSignal",
     `let managerDialectCache = null;
 ${pick(src, /function looksLikeQueueStatus\(s\) \{[\s\S]*?\n\}/, "looksLikeQueueStatus")}
-${pick(src, /async function managerProbe\(route\) \{[\s\S]*?\n\}/, "managerProbe")}
-${pick(src, /async function detectManagerDialect\(\) \{[\s\S]*?\n\}/, "detectManagerDialect")}
+${pick(src, /async function managerProbe\(route, \{ signal \} = \{\}\) \{[\s\S]*?\n\}/, "managerProbe")}
+${pick(src, /async function detectManagerDialect\(\{ signal \} = \{\}\) \{[\s\S]*?\n\}/, "detectManagerDialect")}
 ${pick(src, /function invalidateManagerDialectCache\(\) \{[\s\S]*?\n\}/, "invalidateManagerDialectCache")}
-${pick(src, /async function reProbeManagerDialect\(\) \{[\s\S]*?\n\}/, "reProbeManagerDialect")}
+${pick(src, /async function reProbeManagerDialect\(\{ signal \} = \{\}\) \{[\s\S]*?\n\}/, "reProbeManagerDialect")}
 ${pick(src, /async function managerGet\(route, \{ signal \} = \{\}\) \{[\s\S]*?\n\}/, "managerGet")}
 return { managerGet, getDialectCache: () => managerDialectCache };`,
   );
@@ -280,6 +280,46 @@ test("#605: Manager answering NO dialect surfaces the ORIGINAL error and leaves 
   const healed = await h.managerGet("manager/queue/status");
   assert.equal(healed.servedBy, "v4");
   assert.equal(h.getDialectCache(), "v2");
+});
+
+test("#605 codex r3: the managerGet re-probe aborts with the CALLER's signal (waitForUpdateResult budget)", async () => {
+  // Phase 1 seeds a cached dialect with answering probes; phase 2's probes HANG
+  // until their signal fires. The routed GET 404s fast (a proven route-level
+  // rejection mid-restart) — the heal's re-probe must abort with the caller's
+  // remaining budget, not stack 15s probes past it.
+  let hanging = false;
+  const fetchApi = (route, opts) => {
+    if (!hanging) {
+      return Promise.resolve(route === "/manager/queue/status" ? okJson(QUEUE_STATUS) : notFound());
+    }
+    return new Promise((_, reject) => {
+      const onAbort = () => reject(new Error("This operation was aborted"));
+      if (opts?.signal?.aborted) return onAbort();
+      opts?.signal?.addEventListener("abort", onAbort);
+    });
+  };
+  const managerCall = async (route) => {
+    if (hanging) throw routeMissing();
+    return { servedBy: "legacy", route };
+  };
+  const managerV2 = async () => {
+    throw routeMissing();
+  };
+  const h = buildDialectHarness({ fetchApi, managerCall, managerV2 });
+  await h.managerGet("manager/queue/status"); // seeds cache "legacy"
+  assert.equal(h.getDialectCache(), "legacy");
+
+  hanging = true;
+  const start = Date.now();
+  await assert.rejects(
+    () => h.managerGet("manager/queue/history?ui_id=x", { signal: AbortSignal.timeout(150) }),
+    /not reachable/i,
+  );
+  const elapsed = Date.now() - start;
+  assert.ok(
+    elapsed < 5000,
+    `the re-probe must abort with the caller's signal, not stack 15s probes (took ${elapsed}ms)`,
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/browser_tests/unit/manager-dialect.test.mjs
+++ b/browser_tests/unit/manager-dialect.test.mjs
@@ -1,0 +1,518 @@
+// Unit tests for #605: the Manager dialect cache must not stay stale after a
+// backend restart swaps Manager generations (3.x ↔ pip v4) under a live tab.
+// Covers the pure retry ladder (dialectRetryTarget) directly, then drives the
+// REAL panel source (managerProbe / detectManagerDialect / reProbeManagerDialect
+// / managerGet / nodes_install / graph_update_node) extracted from
+// comfyui-mcp-panel.js against stubbed transports — the same extraction pattern
+// manager-install.test.mjs uses, so a missing binding or a deleted heal fails
+// here instead of in the browser.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import * as ManagerInstall from "../../web/js/lib/manager-install.js";
+const {
+  dialectRetryTarget,
+  isManagerUnreachable,
+  isMethodNotAllowed,
+  legacyUpdateBody,
+  assertBatchOk,
+  classifyUpdateOutcome,
+} = ManagerInstall;
+
+const UNREACHABLE = "ComfyUI-Manager not reachable (is the built-in Manager enabled?)";
+const QUEUE_STATUS = { total_count: 0, done_count: 0, is_processing: false };
+
+function readPanelSource() {
+  const panelPath = fileURLToPath(
+    new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url),
+  );
+  return readFileSync(panelPath, "utf8");
+}
+
+function pick(src, re, name) {
+  const m = src.match(re);
+  assert.ok(m, `could not locate ${name} in panel source`);
+  return m[0];
+}
+
+const okJson = (payload) => ({ ok: true, text: async () => JSON.stringify(payload) });
+const notFound = () => ({ ok: false, status: 404, text: async () => "" });
+
+// ---------------------------------------------------------------------------
+// Pure retry ladder (#605)
+// ---------------------------------------------------------------------------
+
+test("dialectRetryTarget: a CHANGED fresh probe wins (stale cache after a restart)", () => {
+  assert.equal(dialectRetryTarget("legacy", "v2"), "v2", "stale legacy → live v4 (#605)");
+  assert.equal(dialectRetryTarget("legacy", "v2-batch"), "v2-batch");
+  assert.equal(dialectRetryTarget("v2", "legacy"), "legacy", "stale v2 → live 3.x");
+  assert.equal(dialectRetryTarget("v2-batch", "v2"), "v2");
+});
+
+test("dialectRetryTarget: re-probe agrees (or Manager silent) → legacy last resort for pip dialects (#485)", () => {
+  assert.equal(dialectRetryTarget("v2", "v2"), "legacy");
+  assert.equal(dialectRetryTarget("v2-batch", "v2-batch"), "legacy");
+  assert.equal(dialectRetryTarget("v2", null), "legacy");
+  assert.equal(dialectRetryTarget("v2-batch", null), "legacy");
+});
+
+test("dialectRetryTarget: legacy-on-legacy has no fallback left (null → surface the original error)", () => {
+  assert.equal(dialectRetryTarget("legacy", "legacy"), null);
+  assert.equal(dialectRetryTarget("legacy", null), null);
+});
+
+// ---------------------------------------------------------------------------
+// Real-source harness: cache + detection + re-probe + managerGet
+// ---------------------------------------------------------------------------
+
+function buildDialectHarness({ fetchApi, managerCall, managerV2 }) {
+  const src = readPanelSource();
+  const factory = new Function(
+    "api",
+    "managerCall",
+    "managerV2",
+    "isManagerUnreachable",
+    "dialectRetryTarget",
+    "MANAGER_FETCH_TIMEOUT_MS",
+    "AbortSignal",
+    `let managerDialectCache = null;
+${pick(src, /function looksLikeQueueStatus\(s\) \{[\s\S]*?\n\}/, "looksLikeQueueStatus")}
+${pick(src, /async function managerProbe\(route\) \{[\s\S]*?\n\}/, "managerProbe")}
+${pick(src, /async function detectManagerDialect\(\) \{[\s\S]*?\n\}/, "detectManagerDialect")}
+${pick(src, /function invalidateManagerDialectCache\(\) \{[\s\S]*?\n\}/, "invalidateManagerDialectCache")}
+${pick(src, /async function reProbeManagerDialect\(\) \{[\s\S]*?\n\}/, "reProbeManagerDialect")}
+${pick(src, /async function managerGet\(route, \{ signal \} = \{\}\) \{[\s\S]*?\n\}/, "managerGet")}
+return { managerGet, getDialectCache: () => managerDialectCache };`,
+  );
+  return factory(
+    { fetchApi },
+    managerCall,
+    managerV2,
+    isManagerUnreachable,
+    dialectRetryTarget,
+    15000,
+    AbortSignal,
+  );
+}
+
+/** A fake backend whose Manager generation can be swapped mid-test (the
+ *  restart). `mode`: "legacy" (3.x), "v4" (pip normal), "down" (mid-restart). */
+function fakeBackend(modeRef) {
+  const probes = [];
+  const fetchApi = async (route) => {
+    probes.push(route);
+    const mode = modeRef.mode;
+    if (mode === "legacy") {
+      return route === "/manager/queue/status" ? okJson(QUEUE_STATUS) : notFound();
+    }
+    if (mode === "v4") {
+      if (route === "/v2/manager/queue/status") return okJson(QUEUE_STATUS);
+      if (route === "/v2/manager/is_legacy_manager_ui") return okJson({ is_legacy_manager_ui: false });
+      return notFound();
+    }
+    return notFound(); // "down" — nothing answers
+  };
+  return { fetchApi, probes };
+}
+
+test("#605: stale 'legacy' cache self-heals to v4 after a backend restart (the issue's repro)", async () => {
+  const modeRef = { mode: "legacy" };
+  const { fetchApi, probes } = fakeBackend(modeRef);
+  const calls = [];
+  const managerCall = async (route) => {
+    calls.push(["legacy", route]);
+    if (modeRef.mode !== "legacy") throw new Error(UNREACHABLE); // v4 dropped the 3.x routes
+    return { servedBy: "legacy", route };
+  };
+  const managerV2 = async (route) => {
+    calls.push(["v2", route]);
+    if (modeRef.mode !== "v4") throw new Error(UNREACHABLE);
+    return { servedBy: "v4", route };
+  };
+  const h = buildDialectHarness({ fetchApi, managerCall, managerV2 });
+
+  // 1. On the 3.x backend the list routes legacy and caches "legacy".
+  const first = await h.managerGet("customnode/installed?mode=default");
+  assert.equal(first.servedBy, "legacy");
+  assert.equal(h.getDialectCache(), "legacy");
+
+  // 2. The backend RESTARTS to pip v4 with the tab alive — the stale cache
+  // routes the GET at /customnode/installed, which 404s. The heal must
+  // invalidate, re-probe the LIVE backend, and re-issue the SAME route on /v2.
+  modeRef.mode = "v4";
+  const healed = await h.managerGet("customnode/installed?mode=default");
+  assert.equal(healed.servedBy, "v4", "the re-probed dialect must serve the list");
+  assert.equal(healed.route, "customnode/installed?mode=default", "same route, re-issued");
+  assert.equal(h.getDialectCache(), "v2", "the live verdict is re-pinned");
+  assert.deepEqual(
+    calls.filter(([d]) => d === "legacy").length,
+    2, // phase 1 + the one route-level rejection in phase 2
+    "the stale attempt is the ONLY extra legacy call",
+  );
+
+  // 3. A later call uses the re-pinned dialect directly — no re-probe storm.
+  const probeCount = probes.length;
+  const third = await h.managerGet("manager/queue/status");
+  assert.equal(third.servedBy, "v4");
+  assert.equal(probes.length, probeCount, "no re-probe once the cache is truthful");
+});
+
+test("#605: re-probe that AGREES falls back to the legacy absolute route (#423 hybrid preserved)", async () => {
+  const modeRef = { mode: "v4" };
+  const { fetchApi } = fakeBackend(modeRef);
+  const calls = [];
+  // The hybrid shape: /v2 probe answers, but the /v2 DATA GET 404s while the
+  // absolute legacy route serves fine.
+  const managerV2 = async (route) => {
+    calls.push(["v2", route]);
+    throw new Error(UNREACHABLE);
+  };
+  const managerCall = async (route) => {
+    calls.push(["legacy", route]);
+    return { servedBy: "legacy", route };
+  };
+  const h = buildDialectHarness({ fetchApi, managerCall, managerV2 });
+  const res = await h.managerGet("customnode/installed?mode=default");
+  assert.equal(res.servedBy, "legacy", "the legacy absolute route is the last resort");
+  assert.equal(res.route, "customnode/installed?mode=default");
+  assert.deepEqual(calls.map(([d]) => d), ["v2", "legacy"], "one routed attempt, one fallback");
+});
+
+test("#605: a non-unreachable error propagates WITHOUT a re-probe (not a dialect signal)", async () => {
+  const modeRef = { mode: "v4" };
+  const { fetchApi, probes } = fakeBackend(modeRef);
+  let legacyCalls = 0;
+  const managerV2 = async () => {
+    throw new Error("Manager manager/queue/status: HTTP 500");
+  };
+  const managerCall = async () => {
+    legacyCalls += 1;
+    throw new Error(UNREACHABLE);
+  };
+  const h = buildDialectHarness({ fetchApi, managerCall, managerV2 });
+  await assert.rejects(() => h.managerGet("manager/queue/status"), /HTTP 500/);
+  const probeCount = probes.length;
+  await assert.rejects(() => h.managerGet("manager/queue/status"), /HTTP 500/);
+  assert.equal(probes.length, probeCount, "a 500 must not buy a re-probe");
+  assert.equal(legacyCalls, 0, "a 500 must not fall back to legacy");
+});
+
+test("#605: Manager answering NO dialect surfaces the ORIGINAL error and leaves the cache empty", async () => {
+  const modeRef = { mode: "legacy" };
+  const { fetchApi } = fakeBackend(modeRef);
+  const managerCall = async (route) => {
+    if (modeRef.mode !== "legacy") throw new Error(UNREACHABLE);
+    return { servedBy: "legacy", route };
+  };
+  const managerV2 = async (route) => ({ servedBy: "v4", route });
+  const h = buildDialectHarness({ fetchApi, managerCall, managerV2 });
+
+  await h.managerGet("manager/queue/status"); // seeds cache "legacy"
+  assert.equal(h.getDialectCache(), "legacy");
+
+  // Mid-restart: nothing answers any dialect. The stale attempt's OWN error is
+  // the one with the operation's context — the detection failure must not
+  // replace it.
+  modeRef.mode = "down";
+  await assert.rejects(
+    () => h.managerGet("manager/queue/status"),
+    (err) => {
+      assert.equal(err.message, UNREACHABLE, "the original routed error surfaces");
+      return true;
+    },
+  );
+  assert.equal(h.getDialectCache(), null, "a failed re-probe never re-pins the stale value");
+
+  // When the backend comes back as v4, the empty cache re-probes and heals.
+  modeRef.mode = "v4";
+  const healed = await h.managerGet("manager/queue/status");
+  assert.equal(healed.servedBy, "v4");
+  assert.equal(h.getDialectCache(), "v2");
+});
+
+// ---------------------------------------------------------------------------
+// Wiring guards: the lifecycle invalidation + both mutation paths
+// ---------------------------------------------------------------------------
+
+test("#605: the backend 'reconnected' listener invalidates the dialect cache", () => {
+  const src = readPanelSource();
+  const m = src.match(/addEventListener\("reconnected"[\s\S]*?\}\s*\);/);
+  assert.ok(m, "could not locate the reconnected listener");
+  assert.ok(
+    m[0].includes("invalidateManagerDialectCache()"),
+    "a backend restart (socket re-established) must drop the cached dialect",
+  );
+});
+
+test("#605: nodes_install re-probes the dialect on an unreachable submit before retrying", () => {
+  const src = readPanelSource();
+  const m = src.match(/async nodes_install\(args\) \{[\s\S]*?\n  \},\r?\n/);
+  assert.ok(m, "could not locate nodes_install");
+  assert.ok(m[0].includes("reProbeManagerDialect"), "nodes_install must re-probe on unreachable");
+  assert.ok(m[0].includes("dialectRetryTarget"), "nodes_install must pick the retry via the ladder");
+});
+
+test("#605: graph_update_node re-probes on unreachable and never re-sends a landed enqueue", () => {
+  const src = readPanelSource();
+  const m = src.match(/async graph_update_node\(\{ id, version, channel, mode \}\) \{[\s\S]*?\n  \},\r?\n/);
+  assert.ok(m, "could not locate graph_update_node");
+  assert.ok(m[0].includes("reProbeManagerDialect"), "graph_update_node must re-probe on unreachable");
+  assert.ok(m[0].includes("dialectRetryTarget"), "graph_update_node must pick the retry via the ladder");
+  assert.ok(m[0].includes("enqueued"), "the retry must be gated on the enqueue NOT having landed");
+});
+
+// ---------------------------------------------------------------------------
+// Real-source harness: graph_update_node (the mutation path)
+// ---------------------------------------------------------------------------
+
+function buildGraphUpdateNode(deps) {
+  const src = readPanelSource();
+  const methodSrc = pick(
+    src,
+    /async graph_update_node\(\{ id, version, channel, mode \}\) \{[\s\S]*?\n  \},\r?\n/,
+    "graph_update_node",
+  );
+  const factory = new Function(
+    ...Object.keys(deps),
+    `const handlers = { ${methodSrc} };\nreturn handlers.graph_update_node;`,
+  );
+  return factory(...Object.values(deps));
+}
+
+function graphUpdateDeps(overrides) {
+  return {
+    detectManagerDialect: async () => "legacy",
+    crypto: { randomUUID: () => "u-1" },
+    api: { clientId: "c-1" },
+    legacyUpdateBody,
+    managerCall: async () => {
+      throw new Error(UNREACHABLE);
+    },
+    managerV2: async () => ({}),
+    isMethodNotAllowed,
+    assertBatchOk,
+    isManagerUnreachable,
+    dialectRetryTarget,
+    reProbeManagerDialect: async () => "v2",
+    waitForUpdateResult: async () => ({
+      item: { ui_id: "u-1", status: { status_str: "success", completed: true, messages: [] } },
+      status: QUEUE_STATUS,
+    }),
+    classifyUpdateOutcome,
+    ...overrides,
+  };
+}
+
+test("#605: graph_update_node with a stale 'legacy' cache re-probes and updates through live v4", async () => {
+  const calls = [];
+  const update = buildGraphUpdateNode(
+    graphUpdateDeps({
+      managerCall: async (route) => {
+        calls.push(["legacy", route]);
+        throw new Error(UNREACHABLE); // the restarted v4 backend dropped the 3.x routes
+      },
+      managerV2: async (route) => {
+        calls.push(["v2", route]);
+        return {};
+      },
+    }),
+  );
+  const res = await update({ id: "some-pack" });
+  assert.equal(res.updated, true, "the v4 task success is reported");
+  assert.equal(res.verified, true);
+  assert.equal(res.dialect, "v2", "the result names the dialect the update ACTUALLY used");
+  assert.deepEqual(
+    calls,
+    [
+      ["legacy", "manager/queue/update"], // the route-level rejection — nothing ran
+      ["v2", "manager/queue/task"], // the healed re-enqueue
+      ["v2", "manager/queue/start"],
+    ],
+    "exactly one enqueue lands, on the live dialect",
+  );
+});
+
+test("#605: graph_update_node never re-enqueues after the task POST landed (start failure surfaces)", async () => {
+  const calls = [];
+  let reprobes = 0;
+  const update = buildGraphUpdateNode(
+    graphUpdateDeps({
+      detectManagerDialect: async () => "v2",
+      managerV2: async (route) => {
+        calls.push(route);
+        if (route === "manager/queue/start") throw new Error(UNREACHABLE);
+        return {};
+      },
+      reProbeManagerDialect: async () => {
+        reprobes += 1;
+        return "legacy";
+      },
+    }),
+  );
+  await assert.rejects(() => update({ id: "some-pack" }), /not reachable/);
+  assert.deepEqual(calls, ["manager/queue/task", "manager/queue/start"], "no second task POST");
+  assert.equal(reprobes, 0, "a landed enqueue is never re-probed for a retry");
+});
+
+test("#605: the legacy update POST landing is tracked too — a start failure after it never re-fires", async () => {
+  const calls = [];
+  let reprobes = 0;
+  const update = buildGraphUpdateNode(
+    graphUpdateDeps({
+      detectManagerDialect: async () => "legacy",
+      managerCall: async (route) => {
+        calls.push(route);
+        if (route === "manager/queue/start") throw new Error(UNREACHABLE);
+        return {};
+      },
+      reProbeManagerDialect: async () => {
+        reprobes += 1;
+        return "v2"; // a heal WOULD switch dialect — it must not get the chance
+      },
+    }),
+  );
+  await assert.rejects(() => update({ id: "some-pack" }), /not reachable/);
+  assert.deepEqual(
+    calls,
+    ["manager/queue/update", "manager/queue/start"],
+    "the landed legacy update is not re-sent",
+  );
+  assert.equal(reprobes, 0, "no re-probe once the update has landed");
+});
+
+test("#605: graph_update_node legacy-on-legacy unreachable surfaces the original error (no retry left)", async () => {
+  const calls = [];
+  const update = buildGraphUpdateNode(
+    graphUpdateDeps({
+      detectManagerDialect: async () => "legacy",
+      reProbeManagerDialect: async () => "legacy", // the probe AGREES
+      managerCall: async (route) => {
+        calls.push(route);
+        throw new Error(UNREACHABLE);
+      },
+    }),
+  );
+  await assert.rejects(
+    () => update({ id: "some-pack" }),
+    (err) => {
+      assert.equal(err.message, UNREACHABLE);
+      return true;
+    },
+  );
+  assert.deepEqual(calls, ["manager/queue/update"], "the rejected enqueue is not repeated");
+});
+
+// ---------------------------------------------------------------------------
+// Real-source harness: nodes_install (the mutation path)
+// ---------------------------------------------------------------------------
+
+function buildNodesInstall(deps) {
+  const src = readPanelSource();
+  const methodSrc = pick(src, /async nodes_install\(args\) \{[\s\S]*?\n  \},\r?\n/, "nodes_install");
+  const factory = new Function(
+    ...Object.keys(deps),
+    `const handlers = { ${methodSrc} };\nreturn handlers.nodes_install;`,
+  );
+  return factory(...Object.values(deps));
+}
+
+function nodesInstallDeps(overrides) {
+  return {
+    installGitUrl: ManagerInstall.installGitUrl,
+    buildInstallRequest: ManagerInstall.buildInstallRequest,
+    detectManagerDialect: async () => "legacy",
+    crypto: { randomUUID: () => "u-1" },
+    api: { clientId: "c-1" },
+    MANAGER_FETCH_TIMEOUT_MS: 15000,
+    AbortSignal,
+    managerV2: async () => ({}),
+    managerCall: async () => ({}),
+    isManagerUnreachable,
+    dialectRetryTarget,
+    reProbeManagerDialect: async () => "v2",
+    managerQueueControl: async () => {},
+    verifyInstalled: async () => ({ state: "installed", status: QUEUE_STATUS }),
+    ...overrides,
+  };
+}
+
+test("#605: nodes_install with a stale 'legacy' cache re-probes and installs through live v4", async () => {
+  const calls = [];
+  const install = buildNodesInstall(
+    nodesInstallDeps({
+      managerCall: async (route) => {
+        calls.push(["legacy", route]);
+        throw new Error(UNREACHABLE); // the restarted v4 backend dropped the 3.x routes
+      },
+      managerV2: async (route) => {
+        calls.push(["v2", route]);
+        return {};
+      },
+    }),
+  );
+  const res = await install({ id: "some-pack" });
+  assert.equal(res.installed, true);
+  assert.equal(res.verified, true);
+  assert.equal(res.dialect, "v2", "the result names the dialect the install ACTUALLY used");
+  assert.deepEqual(
+    calls,
+    [
+      ["legacy", "manager/queue/install"], // the route-level rejection — nothing enqueued
+      ["v2", "manager/queue/task"], // the healed re-submit
+    ],
+    "exactly one submit lands, on the live dialect",
+  );
+});
+
+test("#485 regression: a v2-batch unreachable submit still falls back to legacy when the re-probe agrees", async () => {
+  const calls = [];
+  const install = buildNodesInstall(
+    nodesInstallDeps({
+      detectManagerDialect: async () => "v2-batch",
+      reProbeManagerDialect: async () => "v2-batch", // the probe AGREES (hybrid build)
+      managerV2: async (route) => {
+        calls.push(["v2", route]);
+        throw new Error(UNREACHABLE); // hybrid: /v2 mutation routes not registered
+      },
+      managerCall: async (route) => {
+        calls.push(["legacy", route]);
+        return {};
+      },
+    }),
+  );
+  const res = await install({ id: "some-pack" });
+  assert.equal(res.installed, true);
+  assert.equal(res.dialect, "legacy", "the #485 legacy last resort still fires");
+  assert.deepEqual(
+    calls,
+    [
+      ["v2", "manager/queue/batch"],
+      ["legacy", "manager/queue/install"],
+    ],
+    "one rejected batch submit, then the legacy absolute submit",
+  );
+});
+
+test("#605: nodes_install legacy-on-legacy unreachable surfaces the original error (no retry left)", async () => {
+  const calls = [];
+  const install = buildNodesInstall(
+    nodesInstallDeps({
+      detectManagerDialect: async () => "legacy",
+      reProbeManagerDialect: async () => "legacy",
+      managerCall: async (route) => {
+        calls.push(route);
+        throw new Error(UNREACHABLE);
+      },
+    }),
+  );
+  await assert.rejects(
+    () => install({ id: "some-pack" }),
+    (err) => {
+      assert.equal(err.message, UNREACHABLE);
+      return true;
+    },
+  );
+  assert.deepEqual(calls, ["manager/queue/install"], "the rejected submit is not repeated");
+});

--- a/browser_tests/unit/manager-dialect.test.mjs
+++ b/browser_tests/unit/manager-dialect.test.mjs
@@ -282,6 +282,55 @@ test("#605: Manager answering NO dialect surfaces the ORIGINAL error and leaves 
   assert.equal(h.getDialectCache(), "v2");
 });
 
+test("#605 codex r4: a cache-MISS entry detection is bounded by the caller's signal too", async () => {
+  // Fresh cache: EVERY probe hangs until its signal fires. A managerGet under a
+  // tight caller budget must fail fast, not stack 15s probes.
+  const fetchApi = (_route, opts) =>
+    new Promise((_, reject) => {
+      const onAbort = () => reject(new Error("This operation was aborted"));
+      if (opts?.signal?.aborted) return onAbort();
+      opts?.signal?.addEventListener("abort", onAbort);
+    });
+  const h = buildDialectHarness({
+    fetchApi,
+    managerCall: async () => ({}),
+    managerV2: async () => ({}),
+  });
+  const start = Date.now();
+  await assert.rejects(
+    () => h.managerGet("manager/queue/history?ui_id=x", { signal: AbortSignal.timeout(150) }),
+    /aborted mid-probe/,
+  );
+  const elapsed = Date.now() - start;
+  assert.ok(elapsed < 5000, `entry detection must abort with the caller's signal (took ${elapsed}ms)`);
+  assert.equal(h.getDialectCache(), null, "an aborted detection caches nothing");
+});
+
+test("#605 codex r4: an aborted legacy-UI sub-probe is never pinned as a 'v2' verdict", async () => {
+  // The /v2 status probe answers, but the is_legacy_manager_ui probe hangs
+  // until the caller's signal fires. Detection must bail WITHOUT caching —
+  // committing "v2" here would misroute v2-batch mutations to the task route
+  // (which 405s on legacy-UI builds).
+  const fetchApi = (route, opts) => {
+    if (route === "/v2/manager/queue/status") return Promise.resolve(okJson(QUEUE_STATUS));
+    return new Promise((_, reject) => {
+      const onAbort = () => reject(new Error("This operation was aborted"));
+      if (opts?.signal?.aborted) return onAbort();
+      opts?.signal?.addEventListener("abort", onAbort);
+    });
+  };
+  const h = buildDialectHarness({
+    fetchApi,
+    managerCall: async () => ({}),
+    managerV2: async () => ({}),
+  });
+  await assert.rejects(
+    () => h.managerGet("manager/queue/status", { signal: AbortSignal.timeout(150) }),
+    /aborted mid-probe/,
+  );
+  assert.equal(h.getDialectCache(), null, "no verdict from a partial reading");
+});
+
 test("#605 codex r3: the managerGet re-probe aborts with the CALLER's signal (waitForUpdateResult budget)", async () => {
   // Phase 1 seeds a cached dialect with answering probes; phase 2's probes HANG
   // until their signal fires. The routed GET 404s fast (a proven route-level

--- a/browser_tests/unit/manager-dialect.test.mjs
+++ b/browser_tests/unit/manager-dialect.test.mjs
@@ -483,6 +483,72 @@ test("#605: graph_update_node legacy-on-legacy unreachable surfaces the original
   assert.equal(reprobes, 1, "one re-probe, then the ladder gives up");
 });
 
+test("#424: a 405 on the /v2 envelope still lands on the legacy self-update route (via marker)", async () => {
+  const calls = [];
+  const update = buildGraphUpdateNode(
+    graphUpdateDeps({
+      detectManagerDialect: async () => "v2",
+      managerV2: async (route) => {
+        calls.push(["v2", route]);
+        throw new Error(`Manager ${route}: HTTP 405`); // frontend catchall
+      },
+      managerCall: async (route) => {
+        calls.push(["legacy", route]);
+        return {};
+      },
+    }),
+  );
+  const res = await update({ id: "comfyui-manager" });
+  assert.equal(res.via, "legacy-self-update", "the 405 fallback is named");
+  assert.equal(res.dialect, "legacy", "the result names the dialect the update ACTUALLY used");
+  assert.equal(res.pending, true, "a legacy update reports honest pending (no per-task history)");
+  assert.deepEqual(
+    calls,
+    [
+      ["v2", "manager/queue/task"], // method-rejected — nothing landed
+      ["legacy", "manager/queue/update"],
+      ["legacy", "manager/queue/start"],
+    ],
+  );
+});
+
+test("codex r2: a route-404 from the 405-fallback's legacy POST heals through the ladder", async () => {
+  const calls = [];
+  let mode = "legacy-ui-v4"; // 405s the /v2 task POST; serves legacy routes…
+  const update = buildGraphUpdateNode(
+    graphUpdateDeps({
+      detectManagerDialect: async () => "v2",
+      reProbeManagerDialect: async () => "v2", // …until the restart lands normal v4
+      managerV2: async (route) => {
+        calls.push(["v2", route]);
+        if (mode === "legacy-ui-v4") throw new Error(`Manager ${route}: HTTP 405`);
+        return {};
+      },
+      managerCall: async (route) => {
+        calls.push(["legacy", route]);
+        // The restart to normal v4 lands BEFORE the legacy fallback POST: the
+        // 3.x routes are gone (proven 404, nothing ran).
+        mode = "v4";
+        throw routeMissing();
+      },
+    }),
+  );
+  const res = await update({ id: "comfyui-manager" });
+  assert.equal(res.updated, true, "the healed v4 update is verified");
+  assert.equal(res.dialect, "v2", "the result names the live dialect");
+  assert.equal(res.via, undefined, "the legacy via marker is cleared after the heal");
+  assert.deepEqual(
+    calls,
+    [
+      ["v2", "manager/queue/task"], // 405 — nothing landed
+      ["legacy", "manager/queue/update"], // 404 after the restart — nothing landed
+      ["v2", "manager/queue/task"], // healed re-enqueue on the live v4
+      ["v2", "manager/queue/start"],
+    ],
+    "exactly one update lands, on the live dialect",
+  );
+});
+
 // ---------------------------------------------------------------------------
 // Real-source harness: nodes_install (the mutation path)
 // ---------------------------------------------------------------------------

--- a/browser_tests/unit/manager-dialect.test.mjs
+++ b/browser_tests/unit/manager-dialect.test.mjs
@@ -117,7 +117,7 @@ return { managerV2, managerCall };`,
 // Real-source harness: cache + detection + re-probe + managerGet
 // ---------------------------------------------------------------------------
 
-function buildDialectHarness({ fetchApi, managerCall, managerV2 }) {
+function buildDialectHarness({ fetchApi, managerCall, managerV2, AbortSignalImpl = AbortSignal }) {
   const src = readPanelSource();
   const factory = new Function(
     "api",
@@ -129,6 +129,7 @@ function buildDialectHarness({ fetchApi, managerCall, managerV2 }) {
     "AbortSignal",
     `let managerDialectCache = null;
 ${pick(src, /function looksLikeQueueStatus\(s\) \{[\s\S]*?\n\}/, "looksLikeQueueStatus")}
+${pick(src, /function anyAbortSignal\(signals\) \{[\s\S]*?\n\}/, "anyAbortSignal")}
 ${pick(src, /async function managerProbe\(route, \{ signal \} = \{\}\) \{[\s\S]*?\n\}/, "managerProbe")}
 ${pick(src, /async function detectManagerDialect\(\{ signal \} = \{\}\) \{[\s\S]*?\n\}/, "detectManagerDialect")}
 ${pick(src, /function invalidateManagerDialectCache\(\) \{[\s\S]*?\n\}/, "invalidateManagerDialectCache")}
@@ -143,7 +144,7 @@ return { managerGet, getDialectCache: () => managerDialectCache };`,
     isManagerUnreachable,
     dialectRetryTarget,
     15000,
-    AbortSignal,
+    AbortSignalImpl,
   );
 }
 
@@ -329,6 +330,38 @@ test("#605 codex r4: an aborted legacy-UI sub-probe is never pinned as a 'v2' ve
     /aborted mid-probe/,
   );
   assert.equal(h.getDialectCache(), null, "no verdict from a partial reading");
+});
+
+test("#605 codex r5: the heal works on a runtime WITHOUT AbortSignal.any (fallback combiner)", async () => {
+  // A frontend with AbortSignal.timeout but no AbortSignal.any: a missing API
+  // here would be swallowed inside managerProbe and silently disable the heal —
+  // the exact #605 false "not reachable". The fallback combiner must keep the
+  // whole flow working (and bounded).
+  const NoAnyAbortSignal = {
+    timeout: (ms) => AbortSignal.timeout(ms),
+    // no .any
+  };
+  const modeRef = { mode: "legacy" };
+  const { fetchApi } = fakeBackend(modeRef);
+  const managerCall = async (route) => {
+    if (modeRef.mode !== "legacy") throw routeMissing();
+    return { servedBy: "legacy", route };
+  };
+  const managerV2 = async (route) => ({ servedBy: "v4", route });
+  const h = buildDialectHarness({
+    fetchApi,
+    managerCall,
+    managerV2,
+    AbortSignalImpl: NoAnyAbortSignal,
+  });
+
+  await h.managerGet("customnode/installed?mode=default"); // seeds "legacy"
+  assert.equal(h.getDialectCache(), "legacy");
+
+  modeRef.mode = "v4"; // the restart — stale cache, 3.x routes 404
+  const healed = await h.managerGet("customnode/installed?mode=default");
+  assert.equal(healed.servedBy, "v4", "the heal works without AbortSignal.any");
+  assert.equal(h.getDialectCache(), "v2");
 });
 
 test("#605 codex r3: the managerGet re-probe aborts with the CALLER's signal (waitForUpdateResult budget)", async () => {

--- a/browser_tests/unit/manager-dialect.test.mjs
+++ b/browser_tests/unit/manager-dialect.test.mjs
@@ -283,15 +283,28 @@ test("#605: Manager answering NO dialect surfaces the ORIGINAL error and leaves 
   assert.equal(h.getDialectCache(), "v2");
 });
 
+// A fetch stub whose promise settles ONLY via the caller's abort signal — but
+// backed by a real (ref'd) setTimeout fallback so the test process's event loop
+// stays alive on Node versions where AbortSignal.timeout's timer is unref'd
+// (CI runs Node 22; without this, pending tests get "event loop has already
+// resolved"). If the abort wiring regresses, the 2s fallback fails the test
+// with a clear message instead of a runner-level cancellation.
+function hangingUntilAbort(opts) {
+  return new Promise((_, reject) => {
+    const hung = setTimeout(() => reject(new Error("probe never aborted (hung)")), 2000);
+    const onAbort = () => {
+      clearTimeout(hung);
+      reject(new Error("This operation was aborted"));
+    };
+    if (opts?.signal?.aborted) return onAbort();
+    opts?.signal?.addEventListener("abort", onAbort);
+  });
+}
+
 test("#605 codex r4: a cache-MISS entry detection is bounded by the caller's signal too", async () => {
   // Fresh cache: EVERY probe hangs until its signal fires. A managerGet under a
   // tight caller budget must fail fast, not stack 15s probes.
-  const fetchApi = (_route, opts) =>
-    new Promise((_, reject) => {
-      const onAbort = () => reject(new Error("This operation was aborted"));
-      if (opts?.signal?.aborted) return onAbort();
-      opts?.signal?.addEventListener("abort", onAbort);
-    });
+  const fetchApi = (_route, opts) => hangingUntilAbort(opts);
   const h = buildDialectHarness({
     fetchApi,
     managerCall: async () => ({}),
@@ -314,11 +327,7 @@ test("#605 codex r4: an aborted legacy-UI sub-probe is never pinned as a 'v2' ve
   // (which 405s on legacy-UI builds).
   const fetchApi = (route, opts) => {
     if (route === "/v2/manager/queue/status") return Promise.resolve(okJson(QUEUE_STATUS));
-    return new Promise((_, reject) => {
-      const onAbort = () => reject(new Error("This operation was aborted"));
-      if (opts?.signal?.aborted) return onAbort();
-      opts?.signal?.addEventListener("abort", onAbort);
-    });
+    return hangingUntilAbort(opts);
   };
   const h = buildDialectHarness({
     fetchApi,
@@ -374,11 +383,7 @@ test("#605 codex r3: the managerGet re-probe aborts with the CALLER's signal (wa
     if (!hanging) {
       return Promise.resolve(route === "/manager/queue/status" ? okJson(QUEUE_STATUS) : notFound());
     }
-    return new Promise((_, reject) => {
-      const onAbort = () => reject(new Error("This operation was aborted"));
-      if (opts?.signal?.aborted) return onAbort();
-      opts?.signal?.addEventListener("abort", onAbort);
-    });
+    return hangingUntilAbort(opts);
   };
   const managerCall = async (route) => {
     if (hanging) throw routeMissing();

--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -723,16 +723,25 @@ test("#485 nodes_install falls back to the legacy dialect on an unreachable sign
   const fnMatch = src.match(/async nodes_install\(args\)\s*\{[\s\S]*?\n {2}\},/);
   assert.ok(fnMatch, "could not locate nodes_install in panel source");
   const body = fnMatch[0];
-  // The submit is attempted, and on an unreachable error from a non-legacy
-  // dialect, retried as legacy (mirrors nodes_list's absolute fallback).
+  // The submit is attempted, and on an unreachable error the dialect is re-probed
+  // (#605) and the retry picked by the dialectRetryTarget ladder — which still
+  // lands on the absolute legacy routes when the re-probe agrees or the Manager
+  // is silent (the #485 fallback), and gives up (null → original error) when a
+  // legacy submit itself was rejected.
   assert.match(body, /let dialect = detected;/);
   assert.match(body, /submitInstall\(dialect\)/);
-  assert.match(body, /submitInstall\("legacy"\)/);
   assert.match(
     body,
-    /dialect === "legacy" \|\| !isManagerUnreachable\(err\)/,
-    "must rethrow when already legacy or the error is not an unreachable signal",
+    /if \(!isManagerUnreachable\(err\)\) throw err;/,
+    "only an unreachable signal triggers the re-probe/retry",
   );
+  assert.match(
+    body,
+    /dialectRetryTarget\(dialect, await reProbeManagerDialect\(\)\)/,
+    "the retry dialect comes from a live re-probe via the ladder",
+  );
+  assert.match(body, /if \(!retry\) throw err;/, "legacy-on-legacy gives up with the original error");
+  assert.match(body, /submitted = await submitInstall\(retry\)/);
   // The single queue/start MUST live OUTSIDE the try/catch (after it) so a start
   // failure never re-runs the submit (codex P0 — no double-fire).
   const catchIdx = body.indexOf("catch (err)");

--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -732,8 +732,8 @@ test("#485 nodes_install falls back to the legacy dialect on an unreachable sign
   assert.match(body, /submitInstall\(dialect\)/);
   assert.match(
     body,
-    /if \(!isManagerUnreachable\(err\)\) throw err;/,
-    "only an unreachable signal triggers the re-probe/retry",
+    /if \(!isManagerRouteMissing\(err\)\) throw err;/,
+    "only a PROVEN route-level rejection (the 404 marker) triggers the re-probe/retry — an ambiguous no-response failure must never re-send a mutation (codex P0)",
   );
   assert.match(
     body,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3769,9 +3769,7 @@ async function reProbeManagerDialect({ signal } = {}) {
   invalidateManagerDialectCache();
   try {
     return await detectManagerDialect({
-      signal: signal
-        ? AbortSignal.any([AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS), signal])
-        : AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS),
+      signal: anyAbortSignal([AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS), signal]),
     });
   } catch {
     return null;
@@ -3783,6 +3781,27 @@ async function reProbeManagerDialect({ signal } = {}) {
  *  status, list are ALL bounded). */
 const MANAGER_FETCH_TIMEOUT_MS = 15000;
 
+/** AbortSignal.any with a two-listener fallback for runtimes that predate it
+ *  (baseline 2024-03). A re-probe must stay bounded on EVERY frontend the panel
+ *  can load on: calling a missing AbortSignal.any inside managerProbe would
+ *  throw a TypeError that the probe SWALLOWS, silently disabling the #605
+ *  self-heal (codex r5). The sources here are per-call timeout/budget signals,
+ *  so the once-listeners die with them. */
+function anyAbortSignal(signals) {
+  const list = signals.filter(Boolean);
+  if (typeof AbortSignal.any === "function") return AbortSignal.any(list);
+  const ctrl = new AbortController();
+  const fire = () => ctrl.abort();
+  for (const s of list) {
+    if (s.aborted) {
+      fire();
+      break;
+    }
+    s.addEventListener("abort", fire, { once: true });
+  }
+  return ctrl.signal;
+}
+
 /** Soft GET probe: parsed JSON, or null on any non-ok / 404 / throw / stall.
  *  Never throws — a probe must not blow up detection. Bounded by an AbortSignal
  *  so a hanging probe can't wedge dialect detection; an optional caller signal
@@ -3792,9 +3811,7 @@ async function managerProbe(route, { signal } = {}) {
   try {
     const res = await api.fetchApi(route, {
       method: "GET",
-      signal: signal
-        ? AbortSignal.any([AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS), signal])
-        : AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS),
+      signal: anyAbortSignal([AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS), signal]),
     });
     if (!res || !res.ok) return null;
     const txt = await res.text();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10767,7 +10767,16 @@ const GRAPH_TOOL_EXECUTORS = {
     // has landed (`enqueued`), any later failure surfaces as-is, the same
     // submit/start split nodes_install keeps. dialectRetries caps the ladder so
     // a flapping backend mid-restart cannot loop it.
+    //
+    // The #424 405 fallback does NOT call legacyUpdate directly (codex r2): it
+    // routes through this loop as dialect="legacy", so a route-level rejection
+    // of the legacy POST (a backend that swapped generation between the 405 and
+    // the fallback) heals through the same ladder instead of falsely failing.
+    // `methodRejected` records that the via marker applies only when the update
+    // actually LANDS on the legacy route — a later heal to a pip dialect clears
+    // it (the result must name the route the update really took).
     let dialectRetries = 0;
+    let methodRejected = false;
     for (;;) {
       if (dialect === "v2") {
         const params = {
@@ -10792,8 +10801,9 @@ const GRAPH_TOOL_EXECUTORS = {
           // The 405 legacy self-update fallback wraps ONLY the enqueue: once the
           // task POST landed, a legacyUpdate would queue a SECOND update.
           if (!enqueued && isMethodNotAllowed(err)) {
-            await legacyUpdate();
-            return finalizeUpdate("legacy-self-update");
+            methodRejected = true;
+            dialect = "legacy";
+            continue;
           }
           // codex P0: the heal retries ONLY a PROVEN route-level rejection (the
           // 404 marker) before the enqueue landed — never an ambiguous
@@ -10822,8 +10832,9 @@ const GRAPH_TOOL_EXECUTORS = {
         } catch (err) {
           // The 405 legacy self-update fallback wraps ONLY the enqueue (as above).
           if (!enqueued && isMethodNotAllowed(err)) {
-            await legacyUpdate();
-            return finalizeUpdate("legacy-self-update");
+            methodRejected = true;
+            dialect = "legacy";
+            continue;
           }
           if (enqueued || !isManagerRouteMissing(err)) throw err;
           const retry = dialectRetryTarget(dialect, await reProbeManagerDialect());
@@ -10832,6 +10843,7 @@ const GRAPH_TOOL_EXECUTORS = {
           dialect = retry;
           continue;
         }
+        return finalizeUpdate();
       } else {
         try {
           await legacyUpdate();
@@ -10843,8 +10855,10 @@ const GRAPH_TOOL_EXECUTORS = {
           dialect = retry;
           continue;
         }
+        // The via marker names the legacy SELF-UPDATE route only when the update
+        // actually landed there after a /v2 method rejection (#424).
+        return finalizeUpdate(methodRejected ? "legacy-self-update" : undefined);
       }
-      return finalizeUpdate();
     }
   },
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3817,13 +3817,26 @@ function looksLikeQueueStatus(s) {
 /** Detect (and cache per session) which Manager generation the connected
  *  ComfyUI runs. See the dialect comment above. An optional `signal` bounds the
  *  probes (a re-probe inherits the caller's remaining budget — #605 codex r3);
- *  an aborted probe reads as "no answer", never as a dialect verdict. */
+ *  an aborted probe reads as "no answer", never as a dialect verdict — and when
+ *  the signal HAS fired, detection bails WITHOUT caching: a partial reading
+ *  (e.g. the legacy-UI probe dying to the deadline right after the status
+ *  probe answered) must never be pinned as a wrong sub-dialect (codex r4). */
 async function detectManagerDialect({ signal } = {}) {
   if (managerDialectCache) return managerDialectCache;
   const opts = signal ? { signal } : {};
+  const assertNotAborted = () => {
+    if (signal?.aborted) {
+      throw new Error(
+        "ComfyUI-Manager dialect detection was aborted mid-probe (the caller's " +
+          "budget ran out) — no verdict was cached. Retry the operation.",
+      );
+    }
+  };
   const v2 = await managerProbe("/v2/manager/queue/status", opts);
+  assertNotAborted();
   if (looksLikeQueueStatus(v2)) {
     const legacyUi = await managerProbe("/v2/manager/is_legacy_manager_ui", opts);
+    assertNotAborted();
     managerDialectCache =
       legacyUi && typeof legacyUi === "object" && legacyUi.is_legacy_manager_ui === true
         ? "v2-batch"
@@ -3831,6 +3844,7 @@ async function detectManagerDialect({ signal } = {}) {
     return managerDialectCache;
   }
   const legacy = await managerProbe("/manager/queue/status", opts);
+  assertNotAborted();
   if (looksLikeQueueStatus(legacy)) {
     managerDialectCache = "legacy";
     return managerDialectCache;
@@ -3856,7 +3870,7 @@ async function detectManagerDialect({ signal } = {}) {
  *  unreachable fallbacks (#426 /object_info search) still fire exactly as
  *  before. */
 async function managerGet(route, { signal } = {}) {
-  const dialect = await detectManagerDialect();
+  const dialect = await detectManagerDialect({ signal });
   const opts = signal ? { signal } : {};
   try {
     return dialect === "legacy" ? await managerCall(route, opts) : await managerV2(route, opts);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3759,11 +3759,20 @@ function invalidateManagerDialectCache() {
  *  all (mid-restart / disabled) — the caller then surfaces its ORIGINAL error,
  *  which carries the operation's real context. A failed re-probe leaves the
  *  cache EMPTY (never the stale value), so the next call probes again instead
- *  of wedging on a verdict from a server that is gone. */
-async function reProbeManagerDialect() {
+ *  of wedging on a verdict from a server that is gone.
+ *
+ *  The WHOLE re-probe shares ONE budget (codex r3): the caller's signal when it
+ *  carries one (waitForUpdateResult's 15s envelope must not be outlived by
+ *  stacked 15s probes after its routed call already failed), always capped by
+ *  the shared Manager timeout. */
+async function reProbeManagerDialect({ signal } = {}) {
   invalidateManagerDialectCache();
   try {
-    return await detectManagerDialect();
+    return await detectManagerDialect({
+      signal: signal
+        ? AbortSignal.any([AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS), signal])
+        : AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS),
+    });
   } catch {
     return null;
   }
@@ -3776,12 +3785,16 @@ const MANAGER_FETCH_TIMEOUT_MS = 15000;
 
 /** Soft GET probe: parsed JSON, or null on any non-ok / 404 / throw / stall.
  *  Never throws — a probe must not blow up detection. Bounded by an AbortSignal
- *  so a hanging probe can't wedge dialect detection. */
-async function managerProbe(route) {
+ *  so a hanging probe can't wedge dialect detection; an optional caller signal
+ *  is combined in (#605 codex r3 — a re-probe must not outlive the budget that
+ *  paid for the failed routed call). */
+async function managerProbe(route, { signal } = {}) {
   try {
     const res = await api.fetchApi(route, {
       method: "GET",
-      signal: AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS),
+      signal: signal
+        ? AbortSignal.any([AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS), signal])
+        : AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS),
     });
     if (!res || !res.ok) return null;
     const txt = await res.text();
@@ -3802,19 +3815,22 @@ function looksLikeQueueStatus(s) {
 }
 
 /** Detect (and cache per session) which Manager generation the connected
- *  ComfyUI runs. See the dialect comment above. */
-async function detectManagerDialect() {
+ *  ComfyUI runs. See the dialect comment above. An optional `signal` bounds the
+ *  probes (a re-probe inherits the caller's remaining budget — #605 codex r3);
+ *  an aborted probe reads as "no answer", never as a dialect verdict. */
+async function detectManagerDialect({ signal } = {}) {
   if (managerDialectCache) return managerDialectCache;
-  const v2 = await managerProbe("/v2/manager/queue/status");
+  const opts = signal ? { signal } : {};
+  const v2 = await managerProbe("/v2/manager/queue/status", opts);
   if (looksLikeQueueStatus(v2)) {
-    const legacyUi = await managerProbe("/v2/manager/is_legacy_manager_ui");
+    const legacyUi = await managerProbe("/v2/manager/is_legacy_manager_ui", opts);
     managerDialectCache =
       legacyUi && typeof legacyUi === "object" && legacyUi.is_legacy_manager_ui === true
         ? "v2-batch"
         : "v2";
     return managerDialectCache;
   }
-  const legacy = await managerProbe("/manager/queue/status");
+  const legacy = await managerProbe("/manager/queue/status", opts);
   if (looksLikeQueueStatus(legacy)) {
     managerDialectCache = "legacy";
     return managerDialectCache;
@@ -3846,7 +3862,7 @@ async function managerGet(route, { signal } = {}) {
     return dialect === "legacy" ? await managerCall(route, opts) : await managerV2(route, opts);
   } catch (err) {
     if (!isManagerUnreachable(err)) throw err;
-    const fresh = await reProbeManagerDialect();
+    const fresh = await reProbeManagerDialect({ signal });
     const retry = dialectRetryTarget(dialect, fresh);
     // A same-dialect re-probe means the route genuinely does not serve — the
     // retry would repeat the exact call that just failed, so don't.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -71,6 +71,7 @@ import {
   classifyInstallOutcome,
   classifyUpdateOutcome,
   collectRecentTaskFailures,
+  dialectRetryTarget,
   installGitUrl,
   installedListRoute,
   isManagerUnreachable,
@@ -683,6 +684,11 @@ function setupListeners() {
       // new window (codex P1); only an open/new AFTER this reconnect will.
       backendReconnectEpoch += 1;
       backendReconnectedAt = monotonicNow();
+      // #605: this reconnect can be a backend RESTART that swapped the Manager
+      // generation (3.x ↔ pip v4) under the live tab — the cached dialect then
+      // describes a server that is gone. Drop it so the next Manager call
+      // re-probes the backend that is actually answering now.
+      invalidateManagerDialectCache();
       void refreshComfyNodeDefs();
     });
   } catch {
@@ -3720,6 +3726,32 @@ async function managerCall(route, { method = "GET", body, signal } = {}) {
 //              routes /manager/queue/{install,update,start,status,...}.
 let managerDialectCache = null;
 
+/** #605 — the dialect cache is a per-tab HYPOTHESIS about which Manager
+ *  generation the connected backend runs. A ComfyUI restart can swap Manager
+ *  3.x ↔ pip v4 under a live tab (the #605 report), and the stale cache then
+ *  routes every Manager call at routes the new backend does not serve. Dropped
+ *  on the two signals that falsify the hypothesis: the backend socket
+ *  re-establishing (setupListeners' "reconnected") and an "unreachable" verdict
+ *  from a dialect-routed call (reProbeManagerDialect below). */
+function invalidateManagerDialectCache() {
+  managerDialectCache = null;
+}
+
+/** #605 — drop the cached dialect and re-probe the LIVE backend once. Returns
+ *  the fresh dialect, or null when the Manager currently answers no dialect at
+ *  all (mid-restart / disabled) — the caller then surfaces its ORIGINAL error,
+ *  which carries the operation's real context. A failed re-probe leaves the
+ *  cache EMPTY (never the stale value), so the next call probes again instead
+ *  of wedging on a verdict from a server that is gone. */
+async function reProbeManagerDialect() {
+  invalidateManagerDialectCache();
+  try {
+    return await detectManagerDialect();
+  } catch {
+    return null;
+  }
+}
+
 /** Every Manager HTTP call is bounded by this timeout so a stalled request can
  *  never hang the install path (codex round 2 #5 — probes, install, start,
  *  status, list are ALL bounded). */
@@ -3778,11 +3810,32 @@ async function detectManagerDialect() {
 }
 
 /** GET the queue status / installed / getmappings surface for the detected
- *  dialect. Legacy has NO /v2 prefix; both pip modes serve /v2. */
+ *  dialect. Legacy has NO /v2 prefix; both pip modes serve /v2.
+ *
+ *  #605 self-heal: an "unreachable" verdict from the dialect-routed route can
+ *  mean the CACHED dialect outlived a backend restart that swapped Manager
+ *  generations — the routes it routes to no longer exist. That is a route-level
+ *  rejection (a GET ran no mutation), so invalidate + re-probe ONCE and retry
+ *  on the dialect the ladder picks: the fresh verdict when it changed, else the
+ *  legacy absolute last resort (#423 — a hybrid build can answer the /v2 probe
+ *  yet not register the /v2 data GETs). A legacy-on-legacy failure has no
+ *  fallback left and rethrows the ORIGINAL error, so the callers' own
+ *  unreachable fallbacks (#426 /object_info search) still fire exactly as
+ *  before. */
 async function managerGet(route, { signal } = {}) {
   const dialect = await detectManagerDialect();
   const opts = signal ? { signal } : {};
-  return dialect === "legacy" ? managerCall(route, opts) : managerV2(route, opts);
+  try {
+    return dialect === "legacy" ? await managerCall(route, opts) : await managerV2(route, opts);
+  } catch (err) {
+    if (!isManagerUnreachable(err)) throw err;
+    const fresh = await reProbeManagerDialect();
+    const retry = dialectRetryTarget(dialect, fresh);
+    // A same-dialect re-probe means the route genuinely does not serve — the
+    // retry would repeat the exact call that just failed, so don't.
+    if (!retry || retry === dialect) throw err;
+    return retry === "legacy" ? managerCall(route, opts) : managerV2(route, opts);
+  }
 }
 
 /** #426 — fetch the connected ComfyUI's full `/object_info` map (node CLASS →
@@ -10479,7 +10532,9 @@ const GRAPH_TOOL_EXECUTORS = {
     // routed /v2/customnode/installed 404s ("not reachable") while the absolute
     // /customnode/installed serves fine. On that unreachable signal, fall back
     // to the absolute (no-/v2) legacy list route instead of surfacing a generic
-    // "unreachable" error.
+    // "unreachable" error. managerGet already self-heals a stale dialect and
+    // retries legacy internally (#605); this catch is the last-resort layer for
+    // when BOTH routed attempts reported unreachable.
     const route = installedListRoute();
     // #332 — immediately after panel_restart_comfyui, a Manager fetch throws a
     // bare transport error ("Failed to fetch") before any HTTP status exists, so
@@ -10547,14 +10602,26 @@ const GRAPH_TOOL_EXECUTORS = {
     // non-legacy dialect, retry the SUBMIT via the legacy dialect before
     // surfacing the error. The fallback wraps ONLY the enqueue: if the submit
     // already succeeded, a later queue/start failure must NOT re-submit.
+    //
+    // #605: the unreachable verdict can ALSO mean the CACHED dialect outlived a
+    // backend restart that swapped Manager generations (a stale "legacy" cache
+    // aims the submit at /manager/queue/install, which a restarted v4 backend
+    // does not serve — and the old legacy-only fallback then threw a false
+    // "not reachable"). A 404 is a route-level rejection — no handler ran,
+    // NOTHING was enqueued — so re-submitting on the re-probed live dialect
+    // cannot double-fire the install. Re-probe ONCE; dialectRetryTarget picks
+    // the retry: the fresh verdict when it changed, else the #485 legacy last
+    // resort (null when nothing is left — the original error then surfaces).
     let dialect = detected;
     let submitted;
     try {
       submitted = await submitInstall(dialect);
     } catch (err) {
-      if (dialect === "legacy" || !isManagerUnreachable(err)) throw err;
-      dialect = "legacy";
-      submitted = await submitInstall("legacy");
+      if (!isManagerUnreachable(err)) throw err;
+      const retry = dialectRetryTarget(dialect, await reProbeManagerDialect());
+      if (!retry) throw err;
+      dialect = retry;
+      submitted = await submitInstall(retry);
     }
     // The submission landed. NOW start the queue on the SAME (possibly
     // fallen-back) dialect. queue/start goes through managerQueueControl so a
@@ -10601,7 +10668,7 @@ const GRAPH_TOOL_EXECUTORS = {
   async graph_update_node({ id, version, channel, mode }) {
     if (!id) throw new Error("id (installed pack name/dir or registry id) is required");
     const sel = version === "nightly" ? "nightly" : "latest";
-    const dialect = await detectManagerDialect();
+    let dialect = await detectManagerDialect();
     const ui_id = crypto.randomUUID();
     const client_id = api.clientId ?? api.initialClientId ?? "comfyui-mcp-panel";
     // #424: the absolute (no-/v2) legacy self-update route. Updating the
@@ -10610,9 +10677,14 @@ const GRAPH_TOOL_EXECUTORS = {
     // frontend catchall. The released-3.x `/manager/queue/update` handler keys
     // the update off `id` (unified_update) and DOES update the Manager itself,
     // so we retry it whenever the /v2 envelope is method-rejected.
+    // `legacyEnqueued` marks the update POST having LANDED so the #605 heal
+    // below never re-fires it on a later start failure (same submit/start
+    // split as nodes_install — codex P0, no double-fire).
+    let legacyEnqueued = false;
     const legacyUpdate = async () => {
       const body = legacyUpdateBody({ ui_id, id, version });
       await managerCall("manager/queue/update", { method: "POST", body });
+      legacyEnqueued = true;
       await managerCall("manager/queue/start", { method: "POST" });
     };
     // #364: after the task is queued+started, VERIFY its terminal per-task status
@@ -10663,49 +10735,93 @@ const GRAPH_TOOL_EXECUTORS = {
       }
       return { ...base, updated: false, verified: false, pending: true, note: outcome.message };
     };
-    if (dialect === "v2") {
-      const params = {
-        // The Manager's update task keys off node_name; include id too for
-        // correlation parity with install (harmless if the server ignores it).
-        node_name: id,
-        id,
-        selected_version: sel,
-        version: sel,
-        mode: mode || "remote",
-        channel: channel || "default",
-      };
-      try {
-        await managerV2("manager/queue/task", {
-          method: "POST",
-          body: { kind: "update", params, ui_id, client_id },
-        });
-        await managerV2("manager/queue/start", { method: "POST" });
-      } catch (err) {
-        if (!isMethodNotAllowed(err)) throw err;
-        await legacyUpdate();
-        return finalizeUpdate("legacy-self-update");
+    // #605: an "unreachable" verdict from the dialect-routed ENQUEUE can mean the
+    // cached dialect outlived a backend restart that swapped Manager generations
+    // under this live tab (a stale "legacy" cache aims the update at
+    // /manager/queue/update, which a restarted v4 backend does not serve — and
+    // without a heal here that throws a false "not reachable" forever). A 404 is
+    // a route-level rejection — no handler ran, NOTHING was queued — so
+    // re-probing ONCE and re-sending the enqueue on the live dialect cannot
+    // double-fire the update. ONLY the enqueue is retried: once the task POST
+    // has landed (`enqueued`), any later failure surfaces as-is, the same
+    // submit/start split nodes_install keeps. dialectRetries caps the ladder so
+    // a flapping backend mid-restart cannot loop it.
+    let dialectRetries = 0;
+    for (;;) {
+      if (dialect === "v2") {
+        const params = {
+          // The Manager's update task keys off node_name; include id too for
+          // correlation parity with install (harmless if the server ignores it).
+          node_name: id,
+          id,
+          selected_version: sel,
+          version: sel,
+          mode: mode || "remote",
+          channel: channel || "default",
+        };
+        let enqueued = false;
+        try {
+          await managerV2("manager/queue/task", {
+            method: "POST",
+            body: { kind: "update", params, ui_id, client_id },
+          });
+          enqueued = true;
+          await managerV2("manager/queue/start", { method: "POST" });
+        } catch (err) {
+          // The 405 legacy self-update fallback wraps ONLY the enqueue: once the
+          // task POST landed, a legacyUpdate would queue a SECOND update.
+          if (!enqueued && isMethodNotAllowed(err)) {
+            await legacyUpdate();
+            return finalizeUpdate("legacy-self-update");
+          }
+          if (enqueued || !isManagerUnreachable(err)) throw err;
+          const retry = dialectRetryTarget(dialect, await reProbeManagerDialect());
+          if (!retry || dialectRetries >= 2) throw err;
+          dialectRetries += 1;
+          dialect = retry;
+          continue;
+        }
+        return finalizeUpdate();
+      }
+      // v2-batch + legacy: 3.x update body {ui_id, id, version} (issues #187/#182).
+      const body = { ui_id, id, version: sel };
+      if (dialect === "v2-batch") {
+        let enqueued = false;
+        try {
+          const res = await managerV2("manager/queue/batch", {
+            method: "POST",
+            body: { update: [body] },
+          });
+          enqueued = true;
+          assertBatchOk(res, id, "update");
+          await managerV2("manager/queue/start", { method: "POST" });
+        } catch (err) {
+          // The 405 legacy self-update fallback wraps ONLY the enqueue (as above).
+          if (!enqueued && isMethodNotAllowed(err)) {
+            await legacyUpdate();
+            return finalizeUpdate("legacy-self-update");
+          }
+          if (enqueued || !isManagerUnreachable(err)) throw err;
+          const retry = dialectRetryTarget(dialect, await reProbeManagerDialect());
+          if (!retry || dialectRetries >= 2) throw err;
+          dialectRetries += 1;
+          dialect = retry;
+          continue;
+        }
+      } else {
+        try {
+          await legacyUpdate();
+        } catch (err) {
+          if (legacyEnqueued || !isManagerUnreachable(err)) throw err;
+          const retry = dialectRetryTarget(dialect, await reProbeManagerDialect());
+          if (!retry || dialectRetries >= 2) throw err;
+          dialectRetries += 1;
+          dialect = retry;
+          continue;
+        }
       }
       return finalizeUpdate();
     }
-    // v2-batch + legacy: 3.x update body {ui_id, id, version} (issues #187/#182).
-    const body = { ui_id, id, version: sel };
-    if (dialect === "v2-batch") {
-      try {
-        const res = await managerV2("manager/queue/batch", {
-          method: "POST",
-          body: { update: [body] },
-        });
-        assertBatchOk(res, id, "update");
-        await managerV2("manager/queue/start", { method: "POST" });
-      } catch (err) {
-        if (!isMethodNotAllowed(err)) throw err;
-        await legacyUpdate();
-        return finalizeUpdate("legacy-self-update");
-      }
-    } else {
-      await legacyUpdate();
-    }
-    return finalizeUpdate();
   },
 
   async nodes_queue_status() {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -74,6 +74,7 @@ import {
   dialectRetryTarget,
   installGitUrl,
   installedListRoute,
+  isManagerRouteMissing,
   isManagerUnreachable,
   isMethodNotAllowed,
   legacyUpdateBody,
@@ -3669,8 +3670,17 @@ async function managerV2(route, { method = "GET", body, signal } = {}) {
     ...(signal ? { signal } : {}),
     ...(body ? { headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) } : {}),
   });
-  if (!res || res.status === 404) {
+  if (!res) {
     throw new Error("ComfyUI-Manager not reachable (is the built-in Manager enabled?)");
+  }
+  if (res.status === 404) {
+    // A 404 is a PROVEN route-level rejection — no handler ran. Tag it so the
+    // #605 mutation self-heal can tell it apart from the ambiguous no-response
+    // case above (a lost response proves NOTHING about whether the request
+    // landed, so it must never authorize a mutation re-send — codex P0).
+    const err = new Error("ComfyUI-Manager not reachable (is the built-in Manager enabled?)");
+    err.managerRouteMissing = true;
+    throw err;
   }
   if (!res.ok) {
     let msg = `HTTP ${res.status}`;
@@ -3695,8 +3705,15 @@ async function managerCall(route, { method = "GET", body, signal } = {}) {
     ...(signal ? { signal } : {}),
     ...(body ? { headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) } : {}),
   });
-  if (!res || res.status === 404) {
+  if (!res) {
     throw new Error("ComfyUI-Manager not reachable (is the built-in Manager enabled?)");
+  }
+  if (res.status === 404) {
+    // See managerV2: a 404 is the PROVEN route-level rejection the #605
+    // mutation self-heal may retry on (err.managerRouteMissing).
+    const err = new Error("ComfyUI-Manager not reachable (is the built-in Manager enabled?)");
+    err.managerRouteMissing = true;
+    throw err;
   }
   if (!res.ok) {
     let msg = `HTTP ${res.status}`;
@@ -10617,7 +10634,11 @@ const GRAPH_TOOL_EXECUTORS = {
     try {
       submitted = await submitInstall(dialect);
     } catch (err) {
-      if (!isManagerUnreachable(err)) throw err;
+      // codex P0: the retry gate is the PROVEN route-level rejection (the 404
+      // marker), never the broader "not reachable" — a no-response transport
+      // failure says nothing about whether the POST landed, and re-submitting
+      // then would double-fire the install.
+      if (!isManagerRouteMissing(err)) throw err;
       const retry = dialectRetryTarget(dialect, await reProbeManagerDialect());
       if (!retry) throw err;
       dialect = retry;
@@ -10774,7 +10795,10 @@ const GRAPH_TOOL_EXECUTORS = {
             await legacyUpdate();
             return finalizeUpdate("legacy-self-update");
           }
-          if (enqueued || !isManagerUnreachable(err)) throw err;
+          // codex P0: the heal retries ONLY a PROVEN route-level rejection (the
+          // 404 marker) before the enqueue landed — never an ambiguous
+          // no-response failure, which says nothing about whether the POST ran.
+          if (enqueued || !isManagerRouteMissing(err)) throw err;
           const retry = dialectRetryTarget(dialect, await reProbeManagerDialect());
           if (!retry || dialectRetries >= 2) throw err;
           dialectRetries += 1;
@@ -10801,7 +10825,7 @@ const GRAPH_TOOL_EXECUTORS = {
             await legacyUpdate();
             return finalizeUpdate("legacy-self-update");
           }
-          if (enqueued || !isManagerUnreachable(err)) throw err;
+          if (enqueued || !isManagerRouteMissing(err)) throw err;
           const retry = dialectRetryTarget(dialect, await reProbeManagerDialect());
           if (!retry || dialectRetries >= 2) throw err;
           dialectRetries += 1;
@@ -10812,7 +10836,7 @@ const GRAPH_TOOL_EXECUTORS = {
         try {
           await legacyUpdate();
         } catch (err) {
-          if (legacyEnqueued || !isManagerUnreachable(err)) throw err;
+          if (legacyEnqueued || !isManagerRouteMissing(err)) throw err;
           const retry = dialectRetryTarget(dialect, await reProbeManagerDialect());
           if (!retry || dialectRetries >= 2) throw err;
           dialectRetries += 1;

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -382,10 +382,24 @@ export function installedListRoute() {
  *  (a 404 / the panel's "not reachable" throw), i.e. we should retry the
  *  absolute (no-/v2) legacy route? A legacy-UI pip build can answer the queue
  *  probe on /v2 yet NOT register the /v2 data GETs, so the dialect-routed
- *  /v2/customnode/installed 404s while /customnode/installed serves fine. */
+ *  /v2/customnode/installed 404s while /customnode/installed serves fine.
+ *  Broad on purpose: it gates IDEMPOTENT GET fallbacks, where re-issuing the
+ *  request after even an ambiguous transport failure is safe. Mutations must
+ *  use the stricter isManagerRouteMissing instead (codex P0). */
 export function isManagerUnreachable(err) {
   const msg = String(err?.message ?? err ?? "");
   return /not reachable/i.test(msg) || /HTTP\s*404\b/.test(msg);
+}
+
+/** #605 / codex P0 — is this error a PROVEN route-level rejection (an HTTP 404
+ *  surfaced by managerCall/managerV2, tagged with `managerRouteMissing`)? Only
+ *  a 404 proves no handler ran, so ONLY this predicate may authorize re-sending
+ *  a MUTATION on another dialect. The broader isManagerUnreachable also matches
+ *  the transports' no-response "not reachable" throw — a lost response says
+ *  nothing about whether the POST landed, so gating a mutation retry on it
+ *  could double-fire the install/update. */
+export function isManagerRouteMissing(err) {
+  return !!err && err.managerRouteMissing === true;
 }
 
 /** #424 — did the Manager reject the method (HTTP 405)? Updating ComfyUI-Manager

--- a/web/js/lib/manager-install.js
+++ b/web/js/lib/manager-install.js
@@ -406,6 +406,29 @@ export function legacyUpdateBody({ ui_id, id, version } = {}) {
 }
 
 /**
+ * #605 — after a dialect-routed call failed "unreachable" (a route-level
+ * rejection: no handler ran, so re-issuing it cannot double-execute anything),
+ * which dialect should the retry speak? `failed` is the dialect that just
+ * 404'd; `fresh` is the result of re-probing the LIVE backend (null = the
+ * Manager currently answers no dialect at all — mid-restart or disabled).
+ *
+ *   - A fresh verdict that DIFFERS from the failed one wins: the cached dialect
+ *     outlived a backend restart that swapped Manager generations (the #605
+ *     report — a stale "legacy" cache aiming at routes a v4 backend no longer
+ *     serves), and the live probe is the ground truth.
+ *   - Otherwise (the re-probe agrees, or the Manager answers nothing right now)
+ *     the legacy absolute routes remain the last resort for a non-legacy
+ *     dialect (#485 — a hybrid build can answer the /v2 probe yet not register
+ *     the /v2 data/mutation routes).
+ *   - A legacy-on-legacy failure has no fallback left: return null so the
+ *     caller surfaces its ORIGINAL error, which carries the real context.
+ */
+export function dialectRetryTarget(failed, fresh) {
+  if (fresh && fresh !== failed) return fresh;
+  return failed === "legacy" ? null : "legacy";
+}
+
+/**
  * Normalize a ComfyUI-Manager `/customnode/getmappings` payload into the
  * nodes_search result shape `{ count, results:[{id,title,description}] }`,
  * filtered by `query` and capped at `limit` (default 15, max 40). Pure so the


### PR DESCRIPTION
## Issues in this cluster

- artokun/comfyui-mcp-panel#605 — Manager dialect cache stays legacy after a backend restart to v4
- artokun/comfyui-mcp#887 — panel sync no-ops on incoherent Manager queue counts while reinstall succeeds

## What changed (#605)

The per-tab `managerDialectCache` was never invalidated: after a Manager 3.x → pip v4 migration and a ComfyUI restart with the browser tab alive, `panel_list_nodes` (and every other dialect-routed call) kept routing at the retired 3.x routes and reported a false "ComfyUI-Manager not reachable" until a full frontend reload.

The fix treats the cached dialect as a hypothesis that two signals falsify:

- **Lifecycle:** the `reconnected` listener (backend socket re-established = the restart signal) now drops the cache.
- **Per-call backstop:** an "unreachable" verdict from a dialect-routed call invalidates the cache, re-probes the live backend once (`reProbeManagerDialect`), and retries via the pure `dialectRetryTarget` ladder (fresh verdict wins when it changed; else the artokun/comfyui-mcp-panel#485 legacy absolute last resort; legacy-on-legacy surfaces the original error). Applied at `managerGet` (covers nodes_list / nodes_search / nodes_queue_status / update verification) and at the mutation paths (`nodes_install` submit, `graph_update_node` dispatch).

Mutation retries fire ONLY on a proven route-level rejection: the Manager transports now tag their HTTP 404 throw (`err.managerRouteMissing`, checked by `isManagerRouteMissing`) — an ambiguous no-response "not reachable" never re-sends an install/update (no double-fire), and landed-enqueue tracking (`enqueued` / `legacyEnqueued`) keeps a post-enqueue start failure from re-firing. The artokun/comfyui-mcp-panel#424 405→legacyUpdate fallback routes through the same ladder. The whole re-probe shares one budget (caller's signal combined via a feature-detected `anyAbortSignal` with the 15s Manager timeout), and an aborted probe never pins a partial verdict into the cache.

Codex adversarial gate: 5 finding rounds (r1 mutation-retry ambiguity P0, r2 405-fallback ladder bypass, r3 re-probe budget, r4 entry-detection budget + false sub-dialect pin, r5 `AbortSignal.any` baseline) — each fixed with mutation-verified tests; round 6 PASS. Full unit suite 1801/1801; committed blobs scanned for control bytes (0); panel verified as ES module (`node --check` as .mjs).

## What deliberately did NOT change (#598)

`install_panel(action="sync")` is implemented entirely in the orchestrator repo (`comfyui-mcp` `src/services/panel-installer.ts` / `panel-sync.ts`) — it talks to the Manager over HTTP directly; the panel is not in that codepath, so there is no panel-repo change possible here. The current orchestrator already detects the incoherent-counts signature (done > total) and deliberately refuses the git fallback with an actionable remedy (#724 codex gates). The issue's remaining ask — sync offering or automatically using the verified reinstall fallback when the Manager no-ops incoherently and no clean git fallback exists — is an orchestrator-side enhancement and stays open on artokun/comfyui-mcp#887.

## Live-browser confirmation

The stale-cache heal paths are covered by source-extraction unit tests against the real panel functions; the actual 3.x→v4 restart swap with a live tab (the issue's repro) can only be confirmed in a browser.
