### PR TITLE
fix(panel #698): say when a widget structurally cannot hold a value

### DIFF
--- a/browser_tests/unit/dom-widget-diagnosis.test.mjs
+++ b/browser_tests/unit/dom-widget-diagnosis.test.mjs
@@ -1,0 +1,62 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { describeNonValueBearingWidget } from "../../web/js/lib/widget-write.js";
+
+/**
+ * #698 — panel_set_widget on a non-value-bearing DOM widget (PixaromaPrompt's
+ * `pix_prompt_ui`) wrote, reverted, and reported "did not retain the requested
+ * value" — which reads as transient and retryable when it is structural.
+ *
+ * The safety property under test is as much about what this does NOT do: it is
+ * diagnosis appended to an ALREADY-OBSERVED failure, never a gate. So a plain
+ * widget must contribute nothing at all.
+ */
+
+test("a plain value widget contributes NO diagnosis (this must never become a gate)", () => {
+  // The load-bearing negative. If this ever returns text for an ordinary widget,
+  // the message starts blaming DOM-backing for unrelated failures.
+  assert.equal(describeNonValueBearingWidget({ name: "seed", value: 5 }), "");
+  assert.equal(describeNonValueBearingWidget({ name: "text", value: "", options: {} }), "");
+  assert.equal(describeNonValueBearingWidget({ name: "cfg", options: { min: 0, max: 10 } }), "");
+});
+
+test("serialize:false alone is NOT treated as non-value-bearing (#715)", () => {
+  // LoadImage's `upload` button is serialize:false and perfectly healthy. Gating
+  // or blaming on that flag is exactly the false-refusal #715 removed.
+  assert.equal(describeNonValueBearingWidget({ name: "upload", serialize: false }), "");
+});
+
+test("a DOM-element widget is identified, and the message says retrying will not help", () => {
+  const d = describeNonValueBearingWidget({ name: "pix_prompt_ui", element: {} });
+  assert.notEqual(d, "");
+  assert.match(d, /DOM-backed display widget/i);
+  assert.match(d, /Retrying will not help/i);
+  // Must point at where the value actually lives — the thing the reporter had to
+  // discover by reading the pack's source.
+  assert.match(d, /node\.properties/);
+});
+
+test("a widget with getValue/setValue accessors is identified even without an element", () => {
+  const d = describeNonValueBearingWidget({
+    name: "pix_prompt_ui",
+    options: { getValue: () => null, setValue: () => {} },
+  });
+  assert.notEqual(d, "");
+  assert.match(d, /getValue\/setValue/);
+  assert.match(d, /Retrying will not help/i);
+});
+
+test("it never throws on malformed widgets", () => {
+  for (const w of [null, undefined, 0, "str", [], { options: null }, { options: 7 }]) {
+    assert.doesNotThrow(() => describeNonValueBearingWidget(w));
+    assert.equal(typeof describeNonValueBearingWidget(w), "string");
+  }
+});
+
+test("the diagnosis is a suffix — it never replaces the observed wrote/became facts", () => {
+  // The caller appends this to the existing message; it must read as an addition,
+  // not as a substitute for the evidence.
+  const d = describeNonValueBearingWidget({ name: "x", element: {} });
+  assert.ok(d.startsWith(" "), "must append cleanly after the observed-facts sentence");
+  assert.ok(!/did not retain/.test(d), "must not restate the observation");
+});

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1221,7 +1221,14 @@ export function applyWidgetWrite(
   if (!matchesExpected(w.value)) {
     failure =
       `Widget "${w.name}" on node ${targetNode.id} (${targetNode.type}) did not retain the ` +
-      `requested value: wrote ${JSON.stringify(expected)} but it became ${JSON.stringify(w.value)}.`;
+      `requested value: wrote ${JSON.stringify(expected)} but it became ${JSON.stringify(w.value)}.` +
+      // #698 — "did not retain" reads as a transient failure worth retrying. For a
+      // non-value-bearing DOM widget it is STRUCTURAL: the widget is a view, its
+      // real state lives on the node, and no number of retries will change that.
+      // Appended ONLY here, in the branch where the revert has already been
+      // OBSERVED — so this can never turn into a pre-emptive refusal of a widget
+      // that would have worked. Diagnosis, never a gate.
+      describeNonValueBearingWidget(w);
   } else if (parentWidget && !matchesExpected(parentWidget.value)) {
     failure =
       `Promoted rail widget "${parentWidget.name}" on subgraph node ${node.id} did not retain ` +
@@ -1553,4 +1560,47 @@ export function applyWidgetWrite(
         }
       : {}),
   };
+}
+
+/**
+ * #698 — explain a write that reverted, when the widget structurally cannot hold
+ * a value.
+ *
+ * Custom packs register DOM widgets that are pure VIEWS: ComfyUI's `addDOMWidget`
+ * gives them an `element`, and the pack supplies `getValue`/`setValue` that read
+ * and write the node's own state instead of the widget's `.value`. Pixaroma's
+ * `PixaromaPrompt` is the reported case — `pix_prompt_ui` returns null from
+ * `getValue`, `setValue` is a no-op, and the prompt actually lives in
+ * `node.properties.promptState.text`.
+ *
+ * Assigning `.value` on one of those appears to work and then reverts, so the
+ * caller was told the widget "did not retain the requested value" — indistinguishable
+ * from a transient failure, and the reporter reasonably retried before working
+ * around it. This makes the structural case say so.
+ *
+ * DELIBERATELY DIAGNOSIS-ONLY. It is called from the failure branch, after the
+ * revert has been observed, and never decides whether a write may proceed. A
+ * pre-emptive version would have to guess "this widget cannot hold a value" from
+ * `serialize === false` — and #715 established that `serialize:false` is normal
+ * for perfectly healthy widgets (LoadImage's `upload` button is one), so gating on
+ * it would manufacture exactly the kind of false refusal this file exists to avoid.
+ */
+export function describeNonValueBearingWidget(w) {
+  if (!w || typeof w !== "object") return "";
+  const hasElement = !!w.element;
+  const opts = w.options && typeof w.options === "object" ? w.options : null;
+  const hasAccessors = !!(opts && (typeof opts.getValue === "function" || typeof opts.setValue === "function"));
+  if (!hasElement && !hasAccessors) return "";
+  const where = hasAccessors
+    ? "its owning node's own state (commonly `node.properties`), reached through the widget's getValue/setValue"
+    : "its owning node's own state (commonly `node.properties`)";
+  return (
+    ` This looks like a DOM-backed display widget rather than a value widget` +
+    `${hasElement ? " (it owns a DOM element" : " (it defines getValue/setValue"}` +
+    `${hasElement && hasAccessors ? " and defines getValue/setValue" : ""}), so its` +
+    ` real value is held in ${where} — assigning the widget does not reach it.` +
+    ` Retrying will not help. Drive the node another way (an equivalent serialized` +
+    ` input, or a node whose value is a plain widget), or ask the pack's author to` +
+    ` expose a settable value.`
+  );
 }


