### PR TITLE
fix(panel #706): a Manager security refusal is not "not reachable"

### DIFF
--- a/browser_tests/unit/manager-404.test.mjs
+++ b/browser_tests/unit/manager-404.test.mjs
@@ -1,0 +1,70 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classifyManager404, summarizeManagerBody } from "../../web/js/lib/manager-404.js";
+
+/**
+ * #706 — a Manager 404 means one of two OPPOSITE things and the panel reported
+ * both as "not reachable". The wrong-answer half is bad; the wrong-authorization
+ * half is worse (see the module header).
+ */
+
+test("the security refusal is NOT classified as route-missing (the #605 re-send guard)", () => {
+  // This is the load-bearing assertion of the whole change. `routeMissing` is
+  // what authorizes the #605 mutation self-heal to re-send. A security refusal
+  // ran a handler, so re-sending would hand the Manager an install it already
+  // processed and rejected.
+  const r = classifyManager404("A security error has occurred. Please check the terminal logs");
+  assert.equal(r.routeMissing, false, "a refusal must never authorize a re-send");
+});
+
+test("the security refusal says the Manager IS reachable, and why it declined", () => {
+  const r = classifyManager404("A security error has occurred. Please check the terminal logs");
+  // The exact failure reported in #706: the user was told the Manager was
+  // unreachable while /manager/version answered V3.41 at the same moment.
+  assert.ok(!/not reachable/i.test(r.message), "must not claim unreachability");
+  assert.match(r.message, /security gate/i);
+  assert.match(r.message, /running and reachable/i);
+  // The upstream cause must survive into the message — discarding it is the bug.
+  assert.match(r.message, /A security error has occurred/);
+});
+
+test("a genuine route-missing 404 keeps the old message AND the old flag", () => {
+  for (const body of ["", "Not Found", "<html><body>404</body></html>", null, undefined]) {
+    const r = classifyManager404(body);
+    assert.equal(r.routeMissing, true, `body ${JSON.stringify(body)} must stay route-missing`);
+    assert.equal(r.message, "ComfyUI-Manager not reachable (is the built-in Manager enabled?)");
+  }
+});
+
+test("an unreadable body falls back to route-missing rather than inventing a refusal", () => {
+  // Failing back to the conservative pre-#706 classification: we may not claim a
+  // security refusal we cannot evidence.
+  assert.equal(classifyManager404("").routeMissing, true);
+  assert.equal(classifyManager404(123).routeMissing, true);
+});
+
+test("matches the phrasing loosely enough to survive 3.x wording drift", () => {
+  for (const body of [
+    "A security error has occurred. Please check the terminal logs",
+    "security error",
+    "ERROR: A Security Error Has Occurred",
+    "{\"error\":\"a security error has occurred\"}",
+  ]) {
+    assert.equal(classifyManager404(body).routeMissing, false, body);
+  }
+});
+
+test("an untrusted body is flattened and capped before it reaches the UI", () => {
+  const huge = "security error " + "x".repeat(5000);
+  const r = classifyManager404(huge);
+  assert.equal(r.routeMissing, false);
+  assert.ok(r.message.length < 1200, `message should be bounded, got ${r.message.length}`);
+  assert.ok(!/\n/.test(r.message), "must be single-line — no raw newlines from an HTML page");
+});
+
+test("summarizeManagerBody collapses whitespace and caps length", () => {
+  assert.equal(summarizeManagerBody("  a\n\n  b \t c "), "a b c");
+  assert.equal(summarizeManagerBody(""), "");
+  assert.equal(summarizeManagerBody(null), "");
+  assert.ok(summarizeManagerBody("y".repeat(5000)).endsWith("…"));
+});

