### PR TITLE
graph_disconnect silently deletes adjacent nodes instead of only removing the input link

### DIFF
--- a/browser_tests/unit/disconnect-verify.test.mjs
+++ b/browser_tests/unit/disconnect-verify.test.mjs
@@ -1,0 +1,240 @@
+/**
+ * Unit tests for the graph_disconnect pre/post verification (#668) —
+ * web/js/lib/disconnect-verify.js. Run with `node --test`.
+ *
+ * Bug: three panel_disconnect calls on a SUBGRAPH node's inputs silently DELETED
+ * two unrelated nodes (a LoadImage two hops upstream, a downstream SaveVideo)
+ * while every call returned a plain success payload. The panel assumed
+ * node.disconnectInput() only drops one wire and never checked the post-state.
+ * These tests pin the property: after a disconnect, the intended link is gone
+ * and NOTHING else changed — otherwise the verdict is not ok and the caller
+ * must disclose, never report a bare success.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  snapshotGraphState,
+  describeInputLink,
+  verifyDisconnect,
+} from "../../web/js/lib/disconnect-verify.js";
+
+/** Minimal mock graph: nodes by id, links as a legacy record store. */
+function mockGraph(nodes, links) {
+  return {
+    _nodes: nodes,
+    links,
+    getNodeById: (id) => nodes.find((n) => n.id === id) ?? null,
+  };
+}
+
+function node(id, inputs = [], outputs = []) {
+  return { id, inputs, outputs };
+}
+
+// The #668 repro shape (reduced): 121 ImageCrop ← 114 LoadImage; subgraph node
+// 105 ← 121 (first_frame) and 105.VIDEO → 92 SaveVideo. Link ids 1, 2, 3.
+function reproGraph() {
+  const n114 = node(114, [], [{ name: "IMAGE", links: [1] }]);
+  const n121 = node(121, [{ name: "image", link: 1 }], [{ name: "IMAGE", links: [2] }]);
+  const n105 = node(
+    105,
+    [{ name: "first_frame", link: 2 }],
+    [{ name: "VIDEO", links: [3] }],
+  );
+  const n92 = node(92, [{ name: "video", link: 3 }], []);
+  return mockGraph([n114, n121, n105, n92], {
+    1: { id: 1, origin_id: 114, origin_slot: 0, target_id: 121, target_slot: 0 },
+    2: { id: 2, origin_id: 121, origin_slot: 0, target_id: 105, target_slot: 0 },
+    3: { id: 3, origin_id: 105, origin_slot: 0, target_id: 92, target_slot: 0 },
+  });
+}
+
+test("snapshotGraphState: node ids string-normalized, floating links excluded", () => {
+  const g = mockGraph([node(1), node("sub")], {
+    5: { id: 5, origin_id: 1, origin_slot: 0, target_id: "sub", target_slot: 0 },
+    6: { id: 6, origin_id: -1, origin_slot: -1, target_id: "sub", target_slot: 0 }, // floating
+    7: { id: 7, origin_id: 1, origin_slot: 0, target_id: -1, target_slot: -1 }, // floating
+  });
+  const s = snapshotGraphState(g);
+  assert.deepEqual([...s.nodeIds].sort(), ["1", "sub"]);
+  assert.deepEqual([...s.links.keys()], ["5"]);
+});
+
+test("snapshotGraphState: modern Map store (_links) is read", () => {
+  const g = {
+    _nodes: [node(1), node(2)],
+    _links: new Map([
+      [9, { id: 9, origin_id: 1, origin_slot: 0, target_id: 2, target_slot: 0 }],
+    ]),
+  };
+  const s = snapshotGraphState(g);
+  assert.deepEqual([...s.links.keys()], ["9"]);
+  assert.equal(s.links.get("9").origin_id, 1);
+});
+
+test("describeInputLink: names the wire's former source (node id + output name)", () => {
+  const g = reproGraph();
+  const n105 = g.getNodeById(105);
+  const d = describeInputLink(g, n105, 0);
+  assert.equal(d.linkId, 2);
+  assert.equal(d.node_id, 121);
+  assert.equal(d.output, "IMAGE");
+  assert.equal(d.output_index, 0);
+});
+
+test("describeInputLink: unlinked input → null (caller refuses the no-op)", () => {
+  const g = reproGraph();
+  const n105 = g.getNodeById(105);
+  n105.inputs.push({ name: "width", link: null });
+  assert.equal(describeInputLink(g, n105, 1), null);
+});
+
+test("describeInputLink: falls back to origin_slot number when the origin node is gone", () => {
+  const g = reproGraph();
+  const n105 = g.getNodeById(105);
+  n105.inputs[0].link = 99; // dangling id, no record
+  const d = describeInputLink(g, n105, 0);
+  assert.equal(d.linkId, 99);
+  assert.equal(d.node_id, undefined);
+});
+
+test("clean disconnect: intended link gone, nothing else changed → ok", () => {
+  const g = reproGraph();
+  const before = snapshotGraphState(g);
+  // Simulate litegraph dropping link 2 (record deleted, slot ref nulled).
+  delete g.links[2];
+  g.getNodeById(105).inputs[0].link = null;
+  g.getNodeById(121).outputs[0].links = [];
+  const v = verifyDisconnect(g, g.getNodeById(105), before, 2);
+  assert.equal(v.ok, true);
+  assert.equal(v.intendedRemoved, true);
+  assert.deepEqual(v.missingNodes, []);
+  assert.deepEqual(v.addedNodes, []);
+  assert.deepEqual(v.collateralRemovedLinks, []);
+  assert.deepEqual(v.addedLinks, []);
+});
+
+test("#668 repro: unrelated nodes deleted by the cascade → not ok, ids disclosed", () => {
+  const g = reproGraph();
+  const before = snapshotGraphState(g);
+  // The cascade: intended link 2 gone, but LoadImage 114 and SaveVideo 92
+  // DELETED — and their wires (1, 3) removed with them.
+  delete g.links[2];
+  g.getNodeById(105).inputs[0].link = null;
+  delete g.links[1];
+  delete g.links[3];
+  g._nodes = g._nodes.filter((n) => n.id !== 114 && n.id !== 92);
+  const v = verifyDisconnect(g, g.getNodeById(105), before, 2);
+  assert.equal(v.ok, false);
+  assert.equal(v.intendedRemoved, true, "the disconnect itself did land");
+  assert.deepEqual(v.missingNodes.sort(), ["114", "92"]);
+  const collateralIds = v.collateralRemovedLinks.map((l) => String(l.id)).sort();
+  assert.deepEqual(collateralIds, ["1", "3"]);
+});
+
+test("node APPEARED during the disconnect → not ok", () => {
+  const g = reproGraph();
+  const before = snapshotGraphState(g);
+  delete g.links[2];
+  g.getNodeById(105).inputs[0].link = null;
+  g._nodes.push(node(200));
+  const v = verifyDisconnect(g, g.getNodeById(105), before, 2);
+  assert.equal(v.ok, false);
+  assert.deepEqual(v.addedNodes, ["200"]);
+});
+
+test("intended link still in the store → not ok (disconnect silently failed)", () => {
+  const g = reproGraph();
+  const before = snapshotGraphState(g);
+  // Litegraph no-op: slot ref cleared but the record survived (or vice versa —
+  // either half means the wire is not fully gone).
+  g.getNodeById(105).inputs[0].link = null;
+  const v = verifyDisconnect(g, g.getNodeById(105), before, 2);
+  assert.equal(v.ok, false);
+  assert.equal(v.intendedRemoved, false);
+});
+
+test("intended link record deleted but a slot still references it → not ok", () => {
+  const g = reproGraph();
+  const before = snapshotGraphState(g);
+  delete g.links[2];
+  // Boundary-slot cascade shifted the inputs array; the link id is still
+  // referenced by SOME input (checked across the whole array, not a fixed index).
+  const n105 = g.getNodeById(105);
+  n105.inputs = [{ name: "width", link: null }, { name: "first_frame", link: 2 }];
+  const v = verifyDisconnect(g, n105, before, 2);
+  assert.equal(v.ok, false);
+  assert.equal(v.intendedRemoved, false);
+});
+
+test("slot-shift safety: inputs array reordered but link fully gone → ok", () => {
+  const g = reproGraph();
+  const before = snapshotGraphState(g);
+  delete g.links[2];
+  const n105 = g.getNodeById(105);
+  // The boundary slot was removed entirely (indices shifted) — legitimate
+  // cascade the caller discloses via the slotsShifted warning, not a failure.
+  n105.inputs = [];
+  const v = verifyDisconnect(g, n105, before, 2);
+  assert.equal(v.ok, true);
+  assert.equal(v.intendedRemoved, true);
+});
+
+test("collateral wire cut with all nodes surviving → not ok (the 114→121 case)", () => {
+  const g = reproGraph();
+  const before = snapshotGraphState(g);
+  delete g.links[2];
+  g.getNodeById(105).inputs[0].link = null;
+  delete g.links[1]; // ImageCrop's image input silently emptied
+  g.getNodeById(121).inputs[0].link = null;
+  const v = verifyDisconnect(g, g.getNodeById(105), before, 2);
+  assert.equal(v.ok, false);
+  assert.equal(v.intendedRemoved, true);
+  assert.deepEqual(v.missingNodes, []);
+  assert.deepEqual(
+    v.collateralRemovedLinks.map((l) => [l.origin_id, l.target_id]),
+    [[114, 121]],
+  );
+});
+
+test("new link appeared → not ok", () => {
+  const g = reproGraph();
+  const before = snapshotGraphState(g);
+  delete g.links[2];
+  g.getNodeById(105).inputs[0].link = null;
+  g.links[4] = { id: 4, origin_id: 121, origin_slot: 0, target_id: 92, target_slot: 0 };
+  const v = verifyDisconnect(g, g.getNodeById(105), before, 2);
+  assert.equal(v.ok, false);
+  assert.deepEqual(v.addedLinks.map((l) => l.id), [4]);
+});
+
+test("floating-link churn alone does not fail the verdict", () => {
+  const g = reproGraph();
+  g.links[50] = { id: 50, origin_id: -1, origin_slot: -1, target_id: 105, target_slot: 0 };
+  const before = snapshotGraphState(g);
+  delete g.links[2];
+  g.getNodeById(105).inputs[0].link = null;
+  delete g.links[50]; // mid-drag stub discarded during the disconnect — not a wire
+  const v = verifyDisconnect(g, g.getNodeById(105), before, 2);
+  assert.equal(v.ok, true);
+});
+
+test("null/undefined intendedLinkId fails closed", () => {
+  const g = reproGraph();
+  const before = snapshotGraphState(g);
+  const v = verifyDisconnect(g, g.getNodeById(105), before, null);
+  assert.equal(v.ok, false);
+  assert.equal(v.intendedRemoved, false);
+});
+
+test("string-vs-number node ids across the boundary are not false positives", () => {
+  // Subgraph node ids can be strings; _nodes may carry "7" while a rebuilt
+  // array carries 7. The snapshot normalizes both, so no phantom add/remove.
+  const g1 = mockGraph([node("7"), node(8)], {});
+  const before = snapshotGraphState(g1);
+  const g2 = mockGraph([node(7), node("8")], {});
+  const v = verifyDisconnect(g2, g2.getNodeById(7), before, null);
+  assert.deepEqual(v.missingNodes, []);
+  assert.deepEqual(v.addedNodes, []);
+});

