### PR TITLE
widget write honesty: callback-throw refusals and numeric-labelled combo options

### DIFF
--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -2448,7 +2448,7 @@ test("#639: a throwing callback on a verified write is DISCLOSED (write_warning)
   assert.ok(typeof set.write_warning === "string", "the throw is disclosed, never hidden");
   assert.match(set.write_warning, /thrown while applying the write/, "the throw is disclosed, not hidden");
   assert.match(set.write_warning, /reading 'options'/, "carries the original error message");
-  assert.match(set.write_warning, /DID take effect/, "says the write applied — never a clean-failure report");
+  assert.match(set.write_warning, /IS in effect/, "says the requested value is present — never a clean-failure report");
 });
 
 test("#639: a promoted write whose inner callback throws still discloses success when inner + rail both verify", () => {
@@ -2544,7 +2544,7 @@ test("#639: a throwing value SETTER on a verified write is disclosed without une
   assert.equal(node.widgets[0].value, 5, "the setter applied before throwing — the write is in effect");
   assert.match(set.write_warning ?? "", /thrown while applying the write/);
   assert.match(set.write_warning ?? "", /setter boom/);
-  assert.match(set.write_warning ?? "", /DID take effect/);
+  assert.match(set.write_warning ?? "", /IS in effect/);
   assert.doesNotMatch(
     set.write_warning ?? "",
     /never ran|after applying|callback threw|setter threw/,
@@ -2670,4 +2670,58 @@ test("#667×#507 (delta-gate): sibling lists that DISAGREE on a numeric label's 
   assert.equal(inner.widgets[0].value, "", "inner untouched");
   assert.equal(railWidget.value, "", "rail untouched — never holds a value its list does not contain");
   assert.equal(proxyWidget.value, "", "proxy untouched");
+});
+
+test("#639 (delta-gate 2): a FROZEN widget already holding the requested value reports 'IS in effect', never that this write caused it", () => {
+  // Assigning to a frozen widget's `value` throws in strict mode with NO user
+  // code involved; read-back then finds the requested value already present.
+  // The disclosure must claim presence, not causation.
+  const w = Object.freeze({ name: "n", type: "INT", value: 10 });
+  const node = { id: 1, type: "N", widgets: [w] };
+  const set = applyWidgetWrite(node, "n", 10, HOOKS);
+  assert.equal(node.widgets[0].value, 10);
+  assert.match(set.write_warning ?? "", /thrown while applying the write/);
+  assert.match(set.write_warning ?? "", /IS in effect/);
+  assert.doesNotMatch(set.write_warning ?? "", /DID take effect/);
+});
+
+test("#667×#507 (delta-gate 2): re-validation checks the SAME list snapshot as admission — a stateful non-function source cannot cause a false DISAGREE", () => {
+  // A buggy-but-in-scope accessor answers differently per read. Admission reads
+  // the list exactly once per sibling (isComboWidget, the function-type probe,
+  // then comboOptions); a FOURTH read only happens if re-validation re-reads the
+  // source instead of checking the admission snapshot — which must not happen.
+  let reads = 0;
+  const railWidget = {
+    name: "model_alias",
+    type: "combo",
+    value: "",
+    options: {
+      get values() {
+        reads += 1;
+        return reads <= 3 ? ["lt", "4444"] : ["changed-after-admission"];
+      },
+    },
+  };
+  const inner = {
+    id: 301,
+    type: "StarOllamaPromptHelper",
+    widgets: [{ name: "model", type: "combo", options: { values: [] }, value: "" }],
+  };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "301" ? inner : null) };
+  const parent = {
+    id: 320,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [{ name: "model_alias", _widget: railWidget, widget: { name: "model_alias" }, _subgraphSlot: { name: "model_alias" } }],
+    widgets: [railWidget],
+  };
+  const resolveSource = (_n, si) =>
+    si?.name === "model_alias" ? { sourceNodeId: "301", sourceWidgetName: "model" } : null;
+  const set = applyWidgetWrite(parent, "model_alias", 4444, {
+    ...HOOKS,
+    resolveSource,
+    acceptEmptyComboOptions: true,
+  });
+  assert.equal(set.value, "4444");
+  assert.equal(railWidget.value, "4444", "admitted against the admission-time list, not a later answer");
 });

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -1211,7 +1211,7 @@ test("#366×#639: an INNER callback that throws AFTER the value landed is DISCLO
   // NOT rolled back: both inner and parent rail hold the new value (verified).
   assert.equal(inner.widgets[0].value, 704, "inner write stays — it took effect before the throw");
   assert.equal(parent.widgets[0].value, 704, "rail synced — never reported failed while applied");
-  assert.match(set.write_warning ?? "", /callback threw \(inner boom\)/, "the throw is disclosed, not hidden");
+  assert.match(set.write_warning ?? "", /thrown while applying the write \(inner boom\)/, "the throw is disclosed, not hidden");
   assert.equal(afterChangeRan, true, "afterChange still closes the envelope");
 });
 
@@ -1361,7 +1361,7 @@ test("#366×#639: a THROWING afterChange hook does not bypass verification — a
   // effect and is disclosed, never reported as a clean failure (#639).
   assert.equal(inner.widgets[0].value, 704, "inner write stays");
   assert.equal(parent.widgets[0].value, 704, "rail synced");
-  assert.match(set.write_warning ?? "", /callback threw \(inner boom\)/);
+  assert.match(set.write_warning ?? "", /thrown while applying the write \(inner boom\)/);
 });
 
 test("#366 HARD FAIL: an afterChange HOOK that re-stales the rail (after all callbacks) is still caught + rolled back", () => {
@@ -2446,7 +2446,7 @@ test("#639: a throwing callback on a verified write is DISCLOSED (write_warning)
   assert.equal(node.widgets[0].value, 10, "the write took effect and is NOT rolled back");
   assert.equal(set.value, 10);
   assert.ok(typeof set.write_warning === "string", "the throw is disclosed, never hidden");
-  assert.match(set.write_warning, /callback threw/, "names what threw");
+  assert.match(set.write_warning, /thrown while applying the write/, "the throw is disclosed, not hidden");
   assert.match(set.write_warning, /reading 'options'/, "carries the original error message");
   assert.match(set.write_warning, /DID take effect/, "says the write applied — never a clean-failure report");
 });
@@ -2489,7 +2489,7 @@ test("#639: a callback that throws AND leaves the write unverified still FAILS +
     () => applyWidgetWrite(node, "c", "a", HOOKS),
     (err) =>
       err instanceof WidgetWriteError &&
-      /callback threw \(combo boom\)/.test(err.message) &&
+      /thrown while applying the write \(combo boom\)/.test(err.message) &&
       /did not retain the requested value/.test(err.message),
   );
   assert.equal(seenAtCallback, "a", "the requested value WAS assigned before the callback fired");
@@ -2517,13 +2517,13 @@ test("#639: a thrown WidgetWriteError on an unverified write keeps BOTH causes a
     (err) =>
       err instanceof WidgetWriteError &&
       err.combo === true && // the refresh-retry signal survives the composition
-      /callback threw \(combo list went stale\)/.test(err.message) &&
+      /thrown while applying the write \(combo list went stale\)/.test(err.message) &&
       /did not retain the requested value/.test(err.message),
   );
   assert.equal(node.widgets[0].value, "b", "rolled back");
 });
 
