### PR TITLE
CivitAI browser search fails in the frontend while the backend API succeeds

### DIFF
--- a/browser_tests/unit/civitai-drive-results.test.mjs
+++ b/browser_tests/unit/civitai-drive-results.test.mjs
@@ -7,7 +7,7 @@
 // returns METADATA + URLs ONLY, never image bytes, and clamps `limit`.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { serializeCivitaiResults, CIVITAI_PROMPT_CAP } from "../../web/js/cmcp-civitai-ui.js";
+import { serializeCivitaiResults, CIVITAI_PROMPT_CAP, civitaiErrorState } from "../../web/js/cmcp-civitai-ui.js";
 
 // Media rows as produced by CivitaiClient._fromRest / _fromMeili.
 const mediaRows = [
@@ -116,6 +116,34 @@ test("missing/empty urls are dropped, not emitted as null/undefined", () => {
 test("non-array source is tolerated", () => {
   const out = serializeCivitaiResults(null, { model: false });
   assert.deepEqual(out, { items: [], total: 0, loading: false });
+});
+
+// ---- #599: the agent-facing error must distinguish the failure CAUSE ----
+// transport (browser→ComfyUI proxy hop failed, no HTTP response came back) vs
+// an upstream CivitAI error (HTTP status present) vs a true empty result (no
+// error object at all).
+
+test("#599: a transport failure keeps status null and carries kind", () => {
+  const err = Object.assign(new Error("…browser→ComfyUI hop…"), {
+    status: null, kind: "transport",
+  });
+  assert.deepEqual(civitaiErrorState(err), {
+    status: null,
+    message: "…browser→ComfyUI hop…",
+    kind: "transport",
+  });
+});
+
+test("#599: an upstream CivitAI error carries its HTTP status and no kind", () => {
+  const err = Object.assign(new Error("CivitAI API 503: Service Unavailable"), { status: 503 });
+  assert.deepEqual(civitaiErrorState(err), {
+    status: 503,
+    message: "CivitAI API 503: Service Unavailable",
+  });
+});
+
+test("#599: a plain error without a status is recorded without kind", () => {
+  assert.deepEqual(civitaiErrorState(new Error("boom")), { status: null, message: "boom" });
 });
 
 test("long prompts are capped to the token budget with an ellipsis", () => {

--- a/browser_tests/unit/civitai-upstream-error.test.mjs
+++ b/browser_tests/unit/civitai-upstream-error.test.mjs
@@ -84,15 +84,92 @@ test("#417: _request throws a timeout error when the proxy never settles", async
   }
 });
 
-test("#417: a non-abort fetch rejection still propagates unchanged", async () => {
+// ---- #599: browser→proxy transport failures ("Failed to fetch", no status) --
+// A bare TypeError from fetch means no HTTP response came back from the
+// ComfyUI-side proxy — CivitAI is not the cause. The proxy call is always a
+// POST, which
+// Chrome won't self-retry on a stale keep-alive connection, so the client does
+// ONE retry for idempotent (GET) specs, then throws a CLASSIFIED transport
+// error (kind:"transport", status:null) naming the real failed hop — never the
+// browser's bare "Failed to fetch" alone.
+
+test("#599: a transient transport failure on an idempotent request is retried once", async () => {
+  let calls = 0;
   const client = new CivitaiClient({
     fetchApi: async () => {
+      calls++;
+      if (calls === 1) throw new TypeError("Failed to fetch");
+      return { ok: true, status: 200, json: async () => ({ items: [1, 2, 3] }) };
+    },
+    apiURL: (p) => p,
+  });
+  const out = await client._request({ url: "https://civitai.red/api/v1/models" });
+  assert.deepEqual(out, { items: [1, 2, 3] });
+  assert.equal(calls, 2); // first attempt failed at transport, retry succeeded
+});
+
+test("#599: a persistent transport failure throws a classified transport error", async () => {
+  let calls = 0;
+  const client = new CivitaiClient({
+    fetchApi: async () => {
+      calls++;
       throw new TypeError("Failed to fetch");
     },
     apiURL: (p) => p,
   });
   await assert.rejects(
-    () => client._request({ url: "https://civitai.com/api/v1/models" }),
-    /Failed to fetch/,
+    () => client._request({ url: "https://civitai.red/api/v1/models" }),
+    (err) => {
+      assert.equal(err.kind, "transport");
+      assert.equal(err.status, null); // no HTTP response ever existed
+      // The reason, not just the state: the failed hop is browser→ComfyUI
+      // proxy, and the original browser text is preserved for diagnosis.
+      assert.match(err.message, /browser→ComfyUI hop/);
+      assert.match(err.message, /Failed to fetch/);
+      assert.match(err.message, /not an empty result/);
+      return true;
+    },
   );
+  assert.equal(calls, 2); // one bounded retry, then give up
+});
+
+test("#599: a transport failure on a non-idempotent (POST) request is NOT retried", async () => {
+  // reaction.toggle / collection writes must never be double-fired: a retry
+  // could silently apply the mutation twice.
+  let calls = 0;
+  const client = new CivitaiClient({
+    fetchApi: async () => {
+      calls++;
+      throw new TypeError("Failed to fetch");
+    },
+    apiURL: (p) => p,
+  });
+  await assert.rejects(
+    () =>
+      client._request({
+        url: "https://civitai.red/api/trpc/reaction.toggle",
+        method: "POST",
+        body: { json: { entityType: "image", entityId: 1, reaction: "Like" } },
+      }),
+    (err) => err.kind === "transport",
+  );
+  assert.equal(calls, 1);
+});
+
+test("#599: every read path routes through the same-origin proxy (no direct cross-origin fetch)", async () => {
+  // The browser must never call a CivitAI host directly (CORS + bot-gate
+  // headers) — every network call goes through /comfyui_mcp_panel/civitai/*.
+  const seen = [];
+  const client = new CivitaiClient({
+    fetchApi: async (path) => {
+      seen.push(path);
+      return { ok: true, status: 200, json: async () => ({ items: [] }) };
+    },
+    apiURL: (p) => p,
+  });
+  await client.fetchModels({ type: "Checkpoint", query: "wan" });
+  await client.fetchFeed({});
+  await client.searchMedia("wan");
+  assert.ok(seen.length >= 3);
+  for (const p of seen) assert.equal(p, "/comfyui_mcp_panel/civitai/api");
 });

--- a/browser_tests/unit/civitai-upstream-error.test.mjs
+++ b/browser_tests/unit/civitai-upstream-error.test.mjs
@@ -87,11 +87,11 @@ test("#417: _request throws a timeout error when the proxy never settles", async
 // ---- #599: browser→proxy transport failures ("Failed to fetch", no status) --
 // A bare TypeError from fetch means no HTTP response came back from the
 // ComfyUI-side proxy — CivitAI is not the cause. The proxy call is always a
-// POST, which
-// Chrome won't self-retry on a stale keep-alive connection, so the client does
-// ONE retry for idempotent (GET) specs, then throws a CLASSIFIED transport
-// error (kind:"transport", status:null) naming the real failed hop — never the
-// browser's bare "Failed to fetch" alone.
+// POST, which Chrome won't self-retry on a stale keep-alive connection, so the
+// client does ONE retry for idempotent specs (GETs, plus the read-only Meili
+// multi-search POST, which is flagged idempotent at the call site), then throws
+// a CLASSIFIED transport error (kind:"transport", status:null) naming the real
+// failed hop — never the browser's bare "Failed to fetch" alone.
 
 test("#599: a transient transport failure on an idempotent request is retried once", async () => {
   let calls = 0;
@@ -154,6 +154,23 @@ test("#599: a transport failure on a non-idempotent (POST) request is NOT retrie
     (err) => err.kind === "transport",
   );
   assert.equal(calls, 1);
+});
+
+test("#599: a READ issued as a POST (Meili multi-search) IS retried when flagged idempotent", async () => {
+  // Idempotency is a property of the operation, not the HTTP method: keyword
+  // media search goes through MeiliSearch's multi-search, a read-only POST.
+  let calls = 0;
+  const client = new CivitaiClient({
+    fetchApi: async () => {
+      calls++;
+      if (calls === 1) throw new TypeError("Failed to fetch");
+      return { ok: true, status: 200, json: async () => ({ results: [{ hits: [] }] }) };
+    },
+    apiURL: (p) => p,
+  });
+  const out = await client.searchMedia("wan");
+  assert.deepEqual(out, []);
+  assert.equal(calls, 2, "the flagged read-only POST must get the same one retry as a GET");
 });
 
 test("#599: every read path routes through the same-origin proxy (no direct cross-origin fetch)", async () => {

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -285,6 +285,20 @@ export function serializeCivitaiResults(source, { model = false, limit = 20, loa
   return { items, total: rows.length, loading: !!loading };
 }
 
+/** Build the `state.error` object reported by panel_civitai_results (#190).
+ *  The client throws Errors carrying an HTTP `status` for upstream CivitAI
+ *  failures; a browser→proxy transport failure (#599) carries `kind:"transport"`
+ *  and status null (no HTTP response came back); a true empty result sets NO
+ *  error at all. Pure and exported for unit tests. */
+export function civitaiErrorState(e) {
+  const status = e && typeof e.status === "number" ? e.status : null;
+  return {
+    status,
+    message: coerceMessageText(e?.message ?? e),
+    ...(typeof e?.kind === "string" ? { kind: e.kind } : {}),
+  };
+}
+
 /** Content-provider factory for the CivitAI browser tab of the unified side
  *  panel. Builds the grid/lightbox/filter body + the agent-drive surface; the
  *  shell (cmcp-sidepanel-ui.js) owns the overlay, header, tab bar, single search
@@ -686,11 +700,10 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       if (req === state.reqId) {
         sentinel.textContent = "CivitAI error: " + (e.message || e);
         // Record the failure so the agent-facing panel_civitai_results can report
-        // a distinct error state instead of an indistinguishable total:0 (#190).
-        // The client throws Errors carrying an HTTP `status` (see CivitaiClient);
-        // fall back to the message alone when it doesn't.
-        const status = e && typeof e.status === "number" ? e.status : null;
-        state.error = { status, message: coerceMessageText(e?.message ?? e) };
+        // a distinct error state instead of an indistinguishable total:0 (#190);
+        // kind:"transport" marks a browser→proxy failure — no HTTP response
+        // came back (#599, see civitaiErrorState).
+        state.error = civitaiErrorState(e);
       }
     } finally {
       if (req === state.reqId) setLoading(false);

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -307,21 +307,52 @@ export class CivitaiClient {
     // callers) so the existing catch sets state.error and clears loading.
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), CIVITAI_REQUEST_TIMEOUT_MS);
+    // #599: a bare transport rejection (TypeError "Failed to fetch", NO HTTP
+    // status) means the browser→ComfyUI leg failed — no response came back, so
+    // CivitAI is not the cause. The proxy call is always a POST, which Chrome will NOT self-retry when a pooled keep-alive
+    // connection turns out to be stale, so do ONE bounded retry here — but
+    // only for an idempotent (GET) spec: a POST spec (reaction.toggle,
+    // collection writes) must never be double-fired. The retry shares the
+    // #417 abort budget above, so the worst case is unchanged. A failure that
+    // survives the retry is rethrown CLASSIFIED (kind:"transport") so the UI /
+    // panel_civitai_results can tell "the panel couldn't reach its own proxy"
+    // apart from an upstream CivitAI error (always carries an HTTP status) and
+    // from a true empty result (error is null).
+    const idempotent = (method || "GET").toUpperCase() === "GET";
     let res;
     try {
-      res = await this.api.fetchApi("/comfyui_mcp_panel/civitai/api", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ url, method, body, auth, headers }),
-        signal: controller.signal,
-      });
-    } catch (e) {
-      if (e?.name === "AbortError") {
-        throw new Error(
-          `CivitAI request timed out after ${Math.round(CIVITAI_REQUEST_TIMEOUT_MS / 1000)} seconds`,
-        );
+      for (let attempt = 0; ; attempt++) {
+        try {
+          res = await this.api.fetchApi("/comfyui_mcp_panel/civitai/api", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ url, method, body, auth, headers }),
+            signal: controller.signal,
+          });
+          break;
+        } catch (e) {
+          if (e?.name === "AbortError") {
+            throw new Error(
+              `CivitAI request timed out after ${Math.round(CIVITAI_REQUEST_TIMEOUT_MS / 1000)} seconds`,
+            );
+          }
+          if (idempotent && attempt < 1 && typeof e?.status !== "number") continue;
+          if (typeof e?.status !== "number") {
+            throw Object.assign(
+              new Error(
+                `The CivitAI request failed at the browser→ComfyUI hop: no HTTP response came ` +
+                `back (browser transport error: ${coerceMessageText(e?.message ?? e)}). This is a ` +
+                `connection-level failure — not a CivitAI error, and not an empty result. The ` +
+                `ComfyUI server may be restarting, the connection may have dropped, or a browser ` +
+                `extension/policy may have blocked the request. Retry the search; if it persists, ` +
+                `check that ComfyUI is running and reachable.`,
+              ),
+              { status: null, kind: "transport" },
+            );
+          }
+          throw e;
+        }
       }
-      throw e;
     } finally {
       clearTimeout(timeout);
     }

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -298,7 +298,7 @@ export class CivitaiClient {
     return this._request({ url, method: "GET", auth, headers });
   }
 
-  async _request({ url, method = "GET", body, auth = false, headers }) {
+  async _request({ url, method = "GET", body, auth = false, headers, idempotent: idem }) {
     // #417: bound EVERY proxied CivitAI call with a client-side abort. Without it,
     // a proxy/upstream request that never settles leaves this fetch pending
     // forever, so _loadMore never reaches its catch/finally — the docked browser
@@ -309,16 +309,22 @@ export class CivitaiClient {
     const timeout = setTimeout(() => controller.abort(), CIVITAI_REQUEST_TIMEOUT_MS);
     // #599: a bare transport rejection (TypeError "Failed to fetch", NO HTTP
     // status) means the browser→ComfyUI leg failed — no response came back, so
-    // CivitAI is not the cause. The proxy call is always a POST, which Chrome will NOT self-retry when a pooled keep-alive
-    // connection turns out to be stale, so do ONE bounded retry here — but
-    // only for an idempotent (GET) spec: a POST spec (reaction.toggle,
-    // collection writes) must never be double-fired. The retry shares the
-    // #417 abort budget above, so the worst case is unchanged. A failure that
-    // survives the retry is rethrown CLASSIFIED (kind:"transport") so the UI /
-    // panel_civitai_results can tell "the panel couldn't reach its own proxy"
-    // apart from an upstream CivitAI error (always carries an HTTP status) and
-    // from a true empty result (error is null).
-    const idempotent = (method || "GET").toUpperCase() === "GET";
+    // CivitAI is not the cause. The proxy call is always a POST, which Chrome
+    // will NOT self-retry when a pooled keep-alive connection turns out to be
+    // stale, so do ONE bounded retry here — but only for an idempotent spec: a
+    // mutation (reaction.toggle, collection writes) must never be double-fired.
+    // The retry shares the #417 abort budget above, so the worst case is
+    // unchanged. A failure that survives the retry is rethrown CLASSIFIED
+    // (kind:"transport") so the UI / panel_civitai_results can tell "the panel
+    // couldn't reach its own proxy" apart from an upstream CivitAI error
+    // (always carries an HTTP status) and from a true empty result (error is
+    // null).
+    //
+    // Idempotency is a property of the OPERATION, not the HTTP method: CivitAI
+    // reads are GETs EXCEPT MeiliSearch multi-search, which is a read-only
+    // POST — callers pass `idempotent: true` for that one. Anything else POST
+    // (reaction.toggle, collection writes) is a mutation and is never retried.
+    const idempotent = idem ?? ((method || "GET").toUpperCase() === "GET");
     let res;
     try {
       for (let attempt = 0; ; attempt++) {
@@ -540,6 +546,10 @@ export class CivitaiClient {
     if (username) filter.push(`user.username = "${CivitaiClient.escapeMeili(username)}"`);
     const data = await this._request({
       url: SEARCH_URL, method: "POST",
+      // A Meili multi-search is a READ issued as a POST — flag it idempotent so
+      // the #599 transport retry covers keyword media search too (a mutation
+      // POST must never pass this flag).
+      idempotent: true,
       headers: {
         authorization: `Bearer ${SEARCH_KEY}`,
         origin: "https://civitai.red",


### PR DESCRIPTION
## Issues in this cluster

- #599

Grouped because they share a codepath or are variations of one defect. An agent takes the whole cluster, so a fix for one is checked against the others rather than landing several times with several different shapes.

**Not yet started** — draft until an agent picks it up.