### PR TITLE
group membership left behind by a move, plus the five-defect editing-session report

### DIFF
--- a/browser_tests/unit/group-geometry.test.mjs
+++ b/browser_tests/unit/group-geometry.test.mjs
@@ -259,19 +259,72 @@ test("refreshNodeArea supports a typed-array boundingRect (ComfyUI Rectangle)", 
 
 // ---- syncNodeArea collapse guard + syncGraphNodeAreas: bounds-create live geometry (#416) ----
 
-test("syncNodeArea leaves an UNREQUESTED collapsed node's cached rect untouched (#416)", () => {
-  // A collapsed node's real footprint is a small title pill; overwriting it with
-  // the full pos/size footprint would overstate its area and risk pulling it into
-  // a nearby group box on a bulk (sync-all) bounds/query read. Default = skip it.
+test("syncNodeArea gives an UNREQUESTED collapsed node its PILL footprint, never the full box (#416)", () => {
+  // #416's guarantee is that a collapsed node's area is never OVERSTATED: its real
+  // footprint is a small title pill, and writing the full pos/size box could pull
+  // it into a nearby group on a bulk bounds/query read. The original guard bought
+  // that by SKIPPING the node — which left the rect stale, and membership is
+  // rect-first, so a collapsed node could be omitted from the group it is sitting
+  // in (left behind by a move, reported as zero moved) or reported as enclosed
+  // when it is not. Writing the PILL keeps #416's guarantee and makes the rect live.
   const collapsed = {
     id: 5,
     pos: [1000, 1000],
     size: [300, 200],
     flags: { collapsed: true },
-    boundingRect: [1000, 970, 120, 30], // small title-only pill
+    boundingRect: [-9999, -9999, 120, 30], // stale pill, nowhere near the live pos
+  };
+  assert.equal(syncNodeArea(collapsed), true);
+  assert.deepEqual([...collapsed.boundingRect], [1000, 970, 80, 30], "pill, tracking the LIVE pos");
+  assert.notDeepEqual(
+    [...collapsed.boundingRect],
+    [1000, 970, 300, 230],
+    "#416: never the full pos/size footprint",
+  );
+});
+
+test("a collapsed node inside a group box is a MEMBER, not silently left behind (#416/#408)", () => {
+  // The stale-rect case that used to be unreachable because the sync skipped it.
+  const collapsed = {
+    id: 5,
+    pos: [120, 120],
+    size: [300, 200],
+    flags: { collapsed: true },
+    boundingRect: [-9999, -9999, 80, 30], // stale: claims to be far outside the box
+  };
+  const graph = graphOf(collapsed);
+  const g = groupBox([100, 60, 200, 200]);
+  assert.deepEqual(groupMemberNodes(graph, g).map((n) => n.id), [], "stale rect hides it");
+  syncGraphNodeAreas(graph);
+  assert.deepEqual(
+    groupMemberNodes(graph, g).map((n) => n.id),
+    [5],
+    "after the resync it reads as the member it visibly is",
+  );
+});
+
+test("syncNodeArea honours a node's own collapsed width when the build records one", () => {
+  const collapsed = {
+    id: 5,
+    pos: [10, 40],
+    size: [300, 200],
+    flags: { collapsed: true },
+    _collapsed_width: 142,
+    boundingRect: [0, 0, 1, 1],
   };
   syncNodeArea(collapsed);
-  assert.deepEqual([...collapsed.boundingRect], [1000, 970, 120, 30], "collapsed rect preserved by default");
+  assert.deepEqual([...collapsed.boundingRect], [10, 10, 142, 30]);
+});
+
+test("syncNodeArea REPORTS an unwritable rect instead of throwing", () => {
+  // It runs inside a group move, after positions have been written. A throw here
+  // would escape past the caller's rollback and leak a half-moved graph.
+  const frozen = { id: 5, pos: [10, 10], size: [100, 100], boundingRect: Object.freeze([0, 0, 1, 1]) };
+  let result;
+  assert.doesNotThrow(() => { result = syncNodeArea(frozen); });
+  assert.equal(result, false, "and it says so");
+  const graph = { _nodes: [frozen, { id: 6, pos: [0, 0], size: [10, 10], boundingRect: [0, 0, 1, 1] }] };
+  assert.deepEqual(syncGraphNodeAreas(graph).map((n) => n.id), [5], "reported up to the caller as a pre-flight");
 });
 
 test("syncNodeArea(node, true) FORCE-syncs a REQUESTED collapsed node into its own box (#391)", () => {

--- a/browser_tests/unit/group-geometry.test.mjs
+++ b/browser_tests/unit/group-geometry.test.mjs
@@ -22,6 +22,7 @@ import {
   syncNodeArea,
   syncGraphNodeAreas,
   moveGroupMembers,
+  nodeAreaIsLive,
 } from "../../web/js/lib/group-geometry.js";
 
 // Minimal fixtures. No boundingRect => nodeFocusBounds falls back to pos/size
@@ -303,6 +304,39 @@ test("a collapsed node inside a group box is a MEMBER, not silently left behind 
   );
 });
 
+test("syncNodeArea rejects a non-finite or negative collapsed width (#416 area guarantee)", () => {
+  // `Number(x) || 80` accepts Infinity and -1: both are truthy. An infinite pill
+  // overstates the area without limit and makes the node a geometric member of
+  // every group — the exact guarantee the pill was chosen to preserve.
+  for (const bad of [Infinity, -Infinity, Number.NaN, -1, "wide", null, undefined, {}]) {
+    const n = {
+      id: 5,
+      pos: [10, 40],
+      size: [300, 200],
+      flags: { collapsed: true },
+      _collapsed_width: bad,
+      boundingRect: [0, 0, 1, 1],
+    };
+    syncNodeArea(n);
+    assert.deepEqual([...n.boundingRect], [10, 10, 80, 30], `_collapsed_width=${String(bad)} falls back to the pill`);
+  }
+});
+
+test("syncNodeArea rejects a non-finite node SIZE too", () => {
+  const n = { id: 5, pos: [10, 40], size: [Infinity, Number.NaN], boundingRect: [0, 0, 1, 1] };
+  syncNodeArea(n);
+  assert.deepEqual([...n.boundingRect], [10, 10, 200, 130], "an unusable extent falls back to the default");
+});
+
+test("syncNodeArea/nodeAreaIsLive refuse a node whose POSITION is not a finite point", () => {
+  // Substituting [0, 0] would put a node with no knowable position into whatever
+  // group happens to sit at the origin.
+  const n = { id: 5, pos: [Number.NaN, 10], size: [100, 100], boundingRect: [0, 0, 1, 1] };
+  assert.equal(syncNodeArea(n), false);
+  assert.deepEqual([...n.boundingRect], [0, 0, 1, 1], "and it is left alone rather than given a made-up rect");
+  assert.equal(nodeAreaIsLive(n), false);
+});
+
 test("syncNodeArea honours a node's own collapsed width when the build records one", () => {
   const collapsed = {
     id: 5,
@@ -324,7 +358,42 @@ test("syncNodeArea REPORTS an unwritable rect instead of throwing", () => {
   assert.doesNotThrow(() => { result = syncNodeArea(frozen); });
   assert.equal(result, false, "and it says so");
   const graph = { _nodes: [frozen, { id: 6, pos: [0, 0], size: [10, 10], boundingRect: [0, 0, 1, 1] }] };
-  assert.deepEqual(syncGraphNodeAreas(graph).map((n) => n.id), [5], "reported up to the caller as a pre-flight");
+  assert.deepEqual(
+    syncGraphNodeAreas(graph).unsynced.map((n) => n.id),
+    [5],
+    "reported up to the caller as a pre-flight",
+  );
+});
+
+test("syncGraphNodeAreas is TRANSACTIONAL: its undo puts every rect it touched back", () => {
+  // The resync is a WRITE. Reconciling node A and then finding node B unwritable
+  // must not leave A's cached geometry changed with no way back, under a caller
+  // that goes on to report that nothing happened.
+  const a = { id: 1, pos: [500, 500], size: [100, 100], boundingRect: [-9, -9, 1, 1] }; // stale, writable
+  const b = { id: 2, pos: [10, 10], size: [100, 100], boundingRect: Object.freeze([-9, -9, 1, 1]) };
+  const graph = { _nodes: [a, b] };
+
+  const res = syncGraphNodeAreas(graph);
+  assert.deepEqual(res.unsynced.map((n) => n.id), [2]);
+  assert.deepEqual([...a.boundingRect], [500, 470, 100, 130], "A really was rewritten");
+
+  assert.deepEqual(res.undo(), [], "and the undo reports nothing left displaced");
+  assert.deepEqual([...a.boundingRect], [-9, -9, 1, 1], "A's cached rect is exactly as it was found");
+});
+
+test("syncGraphNodeAreas.undo reports a rect it could not put back", () => {
+  let frozen = false;
+  const rect = [0, 0, 1, 1];
+  const n = {
+    id: 1,
+    pos: [500, 500],
+    size: [100, 100],
+    get boundingRect() { return frozen ? Object.freeze([...rect]) : rect; },
+  };
+  const res = syncGraphNodeAreas({ _nodes: [n] });
+  assert.deepEqual(res.unsynced, []);
+  frozen = true; // becomes unwritable between the sync and the undo
+  assert.deepEqual(res.undo().map((x) => x.id), [1], "an unrestorable rect is named, not assumed");
 });
 
 test("syncNodeArea(node, true) FORCE-syncs a REQUESTED collapsed node into its own box (#391)", () => {

--- a/browser_tests/unit/move-group.test.mjs
+++ b/browser_tests/unit/move-group.test.mjs
@@ -58,8 +58,13 @@ const moveGroupLabelSrc = grab(/ {4}case "graph_move_group": \{[\s\S]*?\n {4}\}/
  *  sloppy by default, so without this the harness would exercise a more forgiving
  *  language than the one the panel actually runs in — and every "unwritable
  *  geometry" test below would be testing the wrong thing. */
-function realMoveGroup(graph) {
+function realMoveGroup(graph, overrides = {}) {
   const getGraphCtx = () => ({ graph });
+  // `overrides` swaps a single injected dependency for a double. It exists for
+  // ONE purpose: the mutation-phase catch is unreachable while the movers are
+  // total, so the only way to exercise what that net actually DOES — rather than
+  // assert on its source text — is to hand the real handler a mover that throws.
+  const dep = (name, real) => (name in overrides ? overrides[name] : real);
   return new Function(
     "getGraphCtx",
     "groupBoundsOf",
@@ -85,13 +90,13 @@ function realMoveGroup(graph) {
   )(
     getGraphCtx,
     groupBoundsOf,
-    syncGraphNodeAreas,
+    dep("syncGraphNodeAreas", syncGraphNodeAreas),
     groupMemberNodes,
     nestedGroupsOf,
     reroutesInside,
-    moveGroupMembers,
-    translateGroupBoxes,
-    moveReroutePoints,
+    dep("moveGroupMembers", moveGroupMembers),
+    dep("translateGroupBoxes", translateGroupBoxes),
+    dep("moveReroutePoints", moveReroutePoints),
     rerouteWriteIsSound,
     groupBoxIsAt,
     describeItems,
@@ -1367,6 +1372,50 @@ test("#408 P0: a title whose toJSON throws still yields the completed counts, no
   assert.doesNotThrow(() => JSON.stringify(out), "the reply the bridge will serialize must be serializable");
 });
 
+test("#408 P0: a BigInt group_id on the FALLBACK path still yields a serializable completion reply", () => {
+  // Prove the reply you RETURN, not a payload inside it. Round-tripping only the
+  // inner `group` left the ENVELOPE free to carry something the bridge's
+  // JSON.stringify chokes on — a caller-supplied BigInt group_id is enough. That
+  // throws AFTER the move, outside every guard, so the caller receives no
+  // completion reply at all and re-issues an already-completed move:
+  // summary_unavailable bypassed one level further out.
+  const a = node(7, [50, 50], [60, 40]);
+  const g = {
+    id: 1n, // BigInt: summarizeGroup will put it in the summary, stringify will refuse
+    title: "Big",
+    _bounding: [0, 0, 400, 400],
+    recomputeInsideNodes() {},
+  };
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+
+  let out;
+  assert.doesNotThrow(() => { out = realMoveGroup(graph)({ group_id: 1n, pos: [1000, 1000] }); });
+
+  assert.deepEqual(a.pos, [1050, 1050], "the move really did complete");
+  assert.deepEqual(out.moved, { nodes: 1, groups: 0, reroutes: 0 }, "the verified counts survive");
+  assert.match(out.summary_unavailable, /move COMPLETED/);
+  assert.match(out.summary_unavailable, /do NOT re-issue the move/, "the do-not-re-issue signal survives");
+  assert.doesNotThrow(
+    () => JSON.stringify(out),
+    "the reply the bridge is about to serialize must itself be serializable",
+  );
+  assert.equal("group_id" in out, false, "the unserializable id is dropped rather than losing the whole reply");
+});
+
+test("#408: a serializable group_id is still reported on the fallback path", () => {
+  // The degraded reply drops the id only when it has to; an ordinary id survives.
+  const a = node(7, [50, 50], [60, 40]);
+  const hostileTitle = { toJSON() { throw new TypeError("gone"); } };
+  const g = { id: 1, title: hostileTitle, _bounding: [0, 0, 400, 400], recomputeInsideNodes() {} };
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+
+  const out = realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] });
+
+  assert.equal(out.group_id, 1);
+  assert.match(out.summary_unavailable, /do NOT re-issue the move/);
+  assert.doesNotThrow(() => JSON.stringify(out));
+});
+
 test("#408: an ordinary reply is plain JSON — round-tripped, not live engine references", () => {
   const a = node(7, [50, 50], [60, 40]);
   const g = group(1, [0, 0, 400, 400]);
@@ -1600,23 +1649,145 @@ test("writePoint never throws — not even for a container it cannot inspect or 
   assert.equal(result, false);
 });
 
-test("the caught-throw net must never claim 'NOTHING was moved'", () => {
-  // This path is unreachable while the movers are total (each contains per item
-  // and always returns its undo), so no fixture can drive it — but if it ever
-  // fires it CANNOT have undone the mover that raised, because that mover never
-  // handed back its undo. A net that asserts a restoration it could not have made
-  // is worse than no net, so the claim is pinned here at the source level.
-  const netBlock = panelSrc.match(
-    /catch \(error\) \{\s*const unrestored = \[[\s\S]*?partway through the move[\s\S]*?\);\s*\}/,
+// ---- the mutation-phase net, driven for real -------------------------------
+// This path is unreachable while the movers are total, so it used to be pinned
+// only by a source-level assertion on its wording. That was not coverage of what
+// it DOES. Injecting a throwing mover into the real handler drives it properly —
+// and the behaviours below are the two ways it could have made things WORSE if it
+// ever fired, not merely failed to help.
+
+/** The real handler with a mover that mutates and then throws BEFORE returning
+ *  its undo — the exact shape the net exists for. */
+function moveGroupWithThrowingMover(graph, mutateBeforeThrowing) {
+  return realMoveGroup(graph, {
+    moveGroupMembers: (members, dx, dy) => {
+      mutateBeforeThrowing(members, dx, dy);
+      throw new TypeError("mover died before returning its undo");
+    },
+  });
+}
+
+test("#408: the net reports UNKNOWN — it never claims a restoration it could not make", () => {
+  const a = node(7, [50, 50], [60, 40]);
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+
+  let err = null;
+  try {
+    moveGroupWithThrowingMover(graph, (members, dx, dy) => {
+      for (const n of members) n.pos = [n.pos[0] + dx, n.pos[1] + dy];
+    })({ group_id: 1, pos: [1000, 1000] });
+  } catch (error) {
+    err = error;
+  }
+  assert.ok(err, "the move must be refused");
+  assert.doesNotMatch(err.message, /NOTHING was moved/, "it cannot verify a rollback, so it must not assert one");
+  assert.match(err.message, /UNKNOWN/);
+  assert.match(err.message, /PARTIALLY moved/);
+  assert.match(err.message, /Ctrl\+Z/);
+});
+
+test("#408: the STUCK-ITEMS refusal does not write a box the forward path never wrote", () => {
+  // Same rule, reachable path. The stuck check fires BEFORE the box write, and
+  // restoreBox() is a write: on a clamping setter it would displace a box nothing
+  // had displaced. A rollback must not move what no forward path moved.
+  const writes = [];
+  const quad = [0, 0, 400, 400];
+  Object.defineProperty(quad, "0", {
+    get() { return this._x ?? 0; },
+    set(v) { writes.push(v); this._x = Math.max(50, v); }, // a write MOVES it
+    configurable: true,
+  });
+  const g = { id: 1, title: "Clamping", get _bounding() { return quad; } };
+  // A frozen member makes the move refuse at the stuck check.
+  const stuckNode = { id: 7, size: [60, 40], boundingRect: [100, 70, 60, 70], get pos() { return Object.freeze([100, 100]); } };
+  const graph = makeGraph({ nodes: [stuckNode], groups: [g] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
+    /would not accept a new position \(node 7\).*NOTHING was moved/s,
   );
-  assert.ok(netBlock, "could not locate the mutation-phase catch in panel source");
-  assert.doesNotMatch(
-    netBlock[0],
-    /NOTHING was moved/,
-    "the one path that cannot verify a rollback must not assert one",
+  assert.deepEqual(writes, [], "no box write at all — neither forward nor in recovery");
+  assert.equal(quad[0], 0);
+});
+
+test("#408: the net does NOT write the group box, which no forward path had moved", () => {
+  // The box write happens strictly AFTER the movers, so when this net fires
+  // nothing has displaced the box. Calling restoreBox() anyway is a WRITE, and on
+  // an effectful or clamping setter it can create a displacement of its own — a
+  // rollback moving something no forward path moved.
+  const writes = [];
+  const quad = [0, 0, 400, 400];
+  const g = {
+    id: 1,
+    title: "Clamping",
+    get _bounding() { return quad; },
+  };
+  Object.defineProperty(quad, "0", {
+    get() { return this._x ?? 0; },
+    set(v) { writes.push(v); this._x = Math.max(50, v); }, // clamps: a write MOVES it
+    configurable: true,
+  });
+  const a = node(7, [100, 100], [60, 40]);
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+
+  assert.throws(
+    () => moveGroupWithThrowingMover(graph, () => {})({ group_id: 1, pos: [1000, 1000] }),
+    /UNKNOWN/,
   );
-  assert.match(netBlock[0], /UNKNOWN/, "it must say the state is unknown");
-  assert.match(netBlock[0], /PARTIALLY moved/, "and that the graph may be partially moved");
+  assert.deepEqual(writes, [], "the recovery must not write a box the forward path never touched");
+  assert.equal(quad[0], 0, "so the clamping setter never got the chance to displace it");
+});
+
+test("#408: when a LATER mover throws, the net still undoes the ones that completed", () => {
+  // The nets's `unrestored` list is only meaningful for movers that already
+  // ASSIGNED. moveGroupMembers completes here and translateGroupBoxes throws, so
+  // the members' undo is real and must run — that is the half of the recovery the
+  // net can actually do.
+  const a = node(7, [50, 50], [60, 40]);
+  const inner = group(2, [20, 20, 100, 100], "Inner");
+  const outer = group(1, [0, 0, 400, 400], "Outer");
+  const graph = makeGraph({ nodes: [a], groups: [outer, inner] });
+
+  assert.throws(
+    () =>
+      realMoveGroup(graph, {
+        translateGroupBoxes: () => { throw new TypeError("box mover died"); },
+      })({ group_id: 1, pos: [1000, 1000] }),
+    /UNKNOWN/,
+  );
+  assert.deepEqual(a.pos, [50, 50], "the members that DID move are put back");
+  assert.deepEqual(outer._bounding, [0, 0, 400, 400], "and the box was never written");
+});
+
+test("#408: the net leaves rects describing where nodes ARE, not a replayed snapshot", () => {
+  // The mover that threw may have changed `pos` without returning its undo.
+  // Replaying the pre-flight rect snapshot over such a node recreates exactly the
+  // stale-rect fabrication removed from the stranded-member path: a rect claiming
+  // a position the node no longer holds, which reads as membership of a group it
+  // has left. When the state is UNKNOWN, the truthful rect is the live one.
+  const moved7 = node(7, [100, 100], [60, 40]);
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [moved7], groups: [g] });
+
+  assert.throws(
+    () =>
+      moveGroupWithThrowingMover(graph, (members) => {
+        for (const n of members) n.pos = [5000, 5000]; // relocated, undo never returned
+      })({ group_id: 1, pos: [1000, 1000] }),
+    /UNKNOWN/,
+  );
+  assert.deepEqual(moved7.pos, [5000, 5000], "precondition: the mover really did relocate it");
+  assert.deepEqual(
+    [...moved7.boundingRect],
+    [5000, 4970, 60, 70],
+    "its cached rect must describe where it IS",
+  );
+  assert.deepEqual(
+    groupMemberNodes(graph, g).map((n) => n.id),
+    [],
+    "and it must not read as a member of the group it has left",
+  );
 });
 
 test("samePoint is exact unless the destination really is a Float32Array", () => {

--- a/browser_tests/unit/move-group.test.mjs
+++ b/browser_tests/unit/move-group.test.mjs
@@ -952,6 +952,36 @@ test("#408: a NESTED box that throws on read is stuck, not silently left behind"
   assert.deepEqual(a.pos, [50, 50], "and the member is back");
 });
 
+test("#408: an accessor that misbehaves only AFTER the resync still yields a stated refusal", () => {
+  // The pre-flight resync reconciles rects, then membership/nesting/reroutes are
+  // read. An accessor that behaves for the first pass and throws on the second is
+  // the one way a bare TypeError could still reach the caller. Nothing has been
+  // repositioned at that point, so the honest answer is a refusal that says so.
+  let reads = 0;
+  const flaky = {
+    id: 7,
+    size: [60, 40],
+    // No cached rect, so the resync reads pos twice and returns clean, and the
+    // membership pass is the next thing to touch it.
+    _p: [50, 50],
+    get pos() {
+      reads += 1;
+      if (reads > 2) throw new TypeError("disposed mid-read");
+      return this._p;
+    },
+  };
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [flaky], groups: [g] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
+    /disposed mid-read.*cannot be determined.*NOTHING was moved/s,
+  );
+  assert.deepEqual(flaky._p, [50, 50]);
+  assert.deepEqual(g._bounding, [0, 0, 400, 400]);
+  assert.equal(graph.beforeCount, undefined, "and no undo transaction was opened");
+});
+
 test("#408: a node with NO cached rect and a hostile pos is caught by the readability pre-flight", () => {
   // syncNodeArea used to return early when there was no rect to write, without
   // ever touching pos — so this node sailed through the pre-flight and raised a

--- a/browser_tests/unit/move-group.test.mjs
+++ b/browser_tests/unit/move-group.test.mjs
@@ -26,6 +26,9 @@ import {
   writePoint,
   samePoint,
   groupBoxIsAt,
+  rerouteWriteIsSound,
+  syncNodeArea,
+  refreshNodeArea,
 } from "../../web/js/lib/group-geometry.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
@@ -63,6 +66,7 @@ function realMoveGroup(graph) {
     "moveGroupMembers",
     "translateGroupBoxes",
     "moveReroutePoints",
+    "rerouteWriteIsSound",
     "groupBoxIsAt",
     `"use strict";
      ${resolveGroupSrc}
@@ -80,6 +84,7 @@ function realMoveGroup(graph) {
     moveGroupMembers,
     translateGroupBoxes,
     moveReroutePoints,
+    rerouteWriteIsSound,
     groupBoxIsAt,
   );
 }
@@ -108,6 +113,30 @@ function node(id, pos, size = [100, 100], rect = null) {
 
 function group(id, bounding, title = `G${id}`) {
   return { id, title, _bounding: [...bounding], recomputeInsideNodes() {} };
+}
+
+/** A reroute shaped like @comfyorg/litegraph's: `pos` is a get/set pair on the
+ *  PROTOTYPE over the reroute's own Float64Array, and the setter is where the
+ *  build's layout/persistence bookkeeping lives. `store` records every write the
+ *  engine's own path would persist. */
+function reroutePrototype(store) {
+  return {
+    get pos() { return this._p; },
+    set pos(v) {
+      this._p[0] = Number(v[0]);
+      this._p[1] = Number(v[1]);
+      store.push([Number(v[0]), Number(v[1])]);
+    },
+  };
+}
+
+function reroute(id, [x, y], { store = [], extra = {} } = {}) {
+  const r = Object.assign(Object.create(reroutePrototype(store)), {
+    id,
+    _p: new Float64Array([x, y]),
+    ...extra,
+  });
+  return { r, store };
 }
 
 function makeGraph({ nodes = [], groups = [], reroutes = null } = {}) {
@@ -363,42 +392,88 @@ test("#408: a member that CANNOT be repositioned aborts the whole move and rolls
   assert.deepEqual([...frozenPoint], [80, 100], "the stuck node never moved");
 });
 
-test("#408: a reroute is moved through the engine's own move() when the build has one", () => {
+test("#408: an ABSOLUTE reroute move() is never called, and the STORE ends correct", () => {
+  // THE probe hazard. If move(x, y) is ABSOLUTE on this build and also writes the
+  // persisted/reactive store, then "call move(dx, dy) and correct pos afterwards"
+  // records the WRONG coordinate in the store, patches only the in-place array,
+  // reports success — and the next render or save resurrects the wrong point.
+  // You cannot learn an API's semantics by invoking it destructively, so we never
+  // invoke it: the pos SETTER is the engine's own write path and needs no guess.
   const calls = [];
-  const reroute = {
-    id: 11,
-    pos: [100, 100],
-    move(dx, dy) { calls.push([dx, dy]); this.pos = [this.pos[0] + dx, this.pos[1] + dy]; },
-  };
-  const graph = makeGraph({ groups: [group(1, [0, 0, 400, 400])], reroutes: [reroute] });
+  const { r, store } = reroute(11, [100, 100], {
+    extra: { move(x, y) { calls.push([x, y]); this._p[0] = Number(x); this._p[1] = Number(y); } },
+  });
+  const graph = makeGraph({ groups: [group(1, [0, 0, 400, 400])], reroutes: [r] });
 
   const out = realMoveGroup(graph)({ group_id: 1, pos: [100, 100] });
 
-  assert.deepEqual(calls, [[100, 100]], "the engine primitive was used, so the layout store sees the change");
-  assert.deepEqual([reroute.pos[0], reroute.pos[1]], [200, 200]);
+  assert.deepEqual(calls, [], "move() must never be invoked to discover what it means");
+  assert.deepEqual([r.pos[0], r.pos[1]], [200, 200], "the point is where it should be");
+  assert.deepEqual(
+    store,
+    [[200, 200]],
+    "and the STORE — not just pos — recorded exactly the correct coordinate, once",
+  );
   assert.equal(out.moved.reroutes, 1);
 });
 
-test("#408: a build whose reroute move() has the wrong signature is corrected, not trusted", () => {
-  // move(x, y) treated as ABSOLUTE by this build. The verified fallback must put
-  // the point where the delta says, not where the primitive left it.
-  const reroute = { id: 11, pos: [100, 100], move(x, y) { this.pos = [x, y]; } };
-  const graph = makeGraph({ groups: [group(1, [0, 0, 400, 400])], reroutes: [reroute] });
+test("#408: an ABSOLUTE move() with a rollback still leaves the store correct, never a stale coordinate", () => {
+  const calls = [];
+  const { r, store } = reroute(11, [100, 100], {
+    extra: { move(x, y) { calls.push([x, y]); this._p[0] = Number(x); this._p[1] = Number(y); } },
+  });
+  // A frozen member forces the refusal AFTER the reroute has moved.
+  const stuckNode = { id: 8, size: [60, 40], boundingRect: [150, 120, 60, 70], get pos() { return Object.freeze([150, 150]); } };
+  const graph = makeGraph({ nodes: [stuckNode], groups: [group(1, [0, 0, 400, 400])], reroutes: [r] });
+
+  assert.throws(() => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }), /NOTHING was moved/);
+
+  assert.deepEqual(calls, [], "not during the move, and not during the rollback either");
+  assert.deepEqual([r.pos[0], r.pos[1]], [100, 100]);
+  assert.deepEqual(
+    store.at(-1),
+    [100, 100],
+    "the LAST thing the store recorded is the original coordinate — nothing stale survives a save",
+  );
+});
+
+test("#408: a reroute we cannot reposition soundly is REFUSED up front, before anything moves", () => {
+  // `pos` is a plain slot (no setter to carry the build's bookkeeping) and the
+  // build exposes a move() whose meaning we cannot determine without calling it.
+  // That is genuinely unknown, and the honest answer is a refusal — not a
+  // coin-flip whose failure mode is a wrong coordinate at save time.
+  const unsound = { id: 11, pos: [100, 100], move() { throw new Error("must never be called"); } };
+  const a = node(7, [200, 200], [60, 40]);
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [a], groups: [g], reroutes: [unsound] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
+    /reroute 11.*does not let us determine without calling it.*NOTHING was moved.*move_nodes:false/s,
+  );
+  assert.deepEqual(a.pos, [200, 200], "and it is a PRE-FLIGHT refusal: not one node moved first");
+  assert.deepEqual([unsound.pos[0], unsound.pos[1]], [100, 100]);
+  assert.deepEqual(g._bounding, [0, 0, 400, 400]);
+  assert.equal(graph.beforeCount, undefined, "no undo transaction was even opened");
+});
+
+test("#408: a plain-slot reroute with NO move() is still moved — the refusal is scoped to the unknown", () => {
+  const plain = { id: 11, pos: [100, 100] };
+  const graph = makeGraph({ groups: [group(1, [0, 0, 400, 400])], reroutes: [plain] });
 
   const out = realMoveGroup(graph)({ group_id: 1, pos: [100, 100] });
 
-  assert.deepEqual([reroute.pos[0], reroute.pos[1]], [200, 200], "corrected to old + delta");
+  assert.deepEqual([plain.pos[0], plain.pos[1]], [200, 200]);
   assert.equal(out.moved.reroutes, 1);
 });
 
-test("#408: a reroute whose move() throws does not abort the move; the direct write still lands", () => {
-  const reroute = { id: 11, pos: [100, 100], move() { throw new Error("not on this build"); } };
-  const graph = makeGraph({ groups: [group(1, [0, 0, 400, 400])], reroutes: [reroute] });
-
-  const out = realMoveGroup(graph)({ group_id: 1, pos: [100, 100] });
-
-  assert.deepEqual([reroute.pos[0], reroute.pos[1]], [200, 200]);
-  assert.equal(out.moved.reroutes, 1);
+test("rerouteWriteIsSound: a pos setter is sound; a plain slot plus an uncharacterisable move() is not", () => {
+  const { r } = reroute(11, [0, 0]);
+  assert.equal(rerouteWriteIsSound(r), true, "accessor with a setter — the engine's own write path");
+  const { r: withMove } = reroute(12, [0, 0], { extra: { move() {} } });
+  assert.equal(rerouteWriteIsSound(withMove), true, "a setter wins even when move() also exists");
+  assert.equal(rerouteWriteIsSound({ pos: [0, 0] }), true, "a plain slot with no move() is unambiguous");
+  assert.equal(rerouteWriteIsSound({ pos: [0, 0], move() {} }), false, "plain slot + move() is UNKNOWN");
 });
 
 test("#408: a FROZEN reroute point aborts and rolls back rather than half-moving the group", () => {
@@ -705,6 +780,193 @@ test("#408: a node that SNAPS on the way out keeps a cached rect at its REAL pos
   );
 });
 
+// ---- collapsed members and the pre-flight invariant ------------------------
+
+test("#408: a COLLAPSED member with a stale rect is moved, not silently left behind", () => {
+  // Membership is rect-first and the bulk sync used to SKIP collapsed nodes, so a
+  // collapsed node sitting inside the box while its cached rect claimed otherwise
+  // was omitted from the move entirely — left behind, with the reply reporting it
+  // had carried zero nodes.
+  const collapsed = {
+    id: 7,
+    pos: [120, 120],
+    size: [300, 200],
+    flags: { collapsed: true },
+    boundingRect: [-9999, -9999, 80, 30],
+  };
+  const graph = makeGraph({ nodes: [collapsed], groups: [group(1, [100, 60, 200, 200])] });
+
+  const out = realMoveGroup(graph)({ group_id: 1, pos: [1100, 1060] });
+
+  assert.deepEqual(collapsed.pos, [1120, 1120], "the collapsed member travelled with the box");
+  assert.equal(out.moved.nodes, 1, "and the reply says so instead of reporting an empty group");
+  assert.deepEqual(out.group.node_ids, [7]);
+});
+
+test("#408: move_nodes:false does not report a STALE collapsed node as newly enclosed", () => {
+  // The mirror image: its live position is far outside the box the caller is
+  // moving to, but its cached rect claims it is inside.
+  const collapsed = {
+    id: 7,
+    pos: [9000, 9000],
+    size: [300, 200],
+    flags: { collapsed: true },
+    boundingRect: [1150, 1090, 80, 30], // stale: inside the DESTINATION box
+  };
+  const graph = makeGraph({ nodes: [collapsed], groups: [group(1, [0, 0, 200, 200])] });
+
+  const out = realMoveGroup(graph)({ group_id: 1, pos: [1100, 1060], move_nodes: false });
+
+  assert.deepEqual(out.group.node_ids, [], "a node that is not there must not be reported as enclosed");
+  assert.deepEqual(collapsed.pos, [9000, 9000]);
+});
+
+test("#408: a node whose cached rect cannot be resynced is refused BEFORE the box is written", () => {
+  // The pre-flight resync is itself a write. It used to run in move_nodes:false
+  // AFTER the box had already been moved: syncNodeArea threw on the frozen rect,
+  // the box stayed at the requested position, and the caller got an unrelated
+  // TypeError — not success, not "NOTHING was moved", not a stated partial.
+  const frozenRect = {
+    id: 7,
+    pos: [50, 50],
+    size: [100, 100],
+    boundingRect: Object.freeze([0, 0, 1, 1]),
+  };
+  const g = group(1, [0, 0, 200, 200]);
+  const graph = makeGraph({ nodes: [frozenRect], groups: [g] });
+
+  for (const moveNodes of [true, false]) {
+    assert.throws(
+      () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000], move_nodes: moveNodes }),
+      /node 7.*group membership cannot be determined.*NOTHING was moved/s,
+      `move_nodes:${moveNodes}`,
+    );
+    assert.deepEqual(g._bounding, [0, 0, 200, 200], `the box must not have moved (move_nodes:${moveNodes})`);
+    assert.deepEqual(frozenRect.pos, [50, 50]);
+  }
+  assert.equal(graph.beforeCount, undefined, "a pre-flight refusal opens no undo transaction");
+});
+
+test("#408: a COLLAPSED member with a frozen rect is refused up front, not moved-then-thrown", () => {
+  // The precise leak: this node has a MUTABLE pos and a FROZEN boundingRect, and
+  // being collapsed it used to slip past the bulk sync entirely. Its position
+  // would be written successfully and refreshNodeArea would then throw on the
+  // rect — from inside moveGroupMembers, before it returned, so the handler's
+  // rollback never ran and the moved node leaked out under a raw TypeError.
+  const collapsed = {
+    id: 7,
+    pos: [120, 120],
+    size: [300, 200],
+    flags: { collapsed: true },
+    // Frozen AND stale, so the pre-flight resync cannot make it live.
+    boundingRect: Object.freeze([-9999, -9999, 80, 30]),
+  };
+  const g = group(1, [100, 60, 200, 200]);
+  const graph = makeGraph({ nodes: [collapsed], groups: [g] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1100, 1060] }),
+    /node 7.*group membership cannot be determined.*NOTHING was moved/s,
+  );
+  assert.deepEqual(collapsed.pos, [120, 120], "the node must not have moved at all");
+  assert.deepEqual(g._bounding, [100, 60, 200, 200]);
+  assert.equal(graph.beforeCount, undefined, "and it is caught in pre-flight, before the transaction");
+});
+
+test("#408: a member that THROWS on read does not strand the ones already moved", () => {
+  // If a mover threw partway it would never RETURN its undo, so everything it had
+  // already moved would be unrecoverable — the handler's rollback cannot undo what
+  // it was never handed. Containment is per item: a hostile accessor makes that
+  // node stuck, and the whole move is refused with the others put back.
+  const first = node(7, [50, 50], [60, 40]);
+  const hostile = {
+    id: 8,
+    size: [60, 40],
+    boundingRect: [100, 70, 60, 70],
+    get pos() { throw new TypeError("node has been disposed"); },
+  };
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [first, hostile], groups: [g] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
+    /node 8.*NOTHING was moved/s,
+    "a raw TypeError must never be what the caller sees",
+  );
+  assert.deepEqual(first.pos, [50, 50], "the member moved before the hostile one must be back");
+  assert.deepEqual([...first.boundingRect], [50, 20, 60, 70], "rect too");
+  assert.deepEqual(g._bounding, [0, 0, 400, 400]);
+});
+
+test("#408: a member whose rect is already correct is NOT reported as unrestorable", () => {
+  // A frozen rect that happens to describe the node exactly. The forward move
+  // cannot take the rect along, so the node is stuck and the move is refused —
+  // but the ROLLBACK puts the position back and the frozen rect is live again, so
+  // this must read "NOTHING was moved", not an invented partial. The verdict is
+  // whether the rect matches the node, not whether a delta-write happened.
+  const collapsed = {
+    id: 7,
+    pos: [120, 120],
+    size: [300, 200],
+    flags: { collapsed: true },
+    boundingRect: Object.freeze([120, 90, 80, 30]), // exactly the live pill
+  };
+  const g = group(1, [100, 60, 200, 200]);
+  const graph = makeGraph({ nodes: [collapsed], groups: [g] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1100, 1060] }),
+    /node 7.*NOTHING was moved/s,
+  );
+  assert.deepEqual(collapsed.pos, [120, 120]);
+  assert.deepEqual(g._bounding, [100, 60, 200, 200]);
+});
+
+test("#408: a reroute that throws on read is stuck, not raised, and not silently skipped", () => {
+  const hostileReroute = { id: 11, get pos() { throw new TypeError("gone"); } };
+  const g = group(1, [0, 0, 400, 400]);
+  const a = node(7, [50, 50], [60, 40]);
+  const graph = makeGraph({ nodes: [a], groups: [g], reroutes: [hostileReroute] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
+    /would not accept a new position \(reroute 11\).*NOTHING was moved/s,
+  );
+  assert.deepEqual(g._bounding, [0, 0, 400, 400]);
+  assert.deepEqual(a.pos, [50, 50]);
+});
+
+test("#408: a NESTED box that throws on read is stuck, not silently left behind", () => {
+  // Unknown is not "outside". A box we cannot read might be inside this one, and
+  // moving the group away from it while reporting success is the #408 shape.
+  const hostileGroup = { id: 2, get _bounding() { throw new TypeError("gone"); } };
+  const g = group(1, [0, 0, 400, 400]);
+  const a = node(7, [50, 50], [60, 40]);
+  const graph = makeGraph({ nodes: [a], groups: [g, hostileGroup] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
+    /would not accept a new position \(group 2\).*NOTHING was moved/s,
+  );
+  assert.deepEqual(g._bounding, [0, 0, 400, 400]);
+  assert.deepEqual(a.pos, [50, 50], "and the member is back");
+});
+
+test("#408: a node with NO cached rect and a hostile pos is caught by the readability pre-flight", () => {
+  // syncNodeArea used to return early when there was no rect to write, without
+  // ever touching pos — so this node sailed through the pre-flight and raised a
+  // bare TypeError out of groupMemberNodes instead of a stated refusal.
+  const hostile = { id: 7, size: [60, 40], get pos() { throw new TypeError("disposed"); } };
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [hostile], groups: [g] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
+    /node 7.*group membership cannot be determined.*NOTHING was moved/s,
+  );
+  assert.equal(graph.beforeCount, undefined);
+});
+
 // ---- lib branches the handler tests above do not reach ---------------------
 
 test("writePoint reports the truth for every point shape", () => {
@@ -773,6 +1035,69 @@ test("a Float32Array-backed group box (older LiteGraph) still moves and reports 
   assert.deepEqual(a.pos, [1100.1, 2100.2], "the member moved by the exact delta");
 });
 
+test("a mover NEVER throws out of its loop, so its undo is always returned", () => {
+  // The contract the handler's rollback depends on. If a mover threw partway it
+  // would never RETURN its undo, and everything it had already moved would be
+  // unrecoverable — the caller cannot undo what it was never handed. (The handler
+  // also gates hostile nodes in its pre-flight, so this exercises the mover's own
+  // guarantee directly rather than through a path that shadows it.)
+  const first = { id: 1, pos: [10, 10], size: [60, 40], boundingRect: [10, -20, 60, 70] };
+  const hostile = { id: 2, get pos() { throw new TypeError("disposed"); } };
+  const last = { id: 3, pos: [50, 50], size: [60, 40], boundingRect: [50, 20, 60, 70] };
+
+  let res;
+  assert.doesNotThrow(() => { res = moveGroupMembers([first, hostile, last], 100, 100); });
+  assert.deepEqual(res.stuck.map((n) => n.id), [2], "the hostile member is stuck, not an exception");
+  assert.deepEqual(res.moved.map((n) => n.id), [1, 3], "the others still moved");
+  assert.deepEqual(first.pos, [110, 110]);
+  assert.deepEqual(res.undo(), [], "and the undo it returned puts them all back");
+  assert.deepEqual(first.pos, [10, 10]);
+  assert.deepEqual(last.pos, [50, 50]);
+});
+
+test("moveReroutePoints and translateGroupBoxes never throw on a hostile item either", () => {
+  const hostileReroute = { id: 1, get pos() { throw new TypeError("gone"); } };
+  const okReroute = { id: 2, pos: [10, 10] };
+  let rr;
+  assert.doesNotThrow(() => { rr = moveReroutePoints([hostileReroute, okReroute], 5, 5); });
+  assert.deepEqual(rr.stuck.map((r) => r.id), [1]);
+  assert.deepEqual([okReroute.pos[0], okReroute.pos[1]], [15, 15]);
+  assert.deepEqual(rr.undo(), []);
+  assert.deepEqual([okReroute.pos[0], okReroute.pos[1]], [10, 10]);
+
+  const hostileGroup = { id: 1, get _bounding() { throw new TypeError("gone"); } };
+  const okGroup = group(2, [0, 0, 100, 100]);
+  let gr;
+  assert.doesNotThrow(() => { gr = translateGroupBoxes([hostileGroup, okGroup], 5, 5); });
+  assert.deepEqual(gr.stuck.map((x) => x.id), [1]);
+  assert.deepEqual(okGroup._bounding, [5, 5, 100, 100]);
+  assert.deepEqual(gr.undo(), []);
+  assert.deepEqual(okGroup._bounding, [0, 0, 100, 100]);
+});
+
+test("a rollback reports an unrestorable item rather than throwing over the refusal", () => {
+  // restoreNodePositions runs while the caller is already composing an error. A
+  // throw here would replace that carefully-worded refusal with a raw TypeError.
+  let armed = false;
+  const trap = {
+    id: 1,
+    _p: [10, 10],
+    size: [60, 40],
+    boundingRect: [10, -20, 60, 70],
+    get pos() {
+      if (armed) throw new TypeError("disposed between the move and the undo");
+      return this._p;
+    },
+    set pos(v) { this._p = [Number(v[0]), Number(v[1])]; },
+  };
+  const res = moveGroupMembers([trap], 100, 100);
+  assert.deepEqual(res.moved.map((n) => n.id), [1]);
+  armed = true;
+  let failures;
+  assert.doesNotThrow(() => { failures = res.undo(); });
+  assert.deepEqual(failures.map((n) => n.id), [1], "reported as unrestorable, which is the honest answer");
+});
+
 test("moveGroupMembers reports moved vs stuck instead of silently skipping", () => {
   const ok = { id: 1, pos: [10, 10], size: [200, 100] };
   const noPos = { id: 2 };
@@ -816,6 +1141,48 @@ test("translateGroupBoxes.undo restores the SIZE too, not just the corner", () =
 });
 
 
+test("groupBoundsOf falls back on VALIDITY, not on _bounding being nullish", () => {
+  // A present-but-malformed _bounding used to short-circuit the ?? and make a
+  // group with perfectly good pos/size read as having no usable bounds — refused
+  // as unmovable when it was nothing of the sort.
+  assert.deepEqual(
+    groupBoundsOf({ _bounding: ["x", "y", "w", "h"], pos: [10, 20], size: [300, 200] }),
+    [10, 20, 300, 200],
+    "malformed _bounding must not veto valid pos/size",
+  );
+  assert.deepEqual(
+    groupBoundsOf({ _bounding: [1, 2], pos: [10, 20], size: [300, 200] }),
+    [10, 20, 300, 200],
+    "a half-length quad is not usable either",
+  );
+  assert.deepEqual(groupBoundsOf({ _bounding: [1, 2, 3, 4], pos: [9, 9], size: [9, 9] }), [1, 2, 3, 4],
+    "a VALID _bounding still wins");
+  assert.equal(groupBoundsOf({ _bounding: [NaN, 0, 0, 0] }), null, "and neither form usable ⇒ null");
+  assert.equal(groupBoundsOf(null), null);
+});
+
+test("#408: a group whose _bounding is malformed but whose pos/size is valid still moves", () => {
+  const g = { id: 1, title: "Legacy", _bounding: ["x", "y", "w", "h"], pos: [0, 0], size: [200, 200] };
+  const a = node(7, [50, 50], [100, 100]);
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+
+  const out = realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] });
+
+  assert.deepEqual(a.pos, [1050, 1050], "the member moved by the delta from the usable bounds");
+  assert.equal(out.moved.nodes, 1);
+});
+
+test("refreshNodeArea REPORTS an unwritable rect instead of throwing mid-move", () => {
+  const frozen = { pos: [110, 110], boundingRect: Object.freeze([100, 70, 60, 70]) };
+  let result;
+  assert.doesNotThrow(() => { result = refreshNodeArea(frozen, [100, 100]); });
+  assert.equal(result, false);
+  const ok = { pos: [110, 110], boundingRect: [100, 70, 60, 70] };
+  assert.equal(refreshNodeArea(ok, [100, 100]), true);
+  assert.deepEqual([...ok.boundingRect], [110, 80, 60, 70]);
+  assert.equal(refreshNodeArea({ pos: [1, 1] }, [0, 0]), true, "no cached rect ⇒ nothing to keep in step");
+});
+
 test("containsBounds: strict containment, identical rects excluded (litegraph containsRect)", () => {
   assert.equal(containsBounds([0, 0, 100, 100], [10, 10, 50, 50]), true);
   assert.equal(containsBounds([0, 0, 100, 100], [0, 0, 100, 100]), false, "identical rects are peers");
@@ -841,8 +1208,20 @@ test("reroutesInside reads the Map, array and plain-object shapes of graph.rerou
   assert.deepEqual(reroutesInside({ reroutes: [hit, miss] }, bounds).map((r) => r.id), [1]);
   assert.deepEqual(reroutesInside({ reroutes: { a: hit, b: miss } }, bounds).map((r) => r.id), [1]);
   assert.deepEqual(reroutesInside({}, bounds), [], "no reroutes on this build → nothing to move");
-  assert.deepEqual(reroutesInside({ reroutes: [{ id: 3 }, { id: 4, pos: [Number.NaN, 0] }] }, bounds), []);
   assert.deepEqual(reroutesInside({ reroutes: [hit] }, null), []);
+  // A reroute with NO pos is not a positioned item — nothing to move, nothing to
+  // be wrong about. A reroute WITH a pos that is not finite, or that cannot be
+  // read at all, is INDETERMINATE: it must ride along so the move refuses rather
+  // than quietly leaving it behind. "Could not determine" is not "outside".
+  assert.deepEqual(reroutesInside({ reroutes: [{ id: 3 }] }, bounds), []);
+  assert.deepEqual(
+    reroutesInside({ reroutes: [{ id: 4, pos: [Number.NaN, 0] }] }, bounds).map((r) => r.id),
+    [4],
+  );
+  assert.deepEqual(
+    reroutesInside({ reroutes: [{ id: 5, get pos() { throw new TypeError("gone"); } }] }, bounds).map((r) => r.id),
+    [5],
+  );
 });
 
 test("nestedGroupsOf tolerates a group with no usable bounds on either side", () => {

--- a/browser_tests/unit/move-group.test.mjs
+++ b/browser_tests/unit/move-group.test.mjs
@@ -1162,6 +1162,31 @@ test("writePoint reports the truth for every point shape", () => {
   assert.equal(writePoint(snapping, "pos", 113, 113), false, "a snapped write is not the write we asked for");
 });
 
+test("groupBoxIsAt is total even when the accessor throws on its SECOND read", () => {
+  // groupBoxIsAt reads the box twice: once through groupBoundsOf (already safe)
+  // and once directly, for the Float32 check. It is the verification step of the
+  // box write — running after the children have moved and before the rollback —
+  // so a throw from that second read would escape the transaction through the
+  // very check that exists to keep it honest. A first-read-throws fixture cannot
+  // reach it: groupBoundsOf swallows that one and returns early.
+  let reads = 0;
+  const flaky = {
+    get _bounding() {
+      reads += 1;
+      if (reads > 1) throw new TypeError("group detached mid-verification");
+      return [0, 0, 10, 10];
+    },
+  };
+  let result;
+  assert.doesNotThrow(() => { result = groupBoxIsAt(flaky, 0, 0, 10, 10); });
+  assert.equal(reads > 1, true, "precondition: the second read really was attempted");
+  assert.equal(result, false, "cannot be shown to be there ⇒ treated as not there");
+
+  const deadOnArrival = { get _bounding() { throw new TypeError("gone"); } };
+  assert.doesNotThrow(() => { result = groupBoxIsAt(deadOnArrival, 0, 0, 10, 10); });
+  assert.equal(result, false);
+});
+
 test("writePoint never throws — not even for a container it cannot inspect or read", () => {
   // hasSetter walks the prototype chain with getPrototypeOf/getOwnPropertyDescriptor,
   // and BOTH throw on a revoked Proxy — as does reading the property itself. A

--- a/browser_tests/unit/move-group.test.mjs
+++ b/browser_tests/unit/move-group.test.mjs
@@ -1711,6 +1711,110 @@ test("#408: the STUCK-ITEMS refusal does not write a box the forward path never 
   assert.equal(quad[0], 0);
 });
 
+/** A group whose `_bounding[0]` setter REJECTS its first assignment (leaving the
+ *  box untouched) and CLAMPS every later one. "We attempted a write" is true for
+ *  it while "the box changed" is false — the exact gap between intent and state. */
+function rejectThenClampGroup(id = 1) {
+  const quad = [0, 0, 400, 400];
+  const assignments = [];
+  Object.defineProperty(quad, "0", {
+    get() { return this._x ?? 0; },
+    set(v) {
+      assignments.push(v);
+      if (assignments.length === 1) throw new TypeError("first write rejected");
+      this._x = Math.max(50, v); // clamps: any later write MOVES it
+    },
+    configurable: true,
+  });
+  return { g: { id, title: "RejectThenClamp", get _bounding() { return quad; } }, quad, assignments };
+}
+
+test("#408 P0: a box write REJECTED on its first attempt is not 'written' — the rollback must not move it", () => {
+  // The forward write throws without changing anything, so the box is exactly
+  // where it started. Gating the restore on "we attempted a write" would then
+  // fire a recovery write into a clamping setter and displace an untouched box
+  // (x: 0 → 50) — a refusal-time geometry mutation. State, not intent, decides.
+  const { g, quad, assignments } = rejectThenClampGroup();
+  const a = node(7, [100, 100], [60, 40]);
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
+    /the group box did not accept the new position.*NOTHING was moved/s,
+  );
+  assert.deepEqual(assignments, [1000], "exactly the one forward attempt — no recovery write");
+  assert.equal(quad[0], 0, "the box is untouched; the rollback did not move it");
+  assert.deepEqual(a.pos, [100, 100], "and the members are back");
+});
+
+test("#408 P0: the same, on the move_nodes:false branch", () => {
+  const { g, quad, assignments } = rejectThenClampGroup();
+  const graph = makeGraph({ nodes: [], groups: [g] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000], move_nodes: false }),
+    /the group box did not accept the new position.*NOTHING was moved/s,
+  );
+  assert.deepEqual(assignments, [1000], "no recovery write on this branch either");
+  assert.equal(quad[0], 0);
+});
+
+test("#408: a box whose CORNER is unchanged but whose SIZE was mangled is not 'as found'", () => {
+  // The state check has to compare the whole quad. This build pins the corner
+  // (any x/y write clamps back to 0) but mangles the width, so after the forward
+  // write the corner matches the original while the size does not. A corner-only
+  // check would call that "exactly as found", skip the restore, and report
+  // NOTHING was moved over a group the user would find reshaped.
+  const quad = [0, 0, 400, 400];
+  Object.defineProperty(quad, "0", { get() { return 0; }, set() {}, configurable: true });
+  Object.defineProperty(quad, "1", { get() { return 0; }, set() {}, configurable: true });
+  Object.defineProperty(quad, "2", {
+    get() { return this._w ?? 400; },
+    set() { this._w = 1; },
+    configurable: true,
+  });
+  const g = { id: 1, title: "PinnedCornerMangledSize", get _bounding() { return quad; } };
+  const a = node(7, [100, 100], [60, 40]);
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+
+  let err = null;
+  try {
+    realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] });
+  } catch (error) {
+    err = error;
+  }
+  assert.ok(err);
+  assert.equal(quad[2], 1, "precondition: the width really was mangled and cannot be repaired");
+  assert.match(
+    err.message,
+    /PARTIALLY moved — 1 item\(s\) could NOT be put back \(group 1\)/,
+    "the reshaped box must be reported, not waved through as 'NOTHING was moved'",
+  );
+  assert.deepEqual(a.pos, [100, 100], "the members are still back");
+});
+
+test("#408: a box that REALLY moved is still restored — the state check is not a blanket skip", () => {
+  // The mirror of the above: when the forward write did change the box, the
+  // restore must still run. Clamping to [0, 500] means the write lands somewhere
+  // other than asked, so the move is refused and the box must go back to 0.
+  const quad = [0, 0, 400, 400];
+  Object.defineProperty(quad, "0", {
+    get() { return this._x ?? 0; },
+    set(v) { this._x = Math.max(0, Math.min(500, v)); },
+    configurable: true,
+  });
+  const g = { id: 1, title: "Clamped", get _bounding() { return quad; } };
+  const a = node(7, [100, 100], [60, 40]);
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [9000, 10] }),
+    /the group box did not accept the new position.*NOTHING was moved/s,
+  );
+  assert.equal(quad[0], 0, "the box that really did move is put back");
+  assert.deepEqual(a.pos, [100, 100]);
+});
+
 test("#408: the net does NOT write the group box, which no forward path had moved", () => {
   // The box write happens strictly AFTER the movers, so when this net fires
   // nothing has displaced the box. Calling restoreBox() anyway is a WRITE, and on

--- a/browser_tests/unit/move-group.test.mjs
+++ b/browser_tests/unit/move-group.test.mjs
@@ -1636,6 +1636,15 @@ test("refreshNodeArea REPORTS an unwritable rect instead of throwing mid-move", 
   let result;
   assert.doesNotThrow(() => { result = refreshNodeArea(frozen, [100, 100]); });
   assert.equal(result, false);
+  // Its "never throws" contract has to cover the READS too — a disposed accessor
+  // raises as readily on the way in as on the way out, and this runs mid-move
+  // with the caller relying on a verdict rather than an exception.
+  const unreadableRect = { pos: [110, 110], get boundingRect() { throw new TypeError("disposed"); } };
+  assert.doesNotThrow(() => { result = refreshNodeArea(unreadableRect, [100, 100]); });
+  assert.equal(result, false);
+  const unreadablePos = { boundingRect: [100, 70, 60, 70], get pos() { throw new TypeError("disposed"); } };
+  assert.doesNotThrow(() => { result = refreshNodeArea(unreadablePos, [100, 100]); });
+  assert.equal(result, false);
   const ok = { pos: [110, 110], boundingRect: [100, 70, 60, 70] };
   assert.equal(refreshNodeArea(ok, [100, 100]), true);
   assert.deepEqual([...ok.boundingRect], [110, 80, 60, 70]);

--- a/browser_tests/unit/move-group.test.mjs
+++ b/browser_tests/unit/move-group.test.mjs
@@ -352,7 +352,7 @@ test("#408: a member that CANNOT be repositioned aborts the whole move and rolls
 
   assert.throws(
     () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
-    /refusing to move group 1: 1 enclosed item\(s\) would not accept a new position \(node 8\)\. NOTHING was moved/,
+    /refusing to move group 1: 1 enclosed item\(s\) would not accept a new position \(node 8\).*NOTHING was moved/s,
   );
 
   assert.deepEqual(outer._bounding, [0, 0, 400, 400], "the group box must be exactly where it was");
@@ -442,13 +442,23 @@ test("#408: a group box that refuses the write is a refusal, not a reported succ
   const reroute = { id: 11, pos: [200, 200] };
   const graph = makeGraph({ nodes: [a], groups: [g, inner], reroutes: [reroute] });
 
-  assert.throws(
-    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
-    // The parenthetical carries the THROWN write error. Its presence is also the
-    // proof that this harness compiled the handler strict, the way the shipped ES
-    // module runs it — in sloppy mode the same write would silently no-op and this
-    // path would be reached by luck rather than by the catch that handles it.
-    /the group box did not accept the new position[^(]*\(.+\)\. NOTHING was moved/s,
+  let err = null;
+  try {
+    realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] });
+  } catch (error) {
+    err = error;
+  }
+  assert.ok(err, "the move must be refused");
+  assert.match(err.message, /the group box did not accept the new position[^(]*\(.+\)\. NOTHING was moved/s);
+  // The parenthetical must carry a THROWN write error, not the "did not land"
+  // verdict. That is the proof this harness compiled the handler STRICT, the way
+  // the shipped ES module runs it: in sloppy mode the same write to a frozen array
+  // silently no-ops and this refusal would be reached by luck rather than by the
+  // catch that exists to handle it.
+  assert.doesNotMatch(
+    err.message,
+    /the write did not land/,
+    "under strict mode the frozen-quad write THROWS; a 'did not land' verdict means the harness ran sloppy",
   );
   assert.deepEqual(a.pos, [100, 100], "the members must be put back when the box write fails");
   assert.deepEqual([...a.boundingRect], [100, 70, 60, 70], "and their cached rects with them");
@@ -494,6 +504,88 @@ test("#408: a snapping reroute is also restored exactly, not left where the engi
 
   assert.throws(() => realMoveGroup(graph)({ group_id: 1, pos: [1013, 1013] }), /NOTHING was moved/);
   assert.deepEqual(snapping._p, [100, 100], "restored to its original point, not to old+(-delta)");
+});
+
+test("#408: a node whose pos is a plain PROPERTY holding a typed-array view keeps that view", () => {
+  // The view is the node's live geometry container. Replacing it with a fresh
+  // plain array would leave the node at the right coordinates while silently
+  // disconnecting it from whatever else writes through that view.
+  const geometry = new Float64Array([50, 50, 0, 0]);
+  const a = { id: 7, size: [100, 100], boundingRect: [50, 20, 100, 130], pos: geometry.subarray(0, 2) };
+  const view = a.pos;
+  const graph = makeGraph({ nodes: [a], groups: [group(1, [0, 0, 200, 200])] });
+
+  const out = realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] });
+
+  assert.equal(a.pos, view, "the node must still hold the SAME container it started with");
+  assert.deepEqual([geometry[0], geometry[1]], [1050, 1050], "and the write went through it");
+  assert.equal(out.moved.nodes, 1);
+});
+
+test("#408: a group box that CLAMPS the write is refused, and the box is put back", () => {
+  // A frontend whose quad clamps to the positive quadrant: the write does not
+  // throw, it just does not land where we asked.
+  const quad = [0, 0, 400, 400];
+  const clamping = {
+    id: 1,
+    title: "Clamped",
+    get _bounding() { return quad; },
+    set _bounding(v) { quad[0] = Math.max(0, v[0]); quad[1] = Math.max(0, v[1]); },
+  };
+  const a = node(7, [100, 100], [60, 40]);
+  const graph = makeGraph({ nodes: [a], groups: [clamping] });
+  // setGroupBounds mutates _bounding IN PLACE, so emulate the clamp on the quad.
+  Object.defineProperty(quad, "0", {
+    get() { return this._x ?? 0; },
+    set(v) { this._x = Math.max(0, Math.min(500, v)); },
+    configurable: true,
+  });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [9000, 10] }),
+    /the group box did not accept the new position .*NOTHING was moved/s,
+  );
+  assert.equal(quad[0], 0, "the box is back at its original x");
+  assert.deepEqual(a.pos, [100, 100], "and the member is back too");
+});
+
+test("#408: move_nodes:false VERIFIES the box write instead of assuming it", () => {
+  const g = { id: 1, title: "Frozen", _bounding: Object.freeze([0, 0, 400, 400]) };
+  const graph = makeGraph({ nodes: [], groups: [g] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000], move_nodes: false }),
+    /the group box did not accept the new position/,
+  );
+  assert.deepEqual([...g._bounding], [0, 0, 400, 400]);
+});
+
+test("#408: when a child cannot be put back, the refusal says PARTIALLY moved, not 'nothing'", () => {
+  // This node accepts any position except its original one — so the forward move
+  // succeeds and the rollback cannot undo it. Announcing "nothing was moved"
+  // there would be the exact fabrication this whole path exists to prevent.
+  const oneWay = {
+    id: 7,
+    size: [60, 40],
+    boundingRect: [100, 70, 60, 70],
+    _p: [100, 100],
+    get pos() { return [...this._p]; },
+    set pos(v) {
+      if (Number(v[0]) === 100 && Number(v[1]) === 100) return; // refuses to go home
+      this._p = [Number(v[0]), Number(v[1])];
+    },
+  };
+  // A frozen sibling forces the refusal AFTER oneWay has already moved.
+  const stuckNode = { id: 8, size: [60, 40], boundingRect: [150, 120, 60, 70], get pos() { return Object.freeze([150, 150]); } };
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [oneWay, stuckNode], groups: [g] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
+    /The graph is PARTIALLY moved — 1 item\(s\) could NOT be put back \(node 7\)\. Press Ctrl\+Z/s,
+  );
+  assert.deepEqual(oneWay._p, [1100, 1100], "it really is still displaced — the message must not deny it");
+  assert.deepEqual(g._bounding, [0, 0, 400, 400], "the box itself never moved");
 });
 
 // ---- lib branches the handler tests above do not reach ---------------------

--- a/browser_tests/unit/move-group.test.mjs
+++ b/browser_tests/unit/move-group.test.mjs
@@ -24,6 +24,8 @@ import {
   moveReroutePoints,
   containsBounds,
   writePoint,
+  samePoint,
+  groupBoxIsAt,
 } from "../../web/js/lib/group-geometry.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
@@ -41,7 +43,14 @@ const summarizeGroupSrc = grab(/\nfunction summarizeGroup\(graph, g\) \{[\s\S]*?
 const moveGroupSrc = grab(/ {2}graph_move_group\(\{ group_id, pos, move_nodes \}\) \{[\s\S]*?\n {2}\},/, "graph_move_group");
 const moveGroupLabelSrc = grab(/ {4}case "graph_move_group": \{[\s\S]*?\n {4}\}/, 'the graph_move_group activity label');
 
-/** The real shipped handler, wired to the real shipped geometry lib. */
+/** The real shipped handler, wired to the real shipped geometry lib.
+ *
+ *  `"use strict"` is NOT decoration: comfyui-mcp-panel.js is an ES module, so the
+ *  shipped code runs strict, where a write to a frozen array or a setter-less
+ *  accessor THROWS instead of silently doing nothing. A `new Function` body is
+ *  sloppy by default, so without this the harness would exercise a more forgiving
+ *  language than the one the panel actually runs in — and every "unwritable
+ *  geometry" test below would be testing the wrong thing. */
 function realMoveGroup(graph) {
   const getGraphCtx = () => ({ graph });
   return new Function(
@@ -54,7 +63,9 @@ function realMoveGroup(graph) {
     "moveGroupMembers",
     "translateGroupBoxes",
     "moveReroutePoints",
-    `${resolveGroupSrc}
+    "groupBoxIsAt",
+    `"use strict";
+     ${resolveGroupSrc}
      ${setGroupBoundsSrc}
      ${summarizeGroupSrc}
      const executors = { ${moveGroupSrc} };
@@ -69,13 +80,15 @@ function realMoveGroup(graph) {
     moveGroupMembers,
     translateGroupBoxes,
     moveReroutePoints,
+    groupBoxIsAt,
   );
 }
 
 /** The real shipped activity-card label for a graph_move_group reply. */
 const realMoveGroupLabel = new Function(
   "r",
-  `switch ("graph_move_group") { ${moveGroupLabelSrc} }
+  `"use strict";
+   switch ("graph_move_group") { ${moveGroupLabelSrc} }
    return null;`,
 );
 
@@ -418,17 +431,69 @@ test("#408: a nested box that will not move aborts and rolls back the members", 
 });
 
 test("#408: a group box that refuses the write is a refusal, not a reported success", () => {
-  // _bounding is frozen AND there is no pos/size pair to fall back to, so
-  // setGroupBounds cannot put the box anywhere.
+  // _bounding is frozen, so setGroupBounds cannot put the box anywhere. Under the
+  // strict-mode semantics the shipped module actually runs under, that write
+  // THROWS — after the children have already moved. The throw must not escape
+  // past the rollback, or the graph is torn apart by an error that says nothing
+  // was moved.
   const g = { id: 1, title: "Frozen", _bounding: Object.freeze([0, 0, 400, 400]) };
   const a = node(7, [100, 100], [60, 40]);
-  const graph = makeGraph({ nodes: [a], groups: [g] });
+  const inner = group(2, [50, 50, 100, 100], "Inner");
+  const reroute = { id: 11, pos: [200, 200] };
+  const graph = makeGraph({ nodes: [a], groups: [g, inner], reroutes: [reroute] });
 
   assert.throws(
     () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
-    /the group box did not accept the new position .* NOTHING was moved/s,
+    // The parenthetical carries the THROWN write error. Its presence is also the
+    // proof that this harness compiled the handler strict, the way the shipped ES
+    // module runs it — in sloppy mode the same write would silently no-op and this
+    // path would be reached by luck rather than by the catch that handles it.
+    /the group box did not accept the new position[^(]*\(.+\)\. NOTHING was moved/s,
   );
   assert.deepEqual(a.pos, [100, 100], "the members must be put back when the box write fails");
+  assert.deepEqual([...a.boundingRect], [100, 70, 60, 70], "and their cached rects with them");
+  assert.deepEqual(inner._bounding, [50, 50, 100, 100], "the nested box must be put back too");
+  assert.deepEqual([reroute.pos[0], reroute.pos[1]], [200, 200], "and the reroute");
+  assert.deepEqual(g._bounding, [0, 0, 400, 400]);
+});
+
+test("#408: a child that lands SOMEWHERE ELSE is rolled back too, not just the ones that landed", () => {
+  // This build's pos setter snaps to a 25px grid, so the requested position is
+  // never reached and the node counts as stuck — but it HAS moved. An undo that
+  // only walked the successful moves would strand it there while the error says
+  // nothing moved.
+  const snapping = {
+    id: 7,
+    size: [60, 40],
+    boundingRect: [100, 70, 60, 70],
+    _p: [100, 100],
+    get pos() { return [...this._p]; },
+    set pos(v) { this._p = [Math.round(Number(v[0]) / 25) * 25, Math.round(Number(v[1]) / 25) * 25]; },
+  };
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [snapping], groups: [g] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1013, 1013] }),
+    /node 7.*NOTHING was moved/s,
+  );
+  assert.deepEqual(snapping._p, [100, 100], "the snapped node must be restored to its ORIGINAL position");
+  assert.deepEqual(g._bounding, [0, 0, 400, 400]);
+});
+
+test("#408: a snapping reroute is also restored exactly, not left where the engine put it", () => {
+  const snapping = {
+    id: 11,
+    _p: [100, 100],
+    get pos() { return [...this._p]; },
+    set pos(v) { this._p = [Math.round(Number(v[0]) / 25) * 25, Math.round(Number(v[1]) / 25) * 25]; },
+  };
+  const frozenNode = { id: 7, size: [60, 40], boundingRect: [50, 20, 60, 70], get pos() { return Object.freeze([50, 50]); } };
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [frozenNode], groups: [g], reroutes: [snapping] });
+
+  assert.throws(() => realMoveGroup(graph)({ group_id: 1, pos: [1013, 1013] }), /NOTHING was moved/);
+  assert.deepEqual(snapping._p, [100, 100], "restored to its original point, not to old+(-delta)");
 });
 
 // ---- lib branches the handler tests above do not reach ---------------------
@@ -451,10 +516,52 @@ test("writePoint reports the truth for every point shape", () => {
   const f32 = { get pos() { return f32backing; } };
   assert.equal(writePoint(f32, "pos", 1234.1, 5678.2), true);
   assert.notEqual(f32backing[0], 1234.1, "precondition: the read-back is genuinely not equal");
-  assert.ok(Math.abs(f32backing[0] - 1234.1) < 0.01, "but it is the same point");
+  assert.equal(f32backing[0], Math.fround(1234.1), "but it is exactly what Float32 storage can hold");
 
   const readOnly = { get pos() { return Object.freeze([1, 2]); } };
   assert.equal(writePoint(readOnly, "pos", 10, 20), false, "an unwritable point must report false");
+
+  // A build that SNAPS the write to a grid did not put the point where we asked.
+  // Accepting that would be reporting a move to coordinates the node is not at.
+  const snapping = {
+    _p: [0, 0],
+    get pos() { return [...this._p]; },
+    set pos(v) { this._p = [Math.round(v[0] / 25) * 25, Math.round(v[1] / 25) * 25]; },
+  };
+  assert.equal(writePoint(snapping, "pos", 113, 113), false, "a snapped write is not the write we asked for");
+});
+
+test("samePoint is exact unless the destination really is a Float32Array", () => {
+  assert.equal(samePoint(10, 10), true);
+  assert.equal(samePoint(1234.2, 1234.1), false, "0.1px of slack is already a different point");
+  assert.equal(
+    samePoint(Math.fround(1234.1), 1234.1),
+    false,
+    "Float32 rounding is only forgiven for a Float32 container, not by default",
+  );
+  assert.equal(samePoint(Math.fround(1234.1), 1234.1, true), true, "…and it IS forgiven for one");
+  // The failure mode a RELATIVE tolerance has: at a large coordinate it accepts a
+  // huge error, so a write that did nothing at all reads as a completed move.
+  assert.equal(samePoint(1e9, 1e9 + 1), false, "a no-op at a large coordinate is NOT a move");
+  assert.equal(samePoint(1e9, 1e9 + 1000), false);
+  assert.equal(samePoint(1e9, 1e9 + 1000, true), false, "not even for a Float32 container");
+  assert.equal(samePoint(Number.NaN, 10), false);
+  assert.equal(samePoint(10, Number.NaN), false);
+  assert.equal(samePoint(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY), false);
+});
+
+test("a Float32Array-backed group box (older LiteGraph) still moves and reports honestly", () => {
+  // _bounding is a Float32Array on those builds. An EXACT read-back would reject
+  // every write to it and turn every group move into a refusal.
+  const g = { id: 1, title: "F32", _bounding: new Float32Array([0, 0, 400, 400]) };
+  const a = node(7, [100, 100], [60, 40]);
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+
+  const out = realMoveGroup(graph)({ group_id: 1, pos: [1000.1, 2000.2] });
+
+  assert.equal(groupBoxIsAt(g, 1000.1, 2000.2), true, "the box is where Float32 storage can put it");
+  assert.equal(out.moved.nodes, 1);
+  assert.deepEqual(a.pos, [1100.1, 2100.2], "the member moved by the exact delta");
 });
 
 test("moveGroupMembers reports moved vs stuck instead of silently skipping", () => {

--- a/browser_tests/unit/move-group.test.mjs
+++ b/browser_tests/unit/move-group.test.mjs
@@ -506,6 +506,36 @@ test("#408: a snapping reroute is also restored exactly, not left where the engi
   assert.deepEqual(snapping._p, [100, 100], "restored to its original point, not to old+(-delta)");
 });
 
+test("#408: a node whose pos SETTER carries side effects has that setter run", () => {
+  // Current ComfyUI defines LGraphNode.pos as an accessor on the PROTOTYPE whose
+  // setter also commits the move to the frontend's layout store. Poking the
+  // underlying array directly would move the canvas and leave that store holding
+  // the old coordinates — a success report over a half-applied move.
+  const layoutStore = [];
+  const proto = {
+    get pos() { return this._geometry; },
+    set pos(v) {
+      this._geometry[0] = Number(v[0]);
+      this._geometry[1] = Number(v[1]);
+      layoutStore.push([Number(v[0]), Number(v[1])]);
+    },
+  };
+  const a = Object.assign(Object.create(proto), {
+    id: 7,
+    size: [100, 100],
+    boundingRect: [50, 20, 100, 130],
+    _geometry: new Float64Array([50, 50]),
+  });
+  const container = a.pos;
+  const graph = makeGraph({ nodes: [a], groups: [group(1, [0, 0, 200, 200])] });
+
+  const out = realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] });
+
+  assert.deepEqual(layoutStore, [[1050, 1050]], "the setter must have run exactly once, with the new position");
+  assert.equal(a.pos, container, "and it must not have replaced the geometry container");
+  assert.equal(out.moved.nodes, 1);
+});
+
 test("#408: a node whose pos is a plain PROPERTY holding a typed-array view keeps that view", () => {
   // The view is the node's live geometry container. Replacing it with a fresh
   // plain array would leave the node at the right coordinates while silently

--- a/browser_tests/unit/move-group.test.mjs
+++ b/browser_tests/unit/move-group.test.mjs
@@ -588,6 +588,93 @@ test("#408: when a child cannot be put back, the refusal says PARTIALLY moved, n
   assert.deepEqual(g._bounding, [0, 0, 400, 400], "the box itself never moved");
 });
 
+test("#408: a box write that lands the corner but mangles the SIZE is not a move", () => {
+  // This build accepts x/y but rewrites the width. Verifying only the top-left
+  // would call that a completed move and hand back a reshaped group.
+  const quad = [0, 0, 400, 400];
+  Object.defineProperty(quad, "2", {
+    get() { return this._w ?? 400; },
+    set() { this._w = 1; },
+    configurable: true,
+  });
+  const g = { id: 1, title: "Reshaper", _bounding: quad };
+  const a = node(7, [100, 100], [60, 40]);
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
+    /the group box did not accept the new position/,
+  );
+  assert.deepEqual(a.pos, [100, 100], "the member is put back");
+  assert.deepEqual([quad[0], quad[1]], [0, 0], "and the corner is put back");
+});
+
+test("#408: a NESTED box that would be reshaped by the move counts as stuck", () => {
+  // Same hazard one level down: translating a child box must not resize it. If
+  // the size does not survive the write, the child did not move — it mutated.
+  const innerQuad = [50, 50, 100, 100];
+  Object.defineProperty(innerQuad, "3", {
+    get() { return this._h ?? 100; },
+    set() { this._h = 5; },
+    configurable: true,
+  });
+  // Nudge the height through the setter the way a reshaping build would.
+  const inner = { id: 2, title: "Reshaping inner", _bounding: innerQuad };
+  const outer = group(1, [0, 0, 400, 400], "Outer");
+  const a = node(7, [200, 200], [60, 40]);
+  const graph = makeGraph({ nodes: [a], groups: [outer, inner] });
+  // placeGroupBox writes only x/y; make the x write corrupt the height, which is
+  // exactly the "landed the corner, changed the shape" case.
+  Object.defineProperty(innerQuad, "0", {
+    get() { return this._x ?? 50; },
+    set(v) { this._x = v; this._h = 5; },
+    configurable: true,
+  });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
+    /group 2.*(NOTHING was moved|PARTIALLY moved)/s,
+  );
+  assert.deepEqual(a.pos, [200, 200], "the member is put back");
+  assert.deepEqual(outer._bounding, [0, 0, 400, 400], "and the outer box never moved");
+});
+
+test("#408: a node that SNAPS on the way out keeps a cached rect at its REAL position", () => {
+  // The write misses its target (so the node is "stuck" and the move is refused)
+  // but the node HAS relocated, and it refuses to go home. Its cached rect must
+  // describe where it actually is — every membership read prefers that rect, so a
+  // stale one would report the node as still inside the group it has left.
+  const oneWaySnap = {
+    id: 7,
+    size: [60, 40],
+    boundingRect: [100, 70, 60, 70],
+    _p: [100, 100],
+    get pos() { return [...this._p]; },
+    set pos(v) {
+      const x = Math.round(Number(v[0]) / 25) * 25;
+      const y = Math.round(Number(v[1]) / 25) * 25;
+      if (x === 100 && y === 100) return; // refuses to go home
+      this._p = [x, y];
+    },
+  };
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [oneWaySnap], groups: [g] });
+
+  assert.throws(() => realMoveGroup(graph)({ group_id: 1, pos: [1013, 1013] }), /PARTIALLY moved/);
+
+  assert.deepEqual(oneWaySnap._p, [1125, 1125], "precondition: it really did relocate and could not return");
+  assert.deepEqual(
+    [...oneWaySnap.boundingRect],
+    [1125, 1095, 60, 70],
+    "the cached rect must have followed it, not stayed at the old spot",
+  );
+  assert.deepEqual(
+    groupMemberNodes(graph, g).map((n) => n.id),
+    [],
+    "and it must no longer read as a member of the group it left",
+  );
+});
+
 // ---- lib branches the handler tests above do not reach ---------------------
 
 test("writePoint reports the truth for every point shape", () => {

--- a/browser_tests/unit/move-group.test.mjs
+++ b/browser_tests/unit/move-group.test.mjs
@@ -1,0 +1,310 @@
+// #408: `panel_move_group` must move a group's BOX and everything the box
+// encloses — nodes, nested group boxes, reroute points — and must never report a
+// membership it computed from stale geometry. The box is not the membership.
+//
+// These tests extract the SHIPPED graph_move_group (plus the real resolveGroup /
+// setGroupBounds / summarizeGroup helpers) out of the panel source and run it
+// against LiteGraph-shaped doubles, so they verify the real implementation rather
+// than a copy of it. Deleting any of the behaviours under test turns one of these
+// red — each assertion is pinned to a specific line of the handler.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  groupMemberNodes,
+  syncGraphNodeAreas,
+  moveGroupMembers,
+  groupBoundsOf,
+  nestedGroupsOf,
+  translateGroupBox,
+  reroutesInside,
+  moveReroutePoints,
+  containsBounds,
+} from "../../web/js/lib/group-geometry.js";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8");
+
+const grab = (re, what) => {
+  const m = panelSrc.match(re);
+  assert.ok(m, `could not locate ${what} in panel source`);
+  return m[0];
+};
+
+const resolveGroupSrc = grab(/\nfunction resolveGroup\(graph, groupId\) \{[\s\S]*?\n\}/, "resolveGroup");
+const setGroupBoundsSrc = grab(/\nfunction setGroupBounds\(group, \[x, y, w, h\]\) \{[\s\S]*?\n\}/, "setGroupBounds");
+const summarizeGroupSrc = grab(/\nfunction summarizeGroup\(graph, g\) \{[\s\S]*?\n\}/, "summarizeGroup");
+const moveGroupSrc = grab(/ {2}graph_move_group\(\{ group_id, pos, move_nodes \}\) \{[\s\S]*?\n {2}\},/, "graph_move_group");
+const moveGroupLabelSrc = grab(/ {4}case "graph_move_group": \{[\s\S]*?\n {4}\}/, 'the graph_move_group activity label');
+
+/** The real shipped handler, wired to the real shipped geometry lib. */
+function realMoveGroup(graph) {
+  const getGraphCtx = () => ({ graph });
+  return new Function(
+    "getGraphCtx",
+    "groupBoundsOf",
+    "syncGraphNodeAreas",
+    "groupMemberNodes",
+    "nestedGroupsOf",
+    "reroutesInside",
+    "moveGroupMembers",
+    "translateGroupBox",
+    "moveReroutePoints",
+    `${resolveGroupSrc}
+     ${setGroupBoundsSrc}
+     ${summarizeGroupSrc}
+     const executors = { ${moveGroupSrc} };
+     return executors.graph_move_group;`,
+  )(
+    getGraphCtx,
+    groupBoundsOf,
+    syncGraphNodeAreas,
+    groupMemberNodes,
+    nestedGroupsOf,
+    reroutesInside,
+    moveGroupMembers,
+    translateGroupBox,
+    moveReroutePoints,
+  );
+}
+
+/** The real shipped activity-card label for a graph_move_group reply. */
+const realMoveGroupLabel = new Function(
+  "r",
+  `switch ("graph_move_group") { ${moveGroupLabelSrc} }
+   return null;`,
+);
+
+// ---- LiteGraph-shaped doubles ---------------------------------------------
+
+/** A node whose cached boundingRect is kept exactly where the caller puts it,
+ *  so "stale rect" scenarios are reproducible. `rect` defaults to the live
+ *  footprint (pos/size + title band), matching nodeFocusBounds' own fallback. */
+function node(id, pos, size = [100, 100], rect = null) {
+  return {
+    id,
+    pos: [...pos],
+    size: [...size],
+    boundingRect: rect ? [...rect] : [pos[0], pos[1] - 30, size[0], size[1] + 30],
+  };
+}
+
+function group(id, bounding, title = `G${id}`) {
+  return { id, title, _bounding: [...bounding], recomputeInsideNodes() {} };
+}
+
+function makeGraph({ nodes = [], groups = [], reroutes = null } = {}) {
+  return {
+    _nodes: nodes,
+    _groups: groups,
+    ...(reroutes ? { reroutes } : {}),
+    beforeChange() { this.beforeCount = (this.beforeCount ?? 0) + 1; },
+    afterChange() { this.afterCount = (this.afterCount ?? 0) + 1; },
+    setDirtyCanvas() { this.dirty = true; },
+  };
+}
+
+// ---------------------------------------------------------------------------
+
+test("#408: moving a group carries its NESTED group box, so its members stay grouped", () => {
+  const inner = group(2, [50, 50, 100, 100], "Inner");
+  const outer = group(1, [0, 0, 400, 400], "Outer");
+  const a = node(7, [70, 90], [60, 40]); // rect [70,60,60,70], centre (100,95) → inside both
+  const graph = makeGraph({ nodes: [a], groups: [outer, inner] });
+
+  assert.deepEqual(groupMemberNodes(graph, inner).map((n) => n.id), [7], "precondition: node 7 is in the inner group");
+
+  const out = realMoveGroup(graph)({ group_id: 1, pos: [100, 100], move_nodes: true });
+
+  assert.deepEqual(a.pos, [170, 190], "the member node moved with the outer box");
+  assert.deepEqual(inner._bounding, [150, 150, 100, 100], "the NESTED group box moved by the same delta");
+  // The point of the whole fix: the node that was grouped is STILL grouped.
+  assert.deepEqual(
+    groupMemberNodes(graph, inner).map((n) => n.id),
+    [7],
+    "node 7 must still be a member of the inner group after the outer group moved",
+  );
+  assert.equal(out.moved.groups, 1, "the reply reports the nested group it carried");
+  assert.equal(out.moved.nodes, 1);
+});
+
+test("#408: a group that is only OVERLAPPED (or exactly coincident) is NOT dragged along", () => {
+  const outer = group(1, [0, 0, 400, 400], "Outer");
+  const overlapping = group(2, [350, 350, 200, 200], "Neighbour"); // pokes outside → not a child
+  const coincident = group(3, [0, 0, 400, 400], "Twin"); // identical box → peer, not child
+  const graph = makeGraph({ nodes: [], groups: [outer, overlapping, coincident] });
+
+  const out = realMoveGroup(graph)({ group_id: 1, pos: [100, 100] });
+
+  assert.deepEqual(overlapping._bounding, [350, 350, 200, 200], "a partially overlapping group must not move");
+  assert.deepEqual(coincident._bounding, [0, 0, 400, 400], "an identically-bounded group is a peer, not a child");
+  assert.equal(out.moved.groups, 0);
+});
+
+test("#408: moving a group carries the reroute points inside its box and leaves the others", () => {
+  const g = group(1, [0, 0, 400, 400]);
+  const inside = { id: 11, pos: [100, 100] };
+  const outside = { id: 12, pos: [900, 900] };
+  const graph = makeGraph({
+    groups: [g],
+    reroutes: new Map([[11, inside], [12, outside]]),
+  });
+
+  const out = realMoveGroup(graph)({ group_id: 1, pos: [100, 100] });
+
+  assert.deepEqual([inside.pos[0], inside.pos[1]], [200, 200], "an enclosed reroute moved with the box");
+  assert.deepEqual([outside.pos[0], outside.pos[1]], [900, 900], "a reroute outside the box stayed put");
+  assert.equal(out.moved.reroutes, 1);
+});
+
+test("#408: a reroute whose pos is a COPY-returning getter is still moved (assignment fallback)", () => {
+  const g = group(1, [0, 0, 400, 400]);
+  const reroute = {
+    id: 11,
+    _p: [100, 100],
+    get pos() { return [...this._p]; }, // in-place writes are dropped
+    set pos(v) { this._p = [Number(v[0]), Number(v[1])]; },
+  };
+  const graph = makeGraph({ groups: [g], reroutes: [reroute] });
+
+  realMoveGroup(graph)({ group_id: 1, pos: [100, 100] });
+
+  assert.deepEqual(reroute._p, [200, 200], "the in-place write was dropped, so the setter must have been used");
+});
+
+test("#408: move_nodes:false reports the membership of the NEW box from LIVE geometry, not stale rects", () => {
+  const g = group(1, [0, 0, 200, 200]);
+  // Node 7 is really at [50,50] (centre inside the box) but its CACHED rect is
+  // left over from a position the panel never saw it leave (paste / load / drag).
+  const a = node(7, [50, 50], [100, 100], [1000, 1000, 100, 130]);
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+
+  const out = realMoveGroup(graph)({ group_id: 1, pos: [10, 10], move_nodes: false });
+
+  assert.deepEqual(a.pos, [50, 50], "move_nodes:false must not move the node");
+  assert.deepEqual(out.group.bounding, [10, 10, 200, 200], "the box moved");
+  assert.deepEqual(
+    out.group.node_ids,
+    [7],
+    "membership must be recomputed from the node's LIVE footprint, not its stale cached rect",
+  );
+  assert.equal(out.group.node_count, 1);
+  assert.deepEqual(out.moved, { nodes: 0, groups: 0, reroutes: 0 }, "box-only moves must report carrying nothing");
+});
+
+test("#408: move_nodes:false drops a node whose live position left the new box", () => {
+  const g = group(1, [0, 0, 200, 200]);
+  // Live pos is far away; the STALE rect still claims it is inside the box.
+  const a = node(7, [5000, 5000], [100, 100], [50, 20, 100, 130]);
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+
+  const out = realMoveGroup(graph)({ group_id: 1, pos: [0, 0], move_nodes: false });
+
+  assert.deepEqual(out.group.node_ids, [], "a node that has really moved out must not be reported as a member");
+});
+
+test("#408: a non-finite pos is refused LOUDLY instead of NaN-ing the whole group", () => {
+  const g = group(1, [0, 0, 200, 200]);
+  const a = node(7, [50, 50], [100, 100]);
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+  const move = realMoveGroup(graph);
+
+  for (const bad of [[Number.NaN, 0], [0, undefined], ["left", 10], [10], undefined, null, "10,10"]) {
+    assert.throws(() => move({ group_id: 1, pos: bad, move_nodes: true }), /pos must be \[x, y\] finite numbers/);
+  }
+  assert.deepEqual(a.pos, [50, 50], "no member position may be corrupted by a refused move");
+  assert.deepEqual(g._bounding, [0, 0, 200, 200], "the group box must be untouched by a refused move");
+  assert.equal(graph.beforeCount, undefined, "a refused move must not open an undo transaction");
+});
+
+test("#408: a group with unusable bounds is refused with a stated remedy, not moved to NaN", () => {
+  const broken = { id: 1, title: "Broken", _bounding: ["x", "y", "w", "h"] };
+  const graph = makeGraph({ groups: [broken] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [10, 10] }),
+    /no usable bounds .* panel_edit_group/s,
+  );
+});
+
+test("#408 regression: the members move with the box and the reply says so", () => {
+  const g = group(1, [0, 0, 300, 300]);
+  const a = node(7, [50, 50], [100, 100]);
+  const b = node(8, [150, 150], [100, 100]);
+  const away = node(9, [9000, 9000], [100, 100]);
+  const graph = makeGraph({ nodes: [a, b, away], groups: [g] });
+
+  const out = realMoveGroup(graph)({ group_id: 1, pos: [1000, 2000] });
+
+  assert.deepEqual(a.pos, [1050, 2050]);
+  assert.deepEqual(b.pos, [1150, 2150]);
+  assert.deepEqual(away.pos, [9000, 9000], "a node outside the box is not a member and must not move");
+  assert.deepEqual(out.group.node_ids, [7, 8], "membership at the new box is reported from the moved footprints");
+  assert.equal(out.moved.nodes, 2);
+  assert.equal(graph.beforeCount, 1, "the whole move is one undo transaction");
+  assert.equal(graph.afterCount, 1);
+});
+
+test("the activity card names what came with the box, and says so when nothing did", () => {
+  assert.match(
+    realMoveGroupLabel({ group: { id: 1, title: "Outer" }, moved: { nodes: 2, groups: 1, reroutes: 3 } }).text,
+    /with 2 nodes, 1 nested group, 3 reroutes/,
+  );
+  assert.match(
+    realMoveGroupLabel({ group: { id: 1, title: "Outer" }, moved: { nodes: 1, groups: 0, reroutes: 0 } }).text,
+    /with 1 node$/,
+  );
+  assert.match(
+    realMoveGroupLabel({ group: { id: 1, title: "Outer" }, moved: { nodes: 0, groups: 0, reroutes: 0 } }).text,
+    /box only/,
+  );
+});
+
+// ---- lib branches the handler tests above do not reach ---------------------
+
+test("containsBounds: strict containment, identical rects excluded (litegraph containsRect)", () => {
+  assert.equal(containsBounds([0, 0, 100, 100], [10, 10, 50, 50]), true);
+  assert.equal(containsBounds([0, 0, 100, 100], [0, 0, 100, 100]), false, "identical rects are peers");
+  assert.equal(containsBounds([0, 0, 100, 100], [0, 0, 100, 50]), true, "sharing an edge is still containment");
+  assert.equal(containsBounds([0, 0, 100, 100], [90, 90, 50, 50]), false, "overlap is not containment");
+  assert.equal(containsBounds(null, [0, 0, 1, 1]), false);
+  assert.equal(containsBounds([0, 0, 1, 1], null), false);
+});
+
+test("translateGroupBox falls back to pos when the build exposes no _bounding quad", () => {
+  const g = { pos: [10, 20], size: [100, 50] };
+  translateGroupBox(g, 5, -5);
+  assert.deepEqual(g.pos, [15, 15]);
+  assert.deepEqual(g.size, [100, 50], "a move must never change the box size");
+  assert.doesNotThrow(() => translateGroupBox(null, 1, 1));
+});
+
+test("reroutesInside reads the Map, array and plain-object shapes of graph.reroutes", () => {
+  const bounds = [0, 0, 100, 100];
+  const hit = { id: 1, pos: [50, 50] };
+  const miss = { id: 2, pos: [500, 500] };
+  assert.deepEqual(reroutesInside({ reroutes: new Map([[1, hit], [2, miss]]) }, bounds).map((r) => r.id), [1]);
+  assert.deepEqual(reroutesInside({ reroutes: [hit, miss] }, bounds).map((r) => r.id), [1]);
+  assert.deepEqual(reroutesInside({ reroutes: { a: hit, b: miss } }, bounds).map((r) => r.id), [1]);
+  assert.deepEqual(reroutesInside({}, bounds), [], "no reroutes on this build → nothing to move");
+  assert.deepEqual(reroutesInside({ reroutes: [{ id: 3 }, { id: 4, pos: [Number.NaN, 0] }] }, bounds), []);
+  assert.deepEqual(reroutesInside({ reroutes: [hit] }, null), []);
+});
+
+test("nestedGroupsOf tolerates a group with no usable bounds on either side", () => {
+  const outer = group(1, [0, 0, 400, 400]);
+  const junk = { id: 2, title: "junk", _bounding: ["a", "b", "c", "d"] };
+  const graph = makeGraph({ groups: [outer, junk] });
+  assert.deepEqual(nestedGroupsOf(graph, outer), []);
+  assert.deepEqual(nestedGroupsOf(graph, junk), [], "an unbounded group has no children");
+  assert.deepEqual(nestedGroupsOf(null, outer), []);
+});
+
+test("moveReroutePoints skips malformed points and never throws", () => {
+  const ok = { pos: [1, 2] };
+  assert.doesNotThrow(() => moveReroutePoints([ok, {}, { pos: [1] }, { pos: ["a", "b"] }, null], 10, 10));
+  assert.deepEqual(ok.pos, [11, 12]);
+  assert.doesNotThrow(() => moveReroutePoints(undefined, 1, 1));
+});

--- a/browser_tests/unit/move-group.test.mjs
+++ b/browser_tests/unit/move-group.test.mjs
@@ -43,6 +43,7 @@ const grab = (re, what) => {
 const resolveGroupSrc = grab(/\nfunction resolveGroup\(graph, groupId\) \{[\s\S]*?\n\}/, "resolveGroup");
 const setGroupBoundsSrc = grab(/\nfunction setGroupBounds\(group, \[x, y, w, h\]\) \{[\s\S]*?\n\}/, "setGroupBounds");
 const summarizeGroupSrc = grab(/\nfunction summarizeGroup\(graph, g\) \{[\s\S]*?\n\}/, "summarizeGroup");
+const preflightUndoSrc = grab(/\nfunction describePreflightUndo\(unrestored\) \{[\s\S]*?\n\}/, "describePreflightUndo");
 const moveGroupSrc = grab(/ {2}graph_move_group\(\{ group_id, pos, move_nodes \}\) \{[\s\S]*?\n {2}\},/, "graph_move_group");
 const moveGroupLabelSrc = grab(/ {4}case "graph_move_group": \{[\s\S]*?\n {4}\}/, 'the graph_move_group activity label');
 
@@ -72,6 +73,7 @@ function realMoveGroup(graph) {
      ${resolveGroupSrc}
      ${setGroupBoundsSrc}
      ${summarizeGroupSrc}
+     ${preflightUndoSrc}
      const executors = { ${moveGroupSrc} };
      return executors.graph_move_group;`,
   )(
@@ -997,6 +999,134 @@ test("#408: a node with NO cached rect and a hostile pos is caught by the readab
   assert.equal(graph.beforeCount, undefined);
 });
 
+// ---- the guards are themselves operations that can fail --------------------
+
+test("#408: a pre-flight refusal ROLLS BACK the rects it already reconciled", () => {
+  // The resync is a write. Node A's stale rect accepts the reconciliation, node
+  // B's rejects it — and the reply says NOTHING was moved. That claim is only
+  // true if A's cached geometry went back exactly as it was found.
+  const a = { id: 7, pos: [500, 500], size: [100, 100], boundingRect: [-9, -9, 1, 1] };
+  const b = { id: 8, pos: [10, 10], size: [100, 100], boundingRect: Object.freeze([-9, -9, 1, 1]) };
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [a, b], groups: [g] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
+    /node 8.*group membership cannot be determined.*NOTHING was moved/s,
+  );
+  assert.deepEqual(
+    [...a.boundingRect],
+    [-9, -9, 1, 1],
+    "the rect the pre-flight had already rewritten must be back — 'NOTHING was moved' has to be true",
+  );
+  assert.deepEqual(a.pos, [500, 500]);
+  assert.deepEqual(g._bounding, [0, 0, 400, 400]);
+});
+
+test("#408: when a reconciled rect CANNOT be put back, the refusal says so instead of 'NOTHING'", () => {
+  // A rect that accepts the forward reconciliation and then refuses the restore.
+  // Claiming "NOTHING was moved" over it would be the fabrication this whole
+  // path exists to prevent.
+  const live = [-9, -9, 1, 1];
+  // The pre-flight reads this rect twice (capture, then sync) and the undo reads
+  // it a third time; from then on it is unwritable.
+  let reads = 0;
+  const oneWay = {
+    id: 7,
+    pos: [500, 500],
+    size: [100, 100],
+    get boundingRect() {
+      reads += 1;
+      return reads > 2 ? Object.freeze([...live]) : live;
+    },
+  };
+  const blocker = { id: 8, pos: [10, 10], size: [100, 100], boundingRect: Object.freeze([-9, -9, 1, 1]) };
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [oneWay, blocker], groups: [g] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
+    /cached rect\(s\) could NOT be put back \(node 7\).*panel_query_graph/s,
+  );
+  assert.deepEqual(live, [500, 470, 100, 130], "it really is still holding the reconciled value");
+});
+
+test("#408: a summary that throws AFTER the move reports a COMPLETED move, not a failure", () => {
+  // Reporting happens after the last geometry write. Re-raising there would tell
+  // the caller a completed move failed — and an agent that retries would move the
+  // group twice.
+  const a = node(7, [50, 50], [60, 40]);
+  const g = group(1, [0, 0, 400, 400]);
+  let moved = false;
+  Object.defineProperty(g, "title", {
+    get() { if (moved) throw new TypeError("group detached during summary"); return "G1"; },
+    configurable: true,
+  });
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+
+  let out;
+  assert.doesNotThrow(() => {
+    moved = true;
+    out = realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] });
+  });
+  assert.deepEqual(a.pos, [1050, 1050], "the move really did complete");
+  assert.equal(out.moved.nodes, 1, "and the reply still reports what it carried");
+  assert.match(out.summary_unavailable, /move COMPLETED.*do NOT re-issue the move/s);
+  assert.equal(out.group, undefined, "no fabricated summary stands in for the one that failed");
+});
+
+test("#408: a throwing afterChange cannot turn a completed move into a raw failure", () => {
+  const a = node(7, [50, 50], [60, 40]);
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+  graph.afterChange = () => { throw new TypeError("undo stack detached"); };
+  graph.setDirtyCanvas = () => { throw new TypeError("no canvas"); };
+
+  let out;
+  assert.doesNotThrow(() => { out = realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }); });
+  assert.deepEqual(a.pos, [1050, 1050]);
+  assert.equal(out.moved.nodes, 1);
+});
+
+test("#408: a nested group with a MALFORMED _bounding but valid pos/size still moves", () => {
+  // The validity rule has to reach the WRITE, not just the read. Picking
+  // `_bounding` because it merely has length 4, then writing only x/y into it,
+  // leaves it malformed — the read falls back to the untouched pos/size and a
+  // movable nested group is reported as refusing to move.
+  const inner = {
+    id: 2,
+    title: "Legacy inner",
+    _bounding: ["x", "y", "w", "h"],
+    pos: [50, 50],
+    size: [100, 100],
+  };
+  const outer = group(1, [0, 0, 400, 400], "Outer");
+  const a = node(7, [200, 200], [60, 40]);
+  const graph = makeGraph({ nodes: [a], groups: [outer, inner] });
+
+  const out = realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] });
+
+  assert.deepEqual(inner.pos, [1050, 1050], "written through the container the read comes back from");
+  assert.deepEqual(inner.size, [100, 100], "and the size is untouched");
+  assert.equal(out.moved.groups, 1);
+});
+
+test("#408: a reroute whose move() is a THROWING getter is refused, not raised", () => {
+  // The refuse-by-inspection path is only as safe as inspection being safe:
+  // `typeof r.move` RUNS the getter.
+  const hostile = { id: 11, pos: [100, 100], get move() { throw new TypeError("gone"); } };
+  const a = node(7, [50, 50], [60, 40]);
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [a], groups: [g], reroutes: [hostile] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
+    /reroute 11.*does not let us determine without calling it/s,
+  );
+  assert.deepEqual(a.pos, [50, 50]);
+  assert.deepEqual([hostile.pos[0], hostile.pos[1]], [100, 100]);
+});
+
 // ---- lib branches the handler tests above do not reach ---------------------
 
 test("writePoint reports the truth for every point shape", () => {
@@ -1030,6 +1160,40 @@ test("writePoint reports the truth for every point shape", () => {
     set pos(v) { this._p = [Math.round(v[0] / 25) * 25, Math.round(v[1] / 25) * 25]; },
   };
   assert.equal(writePoint(snapping, "pos", 113, 113), false, "a snapped write is not the write we asked for");
+});
+
+test("writePoint never throws — not even for a container it cannot inspect or read", () => {
+  // hasSetter walks the prototype chain with getPrototypeOf/getOwnPropertyDescriptor,
+  // and BOTH throw on a revoked Proxy — as does reading the property itself. A
+  // write helper whose callers guard on its RETURN value must not raise instead.
+  const { proxy, revoke } = Proxy.revocable({ pos: [0, 0] }, {});
+  revoke();
+  let result;
+  assert.doesNotThrow(() => { result = writePoint(proxy, "pos", 10, 20); });
+  assert.equal(result, false, "and it reports the honest verdict: the write did not land");
+
+  const hostile = { get pos() { throw new TypeError("disposed"); } };
+  assert.doesNotThrow(() => { result = writePoint(hostile, "pos", 10, 20); });
+  assert.equal(result, false);
+});
+
+test("the caught-throw net must never claim 'NOTHING was moved'", () => {
+  // This path is unreachable while the movers are total (each contains per item
+  // and always returns its undo), so no fixture can drive it — but if it ever
+  // fires it CANNOT have undone the mover that raised, because that mover never
+  // handed back its undo. A net that asserts a restoration it could not have made
+  // is worse than no net, so the claim is pinned here at the source level.
+  const netBlock = panelSrc.match(
+    /catch \(error\) \{\s*const unrestored = \[[\s\S]*?raised "\$\{error\?\.message \?\? error\}" partway through the move[\s\S]*?\);\s*\}/,
+  );
+  assert.ok(netBlock, "could not locate the mutation-phase catch in panel source");
+  assert.doesNotMatch(
+    netBlock[0],
+    /NOTHING was moved/,
+    "the one path that cannot verify a rollback must not assert one",
+  );
+  assert.match(netBlock[0], /UNKNOWN/, "it must say the state is unknown");
+  assert.match(netBlock[0], /PARTIALLY moved/, "and that the graph may be partially moved");
 });
 
 test("samePoint is exact unless the destination really is a Float32Array", () => {

--- a/browser_tests/unit/move-group.test.mjs
+++ b/browser_tests/unit/move-group.test.mjs
@@ -19,9 +19,11 @@ import {
   groupBoundsOf,
   nestedGroupsOf,
   translateGroupBox,
+  translateGroupBoxes,
   reroutesInside,
   moveReroutePoints,
   containsBounds,
+  writePoint,
 } from "../../web/js/lib/group-geometry.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
@@ -50,7 +52,7 @@ function realMoveGroup(graph) {
     "nestedGroupsOf",
     "reroutesInside",
     "moveGroupMembers",
-    "translateGroupBox",
+    "translateGroupBoxes",
     "moveReroutePoints",
     `${resolveGroupSrc}
      ${setGroupBoundsSrc}
@@ -65,7 +67,7 @@ function realMoveGroup(graph) {
     nestedGroupsOf,
     reroutesInside,
     moveGroupMembers,
-    translateGroupBox,
+    translateGroupBoxes,
     moveReroutePoints,
   );
 }
@@ -262,7 +264,219 @@ test("the activity card names what came with the box, and says so when nothing d
   );
 });
 
+// ---- point shapes: the write must land on every frontend, or say it didn't --
+
+test("#408: a node whose pos is a TYPED-ARRAY VIEW into its boundingRect is moved", () => {
+  // Current ComfyUI frontends expose LGraphNode.pos as a Float64Array subarray of
+  // the node's bounding Rectangle — Array.isArray(pos) is FALSE. A member loop
+  // written for plain arrays skips every node on those builds: the box moves
+  // alone, which is the exact #408 report.
+  const backing = new Float64Array([50, 50]);
+  const a = {
+    id: 7,
+    size: [100, 100],
+    boundingRect: [50, 20, 100, 130],
+    get pos() { return backing.subarray(0, 2); },
+    set pos(v) { backing[0] = Number(v[0]); backing[1] = Number(v[1]); },
+  };
+  assert.equal(Array.isArray(a.pos), false, "precondition: this is exactly the shape a plain-array guard skips");
+  const graph = makeGraph({ nodes: [a], groups: [group(1, [0, 0, 200, 200])] });
+
+  const out = realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] });
+
+  assert.deepEqual([a.pos[0], a.pos[1]], [1050, 1050], "the typed-array-backed node moved with the box");
+  assert.equal(out.moved.nodes, 1);
+  assert.deepEqual(out.group.node_ids, [7], "and it is still a member at the new box");
+});
+
+test("#408: a typed-array pos with NO setter is moved in place (assignment would throw)", () => {
+  const backing = new Float64Array([50, 50]);
+  const a = { id: 7, size: [100, 100], boundingRect: [50, 20, 100, 130], get pos() { return backing; } };
+  const graph = makeGraph({ nodes: [a], groups: [group(1, [0, 0, 200, 200])] });
+
+  const out = realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] });
+
+  assert.deepEqual([...backing], [1050, 1050]);
+  assert.equal(out.moved.nodes, 1);
+});
+
+test("#408: a node whose pos getter returns a COPY is still moved (assignment path)", () => {
+  const a = {
+    id: 7,
+    size: [100, 100],
+    boundingRect: [50, 20, 100, 130],
+    _p: [50, 50],
+    get pos() { return [...this._p]; },
+    set pos(v) { this._p = [Number(v[0]), Number(v[1])]; },
+  };
+  const graph = makeGraph({ nodes: [a], groups: [group(1, [0, 0, 200, 200])] });
+
+  const out = realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] });
+
+  assert.deepEqual(a._p, [1050, 1050]);
+  assert.equal(out.moved.nodes, 1);
+});
+
+test("#408: a member that CANNOT be repositioned aborts the whole move and rolls it back", () => {
+  const outer = group(1, [0, 0, 400, 400], "Outer");
+  const inner = group(2, [50, 50, 100, 100], "Inner");
+  const movable = node(7, [200, 200], [60, 40]);
+  // A read-only point: assignment throws (strict mode) and the in-place write is
+  // rejected, so nothing can put this node anywhere.
+  const frozenPoint = Object.freeze([80, 100]);
+  const stuck = {
+    id: 8,
+    size: [60, 40],
+    boundingRect: [80, 70, 60, 70],
+    get pos() { return frozenPoint; },
+  };
+  const reroute = { id: 11, pos: [300, 300] };
+  const graph = makeGraph({
+    nodes: [movable, stuck],
+    groups: [outer, inner],
+    reroutes: new Map([[11, reroute]]),
+  });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
+    /refusing to move group 1: 1 enclosed item\(s\) would not accept a new position \(node 8\)\. NOTHING was moved/,
+  );
+
+  assert.deepEqual(outer._bounding, [0, 0, 400, 400], "the group box must be exactly where it was");
+  assert.deepEqual(inner._bounding, [50, 50, 100, 100], "the nested box must be rolled back");
+  assert.deepEqual(movable.pos, [200, 200], "the movable member must be rolled back");
+  assert.deepEqual([...movable.boundingRect], [200, 170, 60, 70], "its cached rect must be rolled back too");
+  assert.deepEqual([reroute.pos[0], reroute.pos[1]], [300, 300], "the reroute must be rolled back");
+  assert.deepEqual([...frozenPoint], [80, 100], "the stuck node never moved");
+});
+
+test("#408: a reroute is moved through the engine's own move() when the build has one", () => {
+  const calls = [];
+  const reroute = {
+    id: 11,
+    pos: [100, 100],
+    move(dx, dy) { calls.push([dx, dy]); this.pos = [this.pos[0] + dx, this.pos[1] + dy]; },
+  };
+  const graph = makeGraph({ groups: [group(1, [0, 0, 400, 400])], reroutes: [reroute] });
+
+  const out = realMoveGroup(graph)({ group_id: 1, pos: [100, 100] });
+
+  assert.deepEqual(calls, [[100, 100]], "the engine primitive was used, so the layout store sees the change");
+  assert.deepEqual([reroute.pos[0], reroute.pos[1]], [200, 200]);
+  assert.equal(out.moved.reroutes, 1);
+});
+
+test("#408: a build whose reroute move() has the wrong signature is corrected, not trusted", () => {
+  // move(x, y) treated as ABSOLUTE by this build. The verified fallback must put
+  // the point where the delta says, not where the primitive left it.
+  const reroute = { id: 11, pos: [100, 100], move(x, y) { this.pos = [x, y]; } };
+  const graph = makeGraph({ groups: [group(1, [0, 0, 400, 400])], reroutes: [reroute] });
+
+  const out = realMoveGroup(graph)({ group_id: 1, pos: [100, 100] });
+
+  assert.deepEqual([reroute.pos[0], reroute.pos[1]], [200, 200], "corrected to old + delta");
+  assert.equal(out.moved.reroutes, 1);
+});
+
+test("#408: a reroute whose move() throws does not abort the move; the direct write still lands", () => {
+  const reroute = { id: 11, pos: [100, 100], move() { throw new Error("not on this build"); } };
+  const graph = makeGraph({ groups: [group(1, [0, 0, 400, 400])], reroutes: [reroute] });
+
+  const out = realMoveGroup(graph)({ group_id: 1, pos: [100, 100] });
+
+  assert.deepEqual([reroute.pos[0], reroute.pos[1]], [200, 200]);
+  assert.equal(out.moved.reroutes, 1);
+});
+
+test("#408: a FROZEN reroute point aborts and rolls back rather than half-moving the group", () => {
+  const g = group(1, [0, 0, 400, 400]);
+  const a = node(7, [100, 100], [60, 40]);
+  const frozen = Object.freeze([200, 200]);
+  const reroute = { id: 11, get pos() { return frozen; } };
+  const graph = makeGraph({ nodes: [a], groups: [g], reroutes: [reroute] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
+    /reroute 11.*NOTHING was moved/s,
+  );
+  assert.deepEqual(a.pos, [100, 100]);
+  assert.deepEqual(g._bounding, [0, 0, 400, 400]);
+});
+
+test("#408: a nested box that will not move aborts and rolls back the members", () => {
+  const outer = group(1, [0, 0, 400, 400], "Outer");
+  const inner = { id: 2, title: "Frozen inner", _bounding: Object.freeze([50, 50, 100, 100]) };
+  const a = node(7, [200, 200], [60, 40]);
+  const graph = makeGraph({ nodes: [a], groups: [outer, inner] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
+    /group 2.*NOTHING was moved/s,
+  );
+  assert.deepEqual(a.pos, [200, 200], "the member must be back where it started");
+  assert.deepEqual(outer._bounding, [0, 0, 400, 400]);
+});
+
+test("#408: a group box that refuses the write is a refusal, not a reported success", () => {
+  // _bounding is frozen AND there is no pos/size pair to fall back to, so
+  // setGroupBounds cannot put the box anywhere.
+  const g = { id: 1, title: "Frozen", _bounding: Object.freeze([0, 0, 400, 400]) };
+  const a = node(7, [100, 100], [60, 40]);
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
+    /the group box did not accept the new position .* NOTHING was moved/s,
+  );
+  assert.deepEqual(a.pos, [100, 100], "the members must be put back when the box write fails");
+});
+
 // ---- lib branches the handler tests above do not reach ---------------------
+
+test("writePoint reports the truth for every point shape", () => {
+  const plain = { pos: [1, 2] };
+  assert.equal(writePoint(plain, "pos", 10, 20), true);
+  assert.deepEqual([plain.pos[0], plain.pos[1]], [10, 20]);
+
+  const typed = { pos: new Float64Array([1, 2]) };
+  assert.equal(writePoint(typed, "pos", 10, 20), true);
+  assert.deepEqual([typed.pos[0], typed.pos[1]], [10, 20]);
+
+  // A Float32-backed point (older LiteGraph) cannot store an arbitrary double
+  // exactly, so the value read back differs from the value written. A strict
+  // read-back would call this perfectly good write a FAILURE — and since an
+  // unmovable child now aborts the whole group move, that would turn every group
+  // move on those builds into a refusal.
+  const f32backing = new Float32Array([0, 0]);
+  const f32 = { get pos() { return f32backing; } };
+  assert.equal(writePoint(f32, "pos", 1234.1, 5678.2), true);
+  assert.notEqual(f32backing[0], 1234.1, "precondition: the read-back is genuinely not equal");
+  assert.ok(Math.abs(f32backing[0] - 1234.1) < 0.01, "but it is the same point");
+
+  const readOnly = { get pos() { return Object.freeze([1, 2]); } };
+  assert.equal(writePoint(readOnly, "pos", 10, 20), false, "an unwritable point must report false");
+});
+
+test("moveGroupMembers reports moved vs stuck instead of silently skipping", () => {
+  const ok = { id: 1, pos: [10, 10], size: [200, 100] };
+  const noPos = { id: 2 };
+  const res = moveGroupMembers([ok, null, noPos, { id: 3, pos: null }], 5, 7);
+  assert.deepEqual(ok.pos, [15, 17]);
+  assert.deepEqual(res.moved.map((n) => n.id), [1]);
+  assert.deepEqual(res.stuck.map((n) => n.id), [2, 3], "an unmovable member is reported, never dropped silently");
+  assert.doesNotThrow(() => moveGroupMembers(null, 1, 1));
+});
+
+test("translateGroupBoxes reports a box that would not move", () => {
+  const ok = group(1, [0, 0, 100, 100]);
+  const frozen = { id: 2, _bounding: Object.freeze([0, 0, 100, 100]) };
+  const res = translateGroupBoxes([ok, frozen], 10, 10);
+  assert.deepEqual(ok._bounding, [10, 10, 100, 100]);
+  assert.deepEqual(res.moved.map((g) => g.id), [1]);
+  assert.deepEqual(res.stuck.map((g) => g.id), [2]);
+  assert.equal(translateGroupBox({ nonsense: true }, 1, 1), false, "a group with no bounds cannot be moved");
+});
+
 
 test("containsBounds: strict containment, identical rects excluded (litegraph containsRect)", () => {
   assert.equal(containsBounds([0, 0, 100, 100], [10, 10, 50, 50]), true);

--- a/browser_tests/unit/move-group.test.mjs
+++ b/browser_tests/unit/move-group.test.mjs
@@ -27,6 +27,9 @@ import {
   samePoint,
   groupBoxIsAt,
   rerouteWriteIsSound,
+  describeItems,
+  describeThrown,
+  describeItem,
   syncNodeArea,
   refreshNodeArea,
 } from "../../web/js/lib/group-geometry.js";
@@ -69,6 +72,8 @@ function realMoveGroup(graph) {
     "moveReroutePoints",
     "rerouteWriteIsSound",
     "groupBoxIsAt",
+    "describeItems",
+    "describeThrown",
     `"use strict";
      ${resolveGroupSrc}
      ${setGroupBoundsSrc}
@@ -88,6 +93,8 @@ function realMoveGroup(graph) {
     moveReroutePoints,
     rerouteWriteIsSound,
     groupBoxIsAt,
+    describeItems,
+    describeThrown,
   );
 }
 
@@ -1127,7 +1134,240 @@ test("#408: a reroute whose move() is a THROWING getter is refused, not raised",
   assert.deepEqual([hostile.pos[0], hostile.pos[1]], [100, 100]);
 });
 
+// ---- roll back FIRST, format SECOND ----------------------------------------
+// Every one of these puts a THROWING `id`/`title`/`message` on an item that the
+// refusal path wants to NAME. Ids and titles exist only for display; nothing
+// about restoring geometry needs them, so a message assembled over a dirty graph
+// must never be what aborts the rollback.
+
+/** A node whose geometry is perfectly ordinary but whose `id` cannot be read. */
+function unnameableNode(pos, size, rect) {
+  return {
+    get id() { throw new TypeError("id is a revoked proxy"); },
+    pos: [...pos],
+    size: [...size],
+    boundingRect: [...rect],
+  };
+}
+
+test("#408 P0: a pre-flight refusal rolls back BEFORE naming the node that failed", () => {
+  // A writable stale node A, then a frozen node B whose `id` getter throws.
+  // Formatting B's name first would leave A's rect reconciled and emit a raw
+  // TypeError instead of the refusal this path promises.
+  const a = { id: 7, pos: [500, 500], size: [100, 100], boundingRect: [-9, -9, 1, 1] };
+  const b = {
+    get id() { throw new TypeError("id is a revoked proxy"); },
+    pos: [10, 10],
+    size: [100, 100],
+    boundingRect: Object.freeze([-9, -9, 1, 1]),
+  };
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [a, b], groups: [g] });
+
+  let err = null;
+  try {
+    realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] });
+  } catch (error) {
+    err = error;
+  }
+  assert.ok(err, "the move must be refused");
+  assert.match(err.message, /refusing to move group 1/, "a stated refusal, not a raw TypeError");
+  assert.match(err.message, /node unnamed/, "the unreadable id degrades to a placeholder");
+  assert.match(err.message, /NOTHING was moved/);
+  assert.deepEqual(
+    [...a.boundingRect],
+    [-9, -9, 1, 1],
+    "and the rect the pre-flight had reconciled is back — the claim has to be true",
+  );
+});
+
+test("#408 P0: the mutation-phase refusal rolls back BEFORE naming the stuck member", () => {
+  // This member's setter CLAMPS (so it lands elsewhere and counts as stuck) and
+  // its `id` throws. Building the name first left it displaced and threw raw.
+  const clamped = {
+    get id() { throw new TypeError("id is a revoked proxy"); },
+    _p: [50, 50],
+    size: [60, 40],
+    boundingRect: [50, 20, 60, 70],
+    get pos() { return [...this._p]; },
+    set pos(v) { this._p = [Math.min(Number(v[0]), 200), Math.min(Number(v[1]), 200)]; },
+  };
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [clamped], groups: [g] });
+
+  let err = null;
+  try {
+    realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] });
+  } catch (error) {
+    err = error;
+  }
+  assert.ok(err);
+  assert.match(err.message, /would not accept a new position \(node unnamed\)/);
+  assert.match(err.message, /NOTHING was moved/);
+  assert.deepEqual(clamped._p, [50, 50], "the clamped member is back where it started");
+  assert.deepEqual(g._bounding, [0, 0, 400, 400]);
+});
+
+test("#408 P0: an UNRESTORABLE item with an unreadable id is named after the rollback, not during it", () => {
+  // The rollback must deal in items, never in strings. This member accepts the
+  // forward move and refuses to go home, so it lands in the UNRESTORED list — and
+  // its `id` throws. Formatting names while walking the rollback would abort the
+  // rollback itself, halfway through putting the rest of the group back.
+  const oneWay = {
+    get id() { throw new TypeError("id is a revoked proxy"); },
+    _p: [50, 50],
+    size: [60, 40],
+    boundingRect: [50, 20, 60, 70],
+    get pos() { return [...this._p]; },
+    set pos(v) {
+      if (Number(v[0]) === 50 && Number(v[1]) === 50) return; // refuses to go home
+      this._p = [Number(v[0]), Number(v[1])];
+    },
+  };
+  // A frozen sibling forces the refusal AFTER oneWay has already moved.
+  const blocker = { id: 8, size: [60, 40], boundingRect: [150, 120, 60, 70], get pos() { return Object.freeze([150, 150]); } };
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [oneWay, blocker], groups: [g] });
+
+  let err = null;
+  try {
+    realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] });
+  } catch (error) {
+    err = error;
+  }
+  assert.ok(err);
+  assert.match(err.message, /PARTIALLY moved — 1 item\(s\) could NOT be put back \(node unnamed\)/);
+  assert.deepEqual(g._bounding, [0, 0, 400, 400], "and the box the rollback also had to restore is back");
+});
+
+test("#408 P0: the box-write refusal names nothing until the children are back", () => {
+  const unnameable = unnameableNode([50, 50], [60, 40], [50, 20, 60, 70]);
+  const g = { id: 1, get title() { throw new TypeError("title is a revoked proxy"); }, _bounding: Object.freeze([0, 0, 400, 400]) };
+  const graph = makeGraph({ nodes: [unnameable], groups: [g] });
+
+  let err = null;
+  try {
+    realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] });
+  } catch (error) {
+    err = error;
+  }
+  assert.ok(err);
+  assert.match(err.message, /the group box did not accept the new position/);
+  assert.deepEqual(unnameable.pos, [50, 50], "the member is back");
+});
+
+test("#408 P0 (the nastiest): a summary error whose OWN message throws still reports a COMPLETED move", () => {
+  // The error path of the error path. summarizeGroup raises because `title`
+  // throws; the resulting error's `message` getter throws too. Formatting the
+  // fallback used to raise from inside the catch, so the caller saw a raw failure
+  // for a move that COMPLETED — and re-issued it. That double move is precisely
+  // what summary_unavailable exists to prevent.
+  const hostileError = {
+    get message() { throw new TypeError("message is a revoked proxy"); },
+    get name() { throw new TypeError("name is a revoked proxy"); },
+    toString() { throw new TypeError("toString is a revoked proxy"); },
+    [Symbol.toPrimitive]() { throw new TypeError("coercion is a revoked proxy"); },
+  };
+  const a = node(7, [50, 50], [60, 40]);
+  let movedYet = false;
+  const g = {
+    id: 1,
+    _bounding: [0, 0, 400, 400],
+    recomputeInsideNodes() {},
+    get title() { if (movedYet) throw hostileError; return "G1"; },
+  };
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+
+  let out;
+  assert.doesNotThrow(() => {
+    movedYet = true;
+    out = realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] });
+  }, "the completed move must not surface as a failure");
+
+  assert.deepEqual(a.pos, [1050, 1050], "the move really did complete");
+  assert.deepEqual(out.moved, { nodes: 1, groups: 0, reroutes: 0 }, "the caller still gets the counts");
+  assert.match(out.summary_unavailable, /move COMPLETED/);
+  assert.match(out.summary_unavailable, /do NOT re-issue the move/, "and the do-not-re-issue signal survives");
+  assert.match(out.summary_unavailable, /could not be read/, "with an honest stand-in for the unreadable cause");
+});
+
+test("#408 P0: a beforeChange that throws rolls back the pre-flight's writes", () => {
+  const a = { id: 7, pos: [500, 500], size: [100, 100], boundingRect: [-9, -9, 1, 1] };
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+  graph.beforeChange = () => { throw new TypeError("undo stack detached"); };
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
+    /opening the undo transaction.*NOTHING was moved/s,
+  );
+  assert.deepEqual([...a.boundingRect], [-9, -9, 1, 1], "the reconciled rect is back");
+  assert.deepEqual(a.pos, [500, 500]);
+  assert.deepEqual(g._bounding, [0, 0, 400, 400]);
+});
+
+test("#408 P0: a node list that dies MID-WALK still yields a rollback, not a raw throw", () => {
+  // Containing per item is not enough while the TRAVERSAL can throw: the walk can
+  // die fetching the next entry after earlier rects are already reconciled, and a
+  // sync that threw there would never return the undo those writes need.
+  const a = { id: 7, pos: [500, 500], size: [100, 100], boundingRect: [-9, -9, 1, 1] };
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [], groups: [g] });
+  graph._nodes = {
+    [Symbol.iterator]() {
+      let i = 0;
+      return {
+        next() {
+          i += 1;
+          if (i === 1) return { value: a, done: false };
+          throw new TypeError("node list detached mid-walk");
+        },
+      };
+    },
+  };
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
+    /could not be walked to the end.*NOTHING was moved/s,
+  );
+  assert.deepEqual(
+    [...a.boundingRect],
+    [-9, -9, 1, 1],
+    "the rect reconciled before the walk died is back",
+  );
+  assert.deepEqual(g._bounding, [0, 0, 400, 400]);
+});
+
 // ---- lib branches the handler tests above do not reach ---------------------
+
+test("describeItem / describeItems never throw, and degrade to a placeholder", () => {
+  assert.equal(describeItem("node", { id: 7 }), "node 7");
+  assert.equal(describeItem("node", {}), "node ?", "a missing id is not an error");
+  assert.equal(describeItem("node", null), "node ?");
+  assert.equal(describeItem("node", { get id() { throw new TypeError("gone"); } }), "node unnamed");
+  assert.equal(
+    describeItem("node", { id: { toString() { throw new TypeError("gone"); } } }),
+    "node unnamed",
+    "even the String() coercion is contained",
+  );
+
+  const many = Array.from({ length: 8 }, (_, i) => ["node", { id: i }]);
+  assert.equal(describeItems(many), "node 0, node 1, node 2, node 3, node 4, …");
+  assert.equal(describeItems([]), "");
+  assert.doesNotThrow(() => describeItems([["node", { get id() { throw new Error("x"); } }]]));
+});
+
+test("describeThrown survives an error whose message AND coercion both throw", () => {
+  assert.equal(describeThrown(new Error("plain")), "plain");
+  assert.equal(describeThrown("a string"), "a string");
+  assert.equal(describeThrown({ message: 42 }), "[object Object]", "a non-string message falls back to coercion");
+  const hostile = {
+    get message() { throw new TypeError("gone"); },
+    toString() { throw new TypeError("gone"); },
+    [Symbol.toPrimitive]() { throw new TypeError("gone"); },
+  };
+  assert.equal(describeThrown(hostile), "an error whose message could not be read");
+});
 
 test("writePoint reports the truth for every point shape", () => {
   const plain = { pos: [1, 2] };
@@ -1209,7 +1449,7 @@ test("the caught-throw net must never claim 'NOTHING was moved'", () => {
   // handed back its undo. A net that asserts a restoration it could not have made
   // is worse than no net, so the claim is pinned here at the source level.
   const netBlock = panelSrc.match(
-    /catch \(error\) \{\s*const unrestored = \[[\s\S]*?raised "\$\{error\?\.message \?\? error\}" partway through the move[\s\S]*?\);\s*\}/,
+    /catch \(error\) \{\s*const unrestored = \[[\s\S]*?partway through the move[\s\S]*?\);\s*\}/,
   );
   assert.ok(netBlock, "could not locate the mutation-phase catch in panel source");
   assert.doesNotMatch(

--- a/browser_tests/unit/move-group.test.mjs
+++ b/browser_tests/unit/move-group.test.mjs
@@ -793,6 +793,28 @@ test("translateGroupBoxes reports a box that would not move", () => {
   assert.equal(translateGroupBox({ nonsense: true }, 1, 1), false, "a group with no bounds cannot be moved");
 });
 
+test("translateGroupBoxes.undo restores the SIZE too, not just the corner", () => {
+  // A build that reshapes on reposition: putting only the corner back would leave
+  // the box the wrong shape while the undo reported success.
+  const quad = [0, 0, 100, 100];
+  Object.defineProperty(quad, "0", {
+    get() { return this._x ?? 0; },
+    set(v) { this._x = v; this._h = 5; },
+    configurable: true,
+  });
+  Object.defineProperty(quad, "3", {
+    get() { return this._h ?? 100; },
+    set(v) { this._h = v; },
+    configurable: true,
+  });
+  const g = { id: 1, _bounding: quad };
+
+  const res = translateGroupBoxes([g], 10, 10);
+  assert.deepEqual(res.stuck.map((x) => x.id), [1], "reshaping the box is not moving it");
+  assert.deepEqual(res.undo(), [], "and the undo puts the whole quad back");
+  assert.deepEqual([quad[0], quad[1], quad[2], quad[3]], [0, 0, 100, 100]);
+});
+
 
 test("containsBounds: strict containment, identical rects excluded (litegraph containsRect)", () => {
   assert.equal(containsBounds([0, 0, 100, 100], [10, 10, 50, 50]), true);

--- a/browser_tests/unit/move-group.test.mjs
+++ b/browser_tests/unit/move-group.test.mjs
@@ -74,6 +74,7 @@ function realMoveGroup(graph) {
     "groupBoxIsAt",
     "describeItems",
     "describeThrown",
+    "syncNodeArea",
     `"use strict";
      ${resolveGroupSrc}
      ${setGroupBoundsSrc}
@@ -95,6 +96,7 @@ function realMoveGroup(graph) {
     groupBoxIsAt,
     describeItems,
     describeThrown,
+    syncNodeArea,
   );
 }
 
@@ -1338,7 +1340,163 @@ test("#408 P0: a node list that dies MID-WALK still yields a rollback, not a raw
   assert.deepEqual(g._bounding, [0, 0, 400, 400]);
 });
 
+// ---- the transaction ends at SERIALIZATION, not at the last write ----------
+
+test("#408 P0: a title whose toJSON throws still yields the completed counts, not a lost reply", () => {
+  // summarizeGroup returns `title` UNCOERCED, so a title with a throwing toJSON
+  // lets it succeed and then makes the bridge's JSON.stringify fail — after the
+  // move, outside the guard, where the caller receives no success response at all
+  // and re-issues. That is the double move summary_unavailable exists to prevent,
+  // surviving one layer further out than the guard reached.
+  const a = node(7, [50, 50], [60, 40]);
+  const hostileTitle = {
+    toJSON() { throw new TypeError("title toJSON is a revoked proxy"); },
+    toString() { return "Hostile"; },
+  };
+  const g = { id: 1, title: hostileTitle, _bounding: [0, 0, 400, 400], recomputeInsideNodes() {} };
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+
+  let out;
+  assert.doesNotThrow(() => { out = realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }); });
+
+  assert.deepEqual(a.pos, [1050, 1050], "the move really did complete");
+  assert.deepEqual(out.moved, { nodes: 1, groups: 0, reroutes: 0 }, "the caller still gets the counts");
+  assert.match(out.summary_unavailable, /move COMPLETED/);
+  assert.match(out.summary_unavailable, /do NOT re-issue the move/);
+  // And the whole reply must itself survive the boundary it is about to cross.
+  assert.doesNotThrow(() => JSON.stringify(out), "the reply the bridge will serialize must be serializable");
+});
+
+test("#408: an ordinary reply is plain JSON — round-tripped, not live engine references", () => {
+  const a = node(7, [50, 50], [60, 40]);
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+
+  const out = realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] });
+
+  assert.deepEqual(out.group.node_ids, [7]);
+  assert.deepEqual(out.moved, { nodes: 1, groups: 0, reroutes: 0 });
+  assert.deepEqual(JSON.parse(JSON.stringify(out)), out, "already plain");
+});
+
+// ---- both undos, and only what was recorded --------------------------------
+
+test("#408 P0: the mutation-phase rollback also undoes the PRE-FLIGHT's rect writes", () => {
+  // Node A carries a stale rect the pre-flight reconciles. Node B is frozen in
+  // place so the move is refused. Rolling back only the mutation phase left A's
+  // reconciled rect in place under a reply saying NOTHING was moved.
+  const a = { id: 7, pos: [100, 100], size: [60, 40], boundingRect: [-9, -9, 1, 1] };
+  const b = { id: 8, size: [60, 40], boundingRect: [150, 120, 60, 70], get pos() { return Object.freeze([150, 150]); } };
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [a, b], groups: [g] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
+    /node 8.*NOTHING was moved/s,
+  );
+  assert.deepEqual(a.pos, [100, 100], "the member is back");
+  assert.deepEqual(
+    [...a.boundingRect],
+    [-9, -9, 1, 1],
+    "and the rect the PRE-FLIGHT reconciled is back too — there are two undos and this path owns both",
+  );
+});
+
+test("#408 P0: move_nodes:false undoes the pre-flight when its box write fails", () => {
+  const a = { id: 7, pos: [100, 100], size: [60, 40], boundingRect: [-9, -9, 1, 1] };
+  const g = { id: 1, title: "Frozen", _bounding: Object.freeze([0, 0, 400, 400]) };
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000], move_nodes: false }),
+    /the group box did not accept the new position.*NOTHING was moved/s,
+  );
+  assert.deepEqual([...a.boundingRect], [-9, -9, 1, 1], "the pre-flight's write is taken back");
+});
+
+test("#408 P0: a node whose rect SNAPSHOT throws is never written to", () => {
+  // You cannot undo what you never recorded. This rect's `[1]` getter throws once
+  // — while the snapshot is being taken — and then accepts every write. Syncing it
+  // anyway would reconcile it with no undo recorded, and a later refusal would say
+  // NOTHING was moved over a node it has no way to put back.
+  let reads = 0;
+  const values = [-9, -9, 1, 1];
+  const trapRect = {
+    length: 4,
+    get 0() { return values[0]; },
+    set 0(v) { values[0] = v; },
+    get 1() {
+      reads += 1;
+      if (reads === 1) throw new TypeError("rect read is a revoked proxy");
+      return values[1];
+    },
+    set 1(v) { values[1] = v; },
+    get 2() { return values[2]; },
+    set 2(v) { values[2] = v; },
+    get 3() { return values[3]; },
+    set 3(v) { values[3] = v; },
+  };
+  const a = { id: 7, pos: [100, 100], size: [60, 40], boundingRect: trapRect };
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+
+  assert.throws(
+    () => realMoveGroup(graph)({ group_id: 1, pos: [1000, 1000] }),
+    /node 7.*group membership cannot be determined.*NOTHING was moved/s,
+  );
+  assert.deepEqual(values, [-9, -9, 1, 1], "the rect it could not snapshot was never written");
+  assert.deepEqual(a.pos, [100, 100]);
+});
+
+test("#408 P0: the target coordinates are read ONCE, before the first write", () => {
+  // An array whose index 0 answers during validation and throws on a later read
+  // used to pass pre-flight, move the members, and then raise before writeBox —
+  // a new throwable operation performed after the first geometry write.
+  let reads = 0;
+  const hostilePos = [1000, 1000]; // a REAL array, so Array.isArray still holds
+  Object.defineProperty(hostilePos, "0", {
+    get() {
+      reads += 1;
+      if (reads > 1) throw new TypeError("pos read is a revoked proxy");
+      return 1000;
+    },
+    configurable: true,
+  });
+  const a = node(7, [50, 50], [60, 40]);
+  const g = group(1, [0, 0, 400, 400]);
+  const graph = makeGraph({ nodes: [a], groups: [g] });
+
+  const out = realMoveGroup(graph)({ group_id: 1, pos: hostilePos });
+
+  assert.equal(reads, 1, "exactly one read of the target, taken before anything moved");
+  assert.deepEqual(a.pos, [1050, 1050], "and the move completed from the value read then");
+  assert.equal(out.moved.nodes, 1);
+});
+
 // ---- lib branches the handler tests above do not reach ---------------------
