### PR TITLE
fix(panel): keep the backend node definition unmutated across the add-node refresh (#700)

### DIFF
--- a/browser_tests/unit/add-node-upload-widget.test.mjs
+++ b/browser_tests/unit/add-node-upload-widget.test.mjs
@@ -1,0 +1,452 @@
+// #700: panel_add_node("LoadImage") failed with
+//   Required custom widget "upload" did not initialize for "LoadImage".
+//   Reload ComfyUI so its node extension can register, then retry.
+//
+// WHAT THIS FILE PINS, and why it is built the way it is.
+//
+// The report suspected panel_refresh_nodes: that re-registering node defs mints new
+// LiteGraph classes without re-applying the extension hooks, so every node created
+// afterwards permanently lacks the extension's `upload` widget (already-instantiated
+// nodes keep their old constructor, which is why copy/paste still worked). The reporter
+// explicitly flagged that as UNPROVEN.
+//
+// It is DISPROVEN here. The `upload` widget is not missing at all. ComfyUI's own
+// Comfy.UploadImage extension does two things (verified against the shipped
+// comfyui_frontend_package bundle, `useImageUploadWidget`):
+//
+//   1. beforeRegisterNodeDef INJECTS a required input the backend never declares:
+//        required.upload = ["IMAGEUPLOAD", { ...imageConfig, imageInputName }]
+//   2. the IMAGEUPLOAD constructor materializes it as
+//        node.addWidget("button", "upload", "image", cb, { serialize: false, canvasOnly: true })
+//
+// So a healthy, fully-materialized LoadImage ALWAYS carries an `upload` widget whose
+// options.serialize === false — and missingRequiredWidgetMaterializations treats a
+// non-serializing widget for a required input as "did not materialize" (correctly: a
+// canvas-only control cannot carry a required prompt value). Scanning the FRONTEND
+// nodeData therefore reports `upload` every single time, with no refresh involved.
+//
+// The fix for that is already on main (#620/#626): the guards scan the FRESH backend
+// /object_info def, which has no `upload`. What is NOT fixed, and is the live defect
+// this file drives, is that graph_add_node reads that fresh def by REFERENCE out of the
+// same map it hands to app.registerNodesFromDefs — and registerNodesFromDefs passes each
+// def straight to beforeRegisterNodeDef, which mutates it IN PLACE. Once the refresh
+// branch runs (the class is not yet in the LiteGraph registry: a freshly installed pack,
+// or any class registered after page load) the "backend truth" the guard consults has
+// grown a frontend-injected `upload` input, and #700's error comes back.
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+  applyCurrentDefWidgetValues,
+  driftedRequiredInputNames,
+  missingRequiredWidgetMaterializations,
+  registeredSocketTypes,
+  unavailableRequiredCustomWidgetTypes,
+} from "../../web/js/lib/node-widget-materialization.js";
+import { assertAddNodeResolvableRefreshing } from "../../web/js/lib/node-resolve.js";
+import {
+  classifyUnmaterializedWidget,
+  describeUnmaterializedRequiredWidgets,
+  snapshotBackendDef,
+  WIDGET_ABSENT,
+  WIDGET_NON_SERIALIZING,
+} from "../../web/js/lib/add-node-widget-guard.js";
+
+const panelPath = fileURLToPath(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url));
+const panelSrc = readFileSync(panelPath, "utf8");
+
+const addNodeMatch = panelSrc.match(
+  /\n {2}async graph_add_node\(\{ class_type, pos, title \}\) \{[\s\S]*?\n {2}\},/,
+);
+assert.ok(addNodeMatch, "could not locate graph_add_node in panel source");
+
+const awaitWidgetsMatch = panelSrc.match(
+  /\nasync function awaitRequiredCustomWidgetRegistration\([\s\S]*?\n\}/,
+);
+assert.ok(awaitWidgetsMatch, "could not locate awaitRequiredCustomWidgetRegistration");
+
+const placementMatch = panelSrc.match(/\nfunction placementFor\(graph, pos\) \{[\s\S]*?\n\}/);
+assert.ok(placementMatch, "could not locate placementFor");
+
+// ---------------------------------------------------------------------------
+// A ComfyUI double faithful to the parts that decide this bug.
+// ---------------------------------------------------------------------------
+
+/** ComfyUI's Comfy.UploadImage beforeRegisterNodeDef, transcribed from the shipped
+ *  frontend bundle. Note that it mutates the nodeData object it is HANDED. */
+function comfyUploadImageBeforeRegisterNodeDef(_nodeType, nodeData) {
+  const required = nodeData?.input?.required;
+  if (!required) return;
+  const found = Object.entries(required).find(
+    ([, spec]) => Array.isArray(spec) && spec[1] && spec[1].image_upload === true,
+  );
+  if (!found) return;
+  const [imageInputName, spec] = found;
+  required.upload = ["IMAGEUPLOAD", { ...spec[1], imageInputName }];
+}
+
+/** The live /object_info payload. A fresh object every call, exactly like a real fetch. */
+function backendObjectInfo() {
+  return {
+    LoadImage: {
+      name: "LoadImage",
+      input: { required: { image: [["a.png", "b.png"], { image_upload: true }] } },
+      output: ["IMAGE", "MASK"],
+    },
+    PreviewImage: {
+      name: "PreviewImage",
+      input: { required: { images: ["IMAGE", {}] } },
+      output: [],
+    },
+  };
+}
+
+function makeComfy({ preRegistered = ["LoadImage", "PreviewImage"] } = {}) {
+  const widgets = {
+    COMBO(node, name, spec) {
+      return { widget: node.addWidget("combo", name, spec[0][0], null, { values: spec[0] }) };
+    },
+    IMAGEUPLOAD(node, name) {
+      // The shipped constructor: a canvas-only button paired with the real value widget.
+      const widget = node.addWidget("button", name, "image", () => {}, {
+        serialize: false,
+        canvasOnly: true,
+      });
+      widget.label = "choose file to upload";
+      return { widget };
+    },
+  };
+
+  const registry = {};
+  let nextId = 1;
+
+  const LG = {
+    registered_node_types: registry,
+    createNode(type) {
+      const cls = registry[type];
+      if (!cls) return null;
+      const node = {
+        id: nextId++,
+        type,
+        constructor: cls,
+        pos: [0, 0],
+        size: [210, 100],
+        widgets: [],
+        inputs: [],
+        outputs: [],
+        addWidget(kind, name, value, callback, options) {
+          const widget = { type: kind, name, value, callback, options: options ?? {} };
+          node.widgets.push(widget);
+          return widget;
+        },
+      };
+      for (const [name, spec] of Object.entries(cls.nodeData?.input?.required ?? {})) {
+        const declared = Array.isArray(spec) ? spec[0] : null;
+        if (Array.isArray(declared)) widgets.COMBO(node, name, spec);
+        else if (typeof widgets[declared] === "function") widgets[declared](node, name, spec);
+        else node.inputs.push({ name, type: declared });
+      }
+      return node;
+    },
+  };
+
+  const app = {
+    widgets,
+    async registerNodesFromDefs(defs) {
+      for (const [type, nodeData] of Object.entries(defs ?? {})) {
+        const cls = function ComfyNode() {};
+        // ComfyUI hands registerNodeDef the CALLER's def object and lets the extension
+        // hooks mutate it before wrapping it as the class's nodeData.
+        comfyUploadImageBeforeRegisterNodeDef(cls, nodeData);
+        cls.nodeData = nodeData;
+        cls.comfyClass = type;
+        registry[type] = cls;
+      }
+    },
+  };
+
+  // Page load: whatever the tab already registered.
+  const boot = backendObjectInfo();
+  const bootDefs = Object.fromEntries(
+    Object.entries(boot).filter(([type]) => preRegistered.includes(type)),
+  );
+  void app.registerNodesFromDefs(bootDefs);
+
+  const graph = {
+    _nodes: [],
+    add(node) {
+      graph._nodes.push(node);
+    },
+    beforeChange() {},
+    afterChange() {},
+    setDirtyCanvas() {},
+  };
+
+  return { app, LG, graph, registry };
+}
+
+/** Build the SHIPPED graph_add_node with its collaborators injected. */
+function realGraphAddNode(comfy, overrides = {}) {
+  const { app, LG, graph } = comfy;
+  const context = { app, LG, graph, rootGraph: graph, workflow: { uuid: "wf" } };
+
+  const deps = {
+    captureGraphMutationContext: () => context,
+    revalidateGraphMutationContext: () => context,
+    awaitObjectInfoHistorySeed: async () => {},
+    recordObjectInfoTypes: (defs) => defs,
+    objectInfoHistory: { wasTypeEverDefined: () => false },
+    api: { getNodeDefs: async () => backendObjectInfo() },
+    refreshComfyNodeDefs: async (defs) => app.registerNodesFromDefs(defs ?? backendObjectInfo()),
+    summarizeNode: (node) => ({
+      id: node.id,
+      type: node.type,
+      widgets: node.widgets.map((w) => w.name),
+    }),
+    assertAddNodeResolvableRefreshing,
+    driftedRequiredInputNames,
+    registeredSocketTypes,
+    missingRequiredWidgetMaterializations,
+    applyCurrentDefWidgetValues,
+    unavailableRequiredCustomWidgetTypes,
+    snapshotBackendDef,
+    describeUnmaterializedRequiredWidgets,
+    ...overrides,
+  };
+
+  const names = Object.keys(deps);
+  const factory = new Function(
+    ...names,
+    `${awaitWidgetsMatch[0]}
+     ${placementMatch[0]}
+     const CUSTOM_WIDGET_REGISTRATION_TIMEOUT_MS = 200;
+     const CUSTOM_WIDGET_REGISTRATION_POLL_MS = 5;
+     const executors = {${addNodeMatch[0]}};
+     return executors.graph_add_node;`,
+  );
+  return factory(...names.map((n) => deps[n]));
+}
+
+// ---------------------------------------------------------------------------
+// 1. Disproof of the refresh hypothesis + proof of the real mechanism.
+// ---------------------------------------------------------------------------
+
+test("#700 mechanism: a HEALTHY LoadImage always trips the frontend-nodeData scan, no refresh involved", () => {
+  // No panel_refresh_nodes anywhere in this test — just page-load registration.
+  const comfy = makeComfy();
+  const node = comfy.LG.createNode("LoadImage");
+
+  // The node is perfectly healthy: it has BOTH widgets, the upload button included.
+  assert.deepEqual(
+    node.widgets.map((w) => w.name),
+    ["image", "upload"],
+  );
+  const upload = node.widgets.find((w) => w.name === "upload");
+  assert.equal(upload.options.serialize, false, "ComfyUI builds the upload button canvas-only");
+
+  // Yet the pre-#620 two-argument call — which scans the FRONTEND nodeData, where
+  // beforeRegisterNodeDef injected `upload` — reports it missing. Deterministically,
+  // on a freshly booted tab. That is #700's error, and nothing refreshed anything.
+  assert.deepEqual(
+    missingRequiredWidgetMaterializations(node, comfy.app.widgets),
+    ["upload"],
+    "the frontend nodeData alone cannot decide this: it carries an injected canvas-only input",
+  );
+
+  // The fresh BACKEND def never declares `upload`, so scanning it clears the guard.
+  assert.deepEqual(
+    missingRequiredWidgetMaterializations(node, comfy.app.widgets, backendObjectInfo().LoadImage),
+    [],
+  );
+});
+
+test("#700 asymmetry: a created LoadImage and a cloned one carry the SAME widgets", () => {
+  // The report inferred a class-vs-instance divergence from panel_copy_nodes working.
+  // There is none — clone and create produce identical widget sets; only the GUARD
+  // differed, because the paste path never runs it.
+  const comfy = makeComfy();
+  const created = comfy.LG.createNode("LoadImage");
+  const cloneSource = comfy.LG.createNode("LoadImage");
+  const cloned = { ...cloneSource, widgets: cloneSource.widgets.map((w) => ({ ...w })) };
+
+  assert.deepEqual(
+    created.widgets.map((w) => [w.name, w.type, w.options.serialize]),
+    cloned.widgets.map((w) => [w.name, w.type, w.options.serialize]),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 2. The live defect on the shipped add path.
+// ---------------------------------------------------------------------------
+
+test("#700: add LoadImage on a tab that already registered it (the reported scenario)", async () => {
+  const comfy = makeComfy();
+  const graph_add_node = realGraphAddNode(comfy);
+  const { added } = await graph_add_node({ class_type: "LoadImage" });
+  assert.deepEqual(added.widgets, ["image", "upload"]);
+});
+
+test("#700: add LoadImage when the class is NOT yet registered — registerNodesFromDefs must not poison the backend def", async () => {
+  // A pack installed after page load: the resolver refreshes to register the class,
+  // and that refresh hands graph_add_node's own /object_info map to
+  // registerNodesFromDefs, whose beforeRegisterNodeDef injects `upload` into it in
+  // place. If the guard then reads that same object as "the backend's current truth"
+  // it sees a required `upload`, finds only the canvas-only button, and reports #700.
+  const comfy = makeComfy({ preRegistered: ["PreviewImage"] });
+  const graph_add_node = realGraphAddNode(comfy);
+  const { added } = await graph_add_node({ class_type: "LoadImage" });
+  assert.deepEqual(added.widgets, ["image", "upload"]);
+});
+
+test("#700: the fetched /object_info map really IS mutated by the refresh — the snapshot is what saves the add", async () => {
+  // Without this the test above could pass for the wrong reason (a double that simply
+  // never pollutes). Hold on to the exact object api.getNodeDefs handed back and show
+  // that registerNodesFromDefs grew an `upload` requirement on it — the poison the
+  // snapshot is taken to escape.
+  const comfy = makeComfy({ preRegistered: ["PreviewImage"] });
+  const handedOut = [];
+  const graph_add_node = realGraphAddNode(comfy, {
+    api: {
+      getNodeDefs: async () => {
+        const defs = backendObjectInfo();
+        handedOut.push(defs);
+        return defs;
+      },
+    },
+  });
+
+  await graph_add_node({ class_type: "LoadImage" });
+
+  assert.equal(handedOut.length, 1);
+  assert.ok(
+    "upload" in handedOut[0].LoadImage.input.required,
+    "the fetched def must still be poisoned in place — otherwise this test proves nothing",
+  );
+});
+
+test("#700: repeated adds after the registering refresh stay clean", async () => {
+  const comfy = makeComfy({ preRegistered: ["PreviewImage"] });
+  const graph_add_node = realGraphAddNode(comfy);
+  await graph_add_node({ class_type: "LoadImage" });
+  const { added } = await graph_add_node({ class_type: "LoadImage" });
+  assert.deepEqual(added.widgets, ["image", "upload"]);
+});
+
+test("a genuinely unmaterialized BACKEND-required widget is still refused", async () => {
+  // The guard must keep failing closed: #580's bad prompt is the reason it exists.
+  const comfy = makeComfy();
+  const brokenDefs = () => ({
+    ...backendObjectInfo(),
+    BrokenNode: {
+      name: "BrokenNode",
+      input: { required: { amount: ["INT", { default: 1 }] } },
+      output: [],
+    },
+  });
+  const graph_add_node = realGraphAddNode(comfy, {
+    api: { getNodeDefs: async () => brokenDefs() },
+    refreshComfyNodeDefs: async (defs) => comfy.app.registerNodesFromDefs(defs ?? brokenDefs()),
+  });
+  // INT has a registered constructor, but this double materializes no INT widget.
+  comfy.app.widgets.INT = () => undefined;
+  await assert.rejects(
+    () => graph_add_node({ class_type: "BrokenNode" }),
+    (err) => {
+      assert.match(err.message, /Cannot add "BrokenNode"/);
+      assert.match(err.message, /required input "amount" was not built onto the node/);
+      assert.match(err.message, /Nothing was added\./);
+      assert.match(err.message, /Reload the ComfyUI tab/);
+      return true;
+    },
+  );
+  assert.equal(comfy.graph._nodes.length, 0, "the refusal must not have added anything");
+});
+
+// ---------------------------------------------------------------------------
+// 3. The snapshot, in isolation.
+// ---------------------------------------------------------------------------
+
+test("snapshotBackendDef survives an in-place rewrite of the map it came from", () => {
+  const defs = backendObjectInfo();
+  const snapshot = snapshotBackendDef(defs, "LoadImage");
+
+  // Exactly what ComfyUI's beforeRegisterNodeDef does to the def it is handed.
+  comfyUploadImageBeforeRegisterNodeDef(function ComfyNode() {}, defs.LoadImage);
+  defs.LoadImage.input.required.image[1].image_upload = false;
+  defs.LoadImage.input.required.image[0].push("mutated.png");
+
+  assert.deepEqual(Object.keys(snapshot.input.required), ["image"]);
+  assert.equal(snapshot.input.required.image[1].image_upload, true);
+  assert.deepEqual(snapshot.input.required.image[0], ["a.png", "b.png"]);
+});
+
+test("snapshotBackendDef reports no def for a type the backend does not define", () => {
+  // The frontend-only exemption (Note / Reroute / …). `undefined` is what makes the
+  // guards fall back to scanning the registered node data, so it must not become {}.
+  assert.equal(snapshotBackendDef(backendObjectInfo(), "MarkdownNote"), undefined);
+  assert.equal(snapshotBackendDef(null, "LoadImage"), undefined);
+  assert.equal(snapshotBackendDef(backendObjectInfo(), undefined), undefined);
+  assert.equal(snapshotBackendDef({ Weird: null }, "Weird"), undefined);
+});
+
+// ---------------------------------------------------------------------------
+// 4. The refusal message.
+// ---------------------------------------------------------------------------
+
+test("#700: the refusal names the condition that held and never claims a registration failure", () => {
+  const absentOnly = describeUnmaterializedRequiredWidgets(
+    "BrokenNode",
+    { widgets: [] },
+    ["amount"],
+  );
+  assert.match(absentOnly, /required input "amount" was not built onto the node/);
+  assert.match(absentOnly, /Reload the ComfyUI tab/);
+
+  const canvasOnly = describeUnmaterializedRequiredWidgets(
+    "ZipnStyler",
+    { widgets: [{ name: "gallery", options: { serialize: false, canvasOnly: true } }] },
+    ["gallery"],
+  );
+  assert.match(canvasOnly, /required input "gallery" is present but canvas-only/);
+  assert.match(canvasOnly, /extension IS registered, so reloading is unlikely to help/);
+  assert.match(canvasOnly, /Update the node's pack/);
+
+  const mixed = describeUnmaterializedRequiredWidgets(
+    "HalfBroken",
+    { widgets: [{ name: "gallery", options: { serialize: false } }] },
+    ["amount", "gallery"],
+  );
+  assert.match(mixed, /"amount" was not built onto the node/);
+  assert.match(mixed, /"gallery" is present but canvas-only/);
+  assert.match(mixed, /if that does not clear it/);
+
+  // The claim that misdirected #700 for ~90 tool calls must not survive anywhere.
+  for (const message of [absentOnly, canvasOnly, mixed]) {
+    assert.doesNotMatch(message, /did not initialize/);
+    assert.doesNotMatch(message, /so its node extension can register/);
+    assert.match(message, /Nothing was added\./);
+  }
+});
+
+test("#700: the refusal pluralizes without lying about how many inputs it saw", () => {
+  const two = describeUnmaterializedRequiredWidgets("N", { widgets: [] }, ["a", "b"]);
+  assert.match(two, /required inputs "a", "b" were not built onto the node/);
+  assert.match(two, /constructor for their type is registered/);
+
+  const twoCanvas = describeUnmaterializedRequiredWidgets(
+    "N",
+    { widgets: [{ name: "a" }, { name: "b" }] },
+    ["a", "b"],
+  );
+  assert.match(twoCanvas, /required inputs "a", "b" are present but canvas-only/);
+  assert.match(twoCanvas, /would omit them/);
+});
+
+test("classifyUnmaterializedWidget distinguishes the two faults", () => {
+  const node = { widgets: [{ name: "upload", options: { serialize: false } }] };
+  assert.equal(classifyUnmaterializedWidget(node, "upload"), WIDGET_NON_SERIALIZING);
+  assert.equal(classifyUnmaterializedWidget(node, "image"), WIDGET_ABSENT);
+  assert.equal(classifyUnmaterializedWidget(undefined, "image"), WIDGET_ABSENT);
+});

--- a/browser_tests/unit/add-node-upload-widget.test.mjs
+++ b/browser_tests/unit/add-node-upload-widget.test.mjs
@@ -43,7 +43,8 @@ import {
   driftedRequiredInputNames,
   missingRequiredWidgetMaterializations,
   registeredSocketTypes,
-  unavailableRequiredCustomWidgetTypes,
+  unavailableRequiredWidgetMessage,
+  unavailableRequiredWidgetReport,
 } from "../../web/js/lib/node-widget-materialization.js";
 import { assertAddNodeResolvableRefreshing } from "../../web/js/lib/node-resolve.js";
 import {
@@ -210,7 +211,8 @@ function realGraphAddNode(comfy, overrides = {}) {
     registeredSocketTypes,
     missingRequiredWidgetMaterializations,
     applyCurrentDefWidgetValues,
-    unavailableRequiredCustomWidgetTypes,
+    unavailableRequiredWidgetReport,
+    unavailableRequiredWidgetMessage,
     snapshotBackendDef,
     describeUnmaterializedRequiredWidgets,
     ...overrides,

--- a/browser_tests/unit/add-node-upload-widget.test.mjs
+++ b/browser_tests/unit/add-node-upload-widget.test.mjs
@@ -433,8 +433,8 @@ test("#700: the refusal names the condition that held and never claims a registr
     ["gallery"],
   );
   assert.match(nonSerializing, /required input "gallery" is present but does not serialize a value/);
-  assert.match(nonSerializing, /widget constructor IS registered/);
-  assert.match(nonSerializing, /update the node's pack/);
+  assert.match(nonSerializing, /not a widget-registration failure/);
+  assert.match(nonSerializing, /its pack needs updating/);
 
   const mixed = describeUnmaterializedRequiredWidgets(
     "HalfBroken",
@@ -443,7 +443,7 @@ test("#700: the refusal names the condition that held and never claims a registr
   );
   assert.match(mixed, /"amount" was not built onto the node/);
   assert.match(mixed, /"gallery" is present but does not serialize a value/);
-  assert.match(mixed, /if that does not clear it/);
+  assert.match(mixed, /If it still fails/);
 
   // The claim that misdirected #700 for ~90 tool calls must not survive anywhere.
   for (const message of [absentOnly, nonSerializing, mixed]) {
@@ -451,6 +451,31 @@ test("#700: the refusal names the condition that held and never claims a registr
     assert.doesNotMatch(message, /so its node extension can register/);
     assert.match(message, /Nothing was added\./);
   }
+});
+
+test("#700: the remedy asserts no mechanism the guard cannot see", () => {
+  // codex gate r2 P2. Two drafts named a cause and both were falsifiable:
+  //  - "reload so the node's EXTENSION re-runs" is wrong for a core/built-in widget,
+  //    which has no node extension behind it; and
+  //  - "reloading helps ONLY IF the pack's frontend changed on disk" is wrong for a
+  //    constructor that reads a mutable setting, where changing it and reloading works.
+  // The only causal claim left is the one the caller proved, and only where it applies.
+  const absentOnly = describeUnmaterializedRequiredWidgets("N", { widgets: [] }, ["amount"]);
+  const present = describeUnmaterializedRequiredWidgets(
+    "N",
+    { widgets: [{ name: "amount", options: { serialize: false } }] },
+    ["amount"],
+  );
+
+  for (const message of [absentOnly, present]) {
+    assert.doesNotMatch(message, /extension re-runs/);
+    assert.doesNotMatch(message, /on disk/);
+    assert.doesNotMatch(message, /only if/i);
+    assert.match(message, /Reload the ComfyUI tab so this node type is registered again/);
+  }
+  // The registration claim is made ONLY where the widget was observed on the node.
+  assert.doesNotMatch(absentOnly, /not a widget-registration failure/);
+  assert.match(present, /not a widget-registration failure/);
 });
 
 test("#700: the refusal describes only the flag the guard actually reads", () => {

--- a/browser_tests/unit/add-node-upload-widget.test.mjs
+++ b/browser_tests/unit/add-node-upload-widget.test.mjs
@@ -382,6 +382,27 @@ test("snapshotBackendDef survives an in-place rewrite of the map it came from", 
   assert.deepEqual(snapshot.input.required.image[0], ["a.png", "b.png"]);
 });
 
+test("snapshotBackendDef keeps a required input literally named __proto__", () => {
+  // JSON.parse hands `__proto__` back as an OWN data property, so /object_info can carry
+  // one. A plain `copy[key] = …` would run Object.prototype's setter: the entry vanishes
+  // from the snapshot and the guards silently stop checking that required input — a
+  // fail-OPEN, the one direction this must never break in (codex gate r1 P1).
+  const defs = JSON.parse('{"Odd":{"input":{"required":{"__proto__":["INT",{"default":3}]}}}}');
+  const snapshot = snapshotBackendDef(defs, "Odd");
+
+  const required = snapshot.input.required;
+  assert.ok(Object.prototype.hasOwnProperty.call(required, "__proto__"));
+  assert.deepEqual(Object.keys(required), ["__proto__"]);
+  assert.deepEqual(Object.entries(required)[0][1], ["INT", { default: 3 }]);
+  assert.equal(Object.getPrototypeOf(required), Object.prototype, "must not be re-parented");
+
+  // …and the guard therefore still sees it as a required input to check.
+  assert.deepEqual(
+    missingRequiredWidgetMaterializations({ widgets: [] }, { INT: () => {} }, snapshot),
+    ["__proto__"],
+  );
+});
+
 test("snapshotBackendDef reports no def for a type the backend does not define", () => {
   // The frontend-only exemption (Note / Reroute / …). `undefined` is what makes the
   // guards fall back to scanning the registered node data, so it must not become {}.
@@ -404,14 +425,14 @@ test("#700: the refusal names the condition that held and never claims a registr
   assert.match(absentOnly, /required input "amount" was not built onto the node/);
   assert.match(absentOnly, /Reload the ComfyUI tab/);
 
-  const canvasOnly = describeUnmaterializedRequiredWidgets(
+  const nonSerializing = describeUnmaterializedRequiredWidgets(
     "ZipnStyler",
     { widgets: [{ name: "gallery", options: { serialize: false, canvasOnly: true } }] },
     ["gallery"],
   );
-  assert.match(canvasOnly, /required input "gallery" is present but canvas-only/);
-  assert.match(canvasOnly, /extension IS registered, so reloading is unlikely to help/);
-  assert.match(canvasOnly, /Update the node's pack/);
+  assert.match(nonSerializing, /required input "gallery" is present but does not serialize a value/);
+  assert.match(nonSerializing, /widget constructor IS registered/);
+  assert.match(nonSerializing, /update the node's pack/);
 
   const mixed = describeUnmaterializedRequiredWidgets(
     "HalfBroken",
@@ -419,15 +440,30 @@ test("#700: the refusal names the condition that held and never claims a registr
     ["amount", "gallery"],
   );
   assert.match(mixed, /"amount" was not built onto the node/);
-  assert.match(mixed, /"gallery" is present but canvas-only/);
+  assert.match(mixed, /"gallery" is present but does not serialize a value/);
   assert.match(mixed, /if that does not clear it/);
 
   // The claim that misdirected #700 for ~90 tool calls must not survive anywhere.
-  for (const message of [absentOnly, canvasOnly, mixed]) {
+  for (const message of [absentOnly, nonSerializing, mixed]) {
     assert.doesNotMatch(message, /did not initialize/);
     assert.doesNotMatch(message, /so its node extension can register/);
     assert.match(message, /Nothing was added\./);
   }
+});
+
+test("#700: the refusal describes only the flag the guard actually reads", () => {
+  // The guard's condition is `widget.options?.serialize === false` — it never consults
+  // `canvasOnly`. A widget carrying serialize:false WITHOUT canvasOnly is a reachable
+  // refusal, so the message must not assert a canvas-only state it did not observe
+  // (codex gate r1 P2).
+  const message = describeUnmaterializedRequiredWidgets(
+    "SomePack",
+    { widgets: [{ name: "gallery", options: { serialize: false } }] },
+    ["gallery"],
+  );
+  assert.match(message, /does not serialize a value \(serialize:false\)/);
+  assert.doesNotMatch(message, /canvas-only/);
+  assert.doesNotMatch(message, /canvasOnly/);
 });
 
 test("#700: the refusal pluralizes without lying about how many inputs it saw", () => {
@@ -435,13 +471,13 @@ test("#700: the refusal pluralizes without lying about how many inputs it saw", 
   assert.match(two, /required inputs "a", "b" were not built onto the node/);
   assert.match(two, /constructor for their type is registered/);
 
-  const twoCanvas = describeUnmaterializedRequiredWidgets(
+  const twoPresent = describeUnmaterializedRequiredWidgets(
     "N",
     { widgets: [{ name: "a" }, { name: "b" }] },
     ["a", "b"],
   );
-  assert.match(twoCanvas, /required inputs "a", "b" are present but canvas-only/);
-  assert.match(twoCanvas, /would omit them/);
+  assert.match(twoPresent, /required inputs "a", "b" are present but do not serialize a value/);
+  assert.match(twoPresent, /would omit them/);
 });
 
 test("classifyUnmaterializedWidget distinguishes the two faults", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -223,6 +223,10 @@ import {
   unavailableRequiredWidgetMessage,
   unavailableRequiredWidgetReport,
 } from "./lib/node-widget-materialization.js";
+import {
+  describeUnmaterializedRequiredWidgets,
+  snapshotBackendDef,
+} from "./lib/add-node-widget-guard.js";
 import { sameGraphMutationContext } from "./lib/graph-mutation-context.js";
 import { isImeComposing } from "./lib/ime.js";
 import { installGraphToPromptNullSafety } from "./lib/widget-null-safety.js";
@@ -8335,17 +8339,29 @@ const GRAPH_TOOL_EXECUTORS = {
     // guarded, and inputs the backend added since page load are still seen.
     // `undefined` when the type is a frontend-only exemption (no backend def
     // exists), which falls back to scanning the registered node data.
+    //
+    // #700: it is a SNAPSHOT, taken the instant the payload lands, and NOT a reference
+    // into freshDefs. `refresh` below hands that same map to app.registerNodesFromDefs,
+    // which passes every def STRAIGHT to the extensions' beforeRegisterNodeDef — and
+    // ComfyUI's own Comfy.UploadImage hook mutates it in place, adding an `upload` input
+    // the backend never declared whose only possible widget is canvas-only. Read back
+    // afterwards, "the backend's current truth" would require a prompt value that no
+    // backend ever asked for, and the guard below would refuse every image/video/audio
+    // upload loader whose class the refresh had just registered.
     let freshDefs = null;
+    let currentDef;
     await assertAddNodeResolvableRefreshing(() => LG?.registered_node_types ?? {}, class_type, {
-      getFreshObjectInfo: async () =>
-        (freshDefs = recordObjectInfoTypes(
+      getFreshObjectInfo: async () => {
+        freshDefs = recordObjectInfoTypes(
           typeof api?.getNodeDefs === "function" ? await api.getNodeDefs() : null,
-        )),
+        );
+        currentDef = snapshotBackendDef(freshDefs, class_type);
+        return freshDefs;
+      },
       refresh: (defs) => refreshComfyNodeDefs(defs),
       // #458 OBSERVED-BACKEND-HISTORY trust root, identical to graph_set_widget's.
       wasTypeEverDefined: (t) => objectInfoHistory.wasTypeEverDefined(t),
     });
-    const currentDef = freshDefs?.[class_type] ?? undefined;
     const nodeData = LG?.registered_node_types?.[class_type]?.nodeData;
     // A pack upgraded mid-session can add required inputs to an ALREADY
     // registered class; the resolver only refreshes absent classes, so
@@ -8388,11 +8404,11 @@ const GRAPH_TOOL_EXECUTORS = {
       currentDef,
     );
     if (missingWidgets.length) {
-      throw new Error(
-        `Required custom widget${missingWidgets.length === 1 ? "" : "s"} ` +
-          `${missingWidgets.map((name) => `"${name}"`).join(", ")} did not initialize for ` +
-          `"${class_type}". Reload ComfyUI so its node extension can register, then retry.`,
-      );
+      // #700: report the condition that ACTUALLY held. The old wording asserted the
+      // extension had failed to register — which awaitRequiredCustomWidgetRegistration
+      // above had just disproven — and sent the reporter looking there for ~90 tool
+      // calls while the widget in question was sitting on the node the whole time.
+      throw new Error(describeUnmaterializedRequiredWidgets(class_type, node, missingWidgets));
     }
     // LG.createNode built this from the REGISTERED nodeData, which is refreshed only for
     // ABSENT classes — so a pack upgraded mid-session leaves the node holding the OLD

--- a/web/js/lib/add-node-widget-guard.js
+++ b/web/js/lib/add-node-widget-guard.js
@@ -31,7 +31,19 @@ function cloneDefValue(value) {
     const proto = Object.getPrototypeOf(value);
     if (proto !== Object.prototype && proto !== null) return value;
     const copy = {};
-    for (const [key, inner] of Object.entries(value)) copy[key] = cloneDefValue(inner);
+    for (const [key, inner] of Object.entries(value)) {
+      // defineProperty, not `copy[key] = …`: JSON.parse gives `__proto__` as an OWN data
+      // property, and a plain assignment to that name runs Object.prototype's setter — it
+      // would silently DROP the entry from the snapshot (and re-parent the clone). A
+      // required input the snapshot loses is a required input the guards stop checking,
+      // which is the one direction this module must never fail in.
+      Object.defineProperty(copy, key, {
+        value: cloneDefValue(inner),
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+    }
     return copy;
   }
   return value;
@@ -66,7 +78,7 @@ export function snapshotBackendDef(defs, classType) {
 
 /** The required input was never built onto the node at all. */
 export const WIDGET_ABSENT = "absent";
-/** The widget IS on the node, but it is canvas-only: it serializes no prompt value. */
+/** The widget IS on the node, but it serializes no prompt value (options.serialize:false). */
 export const WIDGET_NON_SERIALIZING = "non-serializing";
 
 /**
@@ -105,7 +117,7 @@ function quoteNames(names) {
 export function describeUnmaterializedRequiredWidgets(classType, node, names) {
   const list = Array.isArray(names) ? names : [];
   const absent = list.filter((name) => classifyUnmaterializedWidget(node, name) === WIDGET_ABSENT);
-  const canvasOnly = list.filter(
+  const nonSerializing = list.filter(
     (name) => classifyUnmaterializedWidget(node, name) === WIDGET_NON_SERIALIZING,
   );
 
@@ -117,25 +129,32 @@ export function describeUnmaterializedRequiredWidgets(classType, node, names) {
         `constructor for ${absent.length === 1 ? "its" : "their"} type is registered`,
     );
   }
-  if (canvasOnly.length) {
+  if (nonSerializing.length) {
+    // State the flag that was actually read (options.serialize === false) and nothing
+    // more. An earlier draft called these widgets "canvas-only", which the guard never
+    // checks — a widget can carry serialize:false without canvasOnly, and describing a
+    // state the code did not observe is the same fault this message exists to correct.
     findings.push(
-      `required input${canvasOnly.length === 1 ? "" : "s"} ${quoteNames(canvasOnly)} ` +
-        `${canvasOnly.length === 1 ? "is" : "are"} present but canvas-only (serialize:false), ` +
-        `so a queued prompt would omit ${canvasOnly.length === 1 ? "it" : "them"}`,
+      `required input${nonSerializing.length === 1 ? "" : "s"} ${quoteNames(nonSerializing)} ` +
+        `${nonSerializing.length === 1 ? "is" : "are"} present but ` +
+        `${nonSerializing.length === 1 ? "does" : "do"} not serialize a value ` +
+        `(serialize:false), so a queued prompt would omit ` +
+        `${nonSerializing.length === 1 ? "it" : "them"}`,
     );
   }
 
   let remedy;
-  if (absent.length && canvasOnly.length) {
+  if (absent.length && nonSerializing.length) {
     remedy =
       "Reload the ComfyUI tab so the node's extension re-runs against the current definition; " +
       "if that does not clear it, this node's frontend and backend definitions disagree and its " +
       "pack needs updating.";
-  } else if (canvasOnly.length) {
+  } else if (nonSerializing.length) {
     remedy =
-      "The node's extension IS registered, so reloading is unlikely to help: its frontend " +
-      "definition disagrees with the backend definition that requires the input. Update the " +
-      "node's pack (or report it to the pack author), then retry.";
+      "The widget constructor IS registered, so this is the node's frontend definition " +
+      "disagreeing with the backend definition that requires the input, not a registration " +
+      "failure. Reloading the ComfyUI tab helps only if the pack's frontend changed on disk " +
+      "since this tab loaded; otherwise update the node's pack or report it to its author.";
   } else {
     remedy =
       "Reload the ComfyUI tab so the node's extension re-runs against the current definition, " +

--- a/web/js/lib/add-node-widget-guard.js
+++ b/web/js/lib/add-node-widget-guard.js
@@ -1,0 +1,146 @@
+// The two things graph_add_node's post-create widget guard needs in order to be HONEST
+// about what it actually observed (#700): a backend definition nothing has been allowed
+// to rewrite, and a diagnosis that matches the condition that really held.
+//
+// #700 BACKGROUND. ComfyUI's core Comfy.UploadImage extension registers a
+// `beforeRegisterNodeDef` hook that INJECTS a required input the backend never declares:
+//
+//   required.upload = ["IMAGEUPLOAD", { ...imageConfig, imageInputName }]
+//
+// and its IMAGEUPLOAD constructor materializes that input as
+//
+//   node.addWidget("button", "upload", "image", cb, { serialize: false, canvasOnly: true })
+//
+// A perfectly healthy LoadImage therefore ALWAYS carries an `upload` widget that does not
+// serialize — which is exactly the shape the materialization guard treats as "did not
+// materialize", because for a genuinely BACKEND-required input a canvas-only control
+// cannot carry the prompt value (#580). The guards resolve this by scanning the FRESH
+// backend /object_info definition, where `upload` simply does not exist (#620/#626).
+//
+// That only works while the fetched definition still says what the backend said.
+
+/**
+ * Deep copy of the JSON-shaped values /object_info returns. Anything that is not a plain
+ * object or an array is passed through by identity — the payload is parsed JSON, so that
+ * only ever covers primitives, and copying by reference is the safe default for a value
+ * this module does not understand.
+ */
+function cloneDefValue(value) {
+  if (Array.isArray(value)) return value.map(cloneDefValue);
+  if (value && typeof value === "object") {
+    const proto = Object.getPrototypeOf(value);
+    if (proto !== Object.prototype && proto !== null) return value;
+    const copy = {};
+    for (const [key, inner] of Object.entries(value)) copy[key] = cloneDefValue(inner);
+    return copy;
+  }
+  return value;
+}
+
+/**
+ * The backend's OWN definition of `classType`, detached from the /object_info map it came
+ * out of.
+ *
+ * This must be a SNAPSHOT, never a reference (#700). graph_add_node hands the very map it
+ * fetched to `refresh` → app.registerNodesFromDefs, and ComfyUI passes each def object
+ * STRAIGHT to the extensions' beforeRegisterNodeDef, which mutate it IN PLACE (verified
+ * against the shipped frontend: `registerNodeDef(t, n)` invokes the hooks on `n` and only
+ * then wraps it as the class's nodeData). Reading the def back afterwards no longer yields
+ * the backend's requirements — it yields the backend's requirements plus whatever the
+ * frontend injected. For any image/video/audio-upload loader that means an `upload` input
+ * the backend never required, whose only possible widget is canvas-only, so the post-create
+ * guard refuses a node it just built correctly, with a message blaming the extension
+ * registration that in fact succeeded.
+ *
+ * Take it the instant the payload arrives and before anything can register from it.
+ * Returns `undefined` when the map has no entry for the type — the frontend-only exemption
+ * (Note/Reroute/…), where there is no backend definition to consult and the guards
+ * correctly fall back to scanning the registered node data.
+ */
+export function snapshotBackendDef(defs, classType) {
+  if (!defs || typeof defs !== "object") return undefined;
+  if (typeof classType !== "string") return undefined;
+  if (!Object.prototype.hasOwnProperty.call(defs, classType)) return undefined;
+  return cloneDefValue(defs[classType]) ?? undefined;
+}
+
+/** The required input was never built onto the node at all. */
+export const WIDGET_ABSENT = "absent";
+/** The widget IS on the node, but it is canvas-only: it serializes no prompt value. */
+export const WIDGET_NON_SERIALIZING = "non-serializing";
+
+/**
+ * Which of the two conditions the materialization guard reports actually held for `name`.
+ * They are different faults with different remedies, and the pre-#700 message asserted the
+ * first one unconditionally.
+ */
+export function classifyUnmaterializedWidget(node, name) {
+  const widgets = Array.isArray(node?.widgets) ? node.widgets : [];
+  const widget = widgets.find((candidate) => candidate?.name === name);
+  return widget ? WIDGET_NON_SERIALIZING : WIDGET_ABSENT;
+}
+
+function quoteNames(names) {
+  return names.map((name) => `"${name}"`).join(", ");
+}
+
+/**
+ * The refusal graph_add_node raises when a required input has no usable widget on the node
+ * it just created.
+ *
+ * The message this replaced said, for every case:
+ *
+ *   Required custom widget "upload" did not initialize for "LoadImage".
+ *   Reload ComfyUI so its node extension can register, then retry.
+ *
+ * Both halves could be false at once. The widget had initialized — it was sitting on the
+ * node — and the extension had registered; the caller's own preflight
+ * (awaitRequiredCustomWidgetRegistration) had just PROVEN the constructor was present, so
+ * the guard was recommending a reload to fix something it knew was not broken. #700 was
+ * filed after ~90 tool calls spent investigating extension registration on that advice.
+ *
+ * So: say which condition held, say that nothing was added, and only recommend a reload
+ * where a reload is the thing that could plausibly change the outcome.
+ */
+export function describeUnmaterializedRequiredWidgets(classType, node, names) {
+  const list = Array.isArray(names) ? names : [];
+  const absent = list.filter((name) => classifyUnmaterializedWidget(node, name) === WIDGET_ABSENT);
+  const canvasOnly = list.filter(
+    (name) => classifyUnmaterializedWidget(node, name) === WIDGET_NON_SERIALIZING,
+  );
+
+  const findings = [];
+  if (absent.length) {
+    findings.push(
+      `required input${absent.length === 1 ? "" : "s"} ${quoteNames(absent)} ` +
+        `${absent.length === 1 ? "was" : "were"} not built onto the node, even though a widget ` +
+        `constructor for ${absent.length === 1 ? "its" : "their"} type is registered`,
+    );
+  }
+  if (canvasOnly.length) {
+    findings.push(
+      `required input${canvasOnly.length === 1 ? "" : "s"} ${quoteNames(canvasOnly)} ` +
+        `${canvasOnly.length === 1 ? "is" : "are"} present but canvas-only (serialize:false), ` +
+        `so a queued prompt would omit ${canvasOnly.length === 1 ? "it" : "them"}`,
+    );
+  }
+
+  let remedy;
+  if (absent.length && canvasOnly.length) {
+    remedy =
+      "Reload the ComfyUI tab so the node's extension re-runs against the current definition; " +
+      "if that does not clear it, this node's frontend and backend definitions disagree and its " +
+      "pack needs updating.";
+  } else if (canvasOnly.length) {
+    remedy =
+      "The node's extension IS registered, so reloading is unlikely to help: its frontend " +
+      "definition disagrees with the backend definition that requires the input. Update the " +
+      "node's pack (or report it to the pack author), then retry.";
+  } else {
+    remedy =
+      "Reload the ComfyUI tab so the node's extension re-runs against the current definition, " +
+      "then retry.";
+  }
+
+  return `Cannot add "${classType}": ${findings.join("; and ")}. Nothing was added. ${remedy}`;
+}

--- a/web/js/lib/add-node-widget-guard.js
+++ b/web/js/lib/add-node-widget-guard.js
@@ -111,8 +111,16 @@ function quoteNames(names) {
  * the guard was recommending a reload to fix something it knew was not broken. #700 was
  * filed after ~90 tool calls spent investigating extension registration on that advice.
  *
- * So: say which condition held, say that nothing was added, and only recommend a reload
- * where a reload is the thing that could plausibly change the outcome.
+ * So: say which condition held, say that nothing was added, and let the remedy assert
+ * nothing about WHY beyond what was observed.
+ *
+ * The remedy is deliberately mechanism-free (codex gate r2 P2). Two earlier drafts named
+ * a cause and both were falsifiable: "reload so the node's extension re-runs" misdescribes
+ * a core/built-in widget that has no node extension behind it, and "reloading helps only
+ * if the pack's frontend changed on disk" is wrong for a constructor that reads a mutable
+ * setting, where changing the setting and reloading does fix it. The one causal claim left
+ * is the one the caller PROVED — the constructor is registered — and it is made only in
+ * the branch where the widget was also observed on the node.
  */
 export function describeUnmaterializedRequiredWidgets(classType, node, names) {
   const list = Array.isArray(names) ? names : [];
@@ -143,23 +151,20 @@ export function describeUnmaterializedRequiredWidgets(classType, node, names) {
     );
   }
 
-  let remedy;
-  if (absent.length && nonSerializing.length) {
-    remedy =
-      "Reload the ComfyUI tab so the node's extension re-runs against the current definition; " +
-      "if that does not clear it, this node's frontend and backend definitions disagree and its " +
-      "pack needs updating.";
-  } else if (nonSerializing.length) {
-    remedy =
-      "The widget constructor IS registered, so this is the node's frontend definition " +
-      "disagreeing with the backend definition that requires the input, not a registration " +
-      "failure. Reloading the ComfyUI tab helps only if the pack's frontend changed on disk " +
-      "since this tab loaded; otherwise update the node's pack or report it to its author.";
-  } else {
-    remedy =
-      "Reload the ComfyUI tab so the node's extension re-runs against the current definition, " +
-      "then retry.";
-  }
+  // Stated only where the widget was actually SEEN on the node, which is exactly where it
+  // is provable — and it is the correction #700 needs, because the old message asserted
+  // the opposite of it.
+  const notARegistrationFailure = nonSerializing.length
+    ? "The widget constructor is registered and the widget was built, so this is not a " +
+      "widget-registration failure. "
+    : "";
+  const remedy =
+    "Reload the ComfyUI tab so this node type is registered again from the current " +
+    "definition, then retry. If it still fails, this node's frontend and backend " +
+    "definitions disagree and its pack needs updating (or its author needs to hear about it).";
 
-  return `Cannot add "${classType}": ${findings.join("; and ")}. Nothing was added. ${remedy}`;
+  return (
+    `Cannot add "${classType}": ${findings.join("; and ")}. Nothing was added. ` +
+    `${notARegistrationFailure}${remedy}`
+  );
 }


### PR DESCRIPTION
Fixes artokun/comfyui-mcp-panel#700. Also the live half of artokun/comfyui-mcp-panel#620 (its part B — see below).

## The hypothesis in #700 is disproven

The report suspected `panel_refresh_nodes`: that re-registering mints new LiteGraph classes without re-applying the extension hooks, so every node created afterwards permanently lacks the extension's `upload` widget — with already-instantiated nodes keeping their old constructor, which would explain why `panel_copy_nodes`/`panel_paste_nodes` still worked. The reporter explicitly flagged this as unproven. It is wrong, three ways:

1. **The frontend cannot mint a class without the hooks.** In the shipped bundle, `registerNodeDef(type, nodeData)` invokes `beforeRegisterNodeDef` unconditionally *before* it mints the class, and `app.widgets` is a persistent store. `refreshComboInNodes` re-registers every def too. There is no path that produces a hook-less class.
2. **The error text is its own disproof.** `upload` is named as a *required* input. It only exists in `nodeData.input.required` because `beforeRegisterNodeDef` put it there. Had the hooks not run, `upload` would be absent and the guard could not have named it.
3. **The failure is deterministic and refresh-independent** — reproduced on a freshly booted tab with no refresh anywhere (first test in the new file).

**The asymmetry the report inferred does not exist either.** A created LoadImage and a cloned one carry identical widgets. Only the *guard* differed: `panel_add_node` runs it, the clipboard path does not.

## What actually happens

ComfyUI's core `Comfy.UploadImage` extension:

- injects a required input the backend never declares — `required.upload = ["IMAGEUPLOAD", {...imageConfig, imageInputName}]`; and
- materializes it as `node.addWidget("button", "upload", "image", cb, { serialize: false, canvasOnly: true })`.

(Both verified against the installed `comfyui_frontend_package` bundle, not from memory.)

So a perfectly healthy LoadImage **always** carries an `upload` widget that does not serialize — which is exactly the shape `missingRequiredWidgetMaterializations` reports as "did not materialize", and correctly so for a genuinely backend-required input (#580). Scanning the *frontend* nodeData reports it every single time. That is what the reporter hit on panel 0.11.38, and it is what #620 part B described a week earlier.

#620/#626 fixed that on `main` by scanning the **fresh backend def**, where `upload` does not exist.

## The hole that remains, and that this fixes

`graph_add_node` read that fresh def **by reference** out of the same map it hands to `refresh` -> `app.registerNodesFromDefs` — and ComfyUI passes each def straight to `beforeRegisterNodeDef`, which mutates it **in place**. So whenever the refresh branch runs (the class is not in the LiteGraph registry yet: any freshly installed pack), the "backend truth" the guard consults has grown a frontend-injected `upload`, and #700's refusal comes back for every image/video/audio upload loader in that pack.

The fix takes a **snapshot** of the class's definition the instant the payload lands, before anything can register from it. That is the cause, not the symptom: `panel_add_node` was not made tolerant of a missing widget — the guard still fails closed on a genuinely unmaterialized backend-required widget, which is covered by a test.

## The error message

It said, for every case:

> Required custom widget "upload" did not initialize for "LoadImage". Reload ComfyUI so its node extension can register, then retry.

Both halves could be false at once. The widget *had* initialized — it was on the node — and the extension *had* registered: `awaitRequiredCustomWidgetRegistration`, one line earlier, had just proven the constructor was present. The guard was recommending a reload for something it knew was not broken, and #700 was filed after ~90 tool calls spent investigating extension registration on that advice.

It now names the condition that actually held, says nothing was added, and asserts no mechanism it cannot see:

> Cannot add "LoadImage": required input "upload" is present but does not serialize a value (serialize:false), so a queued prompt would omit it. Nothing was added. The widget constructor is registered and the widget was built, so this is not a widget-registration failure. Reload the ComfyUI tab so this node type is registered again from the current definition, then retry. If it still fails, this node's frontend and backend definitions disagree and its pack needs updating (or its author needs to hear about it).

> Cannot add "BrokenNode": required input "amount" was not built onto the node, even though a widget constructor for its type is registered. Nothing was added. Reload the ComfyUI tab so this node type is registered again from the current definition, then retry. ...

## Verification

- **Reproduced first**, against the *shipped* `graph_add_node` extracted from the bundle and driven with a ComfyUI double transcribed from the real frontend. On `origin/main` it fails with the byte-exact #700 error.
- **Re-verified after rebasing onto #714** (`2892f2a`, which touches `node-widget-materialization.js`): still reproduces, so #714 does not fix this. #714 changed socket-vs-widget classification for comma-joined union datatypes; `upload` is a genuine IMAGEUPLOAD widget and its `serialize:false` disqualifier is untouched.
- **Mutation-verified**, six reverts, each failing the specific test:

  | mutation | test that fails |
  |---|---|
  | snapshot -> by-reference read | the 3 refresh-branch add tests |
  | `snapshotBackendDef` stops cloning | those 3 + `snapshotBackendDef survives an in-place rewrite` |
  | old error message restored | `a genuinely unmaterialized BACKEND-required widget is still refused` |
  | `defineProperty` -> plain assignment | `snapshotBackendDef keeps a required input literally named __proto__` |
  | "canvas-only" wording restored | `describes only the flag the guard actually reads` + 2 |
  | mechanism-asserting remedy restored | `the remedy asserts no mechanism the guard cannot see` |

- The regression test also pins that the fetched map **is** still mutated in place, so it cannot pass for the wrong reason.
- Full unit suite: 2583 passing. `tsc --noEmit`, `node --check`, tool-vocabulary gate, YARA parity (svg/onload/onerror + exec literals), control-byte scan (0 on every changed file), ES-module parse+link as `.mjs`.
- `pyproject.toml` and `PANEL_VERSION` deliberately untouched.

## Gate

Three adversarial rounds. Round 1: a `__proto__` fail-open in the clone (P1) and a "canvas-only" over-claim in the message (P2) — both fixed and mutation-verified. Round 2: the remedy asserted mechanisms that can be false (P2) — fixed. Round 3 on the full diff including the repairs: PASS, no substantive findings.

## Relationship to #620

#620 is the same defect. Its part A (MASK/STITCHER socket types) was fixed by #620's own follow-ups and #714; its **part B is exactly this bug**, independently diagnosed by the same reporter, down to quoting the same two lines of the frontend bundle. #620 should be closed by this rather than as stale.

## Left out

- `reapplyDefsToLiveNodes(rootGraph, defs)` in `registerComfyNodeDefs` also runs on a post-mutation map. That is stamping onto frontend node *instances*, whose nodeData is expected to be frontend-shaped, so it is left alone deliberately.
- No live browser reproduction: the reporter's environment is a from-source ComfyUI_frontend on a vite dev server against a remote backend. Every frontend behaviour this depends on was read out of the installed `comfyui_frontend_package` bundle instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
