### PR TITLE
run targeting: to_node_id drift guard false-positives on COMFY_AUTOGROW_V3 dynamic-input nodes

### DIFF
--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -25,6 +25,8 @@ import {
   repairScopeInBody,
   promptContentHash,
   promptContentHashFromBody,
+  canonicalizePrompt,
+  diffPromptCanons,
   collectVolatileInputs,
   verifyScopedPromptBody,
   scopeDroppedError,
@@ -2194,4 +2196,228 @@ test("#556: a NON-output target is refused (not_output) — it can never be an e
   const res = resolveRunToNodeTarget(root, null, 3);
   assert.equal(res.ok, false);
   assert.equal(res.code, "not_output");
+});
+
+// ---------------------------------------------------------------------------
+// #659 — JSON-invisible widget values (undefined / function / symbol) must not
+// false-positive the #556 drift guard, and a graph_changed refusal must say
+// WHAT differed instead of asserting a cause.
+// ---------------------------------------------------------------------------
+
+test("#659 promptContentHash: an input whose value JSON cannot transmit is absent on BOTH channels — in-memory output and wire body hash identically", () => {
+  // graphToPrompt assigns inputs[name] = widget.value unconditionally for
+  // serialized widgets, so an async-populated combo that never got a value
+  // (the issue's OllamaConnectivityV2 "model": ((), {}) — empty options, no
+  // default) or a multi-spec COMFY_AUTOGROW_V3 shim widget lands in the
+  // in-memory output as a key with an undefined value. JSON.stringify DROPS
+  // that key from the POST body, so the parsed body never has it — and the
+  // two hashes of the SAME untouched graph used to differ deterministically.
+  const inMemory = {
+    "3": { class_type: "KSampler", inputs: { steps: 20, model: undefined } },
+    "9": { class_type: "SaveImage", inputs: {} },
+  };
+  const wireBody = (inputs3) =>
+    JSON.stringify({ prompt: { "3": { class_type: "KSampler", inputs: inputs3 }, "9": { class_type: "SaveImage", inputs: {} } } });
+  assert.equal(
+    promptContentHash(inMemory),
+    promptContentHashFromBody(wireBody({ steps: 20 })),
+    "undefined-valued key in memory, key absent on the wire ⇒ SAME hash",
+  );
+  // Functions/symbols are dropped from the wire body exactly like undefined.
+  const withFn = {
+    "3": { class_type: "KSampler", inputs: { steps: 20, cb: () => {} } },
+    "9": { class_type: "SaveImage", inputs: {} },
+  };
+  assert.equal(promptContentHash(withFn), promptContentHashFromBody(wireBody({ steps: 20 })),
+    "a function-valued input is equally invisible to the wire");
+  // null IS wire-representable — kept on both channels, so it hashes fine…
+  const withNull = {
+    "3": { class_type: "KSampler", inputs: { steps: 20, model: null } },
+    "9": { class_type: "SaveImage", inputs: {} },
+  };
+  assert.equal(promptContentHash(withNull), promptContentHashFromBody(wireBody({ steps: 20, model: null })),
+    "an explicit null survives the wire and stays covered");
+  // …and undefined → null is a change the wire CARRIES: it must mismatch.
+  assert.notEqual(
+    promptContentHash(inMemory),
+    promptContentHashFromBody(wireBody({ steps: 20, model: null })),
+    "a key that APPEARS on the wire (undefined → null/value) is genuine drift, still detected",
+  );
+  // value → absent is equally a wire-carried change: still detected.
+  assert.notEqual(
+    promptContentHash(withNull),
+    promptContentHashFromBody(wireBody({ steps: 20 })),
+    "a key that VANISHES from the wire (value → undefined) is genuine drift, still detected",
+  );
+});
+
+test("#659 guard: OUR marked post whose body lacks only a JSON-invisible input is OBSERVED, not refused as graph_changed", async () => {
+  const spy = makeServer();
+  const outputAtQueue = {
+    "3": { class_type: "KSampler", inputs: { steps: 20, model: undefined } },
+    "14": { class_type: "PreviewAny", inputs: {} },
+  };
+  const guard = createScopedRunGuard({
+    origFetchApi: spy,
+    execIds: ["14"],
+    contentHash: promptContentHash(outputAtQueue),
+    contentCanon: canonicalizePrompt(outputAtQueue),
+    batch: 1,
+    toNodeId: 14,
+    queueMark: MARK_A,
+  });
+  // The frontend's body: JSON.stringify dropped the undefined-valued key.
+  const wireOutput = JSON.parse(JSON.stringify(outputAtQueue));
+  const res = await guard(...promptPost(frontendBody({ output: wireOutput, targets: ["14"] })));
+  assert.equal(res.status, 200, "the same graph through the wire is OUR dispatch");
+  assert.equal(guard.state.observed, 1);
+  assert.equal(spy.calls.length, 1, "dispatched, not refused");
+});
+
+test("#659 guard: normalization is NOT tolerance — the previously-undefined input materializing in the body is genuine drift ⇒ refused, and the refusal NAMES the input", async () => {
+  const spy = makeServer();
+  const outputAtQueue = {
+    "3": { class_type: "KSampler", inputs: { steps: 20, model: undefined } },
+    "14": { class_type: "PreviewAny", inputs: {} },
+  };
+  const guard = createScopedRunGuard({
+    origFetchApi: spy,
+    execIds: ["14"],
+    contentHash: promptContentHash(outputAtQueue),
+    contentCanon: canonicalizePrompt(outputAtQueue),
+    batch: 1,
+    toNodeId: 14,
+    queueMark: MARK_A,
+  });
+  const drifted = {
+    "3": { class_type: "KSampler", inputs: { steps: 20, model: "llama3" } },
+    "14": { class_type: "PreviewAny", inputs: {} },
+  };
+  const res = await guard(...promptPost(frontendBody({ output: drifted, targets: ["14"] })));
+  assert.equal(res.status, 400, "a mid-window edit into the same input still refuses");
+  assert.equal(spy.calls.length, 0, "the drifted prompt never left the tab");
+  assert.equal(guard.state.droppedReason, "graph_changed");
+  assert.match(guard.state.dropped, /3 model/, "the refusal names the differing execId inputName pair");
+  assert.match(guard.state.dropped, /Nothing was queued/);
+});
+
+test("#659 diffPromptCanons: names input-level changes, node add/remove, and class_type changes — and never throws on odd input", () => {
+  const a = canonicalizePrompt({
+    "3": { class_type: "KSampler", inputs: { steps: 20, model: ["4", 0] } },
+    "9": { class_type: "SaveImage", inputs: {} },
+  });
+  const b = canonicalizePrompt({
+    "3": { class_type: "KSampler", inputs: { steps: 25 } },
+    "10": { class_type: "PreviewAny", inputs: {} },
+  });
+  const tokens = diffPromptCanons(a, b);
+  assert.ok(tokens.includes("3 steps"), "a changed value names the pair");
+  assert.ok(tokens.includes("3 model"), "an input present on only one side names the pair");
+  assert.ok(tokens.includes("9 (node only in queued prompt)"), "a removed node is named");
+  assert.ok(tokens.includes("10 (node only in dispatch body)"), "an added node is named");
+  const c = canonicalizePrompt({ "3": { class_type: "OTHER", inputs: {} } });
+  assert.ok(diffPromptCanons(a, c).includes("3 (class_type changed)"), "a replaced node is named");
+  assert.deepEqual(diffPromptCanons(a, a), [], "identical canons have no drift");
+  assert.equal(diffPromptCanons(null, b), null, "an unusable canon degrades to null");
+  assert.equal(diffPromptCanons("junk", b), null);
+  assert.equal(diffPromptCanons(a, undefined), null);
+});
+
+test("#659 scopeDroppedError: a graph_changed refusal with drift tokens leads with the differing pairs; without them the hook guidance remains", () => {
+  const withDrift = scopeDroppedError({
+    toNodeId: 143,
+    verdict: { ok: false, reason: "graph_changed", drift: ["42 model", "7 (node only in dispatch body)"] },
+  });
+  assert.match(withDrift, /node 143/);
+  assert.match(withDrift, /42 model/);
+  assert.match(withDrift, /7 \(node only in dispatch body\)/);
+  assert.match(withDrift, /Retrying is safe/);
+  assert.match(withDrift, /Nothing was queued/);
+  const bare = scopeDroppedError({ toNodeId: 116, verdict: { ok: false, reason: "graph_changed", drift: null } });
+  assert.match(bare, /queue-time widget hook/, "no diff available ⇒ the candidate-cause guidance stays");
+  assert.match(bare, /Retrying is safe \(nothing was queued\)/);
+});
+
+test("#659 integration: a graph whose serialized widget value is undefined (the issue's OllamaConnectivityV2 shape) no longer false-refuses — the scoped run DISPATCHES", async () => {
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    // Reproduced live against ComfyUI_frontend 1.47.12 (#659): graphToPrompt's
+    // in-memory output carries `model: undefined` for the empty-options combo;
+    // the POST body drops the key — the old hash pair differed 5/5 with zero
+    // edits and every scoped run was refused as "graph CHANGED".
+    const output = {
+      "3": { class_type: "KSampler", inputs: { steps: 20 } },
+      "7": { class_type: "OllamaConnectivityV2", inputs: { url: "http://127.0.0.1:11434", model: undefined } },
+      "14": { class_type: "PreviewAny", inputs: {} },
+    };
+    const app = makeFrontend({ shape: "shim", apiTarget, output });
+    const result = await dispatchScopedRun({
+      app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
+      verifyTimeoutMs: 500,
+    });
+    assert.equal(result.outcome, "dispatched", "no user edit ⇒ no drift ⇒ the scoped run goes out");
+    assert.equal(server.calls.length, 1);
+    const posted = JSON.parse(server.calls[0].options.body);
+    assert.deepEqual(posted.partial_execution_targets, ["14"]);
+    assert.ok(!("model" in posted.prompt["7"].inputs), "the wire body never carried the JSON-invisible key");
+  } finally {
+    stop();
+  }
+});
+
+test("#659 integration: a graph_changed refusal through dispatchScopedRun NAMES what differed — value edits, rewired links, added/removed nodes", async () => {
+  const stop = keepAlive();
+  try {
+    for (const { drift, token } of [
+      { drift: { "3": { class_type: "KSampler", inputs: { steps: 25 } } }, token: /3 steps/ },
+      { drift: { "9": { class_type: "SaveImage", inputs: { images: ["4", 0] } } }, token: /9 images/ },
+      { drift: { "20": { class_type: "SaveImage", inputs: {} } }, token: /20 \(node only in dispatch body\)/ },
+    ]) {
+      const server = makeServer();
+      const apiTarget = { fetchApi: server };
+      const driftedOutput = { ...OUR_OUTPUT, ...drift };
+      const app = makeFrontend({ shape: "shim", defer: true, apiTarget });
+      app.postDeferred = async (item) => {
+        const body = frontendBody({ output: driftedOutput, number: item.number, targets: ["14"] });
+        app.posted.push(body);
+        return apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
+      };
+      const promise = dispatchScopedRun({
+        app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
+        verifyTimeoutMs: 500,
+      });
+      await sleep(20);
+      const res = await app.postDeferred(app.deferredItem);
+      const result = await promise;
+      assert.equal(res.status, 400);
+      assert.equal(result.outcome, "refused");
+      assert.match(result.error, /graph CHANGED/i);
+      assert.match(result.error, token, `the refusal names the drift: ${token}`);
+      assert.equal(server.calls.length, 0, "the drifted prompt never left the tab");
+    }
+    // A node REMOVED mid-window is named from the other side.
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const { "9": _dropped, ...shrunkOutput } = OUR_OUTPUT;
+    const app = makeFrontend({ shape: "shim", defer: true, apiTarget });
+    app.postDeferred = async (item) => {
+      const body = frontendBody({ output: shrunkOutput, number: item.number, targets: ["14"] });
+      app.posted.push(body);
+      return apiTarget.fetchApi("/prompt", { method: "POST", body: JSON.stringify(body) });
+    };
+    const promise = dispatchScopedRun({
+      app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14,
+      verifyTimeoutMs: 500,
+    });
+    await sleep(20);
+    await app.postDeferred(app.deferredItem);
+    const result = await promise;
+    assert.equal(result.outcome, "refused");
+    assert.match(result.error, /9 \(node only in queued prompt\)/, "a removed node is named");
+    assert.equal(server.calls.length, 0);
+  } finally {
+    stop();
+  }
 });

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -2363,6 +2363,52 @@ test("#659 promptContentHash: the probe uses the REAL input name and its parsed 
   assert.equal(calls, 1, "toJSON fires exactly once per input per canonicalization");
 });
 
