### PR TITLE
workflow_open: the dialect hypothesis is refuted — name what the open could not prove, and prove the rebind with evidence a stale tag cannot fake

### DIFF
--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -467,7 +467,7 @@ test("#721 P1: an already-active workflow requires state even when empty, then p
     "a state-less EMPTY target cannot report opened against the prior canvas",
   );
   const repaintAt = body.indexOf("await app.loadGraphData(repaintState, true, true, target);");
-  const proofAt = body.indexOf("graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid: targetUuid })", repaintAt);
+  const proofAt = body.indexOf("const verdict = resolveOpenRebindVerdict({", repaintAt);
   const openedAt = body.lastIndexOf("applied: true");
   assert.ok(repaintAt !== -1 && proofAt > repaintAt && openedAt > proofAt, "must prove the repaint before success");
   // A failed/missing repaint is an honest unknown after s.openWorkflow may have
@@ -484,9 +484,17 @@ test("#721 P1: dirty rebind success requires the target UUID, never only a read-
   assert.match(repaint, /const targetUuid = workflowStableUuid\(target, \{ embed: true \}\);/);
   assert.match(repaint, /\[WORKFLOW_UUID_FIELD\]: targetUuid/);
   assert.match(repaint, /await app\.loadGraphData\(repaintState, true, true, target\);/);
-  assert.match(repaint, /activeWorkflowRef\(\) !== target/);
+  // The instance check is PROXY-SAFE. A bare `!==` compares a Vue proxy against a raw
+  // lookup result and can report a tab switch that never happened (#558 r2) — a false
+  // negative on the one part that makes every other part meaningless.
+  assert.match(repaint, /const instanceStillTarget = sameWorkflowObject\(activeNow, target\);/);
+  assert.doesNotMatch(repaint, /activeWorkflowRef\(\) !== target/, "the raw-identity comparison must be gone");
   assert.match(repaint, /graphRootWorkflowUuidMatches\(\{ rootGraph, activeWorkflowUuid: targetUuid \}\)/);
   assert.match(repaint, /graphRootMatchesState\(\{ rootGraph, state: repaintState \}\)/);
+  // The ATTEMPT-scoped marker: a workflow uuid can be on the root from a previous load
+  // or a rebind heal, so it cannot say that THIS load landed.
+  assert.match(repaint, /\[OPEN_PROOF_FIELD\]: openProofMarker/, "the payload must carry a single-use marker");
+  assert.match(repaint, /graphRootCarriesOpenProof\(\{ rootGraph, proofMarker: openProofMarker \}\)/);
   assert.doesNotMatch(repaint, /assertGraphBoundToActiveWorkflow\(/, "the read guard is deliberately non-strict for dirty roots");
 });
 

--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -458,11 +458,42 @@ test("an ABSENT contentComparable takes the non-asserting wording, never the mis
   });
   for (const unstated of [undefined, null, "true", 1]) {
     const text = describeOpenRebindOutcome(verdict, { targetLabel: "a.json", contentComparable: unstated });
-    assert.doesNotMatch(
-      text,
-      /does not match the state that was loaded/,
-      `an unstated comparability (${JSON.stringify(unstated)}) must not license a mismatch claim`,
+    const why = `an unstated comparability (${JSON.stringify(unstated)})`;
+    assert.doesNotMatch(text, /does not match the state that was loaded/, `${why} must not license a HEADLINE mismatch claim`);
+    // ...and the per-part CLAUSE must not smuggle the same claim back in. The first cut
+    // fixed only the headline: the clause tested `=== false`, so an absent value fell
+    // down the opposite branch and the one disclosure contradicted itself — it said
+    // "could not READ … NOT established as wrong" and then "the graph … differs".
+    assert.doesNotMatch(text, /differs from what was loaded/, `${why} must not license a CLAUSE mismatch claim either`);
+    assert.match(text, /could not compare the loaded graph/, `${why} must say a comparison did not happen`);
+  }
+});
+
+test("the headline and the content clause always agree about whether a comparison happened", () => {
+  // They are two sentences in ONE disclosure and were derived from opposite tests
+  // (`=== true` vs `=== false`). Whatever the input, they must never state both
+  // "could not read it" and "it differs".
+  const verdict = resolveOpenRebindVerdict({
+    instanceStillTarget: true,
+    markerMatches: true,
+    identityMatches: true,
+    contentMatches: false,
+  });
+  for (const value of [true, false, undefined, null, "true", 1, 0, {}]) {
+    const text = describeOpenRebindOutcome(verdict, {
+      targetLabel: "a.json",
+      contentComparable: value,
+      contentSurfaces: ["nodes"],
+    });
+    const claimsDifference = /differs from what was loaded/.test(text) || /does not match the state that was loaded/.test(text);
+    const claimsUnreadable = /could not compare the loaded graph/.test(text) || /could not READ the graph on it/.test(text);
+    assert.notEqual(
+      claimsDifference && claimsUnreadable,
+      true,
+      `contentComparable=${JSON.stringify(value)} produced a self-contradicting disclosure`,
     );
+    assert.equal(claimsDifference || claimsUnreadable, true, "it must say one or the other");
+    assert.equal(claimsDifference, value === true, "only an explicit `true` may license the difference claim");
   }
 });
 

--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -419,7 +419,76 @@ test("an UNCOMPARABLE content check is disclosed as unknown, not as a difference
     contentSurfaces: [],
   });
   assert.match(text, /UNKNOWN/, "an absent comparison must be stated as unknown");
