### PR TITLE
0.11.43 — ten fixes from a day of live panel reports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.42"
+version = "0.11.43"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -843,7 +843,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.42";
+const PANEL_VERSION = "0.11.43";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
Version bump so today's fixes actually reach users. **Merging this publishes to the Comfy Registry** (the publish fires on the `pyproject.toml` change).

Every fix below came from a **via-panel report filed in the last day**, and none has shipped — 0.11.42 carried the 0.50.0 tool-surface migration, and all nine landed after it.

| issue | fix |
|---|---|
| **#711** | `ask_user` / `request_secret` fenced to the conversation whose turn asked. An abandoned turn could paint a **secure-input card into whatever conversation the tab was showing**, and the token typed there returned as that turn's result |
| **#695** | socket-vs-widget classified structurally, so comma-joined unions (`"IMAGE,MASK"`) stop failing closed — **17 more node classes addable, 0 newly refused** across all 2887 |
| **#700** | the backend node def is snapshotted, not read by reference, so a refresh can't mutate the "backend truth" the guard compares against — `LoadImage` had become permanently unaddable |
| **#706** | a Manager **security refusal** no longer reports as "not reachable", and no longer carries the flag that authorizes a mutation **re-send** |
| **#710** | `panel_show_media` **plays** audio instead of painting a broken image, and a kind it cannot present is no longer counted as `painted` |
| **#705** | a CivitAI outage surfaces the upstream reason instead of a bare `503`, so it stops reading as a broken search |
| **#696 #701 #702 #663** | a content difference is wrong-canvas evidence only when **structural** — the guard compared full `serialize()` against a tracker that only snapshots on *user* input, so any node-driven widget write looked like a different graph |
| **#698** | a widget that structurally cannot hold a value says so, instead of a retryable-sounding "did not retain the requested value" |
| **#703** | the **Prompts** button no longer opens a console page this build doesn't serve; it disables itself on a definitive 404 and re-enables when the route ships |

Two themes run through them, and they're the same classes the 0.50.0 work kept hitting: **false refusals** (valid operations rejected) and **dishonest results** (a tool reporting success, or a wrong cause). Both mislead the agent rather than merely inconveniencing the user.

## Verification

- full suite **2665/2665**
- panel **parses and links** as an ES module
- `PANEL_VERSION` and `pyproject` bumped together — they must match or the publish is wrong
- control-byte scan 0 on both changed files

Each underlying PR was independently mutation-verified before merge, and `main` was re-verified composed afterwards — each was CI-green against a *different* `main`, which is exactly the stale-green trap that produced a regression earlier in this cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)