### PR TITLE
oversized local media: a sampled preview that says it is a sample, instead of a dead end

### DIFF
--- a/browser_tests/unit/media-preview.test.mjs
+++ b/browser_tests/unit/media-preview.test.mjs
@@ -257,7 +257,7 @@ test("a video the browser cannot decode degrades with a reason and a remedy", as
   const h = harness({ buildVideoStoryboard: async () => null });
   const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
   assert.equal(reply.previews.length, 0);
-  assert.match(reply.note, /could not be decoded or seeked/);
+  assert.match(reply.note, /could be decoded, seeked and painted/);
   assert.match(reply.note, /call get_image with filename "reference_clip\.mp4"/);
 });
 
@@ -290,7 +290,11 @@ test("a PARTIALLY sampled sheet reports what was sampled, not the grid capacity"
   assert.equal(reply.previews[0].frames, 3);
   assert.equal(reply.previews[0].cells, 20);
   assert.match(reply.note, /contact sheet of 20 cells, 3 of which hold a sampled frame/);
-  assert.match(reply.note, /the other 17 could not be seeked and are blank/);
+  // The builder blanks a cell when the SEEK fails and when the DRAW fails after
+  // a successful seek, and it does not distinguish them — so naming a cause
+  // would hand the agent a diagnosis nothing observed.
+  assert.match(reply.note, /the other 17 could not be captured and are blank/);
+  assert.doesNotMatch(reply.note, /could not be seeked/);
   assert.match(reply.note, /do not describe the video as 3 frames long/);
   assert.doesNotMatch(reply.note, /a 20-frame contact sheet/);
   // The builder aims at even spacing but SKIPS unseekable positions, so the
@@ -470,7 +474,7 @@ test("a throwing logger does not become the failure it was logging", async () =>
   });
   const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
   assert.equal(reply.ok, true);
