### PR TITLE
fix(#606,#607): #622's gate findings — creation-stamp evidence bar, bounded re-hello, and a refusal that stops promising a reload

### DIFF
--- a/browser_tests/unit/binding-recovery.test.mjs
+++ b/browser_tests/unit/binding-recovery.test.mjs
@@ -6,20 +6,23 @@
  *     reconnect: ComfyUI reuses app.graph across tabs and clear/configure does NOT
  *     reset graph.extra, so the new tab inherited the PREVIOUS workflow's root tag;
  *     with its ChangeTracker not yet PROVEN empty the both-empty heal could not fire,
- *     and nothing re-stamped the root. workflow_new now stamps the root at creation
- *     (only when the root is PROVEN content-free). workflow_open's side of the
- *     cluster is covered by open-rebind-proof.test.mjs (the #623 attempt-scoped
- *     open_proof marker, which superseded this file's earlier re-stamp tests when
- *     the two integrated).
+ *     and nothing re-stamped the root. workflow_new now stamps the root at creation,
+ *     and only when the root is PROVEN content-free.
+ *
+ *     The branch's second half — re-stamping the tag after a repaint whose tag "did
+ *     not ride" — is deliberately NOT shipped; see the section comment below. main's
+ *     single-use open-proof marker made it unnecessary, and the evidence it would
+ *     have been licensed by could not tell "did not match" from "could not be read".
  *
  *   #607 — a fence refusal ("workflow instance mismatch") meant the orchestrator's
  *     cached stamp was stale relative to the panel's LIVE identity, yet the advertised
  *     recovery never reached that cache: the panel re-hellos (the frame the
- *     orchestrator re-stamps from) when the refusal fires.
+ *     orchestrator re-stamps from) when the refusal fires — BOUNDED per identity, and
+ *     spending its budget only on hellos that reached the wire.
  *
  * The harnesses extract the SHIPPING code from the panel monolith and drive it with
  * injected doubles, so the tests are about the code that actually runs (delete the
- * stamp / the hook call and the matching test fails).
+ * stamp / the bound / the hook call and the matching test fails).
  */
 import test from "node:test";
 import assert from "node:assert/strict";