--- a/browser_tests/unit/manager-dialect.test.mjs
+++ b/browser_tests/unit/manager-dialect.test.mjs
@@ -10,6 +10,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { classifyManager404 } from "../../web/js/lib/manager-404.js";
 
 import * as ManagerInstall from "../../web/js/lib/manager-install.js";
 const {
@@ -86,17 +87,24 @@ test("isManagerRouteMissing: ONLY the proven-404 marker qualifies a mutation ret
 // a 404 response tags the error; a no-response (null) failure does NOT.
 test("managerV2/managerCall tag a 404 as managerRouteMissing, never the no-response case", async () => {
   const src = readPanelSource();
+  // #706 — the extracted functions now depend on the classifyManager404 helper,
+  // so it is injected the same way `api` is. Injecting the REAL implementation
+  // (not a stub) keeps this a real-source harness.
   const factory = new Function(
     "api",
+    "classifyManager404",
     `${pick(src, /async function managerV2\(route, \{ method = "GET", body, signal \} = \{\}\) \{[\s\S]*?\n\}/, "managerV2")}
 ${pick(src, /async function managerCall\(route, \{ method = "GET", body, signal \} = \{\}\) \{[\s\S]*?\n\}/, "managerCall")}
 return { managerV2, managerCall };`,
   );
   for (const res of [
-    { status: 404, ok: false }, // route not registered → proven rejection
+    { status: 404, ok: false, text: async () => "" }, // route not registered → proven rejection
     null, // no response → ambiguous
   ]) {
-    const { managerV2: mv2, managerCall: mcall } = factory({ fetchApi: async () => res });
+    const { managerV2: mv2, managerCall: mcall } = factory(
+      { fetchApi: async () => res },
+      classifyManager404,
+    );
     for (const call of [mv2, mcall]) {
       const err = await call("manager/queue/status").then(
         () => null,
@@ -110,6 +118,51 @@ return { managerV2, managerCall };`,
         `marker only for the proven 404 (res=${JSON.stringify(res)})`,
       );
     }
+  }
+
+  // #706 — the ONE 404 that must NOT carry the marker: legacy Manager 3.x
+  // answers a security-gated operation with 404 + a refusal body. A handler ran
+  // and said no, so authorizing a #605 mutation re-send would re-submit an
+  // install the Manager already rejected.
+  {
+    const secRes = {
+      status: 404,
+      ok: false,
+      text: async () => "A security error has occurred. Please check the terminal logs",
+    };
+    const { managerV2: mv2, managerCall: mcall } = factory(
+      { fetchApi: async () => secRes },
+      classifyManager404,
+    );
+    for (const call of [mv2, mcall]) {
+      const err = await call("manager/queue/install").then(
+        () => null,
+        (e) => e,
+      );
+      assert.ok(err, "must throw");
+      assert.equal(isManagerRouteMissing(err), false, "a security refusal must not authorize a re-send");
+      assert.ok(!/not reachable/i.test(err.message), "must not claim the Manager is unreachable");
+      assert.match(err.message, /security gate/i);
+    }
+  }
+
+  // A 404 whose body cannot be read stays route-missing (pre-#706 behaviour) —
+  // we may not claim a refusal we cannot evidence.
+  {
+    const brokenBody = {
+      status: 404,
+      ok: false,
+      text: async () => {
+        throw new Error("stream already consumed");
+      },
+    };
+    const { managerV2: mv2 } = factory({ fetchApi: async () => brokenBody }, classifyManager404);
+    const err = await mv2("manager/queue/status").then(
+      () => null,
+      (e) => e,
+    );
+    assert.ok(err, "must throw");
+    assert.equal(isManagerRouteMissing(err), true, "unreadable body falls back to route-missing");
   }
 });
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -357,6 +357,7 @@ import {
 } from "./lib/session-rebind.js";
 import { createRestartTabIdentity, sendBridgeHello } from "./lib/restart-tab-identity.js";
 import { primeModuleCache, resolveBundleStaleness } from "./lib/bundle-version.js";
+import { classifyManager404 } from "./lib/manager-404.js";
 import {
   createTabRouteIdentity,
   describeRefusedRoute,
@@ -3929,8 +3930,22 @@ async function managerV2(route, { method = "GET", body, signal } = {}) {
     // #605 mutation self-heal can tell it apart from the ambiguous no-response
     // case above (a lost response proves NOTHING about whether the request
     // landed, so it must never authorize a mutation re-send — codex P0).
-    const err = new Error("ComfyUI-Manager not reachable (is the built-in Manager enabled?)");
-    err.managerRouteMissing = true;
+    //
+    // …EXCEPT legacy Manager 3.x answers a SECURITY-GATED operation with 404 +
+    // an "A security error has occurred" body, where the route exists and its
+    // handler REFUSED (#706). That is not route-missing and must NOT authorize
+    // a re-send. Read the body before deciding; an unreadable body falls back
+    // to route-missing, which is the pre-#706 behaviour.
+    let body = "";
+    try {
+      body = await res.text();
+    } catch {
+      /* body unreadable — classifyManager404 treats that as route-missing */
+    }
+    const { routeMissing, message } = classifyManager404(body);
+    const err = new Error(message);
+    if (routeMissing) err.managerRouteMissing = true;
+    else err.managerSecurityRefusal = true;
     throw err;
   }
   if (!res.ok) {
@@ -3961,9 +3976,19 @@ async function managerCall(route, { method = "GET", body, signal } = {}) {
   }
   if (res.status === 404) {
     // See managerV2: a 404 is the PROVEN route-level rejection the #605
-    // mutation self-heal may retry on (err.managerRouteMissing).
-    const err = new Error("ComfyUI-Manager not reachable (is the built-in Manager enabled?)");
-    err.managerRouteMissing = true;
+    // mutation self-heal may retry on (err.managerRouteMissing) — unless the
+    // body says the Manager's SECURITY GATE refused it (#706), in which case a
+    // handler ran and a re-send must not be authorized.
+    let body = "";
+    try {
+      body = await res.text();
+    } catch {
+      /* body unreadable — classifyManager404 treats that as route-missing */
+    }
+    const { routeMissing, message } = classifyManager404(body);
+    const err = new Error(message);
+    if (routeMissing) err.managerRouteMissing = true;
+    else err.managerSecurityRefusal = true;
     throw err;
   }
   if (!res.ok) {

--- a/web/js/lib/manager-404.js
+++ b/web/js/lib/manager-404.js
@@ -1,0 +1,79 @@
+/**
+ * Classify a ComfyUI-Manager 404.
+ *
+ * A 404 from the Manager means one of TWO opposite things, and the panel used to
+ * report both as "ComfyUI-Manager not reachable (is the built-in Manager
+ * enabled?)":
+ *
+ *   ROUTE MISSING   — no handler exists at that path. Nothing ran. This is the
+ *                     proven route-level rejection the #605 mutation self-heal
+ *                     is allowed to retry on.
+ *   SECURITY REFUSAL — legacy Manager 3.x answers a security-gated operation
+ *                     (e.g. a git-URL install of a pack outside its registry at
+ *                     the default security level) with 404 + a body reading
+ *                     "A security error has occurred. Please check the terminal
+ *                     logs". The route EXISTS and its handler REFUSED.
+ *
+ * Two separate defects came from collapsing them (#706):
+ *
+ *  1. WRONG ANSWER. The user was told the Manager was unreachable while
+ *     `/manager/version` was answering V3.41 at that very moment, so they went
+ *     looking for a disabled Manager instead of a security gate. The actionable
+ *     cause was in the body we discarded.
+ *
+ *  2. WRONG AUTHORIZATION, which is the dangerous half. A route-missing 404 is
+ *     tagged `managerRouteMissing` precisely because nothing ran, so re-sending
+ *     a mutation is safe. A security refusal DID run a handler — tagging it the
+ *     same way authorizes the #605 self-heal to re-send an install that the
+ *     Manager already processed and rejected. "Nothing ran" and "something ran
+ *     and said no" must not share a flag.
+ *
+ * Pure and body-only: the caller owns the fetch, so this stays unit-testable and
+ * cannot itself consume a stream twice.
+ */
+
+/** Manager's security refusal, matched on the stable part of its phrasing.
+ *  Deliberately loose on surrounding text (the message has carried different
+ *  trailing advice across 3.x builds) and anchored on the two words that have
+ *  not moved. */
+const SECURITY_REFUSAL_RE = /security\s+error/i;
+
+/** An upstream body is untrusted, arbitrary-length text heading for a UI string.
+ *  Cap it rather than let a stray HTML error page become the message. */
+const MAX_DETAIL = 300;
+
+/** Squeeze an upstream body into one short, single-line detail fragment. */
+export function summarizeManagerBody(bodyText) {
+  if (typeof bodyText !== "string") return "";
+  const flat = bodyText.replace(/\s+/g, " ").trim();
+  if (!flat) return "";
+  return flat.length > MAX_DETAIL ? `${flat.slice(0, MAX_DETAIL)}…` : flat;
+}
+
+/**
+ * @param {string|null|undefined} bodyText  the 404 response body, or null/"" if
+ *   it could not be read. An unread body resolves to ROUTE MISSING, which is the
+ *   pre-#706 behaviour — failing back to the conservative classification rather
+ *   than inventing a refusal we cannot evidence.
+ * @returns {{ routeMissing: boolean, message: string }}
+ */
+export function classifyManager404(bodyText) {
+  const detail = summarizeManagerBody(bodyText);
+  if (detail && SECURITY_REFUSAL_RE.test(detail)) {
+    return {
+      // NOT route-missing: a handler ran and refused. See (2) above — this is
+      // what keeps a refusal from authorizing a mutation re-send.
+      routeMissing: false,
+      message:
+        `ComfyUI-Manager refused the operation (security gate): ${detail} ` +
+        `The Manager is running and reachable — it declined this request. ` +
+        `Legacy Manager 3.x gates installs from outside its registry (e.g. a raw git URL) ` +
+        `at the default security level; check the ComfyUI terminal log for the specific rule, ` +
+        `and either install the pack from the registry or adjust the Manager's security level.`,
+    };
+  }
+  return {
+    routeMissing: true,
+    message: "ComfyUI-Manager not reachable (is the built-in Manager enabled?)",
+  };
+}


### PR DESCRIPTION
Closes #706.

## The defect

Legacy ComfyUI-Manager **3.x** answers a **security-gated** operation — e.g. a git-URL install of a pack outside its registry, at the default security level — with `HTTP 404` plus a body reading `A security error has occurred. Please check the terminal logs`.

Both `managerV2()` and `managerCall()` treated **every** 404 as route-missing and never read the body. That produced two defects, and the second is worse than the one in the title.

### 1. Wrong answer

The user saw:

> `Error: ComfyUI-Manager not reachable (is the built-in Manager enabled?)`

…while `GET /manager/version` returned `V3.41` and `/manager/queue/status` returned 200 **at the same moment**. So they went hunting for a disabled Manager instead of a security gate. The actionable cause was sitting in the body we discarded.

### 2. Wrong authorization — the dangerous half

A route-missing 404 is tagged `managerRouteMissing` *precisely because no handler ran*, which is what permits the #605 mutation self-heal to re-send. A security refusal **did** run a handler and rejected the request. Tagging it identically authorizes re-submitting an install the Manager already refused.

**"Nothing ran" and "something ran and said no" must not share a flag.**

The reporter saw the downstream shape of this too: an earlier queued git-URL install was security-blocked the same way, Manager marked the queue task done, and the pack never appeared — with no hint that a security gate was the reason.

## The fix

`classifyManager404()` — a pure, body-only classifier in `web/js/lib/` so the rule lives in **one** place and is unit-testable. Both call sites read the body before deciding.

- a body matching the refusal phrasing → a specific "refused the operation (security gate)" error that states the Manager **is** reachable, quotes the upstream detail, and points at the actual remedy (install from the registry, or adjust the security level). It sets `managerSecurityRefusal`, **not** `managerRouteMissing`.
- anything else, including an **unreadable** body → unchanged route-missing behaviour. We may not claim a refusal we cannot evidence, so this fails back to the conservative pre-#706 classification.
- the upstream detail is whitespace-flattened and length-capped before it reaches a UI string, so a stray HTML error page can't become the message.

Matching is deliberately loose on surrounding prose and anchored on the two words that haven't moved across 3.x builds.

## On the #605 guard test

`manager-dialect.test.mjs` is a real-source harness that `eval`s the extracted function bodies, so it needed the helper injected the same way `api` already is. **Extended, not relaxed** — it still proves the marker appears for a proven 404 and never for the no-response case, and now additionally that a security-body 404 does **not** carry it, and that an unreadable body still does.

## Verification

Mutation-verified, each failing its own tests:

| mutation | result |
|---|---|
| revert to `origin/main` classification | **4 fail** |
| classify the refusal correctly but still tag it `routeMissing` | **3 fail** ← the safety property |
| drop the untrusted-body cap | **2 fail** |

Full suite **2590/2590**. Panel re-verified to **parse and link** as an ES module (halts only at `window is not defined`). `check-tool-vocabulary` OK. Control-byte scan 0 on every changed file. `pyproject.toml` / `PANEL_VERSION` untouched — no Registry publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)