### PR TITLE
release: 0.11.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.39] - 2026-08-04
+
+### Fixed
+- **CRITICAL: mutations could reach the WRONG graph** — nodes deleted from another
+  workflow, and writes reported not-applied that were in fact applied (#621).
+  After a ComfyUI restart with no page reload, the panel could point the canvas at an
+  empty root while the user's unsaved graph was still on screen; every downstream guard
+  was then handed a self-consistent pair that no longer described the canvas the command
+  was issued for. The divergence is now detected and refused instead of silently
+  repointing, the dispatch fence no longer exempts mutations from the baseline read
+  guard, and the destructive revert path awaits its load, fences both the bridge and the
+  user, and reports a discriminated outcome rather than a null that meant two different
+  things. Fixes #545, #442, #308, #220; partially addresses #604, #603, #616, #374.
+- repair main — #614's title coercion broke #631's move-group harness (#643)
+- truncated results name their own remedy — and one that works from where the caller is (#614)
+- make panel_move_group a verified transaction that never reports a move it did not make (#408) (#631)
+- prevent restart resume from duplicating an active render (#585) (#597)
+- materialize V3 custom widgets before add (#593)
+- label cancelled reconnect runs truthfully (#582) (#595)
+- reply before expensive graph snapshot (#581) (#594)
+- separate stale red outlines from errors (#579) (#592)
+- report outer previous value for promoted widgets (#591)
+- the fixed-ness check must GATE the volatile exclusion (codex r2)
+- refuse the false-empty authoritative read (empty-binding-unproven)
+- narrow + surface the volatile-input exclusion (codex gate)
+- exclude linked value-control targets from the scoped-run drift hash
+
+
 ## [0.11.38] - 2026-08-03
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.38"
+version = "0.11.39"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -715,7 +715,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.38";
+const PANEL_VERSION = "0.11.39";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Ships the **CRITICAL wrong-graph fix (#621)** to users — that is the reason to take this release.

After a ComfyUI restart with no page reload, the panel could point the canvas at an empty root while the user's unsaved graph was still on screen. Every downstream guard was then handed a self-consistent `(app.graph, activeWorkflow)` pair that no longer described the canvas the command was issued for — so a mutation could land on **another workflow**, and a write that succeeded could be reported as not applied.

## Contents

| PR | |
|---|---|
| **#621** | CRITICAL: mutations could reach the wrong graph |
| #631 | `panel_move_group` is a verified transaction that never reports a move it did not make |
| #614 | truncated results name their own remedy — one actionable from where the caller is |
| #643 | repair main — #614's title coercion broke #631's move-group harness |

plus #597, #593, #595, #594, #592, #591 and the codex-round follow-ups.

## One thing to know about the changelog

**The generator missed #621.** Its squash title begins `CRITICAL:` rather than a conventional `fix(` prefix, and `gen-changelog` only matches those — so the single most important entry in this release was absent from the generated list. Added by hand and put first.

This is a recurring trap in these repos (non-conventional squash titles are invisible to the generator). Worth either widening the generator or requiring conventional prefixes on squash titles; silently dropping the release's headline fix is the failure mode.

## Verification

- 1978/1978 unit tests pass; `tsc --noEmit` clean
- Zero control bytes across all changed files; LF
- `PANEL_VERSION` matches `pyproject.toml` — the publish gate enforces this, and a mismatch would ship a stale panel version

Merging this fires the Comfy Registry publish.