+
+test("describeItem / describeItems are total where they are EXPORTED, not just in the happy path", () => {
+  // The contract says total. `kind` is coerced by the template, and describeItems
+  // calls slice / destructures entries / reads length — all on caller-supplied
+  // values, all outside the original guard. A totality claim that holds for most
+  // of a function is the class of comment this codebase keeps getting burned by.
+  const hostileKind = { toString() { throw new TypeError("gone"); }, [Symbol.toPrimitive]() { throw new TypeError("gone"); } };
+  let out;
+  assert.doesNotThrow(() => { out = describeItem(hostileKind, { id: 1 }); });
+  assert.equal(typeof out, "string");
+
+  const hostilePairs = {
+    get length() { throw new TypeError("gone"); },
+    [Symbol.iterator]() { return [["node", { id: 1 }]][Symbol.iterator](); },
+  };
+  assert.doesNotThrow(() => { out = describeItems(hostilePairs); });
+  assert.match(out, /node 1/);
+
+  const noIterator = { length: 3 };
+  assert.doesNotThrow(() => { out = describeItems(noIterator); });
+  assert.equal(typeof out, "string");
+  assert.doesNotThrow(() => describeItems(null));
+});
 
 test("describeItem / describeItems never throw, and degrade to a placeholder", () => {
   assert.equal(describeItem("node", { id: 7 }), "node 7");

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10084,7 +10084,11 @@ const GRAPH_TOOL_EXECUTORS = {
       } catch (error) {
         return error;
       }
-      return groupBoxIsAt(g, x, y) ? null : new Error("the write did not land");
+      // Verify the WHOLE quad, not just the corner: setGroupBounds assigns all
+      // four components, so a clamp or a mid-quad throw can land the corner while
+      // corrupting the size. b[2]/b[3] are the size the group had before this call
+      // — a move must not change it.
+      return groupBoxIsAt(g, x, y, b[2], b[3]) ? null : new Error("the write did not land");
     };
     // Put the box back at its ORIGINAL top-left, and report whether it is really
     // there. A thrown write is not by itself a failed restore — a frozen quad
@@ -10093,7 +10097,7 @@ const GRAPH_TOOL_EXECUTORS = {
     // Only the box's actual position decides.
     const restoreBox = () => {
       writeBox(b[0], b[1]);
-      return !groupBoxIsAt(g, b[0], b[1]);
+      return !groupBoxIsAt(g, b[0], b[1], b[2], b[3]);
     };
     graph.beforeChange();
     try {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10126,9 +10126,27 @@ const GRAPH_TOOL_EXECUTORS = {
     // inside the box now. Reimplementing only the node half moved the outer box and
     // its nodes but stranded every inner group box over the vacated space, so nodes
     // that looked grouped silently were not any more (#408).
-    const members = move_nodes !== false ? groupMemberNodes(graph, g) : [];
-    const nested = move_nodes !== false ? nestedGroupsOf(graph, g) : [];
-    const reroutes = move_nodes !== false ? reroutesInside(graph, b) : [];
+    let members = [];
+    let nested = [];
+    let reroutes = [];
+    try {
+      if (move_nodes !== false) {
+        members = groupMemberNodes(graph, g);
+        nested = nestedGroupsOf(graph, g);
+        reroutes = reroutesInside(graph, b);
+      }
+    } catch (error) {
+      // These are reads, and the only writes before them are the pre-flight's
+      // idempotent rect reconciliation — so no position has changed and nothing
+      // needs rolling back. Still, a throw here would reach the caller as a bare
+      // TypeError from a tool that promises a stated outcome, so it is turned into
+      // one. (Reachable only by an accessor that misbehaves inconsistently between
+      // the resync and this pass; the individual readers already return "unknown"
+      // rather than raising.)
+      throw new Error(
+        `refusing to move group ${group_id}: the frontend raised "${error?.message ?? error}" while reading what the group encloses, so its contents cannot be determined. NOTHING was moved. Reload the ComfyUI tab (panel_reload) and retry.`,
+      );
+    }
     // A reroute we cannot reposition SOUNDLY is decided here, by INSPECTION, and
     // never by invoking an API to see what it does. Refusing before beforeChange()
     // also means this call leaves no empty undo step behind.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10074,9 +10074,24 @@ const GRAPH_TOOL_EXECUTORS = {
     // box itself — an unrecoverable, invisible corruption of the user's layout
     // reported as a success. Every other geometry writer (graph_edit_node) already
     // validates; this one used to be the hole.
-    if (!Array.isArray(pos) || pos.length !== 2 || !pos.every((n) => Number.isFinite(Number(n)))) {
-      throw new Error("pos must be [x, y] finite numbers — pass the new top-left corner of the group box");
+    //
+    // Read the target coordinates EXACTLY ONCE, here, before anything is written.
+    // Re-reading `pos[0]` later is a new throwable operation performed after the
+    // first geometry write: an array whose index 0 returns 1000 during validation
+    // and throws on the second read would pass this check, move the members, and
+    // then raise before writeBox with nothing rolled back. Every later use is of
+    // these locals.
+    const badPos = new Error("pos must be [x, y] finite numbers — pass the new top-left corner of the group box");
+    if (!Array.isArray(pos) || pos.length !== 2) throw badPos;
+    let targetX;
+    let targetY;
+    try {
+      targetX = Number(pos[0]);
+      targetY = Number(pos[1]);
+    } catch {
+      throw badPos;
     }
+    if (!Number.isFinite(targetX) || !Number.isFinite(targetY)) throw badPos;
     // groupBoundsOf reads _bounding OR pos/size and returns null when neither is
     // usable. The old fallback invented [0, 0, 0, 0] in that case, which is not the
     // group's box — it silently relocated the group to the origin with a zero-size
@@ -10086,8 +10101,8 @@ const GRAPH_TOOL_EXECUTORS = {
     if (!b) {
       throw new Error(`group ${group_id} has no usable bounds on this frontend — re-read it via panel_query_graph, or set its box explicitly with panel_edit_group({bounds})`);
     }
-    const dx = Number(pos[0]) - b[0];
-    const dy = Number(pos[1]) - b[1];
+    const dx = targetX - b[0];
+    const dy = targetY - b[1];
     let movedNodes = 0;
     let movedGroups = 0;
     let movedReroutes = 0;
@@ -10233,6 +10248,8 @@ const GRAPH_TOOL_EXECUTORS = {
             ...rerouteMove.undo(),
             ...memberMove.undo(),
             ...(restoreBox() ? [g] : []),
+            // …and the PRE-FLIGHT's writes, which this path also owns.
+            ...resync.undo(),
           ];
           throw new Error(
             `refusing to move group ${group_id}: the frontend raised "${describeThrown(error)}" partway through the move. ` +
@@ -10259,12 +10276,29 @@ const GRAPH_TOOL_EXECUTORS = {
         // `id` — display-only, and exactly the accessor most likely to be a proxy
         // or a throwing getter — so a name assembled while the graph is still
         // dirty can abort the very rollback it is describing.
-        const rollback = () => [
-          ...nestedMove.undo().map((c) => ["group", c]),
-          ...rerouteMove.undo().map((r) => ["reroute", r]),
-          ...memberMove.undo().map((n) => ["node", n]),
-          ...(restoreBox() ? [["group", g]] : []),
-        ];
+        //
+        // There are TWO undos, and this path owns BOTH. The pre-flight's rect
+        // reconciliation happened before any of this, so its undo runs LAST —
+        // after the member restores, whose own rect refresh would otherwise
+        // overwrite it. Rolling back only the mutation phase and then reporting
+        // "NOTHING was moved" left every reconciled rect in place.
+        const rollback = () => {
+          const stillWrong = [
+            ...nestedMove.undo().map((c) => ["group", c]),
+            ...rerouteMove.undo().map((r) => ["reroute", r]),
+          ];
+          const strandedMembers = memberMove.undo();
+          stillWrong.push(...strandedMembers.map((n) => ["node", n]));
+          if (restoreBox()) stillWrong.push(["group", g]);
+          stillWrong.push(...resync.undo().map((n) => ["node", n]));
+          // A member that could NOT be put back is somewhere else now, and the
+          // pre-flight undo has just restored its cached rect to where it used to
+          // be — which would report it as still inside the group it has actually
+          // left. This path already admits the graph is partially moved; the rect
+          // must describe where the node really IS, not resurrect a stale claim.
+          for (const n of strandedMembers) syncNodeArea(n);
+          return stillWrong;
+        };
         // `describeReason` is a THUNK: it is invoked only after the rollback has
         // run and the graph is provably back. Roll back first, format second.
         const refuse = (describeReason) => {
@@ -10290,7 +10324,7 @@ const GRAPH_TOOL_EXECUTORS = {
         // The box write is the LAST thing that can fail. Its failure has to put the
         // children back too, or the group is left torn apart with an error saying
         // otherwise.
-        const boxError = writeBox(Number(pos[0]), Number(pos[1]));
+        const boxError = writeBox(targetX, targetY);
         if (boxError) {
           refuse(() => `the group box did not accept the new position on this frontend (${describeThrown(boxError)})`);
         }
@@ -10301,14 +10335,17 @@ const GRAPH_TOOL_EXECUTORS = {
         // Even the box-only move must be VERIFIED, not assumed: a clamping setter
         // or a proxy that ignores the write would otherwise return a confident
         // "moved the box to [x, y]" for a box that never left.
-        const boxError = writeBox(Number(pos[0]), Number(pos[1]));
+        const boxError = writeBox(targetX, targetY);
         if (boxError) {
-          const restoreFailed = restoreBox(); // rollback first…
+          // Rollback FIRST — and BOTH undos: the box, and the pre-flight's rect
+          // reconciliation, which this branch also performed.
+          const restoreFailed = restoreBox();
+          const unrestoredRects = resync.undo();
           throw new Error( // …then format
             `refusing to move group ${group_id}: the group box did not accept the new position on this frontend (${describeThrown(boxError)}). ` +
               (restoreFailed
                 ? `The box could NOT be put back at [${b[0]}, ${b[1]}] either — press Ctrl+Z on the canvas, or set it explicitly with panel_edit_group({bounds}).`
-                : "NOTHING was moved."),
+                : describePreflightUndo(unrestoredRects)),
           );
         }
         // NOTE: the resync that makes this branch's membership live already ran in
@@ -10330,12 +10367,11 @@ const GRAPH_TOOL_EXECUTORS = {
         /* the geometry is already written; the envelope is bookkeeping */
       }
     }
-    // ---- REPORTING (after the last write — it may not throw either) ----------
-    // The invariant is "after the first write, only complete or roll back", and
-    // reporting is after the first write. If summarizeGroup raises, the move HAS
+    // ---- REPORTING (still inside the transaction) ----------------------------
+    // The transaction ends when the reply is SERIALIZED and returned, not when the
+    // last geometry write completes. If summarizeGroup raises, the move HAS
     // happened: rolling back is wrong and re-raising is worse, because the caller
-    // would read a completed move as a failed one and retry it. Say what was done
-    // and that the summary is unavailable.
+    // would read a completed move as a failed one and retry it.
     try {
       graph.setDirtyCanvas(true, true);
     } catch {
@@ -10343,7 +10379,15 @@ const GRAPH_TOOL_EXECUTORS = {
     }
     const moved = { nodes: movedNodes, groups: movedGroups, reroutes: movedReroutes };
     try {
-      return { group: summarizeGroup(graph, g), moved };
+      // summarizeGroup returns the group's own `title`/`color`/`id` and its member
+      // ids UNCOERCED, so a title with a throwing `toJSON` lets it succeed here and
+      // then makes the BRIDGE's JSON.stringify fail — after the move, outside this
+      // guard, where the caller gets no success response at all and re-issues.
+      // Proving the payload survives serialization INSIDE the guard is what pulls
+      // that last step back inside the transaction; round-tripping it also hands
+      // back a plainly-serializable object rather than live engine references.
+      const group = JSON.parse(JSON.stringify(summarizeGroup(graph, g)));
+      return { group, moved };
     } catch (error) {
       // The error path OF THE ERROR PATH. `error.message` can itself throw — a
       // group with a throwing `title` produces exactly such an error — and a throw

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10124,20 +10124,29 @@ const GRAPH_TOOL_EXECUTORS = {
       // — a move must not change it.
       return groupBoxIsAt(g, x, y, b[2], b[3]) ? null : new Error("the write did not land");
     };
-    // Put the box back at its ORIGINAL top-left, and report whether it is really
-    // there. A thrown write is not by itself a failed restore — a frozen quad
-    // rejects the write but was never displaced in the first place, and calling
-    // that "could not be put back" would invent a partial move that never happened.
-    // Only the box's actual position decides.
+    // Put the box back at its ORIGINAL box, and report whether it is really there.
+    //
+    // Decided on STATE, never on intent. An earlier version gated this on a
+    // "we attempted a write" flag, but "did we try" is not "did it change": a
+    // setter that REJECTS its first assignment and CLAMPS a later one leaves the
+    // box untouched, sets the flag anyway, and the restore then moves a box no
+    // forward path had moved (0 → clamped to 50) — a refusal-time geometry
+    // mutation, which is the whole family of defect this handler exists to avoid.
+    //
+    // So: read where the box actually IS and write only if it differs from what we
+    // recorded. Same shape as the stranded-member rect — reconcile against reality
+    // rather than replay a classification of what we think happened — and robust
+    // to a setter that partially applied, which no attempt-flag could classify.
+    //
+    // A thrown write is also not by itself a failed restore: a frozen quad rejects
+    // the write but was never displaced, and calling that "could not be put back"
+    // would invent a partial move that never happened. Only the box's actual
+    // position decides.
     const restoreBox = () => {
+      if (groupBoxIsAt(g, b[0], b[1], b[2], b[3])) return false; // exactly as found
       writeBox(b[0], b[1]);
       return !groupBoxIsAt(g, b[0], b[1], b[2], b[3]);
     };
-    // Has any forward path written the box yet? Restoring a box nothing displaced
-    // is not a no-op: on an effectful or clamping setter the recovery write can
-    // create a displacement of its own. A rollback must not move what no forward
-    // path moved.
-    let boxWritten = false;
     // ---- PRE-FLIGHT (no mutations past this point until it is complete) ------
     // Everything this move needs to KNOW is established here, before the first
     // byte is written. After the first write the only permitted actions are
@@ -10268,7 +10277,7 @@ const GRAPH_TOOL_EXECUTORS = {
             ...nestedMove.undo(),
             ...rerouteMove.undo(),
             ...memberMove.undo(),
-            ...(boxWritten && restoreBox() ? [g] : []),
+            ...(restoreBox() ? [g] : []),
           ];
           syncGraphNodeAreas(graph);
           throw new Error(
@@ -10313,7 +10322,7 @@ const GRAPH_TOOL_EXECUTORS = {
           // refusal fires BEFORE the box write, and restoreBox() is itself a write:
           // on an effectful or clamping setter it would displace a box nothing had
           // displaced — a rollback moving something no forward path moved.
-          if (boxWritten && restoreBox()) stillWrong.push(["group", g]);
+          if (restoreBox()) stillWrong.push(["group", g]);
           stillWrong.push(...resync.undo().map((n) => ["node", n]));
           // A member that could NOT be put back is somewhere else now, and the
           // pre-flight undo has just restored its cached rect to where it used to
@@ -10348,7 +10357,6 @@ const GRAPH_TOOL_EXECUTORS = {
         // The box write is the LAST thing that can fail. Its failure has to put the
         // children back too, or the group is left torn apart with an error saying
         // otherwise.
-        boxWritten = true;
         const boxError = writeBox(targetX, targetY);
         if (boxError) {
           refuse(() => `the group box did not accept the new position on this frontend (${describeThrown(boxError)})`);
@@ -10360,14 +10368,12 @@ const GRAPH_TOOL_EXECUTORS = {
         // Even the box-only move must be VERIFIED, not assumed: a clamping setter
         // or a proxy that ignores the write would otherwise return a confident
         // "moved the box to [x, y]" for a box that never left.
-        boxWritten = true;
         const boxError = writeBox(targetX, targetY);
         if (boxError) {
           // Rollback FIRST — and BOTH undos: the box, and the pre-flight's rect
-          // reconciliation, which this branch also performed. (The box write is
-          // unconditionally above this line, so boxWritten is true here; the guard
-          // states the rule rather than relying on the reader tracing it.)
-          const restoreFailed = boxWritten ? restoreBox() : false;
+          // reconciliation, which this branch also performed. restoreBox() decides
+          // for itself whether the box actually needs putting back.
+          const restoreFailed = restoreBox();
           const unrestoredRects = resync.undo();
           throw new Error( // …then format
             `refusing to move group ${group_id}: the group box did not accept the new position on this frontend (${describeThrown(boxError)}). ` +

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -225,6 +225,8 @@ import {
   moveReroutePoints,
   rerouteWriteIsSound,
   groupBoxIsAt,
+  describeItems,
+  describeThrown,
 } from "./lib/group-geometry.js";
 import {
   activeWorkflowPossiblyStale,
@@ -5770,7 +5772,7 @@ function describePreflightUndo(unrestored) {
   if (!unrestored.length) return "NOTHING was moved.";
   return (
     `No node was repositioned, but ${unrestored.length} cached rect(s) could NOT be put back ` +
-    `(${unrestored.slice(0, 5).map((n) => `node ${n.id}`).join(", ")}${unrestored.length > 5 ? ", …" : ""}) — ` +
+    `(${describeItems(unrestored.map((n) => ["node", n]))}) — ` +
     "re-read the graph with panel_query_graph before relying on group membership."
   );
 }
@@ -10132,10 +10134,19 @@ const GRAPH_TOOL_EXECUTORS = {
     // rect and then finding node B's rect unwritable used to leave A's cached
     // geometry changed with no undo, under a reply that said NOTHING was moved.
     const resync = syncGraphNodeAreas(graph);
-    if (resync.unsynced.length) {
-      const names = resync.unsynced.slice(0, 5).map((n) => `node ${n.id}`).join(", ");
+    if (resync.walkFailed || resync.unsynced.length) {
+      // ROLL BACK FIRST, FORMAT SECOND. Naming the offending nodes means reading
+      // `id` — a field that exists only for display and is exactly the kind of
+      // exotic accessor (proxy, getter, reactive store) that throws. Building that
+      // string before the undo would leave the reconciled rects in place and emit a
+      // raw exception instead of the refusal this path promises. Nothing about
+      // restoring geometry requires knowing what a node is called.
+      const unrestored = resync.undo();
+      const cause = resync.walkFailed
+        ? "the graph's node list could not be walked to the end, so group membership cannot be determined"
+        : `${resync.unsynced.length} node(s) have a cached bounding rect that cannot be updated (${describeItems(resync.unsynced.map((n) => ["node", n]))}), so their group membership cannot be determined`;
       throw new Error(
-        `refusing to move group ${group_id}: ${resync.unsynced.length} node(s) have a cached bounding rect that cannot be updated (${names}${resync.unsynced.length > 5 ? ", …" : ""}), so their group membership cannot be determined. ${describePreflightUndo(resync.undo())} Reload the ComfyUI tab (panel_reload) and retry.`,
+        `refusing to move group ${group_id}: ${cause}. ${describePreflightUndo(unrestored)} Reload the ComfyUI tab (panel_reload) and retry.`,
       );
     }
     // What the box encloses is captured against the PRE-move bounds — pure reads,
@@ -10162,8 +10173,9 @@ const GRAPH_TOOL_EXECUTORS = {
       // stated outcome. (Reachable only by an accessor that misbehaves
       // inconsistently between the resync and this pass; the individual readers
       // already return "unknown" rather than raising.)
-      throw new Error(
-        `refusing to move group ${group_id}: the frontend raised "${error?.message ?? error}" while reading what the group encloses, so its contents cannot be determined. ${describePreflightUndo(resync.undo())} Reload the ComfyUI tab (panel_reload) and retry.`,
+      const unrestored = resync.undo(); // rollback first…
+      throw new Error( // …then format, over a graph that is provably back
+        `refusing to move group ${group_id}: the frontend raised "${describeThrown(error)}" while reading what the group encloses, so its contents cannot be determined. ${describePreflightUndo(unrestored)} Reload the ComfyUI tab (panel_reload) and retry.`,
       );
     }
     // A reroute we cannot reposition SOUNDLY is decided here, by INSPECTION, and
@@ -10171,11 +10183,21 @@ const GRAPH_TOOL_EXECUTORS = {
     // also means this call leaves no empty undo step behind.
     const unsound = reroutes.filter((r) => !rerouteWriteIsSound(r));
     if (unsound.length) {
+      const unrestored = resync.undo();
       throw new Error(
-        `refusing to move group ${group_id}: ${unsound.length} enclosed reroute point(s) (${unsound.slice(0, 5).map((r) => `reroute ${r.id ?? "?"}`).join(", ")}${unsound.length > 5 ? ", …" : ""}) expose a move() whose meaning this frontend does not let us determine without calling it, and calling it could persist the wrong coordinate. ${describePreflightUndo(resync.undo())} Pass move_nodes:false to move only the box, or move the reroutes by hand.`,
+        `refusing to move group ${group_id}: ${unsound.length} enclosed reroute point(s) (${describeItems(unsound.map((r) => ["reroute", r]))}) expose a move() whose meaning this frontend does not let us determine without calling it, and calling it could persist the wrong coordinate. ${describePreflightUndo(unrestored)} Pass move_nodes:false to move only the box, or move the reroutes by hand.`,
       );
     }
-    graph.beforeChange();
+    // Opening the undo envelope is the first thing after the resync WRITE, so its
+    // failure owes the same rollback as any other refusal past that point.
+    try {
+      graph.beforeChange();
+    } catch (error) {
+      const unrestored = resync.undo();
+      throw new Error(
+        `refusing to move group ${group_id}: the frontend raised "${describeThrown(error)}" opening the undo transaction, so this move could not be made undoable. ${describePreflightUndo(unrestored)} Reload the ComfyUI tab (panel_reload) and retry.`,
+      );
+    }
     try {
       if (move_nodes !== false) {
         // Move the CHILDREN first and the box LAST, as one all-or-nothing
@@ -10213,7 +10235,7 @@ const GRAPH_TOOL_EXECUTORS = {
             ...(restoreBox() ? [g] : []),
           ];
           throw new Error(
-            `refusing to move group ${group_id}: the frontend raised "${error?.message ?? error}" partway through the move. ` +
+            `refusing to move group ${group_id}: the frontend raised "${describeThrown(error)}" partway through the move. ` +
               "The movers that had already completed were rolled back, but the one that raised never returned its undo, " +
               "so ITS OWN writes cannot be reversed from here: the state of this group is UNKNOWN and it may be PARTIALLY moved. " +
               (unrestored.length
@@ -10233,29 +10255,36 @@ const GRAPH_TOOL_EXECUTORS = {
         // unverified "nothing was moved". The parent box is restored too: it is
         // written last, but setGroupBounds writes x/y/w/h one at a time, so a clamp
         // or a mid-quad throw can leave it displaced.
+        // The rollback deals in ITEMS, never in strings. Formatting reaches for
+        // `id` — display-only, and exactly the accessor most likely to be a proxy
+        // or a throwing getter — so a name assembled while the graph is still
+        // dirty can abort the very rollback it is describing.
         const rollback = () => [
-          ...nestedMove.undo().map((c) => `group ${c.id ?? "?"}`),
-          ...rerouteMove.undo().map((r) => `reroute ${r.id ?? "?"}`),
-          ...memberMove.undo().map((n) => `node ${n.id}`),
-          ...(restoreBox() ? [`group ${group_id} (its own box)`] : []),
+          ...nestedMove.undo().map((c) => ["group", c]),
+          ...rerouteMove.undo().map((r) => ["reroute", r]),
+          ...memberMove.undo().map((n) => ["node", n]),
+          ...(restoreBox() ? [["group", g]] : []),
         ];
-        const refuse = (reason) => {
+        // `describeReason` is a THUNK: it is invoked only after the rollback has
+        // run and the graph is provably back. Roll back first, format second.
+        const refuse = (describeReason) => {
           const unrestored = rollback();
           throw new Error(
-            `refusing to move group ${group_id}: ${reason}. ` +
+            `refusing to move group ${group_id}: ${describeReason()}. ` +
               (unrestored.length
-                ? `The graph is PARTIALLY moved — ${unrestored.length} item(s) could NOT be put back (${unrestored.slice(0, 5).join(", ")}${unrestored.length > 5 ? ", …" : ""}). Press Ctrl+Z on the canvas, or reposition them with panel_edit_node.`
+                ? `The graph is PARTIALLY moved — ${unrestored.length} item(s) could NOT be put back (${describeItems(unrestored)}). Press Ctrl+Z on the canvas, or reposition them with panel_edit_node.`
                 : "NOTHING was moved."),
           );
         };
         const stuck = [
-          ...memberMove.stuck.map((n) => `node ${n.id}`),
-          ...rerouteMove.stuck.map((r) => `reroute ${r.id ?? "?"}`),
-          ...nestedMove.stuck.map((c) => `group ${c.id ?? "?"}`),
+          ...memberMove.stuck.map((n) => ["node", n]),
+          ...rerouteMove.stuck.map((r) => ["reroute", r]),
+          ...nestedMove.stuck.map((c) => ["group", c]),
         ];
         if (stuck.length) {
           refuse(
-            `${stuck.length} enclosed item(s) would not accept a new position (${stuck.slice(0, 5).join(", ")}${stuck.length > 5 ? ", …" : ""}) — move them out of the group (panel_edit_node) and retry, or pass move_nodes:false to move only the box`,
+            () =>
+              `${stuck.length} enclosed item(s) would not accept a new position (${describeItems(stuck)}) — move them out of the group (panel_edit_node) and retry, or pass move_nodes:false to move only the box`,
           );
         }
         // The box write is the LAST thing that can fail. Its failure has to put the
@@ -10263,7 +10292,7 @@ const GRAPH_TOOL_EXECUTORS = {
         // otherwise.
         const boxError = writeBox(Number(pos[0]), Number(pos[1]));
         if (boxError) {
-          refuse(`the group box did not accept the new position on this frontend (${boxError.message})`);
+          refuse(() => `the group box did not accept the new position on this frontend (${describeThrown(boxError)})`);
         }
         movedNodes = memberMove.moved.length;
         movedGroups = nestedMove.moved.length;
@@ -10274,9 +10303,9 @@ const GRAPH_TOOL_EXECUTORS = {
         // "moved the box to [x, y]" for a box that never left.
         const boxError = writeBox(Number(pos[0]), Number(pos[1]));
         if (boxError) {
-          const restoreFailed = restoreBox();
-          throw new Error(
-            `refusing to move group ${group_id}: the group box did not accept the new position on this frontend (${boxError.message}). ` +
+          const restoreFailed = restoreBox(); // rollback first…
+          throw new Error( // …then format
+            `refusing to move group ${group_id}: the group box did not accept the new position on this frontend (${describeThrown(boxError)}). ` +
               (restoreFailed
                 ? `The box could NOT be put back at [${b[0]}, ${b[1]}] either — press Ctrl+Z on the canvas, or set it explicitly with panel_edit_group({bounds}).`
                 : "NOTHING was moved."),
@@ -10316,10 +10345,16 @@ const GRAPH_TOOL_EXECUTORS = {
     try {
       return { group: summarizeGroup(graph, g), moved };
     } catch (error) {
+      // The error path OF THE ERROR PATH. `error.message` can itself throw — a
+      // group with a throwing `title` produces exactly such an error — and a throw
+      // while FORMATTING this fallback would surface the completed move as a raw
+      // failure, so the caller re-issues it and the group moves twice. That double
+      // move is the whole reason summary_unavailable exists; describeThrown is
+      // total so the reason can never defeat the report.
       return {
         group_id,
         moved,
-        summary_unavailable: `the move COMPLETED, but the group could not be summarized afterwards: ${error?.message ?? error}. Re-read it with panel_query_graph — do NOT re-issue the move.`,
+        summary_unavailable: `the move COMPLETED, but the group could not be summarized afterwards: ${describeThrown(error)}. Re-read it with panel_query_graph — do NOT re-issue the move.`,
       };
     }
   },

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10133,6 +10133,11 @@ const GRAPH_TOOL_EXECUTORS = {
       writeBox(b[0], b[1]);
       return !groupBoxIsAt(g, b[0], b[1], b[2], b[3]);
     };
+    // Has any forward path written the box yet? Restoring a box nothing displaced
+    // is not a no-op: on an effectful or clamping setter the recovery write can
+    // create a displacement of its own. A rollback must not move what no forward
+    // path moved.
+    let boxWritten = false;
     // ---- PRE-FLIGHT (no mutations past this point until it is complete) ------
     // Everything this move needs to KNOW is established here, before the first
     // byte is written. After the first write the only permitted actions are
@@ -10243,14 +10248,29 @@ const GRAPH_TOOL_EXECUTORS = {
           rerouteMove = moveReroutePoints(reroutes, dx, dy);
           nestedMove = translateGroupBoxes(nested, dx, dy);
         } catch (error) {
+          // This net used to be an EXCEPTION to two rules the reachable paths
+          // follow, so if it ever fired it would have introduced defects of its
+          // own rather than merely failing to help:
+          //
+          //  - it called restoreBox() even though the box write happens strictly
+          //    AFTER the movers, so nothing had displaced the box yet. On an
+          //    effectful or clamping setter that recovery WRITE could create a
+          //    displacement of its own — a rollback moving something no forward
+          //    path had moved. It is now gated on the box actually having been
+          //    written, which here it never has.
+          //  - it replayed the pre-flight rect snapshot over members whose `pos`
+          //    the unreturned mover may have changed, recreating exactly the
+          //    stale-rect fabrication removed from the stranded-member path: a
+          //    rect claiming a position the node no longer holds. When the state
+          //    is UNKNOWN the truthful rect is the one that matches live geometry,
+          //    so this re-syncs instead of replaying a snapshot.
           const unrestored = [
             ...nestedMove.undo(),
             ...rerouteMove.undo(),
             ...memberMove.undo(),
-            ...(restoreBox() ? [g] : []),
-            // …and the PRE-FLIGHT's writes, which this path also owns.
-            ...resync.undo(),
+            ...(boxWritten && restoreBox() ? [g] : []),
           ];
+          syncGraphNodeAreas(graph);
           throw new Error(
             `refusing to move group ${group_id}: the frontend raised "${describeThrown(error)}" partway through the move. ` +
               "The movers that had already completed were rolled back, but the one that raised never returned its undo, " +
@@ -10289,7 +10309,11 @@ const GRAPH_TOOL_EXECUTORS = {
           ];
           const strandedMembers = memberMove.undo();
           stillWrong.push(...strandedMembers.map((n) => ["node", n]));
-          if (restoreBox()) stillWrong.push(["group", g]);
+          // Only restore a box some forward path actually WROTE. The stuck-items
+          // refusal fires BEFORE the box write, and restoreBox() is itself a write:
+          // on an effectful or clamping setter it would displace a box nothing had
+          // displaced — a rollback moving something no forward path moved.
+          if (boxWritten && restoreBox()) stillWrong.push(["group", g]);
           stillWrong.push(...resync.undo().map((n) => ["node", n]));
           // A member that could NOT be put back is somewhere else now, and the
           // pre-flight undo has just restored its cached rect to where it used to
@@ -10324,6 +10348,7 @@ const GRAPH_TOOL_EXECUTORS = {
         // The box write is the LAST thing that can fail. Its failure has to put the
         // children back too, or the group is left torn apart with an error saying
         // otherwise.
+        boxWritten = true;
         const boxError = writeBox(targetX, targetY);
         if (boxError) {
           refuse(() => `the group box did not accept the new position on this frontend (${describeThrown(boxError)})`);
@@ -10335,11 +10360,14 @@ const GRAPH_TOOL_EXECUTORS = {
         // Even the box-only move must be VERIFIED, not assumed: a clamping setter
         // or a proxy that ignores the write would otherwise return a confident
         // "moved the box to [x, y]" for a box that never left.
+        boxWritten = true;
         const boxError = writeBox(targetX, targetY);
         if (boxError) {
           // Rollback FIRST — and BOTH undos: the box, and the pre-flight's rect
-          // reconciliation, which this branch also performed.
-          const restoreFailed = restoreBox();
+          // reconciliation, which this branch also performed. (The box write is
+          // unconditionally above this line, so boxWritten is true here; the guard
+          // states the rule rather than relying on the reader tracing it.)
+          const restoreFailed = boxWritten ? restoreBox() : false;
           const unrestoredRects = resync.undo();
           throw new Error( // …then format
             `refusing to move group ${group_id}: the group box did not accept the new position on this frontend (${describeThrown(boxError)}). ` +
@@ -10377,29 +10405,42 @@ const GRAPH_TOOL_EXECUTORS = {
     } catch {
       /* a repaint failure does not un-move anything */
     }
+    // `moved` is built only from array lengths — primitives this function owns,
+    // never caller- or graph-supplied — so it survives serialization by
+    // construction and can carry the completion signal on its own.
     const moved = { nodes: movedNodes, groups: movedGroups, reroutes: movedReroutes };
+    // Prove the reply we RETURN, not a payload inside it: the ENVELOPE is part of
+    // the reply. Round-tripping only an inner field left the outer object free to
+    // carry something the bridge's JSON.stringify chokes on (a BigInt group_id is
+    // enough), which throws AFTER the move, outside every guard — so the caller
+    // gets no completion reply at all and re-issues an already-completed move.
+    const proven = (reply) => JSON.parse(JSON.stringify(reply));
     try {
       // summarizeGroup returns the group's own `title`/`color`/`id` and its member
-      // ids UNCOERCED, so a title with a throwing `toJSON` lets it succeed here and
-      // then makes the BRIDGE's JSON.stringify fail — after the move, outside this
-      // guard, where the caller gets no success response at all and re-issues.
-      // Proving the payload survives serialization INSIDE the guard is what pulls
-      // that last step back inside the transaction; round-tripping it also hands
-      // back a plainly-serializable object rather than live engine references.
-      const group = JSON.parse(JSON.stringify(summarizeGroup(graph, g)));
-      return { group, moved };
+      // ids UNCOERCED, so a title with a throwing `toJSON` — or a BigInt node id —
+      // gets caught here rather than at the bridge.
+      return proven({ group: summarizeGroup(graph, g), moved });
     } catch (error) {
-      // The error path OF THE ERROR PATH. `error.message` can itself throw — a
-      // group with a throwing `title` produces exactly such an error — and a throw
-      // while FORMATTING this fallback would surface the completed move as a raw
-      // failure, so the caller re-issues it and the group moves twice. That double
-      // move is the whole reason summary_unavailable exists; describeThrown is
-      // total so the reason can never defeat the report.
-      return {
-        group_id,
-        moved,
-        summary_unavailable: `the move COMPLETED, but the group could not be summarized afterwards: ${describeThrown(error)}. Re-read it with panel_query_graph — do NOT re-issue the move.`,
-      };
+      // The error path OF THE ERROR PATH. `error.message` can itself throw, and
+      // `group_id` is caller-supplied, so this fallback has to be proven too.
+      try {
+        return proven({
+          group_id,
+          moved,
+          summary_unavailable: `the move COMPLETED, but the group could not be summarized afterwards: ${describeThrown(error)}. Re-read it with panel_query_graph — do NOT re-issue the move.`,
+        });
+      } catch {
+        // Even the fallback would not serialize — the caller's own `group_id` is
+        // the likeliest culprit. Degrade to a reply built ONLY from primitives we
+        // control: the verified counts and a literal string. Losing the id is a
+        // far smaller harm than losing the completion signal and being re-issued.
+        return {
+          moved,
+          summary_unavailable:
+            "the move COMPLETED, but neither the group summary nor the group id could be represented in the reply. " +
+            "Re-read the group with panel_query_graph — do NOT re-issue the move.",
+        };
+      }
     }
   },
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -218,6 +218,11 @@ import {
   syncNodeArea,
   syncGraphNodeAreas,
   moveGroupMembers,
+  groupBoundsOf,
+  nestedGroupsOf,
+  translateGroupBox,
+  reroutesInside,
+  moveReroutePoints,
 } from "./lib/group-geometry.js";
 import {
   activeWorkflowPossiblyStale,
@@ -10037,39 +10042,83 @@ const GRAPH_TOOL_EXECUTORS = {
     return { group: summary };
   },
 
-  // Move a group's box to [x,y]; by default the contained nodes move with it
-  // (move_nodes:false moves only the box).
+  // Move a group's box to [x,y]; by default everything the box encloses moves
+  // with it — nodes, NESTED group boxes and link reroute points, i.e. exactly
+  // what a canvas drag of the group header moves (move_nodes:false moves only
+  // the box, deliberately re-cutting which nodes the group encloses).
   graph_move_group({ group_id, pos, move_nodes }) {
     const { graph } = getGraphCtx();
     const g = resolveGroup(graph, group_id);
-    const b = g._bounding ?? [g.pos?.[0] ?? 0, g.pos?.[1] ?? 0, 0, 0];
+    // Refuse a non-finite target LOUDLY. `Number(undefined)` is NaN, and a NaN
+    // delta silently propagates into every member node's pos and into the group
+    // box itself — an unrecoverable, invisible corruption of the user's layout
+    // reported as a success. Every other geometry writer (graph_edit_node) already
+    // validates; this one used to be the hole.
+    if (!Array.isArray(pos) || pos.length !== 2 || !pos.every((n) => Number.isFinite(Number(n)))) {
+      throw new Error("pos must be [x, y] finite numbers — pass the new top-left corner of the group box");
+    }
+    // groupBoundsOf reads _bounding OR pos/size and returns null when neither is
+    // usable. The old fallback invented [0, 0, 0, 0] in that case, which is not the
+    // group's box — it silently relocated the group to the origin with a zero-size
+    // box that encloses nothing. Refuse instead: "could not determine" is not an
+    // answer in either direction.
+    const b = groupBoundsOf(g);
+    if (!b) {
+      throw new Error(`group ${group_id} has no usable bounds on this frontend — re-read it via panel_query_graph, or set its box explicitly with panel_edit_group({bounds})`);
+    }
     const dx = Number(pos[0]) - b[0];
     const dy = Number(pos[1]) - b[1];
+    let movedNodes = 0;
+    let movedGroups = 0;
+    let movedReroutes = 0;
     graph.beforeChange();
     try {
       if (move_nodes !== false) {
-        // Move the box AND the LIVE geometric members together. We don't rely on
-        // g.move(), which shifts LiteGraph's cached g._nodes — that cache is stale
+        // Move the box AND everything it encloses together. We don't rely on
+        // g.move(), which shifts LiteGraph's cached child set — that cache is stale
         // or empty on affected builds (#287/#311/#312), so it would move the wrong
-        // nodes or none. Resync live geometry first so we capture the members that
-        // are ACTUALLY inside the box now (not a stale cache), recompute membership,
-        // then translate each member plus the box by the same delta.
+        // children or none. Resync live geometry first so we capture what is
+        // ACTUALLY inside the box now (not a stale cache), then translate the box
+        // and every captured child by the same delta.
         syncGraphNodeAreas(graph);
         const members = groupMemberNodes(graph, g);
+        // Nested group boxes and reroute points are captured against the PRE-move
+        // bounds, before the box is written, so containment is judged where the
+        // children actually are. Reimplementing only the node half moved the outer
+        // box and its nodes but stranded every inner group box over the vacated
+        // space, so nodes that looked grouped silently were not any more (#408).
+        const nested = nestedGroupsOf(graph, g);
+        const reroutes = reroutesInside(graph, b);
         setGroupBounds(g, [Number(pos[0]), Number(pos[1]), b[2], b[3]]);
         // Move each member AND refresh its cached boundingRect by the same delta.
         // Without the rect refresh the box moves but the members "stay behind" for
         // the immediate summarizeGroup below and any later panel_query_graph read,
         // which then reports stale node_ids (#408); mirrors the move_node path (#355).
         moveGroupMembers(members, dx, dy);
+        for (const child of nested) translateGroupBox(child, dx, dy);
+        moveReroutePoints(reroutes, dx, dy);
+        movedNodes = members.length;
+        movedGroups = nested.length;
+        movedReroutes = reroutes.length;
       } else {
         setGroupBounds(g, [Number(pos[0]), Number(pos[1]), b[2], b[3]]);
+        // The box moved and NOTHING else did, so the group now encloses a DIFFERENT
+        // set of nodes. Membership is read boundingRect-first, so resync every
+        // cached rect to live pos/size before summarizing — otherwise this reply
+        // answers "which nodes are in the box now?" with rects left over from a
+        // paste / load / manual drag the panel never saw. The box is not the
+        // membership (#408); every other group path already resyncs before it
+        // reports, and this branch was the last one that did not.
+        syncGraphNodeAreas(graph);
       }
     } finally {
       graph.afterChange();
     }
     graph.setDirtyCanvas(true, true);
-    return { group: summarizeGroup(graph, g) };
+    return {
+      group: summarizeGroup(graph, g),
+      moved: { nodes: movedNodes, groups: movedGroups, reroutes: movedReroutes },
+    };
   },
 
   // Edit a group's title / color / font_size / bounds — only the fields passed.
@@ -13401,8 +13450,21 @@ function describeCommand(cmd, msg, reply) {
         : "";
       return { icon: "pi-clone", text: `Created group “${r.group?.title}” (id ${r.group?.id})${suffix}` };
     }
-    case "graph_move_group":
-      return { icon: "pi-arrows-alt", text: `Moved group ${r.group?.id} (“${r.group?.title}”)` };
+    case "graph_move_group": {
+      // Say what came WITH the box. A move that carried nothing is exactly the
+      // "only the box moved" symptom (#408), so it must be visible on the card
+      // rather than hidden behind an unqualified "Moved group".
+      const m = r.moved;
+      const carried = [
+        ...(m?.nodes ? [`${m.nodes} node${m.nodes === 1 ? "" : "s"}`] : []),
+        ...(m?.groups ? [`${m.groups} nested group${m.groups === 1 ? "" : "s"}`] : []),
+        ...(m?.reroutes ? [`${m.reroutes} reroute${m.reroutes === 1 ? "" : "s"}`] : []),
+      ].join(", ");
+      return {
+        icon: "pi-arrows-alt",
+        text: `Moved group ${r.group?.id} (“${r.group?.title}”)${carried ? ` with ${carried}` : " — box only"}`,
+      };
+    }
     case "graph_edit_group":
       return { icon: "pi-pencil", text: `Edited group ${r.group?.id} (“${r.group?.title}”)` };
     case "graph_remove_group":

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -223,6 +223,7 @@ import {
   translateGroupBoxes,
   reroutesInside,
   moveReroutePoints,
+  groupBoxIsAt,
 } from "./lib/group-geometry.js";
 import {
   activeWorkflowPossiblyStale,
@@ -10103,10 +10104,15 @@ const GRAPH_TOOL_EXECUTORS = {
         const memberMove = moveGroupMembers(members, dx, dy);
         const rerouteMove = moveReroutePoints(reroutes, dx, dy);
         const nestedMove = translateGroupBoxes(nested, dx, dy);
+        // Undo ABSOLUTELY, over every ATTEMPTED child — not by the inverse delta
+        // over the ones that landed. A build whose setter clamps or snaps leaves a
+        // child at a third position that counts as stuck; an inverse-delta undo of
+        // only the `moved` list would strand it there while this reply claimed
+        // nothing had moved.
         const rollback = () => {
-          translateGroupBoxes(nestedMove.moved, -dx, -dy);
-          moveReroutePoints(rerouteMove.moved, -dx, -dy);
-          moveGroupMembers(memberMove.moved, -dx, -dy);
+          nestedMove.undo();
+          rerouteMove.undo();
+          memberMove.undo();
         };
         const stuck = [
           ...memberMove.stuck.map((n) => `node ${n.id}`),
@@ -10119,12 +10125,20 @@ const GRAPH_TOOL_EXECUTORS = {
             `refusing to move group ${group_id}: ${stuck.length} enclosed item(s) would not accept a new position (${stuck.slice(0, 5).join(", ")}${stuck.length > 5 ? ", …" : ""}). NOTHING was moved. Move those items out of the group (panel_edit_node) and retry, or pass move_nodes:false to move only the box.`,
           );
         }
-        setGroupBounds(g, [Number(pos[0]), Number(pos[1]), b[2], b[3]]);
-        const landed = groupBoundsOf(g);
-        if (!landed || Math.abs(landed[0] - Number(pos[0])) > 0.5 || Math.abs(landed[1] - Number(pos[1])) > 0.5) {
+        // The box write is the LAST thing that can fail, and it can fail by
+        // THROWING (a frozen quad rejects the write outright in a strict-mode
+        // module) as well as by quietly not landing. Both have to put the children
+        // back, or the group is left torn apart with an error that says otherwise.
+        let boxError = null;
+        try {
+          setGroupBounds(g, [Number(pos[0]), Number(pos[1]), b[2], b[3]]);
+        } catch (error) {
+          boxError = error;
+        }
+        if (boxError || !groupBoxIsAt(g, Number(pos[0]), Number(pos[1]))) {
           rollback();
           throw new Error(
-            `refusing to move group ${group_id}: the group box did not accept the new position on this frontend. NOTHING was moved.`,
+            `refusing to move group ${group_id}: the group box did not accept the new position on this frontend${boxError ? ` (${boxError.message})` : ""}. NOTHING was moved.`,
           );
         }
         movedNodes = memberMove.moved.length;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -223,6 +223,7 @@ import {
   translateGroupBoxes,
   reroutesInside,
   moveReroutePoints,
+  rerouteWriteIsSound,
   groupBoxIsAt,
 } from "./lib/group-geometry.js";
 import {
@@ -10099,24 +10100,47 @@ const GRAPH_TOOL_EXECUTORS = {
       writeBox(b[0], b[1]);
       return !groupBoxIsAt(g, b[0], b[1], b[2], b[3]);
     };
+    // ---- PRE-FLIGHT (no mutations past this point until it is complete) ------
+    // Everything this move needs to KNOW is established here, before the first
+    // byte is written. After the first write the only permitted actions are
+    // completing the transaction or rolling it back — never discovering something
+    // new that can throw, because a throw from the middle of the mutation phase
+    // escapes past the rollback and leaks a half-moved graph out under an
+    // unrelated TypeError.
+    //
+    // Resyncing cached rects is itself a WRITE (to boundingRect), so it happens
+    // here for BOTH branches, and a rect that will not accept the resync is a
+    // refusal now rather than an exception later. Membership is rect-first, so a
+    // node whose rect cannot be made live cannot be classified honestly at all.
+    const unsynced = syncGraphNodeAreas(graph);
+    if (unsynced.length) {
+      throw new Error(
+        `refusing to move group ${group_id}: ${unsynced.length} node(s) have a cached bounding rect that cannot be updated (${unsynced.slice(0, 5).map((n) => `node ${n.id}`).join(", ")}${unsynced.length > 5 ? ", …" : ""}), so their group membership cannot be determined. NOTHING was moved. Reload the ComfyUI tab (panel_reload) and retry.`,
+      );
+    }
+    // What the box encloses is captured against the PRE-move bounds — pure reads,
+    // so they belong out here with the rest of the discovery. We don't rely on
+    // g.move(), which shifts LiteGraph's cached child set: that cache is stale or
+    // empty on affected builds (#287/#311/#312), so it would move the wrong
+    // children or none. The resync above means what we capture is what is ACTUALLY
+    // inside the box now. Reimplementing only the node half moved the outer box and
+    // its nodes but stranded every inner group box over the vacated space, so nodes
+    // that looked grouped silently were not any more (#408).
+    const members = move_nodes !== false ? groupMemberNodes(graph, g) : [];
+    const nested = move_nodes !== false ? nestedGroupsOf(graph, g) : [];
+    const reroutes = move_nodes !== false ? reroutesInside(graph, b) : [];
+    // A reroute we cannot reposition SOUNDLY is decided here, by INSPECTION, and
+    // never by invoking an API to see what it does. Refusing before beforeChange()
+    // also means this call leaves no empty undo step behind.
+    const unsound = reroutes.filter((r) => !rerouteWriteIsSound(r));
+    if (unsound.length) {
+      throw new Error(
+        `refusing to move group ${group_id}: ${unsound.length} enclosed reroute point(s) (${unsound.slice(0, 5).map((r) => `reroute ${r.id ?? "?"}`).join(", ")}${unsound.length > 5 ? ", …" : ""}) expose a move() whose meaning this frontend does not let us determine without calling it, and calling it could persist the wrong coordinate. NOTHING was moved. Pass move_nodes:false to move only the box, or move the reroutes by hand.`,
+      );
+    }
     graph.beforeChange();
     try {
       if (move_nodes !== false) {
-        // Move the box AND everything it encloses together. We don't rely on
-        // g.move(), which shifts LiteGraph's cached child set — that cache is stale
-        // or empty on affected builds (#287/#311/#312), so it would move the wrong
-        // children or none. Resync live geometry first so we capture what is
-        // ACTUALLY inside the box now (not a stale cache), then translate the box
-        // and every captured child by the same delta.
-        syncGraphNodeAreas(graph);
-        const members = groupMemberNodes(graph, g);
-        // Nested group boxes and reroute points are captured against the PRE-move
-        // bounds, before the box is written, so containment is judged where the
-        // children actually are. Reimplementing only the node half moved the outer
-        // box and its nodes but stranded every inner group box over the vacated
-        // space, so nodes that looked grouped silently were not any more (#408).
-        const nested = nestedGroupsOf(graph, g);
-        const reroutes = reroutesInside(graph, b);
         // Move the CHILDREN first and the box LAST, as one all-or-nothing
         // transaction. Every child write is verified and reports whether it
         // landed — a point can be a plain array, a typed-array view, an accessor
@@ -10128,9 +10152,31 @@ const GRAPH_TOOL_EXECUTORS = {
         // Member rects are refreshed by the same delta inside moveGroupMembers,
         // without which the members "stay behind" for the summarizeGroup below and
         // any later panel_query_graph read (mirrors the move_node path, #355).
-        const memberMove = moveGroupMembers(members, dx, dy);
-        const rerouteMove = moveReroutePoints(reroutes, dx, dy);
-        const nestedMove = translateGroupBoxes(nested, dx, dy);
+        let memberMove = { moved: [], stuck: [], undo: () => [] };
+        let rerouteMove = { moved: [], stuck: [], undo: () => [] };
+        let nestedMove = { moved: [], stuck: [], undo: () => [] };
+        // Belt and braces on the invariant: the movers are written not to throw,
+        // but if any of them ever does, the graph is already partly written and
+        // the error must not escape the rollback. Undo whatever was recorded, then
+        // re-raise with that fact attached.
+        try {
+          memberMove = moveGroupMembers(members, dx, dy);
+          rerouteMove = moveReroutePoints(reroutes, dx, dy);
+          nestedMove = translateGroupBoxes(nested, dx, dy);
+        } catch (error) {
+          const unrestored = [
+            ...nestedMove.undo(),
+            ...rerouteMove.undo(),
+            ...memberMove.undo(),
+            ...(restoreBox() ? [g] : []),
+          ];
+          throw new Error(
+            `refusing to move group ${group_id}: the frontend raised "${error?.message ?? error}" partway through the move. ` +
+              (unrestored.length
+                ? `The graph is PARTIALLY moved — ${unrestored.length} item(s) could NOT be put back. Press Ctrl+Z on the canvas.`
+                : "Everything was put back; NOTHING was moved."),
+          );
+        }
         // Undo ABSOLUTELY, over every ATTEMPTED child — not by the inverse delta
         // over the ones that landed. A build whose setter clamps or snaps leaves a
         // child at a third position that counts as stuck; an inverse-delta undo of
@@ -10191,14 +10237,14 @@ const GRAPH_TOOL_EXECUTORS = {
                 : "NOTHING was moved."),
           );
         }
-        // The box moved and NOTHING else did, so the group now encloses a DIFFERENT
-        // set of nodes. Membership is read boundingRect-first, so resync every
-        // cached rect to live pos/size before summarizing — otherwise this reply
-        // answers "which nodes are in the box now?" with rects left over from a
-        // paste / load / manual drag the panel never saw. The box is not the
-        // membership (#408); every other group path already resyncs before it
-        // reports, and this branch was the last one that did not.
-        syncGraphNodeAreas(graph);
+        // NOTE: the resync that makes this branch's membership live already ran in
+        // the pre-flight, BEFORE the box write. It used to run here, after it — and
+        // a node with an unwritable cached rect then threw out of syncNodeArea with
+        // the box already sitting at the requested position: not a success, not
+        // "NOTHING was moved", not even a stated partial. The box moved and nothing
+        // else did, so the group now encloses a DIFFERENT set of nodes, and
+        // summarizeGroup below reads that membership from rects that are live as of
+        // the pre-flight. The box is not the membership (#408).
       }
     } finally {
       graph.afterChange();

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10072,6 +10072,29 @@ const GRAPH_TOOL_EXECUTORS = {
     let movedNodes = 0;
     let movedGroups = 0;
     let movedReroutes = 0;
+    // Write the box to a top-left and say whether it is REALLY there afterwards.
+    // setGroupBounds can fail two ways — by throwing (a frozen quad rejects the
+    // write outright in a strict-mode module) and by quietly not landing (a
+    // clamping setter or a proxy) — and it writes x, y, w, h one at a time, so a
+    // throw partway leaves the quad half-written. Both branches below route every
+    // box write through here so neither can report a position the box is not at.
+    const writeBox = (x, y) => {
+      try {
+        setGroupBounds(g, [x, y, b[2], b[3]]);
+      } catch (error) {
+        return error;
+      }
+      return groupBoxIsAt(g, x, y) ? null : new Error("the write did not land");
+    };
+    // Put the box back at its ORIGINAL top-left, and report whether it is really
+    // there. A thrown write is not by itself a failed restore — a frozen quad
+    // rejects the write but was never displaced in the first place, and calling
+    // that "could not be put back" would invent a partial move that never happened.
+    // Only the box's actual position decides.
+    const restoreBox = () => {
+      writeBox(b[0], b[1]);
+      return !groupBoxIsAt(g, b[0], b[1]);
+    };
     graph.beforeChange();
     try {
       if (move_nodes !== false) {
@@ -10109,10 +10132,26 @@ const GRAPH_TOOL_EXECUTORS = {
         // child at a third position that counts as stuck; an inverse-delta undo of
         // only the `moved` list would strand it there while this reply claimed
         // nothing had moved.
-        const rollback = () => {
-          nestedMove.undo();
-          rerouteMove.undo();
-          memberMove.undo();
+        // The undo is BEST-EFFORT — a constrained setter can accept the new
+        // coordinates and refuse the old ones — so it reports what it could not put
+        // back, and the refusal says "PARTIALLY moved" with a remedy rather than an
+        // unverified "nothing was moved". The parent box is restored too: it is
+        // written last, but setGroupBounds writes x/y/w/h one at a time, so a clamp
+        // or a mid-quad throw can leave it displaced.
+        const rollback = () => [
+          ...nestedMove.undo().map((c) => `group ${c.id ?? "?"}`),
+          ...rerouteMove.undo().map((r) => `reroute ${r.id ?? "?"}`),
+          ...memberMove.undo().map((n) => `node ${n.id}`),
+          ...(restoreBox() ? [`group ${group_id} (its own box)`] : []),
+        ];
+        const refuse = (reason) => {
+          const unrestored = rollback();
+          throw new Error(
+            `refusing to move group ${group_id}: ${reason}. ` +
+              (unrestored.length
+                ? `The graph is PARTIALLY moved — ${unrestored.length} item(s) could NOT be put back (${unrestored.slice(0, 5).join(", ")}${unrestored.length > 5 ? ", …" : ""}). Press Ctrl+Z on the canvas, or reposition them with panel_edit_node.`
+                : "NOTHING was moved."),
+          );
         };
         const stuck = [
           ...memberMove.stuck.map((n) => `node ${n.id}`),
@@ -10120,32 +10159,34 @@ const GRAPH_TOOL_EXECUTORS = {
           ...nestedMove.stuck.map((c) => `group ${c.id ?? "?"}`),
         ];
         if (stuck.length) {
-          rollback();
-          throw new Error(
-            `refusing to move group ${group_id}: ${stuck.length} enclosed item(s) would not accept a new position (${stuck.slice(0, 5).join(", ")}${stuck.length > 5 ? ", …" : ""}). NOTHING was moved. Move those items out of the group (panel_edit_node) and retry, or pass move_nodes:false to move only the box.`,
+          refuse(
+            `${stuck.length} enclosed item(s) would not accept a new position (${stuck.slice(0, 5).join(", ")}${stuck.length > 5 ? ", …" : ""}) — move them out of the group (panel_edit_node) and retry, or pass move_nodes:false to move only the box`,
           );
         }
-        // The box write is the LAST thing that can fail, and it can fail by
-        // THROWING (a frozen quad rejects the write outright in a strict-mode
-        // module) as well as by quietly not landing. Both have to put the children
-        // back, or the group is left torn apart with an error that says otherwise.
-        let boxError = null;
-        try {
-          setGroupBounds(g, [Number(pos[0]), Number(pos[1]), b[2], b[3]]);
-        } catch (error) {
-          boxError = error;
-        }
-        if (boxError || !groupBoxIsAt(g, Number(pos[0]), Number(pos[1]))) {
-          rollback();
-          throw new Error(
-            `refusing to move group ${group_id}: the group box did not accept the new position on this frontend${boxError ? ` (${boxError.message})` : ""}. NOTHING was moved.`,
-          );
+        // The box write is the LAST thing that can fail. Its failure has to put the
+        // children back too, or the group is left torn apart with an error saying
+        // otherwise.
+        const boxError = writeBox(Number(pos[0]), Number(pos[1]));
+        if (boxError) {
+          refuse(`the group box did not accept the new position on this frontend (${boxError.message})`);
         }
         movedNodes = memberMove.moved.length;
         movedGroups = nestedMove.moved.length;
         movedReroutes = rerouteMove.moved.length;
       } else {
-        setGroupBounds(g, [Number(pos[0]), Number(pos[1]), b[2], b[3]]);
+        // Even the box-only move must be VERIFIED, not assumed: a clamping setter
+        // or a proxy that ignores the write would otherwise return a confident
+        // "moved the box to [x, y]" for a box that never left.
+        const boxError = writeBox(Number(pos[0]), Number(pos[1]));
+        if (boxError) {
+          const restoreFailed = restoreBox();
+          throw new Error(
+            `refusing to move group ${group_id}: the group box did not accept the new position on this frontend (${boxError.message}). ` +
+              (restoreFailed
+                ? `The box could NOT be put back at [${b[0]}, ${b[1]}] either — press Ctrl+Z on the canvas, or set it explicitly with panel_edit_group({bounds}).`
+                : "NOTHING was moved."),
+          );
+        }
         // The box moved and NOTHING else did, so the group now encloses a DIFFERENT
         // set of nodes. Membership is read boundingRect-first, so resync every
         // cached rect to live pos/size before summarizing — otherwise this reply

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -220,7 +220,7 @@ import {
   moveGroupMembers,
   groupBoundsOf,
   nestedGroupsOf,
-  translateGroupBox,
+  translateGroupBoxes,
   reroutesInside,
   moveReroutePoints,
 } from "./lib/group-geometry.js";
@@ -10089,17 +10089,47 @@ const GRAPH_TOOL_EXECUTORS = {
         // space, so nodes that looked grouped silently were not any more (#408).
         const nested = nestedGroupsOf(graph, g);
         const reroutes = reroutesInside(graph, b);
+        // Move the CHILDREN first and the box LAST, as one all-or-nothing
+        // transaction. Every child write is verified and reports whether it
+        // landed — a point can be a plain array, a typed-array view, an accessor
+        // pair, or frozen, and a write that quietly did nothing is how "the box
+        // moved but the nodes stayed" happened in the first place (#408). If ANY
+        // child could not be moved we put the moved ones back and refuse, so the
+        // caller never gets a success for a half-applied move; the box has not
+        // been touched at that point, so the rollback is exact.
+        // Member rects are refreshed by the same delta inside moveGroupMembers,
+        // without which the members "stay behind" for the summarizeGroup below and
+        // any later panel_query_graph read (mirrors the move_node path, #355).
+        const memberMove = moveGroupMembers(members, dx, dy);
+        const rerouteMove = moveReroutePoints(reroutes, dx, dy);
+        const nestedMove = translateGroupBoxes(nested, dx, dy);
+        const rollback = () => {
+          translateGroupBoxes(nestedMove.moved, -dx, -dy);
+          moveReroutePoints(rerouteMove.moved, -dx, -dy);
+          moveGroupMembers(memberMove.moved, -dx, -dy);
+        };
+        const stuck = [
+          ...memberMove.stuck.map((n) => `node ${n.id}`),
+          ...rerouteMove.stuck.map((r) => `reroute ${r.id ?? "?"}`),
+          ...nestedMove.stuck.map((c) => `group ${c.id ?? "?"}`),
+        ];
+        if (stuck.length) {
+          rollback();
+          throw new Error(
+            `refusing to move group ${group_id}: ${stuck.length} enclosed item(s) would not accept a new position (${stuck.slice(0, 5).join(", ")}${stuck.length > 5 ? ", …" : ""}). NOTHING was moved. Move those items out of the group (panel_edit_node) and retry, or pass move_nodes:false to move only the box.`,
+          );
+        }
         setGroupBounds(g, [Number(pos[0]), Number(pos[1]), b[2], b[3]]);
-        // Move each member AND refresh its cached boundingRect by the same delta.
-        // Without the rect refresh the box moves but the members "stay behind" for
-        // the immediate summarizeGroup below and any later panel_query_graph read,
-        // which then reports stale node_ids (#408); mirrors the move_node path (#355).
-        moveGroupMembers(members, dx, dy);
-        for (const child of nested) translateGroupBox(child, dx, dy);
-        moveReroutePoints(reroutes, dx, dy);
-        movedNodes = members.length;
-        movedGroups = nested.length;
-        movedReroutes = reroutes.length;
+        const landed = groupBoundsOf(g);
+        if (!landed || Math.abs(landed[0] - Number(pos[0])) > 0.5 || Math.abs(landed[1] - Number(pos[1])) > 0.5) {
+          rollback();
+          throw new Error(
+            `refusing to move group ${group_id}: the group box did not accept the new position on this frontend. NOTHING was moved.`,
+          );
+        }
+        movedNodes = memberMove.moved.length;
+        movedGroups = nestedMove.moved.length;
+        movedReroutes = rerouteMove.moved.length;
       } else {
         setGroupBounds(g, [Number(pos[0]), Number(pos[1]), b[2], b[3]]);
         // The box moved and NOTHING else did, so the group now encloses a DIFFERENT

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -5746,7 +5746,11 @@ function nextGroupId(graph) {
   return (ids.length ? Math.max(...ids) : 0) + 1;
 }
 
-/** Set a group's box, preferring its _bounding array (most portable). */
+/** Set a group's box, preferring its _bounding array (most portable). Writing
+ *  ALL FOUR components is what makes `length >= 4` a safe test here even for a
+ *  malformed quad — nothing is left half-written, so the quad is repaired rather
+ *  than diverging from the pos/size the read would otherwise fall back to. A
+ *  PARTIAL writer must instead follow groupBoundsTarget (see placeGroupBox). */
 function setGroupBounds(group, [x, y, w, h]) {
   if (group._bounding && group._bounding.length >= 4) {
     group._bounding[0] = x;
@@ -5757,6 +5761,18 @@ function setGroupBounds(group, [x, y, w, h]) {
     group.pos = [x, y];
     group.size = [w, h];
   }
+}
+
+/** Phrase the outcome of undoing the move pre-flight's rect reconciliation. The
+ *  pre-flight WRITES, so a refusal after it may only claim "NOTHING was moved"
+ *  once those writes are provably back. */
+function describePreflightUndo(unrestored) {
+  if (!unrestored.length) return "NOTHING was moved.";
+  return (
+    `No node was repositioned, but ${unrestored.length} cached rect(s) could NOT be put back ` +
+    `(${unrestored.slice(0, 5).map((n) => `node ${n.id}`).join(", ")}${unrestored.length > 5 ? ", …" : ""}) — ` +
+    "re-read the graph with panel_query_graph before relying on group membership."
+  );
 }
 
 /** Compact JSON-friendly view of a group box. */
@@ -10112,10 +10128,14 @@ const GRAPH_TOOL_EXECUTORS = {
     // here for BOTH branches, and a rect that will not accept the resync is a
     // refusal now rather than an exception later. Membership is rect-first, so a
     // node whose rect cannot be made live cannot be classified honestly at all.
-    const unsynced = syncGraphNodeAreas(graph);
-    if (unsynced.length) {
+    // …and the resync is TRANSACTIONAL, because it is a write. Reconciling node A's
+    // rect and then finding node B's rect unwritable used to leave A's cached
+    // geometry changed with no undo, under a reply that said NOTHING was moved.
+    const resync = syncGraphNodeAreas(graph);
+    if (resync.unsynced.length) {
+      const names = resync.unsynced.slice(0, 5).map((n) => `node ${n.id}`).join(", ");
       throw new Error(
-        `refusing to move group ${group_id}: ${unsynced.length} node(s) have a cached bounding rect that cannot be updated (${unsynced.slice(0, 5).map((n) => `node ${n.id}`).join(", ")}${unsynced.length > 5 ? ", …" : ""}), so their group membership cannot be determined. NOTHING was moved. Reload the ComfyUI tab (panel_reload) and retry.`,
+        `refusing to move group ${group_id}: ${resync.unsynced.length} node(s) have a cached bounding rect that cannot be updated (${names}${resync.unsynced.length > 5 ? ", …" : ""}), so their group membership cannot be determined. ${describePreflightUndo(resync.undo())} Reload the ComfyUI tab (panel_reload) and retry.`,
       );
     }
     // What the box encloses is captured against the PRE-move bounds — pure reads,
@@ -10136,15 +10156,14 @@ const GRAPH_TOOL_EXECUTORS = {
         reroutes = reroutesInside(graph, b);
       }
     } catch (error) {
-      // These are reads, and the only writes before them are the pre-flight's
-      // idempotent rect reconciliation — so no position has changed and nothing
-      // needs rolling back. Still, a throw here would reach the caller as a bare
-      // TypeError from a tool that promises a stated outcome, so it is turned into
-      // one. (Reachable only by an accessor that misbehaves inconsistently between
-      // the resync and this pass; the individual readers already return "unknown"
-      // rather than raising.)
+      // These are reads, but the resync BEFORE them was a write, so a refusal here
+      // has to take that back before it can claim nothing happened. A throw would
+      // otherwise reach the caller as a bare TypeError from a tool that promises a
+      // stated outcome. (Reachable only by an accessor that misbehaves
+      // inconsistently between the resync and this pass; the individual readers
+      // already return "unknown" rather than raising.)
       throw new Error(
-        `refusing to move group ${group_id}: the frontend raised "${error?.message ?? error}" while reading what the group encloses, so its contents cannot be determined. NOTHING was moved. Reload the ComfyUI tab (panel_reload) and retry.`,
+        `refusing to move group ${group_id}: the frontend raised "${error?.message ?? error}" while reading what the group encloses, so its contents cannot be determined. ${describePreflightUndo(resync.undo())} Reload the ComfyUI tab (panel_reload) and retry.`,
       );
     }
     // A reroute we cannot reposition SOUNDLY is decided here, by INSPECTION, and
@@ -10153,7 +10172,7 @@ const GRAPH_TOOL_EXECUTORS = {
     const unsound = reroutes.filter((r) => !rerouteWriteIsSound(r));
     if (unsound.length) {
       throw new Error(
-        `refusing to move group ${group_id}: ${unsound.length} enclosed reroute point(s) (${unsound.slice(0, 5).map((r) => `reroute ${r.id ?? "?"}`).join(", ")}${unsound.length > 5 ? ", …" : ""}) expose a move() whose meaning this frontend does not let us determine without calling it, and calling it could persist the wrong coordinate. NOTHING was moved. Pass move_nodes:false to move only the box, or move the reroutes by hand.`,
+        `refusing to move group ${group_id}: ${unsound.length} enclosed reroute point(s) (${unsound.slice(0, 5).map((r) => `reroute ${r.id ?? "?"}`).join(", ")}${unsound.length > 5 ? ", …" : ""}) expose a move() whose meaning this frontend does not let us determine without calling it, and calling it could persist the wrong coordinate. ${describePreflightUndo(resync.undo())} Pass move_nodes:false to move only the box, or move the reroutes by hand.`,
       );
     }
     graph.beforeChange();
@@ -10173,10 +10192,15 @@ const GRAPH_TOOL_EXECUTORS = {
         let memberMove = { moved: [], stuck: [], undo: () => [] };
         let rerouteMove = { moved: [], stuck: [], undo: () => [] };
         let nestedMove = { moved: [], stuck: [], undo: () => [] };
-        // Belt and braces on the invariant: the movers are written not to throw,
-        // but if any of them ever does, the graph is already partly written and
-        // the error must not escape the rollback. Undo whatever was recorded, then
-        // re-raise with that fact attached.
+        // Belt and braces on the invariant: the movers are written not to throw
+        // (each contains per item and always RETURNS its undo). If one ever does
+        // throw, this catch can only undo the movers that already ASSIGNED — the
+        // one that raised never handed back its undo, so whatever it had already
+        // written is unreachable from here.
+        //
+        // Which is exactly why this path must NOT claim "NOTHING was moved". A net
+        // that lies when it catches is worse than no net: the honest report is that
+        // restoration is UNKNOWN and the graph may be partially moved.
         try {
           memberMove = moveGroupMembers(members, dx, dy);
           rerouteMove = moveReroutePoints(reroutes, dx, dy);
@@ -10190,9 +10214,12 @@ const GRAPH_TOOL_EXECUTORS = {
           ];
           throw new Error(
             `refusing to move group ${group_id}: the frontend raised "${error?.message ?? error}" partway through the move. ` +
+              "The movers that had already completed were rolled back, but the one that raised never returned its undo, " +
+              "so ITS OWN writes cannot be reversed from here: the state of this group is UNKNOWN and it may be PARTIALLY moved. " +
               (unrestored.length
-                ? `The graph is PARTIALLY moved — ${unrestored.length} item(s) could NOT be put back. Press Ctrl+Z on the canvas.`
-                : "Everything was put back; NOTHING was moved."),
+                ? `${unrestored.length} further item(s) are known to still be displaced. `
+                : "") +
+              "Press Ctrl+Z on the canvas and re-read the group with panel_query_graph.",
           );
         }
         // Undo ABSOLUTELY, over every ATTEMPTED child — not by the inverse delta
@@ -10265,13 +10292,36 @@ const GRAPH_TOOL_EXECUTORS = {
         // the pre-flight. The box is not the membership (#408).
       }
     } finally {
-      graph.afterChange();
+      // Closing the undo envelope must not be able to convert a completed move
+      // into a raw failure — a `finally` that throws REPLACES the outcome, success
+      // or refusal alike.
+      try {
+        graph.afterChange();
+      } catch {
+        /* the geometry is already written; the envelope is bookkeeping */
+      }
     }
-    graph.setDirtyCanvas(true, true);
-    return {
-      group: summarizeGroup(graph, g),
-      moved: { nodes: movedNodes, groups: movedGroups, reroutes: movedReroutes },
-    };
+    // ---- REPORTING (after the last write — it may not throw either) ----------
+    // The invariant is "after the first write, only complete or roll back", and
+    // reporting is after the first write. If summarizeGroup raises, the move HAS
+    // happened: rolling back is wrong and re-raising is worse, because the caller
+    // would read a completed move as a failed one and retry it. Say what was done
+    // and that the summary is unavailable.
+    try {
+      graph.setDirtyCanvas(true, true);
+    } catch {
+      /* a repaint failure does not un-move anything */
+    }
+    const moved = { nodes: movedNodes, groups: movedGroups, reroutes: movedReroutes };
+    try {
+      return { group: summarizeGroup(graph, g), moved };
+    } catch (error) {
+      return {
+        group_id,
+        moved,
+        summary_unavailable: `the move COMPLETED, but the group could not be summarized afterwards: ${error?.message ?? error}. Re-read it with panel_query_graph — do NOT re-issue the move.`,
+      };
+    }
   },
 
   // Edit a group's title / color / font_size / bounds — only the fields passed.

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -207,6 +207,112 @@ export function moveGroupMembers(members, dx, dy) {
 }
 
 /**
+ * Does box `outer` fully enclose box `inner`? Mirrors @comfyorg/litegraph's
+ * `containsRect`, INCLUDING its deliberate exclusion of two identical rects:
+ * coincident boxes are peers, not parent/child, so neither one drags the other.
+ */
+export function containsBounds(outer, inner) {
+  if (!outer || !inner) return false;
+  const [ax, ay, aw, ah] = outer;
+  const [bx, by, bw, bh] = inner;
+  const aRight = ax + aw;
+  const aBottom = ay + ah;
+  const bRight = bx + bw;
+  const bBottom = by + bh;
+  if (ax === bx && ay === by && aRight === bRight && aBottom === bBottom) return false;
+  return ax <= bx && ay <= by && aRight >= bRight && aBottom >= bBottom;
+}
+
+/**
+ * Groups NESTED inside `g` — every OTHER group whose box is fully contained in
+ * g's box. This mirrors LiteGraph's own child-group rule (containsRect in
+ * LGraphGroup.recomputeInsideNodes), which is FULL containment for groups even
+ * though membership for NODES is centre-in-rect: a merely overlapping neighbour
+ * is not a child and must not be dragged along.
+ *
+ * Needed because the panel reimplements the group move instead of calling
+ * g.move() (whose cached children are stale/empty on affected builds, #287/#311/
+ * #312). Reimplementing only the NODE half moved the outer box and its nodes but
+ * stranded every inner group box over the space the nodes just vacated — the
+ * "nodes that looked grouped no longer are" half of #408, and a divergence from
+ * the documented "like dragging the group header" contract.
+ */
+export function nestedGroupsOf(graph, g) {
+  const outer = groupBoundsOf(g);
+  if (!outer) return [];
+  return (graph?._groups ?? []).filter((other) => {
+    if (!other || other === g) return false;
+    const inner = groupBoundsOf(other);
+    return !!inner && containsBounds(outer, inner);
+  });
+}
+
+/**
+ * Translate a group's box by (dx, dy), writing through whichever geometry the
+ * build exposes — the `_bounding` quad (plain OR typed array, mutated in place)
+ * or the pos/size pair. Mirrors the panel's setGroupBounds write policy.
+ */
+export function translateGroupBox(g, dx, dy) {
+  const b = g?._bounding;
+  if (b && b.length >= 4) {
+    b[0] += dx;
+    b[1] += dy;
+    return;
+  }
+  if (!g) return;
+  const x = Number(g.pos?.[0] ?? 0);
+  const y = Number(g.pos?.[1] ?? 0);
+  g.pos = [x + dx, y + dy];
+}
+
+/** Every reroute point of a graph, across the Map / array / plain-object shapes
+ *  different frontend builds expose on `graph.reroutes`. */
+function allReroutes(graph) {
+  const r = graph?.reroutes;
+  if (!r) return [];
+  if (typeof r.values === "function") return [...r.values()];
+  if (Array.isArray(r)) return r;
+  if (typeof r === "object") return Object.values(r);
+  return [];
+}
+
+/**
+ * Link reroute points whose position falls inside `bounds` — LiteGraph's own
+ * rule for reroute children of a group (isPointInRect on the reroute position,
+ * NOT a centre-of-box test, because a reroute IS a point).
+ */
+export function reroutesInside(graph, bounds) {
+  if (!bounds) return [];
+  const [x, y, w, h] = bounds;
+  return allReroutes(graph).filter((r) => {
+    const px = Number(r?.pos?.[0]);
+    const py = Number(r?.pos?.[1]);
+    if (!Number.isFinite(px) || !Number.isFinite(py)) return false;
+    return px >= x && px < x + w && py >= y && py < y + h;
+  });
+}
+
+/**
+ * Translate reroute points by (dx, dy). Writes IN PLACE first because current
+ * builds back `Reroute.pos` with a typed array behind a getter (an assignment
+ * would be dropped by a getter-only property); if the in-place write did not
+ * take, fall back to assigning a fresh pair. Without this a moved group leaves
+ * its wire elbows behind and the links visibly snake back to the old box.
+ */
+export function moveReroutePoints(reroutes, dx, dy) {
+  for (const r of reroutes ?? []) {
+    const pos = r?.pos;
+    if (!pos || pos.length < 2) continue;
+    const px = Number(pos[0]);
+    const py = Number(pos[1]);
+    if (!Number.isFinite(px) || !Number.isFinite(py)) continue;
+    pos[0] = px + dx;
+    pos[1] = py + dy;
+    if (r.pos?.[0] !== px + dx || r.pos?.[1] !== py + dy) r.pos = [px + dx, py + dy];
+  }
+}
+
+/**
  * Compare the node ids actually enclosed (geometric) against the ids the caller
  * asked to group. Returns { requested, members, extra, missing } so a create
  * handler can warn honestly in dense layouts (#297) instead of reporting a

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -121,13 +121,33 @@ function finiteQuad(v) {
  */
 export function groupBoundsOf(g) {
   try {
-    return (
-      finiteQuad(g?._bounding) ??
-      finiteQuad([g?.pos?.[0], g?.pos?.[1], g?.size?.[0], g?.size?.[1]])
-    );
+    return groupBoundsTarget(g)?.bounds ?? null;
   } catch {
     return null; // a hostile/disposed accessor is "no usable bounds", not a throw
   }
+}
+
+/**
+ * WHICH container currently holds this group's box, and what it says — the ONE
+ * rule every reader and every partial writer must share.
+ *
+ * Chosen by VALIDITY, never by mere presence. A malformed `_bounding` (a
+ * half-initialised quad, a leftover from a failed deserialize) must not capture
+ * the write while the read falls through to pos/size: a translate that writes
+ * only x/y into the malformed quad leaves it malformed, the read still returns
+ * the unchanged pos/size, verification fails, and a perfectly movable group is
+ * refused. Reading and writing have to agree on the container, so they ask the
+ * same question here.
+ *
+ * Returns `{ kind: "bounding" | "possize", bounds: [x, y, w, h] }`, or null when
+ * neither form is usable.
+ */
+export function groupBoundsTarget(g) {
+  const fromQuad = finiteQuad(g?._bounding);
+  if (fromQuad) return { kind: "bounding", bounds: fromQuad };
+  const fromPosSize = finiteQuad([g?.pos?.[0], g?.pos?.[1], g?.size?.[0], g?.size?.[1]]);
+  if (fromPosSize) return { kind: "possize", bounds: fromPosSize };
+  return null;
 }
 
 /**
@@ -197,19 +217,37 @@ export function groupMemberNodes(graph, g) {
 export const COLLAPSED_TITLE_HEIGHT = 30;
 export const COLLAPSED_PILL_WIDTH = 80; // LiteGraph.NODE_COLLAPSED_WIDTH
 
-/** The rect a node's cached boundingRect SHOULD hold for its live pos/size. */
+/** A finite, POSITIVE extent, or the given default. `Number(x) || d` is not
+ *  enough: Infinity and -1 are both truthy, and an infinite (or negative) extent
+ *  written into a cached rect makes the node a geometric member of every group —
+ *  or of none — which is precisely the area overstatement the pill exists to
+ *  avoid (#416). Zero is rejected for the same reason from the other side: a
+ *  degenerate rect has no centre worth testing. `Number(null)` is 0, so a missing
+ *  value lands here rather than sneaking through as a valid extent. */
+function finiteExtent(value, fallback) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+/**
+ * The rect a node's cached boundingRect SHOULD hold for its live pos/size, or
+ * NULL when the node's position is not a finite point.
+ *
+ * Null rather than a substituted origin: a node whose position cannot be read as
+ * a number has no knowable footprint, and writing a made-up [0, 0] would place it
+ * in whatever group happens to sit at the origin. Callers turn null into "cannot
+ * be determined", which is the honest answer.
+ */
 function wantedNodeArea(node, forceCollapsed = false) {
+  const x = Number(node?.pos?.[0]);
+  const y = Number(node?.pos?.[1]);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
   const collapsed = !!node.flags?.collapsed && !forceCollapsed;
   const w = collapsed
-    ? Number(node._collapsed_width) || COLLAPSED_PILL_WIDTH
-    : node.size?.[0] ?? 200;
-  const h = collapsed ? 0 : node.size?.[1] ?? 100;
-  return [
-    node.pos?.[0] ?? 0,
-    (node.pos?.[1] ?? 0) - COLLAPSED_TITLE_HEIGHT, // title bar renders above pos
-    w,
-    h + COLLAPSED_TITLE_HEIGHT,
-  ];
+    ? finiteExtent(node._collapsed_width, COLLAPSED_PILL_WIDTH)
+    : finiteExtent(node.size?.[0], 200);
+  const h = collapsed ? 0 : finiteExtent(node.size?.[1], 100);
+  return [x, y - COLLAPSED_TITLE_HEIGHT, w, h + COLLAPSED_TITLE_HEIGHT]; // title above pos
 }
 
 /**
@@ -222,9 +260,11 @@ function wantedNodeArea(node, forceCollapsed = false) {
  */
 export function nodeAreaIsLive(node) {
   try {
+    const want = wantedNodeArea(node);
+    if (!want) return false; // no knowable footprint ⇒ cannot be shown to be live
     const br = node?.boundingRect;
     if (!br || br.length !== 4) return true;
-    return wantedNodeArea(node).every((v, i) => br[i] === v);
+    return want.every((v, i) => br[i] === v);
   } catch {
     return false; // an unreadable node cannot be shown to be live
   }
@@ -238,6 +278,7 @@ export function syncNodeArea(node, forceCollapsed = false) {
     // before groupMemberNodes touches it and raises a bare TypeError at a caller
     // who asked to move a group.
     const want = wantedNodeArea(node, forceCollapsed);
+    if (!want) return false; // no knowable footprint ⇒ cannot be made live
     const br = node?.boundingRect;
     if (!br || br.length !== 4) return true;
     try {
@@ -270,14 +311,55 @@ export function syncNodeArea(node, forceCollapsed = false) {
  * makes the membership reflect the CURRENT layout. Collapsed nodes are synced to
  * their collapsed pill rather than skipped (see syncNodeArea). Dependency-free.
  *
- * NEVER THROWS, and returns the nodes whose cached rect would not accept the
- * resync. Callers doing this as a PRE-FLIGHT before mutating can then refuse up
- * front instead of discovering an unwritable rect halfway through a transaction.
+ * NEVER THROWS. Returns `{ unsynced, undo }`: the nodes whose cached rect would
+ * not accept the resync, and an undo that puts every rect this touched back
+ * exactly as it found it (returning the ones it could not restore).
+ *
+ * The undo is not optional. Writing rects IS a mutation, and a caller that runs
+ * this as a pre-flight and then refuses because one node failed would otherwise
+ * have already changed every earlier node's cached geometry — with no way to take
+ * it back — while telling the user NOTHING was moved. Moving a mutation earlier
+ * does not stop it being a mutation: the pre-flight needs the same
+ * contain-per-item-and-return-undo contract as the movers it precedes.
  */
 export function syncGraphNodeAreas(graph) {
   const unsynced = [];
-  for (const n of graph?._nodes ?? []) if (!syncNodeArea(n)) unsynced.push(n);
-  return unsynced;
+  const attempted = [];
+  for (const n of graph?._nodes ?? []) {
+    let before = null;
+    try {
+      const br = n?.boundingRect;
+      if (br && br.length === 4) before = [br[0], br[1], br[2], br[3]];
+    } catch {
+      /* unreadable rect: syncNodeArea reports it below; nothing to capture */
+    }
+    if (before) attempted.push([n, before]);
+    if (!syncNodeArea(n)) unsynced.push(n);
+  }
+  return {
+    unsynced,
+    undo: () => {
+      const failed = [];
+      for (const [n, before] of attempted) {
+        try {
+          const br = n?.boundingRect;
+          if (!br || br.length !== 4) continue;
+          try {
+            br[0] = before[0];
+            br[1] = before[1];
+            br[2] = before[2];
+            br[3] = before[3];
+          } catch {
+            /* frozen — reported below */
+          }
+          if (!before.every((v, i) => br[i] === v)) failed.push(n);
+        } catch {
+          failed.push(n);
+        }
+      }
+      return failed;
+    },
+  };
 }
 
 /**
@@ -469,13 +551,19 @@ export function groupBoxIsAt(g, x, y, w, h) {
  * write; a getter with no setter throws on assignment in a strict-mode module).
  *
  * Returning the verdict is the point — the caller must never report a move it did
- * not make.
+ * not make. NEVER THROWS: even READING `owner[key]` can raise (a revoked Proxy,
+ * a disposed accessor), and a write helper that raises would defeat every caller
+ * that guards on its return value.
  */
 export function writePoint(owner, key, x, y) {
   const landed = () => {
-    const point = owner?.[key];
-    const f32 = isFloat32(point);
-    return samePoint(Number(point?.[0]), x, f32) && samePoint(Number(point?.[1]), y, f32);
+    try {
+      const point = owner?.[key];
+      const f32 = isFloat32(point);
+      return samePoint(Number(point?.[0]), x, f32) && samePoint(Number(point?.[1]), y, f32);
+    } catch {
+      return false; // unreadable ⇒ cannot be shown to have landed
+    }
   };
   const assign = () => {
     try {
@@ -485,13 +573,13 @@ export function writePoint(owner, key, x, y) {
     }
   };
   const inPlace = () => {
-    const point = owner?.[key];
-    if (!point || point.length < 2) return;
     try {
+      const point = owner?.[key];
+      if (!point || point.length < 2) return;
       point[0] = x;
       point[1] = y;
     } catch {
-      /* frozen/read-only point */
+      /* frozen/read-only point, or an unreadable container */
     }
   };
   const [first, second] = hasSetter(owner, key) ? [assign, inPlace] : [inPlace, assign];
@@ -503,11 +591,21 @@ export function writePoint(owner, key, x, y) {
 
 /** Does writing `owner[key]` run a SETTER (rather than replacing a data
  *  property)? Walks the prototype chain, because LiteGraph defines its geometry
- *  accessors on the class prototype, not on each instance. */
+ *  accessors on the class prototype, not on each instance.
+ *
+ *  Inspection is itself an operation that can fail: getPrototypeOf and
+ *  getOwnPropertyDescriptor both THROW on a revoked Proxy. Falling back to
+ *  "no setter" only picks the write ORDER, and writePoint tries the other way
+ *  round anyway and verifies — so a failed inspection costs nothing and must not
+ *  be allowed to raise out of a decision function. */
 function hasSetter(owner, key) {
-  for (let o = owner; o != null; o = Object.getPrototypeOf(o)) {
-    const d = Object.getOwnPropertyDescriptor(o, key);
-    if (d) return typeof d.set === "function";
+  try {
+    for (let o = owner; o != null; o = Object.getPrototypeOf(o)) {
+      const d = Object.getOwnPropertyDescriptor(o, key);
+      if (d) return typeof d.set === "function";
+    }
+  } catch {
+    /* uninspectable ⇒ treat as a data property; writePoint still tries both */
   }
   return false;
 }
@@ -585,12 +683,21 @@ export function placeGroupBox(g, x, y) {
 }
 
 function placeGroupBoxUnsafe(g, x, y) {
-  // A move must not change the SIZE. Capture it first and verify it survived, so
-  // a build that resizes on reposition is reported as not-moved instead of
+  // Write into the container the READ will come back from. Picking `_bounding`
+  // merely because it has length 4 is how a malformed quad captured the write
+  // while groupBoundsOf fell through to pos/size: this writes only x/y, so the
+  // quad stays malformed, the read still returns the unchanged pos/size, and a
+  // perfectly movable group is reported as refusing to move. groupBoundsTarget is
+  // the one rule both sides ask.
+  //
+  // A move must not change the SIZE either — captured first and verified, so a
+  // build that resizes on reposition is reported as not-moved rather than
   // silently reshaping the user's group.
-  const before = groupBoundsOf(g);
-  const b = g?._bounding;
-  if (b && b.length >= 4) {
+  const target = groupBoundsTarget(g);
+  if (!target) return false;
+  const before = target.bounds;
+  if (target.kind === "bounding") {
+    const b = g._bounding;
     try {
       b[0] = x;
       b[1] = y;
@@ -600,7 +707,7 @@ function placeGroupBoxUnsafe(g, x, y) {
   } else {
     writePoint(g, "pos", x, y);
   }
-  return groupBoxIsAt(g, x, y, before?.[2], before?.[3]);
+  return groupBoxIsAt(g, x, y, before[2], before[3]);
 }
 
 export function translateGroupBox(g, dx, dy) {
@@ -619,6 +726,10 @@ export function translateGroupBox(g, dx, dy) {
 function restoreGroupBox(g, quad) {
   const [x, y, w, h] = quad;
   try {
+    // Unlike a translate, a restore writes all four components — so it can also
+    // REPAIR a quad the forward pass left malformed. Write the quad when the
+    // build has one at all (length 4 is enough here precisely because nothing is
+    // left half-written), else the pos/size pair.
     const b = g?._bounding;
     if (b && b.length >= 4) {
       try {
@@ -740,8 +851,15 @@ export function reroutesInside(graph, bounds) {
  * than moved on a coin-flip whose failure mode only shows up at save time.
  */
 export function rerouteWriteIsSound(r) {
-  if (hasSetter(r, "pos")) return true;
-  return typeof r?.move !== "function";
+  try {
+    if (hasSetter(r, "pos")) return true;
+    // `typeof r.move` RUNS a getter, and a getter that throws would raise out of
+    // the very inspection whose whole job is to decide without side effects. A
+    // reroute we cannot even inspect is exactly the "unknown" this refuses on.
+    return typeof r?.move !== "function";
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -219,6 +219,15 @@ export function moveGroupMembers(members, dx, dy) {
   return { moved, stuck, undo: () => restoreNodePositions(attempted) };
 }
 
+/** Keep a node's cached rect in step with a restore, then say whether the node
+ *  is back where it started. */
+function restoreNodePosition(n, px, py) {
+  const cur = [Number(n?.pos?.[0]), Number(n?.pos?.[1])];
+  const ok = writePoint(n, "pos", px, py);
+  refreshNodeArea(n, cur);
+  return ok;
+}
+
 /**
  * Put every ATTEMPTED node back at the exact coordinates it had before the move,
  * whether its write landed, landed somewhere else, or did not land at all.
@@ -228,13 +237,19 @@ export function moveGroupMembers(members, dx, dy) {
  * as not-landed — and an undo that only walked the `moved` list would leave that
  * node displaced while the caller announced that nothing had moved. Restoring
  * absolutely, over the whole attempted set, is what makes that announcement true.
+ *
+ * Returns the nodes that could NOT be put back. A restore can fail for the same
+ * reasons a move can (a constrained setter may accept the new coordinates and
+ * refuse the old ones), and a caller that announces "nothing was moved" without
+ * looking at this list is making exactly the unverified claim this whole change
+ * exists to stop.
  */
 function restoreNodePositions(attempted) {
+  const failed = [];
   for (const [n, px, py] of attempted ?? []) {
-    const cur = [Number(n?.pos?.[0]), Number(n?.pos?.[1])];
-    writePoint(n, "pos", px, py);
-    refreshNodeArea(n, cur);
+    if (!restoreNodePosition(n, px, py)) failed.push(n);
   }
+  return failed;
 }
 
 /**
@@ -286,9 +301,16 @@ export function groupBoxIsAt(g, x, y) {
  *     silently dropped, or a getter with NO setter, where assignment throws in a
  *     strict-mode ES module.
  *
- * So: assign (the proven path, and the one that runs any setter bookkeeping),
- * verify, then fall back to an in-place write, then verify again. Returning the
- * verdict is the point — the caller must never report a move it did not make.
+ * IN-PLACE FIRST, then assignment. Order matters: when `pos` is a plain writable
+ * property holding a typed-array VIEW into the node's bounding rect, assigning a
+ * fresh plain array REPLACES the view — the node keeps the right coordinates but
+ * silently loses its aliasing to the rect, and every later write through that
+ * view (LiteGraph's own drag path, the layout store) stops reaching it. Mutating
+ * the two slots keeps the container the engine handed us. Assignment stays as the
+ * fallback for a getter that returns a COPY, where an in-place write is dropped.
+ *
+ * Returning the verdict is the point — the caller must never report a move it did
+ * not make.
  */
 export function writePoint(owner, key, x, y) {
   const landed = () => {
@@ -296,20 +318,20 @@ export function writePoint(owner, key, x, y) {
     const f32 = isFloat32(point);
     return samePoint(Number(point?.[0]), x, f32) && samePoint(Number(point?.[1]), y, f32);
   };
-  try {
-    owner[key] = [x, y];
-  } catch {
-    /* accessor with no setter — strict-mode assignment throws; try in place */
-  }
-  if (landed()) return true;
   const point = owner?.[key];
   if (point && point.length >= 2) {
     try {
       point[0] = x;
       point[1] = y;
     } catch {
-      /* frozen/read-only point — reported as stuck below */
+      /* frozen/read-only point — the assignment below is the remaining hope */
     }
+    if (landed()) return true;
+  }
+  try {
+    owner[key] = [x, y];
+  } catch {
+    /* accessor with no setter — strict-mode assignment throws; reported below */
   }
   return landed();
 }
@@ -401,9 +423,8 @@ export function translateGroupBoxes(groups, dx, dy) {
   return {
     moved,
     stuck,
-    undo: () => {
-      for (const [g, x, y] of attempted) placeGroupBox(g, x, y);
-    },
+    /** Returns the boxes that could NOT be put back. */
+    undo: () => attempted.filter(([g, x, y]) => !placeGroupBox(g, x, y)).map(([g]) => g),
   };
 }
 
@@ -479,9 +500,8 @@ export function moveReroutePoints(reroutes, dx, dy) {
   return {
     moved,
     stuck,
-    undo: () => {
-      for (const [r, px, py] of attempted) placeReroute(r, px, py);
-    },
+    /** Returns the reroutes that could NOT be put back. */
+    undo: () => attempted.filter(([r, px, py]) => !placeReroute(r, px, py)).map(([r]) => r),
   };
 }
 

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -103,6 +103,58 @@ export function boundsAroundNodes(nodes, pad = 30, titlePad = 70) {
   return [minX - pad, minY - titlePad, maxX - minX + pad * 2, maxY - minY + titlePad + pad];
 }
 
+/**
+ * Name an item for a HUMAN-READABLE message, and never throw doing it.
+ *
+ * `id` and `title` are the fields most likely to be exotic — proxies, getters,
+ * reactive stores — and they are needed only for display. Nothing about restoring
+ * geometry requires knowing what a node is called, so a message that cannot be
+ * assembled must degrade to a plainer one rather than raise over a graph the
+ * caller has just been told is intact. `String(x)` throws too (a throwing
+ * toString/Symbol.toPrimitive), so even the coercion is contained.
+ */
+export function describeItem(kind, item) {
+  let text = "?";
+  try {
+    const id = item?.id;
+    if (id != null) text = String(id);
+  } catch {
+    text = "unnamed";
+  }
+  return `${kind} ${text}`;
+}
+
+/** A comma-separated list of at most `max` item names, with an ellipsis when
+ *  truncated. Total, for the same reason describeItem is. */
+export function describeItems(pairs, max = 5) {
+  const names = [];
+  for (const [kind, item] of pairs.slice(0, max)) names.push(describeItem(kind, item));
+  return names.join(", ") + (pairs.length > max ? ", …" : "");
+}
+
+/**
+ * Render a thrown value as text without throwing again.
+ *
+ * The error path of the error path: a caught error may itself be an object whose
+ * `message` getter throws (a throwing `title` on a group is enough to produce
+ * one), and `String(error)` can throw for the same reason. If reading the cause
+ * can defeat the handler that exists to report it, the caller receives a raw
+ * failure for a move that COMPLETED — and re-issues it.
+ */
+export function describeThrown(error) {
+  try {
+    const message = error?.message;
+    if (typeof message === "string") return message;
+  } catch {
+    /* fall through to the coercion attempt */
+  }
+  try {
+    return String(error);
+  } catch {
+    return "an error whose message could not be read";
+  }
+}
+
 /** [x, y, w, h] as finite numbers, or null if any component is not one. */
 function finiteQuad(v) {
   const x = Number(v?.[0]), y = Number(v?.[1]), w = Number(v?.[2]), h = Number(v?.[3]);
@@ -321,22 +373,37 @@ export function syncNodeArea(node, forceCollapsed = false) {
  * it back — while telling the user NOTHING was moved. Moving a mutation earlier
  * does not stop it being a mutation: the pre-flight needs the same
  * contain-per-item-and-return-undo contract as the movers it precedes.
+ *
+ * `walkFailed` is that contract extended to the TRAVERSAL. Containing per item is
+ * not enough while iterating `_nodes` can itself throw — a getter or a proxy can
+ * die fetching the NEXT entry, after earlier rects have already been reconciled,
+ * and a function that threw at that point would never return the undo those
+ * writes need. The accumulator therefore lives outside the loop and the whole
+ * walk is contained, so the caller always gets something it can roll back with.
  */
 export function syncGraphNodeAreas(graph) {
   const unsynced = [];
   const attempted = [];
-  for (const n of graph?._nodes ?? []) {
-    let before = null;
-    try {
-      const br = n?.boundingRect;
-      if (br && br.length === 4) before = [br[0], br[1], br[2], br[3]];
-    } catch {
-      /* unreadable rect: syncNodeArea reports it below; nothing to capture */
+  let walkFailed = false;
+  try {
+    for (const n of graph?._nodes ?? []) {
+      let before = null;
+      try {
+        const br = n?.boundingRect;
+        if (br && br.length === 4) before = [br[0], br[1], br[2], br[3]];
+      } catch {
+        /* unreadable rect: syncNodeArea reports it below; nothing to capture */
+      }
+      if (before) attempted.push([n, before]);
+      if (!syncNodeArea(n)) unsynced.push(n);
     }
-    if (before) attempted.push([n, before]);
-    if (!syncNodeArea(n)) unsynced.push(n);
+  } catch {
+    // The traversal died. Whatever was reconciled before that point is still in
+    // `attempted`, so the undo below is complete for everything actually written.
+    walkFailed = true;
   }
   return {
+    walkFailed,
     unsynced,
     undo: () => {
       const failed = [];

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -198,12 +198,69 @@ export function syncGraphNodeAreas(graph) {
  * the delta correction is exact and build-independent. Dependency-free.
  */
 export function moveGroupMembers(members, dx, dy) {
+  const moved = [];
+  const stuck = [];
   for (const n of members ?? []) {
-    if (!n || !Array.isArray(n.pos)) continue;
-    const prev = [n.pos[0], n.pos[1]];
-    n.pos = [(n.pos[0] ?? 0) + dx, (n.pos[1] ?? 0) + dy];
-    refreshNodeArea(n, prev);
+    const px = Number(n?.pos?.[0]);
+    const py = Number(n?.pos?.[1]);
+    if (!Number.isFinite(px) || !Number.isFinite(py)) {
+      if (n) stuck.push(n);
+      continue;
+    }
+    if (writePoint(n, "pos", px + dx, py + dy)) {
+      refreshNodeArea(n, [px, py]);
+      moved.push(n);
+    } else {
+      stuck.push(n);
+    }
   }
+  return { moved, stuck };
+}
+
+/** Two coordinates are the same point for our purposes. A Float32-backed pos
+ *  (older LiteGraph builds) cannot store an arbitrary double exactly, so an
+ *  `===` read-back would report a perfectly good write as a failed one. */
+function closeEnough(a, b) {
+  return Math.abs(a - b) <= Math.max(1e-3, Math.abs(b) * 1e-6);
+}
+
+/**
+ * Write an [x, y] point property and REPORT whether the write actually landed.
+ *
+ * Frontends back these points with three different shapes and a single write
+ * strategy silently loses on at least one of them:
+ *   - a plain array (assignment and in-place both work);
+ *   - a typed-array VIEW (current builds expose LGraphNode.pos as a Float64Array
+ *     subarray of the node's boundingRect) — `Array.isArray` is FALSE for it, so
+ *     a guard written for plain arrays skipped every node on those builds and the
+ *     group box moved alone: exactly the #408 symptom the move was meant to fix;
+ *   - an accessor pair whose getter returns a COPY, where an in-place write is
+ *     silently dropped, or a getter with NO setter, where assignment throws in a
+ *     strict-mode ES module.
+ *
+ * So: assign (the proven path, and the one that runs any setter bookkeeping),
+ * verify, then fall back to an in-place write, then verify again. Returning the
+ * verdict is the point — the caller must never report a move it did not make.
+ */
+export function writePoint(owner, key, x, y) {
+  const landed = () =>
+    closeEnough(Number(owner?.[key]?.[0]), x) && closeEnough(Number(owner?.[key]?.[1]), y);
+  try {
+    owner[key] = [x, y];
+  } catch {
+    /* accessor with no setter — strict-mode assignment throws; try in place */
+  }
+  if (landed()) return true;
+  const point = owner?.[key];
+  if (point && point.length >= 2) {
+    try {
+      point[0] = x;
+      point[1] = y;
+    } catch {
+      /* frozen/read-only point — reported as stuck below */
+    }
+  }
+  return landed();
 }
 
 /**
@@ -250,19 +307,34 @@ export function nestedGroupsOf(graph, g) {
 /**
  * Translate a group's box by (dx, dy), writing through whichever geometry the
  * build exposes — the `_bounding` quad (plain OR typed array, mutated in place)
- * or the pos/size pair. Mirrors the panel's setGroupBounds write policy.
+ * or the pos/size pair — and REPORT whether the box actually ended up there.
+ * Mirrors the panel's setGroupBounds write policy.
  */
 export function translateGroupBox(g, dx, dy) {
+  const before = groupBoundsOf(g);
+  if (!before) return false;
+  const [x, y] = before;
   const b = g?._bounding;
   if (b && b.length >= 4) {
-    b[0] += dx;
-    b[1] += dy;
-    return;
+    try {
+      b[0] = x + dx;
+      b[1] = y + dy;
+    } catch {
+      /* frozen quad — verified below */
+    }
+  } else {
+    writePoint(g, "pos", x + dx, y + dy);
   }
-  if (!g) return;
-  const x = Number(g.pos?.[0] ?? 0);
-  const y = Number(g.pos?.[1] ?? 0);
-  g.pos = [x + dx, y + dy];
+  const after = groupBoundsOf(g);
+  return !!after && closeEnough(after[0], x + dx) && closeEnough(after[1], y + dy);
+}
+
+/** Translate several group boxes, reporting which ones actually moved. */
+export function translateGroupBoxes(groups, dx, dy) {
+  const moved = [];
+  const stuck = [];
+  for (const g of groups ?? []) (translateGroupBox(g, dx, dy) ? moved : stuck).push(g);
+  return { moved, stuck };
 }
 
 /** Every reroute point of a graph, across the Map / array / plain-object shapes
@@ -293,23 +365,42 @@ export function reroutesInside(graph, bounds) {
 }
 
 /**
- * Translate reroute points by (dx, dy). Writes IN PLACE first because current
- * builds back `Reroute.pos` with a typed array behind a getter (an assignment
- * would be dropped by a getter-only property); if the in-place write did not
- * take, fall back to assigning a fresh pair. Without this a moved group leaves
- * its wire elbows behind and the links visibly snake back to the old box.
+ * Translate reroute points by (dx, dy), reporting which ones actually moved.
+ * Without this a moved group leaves its wire elbows behind and the links
+ * visibly snake back to where the group used to be.
+ *
+ * Prefers the engine's OWN `Reroute.move(dx, dy)` when the build exposes it, so
+ * the frontend's reactive layout store records the change rather than only the
+ * canvas seeing a mutated point — the same "use the engine primitive, then
+ * verify" policy the panel already applies to node.setSize / graph.removeGroup.
+ * The result is verified either way, so a build whose `move` has a different
+ * signature (or none) is corrected by the direct point write, and a frozen point
+ * is reported as stuck instead of throwing halfway through a group move.
  */
 export function moveReroutePoints(reroutes, dx, dy) {
+  const moved = [];
+  const stuck = [];
   for (const r of reroutes ?? []) {
-    const pos = r?.pos;
-    if (!pos || pos.length < 2) continue;
-    const px = Number(pos[0]);
-    const py = Number(pos[1]);
-    if (!Number.isFinite(px) || !Number.isFinite(py)) continue;
-    pos[0] = px + dx;
-    pos[1] = py + dy;
-    if (r.pos?.[0] !== px + dx || r.pos?.[1] !== py + dy) r.pos = [px + dx, py + dy];
+    const px = Number(r?.pos?.[0]);
+    const py = Number(r?.pos?.[1]);
+    if (!Number.isFinite(px) || !Number.isFinite(py)) {
+      if (r) stuck.push(r);
+      continue;
+    }
+    const wantX = px + dx;
+    const wantY = py + dy;
+    const landed = () =>
+      closeEnough(Number(r?.pos?.[0]), wantX) && closeEnough(Number(r?.pos?.[1]), wantY);
+    if (typeof r.move === "function") {
+      try {
+        r.move(dx, dy);
+      } catch {
+        /* build-specific; the direct write below still gets it there */
+      }
+    }
+    (landed() || writePoint(r, "pos", wantX, wantY) ? moved : stuck).push(r);
   }
+  return { moved, stuck };
 }
 
 /**

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -52,35 +52,44 @@ export function nodeFocusBounds(node) {
  * Returns true when the rect is in step with the node's live position.
  */
 export function refreshNodeArea(node, prevPos) {
-  if (!node) return true;
-  const rectBefore = node.boundingRect;
-  const originBefore =
-    rectBefore && rectBefore.length === 4 ? [rectBefore[0], rectBefore[1]] : null;
+  // The whole body is contained, not just the writes: READING `boundingRect` or
+  // `pos` can throw as easily as writing them (a disposed accessor, a revoked
+  // proxy), and this function claims never to throw. A claimed contract that only
+  // holds for the write half is the kind of guard that fails exactly when it is
+  // needed — while the caller is mid-transaction and relying on a verdict.
   try {
-    node.updateArea?.();
+    if (!node) return true;
+    const rectBefore = node.boundingRect;
+    const originBefore =
+      rectBefore && rectBefore.length === 4 ? [rectBefore[0], rectBefore[1]] : null;
+    try {
+      node.updateArea?.();
+    } catch {
+      /* some builds need a canvas ctx; the delta-sync below still corrects it */
+    }
+    const br = node.boundingRect;
+    if (!br || br.length !== 4) return true; // nothing cached ⇒ reads use live pos/size
+    // Engine already moved the rect origin → trust its authoritative recompute.
+    if (originBefore && (br[0] !== originBefore[0] || br[1] !== originBefore[1])) return true;
+    if (!Array.isArray(prevPos) || prevPos.length !== 2) return true;
+    const px = Number(prevPos[0]);
+    const py = Number(prevPos[1]);
+    if (!Number.isFinite(px) || !Number.isFinite(py)) return true;
+    const dx = (node.pos?.[0] ?? 0) - px;
+    const dy = (node.pos?.[1] ?? 0) - py;
+    if (!dx && !dy) return true;
+    const wantX = br[0] + dx;
+    const wantY = br[1] + dy;
+    try {
+      br[0] = wantX;
+      br[1] = wantY;
+    } catch {
+      /* frozen/read-only rect — reported below, never thrown mid-transaction */
+    }
+    return br[0] === wantX && br[1] === wantY;
   } catch {
-    /* some builds need a canvas ctx; the delta-sync below still corrects it */
+    return false; // cannot be shown to be in step ⇒ the caller treats it as stuck
   }
-  const br = node.boundingRect;
-  if (!br || br.length !== 4) return true; // nothing cached ⇒ reads use live pos/size
-  // Engine already moved the rect origin → trust its authoritative recompute.
-  if (originBefore && (br[0] !== originBefore[0] || br[1] !== originBefore[1])) return true;
-  if (!Array.isArray(prevPos) || prevPos.length !== 2) return true;
-  const px = Number(prevPos[0]);
-  const py = Number(prevPos[1]);
-  if (!Number.isFinite(px) || !Number.isFinite(py)) return true;
-  const dx = (node.pos?.[0] ?? 0) - px;
-  const dy = (node.pos?.[1] ?? 0) - py;
-  if (!dx && !dy) return true;
-  const wantX = br[0] + dx;
-  const wantY = br[1] + dy;
-  try {
-    br[0] = wantX;
-    br[1] = wantY;
-  } catch {
-    /* frozen/read-only rect — reported below, never thrown mid-transaction */
-  }
-  return br[0] === wantX && br[1] === wantY;
 }
 
 /** [x, y, w, h] that wraps the given nodes, padded for the group + node titles. */

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -123,22 +123,51 @@ export function boundsAroundNodes(nodes, pad = 30, titlePad = 70) {
  * toString/Symbol.toPrimitive), so even the coercion is contained.
  */
 export function describeItem(kind, item) {
-  let text = "?";
+  // EVERY operation is inside the guard, including the template's coercion of
+  // `kind` and the `String(id)` call. A totality contract that holds for most of
+  // a function is the class of comment this codebase keeps getting burned by:
+  // callers guard on the promise, not on the implementation.
   try {
-    const id = item?.id;
-    if (id != null) text = String(id);
+    let text = "?";
+    try {
+      const id = item?.id;
+      if (id != null) text = String(id);
+    } catch {
+      text = "unnamed";
+    }
+    return `${String(kind)} ${text}`;
   } catch {
-    text = "unnamed";
+    return "an item that could not be named";
   }
-  return `${kind} ${text}`;
 }
 
 /** A comma-separated list of at most `max` item names, with an ellipsis when
- *  truncated. Total, for the same reason describeItem is. */
+ *  truncated. Total, for the same reason describeItem is — `slice`, the entry
+ *  destructuring and `length` are all operations on a caller-supplied value, so
+ *  they are inside the guard too. */
 export function describeItems(pairs, max = 5) {
-  const names = [];
-  for (const [kind, item] of pairs.slice(0, max)) names.push(describeItem(kind, item));
-  return names.join(", ") + (pairs.length > max ? ", …" : "");
+  try {
+    const names = [];
+    let count = 0;
+    for (const entry of pairs ?? []) {
+      if (count >= max) break;
+      count += 1;
+      try {
+        names.push(describeItem(entry?.[0], entry?.[1]));
+      } catch {
+        names.push("an item that could not be named");
+      }
+    }
+    let total = count;
+    try {
+      total = Number(pairs?.length);
+    } catch {
+      total = count;
+    }
+    return names.join(", ") + (Number.isFinite(total) && total > max ? ", …" : "");
+  } catch {
+    return "items that could not be named";
+  }
 }
 
 /**
@@ -396,12 +425,19 @@ export function syncGraphNodeAreas(graph) {
   let walkFailed = false;
   try {
     for (const n of graph?._nodes ?? []) {
+      // SNAPSHOT FIRST, and never write what the snapshot could not capture. The
+      // snapshot is itself inside the transaction: a rect whose `[1]` getter
+      // throws once and then accepts every subsequent write would otherwise be
+      // reconciled with NO undo recorded for it — and a later refusal would say
+      // "NOTHING was moved" over a node it has no way to put back. You cannot undo
+      // what you never recorded, so an uncapturable node is reported instead.
       let before = null;
       try {
         const br = n?.boundingRect;
         if (br && br.length === 4) before = [br[0], br[1], br[2], br[3]];
       } catch {
-        /* unreadable rect: syncNodeArea reports it below; nothing to capture */
+        unsynced.push(n);
+        continue; // unreadable rect ⇒ no restore point ⇒ do not touch it
       }
       if (before) attempted.push([n, before]);
       if (!syncNodeArea(n)) unsynced.push(n);

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -42,9 +42,17 @@ export function nodeFocusBounds(node) {
  * shifts the bounding-box origin by the same amount, so this correction is exact
  * and build-independent. Dependency-free (no LiteGraph, no DOM) so it is
  * unit-testable with plain object fixtures.
+ *
+ * NEVER THROWS. This runs AFTER a node's position has already been written, so a
+ * throw here would escape from the middle of a group move — past the caller's
+ * rollback, which only runs once the mover returns — and leak a moved node out
+ * under an unrelated TypeError. A cached rect that will not accept the correction
+ * is reported by the return value (false) instead, so the caller can treat that
+ * node as stuck and refuse the whole move rather than discovering it mid-flight.
+ * Returns true when the rect is in step with the node's live position.
  */
 export function refreshNodeArea(node, prevPos) {
-  if (!node) return;
+  if (!node) return true;
   const rectBefore = node.boundingRect;
   const originBefore =
     rectBefore && rectBefore.length === 4 ? [rectBefore[0], rectBefore[1]] : null;
@@ -54,19 +62,25 @@ export function refreshNodeArea(node, prevPos) {
     /* some builds need a canvas ctx; the delta-sync below still corrects it */
   }
   const br = node.boundingRect;
-  if (!br || br.length !== 4) return;
+  if (!br || br.length !== 4) return true; // nothing cached ⇒ reads use live pos/size
   // Engine already moved the rect origin → trust its authoritative recompute.
-  if (originBefore && (br[0] !== originBefore[0] || br[1] !== originBefore[1])) return;
-  if (!Array.isArray(prevPos) || prevPos.length !== 2) return;
+  if (originBefore && (br[0] !== originBefore[0] || br[1] !== originBefore[1])) return true;
+  if (!Array.isArray(prevPos) || prevPos.length !== 2) return true;
   const px = Number(prevPos[0]);
   const py = Number(prevPos[1]);
-  if (!Number.isFinite(px) || !Number.isFinite(py)) return;
+  if (!Number.isFinite(px) || !Number.isFinite(py)) return true;
   const dx = (node.pos?.[0] ?? 0) - px;
   const dy = (node.pos?.[1] ?? 0) - py;
-  if (dx || dy) {
-    br[0] += dx;
-    br[1] += dy;
+  if (!dx && !dy) return true;
+  const wantX = br[0] + dx;
+  const wantY = br[1] + dy;
+  try {
+    br[0] = wantX;
+    br[1] = wantY;
+  } catch {
+    /* frozen/read-only rect — reported below, never thrown mid-transaction */
   }
+  return br[0] === wantX && br[1] === wantY;
 }
 
 /** [x, y, w, h] that wraps the given nodes, padded for the group + node titles. */
@@ -89,11 +103,31 @@ export function boundsAroundNodes(nodes, pad = 30, titlePad = 70) {
   return [minX - pad, minY - titlePad, maxX - minX + pad * 2, maxY - minY + titlePad + pad];
 }
 
-/** Current [x,y,w,h] of a group box, or null if not finite. */
-export function groupBoundsOf(g) {
-  const b = g?._bounding ?? [g?.pos?.[0], g?.pos?.[1], g?.size?.[0], g?.size?.[1]];
-  const x = Number(b?.[0]), y = Number(b?.[1]), w = Number(b?.[2]), h = Number(b?.[3]);
+/** [x, y, w, h] as finite numbers, or null if any component is not one. */
+function finiteQuad(v) {
+  const x = Number(v?.[0]), y = Number(v?.[1]), w = Number(v?.[2]), h = Number(v?.[3]);
   return [x, y, w, h].every(Number.isFinite) ? [x, y, w, h] : null;
+}
+
+/**
+ * Current [x, y, w, h] of a group box, or null when the build exposes neither
+ * usable form.
+ *
+ * The fallback to pos/size is on VALIDITY, not on `_bounding` being nullish. A
+ * present-but-malformed `_bounding` (a half-initialised quad, a leftover from a
+ * failed deserialize) used to short-circuit the `??` and make the whole group
+ * read as unbounded — so a group carrying perfectly good finite pos/size was
+ * refused as having no usable bounds. "Present" is not "usable".
+ */
+export function groupBoundsOf(g) {
+  try {
+    return (
+      finiteQuad(g?._bounding) ??
+      finiteQuad([g?.pos?.[0], g?.pos?.[1], g?.size?.[0], g?.size?.[1]])
+    );
+  } catch {
+    return null; // a hostile/disposed accessor is "no usable bounds", not a throw
+  }
 }
 
 /**
@@ -144,26 +178,83 @@ export function groupMemberNodes(graph, g) {
  * is no cached rect — nodeFocusBounds already uses live pos/size in that case.
  * Mutates in place so it works on plain arrays AND typed-array rects (ComfyUI
  * Rectangle). Dependency-free for unit testing with plain object fixtures.
+ *
+ * A COLLAPSED node is synced to its COLLAPSED footprint — the title pill LiteGraph
+ * actually draws — not skipped and not given the full pos/size box. Skipping it
+ * (the original #416 guard) kept its area from being overstated but left the rect
+ * STALE, and membership is boundingRect-first: a collapsed node sitting inside a
+ * group box while its cached rect claimed somewhere else was silently omitted from
+ * the group (left behind by a move, reported as zero moved) or reported as newly
+ * enclosed when it was not. Writing the pill keeps #416's guarantee — the area is
+ * never overstated — while making the rect live. `forceCollapsed` still writes the
+ * FULL footprint, which create-by-node_ids needs because it builds the box around
+ * the node's full pos/size (#391).
+ *
+ * NEVER THROWS: this is called from read paths and from inside a group move, so a
+ * frozen rect must be reported (false), never raised. Returns whether the cached
+ * rect now matches the footprint it was asked to describe.
  */
+export const COLLAPSED_TITLE_HEIGHT = 30;
+export const COLLAPSED_PILL_WIDTH = 80; // LiteGraph.NODE_COLLAPSED_WIDTH
+
+/** The rect a node's cached boundingRect SHOULD hold for its live pos/size. */
+function wantedNodeArea(node, forceCollapsed = false) {
+  const collapsed = !!node.flags?.collapsed && !forceCollapsed;
+  const w = collapsed
+    ? Number(node._collapsed_width) || COLLAPSED_PILL_WIDTH
+    : node.size?.[0] ?? 200;
+  const h = collapsed ? 0 : node.size?.[1] ?? 100;
+  return [
+    node.pos?.[0] ?? 0,
+    (node.pos?.[1] ?? 0) - COLLAPSED_TITLE_HEIGHT, // title bar renders above pos
+    w,
+    h + COLLAPSED_TITLE_HEIGHT,
+  ];
+}
+
+/**
+ * Does this node's cached rect describe where the node ACTUALLY is? A pure read.
+ *
+ * This, not "did my delta-write succeed", is the property that matters: a rect
+ * that never had to move is already live, and reporting it as stuck would refuse
+ * a perfectly good move (or invent a partial one during a rollback). True when
+ * there is no cached rect at all, since reads then use live pos/size.
+ */
+export function nodeAreaIsLive(node) {
+  try {
+    const br = node?.boundingRect;
+    if (!br || br.length !== 4) return true;
+    return wantedNodeArea(node).every((v, i) => br[i] === v);
+  } catch {
+    return false; // an unreadable node cannot be shown to be live
+  }
+}
+
 export function syncNodeArea(node, forceCollapsed = false) {
-  const br = node?.boundingRect;
-  if (!br || br.length !== 4) return;
-  // A COLLAPSED node's real footprint is just its title band (a small pill), not
-  // its full pos/size. When syncing UNREQUESTED nodes in bulk (syncGraphNodeAreas,
-  // used before a bounds/query membership read) overwriting a collapsed node's
-  // cached rect with the full footprint would OVERSTATE its area and could wrongly
-  // pull it into a nearby group box — so skip it and leave its (already-small)
-  // rect to the engine (#416). But when the caller explicitly REQUESTED this node
-  // (create-by-node_ids), force the sync: the group box is built around the node's
-  // full pos/size (boundsAroundNodes), so its rect must match to be a member of its
-  // own box — otherwise a requested collapsed node with a stale rect is dropped (#391).
-  if (node.flags?.collapsed && !forceCollapsed) return;
-  const w = node.size?.[0] ?? 200;
-  const h = node.size?.[1] ?? 100;
-  br[0] = node.pos?.[0] ?? 0;
-  br[1] = (node.pos?.[1] ?? 0) - 30; // title bar renders above pos
-  br[2] = w;
-  br[3] = h + 30;
+  try {
+    // Read the live geometry FIRST, even when there is no cached rect to write.
+    // This is what makes the bulk sync a genuine readability pre-flight: a node
+    // whose pos/size/flags accessors are hostile or disposed is reported here,
+    // before groupMemberNodes touches it and raises a bare TypeError at a caller
+    // who asked to move a group.
+    const want = wantedNodeArea(node, forceCollapsed);
+    const br = node?.boundingRect;
+    if (!br || br.length !== 4) return true;
+    try {
+      br[0] = want[0];
+      br[1] = want[1];
+      br[2] = want[2];
+      br[3] = want[3];
+    } catch {
+      /* frozen/read-only rect — reported below, never thrown into a caller */
+    }
+    return want.every((v, i) => br[i] === v);
+  } catch {
+    // A hostile/disposed accessor (pos, size, flags, boundingRect) must be
+    // REPORTED — this runs in read paths and in a move's pre-flight, where a raw
+    // TypeError would replace a clean refusal.
+    return false;
+  }
 }
 
 /**
@@ -176,11 +267,17 @@ export function syncNodeArea(node, forceCollapsed = false) {
  * boundingRect-first footprint (nodeFocusBounds), a single stale rect makes the
  * box wrap a node the geometry misses — or capture one that has moved away —
  * yielding the wrong node_ids (#416). Syncing all rects to live geometry first
- * makes the membership reflect the CURRENT layout. Collapsed nodes are left
- * untouched by syncNodeArea (see above). Dependency-free for unit testing.
+ * makes the membership reflect the CURRENT layout. Collapsed nodes are synced to
+ * their collapsed pill rather than skipped (see syncNodeArea). Dependency-free.
+ *
+ * NEVER THROWS, and returns the nodes whose cached rect would not accept the
+ * resync. Callers doing this as a PRE-FLIGHT before mutating can then refuse up
+ * front instead of discovering an unwritable rect halfway through a transaction.
  */
 export function syncGraphNodeAreas(graph) {
-  for (const n of graph?._nodes ?? []) syncNodeArea(n);
+  const unsynced = [];
+  for (const n of graph?._nodes ?? []) if (!syncNodeArea(n)) unsynced.push(n);
+  return unsynced;
 }
 
 /**
@@ -202,14 +299,27 @@ export function moveGroupMembers(members, dx, dy) {
   const stuck = [];
   const attempted = [];
   for (const n of members ?? []) {
-    const px = Number(n?.pos?.[0]);
-    const py = Number(n?.pos?.[1]);
+    // Per-item containment. If this loop threw partway it would never RETURN its
+    // undo, so everything it had already moved would be unrecoverable — the
+    // caller's rollback cannot undo what it was never handed. Reading `pos` can
+    // itself throw (a getter over a disposed/revoked proxy), so the read is inside
+    // the guard too. A throwing item is stuck, exactly like an unwritable one.
+    let px = Number.NaN;
+    let py = Number.NaN;
+    try {
+      px = Number(n?.pos?.[0]);
+      py = Number(n?.pos?.[1]);
+    } catch {
+      /* unreadable position ⇒ stuck below */
+    }
     if (!Number.isFinite(px) || !Number.isFinite(py)) {
       if (n) stuck.push(n);
       continue;
     }
     attempted.push([n, px, py]);
-    const landedExactly = writePoint(n, "pos", px + dx, py + dy);
+    let landedExactly = false;
+    try {
+      landedExactly = writePoint(n, "pos", px + dx, py + dy);
     // Sync the cached rect UNCONDITIONALLY. A write can miss its target and still
     // RELOCATE the node (a setter that snaps or clamps): refreshing only on an
     // exact landing would leave that node's cached rect describing where it used
@@ -217,7 +327,18 @@ export function moveGroupMembers(members, dx, dy) {
     // cached rect — would place it in the group it has actually left. The refresh
     // is a delta from the pre-write position, so it is correct wherever the node
     // ended up, including "did not move at all".
-    refreshNodeArea(n, [px, py]);
+      // A rect that will not accept the correction makes the node STUCK, not an
+      // exception: its live position and its cached rect would disagree, and
+      // membership is rect-first, so leaving it "moved" would report it in a group
+      // it is no longer in. refreshNodeArea never throws precisely so this decision
+      // is made here rather than escaping past the caller's rollback. The verdict
+      // is whether the rect ends up LIVE, not whether the delta-write happened: a
+      // rect that was already right needs no write and is not stuck.
+      refreshNodeArea(n, [px, py]);
+      if (!nodeAreaIsLive(n)) landedExactly = false;
+    } catch {
+      landedExactly = false;
+    }
     (landedExactly ? moved : stuck).push(n);
   }
   return { moved, stuck, undo: () => restoreNodePositions(attempted) };
@@ -229,7 +350,10 @@ function restoreNodePosition(n, px, py) {
   const cur = [Number(n?.pos?.[0]), Number(n?.pos?.[1])];
   const ok = writePoint(n, "pos", px, py);
   refreshNodeArea(n, cur);
-  return ok;
+  // "Back where it started" means the position is restored AND the cached rect
+  // describes it — a rect that never moved is already live and must not be
+  // reported as an unrestorable item, which would invent a partial move.
+  return ok && nodeAreaIsLive(n);
 }
 
 /**
@@ -251,7 +375,16 @@ function restoreNodePosition(n, px, py) {
 function restoreNodePositions(attempted) {
   const failed = [];
   for (const [n, px, py] of attempted ?? []) {
-    if (!restoreNodePosition(n, px, py)) failed.push(n);
+    // Per-item containment again: one unrestorable node must not stop the rest of
+    // the rollback, and must be REPORTED rather than raised — a throw here would
+    // replace the caller's carefully-worded refusal with a raw TypeError.
+    let ok = false;
+    try {
+      ok = restoreNodePosition(n, px, py);
+    } catch {
+      ok = false;
+    }
+    if (!ok) failed.push(n);
   }
   return failed;
 }
@@ -416,8 +549,25 @@ export function nestedGroupsOf(graph, g) {
   return (graph?._groups ?? []).filter((other) => {
     if (!other || other === g) return false;
     const inner = groupBoundsOf(other);
-    return !!inner && containsBounds(outer, inner);
+    // Same rule as reroutesInside: a box we cannot read is UNKNOWN, not "outside".
+    // It rides along so it is classified stuck and the move is refused, rather
+    // than being quietly left behind by a move that reports success.
+    if (!inner) return !groupHasReadableBounds(other);
+    return containsBounds(outer, inner);
   });
+}
+
+/** Could we read this group's geometry at all? Distinguishes "no usable bounds"
+ *  (a well-formed object we can inspect) from "unreadable" (a hostile accessor). */
+function groupHasReadableBounds(g) {
+  try {
+    void g?._bounding;
+    void g?.pos?.[0];
+    void g?.size?.[0];
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -427,6 +577,14 @@ export function nestedGroupsOf(graph, g) {
  * Mirrors the panel's setGroupBounds write policy.
  */
 export function placeGroupBox(g, x, y) {
+  try {
+    return placeGroupBoxUnsafe(g, x, y);
+  } catch {
+    return false; // never raised out of a move or its rollback
+  }
+}
+
+function placeGroupBoxUnsafe(g, x, y) {
   // A move must not change the SIZE. Capture it first and verify it survived, so
   // a build that resizes on reposition is reported as not-moved instead of
   // silently reshaping the user's group.
@@ -460,21 +618,25 @@ export function translateGroupBox(g, dx, dy) {
  */
 function restoreGroupBox(g, quad) {
   const [x, y, w, h] = quad;
-  const b = g?._bounding;
-  if (b && b.length >= 4) {
-    try {
-      b[0] = x;
-      b[1] = y;
-      b[2] = w;
-      b[3] = h;
-    } catch {
-      /* frozen quad — verified below */
+  try {
+    const b = g?._bounding;
+    if (b && b.length >= 4) {
+      try {
+        b[0] = x;
+        b[1] = y;
+        b[2] = w;
+        b[3] = h;
+      } catch {
+        /* frozen quad — verified below */
+      }
+    } else {
+      writePoint(g, "pos", x, y);
+      writePoint(g, "size", w, h);
     }
-  } else {
-    writePoint(g, "pos", x, y);
-    writePoint(g, "size", w, h);
+    return groupBoxIsAt(g, x, y, w, h);
+  } catch {
+    return false; // a rollback reports, it never raises
   }
-  return groupBoxIsAt(g, x, y, w, h);
 }
 
 /** Translate several group boxes, reporting which ones actually moved and
@@ -485,7 +647,12 @@ export function translateGroupBoxes(groups, dx, dy) {
   const stuck = [];
   const attempted = [];
   for (const g of groups ?? []) {
-    const before = groupBoundsOf(g);
+    let before = null;
+    try {
+      before = groupBoundsOf(g);
+    } catch {
+      /* unreadable bounds ⇒ stuck below */
+    }
     if (!before) {
       if (g) stuck.push(g);
       continue;
@@ -521,48 +688,95 @@ export function reroutesInside(graph, bounds) {
   if (!bounds) return [];
   const [x, y, w, h] = bounds;
   return allReroutes(graph).filter((r) => {
-    const px = Number(r?.pos?.[0]);
-    const py = Number(r?.pos?.[1]);
-    if (!Number.isFinite(px) || !Number.isFinite(py)) return false;
+    // Three cases, and only one of them is "outside":
+    //  - the position cannot be READ at all (hostile/disposed accessor), or it is
+    //    present but not finite ⇒ UNKNOWN. Unknown is not "outside": include it so
+    //    it goes down the same path as any other item that will not accept a new
+    //    position — reported stuck, whole move refused — rather than being quietly
+    //    dropped while the group moves away from it.
+    //  - no `pos` at all ⇒ not a positioned item; there is nothing to move and
+    //    nothing to be wrong about.
+    let pos;
+    try {
+      pos = r?.pos;
+    } catch {
+      return true;
+    }
+    if (pos == null || pos.length < 2) return false;
+    let px;
+    let py;
+    try {
+      px = Number(pos[0]);
+      py = Number(pos[1]);
+    } catch {
+      return true;
+    }
+    if (!Number.isFinite(px) || !Number.isFinite(py)) return true;
     return px >= x && px < x + w && py >= y && py < y + h;
   });
 }
 
 /**
- * Translate reroute points by (dx, dy), reporting which ones actually moved.
- * Without this a moved group leaves its wire elbows behind and the links
- * visibly snake back to where the group used to be.
+ * Can this reroute be repositioned SOUNDLY? A pure read — safe to call as a
+ * pre-flight, before anything has been mutated.
  *
- * Prefers the engine's OWN `Reroute.move(dx, dy)` when the build exposes it, so
- * the frontend's reactive layout store records the change rather than only the
- * canvas seeing a mutated point — the same "use the engine primitive, then
- * verify" policy the panel already applies to node.setSize / graph.removeGroup.
- * The result is verified either way, so a build whose `move` has a different
- * signature (or none) is corrected by the direct point write, and a frozen point
- * is reported as stuck instead of throwing halfway through a group move.
+ * We must never learn what a build's `Reroute.move()` means by CALLING it. An
+ * earlier version invoked `move(x - cx, y - cy)` assuming a relative API and then
+ * "corrected" `r.pos` if the point ended up somewhere else. On a build where
+ * `move(x, y)` is ABSOLUTE and also writes a reactive/persisted store, that
+ * sequence is silent corruption: a reroute at [100,100] targeting [200,200] gets
+ * move(100,100), the STORE records [100,100], the fallback fixes only the in-place
+ * `pos` array to [200,200], verification passes, success is reported — and the
+ * next render or save resurrects the wrong coordinate. Arity cannot tell the two
+ * signatures apart, and a "no-op probe" of move(0,0) is a teleport on the absolute
+ * build. There is no non-destructive way to find out, so we do not try.
+ *
+ * What IS sound is writing `pos` when that is an accessor: the setter is the
+ * engine's own write path (current @comfyorg/litegraph defines `Reroute.pos` as a
+ * get/set pair over its own Float64Array), so any store bookkeeping runs, with no
+ * guess about anyone's signature. When `pos` is a plain slot AND the build also
+ * exposes a `move()` we cannot characterise, the honest answer is "unknown": the
+ * reroute is reported stuck and the whole move is refused with a remedy, rather
+ * than moved on a coin-flip whose failure mode only shows up at save time.
  */
-export function placeReroute(r, x, y) {
-  const cx = Number(r?.pos?.[0]);
-  const cy = Number(r?.pos?.[1]);
-  if (typeof r?.move === "function" && Number.isFinite(cx) && Number.isFinite(cy)) {
-    try {
-      r.move(x - cx, y - cy);
-    } catch {
-      /* build-specific; the direct write below still gets it there */
-    }
-    const f32 = isFloat32(r?.pos);
-    if (samePoint(Number(r?.pos?.[0]), x, f32) && samePoint(Number(r?.pos?.[1]), y, f32)) return true;
-  }
-  return writePoint(r, "pos", x, y);
+export function rerouteWriteIsSound(r) {
+  if (hasSetter(r, "pos")) return true;
+  return typeof r?.move !== "function";
 }
 
+/**
+ * Put a reroute point at (x, y) and report whether it is really there. Only ever
+ * writes `pos` — see rerouteWriteIsSound for why `move()` is never invoked.
+ */
+export function placeReroute(r, x, y) {
+  // Never throws: it runs inside a group move (and inside that move's rollback),
+  // so a hostile accessor must be reported as "did not move", not raised.
+  try {
+    if (!rerouteWriteIsSound(r)) return false;
+    return writePoint(r, "pos", x, y);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Translate reroute points by (dx, dy), reporting which ones actually moved.
+ * Without this a moved group leaves its wire elbows behind and the links visibly
+ * snake back to where the group used to be.
+ */
 export function moveReroutePoints(reroutes, dx, dy) {
   const moved = [];
   const stuck = [];
   const attempted = [];
   for (const r of reroutes ?? []) {
-    const px = Number(r?.pos?.[0]);
-    const py = Number(r?.pos?.[1]);
+    let px = Number.NaN;
+    let py = Number.NaN;
+    try {
+      px = Number(r?.pos?.[0]);
+      py = Number(r?.pos?.[1]);
+    } catch {
+      /* unreadable point ⇒ stuck below */
+    }
     if (!Number.isFinite(px) || !Number.isFinite(py)) {
       if (r) stuck.push(r);
       continue;

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -451,6 +451,32 @@ export function translateGroupBox(g, dx, dy) {
   return placeGroupBox(g, before[0] + dx, before[1] + dy);
 }
 
+/**
+ * Restore a group's FULL box — corner and size — and report whether it is really
+ * back. placeGroupBox writes only the corner, which is right for a move but wrong
+ * for an undo: if the forward write reshaped the box on the way through, putting
+ * the corner back leaves the wrong size behind while the caller announces that
+ * nothing was moved.
+ */
+function restoreGroupBox(g, quad) {
+  const [x, y, w, h] = quad;
+  const b = g?._bounding;
+  if (b && b.length >= 4) {
+    try {
+      b[0] = x;
+      b[1] = y;
+      b[2] = w;
+      b[3] = h;
+    } catch {
+      /* frozen quad — verified below */
+    }
+  } else {
+    writePoint(g, "pos", x, y);
+    writePoint(g, "size", w, h);
+  }
+  return groupBoxIsAt(g, x, y, w, h);
+}
+
 /** Translate several group boxes, reporting which ones actually moved and
  *  handing back an ABSOLUTE undo (see restoreNodePositions for why the inverse
  *  delta is not good enough). */
@@ -464,14 +490,14 @@ export function translateGroupBoxes(groups, dx, dy) {
       if (g) stuck.push(g);
       continue;
     }
-    attempted.push([g, before[0], before[1]]);
+    attempted.push([g, before]);
     (placeGroupBox(g, before[0] + dx, before[1] + dy) ? moved : stuck).push(g);
   }
   return {
     moved,
     stuck,
     /** Returns the boxes that could NOT be put back. */
-    undo: () => attempted.filter(([g, x, y]) => !placeGroupBox(g, x, y)).map(([g]) => g),
+    undo: () => attempted.filter(([g, quad]) => !restoreGroupBox(g, quad)).map(([g]) => g),
   };
 }
 

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -320,13 +320,20 @@ export function groupBoxIsAt(g, x, y, w, h) {
  *     silently dropped, or a getter with NO setter, where assignment throws in a
  *     strict-mode ES module.
  *
- * IN-PLACE FIRST, then assignment. Order matters: when `pos` is a plain writable
- * property holding a typed-array VIEW into the node's bounding rect, assigning a
- * fresh plain array REPLACES the view — the node keeps the right coordinates but
- * silently loses its aliasing to the rect, and every later write through that
- * view (LiteGraph's own drag path, the layout store) stops reaching it. Mutating
- * the two slots keeps the container the engine handed us. Assignment stays as the
- * fallback for a getter that returns a COPY, where an in-place write is dropped.
+ * WHICH WRITE GOES FIRST DEPENDS ON THE PROPERTY, and both orders are wrong for
+ * the other kind:
+ *   - An ACCESSOR with a setter (current ComfyUI's LGraphNode.pos) must be
+ *     ASSIGNED. Its setter does more than store two numbers — it commits the move
+ *     to the frontend's layout store — and a setter writes into the array it
+ *     already owns, so assignment does not replace anything. Poking the array
+ *     directly moves the canvas while the layout store keeps the old coordinates.
+ *   - A plain DATA property holding a typed-array VIEW (into the node's bounding
+ *     rect) must be written IN PLACE. Assigning a fresh array there replaces the
+ *     view: right coordinates, silently severed aliasing, and every later write
+ *     through that view stops reaching the node.
+ * So the property is inspected once and the write that respects it goes first;
+ * the other stays as a fallback (a getter that returns a COPY drops an in-place
+ * write; a getter with no setter throws on assignment in a strict-mode module).
  *
  * Returning the verdict is the point — the caller must never report a move it did
  * not make.
@@ -337,22 +344,39 @@ export function writePoint(owner, key, x, y) {
     const f32 = isFloat32(point);
     return samePoint(Number(point?.[0]), x, f32) && samePoint(Number(point?.[1]), y, f32);
   };
-  const point = owner?.[key];
-  if (point && point.length >= 2) {
+  const assign = () => {
+    try {
+      owner[key] = [x, y];
+    } catch {
+      /* accessor with no setter — strict-mode assignment throws */
+    }
+  };
+  const inPlace = () => {
+    const point = owner?.[key];
+    if (!point || point.length < 2) return;
     try {
       point[0] = x;
       point[1] = y;
     } catch {
-      /* frozen/read-only point — the assignment below is the remaining hope */
+      /* frozen/read-only point */
     }
-    if (landed()) return true;
-  }
-  try {
-    owner[key] = [x, y];
-  } catch {
-    /* accessor with no setter — strict-mode assignment throws; reported below */
-  }
+  };
+  const [first, second] = hasSetter(owner, key) ? [assign, inPlace] : [inPlace, assign];
+  first();
+  if (landed()) return true;
+  second();
   return landed();
+}
+
+/** Does writing `owner[key]` run a SETTER (rather than replacing a data
+ *  property)? Walks the prototype chain, because LiteGraph defines its geometry
+ *  accessors on the class prototype, not on each instance. */
+function hasSetter(owner, key) {
+  for (let o = owner; o != null; o = Object.getPrototypeOf(o)) {
+    const d = Object.getOwnPropertyDescriptor(o, key);
+    if (d) return typeof d.set === "function";
+  }
+  return false;
 }
 
 /**

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -209,12 +209,16 @@ export function moveGroupMembers(members, dx, dy) {
       continue;
     }
     attempted.push([n, px, py]);
-    if (writePoint(n, "pos", px + dx, py + dy)) {
-      refreshNodeArea(n, [px, py]);
-      moved.push(n);
-    } else {
-      stuck.push(n);
-    }
+    const landedExactly = writePoint(n, "pos", px + dx, py + dy);
+    // Sync the cached rect UNCONDITIONALLY. A write can miss its target and still
+    // RELOCATE the node (a setter that snaps or clamps): refreshing only on an
+    // exact landing would leave that node's cached rect describing where it used
+    // to be, and every geometric membership read afterwards — which prefers the
+    // cached rect — would place it in the group it has actually left. The refresh
+    // is a delta from the pre-write position, so it is correct wherever the node
+    // ended up, including "did not move at all".
+    refreshNodeArea(n, [px, py]);
+    (landedExactly ? moved : stuck).push(n);
   }
   return { moved, stuck, undo: () => restoreNodePositions(attempted) };
 }
@@ -280,11 +284,26 @@ function isFloat32(container) {
   return typeof Float32Array !== "undefined" && container instanceof Float32Array;
 }
 
-/** Did the group's box actually end up with its top-left at (x, y)? */
-export function groupBoxIsAt(g, x, y) {
+/**
+ * Did the group's box actually end up as [x, y] — and, when `w`/`h` are given,
+ * with those dimensions?
+ *
+ * The size half is not decoration. A group box is written component by component
+ * (setGroupBounds assigns x, y, w AND h), so a clamping setter or a throw partway
+ * through the quad can leave the box at the right corner with the wrong size, or
+ * put the corner back while the size stays corrupted. Verifying only the top-left
+ * would call both of those a completed move — and, worse, would let a rollback
+ * report "nothing was moved" over a box whose dimensions no longer match what the
+ * user had.
+ */
+export function groupBoxIsAt(g, x, y, w, h) {
   const after = groupBoundsOf(g);
+  if (!after) return false;
   const f32 = isFloat32(g?._bounding);
-  return !!after && samePoint(after[0], x, f32) && samePoint(after[1], y, f32);
+  if (!samePoint(after[0], x, f32) || !samePoint(after[1], y, f32)) return false;
+  if (w != null && !samePoint(after[2], w, f32)) return false;
+  if (h != null && !samePoint(after[3], h, f32)) return false;
+  return true;
 }
 
 /**
@@ -384,6 +403,10 @@ export function nestedGroupsOf(graph, g) {
  * Mirrors the panel's setGroupBounds write policy.
  */
 export function placeGroupBox(g, x, y) {
+  // A move must not change the SIZE. Capture it first and verify it survived, so
+  // a build that resizes on reposition is reported as not-moved instead of
+  // silently reshaping the user's group.
+  const before = groupBoundsOf(g);
   const b = g?._bounding;
   if (b && b.length >= 4) {
     try {
@@ -395,7 +418,7 @@ export function placeGroupBox(g, x, y) {
   } else {
     writePoint(g, "pos", x, y);
   }
-  return groupBoxIsAt(g, x, y);
+  return groupBoxIsAt(g, x, y, before?.[2], before?.[3]);
 }
 
 export function translateGroupBox(g, dx, dy) {

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -512,13 +512,22 @@ function isFloat32(container) {
  * user had.
  */
 export function groupBoxIsAt(g, x, y, w, h) {
-  const after = groupBoundsOf(g);
-  if (!after) return false;
-  const f32 = isFloat32(g?._bounding);
-  if (!samePoint(after[0], x, f32) || !samePoint(after[1], y, f32)) return false;
-  if (w != null && !samePoint(after[2], w, f32)) return false;
-  if (h != null && !samePoint(after[3], h, f32)) return false;
-  return true;
+  // Total, like every other guard here. groupBoundsOf is safe, but the follow-up
+  // `g._bounding` read is a second touch of the same accessor — and this runs as
+  // the verification step of a box write, AFTER the children have moved and
+  // BEFORE the rollback. A throw there would escape the transaction through the
+  // very check that exists to keep it honest.
+  try {
+    const after = groupBoundsOf(g);
+    if (!after) return false;
+    const f32 = isFloat32(g?._bounding);
+    if (!samePoint(after[0], x, f32) || !samePoint(after[1], y, f32)) return false;
+    if (w != null && !samePoint(after[2], w, f32)) return false;
+    if (h != null && !samePoint(after[3], h, f32)) return false;
+    return true;
+  } catch {
+    return false; // cannot be shown to be there ⇒ treated as not there
+  }
 }
 
 /**

--- a/web/js/lib/group-geometry.js
+++ b/web/js/lib/group-geometry.js
@@ -200,6 +200,7 @@ export function syncGraphNodeAreas(graph) {
 export function moveGroupMembers(members, dx, dy) {
   const moved = [];
   const stuck = [];
+  const attempted = [];
   for (const n of members ?? []) {
     const px = Number(n?.pos?.[0]);
     const py = Number(n?.pos?.[1]);
@@ -207,6 +208,7 @@ export function moveGroupMembers(members, dx, dy) {
       if (n) stuck.push(n);
       continue;
     }
+    attempted.push([n, px, py]);
     if (writePoint(n, "pos", px + dx, py + dy)) {
       refreshNodeArea(n, [px, py]);
       moved.push(n);
@@ -214,14 +216,60 @@ export function moveGroupMembers(members, dx, dy) {
       stuck.push(n);
     }
   }
-  return { moved, stuck };
+  return { moved, stuck, undo: () => restoreNodePositions(attempted) };
 }
 
-/** Two coordinates are the same point for our purposes. A Float32-backed pos
- *  (older LiteGraph builds) cannot store an arbitrary double exactly, so an
- *  `===` read-back would report a perfectly good write as a failed one. */
-function closeEnough(a, b) {
-  return Math.abs(a - b) <= Math.max(1e-3, Math.abs(b) * 1e-6);
+/**
+ * Put every ATTEMPTED node back at the exact coordinates it had before the move,
+ * whether its write landed, landed somewhere else, or did not land at all.
+ *
+ * Undoing by the inverse delta is not good enough: a build whose setter clamps or
+ * snaps leaves the node at a THIRD position, which writePoint correctly reports
+ * as not-landed — and an undo that only walked the `moved` list would leave that
+ * node displaced while the caller announced that nothing had moved. Restoring
+ * absolutely, over the whole attempted set, is what makes that announcement true.
+ */
+function restoreNodePositions(attempted) {
+  for (const [n, px, py] of attempted ?? []) {
+    const cur = [Number(n?.pos?.[0]), Number(n?.pos?.[1])];
+    writePoint(n, "pos", px, py);
+    refreshNodeArea(n, cur);
+  }
+}
+
+/**
+ * Is `actual` the value a write of `want` was supposed to leave behind?
+ *
+ * EXACT equality — with one narrowly scoped exception: when the destination is
+ * literally a Float32Array (older LiteGraph builds back node positions and group
+ * bounds with one), it physically cannot hold an arbitrary double, so the value
+ * it does hold, `Math.fround(want)`, is the write succeeding. Pass float32 only
+ * after checking the actual container.
+ *
+ * Deliberately NOT a relative tolerance. Slack proportional to the coordinate
+ * accepts an arbitrarily large error at a large coordinate — which means
+ * reporting a write that did nothing, or that a build snapped/clamped somewhere
+ * else, as a completed move. Now that an unmovable child aborts the whole group
+ * move, this predicate decides between a truthful refusal and a fabricated
+ * success, so it gets no free slack.
+ */
+export function samePoint(actual, want, float32 = false) {
+  if (!Number.isFinite(actual) || !Number.isFinite(want)) return false;
+  if (actual === want) return true;
+  return float32 && actual === Math.fround(want);
+}
+
+/** Is this point/quad container a 32-bit float array (which cannot hold an
+ *  arbitrary double)? */
+function isFloat32(container) {
+  return typeof Float32Array !== "undefined" && container instanceof Float32Array;
+}
+
+/** Did the group's box actually end up with its top-left at (x, y)? */
+export function groupBoxIsAt(g, x, y) {
+  const after = groupBoundsOf(g);
+  const f32 = isFloat32(g?._bounding);
+  return !!after && samePoint(after[0], x, f32) && samePoint(after[1], y, f32);
 }
 
 /**
@@ -243,8 +291,11 @@ function closeEnough(a, b) {
  * verdict is the point — the caller must never report a move it did not make.
  */
 export function writePoint(owner, key, x, y) {
-  const landed = () =>
-    closeEnough(Number(owner?.[key]?.[0]), x) && closeEnough(Number(owner?.[key]?.[1]), y);
+  const landed = () => {
+    const point = owner?.[key];
+    const f32 = isFloat32(point);
+    return samePoint(Number(point?.[0]), x, f32) && samePoint(Number(point?.[1]), y, f32);
+  };
   try {
     owner[key] = [x, y];
   } catch {
@@ -310,31 +361,50 @@ export function nestedGroupsOf(graph, g) {
  * or the pos/size pair — and REPORT whether the box actually ended up there.
  * Mirrors the panel's setGroupBounds write policy.
  */
-export function translateGroupBox(g, dx, dy) {
-  const before = groupBoundsOf(g);
-  if (!before) return false;
-  const [x, y] = before;
+export function placeGroupBox(g, x, y) {
   const b = g?._bounding;
   if (b && b.length >= 4) {
     try {
-      b[0] = x + dx;
-      b[1] = y + dy;
+      b[0] = x;
+      b[1] = y;
     } catch {
       /* frozen quad — verified below */
     }
   } else {
-    writePoint(g, "pos", x + dx, y + dy);
+    writePoint(g, "pos", x, y);
   }
-  const after = groupBoundsOf(g);
-  return !!after && closeEnough(after[0], x + dx) && closeEnough(after[1], y + dy);
+  return groupBoxIsAt(g, x, y);
 }
 
-/** Translate several group boxes, reporting which ones actually moved. */
+export function translateGroupBox(g, dx, dy) {
+  const before = groupBoundsOf(g);
+  if (!before) return false;
+  return placeGroupBox(g, before[0] + dx, before[1] + dy);
+}
+
+/** Translate several group boxes, reporting which ones actually moved and
+ *  handing back an ABSOLUTE undo (see restoreNodePositions for why the inverse
+ *  delta is not good enough). */
 export function translateGroupBoxes(groups, dx, dy) {
   const moved = [];
   const stuck = [];
-  for (const g of groups ?? []) (translateGroupBox(g, dx, dy) ? moved : stuck).push(g);
-  return { moved, stuck };
+  const attempted = [];
+  for (const g of groups ?? []) {
+    const before = groupBoundsOf(g);
+    if (!before) {
+      if (g) stuck.push(g);
+      continue;
+    }
+    attempted.push([g, before[0], before[1]]);
+    (placeGroupBox(g, before[0] + dx, before[1] + dy) ? moved : stuck).push(g);
+  }
+  return {
+    moved,
+    stuck,
+    undo: () => {
+      for (const [g, x, y] of attempted) placeGroupBox(g, x, y);
+    },
+  };
 }
 
 /** Every reroute point of a graph, across the Map / array / plain-object shapes
@@ -377,9 +447,25 @@ export function reroutesInside(graph, bounds) {
  * signature (or none) is corrected by the direct point write, and a frozen point
  * is reported as stuck instead of throwing halfway through a group move.
  */
+export function placeReroute(r, x, y) {
+  const cx = Number(r?.pos?.[0]);
+  const cy = Number(r?.pos?.[1]);
+  if (typeof r?.move === "function" && Number.isFinite(cx) && Number.isFinite(cy)) {
+    try {
+      r.move(x - cx, y - cy);
+    } catch {
+      /* build-specific; the direct write below still gets it there */
+    }
+    const f32 = isFloat32(r?.pos);
+    if (samePoint(Number(r?.pos?.[0]), x, f32) && samePoint(Number(r?.pos?.[1]), y, f32)) return true;
+  }
+  return writePoint(r, "pos", x, y);
+}
+
 export function moveReroutePoints(reroutes, dx, dy) {
   const moved = [];
   const stuck = [];
+  const attempted = [];
   for (const r of reroutes ?? []) {
     const px = Number(r?.pos?.[0]);
     const py = Number(r?.pos?.[1]);
@@ -387,20 +473,16 @@ export function moveReroutePoints(reroutes, dx, dy) {
       if (r) stuck.push(r);
       continue;
     }
-    const wantX = px + dx;
-    const wantY = py + dy;
-    const landed = () =>
-      closeEnough(Number(r?.pos?.[0]), wantX) && closeEnough(Number(r?.pos?.[1]), wantY);
-    if (typeof r.move === "function") {
-      try {
-        r.move(dx, dy);
-      } catch {
-        /* build-specific; the direct write below still gets it there */
-      }
-    }
-    (landed() || writePoint(r, "pos", wantX, wantY) ? moved : stuck).push(r);
+    attempted.push([r, px, py]);
+    (placeReroute(r, px + dx, py + dy) ? moved : stuck).push(r);
   }
-  return { moved, stuck };
+  return {
+    moved,
+    stuck,
+    undo: () => {
+      for (const [r, px, py] of attempted) placeReroute(r, px, py);
+    },
+  };
 }
 
 /**


### PR DESCRIPTION
Closes artokun/comfyui-mcp-panel#408.

Does **not** close #442 — see the per-defect reconciliation at the bottom. Four of its five defects are already shipped and one is not reproducible on current, but defect 3 still has no live proof, so #442 stays open.

## #408 — `panel_move_group` moved only the box and left stale membership

Prior work on `main` had already made membership live and geometric. What remained:

- **The move carried only the NODE half.** The panel reimplements LiteGraph's group move (`g.move()` shifts a cached child set that affected builds leave stale or empty, #287/#311/#312) but reimplemented nodes only. Nested group boxes and enclosed reroute points stayed behind, so an outer group's move stranded every inner box over the space its nodes had just vacated: nodes that looked grouped were no longer grouped. Nesting uses FULL containment (mirroring litegraph's `containsRect`, identical rects excluded), so a merely overlapping neighbour is never dragged along.
- **On current frontends the members did not move at all.** `moveGroupMembers` gated on `Array.isArray(node.pos)`, false for the typed-array-backed `pos` current ComfyUI exposes. The box moved alone and the reply still counted the members as moved — the original report, still live.
- **`move_nodes:false` reported membership from unsynced rects.** The box is not the membership.
- **A non-finite `pos`** NaN-ed the box and every member position and reported success. **Unusable bounds** silently relocated the group to an invented `[0,0,0,0]` box. Both now refuse with a stated remedy.
- **Collapsed nodes were skipped by the rect sync**, so a collapsed node inside a box could be omitted from the move and reported as zero carried, or reported as newly enclosed when it was not. They now sync to their collapsed **pill**, which keeps #416's "never overstate the area" guarantee while making the rect live.

### The three invariants this ended up being about

**Establish everything before the first write.** After the first mutation the only permitted actions are completing the transaction or rolling it back — never discovering something new that can throw. Rect reconciliation is itself a write, so it moved into a shared pre-flight ahead of both branches; a rect that will not accept it is a refusal there rather than an exception later.

**Every guard is itself an operation that can fail.** Moving a mutation earlier does not stop it being a mutation: the pre-flight resync returns its own undo, and *every* refusal past it — including the mutation-phase rollback — runs **both** undos, so "NOTHING was moved" is verified rather than assumed. It also never writes what it could not snapshot: you cannot undo what you never recorded. Every mover contains per item and always *returns* its undo — one that threw mid-loop would leave what it had already moved unrecoverable, because the caller cannot undo what it was never handed. Inspection, verification, rollback and reporting are all total: `typeof r.move` runs a getter, `getPrototypeOf` throws on a revoked Proxy, and `groupBoxIsAt` re-reads the box during the verification step that runs *between* the children moving and the rollback. Inputs are read **once, before the first write** — a re-read afterwards is a new throwable operation.

**The transaction ends when the reply is serialized, not when the last geometry write completes.** `afterChange`, `setDirtyCanvas`, `summarizeGroup` and `JSON.stringify` are all inside it, because an agent that reads a completed move as failed retries it and moves the group twice. A summary that raises returns the completed `moved` counts plus an explicit `summary_unavailable` telling the caller not to re-issue — and the payload is *proven to serialize inside that guard*, since `summarizeGroup` hands back the group's own `title`/`color` uncoerced and a throwing `toJSON` would otherwise fail at the bridge, outside every guard, where the caller gets no response at all.

**You cannot probe an API's semantics by invoking it destructively.** An earlier revision called `Reroute.move(dx, dy)` before knowing whether that API was relative, then "corrected" `r.pos`. On a build where `move(x, y)` is absolute and also writes a reactive/persisted store, the store keeps the wrong coordinate, the patched array passes verification, success is reported, and the next render or save resurrects it. `move()` is now **never called**. Reroutes are written through `pos`, whose setter *is* the engine's own write path on current litegraph; a plain-slot `pos` plus an uncharacterisable `move()` is genuinely unknown and is refused up front, by inspection, with a remedy.

Every geometry write is verified and reports whether it landed. If any enclosed item will not accept a new position, the attempted ones are restored to their captured original coordinates and the call refuses by name — and the refusal either proves "NOTHING was moved" or names what is still displaced. "Could not determine" never collapses into a definite verdict: a reroute or nested box whose geometry cannot be read rides along so the move refuses, rather than being silently left behind by a move that reports success.

**Roll back first, format second.** Restoring geometry never needs to know what a node is *called*. `id` and `title` are display-only and are exactly the fields most likely to be a proxy or a throwing getter, so every refusal restores state, verifies the restore, and only then assembles the message — accepting a plainer sentence about a graph that is provably intact over a nicer one built on top of a dirty graph. The formatters (`describeItem`, `describeThrown`) are themselves total, down to the `String()` coercion, because the error path of the error path is still a path: a `summarizeGroup` error whose own `message` getter throws must not turn a completed move into a reported failure that the caller then re-issues.

**Prove the reply you RETURN, not a payload inside it.** The envelope is part of the reply: round-tripping only the inner `group` still let a caller-supplied BigInt `group_id` break `JSON.stringify` at the bridge, outside every guard. Both replies are proven at the point of return, and if even the fallback will not serialize it degrades to one built solely from primitives this function owns.

**Gate on state, never on intent.** The rollback's box restore was once gated on a flag meaning "a write was attempted". A setter that rejects its first assignment and clamps a later one then made the *rollback itself* move an untouched box — a refusal that mutates geometry, reached through the gate built to prevent exactly that. The gate now compares the box's current value against the recorded prior and writes only if they differ, across the whole quad. "Did we try" is not "did it change", and only the second is an answer to the question being asked.

One path — the outer catch around the mutation phase — can never verify a rollback, because a mover that threw would not have returned its undo. It is kept as a net for future edits, but it reports the state as **UNKNOWN and possibly partially moved** rather than asserting a restoration it could not have made. A net that lies when it catches is the failure mode this whole PR is about. It also no longer *writes* anything a forward path did not write, and no longer replays a rect snapshot over a node that may have moved.

Point writes inspect the property before choosing a strategy: an accessor **with** a setter is assigned (its setter runs the build's bookkeeping and writes into the array it already owns), while a plain data property holding a typed-array **view** is written in place (assignment there would sever the node's aliasing). Landed-checks are exact, with one narrowly scoped exception for a destination that literally is a `Float32Array`.

No orchestrator change: `panel_move_group`'s signature is unchanged and `moved` is an additive reply field.

## Verification

- Panel unit suite **1876/1876**; `tsc --noEmit` clean; `check-tool-vocabulary` clean.
- Both changed modules verified to parse as **ES modules** (`node --check` on `.mjs` copies) — CJS `node --check` would not catch a duplicate top-level declaration. Zero control bytes on all four committed blobs.
- **92 mutants across seven suites, ALL CAUGHT on a green baseline — none surviving**, each still parsing as an ES module. One per fixed behaviour, including: reverting the harness to sloppy mode; each wrong write-order; reinstating the `Array.isArray` guard; reinstating the destructive `move()` probe; re-skipping collapsed nodes; both inverse-delta rollbacks; dropping the size half of the box verification; removing the pre-flight's undo, its walk containment and its snapshot gate; skipping the pre-flight undo from each of the three rollback sites; re-reading the target coordinates after the first write; returning either reply without proving it serializes; restoring the format-before-rollback order at each site; each of the net's two latent defects; and reinstating the intent-based restore flag verbatim.
- Mutants that became **equivalent** as the code hardened are **retired with the reason recorded in the harness**, never left in place looking covered.
- The 94 tests in `browser_tests/unit/move-group.test.mjs` extract the **shipped** handler and helpers from panel source and run them under `"use strict"`, matching the semantics the module really runs under.
- Self-gated with codex (`gpt-5.6-terra`) over **twelve rounds**: FAIL on 1–5, PASS on 6–12. **Six maintainer reviews** found a further **4 P0 + 1 P1**, then **2 P0 + 2 P1 + 1 P2**, then **5 P0**, then **4 P0 + 1 P1**, then **1 P0**, then **1 P0** that the gate had missed — all fixed here, all mutation-verified.

### What is *not* covered, stated plainly

- **No browser test.** Whether a real ComfyUI canvas repaints nested boxes and reroutes correctly after a programmatic move is unverified here.
- **A state-based gate cannot outperform its accessor.** `restoreBox()` decides whether to write by reading where the box currently is. A *temporally* flaky `_bounding` accessor — one that reports the box as elsewhere before any write has happened — would make it attempt a recovery write. This is structural, not an oversight: if the geometry cannot be read truthfully, no gate can classify it, and the alternative (skip the restore when the box is unreadable) would strand a genuinely displaced box instead. The choice errs toward restoring. Not a current ComfyUI shape (P2, carried knowingly).
- **Two ordering mutants are equivalent only under stated conditions**, and were dropped rather than left looking covered. The conditions: the pairs are **handler-created plain arrays**, and the formatter operations are **total**. They are *not* unqualified behavioural equivalents — a **stateful `id` getter can observe a different position before versus after the rollback and change the refusal text**, which the roll-back-first ordering prevents and the equivalence argument does not. The ordering is kept because it is the correct structure; the mutation-covered half is the totality.
  - That equivalence argument also never covered three things that turned out to be real defects, all since fixed and separately mutation-covered: the **post-write re-read of the target coordinates**, the **reply-serialization path**, and the **reply envelope** (round-tripping an inner field still let a BigInt `group_id` break serialization at the bridge).

### Previously disclosed as uncovered — now covered

The mutation-phase catch used to have **no behavioural coverage**: unreachable while the movers are total, pinned only by a source-level assertion on its wording. That was not evidence its rollback worked. The test harness already injects the movers, so it now accepts an `overrides` parameter and drives the real handler with a mover that mutates and then throws before returning its undo. Four behavioural tests replaced the source assertion.

Doing so showed the net was **not merely dead — it would have introduced two defects** if it ever fired: it wrote the group box although no forward path had written it (a clamping setter would displace a box nothing had moved), and it replayed the pre-flight rect snapshot over members the unreturned mover may have relocated, recreating the stale-rect fabrication removed elsewhere. Both are fixed; the net now follows the same rules as the reachable paths. Chasing the first also uncovered the *same* defect in a reachable path — the stuck-items refusal called `restoreBox()` before any box write.

**Every mutant in every suite is now caught. None survive.**


## #442 — five-defect reconciliation (issue stays OPEN)

| # | Defect | Outcome |
|---|---|---|
| 1 | No node-resize tool | **Fixed, already shipped.** `panel_edit_node({size})` (panel #538 / mcp #697) plus a `panel_resize_node` wrapper. The attached patch's standalone `graph_set_node_size` / `panel_set_node_size` was **not** taken — it would have added a second one-off tool beside the consolidated edit path. |
| 2 | `panel_open_workflow` serves a stale cached tab | **Fixed, already shipped** (#483 detection, #514 re-read + explicit conflict when the tab has unsaved work). |
| 3 | `panel_save_workflow` 409s saving in place | **Code-covered, live-unproven.** #495's raw-byte baseline gate authorizes the drifted-own-file case and refuses when disk differs. Not verified live, so not claimed. |
| 4 | Edit channel disconnects while reads work | **Fixed, already shipped** (#402/#508 via #514); the `Connected: none` error now names the remedy, which is the sub-item the report asked for. |
| 5 | Restart closes every workflow tab | **Not reproducible on current** — live-tested 2026-08-02 on ComfyUI 0.29.2 / panel 0.11.33 / MCP 0.49.1 (report was 0.29.0 / 0.11.0 / 0.48.22); 4 tabs including an unsaved one survived a real stop-then-start. The original report had 13 tabs on a 319-node workflow, so this is "not reproducible", not "proven fixed". |

Nothing in defects 1–5 needed a code change on this branch. The only #442 work here is indirect: defect 1's own use case ("make every node in a group match the largest in its column") resizes nodes inside groups, and it was the group side of that surface that was still incoherent.
