### PR TITLE
fix(panel): classify socket-vs-widget structurally so union datatypes stop failing closed (#695)

### DIFF
--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -6,9 +6,12 @@ import {
   applyCurrentDefWidgetValues,
   driftedRequiredInputNames,
   missingRequiredWidgetMaterializations,
+  declaredTypeMembers,
   registeredSocketTypes,
   requiredWidgetInputTypes,
   unavailableRequiredCustomWidgetTypes,
+  unavailableRequiredWidgetMessage,
+  unavailableRequiredWidgetReport,
 } from "../../web/js/lib/node-widget-materialization.js";
 
 const PANEL_JS = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
@@ -530,5 +533,225 @@ test("#626: graph_add_node actually CONSUMES the reconciliation and discloses it
     src.indexOf("const valueCorrections = applyCurrentDefWidgetValues(node, currentDef);") <
       src.indexOf("      graph.add(node);"),
     "reconciliation must precede graph.add",
+  );
+});
+// ---- #695: socket-vs-widget classification must be STRUCTURAL, not a name list ------
+//
+// Reported as "MASK is missing from SAFE_SOCKET_TYPES". MASK/MESH/VOXEL were added by
+// the #620/#608 work, but the same failure class survives in two places, both verified
+// against a live /object_info (2887 classes):
+//   * PHOTOMAKER — a stock core datatype the list still omits.
+//   * COMMA-JOINED UNION types. ComfyUI declares a link-compatible union of datatypes as
+//     ONE string: core `PreviewImageOrMask` requires ("IMAGE,MASK"), `ImageUncropByMask`
+//     requires ("BBOX,BOUNDING_BOX"), `LoraExtractKJ` requires ("MODEL,CLIP"). The guard
+//     compared the WHOLE string against the allowlist and against the output-proof set
+//     (which only ever holds single type names), so every union failed closed — a 5s
+//     poll for a widget constructor that can never appear, reported as "custom widgets
+//     still loading".
+
+const CORE_SOCKET_DATATYPES = ["MASK", "MESH", "VOXEL", "PHOTOMAKER"];
+
+function requiring(required) {
+  return { constructor: { nodeData: { input: { required } } } };
+}
+
+test("#695: the core connection datatypes named in the report are all safe sockets", () => {
+  // Pinned by name so a future edit cannot quietly drop one again. No output proof and
+  // no fresh def is supplied: this is the allowlist half on its own.
+  for (const type of CORE_SOCKET_DATATYPES) {
+    assert.deepEqual(
+      unavailableRequiredCustomWidgetTypes(requiring({ thing: [type, {}] }), {}),
+      [],
+      `${type} must not be treated as a possibly-registering custom widget`,
+    );
+  }
+});
+
+test("#695: core PhotoMakerEncode adds without waiting for a widget", () => {
+  // Verbatim from live /object_info.
+  const def = {
+    input: {
+      required: {
+        photomaker: ["PHOTOMAKER", {}],
+        image: ["IMAGE", {}],
+        clip: ["CLIP", {}],
+        text: ["STRING", { default: "photograph of photomaker", multiline: true, dynamicPrompts: true }],
+      },
+    },
+  };
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(def, { STRING: () => {} }, new Set(), def),
+    [],
+  );
+});
+
+test("#695: a comma-joined union of core link datatypes is a socket (core PreviewImageOrMask)", () => {
+  // Verbatim from live /object_info: required.input = ["IMAGE,MASK", {tooltip}].
+  const def = { input: { required: { input: ["IMAGE,MASK", { tooltip: "The image or mask to preview." }] } } };
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(def, {}, new Set(), def), []);
+  // …and the same union with no config at all (ImageConcanate.image2).
+  const bare = { input: { required: { image2: ["IMAGE,MASK", {}] } } };
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(bare, {}, new Set(), bare), []);
+});
+
+test("#695: a union whose members are only proven by /object_info outputs resolves too", () => {
+  // ImageUncropByMask.bbox = ["BBOX,BOUNDING_BOX"]. BBOX is allowlisted; BOUNDING_BOX is
+  // not, and is proven a link datatype only because some installed node outputs it.
+  const def = { input: { required: { mask: ["MASK"], bbox: ["BBOX,BOUNDING_BOX"] } } };
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(def, {}, new Set(["BOUNDING_BOX"]), def),
+    [],
+  );
+  // Without that proof it still fails closed — an unproven member is still unknown.
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(def, {}, new Set(), def),
+    ["BBOX,BOUNDING_BOX"],
+  );
+});
+
+test("#695: a union input that DECLARES a widget value still fails closed (#580/#626 intact)", () => {
+  // LTXVEmptyLatentAudio.frame_rate = ["FLOAT,INT", {widgetType:"FLOAT", default:25, min, max, step}].
+  // Both members are output by some node, so the type half passes — but the input half
+  // says this carries a VALUE, so the wait for its widget constructor must survive.
+  const def = {
+    input: {
+      required: {
+        frame_rate: ["FLOAT,INT", { widgetType: "FLOAT", default: 25, min: 1, max: 1000, step: 0.01 }],
+      },
+    },
+  };
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(def, {}, new Set(["FLOAT", "INT"]), def),
+    ["FLOAT,INT"],
+  );
+  // …and it clears the instant the constructor registers under the union's own key.
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(def, { "FLOAT,INT": () => {} }, new Set(["FLOAT", "INT"]), def),
+    [],
+  );
+});
+
+test("#695: a genuinely-still-registering custom widget is still waited for", () => {
+  // The legitimate #580 case must be untouched by any of the above: an unknown type that
+  // is not a union, has no output proof, and declares a value.
+  const def = { input: { required: { gallery: ["ZIPN_STYLE_GALLERY", { default: "none" }] } } };
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(def, {}, new Set(), def),
+    ["ZIPN_STYLE_GALLERY"],
+  );
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(def, { ZIPN_STYLE_GALLERY: () => {} }, new Set(), def),
+    [],
+  );
+});
+
+test("#695: declaredTypeMembers splits a union and leaves a single type alone", () => {
+  assert.deepEqual(declaredTypeMembers("MASK"), ["MASK"]);
+  assert.deepEqual(declaredTypeMembers("IMAGE,MASK"), ["IMAGE", "MASK"]);
+  assert.deepEqual(declaredTypeMembers("BBOX, BOUNDING_BOX"), ["BBOX", "BOUNDING_BOX"]);
+  // ComfyUI's own `INT:seed` / `INT:noise_seed` registry keys carry no comma and must
+  // survive intact — they ARE registered widget constructors, not unions.
+  assert.deepEqual(declaredTypeMembers("INT:seed"), ["INT:seed"]);
+  assert.deepEqual(declaredTypeMembers(""), []);
+  assert.deepEqual(declaredTypeMembers(",,"), []);
+  assert.deepEqual(declaredTypeMembers(undefined), []);
+});
+
+test("#695: a union registered under its own key in the widget registry is a widget", () => {
+  // The whole declared string is looked up before it is decomposed, so a pack that
+  // registers a constructor for the union itself keeps it.
+  const def = { input: { required: { value: ["IMAGE,MASK", {}] } } };
+  assert.deepEqual(unavailableRequiredWidgetReport(def, { "IMAGE,MASK": () => {} }, new Set(), def), []);
+});
+
+test("#695: a union with ONE unproven member still fails closed", () => {
+  // SaveGaussianSplat.model_3d = FILE_3D_SPLAT_ANY,FILE_3D_PLY,… — proving some members
+  // is not proving the type, so the guard is not weakened into "any member counts".
+  const def = { input: { required: { model_3d: ["FILE_3D_SPLAT_ANY,FILE_3D_PLY", {}] } } };
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(def, {}, new Set(["FILE_3D_SPLAT_ANY"]), def),
+    ["FILE_3D_SPLAT_ANY,FILE_3D_PLY"],
+  );
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(
+      def,
+      {},
+      new Set(["FILE_3D_SPLAT_ANY", "FILE_3D_PLY"]),
+      def,
+    ),
+    [],
+  );
+});
+
+test("#695: the report names the stuck INPUT and which of the two causes it is", () => {
+  const def = {
+    input: {
+      required: {
+        // Proven a link datatype by the backend, but declares a widget value.
+        amount: ["ACME_VALUE", { default: 3 }],
+        // Nothing outputs this and nothing registers a widget for it.
+        gallery: ["ZIPN_STYLE_GALLERY", { default: "none" }],
+        also_gallery: ["ZIPN_STYLE_GALLERY", { default: "none" }],
+      },
+    },
+  };
+  assert.deepEqual(unavailableRequiredWidgetReport(def, {}, new Set(["ACME_VALUE"]), def), [
+    { type: "ACME_VALUE", inputs: ["amount"], linkProven: true },
+    { type: "ZIPN_STYLE_GALLERY", inputs: ["gallery", "also_gallery"], linkProven: false },
+  ]);
+});
+
+test("#695: the refusal message stops asserting one cause for two situations", () => {
+  const message = unavailableRequiredWidgetMessage(
+    [{ type: "ZIPN_STYLE_GALLERY", inputs: ["gallery"], linkProven: false }],
+    "ZipnStyler",
+    5000,
+  );
+  // Before: `Required custom widget "MASK" have not registered. They may be custom
+  // widgets still loading; retry shortly.` — no node, no input, one asserted cause, and
+  // a remedy ("retry shortly") that cannot work for a datatype with no widget.
+  assert.match(message, /Cannot add "ZipnStyler"/);
+  assert.match(message, /input "gallery"/, "names the input, not just the datatype");
+  assert.match(message, /no installed node outputs "ZIPN_STYLE_GALLERY"/);
+  assert.match(message, /5\.0s/, "discloses what the wait cost");
+  assert.match(message, /Reload the ComfyUI browser tab/, "gives the remedy that can work");
+  assert.match(message, /retrying alone will not fix it/);
+  assert.doesNotMatch(message, /retry shortly/, "no longer promises a retry will help");
+
+  const linkProven = unavailableRequiredWidgetMessage(
+    [{ type: "ACME_VALUE", inputs: ["amount", "other"], linkProven: true }],
+    "AcmeNode",
+    5000,
+  );
+  assert.match(linkProven, /input "amount", "other"/);
+  assert.match(linkProven, /declares "ACME_VALUE" as a link datatype, but this input also declares a widget value/);
+  // The line #695's reporter needed: this is not the socket-allowlist bug again.
+  assert.match(linkProven, /added immediately, without any wait/);
+});
+
+test("#695: graph_add_node consumes the report and message, and names the class", () => {
+  // Without this the classification could be perfect and entirely unwired.
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /unavailableRequiredWidgetReport,/, "imported");
+  assert.match(src, /unavailableRequiredWidgetMessage,/, "imported");
+  assert.doesNotMatch(
+    src,
+    /They may be custom widgets still loading; retry shortly/,
+    "the single-cause message is gone from the add path",
+  );
+  assert.match(
+    src,
+    /unavailableRequiredWidgetReport\(nodeData, comfyApp\?\.widgets, knownSocketTypes, currentDef\)/,
+    "the poll checks the report",
+  );
+  assert.match(
+    src,
+    /unavailableRequiredWidgetMessage\(unavailable, classType, Date\.now\(\) - startedAt\)/,
+    "the refusal is built from the report, with the elapsed wait",
+  );
+  assert.match(
+    src,
+    /await awaitRequiredCustomWidgetRegistration\(\s*nodeData,\s*comfyApp,\s*knownSocketTypes,\s*currentDef,\s*class_type,\s*\)/,
+    "the class_type reaches the message",
   );
 });