-  assert.doesNotMatch(text, /differs from what was loaded on/, "it must not claim a difference it never observed");
+  assert.doesNotMatch(text, /differs from what was loaded on/, "the CLAUSE must not claim a difference it never observed");
+  // ...and neither may the SENTENCE IN FRONT of it. `graphRootMatchesState` returns
+  // false for both "compared and differed" and "could not read the root", so the
+  // headline used to report a definite mismatch for a canvas nobody could look at —
+  // the could-not-determine/determined-not fold, inside the fix meant to remove it.
+  assert.doesNotMatch(text, /does not match the state that was loaded/, "the headline must not assert it either");
+  assert.match(text, /could not READ the graph on it/, "it must say what actually happened");
+  assert.match(text, /NOT established as wrong/);
+  // The binding half is still stated as settled — that part WAS observed.
+  assert.match(text, /canvas IS bound to a\.json/);
+});
+
+test("a COMPARED content mismatch still says so plainly — the fix must not blunt the real case", () => {
+  const verdict = resolveOpenRebindVerdict({
+    instanceStillTarget: true,
+    markerMatches: true,
+    identityMatches: true,
+    contentMatches: false,
+  });
+  const text = describeOpenRebindOutcome(verdict, {
+    targetLabel: "a.json",
+    contentComparable: true,
+    contentSurfaces: ["nodes"],
+  });
+  assert.match(text, /does not match the state that was loaded/);
+  assert.doesNotMatch(text, /could not READ the graph on it/);
+});
+
+test("an ABSENT contentComparable takes the non-asserting wording, never the mismatch claim", () => {
+  // A caller that reports nothing about comparability has not established one, and
+  // the safe direction for an unstated observation is the one that claims less.
+  const verdict = resolveOpenRebindVerdict({
+    instanceStillTarget: true,
+    markerMatches: true,
+    identityMatches: true,
+    contentMatches: false,
+  });
+  for (const unstated of [undefined, null, "true", 1]) {
+    const text = describeOpenRebindOutcome(verdict, { targetLabel: "a.json", contentComparable: unstated });
+    assert.doesNotMatch(
+      text,
+      /does not match the state that was loaded/,
+      `an unstated comparability (${JSON.stringify(unstated)}) must not license a mismatch claim`,
+    );
+  }
+});
+
+test("the marker is NOT a superset of the uuid check — both are required", () => {
+  // The overclaim an independent gate caught: a root carrying THIS attempt's marker
+  // alongside a DIFFERENT workflow's uuid passes the marker and fails the identity
+  // check. They answer different questions ("did this attempt configure it" vs "whose
+  // workflow is it"), so treating the marker as the stronger check would licence
+  // dropping the identity one in a later refactor — a real hole from a comment.
+  const foreign = liveRoot({
+    nodes: [],
+    extra: { [PANEL_GRAPH_META_KEY]: { workflow_uuid: "workflow-B", [OPEN_PROOF_FIELD]: MARKER } },
+  });
+  assert.equal(graphRootCarriesOpenProof({ rootGraph: foreign, proofMarker: MARKER }), true, "marker passes");
+  assert.equal(graphRootWorkflowUuidMatches({ rootGraph: foreign, activeWorkflowUuid: UUID_A }), false, "identity fails");
+  // ...and the verdict ANDs them, so the combination is still refused.
+  assert.equal(
+    resolveOpenRebindVerdict({
+      instanceStillTarget: true,
+      markerMatches: true,
+      identityMatches: false,
+      contentMatches: true,
+    }).bindingProven,
+    false,
+    "the AND is what makes the pair safe — neither predicate covers the other",
+  );
 });
 
 test("only the parts that actually failed are narrated", () => {

--- a/browser_tests/unit/open-rebind-proof.test.mjs
+++ b/browser_tests/unit/open-rebind-proof.test.mjs
@@ -1,0 +1,556 @@
+// workflow_open's post-repaint rebind proof — #604 (item 3), #603 (item 4),
+// #616 (recovery path), #374 (reopen), #641 (the mirror report).
+//
+// The field symptom: `panel_open_workflow` answered "could not prove that the
+// active canvas was rebound to the requested workflow" on EVERY call, surfacing
+// as `applied:"unknown"`, which also disabled the recovery every one of those
+// issues points at ("re-open the tab to rebind the graph").
+//
+// The standing hypothesis was that the proof compared two serializer DIALECTS —
+// `rootGraph.serialize()` against a `changeTracker.activeState`. That is REFUTED:
+// `graphRootMatchesState` normalizes BOTH sides through the same `graphShape`
+// (that is what #560 built), and `activeState` is itself a clone of
+// `rootGraph.serialize()`, so the two sides are the same dialect by construction.
+//
+// The defect is one level up and is the same SHAPE: the content check answers
+// "did the load land faithfully?" and was read as the answer to "is this the
+// canvas I asked for?". `loadGraphData` TRANSFORMS the payload it is handed
+// before the root serializes again — it grows every node to at least
+// `computeSize()`, rewrites null combo values and `control_after_generate`,
+// may substitute a schema-validated copy of the payload, and runs every
+// installed extension's `loadedGraphNode` hook on every node. A canvas that was
+// rebound perfectly therefore differs from the bytes handed in, and denying the
+// rebind for it is a false negative on a question the marker already answers.
+//
+// The fix does NOT loosen the #349 wrong-canvas fence. It replaces the weaker
+// binding evidence with STRONGER evidence: a single-use marker minted per
+// attempt and written into that attempt's payload. `configure()` replaces
+// `graph.extra` wholesale from the data it is given, so nothing but this load
+// can put that value on the live root — where a WORKFLOW uuid could already be
+// there from a previous load of the same tab or from the guard's own rebind
+// heal (#545/#557/#565).
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  describeGraphStateDifference,
+  describeOpenRebindOutcome,
+  graphRootCarriesOpenProof,
+  graphRootMatchesState,
+  graphRootWorkflowUuidMatches,
+  resolveOpenRebindVerdict,
+  OPEN_PROOF_FIELD,
+  OPEN_REBIND_STATUS,
+  PANEL_GRAPH_META_KEY,
+} from "../../web/js/lib/graph-binding.js";
+import { shouldForkEmbeddedUuidForLiveOwner } from "../../web/js/lib/workflow-chat-identity.js";
+
+const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+
+/** A live root as the panel sees it: `_nodes` plus a `serialize()`, and the
+ *  `extra` the panel reads its markers off (LiteGraph's `configure()` installs
+ *  `extra` on the graph object itself, which is why the marker is readable
+ *  there and not only through `serialize()`). */
+const liveRoot = (serialized) => ({
+  _nodes: (serialized.nodes ?? []).map(({ id, type }) => ({ id, type })),
+  extra: serialized.extra ?? {},
+  serialize: () => serialized,
+});
+
+const UUID_A = "workflow-A";
+const MARKER = "marker-for-this-attempt";
+
+/** The payload workflow_open builds: the tab's own state plus the panel's tags. */
+const payload = (nodes, extra = {}) => ({
+  nodes,
+  links: [[1, 1, 0, 2, 0, "MODEL"]],
+  extra: {
+    ...extra,
+    [PANEL_GRAPH_META_KEY]: {
+      workflow_uuid: UUID_A,
+      workflow_path: "workflows/a.json",
+      [OPEN_PROOF_FIELD]: MARKER,
+    },
+  },
+});
+
+const NODES = [
+  { id: 1, type: "CheckpointLoaderSimple", pos: [10, 10], size: [270, 98], widgets_values: ["m.safetensors"] },
+  { id: 2, type: "KSampler", pos: [400, 10], size: [315, 262], widgets_values: [1, "fixed", 20] },
+];
+
+// ── the reported failure: a FAITHFUL open that the loader transformed ────────
+
+test("#604/#603/#616: the reported failure — a faithful repaint the frontend NORMALIZED", () => {
+  const loaded = payload(NODES);
+  // What loadGraphData actually leaves behind: every node grown to at least
+  // computeSize() and snapped, and the extra surfaces LiteGraph re-emits. The
+  // graph is the one we asked for; the bytes are not the ones we handed in.
+  const afterLoad = {
+    ...structuredClone(loaded),
+    nodes: [
+      { ...structuredClone(NODES[0]), size: [280, 106] },
+      { ...structuredClone(NODES[1]), size: [320, 270] },
+    ],
+    groups: [],
+    reroutes: [],
+    config: {},
+    extra: { ...structuredClone(loaded.extra), ds: { scale: 0.85, offset: [3, 4] } },
+  };
+  const rootGraph = liveRoot(afterLoad);
+
+  // The content check FAILS — correctly. It is a FIDELITY question and the bytes differ.
+  assert.equal(graphRootMatchesState({ rootGraph, state: loaded }), false, "content genuinely differs");
+  // ...and every BINDING part passes.
+  assert.equal(graphRootCarriesOpenProof({ rootGraph, proofMarker: MARKER }), true);
+  assert.equal(graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid: UUID_A }), true);
+
+  const verdict = resolveOpenRebindVerdict({
+    instanceStillTarget: true,
+    markerMatches: true,
+    identityMatches: true,
+    contentMatches: false,
+  });
+  // Assert the REASON, not just the state. The OUTCOME is unchanged — workflow_open
+  // still answers `unknown` here, deliberately (see the next test). What changed is
+  // that the panel now KNOWS which half is settled and can say so.
+  assert.equal(verdict.status, OPEN_REBIND_STATUS.CONTENT_UNVERIFIED);
+  assert.equal(verdict.bindingProven, true, "the canvas IS the requested workflow, and that is now proven");
+  assert.deepEqual(verdict.unproven, ["content"]);
+
+  const text = describeOpenRebindOutcome(verdict, {
+    targetLabel: "a.json",
+    contentComparable: true,
+    contentSurfaces: describeGraphStateDifference({ rootGraph, state: loaded }).surfaces,
+  });
+  assert.match(text, /canvas IS bound to a\.json/, "the settled half must be stated as settled");
+  assert.match(text, /You are NOT on the wrong workflow/, "the old message's worst implication is retracted");
+  assert.match(text, /UNKNOWN/, "...while the unsettled half stays unknown");
+  assert.match(text, /nodes/, "the disclosure must name WHICH surface disagreed");
+});
+
+test("a CONTENT mismatch is still NOT a success — the relaxation was tried and reverted", () => {
+  // Softening this into an applied open was implemented here and then withdrawn.
+  // LiteGraph creates every node (id and type) and THEN configures each one, and
+  // loadGraphData catches a configure() failure and returns. A throw in that second
+  // pass leaves the complete node id/type set, the links, and this attempt's marker —
+  // written by _configureBase before any node is built — over nodes that silently LOST
+  // their widget values. That observation is byte-identical to "the loader normalized
+  // the widget values", and no evidence available to the panel separates them.
+  // Reporting it as applied would fabricate a success over data loss.
+  const loaded = payload(NODES);
+  const widgetsLost = structuredClone(loaded);
+  delete widgetsLost.nodes[1].widgets_values;
+  const rootGraph = liveRoot(widgetsLost);
+
+  assert.equal(graphRootCarriesOpenProof({ rootGraph, proofMarker: MARKER }), true, "the marker DID land");
+  const verdict = resolveOpenRebindVerdict({
+    instanceStillTarget: true,
+    markerMatches: true,
+    identityMatches: true,
+    contentMatches: graphRootMatchesState({ rootGraph, state: loaded }),
+  });
+  assert.notEqual(verdict.status, OPEN_REBIND_STATUS.PROVEN, "a lost widget value is never a proven open");
+  assert.equal(verdict.status, OPEN_REBIND_STATUS.CONTENT_UNVERIFIED);
+});
+
+test("a PARTLY APPLIED load carries this attempt's marker and must still not be PROVEN", () => {
+  // The same route at its most extreme: the marker rides in `extra`, which
+  // _configureBase installs BEFORE any node is built, so a configure() that throws
+  // early leaves the root carrying this attempt's marker AND uuid over an empty graph.
+  const loaded = payload(NODES);
+  const rootGraph = liveRoot({ ...structuredClone(loaded), nodes: [] });
+
+  assert.equal(graphRootCarriesOpenProof({ rootGraph, proofMarker: MARKER }), true, "the marker DID land");
+  assert.equal(graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid: UUID_A }), true, "the uuid DID land");
+
+  const verdict = resolveOpenRebindVerdict({
+    instanceStillTarget: true,
+    markerMatches: true,
+    identityMatches: true,
+    contentMatches: graphRootMatchesState({ rootGraph, state: loaded }),
+  });
+  assert.notEqual(verdict.status, OPEN_REBIND_STATUS.PROVEN, "a truncated canvas is never a completed open");
+  assert.deepEqual(verdict.unproven, ["content"]);
+});
+
+// ── the #349 direction: this must still catch a canvas that was NOT rebound ──
+
+test("#349: a load that leaves the PREVIOUS canvas mounted is still UNPROVEN", () => {
+  // loadGraphData resolved, but the canvas is still tab B's graph. B's root
+  // carries B's own tags — it cannot carry a marker minted seconds ago for A.
+  const otherTab = {
+    nodes: [{ id: 9, type: "SaveImage" }],
+    extra: { [PANEL_GRAPH_META_KEY]: { workflow_uuid: "workflow-B", [OPEN_PROOF_FIELD]: "some-older-marker" } },
+  };
+  const rootGraph = liveRoot(otherTab);
+  assert.equal(graphRootCarriesOpenProof({ rootGraph, proofMarker: MARKER }), false);
+
+  const verdict = resolveOpenRebindVerdict({
+    instanceStillTarget: true,
+    markerMatches: graphRootCarriesOpenProof({ rootGraph, proofMarker: MARKER }),
+    identityMatches: graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid: UUID_A }),
+    contentMatches: graphRootMatchesState({ rootGraph, state: payload(NODES) }),
+  });
+  assert.equal(verdict.status, OPEN_REBIND_STATUS.UNPROVEN);
+  assert.equal(verdict.bindingProven, false, "a wrong canvas must never be reported as bound");
+  assert.deepEqual(verdict.unproven, ["marker", "identity"]);
+});
+
+test("#349: the marker is what a stale ROOT TAG cannot fake — the hole the uuid alone left", () => {
+  // The exact case the workflow uuid cannot decide: the root already carries A's
+  // uuid (a previous load of A, or the guard's rebind heal stamped it) while the
+  // canvas holds a DIFFERENT graph and our load never landed. The old proof's
+  // identity part passes here; only content stood between this and a fabricated
+  // success. The attempt-scoped marker refuses it on the BINDING question itself.
+  const staleRootWithOurTag = {
+    nodes: [{ id: 9, type: "SaveImage" }],
+    extra: { [PANEL_GRAPH_META_KEY]: { workflow_uuid: UUID_A } },
+  };
+  const rootGraph = liveRoot(staleRootWithOurTag);
+  assert.equal(
+    graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid: UUID_A }),
+    true,
+    "the workflow uuid is satisfied by a stale tag — that is why it is not sufficient",
+  );
+  assert.equal(graphRootCarriesOpenProof({ rootGraph, proofMarker: MARKER }), false);
+  const verdict = resolveOpenRebindVerdict({
+    instanceStillTarget: true,
+    markerMatches: false,
+    identityMatches: true,
+    contentMatches: false,
+  });
+  assert.equal(verdict.bindingProven, false);
+  assert.deepEqual(verdict.unproven, ["marker"]);
+});
+
+test("a tab switch during the load makes every other observation describe another canvas", () => {
+  // Even with a perfect marker and content match: if the active workflow is no
+  // longer the target, what was proven was proven about someone else's tab.
+  const verdict = resolveOpenRebindVerdict({
+    instanceStillTarget: false,
+    markerMatches: true,
+    identityMatches: true,
+    contentMatches: true,
+  });
+  assert.equal(verdict.status, OPEN_REBIND_STATUS.UNPROVEN);
+  assert.deepEqual(verdict.unproven, ["instance"]);
+});
+
+test("an UNREADABLE observation is not a passing one — every part is compared against true", () => {
+  for (const absent of [undefined, null, "yes", 1, {}]) {
+    assert.equal(
+      resolveOpenRebindVerdict({
+        instanceStillTarget: absent,
+        markerMatches: true,
+        identityMatches: true,
+        contentMatches: true,
+      }).bindingProven,
+      false,
+      `a non-true instance observation (${JSON.stringify(absent)}) must not prove the rebind`,
+    );
+    assert.equal(
+      resolveOpenRebindVerdict({
+        instanceStillTarget: true,
+        markerMatches: absent,
+        identityMatches: true,
+        contentMatches: true,
+      }).bindingProven,
+      false,
+      `a non-true marker observation (${JSON.stringify(absent)}) must not prove the rebind`,
+    );
+  }
+  assert.equal(resolveOpenRebindVerdict().status, OPEN_REBIND_STATUS.UNPROVEN, "no observations at all proves nothing");
+});
+
+test("a fully faithful load is PROVEN, so the ordinary open is untouched", () => {
+  const loaded = payload(NODES);
+  const rootGraph = liveRoot(structuredClone(loaded));
+  const verdict = resolveOpenRebindVerdict({
+    instanceStillTarget: true,
+    markerMatches: graphRootCarriesOpenProof({ rootGraph, proofMarker: MARKER }),
+    identityMatches: graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid: UUID_A }),
+    contentMatches: graphRootMatchesState({ rootGraph, state: loaded }),
+  });
+  assert.equal(verdict.status, OPEN_REBIND_STATUS.PROVEN);
+  assert.deepEqual(verdict.unproven, []);
+  assert.equal(describeOpenRebindOutcome(verdict, {}), "", "a proven open says nothing extra");
+});
+
+// ── the marker itself ────────────────────────────────────────────────────────
+
+test("graphRootCarriesOpenProof: only an EXACT match of a real marker proves anything", () => {
+  const withMarker = liveRoot({ nodes: [], extra: { [PANEL_GRAPH_META_KEY]: { [OPEN_PROOF_FIELD]: MARKER } } });
+  assert.equal(graphRootCarriesOpenProof({ rootGraph: withMarker, proofMarker: MARKER }), true);
+  assert.equal(graphRootCarriesOpenProof({ rootGraph: withMarker, proofMarker: "other" }), false);
+  // An EMPTY expectation must never be satisfiable — otherwise a failure to mint
+  // a marker would silently prove every canvas.
+  assert.equal(graphRootCarriesOpenProof({ rootGraph: withMarker, proofMarker: "" }), false);
+  assert.equal(graphRootCarriesOpenProof({ rootGraph: withMarker }), false);
+  assert.equal(graphRootCarriesOpenProof({ rootGraph: liveRoot({ nodes: [] }), proofMarker: MARKER }), false);
+  assert.equal(graphRootCarriesOpenProof({ proofMarker: MARKER }), false, "no root proves nothing");
+  // A non-string marker on the root (a doctored or half-written extra) is not a match.
+  const numeric = liveRoot({ nodes: [], extra: { [PANEL_GRAPH_META_KEY]: { [OPEN_PROOF_FIELD]: 7 } } });
+  assert.equal(graphRootCarriesOpenProof({ rootGraph: numeric, proofMarker: "7" }), false);
+});
+
+test("the marker rides in the panel's own namespace, so it can never affect a CONTENT comparison", () => {
+  // Both sides are written with LITERAL key names, not the exported constants. Using
+  // the constants makes this test self-consistent and therefore blind: move the field
+  // out of the panel namespace and a constants-based fixture moves with it and still
+  // passes, while the live root — whose `extra` comes from ComfyUI, not from us —
+  // would put the marker where the content comparison can see it, and every repaint
+  // would mismatch. That is the false negative this whole change removes,
+  // reintroduced by the fix.
+  assert.equal(PANEL_GRAPH_META_KEY, "comfyui_mcp", "the namespace buildGraphShape strips");
+  assert.equal(OPEN_PROOF_FIELD, "open_proof");
+  const state = { nodes: NODES, extra: { comfyui_mcp: { workflow_uuid: UUID_A } } };
+  const withMarker = {
+    nodes: structuredClone(NODES),
+    extra: { comfyui_mcp: { workflow_uuid: UUID_A, open_proof: MARKER } },
+  };
+  assert.equal(graphRootMatchesState({ rootGraph: liveRoot(withMarker), state }), true);
+  // ...and the reader looks in that same literal place.
+  assert.equal(graphRootCarriesOpenProof({ rootGraph: liveRoot(withMarker), proofMarker: MARKER }), true);
+  // A marker parked anywhere else is NOT a proof, and IS content.
+  const topLevel = { nodes: structuredClone(NODES), extra: { comfyui_mcp: { workflow_uuid: UUID_A }, open_proof: MARKER } };
+  assert.equal(graphRootCarriesOpenProof({ rootGraph: liveRoot(topLevel), proofMarker: MARKER }), false);
+  assert.equal(graphRootMatchesState({ rootGraph: liveRoot(topLevel), state }), false);
+});
+
+// ── "could not compare" is never "compared and they differ" ──────────────────
+
+test("describeGraphStateDifference: an unshapeable side reports NOT COMPARABLE, never a difference", () => {
+  const state = payload(NODES);
+  assert.deepEqual(describeGraphStateDifference({ rootGraph: { serialize: () => null }, state }), {
+    comparable: false,
+    surfaces: [],
+  });
+  assert.deepEqual(
+    describeGraphStateDifference({
+      rootGraph: {
+        serialize: () => {
+          throw new Error("serializer unavailable");
+        },
+      },
+      state,
+    }),
+    { comparable: false, surfaces: [] },
+    "a THROWING serializer is an absent observation, not evidence of a mismatch",
+  );
+  assert.deepEqual(describeGraphStateDifference({ rootGraph: liveRoot(structuredClone(state)) }), {
+    comparable: false,
+    surfaces: [],
+  });
+  assert.deepEqual(describeGraphStateDifference(), { comparable: false, surfaces: [] });
+});
+
+test("describeGraphStateDifference: names the surfaces that disagreed, and only those", () => {
+  const state = payload(NODES);
+  const equal = describeGraphStateDifference({ rootGraph: liveRoot(structuredClone(state)), state });
+  assert.deepEqual(equal, { comparable: true, surfaces: [] });
+
+  const nodesDiffer = structuredClone(state);
+  nodesDiffer.nodes = [nodesDiffer.nodes[0]];
+  assert.deepEqual(describeGraphStateDifference({ rootGraph: liveRoot(nodesDiffer), state }), {
+    comparable: true,
+    surfaces: ["nodes"],
+  });
+
+  const groupsDiffer = structuredClone(state);
+  groupsDiffer.groups = [{ title: "G", bounding: [0, 0, 10, 10] }];
+  assert.deepEqual(describeGraphStateDifference({ rootGraph: liveRoot(groupsDiffer), state }), {
+    comparable: true,
+    surfaces: ["groups"],
+  });
+
+  // Serializer DIALECT must not be named as a difference — it is not one (#560).
+  const dialect = structuredClone(state);
+  dialect.reroutes = [];
+  dialect.config = {};
+  dialect.extra.ds = { scale: 1.1, offset: [0, 0] };
+  assert.deepEqual(describeGraphStateDifference({ rootGraph: liveRoot(dialect), state }), {
+    comparable: true,
+    surfaces: [],
+    // A present-but-empty surface and a viewport are dialect, and this must agree
+    // with graphRootMatchesState exactly — one normalization, two readings of it.
+  });
+  assert.equal(graphRootMatchesState({ rootGraph: liveRoot(dialect), state }), true);
+});
+
+// ── the disclosure ───────────────────────────────────────────────────────────
+
+test("the UNPROVEN disclosure never invites a clean retry and never asserts a cause it did not observe", () => {
+  const verdict = resolveOpenRebindVerdict({ instanceStillTarget: false, markerMatches: false, identityMatches: false });
+  const text = describeOpenRebindOutcome(verdict, {
+    targetLabel: "a.json",
+    activeLabel: "b.json",
+    expectedMarker: "M1",
+    observedMarker: null,
+    expectedUuid: UUID_A,
+    observedUuid: "workflow-B",
+    contentComparable: true,
+    contentSurfaces: [],
+  });
+  // workflow_open is destructive and its load has ALREADY run — a disclosure, never
+  // a refusal that reads as "nothing happened".
+  assert.match(text, /RAN/, "it must say the open ran");
+  assert.doesNotMatch(text, /nothing (was )?(changed|happened)/i);
+  assert.doesNotMatch(text, /retrying is safe/i);
+  // It must name WHICH values disagreed — "the fence rejected" is not actionable.
+  assert.match(text, /a\.json/);
+  assert.match(text, /b\.json/);
+  assert.match(text, /M1/);
+  assert.match(text, /workflow-B/);
+});
+
+test("an UNCOMPARABLE content check is disclosed as unknown, not as a difference", () => {
+  const verdict = resolveOpenRebindVerdict({
+    instanceStillTarget: true,
+    markerMatches: true,
+    identityMatches: true,
+    contentMatches: false,
+  });
+  const text = describeOpenRebindOutcome(verdict, {
+    targetLabel: "a.json",
+    contentComparable: false,
+    contentSurfaces: [],
+  });
+  assert.match(text, /UNKNOWN/, "an absent comparison must be stated as unknown");
+  assert.doesNotMatch(text, /differs from what was loaded on/, "it must not claim a difference it never observed");
+});
+
+test("only the parts that actually failed are narrated", () => {
+  const verdict = resolveOpenRebindVerdict({
+    instanceStillTarget: true,
+    markerMatches: false,
+    identityMatches: true,
+    contentMatches: true,
+  });
+  const text = describeOpenRebindOutcome(verdict, {
+    targetLabel: "a.json",
+    activeLabel: "a.json",
+    expectedMarker: "M1",
+    observedMarker: "M0",
+    expectedUuid: UUID_A,
+    observedUuid: UUID_A,
+  });
+  assert.match(text, /one-time marker/);
+  assert.doesNotMatch(text, /the active workflow changed during the load/, "an instance check that PASSED must not be blamed");
+  assert.doesNotMatch(text, /graph-command fence/, "an identity check that PASSED must not be blamed");
+  // ...and the PREFIX must not smuggle the same unobserved cause back in. This was a
+  // gate finding: the named clauses were careful, and then the sentence in front of
+  // them said "the open may have switched the active workflow" regardless. And no branch
+  // may narrate a tab SWITCH: the check reads "is the active workflow this target now",
+  // which does not witness a switch and is equally true if the target was already active.
+  assert.doesNotMatch(text, /could not confirm which workflow is active/, "a confirmed active workflow is not unconfirmed");
+  assert.match(text, /a\.json IS the active workflow/, "a check that passed is information — state it");
+  // ...and no branch may narrate a tab SWITCH at all. The check reads "is the active
+  // workflow this target NOW"; it does not witness a switch, and it is equally true
+  // when the target was already active before the call.
+  assert.doesNotMatch(text, /switch/i, "no branch may narrate an event the panel did not witness");
+});
+
+test("...but an unproven instance DOES say which workflow is active is unconfirmed", () => {
+  const verdict = resolveOpenRebindVerdict({ instanceStillTarget: false, markerMatches: true, identityMatches: true });
+  const text = describeOpenRebindOutcome(verdict, { targetLabel: "a.json", activeLabel: "b.json" });
+  assert.match(text, /could not confirm which workflow is active/);
+  assert.doesNotMatch(text, /a\.json IS the active workflow/);
+  assert.doesNotMatch(text, /switch/i, "even here, no witnessed switch may be claimed");
+});
+
+test("an UNREADABLE active workflow is 'could not confirm', never 'it changed'", () => {
+  // The instance observation is `!== true`, which an unreadable pointer produces just
+  // as a real tab switch does. Wording it as a switch states a cause for a reading
+  // that was never taken — the same could-not-determine-becomes-a-verdict defect this
+  // whole cluster is about, in the message instead of the logic.
+  for (const unreadable of [undefined, null]) {
+    const verdict = resolveOpenRebindVerdict({ instanceStillTarget: unreadable, markerMatches: true, identityMatches: true });
+    const text = describeOpenRebindOutcome(verdict, { targetLabel: "a.json", activeLabel: "no active tab" });
+    assert.match(text, /could not confirm the active workflow is still a\.json/);
+    assert.doesNotMatch(text, /changed during the load/, "an unread pointer is not an observed change");
+  }
+});
+
+// ── wiring: the panel must actually use all of this ──────────────────────────
+
+test("wiring: every non-proven verdict keeps the honest `unknown`, with the named cause", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  // One outcome for every non-proven verdict — the split buys a better MESSAGE, not a
+  // softer answer. A branch that turned a binding-proven verdict into a success is
+  // exactly what was reverted, so its absence is asserted.
+  assert.match(src, /if \(verdict\.status !== OPEN_REBIND_STATUS\.PROVEN\) \{/);
+  assert.match(src, /rebindFailed = new Error\(\r?\n\s*describeOpenRebindOutcome\(verdict, \{/);
+  assert.doesNotMatch(src, /contentUnverified/, "the applied-with-caveat path must be gone");
+  assert.doesNotMatch(src, /content_verified/, "...and so must its reply field");
+  // The surface diff feeds the MESSAGE only, and is computed only once something failed.
+  const failAt = src.indexOf("if (verdict.status !== OPEN_REBIND_STATUS.PROVEN) {");
+  assert.ok(src.indexOf("describeGraphStateDifference({ rootGraph, state: repaintState })", failAt) > failAt);
+  // The marker is stripped only AFTER the verdict is decided — evidence first. Asserted
+  // over EVERY deletion of the field, not just the one we wrote: pinning a single known
+  // statement leaves the file free to grow an earlier one, and a marker deleted before
+  // it is read makes the proof fail for a canvas that was rebound perfectly.
+  const verdictAt = src.indexOf("const verdict = resolveOpenRebindVerdict({");
+  assert.notEqual(verdictAt, -1);
+  const deletions = [...src.matchAll(/delete\s+[^;\n]*\[OPEN_PROOF_FIELD\]/g)].map((m) => m.index);
+  assert.ok(deletions.length >= 1, "the marker must be stripped so it does not ride the user's next save");
+  for (const at of deletions) {
+    assert.ok(at > verdictAt, "no deletion of the marker may precede the verdict that reads it");
+  }
+  // ...and the strip must run on the FAILURE paths too. `getGraphCtx()` refuses a
+  // canvas/root divergence by throwing, so a cleanup placed after the observations
+  // is skipped on exactly the calls that fail — and the marker then rides the user's
+  // next save. It therefore lives in a `finally`, resolved from the live app rather
+  // than a local that may never have been assigned.
+  // Compared over CODE only: this block is heavily commented, and a length-sensitive
+  // match would break on the next comment edit rather than on a real regression.
+  const code = src.replace(/^\s*\/\/[^\n]*$/gm, "");
+  assert.match(code, /\} finally \{[\s\S]{0,400}?delete meta\[OPEN_PROOF_FIELD\];/);
+  // ...and the LOAD is inside that try, not before it. The payload carrying the marker
+  // is handed over the instant loadGraphData starts, so a REJECTION leaves the marker on
+  // a partially-mutated live graph — and a cleanup that begins after the await never runs
+  // for exactly that case.
+  const tryAt = code.indexOf("try {", code.indexOf("const openProofMarker"));
+  const loadAt = code.indexOf("await app.loadGraphData(repaintState, true, true, target);");
+  assert.ok(tryAt !== -1 && loadAt > tryAt, "the repaint load must sit inside the marker-cleanup try");
+  // It deletes only THIS attempt's value: an unconditional delete would remove a
+  // concurrent open's live evidence before that open could read it.
+  assert.match(src, /meta\[OPEN_PROOF_FIELD\] === openProofMarker/);
+});
+
+test("#641: a save/reconnect INSTANCE REFRESH of the same file keeps its uuid (fixed by #545/#557)", () => {
+  // #641 traced the fence's false rejection to `workflowStableUuid` minting a fresh
+  // uuid whenever the embedded uuid's remembered owner was a different object — which
+  // a save cycle or a reconnect workflow-list refresh always makes true, because the
+  // store hands out a NEW ComfyWorkflow for the SAME saved file. The reporter's build
+  // (0.11.35 / 675ace8) predates 5b4c8a9, which replaced that line: the fork now
+  // requires the owner to still be an OPEN tab. A replaced predecessor is not, so the
+  // successor INHERITS the identity and the root tag stays aligned.
+  const predecessor = { path: "workflows/a.json", isPersisted: true };
+  const successor = { path: "workflows/a.json", isPersisted: true };
+  assert.equal(
+    shouldForkEmbeddedUuidForLiveOwner({
+      embeddedUuid: UUID_A,
+      embeddedOwner: predecessor,
+      identityObject: successor,
+      ownerIsOpenWorkflow: false, // the save/reconnect replaced it — it is gone from the tab list
+      successionProven: true,
+    }),
+    false,
+    "an instance refresh of the same file must NOT mint a fresh uuid (that is #641)",
+  );
+  // ...and the co-open COPY case still forks, so the fix is not a blanket relaxation.
+  assert.equal(
+    shouldForkEmbeddedUuidForLiveOwner({
+      embeddedUuid: UUID_A,
+      embeddedOwner: predecessor,
+      identityObject: successor,
+      ownerIsOpenWorkflow: true, // the owner is still open — this really is a second copy
+      successionProven: true,
+    }),
+    true,
+    "a genuine co-open copy must still get its own identity (#557/#570)",
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -290,6 +290,12 @@ import {
   resolveGraphBindingVerdict,
   graphReadBindingChanged,
   resolveGraphRootUuidRebind,
+  graphRootCarriesOpenProof,
+  describeGraphStateDifference,
+  resolveOpenRebindVerdict,
+  describeOpenRebindOutcome,
+  OPEN_REBIND_STATUS,
+  OPEN_PROOF_FIELD,
 } from "./lib/graph-binding.js";
 import { summarizePromptRejection, buildQueueAcceptResult } from "./lib/queue-rejection.js";
 import { createRunFetchInterceptor, dispatchScopedRun } from "./lib/run-scope-guard.js";
@@ -9927,6 +9933,17 @@ const GRAPH_TOOL_EXECUTORS = {
             // the resulting root. The UUID is panel-owned metadata, not caller input;
             // this is the same workflow identity used by the command fence.
             const targetUuid = workflowStableUuid(target, { embed: true });
+            // ...and a SINGLE-USE marker for THIS attempt. The uuid alone cannot
+            // separate "this load landed" from "the root already carried this
+            // workflow's tag" — a previous load of the same tab leaves it there, and
+            // the guard's own rebind heal (#545/#557/#565) can stamp it onto a root
+            // deliberately. `configure()` replaces `graph.extra` wholesale from the
+            // data it is handed, so a value minted here and written into THIS payload
+            // can only reach the live root by way of this load.
+            const openProofMarker =
+              typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+                ? crypto.randomUUID()
+                : `open-${Date.now()}-${Math.random().toString(36).slice(2)}`;
             const repaintState = JSON.parse(JSON.stringify(st));
             const repaintExtra =
               repaintState.extra && typeof repaintState.extra === "object" && !Array.isArray(repaintState.extra)
@@ -9943,24 +9960,86 @@ const GRAPH_TOOL_EXECUTORS = {
               [WORKFLOW_META_NAMESPACE]: {
                 ...repaintMeta,
                 [WORKFLOW_UUID_FIELD]: targetUuid,
+                [OPEN_PROOF_FIELD]: openProofMarker,
                 ...(target.path ? { [WORKFLOW_PATH_FIELD]: target.path } : {}),
               },
             };
-            await app.loadGraphData(repaintState, true, true, target);
-            // A successful promise alone is not a binding receipt: old/partial frontend
-            // implementations can resolve while leaving app.canvas on the previous root.
-            // Demand the positive, target-specific marker even for dirty workflows —
-            // read-only graph comparisons intentionally cannot prove that case.
-            const { rootGraph } = getGraphCtx();
-            if (
-              activeWorkflowRef() !== target ||
-              !graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid: targetUuid }) ||
-              !graphRootMatchesState({ rootGraph, state: repaintState })
-            ) {
-              rebindFailed = new Error(
-                "workflow_open could not prove that the active canvas was rebound to the requested workflow. " +
-                  "The open may have switched the active workflow; reload the panel before graph edits.",
-              );
+            // The load is INSIDE the try whose finally strips the marker: the payload
+            // carrying the marker is handed over the moment this call starts, so a
+            // REJECTION leaves it on a partially-mutated live graph. A cleanup that
+            // begins after the await never runs for exactly that case.
+            try {
+              await app.loadGraphData(repaintState, true, true, target);
+              // A successful promise alone is not a binding receipt: old/partial frontend
+              // implementations can resolve while leaving app.canvas on the previous root.
+              // Demand the positive, attempt-specific marker even for dirty workflows —
+              // read-only graph comparisons intentionally cannot prove that case.
+              //
+              // Each part is captured SEPARATELY and kept. They answer different
+              // questions, and OR-ing them into one boolean threw away the only thing
+              // that could say why an open failed — which is why #604/#603/#616 could
+              // report "could not prove rebound" on every call with no way to learn
+              // which check fired. Evidence first, verdict second.
+              const { rootGraph } = getGraphCtx();
+              const activeNow = activeWorkflowRef();
+              // Proxy-safe, like every other workflow-object comparison in this file:
+              // the store hands out Vue proxies while lookups can yield raw objects, so
+              // a bare `!==` can report a tab switch that never happened (#558 r2).
+              const instanceStillTarget = sameWorkflowObject(activeNow, target);
+              const markerMatches = graphRootCarriesOpenProof({ rootGraph, proofMarker: openProofMarker });
+              const identityMatches = graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid: targetUuid });
+              const contentMatches = graphRootMatchesState({ rootGraph, state: repaintState });
+              const verdict = resolveOpenRebindVerdict({
+                instanceStillTarget,
+                markerMatches,
+                identityMatches,
+                contentMatches,
+              });
+              if (verdict.status !== OPEN_REBIND_STATUS.PROVEN) {
+                // Only once something has already failed: this re-serializes the root,
+                // which is the expensive part of the whole proof. It feeds the MESSAGE
+                // only — it decides nothing.
+                const contentDiff = contentMatches
+                  ? { comparable: true, surfaces: [] }
+                  : describeGraphStateDifference({ rootGraph, state: repaintState });
+                rebindFailed = new Error(
+                  describeOpenRebindOutcome(verdict, {
+                    targetLabel: target.filename || target.path || "the requested workflow",
+                    activeLabel: activeNow ? activeNow.filename || activeNow.path || "another tab" : "no active tab",
+                    expectedMarker: openProofMarker,
+                    observedMarker: rootGraph?.extra?.[WORKFLOW_META_NAMESPACE]?.[OPEN_PROOF_FIELD] ?? null,
+                    expectedUuid: targetUuid,
+                    observedUuid: rootGraph?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD] ?? null,
+                    contentComparable: contentDiff.comparable,
+                    contentSurfaces: contentDiff.surfaces,
+                  }),
+                );
+              }
+            } finally {
+              // Strip the marker so it does not ride the user's next save. In a FINALLY,
+              // because the observations above can throw — `getGraphCtx()` refuses a
+              // canvas/root divergence by design — and a cleanup that only runs when the
+              // proof succeeded leaves the marker behind on exactly the failure paths.
+              // It runs AFTER the verdict, so it never destroys evidence before it is read.
+              //
+              // Resolved from the live app rather than the (possibly unreachable) `rootGraph`
+              // local, and it deletes ONLY a value equal to the marker THIS attempt minted:
+              // an unconditional delete could remove a concurrent open's live evidence.
+              try {
+                // `canvasView` (not `app.canvas`) for the #268 contract scanner's sake: it
+                // captures members off the workflow-service alias `s` with an unanchored
+                // `s\.` pattern, so `canvas.graph` reads to it as a new workflow-SERVICE
+                // dependency. This is a LiteGraph canvas, not the workflow service.
+                for (const graph of [app?.rootGraph, app?.graph, canvasView?.graph]) {
+                  const meta = graph?.extra?.[WORKFLOW_META_NAMESPACE];
+                  if (meta && typeof meta === "object" && meta[OPEN_PROOF_FIELD] === openProofMarker) {
+                    delete meta[OPEN_PROOF_FIELD];
+                  }
+                }
+              } catch {
+                /* cosmetic only — a leftover marker cannot make a later proof pass, because
+                   every attempt mints a fresh one and requires an exact match */
+              }
             }
           }
         } catch (err) {
@@ -9973,6 +10052,7 @@ const GRAPH_TOOL_EXECUTORS = {
         // the target-specific repaint proof above succeeds. In particular, capturing a
         // still-stale root as a clean baseline after a failed repaint would corrupt the
         // target's in-memory state and make a later save/fence believe it was trustworthy.
+        //
         if (!rebindFailed) {
         // Opening alone must not dirty the tab (a spurious post-load change-tracker
         // diff otherwise flips it to modified:true and blocks an unforced close).

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -608,6 +608,19 @@ export function resolveOpenRebindVerdict({
   return { status: OPEN_REBIND_STATUS.PROVEN, bindingProven: true, unproven: [] };
 }
 
+/** Did a content comparison actually HAPPEN? The single rule every sentence about
+ *  content asks, so the headline and the per-part clause cannot disagree with each
+ *  other — which they did, because one tested `=== true` and the other `=== false`
+ *  and an absent value fell down opposite branches.
+ *
+ *  Only an explicit `true` counts. `graphRootMatchesState` returns false for BOTH
+ *  "compared and differed" and "could not read the root", so a caller that says
+ *  nothing about comparability has not established one — and an unestablished
+ *  observation must never license the definite claim. */
+function contentWasCompared(observed) {
+  return observed?.contentComparable === true;
+}
+
 /** One clause per failed part, naming the TWO VALUES that disagreed. A refusal
  *  that says only "the fence rejected" is not actionable; one that says which
  *  observation failed and what was seen instead is. */
@@ -635,11 +648,17 @@ function openRebindPartClause(part, observed = {}) {
         `so the graph-command fence would still treat it as a different canvas`
       );
     case "content":
-      return observed.contentComparable === false
-        ? `the panel could not compare the loaded graph with the canvas at all, so it is UNKNOWN — ` +
-            `not established — whether the whole graph landed`
-        : `the graph on the canvas differs from what was loaded on: ` +
-            `${(observed.contentSurfaces ?? []).join(", ") || "an unnamed surface"}`;
+      // `contentWasCompared`, NOT `=== false`. Testing only the literal false let an
+      // ABSENT or non-boolean comparability fall through to the definite-difference
+      // wording — so this clause asserted a measured mismatch while the headline
+      // (which tests `=== true`) correctly said the panel could not read the graph,
+      // and one disclosure contradicted itself. Both now ask the same question, and
+      // the burden sits on the CLAIM: only a positive "yes, compared" licenses it.
+      return contentWasCompared(observed)
+        ? `the graph on the canvas differs from what was loaded on: ` +
+            `${(observed.contentSurfaces ?? []).join(", ") || "an unnamed surface"}`
+        : `the panel could not compare the loaded graph with the canvas at all, so it is UNKNOWN — ` +
+            `not established — whether the whole graph landed`;
     default:
       return `an unrecognized check (${part}) did not pass`;
   }
@@ -680,7 +699,7 @@ export function describeOpenRebindOutcome(verdict, observed = {}) {
     // truth is that we could not look. `describeGraphStateDifference` keeps the two
     // apart and the caller passes that through as `contentComparable`; anything but
     // an explicit `true` takes the non-asserting wording.
-    const compared = observed.contentComparable === true;
+    const compared = contentWasCompared(observed);
     return (
       `workflow_open RAN and the canvas IS bound to ${workflow} — that much was proven — but ` +
       (compared

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -502,6 +502,15 @@ export const OPEN_PROOF_FIELD = "open_proof";
  * `extra` does: ComfyUI's `configure()` replaces `graph.extra` wholesale from the
  * data it is given, so nothing but that payload can put this value on the root.
  *
+ * ADDITIONAL evidence, NOT a replacement — and specifically NOT a superset of the
+ * uuid predicate, which is easy to assume and false: a root carrying
+ * `{ open_proof: M, workflow_uuid: "B" }` PASSES this for marker M while
+ * `graphRootWorkflowUuidMatches` correctly FAILS it for workflow A. The two answer
+ * different questions — this one "was the root configured by this attempt", that
+ * one "whose workflow is this" — and `resolveOpenRebindVerdict` requires BOTH.
+ * Reading this as the stronger check would licence dropping the identity one, which
+ * is how an overclaiming comment turns into a real hole several refactors later.
+ *
  * Absent or non-matching is NOT proof of a wrong canvas — it is absence of
  * proof. The caller must disclose it as such and must never widen it into a
  * claim about which workflow the canvas holds.
@@ -537,13 +546,18 @@ export const OPEN_REBIND_STATUS = Object.freeze({
  *   instance — the active workflow is still the tab we were asked to open. A tab
  *              switch during the load makes every other part describe a DIFFERENT
  *              canvas, so nothing else is meaningful without it.
- *   marker   — the live root was configured from THIS attempt's payload. Strictly
- *              stronger than the workflow uuid it supplements: the uuid can already
- *              be on the root from a previous load of the same tab or from the
- *              guard's own rebind heal (#545/#557/#565), so it cannot establish
- *              that this load landed. A single-use marker can.
+ *   marker   — the live root was configured from THIS attempt's payload. It answers
+ *              FRESHNESS, which the workflow uuid cannot: the uuid can already be on
+ *              the root from a previous load of the same tab or from the guard's own
+ *              rebind heal (#545/#557/#565), so it never established that this load
+ *              landed. It is NOT a superset of `identity` and must never be treated
+ *              as one — a root carrying this attempt's marker alongside a DIFFERENT
+ *              workflow's uuid passes here and fails `identity`, which is the whole
+ *              reason both are ANDed. Dropping either in a later refactor reopens a
+ *              hole the other does not cover.
  *   identity — the root carries the workflow uuid the command fence will compare,
- *              i.e. the desync fence is actually healed by this open.
+ *              i.e. the desync fence is actually healed by this open. Answers WHICH
+ *              WORKFLOW, which the marker does not.
  *   content  — the graph on the canvas reproduces the payload exactly.
  *
  * WHY `content` STILL BLOCKS SUCCESS, even though it is a FIDELITY question and the
@@ -656,12 +670,27 @@ export function describeOpenRebindOutcome(verdict, observed = {}) {
     // workflow's, and what is unknown is narrower than "which workflow is this".
     // The open still reports `unknown`, because the panel cannot tell the frontend
     // NORMALIZING the graph apart from the load only partly applying it.
+    //
+    // "does not match" is stated ONLY when a comparison actually happened.
+    // `graphRootMatchesState` returns false for BOTH "compared and differed" and
+    // "could not read the root at all" — one return value doing two jobs, the same
+    // fold this whole change exists to remove, hiding one level down in the wording.
+    // An unreadable post-load root would otherwise be disclosed as a definite
+    // mismatch: telling the user their canvas holds something different when the
+    // truth is that we could not look. `describeGraphStateDifference` keeps the two
+    // apart and the caller passes that through as `contentComparable`; anything but
+    // an explicit `true` takes the non-asserting wording.
+    const compared = observed.contentComparable === true;
     return (
-      `workflow_open RAN and the canvas IS bound to ${workflow} — that much was proven — but the graph ` +
-      `on it does not match the state that was loaded, and the panel cannot tell whether the ComfyUI ` +
-      `frontend merely normalized it (node sizes, widget values) or the load only partly applied. Treat ` +
-      `the canvas as UNKNOWN and re-read it (panel_graph_outline) before editing.${because} You are NOT ` +
-      `on the wrong workflow: ${workflow} IS the active one.`
+      `workflow_open RAN and the canvas IS bound to ${workflow} — that much was proven — but ` +
+      (compared
+        ? `the graph on it does not match the state that was loaded, and the panel cannot tell whether ` +
+          `the ComfyUI frontend merely normalized it (node sizes, widget values) or the load only ` +
+          `partly applied. `
+        : `the panel could not READ the graph on it to compare against the state that was loaded, so ` +
+          `whether the whole graph landed is unestablished — NOT established as wrong. `) +
+      `Treat the canvas as UNKNOWN and re-read it (panel_graph_outline) before editing.${because} ` +
+      `You are NOT on the wrong workflow: ${workflow} IS the active one.`
     );
   }
   if (verdict?.status === OPEN_REBIND_STATUS.UNPROVEN) {

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -237,7 +237,14 @@ export function graphRootProvenEmpty(rootGraph) {
   }
 }
 
-function graphShape(state) {
+/**
+ * The ONE normalization. `graphShape` (whole-graph equality) and
+ * `graphShapeSurfaces` (which surface disagreed) are both derived from this, so
+ * the answer to "do these match?" and the answer to "what differs?" can never
+ * drift apart — a second, subtly-different comparator is how this family of bugs
+ * keeps recurring.
+ */
+function buildGraphShape(state) {
   if (!state || !Array.isArray(state.nodes)) return null;
   // Omit counters/version metadata that can legitimately differ after LiteGraph
   // rebuilds; retain every serialized graph surface ChangeTracker treats as
@@ -302,21 +309,66 @@ function graphShape(state) {
     // changing the workflow, so it must not block a valid graph command.
     extra,
   };
+  return shape;
+}
+
+const canonicalizeShapeValue = (value) => {
+  if (Array.isArray(value)) return value.map(canonicalizeShapeValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonicalizeShapeValue(value[key])]),
+    );
+  }
+  return value;
+};
+
+function graphShape(state) {
+  const shape = buildGraphShape(state);
+  if (shape == null) return null;
   try {
-    const canonicalize = (value) => {
-      if (Array.isArray(value)) return value.map(canonicalize);
-      if (value && typeof value === "object") {
-        return Object.fromEntries(
-          Object.keys(value)
-            .sort()
-            .map((key) => [key, canonicalize(value[key])]),
-        );
-      }
-      return value;
-    };
-    return JSON.stringify(canonicalize(shape));
+    return JSON.stringify(canonicalizeShapeValue(shape));
   } catch {
     return null;
+  }
+}
+
+/**
+ * WHICH surfaces of a just-loaded state the live root does not reproduce.
+ *
+ * This exists for the DISCLOSURE only — it names what disagreed so the answer is
+ * actionable ("nodes differ" and "groups differ" send a reader to different
+ * places). It deliberately decides NOTHING: see the note on
+ * `resolveOpenRebindVerdict` for why no classification of a content mismatch is
+ * currently trustworthy enough to soften a verdict.
+ *
+ * "The panel could not compare" and "the panel compared and they differ" are
+ * different answers, and collapsing the first into the second is the defect this
+ * whole cluster is about. `comparable:false` means exactly that no comparison
+ * happened — it is never evidence of a mismatch.
+ */
+export function describeGraphStateDifference({ rootGraph, state } = {}) {
+  const NOT_COMPARABLE = { comparable: false, surfaces: [] };
+  try {
+    const expectedShape = buildGraphShape(state);
+    let actualShape = null;
+    try {
+      actualShape = buildGraphShape(rootGraph?.serialize?.());
+    } catch {
+      actualShape = null;
+    }
+    if (!expectedShape || !actualShape) return NOT_COMPARABLE;
+    const canon = (shape) => {
+      const out = {};
+      for (const key of Object.keys(shape)) out[key] = JSON.stringify(canonicalizeShapeValue(shape[key]));
+      return out;
+    };
+    const expected = canon(expectedShape);
+    const actual = canon(actualShape);
+    return { comparable: true, surfaces: Object.keys(expected).filter((key) => expected[key] !== actual[key]) };
+  } catch {
+    return NOT_COMPARABLE;
   }
 }
 
@@ -429,6 +481,202 @@ export function graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid } =
   if (typeof activeWorkflowUuid !== "string" || !activeWorkflowUuid) return false;
   const rootUuid = rootGraph?.extra?.comfyui_mcp?.workflow_uuid;
   return typeof rootUuid === "string" && rootUuid === activeWorkflowUuid;
+}
+
+/** The panel's own namespace inside a serialized graph's `extra`. Not workflow
+ *  content — `buildGraphShape` strips it from every content comparison. */
+export const PANEL_GRAPH_META_KEY = "comfyui_mcp";
+/** Where workflow_open records the single-use marker for THIS repaint attempt. */
+export const OPEN_PROOF_FIELD = "open_proof";
+
+/**
+ * ATTEMPT-scoped proof that the live root was configured from the exact payload
+ * this call just handed `loadGraphData` (#604/#603/#616 residue).
+ *
+ * `graphRootWorkflowUuidMatches` proves the root carries a WORKFLOW's durable
+ * identity. That is weaker than it looks for a post-load receipt: the tag is
+ * panel-owned bookkeeping that a rebind HEAL (#545/#557/#565) can legitimately
+ * stamp onto a root, and a previous load of the same workflow leaves it there
+ * too — so "the root carries A's uuid" does not establish that THIS load landed.
+ * A single-use marker minted per attempt and written into the payload's own
+ * `extra` does: ComfyUI's `configure()` replaces `graph.extra` wholesale from the
+ * data it is given, so nothing but that payload can put this value on the root.
+ *
+ * Absent or non-matching is NOT proof of a wrong canvas — it is absence of
+ * proof. The caller must disclose it as such and must never widen it into a
+ * claim about which workflow the canvas holds.
+ */
+export function graphRootCarriesOpenProof({ rootGraph, proofMarker } = {}) {
+  if (typeof proofMarker !== "string" || !proofMarker) return false;
+  const seen = rootGraph?.extra?.[PANEL_GRAPH_META_KEY]?.[OPEN_PROOF_FIELD];
+  return typeof seen === "string" && seen === proofMarker;
+}
+
+export const OPEN_REBIND_STATUS = Object.freeze({
+  /** The canvas is provably the requested workflow AND holds what was loaded. */
+  PROVEN: "proven",
+  /** The BINDING is proven — the canvas is this workflow's canvas — but the graph
+   *  on it could not be confirmed to be what was loaded. Still not a success:
+   *  `workflow_open` answers `unknown` for this exactly as it does for a wholly
+   *  unproven rebind. It is a distinct STATUS so the disclosure can say which half
+   *  is settled, which is the difference between an actionable answer and a bare
+   *  "the fence rejected". */
+  CONTENT_UNVERIFIED: "content-unverified",
+  /** Nothing here says the canvas is wrong — only that this call cannot show it is
+   *  right. */
+  UNPROVEN: "unproven",
+});
+
+/**
+ * workflow_open's post-repaint verdict, as a NAMED answer per part rather than one
+ * boolean.
+ *
+ * The parts answer different questions and no one of them answers another's (#621
+ * established the shape; this names them so a failure can say which one fired):
+ *
+ *   instance — the active workflow is still the tab we were asked to open. A tab
+ *              switch during the load makes every other part describe a DIFFERENT
+ *              canvas, so nothing else is meaningful without it.
+ *   marker   — the live root was configured from THIS attempt's payload. Strictly
+ *              stronger than the workflow uuid it supplements: the uuid can already
+ *              be on the root from a previous load of the same tab or from the
+ *              guard's own rebind heal (#545/#557/#565), so it cannot establish
+ *              that this load landed. A single-use marker can.
+ *   identity — the root carries the workflow uuid the command fence will compare,
+ *              i.e. the desync fence is actually healed by this open.
+ *   content  — the graph on the canvas reproduces the payload exactly.
+ *
+ * WHY `content` STILL BLOCKS SUCCESS, even though it is a FIDELITY question and the
+ * binding is separately proven. `loadGraphData` transforms the payload it is given
+ * before the root serializes again — it grows every node to at least
+ * `computeSize()`, normalizes combo and `control_after_generate` widget values, may
+ * substitute a schema-validated copy, and runs every installed extension's
+ * `loadedGraphNode` hook on every node — so a perfectly rebound canvas can differ
+ * from the bytes handed in. It is therefore genuinely a false negative to deny the
+ * OPEN for it, and softening it was tried here.
+ *
+ * It was reverted, because the two cases cannot currently be told apart. LiteGraph
+ * creates every node (with its id and type) and THEN configures each one, and
+ * `loadGraphData` catches a `configure()` failure and returns. A throw in that
+ * second pass leaves the complete node id/type set, the links, and the panel's
+ * marker — written by `_configureBase` before any node is built — over nodes that
+ * silently LOST their widget values and properties. That is byte-for-byte the same
+ * observation as "the loader normalized the widget values", and no discriminator
+ * available to the panel separates them. Reporting it as a completed open would
+ * fabricate a success over data loss, which is worse than the false negative.
+ *
+ * So `unknown` stays `unknown` here — deliberately, and it is the honest answer to a
+ * question this code cannot settle. What the status split buys is that the
+ * DISCLOSURE can now say the binding IS proven and only the content is unconfirmed,
+ * instead of implying the canvas may be the wrong workflow.
+ *
+ * Every part is compared against `true` explicitly: an unreadable observation
+ * arrives as null/undefined and must count as NOT proven, never as proven.
+ */
+export function resolveOpenRebindVerdict({
+  instanceStillTarget,
+  markerMatches,
+  identityMatches,
+  contentMatches,
+} = {}) {
+  const unproven = [];
+  if (instanceStillTarget !== true) unproven.push("instance");
+  if (markerMatches !== true) unproven.push("marker");
+  if (identityMatches !== true) unproven.push("identity");
+  if (unproven.length) {
+    return { status: OPEN_REBIND_STATUS.UNPROVEN, bindingProven: false, unproven };
+  }
+  if (contentMatches !== true) {
+    // Binding proven, content not. NOT a success — see above — but the disclosure
+    // gets to say which half is settled.
+    return { status: OPEN_REBIND_STATUS.CONTENT_UNVERIFIED, bindingProven: true, unproven: ["content"] };
+  }
+  return { status: OPEN_REBIND_STATUS.PROVEN, bindingProven: true, unproven: [] };
+}
+
+/** One clause per failed part, naming the TWO VALUES that disagreed. A refusal
+ *  that says only "the fence rejected" is not actionable; one that says which
+ *  observation failed and what was seen instead is. */
+function openRebindPartClause(part, observed = {}) {
+  switch (part) {
+    case "instance":
+      // "could not confirm", NOT "changed". The observation is `!== true`, which an
+      // UNREADABLE active-workflow pointer produces just as a genuine tab switch does.
+      // Asserting the switch would state a cause for a reading that was never taken.
+      return (
+        `the panel could not confirm the active workflow is still ${observed.targetLabel ?? "the requested tab"} ` +
+        `(it now reads ${observed.activeLabel ?? "something else"}), so nothing else observed here is known ` +
+        `to describe the tab you asked for`
+      );
+    case "marker":
+      return (
+        `the live canvas does not carry this open's one-time marker ` +
+        `(expected ${observed.expectedMarker ?? "a marker"}, found ${observed.observedMarker ?? "none"}), ` +
+        `so the panel cannot show that the graph it loaded is the one now on screen`
+      );
+    case "identity":
+      return (
+        `the live canvas does not carry this workflow's identity ` +
+        `(expected ${observed.expectedUuid ?? "its uuid"}, found ${observed.observedUuid ?? "none"}), ` +
+        `so the graph-command fence would still treat it as a different canvas`
+      );
+    case "content":
+      return observed.contentComparable === false
+        ? `the panel could not compare the loaded graph with the canvas at all, so it is UNKNOWN — ` +
+            `not established — whether the whole graph landed`
+        : `the graph on the canvas differs from what was loaded on: ` +
+            `${(observed.contentSurfaces ?? []).join(", ") || "an unnamed surface"}`;
+    default:
+      return `an unrecognized check (${part}) did not pass`;
+  }
+}
+
+/**
+ * What workflow_open tells the caller about its own repaint.
+ *
+ * DISCLOSURE, never refusal: by the time this runs the destructive load has
+ * ALREADY executed. Wording that invites a clean retry ("nothing happened")
+ * would be false, and wording that asserts a cause the panel did not observe
+ * ("the open may have switched the active workflow") narrates a bucket as if it
+ * were the diagnosis. Each clause states only what was actually observed.
+ */
+export function describeOpenRebindOutcome(verdict, observed = {}) {
+  const workflow = observed.targetLabel ?? "the requested workflow";
+  const clauses = (verdict?.unproven ?? []).map((part) => openRebindPartClause(part, observed));
+  const because = clauses.length ? ` Specifically: ${clauses.join("; ")}.` : "";
+  // Every sentence below states an OBSERVATION, never the event that produced it. The
+  // instance check reads "is the active workflow this target now" — it does not watch a
+  // switch happen, and the target may already have been active — so "the tab switched"
+  // would narrate an event nobody saw. Its failure is likewise `!== true`, which an
+  // unreadable pointer produces just as a real switch does, so that direction can only
+  // say the panel could not confirm which workflow is active.
+  const activeIsTarget = !(verdict?.unproven ?? []).includes("instance");
+  if (verdict?.status === OPEN_REBIND_STATUS.CONTENT_UNVERIFIED) {
+    // The precise answer, and precisely as far as it goes: the canvas IS this
+    // workflow's, and what is unknown is narrower than "which workflow is this".
+    // The open still reports `unknown`, because the panel cannot tell the frontend
+    // NORMALIZING the graph apart from the load only partly applying it.
+    return (
+      `workflow_open RAN and the canvas IS bound to ${workflow} — that much was proven — but the graph ` +
+      `on it does not match the state that was loaded, and the panel cannot tell whether the ComfyUI ` +
+      `frontend merely normalized it (node sizes, widget values) or the load only partly applied. Treat ` +
+      `the canvas as UNKNOWN and re-read it (panel_graph_outline) before editing.${because} You are NOT ` +
+      `on the wrong workflow: ${workflow} IS the active one.`
+    );
+  }
+  if (verdict?.status === OPEN_REBIND_STATUS.UNPROVEN) {
+    return (
+      `workflow_open RAN but could not prove that the active canvas was rebound to ${workflow}, so ` +
+      `treat the canvas as unknown rather than unchanged. ` +
+      (activeIsTarget
+        ? `${workflow} IS the active workflow — what could not be established is the state of the ` +
+          `canvas under it.`
+        : `The panel could not confirm which workflow is active, so the open may have left a ` +
+          `different one active.`) +
+      `${because} Check panel_list_workflows, then reload the panel before graph edits.`
+    );
+  }
+  return "";
 }
 
 /**


### PR DESCRIPTION
## The hypothesis was REFUTED

`workflow_open`'s content proof does **not** compare two dialects.

`graphRootMatchesState` runs **both** sides through the same `graphShape` — that is exactly what #560 built — and `changeTracker.activeState` is itself `clone(app.rootGraph.serialize())` (`src/scripts/changeTracker.ts`), i.e. the *same producer* as the live side. Node order, `last_node_id`/`last_link_id`/`version`/`state`, `extra.ds` and the panel's own tag are already normalized away, and a present-but-empty surface already compares equal to an absent one. There is no dialect asymmetry left to find at that level.

**The real defect is the same shape, one level up.** `loadGraphData` *transforms the payload it is handed* before the root serializes again — it grows every node to at least `computeSize()` and snaps it, rewrites null combo values and `control_after_generate`, may substitute a schema-validated copy of the payload, and runs every installed extension's `loadedGraphNode` hook on every node. So a perfectly rebound canvas routinely differs from the bytes handed in. That **fidelity** answer was OR'd into the **binding** gate and read as the answer to "is this the canvas I asked for?" — a value computed for one purpose read as the answer to a different question.

## I could not make that sound, and say so rather than guess

Softening the content check was implemented here and then **withdrawn**. LiteGraph creates every node (id and type) and *then* configures each one, and `loadGraphData` catches a `configure()` failure and returns. A throw in that second pass leaves the complete node id/type set, the links, and the panel's marker — written by `_configureBase` *before* any node is built — over nodes that silently **lost their widget values**. That observation is byte-identical to "the loader normalized the widget values", and no evidence available to the panel separates them. Reporting it as a completed open would fabricate a success over data loss.

**A content mismatch therefore still answers `applied: "unknown"`.** Nothing here loosens the #349 fence.

## What this does deliver

**1. An attempt-scoped proof.** `graphRootWorkflowUuidMatches` proves the root carries a *workflow's* durable identity — weaker than it looks for a post-load receipt, because a previous load of the same tab leaves that tag there and the guard's own rebind heal (#545/#557/#565) stamps it deliberately. A **single-use marker minted per attempt** and written into that attempt's payload proves the root was configured *from this load*: `configure()` replaces `graph.extra` wholesale from the data it is given, so nothing else can put that value there.

> **It is additional *freshness* evidence, not a replacement for the uuid, and NOT a superset of it.** An earlier revision of this PR claimed "strictly stronger"; that was false and an independent gate caught it. A root carrying `{ open_proof: M, workflow_uuid: "B" }` **passes** the marker check for `M` while `graphRootWorkflowUuidMatches` correctly **fails** it for workflow A. The two answer different questions — *"did this attempt configure the root"* vs *"whose workflow is this"* — which is precisely why `resolveOpenRebindVerdict` **ANDs** them. Dropping either in a later refactor reopens a hole the other does not cover; both doc comments now say so explicitly, and a test constructs that exact root.

**2. The verdict is split and named** (`instance` / `marker` / `identity` / `content`), so the answer says *which* check failed and *which two values* disagreed, including which graph surfaces. Before, four different failures collapsed into one message that asserted a cause — "the open may have switched the active workflow" — that only one of them could support. **That is why nobody, including this investigation, can tell which part fires in the field.** `CONTENT_UNVERIFIED` is a distinct status with the *same* outcome; it exists only so the message can say the binding half IS settled and the caller is not on the wrong tab.

**3. The instance check is proxy-safe** (`sameWorkflowObject`, not a bare `!==`), matching every other workflow-object comparison in this file. The store hands out Vue proxies while lookups can yield raw objects (#558 r2), so `!==` could report a tab switch that never happened. This is the one place the change is *not* strictly stricter, and it is intentional.

`describeGraphStateDifference` reuses the **same** `buildGraphShape` the comparator uses — one normalization, two readings of it — rather than a second comparator that could drift. It feeds the message only; it decides nothing.

## #641 is already fixed on main

The line #641 traces to (the mint-on-owner-mismatch in `workflowStableUuid`) no longer exists. It was replaced by `5b4c8a9` (#545/#557), which landed **after** the reporter's build (`675ace8`, panel 0.11.35): the fork now requires the owner to still be an **open** tab, so a save/reconnect instance refresh inherits the identity instead of minting a fresh one. Locked with a regression test rather than re-fixed.

## Gate findings, all closed

Nine adversarial rounds plus an independent gate; four `NO-SHIP` verdicts, all accepted and acted on (the second is what killed the relaxation).

- **The `CONTENT_UNVERIFIED` disclosure asserted a mismatch it never compared.** `graphRootMatchesState` returns `false` for *both* "compared and differed" and "could not read the root" — one return value doing two jobs — so an unreadable post-load root was disclosed as a definite mismatch: telling the user their canvas holds something different when the truth is we could not look. **This repo's dominant fold, inside the fix meant to remove it.** The first cut fixed only the HEADLINE and left the per-part clause testing `=== false`, so an absent value fell down the opposite branch and one disclosure said both “could not READ it” and “it differs” — the gate caught that too. Both sentences now go through a single `contentWasCompared()`, and only an explicit `true` licenses the difference claim, because an unstated observation is not an established one.
- The marker is stripped in a **`finally`**, with the load **inside** that try. A cleanup after the observations is skipped exactly when `getGraphCtx()` refuses a canvas/root divergence or the load rejects — leaving the marker to ride the user's next save. It deletes only a value equal to *this* attempt's marker, so it cannot erase a concurrent open's evidence, and it runs after the verdict has read it.
- No branch narrates a tab **switch**. The instance check reads "is the active workflow this target *now*"; it does not witness a switch and is equally true when the target was already active. Its failure is `!== true`, which an unreadable pointer produces just as a real switch does — so that direction says only that the panel could not confirm which workflow is active.
- The cleanup reads `canvasView`, not `app.canvas.graph` — the #268 contract scanner's unanchored `s\.` pattern misreads the latter as a workflow-service dependency (caught by that test).

## Verification

- **2000/2000** unit tests pass. 23 new in `browser_tests/unit/open-rebind-proof.test.mjs`; the #721 wiring tests updated to the new call shape.
- **33 mutants, all caught**, including three aimed squarely at the reopened-#349 direction (make the proof pass for a canvas that was *not* rebound), one that reintroduces the withdrawn relaxation, two that assert a mismatch nobody measured (the headline, and — after the gate caught the incomplete first cut — the per-part clause), and one that collapses the marker and uuid predicates into a single read.
- `tsc --noEmit` clean; tool-vocabulary gate clean; every changed file re-verified as an **ES module** (`.mjs`), not just `node --check` in CJS mode; `.githooks/pre-commit` verified passing.
- Committed blobs scanned for control bytes: **0** in every file. (One raw `0x00` was introduced and repaired mid-work — the escape-mangling failure mode this repo has hit before.)

## What is NOT fixed, and what only a live session can settle

- **Which of the four checks actually fires in the field is still unknown.** That is precisely what the named verdict now makes reportable. #645 (already-active tab after reconnect) is the cleanest reproduction and the next report on it should name the failing part directly.
- **#638 is not addressed** — it is a different subsystem (the orchestrator-side command-UUID fence and its circular recovery), not `workflow_open`'s proof.
- The handler's wiring tests are **static source scans**. Driving `workflow_open` end to end needs a ComfyUI + Vue + LiteGraph harness this repo does not have, so a statement-disabling mutation *inside* the handler is not caught. Stated rather than hidden.
- `browser_tests/unit/manager-install.test.mjs::waitForQueueDrain` is flaky on a loaded machine (hard 5s wall-clock budget, real timers). **Pre-existing** — verified failing 3/3 on clean `origin/main`.

Refs #604, #603, #616, #374, #641, #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)
