### PR TITLE
release: 0.11.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ All notable changes to this project are documented here. This project adheres to
 
 ## [Unreleased]
 
+## [0.11.41] - 2026-08-05
+
+### Fixed
+- the changelog generator silently dropped the entries that mattered most (#657)
+
+### Changed
+- **`to_node_id` is honoured instead of only refused (#556).** Running "up to node N"
+  used to run the WHOLE graph — a different request executed successfully, spending real
+  GPU time or API-node credits on work nobody asked for. An earlier fix made the panel
+  refuse instead, which was safe but refused every time, so the feature was unusable.
+  A last-resort delivery attempt now writes the scope into the run's own `/prompt` body —
+  the one interface every frontend build shares — identity-gated on the run's mark and
+  content hash, never overwriting a value it cannot interpret, and disclosed via
+  `scope_applied_by`.
+
+  Reading the real frontend sources (1.42.15, 1.47.11, 1.50.1) showed that **every one
+  accepts both `app.queuePrompt` argument shapes**, so the old refusal's assertion that
+  "this frontend build ignored the run-to-node argument" was almost certainly wrong — and
+  three field reports pasted it verbatim into the tracker. The root cause is still unknown;
+  the outcome is now correct regardless of which layer drops the scope, and the next report
+  will be diagnosable. Ten adversarial rounds found ten distinct paths by which a request
+  could still reach the network unscoped — including a retrying run restoring its
+  entry-time `fetchApi` over a concurrent run's guard. #581 needed no code: already fixed
+  on main by #594 and #621.
+
+
 ## [0.11.40] - 2026-08-05
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.40"
+version = "0.11.41"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -728,7 +728,7 @@ const DISCORD_INVITE_URL = "https://discord.gg/cW9arBhzCu";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.40";
+const PANEL_VERSION = "0.11.41";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
## Contents

| PR | |
|---|---|
| **#630** | `to_node_id` is **honoured** instead of only refused (#556); #581 needed no code |
| #657 | the changelog generator silently dropped the entries that mattered most |

## #630 is the user-facing one

Running *"up to node N"* used to run the **whole graph** — a different request executed successfully, spending real GPU time or API-node credits on work nobody asked for. An earlier fix made the panel **refuse** instead: safe, but it refused *every time*, so the feature was unusable.

The scope is now written into the run's own `/prompt` body — the one interface every frontend build shares — identity-gated on the run's mark and content hash, never overwriting a value it cannot interpret, and disclosed via `scope_applied_by`.

**The most useful finding isn't the fix.** Reading the real frontend sources (1.42.15, 1.47.11, 1.50.1) showed that **every one accepts both `app.queuePrompt` argument shapes** and funnels both into `partial_execution_targets` — so the old refusal's assertion that *"this frontend build ignored the run-to-node argument"* was almost certainly **wrong**, and three field reports pasted it verbatim into the tracker. An asserted cause the code could not observe is why the real cause is still unknown.

The root cause remains unknown and this does not claim otherwise. What it does is make the outcome correct regardless of which layer drops the scope, and make the next report diagnosable.

**Ten adversarial rounds found ten distinct paths** by which a marked request could still reach the network unscoped — including a retrying run restoring its entry-time `fetchApi` over a *concurrent* run's guard, so the other run's late post went out unscoped. The PR says outright to assume a twelfth exit exists.

## Verification

- **2131/2131** unit tests; `tsc` clean; zero control bytes; `PANEL_VERSION` matches `pyproject.toml`
- Second release running where the generator captured everything, including #630's descriptive title — the exact class it used to drop. Expanded by hand for context only, not to add a missing line.

Merging fires the Comfy Registry publish.
