### PR TITLE
fix(panel): say when the live-canvas tools may not have reached the agent (#291)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,28 @@ backend, provider slash commands (`/compact`, `/loop`, …) are available too.
 The agent drives the workflow you're viewing through a **fixed allowlist** of
 `panel_*` commands (no arbitrary JavaScript). Every graph mutation goes through
 LiteGraph's change tracking, so ComfyUI's native **Ctrl+Z** reverts an agent
-edit exactly like your own. **Both providers expose this identical surface** —
-the `panel_*` tools live in one shared definition list, registered onto the
-in-process Claude Agent SDK server *and* a loopback HTTP MCP the orchestrator
-hosts for the ChatGPT/Codex backend, so feature parity is automatic.
+edit exactly like your own. The `panel_*` tools live in one shared definition
+list, registered onto the in-process Claude Agent SDK server *and* a loopback
+HTTP MCP the orchestrator hosts for the ChatGPT/Codex and other CLI backends, so
+both surfaces are identical **as served**.
+
+They are not automatically identical **as received**, and this page used to claim
+they were. A backend applies its own tool budget to everything it is handed, and
+Codex was observed silently dropping the entire panel MCP server once the ~250
+headless comfyui tools saturated that budget — the tools were advertised, the
+model never got them, and it improvised (saving a workflow file instead of
+editing the canvas) rather than saying it could not
+([#291](https://github.com/artokun/comfyui-mcp-panel/issues/291)). The cause is
+fixed upstream in comfyui-mcp — the non-Claude lane now spawns comfyui in compact
+mode, leaving budget for `panel_*` — so keep comfyui-mcp current.
+
+Because the panel cannot see the agent's toolset, it does not pretend to check.
+It asks the agent once per session to look, and to say so plainly instead of
+improvising — both when the canvas tools are absent and when one is listed but
+its call fails. If you ever see that message: update comfyui-mcp; unset
+`COMFYUI_MCP_TOOL_MODE=full` and drop MCP servers you don't need from that
+backend's own config; then `/restart`, or switch the chat to the Claude backend,
+which receives `panel_*` by a different route.
 
 **Read**
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,13 @@ Claude or ChatGPT (your own subscription, no API key).**
 **Stuck or have a question? [Join the Discord](https://discord.gg/cW9arBhzCu)** — or hit **🆘 Need help?** in the panel's Settings → About (it copies a diagnostics summary and opens the Discord for you).
 
 Pick a provider — **Claude** or **ChatGPT** — and the matching agent runs in the background on
-*your* subscription, sees the graph you're looking at, and edits it live. Both providers reach
-**full feature parity**: the same live-canvas tools, the same model knowledge, the same one-shot
-workflow loads, the same cost guardrail.
+*your* subscription, sees the graph you're looking at, and edits it live. Every provider is
+**offered the same surface**: the same live-canvas tools, the same model knowledge, the same
+one-shot workflow loads, the same cost guardrail. Offered, not guaranteed received — a provider
+applies its own tool budget to what we hand it, and Codex was seen dropping the live-canvas tools
+silently ([#291](https://github.com/artokun/comfyui-mcp-panel/issues/291)). That is fixed upstream,
+and the panel now asks the agent to say so rather than improvise if it ever recurs — see
+[What the agent can do](#what-the-agent-can-do).
 
 Part of the **[comfyui-mcp](https://github.com/artokun/comfyui-mcp)** project — the local-first,
 agent-native control plane for ComfyUI (MCP server + agent orchestrator). Full documentation at

--- a/browser_tests/unit/canvas-tool-disclosure.test.mjs
+++ b/browser_tests/unit/canvas-tool-disclosure.test.mjs
@@ -1,0 +1,443 @@
+// Unit tests for the live-canvas tool disclosure (web/js/lib/canvas-tool-disclosure.js).
+//
+// #291: a Codex sidebar session received the panel system instructions but none of
+// the panel_* live-graph tools — Codex silently dropped the whole panel MCP server
+// once the headless comfyui surface saturated its tool budget. The model did not
+// report the gap; it improvised a save_workflow fallback, and the user read that as
+// the panel being broken.
+//
+// The panel cannot detect the gap (it gets no tool-use events and no toolset
+// manifest), so these tests pin the two things it CAN be held to:
+//
+//   • it never asserts the tools are absent — the only evidence it has is positive,
+//     and "no panel_* command yet" must stay UNESTABLISHED, not "unavailable";
+//   • the text it sends actually tells the model to REFUSE the improvisations and
+//     hands the user remedies they can act on.
+//
+// The reason is asserted alongside the boolean throughout: "do not disclose" is
+// right for two entirely different states (proven present, already said), and a test
+// that only checked the boolean would pass if they were confused for each other.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  AGENT_SESSION_RESET_FRAMES,
+  CANVAS_TOOL_DISCLOSURE,
+  commandProvesExposure,
+  planCanvasToolDisclosure,
+  startsNewAgentSession,
+} from "../../web/js/lib/canvas-tool-disclosure.js";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSource = () => readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
+
+test("a fresh session generation with no evidence discloses, as UNESTABLISHED", () => {
+  const d = planCanvasToolDisclosure({ agentEpoch: 1, provenEpoch: null, disclosedEpoch: null });
+  assert.equal(d.disclose, true);
+  assert.equal(
+    d.reason,
+    "unestablished",
+    "no evidence must be reported as unestablished — never as the tools being unavailable",
+  );
+});
+
+test("a panel_* command in THIS generation proves exposure → no disclosure", () => {
+  const d = planCanvasToolDisclosure({ agentEpoch: 4, provenEpoch: 4, disclosedEpoch: null });
+  assert.equal(d.disclose, false);
+  assert.equal(d.reason, "proven", "suppression here must be evidence, not the once-per-session rule");
+});
+
+test("proof from a PRIOR generation does not carry across a reconnect", () => {
+  // sessionEpoch bumps on every orchestrator socket (re)connect, which may be a new
+  // agent session with a different toolset — the previous generation's proof says
+  // nothing about this one. A backend switch reconnects too, which is exactly the
+  // Claude→Codex transition where #291 appears.
+  const d = planCanvasToolDisclosure({ agentEpoch: 5, provenEpoch: 4, disclosedEpoch: null });
+  assert.equal(d.disclose, true);
+  assert.equal(d.reason, "unestablished");
+});
+
+test("already disclosed in this generation → silent, and for that reason specifically", () => {
+  const d = planCanvasToolDisclosure({ agentEpoch: 2, provenEpoch: null, disclosedEpoch: 2 });
+  assert.equal(d.disclose, false);
+  assert.equal(d.reason, "already-disclosed");
+});
+
+test("a disclosure from a PRIOR generation is re-sent after a reconnect", () => {
+  const d = planCanvasToolDisclosure({ agentEpoch: 3, provenEpoch: null, disclosedEpoch: 2 });
+  assert.equal(d.disclose, true);
+  assert.equal(d.reason, "unestablished");
+});
+
+test("proof outranks the once-per-session rule when both apply", () => {
+  // Both suppress, but only one is backed by evidence. Reporting "already-disclosed"
+  // here would hide the fact that the question is settled.
+  const d = planCanvasToolDisclosure({ agentEpoch: 7, provenEpoch: 7, disclosedEpoch: 7 });
+  assert.equal(d.disclose, false);
+  assert.equal(d.reason, "proven");
+});
+
+test("an unusable session epoch discloses rather than deciding on garbage", () => {
+  // Neither scoped comparison means anything without a real epoch: null === null and
+  // NaN !== NaN would each answer the question by accident. Withholding is the
+  // failure that produced #291, so the unknown case fails toward saying it.
+  for (const agentEpoch of [undefined, null, NaN, "3"]) {
+    const d = planCanvasToolDisclosure({ agentEpoch, provenEpoch: agentEpoch, disclosedEpoch: agentEpoch });
+    assert.equal(d.disclose, true, `epoch ${String(agentEpoch)} must not suppress`);
+    assert.equal(d.reason, "epoch-unknown");
+  }
+});
+
+test("a non-finite proof stamp is not evidence", () => {
+  // Guards the `provenEpoch === sessionEpoch` shortcut: without the finiteness check
+  // an uninitialized stamp could compare equal to an equally broken epoch and claim
+  // proof that no command ever provided.
+  for (const provenEpoch of [undefined, null, NaN, "6"]) {
+    const d = planCanvasToolDisclosure({ agentEpoch: 6, provenEpoch, disclosedEpoch: null });
+    assert.equal(d.disclose, true, `proof stamp ${String(provenEpoch)} must not count as proof`);
+    assert.equal(d.reason, "unestablished");
+  }
+});
+
+test("a non-finite disclosure stamp does not suppress", () => {
+  for (const disclosedEpoch of [undefined, null, NaN, "6"]) {
+    const d = planCanvasToolDisclosure({ agentEpoch: 6, provenEpoch: null, disclosedEpoch });
+    assert.equal(d.disclose, true, `disclosure stamp ${String(disclosedEpoch)} must not suppress`);
+    assert.equal(d.reason, "unestablished");
+  }
+});
+
+test("called with nothing at all, it discloses", () => {
+  const d = planCanvasToolDisclosure();
+  assert.equal(d.disclose, true);
+  assert.equal(d.reason, "epoch-unknown");
+});
+
+test("a same-socket new/resumed chat is a new generation, not a continuation", () => {
+  // Round 2 of the gate caught this: the scope was the SOCKET, but a toolset belongs
+  // to the AGENT. /new, closing a thread, and opening a chat from history all send
+  // new_session over the live socket, so a socket-scoped rule handed the previous
+  // agent's proof and disclosure to a fresh model that received neither — exactly
+  // the #291 session, reachable without ever reconnecting.
+  assert.equal(startsNewAgentSession("new_session"), true);
+  assert.equal(startsNewAgentSession("resume_session"), true, "a resume renegotiates the toolset too");
+  // Round 4 of the gate: the per-workflow re-target hellos the LIVE socket with the
+  // session key cleared, which spawns a clean agent outright — no new_session frame
+  // is sent anywhere, so a list without `hello` left that agent inheriting its
+  // predecessor's proof and disclosure.
+  assert.equal(startsNewAgentSession("hello"), true, "a re-hello can spawn a clean agent on a live socket");
+  for (const t of ["set_options", "agent_event", "interrupt", "user_message", "title", undefined, null]) {
+    assert.equal(startsNewAgentSession(t), false, `${String(t)} must not reset the disclosure`);
+  }
+  assert.deepEqual(AGENT_SESSION_RESET_FRAMES, ["hello", "new_session", "resume_session"]);
+});
+
+test("a command answering THIS generation's own message is proof", () => {
+  assert.equal(commandProvesExposure({ agentEpoch: 3, messagedEpoch: 3 }), true);
+});
+
+test("a command that arrives before this generation was ever prompted is NOT proof", () => {
+  // Round 3 of the gate caught this: sendFrame advances the generation the instant
+  // new_session goes out, but the socket is bidirectional and the OUTGOING agent's
+  // panel_* command can already be in flight. Landing after the bump, it used to
+  // vouch for a successor it has nothing to do with — and the fresh, possibly
+  // toolless model then got no disclosure. #291, reached by ordinary timing.
+  //
+  // Exact, not a timing window: a command answers a TURN, and the new agent has had
+  // none until we send it one.
+  assert.equal(
+    commandProvesExposure({ agentEpoch: 4, messagedEpoch: 3 }),
+    false,
+    "a straggler from the agent the user just replaced must not vouch for its successor",
+  );
+  assert.equal(
+    commandProvesExposure({ agentEpoch: 1, messagedEpoch: null }),
+    false,
+    "nothing has been prompted yet, so nothing can be answering",
+  );
+});
+
+test("proof needs a real generation, and the comparison stays strict", () => {
+  for (const agentEpoch of [undefined, null, NaN, "3"]) {
+    assert.equal(
+      commandProvesExposure({ agentEpoch, messagedEpoch: agentEpoch }),
+      false,
+      `epoch ${String(agentEpoch)} must not manufacture proof by comparing equal to itself`,
+    );
+  }
+  assert.equal(commandProvesExposure({ agentEpoch: 3, messagedEpoch: "3" }), false, "no loose ==");
+  assert.equal(commandProvesExposure(), false);
+});
+
+test("the text asks about the toolset instead of asserting anything about it", () => {
+  // The defect class this repo keeps hitting is "could not determine X" shipped as
+  // "determined X is not the case". The panel genuinely cannot determine this, so
+  // the text must not read as a verdict in EITHER direction.
+  assert.match(
+    CANVAS_TOOL_DISCLOSURE,
+    /CANNOT observe whether they reached your toolset/,
+    "must state the panel's own blindness as the reason it is asking",
+  );
+  assert.match(
+    CANVAS_TOOL_DISCLOSURE,
+    /a question, not a claim that anything is wrong/,
+    "must disclaim that anything has been established",
+  );
+  assert.doesNotMatch(
+    CANVAS_TOOL_DISCLOSURE,
+    /you (?:do not|don't) have|are (?:not available|unavailable|missing)/i,
+    "must never assert the tools are absent — the panel has no evidence of absence",
+  );
+});
+
+test("the text names the tool the model should look for", () => {
+  // "Check your tools" is unfalsifiable advice. It has to name one, and it has to be
+  // a tool that actually exists — vendor/tool-vocabulary.json is the ledger and
+  // scripts/check-tool-vocabulary.mjs enforces it against this file too.
+  assert.match(CANVAS_TOOL_DISCLOSURE, /panel_graph_outline/);
+});
+
+test("a LISTED tool is not treated as a working one", () => {
+  // "Listed, therefore fine" is the same defect as "unlisted, therefore impossible",
+  // running the other way — and it is the direction the settled rules call out
+  // explicitly: a tool that appears and then fails is worse than one never listed.
+  // So the present branch must not be a free pass; a FAILED panel_* call has to
+  // surface, not quietly become a headless workaround.
+  assert.match(CANVAS_TOOL_DISCLOSURE, /being listed is not proof the canvas is reachable/);
+  assert.match(CANVAS_TOOL_DISCLOSURE, /if a panel_\* call then FAILS, report that failure/);
+  assert.match(CANVAS_TOOL_DISCLOSURE, /do NOT quietly substitute a headless workaround for it/);
+});
+
+test("the text does not claim a transport it cannot claim for every backend", () => {
+  // It is sent to EVERY backend. Claude receives panel_* from an in-process SDK MCP
+  // server; only the non-Claude lane uses the orchestrator's loopback HTTP MCP. An
+  // earlier draft told all of them "over a separate MCP connection", which is false
+  // agent-facing operational detail — and the model does not need it either way.
+  assert.doesNotMatch(CANVAS_TOOL_DISCLOSURE, /separate MCP connection|loopback|HTTP MCP/i);
+  assert.match(CANVAS_TOOL_DISCLOSURE, /supplied to you by the panel's orchestrator/);
+});
+
+test("the text refuses the specific improvisations #291 produced", () => {
+  // The reporter's session fell back to save_workflow and the user could not tell
+  // that anything had failed. A bare "say if you can't" does not cover it: each of
+  // these is a plausible-looking action on its own.
+  assert.match(CANVAS_TOOL_DISCLOSURE, /saving a workflow file/);
+  assert.match(CANVAS_TOOL_DISCLOSURE, /generate_image\/enqueue_workflow/);
+  assert.match(CANVAS_TOOL_DISCLOSURE, /never\s+describe graph edits you did not make/);
+  assert.match(CANVAS_TOOL_DISCLOSURE, /Say plainly that this session did not receive the live-canvas tools/);
+});
+
+test("the remedies are actionable from where the user already is, and are distinct", () => {
+  // One "not available" sentence covering several faults is a bucket narrated as a
+  // cause. These are three different faults with three different fixes: a crowded
+  // tool budget, a deliberate full-surface override, and a session to rebuild.
+  assert.match(CANVAS_TOOL_DISCLOSURE, /update comfyui-mcp/);
+  assert.match(CANVAS_TOOL_DISCLOSURE, /COMFYUI_MCP_TOOL_MODE=full/);
+  assert.match(CANVAS_TOOL_DISCLOSURE, /\/restart/);
+  assert.match(CANVAS_TOOL_DISCLOSURE, /switch this chat to the Claude backend/);
+});
+
+test("the text ends with a blank line so it cannot run into the user's message", () => {
+  // It is PREPENDED to the turn text. Without the separator the user's first words
+  // continue the disclosure's last sentence.
+  assert.ok(CANVAS_TOOL_DISCLOSURE.endsWith("\n\n"));
+});
+
+// ---------------------------------------------------------------------------
+// Wiring. The module above is pure and fully covered, but a correct decision that
+// nothing calls is worth nothing — and the panel's send path and bridge callbacks
+// live inside a 23k-line browser module with no DOM-free entry point. These read
+// the source the way pi-readiness-ordering.test.mjs does, and pin the three joints
+// where this fix can silently come apart. The browser BEHAVIOUR (that the model
+// actually receives the paragraph) is only confirmable in a live session.
+// ---------------------------------------------------------------------------
+
+test("wiring: a received command frame stamps proof for the CURRENT generation", () => {
+  const source = panelSource();
+  const start = source.indexOf("    onCommandReceived() {");
+  const end = source.indexOf("    onCommand(cmd, msg, reply) {", start);
+  assert.ok(start >= 0 && end > start, "could not locate the onCommandReceived bridge callback");
+  const handler = source.slice(start, end);
+  assert.match(
+    handler,
+    /canvasToolsProvenEpoch = agentSessionEpoch/,
+    "the only evidence the panel has must be recorded where every command frame lands",
+  );
+  assert.match(
+    handler,
+    /if \(commandProvesExposure\(\{ agentEpoch: agentSessionEpoch, messagedEpoch: canvasToolMessagedEpoch \}\)\)/,
+    "and must be gated — an unconditional stamp lets a replaced agent's straggler vouch for its successor",
+  );
+});
+
+test("wiring: a generation is marked prompted only after its message reached the wire", () => {
+  // The gate above is only as good as this stamp. Set before the send, a message
+  // that threw would still mark the generation prompted, and the very next straggler
+  // would count as proof — reopening the round-3 hole.
+  const body = sendUserMessageBody(panelSource());
+  const send = body.indexOf("sock.send(");
+  const stamp = body.indexOf("canvasToolMessagedEpoch = agentSessionEpoch");
+  assert.ok(send >= 0 && stamp > send, "the prompted stamp must follow the send");
+});
+
+test("wiring: proof is stamped on RECEIPT, not on a successful command", () => {
+  // onCommand runs only for non-silent commands and has the reply in hand, so
+  // stamping there would miss silent commands and could be narrowed to reply.ok —
+  // and a tool that ERRORS is still a tool the model was given.
+  const source = panelSource();
+  const start = source.indexOf("    onCommand(cmd, msg, reply) {");
+  const end = source.indexOf("onAgentStatus(s) {", start);
+  assert.ok(start >= 0 && end > start, "could not locate the onCommand bridge callback");
+  assert.doesNotMatch(source.slice(start, end), /canvasToolsProvenEpoch/);
+});
+
+/** The bridge client's sendUserMessage — the single frame-emitting choke point. */
+function sendUserMessageBody(source) {
+  const start = source.indexOf("    sendUserMessage(text, context, images, mid) {");
+  const end = source.indexOf("    /** Send an arbitrary control frame", start);
+  assert.ok(start >= 0 && end > start, "could not locate sendUserMessage");
+  return source.slice(start, end);
+}
+
+test("wiring: the disclosure rides on the WIRE frame, not on the composer", () => {
+  // Round 1 of the gate caught this: assembling it in the composer covered typed
+  // messages only. The post-restart and soft-reload RESUME nudges call
+  // sendUserMessage directly, on a brand-new socket — a fresh generation whose
+  // toolset is precisely what is in question — and they instruct the agent to
+  // "continue exactly what you were doing", which is the instruction a toolless
+  // model improvises around. Those turns must carry the disclosure too.
+  const body = sendUserMessageBody(panelSource());
+  assert.match(
+    body,
+    /planCanvasToolDisclosure\(\{\s*agentEpoch: agentSessionEpoch,\s*provenEpoch: canvasToolsProvenEpoch,\s*disclosedEpoch: canvasToolDisclosedEpoch,\s*\}\)/,
+    "the decision must be delegated to the tested module, with the real epochs",
+  );
+  assert.match(
+    body,
+    /const disclosed = disclosure\.disclose && typeof text === "string";/,
+    "the module's verdict must actually gate the prepend — a constant here silently disables the fix",
+  );
+  assert.match(
+    body,
+    /CANVAS_TOOL_DISCLOSURE \+ text/,
+    "the disclosure must be PREPENDED — appended after the message it reads as commentary",
+  );
+  assert.match(body, /text: outText/, "the frame must carry the disclosed text, not the original");
+});
+
+test("wiring: the composer no longer assembles the disclosure itself", () => {
+  // Two prepend sites would double it on every typed message. Asserting the
+  // absence of the old form, not merely the presence of the new one.
+  const source = panelSource();
+  const start = source.indexOf("    const changeBanner = manualChangeBanner();");
+  const end = source.indexOf("    // Track delivery:", start);
+  assert.ok(start >= 0 && end > start, "could not locate the composer's agent-facing text assembly");
+  assert.doesNotMatch(source.slice(start, end), /CANVAS_TOOL_DISCLOSURE/);
+});
+
+test("wiring: every user_message path goes through the one choke point", () => {
+  // The guarantee above holds only while sendUserMessage is the sole emitter of a
+  // user_message frame. A second one would be a silent hole.
+  // Comment lines are excluded by content, not by position: the wire-protocol
+  // header at the top of the file documents the frame and would otherwise count.
+  const emitters = panelSource()
+    .split("\n")
+    .filter((l) => l.includes('type: "user_message"') && !l.trim().startsWith("//"));
+  assert.deepEqual(emitters.map((l) => l.trim()), ['type: "user_message",'],
+    "a second user_message emitter would bypass the disclosure");
+});
+
+test("wiring: the disclosure is marked sent only AFTER the frame actually went out", () => {
+  // Rule: every guard is itself an operation that can fail. sock.send() throws on a
+  // socket that closed after the readyState check, and stamping first would spend
+  // this generation's one disclosure on a frame that never left.
+  const body = sendUserMessageBody(panelSource());
+  const send = body.indexOf("sock.send(");
+  const stamp = body.indexOf("canvasToolDisclosedEpoch = agentSessionEpoch");
+  assert.ok(send >= 0 && stamp > send, "the stamp must follow the send, not precede it");
+  assert.match(
+    body,
+    /if \(disclosed\) canvasToolDisclosedEpoch = agentSessionEpoch/,
+    "and must be conditional on having actually disclosed",
+  );
+});
+
+test("wiring: every hello advances the generation — including a re-hello on a live socket", () => {
+  const source = panelSource();
+  const start = source.indexOf("  function sendHello() {");
+  const end = source.indexOf("    void sendBridgeHello({", start);
+  assert.ok(start >= 0 && end > start, "could not locate sendHello");
+  assert.match(
+    source.slice(start, end),
+    /agentSessionEpoch\+\+/,
+    "a hello binds this socket to an agent session, and a re-hello can bind it to a NEW one",
+  );
+  // The socket-open path must actually reach it, since the explicit bump that used
+  // to sit in the open handler was removed in favour of this one.
+  const openStart = source.indexOf('    thisSock.addEventListener("open", () => {');
+  const openEnd = source.indexOf("      clearHandshake();", openStart);
+  assert.ok(openStart >= 0 && openEnd > openStart, "could not locate the socket open handler");
+  assert.match(source.slice(openStart, openEnd), /sendHello\(\);/);
+});
+
+test("wiring: a same-socket session reset frame advances the generation, after it is sent", () => {
+  // Decided by the module's list rather than by a condition rewritten at the call
+  // site, so adding a session-starting frame is an edit to one list.
+  const source = panelSource();
+  const frameStart = source.indexOf("    sendFrame(frame) {");
+  const frameEnd = source.indexOf("    sendCancel(", frameStart) >= 0
+    ? source.indexOf("    sendCancel(", frameStart)
+    : frameStart + 3000;
+  const body = source.slice(frameStart, frameEnd);
+  assert.match(body, /if \(startsNewAgentSession\(frame\?\.type\)\) agentSessionEpoch\+\+/);
+  const send = body.indexOf("sock.send(");
+  assert.ok(body.indexOf("startsNewAgentSession") > send, "reset only after the frame actually went out");
+});
+
+test("wiring: the disclosure is scoped to the AGENT epoch, never the socket epoch", () => {
+  // sessionEpoch (the socket binding, #369) does not move on a same-socket
+  // new_session, so reading it here would silently reintroduce the round-2 hole.
+  const source = panelSource();
+  for (const name of ["canvasToolsProvenEpoch", "canvasToolDisclosedEpoch"]) {
+    // Every ASSIGNMENT, excluding the `let … = null` declaration, which is the
+    // initial state rather than a stamp.
+    const stamps = [...source.matchAll(new RegExp(`(let )?\\b${name} = (\\w+)`, "g"))]
+      .filter((m) => !m[1])
+      .map((m) => m[2]);
+    assert.ok(stamps.length, `could not find any assignment to ${name}`);
+    assert.deepEqual(
+      [...new Set(stamps)],
+      ["agentSessionEpoch"],
+      `${name} must be stamped only with the agent epoch, not ${stamps.join("/")}`,
+    );
+  }
+});
+
+test("wiring: the panel's import edge names every binding it uses (module-link P0)", () => {
+  // The named imports at the top of THIS file are the link check for the module's
+  // exports — if one were missing, this file would fail to link and node --test
+  // would say so. That does not cover the PANEL's own import statement: a binding
+  // used in comfyui-mcp-panel.js but absent from its import list is a ReferenceError
+  // at panel load, which `node --check` cannot see and which takes down the whole
+  // sidebar (see module-graph-link.test.mjs for the same P0 in another edge).
+  const source = panelSource();
+  const stmt = source.match(/import \{([^}]*)\} from "\.\/lib\/canvas-tool-disclosure\.js";/);
+  assert.ok(stmt, "the panel must import from lib/canvas-tool-disclosure.js");
+  const imported = new Set(stmt[1].split(",").map((s) => s.trim()).filter(Boolean));
+  const body = source.slice(stmt.index + stmt[0].length);
+  for (const name of ["CANVAS_TOOL_DISCLOSURE", "commandProvesExposure", "planCanvasToolDisclosure", "startsNewAgentSession"]) {
+    if (new RegExp(`(?<![A-Za-z0-9_])${name}(?![A-Za-z0-9_])`).test(body))
+      assert.ok(imported.has(name), `${name} is used in the panel but not imported`);
+  }
+});
+
+test("wiring: the panel never decides this itself", () => {
+  // The whole point is that the panel cannot see the toolset. If it ever grows its
+  // own branch on these epochs, the decision has escaped the module that documents
+  // why "no command yet" is not "no tools".
+  const source = panelSource();
+  const decisions = source.match(/canvasToolsProvenEpoch\s*(?:===|!==|==|!=|<|>)/g) ?? [];
+  assert.deepEqual(decisions, [], "exposure must be judged only in lib/canvas-tool-disclosure.js");
+});

--- a/browser_tests/unit/canvas-tool-disclosure.test.mjs
+++ b/browser_tests/unit/canvas-tool-disclosure.test.mjs
@@ -29,6 +29,7 @@ import {
   planCanvasToolDisclosure,
   startsNewAgentSession,
 } from "../../web/js/lib/canvas-tool-disclosure.js";
+import { sendBridgeHello } from "../../web/js/lib/restart-tab-identity.js";
 
 const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
 const panelSource = () => readFileSync(panelPath, "utf8").replace(/\r\n/g, "\n");
@@ -364,22 +365,102 @@ test("wiring: the disclosure is marked sent only AFTER the frame actually went o
   );
 });
 
-test("wiring: every hello advances the generation — including a re-hello on a live socket", () => {
-  const source = panelSource();
-  const start = source.indexOf("  function sendHello() {");
-  const end = source.indexOf("    void sendBridgeHello({", start);
-  assert.ok(start >= 0 && end > start, "could not locate sendHello");
-  assert.match(
-    source.slice(start, end),
-    /agentSessionEpoch\+\+/,
-    "a hello binds this socket to an agent session, and a re-hello can bind it to a NEW one",
+test("sendBridgeHello reports whether the hello reached the wire — the contract the epoch rides on", async () => {
+  // Executable, because the panel's generation advance is now gated on this return
+  // value. If it ever became void, the panel would stop advancing the generation
+  // ENTIRELY and silently — the original #291 direction — and a purely static
+  // wiring test would still be green.
+  const sent = [];
+  const socket = { send: (s) => sent.push(s) };
+  const ok = await sendBridgeHello({
+    socket,
+    isCurrent: () => true,
+    resolveTabIdentity: async () => "tab-1",
+    makePayload: (id) => ({ type: "hello", tabSessionId: id }),
+  });
+  assert.equal(ok, true, "a hello that was written to the socket must report true");
+  assert.equal(sent.length, 1);
+
+  const superseded = await sendBridgeHello({
+    socket,
+    isCurrent: () => false, // this socket was replaced while identity resolved
+    resolveTabIdentity: async () => "tab-2",
+    makePayload: (id) => ({ type: "hello", tabSessionId: id }),
+  });
+  assert.equal(superseded, false, "a hello abandoned mid-flight must report false");
+  assert.equal(sent.length, 1, "and must not have written anything");
+});
+
+test("the README does not promise parity it cannot guarantee — anywhere in the file", () => {
+  // Normally prose is not worth a test. This is, because the claim is the reason
+  // #291 stayed invisible: "both providers expose this identical surface … feature
+  // parity is automatic" told every reader there was nothing to check. The first
+  // retraction fixed the body and left the SAME claim standing in the introduction,
+  // which a reader hits first — so the file contradicted itself and the retraction
+  // was largely undone. Scanning the whole file is what catches that.
+  //
+  // CHANGELOG.md is deliberately NOT scanned. It records what was claimed at the
+  // time of each release, and rewriting that is falsifying history, not correcting
+  // a claim — the same reason the repo's tool-vocabulary gate exempts it.
+  const readme = readFileSync(
+    fileURLToPath(new URL("../../README.md", import.meta.url)),
+    "utf8",
   );
-  // The socket-open path must actually reach it, since the explicit bump that used
-  // to sit in the open handler was removed in favour of this one.
+  for (const claim of ["full feature parity", "feature parity is automatic", "identical surface"]) {
+    assert.equal(
+      readme.includes(claim),
+      false,
+      `README still promises "${claim}" — parity is offered, not guaranteed received`,
+    );
+  }
+  // …and the qualification is actually there, not merely the absence of the boast.
+  assert.match(readme, /Offered, not guaranteed received/);
+  assert.match(readme, /identical \*\*as served\*\*/);
+});
+
+/** The whole body of the bridge client's sendHello(). */
+function sendHelloBody(source) {
+  const start = source.indexOf("  function sendHello() {");
+  const end = source.indexOf("  // When the workflow title changes", start);
+  assert.ok(start >= 0 && end > start, "could not locate sendHello");
+  return source.slice(start, end);
+}
+
+test("wiring: the generation advances only once the hello is ON THE WIRE", () => {
+  // The independent gate's P0. Advancing before `sendBridgeHello` resolves means a
+  // hello that never reached the orchestrator — identity still resolving when the
+  // socket was superseded or closed — still burned a generation. Nothing new was
+  // bound, so the consequence is the INVERSE of #291: a working agent's proof is
+  // invalidated and a session that demonstrably had the tools is asked whether it
+  // does. Same rule as #621 and #836: do not record that you did something before
+  // you did it.
+  const body = sendHelloBody(panelSource());
+  assert.match(
+    body,
+    /if \(sent\) agentSessionEpoch\+\+/,
+    "the advance must be conditional on the hello having actually been sent",
+  );
+  const call = body.indexOf("sendBridgeHello({");
+  const bump = body.indexOf("agentSessionEpoch++");
+  assert.ok(call >= 0 && bump > call, "the advance must FOLLOW the send, not precede it");
+  // …and there must be no second, unconditional one left behind in front of it.
+  assert.equal(
+    (body.match(/agentSessionEpoch\+\+/g) ?? []).length,
+    1,
+    "exactly one advance — a stray eager one would reintroduce the P0",
+  );
+});
+
+test("wiring: the socket-open path still reaches the hello that advances the generation", () => {
+  // The explicit bump that used to sit in the open handler was removed in favour of
+  // sendHello's. That is only sound while the open handler actually calls it.
+  const source = panelSource();
   const openStart = source.indexOf('    thisSock.addEventListener("open", () => {');
   const openEnd = source.indexOf("      clearHandshake();", openStart);
   assert.ok(openStart >= 0 && openEnd > openStart, "could not locate the socket open handler");
-  assert.match(source.slice(openStart, openEnd), /sendHello\(\);/);
+  const open = source.slice(openStart, openEnd);
+  assert.match(open, /sendHello\(\);/);
+  assert.doesNotMatch(open, /agentSessionEpoch/, "the open handler must not advance it a second time");
 });
 
 test("wiring: a same-socket session reset frame advances the generation, after it is sent", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13390,17 +13390,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     // `new_session` frame is sent, so `sendFrame`'s reset never fires and the
     // previous agent's proof and disclosure would carry onto a model that received
     // neither. `hello` is in AGENT_SESSION_RESET_FRAMES for that reason; it is
-    // bumped here rather than there only because sendHello, not sendFrame,
+    // bumped below rather than in sendFrame only because sendHello, not sendFrame,
     // dispatches it. This also covers the socket-open hello, so no separate bump is
     // needed in the open handler.
-    //
-    // Bumped EAGERLY, unlike sendFrame's reset, which waits for its send to return.
-    // That asymmetry is deliberate and both halves fail the same way: the hello goes
-    // out through an async helper with no synchronous success to hook, and a hello
-    // that never lands leaves the generation merely over-advanced — one extra
-    // disclosure. A new_session that never lands, by contrast, spawns no new agent,
-    // so NOT bumping there is the accurate answer, not a cautious one.
-    agentSessionEpoch++;
     const target = sock;
     void sendBridgeHello({
       socket: target,
@@ -13449,9 +13441,32 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // replayLostReplies, computed with the SAME epoch the replay uses.
         });
       },
-    }).catch(() => {
-      // Reconnect path will retry.
-    });
+    })
+      .then((sent) => {
+        // #291 — advance the agent-session generation ONLY once the hello is
+        // actually ON THE WIRE. sendBridgeHello resolves false when identity
+        // resolution outlived this socket (superseded / closed), and rejects when
+        // the send throws; in both cases NO hello reached the orchestrator, so no
+        // new agent exists and the current generation is still the right one.
+        //
+        // Advancing before the send was the inverse of the bug this whole module
+        // exists to fix: it invalidated a WORKING agent's proof and re-asked a
+        // session that demonstrably had the tools whether it had them. "Recorded
+        // before it happened" is the same defect as #621's interaction lock
+        // registering its holder before the freeze write landed and #836's
+        // panel-op lock releasing a claim it no longer owned.
+        //
+        // The in-flight window needs no extra state. A `user_message` frame carries
+        // NO tab id (only sendFrame stamps one), so the orchestrator can route it
+        // only by the binding this socket already has — and frames on one socket are
+        // ordered anyway, so a message sent while this hello is still awaiting
+        // identity is written BEFORE the hello. Either way it is handled by the
+        // pre-hello agent, which is exactly the generation it was stamped with.
+        if (sent) agentSessionEpoch++;
+      })
+      .catch(() => {
+        // Reconnect path will retry. No hello landed, so no generation advance.
+      });
   }
 
   // When the workflow title changes (rename / open a different file / progress

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -170,6 +170,12 @@ import {
   clipOutlineTitle,
 } from "./lib/graph-read.js";
 import { classifyManualChangeBaseline } from "./lib/manual-change-gate.js";
+import {
+  CANVAS_TOOL_DISCLOSURE,
+  commandProvesExposure,
+  planCanvasToolDisclosure,
+  startsNewAgentSession,
+} from "./lib/canvas-tool-disclosure.js";
 import { safeRemoveNode } from "./lib/safe-remove-node.js";
 import {
   classifyLtxTimelineWrite,
@@ -5259,6 +5265,34 @@ let lastAgentGraphKey = null;
 // "100+ nodes removed" notice that the very next live graph read contradicted.
 let lastAgentGraphEpoch = -1;
 let sessionEpoch = 0;
+
+// #291 — live-canvas tool exposure.
+//
+// agentSessionEpoch counts AGENT-session generations, which is NOT sessionEpoch
+// above. sessionEpoch tracks the SOCKET binding; a toolset belongs to the agent,
+// and `/new`, closing a thread, and picking a chat out of history all hand the
+// next turn to a fresh agent over the SAME live socket. Scoping to sessionEpoch
+// carried the old agent's proof and old disclosure onto that new model, which
+// received neither. So this bumps on a socket (re)connect AND on every
+// AGENT_SESSION_RESET_FRAMES frame.
+let agentSessionEpoch = 0;
+// canvasToolsProvenEpoch is the ONLY evidence the panel has about the agent's
+// toolset, and it is one-directional: a `cmd` frame reaches this panel solely
+// because the model invoked a panel_* tool (panel-tools.ts is the only caller of
+// the bridge's command send), so receiving one PROVES the tools are exposed in
+// that generation. Not receiving one proves nothing — a session with no canvas
+// work to do looks identical from here — so this is never read as "unavailable".
+// See lib/canvas-tool-disclosure.js for why the panel discloses rather than checks.
+// …with one qualification, which is why commandProvesExposure() exists: a command
+// is a response to a TURN, so a command arriving in a generation this panel has not
+// yet prompted is a straggler from the outgoing agent, not evidence about the new
+// one. canvasToolMessagedEpoch is the generation of the last user_message that
+// actually reached the wire, and gates that.
+let canvasToolsProvenEpoch = null;
+let canvasToolMessagedEpoch = null;
+// The generation CANVAS_TOOL_DISCLOSURE was last prepended in — once per agent
+// session, not once per turn.
+let canvasToolDisclosedEpoch = null;
 
 const MODE_NAME = { 0: "active", 2: "mute", 4: "bypass" };
 const modeName = (m) => MODE_NAME[m] ?? `mode${m ?? 0}`;
@@ -12653,6 +12687,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // baseline captured before this boundary instead of diffing it against a
       // possibly rebound / mid-reload canvas (a false "manual edits" delta).
       sessionEpoch++;
+      // (#291's agent-session generation advances in sendHello() below, which this
+      // handler always reaches — a new socket is a new agent session, and so is
+      // every later re-hello on this one.)
       // A bare WS open is NOT progress — the orchestrator handshake (`models`)
       // hasn't arrived yet. Do NOT reset attempt/gaveUp here (only markConnected
       // does), so an open-then-close-before-`models` cycle still INCREMENTS toward
@@ -13346,6 +13383,24 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
 
   function sendHello() {
     if (!sock || sock.readyState !== WebSocket.OPEN) return;
+    // #291 — a hello BINDS this socket to an agent session, and not always the one
+    // it was bound to a moment ago. Besides the socket-open hello, the panel
+    // re-hellos the LIVE socket to follow the user's workflow tabs, and with the
+    // session key cleared that hello spawns a clean agent outright — no
+    // `new_session` frame is sent, so `sendFrame`'s reset never fires and the
+    // previous agent's proof and disclosure would carry onto a model that received
+    // neither. `hello` is in AGENT_SESSION_RESET_FRAMES for that reason; it is
+    // bumped here rather than there only because sendHello, not sendFrame,
+    // dispatches it. This also covers the socket-open hello, so no separate bump is
+    // needed in the open handler.
+    //
+    // Bumped EAGERLY, unlike sendFrame's reset, which waits for its send to return.
+    // That asymmetry is deliberate and both halves fail the same way: the hello goes
+    // out through an async helper with no synchronous success to hook, and a hello
+    // that never lands leaves the generation merely over-advanced — one extra
+    // disclosure. A new_session that never lands, by contrast, spawns no new agent,
+    // so NOT bumping there is the accurate answer, not a cautious one.
+    agentSessionEpoch++;
     const target = sock;
     void sendBridgeHello({
       socket: target,
@@ -13488,11 +13543,35 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       const mergedContext =
         [pendingContext, serializeContext(context)].filter(Boolean).join("\n\n") || undefined;
       pendingContext = null;
+      // #291 — ask the agent, ONCE per session generation, to check whether the
+      // panel_* live-canvas tools actually reached its toolset, and tell it what to
+      // do if they did not. The panel never asserts they are missing; it cannot
+      // know that (see lib/canvas-tool-disclosure.js).
+      //
+      // THIS is the choke point, deliberately — not the composer. The composer is
+      // only one of the paths that opens a turn; the post-restart and soft-reload
+      // RESUME nudges are others, and they are the worst ones to miss. They fire
+      // on a brand-new socket (a fresh session generation, whose toolset is exactly
+      // what is in question) and they say "continue exactly what you were doing" —
+      // an instruction a model with no canvas tools cannot follow and, per #291,
+      // will improvise around instead of refusing. Every user_message on the wire
+      // goes through here, so the once-per-generation scope is real rather than
+      // once-per-generation-if-the-user-happened-to-type-first.
+      //
+      // Prepended, so it reads before the message it rides on: a model with no
+      // canvas tools must decide before it starts, not after it has improvised.
+      const disclosure = planCanvasToolDisclosure({
+        agentEpoch: agentSessionEpoch,
+        provenEpoch: canvasToolsProvenEpoch,
+        disclosedEpoch: canvasToolDisclosedEpoch,
+      });
+      const disclosed = disclosure.disclose && typeof text === "string";
+      const outText = disclosed ? CANVAS_TOOL_DISCLOSURE + text : text;
       try {
         sock.send(
           JSON.stringify({
             type: "user_message",
-            text,
+            text: outText,
             ...(mergedContext ? { context: mergedContext } : {}),
             ...(images?.length ? { images: normalizeImageList(images) } : {}),
             // Client message id — the orchestrator echoes it in the "working"
@@ -13500,6 +13579,19 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             ...(mid ? { mid } : {}),
           }),
         );
+        // Mark it sent only AFTER the send returned. sock.send() throws on a socket
+        // that closed between the readyState check above and here, and stamping
+        // before it would spend the one disclosure this generation gets on a frame
+        // that never left — leaving the retry, which is exactly the turn that needs
+        // it, silent. (Bytes accepted is still not bytes received; that residual is
+        // the same one every frame on this socket has, and a redundant disclosure
+        // on the next turn is the harmless direction.)
+        if (disclosed) canvasToolDisclosedEpoch = agentSessionEpoch;
+        // This generation has now been PROMPTED, so a command arriving from here on
+        // can plausibly be its answer. Until this point any command belongs to the
+        // agent this one replaced (see commandProvesExposure). Also after the send,
+        // for the same reason: a message that never left prompted nothing.
+        canvasToolMessagedEpoch = agentSessionEpoch;
         return true;
       } catch {
         return false;
@@ -13523,6 +13615,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       }
       try {
         sock.send(JSON.stringify({ tab_id: workflowTabId(), ...frame }));
+        // #291 — `new_session` / `resume_session` hand the next turn to a different
+        // agent over THIS same socket (/new, closing a thread, opening one from
+        // history), so the socket generation does not move and, without this, the
+        // outgoing agent's proof and disclosure would suppress the paragraph for a
+        // fresh model that got neither. Bumped AFTER the send for the same reason
+        // the disclosure stamp is: a frame that threw never reset anything.
+        if (startsNewAgentSession(frame?.type)) agentSessionEpoch++;
         return true;
       } catch {
         return false;
@@ -20059,6 +20158,16 @@ function buildPanel() {
     // via onCommand; the activity marking lives here so silent commands count too.
     onCommandReceived() {
       noteActivity();
+      // #291 — this frame is proof the model HAS the panel_* tools in this session
+      // generation: nothing but a panel_* tool invocation produces a command frame.
+      // Stamping it here (not in onCommand) covers SILENT commands too, and covers
+      // a command that goes on to FAIL — a tool that errors is still a tool the
+      // model was given, which is the only thing this stamp claims. Whether it is
+      // THIS generation's evidence at all is the module's call, not a check written
+      // out here (see commandProvesExposure — an in-flight command from an agent
+      // the user just replaced must not vouch for its successor).
+      if (commandProvesExposure({ agentEpoch: agentSessionEpoch, messagedEpoch: canvasToolMessagedEpoch }))
+        canvasToolsProvenEpoch = agentSessionEpoch;
     },
     onCommand(cmd, msg, reply) {
       appendActivity(cmd, msg, reply);

--- a/web/js/lib/canvas-tool-disclosure.js
+++ b/web/js/lib/canvas-tool-disclosure.js
@@ -100,6 +100,13 @@ export const CANVAS_TOOL_DISCLOSURE =
  *     dispatches it — so it is listed here for the rule, and the bump lives in
  *     `sendHello`.
  *
+ * EVERY ONE OF THESE ADVANCES THE GENERATION ONLY ONCE ITS FRAME IS ON THE WIRE.
+ * A frame that was never sent bound nothing, so advancing for it would invalidate a
+ * working agent's proof and re-ask a session that demonstrably had the tools whether
+ * it had them — the inverse of the bug this module exists to fix. The hello case is
+ * the subtle one, because its send is asynchronous (it waits on restart-identity
+ * exclusivity) and can be abandoned mid-flight when the socket is superseded.
+ *
  * THE TRADE, named rather than left as a surprise: this list is deliberately coarse.
  * A re-hello (plus its `resume_session`) also fires for events that keep the SAME
  * conversation — a save migrating a tab from `tmp:` to `wf:`, a rename — so those

--- a/web/js/lib/canvas-tool-disclosure.js
+++ b/web/js/lib/canvas-tool-disclosure.js
@@ -1,0 +1,202 @@
+// #291 — the panel cannot see the agent's toolset, so it must not let the agent
+// pretend it can see the canvas.
+//
+// THE DEFECT. The `panel_*` tools that read and edit the workflow the user is
+// looking at are DEFINED once and served two ways: the Claude backend hosts them
+// on an in-process SDK MCP server, every other backend receives them from the
+// orchestrator over a loopback HTTP MCP. Sharing the definitions makes the two
+// surfaces identical AT THE SERVER. It does not make them identical AT THE MODEL:
+// a backend applies its own tool budget to everything it is given, and Codex was
+// observed to SILENTLY DROP the whole panel MCP server once the ~250-tool headless
+// comfyui surface saturated that budget — the server advertised the tools, the
+// model never received them. (Root cause and the upstream remedy: comfyui-mcp#594,
+// which spawns comfyui in compact mode for the non-Claude lane.)
+//
+// WHY A DISCLOSURE AND NOT A CHECK. The obvious fix — have the panel detect the
+// missing tools and say so — is not available to the panel, and shipping a guess
+// dressed as a check would be the worse bug. The panel receives no tool-use events
+// and no toolset manifest; the ONLY panel-observable fact is POSITIVE: a `cmd`
+// frame arrives only because the model invoked a panel_* tool, so one command
+// PROVES exposure. Nothing proves the converse. An agent that simply had no reason
+// to touch the canvas this session is indistinguishable, from here, from one that
+// could not. So "no panel_* command yet" is UNESTABLISHED, never "unavailable",
+// and this module never asserts the tools are missing.
+//
+// The one party that can see the toolset is the model. So the panel asks it, once,
+// and tells it what to do with the answer — because the failure mode is not that
+// the model lacks the tools, it is that a model told (by the system prompt) that it
+// has panel_* tools, finding none, IMPROVISES: it saves a workflow file, enqueues
+// headlessly, or narrates canvas edits it never made, and the user reads that as
+// the panel being broken. That is the whole of #291 as the reporter experienced it.
+//
+// Pure + side-effect-free so the decision is unit-testable in isolation; the caller
+// stamps the epochs and prepends the text.
+
+/**
+ * The text prepended to the agent's turn. Exported so the wiring and the tests
+ * assert the SAME string, and so a change to what we tell the model is a visible
+ * change to a named constant rather than an edit buried in a send path.
+ *
+ * Three properties this text must keep:
+ *
+ *  1. It states our own UNCERTAINTY as uncertainty. It does not tell the model its
+ *     tools are missing (we do not know that) and it does not tell it they are
+ *     present (we do not know that either). It asks the one party that can see.
+ *
+ *  2. It names the substitutes to REFUSE. "Say if you can't" is not enough on its
+ *     own: the improvisations are individually reasonable-looking actions, and the
+ *     reporter's session took one (`save_workflow`) and read as merely unhelpful
+ *     rather than as a missing capability.
+ *
+ *  2b. It covers ADVERTISED-BUT-UNUSABLE, not only absent. A tool present in the
+ *     list can still fail at call time — the loopback MCP can die, the panel tab
+ *     can be gone — and "listed, therefore fine" is the same defect as "unlisted,
+ *     therefore impossible", running the other way. So the present branch is not a
+ *     free pass: it forbids the identical silent headless substitution after a
+ *     panel_* call FAILS, which is where the fabrication would otherwise reappear.
+ *
+ *  3. Its remedies are actionable from where the user already is — update, prune
+ *     the backend's own MCP config, restart, or switch backend — not "unavailable".
+ *     They are also ordered by likelihood, and each names its OWN cause: a crowded
+ *     tool budget, a deliberate `full` override, and a session that needs rebuilding
+ *     are three different faults and must not be narrated as one.
+ */
+export const CANVAS_TOOL_DISCLOSURE =
+  `⚙ LIVE-CANVAS TOOLS — CHECK YOUR TOOLSET BEFORE YOU ACT ON THE CANVAS. ` +
+  `The panel_* tools that read and edit the workflow this user has open are supplied to you by the ` +
+  `panel's orchestrator, and the panel CANNOT observe whether they reached your toolset — only you ` +
+  `can see that. This is a question, not a claim that anything is wrong.\n` +
+  `• IF panel_graph_outline IS in your toolset: work on the canvas normally. But being listed is not ` +
+  `proof the canvas is reachable — if a panel_* call then FAILS, report that failure and what it ` +
+  `said; do NOT quietly substitute a headless workaround for it.\n` +
+  `• IF IT IS NOT in your toolset: do NOT improvise a substitute — no saving a workflow file instead ` +
+  `of editing the canvas, no headless generate_image/enqueue_workflow standing in for a canvas run — ` +
+  `and never describe graph edits you did not make. Say plainly that this session did not receive the ` +
+  `live-canvas tools, then give the user these remedies in order: (1) update comfyui-mcp — on a ` +
+  `non-Claude backend the headless comfyui tools can crowd panel_* out of the backend's tool budget, ` +
+  `which is issue #291 and is fixed upstream; (2) if COMFYUI_MCP_TOOL_MODE=full is set, unset it, and ` +
+  `drop MCP servers you don't need from that backend's own config, to leave budget for panel_*; ` +
+  `(3) run /restart in the panel to rebuild the session, or switch this chat to the Claude backend, ` +
+  `which receives panel_* by a different route.\n\n`;
+
+/**
+ * Frames that bind this socket to an agent session whose toolset we have no
+ * evidence about — including ones that do so on a socket that never closed.
+ *
+ * The disclosure's scope is an AGENT session, because that is what owns a toolset,
+ * and a socket generation is NOT the same thing. Three same-socket paths hand the
+ * next turn to a different agent, and every one of them was a hole in an earlier
+ * draft of this fix:
+ *
+ *   • `new_session` — `/new`, or closing the open thread.
+ *   • `resume_session` — picking a chat out of history. Included even though it
+ *     names an EXISTING session: the orchestrator re-establishes that session's
+ *     backend, so the toolset is negotiated again and we have no evidence it came
+ *     back the same.
+ *   • `hello` — the per-workflow re-target. The panel follows the user's workflow
+ *     tabs by re-helloing the LIVE socket with the new tab id; with the session key
+ *     cleared that hello spawns a clean agent outright, with no `new_session` frame
+ *     anywhere. Note this one does NOT travel through `sendFrame` — `sendHello`
+ *     dispatches it — so it is listed here for the rule, and the bump lives in
+ *     `sendHello`.
+ *
+ * THE TRADE, named rather than left as a surprise: this list is deliberately coarse.
+ * A re-hello (plus its `resume_session`) also fires for events that keep the SAME
+ * conversation — a save migrating a tab from `tmp:` to `wf:`, a rename — so those
+ * users see the paragraph again mid-chat. Distinguishing them would mean tracking
+ * which session id we were already on and trusting that tracking to decide whether
+ * to warn, i.e. a second piece of state whose being wrong is silent. The cost of
+ * being coarse is a repeated paragraph on an occasional, user-initiated event; the
+ * cost of being precise and wrong is #291. Frequency is bounded either way: it is
+ * once per generation, never per turn.
+ *
+ * Exported and derived-from rather than inlined at the call sites so the rule is one
+ * testable list, and so a new session-starting frame is a change to this list rather
+ * than a silent hole.
+ */
+export const AGENT_SESSION_RESET_FRAMES = ["hello", "new_session", "resume_session"];
+
+/** Does sending this frame type start a turn under a possibly-different toolset? */
+export function startsNewAgentSession(frameType) {
+  return AGENT_SESSION_RESET_FRAMES.includes(frameType);
+}
+
+/**
+ * May a command frame arriving NOW be counted as proof for the current generation?
+ *
+ * A `cmd` frame carries no agent-session correlation, and the socket is
+ * bidirectional: when a same-socket reset (`/new`, a chat picked from history)
+ * advances the generation, a command the OUTGOING agent already put on the wire can
+ * land immediately afterwards. Stamped naively, that straggler proves a generation
+ * it was never part of — and the fresh, possibly toolless model then gets no
+ * disclosure. That is precisely #291 again, reached by ordinary WebSocket timing
+ * rather than by anything exotic.
+ *
+ * The disambiguator is exact rather than a timing window: a command is a response
+ * to a turn, and the new agent has no turn until the panel sends it one. So a
+ * command arriving in a generation the panel has not yet sent a user_message in
+ * cannot be that agent's, and is refused as evidence.
+ *
+ * `messagedEpoch` is the generation of the last user_message the panel actually got
+ * onto the wire — not the last one composed, since a message that never left cannot
+ * have prompted anything.
+ *
+ * RESIDUAL, stated rather than papered over: a straggler that arrives AFTER the new
+ * generation's first message can still be miscounted. It is benign — by then that
+ * generation's one disclosure has already been delivered, which is the outcome this
+ * whole module exists to secure. Closing it would need a session id on the command
+ * frame, which is an orchestrator-side wire change, not a panel one.
+ */
+export function commandProvesExposure({ agentEpoch, messagedEpoch } = {}) {
+  return Number.isFinite(agentEpoch) && messagedEpoch === agentEpoch;
+}
+
+/**
+ * Decide whether to prepend {@link CANVAS_TOOL_DISCLOSURE} to this turn.
+ *
+ * Epochs count AGENT-session generations: bumped on every orchestrator socket
+ * (re)connect AND on every {@link AGENT_SESSION_RESET_FRAMES} frame. Both the proof
+ * and the disclosure are scoped to ONE generation, so neither carries across a
+ * reconnect, a backend switch, or a same-socket new/resumed chat.
+ *
+ * @param {{agentEpoch?:unknown, provenEpoch?:unknown, disclosedEpoch?:unknown}} state
+ *   agentEpoch     — the current agent-session generation.
+ *   provenEpoch    — the generation in which a panel_* command was last received
+ *                    (i.e. exposure was PROVEN), or null if never.
+ *   disclosedEpoch — the generation this disclosure was last emitted in, or null.
+ * @returns {{disclose:boolean, reason:"proven"|"already-disclosed"|"unestablished"|"epoch-unknown"}}
+ */
+export function planCanvasToolDisclosure({ agentEpoch, provenEpoch, disclosedEpoch } = {}) {
+  // A non-finite epoch (missing / NaN — an uninitialized or corrupted stamp) makes
+  // both scoped comparisons below meaningless: `null === null` and `NaN !== NaN`
+  // would silently decide the question on garbage. We cannot scope the
+  // once-per-session rule, so we do the harmless thing rather than the quiet one
+  // and disclose. A disclosure the model does not need costs it one paragraph it is
+  // explicitly told to ignore; a disclosure wrongly withheld is the #291 session,
+  // where the model improvised and the user blamed the panel.
+  if (!Number.isFinite(agentEpoch)) return { disclose: true, reason: "epoch-unknown" };
+
+  // Both comparisons below are STRICT and are deliberately not paired with their
+  // own finiteness guard. The early return above already establishes that
+  // agentEpoch is a real number, so `undefined`, `null`, `NaN` and the string
+  // "3" all fail `===` against it on their own; a second Number.isFinite() call
+  // could not change any outcome, and a guard no test can distinguish is
+  // decoration that later reads as protection. What DOES matter is that these
+  // stay `===`: a loosened `==` would let the string "3" pass as proof.
+
+  // PROVEN. A panel_* command reached this panel in THIS generation, so the model
+  // demonstrably has the tools — asking it to check would be noise about a
+  // question already answered. This is the only branch backed by evidence, and it
+  // is evidence of PRESENCE; there is deliberately no "proven absent" branch,
+  // because nothing observable from the panel would justify one.
+  if (provenEpoch === agentEpoch) return { disclose: false, reason: "proven" };
+
+  // ALREADY DISCLOSED in this generation — it is in the model's context for the
+  // rest of the session. Repeating it every turn would train the model to skim
+  // past the one paragraph that has to be read.
+  if (disclosedEpoch === agentEpoch) return { disclose: false, reason: "already-disclosed" };
+
+  // UNESTABLISHED — not "unavailable". We have no evidence either way, which is
+  // exactly the state the disclosure is written for.
+  return { disclose: true, reason: "unestablished" };
+}


### PR DESCRIPTION
## #291 — Codex sidebar sessions do not expose live `panel_*` graph editing tools

Closes #291

### Can they be exposed? Yes — and the cause is already fixed upstream. What was left is that the failure was still silent.

The `panel_*` live-canvas tools are defined once (`panel-tools.ts`) and served two ways: Claude hosts them on an in-process SDK MCP server, every other backend receives them from the orchestrator over a loopback HTTP MCP. The wiring was never broken. The failure was **tool-budget saturation in Codex**: the headless comfyui MCP exposes ~250 tools, and once Codex's total tool surface saturated, Codex **silently dropped the entire panel MCP server** — advertised by us, never received by the model. Verified live in comfyui-mcp#594 (merged), which fixed the cause by spawning comfyui in compact mode for the non-Claude lane.

So the answer to "can they be exposed for this session type" is **yes, they can, and they now are**. This PR is about the part #594 did not close: **nothing tells anyone when they are not.**

### What is still reachable, and why the panel cannot detect it

`panel_*` can still be absent from a session when `COMFYUI_MCP_TOOL_MODE=full` is set, when the user's own `~/.codex` MCP servers saturate the budget, or when the orchestrator's loopback panel MCP failed to bind (it logs `UNAVAILABLE` and declares no panel server at all, while the system prompt still asserts the tools exist). In every one of those the model does not say "I have no tools for that" — it **improvises**, which is exactly what the reporter saw: a `save_workflow` fallback and a workflow that never reached the canvas. The user reads that as the panel being broken.

**The panel cannot detect this, and this PR does not pretend to.** It receives no tool-use events and no toolset manifest. The one panel-observable fact is one-directional: a `cmd` frame arrives *only* because the model invoked a `panel_*` tool (`panel-tools.ts` is the sole caller of the bridge's command send), so one command **proves** exposure — and nothing proves the converse. A session with no canvas work to do is indistinguishable, from here, from one that could not do any. So "no `panel_*` command yet" stays **unestablished**, never "unavailable". There is deliberately no "proven absent" branch.

### What it does instead — ask the only party that can see

`web/js/lib/canvas-tool-disclosure.js` (new, pure) + a wire-level hook. Once per agent-session generation, the panel prepends a paragraph to the agent-facing turn text that:

- states the panel's **own blindness** as the reason it is asking, and says outright that this is a question, not a claim that anything is wrong;
- names the tool to look for (`panel_graph_outline`);
- **if absent** — forbids the specific improvisations #291 produced (saving a workflow file, a headless `generate_image`/`enqueue_workflow` standing in for a canvas run, narrating edits it did not make), tells the model to say so plainly, and hands the user three *distinct* remedies, each with its own cause: update comfyui-mcp (crowded tool budget), unset `COMFYUI_MCP_TOOL_MODE=full` / prune that backend's own MCP config (deliberate full-surface override), `/restart` or switch to the Claude backend (session to rebuild);
- **if present** — is still not a free pass: being listed is not proof the canvas is reachable, so a `panel_*` call that FAILS must be reported rather than quietly replaced by a headless workaround. Advertised-but-unusable is the same defect as unlisted-therefore-impossible, running the other way.

It is suppressed permanently within a generation the moment any `panel_*` command proves the tools are there, and never repeated within one.

### Scope is the AGENT session, not the socket

Four gate rounds were spent on this and each found a real hole:

- The disclosure rides on `sendUserMessage`, the **sole emitter** of a `user_message` frame — not the composer. The post-restart and soft-reload **resume nudges** open a turn too, on a brand-new socket, saying "continue exactly what you were doing" — the worst turn to leave unchecked.
- A distinct `agentSessionEpoch` scopes both stamps. It advances on every `hello` (socket-open *and* the per-workflow re-target, which with the session key cleared spawns a clean agent with no `new_session` frame anywhere) and on every `new_session`/`resume_session` — the three same-socket paths that hand the next turn to a different agent.
- A `cmd` carries no session correlation, so an in-flight command from the agent the user just replaced could land after the reset and vouch for its successor. `commandProvesExposure` refuses it, by an exact rule rather than a timing window: a command answers a **turn**, and the new agent has had none until we send it one.

### The README overclaim, retracted

> ~~"**Both providers expose this identical surface** … so feature parity is automatic."~~

That sentence is why nobody looked. The definitions are shared, so the surfaces are identical **as served** — they are not automatically identical **as received**, and the README now says so, names #291, and gives the same remedies.

### Documented residuals (named, not papered over)

- A straggler `cmd` arriving *after* the new generation's first message can still be miscounted as proof. Benign: that generation's one disclosure has already gone out. Closing it needs a session id on the command frame — an orchestrator-side wire change, not a panel one.
- The reset-frame list is deliberately coarse: a save (`tmp:`→`wf:`) or rename also re-hellos, so those users see the paragraph again mid-chat. Being precise would mean a second piece of state whose being wrong is silent; being coarse costs a repeated paragraph on an occasional user-initiated event.

### Verification

- 33 new unit tests. Every assertion checks the **reason**, not just the boolean — "do not disclose" is right for two different states (proven present / already said) and a boolean-only test passes if they are confused.
- **Mutation-verified**: 24 mutants across the module and the wiring, each killed by a named test. Two genuine survivors were found and fixed rather than explained away: a redundant `Number.isFinite` guard no test could distinguish (deleted — a guard nothing can kill is decoration that later reads as protection), and a hardcoded `disclosed = false` that silently disabled the whole fix (now pinned).
- Wiring is asserted by reading the panel source, the repo's existing pattern for a 23k-line module with no DOM-free entry point (cf. `pi-readiness-ordering.test.mjs`), plus a module-link guard for the panel's import edge — a missing binding there is a ReferenceError at load that `node --check` cannot see and that takes down the whole sidebar.
- Full unit suite green. `tsc --noEmit` clean. `node --check` in both CJS and **`.mjs`** mode. Tool-vocabulary gate passes. Control-byte scan (`tr -d '\011\012\015' | tr -dc '\000-\037'`) returns 0 on every changed file. README post-state grepped for the **absence** of the retracted claim as well as the presence of the new one.
- Four rounds of adversarial `gpt-5.6-terra` review, each returning a real P1 that is fixed above.

### Only a live browser session can confirm

That the paragraph actually reaches the model and that a real toolless Codex session responds to it by reporting rather than improvising. Everything above proves the panel emits it under the right conditions and never under the wrong ones; it cannot prove a model's behaviour on receipt.

### Not touched

`pyproject.toml` / `PANEL_VERSION` (a version change publishes to the Comfy Registry). No tool name is hard-coded as a list — the one name in the disclosure is validated against `vendor/tool-vocabulary.json` by the existing gate, so #726's consolidation will catch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
