### PR TITLE
fix(panel): CivitAI transport failure reports an undetermined cause and never destroys an attempt's evidence (#632 gate)

### DIFF
--- a/browser_tests/unit/civitai-drive-results.test.mjs
+++ b/browser_tests/unit/civitai-drive-results.test.mjs
@@ -119,17 +119,17 @@ test("non-array source is tolerated", () => {
 });
 
 // ---- #599: the agent-facing error must distinguish the failure CAUSE ----
-// transport (browser→ComfyUI proxy hop failed, no HTTP response came back) vs
-// an upstream CivitAI error (HTTP status present) vs a true empty result (no
-// error object at all).
+// transport (NO HTTP response was received; which hop failed is undetermined,
+// and CivitAI is NOT excluded) vs an upstream CivitAI error (HTTP status
+// present) vs a true empty result (no error object at all).
 
 test("#599: a transport failure keeps status null and carries kind", () => {
-  const err = Object.assign(new Error("…browser→ComfyUI hop…"), {
+  const err = Object.assign(new Error("…no HTTP response; hop undetermined…"), {
     status: null, kind: "transport",
   });
   assert.deepEqual(civitaiErrorState(err), {
     status: null,
-    message: "…browser→ComfyUI hop…",
+    message: "…no HTTP response; hop undetermined…",
     kind: "transport",
   });
 });

--- a/browser_tests/unit/civitai-upstream-error.test.mjs
+++ b/browser_tests/unit/civitai-upstream-error.test.mjs
@@ -84,14 +84,17 @@ test("#417: _request throws a timeout error when the proxy never settles", async
   }
 });
 
