### PR TITLE
panel_install_node times out while the canvas remains responsive

### DIFF
--- a/browser_tests/unit/manager-dialect.test.mjs
+++ b/browser_tests/unit/manager-dialect.test.mjs
@@ -714,7 +714,7 @@ function nodesInstallDeps(overrides) {
     isStallError: (err) =>
       err?.name === "AbortError" ||
       err?.name === "TimeoutError" ||
-      /aborted mid-probe/.test(String(err?.message ?? "")),
+      String(err?.message ?? "").startsWith("ComfyUI-Manager dialect detection was aborted mid-probe"),
     reProbeManagerDialect: async () => "v2",
     managerQueueControl: async () => {},
     verifyInstalled: async () => ({ state: "installed", status: QUEUE_STATUS }),

--- a/browser_tests/unit/manager-dialect.test.mjs
+++ b/browser_tests/unit/manager-dialect.test.mjs
@@ -707,12 +707,14 @@ function nodesInstallDeps(overrides) {
     // #671: the command budget + stall classifier the extracted nodes_install
     // now closes over. A generous budget keeps these tests on their original
     // code paths (no stall translation); the budget behavior itself is covered
-    // in manager-install.test.mjs.
+    // in manager-install.test.mjs. The classifier mirrors the production
+    // isStallError: abort-primitive names + detect's own mid-probe abort ONLY —
+    // never a message-regex that would swallow a real Manager verdict.
     NODES_INSTALL_COMMAND_BUDGET_MS: 25000,
-    isStallError: (err) => {
-      const msg = String(err?.message ?? err ?? "");
-      return err?.name === "AbortError" || err?.name === "TimeoutError" || /aborted|timed?\s*out/i.test(msg);
-    },
+    isStallError: (err) =>
+      err?.name === "AbortError" ||
+      err?.name === "TimeoutError" ||
+      /aborted mid-probe/.test(String(err?.message ?? "")),
     reProbeManagerDialect: async () => "v2",
     managerQueueControl: async () => {},
     verifyInstalled: async () => ({ state: "installed", status: QUEUE_STATUS }),

--- a/browser_tests/unit/manager-dialect.test.mjs
+++ b/browser_tests/unit/manager-dialect.test.mjs
@@ -704,6 +704,15 @@ function nodesInstallDeps(overrides) {
     isManagerUnreachable,
     isManagerRouteMissing,
     dialectRetryTarget,
+    // #671: the command budget + stall classifier the extracted nodes_install
+    // now closes over. A generous budget keeps these tests on their original
+    // code paths (no stall translation); the budget behavior itself is covered
+    // in manager-install.test.mjs.
+    NODES_INSTALL_COMMAND_BUDGET_MS: 25000,
+    isStallError: (err) => {
+      const msg = String(err?.message ?? err ?? "");
+      return err?.name === "AbortError" || err?.name === "TimeoutError" || /aborted|timed?\s*out/i.test(msg);
+    },
     reProbeManagerDialect: async () => "v2",
     managerQueueControl: async () => {},
     verifyInstalled: async () => ({ state: "installed", status: QUEUE_STATUS }),

--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -703,9 +703,7 @@ test("#671 verifyInstalled (real panel source) answers 'unverified' inside the r
       return Promise.resolve({ is_processing: true, done_count: 0, total_count: 1 });
     }
     if (route === "customnode/installed") {
-      return new Promise((_, reject) => {
-        opts?.signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
-      });
+      return hangUntilAbort(opts);
     }
     return Promise.reject(new Error(`unexpected route ${route}`));
   };
@@ -857,17 +855,28 @@ function loadNodesInstall({ budgetMs, detect, reProbe, managerV2, managerCall, m
 }
 
 // A request that never answers, failing ONLY when its abort signal fires — the
-// shape of a stalled Manager call under api.fetchApi. The 30s fallback keeps a
-// mutant that DROPS the budget signal from hanging the suite: the test then
-// fails its elapsed bound instead of never returning.
+// shape of a stalled Manager call under api.fetchApi. The ref'd fallback timer
+// is load-bearing TWICE: (1) a mutant that DROPS the budget signal fails the
+// test's elapsed bound instead of hanging the suite; (2) AbortSignal.timeout's
+// timer is UNREF'D in Node, so a promise that waits only on "abort" can leave
+// the event loop EMPTY — the runner then cancels the test with "Promise
+// resolution is still pending but the event loop has already resolved" (CI run
+// 31050277380). The fallback keeps the loop alive and is cleared when the abort
+// fires, so it never delays a passing suite.
 function hangUntilAbort(opts, fallbackMs = 30000) {
   return new Promise((_, reject) => {
     const fail = () =>
       reject(Object.assign(new Error("The operation timed out"), { name: "TimeoutError" }));
+    const fallback = setTimeout(fail, fallbackMs);
     if (opts?.signal) {
-      opts.signal.addEventListener("abort", fail, { once: true });
-    } else {
-      setTimeout(fail, fallbackMs);
+      opts.signal.addEventListener(
+        "abort",
+        () => {
+          clearTimeout(fallback);
+          fail();
+        },
+        { once: true },
+      );
     }
   });
 }
@@ -904,13 +913,7 @@ test("#671 nodes_install (real panel source) answers inside the reply window whe
   // The install POST hangs forever (signal-aware); every other call answers.
   const managerV2 = (route, opts) => {
     if (route === "manager/queue/task") {
-      return new Promise((_, reject) => {
-        opts?.signal?.addEventListener(
-          "abort",
-          () => reject(Object.assign(new Error("The operation timed out"), { name: "TimeoutError" })),
-          { once: true },
-        );
-      });
+      return hangUntilAbort(opts);
     }
     return Promise.reject(new Error(`unexpected route ${route}`));
   };

--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -711,7 +711,7 @@ test("#671 verifyInstalled (real panel source) answers 'unverified' inside the r
   };
   const verifyInstalled = loadVerifyInstalled({ budgetMs: 2500, get });
   const started = Date.now();
-  const outcome = await verifyInstalled("ComfyUI-MelBandRoFormer", "v2", {});
+  const outcome = await verifyInstalled("ComfyUI-MelBandRoFormer", "v2", { budgetMs: 2500 });
   const elapsed = Date.now() - started;
 
   // The reply must leave the tab WELL inside the orchestrator's 30s window.
@@ -741,32 +741,169 @@ test("#671 verifyInstalled (real panel source) still verifies a fast-draining in
     throw new Error(`unexpected route ${route}`);
   };
   const verifyInstalled = loadVerifyInstalled({ budgetMs: 3000, get });
-  const outcome = await verifyInstalled("ComfyUI-MelBandRoFormer", "v2", {});
+  const outcome = await verifyInstalled("ComfyUI-MelBandRoFormer", "v2", { budgetMs: 3000 });
   assert.equal(outcome.state, "installed");
 });
 
-// Fast wiring guard: the behavioral test above catches a reverted budget only
-// after waiting out the mutant's 120s drain. Pin the budget pass-through at
-// source level too, so a regression fails in milliseconds — the same style as
-// the #486/#485 wiring guards below.
-test("#671 verifyInstalled passes a sub-30s budget to waitForQueueDrain (wiring)", () => {
+// Fast wiring guard: the behavioral tests catch a reverted budget only after
+// waiting out the mutant's stall. Pin the budget threading at source level too,
+// so a regression fails in milliseconds — the same style as the #486/#485
+// wiring guards below.
+test("#671 nodes_install threads ONE sub-30s command budget through every phase (wiring)", () => {
   const src = readFileSync(
     fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
     "utf8",
   );
-  const constMatch = src.match(/const INSTALL_VERIFY_BUDGET_MS = (\d+);/);
-  assert.ok(constMatch, "INSTALL_VERIFY_BUDGET_MS must be defined");
+  const constMatch = src.match(/const NODES_INSTALL_COMMAND_BUDGET_MS = (\d+);/);
+  assert.ok(constMatch, "NODES_INSTALL_COMMAND_BUDGET_MS must be defined");
   assert.ok(
     Number(constMatch[1]) < 30000,
-    `verify budget (${constMatch[1]} ms) must fit inside the orchestrator's 30s reply window`,
+    `command budget (${constMatch[1]} ms) must fit inside the orchestrator's 30s reply window`,
   );
+  const fnMatch = src.match(/async nodes_install\(args\)\s*\{[\s\S]*?\n {2}\},/);
+  assert.ok(fnMatch, "could not locate nodes_install in panel source");
+  const body = fnMatch[0];
+  // The verify phase draws on what the command budget has LEFT — not a fresh
+  // fixed budget that could stack past the relay window on top of slow calls.
+  assert.match(
+    body,
+    /verifyInstalled\(target, dialect, \{\s*batchFailed, renameProne, budgetMs: remaining\(\)\s*\}\)/,
+    "verifyInstalled must receive the remaining command budget",
+  );
+  // A budget-exhausted stall is reworded per phase, never reported raw.
+  assert.match(body, /translateStall\(err, phase\)/, "stalls past the budget must be translated");
+  // The verify wait is bounded by the threaded budget.
   const verifyMatch = src.match(/async function verifyInstalled\([\s\S]*?\n\}/);
   assert.ok(verifyMatch, "could not locate verifyInstalled in panel source");
   assert.match(
     verifyMatch[0],
-    /waitForQueueDrain\(\{\s*timeoutMs: INSTALL_VERIFY_BUDGET_MS/,
-    "verifyInstalled must bound the drain wait by INSTALL_VERIFY_BUDGET_MS",
+    /waitForQueueDrain\(\{\s*timeoutMs: budget/,
+    "verifyInstalled must bound the drain wait by its budget",
   );
+});
+
+// The codex-round-1 P1/P2: bounding ONLY the verify phase still let the reply
+// miss the 30s window when pre-verify Manager calls each ate their 15s cap.
+// Drive the REAL extracted nodes_install end-to-end against a Manager that
+// accepts the dialect probe but HANGS the install POST: the command must throw
+// an honest, phase-truthful budget error inside the window — never sit silent
+// until the relay reports a wedged tab.
+function loadNodesInstall({ budgetMs, managerV2, managerCall, managerQueueControl, verifyInstalled }) {
+  const src = readFileSync(
+    fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+    "utf8",
+  );
+  const fnMatch = src.match(/async nodes_install\(args\)\s*\{[\s\S]*?\n {2}\},/);
+  assert.ok(fnMatch, "could not locate nodes_install in panel source");
+  const body = fnMatch[0].replace(/,\s*$/, "");
+  const factory = new Function(
+    "detectManagerDialect",
+    "crypto",
+    "api",
+    "installGitUrl",
+    "buildInstallRequest",
+    "isManagerRouteMissing",
+    "dialectRetryTarget",
+    "reProbeManagerDialect",
+    "managerV2",
+    "managerCall",
+    "managerQueueControl",
+    "verifyInstalled",
+    "isStallError",
+    "MANAGER_FETCH_TIMEOUT_MS",
+    "NODES_INSTALL_COMMAND_BUDGET_MS",
+    "AbortSignal",
+    `const handler = { ${body} };\nreturn handler.nodes_install;`,
+  );
+  return factory(
+    async () => "v2", // dialect probe answers instantly — the Manager is ALIVE
+    { randomUUID: () => "ui-test-1" },
+    { clientId: "test-client" },
+    installGitUrl,
+    buildInstallRequest,
+    ManagerInstall.isManagerRouteMissing,
+    ManagerInstall.dialectRetryTarget,
+    async () => { throw new Error("reProbeManagerDialect must not run (no 404 here)"); },
+    managerV2,
+    managerCall,
+    managerQueueControl,
+    verifyInstalled,
+    isStallErrorShim,
+    15000,
+    budgetMs,
+    AbortSignal,
+  );
+}
+
+// Faithful stand-in for the panel's isStallError (a plain predicate, not the
+// unit under test): AbortError / TimeoutError / an aborted-or-timed-out message.
+function isStallErrorShim(err) {
+  const msg = String(err?.message ?? err ?? "");
+  return err?.name === "AbortError" || err?.name === "TimeoutError" || /aborted|timed?\s*out/i.test(msg);
+}
+
+test("#671 nodes_install (real panel source) answers inside the reply window when the Manager stalls the install POST", async () => {
+  // The install POST hangs forever (signal-aware); every other call answers.
+  const managerV2 = (route, opts) => {
+    if (route === "manager/queue/task") {
+      return new Promise((_, reject) => {
+        opts?.signal?.addEventListener(
+          "abort",
+          () => reject(Object.assign(new Error("The operation timed out"), { name: "TimeoutError" })),
+          { once: true },
+        );
+      });
+    }
+    return Promise.reject(new Error(`unexpected route ${route}`));
+  };
+  const nodes_install = loadNodesInstall({
+    budgetMs: 2500,
+    managerV2,
+    managerCall: async () => { throw new Error("managerCall must not run on the v2 dialect"); },
+    managerQueueControl: async () => { throw new Error("start must not run — the submit never landed"); },
+    verifyInstalled: async () => { throw new Error("verify must not run — the submit never landed"); },
+  });
+  const started = Date.now();
+  const err = await nodes_install({ id: "ComfyUI-MelBandRoFormer" }).then(
+    () => null,
+    (e) => e,
+  );
+  const elapsed = Date.now() - started;
+
+  assert.ok(err, "a stalled submit must surface an error, never a silent success");
+  // The reply leaves the tab WELL inside the 30s relay window. A missing
+  // command budget waits out the 15s per-fetch cap — caught by this bound.
+  assert.ok(elapsed < 10000, `the command outlived its budget (${elapsed} ms)`);
+  // Assert the REASON and the honest state claim: queued-state UNKNOWN, never
+  // a fabricated failure — and an actionable next step (a blind retry can
+  // double-queue the install).
+  assert.match(err.message, /command budget/);
+  assert.match(err.message, /UNKNOWN/);
+  assert.match(err.message, /panel_node_queue_status/);
+});
+
+test("#671 nodes_install (real panel source) happy path still verifies inside the window", async () => {
+  // Positive control: a fast Manager must still reach the verified reply.
+  const calls = [];
+  const managerV2 = async (route) => {
+    calls.push(route);
+    return null;
+  };
+  const nodes_install = loadNodesInstall({
+    budgetMs: 2500,
+    managerV2,
+    managerCall: async () => { throw new Error("managerCall must not run on the v2 dialect"); },
+    managerQueueControl: async () => {},
+    verifyInstalled: async () => ({ state: "installed", status: null }),
+  });
+  const started = Date.now();
+  const result = await nodes_install({ id: "ComfyUI-MelBandRoFormer" });
+  const elapsed = Date.now() - started;
+  assert.equal(result.installed, true);
+  assert.equal(result.verified, true);
+  assert.equal(result.ui_id, "ui-test-1");
+  assert.ok(elapsed < 2500, `the happy path must not wait out the budget (${elapsed} ms)`);
+  assert.deepEqual(calls, ["manager/queue/task"], "exactly one submit, on the v2 task route");
 });
 
 // ---------------------------------------------------------------------------
@@ -794,13 +931,18 @@ test("#486 managerQueueControl (real panel source): POST, then GET-retry ONLY on
 
   const isMethodNotAllowed = (err) => /HTTP\s*405\b/.test(String(err?.message ?? err ?? ""));
   const MANAGER_FETCH_TIMEOUT_MS = 15000;
+  // The real source composes the per-fetch cap with an optional caller budget
+  // signal (#671) via anyAbortSignal; inject a faithful stand-in (the helper is
+  // not the unit under test here).
+  const anyAbortSignal = (signals) => AbortSignal.any(signals.filter(Boolean));
   const factory = new Function(
     "isMethodNotAllowed",
     "MANAGER_FETCH_TIMEOUT_MS",
+    "anyAbortSignal",
     "AbortSignal",
     `${fnMatch[0]}\nreturn managerQueueControl;`,
   );
-  const managerQueueControl = factory(isMethodNotAllowed, MANAGER_FETCH_TIMEOUT_MS, AbortSignal);
+  const managerQueueControl = factory(isMethodNotAllowed, MANAGER_FETCH_TIMEOUT_MS, anyAbortSignal, AbortSignal);
 
   // (a) POST succeeds ⇒ exactly one POST, no GET retry.
   {
@@ -860,7 +1002,7 @@ test("#486 nodes_install starts the queue via managerQueueControl, never a raw P
   // The start goes through the negotiator, routed to the effective dialect's caller.
   assert.match(
     body,
-    /managerQueueControl\(\s*dialect === "legacy" \? managerCall : managerV2,\s*"manager\/queue\/start"\s*\)/,
+    /managerQueueControl\(\s*dialect === "legacy" \? managerCall : managerV2,\s*"manager\/queue\/start"/,
   );
   // No raw start POST survives in the install path (the #486 regression).
   assert.ok(
@@ -897,15 +1039,17 @@ test("#485 nodes_install falls back to the legacy dialect on an unreachable sign
   );
   assert.match(
     body,
-    /dialectRetryTarget\(dialect, await reProbeManagerDialect\(\)\)/,
+    /dialectRetryTarget\(\s*dialect,\s*await reProbeManagerDialect\(/,
     "the retry dialect comes from a live re-probe via the ladder",
   );
   assert.match(body, /if \(!retry\) throw err;/, "legacy-on-legacy gives up with the original error");
   assert.match(body, /submitted = await submitInstall\(retry\)/);
-  // The single queue/start MUST live OUTSIDE the try/catch (after it) so a start
-  // failure never re-runs the submit (codex P0 — no double-fire).
+  // The single queue/start MUST live OUTSIDE the submit try/catch (after it) so
+  // a start failure never re-runs the submit (codex P0 — no double-fire). The
+  // call is multiline (it takes a budget signal, #671) — anchor on its name,
+  // which occurs only at that one call site in this body.
   const catchIdx = body.indexOf("catch (err)");
-  const startIdx = body.indexOf('managerQueueControl(dialect === "legacy"');
+  const startIdx = body.indexOf("managerQueueControl(");
   assert.ok(catchIdx >= 0 && startIdx > catchIdx, "queue/start must run after the submit try/catch");
 });
 

--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -772,6 +772,26 @@ test("#671 nodes_install threads ONE sub-30s command budget through every phase 
   );
   // A budget-exhausted stall is reworded per phase, never reported raw.
   assert.match(body, /translateStall\(err, phase\)/, "stalls past the budget must be translated");
+  // EVERY phase draws on the SAME remaining budget (codex r2 P2 — a phase
+  // without the cap can stack past the relay window ahead of verification).
+  assert.match(
+    body,
+    /detectManagerDialect\(\{\s*signal: AbortSignal\.timeout\(bounded\(/,
+    "dialect detection must be budget-bounded",
+  );
+  assert.match(
+    body,
+    /reProbeManagerDialect\(\{ signal: AbortSignal\.timeout\(bounded\(/,
+    "the #605 re-probe must be budget-bounded",
+  );
+  assert.match(
+    body,
+    /"manager\/queue\/start",\s*\{ signal: AbortSignal\.timeout\(bounded\(/,
+    "queue/start must be budget-bounded",
+  );
+  // The re-probe is its own phase: it only runs after a PROVEN 404, so a stall
+  // there can honestly claim NOTHING was queued (codex r2 P2).
+  assert.match(body, /phase = "reprobe";/, "the re-probe must be its own phase");
   // The verify wait is bounded by the threaded budget.
   const verifyMatch = src.match(/async function verifyInstalled\([\s\S]*?\n\}/);
   assert.ok(verifyMatch, "could not locate verifyInstalled in panel source");
@@ -788,13 +808,16 @@ test("#671 nodes_install threads ONE sub-30s command budget through every phase 
 // accepts the dialect probe but HANGS the install POST: the command must throw
 // an honest, phase-truthful budget error inside the window — never sit silent
 // until the relay reports a wedged tab.
-function loadNodesInstall({ budgetMs, managerV2, managerCall, managerQueueControl, verifyInstalled }) {
+function loadNodesInstall({ budgetMs, detect, reProbe, managerV2, managerCall, managerQueueControl, verifyInstalled }) {
   const src = readFileSync(
     fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
     "utf8",
   );
   const fnMatch = src.match(/async nodes_install\(args\)\s*\{[\s\S]*?\n {2}\},/);
-  assert.ok(fnMatch, "could not locate nodes_install in panel source");
+  // The REAL isStallError is compiled in with the handler (codex r2 P2 — a shim
+  // would let the production classifier regress unnoticed).
+  const stallMatch = src.match(/function isStallError\([\s\S]*?\n\}/);
+  assert.ok(fnMatch && stallMatch, "could not locate nodes_install / isStallError in panel source");
   const body = fnMatch[0].replace(/,\s*$/, "");
   const factory = new Function(
     "detectManagerDialect",
@@ -809,38 +832,67 @@ function loadNodesInstall({ budgetMs, managerV2, managerCall, managerQueueContro
     "managerCall",
     "managerQueueControl",
     "verifyInstalled",
-    "isStallError",
     "MANAGER_FETCH_TIMEOUT_MS",
     "NODES_INSTALL_COMMAND_BUDGET_MS",
     "AbortSignal",
-    `const handler = { ${body} };\nreturn handler.nodes_install;`,
+    `${stallMatch[0]}\nconst handler = { ${body} };\nreturn handler.nodes_install;`,
   );
   return factory(
-    async () => "v2", // dialect probe answers instantly — the Manager is ALIVE
+    detect ?? (async () => "v2"), // dialect probe answers instantly — the Manager is ALIVE
     { randomUUID: () => "ui-test-1" },
     { clientId: "test-client" },
     installGitUrl,
     buildInstallRequest,
     ManagerInstall.isManagerRouteMissing,
     ManagerInstall.dialectRetryTarget,
-    async () => { throw new Error("reProbeManagerDialect must not run (no 404 here)"); },
+    reProbe ?? (async () => { throw new Error("reProbeManagerDialect must not run (no 404 here)"); }),
     managerV2,
     managerCall,
     managerQueueControl,
     verifyInstalled,
-    isStallErrorShim,
     15000,
     budgetMs,
     AbortSignal,
   );
 }
 
-// Faithful stand-in for the panel's isStallError (a plain predicate, not the
-// unit under test): AbortError / TimeoutError / an aborted-or-timed-out message.
-function isStallErrorShim(err) {
-  const msg = String(err?.message ?? err ?? "");
-  return err?.name === "AbortError" || err?.name === "TimeoutError" || /aborted|timed?\s*out/i.test(msg);
+// A request that never answers, failing ONLY when its abort signal fires — the
+// shape of a stalled Manager call under api.fetchApi. The 30s fallback keeps a
+// mutant that DROPS the budget signal from hanging the suite: the test then
+// fails its elapsed bound instead of never returning.
+function hangUntilAbort(opts, fallbackMs = 30000) {
+  return new Promise((_, reject) => {
+    const fail = () =>
+      reject(Object.assign(new Error("The operation timed out"), { name: "TimeoutError" }));
+    if (opts?.signal) {
+      opts.signal.addEventListener("abort", fail, { once: true });
+    } else {
+      setTimeout(fail, fallbackMs);
+    }
+  });
 }
+
+test("#671 isStallError (real panel source) classifies aborts as stalls and real verdicts as NOT stalls", () => {
+  const src = readFileSync(
+    fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+    "utf8",
+  );
+  const m = src.match(/function isStallError\([\s\S]*?\n\}/);
+  assert.ok(m, "could not locate isStallError in panel source");
+  const isStallError = new Function(`${m[0]}\nreturn isStallError;`)();
+  assert.equal(isStallError(Object.assign(new Error("x"), { name: "AbortError" })), true);
+  assert.equal(isStallError(Object.assign(new Error("The operation timed out"), { name: "TimeoutError" })), true);
+  assert.equal(
+    isStallError(new Error("ComfyUI-Manager dialect detection was aborted mid-probe (the caller's budget ran out)")),
+    true,
+    "detectManagerDialect's own budget abort is a plain Error — matched by its exact message",
+  );
+  // codex r2 P1: a REAL Manager verdict whose message happens to contain
+  // "timed out" is EVIDENCE, not a stall — it must surface verbatim.
+  assert.equal(isStallError(new Error("Manager manager/queue/task: install timed out")), false);
+  assert.equal(isStallError(new Error("ComfyUI-Manager not reachable (is the built-in Manager enabled?)")), false);
+  assert.equal(isStallError(new Error("Manager manager/queue/task: HTTP 500")), false);
+});
 
 test("#671 nodes_install (real panel source) answers inside the reply window when the Manager stalls the install POST", async () => {
   // The install POST hangs forever (signal-aware); every other call answers.
@@ -904,6 +956,65 @@ test("#671 nodes_install (real panel source) happy path still verifies inside th
   assert.equal(result.ui_id, "ui-test-1");
   assert.ok(elapsed < 2500, `the happy path must not wait out the budget (${elapsed} ms)`);
   assert.deepEqual(calls, ["manager/queue/task"], "exactly one submit, on the v2 task route");
+});
+
+test("#671 nodes_install a stalled dialect detection reports NOTHING queued (a retry is safe)", async () => {
+  // Detection hangs (signal-aware); NO mutation may run. The budget error must
+  // say so — this phase can vouch for it (codex r2 P2).
+  const nodes_install = loadNodesInstall({
+    budgetMs: 2500,
+    detect: (opts) => hangUntilAbort(opts),
+    managerV2: async () => { throw new Error("no mutation may run — detection never answered"); },
+    managerCall: async () => { throw new Error("no mutation may run — detection never answered"); },
+    managerQueueControl: async () => { throw new Error("start must not run"); },
+    verifyInstalled: async () => { throw new Error("verify must not run"); },
+  });
+  const started = Date.now();
+  const err = await nodes_install({ id: "ComfyUI-MelBandRoFormer" }).then(() => null, (e) => e);
+  const elapsed = Date.now() - started;
+  assert.ok(err, "a stalled detection must surface an error, never hang the reply");
+  assert.ok(elapsed < 10000, `the command outlived its budget (${elapsed} ms)`);
+  assert.match(err.message, /command budget/);
+  assert.match(err.message, /NOTHING was queued/);
+});
+
+test("#671 nodes_install a stalled queue/start after a LANDED submit says QUEUED, never failed", async () => {
+  // The submit answers (the install IS queued); the start hangs. The budget
+  // error must claim exactly that — not failure, not "nothing happened".
+  const nodes_install = loadNodesInstall({
+    budgetMs: 2500,
+    managerV2: async () => null, // the submit lands
+    managerCall: async () => { throw new Error("managerCall must not run on the v2 dialect"); },
+    managerQueueControl: (_call, _route, opts) => hangUntilAbort(opts),
+    verifyInstalled: async () => { throw new Error("verify must not run — the start never answered"); },
+  });
+  const started = Date.now();
+  const err = await nodes_install({ id: "ComfyUI-MelBandRoFormer" }).then(() => null, (e) => e);
+  const elapsed = Date.now() - started;
+  assert.ok(err, "a stalled start must surface an error, never hang the reply");
+  assert.ok(elapsed < 10000, `the command outlived its budget (${elapsed} ms)`);
+  assert.match(err.message, /was QUEUED/);
+  assert.match(err.message, /panel_node_queue_status/);
+  assert.ok(!/FAILED/.test(err.message), "a landed install must never be reported as failed");
+});
+
+test("#671 a REAL Manager verdict is never reworded as a budget stall (codex r2 P1)", async () => {
+  // The submit answers LATE — past the command budget — with a real HTTP
+  // verdict whose message happens to contain "timed out". That is EVIDENCE,
+  // not a transport stall: it must surface verbatim, not be reworded into a
+  // phase claim.
+  const verdict = new Error("Manager manager/queue/task: install timed out");
+  const nodes_install = loadNodesInstall({
+    budgetMs: 2500,
+    managerV2: (route) =>
+      new Promise((_, reject) => setTimeout(() => reject(verdict), 2700)),
+    managerCall: async () => { throw new Error("managerCall must not run on the v2 dialect"); },
+    managerQueueControl: async () => { throw new Error("start must not run — the submit failed"); },
+    verifyInstalled: async () => { throw new Error("verify must not run — the submit failed"); },
+  });
+  const err = await nodes_install({ id: "ComfyUI-MelBandRoFormer" }).then(() => null, (e) => e);
+  assert.ok(err, "a failed submit must surface an error");
+  assert.equal(err.message, "Manager manager/queue/task: install timed out", "the real verdict survives verbatim");
 });
 
 // ---------------------------------------------------------------------------

--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -885,11 +885,17 @@ test("#671 isStallError (real panel source) classifies aborts as stalls and real
   assert.equal(
     isStallError(new Error("ComfyUI-Manager dialect detection was aborted mid-probe (the caller's budget ran out)")),
     true,
-    "detectManagerDialect's own budget abort is a plain Error — matched by its exact message",
+    "detectManagerDialect's own budget abort is a plain Error — matched by its exact prefix",
   );
   // codex r2 P1: a REAL Manager verdict whose message happens to contain
   // "timed out" is EVIDENCE, not a stall — it must surface verbatim.
   assert.equal(isStallError(new Error("Manager manager/queue/task: install timed out")), false);
+  // codex r3 P2: a verdict that merely QUOTES the detect-abort phrase is not
+  // the detect abort — the match is anchored at the message start.
+  assert.equal(
+    isStallError(new Error("Manager manager/queue/task: server aborted mid-probe recovery")),
+    false,
+  );
   assert.equal(isStallError(new Error("ComfyUI-Manager not reachable (is the built-in Manager enabled?)")), false);
   assert.equal(isStallError(new Error("Manager manager/queue/task: HTTP 500")), false);
 });
@@ -1015,6 +1021,51 @@ test("#671 a REAL Manager verdict is never reworded as a budget stall (codex r2 
   const err = await nodes_install({ id: "ComfyUI-MelBandRoFormer" }).then(() => null, (e) => e);
   assert.ok(err, "a failed submit must surface an error");
   assert.equal(err.message, "Manager manager/queue/task: install timed out", "the real verdict survives verbatim");
+});
+
+test("#671 nodes_install a stall in the VERIFY phase claims queued+started, never an unconfirmed start (codex r3 P1)", async () => {
+  // Submit and start BOTH returned; the verify step is where the budget runs
+  // out. (Production verifyInstalled is internally bounded and never throws a
+  // stall — this drives the translateStall branch that guards the claim if
+  // that ever changes.) The message must NOT downgrade the acknowledged start.
+  const nodes_install = loadNodesInstall({
+    budgetMs: 2500,
+    managerV2: async () => null, // submit lands
+    managerCall: async () => { throw new Error("managerCall must not run on the v2 dialect"); },
+    managerQueueControl: async () => {}, // start acknowledged
+    verifyInstalled: () =>
+      new Promise((_, reject) =>
+        setTimeout(
+          () => reject(Object.assign(new Error("The operation timed out"), { name: "TimeoutError" })),
+          2600, // past the 2500 budget
+        ),
+      ),
+  });
+  const err = await nodes_install({ id: "ComfyUI-MelBandRoFormer" }).then(() => null, (e) => e);
+  assert.ok(err, "a verify-phase stall must surface an error");
+  assert.match(err.message, /was QUEUED and the queue start was acknowledged/);
+  assert.match(err.message, /could not be VERIFIED/);
+  assert.match(err.message, /panel_node_queue_status/);
+  assert.ok(!/did not answer queue\/start/.test(err.message), "must not claim the start went unanswered");
+  assert.ok(!/FAILED/.test(err.message), "must never claim failure");
+});
+
+test("#671 nodes_install a stall BEFORE the deadline is NOT claimed as budget exhaustion (codex r3 P2)", async () => {
+  // The per-call cap fires while command budget remains: the error is real but
+  // it is NOT the command budget — it must pass through untranslated. (The raw
+  // surfacing of a per-call stall is pre-existing behavior; only the false
+  // budget attribution is the bug guarded here.)
+  const stall = Object.assign(new Error("The operation timed out"), { name: "TimeoutError" });
+  const nodes_install = loadNodesInstall({
+    budgetMs: 2500,
+    managerV2: () => new Promise((_, reject) => setTimeout(() => reject(stall), 500)),
+    managerCall: async () => { throw new Error("managerCall must not run on the v2 dialect"); },
+    managerQueueControl: async () => { throw new Error("start must not run — the submit failed"); },
+    verifyInstalled: async () => { throw new Error("verify must not run — the submit failed"); },
+  });
+  const err = await nodes_install({ id: "ComfyUI-MelBandRoFormer" }).then(() => null, (e) => e);
+  assert.ok(err, "a stalled submit must surface an error");
+  assert.equal(err, stall, "a pre-deadline stall surfaces as itself, not reworded as budget exhaustion");
 });
 
 // ---------------------------------------------------------------------------

--- a/browser_tests/unit/manager-install.test.mjs
+++ b/browser_tests/unit/manager-install.test.mjs
@@ -642,6 +642,134 @@ test("waitForQueueDrain (real panel source) returns a drained status without Ref
 });
 
 // ---------------------------------------------------------------------------
+// #671 — the install verification must fit inside the orchestrator's reply
+// window. panel_install_node relays nodes_install with a 30s timeout, but
+// verifyInstalled waited on waitForQueueDrain's 120s default: any install whose
+// Manager queue had not drained within ~30s (a real clone + pip-deps install
+// routinely takes longer) never replied, and the orchestrator reported
+// `did not reply to "nodes_install" within 30000 ms` on a LIVE canvas while the
+// install was proceeding. The fix bounds the whole verification (drain wait +
+// installed-list read) by INSTALL_VERIFY_BUDGET_MS and lets the honest
+// "unverified/pending" result (with ui_id, pollable via panel_node_queue_status)
+// reach the caller in time.
+// ---------------------------------------------------------------------------
+
+// Compose the REAL boundedDelay + waitForQueueDrain + verifyInstalled sources
+// with injected Manager clients, mirroring the extraction style above. The
+// injected budget keeps the test fast WITHOUT touching the timing assertions:
+// verifyInstalled closes over INSTALL_VERIFY_BUDGET_MS, so the factory passes a
+// small stand-in — the drain-loop arithmetic under test is the panel's own.
+function loadVerifyInstalled({ budgetMs, get }) {
+  const src = readFileSync(
+    fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+    "utf8",
+  );
+  const delayMatch = src.match(/function boundedDelay\([\s\S]*?\n\}/);
+  const waitMatch = src.match(/async function waitForQueueDrain\([\s\S]*?\n\}/);
+  const verifyMatch = src.match(/async function verifyInstalled\([\s\S]*?\n\}/);
+  assert.ok(delayMatch && waitMatch && verifyMatch,
+    "could not locate boundedDelay / waitForQueueDrain / verifyInstalled in panel source");
+  const managerGet = async () => { throw new Error("managerGet must not be called (get is always passed)"); };
+  const factory = new Function(
+    "queueDrained",
+    "classifyInstallOutcome",
+    "managerGet",
+    "managerV2",
+    "managerCall",
+    "MANAGER_FETCH_TIMEOUT_MS",
+    "INSTALL_VERIFY_BUDGET_MS",
+    "AbortSignal",
+    `${delayMatch[0]}\n${waitMatch[0]}\n${verifyMatch[0]}\nreturn verifyInstalled;`,
+  );
+  return factory(
+    queueDrained,
+    classifyInstallOutcome,
+    managerGet,
+    get, // dialect "v2" routes through managerV2
+    async () => { throw new Error("managerCall must not be called on the v2 dialect"); },
+    15000,
+    budgetMs,
+    AbortSignal,
+  );
+}
+
+test("#671 verifyInstalled (real panel source) answers 'unverified' inside the reply window when the queue never drains", async () => {
+  // A Manager that is alive but whose queue stays busy — the issue's exact
+  // scenario: the canvas is responsive, the install is genuinely still running.
+  // The installed-list read HANGS (signal-aware): the ONE shared deadline must
+  // cap it at whatever budget the drain wait left, not at a fresh 15s.
+  const get = (route, opts) => {
+    if (route === "manager/queue/status") {
+      return Promise.resolve({ is_processing: true, done_count: 0, total_count: 1 });
+    }
+    if (route === "customnode/installed") {
+      return new Promise((_, reject) => {
+        opts?.signal?.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+      });
+    }
+    return Promise.reject(new Error(`unexpected route ${route}`));
+  };
+  const verifyInstalled = loadVerifyInstalled({ budgetMs: 2500, get });
+  const started = Date.now();
+  const outcome = await verifyInstalled("ComfyUI-MelBandRoFormer", "v2", {});
+  const elapsed = Date.now() - started;
+
+  // The reply must leave the tab WELL inside the orchestrator's 30s window.
+  // Expected ~budget + the ≤1s capped list read. A missing drain budget waits
+  // 120s; a list read on its own fresh 15s timeout (no shared deadline) waits
+  // ~17.5s — both mutants blow this bound. (10s, not tighter: loaded machines
+  // overrun timers — the suite has seen a 5s budget take 10.4s.)
+  assert.ok(elapsed < 10000, `verification outlived its budget (${elapsed} ms)`);
+  // Assert the REASON, not just the state: not-drained is an honest
+  // "still in progress", never a fabricated success or failure.
+  assert.equal(outcome.state, "unverified");
+  assert.match(outcome.message, /still in progress/);
+  assert.match(outcome.message, /panel_node_queue_status/);
+});
+
+test("#671 verifyInstalled (real panel source) still verifies a fast-draining install", async () => {
+  // Positive control: a queue that drains immediately and a list that contains
+  // the pack must still reach "installed" — the budget only converts SLOW
+  // verifications to "pending", it must not degrade the fast path.
+  const get = async (route) => {
+    if (route === "manager/queue/status") {
+      return { is_processing: false, done_count: 1, total_count: 1 };
+    }
+    if (route === "customnode/installed") {
+      return { "ComfyUI-MelBandRoFormer": { ver: "1.0.0", cnr_id: "ComfyUI-MelBandRoFormer" } };
+    }
+    throw new Error(`unexpected route ${route}`);
+  };
+  const verifyInstalled = loadVerifyInstalled({ budgetMs: 3000, get });
+  const outcome = await verifyInstalled("ComfyUI-MelBandRoFormer", "v2", {});
+  assert.equal(outcome.state, "installed");
+});
+
+// Fast wiring guard: the behavioral test above catches a reverted budget only
+// after waiting out the mutant's 120s drain. Pin the budget pass-through at
+// source level too, so a regression fails in milliseconds — the same style as
+// the #486/#485 wiring guards below.
+test("#671 verifyInstalled passes a sub-30s budget to waitForQueueDrain (wiring)", () => {
+  const src = readFileSync(
+    fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url)),
+    "utf8",
+  );
+  const constMatch = src.match(/const INSTALL_VERIFY_BUDGET_MS = (\d+);/);
+  assert.ok(constMatch, "INSTALL_VERIFY_BUDGET_MS must be defined");
+  assert.ok(
+    Number(constMatch[1]) < 30000,
+    `verify budget (${constMatch[1]} ms) must fit inside the orchestrator's 30s reply window`,
+  );
+  const verifyMatch = src.match(/async function verifyInstalled\([\s\S]*?\n\}/);
+  assert.ok(verifyMatch, "could not locate verifyInstalled in panel source");
+  assert.match(
+    verifyMatch[0],
+    /waitForQueueDrain\(\{\s*timeoutMs: INSTALL_VERIFY_BUDGET_MS/,
+    "verifyInstalled must bound the drain wait by INSTALL_VERIFY_BUDGET_MS",
+  );
+});
+
+// ---------------------------------------------------------------------------
 // #486 / #485 — legacy Manager 3.x install dialect. The install runtime lives in
 // comfyui-mcp-panel.js (managerQueueControl + nodes_install); we extract the real
 // source and assert its wiring so the fixes can't silently regress.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -4166,6 +4166,19 @@ async function waitForQueueDrain({ timeoutMs = 120000, intervalMs = 1500, get = 
   return status; // deadline hit
 }
 
+/** Budget for the post-enqueue install verification (#671). Bounded well under
+ *  the orchestrator's per-command reply timeout (panel_install_node relays
+ *  nodes_install with 30s) so a genuine, slow install — cloning a pack and
+ *  installing its pip deps routinely outlives 30s — reports an honest
+ *  "unverified/pending" with the ui_id to poll (panel_node_queue_status)
+ *  instead of the reply never leaving the tab: the orchestrator then reported
+ *  `did not reply to "nodes_install" within 30000 ms` on a LIVE, responsive
+ *  canvas while the install was proceeding fine. A bounded verify can only
+ *  degrade a verified success to "pending" — classifyInstallOutcome asserts
+ *  failure ONLY on a positively-drained queue, so the budget can never
+ *  manufacture a false failure. Mirrors UPDATE_VERIFY_BUDGET_MS (#364). */
+const INSTALL_VERIFY_BUDGET_MS = 15000;
+
 /**
  * After an install is queued+started, resolve the TRUE outcome (#232 / codex
  * rounds 1-2). Waits for the queue to drain (bounded), reads the installed-nodes
@@ -4174,6 +4187,10 @@ async function waitForQueueDrain({ timeoutMs = 120000, intervalMs = 1500, get = 
  * the raw values — no false drain, no false-readable). `batchFailed` carries the
  * synchronous v2-batch `failed[]` as failure EVIDENCE (still gated by the
  * tri-state — never an early throw). Returns { state, status, message }.
+ *
+ * ONE shared deadline covers the drain wait AND the list read (#671): the whole
+ * verification must fit inside the orchestrator's reply window, or the reply —
+ * success or honest "pending" — never reaches the caller.
  */
 async function verifyInstalled(target, dialect, { batchFailed, renameProne } = {}) {
   // Pin the status/list reads to the dialect the install ACTUALLY landed on. In
@@ -4184,12 +4201,15 @@ async function verifyInstalled(target, dialect, { batchFailed, renameProne } = {
   // (codex P1).
   const get = (route, opts) =>
     dialect === "legacy" ? managerCall(route, opts) : managerV2(route, opts);
-  const status = await waitForQueueDrain({ get });
+  const deadline = Date.now() + INSTALL_VERIFY_BUDGET_MS;
+  const status = await waitForQueueDrain({ timeoutMs: INSTALL_VERIFY_BUDGET_MS, get });
   let installed = null;
   let listError = false;
   try {
     installed = await get("customnode/installed", {
-      signal: AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS),
+      signal: AbortSignal.timeout(
+        Math.max(1000, Math.min(MANAGER_FETCH_TIMEOUT_MS, deadline - Date.now())),
+      ),
     });
   } catch {
     listError = true;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3971,13 +3971,16 @@ const NODES_INSTALL_COMMAND_BUDGET_MS = 25000;
  *  message like "install timed out" arrives as a plain Error from
  *  managerV2/managerCall's HTTP handling — NEVER an AbortError/TimeoutError,
  *  which only the fetch/abort primitives produce). detectManagerDialect's own
- *  budget abort is a plain Error by design, so it is matched by its exact
- *  message. */
+ *  budget abort is a plain Error by design, matched by its exact full-sentence
+ *  PREFIX (anchored — codex r3 P2: a substring match could swallow a real
+ *  verdict that merely QUOTES the phrase). */
 function isStallError(err) {
   return (
     err?.name === "AbortError" ||
     err?.name === "TimeoutError" ||
-    /aborted mid-probe/.test(String(err?.message ?? ""))
+    String(err?.message ?? "").startsWith(
+      "ComfyUI-Manager dialect detection was aborted mid-probe",
+    )
   );
 }
 
@@ -12613,13 +12616,14 @@ const GRAPH_TOOL_EXECUTORS = {
     const remaining = () => Math.max(0, commandDeadline - Date.now());
     // A per-call cap that also respects what the command budget has left.
     const bounded = (ms) => Math.max(1, Math.min(ms, remaining()));
-    // A stall caught AFTER the command budget ran out is reworded as what it
-    // is — the Manager stopped answering in time — claiming only the state the
-    // phase can honestly claim (never a false failure, never a false "nothing
-    // happened"). Any non-stall error, or a stall with budget left (the per-
-    // fetch cap fired first), surfaces unchanged with its real evidence.
+    // A stall caught once the command budget HAS run out is reworded as what
+    // it is — the Manager stopped answering in time — claiming only the state
+    // the phase can honestly claim (never a false failure, never a false
+    // "nothing happened"). Any non-stall error, or a stall surfaced BEFORE the
+    // deadline (the per-fetch cap fired first — budget remains), passes
+    // through unchanged with its real evidence.
     const translateStall = (err, phase) => {
-      if (commandDeadline - Date.now() > 50 || !isStallError(err)) return err;
+      if (commandDeadline - Date.now() > 0 || !isStallError(err)) return err;
       const budget = `${Math.round(NODES_INSTALL_COMMAND_BUDGET_MS / 1000)}s`;
       const what = String(id ?? repository);
       if (phase === "detect" || phase === "reprobe") {
@@ -12639,6 +12643,18 @@ const GRAPH_TOOL_EXECUTORS = {
             `the request may have landed before the abort. Check panel_node_queue_status ` +
             `and panel_list_nodes BEFORE retrying, or a blind retry can queue the install ` +
             `twice.`,
+        );
+      }
+      if (phase === "verify") {
+        // Submit AND start returned — the install is queued and the start was
+        // acknowledged; only the outcome check ran out of time. (Today's
+        // verifyInstalled is internally bounded and never throws a stall — this
+        // branch guards the claim IF that ever changes. #671 codex r3.)
+        return new Error(
+          `the install of "${what}" was QUEUED and the queue start was acknowledged, ` +
+            `but the outcome could not be VERIFIED within the ${budget} command budget. ` +
+            `This is NOT a failure — poll panel_node_queue_status and VERIFY with ` +
+            `panel_list_nodes.`,
         );
       }
       // "start": the submit LANDED — the install is queued; only the queue
@@ -12760,6 +12776,7 @@ const GRAPH_TOOL_EXECUTORS = {
       // inconclusive result returns an honest unverified status (never a silent
       // success, never a false failure). #232 + codex rounds 1-2. The verify
       // draws on whatever the command budget has LEFT (#671).
+      phase = "verify";
       const outcome = await verifyInstalled(target, dialect, { batchFailed, renameProne, budgetMs: remaining() });
       if (outcome.state === "failed") throw new Error(outcome.message);
       if (outcome.state === "installed") {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3954,6 +3954,29 @@ async function reProbeManagerDialect({ signal } = {}) {
  *  status, list are ALL bounded). */
 const MANAGER_FETCH_TIMEOUT_MS = 15000;
 
+/** #671 — ONE budget for the WHOLE nodes_install command (dialect detect →
+ *  submit → queue/start → verify). The orchestrator relays nodes_install with a
+ *  30s reply timeout; per-call 15s caps alone can STACK past that on a
+ *  slow-but-alive Manager (two stalled calls = 30s before verification even
+ *  starts), so the tab never replied and the relay reported a wedged canvas
+ *  (`did not reply to "nodes_install" within 30000 ms`) while the install was
+ *  proceeding. 25s leaves the relay 5s of slack. Mirrors the reasoning of
+ *  UPDATE_VERIFY_BUDGET_MS (#364), lifted from the verify phase to the command. */
+const NODES_INSTALL_COMMAND_BUDGET_MS = 25000;
+
+/** #671 — did this error come from a request that never got an answer (our
+ *  AbortSignal firing, or a fetch stall), as opposed to a REAL response with a
+ *  real verdict? Only stall errors may be reworded as a budget exhaustion —
+ *  rewording a genuine HTTP/error verdict would destroy its evidence. */
+function isStallError(err) {
+  const msg = String(err?.message ?? err ?? "");
+  return (
+    err?.name === "AbortError" ||
+    err?.name === "TimeoutError" ||
+    /aborted|timed?\s*out/i.test(msg)
+  );
+}
+
 /** AbortSignal.any with a two-listener fallback for runtimes that predate it
  *  (baseline 2024-03). A re-probe must stay bounded on EVERY frontend the panel
  *  can load on: calling a missing AbortSignal.any inside managerProbe would
@@ -4101,17 +4124,19 @@ async function fetchObjectInfo() {
  *  answering it (no 405, no GET retry); a GET-only build then starts its queue
  *  instead of failing the whole install. Mirrors the orchestrator's
  *  managerQueueControl (src/services/node-management.ts, #551). `call` is
- *  managerV2 (adds the /v2 prefix) or managerCall (absolute legacy route). */
-async function managerQueueControl(call, route) {
+ *  managerV2 (adds the /v2 prefix) or managerCall (absolute legacy route).
+ *  `signal` is an optional caller budget (#671) composed with the per-fetch
+ *  cap so a stalled start cannot outlive the command's reply window. */
+async function managerQueueControl(call, route, { signal } = {}) {
   try {
-    await call(route, { method: "POST", signal: AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS) });
+    await call(route, { method: "POST", signal: anyAbortSignal([AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS), signal]) });
   } catch (err) {
     // Only a 405 is a method signal we can negotiate; a 404 ("not reachable") or
     // any other error means the route/POST genuinely failed — surface it. A 405
     // leaves the route REGISTERED, so the GET retry hits the real GET handler
     // (not ComfyUI's frontend catchall, which only serves UNREGISTERED GETs).
     if (!isMethodNotAllowed(err)) throw err;
-    await call(route, { signal: AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS) });
+    await call(route, { signal: anyAbortSignal([AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS), signal]) });
   }
 }
 
@@ -4166,17 +4191,20 @@ async function waitForQueueDrain({ timeoutMs = 120000, intervalMs = 1500, get = 
   return status; // deadline hit
 }
 
-/** Budget for the post-enqueue install verification (#671). Bounded well under
+/** Default budget for the post-enqueue install verification (#671), used only
+ *  when the caller does not thread a command budget through. Bounded well under
  *  the orchestrator's per-command reply timeout (panel_install_node relays
  *  nodes_install with 30s) so a genuine, slow install — cloning a pack and
  *  installing its pip deps routinely outlives 30s — reports an honest
  *  "unverified/pending" with the ui_id to poll (panel_node_queue_status)
  *  instead of the reply never leaving the tab: the orchestrator then reported
  *  `did not reply to "nodes_install" within 30000 ms` on a LIVE, responsive
- *  canvas while the install was proceeding fine. A bounded verify can only
- *  degrade a verified success to "pending" — classifyInstallOutcome asserts
- *  failure ONLY on a positively-drained queue, so the budget can never
- *  manufacture a false failure. Mirrors UPDATE_VERIFY_BUDGET_MS (#364). */
+ *  canvas while the install was proceeding fine. nodes_install passes its
+ *  REMAINING command budget (NODES_INSTALL_COMMAND_BUDGET_MS) as `budgetMs`, so
+ *  the whole command — not just this phase — fits the relay window. A bounded
+ *  verify can only degrade a verified success to "pending" —
+ *  classifyInstallOutcome asserts failure ONLY on a positively-drained queue,
+ *  so the budget can never manufacture a false failure. */
 const INSTALL_VERIFY_BUDGET_MS = 15000;
 
 /**
@@ -4189,10 +4217,11 @@ const INSTALL_VERIFY_BUDGET_MS = 15000;
  * tri-state — never an early throw). Returns { state, status, message }.
  *
  * ONE shared deadline covers the drain wait AND the list read (#671): the whole
- * verification must fit inside the orchestrator's reply window, or the reply —
- * success or honest "pending" — never reaches the caller.
+ * verification must fit inside `budgetMs` (the caller's remaining reply budget,
+ * defaulting to INSTALL_VERIFY_BUDGET_MS), or the reply — success or honest
+ * "pending" — never reaches the caller.
  */
-async function verifyInstalled(target, dialect, { batchFailed, renameProne } = {}) {
+async function verifyInstalled(target, dialect, { batchFailed, renameProne, budgetMs } = {}) {
   // Pin the status/list reads to the dialect the install ACTUALLY landed on. In
   // the normal case this equals managerGet's cached detection; after the #485
   // legacy fallback the cache still holds the detected v2 dialect, so re-deriving
@@ -4201,8 +4230,9 @@ async function verifyInstalled(target, dialect, { batchFailed, renameProne } = {
   // (codex P1).
   const get = (route, opts) =>
     dialect === "legacy" ? managerCall(route, opts) : managerV2(route, opts);
-  const deadline = Date.now() + INSTALL_VERIFY_BUDGET_MS;
-  const status = await waitForQueueDrain({ timeoutMs: INSTALL_VERIFY_BUDGET_MS, get });
+  const budget = Math.max(0, budgetMs ?? INSTALL_VERIFY_BUDGET_MS);
+  const deadline = Date.now() + budget;
+  const status = await waitForQueueDrain({ timeoutMs: budget, get });
   let installed = null;
   let listError = false;
   try {
@@ -12566,112 +12596,185 @@ const GRAPH_TOOL_EXECUTORS = {
     if (!id && !repository) {
       throw new Error("id (registry id or author/repo) or repository (git URL) is required");
     }
-    const detected = await detectManagerDialect();
-    const ui_id = crypto.randomUUID();
-    const client_id = api.clientId ?? api.initialClientId ?? "comfyui-mcp-panel";
-    // A git URL or an owner/repo id can install under a directory name that
-    // differs from the repo name (e.g. TenStrip/10S-Comfy-nodes → 10S_Nodes), so
-    // its on-disk presence can't be confirmed OR ruled out by name — absence is
-    // NOT proof of failure for such targets (codex round 3). A claimed registry
-    // id is identifiable (matched via cnr_id/aux_id), so its absence IS proof.
-    const renameProne = !!installGitUrl(args) || String(id ?? "").includes("/");
-    // Every Manager mutation is bounded (codex round 2 #5).
-    const post = (body) => ({ method: "POST", body, signal: AbortSignal.timeout(MANAGER_FETCH_TIMEOUT_MS) });
-    // SUBMIT the install (enqueue only — NOT start) for a given dialect. Kept
-    // separate from queue/start so the #485 unreachable-fallback below can never
-    // re-run a submission that already landed (a start failure must not double-
-    // fire the install — codex P0). Returns the on-disk `target` (already the
-    // repo NAME for a git URL — #232 verifies against it) plus the v2-batch
-    // synchronous `failed[]` (FEEDS the tri-state gate as EVIDENCE — never an
-    // early throw, codex round 2 #4).
-    const submitInstall = async (dialect) => {
-      // buildInstallRequest (./lib/manager-install.js) derives the repo NAME for
-      // a git URL (arriving via id OR repository, any protocol) and picks the
-      // right per-dialect payload — issues #187/#182/#184. A full URL is never
-      // sent as `id` (v4 would silently mark it "done"; 3.x fails late).
-      const req = buildInstallRequest(dialect, args, ui_id);
-      const target = dialect === "v2" ? req.params.id : req.body.id;
-      let batchFailed;
-      if (dialect === "v2") {
-        await managerV2("manager/queue/task", post({ kind: "install", params: req.params, ui_id, client_id }));
-      } else if (dialect === "v2-batch") {
-        const res = await managerV2("manager/queue/batch", post({ install: [req.body] }));
-        batchFailed = Array.isArray(res?.failed) ? res.failed : undefined;
-      } else {
-        await managerCall("manager/queue/install", post(req.body));
+    // #671: ONE budget for the WHOLE command. The orchestrator relays
+    // nodes_install with a 30s reply timeout; per-call 15s caps can STACK past
+    // that on a slow-but-alive Manager (a stalled submit + a stalled start =
+    // 30s before verification even starts), and the 120s drain wait made it
+    // certain — the tab never replied and the relay reported a wedged canvas
+    // (`did not reply to "nodes_install" within 30000 ms`) while the install
+    // was proceeding. Every phase below draws on this single deadline, so the
+    // reply — success, honest pending, or an honest error — ALWAYS leaves the
+    // tab inside the window.
+    const commandDeadline = Date.now() + NODES_INSTALL_COMMAND_BUDGET_MS;
+    const remaining = () => Math.max(0, commandDeadline - Date.now());
+    // A per-call cap that also respects what the command budget has left.
+    const bounded = (ms) => Math.max(1, Math.min(ms, remaining()));
+    // A stall caught AFTER the command budget ran out is reworded as what it
+    // is — the Manager stopped answering in time — claiming only the state the
+    // phase can honestly claim (never a false failure, never a false "nothing
+    // happened"). Any non-stall error, or a stall with budget left (the per-
+    // fetch cap fired first), surfaces unchanged with its real evidence.
+    const translateStall = (err, phase) => {
+      if (commandDeadline - Date.now() > 50 || !isStallError(err)) return err;
+      const budget = `${Math.round(NODES_INSTALL_COMMAND_BUDGET_MS / 1000)}s`;
+      const what = String(id ?? repository);
+      if (phase === "detect") {
+        return new Error(
+          `the ComfyUI-Manager did not answer dialect detection within the ${budget} ` +
+            `command budget — NOTHING was queued. The Manager is answering slowly or ` +
+            `not at all; retry shortly, or check the ComfyUI server log.`,
+        );
       }
-      return { target, batchFailed };
+      if (phase === "submit") {
+        return new Error(
+          `the ComfyUI-Manager did not answer the install request for "${what}" within ` +
+            `the ${budget} command budget. Whether the install was QUEUED is UNKNOWN — ` +
+            `the request may have landed before the abort. Check panel_node_queue_status ` +
+            `and panel_list_nodes BEFORE retrying, or a blind retry can queue the install ` +
+            `twice.`,
+        );
+      }
+      // "start": the submit LANDED — the install is queued; only the queue
+      // start is unconfirmed. Never claim failure here.
+      return new Error(
+        `the install of "${what}" was QUEUED, but the ComfyUI-Manager did not answer ` +
+          `queue/start within the ${budget} command budget, so the queue may not be ` +
+          `running. Poll panel_node_queue_status; if the task stays pending with the ` +
+          `queue idle, the start did not land — check the ComfyUI server log before ` +
+          `retrying.`,
+      );
     };
-    // #485: a dialect-routed SUBMIT that reports the Manager "unreachable" (a /v2
-    // mutation 404s) can still succeed on the ABSOLUTE released-3.x routes — a
-    // build can answer the /v2 queue-status probe (so detection picks v2 /
-    // v2-batch) yet 404 the /v2 MUTATION routes while /manager/queue/install
-    // serves fine. nodes_list already degrades this way for the installed-node
-    // list; without the same fallback here, install threw a false "not reachable"
-    // even though panel_list_nodes worked. So on an unreachable signal from a
-    // non-legacy dialect, retry the SUBMIT via the legacy dialect before
-    // surfacing the error. The fallback wraps ONLY the enqueue: if the submit
-    // already succeeded, a later queue/start failure must NOT re-submit.
-    //
-    // #605: the unreachable verdict can ALSO mean the CACHED dialect outlived a
-    // backend restart that swapped Manager generations (a stale "legacy" cache
-    // aims the submit at /manager/queue/install, which a restarted v4 backend
-    // does not serve — and the old legacy-only fallback then threw a false
-    // "not reachable"). A 404 is a route-level rejection — no handler ran,
-    // NOTHING was enqueued — so re-submitting on the re-probed live dialect
-    // cannot double-fire the install. Re-probe ONCE; dialectRetryTarget picks
-    // the retry: the fresh verdict when it changed, else the #485 legacy last
-    // resort (null when nothing is left — the original error then surfaces).
-    let dialect = detected;
-    let submitted;
+    // Tracks how far the command got so a budget-exhausted stall can claim
+    // exactly the state that phase can vouch for (#671). Declared OUTSIDE the
+    // try so the catch can read it.
+    let phase = "detect";
     try {
-      submitted = await submitInstall(dialect);
-    } catch (err) {
-      // codex P0: the retry gate is the PROVEN route-level rejection (the 404
-      // marker), never the broader "not reachable" — a no-response transport
-      // failure says nothing about whether the POST landed, and re-submitting
-      // then would double-fire the install.
-      if (!isManagerRouteMissing(err)) throw err;
-      const retry = dialectRetryTarget(dialect, await reProbeManagerDialect());
-      if (!retry) throw err;
-      dialect = retry;
-      submitted = await submitInstall(retry);
-    }
-    // The submission landed. NOW start the queue on the SAME (possibly
-    // fallen-back) dialect. queue/start goes through managerQueueControl so a
-    // GET-only 3.x build negotiates POST→GET on HTTP 405 instead of failing the
-    // install (#486). A start failure here is surfaced as-is — the install is
-    // already queued, so re-running the submit would double-fire it.
-    await managerQueueControl(dialect === "legacy" ? managerCall : managerV2, "manager/queue/start");
-    const { target, batchFailed } = submitted;
-    // Resolve the true outcome. Throw ONLY on positive failure evidence; an
-    // inconclusive result returns an honest unverified status (never a silent
-    // success, never a false failure). #232 + codex rounds 1-2.
-    const outcome = await verifyInstalled(target, dialect, { batchFailed, renameProne });
-    if (outcome.state === "failed") throw new Error(outcome.message);
-    if (outcome.state === "installed") {
+      const detected = await detectManagerDialect({
+        signal: AbortSignal.timeout(bounded(MANAGER_FETCH_TIMEOUT_MS)),
+      });
+      const ui_id = crypto.randomUUID();
+      const client_id = api.clientId ?? api.initialClientId ?? "comfyui-mcp-panel";
+      // A git URL or an owner/repo id can install under a directory name that
+      // differs from the repo name (e.g. TenStrip/10S-Comfy-nodes → 10S_Nodes), so
+      // its on-disk presence can't be confirmed OR ruled out by name — absence is
+      // NOT proof of failure for such targets (codex round 3). A claimed registry
+      // id is identifiable (matched via cnr_id/aux_id), so its absence IS proof.
+      const renameProne = !!installGitUrl(args) || String(id ?? "").includes("/");
+      // Every Manager mutation is bounded (codex round 2 #5) — and now also by
+      // the remaining command budget (#671).
+      const post = (body) => ({
+        method: "POST",
+        body,
+        signal: AbortSignal.timeout(bounded(MANAGER_FETCH_TIMEOUT_MS)),
+      });
+      // SUBMIT the install (enqueue only — NOT start) for a given dialect. Kept
+      // separate from queue/start so the #485 unreachable-fallback below can never
+      // re-run a submission that already landed (a start failure must not double-
+      // fire the install — codex P0). Returns the on-disk `target` (already the
+      // repo NAME for a git URL — #232 verifies against it) plus the v2-batch
+      // synchronous `failed[]` (FEEDS the tri-state gate as EVIDENCE — never an
+      // early throw, codex round 2 #4).
+      const submitInstall = async (dialect) => {
+        // buildInstallRequest (./lib/manager-install.js) derives the repo NAME for
+        // a git URL (arriving via id OR repository, any protocol) and picks the
+        // right per-dialect payload — issues #187/#182/#184. A full URL is never
+        // sent as `id` (v4 would silently mark it "done"; 3.x fails late).
+        const req = buildInstallRequest(dialect, args, ui_id);
+        const target = dialect === "v2" ? req.params.id : req.body.id;
+        let batchFailed;
+        if (dialect === "v2") {
+          await managerV2("manager/queue/task", post({ kind: "install", params: req.params, ui_id, client_id }));
+        } else if (dialect === "v2-batch") {
+          const res = await managerV2("manager/queue/batch", post({ install: [req.body] }));
+          batchFailed = Array.isArray(res?.failed) ? res.failed : undefined;
+        } else {
+          await managerCall("manager/queue/install", post(req.body));
+        }
+        return { target, batchFailed };
+      };
+      // #485: a dialect-routed SUBMIT that reports the Manager "unreachable" (a /v2
+      // mutation 404s) can still succeed on the ABSOLUTE released-3.x routes — a
+      // build can answer the /v2 queue-status probe (so detection picks v2 /
+      // v2-batch) yet 404 the /v2 MUTATION routes while /manager/queue/install
+      // serves fine. nodes_list already degrades this way for the installed-node
+      // list; without the same fallback here, install threw a false "not reachable"
+      // even though panel_list_nodes worked. So on an unreachable signal from a
+      // non-legacy dialect, retry the SUBMIT via the legacy dialect before
+      // surfacing the error. The fallback wraps ONLY the enqueue: if the submit
+      // already succeeded, a later queue/start failure must NOT re-submit.
+      //
+      // #605: the unreachable verdict can ALSO mean the CACHED dialect outlived a
+      // backend restart that swapped Manager generations (a stale "legacy" cache
+      // aims the submit at /manager/queue/install, which a restarted v4 backend
+      // does not serve — and the old legacy-only fallback then threw a false
+      // "not reachable"). A 404 is a route-level rejection — no handler ran,
+      // NOTHING was enqueued — so re-submitting on the re-probed live dialect
+      // cannot double-fire the install. Re-probe ONCE; dialectRetryTarget picks
+      // the retry: the fresh verdict when it changed, else the #485 legacy last
+      // resort (null when nothing is left — the original error then surfaces).
+      phase = "submit";
+      let dialect = detected;
+      let submitted;
+      try {
+        submitted = await submitInstall(dialect);
+      } catch (err) {
+        // codex P0: the retry gate is the PROVEN route-level rejection (the 404
+        // marker), never the broader "not reachable" — a no-response transport
+        // failure says nothing about whether the POST landed, and re-submitting
+        // then would double-fire the install.
+        if (!isManagerRouteMissing(err)) throw err;
+        const retry = dialectRetryTarget(
+          dialect,
+          await reProbeManagerDialect({ signal: AbortSignal.timeout(bounded(MANAGER_FETCH_TIMEOUT_MS)) }),
+        );
+        if (!retry) throw err;
+        dialect = retry;
+        submitted = await submitInstall(retry);
+      }
+      // The submission landed. NOW start the queue on the SAME (possibly
+      // fallen-back) dialect. queue/start goes through managerQueueControl so a
+      // GET-only 3.x build negotiates POST→GET on HTTP 405 instead of failing the
+      // install (#486). A start failure here is surfaced as-is — the install is
+      // already queued, so re-running the submit would double-fire it.
+      phase = "start";
+      await managerQueueControl(
+        dialect === "legacy" ? managerCall : managerV2,
+        "manager/queue/start",
+        { signal: AbortSignal.timeout(bounded(MANAGER_FETCH_TIMEOUT_MS)) },
+      );
+      const { target, batchFailed } = submitted;
+      // Resolve the true outcome. Throw ONLY on positive failure evidence; an
+      // inconclusive result returns an honest unverified status (never a silent
+      // success, never a false failure). #232 + codex rounds 1-2. The verify
+      // draws on whatever the command budget has LEFT (#671).
+      const outcome = await verifyInstalled(target, dialect, { batchFailed, renameProne, budgetMs: remaining() });
+      if (outcome.state === "failed") throw new Error(outcome.message);
+      if (outcome.state === "installed") {
+        return {
+          queued: true,
+          installed: true,
+          verified: true,
+          ui_id,
+          id: target,
+          dialect,
+          note:
+            "Installed and VERIFIED present in custom_nodes. A ComfyUI restart " +
+            "(panel_restart_comfyui) is usually required to load new nodes.",
+        };
+      }
       return {
         queued: true,
-        installed: true,
-        verified: true,
+        installed: false,
+        verified: false,
+        pending: outcome.state === "unverified",
         ui_id,
         id: target,
         dialect,
-        note:
-          "Installed and VERIFIED present in custom_nodes. A ComfyUI restart " +
-          "(panel_restart_comfyui) is usually required to load new nodes.",
+        note: outcome.message,
       };
+    } catch (err) {
+      throw translateStall(err, phase);
     }
-    return {
-      queued: true,
-      installed: false,
-      verified: false,
-      pending: outcome.state === "unverified",
-      ui_id,
-      id: target,
-      dialect,
-      note: outcome.message,
-    };
   },
 
   // Update an ALREADY-INSTALLED pack to latest/nightly via the built-in Manager.

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3964,16 +3964,20 @@ const MANAGER_FETCH_TIMEOUT_MS = 15000;
  *  UPDATE_VERIFY_BUDGET_MS (#364), lifted from the verify phase to the command. */
 const NODES_INSTALL_COMMAND_BUDGET_MS = 25000;
 
-/** #671 — did this error come from a request that never got an answer (our
- *  AbortSignal firing, or a fetch stall), as opposed to a REAL response with a
- *  real verdict? Only stall errors may be reworded as a budget exhaustion —
- *  rewording a genuine HTTP/error verdict would destroy its evidence. */
+/** #671 — did this error come from a request that never got an answer (one of
+ *  OUR AbortSignals firing), as opposed to a REAL response with a real verdict?
+ *  Only stall errors may be reworded as a budget exhaustion — rewording a
+ *  genuine Manager verdict would destroy its evidence (codex r2 P1: a server
+ *  message like "install timed out" arrives as a plain Error from
+ *  managerV2/managerCall's HTTP handling — NEVER an AbortError/TimeoutError,
+ *  which only the fetch/abort primitives produce). detectManagerDialect's own
+ *  budget abort is a plain Error by design, so it is matched by its exact
+ *  message. */
 function isStallError(err) {
-  const msg = String(err?.message ?? err ?? "");
   return (
     err?.name === "AbortError" ||
     err?.name === "TimeoutError" ||
-    /aborted|timed?\s*out/i.test(msg)
+    /aborted mid-probe/.test(String(err?.message ?? ""))
   );
 }
 
@@ -12618,7 +12622,10 @@ const GRAPH_TOOL_EXECUTORS = {
       if (commandDeadline - Date.now() > 50 || !isStallError(err)) return err;
       const budget = `${Math.round(NODES_INSTALL_COMMAND_BUDGET_MS / 1000)}s`;
       const what = String(id ?? repository);
-      if (phase === "detect") {
+      if (phase === "detect" || phase === "reprobe") {
+        // Detection — and the #605 RE-PROBE, which only runs after a PROVEN
+        // 404 (no handler ran, so no mutation was ever in flight) — never
+        // reached a mutation: nothing was queued, and a retry is safe.
         return new Error(
           `the ComfyUI-Manager did not answer dialect detection within the ${budget} ` +
             `command budget — NOTHING was queued. The Manager is answering slowly or ` +
@@ -12723,12 +12730,18 @@ const GRAPH_TOOL_EXECUTORS = {
         // failure says nothing about whether the POST landed, and re-submitting
         // then would double-fire the install.
         if (!isManagerRouteMissing(err)) throw err;
+        // The submit 404'd — PROVEN route-level rejection, no handler ran, so
+        // NOTHING is queued: a stall in the re-probe keeps the "nothing was
+        // queued" claim honest (#671 codex r2), and the retry submit below
+        // re-marks the phase before any mutation is in flight again.
+        phase = "reprobe";
         const retry = dialectRetryTarget(
           dialect,
           await reProbeManagerDialect({ signal: AbortSignal.timeout(bounded(MANAGER_FETCH_TIMEOUT_MS)) }),
         );
         if (!retry) throw err;
         dialect = retry;
+        phase = "submit";
         submitted = await submitInstall(retry);
       }
       // The submission landed. NOW start the queue on the SAME (possibly


### PR DESCRIPTION
Install path times out despite a live, responsive canvas tab.

closes #671