### PR TITLE
reconnect recovery: proactive rebind, tmp-key invalidation, subgraph scope receipts, refresh_nodes honesty

### DIFF
--- a/browser_tests/unit/canvas-navigation.test.mjs
+++ b/browser_tests/unit/canvas-navigation.test.mjs
@@ -416,10 +416,125 @@ test("#619: the shipping enter does not claim settled when the canvas moved afte
   assert.match(reply.note, /binding check passed, but the view has already moved elsewhere/);
 });
 
-test("#619: the shipping exit carries the same receipt wiring", () => {
-  // Source-level pin: exit must run the same confirmCanvasNavigation receipt
+test("#619: the shipping exit carries the same receipt wiring", () => {  // Source-level pin: exit must run the same confirmCanvasNavigation receipt
   // (delete it and this fails) and must keep the immediate-parent resolution.
   const body = extractMethod("async graph_exit_subgraph()");
   assert.match(body, /await confirmCanvasNavigation\(\{/, "exit runs the receipt");
   assert.match(body, /findSubgraphOwner\(rootGraph, graph\)\?\.parentGraph/, "exit keeps the immediate-parent walk (#412)");
+});
+
+// ---------------------------------------------------------------------------
+// r9: the terminal observation is three-state — an UNREADABLE canvas read is
+// neither "still on target" nor "moved elsewhere"
+// ---------------------------------------------------------------------------
+
+function buildExitSubgraph(doubles) {
+  const body = extractMethod("async graph_exit_subgraph()").replace(
+    /^async graph_exit_subgraph\(/,
+    "async function graph_exit_subgraph(",
+  );
+  const factory = new Function(
+    "getGraphCtx",
+    "findSubgraphOwner",
+    "confirmCanvasNavigation",
+    "describeActiveGraph",
+    "assertGraphBoundToActiveWorkflow",
+    "coerceMessageText",
+    `return (${body});`,
+  );
+  return factory(
+    doubles.getGraphCtx,
+    doubles.findSubgraphOwner,
+    doubles.confirmCanvasNavigation ?? confirmCanvasNavigation,
+    doubles.describeActiveGraph,
+    doubles.assertGraphBoundToActiveWorkflow,
+    doubles.coerceMessageText ?? ((v) => String(v)),
+  );
+}
+
+test("#619: an UNREADABLE terminal canvas read discloses uncertainty, not displacement (codex r9, enter)", async () => {
+  const rootGraph = { _nodes: [], name: "root" };
+  const sub = { _nodes: [], name: "sub", rootGraph };
+  const node = { id: 105, type: "SubgraphNode", subgraph: sub };
+  let reads = 0;
+  const canvas = {
+    _g: rootGraph,
+    // Reads 1-4 complete the receipt (landing, assert's ctx read, survival
+    // re-read); the reply's own reads throw.
+    get graph() {
+      reads += 1;
+      if (reads >= 5) throw new Error("canvas getter exploded");
+      return this._g;
+    },
+    openSubgraph(s) {
+      this._g = s;
+    },
+    setDirty() {},
+  };
+  const app = { graph: rootGraph, canvas };
+  const enter = buildEnterSubgraph({
+    getGraphCtx: () => ({ app, graph: canvas.graph, rootGraph, canvas }),
+    resolveNode: () => node,
+    describeActiveGraph: (g) => ({ scope: g === rootGraph ? "root" : "subgraph" }),
+    assertGraphBoundToActiveWorkflow: () => {},
+  });
+  const reply = await enter({ node_id: 105 });
+  assert.equal(reply.settled, false);
+  assert.match(reply.note, /could not determine which/, "uncertainty is disclosed");
+  assert.doesNotMatch(reply.note, /navigated away|moved elsewhere/, "no displacement claim without an observation");
+  assert.match(reply.note, /panel_graph_outline/, "the remedy is a scope read");
+});
+
+test("#619: the shipping exit settles at root on a clean navigation (driven, not just source-pinned)", async () => {
+  const rootGraph = { _nodes: [], name: "root" };
+  const sub = { _nodes: [], name: "sub", rootGraph };
+  const canvas = {
+    _g: sub,
+    get graph() {
+      return this._g;
+    },
+    setGraph(g) {
+      this._g = g;
+    },
+    setDirty() {},
+  };
+  const app = { graph: rootGraph, canvas };
+  const exit = buildExitSubgraph({
+    getGraphCtx: () => ({ app, graph: canvas.graph, rootGraph, canvas }),
+    findSubgraphOwner: () => ({ id: 105, parentGraph: rootGraph }),
+    describeActiveGraph: (g) => ({ scope: g === rootGraph ? "root" : "subgraph" }),
+    assertGraphBoundToActiveWorkflow: () => {},
+  });
+  const reply = await exit();
+  assert.equal(reply.settled, true);
+  assert.equal(reply.viewing.scope, "root");
+});
+
+test("#619: an UNREADABLE terminal canvas read discloses uncertainty, not displacement (codex r9, exit)", async () => {
+  const rootGraph = { _nodes: [], name: "root" };
+  const sub = { _nodes: [], name: "sub", rootGraph };
+  let reads = 0;
+  const canvas = {
+    _g: sub,
+    get graph() {
+      reads += 1;
+      if (reads >= 5) throw new Error("canvas getter exploded");
+      return this._g;
+    },
+    setGraph(g) {
+      this._g = g;
+    },
+    setDirty() {},
+  };
+  const app = { graph: rootGraph, canvas };
+  const exit = buildExitSubgraph({
+    getGraphCtx: () => ({ app, graph: canvas.graph, rootGraph, canvas }),
+    findSubgraphOwner: () => ({ id: 105, parentGraph: rootGraph }),
+    describeActiveGraph: (g) => ({ scope: g === rootGraph ? "root" : "subgraph" }),
+    assertGraphBoundToActiveWorkflow: () => {},
+  });
+  const reply = await exit();
+  assert.equal(reply.settled, false);
+  assert.match(reply.note, /could not determine which/);
+  assert.doesNotMatch(reply.note, /navigated away|moved elsewhere/);
 });

--- a/browser_tests/unit/canvas-navigation.test.mjs
+++ b/browser_tests/unit/canvas-navigation.test.mjs
@@ -84,6 +84,26 @@ test("#619: a probe that MOVES the canvas off the target cannot produce a settle
   assert.equal(r.landed, false);
 });
 
+test("#619: a probe that THROWS after moving the canvas still updates the terminal landed (codex r3)", async () => {
+  const target = { name: "sub" };
+  const root = { name: "root" };
+  let current = target;
+  const r = await confirmCanvasNavigation({
+    readCanvasGraph: () => current,
+    target,
+    assertBound: () => {
+      current = root;
+      throw new Error("probe failed after the heal moved the canvas");
+    },
+    tries: 3,
+    sleep: instantSleep,
+  });
+  assert.equal(r.landed, false, "the terminal verdict describes the LAST observation, not the pre-probe one");
+  assert.equal(r.everLanded, true);
+  assert.equal(r.bound, false);
+  assert.match(String(r.lastError?.message), /probe failed/);
+});
+
 test("#619: a navigation that lands a few polls later is still confirmed", async () => {
   const target = { name: "sub" };
   let current = { name: "root" };

--- a/browser_tests/unit/canvas-navigation.test.mjs
+++ b/browser_tests/unit/canvas-navigation.test.mjs
@@ -384,6 +384,38 @@ test("#619: the shipping enter DISCLOSES (never refuses) when the canvas landed 
   assert.match(reply.note, /navigated away/, "the displacement is disclosed, not a false refusal");
 });
 
+test("#619: the shipping enter does not claim settled when the canvas moved after the receipt (codex r8)", async () => {
+  const rootGraph = { _nodes: [], name: "root" };
+  const sub = { _nodes: [], name: "sub", rootGraph };
+  const elsewhere = { _nodes: [], name: "elsewhere", rootGraph };
+  const node = { id: 105, type: "SubgraphNode", subgraph: sub };
+  let reads = 0;
+  const canvas = {
+    _g: rootGraph,
+    // Reads: 1 = enter's own getGraphCtx, 2 = the receipt's landing read,
+    // 3 = the receipt assert's getGraphCtx, 4 = the post-probe survival
+    // re-read, 5+ = the reply's fresh observation (viewing + stillOnTarget).
+    get graph() {
+      reads += 1;
+      return reads <= 4 ? this._g : elsewhere;
+    },
+    openSubgraph(s) {
+      this._g = s;
+    },
+    setDirty() {},
+  };
+  const app = { graph: rootGraph, canvas };
+  const enter = buildEnterSubgraph({
+    getGraphCtx: () => ({ app, graph: canvas.graph, rootGraph, canvas }),
+    resolveNode: () => node,
+    describeActiveGraph: (g) => ({ scope: g === rootGraph ? "root" : "subgraph" }),
+    assertGraphBoundToActiveWorkflow: () => {},
+  });
+  const reply = await enter({ node_id: 105 });
+  assert.equal(reply.settled, false, "no settled receipt for a scope the canvas has already left");
+  assert.match(reply.note, /binding check passed, but the view has already moved elsewhere/);
+});
+
 test("#619: the shipping exit carries the same receipt wiring", () => {
   // Source-level pin: exit must run the same confirmCanvasNavigation receipt
   // (delete it and this fails) and must keep the immediate-parent resolution.

--- a/browser_tests/unit/canvas-navigation.test.mjs
+++ b/browser_tests/unit/canvas-navigation.test.mjs
@@ -538,3 +538,62 @@ test("#619: an UNREADABLE terminal canvas read discloses uncertainty, not displa
   assert.match(reply.note, /could not determine which/);
   assert.doesNotMatch(reply.note, /navigated away|moved elsewhere/);
 });
+
+test("#619: a MISSING post-receipt canvas is unreadable, not 'moved elsewhere' (codex r10, enter)", async () => {
+  const rootGraph = { _nodes: [], name: "root" };
+  const sub = { _nodes: [], name: "sub", rootGraph };
+  const node = { id: 105, type: "SubgraphNode", subgraph: sub };
+  let reads = 0;
+  const canvas = {
+    _g: rootGraph,
+    get graph() {
+      reads += 1;
+      if (reads >= 5) return null; // canvas/graph gone during teardown
+      return this._g;
+    },
+    openSubgraph(s) {
+      this._g = s;
+    },
+    setDirty() {},
+  };
+  const app = { graph: rootGraph, canvas };
+  const enter = buildEnterSubgraph({
+    getGraphCtx: () => ({ app, graph: canvas.graph, rootGraph, canvas }),
+    resolveNode: () => node,
+    describeActiveGraph: (g) => ({ scope: g === rootGraph ? "root" : "subgraph" }),
+    assertGraphBoundToActiveWorkflow: () => {},
+  });
+  const reply = await enter({ node_id: 105 });
+  assert.equal(reply.settled, false);
+  assert.match(reply.note, /could not determine which/);
+  assert.doesNotMatch(reply.note, /navigated away|moved elsewhere/);
+});
+
+test("#619: a MISSING post-receipt canvas is unreadable, not 'moved elsewhere' (codex r10, exit)", async () => {
+  const rootGraph = { _nodes: [], name: "root" };
+  const sub = { _nodes: [], name: "sub", rootGraph };
+  let reads = 0;
+  const canvas = {
+    _g: sub,
+    get graph() {
+      reads += 1;
+      if (reads >= 5) return null;
+      return this._g;
+    },
+    setGraph(g) {
+      this._g = g;
+    },
+    setDirty() {},
+  };
+  const app = { graph: rootGraph, canvas };
+  const exit = buildExitSubgraph({
+    getGraphCtx: () => ({ app, graph: canvas.graph, rootGraph, canvas }),
+    findSubgraphOwner: () => ({ id: 105, parentGraph: rootGraph }),
+    describeActiveGraph: (g) => ({ scope: g === rootGraph ? "root" : "subgraph" }),
+    assertGraphBoundToActiveWorkflow: () => {},
+  });
+  const reply = await exit();
+  assert.equal(reply.settled, false);
+  assert.match(reply.note, /could not determine which/);
+  assert.doesNotMatch(reply.note, /navigated away|moved elsewhere/);
+});

--- a/browser_tests/unit/canvas-navigation.test.mjs
+++ b/browser_tests/unit/canvas-navigation.test.mjs
@@ -306,7 +306,7 @@ test("#619: the shipping enter reports settled:true when the canvas lands and th
   assert.equal(reply.settled, true);
 });
 
-test("#619: the shipping enter REFUSES when openSubgraph never moves the canvas (nothing applied)", async () => {
+test("#619: the shipping enter REFUSES when the canvas was never observed inside the subgraph — without claiming non-occurrence", async () => {
   const scope = fakeScope({ land: false });
   const enter = buildEnterSubgraph({
     ...scope,
@@ -314,8 +314,13 @@ test("#619: the shipping enter REFUSES when openSubgraph never moves the canvas 
   });
   await assert.rejects(
     () => enter({ node_id: 105 }),
-    /could not confirm[\s\S]*did NOT take effect/,
-    "a no-op navigation must not report `entered`",
+    /could not confirm[\s\S]*do NOT assume nothing happened/,
+    "an unconfirmed navigation is an uncertainty, not a proven no-op (codex r5)",
+  );
+  await assert.rejects(
+    () => enter({ node_id: 105 }),
+    /panel_graph_outline/,
+    "the next step it names is a scope READ, not a blind retry",
   );
 });
 

--- a/browser_tests/unit/canvas-navigation.test.mjs
+++ b/browser_tests/unit/canvas-navigation.test.mjs
@@ -63,6 +63,27 @@ test("#619: a canvas observed landed then displaced is everLanded:true, landed:f
   assert.match(String(r.lastError?.message), /still settling/);
 });
 
+test("#619: a probe that MOVES the canvas off the target cannot produce a settled receipt (codex r2 P1)", async () => {
+  // getGraphCtx's verified rebind heal repaints a provably content-free ghost
+  // canvas to root — the probe itself can change what the canvas shows. Only a
+  // landing that SURVIVES the probe is settled.
+  const target = { name: "sub" };
+  const root = { name: "root" };
+  let current = target;
+  const r = await confirmCanvasNavigation({
+    readCanvasGraph: () => current,
+    target,
+    assertBound: () => {
+      current = root; // the probe's side effect: the canvas is healed to root
+    },
+    tries: 3,
+    sleep: instantSleep,
+  });
+  assert.equal(r.bound, false, "no settled receipt for a canvas the probe moved away");
+  assert.equal(r.everLanded, true);
+  assert.equal(r.landed, false);
+});
+
 test("#619: a navigation that lands a few polls later is still confirmed", async () => {
   const target = { name: "sub" };
   let current = { name: "root" };
@@ -79,7 +100,7 @@ test("#619: a navigation that lands a few polls later is still confirmed", async
   });
   assert.equal(r.landed, true);
   assert.equal(r.bound, true);
-  assert.equal(reads, 3, "it polled until the canvas observably moved");
+  assert.equal(reads, 4, "3 polls to land + the post-probe survival re-read (codex r2)");
 });
 
 test("#619: a canvas that never moves is landed:false, bound:false", async () => {

--- a/browser_tests/unit/canvas-navigation.test.mjs
+++ b/browser_tests/unit/canvas-navigation.test.mjs
@@ -1,0 +1,290 @@
+// #619 — subgraph navigation must carry a post-navigation RECEIPT.
+//
+// graph_enter_subgraph used to fire canvas.openSubgraph(sub, node) and report
+// success unconditionally: a silent no-op navigation would report `entered`
+// for a canvas that never moved, and a navigation that landed while the
+// tracker was mid-capture let the IMMEDIATELY following graph read refuse with
+// [root-shape-mismatch]. The receipt polls (bounded) until the canvas
+// observably shows the target AND the read-bar binding assert passes.
+//
+// The poll loop is tested as the pure lib function; the SHIPPING
+// graph_enter_subgraph executor is extracted from the panel monolith and driven
+// with doubles, so deleting the receipt from the panel fails these tests.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { confirmCanvasNavigation } from "../../web/js/lib/canvas-navigation.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+const SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+const instantSleep = () => Promise.resolve();
+
+// ---------------------------------------------------------------------------
+// The pure poll loop
+// ---------------------------------------------------------------------------
+
+test("#619: landed + bound on the first poll resolves immediately", async () => {
+  const target = { name: "sub" };
+  const r = await confirmCanvasNavigation({
+    readCanvasGraph: () => target,
+    target,
+    assertBound: () => {},
+    sleep: instantSleep,
+  });
+  assert.deepEqual(r, { landed: true, bound: true, lastError: null });
+});
+
+test("#619: a navigation that lands a few polls later is still confirmed", async () => {
+  const target = { name: "sub" };
+  let current = { name: "root" };
+  let reads = 0;
+  const r = await confirmCanvasNavigation({
+    readCanvasGraph: () => {
+      reads += 1;
+      if (reads >= 3) current = target;
+      return current;
+    },
+    target,
+    assertBound: () => {},
+    sleep: instantSleep,
+  });
+  assert.equal(r.landed, true);
+  assert.equal(r.bound, true);
+  assert.equal(reads, 3, "it polled until the canvas observably moved");
+});
+
+test("#619: a canvas that never moves is landed:false, bound:false", async () => {
+  let assertCalls = 0;
+  const r = await confirmCanvasNavigation({
+    readCanvasGraph: () => ({ name: "root" }),
+    target: { name: "sub" },
+    assertBound: () => {
+      assertCalls += 1;
+    },
+    tries: 5,
+    sleep: instantSleep,
+  });
+  assert.equal(r.landed, false);
+  assert.equal(r.bound, false);
+  assert.equal(assertCalls, 0, "the binding assert is only evaluated once the canvas has landed");
+});
+
+test("#619: landed but never bound discloses bound:false with the assert's error", async () => {
+  const target = { name: "sub" };
+  const boom = new Error("[root-shape-mismatch] still settling");
+  const r = await confirmCanvasNavigation({
+    readCanvasGraph: () => target,
+    target,
+    assertBound: () => {
+      throw boom;
+    },
+    tries: 4,
+    sleep: instantSleep,
+  });
+  assert.equal(r.landed, true, "the navigation DID happen — the caller must disclose, not refuse");
+  assert.equal(r.bound, false);
+  assert.equal(r.lastError, boom);
+});
+
+test("#619: an assert that settles mid-poll still ends bound", async () => {
+  const target = { name: "sub" };
+  let calls = 0;
+  const r = await confirmCanvasNavigation({
+    readCanvasGraph: () => target,
+    target,
+    assertBound: () => {
+      calls += 1;
+      if (calls < 3) throw new Error("not yet");
+    },
+    sleep: instantSleep,
+  });
+  assert.equal(r.bound, true);
+  assert.equal(calls, 3);
+});
+
+test("#619: a throwing canvas read is not-landed evidence, never a crash", async () => {
+  const r = await confirmCanvasNavigation({
+    readCanvasGraph: () => {
+      throw new Error("canvas gone");
+    },
+    target: { name: "sub" },
+    assertBound: () => {},
+    tries: 3,
+    sleep: instantSleep,
+  });
+  assert.equal(r.landed, false);
+  assert.equal(r.bound, false);
+});
+
+// ---------------------------------------------------------------------------
+// The SHIPPING graph_enter_subgraph executor, extracted and driven with doubles
+// ---------------------------------------------------------------------------
+
+function extractMethod(sig) {
+  const start = SRC.indexOf(sig);
+  assert.notEqual(start, -1, `${sig} not found in the panel source`);
+  // The signature carries a destructured param ("({ node_id })"), so the BODY
+  // brace is the one after the params close paren.
+  const open = SRC.indexOf(") {", start) + 1;
+  let depth = 0;
+  for (let i = open; i < SRC.length; i += 1) {
+    const ch = SRC[i];
+    if (ch === "/" && SRC[i + 1] === "/") {
+      i = SRC.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === "/" && SRC[i + 1] === "*") {
+      i = SRC.indexOf("*/", i + 2);
+      if (i < 0) break;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < SRC.length; i += 1) {
+        if (SRC[i] === "\\") {
+          i += 1;
+          continue;
+        }
+        if (SRC[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) {
+      return SRC.slice(start, i + 1);
+    }
+  }
+  throw new Error(`unterminated method: ${sig}`);
+}
+
+function buildEnterSubgraph(doubles) {
+  const body = extractMethod("async graph_enter_subgraph({ node_id })").replace(
+    /^async graph_enter_subgraph\(/,
+    "async function graph_enter_subgraph(",
+  );
+  const factory = new Function(
+    "getGraphCtx",
+    "resolveNode",
+    "confirmCanvasNavigation",
+    "describeActiveGraph",
+    "assertGraphBoundToActiveWorkflow",
+    "coerceMessageText",
+    `return (${body});`,
+  );
+  return factory(
+    doubles.getGraphCtx,
+    doubles.resolveNode,
+    doubles.confirmCanvasNavigation ?? confirmCanvasNavigation,
+    doubles.describeActiveGraph,
+    doubles.assertGraphBoundToActiveWorkflow,
+    doubles.coerceMessageText ?? ((v) => String(v)),
+  );
+}
+
+/** A minimal canvas/app pair where openSubgraph can be made to land or no-op. */
+function fakeScope({ land = true, landAfterReads = 0 } = {}) {
+  const rootGraph = { _nodes: [], name: "root" };
+  const sub = { _nodes: [], name: "sub", rootGraph };
+  const node = { id: 105, type: "SubgraphNode", subgraph: sub };
+  const canvas = {
+    _graph: rootGraph,
+    reads: 0,
+    // The receipt reads canvas.graph directly, so the delayed landing is
+    // modeled on the property read itself.
+    get graph() {
+      this.reads += 1;
+      if (this.pending && this.reads > landAfterReads) {
+        this._graph = this.pending;
+        this.pending = null;
+      }
+      return this._graph;
+    },
+    openSubgraph(s) {
+      if (!land) return; // silent no-op — the pre-#619 shape this must catch
+      if (landAfterReads <= 0) {
+        this._graph = s;
+      } else {
+        this.pending = s;
+      }
+    },
+    setDirty() {},
+  };
+  const app = { graph: rootGraph, canvas };
+  const getGraphCtx = () => ({ app, graph: canvas.graph, rootGraph, canvas });
+  return {
+    rootGraph,
+    sub,
+    node,
+    canvas,
+    getGraphCtx,
+    resolveNode: () => node,
+    describeActiveGraph: (g) => ({ scope: g === rootGraph ? "root" : "subgraph" }),
+  };
+}
+
+test("#619: the shipping enter reports settled:true when the canvas lands and the binding clears", async () => {
+  const scope = fakeScope();
+  const enter = buildEnterSubgraph({
+    ...scope,
+    assertGraphBoundToActiveWorkflow: () => {},
+  });
+  const reply = await enter({ node_id: 105 });
+  assert.equal(reply.entered, 105);
+  assert.equal(reply.viewing.scope, "subgraph");
+  assert.equal(reply.settled, true);
+});
+
+test("#619: the shipping enter REFUSES when openSubgraph never moves the canvas (nothing applied)", async () => {
+  const scope = fakeScope({ land: false });
+  const enter = buildEnterSubgraph({
+    ...scope,
+    assertGraphBoundToActiveWorkflow: () => {},
+  });
+  await assert.rejects(
+    () => enter({ node_id: 105 }),
+    /could not confirm[\s\S]*did NOT take effect/,
+    "a no-op navigation must not report `entered`",
+  );
+});
+
+test("#619: the shipping enter DISCLOSES settled:false when it landed but the binding has not caught up", async () => {
+  const scope = fakeScope();
+  const enter = buildEnterSubgraph({
+    ...scope,
+    assertGraphBoundToActiveWorkflow: () => {
+      throw new Error("[root-shape-mismatch] tracker mid-capture");
+    },
+  });
+  const reply = await enter({ node_id: 105 });
+  assert.equal(reply.entered, 105, "the navigation DID happen — refuse would invite a pointless retry");
+  assert.equal(reply.settled, false);
+  assert.match(reply.note, /DID enter the subgraph/);
+  assert.match(reply.note, /tracker mid-capture/, "the actual blocker is named");
+});
+
+test("#619: the shipping enter waits out a slow landing instead of racing it", async () => {
+  const scope = fakeScope({ landAfterReads: 2 });
+  const enter = buildEnterSubgraph({
+    ...scope,
+    assertGraphBoundToActiveWorkflow: () => {},
+  });
+  const reply = await enter({ node_id: 105 });
+  assert.equal(reply.settled, true);
+  assert.equal(reply.viewing.scope, "subgraph");
+});
+
+test("#619: the shipping exit carries the same receipt wiring", () => {
+  // Source-level pin: exit must run the same confirmCanvasNavigation receipt
+  // (delete it and this fails) and must keep the immediate-parent resolution.
+  const body = extractMethod("async graph_exit_subgraph()");
+  assert.match(body, /await confirmCanvasNavigation\(\{/, "exit runs the receipt");
+  assert.match(body, /findSubgraphOwner\(rootGraph, graph\)\?\.parentGraph/, "exit keeps the immediate-parent walk (#412)");
+});

--- a/browser_tests/unit/canvas-navigation.test.mjs
+++ b/browser_tests/unit/canvas-navigation.test.mjs
@@ -37,7 +37,30 @@ test("#619: landed + bound on the first poll resolves immediately", async () => 
     assertBound: () => {},
     sleep: instantSleep,
   });
-  assert.deepEqual(r, { landed: true, bound: true, lastError: null });
+  assert.deepEqual(r, { landed: true, everLanded: true, bound: true, lastError: null });
+});
+
+test("#619: a canvas observed landed then displaced is everLanded:true, landed:false — disclose, not refuse", async () => {
+  const target = { name: "sub" };
+  const elsewhere = { name: "other" };
+  let reads = 0;
+  const r = await confirmCanvasNavigation({
+    readCanvasGraph: () => {
+      reads += 1;
+      // Lands on the target once, then something else moves the canvas away.
+      return reads === 1 ? target : elsewhere;
+    },
+    target,
+    assertBound: () => {
+      throw new Error("[root-shape-mismatch] still settling");
+    },
+    tries: 4,
+    sleep: instantSleep,
+  });
+  assert.equal(r.landed, false, "the LAST observation is not the target");
+  assert.equal(r.everLanded, true, "but the navigation WAS observed — a refusal would be a lie");
+  assert.equal(r.bound, false);
+  assert.match(String(r.lastError?.message), /still settling/);
 });
 
 test("#619: a navigation that lands a few polls later is still confirmed", async () => {
@@ -279,6 +302,40 @@ test("#619: the shipping enter waits out a slow landing instead of racing it", a
   const reply = await enter({ node_id: 105 });
   assert.equal(reply.settled, true);
   assert.equal(reply.viewing.scope, "subgraph");
+});
+
+test("#619: the shipping enter DISCLOSES (never refuses) when the canvas landed then navigated away", async () => {
+  const rootGraph = { _nodes: [], name: "root" };
+  const sub = { _nodes: [], name: "sub", rootGraph };
+  const elsewhere = { _nodes: [], name: "elsewhere", rootGraph };
+  const node = { id: 105, type: "SubgraphNode", subgraph: sub };
+  let reads = 0;
+  const canvas = {
+    _g: rootGraph,
+    // The first post-navigation read sees the target; every later one sees the
+    // canvas somewhere else (a user navigation landed in between).
+    get graph() {
+      reads += 1;
+      return reads <= 2 ? this._g : elsewhere;
+    },
+    openSubgraph(s) {
+      this._g = s;
+    },
+    setDirty() {},
+  };
+  const app = { graph: rootGraph, canvas };
+  const enter = buildEnterSubgraph({
+    getGraphCtx: () => ({ app, graph: canvas.graph, rootGraph, canvas }),
+    resolveNode: () => node,
+    describeActiveGraph: (g) => ({ scope: g === rootGraph ? "root" : "subgraph" }),
+    assertGraphBoundToActiveWorkflow: () => {
+      throw new Error("[root-shape-mismatch] still settling");
+    },
+  });
+  const reply = await enter({ node_id: 105 });
+  assert.equal(reply.entered, 105, "the navigation happened — the reply must not claim otherwise");
+  assert.equal(reply.settled, false);
+  assert.match(reply.note, /navigated away/, "the displacement is disclosed, not a false refusal");
 });
 
 test("#619: the shipping exit carries the same receipt wiring", () => {

--- a/browser_tests/unit/module-graph-link.test.mjs
+++ b/browser_tests/unit/module-graph-link.test.mjs
@@ -31,6 +31,12 @@ import { commandIsCanvasIndependent } from "../../web/js/lib/workflow-chat-ident
 import { sealProvenRootBinding } from "../../web/js/lib/graph-binding.js";
 import { composeShowMediaReply } from "../../web/js/lib/media-preview.js";
 import { composeRunCompletionFrame } from "../../web/js/lib/run-completion-frame.js";
+import { describeNodeDefRefresh } from "../../web/js/lib/node-def-refresh.js";
+import { confirmCanvasNavigation } from "../../web/js/lib/canvas-navigation.js";
+import {
+  watchPostReconnectSettle,
+  graphMutationReconnectGate,
+} from "../../web/js/lib/reconnect-recovery.js";
 
 // --- Mirror the shared bounded-step edge (#648) --------------------------------------
 // run-completion-frame.js and media-preview.js BOTH import withTimeout from here. If
@@ -77,6 +83,13 @@ test("panel ↔ media-preview.js / run-completion-frame.js ↔ bounded-step.js e
   assert.equal(typeof composeShowMediaReply, "function");
   assert.equal(typeof composeRunCompletionFrame, "function");
   assert.equal(typeof withTimeout, "function");
+});
+
+test("panel ↔ node-def-refresh.js / canvas-navigation.js / reconnect-recovery.js edges link (#635/#619/#663/#646)", () => {
+  assert.equal(typeof describeNodeDefRefresh, "function");
+  assert.equal(typeof confirmCanvasNavigation, "function");
+  assert.equal(typeof watchPostReconnectSettle, "function");
+  assert.equal(typeof graphMutationReconnectGate, "function");
 });
 
 test("set-widget.js ↔ widget-write.js / node-resolve.js module edges link", () => {

--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -92,6 +92,7 @@ test("#635: the stuck case from the issue — combo API absent — says defs DID
   const v = describeNodeDefRefresh({
     appAvailable: true,
     defsObtained: true,
+    defsRegistered: true,
     comboApiPresent: false,
     comboRan: false,
   });
@@ -102,10 +103,37 @@ test("#635: the stuck case from the issue — combo API absent — says defs DID
   assert.match(v.remedy, /reload/i);
 });
 
+test("#635: registration is claimed ONLY when the call observably ran (codex r2 P1)", () => {
+  const v = describeNodeDefRefresh({
+    appAvailable: true,
+    defsObtained: true,
+    defsRegistered: false, // registerNodesFromDefs absent on this frontend
+    comboApiPresent: false,
+    comboRan: false,
+  });
+  assert.equal(v.refreshed, false);
+  assert.doesNotMatch(v.remedy, /WERE re-registered/, "no fabricated registration claim");
+  assert.match(v.remedy, /NOT registered/);
+  assert.match(v.remedy, /reload the ComfyUI tab/i);
+
+  const thrown = describeNodeDefRefresh({
+    appAvailable: true,
+    defsObtained: true,
+    defsRegistered: false,
+    comboApiPresent: true,
+    comboRan: false,
+    phase: "combo",
+    thrown: new Error("boom"),
+  });
+  assert.doesNotMatch(thrown.remedy, /WERE re-registered/);
+  assert.match(thrown.remedy, /NOT registered/);
+});
+
 test("#635: a throwing combo refresh is distinguished from an absent combo API", () => {
   const v = describeNodeDefRefresh({
     appAvailable: true,
     defsObtained: true,
+    defsRegistered: true,
     comboApiPresent: true,
     comboRan: false,
     phase: "combo",

--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -425,3 +425,65 @@ test("#635: the shipping run attributes a getNodeDefs throw to the fetch, with d
   assert.match(verdict.detail, /fetch failed/);
   assert.equal(getConfirmed(), false);
 });
+
+test("#635: a pre-registration throw must not claim registration was attempted (codex r4)", () => {
+  const recordThrew = describeNodeDefRefresh({
+    appAvailable: true,
+    defsObtained: true,
+    defsRegistered: false,
+    comboApiPresent: true,
+    comboRan: false,
+    phase: "record",
+    thrown: new Error("history exploded"),
+  });
+  assert.equal(recordThrew.reason, NODE_DEF_REFRESH_REASONS.REGISTER_FAILED);
+  assert.match(recordThrew.remedy, /BEFORE registration was attempted/);
+  assert.doesNotMatch(recordThrew.remedy, /re-registering the node definitions failed/);
+
+  const reapplyThrew = describeNodeDefRefresh({
+    appAvailable: true,
+    defsObtained: true,
+    defsRegistered: true, // registration DID run — reapply failed after it
+    comboApiPresent: true,
+    comboRan: false,
+    phase: "reapply",
+    thrown: new Error("live node rejected the def"),
+  });
+  assert.equal(reapplyThrew.reason, NODE_DEF_REFRESH_REASONS.REGISTER_FAILED);
+  assert.match(reapplyThrew.remedy, /WERE re-registered/, "true here — registration ran before the throw");
+  assert.match(reapplyThrew.remedy, /live canvas nodes failed/);
+});
+
+test("#635: the shipping run attributes a history-recording throw to BEFORE registration", async () => {
+  let registerCalls = 0;
+  const body = extractFunction("async function registerComfyNodeDefs(");
+  const factory = new Function(
+    "app",
+    "api",
+    "recordObjectInfoTypes",
+    "reapplyDefsToLiveNodes",
+    "describeNodeDefRefresh",
+    `let nodeDefsRefreshConfirmed = false;
+     ${body}
+     return { registerComfyNodeDefs };`,
+  );
+  const { registerComfyNodeDefs: registerWithThrowingRecorder } = factory(
+    {
+      graph: null,
+      registerNodesFromDefs: async () => {
+        registerCalls += 1;
+      },
+      refreshComboInNodes: async () => {},
+    },
+    { getNodeDefs: async () => ({ SomeNode: {} }) },
+    () => {
+      throw new Error("history exploded");
+    },
+    () => {},
+    describeNodeDefRefresh,
+  );
+  const verdict = await registerWithThrowingRecorder(undefined);
+  assert.equal(verdict.reason, "register_failed");
+  assert.match(verdict.remedy, /BEFORE registration was attempted/);
+  assert.equal(registerCalls, 0, "registerNodesFromDefs was never reached");
+});

--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -32,6 +32,7 @@ test("#635: a fully successful run is refreshed with no failure fields", () => {
   const v = describeNodeDefRefresh({
     appAvailable: true,
     defsObtained: true,
+    defsRegistered: true,
     comboApiPresent: true,
     comboRan: true,
   });
@@ -104,6 +105,8 @@ test("#635: the stuck case from the issue — combo API absent — says defs DID
 });
 
 test("#635: registration is claimed ONLY when the call observably ran (codex r2 P1)", () => {
+  // No registration API at all → its own reason, never a silent refreshed:true
+  // (codex r3), and never a fabricated "WERE re-registered".
   const v = describeNodeDefRefresh({
     appAvailable: true,
     defsObtained: true,
@@ -112,9 +115,20 @@ test("#635: registration is claimed ONLY when the call observably ran (codex r2 
     comboRan: false,
   });
   assert.equal(v.refreshed, false);
+  assert.equal(v.reason, NODE_DEF_REFRESH_REASONS.REGISTER_API_ABSENT);
   assert.doesNotMatch(v.remedy, /WERE re-registered/, "no fabricated registration claim");
   assert.match(v.remedy, /NOT registered/);
   assert.match(v.remedy, /reload the ComfyUI tab/i);
+
+  const combosRan = describeNodeDefRefresh({
+    appAvailable: true,
+    defsObtained: true,
+    defsRegistered: false,
+    comboApiPresent: true,
+    comboRan: true,
+  });
+  assert.equal(combosRan.reason, NODE_DEF_REFRESH_REASONS.REGISTER_API_ABSENT);
+  assert.match(combosRan.remedy, /combo dropdown lists WERE refreshed/, "a true partial success is still said");
 
   const thrown = describeNodeDefRefresh({
     appAvailable: true,
@@ -149,6 +163,7 @@ test("#635: a present-but-not-run combo API with no throw fails closed, never cl
   const v = describeNodeDefRefresh({
     appAvailable: true,
     defsObtained: true,
+    defsRegistered: true,
     comboApiPresent: true,
     comboRan: false,
   });
@@ -280,4 +295,133 @@ test("#635: the shipping registerComfyNodeDefs returns its verdict through the p
     /nodeDefsRefreshConfirmed = !thrown && !!defs && comboRan;/,
     "the shared global stays a strict boolean (concurrent-run trust gate unchanged)",
   );
+});
+
+// ---------------------------------------------------------------------------
+// The SHIPPING registerComfyNodeDefs, extracted and driven end-to-end with
+// doubles (codex gate r3: the verdict unit tests + executor extraction alone
+// did not prove the real registration function produces those verdicts)
+// ---------------------------------------------------------------------------
+
+/** Balanced-brace extraction of a top-level function by its declaration marker. */
+function extractFunction(marker) {
+  const start = SRC.indexOf(marker);
+  assert.notEqual(start, -1, `${marker} not found`);
+  const open = SRC.indexOf("{", start);
+  let depth = 0;
+  for (let i = open; i < SRC.length; i += 1) {
+    const ch = SRC[i];
+    if (ch === "/" && SRC[i + 1] === "/") {
+      i = SRC.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === "/" && SRC[i + 1] === "*") {
+      i = SRC.indexOf("*/", i + 2);
+      if (i < 0) break;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < SRC.length; i += 1) {
+        if (SRC[i] === "\\") {
+          i += 1;
+          continue;
+        }
+        if (SRC[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return SRC.slice(start, i + 1);
+  }
+  throw new Error(`unterminated function: ${marker}`);
+}
+
+function buildRegisterComfyNodeDefs({ appValue, apiValue }) {
+  const body = extractFunction("async function registerComfyNodeDefs(");
+  const factory = new Function(
+    "app",
+    "api",
+    "recordObjectInfoTypes",
+    "reapplyDefsToLiveNodes",
+    "describeNodeDefRefresh",
+    `let nodeDefsRefreshConfirmed = false;
+     ${body}
+     return { registerComfyNodeDefs, getConfirmed: () => nodeDefsRefreshConfirmed };`,
+  );
+  return factory(
+    appValue,
+    apiValue,
+    () => ({}),
+    () => {},
+    describeNodeDefRefresh,
+  );
+}
+
+const FULL_APP = {
+  graph: null,
+  registerNodesFromDefs: async () => {},
+  refreshComboInNodes: async () => {},
+};
+
+test("#635: the shipping register run with no obtainable /object_info reports object_info_unavailable", async () => {
+  const { registerComfyNodeDefs, getConfirmed } = buildRegisterComfyNodeDefs({
+    appValue: FULL_APP,
+    apiValue: { getNodeDefs: async () => null },
+  });
+  const verdict = await registerComfyNodeDefs(undefined);
+  assert.equal(verdict.refreshed, false);
+  assert.equal(verdict.reason, "object_info_unavailable", "the common no-defs case names its cause");
+  assert.match(verdict.remedy, /retry/i);
+  assert.equal(getConfirmed(), false, "the shared trust global stays false");
+});
+
+test("#635: the shipping register run end-to-end success reports refreshed", async () => {
+  const { registerComfyNodeDefs, getConfirmed } = buildRegisterComfyNodeDefs({
+    appValue: FULL_APP,
+    apiValue: { getNodeDefs: async () => ({ SomeNode: {} }) },
+  });
+  const verdict = await registerComfyNodeDefs(undefined);
+  assert.deepEqual(verdict, { refreshed: true, reason: "refreshed" });
+  assert.equal(getConfirmed(), true);
+});
+
+test("#635: the shipping run on a combo-API-absent frontend claims registration only because it RAN", async () => {
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    appValue: { graph: null, registerNodesFromDefs: async () => {} }, // no refreshComboInNodes
+    apiValue: { getNodeDefs: async () => ({ SomeNode: {} }) },
+  });
+  const verdict = await registerComfyNodeDefs(undefined);
+  assert.equal(verdict.reason, "combo_api_absent");
+  assert.match(verdict.remedy, /WERE re-registered/, "registration did run here, so the claim is true");
+});
+
+test("#635: the shipping run on a registerNodesFromDefs-absent frontend does NOT claim registration", async () => {
+  const { registerComfyNodeDefs } = buildRegisterComfyNodeDefs({
+    appValue: { graph: null, refreshComboInNodes: async () => {} }, // no registerNodesFromDefs
+    apiValue: { getNodeDefs: async () => ({ SomeNode: {} }) },
+  });
+  const verdict = await registerComfyNodeDefs(undefined);
+  assert.equal(verdict.refreshed, false);
+  assert.equal(verdict.reason, "register_api_absent");
+  assert.doesNotMatch(verdict.remedy, /WERE re-registered/, "no fabricated registration claim");
+  assert.match(verdict.remedy, /NOT registered/);
+  assert.match(verdict.remedy, /combo dropdown lists WERE refreshed/, "the combo half did run — disclosed");
+});
+
+test("#635: the shipping run attributes a getNodeDefs throw to the fetch, with detail", async () => {
+  const { registerComfyNodeDefs, getConfirmed } = buildRegisterComfyNodeDefs({
+    appValue: FULL_APP,
+    apiValue: {
+      getNodeDefs: async () => {
+        throw new Error("fetch failed");
+      },
+    },
+  });
+  const verdict = await registerComfyNodeDefs(undefined);
+  assert.equal(verdict.reason, "object_info_fetch_failed");
+  assert.match(verdict.detail, /fetch failed/);
+  assert.equal(getConfirmed(), false);
 });

--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -1,0 +1,255 @@
+// #635 — refresh_nodes must say WHY it is not fresh, and what to do about it.
+//
+// The pre-fix reply was {ok:true, refreshed:false} on every failure shape —
+// backend unreachable, /object_info empty, combo API absent, combo refresh
+// threw — indistinguishable from a no-op. These tests pin the verdict's reason
+// token per failure shape AND that the reply carries an actionable remedy.
+//
+// The verdict logic is tested as the pure lib function; the SHIPPING executor
+// is extracted from the panel monolith and driven with doubles, so deleting
+// the reason/remedy wiring in the panel fails these tests.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  describeNodeDefRefresh,
+  NODE_DEF_REFRESH_REASONS,
+} from "../../web/js/lib/node-def-refresh.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+const SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+// ---------------------------------------------------------------------------
+// The pure verdict function
+// ---------------------------------------------------------------------------
+
+test("#635: a fully successful run is refreshed with no failure fields", () => {
+  const v = describeNodeDefRefresh({
+    appAvailable: true,
+    defsObtained: true,
+    comboApiPresent: true,
+    comboRan: true,
+  });
+  assert.deepEqual(v, { refreshed: true, reason: "refreshed" });
+});
+
+test("#635: app unavailable is its own reason with a reload remedy", () => {
+  const v = describeNodeDefRefresh({
+    appAvailable: false,
+    defsObtained: false,
+    comboApiPresent: false,
+    comboRan: false,
+  });
+  assert.equal(v.refreshed, false);
+  assert.equal(v.reason, NODE_DEF_REFRESH_REASONS.APP_UNAVAILABLE);
+  assert.match(v.remedy, /reload the ComfyUI tab/i);
+});
+
+test("#635: /object_info unobtained (no throw) is distinguished from a fetch failure", () => {
+  const v = describeNodeDefRefresh({
+    appAvailable: true,
+    defsObtained: false,
+    comboApiPresent: true,
+    comboRan: false,
+  });
+  assert.equal(v.refreshed, false);
+  assert.equal(v.reason, NODE_DEF_REFRESH_REASONS.OBJECT_INFO_UNAVAILABLE);
+  assert.match(v.remedy, /retry/i);
+
+  const thrown = describeNodeDefRefresh({
+    appAvailable: true,
+    defsObtained: false,
+    comboApiPresent: true,
+    comboRan: false,
+    phase: "fetch",
+    thrown: new Error("fetch failed"),
+  });
+  assert.equal(thrown.refreshed, false);
+  assert.equal(thrown.reason, NODE_DEF_REFRESH_REASONS.OBJECT_INFO_FETCH_FAILED);
+  assert.match(thrown.detail, /fetch failed/, "the underlying error rides along as detail");
+});
+
+test("#635: a throw during registration is not misreported as a fetch failure", () => {
+  const v = describeNodeDefRefresh({
+    appAvailable: true,
+    defsObtained: true,
+    comboApiPresent: false,
+    comboRan: false,
+    phase: "register",
+    thrown: new Error("boom"),
+  });
+  assert.equal(v.refreshed, false);
+  assert.equal(v.reason, NODE_DEF_REFRESH_REASONS.REGISTER_FAILED);
+  assert.match(v.remedy, /re-register/i);
+});
+
+test("#635: the stuck case from the issue — combo API absent — says defs DID register and combos refresh on reload", () => {
+  const v = describeNodeDefRefresh({
+    appAvailable: true,
+    defsObtained: true,
+    comboApiPresent: false,
+    comboRan: false,
+  });
+  assert.equal(v.refreshed, false);
+  assert.equal(v.reason, NODE_DEF_REFRESH_REASONS.COMBO_API_ABSENT);
+  // The remedy must not read as "nothing happened": the defs WERE re-registered.
+  assert.match(v.remedy, /WERE re-registered/);
+  assert.match(v.remedy, /reload/i);
+});
+
+test("#635: a throwing combo refresh is distinguished from an absent combo API", () => {
+  const v = describeNodeDefRefresh({
+    appAvailable: true,
+    defsObtained: true,
+    comboApiPresent: true,
+    comboRan: false,
+    phase: "combo",
+    thrown: new Error("combo exploded"),
+  });
+  assert.equal(v.refreshed, false);
+  assert.equal(v.reason, NODE_DEF_REFRESH_REASONS.COMBO_REFRESH_FAILED);
+  assert.match(v.remedy, /WERE re-registered/);
+  assert.match(v.detail, /combo exploded/);
+});
+
+test("#635: a present-but-not-run combo API with no throw fails closed, never claims fresh", () => {
+  const v = describeNodeDefRefresh({
+    appAvailable: true,
+    defsObtained: true,
+    comboApiPresent: true,
+    comboRan: false,
+  });
+  assert.equal(v.refreshed, false);
+  assert.equal(v.reason, NODE_DEF_REFRESH_REASONS.COMBO_REFRESH_FAILED);
+});
+
+test("#635: every non-fresh verdict carries BOTH a reason and a remedy", () => {
+  const cases = [
+    { appAvailable: false, defsObtained: false, comboApiPresent: false, comboRan: false },
+    { appAvailable: true, defsObtained: false, comboApiPresent: true, comboRan: false },
+    { appAvailable: true, defsObtained: false, comboApiPresent: false, comboRan: false, phase: "fetch", thrown: new Error("x") },
+    { appAvailable: true, defsObtained: true, comboApiPresent: false, comboRan: false },
+    { appAvailable: true, defsObtained: true, comboApiPresent: true, comboRan: false },
+    { appAvailable: true, defsObtained: true, comboApiPresent: true, comboRan: false, phase: "combo", thrown: new Error("x") },
+    { appAvailable: true, defsObtained: true, comboApiPresent: false, comboRan: false, phase: "register", thrown: new Error("x") },
+  ];
+  for (const input of cases) {
+    const v = describeNodeDefRefresh(input);
+    assert.equal(v.refreshed, false);
+    assert.ok(typeof v.reason === "string" && v.reason.length > 0, "reason present");
+    assert.ok(typeof v.remedy === "string" && v.remedy.length > 0, `remedy present for ${v.reason}`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// The SHIPPING refresh_nodes executor, extracted and driven with doubles
+// ---------------------------------------------------------------------------
+
+function buildRefreshNodes(refreshImpl) {
+  const start = SRC.indexOf("async refresh_nodes()");
+  assert.notEqual(start, -1, "refresh_nodes executor not found in the panel source");
+  // Balanced-brace extraction from the signature's opening brace (comments and
+  // strings skipped), so the slice is exactly the executor — not the trailing
+  // comma or the next executor's doc comment.
+  const open = SRC.indexOf("{", start);
+  let depth = 0;
+  let end = -1;
+  for (let i = open; i < SRC.length; i += 1) {
+    const ch = SRC[i];
+    if (ch === "/" && SRC[i + 1] === "/") {
+      i = SRC.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === "/" && SRC[i + 1] === "*") {
+      i = SRC.indexOf("*/", i + 2);
+      if (i < 0) break;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < SRC.length; i += 1) {
+        if (SRC[i] === "\\") {
+          i += 1;
+          continue;
+        }
+        if (SRC[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) {
+      end = i;
+      break;
+    }
+  }
+  assert.notEqual(end, -1, "could not bound the refresh_nodes executor body");
+  const body = SRC.slice(start, end + 1);
+  const factory = new Function(
+    "refreshComfyNodeDefs",
+    `return (${body.replace(/^async refresh_nodes\(\)/, "async function refresh_nodes()")});`,
+  );
+  return factory(refreshImpl);
+}
+
+test("#635: the shipping executor returns reason + remedy when the refresh is not fresh", async () => {
+  const refresh_nodes = buildRefreshNodes(async () => ({
+    refreshed: false,
+    reason: "combo_api_absent",
+    remedy: "reload the tab",
+  }));
+  const reply = await refresh_nodes();
+  assert.equal(reply.ok, true);
+  assert.equal(reply.refreshed, false);
+  assert.equal(reply.reason, "combo_api_absent", "the verdict's reason reaches the reply");
+  assert.equal(reply.remedy, "reload the tab", "the verdict's remedy reaches the reply");
+});
+
+test("#635: the shipping executor surfaces the detail when the verdict carries one", async () => {
+  const refresh_nodes = buildRefreshNodes(async () => ({
+    refreshed: false,
+    reason: "object_info_fetch_failed",
+    detail: "(fetch failed)",
+    remedy: "retry later",
+  }));
+  const reply = await refresh_nodes();
+  assert.equal(reply.refreshed, false);
+  assert.equal(reply.detail, "(fetch failed)");
+});
+
+test("#635: the shipping executor reports a clean success with no failure fields", async () => {
+  const refresh_nodes = buildRefreshNodes(async () => ({ refreshed: true, reason: "refreshed" }));
+  const reply = await refresh_nodes();
+  assert.deepEqual(reply, { ok: true, refreshed: true });
+});
+
+test("#635: an undefined verdict (coalesced away) still yields a reason and a remedy, never a bare false", async () => {
+  const refresh_nodes = buildRefreshNodes(async () => undefined);
+  const reply = await refresh_nodes();
+  assert.equal(reply.refreshed, false);
+  assert.equal(reply.reason, "unknown");
+  assert.ok(reply.remedy.length > 0, "a remedy is present even when the verdict itself is missing");
+});
+
+test("#635: the shipping registerComfyNodeDefs returns its verdict through the panel wiring", () => {
+  // Wiring scan: the register function must build its return through
+  // describeNodeDefRefresh (delete the call and this fails), and the shared
+  // global must keep its boolean semantics for the trust gate.
+  const start = SRC.indexOf("async function registerComfyNodeDefs(");
+  assert.notEqual(start, -1);
+  const rest = SRC.slice(start);
+  const m = rest.match(/\n}\n/);
+  const body = rest.slice(0, m.index);
+  assert.match(body, /return describeNodeDefRefresh\(\{/, "the run verdict is returned");
+  assert.match(
+    body,
+    /nodeDefsRefreshConfirmed = !thrown && !!defs && comboRan;/,
+    "the shared global stays a strict boolean (concurrent-run trust gate unchanged)",
+  );
+});

--- a/browser_tests/unit/node-def-refresh.test.mjs
+++ b/browser_tests/unit/node-def-refresh.test.mjs
@@ -292,7 +292,7 @@ test("#635: the shipping registerComfyNodeDefs returns its verdict through the p
   assert.match(body, /return describeNodeDefRefresh\(\{/, "the run verdict is returned");
   assert.match(
     body,
-    /nodeDefsRefreshConfirmed = !thrown && !!defs && comboRan;/,
+    /nodeDefsRefreshConfirmed = !didThrow && !!defs && comboRan;/,
     "the shared global stays a strict boolean (concurrent-run trust gate unchanged)",
   );
 });
@@ -486,4 +486,52 @@ test("#635: the shipping run attributes a history-recording throw to BEFORE regi
   assert.equal(verdict.reason, "register_failed");
   assert.match(verdict.remedy, /BEFORE registration was attempted/);
   assert.equal(registerCalls, 0, "registerNodesFromDefs was never reached");
+});
+
+test("#635: a FALSY thrown value still counts as a failure (codex r5)", () => {
+  const v = describeNodeDefRefresh({
+    appAvailable: true,
+    defsObtained: true,
+    defsRegistered: false,
+    comboApiPresent: true,
+    comboRan: false,
+    phase: "record",
+    didThrow: true,
+    thrown: null, // `throw null` — the value carries nothing, the fact matters
+  });
+  assert.equal(v.refreshed, false);
+  assert.equal(v.reason, NODE_DEF_REFRESH_REASONS.REGISTER_FAILED, "not misattributed to a missing API");
+  assert.match(v.remedy, /BEFORE registration was attempted/);
+  assert.equal(v.detail, undefined, "no detail to invent from a null throw");
+});
+
+test("#635: the shipping register run treats a falsy throw as a failure everywhere", async () => {
+  const body = extractFunction("async function registerComfyNodeDefs(");
+  const factory = new Function(
+    "app",
+    "api",
+    "recordObjectInfoTypes",
+    "reapplyDefsToLiveNodes",
+    "describeNodeDefRefresh",
+    `let nodeDefsRefreshConfirmed = false;
+     ${body}
+     return { registerComfyNodeDefs, getConfirmed: () => nodeDefsRefreshConfirmed };`,
+  );
+  const { registerComfyNodeDefs, getConfirmed } = factory(
+    {
+      graph: null,
+      registerNodesFromDefs: async () => {},
+      refreshComboInNodes: async () => {},
+    },
+    { getNodeDefs: async () => ({ SomeNode: {} }) },
+    () => {
+      throw null; // a falsy throw — must still read as a failed run
+    },
+    () => {},
+    describeNodeDefRefresh,
+  );
+  const verdict = await registerComfyNodeDefs(undefined);
+  assert.equal(verdict.refreshed, false);
+  assert.equal(verdict.reason, "register_failed");
+  assert.equal(getConfirmed(), false, "the shared trust flag must not latch true after a falsy throw");
 });

--- a/browser_tests/unit/reconnect-recovery.test.mjs
+++ b/browser_tests/unit/reconnect-recovery.test.mjs
@@ -256,6 +256,10 @@ test("#646 wiring: the async write boundary re-checks the gate (a dispatch can s
     "the pre-write revalidation consults the same live signals",
   );
   assert.ok(
+    body.indexOf("graphMutationReconnectGate({") < body.indexOf("getGraphCtx()"),
+    "the gate fires BEFORE getGraphCtx — the probe can change the canvas (the rebind heal), which would falsify 'nothing changed' (codex r7)",
+  );
+  assert.ok(
     body.indexOf("graphMutationReconnectGate({") < body.indexOf("assertGraphBoundToActiveWorkflow("),
     "the gate fires BEFORE the write-boundary binding assert",
   );

--- a/browser_tests/unit/reconnect-recovery.test.mjs
+++ b/browser_tests/unit/reconnect-recovery.test.mjs
@@ -219,6 +219,10 @@ test("#646 wiring: the dispatch fence gates MUTATING graph commands through the 
     /graphMutationReconnectGate\(\{[\s\S]*?backendDown: comfyBackendSocketDown,[\s\S]*?bindingSettleWindow: postReconnectBindingSettleWindow\(\)/,
     "the gate reads both live signals",
   );
+  assert.ok(
+    fence.indexOf("graphMutationReconnectGate({") < fence.indexOf("getGraphCtx()"),
+    "the gate fires BEFORE getGraphCtx — the probes can change the canvas (the rebind heal), which would falsify 'nothing changed' (codex r6)",
+  );
 });
 
 test("#663 wiring: BOTH resync sites (open + new) stamp the binding proof, TOCTOU-guarded", () => {

--- a/browser_tests/unit/reconnect-recovery.test.mjs
+++ b/browser_tests/unit/reconnect-recovery.test.mjs
@@ -1,0 +1,258 @@
+// #663 / #646 — the post-reconnect settle watch and the graph-mutation gate.
+//
+// #663: the `reconnected` handler used to only bump the epoch — nothing
+// re-proved the canvas binding, so the settle window ran its full 30s in the
+// healthy case and a never-settling restore hard-refused until a manual
+// open/reload. The watch re-proves the binding with the same evidence bar a
+// graph read runs and closes the binding window early on proof.
+//
+// #646: nothing gated graph mutations on the post-restart state, so a mutation
+// could dispatch into a dying socket (OUTCOME UNKNOWN) or onto a canvas the
+// restore was about to rebuild. The gate refuses graph mutations while the
+// backend socket is down or the binding is unproven inside the window.
+//
+// The loop and the gate are tested as pure lib functions; the panel WIRING is
+// pinned by source scans that fail if the wiring is deleted.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  watchPostReconnectSettle,
+  graphMutationReconnectGate,
+} from "../../web/js/lib/reconnect-recovery.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+const SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+const instantSleep = () => Promise.resolve();
+
+// ---------------------------------------------------------------------------
+// watchPostReconnectSettle
+// ---------------------------------------------------------------------------
+
+test("#663: the watch proves on the first poll and stamps the proof exactly once", async () => {
+  let provenCalls = 0;
+  const outcome = await watchPostReconnectSettle({
+    isCurrent: () => true,
+    windowOpen: () => true,
+    proveBinding: () => true,
+    markProven: () => {
+      provenCalls += 1;
+    },
+    sleep: instantSleep,
+    firstDelayMs: 0,
+  });
+  assert.equal(outcome, "proven");
+  assert.equal(provenCalls, 1);
+});
+
+test("#663: a binding that settles on the third poll is proven on the third", async () => {
+  let polls = 0;
+  const outcome = await watchPostReconnectSettle({
+    isCurrent: () => true,
+    windowOpen: () => true,
+    proveBinding: () => {
+      polls += 1;
+      return polls >= 3;
+    },
+    markProven: () => {},
+    sleep: instantSleep,
+    firstDelayMs: 0,
+  });
+  assert.equal(outcome, "proven");
+  assert.equal(polls, 3);
+});
+
+test("#663: a THROWING proof probe is 'not yet', never 'proven' — the watch outlives it", async () => {
+  let polls = 0;
+  let provenCalls = 0;
+  const outcome = await watchPostReconnectSettle({
+    isCurrent: () => true,
+    windowOpen: () => true,
+    proveBinding: () => {
+      polls += 1;
+      if (polls < 3) throw new Error("getGraphCtx: graph not available");
+      return true;
+    },
+    markProven: () => {
+      provenCalls += 1;
+    },
+    sleep: instantSleep,
+    firstDelayMs: 0,
+  });
+  assert.equal(outcome, "proven");
+  assert.equal(provenCalls, 1);
+  assert.equal(polls, 3);
+});
+
+test("#663: a watch superseded by a newer reconnect never stamps its stale proof", async () => {
+  let currentChecks = 0;
+  let provenCalls = 0;
+  const outcome = await watchPostReconnectSettle({
+    // Current on entry and at the poll, superseded by the time the proof lands.
+    isCurrent: () => {
+      currentChecks += 1;
+      return currentChecks < 2;
+    },
+    windowOpen: () => true,
+    proveBinding: () => true,
+    markProven: () => {
+      provenCalls += 1;
+    },
+    sleep: instantSleep,
+    firstDelayMs: 0,
+  });
+  assert.equal(outcome, "superseded");
+  assert.equal(provenCalls, 0, "a stale watch must not close the NEW epoch's window");
+});
+
+test("#663: a window closed externally (explicit open/new, or expiry) stops the watch", async () => {
+  let provenCalls = 0;
+  const outcome = await watchPostReconnectSettle({
+    isCurrent: () => true,
+    windowOpen: () => false,
+    proveBinding: () => true,
+    markProven: () => {
+      provenCalls += 1;
+    },
+    sleep: instantSleep,
+    firstDelayMs: 0,
+  });
+  assert.equal(outcome, "closed");
+  assert.equal(provenCalls, 0);
+});
+
+test("#663: a restore that NEVER settles is bounded — the watch exhausts and proves nothing", async () => {
+  let polls = 0;
+  let provenCalls = 0;
+  const outcome = await watchPostReconnectSettle({
+    isCurrent: () => true,
+    windowOpen: () => true,
+    proveBinding: () => {
+      polls += 1;
+      return false;
+    },
+    markProven: () => {
+      provenCalls += 1;
+    },
+    sleep: instantSleep,
+    firstDelayMs: 0,
+    maxPolls: 5,
+  });
+  assert.equal(outcome, "exhausted");
+  assert.equal(polls, 5, "the loop is bounded even if the window predicate never closes");
+  assert.equal(provenCalls, 0, "an unsettled restore is never reported as proven");
+});
+
+// ---------------------------------------------------------------------------
+// graphMutationReconnectGate
+// ---------------------------------------------------------------------------
+
+test("#646: no instability signal → no gate", () => {
+  assert.equal(
+    graphMutationReconnectGate({ cmd: "graph_set_widget", backendDown: false, bindingSettleWindow: false }),
+    null,
+  );
+});
+
+test("#646: backend down refuses with a retryable, nothing-applied message naming the command", () => {
+  const msg = graphMutationReconnectGate({ cmd: "graph_set_widget", backendDown: true });
+  assert.match(msg, /\[backend-reconnecting\]/);
+  assert.match(msg, /"graph_set_widget"/, "the refusal names the command it refused");
+  assert.match(msg, /NOT applied — nothing changed/, "the refusal is honest that nothing ran");
+  assert.match(msg, /Retry/, "the remedy is actionable from the caller's state");
+});
+
+test("#646: the unproven-binding window refuses and names the escalate-after-30s remedy", () => {
+  const msg = graphMutationReconnectGate({ cmd: "graph_add_node", bindingSettleWindow: true });
+  assert.match(msg, /\[post-reconnect-settling\]/);
+  assert.match(msg, /NOT applied — nothing changed/);
+  assert.match(msg, /panel_open_workflow/, "the persistent case names the proven-rebind remedy");
+});
+
+test("#646: backend-down takes precedence over the settle window (both true)", () => {
+  const msg = graphMutationReconnectGate({ cmd: "graph_run", backendDown: true, bindingSettleWindow: true });
+  assert.match(msg, /\[backend-reconnecting\]/);
+});
+
+// ---------------------------------------------------------------------------
+// Panel wiring (source scans — deleting the wiring fails these)
+// ---------------------------------------------------------------------------
+
+test("#663 wiring: the 'reconnected' listener kicks the settle watch for the NEW epoch", () => {
+  const start = SRC.indexOf('api.addEventListener("reconnected"');
+  assert.notEqual(start, -1);
+  const block = SRC.slice(start, start + 1600);
+  assert.match(block, /backendReconnectEpoch \+= 1/, "the epoch bump is intact (#433)");
+  assert.match(
+    block,
+    /kickPostReconnectSettleWatch\(backendReconnectEpoch\)/,
+    "the proactive re-proof watch is kicked for the epoch just bumped",
+  );
+});
+
+test("#646 wiring: the backend-down flag tracks ComfyUI's own socket events", () => {
+  const reconnecting = SRC.slice(
+    SRC.indexOf('api.addEventListener("reconnecting"'),
+    SRC.indexOf('api.addEventListener("reconnecting"') + 400,
+  );
+  assert.match(reconnecting, /comfyBackendSocketDown = true/, "backend going down arms the mutation gate");
+  const reconnected = SRC.slice(
+    SRC.indexOf('api.addEventListener("reconnected"'),
+    SRC.indexOf('api.addEventListener("reconnected"') + 400,
+  );
+  assert.match(reconnected, /comfyBackendSocketDown = false/, "reconnect disarms it");
+});
+
+test("#646 wiring: the dispatch fence gates MUTATING graph commands through the shared gate", () => {
+  const fenceStart = SRC.indexOf('msg.cmd.startsWith("graph_") && !commandIsCanvasIndependent(msg.cmd)');
+  assert.notEqual(fenceStart, -1);
+  const fence = SRC.slice(fenceStart, fenceStart + 2200);
+  assert.match(fence, /graphCommandMayMutateWorkflow\(msg\.cmd\)/, "reads are NOT gated — mutations are");
+  assert.match(
+    fence,
+    /graphMutationReconnectGate\(\{[\s\S]*?backendDown: comfyBackendSocketDown,[\s\S]*?bindingSettleWindow: postReconnectBindingSettleWindow\(\)/,
+    "the gate reads both live signals",
+  );
+});
+
+test("#663 wiring: BOTH resync sites (open + new) stamp the binding proof, TOCTOU-guarded", () => {
+  const stamps =
+    SRC.match(/if \(backendReconnectEpoch === openedForEpoch\) postReconnectBindingProofEpoch = openedForEpoch;/g) ?? [];
+  assert.equal(stamps.length, 2, "workflow_new AND workflow_open both stamp the proof");
+});
+
+test("#663/#646 wiring: the binding gate consults the #433 window AND the proof epoch, one invariant", () => {
+  const start = SRC.indexOf("function postReconnectBindingSettleWindow()");
+  assert.notEqual(start, -1);
+  const body = SRC.slice(start, start + 400);
+  assert.match(body, /postReconnectSettleWindow\(\)/);
+  assert.match(body, /postReconnectBindingProofEpoch < backendReconnectEpoch/);
+});
+
+test("#618 regression: the binding verdict still receives the #433 settle window on every fenced command", () => {
+  const start = SRC.indexOf("function assertGraphBoundToActiveWorkflow(");
+  assert.notEqual(start, -1);
+  const body = SRC.slice(start, SRC.indexOf("function stampGraphRootWorkflowUuid", start));
+  assert.match(body, /postReconnectWindow: postReconnectSettleWindow\(\)/);
+});
+
+test("#646 wiring: the async write boundary re-checks the gate (a dispatch can span a backend drop)", () => {
+  const start = SRC.indexOf("function revalidateGraphMutationContext(");
+  assert.notEqual(start, -1);
+  const body = SRC.slice(start, start + 1400);
+  assert.match(
+    body,
+    /graphMutationReconnectGate\(\{[\s\S]*?backendDown: comfyBackendSocketDown,[\s\S]*?bindingSettleWindow: postReconnectBindingSettleWindow\(\)/,
+    "the pre-write revalidation consults the same live signals",
+  );
+  assert.ok(
+    body.indexOf("graphMutationReconnectGate({") < body.indexOf("assertGraphBoundToActiveWorkflow("),
+    "the gate fires BEFORE the write-boundary binding assert",
+  );
+});

--- a/browser_tests/unit/restart-identity-retry.test.mjs
+++ b/browser_tests/unit/restart-identity-retry.test.mjs
@@ -122,7 +122,7 @@ test("#654: concurrent callers share one in-flight resolution", async () => {
 });
 
 test("#654: with no lock manager at all, resolve fails closed (and stays retryable)", async () => {
-  let clock = 0;
+  let clock = 1000;
   const identity = createRestartTabIdentity({
     storage: fakeStorage("candidate-a"),
     // `{}` — not undefined: undefined would fall back to the DEFAULT
@@ -137,6 +137,63 @@ test("#654: with no lock manager at all, resolve fails closed (and stays retryab
   assert.equal(await identity.resolve(), undefined, "no lock manager → no identity claim");
   clock += 5001;
   assert.equal(await identity.resolve(), undefined, "a retry still fails closed without locks");
+});
+
+test("#654: a lock manager whose request REJECTS degrades to the same retryable failure, not a cached rejection", async () => {
+  // codex gate: the rejected-promise path used to skip the failure bookkeeping
+  // entirely, leaving every later caller to re-throw the SAME cached rejection —
+  // the page-lifetime wedge wearing a different hat.
+  const locks = {
+    calls: 0,
+    request() {
+      this.calls += 1;
+      return Promise.reject(new Error("lock manager exploded"));
+    },
+  };
+  let clock = 1000;
+  const identity = createRestartTabIdentity({
+    storage: fakeStorage("candidate-a"),
+    locks,
+    randomUUID: () => "rotated",
+    now: () => clock,
+    retryBackoffMs: 5000,
+  });
+  assert.equal(await identity.resolve(), undefined, "a rejecting lock request fails closed");
+  assert.equal(locks.calls, 3, "the three bounded attempts ran");
+  // The rejection is NOT cached: inside the backoff the answer is a quiet
+  // undefined; past it, a fresh attempt runs (and can succeed once the manager
+  // recovers).
+  assert.equal(await identity.resolve(), undefined);
+  assert.equal(locks.calls, 3, "inside the backoff: no new attempt, no re-thrown rejection");
+  clock += 5001;
+  assert.equal(await identity.resolve(), undefined);
+  assert.equal(locks.calls, 6, "past the backoff: a genuine fresh attempt");
+});
+
+test("#654: a THROWING resolver step fails closed and stays retryable — the rejection is never cached", async () => {
+  // The IIFE rejects only when a step OUTSIDE acquire's own try/catch throws
+  // (randomUUID is the reachable one). Without the rejection→undefined degrade
+  // the first resolve re-throws here; without the slot clear, the third call
+  // returns the stale settled promise and no fresh lease attempt runs.
+  const locks = new ContendedLocks();
+  locks.blocked = true;
+  let clock = 1000;
+  const identity = createRestartTabIdentity({
+    storage: fakeStorage("candidate-a"),
+    locks,
+    randomUUID: () => {
+      throw new Error("no entropy");
+    },
+    now: () => clock,
+    retryBackoffMs: 5000,
+  });
+  assert.equal(await identity.resolve(), undefined, "a throwing randomUUID fails closed");
+  assert.equal(locks.calls, 1, "one refused lease attempt before the throw");
+  assert.equal(await identity.resolve(), undefined, "the failure is served quietly, not re-thrown");
+  assert.equal(locks.calls, 1, "no new attempt inside the backoff");
+  clock += 5001;
+  assert.equal(await identity.resolve(), undefined);
+  assert.equal(locks.calls, 2, "a FRESH attempt runs after the backoff — the slot was cleared");
 });
 
 // ---------------------------------------------------------------------------

--- a/browser_tests/unit/restart-identity-retry.test.mjs
+++ b/browser_tests/unit/restart-identity-retry.test.mjs
@@ -1,0 +1,171 @@
+// #654 — a FAILED restart-tab-identity resolution must not wedge the page for
+// its lifetime.
+//
+// createRestartTabIdentity.resolve() used to cache its settled promise
+// FOREVER: one contested lease window (a duplicated tab holding the identity,
+// or a lease request that rejected) meant every later hello reused the cached
+// `undefined`, the route stayed refused, and the tab never re-registered with
+// the agent until a manual browser refresh — even after the contending tab
+// closed and the lease became acquirable.
+//
+// The fix: a failure is retryable once per backoff window; a success stays
+// cached for the page's life. These tests drive the real resolver with a
+// controllable lock manager and a controllable clock — deleting either half
+// (the retry, or the backoff) fails a test.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { createRestartTabIdentity } from "../../web/js/lib/restart-tab-identity.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+const SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+/** A lock manager whose grants are externally controllable. */
+class ContendedLocks {
+  constructor() {
+    this.blocked = false;
+    this.calls = 0;
+    this.held = new Set();
+  }
+
+  request(name, _options, callback) {
+    this.calls += 1;
+    if (this.blocked || this.held.has(name)) return Promise.resolve(callback(null));
+    this.held.add(name);
+    return Promise.resolve(callback({ name })).finally(() => this.held.delete(name));
+  }
+}
+
+function fakeStorage(seed) {
+  let stored = seed;
+  return {
+    getItem: () => stored,
+    setItem: (_k, v) => {
+      stored = v;
+    },
+  };
+}
+
+test("#654: a failed resolve is retried after the backoff and can then succeed", async () => {
+  const locks = new ContendedLocks();
+  locks.blocked = true;
+  let clock = 1000;
+  let rotations = 0;
+  const identity = createRestartTabIdentity({
+    storage: fakeStorage("candidate-a"),
+    locks,
+    randomUUID: () => `rotated-${(rotations += 1)}`,
+    now: () => clock,
+    retryBackoffMs: 5000,
+  });
+
+  // First resolve: 3 lease attempts, all refused → undefined (fail closed).
+  assert.equal(await identity.resolve(), undefined);
+  assert.equal(locks.calls, 3);
+
+  // Inside the backoff window: NO new lease attempt — the failure is fresh.
+  assert.equal(await identity.resolve(), undefined);
+  assert.equal(locks.calls, 3, "the backoff suppresses an immediate re-attempt");
+
+  // Past the backoff, still contended: a genuine new attempt (3 more calls).
+  clock += 5001;
+  assert.equal(await identity.resolve(), undefined);
+  assert.equal(locks.calls, 6, "a retry actually re-runs the lease");
+
+  // The contention clears (the duplicate tab closed): the NEXT retry succeeds
+  // WITHOUT a browser refresh — this is the #654 re-registration path.
+  locks.blocked = false;
+  clock += 5001;
+  const id = await identity.resolve();
+  assert.ok(typeof id === "string" && id.length > 0, "the lease was acquired on retry");
+
+  // A success is cached for the page's life — no further lease traffic.
+  const callsAfterSuccess = locks.calls;
+  assert.equal(await identity.resolve(), id);
+  assert.equal(locks.calls, callsAfterSuccess, "a resolved identity is never re-leased");
+});
+
+test("#654: a first-try success is cached and never re-attempted", async () => {
+  const locks = new ContendedLocks();
+  const identity = createRestartTabIdentity({
+    storage: fakeStorage("candidate-a"),
+    locks,
+    randomUUID: () => "rotated",
+    now: () => 0,
+    retryBackoffMs: 5000,
+  });
+  const id = await identity.resolve();
+  assert.equal(id, "candidate-a");
+  assert.equal(locks.calls, 1);
+  assert.equal(await identity.resolve(), "candidate-a");
+  assert.equal(locks.calls, 1, "no re-lease after success");
+});
+
+test("#654: concurrent callers share one in-flight resolution", async () => {
+  const locks = new ContendedLocks();
+  const identity = createRestartTabIdentity({
+    storage: fakeStorage("candidate-a"),
+    locks,
+    randomUUID: () => "rotated",
+    now: () => 0,
+    retryBackoffMs: 5000,
+  });
+  const [a, b] = await Promise.all([identity.resolve(), identity.resolve()]);
+  assert.equal(a, "candidate-a");
+  assert.equal(b, "candidate-a");
+  assert.equal(locks.calls, 1, "two concurrent resolves ran ONE lease attempt");
+});
+
+test("#654: with no lock manager at all, resolve fails closed (and stays retryable)", async () => {
+  let clock = 0;
+  const identity = createRestartTabIdentity({
+    storage: fakeStorage("candidate-a"),
+    // `{}` — not undefined: undefined would fall back to the DEFAULT
+    // (globalThis.navigator?.locks), which Node ≥22 actually provides. A
+    // request-less object models the plain-http LAN frontend where the Web
+    // Locks API is absent (secure-context-only).
+    locks: {},
+    randomUUID: () => "rotated",
+    now: () => clock,
+    retryBackoffMs: 5000,
+  });
+  assert.equal(await identity.resolve(), undefined, "no lock manager → no identity claim");
+  clock += 5001;
+  assert.equal(await identity.resolve(), undefined, "a retry still fails closed without locks");
+});
+
+// ---------------------------------------------------------------------------
+// Panel wiring: the refused-hello re-registration path (source scans —
+// deleting the wiring fails these)
+// ---------------------------------------------------------------------------
+
+test("#654 wiring: a hello refused for want of a route schedules a bounded re-hello", () => {
+  // The refusal site inside sendHello's makePayload: describeRefusedRoute is
+  // the disclosure; the retry is the recovery.
+  const refusalAt = SRC.indexOf("describeRefusedRoute({ settled: tabRouteIdentity.settled() })");
+  assert.notEqual(refusalAt, -1, "the route-refusal disclosure site exists");
+  const block = SRC.slice(refusalAt, refusalAt + 700);
+  assert.match(
+    block,
+    /scheduleRouteRefusalRetry\(\)/,
+    "the refusal schedules a re-hello — the lease can free up while this socket stays open",
+  );
+});
+
+test("#654 wiring: the retry is BOUNDED and re-runs the (now retryable) identity resolve", () => {
+  const start = SRC.indexOf("function scheduleRouteRefusalRetry()");
+  assert.notEqual(start, -1);
+  const body = SRC.slice(start, start + 900);
+  assert.match(body, /routeRefusalRetries >= ROUTE_REFUSAL_RETRY_MAX/, "bounded — no hot loop against a live duplicate tab");
+  assert.match(body, /void sendHello\(\)/, "the retry is a fresh hello, which re-resolves the identity");
+});
+
+test("#654 wiring: a landed hello or a fresh socket replenishes the retry budget", () => {
+  const resets = SRC.match(/routeRefusalRetries = 0;/g) ?? [];
+  assert.ok(resets.length >= 2, "reset on BOTH a landed hello and a fresh socket open");
+});

--- a/browser_tests/unit/restart-identity-retry.test.mjs
+++ b/browser_tests/unit/restart-identity-retry.test.mjs
@@ -170,8 +170,7 @@ test("#654: a lock manager whose request REJECTS degrades to the same retryable 
   assert.equal(locks.calls, 6, "past the backoff: a genuine fresh attempt");
 });
 
-test("#654: a THROWING resolver step fails closed and stays retryable — the rejection is never cached", async () => {
-  // The IIFE rejects only when a step OUTSIDE acquire's own try/catch throws
+test("#654: a THROWING resolver step fails closed and stays retryable — the rejection is never cached", async () => {  // The IIFE rejects only when a step OUTSIDE acquire's own try/catch throws
   // (randomUUID is the reachable one). Without the rejection→undefined degrade
   // the first resolve re-throws here; without the slot clear, the third call
   // returns the stale settled promise and no fresh lease attempt runs.
@@ -200,6 +199,22 @@ test("#654: a THROWING resolver step fails closed and stays retryable — the re
 // Panel wiring: the refused-hello re-registration path (source scans —
 // deleting the wiring fails these)
 // ---------------------------------------------------------------------------
+
+test("#654: a failure recorded at timestamp 0 still counts as a failure (null sentinel, codex r2)", async () => {
+  const locks = new ContendedLocks();
+  locks.blocked = true;
+  const identity = createRestartTabIdentity({
+    storage: fakeStorage("candidate-a"),
+    locks,
+    randomUUID: () => "rotated",
+    now: () => 0, // a legitimate clock reading — must not read as "never failed"
+    retryBackoffMs: 5000,
+  });
+  assert.equal(await identity.resolve(), undefined);
+  assert.equal(locks.calls, 3);
+  assert.equal(await identity.resolve(), undefined);
+  assert.equal(locks.calls, 3, "a failure at t=0 still arms the backoff");
+});
 
 test("#654 wiring: a hello refused for want of a route schedules a bounded re-hello", () => {
   // The refusal site inside sendHello's makePayload: describeRefusedRoute is

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -6232,8 +6232,9 @@ function hasRawMissingAssetCandidates() {
 // promise itself keeps running (the coalescer owns it) and benefits a later
 // call.
 // Resolves to the refresh's OWN freshness verdict (registerComfyNodeDefs' verdict
-// is refreshed:true only when it authoritatively fetched /object_info AND refreshed
-// combos), or FALSE if the refresh errored or the timeout wins first. get_errors
+// is refreshed:true only when it authoritatively fetched /object_info, registered
+// the defs, AND refreshed combos), or FALSE if the refresh errored or the timeout
+// wins first. get_errors
 // trusts the combo on this returned value — NOT the shared nodeDefsRefreshConfirmed
 // global, which a concurrent refresh can overwrite mid-await against a stale combo
 // (codex round-5/6 P0). Never rejects; a timeout or failure falls to FALSE ⇒

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -12538,18 +12538,40 @@ const GRAPH_TOOL_EXECUTORS = {
         });
       },
     });
-    if (!receipt.landed) {
+    if (!receipt.landed && !receipt.everLanded) {
       throw new Error(
         `panel_enter_subgraph could not confirm that the canvas moved into node ${node.id}'s ` +
           `subgraph — the navigation did NOT take effect and nothing was applied. Retry, or open ` +
           `the subgraph on the ComfyUI canvas (double-click the node) and read it from there.`,
       );
     }
-    const viewing = describeActiveGraph(getGraphCtx().graph);
+    let viewing = null;
+    try {
+      viewing = describeActiveGraph(getGraphCtx().graph);
+    } catch {
+      // The current scope is unresolvable right now — omit `viewing` rather
+      // than fabricate one; the note below already discloses the uncertainty.
+      viewing = null;
+    }
     if (!receipt.bound) {
+      if (!receipt.landed) {
+        // The canvas WAS observed inside the subgraph, then moved elsewhere
+        // before the binding settled — the navigation happened, so this is a
+        // disclosure, never a "nothing was applied" refusal.
+        return {
+          entered: node.id,
+          ...(viewing ? { viewing } : {}),
+          settled: false,
+          note:
+            `The canvas DID enter the subgraph, but it has since navigated away before the panel ` +
+            `could confirm the binding — something else moved the view (a user navigation or a ` +
+            `tab restore). Re-read the current scope (panel_graph_outline) before editing, and ` +
+            `re-enter the subgraph if that is still where you mean to work.`,
+        };
+      }
       return {
         entered: node.id,
-        viewing,
+        ...(viewing ? { viewing } : {}),
         settled: false,
         note:
           `The canvas DID enter the subgraph (the navigation is in effect), but the ` +
@@ -12591,17 +12613,38 @@ const GRAPH_TOOL_EXECUTORS = {
         });
       },
     });
-    if (!receipt.landed) {
+    if (!receipt.landed && !receipt.everLanded) {
       throw new Error(
         `panel_exit_subgraph could not confirm that the canvas returned to the parent graph — ` +
           `the navigation did NOT take effect and nothing was applied. Retry, or leave the ` +
           `subgraph on the ComfyUI canvas (its breadcrumb, or double-click out).`,
       );
     }
-    const viewing = describeActiveGraph(getGraphCtx().graph);
+    let viewing = null;
+    try {
+      viewing = describeActiveGraph(getGraphCtx().graph);
+    } catch {
+      // The current scope is unresolvable right now — omit `viewing` rather
+      // than fabricate one; the note below already discloses the uncertainty.
+      viewing = null;
+    }
     if (!receipt.bound) {
+      if (!receipt.landed) {
+        // The canvas WAS observed back at the parent, then moved elsewhere
+        // before the binding settled — the navigation happened, so this is a
+        // disclosure, never a "nothing was applied" refusal.
+        return {
+          ...(viewing ? { viewing } : {}),
+          settled: false,
+          note:
+            `The canvas DID return to the parent graph, but it has since navigated away before ` +
+            `the panel could confirm the binding — something else moved the view (a user ` +
+            `navigation or a tab restore). Re-read the current scope (panel_graph_outline) ` +
+            `before editing.`,
+        };
+      }
       return {
-        viewing,
+        ...(viewing ? { viewing } : {}),
         settled: false,
         note:
           `The canvas DID return to the parent graph (the navigation is in effect), but the ` +

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -12577,17 +12577,26 @@ const GRAPH_TOOL_EXECUTORS = {
     }
     // The reply must describe the canvas as it is NOW, not as the receipt left
     // it: this post-receipt read is a fresh terminal observation (codex gate
-    // r8). A canvas no longer on the target gets the displacement disclosure,
-    // never settled:true / "in effect" for a scope it has already left.
-    const stillOnTarget = (() => {
+    // r8), and it is THREE-state (r9): a read that throws proves neither "still
+    // on the target" nor "moved elsewhere", so it gets an uncertainty
+    // disclosure, not the displacement one.
+    const terminalState = (() => {
       try {
-        return comfyApp?.canvas?.graph === sub;
+        return comfyApp?.canvas?.graph === sub ? "target" : "elsewhere";
       } catch {
-        return false;
+        return "unreadable";
       }
     })();
+    const unreadableNote =
+      `The canvas DID enter the subgraph, but the panel can no longer read where the canvas is ` +
+      `right now — the navigation may be in effect or the view may have moved; the panel could ` +
+      `not determine which. Read the current scope (panel_graph_outline) before editing, and ` +
+      `re-enter the subgraph if that is still where you mean to work.`;
     if (!receipt.bound) {
-      if (!receipt.landed || !stillOnTarget) {
+      if (terminalState === "unreadable") {
+        return { entered: node.id, ...(viewing ? { viewing } : {}), settled: false, note: unreadableNote };
+      }
+      if (!receipt.landed || terminalState === "elsewhere") {
         // The canvas WAS observed inside the subgraph, then moved elsewhere
         // before the binding settled — the navigation happened, so this is a
         // disclosure, never a "nothing was applied" refusal.
@@ -12614,7 +12623,10 @@ const GRAPH_TOOL_EXECUTORS = {
           `retry the read in a moment.`,
       };
     }
-    if (!stillOnTarget) {
+    if (terminalState === "unreadable") {
+      return { entered: node.id, ...(viewing ? { viewing } : {}), settled: false, note: unreadableNote };
+    }
+    if (terminalState === "elsewhere") {
       return {
         entered: node.id,
         ...(viewing ? { viewing } : {}),
@@ -12679,18 +12691,26 @@ const GRAPH_TOOL_EXECUTORS = {
       // than fabricate one; the note below already discloses the uncertainty.
       viewing = null;
     }
-    // Same fresh terminal observation as graph_enter_subgraph (codex gate r8):
-    // a canvas no longer on the parent gets the displacement disclosure, never
-    // settled:true / "in effect" for a scope it has already left.
-    const stillOnTarget = (() => {
+    // Same fresh terminal observation as graph_enter_subgraph (codex gate r8),
+    // and equally THREE-state (r9): a read that throws proves neither "still on
+    // the parent" nor "moved elsewhere", so it gets an uncertainty disclosure,
+    // not the displacement one.
+    const terminalState = (() => {
       try {
-        return comfyApp?.canvas?.graph === parentGraph;
+        return comfyApp?.canvas?.graph === parentGraph ? "target" : "elsewhere";
       } catch {
-        return false;
+        return "unreadable";
       }
     })();
+    const unreadableNote =
+      `The canvas DID return to the parent graph, but the panel can no longer read where the ` +
+      `canvas is right now — the navigation may be in effect or the view may have moved; the ` +
+      `panel could not determine which. Read the current scope (panel_graph_outline) before editing.`;
     if (!receipt.bound) {
-      if (!receipt.landed || !stillOnTarget) {
+      if (terminalState === "unreadable") {
+        return { ...(viewing ? { viewing } : {}), settled: false, note: unreadableNote };
+      }
+      if (!receipt.landed || terminalState === "elsewhere") {
         // The canvas WAS observed back at the parent, then moved elsewhere
         // before the binding settled — the navigation happened, so this is a
         // disclosure, never a "nothing was applied" refusal.
@@ -12715,7 +12735,10 @@ const GRAPH_TOOL_EXECUTORS = {
           `retry the read in a moment.`,
       };
     }
-    if (!stillOnTarget) {
+    if (terminalState === "unreadable") {
+      return { ...(viewing ? { viewing } : {}), settled: false, note: unreadableNote };
+    }
+    if (terminalState === "elsewhere") {
       return {
         ...(viewing ? { viewing } : {}),
         settled: false,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -659,6 +659,11 @@ async function registerComfyNodeDefs(preloadedDefs) {
   let comboRan = false;
   let phase = "fetch";
   let thrown = null;
+  // Tracked separately from the caught VALUE: a library can throw a FALSY value
+  // (throw null / 0 / "") and `if (thrown)` would then read a failed run as a
+  // clean one — misattributing the verdict and, worse, setting the shared
+  // confirmed flag after a throw (codex gate r5).
+  let didThrow = false;
   try {
     const a = typeof app !== "undefined" && app ? app : window.comfyAPI?.app?.app;
     if (!a) return describeNodeDefRefresh({ appAvailable: false, defsObtained: false, defsRegistered: false, comboApiPresent: false, comboRan: false });
@@ -715,6 +720,7 @@ async function registerComfyNodeDefs(preloadedDefs) {
     phase = "done";
   } catch (e) {
     thrown = e;
+    didThrow = true;
     console.warn("[comfyui-mcp-panel] node-def refresh after reconnect failed:", e);
   } finally {
     // Trust the live combos for suppressing missing-asset candidates ONLY when BOTH an
@@ -725,7 +731,7 @@ async function registerComfyNodeDefs(preloadedDefs) {
     // the FALSE side keeps us in over-report-safe mode. The shared global keeps the
     // pre-#635 semantics exactly: true only when this run completed with an
     // authoritative payload AND a completed combo refresh.
-    nodeDefsRefreshConfirmed = !thrown && !!defs && comboRan;
+    nodeDefsRefreshConfirmed = !didThrow && !!defs && comboRan;
   }
   // RETURN this run's own verdict so a caller can trust the combo based on the result
   // of ITS refresh, independent of the shared nodeDefsRefreshConfirmed global — which a
@@ -733,7 +739,7 @@ async function registerComfyNodeDefs(preloadedDefs) {
   // coalescer forwards this through a forced trailing run, so get_errors' awaited
   // `force:true` refresh resolves to the freshness verdict of the fetch IT triggered
   // (codex round-6 P0).
-  return describeNodeDefRefresh({ appAvailable, defsObtained: !!defs, defsRegistered, comboApiPresent, comboRan, phase, thrown });
+  return describeNodeDefRefresh({ appAvailable, defsObtained: !!defs, defsRegistered, comboApiPresent, comboRan, phase, didThrow, thrown });
 }
 
 // Single-flight refresh that never drops a caller-supplied fresh payload (#289 P2).
@@ -12547,10 +12553,16 @@ const GRAPH_TOOL_EXECUTORS = {
       },
     });
     if (!receipt.landed && !receipt.everLanded) {
+      // Never OBSERVED on the target is not proof the navigation never happened
+      // — a landing displaced between two polls is invisible to a sampler
+      // (codex gate r5). Say what is known (no observation) and make the next
+      // step a scope READ, not a blind retry of a possibly-applied navigation.
       throw new Error(
         `panel_enter_subgraph could not confirm that the canvas moved into node ${node.id}'s ` +
-          `subgraph — the navigation did NOT take effect and nothing was applied. Retry, or open ` +
-          `the subgraph on the ComfyUI canvas (double-click the node) and read it from there.`,
+          `subgraph: no observation ever saw the canvas inside it. The navigation may not have ` +
+          `taken effect — or it may have landed and been displaced between checks, so do NOT ` +
+          `assume nothing happened. Read the current scope (panel_graph_outline); if it is not ` +
+          `the subgraph, retry, or open it on the ComfyUI canvas (double-click the node).`,
       );
     }
     let viewing = null;
@@ -12622,10 +12634,16 @@ const GRAPH_TOOL_EXECUTORS = {
       },
     });
     if (!receipt.landed && !receipt.everLanded) {
+      // Never OBSERVED at the parent is not proof the navigation never happened
+      // — a landing displaced between two polls is invisible to a sampler
+      // (codex gate r5). Say what is known (no observation) and make the next
+      // step a scope READ, not a blind retry of a possibly-applied navigation.
       throw new Error(
-        `panel_exit_subgraph could not confirm that the canvas returned to the parent graph — ` +
-          `the navigation did NOT take effect and nothing was applied. Retry, or leave the ` +
-          `subgraph on the ComfyUI canvas (its breadcrumb, or double-click out).`,
+        `panel_exit_subgraph could not confirm that the canvas returned to the parent graph: no ` +
+          `observation ever saw the canvas there. The navigation may not have taken effect — or ` +
+          `it may have landed and been displaced between checks, so do NOT assume nothing ` +
+          `happened. Read the current scope (panel_graph_outline); if it is still inside the ` +
+          `subgraph, retry, or leave it on the ComfyUI canvas (its breadcrumb, or double-click out).`,
       );
     }
     let viewing = null;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -135,6 +135,9 @@ import { assertAddNodeResolvableRefreshing } from "./lib/node-resolve.js";
 import { displayLabel, boundaryInputLabel, widgetLabelMap } from "./lib/slot-labels.js";
 import { createObjectInfoHistory, awaitHistoryBaseline } from "./lib/object-info-history.js";
 import { makeRefreshCoalescer } from "./lib/refresh-coalesce.js";
+import { describeNodeDefRefresh } from "./lib/node-def-refresh.js";
+import { confirmCanvasNavigation } from "./lib/canvas-navigation.js";
+import { watchPostReconnectSettle, graphMutationReconnectGate } from "./lib/reconnect-recovery.js";
 import { reconcileCompletedDownloads } from "./lib/download-refresh.js";
 import { todoItemGlyph } from "./lib/plan-glyph.js";
 import {
@@ -305,6 +308,7 @@ import {
   graphRootWorkflowUuidMatches,
   graphRootMatchesState,
   graphCommandBindingBar,
+  graphCommandMayMutateWorkflow,
   MUTATION_BINDING_BAR,
   graphBindingRefusalMessage,
   resolveGraphBindingVerdict,
@@ -420,6 +424,21 @@ let backendReconnectedAt = null;
 // The reconnect epoch value at the last authoritative (re)bind by an explicit
 // open/new; when it's >= backendReconnectEpoch the active pointer is trusted again.
 let activeWorkflowResyncEpoch = 0;
+// #663/#646: the reconnect epoch whose CANVAS BINDING has been re-proven since the
+// reconnect — by the proactive settle watch (kickPostReconnectSettleWatch) running
+// the same evidence bar a graph read runs, or by an explicit workflow_open/new,
+// whose receipts are stronger proof. Until proofEpoch >= backendReconnectEpoch,
+// graph MUTATIONS are gated (graphMutationReconnectGate): a mutation dispatched
+// before the restored binding is proven can land on a canvas the restore is about
+// to rebuild. Reads keep their own evidence bars and are not gated.
+let postReconnectBindingProofEpoch = 0;
+// Supersede token for the settle watch — a newer reconnect retires the older watch.
+let postReconnectWatchToken = 0;
+// #646: ComfyUI's own backend socket is DOWN between its "reconnecting" and
+// "reconnected" events (a null "status" payload is the same lost-connection
+// signal). A graph mutation dispatched in that gap can be applied and then wiped
+// by the incoming restore — so mutations are refused while this holds.
+let comfyBackendSocketDown = false;
 // #402 — OPEN RECEIPTS. Every workflow_open / workflow_new that RAN is journaled here
 // with the selector it was asked for, the identity it resolved to, and whether it
 // applied. When a mid-command drop loses the reply, this is the ONLY non-inferential
@@ -627,15 +646,26 @@ async function registerComfyNodeDefs(preloadedDefs) {
   // combo refresh has ACTUALLY RUN and succeeded. If refreshComboInNodes is absent on
   // this ComfyUI build (or throws), the combos are still whatever page-load left them
   // — possibly stale — so we must stay in over-report-safe mode (finding #4).
-  let comboRefreshed = false;
+  //
+  // #635: the run's outcome is a VERDICT (lib/node-def-refresh.js), not a bare
+  // boolean — {refreshed:false} alone was indistinguishable from a no-op, so the
+  // verdict carries the reason (which step did not complete) and an actionable
+  // remedy. Each phase is tracked so a throw is attributed to the step that
+  // actually failed instead of being bucketed as a generic failure.
+  let appAvailable = false;
+  let defs = preloadedDefs ?? null;
+  let comboApiPresent = false;
+  let comboRan = false;
+  let phase = "fetch";
+  let thrown = null;
   try {
     const a = typeof app !== "undefined" && app ? app : window.comfyAPI?.app?.app;
-    if (!a) return false;
+    if (!a) return describeNodeDefRefresh({ appAvailable: false, defsObtained: false, comboApiPresent: false, comboRan: false });
+    appAvailable = true;
     // Obtain an AUTHORITATIVE /object_info payload up front (preloaded, or a fresh
     // getNodeDefs) — this is the OBSERVABLE proof of a real server fetch that gates
     // combo trust below. Decoupled from registerNodesFromDefs so the trust signal
     // doesn't hinge on that method existing (codex #2).
-    let defs = preloadedDefs ?? null;
     if (!defs && typeof api?.getNodeDefs === "function") {
       defs = await api.getNodeDefs();
     }
@@ -652,6 +682,8 @@ async function registerComfyNodeDefs(preloadedDefs) {
     // let a provenance-stripped husk squatting a reserved allowlisted name through the
     // frontend-only exemption. ONLY seedObjectInfoHistory() — the STARTUP baseline, whose
     // observation window begins at page load — may call markObjectInfoHistorySeeded().
+    // (A throw here is attributed to "register": the fetch itself already succeeded.)
+    phase = "register";
     recordObjectInfoTypes(defs);
     // Re-register node definitions so newly installed/updated classes and their
     // current widget schemas are known to LiteGraph (#221/#171).
@@ -667,22 +699,26 @@ async function registerComfyNodeDefs(preloadedDefs) {
     }
     // Refresh combo widget option lists (model dropdowns etc.) so freshly installed
     // models resolve and stale entries clear (#185/#181/#223).
-    let comboRan = false;
-    if (typeof a.refreshComboInNodes === "function") {
+    phase = "combo";
+    comboApiPresent = typeof a.refreshComboInNodes === "function";
+    if (comboApiPresent) {
       await a.refreshComboInNodes();
       comboRan = true;
     }
+    phase = "done";
+  } catch (e) {
+    thrown = e;
+    console.warn("[comfyui-mcp-panel] node-def refresh after reconnect failed:", e);
+  } finally {
     // Trust the live combos for suppressing missing-asset candidates ONLY when BOTH an
     // authoritative /object_info payload was actually obtained this call AND the combo
     // lists were refreshed from it. refreshComboInNodes resolving alone is not proof —
     // without a fetched `defs`, combos may still be the stale page-load snapshot, and
     // trusting them could suppress a genuine miss (finding #4 / codex #2). Failing to
-    // the FALSE side keeps us in over-report-safe mode.
-    comboRefreshed = !!defs && comboRan;
-  } catch (e) {
-    console.warn("[comfyui-mcp-panel] node-def refresh after reconnect failed:", e);
-  } finally {
-    nodeDefsRefreshConfirmed = comboRefreshed;
+    // the FALSE side keeps us in over-report-safe mode. The shared global keeps the
+    // pre-#635 semantics exactly: true only when this run completed with an
+    // authoritative payload AND a completed combo refresh.
+    nodeDefsRefreshConfirmed = !thrown && !!defs && comboRan;
   }
   // RETURN this run's own verdict so a caller can trust the combo based on the result
   // of ITS refresh, independent of the shared nodeDefsRefreshConfirmed global — which a
@@ -690,7 +726,7 @@ async function registerComfyNodeDefs(preloadedDefs) {
   // coalescer forwards this through a forced trailing run, so get_errors' awaited
   // `force:true` refresh resolves to the freshness verdict of the fetch IT triggered
   // (codex round-6 P0).
-  return comboRefreshed;
+  return describeNodeDefRefresh({ appAvailable, defsObtained: !!defs, comboApiPresent, comboRan, phase, thrown });
 }
 
 // Single-flight refresh that never drops a caller-supplied fresh payload (#289 P2).
@@ -719,17 +755,25 @@ function setupListeners() {
     });
     // While the backend socket is down, distrust the combos (they may be about
     // to change) so a stale combo can't suppress a genuine miss (finding #4).
+    // #646: the same down-signal gates graph MUTATIONS — a mutation dispatched
+    // while the backend is away can be applied and then wiped by the incoming
+    // restore.
     api.addEventListener("reconnecting", () => {
       nodeDefsRefreshConfirmed = false;
+      comfyBackendSocketDown = true;
     });
     api.addEventListener("status", (ev) => {
       // A null status payload is ComfyUI's "backend connection lost" signal.
-      if (ev?.detail == null) nodeDefsRefreshConfirmed = false;
+      if (ev?.detail == null) {
+        nodeDefsRefreshConfirmed = false;
+        comfyBackendSocketDown = true;
+      }
     });
     // ComfyUI's own socket to its backend re-establishing is the reliable
     // in-tab signal that the server came back after a restart — refresh the
     // stale node registry + combos then (#221/#171/#185/#181).
     api.addEventListener("reconnected", () => {
+      comfyBackendSocketDown = false;
       // #433: the frontend may now restore a stale/wrong active tab — bump the
       // epoch and arm the monotonic possibly-stale window. Bumping the epoch
       // invalidates any EARLIER resync so a pre-reconnect open can't clear this
@@ -742,6 +786,12 @@ function setupListeners() {
       // re-probes the backend that is actually answering now.
       invalidateManagerDialectCache();
       void refreshComfyNodeDefs();
+      // #663: PROACTIVELY re-prove the canvas binding instead of leaving the
+      // settle window to run its full 30s (or, for a restore that never
+      // settles, to hard-refuse until a manual panel_open_workflow/reload).
+      // The watch runs only the same safe heals a graph command runs lazily;
+      // it never repaints the canvas from serialized state (#604).
+      kickPostReconnectSettleWatch(backendReconnectEpoch);
     });
   } catch {
     // api unavailable — graph_get_errors reports null.
@@ -4718,6 +4768,44 @@ function postReconnectSettleWindow() {
   });
 }
 
+// #663/#646 — the BINDING-side view of the settle window: open while the #433
+// window is armed AND the canvas binding has not been re-proven for the current
+// epoch. This is the one invariant the #646 mutation gate consults; reads and
+// the #618 mid-population verdict keep consulting postReconnectSettleWindow()
+// directly, unchanged.
+function postReconnectBindingSettleWindow() {
+  return (
+    postReconnectSettleWindow() &&
+    postReconnectBindingProofEpoch < backendReconnectEpoch
+  );
+}
+
+// #663 — kick the proactive post-reconnect settle watch for THIS reconnect epoch.
+// The proof is the SAME evidence bar a graph read runs (getGraphCtx performs its
+// verified scope reconcile; the assert applies the full read bar and its
+// rebind/seal heals), so "proven" here means the next command's fence has already
+// been observed to pass — never a weaker proxy. The watch performs no canvas
+// repaint and no workflow mutation; when the restore never settles it simply
+// stops, and the binding refusals keep their existing remedies.
+function kickPostReconnectSettleWatch(epoch) {
+  const token = ++postReconnectWatchToken;
+  void watchPostReconnectSettle({
+    isCurrent: () => token === postReconnectWatchToken && epoch === backendReconnectEpoch,
+    windowOpen: () => postReconnectBindingSettleWindow(),
+    proveBinding: () => {
+      const { graph, rootGraph } = getGraphCtx();
+      assertGraphBoundToActiveWorkflow(graph, rootGraph, { includeBaselineReadGuard: true });
+      return true;
+    },
+    markProven: () => {
+      if (epoch === backendReconnectEpoch) postReconnectBindingProofEpoch = epoch;
+    },
+  }).catch(() => {
+    // Best-effort: the watch must never surface an unhandled rejection, and a
+    // failed watch leaves the pre-#663 behavior (window runs to expiry).
+  });
+}
+
 function assertGraphBoundToActiveWorkflow(
   graph,
   rootGraph,
@@ -6139,16 +6227,18 @@ function hasRawMissingAssetCandidates() {
 // case is today's staleness, never a hung tool call (codex #5). The refresh
 // promise itself keeps running (the coalescer owns it) and benefits a later
 // call.
-// Resolves to the refresh's OWN freshness verdict (registerComfyNodeDefs returns TRUE
-// only when it authoritatively fetched /object_info AND refreshed combos), or FALSE if
-// the refresh errored or the timeout wins first. get_errors trusts the combo on this
-// returned value — NOT the shared nodeDefsRefreshConfirmed global, which a concurrent
-// refresh can overwrite mid-await against a stale combo (codex round-5/6 P0). Never
-// rejects; a timeout or failure falls to FALSE ⇒ distrust ⇒ over-report.
+// Resolves to the refresh's OWN freshness verdict (registerComfyNodeDefs' verdict
+// is refreshed:true only when it authoritatively fetched /object_info AND refreshed
+// combos), or FALSE if the refresh errored or the timeout wins first. get_errors
+// trusts the combo on this returned value — NOT the shared nodeDefsRefreshConfirmed
+// global, which a concurrent refresh can overwrite mid-await against a stale combo
+// (codex round-5/6 P0). Never rejects; a timeout or failure falls to FALSE ⇒
+// distrust ⇒ over-report. The verdict became an OBJECT in #635; the boolean arm is
+// kept so a stale shape can never read as fresh.
 function withRefreshTimeout(promise, timeoutMs) {
   return Promise.race([
     Promise.resolve(promise).then(
-      (v) => v === true,
+      (v) => v === true || (v != null && typeof v === "object" && v.refreshed === true),
       () => false,
     ),
     new Promise((resolve) => setTimeout(() => resolve(false), timeoutMs)),
@@ -6928,11 +7018,24 @@ const GRAPH_TOOL_EXECUTORS = {
   // completed download already triggers automatically. GLOBAL (not tied to the active
   // graph, so it carries no workflow_path and skips the pinned-target guard),
   // undo-neutral, idempotent. Resolves to the refresh's OWN freshness verdict —
-  // refreshComfyNodeDefs returns true only when it authoritatively fetched /object_info
-  // AND refreshed combos — so the tool reply reflects a real fetch, not just a no-op.
+  // refreshed:true only when it authoritatively fetched /object_info AND refreshed
+  // combos — so the tool reply reflects a real fetch, not just a no-op.
+  // #635: a non-fresh verdict now says WHY (reason) and what to do about it
+  // (remedy) — a bare {ok:true, refreshed:false} was indistinguishable from a
+  // no-op and left the caller guessing whether the call did anything.
   async refresh_nodes() {
-    const refreshed = await refreshComfyNodeDefs(undefined, { force: true });
-    return { ok: true, refreshed: !!refreshed };
+    const verdict = await refreshComfyNodeDefs(undefined, { force: true });
+    const refreshed = verdict === true || (verdict != null && typeof verdict === "object" && verdict.refreshed === true);
+    if (refreshed) return { ok: true, refreshed: true };
+    return {
+      ok: true,
+      refreshed: false,
+      reason: verdict?.reason ?? "unknown",
+      ...(verdict?.detail ? { detail: verdict.detail } : {}),
+      remedy:
+        verdict?.remedy ??
+        "The refresh did not complete and the panel could not determine why. Retry; if it persists, reload the ComfyUI tab.",
+    };
   },
   // Full-fidelity capture of the live canvas — the ROOT graph's serialized UI
   // JSON (the same shape ComfyUI writes to disk on save), so the orchestrator
@@ -10395,6 +10498,9 @@ const GRAPH_TOOL_EXECUTORS = {
     // against the epoch we STARTED on, but only if no reconnect intervened during
     // the async work (else its tab-restore may have overridden us — leave armed).
     if (backendReconnectEpoch === openedForEpoch) activeWorkflowResyncEpoch = openedForEpoch;
+    // #663/#646: a created tab's binding is proven by creation — stamp the binding
+    // proof too so the post-reconnect mutation gate opens for this epoch.
+    if (backendReconnectEpoch === openedForEpoch) postReconnectBindingProofEpoch = openedForEpoch;
     // #402 — workflow_new ALSO authoritatively re-points `active`, so it gets a receipt
     // too: a lost reply here leaves the caller unable to tell whether a blank tab was
     // created (and re-issuing would create a SECOND one, unlike the idempotent open).
@@ -10778,6 +10884,10 @@ const GRAPH_TOOL_EXECUTORS = {
         // the epoch we STARTED on, but only if no reconnect intervened during the async
         // open (else its tab-restore may have overridden us — leave the window armed).
         if (backendReconnectEpoch === openedForEpoch) activeWorkflowResyncEpoch = openedForEpoch;
+        // #663/#646: this open only reaches here with a PROVEN rebind receipt, which is
+        // stronger proof than the settle watch's — stamp the binding proof so the
+        // post-reconnect mutation gate opens for this epoch.
+        if (backendReconnectEpoch === openedForEpoch) postReconnectBindingProofEpoch = openedForEpoch;
       // #442 — read the on-disk bytes AS LATE AS POSSIBLE (after openWorkflow + repaint),
       // so an external write during those awaits is still detected. wasOpen was captured
       // before openWorkflow; the baseline (originalContent) is unchanged by an already-open
@@ -12381,8 +12491,20 @@ const GRAPH_TOOL_EXECUTORS = {
   // Navigate INTO a subgraph node so the canvas (and therefore every graph_*
   // editor) targets its inner graph — the way to read/edit nodes inside a
   // subgraph. Pair with graph_exit_subgraph to return to the root.
-  graph_enter_subgraph({ node_id }) {
-    const { graph, canvas } = getGraphCtx();
+  //
+  // #619: the navigation is not complete when openSubgraph returns — the canvas
+  // can land on the subgraph a beat later and the workflow tracker can still be
+  // mid-capture, so a bare call let the IMMEDIATELY following graph read refuse
+  // with [root-shape-mismatch] on a valid navigation, and a silent no-op would
+  // have reported `entered` for a canvas that never moved. The receipt below
+  // polls (bounded) until the canvas observably shows the subgraph AND the
+  // binding guard a read would run clears — so `settled:true` means the next
+  // read has already been proven to pass. Refuse when the navigation did not
+  // take effect; DISCLOSE (settled:false) when it did but the binding has not
+  // caught up — the act already happened, so reporting failure would invite a
+  // pointless re-navigation.
+  async graph_enter_subgraph({ node_id }) {
+    const { app: comfyApp, graph, canvas } = getGraphCtx();
     const node = resolveNode(graph, node_id);
     const sub = node.subgraph;
     if (!sub) throw new Error(`Node ${node.id} (${node.type}) is not a subgraph`);
@@ -12391,7 +12513,42 @@ const GRAPH_TOOL_EXECUTORS = {
     }
     canvas.openSubgraph(sub, node);
     canvas.setDirty?.(true, true);
-    return { entered: node.id, viewing: describeActiveGraph(getGraphCtx().graph) };
+    const receipt = await confirmCanvasNavigation({
+      readCanvasGraph: () => comfyApp?.canvas?.graph ?? null,
+      target: sub,
+      // The SAME evidence bar a following read runs (getGraphCtx performs its
+      // verified scope reconcile; the assert applies the full read bar), so a
+      // passed receipt is a proven pass for the next graph_* read — not a
+      // weaker proxy for one.
+      assertBound: () => {
+        const ctx = getGraphCtx();
+        assertGraphBoundToActiveWorkflow(ctx.graph, ctx.rootGraph, {
+          includeBaselineReadGuard: true,
+        });
+      },
+    });
+    if (!receipt.landed) {
+      throw new Error(
+        `panel_enter_subgraph could not confirm that the canvas moved into node ${node.id}'s ` +
+          `subgraph — the navigation did NOT take effect and nothing was applied. Retry, or open ` +
+          `the subgraph on the ComfyUI canvas (double-click the node) and read it from there.`,
+      );
+    }
+    const viewing = describeActiveGraph(getGraphCtx().graph);
+    if (!receipt.bound) {
+      return {
+        entered: node.id,
+        viewing,
+        settled: false,
+        note:
+          `The canvas DID enter the subgraph (the navigation is in effect), but the ` +
+          `post-navigation binding check has not passed yet (${coerceMessageText(
+            receipt.lastError?.message ?? receipt.lastError ?? "unknown",
+          )}). A graph read issued this instant may still refuse while the tracker catches up — ` +
+          `retry the read in a moment.`,
+      };
+    }
+    return { entered: node.id, viewing, settled: true };
   },
 
   // Leave the current subgraph and return to its IMMEDIATE parent graph. For a
@@ -12399,8 +12556,8 @@ const GRAPH_TOOL_EXECUTORS = {
   // enclosing subgraph, NOT the root — jumping straight to root (graph.rootGraph)
   // skipped the parent, so the next graph_enter_subgraph targeted a node id that
   // only exists inside the skipped parent and navigated nowhere useful (#412).
-  graph_exit_subgraph() {
-    const { graph, canvas, rootGraph } = getGraphCtx();
+  async graph_exit_subgraph() {
+    const { app: comfyApp, graph, canvas, rootGraph } = getGraphCtx();
     if (graph === rootGraph) return { viewing: { scope: "root" }, note: "already at root" };
     if (typeof canvas.setGraph !== "function") {
       throw new Error("subgraph navigation unavailable on this frontend");
@@ -12411,7 +12568,39 @@ const GRAPH_TOOL_EXECUTORS = {
     const parentGraph = findSubgraphOwner(rootGraph, graph)?.parentGraph ?? graph.rootGraph ?? rootGraph;
     canvas.setGraph(parentGraph);
     canvas.setDirty?.(true, true);
-    return { viewing: describeActiveGraph(getGraphCtx().graph) };
+    // #619: same post-navigation receipt as graph_enter_subgraph — a bare setGraph
+    // that did not observably land must not report a scope the canvas is not in.
+    const receipt = await confirmCanvasNavigation({
+      readCanvasGraph: () => comfyApp?.canvas?.graph ?? null,
+      target: parentGraph,
+      assertBound: () => {
+        const ctx = getGraphCtx();
+        assertGraphBoundToActiveWorkflow(ctx.graph, ctx.rootGraph, {
+          includeBaselineReadGuard: true,
+        });
+      },
+    });
+    if (!receipt.landed) {
+      throw new Error(
+        `panel_exit_subgraph could not confirm that the canvas returned to the parent graph — ` +
+          `the navigation did NOT take effect and nothing was applied. Retry, or leave the ` +
+          `subgraph on the ComfyUI canvas (its breadcrumb, or double-click out).`,
+      );
+    }
+    const viewing = describeActiveGraph(getGraphCtx().graph);
+    if (!receipt.bound) {
+      return {
+        viewing,
+        settled: false,
+        note:
+          `The canvas DID return to the parent graph (the navigation is in effect), but the ` +
+          `post-navigation binding check has not passed yet (${coerceMessageText(
+            receipt.lastError?.message ?? receipt.lastError ?? "unknown",
+          )}). A graph read issued this instant may still refuse while the tracker catches up — ` +
+          `retry the read in a moment.`,
+      };
+    }
+    return { viewing, settled: true };
   },
 
   // Reposition a subgraph's input/output RAIL (the boundary I/O node). Must run
@@ -13280,9 +13469,38 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
   // effects (budget reset, soft-reload interlock release).
   let lastStatus = null;
   // #640 — say the route refusal ONCE. The reconnect loop retries the hello
-  // forever and the refusal is sticky (the identity is frozen for the page), so
-  // an unthrottled notice would bury the panel in the same paragraph.
+  // forever and the refusal used to be sticky (the identity was frozen for the
+  // page), so an unthrottled notice would bury the panel in the same paragraph.
   let routeRefusalDisclosed = false;
+  // #654 — a hello REFUSED for want of an established route is no longer the end
+  // of registration: the lease can become acquirable later (the contending tab
+  // closed) while THIS socket stays open, and nothing would otherwise re-hello
+  // until the next socket event — the tab sat unregistered until a manual
+  // browser refresh. Retry the hello a bounded number of times with backoff; a
+  // landed hello or a new socket resets the budget (a new socket is new
+  // evidence: its own open-hello is another attempt).
+  let routeRefusalRetryTimer = null;
+  let routeRefusalRetries = 0;
+  const ROUTE_REFUSAL_RETRY_MAX = 6;
+  const ROUTE_REFUSAL_RETRY_MS = 5000;
+  function clearRouteRefusalRetry() {
+    if (routeRefusalRetryTimer) {
+      clearTimeout(routeRefusalRetryTimer);
+      routeRefusalRetryTimer = null;
+    }
+  }
+  function scheduleRouteRefusalRetry() {
+    if (closed || routeRefusalRetryTimer) return;
+    if (routeRefusalRetries >= ROUTE_REFUSAL_RETRY_MAX) return;
+    routeRefusalRetryTimer = setTimeout(() => {
+      routeRefusalRetryTimer = null;
+      routeRefusalRetries += 1;
+      // sendHello re-runs the identity resolve, which is itself retryable past
+      // its backoff (#654) — so this is a genuine fresh attempt, not a replay
+      // of the cached failure.
+      void sendHello();
+    }, ROUTE_REFUSAL_RETRY_MS);
+  }
   function emitStatus(s) {
     if (s === lastStatus && s !== "connected") return;
     lastStatus = s;
@@ -13568,6 +13786,11 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
     thisSock.addEventListener("open", () => {
       if (!isActive()) return; // superseded socket — ignore its late open
       handshakeDone = false;
+      // #654 — a fresh socket is a fresh registration attempt: replenish the
+      // refused-hello retry budget and drop any retry still pending from the
+      // previous socket (its sendHello below is that attempt).
+      routeRefusalRetries = 0;
+      clearRouteRefusalRetry();
       // #369: a new orchestrator socket is a (re)connect / session-resume boundary.
       // Bump the session generation so the manual-change tracker discards any
       // baseline captured before this boundary instead of diffing it against a
@@ -13993,6 +14216,25 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             if (msg.cmd.startsWith("graph_") && !commandIsCanvasIndependent(msg.cmd)) {
               const { graph, rootGraph } = getGraphCtx();
               assertGraphBoundToActiveWorkflow(graph, rootGraph, graphCommandBindingBar(msg.cmd));
+              // #646 — the post-reconnect MUTATION gate. A graph mutation that
+              // arrives while ComfyUI's backend socket is down, or inside the
+              // settle window before the restored canvas binding has been
+              // re-proven, can land on a canvas the restore is about to rebuild
+              // (applied-then-wiped) or die with the socket mid-command
+              // (OUTCOME UNKNOWN). Reads are exempt — they stay available on
+              // their own evidence bars; the gate refuses BEFORE the executor,
+              // so its "NOT applied" claim is true and the retry is safe. The
+              // settle watch (#663) closes the binding window as soon as the
+              // binding observably re-proves, so the healthy case waits ~1s,
+              // not the full 30s.
+              if (graphCommandMayMutateWorkflow(msg.cmd)) {
+                const reconnectGate = graphMutationReconnectGate({
+                  cmd: msg.cmd,
+                  backendDown: comfyBackendSocketDown,
+                  bindingSettleWindow: postReconnectBindingSettleWindow(),
+                });
+                if (reconnectGate) throw new Error(reconnectGate);
+              }
             }
             // PINNED-TARGET GUARD (#349): a `workflow_path` on the command means the
             // agent's session is pinned to a SPECIFIC workflow. But every executor
@@ -14287,6 +14529,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
       if (!isActive()) return;
       sock = null;
       handshakeDone = false;
+      // #654 — a pending refused-hello retry belongs to the dead socket; the
+      // reconnect loop's next open-hello takes over (and resets the budget).
+      clearRouteRefusalRetry();
       // Fail any in-flight direct tool calls — the reply can never arrive now.
       for (const [, pend] of pendingCalls) {
         clearTimeout(pend.timer);
@@ -14351,6 +14596,9 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           routeRefusalDisclosed = true;
           onLog?.(describeRefusedRoute({ settled: tabRouteIdentity.settled() }));
         }
+        // #654 — and TRY AGAIN: the lease can free up while this socket stays
+        // open. Bounded; a landed hello or a fresh socket resets the budget.
+        scheduleRouteRefusalRetry();
         return null;
       }
       // Carry the last session id so the orchestrator resumes the agent's
@@ -14421,6 +14669,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
           // Published only now, for the same reason the epoch advances only now:
           // a hello that never reached the wire advertised nothing.
           lastAdvertisedWorkflowUuid = advertisedWorkflowUuid;
+          // #654 — registration succeeded: the refused-hello retry budget is
+          // replenished and any pending retry is moot.
+          routeRefusalRetries = 0;
+          clearRouteRefusalRetry();
         }
         return sent === true;
       })

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -12575,8 +12575,19 @@ const GRAPH_TOOL_EXECUTORS = {
       // than fabricate one; the note below already discloses the uncertainty.
       viewing = null;
     }
+    // The reply must describe the canvas as it is NOW, not as the receipt left
+    // it: this post-receipt read is a fresh terminal observation (codex gate
+    // r8). A canvas no longer on the target gets the displacement disclosure,
+    // never settled:true / "in effect" for a scope it has already left.
+    const stillOnTarget = (() => {
+      try {
+        return comfyApp?.canvas?.graph === sub;
+      } catch {
+        return false;
+      }
+    })();
     if (!receipt.bound) {
-      if (!receipt.landed) {
+      if (!receipt.landed || !stillOnTarget) {
         // The canvas WAS observed inside the subgraph, then moved elsewhere
         // before the binding settled — the navigation happened, so this is a
         // disclosure, never a "nothing was applied" refusal.
@@ -12601,6 +12612,18 @@ const GRAPH_TOOL_EXECUTORS = {
             receipt.lastError?.message ?? receipt.lastError ?? "unknown",
           )}). A graph read issued this instant may still refuse while the tracker catches up — ` +
           `retry the read in a moment.`,
+      };
+    }
+    if (!stillOnTarget) {
+      return {
+        entered: node.id,
+        ...(viewing ? { viewing } : {}),
+        settled: false,
+        note:
+          `The canvas DID enter the subgraph and the binding check passed, but the view has ` +
+          `already moved elsewhere (a user navigation, a tab restore, or the panel's own canvas ` +
+          `reconcile). Re-read the current scope (panel_graph_outline) before editing, and ` +
+          `re-enter the subgraph if that is still where you mean to work.`,
       };
     }
     return { entered: node.id, viewing, settled: true };
@@ -12656,8 +12679,18 @@ const GRAPH_TOOL_EXECUTORS = {
       // than fabricate one; the note below already discloses the uncertainty.
       viewing = null;
     }
+    // Same fresh terminal observation as graph_enter_subgraph (codex gate r8):
+    // a canvas no longer on the parent gets the displacement disclosure, never
+    // settled:true / "in effect" for a scope it has already left.
+    const stillOnTarget = (() => {
+      try {
+        return comfyApp?.canvas?.graph === parentGraph;
+      } catch {
+        return false;
+      }
+    })();
     if (!receipt.bound) {
-      if (!receipt.landed) {
+      if (!receipt.landed || !stillOnTarget) {
         // The canvas WAS observed back at the parent, then moved elsewhere
         // before the binding settled — the navigation happened, so this is a
         // disclosure, never a "nothing was applied" refusal.
@@ -12680,6 +12713,16 @@ const GRAPH_TOOL_EXECUTORS = {
             receipt.lastError?.message ?? receipt.lastError ?? "unknown",
           )}). A graph read issued this instant may still refuse while the tracker catches up — ` +
           `retry the read in a moment.`,
+      };
+    }
+    if (!stillOnTarget) {
+      return {
+        ...(viewing ? { viewing } : {}),
+        settled: false,
+        note:
+          `The canvas DID return to the parent graph and the binding check passed, but the view ` +
+          `has already moved elsewhere (a user navigation, a tab restore, or the panel's own ` +
+          `canvas reconcile). Re-read the current scope (panel_graph_outline) before editing.`,
       };
     }
     return { viewing, settled: true };

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -14294,19 +14294,20 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // fence at all: requiring a binding proof for it only false-blocks a
             // server-side operation when the canvas binding is broken.
             if (msg.cmd.startsWith("graph_") && !commandIsCanvasIndependent(msg.cmd)) {
-              const { graph, rootGraph } = getGraphCtx();
-              assertGraphBoundToActiveWorkflow(graph, rootGraph, graphCommandBindingBar(msg.cmd));
               // #646 — the post-reconnect MUTATION gate. A graph mutation that
               // arrives while ComfyUI's backend socket is down, or inside the
               // settle window before the restored canvas binding has been
               // re-proven, can land on a canvas the restore is about to rebuild
               // (applied-then-wiped) or die with the socket mid-command
               // (OUTCOME UNKNOWN). Reads are exempt — they stay available on
-              // their own evidence bars; the gate refuses BEFORE the executor,
-              // so its "NOT applied" claim is true and the retry is safe. The
-              // settle watch (#663) closes the binding window as soon as the
-              // binding observably re-proves, so the healthy case waits ~1s,
-              // not the full 30s.
+              // their own evidence bars. The gate runs BEFORE getGraphCtx and
+              // the binding assert: those probes can themselves change the
+              // canvas (the verified content-free rebind heal), which would
+              // falsify this refusal's "nothing changed" claim (codex gate r6),
+              // and it refuses BEFORE the executor, so "NOT applied" is true
+              // and the retry is safe. The settle watch (#663) closes the
+              // binding window as soon as the binding observably re-proves, so
+              // the healthy case waits ~1s, not the full 30s.
               if (graphCommandMayMutateWorkflow(msg.cmd)) {
                 const reconnectGate = graphMutationReconnectGate({
                   cmd: msg.cmd,
@@ -14315,6 +14316,8 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
                 });
                 if (reconnectGate) throw new Error(reconnectGate);
               }
+              const { graph, rootGraph } = getGraphCtx();
+              assertGraphBoundToActiveWorkflow(graph, rootGraph, graphCommandBindingBar(msg.cmd));
             }
             // PINNED-TARGET GUARD (#349): a `workflow_path` on the command means the
             // agent's session is pinned to a SPECIFIC workflow. But every executor

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -7007,23 +7007,25 @@ function captureGraphMutationContext() {
 }
 
 function revalidateGraphMutationContext(captured) {
-  const current = { ...getGraphCtx(), workflow: activeWorkflowRef() };
-  if (!sameGraphMutationContext(captured, current, sameWorkflowObject)) {
-    throw new Error(
-      "The active workflow or graph view changed while this node was preparing; nothing was added. Retry on the intended tab.",
-    );
-  }
   // #646: the dispatch-time gate can go stale DURING an async preflight — a
   // backend reconnect that starts while /object_info is being awaited would let
-  // the write below land on a canvas the restore is about to rebuild. Re-check
-  // the same gate at the write boundary; nothing has been written yet, so its
-  // "NOT applied" claim stays true here.
+  // the write below land on a canvas the restore is about to rebuild. The gate
+  // runs FIRST, before getGraphCtx and the context comparison: those probes can
+  // themselves change the canvas (the verified rebind heal), which would falsify
+  // the refusal's "NOT applied — nothing changed" claim (codex gate r6/r7).
+  // Nothing has been written to the graph yet, so the claim is true here.
   const reconnectGate = graphMutationReconnectGate({
     cmd: "graph_add_node",
     backendDown: comfyBackendSocketDown,
     bindingSettleWindow: postReconnectBindingSettleWindow(),
   });
   if (reconnectGate) throw new Error(reconnectGate);
+  const current = { ...getGraphCtx(), workflow: activeWorkflowRef() };
+  if (!sameGraphMutationContext(captured, current, sameWorkflowObject)) {
+    throw new Error(
+      "The active workflow or graph view changed while this node was preparing; nothing was added. Retry on the intended tab.",
+    );
+  }
   assertGraphBoundToActiveWorkflow(current.graph, current.rootGraph, {
     ...MUTATION_BINDING_BAR,
   });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -654,13 +654,14 @@ async function registerComfyNodeDefs(preloadedDefs) {
   // actually failed instead of being bucketed as a generic failure.
   let appAvailable = false;
   let defs = preloadedDefs ?? null;
+  let defsRegistered = false;
   let comboApiPresent = false;
   let comboRan = false;
   let phase = "fetch";
   let thrown = null;
   try {
     const a = typeof app !== "undefined" && app ? app : window.comfyAPI?.app?.app;
-    if (!a) return describeNodeDefRefresh({ appAvailable: false, defsObtained: false, comboApiPresent: false, comboRan: false });
+    if (!a) return describeNodeDefRefresh({ appAvailable: false, defsObtained: false, defsRegistered: false, comboApiPresent: false, comboRan: false });
     appAvailable = true;
     // Obtain an AUTHORITATIVE /object_info payload up front (preloaded, or a fresh
     // getNodeDefs) — this is the OBSERVABLE proof of a real server fetch that gates
@@ -686,9 +687,12 @@ async function registerComfyNodeDefs(preloadedDefs) {
     phase = "register";
     recordObjectInfoTypes(defs);
     // Re-register node definitions so newly installed/updated classes and their
-    // current widget schemas are known to LiteGraph (#221/#171).
+    // current widget schemas are known to LiteGraph (#221/#171). defsRegistered
+    // is set ONLY when the registration call actually ran — a frontend without
+    // registerNodesFromDefs must not let the verdict claim it (codex gate r2 P1).
     if (defs && typeof a.registerNodesFromDefs === "function") {
       await a.registerNodesFromDefs(defs);
+      defsRegistered = true;
     }
     // registerNodesFromDefs mints NEW classes; already-loaded node INSTANCES keep
     // their old constructor and would never see the fresh schema. Stamp the fresh
@@ -726,7 +730,7 @@ async function registerComfyNodeDefs(preloadedDefs) {
   // coalescer forwards this through a forced trailing run, so get_errors' awaited
   // `force:true` refresh resolves to the freshness verdict of the fetch IT triggered
   // (codex round-6 P0).
-  return describeNodeDefRefresh({ appAvailable, defsObtained: !!defs, comboApiPresent, comboRan, phase, thrown });
+  return describeNodeDefRefresh({ appAvailable, defsObtained: !!defs, defsRegistered, comboApiPresent, comboRan, phase, thrown });
 }
 
 // Single-flight refresh that never drops a caller-supplied fresh payload (#289 P2).
@@ -12564,8 +12568,8 @@ const GRAPH_TOOL_EXECUTORS = {
           settled: false,
           note:
             `The canvas DID enter the subgraph, but it has since navigated away before the panel ` +
-            `could confirm the binding — something else moved the view (a user navigation or a ` +
-            `tab restore). Re-read the current scope (panel_graph_outline) before editing, and ` +
+            `could confirm the binding — the view moved again first (a user navigation, a ` +
+            `tab restore, or the panel's own canvas reconcile). Re-read the current scope (panel_graph_outline) before editing, and ` +
             `re-enter the subgraph if that is still where you mean to work.`,
         };
       }
@@ -12638,8 +12642,8 @@ const GRAPH_TOOL_EXECUTORS = {
           settled: false,
           note:
             `The canvas DID return to the parent graph, but it has since navigated away before ` +
-            `the panel could confirm the binding — something else moved the view (a user ` +
-            `navigation or a tab restore). Re-read the current scope (panel_graph_outline) ` +
+            `the panel could confirm the binding — the view moved again first (a user ` +
+            `navigation, a tab restore, or the panel's own canvas reconcile). Re-read the current scope (panel_graph_outline) ` +
             `before editing.`,
         };
       }

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -683,13 +683,15 @@ async function registerComfyNodeDefs(preloadedDefs) {
     // let a provenance-stripped husk squatting a reserved allowlisted name through the
     // frontend-only exemption. ONLY seedObjectInfoHistory() — the STARTUP baseline, whose
     // observation window begins at page load — may call markObjectInfoHistorySeeded().
-    // (A throw here is attributed to "register": the fetch itself already succeeded.)
-    phase = "register";
+    // (A throw here is attributed to "record": the fetch itself already succeeded,
+    // and registration has not been attempted yet — the verdict must not claim it.)
+    phase = "record";
     recordObjectInfoTypes(defs);
     // Re-register node definitions so newly installed/updated classes and their
     // current widget schemas are known to LiteGraph (#221/#171). defsRegistered
     // is set ONLY when the registration call actually ran — a frontend without
     // registerNodesFromDefs must not let the verdict claim it (codex gate r2 P1).
+    phase = "register";
     if (defs && typeof a.registerNodesFromDefs === "function") {
       await a.registerNodesFromDefs(defs);
       defsRegistered = true;
@@ -697,6 +699,7 @@ async function registerComfyNodeDefs(preloadedDefs) {
     // registerNodesFromDefs mints NEW classes; already-loaded node INSTANCES keep
     // their old constructor and would never see the fresh schema. Stamp the fresh
     // def onto existing instances + repair UNKNOWN widgets (finding #3).
+    phase = "reapply";
     if (defs) {
       const rootGraph = a.graph ?? a.canvas?.graph;
       if (rootGraph) reapplyDefsToLiveNodes(rootGraph, defs);

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -6999,6 +6999,17 @@ function revalidateGraphMutationContext(captured) {
       "The active workflow or graph view changed while this node was preparing; nothing was added. Retry on the intended tab.",
     );
   }
+  // #646: the dispatch-time gate can go stale DURING an async preflight — a
+  // backend reconnect that starts while /object_info is being awaited would let
+  // the write below land on a canvas the restore is about to rebuild. Re-check
+  // the same gate at the write boundary; nothing has been written yet, so its
+  // "NOT applied" claim stays true here.
+  const reconnectGate = graphMutationReconnectGate({
+    cmd: "graph_add_node",
+    backendDown: comfyBackendSocketDown,
+    bindingSettleWindow: postReconnectBindingSettleWindow(),
+  });
+  if (reconnectGate) throw new Error(reconnectGate);
   assertGraphBoundToActiveWorkflow(current.graph, current.rootGraph, {
     ...MUTATION_BINDING_BAR,
   });

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -12582,7 +12582,11 @@ const GRAPH_TOOL_EXECUTORS = {
     // disclosure, not the displacement one.
     const terminalState = (() => {
       try {
-        return comfyApp?.canvas?.graph === sub ? "target" : "elsewhere";
+        const g = comfyApp?.canvas?.graph;
+        // A MISSING canvas/graph is unreadable, not displacement evidence
+        // (codex gate r10): null/undefined proves nothing about where the view is.
+        if (g == null) return "unreadable";
+        return g === sub ? "target" : "elsewhere";
       } catch {
         return "unreadable";
       }
@@ -12697,7 +12701,11 @@ const GRAPH_TOOL_EXECUTORS = {
     // not the displacement one.
     const terminalState = (() => {
       try {
-        return comfyApp?.canvas?.graph === parentGraph ? "target" : "elsewhere";
+        const g = comfyApp?.canvas?.graph;
+        // A MISSING canvas/graph is unreadable, not displacement evidence
+        // (codex gate r10): null/undefined proves nothing about where the view is.
+        if (g == null) return "unreadable";
+        return g === parentGraph ? "target" : "elsewhere";
       } catch {
         return "unreadable";
       }

--- a/web/js/lib/canvas-navigation.js
+++ b/web/js/lib/canvas-navigation.js
@@ -1,0 +1,65 @@
+// #619 — the post-navigation RECEIPT for canvas scope changes.
+//
+// graph_enter_subgraph used to fire canvas.openSubgraph(sub, node) and immediately
+// report success. openSubgraph is not a receipt: the canvas can land on the target
+// a beat later (or, on a struggling frontend, not observably at all), and the
+// workflow tracker can still be mid-capture right after the view moved — so the
+// IMMEDIATELY following graph read evaluated the root-shape guard against a
+// scope/binding that had not settled and refused with [root-shape-mismatch] on a
+// perfectly valid navigation. A bare call also meant a silent no-op navigation
+// reported `entered` for a canvas that never moved.
+//
+// This helper establishes the receipt: poll (bounded) until the canvas observably
+// shows the navigation target AND the caller-supplied binding assert passes, then
+// report which of the two held. The caller decides refuse-vs-disclose:
+//   - landed === false  → the navigation did NOT take effect: refuse (nothing was
+//     applied, the retry is safe).
+//   - landed === true, bound === false → the navigation DID happen: disclose —
+//     never report failure for an act that succeeded (that invites a destructive
+//     retry), report the settle state instead.
+//
+// Pure-ish: the canvas read, the assert, and the clock are all injected, so the
+// poll loop is unit-testable without a browser.
+
+/**
+ * @param {{
+ *   readCanvasGraph: () => any,   // current canvas graph (may throw → not landed)
+ *   target: any,                  // the graph object the navigation aimed at
+ *   assertBound: () => void,      // throws while the binding/scope has not settled
+ *   tries?: number,               // poll attempts (default 25)
+ *   intervalMs?: number,          // delay between attempts (default 40ms ⇒ ~1s budget)
+ *   sleep?: (ms: number) => Promise<void>,
+ * }} o
+ * @returns {Promise<{ landed: boolean, bound: boolean, lastError: any }>}
+ *   landed: the canvas observably showed `target` on the LAST poll.
+ *   bound:  landed AND assertBound passed (lastError is null in that case).
+ *   lastError: the most recent assertBound rejection reason, for disclosure.
+ */
+export async function confirmCanvasNavigation({
+  readCanvasGraph,
+  target,
+  assertBound,
+  tries = 25,
+  intervalMs = 40,
+  sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+} = {}) {
+  let landed = false;
+  let lastError = null;
+  for (let attempt = 0; attempt < tries; attempt += 1) {
+    try {
+      landed = readCanvasGraph() === target;
+    } catch {
+      landed = false;
+    }
+    if (landed) {
+      try {
+        assertBound();
+        return { landed: true, bound: true, lastError: null };
+      } catch (e) {
+        lastError = e;
+      }
+    }
+    if (attempt + 1 < tries) await sleep(intervalMs);
+  }
+  return { landed, bound: false, lastError };
+}

--- a/web/js/lib/canvas-navigation.js
+++ b/web/js/lib/canvas-navigation.js
@@ -62,17 +62,24 @@ export async function confirmCanvasNavigation({
     }
     if (landed) {
       everLanded = true;
+      let probePassed = false;
       try {
         assertBound();
-        // The probe can itself MOVE the canvas — getGraphCtx's verified rebind
-        // heal repaints a provably content-free ghost to root — so a landing
-        // only counts as settled if the canvas is STILL on the target after
-        // the probe (codex gate r2 P1). Otherwise keep polling: it may re-land.
-        if (readCanvasGraph() === target) {
-          return { landed: true, everLanded: true, bound: true, lastError: null };
-        }
+        probePassed = true;
       } catch (e) {
         lastError = e;
+      }
+      // Re-read after EVERY probe, pass or throw: the probe can MOVE the canvas
+      // (getGraphCtx's verified rebind heal repaints a provably content-free
+      // ghost to root) on either outcome, and the terminal verdict must
+      // describe the LAST observation, not the pre-probe one (codex r2/r3).
+      try {
+        landed = readCanvasGraph() === target;
+      } catch {
+        landed = false;
+      }
+      if (probePassed && landed) {
+        return { landed: true, everLanded: true, bound: true, lastError: null };
       }
     }
     if (attempt + 1 < tries) await sleep(intervalMs);

--- a/web/js/lib/canvas-navigation.js
+++ b/web/js/lib/canvas-navigation.js
@@ -64,7 +64,13 @@ export async function confirmCanvasNavigation({
       everLanded = true;
       try {
         assertBound();
-        return { landed: true, everLanded: true, bound: true, lastError: null };
+        // The probe can itself MOVE the canvas — getGraphCtx's verified rebind
+        // heal repaints a provably content-free ghost to root — so a landing
+        // only counts as settled if the canvas is STILL on the target after
+        // the probe (codex gate r2 P1). Otherwise keep polling: it may re-land.
+        if (readCanvasGraph() === target) {
+          return { landed: true, everLanded: true, bound: true, lastError: null };
+        }
       } catch (e) {
         lastError = e;
       }

--- a/web/js/lib/canvas-navigation.js
+++ b/web/js/lib/canvas-navigation.js
@@ -12,11 +12,15 @@
 // This helper establishes the receipt: poll (bounded) until the canvas observably
 // shows the navigation target AND the caller-supplied binding assert passes, then
 // report which of the two held. The caller decides refuse-vs-disclose:
-//   - landed === false  → the navigation did NOT take effect: refuse (nothing was
-//     applied, the retry is safe).
+//   - never landed (everLanded === false) → the navigation did NOT take effect:
+//     refuse (nothing was applied, the retry is safe).
 //   - landed === true, bound === false → the navigation DID happen: disclose —
 //     never report failure for an act that succeeded (that invites a destructive
 //     retry), report the settle state instead.
+//   - everLanded === true but landed === false → the navigation happened and the
+//     canvas has SINCE moved elsewhere (a user navigation, a tab restore):
+//     disclose that too — claiming "nothing was applied" after an observed
+//     landing is the same lie one poll later (codex gate).
 //
 // Pure-ish: the canvas read, the assert, and the clock are all injected, so the
 // poll loop is unit-testable without a browser.
@@ -30,10 +34,14 @@
  *   intervalMs?: number,          // delay between attempts (default 40ms ⇒ ~1s budget)
  *   sleep?: (ms: number) => Promise<void>,
  * }} o
- * @returns {Promise<{ landed: boolean, bound: boolean, lastError: any }>}
- *   landed: the canvas observably showed `target` on the LAST poll.
- *   bound:  landed AND assertBound passed (lastError is null in that case).
- *   lastError: the most recent assertBound rejection reason, for disclosure.
+ * @returns {Promise<{ landed: boolean, everLanded: boolean, bound: boolean, lastError: any }>}
+ *   landed:     the canvas observably showed `target` on the LAST poll.
+ *   everLanded: the canvas showed `target` on ANY poll. Once observed, the
+ *               navigation DID happen — even if the canvas has since moved
+ *               elsewhere — so the caller must DISCLOSE, never claim "nothing
+ *               was applied" (a false refusal invites a redundant retry).
+ *   bound:      landed AND assertBound passed (lastError is null in that case).
+ *   lastError:  the most recent assertBound rejection reason, for disclosure.
  */
 export async function confirmCanvasNavigation({
   readCanvasGraph,
@@ -44,6 +52,7 @@ export async function confirmCanvasNavigation({
   sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
 } = {}) {
   let landed = false;
+  let everLanded = false;
   let lastError = null;
   for (let attempt = 0; attempt < tries; attempt += 1) {
     try {
@@ -52,14 +61,15 @@ export async function confirmCanvasNavigation({
       landed = false;
     }
     if (landed) {
+      everLanded = true;
       try {
         assertBound();
-        return { landed: true, bound: true, lastError: null };
+        return { landed: true, everLanded: true, bound: true, lastError: null };
       } catch (e) {
         lastError = e;
       }
     }
     if (attempt + 1 < tries) await sleep(intervalMs);
   }
-  return { landed, bound: false, lastError };
+  return { landed, everLanded, bound: false, lastError };
 }

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -1096,7 +1096,13 @@ export function graphBindingRefusalMessage(verdict) {
     `Re-open the active workflow tab (panel_open_workflow) to rebind the graph in place; if that ` +
     `does not clear it, reload the panel (panel_reload scope:frontend), then retry. The reload is ` +
     `REQUESTED, NOT CONFIRMED — the panel cannot observe whether it rebound the canvas, so treat ` +
-    `the retry's own result as the answer rather than assuming the binding was repaired.`;
+    `the retry's own result as the answer rather than assuming the binding was repaired. ` +
+    // #663 — agents burned retries on the WRONG recovery signal: panel_set_workflow_target
+    // only re-points which workflow the agent session follows; it never touches the
+    // canvas binding this guard checks, so its success response does not mean the
+    // desync is resolved. Say so, so the retry budget goes to the remedies that can work.
+    `Re-targeting with panel_set_workflow_target is NOT a remedy for this — it re-points the ` +
+    `session, it does not rebind the canvas.`;
   if (verdict.reason === "root-workflow-uuid-mismatch") {
     return (
       `[root-workflow-uuid-mismatch] The live canvas carries a different workflow's identity tag ` +

--- a/web/js/lib/node-def-refresh.js
+++ b/web/js/lib/node-def-refresh.js
@@ -42,6 +42,8 @@ function detailSuffix(thrown) {
  *   comboApiPresent: boolean,  // app.refreshComboInNodes exists on this build
  *   comboRan: boolean,         // refreshComboInNodes completed this run
  *   phase?: string,            // "fetch" | "record" | "register" | "reapply" | "combo" | "done" — where a throw happened
+ *   didThrow?: boolean,        // a throw happened at all — tracked independently of
+ *                              // the caught VALUE, which can be falsy (throw null)
  *   thrown?: any,              // the error a phase threw, if any
  * }} o
  * @returns {{ refreshed: boolean, reason: string, remedy?: string, detail?: string }}
@@ -53,8 +55,11 @@ export function describeNodeDefRefresh({
   comboApiPresent,
   comboRan,
   phase = "done",
+  didThrow,
   thrown = null,
 } = {}) {
+  // Backstop for a caller that predates didThrow: a truthy caught value implies it.
+  const failed = didThrow === true || !!thrown;
   // The registration clause the combo-failure remedies are allowed to make:
   // "WERE re-registered" only when the registration call observably ran.
   const registrationClause = defsRegistered
@@ -72,7 +77,7 @@ export function describeNodeDefRefresh({
         "refreshed. Reload the ComfyUI tab, then retry.",
     };
   }
-  if (thrown) {
+  if (failed) {
     const reason =
       phase === "fetch"
         ? NODE_DEF_REFRESH_REASONS.OBJECT_INFO_FETCH_FAILED

--- a/web/js/lib/node-def-refresh.js
+++ b/web/js/lib/node-def-refresh.js
@@ -20,6 +20,7 @@ export const NODE_DEF_REFRESH_REASONS = Object.freeze({
   OBJECT_INFO_UNAVAILABLE: "object_info_unavailable",
   OBJECT_INFO_FETCH_FAILED: "object_info_fetch_failed",
   REGISTER_FAILED: "register_failed",
+  REGISTER_API_ABSENT: "register_api_absent",
   COMBO_API_ABSENT: "combo_api_absent",
   COMBO_REFRESH_FAILED: "combo_refresh_failed",
 });
@@ -103,17 +104,32 @@ export function describeNodeDefRefresh({
         "ComfyUI tab.",
     };
   }
+  if (!defsRegistered) {
+    // Registration never RAN (a frontend without registerNodesFromDefs) — the
+    // whole point of the tool for a pack install is defeated, so this is its own
+    // reason, never a silent refreshed:true (codex gate r3). Combos may still
+    // have refreshed; say so when they did.
+    return {
+      refreshed: false,
+      reason: NODE_DEF_REFRESH_REASONS.REGISTER_API_ABSENT,
+      remedy:
+        "A fresh /object_info was fetched, but this frontend exposes no registerNodesFromDefs, " +
+        "so the new/updated node definitions were NOT registered in place." +
+        (comboRan ? " The combo dropdown lists WERE refreshed from it." : "") +
+        " Reload the ComfyUI tab so the frontend picks up the new definitions; if they are " +
+        "still missing after a reload, this frontend build predates the registration API and " +
+        "ComfyUI needs an update.",
+    };
+  }
   if (!comboApiPresent) {
     return {
       refreshed: false,
       reason: NODE_DEF_REFRESH_REASONS.COMBO_API_ABSENT,
       remedy:
         "This ComfyUI frontend build has no refreshComboInNodes API, so combo lists cannot be " +
-        `rebuilt in place. ${registrationClause}` +
-        (defsRegistered
-          ? " — only the combo dropdowns may be stale, and those refresh on a tab reload (reload " +
-            "the ComfyUI page or press R in it)."
-          : ". Reload the ComfyUI tab so both rebuild."),
+        "rebuilt in place. Node definitions WERE re-registered from a fresh /object_info — only " +
+        "the combo dropdowns may be stale, and those refresh on a tab reload (reload the ComfyUI " +
+        "page or press R in it).",
     };
   }
   if (!comboRan) {

--- a/web/js/lib/node-def-refresh.js
+++ b/web/js/lib/node-def-refresh.js
@@ -26,7 +26,7 @@ export const NODE_DEF_REFRESH_REASONS = Object.freeze({
 
 function detailSuffix(thrown) {
   const text = String(thrown?.message ?? thrown ?? "").trim();
-  return text ? ` (${text})` : "";
+  return text ? `(${text})` : "";
 }
 
 /**

--- a/web/js/lib/node-def-refresh.js
+++ b/web/js/lib/node-def-refresh.js
@@ -41,7 +41,7 @@ function detailSuffix(thrown) {
  *                              // remedy claim registration happened (codex r2 P1)
  *   comboApiPresent: boolean,  // app.refreshComboInNodes exists on this build
  *   comboRan: boolean,         // refreshComboInNodes completed this run
- *   phase?: string,            // "fetch" | "register" | "combo" | "done" — where a throw happened
+ *   phase?: string,            // "fetch" | "record" | "register" | "reapply" | "combo" | "done" — where a throw happened
  *   thrown?: any,              // the error a phase threw, if any
  * }} o
  * @returns {{ refreshed: boolean, reason: string, remedy?: string, detail?: string }}
@@ -79,6 +79,20 @@ export function describeNodeDefRefresh({
         : phase === "combo"
           ? NODE_DEF_REFRESH_REASONS.COMBO_REFRESH_FAILED
           : NODE_DEF_REFRESH_REASONS.REGISTER_FAILED;
+    // The register_failed remedy must describe what ACTUALLY threw (codex r3/r4):
+    // "register" is the registerNodesFromDefs call itself, "reapply" runs after
+    // registration succeeded, and "record" fails BEFORE registration was ever
+    // attempted — claiming a registration attempt in the last case is a lie.
+    const registerRemedy =
+      phase === "reapply"
+        ? `${registrationClause}, but applying the fresh definitions to the live canvas ` +
+          "nodes failed, so the refresh is NOT confirmed. Reload the ComfyUI tab, then retry."
+        : phase === "record"
+          ? "A fresh /object_info was obtained, but the refresh failed while recording it, " +
+            "BEFORE registration was attempted, so nothing was refreshed. Retry; if it " +
+            "persists, reload the ComfyUI tab."
+          : "A fresh /object_info was obtained but re-registering the node definitions failed, " +
+            "so the refresh is NOT confirmed. Reload the ComfyUI tab, then retry.";
     const remedy =
       reason === NODE_DEF_REFRESH_REASONS.OBJECT_INFO_FETCH_FAILED
         ? "The /object_info fetch failed, so nothing was refreshed. The backend may still be " +
@@ -89,8 +103,7 @@ export function describeNodeDefRefresh({
             "combo lists failed, so dropdown options may still be stale. Retry; if it keeps " +
             "failing, reload the ComfyUI tab to rebuild the combo lists." +
             registrationRemedy
-          : "A fresh /object_info was obtained but re-registering the node definitions failed, " +
-            "so the refresh is NOT confirmed. Reload the ComfyUI tab, then retry.";
+          : registerRemedy;
     return { refreshed: false, reason, detail: detailSuffix(thrown) || undefined, remedy };
   }
   if (!defsObtained) {

--- a/web/js/lib/node-def-refresh.js
+++ b/web/js/lib/node-def-refresh.js
@@ -1,0 +1,118 @@
+// #635 — the node-def refresh VERDICT, with the cause when it is not fresh.
+//
+// registerComfyNodeDefs used to answer a bare boolean: {ok:true, refreshed:false}
+// gave the caller no way to tell "the backend did not serve /object_info" from
+// "this frontend build has no combo-refresh API" from "the fetch threw" — every
+// failure read as the same no-op, so the agent could neither act nor explain.
+// This module turns the observed evidence into a verdict with a stable `reason`
+// token and a `remedy` that is actionable from the caller's current state.
+//
+// The verdict describes THIS run only. It is deliberately NOT derived from (and
+// never written into) the shared nodeDefsRefreshConfirmed global: a concurrent
+// refresh can overwrite that global mid-await (codex round-6 P0 on the get_errors
+// path), so each caller must read the verdict of the run it triggered.
+//
+// Pure: every input is observed by the caller and passed in.
+
+/** Stable reason tokens for a node-def refresh that is NOT confirmed fresh. */
+export const NODE_DEF_REFRESH_REASONS = Object.freeze({
+  APP_UNAVAILABLE: "app_unavailable",
+  OBJECT_INFO_UNAVAILABLE: "object_info_unavailable",
+  OBJECT_INFO_FETCH_FAILED: "object_info_fetch_failed",
+  REGISTER_FAILED: "register_failed",
+  COMBO_API_ABSENT: "combo_api_absent",
+  COMBO_REFRESH_FAILED: "combo_refresh_failed",
+});
+
+function detailSuffix(thrown) {
+  const text = String(thrown?.message ?? thrown ?? "").trim();
+  return text ? ` (${text})` : "";
+}
+
+/**
+ * Build the verdict for one registerComfyNodeDefs run.
+ *
+ * @param {{
+ *   appAvailable: boolean,     // the ComfyUI frontend app object was reachable
+ *   defsObtained: boolean,     // an /object_info payload was actually obtained
+ *   comboApiPresent: boolean,  // app.refreshComboInNodes exists on this build
+ *   comboRan: boolean,         // refreshComboInNodes completed this run
+ *   phase?: string,            // "fetch" | "register" | "combo" | "done" — where a throw happened
+ *   thrown?: any,              // the error a phase threw, if any
+ * }} o
+ * @returns {{ refreshed: boolean, reason: string, remedy?: string, detail?: string }}
+ */
+export function describeNodeDefRefresh({
+  appAvailable,
+  defsObtained,
+  comboApiPresent,
+  comboRan,
+  phase = "done",
+  thrown = null,
+} = {}) {
+  if (!appAvailable) {
+    return {
+      refreshed: false,
+      reason: NODE_DEF_REFRESH_REASONS.APP_UNAVAILABLE,
+      remedy:
+        "The ComfyUI frontend app object is not available in this browser tab, so nothing was " +
+        "refreshed. Reload the ComfyUI tab, then retry.",
+    };
+  }
+  if (thrown) {
+    const reason =
+      phase === "fetch"
+        ? NODE_DEF_REFRESH_REASONS.OBJECT_INFO_FETCH_FAILED
+        : phase === "combo"
+          ? NODE_DEF_REFRESH_REASONS.COMBO_REFRESH_FAILED
+          : NODE_DEF_REFRESH_REASONS.REGISTER_FAILED;
+    const remedy =
+      reason === NODE_DEF_REFRESH_REASONS.OBJECT_INFO_FETCH_FAILED
+        ? "The /object_info fetch failed, so nothing was refreshed. The backend may still be " +
+          "restarting — retry once it answers, and if it never does, check that the ComfyUI " +
+          "server process is still running."
+        : reason === NODE_DEF_REFRESH_REASONS.COMBO_REFRESH_FAILED
+          ? "Node definitions WERE re-registered from a fresh /object_info, but refreshing the " +
+            "combo lists failed, so dropdown options may still be stale. Retry; if it keeps " +
+            "failing, reload the ComfyUI tab to rebuild the combo lists."
+          : "A fresh /object_info was obtained but re-registering the node definitions failed, " +
+            "so the refresh is NOT confirmed. Reload the ComfyUI tab, then retry.";
+    return { refreshed: false, reason, detail: detailSuffix(thrown) || undefined, remedy };
+  }
+  if (!defsObtained) {
+    return {
+      refreshed: false,
+      reason: NODE_DEF_REFRESH_REASONS.OBJECT_INFO_UNAVAILABLE,
+      remedy:
+        "The panel could not obtain /object_info from the ComfyUI backend (this frontend exposes " +
+        "no getNodeDefs, or it returned nothing), so node definitions and combo lists were NOT " +
+        "refreshed. If the backend is mid-restart, retry once it is up; otherwise reload the " +
+        "ComfyUI tab.",
+    };
+  }
+  if (!comboApiPresent) {
+    return {
+      refreshed: false,
+      reason: NODE_DEF_REFRESH_REASONS.COMBO_API_ABSENT,
+      remedy:
+        "This ComfyUI frontend build has no refreshComboInNodes API, so combo lists cannot be " +
+        "rebuilt in place. Node definitions WERE re-registered from a fresh /object_info — only " +
+        "the combo dropdowns may be stale, and those refresh on a tab reload (reload the ComfyUI " +
+        "page or press R in it).",
+    };
+  }
+  if (!comboRan) {
+    // Defensive: a present combo API that did not run without a throw should be
+    // unreachable — but "could not determine" is not "refreshed", so fail closed
+    // with the honest token rather than claim success.
+    return {
+      refreshed: false,
+      reason: NODE_DEF_REFRESH_REASONS.COMBO_REFRESH_FAILED,
+      remedy:
+        "Node definitions WERE re-registered from a fresh /object_info, but the combo refresh " +
+        "did not complete, so dropdown options may still be stale. Retry; if it keeps " +
+        "happening, reload the ComfyUI tab to rebuild the combo lists.",
+    };
+  }
+  return { refreshed: true, reason: "refreshed" };
+}

--- a/web/js/lib/node-def-refresh.js
+++ b/web/js/lib/node-def-refresh.js
@@ -35,6 +35,9 @@ function detailSuffix(thrown) {
  * @param {{
  *   appAvailable: boolean,     // the ComfyUI frontend app object was reachable
  *   defsObtained: boolean,     // an /object_info payload was actually obtained
+ *   defsRegistered: boolean,   // registerNodesFromDefs actually RAN this run —
+ *                              // a frontend without that API must never let the
+ *                              // remedy claim registration happened (codex r2 P1)
  *   comboApiPresent: boolean,  // app.refreshComboInNodes exists on this build
  *   comboRan: boolean,         // refreshComboInNodes completed this run
  *   phase?: string,            // "fetch" | "register" | "combo" | "done" — where a throw happened
@@ -45,11 +48,20 @@ function detailSuffix(thrown) {
 export function describeNodeDefRefresh({
   appAvailable,
   defsObtained,
+  defsRegistered = false,
   comboApiPresent,
   comboRan,
   phase = "done",
   thrown = null,
 } = {}) {
+  // The registration clause the combo-failure remedies are allowed to make:
+  // "WERE re-registered" only when the registration call observably ran.
+  const registrationClause = defsRegistered
+    ? "Node definitions WERE re-registered from a fresh /object_info"
+    : "Node definitions were fetched but this frontend exposes no registerNodesFromDefs, so they were NOT registered";
+  const registrationRemedy = defsRegistered
+    ? ""
+    : " Reload the ComfyUI tab so the frontend picks up the new definitions.";
   if (!appAvailable) {
     return {
       refreshed: false,
@@ -72,9 +84,10 @@ export function describeNodeDefRefresh({
           "restarting — retry once it answers, and if it never does, check that the ComfyUI " +
           "server process is still running."
         : reason === NODE_DEF_REFRESH_REASONS.COMBO_REFRESH_FAILED
-          ? "Node definitions WERE re-registered from a fresh /object_info, but refreshing the " +
+          ? `${registrationClause}, but refreshing the ` +
             "combo lists failed, so dropdown options may still be stale. Retry; if it keeps " +
-            "failing, reload the ComfyUI tab to rebuild the combo lists."
+            "failing, reload the ComfyUI tab to rebuild the combo lists." +
+            registrationRemedy
           : "A fresh /object_info was obtained but re-registering the node definitions failed, " +
             "so the refresh is NOT confirmed. Reload the ComfyUI tab, then retry.";
     return { refreshed: false, reason, detail: detailSuffix(thrown) || undefined, remedy };
@@ -96,9 +109,11 @@ export function describeNodeDefRefresh({
       reason: NODE_DEF_REFRESH_REASONS.COMBO_API_ABSENT,
       remedy:
         "This ComfyUI frontend build has no refreshComboInNodes API, so combo lists cannot be " +
-        "rebuilt in place. Node definitions WERE re-registered from a fresh /object_info — only " +
-        "the combo dropdowns may be stale, and those refresh on a tab reload (reload the ComfyUI " +
-        "page or press R in it).",
+        `rebuilt in place. ${registrationClause}` +
+        (defsRegistered
+          ? " — only the combo dropdowns may be stale, and those refresh on a tab reload (reload " +
+            "the ComfyUI page or press R in it)."
+          : ". Reload the ComfyUI tab so both rebuild."),
     };
   }
   if (!comboRan) {
@@ -109,9 +124,10 @@ export function describeNodeDefRefresh({
       refreshed: false,
       reason: NODE_DEF_REFRESH_REASONS.COMBO_REFRESH_FAILED,
       remedy:
-        "Node definitions WERE re-registered from a fresh /object_info, but the combo refresh " +
+        `${registrationClause}, but the combo refresh ` +
         "did not complete, so dropdown options may still be stale. Retry; if it keeps " +
-        "happening, reload the ComfyUI tab to rebuild the combo lists.",
+        "happening, reload the ComfyUI tab to rebuild the combo lists." +
+        registrationRemedy,
     };
   }
   return { refreshed: true, reason: "refreshed" };

--- a/web/js/lib/reconnect-recovery.js
+++ b/web/js/lib/reconnect-recovery.js
@@ -1,0 +1,133 @@
+// #663 / #646 — post-reconnect recovery: the proactive settle watch and the
+// graph-mutation gate that rides on it.
+//
+// The panel's post-reconnect machinery used to be entirely PASSIVE on the canvas
+// side: the `reconnected` handler bumped the epoch and armed the 30s possibly-
+// stale window, but nothing ever RE-PROVED that the restored canvas is bound to
+// the active workflow. Two defects shared that root:
+//
+//   #663 — the window (and with it the mid-population refusals) ran its full
+//     30s even when the tab had finished restoring in two seconds, and a restore
+//     that never settled hard-refused every graph command until a manual
+//     panel_open_workflow / panel reload. Nothing proactive ever ran the binding
+//     evidence bar.
+//
+//   #646 — nothing gated graph MUTATIONS on the post-restart state at all: a
+//     mutation dispatched while ComfyUI's backend socket is down, or before the
+//     restored canvas binding was re-proven, could land on a canvas the restore
+//     was about to rebuild (a fabricated success) or die mid-command with the
+//     socket (OUTCOME UNKNOWN).
+//
+// The shared invariant, implemented ONCE here: a graph mutation may only run
+// when the post-reconnect binding has been re-proven — by the watch below, or
+// by an explicit workflow_open/new, whose own receipts are stronger proof. The
+// watch performs only SAFE heals (the ones a graph command performs lazily on
+// every call): getGraphCtx's verified canvas rebind for a provably content-free
+// ghost, and the binding guard's uuid-rebind / proven-binding seal. It
+// deliberately NEVER repaints the canvas from serialized state — a live root
+// whose content differs from the workflow's state can be holding user work
+// (#604), and "could not determine whose canvas this is" must stay a refusal,
+// not an automatic overwrite. A restore that never settles therefore still
+// refuses after the window, with the remedy the refusal message names; what the
+// watch buys is that the healthy case stops refusing as soon as the binding is
+// observably settled instead of at the 30s wall.
+
+/** Poll cadence for the settle watch (ms). */
+export const RECONNECT_SETTLE_POLL_MS = 1000;
+/** First poll delay (ms) — the restore needs a beat before it can pass. */
+export const RECONNECT_SETTLE_FIRST_POLL_MS = 500;
+
+/**
+ * The post-reconnect settle watch. Polls until the caller's binding proof
+ * passes, then stamps the proof via `markProven`. Stops early when the window
+ * closed without it (an explicit open/new re-proved the tab, or the window
+ * expired) and when a newer reconnect superseded it.
+ *
+ * Every dependency is injected, so the loop is unit-testable with fakes; the
+ * panel wires the module-scope epoch state and the real evidence bar.
+ *
+ * @param {{
+ *   isCurrent: () => boolean,    // false once a NEWER reconnect supersedes this watch
+ *   windowOpen: () => boolean,   // the #433/#618 possibly-stale window, live
+ *   proveBinding: () => boolean, // true when the binding clears the full read bar
+ *   markProven: () => void,      // stamp the binding proof for this epoch
+ *   sleep?: (ms: number) => Promise<void>,
+ *   firstDelayMs?: number,
+ *   pollMs?: number,
+ *   maxPolls?: number,           // hard cap so the loop is bounded even if the
+ *                                // window predicate never closes (fail-safe)
+ * }} o
+ * @returns {Promise<"proven"|"closed"|"superseded"|"exhausted">}
+ */
+export async function watchPostReconnectSettle({
+  isCurrent,
+  windowOpen,
+  proveBinding,
+  markProven,
+  sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  firstDelayMs = RECONNECT_SETTLE_FIRST_POLL_MS,
+  pollMs = RECONNECT_SETTLE_POLL_MS,
+  maxPolls = 45,
+} = {}) {
+  await sleep(firstDelayMs);
+  for (let poll = 0; poll < maxPolls; poll += 1) {
+    if (!isCurrent()) return "superseded";
+    if (!windowOpen()) return "closed";
+    let proven = false;
+    try {
+      proven = proveBinding() === true;
+    } catch {
+      // The proof is itself an operation that can fail — a throwing probe is
+      // "not yet", never "proven".
+      proven = false;
+    }
+    if (proven) {
+      // Re-check currency BEFORE stamping: a reconnect that landed while the
+      // proof ran must not let this older watch close the NEW window.
+      if (!isCurrent()) return "superseded";
+      markProven();
+      return "proven";
+    }
+    await sleep(pollMs);
+  }
+  return "exhausted";
+}
+
+/**
+ * The #646 graph-mutation gate: the refusal message for a mutating graph
+ * command that arrives while the post-reconnect environment is known-unstable,
+ * or null when the command may run. Two independent instability signals:
+ *
+ *   - backendDown: ComfyUI's own backend socket is between its "reconnecting"
+ *     and "reconnected" events. A mutation dispatched in that gap lands on a
+ *     canvas the incoming restore is about to rebuild — applied-then-wiped is
+ *     the fabricated-success outcome this repo treats as the worst case.
+ *   - bindingSettleWindow: a reconnect happened within the possibly-stale
+ *     window and the canvas binding has NOT been re-proven for this epoch yet
+ *     (the watch / an explicit open/new closes this). Reads stay available on
+ *     their own evidence bars; only mutations are gated.
+ *
+ * Both refusals are retryable and state that nothing was applied — true
+ * because the gate runs BEFORE the executor.
+ */
+export function graphMutationReconnectGate({ cmd, backendDown = false, bindingSettleWindow = false } = {}) {
+  const name = typeof cmd === "string" && cmd ? `"${cmd}"` : "this graph command";
+  if (backendDown) {
+    return (
+      `[backend-reconnecting] ComfyUI's backend connection is down right now (a restart or ` +
+      `reconnect is in progress), so ${name} was NOT applied — nothing changed. A graph mutation ` +
+      `dispatched in this window can land on a canvas the reconnect is about to rebuild. Retry ` +
+      `once the tab has reconnected (usually seconds); if it never reconnects, reload the ComfyUI page.`
+    );
+  }
+  if (bindingSettleWindow) {
+    return (
+      `[post-reconnect-settling] ComfyUI reconnected moments ago and the panel has not yet ` +
+      `re-proven that the canvas is bound to the active workflow, so ${name} was NOT applied — ` +
+      `nothing changed. The panel re-proves the binding automatically (usually within a few ` +
+      `seconds); retry in a moment. If this persists past ~30 seconds, re-open the active ` +
+      `workflow tab (panel_open_workflow) or reload the panel (panel_reload scope:frontend), then retry.`
+    );
+  }
+  return null;
+}

--- a/web/js/lib/restart-tab-identity.js
+++ b/web/js/lib/restart-tab-identity.js
@@ -108,12 +108,18 @@ export function createRestartTabIdentity({
         write(candidate);
       }
       return undefined;
-    })();
+    })()
+      // A REJECTED attempt (a lock manager whose request promise rejects, a
+      // throwing randomUUID) must degrade to the same retryable failure as a
+      // refused lease — never a cached rejection every later caller re-throws
+      // (that was the page-lifetime wedge all over again, codex gate P1).
+      .catch(() => undefined)
+      // Clear the in-flight slot so a LATER call may retry after a failure (a
+      // success is cached in `resolved`, which short-circuits above).
+      .finally(() => {
+        resolving = null;
+      });
     const outcome = await resolving;
-    // Clear the in-flight slot so a LATER call may retry after a failure (a
-    // success is cached in `resolved`, which short-circuits above). Concurrent
-    // callers awaiting this same run repeat the clear harmlessly.
-    resolving = null;
     if (outcome === undefined) lastFailureAt = now();
     return outcome;
   }

--- a/web/js/lib/restart-tab-identity.js
+++ b/web/js/lib/restart-tab-identity.js
@@ -37,7 +37,9 @@ export function createRestartTabIdentity({
   // cleared), so one contested lease window wedged the tab's registration until a
   // manual browser refresh — even after the contending tab closed and the lease
   // became acquirable. A failure is now retryable once per backoff window.
-  let lastFailureAt = 0;
+  // `null` (not 0) is the never-failed sentinel: a failure recorded at timestamp
+  // 0 must still count as a failure (codex gate r2).
+  let lastFailureAt = null;
 
   const fallback = () => (memoryFallback ??= randomUUID());
   const read = () => {
@@ -92,7 +94,7 @@ export function createRestartTabIdentity({
     // re-runs this resolver, so refusing to retry here is what forced the manual
     // browser refresh. Re-attempt at most once per backoff window; inside the
     // window, fail closed with the same undefined the first failure returned.
-    if (lastFailureAt && now() - lastFailureAt < retryBackoffMs) return undefined;
+    if (lastFailureAt != null && now() - lastFailureAt < retryBackoffMs) return undefined;
     resolving = (async () => {
       let candidate = read() ?? fallback();
       write(candidate);
@@ -114,14 +116,19 @@ export function createRestartTabIdentity({
       // refused lease — never a cached rejection every later caller re-throws
       // (that was the page-lifetime wedge all over again, codex gate P1).
       .catch(() => undefined)
+      // Stamp the failure INSIDE the chain, BEFORE the slot is cleared: a caller
+      // arriving between the clear and the stamp would otherwise see neither
+      // and start a fresh attempt, bypassing the backoff (codex gate r2).
+      .then((outcome) => {
+        if (outcome === undefined) lastFailureAt = now();
+        return outcome;
+      })
       // Clear the in-flight slot so a LATER call may retry after a failure (a
       // success is cached in `resolved`, which short-circuits above).
       .finally(() => {
         resolving = null;
       });
-    const outcome = await resolving;
-    if (outcome === undefined) lastFailureAt = now();
-    return outcome;
+    return resolving;
   }
 
   return { resolve, fallback, releaseForTests: () => releaseLease?.() };

--- a/web/js/lib/restart-tab-identity.js
+++ b/web/js/lib/restart-tab-identity.js
@@ -15,16 +15,29 @@ function nonBlank(value) {
  * an exclusive Web Locks lease held for this page's lifetime. If that cannot be
  * acquired, return undefined so the hello omits the identity and MCP readiness
  * fails closed. There is intentionally no timeout-as-proof fallback.
+ *
+ * A SUCCESS is cached for the life of the page. A FAILURE is retryable (#654):
+ * once `retryBackoffMs` has elapsed, the next resolve() runs a fresh lease
+ * attempt, so a tab that lost a transient contention window re-registers
+ * without a manual browser refresh once the lease becomes acquirable.
  */
 export function createRestartTabIdentity({
   storage = globalThis.sessionStorage,
   locks = globalThis.navigator?.locks,
   randomUUID = () => globalThis.crypto.randomUUID(),
+  now = () => Date.now(),
+  retryBackoffMs = 5000,
 } = {}) {
   let memoryFallback;
   let resolved;
   let resolving;
   let releaseLease;
+  // #654 — the timestamp of the last FAILED resolution. A failed resolve used to
+  // be cached for the LIFE of the page (the settled `resolving` promise was never
+  // cleared), so one contested lease window wedged the tab's registration until a
+  // manual browser refresh — even after the contending tab closed and the lease
+  // became acquirable. A failure is now retryable once per backoff window.
+  let lastFailureAt = 0;
 
   const fallback = () => (memoryFallback ??= randomUUID());
   const read = () => {
@@ -74,6 +87,12 @@ export function createRestartTabIdentity({
   async function resolve() {
     if (resolved) return resolved;
     if (resolving) return resolving;
+    // #654 — a FAILED resolution is not a life sentence: the lease may become
+    // acquirable later (the contending duplicate tab closed), and nothing else
+    // re-runs this resolver, so refusing to retry here is what forced the manual
+    // browser refresh. Re-attempt at most once per backoff window; inside the
+    // window, fail closed with the same undefined the first failure returned.
+    if (lastFailureAt && now() - lastFailureAt < retryBackoffMs) return undefined;
     resolving = (async () => {
       let candidate = read() ?? fallback();
       write(candidate);
@@ -90,7 +109,13 @@ export function createRestartTabIdentity({
       }
       return undefined;
     })();
-    return resolving;
+    const outcome = await resolving;
+    // Clear the in-flight slot so a LATER call may retry after a failure (a
+    // success is cached in `resolved`, which short-circuits above). Concurrent
+    // callers awaiting this same run repeat the clear harmlessly.
+    resolving = null;
+    if (outcome === undefined) lastFailureAt = now();
+    return outcome;
   }
 
   return { resolve, fallback, releaseForTests: () => releaseLease?.() };


### PR DESCRIPTION
The remaining halves of the restart/reconnect family after the #621/#622/#623/#624/#655 wave:
- no proactive canvas/tab rebind on 'reconnected'; unsettled restore hard-refuses until manual recovery
- stale tmp: routing keys not invalidated on frontend reconnect
- graph_enter_subgraph: bare canvas.openSubgraph, no scope/binding receipt, no post-nav reconcile
- mutations not gated until the post-restart socket is proven stable
- tab that never reconnects still requires a manual browser refresh
- panel-side half of #635: refresh_nodes stuck at refreshed:false with no reason/remedy (comfyui-mcp-panel.js:6934)

closes #617
closes #619
closes #646
closes #654
closes #663
refs #635 (panel half only — the restart dispatched:true/wrong-port half is orchestrator-side, tracked in comfyui-mcp)