### PR TITLE
saved-workflow bridge routes collide across browser tabs — commands can execute against another session's canvas

### DIFF
--- a/browser_tests/unit/bridge-route.test.mjs
+++ b/browser_tests/unit/bridge-route.test.mjs
@@ -58,7 +58,7 @@ function copiedStorage(value) {
 }
 
 /** One browser tab: its own lease resolver + its own route identity holder. */
-function fakeTab({ locks, storageSeed, rotation, storageId = storageSeed }) {
+function fakeTab({ locks, storageSeed, rotation }) {
   const restart = createRestartTabIdentity({
     storage: copiedStorage(storageSeed),
     locks,
@@ -66,7 +66,9 @@ function fakeTab({ locks, storageSeed, rotation, storageId = storageSeed }) {
   });
   const route = createTabRouteIdentity({
     locksAvailable: () => typeof locks?.request === "function",
-    tabStorageId: () => storageId,
+    // Unreached whenever `locks` is present, which is the case in every test
+    // using this helper — the lockless branch has its own tests below.
+    mintPageInstanceId: () => `page-instance-of-${storageSeed}`,
   });
   return { restart, route };
 }
@@ -150,7 +152,7 @@ test("#640: an UNIDENTIFIABLE tab is REFUSED, never merged onto the path", () =>
 test("#640: live lock CONTENTION establishes nothing — 'could not determine' is not 'no other tab'", () => {
   const identity = createTabRouteIdentity({
     locksAvailable: () => true,
-    tabStorageId: () => "possibly-copied",
+    mintPageInstanceId: () => "never-reached",
   });
   // The lease resolver returned undefined WITH a lock manager present: another
   // live tab in this origin holds every candidate. The copyable sessionStorage
@@ -163,33 +165,55 @@ test("#640: live lock CONTENTION establishes nothing — 'could not determine' i
 test("#640: a THROWING capability probe refuses too — an unreadable probe is not an absent API", () => {
   const identity = createTabRouteIdentity({
     locksAvailable: () => { throw new Error("probe exploded"); },
-    tabStorageId: () => "possibly-copied",
+    mintPageInstanceId: () => "never-reached",
   });
   assert.equal(identity.adopt(undefined), null);
   assert.equal(identity.established(), null);
 });
 
-test("#640: Web Locks ABSENT (plain-http LAN) uses the per-tab storage id and says so", () => {
+test("#640: Web Locks ABSENT (plain-http LAN) mints a PAGE-INSTANCE id and says so", () => {
   const identity = createTabRouteIdentity({
     locksAvailable: () => false,
-    tabStorageId: () => "session-storage-tab",
+    mintPageInstanceId: () => "page-instance-1",
   });
-  assert.deepEqual(identity.adopt(undefined), { id: "session-storage-tab", proof: "tab-storage" });
-  assert.equal(identity.proof(), "tab-storage", "the narrower backing must be reported, not hidden");
-  // Still a TAB identity: two tabs that each opened the URL have distinct
-  // sessionStorage, so the routes still separate.
-  const other = createTabRouteIdentity({ locksAvailable: () => false, tabStorageId: () => "other-tab" });
-  other.adopt(undefined);
-  assert.notEqual(
-    savedWorkflowRoute(identity.established().id, "workflows/a.json"),
-    savedWorkflowRoute(other.established().id, "workflows/a.json"),
-  );
+  assert.deepEqual(identity.adopt(undefined), { id: "page-instance-1", proof: "page-instance" });
+  assert.equal(identity.proof(), "page-instance", "the narrower backing must be reported, not hidden");
+});
+
+test("#640 REGRESSION: the lockless fallback must NOT read copyable per-tab storage", () => {
+  // Browser tab duplication copies sessionStorage verbatim, so the stored
+  // per-tab id is precisely the value two duplicated tabs would SHARE. Reading
+  // it in the lockless branch re-created the #640 collision in the one mode
+  // that has no lock manager to detect it. Model the duplicate: identical
+  // storage, no locks — the two routes must still differ.
+  const copiedStorageId = "copied-per-tab-id";
+  const mint = (() => { let n = 0; return () => `page-instance-${++n}`; })();
+  const original = createTabRouteIdentity({ locksAvailable: () => false, mintPageInstanceId: mint });
+  const duplicate = createTabRouteIdentity({ locksAvailable: () => false, mintPageInstanceId: mint });
+  original.adopt(undefined);
+  duplicate.adopt(undefined);
+
+  const path = "workflows/shared.json";
+  const routeA = savedWorkflowRoute(original.established().id, path);
+  const routeB = savedWorkflowRoute(duplicate.established().id, path);
+  assert.notEqual(routeA, routeB, "two duplicated tabs must not share one lockless route");
+  for (const route of [routeA, routeB]) {
+    assert.ok(
+      !route.includes(copiedStorageId),
+      "the lockless id must never be sourced from storage a duplicate can copy",
+    );
+  }
+
+  // ...and the shipped panel must not wire storage in either.
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /mintPageInstanceId: \(\) => crypto\.randomUUID\(\)/);
+  assert.doesNotMatch(src, /tabStorageId:/, "getTabId() is copyable and must not back the route");
 });
 
 test("#640: a lease wins over the storage fallback, and the established id is then FROZEN", () => {
   const identity = createTabRouteIdentity({
     locksAvailable: () => true,
-    tabStorageId: () => "storage-id",
+    mintPageInstanceId: () => "never-reached",
   });
   assert.deepEqual(identity.adopt("leased-id"), { id: "leased-id", proof: "exclusive" });
   // A later re-hello must not re-key the route: the route is this tab's agent
@@ -245,7 +269,7 @@ test("#640: the refusal is DISCLOSED in terms of the harm, not as a generic fail
 });
 
 test("#640: a refusal while the lease is STILL PENDING does not claim contention", () => {
-  const identity = createTabRouteIdentity({ locksAvailable: () => true, tabStorageId: () => "x" });
+  const identity = createTabRouteIdentity({ locksAvailable: () => true, mintPageInstanceId: () => "x" });
   assert.equal(identity.settled(), false, "no lease attempt has completed yet");
   const pending = describeRefusedRoute({ settled: identity.settled() });
   // "Could not determine which tab holds this" is not "another tab holds this".
@@ -253,10 +277,11 @@ test("#640: a refusal while the lease is STILL PENDING does not claim contention
   assert.match(pending, /still establishing/i);
   assert.match(pending, /nothing ran/i, "a pre-dispatch refusal must say nothing ran");
 
-  // Once an attempt completes, the settled wording is the contention one.
+  // Once an attempt completes, the settled wording names the likely cause —
+  // "most often" another tab — without asserting it as determined.
   identity.adopt(undefined);
   assert.equal(identity.settled(), true);
-  assert.match(describeRefusedRoute({ settled: identity.settled() }), /Another browser tab/);
+  assert.match(describeRefusedRoute({ settled: identity.settled() }), /Most often another browser tab/);
 });
 
 test("#640 wiring: every refusal message is told whether the lease has settled", () => {
@@ -427,11 +452,13 @@ test("#640 wiring: every outbound frame site reads bridgeRouteId() and refuses o
   assert.match(src, /const uploadRouteId = bridgeRouteId\(\);\s*\n\s*if \(!uploadRouteId\) throw new Error\(describeRefusedRoute\(/);
   assert.match(src, /tab_id: callRouteId,/);
   assert.match(src, /tab_id: uploadRouteId,/);
-  // title — must resolve the route BEFORE recording the title as sent.
+  // title — recorded as sent only once it ACTUALLY was: the assignment stands
+  // AFTER the send inside the try, so a refused route AND a throwing send both
+  // leave it unrecorded and the next title mutation retries.
   assert.match(
     src,
-    /const routeId = bridgeRouteId\(\);\s*\n\s*if \(!routeId\) return;\s*\n\s*lastSentTitle = t;/,
-    "a refused title frame must not be recorded as sent — the retry is the next title change",
+    /const routeId = bridgeRouteId\(\);\s*\n\s*if \(!routeId\) return;\s*\n\s*try \{\s*\n\s*sock\.send\(JSON\.stringify\(\{ type: "title", tab_id: routeId, title: t \}\)\);\s*\n\s*lastSentTitle = t;/,
+    "a title frame must be recorded as sent only once it actually left — recording earlier suppresses the retry",
   );
   // lost_replies — advisory: omit the field rather than name an unestablished route.
   assert.match(src, /const lostRepliesRouteId = bridgeRouteId\(\);/);

--- a/browser_tests/unit/bridge-route.test.mjs
+++ b/browser_tests/unit/bridge-route.test.mjs
@@ -1,0 +1,491 @@
+// #640 — saved-workflow bridge routes collided across browser tabs.
+//
+// ui-bridge keeps exactly ONE connection per hello `tab_id`, so a second hello
+// carrying an id that is already registered TAKES THE ROUTE OVER. The panel's
+// saved-workflow handle is path-only (`wf:<path>`), so two browser tabs showing
+// the same file helloed with the same id and the agent's commands were delivered
+// to the other tab's canvas. The workflow-UUID instance fence refused the ones
+// that carry a UUID — that is the LAST line of defence and it never sees a
+// command that carries none.
+//
+// What is locked here:
+//   1. Two tabs on the SAME saved file get DISTINCT routes.
+//   2. An unestablished tab identity REFUSES the route — it never degrades to
+//      the path, which would re-merge the tabs exactly when identity is hardest
+//      to determine.
+//   3. Every wire site in the shipped panel stamps the ROUTE, and refuses when
+//      there is none, rather than the path-only handle.
+//   4. The reply side and the dispatch side share ONE spelling of the handle
+//      format, because each record's `active` flag is decided by comparing them.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  createTabRouteIdentity,
+  describeRefusedRoute,
+  savedWorkflowHandle,
+  savedWorkflowRoute,
+} from "../../web/js/lib/bridge-route.js";
+import { createRestartTabIdentity, sendBridgeHello } from "../../web/js/lib/restart-tab-identity.js";
+import { buildHelloPayload } from "../../web/js/lib/session-rebind.js";
+import { commandTargetsActiveWorkflow } from "../../web/js/lib/workflow-chat-identity.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+/** The origin-wide lock manager, shared by every tab in these tests. */
+class FakeLocks {
+  held = new Set();
+
+  request(name, _options, callback) {
+    if (this.held.has(name)) return Promise.resolve(callback(null));
+    this.held.add(name);
+    return Promise.resolve(callback({ name })).finally(() => this.held.delete(name));
+  }
+}
+
+/** sessionStorage as a DUPLICATED browser tab sees it: the copy starts equal. */
+function copiedStorage(value) {
+  let stored = value;
+  return {
+    getItem: () => stored,
+    setItem: (_key, next) => { stored = next; },
+  };
+}
+
+/** One browser tab: its own lease resolver + its own route identity holder. */
+function fakeTab({ locks, storageSeed, rotation, storageId = storageSeed }) {
+  const restart = createRestartTabIdentity({
+    storage: copiedStorage(storageSeed),
+    locks,
+    randomUUID: () => rotation,
+  });
+  const route = createTabRouteIdentity({
+    locksAvailable: () => typeof locks?.request === "function",
+    tabStorageId: () => storageId,
+  });
+  return { restart, route };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Two tabs on the same saved workflow
+// ---------------------------------------------------------------------------
+
+test("#640: two browser tabs on the SAME saved workflow get DISTINCT bridge routes", async () => {
+  const locks = new FakeLocks();
+  const first = fakeTab({ locks, storageSeed: "tab-one", rotation: "unused-one" });
+  const second = fakeTab({ locks, storageSeed: "tab-two", rotation: "unused-two" });
+
+  first.route.adopt(await first.restart.resolve());
+  second.route.adopt(await second.restart.resolve());
+
+  const path = "workflows/shared.json";
+  const routeA = savedWorkflowRoute(first.route.established()?.id, path);
+  const routeB = savedWorkflowRoute(second.route.established()?.id, path);
+
+  assert.equal(routeA, "wf:tab-one:workflows/shared.json");
+  assert.equal(routeB, "wf:tab-two:workflows/shared.json");
+  assert.notEqual(routeA, routeB, "the same file in two tabs must not register one route");
+  // Assert the REASON, not just the difference: the tab is what separates them.
+  assert.equal(savedWorkflowHandle(path), "wf:workflows/shared.json");
+  assert.notEqual(routeA, savedWorkflowHandle(path), "the route must not be the path-only handle");
+
+  first.restart.releaseForTests();
+  second.restart.releaseForTests();
+});
+
+test("#640: a DUPLICATED tab (copied sessionStorage) is rotated apart, not merged", async () => {
+  const locks = new FakeLocks();
+  const original = fakeTab({ locks, storageSeed: "copied-tab", rotation: "original-rotation" });
+  const duplicate = fakeTab({ locks, storageSeed: "copied-tab", rotation: "duplicate-rotation" });
+
+  const [a, b] = await Promise.all([original.restart.resolve(), duplicate.restart.resolve()]);
+  original.route.adopt(a);
+  duplicate.route.adopt(b);
+
+  const path = "workflows/shared.json";
+  const routeA = savedWorkflowRoute(original.route.established()?.id, path);
+  const routeB = savedWorkflowRoute(duplicate.route.established()?.id, path);
+  assert.equal(routeA, "wf:copied-tab:workflows/shared.json");
+  assert.equal(routeB, "wf:duplicate-rotation:workflows/shared.json");
+  assert.notEqual(routeA, routeB);
+
+  original.restart.releaseForTests();
+  duplicate.restart.releaseForTests();
+});
+
+test("#640: the SAME file after a rename, and two UNSAVED tabs, also route apart", () => {
+  const tab = "one-tab";
+  assert.notEqual(
+    savedWorkflowRoute(tab, "workflows/before.json"),
+    savedWorkflowRoute(tab, "workflows/after.json"),
+    "a rename changes the path half of the route",
+  );
+  // Unsaved tabs never reach savedWorkflowRoute: they keep the per-object
+  // `tmp:<uuid>`, which the shipped bridgeRouteId() returns unchanged so the
+  // orchestrator's tmp:-gated stable-resume index still recognizes them.
+  const routeSource = namedFunctionSource(readFileSync(PANEL_JS, "utf8"), "bridgeRouteId");
+  assert.match(routeSource, /return workflowTabId\(wf\);/);
+  assert.match(routeSource, /tmp:/, "the unsaved branch must say why it is already tab-unique");
+});
+
+// ---------------------------------------------------------------------------
+// 2. Refusal — never the path
+// ---------------------------------------------------------------------------
+
+test("#640: an UNIDENTIFIABLE tab is REFUSED, never merged onto the path", () => {
+  const path = "workflows/shared.json";
+  for (const unestablished of [null, undefined, "", "   "]) {
+    const route = savedWorkflowRoute(unestablished, path);
+    assert.equal(route, null, `an unestablished id (${JSON.stringify(unestablished)}) must refuse`);
+    assert.notEqual(route, savedWorkflowHandle(path), "refusal must not become the path handle");
+    assert.notEqual(route, path);
+  }
+});
+
+test("#640: live lock CONTENTION establishes nothing — 'could not determine' is not 'no other tab'", () => {
+  const identity = createTabRouteIdentity({
+    locksAvailable: () => true,
+    tabStorageId: () => "possibly-copied",
+  });
+  // The lease resolver returned undefined WITH a lock manager present: another
+  // live tab in this origin holds every candidate. The copyable sessionStorage
+  // id is exactly what must NOT be adopted here.
+  assert.equal(identity.adopt(undefined), null);
+  assert.equal(identity.established(), null, "nothing may be recorded for a failed establishment");
+  assert.equal(savedWorkflowRoute(identity.established()?.id, "workflows/a.json"), null);
+});
+
+test("#640: a THROWING capability probe refuses too — an unreadable probe is not an absent API", () => {
+  const identity = createTabRouteIdentity({
+    locksAvailable: () => { throw new Error("probe exploded"); },
+    tabStorageId: () => "possibly-copied",
+  });
+  assert.equal(identity.adopt(undefined), null);
+  assert.equal(identity.established(), null);
+});
+
+test("#640: Web Locks ABSENT (plain-http LAN) uses the per-tab storage id and says so", () => {
+  const identity = createTabRouteIdentity({
+    locksAvailable: () => false,
+    tabStorageId: () => "session-storage-tab",
+  });
+  assert.deepEqual(identity.adopt(undefined), { id: "session-storage-tab", proof: "tab-storage" });
+  assert.equal(identity.proof(), "tab-storage", "the narrower backing must be reported, not hidden");
+  // Still a TAB identity: two tabs that each opened the URL have distinct
+  // sessionStorage, so the routes still separate.
+  const other = createTabRouteIdentity({ locksAvailable: () => false, tabStorageId: () => "other-tab" });
+  other.adopt(undefined);
+  assert.notEqual(
+    savedWorkflowRoute(identity.established().id, "workflows/a.json"),
+    savedWorkflowRoute(other.established().id, "workflows/a.json"),
+  );
+});
+
+test("#640: a lease wins over the storage fallback, and the established id is then FROZEN", () => {
+  const identity = createTabRouteIdentity({
+    locksAvailable: () => true,
+    tabStorageId: () => "storage-id",
+  });
+  assert.deepEqual(identity.adopt("leased-id"), { id: "leased-id", proof: "exclusive" });
+  // A later re-hello must not re-key the route: the route is this tab's agent
+  // session key on the orchestrator, and silently changing it strands it.
+  assert.deepEqual(identity.adopt("some-other-id"), { id: "leased-id", proof: "exclusive" });
+});
+
+test("#640: a tab id containing ':' is refused so <tab>:<path> can never be read two ways", () => {
+  assert.equal(savedWorkflowRoute("tab:with:colons", "workflows/a.json"), null);
+});
+
+// ---------------------------------------------------------------------------
+// 3. Refusal happens BEFORE dispatch (hello is what registers the route)
+// ---------------------------------------------------------------------------
+
+test("#640: a refused route means NO hello is sent — the route is never registered", async () => {
+  const sent = [];
+  const result = await sendBridgeHello({
+    socket: { send: (frame) => sent.push(JSON.parse(frame)) },
+    isCurrent: () => true,
+    resolveTabIdentity: async () => undefined,
+    // The panel's makePayload returns null when bridgeRouteId() refuses.
+    makePayload: () => null,
+  });
+  assert.equal(sent.length, 0, "refusing must happen before dispatch, not be disclosed after it");
+  assert.equal(result, false, "a hello that never left must not report itself as sent");
+});
+
+test("#640: an ESTABLISHED route is what actually reaches the wire", async () => {
+  const locks = new FakeLocks();
+  const tab = fakeTab({ locks, storageSeed: "lock-proven-tab", rotation: "unused" });
+  const sent = [];
+  const result = await sendBridgeHello({
+    socket: { send: (frame) => sent.push(JSON.parse(frame)) },
+    isCurrent: () => true,
+    resolveTabIdentity: () => tab.restart.resolve(),
+    makePayload: (tabSessionId) => {
+      tab.route.adopt(tabSessionId);
+      const routeId = savedWorkflowRoute(tab.route.established()?.id, "workflows/shared.json");
+      return routeId ? buildHelloPayload({ tabId: routeId, tabSessionId }) : null;
+    },
+  });
+  assert.equal(result, true);
+  assert.equal(sent[0].tab_id, "wf:lock-proven-tab:workflows/shared.json");
+  tab.restart.releaseForTests();
+});
+
+test("#640: the refusal is DISCLOSED in terms of the harm, not as a generic failure", () => {
+  const text = describeRefusedRoute();
+  assert.match(text, /did NOT register/, "must say the panel did not register, not that it is retrying");
+  assert.match(text, /another browser tab/i);
+  assert.match(text, /other\s+tab's canvas/i, "must name the actual harm being refused");
+});
+
+test("#640: a refusal while the lease is STILL PENDING does not claim contention", () => {
+  const identity = createTabRouteIdentity({ locksAvailable: () => true, tabStorageId: () => "x" });
+  assert.equal(identity.settled(), false, "no lease attempt has completed yet");
+  const pending = describeRefusedRoute({ settled: identity.settled() });
+  // "Could not determine which tab holds this" is not "another tab holds this".
+  assert.doesNotMatch(pending, /Another browser tab .* is holding/);
+  assert.match(pending, /still establishing/i);
+  assert.match(pending, /nothing ran/i, "a pre-dispatch refusal must say nothing ran");
+
+  // Once an attempt completes, the settled wording is the contention one.
+  identity.adopt(undefined);
+  assert.equal(identity.settled(), true);
+  assert.match(describeRefusedRoute({ settled: identity.settled() }), /Another browser tab/);
+});
+
+test("#640 wiring: every refusal message is told whether the lease has settled", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const calls = src.match(/describeRefusedRoute\([^)]*\)/g) ?? [];
+  assert.ok(calls.length >= 3, "hello, callTool and uploadMedia must all disclose");
+  for (const call of calls) {
+    assert.match(
+      call,
+      /settled: tabRouteIdentity\.settled\(\)/,
+      `${call} must not assert contention it has not determined`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 3b. Delivery — WHICH tab receives the command, and which tab's reply comes back
+// ---------------------------------------------------------------------------
+
+/**
+ * The orchestrator's ui-bridge, reduced to the property that produced #640:
+ * `conns` is a Map keyed by the hello `tab_id`, so a hello for an id that is
+ * already registered REPLACES the connection under it. Dispatch and reply are
+ * modelled separately, because a correctly-dispatched command whose reply lands
+ * in another tab is the same bug.
+ */
+function fakeBridge() {
+  const conns = new Map();
+  const pending = new Map();
+  return {
+    hello(tabId, tab) { conns.set(tabId, tab); },
+    tabCount: () => conns.size,
+    /** Dispatch to a route; returns the tab that actually received it. */
+    dispatch(tabId, rid) {
+      const tab = conns.get(tabId);
+      if (!tab) return null;
+      pending.set(rid, { tabId });
+      tab.inbox.push({ rid });
+      return tab;
+    },
+    /** A tab replies on ITS OWN socket; the bridge correlates by rid. */
+    reply(tab, rid, value) {
+      const p = pending.get(rid);
+      if (!p) return { delivered: false, reason: "no such in-flight command" };
+      pending.delete(rid);
+      // The bridge stamps the replying SOCKET's bound tab id, never a
+      // client-supplied one — so the reply's origin is whichever tab sent it.
+      return { delivered: true, from: tab.name, value };
+    },
+  };
+}
+
+test("#640: with path-only ids the SECOND tab steals the route and receives the first tab's command", () => {
+  const bridge = fakeBridge();
+  const tabA = { name: "A", inbox: [] };
+  const tabB = { name: "B", inbox: [] };
+  // Pre-fix: both tabs hello with `wf:<path>` because both show the same file.
+  const legacyId = savedWorkflowHandle("workflows/shared.json");
+  bridge.hello(legacyId, tabA);
+  bridge.hello(legacyId, tabB);
+
+  assert.equal(bridge.tabCount(), 1, "two tabs collapsed onto ONE bridge route");
+  const receiver = bridge.dispatch(legacyId, "rid-1");
+  // Assert WHICH tab received it — "it was delivered" passes either way.
+  assert.equal(receiver.name, "B", "tab A's agent command was delivered to tab B's canvas");
+  assert.deepEqual(tabA.inbox, [], "the tab that owns the session got nothing");
+});
+
+test("#640: with tab-scoped routes the command reaches the issuing tab, and so does its reply", async () => {
+  const locks = new FakeLocks();
+  const first = fakeTab({ locks, storageSeed: "tab-A", rotation: "unused-a" });
+  const second = fakeTab({ locks, storageSeed: "tab-B", rotation: "unused-b" });
+  first.route.adopt(await first.restart.resolve());
+  second.route.adopt(await second.restart.resolve());
+
+  const path = "workflows/shared.json";
+  const routeA = savedWorkflowRoute(first.route.established().id, path);
+  const routeB = savedWorkflowRoute(second.route.established().id, path);
+
+  const bridge = fakeBridge();
+  const tabA = { name: "A", inbox: [] };
+  const tabB = { name: "B", inbox: [] };
+  bridge.hello(routeA, tabA);
+  bridge.hello(routeB, tabB);
+  assert.equal(bridge.tabCount(), 2, "the same file in two tabs must keep two routes");
+
+  // Dispatch path.
+  const receiver = bridge.dispatch(routeA, "rid-1");
+  assert.equal(receiver.name, "A", "the command must reach the tab whose route was addressed");
+  assert.deepEqual(tabB.inbox, [], "the other tab must not see it at all");
+
+  // Reply path, checked independently: the tab that DID NOT receive the command
+  // cannot answer for it, and the answer that lands is stamped with its origin.
+  const answer = bridge.reply(tabA, "rid-1", "outline-of-A");
+  assert.deepEqual(answer, { delivered: true, from: "A", value: "outline-of-A" });
+  assert.deepEqual(
+    bridge.reply(tabB, "rid-1", "outline-of-B"),
+    { delivered: false, reason: "no such in-flight command" },
+    "a reply from the tab that never got the command must not settle it",
+  );
+
+  first.restart.releaseForTests();
+  second.restart.releaseForTests();
+});
+
+test("#640: the workflow-UUID instance fence is UNCHANGED and still refuses a cross-tab command", () => {
+  const tabAUuid = "11111111-1111-4111-8111-111111111111";
+  const tabBUuid = "22222222-2222-4222-8222-222222222222";
+  // A command stamped for tab A's workflow instance, arriving at tab B's canvas
+  // (the survivable-by-luck case the routing fix removes) must still be refused.
+  assert.equal(
+    commandTargetsActiveWorkflow({ cmd: "set_widget", commandUuid: tabAUuid, activeUuid: tabBUuid }),
+    false,
+    "the last line of defence must not have been relaxed to make the symptom go away",
+  );
+  // ...and it still fails CLOSED for an unstamped protected command.
+  assert.equal(
+    commandTargetsActiveWorkflow({ cmd: "set_widget", commandUuid: undefined, activeUuid: tabBUuid }),
+    false,
+  );
+  // The matching case still passes, so the assertion above is about the mismatch.
+  assert.equal(
+    commandTargetsActiveWorkflow({ cmd: "set_widget", commandUuid: tabBUuid, activeUuid: tabBUuid }),
+    true,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 4. Shipped-panel wiring — every wire site stamps the route
+// ---------------------------------------------------------------------------
+
+/** Source of a top-level `function name(...) { ... }` from the panel bundle. */
+function namedFunctionSource(src, name) {
+  const start = src.indexOf(`function ${name}(`);
+  assert.notEqual(start, -1, `function ${name} must exist in the shipped panel`);
+  let depth = 0;
+  let seen = false;
+  for (let i = src.indexOf("{", start); i < src.length; i++) {
+    if (src[i] === "{") { depth++; seen = true; }
+    else if (src[i] === "}") { depth--; }
+    if (seen && depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error(`unterminated function ${name}`);
+}
+
+test("#640 wiring: NO frame stamps tab_id from the path-only workflow handle", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  // This is the defect in one line: any `tab_id`/`tabId` fed by workflowTabId()
+  // is a wire route keyed on the FILE, which two tabs share.
+  assert.doesNotMatch(
+    src,
+    /tab_?[Ii]d:\s*workflowTabId\(/,
+    "a wire tab_id must come from bridgeRouteId(), which is tab-scoped and refusable",
+  );
+});
+
+test("#640 wiring: every outbound frame site reads bridgeRouteId() and refuses on null", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  // hello — the registration itself.
+  assert.match(src, /tabRouteIdentity\.adopt\(tabSessionId\)/, "the route must be adopted from the COMPLETED lease");
+  assert.match(src, /const routeId = bridgeRouteId\(\);\s*\n\s*if \(!routeId\) \{/);
+  assert.match(src, /tabId: routeId,/, "the hello payload must carry the established route");
+  // sendFrame — every control/agent frame.
+  assert.match(src, /const routeId = bridgeRouteId\(\);\s*\n\s*if \(!routeId\) return false;/);
+  assert.match(src, /sock\.send\(JSON\.stringify\(\{ tab_id: routeId, \.\.\.frame \}\)\);/);
+  // callTool / uploadMedia — refuse before dispatch, with the reason.
+  assert.match(src, /const callRouteId = bridgeRouteId\(\);\s*\n\s*if \(!callRouteId\) \{\s*\n\s*return Promise\.reject\(new Error\(describeRefusedRoute\(/);
+  assert.match(src, /const uploadRouteId = bridgeRouteId\(\);\s*\n\s*if \(!uploadRouteId\) throw new Error\(describeRefusedRoute\(/);
+  assert.match(src, /tab_id: callRouteId,/);
+  assert.match(src, /tab_id: uploadRouteId,/);
+  // title — must resolve the route BEFORE recording the title as sent.
+  assert.match(
+    src,
+    /const routeId = bridgeRouteId\(\);\s*\n\s*if \(!routeId\) return;\s*\n\s*lastSentTitle = t;/,
+    "a refused title frame must not be recorded as sent — the retry is the next title change",
+  );
+  // lost_replies — advisory: omit the field rather than name an unestablished route.
+  assert.match(src, /const lostRepliesRouteId = bridgeRouteId\(\);/);
+  assert.match(src, /\.\.\.\(lostRepliesRouteId \? \{ tab_id: lostRepliesRouteId \} : \{\}\)/);
+});
+
+test("#640 wiring: the Blind frame no longer overrides sendFrame's route stamp", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  // sendFrame spreads `...frame` AFTER tab_id, so an explicit tab_id on the
+  // frame WINS. This one carried the path-only handle and silently defeated the
+  // stamp for that frame alone.
+  assert.match(src, /type: "set_content_mode", blind: AGENT_BLIND/);
+  assert.doesNotMatch(src, /set_content_mode", tab_id:/);
+});
+
+test("#640 wiring: bridgeRouteId REFUSES rather than returning the path", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const body = namedFunctionSource(src, "bridgeRouteId");
+  assert.match(body, /savedWorkflowRoute\(tabRoute, saved\)/, "the saved branch must compose the tab id in");
+  assert.doesNotMatch(body, /return\s+saved\s*;/, "there must be no path fallback");
+  assert.doesNotMatch(body, /savedWorkflowHandle\(/, "the route must never be the path-only handle");
+  // Deleting the tab half must break the test above, not just this one.
+  assert.match(body, /tabRouteIdentity\.established\(\)/);
+});
+
+test("#640 wiring: dispatch and reply share ONE spelling of the saved handle", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  const handle = namedFunctionSource(src, "workflowTabId");
+  const reply = namedFunctionSource(src, "establishedWorkflowReplyIdentity");
+  assert.match(handle, /savedWorkflowHandle\(saved\)/);
+  assert.match(reply, /savedWorkflowHandle\(savedPath\)/);
+  // A second literal spelling on either side is what would silently flip every
+  // workflow_list record's `active` flag to false.
+  assert.doesNotMatch(reply, /`wf:\$\{/, "the reply side must not re-derive the format");
+  assert.doesNotMatch(handle, /"wf:" \+/, "the dispatch side must not re-derive the format");
+});
+
+test("#640 wiring: the workflow_list `active` flag still compares like with like", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  // routingKey comes from workflowTabId(w); activeRoutingKey comes from
+  // establishedWorkflowReplyIdentity. Both now resolve through
+  // savedWorkflowHandle, so the comparison is meaningful — assert the
+  // comparison is still the one being made.
+  assert.match(src, /const routingKey = workflowTabId\(w\);/);
+  assert.match(src, /active: !!active && \(w === active \|\| routingKey === activeRoutingKey\)/);
+});
+
+test("#640 wiring: routing_key stays the path-only HANDLE the orchestrator corroborates", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  // The orchestrator's post-open command-fence refresh accepts a saved identity
+  // ONLY when routing_key === "wf:" + path (canonicalSavedRecordIdentity). The
+  // recovery path in #640 depends on that refresh, so the ADVERTISED handle must
+  // not become the tab-scoped route — the route belongs on the wire's tab_id.
+  assert.match(src, /routing_key: routingKey,/);
+  assert.doesNotMatch(src, /routing_key: bridgeRouteId\(/);
+  assert.doesNotMatch(src, /routing_key: savedWorkflowRoute\(/);
+});

--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -35,6 +35,7 @@ import {
   receiptAnswersCommand,
   classifyOpenOutcome,
 } from "../../web/js/lib/open-outcome.js";
+import { savedWorkflowHandle } from "../../web/js/lib/bridge-route.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
@@ -939,10 +940,15 @@ test("#716 P1: service rebind during workflow_open omits the former target UUID"
   const replyUuid = new Function(
     "activeWorkflowRef",
     "workflowObjectUuid",
+    "savedWorkflowHandle",
     `${pathSource}; ${canonicalUuidSource}; ${identitySource}; ${helperSource}; return activeWorkflowUuidForOpenReply;`,
   )(
     () => currentService.activeWorkflow,
     (wf) => workflowUuids.get(wf),
+    // #640 — the REAL shared handle helper the panel imports, not a stub: these
+    // sandboxes exist to run the shipped reply-identity code, and a hand-rolled
+    // `wf:` + path here would be the second spelling the shared helper removed.
+    savedWorkflowHandle,
   );
 
   assert.equal(replyUuid(openedTarget), "11111111-1111-4111-8111-111111111111", "the normal completed open reports its actual active tab");
@@ -975,10 +981,15 @@ test("#716 P1: service rebind during workflow_list reports only the current acti
   const listActive = new Function(
     "activeWorkflowRef",
     "workflowObjectUuid",
+    "savedWorkflowHandle",
     `${pathSource}; ${canonicalUuidSource}; ${identitySource}; ${listActiveSource}; return liveWorkflowListActive;`,
   )(
     () => currentService.activeWorkflow,
     (wf) => workflowUuids.get(wf),
+    // #640 — the REAL shared handle helper the panel imports, not a stub: these
+    // sandboxes exist to run the shipped reply-identity code, and a hand-rolled
+    // `wf:` + path here would be the second spelling the shared helper removed.
+    savedWorkflowHandle,
   );
 
   assert.equal(listActive().activeIdentity?.uuid, "11111111-1111-4111-8111-111111111111");
@@ -1002,10 +1013,15 @@ test("#716 P1: a malformed truthy active binding cannot mint reply identity", ()
   const replyUuid = new Function(
     "activeWorkflowRef",
     "workflowObjectUuid",
+    "savedWorkflowHandle",
     `${pathSource}; ${canonicalUuidSource}; ${identitySource}; ${helperSource}; return activeWorkflowUuidForOpenReply;`,
   )(
     () => malformedActive,
     (wf) => workflowUuids.get(wf),
+    // #640 — the REAL shared handle helper the panel imports, not a stub: these
+    // sandboxes exist to run the shipped reply-identity code, and a hand-rolled
+    // `wf:` + path here would be the second spelling the shared helper removed.
+    savedWorkflowHandle,
   );
 
   // Execute the actual shipped reply helper against a truthy but malformed
@@ -1026,10 +1042,15 @@ test("#716 P1: a temporary workflow UUID is never published as a durable refresh
   const replyUuid = new Function(
     "activeWorkflowRef",
     "workflowObjectUuid",
+    "savedWorkflowHandle",
     `${pathSource}; ${canonicalUuidSource}; ${identitySource}; ${helperSource}; return activeWorkflowUuidForOpenReply;`,
   )(
     () => temporaryActive,
     (wf) => workflowUuids.get(wf),
+    // #640 — the REAL shared handle helper the panel imports, not a stub: these
+    // sandboxes exist to run the shipped reply-identity code, and a hand-rolled
+    // `wf:` + path here would be the second spelling the shared helper removed.
+    savedWorkflowHandle,
   );
 
   // Even an existing object-map UUID is insufficient for a temporary tab:
@@ -1056,10 +1077,15 @@ test("#716 P1: existing mapped UUIDs still omit when noncanonical", () => {
   const replyUuid = new Function(
     "activeWorkflowRef",
     "workflowObjectUuid",
+    "savedWorkflowHandle",
     `${pathSource}; ${canonicalUuidSource}; ${identitySource}; ${helperSource}; return activeWorkflowUuidForOpenReply;`,
   )(
     () => active,
     (wf) => workflowUuids.get(wf),
+    // #640 — the REAL shared handle helper the panel imports, not a stub: these
+    // sandboxes exist to run the shipped reply-identity code, and a hand-rolled
+    // `wf:` + path here would be the second spelling the shared helper removed.
+    savedWorkflowHandle,
   );
 
   for (const workflow of [invalidVersion, invalidVariant, uppercase]) {

--- a/docs/design/chat-history-v2.md
+++ b/docs/design/chat-history-v2.md
@@ -17,8 +17,9 @@ export, and merge-import controls.
 
 ## Identity
 
-Bridge routing still uses `wf:<path>`/`tmp:<uuid>` because the orchestrator binds
-agents to the current tab. Transcript identity is separate:
+Bridge routing uses `wf:<tab>:<path>`/`tmp:<uuid>` (the saved form is tab-scoped
+since #640, so two browser tabs on one file register distinct routes) because the
+orchestrator binds agents to the current tab. Transcript identity is separate:
 `workflow:<embedded UUID>`. The UUID is stored in
 `workflow.extra.comfyui_mcp.workflow_uuid` on the first per-workflow chat.
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -1289,7 +1289,11 @@ const restartTabIdentity = createRestartTabIdentity({
 // two tabs on one file registered the same route and the later hello stole it.
 const tabRouteIdentity = createTabRouteIdentity({
   locksAvailable: () => typeof window.navigator?.locks?.request === "function",
-  tabStorageId: () => getTabId(),
+  // Deliberately NOT getTabId(): that value lives in sessionStorage, which
+  // browser tab duplication copies verbatim, so two duplicated tabs would share
+  // it — the #640 collision again, in the one mode that cannot detect it. Mint
+  // per page load and persist nowhere.
+  mintPageInstanceId: () => crypto.randomUUID(),
 });
 // Start establishing the identity at LOAD, not at the first hello. The lease is
 // async, and every frame sent in that window is refused for want of an identity
@@ -13798,16 +13802,18 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     if (!sock || sock.readyState !== WebSocket.OPEN) return;
     const t = getWorkflowTitle();
     if (t === lastSentTitle) return;
-    // #640 — resolve the route BEFORE marking the title as sent. A refused route
-    // means this frame never leaves, and recording it as sent would suppress
-    // every later attempt for a title the orchestrator never received.
+    // #640 — record the title as sent only once it ACTUALLY was. A refused route
+    // and a throwing send both mean this frame never left, and the dedupe would
+    // otherwise suppress every later attempt for a title the orchestrator never
+    // received: the comment below promised a retry the assignment had already
+    // made impossible (pre-existing; fixed here because this is the same line).
     const routeId = bridgeRouteId();
     if (!routeId) return;
-    lastSentTitle = t;
     try {
       sock.send(JSON.stringify({ type: "title", tab_id: routeId, title: t }));
+      lastSentTitle = t;
     } catch {
-      // dropped — next mutation retries
+      // dropped — the next title mutation retries, now that it can.
     }
   }
   const titleObserver = titleEl ? new MutationObserver(() => sendTitle()) : null;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -324,6 +324,12 @@ import {
 } from "./lib/session-rebind.js";
 import { createRestartTabIdentity, sendBridgeHello } from "./lib/restart-tab-identity.js";
 import {
+  createTabRouteIdentity,
+  describeRefusedRoute,
+  savedWorkflowHandle,
+  savedWorkflowRoute,
+} from "./lib/bridge-route.js";
+import {
   adoptRebootRuns,
   decodeRebootMarker,
   isRealBridgeDrop,
@@ -1277,6 +1283,25 @@ const restartTabIdentity = createRestartTabIdentity({
   locks: window.navigator?.locks,
   randomUUID: () => crypto.randomUUID(),
 });
+// #640 — this browser tab's BRIDGE ROUTE identity, adopted from the very lease
+// the hello already awaits. Distinct from workflowTabId(): that is the workflow
+// HANDLE the agent selects with, and for a saved workflow it is path-only, so
+// two tabs on one file registered the same route and the later hello stole it.
+const tabRouteIdentity = createTabRouteIdentity({
+  locksAvailable: () => typeof window.navigator?.locks?.request === "function",
+  tabStorageId: () => getTabId(),
+});
+// Start establishing the identity at LOAD, not at the first hello. The lease is
+// async, and every frame sent in that window is refused for want of an identity
+// that was already on its way — a self-inflicted outage, not a real collision.
+// This changes only WHEN we ask: adopt() still records nothing but a COMPLETED
+// lease, and the resolver caches, so the hello below adopts the same value.
+void restartTabIdentity
+  .resolve()
+  .then((leasedId) => tabRouteIdentity.adopt(leasedId))
+  .catch(() => {
+    // The hello's own adopt() applies the same rule against the same resolver.
+  });
 
 // --- Per-workflow agent identity -----------------------------------------
 // Each ComfyUI workflow gets its OWN agent session. Saved workflows key by file
@@ -1871,7 +1896,10 @@ function workflowStorageKey({ embed = false } = {}) {
 function workflowTabId(wf = activeWorkflowRef()) {
   if (!wf) return getTabId();
   const saved = savedWorkflowPath(wf);
-  if (saved) return "wf:" + wf.path;
+  // The saved HANDLE, not a bridge route — two tabs on this file share it, which
+  // is fine for a selector resolved inside one tab and is why bridgeRouteId()
+  // exists for the wire (#640).
+  if (saved) return savedWorkflowHandle(saved);
   // Key on the STABLE object instance, not the mutable wf.key (see the note at
   // _tempWorkflowInstanceIds): the same unsaved workflow must keep ONE tmp: id for
   // its lifetime, or the 600ms poll churns it into a re-hello storm.
@@ -1887,6 +1915,35 @@ function workflowTabId(wf = activeWorkflowRef()) {
     if (!_priorTempWorkflowIds.has(wf)) _priorTempWorkflowIds.set(wf, id);
   }
   return id;
+}
+
+// #640 — the BRIDGE ROUTE for a workflow: the `tab_id` this panel puts on the
+// wire, and the key ui-bridge keeps exactly ONE connection under.
+//
+// workflowTabId() is NOT usable as that route. Its saved-workflow form is
+// `wf:<path>`, which names the FILE, so two browser tabs showing the same saved
+// workflow helloed with the same id; the bridge's second registration took the
+// route over and the agent's commands were delivered to the other tab's canvas
+// (the workflow-UUID fence refused the ones that carry a UUID — the last line,
+// and only for commands that carry one). The route composes the tab's own
+// established identity in front of the path, so the same file open in two tabs,
+// the same file after a rename, and two unsaved tabs all route separately.
+//
+// Returns null to REFUSE when this tab's identity is not established. Callers
+// must not send. Never falls back to the path: that fallback would re-merge the
+// two tabs precisely when the identity is hardest to determine, which is the
+// defect, not a degradation of it.
+function bridgeRouteId(wf = activeWorkflowRef()) {
+  const tabRoute = tabRouteIdentity.established()?.id ?? null;
+  // No workflow service at all (headless / odd frontend): the tab IS the route.
+  if (!wf) return tabRoute;
+  const saved = savedWorkflowPath(wf);
+  if (saved) return savedWorkflowRoute(tabRoute, saved);
+  // Unsaved: `tmp:<uuid>` is minted per workflow OBJECT with crypto.randomUUID,
+  // and a workflow object never leaves the page that created it, so it is
+  // already unique per browser tab. It also has to keep its `tmp:` prefix — the
+  // orchestrator gates its durable stable-resume index on exactly that prefix.
+  return workflowTabId(wf);
 }
 
 // `workflow_open` does most of its work asynchronously.  Its `target` remains a
@@ -1914,7 +1971,15 @@ function establishedWorkflowReplyIdentity(wf) {
   const uuid = workflowObjectUuid(wf);
   if (!isCanonicalWorkflowInstanceUuid(uuid)) return null;
   const savedPath = savedWorkflowPath(wf);
-  return savedPath ? { routingKey: `wf:${savedPath}`, uuid } : null;
+  if (!savedPath) return null;
+  // #640 — the SHARED spelling of the handle format, not a second local one.
+  // This value is compared against workflowTabId()'s elsewhere in the same reply
+  // (each workflow_list record's `active` flag is `routingKey === activeRoutingKey`),
+  // so two independent spellings are a silent divergence waiting to happen:
+  // whichever changed first, every record would report active:false and the agent
+  // would be told no tab is active.
+  const routingKey = savedWorkflowHandle(savedPath);
+  return routingKey ? { routingKey, uuid } : null;
 }
 
 function activeWorkflowUuidForOpenReply(target) {
@@ -12601,6 +12666,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
   // "connected" is never swallowed — a re-handshake must still re-run its side
   // effects (budget reset, soft-reload interlock release).
   let lastStatus = null;
+  // #640 — say the route refusal ONCE. The reconnect loop retries the hello
+  // forever and the refusal is sticky (the identity is frozen for the page), so
+  // an unthrottled notice would bury the panel in the same paragraph.
+  let routeRefusalDisclosed = false;
   function emitStatus(s) {
     if (s === lastStatus && s !== "connected") return;
     lastStatus = s;
@@ -12772,11 +12841,16 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     // then dropped (or vice versa) — the advertised set and the delivered set
     // must be computed against the SAME instant (codex).
     const now = Date.now();
+    // #640 — advisory frame; an unestablished route omits the field rather than
+    // naming a route this tab has not established. Read ONCE: two reads could
+    // straddle the hello that establishes the identity. The replay below is the
+    // load-bearing delivery and is socket-scoped either way.
+    const lostRepliesRouteId = bridgeRouteId();
     try {
       target.send(
         JSON.stringify({
           type: "lost_replies",
-          tab_id: workflowTabId(),
+          ...(lostRepliesRouteId ? { tab_id: lostRepliesRouteId } : {}),
           entries: lostReplies.summaries({ now, targetUrl, targetEpoch }),
         }),
       );
@@ -13626,6 +13700,23 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       isCurrent: () => sock === target && target.readyState === WebSocket.OPEN,
       resolveTabIdentity: () => restartTabIdentity.resolve(),
       makePayload: (tabSessionId) => {
+      // #640 — the hello is what REGISTERS this tab's bridge route, so establish
+      // the route identity here, from the lease that has just completed, and
+      // refuse the hello outright if it could not be established. Adopting the
+      // COMPLETED lease (never a value we hope to get) is the same ordering rule
+      // as the epoch bump below: nothing is recorded before it is true.
+      tabRouteIdentity.adopt(tabSessionId);
+      const routeId = bridgeRouteId();
+      if (!routeId) {
+        // Nothing has been dispatched, so this is a refusal, not a disclosure of
+        // something already done — but say so, or the panel just sits on a
+        // "connecting" pill it will never leave.
+        if (!routeRefusalDisclosed) {
+          routeRefusalDisclosed = true;
+          onLog?.(describeRefusedRoute({ settled: tabRouteIdentity.settled() }));
+        }
+        return null;
+      }
       // Carry the last session id so the orchestrator resumes the agent's
       // memory after a panel reload (only honored before the tab's agent spawns).
       const resume = getResume?.();
@@ -13636,7 +13727,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       // so a bare `--panel-orchestrator` points the agent at whatever ComfyUI is open.
       const comfyuiUrl = comfyuiUrlForAgent();
         return buildHelloPayload({
-            tabId: workflowTabId(),
+            tabId: routeId,
             title: getWorkflowTitle(),
             // Our build version, so the orchestrator can auto-stamp it into the
             // agent's ENV block (bug reports get version-pinned without digging).
@@ -13707,9 +13798,14 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     if (!sock || sock.readyState !== WebSocket.OPEN) return;
     const t = getWorkflowTitle();
     if (t === lastSentTitle) return;
+    // #640 — resolve the route BEFORE marking the title as sent. A refused route
+    // means this frame never leaves, and recording it as sent would suppress
+    // every later attempt for a title the orchestrator never received.
+    const routeId = bridgeRouteId();
+    if (!routeId) return;
     lastSentTitle = t;
     try {
-      sock.send(JSON.stringify({ type: "title", tab_id: workflowTabId(), title: t }));
+      sock.send(JSON.stringify({ type: "title", tab_id: routeId, title: t }));
     } catch {
       // dropped — next mutation retries
     }
@@ -13855,8 +13951,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           frame = { ...frame, images: normalizeImageList(frame.images) };
         }
       }
+      // #640 — refuse rather than emit a frame with no established route.
+      const routeId = bridgeRouteId();
+      if (!routeId) return false;
       try {
-        sock.send(JSON.stringify({ tab_id: workflowTabId(), ...frame }));
+        sock.send(JSON.stringify({ tab_id: routeId, ...frame }));
         // #291 — `new_session` / `resume_session` hand the next turn to a different
         // agent over THIS same socket (/new, closing a thread, opening one from
         // history), so the socket generation does not move and, without this, the
@@ -13878,6 +13977,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       if (!sock || sock.readyState !== WebSocket.OPEN) {
         return Promise.reject(new Error("bridge not connected"));
       }
+      // #640 — refuse before dispatch. Nothing has been sent yet, so this is a
+      // clean refusal; routing it on an unestablished route could run the tool
+      // for, and return its reply to, a different browser tab.
+      const callRouteId = bridgeRouteId();
+      if (!callRouteId) {
+        return Promise.reject(new Error(describeRefusedRoute({ settled: tabRouteIdentity.settled() })));
+      }
       const cid = `ct-${Date.now()}-${cidSeq++}`;
       const timeoutMs = (opts && opts.timeout) || 60000;
       return new Promise((resolve, reject) => {
@@ -13890,7 +13996,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           sock.send(
             JSON.stringify({
               type: "call_tool",
-              tab_id: workflowTabId(),
+              tab_id: callRouteId,
               cid,
               tool,
               args: args || {},
@@ -13913,6 +14019,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       if (!sock || sock.readyState !== WebSocket.OPEN) {
         throw new Error("bridge not connected");
       }
+      // #640 — refuse before dispatch (see callTool).
+      const uploadRouteId = bridgeRouteId();
+      if (!uploadRouteId) throw new Error(describeRefusedRoute({ settled: tabRouteIdentity.settled() }));
       const cid = `um-${Date.now()}-${cidSeq++}`;
       const buf = new Uint8Array(await blob.arrayBuffer());
       let bin = "";
@@ -13933,7 +14042,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           sock.send(
             JSON.stringify({
               type: "upload_media",
-              tab_id: workflowTabId(),
+              tab_id: uploadRouteId,
               cid,
               filename: name || "upload.png",
               mime: blob.type || "image/png",
@@ -17308,7 +17417,10 @@ function buildPanel() {
     // blind and respawns on change.
     if (_blindAckPending) { clearTimeout(_blindAckPending); _blindAckPending = null; }
     let sent = false;
-    try { sent = client?.sendFrame?.({ type: "set_content_mode", tab_id: workflowTabId(), blind: AGENT_BLIND }) !== false; } catch {}
+    // #640 — no explicit tab_id: sendFrame stamps the established BRIDGE ROUTE
+    // (and refuses when there is none). An explicit one here would have won the
+    // spread and put the path-only workflow handle back on the wire.
+    try { sent = client?.sendFrame?.({ type: "set_content_mode", blind: AGENT_BLIND }) !== false; } catch {}
     if (sent) {
       _blindAckPending = setTimeout(() => {
         _blindAckPending = null;

--- a/web/js/lib/bridge-route.js
+++ b/web/js/lib/bridge-route.js
@@ -1,0 +1,181 @@
+// Per-browser-tab BRIDGE ROUTE identity (#640).
+//
+// The bridge delivers a frame to a browser tab by the `tab_id` that tab helloed
+// with: ui-bridge keeps ONE connection per tab id, so a second hello carrying an
+// id that is already registered TAKES OVER the route. The panel's saved-workflow
+// handle is path-only (`wf:<path>`), so two browser tabs showing the same file
+// helloed with the SAME id — the later one silently stole the route, and the
+// agent's commands were delivered to the other tab's canvas. The workflow-UUID
+// instance fence caught the ones that carry a UUID to check; that is the LAST
+// line of defence, not the first, and it never sees a command that carries none.
+//
+// A route therefore has to name the TAB, not the file. This module owns that id
+// and the rule for when it may be used: an id is usable only once it has been
+// ESTABLISHED, and an unestablished identity REFUSES the route rather than
+// falling back to the path. A path fallback would re-create the collision in
+// exactly the case where the tab's identity is hardest to pin down.
+//
+// Deliberately NOT the same thing as the panel's workflow handle. The handle
+// (`wf:<path>` / `tmp:<uuid>`, reported as `routing_key`) names a workflow
+// WITHIN one tab and is resolved only against that tab's own open workflows, so
+// a path is an unambiguous handle there. The route names the tab on the wire.
+
+const ROUTE_PREFIX = "wf:";
+const ROUTE_SEP = ":";
+
+function trimmed(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+/**
+ * The saved-workflow HANDLE: `wf:<path>`.
+ *
+ * This names the workflow, not the tab, and it is deliberately still path-only:
+ * it is resolved against ONE tab's own open workflows (as a selector) and read
+ * by the orchestrator as the exact saved identity that authorizes a command-fence
+ * refresh after an open. It is NOT a bridge route — see savedWorkflowRoute.
+ *
+ * It lives here so the panel spells the format exactly once. It previously had
+ * two independent spellings, one on the dispatch side and one on the reply side,
+ * and the reply's `active` flag is decided by comparing the two: had either been
+ * changed alone, every workflow_list record would have reported active:false and
+ * the agent would have been told no tab is active.
+ */
+export function savedWorkflowHandle(savedPath) {
+  const path = trimmed(savedPath);
+  return path ? ROUTE_PREFIX + path : null;
+}
+
+/**
+ * Compose the bridge route for a SAVED workflow: `wf:<tabRouteId>:<path>`.
+ *
+ * Both halves must be present. With no established tab id there is no route,
+ * and emitting the bare path instead is the collision this exists to prevent —
+ * so this returns null (REFUSE) rather than degrade. A `:` inside the tab id is
+ * refused too, so `<tab>:<path>` can never be read two different ways.
+ */
+export function savedWorkflowRoute(tabRouteId, savedPath) {
+  const tab = trimmed(tabRouteId);
+  const path = trimmed(savedPath);
+  if (!tab || !path) return null;
+  if (tab.includes(ROUTE_SEP)) return null;
+  return ROUTE_PREFIX + tab + ROUTE_SEP + path;
+}
+
+/**
+ * Holds this browser tab's route id.
+ *
+ * `adopt` is the ONLY way a value is ever recorded, and it is called with the
+ * RESULT of the Web Locks lease the hello already awaits — never before it, and
+ * never with a value the resolver has not actually returned. Three outcomes,
+ * two of which are usable:
+ *
+ *  - a leased id ("exclusive"): the lock manager proved no other tab in this
+ *    origin holds it, which is the only thing that also covers a DUPLICATED tab
+ *    (browser tab duplication copies sessionStorage verbatim).
+ *
+ *  - the tab's sessionStorage id ("tab-storage"), used ONLY when Web Locks does
+ *    not exist in this context at all. The panel deliberately supports ComfyUI
+ *    served over plain http:// on a LAN, where `navigator.locks` is undefined
+ *    because the API is secure-context-only — the same reason the panel ships a
+ *    crypto.randomUUID polyfill. sessionStorage is scoped to one browser tab
+ *    (localStorage is not), so two tabs that each OPENED the same URL still get
+ *    distinct routes; only a duplicated tab can be carrying a copy. That is a
+ *    narrower guarantee than a lease and is reported as such — but it is still
+ *    an identity of the TAB, never of the file.
+ *
+ *  - no id: Web Locks IS present and refused every candidate. That is live
+ *    contention — another tab in this origin holds the identity — so nothing is
+ *    recorded and the route is REFUSED.
+ *
+ * Once established the id is frozen for the life of the page: the route keys the
+ * tab's agent session on the orchestrator, and silently re-keying it mid-session
+ * would strand that session behind a route nothing answers on.
+ */
+export function createTabRouteIdentity({ locksAvailable, tabStorageId } = {}) {
+  let established = null;
+  let settled = false;
+
+  return {
+    /** Synchronous read. Null until an identity has ACTUALLY been established. */
+    established: () => established,
+    /** "exclusive" | "tab-storage" | null — what the id above is backed by. */
+    proof: () => established?.proof ?? null,
+    /**
+     * Has a lease attempt COMPLETED? Distinguishes "no identity yet, resolution
+     * is still in flight" from "resolution finished and established nothing".
+     * Both refuse the route, but only the second one knows why — and saying
+     * "another tab holds your identity" while the lease is still pending would
+     * state a cause that has not been determined.
+     */
+    settled: () => settled,
+
+    /**
+     * Record the identity for this page from a COMPLETED lease attempt.
+     * Returns the established record, or null when it could not be established
+     * (in which case nothing is recorded — callers must refuse to route).
+     */
+    adopt(leasedId) {
+      // The caller reaches here only with a resolved lease result, so the
+      // attempt is over whichever way it went.
+      settled = true;
+      if (established) return established;
+
+      const leased = trimmed(leasedId);
+      if (leased) {
+        established = { id: leased, proof: "exclusive" };
+        return established;
+      }
+
+      // No lease. Distinguish "the lock manager said no" (contention — another
+      // live tab holds this identity) from "this context has no lock manager"
+      // (capability absent). Only the second may use the narrower tab-storage
+      // identity. A probe that throws is NOT evidence the API is missing:
+      // "could not determine" is not "determined it is absent", so an
+      // unreadable probe is treated as present and refuses.
+      let available = true;
+      try {
+        available = !!locksAvailable?.();
+      } catch {
+        available = true;
+      }
+      if (available) return null;
+
+      let stored = null;
+      try {
+        stored = trimmed(tabStorageId?.());
+      } catch {
+        stored = null;
+      }
+      if (!stored) return null;
+
+      established = { id: stored, proof: "tab-storage" };
+      return established;
+    },
+  };
+}
+
+/**
+ * Why a route was refused, for the panel's system log. Nothing was dispatched in
+ * either case, so this is a refusal notice, not a disclosure of something done.
+ *
+ * `settled` separates the two states. Reporting contention while the lease is
+ * still in flight would name a cause that has not been determined — "could not
+ * determine which tab holds this identity" is not "another tab holds it".
+ */
+export function describeRefusedRoute({ settled = true } = {}) {
+  if (!settled) {
+    return (
+      "This ComfyUI tab is still establishing its own bridge route, so the panel did NOT send " +
+      "that — nothing ran. Retry in a moment. Sending on a route this tab has not established " +
+      "yet could reach another browser tab's canvas."
+    );
+  }
+  return (
+    "This ComfyUI tab could not establish its own bridge route, so the panel did NOT register " +
+    "with the agent. Another browser tab in this origin is holding this tab's identity. " +
+    "Close the duplicate tab (or reload this one) and reconnect — registering anyway would " +
+    "share one route between two tabs, and the agent's commands could run against the other " +
+    "tab's canvas."
+  );
+}

--- a/web/js/lib/bridge-route.js
+++ b/web/js/lib/bridge-route.js
@@ -74,15 +74,26 @@ export function savedWorkflowRoute(tabRouteId, savedPath) {
  *    origin holds it, which is the only thing that also covers a DUPLICATED tab
  *    (browser tab duplication copies sessionStorage verbatim).
  *
- *  - the tab's sessionStorage id ("tab-storage"), used ONLY when Web Locks does
- *    not exist in this context at all. The panel deliberately supports ComfyUI
- *    served over plain http:// on a LAN, where `navigator.locks` is undefined
- *    because the API is secure-context-only — the same reason the panel ships a
- *    crypto.randomUUID polyfill. sessionStorage is scoped to one browser tab
- *    (localStorage is not), so two tabs that each OPENED the same URL still get
- *    distinct routes; only a duplicated tab can be carrying a copy. That is a
- *    narrower guarantee than a lease and is reported as such — but it is still
- *    an identity of the TAB, never of the file.
+ *  - a freshly minted, NEVER-PERSISTED id ("page-instance"), used only when Web
+ *    Locks does not exist in this context at all. The panel deliberately
+ *    supports ComfyUI served over plain http:// on a LAN, where
+ *    `navigator.locks` is undefined because the API is secure-context-only —
+ *    the same reason the panel ships a crypto.randomUUID polyfill (itself
+ *    backed by crypto.getRandomValues, which is not secure-context gated).
+ *    Refusing outright here would take every LAN panel offline.
+ *
+ *    It is minted per PAGE LOAD and written nowhere. That is what makes it
+ *    safe: browser tab duplication copies sessionStorage verbatim, so the
+ *    stored per-tab id is exactly the value two duplicated tabs would share —
+ *    reading it here would have re-created the #640 collision in the one mode
+ *    that cannot detect it. A value that has never left this page's heap cannot
+ *    be copied into another tab.
+ *
+ *    The cost is route stability, not uniqueness: a reload mints a new id, so
+ *    the orchestrator's tab-id-keyed session index misses and the conversation
+ *    is restored by the panel's own `hello.resume` (sessionStorage) instead.
+ *    Losing a resume is recoverable; delivering a command to the wrong canvas
+ *    is not.
  *
  *  - no id: Web Locks IS present and refused every candidate. That is live
  *    contention — another tab in this origin holds the identity — so nothing is
@@ -92,14 +103,14 @@ export function savedWorkflowRoute(tabRouteId, savedPath) {
  * tab's agent session on the orchestrator, and silently re-keying it mid-session
  * would strand that session behind a route nothing answers on.
  */
-export function createTabRouteIdentity({ locksAvailable, tabStorageId } = {}) {
+export function createTabRouteIdentity({ locksAvailable, mintPageInstanceId } = {}) {
   let established = null;
   let settled = false;
 
   return {
     /** Synchronous read. Null until an identity has ACTUALLY been established. */
     established: () => established,
-    /** "exclusive" | "tab-storage" | null — what the id above is backed by. */
+    /** "exclusive" | "page-instance" | null — what the id above is backed by. */
     proof: () => established?.proof ?? null,
     /**
      * Has a lease attempt COMPLETED? Distinguishes "no identity yet, resolution
@@ -127,12 +138,12 @@ export function createTabRouteIdentity({ locksAvailable, tabStorageId } = {}) {
         return established;
       }
 
-      // No lease. Distinguish "the lock manager said no" (contention — another
-      // live tab holds this identity) from "this context has no lock manager"
-      // (capability absent). Only the second may use the narrower tab-storage
-      // identity. A probe that throws is NOT evidence the API is missing:
-      // "could not determine" is not "determined it is absent", so an
-      // unreadable probe is treated as present and refuses.
+      // No lease. Distinguish "the lock manager said no or could not answer"
+      // from "this context has no lock manager at all" (capability absent).
+      // Only the second may mint a page-instance id; the first is a failure to
+      // establish and must refuse. A probe that throws is NOT evidence the API
+      // is missing — "could not determine" is not "determined it is absent" —
+      // so an unreadable probe is treated as present and refuses.
       let available = true;
       try {
         available = !!locksAvailable?.();
@@ -141,15 +152,15 @@ export function createTabRouteIdentity({ locksAvailable, tabStorageId } = {}) {
       }
       if (available) return null;
 
-      let stored = null;
+      let minted = null;
       try {
-        stored = trimmed(tabStorageId?.());
+        minted = trimmed(mintPageInstanceId?.());
       } catch {
-        stored = null;
+        minted = null;
       }
-      if (!stored) return null;
+      if (!minted) return null;
 
-      established = { id: stored, proof: "tab-storage" };
+      established = { id: minted, proof: "page-instance" };
       return established;
     },
   };
@@ -171,11 +182,16 @@ export function describeRefusedRoute({ settled = true } = {}) {
       "yet could reach another browser tab's canvas."
     );
   }
+  // What IS determined is that the lock manager did not grant this page an
+  // exclusive identity. WHY it did not is not determined: contention with
+  // another tab is the usual cause, but a lock request that rejects or throws
+  // lands here identically. Report the outcome, offer the cause as the likely
+  // one, and do not assert it.
   return (
     "This ComfyUI tab could not establish its own bridge route, so the panel did NOT register " +
-    "with the agent. Another browser tab in this origin is holding this tab's identity. " +
-    "Close the duplicate tab (or reload this one) and reconnect — registering anyway would " +
-    "share one route between two tabs, and the agent's commands could run against the other " +
-    "tab's canvas."
+    "with the agent and nothing has run. Most often another browser tab in this origin is " +
+    "holding this tab's identity — close the duplicate tab, then reload this one and " +
+    "reconnect. Registering anyway would share one route between two tabs, and the agent's " +
+    "commands could run against the other tab's canvas."
   );
 }

--- a/web/js/lib/restart-tab-identity.js
+++ b/web/js/lib/restart-tab-identity.js
@@ -100,6 +100,15 @@ export function createRestartTabIdentity({
 export async function sendBridgeHello({ socket, isCurrent, resolveTabIdentity, makePayload }) {
   const tabSessionId = await resolveTabIdentity();
   if (!isCurrent()) return false;
-  socket.send(JSON.stringify(makePayload(tabSessionId)));
+  // #640 — makePayload REFUSES (returns null) when this browser tab's bridge
+  // route could not be established. A hello is what REGISTERS the route, and
+  // registering one this tab cannot claim exclusively is the whole defect: the
+  // bridge keeps one connection per tab id, so the second hello takes the route
+  // over and the agent's commands land on the other tab's canvas. Refuse before
+  // dispatch rather than disclose after it. Returning false also keeps the
+  // caller from advancing the agent-session epoch for a hello that never left.
+  const payload = makePayload(tabSessionId);
+  if (!payload) return false;
+  socket.send(JSON.stringify(payload));
   return true;
 }


### PR DESCRIPTION
## Issues in this cluster

- artokun/comfyui-mcp-panel#640 — isolate saved-workflow bridge routes per browser tab

## Why this needs its own PR

I previously routed artokun/comfyui-mcp-panel#640 to artokun/comfyui-mcp-panel#623 by mistake — that cluster is artokun/comfyui-mcp-panel#619/#618/#617/#613 (the mid-population reconnect fence), which is a different problem. artokun/comfyui-mcp-panel#640 had no home. This is it.

## Severity is understated by its label

The saved-workflow routing key is **path-only** (`wf:<path>`), so two tabs that open the same saved workflow **register on the same bridge route**. A command or reply can therefore reach the *other* live tab, whose workflow UUID correctly fails the instance fence.

That is the same harm class as artokun/comfyui-mcp-panel#621 — **a mutation reaching the wrong graph** — arriving through *routing* rather than through *binding*. The instance fence catching it is the system working, but it is the **last** line of defence, and it only fires on operations that carry a UUID to check.

This is live on this rig, not theoretical: the report notes multiple concurrent agent sessions using the identical saved-workflow panel URL. Two agents sharing one machine is ordinary here.

## Constraints for whoever takes it

- The route key must identify the **tab/session**, not the file. Two tabs on the same saved workflow, the same unsaved workflow, or the same file after a rename must all get distinct routes.
- **If the tab identity cannot be established, refuse the route — do not fall back to the path.** A silent fallback recreates the collision precisely when identity is hardest to determine. artokun/comfyui-mcp-panel#621's lesson applies directly: a claim must be established, not assumed.
- **Do not weaken the workflow-UUID instance fence** to make the symptom go away. It is currently the only thing stopping a cross-tab mutation from landing.
- The report also shows a recovery `panel_open_workflow` timing out, so check the **recovery** path, not only the read path.
- Check the **reply** path independently of the dispatch path — they can be keyed differently, and a correctly-dispatched command whose reply lands in another tab is the same bug.

## Status

**Implemented.** Saved-workflow bridge routes are now tab-scoped (`wf:<tabRouteId>:<path>`), established only from the COMPLETED Web Locks lease (page-instance mint when Web Locks is absent on plain-http LAN; refusal when it is present but grants nothing). Every wire site (hello, sendFrame, title, callTool, uploadMedia, lost_replies) refuses rather than falling back to the path. The `routing_key` handle stays `wf:<path>` so the orchestrator's post-open command-fence refresh (the recovery path above) still authorizes. The instance fence is untouched. Verified: full unit suite green on the origin/main-merged tree, 10 mutants + delete-module check each turn a distinct test red, control-byte scan clean, codex adversarial gate PASS.
