### PR TITLE
fix(panel): play audio in panel_show_media, and stop reporting unpresentable kinds as painted (#710)

### DIFF
--- a/browser_tests/unit/chat-media-persistence.test.mjs
+++ b/browser_tests/unit/chat-media-persistence.test.mjs
@@ -102,6 +102,20 @@ test("data: / blob: / whitespace-prefixed data: urls are NEVER persisted (#177 P
   assert.equal(mediaRecordFor("image", "file:///etc/passwd", "x"), null, "file: rejected");
 });
 
+test("audio and unpresentable-file cards keep their own kind across a reload (#710)", () => {
+  // A card that persists under the wrong kind replays under the wrong painter,
+  // which is the broken-<img> defect reappearing one refresh later.
+  const audio = mediaRecordFor("audio", "/view?filename=vo.mp3&type=output", "line 1");
+  assert.ok(audio);
+  assert.equal(audio.mkind, "audio");
+  const file = mediaRecordFor("file", "/view?filename=scene.blend&type=output", "scene");
+  assert.ok(file);
+  assert.equal(file.mkind, "file");
+  // Anything this panel does not know stays an image — the only kind every
+  // already-stored record can be.
+  assert.equal(mediaRecordFor("hologram", "/view?filename=x.png", "x").mkind, "image");
+});
+
 test("replay never re-records -> reload preserves media count (#177)", () => {
   // The replay guard: paintThread() repaints stored media with replaying=true,
   // which must yield NO new record (otherwise every reload would duplicate it).

--- a/browser_tests/unit/media-preview.test.mjs
+++ b/browser_tests/unit/media-preview.test.mjs
@@ -13,6 +13,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import {
+  classifyShowMediaItem,
   composeShowMediaReply,
   dataUrlByteLength,
   isVideoShowMediaItem,
@@ -41,6 +42,8 @@ function harness(over = {}) {
   const calls = {
     paintedImages: [],
     paintedVideos: [],
+    paintedAudio: [],
+    paintedLinks: [],
     storyboardsFor: [],
     uploads: [],
     warnings: [],
@@ -49,6 +52,8 @@ function harness(over = {}) {
   const deps = {
     paintImage: (url, caption) => calls.paintedImages.push({ url, caption }),
     paintVideo: (url, caption) => calls.paintedVideos.push({ url, caption }),
+    paintAudio: (url, caption) => calls.paintedAudio.push({ url, caption }),
+    paintFileLink: (url, caption) => calls.paintedLinks.push({ url, caption }),
     imageViewUrl: (ref) =>
       `/view?filename=${ref.filename}&subfolder=${ref.subfolder ?? ""}&type=${ref.type ?? "output"}`,
     coerceMessageText: (v) => (typeof v === "string" ? v : v == null ? "" : String(v)),
@@ -609,7 +614,7 @@ test("a painter whose returned object has a THROWING then getter still yields a 
   );
   assert.equal(reply.ok, true);
   assert.equal(reply.unconfirmed, 1);
-  assert.match(reply.note, /whether the user can see it is UNKNOWN/);
+  assert.match(reply.note, /whether the user can see or hear it is UNKNOWN/);
 });
 
 test("a painter that returns a thenable whose then() THROWS still yields a reply", async () => {
@@ -627,7 +632,7 @@ test("a painter that returns a thenable whose then() THROWS still yields a reply
   assert.equal(reply.ok, true);
   assert.equal(reply.painted, 0);
   assert.equal(reply.unconfirmed, 1);
-  assert.match(reply.note, /whether the user can see it is UNKNOWN/);
+  assert.match(reply.note, /whether the user can see or hear it is UNKNOWN/);
 });
 
 test("a throwing text coercer does not cost the agent its reply", async () => {
@@ -666,7 +671,7 @@ test("a painter that settles LATER is reported unconfirmed, not counted as shown
   );
   assert.equal(reply.painted, 0, "an unconfirmed paint is not a paint");
   assert.equal(reply.unconfirmed, 1);
-  assert.match(reply.note, /whether the user can see it is UNKNOWN/);
+  assert.match(reply.note, /whether the user can see or hear it is UNKNOWN/);
   await new Promise((r) => setImmediate(r));
 });
 
@@ -851,6 +856,210 @@ test("a video whose inline payload is malformed reports its size UNKNOWN, never 
   assert.equal(reply.previews[0].sourceBytes, null);
 });
 
+// ── #710 — audio, and kinds the panel cannot present ───────────────────────
+//
+// The panel used to know exactly two media kinds. An AUDIO ref (a ComfyUI /view
+// ref can name anything on disk) fell through to the image branch, so the user
+// got a broken <img> icon — and the reply still said `painted:N, unconfirmed:0`,
+// a full success. The agent then told the user to listen to something nobody
+// could hear. Both halves are tested here: audio must PLAY, and anything the
+// panel cannot present must never be counted as painted.
+
+const AUDIO_REF = {
+  kind: "viewRef",
+  viewRef: { filename: "vo_sophie_00001.mp3", subfolder: "synlara", type: "output" },
+  filename: "vo_sophie_00001.mp3",
+  caption: "Sophie, line 1",
+};
+
+test("an audio ref is PLAYED, never painted as an image (#710)", async () => {
+  const h = harness();
+  const reply = await composeShowMediaReply([AUDIO_REF], h.deps);
+
+  assert.equal(
+    h.calls.paintedImages.length,
+    0,
+    "audio painted through the image branch is the broken-<img> icon the user saw",
+  );
+  assert.equal(h.calls.paintedVideos.length, 0);
+  assert.equal(h.calls.paintedAudio.length, 1, "audio must reach the audio painter");
+  assert.match(h.calls.paintedAudio[0].url, /filename=vo_sophie_00001\.mp3/);
+  assert.equal(h.calls.paintedAudio[0].caption, "Sophie, line 1");
+  assert.equal(h.calls.storyboardsFor.length, 0, "audio has no frames to sample");
+  assert.equal(reply.previews.length, 0);
+});
+
+test("an audio item's reply says the user can HEAR it and that the agent cannot (#710)", async () => {
+  const h = harness();
+  const reply = await composeShowMediaReply([AUDIO_REF], h.deps);
+
+  assert.equal(reply.painted, 1, "a played audio file IS presented to the user");
+  assert.deepEqual(reply.unrenderable, []);
+  // The headline must not claim the audio was DISPLAYED — a player is not a picture.
+  assert.match(reply.note, /audio player/i);
+  // …and it must disarm the fabrication an audio card invites: the agent has
+  // heard nothing, so it must not describe how the file sounds.
+  assert.match(reply.note, /do not describe how it sounds/i);
+  assert.match(reply.note, /vo_sophie_00001\.mp3/);
+  // A real next step, and one that actually works: get_image saves audio to disk.
+  assert.match(
+    reply.note,
+    /call get_image with filename "vo_sophie_00001\.mp3", type "output", subfolder "synlara"/,
+  );
+});
+
+test("an audio file whose player could not be painted is not counted as painted (#710)", async () => {
+  const h = harness({
+    paintAudio: () => {
+      throw new Error("DOM exploded");
+    },
+  });
+  const reply = await composeShowMediaReply([AUDIO_REF], h.deps);
+  assert.equal(reply.painted, 0);
+  assert.match(reply.note, /were NOT displayed/);
+  assert.match(reply.note, /vo_sophie_00001\.mp3/);
+});
+
+test("a kind the panel cannot present is NOT counted as painted (#710)", async () => {
+  // The honesty half in one assertion: the agent must be able to tell "the user
+  // can perceive this" from "I was handed something I could not present".
+  const h = harness();
+  const reply = await composeShowMediaReply(
+    [
+      { kind: "image", dataUrl: "data:image/png;base64,AAAA", filename: "a.png" },
+      {
+        kind: "viewRef",
+        viewRef: { filename: "notes.txt", subfolder: "", type: "output" },
+        filename: "notes.txt",
+      },
+    ],
+    h.deps,
+  );
+
+  assert.equal(reply.count, 2);
+  assert.equal(reply.painted, 1, "only the image was presented; the .txt was not");
+  assert.equal(reply.unconfirmed, 0);
+  assert.equal(reply.unrenderable.length, 1);
+  assert.equal(reply.unrenderable[0].name, "notes.txt");
+  assert.equal(reply.unrenderable[0].ext, ".txt");
+  assert.equal(h.calls.paintedImages.length, 1, "the .txt must not go to the image painter");
+  assert.match(reply.note, /the panel cannot present/i);
+  assert.match(reply.note, /notes\.txt/);
+  // get_image only returns image/video/audio and REFUSES anything else, so
+  // pointing the agent at it here would be a remedy that cannot be followed.
+  assert.doesNotMatch(reply.note, /call get_image with filename "notes\.txt"/);
+});
+
+test("an unpresentable item still gives the USER something to act on — a link (#710)", async () => {
+  const h = harness();
+  const reply = await composeShowMediaReply(
+    [
+      {
+        kind: "viewRef",
+        viewRef: { filename: "scene.blend", subfolder: "", type: "output" },
+        filename: "scene.blend",
+      },
+    ],
+    h.deps,
+  );
+  assert.equal(h.calls.paintedLinks.length, 1);
+  assert.match(h.calls.paintedLinks[0].url, /filename=scene\.blend/);
+  assert.equal(reply.unrenderable[0].shown, "link");
+  assert.match(reply.note, /LINK/);
+});
+
+test("an unpresentable item whose link ALSO failed says the user got nothing at all (#710)", async () => {
+  const h = harness({
+    paintFileLink: () => {
+      throw new Error("DOM exploded");
+    },
+  });
+  const reply = await composeShowMediaReply(
+    [{ kind: "viewRef", viewRef: { filename: "scene.blend", type: "output" }, filename: "scene.blend" }],
+    h.deps,
+  );
+  assert.equal(reply.painted, 0);
+  assert.equal(reply.unrenderable[0].shown, "nothing");
+  assert.match(reply.note, /nothing at all/i);
+});
+
+test("audio in a panel with no audio painter degrades to a link and is NOT painted (#710)", async () => {
+  // A dep the panel forgot to wire must fail honest, not fail silent.
+  const h = harness({ paintAudio: undefined });
+  const reply = await composeShowMediaReply([AUDIO_REF], h.deps);
+  assert.equal(h.calls.paintedImages.length, 0, "never fall back to the image painter");
+  assert.equal(reply.painted, 0);
+  assert.equal(reply.unrenderable.length, 1);
+  assert.equal(h.calls.paintedLinks.length, 1);
+});
+
+test("classifyShowMediaItem decides by explicit kind, then the ref's filename, then the data URL", () => {
+  const ref = (filename) => ({ kind: "viewRef", viewRef: { filename }, filename });
+  // The orchestrator's own kind wins — it built the MIME from the extension.
+  assert.equal(classifyShowMediaItem({ kind: "image", dataUrl: "data:image/png;base64,AA==" }).kind, "image");
+  assert.equal(classifyShowMediaItem({ kind: "video", dataUrl: "data:video/mp4;base64,AA==" }).kind, "video");
+  assert.equal(classifyShowMediaItem({ kind: "audio", dataUrl: "data:audio/mpeg;base64,AA==" }).kind, "audio");
+  // A /view ref carries no kind, so the filename decides.
+  assert.equal(classifyShowMediaItem(ref("a.png")).kind, "image");
+  assert.equal(classifyShowMediaItem(ref("a.WEBP")).kind, "image");
+  assert.equal(classifyShowMediaItem(ref("a.gif")).kind, "image", "animated gifs render in <img>");
+  assert.equal(classifyShowMediaItem(ref("a.mp4")).kind, "video");
+  assert.equal(classifyShowMediaItem(ref("a.MP3")).kind, "audio");
+  assert.equal(classifyShowMediaItem(ref("a.wav")).kind, "audio");
+  assert.equal(classifyShowMediaItem(ref("a.flac")).kind, "audio");
+  assert.equal(classifyShowMediaItem(ref("a.ogg")).kind, "audio");
+  assert.equal(classifyShowMediaItem(ref("a.m4a")).kind, "audio");
+  assert.equal(classifyShowMediaItem(ref("a.aac")).kind, "audio");
+  // Query strings and fragments must not demote a kind (the #648 dot bug's twin).
+  assert.equal(classifyShowMediaItem(ref("a.mp3?download=1")).kind, "audio");
+  assert.equal(classifyShowMediaItem(ref("a.mp3#t=3")).kind, "audio");
+  // An unescaped dot would make "xmp3" audio, exactly as it once made "xmp4" video.
+  assert.equal(classifyShowMediaItem(ref("xmp3")).kind, "unknown");
+  // UNKNOWN is a decision, not a fallback to <img>.
+  assert.equal(classifyShowMediaItem(ref("notes.txt")).kind, "unknown");
+  assert.equal(classifyShowMediaItem(ref("notes.txt")).ext, ".txt");
+  assert.equal(classifyShowMediaItem(ref("noextension")).kind, "unknown");
+  assert.equal(classifyShowMediaItem(ref("noextension")).ext, "");
+  // A data URL with no declared kind is classified by its MIME.
+  assert.equal(classifyShowMediaItem({ dataUrl: "data:audio/wav;base64,AA==" }).kind, "audio");
+  assert.equal(classifyShowMediaItem({ dataUrl: "data:application/pdf;base64,AA==" }).kind, "unknown");
+  assert.equal(classifyShowMediaItem(null).kind, "unknown");
+});
+
+test("the audio branch does not change how images and videos are classified (#710)", () => {
+  // The common path is the one a regression here would cost, so it is asserted
+  // against the SAME classifier the paint pass uses.
+  const ref = (filename) => ({ kind: "viewRef", viewRef: { filename }, filename });
+  for (const name of ["out.png", "out.jpg", "out.jpeg", "out.webp", "out.gif", "out.bmp", "out.avif"]) {
+    assert.equal(classifyShowMediaItem(ref(name)).kind, "image", name);
+    assert.equal(isVideoShowMediaItem(ref(name)), false, name);
+  }
+  for (const name of ["clip.mp4", "clip.webm", "clip.mov", "clip.m4v", "clip.mkv", "clip.avi"]) {
+    assert.equal(classifyShowMediaItem(ref(name)).kind, "video", name);
+    assert.equal(isVideoShowMediaItem(ref(name)), true, name);
+  }
+});
+
+test("a mixed batch reports each kind's outcome separately (#710)", async () => {
+  const h = harness();
+  const reply = await composeShowMediaReply(
+    [
+      { kind: "image", dataUrl: "data:image/png;base64,AAAA", filename: "a.png" },
+      AUDIO_REF,
+      { kind: "viewRef", viewRef: { filename: "notes.txt", type: "output" }, filename: "notes.txt" },
+    ],
+    h.deps,
+  );
+  assert.equal(h.calls.paintedImages.length, 1);
+  assert.equal(h.calls.paintedAudio.length, 1);
+  assert.equal(h.calls.paintedLinks.length, 1);
+  assert.equal(reply.count, 3);
+  assert.equal(reply.painted, 2, "the image and the audio — not the .txt");
+  assert.equal(reply.unrenderable.length, 1);
+  assert.match(reply.note, /1 item was displayed/);
+  assert.match(reply.note, /1 audio player/);
+});
+
 // ── the SHIPPED panel is actually wired to this module ─────────────────────
 //
 // Everything above tests a module the panel could simply stop calling. Deleting
@@ -942,6 +1151,58 @@ test("onShowMedia routes through composeShowMediaReply with the storyboard pipel
     /paintVideo\(url, caption\)/,
     "the handler must not keep its own painting loop — that is the drift this fix removes",
   );
+  // #710 — a painter the panel never passes leaves this module with nothing to
+  // dispatch to, and the composer degrades every audio file to a link card. The
+  // module's audio branch is only real if the panel actually wires it.
+  for (const dep of ["paintAudio", "paintFileLink"]) {
+    assert.ok(handler[0].includes(dep), `onShowMedia must pass ${dep} through (#710)`);
+  }
+});
+
+/** One `function name(...) { … }` at the panel closure's 2-space indent, sliced
+ *  at its OWN closing brace — a fixed window (or one bounded by the next
+ *  function) runs into the following declaration's comment block and asserts
+ *  against prose rather than code. */
+function panelFunctionBody(src, decl) {
+  const i = src.indexOf(decl);
+  assert.ok(i > 0, `could not locate ${decl}`);
+  const end = src.slice(i).search(/\n {2}\}/);
+  assert.ok(end > 0, `could not find the end of ${decl}`);
+  return src.slice(i, i + end + 4);
+}
+
+test("paintAudio builds a real <audio> player, not an <img> (#710)", () => {
+  const src = panelSource();
+  const fn = panelFunctionBody(src, "function paintAudio(");
+  assert.match(fn, /createElement\("audio"\)/);
+  assert.match(fn, /\.controls = true/, "a player with no controls is not playable");
+  assert.doesNotMatch(fn, /createElement\("img"\)/);
+  // The chat lightbox gathers `.cmcp-imgcard` and renders every member as an
+  // image or a video. An audio card in that gallery is the broken <img> back by
+  // another route, so it must carry its own class and no _cmcpMedia descriptor.
+  assert.doesNotMatch(fn, /cmcp-imgcard/);
+  assert.doesNotMatch(fn, /_cmcpMedia/);
+  assert.match(fn, /recordMedia\("audio", url, name\)/, "audio must survive a reload as audio");
+});
+
+test("paintFileLink gives the user an openable link for a kind the panel cannot present (#710)", () => {
+  const src = panelSource();
+  const fn = panelFunctionBody(src, "function paintFileLink(");
+  assert.match(fn, /createElement\("a"\)/);
+  assert.match(fn, /\.href = url/);
+  assert.doesNotMatch(fn, /createElement\("img"\)/);
+  assert.doesNotMatch(fn, /cmcp-imgcard/);
+});
+
+test("a persisted audio card REPLAYS as audio, not as a broken image (#710)", () => {
+  // The reload path is a second copy of the kind decision. Leaving it behind
+  // reproduces the exact defect one refresh later.
+  const src = panelSource();
+  const i = src.indexOf('if (m.mkind === "video") paintVideo(m.url, m.caption);');
+  assert.ok(i > 0, "could not locate the media replay branch");
+  const branch = src.slice(i, i + 400);
+  assert.match(branch, /m\.mkind === "audio"[\s\S]{0,40}paintAudio\(m\.url, m\.caption\)/);
+  assert.match(branch, /m\.mkind === "file"[\s\S]{0,40}paintFileLink\(m\.url, m\.caption\)/);
 });
 
 // ── the shared bound is itself a guard that can fail ───────────────────────

--- a/browser_tests/unit/media-preview.test.mjs
+++ b/browser_tests/unit/media-preview.test.mjs
@@ -1203,12 +1203,14 @@ test("paintFileLink gives the user an openable link for a kind the panel cannot 
 test("chat audio is STOPPED at every teardown — a detached <audio> keeps playing (#710)", () => {
   // Removing a playing <audio> from the DOM does not pause it, and once the card
   // is gone there are no controls left to stop it with. Videos are covered by
-  // their IntersectionObserver; audio needs an explicit release.
+  // their IntersectionObserver; audio needs an explicit stop.
   const src = panelSource();
-  const fn = panelFunctionBody(src, "function releaseChatAudio(");
+  const fn = panelFunctionBody(src, "function stopChatAudio(");
   assert.match(fn, /querySelectorAll\("audio"\)/);
   assert.match(fn, /\.pause\(\)/);
-  assert.match(fn, /removeAttribute\("src"\)/);
+  // A permanent teardown drops the source too; a keep-alive detach must NOT —
+  // the same element is re-attached, and a player with no src is a new bug.
+  assert.match(fn, /if \(release\)[\s\S]{0,120}removeAttribute\("src"\)/);
   const reset = panelFunctionBody(src, "function resetFeed(");
   assert.match(reset, /releaseChatAudio\(\);/, "a thread/workflow switch must not leave sound playing");
   assert.ok(
@@ -1223,6 +1225,60 @@ test("chat audio is STOPPED at every teardown — a detached <audio> keeps playi
     .filter((body) => body.includes("unsubscribeHistorySync()"));
   assert.equal(destroys.length, 1, "could not locate the panel's own destroy()");
   assert.match(destroys[0], /releaseChatAudio\(\);/);
+});
+
+test("a KEEP-ALIVE sidebar detach pauses chat audio without destroying the player (#710)", () => {
+  // A sidebar-tab switch does not tear the panel down — it detaches the root and
+  // re-attaches the same DOM on re-entry. The audio still has to stop (its
+  // controls just left with the root, and the chat's videos are already paused
+  // here by their IntersectionObserver), but only by PAUSING: dropping `src`
+  // would hand the returning user a dead player.
+  const src = panelSource();
+  const onHide = src.match(/onHide\(\) \{[\s\S]*?\n {4}\},/);
+  assert.ok(onHide, "the panel handle must expose onHide for the keep-alive detach");
+  assert.match(onHide[0], /stopChatAudio\(\);/);
+  assert.doesNotMatch(onHide[0], /release/, "a keep-alive detach must not drop the source");
+  // BOTH detach paths must call it: the tab's own destroy(), and the
+  // sidebar-overlap guard that removes a stray root when another tab is active.
+  const tabDestroy = src.match(/destroy: \(\) => \{[\s\S]*?\n {8}\},/);
+  assert.ok(tabDestroy, "could not locate the sidebar tab's destroy()");
+  assert.match(tabDestroy[0], /mounted\?\.onHide\?\.\(\);/);
+  assert.ok(
+    tabDestroy[0].indexOf("onHide") < tabDestroy[0].indexOf("root?.remove()"),
+    "pause BEFORE the root is detached",
+  );
+  const guard = src.match(/function installSidebarTabGuard\([\s\S]*?\n {2}const start =/);
+  assert.ok(guard, "could not locate installSidebarTabGuard");
+  assert.match(guard[0], /onDetach\?\.\(\)/);
+  assert.match(
+    src,
+    /installSidebarTabGuard\(\s*tabId,[\s\S]{0,160}mounted\?\.onHide\?\.\(\)/,
+    "the guard must actually be given the panel's onHide",
+  );
+});
+
+test("run completion PLAYS an audio output instead of painting it as an image (#710)", () => {
+  // The second copy of the kind decision. The completion path knew only
+  // image-vs-video, so an audio descriptor arriving there was painted as an
+  // <img> AND handed to the agent as an inline image — a picture nobody has.
+  const src = panelSource();
+  const fn = panelFunctionBody(src, "function isAudioOutput(");
+  assert.match(fn, /fmt\.startsWith\("audio\/"\)/);
+  assert.match(fn, /mp3\|wav\|flac/);
+  const onExecuted = panelFunctionBody(src, "function onExecuted(");
+  // The exact branch, not merely a mention of the predicate: `false &&
+  // isAudioOutput(m)` still "mentions" it while routing every audio file back
+  // through paintImage, and a test that passes on that is testing nothing.
+  assert.match(onExecuted, /\} else if \(isAudioOutput\(m\)\) \{/);
+  assert.match(onExecuted, /isAudioOutput\(m\)\) \{[\s\S]{0,600}paintAudio\(url, m\.filename\)/);
+  const audioBranch = onExecuted.slice(onExecuted.indexOf("isAudioOutput(m)"));
+  const branchEnd = audioBranch.indexOf("} else {");
+  assert.ok(branchEnd > 0);
+  assert.doesNotMatch(
+    audioBranch.slice(0, branchEnd),
+    /inlineImages\.push/,
+    "audio must never join the agent's inline-IMAGE delivery",
+  );
 });
 
 test("a persisted audio card REPLAYS as audio, not as a broken image (#710)", () => {

--- a/browser_tests/unit/media-preview.test.mjs
+++ b/browser_tests/unit/media-preview.test.mjs
@@ -906,6 +906,12 @@ test("an audio item's reply says the user can HEAR it and that the agent cannot 
     reply.note,
     /call get_image with filename "vo_sophie_00001\.mp3", type "output", subfolder "synlara"/,
   );
+  // …and `painted` must not be oversold. The painter is synchronous: it returns
+  // before a byte is fetched, so a player in the chat is not evidence the file
+  // decoded. Claiming "the user can play it" full stop is the same overclaim as
+  // the success this fix removes, one layer down.
+  assert.match(reply.note, /NOT proof the browser could decode the file/);
+  assert.match(reply.note, /ask the user whether it actually plays/);
 });
 
 test("an audio file whose player could not be painted is not counted as painted (#710)", async () => {
@@ -1192,6 +1198,31 @@ test("paintFileLink gives the user an openable link for a kind the panel cannot 
   assert.match(fn, /\.href = url/);
   assert.doesNotMatch(fn, /createElement\("img"\)/);
   assert.doesNotMatch(fn, /cmcp-imgcard/);
+});
+
+test("chat audio is STOPPED at every teardown — a detached <audio> keeps playing (#710)", () => {
+  // Removing a playing <audio> from the DOM does not pause it, and once the card
+  // is gone there are no controls left to stop it with. Videos are covered by
+  // their IntersectionObserver; audio needs an explicit release.
+  const src = panelSource();
+  const fn = panelFunctionBody(src, "function releaseChatAudio(");
+  assert.match(fn, /querySelectorAll\("audio"\)/);
+  assert.match(fn, /\.pause\(\)/);
+  assert.match(fn, /removeAttribute\("src"\)/);
+  const reset = panelFunctionBody(src, "function resetFeed(");
+  assert.match(reset, /releaseChatAudio\(\);/, "a thread/workflow switch must not leave sound playing");
+  assert.ok(
+    reset.indexOf("releaseChatAudio()") < reset.indexOf("el.remove()"),
+    "release BEFORE detaching — a detached element is no longer reachable from `log`",
+  );
+  // The panel's own unmount is the other teardown: after it there is no card at
+  // all, so nothing else could ever stop the sound. Several objects in this file
+  // have a destroy(); the panel's is the one that unsubscribes history sync.
+  const destroys = [...src.matchAll(/\n {4}destroy\(\) \{/g)]
+    .map((m) => src.slice(m.index, m.index + 4000))
+    .filter((body) => body.includes("unsubscribeHistorySync()"));
+  assert.equal(destroys.length, 1, "could not locate the panel's own destroy()");
+  assert.match(destroys[0], /releaseChatAudio\(\);/);
 });
 
 test("a persisted audio card REPLAYS as audio, not as a broken image (#710)", () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -20122,12 +20122,19 @@ function buildPanel() {
 
   /** The same question for AUDIO. The run-completion path had only the
    *  image-vs-video split, so an audio descriptor arriving there was painted as
-   *  an <img> — the #710 defect on a second surface. ComfyUI files audio under
-   *  its own `audio` output key, which this panel does not collect, so this is
-   *  reachable only when a node files audio under images/gifs/videos; the point
-   *  is that ONE kind decision now answers for every surface rather than two
-   *  that can drift. Audio is also kept out of the agent's inline delivery: an
-   *  audio file handed over as an inline IMAGE is a perception nobody had. */
+   *  an <img> — the #710 defect on a second surface. The point is that ONE kind
+   *  decision now answers for every surface rather than two that can drift.
+   *  Audio is also kept out of the agent's inline delivery: an audio file handed
+   *  over as an inline IMAGE is a perception nobody had.
+   *
+   *  DELIBERATELY NOT DONE HERE: collecting ComfyUI's own `audio` output key.
+   *  onExecuted reads images/gifs/videos only, so a SaveAudio render paints
+   *  nothing in chat today and reports nothing to the agent — that is silence,
+   *  not a false claim, so it is a missing feature on this surface rather than
+   *  the #710 honesty defect. Adding it changes what appears in chat after every
+   *  audio render and touches the completion-delivery lifecycle (#269/#468), so
+   *  it belongs in its own change. Until then this branch covers a descriptor
+   *  that arrives misfiled under one of the three collected keys. */
   function isAudioOutput(m) {
     const fmt = String(m?.format || "").toLowerCase();
     if (fmt.startsWith("audio/")) return true;

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -15869,6 +15869,19 @@ const PANEL_CSS = `
 }
 .cmcp-imgcard:hover .cmcp-media-expand, .cmcp-media-expand:focus-visible { opacity: 1; }
 .cmcp-media-expand:hover { background: var(--p-primary-color, #3a7bd5); }
+/* Audio cards (#710) — a real <audio controls> player, and a link card for a
+   kind the panel can neither draw nor play. Neither is a .cmcp-imgcard: the
+   lightbox gallery collects those and renders every member as image/video. */
+.cmcp-audiocard audio { width: 100%; display: block; }
+.cmcp-filecard {
+  border: 1px solid var(--p-content-border-color, #3f3f46); border-radius: 6px;
+  padding: 0.5rem 0.6rem; background: var(--p-surface-800, #27272a);
+}
+.cmcp-file-open {
+  color: var(--p-primary-color, #60a5fa); text-decoration: none; font-size: 0.8rem;
+  word-break: break-all;
+}
+.cmcp-file-open:hover { text-decoration: underline; }
 /* Agent text flows freely — no card/bubble. Only user messages are boxed. */
 .cmcp-bubble.agent {
   align-self: stretch; max-width: 100%;
@@ -20027,6 +20040,75 @@ function buildPanel() {
     recordMedia("video", url, name);
   }
 
+  // An audio card is a real PLAYER, not a picture (#710). Audio used to fall
+  // through to paintImage — a ComfyUI /view ref can name anything on disk, so a
+  // .mp3 became an <img src="…mp3">, i.e. a broken-image icon with a caption
+  // under it, while panel_show_media still reported a full success.
+  //
+  // TWO THINGS THIS CARD DELIBERATELY DOES NOT DO:
+  //  - it is NOT a .cmcp-imgcard and carries NO _cmcpMedia. The chat lightbox
+  //    gathers every .cmcp-imgcard and renders each as an image or a video, so
+  //    an audio card in that gallery is the same broken <img> arriving by a
+  //    different route.
+  //  - it does not autoplay. A picture appearing is silent; sound starting on
+  //    its own is not, and the user asked to be shown a file, not played at.
+  function paintAudio(url, name) {
+    // Coerce the caption at the painter boundary — see paintImage (#276).
+    name = name == null ? name : coerceMessageText(name);
+    clearEmpty();
+    const card = document.createElement("div");
+    card.className = "cmcp-bubble agent cmcp-audiocard";
+    const audio = document.createElement("audio");
+    audio.controls = true;
+    audio.preload = "metadata";
+    audio.src = url;
+    audio.style.cssText = "width:100%;display:block;";
+    card.appendChild(audio);
+    if (name) {
+      const cap = document.createElement("div");
+      cap.style.cssText = "font-size:0.625rem;color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
+      cap.textContent = name;
+      card.appendChild(cap);
+    }
+    log.appendChild(card);
+    scrollLog();
+    // Persist servable audio so it survives reload / thread switch, AS AUDIO —
+    // a card stored as an image replays through paintImage next reload (#710).
+    recordMedia("audio", url, name);
+  }
+
+  // The last resort for a kind this panel can neither draw nor play (#710): a
+  // link the person can actually open. It is deliberately NOT a media card —
+  // no .cmcp-imgcard, no <img> — because the point is that nothing was
+  // rendered. panel_show_media reports these separately from `painted`, so the
+  // agent never learns that the user saw or heard something they did not.
+  function paintFileLink(url, name) {
+    // Coerce the caption at the painter boundary — see paintImage (#276).
+    name = name == null ? name : coerceMessageText(name);
+    clearEmpty();
+    const card = document.createElement("div");
+    card.className = "cmcp-bubble agent cmcp-filecard";
+    const a = document.createElement("a");
+    a.href = url;
+    a.className = "cmcp-file-open";
+    // A new tab, so a click never navigates the panel (and ComfyUI) away. The
+    // download hint makes the browser save rather than try to display a file it
+    // has no viewer for; a cross-origin URL ignores it and simply opens, which
+    // is the same outcome from the user's side.
+    a.target = "_blank";
+    a.rel = "noopener noreferrer";
+    if (name) a.download = name;
+    a.textContent = name || "Open file";
+    card.appendChild(a);
+    const hint = document.createElement("div");
+    hint.style.cssText = "font-size:0.625rem;color:var(--p-text-muted-color,#a1a1aa);margin-top:0.25rem;";
+    hint.textContent = "The panel can't preview this file type — open or download it.";
+    card.appendChild(hint);
+    log.appendChild(card);
+    scrollLog();
+    recordMedia("file", url, name);
+  }
+
   /** Decide whether a ComfyUI output descriptor is a VIDEO (render <video>) vs an
    *  image (<img>). ComfyUI groups video outputs under `gifs`/`videos` and tags
    *  them with a `format` like "video/h264-mp4" (vs "image/gif" for animated gifs,
@@ -20845,7 +20927,13 @@ function buildPanel() {
         if (m.role === "user") paintUser(m.text, { attachments: m.attachments, workflowVersion: m.workflowVersion });
         else if (m.role === "agent") paintAgent(m.text);
         else if (m.role === "media") {
+          // The kind decision has to be repeated here, or a reload replays an
+          // audio card through paintImage and the broken <img> is back (#710).
+          // Unrecognized kinds stay images: every record written before audio
+          // existed is one.
           if (m.mkind === "video") paintVideo(m.url, m.caption);
+          else if (m.mkind === "audio") paintAudio(m.url, m.caption);
+          else if (m.mkind === "file") paintFileLink(m.url, m.caption);
           else paintImage(m.url, m.caption);
         } else if (m.role === "card") {
           if (m.kind === "a2ui") paintA2UIRecord(m);
@@ -21858,8 +21946,8 @@ function buildPanel() {
     onTodo(items) {
       renderTodo(items);
     },
-    // The agent called panel_show_media — render images/videos directly in the
-    // chat AND answer the agent honestly about what it was handed (#648).
+    // The agent called panel_show_media — render images/videos/audio directly in
+    // the chat AND answer the agent honestly about what it was handed (#648).
     //
     // This used to paint and return nothing, so the tool replied {ok:true} to an
     // agent that had been shown nothing. For a video that reads as "I have seen
@@ -21867,10 +21955,16 @@ function buildPanel() {
     // impossible". composeShowMediaReply paints exactly as before and then routes
     // every video through the panel's EXISTING storyboard pipeline — bounded, and
     // disclosed as a sample rather than as the video.
+    //
+    // #710 widened the same principle to KIND: a painter per kind (audio plays,
+    // an unpresentable kind gets a link), and an item the panel cannot present
+    // is reported apart from `painted` instead of counted as a success.
     onShowMedia(items) {
       return composeShowMediaReply(items, {
         paintImage,
         paintVideo,
+        paintAudio,
+        paintFileLink,
         imageViewUrl,
         coerceMessageText,
         buildVideoStoryboard,

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -20120,6 +20120,21 @@ function buildPanel() {
     return /\.(mp4|webm|mov|mkv|m4v|avi)$/i.test(String(m?.filename || ""));
   }
 
+  /** The same question for AUDIO. The run-completion path had only the
+   *  image-vs-video split, so an audio descriptor arriving there was painted as
+   *  an <img> — the #710 defect on a second surface. ComfyUI files audio under
+   *  its own `audio` output key, which this panel does not collect, so this is
+   *  reachable only when a node files audio under images/gifs/videos; the point
+   *  is that ONE kind decision now answers for every surface rather than two
+   *  that can drift. Audio is also kept out of the agent's inline delivery: an
+   *  audio file handed over as an inline IMAGE is a perception nobody had. */
+  function isAudioOutput(m) {
+    const fmt = String(m?.format || "").toLowerCase();
+    if (fmt.startsWith("audio/")) return true;
+    if (fmt.startsWith("image/") || fmt.startsWith("video/")) return false;
+    return /\.(mp3|wav|flac|ogg|oga|opus|m4a|aac)$/i.test(String(m?.filename || ""));
+  }
+
   // ---- A2UI cards ------------------------------------------------------------
   // Live interactive cards by card_id (for panel_ui_update). Entries also point
   // at their thread record so resolve/update persist. Cards are per-mount DOM;
@@ -20875,18 +20890,29 @@ function buildPanel() {
   // sound the user has no way to pause (#710). Chat VIDEOS are spared this by
   // their IntersectionObserver, which unmounts them when they leave the DOM;
   // audio cards have no observer (pausing audio because it scrolled off screen
-  // would be its own bug), so they are released explicitly at every teardown.
-  function releaseChatAudio() {
+  // would be its own bug), so they are stopped explicitly whenever they leave.
+  //
+  // TWO KINDS OF LEAVING, and they must not be treated alike:
+  //  - PERMANENT (resetFeed, the panel's own destroy): the card is never coming
+  //    back, so release the source too and drop the decoded buffers.
+  //  - KEEP-ALIVE (a sidebar-tab switch, which only DETACHES this root and
+  //    re-attaches the same DOM on re-entry): pause ONLY. Dropping `src` here
+  //    would hand the returning user a dead player — trading one bug for
+  //    another — whereas a pause preserves the position they were at.
+  function stopChatAudio({ release = false } = {}) {
     try {
       for (const a of log.querySelectorAll("audio")) {
         try {
           a.pause();
-          a.removeAttribute("src");
-          a.load(); // drop the decoded buffers, same as the lightbox's releaseVideo
+          if (release) {
+            a.removeAttribute("src");
+            a.load(); // drop the decoded buffers, same as the lightbox's releaseVideo
+          }
         } catch { /* best-effort */ }
       }
     } catch { /* the log itself is already gone */ }
   }
+  const releaseChatAudio = () => stopChatAudio({ release: true });
 
   function resetFeed() {
     releaseChatAudio();
@@ -23483,6 +23509,12 @@ function buildPanel() {
         paintVideo(url, m.filename);
         // Carry the node id so the deferred storyboard event can name its node.
         videos.push({ m, nodeId });
+      } else if (isAudioOutput(m)) {
+        // Played, never painted as an image — and deliberately NOT added to
+        // inlineImages: that list is delivered to the agent as inline image
+        // blocks, so audio there would be both a broken picture and a claim of
+        // something the agent cannot perceive (#710).
+        paintAudio(url, m.filename);
       } else {
         paintImage(url, m.filename);
         inlineImages.push(m);
@@ -26347,6 +26379,15 @@ function buildPanel() {
       markAgentSeen();
       scrollLog();
     },
+    /** Called when the tab is left with the panel kept ALIVE (the root is
+     *  detached, not destroyed). A detached <audio> keeps playing and its
+     *  controls went with the root, so pause it — the chat's videos are already
+     *  paused here by their IntersectionObserver, and audio that kept going
+     *  while the panel was gone would be sound the user cannot reach (#710).
+     *  Pause only: the same element is re-attached on re-entry. */
+    onHide() {
+      stopChatAudio();
+    },
     setChatSurface: cmcpSetChatSurface, // A2UI seam: widen/restore the chat surface
     destroy() {
       try {
@@ -26445,7 +26486,7 @@ function buildPanel() {
 // `side-bar-button-selected` plus a unique `<tabId>-tab-button` class. When our tab
 // isn't selected we remove our own root; render() rebuilds it on re-entry. We guard
 // only OUR root, never another tab's.
-function installSidebarTabGuard(tabId, getRoot) {
+function installSidebarTabGuard(tabId, getRoot, onDetach) {
   const activeTabId = () => {
     const b = document.querySelector(".side-bar-button-selected");
     if (!b) return null;
@@ -26455,7 +26496,13 @@ function installSidebarTabGuard(tabId, getRoot) {
   const enforce = () => {
     if (activeTabId() === tabId) return;             // our tab active → keep content
     const r = getRoot();                              // inactive → drop our stray content
-    if (r && r.isConnected) r.remove();
+    if (r && r.isConnected) {
+      // This is the OTHER path that detaches a live panel (the tab's own
+      // destroy() is the first), so audio has to be paused here too — a
+      // detached <audio> keeps playing and its controls just left (#710).
+      try { onDetach?.(); } catch { /* a pause that fails must not strand the stray root */ }
+      r.remove();
+    }
   };
   const start = (tries = 0) => {
     const toolbar = document.querySelector(".side-tool-bar-container");
@@ -26655,6 +26702,9 @@ function registerExtensionWhenReady(tries = 0) {
         destroy: () => {
           // Detach only — never mounted.destroy(). Tearing down here is what used
           // to kill the live agent whenever the user peeked at another tab.
+          // onHide() first: a detached <audio> keeps playing and its controls
+          // leave with the root, so it must be paused BEFORE the root goes (#710).
+          mounted?.onHide?.();
           mounted?.root?.remove();
         },
       };
@@ -26667,7 +26717,11 @@ function registerExtensionWhenReady(tries = 0) {
         // the panel stylesheet only loads on first render (codex-review F1).
         ensureTabIconStyle();
         mgr.registerSidebarTab(tabSpec);
-        installSidebarTabGuard(tabId, () => document.querySelector(".cmcp-root"));
+        installSidebarTabGuard(
+          tabId,
+          () => document.querySelector(".cmcp-root"),
+          () => mounted?.onHide?.(),
+        );
       } else {
         console.error(
           "[comfyui-mcp-panel] app.extensionManager.registerSidebarTab is unavailable; " +

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -20870,7 +20870,26 @@ function buildPanel() {
     record({ role: "card", ...card });
   }
 
+  // Detaching a PLAYING <audio> does NOT stop it — the element goes on playing
+  // with its controls gone, so a thread/workflow switch mid-voice-line leaves
+  // sound the user has no way to pause (#710). Chat VIDEOS are spared this by
+  // their IntersectionObserver, which unmounts them when they leave the DOM;
+  // audio cards have no observer (pausing audio because it scrolled off screen
+  // would be its own bug), so they are released explicitly at every teardown.
+  function releaseChatAudio() {
+    try {
+      for (const a of log.querySelectorAll("audio")) {
+        try {
+          a.pause();
+          a.removeAttribute("src");
+          a.load(); // drop the decoded buffers, same as the lightbox's releaseVideo
+        } catch { /* best-effort */ }
+      }
+    } catch { /* the log itself is already gone */ }
+  }
+
   function resetFeed() {
+    releaseChatAudio();
     for (const el of [...log.children]) el.remove();
     streamBubbles.clear(); // drop any in-flight streaming previews (DOM is gone)
     // Drop live A2UI card handles — their DOM was just removed. Without this,
@@ -26346,6 +26365,10 @@ function buildPanel() {
       if (workWordTimer) { clearInterval(workWordTimer); workWordTimer = null; }
       if (thinkingSafety) { clearTimeout(thinkingSafety); thinkingSafety = null; }
       document.removeEventListener("keydown", onInterruptKeydown, true);
+      // Stop any chat audio before the panel's DOM goes away — a detached
+      // <audio> keeps playing, and after an unmount there is no card left to
+      // pause it with (#710). resetFeed() covers the in-panel teardowns.
+      releaseChatAudio();
       // Tear down a live media lightbox (#163): it's body-mounted with its own
       // window keydown listener, so without this an unmount/remount would strand
       // the overlay + listener (and a remount's fresh _activeLightboxClose tracker

--- a/web/js/lib/chat-media.js
+++ b/web/js/lib/chat-media.js
@@ -1,6 +1,7 @@
 // Media-card persistence helpers (issue #177).
 //
-// Image/video cards are persisted as role:"media" messages so they survive a
+// Media cards (image/video, plus audio and the unpresentable-file link card
+// added by #710) are persisted as role:"media" messages so they survive a
 // reload / thread switch. Only DURABLE, re-servable urls may be stored: a
 // ComfyUI `/view` link or an absolute http(s) URL. Everything else is rejected
 // on a POSITIVE-admission basis:
@@ -29,13 +30,21 @@ export function isDurableMediaUrl(url) {
   return false;
 }
 
+/** The kinds a stored card can replay as. Each one has its own painter in the
+ *  panel; a card stored under the WRONG kind replays through the wrong painter,
+ *  which is how an audio file came back as a broken <img> one reload after it
+ *  was fixed live (#710). "file" is the link card for a kind the panel cannot
+ *  present at all. Anything unrecognized stays "image" — that is what every
+ *  record written before this list existed actually is. */
+const MEDIA_KINDS = new Set(["image", "video", "audio", "file"]);
+
 /** Build the role:"media" record for a painted card, or null when it must not
  *  be persisted (currently replaying stored history, or a non-durable url).
  *  Kept pure so the admission + replay-guard logic is unit-testable. */
 export function mediaRecordFor(mkind, url, caption, { replaying = false } = {}) {
   if (replaying) return null; // replay repaints; it must never re-record (would dupe every reload)
   if (!isDurableMediaUrl(url)) return null;
-  const kind = mkind === "video" ? "video" : "image";
+  const kind = MEDIA_KINDS.has(mkind) ? mkind : "image";
   return {
     role: "media",
     mkind: kind,

--- a/web/js/lib/media-preview.js
+++ b/web/js/lib/media-preview.js
@@ -655,12 +655,24 @@ export async function composeShowMediaReply(items, deps = {}) {
   // One disclosure per audio file. The video branch already learned this lesson
   // the expensive way (#648): the agent must be told, in the same breath as the
   // good news, exactly which observations it is NOT entitled to make.
+  //
+  // WHAT `painted` CLAIMS, EXACTLY. Every painter here is synchronous: it puts
+  // an element in the chat, and returns before the browser has fetched or
+  // decoded a single byte. So `painted` means "a player for it is in the chat",
+  // never "the bytes decoded" — the same limit the image and video branches have
+  // always had. Rather than pretend otherwise (a `canPlayType` probe answers
+  // about the TYPE, not about this file, and would still miss a corrupt or
+  // missing one), the disclosure says what was observed and hands the one check
+  // that actually settles it to the person who can hear the result. The video
+  // branch's remedy already ends the same way, deliberately.
   for (const a of audible) {
     const human =
       a.shown === "unconfirmed"
         ? `Whether its player reached the chat is UNKNOWN, so ask the user whether they can play it before ` +
           `asking them about it.`
-        : `Its player is in the chat, so the USER can play it — ask them how it sounds if you need to know.`;
+        : `Its player is in the chat — that is a player, NOT proof the browser could decode the file, so ` +
+          `ask the user whether it actually plays before you rely on it (and how it sounds, if you need ` +
+          `to know).`;
     const fetchIt = a.ref
       ? `To get the file itself, call get_image with ${refClause(a.ref, text)} — audio is SAVED TO DISK ` +
         `rather than returned to you inline, so what you get is a path a local tool can open (you still ` +

--- a/web/js/lib/media-preview.js
+++ b/web/js/lib/media-preview.js
@@ -59,38 +59,114 @@ export const MEDIA_PREVIEW_TIMEOUT_MS = 20000;
 export const MEDIA_SIZE_PROBE_TIMEOUT_MS = 8000;
 
 /**
- * Filenames the panel plays as video.
+ * WHAT THE PANEL CAN ACTUALLY PRESENT (#710).
  *
- * The dot is escaped, unlike the inline test this replaces (`/.(mp4|webm)$/i`),
- * where `.` matched any character — so a file ending `xmp4` was painted as a
- * video. Widened past mp4/webm because a ComfyUI /view ref can name anything on
- * disk; the orchestrator's own inline path is stricter, which is fine, this only
- * has to decide "try to sample frames from it".
+ * The panel knew exactly two kinds, and everything that was not a video was
+ * painted with `<img>`. A ComfyUI /view ref can name ANYTHING on disk, so an
+ * audio output reached the image branch: the user got a broken-image icon with
+ * a caption under it, and the reply still said `painted:N, unconfirmed:0`. The
+ * agent then told them to listen to something nobody could hear.
  *
- * Anchored at the end, so it is applied to the filename with any query string or
- * fragment removed FIRST (see videoFilenameStem). A ref whose filename arrives
- * as `clip.mp4?download=1` is a video; classifying it as an image skips the
- * storyboard and the whole sampled-preview disclosure for a legitimate video,
- * which is the failure this module exists to prevent, reached by a different
- * route than the unescaped dot.
+ * So the kinds are an ALLOWLIST per element, and "not video" is no longer a
+ * synonym for "image". Each set is what that HTML element can actually play or
+ * draw — the question being answered is "can the person perceive this in the
+ * chat", which is a browser-decoding question, not a ComfyUI one:
+ *
+ *  - IMAGE  — deliberately generous, because this is the common path and a
+ *             legitimate image demoted to a link card is a regression a user
+ *             feels immediately. `gif` stays here (animated gifs render in
+ *             `<img>`), matching the panel's own isVideoOutput.
+ *  - VIDEO  — unchanged from the set this module already sampled frames from.
+ *  - AUDIO  — the suite's `upload_image action:"stage"` kind:"audio" set
+ *             (wav/mp3/flac/ogg/m4a/aac), PLUS oga/opus: that set governs what
+ *             ComfyUI's loaders accept, whereas this one governs what an
+ *             `<audio>` element decodes, and the Ogg family plays fine.
+ *
+ * Anything else is UNKNOWN, which is a decision and not a fallback: an unknown
+ * kind is never handed to a painter that will render it wrong, and never
+ * counted as painted.
  */
-const VIDEO_FILENAME = /\.(?:mp4|webm|mov|m4v|mkv|avi)$/i;
+const IMAGE_EXTENSIONS = new Set([
+  ".png", ".jpg", ".jpeg", ".jfif", ".webp", ".gif", ".apng", ".bmp", ".tif", ".tiff",
+  ".avif", ".ico", ".ppm", ".heic", ".heif", ".svg",
+]);
+const VIDEO_EXTENSIONS = new Set([".mp4", ".webm", ".mov", ".m4v", ".mkv", ".avi"]);
+const AUDIO_EXTENSIONS = new Set([
+  ".wav", ".mp3", ".flac", ".ogg", ".oga", ".opus", ".m4a", ".aac",
+]);
 
 /** The filename with a `?query` / `#fragment` tail removed. */
-function videoFilenameStem(filename) {
+function filenameStem(filename) {
   return String(filename).split("#")[0].split("?")[0];
+}
+
+/**
+ * The filename's extension, lowercased, WITH its dot — or "" when it has none.
+ *
+ * Read off the stem, so `clip.mp4?download=1` is still `.mp4`: a ref whose
+ * filename arrives with a query string must not be demoted to another kind,
+ * which for a video would skip the storyboard and the whole sampled-preview
+ * disclosure this module exists to produce.
+ *
+ * The dot is REQUIRED rather than implied, which is the structural version of
+ * the fix that escaped it in the old `/.(mp4|webm)$/i` (where `.` matched any
+ * character, so a file ending `xmp4` was painted as a video). A name with no dot
+ * has no extension here, and no set can match "".
+ */
+function extensionOf(filename) {
+  const m = /\.([A-Za-z0-9]+)$/.exec(filenameStem(filename));
+  return m ? `.${m[1].toLowerCase()}` : "";
 }
 
 const defaultCoerce = (v) => (typeof v === "string" ? v : v == null ? "" : String(v));
 
+function kindForExtension(ext) {
+  if (VIDEO_EXTENSIONS.has(ext)) return "video";
+  if (AUDIO_EXTENSIONS.has(ext)) return "audio";
+  if (IMAGE_EXTENSIONS.has(ext)) return "image";
+  return "unknown";
+}
+
+/**
+ * What kind of media one resolved show_media item is: `{ kind, ext }` where
+ * kind is "image" | "video" | "audio" | "unknown".
+ *
+ * THREE SOURCES OF TRUTH, IN THIS ORDER, because they are not equally informed:
+ *
+ *  1. The orchestrator's OWN `kind`. It set it from the file's extension and
+ *     built the data URL's MIME from the same decision, so second-guessing it
+ *     here would put two disagreeing classifiers on one item.
+ *  2. A /view ref's FILENAME. The orchestrator forwards these unclassified
+ *     (it never reads the bytes), so the panel is the first place that can
+ *     decide — this is the path the audio in #710 arrived on.
+ *  3. A data URL's declared MIME, for an item carrying neither. Nothing the
+ *     orchestrator sends today lands here; it is the honest answer for a
+ *     caller that hands over bytes without saying what they are.
+ *
+ * An item with no signal at all is UNKNOWN, never "probably an image".
+ */
+export function classifyShowMediaItem(item, coerce = defaultCoerce) {
+  if (!item) return { kind: "unknown", ext: "" };
+  const refName = item.kind === "viewRef" ? coerce(item.viewRef?.filename) : "";
+  const name = refName || coerce(item.filename);
+  const ext = extensionOf(name);
+  if (item.kind === "image" || item.kind === "video" || item.kind === "audio") {
+    return { kind: item.kind, ext };
+  }
+  if (name) {
+    const byName = kindForExtension(ext);
+    if (byName !== "unknown") return { kind: byName, ext };
+  }
+  if (typeof item.dataUrl === "string") {
+    const m = /^data:(image|video|audio)\//i.exec(item.dataUrl);
+    if (m) return { kind: m[1].toLowerCase(), ext };
+  }
+  return { kind: "unknown", ext };
+}
+
 /** True when a resolved show_media item should be treated as a video. */
 export function isVideoShowMediaItem(item, coerce = defaultCoerce) {
-  if (!item) return false;
-  if (item.kind === "video") return true;
-  if (item.kind === "viewRef" && item.viewRef) {
-    return VIDEO_FILENAME.test(videoFilenameStem(coerce(item.viewRef.filename)));
-  }
-  return false;
+  return classifyShowMediaItem(item, coerce).kind === "video";
 }
 
 /**
@@ -248,12 +324,20 @@ function refClause(ref, coerce) {
 }
 
 /**
- * Compose the panel's reply to one `show_media` command: paint every item for
- * the user, build a bounded sampled preview of every video, and return a reply
- * that states what the agent was and was not given.
+ * Compose the panel's reply to one `show_media` command: present every item to
+ * the user with the element its KIND actually needs, build a bounded sampled
+ * preview of every video, and return a reply that states what the agent was and
+ * was not given.
  *
- * Resolves to `{ ok, count, painted, previews, note }`. Never rejects — a reply
- * the agent cannot read is the failure this exists to remove.
+ * Resolves to `{ ok, count, painted, unconfirmed, unrenderable, previews, note }`.
+ * Never rejects — a reply the agent cannot read is the failure this exists to
+ * remove.
+ *
+ * `painted` counts ONLY items the person can now see or hear. An item whose kind
+ * the panel cannot present is reported in `unrenderable` instead (#710): it is
+ * the difference between "the user can hear this" and "I was handed something I
+ * could not present", and an agent that cannot tell them apart will confidently
+ * ask about a file nobody perceived.
  *
  * @param {Array<object>} items resolved show_media items from the orchestrator
  * @param {object} deps injected panel helpers (see the call site)
@@ -262,6 +346,8 @@ export async function composeShowMediaReply(items, deps = {}) {
   const {
     paintImage,
     paintVideo,
+    paintAudio,
+    paintFileLink,
     imageViewUrl,
     coerceMessageText = defaultCoerce,
     buildVideoStoryboard,
@@ -301,8 +387,22 @@ export async function composeShowMediaReply(items, deps = {}) {
   const jobs = [];
   let painted = 0;
   let unconfirmed = 0;
+  /** How many of `painted` the user can SEE vs HEAR — the headline must not
+   *  call an audio player a display, and must not leave the agent to guess
+   *  which sense it is talking about. */
+  const paintedByKind = { image: 0, video: 0, audio: 0 };
   /** Items the user cannot see, each with the REASON it is missing. */
   const dropped = [];
+  /** Items of a kind the panel cannot present at all (#710). Reported apart
+   *  from `painted` because a link the user has to open is not a rendering,
+   *  and apart from `dropped` because the user was still given SOMETHING. */
+  const unrenderable = [];
+  /** Audio the user can play. Each gets its own disclosure below, because an
+   *  audio card is the one thing here an agent is most likely to narrate
+   *  without having heard it. */
+  const audible = [];
+
+  const painterFor = { image: paintImage, video: paintVideo, audio: paintAudio };
 
   // ── Paint pass ──────────────────────────────────────────────────────────
   // One item's painter throwing must not cost the whole batch its reply, and
@@ -312,7 +412,8 @@ export async function composeShowMediaReply(items, deps = {}) {
   // cause sends the caller to re-send a file that was perfectly resolvable.
   for (const item of list) {
     const caption = text(item?.caption) || text(item?.filename) || "";
-    const isVideo = isVideoShowMediaItem(item, text);
+    const { kind, ext } = classifyShowMediaItem(item, text);
+    const isVideo = kind === "video";
     let url = null;
     let ref = null;
     let why = null;
@@ -353,7 +454,48 @@ export async function composeShowMediaReply(items, deps = {}) {
       });
       continue;
     }
-    const shownState = safePaint(isVideo ? paintVideo : paintImage, url, caption, note, name);
+    // A kind with no painter here is NOT painted as an image. That fallback is
+    // the whole of #710: an `<img>` pointed at an audio file is a broken-image
+    // icon, and the reply counted it as a success. The user still gets a link
+    // card — the person can open the file themselves, which is exactly the
+    // workaround the reporter ended up performing by hand — but a link is not a
+    // rendering, so it is reported as unrenderable rather than as painted.
+    const painter = painterFor[kind];
+    if (typeof painter !== "function") {
+      const linkState =
+        typeof paintFileLink === "function"
+          ? safePaint(paintFileLink, url, caption, note, name)
+          : "failed";
+      unrenderable.push({
+        name,
+        ext,
+        kind,
+        shown: linkState === "shown" ? "link" : linkState === "unconfirmed" ? "unconfirmed" : "nothing",
+        // The two ways to land here are genuinely different diagnoses, and one
+        // of them is a panel wiring bug the agent should not describe as a
+        // property of the user's file.
+        why:
+          kind === "unknown"
+            ? `the panel has no viewer or player for ${ext ? `"${ext}" files` : "a file with no extension"}`
+            : `this panel build has no ${kind} player wired, so it could not present a ${kind} file`,
+        // get_image is only a remedy when it will actually answer. It returns
+        // image/video/audio payloads and REFUSES anything else, so offering it
+        // for an unknown kind would be a next step that cannot be taken — the
+        // exact defect the rest of this module exists to remove.
+        remedy:
+          kind === "unknown"
+            ? `get_image returns only image/video/audio payloads and refuses anything else, so do not ` +
+              `assume you can fetch it either. Ask the user what they need from the file, or re-send it ` +
+              `as an image, video or audio file.`
+            : ref
+              ? `The file itself is fine — call get_image with ${refClause(ref, text)} to save it to disk ` +
+                `and get a path a local tool can open, and tell the user their player did not appear.`
+              : `The file itself is fine; this tool never sends it to you either. Tell the user their ` +
+                `player did not appear.`,
+      });
+      continue;
+    }
+    const shownState = safePaint(painter, url, caption, note, name);
     if (shownState === "failed") {
       dropped.push({
         name,
@@ -367,8 +509,15 @@ export async function composeShowMediaReply(items, deps = {}) {
             `sampled-preview note below for what you can still do with it, and tell the user their ` +
             `player did not appear.`
           : (ref
-              ? `The file itself resolved fine, so re-sending it unchanged will not help. To see it ` +
-                `YOURSELF, call get_image with ${refClause(ref, text)} — it returns the image inline. `
+              ? `The file itself resolved fine, so re-sending it unchanged will not help. To ` +
+                (kind === "audio"
+                  ? // An audio file is NOT returned inline, so "it returns the
+                    // image inline" would promise the agent a perception it
+                    // cannot have.
+                    `get the file YOURSELF, call get_image with ${refClause(ref, text)} — audio is saved ` +
+                    `to disk rather than returned to you, so you get a path a local tool can open, and ` +
+                    `you still cannot hear it. `
+                  : `see it YOURSELF, call get_image with ${refClause(ref, text)} — it returns the image inline. `)
               : `The file itself resolved fine, so re-sending it unchanged will not help; this tool never ` +
                 `sends it to you either. Put it somewhere ComfyUI serves and call get_image on it if you ` +
                 `need to look at it. `) +
@@ -378,6 +527,13 @@ export async function composeShowMediaReply(items, deps = {}) {
       unconfirmed += 1;
     } else {
       painted += 1;
+      paintedByKind[kind] += 1;
+    }
+    // Audio that reached a painter — confirmed or not — gets its own disclosure.
+    // A player in the chat is the user's to hear and NOT the agent's, and that
+    // asymmetry is what an agent narrating a voice line gets wrong.
+    if (kind === "audio" && shownState !== "failed") {
+      audible.push({ name: name || "audio", ref, shown: shownState });
     }
     // A video's sampled preview needs only the URL — not the chat player — so a
     // painter failure must NOT also cost the agent its preview.
@@ -438,30 +594,95 @@ export async function composeShowMediaReply(items, deps = {}) {
   // The batch headline. It leads with the thing an agent most easily gets wrong
   // about this tool: panel_show_media paints for the HUMAN and returns text, so
   // nothing here was shown to the caller.
-  const shown =
-    painted === 1 ? "1 item was displayed" : `${painted} items were displayed`;
+  //
+  // Seen and heard are counted APART. "3 items were displayed" over a batch that
+  // was two pictures and a voice line is the same class of error as the broken
+  // <img> it replaces: it tells the agent something about the user's senses that
+  // did not happen.
+  const seen = paintedByKind.image + paintedByKind.video;
+  const heard = paintedByKind.audio;
+  const shown = seen === 1 ? "1 item was displayed" : `${seen} items were displayed`;
+  const players =
+    heard === 1 ? "1 audio player was placed" : `${heard} audio players were placed`;
+  const clauses = [];
+  // A batch that presented nothing still needs the "0 items were displayed"
+  // clause — the reply must state the outcome, not omit it.
+  if (seen > 0 || heard === 0) clauses.push(`${shown} to the USER in the panel chat`);
+  if (heard > 0) {
+    clauses.push(seen > 0 ? `${players} there too` : `${players} in the panel chat for the USER`);
+  }
   const headline =
-    `${shown} to the USER in the panel chat. You were NOT sent ` +
+    `${clauses.join(", and ")}. You were NOT sent ` +
     (painted === 1 ? "this file" : "these files") +
-    ` — this tool renders media for the person, not for you.`;
+    ` — this tool renders media for the person, not for you.` +
+    (heard > 0 ? ` You cannot hear the audio.` : "");
   noteSections.push(headline);
 
   if (dropped.length > 0) {
     noteSections.push(
       `${dropped.length} of the ${list.length} requested item(s) were NOT displayed, so the user ` +
-        `cannot see ${dropped.length === 1 ? "it" : "them"} either:\n` +
+        `cannot see or hear ${dropped.length === 1 ? "it" : "them"} either:\n` +
         dropped
           .map((d) => `• ${d.name || "(unnamed item)"} — ${d.why}. ${d.remedy}`)
           .join("\n"),
     );
   }
 
+  // Items of a kind this panel cannot present. Kept SEPARATE from both painted
+  // and dropped: the user got a link, which is real and actionable, and is also
+  // not a rendering. An agent that reads this must come away unable to say the
+  // person saw or heard the content.
+  if (unrenderable.length > 0) {
+    const kinds = [...new Set(unrenderable.map((u) => u.ext || "no extension"))].join(", ");
+    noteSections.push(
+      `${unrenderable.length} of the ${list.length} requested item(s) are of a kind the panel cannot ` +
+        `present (${kinds}) — the USER has NOT seen or heard the content, so do not tell them to look ` +
+        `at or listen to ${unrenderable.length === 1 ? "it" : "them"}:\n` +
+        unrenderable
+          .map((u) => {
+            const got =
+              u.shown === "link"
+                ? `An open/download LINK is in the chat, so the user can open it themselves.`
+                : u.shown === "unconfirmed"
+                  ? `Whether even a link reached the chat is UNKNOWN.`
+                  : `The panel could not put even a link in the chat, so the user got nothing at all.`;
+            return `• ${u.name || "(unnamed item)"} — ${u.why}. ${got} ${u.remedy}`;
+          })
+          .join("\n"),
+    );
+  }
+
+  // One disclosure per audio file. The video branch already learned this lesson
+  // the expensive way (#648): the agent must be told, in the same breath as the
+  // good news, exactly which observations it is NOT entitled to make.
+  for (const a of audible) {
+    const human =
+      a.shown === "unconfirmed"
+        ? `Whether its player reached the chat is UNKNOWN, so ask the user whether they can play it before ` +
+          `asking them about it.`
+        : `Its player is in the chat, so the USER can play it — ask them how it sounds if you need to know.`;
+    const fetchIt = a.ref
+      ? `To get the file itself, call get_image with ${refClause(a.ref, text)} — audio is SAVED TO DISK ` +
+        `rather than returned to you inline, so what you get is a path a local tool can open (you still ` +
+        `cannot hear it). `
+      : `The panel has no ComfyUI reference for it, so there is nothing for you to re-fetch. `;
+    noteSections.push(
+      `🔊 ${a.name} — you were NOT sent this audio and there is no way for you to hear it, so do not ` +
+        `describe how it sounds, how long it is, or what is said in it. ` +
+        fetchIt +
+        human,
+    );
+  }
+
   if (unconfirmed > 0) {
     noteSections.push(
+      // "see or hear", because this count spans kinds: an audio player that did
+      // not settle is not something the user can SEE, and describing it that way
+      // is the same conflation the kind split exists to end (#710).
       `${unconfirmed} of the ${list.length} requested item(s) were handed to a painter that had not ` +
-        `finished when this reply was composed, so whether the user can see ` +
+        `finished when this reply was composed, so whether the user can see or hear ` +
         `${unconfirmed === 1 ? "it" : "them"} is UNKNOWN — do not assume ` +
-        `${unconfirmed === 1 ? "it was" : "they were"} displayed.`,
+        `${unconfirmed === 1 ? "it was" : "they were"} presented.`,
     );
   }
 
@@ -474,8 +695,19 @@ export async function composeShowMediaReply(items, deps = {}) {
   return {
     ok: true,
     count: list.length,
+    // Only what the person can SEE or HEAR. painted + unconfirmed +
+    // unrenderable.length + (dropped) === count, so a caller that reads nothing
+    // but the numbers still cannot mistake a link card for a rendering.
     painted,
     unconfirmed,
+    /** Structured twin of the note's unrenderable section, so the honesty does
+     *  not depend on an agent parsing prose (#710). */
+    unrenderable: unrenderable.map((u) => ({
+      name: u.name,
+      ext: u.ext,
+      kind: u.kind,
+      shown: u.shown,
+    })),
     previews,
     note: noteSections.join("\n\n"),
   };


### PR DESCRIPTION
Fixes #710.

## The defect, both halves

`panel_show_media` accepts any ComfyUI output ref, but the card renderer knew exactly two kinds and painted everything that was not a video with `<img>`. A `/view` ref can name anything on disk, so an audio output rendered as a **broken-image icon with a caption under it** — and the reply still said `{ok:true, painted:3, unconfirmed:0}`, a full success. The agent went on to tell the user to listen to something nobody could hear. Their answer was "??????????????????".

The second half is the one that matters, and it is #648's rule applied to kind: a tool that reports `painted` for something nobody can perceive is a *wrong answer* the agent then reasons from.

## What it renders now

- **Audio** → a real `<audio controls>` card. No autoplay: the user asked to be shown a file, not played at.
- **A kind the panel can neither draw nor play** → an open/download **link card**, which is exactly the workaround the reporter performed by hand. It is deliberately *not* counted as a rendering.
- Neither new card is a `.cmcp-imgcard` and neither sets `_cmcpMedia`: the chat lightbox gathers those and renders every member as image/video, so an audio card in that gallery would be the same broken `<img>` arriving by another route.

## How kind is decided

Three sources, in order of how well informed they are: the orchestrator's own `kind` (it built the data URL's MIME from the same decision) → a `/view` ref's filename extension (the orchestrator forwards these unclassified; this is the path #710's audio arrived on) → a data URL's declared MIME. **An item with no signal is UNKNOWN, which is a decision and not a fallback to `<img>`.**

Extensions are an allowlist per element, because the question is "can the person perceive this in the chat" — a browser-decoding question, not a ComfyUI one. Audio mirrors the suite's `upload_image action:"stage"` `kind:"audio"` set plus `oga`/`opus`; the image set is deliberately generous, because a legitimate image demoted to a link card is a regression a user feels immediately.

## What the tool returns

| case | reply |
|---|---|
| image / video | unchanged — `painted` |
| audio | `painted`, plus a per-file disclosure: the agent was sent nothing, must not describe how it sounds, and a player is **not proof the browser decoded the file** — ask the user whether it actually plays. Remedy is `get_image`, which really does save audio to disk. |
| unpresentable kind | **not** `painted`. A new `unrenderable: [{name, ext, kind, shown}]` array plus prose saying the user has NOT seen or heard the content. The remedy deliberately does **not** name `get_image`: it returns only image/video/audio and refuses anything else, so offering it there would be a next step that cannot be taken. |
| link also failed | `shown: "nothing"` — "the user got nothing at all". |

Seen and heard are counted apart in the headline, so `3 items were displayed` can never be said of a batch that was two pictures and a voice line.

## The second copies of the kind decision

Both were found and closed, because leaving one behind reproduces the defect one step later:
- **reload/replay** — the persisted record now carries `mkind: "audio" | "file"` and `paintThread` replays through the matching painter (an unknown kind stays `image`, which is what every pre-existing record is);
- **run completion** — `isAudioOutput()` mirrors `isVideoOutput()`, routes to `paintAudio`, and keeps audio out of `inlineImages` (that list is delivered to the agent as inline **image** blocks).

## Audio that outlives its controls

A detached `<audio>` keeps playing. Chat videos are spared this by their IntersectionObserver; audio has none (pausing it because it scrolled off screen would be its own bug), so it is stopped explicitly — and the two kinds of leaving are not treated alike:
- **permanent** (`resetFeed`, the panel's `destroy`) — pause *and* drop the source;
- **keep-alive** (a sidebar-tab switch, which detaches the root and re-attaches the same DOM) — **pause only**, via a new `onHide()` on the panel handle. Dropping `src` there would hand the returning user a dead player.

## Verification

- Failing test written first: on `origin/main`'s behaviour the audio case does not report a plain painted-success.
- Full unit suite: **2571 pass / 0 fail** (was 2554). `node --check`, `tsc --noEmit`, and the tool-vocabulary gate pass; the bundle **parses and links as an ES module** (verified by import, with a positive control proving a duplicate top-level declaration is caught); no control bytes and no git-binary files in the diff; YARA parity (svg+onload/onerror, spawn literals) clean.
- `pyproject.toml` / `PANEL_VERSION` untouched.
- **Mutation-verified**, each half separately:
  - counting `unrenderable` items as `painted` → fails *"a kind the panel cannot present is NOT counted as painted"*;
  - routing audio back to the image painter → fails *"an audio ref is PLAYED, never painted as an image"*;
  - `paintAudio` building an `<img>` → fails the panel-source wiring test;
  - dropping `releaseChatAudio()` from `resetFeed` → fails the teardown test;
  - dropping `onHide()` from the sidebar tab's destroy → fails the keep-alive test;
  - deleting the run-completion audio branch **and** short-circuiting its predicate → both fail the completion test. (An earlier version of that assertion survived the short-circuit; it was tightened.)

Three rounds of independent adversarial review. Round 1 (audio outliving teardown; `painted` overclaiming what a synchronous painter proves) and round 2 (the keep-alive detach paths; the run-completion kind decision) were fixed and re-reviewed closed.

## Deliberately out of scope

`onExecuted` reads `images`/`gifs`/`videos` only, so ComfyUI's own `audio` output key is still not collected and a `SaveAudio` render paints nothing in chat. That is pre-existing **silence, not a false claim** — a missing feature on the completion surface rather than #710's honesty defect — and collecting it changes what appears after every audio render and touches the completion-delivery lifecycle (#269/#468). Recorded as a decision at the classifier so it does not read as an oversight; worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)