--- a/browser_tests/unit/disconnect-verify.test.mjs
+++ b/browser_tests/unit/disconnect-verify.test.mjs
@@ -19,13 +19,15 @@ import {
   verifyDisconnect,
 } from "../../web/js/lib/disconnect-verify.js";
 
-/** Minimal mock graph: nodes by id, links as a legacy record store. */
+/** Minimal mock graph: nodes by id, links as a legacy record store. getNodeById
+ *  reads the LIVE _nodes array, like litegraph's _nodes_by_id lookup. */
 function mockGraph(nodes, links) {
-  return {
+  const g = {
     _nodes: nodes,
     links,
-    getNodeById: (id) => nodes.find((n) => n.id === id) ?? null,
+    getNodeById: (id) => g._nodes.find((n) => n.id === id) ?? null,
   };
+  return g;
 }
 
 function node(id, inputs = [], outputs = []) {
@@ -90,13 +92,22 @@ test("describeInputLink: unlinked input → null (caller refuses the no-op)", ()
   assert.equal(describeInputLink(g, n105, 1), null);
 });
 
-test("describeInputLink: falls back to origin_slot number when the origin node is gone", () => {
+test("describeInputLink: dangling slot ref (no link record) → null, like unlinked", () => {
   const g = reproGraph();
   const n105 = g.getNodeById(105);
-  n105.inputs[0].link = 99; // dangling id, no record
+  n105.inputs[0].link = 99; // dangling id, no record in the store
+  assert.equal(describeInputLink(g, n105, 0), null);
+});
+
+test("describeInputLink: origin node gone but record present → slot-index fallback", () => {
+  const g = reproGraph();
+  const n105 = g.getNodeById(105);
+  g._nodes = g._nodes.filter((n) => n.id !== 121); // origin deleted, record survives
   const d = describeInputLink(g, n105, 0);
-  assert.equal(d.linkId, 99);
-  assert.equal(d.node_id, undefined);
+  assert.equal(d.linkId, 2);
+  assert.equal(d.node_id, 121);
+  assert.equal(d.output, 0); // no origin outputs to name — the slot index
+  assert.equal(d.output_index, 0);
 });
 
 test("clean disconnect: intended link gone, nothing else changed → ok", () => {
@@ -217,6 +228,39 @@ test("floating-link churn alone does not fail the verdict", () => {
   g.getNodeById(105).inputs[0].link = null;
   delete g.links[50]; // mid-drag stub discarded during the disconnect — not a wire
   const v = verifyDisconnect(g, g.getNodeById(105), before, 2);
+  assert.equal(v.ok, true);
+});
+
+test("interior node deletion inside the target's subgraph is detected (path-qualified)", () => {
+  const g = reproGraph();
+  const n105 = g.getNodeById(105);
+  n105.subgraph = { _nodes: [node(12), node(13)] };
+  const before = snapshotGraphState(g);
+  assert.ok(before.nodeIds.has("105>12"), "interior nodes are in the snapshot");
+  delete g.links[2];
+  n105.inputs[0].link = null;
+  n105.subgraph._nodes = [node(13)]; // inner node 12 deleted by the cascade
+  const v = verifyDisconnect(g, n105, before, 2);
+  assert.equal(v.ok, false);
+  assert.deepEqual(v.missingNodes, ["105>12"]);
+});
+
+test("interior LINK pruning (boundary-slot cascade) does NOT fail — documented asymmetry", () => {
+  const g = reproGraph();
+  const n105 = g.getNodeById(105);
+  n105.subgraph = {
+    _nodes: [node(12)],
+    links: { 1: { id: 1, origin_id: -10, origin_slot: 0, target_id: 12, target_slot: 0 } },
+  };
+  const before = snapshotGraphState(g);
+  delete g.links[2];
+  n105.inputs[0].link = null;
+  // The boundary slot was pruned: its interior rail link went with it. Interior
+  // link stores are deliberately NOT diffed (legitimate cascade) — only the
+  // interior NODE set is. The panel's slotsShifted warning covers the shape.
+  n105.subgraph.links = {};
+  n105.inputs = [];
+  const v = verifyDisconnect(g, n105, before, 2);
   assert.equal(v.ok, true);
 });
 

--- a/browser_tests/unit/module-graph-link.test.mjs
+++ b/browser_tests/unit/module-graph-link.test.mjs
@@ -31,6 +31,11 @@ import { commandIsCanvasIndependent } from "../../web/js/lib/workflow-chat-ident
 import { sealProvenRootBinding } from "../../web/js/lib/graph-binding.js";
 import { composeShowMediaReply } from "../../web/js/lib/media-preview.js";
 import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame.js";
+import {
+  snapshotGraphState,
+  describeInputLink,
+  verifyDisconnect,
+} from "../../web/js/lib/disconnect-verify.js";
 
 // --- Mirror the shared bounded-step edge (#648) --------------------------------------
 // run-completion-frame.js and media-preview.js BOTH import withTimeout from here. If
@@ -77,6 +82,12 @@ test("panel ↔ media-preview.js / run-completion-frame.js ↔ bounded-step.js e
   assert.equal(typeof composeShowMediaReply, "function");
   assert.equal(typeof composeRunCompletionFrame, "function");
   assert.equal(typeof withTimeout, "function");
+});
+
+test("panel ↔ disconnect-verify.js module edge links (#668)", () => {
+  assert.equal(typeof snapshotGraphState, "function");
+  assert.equal(typeof describeInputLink, "function");
+  assert.equal(typeof verifyDisconnect, "function");
 });
 
 test("set-widget.js ↔ widget-write.js / node-resolve.js module edges link", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -8631,18 +8631,18 @@ const GRAPH_TOOL_EXECUTORS = {
     // cascade failing midway). Capture the error and STILL verify the
     // post-state — a raw throw would read as "nothing changed" and invite a
     // destructive retry of a disconnect that may have landed.
-    let mutationError = null;
+    let mutationErr = null;
     graph.beforeChange();
     try {
       node.disconnectInput(inIdx);
     } catch (err) {
-      mutationError = err;
+      mutationErr = err;
     }
-    let envelopeError = null;
+    let envelopeErr = null;
     try {
       graph.afterChange();
     } catch (err) {
-      envelopeError = err;
+      envelopeErr = err;
     }
     graph.setDirtyCanvas(true, true);
     const verdict = verifyDisconnect(graph, node, before, removedLink.linkId);
@@ -8682,12 +8682,12 @@ const GRAPH_TOOL_EXECUTORS = {
       `success. Press Ctrl+Z in the ComfyUI tab to undo, then re-check the graph with ` +
       `panel_graph_outline BEFORE queueing anything — a silently deleted output node runs ` +
       `to completion and saves nothing.`;
-    if (mutationError || envelopeError) {
+    if (mutationErr || envelopeErr) {
       throw new Error(
         [
           `panel_disconnect on node ${node.id} input "${inputName}" threw (#668): ` +
-            `${mutationError?.message ?? mutationError ?? ""}` +
-            (envelopeError ? ` (afterChange also threw: ${envelopeError?.message ?? envelopeError})` : ""),
+            `${mutationErr?.message ?? mutationErr ?? ""}` +
+            (envelopeErr ? ` (afterChange also threw: ${envelopeErr?.message ?? envelopeErr})` : ""),
           `Post-state check of the live graph:`,
           ...disclosureBullets(),
           undoRemedy,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -204,6 +204,11 @@ import {
 } from "./lib/control-after-generate.js";
 import { autoMatchSlots, slotDiagnostic } from "./lib/connect-match.js";
 import { isLinkPersisted, removePhantomLink, isWidgetBackedInput } from "./lib/connect-verify.js";
+import {
+  snapshotGraphState,
+  describeInputLink,
+  verifyDisconnect,
+} from "./lib/disconnect-verify.js";
 import { deferChangeTrackerSnapshot } from "./lib/change-tracker-snapshot.js";
 import { coerceMessageText, isDroppedAgentReplay, serializeContext } from "./lib/chat-serialize.js";
 import {
@@ -8602,6 +8607,26 @@ const GRAPH_TOOL_EXECUTORS = {
     const { graph } = getGraphCtx();
     const node = resolveNode(graph, node_id);
     const inIdx = resolveSlot(node.inputs, input ?? 0, "input");
+    // #668 DISCONNECT HONESTY: capture the intent BEFORE the mutation. On a
+    // SubgraphNode, disconnectInput can cascade beyond dropping the wire — #668
+    // observed it DELETE unrelated nodes (a LoadImage two hops upstream, a
+    // downstream SaveVideo) while reporting plain success, and boundary-slot
+    // removal can shift the inputs array so any slot read AFTER the call may
+    // describe a different input. Snapshot first; verify after; never report a
+    // bare success for a change the graph does not actually show.
+    const inputName = node.inputs?.[inIdx]?.name ?? inIdx;
+    const inputNamesBefore = (node.inputs ?? []).map((s) => s?.name ?? null);
+    const removedLink = describeInputLink(graph, node, inIdx);
+    if (!removedLink) {
+      // Nothing to remove: reporting `disconnected` here would fabricate a
+      // mutation that never happened. REFUSE (the graph is untouched).
+      throw new Error(
+        `panel_disconnect: node ${node.id} input "${inputName}" is not connected — ` +
+          `there is no link to remove. Check the live wiring with panel_graph_outline; ` +
+          `if a previous disconnect already removed it, no retry is needed (#668).`,
+      );
+    }
+    const before = snapshotGraphState(graph);
     graph.beforeChange();
     try {
       node.disconnectInput(inIdx);
@@ -8609,8 +8634,67 @@ const GRAPH_TOOL_EXECUTORS = {
       graph.afterChange();
     }
     graph.setDirtyCanvas(true, true);
+    const verdict = verifyDisconnect(graph, node, before, removedLink.linkId);
+    if (!verdict.ok) {
+      // The mutation ALREADY happened — disclose exactly what was observed
+      // (never refuse after the fact: that reports failure for a disconnect
+      // that may have landed and invites a destructive retry). The panel
+      // cannot safely restore deleted nodes itself; the change is inside one
+      // beforeChange/afterChange envelope, so a single Ctrl+Z reverts it.
+      const lines = [
+        `panel_disconnect on node ${node.id} input "${inputName}" did not complete cleanly (#668):`,
+      ];
+      lines.push(
+        verdict.intendedRemoved
+          ? `- the intended link (from node ${removedLink.node_id} output "${removedLink.output}") WAS removed`
+          : `- the intended link (from node ${removedLink.node_id} output "${removedLink.output}") is STILL PRESENT — the disconnect did not take effect`,
+      );
+      if (verdict.missingNodes.length) {
+        lines.push(
+          `- node(s) ${verdict.missingNodes.join(", ")} were REMOVED from the graph — ` +
+            `this is the #668 cascade: unrelated nodes deleted by a disconnect`,
+        );
+      }
+      if (verdict.addedNodes.length) {
+        lines.push(`- node(s) ${verdict.addedNodes.join(", ")} APPEARED that were not there before`);
+      }
+      for (const l of verdict.collateralRemovedLinks) {
+        lines.push(
+          `- a link that was NOT the target was removed: node ${l.origin_id} output ${l.origin_slot} → node ${l.target_id} input ${l.target_slot}`,
+        );
+      }
+      for (const l of verdict.addedLinks) {
+        lines.push(
+          `- a link APPEARED that this disconnect did not create: node ${l.origin_id} output ${l.origin_slot} → node ${l.target_id} input ${l.target_slot}`,
+        );
+      }
+      lines.push(
+        `The change already happened and the panel did not fabricate a success. ` +
+          `Press Ctrl+Z in the ComfyUI tab to undo, then re-check the graph with ` +
+          `panel_graph_outline BEFORE queueing anything — a silently deleted output ` +
+          `node runs to completion and saves nothing.`,
+      );
+      throw new Error(lines.join("\n"));
+    }
+    // Boundary-slot disclosure: a subgraph (or dynamic) node may drop the
+    // now-unlinked input slot itself. That is a legitimate cascade, but it
+    // shifts slot indices — a follow-up disconnect by NAME is safe, by INDEX
+    // is not, unless the caller re-resolves first.
+    const inputNamesAfter = (node.inputs ?? []).map((s) => s?.name ?? null);
+    const slotsShifted =
+      inputNamesBefore.length !== inputNamesAfter.length ||
+      inputNamesBefore.some((n, i) => n !== inputNamesAfter[i]);
     return {
-      disconnected: { node_id: node.id, input: node.inputs?.[inIdx]?.name ?? inIdx },
+      disconnected: { node_id: node.id, input: inputName },
+      removed_link: { node_id: removedLink.node_id, output: removedLink.output },
+      ...(slotsShifted
+        ? {
+            warning:
+              `the node's input slots changed during the disconnect (a now-unlinked ` +
+              `slot was removed, shifting indices) — re-resolve input names with ` +
+              `panel_graph_outline before any further disconnect by index`,
+          }
+        : {}),
     };
   },
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -8656,9 +8656,11 @@ const GRAPH_TOOL_EXECUTORS = {
       ];
       if (verdict.missingNodes.length) {
         lines.push(
-          `- node(s) ${verdict.missingNodes.join(", ")} were REMOVED from the graph during this ` +
-            `disconnect — they were not the disconnect target`,
+          `- node(s) ${verdict.missingNodes.join(", ")} were REMOVED from the graph during this disconnect`,
         );
+        if (verdict.missingNodes.includes(String(node.id))) {
+          lines.push(`- the removed nodes INCLUDE the disconnect target (node ${node.id}) itself`);
+        }
       }
       if (verdict.addedNodes.length) {
         lines.push(`- node(s) ${verdict.addedNodes.join(", ")} APPEARED that were not there before`);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -8627,32 +8627,37 @@ const GRAPH_TOOL_EXECUTORS = {
       );
     }
     const before = snapshotGraphState(graph);
+    // The mutation can throw AFTER partially applying (a node hook or the
+    // cascade failing midway). Capture the error and STILL verify the
+    // post-state — a raw throw would read as "nothing changed" and invite a
+    // destructive retry of a disconnect that may have landed.
+    let mutationError = null;
     graph.beforeChange();
     try {
       node.disconnectInput(inIdx);
-    } finally {
+    } catch (err) {
+      mutationError = err;
+    }
+    let envelopeError = null;
+    try {
       graph.afterChange();
+    } catch (err) {
+      envelopeError = err;
     }
     graph.setDirtyCanvas(true, true);
     const verdict = verifyDisconnect(graph, node, before, removedLink.linkId);
-    if (!verdict.ok) {
-      // The mutation ALREADY happened — disclose exactly what was observed
-      // (never refuse after the fact: that reports failure for a disconnect
-      // that may have landed and invites a destructive retry). The panel
-      // cannot safely restore deleted nodes itself; the change is inside one
-      // beforeChange/afterChange envelope, so a single Ctrl+Z reverts it.
+    // Shared disclosure bullets: observed post-state facts ONLY — the verifier
+    // proves what changed, never why, so no bucket is narrated as a cause.
+    const disclosureBullets = () => {
       const lines = [
-        `panel_disconnect on node ${node.id} input "${inputName}" did not complete cleanly (#668):`,
-      ];
-      lines.push(
         verdict.intendedRemoved
           ? `- the intended link (from node ${removedLink.node_id} output "${removedLink.output}") WAS removed`
-          : `- the intended link (from node ${removedLink.node_id} output "${removedLink.output}") is STILL PRESENT — the disconnect did not take effect`,
-      );
+          : `- the intended link (from node ${removedLink.node_id} output "${removedLink.output}") is STILL PRESENT on the live graph`,
+      ];
       if (verdict.missingNodes.length) {
         lines.push(
-          `- node(s) ${verdict.missingNodes.join(", ")} were REMOVED from the graph — ` +
-            `this is the #668 cascade: unrelated nodes deleted by a disconnect`,
+          `- node(s) ${verdict.missingNodes.join(", ")} were REMOVED from the graph during this ` +
+            `disconnect — they were not the disconnect target`,
         );
       }
       if (verdict.addedNodes.length) {
@@ -8668,18 +8673,43 @@ const GRAPH_TOOL_EXECUTORS = {
           `- a link APPEARED that this disconnect did not create: node ${l.origin_id} output ${l.origin_slot} → node ${l.target_id} input ${l.target_slot}`,
         );
       }
-      lines.push(
-        `The change already happened and the panel did not fabricate a success. ` +
-          `Press Ctrl+Z in the ComfyUI tab to undo, then re-check the graph with ` +
-          `panel_graph_outline BEFORE queueing anything — a silently deleted output ` +
-          `node runs to completion and saves nothing.`,
+      return lines;
+    };
+    const undoRemedy =
+      `The state above is what the live graph ACTUALLY shows; the panel did not fabricate a ` +
+      `success. Press Ctrl+Z in the ComfyUI tab to undo, then re-check the graph with ` +
+      `panel_graph_outline BEFORE queueing anything — a silently deleted output node runs ` +
+      `to completion and saves nothing.`;
+    if (mutationError || envelopeError) {
+      throw new Error(
+        [
+          `panel_disconnect on node ${node.id} input "${inputName}" threw (#668): ` +
+            `${mutationError?.message ?? mutationError ?? ""}` +
+            (envelopeError ? ` (afterChange also threw: ${envelopeError?.message ?? envelopeError})` : ""),
+          `Post-state check of the live graph:`,
+          ...disclosureBullets(),
+          undoRemedy,
+        ].join("\n"),
       );
-      throw new Error(lines.join("\n"));
     }
-    // Boundary-slot disclosure: a subgraph (or dynamic) node may drop the
-    // now-unlinked input slot itself. That is a legitimate cascade, but it
-    // shifts slot indices — a follow-up disconnect by NAME is safe, by INDEX
-    // is not, unless the caller re-resolves first.
+    if (!verdict.ok) {
+      // The mutation ALREADY happened — disclose exactly what was observed
+      // (never refuse after the fact: that reports failure for a disconnect
+      // that may have landed and invites a destructive retry). The panel
+      // cannot safely restore deleted nodes itself; the change is inside one
+      // beforeChange/afterChange envelope, so a single Ctrl+Z reverts it.
+      throw new Error(
+        [
+          `panel_disconnect on node ${node.id} input "${inputName}" did not complete cleanly (#668):`,
+          ...disclosureBullets(),
+          undoRemedy,
+        ].join("\n"),
+      );
+    }
+    // Boundary-slot disclosure: a subgraph (or dynamic) node may change its
+    // input slots on disconnect. That is a legitimate cascade, but it shifts
+    // slot indices — a follow-up disconnect by NAME is safe, by INDEX is not,
+    // unless the caller re-resolves first.
     const inputNamesAfter = (node.inputs ?? []).map((s) => s?.name ?? null);
     const slotsShifted =
       inputNamesBefore.length !== inputNamesAfter.length ||
@@ -8690,9 +8720,9 @@ const GRAPH_TOOL_EXECUTORS = {
       ...(slotsShifted
         ? {
             warning:
-              `the node's input slots changed during the disconnect (a now-unlinked ` +
-              `slot was removed, shifting indices) — re-resolve input names with ` +
-              `panel_graph_outline before any further disconnect by index`,
+              `the node's input slots changed during the disconnect (count, order, or names ` +
+              `differ) — re-resolve input names with panel_graph_outline before any further ` +
+              `disconnect by index`,
           }
         : {}),
     };

--- a/web/js/lib/disconnect-verify.js
+++ b/web/js/lib/disconnect-verify.js
@@ -18,6 +18,18 @@
 // fact would report failure for a disconnect that may have landed and invite a
 // destructive retry.
 //
+// Scope of the snapshot, deliberately asymmetric:
+//   - NODE SETS are tracked RECURSIVELY into descendant subgraphs (ids qualified
+//     by the subgraph-node path, "105>12"): a disconnect can never legitimately
+//     delete a node anywhere, interior or not, so every deletion is reported.
+//   - LINK SETS are tracked for the CURRENT graph only. A disconnect of the
+//     last external wire to a subgraph boundary slot may legitimately prune that
+//     slot and its INTERIOR rail links — flagging those would fail ordinary,
+//     correct use. Collateral link loss in the graph the caller is looking at
+//     is never legitimate, so there it fails. The panel discloses a changed
+//     boundary-slot shape via its own warning, which covers the legitimate
+//     interior case.
+//
 // Pure (no DOM / no ComfyUI globals — graph + nodes are passed in) so the unit
 // tests drive the SAME check production runs.
 
@@ -60,19 +72,22 @@ function linkIsFloating(link) {
 
 /**
  * Snapshot the parts of `graph` a disconnect must never change beyond the one
- * intended link: the node id set and the set of real (non-floating) links.
- * Ids are string-normalized — subgraph node ids can be strings while link
- * endpoints may carry them as numbers, and Map keys / legacy record keys
- * differ in type across litegraph builds.
+ * intended link: the node id set (RECURSIVELY into descendant subgraphs — a
+ * node deletion is never a legitimate disconnect side effect anywhere) and the
+ * set of real (non-floating) links OF THIS GRAPH (interior link pruning by a
+ * boundary-slot cascade is legitimate; see the module header). Ids are
+ * string-normalized — subgraph node ids can be strings while link endpoints
+ * may carry them as numbers, and Map keys / legacy record keys differ in type
+ * across litegraph builds. Interior node ids are qualified by the subgraph-node
+ * path ("105>12") so rail ids (-10/-20) and local id collisions across nested
+ * graphs can never alias each other.
  *
  * Returns `{ nodeIds: Set<string>, links: Map<string, linkView> }` where
  * linkView is `{ id, origin_id, origin_slot, target_id, target_slot }`.
  */
 export function snapshotGraphState(graph) {
   const nodeIds = new Set();
-  for (const n of graph?._nodes ?? []) {
-    if (n?.id != null) nodeIds.add(String(n.id));
-  }
+  collectNodeIds(graph, "", nodeIds);
   const links = new Map();
   for (const [id, link] of linkEntries(graph)) {
     if (!link || id == null || linkIsFloating(link)) continue;
@@ -87,23 +102,43 @@ export function snapshotGraphState(graph) {
   return { nodeIds, links };
 }
 
+/** Recursively add "path-qualified" node ids: top-level ids plain, interior
+ *  ids as "<subgraphNodeId>><innerId>" (deeper nesting extends the path). */
+function collectNodeIds(graph, prefix, out) {
+  for (const n of graph?._nodes ?? []) {
+    if (n?.id == null) continue;
+    const path = prefix + String(n.id);
+    out.add(path);
+    const inner = n?.subgraph;
+    if (inner && Array.isArray(inner._nodes)) collectNodeIds(inner, `${path}>`, out);
+  }
+}
+
 /**
  * Describe the link currently feeding `node`'s input `inIdx`, or null when the
  * input is not connected. Captured BEFORE the mutation: on a SubgraphNode the
  * disconnect can remove the boundary slot and shift the inputs array, so any
  * slot read taken afterwards may describe a DIFFERENT input. `node_id`/`output`
  * name the wire's former source (symmetric with graph_connect's replaced_link).
+ *
+ * A slot whose `link` id has NO record in the graph's link store is a DANGLING
+ * reference, not a connection — null is returned so the caller's not-connected
+ * refusal covers it (reporting a "removed" wire that never existed would
+ * fabricate a mutation). The inverse is fine: the ORIGIN NODE may be gone while
+ * its link record still exists, in which case the description falls back to the
+ * origin slot index.
  */
 export function describeInputLink(graph, node, inIdx) {
   const linkId = node?.inputs?.[inIdx]?.link;
   if (linkId == null) return null;
   const link = getLinkRecord(graph, linkId);
-  const origin = link ? graph?.getNodeById?.(link.origin_id) : null;
+  if (!link) return null;
+  const origin = graph?.getNodeById?.(link.origin_id);
   return {
     linkId,
-    node_id: link?.origin_id,
-    output: origin?.outputs?.[link?.origin_slot]?.name ?? link?.origin_slot,
-    output_index: link?.origin_slot,
+    node_id: link.origin_id,
+    output: origin?.outputs?.[link.origin_slot]?.name ?? link.origin_slot,
+    output_index: link.origin_slot,
   };
 }
 

--- a/web/js/lib/disconnect-verify.js
+++ b/web/js/lib/disconnect-verify.js
@@ -1,0 +1,153 @@
+// Pre/post-mutation verification for graph_disconnect (#668).
+//
+// `node.disconnectInput(inIdx)` is documented as "remove the link on this input",
+// but on a SubgraphNode the frontend can cascade far beyond that: #668 observed
+// three panel_disconnect calls on a subgraph node's inputs DELETE two unrelated
+// nodes — a LoadImage two hops upstream and a downstream SaveVideo consuming the
+// subgraph's output — while every call returned a plain success payload. The exact
+// frontend mechanism is unconfirmed (a boundary-slot removal shifting the inputs
+// array is one lead); what is certain is that the panel assumed disconnectInput
+// only drops one wire and never checked.
+//
+// This module fixes the PROPERTY, mirroring the #397 connect honesty pattern
+// (connect-verify.js): the panel snapshots the graph's node set and link set
+// BEFORE the call, re-reads them AFTER, and refuses to report a bare success when
+// anything beyond the intended link changed. Because the destruction has already
+// happened when verification fails, the caller DISCLOSES loudly (exactly which
+// nodes/links changed, undo remedy) rather than refusing — refusing after the
+// fact would report failure for a disconnect that may have landed and invite a
+// destructive retry.
+//
+// Pure (no DOM / no ComfyUI globals — graph + nodes are passed in) so the unit
+// tests drive the SAME check production runs.
+
+// litegraph's sentinel for the unassigned end of a FLOATING link (a mid-drag
+// stub). Floating links are transient UI state, not graph wires, so they are
+// excluded from the before/after link diff — their appearance/disappearance is
+// not a mutation worth failing on.
+const UNASSIGNED_NODE_ID = -1;
+
+/** Read a link record by id from either the modern Map (`_links`) or the
+ *  back-compat record/proxy (`links`). Returns undefined when absent. */
+function getLinkRecord(graph, id) {
+  if (id == null) return undefined;
+  const map = graph?._links;
+  if (map && typeof map.get === "function") return map.get(id);
+  const rec = graph?.links;
+  return rec ? rec[id] : undefined;
+}
+
+/** Enumerate [id, record] pairs from either the Map store or the legacy record. */
+function linkEntries(graph) {
+  const map = graph?._links;
+  if (map && typeof map.forEach === "function" && typeof map.get === "function") {
+    return [...map.entries()];
+  }
+  const rec = graph?.links;
+  if (rec && typeof rec === "object") {
+    return Object.keys(rec).map((k) => [rec[k]?.id ?? k, rec[k]]);
+  }
+  return [];
+}
+
+/** True when the link is a floating mid-drag stub (one end unassigned). */
+function linkIsFloating(link) {
+  return (
+    Number(link?.origin_id) === UNASSIGNED_NODE_ID ||
+    Number(link?.target_id) === UNASSIGNED_NODE_ID
+  );
+}
+
+/**
+ * Snapshot the parts of `graph` a disconnect must never change beyond the one
+ * intended link: the node id set and the set of real (non-floating) links.
+ * Ids are string-normalized — subgraph node ids can be strings while link
+ * endpoints may carry them as numbers, and Map keys / legacy record keys
+ * differ in type across litegraph builds.
+ *
+ * Returns `{ nodeIds: Set<string>, links: Map<string, linkView> }` where
+ * linkView is `{ id, origin_id, origin_slot, target_id, target_slot }`.
+ */
+export function snapshotGraphState(graph) {
+  const nodeIds = new Set();
+  for (const n of graph?._nodes ?? []) {
+    if (n?.id != null) nodeIds.add(String(n.id));
+  }
+  const links = new Map();
+  for (const [id, link] of linkEntries(graph)) {
+    if (!link || id == null || linkIsFloating(link)) continue;
+    links.set(String(id), {
+      id,
+      origin_id: link.origin_id,
+      origin_slot: link.origin_slot,
+      target_id: link.target_id,
+      target_slot: link.target_slot,
+    });
+  }
+  return { nodeIds, links };
+}
+
+/**
+ * Describe the link currently feeding `node`'s input `inIdx`, or null when the
+ * input is not connected. Captured BEFORE the mutation: on a SubgraphNode the
+ * disconnect can remove the boundary slot and shift the inputs array, so any
+ * slot read taken afterwards may describe a DIFFERENT input. `node_id`/`output`
+ * name the wire's former source (symmetric with graph_connect's replaced_link).
+ */
+export function describeInputLink(graph, node, inIdx) {
+  const linkId = node?.inputs?.[inIdx]?.link;
+  if (linkId == null) return null;
+  const link = getLinkRecord(graph, linkId);
+  const origin = link ? graph?.getNodeById?.(link.origin_id) : null;
+  return {
+    linkId,
+    node_id: link?.origin_id,
+    output: origin?.outputs?.[link?.origin_slot]?.name ?? link?.origin_slot,
+    output_index: link?.origin_slot,
+  };
+}
+
+/**
+ * Verify that a disconnect did EXACTLY what was asked: the intended link is
+ * gone (from the link store AND from every input slot of the target node — a
+ * boundary-slot cascade can shift `node.inputs`, so the slot reference check
+ * scans the whole array, never a fixed index) and NOTHING else changed.
+ *
+ * `before` is the snapshotGraphState taken pre-mutation; `intendedLinkId` is
+ * the link that was on the target input pre-mutation.
+ *
+ * Returns `{ ok, intendedRemoved, missingNodes, addedNodes,
+ * collateralRemovedLinks, addedLinks }` — the caller composes the honest
+ * disclosure from whichever buckets are non-empty. `ok` is true only when the
+ * intended link is fully gone and every other bucket is empty.
+ */
+export function verifyDisconnect(graph, node, before, intendedLinkId) {
+  const after = snapshotGraphState(graph);
+  const intendedId = intendedLinkId != null ? String(intendedLinkId) : null;
+
+  const missingNodes = [...(before?.nodeIds ?? [])].filter((id) => !after.nodeIds.has(id));
+  const addedNodes = [...after.nodeIds].filter((id) => !(before?.nodeIds?.has(id) ?? false));
+
+  const collateralRemovedLinks = [];
+  for (const [id, view] of before?.links ?? []) {
+    if (!after.links.has(id) && id !== intendedId) collateralRemovedLinks.push(view);
+  }
+  const addedLinks = [];
+  for (const [id, view] of after.links) {
+    if (!(before?.links?.has(id) ?? false)) addedLinks.push(view);
+  }
+
+  const stillInStore = intendedId != null && after.links.has(intendedId);
+  const stillReferenced =
+    intendedId != null &&
+    (node?.inputs ?? []).some((inp) => inp?.link != null && String(inp.link) === intendedId);
+  const intendedRemoved = intendedId != null && !stillInStore && !stillReferenced;
+
+  const ok =
+    intendedRemoved &&
+    missingNodes.length === 0 &&
+    addedNodes.length === 0 &&
+    collateralRemovedLinks.length === 0 &&
+    addedLinks.length === 0;
+  return { ok, intendedRemoved, missingNodes, addedNodes, collateralRemovedLinks, addedLinks };
+}


### PR DESCRIPTION
Severe mutation-integrity defect: `graph_disconnect` (web/js/comfyui-mcp-panel.js:8601) is a bare `node.disconnectInput(inIdx)` with no subgraph-boundary handling, no pre/post node-set snapshot, and no verification.

closes #668