### PR TITLE
Panel features cluster: triage first — secret-card sizing (#8) and the docs users could never find (#111)

### DIFF
--- a/browser_tests/unit/docs-discoverability.test.mjs
+++ b/browser_tests/unit/docs-discoverability.test.mjs
@@ -42,6 +42,12 @@ test("#111 Settings → About has a docs row that opens the docs site", () => {
   assert.notEqual(at, -1, "the About section must have a docs row");
   const row = SRC.slice(at, at + 1200);
   assert.match(row, /category: cat\("About"/, "it belongs to About, beside Star/Discord/Need-help");
+  // The tooltip names the DESTINATION, never the mechanism: the panel-wide click
+  // delegate routes this through openExternalUrl, whose desktop path hands off to
+  // the system browser rather than a tab, and reports nothing back either way.
+  const tooltip = row.match(/tooltip:\s*\n?\s*"([^"]+)"/)[1];
+  assert.match(tooltip, /comfyui-mcp\.artokun\.io\/docs/, "the tooltip says where the link goes");
+  assert.doesNotMatch(tooltip, /new tab|opens\b/i, "no claim about how or whether it opens");
   assert.match(row, /a\.href = DOCS_URL/, "the anchor points at the docs constant");
   // Opening in-frame hijacks the whole window in the ComfyUI desktop app.
   assert.match(row, /a\.target = "_blank"/);

--- a/browser_tests/unit/docs-discoverability.test.mjs
+++ b/browser_tests/unit/docs-discoverability.test.mjs
@@ -76,6 +76,14 @@ test("#111 /docs is a LOCAL command — it opens externally, never in-frame", ()
   // tab", is a state never observed (and the tab wording is simply wrong on
   // desktop). What survives is the URL plus a conditional remedy.
   assert.match(code, /Docs: \$\{DOCS_URL\} — if nothing opened, copy that address\./);
+  // ORDER MATTERS. The note is the remedy for the open having failed, so emitting it
+  // after the attempt made it conditional on that attempt not throwing — backwards.
+  // openExternalUrl is guarded and should not throw, but a remedy that relies on its
+  // own failure path staying healthy is not a remedy.
+  assert.ok(
+    code.indexOf("appendSystem(") < code.indexOf("openExternalUrl("),
+    "the URL must reach the transcript BEFORE the open is attempted",
+  );
   assert.doesNotMatch(code, /appendSystem\(`Opening\b/, "must not report an outcome it cannot see");
   assert.doesNotMatch(code, /appendSystem\([^)]*new tab/, "must not name a mechanism it does not control");
 });

--- a/browser_tests/unit/docs-discoverability.test.mjs
+++ b/browser_tests/unit/docs-discoverability.test.mjs
@@ -1,0 +1,83 @@
+// #111 — the panel must point somewhere other than Discord.
+//
+// The community feature requests in #111 include items that had ALREADY SHIPPED and
+// were already documented (the eval ladder at /docs/arena; compact tool mode; the
+// panel/npx version-skew sync flow). Users asked for them because a panel user's
+// entire discovery path was: an empty-state sentence, four prompt chips, a nine-item
+// slash list, and a Discord invite. No surface in this file linked to the docs site
+// at all — so "ask a human" was the only exit, and the community carried questions
+// the docs already answered.
+//
+// This does not make the panel self-documenting and does not pretend to. It asserts
+// only that the signpost exists and stays wired, in both places a stuck user looks:
+// Settings → About, and /help.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(join(HERE, "../../web/js/comfyui-mcp-panel.js"), "utf8");
+
+test("#111 the docs URL is a single named constant, not a literal copied around", () => {
+  const decl = SRC.match(/const DOCS_URL = "([^"]+)";/);
+  assert.ok(decl, "DOCS_URL must be declared");
+  // Verified reachable at the time of the change: /docs and /docs/arena both serve.
+  assert.equal(decl[1], "https://comfyui-mcp.artokun.io/docs");
+  // One declaration only — this file loads as an ES MODULE, where a second
+  // top-level `const DOCS_URL` is a SyntaxError that takes down the entire panel
+  // (and `node --check` in CJS mode does not catch it).
+  assert.equal(SRC.match(/const DOCS_URL\b/g).length, 1, "exactly one top-level declaration");
+  // Every use goes through the constant, so the link can never be half-updated.
+  assert.doesNotMatch(
+    SRC.replace(/const DOCS_URL = "[^"]+";/, ""),
+    /"https:\/\/comfyui-mcp\.artokun\.io\/docs/,
+    "no second hard-coded docs literal",
+  );
+});
+
+test("#111 Settings → About has a docs row that opens the docs site", () => {
+  const at = SRC.indexOf('id: "comfyui-mcp.readDocs"');
+  assert.notEqual(at, -1, "the About section must have a docs row");
+  const row = SRC.slice(at, at + 1200);
+  assert.match(row, /category: cat\("About"/, "it belongs to About, beside Star/Discord/Need-help");
+  assert.match(row, /a\.href = DOCS_URL/, "the anchor points at the docs constant");
+  // Opening in-frame hijacks the whole window in the ComfyUI desktop app.
+  assert.match(row, /a\.target = "_blank"/);
+  assert.match(row, /a\.rel = "noopener noreferrer"/);
+  // It must sort ABOVE the Discord row: asking a human was previously the only exit.
+  const docsOrder = Number(row.match(/sortOrder: ([\d.]+)/)[1]);
+  const discord = SRC.slice(SRC.indexOf('id: "comfyui-mcp.joinDiscord"'), SRC.indexOf('id: "comfyui-mcp.joinDiscord"') + 400);
+  const discordOrder = Number(discord.match(/sortOrder: ([\d.]+)/)[1]);
+  assert.ok(docsOrder > discordOrder, `docs (${docsOrder}) must render above Discord (${discordOrder})`);
+});
+
+test("#111 /docs is a LOCAL command — it opens externally, never in-frame", () => {
+  const at = SRC.indexOf('cmd: "/docs"');
+  assert.notEqual(at, -1, "a /docs slash command must exist");
+  // Only THIS entry, and only its executable part: a `//` comment naming the
+  // forbidden call (this one does) must not satisfy — or fail — the assertion.
+  const entry = SRC.slice(at, SRC.indexOf('cmd: "', at + 10));
+  const code = entry.replace(/\/\/[^\n]*/g, "");
+  assert.match(code, /openExternalUrl\(DOCS_URL\)/, "must route through openExternalUrl");
+  // window.location/window.open would navigate the ComfyUI app itself in the
+  // desktop build — no back button, hard-reload to escape.
+  assert.doesNotMatch(code, /window\.location|window\.open/, "must not navigate the app frame");
+});
+
+test("#111 /help says its list is only panel shortcuts, and names where the rest is", () => {
+  const at = SRC.indexOf('cmd: "/help"');
+  assert.notEqual(at, -1);
+  const entry = SRC.slice(at, at + 1400);
+  assert.match(entry, /DOCS_URL/, "/help must carry the docs pointer");
+  // The framing is the point: a bare list of nine shortcuts reads as the full
+  // extent of what the panel can do, which is how #111 happened.
+  assert.match(entry, /panel shortcuts/, "/help must not let its list read as everything");
+  // No tool names or counts: mcp RFC #726 is consolidating the tool surface, and a
+  // number baked in here would be wrong on the day it lands.
+  assert.doesNotMatch(entry, /\b\d+\s+tools\b/, "no tool count to go stale");
+  // Newlines would silently collapse — .cmcp-sys has no white-space:pre-wrap.
+  const helpString = entry.slice(entry.indexOf("appendSystem"));
+  assert.doesNotMatch(helpString.slice(0, helpString.indexOf("},")), /\\n/, "no newline that cannot render");
+});

--- a/browser_tests/unit/docs-discoverability.test.mjs
+++ b/browser_tests/unit/docs-discoverability.test.mjs
@@ -42,9 +42,11 @@ test("#111 Settings → About has a docs row that opens the docs site", () => {
   assert.notEqual(at, -1, "the About section must have a docs row");
   const row = SRC.slice(at, at + 1200);
   assert.match(row, /category: cat\("About"/, "it belongs to About, beside Star/Discord/Need-help");
-  // The tooltip names the DESTINATION, never the mechanism: the panel-wide click
-  // delegate routes this through openExternalUrl, whose desktop path hands off to
-  // the system browser rather than a tab, and reports nothing back either way.
+  // The tooltip names the DESTINATION, never the mechanism. This row renders into
+  // ComfyUI's own Settings dialog, outside the sidebar root that wireExternalLinks
+  // delegates on, so the anchor's native target=_blank is the whole mechanism —
+  // and where it lands (a tab, the desktop build's system browser, or nowhere if a
+  // popup blocker eats it) is neither chosen nor observed here.
   const tooltip = row.match(/tooltip:\s*\n?\s*"([^"]+)"/)[1];
   assert.match(tooltip, /comfyui-mcp\.artokun\.io\/docs/, "the tooltip says where the link goes");
   assert.doesNotMatch(tooltip, /new tab|opens\b/i, "no claim about how or whether it opens");

--- a/browser_tests/unit/docs-discoverability.test.mjs
+++ b/browser_tests/unit/docs-discoverability.test.mjs
@@ -64,12 +64,14 @@ test("#111 /docs is a LOCAL command — it opens externally, never in-frame", ()
   // window.location/window.open would navigate the ComfyUI app itself in the
   // desktop build — no back button, hard-reload to escape.
   assert.doesNotMatch(code, /window\.location|window\.open/, "must not navigate the app frame");
-  // …and it must not CLAIM the docs opened. Opening happens in a desktop bridge or
-  // a popup and neither reports back, so a popup blocker or a refusing bridge is
-  // invisible from here — "Opening the docs…" would assert a state never observed.
-  // The note names the URL, which is both true and the remedy.
-  assert.match(code, /DOCS_URL\} — opening in a new tab; if nothing opened/, "states the URL as the fallback");
-  assert.doesNotMatch(code, /appendSystem\(`Opening the docs/, "must not report an outcome it cannot see");
+  // …and it must claim NOTHING about what happened. Neither destination reports
+  // back — the desktop bridge hands off to the system browser, the web build opens
+  // a popup — so an assertion that the docs "opened", or that they opened "in a new
+  // tab", is a state never observed (and the tab wording is simply wrong on
+  // desktop). What survives is the URL plus a conditional remedy.
+  assert.match(code, /Docs: \$\{DOCS_URL\} — if nothing opened, copy that address\./);
+  assert.doesNotMatch(code, /appendSystem\(`Opening\b/, "must not report an outcome it cannot see");
+  assert.doesNotMatch(code, /appendSystem\([^)]*new tab/, "must not name a mechanism it does not control");
 });
 
 test("#111 /help says its list is only panel shortcuts, and names where the rest is", () => {

--- a/browser_tests/unit/docs-discoverability.test.mjs
+++ b/browser_tests/unit/docs-discoverability.test.mjs
@@ -64,6 +64,12 @@ test("#111 /docs is a LOCAL command — it opens externally, never in-frame", ()
   // window.location/window.open would navigate the ComfyUI app itself in the
   // desktop build — no back button, hard-reload to escape.
   assert.doesNotMatch(code, /window\.location|window\.open/, "must not navigate the app frame");
+  // …and it must not CLAIM the docs opened. Opening happens in a desktop bridge or
+  // a popup and neither reports back, so a popup blocker or a refusing bridge is
+  // invisible from here — "Opening the docs…" would assert a state never observed.
+  // The note names the URL, which is both true and the remedy.
+  assert.match(code, /DOCS_URL\} — opening in a new tab; if nothing opened/, "states the URL as the fallback");
+  assert.doesNotMatch(code, /appendSystem\(`Opening the docs/, "must not report an outcome it cannot see");
 });
 
 test("#111 /help says its list is only panel shortcuts, and names where the rest is", () => {

--- a/browser_tests/unit/docs-discoverability.test.mjs
+++ b/browser_tests/unit/docs-discoverability.test.mjs
@@ -54,6 +54,22 @@ test("#111 Settings → About has a docs row that opens the docs site", () => {
   // Opening in-frame hijacks the whole window in the ComfyUI desktop app.
   assert.match(row, /a\.target = "_blank"/);
   assert.match(row, /a\.rel = "noopener noreferrer"/);
+
+  // THE VISIBLE LABEL. Everything above this verifies the link exists and where it
+  // points — none of it notices if the control renders BLANK. Deleting the
+  // textContent line left every other assertion in this file green while shipping an
+  // unlabeled link, which is functionally the same absence this whole change set out
+  // to remove: a signpost nobody can read is not a signpost.
+  const label = row.match(/a\.textContent = "([^"]*)"/);
+  assert.ok(label, "the docs link must set a visible label");
+  const text = label[1].trim();
+  assert.notEqual(text, "", "an empty label renders a blank control");
+  // Words, not just an emoji: a bare 📖 is unreadable to a screen reader and
+  // ambiguous to everyone else.
+  assert.match(text, /[A-Za-z]{2,}/, `the label needs words, not only an icon (got ${JSON.stringify(text)})`);
+  // And it must name what it points at — "Click here" would pass every check above
+  // while telling a lost user nothing, which is the exact failure mode of #111.
+  assert.match(text, /docs|documentation/i, `the label must say it leads to the docs (got ${JSON.stringify(text)})`);
   // It must sort ABOVE the Discord row: asking a human was previously the only exit.
   const docsOrder = Number(row.match(/sortOrder: ([\d.]+)/)[1]);
   const discord = SRC.slice(SRC.indexOf('id: "comfyui-mcp.joinDiscord"'), SRC.indexOf('id: "comfyui-mcp.joinDiscord"') + 400);

--- a/browser_tests/unit/open-external-url.test.mjs
+++ b/browser_tests/unit/open-external-url.test.mjs
@@ -1,0 +1,149 @@
+// openExternalUrl is the panel's ONLY sanctioned way to leave the frame: in the
+// ComfyUI desktop (Electron) build a plain in-frame navigation hijacks the whole
+// window — no back button, hard-reload to escape.
+//
+// It prefers a desktop "open externally" bridge and documents a fallback to a new
+// browser tab. But that bridge is ASYNC (Electron's shell.openExternal returns a
+// Promise), and the function's try/catch only ever covered a SYNCHRONOUS throw. A
+// rejected promise escaped it completely: nothing opened, the documented fallback
+// never ran, and the failure surfaced only as an unhandled rejection in the console
+// — while the caller had already told the user it was opening something. A guard
+// that covers one of the two failure shapes is not a guard.
+//
+// These are BEHAVIOURAL tests. openExternalUrl is a self-contained module-level
+// function in a file that cannot be imported (it boots the whole panel against
+// ComfyUI globals), so it is extracted from the source and evaluated against a fake
+// `window`. Deleting the fix makes them fail; they are not string matching.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(join(HERE, "../../web/js/comfyui-mcp-panel.js"), "utf8");
+
+/** Extract `function openExternalUrl(...) { … }` by brace-matching from the source. */
+function loadOpenExternalUrl() {
+  const start = SRC.indexOf("function openExternalUrl(href) {");
+  assert.notEqual(start, -1, "openExternalUrl must exist");
+  let depth = 0;
+  let end = -1;
+  for (let i = SRC.indexOf("{", start); i < SRC.length; i++) {
+    if (SRC[i] === "{") depth++;
+    else if (SRC[i] === "}" && --depth === 0) {
+      end = i + 1;
+      break;
+    }
+  }
+  assert.notEqual(end, -1, "openExternalUrl must be brace-balanced");
+  // `window` is a parameter, so it shadows any global inside the extracted body.
+  return new Function("window", `${SRC.slice(start, end)}; return openExternalUrl;`);
+}
+
+/** A fake window whose bridge opener behaves as scripted. */
+function fakeWindow(openExternal) {
+  const opened = [];
+  return {
+    win: {
+      electronAPI: openExternal ? { openExternal } : undefined,
+      open: (href, target, features) => {
+        opened.push({ href, target, features });
+        return null;
+      },
+    },
+    opened,
+  };
+}
+
+const make = loadOpenExternalUrl();
+
+test("no bridge present → opens a new tab with noopener", () => {
+  const { win, opened } = fakeWindow(null);
+  make(win)("https://example.test/docs");
+  assert.deepEqual(opened, [
+    { href: "https://example.test/docs", target: "_blank", features: "noopener,noreferrer" },
+  ]);
+});
+
+test("a bridge that RESOLVES opens once — no duplicate tab", async () => {
+  const calls = [];
+  const { win, opened } = fakeWindow(async (href) => {
+    calls.push(href);
+  });
+  make(win)("https://example.test/docs");
+  await new Promise((r) => setTimeout(r, 0));
+  assert.deepEqual(calls, ["https://example.test/docs"]);
+  assert.equal(opened.length, 0, "the bridge handled it; a second tab would be a duplicate");
+});
+
+test("a bridge that REJECTS falls back to a new tab instead of silently doing nothing", async () => {
+  const { win, opened } = fakeWindow(() => Promise.reject(new Error("bridge refused")));
+  make(win)("https://example.test/docs");
+  await new Promise((r) => setTimeout(r, 0));
+  // Before the fix this array stayed EMPTY: the rejection escaped the try/catch,
+  // the documented "else a new browser tab" never happened, and the user was left
+  // with a message saying something had opened.
+  assert.deepEqual(opened, [
+    { href: "https://example.test/docs", target: "_blank", features: "noopener,noreferrer" },
+  ]);
+});
+
+test("a bridge rejection never escapes as an unhandled rejection", async () => {
+  const unhandled = [];
+  const onUnhandled = (err) => unhandled.push(err);
+  process.on("unhandledRejection", onUnhandled);
+  try {
+    const { win } = fakeWindow(() => Promise.reject(new Error("bridge refused")));
+    make(win)("https://example.test/docs");
+    // Two macrotask turns: Node reports an unhandled rejection only after the
+    // microtask queue drains with no handler attached.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+  } finally {
+    process.off("unhandledRejection", onUnhandled);
+  }
+  assert.deepEqual(unhandled, [], "the rejection must be handled where it happens");
+});
+
+test("a bridge that throws SYNCHRONOUSLY still falls back (the original guard, unbroken)", () => {
+  const { win, opened } = fakeWindow(() => {
+    throw new Error("sync boom");
+  });
+  make(win)("https://example.test/docs");
+  assert.deepEqual(opened, [
+    { href: "https://example.test/docs", target: "_blank", features: "noopener,noreferrer" },
+  ]);
+});
+
+test("the fallback's own failure cannot throw out of openExternalUrl", async () => {
+  // Rule: every guard is itself an operation that can fail. If window.open is
+  // blocked and throws, the recovery path must not become a NEW unhandled
+  // rejection on top of the one it was recovering from.
+  const unhandled = [];
+  const onUnhandled = (err) => unhandled.push(err);
+  process.on("unhandledRejection", onUnhandled);
+  try {
+    const win = {
+      electronAPI: { openExternal: () => Promise.reject(new Error("bridge refused")) },
+      open: () => {
+        throw new Error("popup blocked");
+      },
+    };
+    assert.doesNotThrow(() => make(win)("https://example.test/docs"));
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+  } finally {
+    process.off("unhandledRejection", onUnhandled);
+  }
+  assert.deepEqual(unhandled, []);
+});
+
+test("an empty href is a no-op — no tab, no bridge call", () => {
+  const calls = [];
+  const { win, opened } = fakeWindow((href) => calls.push(href));
+  make(win)("");
+  make(win)(undefined);
+  assert.deepEqual(calls, []);
+  assert.deepEqual(opened, []);
+});

--- a/browser_tests/unit/open-external-url.test.mjs
+++ b/browser_tests/unit/open-external-url.test.mjs
@@ -139,6 +139,40 @@ test("the fallback's own failure cannot throw out of openExternalUrl", async () 
   assert.deepEqual(unhandled, []);
 });
 
+// The three ways out of this function all end in window.open, and only ONE of them
+// was guarded. Callers use openExternalUrl fire-and-forget, usually after something
+// has already suppressed the anchor's native navigation, so an exception escaping
+// here aborts whatever the caller meant to do next instead of falling back to
+// anything. /docs hit exactly that: a throwing window.open killed the statement that
+// puts the URL in the transcript, leaving "/docs failed: …" and no address to copy.
+test("NO-BRIDGE path: a throwing window.open does not escape", () => {
+  const win = {
+    electronAPI: undefined,
+    open: () => {
+      throw new Error("popup blocked");
+    },
+  };
+  assert.doesNotThrow(() => make(win)("https://example.test/docs"));
+});
+
+test("SYNC-THROW path: a throwing window.open does not escape either", () => {
+  const win = {
+    electronAPI: {
+      get openExternal() {
+        throw new Error("bridge getter exploded");
+      },
+    },
+    open: () => {
+      throw new Error("popup blocked");
+    },
+  };
+  assert.doesNotThrow(() => make(win)("https://example.test/docs"));
+});
+
+test("a window with no open() at all is survivable", () => {
+  assert.doesNotThrow(() => make({})("https://example.test/docs"));
+});
+
 test("an empty href is a no-op — no tab, no bridge call", () => {
   const calls = [];
   const { win, opened } = fakeWindow((href) => calls.push(href));

--- a/browser_tests/unit/secret-card-sizing.test.mjs
+++ b/browser_tests/unit/secret-card-sizing.test.mjs
@@ -1,0 +1,117 @@
+// #8 — the secret card's token field must not be the thing that gets squeezed.
+//
+// paintSecret asks for the one input in the panel whose value the user cannot see
+// while typing it. A masked field crushed to a stub is not a cosmetic complaint: it
+// is where you paste a 70-character API key and cannot tell how much of it arrived.
+//
+// The old row was `display:flex` with no wrap, an input at `flex:1;min-width:7rem`,
+// and two buttons whose min-content IS their label (so they cannot shrink at all).
+// Every pixel of loss therefore landed on the input until it hit its floor, and past
+// that point the row simply overflowed the card. MEASURED on the shipped style
+// declarations, rendered in headless Chromium inside the real `.cmcp-log`/`.cmcp-card`
+// rules: Skip spills past the card's right edge below ~296px of log width, and the
+// log grows a horizontal scrollbar below ~264px — the exact failure the log's own
+// `overflow-wrap:anywhere` comment elsewhere in this file exists to prevent.
+//
+// These are STRUCTURAL assertions over the source because the invariant is about what
+// the layout is PERMITTED to do, not about one sampled width. Each declaration pinned
+// below was verified load-bearing by mutating it alone and re-measuring; the failure
+// each one prevents is named in its test, so a future edit that trades one for another
+// has to argue with a specific number rather than with "looks fine on my monitor".
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+/** The paintSecret body, from its signature to the next top-level function. */
+function paintSecretBody() {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const start = src.indexOf("function paintSecret(msg) {");
+  assert.notEqual(start, -1, "paintSecret must exist");
+  const end = src.indexOf("\n  function ", start + 1);
+  assert.notEqual(end, -1, "paintSecret must be followed by another function");
+  return src.slice(start, end);
+}
+
+/**
+ * The concatenated string literals assigned to `<name>.style.cssText` inside
+ * paintSecret — i.e. the declarations that actually reach the element, joined across
+ * the `+` continuations, so a reflow of the source formatting cannot break these
+ * assertions. Whitespace runs are collapsed but NOT removed: `flex:1 1 10rem` and
+ * `flex:1110rem` must not become the same string.
+ */
+function inlineStyle(body, name) {
+  const anchor = `${name}.style.cssText =`;
+  const at = body.indexOf(anchor);
+  assert.notEqual(at, -1, `${name}.style.cssText must be assigned in paintSecret`);
+  const tail = body.slice(at + anchor.length);
+  let out = "";
+  for (let i = 0; i < tail.length; i++) {
+    if (tail[i] === '"') {
+      let j = i + 1;
+      while (j < tail.length && tail[j] !== '"') out += tail[j++];
+      i = j;
+      continue;
+    }
+    if (tail[i] === ";") break; // end of the assignment statement
+  }
+  return out.replace(/\s+/g, " ").trim();
+}
+
+test("#8 the secret row WRAPS — without it the field shrinks to 18–67px", () => {
+  const row = inlineStyle(paintSecretBody(), "row");
+  assert.match(row, /display:flex/);
+  // Mutant: drop flex-wrap and the measured input width at 320/280/240/190px of log
+  // width falls to 141/104/67/21px. Wrapping is the only thing standing between a
+  // narrow sidebar and an unusable token field, because nothing else on the row can
+  // give up space.
+  assert.match(row, /flex-wrap:wrap/, "the row must wrap rather than crush the input");
+});
+
+test("#8 the field's flex-basis is NON-ZERO — that basis is what picks the wrap point", () => {
+  const input = inlineStyle(paintSecretBody(), "input");
+  // `flex:1` means basis 0: the item's hypothetical size is zero, so a wrapping row
+  // never has a reason to break and the input shrinks exactly as it did before the
+  // fix (measured: identical 141/104/67/21px). The basis is the declaration that says
+  // "below this width I would rather have my own line", so it must be a real length.
+  const shorthand = input.match(/flex:\s*([^;]+);/);
+  assert.ok(shorthand, `input must set the flex shorthand, got: ${input}`);
+  const basis = shorthand[1].trim().split(/\s+/)[2];
+  assert.ok(
+    basis && /^[\d.]+rem$/.test(basis) && parseFloat(basis) > 0,
+    `flex basis must be a non-zero length (got \`flex:${shorthand[1].trim()}\`) — ` +
+      "a basis of 0, or an omitted basis, means the row never has a reason to wrap",
+  );
+});
+
+test("#8 the field declares min-width:0 — `min-width:auto` h-scrolls the whole log", () => {
+  const input = inlineStyle(paintSecretBody(), "input");
+  // A flex item's default `min-width:auto` resolves to its intrinsic size, and for an
+  // <input> that is its default `size` attribute — ~174px. Measured: with min-width
+  // omitted the log grows a horizontal scrollbar below ~190px of width. The old
+  // `min-width:7rem` was the same mistake with a smaller number: a floor the row then
+  // overflows the card to honor.
+  assert.match(input, /min-width:0/, "the field must be allowed to shrink once wrapped");
+  assert.doesNotMatch(input, /min-width:[1-9]/, "a non-zero floor is what overflowed the card");
+});
+
+test("#8 Save/Skip are flex:none and travel together, so no label ever clips", () => {
+  const body = paintSecretBody();
+  // Mutant: give the buttons `flex:1 1 0;min-width:0` and the labels clip ("Sav") AND
+  // the group spills past the card edge at 320/280px. They behave this way today only
+  // by accident of min-content; declaring it is what keeps a later "just add
+  // min-width:0 everywhere" edit from silently truncating the confirm button.
+  for (const name of ["submit", "skip", "btns"]) {
+    assert.match(inlineStyle(body, name), /flex:none/, `${name} must be flex:none`);
+  }
+  // Both buttons hang off the shared wrapper, not off the row: on the row directly,
+  // only Skip wrapped and Save stayed marooned beside a half-width field.
+  assert.match(body, /btns\.appendChild\(submit\)/, "Save belongs to the button group");
+  assert.match(body, /btns\.appendChild\(skip\)/, "Skip belongs to the button group");
+  assert.doesNotMatch(body, /row\.appendChild\(submit\)/, "Save must not sit on the row itself");
+  assert.doesNotMatch(body, /row\.appendChild\(skip\)/, "Skip must not sit on the row itself");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -725,6 +725,13 @@ function setupListeners() {
 // Community + support. The Discord is the one-tap "I'm stuck" channel surfaced
 // in Settings → About (Join + Need help buttons) and linked from the README.
 const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
+// The docs site — every published guide lives here, and until now NOTHING in this
+// panel linked to it. That is a measured cost, not a hypothetical one: community
+// users have asked for features that already shipped and were documented (#111),
+// because a panel user's entire discovery path was an empty-state sentence, four
+// prompt chips, a nine-item slash list and a Discord invite. A link is not a
+// capability index and does not pretend to be one — it is the missing signpost.
+const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
@@ -2778,6 +2785,29 @@ function panelSettingsList() {
         a.target = "_blank";
         a.rel = "noopener noreferrer";
         a.textContent = "⭐ Star comfyui-mcp-panel on GitHub";
+        a.style.cssText =
+          "display:inline-flex;align-items:center;gap:0.4rem;padding:0.3rem 0.7rem;border-radius:6px;" +
+          "border:1px solid var(--p-surface-500,#555);background:var(--p-surface-800,#27272a);" +
+          "color:var(--p-text-color,#e4e4e7);text-decoration:none;font-size:0.8rem;white-space:nowrap;";
+        return a;
+      },
+    },
+    {
+      // A link row — "📖 Read the docs". Sits ABOVE Discord deliberately: asking a
+      // human was previously the ONLY exit from the panel, so the community carried
+      // questions the docs already answered (#111).
+      id: "comfyui-mcp.readDocs",
+      name: "Documentation",
+      category: cat("About", "Documentation"),
+      sortOrder: 199.5,
+      tooltip:
+        "Guides for the panel, tools, local LLMs and troubleshooting. Opens comfyui-mcp.artokun.io/docs in a new tab.",
+      type: () => {
+        const a = document.createElement("a");
+        a.href = DOCS_URL;
+        a.target = "_blank";
+        a.rel = "noopener noreferrer";
+        a.textContent = "📖 Read the docs";
         a.style.cssText =
           "display:inline-flex;align-items:center;gap:0.4rem;padding:0.3rem 0.7rem;border-radius:6px;" +
           "border:1px solid var(--p-surface-500,#555);background:var(--p-surface-800,#27272a);" +
@@ -22692,10 +22722,34 @@ function buildPanel() {
       run: () => runLocalCommand("graph_get_errors", {}),
     },
     {
+      cmd: "/docs",
+      icon: "pi-book",
+      hint: "open the docs — guides for the panel, tools, local LLMs and troubleshooting",
+      // openExternalUrl, not window.location: in the ComfyUI desktop app an in-frame
+      // navigation hijacks the whole window with no way back.
+      run: () => {
+        openExternalUrl(DOCS_URL);
+        appendSystem(`Opening the docs — ${DOCS_URL}`);
+      },
+    },
+    {
       cmd: "/help",
       icon: "pi-question-circle",
       hint: "list commands",
-      run: () => appendSystem(SLASH_COMMANDS.map((c) => `${c.cmd} — ${c.hint}`).join(" · ")),
+      // These are PANEL SHORTCUTS, not a list of what the agent can do — so /help
+      // says where the rest lives rather than leaving the reader to conclude this is
+      // everything (#111). Joined with the same " · " as the rest of the line, NOT
+      // newlines: .cmcp-sys has no white-space:pre-wrap, so a "\n" here would
+      // silently collapse to a space. Deliberately no tool names or counts either —
+      // the tool surface is being consolidated (mcp RFC #726) and a number baked
+      // into this string would start rotting the day it was written.
+      run: () =>
+        appendSystem(
+          [
+            ...SLASH_COMMANDS.map((c) => `${c.cmd} — ${c.hint}`),
+            `these are panel shortcuts; for what the agent itself can do, see the docs: ${DOCS_URL}`,
+          ].join(" · "),
+        ),
     },
   ];
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2802,11 +2802,13 @@ function panelSettingsList() {
       name: "Documentation",
       category: cat("About", "Documentation"),
       sortOrder: 199.5,
-      // Names the DESTINATION, not the mechanism. "Opens in a new tab" would be a
-      // claim about something nothing here observes: the panel-wide click delegate
-      // routes this through openExternalUrl, whose desktop path hands off to the
-      // system browser (not a tab) and reports nothing back either way. A link
-      // tooltip's job is to say where the link goes.
+      // Names the DESTINATION, not the mechanism. This row renders into ComfyUI's
+      // own Settings dialog, which is OUTSIDE the sidebar root that wireExternalLinks
+      // delegates on — so unlike /docs there is no openExternalUrl in the path at
+      // all, just the anchor's native target=_blank. Where that lands (a tab, the
+      // desktop build's system browser, or nowhere if a popup blocker eats it) is
+      // neither chosen nor observed here. A link tooltip's job is to say where the
+      // link goes.
       tooltip:
         "Guides for the panel, tools, local LLMs and troubleshooting — comfyui-mcp.artokun.io/docs",
       type: () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15099,7 +15099,16 @@ DOMPurify.addHook("afterSanitizeAttributes", (node) => {
 });
 
 /** Open a URL outside the panel frame — never navigate the app/webview itself.
- *  Prefers a desktop external-open bridge if present, else a new browser tab. */
+ *  Prefers a desktop external-open bridge if present, else a new browser tab.
+ *
+ *  BEST-EFFORT AND NEVER THROWS. Callers use this fire-and-forget, often after
+ *  something has already suppressed the anchor's native navigation (the delegated
+ *  link handler) — so an exception escaping here does not fall back to anything, it
+ *  just aborts whatever the caller was doing next. /docs hit exactly that: a
+ *  throwing window.open killed the statement that puts the URL in the transcript,
+ *  and the user was left with "/docs failed: …" and no address to copy. Every exit
+ *  is guarded; a caller that needs the user to have the URL must print it
+ *  regardless, not conditionally on this returning. */
 function openExternalUrl(href) {
   if (!href) return;
   try {
@@ -15132,7 +15141,12 @@ function openExternalUrl(href) {
   } catch {
     // fall through to window.open
   }
-  window.open(href, "_blank", "noopener,noreferrer");
+  try {
+    window.open(href, "_blank", "noopener,noreferrer");
+  } catch {
+    // Popup blocked / window.open unavailable. There is nothing further to try,
+    // and throwing would only take the caller down with it (see the header note).
+  }
 }
 
 /** Open a chat media URL in a new tab. Bridge-delivered images on remote pods
@@ -18751,8 +18765,13 @@ function buildPanel() {
 
     const submit = document.createElement("button");
     submit.type = "button";
-    // flex:none is DECLARED, not inherited from min-content: a later `min-width:0`
-    // here (the usual flexbox reflex) would let the label clip to "Sav".
+    // flex:none is DECLARED rather than left to min-content. On its own that is
+    // belt-and-braces — with flex:none in place, adding `min-width:0` here changes
+    // nothing, because a non-shrinking item never consults its minimum. What it
+    // guards against is the PAIR: the measured mutant made the buttons shrinkable
+    // AND gave them min-width:0, and only then did the label clip to "Sav" and the
+    // group spill the card at 320/280px. Stating the intent stops a future
+    // "everything gets min-width:0" sweep from supplying the missing half.
     submit.style.cssText =
       "flex:none;padding:0.35rem 0.7rem;border-radius:6px;border:none;cursor:pointer;font-size:0.8rem;" +
       "background:var(--p-primary-color,#3a7bd5);color:#fff;";
@@ -22759,9 +22778,15 @@ function buildPanel() {
       // never observed, and the second is simply wrong on desktop. What is left is
       // the URL (true unconditionally) and a conditional remedy that costs nothing
       // if it did open and rescues the user if it did not.
+      //
+      // The note goes in FIRST. It is the remedy for the open having failed, so
+      // sequencing it after the attempt made it conditional on that attempt not
+      // throwing — precisely backwards. openExternalUrl is guarded and should not
+      // throw, but a remedy that depends on its own failure path staying healthy is
+      // not a remedy.
       run: () => {
-        openExternalUrl(DOCS_URL);
         appendSystem(`Docs: ${DOCS_URL} — if nothing opened, copy that address.`);
+        openExternalUrl(DOCS_URL);
       },
     },
     {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -18631,15 +18631,33 @@ function buildPanel() {
     let resolveFn;
     const promise = new Promise((res) => { resolveFn = res; });
 
+    // #8 SIZING. The field is the whole point of this card, and it used to be the
+    // first thing squeezed: on one unwrapped line the two buttons cannot shrink
+    // (their min-content IS the word), so every pixel of loss landed on the input
+    // until it hit a hard `min-width:7rem` — after which the row simply overflowed
+    // the card and forced a horizontal scrollbar across the entire log. Measured on
+    // the shipped declarations: Skip spills past the card edge below ~296px of log
+    // width, and the log h-scrolls below ~264px. A floor the layout then breaks in
+    // order to honor is not a floor.
+    //
+    // So the row WRAPS instead, and each declaration below carries a failure of its
+    // own (each verified by mutating it alone and re-measuring):
+    //   flex-wrap:wrap  — without it nothing wraps and the input shrinks to 18–67px.
+    //   flex:1 1 10rem  — a NON-ZERO basis is what decides the wrap point; `flex:1`
+    //                     (basis 0) also never wraps and shrinks to the same 18–67px.
+    //   min-width:0     — an input's default `min-width:auto` resolves to its
+    //                     intrinsic ~174px, which h-scrolls the log below ~190px.
+    //   flex:none       — see the buttons; declared, not left to min-content.
+    // Wrapping gives the field a whole card-width line rather than a 7rem stub.
     const row = document.createElement("div");
-    row.style.cssText = "display:flex;gap:0.3rem;";
+    row.style.cssText = "display:flex;flex-wrap:wrap;gap:0.3rem;";
     const input = document.createElement("input");
     input.type = "password";
     input.autocomplete = "off";
     input.spellcheck = false;
     input.placeholder = "Paste token…";
     input.style.cssText =
-      "flex:1;min-width:7rem;padding:0.35rem 0.5rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
+      "flex:1 1 10rem;min-width:0;padding:0.35rem 0.5rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
       "background:var(--p-surface-900,#1e1e1e);color:inherit;font-size:0.8rem;";
 
     // Show/record only a masked preview (first 4 … last 4) so the user can
@@ -18669,23 +18687,33 @@ function buildPanel() {
     });
     row.appendChild(input);
 
+    // Save and Skip travel together as ONE flex item, so the row has exactly two
+    // layouts — [field | buttons] or field-on-top / buttons-below — instead of a
+    // third, ragged one where only Skip wrapped and Save stayed marooned beside a
+    // half-width field.
+    const btns = document.createElement("div");
+    btns.style.cssText = "display:flex;gap:0.3rem;flex:none;";
+
     const submit = document.createElement("button");
     submit.type = "button";
+    // flex:none is DECLARED, not inherited from min-content: a later `min-width:0`
+    // here (the usual flexbox reflex) would let the label clip to "Sav".
     submit.style.cssText =
-      "padding:0.35rem 0.7rem;border-radius:6px;border:none;cursor:pointer;font-size:0.8rem;" +
+      "flex:none;padding:0.35rem 0.7rem;border-radius:6px;border:none;cursor:pointer;font-size:0.8rem;" +
       "background:var(--p-primary-color,#3a7bd5);color:#fff;";
     submit.textContent = "Save";
     submit.addEventListener("click", () => finish(input.value.trim()));
-    row.appendChild(submit);
+    btns.appendChild(submit);
 
     const skip = document.createElement("button");
     skip.type = "button";
     skip.style.cssText =
-      "padding:0.35rem 0.6rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
+      "flex:none;padding:0.35rem 0.6rem;border-radius:6px;border:1px solid var(--p-surface-500,#555);" +
       "background:transparent;color:inherit;cursor:pointer;font-size:0.8rem;";
     skip.textContent = "Skip";
     skip.addEventListener("click", () => finish(""));
-    row.appendChild(skip);
+    btns.appendChild(skip);
+    row.appendChild(btns);
 
     card.appendChild(row);
     log.appendChild(card);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2802,8 +2802,13 @@ function panelSettingsList() {
       name: "Documentation",
       category: cat("About", "Documentation"),
       sortOrder: 199.5,
+      // Names the DESTINATION, not the mechanism. "Opens in a new tab" would be a
+      // claim about something nothing here observes: the panel-wide click delegate
+      // routes this through openExternalUrl, whose desktop path hands off to the
+      // system browser (not a tab) and reports nothing back either way. A link
+      // tooltip's job is to say where the link goes.
       tooltip:
-        "Guides for the panel, tools, local LLMs and troubleshooting. Opens comfyui-mcp.artokun.io/docs in a new tab.",
+        "Guides for the panel, tools, local LLMs and troubleshooting — comfyui-mcp.artokun.io/docs",
       type: () => {
         const a = document.createElement("a");
         a.href = DOCS_URL;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -725,8 +725,10 @@ function setupListeners() {
 // Community + support. The Discord is the one-tap "I'm stuck" channel surfaced
 // in Settings → About (Join + Need help buttons) and linked from the README.
 const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
-// The docs site — every published guide lives here, and until now NOTHING in this
-// panel linked to it. That is a measured cost, not a hypothetical one: community
+// The docs site. Not the only place things are written down — the README and the
+// `setup` command's own output cover some of the same ground — but it is the one a
+// panel user can actually reach, and until now NOTHING in this panel linked to it.
+// That is a measured cost, not a hypothetical one: community
 // users have asked for features that already shipped and were documented (#111),
 // because a panel user's entire discovery path was an empty-state sentence, four
 // prompt chips, a nine-item slash list and a Discord invite. A link is not a
@@ -15101,7 +15103,25 @@ function openExternalUrl(href) {
       window.comfyAPI?.electron?.openExternal ||
       window.api?.openExternal;
     if (typeof ext === "function") {
-      ext(href);
+      // The bridge opener is usually ASYNC (Electron's shell.openExternal returns
+      // a Promise). The try/catch above only guards a SYNCHRONOUS throw, so a
+      // rejected promise escaped it entirely: nothing opened, nothing fell back,
+      // and the rejection surfaced only as an unhandled-rejection in the console.
+      // A guard that covers one of the two failure shapes is not a guard.
+      // Promise.resolve() normalizes both a promise and a plain return value, and
+      // is itself inside the try — so a non-thenable that throws on access still
+      // reaches the window.open fallback below.
+      const opened = Promise.resolve(ext(href));
+      opened.catch(() => {
+        // Bridge refused. Honor the documented contract — "else a new browser
+        // tab" — rather than leaving the caller with nothing.
+        try {
+          window.open(href, "_blank", "noopener,noreferrer");
+        } catch {
+          // Nothing left to try; the caller's message names the URL so the user
+          // can still open it by hand.
+        }
+      });
       return;
     }
   } catch {
@@ -22727,9 +22747,16 @@ function buildPanel() {
       hint: "open the docs — guides for the panel, tools, local LLMs and troubleshooting",
       // openExternalUrl, not window.location: in the ComfyUI desktop app an in-frame
       // navigation hijacks the whole window with no way back.
+      //
+      // The note does NOT say the docs opened. Opening happens in a desktop bridge
+      // or a popup, and neither reports back — a popup blocker or a refusing bridge
+      // is invisible from here, so "Opening the docs…" would be a state we never
+      // observed. It states the URL instead, which is both true and the remedy: if
+      // nothing appeared, the address the user needs is right there in the
+      // transcript to copy.
       run: () => {
         openExternalUrl(DOCS_URL);
-        appendSystem(`Opening the docs — ${DOCS_URL}`);
+        appendSystem(`Docs: ${DOCS_URL} — opening in a new tab; if nothing opened, copy that address.`);
       },
     },
     {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -22748,15 +22748,15 @@ function buildPanel() {
       // openExternalUrl, not window.location: in the ComfyUI desktop app an in-frame
       // navigation hijacks the whole window with no way back.
       //
-      // The note does NOT say the docs opened. Opening happens in a desktop bridge
-      // or a popup, and neither reports back — a popup blocker or a refusing bridge
-      // is invisible from here, so "Opening the docs…" would be a state we never
-      // observed. It states the URL instead, which is both true and the remedy: if
-      // nothing appeared, the address the user needs is right there in the
-      // transcript to copy.
+      // The note claims NOTHING about what happened. Neither destination reports
+      // back — the desktop bridge hands off to the system browser, the web build
+      // opens a popup — so "opening" and "in a new tab" would both be states we
+      // never observed, and the second is simply wrong on desktop. What is left is
+      // the URL (true unconditionally) and a conditional remedy that costs nothing
+      // if it did open and rescues the user if it did not.
       run: () => {
         openExternalUrl(DOCS_URL);
-        appendSystem(`Docs: ${DOCS_URL} — opening in a new tab; if nothing opened, copy that address.`);
+        appendSystem(`Docs: ${DOCS_URL} — if nothing opened, copy that address.`);
       },
     },
     {


### PR DESCRIPTION
These five are **feature requests, not defects**, and they differ in size by orders of
magnitude — #8 is polish, #428 is an application. So the primary deliverable here is
the triage, not the code. Two things shipped; three did not, on purpose.

## Triage

| Issue | Verdict | Detail |
|---|---|---|
| **#8** — secret-card min-size | **Shipped** (sizing half) | Reproduced and fixed with measurements. See below. |
| **#8** — `/compact` slash command | **Needs an orchestrator change first — not shipped** | The panel cannot observe whether compaction happened. Evidence below. |
| **#111** — community requests | **Mostly already exists; the discoverability gap is shipped** | Three of the asks already ship and are documented. What was missing was any way to find them *from the panel*. |
| **#350** — record a skill | **Needs a maintainer design decision. Not started.** | The issue itself says "product-direction call for @artokun to prioritize". |
| **#351** — cowork mode | **Not applicable — already closed** | Closed 2026, fixed in #353. Nothing to do. |
| **#428** — video-gen app | **Needs a maintainer design decision. Not started.** | The issue itself says "needs @artokun's call on scope **before any design/build work starts**". |

A half-built cowork mode or video-gen app is worse than none: it creates a surface
users find, depend on, and file bugs against. #350 and #428 are untouched.

---

## Shipped 1 — #8, the secret card's token field

`paintSecret` renders the masked field you paste an API key into and cannot read back.
On one unwrapped flex line the two buttons cannot shrink — their min-content *is* their
label — so every pixel of loss landed on the input until it hit a hard `min-width:7rem`,
after which the row simply overflowed the card.

Measured in headless Chromium, driving the **shipped style declarations extracted from
the source file** and rendered inside the real `.cmcp-log` / `.cmcp-card` rules:

| log width | 500 | 420 | 380 | 340 | 320 | 300 | 280 | 260 | 240 | 220 |
|---|---|---|---|---|---|---|---|---|---|---|
| **before** — input px | 307 | 233 | 196 | 160 | 141 | **130** | **130** | **130** | **130** | **130** |
| **before** — Skip spills card | | | | | | | ✗ 16px | ✗ 34px | ✗ 53px | ✗ 71px |
| **before** — log h-scrolls | | | | | | | | ✗ | ✗ | ✗ |
| **after** — input px | 307 | 233 | 196 | 267 | 248 | 230 | 212 | 193 | 175 | 156 |
| **after** — any breakage | | | | | | | | | | |

Above ~350px the layout is **byte-identical to before**, so the common case does not
move. Below that the row wraps and the field gets a whole card-width line. Save and Skip
travel as one flex item, giving exactly two layouts instead of a third ragged one where
only Skip wrapped.

A floor the layout then breaks in order to honor is not a floor.

Each declaration was verified load-bearing by mutating it **alone** and re-measuring:

| declaration | what happens without it |
|---|---|
| `flex-wrap:wrap` | nothing wraps; the field shrinks to 18–67px |
| `flex:1 1 10rem` | a zero basis (`flex:1`) also never wraps — same 18–67px |
| `min-width:0` | an input's default `min-width:auto` is its intrinsic ~174px, which h-scrolls the log below ~190px |
| `flex:none` | labels clip to "Sav" and the group spills the card at 320/280px |

Layout only — no color tokens touched, so light and dark are unaffected.

## Shipped 2 — #111, the panel points at its own docs

The striking thing about #111 is how much of it **already exists**. Verified in the
source, not from memory:

- **`npm run arena`** — the 10-scenario verified eval ladder, live at `/docs/arena`.
  The README mentions it exactly once, mid-sentence, in paragraph 3; the string
  `npm run arena` appears in the README **zero** times.
- **Compact tool mode** — the default since comfyui-mcp #667, documented across four
  docs pages, the README, and the `setup` command's own stdout.
- **Node-pack ↔ npx version skew** (the 2026-08-01 comment) — a whole reconcile system
  already ships: a `panel-node-pack-sync` skill, `install_panel(action='sync')`,
  auto-sync on hello, and pin safety. It exceeds what was asked for.

Users asked anyway, and the panel is why. A panel user's entire discovery path was an
empty-state sentence, four prompt chips, a nine-item slash list, and a Discord invite.
**Nothing in the panel linked to the docs site at all** — asking a human was the only
exit, so the community carried questions the docs already answered.

So: a "Read the docs" row in Settings → About (sorted above Discord, deliberately), a
local `/docs` command, and `/help` now saying that its list is panel *shortcuts* and
naming where the rest lives.

What this deliberately is **not**: a capability index, and it does not claim to be one.
It is a signpost. No tool names or counts appear in any new string — comfyui-mcp RFC
**#726** is consolidating the tool surface, and a number baked in here would be wrong on
the day that lands. It implements none of the requested features.

Both URLs were fetched and confirmed serving before linking; a signpost to a 404 is
worse than no signpost.

The remaining #111 items are out of this repo (items 1–4 are `comfyui-mcp-mobile`) or
explicitly parked pending a trust-model design (item 5) — see the issue.

---

## Not shipped — #8's `/compact` half, and why

There is a live regression report on #8: `/compact` is offered in the composer's
completion menu but submitting it only sends an ordinary chat message, with no
confirmation. What I found:

- the panel sends the text verbatim; nothing special-cases a leading `/`
- the Agent SDK's bundled CLI **does** intercept built-in slash commands arriving as
  ordinary streaming-input user messages (`processPromptSlashCommand`,
  `looksLikeCommand`, `<local-command-stdout>`, `shouldQuery:false`)
- there is **no** programmatic compaction API on the SDK `Query` object — every method
  was enumerated; none compact
- `/compact` reports itself via `SDKCompactBoundaryMessage`
  (`subtype:'compact_boundary'`), and the orchestrator's `route()` does **not** handle
  that subtype

So compaction plausibly *does* occur, but the panel cannot see it — which is
indistinguishable from "did nothing". **I have not confirmed either way, and this PR
claims neither.**

The confirmation signal has to be routed by the orchestrator, in a different repo.
Building a panel-side "compacted!" notice for a frame that is never sent would be
exactly the fake-surface failure. A panel-side *warning* would be no better: the panel
does not know the command failed, only that it cannot observe it — that would be an
unverified claim in the other direction.

**Actionable now:** `/compact` still reaches the SDK, so a user who wants to compact can
type it; they just get no receipt. #8 should stay open on that half.

## Related work — not collided with

- **#628** (`run-completion-frame.js`), **#649** (oversized-media preview, since merged),
  **#653** (`graph-binding.js`) — none of those files are touched here.
- **#841** (orchestrator) owns "users cannot tell whether a tool is absent, blocked, or
  merely undiscoverable". My #111 finding is a **product**-level instance of the same
  disease — features that ship, are documented, and are still unreachable from the
  product — reported here rather than solved separately.

## Verification

- Full `browser_tests` unit suite: **2149 pass, 0 fail** (against the rebased `main`).
- `tsc --noEmit`, the tool-vocabulary gate, `node --check`, and an ESM check (verified
  as `.mjs`, which is what actually catches a duplicate top-level declaration).
- **Mutation-verified**: 26 source mutants across the three new test files, every one
  caught by the intended test, source restored byte-identical each time.
- An independent gate then caught the one thing my own mutants had not: the docs link's
  **visible label** was untested. Deleting `a.textContent` left every assertion green
  while rendering an *unlabeled blank link* — functionally the same absence this change
  set out to remove. Checking properly, five label mutants survived: deleted, empty,
  whitespace-only, emoji-only (unreadable to a screen reader), and `"Click here"` (says
  nothing about docs). All five are now caught. Exactly the standing rule landing where
  it is meant to: *if deleting the code under test leaves the test green, the test is
  not about that code.*
- Committed blobs scanned for control bytes (all `\000-\037` except tab/CR/LF): zero.
- `pyproject.toml` and `PANEL_VERSION` untouched.
- Adversarial review gate: **PASS on round 6**. It caught five real defects across
  rounds 1–5, all of the same family — claiming an outcome nothing observed. Most
  notable: `openExternalUrl` had three exits and only one was guarded, so a throwing
  `window.open` aborted `/docs` *before* it printed the URL the user needed. That helper
  is now best-effort-never-throws, which every caller benefits from.

Closes #8 is **not** claimed — only the sizing half is done.

Refs #8, #111
