### PR TITLE
fix(civitai): surface the upstream response body so a CivitAI outage stops reading as a broken search (#705)

### DIFF
--- a/browser_tests/unit/civitai-error-body.test.mjs
+++ b/browser_tests/unit/civitai-error-body.test.mjs
@@ -297,6 +297,49 @@ test("#705: ordinary prose containing 'token' or 'API key' is NOT redacted away"
   }
 });
 
+test("#705: a proxy body that does NOT declare retryability claims neither outcome", async () => {
+  // Codex gate round 2. A proxy older than this panel JS sends `source` without
+  // `retryable`. Falling back to the status would read OUR 502 as CivitAI's and
+  // print "the panel's proxy said …" immediately followed by "CivitAI failed
+  // this on its own side" — two contradictory claims in one sentence.
+  const err = await rejectionFrom(
+    clientReturning(
+      errorResponse(502, "Bad Gateway", '{"error":"redirect blocked","source":"comfyui-mcp-panel"}'),
+    ),
+  );
+  assert.equal(err.retryable, null);
+  assert.doesNotMatch(err.message, /CivitAI failed this request on its own side/);
+  assert.doesNotMatch(err.message, /retrying shortly may succeed/i);
+  assert.doesNotMatch(err.message, /will not help/i);
+  assert.match(err.message, /came from the panel's CivitAI proxy/);
+});
+
+test("#705: a `retryable` field on a body we did NOT author is ignored", async () => {
+  // Only the panel's own proxy gets to declare this; an upstream body claiming
+  // `retryable` must not steer our advice.
+  const err = await rejectionFrom(
+    clientReturning(errorResponse(400, "Bad Request", '{"error":"nope","retryable":true}')),
+  );
+  assert.equal(err.retryable, false);
+  assert.match(err.message, /CivitAI said/);
+  assert.match(err.message, /will not help/i);
+});
+
+test("#705: content dropped by the redaction window is never silently lost", async () => {
+  // Codex gate round 2: redaction SHRINKS text, so a body that overflowed the
+  // window can land back under the cap and skip the truncation marker — the
+  // reader sees a message that looks whole while the real cause sat past the
+  // window. Three long token runs, then the actual reason.
+  const raw =
+    `token=${"A".repeat(900)} token=${"B".repeat(900)} token=${"C".repeat(900)} ` +
+    "the actual cause was a schema migration";
+  const err = await rejectionFrom(
+    clientReturning(errorResponse(500, "Internal Server Error", JSON.stringify({ error: raw }))),
+  );
+  assert.doesNotMatch(err.detail, /AAAA|BBBB|CCCC/, "the credential runs are still redacted");
+  assert.ok(err.detail.endsWith("…"), `truncation must stay visible: ${err.detail}`);
+});
+
 test("#705: redaction of a huge hostile body stays fast (bounded window)", async () => {
   // The /api cap allows megabytes through, and the credential patterns have
   // adjacent overlapping quantifiers. Redacting the whole body would be wasted

--- a/browser_tests/unit/civitai-error-body.test.mjs
+++ b/browser_tests/unit/civitai-error-body.test.mjs
@@ -176,6 +176,25 @@ test("#705: a proxy-authored 401 still points at sign-in, not at the proxy", asy
   assert.equal(err.retryable, false);
 });
 
+test("#705: a proxy body with no readable message is not attributed to CivitAI either", async () => {
+  // Codex gate round 3: the "JSON with no error message" note hardcoded CivitAI,
+  // so a marked body that carried no readable message described OUR reply as
+  // CivitAI's while the advice beside it named the proxy.
+  const err = await rejectionFrom(
+    clientReturning(
+      errorResponse(502, "Bad Gateway", '{"source":"comfyui-mcp-panel","retryable":false}'),
+    ),
+  );
+  assert.doesNotMatch(err.message, /CivitAI's response body/);
+  assert.match(err.message, /panel's CivitAI proxy returned JSON with no error message/);
+  assert.equal(err.retryable, false);
+});
+
+test("#705: an UNMARKED body with no readable message is still attributed to CivitAI", async () => {
+  const err = await rejectionFrom(clientReturning(errorResponse(502, "Bad Gateway", '{"traceId":"x"}')));
+  assert.match(err.message, /CivitAI's response body was JSON with no error message/);
+});
+
 test("#705: a quote without terminal punctuation does not run into the advice", async () => {
   const err = await rejectionFrom(clientReturning(errorResponse(429, "Too Many Requests", '{"error":"slow down"}')));
   assert.ok(err.message.includes("“slow down”."), err.message);

--- a/browser_tests/unit/civitai-error-body.test.mjs
+++ b/browser_tests/unit/civitai-error-body.test.mjs
@@ -13,9 +13,9 @@
 // The bar these tests hold: the user must be able to tell an outage on the OTHER
 // side of the wire from a bug on ours — without the message ever pretending to a
 // cause it does not have.
-import { test } from "node:test";
+import { test, mock } from "node:test";
 import assert from "node:assert/strict";
-import { CivitaiClient } from "../../web/js/cmcp-civitai.js";
+import { CivitaiClient, CIVITAI_REQUEST_TIMEOUT_MS } from "../../web/js/cmcp-civitai.js";
 
 // Control characters, written as escapes on purpose: a literal control byte in
 // a source file makes it git-BINARY and unreviewable.
@@ -124,12 +124,56 @@ test("#705: a body the panel's OWN proxy authored is not narrated as CivitAI's w
     clientReturning(
       errorResponse(502, "Bad Gateway",
         '{"error":"CivitAI redirected the download to a host this proxy will not follow",' +
-        '"source":"comfyui-mcp-panel"}'),
+        '"source":"comfyui-mcp-panel","retryable":false}'),
     ),
   );
   assert.match(err.message, /panel's CivitAI proxy said/);
   assert.doesNotMatch(err.message, /CivitAI said/);
   assert.equal(err.detail, "CivitAI redirected the download to a host this proxy will not follow");
+});
+
+test("#705: a proxy guard's PERMANENT refusal is never sold as a transient outage", async () => {
+  // Codex gate P2. upstreamFailureClass(502) says "transient", but the 502 here
+  // is OURS: the redirect allow-list refused, and it will refuse identically
+  // forever. Advising a retry would be the wrong-advice half of this very issue.
+  const err = await rejectionFrom(
+    clientReturning(
+      errorResponse(502, "Bad Gateway",
+        '{"error":"CivitAI redirected the download to a host this proxy will not follow",' +
+        '"source":"comfyui-mcp-panel","retryable":false}'),
+    ),
+  );
+  assert.equal(err.retryable, false);
+  assert.doesNotMatch(err.message, /retrying shortly may succeed/i);
+  assert.match(err.message, /will not help/i);
+  // And it must not put words in CivitAI's mouth about what CivitAI did.
+  assert.doesNotMatch(err.message, /CivitAI failed this request on its own side/);
+});
+
+test("#705: a proxy failure the proxy calls RETRYABLE keeps the retry advice", async () => {
+  const err = await rejectionFrom(
+    clientReturning(
+      errorResponse(502, "Bad Gateway",
+        '{"error":"could not reach CivitAI: connection reset",' +
+        '"source":"comfyui-mcp-panel","retryable":true}'),
+    ),
+  );
+  assert.equal(err.retryable, true);
+  assert.match(err.message, /retrying shortly may succeed/i);
+  assert.match(err.message, /panel's CivitAI proxy/);
+});
+
+test("#705: a proxy-authored 401 still points at sign-in, not at the proxy", async () => {
+  // Whoever produced the body, the ACTION for a 401 is the same.
+  const err = await rejectionFrom(
+    clientReturning(
+      errorResponse(401, "Unauthorized",
+        '{"error":"sign-in required to download this file",' +
+        '"source":"comfyui-mcp-panel","retryable":false}'),
+    ),
+  );
+  assert.match(err.message, /sign in|sign-in|signed-in/i);
+  assert.equal(err.retryable, false);
 });
 
 test("#705: a quote without terminal punctuation does not run into the advice", async () => {
@@ -225,6 +269,47 @@ test("#705: a credential echoed back by the upstream is never re-displayed", asy
   assert.match(err.detail, /redacted/i);
 });
 
+test("#705: a Basic credential is redacted too — the scheme must not smuggle it through", async () => {
+  // Codex gate P2: the labelled-secret pattern could not step over an auth
+  // SCHEME, so "Authorization: Basic <base64>" walked straight through while
+  // Bearer was caught. Value below is base64 of a well-known RFC example pair.
+  const body = JSON.stringify({
+    error: "rejected: Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==",
+  });
+  const err = await rejectionFrom(clientReturning(errorResponse(401, "Unauthorized", body)));
+  assert.doesNotMatch(err.message, /QWxhZGRpbjpvcGVu/);
+  assert.doesNotMatch(err.detail, /QWxhZGRpbjpvcGVu/);
+  assert.match(err.detail, /redacted/i);
+});
+
+test("#705: ordinary prose containing 'token' or 'API key' is NOT redacted away", async () => {
+  // Over-redaction destroys the actionable message — the failure mode this whole
+  // change exists to remove. Short, wordy values must survive untouched.
+  for (const msg of [
+    "Your token expired, please sign in again",
+    "Invalid API key provided",
+    "authorization required for this endpoint",
+  ]) {
+    const err = await rejectionFrom(
+      clientReturning(errorResponse(401, "Unauthorized", JSON.stringify({ error: msg }))),
+    );
+    assert.equal(err.detail, msg);
+  }
+});
+
+test("#705: redaction of a huge hostile body stays fast (bounded window)", async () => {
+  // The /api cap allows megabytes through, and the credential patterns have
+  // adjacent overlapping quantifiers. Redacting the whole body would be wasted
+  // polynomial work on text that is discarded by the cap regardless.
+  const hostile = "token" + " ".repeat(200000) + "=".repeat(200000);
+  const started = Date.now();
+  const err = await rejectionFrom(
+    clientReturning(errorResponse(500, "Internal Server Error", JSON.stringify({ error: hostile }))),
+  );
+  assert.ok(Date.now() - started < 2000, "redaction must not blow up on a large body");
+  assert.ok(err.detail.length <= 240);
+});
+
 test("#705: a JWT-shaped string in the body is redacted even without a label", async () => {
   const jwtish = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJub3RyZWFsIn0.notarealsignaturehere";
   const err = await rejectionFrom(
@@ -252,6 +337,46 @@ test("#705: a body that cannot be read still yields the status message", async (
   assert.equal(err.detail, "");
   // The read failure is OUR problem, not something to narrate as CivitAI's.
   assert.doesNotMatch(err.message, /body stream already read/);
+});
+
+test("#705: a body that NEVER SETTLES must not turn a known 503 into a hang", async () => {
+  // Codex gate P1. Headers can arrive and the body then never finish. Reading it
+  // after the #417 abort budget was cleared would leave _request pending
+  // forever — _loadMore never reaching its catch/finally, the grid frozen on
+  // {loading:true, total:0, error:null}: the exact defect #417 removed,
+  // reintroduced by the fix for #705. The read happens INSIDE the budget, so the
+  // abort fires, the body read is abandoned, and the status is still reported.
+  mock.timers.enable({ apis: ["setTimeout"] });
+  try {
+    const client = new CivitaiClient({
+      fetchApi: async (_path, opts) => ({
+        ok: false,
+        status: 503,
+        statusText: "Service Unavailable",
+        // Real fetch errors a pending body read when its signal aborts.
+        text: () =>
+          new Promise((_resolve, reject) => {
+            opts.signal.addEventListener("abort", () => {
+              const e = new Error("The operation was aborted");
+              e.name = "AbortError";
+              reject(e);
+            });
+          }),
+      }),
+      apiURL: (p) => p,
+    });
+    const pending = client._request({ url: "https://civitai.red/api/v1/models" });
+    await Promise.resolve(); // let the fetch resolve and the body read start
+    mock.timers.tick(CIVITAI_REQUEST_TIMEOUT_MS + 1);
+    await assert.rejects(pending, (e) => {
+      assert.equal(e.status, 503);
+      assert.match(e.message, /CivitAI API 503: Service Unavailable/);
+      assert.equal(e.detail, "");
+      return true;
+    });
+  } finally {
+    mock.timers.reset();
+  }
 });
 
 test("#705: a response with no text() at all degrades to the status message", async () => {
@@ -289,7 +414,7 @@ test("#705: downloadVersionFile carries the upstream reason and status", async (
   const client = new CivitaiClient({
     fetchApi: async () =>
       errorResponse(401, "Unauthorized",
-        '{"error":"sign-in required to download this file","source":"comfyui-mcp-panel"}'),
+        '{"error":"sign-in required to download this file","source":"comfyui-mcp-panel","retryable":false}'),
     apiURL: (p) => p,
   });
   await assert.rejects(
@@ -309,7 +434,7 @@ test("#705: a download blocked by the proxy's own guard names the guard, and nam
     fetchApi: async () =>
       errorResponse(502, "Bad Gateway",
         '{"error":"CivitAI redirected the download to a host this proxy will not follow",' +
-        '"source":"comfyui-mcp-panel"}'),
+        '"source":"comfyui-mcp-panel","retryable":false}'),
     apiURL: (p) => p,
   });
   await assert.rejects(
@@ -317,7 +442,8 @@ test("#705: a download blocked by the proxy's own guard names the guard, and nam
     (e) => {
       assert.ok(e.message.includes("this proxy will not follow"));
       assert.match(e.message, /panel's CivitAI proxy said/);
-      assert.equal(e.retryable, true); // 502 is an upstream failure, not a rejection
+      // The guard is deterministic: retrying it unchanged can never work.
+      assert.equal(e.retryable, false);
       return true;
     },
   );

--- a/browser_tests/unit/civitai-error-body.test.mjs
+++ b/browser_tests/unit/civitai-error-body.test.mjs
@@ -1,0 +1,324 @@
+// Unit tests for #705 — CivitAI errors must carry the UPSTREAM RESPONSE BODY.
+//
+// The defect: a user searched "min" on the LoRA tab and got, repeatedly,
+//     CivitAI error: CivitAI API 503: Service Unavailable
+// A bare status reads as QUERY-SPECIFIC ("my search is broken") and sent the
+// reporter hunting for a bug in our code. It was a CivitAI-side outage of their
+// model-search backend, and their API said so in the response body:
+//     {"error":"Model search is temporarily overloaded — please retry."}
+// The Python proxy forwards that body verbatim with the upstream status; the
+// browser client then threw it away and built its Error from status/statusText
+// alone. Every bit of diagnostic value the proxy carried was lost at the last hop.
+//
+// The bar these tests hold: the user must be able to tell an outage on the OTHER
+// side of the wire from a bug on ours — without the message ever pretending to a
+// cause it does not have.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { CivitaiClient } from "../../web/js/cmcp-civitai.js";
+
+// Control characters, written as escapes on purpose: a literal control byte in
+// a source file makes it git-BINARY and unreviewable.
+const CONTROL_CHARS = /[\u0000-\u001f\u007f]/;
+
+/** A response double shaped like the one `fetchApi` hands back for a non-2xx
+ *  proxy reply: the body is readable exactly once, via text(). */
+function errorResponse(status, statusText, bodyText) {
+  return { ok: false, status, statusText, text: async () => bodyText };
+}
+
+const clientReturning = (response) =>
+  new CivitaiClient({ fetchApi: async () => response, apiURL: (p) => p });
+
+const rejectionFrom = async (client, spec = { url: "https://civitai.red/api/v1/models" }) => {
+  try {
+    await client._request(spec);
+  } catch (e) {
+    return e;
+  }
+  throw new Error("expected _request to reject");
+};
+
+// ── the reporter's exact failure ────────────────────────────────────────────
+
+test("#705: a 503 whose JSON body carries an `error` string surfaces that string", async () => {
+  const client = clientReturning(
+    errorResponse(503, "Service Unavailable",
+      '{"error":"Model search is temporarily overloaded — please retry."}'),
+  );
+  const err = await rejectionFrom(client);
+  // The regression this issue is about: the message must NOT be the bare status.
+  assert.notEqual(err.message, "CivitAI API 503: Service Unavailable");
+  // The actionable sentence CivitAI put in the body reaches the user…
+  assert.match(err.message, /Model search is temporarily overloaded — please retry\./);
+  // …attributed, so it reads as CivitAI's words and not as ours.
+  assert.match(err.message, /CivitAI said/);
+  // …and is available separately for the UI / the agent-facing error state.
+  assert.equal(err.detail, "Model search is temporarily overloaded — please retry.");
+  // The status still classifies the failure for existing callers (#190).
+  assert.equal(err.status, 503);
+});
+
+test("#705: nested JSON error shapes (error.message, tRPC error.json.message) are read too", async () => {
+  for (const [body, want] of [
+    ['{"error":{"message":"rate limit exceeded for this key"}}', "rate limit exceeded for this key"],
+    ['{"error":{"json":{"message":"UNAUTHORIZED"}}}', "UNAUTHORIZED"],
+    ['{"message":"upstream timeout talking to the search index"}', "upstream timeout talking to the search index"],
+    ['{"error":{"issues":[{"message":"Invalid enum value for sort"}]}}', "Invalid enum value for sort"],
+  ]) {
+    const err = await rejectionFrom(clientReturning(errorResponse(500, "Internal Server Error", body)));
+    assert.equal(err.detail, want, body);
+    assert.ok(err.message.includes(want), `message should quote ${want}`);
+  }
+});
+
+// ── body shapes that must NOT be dumped or over-claimed ─────────────────────
+
+test("#705: an HTML error page is REPORTED, never dumped into the message", async () => {
+  const html =
+    "<!DOCTYPE html><html><head><title>503 Service Temporarily Unavailable</title>" +
+    "<style>body{font:14px sans-serif}</style></head><body><h1>Error 503</h1>" +
+    "<p>Ray ID: 8f2a11c0abcdef</p></body></html>";
+  const err = await rejectionFrom(clientReturning(errorResponse(503, "Service Unavailable", html)));
+  // Dumping markup into a user-facing string is its own misleading-error bug.
+  assert.doesNotMatch(err.message, /</, "no markup may reach the message");
+  assert.doesNotMatch(err.message, /DOCTYPE|Ray ID/i);
+  // It still says MORE than the bare status: the shape of what came back.
+  assert.notEqual(err.message, "CivitAI API 503: Service Unavailable");
+  assert.match(err.message, /HTML/i);
+  // …without claiming a cause it does not have.
+  assert.match(err.message, /no machine-readable/i);
+  assert.equal(err.detail, "", "an HTML page yields no quotable upstream detail");
+});
+
+test("#705: an empty body says so plainly instead of inventing a cause", async () => {
+  const err = await rejectionFrom(clientReturning(errorResponse(503, "Service Unavailable", "")));
+  assert.match(err.message, /CivitAI API 503: Service Unavailable/);
+  assert.match(err.message, /no detail/i);
+  assert.equal(err.detail, "");
+  // Nothing invented: an empty body must not grow a fabricated reason.
+  assert.doesNotMatch(err.message, /overloaded|search is down|rate limit/i);
+});
+
+test("#705: a plain-text (non-JSON, non-HTML) body IS quoted", async () => {
+  const err = await rejectionFrom(clientReturning(errorResponse(502, "Bad Gateway", "upstream read error")));
+  assert.equal(err.detail, "upstream read error");
+  assert.ok(err.message.includes("upstream read error"));
+});
+
+// ── WHOSE words are these? ──────────────────────────────────────────────────
+// Attributing the panel proxy's own guard rails to CivitAI would be the same
+// misattribution #705 is about, pointed the other way. py/civitai_proxy.py tags
+// the bodies it authors with `source`; an untagged body is CivitAI's.
+
+test("#705: an unmarked body is attributed to CivitAI", async () => {
+  const err = await rejectionFrom(
+    clientReturning(errorResponse(503, "Service Unavailable", '{"error":"Model search is overloaded"}')),
+  );
+  assert.match(err.message, /CivitAI said/);
+  assert.doesNotMatch(err.message, /panel's CivitAI proxy said/);
+});
+
+test("#705: a body the panel's OWN proxy authored is not narrated as CivitAI's words", async () => {
+  const err = await rejectionFrom(
+    clientReturning(
+      errorResponse(502, "Bad Gateway",
+        '{"error":"CivitAI redirected the download to a host this proxy will not follow",' +
+        '"source":"comfyui-mcp-panel"}'),
+    ),
+  );
+  assert.match(err.message, /panel's CivitAI proxy said/);
+  assert.doesNotMatch(err.message, /CivitAI said/);
+  assert.equal(err.detail, "CivitAI redirected the download to a host this proxy will not follow");
+});
+
+test("#705: a quote without terminal punctuation does not run into the advice", async () => {
+  const err = await rejectionFrom(clientReturning(errorResponse(429, "Too Many Requests", '{"error":"slow down"}')));
+  assert.ok(err.message.includes("“slow down”."), err.message);
+});
+
+test("#705: JSON with no recognizable message field reports the shape, not the blob", async () => {
+  const err = await rejectionFrom(
+    clientReturning(errorResponse(500, "Internal Server Error", '{"traceId":"abc","meta":{"a":1,"b":[2,3]}}')),
+  );
+  assert.equal(err.detail, "");
+  assert.match(err.message, /no error message/i);
+  assert.doesNotMatch(err.message, /traceId|\{|\}/);
+});
+
+// ── transient vs terminal: the ADVICE differs, and getting it wrong misleads ─
+
+test("#705: a 503 is transient — retrying is worth advising", async () => {
+  const err = await rejectionFrom(clientReturning(errorResponse(503, "Service Unavailable", "")));
+  assert.match(err.message, /retry/i);
+  assert.equal(err.retryable, true);
+});
+
+test("#705: a 429 is transient too", async () => {
+  const err = await rejectionFrom(clientReturning(errorResponse(429, "Too Many Requests", '{"error":"slow down"}')));
+  assert.match(err.message, /retry/i);
+  assert.equal(err.retryable, true);
+});
+
+test("#705: a 400 is TERMINAL — it must never be dressed up as 'retry shortly'", async () => {
+  // #459: CivitAI ZodError-rejects an out-of-enum sort/period with a hard 400.
+  // Telling the user to retry an unchanged malformed query is wrong guidance.
+  const err = await rejectionFrom(
+    clientReturning(errorResponse(400, "Bad Request", '{"error":"Invalid enum value. Expected Newest | Oldest"}')),
+  );
+  assert.equal(err.retryable, false);
+  assert.match(err.detail, /Invalid enum value/);
+  assert.match(err.message, /not help/i);
+  assert.doesNotMatch(err.message, /retry shortly|retrying shortly/i);
+});
+
+test("#705: a 404 is terminal as well", async () => {
+  const err = await rejectionFrom(clientReturning(errorResponse(404, "Not Found", "")));
+  assert.equal(err.retryable, false);
+  assert.doesNotMatch(err.message, /retrying shortly/i);
+});
+
+test("#705: 401/403 point at sign-in rather than at retrying", async () => {
+  for (const status of [401, 403]) {
+    const err = await rejectionFrom(clientReturning(errorResponse(status, "Unauthorized", "")));
+    assert.equal(err.retryable, false, `status ${status}`);
+    assert.match(err.message, /sign in|signed-in|sign-in/i, `status ${status}`);
+    assert.doesNotMatch(err.message, /retrying shortly/i, `status ${status}`);
+  }
+});
+
+// ── the body is untrusted, arbitrary-length text going into the UI ───────────
+
+test("#705: an oversized body is capped, with the truncation visible", async () => {
+  const long = "A".repeat(20000);
+  const err = await rejectionFrom(
+    clientReturning(errorResponse(500, "Internal Server Error", JSON.stringify({ error: long }))),
+  );
+  assert.ok(err.detail.length < 400, `detail was ${err.detail.length} chars`);
+  assert.ok(err.detail.endsWith("…"), "truncation must be visible, not silent");
+  assert.ok(err.message.length < 700, `message was ${err.message.length} chars`);
+});
+
+test("#705: newlines and control bytes are flattened out of the message", async () => {
+  const nasty = "line one\nline two\r\n\tindented \u001b[31mred";
+  const err = await rejectionFrom(
+    clientReturning(errorResponse(500, "Internal Server Error", JSON.stringify({ error: nasty }))),
+  );
+  // A one-line error card must stay one line, and no control byte (ANSI escapes
+  // included) may ride an untrusted body into the UI or the console.
+  assert.doesNotMatch(err.message, CONTROL_CHARS);
+  assert.doesNotMatch(err.detail, CONTROL_CHARS);
+  assert.match(err.detail, /line one line two indented/);
+});
+
+test("#705: a credential echoed back by the upstream is never re-displayed", async () => {
+  // The proxy injects the CivitAI OAuth bearer server-side. An upstream that
+  // echoes the request's auth header into its error body must not turn our own
+  // error card (or the ComfyUI console) into a token leak.
+  // NOTE: the values below are deliberately NOT real-token-shaped secrets.
+  const body = JSON.stringify({
+    error: "rejected request with Authorization: Bearer notarealtokenvaluenotarealtoken",
+  });
+  const err = await rejectionFrom(clientReturning(errorResponse(401, "Unauthorized", body)));
+  assert.doesNotMatch(err.message, /notarealtokenvalue/);
+  assert.doesNotMatch(err.detail, /notarealtokenvalue/);
+  assert.match(err.detail, /redacted/i);
+});
+
+test("#705: a JWT-shaped string in the body is redacted even without a label", async () => {
+  const jwtish = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJub3RyZWFsIn0.notarealsignaturehere";
+  const err = await rejectionFrom(
+    clientReturning(errorResponse(500, "Internal Server Error", JSON.stringify({ error: `sent ${jwtish} upstream` }))),
+  );
+  assert.doesNotMatch(err.message, /eyJ/);
+  assert.doesNotMatch(err.detail, /eyJ/);
+});
+
+// ── reading the body must never MASK the failure it is describing ───────────
+
+test("#705: a body that cannot be read still yields the status message", async () => {
+  const err = await rejectionFrom(
+    clientReturning({
+      ok: false,
+      status: 503,
+      statusText: "Service Unavailable",
+      text: async () => {
+        throw new TypeError("body stream already read");
+      },
+    }),
+  );
+  assert.match(err.message, /CivitAI API 503: Service Unavailable/);
+  assert.equal(err.status, 503);
+  assert.equal(err.detail, "");
+  // The read failure is OUR problem, not something to narrate as CivitAI's.
+  assert.doesNotMatch(err.message, /body stream already read/);
+});
+
+test("#705: a response with no text() at all degrades to the status message", async () => {
+  const err = await rejectionFrom(clientReturning({ ok: false, status: 503, statusText: "Service Unavailable" }));
+  assert.match(err.message, /CivitAI API 503: Service Unavailable/);
+  assert.equal(err.detail, "");
+});
+
+// ── the success path is untouched ───────────────────────────────────────────
+
+test("#705: a 2xx still returns the normalized body and never touches text()", async () => {
+  let textCalls = 0;
+  const client = new CivitaiClient({
+    fetchApi: async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ items: [1, 2, 3] }),
+      text: async () => {
+        textCalls++;
+        return "{}";
+      },
+    }),
+    apiURL: (p) => p,
+  });
+  assert.deepEqual(await client._request({ url: "https://civitai.red/api/v1/models" }), { items: [1, 2, 3] });
+  assert.equal(textCalls, 0, "the success path must not read the body twice");
+});
+
+// ── the OTHER call site with the same swallow: the download route ───────────
+
+test("#705: downloadVersionFile carries the upstream reason and status", async () => {
+  // The body below is the one py/civitai_proxy.py really sends for a gated file
+  // (see _proxy_error / _is_auth_redirect); all of it was dropped for a bare
+  // `civitai download 401`.
+  const client = new CivitaiClient({
+    fetchApi: async () =>
+      errorResponse(401, "Unauthorized",
+        '{"error":"sign-in required to download this file","source":"comfyui-mcp-panel"}'),
+    apiURL: (p) => p,
+  });
+  await assert.rejects(
+    () => client.downloadVersionFile(1),
+    (e) => {
+      assert.equal(e.status, 401);
+      assert.match(e.message, /401/);
+      assert.ok(e.message.includes("sign-in required to download this file"));
+      assert.equal(e.detail, "sign-in required to download this file");
+      return true;
+    },
+  );
+});
+
+test("#705: a download blocked by the proxy's own guard names the guard, and names WHO blocked it", async () => {
+  const client = new CivitaiClient({
+    fetchApi: async () =>
+      errorResponse(502, "Bad Gateway",
+        '{"error":"CivitAI redirected the download to a host this proxy will not follow",' +
+        '"source":"comfyui-mcp-panel"}'),
+    apiURL: (p) => p,
+  });
+  await assert.rejects(
+    () => client.downloadVersionFile(1),
+    (e) => {
+      assert.ok(e.message.includes("this proxy will not follow"));
+      assert.match(e.message, /panel's CivitAI proxy said/);
+      assert.equal(e.retryable, true); // 502 is an upstream failure, not a rejection
+      return true;
+    },
+  );
+});

--- a/browser_tests/unit/civitai-upstream-error.test.mjs
+++ b/browser_tests/unit/civitai-upstream-error.test.mjs
@@ -294,7 +294,18 @@ test("#599: a plain upstream error with no prior attempt is unchanged", async ()
   await assert.rejects(
     () => client._request({ url: "https://civitai.red/api/v1/models" }),
     (err) => {
-      assert.equal(err.message, "CivitAI API 503: Service Unavailable");
+      // #705 changed this exact string: a bare status was the misleading-error
+      // defect, so the description now names what came back (here: nothing —
+      // this double has no text()) and whether retrying can help. The guard the
+      // test exists for is unchanged: no attempt trail, no cause, nothing about
+      // a first attempt that never happened.
+      assert.equal(
+        err.message,
+        "CivitAI API 503: Service Unavailable — There was no detail in CivitAI's " +
+          "response body. CivitAI failed this request on its own side rather than " +
+          "rejecting it, so retrying shortly may succeed.",
+      );
+      assert.doesNotMatch(err.message, /attempt/i);
       assert.equal(err.cause, undefined);
       return true;
     },

--- a/browser_tests/unit/test_civitai_api_route.py
+++ b/browser_tests/unit/test_civitai_api_route.py
@@ -148,6 +148,41 @@ class ApiPassthrough(unittest.IsolatedAsyncioTestCase):
         # The defining property: nothing partial is handed onward.
         self.assertNotIn("xxxx", body["error"])
         self.assertLess(len(await resp.text()), 1024)
+        # This refusal is OURS, so it must be attributed to us and must not be
+        # advertised as worth retrying — the panel would otherwise narrate the
+        # proxy's own limit as a transient CivitAI outage.
+        self.assertEqual(body["source"], cp._PROXY_SOURCE)
+        self.assertIs(body["retryable"], False)
+
+    # --- proxy-authored errors declare who spoke and whether to retry ---------
+
+    async def test_proxy_authored_errors_are_tagged_and_classified(self):
+        """`source` keeps the panel from quoting our guard rails as CivitAI's
+        words; `retryable` keeps it from advising a retry that cannot work. The
+        status alone carries neither fact — our 502 covers both a transient
+        "could not reach CivitAI" and a permanent allow-list refusal."""
+        cp._host_ok = self._host_ok  # this test wants the REAL allow-list
+        resp = await self.client.post(
+            "/comfyui_mcp_panel/civitai/api", json={"url": "not-a-url"}
+        )
+        self.assertEqual(resp.status, 400)
+        body = await resp.json()
+        self.assertEqual(body["source"], cp._PROXY_SOURCE)
+        self.assertIs(body["retryable"], False)
+        self.assertIn("allow-list", body["error"])
+
+    async def test_an_unreachable_upstream_is_marked_retryable(self):
+        # Point the route at a port nothing is listening on: the request fails at
+        # the socket, which IS worth retrying, and must say so.
+        resp = await self.client.post(
+            "/comfyui_mcp_panel/civitai/api",
+            json={"url": "http://127.0.0.1:1/api/v1/models"},
+        )
+        self.assertEqual(resp.status, 502)
+        body = await resp.json()
+        self.assertEqual(body["source"], cp._PROXY_SOURCE)
+        self.assertIs(body["retryable"], True)
+        self.assertIn("could not reach CivitAI", body["error"])
 
     # --- where redaction lives, pinned on purpose ----------------------------
 

--- a/browser_tests/unit/test_civitai_api_route.py
+++ b/browser_tests/unit/test_civitai_api_route.py
@@ -1,0 +1,168 @@
+"""aiohttp-LEVEL integration tests for the /civitai/api passthrough route (#705).
+
+The panel's user-facing CivitAI error now QUOTES the upstream response body, so
+this route's contract matters in a way it did not before: it must hand the body
+back verbatim with the upstream status — whatever shape that body is in (JSON,
+HTML, empty) — and it must bound what it buffers without ever truncating a body
+into unparseable garbage.
+
+These mount the REAL route via civitai_proxy.register — exactly as __init__.py
+does — in a live aiohttp Application, driven against a mock "civitai" upstream.
+
+Run (needs aiohttp, i.e. ComfyUI's interpreter):
+    python -m unittest browser_tests.unit.test_civitai_api_route
+    python browser_tests/unit/test_civitai_api_route.py
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "py"))
+
+from aiohttp import web  # noqa: E402
+from aiohttp.test_utils import TestClient, TestServer  # noqa: E402
+
+import civitai_proxy as cp  # noqa: E402
+
+# The exact body CivitAI served during the outage reported in #705 (the em dash
+# is spelled as an escape so this file stays plain ASCII).
+OUTAGE_BODY = '{"error":"Model search is temporarily overloaded \\u2014 please retry."}'
+# A CDN/edge error page: a 5xx that never reached the API at all.
+HTML_BODY = "<!DOCTYPE html><html><body><h1>503 Service Temporarily Unavailable</h1></body></html>"
+
+
+def _build_app():
+    """Mount the real /api route plus the mock upstream it proxies to."""
+    routes = web.RouteTableDef()
+    cp.register(routes, web)
+
+    async def mock_models(request):
+        case = request.query.get("case", "ok")
+        if case == "outage":
+            return web.Response(body=OUTAGE_BODY, status=503, content_type="application/json")
+        if case == "html":
+            return web.Response(body=HTML_BODY, status=503, content_type="text/html")
+        if case == "empty":
+            return web.Response(body=b"", status=503)
+        if case == "terminal":
+            return web.Response(
+                body='{"error":"Invalid enum value for sort"}',
+                status=400,
+                content_type="application/json",
+            )
+        if case == "oversize":
+            # Deliberately past whatever cap is in force for this test.
+            filler = "x" * (cp._API_CAP + 1024)
+            return web.Response(
+                body='{"items":"' + filler + '"}', status=200, content_type="application/json"
+            )
+        if case == "undersize":
+            # Comfortably under the cap: must survive byte for byte.
+            filler = "y" * max(1, cp._API_CAP // 2)
+            return web.Response(
+                body='{"items":"' + filler + '"}', status=200, content_type="application/json"
+            )
+        if case == "echo_auth":
+            # An upstream that reflects the request's auth header back into its
+            # error body.
+            return web.Response(
+                body='{"error":"rejected: ' + request.headers.get("Authorization", "none") + '"}',
+                status=401,
+                content_type="application/json",
+            )
+        return web.Response(body='{"items":[1,2,3]}', status=200, content_type="application/json")
+
+    app = web.Application()
+    app.add_routes(routes)
+    app.router.add_get("/api/v1/models", mock_models)
+    return app
+
+
+class ApiPassthrough(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.client = TestClient(TestServer(_build_app()))
+        await self.client.start_server()
+        self.upstream = str(self.client.make_url("/")).rstrip("/") + "/api/v1/models"
+        # The route proxies allow-listed hosts only; point that check at the
+        # mock server for the duration of the test (same stubbing approach the
+        # /download route's integration test uses for its SSRF guards).
+        self._host_ok = cp._host_ok
+        cp._host_ok = lambda url: True
+        self._cap = cp._API_CAP
+
+    async def asyncTearDown(self):
+        cp._host_ok = self._host_ok
+        cp._API_CAP = self._cap
+        await self.client.close()
+
+    async def _post(self, case):
+        return await self.client.post(
+            "/comfyui_mcp_panel/civitai/api", json={"url": self.upstream + "?case=" + case}
+        )
+
+    # --- the body must reach the panel, which is what #705 depends on ---------
+
+    async def test_error_body_is_forwarded_verbatim_with_the_upstream_status(self):
+        """#705's premise: the actionable sentence must survive the proxy."""
+        resp = await self._post("outage")
+        self.assertEqual(resp.status, 503)
+        self.assertEqual(await resp.text(), OUTAGE_BODY)
+
+    async def test_html_error_page_is_forwarded_not_swallowed(self):
+        resp = await self._post("html")
+        self.assertEqual(resp.status, 503)
+        self.assertEqual(await resp.text(), HTML_BODY)
+
+    async def test_empty_error_body_keeps_its_status(self):
+        resp = await self._post("empty")
+        self.assertEqual(resp.status, 503)
+        self.assertEqual(await resp.text(), "")
+
+    async def test_terminal_4xx_body_is_forwarded_too(self):
+        resp = await self._post("terminal")
+        self.assertEqual(resp.status, 400)
+        self.assertIn("Invalid enum value", await resp.text())
+
+    async def test_success_body_is_unchanged(self):
+        resp = await self._post("ok")
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(await resp.json(), {"items": [1, 2, 3]})
+
+    # --- the bound, and the thing the bound must never do --------------------
+
+    async def test_a_body_under_the_cap_survives_intact(self):
+        """A truncated body would be a NEW misleading error in place of the old
+        one, so the cap must be invisible to anything legitimately sized."""
+        cp._API_CAP = 256 * 1024
+        resp = await self._post("undersize")
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(len((await resp.json())["items"]), cp._API_CAP // 2)
+
+    async def test_an_over_cap_body_is_refused_rather_than_truncated(self):
+        cp._API_CAP = 256 * 1024
+        resp = await self._post("oversize")
+        self.assertEqual(resp.status, 502)
+        body = await resp.json()
+        self.assertIn("exceeded", body["error"])
+        # The defining property: nothing partial is handed onward.
+        self.assertNotIn("xxxx", body["error"])
+        self.assertLess(len(await resp.text()), 1024)
+
+    # --- where redaction lives, pinned on purpose ----------------------------
+
+    async def test_the_proxy_forwards_bodies_verbatim_by_design(self):
+        """An upstream can echo the request's auth header back into its error
+        body. The proxy does NOT rewrite bodies; the redaction that keeps a
+        credential off the screen lives where the text is DISPLAYED (the browser
+        client's describeUpstreamFailure). This pins that split so a later change
+        cannot quietly assume the proxy is scrubbing on its behalf."""
+        resp = await self._post("echo_auth")
+        self.assertEqual(resp.status, 401)
+        # No OAuth session exists here, so no Authorization header was sent at
+        # all — the proxy only attaches one when a stored session is present.
+        self.assertIn("none", await resp.text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/browser_tests/unit/test_civitai_download_route.py
+++ b/browser_tests/unit/test_civitai_download_route.py
@@ -135,7 +135,12 @@ class DownloadRouteIntegration(unittest.TestCase):
             try:
                 resp = await client.get("/comfyui_mcp_panel/civitai/download?versionId=2")
                 self.assertEqual(resp.status, 502)
-                self.assertIn("redirect target not allowed", await resp.text())
+                # #705: the guard's reason is now a JSON body the panel can quote,
+                # tagged with `source` so it is attributed to THIS proxy and not
+                # narrated to the user as something CivitAI said.
+                body = await resp.json()
+                self.assertIn("will not follow", body["error"])
+                self.assertEqual(body["source"], cp._PROXY_SOURCE)
             finally:
                 await client.close()
         self._run(go())

--- a/py/civitai_proxy.py
+++ b/py/civitai_proxy.py
@@ -67,10 +67,21 @@ _API_CAP = 16 * 1024 * 1024
 _PROXY_SOURCE = "comfyui-mcp-panel"
 
 
-def _proxy_error(web, message, status):
+def _proxy_error(web, message, status, retryable=False):
     """A JSON error THIS proxy authored, tagged so the panel attributes it to the
-    panel rather than to CivitAI."""
-    return web.json_response({"error": message, "source": _PROXY_SOURCE}, status=status)
+    panel rather than to CivitAI.
+
+    ``retryable`` is declared here rather than inferred from the status, because
+    the status belongs to US and says nothing about whether trying again helps: a
+    502 from the "could not reach CivitAI" path is worth retrying, and a 502 from
+    the redirect allow-list guard is a deterministic refusal that will fail
+    identically forever. Guessing from the number would tell the user to retry a
+    request that cannot succeed — the wrong-advice half of #705.
+    """
+    return web.json_response(
+        {"error": message, "source": _PROXY_SOURCE, "retryable": bool(retryable)},
+        status=status,
+    )
 
 
 # Only these hosts may be proxied (SSRF guard).
@@ -320,14 +331,11 @@ def register(routes, web):
                                 over = True
                                 break
                         if over:
-                            return web.json_response(
-                                {
-                                    "error": "CivitAI's response exceeded the {} MB proxy limit "
-                                    "and was discarded rather than truncated".format(
-                                        _API_CAP // (1024 * 1024)
-                                    )
-                                },
-                                status=502,
+                            return _proxy_error(
+                                web,
+                                "CivitAI's response exceeded the {} MB proxy limit and was "
+                                "discarded rather than truncated".format(_API_CAP // (1024 * 1024)),
+                                502,
                             )
                         try:
                             text = buf.decode(resp.charset or "utf-8", errors="replace")
@@ -348,8 +356,8 @@ def register(routes, web):
                         )
                 except Exception as e:  # network flake
                     if attempt == 2:
-                        return _proxy_error(web, "could not reach CivitAI: " + str(e), 502)
-        return _proxy_error(web, "could not reach CivitAI", 502)
+                        return _proxy_error(web, "could not reach CivitAI: " + str(e), 502, retryable=True)
+        return _proxy_error(web, "could not reach CivitAI", 502, retryable=True)
 
     # Upper bound on a single proxied media body (thumbs + full images). Generous
     # for any real CivitAI asset; caps memory for a hostile/oversize upstream.
@@ -423,7 +431,7 @@ def register(routes, web):
                         if resp.status in _REDIRECTS:
                             loc = resp.headers.get("Location")
                             if not loc:
-                                return _proxy_error(web, "CivitAI sent a redirect with no Location header", 502)
+                                return _proxy_error(web, "CivitAI sent a redirect with no Location header", 502, retryable=True)
                             u = resp.url.join(URL(loc))
                             # A redirect to civitai's own /login (live: 307 →
                             # /login?returnUrl=…&reason=download-auth) means the
@@ -475,7 +483,7 @@ def register(routes, web):
                             await out.write(chunk)
                         await out.write_eof()
                         return out
-                return _proxy_error(web, "CivitAI redirected the download too many times", 502)
+                return _proxy_error(web, "CivitAI redirected the download too many times", 502, retryable=True)
             except Exception as e:
                 # Surface the traceback to ComfyUI's log — a swallowed handler
                 # exception here reads as an opaque 502 to the panel.
@@ -486,7 +494,7 @@ def register(routes, web):
                     if request.transport is not None:
                         request.transport.close()
                     raise
-                return _proxy_error(web, "the download failed: " + str(e), 502)
+                return _proxy_error(web, "the download failed: " + str(e), 502, retryable=True)
 
     @routes.get("/comfyui_mcp_panel/civitai/oauth/start")
     async def _oauth_start(request):

--- a/py/civitai_proxy.py
+++ b/py/civitai_proxy.py
@@ -46,6 +46,33 @@ _CDN_KEY = "xG1nkqKTMzGDvpLrqFT7WA"
 # so the aiohttp-level integration test can point it at a local mock server.
 _DOWNLOAD_BASE = "https://civitai.red/api/download/models/"
 
+# Upper bound on a single proxied JSON body (/api). /media and /download were
+# both capped and /api was not, so an accidental or hostile multi-hundred-MB
+# upstream body was buffered whole inside the ComfyUI process and then shipped to
+# the browser. Generous for anything CivitAI really returns — a 100-item
+# /v1/models page is a few hundred KB.
+#
+# An over-cap body is REFUSED, never truncated: half a JSON document would reach
+# the panel as an unparseable body, i.e. a brand-new misleading error substituted
+# for the one #705 removed. Module-level (like _DOWNLOAD_BASE) so the
+# aiohttp-level test can shrink it instead of moving 16 MB through the loopback.
+_API_CAP = 16 * 1024 * 1024
+
+# Marker stamped on error bodies THIS MODULE generates, so the panel can tell
+# them apart from a body CivitAI produced (#705). Without it the browser sees
+# only "some JSON with an error field" and would quote our own guard rails back
+# at the user as "CivitAI said: redirect target not allowed" — the same class of
+# misattribution the issue is about, just pointed the other way. Bodies forwarded
+# from upstream are NEVER stamped: an absent marker means CivitAI spoke.
+_PROXY_SOURCE = "comfyui-mcp-panel"
+
+
+def _proxy_error(web, message, status):
+    """A JSON error THIS proxy authored, tagged so the panel attributes it to the
+    panel rather than to CivitAI."""
+    return web.json_response({"error": message, "source": _PROXY_SOURCE}, status=status)
+
+
 # Only these hosts may be proxied (SSRF guard).
 _ALLOWED_HOSTS = frozenset(
     {
@@ -256,10 +283,10 @@ def register(routes, web):
         try:
             spec = await request.json()
         except Exception:
-            return web.json_response({"error": "invalid JSON"}, status=400)
+            return _proxy_error(web, "the panel sent an invalid JSON request spec", 400)
         url = spec.get("url")
         if not isinstance(url, str) or not _host_ok(url):
-            return web.json_response({"error": "url host not allowed"}, status=400)
+            return _proxy_error(web, "that URL host is not on the CivitAI allow-list", 400)
         method = (spec.get("method") or "GET").upper()
         extra = spec.get("headers") if isinstance(spec.get("headers"), dict) else {}
         body = spec.get("body")
@@ -281,7 +308,39 @@ def register(routes, web):
 
                             await asyncio.sleep(0.35 * (2**attempt))
                             continue
-                        text = await resp.text()
+                        # Read in bounded chunks rather than resp.text(): the
+                        # body is untrusted and, on an error, is exactly what
+                        # the panel now quotes back to the user (#705), so it
+                        # must not be able to grow without limit on the way.
+                        buf = bytearray()
+                        over = False
+                        async for chunk in resp.content.iter_chunked(1 << 16):
+                            buf += chunk
+                            if len(buf) > _API_CAP:
+                                over = True
+                                break
+                        if over:
+                            return web.json_response(
+                                {
+                                    "error": "CivitAI's response exceeded the {} MB proxy limit "
+                                    "and was discarded rather than truncated".format(
+                                        _API_CAP // (1024 * 1024)
+                                    )
+                                },
+                                status=502,
+                            )
+                        try:
+                            text = buf.decode(resp.charset or "utf-8", errors="replace")
+                        except LookupError:
+                            # Upstream named a charset this Python doesn't know;
+                            # decode permissively rather than 500 on the panel.
+                            text = buf.decode("utf-8", errors="replace")
+                        # NOTE: the body is forwarded VERBATIM with the upstream
+                        # status — the panel's client is what turns it into a
+                        # user-facing sentence (bounded, credential-redacted,
+                        # attributed; see describeUpstreamFailure). content_type
+                        # is stamped json even when CivitAI answered with HTML,
+                        # so the client sniffs the body and never trusts this.
                         return web.Response(
                             body=text,
                             status=resp.status,
@@ -289,8 +348,8 @@ def register(routes, web):
                         )
                 except Exception as e:  # network flake
                     if attempt == 2:
-                        return web.json_response({"error": str(e)}, status=502)
-        return web.json_response({"error": "unreachable"}, status=502)
+                        return _proxy_error(web, "could not reach CivitAI: " + str(e), 502)
+        return _proxy_error(web, "could not reach CivitAI", 502)
 
     # Upper bound on a single proxied media body (thumbs + full images). Generous
     # for any real CivitAI asset; caps memory for a hostile/oversize upstream.
@@ -347,7 +406,7 @@ def register(routes, web):
     async def _civitai_download(request):
         version_id = request.query.get("versionId", "")
         if not version_id.isdigit():
-            return web.Response(status=400, text="numeric versionId required")
+            return _proxy_error(web, "a numeric versionId is required", 400)
         q = {k: request.query[k] for k in ("type", "format") if request.query.get(k)}
         url = _DOWNLOAD_BASE + version_id
         if q:
@@ -364,7 +423,7 @@ def register(routes, web):
                         if resp.status in _REDIRECTS:
                             loc = resp.headers.get("Location")
                             if not loc:
-                                return web.Response(status=502, text="redirect without Location")
+                                return _proxy_error(web, "CivitAI sent a redirect with no Location header", 502)
                             u = resp.url.join(URL(loc))
                             # A redirect to civitai's own /login (live: 307 →
                             # /login?returnUrl=…&reason=download-auth) means the
@@ -374,18 +433,15 @@ def register(routes, web):
                             # hint deterministically, instead of chasing the
                             # login page and handing back its HTML as the file.
                             if _is_auth_redirect(u.path, u.query_string):
-                                return web.json_response(
-                                    {"error": "sign-in required to download this file"},
-                                    status=401,
-                                )
+                                return _proxy_error(web, "sign-in required to download this file", 401)
                             # SSRF guard: only follow to https on a civitai/B2
                             # host, and only when EVERY address it resolves to
                             # is public — never loopback/RFC1918/link-local/
                             # metadata, even via a rebinding DNS answer.
                             if u.scheme != "https" or not _redirect_host_ok(u.host):
-                                return web.Response(status=502, text="redirect target not allowed")
+                                return _proxy_error(web, "CivitAI redirected the download to a host this proxy will not follow", 502)
                             if not await _resolves_public(u.host):
-                                return web.Response(status=502, text="redirect target not allowed")
+                                return _proxy_error(web, "CivitAI redirected the download to a host this proxy will not follow", 502)
                             url = str(u)
                             headers = dict(_API_HEADERS)  # drop Authorization on the hop
                             continue
@@ -396,12 +452,9 @@ def register(routes, web):
                         # than handing the panel an HTML "workflow" to choke on.
                         ctype = (resp.headers.get("Content-Type") or "").lower()
                         if ctype.startswith("text/html"):
-                            return web.json_response(
-                                {"error": "sign-in required to download this file"},
-                                status=401,
-                            )
+                            return _proxy_error(web, "sign-in required to download this file", 401)
                         if (resp.content_length or 0) > _DL_CAP:
-                            return web.Response(status=413, text="file too large")
+                            return _proxy_error(web, "the file is larger than the {} MB download limit".format(_DL_CAP // (1024 * 1024)), 413)
                         # Stream through — no 100MB buffer. Past the cap the
                         # headers are already gone, so abort the connection:
                         # the browser sees a failed fetch, never a silently
@@ -422,7 +475,7 @@ def register(routes, web):
                             await out.write(chunk)
                         await out.write_eof()
                         return out
-                return web.Response(status=502, text="too many redirects")
+                return _proxy_error(web, "CivitAI redirected the download too many times", 502)
             except Exception as e:
                 # Surface the traceback to ComfyUI's log — a swallowed handler
                 # exception here reads as an opaque 502 to the panel.
@@ -433,13 +486,13 @@ def register(routes, web):
                     if request.transport is not None:
                         request.transport.close()
                     raise
-                return web.Response(status=502, text="download error: " + str(e))
+                return _proxy_error(web, "the download failed: " + str(e), 502)
 
     @routes.get("/comfyui_mcp_panel/civitai/oauth/start")
     async def _oauth_start(request):
         origin = request.query.get("origin", "")
         if not origin.startswith("http"):
-            return web.json_response({"error": "origin required"}, status=400)
+            return _proxy_error(web, "origin required", 400)
         verifier, challenge = _pkce_pair()
         state = base64.urlsafe_b64encode(os.urandom(16)).rstrip(b"=").decode("ascii")
         redirect = origin.rstrip("/") + _CALLBACK_PATH

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -297,6 +297,14 @@ export function civitaiErrorState(e) {
     status,
     message: coerceMessageText(e?.message ?? e),
     ...(typeof e?.kind === "string" ? { kind: e.kind } : {}),
+    // #705: the upstream body's OWN words (already bounded, flattened and
+    // credential-redacted by describeUpstreamFailure) and whether retrying can
+    // help. The agent being able to report "CivitAI's model search is
+    // overloaded — retry shortly" instead of "503" is the point of the issue;
+    // both keys are omitted when absent so a transport/empty failure keeps its
+    // existing shape and cannot be read as a claim about the upstream.
+    ...(typeof e?.detail === "string" && e.detail ? { detail: e.detail } : {}),
+    ...(typeof e?.retryable === "boolean" ? { retryable: e.retryable } : {}),
   };
 }
 

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -287,6 +287,204 @@ export function normalizeTrpcResponse(data) {
   return data;
 }
 
+// ── upstream failure description (#705) ─────────────────────────────────────
+// A bare "CivitAI API 503: Service Unavailable" is a MISLEADING error, not just
+// a terse one: it reads as QUERY-SPECIFIC ("my search for 'min' is broken") and
+// sent the reporter of #705 hunting through our code, while the actual cause was
+// sitting in the response body the Python proxy already forwards verbatim —
+//   {"error":"Model search is temporarily overloaded — please retry."}
+// The user has to be able to tell an outage on CivitAI's side of the wire from a
+// bug on ours, and the body is the only place that distinction exists.
+//
+// Three rules hold everything below together:
+//   1. NEVER pretend to a cause. An empty body, an HTML edge-cache page and a
+//      JSON blob with no message field each get a description of what ACTUALLY
+//      came back; none of them get a fabricated reason. "503, no detail from
+//      CivitAI" beats a bare status, and beats an invented explanation by more.
+//   2. NEVER dump the body. It is untrusted, arbitrary-length text heading for a
+//      UI string and the ComfyUI console: bounded, flattened to one line, control
+//      bytes stripped, credential-shaped runs redacted, and always QUOTED and
+//      ATTRIBUTED so CivitAI's words can never be mistaken for ours. (The error
+//      card renders via textContent, so markup can't execute — but pasting a CDN
+//      error page into a sentence is its own misleading-error bug.)
+//   3. Advice follows the STATUS, not the body. "Retry shortly" is right for a
+//      503 and actively wrong for a 400 that will never succeed however often
+//      it is repeated.
+
+/** Longest run of upstream text quoted into a user-facing message. Generous
+ *  enough for a real API sentence, small enough that a hostile or accidental
+ *  megabyte-long body cannot BECOME the error card. */
+export const CIVITAI_DETAIL_MAX = 240;
+
+// Credential-shaped runs, redacted before any upstream text is displayed or
+// logged. The proxy injects the CivitAI OAuth bearer (and the MeiliSearch key)
+// into the REQUEST, server-side; an upstream that echoes a request header back
+// inside its error body must not turn our own error card into a token leak.
+// Two rules: a LABELLED secret (Authorization: Bearer …, api_key=…), and a bare
+// JWT, which is the shape of CivitAI's OAuth access tokens. The 20-char floor on
+// the value keeps ordinary prose intact ("Invalid API key provided" survives).
+const _LABELLED_SECRET_RE =
+  /\b(bearer|authorization|api[-_ ]?key|access[-_ ]?token|refresh[-_ ]?token|token)\b[\s:=]*["']?[A-Za-z0-9._~+/-]{20,}={0,2}["']?/gi;
+const _JWT_RE = /\beyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}/g;
+
+/** Replace credential-shaped runs with a visible marker. Never silently drop:
+ *  the reader should be able to tell that something was withheld. */
+export function redactCredentials(text) {
+  return String(text)
+    .replace(_JWT_RE, "[redacted]")
+    .replace(_LABELLED_SECRET_RE, (_m, label) => `${label} [redacted]`);
+}
+
+/** One-line, control-byte-free, credential-free, bounded rendering of untrusted
+ *  upstream text. Truncation is MARKED (…), never silent — a message that was
+ *  quietly cut in half is a new way to mislead. */
+function _cleanUpstreamText(raw) {
+  const flat = String(raw ?? "")
+    // Newlines, tabs, ANSI escapes and stray NULs all become spaces: a one-line
+    // error card must stay one line, and no control byte may ride an untrusted
+    // body into the DOM or the console.
+    .replace(/[\u0000-\u001f\u007f]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  const safe = redactCredentials(flat).replace(/\s+/g, " ").trim();
+  return safe.length > CIVITAI_DETAIL_MAX
+    ? `${safe.slice(0, CIVITAI_DETAIL_MAX - 1).trimEnd()}…`
+    : safe;
+}
+
+const _firstString = (...vals) => {
+  for (const v of vals) if (typeof v === "string" && v.trim()) return v;
+  return "";
+};
+
+/** Pull the human sentence out of a parsed error body. The shapes are the ones
+ *  CivitAI and this proxy actually produce: REST {"error":"…"}, the panel proxy's
+ *  own {"error":"…"} guards, tRPC {"error":{"json":{"message":…}}}, and Zod's
+ *  {"error":{"issues":[{"message":…}]}} (which is what a #459-class 400 looks
+ *  like). A deliberately SHALLOW, ordered lookup — a generic deep search would
+ *  happily surface some unrelated nested string as "the reason". */
+function _messageFromJson(j) {
+  if (typeof j === "string") return j;
+  if (Array.isArray(j)) return j.length ? _messageFromJson(j[0]) : ""; // tRPC batch
+  if (!j || typeof j !== "object") return "";
+  const e = j.error;
+  return _firstString(
+    typeof e === "string" ? e : "",
+    e?.message,
+    e?.json?.message,
+    j.message,
+    j.detail,
+    j.error_description,
+    e?.issues?.[0]?.message,
+    j.issues?.[0]?.message,
+  );
+}
+
+/** Marker py/civitai_proxy.py stamps on error bodies IT authored. Its absence
+ *  means the body came from CivitAI. Quoting our own guard rails back at the
+ *  user as "CivitAI said: …" would be the same misattribution #705 is about,
+ *  only pointed the other way — the whole bar here is that the user can tell an
+ *  outage on CivitAI's side of the wire from a problem on ours. */
+const PANEL_PROXY_SOURCE = "comfyui-mcp-panel";
+
+/** Turn a raw upstream body into `{ text, shape, fromProxy }`. `text` is the
+ *  quotable sentence — already flattened, redacted and bounded — or "" when
+ *  there isn't one; `shape` says what actually came back so the caller can be
+ *  honest instead of silent; `fromProxy` says who to attribute it to. */
+export function extractUpstreamDetail(bodyText) {
+  const raw = typeof bodyText === "string" ? bodyText.trim() : "";
+  if (!raw) return { text: "", shape: "empty", fromProxy: false };
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // The proxy stamps content_type:"application/json" on WHATEVER CivitAI
+    // returned, so the header is not evidence — only the body is. A leading "<"
+    // is an HTML/XML error page (a CDN or edge 5xx): reporting its shape is
+    // honest; pasting its markup into a sentence would be misleading noise.
+    if (raw.startsWith("<")) return { text: "", shape: "html", fromProxy: false };
+    // Everything else is plain text. The panel's own proxy always answers in
+    // JSON on the routes this client reads, so unmarked text is CivitAI's.
+    return { text: _cleanUpstreamText(raw), shape: "text", fromProxy: false };
+  }
+  const fromProxy = parsed?.source === PANEL_PROXY_SOURCE;
+  const msg = _cleanUpstreamText(_messageFromJson(parsed));
+  return msg
+    ? { text: msg, shape: "json", fromProxy }
+    : { text: "", shape: "json-nomessage", fromProxy };
+}
+
+/** How an upstream HTTP status should steer the user:
+ *   transient — CivitAI failed the request on its own side; retrying may work.
+ *   terminal  — CivitAI REJECTED the request; repeating it unchanged cannot work.
+ *   auth      — it needs a signed-in account.
+ *   unknown   — claim neither.
+ *  Status-driven on purpose: the body says what went wrong, the status says
+ *  whether doing the same thing again is worth the user's time. */
+export function upstreamFailureClass(status) {
+  const s = Number(status);
+  if (s === 401 || s === 403) return "auth";
+  if (s === 408 || s === 425 || s === 429) return "transient";
+  // 501/505 are 5xx the server will never satisfy, however long you wait.
+  if (s === 501 || s === 505) return "terminal";
+  if (s >= 500 && s <= 599) return "transient";
+  if (s >= 400 && s <= 499) return "terminal";
+  return "unknown";
+}
+
+const _SHAPE_NOTE = {
+  empty: "There was no detail in CivitAI's response body.",
+  html:
+    "CivitAI returned an HTML error page instead of JSON (typically a CDN or edge " +
+    "failure in front of the API), so it gave no machine-readable reason.",
+  "json-nomessage": "CivitAI's response body was JSON with no error message in it.",
+};
+
+const _ADVICE = {
+  transient:
+    "CivitAI failed this request on its own side rather than rejecting it, so " +
+    "retrying shortly may succeed.",
+  terminal: "CivitAI rejected the request itself, so repeating it unchanged will not help.",
+  auth:
+    "CivitAI wants a signed-in account for this — use the account button in the " +
+    "CivitAI browser to sign in (or sign out and back in if you already are).",
+};
+
+/** Build the user-facing description of a non-2xx proxy reply.
+ *  Returns `{ message, detail, retryable }`: `message` is the whole sentence for
+ *  the error card, `detail` is the bounded upstream text ALONE (so the UI and the
+ *  agent-facing error state can use it without re-parsing prose), and `retryable`
+ *  is true / false / null. Pure, and exported for unit tests. */
+export function describeUpstreamFailure({ status, statusText, bodyText, label = "CivitAI API" }) {
+  const { text, shape, fromProxy } = extractUpstreamDetail(bodyText);
+  const cls = upstreamFailureClass(status);
+  const head = `${label} ${status}: ${statusText || "request failed"}`;
+  // Quote and attribute, always: the reader must be able to tell borrowed words
+  // from ours, and WHOSE they are. A trailing stop is added when the quote
+  // doesn't carry one, so the advice that follows doesn't run into it.
+  const who = fromProxy ? "The panel's CivitAI proxy said" : "CivitAI said";
+  const said = text
+    ? `${who}: “${text}”${/[.!?…]$/.test(text) ? "" : "."}`
+    : _SHAPE_NOTE[shape] || _SHAPE_NOTE.empty;
+  return {
+    message: [head, "—", said, _ADVICE[cls]].filter(Boolean).join(" "),
+    detail: text,
+    retryable: cls === "transient" ? true : cls === "unknown" ? null : false,
+  };
+}
+
+/** Best-effort read of a FAILED response's body. A body we cannot read is our
+ *  problem, not CivitAI's: it degrades to the status description and must never
+ *  mask, replace or narrate over the failure it was meant to explain. Only ever
+ *  called on the !res.ok path, so it can never consume a success body. */
+async function _readErrorBody(res) {
+  try {
+    return typeof res?.text === "function" ? await res.text() : "";
+  } catch {
+    return ""; // e.g. an already-consumed stream — say nothing rather than lie
+  }
+}
+
 export class CivitaiClient {
   /** @param {object} api ComfyUI api ({fetchApi, apiURL}) injected by the monolith. */
   constructor(api) {
@@ -416,8 +614,21 @@ export class CivitaiClient {
       // (an extension blocking the request, a dropped connection) is silently
       // replaced by an unrelated upstream status. Same rule as the transport
       // and timeout throws above: report the whole trail, never just the last.
-      throw Object.assign(new Error(withFirstAttempt(`CivitAI API ${res.status}: ${res.statusText || "request failed"}`)), {
+      //
+      // #705: read the forwarded BODY too. The proxy hands CivitAI's own bytes
+      // back with the upstream status, and that is where the actionable text
+      // lives ("Model search is temporarily overloaded — please retry."); a
+      // message built from status/statusText alone throws all of it away and
+      // reads as though the user's own query were at fault.
+      const upstream = describeUpstreamFailure({
         status: res.status,
+        statusText: res.statusText,
+        bodyText: await _readErrorBody(res),
+      });
+      throw Object.assign(new Error(withFirstAttempt(upstream.message)), {
+        status: res.status,
+        detail: upstream.detail,
+        retryable: upstream.retryable,
         ...(firstTransportError ? { cause: firstTransportError } : {}),
       });
     }
@@ -901,9 +1112,22 @@ export class CivitaiClient {
     if (format) q.set("format", format);
     const res = await this.api.fetchApi(`/comfyui_mcp_panel/civitai/download?${q.toString()}`);
     if (!res.ok) {
-      const err = new Error(`civitai download ${res.status}`);
-      err.status = res.status;
-      throw err;
+      // #705, second call site with the same swallow: `civitai download 502` told
+      // the user nothing, while the proxy's reply says exactly what happened —
+      // {"error":"sign-in required to download this file"} for a gated file, and
+      // text/plain reasons from its own guards ("redirect target not allowed",
+      // "file too large"). Same bounded, attributed treatment as _request.
+      const upstream = describeUpstreamFailure({
+        status: res.status,
+        statusText: res.statusText,
+        bodyText: await _readErrorBody(res),
+        label: "CivitAI download",
+      });
+      throw Object.assign(new Error(upstream.message), {
+        status: res.status,
+        detail: upstream.detail,
+        retryable: upstream.retryable,
+      });
     }
     return new Uint8Array(await res.arrayBuffer());
   }

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -323,9 +323,17 @@ export const CIVITAI_DETAIL_MAX = 240;
 // Two rules: a LABELLED secret (Authorization: Bearer …, api_key=…), and a bare
 // JWT, which is the shape of CivitAI's OAuth access tokens. The 20-char floor on
 // the value keeps ordinary prose intact ("Invalid API key provided" survives).
+// The optional scheme token matters: "Authorization: Basic <base64>" puts a word
+// between the label and the secret, and without it the credential walks straight
+// through (codex gate finding — Bearer and JWT were covered, Basic was not).
 const _LABELLED_SECRET_RE =
-  /\b(bearer|authorization|api[-_ ]?key|access[-_ ]?token|refresh[-_ ]?token|token)\b[\s:=]*["']?[A-Za-z0-9._~+/-]{20,}={0,2}["']?/gi;
+  /\b(bearer|authorization|api[-_ ]?key|access[-_ ]?token|refresh[-_ ]?token|token)\b[\s:=]*(?:basic|bearer|digest|negotiate|token)?[\s:=]*["']?[A-Za-z0-9._~+/-]{20,}={0,2}["']?/gi;
 const _JWT_RE = /\beyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}/g;
+
+// Redaction runs over a WINDOW, never the whole body. The patterns are cheap on a
+// sentence and needlessly expensive on the megabytes /api will now carry, and
+// everything past the window is discarded by the cap anyway.
+const _REDACT_WINDOW = CIVITAI_DETAIL_MAX * 8;
 
 /** Replace credential-shaped runs with a visible marker. Never silently drop:
  *  the reader should be able to tell that something was withheld. */
@@ -346,7 +354,13 @@ function _cleanUpstreamText(raw) {
     .replace(/[\u0000-\u001f\u007f]+/g, " ")
     .replace(/\s+/g, " ")
     .trim();
-  const safe = redactCredentials(flat).replace(/\s+/g, " ").trim();
+  // Narrow to the redaction window BEFORE running the credential patterns: those
+  // have adjacent overlapping quantifiers (polynomial, not exponential, but
+  // still wasted work on a multi-megabyte body), and nothing past the window can
+  // reach the user anyway. Flattening above is a linear character-class pass, so
+  // it is safe to do on the whole string.
+  const windowed = flat.length > _REDACT_WINDOW ? flat.slice(0, _REDACT_WINDOW) : flat;
+  const safe = redactCredentials(windowed).replace(/\s+/g, " ").trim();
   return safe.length > CIVITAI_DETAIL_MAX
     ? `${safe.slice(0, CIVITAI_DETAIL_MAX - 1).trimEnd()}…`
     : safe;
@@ -393,7 +407,7 @@ const PANEL_PROXY_SOURCE = "comfyui-mcp-panel";
  *  honest instead of silent; `fromProxy` says who to attribute it to. */
 export function extractUpstreamDetail(bodyText) {
   const raw = typeof bodyText === "string" ? bodyText.trim() : "";
-  if (!raw) return { text: "", shape: "empty", fromProxy: false };
+  if (!raw) return { text: "", shape: "empty", fromProxy: false, proxyRetryable: null };
   let parsed;
   try {
     parsed = JSON.parse(raw);
@@ -402,16 +416,23 @@ export function extractUpstreamDetail(bodyText) {
     // returned, so the header is not evidence — only the body is. A leading "<"
     // is an HTML/XML error page (a CDN or edge 5xx): reporting its shape is
     // honest; pasting its markup into a sentence would be misleading noise.
-    if (raw.startsWith("<")) return { text: "", shape: "html", fromProxy: false };
+    if (raw.startsWith("<")) return { text: "", shape: "html", fromProxy: false, proxyRetryable: null };
     // Everything else is plain text. The panel's own proxy always answers in
     // JSON on the routes this client reads, so unmarked text is CivitAI's.
-    return { text: _cleanUpstreamText(raw), shape: "text", fromProxy: false };
+    return { text: _cleanUpstreamText(raw), shape: "text", fromProxy: false, proxyRetryable: null };
   }
   const fromProxy = parsed?.source === PANEL_PROXY_SOURCE;
+  // When the panel's own proxy authored the body, IT decides whether retrying
+  // helps: the status on such a reply is ours, and says nothing useful. Its 502
+  // covers both "could not reach CivitAI" (worth retrying) and the redirect
+  // allow-list refusal (deterministic — it will fail identically forever), and
+  // inferring "transient" from the number would advise a retry that cannot work.
+  const proxyRetryable =
+    fromProxy && typeof parsed?.retryable === "boolean" ? parsed.retryable : null;
   const msg = _cleanUpstreamText(_messageFromJson(parsed));
   return msg
-    ? { text: msg, shape: "json", fromProxy }
-    : { text: "", shape: "json-nomessage", fromProxy };
+    ? { text: msg, shape: "json", fromProxy, proxyRetryable }
+    : { text: "", shape: "json-nomessage", fromProxy, proxyRetryable };
 }
 
 /** How an upstream HTTP status should steer the user:
@@ -448,6 +469,12 @@ const _ADVICE = {
   auth:
     "CivitAI wants a signed-in account for this — use the account button in the " +
     "CivitAI browser to sign in (or sign out and back in if you already are).",
+  // The panel's own proxy stopped the request. Neither sentence may claim
+  // anything about what CivitAI did — the request may never have reached it.
+  "transient-proxy":
+    "The panel's CivitAI proxy could not complete the request, so retrying " +
+    "shortly may succeed.",
+  "terminal-proxy": "The panel's CivitAI proxy refused this outright, so repeating it will not help.",
 };
 
 /** Build the user-facing description of a non-2xx proxy reply.
@@ -456,8 +483,19 @@ const _ADVICE = {
  *  agent-facing error state can use it without re-parsing prose), and `retryable`
  *  is true / false / null. Pure, and exported for unit tests. */
 export function describeUpstreamFailure({ status, statusText, bodyText, label = "CivitAI API" }) {
-  const { text, shape, fromProxy } = extractUpstreamDetail(bodyText);
-  const cls = upstreamFailureClass(status);
+  const { text, shape, fromProxy, proxyRetryable } = extractUpstreamDetail(bodyText);
+  // A proxy-authored reply carries OUR status, so upstreamFailureClass would be
+  // reading a number that says nothing about CivitAI. Honour what the proxy
+  // declared instead — except for 401/403, where "sign in" is the action either
+  // way. (Codex gate: a 502 from the redirect allow-list guard was being sold to
+  // the user as a transient CivitAI outage worth retrying. It never succeeds.)
+  const statusCls = upstreamFailureClass(status);
+  const cls =
+    proxyRetryable === null || statusCls === "auth"
+      ? statusCls
+      : proxyRetryable
+        ? "transient-proxy"
+        : "terminal-proxy";
   const head = `${label} ${status}: ${statusText || "request failed"}`;
   // Quote and attribute, always: the reader must be able to tell borrowed words
   // from ours, and WHOSE they are. A trailing stop is added when the quote
@@ -469,7 +507,12 @@ export function describeUpstreamFailure({ status, statusText, bodyText, label = 
   return {
     message: [head, "—", said, _ADVICE[cls]].filter(Boolean).join(" "),
     detail: text,
-    retryable: cls === "transient" ? true : cls === "unknown" ? null : false,
+    retryable:
+      cls === "transient" || cls === "transient-proxy"
+        ? true
+        : cls === "unknown"
+          ? null
+          : false,
   };
 }
 
@@ -550,6 +593,7 @@ export class CivitaiClient {
         ? `${msg} (a first attempt had already failed at transport with: ${errText(firstTransportError)})`
         : msg;
     let res;
+    let errorBody = "";
     try {
       for (let attempt = 0; ; attempt++) {
         try {
@@ -599,6 +643,15 @@ export class CivitaiClient {
           throw e;
         }
       }
+      // #705 + #417: read a FAILED response's body while the abort budget above
+      // is still ARMED. Headers can arrive and the body then never finish, and a
+      // body read placed after clearTimeout would turn a perfectly known 503
+      // into the exact hang #417 exists to prevent — _loadMore never reaching
+      // its catch/finally, the grid stuck on {loading:true, total:0}. Inside the
+      // budget, an unfinished body aborts, _readErrorBody swallows it, and the
+      // status is still reported. Only ever entered on the !ok path, so it can
+      // never consume a success body.
+      if (!res.ok) errorBody = await _readErrorBody(res);
     } finally {
       clearTimeout(timeout);
     }
@@ -623,7 +676,7 @@ export class CivitaiClient {
       const upstream = describeUpstreamFailure({
         status: res.status,
         statusText: res.statusText,
-        bodyText: await _readErrorBody(res),
+        bodyText: errorBody,
       });
       throw Object.assign(new Error(withFirstAttempt(upstream.message)), {
         status: res.status,

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -360,10 +360,17 @@ function _cleanUpstreamText(raw) {
   // reach the user anyway. Flattening above is a linear character-class pass, so
   // it is safe to do on the whole string.
   const windowed = flat.length > _REDACT_WINDOW ? flat.slice(0, _REDACT_WINDOW) : flat;
+  const clipped = windowed.length < flat.length;
   const safe = redactCredentials(windowed).replace(/\s+/g, " ").trim();
-  return safe.length > CIVITAI_DETAIL_MAX
-    ? `${safe.slice(0, CIVITAI_DETAIL_MAX - 1).trimEnd()}…`
-    : safe;
+  if (safe.length > CIVITAI_DETAIL_MAX) {
+    return `${safe.slice(0, CIVITAI_DETAIL_MAX - 1).trimEnd()}…`;
+  }
+  // Redaction SHRINKS text, so a body that overflowed the window can come back
+  // under the cap and skip the marker above — the reader would then see a
+  // message that looks whole while the real cause sat past the window. If
+  // anything was dropped, say so. (Codex gate: three long `token=…` runs
+  // followed by the actual reason rendered as "token [redacted]" ×3, full stop.)
+  return clipped ? `${safe}…` : safe;
 }
 
 const _firstString = (...vals) => {
@@ -475,6 +482,8 @@ const _ADVICE = {
     "The panel's CivitAI proxy could not complete the request, so retrying " +
     "shortly may succeed.",
   "terminal-proxy": "The panel's CivitAI proxy refused this outright, so repeating it will not help.",
+  // Ours, but we don't know whether retrying helps — so claim neither.
+  "unknown-proxy": "This failure came from the panel's CivitAI proxy rather than from a CivitAI response.",
 };
 
 /** Build the user-facing description of a non-2xx proxy reply.
@@ -490,12 +499,22 @@ export function describeUpstreamFailure({ status, statusText, bodyText, label = 
   // way. (Codex gate: a 502 from the redirect allow-list guard was being sold to
   // the user as a transient CivitAI outage worth retrying. It never succeeds.)
   const statusCls = upstreamFailureClass(status);
-  const cls =
-    proxyRetryable === null || statusCls === "auth"
-      ? statusCls
-      : proxyRetryable
-        ? "transient-proxy"
-        : "terminal-proxy";
+  let cls;
+  if (statusCls === "auth") {
+    cls = "auth"; // whoever spoke, signing in is the action
+  } else if (!fromProxy) {
+    cls = statusCls;
+  } else if (proxyRetryable === true) {
+    cls = "transient-proxy";
+  } else if (proxyRetryable === false) {
+    cls = "terminal-proxy";
+  } else {
+    // Proxy-authored but silent about retryability (an older proxy than this
+    // panel JS). Falling back to the status would read the number as CivitAI's
+    // and tell the user "CivitAI failed this on its own side" directly after
+    // saying the PANEL's proxy spoke — two contradictory claims in one message.
+    cls = "unknown-proxy";
+  }
   const head = `${label} ${status}: ${statusText || "request failed"}`;
   // Quote and attribute, always: the reader must be able to tell borrowed words
   // from ours, and WHOSE they are. A trailing stop is added when the quote
@@ -510,7 +529,7 @@ export function describeUpstreamFailure({ status, statusText, bodyText, label = 
     retryable:
       cls === "transient" || cls === "transient-proxy"
         ? true
-        : cls === "unknown"
+        : cls === "unknown" || cls === "unknown-proxy"
           ? null
           : false,
   };

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -466,6 +466,12 @@ const _SHAPE_NOTE = {
     "CivitAI returned an HTML error page instead of JSON (typically a CDN or edge " +
     "failure in front of the API), so it gave no machine-readable reason.",
   "json-nomessage": "CivitAI's response body was JSON with no error message in it.",
+  // Same shape, ours: the note must not name CivitAI when the marker says the
+  // panel's own proxy wrote the body. (`empty` and `html` need no such variant —
+  // a body with no readable JSON carries no marker to read, so it is CivitAI's
+  // by construction.)
+  "json-nomessage-proxy":
+    "The panel's CivitAI proxy returned JSON with no error message in it.",
 };
 
 const _ADVICE = {
@@ -520,9 +526,10 @@ export function describeUpstreamFailure({ status, statusText, bodyText, label = 
   // from ours, and WHOSE they are. A trailing stop is added when the quote
   // doesn't carry one, so the advice that follows doesn't run into it.
   const who = fromProxy ? "The panel's CivitAI proxy said" : "CivitAI said";
+  const noteKey = fromProxy && _SHAPE_NOTE[`${shape}-proxy`] ? `${shape}-proxy` : shape;
   const said = text
     ? `${who}: “${text}”${/[.!?…]$/.test(text) ? "" : "."}`
-    : _SHAPE_NOTE[shape] || _SHAPE_NOTE.empty;
+    : _SHAPE_NOTE[noteKey] || _SHAPE_NOTE.empty;
   return {
     message: [head, "—", said, _ADVICE[cls]].filter(Boolean).join(" "),
     detail: text,


### PR DESCRIPTION
Fixes artokun/comfyui-mcp-panel#705.

## The defect

A user searched `min` on the CivitAI **LoRA** tab and got, repeatedly:

> `CivitAI error: CivitAI API 503: Service Unavailable`

Carrying only the HTTP status, that reads as **query-specific** — "my search for 'min' is broken" — and the reporter went hunting for a bug in our code. It was nothing of the sort: CivitAI's model-search backend was down, and **their API said so in the response body**:

```
GET /api/v1/models?limit=5&types=LORA&query=min   -> 503 {"error":"Model search is temporarily overloaded — please retry."}
GET /api/v1/models?limit=3&types=LORA             -> 200 OK, items returned
```

`py/civitai_proxy.py` already forwarded that body verbatim with the upstream status. The browser client threw it away: `_request` built its Error from `res.status`/`res.statusText` and never read the body, so every bit of diagnostic value the proxy carried was lost at the last hop.

## Before / after

| body shape | before | after |
|---|---|---|
| JSON `{error}` (the reported 503) | `CivitAI API 503: Service Unavailable` | `CivitAI API 503: Service Unavailable — CivitAI said: “Model search is temporarily overloaded — please retry.” CivitAI failed this request on its own side rather than rejecting it, so retrying shortly may succeed.` |
| HTML / CDN error page | `CivitAI API 503: Service Unavailable` | `… — CivitAI returned an HTML error page instead of JSON (typically a CDN or edge failure in front of the API), so it gave no machine-readable reason. …` |
| empty | `CivitAI API 503: Service Unavailable` | `… — There was no detail in CivitAI's response body. …` |
| JSON, no message field | `CivitAI API 500: Internal Server Error` | `… — CivitAI's response body was JSON with no error message in it. …` |
| terminal 400 | `CivitAI API 400: Bad Request` | `… — CivitAI said: “Invalid enum value…” CivitAI rejected the request itself, so repeating it unchanged will not help.` |
| gated download 401 | `civitai download 401` | `CivitAI download 401: Unauthorized — The panel's CivitAI proxy said: “sign-in required to download this file.” CivitAI wants a signed-in account for this — use the account button…` |

## Design decisions

Three rules hold `describeUpstreamFailure` together:

1. **Never pretend to a cause.** Empty, HTML and message-less-JSON bodies each get a description of what *actually* came back. None gets a fabricated reason.
2. **Never dump the body.** It is untrusted, arbitrary-length text heading for a UI string and the ComfyUI console: flattened to one line, control bytes stripped, credential-shaped runs redacted (labelled secrets incl. an auth scheme, plus bare JWTs), capped at 240 chars with **visible** truncation, and always quoted. Markup is reported by shape, never pasted — dumping a CDN error page into a sentence is its own misleading-error bug.
3. **Advice follows the STATUS, not the body.** "Retrying shortly may succeed" is right for 503/429 and actively wrong for a 400 that will never succeed; 401/403 point at sign-in.

**Attribution is explicit**, because "an outage on their side vs a bug on ours" is the entire point of the issue. The proxy now tags the error bodies *it* authors with a `source` marker and declares its own `retryable` — its 502 covers both a transient "could not reach CivitAI" and the permanent redirect allow-list refusal, and the status alone distinguishes neither. Without this, the fix would have narrated our own guard rails as *"CivitAI said: redirect target not allowed"* and advised retrying a refusal that can never succeed.

## Other call sites

Every `/api` read (search, creators, model-version, favourites, collections) funnels through `_request`, so all of them are covered by the one change. `downloadVersionFile` was the **second** swallow (`civitai download 502`) and is fixed the same way. `/media` was checked and deliberately left alone: it is a byte route feeding `<img src>`, and no JS error path reads its body.

## Also

- **Bounds `/api`**, the one proxy route with no cap on the untrusted body it buffers (`/media` and `/download` both had one). Over-cap bodies are **refused, not truncated** — half a JSON document would reach the panel as an unparseable body, a brand-new misleading error in place of the old one.
- `err.detail` and `err.retryable` flow into `civitaiErrorState`, so the agent-facing `panel_civitai_results` can report the cause too, not just a status. Both keys are omitted when absent, so transport/empty failures keep their existing shape.

## Verification

- Failing tests first: 19/20 of the new cases failed on `origin/main`'s behaviour; only the success-path test passed (as it should).
- 2625 JS unit tests, `tsc --noEmit`, tool-vocabulary gate, all 7 Python test files, `py_compile`, bandit (Registry parity), comfy-cli AST parity and the YARA parity scan — all green, rebased onto current `main`.
- Mutation-verified: reverting the body extraction fails the JSON-body test (9 total); reverting the HTML branch fails exactly one *different* test; reverting the Python cap fails the over-cap test (200 != 502); reverting the source-aware shape note fails only the attribution test.
- New coverage: `browser_tests/unit/civitai-error-body.test.mjs` (35 cases) and `browser_tests/unit/test_civitai_api_route.py` (10 cases — the first aiohttp-level coverage of the `/api` passthrough).

## Independent codex gate — 3 rounds, all findings fixed

1. **P1** the failed-response body was read *after* the #417 abort budget was cleared, so a body that sends headers and never finishes hung `_request` forever — reintroducing the exact defect #417 removed. Now read inside the budget.
2. **P2** a proxy-authored 502 was classified transient from its status and advised a retry that could never work → the proxy now declares `retryable`.
3. **P2** the over-cap refusal bypassed `_proxy_error` and so lacked the `source` marker.
4. **P2** `redactCredentials` could not step over an auth scheme, so `Authorization: Basic <base64>` survived while Bearer was caught.
5. **P2** a proxy body with `source` but no `retryable` fell back to status advice that contradicted its own attribution.
6. **P2** a redaction-window clip could land back under the cap and skip the truncation marker, showing a message that looked whole while the real cause sat past the window.
7. **P2** the "JSON with no error message" note hardcoded CivitAI, misattributing a marked body.

## Not done (deliberate)

The issue's suggested follow-up — detecting that a `query=` search 503s while the same filters without a query succeed, and offering a one-click "browse without search term" — is a product call and is **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)