### PR TITLE
fix(panel #712): attribute an empty model grid to the browsing level

### DIFF
--- a/browser_tests/unit/civitai-level-attribution.test.mjs
+++ b/browser_tests/unit/civitai-level-attribution.test.mjs
@@ -1,0 +1,83 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { CivitaiClient } from "../../web/js/cmcp-civitai.js";
+
+/**
+ * #712 — every CivitAI model search returned zero results with `error: null`,
+ * indistinguishable from "nothing matched".
+ *
+ * Cause: `browsingLevels` defaults to `[1]` (PG), and `_modelFromJson` drops a
+ * model outright when no cover image falls in the mask (a deliberate #515 SFW
+ * guarantee). Almost no LoRA/checkpoint has a PG-rated cover, so everything
+ * vanished — silently.
+ *
+ * The filter is NOT changed here: what it removes is a content-policy decision.
+ * What is fixed is the silence, so the empty grid becomes attributable the way
+ * an empty favorites feed already is (#190/#375).
+ */
+
+function clientWith(pages) {
+  // Same injection shape the other civitai suites use: the monolith hands the
+  // client ComfyUI's api ({fetchApi, apiURL}).
+  const c = new CivitaiClient({ fetchApi: async () => ({ status: 200 }), apiURL: (p) => p });
+  let i = 0;
+  c._get = async () => pages[Math.min(i++, pages.length - 1)];
+  return c;
+}
+
+const model = (id, nsfwLevel) => ({
+  id,
+  name: `m${id}`,
+  modelVersions: [{ images: [{ url: `http://x/${id}.png`, nsfwLevel, type: "image" }] }],
+});
+
+test("counts what the browsing level removed", async () => {
+  // Three models with mature covers, PG-only filter → all dropped.
+  const c = clientWith([{ items: [model(1, 4), model(2, 8), model(3, 16)], metadata: {} }]);
+  const page = await c.fetchModels({ type: "LORA", levels: [1] });
+  assert.equal(page.models.length, 0, "all dropped by the level filter");
+  assert.equal(page.hiddenByLevel, 3, "and the count says so — this is what was silent");
+});
+
+test("reports zero hidden when the level admits everything", async () => {
+  const c = clientWith([{ items: [model(1, 1), model(2, 1)], metadata: {} }]);
+  const page = await c.fetchModels({ type: "LORA", levels: [1] });
+  assert.equal(page.models.length, 2);
+  assert.equal(page.hiddenByLevel, 0, "a genuine result set must not claim anything was hidden");
+});
+
+test("a KEYWORD miss is not counted as level-hidden", async () => {
+  // The load-bearing distinction. Counting keyword misses here would tell the
+  // user to widen a browsing level that was never the reason they saw nothing.
+  const c = clientWith([{ items: [model(1, 1), model(2, 1)], metadata: {} }]);
+  // The client-side keyword filter only engages when BOTH query and username
+  // are sent — /v1/models returns an empty page for that combination, so the
+  // client sends username alone and matches the keyword locally.
+  const page = await c.fetchModels({
+    type: "LORA",
+    levels: [1],
+    query: "zzz-no-such-model",
+    username: "someone",
+  });
+  assert.equal(page.models.length, 0, "keyword removed them");
+  assert.equal(page.hiddenByLevel, 0, "but the LEVEL removed nothing");
+});
+
+test("accumulates across the thin-page hop chain, not just the last page", async () => {
+  // fetchModels chases continuable empty pages; a count taken only from the
+  // final hop would under-report everything the earlier hops dropped.
+  const c = clientWith([
+    { items: [model(1, 4), model(2, 4)], metadata: { nextCursor: "c1" } },
+    { items: [model(3, 8)], metadata: { nextCursor: "c2" } },
+    { items: [model(4, 1)], metadata: {} },
+  ]);
+  const page = await c.fetchModels({ type: "LORA", levels: [1] });
+  assert.equal(page.models.length, 1, "only the PG one survives");
+  assert.equal(page.hiddenByLevel, 3, "all three dropped across the hops are counted");
+});
+
+test("an empty upstream page reports nothing hidden", async () => {
+  const c = clientWith([{ items: [], metadata: {} }]);
+  const page = await c.fetchModels({ type: "LORA", levels: [1] });
+  assert.equal(page.hiddenByLevel, 0);
+});

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -666,6 +666,12 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
         });
         if (req !== state.reqId) return;
         state.cursor = page.nextCursor; state.done = !page.nextCursor;
