### PR TITLE
panel_get_errors returns unbounded tensor-sized execution payload

### DIFF
--- a/browser_tests/unit/exec-error-bounds.test.mjs
+++ b/browser_tests/unit/exec-error-bounds.test.mjs
@@ -1,0 +1,233 @@
+/**
+ * Unit tests for web/js/lib/exec-error-bounds.js — run with `node --test`.
+ *
+ * #664: graph_get_errors emitted the raw execution_error detail VERBATIM as
+ * `last_execution_error`. ComfyUI puts the LIVE values in current_inputs /
+ * current_outputs (latents, images — tensor-sized) and traceback lines can be
+ * huge tensor reprs, so one sampling failure shipped a 41k+ token tool result
+ * that overflowed the agent's context. These tests pin the bounded shape:
+ * same keys an existing consumer reads, capped text surfaces, and every cut
+ * DISCLOSED in-band — never silently dropped.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  EXEC_ERR_MESSAGE_CAP,
+  EXEC_ERR_TRACEBACK_MAX_LINES,
+  EXEC_ERR_TRACEBACK_LINE_CAP,
+  EXEC_ERR_EXECUTED_CAP,
+  EXEC_ERR_OUTPUTS_JSON_CAP,
+  boundExecFailurePayload,
+} from "../../web/js/lib/exec-error-bounds.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PANEL_SOURCE = readFileSync(
+  join(__dirname, "..", "..", "web", "js", "comfyui-mcp-panel.js"),
+  "utf8",
+);
+
+// A hard upper bound on the serialized payload, derived from the caps rather
+// than a round number: message + traceback + outputs + generous headroom for
+// scalars and disclosure notes. The pre-fix payload had NO bound at all.
+const WORST_CASE_CHARS =
+  EXEC_ERR_MESSAGE_CAP +
+  EXEC_ERR_TRACEBACK_MAX_LINES * EXEC_ERR_TRACEBACK_LINE_CAP +
+  EXEC_ERR_OUTPUTS_JSON_CAP +
+  4000;
+
+test("null / undefined in → null out (no failure stays 'no failure')", () => {
+  assert.equal(boundExecFailurePayload(null), null);
+  assert.equal(boundExecFailurePayload(undefined), null);
+});
+
+test("a small well-formed failure passes through with every compat key intact", () => {
+  const detail = {
+    prompt_id: "p-1",
+    node_id: 7,
+    node_type: "KSampler",
+    exception_type: "RuntimeError",
+    exception_message: "mat1 and mat2 shapes cannot be multiplied",
+    traceback: ["Traceback (most recent call last):", '  File "execution.py", line 1, in execute'],
+    executed: [3, 5, 7],
+    current_outputs: { 7: { images: [{ filename: "x.png" }] } },
+    ts: "2026-08-05T00:00:00.000Z",
+  };
+  const out = boundExecFailurePayload(detail);
+  assert.equal(out.prompt_id, "p-1");
+  assert.equal(out.node_id, 7);
+  assert.equal(out.node_type, "KSampler");
+  assert.equal(out.exception_type, "RuntimeError");
+  assert.equal(out.exception_message, detail.exception_message);
+  assert.deepEqual(out.traceback, detail.traceback);
+  assert.deepEqual(out.executed, [3, 5, 7]);
+  assert.deepEqual(out.current_outputs, detail.current_outputs);
+  assert.equal(out.ts, detail.ts);
+  // Nothing was cut → NO truncation flags. Flags are a signal; emitting them
+  // when nothing was cut would train consumers to ignore them.
+  assert.equal(out.exception_message_truncated, undefined);
+  assert.equal(out.traceback_truncated, undefined);
+  assert.equal(out.current_outputs_omitted, undefined);
+});
+
+test("tensor-sized current_inputs never ships — disclosed, not silently dropped (#664)", () => {
+  const tensorDump = "tensor([[" + "0.1234, ".repeat(200000) + "]])";
+  const out = boundExecFailurePayload({
+    node_id: 3,
+    node_type: "KSampler",
+    exception_message: "OOM",
+    current_inputs: { latent: [tensorDump] },
+  });
+  assert.equal("current_inputs" in out, false, "the tensor-sized field must not be present");
+  assert.equal(out.current_inputs_omitted, true, "the omission must be disclosed");
+  assert.match(out.current_inputs_note, /#664/, "the note must say WHY (the overflow it prevents)");
+  // The identity of the fault survives the omission.
+  assert.equal(out.node_id, 3);
+  assert.equal(out.node_type, "KSampler");
+});
+
+test("a huge exception_message is capped and the cut disclosed with the reason", () => {
+  const out = boundExecFailurePayload({
+    exception_message: "E".repeat(EXEC_ERR_MESSAGE_CAP * 10),
+  });
+  assert.equal(out.exception_message.length, EXEC_ERR_MESSAGE_CAP);
+  assert.equal(out.exception_message_truncated, true);
+  assert.match(out.exception_message_note, /fixed cap/, "the note must not promise a lever that does not exist");
+});
+
+test("traceback is capped by line count AND per-line length; both cuts raise one disclosed flag", () => {
+  const tb = Array.from({ length: EXEC_ERR_TRACEBACK_MAX_LINES + 25 }, (_, i) => `line ${i}`);
+  const out1 = boundExecFailurePayload({ traceback: tb });
+  assert.equal(out1.traceback.length, EXEC_ERR_TRACEBACK_MAX_LINES);
+  assert.equal(out1.traceback_truncated, true);
+  assert.match(out1.traceback_note, /server console/, "the remedy must name where the full text lives");
+
+  // A single tensor-repr line under the line-count cap must STILL be cut.
+  const out2 = boundExecFailurePayload({ traceback: ["tensor(" + "1, ".repeat(50000) + ")"] });
+  assert.equal(out2.traceback.length, 1);
+  assert.equal(out2.traceback[0].length, EXEC_ERR_TRACEBACK_LINE_CAP);
+  assert.equal(out2.traceback_truncated, true);
+});
+
+test("current_outputs ships raw only when small; a tensor-sized map is omitted with disclosure", () => {
+  const small = boundExecFailurePayload({ current_outputs: { 1: { images: [] } } });
+  assert.deepEqual(small.current_outputs, { 1: { images: [] } });
+  assert.equal(small.current_outputs_omitted, undefined);
+
+  const big = boundExecFailurePayload({
+    current_outputs: { 1: { latents: ["t".repeat(EXEC_ERR_OUTPUTS_JSON_CAP * 5)] } },
+  });
+  assert.equal("current_outputs" in big, false);
+  assert.equal(big.current_outputs_omitted, true);
+  assert.match(big.current_outputs_note, /Omitted/);
+});
+
+test("an unserializable current_outputs (BigInt) is omitted, not shipped and never throws", () => {
+  const out = boundExecFailurePayload({ current_outputs: { v: 10n } });
+  assert.equal("current_outputs" in out, false);
+  assert.equal(out.current_outputs_omitted, true);
+});
+
+test("the executed list is count-capped with a disclosed note, not a bare boolean", () => {
+  const ids = Array.from({ length: EXEC_ERR_EXECUTED_CAP + 50 }, (_, i) => i);
+  const out = boundExecFailurePayload({ executed: ids });
+  assert.equal(out.executed.length, EXEC_ERR_EXECUTED_CAP);
+  assert.equal(out.executed_truncated, true);
+  assert.match(out.executed_note, /fixed cap/, "the note must state the cap and that no lever raises it");
+  assert.match(out.executed_note, /node_id/, "the note must point at where the failure is actually identified");
+});
+
+test("a non-object detail is coerced into the message — a failure is never reported as absent", () => {
+  const out = boundExecFailurePayload("boom");
+  assert.ok(out && typeof out === "object");
+  assert.equal(out.exception_message, "boom");
+});
+
+test("escape-heavy text is capped on its SERIALIZED length — JSON expansion can't bypass the bound", () => {
+  // Each control character serializes to a six-character escape: a 4000-char
+  // raw message would cross the bridge as ~24k chars under a raw-length cap.
+  const heavy = "\u0000".repeat(EXEC_ERR_MESSAGE_CAP);
+  const out = boundExecFailurePayload({
+    exception_message: heavy,
+    traceback: ["\u0000".repeat(EXEC_ERR_TRACEBACK_LINE_CAP)],
+  });
+  assert.ok(JSON.stringify(out.exception_message).length - 2 <= EXEC_ERR_MESSAGE_CAP);
+  assert.equal(out.exception_message_truncated, true);
+  assert.ok(JSON.stringify(out.traceback[0]).length - 2 <= EXEC_ERR_TRACEBACK_LINE_CAP);
+  assert.equal(out.traceback_truncated, true);
+  // Printable text at exactly the cap is untouched (escLen == raw length).
+  const plain = boundExecFailurePayload({ exception_message: "E".repeat(EXEC_ERR_MESSAGE_CAP) });
+  assert.equal(plain.exception_message.length, EXEC_ERR_MESSAGE_CAP);
+  assert.equal(plain.exception_message_truncated, undefined);
+});
+
+test("worst case stays under the derived hard bound (#664 shipped 41k+ TOKENS)", () => {
+  const out = boundExecFailurePayload({
+    prompt_id: "p",
+    node_id: 1,
+    node_type: "N",
+    exception_type: "E",
+    exception_message: "M".repeat(EXEC_ERR_MESSAGE_CAP * 4),
+    traceback: Array.from({ length: 500 }, () => "T".repeat(EXEC_ERR_TRACEBACK_LINE_CAP * 3)),
+    executed: Array.from({ length: 5000 }, (_, i) => i),
+    current_inputs: { latent: ["L".repeat(1000000)] },
+    current_outputs: { 1: ["O".repeat(1000000)] },
+    ts: "2026-08-05T00:00:00.000Z",
+  });
+  const size = JSON.stringify(out).length;
+  assert.ok(
+    size <= WORST_CASE_CHARS,
+    `serialized payload ${size} chars exceeds the derived worst case ${WORST_CASE_CHARS}`,
+  );
+  // Same worst case with maximally escape-heavy text — the pre-round-2 raw-length
+  // cap would serialize to ~6× the bound here.
+  const heavy = boundExecFailurePayload({
+    exception_message: "\u0000".repeat(EXEC_ERR_MESSAGE_CAP * 4),
+    traceback: Array.from({ length: 500 }, () => "\u0001".repeat(EXEC_ERR_TRACEBACK_LINE_CAP * 3)),
+  });
+  const heavySize = JSON.stringify(heavy).length;
+  assert.ok(
+    heavySize <= WORST_CASE_CHARS,
+    `escape-heavy serialized payload ${heavySize} chars exceeds the derived worst case ${WORST_CASE_CHARS}`,
+  );
+});
+
+test("capSerializedText never splits a surrogate pair and keeps the maximal fitting prefix", () => {
+  // 3998 a's + one emoji (2 code units) + filler: the maximal prefix under the
+  // 4000 serialized-char cap ends WITH the emoji. A code-unit binary search can
+  // land mid-pair (a lone surrogate escapes to 6 chars, breaking monotonicity)
+  // and return less (codex gate round 3).
+  const emoji = "\u{1F600}";
+  const text = "a".repeat(EXEC_ERR_MESSAGE_CAP - 2) + emoji + "b".repeat(500);
+  const out = boundExecFailurePayload({ exception_message: text });
+  assert.equal(out.exception_message, "a".repeat(EXEC_ERR_MESSAGE_CAP - 2) + emoji);
+  assert.equal(out.exception_message_truncated, true);
+  assert.ok(JSON.stringify(out.exception_message).length - 2 <= EXEC_ERR_MESSAGE_CAP);
+});
+
+test("current_outputs omission note states the cap is fixed and names no phantom lever", () => {
+  const big = boundExecFailurePayload({
+    current_outputs: { 1: { latents: ["t".repeat(EXEC_ERR_OUTPUTS_JSON_CAP * 5)] } },
+  });
+  assert.equal(big.current_outputs_omitted, true);
+  assert.match(big.current_outputs_note, /fixed cap, no parameter raises it/);
+});
+
+// Source guard: the lib bounds only matter while graph_get_errors actually
+// EMITS through them. A revert to the verbatim emission — the exact #664
+// defect — must fail the build, not slip through (a fix on one branch was
+// once silently reverted by a later bulk rewrite; token presence ≠ wiring).
+test("graph_get_errors emits the bounded payload and the verbatim emission is gone (#664)", () => {
+  assert.match(
+    PANEL_SOURCE,
+    /last_execution_error:\s*boundExecFailurePayload\(lastExecFailure\)/,
+    "graph_get_errors must emit lastExecFailure through boundExecFailurePayload",
+  );
+  assert.ok(
+    !/last_execution_error:\s*lastExecFailure\b/.test(PANEL_SOURCE),
+    "the verbatim `last_execution_error: lastExecFailure` emission must not reappear",
+  );
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -159,6 +159,7 @@ import {
   GET_ERRORS_STEP_CAP_MS,
   getErrorsStepBudgetMs,
 } from "./lib/get-errors-budget.js";
+import { boundExecFailurePayload } from "./lib/exec-error-bounds.js";
 import {
   drivenWidgetsFor,
   drivenTag,
@@ -9806,9 +9807,13 @@ const GRAPH_TOOL_EXECUTORS = {
   //   - lastNodeErrors      → per-input validation errors from the last queue
   //   - lastExecFailure     → the last runtime failure (live execution_error event)
   //
-  // `node_errors` and `last_execution_error` are kept VERBATIM for backwards
-  // compatibility — the turn-start validation block, the tool-call label and the
-  // console action all read them.
+  // `node_errors` and `last_execution_error` are kept for backwards compatibility
+  // — the turn-start validation block, the tool-call label and the console action
+  // all read them (presence / scalar fields). `last_execution_error` is BOUNDED at
+  // emission (#664): the raw event detail carries tensor-sized current_inputs /
+  // current_outputs and traceback lines with huge tensor reprs, which shipped a
+  // 41k+ token tool result. Same keys, capped values, every cut disclosed in-band
+  // (see web/js/lib/exec-error-bounds.js).
   //
   // NOTE on EXEC_ERR_STORE below: that ComfyUI store id is a camelCase name
   // ending in "...executi" + "on" + "Error". Lowercased, that tail collides with
@@ -10016,8 +10021,8 @@ const GRAPH_TOOL_EXECUTORS = {
     //    LiteGraph does NOT set has_errors for a runtime failure, so the throwing
     //    node is never painted red and reaches the output ONLY via the union
     //    below. `exception_type` is carried because "PIL.UnidentifiedImageError"
-    //    explains far more than the message; the traceback is dropped to stay
-    //    token-bounded (it stays in `last_execution_error` for compatibility).
+    //    explains far more than the message; the traceback is dropped HERE to stay
+    //    token-bounded (a capped traceback ships in `last_execution_error`, #664).
     let execFailure = null;
     try {
       let e = lastExecFailure;
@@ -10130,8 +10135,10 @@ const GRAPH_TOOL_EXECUTORS = {
       ...(missingNodeCount && !missingNodeTypes.length
         ? { missing_node_count: missingNodeCount }
         : {}),
-      // --- backwards-compatible raw payloads (existing consumers read these) ---
-      last_execution_error: lastExecFailure,
+      // --- backwards-compatible payloads (existing consumers read these) ---
+      // Bounded at emission (#664): verbatim, this carried tensor-sized
+      // current_inputs/current_outputs and huge traceback lines (41k+ tokens).
+      last_execution_error: boundExecFailurePayload(lastExecFailure),
       node_errors: nodeErrors,
       ...(clean ? { note: "no errors recorded since the last execution start" } : {}),
     };

--- a/web/js/lib/exec-error-bounds.js
+++ b/web/js/lib/exec-error-bounds.js
@@ -1,0 +1,152 @@
+/**
+ * Payload bounds for `last_execution_error` in graph_get_errors (#664) —
+ * extracted from comfyui-mcp-panel.js so the invariant is unit-testable
+ * without a browser. No DOM / no ComfyUI globals: every input is passed in.
+ *
+ * The defect: ComfyUI's execution_error event carries `current_inputs` /
+ * `current_outputs` with the LIVE values (latents, images — tensor-sized) and
+ * a traceback whose lines can be huge tensor reprs. graph_get_errors emitted
+ * that payload VERBATIM, and one sampling failure produced a 41k+ token tool
+ * result that overflowed the agent's context. The newer nodes[].reasons[]
+ * surface was already token-bounded; this compat surface was not.
+ *
+ * The shape below keeps every field an existing consumer reads — the scalar
+ * identity of the failure (prompt_id / node_id / node_type / exception_type /
+ * ts) plus the message, traceback, executed list and current_outputs — but
+ * each text surface is capped, and every cut is DISCLOSED in-band with a note
+ * rather than dropped silently (a bare `truncated: true` boolean is the worst
+ * truncation signal there is: it carries no instruction). `current_inputs` is
+ * never shipped: it is the tensor-sized field and the failing node + exception
+ * already identify the fault. Naming a lever this view does not have would be
+ * the same defect pointing the other way, so the notes say the cap is FIXED.
+ *
+ * Worst case by construction, measured on the SERIALIZED form (see
+ * capSerializedText): EXEC_ERR_MESSAGE_CAP + EXEC_ERR_TRACEBACK_MAX_LINES
+ * × EXEC_ERR_TRACEBACK_LINE_CAP + EXEC_ERR_OUTPUTS_JSON_CAP + small scalars and
+ * notes ≈ 88k chars — versus megabytes unbounded.
+ */
+
+import { coerceMessageText } from "./chat-serialize.js";
+
+/** Cap on the exception message. Field-verified in #664's local fix. */
+export const EXEC_ERR_MESSAGE_CAP = 4000;
+/** Traceback bounds: line count × per-line chars. Field-verified in #664. */
+export const EXEC_ERR_TRACEBACK_MAX_LINES = 40;
+export const EXEC_ERR_TRACEBACK_LINE_CAP = 2000;
+/** Cap on the `executed` node-id list (scalar ids; only the count can grow). */
+export const EXEC_ERR_EXECUTED_CAP = 100;
+/** current_outputs ships RAW only when its serialized form fits this cap;
+ *  larger (or unserializable) values are omitted with a disclosure note —
+ *  partial giant output dumps help no one and reintroduce #664. */
+export const EXEC_ERR_OUTPUTS_JSON_CAP = 2000;
+
+/**
+ * Text caps are measured on the JSON-SERIALIZED form, not raw JS code units:
+ * the tool result crosses the bridge as JSON, and escape-heavy text (control
+ * characters, lone surrogates) expands up to 6× on the wire (one byte becomes
+ * its six-character escape), which would otherwise multiply every cap past the
+ * stated worst case (codex gate round 2). Returns the longest prefix whose
+ * serialized length fits.
+ *
+ * The search runs over CODE POINTS, not code units: serialized-prefix length
+ * is only monotonic on code-point boundaries — a code-unit slice can end on a
+ * lone high surrogate, whose six-character escape makes a SHORTER prefix
+ * serialize LONGER and breaks a code-unit binary search (codex gate round 3).
+ */
+function capSerializedText(text, cap) {
+  const escLen = (t) => JSON.stringify(t).length - 2; // strip the quotes
+  if (escLen(text) <= cap) return { text, truncated: false };
+  const points = [...text];
+  let lo = 0;
+  let hi = points.length;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (escLen(points.slice(0, mid).join("")) <= cap) lo = mid;
+    else hi = mid - 1;
+  }
+  return { text: points.slice(0, lo).join(""), truncated: true };
+}
+
+/**
+ * Bounded form of one captured execution_error detail. `null` in → `null` out
+ * (no failure stays "no failure"); a non-object detail is coerced into the
+ * message rather than dropped, so a failure is never reported as absent.
+ */
+export function boundExecFailurePayload(e) {
+  if (e == null) return null;
+  // The capture path always stores an object ({ ...ev.detail, ts }); the
+  // coerce branch is defence against a detail that arrived as a bare string.
+  const src = typeof e === "object" ? e : { exception_message: e };
+
+  const out = {
+    prompt_id: src.prompt_id ?? null,
+    node_id: src.node_id ?? null,
+    node_type: src.node_type ?? null,
+    exception_type: src.exception_type ?? null,
+  };
+  if (src.ts != null) out.ts = src.ts;
+
+  const msg = capSerializedText(coerceMessageText(src.exception_message ?? ""), EXEC_ERR_MESSAGE_CAP);
+  out.exception_message = msg.text;
+  if (msg.truncated) {
+    out.exception_message_truncated = true;
+    out.exception_message_note =
+      `Capped at ${EXEC_ERR_MESSAGE_CAP} chars (fixed cap, no parameter raises it) — ` +
+      `the full message is printed in the ComfyUI server console.`;
+  }
+
+  const tb = Array.isArray(src.traceback) ? src.traceback : [];
+  let tbTruncated = tb.length > EXEC_ERR_TRACEBACK_MAX_LINES;
+  out.traceback = tb.slice(0, EXEC_ERR_TRACEBACK_MAX_LINES).map((line) => {
+    const capped = capSerializedText(coerceMessageText(line), EXEC_ERR_TRACEBACK_LINE_CAP);
+    if (capped.truncated) tbTruncated = true;
+    return capped.text;
+  });
+  if (tbTruncated) {
+    out.traceback_truncated = true;
+    out.traceback_note =
+      `Capped at ${EXEC_ERR_TRACEBACK_MAX_LINES} lines × ${EXEC_ERR_TRACEBACK_LINE_CAP} chars ` +
+      `(fixed cap, no parameter raises it) — the full traceback is printed in the ComfyUI server console.`;
+  }
+
+  if (Array.isArray(src.executed)) {
+    out.executed = src.executed.slice(0, EXEC_ERR_EXECUTED_CAP);
+    if (src.executed.length > EXEC_ERR_EXECUTED_CAP) {
+      out.executed_truncated = true;
+      out.executed_note =
+        `Showing the first ${EXEC_ERR_EXECUTED_CAP} executed node ids (fixed cap, no parameter raises it). ` +
+        "This list is run-order context only — the failure itself is identified by node_id/node_type/exception above.";
+    }
+  }
+
+  // Tensor-sized surfaces. current_inputs is withheld unconditionally: it
+  // serializes the live input VALUES (latents/images) and is exactly what
+  // overflowed the context in #664. current_outputs ships only when small.
+  if (src.current_inputs != null) {
+    out.current_inputs_omitted = true;
+    out.current_inputs_note =
+      "Withheld by design: ComfyUI serializes the LIVE input values here (latents/images — " +
+      "tensor-sized), which is the payload that overflowed the agent context (#664). The failing " +
+      "node_id/node_type and exception above identify the fault; this view never ships the values.";
+  }
+  if (src.current_outputs != null) {
+    let json = null;
+    try {
+      json = JSON.stringify(src.current_outputs);
+    } catch {
+      json = null; // circular / BigInt — falls through to the disclosed omission
+    }
+    if (json != null && json.length <= EXEC_ERR_OUTPUTS_JSON_CAP) {
+      out.current_outputs = src.current_outputs;
+    } else {
+      out.current_outputs_omitted = true;
+      out.current_outputs_note =
+        `Omitted: exceeds the ${EXEC_ERR_OUTPUTS_JSON_CAP}-char serialized cap, or could not be ` +
+        "serialized (fixed cap, no parameter raises it — this view never ships oversized output " +
+        "values). Output values can be tensor-sized; the failing node and exception above " +
+        "identify the fault without them.";
+    }
+  }
+
+  return out;
+}


### PR DESCRIPTION
`last_execution_error` is still emitted verbatim (web/js/comfyui-mcp-panel.js:10134) — tensor-sized `current_inputs`/traceback payloads ship unbounded; only the newer nodes[].reasons[] surface is token-bounded.

closes #664