### PR TITLE
fix(panel #703): don't offer a console page this build doesn't serve

### DIFF
--- a/browser_tests/unit/console-route-probe.test.mjs
+++ b/browser_tests/unit/console-route-probe.test.mjs
@@ -1,0 +1,75 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { probeConsoleRoute, UNBUILT_ROUTE_TITLE } from "../../web/js/lib/console-route-probe.js";
+
+/**
+ * #703 — the Prompts button opened a console page that was never built, showing
+ * {"ok":false,"error":"not_found"} in a new tab.
+ *
+ * The asymmetry is the whole design: a 404 is EVIDENCE the route is missing;
+ * everything else is not. So most of these tests assert that the button stays
+ * ENABLED — removing a working button because a probe flaked is worse than the
+ * 404 this fixes.
+ */
+
+test("a definitive 404 marks the route unavailable", () => {
+  return probeConsoleRoute("http://c/prompts", { fetchImpl: async () => ({ status: 404 }) }).then(
+    (r) => {
+      assert.equal(r.available, false);
+      assert.equal(r.reason, "not-found");
+    },
+  );
+});
+
+test("a served route is available", async () => {
+  const r = await probeConsoleRoute("http://c/prompts", { fetchImpl: async () => ({ status: 200 }) });
+  assert.equal(r.available, true);
+});
+
+test("a NETWORK failure leaves it available — a flaky probe must not remove a working button", async () => {
+  // The load-bearing negative. If this ever flips to unavailable, a transient
+  // console blip silently deletes a working feature from the UI.
+  const r = await probeConsoleRoute("http://c/prompts", {
+    fetchImpl: async () => {
+      throw new Error("network down");
+    },
+  });
+  assert.equal(r.available, true);
+  assert.equal(r.reason, "probe-failed");
+});
+
+test("a timeout leaves it available", async () => {
+  const r = await probeConsoleRoute("http://c/prompts", {
+    fetchImpl: (_u, opts) =>
+      new Promise((_res, rej) => {
+        opts?.signal?.addEventListener?.("abort", () => rej(new Error("aborted")));
+      }),
+    timeoutMs: 20,
+  });
+  assert.equal(r.available, true);
+});
+
+test("a response with no usable status leaves it available", async () => {
+  for (const bad of [null, undefined, {}, { status: "404" }]) {
+    const r = await probeConsoleRoute("http://c/prompts", { fetchImpl: async () => bad });
+    assert.equal(r.available, true, `status ${JSON.stringify(bad)} is not evidence of absence`);
+  }
+});
+
+test("other 4xx/5xx do NOT mark it unavailable — only 404 is evidence", async () => {
+  for (const status of [401, 403, 500, 502, 503]) {
+    const r = await probeConsoleRoute("http://c/prompts", { fetchImpl: async () => ({ status }) });
+    assert.equal(r.available, true, `status ${status} must not disable the button`);
+  }
+});
+
+test("a missing url or fetch resolves to available rather than throwing", async () => {
+  assert.equal((await probeConsoleRoute("")).available, true);
+  assert.equal((await probeConsoleRoute(null)).available, true);
+  assert.equal((await probeConsoleRoute("http://c/x", { fetchImpl: null })).available, true);
+});
+
+test("the disabled tooltip blames the build, not the running server", () => {
+  assert.match(UNBUILT_ROUTE_TITLE, /isn't available in this build/i);
+  assert.ok(!/error|failed|broken/i.test(UNBUILT_ROUTE_TITLE), "must not imply a fault");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -358,6 +358,7 @@ import {
 import { createRestartTabIdentity, sendBridgeHello } from "./lib/restart-tab-identity.js";
 import { primeModuleCache, resolveBundleStaleness } from "./lib/bundle-version.js";
 import { classifyManager404 } from "./lib/manager-404.js";
+import { probeConsoleRoute, UNBUILT_ROUTE_TITLE } from "./lib/console-route-probe.js";
 import {
   createTabRouteIdentity,
   describeRefusedRoute,
@@ -17259,6 +17260,28 @@ function buildPanel() {
     }
     window.open(`${cmcpConsoleUrl}/prompts?token=${encodeURIComponent(cmcpConsoleToken)}`, "_blank", "noopener");
   });
+  // #703 — the console page this opens was never built: the orchestrator serves
+  // neither /prompts nor /api/prompts, so clicking used to open a tab showing
+  // {"ok":false,"error":"not_found"} — which reads like the running server is
+  // broken rather than like an unbuilt feature.
+  //
+  // Probe HERE, while the popover is being built, rather than on click: an async
+  // window.open after an awaited fetch loses the user-gesture and gets caught by
+  // popup blockers. Only a definitive 404 disables the button (see the probe's
+  // header) — a flaky or unreachable console leaves it enabled, because removing
+  // a working button on a failed probe is the worse error. When the console
+  // starts serving the page, this re-enables itself with no further change.
+  if (cmcpConsoleUrl && cmcpConsoleToken) {
+    void probeConsoleRoute(
+      `${cmcpConsoleUrl}/prompts?token=${encodeURIComponent(cmcpConsoleToken)}`,
+    ).then(({ available }) => {
+      if (available) return;
+      promptsBtn.disabled = true;
+      promptsBtn.style.opacity = "0.4";
+      promptsBtn.style.cursor = "not-allowed";
+      promptsBtn.title = UNBUILT_ROUTE_TITLE;
+    });
+  }
 
   const btnRow = document.createElement("div");
   btnRow.style.cssText = "display:flex;gap:0.375rem;align-items:center;flex-wrap:wrap;";

--- a/web/js/lib/console-route-probe.js
+++ b/web/js/lib/console-route-probe.js
@@ -1,0 +1,67 @@
+/**
+ * #703 — decide whether the orchestrator's console actually serves a route,
+ * before offering a button that opens it.
+ *
+ * The connection popover's "Prompts" button opens `<console>/prompts`, a page
+ * that was never built: the orchestrator registers no `/prompts` page route and
+ * no `/api/prompts` data route. Clicking it opened a new tab showing
+ * `{"ok":false,"error":"not_found"}`, which reads like the running server is
+ * broken rather than like a feature that does not exist yet.
+ *
+ * FAILS BACK TO AVAILABLE, deliberately. Only a definitive 404 disables the
+ * button. A network error, a timeout, an opaque response or an unreachable
+ * console all resolve to "available", because none of them is evidence the route
+ * is missing — and disabling a working button because the probe itself failed
+ * would be a false refusal, which is the worse error. The 404 page is a nuisance;
+ * a button that vanishes on a flaky probe is a bug report.
+ *
+ * FORWARD-COMPATIBLE. The day the console starts serving `/prompts`, the probe
+ * stops returning 404 and the button starts working with no further change.
+ */
+
+/** Probe timeout. Short: this runs while a popover is being built, and a slow
+ *  console must not delay the UI. Expiry resolves to "available" per above. */
+const PROBE_TIMEOUT_MS = 2500;
+
+/**
+ * @returns {Promise<{available: boolean, reason: string}>}
+ *   `available:false` ONLY on a definitive 404.
+ */
+export async function probeConsoleRoute(url, { fetchImpl, timeoutMs = PROBE_TIMEOUT_MS } = {}) {
+  if (typeof url !== "string" || !url) return { available: true, reason: "no-url" };
+  const doFetch = fetchImpl || (typeof fetch === "function" ? fetch : null);
+  if (!doFetch) return { available: true, reason: "no-fetch" };
+
+  let timer = null;
+  try {
+    const ctrl = typeof AbortController === "function" ? new AbortController() : null;
+    if (ctrl && typeof setTimeout === "function") {
+      timer = setTimeout(() => {
+        try {
+          ctrl.abort();
+        } catch {
+          /* aborting is best-effort */
+        }
+      }, timeoutMs);
+    }
+    const res = await doFetch(url, {
+      method: "GET",
+      credentials: "same-origin",
+      ...(ctrl ? { signal: ctrl.signal } : {}),
+    });
+    // No response object at all tells us nothing about the route.
+    if (!res || typeof res.status !== "number") return { available: true, reason: "no-status" };
+    if (res.status === 404) return { available: false, reason: "not-found" };
+    return { available: true, reason: `status-${res.status}` };
+  } catch {
+    // Aborted, offline, CORS, DNS — none of these is evidence of a missing route.
+    return { available: true, reason: "probe-failed" };
+  } finally {
+    if (timer !== null && typeof clearTimeout === "function") clearTimeout(timer);
+  }
+}
+
+/** The tooltip for a button whose console page this build does not serve. Says
+ *  what is true (not built here) rather than implying a fault in the server. */
+export const UNBUILT_ROUTE_TITLE =
+  "The prompt editor isn't available in this build — this orchestrator doesn't serve the prompts console page yet.";


### PR DESCRIPTION
Closes #703.

## The defect

The connection popover's **Prompts** button opens `<console>/prompts`. The orchestrator serves **neither** that page route **nor** the `/api/prompts` data route the surrounding comment anticipates — I grepped `comfyui-mcp/src/` for both and got nothing. So clicking opened a new tab showing:

```json
{"ok":false,"error":"not_found"}
```

That reads like the running server is broken, when the truth is the page was planned and never built.

## Why the button is not removed

Its tooltip — *"Edit the agent's system prompts (persona, per-backend, Ask-AI)"* — describes a capability someone deliberately planned. Deleting it is a **product decision**, not a defect fix, and building the console is a **feature** parked behind the stabilization pass. So this fixes only the part that is unambiguously a defect: the misleading 404.

The popover now probes the route as it is built and, on a definitive 404, disables the button with a tooltip that blames the **build** rather than the server.

## Three deliberate choices

**Probe at popover-build time, not on click.** An async `window.open` after an awaited `fetch` loses the user gesture and gets caught by popup blockers.

**Fail back to AVAILABLE.** Only a definitive 404 disables. A network error, a timeout, an opaque response, an unreachable console, and every other 4xx/5xx leave the button **enabled** — none is evidence the route is missing, and removing a working button because the probe flaked is the worse error. The 404 page is a nuisance; a feature silently vanishing on a transient blip is a bug report. This is the same fail-back-to-conservative shape as #706's unreadable-body case.

**Forward-compatible.** The day the console serves `/prompts`, the probe stops 404ing and the button works again with no further change.

## Verification

Mutation-verified: making the probe pessimistic — any non-200, or a network failure, disables — fails **4 of 8** tests. The false-disable guards are the load-bearing ones, which is why most of the suite asserts the button stays *enabled*.

Full suite **2665/2665**. Panel parses **and links** as an ES module. `typecheck` and the tool-vocabulary gate clean. Control-byte scan 0 on all three changed files. `pyproject.toml` / `PANEL_VERSION` untouched — release #722 is pending and must not be disturbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)