### PR TITLE
release: 0.11.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.40] - 2026-08-05
+
+### Fixed
+- **`panel_show_media` no longer dead-ends on video, and no longer acknowledges a delivery
+  it did not make (#649).** Under the size ceiling the panel painted a player for the *user*
+  and returned `{ok:true,count:1}` to an agent that had been shown nothing. An absent handler
+  now fails loudly, and a handler that returns nothing reports the delivery as UNKNOWN.
+  Oversized video routes through the existing storyboard pipeline with an explicit disclosure —
+  the video was **not** sent, the sheet is N *sampled* frames, and `get_image` is the way to
+  actually look at it. A partial sheet withholds the "evenly-spaced" claim. Also fixed:
+  `clip.mp4?download=1` classified as an image, `/.(mp4|webm)$/` matching `xmp4`, and a
+  truthy-but-unusable upload reference producing a `get_image` remedy with an empty filename.
+  The 20 MB refusal itself is orchestrator-side and still open (artokun/comfyui-mcp#854).
+- **`workflow_open` now says which check it could not prove (#653).** The verdict is split and
+  named (`instance` / `marker` / `identity` / `content`), so a failure states which observation
+  failed and which two values disagreed, instead of four distinct causes collapsing into one
+  message that asserted whichever it happened to name. An attempt-scoped single-use marker
+  proves the rebind with evidence a stale tag cannot fake. The long-standing "two dialects"
+  hypothesis was tested and **refuted**; whether the whole graph *landed* is still reported as
+  unknown, deliberately — a `configure()` failure that silently drops widget values is
+  byte-identical to the loader normalizing them. Partially addresses #604, #603, #616, #374;
+  closes #641.
+- say when the live-canvas tools may not have reached the agent (#291) (#633)
+- the `waitForQueueDrain` test was flaky under load — it stubbed a bounded delay with a real
+  `setTimeout` against a 5s budget, so a loaded machine consumed the whole budget before the
+  polls completed. The injected delay now resolves instantly, and the test additionally asserts
+  the loop's pacing, which it had been taking on trust (#652)
+
+
 ## [0.11.39] - 2026-08-04
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.39"
+version = "0.11.40"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -728,7 +728,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.39";
+const PANEL_VERSION = "0.11.40";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
## Contents

| PR | |
|---|---|
| **#649** | `panel_show_media`: sampled previews that **say they are samples**, and no more acknowledging a delivery that never happened |
| **#653** | `workflow_open` names *which* check it could not prove; the dialect hypothesis is refuted, and `unknown` deliberately stays for graph fidelity |
| **#633** | say when the live-canvas tools may not have reached the agent (#291) |
| **#652** | de-flake `waitForQueueDrain`, and assert the pacing it was taking on trust |

Two of these fixed a **fabricated success**, which is the failure mode this project ranks worst:

- #649 — under the size ceiling the panel painted a player for the *user* and returned `{ok:true,count:1}` to an agent that had been shown nothing. It was counting the request as the delivery.
- #653 — `CONTENT_UNVERIFIED` asserted the canvas "does not match" *before* the clause admitting it could not compare. Both sentences now route through one predicate that requires an explicit `true`.

## The changelog generator dropped 3 of 4 again

It captured **one** commit. #649, #653 and #652 were omitted because their squash titles do not begin with a conventional `fix(`/`feat(` prefix.

**This is the third consecutive release with silent omissions, and each time it dropped the entry a user most needed** — panel 0.11.39 lost #621 (a CRITICAL wrong-graph fix), mcp 0.49.6 lost #831 (which closed eleven issues), and now this. Written by hand again; **fixing `gen-changelog` is the immediate follow-up** rather than a fourth manual patch. A generator that silently drops the headline entry is worse than no generator, because the output looks complete.

## Verification

- **2094/2094** unit tests (the `waitForQueueDrain` flake is gone, courtesy of #652)
- `tsc --noEmit` clean; zero control bytes across changed files
- `PANEL_VERSION` matches `pyproject.toml` — the publish gate enforces this

Merging fires the Comfy Registry publish.