### PR TITLE
0.11.42 — panel side of the comfyui-mcp 0.50.0 tool-surface migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.41"
+version = "0.11.42"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -832,7 +832,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.41";
+const PANEL_VERSION = "0.11.42";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Version bump so the #683 migration actually reaches users. The Comfy Registry publishes off a `pyproject.toml` change on `main`, so merging #683 alone shipped nothing.

## Why this is release-blocking for mcp 0.50.0

comfyui-mcp 0.50.0 folds the core surface from **154 tools to 37**. This panel calls those tools by name from browser JS. A user whose comfyui-mcp auto-updates to 0.50.0 while the Registry still serves **0.11.41** loses:

- the entire **Training tab** (7 call sites)
- the **CivitAI download** path
- **missing-model resolution**
- the **node listing** in the app-dependency panel

Every one of them calling a name that retired. And `self-update` only moves users *forward*, so it cannot be walked back.

mcp 0.50.0 is tagged and held (its Release workflow is deliberately disabled) specifically waiting on this.

## What shipped in #683

- `vendor/tool-vocabulary.json` re-vendored from core `main`: 145 → **37** tools, **160** dead names. Verified byte-identical to the core artefact by regenerating it in a clean core worktree.
- **15 dead call literals** and **67 dead references** rewritten to `tool` + explicit `action`, across five mechanisms — call literals, the `callJson` envelope wrapper, model-facing error strings, Python route docstrings, and 22 Playwright stubs keyed on `frame.tool`.
- **Seven live calls that omitted `action` on a SURVIVING tool** — including `enqueue_workflow` and `save_workflow`. This is the class no name-based gate can see: the name is alive, only the arguments changed, so the vocabulary gate is structurally blind to it.
- A new gate rule pinning `action` as the **first key** of a call's args object, so that class cannot silently return.

## This PR

`pyproject.toml` and `PANEL_VERSION` bumped together `0.11.41 → 0.11.42` — they must match or the publish is wrong.

Control-byte scan clean on both changed files.

## Sequence after this merges

1. this merges → Comfy Registry publishes 0.11.42
2. `gh workflow enable release.yml` in comfyui-mcp
3. re-push tag `v0.50.0` at `08a0506` (the existing run is wedged and uncancellable — do not rely on re-running it)
4. confirm `npm view comfyui-mcp version` → `0.50.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)