### PR TITLE
fix(panel): a content difference is only wrong-canvas evidence when it is STRUCTURAL (#696, #701, #702, #663)

### DIFF
--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -23,6 +23,7 @@ import {
   graphReadDesynced,
   graphRootMidPopulation,
   graphRootMismatchesActiveWorkflow,
+  graphRootContentDriftOnBoundCanvas,
   graphRootProvenEmpty,
   graphRootWorkflowUuidMismatches,
   graphRootWorkflowUuidMatches,
@@ -694,6 +695,322 @@ test("graphRootMismatchesActiveWorkflow: FALSE - initialState is a baseline, not
     }),
     false,
   );
+});
+
+// ── #696/#663/#701/#702 — CONTENT DRIFT ON A POSITIVELY-BOUND CANVAS ─────────
+//
+// The shape guard compares the live root's FULL serialized node content against
+// ChangeTracker's `activeState` and treats ANY difference as "the canvas is bound
+// to a different graph". That inference does not hold, and the panel's own source
+// says why: ComfyUI's ChangeTracker "snapshots on USER input events only" (the
+// comment on the post-command `deferChangeTrackerSnapshot` wiring). So a widget a
+// node rewrites WITHOUT user input — Impact-Pack's ImpactWildcardEncode in
+// `populate` mode, `control_after_generate`, an rgthree mode toggle, any
+// `loadedGraphNode` hook — drifts the live root away from `activeState` while the
+// tab still reads `isModified: false`. The tab is clean, the canvas is the right
+// canvas, and every graph read and write is refused.
+//
+// It is also SELF-REINFORCING, which is what turned it into "the remedy does not
+// remedy" (#701/#702): the tracker is only re-captured after a command SUCCEEDS,
+// and `workflow_open`'s repaint re-runs the very hook that rewrites the widget, so
+// its own content proof fails, its tracker re-baseline is skipped, and the next
+// read fails identically. Nothing short of a page reload breaks the loop.
+//
+// The fix is the EVIDENCE, not the verdict: a content difference is only proof of
+// a WRONG CANVAS when it is STRUCTURAL. A difference confined to per-node mutable
+// content, on a root that POSITIVELY carries this workflow's identity, is drift on
+// the right canvas.
+const driftFixture = ({
+  uuid = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa",
+  rootUuid = uuid,
+  drift = (nodes) => {
+    nodes[1].widgets_values[1] = "a sorceress"; // the populate rewrite
+    nodes[2].widgets_values[0] = 124; // control_after_generate bumped the seed
+  },
+  mutateLive = () => {},
+} = {}) => {
+  const trackerState = {
+    nodes: [
+      { id: 1, type: "CheckpointLoaderSimple", widgets_values: ["anime.safetensors"] },
+      { id: 2, type: "ImpactWildcardEncode", widgets_values: ["__character__", "a knight"] },
+      { id: 3, type: "KSampler", widgets_values: [123, "fixed", 20] },
+    ],
+    links: [[1, 1, 0, 3, 0, "MODEL"]],
+    groups: [{ title: "sampling", bounding: [0, 0, 10, 10] }],
+  };
+  const liveSerialized = structuredClone(trackerState);
+  drift(liveSerialized.nodes, liveSerialized);
+  mutateLive(liveSerialized);
+  const rootGraph = {
+    _nodes: liveSerialized.nodes.map(({ id, type }) => ({ id, type })),
+    serialize: () => liveSerialized,
+    ...(rootUuid ? { extra: { comfyui_mcp: { workflow_uuid: rootUuid } } } : {}),
+  };
+  return {
+    rootGraph,
+    activeWorkflowUuid: uuid,
+    activeWorkflow: wf({ isModified: false, changeTracker: { activeState: trackerState } }),
+  };
+};
+
+const driftVerdict = (fixture, over = {}) =>
+  resolveGraphBindingVerdict({
+    graph: fixture.rootGraph,
+    rootGraph: fixture.rootGraph,
+    activeWorkflow: fixture.activeWorkflow,
+    activeWorkflowUuid: fixture.activeWorkflowUuid,
+    liveNodeCount: fixture.rootGraph._nodes.length,
+    includeBaselineReadGuard: true,
+    requireDirtyMutationBinding: true,
+    ...over,
+  });
+
+test("#696: a widget a node rewrote itself is NOT a wrong canvas — the bound root is permitted", () => {
+  const fixture = driftFixture();
+  assert.equal(
+    graphRootMismatchesActiveWorkflow({ rootGraph: fixture.rootGraph, activeWorkflow: fixture.activeWorkflow }),
+    true,
+    "the raw content comparator still reports the difference — that is its job",
+  );
+  assert.equal(
+    graphRootContentDriftOnBoundCanvas(fixture),
+    true,
+    "…but with the workflow's identity on the root and every structural surface equal, " +
+      "the difference is drift on the RIGHT canvas, not evidence of another one",
+  );
+  assert.equal(
+    driftVerdict(fixture),
+    null,
+    "a read AND a mutation on a positively-identified canvas whose only drift is widget " +
+      "content must not be refused (#696)",
+  );
+});
+
+test("#696: the relaxation needs POSITIVE identity — an untagged root is still refused", () => {
+  // Absence of the tag is absence of proof, and the whole relaxation rests on it:
+  // without the tag, byte-identical structure cannot tell the active tab's canvas
+  // from a duplicate tab's. Fail closed, exactly as before.
+  const fixture = driftFixture({ rootUuid: null });
+  assert.equal(graphRootContentDriftOnBoundCanvas(fixture), false);
+  assert.equal(driftVerdict(fixture)?.reason, "root-shape-mismatch");
+});
+
+test("#696: a STRUCTURAL difference on a tagged root is still a refusal, in every surface", () => {
+  // The direction that must NOT be softened. Each of these is a real wrong-canvas
+  // signature; the identity tag is present in all of them, so only the structural
+  // comparison can hold the line.
+  const cases = {
+    "a node type changed": (nodes) => {
+      nodes[0].type = "UNETLoader";
+    },
+    "a node id changed": (nodes) => {
+      nodes[0].id = 99;
+    },
+    "a node was removed": (nodes, state) => {
+      state.nodes = nodes.slice(1);
+    },
+    "the links differ": (nodes, state) => {
+      state.links = [];
+    },
+    "a group differs": (nodes, state) => {
+      state.groups = [{ title: "OTHER", bounding: [0, 0, 10, 10] }];
+    },
+    "a reroute appeared": (nodes, state) => {
+      state.reroutes = [{ id: "r1", pos: [1, 2] }];
+    },
+    "a top-level subgraph appeared": (nodes, state) => {
+      state.subgraphs = [{ id: "s1", nodes: [{ id: 7, type: "SaveImage" }] }];
+    },
+  };
+  for (const [label, drift] of Object.entries(cases)) {
+    const fixture = driftFixture({ drift });
+    assert.equal(
+      graphRootContentDriftOnBoundCanvas(fixture),
+      false,
+      `${label} is STRUCTURAL — it must never be waved through as content drift`,
+    );
+    assert.ok(driftVerdict(fixture), `${label} must still be refused`);
+  }
+});
+
+test("#696: a CONFLICTING identity tag still refuses ahead of any content reasoning", () => {
+  const fixture = driftFixture({ rootUuid: "bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb" });
+  assert.equal(
+    graphRootContentDriftOnBoundCanvas(fixture),
+    false,
+    "the relaxation demands a MATCH, and a foreign tag is the #349 wrong-canvas case",
+  );
+  assert.equal(driftVerdict(fixture, { rootUuidMismatch: true })?.reason, "root-workflow-uuid-mismatch");
+});
+
+test("#618: a mid-restore canvas is count-short, so the relaxation cannot mask it", () => {
+  const fixture = driftFixture({
+    drift: (nodes, state) => {
+      state.nodes = nodes.slice(0, 1); // still restoring: 1 of 3
+    },
+  });
+  fixture.rootGraph._nodes = [{ id: 1, type: "CheckpointLoaderSimple" }];
+  assert.equal(graphRootContentDriftOnBoundCanvas(fixture), false);
+  assert.equal(driftVerdict(fixture, { postReconnectWindow: true })?.reason, "root-mid-population");
+});
+
+test("#696: an unreadable root serializer stays inconclusive rather than relaxing", () => {
+  const fixture = driftFixture();
+  const blind = {
+    ...fixture,
+    rootGraph: {
+      _nodes: fixture.rootGraph._nodes,
+      extra: fixture.rootGraph.extra,
+      serialize: () => {
+        throw new Error("serializer unavailable");
+      },
+    },
+  };
+  assert.equal(
+    graphRootContentDriftOnBoundCanvas(blind),
+    false,
+    "a structural comparison that could not RUN is not a structural match",
+  );
+
+  // The subtler direction: BOTH sides unreadable. Two failed reads must not
+  // collapse into "equal" — that is `graphRootMatchesState`'s original sin
+  // (one return value doing two jobs) reappearing inside the relaxation, and it
+  // would permit on a canvas nothing ever managed to look at.
+  const uuid = fixture.activeWorkflowUuid;
+  const tagged = (serialize) => ({
+    _nodes: [{ id: 1, type: "KSampler" }],
+    extra: { comfyui_mcp: { workflow_uuid: uuid } },
+    serialize,
+  });
+  assert.equal(
+    graphRootContentDriftOnBoundCanvas({
+      rootGraph: tagged(() => ({})),
+      activeWorkflow: wf({ isModified: false, changeTracker: {} }),
+      activeWorkflowUuid: uuid,
+    }),
+    false,
+    "no tracker state and no serialized nodes is two absences, not a match",
+  );
+  assert.equal(
+    graphRootContentDriftOnBoundCanvas({
+      rootGraph: tagged(() => ({ nodes: [{ id: 1 }] })),
+      activeWorkflow: wf({ isModified: false, changeTracker: { activeState: { nodes: [{ id: 1 }] } } }),
+      activeWorkflowUuid: uuid,
+    }),
+    false,
+    "nodes with no usable type cannot be structurally compared on EITHER side (older frontends), " +
+      "and an uncomparable pair must not read as identical",
+  );
+
+  assert.equal(graphRootContentDriftOnBoundCanvas(), false, "no arguments ⇒ no relaxation");
+  assert.equal(graphRootContentDriftOnBoundCanvas({}), false);
+});
+
+test("#701/#702: the refusal reports the LIVE count and only claims 'a different graph' when it is one", () => {
+  // Three reports read "the workflow reports N node(s), but the canvas is bound to
+  // a different graph" / "left this command pointed at the wrong canvas" and went
+  // hunting a wrong-tab bug. The counts were EQUAL in all of them — the message
+  // never printed the live one, and asserted a conclusion the evidence (one widget
+  // value) did not support. BOTH claims are unmeasured, so both must go.
+  const contentOnly = graphBindingRefusalMessage({ reason: "root-shape-mismatch", expected: 23, live: 23 });
+  assert.match(contentOnly, /^\[root-shape-mismatch\]/);
+  assert.match(contentOnly, /23/, "the counts the verdict measured must appear");
+  assert.doesNotMatch(
+    contentOnly,
+    /bound to a different graph/,
+    "equal counts + a content difference is NOT proof of a different graph",
+  );
+  assert.doesNotMatch(
+    contentOnly,
+    /pointed at the wrong canvas/,
+    "…and neither is it proof that a load/switch/reconnect mis-pointed the command",
+  );
+  assert.match(contentOnly, /cannot tell/, "an unresolved ambiguity must be disclosed as one");
+
+  const reallyDifferent = graphBindingRefusalMessage({ reason: "root-shape-mismatch", expected: 23, live: 4 });
+  assert.match(reallyDifferent, /23/);
+  assert.match(reallyDifferent, /\b4\b/, "the LIVE count is the reader's only way to tell the two apart");
+  assert.match(reallyDifferent, /holds a graph other than/, "a real size disagreement may still say so");
+  // …but even THERE the event is offered as an explanation, never asserted: the
+  // predicate measured a mismatch, it did not watch a load/switch/reconnect happen.
+  assert.match(reallyDifferent, /observed the mismatch, not the event/);
+  assert.doesNotMatch(reallyDifferent, /reconnect left this command pointed at the wrong canvas, so/);
+
+  // An absent live count is an UNMEASURED one: it must not become a claim either way.
+  const unmeasured = graphBindingRefusalMessage({ reason: "root-node-count-desync", expected: 3 });
+  assert.match(unmeasured, /the workflow reports 3 node\(s\)/);
+  assert.doesNotMatch(
+    unmeasured,
+    /bound to a different graph|pointed at the wrong canvas/,
+    "a live count nobody measured cannot support a different-graph claim",
+  );
+});
+
+test("#701: a structure-matching refusal names the remedy that actually supplies the missing proof", () => {
+  // The one refusal whose remedy is guaranteed to help, and the reason to
+  // distinguish it: the canvas IS structurally this workflow and the only thing
+  // absent is the identity stamp — which panel_open_workflow writes. Saying so is
+  // the difference between an actionable refusal and the one the reporters got,
+  // whose named remedy re-created the same drift and failed identically forever.
+  const msg = graphBindingRefusalMessage({
+    reason: "root-shape-mismatch",
+    expected: 23,
+    live: 23,
+    structureMatches: true,
+  });
+  assert.match(msg, /^\[root-shape-mismatch\]/);
+  assert.match(msg, /STRUCTURE/, "the disclosure must say what DID match");
+  assert.match(msg, /panel_open_workflow/);
+  assert.match(msg, /identity/, "…and why that remedy is the one that can clear it");
+  assert.doesNotMatch(msg, /pointed at the wrong canvas/);
+  assert.match(msg, /NOT applied/);
+  // The #606 promises survive the new branch — and extend to the OPEN, which is
+  // no more observable than the reload: workflow_open can run and still fail to
+  // prove its rebind, so neither "it will clear this" nor its contrapositive
+  // ("still refusing ⇒ the difference is more than content") may be stated.
+  assert.match(msg, /panel_reload/);
+  assert.match(msg, /REQUESTED, NOT CONFIRMED/);
+  assert.match(msg, /cannot observe/);
+  assert.doesNotMatch(msg, /which (restores|rebinds|re-?establishes|rebuilds)|reload always/i);
+  assert.doesNotMatch(
+    msg,
+    /after that a content-only difference no longer refuses|the difference is NOT content-only/,
+    "an unprovable rebind must not be reported as a completed one, in either direction",
+  );
+  assert.match(msg, /do NOT read that as proof/, "the invalid inference is named and refused");
+  assert.match(msg, /panel_set_workflow_target is NOT a remedy/);
+
+  // A structure match is NOT claimable when the sizes disagree — the two cannot
+  // both be true, and the size evidence is the stronger one.
+  const conflicting = graphBindingRefusalMessage({
+    reason: "root-shape-mismatch",
+    expected: 23,
+    live: 4,
+    structureMatches: true,
+  });
+  assert.match(conflicting, /different graph/);
+  assert.doesNotMatch(conflicting, /reproduces this workflow's STRUCTURE/);
+});
+
+test("#701: the verdict carries the structural answer, positively — never from an unread comparison", () => {
+  const fixture = driftFixture({ rootUuid: null }); // structure equal, identity unproven
+  const verdict = driftVerdict(fixture);
+  assert.equal(verdict.reason, "root-shape-mismatch");
+  assert.equal(verdict.structureMatches, true, "the structural comparison RAN and matched");
+
+  const structural = driftFixture({ rootUuid: null, drift: (nodes) => void (nodes[0].type = "UNETLoader") });
+  assert.equal(driftVerdict(structural).structureMatches, false);
+
+  // Unreadable ⇒ false ("unestablished"), never true.
+  const blind = driftFixture({ rootUuid: null });
+  blind.rootGraph = {
+    _nodes: blind.rootGraph._nodes,
+    serialize: () => {
+      throw new Error("serializer unavailable");
+    },
+  };
+  const blindVerdict = driftVerdict(blind);
+  if (blindVerdict) assert.equal(blindVerdict.structureMatches, false);
 });
 
 test("#545: a DIRTY workflow's tracker state may lag legitimate canvas edits, so it is never a binding refusal", () => {
@@ -2927,6 +3244,16 @@ test("#606 refusal message: uuid-mismatch names the identity tag, not a 0-node d
   assert.match(msg, /NOT applied/);
   assert.match(msg, /panel_open_workflow/);
   assert.match(msg, /panel_reload/);
+  // …and it states the OBSERVATION, not a cause nobody watched happen. The
+  // predicate saw two tags disagree; "a load, tab switch, or reconnect left a
+  // stale tag behind" was one guess presented as the finding — the same defect
+  // the shape branch's wrong-canvas sentence had (codex gate, r2 P2).
+  assert.match(msg, /observed is the disagreement itself, not what produced it/);
+  assert.doesNotMatch(
+    msg,
+    /reconnect left a stale tag behind, so/,
+    "the usual explanation may be offered as one — never asserted as what happened",
+  );
 });
 
 test("#606 refusal message: a 0-expected shape mismatch drops the node-count clause", () => {

--- a/web/js/lib/graph-binding.js
+++ b/web/js/lib/graph-binding.js
@@ -516,6 +516,158 @@ export function graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow } 
 }
 
 /**
+ * The STRUCTURE of a serialized graph — everything that says WHICH workflow a
+ * canvas holds — with the per-node content that can legitimately drift on a
+ * correctly-bound canvas removed.
+ *
+ * Derived from `buildGraphShape` so it can never disagree with the full
+ * comparison about what a surface even IS (the one-normalization rule above);
+ * the ONLY difference is that each node collapses to its `id` and `type`. Every
+ * non-node surface — links, floating links, reroutes, groups, config, top-level
+ * subgraphs, definitions, extra — is compared in FULL, unchanged, because those
+ * are where a genuinely different workflow shows itself.
+ *
+ * `null` when no structural read is possible (no serialized state, or any node
+ * without a usable id/type): callers must treat that as NOT a match, never as
+ * one — "could not compare" is not "compared and equal".
+ */
+function buildGraphStructureShape(state) {
+  const shape = buildGraphShape(state);
+  if (shape == null) return null;
+  const nodes = [];
+  for (const node of shape.nodes) {
+    const id = node?.id;
+    const type = node?.type;
+    if ((typeof id !== "string" && typeof id !== "number") || typeof type !== "string") return null;
+    // Type-qualified, exactly like the legacy id:type fallback: numeric 1 and
+    // string "1" are different ids and must not collide.
+    nodes.push({ id: `${typeof id}:${id}`, type });
+  }
+  return { ...shape, nodes };
+}
+
+function graphStructureShape(state) {
+  const shape = buildGraphStructureShape(state);
+  if (shape == null) return null;
+  try {
+    return JSON.stringify(canonicalizeShapeValue(shape));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * #696/#663/#701/#702 — the live root differs from the active workflow's own
+ * current state ONLY in per-node mutable content, on a canvas that POSITIVELY
+ * carries this workflow's identity. That is drift on the RIGHT canvas, not
+ * evidence of a different one, and it must not refuse a graph command.
+ *
+ * WHY the plain content comparison is the wrong evidence. `graphRootMismatches-
+ * ActiveWorkflow` reads a difference between `rootGraph.serialize()` and
+ * ChangeTracker's `activeState` as "bound to a different graph". That inference
+ * needs `activeState` to be a faithful mirror of the live root whenever the tab
+ * is clean — and it is not. ComfyUI's ChangeTracker captures on USER INPUT
+ * events (see the panel's post-command `deferChangeTrackerSnapshot` wiring, which
+ * exists precisely because bridge-driven edits are otherwise invisible to it), so
+ * a widget a NODE rewrites without user input drifts the root while the tab still
+ * reports `isModified: false`: Impact-Pack's ImpactWildcardEncode re-resolving
+ * `populated_text` on every execution, `control_after_generate` advancing a seed,
+ * an rgthree mode toggle, any extension's `loadedGraphNode` hook. Every reported
+ * instance of this cluster carried the RIGHT node count on the RIGHT tab.
+ *
+ * It is self-reinforcing, which is what made "the remedy does not remedy" (#701):
+ * the tracker is re-captured only after a command SUCCEEDS, and `workflow_open`'s
+ * repaint re-runs the same hook that rewrote the widget, so its own content proof
+ * fails, its tracker re-baseline is skipped, and the retried read fails
+ * identically. Only a page reload broke the loop.
+ *
+ * The relaxation is deliberately NARROW, and both conjuncts are load-bearing:
+ *
+ *   IDENTITY — `graphRootWorkflowUuidMatches`. Structural equality alone cannot
+ *     tell the active tab's canvas from a DUPLICATE tab's: two copies of one
+ *     workflow are structurally identical and differ only in widget values, which
+ *     is exactly the difference this would wave through. The same exclusivity
+ *     problem already blocks `sealProvenRootBinding`, and the answer is the same
+ *     one — require the canvas to positively claim THIS workflow. An untagged
+ *     root is absence of proof and stays refused; a foreign tag is the #349
+ *     wrong-canvas case and is refused earlier still.
+ *
+ *   STRUCTURE — every surface that identifies a workflow must be EQUAL, read
+ *     through the shared normalization. A different node set, a different id or
+ *     type, different links, groups, reroutes, floating links, top-level
+ *     subgraphs, definitions or content-bearing extra all remain refusals, so
+ *     #349 is untouched. A count-short mid-restore canvas (#618) differs in its
+ *     node set and cannot reach this at all.
+ *
+ * An unreadable structural comparison on EITHER side returns false: the relaxation
+ * only ever fires on a positive, completed match.
+ *
+ * KNOWN, DELIBERATE GAPS — both pre-existing, neither opened here:
+ *
+ *   drift INSIDE a `subgraphs`/`definitions` payload still refuses, because that
+ *   surface is compared whole. Narrowing it would mean recursing a nested
+ *   serializer dialect, and the fail-closed direction is the right one to leave
+ *   standing.
+ *
+ *   a BYTE-IDENTICAL duplicate whose canvas got the active workflow's tag, and
+ *   this one IS widened here — stated plainly rather than argued away (codex
+ *   gate, two rounds). The only writer that can put A's tag on a root without A's
+ *   own claim is `sealProvenRootBinding`, and it fires only on an UNTAGGED root
+ *   that already serializes EQUAL to A's current state with no other OPEN
+ *   workflow matching it — which a CLOSED duplicate's stranded canvas can satisfy,
+ *   since the exclusivity sweep can only see open tabs (its own comment says so).
+ *   From the seal onward that canvas is content-equal to A, so reads AND
+ *   mutations alike were already permitted on it; what the old shape guard added
+ *   was that the permission ENDED whenever the stranded canvas happened to drift.
+ *   This removes that late stop. It is accepted knowingly: the stop was
+ *   timing-dependent (it arrived only after arbitrary work had already landed on
+ *   that same canvas), the ambiguity it half-covered is `proofExclusive`'s
+ *   documented limit, and in the one construction that reaches it the stranded
+ *   root is also the object the active workflow would itself serialize on save.
+ *   Buying back that fraction of a case by refusing the four reported ones — the
+ *   right canvas, permanently locked, with no working remedy — is the worse trade.
+ */
+export function graphRootContentDriftOnBoundCanvas({
+  rootGraph,
+  activeWorkflow,
+  activeWorkflowUuid,
+} = {}) {
+  if (!graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid })) return false;
+  return graphRootStructureMatchesActiveWorkflow({ rootGraph, activeWorkflow });
+}
+
+/**
+ * Does the live root reproduce the active workflow's STRUCTURE — its node set
+ * (ids and types), links, floating links, reroutes, groups, config, top-level
+ * subgraphs, definitions and content-bearing extra?
+ *
+ * Exported separately from the relaxation above because the answer is also what
+ * makes a REFUSAL truthful. "The counts agree but the contents differ" leaves the
+ * reader unable to tell a genuinely different graph from the right one whose
+ * widgets drifted — and the old message resolved that ambiguity by asserting the
+ * worse reading ("a load, tab switch, or reconnect left this command pointed at
+ * the wrong canvas"), which is the sentence three reports in this cluster were
+ * derailed by. With this the disclosure states which of the two was measured.
+ *
+ * False when either side cannot be read: an uncompleted comparison is not a match.
+ */
+export function graphRootStructureMatchesActiveWorkflow({ rootGraph, activeWorkflow } = {}) {
+  try {
+    const expected = graphStructureShape(activeWorkflowCurrentState(activeWorkflow));
+    if (expected == null) return false;
+    let actual = null;
+    try {
+      actual = graphStructureShape(rootGraph?.serialize?.());
+    } catch {
+      return false;
+    }
+    return actual != null && actual === expected;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * True only when a root graph carries a durable workflow UUID that conflicts
  * with the active workflow object's already-established UUID. Missing identity
  * on either side is inconclusive: older frontends and first observation must
@@ -1009,7 +1161,24 @@ export function resolveGraphBindingVerdict({
       inSubgraph,
       postReconnectWindow,
     });
-  const rootShapeMismatch = graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow });
+  // #696/#663/#701/#702 — a content difference is only WRONG-CANVAS evidence when
+  // it is STRUCTURAL. On a root that positively carries this workflow's identity
+  // and reproduces every structural surface, the residue is a widget the canvas
+  // rewrote itself between ChangeTracker captures (see
+  // graphRootContentDriftOnBoundCanvas): the right canvas, drifted — and refusing
+  // it blocked every read and write with no recovery, because the remedy's own
+  // repaint re-created the same drift.
+  //
+  // The structural answer is computed ONCE and kept, because it is also what the
+  // refusal has to say when it does fire: without it a shape refusal cannot tell
+  // "a different graph" from "this graph, drifted, with no identity stamp", and
+  // the old message resolved that ambiguity by asserting the worse one.
+  const contentDiffers = graphRootMismatchesActiveWorkflow({ rootGraph, activeWorkflow });
+  const structureMatches =
+    contentDiffers && graphRootStructureMatchesActiveWorkflow({ rootGraph, activeWorkflow });
+  const rootShapeMismatch =
+    contentDiffers &&
+    !(structureMatches && graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid }));
   const currentStateTrustworthy = activeWorkflow?.isModified !== true;
   const baselineReadDesync =
     currentStateTrustworthy &&
@@ -1033,6 +1202,10 @@ export function resolveGraphBindingVerdict({
         ? activeWorkflowCurrentNodeCount(activeWorkflow)
         : activeWorkflowNodeCount(activeWorkflow),
       live: nodeCount,
+      // Only meaningful for the shape verdict, and only ever a POSITIVE `true`:
+      // a comparison that could not run leaves it false, which the message reads
+      // as "unestablished", never as "they differ".
+      ...(reason === "root-shape-mismatch" ? { structureMatches: structureMatches === true } : {}),
     };
   }
   if (graphEmptyBindingUnproven({ graph, rootGraph, activeWorkflow, activeWorkflowUuid })) {
@@ -1104,10 +1277,17 @@ export function graphBindingRefusalMessage(verdict) {
     `Re-targeting with panel_set_workflow_target is NOT a remedy for this — it re-points the ` +
     `session, it does not rebind the canvas.`;
   if (verdict.reason === "root-workflow-uuid-mismatch") {
+    // The predicate observed TWO TAGS THAT DISAGREE and nothing else. The earlier
+    // text went on to narrate "a load, tab switch, or reconnect left a stale tag
+    // behind" — a cause nobody watched happen, and one of several (a stranded
+    // canvas from a closed tab reads identically). Same defect as the shape
+    // message's wrong-canvas sentence, one branch over: state the observation,
+    // offer the usual causes as possibilities rather than as the finding.
     return (
       `[root-workflow-uuid-mismatch] The live canvas carries a different workflow's identity tag ` +
-      `than the active workflow — a load, tab switch, or reconnect left a stale tag behind, so ` +
-      `this command was NOT applied. ${remedy}`
+      `than the active workflow, so this command was NOT applied. What the panel observed is the ` +
+      `disagreement itself, not what produced it — a load, tab switch or reconnect leaving a stale ` +
+      `tag behind is the usual explanation, but none of them was witnessed here. ${remedy}`
     );
   }
   // #601 — name the ACTUAL failing predicate. This verdict is not a node-count
@@ -1130,15 +1310,70 @@ export function graphBindingRefusalMessage(verdict) {
       `remedy: close the extra tab.`
     );
   }
-  const expectation =
-    Number(verdict.expected) > 0
-      ? `the workflow reports ${verdict.expected} node(s), but the canvas is bound to a different graph`
-      : `the canvas's content does not match the active workflow's own state`;
-  return (
-    `[${verdict.reason}] The live graph is out of sync with the active workflow: ${expectation}. ` +
-    `A load, tab switch, or reconnect left this command pointed at the wrong canvas, so it was ` +
-    `NOT applied. ${remedy}`
-  );
+  // #701/#702 — SAY WHAT WAS MEASURED, AND ONLY THAT.
+  //
+  // The verdict already carried the LIVE count and the message threw it away, then
+  // asserted "a load, tab switch, or reconnect left this command pointed at the
+  // wrong canvas" from the half it kept. In every report in this cluster the two
+  // counts were EQUAL and the difference was a widget the canvas rewrote itself,
+  // so that sentence narrated a cause nobody observed — and three diagnoses went
+  // hunting a wrong-tab bug that was not there.
+  //
+  // Three distinct observations now get three distinct sentences:
+  //   sizes DISAGREE          → the canvas provably holds a different graph;
+  //   structure MATCHES       → the canvas reproduces this workflow's node set,
+  //                             links and groups exactly, and only its content and
+  //                             its identity stamp are unestablished. That is the
+  //                             one case where the ONLY thing missing is proof,
+  //                             and it names the remedy that supplies it;
+  //   anything else           → the contents disagree and the panel does not know
+  //                             which of the two it is looking at. Say that.
+  const expected = Number(verdict.expected);
+  const live = Number(verdict.live);
+  const measured = Number.isFinite(live) && Number.isFinite(expected);
+  const sizesDisagree = measured && expected > 0 && live !== expected;
+  if (verdict.reason === "root-shape-mismatch" && verdict.structureMatches === true && !sizesDisagree) {
+    return (
+      `[root-shape-mismatch] The live canvas reproduces this workflow's STRUCTURE exactly — same ` +
+      `node ids and types${measured ? ` (${expected})` : ""}, same links, groups and subgraphs — but its ` +
+      `CONTENT differs from the state the workflow last captured, and the canvas carries no identity ` +
+      `stamp proving it is this workflow's. A canvas whose widgets a node rewrote itself (a populate/ ` +
+      `wildcard node, control_after_generate, a bypass toggle) looks exactly like a DUPLICATE tab's ` +
+      `canvas from here, and the panel cannot tell them apart, so this command was NOT applied. ` +
+      `Re-open the active workflow tab (panel_open_workflow): its repaint is the one path that can ` +
+      `put this workflow's identity on the canvas, which is the proof this refusal is missing. ` +
+      `Whether it lands is REQUESTED, NOT CONFIRMED — the open reports its own rebind verdict and the ` +
+      `panel cannot observe the outcome otherwise, so treat the retry's own result as the answer. If ` +
+      `it still refuses, do NOT read that as proof the difference is more than content: an open that ` +
+      `could not prove its rebind leaves this refusal exactly where it was. A panel reload ` +
+      `(panel_reload scope:frontend) is the next step, and it is unconfirmed on the same terms. ` +
+      `Re-targeting with panel_set_workflow_target is NOT a remedy for this — it re-points the ` +
+      `session, it does not rebind the canvas.`
+    );
+  }
+  const expectation = sizesDisagree
+    ? `the workflow reports ${expected} node(s) but the live canvas holds ${live} — it is bound to a ` +
+      `different graph`
+    : measured && expected > 0
+      ? `both the workflow and the live canvas report ${expected} node(s), but the canvas does not ` +
+        `reproduce the workflow's own state — the difference is in the graph's CONTENT, not its size`
+      : expected > 0
+        ? `the workflow reports ${expected} node(s) and the live count was not measured here`
+        : `the canvas's content does not match the active workflow's own state`;
+  // Neither branch narrates an EVENT. A size disagreement establishes the canvas
+  // holds a different graph — it does not establish what put it there, and the
+  // load/switch/reconnect list is a set of usual explanations, not the finding
+  // (codex gate r3; the same defect the uuid-mismatch branch had). A content
+  // disagreement at equal size does not even establish that much: it is exactly
+  // the ambiguity above, and resolving it in the text is how this message misled
+  // three readers.
+  const cause = sizesDisagree
+    ? `The canvas therefore holds a graph other than the one the workflow describes, so this ` +
+      `command was NOT applied. A load, tab switch or reconnect leaving the command on the wrong ` +
+      `canvas is the usual explanation — the panel observed the mismatch, not the event.`
+    : `The panel cannot tell whether this is a DIFFERENT workflow's canvas or this workflow's own ` +
+      `canvas drifted from the state it last captured, so it was NOT applied.`;
+  return `[${verdict.reason}] The live graph is out of sync with the active workflow: ${expectation}. ${cause} ${remedy}`;
 }
 
 /**


### PR DESCRIPTION
## The cluster is one bug, not four

`#696`, `#701` (defect 1), `#702` and the recurring tail of `#663` are the same
predicate failing in both directions. `resolveGraphBindingVerdict` refused with
`root-shape-mismatch` whenever the live root's `serialize()` differed in ANY way
from the active workflow's `changeTracker.activeState`, and reported that as
"the canvas is bound to a different graph".

The inference requires `activeState` to mirror the live root whenever the tab is
clean. It does not. **ComfyUI's ChangeTracker captures on USER INPUT events
only** — the panel says so itself, in the comment on the post-command
`deferChangeTrackerSnapshot` wiring, which exists precisely because bridge-driven
edits are otherwise invisible to it. So a widget a *node* rewrites without user
input drifts the root while the tab still reports `isModified: false`:
`ImpactWildcardEncode` re-resolving `populated_text` on every execution
(`#696`), `control_after_generate` advancing a seed, an rgthree bypass toggle
(the `#663` recurrence on 0.11.41). Every report in this cluster carried the
right tab, the right workflow and the right node count.

**And it was self-reinforcing**, which is what turned it into "the documented
remedy does not remedy" (`#701`, `#702`):

1. the tracker is re-captured only after a command **succeeds**, and every
   command was being refused;
2. `workflow_open`'s repaint re-runs the very `loadedGraphNode` hook that rewrote
   the widget, so its own strict content proof fails;
3. `rebindFailed` then skips the `if (!rebindFailed)` block, so the tracker
   re-baseline (`clearSpuriousOpenModified`) never runs;
4. the tracker still holds the pre-drift state, and the next read fails
   **identically**, forever.

Only a page reload broke the loop, which is exactly what all four reporters
found.

## The fix — the evidence, not the verdict

A content difference is only proof of a **wrong canvas** when it is
**structural**.

- **`graphRootStructureMatchesActiveWorkflow`** — node id+type set plus every
  non-node surface (`links`, `floatingLinks`, `reroutes`, `groups`, `config`,
  `subgraphs`, `definitions`, `extra`) compared through the *same*
  `buildGraphShape` normalization, so it can never disagree with the full
  comparison about what a surface is. Per-node mutable content is dropped. An
  unreadable side is never a match.
- **`graphRootContentDriftOnBoundCanvas`** — that structural match **AND** a
  positive identity (`graphRootWorkflowUuidMatches`). Both conjuncts are
  load-bearing: structure alone cannot tell the active tab's canvas from a
  duplicate tab's (the same problem `proofExclusive` already guards in
  `sealProvenRootBinding`), so an untagged root stays refused and a foreign tag
  refuses earlier still.

Zero changes to `comfyui-mcp-panel.js` — the whole fix lives in the pure lib the
verdict already calls.

### The refusal now states only what was measured

The message threw away the LIVE count it already had, then asserted a cause from
the half it kept. In every report the counts were **equal**, so
"the canvas is bound to a different graph" / "a load, tab switch, or reconnect
left this command pointed at the wrong canvas" was a conclusion the evidence
never supported — and it sent three diagnoses hunting a wrong-tab bug that was
not there.

- both counts are printed;
- the wrong-canvas conclusion is stated only when the sizes provably disagree,
  and even there the *event* is offered as the usual explanation rather than
  asserted as the finding;
- a dedicated branch for **structure matches, identity unproven** names
  `panel_open_workflow` as the one path that can supply the missing proof —
  marked `REQUESTED, NOT CONFIRMED`, with the invalid contrapositive ("still
  refusing means the difference is more than content") explicitly refused,
  because an open can run and still fail to prove its rebind;
- `root-workflow-uuid-mismatch` stops narrating "a load, tab switch, or reconnect
  left a stale tag behind" as the finding. It observed two tags disagreeing.

## Both directions are pinned

Failing tests were written **first**, on `origin/main`.

Still refused, unchanged: a different node type or id, a removed node, different
links, groups, reroutes or top-level subgraphs (`#349`); a root with **no**
identity tag; a **conflicting** tag; a count-short mid-restore canvas (`#618`);
an unreadable structural comparison on either side; the `#545` dirty-tab
relaxation; `#604`'s mutation-vs-read bar.

**11 mutations verified**, each caught by a named test:

| mutation | caught by |
|---|---|
| `resolveGraphBindingVerdict` returns null (**always permit**) | 5 new + 20 existing |
| relaxation always fires | positive-identity, structural, `#565`, `#601`, `#618` |
| fix reverted (`origin/main`) | the `#696` drift test |
| identity conjunct dropped | positive-identity, structural-answer |
| structure conjunct dropped | structural (all 7 surfaces) |
| `links` dropped from the structural surfaces | structural |
| unreadable structural read becomes comparable | unreadable-serializer |
| node id/type requirement dropped | unreadable-serializer |
| `structureMatches` set without the comparison running | structural-answer |
| message reverts to the unconditional wrong-canvas cause | `#701`/`#702` message |
| uuid-mismatch re-asserts the unobserved cause | `#606` message |

Full suite: **2577 pass, 0 fail** (was 2568). `typecheck`, `node --check`, ES
module link check, tool-vocabulary gate, YARA-parity scan and a control-byte scan
of both changed files all clean. `pyproject.toml` and `PANEL_VERSION` untouched.

## Gate

Own adversarial codex gate, 3 rounds. R1: message asserted a wrong canvas at
equal counts, and asserted "different graph" on an unmeasured live count — both
fixed. R2: the uuid-mismatch branch asserted an unobserved cause — fixed. R3: the
size-disagree branch still narrated an event, and the new remedy branch promised
an unobservable recovery — both fixed.

**Held, with reasoning in the code:** the gate is right that the relaxation
widens the byte-identical-duplicate window. `sealProvenRootBinding` can stamp a
*closed* duplicate's stranded, untagged root (the exclusivity sweep only sees
open tabs), and this change removes the point at which a later drift would have
ended that permission. Taken knowingly: from the seal onward that canvas was
already content-equal, so reads **and** writes were already permitted on it; the
old stop was timing-dependent and arrived only after arbitrary work had landed;
and in the one construction that reaches it, the stranded root is also the object
the active workflow would itself serialize on save. The trade is documented on
the predicate rather than argued away.

## Not in this PR

- `#701` defects (2) and (3) — `panel_reload(scope:'frontend')` dropping the tab
  socket, and the truncated `wf:workf` routing key (orchestrator-side). Separate
  lifecycle/formatting bugs, untouched.
- `#663`'s remaining orchestrator item — `panel_set_workflow_target(mode:"current")`
  reporting success without verifying. Lives in `comfyui-mcp`'s `panel-tools.ts`.
- `workflow_open`'s own strict content proof (`graphRootMatchesState`) is
  deliberately **not** softened: that was tried, gated and reverted for stated
  reasons, and with this fix the open no longer needs to be soft — its repaint
  stamps the identity, and a content-only difference then stops refusing.

Refs artokun/comfyui-mcp-panel#696, artokun/comfyui-mcp-panel#701,
artokun/comfyui-mcp-panel#702, artokun/comfyui-mcp-panel#663

🤖 Generated with [Claude Code](https://claude.com/claude-code)