### PR DESCRIPTION
Addresses the reportable half of #698.

## The defect

`panel_set_widget` on `PixaromaPrompt`'s `pix_prompt_ui` wrote the string, the widget reverted to `""`, and the tool reported:

> `Widget "pix_prompt_ui" on node 44 (PixaromaPrompt) did not retain the requested value: wrote "A cinematic portrait ..." but it became "".`

That reads as a **transient** failure worth retrying. It is **structural**: the pack registers `pix_prompt_ui` as a non-serialized DOM widget — `getValue` returns null, `setValue` is a no-op — and the real prompt lives in `node.properties.promptState.text`. No retry can ever succeed. The reporter retried, then worked around it with a `CLIPTextEncode` route.

The failure message now names what the widget is and where its value actually lives.

## Scope — deliberately the second of the two paths

The issue proposes either supporting a generic DOM-widget contract, or refusing honestly.

- **Generic DOM-widget support is a compatibility FEATURE**, not a defect fix, and is out of scope under the stabilization freeze. It also needs a real contract design (which packs opt in, how state is addressed), not a Pixaroma special case.
- **Making the refusal honest is the bug fix.** That is this PR.

Note the failed write **already rolls back**, so nothing was half-applied — the defect was the explanation, not the state. That is why this is a message change rather than a mutation-safety change.

## Diagnosis only, never a gate

This is the constraint that shaped the implementation. `describeNonValueBearingWidget()` is called **from the failure branch, after the revert has already been observed**. It cannot pre-emptively refuse a widget that would have worked.

A pre-write detector was considered and rejected: it would have to infer "this widget cannot hold a value" from `serialize === false` — and **#715 just established that flag is entirely normal on healthy widgets** (LoadImage's `upload` button is `serialize:false` and works fine). Gating on it would manufacture exactly the class of false refusal `widget-write.js` exists to prevent, in the same guard family that took three PRs to fix today.

## Verification

Mutation-verified — making the helper fire for **every** widget fails **3 of 6** tests. The negative cases are the load-bearing ones:

- a plain value widget contributes **nothing**
- a `serialize:false` widget contributes **nothing** (the #715 lesson, pinned)

Full suite **2657/2657**. Panel parses **and links** as an ES module. `typecheck` clean. Control-byte scan 0. `pyproject.toml` / `PANEL_VERSION` untouched — no Registry publish.

## Left open

#698 stays open for the generic DOM-widget contract (and its related #314). This PR removes the misleading guidance; it does not make `PixaromaPrompt` drivable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)