-  assert.match(reply.note, /could not be decoded or seeked/);
+  assert.match(reply.note, /could be decoded, seeked and painted/);
 });
 
 test("a painter that settles LATER is reported unconfirmed, not counted as shown", async () => {

--- a/browser_tests/unit/media-preview.test.mjs
+++ b/browser_tests/unit/media-preview.test.mjs
@@ -293,6 +293,33 @@ test("a PARTIALLY sampled sheet reports what was sampled, not the grid capacity"
   assert.match(reply.note, /the other 17 could not be seeked and are blank/);
   assert.match(reply.note, /do not describe the video as 3 frames long/);
   assert.doesNotMatch(reply.note, /a 20-frame contact sheet/);
+  // The builder aims at even spacing but SKIPS unseekable positions, so the
+  // three that survived may all sit near the start. Claiming coverage that was
+  // not observed is the same fabrication one level down.
+  assert.doesNotMatch(reply.note, /evenly-spaced SAMPLES across the video/);
+  assert.match(reply.note, /may be CLUSTERED rather than spread/);
+});
+
+test("a COMPLETE sheet may claim even spacing; a partial one may not", async () => {
+  const complete = harness({ storyboardFrameCount: () => 20 });
+  const a = await composeShowMediaReply([VIDEO_REF], complete.deps);
+  assert.match(a.note, /Those 20 frames are evenly-spaced SAMPLES across the video/);
+
+  const partial = harness({ buildVideoStoryboard: async () => ({ size: 1, paintedFrames: 19 }) });
+  const b = await composeShowMediaReply([VIDEO_REF], partial.deps);
+  assert.doesNotMatch(b.note, /evenly-spaced SAMPLES across the video/);
+});
+
+test("an unknown grid capacity may not claim even spacing either", async () => {
+  const h = harness({ storyboardFrameCount: () => 0 });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+  assert.equal(reply.previews[0].cells, null);
+  assert.doesNotMatch(
+    reply.note,
+    /evenly-spaced SAMPLES across the video/,
+    "with no plan size, nothing establishes that no positions were skipped",
+  );
+  assert.match(reply.note, /may be CLUSTERED rather than spread/);
 });
 
 test("an unknown grid capacity still allows an honest N-sample description", async () => {
@@ -327,7 +354,7 @@ test("storyboard previews turned off is stated as the reason, not silently skipp
 
 // ── one item's failure must not eat the batch ──────────────────────────────
 
-test("one painter throwing costs that item only, and the reply says so", async () => {
+test("one painter throwing costs that item only, and the reply names the REAL reason", async () => {
   const h = harness();
   const boom = h.deps.paintImage;
   let n = 0;
@@ -346,7 +373,78 @@ test("one painter throwing costs that item only, and the reply says so", async (
   assert.equal(reply.ok, true);
   assert.equal(reply.painted, 1);
   assert.equal(reply.count, 2);
-  assert.match(reply.note, /1 of the 2 requested item\(s\) could not be rendered at all/);
+  assert.match(reply.note, /1 of the 2 requested item\(s\) were NOT displayed/);
+  assert.match(reply.note, /• bad\.png — the panel's own painter failed/);
+  assert.doesNotMatch(
+    reply.note,
+    /no usable source/,
+    "the file resolved fine — telling the caller to re-send it is a wrong remedy",
+  );
+});
+
+test("a VIDEO whose player fails to paint still gets its sampled preview", async () => {
+  // The storyboard needs the URL, not the chat player. Dropping the preview
+  // because the DOM failed would deny the agent the only thing it can see.
+  const h = harness({
+    paintVideo: () => {
+      throw new Error("video element exploded");
+    },
+    fetchMediaBytes: async () => OVERSIZED_BYTES,
+  });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+  assert.equal(reply.previews.length, 1, "a painter failure must not cost the preview");
+  assert.match(reply.note, /• reference_clip\.mp4 — the panel's own painter failed/);
+  assert.doesNotMatch(reply.note, /no usable source/);
+  assert.match(reply.note, /SAMPLED PREVIEW/);
+  assert.match(reply.note, /72\.1 MB/);
+});
+
+test("a viewRef whose URL cannot be built says THAT, not 'no usable source'", async () => {
+  const h = harness({
+    imageViewUrl: () => {
+      throw new Error("apiURL exploded");
+    },
+  });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+  assert.match(reply.note, /could not build a view URL for its ComfyUI reference/);
+  assert.doesNotMatch(reply.note, /no usable source/);
+});
+
+test("a painter whose returned object has a THROWING then getter still yields a reply", async () => {
+  // Merely READING `.then` is an operation that can fail. Doing it outside the
+  // guard rejected the whole reply.
+  const h = harness({
+    paintImage: () => ({
+      get then() {
+        throw new Error("then getter threw");
+      },
+    }),
+  });
+  const reply = await composeShowMediaReply(
+    [{ kind: "image", dataUrl: "data:image/png;base64,AAAA", filename: "a.png" }],
+    h.deps,
+  );
+  assert.equal(reply.ok, true);
+  assert.equal(reply.unconfirmed, 1);
+  assert.match(reply.note, /whether the user can see it is UNKNOWN/);
+});
+
+test("a painter that returns a thenable whose then() THROWS still yields a reply", async () => {
+  const h = harness({
+    paintImage: () => ({
+      then() {
+        throw new Error("then threw");
+      },
+    }),
+  });
+  const reply = await composeShowMediaReply(
+    [{ kind: "image", dataUrl: "data:image/png;base64,AAAA", filename: "a.png" }],
+    h.deps,
+  );
+  assert.equal(reply.ok, true);
+  assert.equal(reply.painted, 0);
+  assert.equal(reply.unconfirmed, 1);
+  assert.match(reply.note, /whether the user can see it is UNKNOWN/);
 });
 
 test("a throwing text coercer does not cost the agent its reply", async () => {
@@ -447,7 +545,8 @@ test("an item with no usable source is reported unrendered, not counted as shown
   const reply = await composeShowMediaReply([{ kind: "image", filename: "nothing.png" }], h.deps);
   assert.equal(reply.painted, 0);
   assert.equal(h.calls.paintedImages.length, 0);
-  assert.match(reply.note, /1 of the 1 requested item\(s\) could not be rendered at all/);
+  assert.match(reply.note, /1 of the 1 requested item\(s\) were NOT displayed/);
+  assert.match(reply.note, /• nothing\.png — no usable source/);
 });
 
 // ── classification + byte accounting ───────────────────────────────────────

--- a/browser_tests/unit/media-preview.test.mjs
+++ b/browser_tests/unit/media-preview.test.mjs
@@ -246,19 +246,57 @@ test("a storyboard step that never settles is bounded, degrades, and names a nex
   );
   // Still actionable: the file itself, plus the human who can see it.
   assert.match(reply.note, /call get_image with filename "reference_clip\.mp4", type "input"/);
-  assert.match(reply.note, /Ask the user how it looks/);
+  assert.match(reply.note, /ask the user how it looks/);
   // …and the size it DID manage to read is still reported.
   assert.match(reply.note, /72\.1 MB/);
   // The user still got the player.
   assert.equal(h.calls.paintedVideos.length, 1);
 });
 
-test("a video the browser cannot decode degrades with a reason and a remedy", async () => {
+test("a sampler that returns nothing degrades with a remedy and NO invented cause", async () => {
   const h = harness({ buildVideoStoryboard: async () => null });
   const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
   assert.equal(reply.previews.length, 0);
-  assert.match(reply.note, /could be decoded, seeked and painted/);
+  assert.match(reply.note, /the sampler returned no contact sheet/);
+  assert.match(reply.note, /the panel is not told which/);
+  // The builder returns nothing for a metadata failure, an unusable frame, AND
+  // a sheet that will not encode. Naming one of them is a diagnosis nothing made.
+  assert.doesNotMatch(reply.note, /could not be seeked/);
+  assert.doesNotMatch(reply.note, /not one of its frames/);
   assert.match(reply.note, /call get_image with filename "reference_clip\.mp4"/);
+});
+
+test("the 'ask the user' remedy is withheld when the user cannot see it either", async () => {
+  // Telling the caller to ask a person who was never shown the video sends it
+  // somewhere that does not work from where it is.
+  const h = harness({
+    paintVideo: () => {
+      throw new Error("player exploded");
+    },
+    buildVideoStoryboard: async () => null,
+  });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+  assert.match(reply.note, /The user cannot see it either/);
+  assert.match(reply.note, /asking them how it looks will not help/);
+  assert.doesNotMatch(reply.note, /they can answer for the parts you cannot/);
+  // …and the reachable-file remedy is still offered.
+  assert.match(reply.note, /call get_image with filename "reference_clip\.mp4"/);
+});
+
+test("an UNCONFIRMED player makes the 'ask the user' remedy conditional, not confident", async () => {
+  const h = harness({
+    paintVideo: () => Promise.resolve(),
+    buildVideoStoryboard: async () => null,
+  });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+  assert.match(reply.note, /Whether the user can see it in the chat is UNKNOWN/);
+  assert.match(reply.note, /ask whether they can see it before asking them to describe it/);
+});
+
+test("a player that WAS put in the chat gets the confident remedy", async () => {
+  const h = harness({ buildVideoStoryboard: async () => null });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+  assert.match(reply.note, /Its player is in the chat, so ask the user how it looks/);
 });
 
 test("a failed sheet upload degrades with a reason and a remedy", async () => {
@@ -345,7 +383,7 @@ test("a storyboard pipeline that THROWS degrades instead of failing the reply", 
   assert.equal(reply.ok, true);
   assert.equal(reply.previews.length, 0);
   assert.match(reply.note, /sampling pipeline failed/);
-  assert.match(reply.note, /Ask the user how it looks/);
+  assert.match(reply.note, /ask the user how it looks/);
 });
 
 test("storyboard previews turned off is stated as the reason, not silently skipped", async () => {
@@ -474,7 +512,7 @@ test("a throwing logger does not become the failure it was logging", async () =>
   });
   const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
   assert.equal(reply.ok, true);
-  assert.match(reply.note, /could be decoded, seeked and painted/);
+  assert.match(reply.note, /the sampler returned no contact sheet/);
 });
 
 test("a painter that settles LATER is reported unconfirmed, not counted as shown", async () => {

--- a/browser_tests/unit/media-preview.test.mjs
+++ b/browser_tests/unit/media-preview.test.mjs
@@ -52,9 +52,11 @@ function harness(over = {}) {
     imageViewUrl: (ref) =>
       `/view?filename=${ref.filename}&subfolder=${ref.subfolder ?? ""}&type=${ref.type ?? "output"}`,
     coerceMessageText: (v) => (typeof v === "string" ? v : v == null ? "" : String(v)),
+    // The real builder returns a PNG Blob carrying `paintedFrames` — the number
+    // of cells it actually drew into, which is NOT the grid capacity.
     buildVideoStoryboard: async (url) => {
       calls.storyboardsFor.push(url);
-      return { size: 4096 };
+      return { size: 4096, paintedFrames: 20 };
     },
     uploadBlobToInput: async (blob, name, opts) => {
       calls.uploads.push({ blob, name, opts });
@@ -267,14 +269,39 @@ test("a failed sheet upload degrades with a reason and a remedy", async () => {
   assert.match(reply.note, /call get_image with filename "reference_clip\.mp4"/);
 });
 
-test("a sheet whose frame count is unknown is NOT offered as an N-frame sample", async () => {
-  // A sheet exists, but nothing can say how many cells it holds. "Some frames"
-  // is not a disclosure, so the preview is withheld rather than described vaguely.
-  const h = harness({ storyboardFrameCount: () => 0 });
+test("a sheet whose SAMPLE count is unknown is NOT offered as an N-frame sample", async () => {
+  // A sheet exists, but the builder did not say how many cells it drew into.
+  // Quoting the grid capacity instead would invent observations from blank
+  // cells, so the preview is withheld rather than described vaguely.
+  const h = harness({ buildVideoStoryboard: async () => ({ size: 1 }) });
   const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
   assert.equal(reply.previews.length, 0);
-  assert.match(reply.note, /could not say how many frames it holds/);
-  assert.doesNotMatch(reply.note, /contact sheet built in the browser/);
+  assert.match(reply.note, /could not say how many frames it actually sampled/);
+  assert.doesNotMatch(reply.note, /SAMPLED PREVIEW/);
+  assert.doesNotMatch(reply.note, /20/, "the grid capacity must never stand in for the sample count");
+});
+
+test("a PARTIALLY sampled sheet reports what was sampled, not the grid capacity", async () => {
+  // 20 cells, 3 seeks succeeded. Describing this as "20 evenly-spaced samples"
+  // is a fabricated observation about 17 blank cells.
+  const h = harness({ buildVideoStoryboard: async () => ({ size: 1, paintedFrames: 3 }) });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+  assert.equal(reply.previews.length, 1);
+  assert.equal(reply.previews[0].frames, 3);
+  assert.equal(reply.previews[0].cells, 20);
+  assert.match(reply.note, /contact sheet of 20 cells, 3 of which hold a sampled frame/);
+  assert.match(reply.note, /the other 17 could not be seeked and are blank/);
+  assert.match(reply.note, /do not describe the video as 3 frames long/);
+  assert.doesNotMatch(reply.note, /a 20-frame contact sheet/);
+});
+
+test("an unknown grid capacity still allows an honest N-sample description", async () => {
+  const h = harness({ storyboardFrameCount: () => 0 });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+  assert.equal(reply.previews.length, 1);
+  assert.equal(reply.previews[0].frames, 20);
+  assert.equal(reply.previews[0].cells, null);
+  assert.match(reply.note, /a 20-frame contact sheet/);
 });
 
 test("a storyboard pipeline that THROWS degrades instead of failing the reply", async () => {
@@ -322,10 +349,51 @@ test("one painter throwing costs that item only, and the reply says so", async (
   assert.match(reply.note, /1 of the 2 requested item\(s\) could not be rendered at all/);
 });
 
+test("a throwing text coercer does not cost the agent its reply", async () => {
+  // The trivial helpers are operations that can fail too. A throwing coercer
+  // used to reject before anything was composed — a transport error instead of
+  // a reply is exactly the dead end this module removes.
+  const h = harness({
+    coerceMessageText: () => {
+      throw new Error("coercion exploded");
+    },
+  });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+  assert.equal(reply.ok, true);
+  assert.match(reply.note, /You were NOT sent/);
+});
+
+test("a throwing logger does not become the failure it was logging", async () => {
+  const h = harness({
+    warn: () => {
+      throw new Error("logger exploded");
+    },
+    buildVideoStoryboard: async () => null,
+  });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+  assert.equal(reply.ok, true);
+  assert.match(reply.note, /could not be decoded or seeked/);
+});
+
+test("a painter that settles LATER is reported unconfirmed, not counted as shown", async () => {
+  // A promise-returning painter cannot be confirmed from here, and its rejection
+  // must not surface as an unhandled rejection either.
+  const h = harness({ paintImage: () => Promise.reject(new Error("late failure")) });
+  const reply = await composeShowMediaReply(
+    [{ kind: "image", dataUrl: "data:image/png;base64,AAAA", filename: "a.png" }],
+    h.deps,
+  );
+  assert.equal(reply.painted, 0, "an unconfirmed paint is not a paint");
+  assert.equal(reply.unconfirmed, 1);
+  assert.match(reply.note, /whether the user can see it is UNKNOWN/);
+  await new Promise((r) => setImmediate(r));
+});
+
 test("two videos are previewed independently — one wedged does not suppress the other", async () => {
   const second = { ...VIDEO_REF, viewRef: { ...VIDEO_REF.viewRef, filename: "other.mp4" } };
   const h = harness({
-    buildVideoStoryboard: async (url) => (url.includes("other") ? { size: 1 } : new Promise(() => {})),
+    buildVideoStoryboard: async (url) =>
+      url.includes("other") ? { size: 1, paintedFrames: 20 } : new Promise(() => {}),
   });
   const p = composeShowMediaReply([VIDEO_REF, second], h.deps);
   await h.elapse(MEDIA_PREVIEW_TIMEOUT_MS);
@@ -369,6 +437,26 @@ test("dataUrlByteLength reads the payload exactly, and refuses to guess otherwis
   assert.equal(dataUrlByteLength("/view?filename=a.mp4"), null, "not a data URL ⇒ unknown");
   assert.equal(dataUrlByteLength("data:video/mp4,raw"), null, "not base64 ⇒ unknown");
   assert.equal(dataUrlByteLength(null), null);
+  // MALFORMED payloads must be unknown, not measured. The arithmetic is happy
+  // to measure nonsense, and a measured nonsense payload told the agent the
+  // source video was a few bytes — an invented size.
+  assert.equal(dataUrlByteLength("data:video/mp4;base64,A"), null, "1 char is not a base64 group");
+  assert.equal(dataUrlByteLength("data:video/mp4;base64,AAA"), null, "3 chars is not a base64 group");
+  assert.equal(dataUrlByteLength("data:video/mp4;base64,!!!!"), null, "not the base64 alphabet");
+  assert.equal(dataUrlByteLength("data:video/mp4;base64,A==="), null, "3 pad chars is not base64");
+  assert.equal(dataUrlByteLength("data:video/mp4;base64,AA=A"), null, "padding is trailing-only");
+  assert.equal(dataUrlByteLength("data:video/mp4;base64,ab-_"), null, "base64url is not decoded here");
+});
+
+test("a video whose inline payload is malformed reports its size UNKNOWN, never a tiny one", async () => {
+  const h = harness();
+  const reply = await composeShowMediaReply(
+    [{ kind: "video", dataUrl: "data:video/mp4;base64,!!!!", filename: "broken.mp4" }],
+    h.deps,
+  );
+  assert.match(reply.note, /size UNKNOWN/);
+  assert.doesNotMatch(reply.note, /source file \d/, "a size that could not be read must not be stated");
+  assert.equal(reply.previews[0].sourceBytes, null);
 });
 
 // ── the SHIPPED panel is actually wired to this module ─────────────────────
@@ -397,6 +485,18 @@ test("the show_media dispatcher answers with the handler's reply, not a fixed ac
     /result = \(await onShowMedia\?\.\(mediaItems\)\)/,
     "the reply must be AWAITED from the handler — a preview is real work",
   );
+});
+
+test("the panel's storyboard builder carries the count it ACTUALLY drew", () => {
+  // Without this, media-preview has only the grid capacity to go on and every
+  // partially-sampled sheet is described as a full one — 19 blank cells
+  // presented to the agent as 19 observations.
+  const src = panelSource();
+  const i = src.indexOf("async function buildVideoStoryboard(");
+  assert.ok(i > 0, "could not locate buildVideoStoryboard");
+  const fn = src.slice(i, i + 4000);
+  assert.match(fn, /blob\.paintedFrames = painted;/);
+  assert.match(fn, /if \(!blob\) return null;/);
 });
 
 test("onShowMedia routes through composeShowMediaReply with the storyboard pipeline wired", () => {
@@ -480,7 +580,7 @@ test("withTimeout still settles when clearTimer THROWS", async () => {
   assert.equal(v, "ok");
 });
 
-test("withTimeout still settles when setTimer THROWS (unbounded, but never rejecting)", async () => {
+test("withTimeout still settles when setTimer THROWS", async () => {
   const v = await withTimeout(Promise.resolve("ok"), 1000, () => "late", {
     setTimer: () => {
       throw new Error("no timers available");
@@ -488,6 +588,19 @@ test("withTimeout still settles when setTimer THROWS (unbounded, but never rejec
     clearTimer: () => {},
   });
   assert.equal(v, "ok");
+});
+
+test("a THROWING setTimer must not silently REMOVE the bound", async () => {
+  // Falling through to "unbounded" turns "bounded, degrades" into "pending
+  // forever" — the one outcome this helper exists to prevent. It falls back to
+  // the platform timer instead, so a never-settling step still degrades.
+  const v = await withTimeout(new Promise(() => {}), 5, () => "fallback", {
+    setTimer: () => {
+      throw new Error("no timers available");
+    },
+    clearTimer: () => {},
+  });
+  assert.equal(v, "fallback");
 });
 
 test("withTimeout with a non-positive bound is a passthrough", async () => {

--- a/browser_tests/unit/media-preview.test.mjs
+++ b/browser_tests/unit/media-preview.test.mjs
@@ -422,6 +422,107 @@ test("one painter throwing costs that item only, and the reply names the REAL re
     /no usable source/,
     "the file resolved fine — telling the caller to re-send it is a wrong remedy",
   );
+  // "Re-sending will not help" is true and is NOT a next step. Every drop must
+  // carry one, or the reply is a dead end with a better explanation.
+  assert.match(reply.note, /ask them to reload the panel and try again/);
+  assert.match(reply.note, /call get_image on it if you need to look at it/);
+});
+
+test("a non-video DROP with a ComfyUI ref is pointed at get_image, not just told to give up", async () => {
+  const h = harness({
+    paintImage: () => {
+      throw new Error("DOM exploded");
+    },
+  });
+  const reply = await composeShowMediaReply(
+    [
+      {
+        kind: "viewRef",
+        viewRef: { filename: "sheet.png", subfolder: "sub", type: "output" },
+        filename: "sheet.png",
+      },
+    ],
+    h.deps,
+  );
+  assert.match(reply.note, /• sheet\.png — the panel's own painter failed/);
+  assert.match(
+    reply.note,
+    /call get_image with filename "sheet\.png", type "output", subfolder "sub" — it returns the image inline/,
+  );
+});
+
+test("a viewRef whose URL cannot be built is handed the ref, not a dead end", async () => {
+  // The reference is right there; get_image resolves it without the panel's URL
+  // builder, which is the very step that failed.
+  const h = harness({
+    imageViewUrl: () => {
+      throw new Error("apiURL exploded");
+    },
+  });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+  assert.match(reply.note, /could not build a view URL for its ComfyUI reference/);
+  assert.match(reply.note, /The reference itself is intact/);
+  assert.match(
+    reply.note,
+    /call get_image with filename "reference_clip\.mp4", type "input"/,
+    "the URL-build failure must still name a next step — no preview job exists to carry one",
+  );
+});
+
+test("EVERY drop carries a next step, whatever the cause", async () => {
+  // The discrimination the reasons provide is worthless if one of the branches
+  // still ends in "you cannot".
+  const cases = [
+    // no usable source
+    { deps: {}, items: [{ kind: "image", filename: "nothing.png" }] },
+    // URL build failed
+    {
+      deps: {
+        imageViewUrl: () => {
+          throw new Error("no url");
+        },
+      },
+      items: [VIDEO_REF],
+    },
+    // painter failed, image with a ref
+    {
+      deps: {
+        paintImage: () => {
+          throw new Error("dom");
+        },
+      },
+      items: [{ kind: "viewRef", viewRef: { filename: "a.png", type: "output" }, filename: "a.png" }],
+    },
+    // painter failed, inline image with no ref
+    {
+      deps: {
+        paintImage: () => {
+          throw new Error("dom");
+        },
+      },
+      items: [{ kind: "image", dataUrl: "data:image/png;base64,AAAA", filename: "a.png" }],
+    },
+    // painter failed, video
+    {
+      deps: {
+        paintVideo: () => {
+          throw new Error("dom");
+        },
+      },
+      items: [VIDEO_REF],
+    },
+  ];
+  for (const c of cases) {
+    const h = harness(c.deps);
+    const reply = await composeShowMediaReply(c.items, h.deps);
+    const line = reply.note.split("\n").find((l) => l.startsWith("• "));
+    assert.ok(line, `no drop line for ${JSON.stringify(c.items[0].filename)}`);
+    assert.match(
+      line,
+      /(call get_image|Re-send it as an absolute path|reload the panel|sampled-preview note below)/,
+      `drop line names no next step: ${line}`,
+    );
+  }
 });
 
 test("a VIDEO whose player fails to paint still gets its sampled preview", async () => {
@@ -450,6 +551,18 @@ test("a viewRef whose URL cannot be built says THAT, not 'no usable source'", as
   const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
   assert.match(reply.note, /could not build a view URL for its ComfyUI reference/);
   assert.doesNotMatch(reply.note, /no usable source/);
+});
+
+test("a VIDEO drop points at its own sampled-preview note rather than repeating a remedy", async () => {
+  const h = harness({
+    paintVideo: () => {
+      throw new Error("player exploded");
+    },
+  });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+  assert.match(reply.note, /see this video's sampled-preview note below/);
+  assert.match(reply.note, /tell the user their player did not appear/);
+  assert.match(reply.note, /SAMPLED PREVIEW/, "…and that note must actually be there");
 });
 
 test("a painter whose returned object has a THROWING then getter still yields a reply", async () => {
@@ -606,6 +719,33 @@ test("video classification does not treat an arbitrary character as a dot", () =
   );
   assert.equal(isVideoShowMediaItem({ kind: "video", dataUrl: "data:video/mp4;base64,AA==" }), true);
   assert.equal(isVideoShowMediaItem(null), false);
+  // A query string or fragment on the filename must not demote a real video to
+  // an image — that skips the storyboard AND the whole sampled-preview
+  // disclosure, which is this module's entire job.
+  assert.equal(isVideoShowMediaItem(ref("clip.mp4?download=1")), true);
+  assert.equal(isVideoShowMediaItem(ref("clip.MP4?t=3")), true);
+  assert.equal(isVideoShowMediaItem(ref("clip.webm#t=10")), true);
+  assert.equal(isVideoShowMediaItem(ref("clip.mp4?a=1#b")), true);
+  assert.equal(isVideoShowMediaItem(ref("sheet.png?v=2")), false);
+  assert.equal(isVideoShowMediaItem(ref("xmp4?v=2")), false);
+});
+
+test("a video ref carrying a query string still gets a full sampled preview", async () => {
+  const h = harness({ fetchMediaBytes: async () => OVERSIZED_BYTES });
+  const reply = await composeShowMediaReply(
+    [
+      {
+        kind: "viewRef",
+        viewRef: { filename: "reference_clip.mp4?download=1", type: "input" },
+        filename: "reference_clip.mp4?download=1",
+      },
+    ],
+    h.deps,
+  );
+  assert.equal(h.calls.paintedVideos.length, 1, "it must be played, not painted as an image");
+  assert.equal(reply.previews.length, 1);
+  assert.match(reply.note, /SAMPLED PREVIEW/);
+  assert.match(reply.note, /72\.1 MB/);
 });
 
 test("dataUrlByteLength reads the payload exactly, and refuses to guess otherwise", () => {
@@ -640,6 +780,36 @@ test("dataUrlByteLength reads the payload exactly, and refuses to guess otherwis
   assert.equal(dataUrlByteLength("data:video/mp4;base64,AAAA="), null, "padding must complete a group");
   assert.equal(dataUrlByteLength("data:video/mp4;base64,AAAA=="), null, "a full group needs no padding");
   assert.equal(dataUrlByteLength("data:video/mp4;base64,ab-_"), null, "base64url is not decoded here");
+  // Only the five ASCII whitespace characters the decoder itself ignores may be
+  // removed. Stripping JavaScript's \s scrubbed U+00A0 / U+2028 out of a payload
+  // no browser will decode, and then reported a byte count for it.
+  assert.equal(dataUrlByteLength("data:video/mp4;base64,AA ==\t\r\n"), 1, "ASCII whitespace is ignored");
+  // Written as \u escapes on purpose: these characters are invisible, and a
+  // reviewer has to be able to see WHICH codepoint each case is about.
+  for (const cp of ["\u00A0", "\u2028", "\u2029", "\uFEFF", "\u3000", "\u000B", "\u2003"]) {
+    const u = `U+${cp.codePointAt(0).toString(16).toUpperCase().padStart(4, "0")}`;
+    assert.equal(
+      dataUrlByteLength(`data:video/mp4;base64,AA==${cp}`),
+      null,
+      `${u} is not base64 and must not be scrubbed away`,
+    );
+    assert.equal(
+      dataUrlByteLength(`data:video/mp4;base64,A${cp}A==`),
+      null,
+      `${u} is not base64 anywhere in the body either`,
+    );
+  }
+});
+
+test("a payload padded with non-ASCII whitespace reports UNKNOWN, not a byte count", async () => {
+  const h = harness();
+  const reply = await composeShowMediaReply(
+    [{ kind: "video", dataUrl: "data:video/mp4;base64,AA==\u00A0", filename: "sneaky.mp4" }],
+    h.deps,
+  );
+  assert.equal(reply.previews[0].sourceBytes, null);
+  assert.match(reply.note, /size UNKNOWN/);
+  assert.doesNotMatch(reply.note, /source file \d/);
 });
 
 test("a video whose inline payload is malformed reports its size UNKNOWN, never a tiny one", async () => {
@@ -673,11 +843,39 @@ test("the show_media dispatcher answers with the handler's reply, not a fixed ac
   );
   const i = src.indexOf('msg.cmd === "show_media"');
   assert.ok(i > 0, "could not locate the show_media dispatcher branch");
-  const branch = src.slice(i, i + 1600);
+  // Bound the slice to THIS branch — a fixed window ran into the next one and
+  // asserted against its code.
+  const j = src.indexOf('} else if (msg.cmd === "open_civitai")', i);
+  assert.ok(j > i, "could not find the end of the show_media branch");
+  const branch = src.slice(i, j);
   assert.match(
     branch,
-    /result = \(await onShowMedia\?\.\(mediaItems\)\)/,
+    /const mediaReply = await onShowMedia\(mediaItems\);/,
     "the reply must be AWAITED from the handler — a preview is real work",
+  );
+  // The handler is what paints and what composes the disclosure, so its absence
+  // cannot be success. An optional call with an {ok:true} fallback reproduces
+  // the exact dead-end acknowledgement this whole PR removes, on the branch
+  // nobody re-reads.
+  assert.match(
+    branch,
+    /if \(!onShowMedia\) throw new Error\(/,
+    "an absent handler must fail loudly, not succeed quietly",
+  );
+  assert.doesNotMatch(
+    branch,
+    /onShowMedia\?\./,
+    "the optional call is the tell — it makes 'no handler' indistinguishable from 'delivered'",
+  );
+  assert.doesNotMatch(
+    branch,
+    /ok: true/,
+    "no branch of show_media may report success the panel did not observe",
+  );
+  assert.match(
+    branch,
+    /delivered: "unknown"/,
+    "a handler that returns nothing leaves the delivery UNKNOWN, not done",
   );
 });
 

--- a/browser_tests/unit/media-preview.test.mjs
+++ b/browser_tests/unit/media-preview.test.mjs
@@ -1,0 +1,517 @@
+/**
+ * #648 — panel_show_media must never leave the caller at a dead end, and must
+ * never let a sampled preview be mistaken for the media.
+ *
+ * These tests are about the REPLY TEXT, not about whether a blob was produced.
+ * "A preview was returned" passes whether or not the reply discloses that it is
+ * sampled — and the disclosure is the entire point, so every preview case here
+ * asserts the disclosure and every failure case asserts a named next step.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  composeShowMediaReply,
+  dataUrlByteLength,
+  isVideoShowMediaItem,
+  MEDIA_PREVIEW_TIMEOUT_MS,
+  MEDIA_SIZE_PROBE_TIMEOUT_MS,
+} from "../../web/js/lib/media-preview.js";
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
+
+// ── harness ────────────────────────────────────────────────────────────────
+
+/** The panel's own humanizeBytes, mirrored so the sizes in a note are real. */
+function humanizeBytes(n) {
+  if (!Number.isFinite(n) || n < 0) return null;
+  if (n < 1024) return `${n} B`;
+  const u = ["KB", "MB", "GB", "TB"];
+  let i = -1;
+  let v = n;
+  do {
+    v /= 1024;
+    i++;
+  } while (v >= 1024 && i < u.length - 1);
+  return `${v.toFixed(1)} ${u[i]}`;
+}
+
+function harness(over = {}) {
+  const calls = {
+    paintedImages: [],
+    paintedVideos: [],
+    storyboardsFor: [],
+    uploads: [],
+    warnings: [],
+  };
+  const timers = [];
+  const deps = {
+    paintImage: (url, caption) => calls.paintedImages.push({ url, caption }),
+    paintVideo: (url, caption) => calls.paintedVideos.push({ url, caption }),
+    imageViewUrl: (ref) =>
+      `/view?filename=${ref.filename}&subfolder=${ref.subfolder ?? ""}&type=${ref.type ?? "output"}`,
+    coerceMessageText: (v) => (typeof v === "string" ? v : v == null ? "" : String(v)),
+    buildVideoStoryboard: async (url) => {
+      calls.storyboardsFor.push(url);
+      return { size: 4096 };
+    },
+    uploadBlobToInput: async (blob, name, opts) => {
+      calls.uploads.push({ blob, name, opts });
+      return { filename: name, subfolder: "", type: opts?.type ?? "input" };
+    },
+    storyboardFrameCount: () => 20,
+    humanizeBytes,
+    fetchMediaBytes: async () => null,
+    videoStoryboardEnabled: true,
+    warn: (...a) => calls.warnings.push(a.map(String).join(" ")),
+    // Deterministic timers: nothing fires unless a test fires it.
+    setTimer: (fn, ms) => {
+      const t = { fn, ms, cleared: false };
+      timers.push(t);
+      return t;
+    },
+    clearTimer: (t) => {
+      if (t) t.cleared = true;
+    },
+    ...over,
+  };
+  return {
+    deps,
+    calls,
+    timers,
+    /**
+     * Let every already-resolvable step settle, then fire the still-armed timers
+     * whose bound is `ms` — i.e. "that particular wall clock elapsed, and only
+     * for the steps that had not finished". Draining first is what makes the
+     * assertion meaningful: a healthy step's timer is cleared by then, so firing
+     * cannot be mistaken for having caused its degradation.
+     */
+    async elapse(ms) {
+      for (let i = 0; i < 8; i += 1) await new Promise((r) => setImmediate(r));
+      for (const t of timers) if (!t.cleared && t.ms === ms) t.fn();
+    },
+  };
+}
+
+const VIDEO_REF = {
+  kind: "viewRef",
+  viewRef: { filename: "reference_clip.mp4", subfolder: "", type: "input" },
+  filename: "reference_clip.mp4",
+  caption: "the reference",
+};
+
+// 72.1 MB — the size in the report.
+const OVERSIZED_BYTES = 75_600_000;
+
+// ── the sampled-preview disclosure ─────────────────────────────────────────
+
+test("an oversized local video yields a preview AND says it is a sample, not the video (#648)", async () => {
+  const h = harness({ fetchMediaBytes: async () => OVERSIZED_BYTES });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+
+  // It got somewhere: a sheet exists and is reachable.
+  assert.equal(reply.previews.length, 1);
+  assert.equal(reply.previews[0].frames, 20);
+  assert.equal(reply.previews[0].sourceBytes, OVERSIZED_BYTES);
+  assert.equal(reply.previews[0].type, "temp", "the sheet must land in ComfyUI's swept temp/");
+  assert.equal(h.calls.uploads.length, 1);
+  assert.equal(h.calls.uploads[0].opts.type, "temp");
+
+  // …and the reply cannot be read as "you have seen the video".
+  assert.match(reply.note, /NOT shown this video/);
+  assert.match(reply.note, /SAMPLED PREVIEW/);
+  assert.match(reply.note, /20-frame contact sheet/);
+  assert.match(reply.note, /evenly-spaced SAMPLES/);
+  assert.match(
+    reply.note,
+    /do not describe the video as 20 frames long/,
+    "the frame count must be disarmed explicitly — this is the fabrication the disclosure exists to stop",
+  );
+  // The source size, in the note, in human units.
+  assert.match(reply.note, /72\.1 MB/);
+  // A next step that actually shows the agent the sheet.
+  assert.match(reply.note, /call get_image with filename "storyboard_reference_clip\.png", type "temp"/);
+});
+
+test("the batch headline states the agent was not sent the files at all", async () => {
+  const h = harness();
+  const reply = await composeShowMediaReply(
+    [{ kind: "image", dataUrl: "data:image/png;base64,AAAA", filename: "a.png" }],
+    h.deps,
+  );
+  assert.match(reply.note, /displayed to the USER/);
+  assert.match(reply.note, /You were NOT sent this file/);
+});
+
+// ── under-cap / non-video: behaviour unchanged ─────────────────────────────
+
+test("an image-only call paints exactly as before and claims no sampled preview", async () => {
+  const h = harness();
+  const reply = await composeShowMediaReply(
+    [
+      { kind: "image", dataUrl: "data:image/png;base64,AAAA", filename: "a.png", caption: "A" },
+      {
+        kind: "viewRef",
+        viewRef: { filename: "b.png", subfolder: "sub", type: "output" },
+        filename: "b.png",
+      },
+    ],
+    h.deps,
+  );
+
+  assert.equal(h.calls.paintedImages.length, 2);
+  assert.equal(h.calls.paintedVideos.length, 0);
+  assert.equal(h.calls.storyboardsFor.length, 0, "no video ⇒ no sampling work at all");
+  assert.equal(reply.previews.length, 0);
+  assert.equal(reply.ok, true);
+  assert.equal(reply.count, 2);
+  assert.equal(reply.painted, 2);
+  assert.doesNotMatch(reply.note, /SAMPLED PREVIEW/);
+  assert.doesNotMatch(reply.note, /contact sheet/);
+});
+
+test("an inlined (under-cap) video is still disclosed as sampled, with its exact size", async () => {
+  // 6 base64 chars, no padding → 4 bytes of payload. Size is COMPUTED, not probed.
+  const dataUrl = `data:video/mp4;base64,${"A".repeat(1400)}`;
+  const h = harness({
+    fetchMediaBytes: async () => {
+      throw new Error("a data URL must never be probed over the network");
+    },
+  });
+  const reply = await composeShowMediaReply(
+    [{ kind: "video", dataUrl, filename: "small.mp4" }],
+    h.deps,
+  );
+  assert.equal(h.calls.paintedVideos.length, 1);
+  assert.equal(reply.previews.length, 1);
+  assert.equal(reply.previews[0].sourceBytes, dataUrlByteLength(dataUrl));
+  assert.match(reply.note, /NOT shown this video/);
+  assert.match(reply.note, new RegExp(humanizeBytes(dataUrlByteLength(dataUrl)).replace(".", "\\.")));
+});
+
+// ── "could not determine X" is not "determined X is not the case" ──────────
+
+test("a source size that cannot be read is reported UNKNOWN — not omitted, not guessed", async () => {
+  const h = harness({ fetchMediaBytes: async () => null });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+
+  assert.equal(reply.previews.length, 1, "an unreadable size must not cost the preview");
+  assert.equal(reply.previews[0].sourceBytes, null);
+  assert.match(reply.note, /size UNKNOWN/);
+  assert.match(reply.note, /not the same as knowing it is small/);
+  assert.doesNotMatch(reply.note, /\d+(\.\d+)? (B|KB|MB|GB|TB)\b/, "no size may be stated");
+});
+
+test("a size probe that THROWS is also UNKNOWN, and still yields a preview", async () => {
+  const h = harness({
+    fetchMediaBytes: async () => {
+      throw new Error("HEAD blew up");
+    },
+  });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+  assert.equal(reply.previews.length, 1);
+  assert.match(reply.note, /size UNKNOWN/);
+});
+
+test("a size probe that never settles is bounded and degrades to UNKNOWN", async () => {
+  const h = harness({ fetchMediaBytes: () => new Promise(() => {}) });
+  const p = composeShowMediaReply([VIDEO_REF], h.deps);
+  await h.elapse(MEDIA_SIZE_PROBE_TIMEOUT_MS);
+  const reply = await p;
+  assert.equal(reply.previews.length, 1, "a hung HEAD must not cost the preview");
+  assert.match(reply.note, /size UNKNOWN/);
+});
+
+// ── bounded, and honest about having degraded ──────────────────────────────
+
+test("a storyboard step that never settles is bounded, degrades, and names a next step", async () => {
+  const h = harness({
+    buildVideoStoryboard: () => new Promise(() => {}),
+    fetchMediaBytes: async () => OVERSIZED_BYTES,
+  });
+  const p = composeShowMediaReply([VIDEO_REF], h.deps);
+  await h.elapse(MEDIA_PREVIEW_TIMEOUT_MS);
+  const reply = await p;
+
+  assert.equal(reply.previews.length, 0);
+  assert.match(reply.note, /NOT shown this video/);
+  assert.match(reply.note, /no sampled preview could be built/);
+  assert.match(
+    reply.note,
+    new RegExp(`took longer than ${Math.round(MEDIA_PREVIEW_TIMEOUT_MS / 1000)}s`),
+    "the reply must say the bound fired, not merely that nothing happened",
+  );
+  // Still actionable: the file itself, plus the human who can see it.
+  assert.match(reply.note, /call get_image with filename "reference_clip\.mp4", type "input"/);
+  assert.match(reply.note, /Ask the user how it looks/);
+  // …and the size it DID manage to read is still reported.
+  assert.match(reply.note, /72\.1 MB/);
+  // The user still got the player.
+  assert.equal(h.calls.paintedVideos.length, 1);
+});
+
+test("a video the browser cannot decode degrades with a reason and a remedy", async () => {
+  const h = harness({ buildVideoStoryboard: async () => null });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+  assert.equal(reply.previews.length, 0);
+  assert.match(reply.note, /could not be decoded or seeked/);
+  assert.match(reply.note, /call get_image with filename "reference_clip\.mp4"/);
+});
+
+test("a failed sheet upload degrades with a reason and a remedy", async () => {
+  const h = harness({ uploadBlobToInput: async () => null });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+  assert.equal(reply.previews.length, 0);
+  assert.match(reply.note, /could not be uploaded to ComfyUI/);
+  assert.match(reply.note, /call get_image with filename "reference_clip\.mp4"/);
+});
+
+test("a sheet whose frame count is unknown is NOT offered as an N-frame sample", async () => {
+  // A sheet exists, but nothing can say how many cells it holds. "Some frames"
+  // is not a disclosure, so the preview is withheld rather than described vaguely.
+  const h = harness({ storyboardFrameCount: () => 0 });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+  assert.equal(reply.previews.length, 0);
+  assert.match(reply.note, /could not say how many frames it holds/);
+  assert.doesNotMatch(reply.note, /contact sheet built in the browser/);
+});
+
+test("a storyboard pipeline that THROWS degrades instead of failing the reply", async () => {
+  const h = harness({
+    buildVideoStoryboard: async () => {
+      throw new Error("decoder exploded");
+    },
+  });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+  assert.equal(reply.ok, true);
+  assert.equal(reply.previews.length, 0);
+  assert.match(reply.note, /sampling pipeline failed/);
+  assert.match(reply.note, /Ask the user how it looks/);
+});
+
+test("storyboard previews turned off is stated as the reason, not silently skipped", async () => {
+  const h = harness({ videoStoryboardEnabled: false });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+  assert.equal(h.calls.storyboardsFor.length, 0);
+  assert.match(reply.note, /turned off in the panel's settings/);
+  assert.match(reply.note, /call get_image with filename "reference_clip\.mp4"/);
+});
+
+// ── one item's failure must not eat the batch ──────────────────────────────
+
+test("one painter throwing costs that item only, and the reply says so", async () => {
+  const h = harness();
+  const boom = h.deps.paintImage;
+  let n = 0;
+  h.deps.paintImage = (url, caption) => {
+    n += 1;
+    if (n === 1) throw new Error("DOM exploded");
+    return boom(url, caption);
+  };
+  const reply = await composeShowMediaReply(
+    [
+      { kind: "image", dataUrl: "data:image/png;base64,AAAA", filename: "bad.png" },
+      { kind: "image", dataUrl: "data:image/png;base64,BBBB", filename: "good.png" },
+    ],
+    h.deps,
+  );
+  assert.equal(reply.ok, true);
+  assert.equal(reply.painted, 1);
+  assert.equal(reply.count, 2);
+  assert.match(reply.note, /1 of the 2 requested item\(s\) could not be rendered at all/);
+});
+
+test("two videos are previewed independently — one wedged does not suppress the other", async () => {
+  const second = { ...VIDEO_REF, viewRef: { ...VIDEO_REF.viewRef, filename: "other.mp4" } };
+  const h = harness({
+    buildVideoStoryboard: async (url) => (url.includes("other") ? { size: 1 } : new Promise(() => {})),
+  });
+  const p = composeShowMediaReply([VIDEO_REF, second], h.deps);
+  await h.elapse(MEDIA_PREVIEW_TIMEOUT_MS);
+  const reply = await p;
+  assert.equal(reply.previews.length, 1);
+  assert.equal(reply.previews[0].of, "other.mp4");
+  assert.match(reply.note, /reference_clip\.mp4 — you were NOT shown this video, and no sampled preview/);
+  assert.match(reply.note, /other\.mp4 — you were NOT shown this video\. What exists for you is a SAMPLED PREVIEW/);
+});
+
+test("an item with no usable source is reported unrendered, not counted as shown", async () => {
+  const h = harness();
+  const reply = await composeShowMediaReply([{ kind: "image", filename: "nothing.png" }], h.deps);
+  assert.equal(reply.painted, 0);
+  assert.equal(h.calls.paintedImages.length, 0);
+  assert.match(reply.note, /1 of the 1 requested item\(s\) could not be rendered at all/);
+});
+
+// ── classification + byte accounting ───────────────────────────────────────
+
+test("video classification does not treat an arbitrary character as a dot", () => {
+  const ref = (filename) => ({ kind: "viewRef", viewRef: { filename } });
+  assert.equal(isVideoShowMediaItem(ref("clip.mp4")), true);
+  assert.equal(isVideoShowMediaItem(ref("clip.MP4")), true);
+  assert.equal(isVideoShowMediaItem(ref("clip.mov")), true);
+  assert.equal(isVideoShowMediaItem(ref("sheet.png")), false);
+  assert.equal(
+    isVideoShowMediaItem(ref("xmp4")),
+    false,
+    "the old test used an unescaped dot, so this was painted as a video",
+  );
+  assert.equal(isVideoShowMediaItem({ kind: "video", dataUrl: "data:video/mp4;base64,AA==" }), true);
+  assert.equal(isVideoShowMediaItem(null), false);
+});
+
+test("dataUrlByteLength reads the payload exactly, and refuses to guess otherwise", () => {
+  assert.equal(dataUrlByteLength("data:video/mp4;base64,AAAA"), 3);
+  assert.equal(dataUrlByteLength("data:video/mp4;base64,AAA="), 2);
+  assert.equal(dataUrlByteLength("data:video/mp4;base64,AA=="), 1);
+  assert.equal(dataUrlByteLength("data:video/mp4;base64,"), 0);
+  assert.equal(dataUrlByteLength("/view?filename=a.mp4"), null, "not a data URL ⇒ unknown");
+  assert.equal(dataUrlByteLength("data:video/mp4,raw"), null, "not base64 ⇒ unknown");
+  assert.equal(dataUrlByteLength(null), null);
+});
+
+// ── the SHIPPED panel is actually wired to this module ─────────────────────
+//
+// Everything above tests a module the panel could simply stop calling. Deleting
+// the wiring in comfyui-mcp-panel.js would leave every assertion in this file
+// green while the shipped panel went back to answering {ok:true,count:N} — so
+// the wiring is asserted against the real source, the way manager-install.test
+// already does for the install runtime.
+
+const panelSource = () =>
+  readFileSync(fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)), "utf8");
+
+test("the show_media dispatcher answers with the handler's reply, not a fixed acknowledgement", () => {
+  const src = panelSource();
+  assert.match(
+    src,
+    /import \{ composeShowMediaReply \} from "\.\/lib\/media-preview\.js";/,
+    "the panel must import the reply composer",
+  );
+  const i = src.indexOf('msg.cmd === "show_media"');
+  assert.ok(i > 0, "could not locate the show_media dispatcher branch");
+  const branch = src.slice(i, i + 1600);
+  assert.match(
+    branch,
+    /result = \(await onShowMedia\?\.\(mediaItems\)\)/,
+    "the reply must be AWAITED from the handler — a preview is real work",
+  );
+});
+
+test("onShowMedia routes through composeShowMediaReply with the storyboard pipeline wired", () => {
+  const src = panelSource();
+  const handler = src.match(/onShowMedia\(items\) \{[\s\S]*?\n {4}\},/);
+  assert.ok(handler, "could not locate the onShowMedia handler");
+  assert.match(handler[0], /return composeShowMediaReply\(items, \{/);
+  for (const dep of [
+    "paintImage",
+    "paintVideo",
+    "imageViewUrl",
+    "buildVideoStoryboard",
+    "uploadBlobToInput",
+    "storyboardFrameCount",
+    "humanizeBytes",
+    "fetchMediaBytes: fetchImageBytes",
+    "videoStoryboardEnabled",
+  ]) {
+    assert.ok(handler[0].includes(dep), `onShowMedia must pass ${dep} through`);
+  }
+  assert.doesNotMatch(
+    handler[0],
+    /paintVideo\(url, caption\)/,
+    "the handler must not keep its own painting loop — that is the drift this fix removes",
+  );
+});
+
+// ── the shared bound is itself a guard that can fail ───────────────────────
+
+test("withTimeout resolves the value when the bounded step wins", async () => {
+  const timers = [];
+  const v = await withTimeout(Promise.resolve("ok"), 1000, () => "late", {
+    setTimer: (fn) => {
+      const t = { fn, cleared: false };
+      timers.push(t);
+      return t;
+    },
+    clearTimer: (t) => {
+      t.cleared = true;
+    },
+  });
+  assert.equal(v, "ok");
+  assert.equal(timers[0].cleared, true, "the timer must be cleared on settle so it cannot leak");
+});
+
+test("withTimeout falls back when the bounded step REJECTS", async () => {
+  const v = await withTimeout(Promise.reject(new Error("nope")), 1000, () => "fallback", {
+    setTimer: () => ({}),
+    clearTimer: () => {},
+  });
+  assert.equal(v, "fallback");
+});
+
+test("withTimeout still settles when onTimeout THROWS — a guard that wedges is not a guard", async () => {
+  let fire;
+  const p = withTimeout(
+    new Promise(() => {}),
+    1000,
+    () => {
+      throw new Error("the fallback itself failed");
+    },
+    {
+      setTimer: (fn) => {
+        fire = fn;
+        return {};
+      },
+      clearTimer: () => {},
+    },
+  );
+  fire();
+  assert.equal(await p, undefined);
+});
+
+test("withTimeout still settles when clearTimer THROWS", async () => {
+  const v = await withTimeout(Promise.resolve("ok"), 1000, () => "late", {
+    setTimer: () => ({}),
+    clearTimer: () => {
+      throw new Error("clear blew up");
+    },
+  });
+  assert.equal(v, "ok");
+});
+
+test("withTimeout still settles when setTimer THROWS (unbounded, but never rejecting)", async () => {
+  const v = await withTimeout(Promise.resolve("ok"), 1000, () => "late", {
+    setTimer: () => {
+      throw new Error("no timers available");
+    },
+    clearTimer: () => {},
+  });
+  assert.equal(v, "ok");
+});
+
+test("withTimeout with a non-positive bound is a passthrough", async () => {
+  assert.equal(await withTimeout(Promise.resolve(7), 0, () => 8, {}), 7);
+});
+
+test("a late fulfilment after the bound fired does not overwrite the fallback", async () => {
+  let fire;
+  let settle;
+  const p = withTimeout(
+    new Promise((res) => {
+      settle = res;
+    }),
+    1000,
+    () => "fallback",
+    {
+      setTimer: (fn) => {
+        fire = fn;
+        return {};
+      },
+      clearTimer: () => {},
+    },
+  );
+  fire();
+  settle("too late");
+  assert.equal(await p, "fallback");
+});

--- a/browser_tests/unit/media-preview.test.mjs
+++ b/browser_tests/unit/media-preview.test.mjs
@@ -389,6 +389,44 @@ test("a painter that settles LATER is reported unconfirmed, not counted as shown
   await new Promise((r) => setImmediate(r));
 });
 
+test("the STORYBOARD SHEET's painter is guarded exactly like the batch pass's", async () => {
+  // A second, hand-rolled painter call is how this one ended up unguarded: it
+  // could reject after the fact, producing an unhandled rejection and a reply
+  // that quietly implied the user could see the sheet.
+  const rejections = [];
+  const onUnhandled = (err) => rejections.push(err);
+  process.on("unhandledRejection", onUnhandled);
+  try {
+    const h = harness({ paintImage: () => Promise.reject(new Error("sheet DOM failure")) });
+    const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+    assert.equal(reply.previews.length, 1, "the agent's own copy is unaffected");
+    assert.match(reply.note, /could not be confirmed as shown/);
+    assert.match(reply.note, /Your own copy, below, is unaffected/);
+    await new Promise((r) => setImmediate(r));
+    assert.deepEqual(rejections, [], "a deferred painter must not surface as an unhandled rejection");
+  } finally {
+    process.off("unhandledRejection", onUnhandled);
+  }
+});
+
+test("a sheet painter that THROWS is disclosed and still leaves the agent its copy", async () => {
+  const h = harness({
+    paintImage: () => {
+      throw new Error("DOM exploded");
+    },
+  });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+  assert.equal(reply.previews.length, 1);
+  assert.match(reply.note, /could not be shown\s+in the chat/);
+  assert.match(reply.note, /call get_image with filename "storyboard_reference_clip\.png"/);
+});
+
+test("a sheet that IS painted carries no visibility caveat", async () => {
+  const h = harness({ fetchMediaBytes: async () => OVERSIZED_BYTES });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+  assert.doesNotMatch(reply.note, /could not be (shown|confirmed as shown)/);
+});
+
 test("two videos are previewed independently — one wedged does not suppress the other", async () => {
   const second = { ...VIDEO_REF, viewRef: { ...VIDEO_REF.viewRef, filename: "other.mp4" } };
   const h = harness({
@@ -437,14 +475,29 @@ test("dataUrlByteLength reads the payload exactly, and refuses to guess otherwis
   assert.equal(dataUrlByteLength("/view?filename=a.mp4"), null, "not a data URL ⇒ unknown");
   assert.equal(dataUrlByteLength("data:video/mp4,raw"), null, "not base64 ⇒ unknown");
   assert.equal(dataUrlByteLength(null), null);
+  // UNPADDED bodies are legal in a data URL and the browser decodes them, so
+  // calling them unknown would be its own dishonesty in the other direction.
+  assert.equal(dataUrlByteLength("data:video/mp4;base64,AAA"), 2);
+  assert.equal(dataUrlByteLength("data:video/mp4;base64,AA"), 1);
+  assert.equal(dataUrlByteLength("data:video/mp4;base64,AAAAAA"), 4);
+  assert.equal(dataUrlByteLength("data:video/mp4;base64,AAAAA"), null, "trailing 1-char group");
+  // Cross-check the whole table against a real base64 decoder.
+  for (const body of ["AAAA", "AAA=", "AA==", "AAA", "AA", "AAAAAA"]) {
+    assert.equal(
+      dataUrlByteLength(`data:video/mp4;base64,${body}`),
+      Buffer.from(body, "base64").length,
+      `payload "${body}" must measure what it actually decodes to`,
+    );
+  }
   // MALFORMED payloads must be unknown, not measured. The arithmetic is happy
   // to measure nonsense, and a measured nonsense payload told the agent the
   // source video was a few bytes — an invented size.
-  assert.equal(dataUrlByteLength("data:video/mp4;base64,A"), null, "1 char is not a base64 group");
-  assert.equal(dataUrlByteLength("data:video/mp4;base64,AAA"), null, "3 chars is not a base64 group");
+  assert.equal(dataUrlByteLength("data:video/mp4;base64,A"), null, "1 char encodes nothing");
   assert.equal(dataUrlByteLength("data:video/mp4;base64,!!!!"), null, "not the base64 alphabet");
   assert.equal(dataUrlByteLength("data:video/mp4;base64,A==="), null, "3 pad chars is not base64");
   assert.equal(dataUrlByteLength("data:video/mp4;base64,AA=A"), null, "padding is trailing-only");
+  assert.equal(dataUrlByteLength("data:video/mp4;base64,AAAA="), null, "padding must complete a group");
+  assert.equal(dataUrlByteLength("data:video/mp4;base64,AAAA=="), null, "a full group needs no padding");
   assert.equal(dataUrlByteLength("data:video/mp4;base64,ab-_"), null, "base64url is not decoded here");
 });
 

--- a/browser_tests/unit/media-preview.test.mjs
+++ b/browser_tests/unit/media-preview.test.mjs
@@ -307,6 +307,34 @@ test("a failed sheet upload degrades with a reason and a remedy", async () => {
   assert.match(reply.note, /call get_image with filename "reference_clip\.mp4"/);
 });
 
+test("a truthy-but-UNRETRIEVABLE sheet ref is not announced as a preview", async () => {
+  // uploadBlobToInput builds {filename: info.name, …}, so an /upload/image
+  // response without `name` yields a truthy object with no filename. Announcing
+  // a preview and telling the agent to fetch `filename ""` is a remedy that
+  // cannot be followed — worse than saying the preview failed.
+  for (const bad of [{}, { filename: "" }, { filename: "   " }, { filename: null }]) {
+    const h = harness({ uploadBlobToInput: async () => bad });
+    const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+    assert.equal(reply.previews.length, 0, `announced a preview for ${JSON.stringify(bad)}`);
+    assert.match(reply.note, /came back with no filename/);
+    assert.doesNotMatch(reply.note, /SAMPLED PREVIEW/);
+    assert.doesNotMatch(reply.note, /filename ""/);
+    // …and it still ends somewhere the caller can go.
+    assert.match(reply.note, /call get_image with filename "reference_clip\.mp4"/);
+  }
+});
+
+test("a URL builder that RETURNS nothing is the same failure as one that throws", async () => {
+  // Keyed on the outcome, not on whether it threw: "carried neither inline data
+  // nor a ComfyUI reference" is false when the reference is right there, and it
+  // tells the caller to re-send something it already sent correctly.
+  const h = harness({ imageViewUrl: () => null });
+  const reply = await composeShowMediaReply([VIDEO_REF], h.deps);
+  assert.match(reply.note, /could not build a view URL for its ComfyUI reference/);
+  assert.doesNotMatch(reply.note, /carried neither inline data/);
+  assert.match(reply.note, /call get_image with filename "reference_clip\.mp4", type "input"/);
+});
+
 test("a sheet whose SAMPLE count is unknown is NOT offered as an N-frame sample", async () => {
   // A sheet exists, but the builder did not say how many cells it drew into.
   // Quoting the grid capacity instead would invent observations from blank
@@ -997,6 +1025,29 @@ test("a THROWING setTimer must not silently REMOVE the bound", async () => {
 
 test("withTimeout with a non-positive bound is a passthrough", async () => {
   assert.equal(await withTimeout(Promise.resolve(7), 0, () => 8, {}), 7);
+});
+
+test("firing the bound clears the timer it holds, so two timers are never left pending", async () => {
+  // The arm-then-throw case leaks the injected timer irrecoverably (its handle
+  // was never returned). Whichever timer fires first must at least clear the
+  // other, or the leak is two rather than one.
+  let injected;
+  let cleared = 0;
+  const v = await withTimeout(new Promise(() => {}), 1000, () => "fallback", {
+    setTimer: (fn) => {
+      injected = fn;
+      throw new Error("armed, then threw");
+    },
+    clearTimer: () => {
+      cleared += 1;
+    },
+  });
+  assert.equal(v, "fallback");
+  assert.equal(typeof injected, "function", "the thrower still captured the callback");
+  // The platform fallback is what resolved; firing the leaked injected timer now
+  // must be a no-op rather than a second resolution.
+  injected();
+  assert.equal(await withTimeout(Promise.resolve("x"), 0, () => "y", {}), "x");
 });
 
 test("a late fulfilment after the bound fired does not overwrite the fallback", async () => {

--- a/browser_tests/unit/module-graph-link.test.mjs
+++ b/browser_tests/unit/module-graph-link.test.mjs
@@ -22,6 +22,14 @@ import {
 } from "../../web/js/lib/asset-staleness.js";
 import { assertAddNodeResolvableRefreshing } from "../../web/js/lib/node-resolve.js";
 import { runSetWidget } from "../../web/js/lib/set-widget.js";
+import { composeShowMediaReply } from "../../web/js/lib/media-preview.js";
+import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame.js";
+
+// --- Mirror the shared bounded-step edge (#648) --------------------------------------
+// run-completion-frame.js and media-preview.js BOTH import withTimeout from here. If
+// that export is renamed or dropped, the completion frame and every video preview stop
+// linking — and neither has a syntax error to catch it.
+import { withTimeout } from "../../web/js/lib/bounded-step.js";
 
 // --- Mirror set-widget.js imports (the fix's internal module edges) -----------------
 import {
@@ -45,6 +53,12 @@ test("panel ↔ asset-staleness.js module edge links (incl. refreshComboOptionsF
 test("panel ↔ node-resolve.js / set-widget.js module edges link", () => {
   assert.equal(typeof assertAddNodeResolvableRefreshing, "function");
   assert.equal(typeof runSetWidget, "function");
+});
+
+test("panel ↔ media-preview.js / run-completion-frame.js ↔ bounded-step.js edges link (#648)", () => {
+  assert.equal(typeof composeShowMediaReply, "function");
+  assert.equal(typeof composeRunCompletionFrame, "function");
+  assert.equal(typeof withTimeout, "function");
 });
 
 test("set-widget.js ↔ widget-write.js / node-resolve.js module edges link", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -276,6 +276,7 @@ import {
 } from "./lib/workflow-save.js";
 import { createRunCompletionTracker } from "./lib/run-completion.js";
 import { composeRunCompletionFrame } from "./lib/run-completion-frame.js";
+import { composeShowMediaReply } from "./lib/media-preview.js";
 import { readyAckCanPromoteBackend } from "./lib/pi-readiness.js";
 import { createRunReconcileSweep } from "./lib/run-reconcile-sweep.js";
 import {
@@ -12988,9 +12989,19 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           } else if (msg.cmd === "show_media") {
             // Render agent-requested media (images/videos) into the chat.
             // items: [{ kind: "image"|"video"|"viewRef", dataUrl?, viewRef?, filename, caption? }]
+            //
+            // #648 — the reply is now the handler's, not a fixed {ok,count}. It
+            // paints for the user AND tells the AGENT what it did not receive:
+            // a video is answered with a bounded sampled contact sheet plus the
+            // disclosure that the sheet is samples, not the video. Awaited,
+            // because that preview is real work; a handler that returns nothing
+            // (or is absent) still gets the original acknowledgement, so an older
+            // wiring degrades to exactly the previous behaviour.
             const mediaItems = Array.isArray(msg.items) ? msg.items : [];
-            onShowMedia?.(mediaItems);
-            result = { ok: true, count: mediaItems.length };
+            result = (await onShowMedia?.(mediaItems)) ?? {
+              ok: true,
+              count: mediaItems.length,
+            };
           } else if (msg.cmd === "open_civitai") {
             // Agent opens the CivitAI browser pre-seeded with a query + filters so
             // the user can visually pick a resource.
@@ -19905,22 +19916,29 @@ function buildPanel() {
     onTodo(items) {
       renderTodo(items);
     },
-    // The agent called panel_show_media — render images/videos directly in the chat.
+    // The agent called panel_show_media — render images/videos directly in the
+    // chat AND answer the agent honestly about what it was handed (#648).
+    //
+    // This used to paint and return nothing, so the tool replied {ok:true} to an
+    // agent that had been shown nothing. For a video that reads as "I have seen
+    // it"; over the orchestrator's inline ceiling it reads as "this is
+    // impossible". composeShowMediaReply paints exactly as before and then routes
+    // every video through the panel's EXISTING storyboard pipeline — bounded, and
+    // disclosed as a sample rather than as the video.
     onShowMedia(items) {
-      for (const item of items) {
-        const caption = coerceMessageText(item.caption) || coerceMessageText(item.filename) || "";
-        if (item.kind === "viewRef" && item.viewRef) {
-          const url = imageViewUrl(item.viewRef);
-          // Determine if ComfyUI ref is a video by extension
-          const isVid = /.(mp4|webm)$/i.test(item.viewRef.filename || "");
-          if (isVid) paintVideo(url, caption);
-          else paintImage(url, caption);
-        } else if (item.kind === "video" && item.dataUrl) {
-          paintVideo(item.dataUrl, caption);
-        } else if (item.dataUrl) {
-          paintImage(item.dataUrl, caption);
-        }
-      }
+      return composeShowMediaReply(items, {
+        paintImage,
+        paintVideo,
+        imageViewUrl,
+        coerceMessageText,
+        buildVideoStoryboard,
+        uploadBlobToInput,
+        storyboardFrameCount,
+        humanizeBytes,
+        fetchMediaBytes: fetchImageBytes,
+        videoStoryboardEnabled: prefs.videoStoryboard !== false,
+        warn: (...a) => console.warn(...a),
+      });
     },
     // The agent called panel_open_civitai — open the CivitAI browser pre-seeded
     // with a query + suggested filters so the user can visually pick a resource.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -4237,7 +4237,20 @@ async function buildVideoStoryboard(url) {
     if (!painted) return null;
 
     const blob = await new Promise((resolve) => canvas.toBlob(resolve, "image/png"));
-    return blob || null;
+    if (!blob) return null;
+    // #648 — the grid has COLS*ROWS CELLS, but a video with unseekable frames
+    // paints fewer and leaves the rest blank. storyboardFrameCount() reports the
+    // capacity, not the sample count, so a caller reading only that would tell
+    // the agent it is looking at 20 samples when it is looking at 1 sample and
+    // 19 empty cells. Carry the count that was actually drawn; callers that
+    // describe the sheet must use THIS.
+    try {
+      blob.paintedFrames = painted;
+    } catch {
+      // A Blob implementation that refuses extra properties leaves the count
+      // absent, which callers must treat as unknown — never as the capacity.
+    }
+    return blob;
   } catch {
     return null; // decode/seek/metadata failure → caller falls back to video-only
   } finally {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -13003,17 +13003,33 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // Render agent-requested media (images/videos) into the chat.
             // items: [{ kind: "image"|"video"|"viewRef", dataUrl?, viewRef?, filename, caption? }]
             //
-            // #648 — the reply is now the handler's, not a fixed {ok,count}. It
+            // #648 — the reply is the handler's, not a fixed {ok,count}. It
             // paints for the user AND tells the AGENT what it did not receive:
             // a video is answered with a bounded sampled contact sheet plus the
             // disclosure that the sheet is samples, not the video. Awaited,
-            // because that preview is real work; a handler that returns nothing
-            // (or is absent) still gets the original acknowledgement, so an older
-            // wiring degrades to exactly the previous behaviour.
+            // because that preview is real work.
+            //
+            // The absent/empty cases are NOT success. The handler is the thing
+            // that paints and that composes the disclosure, so without it
+            // nothing was displayed and nothing was sampled — and the old
+            // `{ok:true, count: msg.items.length}` fallback would hand the agent
+            // the exact dead-end acknowledgement this fix exists to remove,
+            // counting the REQUEST as though it were the delivery. An absent
+            // handler throws (the same shape every other unwireable command in
+            // this dispatcher uses); a handler that returns nothing reports the
+            // delivery as UNKNOWN rather than as done.
+            if (!onShowMedia) throw new Error("This panel build can't display media.");
             const mediaItems = Array.isArray(msg.items) ? msg.items : [];
-            result = (await onShowMedia?.(mediaItems)) ?? {
-              ok: true,
-              count: mediaItems.length,
+            const mediaReply = await onShowMedia(mediaItems);
+            result = mediaReply ?? {
+              ok: false,
+              requested: mediaItems.length,
+              delivered: "unknown",
+              note:
+                `The panel's media handler returned nothing, so what reached the chat is UNKNOWN. ` +
+                `Do not assume the user saw ${mediaItems.length === 1 ? "this file" : "these files"}, ` +
+                `and do not assume you were shown anything — this tool never sends media to you. ` +
+                `If you need to see a file yourself, call get_image with its ComfyUI filename/type/subfolder.`,
             };
           } else if (msg.cmd === "open_civitai") {
             // Agent opens the CivitAI browser pre-seeded with a query + filters so

--- a/web/js/lib/bounded-step.js
+++ b/web/js/lib/bounded-step.js
@@ -62,26 +62,37 @@ export function withTimeout(promise, ms, onTimeout, timers = {}) {
       }
     };
     let t;
+    let clear = clearTimer;
     const done = (v) => {
       if (settled) return;
       settled = true;
       try {
-        clearTimer(t);
+        clear(t);
       } catch {
         // A leaked timer is a leak; a throw here would be a wedge. Prefer the leak.
       }
       resolve(v);
     };
+    const fire = () => {
+      if (settled) return;
+      settled = true;
+      resolve(fallback());
+    };
     try {
-      t = setTimer(() => {
-        if (settled) return;
-        settled = true;
-        resolve(fallback());
-      }, ms);
+      t = setTimer(fire, ms);
     } catch {
-      // No timer could be armed, so this step is UNBOUNDED — but a throw out of
-      // the executor would reject, and this helper's whole contract is that it
-      // does not. Fall through: the result still arrives via the chain below.
+      // An injected timer that cannot arm must not silently REMOVE the bound —
+      // that turns "bounded, degrades" into "pending forever", which is the one
+      // outcome this helper exists to prevent. Fall back to the platform timer
+      // (and its matching clear, since the injected pair no longer owns it).
+      try {
+        t = setTimeout(fire, ms);
+        clear = (h) => clearTimeout(h);
+      } catch {
+        // No timer source at all. This step is genuinely UNBOUNDED — stated
+        // rather than papered over — but the helper still never rejects: the
+        // result arrives via the chain below if it ever arrives.
+      }
     }
     promise.then(done, () => done(fallback()));
   });

--- a/web/js/lib/bounded-step.js
+++ b/web/js/lib/bounded-step.js
@@ -85,6 +85,12 @@ export function withTimeout(promise, ms, onTimeout, timers = {}) {
       // that turns "bounded, degrades" into "pending forever", which is the one
       // outcome this helper exists to prevent. Fall back to the platform timer
       // (and its matching clear, since the injected pair no longer owns it).
+      //
+      // Stated plainly: if `setTimer` ARMED a timer and then threw, that timer
+      // is leaked — its handle was never returned, so nothing can clear it. The
+      // result is still correct (`fire` is idempotent via `settled`, so the late
+      // timer resolves nothing), and the cost is one stray timer. There is no
+      // way to recover a handle a thrower never yielded.
       try {
         t = setTimeout(fire, ms);
         clear = (h) => clearTimeout(h);

--- a/web/js/lib/bounded-step.js
+++ b/web/js/lib/bounded-step.js
@@ -76,6 +76,14 @@ export function withTimeout(promise, ms, onTimeout, timers = {}) {
     const fire = () => {
       if (settled) return;
       settled = true;
+      // Clear whichever timer we hold a handle for. In the arm-then-throw case
+      // below this is the FALLBACK timer, fired by the leaked one — without this
+      // both were left pending.
+      try {
+        clear(t);
+      } catch {
+        /* see done(): a leaked timer beats a wedge */
+      }
       resolve(fallback());
     };
     try {
@@ -86,11 +94,12 @@ export function withTimeout(promise, ms, onTimeout, timers = {}) {
       // outcome this helper exists to prevent. Fall back to the platform timer
       // (and its matching clear, since the injected pair no longer owns it).
       //
-      // Stated plainly: if `setTimer` ARMED a timer and then threw, that timer
-      // is leaked — its handle was never returned, so nothing can clear it. The
-      // result is still correct (`fire` is idempotent via `settled`, so the late
-      // timer resolves nothing), and the cost is one stray timer. There is no
-      // way to recover a handle a thrower never yielded.
+      // Stated plainly: if `setTimer` ARMED a timer and then threw, THAT timer
+      // is leaked — its handle was never returned, so nothing can clear it, and
+      // there is no way to recover a handle a thrower never yielded. The result
+      // is still correct (`fire` and `done` are both idempotent via `settled`),
+      // and whichever of the two fires first now clears the other, so the cost
+      // is exactly one stray timer rather than two.
       try {
         t = setTimeout(fire, ms);
         clear = (h) => clearTimeout(h);

--- a/web/js/lib/bounded-step.js
+++ b/web/js/lib/bounded-step.js
@@ -1,0 +1,88 @@
+// ONE bounded-step primitive, shared by every panel path that must not be
+// suspended by an I/O step that can fail to settle.
+//
+// Extracted (not re-written) from run-completion-frame.js, where it was private.
+// The oversized-media preview path (#648) runs the SAME storyboard pipeline —
+// sample frames, upload the sheet, HEAD its size — and therefore needs the SAME
+// bound. A second timeout helper written alongside the first is how this repo
+// keeps producing near-duplicate bugs, so there is one here and both callers
+// import it.
+//
+// WHAT IT GUARANTEES
+//
+//   - The returned promise ALWAYS settles, and always fulfils: it never rejects.
+//     A rejected `promise` degrades through `onTimeout()` exactly as a timeout
+//     does, because both mean "the bounded step did not produce a result".
+//   - It settles at most once. A late fulfilment after the bound has fired is
+//     dropped, not raced against the fallback.
+//   - The timer is cleared on settle, so a long-lived page cannot accumulate
+//     pending timers per bounded step.
+//   - A non-positive `ms` disables the bound and returns `promise` unchanged.
+//
+// WHAT IT DELIBERATELY DOES NOT DO
+//
+//   It does not CANCEL the work it bounds. `buildVideoStoryboard` keeps decoding
+//   and `uploadBlobToInput` keeps fetching after the bound fires; the bound only
+//   stops the caller waiting on them. That is the intended contract — the caller
+//   is composing a reply, not managing the pipeline's lifetime.
+//
+// EVERY GUARD IS ITSELF AN OPERATION THAT CAN FAIL
+//
+// `onTimeout()` and `clearTimer()` are injected, so both can throw. In the
+// original private version a throw from either left the outer promise pending
+// FOREVER — the exact failure the bound exists to prevent, reintroduced by the
+// bound itself. Both are therefore called inside a catch here. When `onTimeout`
+// throws there is no fallback value to report, so the step resolves `undefined`
+// and the caller's own "no segment" branch handles it; that is strictly better
+// than never resolving. This is the ONLY behavioural difference from the
+// extracted original, and it cannot change any case where neither throws.
+
+/**
+ * Resolve `promise`, but if it has not settled within `ms`, resolve with
+ * `onTimeout()` instead.
+ *
+ * @param {Promise<any>} promise      the bounded step
+ * @param {number} ms                 wall-clock bound; <= 0 disables it
+ * @param {() => any} onTimeout       fallback value factory (must be cheap + sync)
+ * @param {{setTimer?:Function, clearTimer?:Function}} [timers] injectable for tests
+ * @returns {Promise<any>} never rejects
+ */
+export function withTimeout(promise, ms, onTimeout, timers = {}) {
+  const setTimer = timers.setTimer ?? ((fn, delay) => setTimeout(fn, delay));
+  const clearTimer = timers.clearTimer ?? ((t) => clearTimeout(t));
+  if (!(ms > 0)) return promise;
+  return new Promise((resolve) => {
+    let settled = false;
+    // Never let the fallback factory's own failure become "hangs forever".
+    const fallback = () => {
+      try {
+        return onTimeout();
+      } catch {
+        return undefined;
+      }
+    };
+    let t;
+    const done = (v) => {
+      if (settled) return;
+      settled = true;
+      try {
+        clearTimer(t);
+      } catch {
+        // A leaked timer is a leak; a throw here would be a wedge. Prefer the leak.
+      }
+      resolve(v);
+    };
+    try {
+      t = setTimer(() => {
+        if (settled) return;
+        settled = true;
+        resolve(fallback());
+      }, ms);
+    } catch {
+      // No timer could be armed, so this step is UNBOUNDED — but a throw out of
+      // the executor would reject, and this helper's whole contract is that it
+      // does not. Fall through: the result still arrives via the chain below.
+    }
+    promise.then(done, () => done(fallback()));
+  });
+}

--- a/web/js/lib/media-preview.js
+++ b/web/js/lib/media-preview.js
@@ -151,6 +151,27 @@ function sheetClause(frames, cells) {
 }
 
 /**
+ * Whether the surviving frames are actually spread across the video.
+ *
+ * The builder aims at evenly-spaced timestamps but SKIPS the ones it cannot
+ * seek, so a sheet missing cells is not a sample of the whole video — the
+ * frames it does hold may all sit near the start. Calling those "evenly-spaced
+ * samples across the video" claims coverage that was not observed, which is the
+ * same fabrication as calling the sheet the video, one level down. Only a sheet
+ * whose every planned cell was filled may claim even spacing.
+ */
+function spacingClause(frames, cells) {
+  if (Number.isFinite(cells) && frames === cells) {
+    return `Those ${frames} frames are evenly-spaced SAMPLES across the video`;
+  }
+  return (
+    `Those ${frames} frames are SAMPLES taken at whichever of the planned, evenly-spaced ` +
+    `positions could be seeked — the ones that survived may be CLUSTERED rather than spread ` +
+    `across the video, so do not assume they cover it`
+  );
+}
+
+/**
  * Call a painter without letting it throw OR reject.
  *
  * Returns "shown", "failed", or "unconfirmed". A painter that settles later
@@ -167,13 +188,23 @@ function safePaint(paint, url, caption, warn, what) {
     warn("[cmcp] show_media: painting failed for", what, err);
     return "failed";
   }
-  if (outcome && typeof outcome.then === "function") {
-    outcome.then(null, (err) =>
-      warn("[cmcp] show_media: a deferred painter rejected for", what, err),
-    );
+  // Reading and calling `.then` are themselves operations that can fail — a
+  // getter that throws, or a thenable whose `then` throws — and doing either
+  // outside the guard rejected the whole reply, which is the failure this
+  // helper exists to prevent.
+  let deferred = false;
+  try {
+    deferred = !!outcome && typeof outcome.then === "function";
+    if (deferred) {
+      outcome.then(null, (err) =>
+        warn("[cmcp] show_media: a deferred painter rejected for", what, err),
+      );
+    }
+  } catch (err) {
+    warn("[cmcp] show_media: a painter's own thenable threw for", what, err);
     return "unconfirmed";
   }
-  return "shown";
+  return deferred ? "unconfirmed" : "shown";
 }
 
 /** A ComfyUI ref written the way `get_image` takes its arguments. */
@@ -239,18 +270,22 @@ export async function composeShowMediaReply(items, deps = {}) {
   const list = Array.isArray(items) ? items : [];
   const jobs = [];
   let painted = 0;
-  let unrendered = 0;
   let unconfirmed = 0;
+  /** Items the user cannot see, each with the REASON it is missing. */
+  const dropped = [];
 
   // ── Paint pass ──────────────────────────────────────────────────────────
   // One item's painter throwing must not cost the whole batch its reply, and
   // must not be counted as painted — an item silently dropped is exactly the
-  // kind of thing the reply has to be honest about.
+  // kind of thing the reply has to be honest about. Each drop carries its own
+  // reason: "no usable source" is one specific cause, and using it for every
+  // cause sends the caller to re-send a file that was perfectly resolvable.
   for (const item of list) {
     const caption = text(item?.caption) || text(item?.filename) || "";
     const isVideo = isVideoShowMediaItem(item, text);
     let url = null;
     let ref = null;
+    let why = null;
     let name = text(item?.filename);
     if (item?.kind === "viewRef" && item?.viewRef) {
       ref = item.viewRef;
@@ -260,21 +295,34 @@ export async function composeShowMediaReply(items, deps = {}) {
       } catch (err) {
         note("[cmcp] show_media: could not build a view URL for", name, err);
         url = null;
+        why = "the panel could not build a view URL for its ComfyUI reference";
       }
     } else if (typeof item?.dataUrl === "string" && item.dataUrl) {
       url = item.dataUrl;
     }
     if (!url) {
-      unrendered += 1;
+      dropped.push({
+        name,
+        why:
+          why ??
+          "no usable source — it carried neither inline data nor a ComfyUI reference with a filename; re-send it as an absolute path or as such a reference",
+      });
       continue;
     }
     const shownState = safePaint(isVideo ? paintVideo : paintImage, url, caption, note, name);
     if (shownState === "failed") {
-      unrendered += 1;
-      continue;
+      dropped.push({
+        name,
+        why:
+          "the panel's own painter failed while putting it in the chat (the file itself resolved fine, so re-sending it unchanged will not help)",
+      });
+    } else if (shownState === "unconfirmed") {
+      unconfirmed += 1;
+    } else {
+      painted += 1;
     }
-    if (shownState === "unconfirmed") unconfirmed += 1;
-    else painted += 1;
+    // A video's sampled preview needs only the URL — not the chat player — so a
+    // painter failure must NOT also cost the agent its preview.
     if (isVideo) {
       jobs.push({
         url,
@@ -333,11 +381,11 @@ export async function composeShowMediaReply(items, deps = {}) {
     ` — this tool renders media for the person, not for you.`;
   noteSections.push(headline);
 
-  if (unrendered > 0) {
+  if (dropped.length > 0) {
     noteSections.push(
-      `${unrendered} of the ${list.length} requested item(s) could not be rendered at all ` +
-        `(no usable source), so the user did not see ${unrendered === 1 ? "it" : "them"} either. ` +
-        `Re-send ${unrendered === 1 ? "it" : "them"} as an absolute path or as a ComfyUI reference with a filename.`,
+      `${dropped.length} of the ${list.length} requested item(s) were NOT displayed, so the user ` +
+        `cannot see ${dropped.length === 1 ? "it" : "them"} either:\n` +
+        dropped.map((d) => `• ${d.name || "(unnamed item)"} — ${d.why}`).join("\n"),
     );
   }
 
@@ -500,7 +548,7 @@ async function buildSampledPreview(job, deps) {
     note:
       `📽️ ${job.name} — you were NOT shown this video. What exists for you is a SAMPLED PREVIEW of it: ` +
       `${sheetClause(n, cells)}, built in the browser (its ${size}). ` +
-      `Those ${n} frames are evenly-spaced SAMPLES across the video — they are NOT its frame count, ` +
+      `${spacingClause(n, cells)} — they are NOT its frame count, ` +
       `its duration, or its frame rate, so do not describe the video as ${n} frames long, and do not ` +
       `report anything about it that a ${n}-frame sample cannot show (audio, timing, brief events). ` +
       `Cells read left to right, top to bottom = start to end. ` +

--- a/web/js/lib/media-preview.js
+++ b/web/js/lib/media-preview.js
@@ -135,16 +135,23 @@ function sizeClause(sizeBytes, humanizeBytes) {
  * How to describe the sheet's cells truthfully.
  *
  * `cells` is the grid's capacity; `frames` is how many of them a frame was
- * actually drawn into. They differ whenever a seek failed, and reporting the
- * capacity as the sample count is a fabricated observation of exactly the kind
- * this module exists to prevent — so when they differ, both are stated.
+ * actually drawn into. They differ whenever a cell could not be filled, and
+ * reporting the capacity as the sample count is a fabricated observation of
+ * exactly the kind this module exists to prevent — so when they differ, both
+ * are stated.
+ *
+ * The REASON a cell is blank is deliberately not named. The builder skips a
+ * cell when a seek fails AND when the draw fails after a successful seek, and
+ * it does not distinguish the two — so "could not be seeked" would be a
+ * fabricated diagnosis in the second case, handed to an agent that will repeat
+ * it. "Could not be captured" is what is actually known.
  */
 function sheetClause(frames, cells) {
   if (Number.isFinite(cells) && cells > frames) {
     const blank = cells - frames;
     return (
       `a contact sheet of ${cells} cells, ${frames} of which hold a sampled frame ` +
-      `(the other ${blank} could not be seeked and are blank — judge nothing from them)`
+      `(the other ${blank} could not be captured and are blank — judge nothing from them)`
     );
   }
   return `a ${frames}-frame contact sheet`;
@@ -166,7 +173,7 @@ function spacingClause(frames, cells) {
   }
   return (
     `Those ${frames} frames are SAMPLES taken at whichever of the planned, evenly-spaced ` +
-    `positions could be seeked — the ones that survived may be CLUSTERED rather than spread ` +
+    `positions could be captured — the ones that survived may be CLUSTERED rather than spread ` +
     `across the video, so do not assume they cover it`
   );
 }
@@ -568,7 +575,7 @@ async function produceSheet(job, deps) {
         ref: null,
         frames: null,
         cells: null,
-        why: "its frames could not be decoded or seeked in this browser",
+        why: "not one of its frames could be decoded, seeked and painted in this browser",
       };
     }
     const base = job.name.replace(/\.[^.]+$/, "") || "video";

--- a/web/js/lib/media-preview.js
+++ b/web/js/lib/media-preview.js
@@ -66,8 +66,20 @@ export const MEDIA_SIZE_PROBE_TIMEOUT_MS = 8000;
  * video. Widened past mp4/webm because a ComfyUI /view ref can name anything on
  * disk; the orchestrator's own inline path is stricter, which is fine, this only
  * has to decide "try to sample frames from it".
+ *
+ * Anchored at the end, so it is applied to the filename with any query string or
+ * fragment removed FIRST (see videoFilenameStem). A ref whose filename arrives
+ * as `clip.mp4?download=1` is a video; classifying it as an image skips the
+ * storyboard and the whole sampled-preview disclosure for a legitimate video,
+ * which is the failure this module exists to prevent, reached by a different
+ * route than the unescaped dot.
  */
 const VIDEO_FILENAME = /\.(?:mp4|webm|mov|m4v|mkv|avi)$/i;
+
+/** The filename with a `?query` / `#fragment` tail removed. */
+function videoFilenameStem(filename) {
+  return String(filename).split("#")[0].split("?")[0];
+}
 
 const defaultCoerce = (v) => (typeof v === "string" ? v : v == null ? "" : String(v));
 
@@ -76,7 +88,7 @@ export function isVideoShowMediaItem(item, coerce = defaultCoerce) {
   if (!item) return false;
   if (item.kind === "video") return true;
   if (item.kind === "viewRef" && item.viewRef) {
-    return VIDEO_FILENAME.test(coerce(item.viewRef.filename));
+    return VIDEO_FILENAME.test(videoFilenameStem(coerce(item.viewRef.filename)));
   }
   return false;
 }
@@ -92,14 +104,25 @@ export function isVideoShowMediaItem(item, coerce = defaultCoerce) {
  * Both would have told the agent the source file was a few bytes — an invented
  * size, and precisely the "unknown reported as a value" failure this module
  * exists to avoid. Anything that does not decode cleanly is null, i.e. unknown.
+ *
+ * NOTHING IS NORMALISED THAT THE DECODER WOULD NOT NORMALISE. An earlier version
+ * stripped `\s+`, which in JavaScript includes U+00A0, U+2028 and friends — so
+ * `…;base64,AA==<NBSP>` was scrubbed until it parsed and reported ONE BYTE for a
+ * payload no browser will decode. A validator that cleans its input until it
+ * passes certifies something the real consumer rejects. Only the five ASCII
+ * whitespace characters are removed, which is exactly what the forgiving-base64
+ * algorithm behind `atob`/`data:` ignores; every other character has to be in
+ * the alphabet or the answer is unknown.
  */
+const BASE64_ASCII_WHITESPACE = /[\t\n\f\r ]/g;
+
 export function dataUrlByteLength(dataUrl) {
   if (typeof dataUrl !== "string") return null;
   const comma = dataUrl.indexOf(",");
   if (comma < 0) return null;
   const head = dataUrl.slice(0, comma);
   if (!/^data:/i.test(head) || !/;base64$/i.test(head)) return null;
-  const body = dataUrl.slice(comma + 1).replace(/\s+/g, "");
+  const body = dataUrl.slice(comma + 1).replace(BASE64_ASCII_WHITESPACE, "");
   if (!body) return 0;
   // Standard base64: the alphabet, and padding only at the end. Padding is
   // OPTIONAL — browsers decode an unpadded data URL body happily, so requiring
@@ -312,7 +335,16 @@ export async function composeShowMediaReply(items, deps = {}) {
         name,
         why:
           why ??
-          "no usable source — it carried neither inline data nor a ComfyUI reference with a filename; re-send it as an absolute path or as such a reference",
+          "no usable source — it carried neither inline data nor a ComfyUI reference with a filename",
+        // A failed URL build is NOT a dead end: the reference itself is right
+        // here, and get_image resolves it without going through the panel's URL
+        // builder at all.
+        remedy: ref
+          ? `The reference itself is intact — call get_image with ${refClause(ref, text)}, ` +
+            `which fetches it without the panel's URL builder (an image comes back inline; a video is ` +
+            `saved to disk and you get a path).`
+          : `Re-send it as an absolute path on the orchestrator host, or as a ComfyUI reference with a ` +
+            `filename.`,
       });
       continue;
     }
@@ -320,8 +352,22 @@ export async function composeShowMediaReply(items, deps = {}) {
     if (shownState === "failed") {
       dropped.push({
         name,
-        why:
-          "the panel's own painter failed while putting it in the chat (the file itself resolved fine, so re-sending it unchanged will not help)",
+        why: "the panel's own painter failed while putting it in the chat",
+        // "Re-sending will not help" is true and is not a next step. What the
+        // caller can still do depends on what it has: a video always gets its
+        // own sampled-preview note below, and anything with a ComfyUI reference
+        // can be fetched directly.
+        remedy: isVideo
+          ? `The file itself resolved fine, so re-sending it unchanged will not help — see this video's ` +
+            `sampled-preview note below for what you can still do with it, and tell the user their ` +
+            `player did not appear.`
+          : (ref
+              ? `The file itself resolved fine, so re-sending it unchanged will not help. To see it ` +
+                `YOURSELF, call get_image with ${refClause(ref, text)} — it returns the image inline. `
+              : `The file itself resolved fine, so re-sending it unchanged will not help; this tool never ` +
+                `sends it to you either. Put it somewhere ComfyUI serves and call get_image on it if you ` +
+                `need to look at it. `) +
+            `To get it in front of the USER, ask them to reload the panel and try again.`,
       });
     } else if (shownState === "unconfirmed") {
       unconfirmed += 1;
@@ -399,7 +445,9 @@ export async function composeShowMediaReply(items, deps = {}) {
     noteSections.push(
       `${dropped.length} of the ${list.length} requested item(s) were NOT displayed, so the user ` +
         `cannot see ${dropped.length === 1 ? "it" : "them"} either:\n` +
-        dropped.map((d) => `• ${d.name || "(unnamed item)"} — ${d.why}`).join("\n"),
+        dropped
+          .map((d) => `• ${d.name || "(unnamed item)"} — ${d.why}. ${d.remedy}`)
+          .join("\n"),
     );
   }
 

--- a/web/js/lib/media-preview.js
+++ b/web/js/lib/media-preview.js
@@ -1,0 +1,462 @@
+// What `panel_show_media` tells the agent it did — and did NOT — hand it.
+//
+// THE DEFECT (#648). An agent asked to inspect a local reference video hits a
+// dead end. Over the orchestrator's inline ceiling the call is refused outright,
+// and even when a video DOES reach the panel (as a ComfyUI /view ref, which has
+// no such ceiling) the reply is `{ok:true,count:1}`: the USER gets a player, the
+// agent gets a success acknowledgement for something it cannot see and no next
+// step. Both readings are "this is impossible".
+//
+// A refusal that names no next step is the same failure as a ceiling with no way
+// past it. So this module composes the reply, and every branch of it ends
+// somewhere the caller can actually go from where it is.
+//
+// THE PREVIEW IS THE ONE THE PANEL ALREADY BUILDS. Videos route through the SAME
+// pipeline the run-completion frame uses — `buildVideoStoryboard` samples frames
+// off a hidden <video> into a canvas contact sheet, `uploadBlobToInput` puts the
+// sheet in ComfyUI's swept temp/ namespace, `storyboardFrameCount` says how many
+// cells it has. Nothing here re-implements any of that; a second storyboard
+// builder that drifts from the first is a bug generator.
+//
+// THREE RULES THIS FILE EXISTS TO ENFORCE
+//
+//  1. BOUNDED. The pipeline contains steps that can fail to settle: a decode
+//     that never fires `loadedmetadata`, an `/upload/image` with no timeout of
+//     its own. `show_media` is answered under a wall clock on the orchestrator
+//     side, so every preview is bounded and degrades to a note rather than
+//     eating the reply.
+//
+//  2. NEVER PRESENT THE PREVIEW AS THE MEDIA. A contact sheet described as the
+//     video is a fabricated observation — an agent that reads "20 frames" as the
+//     video's length will tell the user something false about their file. Every
+//     reply that carries a storyboard states, in the same breath, that the video
+//     itself was not sent, that the sheet is N evenly-spaced SAMPLES, and how
+//     big the source file is. This is the single most important thing here.
+//
+//  3. UNKNOWN IS NOT A VALUE. If the source size cannot be read, the reply says
+//     it could not be read. It never omits it (an omitted size reads as "small")
+//     and never guesses one.
+//
+// WHY THE REMEDY IS `get_image` AND NOT `panel_show_media`. `panel_show_media`
+// paints into the human's chat; its reply to the agent is text. `get_image`
+// returns an inline image block the agent can actually look at, and it accepts
+// exactly the `{filename, type, subfolder}` shape `uploadBlobToInput` returns —
+// so the sheet this module uploads is reachable in one call from the reply that
+// names it. That is what makes the remedy actionable rather than decorative.
+
+import { withTimeout } from "./bounded-step.js";
+
+/**
+ * Whole wall-clock bound for ONE video's preview (size probe + sample + upload).
+ * Previews run in parallel, so a batch costs at most one of these. Deliberately
+ * well under the orchestrator's 60 s `show_media` deadline: the reply must come
+ * back as a degraded note, never as a transport timeout the agent cannot read.
+ */
+export const MEDIA_PREVIEW_TIMEOUT_MS = 20000;
+
+/** Bound on the size probe alone, so a hanging HEAD cannot consume the budget
+ *  the storyboard needs. Unknown size still produces a preview. */
+export const MEDIA_SIZE_PROBE_TIMEOUT_MS = 8000;
+
+/**
+ * Filenames the panel plays as video.
+ *
+ * The dot is escaped, unlike the inline test this replaces (`/.(mp4|webm)$/i`),
+ * where `.` matched any character — so a file ending `xmp4` was painted as a
+ * video. Widened past mp4/webm because a ComfyUI /view ref can name anything on
+ * disk; the orchestrator's own inline path is stricter, which is fine, this only
+ * has to decide "try to sample frames from it".
+ */
+const VIDEO_FILENAME = /\.(?:mp4|webm|mov|m4v|mkv|avi)$/i;
+
+const defaultCoerce = (v) => (typeof v === "string" ? v : v == null ? "" : String(v));
+
+/** True when a resolved show_media item should be treated as a video. */
+export function isVideoShowMediaItem(item, coerce = defaultCoerce) {
+  if (!item) return false;
+  if (item.kind === "video") return true;
+  if (item.kind === "viewRef" && item.viewRef) {
+    return VIDEO_FILENAME.test(coerce(item.viewRef.filename));
+  }
+  return false;
+}
+
+/**
+ * Exact byte length of a base64 data URL payload, or null when it is not one.
+ * Computed rather than probed — the bytes are already in hand, so there is no
+ * reason to report this size as unknown.
+ */
+export function dataUrlByteLength(dataUrl) {
+  if (typeof dataUrl !== "string") return null;
+  const comma = dataUrl.indexOf(",");
+  if (comma < 0) return null;
+  const head = dataUrl.slice(0, comma);
+  if (!/^data:/i.test(head) || !/;base64$/i.test(head)) return null;
+  const body = dataUrl.slice(comma + 1).replace(/\s+/g, "");
+  if (!body) return 0;
+  let pad = 0;
+  if (body.endsWith("==")) pad = 2;
+  else if (body.endsWith("=")) pad = 1;
+  const n = Math.floor((body.length * 3) / 4) - pad;
+  return n >= 0 ? n : null;
+}
+
+/** "72.1 MB" when known; an explicit statement of ignorance when not. */
+function sizeClause(sizeBytes, humanizeBytes) {
+  if (!Number.isFinite(sizeBytes) || sizeBytes < 0) {
+    return "source file size UNKNOWN (it could not be read — that is not the same as knowing it is small)";
+  }
+  const human = humanizeBytes(sizeBytes);
+  return `source file ${human || `${sizeBytes} bytes`}`;
+}
+
+/** A ComfyUI ref written the way `get_image` takes its arguments. */
+function refClause(ref, coerce) {
+  const filename = coerce(ref?.filename);
+  const type = coerce(ref?.type) || "output";
+  const subfolder = coerce(ref?.subfolder);
+  const parts = [`filename "${filename}"`, `type "${type}"`];
+  if (subfolder) parts.push(`subfolder "${subfolder}"`);
+  return parts.join(", ");
+}
+
+/**
+ * Compose the panel's reply to one `show_media` command: paint every item for
+ * the user, build a bounded sampled preview of every video, and return a reply
+ * that states what the agent was and was not given.
+ *
+ * Resolves to `{ ok, count, painted, previews, note }`. Never rejects — a reply
+ * the agent cannot read is the failure this exists to remove.
+ *
+ * @param {Array<object>} items resolved show_media items from the orchestrator
+ * @param {object} deps injected panel helpers (see the call site)
+ */
+export async function composeShowMediaReply(items, deps = {}) {
+  const {
+    paintImage,
+    paintVideo,
+    imageViewUrl,
+    coerceMessageText = defaultCoerce,
+    buildVideoStoryboard,
+    uploadBlobToInput,
+    storyboardFrameCount,
+    humanizeBytes = () => null,
+    fetchMediaBytes = async () => null,
+    videoStoryboardEnabled = true,
+    warn = () => {},
+    timeoutMs = MEDIA_PREVIEW_TIMEOUT_MS,
+    sizeProbeTimeoutMs = MEDIA_SIZE_PROBE_TIMEOUT_MS,
+    setTimer,
+    clearTimer,
+  } = deps;
+
+  const list = Array.isArray(items) ? items : [];
+  const jobs = [];
+  let painted = 0;
+  let unrendered = 0;
+
+  // ── Paint pass ──────────────────────────────────────────────────────────
+  // One item's painter throwing must not cost the whole batch its reply, and
+  // must not be counted as painted — an item silently dropped is exactly the
+  // kind of thing the reply has to be honest about.
+  for (const item of list) {
+    const caption =
+      coerceMessageText(item?.caption) || coerceMessageText(item?.filename) || "";
+    const isVideo = isVideoShowMediaItem(item, coerceMessageText);
+    let url = null;
+    let ref = null;
+    let name = coerceMessageText(item?.filename);
+    if (item?.kind === "viewRef" && item?.viewRef) {
+      ref = item.viewRef;
+      name = coerceMessageText(ref.filename) || name;
+      try {
+        url = imageViewUrl(ref);
+      } catch (err) {
+        warn("[cmcp] show_media: could not build a view URL for", name, err);
+        url = null;
+      }
+    } else if (typeof item?.dataUrl === "string" && item.dataUrl) {
+      url = item.dataUrl;
+    }
+    if (!url) {
+      unrendered += 1;
+      continue;
+    }
+    try {
+      if (isVideo) paintVideo(url, caption);
+      else paintImage(url, caption);
+      painted += 1;
+    } catch (err) {
+      warn("[cmcp] show_media: painting failed for", name, err);
+      unrendered += 1;
+      continue;
+    }
+    if (isVideo) {
+      jobs.push({
+        url,
+        name: name || "video",
+        ref,
+        // A data URL carries its own exact length; a /view ref has to be probed.
+        knownBytes: ref ? null : dataUrlByteLength(url),
+      });
+    }
+  }
+
+  // ── Preview pass ────────────────────────────────────────────────────────
+  // Parallel, each independently bounded: the batch costs one timeout window at
+  // worst, and one wedged video cannot suppress another's preview.
+  const segments = await Promise.all(
+    jobs.map((job) =>
+      buildSampledPreview(job, {
+        buildVideoStoryboard,
+        uploadBlobToInput,
+        storyboardFrameCount,
+        imageViewUrl,
+        paintImage,
+        humanizeBytes,
+        fetchMediaBytes,
+        coerceMessageText,
+        videoStoryboardEnabled,
+        warn,
+        timeoutMs,
+        sizeProbeTimeoutMs,
+        setTimer,
+        clearTimer,
+      }).catch((err) => {
+        // buildSampledPreview swallows its own failures; this is the last guard
+        // so one video can never reject the batch.
+        warn("[cmcp] show_media preview segment failed:", err);
+        return {
+          note: `${job.name} — no sampled preview could be built and the panel could not say why. Ask the user how the video looks; they can see it playing in the chat.`,
+          preview: null,
+        };
+      }),
+    ),
+  );
+
+  const previews = [];
+  const noteSections = [];
+
+  // The batch headline. It leads with the thing an agent most easily gets wrong
+  // about this tool: panel_show_media paints for the HUMAN and returns text, so
+  // nothing here was shown to the caller.
+  const shown =
+    painted === 1 ? "1 item was displayed" : `${painted} items were displayed`;
+  const headline =
+    `${shown} to the USER in the panel chat. You were NOT sent ` +
+    (painted === 1 ? "this file" : "these files") +
+    ` — this tool renders media for the person, not for you.`;
+  noteSections.push(headline);
+
+  if (unrendered > 0) {
+    noteSections.push(
+      `${unrendered} of the ${list.length} requested item(s) could not be rendered at all ` +
+        `(no usable source), so the user did not see ${unrendered === 1 ? "it" : "them"} either. ` +
+        `Re-send ${unrendered === 1 ? "it" : "them"} as an absolute path or as a ComfyUI reference with a filename.`,
+    );
+  }
+
+  for (const seg of segments) {
+    if (!seg) continue;
+    if (seg.preview) previews.push(seg.preview);
+    if (seg.note) noteSections.push(seg.note);
+  }
+
+  return {
+    ok: true,
+    count: list.length,
+    painted,
+    previews,
+    note: noteSections.join("\n\n"),
+  };
+}
+
+/**
+ * One video's sampled preview. Returns `{ note, preview }` — `preview` is the
+ * uploaded contact sheet's ref, or null when none could be produced. Never
+ * throws, never rejects, and never returns a note that could be read as "here is
+ * the video".
+ */
+async function buildSampledPreview(job, deps) {
+  const {
+    buildVideoStoryboard,
+    uploadBlobToInput,
+    storyboardFrameCount,
+    imageViewUrl,
+    paintImage,
+    humanizeBytes,
+    fetchMediaBytes,
+    coerceMessageText,
+    videoStoryboardEnabled,
+    warn,
+    timeoutMs,
+    sizeProbeTimeoutMs,
+    setTimer,
+    clearTimer,
+  } = deps;
+
+  const timers = { setTimer, clearTimer };
+
+  // The size probe runs alongside the storyboard and is separately bounded, so a
+  // HEAD that never answers costs the reply a size — not a preview.
+  const sizePromise = withTimeout(
+    resolveSourceBytes(job, fetchMediaBytes, warn),
+    sizeProbeTimeoutMs,
+    () => null,
+    timers,
+  );
+
+  const canSample =
+    videoStoryboardEnabled &&
+    typeof buildVideoStoryboard === "function" &&
+    typeof uploadBlobToInput === "function" &&
+    typeof storyboardFrameCount === "function";
+
+  const sheetPromise = canSample
+    ? withTimeout(
+        produceSheet(job, {
+          buildVideoStoryboard,
+          uploadBlobToInput,
+          storyboardFrameCount,
+          warn,
+        }),
+        timeoutMs,
+        () => {
+          warn("[cmcp] show_media: sampled preview timed out for", job.name);
+          return {
+            ref: null,
+            frames: null,
+            why: `sampling it took longer than ${Math.round(timeoutMs / 1000)}s and was abandoned`,
+          };
+        },
+        timers,
+      )
+    : Promise.resolve({
+        ref: null,
+        frames: null,
+        why: videoStoryboardEnabled
+          ? "this panel build cannot sample video frames"
+          : "storyboard previews are turned off in the panel's settings",
+      });
+
+  const [sizeBytes, sheet] = await Promise.all([sizePromise, sheetPromise]);
+  const size = sizeClause(sizeBytes, humanizeBytes);
+  const outcome = sheet ?? { ref: null, frames: null, why: "the panel could not say why" };
+
+  if (!outcome.ref) {
+    return {
+      note:
+        `🎬 ${job.name} — you were NOT shown this video, and no sampled preview could be built ` +
+        `(${outcome.why}). Its ${size}. ` +
+        remedyWithoutPreview(job, coerceMessageText),
+      preview: null,
+    };
+  }
+
+  const n = outcome.frames;
+  // Show the human the same sheet the agent is being pointed at, so what the
+  // agent is judging from is visible in the chat next to the player.
+  try {
+    paintImage(imageViewUrl(outcome.ref), `Storyboard · ${n} frames`);
+  } catch (err) {
+    warn("[cmcp] show_media: could not paint the storyboard sheet", err);
+  }
+
+  return {
+    preview: {
+      of: job.name,
+      frames: n,
+      sourceBytes: Number.isFinite(sizeBytes) ? sizeBytes : null,
+      filename: coerceMessageText(outcome.ref.filename),
+      subfolder: coerceMessageText(outcome.ref.subfolder),
+      type: coerceMessageText(outcome.ref.type) || "temp",
+      sampled: true,
+    },
+    note:
+      `📽️ ${job.name} — you were NOT shown this video. What exists for you is a SAMPLED PREVIEW of it: ` +
+      `a ${n}-frame contact sheet built in the browser (its ${size}). ` +
+      `Those ${n} frames are evenly-spaced SAMPLES across the video — they are NOT its frame count, ` +
+      `its duration, or its frame rate, so do not describe the video as ${n} frames long, and do not ` +
+      `report anything about it that a ${n}-frame sample cannot show (audio, timing, brief events). ` +
+      `Cells read left to right, top to bottom = start to end. ` +
+      `To actually look at the sheet, call get_image with ${refClause(outcome.ref, coerceMessageText)}.`,
+  };
+}
+
+/** Sample + upload. Resolves `{ref, frames, why}`; never throws. */
+async function produceSheet(job, deps) {
+  const { buildVideoStoryboard, uploadBlobToInput, storyboardFrameCount, warn } = deps;
+  try {
+    const blob = await buildVideoStoryboard(job.url);
+    if (!blob) {
+      warn("[cmcp] show_media: could not sample frames from", job.name);
+      return {
+        ref: null,
+        frames: null,
+        why: "its frames could not be decoded or seeked in this browser",
+      };
+    }
+    const base = job.name.replace(/\.[^.]+$/, "") || "video";
+    // #209 — a panel-generated sheet is not a user input: it goes to ComfyUI's
+    // swept temp/ namespace so it cannot accumulate as permanent input litter.
+    const ref = await uploadBlobToInput(blob, `storyboard_${base}.png`, { type: "temp" });
+    if (!ref) {
+      warn("[cmcp] show_media: storyboard upload failed for", job.name);
+      return { ref: null, frames: null, why: "its contact sheet could not be uploaded to ComfyUI" };
+    }
+    let frames = null;
+    try {
+      frames = storyboardFrameCount();
+    } catch {
+      frames = null;
+    }
+    if (!Number.isFinite(frames) || frames <= 0) {
+      // A sheet whose cell count is unknown cannot be described honestly, and
+      // "some frames" is not a disclosure. Degrade rather than hand-wave.
+      return {
+        ref: null,
+        frames: null,
+        why: "its contact sheet was built but the panel could not say how many frames it holds",
+      };
+    }
+    return { ref, frames, why: null };
+  } catch (err) {
+    warn("[cmcp] show_media: sampled preview pipeline failed:", err);
+    return { ref: null, frames: null, why: "the sampling pipeline failed" };
+  }
+}
+
+/** Exact length for an inlined data URL, a bounded HEAD for a /view ref. */
+async function resolveSourceBytes(job, fetchMediaBytes, warn) {
+  if (Number.isFinite(job.knownBytes)) return job.knownBytes;
+  if (typeof fetchMediaBytes !== "function") return null;
+  try {
+    const n = await fetchMediaBytes(job.url);
+    return Number.isFinite(n) ? n : null;
+  } catch (err) {
+    warn("[cmcp] show_media: could not read the source size for", job.name, err);
+    return null;
+  }
+}
+
+/**
+ * What the caller can do when no sampled preview exists. Never "you cannot" —
+ * a refusal that names no next step is the defect this whole module is fixing.
+ */
+function remedyWithoutPreview(job, coerce) {
+  const human =
+    "Ask the user how it looks — they can see it playing in the chat and can answer for the parts you cannot.";
+  if (job.ref) {
+    return (
+      `The video is still reachable: call get_image with ${refClause(job.ref, coerce)} to save it to disk ` +
+      `(a video is saved, not rendered inline, so you get a path rather than a picture — but a path is ` +
+      `something a local tool can open). ` +
+      human
+    );
+  }
+  return (
+    `The file is named ${job.name} and the panel has no ComfyUI reference for it, so there is nothing ` +
+    `for you to re-fetch. Render or export a single still from it and show that image instead. ` +
+    human
+  );
+}

--- a/web/js/lib/media-preview.js
+++ b/web/js/lib/media-preview.js
@@ -101,14 +101,20 @@ export function dataUrlByteLength(dataUrl) {
   if (!/^data:/i.test(head) || !/;base64$/i.test(head)) return null;
   const body = dataUrl.slice(comma + 1).replace(/\s+/g, "");
   if (!body) return 0;
-  // Standard base64 only: 4-character groups, the alphabet, and padding that
-  // appears only at the end. base64url (-_) deliberately measures as unknown
-  // rather than being decoded by a rule this function has not verified.
-  if (body.length % 4 !== 0) return null;
-  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(body)) return null;
-  const pad = body.endsWith("==") ? 2 : body.endsWith("=") ? 1 : 0;
-  const n = (body.length / 4) * 3 - pad;
-  return n >= 0 ? n : null;
+  // Standard base64: the alphabet, and padding only at the end. Padding is
+  // OPTIONAL — browsers decode an unpadded data URL body happily, so requiring
+  // a multiple of four would call a perfectly measurable payload unknown.
+  // base64url (-_) is deliberately unknown rather than decoded by a rule this
+  // function has not verified.
+  const m = /^([A-Za-z0-9+/]*)(={0,2})$/.exec(body);
+  if (!m) return null;
+  const chars = m[1].length;
+  const pad = m[2].length;
+  // A trailing group of one character encodes nothing; padding must complete a
+  // group, and a complete group needs none.
+  if (chars % 4 === 1) return null;
+  if (pad > 0 && ((chars + pad) % 4 !== 0 || chars % 4 === 0)) return null;
+  return Math.floor((chars * 3) / 4);
 }
 
 /** "72.1 MB" when known; an explicit statement of ignorance when not. */
@@ -142,6 +148,32 @@ function sheetClause(frames, cells) {
     );
   }
   return `a ${frames}-frame contact sheet`;
+}
+
+/**
+ * Call a painter without letting it throw OR reject.
+ *
+ * Returns "shown", "failed", or "unconfirmed". A painter that settles later
+ * cannot be confirmed from here, so it is neither counted as shown nor left to
+ * surface as an unhandled rejection. Both painting sites go through this — the
+ * batch pass and the storyboard sheet — because a second, hand-rolled copy is
+ * how the sheet's painter ended up unguarded in the first place.
+ */
+function safePaint(paint, url, caption, warn, what) {
+  let outcome;
+  try {
+    outcome = paint(url, caption);
+  } catch (err) {
+    warn("[cmcp] show_media: painting failed for", what, err);
+    return "failed";
+  }
+  if (outcome && typeof outcome.then === "function") {
+    outcome.then(null, (err) =>
+      warn("[cmcp] show_media: a deferred painter rejected for", what, err),
+    );
+    return "unconfirmed";
+  }
+  return "shown";
 }
 
 /** A ComfyUI ref written the way `get_image` takes its arguments. */
@@ -236,24 +268,13 @@ export async function composeShowMediaReply(items, deps = {}) {
       unrendered += 1;
       continue;
     }
-    let outcome;
-    try {
-      outcome = isVideo ? paintVideo(url, caption) : paintImage(url, caption);
-    } catch (err) {
-      note("[cmcp] show_media: painting failed for", name, err);
+    const shownState = safePaint(isVideo ? paintVideo : paintImage, url, caption, note, name);
+    if (shownState === "failed") {
       unrendered += 1;
       continue;
     }
-    if (outcome && typeof outcome.then === "function") {
-      // A painter that settles LATER cannot be confirmed from here, and an
-      // unconfirmed paint is not a paint. Swallow its rejection so it cannot
-      // surface as an unhandled rejection, and report it as unconfirmed rather
-      // than counting it as shown. The panel's own painters are synchronous.
-      outcome.then(null, (err) => note("[cmcp] show_media: async painter rejected for", name, err));
-      unconfirmed += 1;
-    } else {
-      painted += 1;
-    }
+    if (shownState === "unconfirmed") unconfirmed += 1;
+    else painted += 1;
     if (isVideo) {
       jobs.push({
         url,
@@ -441,12 +462,29 @@ async function buildSampledPreview(job, deps) {
   const n = outcome.frames;
   const cells = outcome.cells;
   // Show the human the same sheet the agent is being pointed at, so what the
-  // agent is judging from is visible in the chat next to the player.
+  // agent is judging from is visible in the chat next to the player. This
+  // painter is guarded exactly like the batch pass's: it can throw, and it can
+  // return a promise that rejects later.
+  let sheetShown;
   try {
-    paintImage(imageViewUrl(outcome.ref), `Storyboard · ${n} sampled frames`);
+    sheetShown = safePaint(
+      paintImage,
+      imageViewUrl(outcome.ref),
+      `Storyboard · ${n} sampled frames`,
+      warn,
+      `the storyboard sheet for ${job.name}`,
+    );
   } catch (err) {
-    warn("[cmcp] show_media: could not paint the storyboard sheet", err);
+    // imageViewUrl itself can throw; the sheet is still reachable via get_image.
+    warn("[cmcp] show_media: could not build a view URL for the storyboard sheet", err);
+    sheetShown = "failed";
   }
+  const sheetVisibility =
+    sheetShown === "shown"
+      ? ""
+      : ` (The sheet could not be ${sheetShown === "failed" ? "shown" : "confirmed as shown"} ` +
+        `in the chat, so the user may not be able to see what you are judging from — say so if you ` +
+        `discuss it. Your own copy, below, is unaffected.)`;
 
   return {
     preview: {
@@ -466,7 +504,8 @@ async function buildSampledPreview(job, deps) {
       `its duration, or its frame rate, so do not describe the video as ${n} frames long, and do not ` +
       `report anything about it that a ${n}-frame sample cannot show (audio, timing, brief events). ` +
       `Cells read left to right, top to bottom = start to end. ` +
-      `To actually look at the sheet, call get_image with ${refClause(outcome.ref, coerceMessageText)}.`,
+      `To actually look at the sheet, call get_image with ${refClause(outcome.ref, coerceMessageText)}.` +
+      sheetVisibility,
   };
 }
 

--- a/web/js/lib/media-preview.js
+++ b/web/js/lib/media-preview.js
@@ -335,6 +335,10 @@ export async function composeShowMediaReply(items, deps = {}) {
         url,
         name: name || "video",
         ref,
+        // Whether the USER got a player. The no-preview remedy leans on "ask
+        // the user"; telling the agent to ask about something the user cannot
+        // see is a remedy that does not work from where the caller is.
+        shown: shownState,
         // A data URL carries its own exact length; a /view ref has to be probed.
         inline: !ref,
         knownBytes: ref ? null : dataUrlByteLength(url),
@@ -367,7 +371,10 @@ export async function composeShowMediaReply(items, deps = {}) {
         // so one video can never reject the batch.
         note("[cmcp] show_media preview segment failed:", err);
         return {
-          note: `${job.name} — no sampled preview could be built and the panel could not say why. Ask the user how the video looks; they can see it playing in the chat.`,
+          note:
+            `${job.name} — you were NOT shown this video, no sampled preview could be built, and the ` +
+            `panel could not say why. ` +
+            remedyWithoutPreview(job, text),
           preview: null,
         };
       }),
@@ -575,7 +582,12 @@ async function produceSheet(job, deps) {
         ref: null,
         frames: null,
         cells: null,
-        why: "not one of its frames could be decoded, seeked and painted in this browser",
+        // Deliberately non-diagnostic. The builder returns nothing when the
+        // metadata never arrives, when the dimensions are unusable, when no
+        // frame could be captured, AND when the finished sheet fails to encode
+        // — and it does not report which. Naming one of them would hand the
+        // agent a cause nothing observed.
+        why: "the sampler returned no contact sheet (its metadata, its frames or the sheet's own encoding failed — the panel is not told which)",
       };
     }
     const base = job.name.replace(/\.[^.]+$/, "") || "video";
@@ -642,8 +654,23 @@ async function resolveSourceBytes(job, fetchMediaBytes, warn) {
  * a refusal that names no next step is the defect this whole module is fixing.
  */
 function remedyWithoutPreview(job, coerce) {
-  const human =
-    "Ask the user how it looks — they can see it playing in the chat and can answer for the parts you cannot.";
+  // "Ask the user" is only a remedy when the user has something to look at.
+  // Asserting they can see it playing when its player never made it into the
+  // chat sends the caller to a person who is as blind to it as they are.
+  let human;
+  if (job.shown === "failed") {
+    human =
+      "The user cannot see it either — its player could not be put in the chat — so asking them how it " +
+      "looks will not help; say plainly that the video could not be inspected.";
+  } else if (job.shown === "unconfirmed") {
+    human =
+      "Whether the user can see it in the chat is UNKNOWN, so ask whether they can see it before asking " +
+      "them to describe it.";
+  } else {
+    human =
+      "Its player is in the chat, so ask the user how it looks — they can answer for the parts you cannot " +
+      "(and will tell you if it does not play).";
+  }
   if (job.ref) {
     return (
       `The video is still reachable: call get_image with ${refClause(job.ref, coerce)} to save it to disk ` +

--- a/web/js/lib/media-preview.js
+++ b/web/js/lib/media-preview.js
@@ -325,8 +325,13 @@ export async function composeShowMediaReply(items, deps = {}) {
       } catch (err) {
         note("[cmcp] show_media: could not build a view URL for", name, err);
         url = null;
-        why = "the panel could not build a view URL for its ComfyUI reference";
       }
+      // Keyed on the OUTCOME, not on whether it threw. A URL builder that
+      // returns null instead of throwing is the same failure, and reporting it
+      // as "carried neither inline data nor a ComfyUI reference" is false — the
+      // reference is right there, and the caller would be told to re-send
+      // something it already sent correctly.
+      if (!url) why = "the panel could not build a view URL for its ComfyUI reference";
     } else if (typeof item?.dataUrl === "string" && item.dataUrl) {
       url = item.dataUrl;
     }
@@ -649,6 +654,22 @@ async function produceSheet(job, deps) {
         frames: null,
         cells: null,
         why: "its contact sheet could not be uploaded to ComfyUI",
+      };
+    }
+    // A truthy ref is not a RETRIEVABLE ref. `uploadBlobToInput` builds
+    // `{filename: info.name, …}` from whatever `/upload/image` returned, so a
+    // response without `name` yields a perfectly truthy object whose filename is
+    // undefined — and the reply would then announce that a sampled preview
+    // exists and tell the agent to fetch `filename ""`, which resolves to
+    // nothing. A remedy that cannot be followed is the defect this module
+    // exists to remove, so an unusable ref degrades like any other failure.
+    if (!String(ref.filename ?? "").trim()) {
+      warn("[cmcp] show_media: storyboard upload returned no filename for", job.name);
+      return {
+        ref: null,
+        frames: null,
+        cells: null,
+        why: "its contact sheet uploaded but came back with no filename, so nothing can point you at it",
       };
     }
     // The GRID's capacity. It is NOT the number of frames sampled: a video whose

--- a/web/js/lib/media-preview.js
+++ b/web/js/lib/media-preview.js
@@ -82,9 +82,16 @@ export function isVideoShowMediaItem(item, coerce = defaultCoerce) {
 }
 
 /**
- * Exact byte length of a base64 data URL payload, or null when it is not one.
- * Computed rather than probed — the bytes are already in hand, so there is no
- * reason to report this size as unknown.
+ * Exact byte length of a base64 data URL payload, or null when the payload is
+ * not one this function can measure EXACTLY. Computed rather than probed — the
+ * bytes are already in hand, so there is no reason to call this size unknown.
+ *
+ * The payload is validated before it is measured, because the arithmetic is
+ * happy to measure nonsense: `…;base64,A` is not a legal base64 body but
+ * `floor(1*3/4)` is 0, and `…;base64,!!!!` is not base64 at all but measures 3.
+ * Both would have told the agent the source file was a few bytes — an invented
+ * size, and precisely the "unknown reported as a value" failure this module
+ * exists to avoid. Anything that does not decode cleanly is null, i.e. unknown.
  */
 export function dataUrlByteLength(dataUrl) {
   if (typeof dataUrl !== "string") return null;
@@ -94,10 +101,13 @@ export function dataUrlByteLength(dataUrl) {
   if (!/^data:/i.test(head) || !/;base64$/i.test(head)) return null;
   const body = dataUrl.slice(comma + 1).replace(/\s+/g, "");
   if (!body) return 0;
-  let pad = 0;
-  if (body.endsWith("==")) pad = 2;
-  else if (body.endsWith("=")) pad = 1;
-  const n = Math.floor((body.length * 3) / 4) - pad;
+  // Standard base64 only: 4-character groups, the alphabet, and padding that
+  // appears only at the end. base64url (-_) deliberately measures as unknown
+  // rather than being decoded by a rule this function has not verified.
+  if (body.length % 4 !== 0) return null;
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(body)) return null;
+  const pad = body.endsWith("==") ? 2 : body.endsWith("=") ? 1 : 0;
+  const n = (body.length / 4) * 3 - pad;
   return n >= 0 ? n : null;
 }
 
@@ -106,8 +116,32 @@ function sizeClause(sizeBytes, humanizeBytes) {
   if (!Number.isFinite(sizeBytes) || sizeBytes < 0) {
     return "source file size UNKNOWN (it could not be read — that is not the same as knowing it is small)";
   }
-  const human = humanizeBytes(sizeBytes);
+  let human = null;
+  try {
+    human = humanizeBytes(sizeBytes);
+  } catch {
+    human = null;
+  }
   return `source file ${human || `${sizeBytes} bytes`}`;
+}
+
+/**
+ * How to describe the sheet's cells truthfully.
+ *
+ * `cells` is the grid's capacity; `frames` is how many of them a frame was
+ * actually drawn into. They differ whenever a seek failed, and reporting the
+ * capacity as the sample count is a fabricated observation of exactly the kind
+ * this module exists to prevent — so when they differ, both are stated.
+ */
+function sheetClause(frames, cells) {
+  if (Number.isFinite(cells) && cells > frames) {
+    const blank = cells - frames;
+    return (
+      `a contact sheet of ${cells} cells, ${frames} of which hold a sampled frame ` +
+      `(the other ${blank} could not be seeked and are blank — judge nothing from them)`
+    );
+  }
+  return `a ${frames}-frame contact sheet`;
 }
 
 /** A ComfyUI ref written the way `get_image` takes its arguments. */
@@ -150,29 +184,49 @@ export async function composeShowMediaReply(items, deps = {}) {
     clearTimer,
   } = deps;
 
+  // EVERY injected helper is an operation that can fail, including the trivial
+  // ones. A throwing `coerceMessageText` or `warn` used to reject this function
+  // before it composed anything — i.e. the agent got a transport error instead
+  // of a reply, which is the dead end this module exists to remove. Text
+  // helpers are wrapped once here; the I/O helpers are guarded at their sites.
+  const text = (v) => {
+    try {
+      return coerceMessageText(v) ?? "";
+    } catch {
+      return "";
+    }
+  };
+  const note = (...a) => {
+    try {
+      warn(...a);
+    } catch {
+      /* a logger that throws must not become the failure it was logging */
+    }
+  };
+
   const list = Array.isArray(items) ? items : [];
   const jobs = [];
   let painted = 0;
   let unrendered = 0;
+  let unconfirmed = 0;
 
   // ── Paint pass ──────────────────────────────────────────────────────────
   // One item's painter throwing must not cost the whole batch its reply, and
   // must not be counted as painted — an item silently dropped is exactly the
   // kind of thing the reply has to be honest about.
   for (const item of list) {
-    const caption =
-      coerceMessageText(item?.caption) || coerceMessageText(item?.filename) || "";
-    const isVideo = isVideoShowMediaItem(item, coerceMessageText);
+    const caption = text(item?.caption) || text(item?.filename) || "";
+    const isVideo = isVideoShowMediaItem(item, text);
     let url = null;
     let ref = null;
-    let name = coerceMessageText(item?.filename);
+    let name = text(item?.filename);
     if (item?.kind === "viewRef" && item?.viewRef) {
       ref = item.viewRef;
-      name = coerceMessageText(ref.filename) || name;
+      name = text(ref.filename) || name;
       try {
         url = imageViewUrl(ref);
       } catch (err) {
-        warn("[cmcp] show_media: could not build a view URL for", name, err);
+        note("[cmcp] show_media: could not build a view URL for", name, err);
         url = null;
       }
     } else if (typeof item?.dataUrl === "string" && item.dataUrl) {
@@ -182,14 +236,23 @@ export async function composeShowMediaReply(items, deps = {}) {
       unrendered += 1;
       continue;
     }
+    let outcome;
     try {
-      if (isVideo) paintVideo(url, caption);
-      else paintImage(url, caption);
-      painted += 1;
+      outcome = isVideo ? paintVideo(url, caption) : paintImage(url, caption);
     } catch (err) {
-      warn("[cmcp] show_media: painting failed for", name, err);
+      note("[cmcp] show_media: painting failed for", name, err);
       unrendered += 1;
       continue;
+    }
+    if (outcome && typeof outcome.then === "function") {
+      // A painter that settles LATER cannot be confirmed from here, and an
+      // unconfirmed paint is not a paint. Swallow its rejection so it cannot
+      // surface as an unhandled rejection, and report it as unconfirmed rather
+      // than counting it as shown. The panel's own painters are synchronous.
+      outcome.then(null, (err) => note("[cmcp] show_media: async painter rejected for", name, err));
+      unconfirmed += 1;
+    } else {
+      painted += 1;
     }
     if (isVideo) {
       jobs.push({
@@ -197,6 +260,7 @@ export async function composeShowMediaReply(items, deps = {}) {
         name: name || "video",
         ref,
         // A data URL carries its own exact length; a /view ref has to be probed.
+        inline: !ref,
         knownBytes: ref ? null : dataUrlByteLength(url),
       });
     }
@@ -215,9 +279,9 @@ export async function composeShowMediaReply(items, deps = {}) {
         paintImage,
         humanizeBytes,
         fetchMediaBytes,
-        coerceMessageText,
+        coerceMessageText: text,
         videoStoryboardEnabled,
-        warn,
+        warn: note,
         timeoutMs,
         sizeProbeTimeoutMs,
         setTimer,
@@ -225,7 +289,7 @@ export async function composeShowMediaReply(items, deps = {}) {
       }).catch((err) => {
         // buildSampledPreview swallows its own failures; this is the last guard
         // so one video can never reject the batch.
-        warn("[cmcp] show_media preview segment failed:", err);
+        note("[cmcp] show_media preview segment failed:", err);
         return {
           note: `${job.name} — no sampled preview could be built and the panel could not say why. Ask the user how the video looks; they can see it playing in the chat.`,
           preview: null,
@@ -256,6 +320,15 @@ export async function composeShowMediaReply(items, deps = {}) {
     );
   }
 
+  if (unconfirmed > 0) {
+    noteSections.push(
+      `${unconfirmed} of the ${list.length} requested item(s) were handed to a painter that had not ` +
+        `finished when this reply was composed, so whether the user can see ` +
+        `${unconfirmed === 1 ? "it" : "them"} is UNKNOWN — do not assume ` +
+        `${unconfirmed === 1 ? "it was" : "they were"} displayed.`,
+    );
+  }
+
   for (const seg of segments) {
     if (!seg) continue;
     if (seg.preview) previews.push(seg.preview);
@@ -266,6 +339,7 @@ export async function composeShowMediaReply(items, deps = {}) {
     ok: true,
     count: list.length,
     painted,
+    unconfirmed,
     previews,
     note: noteSections.join("\n\n"),
   };
@@ -326,6 +400,7 @@ async function buildSampledPreview(job, deps) {
           return {
             ref: null,
             frames: null,
+            cells: null,
             why: `sampling it took longer than ${Math.round(timeoutMs / 1000)}s and was abandoned`,
           };
         },
@@ -334,6 +409,7 @@ async function buildSampledPreview(job, deps) {
     : Promise.resolve({
         ref: null,
         frames: null,
+        cells: null,
         why: videoStoryboardEnabled
           ? "this panel build cannot sample video frames"
           : "storyboard previews are turned off in the panel's settings",
@@ -341,7 +417,12 @@ async function buildSampledPreview(job, deps) {
 
   const [sizeBytes, sheet] = await Promise.all([sizePromise, sheetPromise]);
   const size = sizeClause(sizeBytes, humanizeBytes);
-  const outcome = sheet ?? { ref: null, frames: null, why: "the panel could not say why" };
+  const outcome = sheet ?? {
+    ref: null,
+    frames: null,
+    cells: null,
+    why: "the panel could not say why",
+  };
 
   if (!outcome.ref) {
     return {
@@ -353,11 +434,16 @@ async function buildSampledPreview(job, deps) {
     };
   }
 
+  // `frames` is how many cells actually hold a sampled frame; `cells` is the
+  // grid's capacity. They are the same for a healthy video and differ when a
+  // seek failed — and the note must never quote the capacity as the sample
+  // count, which would invent observations out of blank cells.
   const n = outcome.frames;
+  const cells = outcome.cells;
   // Show the human the same sheet the agent is being pointed at, so what the
   // agent is judging from is visible in the chat next to the player.
   try {
-    paintImage(imageViewUrl(outcome.ref), `Storyboard · ${n} frames`);
+    paintImage(imageViewUrl(outcome.ref), `Storyboard · ${n} sampled frames`);
   } catch (err) {
     warn("[cmcp] show_media: could not paint the storyboard sheet", err);
   }
@@ -366,6 +452,7 @@ async function buildSampledPreview(job, deps) {
     preview: {
       of: job.name,
       frames: n,
+      cells: Number.isFinite(cells) ? cells : null,
       sourceBytes: Number.isFinite(sizeBytes) ? sizeBytes : null,
       filename: coerceMessageText(outcome.ref.filename),
       subfolder: coerceMessageText(outcome.ref.subfolder),
@@ -374,7 +461,7 @@ async function buildSampledPreview(job, deps) {
     },
     note:
       `📽️ ${job.name} — you were NOT shown this video. What exists for you is a SAMPLED PREVIEW of it: ` +
-      `a ${n}-frame contact sheet built in the browser (its ${size}). ` +
+      `${sheetClause(n, cells)}, built in the browser (its ${size}). ` +
       `Those ${n} frames are evenly-spaced SAMPLES across the video — they are NOT its frame count, ` +
       `its duration, or its frame rate, so do not describe the video as ${n} frames long, and do not ` +
       `report anything about it that a ${n}-frame sample cannot show (audio, timing, brief events). ` +
@@ -383,7 +470,7 @@ async function buildSampledPreview(job, deps) {
   };
 }
 
-/** Sample + upload. Resolves `{ref, frames, why}`; never throws. */
+/** Sample + upload. Resolves `{ref, frames, cells, why}`; never throws. */
 async function produceSheet(job, deps) {
   const { buildVideoStoryboard, uploadBlobToInput, storyboardFrameCount, warn } = deps;
   try {
@@ -393,6 +480,7 @@ async function produceSheet(job, deps) {
       return {
         ref: null,
         frames: null,
+        cells: null,
         why: "its frames could not be decoded or seeked in this browser",
       };
     }
@@ -402,33 +490,49 @@ async function produceSheet(job, deps) {
     const ref = await uploadBlobToInput(blob, `storyboard_${base}.png`, { type: "temp" });
     if (!ref) {
       warn("[cmcp] show_media: storyboard upload failed for", job.name);
-      return { ref: null, frames: null, why: "its contact sheet could not be uploaded to ComfyUI" };
-    }
-    let frames = null;
-    try {
-      frames = storyboardFrameCount();
-    } catch {
-      frames = null;
-    }
-    if (!Number.isFinite(frames) || frames <= 0) {
-      // A sheet whose cell count is unknown cannot be described honestly, and
-      // "some frames" is not a disclosure. Degrade rather than hand-wave.
       return {
         ref: null,
         frames: null,
-        why: "its contact sheet was built but the panel could not say how many frames it holds",
+        cells: null,
+        why: "its contact sheet could not be uploaded to ComfyUI",
       };
     }
-    return { ref, frames, why: null };
+    // The GRID's capacity. It is NOT the number of frames sampled: a video whose
+    // seeks fail leaves cells blank, and the builder still returns a sheet.
+    let cells = null;
+    try {
+      const c = storyboardFrameCount();
+      cells = Number.isFinite(c) && c > 0 ? c : null;
+    } catch {
+      cells = null;
+    }
+    // The count actually DRAWN, carried on the blob by buildVideoStoryboard.
+    const drawn = blob.paintedFrames;
+    const frames = Number.isFinite(drawn) && drawn > 0 ? Math.min(drawn, cells ?? drawn) : null;
+    if (frames == null) {
+      // A sheet whose sample count is unknown cannot be described honestly, and
+      // "some frames" is not a disclosure. Quoting the grid capacity instead
+      // would invent observations out of blank cells. Degrade rather than guess.
+      return {
+        ref: null,
+        frames: null,
+        cells,
+        why: "its contact sheet was built but the panel could not say how many frames it actually sampled",
+      };
+    }
+    return { ref, frames, cells, why: null };
   } catch (err) {
     warn("[cmcp] show_media: sampled preview pipeline failed:", err);
-    return { ref: null, frames: null, why: "the sampling pipeline failed" };
+    return { ref: null, frames: null, cells: null, why: "the sampling pipeline failed" };
   }
 }
 
 /** Exact length for an inlined data URL, a bounded HEAD for a /view ref. */
 async function resolveSourceBytes(job, fetchMediaBytes, warn) {
   if (Number.isFinite(job.knownBytes)) return job.knownBytes;
+  // An inline payload whose length could not be computed stays UNKNOWN: there
+  // is no origin to probe, and a HEAD against a data: URL would answer nothing.
+  if (job.inline) return null;
   if (typeof fetchMediaBytes !== "function") return null;
   try {
     const n = await fetchMediaBytes(job.url);

--- a/web/js/lib/run-completion-frame.js
+++ b/web/js/lib/run-completion-frame.js
@@ -17,6 +17,13 @@
 // pure, testable function — and so a failure inside any single output can never
 // wedge the one send.
 
+// #648 — the per-segment bound below used to be a private helper in this file.
+// The oversized-media preview path runs the SAME storyboard pipeline and needs
+// the SAME bound, so it now lives in one place both import. Behaviour is
+// unchanged except that a throwing `onTimeout`/`clearTimer` degrades instead of
+// leaving the segment pending forever.
+import { withTimeout } from "./bounded-step.js";
+
 /**
  * Build and send the single consolidated completion frame for one finished
  * prompt. Resolves to the frame that was sent (for tests), or null when the
@@ -373,29 +380,4 @@ async function buildVideoSegment(v, deps) {
     },
     { setTimer, clearTimer },
   );
-}
-
-/**
- * Resolve `promise`, but if it hasn't settled within `ms`, resolve with
- * `onTimeout()` instead. Never rejects (a rejected `promise` also falls back).
- * A non-positive `ms` disables the bound. The timer is cleared on settle so it
- * can't leak.
- */
-function withTimeout(promise, ms, onTimeout, { setTimer, clearTimer }) {
-  if (!(ms > 0)) return promise;
-  return new Promise((resolve) => {
-    let settled = false;
-    const done = (v) => {
-      if (settled) return;
-      settled = true;
-      clearTimer(t);
-      resolve(v);
-    };
-    const t = setTimer(() => {
-      if (settled) return;
-      settled = true;
-      resolve(onTimeout());
-    }, ms);
-    promise.then(done, () => done(onTimeout()));
-  });
 }


### PR DESCRIPTION
## Issues in this cluster

- #648 — `panel_show_media` cannot preview local reference videos over 20 MB

## What was broken

`panel_show_media` was a dead end for video, in two different ways.

Over the orchestrator's inline ceiling the call is **refused outright** — `file too large (72.1 MB > 20 MB)` — a ceiling with no way past it. Under the ceiling it is arguably worse: the panel painted a player for the **user** and replied `{ok:true,count:1}` to an agent that had been shown **nothing**. A success acknowledgement for something the caller cannot see is how an agent ends up describing a video it never saw.

The refusal is correct. Raising the cap is not the fix. The defect is that neither outcome names a next step.

## What this does

Videos now route through the panel's **existing** storyboard pipeline — `buildVideoStoryboard` → `uploadBlobToInput({type:"temp"})` → `storyboardFrameCount` — the same one the run-completion frame uses. No second builder was written. The private per-segment bound that pipeline needs was **extracted** to `lib/bounded-step.js` so both callers share one instead of drifting apart; `run-completion-frame.js` (owned by #628) is touched only to delete the private copy and import it, +7/−25.

**The reply is the deliverable.** A contact sheet described as the video is a fabricated observation, so every preview states, in the same breath:

- the video itself was **NOT** sent to the agent;
- the sheet is **N sampled frames**, not the video's frame count, duration or frame rate — with `do not describe the video as N frames long` said explicitly;
- how big the source file is, or that its size is **UNKNOWN** (never omitted — an omitted size reads as "small" — and never guessed);
- how to actually **look** at the sheet: `get_image` with the temp ref, which returns an inline image block. `panel_show_media` does not; it paints for the human.

Where the sheet is **partial** (a cell the browser could not capture), the reply says so and withholds the "evenly-spaced across the video" claim, because the surviving frames may be clustered near the start. Only a sheet whose every planned cell was filled may claim coverage.

Where **no preview can be produced** — sampling disabled, decode failure, upload failure, unknown sample count, or the bound firing — the reply names the reason *and* a next step, and the "ask the user" half of that remedy is withheld when the user's own player failed to paint, because asking someone who saw nothing is not a remedy.

Bounded: 20 s per video with an independent 8 s size probe, run in parallel, well under the orchestrator's 60 s `show_media` deadline. A wedged decode costs one window and degrades to a note.

Also fixed in passing: the panel's video test was `/.(mp4|webm)$/` with an unescaped dot, so a file named `xmp4` was painted as a video — and it was anchored at the raw filename end, so `clip.mp4?download=1` was classified as an **image** and skipped the storyboard and the whole disclosure.

## Scope — this is the PANEL half

The literal `file too large (72.1 MB > 20 MB)` in the report is raised by the **orchestrator**, in `src/orchestrator/panel-tools.ts` (`panel_show_media`, the absolute-path branch), before the panel ever sees the call. **That refusal still fires**, and this PR cannot change it.

The companion change is small and lands directly on this path with no further panel work: for an oversized local file that lives under a ComfyUI root, forward it as a `viewRef` (which has no size cap and is already what a browser panel resolves same-origin) instead of refusing; for one that does not, make the refusal name the remedy. A `viewRef` video arriving here already gets the full sampled preview and disclosure.

## Nothing here reports a state the panel did not observe

That is the rule the fix is built on, and it took two review passes to hold it everywhere:

- **The dispatcher's own fallback was the old bug.** `onShowMedia?.(items) ?? {ok:true, count: items.length}` handed a client without the handler the exact dead-end acknowledgement this PR removes — and `count` was counting the *request*, not the delivery. An absent handler now throws; a handler that returns nothing reports `delivered: "unknown"`.
- **A validator must not clean its input until it passes.** `dataUrlByteLength` stripped JavaScript's `\s` (which includes U+00A0, U+2028, U+FEFF), so a payload no browser can decode was scrubbed and measured as one byte. Only the five ASCII whitespace characters the forgiving-base64 algorithm itself ignores are stripped now.
- **A truthy ref is not a retrievable ref.** `uploadBlobToInput` builds `{filename: info.name, …}`, so an `/upload/image` response without `name` produced a truthy object with no filename — and the reply announced a preview and pointed the agent at an empty filename. It degrades instead.
- **Every drop names its own cause and its own next step.** "No usable source", a failed view-URL build, and a failed painter are three different things with three different remedies; a test walks all five drop causes and fails if any names no next step.
- A blank storyboard cell says it "could not be captured", not "could not be seeked" — the builder blanks a cell on a failed draw too and does not distinguish them.

## Verification

- **32 mutants, all killed** — including deleting the disclosure, quoting the grid capacity as the sample count, measuring a malformed base64 payload, restoring the optional-call fallback, accepting an unretrievable upload ref, removing the bound, stripping the `get_image` remedy, and reverting the panel wiring.
- Full `browser_tests` unit suite: **2058 passing**, on top of current `main`.
- `tsc --noEmit`, `node --check` in both CJS and **ESM** mode, `scripts/check-tool-vocabulary.mjs`.
- No stray control bytes in any committed blob; no file went binary.

## Not verified here, and only a live browser can

Every node test stubs the `<video>`/canvas pipeline. Unverified: real decode and seek behaviour for `/view` and `data:` URLs, canvas tainting, `canvas.toBlob`, and whether a browser `Blob` accepts the `paintedFrames` property the builder attaches. That last one **degrades honestly** if it fails — the reply withholds the preview and says the sample count is unknown — but it has not been observed working against a real oversized MP4.

Because the orchestrator half is not in this PR, **#648's own repro still fails** and the issue should stay open until that lands. Referenced here rather than closed.

Refs #648