-// ---- #599: browser→proxy transport failures ("Failed to fetch", no status) --
-// A bare TypeError from fetch means no HTTP response came back from the
-// ComfyUI-side proxy — CivitAI is not the cause. The proxy call is always a
-// POST, which Chrome won't self-retry on a stale keep-alive connection, so the
-// client does ONE retry for idempotent specs (GETs, plus the read-only Meili
-// multi-search POST, which is flagged idempotent at the call site), then throws
-// a CLASSIFIED transport error (kind:"transport", status:null) naming the real
-// failed hop — never the browser's bare "Failed to fetch" alone.
+// ---- #599: transport failures ("Failed to fetch", no HTTP status) -----------
+// A bare TypeError from fetch establishes exactly one thing: the browser
+// obtained NO HTTP response. It does not identify which leg failed and it does
+// NOT rule CivitAI out — a request that reached ComfyUI whose own upstream
+// CivitAI call then failed rejects identically. So the thrown error must report
+// the cause as UNDETERMINED and list candidates, never assert one hop.
+// The proxy call is always a POST, which Chrome won't self-retry on a stale
+// keep-alive connection, so the client does ONE retry for idempotent specs
+// (GETs, plus the read-only Meili multi-search POST, which is flagged
+// idempotent at the call site), then throws a CLASSIFIED transport error
+// (kind:"transport", status:null) carrying the FULL attempt trail.
 
 test("#599: a transient transport failure on an idempotent request is retried once", async () => {
   let calls = 0;
@@ -122,15 +125,111 @@ test("#599: a persistent transport failure throws a classified transport error",
     (err) => {
       assert.equal(err.kind, "transport");
       assert.equal(err.status, null); // no HTTP response ever existed
-      // The reason, not just the state: the failed hop is browser→ComfyUI
-      // proxy, and the original browser text is preserved for diagnosis.
-      assert.match(err.message, /browser→ComfyUI hop/);
+      // The observation is preserved…
       assert.match(err.message, /Failed to fetch/);
-      assert.match(err.message, /not an empty result/);
+      // …and the one thing that IS established: no HTTP status came back, so
+      // this cannot be read as a confirmed empty result.
+      assert.match(err.message, /not a confirmed empty result/);
       return true;
     },
   );
   assert.equal(calls, 2); // one bounded retry, then give up
+});
+
+// The defect this repo keeps re-growing: an opaque bucket narrated as a CAUSE.
+// "Failed to fetch" is the browser's single bucket for network failure, CORS,
+// a blocked request, DNS, offline and abort. The rejection below happens AFTER
+// the request reached ComfyUI — ComfyUI's own upstream CivitAI call failed and
+// no response made it back — and it is byte-identical to a ComfyUI-unreachable
+// rejection. The error must therefore say the hop is UNDETERMINED and must NOT
+// tell the user CivitAI has been excluded, or they rule out the actual cause.
+test("#599: a rejection that occurred AFTER reaching ComfyUI is reported as undetermined, not as 'not a CivitAI error'", async () => {
+  const client = new CivitaiClient({
+    fetchApi: async () => {
+      // ComfyUI accepted the request and its OWN upstream CivitAI call failed;
+      // the response connection dropped before any status reached the browser.
+      throw new TypeError("Failed to fetch");
+    },
+    apiURL: (p) => p,
+  });
+  await assert.rejects(
+    () => client._request({ url: "https://civitai.red/api/v1/models" }),
+    (err) => {
+      // States the cause is not established…
+      assert.match(err.message, /could NOT be determined/);
+      // …explicitly does not exclude CivitAI, and names it as a live candidate.
+      assert.match(err.message, /does not rule CivitAI out/);
+      assert.match(err.message, /ComfyUI did reach CivitAI/);
+      // …and never asserts a single hop as the diagnosis.
+      assert.doesNotMatch(err.message, /not a CivitAI error/i);
+      assert.doesNotMatch(err.message, /failed at the browser→ComfyUI hop/i);
+      return true;
+    },
+  );
+});
+
+// Never destroy evidence before it can be reported: attempt 1 can carry the
+// actionable error and attempt 2 an unrelated one. If only the retry's message
+// survives, the diagnosis of an intermittent failure is lost.
+test("#599: the retry does not discard the first attempt's error", async () => {
+  let calls = 0;
+  const client = new CivitaiClient({
+    fetchApi: async () => {
+      calls++;
+      if (calls === 1) throw new TypeError("blocked by a browser extension");
+      throw new TypeError("NetworkError when attempting to fetch resource");
+    },
+    apiURL: (p) => p,
+  });
+  await assert.rejects(
+    () => client._request({ url: "https://civitai.red/api/v1/models" }),
+    (err) => {
+      // BOTH failures are reported, and which is which is unambiguous.
+      assert.match(err.message, /attempt 1 failed with: blocked by a browser extension/);
+      assert.match(err.message, /the retry then failed with: NetworkError when attempting to fetch resource/);
+      // The original error object itself survives for programmatic callers.
+      assert.equal(err.cause?.message, "blocked by a browser extension");
+      return true;
+    },
+  );
+  assert.equal(calls, 2);
+});
+
+// Same evidence rule when the retry is cut short by the #417 abort budget
+// rather than by another transport rejection.
+test("#599: a timeout after a failed first attempt still reports that first error", async () => {
+  mock.timers.enable({ apis: ["setTimeout"] });
+  try {
+    let calls = 0;
+    const client = new CivitaiClient({
+      fetchApi: (_path, opts) => {
+        calls++;
+        if (calls === 1) return Promise.reject(new TypeError("blocked by a browser extension"));
+        return new Promise((_resolve, reject) => {
+          opts.signal.addEventListener("abort", () => {
+            const e = new Error("The operation was aborted");
+            e.name = "AbortError";
+            reject(e);
+          });
+        });
+      },
+      apiURL: (p) => p,
+    });
+    const pending = client._request({ url: "https://civitai.red/api/v1/models" });
+    await Promise.resolve(); // let attempt 1 reject and attempt 2 start
+    mock.timers.tick(CIVITAI_REQUEST_TIMEOUT_MS + 1);
+    await assert.rejects(
+      () => pending,
+      (err) => {
+        assert.match(err.message, /timed out after \d+ seconds/i);
+        assert.match(err.message, /blocked by a browser extension/);
+        assert.equal(err.cause?.message, "blocked by a browser extension");
+        return true;
+      },
+    );
+  } finally {
+    mock.timers.reset();
+  }
 });
 
 test("#599: a transport failure on a non-idempotent (POST) request is NOT retried", async () => {

--- a/browser_tests/unit/civitai-upstream-error.test.mjs
+++ b/browser_tests/unit/civitai-upstream-error.test.mjs
@@ -225,6 +225,7 @@ test("#599: an upstream status on the RETRY still reports the first attempt's tr
 
 test("#599: an unparseable body on the RETRY still reports the first attempt's transport error", async () => {
   let calls = 0;
+  const parseError = new SyntaxError("Unexpected token < in JSON");
   const client = new CivitaiClient({
     fetchApi: async () => {
       calls++;
@@ -233,7 +234,7 @@ test("#599: an unparseable body on the RETRY still reports the first attempt's t
         ok: true,
         status: 200,
         json: async () => {
-          throw new SyntaxError("Unexpected token < in JSON");
+          throw parseError;
         },
       };
     },
@@ -247,6 +248,37 @@ test("#599: an unparseable body on the RETRY still reports the first attempt's t
       assert.equal(err.cause?.message, "blocked by a browser extension");
       // res was ok, so there is no upstream error status to claim.
       assert.equal(err.status, undefined);
+      // Attaching attempt 1's evidence must not destroy the RETRY's evidence:
+      // the parse error keeps its identity, its class and its stack. Rebuilding
+      // it as a plain Error would be the same evidence loss in the other
+      // direction.
+      assert.equal(err, parseError, "the original parse error object is thrown, not a copy");
+      assert.ok(err instanceof SyntaxError);
+      assert.equal(err.name, "SyntaxError");
+      assert.ok(err.stack, "the parse error's own stack survives");
+      return true;
+    },
+  );
+});
+
+test("#599: an existing cause on the retry's error is never overwritten", async () => {
+  let calls = 0;
+  const inner = new Error("the real underlying parse problem");
+  const parseError = new SyntaxError("bad body", { cause: inner });
+  const client = new CivitaiClient({
+    fetchApi: async () => {
+      calls++;
+      if (calls === 1) throw new TypeError("blocked by a browser extension");
+      return { ok: true, status: 200, json: async () => { throw parseError; } };
+    },
+    apiURL: (p) => p,
+  });
+  await assert.rejects(
+    () => client._request({ url: "https://civitai.red/api/v1/models" }),
+    (err) => {
+      assert.equal(err.cause, inner, "a pre-existing cause is evidence too");
+      // …and attempt 1 is still reported, via the message.
+      assert.match(err.message, /blocked by a browser extension/);
       return true;
     },
   );

--- a/browser_tests/unit/civitai-upstream-error.test.mjs
+++ b/browser_tests/unit/civitai-upstream-error.test.mjs
@@ -195,6 +195,80 @@ test("#599: the retry does not discard the first attempt's error", async () => {
   assert.equal(calls, 2);
 });
 
+// The evidence rule holds on EVERY final throw, not just the transport one.
+// If attempt 1 dies at transport and the retry comes back with an upstream
+// status, the throw happens outside the retry catch — the first rejection (an
+// extension blocking the request, a dropped connection) must not be silently
+// replaced by an unrelated 503.
+test("#599: an upstream status on the RETRY still reports the first attempt's transport error", async () => {
+  let calls = 0;
+  const client = new CivitaiClient({
+    fetchApi: async () => {
+      calls++;
+      if (calls === 1) throw new TypeError("blocked by a browser extension");
+      return { ok: false, status: 503, statusText: "Service Unavailable", json: async () => ({}) };
+    },
+    apiURL: (p) => p,
+  });
+  await assert.rejects(
+    () => client._request({ url: "https://civitai.red/api/v1/models" }),
+    (err) => {
+      assert.equal(err.status, 503); // the upstream status is still classified correctly
+      assert.match(err.message, /503/);
+      assert.match(err.message, /blocked by a browser extension/);
+      assert.equal(err.cause?.message, "blocked by a browser extension");
+      return true;
+    },
+  );
+  assert.equal(calls, 2);
+});
+
+test("#599: an unparseable body on the RETRY still reports the first attempt's transport error", async () => {
+  let calls = 0;
+  const client = new CivitaiClient({
+    fetchApi: async () => {
+      calls++;
+      if (calls === 1) throw new TypeError("blocked by a browser extension");
+      return {
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new SyntaxError("Unexpected token < in JSON");
+        },
+      };
+    },
+    apiURL: (p) => p,
+  });
+  await assert.rejects(
+    () => client._request({ url: "https://civitai.red/api/v1/models" }),
+    (err) => {
+      assert.match(err.message, /Unexpected token/);
+      assert.match(err.message, /blocked by a browser extension/);
+      assert.equal(err.cause?.message, "blocked by a browser extension");
+      // res was ok, so there is no upstream error status to claim.
+      assert.equal(err.status, undefined);
+      return true;
+    },
+  );
+});
+
+// A first-attempt-free failure must be left exactly as it was — no invented
+// trail, no invented cause (guards the fix against overshooting).
+test("#599: a plain upstream error with no prior attempt is unchanged", async () => {
+  const client = new CivitaiClient({
+    fetchApi: async () => ({ ok: false, status: 503, statusText: "Service Unavailable", json: async () => ({}) }),
+    apiURL: (p) => p,
+  });
+  await assert.rejects(
+    () => client._request({ url: "https://civitai.red/api/v1/models" }),
+    (err) => {
+      assert.equal(err.message, "CivitAI API 503: Service Unavailable");
+      assert.equal(err.cause, undefined);
+      return true;
+    },
+  );
+});
+
 // Same evidence rule when the retry is cut short by the #417 abort budget
 // rather than by another transport rejection.
 test("#599: a timeout after a failed first attempt still reports that first error", async () => {

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -287,8 +287,9 @@ export function serializeCivitaiResults(source, { model = false, limit = 20, loa
 
 /** Build the `state.error` object reported by panel_civitai_results (#190).
  *  The client throws Errors carrying an HTTP `status` for upstream CivitAI
- *  failures; a browser→proxy transport failure (#599) carries `kind:"transport"`
- *  and status null (no HTTP response came back); a true empty result sets NO
+ *  failures; a transport failure (#599) carries `kind:"transport"` and status
+ *  null, meaning NO HTTP response was received and the failing hop is
+ *  UNDETERMINED (it does not rule CivitAI out); a true empty result sets NO
  *  error at all. Pure and exported for unit tests. */
 export function civitaiErrorState(e) {
   const status = e && typeof e.status === "number" ? e.status : null;
@@ -701,8 +702,8 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
         sentinel.textContent = "CivitAI error: " + (e.message || e);
         // Record the failure so the agent-facing panel_civitai_results can report
         // a distinct error state instead of an indistinguishable total:0 (#190);
-        // kind:"transport" marks a browser→proxy failure — no HTTP response
-        // came back (#599, see civitaiErrorState).
+        // kind:"transport" marks a failure where no HTTP response was received
+        // at all; which hop failed is undetermined (#599, civitaiErrorState).
         state.error = civitaiErrorState(e);
       }
     } finally {

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -308,23 +308,41 @@ export class CivitaiClient {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), CIVITAI_REQUEST_TIMEOUT_MS);
     // #599: a bare transport rejection (TypeError "Failed to fetch", NO HTTP
-    // status) means the browser→ComfyUI leg failed — no response came back, so
-    // CivitAI is not the cause. The proxy call is always a POST, which Chrome
-    // will NOT self-retry when a pooled keep-alive connection turns out to be
-    // stale, so do ONE bounded retry here — but only for an idempotent spec: a
-    // mutation (reaction.toggle, collection writes) must never be double-fired.
-    // The retry shares the #417 abort budget above, so the worst case is
-    // unchanged. A failure that survives the retry is rethrown CLASSIFIED
-    // (kind:"transport") so the UI / panel_civitai_results can tell "the panel
-    // couldn't reach its own proxy" apart from an upstream CivitAI error
-    // (always carries an HTTP status) and from a true empty result (error is
-    // null).
+    // status) establishes exactly ONE thing — the browser obtained no HTTP
+    // response. It does NOT identify which leg failed, and it does NOT rule
+    // CivitAI out: a request that reached ComfyUI, whose own upstream CivitAI
+    // call then failed or whose response connection dropped on the way back,
+    // rejects identically. So `kind:"transport"` means "no HTTP response was
+    // received; the failing hop is UNDETERMINED" — never "the browser→ComfyUI
+    // hop is the cause". Naming one candidate as the cause is the very defect
+    // #599 exists to remove (the opaque bucket narrated as a diagnosis): it
+    // sends the user to rule out a component that may be perfectly healthy.
+    // The marker is still worth carrying, because it distinguishes "no HTTP
+    // response at all" from an upstream CivitAI error (which ALWAYS carries an
+    // HTTP status) and from a true empty result (error is null) — those three
+    // really are different, and only the hop is unknown.
+    //
+    // The proxy call is always a POST, which Chrome will NOT self-retry when a
+    // pooled keep-alive connection turns out to be stale, so do ONE bounded
+    // retry here — but only for an idempotent spec: a mutation
+    // (reaction.toggle, collection writes) must never be double-fired. The
+    // retry shares the #417 abort budget above, so the worst case is unchanged.
     //
     // Idempotency is a property of the OPERATION, not the HTTP method: CivitAI
     // reads are GETs EXCEPT MeiliSearch multi-search, which is a read-only
     // POST — callers pass `idempotent: true` for that one. Anything else POST
     // (reaction.toggle, collection writes) is a mutation and is never retried.
     const idempotent = idem ?? ((method || "GET").toUpperCase() === "GET");
+    // The FIRST attempt's rejection, retained so the retry can never destroy
+    // it: attempt 1 can fail with the actionable error and attempt 2 with an
+    // unrelated one, and showing only the second loses the diagnosis. Every
+    // throw below reports the whole trail and attaches the original as `cause`.
+    let firstTransportError = null;
+    const errText = (e) => coerceMessageText(e?.message ?? e);
+    const attemptTrail = (last) =>
+      firstTransportError
+        ? `attempt 1 failed with: ${errText(firstTransportError)}; the retry then failed with: ${errText(last)}`
+        : `browser transport error: ${errText(last)}`;
     let res;
     try {
       for (let attempt = 0; ; attempt++) {
@@ -338,22 +356,38 @@ export class CivitaiClient {
           break;
         } catch (e) {
           if (e?.name === "AbortError") {
-            throw new Error(
-              `CivitAI request timed out after ${Math.round(CIVITAI_REQUEST_TIMEOUT_MS / 1000)} seconds`,
-            );
-          }
-          if (idempotent && attempt < 1 && typeof e?.status !== "number") continue;
-          if (typeof e?.status !== "number") {
             throw Object.assign(
               new Error(
-                `The CivitAI request failed at the browser→ComfyUI hop: no HTTP response came ` +
-                `back (browser transport error: ${coerceMessageText(e?.message ?? e)}). This is a ` +
-                `connection-level failure — not a CivitAI error, and not an empty result. The ` +
-                `ComfyUI server may be restarting, the connection may have dropped, or a browser ` +
-                `extension/policy may have blocked the request. Retry the search; if it persists, ` +
-                `check that ComfyUI is running and reachable.`,
+                `CivitAI request timed out after ${Math.round(CIVITAI_REQUEST_TIMEOUT_MS / 1000)} seconds` +
+                (firstTransportError
+                  ? ` (a first attempt had already failed with: ${errText(firstTransportError)})`
+                  : ""),
               ),
-              { status: null, kind: "transport" },
+              firstTransportError ? { cause: firstTransportError } : {},
+            );
+          }
+          if (typeof e?.status !== "number") {
+            if (idempotent && attempt < 1) {
+              firstTransportError = e;
+              continue;
+            }
+            throw Object.assign(
+              new Error(
+                `The CivitAI request produced no HTTP response, so the failing hop could NOT be ` +
+                `determined (${attemptTrail(e)}). A rejected fetch carrying no HTTP status does not ` +
+                `say which leg failed and does not rule CivitAI out — every one of these produces ` +
+                `the identical error: ComfyUI is not running, is restarting or is unreachable; the ` +
+                `connection to ComfyUI dropped; a browser extension, proxy or policy blocked the ` +
+                `request; or ComfyUI did reach CivitAI, CivitAI failed, and no response made it ` +
+                `back. What IS certain is that no HTTP status was received, so this is not a ` +
+                `confirmed empty result — no result arrived at all. Start by checking that ComfyUI ` +
+                `is running and reachable, then retry.`,
+              ),
+              {
+                status: null,
+                kind: "transport",
+                ...(firstTransportError ? { cause: firstTransportError } : {}),
+              },
             );
           }
           throw e;

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -343,6 +343,14 @@ export class CivitaiClient {
       firstTransportError
         ? `attempt 1 failed with: ${errText(firstTransportError)}; the retry then failed with: ${errText(last)}`
         : `browser transport error: ${errText(last)}`;
+    // Append attempt 1's rejection to a failure raised AFTER a retry actually
+    // got a response (an upstream status, or a body that won't parse). Those
+    // throws are outside the retry catch, so without this the first attempt's
+    // evidence is dropped exactly as it was before this fix.
+    const withFirstAttempt = (msg) =>
+      firstTransportError
+        ? `${msg} (a first attempt had already failed at transport with: ${errText(firstTransportError)})`
+        : msg;
     let res;
     try {
       for (let attempt = 0; ; attempt++) {
@@ -401,11 +409,31 @@ export class CivitaiClient {
       // catch) can surface a distinct error state instead of an empty grid
       // (#190). The proxy forwards CivitAI's status, so res.status is the real
       // upstream code (e.g. 503 when model search is overloaded).
-      throw Object.assign(new Error(`CivitAI API ${res.status}: ${res.statusText || "request failed"}`), {
+      //
+      // If attempt 1 died at transport and the RETRY is what produced this
+      // status, that first rejection is still evidence and must survive here
+      // too — otherwise the failure that only shows up on the first attempt
+      // (an extension blocking the request, a dropped connection) is silently
+      // replaced by an unrelated upstream status. Same rule as the transport
+      // and timeout throws above: report the whole trail, never just the last.
+      throw Object.assign(new Error(withFirstAttempt(`CivitAI API ${res.status}: ${res.statusText || "request failed"}`)), {
         status: res.status,
+        ...(firstTransportError ? { cause: firstTransportError } : {}),
       });
     }
-    return normalizeTrpcResponse(await res.json());
+    try {
+      return normalizeTrpcResponse(await res.json());
+    } catch (e) {
+      // A body that will not parse is a real failure, and if attempt 1 had
+      // already failed at transport that first error is part of the diagnosis.
+      // Do NOT stamp an HTTP status here: res was ok, so there is no upstream
+      // error status to report, and inventing one would read to
+      // civitaiErrorState as "CivitAI returned an error" — a different claim.
+      if (!firstTransportError) throw e;
+      throw Object.assign(new Error(withFirstAttempt(errText(e))), {
+        cause: firstTransportError,
+      });
+    }
   }
 
   /** Same-origin CDN media URL (usable as <img>/<video> src AND fetchable as a Blob). */

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -429,7 +429,19 @@ export class CivitaiClient {
       // Do NOT stamp an HTTP status here: res was ok, so there is no upstream
       // error status to report, and inventing one would read to
       // civitaiErrorState as "CivitAI returned an error" — a different claim.
+      //
+      // AUGMENT the parse error in place; never rebuild it. Wrapping it in a
+      // fresh Error would drop its class (SyntaxError) and its stack — losing
+      // the retry's evidence in the very act of preserving attempt 1's, which
+      // is the same defect this whole change exists to remove.
       if (!firstTransportError) throw e;
+      if (e instanceof Error) {
+        e.message = withFirstAttempt(e.message);
+        // Only fill an EMPTY cause — an existing one is itself evidence and
+        // must not be overwritten. The trail is in the message either way.
+        if (e.cause === undefined) e.cause = firstTransportError;
+        throw e;
+      }
       throw Object.assign(new Error(withFirstAttempt(errText(e))), {
         cause: firstTransportError,
       });


### PR DESCRIPTION
PR #632 was merged (521f651 / commit 040f4b7) with **both P0s from its own independent gate unaddressed**. Both were live on `main`. This lands the fixes.

### P0 1 — the opaque bucket narrated as a cause

The thrown transport error asserted a diagnosis it had not established:

> "This is a connection-level failure — **not a CivitAI error**, and not an empty result."

…and named the browser→ComfyUI hop as the failing leg. A rejected `fetch` with no HTTP status establishes exactly one thing: **the browser obtained no HTTP response.** It does not identify which leg failed and it does **not** exclude CivitAI — a request that reached ComfyUI whose own upstream CivitAI call then failed, or whose response dropped on the way back, rejects identically. Telling the user CivitAI is ruled out sends them to investigate a healthy component, which is the exact defect #599 exists to remove.

The message now reports the cause as **undetermined**, lists the candidates (including "ComfyUI did reach CivitAI, CivitAI failed, and no response made it back") and asserts none. The one established fact is kept and stated: no HTTP status was received, so this is **not** a confirmed empty result. `kind:"transport"` is retained but redefined — it means "no HTTP response was received", not "the browser→ComfyUI hop is the cause". Its only consumer forwards it without inferring a hop.

### P0 2 — the retry destroyed the first failure's evidence

The bounded retry dropped attempt 1's rejection via `continue`, so an intermittent failure reported only attempt 2. The first error is now retained, reported in full (`attempt 1 failed with: X; the retry then failed with: Y`) and attached as `cause` — on **every** exit, not just the transport one:

- another transport rejection
- the #417 timeout cutting the retry short
- the retry returning an **upstream HTTP status** (found by gate round 1 — this throw is outside the retry catch, so the first patch missed it)
- the retry returning a **body that won't parse**

The parse error is **augmented in place**, never rebuilt (gate round 2): wrapping it in a fresh `Error` dropped its class and stack — the rescue path deleting the thing it was rescuing, the same defect pointed at the other attempt. A pre-existing `cause` is left alone, since that is evidence too.

### Verification

Three adversarial gate rounds (codex `gpt-5.6-terra`, read-only): round 1 found the post-response evidence loss, round 2 the parse-error identity loss, **round 3 CLEAN**.

Five mutations, each caught by exactly the intended test(s):
| mutation | fails |
|---|---|
| reinstate the "not a CivitAI error" claim | the undetermined-diagnosis test only |
| retry drops the first error | the two evidence tests only |
| timeout path drops the first error | the timeout test only |
| `withFirstAttempt` made a no-op | the two post-response tests only |
| rebuild the parse error instead of augmenting | the two identity tests only |

Retry eligibility (idempotent vs mutation, status vs no-status) is **unchanged** — locked by the pre-existing tests plus a no-overshoot test asserting a plain upstream error with no prior attempt keeps its exact original message and no `cause`. Full unit suite green (2326). Control-byte scan clean, no git-binary files, both touched modules parse and import as ES modules.

Closes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)