@@ -27,7 +30,12 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
-import { graphRootProvenEmpty } from "../../web/js/lib/graph-binding.js";
+import {
+  graphRootProvenEmpty,
+  activeWorkflowProvenEmpty,
+  graphRootWorkflowUuidMatches,
+  graphRootMatchesState,
+} from "../../web/js/lib/graph-binding.js";
 import { commandTargetsActiveWorkflow } from "../../web/js/lib/workflow-chat-identity.js";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -101,6 +109,7 @@ function buildWorkflowNew({
     "coerceMessageText",
     "getWorkflowTitle",
     "graphRootProvenEmpty",
+    "activeWorkflowProvenEmpty",
     "stampGraphRootWorkflowUuid",
     "backendReconnectEpoch",
     "activeWorkflowResyncEpoch",
@@ -115,6 +124,7 @@ function buildWorkflowNew({
     (e) => String(e),
     () => "Unsaved Workflow",
     graphRootProvenEmpty,
+    activeWorkflowProvenEmpty,
     onStamp,
     1,
     0,
@@ -159,6 +169,33 @@ test("#606 workflow_new does NOT stamp a root that still holds content (fail clo
   assert.equal(stamps.length, 0, "no re-tagging a root with foreign content");
 });
 
+test("#606 workflow_new does NOT stamp when the NEW workflow is not itself proven empty (codex P0)", async () => {
+  // An empty ROOT is not proof the root BELONGS to the new tab: ComfyUI shares
+  // app.graph, so a frontend that surfaced the new workflow as active while the
+  // canvas still held a DIFFERENT (also blank) tab looks identical here. The bar
+  // is therefore #565's, both sides proven content-free — dropping the workflow
+  // half would stamp the new uuid over the other tab's correct binding and point
+  // the next mutation at the wrong workflow.
+  const rootGraph = { _nodes: [], extra: { comfyui_mcp: { workflow_uuid: "uuid-OTHER-tab" } }, serialize: EMPTY_SERIALIZE };
+  // A tracker that cannot yet PROVE the new tab is empty (the #606 window itself).
+  for (const wf of [
+    { isPersisted: false, isModified: false },                                   // no tracker at all
+    { isPersisted: false, isModified: false, changeTracker: {} },                // no state
+    { isPersisted: false, isModified: true, changeTracker: { activeState: { nodes: [] } } }, // dirty ⇒ tracker may lag
+    { isPersisted: false, isModified: false, changeTracker: { activeState: { nodes: [{ id: 1, type: "KSampler" }] } } },
+  ]) {
+    const stamps = [];
+    const workflow_new = buildWorkflowNew({ rootGraph, activeWorkflow: wf, onStamp: (...a) => stamps.push(a) });
+    assert.equal((await workflow_new({ rid: "r1" })).created, true, "creation still succeeds");
+    assert.equal(stamps.length, 0, "an unprovable workflow side must not license the stamp");
+  }
+  assert.equal(
+    rootGraph.extra.comfyui_mcp.workflow_uuid,
+    "uuid-OTHER-tab",
+    "the other tab's binding survives untouched",
+  );
+});
+
 test("#606 workflow_new does NOT stamp an unserializable root, and a throwing stamp never breaks creation", async () => {
   const wf = { isPersisted: false, isModified: false, changeTracker: { activeState: { nodes: [] } } };
   // Unserializable root: proven-empty fails closed → no stamp.
@@ -181,6 +218,86 @@ test("#606 workflow_new does NOT stamp an unserializable root, and a throwing st
     },
   });
   assert.equal((await workflow_new_throwing({ rid: "r2" })).created, true);
+});
+
+// ---------------------------------------------------------------------------
+// #606/#560 fix 2 — the workflow_open repaint re-stamp, DELIBERATELY NOT SHIPPED.
+//
+// This branch originally repaired the root's identity tag after a repaint whose
+// tag "did not ride" loadGraphData, licensing that write off `!rootMatchedBeforeLoad`
+// — a value that is ALSO false when the pre-load comparison could not be READ at
+// all. An unreadable comparison would have become a positive licence to stamp the
+// target's uuid onto a canvas the load never touched: #349's wrong-canvas hole,
+// reopened by the very family of fixes that exists to keep it shut.
+//
+// main meanwhile landed the POSITIVE form of the same proof. workflow_open mints a
+// single-use marker per attempt and writes it into the payload's own `extra`,
+// beside the workflow uuid; ComfyUI's `configure()` replaces `graph.extra`
+// wholesale from the data it is handed, so nothing but THAT payload can put the
+// marker on the live root. The repair is then unnecessary by construction: both
+// fields ride in the same object literal, so a root carrying this attempt's marker
+// necessarily carries its uuid too, and a root carrying neither is not "a tag that
+// failed to ride" — it is an unproven load, which stays an honest refusal.
+//
+// The two tests below lock exactly what keeps the repair unnecessary, so a later
+// refactor can neither split the fields apart nor reintroduce a post-load stamp.
+// ---------------------------------------------------------------------------
+
+/** The `repaintState.extra = { … }` assignment workflow_open hands to loadGraphData. */
+function repaintPayloadExtraSource() {
+  return balancedFrom(SRC, "repaintState.extra = {");
+}
+
+/** Everything from the load call to the end of the repaint try/catch: the region
+ *  that observes the result and decides the verdict. */
+function postLoadProofSource() {
+  const start = SRC.indexOf("await app.loadGraphData(repaintState");
+  assert.notEqual(start, -1, "workflow_open repaint load not found");
+  const end = SRC.indexOf("\n        } catch (err) {", start);
+  assert.notEqual(end, -1, "repaint try/catch end not found");
+  return SRC.slice(start, end);
+}
+
+test("#606 workflow_open: the identity tag and the single-use marker ride the SAME payload object", () => {
+  // Why this is the whole argument against a post-load re-stamp: if the marker
+  // reached the root, the uuid did too. Splitting them into different objects (or
+  // dropping the uuid from the payload) would recreate the "tag did not ride"
+  // case the unsafe repair was written for.
+  const src = repaintPayloadExtraSource();
+  const uuidAt = src.indexOf("[WORKFLOW_UUID_FIELD]: targetUuid");
+  const markerAt = src.indexOf("[OPEN_PROOF_FIELD]: openProofMarker");
+  assert.notEqual(uuidAt, -1, "the repaint payload must carry the workflow identity tag");
+  assert.notEqual(markerAt, -1, "the repaint payload must carry this attempt's single-use marker");
+  // Both inside the SAME `[WORKFLOW_META_NAMESPACE]: { … }` object, not merely both
+  // somewhere in the assignment.
+  const meta = balancedFrom(src, "[WORKFLOW_META_NAMESPACE]: {");
+  assert.match(meta, /\[WORKFLOW_UUID_FIELD\]: targetUuid/);
+  assert.match(meta, /\[OPEN_PROOF_FIELD\]: openProofMarker/);
+});
+
+test("#606 workflow_open: the post-load proof never STAMPS the root — an unproven load stays refused", () => {
+  // The rejected repair, in one assertion. A stamp on this path can only ever be
+  // licensed by observations that cannot distinguish "the load applied" from "a
+  // stale root already held identical content", and an unreadable observation
+  // must never become a licence.
+  const src = postLoadProofSource();
+  assert.equal(
+    src.includes("stampGraphRootWorkflowUuid"),
+    false,
+    "workflow_open must not re-tag the live root after the load",
+  );
+  // …and the marker is still REQUIRED, so removing the stamp did not soften the
+  // proof into a content-only comparison.
+  assert.match(src, /markerMatches/);
+  assert.match(src, /graphRootCarriesOpenProof\(/);
+});
+
+test("#606 the shared stamp writer is still used where evidence DOES exist", () => {
+  // workflow_new's creation stamp (proven-empty root) and the binding guard's own
+  // rebind heal are the two justified callers; this test fails if the writer is
+  // left orphaned by a refactor that also removes them.
+  const calls = SRC.split("stampGraphRootWorkflowUuid(").length - 1;
+  assert.ok(calls >= 3, `expected the definition plus at least two callers, saw ${calls}`);
 });
 
 // ---------------------------------------------------------------------------
@@ -260,14 +377,307 @@ test("#607 the dispatch-time fence also re-advertises before refusing", () => {
   assert.ok(throwAt > noteAt, "the re-advertise fires BEFORE the refusal throw");
 });
 
-test("#607 the client registers a THROTTLED re-hello as the hook", () => {
-  // A full hello re-greets the user ("agent ready"), so a retry loop against a
-  // genuinely-switched canvas must not storm greetings — the registration is
-  // time-throttled.
+// ---------------------------------------------------------------------------
+// #607 — the registered re-hello itself: BOUNDED per identity, and its budget and
+// backoff are spent only on attempts that actually concluded.
+//
+// The shipping arrow function is extracted verbatim with its own `let`s, so
+// deleting the bound, or moving either bookkeeping write back to before the send,
+// fails a test here.
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the shipping hook verbatim with its own `let`s. The double for
+ * `sendHello` must honour the real one's contract — it publishes the identity it
+ * ADVERTISED (`lastAdvertisedWorkflowUuid`) on its success path only — so the
+ * harness hands the test a setter for exactly that, and nothing else.
+ */
+function buildRehelloHook({ sendHello, stableUuid }) {
+  const declStart = SRC.indexOf("const MISMATCH_REHELLO_MAX_PER_IDENTITY");
+  assert.notEqual(declStart, -1, "the re-hello budget constants are missing");
   const marker = "workflowInstanceMismatchRehello = () => {";
-  const start = SRC.indexOf(marker);
-  assert.notEqual(start, -1, "the bridge client must register the re-hello hook");
-  const region = SRC.slice(start, start + 400);
-  assert.match(region, /lastMismatchRehelloAt/);
-  assert.match(region, /sendHello\(\)/);
+  const bodyStart = SRC.indexOf(marker);
+  assert.notEqual(bodyStart, -1, "the bridge client must register the re-hello hook");
+  // The marker itself ENDS with the body's own "{", so balance from that brace —
+  // the default (first "{" after the marker) would balance the inner try block.
+  const bodyOpen = bodyStart + marker.length - 1;
+  const body = balancedFrom(SRC, marker, bodyOpen);
+  // End the slice at the index the body was balanced FROM plus its length. Using
+  // `bodyStart` here instead silently drops the last (marker.length - 1) chars,
+  // which lopped the tail off the extracted hook: the truncated text still
+  // happened to parse, so the tests ran against a hook whose landed/failed
+  // bookkeeping had been cut away and every budget assertion was meaningless.
+  const slice = SRC.slice(declStart, bodyOpen + body.length);
+  // Extraction is itself an operation that can fail — verify it captured the
+  // whole hook rather than trusting the arithmetic.
+  assert.ok(
+    slice.includes("lastFailedMismatchRehelloAt = Date.now();"),
+    "the extracted hook is truncated — its failure bookkeeping is missing",
+  );
+  assert.ok(
+    slice.includes("mismatchRehelloLandedCount += 1;"),
+    "the extracted hook is truncated — its landed bookkeeping is missing",
+  );
+  const factory = new Function(
+    "sendHello",
+    "workflowStableUuid",
+    `let workflowInstanceMismatchRehello = null;\n${slice};\n` +
+      `return {\n` +
+      `  hook: workflowInstanceMismatchRehello,\n` +
+      `  advertise: (uuid) => { lastAdvertisedWorkflowUuid = uuid; },\n` +
+      `};`,
+  );
+  return factory(sendHello, stableUuid);
+}
+
+/** Let every queued microtask (the hook's own promise chain) drain. */
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+/** A `sendHello` double: lands (or not), and on landing publishes the identity
+ *  that was live AT PAYLOAD TIME — which is what the real one does, and what makes
+ *  the crossed-switch case below observable. */
+function helloDouble(getLiveUuid, { lands = () => true, defer = null, afterBuild = null } = {}) {
+  const calls = [];
+  const impl = {
+    /** what each hello ADVERTISED, in payload-build order */
+    calls,
+    /** how many sends were STARTED (a deferred send is started but not yet built) */
+    started: 0,
+    harness: null,
+    send() {
+      impl.started += 1;
+      // The identity is read where the PAYLOAD is built, which in the real
+      // sendHello is after an awaited tab-identity resolve — so with `defer` it
+      // is read after the gate opens, not when the send was decided.
+      const build = () => {
+        const advertised = getLiveUuid();
+        calls.push(advertised);
+        const ok = lands();
+        if (ok) impl.harness.advertise(advertised);
+        return ok;
+      };
+      const built = defer ? defer.then(build) : Promise.resolve(build());
+      // `afterBuild` holds the RESOLUTION open after the payload was built, so a
+      // tab switch can land between "this hello advertised X" and "the hook learns
+      // it landed" — the window where the advertised identity and the identity
+      // being budgeted genuinely differ.
+      return afterBuild ? built.then((ok) => afterBuild.then(() => ok)) : built;
+    },
+  };
+  return impl;
+}
+
+test("#607 the re-hello is BOUNDED per identity — a persistent mismatch stops churning", async () => {
+  const dbl = helloDouble(() => "uuid-STUCK");
+  const h = buildRehelloHook({ sendHello: () => dbl.send(), stableUuid: () => "uuid-STUCK" });
+  dbl.harness = h;
+  for (let i = 0; i < 25; i += 1) {
+    h.hook();
+    await settle();
+  }
+  assert.equal(dbl.calls.length, 3, "a persistent refusal must not re-hello forever");
+});
+
+test("#607 a NEW live identity resets the budget — a real switch is re-advertised", async () => {
+  let uuid = "uuid-A";
+  const dbl = helloDouble(() => uuid);
+  const h = buildRehelloHook({ sendHello: () => dbl.send(), stableUuid: () => uuid });
+  dbl.harness = h;
+  for (let i = 0; i < 6; i += 1) {
+    h.hook();
+    await settle();
+  }
+  assert.equal(dbl.calls.length, 3, "budget spent on identity A");
+  uuid = "uuid-B";
+  h.hook();
+  await settle();
+  assert.equal(dbl.calls.length, 4, "a genuinely different identity gets a fresh advertisement");
+});
+
+test("#607 a hello that never reached the wire does NOT spend the budget", async () => {
+  // The defect this locks: spending the budget (or claiming the throttle) before
+  // the send resolves means a recovery that never left the tab suppresses the
+  // attempts that could have worked.
+  let lands = false;
+  const dbl = helloDouble(() => "uuid-A", { lands: () => lands });
+  const h = buildRehelloHook({ sendHello: () => dbl.send(), stableUuid: () => "uuid-A" });
+  dbl.harness = h;
+  h.hook();
+  await settle();
+  assert.equal(dbl.calls.length, 1);
+  // Backoff after a failed attempt: an immediate retry is suppressed…
+  h.hook();
+  await settle();
+  assert.equal(dbl.calls.length, 1, "a failed attempt backs off before retrying");
+  // …but once the backoff elapses the budget is still whole (3 landings left).
+  lands = true;
+  const realNow = Date.now;
+  Date.now = () => realNow() + 60_000;
+  try {
+    for (let i = 0; i < 6; i += 1) {
+      h.hook();
+      await settle();
+    }
+  } finally {
+    Date.now = realNow;
+  }
+  assert.equal(dbl.calls.length, 4, "the failed attempt cost no budget: 3 landings still allowed");
+});
+
+test("#607 a hello that CROSSED a tab switch is charged to the identity it advertised", async () => {
+  // The send is decided for A but its payload is built after an awaited identity
+  // resolve, by which time the live workflow is B — so the hello advertises B.
+  // Charging it to A (or discarding it) would let B collect this hello ON TOP of
+  // its own three, i.e. four sends under a bound that says three.
+  let uuid = "uuid-A";
+  let release;
+  const gate = new Promise((r) => {
+    release = r;
+  });
+  const dbl = helloDouble(() => uuid, { defer: gate });
+  const h = buildRehelloHook({ sendHello: () => dbl.send(), stableUuid: () => uuid });
+  dbl.harness = h;
+  h.hook(); // decided for A; its payload is read below, after the switch
+  await settle();
+  uuid = "uuid-B";
+  h.hook(); // suppressed: the first is still in flight
+  await settle();
+  release();
+  await settle();
+  assert.deepEqual(dbl.calls, ["uuid-B"], "the crossed hello advertised B, not A");
+  // B has now had ONE landed hello. Its remaining budget must be two, not three.
+  for (let i = 0; i < 6; i += 1) {
+    h.hook();
+    await settle();
+  }
+  assert.equal(dbl.calls.length, 3, "the crossed hello counted against the identity it carried");
+});
+
+test("#607 a hello that landed for the PREVIOUS identity is not charged to the new one", async () => {
+  // The mirror of the case above, and the one that actually separates "charge the
+  // identity the hello CARRIED" from "charge whichever identity is current when it
+  // resolves". The hello advertises A; the user switches to B (which resets B's
+  // budget) before the hook learns the hello landed. B was never advertised to the
+  // orchestrator, so B's budget must be untouched — charging it would silently
+  // spend one of the three attempts B is entitled to.
+  let uuid = "uuid-A";
+  let releaseAfterBuild;
+  const afterBuild = new Promise((r) => {
+    releaseAfterBuild = r;
+  });
+  const dbl = helloDouble(() => uuid, { afterBuild });
+  const h = buildRehelloHook({ sendHello: () => dbl.send(), stableUuid: () => uuid });
+  dbl.harness = h;
+  h.hook(); // decided for A, payload built for A
+  await settle();
+  assert.deepEqual(dbl.calls, ["uuid-A"], "the hello advertised A");
+  uuid = "uuid-B"; // the switch lands before the hook learns the hello landed
+  h.hook(); // resets the budget to B, then defers to the in-flight send
+  await settle();
+  releaseAfterBuild();
+  await settle();
+  // B has had NO landed hello. Its full budget of three must remain.
+  for (let i = 0; i < 8; i += 1) {
+    h.hook();
+    await settle();
+  }
+  assert.deepEqual(
+    dbl.calls,
+    ["uuid-A", "uuid-B", "uuid-B", "uuid-B"],
+    "A's landing must not be charged to B — B keeps all three of its own attempts",
+  );
+});
+
+test("#607 concurrent refusals fire ONE in-flight re-hello, not a burst", async () => {
+  let release;
+  const gate = new Promise((r) => {
+    release = r;
+  });
+  const dbl = helloDouble(() => "uuid-A", { defer: gate });
+  const h = buildRehelloHook({ sendHello: () => dbl.send(), stableUuid: () => "uuid-A" });
+  dbl.harness = h;
+  h.hook();
+  h.hook();
+  h.hook();
+  await settle();
+  assert.equal(dbl.started, 1, "only one hello is outstanding at a time");
+  release();
+  await settle();
+});
+
+test("#607 an unreadable live identity re-hellos nothing (unknown is not new evidence)", async () => {
+  let hellos = 0;
+  const h = buildRehelloHook({
+    sendHello: () => {
+      hellos += 1;
+      return Promise.resolve(true);
+    },
+    stableUuid: () => {
+      throw new Error("no active workflow");
+    },
+  });
+  h.hook();
+  await settle();
+  assert.equal(hellos, 0, "an unknown identity must not be treated as a changed one");
+});
+
+test("#607 sendHello reports whether the hello reached the wire, and publishes only then", () => {
+  // The hook's budget is only meaningful if `sendHello()` answers truthfully: a
+  // closed socket must resolve false rather than an ignored undefined, and the
+  // advertised identity must be published on the success path, never at payload
+  // time — publishing early would credit a hello that did not happen.
+  const src = balancedFrom(SRC, "function sendHello()");
+  assert.match(src, /readyState !== WebSocket\.OPEN\) return Promise\.resolve\(false\)/);
+  assert.match(src, /return sendBridgeHello\(/);
+  assert.match(src, /return sent === true;/);
+  const publishAt = src.indexOf("lastAdvertisedWorkflowUuid = advertisedWorkflowUuid;");
+  assert.notEqual(publishAt, -1, "sendHello must publish what it advertised");
+  const successAt = src.indexOf("if (sent) {");
+  assert.ok(successAt !== -1 && publishAt > successAt, "…only inside the success branch");
+  const payloadAt = src.indexOf("(advertisedWorkflowUuid = workflowStableUuid())");
+  assert.notEqual(payloadAt, -1, "the advertised identity is read where the PAYLOAD is built");
+  assert.ok(payloadAt < publishAt, "read at payload time, published only after the send lands");
+});
+
+// ---------------------------------------------------------------------------
+// #606 — the refusal's REMEDY names what it does, not an outcome it cannot see
+// ---------------------------------------------------------------------------
+
+test("#606 the binding refusal marks the reload remedy as REQUESTED, not confirmed", async () => {
+  // Two gate rounds died on this one sentence: it first said a reload "always
+  // re-establishes the binding", then "rebuilds the binding from scratch" — both
+  // unconditional claims about an outcome nothing observes. panel_reload asks the
+  // browser to navigate and returns; there is no post-reload binding receipt.
+  //
+  // A phrase blacklist cannot hold this: it passes for every wording nobody
+  // thought to ban. The requirement is POSITIVE — the message must carry an
+  // explicit statement that the reload is unconfirmed, so any rewrite that
+  // reinstates a promise has to delete that statement and fail here.
+  const { graphBindingRefusalMessage } = await import("../../web/js/lib/graph-binding.js");
+  for (const reason of [
+    "root-workflow-uuid-mismatch",
+    "root-shape-mismatch",
+    "root-node-count-desync",
+  ]) {
+    const msg = graphBindingRefusalMessage({ reason, expected: 0 });
+    assert.match(msg, /panel_reload/, `${reason} still names the reload remedy`);
+    assert.match(
+      msg,
+      /REQUESTED, NOT CONFIRMED/,
+      `${reason} must mark the reload as unobserved, not promise it worked`,
+    );
+    assert.match(
+      msg,
+      /cannot observe/,
+      `${reason} must say WHY it is unconfirmed, not merely hedge`,
+    );
+    // …and no unconditional outcome claim smuggled in ALONGSIDE the disclaimer:
+    // a message that both promises the repair and disclaims it is worse than
+    // either, because a reader takes whichever half suits the retry.
+    assert.doesNotMatch(
+      msg,
+      /which (restores|rebinds|re-?establishes|rebuilds)|reload always|will (restore|rebind|re-?establish|rebuild)/i,
+      `${reason} must not also assert the reload succeeds`,
+    );
+  }
 });

--- a/browser_tests/unit/canvas-tool-disclosure.test.mjs
+++ b/browser_tests/unit/canvas-tool-disclosure.test.mjs
@@ -435,14 +435,15 @@ test("wiring: the generation advances only once the hello is ON THE WIRE", () =>
   // does. Same rule as #621 and #836: do not record that you did something before
   // you did it.
   const body = sendHelloBody(panelSource());
-  assert.match(
-    body,
-    /if \(sent\) agentSessionEpoch\+\+/,
-    "the advance must be conditional on the hello having actually been sent",
-  );
+  // The guard, whichever form it takes (`if (sent) …` on one line, or a block that
+  // also publishes what the hello advertised — #607). What matters is that the
+  // advance is INSIDE it and after the send, not the punctuation.
+  const guard = body.search(/if \(sent\)[ ]*\{?/);
+  assert.notEqual(guard, -1, "the advance must be conditional on the hello having actually been sent");
   const call = body.indexOf("sendBridgeHello({");
   const bump = body.indexOf("agentSessionEpoch++");
   assert.ok(call >= 0 && bump > call, "the advance must FOLLOW the send, not precede it");
+  assert.ok(bump > guard, "the advance must sit INSIDE the sent-guard, not beside it");
   // …and there must be no second, unconditional one left behind in front of it.
   assert.equal(
     (body.match(/agentSessionEpoch\+\+/g) ?? []).length,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -4856,9 +4856,16 @@ function assertGraphBoundToActiveWorkflow(
  * Write the panel-owned workflow-identity tag onto a root graph and record its
  * owner. One shared writer so the binding guard's rebind heal (#545/#557/#565)
  * and the workflow_new creation stamp (#606) can never drift into two different
- * tag shapes. Callers decide the EVIDENCE that justifies the stamp (a
- * proven-empty canvas, an ownership claim); this only performs the write they
+ * tag shapes. Callers decide the EVIDENCE that justifies the stamp (an ownership
+ * claim, or both sides proven content-free); this only performs the write they
  * settled on.
+ *
+ * workflow_open is deliberately NOT a caller. Its post-load proof cannot license
+ * a stamp: every observation available there is also consistent with a stale root
+ * that already held identical content, so the repair it would perform is exactly
+ * the wrong-canvas write the guard exists to refuse. It proves the load landed
+ * with a single-use marker carried in the SAME payload `extra` as the uuid
+ * instead, which makes any repair unnecessary — see binding-recovery.test.mjs.
  */
 function stampGraphRootWorkflowUuid(rootGraph, uuid, ownerWorkflow) {
   const extra =
@@ -10349,15 +10356,36 @@ const GRAPH_TOOL_EXECUTORS = {
     // guard reads the leftover tag as a foreign-canvas conflict and nothing in
     // the normal command path re-stamps the root — the tab wedges behind the
     // guard until a frontend reload. The panel itself just created this tab and
-    // its canvas, so stamp the tag at the source instead. Evidence bar: only
-    // when the root is PROVEN content-free on every serialized surface — if the
-    // frontend did not actually hand the new tab an empty canvas, the stamp is
-    // skipped (fail closed) rather than re-tagging a root that still holds the
-    // previous workflow's content. Best-effort: a stamp failure leaves the
-    // pre-existing guard behavior, never a broken creation.
+    // its canvas, so stamp the tag at the source — at the one moment the proof
+    // IS available — instead of waiting for a heal that will no longer be able
+    // to prove anything.
+    //
+    // The evidence bar is EXACTLY #565's, not a weaker one (codex gate P0). The
+    // guard's own `staleTagOnEmptyCanvas` rebind performs this identical write,
+    // and it requires BOTH sides proven content-free:
+    //   - the live root serializes empty on every surface, AND
+    //   - the workflow this tag will name is itself provably empty and clean.
+    // Dropping the second half is what makes it unsafe: a content-empty root is
+    // not proof that the root BELONGS to `wf`. If the frontend surfaced the new
+    // workflow as active while `app.graph` still held a DIFFERENT, also-empty
+    // blank tab, a root-only bar would stamp the new uuid onto that other tab's
+    // canvas — overwriting a correct binding and pointing the next mutation at
+    // the wrong workflow, which this whole family exists to prevent. With both
+    // sides proven empty there is no workflow CONTENT that could be confused,
+    // which is the same trade #565 already reasoned through and accepted.
+    //
+    // What this adds over #565 is TIMING, not permission: #565 heals lazily, on
+    // the next graph command, and #606's wedge is precisely a reconnect landing
+    // before the new tab's ChangeTracker can be proven empty — at which point
+    // the lazy heal can no longer fire and nothing re-stamps the root. Stamping
+    // eagerly, while the proof still exists, closes that window without
+    // widening what may be stamped.
+    //
+    // Best-effort: a stamp failure leaves the pre-existing guard behavior, never
+    // a broken creation.
     try {
       const rootGraph = app?.graph;
-      if (rootGraph && graphRootProvenEmpty(rootGraph)) {
+      if (rootGraph && graphRootProvenEmpty(rootGraph) && activeWorkflowProvenEmpty(wf)) {
         stampGraphRootWorkflowUuid(rootGraph, newWorkflowUuid, wf);
       }
     } catch {
@@ -14280,8 +14308,12 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     });
   }
 
+  /** Returns a promise resolving to whether the hello actually REACHED THE WIRE.
+   *  Every existing caller ignores it; the #607 re-hello does not, because a
+   *  recovery that throttles itself on the strength of a send that never happened
+   *  stays wedged while believing it is being polite. */
   function sendHello() {
-    if (!sock || sock.readyState !== WebSocket.OPEN) return;
+    if (!sock || sock.readyState !== WebSocket.OPEN) return Promise.resolve(false);
     // #291 — a hello BINDS this socket to an agent session, and not always the one
     // it was bound to a moment ago. Besides the socket-open hello, the panel
     // re-hellos the LIVE socket to follow the user's workflow tabs, and with the
@@ -14293,7 +14325,13 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     // dispatches it. This also covers the socket-open hello, so no separate bump is
     // needed in the open handler.
     const target = sock;
-    void sendBridgeHello({
+    // The identity this hello ACTUALLY carries, read where the payload is built
+    // rather than where the send was decided — the two can differ, because
+    // makePayload runs after an awaited tab-identity resolve. Published to
+    // `lastAdvertisedWorkflowUuid` only on the success path below: the #607
+    // budget counts what reached the orchestrator, not what we meant to send.
+    let advertisedWorkflowUuid = null;
+    return sendBridgeHello({
       socket: target,
       isCurrent: () => sock === target && target.readyState === WebSocket.OPEN,
       resolveTabIdentity: () => restartTabIdentity.resolve(),
@@ -14348,7 +14386,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // tmp:<uuid> and the non-unique default title, it survives a reload, so
             // the orchestrator can resume an UNSAVED workflow's conversation without
             // cross-resuming a DIFFERENT same-title unsaved workflow.
-            workflowUuid: workflowStableUuid(),
+            workflowUuid: (advertisedWorkflowUuid = workflowStableUuid()),
             // #508/#694 — NO lostReplies summaries here: the hello fires at
             // socket-open, BEFORE the models handshake stamps this socket's session
             // epoch, so any summary computed now is filtered with an unknown epoch
@@ -14378,10 +14416,17 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
         // ordered anyway, so a message sent while this hello is still awaiting
         // identity is written BEFORE the hello. Either way it is handled by the
         // pre-hello agent, which is exactly the generation it was stamped with.
-        if (sent) agentSessionEpoch++;
+        if (sent) {
+          agentSessionEpoch++;
+          // Published only now, for the same reason the epoch advances only now:
+          // a hello that never reached the wire advertised nothing.
+          lastAdvertisedWorkflowUuid = advertisedWorkflowUuid;
+        }
+        return sent === true;
       })
       .catch(() => {
         // Reconnect path will retry. No hello landed, so no generation advance.
+        return false;
       });
   }
 
@@ -14389,15 +14434,84 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
   // when it refuses a command whose stamp no longer names the active canvas: the
   // panel's live identity is authoritative, so re-hello to push it to the
   // orchestrator (which re-stamps from hello.workflow_uuid), making the refusal's
-  // advertised recovery (re-target, then retry) able to succeed. Throttled: a
-  // retry loop against a genuinely-switched canvas must not become a greeting
-  // storm — a full hello re-greets the user ("agent ready").
-  let lastMismatchRehelloAt = 0;
+  // advertised recovery (re-target, then retry) able to succeed.
+  //
+  // BOUNDED PER IDENTITY (codex gate). A persistent mismatch produces
+  // refusal → hello → same refusal → hello forever, and an unbounded retry is a
+  // NEW wedge rather than a fix — it churns instead of sitting still, and a full
+  // hello re-greets the user ("agent ready"). The evidence a re-hello carries is
+  // the panel's live workflow uuid, so the budget is keyed to THAT: a few attempts
+  // per distinct identity (a lost or ignored hello is worth retrying; the tenth is
+  // not), reset the moment the live identity actually changes — which is new
+  // evidence and deserves a fresh advertisement. Nothing here bounds a genuine tab
+  // switch, which re-hellos through `rehello` on its own path anyway.
+  //
+  // Only re-hellos that PROVABLY reached the wire are counted, and the backoff
+  // clock is stamped only AFTER an attempt has concluded and only when it did NOT
+  // land. Stamping either before the send is the recurring "recorded before it
+  // happened" defect (#621's canvas lock holder, #836's panel-op release,
+  // agentSessionEpoch in #633): a budget spent on, or a throttle claimed for, a
+  // hello that never left the tab suppresses the one attempt that could have
+  // cleared the wedge.
+  const MISMATCH_REHELLO_MAX_PER_IDENTITY = 3;
+  const MISMATCH_REHELLO_BACKOFF_MS = 5000;
+  /** The workflow identity the most recent LANDED hello actually carried (set by
+   *  sendHello on its success path). The budget below is spent against THIS, not
+   *  against the identity that was live when the send was decided: makePayload
+   *  reads the uuid after an awaited identity resolve, so a tab switch that
+   *  interleaves the send makes the hello advertise a different workflow than the
+   *  refusal that triggered it. Counting the intended one would let the switched-to
+   *  identity collect an uncounted hello on top of its own budget. */
+  let lastAdvertisedWorkflowUuid = null;
+  let mismatchRehelloIdentity = null;
+  let mismatchRehelloLandedCount = 0;
+  let mismatchRehelloInFlight = false;
+  let lastFailedMismatchRehelloAt = 0;
   workflowInstanceMismatchRehello = () => {
-    const now = Date.now();
-    if (now - lastMismatchRehelloAt < 5000) return;
-    lastMismatchRehelloAt = now;
-    sendHello();
+    // An identity we cannot READ is not an identity we know to be new. Fall
+    // through to no re-hello rather than resetting the budget on an unknown —
+    // the refusal (with its own remedy) stands either way.
+    let liveUuid = null;
+    try {
+      const read = workflowStableUuid();
+      liveUuid = typeof read === "string" && read ? read : null;
+    } catch {
+      liveUuid = null;
+    }
+    if (!liveUuid) return;
+    if (liveUuid !== mismatchRehelloIdentity) {
+      mismatchRehelloIdentity = liveUuid;
+      mismatchRehelloLandedCount = 0;
+      lastFailedMismatchRehelloAt = 0;
+    }
+    if (mismatchRehelloLandedCount >= MISMATCH_REHELLO_MAX_PER_IDENTITY) return;
+    if (mismatchRehelloInFlight) return;
+    if (
+      lastFailedMismatchRehelloAt &&
+      Date.now() - lastFailedMismatchRehelloAt < MISMATCH_REHELLO_BACKOFF_MS
+    )
+      return;
+    mismatchRehelloInFlight = true;
+    void Promise.resolve()
+      .then(() => sendHello())
+      .then((sent) => sent === true)
+      .catch(() => false)
+      .then((landed) => {
+        mismatchRehelloInFlight = false;
+        if (landed) {
+          // Charge the budget of whichever identity the hello ACTUALLY carried,
+          // and only when that is still the identity being budgeted. The bound
+          // for a landed hello is that budget, not a clock: a later genuine
+          // switch must be re-advertised at once, and it resets the count above.
+          if (lastAdvertisedWorkflowUuid === mismatchRehelloIdentity) {
+            mismatchRehelloLandedCount += 1;
+          }
+        } else {
+          // It did not reach the orchestrator. Back off before trying again, but
+          // do NOT spend the budget on it — nothing was advertised.
+          lastFailedMismatchRehelloAt = Date.now();
+        }
+      });
   };
 
   // When the workflow title changes (rename / open a different file / progress

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1076,18 +1076,27 @@ export function graphBindingRefusalMessage(verdict) {
       `persists, re-open the workflow tab (panel_open_workflow) or reload the panel.`
     );
   }
-  // #606 — name the firing predicate honestly and order the remedies by what
-  // actually recovers. panel_open_workflow rebinds in place (its repaint proof
-  // re-stamps the root's identity tag from the workflow's own state); a panel
-  // reload ALWAYS re-establishes the binding from scratch, so it is the certain
-  // fallback — earlier text sent the agent to open_workflow with no hint that
-  // reload is the reliable one, and phrased a 0-node expectation as "the
-  // workflow reports 0 node(s), but the canvas is bound to a different graph",
-  // which reads as nonsense for a genuinely-empty tab.
+  // #606 — name the firing predicate honestly, and order the remedies by which
+  // one to try first. panel_open_workflow rebinds in place; a panel reload is the
+  // broader fallback when re-opening does not clear it — earlier text sent the
+  // agent to open_workflow with no hint that the reload exists, and phrased a
+  // 0-node expectation as "the workflow reports 0 node(s), but the canvas is bound
+  // to a different graph", which reads as nonsense for a genuinely-empty tab.
+  //
+  // NEITHER remedy is promised to SUCCEED, and the text must not imply one (codex
+  // gate, two rounds). It first said a reload "always re-establishes the binding",
+  // then "rebuilds the binding from scratch" — both unconditional claims about an
+  // outcome nothing here observes. panel_reload asks the browser to navigate and
+  // returns; there is no post-reload binding receipt anywhere, and a reload that
+  // never happens, or that restores the same stale state, would leave the agent
+  // retrying on the strength of a repair it was told had already occurred. So the
+  // remedy names the ACTION and says plainly that it is unconfirmed — the caller
+  // learns whether it worked from the retry, the only thing that can tell.
   const remedy =
     `Re-open the active workflow tab (panel_open_workflow) to rebind the graph in place; if that ` +
-    `does not clear it, reload the panel (panel_reload scope:frontend) — a reload always ` +
-    `re-establishes the binding — then retry.`;
+    `does not clear it, reload the panel (panel_reload scope:frontend), then retry. The reload is ` +
+    `REQUESTED, NOT CONFIRMED — the panel cannot observe whether it rebound the canvas, so treat ` +
+    `the retry's own result as the answer rather than assuming the binding was repaired.`;
   if (verdict.reason === "root-workflow-uuid-mismatch") {
     return (
       `[root-workflow-uuid-mismatch] The live canvas carries a different workflow's identity tag ` +


### PR DESCRIPTION
Follow-up to #622, which merged before its independent gate findings were addressed. Three defects it introduced are live on `main`.

### 1. P0 — `workflow_new`'s creation stamp used a ROOT-ONLY evidence bar

`comfyui-mcp-panel.js` stamped the live root with the new tab's identity whenever `graphRootProvenEmpty(rootGraph)`. The binding guard's own `staleTagOnEmptyCanvas` rebind performs the **identical write** and requires **both** sides proven content-free.

A content-empty root is not proof the root *belongs* to the new tab. ComfyUI shares `app.graph`, so a frontend that surfaced the new workflow as active while the canvas still held a different, also-blank tab is indistinguishable at that point. The root-only bar stamped the new uuid over that other tab's correct binding and pointed the next mutation at the wrong workflow.

Restored to #565's bar: `graphRootProvenEmpty(rootGraph) && activeWorkflowProvenEmpty(wf)`.

What the creation stamp still adds over #565 is **timing, not permission**: #565 heals lazily on the next graph command, and #606's wedge is a reconnect landing *before* the new tab's ChangeTracker can be proven empty — at which point the lazy heal can no longer prove anything. Stamping eagerly, while the proof exists, closes that window without widening what may be stamped.

### 2. P0 — the #607 re-hello was unbounded and stamped its throttle before the send

A persistent mismatch produced refusal → hello → same refusal → hello forever at 5s spacing. And it wrote `lastMismatchRehelloAt` **before** calling `sendHello()`, so a hello that never reached the orchestrator suppressed every retry for the next five seconds on the strength of an attempt that did not happen — the "recorded before it happened" defect for the sixth time in this repo (#621's canvas lock holder, #836's panel-op release, `agentSessionEpoch` in #633).

- `sendHello()` now returns whether the hello reached the wire, and publishes the identity it **advertised** on that success path only.
- Budget of **3 landed re-hellos per distinct live identity**, reset when the identity actually changes.
- The budget is charged to the identity the hello **carried**, not the one live when the send was decided — `makePayload` reads the uuid after an awaited identity resolve, so a tab switch can interleave.
- A failed attempt costs no budget and arms a backoff stamped *after* it concluded. An in-flight guard collapses a burst of refusals into one hello.
- An unreadable live identity re-hellos nothing: an unknown is not a changed identity.

### 3. P1 — the refusal promised an outcome it cannot observe

The remedy said a panel reload "always re-establishes the binding". `panel_reload` asks the browser to navigate and returns; there is no post-reload binding receipt anywhere. It now names the action and marks it `REQUESTED, NOT CONFIRMED`, with the reason.

### Also

The shared stamp writer's doc comment still described a `workflow_open` repaint re-stamp that is deliberately not shipped. That path's observations are all consistent with a stale root already holding identical content; it proves the load landed with a single-use marker carried in the **same payload `extra`** as the uuid instead, which makes any repair unnecessary. Tests lock both properties so it cannot creep back.

### Verification

2353/2353 unit tests pass. Every assertion was mutation-verified against the code it covers: dropping the `activeWorkflowProvenEmpty` half; removing the per-identity bound; spending the budget before the send lands; stamping the backoff before the attempt concludes; charging a landing to the wrong identity in both directions; dropping the in-flight guard; treating an unreadable identity as new; suppressing `sendHello`'s report; publishing the advertised identity at payload time; removing the creation stamp and its proven-empty gate; reintroducing a post-load re-stamp; splitting the uuid and marker across payload objects; and both reinstating the reload promise and deleting its disclaimer.

Independently gated (codex `gpt-5.6-terra`, read-only, two rounds on the fix diff). Round 1 found the creation-stamp bar and the crossed-identity attribution; round 2 found only the remaining reload overclaim. Both addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)