+test("#659 promptContentHash: an own toJSON FUNCTION on the inputs object fails CLOSED, never a false graph_changed (codex gate r3)", () => {
+  // inputs: { steps: 20, toJSON: () => undefined } — the hook protocol makes
+  // the WIRE carry whatever toJSON returns instead of the keys, so no
+  // per-input canonicalization can predict the body's shape. The hash must
+  // refuse to compute (dispatchScopedRun's catch ⇒ the upfront unverifiable
+  // refusal) rather than false-refuse a drift that never happened.
+  const colliding = { "3": { class_type: "X", inputs: { steps: 20, toJSON: () => undefined } } };
+  assert.throws(() => promptContentHash(colliding), TypeError, "unpredictable wire form ⇒ fail closed");
+  // A NON-function toJSON-named input does not trip the hook protocol and
+  // stays fully drift-covered.
+  const harmless = { "3": { class_type: "X", inputs: { steps: 20, toJSON: false } } };
+  assert.equal(
+    promptContentHash(harmless),
+    promptContentHashFromBody(JSON.stringify({ prompt: { "3": { class_type: "X", inputs: { steps: 20, toJSON: false } } } })),
+    "a data-valued toJSON key serializes normally on both channels",
+  );
+});
+
+test("#659 integration: a graph with a toJSON-function inputs collision is refused UPFRONT (unverifiable), queuePrompt never called", async () => {
+  // Pins the end-to-end OUTCOME contract (upfront fail-closed, nothing
+  // queued). The deliberate-throw MECHANISM is pinned by the hash-level test
+  // above: without the canonicalizePrompt guard the probe's own toJSON
+  // hijack still throws by accident, reaching the same outcome by another
+  // path — the hash test is the one that fails there.
+  const stop = keepAlive();
+  try {
+    const server = makeServer();
+    const apiTarget = { fetchApi: server };
+    const output = {
+      "3": { class_type: "KSampler", inputs: { steps: 20, toJSON: () => undefined } },
+      "14": { class_type: "PreviewAny", inputs: {} },
+    };
+    const app = makeFrontend({ shape: "shim", apiTarget, output });
+    let queuePromptCalled = false;
+    const origQP = app.queuePrompt;
+    app.queuePrompt = async (...a) => { queuePromptCalled = true; return origQP(...a); };
+    const result = await dispatchScopedRun({ app, apiTarget, execIds: ["14"], batch: 1, toNodeId: 14 });
+    assert.equal(result.outcome, "unverifiable", "fails closed BEFORE dispatch — never a false drift refusal");
+    assert.match(result.error, /cannot be dispatched safely/);
+    assert.equal(queuePromptCalled, false);
+    assert.equal(server.calls.length, 0, "nothing left the tab");
+  } finally {
+    stop();
+  }
+});
+
 test("#659 diffPromptCanons: names input-level changes, node add/remove, and class_type changes — and never throws on odd input", () => {
   const a = canonicalizePrompt({
     "3": { class_type: "KSampler", inputs: { steps: 20, model: ["4", 0] } },

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -2343,6 +2343,26 @@ test("#659 scopeDroppedError: a malformed drift list can never throw out of the 
   assert.match(long, /3 x+/);
 });
 
+test("#659 promptContentHash: the probe uses the REAL input name and its parsed wire value — a key-sensitive toJSON cannot split the channels (codex gate r2)", () => {
+  // toJSON(key) receives the property name: probing under a fixed key would
+  // misjudge a key-sensitive toJSON (drop decision and value both), and
+  // double-invoking a stateful toJSON could flip between probe and canon.
+  // The probe therefore uses the real input name and the canon stores the
+  // probe's PARSED value, so toJSON fires exactly once with the wire's key.
+  const keySensitive = { toJSON: (key) => (key === "model" ? "llama3" : undefined) };
+  const inMemory = { "3": { class_type: "X", inputs: { model: keySensitive } }, "9": { class_type: "Y", inputs: {} } };
+  const wireBody = JSON.stringify({ prompt: { "3": { class_type: "X", inputs: { model: keySensitive } }, "9": { class_type: "Y", inputs: {} } } });
+  assert.equal(
+    promptContentHash(inMemory),
+    promptContentHashFromBody(wireBody),
+    'toJSON("model") on both channels ⇒ the same value, the same hash',
+  );
+  let calls = 0;
+  const counting = { toJSON: () => (++calls, 1) };
+  promptContentHash({ "3": { class_type: "X", inputs: { a: counting } } });
+  assert.equal(calls, 1, "toJSON fires exactly once per input per canonicalization");
+});
+
 test("#659 diffPromptCanons: names input-level changes, node add/remove, and class_type changes — and never throws on odd input", () => {
   const a = canonicalizePrompt({
     "3": { class_type: "KSampler", inputs: { steps: 20, model: ["4", 0] } },

--- a/browser_tests/unit/run-scope-guard.test.mjs
+++ b/browser_tests/unit/run-scope-guard.test.mjs
@@ -2301,6 +2301,48 @@ test("#659 guard: normalization is NOT tolerance — the previously-undefined in
   assert.match(guard.state.dropped, /Nothing was queued/);
 });
 
+test("#659 promptContentHash: the JSON-survival probe covers toJSON() returning undefined, and unstringifyable values stay drift-covered (fail closed)", () => {
+  const wireBody = (inputs3) =>
+    JSON.stringify({ prompt: { "3": { class_type: "KSampler", inputs: inputs3 }, "9": { class_type: "SaveImage", inputs: {} } } });
+  // codex gate r1: an object whose toJSON() yields undefined is dropped from
+  // the wire body exactly like a bare undefined — a type-based filter would
+  // have kept it and hashed it as [name, null], false-refusing again.
+  const withToJsonUndefined = {
+    "3": { class_type: "KSampler", inputs: { steps: 20, odd: { toJSON: () => undefined } } },
+    "9": { class_type: "SaveImage", inputs: {} },
+  };
+  assert.equal(
+    promptContentHash(withToJsonUndefined),
+    promptContentHashFromBody(wireBody({ steps: 20 })),
+    "a toJSON()-drops-it value is invisible on both channels",
+  );
+  // A value that THROWS on stringify (BigInt) can never be compared against
+  // the wire — fail toward detecting drift: the hash itself refuses to
+  // compute, and dispatchScopedRun's catch turns that into the upfront
+  // fail-closed refusal (unchanged from before #659).
+  assert.throws(
+    () => promptContentHash({ "3": { class_type: "X", inputs: { n: 1n } } }),
+    TypeError,
+    "an unstringifyable value stays covered — the hash fails closed rather than dropping it",
+  );
+});
+
+test("#659 scopeDroppedError: a malformed drift list can never throw out of the refusal's description (codex gate r1)", () => {
+  // verdict.drift is module-internal today, but scopeDroppedError is exported
+  // and runs on the refusal path: odd caller-supplied tokens degrade to the
+  // no-diff guidance, they never escape as a throw.
+  let msg;
+  assert.doesNotThrow(() => {
+    msg = scopeDroppedError({ toNodeId: 5, verdict: { ok: false, reason: "graph_changed", drift: [Symbol("x"), 42, null] } });
+  });
+  assert.match(msg, /queue-time widget hook/, "non-string tokens degrade to the no-diff guidance");
+  assert.match(msg, /Nothing was queued/);
+  // An over-long token is bounded before it reaches a caller-readable error.
+  const long = scopeDroppedError({ toNodeId: 5, verdict: { ok: false, reason: "graph_changed", drift: [`3 ${"x".repeat(500)}`] } });
+  assert.ok(long.length < 1200, "the drift list is length-bounded");
+  assert.match(long, /3 x+/);
+});
+
 test("#659 diffPromptCanons: names input-level changes, node add/remove, and class_type changes — and never throws on odd input", () => {
   const a = canonicalizePrompt({
     "3": { class_type: "KSampler", inputs: { steps: 20, model: ["4", 0] } },

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -65,17 +65,22 @@
 //
 //  - The prompt CONTENT HASH (r7) must be computable BEFORE dispatch: a
 //    stable hash of the full queued prompt — node ids, class types, links,
-//    every input/widget value — excluding ONLY the inputs that self-mutate at
-//    queue time (beforeQueued hooks: seed widgets re-rolled by their linked
+//    every input/widget value — excluding ONLY (a) the inputs that self-mutate
+//    at queue time (beforeQueued hooks: seed widgets re-rolled by their linked
 //    control_after_generate, and the hook widgets themselves), which change
 //    between any two serializations of the SAME graph by design (#572: the
 //    exclusion must reach the hook's serialized TARGET, not just the
-//    unserialized control the hook hangs on). A topology-only fingerprint is
+//    unserialized control the hook hangs on), and (b) inputs whose value JSON
+//    cannot transmit (undefined/function/symbol), which the in-memory
+//    graphToPrompt output carries but the POST body always drops — hashing
+//    those refused every scoped run on such a graph as a false "graph
+//    CHANGED" (#659). A topology-only fingerprint is
 //    insufficient: a busy queue defers serialization to post time, and a user
 //    edit in between (a changed widget value, a rewired link) leaves node
 //    ids/types untouched while rendering a DIFFERENT workflow — the guard
 //    refuses that drifted post and the run ends with a truthful "the graph
-//    changed" error. If the hash can't be computed at all (graphToPrompt
+//    changed" error NAMING the differing inputs (#659). If the hash can't be
+//    computed at all (graphToPrompt
 //    failed), the run FAILS CLOSED: it refuses upfront and never calls
 //    queuePrompt.
 //
@@ -163,39 +168,142 @@ const fnv1aHex = (s) =>
   fnv1a32(s, 0x9e3779b9).toString(16).padStart(8, "0");
 
 /**
+ * The CANONICAL FORM of a queued prompt — sorted node entries of
+ * [execId, class_type, [[inputName, value], …]] — shared by the content hash
+ * and by the drift diff reported on a graph_changed refusal (#659).
+ *
+ * Two exclusion rules, both required for the SAME unmodified graph to
+ * canonicalize identically through the two channels this module compares —
+ * the in-memory `graphToPrompt().output` object (pre-dispatch) and the parsed
+ * POST /prompt body (post-time serialization after a JSON round-trip):
+ *
+ *  1. VOLATILE INPUTS — inputs that self-mutate at queue time (a
+ *     `beforeQueued` hook — stock seed widgets re-rolled by their linked
+ *     control_after_generate, third-party hook widgets, etc.): those change
+ *     between any two serializations of the SAME graph by design, so hashing
+ *     them would refuse our own dispatch. Exclusions are PER-NODE pairs
+ *     (prompt node id + input name, r8): an edit to a NON-hook node's
+ *     same-named input is still detected as drift, and a prompt node that
+ *     can't be resolved to a live node carrying the hook gets NO exclusions
+ *     (fail toward detecting drift). #572: the stock hook rides on the
+ *     unserialized control widget and mutates its LINKED target, so the
+ *     exclusion follows the linkedWidgets convention to the serialized
+ *     target (see collectVolatileInputs).
+ *
+ *  2. JSON-INVISIBLE VALUES (#659) — an input whose value is `undefined`
+ *     (or a function/symbol): the in-memory output object CARRIES the key
+ *     (graphToPrompt assigns `inputs[name] = widget.value` unconditionally
+ *     for serialized widgets), but `JSON.stringify` DROPS the key from the
+ *     POST body, so the parsed body never has it. Without this filter the
+ *     pre-dispatch hash and the post-body hash of an untouched graph differ
+ *     deterministically and every scoped run is refused as "graph CHANGED".
+ *     Live-observed shape: an async-populated combo whose fetch produced no
+ *     value (e.g. OllamaConnectivityV2's `"model": ((), {})` — an
+ *     empty-options combo with no default, left `undefined` when the Ollama
+ *     server is unreachable), and the shim widgets a multi-spec
+ *     COMFY_AUTOGROW_V3 group creates with no value at all.
+ *
+ *     This is NOT a drift-detection loosening: the guard's invariant is that
+ *     the workflow that WOULD EXECUTE is unchanged, and a value JSON cannot
+ *     transmit never reaches the server — it cannot be part of what
+ *     executes. Any change the wire CAN represent still flips the hash: an
+ *     edit from `undefined` to a value makes the key APPEAR in the body
+ *     (mismatch ⇒ refused), and an edit from a value to `undefined` makes it
+ *     VANISH (mismatch ⇒ refused). Only "absent on both channels" is
+ *     tolerated.
+ *
+ * Returns null for a missing/empty prompt (the caller fails closed).
+ */
+export function canonicalizePrompt(output, volatileInputs = null) {
+  if (!output || typeof output !== "object") return null;
+  const keys = Object.keys(output).sort();
+  if (!keys.length) return null;
+  return keys.map((k) => {
+    const node = output[k] ?? {};
+    const inputs = node.inputs && typeof node.inputs === "object" ? node.inputs : {};
+    const names = Object.keys(inputs)
+      .filter((n) => !volatileInputs?.has(`${k} ${n}`))
+      .filter((n) => {
+        const v = inputs[n];
+        return v !== undefined && typeof v !== "function" && typeof v !== "symbol";
+      })
+      .sort();
+    return [k, node.class_type ?? null, names.map((n) => [n, inputs[n]])];
+  });
+}
+
+/**
  * The CONTENT fingerprint attributing a POST /prompt body to THIS run (r7):
  * a stable hash of the full queued prompt — node ids, class types, links, and
  * every input/widget value — canonicalized (sorted keys) so serialization
  * order can't blur it. A topology-only fingerprint (node-id|class_type) is
  * NOT enough: a busy queue defers serialization to post time, and a user edit
  * in between (a changed widget value, a rewired link) leaves the topology
- * untouched while rendering a DIFFERENT workflow.
- *
- * The ONLY values excluded are inputs that self-mutate at queue time (a
- * `beforeQueued` hook — stock seed widgets re-rolled by their linked
- * control_after_generate, third-party hook widgets, etc.): those change
- * between any two serializations of the SAME graph by design, so hashing them
- * would refuse our own dispatch. Exclusions are PER-NODE pairs (prompt node id
- * + input name, r8): an edit to a NON-hook node's same-named input is still
- * detected as drift, and a prompt node that can't be resolved to a live node
- * carrying the hook gets NO exclusions (fail toward detecting drift). #572:
- * the stock hook rides on the unserialized control widget and mutates its
- * LINKED target, so the exclusion follows the linkedWidgets convention to the
- * serialized target (see collectVolatileInputs).
+ * untouched while rendering a DIFFERENT workflow. See canonicalizePrompt for
+ * the two exclusion rules (queue-time-volatile inputs; JSON-invisible values).
  */
 export function promptContentHash(output, volatileInputs = null) {
-  if (!output || typeof output !== "object") return null;
-  const keys = Object.keys(output).sort();
-  if (!keys.length) return null;
-  const canon = keys.map((k) => {
-    const node = output[k] ?? {};
-    const inputs = node.inputs && typeof node.inputs === "object" ? node.inputs : {};
-    const names = Object.keys(inputs)
-      .filter((n) => !volatileInputs?.has(`${k} ${n}`))
-      .sort();
-    return [k, node.class_type ?? null, names.map((n) => [n, inputs[n]])];
-  });
+  const canon = canonicalizePrompt(output, volatileInputs);
+  if (!canon) return null;
   return fnv1aHex(JSON.stringify(canon));
+}
+
+/**
+ * WHAT differed between two canonical prompts (#659) — the observation a
+ * graph_changed refusal must report instead of asserting a cause it cannot
+ * see. One token per difference:
+ *  - `"<id> <inputName>"` — that input's value changed, or it exists on only
+ *    one side (a mid-window edit: changed widget, added/removed link);
+ *  - `"<id> (node only in queued prompt)"` / `"(node only in dispatch
+ *    body)"` — a node was removed/added in the deferred window;
+ *  - `"<id> (class_type changed)"` — the node was replaced.
+ * Input-name tokens name the pair without asserting WHICH side is newer —
+ * the guard knows only that the two serializations differ. Returns null when
+ * either canon is unusable. Never throws: this runs on the refusal path.
+ */
+export function diffPromptCanons(canonA, canonB) {
+  try {
+    if (!Array.isArray(canonA) || !Array.isArray(canonB)) return null;
+    const byId = (canon) => {
+      const m = new Map();
+      for (const entry of canon) {
+        if (Array.isArray(entry)) m.set(String(entry[0]), entry);
+      }
+      return m;
+    };
+    const A = byId(canonA);
+    const B = byId(canonB);
+    const tokens = [];
+    for (const k of A.keys()) {
+      if (!B.has(k)) tokens.push(`${k} (node only in queued prompt)`);
+    }
+    for (const k of B.keys()) {
+      if (!A.has(k)) tokens.push(`${k} (node only in dispatch body)`);
+    }
+    for (const [k, entryA] of A) {
+      const entryB = B.get(k);
+      if (!entryB) continue;
+      if (entryA[1] !== entryB[1]) {
+        tokens.push(`${k} (class_type changed)`);
+        continue;
+      }
+      const insA = Array.isArray(entryA[2]) ? entryA[2] : [];
+      const insB = Array.isArray(entryB[2]) ? entryB[2] : [];
+      const mapA = new Map(insA.filter(Array.isArray).map(([n, v]) => [String(n), v]));
+      const mapB = new Map(insB.filter(Array.isArray).map(([n, v]) => [String(n), v]));
+      for (const [n, v] of mapA) {
+        if (!mapB.has(n) || JSON.stringify(mapB.get(n)) !== JSON.stringify(v)) {
+          tokens.push(`${k} ${n}`);
+        }
+      }
+      for (const n of mapB.keys()) {
+        if (!mapA.has(n)) tokens.push(`${k} ${n}`);
+      }
+    }
+    return tokens;
+  } catch {
+    return null;
+  }
 }
 
 /** Content hash of a raw POST /prompt body, or null when unparseable/odd. */
@@ -526,14 +634,34 @@ function scopeObservation(verdict) {
  */
 export function scopeDroppedError({ toNodeId, verdict }) {
   if (verdict?.reason === "graph_changed") {
+    // #659 — report WHAT differed (the observation), not a guessed cause. The
+    // old message named only the control_after_generate hook, which sent the
+    // reporter chasing the wrong layer for five runs. When the drift diff is
+    // available, the differing "execId inputName" pairs lead; the hook
+    // guidance stays as a fallback for when the diff could not be computed.
+    const drift = Array.isArray(verdict.drift) && verdict.drift.length ? verdict.drift : null;
+    const MAX_DRIFT_TOKENS = 12;
+    const driftText = drift
+      ? `The differing entr${drift.length === 1 ? "y" : "ies"}: ` +
+        drift.slice(0, MAX_DRIFT_TOKENS).join("; ") +
+        (drift.length > MAX_DRIFT_TOKENS ? `; …and ${drift.length - MAX_DRIFT_TOKENS} more` : "") +
+        `. `
+      : "";
+    const causeText = drift
+      ? `If you did not edit ${drift.length === 1 ? "it" : "these"} between queueing and ` +
+        `dispatch, a queue-time widget hook or a dynamic-input node rewrote ${drift.length === 1 ? "it" : "them"} ` +
+        `between serialization and dispatch — please report this with the differing list above. `
+      : `If this recurs without any edit in between, ` +
+        `a queue-time widget hook is mutating values between serialization and dispatch (e.g. a ` +
+        `control_after_generate widget with WidgetControlMode "before" — switch it to ` +
+        `"after" or fix the target widget's value). `;
     return (
       `run-to-node scope for node ${toNodeId} was NOT applied: the workflow graph ` +
       `CHANGED after the run was queued — the deferred dispatch would render a ` +
-      `modified workflow, not the one that was scoped. Retrying is safe (nothing ` +
-      `was queued); if this recurs without any edit in between, a queue-time widget ` +
-      `hook is mutating values between serialization and dispatch (e.g. a ` +
-      `control_after_generate widget with WidgetControlMode "before" — switch it to ` +
-      `"after" or fix the target widget's value). ` +
+      `modified workflow, not the one that was scoped. ` +
+      driftText +
+      `Retrying is safe (nothing was queued). ` +
+      causeText +
       `Nothing was queued — refusing to fall through to a full-graph execution (#556).`
     );
   }
@@ -791,6 +919,7 @@ export function createScopedRunGuard({
   execIds,
   contentHash,
   volatileInputs = null,
+  contentCanon = null,
   batch = 1,
   toNodeId = null,
   queueMark,
@@ -805,6 +934,20 @@ export function createScopedRunGuard({
   const waiters = new Set();
   const notify = () => {
     for (const fire of [...waiters]) fire();
+  };
+  // #659 — WHAT differed between the pre-dispatch canonical prompt and this
+  // attributed body's, for the graph_changed refusal to report. Runs only on
+  // the refusal path, after the refusal is already decided; a failure to diff
+  // (unparseable body, odd canon) degrades to null and never changes the
+  // refusal itself.
+  const driftTokensForBody = (bodyText) => {
+    try {
+      if (!contentCanon) return null;
+      const body = JSON.parse(bodyText);
+      return diffPromptCanons(contentCanon, canonicalizePrompt(body?.prompt, volatileInputs));
+    } catch {
+      return null;
+    }
   };
 
   const guard = async (route, options) => {
@@ -972,7 +1115,7 @@ export function createScopedRunGuard({
       // no-usable-scope states actually occurred (readScopeFromBody), with
       // the body's top-level keys as evidence for the next report.
       const verdict = !contentOk
-        ? { ok: false, reason: "graph_changed" }
+        ? { ok: false, reason: "graph_changed", drift: driftTokensForBody(options?.body) }
         : targets
           ? { ok: false, reason: "scope_mismatch", expected, got: targets }
           : {
@@ -1158,19 +1301,25 @@ export async function dispatchScopedRun({
   // The CONTENT HASH that (with the queue mark) attributes a POST /prompt
   // body to THIS run: the full prompt we are about to queue — ids, class
   // types, links, widget values — minus only the self-mutating (beforeQueued)
-  // inputs that change between any two serializations by design. No hash ⇒
-  // no attribution ⇒ fail closed BEFORE dispatch.
+  // inputs that change between any two serializations by design, and the
+  // JSON-invisible values that cannot survive the POST body at all (#659).
+  // No hash ⇒ no attribution ⇒ fail closed BEFORE dispatch. The canonical
+  // form is RETAINED (contentCanon) so a graph_changed refusal can say WHAT
+  // differed instead of asserting a cause (#659).
   let contentHash = null;
+  let contentCanon = null;
   let volatileInputs = null;
   try {
     if (typeof app.graphToPrompt === "function") {
       // This panel's live root is app.graph (r8) — app.rootGraph only as a
       // fallback for frontends that expose it instead.
       volatileInputs = collectVolatileInputs(app?.graph ?? app?.rootGraph ?? null);
-      contentHash = promptContentHash((await app.graphToPrompt())?.output, volatileInputs);
+      contentCanon = canonicalizePrompt((await app.graphToPrompt())?.output, volatileInputs);
+      contentHash = contentCanon ? fnv1aHex(JSON.stringify(contentCanon)) : null;
     }
   } catch {
     contentHash = null;
+    contentCanon = null;
   }
   if (!contentHash) {
     return { outcome: "unverifiable", queueMark: mark, error: scopeUnattributableError({ toNodeId }) };
@@ -1221,6 +1370,7 @@ export async function dispatchScopedRun({
       execIds,
       contentHash,
       volatileInputs,
+      contentCanon,
       batch,
       toNodeId,
       queueMark: mark,

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -236,6 +236,16 @@ export function canonicalizePrompt(output, volatileInputs = null) {
   return keys.map((k) => {
     const node = output[k] ?? {};
     const inputs = node.inputs && typeof node.inputs === "object" ? node.inputs : {};
+    // An own `toJSON` FUNCTION on the inputs object hijacks JSON.stringify's
+    // hook protocol for the WHOLE object (codex gate r3): on the wire the
+    // body carries whatever `inputs.toJSON("inputs")` returns instead of
+    // these keys, and the same name would hijack the one-key probe below.
+    // The wire form of such a node cannot be predicted faithfully from here,
+    // so fail CLOSED — dispatchScopedRun's catch turns this throw into the
+    // upfront "cannot fingerprint" refusal, never a false "graph CHANGED".
+    if (typeof inputs.toJSON === "function") {
+      throw new TypeError(`prompt node ${k} carries an own toJSON function — its wire form is not predictable`);
+    }
     const names = [];
     const wireValues = new Map();
     for (const n of Object.keys(inputs)) {

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -204,13 +204,19 @@ const fnv1aHex = (s) =>
  *     `"model": ((), {})` — an empty-options combo with no default, left
  *     `undefined` when the Ollama server is unreachable), and the shim
  *     widgets a multi-spec COMFY_AUTOGROW_V3 group creates with no value at
- *     all. The check is an exact emulation of the wire — `JSON.stringify`
- *     of a one-key probe object — not a type guess, so it cannot drift from
- *     what the body actually carries (codex gate r1: a `toJSON()` returning
- *     `undefined` is dropped on the wire but would have read as `null` in
- *     the canonical pair). A value that THROWS on stringify (BigInt,
- *     circular) is KEPT — fail toward detecting drift; the hash itself then
- *     fails closed exactly as before.
+ *     all.
+ *
+ *     The check is an exact emulation of the wire, not a type guess: each
+ *     input is serialized once in a one-key probe object UNDER ITS REAL NAME
+ *     (codex gate r2: `toJSON(key)` receives the property name, so probing
+ *     under a fixed key misjudges a key-sensitive `toJSON`), a dropped key
+ *     yields exactly `"{}"`, and the probe's PARSED value is what the canon
+ *     stores — so `toJSON` fires exactly once per input, with the same key
+ *     the POST body would use, and the canon holds the same wire-normalized
+ *     value the parsed body will (dates, toJSON results, -0, NaN→null all
+ *     land identically on both channels). A value that THROWS on stringify
+ *     (BigInt, circular) is KEPT raw — fail toward detecting drift; the hash
+ *     itself then fails closed exactly as before.
  *
  *     This is NOT a drift-detection loosening: the guard's invariant is that
  *     the workflow that WOULD EXECUTE is unchanged, and a value JSON cannot
@@ -230,19 +236,29 @@ export function canonicalizePrompt(output, volatileInputs = null) {
   return keys.map((k) => {
     const node = output[k] ?? {};
     const inputs = node.inputs && typeof node.inputs === "object" ? node.inputs : {};
-    const names = Object.keys(inputs)
-      .filter((n) => !volatileInputs?.has(`${k} ${n}`))
-      .filter((n) => {
-        // Would this key survive JSON.stringify as an object property? Only
-        // then can it reach the server — and only then can it drift.
-        try {
-          return JSON.stringify({ v: inputs[n] }) !== "{}";
-        } catch {
-          return true; // unstringifyable (BigInt/circular) — keep it covered
-        }
-      })
-      .sort();
-    return [k, node.class_type ?? null, names.map((n) => [n, inputs[n]])];
+    const names = [];
+    const wireValues = new Map();
+    for (const n of Object.keys(inputs)) {
+      if (volatileInputs?.has(`${k} ${n}`)) continue;
+      let probe;
+      try {
+        probe = JSON.stringify({ [n]: inputs[n] });
+      } catch {
+        // Unstringifyable (BigInt/circular): keep the RAW value — the hash
+        // then fails closed exactly as before #659, never dropping coverage.
+        names.push(n);
+        continue;
+      }
+      // A one-key object renders as exactly "{}" when the key is dropped —
+      // that value cannot reach the server, so it cannot drift.
+      if (probe === "{}") continue;
+      names.push(n);
+      // The canon stores the WIRE form of the value (toJSON applied once,
+      // under the real key) so both channels compare the same thing.
+      wireValues.set(n, JSON.parse(probe)[n]);
+    }
+    names.sort();
+    return [k, node.class_type ?? null, names.map((n) => [n, wireValues.has(n) ? wireValues.get(n) : inputs[n]])];
   });
 }
 
@@ -677,20 +693,22 @@ export function scopeDroppedError({ toNodeId, verdict }) {
         (drift.length > MAX_DRIFT_TOKENS ? `; …and ${drift.length - MAX_DRIFT_TOKENS} more` : "") +
         `. `
       : "";
-    // Enumerate CANDIDATES, never assert one (codex gate r1): the guard
-    // observed two differing serializations, nothing more. A nondeterministic
-    // widget serializer (a serializeValue emitting a timestamp) produces this
-    // same refusal with no hook and no dynamic-input node involved.
+    // Enumerate CANDIDATES, never assert one (codex gate r1/r2): the guard
+    // observed two differing serializations, nothing more — it cannot see
+    // WHAT rewrote the value, or even that a "rewrite" happened at all (a
+    // nondeterministic widget serializer — a serializeValue emitting a
+    // timestamp — produces this same refusal on an untouched graph).
     const causeText = drift
       ? `If you did not edit ${drift.length === 1 ? "it" : "these"} between queueing and ` +
-        `dispatch, something rewrote ${drift.length === 1 ? "it" : "them"} between serialization ` +
-        `and dispatch that the panel cannot identify from here — candidates: a queue-time ` +
-        `widget hook (e.g. control_after_generate), a dynamic-input node reshaping its slots, ` +
-        `or a nondeterministic widget serializer. Please report this with the differing list above. `
-      : `If this recurs without any edit in between, ` +
-        `a queue-time widget hook is mutating values between serialization and dispatch (e.g. a ` +
-        `control_after_generate widget with WidgetControlMode "before" — switch it to ` +
-        `"after" or fix the target widget's value). `;
+        `dispatch, the two serializations differ for a reason the panel cannot identify from ` +
+        `here — candidates: a queue-time widget hook (e.g. control_after_generate), a ` +
+        `dynamic-input node reshaping its slots, or a nondeterministic widget serializer. ` +
+        `Please report this with the differing list above. `
+      : `If this recurs without any edit in between, the two serializations differ for a ` +
+        `reason the panel cannot identify from here — candidates: a queue-time widget hook ` +
+        `mutating values between serialization and dispatch (e.g. a control_after_generate ` +
+        `widget with WidgetControlMode "before" — switch it to "after" or fix the target ` +
+        `widget's value), or a nondeterministic widget serializer. `;
     return (
       `run-to-node scope for node ${toNodeId} was NOT applied: the workflow graph ` +
       `CHANGED after the run was queued — the deferred dispatch would render a ` +

--- a/web/js/lib/run-scope-guard.js
+++ b/web/js/lib/run-scope-guard.js
@@ -70,9 +70,10 @@
 //    control_after_generate, and the hook widgets themselves), which change
 //    between any two serializations of the SAME graph by design (#572: the
 //    exclusion must reach the hook's serialized TARGET, not just the
-//    unserialized control the hook hangs on), and (b) inputs whose value JSON
-//    cannot transmit (undefined/function/symbol), which the in-memory
-//    graphToPrompt output carries but the POST body always drops — hashing
+//    unserialized control the hook hangs on), and (b) inputs whose value the
+//    POST body's JSON cannot carry (undefined/function/symbol, or a toJSON
+//    that yields one), which the in-memory graphToPrompt output carries but
+//    the wire always drops — hashing
 //    those refused every scoped run on such a graph as a false "graph
 //    CHANGED" (#659). A topology-only fingerprint is
 //    insufficient: a busy queue defers serialization to post time, and a user
@@ -190,18 +191,26 @@ const fnv1aHex = (s) =>
  *     exclusion follows the linkedWidgets convention to the serialized
  *     target (see collectVolatileInputs).
  *
- *  2. JSON-INVISIBLE VALUES (#659) — an input whose value is `undefined`
- *     (or a function/symbol): the in-memory output object CARRIES the key
- *     (graphToPrompt assigns `inputs[name] = widget.value` unconditionally
- *     for serialized widgets), but `JSON.stringify` DROPS the key from the
- *     POST body, so the parsed body never has it. Without this filter the
- *     pre-dispatch hash and the post-body hash of an untouched graph differ
- *     deterministically and every scoped run is refused as "graph CHANGED".
- *     Live-observed shape: an async-populated combo whose fetch produced no
- *     value (e.g. OllamaConnectivityV2's `"model": ((), {})` — an
- *     empty-options combo with no default, left `undefined` when the Ollama
- *     server is unreachable), and the shim widgets a multi-spec
- *     COMFY_AUTOGROW_V3 group creates with no value at all.
+ *  2. JSON-INVISIBLE VALUES (#659) — an input whose value JSON.stringify
+ *     would DROP from the inputs object: `undefined`, functions, symbols,
+ *     and object values whose own `toJSON()` returns one of those. The
+ *     in-memory output object CARRIES the key (graphToPrompt assigns
+ *     `inputs[name] = widget.value` unconditionally for serialized widgets),
+ *     but the key never reaches the POST body, so the parsed body never has
+ *     it. Without this filter the pre-dispatch hash and the post-body hash
+ *     of an untouched graph differ deterministically and every scoped run is
+ *     refused as "graph CHANGED". Live-observed shape: an async-populated
+ *     combo whose fetch produced no value (e.g. OllamaConnectivityV2's
+ *     `"model": ((), {})` — an empty-options combo with no default, left
+ *     `undefined` when the Ollama server is unreachable), and the shim
+ *     widgets a multi-spec COMFY_AUTOGROW_V3 group creates with no value at
+ *     all. The check is an exact emulation of the wire — `JSON.stringify`
+ *     of a one-key probe object — not a type guess, so it cannot drift from
+ *     what the body actually carries (codex gate r1: a `toJSON()` returning
+ *     `undefined` is dropped on the wire but would have read as `null` in
+ *     the canonical pair). A value that THROWS on stringify (BigInt,
+ *     circular) is KEPT — fail toward detecting drift; the hash itself then
+ *     fails closed exactly as before.
  *
  *     This is NOT a drift-detection loosening: the guard's invariant is that
  *     the workflow that WOULD EXECUTE is unchanged, and a value JSON cannot
@@ -224,8 +233,13 @@ export function canonicalizePrompt(output, volatileInputs = null) {
     const names = Object.keys(inputs)
       .filter((n) => !volatileInputs?.has(`${k} ${n}`))
       .filter((n) => {
-        const v = inputs[n];
-        return v !== undefined && typeof v !== "function" && typeof v !== "symbol";
+        // Would this key survive JSON.stringify as an object property? Only
+        // then can it reach the server — and only then can it drift.
+        try {
+          return JSON.stringify({ v: inputs[n] }) !== "{}";
+        } catch {
+          return true; // unstringifyable (BigInt/circular) — keep it covered
+        }
       })
       .sort();
     return [k, node.class_type ?? null, names.map((n) => [n, inputs[n]])];
@@ -639,7 +653,23 @@ export function scopeDroppedError({ toNodeId, verdict }) {
     // reporter chasing the wrong layer for five runs. When the drift diff is
     // available, the differing "execId inputName" pairs lead; the hook
     // guidance stays as a fallback for when the diff could not be computed.
-    const drift = Array.isArray(verdict.drift) && verdict.drift.length ? verdict.drift : null;
+    //
+    // The tokens are normalized defensively (codex gate r1): verdict.drift is
+    // module-internal today (diffPromptCanons only ever emits bounded
+    // strings), but this function is exported and runs on the refusal path —
+    // a malformed caller-supplied drift must degrade to the no-diff message,
+    // never throw out of the refusal's description.
+    const drift = (() => {
+      try {
+        if (!Array.isArray(verdict.drift) || !verdict.drift.length) return null;
+        const tokens = verdict.drift
+          .filter((t) => typeof t === "string" && t.length)
+          .map((t) => (t.length > 120 ? `${t.slice(0, 120)}…` : t));
+        return tokens.length ? tokens : null;
+      } catch {
+        return null;
+      }
+    })();
     const MAX_DRIFT_TOKENS = 12;
     const driftText = drift
       ? `The differing entr${drift.length === 1 ? "y" : "ies"}: ` +
@@ -647,10 +677,16 @@ export function scopeDroppedError({ toNodeId, verdict }) {
         (drift.length > MAX_DRIFT_TOKENS ? `; …and ${drift.length - MAX_DRIFT_TOKENS} more` : "") +
         `. `
       : "";
+    // Enumerate CANDIDATES, never assert one (codex gate r1): the guard
+    // observed two differing serializations, nothing more. A nondeterministic
+    // widget serializer (a serializeValue emitting a timestamp) produces this
+    // same refusal with no hook and no dynamic-input node involved.
     const causeText = drift
       ? `If you did not edit ${drift.length === 1 ? "it" : "these"} between queueing and ` +
-        `dispatch, a queue-time widget hook or a dynamic-input node rewrote ${drift.length === 1 ? "it" : "them"} ` +
-        `between serialization and dispatch — please report this with the differing list above. `
+        `dispatch, something rewrote ${drift.length === 1 ? "it" : "them"} between serialization ` +
+        `and dispatch that the panel cannot identify from here — candidates: a queue-time ` +
+        `widget hook (e.g. control_after_generate), a dynamic-input node reshaping its slots, ` +
+        `or a nondeterministic widget serializer. Please report this with the differing list above. `
       : `If this recurs without any edit in between, ` +
         `a queue-time widget hook is mutating values between serialization and dispatch (e.g. a ` +
         `control_after_generate widget with WidgetControlMode "before" — switch it to ` +


### PR DESCRIPTION
`panel_run to_node_id` always refused with "graph CHANGED after the run was queued" (#556 drift guard false positive) when the graph contains a COMFY_AUTOGROW_V3 dynamic-input node: `promptContentHash`/`collectVolatileInputs` (web/js/lib/run-scope-guard.js:186,251) exclude only beforeQueued-hook inputs; non-idempotent `graphToPrompt()` on autogrow nodes trips the guard.

closes #659