+        // #712 — accumulate what the BROWSING LEVEL removed, so an empty model
+        // grid is attributable the way an empty favorites feed already is
+        // (#190/#375). Without this, a level that hid every result looked
+        // identical to "nothing matched your search", and the docked browser
+        // read as broken.
+        state.hiddenByLevel = (state.hiddenByLevel || 0) + (page.hiddenByLevel || 0);
         appendModels(page.models);
         stalled = !page.models.length && !state.done;
       } else if (state.query) {
@@ -2009,6 +2015,21 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
       error: state.error || null,
       authenticated: !!state.signedIn,
       ...(tabDef().fav ? { favoritesStatus: state.favoritesStatus || "ok" } : {}),
+      // #712 — the model tabs' half of the same rule. An empty model grid was
+      // reported as `error: null, done: true`, indistinguishable from "nothing
+      // matched" even when the browsing level had removed every result — which
+      // is what made "0 results for any search" read as a broken browser.
+      // Emitted only when the level actually removed something, so a genuine
+      // no-match stays a clean empty result.
+      ...(isModelTab() && state.hiddenByLevel
+        ? {
+            hiddenByBrowsingLevel: state.hiddenByLevel,
+            levelFilterNote:
+              `${state.hiddenByLevel} result(s) were removed by the current browsing level ` +
+              `(${(state.filters?.browsingLevels || []).join(", ") || "default"}). ` +
+              `They are not missing from CivitAI — widen browsingLevels to see them.`,
+          }
+        : {}),
     };
   }
   /** Highlight a set of ids (REPLACEMENT semantics). Awaits the in-flight

--- a/web/js/cmcp-civitai.js
+++ b/web/js/cmcp-civitai.js
@@ -1029,6 +1029,9 @@ export class CivitaiClient {
     const kw = clientFilter ? String(query).toLowerCase() : null;
     let next = cursor || null;
     let models = [];
+    // Accumulated across hops, so a search that chased several thin pages
+    // reports everything the level filter removed, not just the last page's.
+    let hiddenByLevel = 0;
     // An empty page with a cursor is not the end of a search: /v1/models can
     // thin pages server-side, and keyword×creator additionally filters them
     // client-side. Chase a bounded number of continuable empty pages.
@@ -1036,14 +1039,22 @@ export class CivitaiClient {
       const q = new URLSearchParams(base);
       if (next) q.set("cursor", next);
       const data = await this._get(`${API}/v1/models?${q.toString()}`);
-      models = (data.items || [])
-        .map((x) => this._modelFromJson(x, levels))
-        .filter(Boolean);
+      const raw = data.items || [];
+      models = raw.map((x) => this._modelFromJson(x, levels)).filter(Boolean);
+      // #712 — how many CivitAI returned that the BROWSING LEVEL removed.
+      // Counted HERE, before the keyword filter below: a keyword miss is "no
+      // match", not "hidden by your level", and conflating them would tell the
+      // user to widen a filter that was never the reason.
+      hiddenByLevel += raw.length - models.length;
       if (kw) models = models.filter((m) => (m.name || "").toLowerCase().includes(kw));
       next = data.metadata?.nextCursor || null;
       if (models.length || !next || hop >= 4) break;
     }
-    return { models, nextCursor: next };
+    // hiddenByLevel is what makes an empty grid ATTRIBUTABLE (#190/#375): the
+    // favorites tab already distinguishes "filtered out" from "genuinely empty";
+    // the model tabs reported neither, so a browsing level that removed every
+    // result was indistinguishable from "nothing matched your search".
+    return { models, nextCursor: next, hiddenByLevel };
   }
 
   async fetchModelDetail(modelId, { levels = [1] } = {}) {


### PR DESCRIPTION
Closes #712.

## The defect

Every CivitAI model search returned **zero results** with `error: null` and eventually `done: true` — indistinguishable from "nothing matched your search". That is why the docked browser read as *broken* rather than *filtered*, including for maximally generic queries like `anime`.

**Cause** (as diagnosed in the issue, confirmed here): `DEFAULT_FILTERS.browsingLevels` is `[1]` (PG), and `_modelFromJson` drops a model **outright** when no cover image falls in the mask. Almost no LoRA/checkpoint on CivitAI has a PG-rated cover, so effectively everything was removed — silently.

## What this deliberately does NOT do

**It does not change the filter or the default.** The dropping is intentional: `_modelFromJson` carries an explicit **#515** guarantee — *"no NSFW cover leaking into an SFW view"* — and drops both `nsfw:true` models and models whose every cover sits outside the mask.

What the browsing level removes is a **content-policy decision**, and widening what this project shows by default is not something to slip into a bug fix. If the default should change, that deserves to be its own deliberate call.

## What it fixes: the silence

This codebase **already made exactly this rule** for the favorites tab (#190/#375) — an empty grid must be attributable, never silent:

```
//  favoritesStatus — 'ok' | 'signed_out' | 'no_likes_collection' | 'filtered_out',
//                    so an empty favorites feed is attributable rather than silent.
```

…complete with a `favOut` buffer retaining what the level removed. **None of it had been extended to loras/checkpoints/workflows**, which carried only `error` (upstream failure) and so had no way to express "your level hid everything".

`fetchModels` now returns `hiddenByLevel`; the agent-facing serialization gains `hiddenByBrowsingLevel` plus a note naming the active levels — emitted **only** when the level actually removed something, so a genuine no-match stays a clean empty result.

## The subtle part

**The count is taken BEFORE the client-side keyword filter.** A keyword miss is "no match", not "hidden by your level" — conflating them would tell the user to widen a filter that was never the reason they saw nothing. Moving the count one line later fails exactly that test.

It also **accumulates across the thin-page hop chain**: `fetchModels` chases up to 5 continuable empty pages, and a count taken only from the final hop would under-report everything the earlier hops dropped.

## Verification

Mutation-verified — moving the count after the keyword filter fails the conflation guard specifically. Tests cover: all-dropped, none-dropped, keyword-miss-is-not-level-hidden, multi-hop accumulation, and an empty upstream page.

Full suite **2670/2670**. Panel parses **and links** as an ES module. `typecheck` clean, control-byte scan 0. `pyproject.toml` / `PANEL_VERSION` untouched (release #722 pending).

Note **#599** looks like a *different* failure — `Failed to fetch` in the panel while the same query succeeds via `search_civitai_models` and direct — a transport/proxy problem rather than this filter. Left separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)