### PR TITLE
test(panel): de-flake waitForQueueDrain, and assert the pacing it was taking on trust

### DIFF
--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -584,8 +584,27 @@ test("waitForQueueDrain (real panel source) returns a drained status without Ref
 
   // Provide the exact free identifiers the function closes over at module scope.
   const MANAGER_FETCH_TIMEOUT_MS = 15000;
-  const boundedDelay = (ms, deadline) =>
-    new Promise((r) => setTimeout(r, Math.max(0, Math.min(ms, deadline - Date.now()))));
+  // The injected delay resolves IMMEDIATELY, and that is the point of injecting it.
+  // What this test pins is the drain loop's identifier bindings and its use of
+  // queueDrained — a missing binding throws a ReferenceError right here. It is not
+  // a timing test, so it must not depend on a real timer winning a race.
+  //
+  // A sleeping stub made it FLAKY: waitForQueueDrain opens with a fixed
+  // boundedDelay(1000, deadline) warm-up, and under load (a loaded machine, the
+  // suite's own parallelism) that timer plus scheduling can consume the whole
+  // 5000ms budget before two polls complete. The loop then exits on its deadline
+  // with status still null, queueDrained(null) is false, and the assertion fails
+  // for a reason that has nothing to do with the code under test. Observed at
+  // 3.4s / 10.4s / 10.5s across consecutive runs on the same commit.
+  //
+  // Resolving instantly keeps every assertion meaningful: Date.now() barely moves,
+  // so the deadline is still in the future, both polls still run in order, and the
+  // drained status is still reached through the real loop.
+  const delays = [];
+  const boundedDelay = (ms, deadline) => {
+    delays.push({ ms, remaining: deadline - Date.now() });
+    return Promise.resolve();
+  };
   let polls = 0;
   const managerGet = async () => {
     // First poll: still processing; second: positively drained.
@@ -607,6 +626,19 @@ test("waitForQueueDrain (real panel source) returns a drained status without Ref
   const status = await realWait({ timeoutMs: 5000, intervalMs: 10 });
   assert.equal(queueDrained(status), true, "should return a positively-drained status");
   assert.ok(polls >= 2, "should have polled until drained");
+  // The delays are now observable rather than merely endured, so the loop's own
+  // pacing is asserted instead of being taken on trust: a warm-up before the first
+  // poll, then the caller's interval between polls. Each is bounded by the budget
+  // that remains, which is what stops a long interval from overrunning the deadline.
+  assert.deepEqual(
+    delays.map((d) => d.ms),
+    [1000, 10],
+    "one warm-up before the first poll, then the caller's intervalMs between polls",
+  );
+  assert.ok(
+    delays.every((d) => d.remaining > 0),
+    "every delay is handed the remaining budget, so it can be capped by the deadline",
+  );
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
`waitForQueueDrain (real panel source)` fails intermittently on a clean `main`. Same commit, consecutive runs: **3.4s pass, 10.4s fail, 10.5s fail.**

**Not a bug in the code under test.** The function opens with a fixed `boundedDelay(1000, deadline)` warm-up before its first poll, and the test gave it a 5000ms budget while stubbing `boundedDelay` with a **real `setTimeout`**. On a loaded machine — and this suite runs its files in parallel — that timer plus scheduling can consume the whole budget before two polls complete. The loop exits on its deadline with `status` still `null`, `queueDrained(null)` is false, and the assertion fails for a reason that has nothing to do with the code.

The stub was already injected, so the fix is to stop depending on wall-clock at all: **`boundedDelay` now resolves immediately.** What this test pins is the drain loop's identifier bindings and its use of `queueDrained` — a missing binding throws a ReferenceError right here — not timing. Resolving instantly keeps every assertion meaningful: `Date.now()` barely moves, the deadline stays in the future, both polls still run in order, and the drained status is still reached through the real loop.

## It is now stricter than it was

Recording the delays instead of merely enduring them let the test assert the loop's **own pacing** — a warm-up before the first poll, then the caller's `intervalMs` between polls — and that each delay is handed the remaining budget, which is what stops a long interval overrunning the deadline.

**Mutation-verified, both killed — and note the first one the old test could not catch:**

| mutant | result |
|---|---|
| drop the warm-up before the first poll | **fails** (old test would have passed) |
| return without checking `queueDrained` | **fails** |

## Verification

- 8/8 consecutive runs of the file, **3.3–5.2ms each** (was 3400–10500ms)
- Full suite **1978/1978**, `tsc` clean, zero control bytes

## Noted, not changed

Sweeping for the same pattern: `workflow-grounding.test.mjs:156` sleeps 15ms to *"let turn1 reach the hung commit"*, and `restart-tab-identity.test.mjs:92` sleeps 40ms. Both are race-dependent on a real timer and are latent flakes of this class. They pass today, so I left them alone rather than churn tests without evidence — but that is where to look if this recurs.

This is the panel twin of orchestrator #821 (a fixture binding a guessed random port, hanging ~1 in 8), fixed in #843 and shipped in 0.49.6. Same principle both times: **remove the mechanism, do not widen the tolerance.** A longer fuse on a race is not a fix, and a suite that cries wolf will eventually mask a real break.