-test("#639: a throwing value SETTER on a verified write is disclosed with union wording (no unestablishable attribution)", () => {
+test("#639: a throwing value SETTER on a verified write is disclosed without unestablishable attribution", () => {
   const w = {
     name: "n",
     type: "INT",
@@ -2542,21 +2542,21 @@ test("#639: a throwing value SETTER on a verified write is disclosed with union 
   const node = { id: 1, type: "N", widgets: [w] };
   const set = applyWidgetWrite(node, "n", 5, HOOKS);
   assert.equal(node.widgets[0].value, 5, "the setter applied before throwing — the write is in effect");
-  assert.match(set.write_warning ?? "", /setter or callback threw/);
+  assert.match(set.write_warning ?? "", /thrown while applying the write/);
   assert.match(set.write_warning ?? "", /setter boom/);
   assert.match(set.write_warning ?? "", /DID take effect/);
   assert.doesNotMatch(
     set.write_warning ?? "",
-    /never ran|after applying|the widget's own callback threw/,
-    "claims nothing the mechanism cannot establish (codex round-3)",
+    /never ran|after applying|callback threw|setter threw/,
+    "names NO construct — the mechanism cannot establish which one threw (codex delta-gate)",
   );
 });
 
-test("#639: a REENTRANT setter (one that invokes the callback, which throws) gets the same honest union wording", () => {
+test("#639: a REENTRANT setter (one that invokes the callback, which throws) gets the same attribution-free wording", () => {
   // codex round-2/3: a value setter can invoke `this.callback()` itself and let
   // its exception propagate — then the callback DID run and threw, but the throw
-  // surfaced from the ASSIGNMENT. The disclosure names only the union and never
-  // asserts which one threw or whether the callback ran.
+  // surfaced from the ASSIGNMENT. The disclosure never asserts which construct
+  // threw or whether the callback ran.
   const w = {
     name: "n",
     type: "INT",
@@ -2575,9 +2575,9 @@ test("#639: a REENTRANT setter (one that invokes the callback, which throws) get
   const node = { id: 1, type: "N", widgets: [w] };
   const set = applyWidgetWrite(node, "n", 5, HOOKS);
   assert.equal(node.widgets[0].value, 5, "the write is in effect");
-  assert.match(set.write_warning ?? "", /setter or callback threw/);
+  assert.match(set.write_warning ?? "", /thrown while applying the write/);
   assert.match(set.write_warning ?? "", /reentrant boom/);
-  assert.doesNotMatch(set.write_warning ?? "", /callback never ran|after applying/);
+  assert.doesNotMatch(set.write_warning ?? "", /callback never ran|after applying|callback threw|setter threw/);
 });
 
 test("#667×#507: a numeric request against a numeric-LABELLED rail option is ADOPTED on the empty-inner-list path (codex round-3)", () => {
@@ -2607,4 +2607,67 @@ test("#667×#507: a numeric request matching NO rail label is still refused on t
   );
   assert.equal(inner.widgets[0].value, "", "untouched — refused before any mutation");
   assert.equal(railWidget.value, "", "rail untouched");
+});
+
+// A promoted EMPTY-inner combo whose rail AND a parent-facing display proxy both
+// carry option lists — the multi-sibling shape the delta-gate finding exercised.
+const makeEmptyInnerRailProxyFixture = (railValues, proxyValues) => {
+  const inner = {
+    id: 301,
+    type: "StarOllamaPromptHelper",
+    widgets: [{ name: "model", type: "combo", options: { values: [] }, value: "" }],
+  };
+  const subgraph = { _nodes: [inner], getNodeById: (id) => (String(id) === "301" ? inner : null) };
+  const railWidget = { name: "model_alias", type: "combo", options: { values: railValues }, value: "" };
+  const proxyWidget = { name: "model_alias", type: "combo", options: { values: proxyValues }, value: "" };
+  const parent = {
+    id: 320,
+    type: "SubgraphNode",
+    subgraph,
+    inputs: [
+      { name: "model_alias", _widget: railWidget, widget: proxyWidget, _subgraphSlot: { name: "model_alias" } },
+    ],
+    widgets: [railWidget, proxyWidget],
+  };
+  const resolveSource = (_node, subgraphInput) =>
+    subgraphInput?.name === "model_alias" ? { sourceNodeId: "301", sourceWidgetName: "model" } : null;
+  return { parent, inner, railWidget, proxyWidget, resolveSource };
+};
+
+test("#667×#507: sibling lists that AGREE on the label's type adopt once and write the original everywhere", () => {
+  const { parent, inner, railWidget, proxyWidget, resolveSource } = makeEmptyInnerRailProxyFixture(
+    ["lt", "4444"],
+    ["4444", "hq"],
+  );
+  const set = applyWidgetWrite(parent, "model_alias", 4444, {
+    ...HOOKS,
+    resolveSource,
+    acceptEmptyComboOptions: true,
+  });
+  assert.equal(set.value, "4444");
+  assert.equal(typeof set.value, "string");
+  assert.equal(inner.widgets[0].value, "4444");
+  assert.equal(railWidget.value, "4444");
+  assert.equal(proxyWidget.value, "4444", "every mutated sibling holds the SAME original option");
+});
+
+test("#667×#507 (delta-gate): sibling lists that DISAGREE on a numeric label's type fail closed — never a flip-flopped write", () => {
+  // Rail lists the label as the STRING "4444"; the display proxy lists the NUMBER
+  // 4444. Adopting the rail's original and then the proxy's would end with the
+  // numeric value written into the rail whose list only holds the string — the
+  // final value must be re-validated against EVERY sibling, and here no single
+  // value satisfies both lists, so the write refuses without mutating anything.
+  const { parent, inner, railWidget, proxyWidget, resolveSource } = makeEmptyInnerRailProxyFixture(["4444"], [4444]);
+  assert.throws(
+    () =>
+      applyWidgetWrite(parent, "model_alias", 4444, {
+        ...HOOKS,
+        resolveSource,
+        acceptEmptyComboOptions: true,
+      }),
+    (err) => err instanceof WidgetWriteError && /DISAGREE/.test(err.message),
+  );
+  assert.equal(inner.widgets[0].value, "", "inner untouched");
+  assert.equal(railWidget.value, "", "rail untouched — never holds a value its list does not contain");
+  assert.equal(proxyWidget.value, "", "proxy untouched");
 });

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -2725,3 +2725,50 @@ test("#667×#507 (delta-gate 2): re-validation checks the SAME list snapshot as 
   assert.equal(set.value, "4444");
   assert.equal(railWidget.value, "4444", "admitted against the admission-time list, not a later answer");
 });
+
+test("#667×#507 (final gate): a sibling list with a THROWING later-index getter still admits an exact early member (no-adoption path unchanged)", () => {
+  // includes() finds the exact match at index 0 and never touches the throwing
+  // getter at index 1 — but a full-array snapshot copy WOULD. The snapshot must
+  // be exception-safe so this legitimate write behaves exactly as before.
+  const tricky = ["llama3.2:3b"];
+  Object.defineProperty(tricky, "1", {
+    get() {
+      throw new Error("late getter boom");
+    },
+  });
+  const { parent, inner, railWidget, resolveSource } = makeEmptyInnerPromotedFixture({ values: tricky });
+  const set = applyWidgetWrite(parent, "model_alias", "llama3.2:3b", {
+    ...HOOKS,
+    resolveSource,
+    acceptEmptyComboOptions: true,
+  });
+  assert.equal(set.value, "llama3.2:3b");
+  assert.equal(railWidget.value, "llama3.2:3b");
+  assert.equal(inner.widgets[0].value, "llama3.2:3b");
+});
+
+test("#667×#507 (final gate): an adoption that cannot be re-validated against a sibling (unreadable tail) fails closed — no false success", () => {
+  // The rail strictly contains the requested "4444" at index 0, but its list
+  // cannot be fully copied (throwing getter at index 1). The proxy then label-
+  // adopts the NUMBER 4444, changing the write value — and the rail can no
+  // longer be re-validated against it. Refuse, mutating nothing.
+  const trickyRail = ["4444"];
+  Object.defineProperty(trickyRail, "1", {
+    get() {
+      throw new Error("late getter boom");
+    },
+  });
+  const { parent, inner, railWidget, proxyWidget, resolveSource } = makeEmptyInnerRailProxyFixture(trickyRail, [4444]);
+  assert.throws(
+    () =>
+      applyWidgetWrite(parent, "model_alias", "4444", {
+        ...HOOKS,
+        resolveSource,
+        acceptEmptyComboOptions: true,
+      }),
+    (err) => err instanceof WidgetWriteError && /could not be fully read/.test(err.message),
+  );
+  assert.equal(inner.widgets[0].value, "", "inner untouched");
+  assert.equal(railWidget.value, "", "rail untouched");
+  assert.equal(proxyWidget.value, "", "proxy untouched");
+});

--- a/browser_tests/unit/widget-write.test.mjs
+++ b/browser_tests/unit/widget-write.test.mjs
@@ -583,10 +583,16 @@ test("combo: a numeric index is NOT reinterpreted as a dropdown position", () =>
   assert.equal(node.widgets[0].value, "alpha");
 });
 
-test("combo: numeric-STRING options reject the number 1 (strict, no coercion) but accept \"1\"", () => {
+test("combo: numeric-STRING options accept the number 1 via a LABEL match and write back the original string (#667)", () => {
+  // The old strict rule refused the number 1 against ["0","1","2"] so a number
+  // could never be reinterpreted as an index. The #667 fallback keeps that
+  // guarantee differently: it matches the option's LABEL stringified and writes
+  // back the list's ORIGINAL value, so the number itself never lands on the widget.
   const mk = () => ({ id: 1, type: "N", widgets: [{ name: "c", options: { values: ["0", "1", "2"] }, value: "0" }] });
   const nNum = mk();
-  assert.throws(() => applyWidgetWrite(nNum, "c", 1, HOOKS), WidgetWriteError);
+  const set = applyWidgetWrite(nNum, "c", 1, HOOKS);
+  assert.equal(set.value, "1");
+  assert.equal(typeof set.value, "string", "the original string option is written, never the incoming number");
   const nStr = mk();
   assert.equal(applyWidgetWrite(nStr, "c", "1", HOOKS).value, "1");
 });
@@ -1184,26 +1190,28 @@ test("#366: the rail write lands INSIDE the undo envelope (before afterChange fi
   assert.equal(parentValueAtAfterChange, 704, "parent must be written before afterChange (single undo op)");
 });
 
-test("#366 ATOMIC: an INNER callback that throws rolls BOTH back — no partial write, surfaced as failure", () => {
+test("#366×#639: an INNER callback that throws AFTER the value landed is DISCLOSED, not rolled back — the write already took effect", () => {
+  // #639 changed the contract this test pinned: a throw from the callback fires
+  // AFTER both values are assigned, so inner=new / parent=stale — the partial
+  // state #366's atomicity guards — cannot arise from the throw. Rolling a
+  // verified write back and refusing would report failure for work that succeeded
+  // and invite a destructive retry, so the result is success + write_warning.
   const { parent, inner, resolveSource } = makePromotedMirrorFixture();
   // Inner widget callback throws AFTER the inner value is assigned.
   inner.widgets[0].callback = () => {
     throw new Error("inner boom");
   };
   let afterChangeRan = false;
-  assert.throws(
-    () =>
-      applyWidgetWrite(parent, "value_2", 704, {
-        resolveSource,
-        afterChange: () => {
-          afterChangeRan = true;
-        },
-      }),
-    (err) => err instanceof WidgetWriteError && /callback threw|inner boom/.test(err.message),
-  );
-  // ROLLED BACK: neither inner nor parent rail left at the new value.
-  assert.equal(inner.widgets[0].value, 1280, "inner rolled back");
-  assert.equal(parent.widgets[0].value, 1280, "parent rolled back — never inner=new/parent=stale");
+  const set = applyWidgetWrite(parent, "value_2", 704, {
+    resolveSource,
+    afterChange: () => {
+      afterChangeRan = true;
+    },
+  });
+  // NOT rolled back: both inner and parent rail hold the new value (verified).
+  assert.equal(inner.widgets[0].value, 704, "inner write stays — it took effect before the throw");
+  assert.equal(parent.widgets[0].value, 704, "rail synced — never reported failed while applied");
+  assert.match(set.write_warning ?? "", /callback threw \(inner boom\)/, "the throw is disclosed, not hidden");
   assert.equal(afterChangeRan, true, "afterChange still closes the envelope");
 });
 
@@ -1273,7 +1281,10 @@ test("#366: a value setter that REJECTS the rollback surfaces an HONEST partial-
       this._touched = true;
     },
     callback() {
-      throw new Error("inner boom");
+      // #639: a callback THROW no longer forces rollback (a verified write is
+      // disclosed, not refused) — drift the value so verification fails and the
+      // rollback path under test actually runs.
+      this._v = 999;
     },
   };
   inner.widgets.push(w);
@@ -1307,11 +1318,14 @@ test("#366: a value setter that SILENTLY IGNORES the rollback (keeps the new val
     },
     set value(x) {
       // Ignore any attempt to restore the old value (silent no-op rollback).
-      if (x === 1280 && this._v === 704) return;
+      if (x === 1280 && this._v !== 1280) return;
       this._v = x;
     },
     callback() {
-      throw new Error("inner boom");
+      // #639: a callback THROW no longer forces rollback (a verified write is
+      // disclosed, not refused) — drift the value so verification fails and the
+      // rollback path under test actually runs.
+      this._v = 999;
     },
   };
   inner.widgets.push(w);
@@ -1334,7 +1348,7 @@ test("#366: a value setter that SILENTLY IGNORES the rollback (keeps the new val
   );
 });
 
-test("#366 ATOMIC: a THROWING afterChange hook does not bypass rollback", () => {
+test("#366×#639: a THROWING afterChange hook does not bypass verification — a verified write is still disclosed, not refused", () => {
   const { parent, inner, resolveSource } = makePromotedMirrorFixture();
   inner.widgets[0].callback = () => {
     throw new Error("inner boom");
@@ -1342,12 +1356,12 @@ test("#366 ATOMIC: a THROWING afterChange hook does not bypass rollback", () => 
   const afterChange = () => {
     throw new Error("afterChange boom");
   };
-  assert.throws(
-    () => applyWidgetWrite(parent, "value_2", 704, { resolveSource, afterChange }),
-    (err) => err instanceof WidgetWriteError && /callback threw|inner boom/.test(err.message),
-  );
-  assert.equal(inner.widgets[0].value, 1280, "inner rolled back despite a throwing afterChange hook");
-  assert.equal(parent.widgets[0].value, 1280, "rail untouched / rolled back");
+  const set = applyWidgetWrite(parent, "value_2", 704, { resolveSource, afterChange });
+  // Verification ran to completion despite BOTH hooks throwing: the write took
+  // effect and is disclosed, never reported as a clean failure (#639).
+  assert.equal(inner.widgets[0].value, 704, "inner write stays");
+  assert.equal(parent.widgets[0].value, 704, "rail synced");
+  assert.match(set.write_warning ?? "", /callback threw \(inner boom\)/);
 });
 
 test("#366 HARD FAIL: an afterChange HOOK that re-stales the rail (after all callbacks) is still caught + rolled back", () => {
@@ -1483,7 +1497,10 @@ test("#366 HARD FAIL: a rollback afterChange that mutates the RESTORED composite
     name: "value",
     value: { on: true, lora: "a.safetensors", strength: 1 },
     callback() {
-      throw new Error("inner boom"); // force entry into rollback
+      // #639: a callback THROW no longer forces rollback (a verified write is
+      // disclosed, not refused) — drift the written composite in place so
+      // verification fails and the rollback path under test actually runs.
+      this.value.strength = 12345;
     },
   };
   const inner = { id: 300, type: "Power Lora Loader (rgthree)", widgets: [innerW] };
@@ -1909,9 +1926,11 @@ test("#477 P1: a STATEFUL afterChange that RE-ADDS a replacement proxy every fir
   const newProxy = { name: "value_2", type: "INT", value: 1280 };
   const hostInput = { name: "value_2", _widget: railWidget, widget: oldProxy, _subgraphSlot: { name: "value_2" } };
   const parent = { id: 267, type: "SubgraphNode", subgraph, inputs: [hostInput], widgets: [railWidget, oldProxy] };
-  // Inner callback throws → forces rollback.
-  inner.widgets[0].callback = () => {
-    throw new Error("inner callback boom");
+  // Inner callback DRIFTS the value → verification fails → forces rollback. (#639:
+  // a callback THROW no longer forces rollback — a verified write is disclosed,
+  // not refused — so this fixture drives the rollback path with a real failure.)
+  inner.widgets[0].callback = function () {
+    this.value = 999;
   };
   const resolveSource = (_n, si) =>
     si?.name === "value_2" ? { sourceNodeId: "257", sourceWidgetName: "value" } : null;
@@ -2327,4 +2346,265 @@ test("#507 confirmation round: coerceWidgetValue reports empty-list acceptance O
     (err) => err instanceof WidgetWriteError && err.emptyOptions === true && err.combo === true,
   );
   assert.equal(outOff.emptyAcceptanceUsed, undefined);
+});
+
+// ---- #667: combo options whose LABEL is numeric (VHS ProRes profile "4444",
+//      ffv1 level ["0","1","3"]). The tool's value param is string|number|boolean,
+//      so a numeric-looking label can arrive as the NUMBER 4444 after upstream JSON
+//      coercion; strict typed membership then refused it even though the label sits
+//      right there in the option list — the option was unreachable via the panel.
+//      The fallback matches the option's LABEL stringified and writes back the
+//      option's ORIGINAL value from the list — never the incoming scalar — so no
+//      mistyped value lands on the widget and no number is ever reinterpreted as
+//      an INDEX (#240 intact). -----------------------------------------------
+
+test("#667: a numeric-labelled combo option is reachable when the value arrives as a NUMBER (VHS ProRes '4444')", () => {
+  const mk = () => ({
+    id: 226,
+    type: "VHS_VideoCombine",
+    widgets: [
+      {
+        name: "profile",
+        type: "combo",
+        options: { values: ["lt", "standard", "hq", "4444", "4444xq"] },
+        value: "hq",
+      },
+    ],
+  });
+  const node = mk();
+  const set = applyWidgetWrite(node, "profile", 4444, HOOKS);
+  assert.equal(set.value, "4444");
+  assert.equal(typeof set.value, "string", "the list's ORIGINAL string option is written, not the incoming number");
+  assert.equal(node.widgets[0].value, "4444");
+  // The exact string still takes the strict-membership path (unchanged).
+  assert.equal(applyWidgetWrite(mk(), "profile", "4444", HOOKS).value, "4444");
+  // A non-numeric label is untouched by the fallback.
+  assert.equal(applyWidgetWrite(mk(), "profile", "4444xq", HOOKS).value, "4444xq");
+});
+
+test("#667: string-valued numeric enum labels (ffv1 level ['0','1','3']) accept the number, write back the string", () => {
+  const node = { id: 1, type: "N", widgets: [{ name: "level", options: { values: ["0", "1", "3"] }, value: "0" }] };
+  const set = applyWidgetWrite(node, "level", 3, HOOKS);
+  assert.equal(set.value, "3");
+  assert.equal(typeof set.value, "string");
+  assert.equal(node.widgets[0].value, "3");
+});
+
+test("#667: the fallback writes back the ORIGINAL option — string '1' into numeric options [0,1,2] writes the NUMBER 1", () => {
+  const node = { id: 1, type: "N", widgets: [{ name: "c", options: { values: [0, 1, 2] }, value: 0 }] };
+  const set = applyWidgetWrite(node, "c", "1", HOOKS);
+  assert.equal(set.value, 1);
+  assert.equal(typeof set.value, "number", "the list's original numeric option, not the incoming string");
+});
+
+test("#667: an OFF-list numeric value is still refused — no label match, no index semantics (#240)", () => {
+  const mk = () => ({
+    id: 1,
+    type: "N",
+    widgets: [{ name: "c", options: { values: ["lt", "standard", "hq", "4444", "4444xq"] }, value: "hq" }],
+  });
+  // 1 is not a LABEL in this list — it must NOT be read as a dropdown position.
+  assert.throws(
+    () => applyWidgetWrite(mk(), "c", 1, HOOKS),
+    (err) => err instanceof WidgetWriteError && /not a valid option/.test(err.message),
+  );
+  assert.throws(
+    () => applyWidgetWrite(mk(), "c", 9999, HOOKS),
+    (err) => err instanceof WidgetWriteError && /not a valid option/.test(err.message),
+  );
+  const untouched = mk();
+  assert.throws(() => applyWidgetWrite(untouched, "c", 1, HOOKS), WidgetWriteError);
+  assert.equal(untouched.widgets[0].value, "hq", "must not have mutated on reject");
+});
+
+// ---- #639: a throwing widget callback does NOT void a write that already took
+//      effect. The value assignments run BEFORE the callback fires, so when the
+//      callback throws (MiniMaxH3Director's `duration`: the DaSiWa extension's
+//      lengthWidget callback throws on `options` of undefined on ANY programmatic
+//      invocation) the write may ALREADY be in effect. Rolling it back and
+//      refusing would report failure for work that succeeded and invite a
+//      destructive retry — so a VERIFIED write is reported as applied with a
+//      `write_warning` disclosure; only a write that ALSO fails verification
+//      fails + rolls back. ---------------------------------------------------
+
+test("#639: a throwing callback on a verified write is DISCLOSED (write_warning), not refused — the value stays", () => {
+  const node = {
+    id: 2693,
+    type: "MiniMaxH3Director",
+    widgets: [
+      {
+        name: "duration",
+        type: "INT",
+        value: 5,
+        callback() {
+          throw new TypeError("Cannot read properties of undefined (reading 'options')");
+        },
+      },
+    ],
+  };
+  const set = applyWidgetWrite(node, "duration", 10, HOOKS);
+  assert.equal(node.widgets[0].value, 10, "the write took effect and is NOT rolled back");
+  assert.equal(set.value, 10);
+  assert.ok(typeof set.write_warning === "string", "the throw is disclosed, never hidden");
+  assert.match(set.write_warning, /callback threw/, "names what threw");
+  assert.match(set.write_warning, /reading 'options'/, "carries the original error message");
+  assert.match(set.write_warning, /DID take effect/, "says the write applied — never a clean-failure report");
+});
+
+test("#639: a promoted write whose inner callback throws still discloses success when inner + rail both verify", () => {
+  const { parent, inner, resolveSource } = makePromotedMirrorFixture();
+  inner.widgets[0].callback = () => {
+    throw new Error("inner boom");
+  };
+  const set = applyWidgetWrite(parent, "value_2", 704, { resolveSource });
+  assert.equal(inner.widgets[0].value, 704);
+  assert.equal(parent.widgets[0].value, 704, "rail synced — the write genuinely took effect");
+  assert.equal(set.promoted_from.parent_widget_synced, true);
+  assert.match(set.write_warning ?? "", /inner boom/);
+});
+
+test("#639: a callback that throws AND leaves the write unverified still FAILS + rolls back, naming the throw", () => {
+  // Three DISTINCT values so each leg is proven independently (codex round-1):
+  // seenAtCallback==="a" proves the assignment ran BEFORE the callback; the drift
+  // to "c" is what verification rejects; the final "b" proves rollback restored
+  // the ORIGINAL — not the drifted value, not the requested one.
+  let seenAtCallback;
+  const node = {
+    id: 1,
+    type: "N",
+    widgets: [
+      {
+        name: "c",
+        options: { values: ["a", "b", "c"] },
+        value: "b",
+        callback() {
+          seenAtCallback = this.value;
+          this.value = "c"; // drift to a THIRD value, THEN throw
+          throw new Error("combo boom");
+        },
+      },
+    ],
+  };
+  assert.throws(
+    () => applyWidgetWrite(node, "c", "a", HOOKS),
+    (err) =>
+      err instanceof WidgetWriteError &&
+      /callback threw \(combo boom\)/.test(err.message) &&
+      /did not retain the requested value/.test(err.message),
+  );
+  assert.equal(seenAtCallback, "a", "the requested value WAS assigned before the callback fired");
+  assert.equal(node.widgets[0].value, "b", "rolled back to the ORIGINAL — not the drift, not the request");
+});
+
+test("#639: a thrown WidgetWriteError on an unverified write keeps BOTH causes and its retry flags", () => {
+  const node = {
+    id: 1,
+    type: "N",
+    widgets: [
+      {
+        name: "c",
+        options: { values: ["a", "b", "c"] },
+        value: "b",
+        callback() {
+          this.value = "c"; // drift so verification fails
+          throw new WidgetWriteError("combo list went stale", { combo: true });
+        },
+      },
+    ],
+  };
+  assert.throws(
+    () => applyWidgetWrite(node, "c", "a", HOOKS),
+    (err) =>
+      err instanceof WidgetWriteError &&
+      err.combo === true && // the refresh-retry signal survives the composition
+      /callback threw \(combo list went stale\)/.test(err.message) &&
+      /did not retain the requested value/.test(err.message),
+  );
+  assert.equal(node.widgets[0].value, "b", "rolled back");
+});
+
+test("#639: a throwing value SETTER on a verified write is disclosed with union wording (no unestablishable attribution)", () => {
+  const w = {
+    name: "n",
+    type: "INT",
+    _v: 1,
+    get value() {
+      return this._v;
+    },
+    set value(x) {
+      this._v = x; // applies FIRST…
+      throw new Error("setter boom"); // …then throws
+    },
+    callback() {
+      throw new Error("must not be blamed — this never fired");
+    },
+  };
+  const node = { id: 1, type: "N", widgets: [w] };
+  const set = applyWidgetWrite(node, "n", 5, HOOKS);
+  assert.equal(node.widgets[0].value, 5, "the setter applied before throwing — the write is in effect");
+  assert.match(set.write_warning ?? "", /setter or callback threw/);
+  assert.match(set.write_warning ?? "", /setter boom/);
+  assert.match(set.write_warning ?? "", /DID take effect/);
+  assert.doesNotMatch(
+    set.write_warning ?? "",
+    /never ran|after applying|the widget's own callback threw/,
+    "claims nothing the mechanism cannot establish (codex round-3)",
+  );
+});
+
+test("#639: a REENTRANT setter (one that invokes the callback, which throws) gets the same honest union wording", () => {
+  // codex round-2/3: a value setter can invoke `this.callback()` itself and let
+  // its exception propagate — then the callback DID run and threw, but the throw
+  // surfaced from the ASSIGNMENT. The disclosure names only the union and never
+  // asserts which one threw or whether the callback ran.
+  const w = {
+    name: "n",
+    type: "INT",
+    _v: 1,
+    get value() {
+      return this._v;
+    },
+    set value(x) {
+      this._v = x;
+      this.callback(); // reentrant: the callback runs INSIDE the setter and throws
+    },
+    callback() {
+      throw new Error("reentrant boom");
+    },
+  };
+  const node = { id: 1, type: "N", widgets: [w] };
+  const set = applyWidgetWrite(node, "n", 5, HOOKS);
+  assert.equal(node.widgets[0].value, 5, "the write is in effect");
+  assert.match(set.write_warning ?? "", /setter or callback threw/);
+  assert.match(set.write_warning ?? "", /reentrant boom/);
+  assert.doesNotMatch(set.write_warning ?? "", /callback never ran|after applying/);
+});
+
+test("#667×#507: a numeric request against a numeric-LABELLED rail option is ADOPTED on the empty-inner-list path (codex round-3)", () => {
+  // The promoted empty-list acceptance writes a value nothing validated; the
+  // sibling rail cross-check is the only validator — and it applied STRICT typed
+  // membership, so a numeric 4444 against the rail's string "4444" was refused
+  // even though the rail itself publishes that option (#667 on the #507 path).
+  const { parent, inner, railWidget, resolveSource } = makeEmptyInnerPromotedFixture({
+    values: ["lt", "standard", "hq", "4444", "4444xq"],
+  });
+  const set = applyWidgetWrite(parent, "model_alias", 4444, {
+    ...HOOKS,
+    resolveSource,
+    acceptEmptyComboOptions: true,
+  });
+  assert.equal(set.value, "4444");
+  assert.equal(typeof set.value, "string", "the rail list's ORIGINAL option is written, not the incoming number");
+  assert.equal(inner.widgets[0].value, "4444");
+  assert.equal(railWidget.value, "4444", "the rail is synced with its own original option");
+});
+
+test("#667×#507: a numeric request matching NO rail label is still refused on the empty-inner-list path", () => {
+  const { parent, inner, railWidget, resolveSource } = makeEmptyInnerPromotedFixture({ values: ["lt", "hq"] });
+  assert.throws(
+    () => applyWidgetWrite(parent, "model_alias", 4444, { ...HOOKS, resolveSource, acceptEmptyComboOptions: true }),
+    (err) => err instanceof WidgetWriteError && /not a valid option for the parent subgraph/.test(err.message),
+  );
+  assert.equal(inner.widgets[0].value, "", "untouched — refused before any mutation");
+  assert.equal(railWidget.value, "", "rail untouched");
 });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -16031,7 +16031,7 @@ function describeCommand(cmd, msg, reply) {
             text:
               `Set ${r.set?.widget} = ${JSON.stringify(r.set?.value)} on node ${r.set?.node_id}` +
               (writeDisclosed
-                ? ` — value applied and verified, but an exception was thrown while applying it; side effects may not have run or completed`
+                ? ` — requested value verified in effect, but an exception was thrown while applying it; side effects may not have run or completed`
                 : ""),
             detail: `was ${JSON.stringify(r.set?.previous)}`,
           };

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15860,11 +15860,12 @@ function describeCommand(cmd, msg, reply) {
       // but guard defensively — never render an un-synced promoted write as a plain
       // "Set …" success, or the summary would repeat the exact #366 lie.
       const railStale = r.set?.promoted_from && r.set.promoted_from.parent_widget_synced === false;
-      // #639: a write whose widget write-path (value setter or callback) threw
-      // AFTER the value verified is APPLIED (not refused) — the summary must carry
-      // the disclosure, never a plain "Set …" success that hides the uncertainty
-      // about side effects. The wording stays neutral: `write_warning` covers a
-      // throwing SETTER too, so it must not assert the callback was the thrower.
+      // #639: a write whose apply path threw AFTER the value verified is APPLIED
+      // (not refused) — the summary must carry the disclosure, never a plain
+      // "Set …" success that hides the uncertainty about side effects. The wording
+      // names NO construct: `write_warning` covers a throwing setter, accessor, or
+      // callback on any of the widgets the write touches, so it must not assert
+      // which one threw (codex delta-gate).
       const writeDisclosed = typeof r.set?.write_warning === "string";
       return railStale
         ? {
@@ -15877,7 +15878,7 @@ function describeCommand(cmd, msg, reply) {
             text:
               `Set ${r.set?.widget} = ${JSON.stringify(r.set?.value)} on node ${r.set?.node_id}` +
               (writeDisclosed
-                ? ` — value applied and verified, but the widget's setter or callback threw; side effects may not have run or completed`
+                ? ` — value applied and verified, but an exception was thrown while applying it; side effects may not have run or completed`
                 : ""),
             detail: `was ${JSON.stringify(r.set?.previous)}`,
           };

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15737,6 +15737,12 @@ function describeCommand(cmd, msg, reply) {
       // but guard defensively — never render an un-synced promoted write as a plain
       // "Set …" success, or the summary would repeat the exact #366 lie.
       const railStale = r.set?.promoted_from && r.set.promoted_from.parent_widget_synced === false;
+      // #639: a write whose widget write-path (value setter or callback) threw
+      // AFTER the value verified is APPLIED (not refused) — the summary must carry
+      // the disclosure, never a plain "Set …" success that hides the uncertainty
+      // about side effects. The wording stays neutral: `write_warning` covers a
+      // throwing SETTER too, so it must not assert the callback was the thrower.
+      const writeDisclosed = typeof r.set?.write_warning === "string";
       return railStale
         ? {
             icon: "pi-exclamation-triangle",
@@ -15744,8 +15750,12 @@ function describeCommand(cmd, msg, reply) {
             detail: `was ${JSON.stringify(r.set?.previous)}`,
           }
         : {
-            icon: "pi-sliders-h",
-            text: `Set ${r.set?.widget} = ${JSON.stringify(r.set?.value)} on node ${r.set?.node_id}`,
+            icon: writeDisclosed ? "pi-exclamation-triangle" : "pi-sliders-h",
+            text:
+              `Set ${r.set?.widget} = ${JSON.stringify(r.set?.value)} on node ${r.set?.node_id}` +
+              (writeDisclosed
+                ? ` — value applied and verified, but the widget's setter or callback threw; side effects may not have run or completed`
+                : ""),
             detail: `was ${JSON.stringify(r.set?.previous)}`,
           };
     }

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -73,6 +73,25 @@ export function isComboWidget(widget) {
   return String(widget?.type ?? "").toLowerCase() === "combo";
 }
 
+/**
+ * #667: the index of the option whose stringified LABEL equals the stringified
+ * scalar `value`, or -1. Scalars only (string/number/boolean) on both sides.
+ * Used by the combo coercion fallback AND by the #507 empty-list sibling rail
+ * cross-check, so both apply the SAME matching rule; callers always write back
+ * the list's ORIGINAL option, never the incoming scalar, so no number is ever
+ * reinterpreted as an index and no mistyped value lands (#240 intact).
+ */
+function optionLabelIndex(options, value) {
+  if (typeof value !== "string" && typeof value !== "number" && typeof value !== "boolean") {
+    return -1;
+  }
+  return options.findIndex(
+    (o) =>
+      (typeof o === "string" || typeof o === "number" || typeof o === "boolean") &&
+      String(o) === String(value),
+  );
+}
+
 // litegraph "number"/"slider" and Comfy "INT"/"FLOAT" all render numeric.
 export function isNumericWidget(widget) {
   const t = String(widget?.type ?? "").toLowerCase();
@@ -378,10 +397,20 @@ export function coerceWidgetValue(
         { combo: true, emptyOptions: true },
       );
     }
-    // STRICT typed membership: no numeric<->string coercion. Numeric options
-    // [0,1,2] accept numeric 1; string options ["0","1","2"] require "1", never
-    // the number 1 (which would otherwise behave like an index).
+    // STRICT typed membership first: an exact-typed option is always writable.
     if (options.includes(value)) return value;
+    // #667: NUMERIC-LABELLED options (VHS ProRes profile ["lt",…,"4444",…], ffv1
+    // level ["0","1","3"]). The tool's `value` param is string|number|boolean, so a
+    // numeric-looking label can arrive as the NUMBER 4444 after upstream JSON
+    // coercion, and strict membership then refused it even though the label sits in
+    // the list — the option was unreachable via the panel. Fall back to matching the
+    // option's LABEL stringified, and on a match return the option's ORIGINAL value
+    // from the list — NEVER the incoming scalar — so no mistyped value lands on the
+    // widget and no number is ever reinterpreted as an INDEX: the #240 concern was
+    // a number silently read as a dropdown position, and that stays refused below
+    // (options ["alpha","beta","gamma"] with value 1 matches no label).
+    const labelIdx = optionLabelIndex(options, value);
+    if (labelIdx >= 0) return options[labelIdx];
     const preview = options.slice(0, 40).map((o) => JSON.stringify(o)).join(", ");
     throw new WidgetWriteError(
       `Value ${JSON.stringify(value)} is not a valid option for combo widget ` +
@@ -909,7 +938,11 @@ export function applyWidgetWrite(
   // /object_info gate authorized (#458), and resolveWidgetWrite also fails closed if
   // the AUTHORITATIVE parent rail widget can't be identified (#366).
   const coerceOutcome = {};
-  const { targetNode, widget: w, coerced, promotedFrom, promotedParentWidget, promotedParentWidgets, promotedHostInput } =
+  // `coerced` is mutable: the #507 empty-list sibling cross-check below may ADOPT a
+  // rail option's original value when the numeric-labelled fallback matches there
+  // (#667 codex round-3) — the write then lands the list's own value, not the
+  // caller's coerced scalar.
+  let { targetNode, widget: w, coerced, promotedFrom, promotedParentWidget, promotedParentWidgets, promotedHostInput } =
     resolveWidgetWrite(node, widgetName, value, resolveSource, assertTargetWritable, promotedResolution, {
       acceptEmptyComboOptions,
       // Filled in by coerceWidgetValue when the EMPTY-LIST acceptance (not ordinary
@@ -975,6 +1008,17 @@ export function applyWidgetWrite(
       const otherOptions = comboOptions(other);
       if (!Array.isArray(otherOptions) || otherOptions.length === 0) continue;
       if (otherOptions.includes(coerced)) continue;
+      // #667 (codex round-3): the SAME numeric-labelled-option rule applies here —
+      // a numeric request (4444) against a rail list holding the string "4444" must
+      // not refuse an option the rail itself publishes. On a label match ADOPT the
+      // rail list's ORIGINAL value for the whole write (the inner's empty list
+      // accepted any scalar, so writing the rail's own option there is at least as
+      // valid), never the incoming scalar — the #240 no-index guarantee holds.
+      const siblingLabelIdx = optionLabelIndex(otherOptions, coerced);
+      if (siblingLabelIdx >= 0) {
+        coerced = otherOptions[siblingLabelIdx];
+        continue;
+      }
       throw new WidgetWriteError(
         `Value ${JSON.stringify(coerced)} is not a valid option for the parent subgraph's ` +
           `combo widget "${other.name}" (${otherOptions.length} options), which this promoted ` +
@@ -1090,26 +1134,37 @@ export function applyWidgetWrite(
     // same single invocation a manual UI edit of the promoted control performs.
     w.callback?.(coerced, canvas, targetNode, targetNode.pos, undefined);
   } catch (err) {
+    // #639 (codex round-3): WHICH statement threw is NOT recorded — a value setter
+    // can invoke the callback itself, the callback property can be a throwing
+    // accessor, and a setter can throw before OR after applying — so no
+    // attribution the mechanism cannot establish is ever reported. The disclosure
+    // below names the union ("the widget's setter or callback") only.
     threw = err;
   } finally {
     safeAfter();
   }
 
   // VERIFY AFTER afterChange. Compute the failure reason (if any) WITHOUT mutating,
-  // so rollback happens in its own envelope below. Order: a thrown callback; then a
-  // value that did not stick on the inner (#240) or the authoritative rail (#366);
-  // then a promotion-relationship change (re-resolved from the LIVE graph, catching
-  // an outer link, a replaced/detached host input, or a re-pointed slot→widget map).
+  // so rollback happens in its own envelope below. Order: a value that did not stick
+  // on the inner (#240) or the authoritative rail (#366); then a promotion-
+  // relationship change (re-resolved from the LIVE graph, catching an outer link, a
+  // replaced/detached host input, or a re-pointed slot→widget map).
+  //
+  // #639: a THROWN callback is deliberately NOT a verdict in this chain. The value
+  // assignments above run BEFORE the callback fires, so when the callback throws the
+  // write may ALREADY be in effect (MiniMaxH3Director's `duration`: the extension's
+  // own callback throws on `options` of undefined on ANY programmatic invocation,
+  // which made the widget permanently unwritable when any throw forced a refusal).
+  // Rolling a VERIFIED write back and refusing would report failure for work that
+  // succeeded and invite a destructive retry — so the structural checks below
+  // decide. A throw on a verified write is DISCLOSED on the success result
+  // (`write_warning`); only a write that ALSO fails verification fails + rolls
+  // back, with the throw named as the likely cause.
   let failure = null;
   let originalErr = null;
   let driftFailure = false;
-  if (threw) {
-    originalErr = threw instanceof WidgetWriteError ? threw : null;
-    failure =
-      threw instanceof WidgetWriteError
-        ? threw.message
-        : `a widget callback threw (${threw?.message ?? threw})`;
-  } else if (!matchesExpected(w.value)) {
+  let writeWarning = null;
+  if (!matchesExpected(w.value)) {
     failure =
       `Widget "${w.name}" on node ${targetNode.id} (${targetNode.type}) did not retain the ` +
       `requested value: wrote ${JSON.stringify(expected)} but it became ${JSON.stringify(w.value)}.`;
@@ -1176,6 +1231,43 @@ export function applyWidgetWrite(
           recheckThrew ? "; re-resolving the promotion threw" : ""
         }), so the rail that was synced is no longer the value that serializes at queue time. Rolled ` +
         `back to avoid a silently-stale render (#366).`;
+    }
+  }
+
+  // #639: reconcile a captured throw with the verification verdict. The write
+  // VERIFIED (value + rail + proxies retained, promotion topology intact) — the
+  // throw came from the widget's own write path: DISCLOSE it on the success
+  // result, never report a clean failure for an applied write. The write did NOT
+  // verify — the throw is the likely cause: compose BOTH causes into the failure
+  // (codex round-1: a thrown WidgetWriteError saved un-composed discarded the
+  // structural detail), keeping the error's retry flags (combo/emptyOptions)
+  // through the composition.
+  //
+  // Attribution (codex rounds 2-3): only what the mechanism can ESTABLISH is
+  // claimed. An exception caught above came from evaluating the value assignments
+  // or the callback read/invocation — but a value setter can itself invoke the
+  // callback, the callback property can be a throwing accessor, and a setter can
+  // throw before OR after applying — so the message names the UNION ("the
+  // widget's setter or callback") and never asserts which one threw, whether the
+  // callback ran, or whether a setter applied first. What IS established and
+  // claimed: the value was verified written by read-back, and the write's side
+  // effects may not have run or completed.
+  if (threw) {
+    const threwLabel = "the widget's setter or callback threw";
+    if (!failure) {
+      writeWarning =
+        `${threwLabel} (${threw?.message ?? threw}), but the value was verified written ` +
+        `by read-back — the write DID take effect and was NOT rolled back. Side effects ` +
+        `the write would normally trigger (refreshing dependent widgets, previews, ` +
+        `thumbnails) may not have run or completed; inspect the node if dependents look stale.`;
+    } else {
+      failure = `${threwLabel} (${threw?.message ?? threw}); ${failure}`;
+      if (threw instanceof WidgetWriteError) {
+        originalErr = new WidgetWriteError(failure, {
+          combo: threw.combo,
+          emptyOptions: threw.emptyOptions,
+        });
+      }
     }
   }
 
@@ -1386,11 +1478,14 @@ export function applyWidgetWrite(
   // parent_widget_synced is reported for observability / defense-in-depth in the
   // panel summary. display_widgets_synced counts the additional parent-facing display
   // proxies also synced so the outer node no longer shows a stale value (#477).
+  // #639: write_warning discloses a widget callback that threw AFTER the verified
+  // write landed — the value IS in effect, its side effects are uncertain.
   return {
     node_id: targetNode.id,
     widget: w.name,
     previous: parentWidget ? previousParent : previous,
     value: w.value,
+    ...(writeWarning ? { write_warning: writeWarning } : {}),
     ...(promotedFrom
       ? {
           inner_previous: previous,

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1015,7 +1015,22 @@ export function applyWidgetWrite(
       }
       const otherOptions = comboOptions(other);
       if (!Array.isArray(otherOptions) || otherOptions.length === 0) continue;
-      siblingSnapshots.push({ name: other.name, options: otherOptions.slice() });
+      // Snapshot the list AS READ (a stateful non-function source can answer
+      // differently per read — the re-validation below must check the SAME list
+      // admission was decided against, codex delta-gate 2). The copy itself can
+      // throw: a buggy-but-in-scope array with a THROWING later-index getter must
+      // not crash a write `includes()` would admit from an early member (codex
+      // final gate) — so a failed copy records a NULL snapshot and admission
+      // proceeds exactly as before. Only if an adoption later REPLACES the value
+      // does the missing snapshot matter, and then the write fails closed (below)
+      // rather than skip re-validation.
+      let snapshot = null;
+      try {
+        snapshot = otherOptions.slice();
+      } catch {
+        snapshot = null;
+      }
+      siblingSnapshots.push({ name: other.name, options: snapshot });
       if (otherOptions.includes(coerced)) continue;
       // #667 (codex round-3): the SAME numeric-labelled-option rule applies here —
       // a numeric request (4444) against a rail list holding the string "4444" must
@@ -1046,13 +1061,21 @@ export function applyWidgetWrite(
     // fail closed.
     if (adoptedOption) {
       for (const snap of siblingSnapshots) {
-        if (snap.options.includes(coerced)) continue;
+        // A NULL snapshot (the list could not be fully copied — a member access
+        // threw) means the adopted value cannot be re-validated against this
+        // sibling at all: fail closed rather than skip the check. A snapshot's
+        // elements are plain copies, so `includes` here cannot throw.
+        if (snap.options && snap.options.includes(coerced)) continue;
         throw new WidgetWriteError(
-          `The sibling combo widgets this promoted write mutates DISAGREE about option ` +
-            `${JSON.stringify(coerced)}: after matching it by label, "${snap.name}"'s list ` +
-            `(${snap.options.length} options) does not contain the resulting value — the lists ` +
-            `hold the same label with different types (or not at all), so no single value ` +
-            `satisfies every list. Refusing to write.`,
+          snap.options
+            ? `The sibling combo widgets this promoted write mutates DISAGREE about option ` +
+              `${JSON.stringify(coerced)}: after matching it by label, "${snap.name}"'s list ` +
+              `(${snap.options.length} options) does not contain the resulting value — the lists ` +
+              `hold the same label with different types (or not at all), so no single value ` +
+              `satisfies every list. Refusing to write.`
+            : `The sibling combo widget "${snap.name}"'s option list could not be fully read ` +
+              `(a member access threw), so the label-adopted value ${JSON.stringify(coerced)} ` +
+              `cannot be re-validated against it. Refusing to write.`,
         );
       }
     }

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -990,6 +990,7 @@ export function applyWidgetWrite(
   // source can disagree with the first, which would turn the narrowing into an escape
   // hatch around this very check (codex confirmation round).
   if (coerceOutcome.emptyAcceptanceUsed) {
+    let adoptedOption = false;
     for (const other of [parentWidget, ...displayWidgets]) {
       if (!other || !isComboWidget(other)) continue;
       // A DYNAMIC (function) sibling list is UNVERIFIABLE from here (codex round-5): it
@@ -1016,6 +1017,7 @@ export function applyWidgetWrite(
       // valid), never the incoming scalar — the #240 no-index guarantee holds.
       const siblingLabelIdx = optionLabelIndex(otherOptions, coerced);
       if (siblingLabelIdx >= 0) {
+        adoptedOption = true;
         coerced = otherOptions[siblingLabelIdx];
         continue;
       }
@@ -1025,6 +1027,28 @@ export function applyWidgetWrite(
           `write also mutates — the inner widget's option list is empty, but this one is not. ` +
           `Refusing to write.`,
       );
+    }
+    // Codex delta-gate: an adoption REPLACES the value mid-loop, and a later sibling
+    // can adopt a DIFFERENTLY-TYPED original of the same label (rail lists "4444",
+    // a display proxy lists 4444) — the final write would then land a value an
+    // earlier-validated sibling's list does not contain. When any adoption
+    // happened, re-validate the FINAL value against every sibling: a sibling that
+    // does not strictly contain it conflicts (same label, different type — or the
+    // value absent there), so no single value satisfies every list; fail closed.
+    if (adoptedOption) {
+      for (const other of [parentWidget, ...displayWidgets]) {
+        if (!other || !isComboWidget(other) || typeof other.options?.values === "function") continue;
+        const otherOptions = comboOptions(other);
+        if (!Array.isArray(otherOptions) || otherOptions.length === 0) continue;
+        if (otherOptions.includes(coerced)) continue;
+        throw new WidgetWriteError(
+          `The sibling combo widgets this promoted write mutates DISAGREE about option ` +
+            `${JSON.stringify(coerced)}: after matching it by label, "${other.name}"'s list ` +
+            `(${otherOptions.length} options) does not contain the resulting value — the lists ` +
+            `hold the same label with different types (or not at all), so no single value ` +
+            `satisfies every list. Refusing to write.`,
+        );
+      }
     }
   }
 
@@ -1134,11 +1158,12 @@ export function applyWidgetWrite(
     // same single invocation a manual UI edit of the promoted control performs.
     w.callback?.(coerced, canvas, targetNode, targetNode.pos, undefined);
   } catch (err) {
-    // #639 (codex round-3): WHICH statement threw is NOT recorded — a value setter
-    // can invoke the callback itself, the callback property can be a throwing
-    // accessor, and a setter can throw before OR after applying — so no
-    // attribution the mechanism cannot establish is ever reported. The disclosure
-    // below names the union ("the widget's setter or callback") only.
+    // #639 (codex round-3 + delta-gate): WHICH construct threw is NOT recorded — a
+    // value setter can invoke the callback itself, `w.callback` can be a throwing
+    // accessor, a setter can throw before OR after applying, a rail/proxy setter
+    // or a `targetNode.pos` getter can throw, and a write to a frozen widget
+    // throws with no user code at all — so no attribution the mechanism cannot
+    // establish is ever reported. The disclosure below names none of them.
     threw = err;
   } finally {
     safeAfter();
@@ -1236,24 +1261,24 @@ export function applyWidgetWrite(
 
   // #639: reconcile a captured throw with the verification verdict. The write
   // VERIFIED (value + rail + proxies retained, promotion topology intact) — the
-  // throw came from the widget's own write path: DISCLOSE it on the success
-  // result, never report a clean failure for an applied write. The write did NOT
-  // verify — the throw is the likely cause: compose BOTH causes into the failure
-  // (codex round-1: a thrown WidgetWriteError saved un-composed discarded the
-  // structural detail), keeping the error's retry flags (combo/emptyOptions)
-  // through the composition.
+  // throw came from applying the write: DISCLOSE it on the success result, never
+  // report a clean failure for an applied write. The write did NOT verify — the
+  // throw is the likely cause: compose BOTH causes into the failure (codex
+  // round-1: a thrown WidgetWriteError saved un-composed discarded the structural
+  // detail), keeping the error's retry flags (combo/emptyOptions) through the
+  // composition.
   //
-  // Attribution (codex rounds 2-3): only what the mechanism can ESTABLISH is
-  // claimed. An exception caught above came from evaluating the value assignments
-  // or the callback read/invocation — but a value setter can itself invoke the
-  // callback, the callback property can be a throwing accessor, and a setter can
-  // throw before OR after applying — so the message names the UNION ("the
-  // widget's setter or callback") and never asserts which one threw, whether the
-  // callback ran, or whether a setter applied first. What IS established and
-  // claimed: the value was verified written by read-back, and the write's side
-  // effects may not have run or completed.
+  // Attribution (codex rounds 2-3 + delta-gate): only what the mechanism can
+  // ESTABLISH is claimed. The write envelope evaluates value setters on the inner,
+  // rail, and display proxies, property reads (`w.callback` may be a throwing
+  // accessor, `targetNode.pos` a getter), and the callback invocation — and a
+  // plain write to a frozen widget throws with NO user code involved. So the
+  // message does not name ANY construct: only that an exception was thrown while
+  // applying the write. What IS established and claimed: the value was verified
+  // written by read-back, and the write's side effects may not have run or
+  // completed.
   if (threw) {
-    const threwLabel = "the widget's setter or callback threw";
+    const threwLabel = "an exception was thrown while applying the write";
     if (!failure) {
       writeWarning =
         `${threwLabel} (${threw?.message ?? threw}), but the value was verified written ` +

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -991,6 +991,13 @@ export function applyWidgetWrite(
   // hatch around this very check (codex confirmation round).
   if (coerceOutcome.emptyAcceptanceUsed) {
     let adoptedOption = false;
+    // Each sibling's option list AS READ during admission. A STATEFUL non-function
+    // source (an accessor/proxy answering differently per read) must not be read a
+    // second time: the post-adoption re-validation below checks the SAME snapshots
+    // admission was decided against — a fresh read could produce a false DISAGREE
+    // or pass against a list that has since changed (codex delta-gate 2), the same
+    // never-read-twice rule `emptyAcceptanceUsed` itself follows (above).
+    const siblingSnapshots = [];
     for (const other of [parentWidget, ...displayWidgets]) {
       if (!other || !isComboWidget(other)) continue;
       // A DYNAMIC (function) sibling list is UNVERIFIABLE from here (codex round-5): it
@@ -1008,6 +1015,7 @@ export function applyWidgetWrite(
       }
       const otherOptions = comboOptions(other);
       if (!Array.isArray(otherOptions) || otherOptions.length === 0) continue;
+      siblingSnapshots.push({ name: other.name, options: otherOptions.slice() });
       if (otherOptions.includes(coerced)) continue;
       // #667 (codex round-3): the SAME numeric-labelled-option rule applies here —
       // a numeric request (4444) against a rail list holding the string "4444" must
@@ -1032,19 +1040,17 @@ export function applyWidgetWrite(
     // can adopt a DIFFERENTLY-TYPED original of the same label (rail lists "4444",
     // a display proxy lists 4444) — the final write would then land a value an
     // earlier-validated sibling's list does not contain. When any adoption
-    // happened, re-validate the FINAL value against every sibling: a sibling that
-    // does not strictly contain it conflicts (same label, different type — or the
-    // value absent there), so no single value satisfies every list; fail closed.
+    // happened, re-validate the FINAL value against every sibling's SNAPSHOT: a
+    // sibling that does not strictly contain it conflicts (same label, different
+    // type — or the value absent there), so no single value satisfies every list;
+    // fail closed.
     if (adoptedOption) {
-      for (const other of [parentWidget, ...displayWidgets]) {
-        if (!other || !isComboWidget(other) || typeof other.options?.values === "function") continue;
-        const otherOptions = comboOptions(other);
-        if (!Array.isArray(otherOptions) || otherOptions.length === 0) continue;
-        if (otherOptions.includes(coerced)) continue;
+      for (const snap of siblingSnapshots) {
+        if (snap.options.includes(coerced)) continue;
         throw new WidgetWriteError(
           `The sibling combo widgets this promoted write mutates DISAGREE about option ` +
-            `${JSON.stringify(coerced)}: after matching it by label, "${other.name}"'s list ` +
-            `(${otherOptions.length} options) does not contain the resulting value — the lists ` +
+            `${JSON.stringify(coerced)}: after matching it by label, "${snap.name}"'s list ` +
+            `(${snap.options.length} options) does not contain the resulting value — the lists ` +
             `hold the same label with different types (or not at all), so no single value ` +
             `satisfies every list. Refusing to write.`,
         );
@@ -1268,23 +1274,25 @@ export function applyWidgetWrite(
   // detail), keeping the error's retry flags (combo/emptyOptions) through the
   // composition.
   //
-  // Attribution (codex rounds 2-3 + delta-gate): only what the mechanism can
+  // Attribution (codex rounds 2-3 + delta-gates): only what the mechanism can
   // ESTABLISH is claimed. The write envelope evaluates value setters on the inner,
   // rail, and display proxies, property reads (`w.callback` may be a throwing
   // accessor, `targetNode.pos` a getter), and the callback invocation — and a
   // plain write to a frozen widget throws with NO user code involved. So the
   // message does not name ANY construct: only that an exception was thrown while
-  // applying the write. What IS established and claimed: the value was verified
-  // written by read-back, and the write's side effects may not have run or
-  // completed.
+  // applying the write. And read-back verifies only that the requested value IS
+  // present — not that THIS write put it there (a frozen widget may already have
+  // held it), so the disclosure claims "IS in effect", never "DID take effect".
+  // What IS established and claimed: the requested value is present by read-back,
+  // and the write's side effects may not have run or completed.
   if (threw) {
     const threwLabel = "an exception was thrown while applying the write";
     if (!failure) {
       writeWarning =
-        `${threwLabel} (${threw?.message ?? threw}), but the value was verified written ` +
-        `by read-back — the write DID take effect and was NOT rolled back. Side effects ` +
-        `the write would normally trigger (refreshing dependent widgets, previews, ` +
-        `thumbnails) may not have run or completed; inspect the node if dependents look stale.`;
+        `${threwLabel} (${threw?.message ?? threw}); the requested value IS in effect — ` +
+        `verified present by read-back — and was NOT rolled back. Side effects the write ` +
+        `would normally trigger (refreshing dependent widgets, previews, thumbnails) may ` +
+        `not have run or completed; inspect the node if dependents look stale.`;
     } else {
       failure = `${threwLabel} (${threw?.message ?? threw}); ${failure}`;
       if (threw instanceof WidgetWriteError) {


### PR DESCRIPTION
Two widget-write defects, same file (web/js/lib/widget-write.js):
- a widget callback that throws (MiniMaxH3Director duration, options undefined) hard-refuses the write (:1079-1111)
- a combo option whose label is numeric (ProRes profile "4444") is refused by strict typed membership (:384)

closes #639
closes #667