### PR TITLE
run targeting: honour to_node_id instead of only refusing to violate it (#556); #581 already fixed on main

### DIFF
--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -980,6 +980,101 @@ test("#630 gate r4: a LATE extra post, arriving AFTER the run reported success, 
   }
 });
 
+test("#630 gate r8 P0: a RETRYING run never displaces a concurrent run's sentinel — B's late post is still fenced", async () => {
+  // A installs GA1 and waits on a deferred first attempt. B starts, captures
+  // GA1 as its chain, succeeds, and retains GB. A's deferred post arrives
+  // scopeless, GA1 refuses it, and A retries. A's finally used to restore A's
+  // ENTRY-TIME fetchApi (raw), CLOBBERING GB — and A's next guard also
+  // delegated to A's entry-time raw fetch, bypassing B. A late B post then
+  // passed through as foreign and reached raw fetch scopeless: full graph.
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    // A: shim-less (drops the positional array) and DEFERRED, so attempt 1's
+    // post is driven manually below — the interleaving the old overlap test
+    // never produced, because it only started B after A had already returned.
+    const appA = makeFrontend({ shape: "shimless", defer: true, apiTarget });
+    const runA = dispatchScopedRun({
+      app: appA, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14, verifyTimeoutMs: 1500,
+    });
+    await sleep(15); // A has installed GA1 and is waiting on its deferred post
+    const attempt1Item = appA.deferredItem;
+    // B runs to completion WHILE A is mid-flight, and retains GB as current.
+    const appB = makeFrontend({ shape: "shim", apiTarget });
+    const resultB = await dispatchScopedRun({
+      app: appB, apiTarget, execIds: ["15"], batch: 1, toNodeId: 15,
+    });
+    assert.equal(resultB.outcome, "dispatched");
+    const callsAfterB = server.calls.length;
+    // A's deferred attempt-1 post lands SCOPELESS (shim-less dropped the array)
+    // and is refused — which is what makes A RETRY the next shape. That retry
+    // is the moment the old code restored A's entry-time fetchApi over GB.
+    await appA.postDeferred(attempt1Item);
+    await runA;
+    // THE REGRESSION: B's late scopeless post must still be fenced. If A's
+    // retry clobbered GB, or A's next guard delegated to A's entry-time raw
+    // fetch instead of the current chain, this reaches the server unscoped.
+    const lateB = frontendBody({ output: OUR_OUTPUT, number: resultB.queueMark, targets: null });
+    await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(lateB) });
+    assert.equal(
+      server.calls.length,
+      callsAfterB,
+      "B's late scopeless post never reached ComfyUI — A's retry did not displace or bypass B's fence",
+    );
+  } finally {
+    stop();
+  }
+});
+
+test("#630 gate r8 P0: a superseded attempt RETIRES rather than unhooking — it never double-handles its successor's post", async () => {
+  // Standing down by writing fetchApi back to an older value is what displaced
+  // other runs. Retiring keeps the chain intact; the retired guard must then be
+  // fully transparent, or it would refuse its own successor's repaired body.
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const raw = apiTarget.fetchApi;
+    const app = makeFrontend({ shape: "dropping", apiTarget });
+    const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
+    // The repair attempt is attempt 3; attempts 1 and 2 were superseded. If a
+    // retired guard still acted on the mark, the repaired body would have been
+    // refused on its way down the chain instead of reaching the server.
+    assert.equal(result.outcome, "dispatched");
+    assert.equal(result.scopeAppliedBy, "request_body_repair");
+    assert.equal(server.calls.length, 1);
+    assert.deepEqual(JSON.parse(server.calls[0].options.body).partial_execution_targets, ["14"]);
+    // The chain was never unwound back to raw.
+    assert.notEqual(apiTarget.fetchApi, raw, "the terminal sentinel is current, and raw fetch was never restored");
+  } finally {
+    stop();
+  }
+});
+
+test("#630 gate r8 P1: an INDETERMINATE dispatch omits `queued` — neither true nor false is honest", () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const source = readFileSync(join(here, "../../web/js/comfyui-mcp-panel.js"), "utf8").replace(/\r\n/g, "\n");
+  const start = source.indexOf('if (runScopeResult && runScopeResult.outcome !== "dispatched")');
+  assert.ok(start > 0);
+  const block = source.slice(start, start + 6000).replace(/`\s*\+\s*\n\s*`/g, "").replace(/\s+/g, " ");
+  // The indeterminate branch must NOT assert queued:false…
+  const indetStart = block.indexOf("if (runScopeResult.indeterminate > 0)");
+  assert.ok(indetStart > 0, "the indeterminate case is handled separately");
+  // Bound the slice to THIS branch's return, or it runs on into the
+  // nothing-dispatched `queued: false` below and the assertion means nothing.
+  const indetBlock = block.slice(indetStart, block.indexOf("}; }", indetStart) + 4);
+  assert.ok(indetBlock.length > 100 && indetBlock.length < 900, "the branch was isolated, not the whole tail");
+  assert.doesNotMatch(indetBlock, /queued: false/,
+    "a definite negative about a request whose fate we say we cannot determine");
+  assert.match(indetBlock, /queued_unknown: true/);
+  assert.match(indetBlock, /deliberately omits "queued"/, "and the omission is explained, not silent");
+  assert.match(indetBlock, /a blind retry can render the branch twice/);
+  // …while a run where nothing left the panel still gets the definite answer.
+  assert.match(block, /return \{ queued: false, error: runScopeResult\.error \};/,
+    "nothing dispatched ⇒ queued:false is observable and still stated plainly");
+});
+
 test("#630 gate r7 P0-1: only a genuinely ABSENT key is repaired — a PRESENT value we cannot interpret is refused, never overwritten", async () => {
   // Absence is ours to fill. `[]`, `null`, `"14"` and especially
   // `{ queueNodeIds: [...] }` are PRESENT values in a shape we did not expect —
@@ -1300,7 +1395,10 @@ test("#630 gate r6: graph_run never states a remainder it cannot count, and neve
   assert.match(block, /the remaining count cannot be stated from here without risking a duplicate render/);
   assert.match(block, /Check the ComfyUI queue before re-running anything/);
   // Zero verified + an indeterminate dispatch is still not "nothing ran".
-  assert.match(block, /outcome_unknown = true/);
+  // #630 r8 — this used to be `outcome_unknown` beside a `queued: false`. The
+  // flag is now `queued_unknown` and `queued` is omitted entirely, because no
+  // boolean is an honest answer for a request whose fate we cannot determine.
+  assert.match(block, /queued_unknown: true/);
   assert.match(block, /rather than assuming nothing ran/);
 });
 

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -30,6 +30,7 @@ import {
   scopeDroppedError,
   scopeUnverifiedError,
   scopeUnattributableError,
+  scopeDispatchError,
   createRunFetchInterceptor,
   createScopedRunGuard,
   describeObserved,
@@ -233,8 +234,10 @@ test("#630 repairScopeInBody: refuses what it cannot safely rewrite — unparsea
     null,
     "no resolved scope ⇒ nothing to write; never an empty partial_execution_targets",
   );
-  // A wrong/foreign value IS overwritten by the primitive — the CALLER is what
-  // withholds repair from a genuine mismatch (asserted in the guard tests).
+  // The PRIMITIVE will rewrite whatever it is handed — it is the caller that
+  // decides what may be repaired, and the guard now hands it ONLY a genuinely
+  // absent key (asserted in the guard tests below). This documents the split of
+  // responsibility; it is not a licence to overwrite a present value.
   const overwritten = repairScopeInBody(
     JSON.stringify(frontendBody({ number: MARK_A, targets: ["999"] })),
     ["14"],
@@ -518,7 +521,10 @@ test("#556 r6: an attributed post whose fetch THROWS is a dispatch FAILURE — n
   await assert.rejects(guard(...promptPost(frontendBody({ targets: ["14"] }))), /connection reset/);
   assert.equal(guard.state.observed, 0, "a thrown fetch never satisfies the batch verdict");
   assert.match(guard.state.failed, /connection reset/);
-  assert.match(guard.state.failed, /NOT reported as queued/);
+  // #630 r7 P0-4 — the message is now a DISCLOSURE, not a denial: the request
+  // had already left, so whether ComfyUI accepted it is not observable.
+  assert.match(guard.state.failed, /NOT confirmed queued/);
+  assert.match(guard.state.failed, /CANNOT be determined from here/);
   assert.equal(captured, null, "no prompt_id claimed");
 });
 
@@ -972,6 +978,131 @@ test("#630 gate r4: a LATE extra post, arriving AFTER the run reported success, 
   } finally {
     stop();
   }
+});
+
+test("#630 gate r7 P0-1: only a genuinely ABSENT key is repaired — a PRESENT value we cannot interpret is refused, never overwritten", async () => {
+  // Absence is ours to fill. `[]`, `null`, `"14"` and especially
+  // `{ queueNodeIds: [...] }` are PRESENT values in a shape we did not expect —
+  // the last looks like another layer's scope convention. Rewriting one would
+  // be executing our intent over a request that said something different, which
+  // is the same violation as overwriting a mismatch.
+  const stop = keepAlive();
+  try {
+    const cases = [
+      { targets: [], label: "empty list" },
+      { targets: null, label: "explicit null" },
+      { targets: "14", label: "bare string" },
+      { targets: { queueNodeIds: ["9"] }, label: "another layer's convention" },
+    ];
+    for (const { targets, label } of cases) {
+      const server = makeServer();
+      const guard = createScopedRunGuard({
+        origFetchApi: server, execIds: ["14"], contentHash: OUR_HASH, batch: 1, toNodeId: 14, queueMark: MARK_A,
+        repairScope: true,
+      });
+      const body = { prompt: OUR_OUTPUT, client_id: "x", number: MARK_A, partial_execution_targets: targets };
+      const res = await guard(...promptPost(body));
+      assert.equal(res.status, 400, `${label}: refused, not repaired`);
+      assert.equal(guard.state.repaired, 0, `${label}: never rewritten`);
+      assert.equal(server.calls.length, 0, `${label}: nothing left the tab`);
+      // …and the refusal names what it actually saw, so the next report is diagnosable.
+      assert.match(guard.state.dropped, /was not a list|EMPTY partial_execution_targets/, `${label}: observation named`);
+    }
+    // The one case that IS repaired: the key genuinely absent.
+    const server = makeServer();
+    const guard = createScopedRunGuard({
+      origFetchApi: server, execIds: ["14"], contentHash: OUR_HASH, batch: 1, toNodeId: 14, queueMark: MARK_A,
+      repairScope: true,
+    });
+    await guard(...promptPost({ prompt: OUR_OUTPUT, client_id: "x", number: MARK_A }));
+    assert.equal(guard.state.repaired, 1, "an absent key is ours to fill");
+    assert.deepEqual(JSON.parse(server.calls[0].options.body).partial_execution_targets, ["14"]);
+  } finally {
+    stop();
+  }
+});
+
+test("#630 gate r7 P0-2: app.queuePrompt THROWING mid-run leaves the fence UP — a deferred duplicate cannot post scopeless", async () => {
+  // The `finally` always runs; the terminal-path decision may never. A throw
+  // from queuePrompt after it had already emitted a scoped post used to unwind
+  // through the finally with keepGuardInstalled still false, restoring raw
+  // fetchApi — and a deferred same-mark duplicate then ran the full graph.
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const prev = apiTarget.fetchApi;
+    const app = makeFrontend({ shape: "dropping", apiTarget });
+    let runMark = null;
+    app.queuePrompt = async (number) => {
+      runMark = number; // the run's real mark — a module counter, not a fixed value
+      const body = frontendBody({ output: OUR_OUTPUT, number, targets: null });
+      app.posted.push(body);
+      await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
+      throw new Error("frontend blew up after posting");
+    };
+    await assert.rejects(
+      () => dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 }),
+      /frontend blew up/,
+    );
+    assert.notEqual(apiTarget.fetchApi, prev, "the fence is NOT torn down by an exception unwinding the finally");
+    // The deferred duplicate that used to escape.
+    const late = frontendBody({ output: OUR_OUTPUT, number: runMark, targets: null });
+    const before = server.calls.length;
+    await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(late) });
+    assert.equal(server.calls.length, before, "a late scopeless duplicate never reached ComfyUI");
+  } finally {
+    stop();
+  }
+});
+
+test("#630 gate r7 P0-3: a SUCCESSFUL cancel still keeps the sentinel — removing what we could see proves nothing about what we could not", async () => {
+  // `removed > 0` proves only that tagged entries still in app.queueItems were
+  // spliced. A copy the frontend already took, popped, or scheduled is
+  // invisible to that check, and restoring raw fetchApi lets it post scopeless.
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const prev = apiTarget.fetchApi;
+    // "shim" so the TAGGED targets array is what the queue item holds — that is
+    // what makes the cancel succeed, which is the precondition under test.
+    const app = makeFrontend({ shape: "shim", defer: true, apiTarget });
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14, verifyTimeoutMs: 40,
+    });
+    assert.equal(result.outcome, "unverified");
+    assert.match(result.error, /located and REMOVED/, "the cancel did succeed — that part is unchanged");
+    assert.notEqual(apiTarget.fetchApi, prev, "and the sentinel STAYS, because the cancel is not proof about unseen copies");
+    // A retained same-mark copy posting later is still fenced.
+    const late = frontendBody({ output: OUR_OUTPUT, number: result.queueMark, targets: null });
+    await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(late) });
+    assert.equal(server.calls.length, 0, "no scopeless full-graph post ever left the tab");
+  } finally {
+    stop();
+  }
+});
+
+test("#630 gate r7 P0-4: the dispatch-failure message DISCLOSES an unknown outcome instead of denying arrival", () => {
+  // It used to end "this prompt did not reach ComfyUI" — a definite negative
+  // the panel cannot observe, contradicting the module's own INDETERMINATE
+  // handling, and one that makes the caller resubmit a render that may already
+  // be running.
+  const msg = scopeDispatchError({
+    toNodeId: 14,
+    detail: "the /prompt request itself threw (connection reset)",
+    verified: 0,
+    batch: 1,
+  });
+  assert.doesNotMatch(msg, /this prompt did not reach ComfyUI/,
+    "the unobservable denial must be gone, not reworded around");
+  assert.match(msg, /CANNOT be determined from here/, "the uncertainty is named as uncertainty");
+  assert.match(msg, /may be queued or running right now/);
+  assert.match(msg, /Check the ComfyUI queue before resubmitting/, "with an action that works from where the caller is");
+  assert.match(msg, /a retry may render the branch twice/, "and the cost of getting it wrong");
+  // What IS observable is still asserted plainly.
+  assert.match(msg, /no full-graph dispatch occurred/);
+  assert.match(msg, /NOT confirmed queued/);
 });
 
 test("#630 gate r5 P0: a TERMINAL PARTIAL batch keeps its sentinel — a late post cannot escape after a half-succeeded run", async () => {
@@ -1750,7 +1881,8 @@ test("#556 r6 integration: batch=1 whose /prompt fetch THROWS ⇒ 'failed' outco
     assert.notEqual(result.outcome, "dispatched");
     assert.equal(result.verified, 0);
     assert.match(result.error, /connection reset/);
-    assert.match(result.error, /NOT reported as queued/);
+    assert.match(result.error, /NOT confirmed queued/);
+    assert.match(result.error, /CANNOT be determined from here/, "#630 r7 P0-4: never a definite non-arrival claim");
     assert.deepEqual(ids, [], "no prompt_id claimed");
     assert.notEqual(apiTarget.fetchApi, prev, "batch unaccounted ⇒ sentinel stays (the frontend may keep looping)");
     // A late CORRUPTED post of this run is still refused by the sentinel.
@@ -1804,10 +1936,11 @@ test("#556 r6 integration: batch=2 where post 1's fetch throws and post 2 verifi
   }
 });
 
-test("#556 r3 P0-3 integration: timeout CANCELS our tagged pending item (assert the removal) — guard restored, no sentinel", async () => {
+test("#556 r3 P0-3 integration: timeout CANCELS our tagged pending item (assert the removal) — and the sentinel STAYS (#630 r7)", async () => {
   const stop = keepAlive();
   try {
-    const apiTarget = { fetchApi: makeServer() };
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
     const prev = apiTarget.fetchApi;
     const app = makeFrontend({ shape: "shim", defer: true, apiTarget });
     // A foreign identical-scope item also pending — must survive.
@@ -1820,8 +1953,15 @@ test("#556 r3 P0-3 integration: timeout CANCELS our tagged pending item (assert 
     assert.match(result.error, /REMOVED/);
     assert.equal(app.queueItems.length, 1, "ONLY our tagged item was removed");
     assert.deepEqual(app.queueItems[0].queueNodeIds, ["14"]);
-    assert.equal(apiTarget.fetchApi, prev, "guard restored — no sentinel needed after a successful cancel");
-    assert.equal(apiTarget.fetchApi.calls.length, 0, "nothing was ever dispatched");
+    // #630 r7 P0-3 — DELIBERATE CHANGE. This asserted "guard restored — no
+    // sentinel needed after a successful cancel". A successful cancel proves
+    // only that tagged entries STILL IN app.queueItems were spliced; it says
+    // nothing about a copy the frontend already took, popped, or scheduled.
+    // Positive evidence about what we could see is not evidence about what we
+    // could not, and restoring on it let an unseen same-mark copy post
+    // scopeless later.
+    assert.notEqual(apiTarget.fetchApi, prev, "the sentinel stays — the cancel is not proof about unseen copies");
+    assert.equal(server.calls.length, 0, "nothing was ever dispatched");
   } finally {
     stop();
   }

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -974,6 +974,66 @@ test("#630 gate r4: a LATE extra post, arriving AFTER the run reported success, 
   }
 });
 
+test("#630 gate r4: two CONCURRENT same-mark posts — the quota is a reservation, so the branch still runs exactly once", async () => {
+  // The sequential fence was racy: counting only COMPLETED requests let two
+  // in-flight posts both read observed=0, both clear the quota, and both be
+  // forwarded — rendering the requested branch twice, at real GPU/API cost,
+  // while the result reported no overrun at all. The slot must be reserved
+  // BEFORE the await, not counted after it.
+  const stop = keepAlive();
+  try {
+    let release;
+    const gate = new Promise((r) => { release = r; });
+    let n = 0;
+    const server = makeServer(async () => {
+      // Hold the FIRST request open so the second arrives while it is in flight.
+      if (n++ === 0) await gate;
+      return jsonResponse(200, { prompt_id: `srv-${n}` });
+    });
+    const guard = createScopedRunGuard({
+      origFetchApi: server, execIds: ["14"], contentHash: OUR_HASH, batch: 1, toNodeId: 14, queueMark: MARK_A,
+      repairScope: true,
+    });
+    const post = () => guard(...promptPost(frontendBody({ number: MARK_A, targets: null })));
+    const first = post();
+    const second = await post(); // arrives while `first` is still awaiting the server
+    assert.equal(second.status, 400, "the concurrent duplicate is fenced by the RESERVED slot");
+    assert.equal(guard.state.overrun, 1, "and it is counted as an overrun, not silently allowed");
+    release();
+    await first;
+    assert.equal(guard.state.observed, 1);
+    assert.equal(server.calls.length, 1, "EXACTLY one request reached ComfyUI — the branch runs once");
+    assert.deepEqual(JSON.parse(server.calls[0].options.body).partial_execution_targets, ["14"]);
+  } finally {
+    stop();
+  }
+});
+
+test("#630 gate r4: a MALFORMED response keeps its slot — 'could not tell whether it queued' is not 'it did not queue'", async () => {
+  // The post reached ComfyUI and MAY have queued. Releasing the slot on that
+  // uncertainty would let a retry render the branch a second time. A throw is
+  // different — it never left — and that slot IS released (covered above).
+  const stop = keepAlive();
+  try {
+    const server = makeServer(() => jsonResponse(200, { no_prompt_id: true }));
+    const guard = createScopedRunGuard({
+      origFetchApi: server, execIds: ["14"], contentHash: OUR_HASH, batch: 1, toNodeId: 14, queueMark: MARK_A,
+      repairScope: true,
+    });
+    const post = () => guard(...promptPost(frontendBody({ number: MARK_A, targets: null })));
+    await post();
+    assert.ok(guard.state.failed, "a malformed response is a dispatch failure, never a success");
+    assert.equal(guard.state.observed, 0, "and never counted as verified");
+    // The slot stays consumed, so a retry cannot double-render the branch.
+    const retry = await post();
+    assert.equal(retry.status, 400);
+    assert.equal(guard.state.overrun, 1);
+    assert.equal(server.calls.length, 1, "the branch was never dispatched a second time on an unknown outcome");
+  } finally {
+    stop();
+  }
+});
+
 test("#630 gate r3: the quota counts only COMPLETED work — a failed post does not fence out the retry that is still owed", async () => {
   // A post whose fetch threw never reached ComfyUI, so a later post of the same
   // batch is legitimately still owed. Counting it toward the quota would fence

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -980,6 +980,62 @@ test("#630 gate r4: a LATE extra post, arriving AFTER the run reported success, 
   }
 });
 
+test("#630 gate r9 P1: a request STILL IN FLIGHT at timeout is not reported as 'nothing queued'", async () => {
+  // A busy frontend can fire-and-forget a correctly-scoped POST and return. If
+  // the server has not answered by the time the wait expires, that request HAS
+  // left the panel and may still be accepted — reporting the run as
+  // queued:false then is a definite negative about something unobserved, and
+  // the caller acting on it re-renders a branch that is already running.
+  const stop = keepAlive();
+  try {
+    let releaseResponse;
+    const held = new Promise((r) => { releaseResponse = r; });
+    const server = makeServer(async () => {
+      await held;
+      return jsonResponse(200, { prompt_id: "srv-late" });
+    });
+    const apiTarget = { fetchApi: server };
+    const app = makeFrontend({ shape: "shim", apiTarget });
+    // Fire-and-forget: post WITHOUT awaiting, then return — the request is in
+    // flight when dispatchScopedRun starts waiting.
+    app.queuePrompt = async (number) => {
+      const body = frontendBody({ output: OUR_OUTPUT, number, targets: ["14"] });
+      app.posted.push(body);
+      void apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
+      return true;
+    };
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14, verifyTimeoutMs: 25,
+    });
+    assert.equal(result.outcome, "unverified");
+    assert.equal(result.verified, 0, "it was genuinely not confirmed");
+    assert.equal(result.inFlight, 1, "but one correctly-scoped request had already left the panel");
+    assert.match(result.error, /ALREADY LEFT the panel/);
+    assert.match(result.error, /NOT a report that nothing was queued/);
+    assert.match(result.error, /Check the ComfyUI queue before retrying/);
+    // And it really can be accepted afterwards — which is why the claim matters.
+    releaseResponse();
+    await sleep(5);
+    assert.equal(server.calls.length, 1, "the scoped request did leave, exactly once");
+    assert.deepEqual(JSON.parse(server.calls[0].options.body).partial_execution_targets, ["14"]);
+  } finally {
+    stop();
+  }
+});
+
+test("#630 gate r9 P1: graph_run counts in-flight requests as unresolved, so `queued` is omitted rather than asserted false", () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const source = readFileSync(join(here, "../../web/js/comfyui-mcp-panel.js"), "utf8").replace(/\r\n/g, "\n");
+  const start = source.indexOf('if (runScopeResult && runScopeResult.outcome !== "dispatched")');
+  const block = source.slice(start, start + 6000).replace(/`\s*\+\s*\n\s*`/g, "").replace(/\s+/g, " ");
+  assert.match(
+    block,
+    /const unresolved = \(runScopeResult\.indeterminate \?\? 0\) \+ \(runScopeResult\.inFlight \?\? 0\);/,
+    "an in-flight request has the same epistemic status as an indeterminate one",
+  );
+  assert.match(block, /if \(unresolved > 0\)/, "and it gates the queued-unknown shape");
+});
+
 test("#630 gate r8 P0: a RETRYING run never displaces a concurrent run's sentinel — B's late post is still fenced", async () => {
   // A installs GA1 and waits on a deferred first attempt. B starts, captures
   // GA1 as its chain, succeeds, and retains GB. A's deferred post arrives
@@ -1059,7 +1115,7 @@ test("#630 gate r8 P1: an INDETERMINATE dispatch omits `queued` — neither true
   assert.ok(start > 0);
   const block = source.slice(start, start + 6000).replace(/`\s*\+\s*\n\s*`/g, "").replace(/\s+/g, " ");
   // The indeterminate branch must NOT assert queued:false…
-  const indetStart = block.indexOf("if (runScopeResult.indeterminate > 0)");
+  const indetStart = block.indexOf("if (unresolved > 0)");
   assert.ok(indetStart > 0, "the indeterminate case is handled separately");
   // Bound the slice to THIS branch's return, or it runs on into the
   // nothing-dispatched `queued: false` below and the assertion means nothing.

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -18,6 +18,8 @@ import {
   newScopedQueueMark,
   QUEUE_ITEM_TAG,
   queuePromptScopeArgs,
+  queuePromptScopeAttempts,
+  repairScopeInBody,
   promptContentHash,
   promptContentHashFromBody,
   collectVolatileInputs,
@@ -101,9 +103,12 @@ function frontendBody({ output = OUR_OUTPUT, number = MARK_A, targets = null }) 
 /**
  * A mock frontend. `shape`: "shim" (options object AND legacy array both
  * honored), "positional" (array only), "shimless" (options object only — the
- * #556 build). `defer`: queuePrompt pushes the item and returns early (busy
- * processor); the TEST then drives the deferred post manually through
- * apiTarget.fetchApi, exactly like the in-flight processor would.
+ * #556 build), "dropping" (BOTH shapes ignored — the build the three #556
+ * field recurrences describe, where the /prompt body arrived with no
+ * partial_execution_targets whichever argument was passed).
+ * `defer`: queuePrompt pushes the item and returns early (busy processor); the
+ * TEST then drives the deferred post manually through apiTarget.fetchApi,
+ * exactly like the in-flight processor would.
  */
 function makeFrontend({ shape = "shim", defer = false, apiTarget, output = OUR_OUTPUT, failGraphToPrompt = false } = {}) {
   const app = {
@@ -115,17 +120,19 @@ function makeFrontend({ shape = "shim", defer = false, apiTarget, output = OUR_O
     },
     queuePrompt: async (number, batch, arg) => {
       const queueNodeIds =
-        shape === "shim"
-          ? Array.isArray(arg)
-            ? arg
-            : arg?.queueNodeIds
-          : shape === "positional"
+        shape === "dropping"
+          ? undefined
+          : shape === "shim"
             ? Array.isArray(arg)
               ? arg
-              : undefined
-            : Array.isArray(arg)
-              ? undefined
-              : arg?.queueNodeIds;
+              : arg?.queueNodeIds
+            : shape === "positional"
+              ? Array.isArray(arg)
+                ? arg
+                : undefined
+              : Array.isArray(arg)
+                ? undefined
+                : arg?.queueNodeIds;
       const item = { number, batchCount: batch, queueNodeIds };
       if (defer) {
         app.queueItems?.push(item); // hard-private builds hide the array from us
@@ -166,6 +173,68 @@ test("#556 queuePromptScopeArgs: no scope ⇒ [undefined]; scope ⇒ array first
   const [first, second] = queuePromptScopeArgs(["76:34"]);
   assert.deepEqual(first, ["76:34"]);
   assert.deepEqual(second, { queueNodeIds: ["76:34"] });
+});
+
+// ---------------------------------------------------------------------------
+// #630 — HONOURING the scope, not merely refusing to violate it.
+//
+// Refusing a scoped run is the SAFE outcome for #556; running the requested
+// subset is the CORRECT one. These cover the last-resort delivery route: when
+// neither app.queuePrompt argument shape carries the scope, the panel writes
+// partial_execution_targets into this run's own /prompt body and re-verifies
+// it before it leaves.
+// ---------------------------------------------------------------------------
+
+test("#630 queuePromptScopeAttempts: both argument shapes are tried BEFORE the body repair, and repair is licensed only on the last attempt", () => {
+  assert.deepEqual(queuePromptScopeAttempts(undefined), [{ arg: undefined, repair: false }]);
+  assert.deepEqual(queuePromptScopeAttempts([]), [{ arg: undefined, repair: false }]);
+  const attempts = queuePromptScopeAttempts(["76:34"]);
+  assert.equal(attempts.length, 3);
+  assert.deepEqual(attempts[0], { arg: ["76:34"], repair: false });
+  assert.deepEqual(attempts[1], { arg: { queueNodeIds: ["76:34"] }, repair: false });
+  assert.deepEqual(attempts[2], { arg: ["76:34"], repair: true });
+  assert.equal(
+    attempts.filter((a) => a.repair).length,
+    1,
+    "a frontend that delivers the scope natively must always win — repair is the last resort only",
+  );
+});
+
+test("#630 repairScopeInBody: writes EXACTLY the resolved targets, leaves the prompt (and therefore the content hash) untouched", () => {
+  const body = JSON.stringify(frontendBody({ number: MARK_A, targets: null }));
+  const repaired = repairScopeInBody(body, ["14"]);
+  assert.notEqual(repaired, null);
+  const parsed = JSON.parse(repaired);
+  assert.deepEqual(parsed.partial_execution_targets, ["14"], "exactly the resolved scope, nothing widened");
+  assert.deepEqual(parsed.prompt, OUR_OUTPUT, "the prompt is not rewritten");
+  assert.equal(parsed.number, MARK_A, "the run identity mark survives the repair");
+  assert.equal(
+    promptContentHashFromBody(repaired),
+    OUR_HASH,
+    "repair must not invalidate this run's own content attribution",
+  );
+  // The repair verifies its own output: it is itself an operation that can
+  // fail, and a repair that cannot be confirmed is not handed on.
+  assert.equal(verifyScopedPromptBody(repaired, ["14"]).ok, true);
+});
+
+test("#630 repairScopeInBody: refuses what it cannot safely rewrite — unparseable, non-object, or no scope to write", () => {
+  assert.equal(repairScopeInBody("not-json{", ["14"]), null, "an unreadable body is never repaired");
+  assert.equal(repairScopeInBody(JSON.stringify([1, 2]), ["14"]), null, "an array body is not a prompt request");
+  assert.equal(repairScopeInBody(JSON.stringify("scalar"), ["14"]), null);
+  assert.equal(repairScopeInBody(undefined, ["14"]), null);
+  assert.equal(
+    repairScopeInBody(JSON.stringify(frontendBody({})), []),
+    null,
+    "no resolved scope ⇒ nothing to write; never an empty partial_execution_targets",
+  );
+  // A wrong/foreign value IS overwritten by the primitive — the CALLER is what
+  // withholds repair from a genuine mismatch (asserted in the guard tests).
+  const overwritten = repairScopeInBody(
+    JSON.stringify(frontendBody({ number: MARK_A, targets: ["999"] })),
+    ["14"],
+  );
+  assert.deepEqual(JSON.parse(overwritten).partial_execution_targets, ["14"]);
 });
 
 test("#556 r7 promptContentHash: full CONTENT covered (ids, class types, links, widget values), key-order-insensitive", () => {
@@ -289,6 +358,83 @@ test("#572 promptContentHash: the narrowed exclusion tolerates ONLY the hook's o
     atHash,
     "a genuine mid-window edit to a non-excluded input of the same node refuses",
   );
+});
+
+test("#630 scopeDroppedError: the no-scope refusal states the OBSERVATION and no longer asserts a cause it cannot see", () => {
+  // The pre-#630 message asserted "this frontend build ignored the run-to-node
+  // argument" for every no-usable-scope state. That is a bucket narrated as a
+  // cause, and the evidence contradicts it: ComfyUI_frontend 1.42 through 1.50
+  // all accept BOTH app.queuePrompt third-argument shapes and funnel them into
+  // api.queuePrompt's options.partialExecutionTargets. Three #556 field reports
+  // pasted that asserted cause into the tracker, which is why the real cause is
+  // still unknown. The message must survive that lesson.
+  const msg = scopeDroppedError({
+    toNodeId: 4995,
+    verdict: { ok: false, reason: "scope_missing", expected: ["4995"], got: null, bodyKeys: ["client_id", "extra_data", "number", "prompt"] },
+  });
+  assert.match(msg, /node 4995/);
+  assert.match(msg, /no partial_execution_targets key at all/, "says what was seen");
+  assert.doesNotMatch(
+    msg,
+    /this frontend build ignored the run-to-node argument/,
+    "the discredited single-cause assertion must be gone, not merely reworded around",
+  );
+  // Evidence survives to the report instead of being thrown away.
+  assert.match(msg, /body keys: client_id, extra_data, number, prompt/);
+  // Refusal, not a silent fallback.
+  assert.match(msg, /Nothing was queued/);
+  assert.match(msg, /refusing to fall through to a full-graph execution/);
+  // A remedy that works from where the caller is standing — and the full-graph
+  // cost is stated, never taken silently on their behalf.
+  assert.match(msg, /panel_run without to_node_id/);
+  assert.match(msg, /WHOLE graph/);
+});
+
+test("#630 scopeDroppedError: the four distinct no-usable-scope states read differently — a timed-out/unreadable observation is not a definite 'the key was absent'", () => {
+  const of = (reason, extra = {}) =>
+    scopeDroppedError({ toNodeId: 7, verdict: { ok: false, reason, expected: ["7"], got: null, ...extra } });
+  const absent = of("scope_missing");
+  const empty = of("scope_empty");
+  const notList = of("scope_not_a_list", { raw: { queueNodeIds: ["7"] } });
+  const unreadable = of("body_unreadable");
+  assert.match(absent, /no partial_execution_targets key at all/);
+  assert.match(empty, /EMPTY partial_execution_targets list/);
+  assert.match(notList, /was not a list/);
+  assert.match(notList, /queueNodeIds/, "the actual value is evidence for the next report");
+  assert.match(unreadable, /could not be parsed/);
+  const all = [absent, empty, notList, unreadable];
+  assert.equal(new Set(all).size, 4, "four observations, four messages — never one verdict standing in for all of them");
+  // None of them may claim the key was absent when that is not what happened.
+  assert.doesNotMatch(empty, /no partial_execution_targets key at all/);
+  assert.doesNotMatch(notList, /no partial_execution_targets key at all/);
+  assert.doesNotMatch(unreadable, /no partial_execution_targets key at all/);
+});
+
+test("#630 guard: each distinct no-usable-scope state is reported as ITSELF, not folded into scope_missing", async () => {
+  const stop = keepAlive();
+  try {
+    const run = async (targetsValue) => {
+      const orig = makeServer();
+      const guard = createScopedRunGuard({
+        origFetchApi: orig,
+        execIds: ["14"],
+        contentHash: OUR_HASH,
+        batch: 1,
+        toNodeId: 14,
+        queueMark: MARK_A,
+      });
+      const body = { prompt: OUR_OUTPUT, client_id: "x", number: MARK_A };
+      if (targetsValue !== undefined) body.partial_execution_targets = targetsValue;
+      await guard(...promptPost(body));
+      return guard.state.droppedReason;
+    };
+    assert.equal(await run(undefined), "scope_missing");
+    assert.equal(await run([]), "scope_empty");
+    assert.equal(await run({ queueNodeIds: ["14"] }), "scope_not_a_list");
+    assert.equal(await run("14"), "scope_not_a_list");
+  } finally {
+    stop();
+  }
 });
 
 test("#572 scopeDroppedError: graph_changed guidance names the retry safety and the queue-time hook cause", () => {
@@ -555,23 +701,118 @@ test("#556 integration: a shim-less options build drops the legacy array — att
   }
 });
 
-test("#556 integration: a build honoring NEITHER shape ⇒ truthful refusal, ZERO dispatches", async () => {
+test("#630 integration: a build honoring NEITHER shape is now HONOURED, not refused — and the request that reaches ComfyUI names ONLY node 14's branch", async () => {
+  // Supersedes the pre-#630 expectation ("truthful refusal, zero dispatches").
+  // Refusing was safe but was not what the caller asked for; the requested
+  // subset is now actually executed. The assertion that matters is not "the
+  // run completed" — it is WHICH nodes ComfyUI was told to execute.
   const stop = keepAlive();
   try {
     const apiTarget = { fetchApi: makeServer() };
-    const app = makeFrontend({ shape: "positional", apiTarget });
-    // positional honors the array… force neither by overriding queuePrompt to always drop targets
-    app.queuePrompt = async (number, batch) => {
-      const body = frontendBody({ output: OUR_OUTPUT, number, targets: null });
+    const app = makeFrontend({ shape: "dropping", apiTarget });
+    const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
+    assert.equal(result.outcome, "dispatched");
+    assert.equal(result.scopeAppliedBy, "request_body_repair", "the caller can tell HOW the scope was delivered");
+    assert.equal(result.repaired, 1);
+    // Both native shapes were tried first and both dropped the scope…
+    assert.equal(app.posted.length, 3, "array shape, options shape, then the repair attempt");
+    assert.equal(app.posted[0].partial_execution_targets, undefined);
+    assert.equal(app.posted[1].partial_execution_targets, undefined);
+    // …and exactly ONE request reached ComfyUI, carrying exactly node 14.
+    assert.equal(apiTarget.fetchApi.calls.length, 1, "the two unrepaired attempts were blocked, not forwarded");
+    const sent = JSON.parse(apiTarget.fetchApi.calls[0].options.body);
+    assert.deepEqual(
+      sent.partial_execution_targets,
+      ["14"],
+      "ONLY the requested branch is an execution root — SaveImage (9) is never named",
+    );
+    assert.ok(!sent.partial_execution_targets.includes("9"), "the unrelated SaveImage branch is not a root (#556)");
+    assert.deepEqual(sent.prompt, OUR_OUTPUT, "the prompt itself is untouched by the repair");
+    assert.equal(sent.number, result.queueMark, "the repaired body keeps this run's identity mark");
+  } finally {
+    stop();
+  }
+});
+
+test("#630 integration: repair NEVER overwrites a scope MISMATCH — a body carrying targets we did not ask for is still refused, zero dispatches", async () => {
+  // The repair widens nothing. When our own attributed post carries DIFFERENT
+  // targets, the panel does not understand why and must not paper over it by
+  // writing its own — that would be executing something other than what the
+  // body says while claiming to have fixed it.
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const app = makeFrontend({ shape: "shim", apiTarget });
+    app.queuePrompt = async (number) => {
+      const body = frontendBody({ output: OUR_OUTPUT, number, targets: ["9"] }); // WRONG branch
       app.posted.push(body);
       await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
       return true;
     };
     const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
     assert.equal(result.outcome, "refused");
-    assert.match(result.error, /node 14/);
-    assert.match(result.error, /Nothing was queued/);
-    assert.equal(apiTarget.fetchApi.calls.length, 0, "no full-graph prompt ever left the tab");
+    assert.match(result.error, /instead of \["14"\]/, "the observed mismatch is named, not overwritten");
+    assert.equal(apiTarget.fetchApi.calls.length, 0, "nothing reached ComfyUI — not the wrong scope, not a repaired one");
+  } finally {
+    stop();
+  }
+});
+
+test("#630 integration: repair is scoped to OUR OWN post — a stranger's scopeless /prompt is passed through untouched, never rewritten", async () => {
+  // The repair rides on the same run-identity gate as every other guard
+  // action. A foreign full run of the same graph must leave the tab exactly as
+  // the user queued it: unscoped, unmodified.
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const orig = apiTarget.fetchApi;
+    const guard = createScopedRunGuard({
+      origFetchApi: orig,
+      execIds: ["14"],
+      contentHash: OUR_HASH,
+      batch: 1,
+      toNodeId: 14,
+      queueMark: MARK_A,
+      repairScope: true,
+    });
+    // Someone else's full run: same graph, same node set, NO mark of ours.
+    const foreign = frontendBody({ number: 0, targets: null });
+    await guard(...promptPost(foreign));
+    assert.equal(orig.calls.length, 1);
+    const forwarded = JSON.parse(orig.calls[0].options.body);
+    assert.equal(
+      forwarded.partial_execution_targets,
+      undefined,
+      "a stranger's full run is never silently narrowed to our scope",
+    );
+    assert.equal(guard.state.repaired, 0);
+    assert.equal(guard.state.refused, 0, "and it is never refused either");
+  } finally {
+    stop();
+  }
+});
+
+test("#630 integration: an UNPARSEABLE own-post body is refused, not 'repaired' — a repair that cannot be verified is not a repair", async () => {
+  const stop = keepAlive();
+  try {
+    const apiTarget = { fetchApi: makeServer() };
+    const orig = apiTarget.fetchApi;
+    const guard = createScopedRunGuard({
+      origFetchApi: orig,
+      execIds: ["14"],
+      contentHash: OUR_HASH,
+      batch: 1,
+      toNodeId: 14,
+      queueMark: MARK_A,
+      repairScope: true,
+    });
+    // Our mark is readable but the content hash cannot be computed ⇒ not
+    // attributable as our unmodified prompt ⇒ never repaired.
+    const drifted = frontendBody({ output: { "3": { class_type: "KSampler", inputs: { steps: 99 } } }, number: MARK_A, targets: null });
+    await guard(...promptPost(drifted));
+    assert.equal(guard.state.repaired, 0, "content drift is never repaired into a dispatch");
+    assert.equal(orig.calls.length, 0, "nothing left the tab");
+    assert.equal(guard.state.droppedReason, "graph_changed");
   } finally {
     stop();
   }

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -875,6 +875,79 @@ test("#630 gate r2: an explicit partial_execution_targets:null is a PRESENT key,
   }
 });
 
+test("#630 gate r3: an EXTRA post beyond the requested batch is FENCED, not dispatched — the branch never runs more times than asked", async () => {
+  // The old batch bound was observational: it stopped the orchestration
+  // waiting, but never stopped a post leaving. A duplicate/stale same-identity
+  // post therefore executed the requested branch AGAIN — real GPU/API cost —
+  // while graph_run still reported batch_count as what was asked for. The
+  // repair would have widened this: a duplicate whose scope was dropped used
+  // to be refused, and would now have been repaired into a dispatch.
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const app = makeFrontend({ shape: "dropping", apiTarget });
+    app.queuePrompt = async (number, batch) => {
+      // The defect mode: batch+1 posts for a batch of `batch`.
+      for (let i = 0; i < batch + 1; i++) {
+        const body = frontendBody({ output: OUR_OUTPUT, number, targets: null });
+        app.posted.push(body);
+        await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
+      }
+      return true;
+    };
+    const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
+    assert.equal(result.outcome, "dispatched", "the prompt that WAS asked for is queued — not a failure");
+    assert.equal(result.verified, 1);
+    assert.equal(
+      server.calls.length,
+      1,
+      "EXACTLY the requested number of prompts reached ComfyUI — the extra was fenced, not forwarded",
+    );
+    assert.deepEqual(JSON.parse(server.calls[0].options.body).partial_execution_targets, ["14"]);
+    // Disclosed, never silent: the caller learns their frontend produced an extra.
+    assert.equal(result.overrunBlocked, 1);
+    assert.match(result.overrunNote, /EXTRA \/prompt post/);
+    assert.match(result.overrunNote, /refused rather than dispatched/);
+    assert.match(result.overrunNote, /requested prompts are queued and unaffected/,
+      "a disclosure about work that succeeded — never a failure that invites a retry");
+  } finally {
+    stop();
+  }
+});
+
+test("#630 gate r3: the quota counts only COMPLETED work — a failed post does not fence out the retry that is still owed", async () => {
+  // A post whose fetch threw never reached ComfyUI, so a later post of the same
+  // batch is legitimately still owed. Counting it toward the quota would fence
+  // out real requested work.
+  const stop = keepAlive();
+  try {
+    let n = 0;
+    const server = makeServer(() => {
+      if (n++ === 0) throw new Error("network blip");
+      return jsonResponse(200, { prompt_id: "srv-late" });
+    });
+    const guard = createScopedRunGuard({
+      origFetchApi: server, execIds: ["14"], contentHash: OUR_HASH, batch: 1, toNodeId: 14, queueMark: MARK_A,
+      repairScope: true,
+    });
+    const post = () => guard(...promptPost(frontendBody({ number: MARK_A, targets: null })));
+    await assert.rejects(post, /network blip/, "the frontend sees the failure it would have seen");
+    assert.ok(guard.state.failed, "recorded as a dispatch FAILURE, never a success");
+    assert.equal(guard.state.observed, 0);
+    // The retry is still owed — it must not be fenced as an overrun.
+    await post();
+    assert.equal(guard.state.observed, 1, "the owed prompt still dispatches");
+    assert.equal(guard.state.overrun, 0, "a failed post never consumed the quota");
+    // …and NOW the quota is spent, so a third post is fenced.
+    await post();
+    assert.equal(guard.state.overrun, 1);
+    assert.equal(guard.state.observed, 1, "no extra execution of the branch");
+  } finally {
+    stop();
+  }
+});
+
 test("#630 gate r2 P1: describeObserved NEVER throws — the refusal path's own formatting cannot be what fails", () => {
   // JSON.stringify is not a safe formatter for a value off the wire: circular
   // structures and BigInt throw outright, and a deeply nested value throws

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -631,7 +631,7 @@ test("#556 r4 P0-2: newScopedQueueMark is unique per run, nonzero, a safe intege
 // dispatchScopedRun — the REAL orchestration graph_run runs (integration)
 // ---------------------------------------------------------------------------
 
-test("#556 integration: happy path — marked scoped dispatch observed, prompt_id captured, fetchApi restored", async () => {
+test("#556 integration: happy path — marked scoped dispatch observed, prompt_id captured, sentinel RETAINED (#630 r4)", async () => {
   const stop = keepAlive();
   try {
     const apiTarget = { fetchApi: makeServer() };
@@ -644,7 +644,12 @@ test("#556 integration: happy path — marked scoped dispatch observed, prompt_i
     });
     assert.equal(result.outcome, "dispatched");
     assert.deepEqual(ids, ["srv-1"]);
-    assert.equal(apiTarget.fetchApi, prev, "guard restored after observation");
+    // #630 r4 — DELIBERATE CHANGE. This used to assert restoration. Restoring
+    // on success uninstalled the quota fence, so a LATE same-mark post (a
+    // deferred duplicate emitted after queuePrompt returned) bypassed the guard
+    // and, on a scope-dropping build, left the tab UNSCOPED — a full-graph run
+    // arriving after a scoped success was already reported.
+    assert.notEqual(apiTarget.fetchApi, prev, "the sentinel is retained so a late post of THIS run is still fenced");
     assert.equal(app.posted.length, 1, "first arg shape worked — no retry");
     assert.equal(app.posted[0].number, result.queueMark, "our posts carry THIS run's queue mark");
     assert.deepEqual(app.posted[0].partial_execution_targets, ["14"]);
@@ -693,14 +698,17 @@ test("#572 integration: a graph with NO queue-time hooks reports full drift cove
 test("#556 integration: a shim-less options build drops the legacy array — attempt 1 refused with ZERO dispatch, attempt 2 delivers", async () => {
   const stop = keepAlive();
   try {
-    const apiTarget = { fetchApi: makeServer() };
+    // Hold the SERVER double directly: since #630 r4 a successful run retains
+    // its sentinel, so apiTarget.fetchApi is the guard afterwards, not this.
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
     const app = makeFrontend({ shape: "shimless", apiTarget });
     const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
     assert.equal(result.outcome, "dispatched");
     assert.equal(app.posted.length, 2, "both shapes attempted");
     assert.equal(app.posted[0].partial_execution_targets, undefined, "attempt 1 (array) dropped by this build");
-    assert.equal(apiTarget.fetchApi.calls.length, 1, "only the correctly-shaped dispatch reached the server");
-    assert.deepEqual(apiTarget.fetchApi.calls[0].options.body && JSON.parse(apiTarget.fetchApi.calls[0].options.body).partial_execution_targets, ["14"]);
+    assert.equal(server.calls.length, 1, "only the correctly-shaped dispatch reached the server");
+    assert.deepEqual(JSON.parse(server.calls[0].options.body).partial_execution_targets, ["14"]);
   } finally {
     stop();
   }
@@ -713,7 +721,9 @@ test("#630 integration: a build honoring NEITHER shape is now HONOURED, not refu
   // run completed" — it is WHICH nodes ComfyUI was told to execute.
   const stop = keepAlive();
   try {
-    const apiTarget = { fetchApi: makeServer() };
+    // Hold the SERVER double directly (see #630 r4: success retains the sentinel).
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
     const app = makeFrontend({ shape: "dropping", apiTarget });
     const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
     assert.equal(result.outcome, "dispatched");
@@ -724,8 +734,8 @@ test("#630 integration: a build honoring NEITHER shape is now HONOURED, not refu
     assert.equal(app.posted[0].partial_execution_targets, undefined);
     assert.equal(app.posted[1].partial_execution_targets, undefined);
     // …and exactly ONE request reached ComfyUI, carrying exactly node 14.
-    assert.equal(apiTarget.fetchApi.calls.length, 1, "the two unrepaired attempts were blocked, not forwarded");
-    const sent = JSON.parse(apiTarget.fetchApi.calls[0].options.body);
+    assert.equal(server.calls.length, 1, "the two unrepaired attempts were blocked, not forwarded");
+    const sent = JSON.parse(server.calls[0].options.body);
     assert.deepEqual(
       sent.partial_execution_targets,
       ["14"],
@@ -911,6 +921,54 @@ test("#630 gate r3: an EXTRA post beyond the requested batch is FENCED, not disp
     assert.match(result.overrunNote, /refused rather than dispatched/);
     assert.match(result.overrunNote, /requested prompts are queued and unaffected/,
       "a disclosure about work that succeeded — never a failure that invites a retry");
+  } finally {
+    stop();
+  }
+});
+
+test("#630 gate r4: a LATE extra post, arriving AFTER the run reported success, still cannot run the full graph", async () => {
+  // The deferred race the r3 fence alone did not cover. Completing the batch
+  // used to restore fetchApi, uninstalling the quota fence — so a duplicate the
+  // frontend's processor emits after queuePrompt returned bypassed the guard
+  // entirely and, on a scope-dropping build, went out UNSCOPED. A full-graph
+  // execution arriving after we already reported a scoped success is the worst
+  // shape of #556: nothing in the reply hints at it.
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const prev = apiTarget.fetchApi;
+    const app = makeFrontend({ shape: "dropping", apiTarget });
+    let lateNumber = null;
+    app.queuePrompt = async (number, batch) => {
+      lateNumber = number;
+      for (let i = 0; i < batch; i++) {
+        const body = frontendBody({ output: OUR_OUTPUT, number, targets: null });
+        app.posted.push(body);
+        await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
+      }
+      return true;
+    };
+    const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
+    assert.equal(result.outcome, "dispatched");
+    assert.equal(server.calls.length, 1);
+    assert.deepEqual(JSON.parse(server.calls[0].options.body).partial_execution_targets, ["14"]);
+    // The guard must NOT have been uninstalled by success.
+    assert.notEqual(apiTarget.fetchApi, prev, "a completed scoped run keeps its sentinel for the page session");
+    // NOW the late duplicate, exactly as a stalled processor would emit it.
+    const late = frontendBody({ output: OUR_OUTPUT, number: lateNumber, targets: null });
+    const res = await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(late) });
+    assert.equal(res.status, 400, "the late duplicate is refused");
+    assert.equal(server.calls.length, 1, "and it NEVER reached ComfyUI — no unscoped full-graph post, ever");
+    // A stranger's traffic still passes through the lingering sentinel.
+    const foreign = frontendBody({ output: OUR_OUTPUT, number: 0, targets: null });
+    await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(foreign) });
+    assert.equal(server.calls.length, 2, "the sentinel only ever constrains its own run");
+    assert.equal(
+      JSON.parse(server.calls[1].options.body).partial_execution_targets,
+      undefined,
+      "and it does not narrow a stranger's full run either",
+    );
   } finally {
     stop();
   }
@@ -1254,8 +1312,12 @@ test("#556 r4 P0-2 integration: two overlapping scoped runs — B's traffic pass
     assert.deepEqual(idsB, ["srv-1"], "B's prompt_id captured by B's guard, never by A's sentinel");
     assert.equal(server.calls.length, 1, "B's scoped dispatch reached the server THROUGH A's sentinel, untouched");
     assert.deepEqual(JSON.parse(server.calls[0].options.body).partial_execution_targets, ["15"]);
-    // Chaining: B restored the wrap that was current when IT installed — A's sentinel.
-    assert.equal(apiTarget.fetchApi, sentinelA, "B's cleanup did not clobber A's sentinel");
+    // Chaining (#630 r4): B SUCCEEDED, so B now keeps its own sentinel too and
+    // it is the current wrap. What must hold is not "A's sentinel is current"
+    // but that the chain is intact — A's sentinel is still reachable THROUGH
+    // B's, and neither run's guard clobbered the other's.
+    assert.notEqual(apiTarget.fetchApi, sentinelA, "B retains its own sentinel on success");
+    assert.notEqual(apiTarget.fetchApi, prev, "and the chain never unwinds back to the raw fetchApi");
     // A's late scope-dropped post is STILL refused by A's sentinel.
     const resA = await appA.postDeferred(appA.deferredItem);
     assert.equal(resA.status, 400, "A's sentinel still constrains exactly A's items");
@@ -1452,7 +1514,9 @@ test("#556 r5 integration: batch=2 FULLY verified ⇒ dispatched (guard held unt
     assert.equal(result.verified, 2);
     assert.deepEqual(ids, ["srv-1", "srv-2"], "every batch prompt_id captured");
     assert.equal(server.calls.length, 2);
-    assert.equal(apiTarget.fetchApi, prev, "guard restored once the whole batch verified");
+    // #630 r4 — see the happy-path note: success retains the sentinel so a late
+    // duplicate of this run cannot post the full graph after we reported done.
+    assert.notEqual(apiTarget.fetchApi, prev, "sentinel retained once the whole batch verified");
   } finally {
     stop();
   }

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -974,6 +974,88 @@ test("#630 gate r4: a LATE extra post, arriving AFTER the run reported success, 
   }
 });
 
+test("#630 gate r5 P0: a TERMINAL PARTIAL batch keeps its sentinel — a late post cannot escape after a half-succeeded run", async () => {
+  // Success and dispatch-failure kept the sentinel; the terminal partial did
+  // not. One post repaired and queued, a later one refused for drift, then
+  // fetchApi restored — and a late same-mark scopeless post bypassed both the
+  // quota fence and the repair to reach ComfyUI as a full graph.
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const prev = apiTarget.fetchApi;
+    const app = makeFrontend({ shape: "dropping", apiTarget });
+    let lateNumber = null;
+    app.queuePrompt = async (number, batch) => {
+      lateNumber = number;
+      for (let i = 0; i < batch; i++) {
+        const output = i === 0 ? OUR_OUTPUT : { ...OUR_OUTPUT, "3": { class_type: "KSampler", inputs: { steps: 99 } } };
+        const body = frontendBody({ output, number, targets: null });
+        app.posted.push(body);
+        const res = await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
+        if (res.status !== 200) break;
+      }
+      return true;
+    };
+    const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 2, toNodeId: 14 });
+    assert.equal(result.outcome, "refused", "a partial batch is never claimed as dispatched");
+    assert.equal(result.verified, 1);
+    assert.notEqual(apiTarget.fetchApi, prev, "the sentinel is retained on the PARTIAL path too");
+    // The late post that used to escape.
+    const late = frontendBody({ output: OUR_OUTPUT, number: lateNumber, targets: null });
+    const res = await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(late) });
+    assert.equal(res.status, 400);
+    assert.equal(server.calls.length, 1, "no unscoped full-graph post ever left the tab");
+  } finally {
+    stop();
+  }
+});
+
+test("#630 gate r5 P0: an ALL-REFUSED run keeps its sentinel too — the last attempt's return is terminal, not a handover", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const prev = apiTarget.fetchApi;
+    const app = makeFrontend({ shape: "shim", apiTarget });
+    let lateNumber = null;
+    app.queuePrompt = async (number) => {
+      lateNumber = number;
+      const body = frontendBody({ output: OUR_OUTPUT, number, targets: ["9"] }); // mismatch: never repaired
+      app.posted.push(body);
+      await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
+      return true;
+    };
+    const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
+    assert.equal(result.outcome, "refused");
+    assert.equal(server.calls.length, 0, "nothing was queued");
+    assert.notEqual(apiTarget.fetchApi, prev, "and the sentinel remains for a late post of this run");
+    const late = frontendBody({ output: OUR_OUTPUT, number: lateNumber, targets: null });
+    const res = await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(late) });
+    assert.equal(res.status, 400);
+    assert.equal(server.calls.length, 0, "STILL nothing — a late scopeless post is refused, not run as a full graph");
+  } finally {
+    stop();
+  }
+});
+
+test("#630 gate r5 P1: graph_run discloses a PARTIAL batch's queued work instead of reporting a bare failure", () => {
+  // A partial batch is not a run that failed; it is one that partly succeeded.
+  // A bare queued:false reports failure for prompts that are executing right
+  // now, and the obvious reaction — re-run the batch — queues them a second
+  // time. Refuse-vs-disclose: refuse only what did not happen.
+  const here = dirname(fileURLToPath(import.meta.url));
+  const source = readFileSync(join(here, "../../web/js/comfyui-mcp-panel.js"), "utf8").replace(/\r\n/g, "\n");
+  const start = source.indexOf("if (runScopeResult && runScopeResult.outcome !== \"dispatched\")");
+  assert.ok(start > 0);
+  const block = source.slice(start, start + 2200).replace(/`\s*\+\s*\n\s*`/g, "").replace(/\s+/g, " ");
+  assert.match(block, /if \(runScopeResult\.verified > 0\)/, "the partial case is distinguished from a total failure");
+  assert.match(block, /partially_queued = true/);
+  assert.match(block, /queued_prompt_ids = queuedPromptIds/, "the caller can TRACK what is already running");
+  assert.match(block, /Re-run only the remaining/, "and is told not to re-run the whole batch");
+  assert.match(block, /would queue the already-running prompt\(s\) again/, "with the reason stated");
+});
+
 test("#630 gate r4: two CONCURRENT same-mark posts — the quota is a reservation, so the branch still runs exactly once", async () => {
   // The sequential fence was racy: counting only COMPLETED requests let two
   // in-flight posts both read observed=0, both clear the quota, and both be
@@ -1235,7 +1317,8 @@ test("#630 integration: repair NEVER overwrites a scope MISMATCH — a body carr
   // body says while claiming to have fixed it.
   const stop = keepAlive();
   try {
-    const apiTarget = { fetchApi: makeServer() };
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
     const app = makeFrontend({ shape: "shim", apiTarget });
     app.queuePrompt = async (number) => {
       const body = frontendBody({ output: OUR_OUTPUT, number, targets: ["9"] }); // WRONG branch
@@ -1246,7 +1329,7 @@ test("#630 integration: repair NEVER overwrites a scope MISMATCH — a body carr
     const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
     assert.equal(result.outcome, "refused");
     assert.match(result.error, /instead of \["14"\]/, "the observed mismatch is named, not overwritten");
-    assert.equal(apiTarget.fetchApi.calls.length, 0, "nothing reached ComfyUI — not the wrong scope, not a repaired one");
+    assert.equal(server.calls.length, 0, "nothing reached ComfyUI — not the wrong scope, not a repaired one");
   } finally {
     stop();
   }

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -32,6 +32,8 @@ import {
   scopeUnattributableError,
   createRunFetchInterceptor,
   createScopedRunGuard,
+  describeObserved,
+  readScopeFromBody,
   cancelPendingScopedQueueItem,
   dispatchScopedRun,
 } from "../../web/js/lib/run-scope-guard.js";
@@ -868,6 +870,168 @@ test("#630 gate r2: an explicit partial_execution_targets:null is a PRESENT key,
     await g2(...promptPost({ prompt: OUR_OUTPUT, client_id: "x", number: MARK_A }));
     assert.equal(g2.state.droppedReason, "scope_missing");
     assert.match(g2.state.dropped, /no partial_execution_targets key at all/);
+  } finally {
+    stop();
+  }
+});
+
+test("#630 gate r2 P1: describeObserved NEVER throws — the refusal path's own formatting cannot be what fails", () => {
+  // JSON.stringify is not a safe formatter for a value off the wire: circular
+  // structures and BigInt throw outright, and a deeply nested value throws
+  // RangeError from a shallow stack. This function sits on the refusal path,
+  // between deciding to refuse and recording it, so a throw here escaped the
+  // guard mid-decision. A guard that can throw is not a guard. The contract is
+  // total: any input, no throw, bounded output.
+  const circular = { a: 1 };
+  circular.self = circular;
+  let deep = { end: true };
+  for (let i = 0; i < 60000; i++) deep = { a: deep };
+  const cases = [
+    circular,
+    { big: 1n },
+    1n,
+    deep,
+    undefined,
+    Symbol("s"),
+    () => {},
+    { toJSON() { throw new Error("hostile toJSON"); } },
+    null,
+    42,
+    "plain",
+    ["a", "b"],
+  ];
+  for (const value of cases) {
+    let out;
+    assert.doesNotThrow(() => {
+      out = describeObserved(value);
+    }, `describeObserved must not throw for ${String(value?.constructor?.name ?? typeof value)}`);
+    assert.equal(typeof out, "string", "and it always yields a string the message can interpolate");
+    assert.ok(out.length <= 220, "bounded — this lands in an error a human reads");
+  }
+  // It still says something useful for ordinary values.
+  assert.equal(describeObserved(["14"]), '["14"]');
+  assert.match(describeObserved(circular), /unserializable/);
+});
+
+test("#630 gate r2 P1: a refusal is ALWAYS recorded, so a description failure can never leave the next post unguarded", async () => {
+  const stop = keepAlive();
+  try {
+    const orig = makeServer();
+    const guard = createScopedRunGuard({
+      origFetchApi: orig, execIds: ["14"], contentHash: OUR_HASH, batch: 1, toNodeId: 14, queueMark: MARK_A,
+    });
+    // A body whose partial_execution_targets is valid JSON but pathological to
+    // re-render. Whatever happens while describing it, the post must be refused
+    // and the refusal recorded.
+    let deep = "null";
+    for (let i = 0; i < 5000; i++) deep = `{"a":${deep}}`;
+    const nested = `{"prompt":${JSON.stringify(OUR_OUTPUT)},"client_id":"x","number":${MARK_A},"partial_execution_targets":${deep}}`;
+    let threw = null;
+    let first;
+    try {
+      first = await guard("/prompt", { method: "POST", body: nested });
+    } catch (err) {
+      threw = err;
+    }
+    assert.equal(threw, null, "the guard must not throw out of the refusal path");
+    assert.equal(first.status, 400, "the corrupted post is refused");
+    assert.equal(orig.calls.length, 0, "and nothing left the tab");
+    assert.ok(guard.state.dropped, "a refusal is always recorded, even when the value cannot be rendered");
+  } finally {
+    stop();
+  }
+});
+
+test("#630 gate r2 P1: describeObserved never throws — and beyond the batch budget our corrupted post is refused, not forwarded", async () => {
+  const stop = keepAlive();
+  try {
+    const orig = makeServer();
+    const guard = createScopedRunGuard({
+      origFetchApi: orig, execIds: ["14"], contentHash: OUR_HASH, batch: 1, toNodeId: 14, queueMark: MARK_A,
+    });
+    // Three attributed scopeless posts against a batch budget of 1.
+    for (let i = 0; i < 3; i++) {
+      const res = await guard(...promptPost({ prompt: OUR_OUTPUT, client_id: "x", number: MARK_A }));
+      assert.equal(res.status, 400, `post ${i + 1} refused`);
+    }
+    assert.equal(orig.calls.length, 0, "not one of them was ever forwarded unscoped");
+    assert.equal(guard.state.refused, 1, "the RECORDING stays bounded — only the forwarding was the bug");
+  } finally {
+    stop();
+  }
+});
+
+test("#630 gate r2 P2: readScopeFromBody classifies every body shape as ITSELF — a successful parse is never reported as a failed one", () => {
+  const state = (b) => readScopeFromBody(typeof b === "string" ? b : JSON.stringify(b)).state;
+  // A genuine parse failure.
+  assert.equal(state("not-json{"), "body_unreadable");
+  assert.equal(state(undefined), "body_unreadable");
+  // Parsed fine, but not a prompt request object. Reporting these as
+  // "could not be parsed" would be a definite negative about an operation that
+  // SUCCEEDED — the collapse this whole split exists to remove.
+  assert.equal(state("null"), "body_not_an_object");
+  assert.equal(state("42"), "body_not_an_object");
+  assert.equal(state('"a string"'), "body_not_an_object");
+  assert.equal(state([1, 2, 3]), "body_not_an_object");
+  // A real request object, per scope shape.
+  assert.equal(state({ prompt: {} }), "absent");
+  assert.equal(state({ prompt: {}, partial_execution_targets: null }), "not_a_list");
+  assert.equal(state({ prompt: {}, partial_execution_targets: "14" }), "not_a_list");
+  assert.equal(state({ prompt: {}, partial_execution_targets: { queueNodeIds: ["14"] } }), "not_a_list");
+  assert.equal(state({ prompt: {}, partial_execution_targets: [] }), "empty");
+  assert.equal(state({ prompt: {}, partial_execution_targets: ["14"] }), "present");
+  // Body keys are evidence, and only exist where there is an object to read.
+  assert.deepEqual(readScopeFromBody(JSON.stringify({ b: 1, a: 2 })).bodyKeys, ["a", "b"]);
+  assert.equal(readScopeFromBody(JSON.stringify([1, 2])).bodyKeys, null, "array indices are not body keys");
+  assert.equal(readScopeFromBody("not-json{").bodyKeys, null);
+});
+
+test("#630 gate r2 P2: an unparseable or non-object body is FOREIGN by identity — it can carry no mark, so it is passed through, never refused", async () => {
+  // Why the two body-shape states cannot reach the refusal path: run identity
+  // is tested first, and it is read from a top-level `number`. This pins the
+  // reasoning rather than leaving it as an unstated assumption.
+  const stop = keepAlive();
+  try {
+    for (const body of ["not-json{", JSON.stringify([1, 2, 3]), JSON.stringify(42), "null"]) {
+      const orig = makeServer();
+      const guard = createScopedRunGuard({
+        origFetchApi: orig, execIds: ["14"], contentHash: OUR_HASH, batch: 1, toNodeId: 14, queueMark: MARK_A,
+        repairScope: true,
+      });
+      await guard("/prompt", { method: "POST", body });
+      assert.equal(orig.calls.length, 1, `passed through untouched: ${body.slice(0, 12)}`);
+      assert.equal(orig.calls[0].options.body, body, "and byte-identical — never rewritten by the repair");
+      assert.equal(guard.state.refused, 0);
+      assert.equal(guard.state.repaired, 0);
+      assert.equal(guard.state.observed, 0, "never counted as our own dispatch either");
+    }
+  } finally {
+    stop();
+  }
+});
+
+test("#630 gate r2 P2: a body that PARSED but is not a request object is not reported as unparseable", async () => {
+  // JSON.parse succeeded. Saying "could not be parsed" would be a definite
+  // negative about an operation that worked — the collapse this split removes.
+  const stop = keepAlive();
+  try {
+    const scalar = scopeDroppedError({ toNodeId: 7, verdict: { ok: false, reason: "body_not_an_object", expected: ["7"], got: null, raw: 42 } });
+    assert.match(scalar, /body parsed, but it was not a request object \(42\)/);
+    assert.doesNotMatch(scalar, /could not be parsed/, "a successful parse is never reported as a failed one");
+    const unreadable = scopeDroppedError({ toNodeId: 7, verdict: { ok: false, reason: "body_unreadable", expected: ["7"], got: null } });
+    assert.match(unreadable, /could not be parsed/, "and a genuine parse failure still says so");
+    assert.notEqual(scalar, unreadable);
+    // End to end through the guard: an array body parses, and is classified as
+    // a shape problem, not a parse problem and not an absent key.
+    const orig = makeServer();
+    const guard = createScopedRunGuard({
+      origFetchApi: orig, execIds: ["14"], contentHash: OUR_HASH, batch: 1, toNodeId: 14, queueMark: MARK_A,
+    });
+    // Marked via a top-level `number`… an array cannot carry one, so it is
+    // foreign by identity and must simply pass through untouched.
+    await guard("/prompt", { method: "POST", body: JSON.stringify([1, 2, 3]) });
+    assert.equal(orig.calls.length, 1, "an unattributable body is foreign traffic, passed through");
+    assert.equal(guard.state.refused, 0);
   } finally {
     stop();
   }

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -13,6 +13,9 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
 
 import {
   newScopedQueueMark,
@@ -729,6 +732,142 @@ test("#630 integration: a build honoring NEITHER shape is now HONOURED, not refu
     assert.ok(!sent.partial_execution_targets.includes("9"), "the unrelated SaveImage branch is not a root (#556)");
     assert.deepEqual(sent.prompt, OUR_OUTPUT, "the prompt itself is untouched by the repair");
     assert.equal(sent.number, result.queueMark, "the repaired body keeps this run's identity mark");
+  } finally {
+    stop();
+  }
+});
+
+test("#630 gate r1: batch=2 through the REPAIR path — EVERY post is repaired and EVERY body that reaches ComfyUI names only node 14", async () => {
+  // Repair must survive the batch accounting, not just the single-post case:
+  // a batch is N separate /prompt posts, and a scope that reached only the
+  // first would leave the rest running the full graph.
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const app = makeFrontend({ shape: "dropping", apiTarget });
+    app.queuePrompt = async (number, batch) => {
+      for (let i = 0; i < batch; i++) {
+        const body = frontendBody({ output: OUR_OUTPUT, number, targets: null }); // scope dropped every time
+        app.posted.push(body);
+        await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
+      }
+      return true;
+    };
+    const ids = [];
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["14"], batch: 2, toNodeId: 14,
+      onPromptId: (p) => ids.push(p),
+    });
+    assert.equal(result.outcome, "dispatched");
+    assert.equal(result.verified, 2, "the WHOLE batch verified — never dispatched on a partial");
+    assert.equal(result.repaired, 2, "both posts needed the repair, both got it");
+    assert.equal(result.scopeAppliedBy, "request_body_repair");
+    assert.deepEqual(ids, ["srv-1", "srv-2"], "every repaired prompt_id still reaches the recovery ledger");
+    // The assertion that matters: what ComfyUI was told to execute, per post.
+    assert.equal(server.calls.length, 2);
+    for (const call of server.calls) {
+      assert.deepEqual(
+        JSON.parse(call.options.body).partial_execution_targets,
+        ["14"],
+        "every post in the batch is scoped — not just the first",
+      );
+    }
+  } finally {
+    stop();
+  }
+});
+
+test("#630 gate r1: a batch where a LATER post drifts is still a truthful partial — repair never rescues a changed graph into a full-batch claim", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const app = makeFrontend({ shape: "dropping", apiTarget });
+    app.queuePrompt = async (number, batch) => {
+      for (let i = 0; i < batch; i++) {
+        // Post 2 of EACH attempt serializes a DRIFTED graph (a widget value
+        // changed under the deferred item). Per-attempt, not cumulative: the
+        // earlier argument-shape attempts must present the same situation.
+        const output = i === 0 ? OUR_OUTPUT : { ...OUR_OUTPUT, "3": { class_type: "KSampler", inputs: { steps: 99 } } };
+        const body = frontendBody({ output, number, targets: null });
+        app.posted.push(body);
+        const res = await apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
+        if (res.status !== 200) break; // the frontend's batch loop breaks on a refusal
+      }
+      return true;
+    };
+    const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 2, toNodeId: 14 });
+    assert.equal(result.outcome, "refused", "never 'dispatched' on a partial batch");
+    assert.equal(result.verified, 1, "the truthful count of what IS queued");
+    assert.match(result.error, /1 of 2/);
+    assert.match(result.error, /graph changed/i, "the drift is named, not repaired away");
+    assert.equal(server.calls.length, 1, "only the undrifted post reached ComfyUI");
+    assert.deepEqual(JSON.parse(server.calls[0].options.body).partial_execution_targets, ["14"]);
+  } finally {
+    stop();
+  }
+});
+
+test("#630 gate r1: graph_run's repair disclosure separates what was OBSERVED from what was not — it never asserts the frontend's internal hook mode", () => {
+  // The panel sees the outgoing request body, not the frontend's queue loop.
+  // Two different frontend behaviours produce the identical observation: the
+  // positional argument accepted (hooks ran partial) with the field dropped
+  // later, or the argument ignored outright (hooks ran full). Naming the
+  // second as fact would be asserting a cause from a bucket — the exact defect
+  // this change exists to remove — so the note must state the uncertainty.
+  const here = dirname(fileURLToPath(import.meta.url));
+  const source = readFileSync(join(here, "../../web/js/comfyui-mcp-panel.js"), "utf8").replace(/\r\n/g, "\n");
+  const start = source.indexOf('accept.scope_applied_by = "request_body_repair"');
+  assert.ok(start > 0, "graph_run discloses a body-repaired scope rather than reporting it as a native scoped run");
+  // Rebuild the message the caller actually receives: the source spells it as
+  // adjacent template chunks joined with `+`, so strip the concatenation
+  // scaffolding and assert against the prose itself, not its line breaks.
+  const note = source
+    .slice(start, start + 1800)
+    .replace(/`\s*\+\s*\n\s*`/g, "")
+    .replace(/\s+/g, " ");
+  assert.match(note, /OBSERVED: the request ComfyUI received names ONLY node \$\{to_node_id\} as an execution root/,
+    "what the panel actually saw is labelled as such, and it is which nodes execute");
+  assert.match(note, /NOT OBSERVED: whether the frontend also treated this as a partial execution internally/,
+    "and what it could not see is labelled too");
+  // The discredited definite claim must be gone, not softened around.
+  assert.doesNotMatch(
+    note,
+    /the frontend ran its queue-time widget hooks as if this were a full run/,
+    "the unobserved hook mode must never be stated as fact",
+  );
+  assert.match(note, /If it did not, its queue-time widget hooks ran/,
+    "the hook consequence is conditional on the unobserved branch");
+  assert.match(note, /does not change which nodes execute/, "and its blast radius is bounded honestly");
+});
+
+test("#630 gate r2: an explicit partial_execution_targets:null is a PRESENT key, never reported as 'no key at all'", async () => {
+  // The body keys printed as evidence would show the key present. Saying the
+  // key was absent would contradict the panel's own evidence — the observed-
+  // state-collapsed-into-a-definite-negative defect this split exists to stop.
+  const stop = keepAlive();
+  try {
+    const orig = makeServer();
+    const guard = createScopedRunGuard({
+      origFetchApi: orig,
+      execIds: ["14"],
+      contentHash: OUR_HASH,
+      batch: 1,
+      toNodeId: 14,
+      queueMark: MARK_A,
+    });
+    await guard(...promptPost({ prompt: OUR_OUTPUT, client_id: "x", number: MARK_A, partial_execution_targets: null }));
+    assert.equal(guard.state.droppedReason, "scope_not_a_list", "a present-but-unusable value is not an absent key");
+    assert.doesNotMatch(guard.state.dropped, /no partial_execution_targets key at all/);
+    assert.match(guard.state.dropped, /was not a list \(null\)/);
+    // …while a genuinely absent key still reads as absent.
+    const g2 = createScopedRunGuard({
+      origFetchApi: makeServer(), execIds: ["14"], contentHash: OUR_HASH, batch: 1, toNodeId: 14, queueMark: MARK_A,
+    });
+    await g2(...promptPost({ prompt: OUR_OUTPUT, client_id: "x", number: MARK_A }));
+    assert.equal(g2.state.droppedReason, "scope_missing");
+    assert.match(g2.state.dropped, /no partial_execution_targets key at all/);
   } finally {
     stop();
   }

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -1048,10 +1048,10 @@ test("#630 gate r5 P1: graph_run discloses a PARTIAL batch's queued work instead
   const source = readFileSync(join(here, "../../web/js/comfyui-mcp-panel.js"), "utf8").replace(/\r\n/g, "\n");
   const start = source.indexOf("if (runScopeResult && runScopeResult.outcome !== \"dispatched\")");
   assert.ok(start > 0);
-  const block = source.slice(start, start + 2200).replace(/`\s*\+\s*\n\s*`/g, "").replace(/\s+/g, " ");
+  const block = source.slice(start, start + 4600).replace(/`\s*\+\s*\n\s*`/g, "").replace(/\s+/g, " ");
   assert.match(block, /if \(runScopeResult\.verified > 0\)/, "the partial case is distinguished from a total failure");
-  assert.match(block, /partially_queued = true/);
-  assert.match(block, /queued_prompt_ids = queuedPromptIds/, "the caller can TRACK what is already running");
+  assert.match(block, /partially_queued: true/);
+  assert.match(block, /queued_prompt_ids: queuedPromptIds\.slice\(\)/, "the caller can TRACK what is already running");
   assert.match(block, /Re-run only the remaining/, "and is told not to re-run the whole batch");
   assert.match(block, /would queue the already-running prompt\(s\) again/, "with the reason stated");
 });
@@ -1116,36 +1116,61 @@ test("#630 gate r4: a MALFORMED response keeps its slot — 'could not tell whet
   }
 });
 
-test("#630 gate r3: the quota counts only COMPLETED work — a failed post does not fence out the retry that is still owed", async () => {
-  // A post whose fetch threw never reached ComfyUI, so a later post of the same
-  // batch is legitimately still owed. Counting it toward the quota would fence
-  // out real requested work.
+test("#630 gate r6: a THROWN fetch is INDETERMINATE, not proof of non-arrival — its slot stays consumed", async () => {
+  // This test previously asserted the opposite: that a throw means the request
+  // never reached ComfyUI, so its quota slot was released and a retry could
+  // dispatch. That premise is wrong and is this cluster's defect class exactly.
+  // A fetch can throw AFTER ComfyUI received and queued the prompt — a reset
+  // while reading the response is indistinguishable from one before the request
+  // left. Releasing the slot on that basis re-dispatches a branch that may
+  // already be rendering.
   const stop = keepAlive();
   try {
-    let n = 0;
     const server = makeServer(() => {
-      if (n++ === 0) throw new Error("network blip");
-      return jsonResponse(200, { prompt_id: "srv-late" });
+      throw new Error("connection reset");
     });
     const guard = createScopedRunGuard({
       origFetchApi: server, execIds: ["14"], contentHash: OUR_HASH, batch: 1, toNodeId: 14, queueMark: MARK_A,
       repairScope: true,
     });
     const post = () => guard(...promptPost(frontendBody({ number: MARK_A, targets: null })));
-    await assert.rejects(post, /network blip/, "the frontend sees the failure it would have seen");
+    await assert.rejects(post, /connection reset/, "the frontend still sees the failure it would have seen");
     assert.ok(guard.state.failed, "recorded as a dispatch FAILURE, never a success");
-    assert.equal(guard.state.observed, 0);
-    // The retry is still owed — it must not be fenced as an overrun.
-    await post();
-    assert.equal(guard.state.observed, 1, "the owed prompt still dispatches");
-    assert.equal(guard.state.overrun, 0, "a failed post never consumed the quota");
-    // …and NOW the quota is spent, so a third post is fenced.
-    await post();
+    assert.equal(guard.state.observed, 0, "and never counted as verified");
+    assert.equal(guard.state.indeterminate, 1, "its outcome is recorded as UNKNOWN, which is what it is");
+    // The slot is spent: a second post cannot double-render a branch that may
+    // already be queued.
+    const again = await post();
+    assert.equal(again.status, 400);
     assert.equal(guard.state.overrun, 1);
-    assert.equal(guard.state.observed, 1, "no extra execution of the branch");
+    assert.equal(server.calls.length, 1, "exactly one request ever left the panel");
   } finally {
     stop();
   }
+});
+
+test("#630 gate r6: graph_run never states a remainder it cannot count, and never claims 'nothing queued' after an indeterminate dispatch", () => {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const source = readFileSync(join(here, "../../web/js/comfyui-mcp-panel.js"), "utf8").replace(/\r\n/g, "\n");
+  const start = source.indexOf('if (runScopeResult && runScopeResult.outcome !== "dispatched")');
+  assert.ok(start > 0);
+  const block = source.slice(start, start + 4200).replace(/`\s*\+\s*\n\s*`/g, "").replace(/\s+/g, " ");
+  // A partial no longer asserts "not queued" for prompts that are executing.
+  assert.match(block, /queued: true, complete: false, partially_queued: true/,
+    "a partial batch is queued-but-incomplete, never a flat failure");
+  assert.match(block, /incomplete_reason: runScopeResult\.error/,
+    "and its reason does not masquerade as an error about work that did happen");
+  // The remainder is only named when it is actually knowable.
+  assert.match(block, /const unknown = runScopeResult\.indeterminate > 0;/);
+  // …and that flag must actually SELECT the guidance. Asserting only that both
+  // strings exist would pass a version that always names a remainder.
+  assert.match(block, /retry_guidance: unknown \?/,
+    "the indeterminate flag gates which guidance is given, it is not merely computed");
+  assert.match(block, /the remaining count cannot be stated from here without risking a duplicate render/);
+  assert.match(block, /Check the ComfyUI queue before re-running anything/);
+  // Zero verified + an indeterminate dispatch is still not "nothing ran".
+  assert.match(block, /outcome_unknown = true/);
+  assert.match(block, /rather than assuming nothing ran/);
 });
 
 test("#630 gate r2 P1: describeObserved NEVER throws — the refusal path's own formatting cannot be what fails", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9229,24 +9229,33 @@ const GRAPH_TOOL_EXECUTORS = {
     // #556 — DISCLOSE how the scope actually reached ComfyUI. When both
     // app.queuePrompt argument shapes failed to carry it, the panel wrote
     // partial_execution_targets into this run's own /prompt body and
-    // re-verified it before it left. The run IS scoped to the requested
-    // branch — but the frontend queued it believing it was a full run, so its
-    // queue-time widget hooks ran with isPartialExecution=false (a
-    // control_after_generate seed may have advanced as it would for a full
-    // run). That difference is stated here rather than left for the caller to
-    // discover; ran_to_node alone would imply a native scoped run.
+    // re-verified it before it left. The run IS scoped to the requested branch
+    // — that much was observed on the outgoing request.
+    //
+    // What is NOT observed, and must therefore not be asserted: whether the
+    // frontend treated this as a partial execution INTERNALLY. The panel sees
+    // the request body, not the queue loop. The frontend may have accepted the
+    // positional argument and run its queue-time widget hooks with
+    // isPartialExecution=true, only for a later layer to drop the field from
+    // the body; or it may have ignored the argument and run them as a full
+    // run. Both produce exactly the observation the panel made. Claiming the
+    // second would be asserting a cause from a bucket — the very defect this
+    // change exists to stop — so the note states the uncertainty instead.
     if (partialTargets && runScopeResult?.scopeAppliedBy === "request_body_repair") {
       accept.scope_applied_by = "request_body_repair";
       accept.scope_note =
-        `This frontend build did not carry the run-to-node scope through ` +
+        `The run-to-node scope did not reach the /prompt request through ` +
         `app.queuePrompt in either supported argument shape, so the panel wrote ` +
-        `partial_execution_targets into this run's own /prompt request and confirmed ` +
-        `it before dispatch. ONLY node ${to_node_id}'s branch was queued for execution. ` +
-        `One difference from a natively scoped run: the frontend ran its queue-time ` +
-        `widget hooks as if this were a full run (isPartialExecution=false), so a ` +
-        `control_after_generate widget may have advanced its value the way a full run ` +
-        `would. Please report this build (#556) — it is not reproducible against ` +
-        `ComfyUI_frontend 1.42-1.50.`;
+        `partial_execution_targets into this run's own request and confirmed it was ` +
+        `there before dispatch. OBSERVED: the request ComfyUI received names ONLY ` +
+        `node ${to_node_id} as an execution root, so only that branch executes. ` +
+        `NOT OBSERVED: whether the frontend also treated this as a partial execution ` +
+        `internally — the panel can see the request body but not the frontend's queue ` +
+        `loop. If it did not, its queue-time widget hooks ran as they would for a full ` +
+        `run, so a control_after_generate widget may have advanced its value ` +
+        `differently than a natively scoped run would. This does not change which ` +
+        `nodes execute. Please report this build (#556) — this path is not ` +
+        `reproducible against ComfyUI_frontend 1.42-1.50.`;
     }
     return accept;
   },

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9229,16 +9229,31 @@ const GRAPH_TOOL_EXECUTORS = {
       }
       // Nothing verified. But "nothing verified" is still not always "nothing
       // queued": an indeterminate dispatch left the panel and may have been
-      // accepted. Refuse — but never claim more certainty than was observed.
-      const failed = { queued: false, error: runScopeResult.error };
+      // accepted.
+      //
+      // codex gate r8, P1 — so `queued` is OMITTED entirely in that case rather
+      // than set false. `queued: false` is a definite negative on the field
+      // callers branch on, and asserting it about a request whose fate we
+      // explicitly say we cannot determine is the same contradiction this
+      // cluster keeps producing. There is no boolean that means "unknown", so
+      // the field that only has two honest values simply is not present, and
+      // `queued_unknown` says why. Only a run where nothing left the panel gets
+      // the definite `queued: false`.
       if (runScopeResult.indeterminate > 0) {
-        failed.outcome_unknown = true;
-        failed.retry_guidance =
-          `No prompt was confirmed queued, but ${runScopeResult.indeterminate} request(s) ` +
-          `DID leave the panel and their outcome could not be determined — ComfyUI may have ` +
-          `queued them. Check the ComfyUI queue before retrying rather than assuming nothing ran.`;
+        return {
+          queued_unknown: true,
+          error: runScopeResult.error,
+          indeterminate_count: runScopeResult.indeterminate,
+          retry_guidance:
+            `No prompt was CONFIRMED queued, but ${runScopeResult.indeterminate} request(s) ` +
+            `DID leave the panel and their outcome could not be determined — ComfyUI may have ` +
+            `queued them, and they carried the run-to-node scope. Check the ComfyUI queue ` +
+            `before retrying rather than assuming nothing ran; a blind retry can render the ` +
+            `branch twice. This result deliberately omits "queued" because neither true nor ` +
+            `false is an honest answer here.`,
+        };
       }
-      return failed;
+      return { queued: false, error: runScopeResult.error };
     }
     // Verdict from BOTH channels: the captured top-level rejection (#358) and the
     // per-node errors the frontend stashed. null ⇒ genuinely accepted.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9257,6 +9257,15 @@ const GRAPH_TOOL_EXECUTORS = {
         `nodes execute. Please report this build (#556) — this path is not ` +
         `reproducible against ComfyUI_frontend 1.42-1.50.`;
     }
+    // #556 (codex gate r3) — an EXTRA /prompt post carrying this run's identity
+    // was fenced out. The requested prompts queued, so this is a DISCLOSURE and
+    // not a failure: reporting it as one would invite a retry that re-queues
+    // work already running. But it is never silent — the caller asked for
+    // batch_count prompts and their frontend tried to send more.
+    if (partialTargets && runScopeResult?.overrunBlocked > 0) {
+      accept.extra_dispatch_blocked = runScopeResult.overrunBlocked;
+      accept.extra_dispatch_note = runScopeResult.overrunNote;
+    }
     return accept;
   },
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9190,25 +9190,53 @@ const GRAPH_TOOL_EXECUTORS = {
     // comes AFTER the ledger registration above so any partially-verified
     // prompts (which ARE queued, scoped) stay reconcilable (#370).
     if (runScopeResult && runScopeResult.outcome !== "dispatched") {
-      const failed = { queued: false, error: runScopeResult.error };
-      // #556 (codex gate r5, P1) — DISCLOSE the work that DID happen. A partial
-      // batch (one or more prompts verified and queued WITH the scope, a later
-      // one refused) is not a run that failed; it is a run that partly
-      // succeeded. Returning a bare queued:false for it reports failure for
-      // work that is at this moment executing on the GPU, and the obvious
-      // reaction — re-run the whole batch — queues the verified prompts a
-      // SECOND time. Refuse-vs-disclose: the refusal covers only what did not
-      // happen, and what did happen is named, with its prompt_ids, so the
-      // caller can track it and re-run only the remainder.
+      // #556 (codex gate r5/r6, P1) — a PARTIAL batch is not a failed run.
+      // One or more prompts were verified and queued WITH the scope; a later
+      // one was not. `queued:false` asserts that nothing was queued, which is
+      // FALSE while those prompts are executing on the GPU — and a caller
+      // branching on that flag re-runs the batch and pays for them twice.
+      // Between the two possible misreadings, "nothing happened" is the
+      // destructive one; "everything happened" merely leaves a visible,
+      // recoverable gap. So a partial reports queued:true with complete:false,
+      // and the reason moves out of `error` (which reads as "this did not
+      // happen") into `incomplete_reason`.
       if (runScopeResult.verified > 0) {
-        failed.partially_queued = true;
-        failed.queued_count = runScopeResult.verified;
-        failed.queued_prompt_ids = queuedPromptIds.slice();
+        const unknown = runScopeResult.indeterminate > 0;
+        return {
+          queued: true,
+          complete: false,
+          partially_queued: true,
+          queued_count: runScopeResult.verified,
+          queued_prompt_ids: queuedPromptIds.slice(),
+          ran_to_node: Number(to_node_id),
+          incomplete_reason: runScopeResult.error,
+          // RETRY GUIDANCE MUST NOT ASSERT A REMAINDER IT CANNOT COUNT
+          // (gate r6). When a prompt's outcome is INDETERMINATE — its fetch
+          // threw, or its response was unparseable — ComfyUI may or may not
+          // have queued it. Naming a precise remainder there would send the
+          // caller to re-run something that could already be rendering.
+          retry_guidance: unknown
+            ? `${runScopeResult.verified} of ${batch} prompt(s) ARE queued and scoped to ` +
+              `node ${to_node_id} (prompt_ids above). ${runScopeResult.indeterminate} more ` +
+              `left the panel but their outcome could NOT be determined — ComfyUI may or ` +
+              `may not have queued them. Check the ComfyUI queue before re-running anything: ` +
+              `the remaining count cannot be stated from here without risking a duplicate render.`
+            : `${runScopeResult.verified} of ${batch} prompt(s) ARE queued and scoped to ` +
+              `node ${to_node_id}; they are running and are tracked by the prompt_ids above. ` +
+              `Re-run only the remaining ${Math.max(0, batch - runScopeResult.verified)} — ` +
+              `re-running the full batch would queue the already-running prompt(s) again.`,
+        };
+      }
+      // Nothing verified. But "nothing verified" is still not always "nothing
+      // queued": an indeterminate dispatch left the panel and may have been
+      // accepted. Refuse — but never claim more certainty than was observed.
+      const failed = { queued: false, error: runScopeResult.error };
+      if (runScopeResult.indeterminate > 0) {
+        failed.outcome_unknown = true;
         failed.retry_guidance =
-          `${runScopeResult.verified} of ${batch} prompt(s) ARE queued and scoped to node ` +
-          `${to_node_id}; they are running and are tracked by the prompt_ids above. ` +
-          `Re-run only the remaining ${Math.max(0, batch - runScopeResult.verified)} — ` +
-          `re-running the full batch would queue the already-running prompt(s) again.`;
+          `No prompt was confirmed queued, but ${runScopeResult.indeterminate} request(s) ` +
+          `DID leave the panel and their outcome could not be determined — ComfyUI may have ` +
+          `queued them. Check the ComfyUI queue before retrying rather than assuming nothing ran.`;
       }
       return failed;
     }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9226,6 +9226,28 @@ const GRAPH_TOOL_EXECUTORS = {
           "mutation and would NOT have been caught. Every other input was drift-covered.",
       };
     }
+    // #556 — DISCLOSE how the scope actually reached ComfyUI. When both
+    // app.queuePrompt argument shapes failed to carry it, the panel wrote
+    // partial_execution_targets into this run's own /prompt body and
+    // re-verified it before it left. The run IS scoped to the requested
+    // branch — but the frontend queued it believing it was a full run, so its
+    // queue-time widget hooks ran with isPartialExecution=false (a
+    // control_after_generate seed may have advanced as it would for a full
+    // run). That difference is stated here rather than left for the caller to
+    // discover; ran_to_node alone would imply a native scoped run.
+    if (partialTargets && runScopeResult?.scopeAppliedBy === "request_body_repair") {
+      accept.scope_applied_by = "request_body_repair";
+      accept.scope_note =
+        `This frontend build did not carry the run-to-node scope through ` +
+        `app.queuePrompt in either supported argument shape, so the panel wrote ` +
+        `partial_execution_targets into this run's own /prompt request and confirmed ` +
+        `it before dispatch. ONLY node ${to_node_id}'s branch was queued for execution. ` +
+        `One difference from a natively scoped run: the frontend ran its queue-time ` +
+        `widget hooks as if this were a full run (isPartialExecution=false), so a ` +
+        `control_after_generate widget may have advanced its value the way a full run ` +
+        `would. Please report this build (#556) — it is not reproducible against ` +
+        `ComfyUI_frontend 1.42-1.50.`;
+    }
     return accept;
   },
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9190,7 +9190,27 @@ const GRAPH_TOOL_EXECUTORS = {
     // comes AFTER the ledger registration above so any partially-verified
     // prompts (which ARE queued, scoped) stay reconcilable (#370).
     if (runScopeResult && runScopeResult.outcome !== "dispatched") {
-      return { queued: false, error: runScopeResult.error };
+      const failed = { queued: false, error: runScopeResult.error };
+      // #556 (codex gate r5, P1) — DISCLOSE the work that DID happen. A partial
+      // batch (one or more prompts verified and queued WITH the scope, a later
+      // one refused) is not a run that failed; it is a run that partly
+      // succeeded. Returning a bare queued:false for it reports failure for
+      // work that is at this moment executing on the GPU, and the obvious
+      // reaction — re-run the whole batch — queues the verified prompts a
+      // SECOND time. Refuse-vs-disclose: the refusal covers only what did not
+      // happen, and what did happen is named, with its prompt_ids, so the
+      // caller can track it and re-run only the remainder.
+      if (runScopeResult.verified > 0) {
+        failed.partially_queued = true;
+        failed.queued_count = runScopeResult.verified;
+        failed.queued_prompt_ids = queuedPromptIds.slice();
+        failed.retry_guidance =
+          `${runScopeResult.verified} of ${batch} prompt(s) ARE queued and scoped to node ` +
+          `${to_node_id}; they are running and are tracked by the prompt_ids above. ` +
+          `Re-run only the remaining ${Math.max(0, batch - runScopeResult.verified)} — ` +
+          `re-running the full batch would queue the already-running prompt(s) again.`;
+      }
+      return failed;
     }
     // Verdict from BOTH channels: the captured top-level rejection (#358) and the
     // per-node errors the frontend stashed. null ⇒ genuinely accepted.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9239,13 +9239,17 @@ const GRAPH_TOOL_EXECUTORS = {
       // the field that only has two honest values simply is not present, and
       // `queued_unknown` says why. Only a run where nothing left the panel gets
       // the definite `queued: false`.
-      if (runScopeResult.indeterminate > 0) {
+      // `inFlight` counts requests that HAD LEFT the panel and were still
+      // awaiting a response when the wait expired (gate r9) — same epistemic
+      // status as an indeterminate one: it may be accepted a moment from now.
+      const unresolved = (runScopeResult.indeterminate ?? 0) + (runScopeResult.inFlight ?? 0);
+      if (unresolved > 0) {
         return {
           queued_unknown: true,
           error: runScopeResult.error,
-          indeterminate_count: runScopeResult.indeterminate,
+          indeterminate_count: unresolved,
           retry_guidance:
-            `No prompt was CONFIRMED queued, but ${runScopeResult.indeterminate} request(s) ` +
+            `No prompt was CONFIRMED queued, but ${unresolved} request(s) ` +
             `DID leave the panel and their outcome could not be determined — ComfyUI may have ` +
             `queued them, and they carried the run-to-node scope. Check the ComfyUI queue ` +
             `before retrying rather than assuming nothing ran; a blind retry can render the ` +

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -317,20 +317,37 @@ function bodyQueueMark(bodyText) {
  * So the states are now reported separately, the message states only what was
  * OBSERVED, and the body's top-level keys ride along as evidence.
  *
- * @typedef {"present"|"absent"|"empty"|"not_a_list"|"body_unreadable"} ScopeReadState
+ * `body_unreadable` and `body_not_an_object` are deliberately separate (codex
+ * gate r2): a JSON scalar, `null`, or an array PARSES fine — saying it "could
+ * not be parsed" would report a definite negative about an operation that
+ * actually succeeded, which is the same collapse this split exists to remove.
+ *
+ * REACHABILITY, stated plainly rather than implied: neither of those two states
+ * can reach the guard's refusal path today, and that is by construction, not by
+ * luck. The guard's FIRST test is run identity — this run's unique queue mark,
+ * read from the body's top-level `number`. A body that will not parse, or that
+ * parses to a scalar/array, cannot carry that mark, so it is FOREIGN traffic:
+ * passed through untouched, never refused, never repaired, never observed. The
+ * two states therefore exist for correctness of the classification itself (and
+ * for any future caller that reads a body it has already attributed some other
+ * way), and the tests pin BOTH the classification and the pass-through.
+ *
+ * @typedef {"present"|"absent"|"empty"|"not_a_list"|"body_unreadable"|"body_not_an_object"} ScopeReadState
  * @returns {{state: ScopeReadState, targets: string[]|null, bodyKeys: string[]|null, raw: unknown}}
  */
-function readScopeFromBody(bodyText) {
+export function readScopeFromBody(bodyText) {
   let body;
   try {
     body = JSON.parse(bodyText);
   } catch {
     return { state: "body_unreadable", targets: null, bodyKeys: null, raw: undefined };
   }
-  const bodyKeys = body && typeof body === "object" ? Object.keys(body).sort() : null;
-  if (!body || typeof body !== "object") {
-    return { state: "body_unreadable", targets: null, bodyKeys, raw: undefined };
+  // An array parses and has keys, but it is not a prompt request; treat it with
+  // the scalars rather than letting Object.keys present indices as body keys.
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { state: "body_not_an_object", targets: null, bodyKeys: null, raw: body };
   }
+  const bodyKeys = Object.keys(body).sort();
   const t = body.partial_execution_targets;
   // "absent" means the key is genuinely not there. JSON cannot encode
   // `undefined`, so after a parse `undefined` is exactly "no such key". An
@@ -420,27 +437,73 @@ export function repairScopeInBody(bodyText, expectedExecIds) {
 }
 
 /**
+ * Render an arbitrary observed value for a human-readable message WITHOUT ever
+ * throwing (codex gate r2, P1).
+ *
+ * `JSON.stringify` is not a safe formatter for a value that came off the wire:
+ * a deeply nested object throws RangeError, a BigInt throws TypeError, a
+ * circular structure throws. This function sat between the guard's decision to
+ * refuse and the recording of that refusal, so a throw here escaped the guard
+ * with the refusal budget already spent — and on the next attributed scopeless
+ * post the exhausted-budget path forwarded it UNCHANGED, i.e. a full-graph run.
+ * A guard that can throw is not a guard.
+ *
+ * Bounded in length too: this string goes into an error a caller reads.
+ *
+ * NOTE on reproducibility (be honest about what is proven): the depth-based
+ * trigger codex found is engine- and stack-dependent. `JSON.stringify` DOES
+ * throw RangeError on a ~5000-deep value when called from a shallow stack on
+ * this Node, but from inside the guard's async call chain it survived 150k
+ * levels — V8's stringify is iterative there. So the exploit is real but not
+ * deterministically reproducible from the guard's entry point on this engine.
+ * The contract enforced by the tests is therefore the one that matters and can
+ * be proven: this function NEVER throws, for any input. Exported for that test.
+ */
+export function describeObserved(value) {
+  try {
+    const text = JSON.stringify(value);
+    if (typeof text === "string") return text.length > 200 ? `${text.slice(0, 200)}…` : text;
+    return String(typeof value); // undefined / function / symbol — stringify returns undefined
+  } catch {
+    // Unserializable (too deep, circular, BigInt). Say what it was, not what it said.
+    try {
+      return Array.isArray(value) ? `an unserializable array` : `an unserializable ${typeof value} value`;
+    } catch {
+      return "an unserializable value";
+    }
+  }
+}
+
+/**
  * What was OBSERVED about the scope in our own dispatch — one clause per
  * distinct state, asserting nothing beyond the observation. See
  * readScopeFromBody for why these are no longer one bucket.
+ *
+ * Every interpolation goes through describeObserved: this runs on the refusal
+ * path, and the refusal path must not be able to fail.
  */
 function scopeObservation(verdict) {
   switch (verdict?.reason) {
     case "scope_mismatch":
       return (
         `the POST /prompt body carried partial_execution_targets ` +
-        `${JSON.stringify(verdict.got)} instead of ${JSON.stringify(verdict.expected)}`
+        `${describeObserved(verdict.got)} instead of ${describeObserved(verdict.expected)}`
       );
     case "scope_not_a_list":
       return (
         `the POST /prompt body's partial_execution_targets was not a list ` +
-        `(${JSON.stringify(verdict.raw)}) — the requested scope did not survive ` +
+        `(${describeObserved(verdict.raw)}) — the requested scope did not survive ` +
         `the trip through app.queuePrompt in a usable shape`
       );
     case "scope_empty":
       return `the POST /prompt body carried an EMPTY partial_execution_targets list`;
     case "body_unreadable":
       return `the POST /prompt body could not be parsed, so the scope could not be read from it`;
+    case "body_not_an_object":
+      return (
+        `the POST /prompt body parsed, but it was not a request object ` +
+        `(${describeObserved(verdict.raw)}), so it carries no scope to read`
+      );
     default:
       return (
         `the POST /prompt body carried no partial_execution_targets key at all` +
@@ -784,41 +847,70 @@ export function createScopedRunGuard({
     // OUR dispatch CORRUPTED. Content drift (r7) takes naming precedence: a
     // changed graph would render the wrong workflow even with the scope
     // intact. Then the scope itself: missing, or wrong/extra/partial targets.
-    if (state.refused < maxBatch) {
-      state.refused++;
-      if (state.dropped == null) {
-        // Report the OBSERVATION, not a bucket: which of the distinct
-        // no-usable-scope states actually occurred (readScopeFromBody), with
-        // the body's top-level keys as evidence for the next report.
-        const verdict = !contentOk
-          ? { ok: false, reason: "graph_changed" }
-          : targets
-            ? { ok: false, reason: "scope_mismatch", expected, got: targets }
-            : {
-                ok: false,
-                reason:
-                  scopeRead.state === "not_a_list"
-                    ? "scope_not_a_list"
-                    : scopeRead.state === "empty"
-                      ? "scope_empty"
-                      : scopeRead.state === "body_unreadable"
-                        ? "body_unreadable"
+    //
+    // REFUSE FIRST, DESCRIBE AFTER (codex gate r2, P1). The refusal is the
+    // thing that makes this post safe; the message is only its description.
+    // Recording the message used to sit BETWEEN spending the refusal budget
+    // and returning the refusal, so a throw while formatting an observed value
+    // escaped the guard with the budget already spent — and the next
+    // attributed post then took the exhausted-budget path and was FORWARDED,
+    // scopeless, as a full graph. The budget is now spent only alongside a
+    // recorded message, and the description is fenced so it cannot throw at
+    // all (describeObserved) AND cannot escape if a future edit reintroduces a
+    // throw (the catch below).
+    if (state.dropped == null) {
+      // Report the OBSERVATION, not a bucket: which of the distinct
+      // no-usable-scope states actually occurred (readScopeFromBody), with
+      // the body's top-level keys as evidence for the next report.
+      const verdict = !contentOk
+        ? { ok: false, reason: "graph_changed" }
+        : targets
+          ? { ok: false, reason: "scope_mismatch", expected, got: targets }
+          : {
+              ok: false,
+              reason:
+                scopeRead.state === "not_a_list"
+                  ? "scope_not_a_list"
+                  : scopeRead.state === "empty"
+                    ? "scope_empty"
+                    : scopeRead.state === "body_unreadable"
+                      ? "body_unreadable"
+                      : scopeRead.state === "body_not_an_object"
+                        ? "body_not_an_object"
                         : "scope_missing",
-                expected,
-                got: null,
-                raw: scopeRead.raw,
-                bodyKeys: scopeRead.bodyKeys,
-              };
-        state.droppedReason = verdict.reason;
+              expected,
+              got: null,
+              raw: scopeRead.raw,
+              bodyKeys: scopeRead.bodyKeys,
+            };
+      state.droppedReason = verdict.reason;
+      try {
         state.dropped = scopeDroppedError({ toNodeId, verdict });
+      } catch {
+        // The description failed; the REFUSAL must not. Never leave
+        // state.dropped null here — a null would re-enter this branch on the
+        // next post and could spend the whole batch's budget describing.
+        state.dropped =
+          `run-to-node scope for node ${toNodeId} was NOT applied and the reason could ` +
+          `not be described. Nothing was queued — refusing to fall through to a ` +
+          `full-graph execution (#556).`;
+      }
+      state.refused++;
+      try {
         onScopeDropped?.(state.dropped);
+      } catch {
+        // A caller's notification failure must not turn a refusal into a forward.
       }
       notify();
       return SCOPE_DROPPED_RESPONSE();
     }
-    // Refusal budget for this batch is exhausted (paranoia bound; normally the
-    // frontend's batch loop breaks on the first refusal).
-    return origFetchApi(route, options);
+    // Already refused once in this batch: still OUR corrupted post, so it is
+    // still refused. Only the RECORDING is bounded (one message per attempt) —
+    // the budget never licensed dispatching a scopeless full graph, and letting
+    // it do so is the #556 harm itself.
+    if (state.refused < maxBatch) state.refused++;
+    notify();
+    return SCOPE_DROPPED_RESPONSE();
   };
   guard.state = state;
   // Verdict = the run reached a TERMINAL state: the whole batch verified, a

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -862,10 +862,15 @@ export function createScopedRunGuard({
       try {
         res = await origFetchApi(route, forwardOptions);
       } catch (err) {
-        // The request never reached ComfyUI, so this slot was NOT consumed —
-        // release it, or the retry that is still owed would be fenced out as an
-        // overrun. Only work that actually left counts against the quota.
+        // INDETERMINATE, not "never arrived" (codex gate r6). A fetch can throw
+        // after ComfyUI already received and queued the prompt — a reset while
+        // reading the response looks identical to one before the request left.
+        // Treating the throw as proof of non-arrival is this cluster's defect
+        // class exactly, and acting on it re-dispatches a branch that may
+        // already be rendering. So the slot stays CONSUMED and the outcome is
+        // recorded as unknown, which is what it is.
         state.inFlight--;
+        state.indeterminate++;
         if (state.failed == null) {
           state.failed = scopeDispatchError({
             toNodeId,
@@ -1158,7 +1163,8 @@ export async function dispatchScopedRun({
             outcome: "unverified",
             queueMark: mark,
             verified,
-            volatileInputs: volatileList,
+            indeterminate: guard.state.indeterminate,
+      volatileInputs: volatileList,
             error: scopeUnverifiedError({ toNodeId, timeoutMs: verifyTimeoutMs, cancelled: true, verified, batch }),
           };
         }
@@ -1167,7 +1173,8 @@ export async function dispatchScopedRun({
           outcome: "unverified",
           queueMark: mark,
           verified,
-          volatileInputs: volatileList,
+          indeterminate: guard.state.indeterminate,
+      volatileInputs: volatileList,
           error: scopeUnverifiedError({ toNodeId, timeoutMs: verifyTimeoutMs, cancelled: false, verified, batch }),
         };
       }
@@ -1239,7 +1246,8 @@ export async function dispatchScopedRun({
         outcome: "failed",
         queueMark: mark,
         verified: guard.state.observed,
-        volatileInputs: volatileList,
+        indeterminate: guard.state.indeterminate,
+      volatileInputs: volatileList,
         error: guard.state.failed +
           (keepGuardInstalled
             ? " The scope guard stays installed as a sentinel for the rest of this page session."
@@ -1256,7 +1264,8 @@ export async function dispatchScopedRun({
         verified: guard.state.observed,
         repaired: guard.state.repaired,
         scopeAppliedBy: guard.state.repaired > 0 ? "request_body_repair" : "frontend",
-        volatileInputs: volatileList,
+        indeterminate: guard.state.indeterminate,
+      volatileInputs: volatileList,
       };
     }
     // The FULL batch verified — genuinely dispatched (r5: never on a partial).
@@ -1280,7 +1289,8 @@ export async function dispatchScopedRun({
         // frontend produced one rather than be left to wonder at the queue.
         overrunBlocked: guard.state.overrun,
         overrunNote: guard.state.overrunError,
-        volatileInputs: volatileList,
+        indeterminate: guard.state.indeterminate,
+      volatileInputs: volatileList,
       };
     }
     // r7 CONTENT DRIFT with ZERO verified posts is NOT an argument-shape
@@ -1305,6 +1315,7 @@ export async function dispatchScopedRun({
       outcome: "refused",
       queueMark: mark,
       verified: guard.state.observed,
+      indeterminate: guard.state.indeterminate,
       volatileInputs: volatileList,
       error: scopePartialBatchError({
         toNodeId,

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -770,7 +770,7 @@ export function createScopedRunGuard({
 } = {}) {
   const expected = (execIds ?? []).map(String);
   const maxBatch = Math.max(1, Math.floor(Number(batch)) || 1);
-  const state = { observed: 0, repaired: 0, rejected: 0, refused: 0, overrun: 0, overrunError: null, inFlight: 0, indeterminate: 0, dropped: null, droppedReason: null, failed: null };
+  const state = { observed: 0, repaired: 0, rejected: 0, refused: 0, overrun: 0, overrunError: null, inFlight: 0, indeterminate: 0, closed: false, dropped: null, droppedReason: null, failed: null };
   const waiters = new Set();
   const notify = () => {
     for (const fire of [...waiters]) fire();
@@ -799,15 +799,24 @@ export function createScopedRunGuard({
     // `rejected` (ComfyUI said no — that prompt is spent). A `failed` post never
     // reached ComfyUI, so a later post of the same batch is legitimately still
     // owed and must not be fenced out.
-    if (state.observed + state.rejected + state.indeterminate + state.inFlight >= maxBatch) {
+    // CLOSED (codex gate r5): the orchestration has already RETURNED and told
+    // the caller what happened. The report is itself a fence — a post that
+    // dispatches after it contradicts what the caller was told, and a caller
+    // instructed to "re-run only the remaining N" would then get those N twice.
+    // So a closed guard refuses every attributed post, whatever the quota says.
+    if (state.closed || state.observed + state.rejected + state.indeterminate + state.inFlight >= maxBatch) {
       state.overrun++;
       if (state.overrunError == null) {
-        state.overrunError =
-          `run-to-node scope for node ${toNodeId}: an EXTRA /prompt post carrying this ` +
-          `run's identity arrived after all ${maxBatch} requested prompt(s) were already ` +
-          `accounted for. It was refused rather than dispatched — queueing it would have ` +
-          `executed the requested branch more times than asked, at real GPU/API cost. ` +
-          `The requested prompts are queued and unaffected (#556).`;
+        state.overrunError = state.closed
+          ? `run-to-node scope for node ${toNodeId}: a /prompt post carrying this run's ` +
+            `identity arrived AFTER the run's outcome had already been reported. It was ` +
+            `refused rather than dispatched — executing it would contradict the result the ` +
+            `caller was given, and could double-render the branch alongside their retry (#556).`
+          : `run-to-node scope for node ${toNodeId}: an EXTRA /prompt post carrying this ` +
+            `run's identity arrived after all ${maxBatch} requested prompt(s) were already ` +
+            `accounted for. It was refused rather than dispatched — queueing it would have ` +
+            `executed the requested branch more times than asked, at real GPU/API cost. ` +
+            `The requested prompts are queued and unaffected (#556).`;
       }
       notify();
       return SCOPE_DROPPED_RESPONSE();
@@ -962,6 +971,11 @@ export function createScopedRunGuard({
     return SCOPE_DROPPED_RESPONSE();
   };
   guard.state = state;
+  // Called by the orchestration when it RETURNS: from here on this run has an
+  // answer, and no further post of it may execute.
+  guard.close = () => {
+    state.closed = true;
+  };
   // Verdict = the run reached a TERMINAL state: the whole batch verified, a
   // genuine server rejection arrived, a dispatch failure occurred (r6), or a
   // corrupted post ended the attempt (the frontend's batch loop breaks on the
@@ -1100,7 +1114,10 @@ export async function dispatchScopedRun({
     // non-extensible array — cancellation will report 0 and the sentinel covers it.
   }
   let dropped = null;
-  for (const { arg: scopeArg, repair } of queuePromptScopeAttempts(execIds)) {
+  const attempts = queuePromptScopeAttempts(execIds);
+  for (let attemptIndex = 0; attemptIndex < attempts.length; attemptIndex++) {
+    const { arg: scopeArg, repair } = attempts[attemptIndex];
+    const isLastAttempt = attemptIndex === attempts.length - 1;
     dropped = null;
     let keepGuardInstalled = false;
     const guard = createScopedRunGuard({
@@ -1185,11 +1202,35 @@ export async function dispatchScopedRun({
       // and chaining is already the documented behaviour for the other terminal
       // paths — a real but small price for the guarantee that no late post of a
       // finished run can run the full graph.
-      if (guard.state.observed >= batch || guard.state.rejected > 0) {
-        keepGuardInstalled = true;
-      }
+      // EVERY TERMINAL OUTCOME IS A SENTINEL CASE (codex gate r5, P0). Success
+      // was not the only path that restored fetchApi and reopened the hole:
+      //  - a TERMINAL PARTIAL batch (one post repaired and queued, a later one
+      //    refused for drift/mismatch) restored it too;
+      //  - so did a graph_changed refusal;
+      //  - and so did the LAST attempt's all-refused return, after the loop.
+      // In each case a late same-mark scopeless post then bypassed both the
+      // quota fence and the repair and reached ComfyUI as a full graph.
+      //
+      // The only attempt that may safely restore is one that is about to hand
+      // over to ANOTHER attempt of this same run (the shape retry), because
+      // that attempt immediately installs its own guard on the same mark. So
+      // the rule is: restore ONLY when we are continuing. `continuing` is
+      // exactly the post-loop `observed === 0 && droppedReason !== "graph_changed"`
+      // condition, computed HERE so this finally can honor it.
+      //
+      // Note this also bounds the chaining: within a run each attempt
+      // overwrites the previous attempt's guard, so at most ONE guard per run
+      // ever persists.
+      const continuing =
+        !isLastAttempt &&
+        guard.state.failed == null &&
+        guard.state.rejected === 0 &&
+        guard.state.observed === 0 &&
+        guard.state.droppedReason !== "graph_changed";
+      if (!continuing) keepGuardInstalled = true;
     } finally {
-      if (!keepGuardInstalled) apiTarget.fetchApi = prevFetchApi;
+      if (keepGuardInstalled) guard.close();
+      else apiTarget.fetchApi = prevFetchApi;
     }
     // r6: the dispatch itself failed (fetch threw / malformed response) —
     // terminal, truthful, NEVER queued:true.

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -332,7 +332,13 @@ function readScopeFromBody(bodyText) {
     return { state: "body_unreadable", targets: null, bodyKeys, raw: undefined };
   }
   const t = body.partial_execution_targets;
-  if (t === undefined || t === null) return { state: "absent", targets: null, bodyKeys, raw: t };
+  // "absent" means the key is genuinely not there. JSON cannot encode
+  // `undefined`, so after a parse `undefined` is exactly "no such key". An
+  // explicit `null` is a key that IS present carrying an unusable value —
+  // reporting that as "no partial_execution_targets key at all" would
+  // contradict the body keys printed alongside it, and would be this module's
+  // own defect class (an observation collapsed into a definite negative).
+  if (t === undefined) return { state: "absent", targets: null, bodyKeys, raw: t };
   if (!Array.isArray(t)) return { state: "not_a_list", targets: null, bodyKeys, raw: t };
   if (!t.length) return { state: "empty", targets: null, bodyKeys, raw: t };
   return { state: "present", targets: t.map(String), bodyKeys, raw: t };

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -581,7 +581,7 @@ export function scopeUnattributableError({ toNodeId }) {
  *    verified prompts DID queue (scoped); only the unverified remainder is
  *    in doubt.
  */
-export function scopeUnverifiedError({ toNodeId, timeoutMs, cancelled = false, verified = 0, batch = 1 }) {
+export function scopeUnverifiedError({ toNodeId, timeoutMs, cancelled = false, verified = 0, batch = 1, inFlight = 0 }) {
   const count =
     verified > 0
       ? ` (${verified} of ${batch} batch prompts WERE verified and are queued with the scope)`
@@ -590,13 +590,29 @@ export function scopeUnverifiedError({ toNodeId, timeoutMs, cancelled = false, v
     `run-to-node scope for node ${toNodeId} could not be verified: no scoped ` +
     `dispatch was observed within ${Math.round(timeoutMs / 1000)}s of queueing ` +
     `(the frontend deferred or silently dropped the request)${count}. `;
+  // IN FLIGHT ≠ NEVER SENT (codex gate r9). A correctly-scoped request that has
+  // already left the panel but whose response has not come back yet is neither
+  // verified nor absent — it may be accepted a moment from now. Saying "nothing
+  // was queued" about it is a definite negative we cannot observe, and the
+  // caller acting on it re-renders a branch that is already running.
+  const inFlightNote =
+    inFlight > 0
+      ? `${inFlight} correctly-scoped request(s) had ALREADY LEFT the panel and were ` +
+        `still awaiting a response when the wait expired — those may yet be accepted by ` +
+        `ComfyUI, so this is NOT a report that nothing was queued. Check the ComfyUI ` +
+        `queue before retrying. `
+      : "";
   if (cancelled) {
     return (
       base +
+      inFlightNote +
       `The still-pending queue item was located and REMOVED, so nothing ` +
-      `${verified > 0 ? "more " : ""}was queued and no scope-dropped full-graph dispatch can execute — retry the run (#556).`
+      `${verified > 0 || inFlight > 0 ? "more " : ""}was queued from the pending item and no ` +
+      `scope-dropped full-graph dispatch can execute` +
+      (inFlight > 0 ? ` (#556).` : ` — retry the run (#556).`)
     );
   }
+  if (inFlightNote) return base + inFlightNote + `The scope guard stays installed as a sentinel (#556).`;
   return (
     base +
     `The pending queue item could not be removed on this frontend, so the scope ` +
@@ -1243,6 +1259,14 @@ export async function dispatchScopedRun({
         // we could not. So the sentinel stays either way; the cancel result
         // only changes what we can honestly CLAIM about what was queued.
         const verified = guard.state.observed;
+        // STILL IN FLIGHT is its own state (codex gate r9). A busy frontend can
+        // fire-and-forget a correctly-scoped POST and return; if the server has
+        // not answered by the time the wait expires, that request HAS left the
+        // panel and may still be accepted. Reporting the run as "nothing
+        // queued" then is a definite negative about something unobserved, and a
+        // caller acting on it re-renders a branch that is already running. It is
+        // surfaced so graph_run can omit `queued` rather than assert it false.
+        const inFlight = guard.state.inFlight;
         const cancel = cancelPendingScopedQueueItem(app, { runTag, queueMark: mark });
         if (cancel.removed > 0) {
           return {
@@ -1250,8 +1274,9 @@ export async function dispatchScopedRun({
             queueMark: mark,
             verified,
             indeterminate: guard.state.indeterminate,
+            inFlight,
             volatileInputs: volatileList,
-            error: scopeUnverifiedError({ toNodeId, timeoutMs: verifyTimeoutMs, cancelled: true, verified, batch }),
+            error: scopeUnverifiedError({ toNodeId, timeoutMs: verifyTimeoutMs, cancelled: true, verified, batch, inFlight }),
           };
         }
         return {
@@ -1259,8 +1284,9 @@ export async function dispatchScopedRun({
           queueMark: mark,
           verified,
           indeterminate: guard.state.indeterminate,
-      volatileInputs: volatileList,
-          error: scopeUnverifiedError({ toNodeId, timeoutMs: verifyTimeoutMs, cancelled: false, verified, batch }),
+          inFlight,
+          volatileInputs: volatileList,
+          error: scopeUnverifiedError({ toNodeId, timeoutMs: verifyTimeoutMs, cancelled: false, verified, batch, inFlight }),
         };
       }
       // r6: a dispatch FAILURE with the batch not fully accounted — the

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -770,7 +770,7 @@ export function createScopedRunGuard({
 } = {}) {
   const expected = (execIds ?? []).map(String);
   const maxBatch = Math.max(1, Math.floor(Number(batch)) || 1);
-  const state = { observed: 0, repaired: 0, rejected: 0, refused: 0, dropped: null, droppedReason: null, failed: null };
+  const state = { observed: 0, repaired: 0, rejected: 0, refused: 0, overrun: 0, overrunError: null, dropped: null, droppedReason: null, failed: null };
   const waiters = new Set();
   const notify = () => {
     for (const fire of [...waiters]) fire();
@@ -783,6 +783,34 @@ export function createScopedRunGuard({
     // the SAME targets, safe from our refusals and our capture.
     if (bodyQueueMark(options?.body) !== queueMark) {
       return origFetchApi(route, options);
+    }
+    // BATCH QUOTA (codex gate r3). This run asked for `maxBatch` prompts. An
+    // attributed post BEYOND that is work nobody requested — the requested
+    // branch executed again, at real GPU/API cost, while graph_run still
+    // reports batch_count as what was asked for. The old batch bound was purely
+    // OBSERVATIONAL: it stopped the orchestration waiting, but never stopped a
+    // post leaving. That was already true for a natively-scoped duplicate, and
+    // the repair would have widened it — turning a duplicate that used to be
+    // refused (its scope was dropped) into one that dispatches. So the bound is
+    // now a FENCE on dispatch, checked before the repair and before any
+    // forwarding.
+    //
+    // Only completed work counts toward the quota: `observed` (queued) and
+    // `rejected` (ComfyUI said no — that prompt is spent). A `failed` post never
+    // reached ComfyUI, so a later post of the same batch is legitimately still
+    // owed and must not be fenced out.
+    if (state.observed + state.rejected >= maxBatch) {
+      state.overrun++;
+      if (state.overrunError == null) {
+        state.overrunError =
+          `run-to-node scope for node ${toNodeId}: an EXTRA /prompt post carrying this ` +
+          `run's identity arrived after all ${maxBatch} requested prompt(s) were already ` +
+          `accounted for. It was refused rather than dispatched — queueing it would have ` +
+          `executed the requested branch more times than asked, at real GPU/API cost. ` +
+          `The requested prompts are queued and unaffected (#556).`;
+      }
+      notify();
+      return SCOPE_DROPPED_RESPONSE();
     }
     const scopeRead = readScopeFromBody(options?.body);
     let targets = scopeRead.targets;
@@ -1161,6 +1189,12 @@ export async function dispatchScopedRun({
         // ran with isPartialExecution=false. graph_run states this in the
         // result rather than letting the caller infer a native scoped run.
         scopeAppliedBy: guard.state.repaired > 0 ? "request_body_repair" : "frontend",
+        // DISCLOSE a fenced overrun (r3). The requested prompts DID queue, so
+        // this is not a failure and must not be reported as one — but an extra
+        // identical-identity post was blocked, and the caller should know their
+        // frontend produced one rather than be left to wonder at the queue.
+        overrunBlocked: guard.state.overrun,
+        overrunNote: guard.state.overrunError,
         volatileInputs: volatileList,
       };
     }

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -652,13 +652,28 @@ function isPromptPost(route, options) {
  * was malformed (no parseable prompt_id, no rejection body). That post is NOT
  * verified and NOT a server rejection — the run must never report queued:true
  * for it. Names what failed and how much of the batch was confirmed first.
+ *
+ * DISCLOSURE, NOT A DENIAL (codex gate r7, P0-4). This message used to end
+ * "this prompt did not reach ComfyUI" — a definite negative the panel cannot
+ * observe, and one that now contradicts the module's own handling: a thrown
+ * fetch is recorded as INDETERMINATE precisely because the throw can happen
+ * AFTER ComfyUI received and queued the prompt (a reset while reading the
+ * response is indistinguishable from one before the request left). Telling the
+ * caller it did not run makes them do the reasonable thing — resubmit — and
+ * pay twice in GPU time or API credits for a render that may already be
+ * running. Refuse vs disclose: once the request may have left, the only honest
+ * answer is what is known and what is not, plus where to look.
  */
 export function scopeDispatchError({ toNodeId, detail, verified, batch }) {
   return (
     `run-to-node scope for node ${toNodeId}: a verified-scoped /prompt request ` +
     `FAILED to complete — ${detail}. ${verified} of ${batch} batch prompts were ` +
-    `confirmed queued before the failure. The run is NOT reported as queued: ` +
-    `this prompt did not reach ComfyUI, and no full-graph dispatch occurred (#556).`
+    `confirmed queued before the failure. This one is NOT confirmed queued — but ` +
+    `it had already left the panel, so whether ComfyUI accepted it CANNOT be ` +
+    `determined from here: it may be queued or running right now. Check the ` +
+    `ComfyUI queue before resubmitting, or a retry may render the branch twice. ` +
+    `What IS certain: the request carried the run-to-node scope, so no full-graph ` +
+    `dispatch occurred (#556).`
   );
 }
 
@@ -836,7 +851,16 @@ export function createScopedRunGuard({
       repairScope &&
       contentOk &&
       !targets &&
-      (scopeRead.state === "absent" || scopeRead.state === "empty" || scopeRead.state === "not_a_list")
+      // ONLY a genuinely ABSENT key (codex gate r7, P0-1). Previously `empty`
+      // and `not_a_list` were repaired too, which broke this module's own rule
+      // that a scope we did not put there is never overwritten. `[]`, `null`,
+      // `"14"`, and especially `{ queueNodeIds: [...] }` are PRESENT values in
+      // a shape we did not expect — the last looks like another layer's scope
+      // convention, not an absence. Absence is ours to fill; a present value we
+      // cannot interpret is someone else's data, and rewriting it would be
+      // executing our intent over a request that said something different.
+      // Those states now fall through to the refusal, which names what it saw.
+      scopeRead.state === "absent"
     ) {
       const repairedBody = repairScopeInBody(options?.body, expected);
       if (repairedBody != null) {
@@ -1124,7 +1148,20 @@ export async function dispatchScopedRun({
     const { arg: scopeArg, repair } = attempts[attemptIndex];
     const isLastAttempt = attemptIndex === attempts.length - 1;
     dropped = null;
-    let keepGuardInstalled = false;
+    // DEFAULT TO KEEPING THE FENCE (codex gate r7, P0-2). This used to start
+    // false, so any exit that did not reach the terminal-path logic — most
+    // importantly `app.queuePrompt` THROWING partway through, after it had
+    // already emitted a scoped post — unwound through the `finally` and
+    // RESTORED raw fetchApi. A deferred duplicate carrying this run's mark
+    // could then post with no scope and run the full graph.
+    //
+    // The ordering rule, in its teardown direction: a fence must not be
+    // removed before something has decided it is no longer needed. The
+    // `finally` always runs; the decision may never. So the decision is now
+    // the one that has to fire — `continuing` is set explicitly on the only
+    // exit that is safe to restore on (handing over to another attempt of this
+    // same run, which installs its own guard on the same mark immediately).
+    let keepGuardInstalled = true;
     const guard = createScopedRunGuard({
       origFetchApi,
       execIds,
@@ -1156,6 +1193,16 @@ export async function dispatchScopedRun({
         // expiry timer (r4): the uncancellable item can post whenever the
         // stalled processor resumes, so the refusal must not go away. Safe by
         // construction: the sentinel only ever acts on THIS run's unique mark.
+        //
+        // P0-3 (codex gate r7): a successful cancel is NOT grounds to tear the
+        // fence down. `removed > 0` proves only that tagged entries STILL IN
+        // app.queueItems were spliced. It says nothing about an item the
+        // frontend has already copied, popped, or scheduled — and if such a
+        // same-mark item exists alongside one that was still removable,
+        // restoring raw fetchApi lets that copy post scopeless later. Positive
+        // evidence about the items we COULD see is not evidence about the ones
+        // we could not. So the sentinel stays either way; the cancel result
+        // only changes what we can honestly CLAIM about what was queued.
         const verified = guard.state.observed;
         const cancel = cancelPendingScopedQueueItem(app, { runTag, queueMark: mark });
         if (cancel.removed > 0) {
@@ -1164,11 +1211,10 @@ export async function dispatchScopedRun({
             queueMark: mark,
             verified,
             indeterminate: guard.state.indeterminate,
-      volatileInputs: volatileList,
+            volatileInputs: volatileList,
             error: scopeUnverifiedError({ toNodeId, timeoutMs: verifyTimeoutMs, cancelled: true, verified, batch }),
           };
         }
-        keepGuardInstalled = true;
         return {
           outcome: "unverified",
           queueMark: mark,
@@ -1234,7 +1280,11 @@ export async function dispatchScopedRun({
         guard.state.rejected === 0 &&
         guard.state.observed === 0 &&
         guard.state.droppedReason !== "graph_changed";
-      if (!continuing) keepGuardInstalled = true;
+      // The ONLY place the fence may be torn down. Reached only when
+      // app.queuePrompt returned normally AND this attempt is handing over to
+      // another attempt of the same run; a throw skips this line entirely and
+      // the fence stays up (P0-2).
+      keepGuardInstalled = !continuing;
     } finally {
       if (keepGuardInstalled) guard.close();
       else apiTarget.fetchApi = prevFetchApi;

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -118,6 +118,35 @@ export function queuePromptScopeArgs(partialTargets) {
   return [partialTargets, { queueNodeIds: partialTargets }];
 }
 
+/**
+ * The ordered DELIVERY ATTEMPTS for a run-to-node scope. The first two hand the
+ * scope to `app.queuePrompt` in each of its two documented third-argument
+ * shapes. The LAST one hands over the positional array again but also licenses
+ * the guard to write `partial_execution_targets` straight into this run's own
+ * /prompt body (repairScopeInBody) if it still has not arrived.
+ *
+ * The final attempt exists because refusing is the SAFE outcome for #556, not
+ * the CORRECT one: the caller asked for a subset and is entitled to get it. The
+ * request body is the one interface every frontend build shares, so repairing
+ * it there honours the request on builds whose `app.queuePrompt` wrapper drops
+ * the argument for any reason — including reasons this panel cannot see. It is
+ * ordered LAST so a frontend that delivers the scope natively always wins, and
+ * the panel only reaches for the body when the supported routes have failed.
+ *
+ * @param {string[]|undefined} partialTargets
+ * @returns {{arg: string[]|{queueNodeIds:string[]}|undefined, repair: boolean}[]}
+ */
+export function queuePromptScopeAttempts(partialTargets) {
+  if (!Array.isArray(partialTargets) || !partialTargets.length) {
+    return [{ arg: undefined, repair: false }];
+  }
+  return [
+    { arg: partialTargets, repair: false },
+    { arg: { queueNodeIds: partialTargets }, repair: false },
+    { arg: partialTargets, repair: true },
+  ];
+}
+
 // Two-seed 32-bit FNV-1a, concatenated — change-detection hashing only (no
 // security requirement): stable across key order (canonicalized before
 // hashing) and cheap enough to run once at queue time + once per observed post.
@@ -268,17 +297,50 @@ function bodyQueueMark(bodyText) {
   return Number.isFinite(n) ? n : null;
 }
 
-/** The body's partial_execution_targets as strings, or null when absent/empty/unparseable. */
-function targetsFromBody(bodyText) {
+/**
+ * WHY a POST /prompt body carries no usable scope — the OBSERVATION, kept
+ * distinct instead of folded into one verdict.
+ *
+ * The previous single "scope_missing" verdict covered FOUR different states
+ * and its message asserted one specific cause for all of them ("this frontend
+ * build ignored the run-to-node argument"). That assertion is a BUCKET
+ * narrated as a CAUSE, and the evidence says it is usually the wrong cause:
+ * every ComfyUI_frontend build from 1.42 through 1.50 demonstrably accepts
+ * BOTH `app.queuePrompt` third-argument shapes (the positional
+ * `NodeExecutionId[]` natively on older builds, and on newer builds through an
+ * `Array.isArray(optionsOrQueueNodeIds)` normalisation into
+ * `{ queueNodeIds }`), and both funnel into `api.queuePrompt`'s
+ * `options.partialExecutionTargets` → `body.partial_execution_targets`. Three
+ * separate field reports on #556 pasted that asserted cause verbatim into the
+ * tracker, which is precisely why the real cause is still unknown.
+ *
+ * So the states are now reported separately, the message states only what was
+ * OBSERVED, and the body's top-level keys ride along as evidence.
+ *
+ * @typedef {"present"|"absent"|"empty"|"not_a_list"|"body_unreadable"} ScopeReadState
+ * @returns {{state: ScopeReadState, targets: string[]|null, bodyKeys: string[]|null, raw: unknown}}
+ */
+function readScopeFromBody(bodyText) {
   let body;
   try {
     body = JSON.parse(bodyText);
   } catch {
-    return null;
+    return { state: "body_unreadable", targets: null, bodyKeys: null, raw: undefined };
   }
-  const t = body?.partial_execution_targets;
-  if (!Array.isArray(t) || !t.length) return null;
-  return t.map(String);
+  const bodyKeys = body && typeof body === "object" ? Object.keys(body).sort() : null;
+  if (!body || typeof body !== "object") {
+    return { state: "body_unreadable", targets: null, bodyKeys, raw: undefined };
+  }
+  const t = body.partial_execution_targets;
+  if (t === undefined || t === null) return { state: "absent", targets: null, bodyKeys, raw: t };
+  if (!Array.isArray(t)) return { state: "not_a_list", targets: null, bodyKeys, raw: t };
+  if (!t.length) return { state: "empty", targets: null, bodyKeys, raw: t };
+  return { state: "present", targets: t.map(String), bodyKeys, raw: t };
+}
+
+/** The body's partial_execution_targets as strings, or null when absent/empty/not-a-list/unparseable. */
+function targetsFromBody(bodyText) {
+  return readScopeFromBody(bodyText).targets;
 }
 
 function sameSet(a, b) {
@@ -306,28 +368,118 @@ export function verifyScopedPromptBody(bodyText, expectedExecIds) {
 }
 
 /**
+ * REPAIR the scope into a POST /prompt body we have already ATTRIBUTED to this
+ * run (its unique queue mark AND its content hash both match), when the body
+ * reached the wire without a usable `partial_execution_targets`.
+ *
+ * This is what turns #556's outcome from "refuse and explain" into "honour the
+ * request". `partial_execution_targets` is a plain top-level key of the /prompt
+ * body — the one place every ComfyUI_frontend build must put the scope,
+ * whatever shape its `app.queuePrompt` wrapper takes — so writing it here works
+ * on any build, present or future, including one whose wrapper drops the
+ * argument entirely. The alternative at this point is NOT a full-graph run (the
+ * guard blocks that unconditionally); it is a refusal. So repair can only ever
+ * improve the outcome, and never widens what executes: the targets written are
+ * exactly the ones graph_run resolved.
+ *
+ * The repair is ITSELF an operation that can fail, so it verifies its own
+ * output: the rewritten text is re-parsed and re-checked, and anything short of
+ * a clean pass returns null so the caller refuses instead of forwarding an
+ * unverified body. `prompt` is untouched, so the content hash still matches.
+ *
+ * @param {string|undefined} bodyText
+ * @param {string[]} expectedExecIds
+ * @returns {string|null} the repaired body text, or null when repair is impossible
+ */
+export function repairScopeInBody(bodyText, expectedExecIds) {
+  const expected = (expectedExecIds ?? []).map(String);
+  if (!expected.length) return null;
+  let body;
+  try {
+    body = JSON.parse(bodyText);
+  } catch {
+    return null;
+  }
+  if (!body || typeof body !== "object" || Array.isArray(body)) return null;
+  let text;
+  try {
+    text = JSON.stringify({ ...body, partial_execution_targets: expected.slice() });
+  } catch {
+    return null;
+  }
+  // Re-read what we just produced: a repair that cannot be verified is not a
+  // repair. Never hand on a body we have not confirmed carries the scope.
+  if (!verifyScopedPromptBody(text, expected).ok) return null;
+  return text;
+}
+
+/**
+ * What was OBSERVED about the scope in our own dispatch — one clause per
+ * distinct state, asserting nothing beyond the observation. See
+ * readScopeFromBody for why these are no longer one bucket.
+ */
+function scopeObservation(verdict) {
+  switch (verdict?.reason) {
+    case "scope_mismatch":
+      return (
+        `the POST /prompt body carried partial_execution_targets ` +
+        `${JSON.stringify(verdict.got)} instead of ${JSON.stringify(verdict.expected)}`
+      );
+    case "scope_not_a_list":
+      return (
+        `the POST /prompt body's partial_execution_targets was not a list ` +
+        `(${JSON.stringify(verdict.raw)}) — the requested scope did not survive ` +
+        `the trip through app.queuePrompt in a usable shape`
+      );
+    case "scope_empty":
+      return `the POST /prompt body carried an EMPTY partial_execution_targets list`;
+    case "body_unreadable":
+      return `the POST /prompt body could not be parsed, so the scope could not be read from it`;
+    default:
+      return (
+        `the POST /prompt body carried no partial_execution_targets key at all` +
+        (verdict?.bodyKeys?.length ? ` (body keys: ${verdict.bodyKeys.join(", ")})` : "")
+      );
+  }
+}
+
+/**
  * The truthful refusal message when our own dispatch surfaced WITHOUT the
  * scope. Names the node that couldn't be scoped and states plainly that
  * NOTHING was queued — never a false `queued:true`/`ran_to_node` for what
  * would have been a full-graph run.
+ *
+ * It reports the OBSERVATION and, where the cause is not observable from here,
+ * enumerates the candidates rather than asserting whichever one it happened to
+ * name. It also gives a remedy that works from where the caller is standing:
+ * the scope is what could not be delivered, so the run that CAN still be made
+ * is the unscoped one — stated as a choice with its cost, never taken silently.
  */
 export function scopeDroppedError({ toNodeId, verdict }) {
-  const detail =
-    verdict?.reason === "graph_changed"
-      ? `the workflow graph CHANGED after the run was queued — the deferred ` +
-        `dispatch would render a modified workflow, not the one that was scoped. ` +
-        `Retrying is safe (nothing was queued); if this recurs without any edit in ` +
-        `between, a queue-time widget hook is mutating values between serialization ` +
-        `and dispatch (e.g. a control_after_generate widget with WidgetControlMode ` +
-        `"before" — switch it to "after" or fix the target widget's value)`
-      : verdict?.reason === "scope_mismatch"
-        ? `the POST /prompt body carried partial_execution_targets ` +
-          `${JSON.stringify(verdict.got)} instead of ${JSON.stringify(verdict.expected)}`
-        : `the POST /prompt body carried no partial_execution_targets — this ` +
-          `frontend build ignored the run-to-node argument`;
+  if (verdict?.reason === "graph_changed") {
+    return (
+      `run-to-node scope for node ${toNodeId} was NOT applied: the workflow graph ` +
+      `CHANGED after the run was queued — the deferred dispatch would render a ` +
+      `modified workflow, not the one that was scoped. Retrying is safe (nothing ` +
+      `was queued); if this recurs without any edit in between, a queue-time widget ` +
+      `hook is mutating values between serialization and dispatch (e.g. a ` +
+      `control_after_generate widget with WidgetControlMode "before" — switch it to ` +
+      `"after" or fix the target widget's value). ` +
+      `Nothing was queued — refusing to fall through to a full-graph execution (#556).`
+    );
+  }
   return (
-    `run-to-node scope for node ${toNodeId} was NOT applied: ${detail}. ` +
-    `Nothing was queued — refusing to fall through to a full-graph execution (#556).`
+    `run-to-node scope for node ${toNodeId} was NOT applied: ${scopeObservation(verdict)}. ` +
+    `Every delivery route was tried — the positional NodeExecutionId[] argument, the ` +
+    `QueuePromptOptions { queueNodeIds } argument, and writing partial_execution_targets ` +
+    `directly into this run's own /prompt body — and the scope still did not reach the ` +
+    `request, so the panel cannot say which layer dropped it from here. ` +
+    `Nothing was queued — refusing to fall through to a full-graph execution (#556). ` +
+    `To render this branch now, either run it unscoped (panel_run without to_node_id, ` +
+    `which executes the WHOLE graph — every other output branch included, at full GPU/API ` +
+    `cost) or delete/bypass the output nodes you do not want and run unscoped. ` +
+    `Please report this with the body keys above — this path is not reproducible against ` +
+    `ComfyUI_frontend 1.42–1.50, where both argument shapes are honoured.`
   );
 }
 
@@ -520,9 +672,19 @@ export function createRunFetchInterceptor({ origFetchApi, onRejection = null, on
  *                                   edit, or the deferred serialization
  *                                   picking up a modified graph): refused
  *                                   before it leaves, batch-bounded.
- * state = { observed, rejected, refused, dropped, droppedReason, failed } is
- * live; waitForVerdict(ms) resolves true at any terminal state, false on
- * timeout.
+ *
+ * REPAIR (`repairScope`, the final dispatch attempt): when the body is OURS
+ * (mark AND content hash both match) and carries no usable scope, the guard
+ * WRITES the resolved targets into the body and forwards it, instead of
+ * refusing — see repairScopeInBody. This is what lets #556 end in the
+ * PREFERRED outcome (the requested subset actually runs) rather than the
+ * merely-safe one (a refusal). It is never a widening: a scope MISMATCH — a
+ * body carrying targets we did not ask for — is never overwritten, and an
+ * unreadable body is never repaired; both still refuse.
+ *
+ * state = { observed, repaired, rejected, refused, dropped, droppedReason,
+ * failed } is live; waitForVerdict(ms) resolves true at any terminal state,
+ * false on timeout.
  */
 export function createScopedRunGuard({
   origFetchApi,
@@ -532,13 +694,14 @@ export function createScopedRunGuard({
   batch = 1,
   toNodeId = null,
   queueMark,
+  repairScope = false,
   onRejection = null,
   onPromptId = null,
   onScopeDropped = null,
 } = {}) {
   const expected = (execIds ?? []).map(String);
   const maxBatch = Math.max(1, Math.floor(Number(batch)) || 1);
-  const state = { observed: 0, rejected: 0, refused: 0, dropped: null, droppedReason: null, failed: null };
+  const state = { observed: 0, repaired: 0, rejected: 0, refused: 0, dropped: null, droppedReason: null, failed: null };
   const waiters = new Set();
   const notify = () => {
     for (const fire of [...waiters]) fire();
@@ -552,9 +715,30 @@ export function createScopedRunGuard({
     if (bodyQueueMark(options?.body) !== queueMark) {
       return origFetchApi(route, options);
     }
-    const targets = targetsFromBody(options?.body);
+    const scopeRead = readScopeFromBody(options?.body);
+    let targets = scopeRead.targets;
     const contentOk =
       contentHash && promptContentHashFromBody(options?.body, volatileInputs) === contentHash;
+    // SCOPE REPAIR — only for a body already attributed to THIS run (mark +
+    // content hash), only when no usable scope is present (absent / empty /
+    // not-a-list), and only on the attempt that asked for it. A body carrying
+    // DIFFERENT targets is a mismatch we do not understand and must not
+    // overwrite; an unparseable body cannot be repaired. Both fall through to
+    // the refusal below, exactly as before.
+    let forwardOptions = options;
+    if (
+      repairScope &&
+      contentOk &&
+      !targets &&
+      (scopeRead.state === "absent" || scopeRead.state === "empty" || scopeRead.state === "not_a_list")
+    ) {
+      const repairedBody = repairScopeInBody(options?.body, expected);
+      if (repairedBody != null) {
+        forwardOptions = { ...options, body: repairedBody };
+        targets = expected.slice();
+        state.repaired++;
+      }
+    }
     if (contentOk && targets && sameSet(targets, expected)) {
       // OUR scoped dispatch. It counts as VERIFIED only when the fetch itself
       // completes with a real 200 + prompt_id (r6) — a thrown fetch or a
@@ -562,7 +746,7 @@ export function createScopedRunGuard({
       // a genuine server rejection flows through the established #358 channel.
       let res;
       try {
-        res = await origFetchApi(route, options);
+        res = await origFetchApi(route, forwardOptions);
       } catch (err) {
         if (state.failed == null) {
           state.failed = scopeDispatchError({
@@ -597,11 +781,28 @@ export function createScopedRunGuard({
     if (state.refused < maxBatch) {
       state.refused++;
       if (state.dropped == null) {
+        // Report the OBSERVATION, not a bucket: which of the distinct
+        // no-usable-scope states actually occurred (readScopeFromBody), with
+        // the body's top-level keys as evidence for the next report.
         const verdict = !contentOk
           ? { ok: false, reason: "graph_changed" }
           : targets
             ? { ok: false, reason: "scope_mismatch", expected, got: targets }
-            : { ok: false, reason: "scope_missing", expected, got: null };
+            : {
+                ok: false,
+                reason:
+                  scopeRead.state === "not_a_list"
+                    ? "scope_not_a_list"
+                    : scopeRead.state === "empty"
+                      ? "scope_empty"
+                      : scopeRead.state === "body_unreadable"
+                        ? "body_unreadable"
+                        : "scope_missing",
+                expected,
+                got: null,
+                raw: scopeRead.raw,
+                bodyKeys: scopeRead.bodyKeys,
+              };
         state.droppedReason = verdict.reason;
         state.dropped = scopeDroppedError({ toNodeId, verdict });
         onScopeDropped?.(state.dropped);
@@ -752,7 +953,7 @@ export async function dispatchScopedRun({
     // non-extensible array — cancellation will report 0 and the sentinel covers it.
   }
   let dropped = null;
-  for (const scopeArg of queuePromptScopeArgs(execIds)) {
+  for (const { arg: scopeArg, repair } of queuePromptScopeAttempts(execIds)) {
     dropped = null;
     let keepGuardInstalled = false;
     const guard = createScopedRunGuard({
@@ -763,6 +964,7 @@ export async function dispatchScopedRun({
       batch,
       toNodeId,
       queueMark: mark,
+      repairScope: repair,
       onRejection,
       onPromptId,
     });
@@ -837,11 +1039,32 @@ export async function dispatchScopedRun({
     // established rejection channel — the run "dispatched" and ComfyUI said
     // no; graph_run's summarizePromptRejection surfaces it, never queued:true.
     if (guard.state.rejected > 0) {
-      return { outcome: "dispatched", queueMark: mark, verified: guard.state.observed, volatileInputs: volatileList };
+      return {
+        outcome: "dispatched",
+        queueMark: mark,
+        verified: guard.state.observed,
+        repaired: guard.state.repaired,
+        scopeAppliedBy: guard.state.repaired > 0 ? "request_body_repair" : "frontend",
+        volatileInputs: volatileList,
+      };
     }
     // The FULL batch verified — genuinely dispatched (r5: never on a partial).
     if (guard.state.observed >= batch) {
-      return { outcome: "dispatched", queueMark: mark, verified: guard.state.observed, volatileInputs: volatileList };
+      return {
+        outcome: "dispatched",
+        queueMark: mark,
+        verified: guard.state.observed,
+        repaired: guard.state.repaired,
+        // DISCLOSURE, not a footnote: on this path the scope reached ComfyUI
+        // because the panel wrote it into the request body, NOT because the
+        // frontend delivered it. The run IS correctly scoped (the guard
+        // re-verified the repaired body before it left), but the frontend
+        // believed it was queueing a full run — so its queue-time widget hooks
+        // ran with isPartialExecution=false. graph_run states this in the
+        // result rather than letting the caller infer a native scoped run.
+        scopeAppliedBy: guard.state.repaired > 0 ? "request_body_repair" : "frontend",
+        volatileInputs: volatileList,
+      };
     }
     // r7 CONTENT DRIFT with ZERO verified posts is NOT an argument-shape
     // problem — retrying the other shape would produce the same drifted post.

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -1144,6 +1144,29 @@ export async function dispatchScopedRun({
       ) {
         keepGuardInstalled = true;
       }
+      // SUCCESS IS ALSO A SENTINEL CASE (codex gate r4). Completing the batch
+      // used to RESTORE fetchApi — which uninstalled the quota fence, so a LATE
+      // same-mark post (a deferred duplicate the processor emits after
+      // queuePrompt returned) bypassed the guard entirely. On a build that
+      // drops the scope that post goes out UNSCOPED: the full-graph execution
+      // this whole module exists to prevent, arriving after we already reported
+      // success. Verdict-reached is not the same as no-more-traffic.
+      //
+      // So a completed scoped run keeps its guard installed for the page
+      // session, exactly as the timeout and dispatch-failure paths already do,
+      // and on the same by-construction safety argument: the guard only ever
+      // acts on THIS run's unique mark, which no future run, user action, or UI
+      // will ever carry, so every other post passes through untouched forever.
+      //
+      // COST, stated rather than hidden: this makes the sentinel the common
+      // case rather than the exception, so a long session chains one wrapper
+      // per scoped run. Each is a single number comparison before delegating,
+      // and chaining is already the documented behaviour for the other terminal
+      // paths — a real but small price for the guarantee that no late post of a
+      // finished run can run the full graph.
+      if (guard.state.observed >= batch || guard.state.rejected > 0) {
+        keepGuardInstalled = true;
+      }
     } finally {
       if (!keepGuardInstalled) apiTarget.fetchApi = prevFetchApi;
     }

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -785,13 +785,19 @@ export function createScopedRunGuard({
 } = {}) {
   const expected = (execIds ?? []).map(String);
   const maxBatch = Math.max(1, Math.floor(Number(batch)) || 1);
-  const state = { observed: 0, repaired: 0, rejected: 0, refused: 0, overrun: 0, overrunError: null, inFlight: 0, indeterminate: 0, closed: false, dropped: null, droppedReason: null, failed: null };
+  const state = { observed: 0, repaired: 0, rejected: 0, refused: 0, overrun: 0, overrunError: null, inFlight: 0, indeterminate: 0, closed: false, retired: false, dropped: null, droppedReason: null, failed: null };
   const waiters = new Set();
   const notify = () => {
     for (const fire of [...waiters]) fire();
   };
 
   const guard = async (route, options) => {
+    // RETIRED (codex gate r8): this attempt has handed over to a LATER attempt
+    // of the same run, which is now installed above us in the chain and owns
+    // this mark. We must not also act on it — two live guards for one mark
+    // would double-count a forwarded post, or refuse our own successor's
+    // repaired body. Retired means fully transparent, forever.
+    if (state.retired) return origFetchApi(route, options);
     if (!isPromptPost(route, options)) return origFetchApi(route, options);
     // RUN IDENTITY FIRST: no mark ⇒ not ours ⇒ never touch it. This is what
     // keeps a user's full run of the SAME graph, or another scoped run with
@@ -1005,6 +1011,12 @@ export function createScopedRunGuard({
   guard.close = () => {
     state.closed = true;
   };
+  // Called when a LATER attempt of the SAME run takes over: this guard becomes
+  // permanently transparent instead of being unhooked, so the chain below it
+  // (which may include ANOTHER run's live sentinel) is never disturbed.
+  guard.retire = () => {
+    state.retired = true;
+  };
   // Verdict = the run reached a TERMINAL state: the whole batch verified, a
   // genuine server rejection arrived, a dispatch failure occurred (r6), or a
   // corrupted post ended the attempt (the frontend's batch loop breaks on the
@@ -1097,8 +1109,26 @@ export async function dispatchScopedRun({
   onPromptId = null,
 } = {}) {
   const mark = queueMark ?? newScopedQueueMark();
-  const prevFetchApi = typeof apiTarget?.fetchApi === "function" ? apiTarget.fetchApi : null;
-  const origFetchApi = prevFetchApi ? prevFetchApi.bind(apiTarget) : null;
+  // CHAIN COMPOSITION (codex gate r8). Both the entry-time capture below and
+  // the per-attempt restore used to be WRONG in the presence of a concurrent
+  // run:
+  //
+  //   A installs GA1 over raw fetch and waits for its deferred first attempt.
+  //   B starts, captures GA1 as its chain, succeeds, and retains GB as the
+  //   current sentinel. A's deferred post arrives scopeless, GA1 refuses it,
+  //   and A retries — whereupon A's `finally` restored A's ENTRY-TIME
+  //   fetchApi (raw), CLOBBERING GB, and A's next guard also delegated to A's
+  //   entry-time raw fetch, bypassing B entirely. A late B post then passed
+  //   through as foreign and reached raw fetch scopeless: full graph.
+  //
+  // Two rules fix it, and both are needed:
+  //   1. A guard delegates to whatever was CURRENT when it was installed, not
+  //      to what was current when the run began (captured per attempt below).
+  //   2. A superseded attempt is RETIRED — made permanently transparent — and
+  //      never unhooked. Nothing in this module writes apiTarget.fetchApi back
+  //      to an older value any more, so no run can displace another's guard.
+  const entryFetchApi = typeof apiTarget?.fetchApi === "function" ? apiTarget.fetchApi : null;
+  const origFetchApi = entryFetchApi ? entryFetchApi.bind(apiTarget) : null;
   if (!origFetchApi) {
     return {
       outcome: "unverifiable",
@@ -1158,12 +1188,20 @@ export async function dispatchScopedRun({
     // The ordering rule, in its teardown direction: a fence must not be
     // removed before something has decided it is no longer needed. The
     // `finally` always runs; the decision may never. So the decision is now
-    // the one that has to fire — `continuing` is set explicitly on the only
-    // exit that is safe to restore on (handing over to another attempt of this
-    // same run, which installs its own guard on the same mark immediately).
-    let keepGuardInstalled = true;
+    // the one that has to fire — `retireGuard` is set explicitly on the only
+    // exit where this attempt's guard may stand down (handing over to another
+    // attempt of this same run, which installs its own guard on the same mark
+    // immediately). Standing down means RETIRING (transparent), never
+    // unhooking: see the chain-composition note at the top of this function.
+    let retireGuard = false;
+    // The chain this guard delegates to is whatever is installed RIGHT NOW —
+    // which may be another run's live sentinel, or our own previous attempt.
+    // Capturing the run's entry-time fetchApi here instead would bypass a
+    // newer run's guard entirely (r8 P0).
+    const chainBelow =
+      typeof apiTarget.fetchApi === "function" ? apiTarget.fetchApi.bind(apiTarget) : origFetchApi;
     const guard = createScopedRunGuard({
-      origFetchApi,
+      origFetchApi: chainBelow,
       execIds,
       contentHash,
       volatileInputs,
@@ -1185,8 +1223,9 @@ export async function dispatchScopedRun({
         await guard.waitForVerdict(verifyTimeoutMs);
       }
       if (!guard.verdictReached()) {
-        // GIVE-UP — decided HERE, inside the try, so the finally below honors
-        // keepGuardInstalled. The deferred item may still be live in the
+        // GIVE-UP. The guard stays (that is now the default — the finally only
+        // ever stands it down when handing over to another attempt of this same
+        // run, which this is not). The deferred item may still be live in the
         // frontend's pending queue: try to REMOVE it (ownership tag AND this
         // run's mark both checked), and only when that's impossible keep the
         // surgical guard installed for the PAGE SESSION as a sentinel — NO
@@ -1229,12 +1268,6 @@ export async function dispatchScopedRun({
       // later posts of this batch can still come. Keep the guard installed as
       // a page-session sentinel so a later CORRUPTED post is still refused
       // (decided HERE so the finally below honors it).
-      if (
-        guard.state.failed != null &&
-        guard.state.observed + guard.state.rejected + guard.state.refused < batch
-      ) {
-        keepGuardInstalled = true;
-      }
       // SUCCESS IS ALSO A SENTINEL CASE (codex gate r4). Completing the batch
       // used to RESTORE fetchApi — which uninstalled the quota fence, so a LATE
       // same-mark post (a deferred duplicate the processor emits after
@@ -1284,10 +1317,12 @@ export async function dispatchScopedRun({
       // app.queuePrompt returned normally AND this attempt is handing over to
       // another attempt of the same run; a throw skips this line entirely and
       // the fence stays up (P0-2).
-      keepGuardInstalled = !continuing;
+      retireGuard = continuing;
     } finally {
-      if (keepGuardInstalled) guard.close();
-      else apiTarget.fetchApi = prevFetchApi;
+      // Stand down ONLY by retiring; never by writing apiTarget.fetchApi back
+      // to an older value, which would displace a concurrent run's guard (r8).
+      if (retireGuard) guard.retire();
+      else guard.close();
     }
     // r6: the dispatch itself failed (fetch threw / malformed response) —
     // terminal, truthful, NEVER queued:true.
@@ -1299,7 +1334,7 @@ export async function dispatchScopedRun({
         indeterminate: guard.state.indeterminate,
       volatileInputs: volatileList,
         error: guard.state.failed +
-          (keepGuardInstalled
+          (!retireGuard
             ? " The scope guard stays installed as a sentinel for the rest of this page session."
             : ""),
       };

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -770,7 +770,7 @@ export function createScopedRunGuard({
 } = {}) {
   const expected = (execIds ?? []).map(String);
   const maxBatch = Math.max(1, Math.floor(Number(batch)) || 1);
-  const state = { observed: 0, repaired: 0, rejected: 0, refused: 0, overrun: 0, overrunError: null, dropped: null, droppedReason: null, failed: null };
+  const state = { observed: 0, repaired: 0, rejected: 0, refused: 0, overrun: 0, overrunError: null, inFlight: 0, indeterminate: 0, dropped: null, droppedReason: null, failed: null };
   const waiters = new Set();
   const notify = () => {
     for (const fire of [...waiters]) fire();
@@ -799,7 +799,7 @@ export function createScopedRunGuard({
     // `rejected` (ComfyUI said no — that prompt is spent). A `failed` post never
     // reached ComfyUI, so a later post of the same batch is legitimately still
     // owed and must not be fenced out.
-    if (state.observed + state.rejected >= maxBatch) {
+    if (state.observed + state.rejected + state.indeterminate + state.inFlight >= maxBatch) {
       state.overrun++;
       if (state.overrunError == null) {
         state.overrunError =
@@ -841,10 +841,22 @@ export function createScopedRunGuard({
       // completes with a real 200 + prompt_id (r6) — a thrown fetch or a
       // malformed response is a terminal dispatch FAILURE, never a success;
       // a genuine server rejection flows through the established #358 channel.
+      //
+      // RESERVE THE QUOTA SLOT BEFORE FORWARDING (codex gate r4). Counting only
+      // COMPLETED requests left the fence racy: two same-mark posts issued
+      // concurrently both read observed=0, both passed the quota, and both were
+      // forwarded — executing the requested branch twice while reporting no
+      // overrun. The reservation is taken here, synchronously, before the await,
+      // so a second concurrent post sees the slot already taken.
+      state.inFlight++;
       let res;
       try {
         res = await origFetchApi(route, forwardOptions);
       } catch (err) {
+        // The request never reached ComfyUI, so this slot was NOT consumed —
+        // release it, or the retry that is still owed would be fenced out as an
+        // overrun. Only work that actually left counts against the quota.
+        state.inFlight--;
         if (state.failed == null) {
           state.failed = scopeDispatchError({
             toNodeId,
@@ -857,17 +869,26 @@ export function createScopedRunGuard({
         throw err; // the frontend sees exactly the failure it would have seen
       }
       const verdict = await classifyRunResponse(res, { onRejection, onPromptId });
+      // The request DID leave, so the reservation is now settled into a
+      // definite outcome. A malformed response keeps the slot consumed on
+      // purpose: the post reached ComfyUI and MAY have queued, and re-forwarding
+      // on that uncertainty is how a branch gets rendered twice. "Could not
+      // determine whether it queued" is not "determined it did not".
+      state.inFlight--;
       if (verdict === "accepted") {
         state.observed++;
       } else if (verdict === "rejected") {
         state.rejected++;
-      } else if (state.failed == null) {
-        state.failed = scopeDispatchError({
-          toNodeId,
-          detail: `the /prompt response was malformed (HTTP ${res?.status ?? "?"}, no prompt_id and no rejection body)`,
-          verified: state.observed,
-          batch: maxBatch,
-        });
+      } else {
+        state.indeterminate++;
+        if (state.failed == null) {
+          state.failed = scopeDispatchError({
+            toNodeId,
+            detail: `the /prompt response was malformed (HTTP ${res?.status ?? "?"}, no prompt_id and no rejection body)`,
+            verified: state.observed,
+            batch: maxBatch,
+          });
+        }
       }
       notify();
       return res;


### PR DESCRIPTION
## What this cluster turned out to be

Both issues were already partly fixed on `main` before this branch started. That
is the headline; the rest is what genuinely remained.

### #581 — not reproducible on `main`. No code needed.

Both halves are already merged and regression-tested:

- **The timeout itself** was PR **#594**. The command handler synchronously
  called `ChangeTracker.checkState()` — a full graph serialization — after the
  mutation and before constructing the reply, so the link landed but the
  acknowledgement missed the 6000 ms bridge window. It now captures the tracker
  that owned the completed edit and defers the snapshot, so the correlated reply
  goes out first. Verified in source (`deliverReply(...)` precedes
  `deferChangeTrackerSnapshot(...)`) and pinned by
  `change-tracker-snapshot.test.mjs`, which reads the real panel source and
  would fail if the two were ever swapped back.
- **The secondary defect the reporter hit while verifying** — after a soft
  reload, `panel_graph_outline` reporting 9 nodes while the canvas was bound to
  a different graph, with `panel_set_workflow_target({mode:"current"})` failing
  to recover — belongs to the wrong-graph family and was fixed by **#621**
  (shipped in 0.11.39). That change also names the remedy the reporter had to
  find empirically: a full page reload is the only thing that rebuilds the
  binding, and `open_workflow` cannot.

Checked specifically as *fixed* vs *hidden*: #594 is not a raised timeout. The
6000 ms fuse is unchanged; the work that overran it was moved off the reply path.

### #556 — the silent full-graph run is fixed. What remained was that the caller still got nothing.

The headline harm is gone and stays gone. But #559's remedy was to **refuse**,
and three field recurrences on 0.11.37/0.11.38 all end the same way: "no
`partial_execution_targets` in the POST /prompt body, safely refused, nothing
queued". Safe, and useless. Refusing is the *safe* outcome; running the
requested subset is the *correct* one.

## What this PR changes

### 1. `to_node_id` is honoured, not merely protected

A third and final delivery attempt. The first two are unchanged (the positional
`NodeExecutionId[]` argument, then `QueuePromptOptions { queueNodeIds }`). The
third hands over the array again and licenses the guard to write
`partial_execution_targets` directly into **this run's own** /prompt body.

The request body is the one interface every frontend build shares:
`app.queuePrompt`'s third-argument shape varies and can be dropped;
`api.queuePrompt`'s `options.partialExecutionTargets` can be dropped;
`body.partial_execution_targets` is what the server reads. Repairing it there
honours the request on any build — including one dropping the argument for a
reason the panel cannot see, which on the evidence is the situation.

It widens nothing:
- Gated on the run identity that governs every other guard action — this run's
  unique queue mark **and** the prompt content hash. A stranger's full run of the
  same graph passes through untouched, byte-identical, never narrowed.
- Writes exactly the targets `graph_run` resolved.
- A scope **mismatch** is never overwritten. A body carrying targets we did not
  ask for is something the panel does not understand; papering over it would be
  executing one thing while the body said another. Still refused.
- Content drift is never repaired into a dispatch.
- The repair verifies its own output — re-parses and re-checks what it wrote,
  returning null on anything short of a clean pass so the caller refuses rather
  than forwarding an unverified body.
- Ordered last, so a frontend that delivers the scope natively always wins.

And it is **disclosed**: `scope_applied_by: "request_body_repair"` with a note
separating what was observed (the request ComfyUI received names only the
requested node as an execution root) from what was not (whether the frontend
also treated it as partial internally — the panel sees the request body, not the
queue loop).

### 2. The refusal no longer asserts a cause it cannot see

The old message said, for every no-usable-scope state: *"this frontend build
ignored the run-to-node argument."* A bucket narrated as a cause — and the
evidence contradicts it. Reading the actual frontend sources (**1.42.15** as
shipped in the local install, plus **1.47.11** and **1.50.1** upstream),
`app.queuePrompt` accepts **both** third-argument shapes on all of them (older
builds take the positional array natively; newer normalise it via
`Array.isArray(optionsOrQueueNodeIds)`), and both funnel into
`api.queuePrompt`'s `options.partialExecutionTargets` →
`body.partial_execution_targets`.

All three #556 recurrences pasted that asserted cause into the tracker, which is
exactly why the real cause is still unknown. `readScopeFromBody` now separates
the states the single verdict covered — key absent, empty list,
present-but-not-a-list, body unparseable, body parsed but not a request object —
and each reads as itself, with the body's top-level keys as evidence and a
remedy that works from where the caller is standing (run unscoped, full-graph
cost stated plainly rather than taken on their behalf).

## Gate rounds

**Nine rounds, twenty findings, all real, all fixed** — six of my own, then an
independent NO-SHIP with four P0, then two more rounds run under the coordinator's
framing of *assume another unscoped path exists*. Each round after the first
found paths the previous had not.

The pattern, stated plainly: **the guard has to hold on every exit, and there are
a lot of exits.** Eleven distinct ways a /prompt post could have left without the
requested scope, or the branch run more times than asked:

- The guard's own error formatting could **throw**, escaping mid-decision with the
  refusal budget spent — and the next post took the exhausted-budget path and was
  **forwarded unscoped**.
- The batch bound **never stopped a post leaving**; it only stopped the wait.
- That fence **counted completed work**, so two concurrent posts raced past it.
- A **late post escaped after success**, after a **partial batch**, and after an
  **all-refused run**, because those paths restored `fetchApi`.
- **`app.queuePrompt` throwing** unwound through the `finally` before any decision
  ran, tearing the fence down.
- A **successful cancel** was treated as proof — it only proves that items *still
  visible in `queueItems`* were spliced.
- The **repair overwrote a present-but-unrecognised scope** (`[]`, `null`, `"14"`,
  `{queueNodeIds:[...]}`), breaking its own never-overwrite rule — and the test
  explicitly permitted it.
- A **retrying run clobbered a concurrent run's sentinel** and bypassed it, letting
  the *other* run's late post reach raw fetch unscoped.

And four instances of the same fold on the reporting side, each of which would
have driven a caller to duplicate a paid render: a partial batch reporting
`queued: false` for prompts executing on the GPU; a thrown fetch read as proof of
non-arrival; an indeterminate dispatch still asserting `queued: false`; and a
request **still in flight** at timeout reported as nothing-queued.

The structural fixes: the fence now **defaults to up** and stands down only on
the single exit that hands over to another attempt of the same run; standing down
means **retiring** (transparent), never unhooking, so no run can displace
another's guard; each guard delegates to whatever was **current when it was
installed**; and the guard is **closed when the orchestration returns**, because
the report is itself a fence — once the caller has been told what happened, no
further post may execute.

## Verification

- **Tests assert which nodes execute**, not that a run completed — a test checking
  only "dispatched" passes whether the subset or the whole graph ran.
- **21 mutants, each killed by its matching test.** **Five initially survived** and
  were chased rather than explained away: one mutant was malformed (left the
  `try/catch` intact); one test asserted a *message* rather than the *classifier*;
  one asserted both guidance strings existed rather than that the flag *selected*
  between them; one asserted a source slice that had run past the branch under
  test; and the chain-clobbering test did not actually produce the interleaving —
  A's deferred attempt never posted, so A never retried, so the displacing
  `finally` never ran. Each was rewritten until the mutant died.
- Full `browser_tests` unit suite **2131/2131**, `tsc --noEmit`, ESM check as
  `.mjs` (CJS `node --check` does not catch a duplicate top-level declaration),
  and the tool vocabulary gate — which earned its keep by rejecting the first name
  for the disclosure value, `panel_body_repair`, which reads to the model as a
  callable tool. Renamed rather than allowlisted.
- Committed blobs scanned for control bytes: zero, all files git-TEXT.
  `git diff --check` clean.
- Rebased onto current `main` (`99e67cd`). No change to `pyproject.toml` or
  `PANEL_VERSION`.

## Honest limits

- **The root cause of the three field reports is still unknown**, and this PR
  does not claim otherwise. It makes the outcome correct anyway (the scope is
  delivered regardless of which layer dropped it) and the next report
  diagnosable. I could not reproduce a dropped scope against frontend 1.42–1.50
  by reading their sources.
- **Only a live browser can confirm** the repair against a real frontend and a
  real ComfyUI: that the repaired request renders only the targeted branch, and
  what the frontend's queue-time widget hooks actually do on that path. The unit
  suite drives the real orchestration through mock frontends, not a live one.
- **A deliberate behaviour change with a stated cost**: the sentinel is now the
  common case rather than the exception, so a long session chains one wrapper per
  scoped run (at most one per run — later attempts overwrite earlier ones). Each
  is a single number comparison before delegating. Four existing tests asserted
  "fetchApi restored on success"; that assertion *was* the hole, and each now
  carries a note saying why it changed.
- **`body_unreadable` / `body_not_an_object` are unreachable from the guard's
  refusal path** — such a body cannot carry this run's mark, so it is foreign
  traffic and passes through. Stated in the source and pinned by a test rather
  than left as an unstated assumption.
- **The P1 depth trigger was not reproducible from the guard on this Node.**
  `JSON.stringify` does throw `RangeError` on a ~5000-deep value from a shallow
  stack here, but survived 150k levels inside the guard's async chain. The fence
  is correct and kept; the test pins the provable contract (never throws, any
  input) rather than pretending a stack limit is deterministic.
- **The round-9 fence enumeration found no remaining path** by which a marked
  request can reach raw fetch without passing a live guard's exact-scope check.
  That is an enumeration, not a proof, and the last four rounds each found
  something after the previous one looked complete. Assume a twelfth exit exists.

Closes #556
Closes #581