--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -755,3 +755,47 @@ test("#695: graph_add_node consumes the report and message, and names the class"
     "the class_type reaches the message",
   );
 });
+
+test("#695 gate r1: an all-built-in UNION that declares a widget value still fails closed", () => {
+  // Members being built-in link datatypes is not the INPUT being a link. A pack can
+  // declare ("IMAGE,MASK", {widgetType, default}) — the shape LTXV already uses for
+  // ("FLOAT,INT", …) — which is a widget that ACCEPTS those links. Waiving it on the
+  // member types alone added a node with neither a widget value nor a link (#580).
+  const def = {
+    input: { required: { source: ["IMAGE,MASK", { widgetType: "IMAGE", default: "none" }] } },
+  };
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(def, {}, new Set(), def), ["IMAGE,MASK"]);
+  // It is reported as the link-proven case, because that is what it is: the datatypes are
+  // real link types, and the INPUT is nonetheless asking for a value.
+  assert.deepEqual(unavailableRequiredWidgetReport(def, {}, new Set(), def), [
+    { type: "IMAGE,MASK", inputs: ["source"], linkProven: true },
+  ]);
+  // …and it clears once the constructor registers under the union's own key.
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(def, { "IMAGE,MASK": () => {} }, new Set(), def),
+    [],
+  );
+  // A SINGLE built-in keeps its type-only shortcut, exactly as before this fix: no widget
+  // constructor exists for MASK, so there is nothing for the input to be waiting on.
+  const single = { input: { required: { mask: ["MASK", { default: "none" }] } } };
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(single, {}, new Set(), single), []);
+});
+
+test("#695 gate r1: the type list is deduped and first-seen ordered, as it always was", () => {
+  // requiredWidgetInputTypes has always returned [...new Set(...)], so the Map-based
+  // rewrite must not start emitting one entry per input.
+  const def = {
+    input: {
+      required: {
+        first: ["ACME", { default: 1 }],
+        other: ["ZED", { default: 2 }],
+        second: ["ACME", { default: 3 }],
+      },
+    },
+  };
+  assert.deepEqual(unavailableRequiredCustomWidgetTypes(def, {}, new Set(), def), ["ACME", "ZED"]);
+  assert.deepEqual(unavailableRequiredWidgetReport(def, {}, new Set(), def), [
+    { type: "ACME", inputs: ["first", "second"], linkProven: false },
+    { type: "ZED", inputs: ["other"], linkProven: false },
+  ]);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -220,7 +220,8 @@ import {
   driftedRequiredInputNames,
   missingRequiredWidgetMaterializations,
   registeredSocketTypes,
-  unavailableRequiredCustomWidgetTypes,
+  unavailableRequiredWidgetMessage,
+  unavailableRequiredWidgetReport,
 } from "./lib/node-widget-materialization.js";
 import { sameGraphMutationContext } from "./lib/graph-mutation-context.js";
 import { isImeComposing } from "./lib/ime.js";
@@ -7045,15 +7046,12 @@ async function awaitRequiredCustomWidgetRegistration(
   comfyApp,
   knownSocketTypes,
   currentDef,
+  classType,
 ) {
-  const deadline = Date.now() + CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS;
+  const startedAt = Date.now();
+  const deadline = startedAt + CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS;
   const check = () =>
-    unavailableRequiredCustomWidgetTypes(
-      nodeData,
-      comfyApp?.widgets,
-      knownSocketTypes,
-      currentDef,
-    );
+    unavailableRequiredWidgetReport(nodeData, comfyApp?.widgets, knownSocketTypes, currentDef);
   let unavailable = check();
   while (Date.now() < deadline) {
     if (!unavailable.length) return;
@@ -7061,10 +7059,13 @@ async function awaitRequiredCustomWidgetRegistration(
     unavailable = check();
   }
   if (!unavailable.length) return;
+  // #695: the poll is the ONLY thing here a retry can change (nodeData, currentDef and
+  // knownSocketTypes are all snapshots), so a type that is structurally a socket must be
+  // waived by the check rather than waited out — and whatever is left after the wait gets
+  // a message that says which input is stuck and which of the two causes it is, instead of
+  // asserting the single cause that sent #695's reporter to the wrong place.
   throw new Error(
-    `Required custom widget${unavailable.length === 1 ? "" : "s"} ` +
-      `${unavailable.map((type) => `"${type}"`).join(", ")} have not registered. ` +
-      "They may be custom widgets still loading; retry shortly.",
+    unavailableRequiredWidgetMessage(unavailable, classType, Date.now() - startedAt),
   );
 }
 
@@ -8373,6 +8374,7 @@ const GRAPH_TOOL_EXECUTORS = {
       comfyApp,
       knownSocketTypes,
       currentDef,
+      class_type,
     );
     const node = LG.createNode(class_type);
     if (!node) {

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -164,12 +164,24 @@ export function unavailableRequiredWidgetReport(
     if (typeof widgetConstructors?.[type] === "function") continue;
     const members = declaredTypeMembers(type);
     if (!members.length) continue;
-    if (members.every((member) => SAFE_SOCKET_TYPES.has(member))) continue;
-    // Every member is a datatype the CURRENT backend declares as some node's output (or
-    // is a built-in socket), so no widget constructor is ever going to appear for it.
+    // Every member is a datatype no widget constructor will ever appear for: a built-in
+    // connection type, or one the CURRENT backend declares as some node's output.
     const linkProven = members.every(
       (member) => SAFE_SOCKET_TYPES.has(member) || knownSocketTypes?.has?.(member) === true,
     );
+    // A SINGLE built-in connection datatype is waived on the type alone. Unchanged from
+    // before this fix, and sound for the same reason it was then: ComfyUI registers no
+    // widget constructor for any of them, so there is nothing an input-level declaration
+    // could be asking this to wait for.
+    if (members.length === 1 && SAFE_SOCKET_TYPES.has(type)) continue;
+    // A UNION does NOT get that shortcut, even when every member is a built-in. Members
+    // being link datatypes is not the input being a link: a pack can declare
+    // ("IMAGE,MASK", {widgetType: "IMAGE", default: …}) — the exact shape LTXV already
+    // uses for ("FLOAT,INT", {widgetType: "FLOAT", default, min, max}) — and that is a
+    // widget which ACCEPTS those links, not a socket. Only the input's own declaration
+    // settles it, so a union must clear the input-level bar below as well. (Found by the
+    // codex gate: waiving an all-built-in union on the type alone was a #580 false
+    // accept, adding a node with neither a widget value nor a link.)
     // #626 P0: "some node OUTPUTS this type" does NOT establish that THIS input is
     // link-only. ComfyUI's frontend supports converting widget inputs to links, so a
     // widget-bearing input is link-compatible too — INT and a custom ACME_VALUE are

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -46,13 +46,44 @@ export function requiredWidgetInputTypes(nodeOrNodeData) {
 // one is safe to leave as a socket when no widget constructor exists. An
 // unrecognised type is NOT assumed safe: it may be a custom V3 widget whose
 // extension is still registering.
+//
+// This list is a FALLBACK, not the discriminator. It exists only for the case
+// where no fresh /object_info is available to prove link-ness structurally
+// (see registeredSocketTypes + inputDeclaredAsSocket below, which is what the
+// add path actually relies on). Growing it is not how a new core datatype gets
+// fixed — #695 was filed after MASK, and would have been filed again after the
+// next one.
 const SAFE_SOCKET_TYPES = new Set([
   "*", "ANY", "AUDIO", "BBOX", "CLIP", "CLIP_VISION", "CLIP_VISION_OUTPUT",
   "CONDITIONING", "CONTROL_NET", "GLIGEN", "GUIDER", "HOOKS", "IMAGE",
   "IPADAPTER", "LATENT", "LATENT_OPERATION", "MASK", "MESH", "MODEL", "NOISE",
-  "SAMPLER", "SCHEDULER", "SIGMAS", "STYLE_MODEL", "UNET", "UPSCALE_MODEL",
-  "VAE", "VOXEL",
+  "PHOTOMAKER", "SAMPLER", "SCHEDULER", "SIGMAS", "STYLE_MODEL", "UNET",
+  "UPSCALE_MODEL", "VAE", "VOXEL",
 ]);
+
+/**
+ * The individual datatypes a declared input type names.
+ *
+ * ComfyUI declares a link-compatible UNION of datatypes as ONE COMMA-JOINED string:
+ * core `PreviewImageOrMask` requires `("IMAGE,MASK")`, `SaveGLB` requires
+ * `("MESH,FILE_3D_GLB,…")`, `ImageUncropByMask` requires `("BBOX,BOUNDING_BOX")`,
+ * `LoraExtractKJ` requires `("MODEL,CLIP")`. LiteGraph splits on the comma to decide
+ * link compatibility; every guard here must split it too. Comparing the whole string
+ * against a set of single type names can only ever miss — the union is not the name of
+ * any datatype, so it matched neither the allowlist nor the /object_info output proof,
+ * and EVERY union input failed closed. That is #695's defect surviving the addition of
+ * MASK to the allowlist: `PreviewImageOrMask` is still a mask node that cannot be added.
+ *
+ * A single (comma-free) type yields itself, so the single-type path is unchanged.
+ */
+export function declaredTypeMembers(type) {
+  if (typeof type !== "string" || !type) return [];
+  if (!type.includes(",")) return [type];
+  return type
+    .split(",")
+    .map((member) => member.trim())
+    .filter(Boolean);
+}
 
 /**
  * Required input types that might be custom widgets but have not entered the
@@ -83,6 +114,30 @@ export function unavailableRequiredCustomWidgetTypes(
   knownSocketTypes,
   currentDef,
 ) {
+  return unavailableRequiredWidgetReport(
+    nodeOrNodeData,
+    widgetConstructors,
+    knownSocketTypes,
+    currentDef,
+  ).map((entry) => entry.type);
+}
+
+/**
+ * The same verdict as unavailableRequiredCustomWidgetTypes, with what the caller needs
+ * to say something TRUE about it: which required INPUTS carry each unavailable type, and
+ * whether the current backend proves the type is a link datatype.
+ *
+ * #695 was reported against a message that blamed one cause — "may be custom widgets
+ * still loading; retry shortly" — for two situations with opposite remedies, which is
+ * what sent the reporter looking at a widget registry for a datatype that has no widget.
+ * The two are distinguishable here, so they are distinguished here.
+ */
+export function unavailableRequiredWidgetReport(
+  nodeOrNodeData,
+  widgetConstructors,
+  knownSocketTypes,
+  currentDef,
+) {
   const source = currentDef ?? nodeOrNodeData;
   const required = requiredInputs(source) ?? {};
   // Types for which EVERY required input carrying them declares itself socket-shaped.
@@ -91,24 +146,71 @@ export function unavailableRequiredCustomWidgetTypes(
   // reproduce the very error this fixes one level down.
   const socketDeclared = new Set();
   const widgetDeclared = new Set();
-  for (const spec of Object.values(required)) {
+  const inputsByType = new Map();
+  for (const [name, spec] of Object.entries(required)) {
     const type = inputWidgetType(spec);
     if (!type) continue;
     (inputDeclaredAsSocket(spec) ? socketDeclared : widgetDeclared).add(type);
+    if (!inputsByType.has(type)) inputsByType.set(type, []);
+    inputsByType.get(type).push(name);
   }
   for (const type of widgetDeclared) socketDeclared.delete(type);
-  return requiredWidgetInputTypes(source).filter(
-    (type) =>
-      typeof widgetConstructors?.[type] !== "function" &&
-      !SAFE_SOCKET_TYPES.has(type) &&
-      // #626 P0: "some node OUTPUTS this type" does NOT establish that THIS input is
-      // link-only. ComfyUI's frontend supports converting widget inputs to links, so a
-      // widget-bearing input is link-compatible too — INT and a custom ACME_VALUE are
-      // both output by some node somewhere. The output side is evidence about the TYPE;
-      // the question asked here is about the INPUT. So the waiver now needs the
-      // input-level socket declaration as well: the type must be proven a link datatype
-      // AND every required input carrying it must declare itself socket-shaped.
-      !(knownSocketTypes?.has?.(type) === true && socketDeclared.has(type)),
+
+  const report = [];
+  for (const [type, inputs] of inputsByType) {
+    // The registry is keyed by the DECLARED type exactly as written — including
+    // ComfyUI's own `INT:seed` / `INT:noise_seed` keys and any union a pack chooses to
+    // register — so the whole string is checked first, before it is decomposed.
+    if (typeof widgetConstructors?.[type] === "function") continue;
+    const members = declaredTypeMembers(type);
+    if (!members.length) continue;
+    if (members.every((member) => SAFE_SOCKET_TYPES.has(member))) continue;
+    // Every member is a datatype the CURRENT backend declares as some node's output (or
+    // is a built-in socket), so no widget constructor is ever going to appear for it.
+    const linkProven = members.every(
+      (member) => SAFE_SOCKET_TYPES.has(member) || knownSocketTypes?.has?.(member) === true,
+    );
+    // #626 P0: "some node OUTPUTS this type" does NOT establish that THIS input is
+    // link-only. ComfyUI's frontend supports converting widget inputs to links, so a
+    // widget-bearing input is link-compatible too — INT and a custom ACME_VALUE are
+    // both output by some node somewhere. The output side is evidence about the TYPE;
+    // the question asked here is about the INPUT. So the waiver needs the input-level
+    // socket declaration as well: the type must be proven a link datatype AND every
+    // required input carrying it must declare itself socket-shaped. A union is held to
+    // exactly the same bar — LTXV's `("FLOAT,INT", {default, min, max, step})` is a
+    // widget that ACCEPTS an int link, not a socket, and still waits for its constructor.
+    if (linkProven && socketDeclared.has(type)) continue;
+    report.push({ type, inputs, linkProven });
+  }
+  return report;
+}
+
+/**
+ * The refusal text for a report that never cleared. Says which INPUT is unsatisfiable
+ * (not just its datatype), which of the two situations it is, and what actually fixes
+ * each — the previous single-cause message named a remedy ("retry shortly") that cannot
+ * work for a datatype no widget will ever back, and named none for the case that does.
+ */
+export function unavailableRequiredWidgetMessage(report, classType, waitedMs) {
+  const target = classType ? `"${classType}"` : "this node";
+  const lines = report.map((entry) => {
+    const inputs = entry.inputs.map((name) => `"${name}"`).join(", ");
+    const cause = entry.linkProven
+      ? `the backend declares "${entry.type}" as a link datatype, but this input also declares a ` +
+        `widget value (default/min/max/options), so it needs a registered widget and none appeared`
+      : `no installed node outputs "${entry.type}" and no frontend widget is registered for it`;
+    return `  - input ${inputs} (declared type "${entry.type}"): ${cause}.`;
+  });
+  const waited = Number.isFinite(waitedMs) ? `${(waitedMs / 1000).toFixed(1)}s` : "the wait window";
+  return (
+    `Cannot add ${target}: ${report.length} required input type${report.length === 1 ? "" : "s"} ` +
+    `had no widget after ${waited} waiting for node extensions to register.\n` +
+    `${lines.join("\n")}\n` +
+    "Reload the ComfyUI browser tab so node packs can re-register their frontend widgets, then " +
+    "retry. If it fails again the pack's frontend extension is not loading and retrying alone " +
+    "will not fix it. This is NOT a link datatype being misread: an input the backend proves is " +
+    "a socket (MASK, IMAGE, LATENT, a comma-joined union of them) is added immediately, without " +
+    "any wait."
   );
 }
 


### PR DESCRIPTION
Closes #695

## The reported defect, and why the proposed diff is not the fix

#695 reports that `panel_add_node` rejects every node with a required `MASK` input, and
proposes adding `MASK`, `MESH`, `VOXEL`, `PHOTOMAKER` to `SAFE_SOCKET_TYPES`. Three of the
four are already on `main` — the reporter's build (pack git `42d7f76`) predates the #620/#608
work that added them. But the failure class is **not** fixed, and the allowlist is not where
it lives. Patching four more names in guarantees a third occurrence.

## Was there a principled discriminator? Yes — and most of it already exists

`main` already decides this structurally, not by name (#620/#626):

* `registeredSocketTypes(freshDefs)` — every datatype some node declares as an **OUTPUT** in
  the fresh `/object_info` the add path already fetches. A widget constructor will never
  appear for one of those.
* `inputDeclaredAsSocket(spec)` — a positive reading of the input's **own** declaration.
  `default` / `min` / `max` / `options` / `multiline` … are things only a widget can honour;
  an input declaring none of them is asking for a link.

Both halves are required, because a datatype can be a widget on one node and a socket on
another. `SAFE_SOCKET_TYPES` is only the fallback for when no fresh def is available.

**What that discriminator could not see is ComfyUI's union syntax.** ComfyUI declares a
link-compatible union of datatypes as ONE comma-joined string, and LiteGraph splits on the
comma to decide link compatibility. The guards did not — they compared the whole string
against sets of *single* type names, which is a name no datatype has, so it matched neither
the allowlist nor the output proof. Every union input failed closed: a 5s poll for a widget
constructor that can never appear, reported as "custom widgets still loading".

Verified against a live `/object_info` (2887 classes), that is #695's own complaint surviving
`MASK`'s addition to the allowlist:

| class | required input | why it was unaddable |
|---|---|---|
| `PreviewImageOrMask` (core) | `("IMAGE,MASK", {tooltip})` | union unmatched |
| `ImageConcanate` | `("IMAGE,MASK", {})` | union unmatched |
| `ImageUncropByMask`, `SplitBboxes`, `BatchUncrop` (+3) | `("BBOX,BOUNDING_BOX")` | union unmatched |
| `LoraExtractKJ` | `("MODEL,CLIP", {tooltip})` | union unmatched |
| `GetPreviewOverrideFramesKJ` | `("LATENT,IMAGE", {tooltip})` | union unmatched |
| `ComfyNumberConvert` | `("INT,FLOAT,STRING,BOOLEAN", {display_name})` | union unmatched |
| `PhotoMakerEncode` (core) | `("PHOTOMAKER", {})` | allowlist gap (fallback path only) |

`PreviewImageOrMask` is a core mask node the agent still could not add.

## The change

`declaredTypeMembers(type)` splits a declared type on `,`; a comma-free type yields itself,
so the single-type path is behaviourally unchanged. Then:

* The **whole** declared string is looked up in the widget registry first, so ComfyUI's own
  `INT:seed` / `INT:noise_seed` keys — and any union a pack registers itself — keep their
  constructors.
* A union is waived only when **every** member is a known link datatype. "Some member" would
  waive `("FILE_3D_SPLAT_ANY,FILE_3D_PLY")` on half a proof.
* A union must also clear the **input-level** half. Its members being built-in link types does
  not make the input a link: LTXV ships `("FLOAT,INT", {widgetType:"FLOAT", default, min, max})`,
  which is a widget that *accepts* an int link. That still waits for its constructor.
* `PHOTOMAKER` joins the fallback allowlist — the one of the four genuinely absent — with a
  comment stating the list is a fallback and that growing it is not how the next core datatype
  gets fixed.

Net against the live `/object_info` (measured by diffing this branch's classifier against
`4925be7`'s over all 2887 classes): **17 more classes addable, 0 newly refused** —
`PreviewImageOrMask`, `ImageConcanate`, `FastPreviewBatch`, `ImageUncropByMask`, `BatchUncrop`,
`BatchUncropAdvanced`, `SplitBboxes`, `BboxToInt`, `BboxVisualize`, `LoraExtractKJ`,
`GetPreviewOverrideFramesKJ`, `ComfyNumberConvert`, `TripoConversionNode`,
`TencentModelTo3DUVNode`, `Tencent3DTextureEditNode`, `Tencent3DPartNode`,
`TencentSmartTopologyNode`.

## The failure that remains is no longer misleading

Before — one asserted cause for two situations with opposite remedies, naming neither the node
nor the input, which is what sent this reporter to a widget registry for a datatype that has
no widget:

```
Required custom widget "MASK" have not registered. They may be custom widgets still loading; retry shortly.
```

After:

```
Cannot add "ZipnStyler": 1 required input type had no widget after 5.0s waiting for node extensions to register.
  - input "gallery" (declared type "ZIPN_STYLE_GALLERY"): no installed node outputs "ZIPN_STYLE_GALLERY" and no frontend widget is registered for it.
Reload the ComfyUI browser tab so node packs can re-register their frontend widgets, then retry. If it fails again the pack's frontend extension is not loading and retrying alone will not fix it. This is NOT a link datatype being misread: an input the backend proves is a socket (MASK, IMAGE, LATENT, a comma-joined union of them) is added immediately, without any wait.
```

The other branch reads: *the backend declares "X" as a link datatype, but this input also
declares a widget value (default/min/max/options), so it needs a registered widget and none
appeared.*

On "fail fast": the 5s poll is kept, and that is deliberate. The poll is the only thing a
retry can change (`nodeData`, `currentDef` and `knownSocketTypes` are all snapshots), so a
type that is *structurally* a socket is now waived by the check itself and costs **zero**
wait — better than failing fast. Every case that still waits is one where a constructor
genuinely can still register, which is #580's protection.

## Verification

* **Repro first**: 4 tests fail on `4925be7` (`PHOTOMAKER`, `PhotoMakerEncode`, `IMAGE,MASK`,
  `BBOX,BOUNDING_BOX`), pass after.
* Covers `InvertMask`, `SetLatentNoiseMask`, `GrowMaskWithBlur`, `MaskToImage`, and a
  genuinely-still-registering custom widget — the legitimate wait is proven intact, in both
  the single-type and union forms.
* **Mutations verified** (each fails its own tests, then restored): drop `PHOTOMAKER`;
  un-split the union; `every()` to `some()` on member proof; drop the input-level half of the
  waiver; restore the old message; drop `class_type` from the call; restore the
  all-built-in-union shortcut; require socket-declaration on the single-type shortcut.
* Full unit suite 2568/2568, `tsc --noEmit`, `node --check` over `web/js`, tool-vocabulary
  gate, YARA/exec parity scan over changed files, control-byte scan 0, no git-binary files.
  The panel parses **and links** as an ES module (fails only at `window is not defined`,
  i.e. evaluation), so no duplicate top-level declaration.
* `pyproject.toml` and `PANEL_VERSION` untouched.

## Independent codex gate — 2 rounds

**r1 FAIL, 1 SEVERE (accepted, fixed in 2c67e22).** The union path waived on member types
alone, before the input-level half — so `("IMAGE,MASK", {widgetType, default})` would be
added with neither a widget value nor a link (#580's false accept, in the new code path). The
type-only shortcut now applies to a single built-in only, which is what it did before this
branch. Two MINORs: "the wrapper no longer preserves duplicate types" **rejected** as
factually wrong (`requiredWidgetInputTypes` has always returned `[...new Set(...)]`; pinned
with a test anyway); "the `FLOAT,INT` test passes on the base too" **accepted as stated** —
it is a must-not-regress test, not a repro, and the gate's real point was the missing repro
for the SEVERE, which the new test supplies.

**r2 PASS, no findings at any severity.** It walked the single-type truth table against
`4925be7` and confirmed identity, with one intentional exception it named: a comma-free
`PHOTOMAKER` is now accepted where the base could refuse — the intended repair.

## Not in scope

Left unfixed and unclaimed, all pre-existing and separately reported:

* `COMFY_DYNAMICCOMBO_V3` (105 classes, incl. `SaveVideo`), `COMFY_AUTOGROW_V3` (23, #686) —
  genuine V3 widget types that never register. Different defect.
* `LOAD_3D` / `FILE_3D_*` unions (`SaveGaussianSplat`, `Preview3DAdvanced`, …): still fail
  closed because members like `FILE_3D_PLY` are no node's output, so nothing proves them link
  datatypes. Correct under the current rule; these inputs also plausibly *are* frontend
  widgets (the 3D viewport).
* `INT:seed` is not a union and is not touched — it is a real key in ComfyUI's widget registry.

#620 is the same defect class as #695 and is fixed on `main`, but is still open — it likely
needs closing separately (owner-qualified `Closes` refs do not auto-close same-repo issues).

Not merged, per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
