### PR TITLE
fix(panel #708): a save must write the TAB’s graph, and "blank" must be proven before it is claimed

### DIFF
--- a/browser_tests/unit/binding-recovery.test.mjs
+++ b/browser_tests/unit/binding-recovery.test.mjs
@@ -144,6 +144,7 @@ test("#606 workflow_new stamps the fresh tab's identity onto a proven-empty root
   });
   const out = await workflow_new({ rid: "r1" });
   assert.equal(out.created, true);
+  assert.equal(out.empty, true, "#708 — the proof that licensed the stamp also licenses the claim");
   assert.equal(out.routing_key, "tmp:new-tab");
   assert.equal(stamps.length, 1, "the creation stamp must fire exactly once");
   assert.equal(stamps[0][0], rootGraph, "stamps the LIVE root");
@@ -165,7 +166,11 @@ test("#606 workflow_new does NOT stamp a root that still holds content (fail clo
     onStamp: (...args) => stamps.push(args),
   });
   const out = await workflow_new({ rid: "r1" });
-  assert.equal(out.created, true, "creation itself still succeeds");
+  // #708 — the tab and its routing identity are real, but "blank" was never proven,
+  // so the acknowledgement must not claim it (see the ack tests in
+  // new-workflow-persistence.test.mjs for the full contract).
+  assert.equal(out.created, "unknown", "an unproven canvas is not a confirmed blank tab");
+  assert.equal(out.routing_key, "tmp:new-tab", "the routing identity is still returned");
   assert.equal(stamps.length, 0, "no re-tagging a root with foreign content");
 });
 
@@ -186,7 +191,9 @@ test("#606 workflow_new does NOT stamp when the NEW workflow is not itself prove
   ]) {
     const stamps = [];
     const workflow_new = buildWorkflowNew({ rootGraph, activeWorkflow: wf, onStamp: (...a) => stamps.push(a) });
-    assert.equal((await workflow_new({ rid: "r1" })).created, true, "creation still succeeds");
+    const out = await workflow_new({ rid: "r1" });
+    assert.equal(out.created, "unknown", "#708 — an unprovable tab is reported as outcome-unknown");
+    assert.equal(out.routing_key, "tmp:new-tab", "the tab was still created and is addressable");
     assert.equal(stamps.length, 0, "an unprovable workflow side must not license the stamp");
   }
   assert.equal(
@@ -206,7 +213,7 @@ test("#606 workflow_new does NOT stamp an unserializable root, and a throwing st
     activeWorkflow: wf,
     onStamp: (...args) => stamps.push(args),
   });
-  assert.equal((await workflow_new({ rid: "r1" })).created, true);
+  assert.equal((await workflow_new({ rid: "r1" })).created, "unknown", "#708 — unserializable root ⇒ unproven");
   assert.equal(stamps.length, 0);
   // A stamp that throws: creation still reports success (the guard simply keeps its say).
   const rootGraph = { _nodes: [], extra: {}, serialize: EMPTY_SERIALIZE };
@@ -217,7 +224,11 @@ test("#606 workflow_new does NOT stamp an unserializable root, and a throwing st
       throw new Error("root refuses the tag");
     },
   });
-  assert.equal((await workflow_new_throwing({ rid: "r2" })).created, true);
+  // #708 — the emptiness proof is evaluated BEFORE the stamp and in its own guard, so a
+  // stamp that throws is identity bookkeeping failing, never evidence the tab has content.
+  const thrown = await workflow_new_throwing({ rid: "r2" });
+  assert.equal(thrown.created, true);
+  assert.equal(thrown.empty, true);
 });
 
 // ---------------------------------------------------------------------------

--- a/browser_tests/unit/graph-binding.test.mjs
+++ b/browser_tests/unit/graph-binding.test.mjs
@@ -1821,6 +1821,7 @@ function buildProgrammaticSaveHarness({ onSave } = {}) {
     "workflowExistsOnDisk",
     "workflowDiskBytes",
     "reconcileSavedWorkflowCopy",
+    "describeLiveCanvasBinding",
     "describeSaveOutcome",
     "classifyOriginalOnDisk",
     "normalizePath",
@@ -1848,6 +1849,7 @@ function buildProgrammaticSaveHarness({ onSave } = {}) {
     async () => true,
     async () => null,
     async () => "unknown",
+    () => "unknown", // describeLiveCanvasBinding — no durable tag in this harness (#708)
     () => ({ saved_as: false }),
     () => "unknown",
     (p) => p,

--- a/browser_tests/unit/new-workflow-persistence.test.mjs
+++ b/browser_tests/unit/new-workflow-persistence.test.mjs
@@ -1,0 +1,798 @@
+// panel#708 — `panel_new_workflow` reports a blank tab, a reconnect lands, and the
+// tab persists holding the PREVIOUS workflow's graph.
+//
+// THE REPORT. A dirty 12-node / 4-group workflow was active. `panel_new_workflow`
+// returned `{created:true, active:"Unsaved Workflow", key:"tmp:…"}`. The connection
+// dropped before any load or graph edit. After reconnect the new tab had persisted as
+// "Untitled <timestamp>" and `panel_graph_outline` on it showed the previous 12 nodes
+// and 4 groups. No exception anywhere — the success result was simply false. An agent
+// told it has a blank canvas starts BUILDING, so this is silent corruption of the
+// user's work with no signal to either party until the damage is visible.
+//
+// THE TWO HALVES, both covered here.
+//
+// 1. THE CAUSE — a save that reads the GLOBAL canvas for a tab-local file.
+//    ComfyUI keeps ONE root graph and ONE `activeWorkflow` pointer, and they can
+//    disagree: a reconnect's tab-restore repaints the shared canvas by itself, so the
+//    canvas can hold W while the active tab is the brand-new N. `ChangeTracker`
+//    serializes `app.rootGraph` into whichever tracker is ACTIVE, so anything that asks
+//    "what is on the canvas?" in that window answers with W.
+//    The panel's Save-As copy trio did exactly that. `workflowStore.openWorkflow`
+//    (which is what `app.extensionManager.workflow` exposes — the STORE, not the
+//    service) moves the active pointer WITHOUT repainting the canvas; only
+//    `workflowService.openWorkflow` calls `loadGraphData`. The trio then called
+//    `prepareForSave()` on the freshly-activated COPY, and that capture overwrote the
+//    tab-local state `saveAs` had faithfully copied with whatever the shared canvas
+//    held. The fix moves the capture to the SOURCE tab, before the copy is taken, and
+//    only when the canvas is PROVEN to be that tab's canvas.
+//
+// 2. THE ACKNOWLEDGEMENT — `created:true` was never earned. `workflow_new` already
+//    computes a both-sides-proven-empty test (for #606's identity stamp). That is the
+//    only evidence it has that the tab it calls "a brand-new BLANK workflow" is blank,
+//    so it now decides the acknowledgement too: unproven ⇒ outcome-unknown, never
+//    `created:true`.
+//
+// WHAT THESE TESTS DELIBERATELY DO NOT DO. Nothing here blanks a tab. Fixing this by
+// emptying tabs that "should" be empty would be data loss in the other direction, so
+// the legitimate-content cases are asserted just as hard as the corruption ones.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  saveActiveWorkflow,
+  groundActiveWorkflow,
+  normalizeCanvasBinding,
+} from "../../web/js/lib/workflow-save.js";
+import {
+  graphRootProvenEmpty,
+  activeWorkflowProvenEmpty,
+  graphRootWorkflowUuidMatches,
+  graphRootWorkflowUuidMismatches,
+} from "../../web/js/lib/graph-binding.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+const SRC = readFileSync(PANEL_JS, "utf8").replace(/\r\n/g, "\n");
+
+const clone = (v) => JSON.parse(JSON.stringify(v));
+
+/** A serialized graph with `n` nodes and `g` groups — the shape ChangeTracker keeps
+ *  and LiteGraph's serialize() emits. */
+const graph = (n, g = 0, tag = null) => ({
+  last_node_id: n,
+  last_link_id: 0,
+  nodes: Array.from({ length: n }, (_, i) => ({ id: i + 1, type: `Node${i + 1}` })),
+  links: [],
+  groups: Array.from({ length: g }, (_, i) => ({ id: i + 1, title: `Group ${i + 1}` })),
+  config: {},
+  extra: tag ? { comfyui_mcp: { workflow_uuid: tag } } : {},
+  version: 0.4,
+});
+
+// The previous workflow the reporter had open: dirty, 12 nodes, 4 groups.
+const PREVIOUS_WORKFLOW_GRAPH = () => graph(12, 4, "uuid-previous");
+const BLANK_GRAPH = () => graph(0, 0, "uuid-new-tab");
+
+// ---------------------------------------------------------------------------
+// A frontend double that reproduces the exact store semantics this bug lives in.
+//
+// Faithful on the three points that matter, each verified against the installed
+// frontend source (workflowStore.ts / comfyWorkflow.ts / changeTracker.ts):
+//   • `saveAs(wf, path)` builds the copy from `wf.activeState` — TAB-LOCAL content.
+//   • `workflowStore.openWorkflow(copy)` loads the copy's own content and moves the
+//     active pointer, and DOES NOT touch the canvas. The canvas keeps holding whatever
+//     it held. This is the property the bug depends on.
+//   • `prepareForSave()` is `captureCanvasState()`: it serializes the ONE shared live
+//     canvas into whichever tracker is ACTIVE — never "this workflow's graph".
+//   • `save()` writes `JSON.stringify(activeState)`.
+// ---------------------------------------------------------------------------
+function makeFrontend({ liveCanvas, active, disk = [] }) {
+  const canvas = { state: clone(liveCanvas) };
+  const files = new Map(disk.map((d) => [d, "{}"]));
+  const records = [];
+
+  const attachTracker = (wf) => {
+    wf.changeTracker = {
+      get activeState() {
+        return wf._state;
+      },
+      // captureCanvasState(): serializes the shared live canvas into THIS tracker,
+      // but only while this workflow is the active one (isActiveTracker).
+      prepareForSave() {
+        if (svc.activeWorkflow !== wf) return;
+        wf._state = clone(canvas.state);
+      },
+    };
+    return wf;
+  };
+
+  const svc = {
+    activeWorkflow: null,
+    workflows: records,
+    openWorkflows: records,
+    canvas,
+    files,
+    calls: [],
+    getWorkflowByPath(path) {
+      return records.find((r) => r.path === path) ?? null;
+    },
+    saveAs(wf, path) {
+      svc.calls.push(["saveAs", wf.path, path]);
+      // Content comes from the SOURCE TAB's own state — never from the canvas.
+      const copy = {
+        path,
+        filename: path.split("/").pop(),
+        directory: path.split("/").slice(0, -1).join("/"),
+        initialMode: wf.initialMode,
+        isPersisted: false,
+        isTemporary: false,
+        _state: clone(wf.changeTracker?.activeState ?? null),
+        changeTracker: null, // UNLOADED until openWorkflow
+      };
+      records.push(copy);
+      return copy;
+    },
+    async openWorkflow(copy) {
+      svc.calls.push(["openWorkflow", copy.path]);
+      // workflowStore.openWorkflow: load the copy's own content, activate it.
+      // It does NOT repaint the canvas — canvas.state is untouched here on purpose.
+      attachTracker(copy);
+      svc.activeWorkflow = copy;
+    },
+    async saveWorkflow(wf) {
+      svc.calls.push(["saveWorkflow", wf.path]);
+      files.set(wf.path, JSON.stringify(wf.changeTracker?.activeState ?? null));
+    },
+  };
+
+  active.forEach((wf) => {
+    records.push(wf);
+    attachTracker(wf);
+  });
+  svc.activeWorkflow = records[0];
+  return svc;
+}
+
+/** A never-saved tab, as ComfyUI models one: a synthesized path in the workflows dir
+ *  with no file behind it. `state` is its OWN tracker state. */
+const tempTab = (state, { path = "workflows/Unsaved Workflow.json" } = {}) => ({
+  path,
+  filename: path.split("/").pop(),
+  directory: "workflows",
+  isPersisted: false,
+  isTemporary: true,
+  isModified: false,
+  _state: clone(state),
+});
+
+/** A persisted tab with a real file behind it. */
+const savedTab = (path, state) => ({
+  path,
+  filename: path.split("/").pop(),
+  directory: "workflows",
+  isPersisted: true,
+  isTemporary: false,
+  isModified: false,
+  _state: clone(state),
+});
+
+const saveOpts = (svc, extra = {}) => ({
+  autoWorkflowName: () => "Untitled 2026-08-06 12-00-00",
+  existsOnDisk: async (path) => svc.files.has(path),
+  ...extra,
+});
+
+const written = (svc, path) => JSON.parse(svc.files.get(path));
+
+const UNTITLED = "workflows/Untitled 2026-08-06 12-00-00.json";
+
+// ---------------------------------------------------------------------------
+// 1. THE CAUSE — the persisted file must be the TAB's graph, never the canvas's
+// ---------------------------------------------------------------------------
+
+test("#708 the reported repro: a new blank tab first-saved after a reconnect must NOT persist the previous workflow's graph", async () => {
+  // The exact reported state. `panel_new_workflow` created N and it is active; the
+  // reconnect's own tab-restore has left the PREVIOUS dirty 12-node / 4-group workflow
+  // on the shared canvas; N's own tracker still holds the blank graph it was born with.
+  // Nothing has tagged the root in a way this save can read (binding "unknown"), which
+  // is the weakest evidence position — and it must still not write the wrong graph.
+  const n = tempTab(BLANK_GRAPH());
+  const svc = makeFrontend({ liveCanvas: PREVIOUS_WORKFLOW_GRAPH(), active: [n] });
+
+  const saved = await saveActiveWorkflow(svc, undefined, saveOpts(svc, { canvasBinding: () => "unknown" }));
+
+  assert.equal(saved, "Untitled 2026-08-06 12-00-00");
+  const file = written(svc, UNTITLED);
+  assert.equal(file.nodes.length, 0, "the new tab's file must hold the NEW tab's graph — 0 nodes");
+  assert.equal(file.groups.length, 0, "…and none of the previous workflow's 4 groups");
+});
+
+test("#708 the corruption is a canvas READ, not a copy: the copy is never re-captured from the shared canvas", async () => {
+  // Structural lock on the mechanism. `openWorkflow` moves the active pointer without
+  // repainting, so ANY capture taken after it reads a canvas that was never asked to
+  // hold the copy's graph. Prove no such capture happens by making the canvas
+  // observably different from the tab and asserting the file matches the TAB.
+  const n = tempTab(graph(3));
+  const svc = makeFrontend({ liveCanvas: PREVIOUS_WORKFLOW_GRAPH(), active: [n] });
+  const captures = [];
+  const originalOpen = svc.openWorkflow;
+  svc.openWorkflow = async (copy) => {
+    await originalOpen(copy);
+    const trackerPrepare = copy.changeTracker.prepareForSave;
+    copy.changeTracker.prepareForSave = function (...args) {
+      captures.push(copy.path);
+      return trackerPrepare.apply(this, args);
+    };
+  };
+
+  await saveActiveWorkflow(svc, undefined, saveOpts(svc, { canvasBinding: () => "unknown" }));
+
+  assert.deepEqual(captures, [], "no canvas capture may be taken on the copy");
+  assert.equal(written(svc, UNTITLED).nodes.length, 3, "the file is the source tab's own graph");
+});
+
+test("#708 a PROVEN-foreign canvas refuses the first save outright — no file, no fabricated success", async () => {
+  // The other half of the same window. ChangeTracker captures on user input, so by the
+  // time the save runs the new tab's OWN state can ALREADY have been overwritten with
+  // the restored canvas. Then even a perfectly tab-local copy writes the wrong graph —
+  // the tab-local state IS the wrong graph. The only remaining signal is identity: the
+  // canvas positively carries a DIFFERENT workflow's tag. Refuse.
+  const n = tempTab(PREVIOUS_WORKFLOW_GRAPH()); // poisoned by the frontend's own capture
+  const svc = makeFrontend({ liveCanvas: PREVIOUS_WORKFLOW_GRAPH(), active: [n] });
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, undefined, saveOpts(svc, { canvasBinding: () => "foreign" })),
+    /#708/,
+    "a first save onto a provably foreign canvas must refuse, citing the issue",
+  );
+  assert.equal(svc.files.size, 0, "nothing may be written");
+  assert.deepEqual(svc.calls, [], "and nothing may be created in memory either");
+});
+
+test("#708 grounding is best-effort: a refused first save leaves the tab unsaved rather than throwing at the user", async () => {
+  const n = tempTab(PREVIOUS_WORKFLOW_GRAPH());
+  const svc = makeFrontend({ liveCanvas: PREVIOUS_WORKFLOW_GRAPH(), active: [n] });
+
+  const result = await groundActiveWorkflow(svc, saveOpts(svc, { canvasBinding: () => "foreign" }));
+
+  assert.equal(result, null, "grounding reports nothing saved");
+  assert.equal(svc.files.size, 0, "and writes nothing");
+  assert.equal(svc.activeWorkflow, n, "the user's tab is left exactly as it was");
+});
+
+test("#708 grounding on an UNKNOWN binding still saves — the tab's own graph, not the canvas's", async () => {
+  const n = tempTab(BLANK_GRAPH());
+  const svc = makeFrontend({ liveCanvas: PREVIOUS_WORKFLOW_GRAPH(), active: [n] });
+
+  const name = await groundActiveWorkflow(svc, saveOpts(svc, { canvasBinding: () => "unknown" }));
+
+  assert.equal(name, "Untitled 2026-08-06 12-00-00", "an unprovable binding must not block grounding");
+  assert.equal(written(svc, UNTITLED).nodes.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// 2. THE OTHER DIRECTION — a tab that legitimately holds content still saves it
+// ---------------------------------------------------------------------------
+
+test("#708 no blanking: a temp tab holding real work saves that work (unknown binding ⇒ its own tracker state)", async () => {
+  const n = tempTab(graph(7, 2));
+  const svc = makeFrontend({ liveCanvas: graph(7, 2), active: [n] });
+
+  await saveActiveWorkflow(svc, undefined, saveOpts(svc, { canvasBinding: () => "unknown" }));
+
+  const file = written(svc, UNTITLED);
+  assert.equal(file.nodes.length, 7, "the user's 7 nodes must reach disk");
+  assert.equal(file.groups.length, 2, "and their 2 groups");
+});
+
+test("#708 a BOUND canvas is still flushed into the save — freshness is preserved where it is provable", async () => {
+  // The capture was not removed, it was RELOCATED to the source tab. On a canvas proven
+  // to be this tab's, an edit the tracker has not captured yet must still be saved —
+  // otherwise the fix would silently drop the user's most recent work.
+  const n = tempTab(graph(3));
+  const svc = makeFrontend({ liveCanvas: graph(4), active: [n] }); // canvas is one node ahead
+
+  await saveActiveWorkflow(svc, undefined, saveOpts(svc, { canvasBinding: () => "bound" }));
+
+  assert.equal(written(svc, UNTITLED).nodes.length, 4, "the proven-bound canvas is flushed before the copy");
+});
+
+test("#708 the flush lands on the SOURCE tab, while it is still the active one", async () => {
+  // Ordering lock: `prepareForSave` on the source is a no-op once the copy has been
+  // activated (isActiveTracker), so a flush placed after `openWorkflow` would silently
+  // do nothing and the "bound" case would regress to stale-state saves.
+  const n = tempTab(graph(3));
+  const svc = makeFrontend({ liveCanvas: graph(9), active: [n] });
+  const order = [];
+  const wrappedPrepare = n.changeTracker.prepareForSave;
+  n.changeTracker.prepareForSave = function (...args) {
+    order.push(["flush-source", svc.activeWorkflow === n]);
+    return wrappedPrepare.apply(this, args);
+  };
+  const originalSaveAs = svc.saveAs;
+  svc.saveAs = (...args) => {
+    order.push(["saveAs"]);
+    return originalSaveAs(...args);
+  };
+
+  await saveActiveWorkflow(svc, undefined, saveOpts(svc, { canvasBinding: () => "bound" }));
+
+  assert.deepEqual(
+    order,
+    [["flush-source", true], ["saveAs"]],
+    "the source flush must run BEFORE saveAs, while the source is still active",
+  );
+  assert.equal(written(svc, UNTITLED).nodes.length, 9);
+});
+
+test("#708 a source flush that THROWS aborts the save — never a reported success that dropped the newest edit", async () => {
+  // codex gate. "bound" proves the canvas is this tab's; it does not prove `serialize()`
+  // works. main aborted the whole save when its capture threw (the capture sat inside the
+  // trio's try), so swallowing the throw here would turn that into a success that quietly
+  // saved a state we KNOW may be behind the canvas. Refuse, and write nothing.
+  const n = tempTab(graph(3));
+  const svc = makeFrontend({ liveCanvas: graph(9), active: [n] });
+  n.changeTracker.prepareForSave = () => {
+    throw new Error("serialize failed");
+  };
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, undefined, saveOpts(svc, { canvasBinding: () => "bound" })),
+    /serialize failed/,
+    "the underlying cause must be surfaced, not swallowed",
+  );
+  assert.equal(svc.files.size, 0, "nothing may be written");
+  assert.deepEqual(svc.calls, [], "and the copy must not even be created");
+});
+
+test("#708 an absent capture METHOD is not a failed capture: the tab's own state still saves", async () => {
+  // The boundary of the rule above, stated exactly (codex gate r2 was right that the
+  // earlier wording over-claimed). What a real older frontend presents is a LOADED
+  // tracker that simply has no `prepareForSave` — optional chaining then takes no
+  // capture at all, which is the same evidential position as an unproven binding, and
+  // must stay a normal save rather than a refusal.
+  const n = tempTab(graph(3));
+  const svc = makeFrontend({ liveCanvas: graph(9), active: [n] });
+  const state = n.changeTracker.activeState;
+  n.changeTracker = { activeState: state }; // loaded tracker, no capture method
+
+  await saveActiveWorkflow(svc, undefined, saveOpts(svc, { canvasBinding: () => "bound" }));
+
+  assert.equal(written(svc, UNTITLED).nodes.length, 3, "saved the tab's own state, unrefused");
+});
+
+test("#708 a fully UNLOADED tracker is not a failed capture either — the refusal is throw-only", async () => {
+  // The stronger form: no tracker object at all. `wf?.changeTracker?.prepareForSave?.()`
+  // must be a no-op, NOT a throw, so this path is left exactly where main had it (the
+  // trio's own `openWorkflow` is what loads a tracker; see resolveSaveAsCopy's preamble
+  // on why an unopened copy may never be persisted). This fix must not turn an unloaded
+  // tracker into a new refusal.
+  const n = tempTab(graph(3));
+  const svc = makeFrontend({ liveCanvas: graph(9), active: [n] });
+  n._savedState = n.changeTracker.activeState;
+  delete n.changeTracker;
+  // Feed saveAs the tab's content the way a real unloaded-then-loaded source would.
+  const originalSaveAs = svc.saveAs;
+  svc.saveAs = (wf, path) => {
+    wf.changeTracker = { activeState: wf._savedState };
+    return originalSaveAs(wf, path);
+  };
+
+  await saveActiveWorkflow(svc, undefined, saveOpts(svc, { canvasBinding: () => "bound" }));
+
+  assert.equal(written(svc, UNTITLED).nodes.length, 3, "no tracker ⇒ no capture ⇒ no refusal");
+});
+
+test("#708 the refusal message names WHAT was thrown — never '[object Object]', never a bare 'undefined'", async () => {
+  // The refusal above is the only new user-facing error, and it interpolates the thrown
+  // value. A plain object stringifies to "[object Object]" and one with a toJSON() that
+  // returns undefined defeats JSON.stringify too (codex gate r2), so both are pinned.
+  const cases = [
+    [{ code: 42 }, /"code":42/],
+    [{ toJSON: () => undefined }, /non-Error Object was thrown/],
+    [undefined, /non-Error value \(undefined\) was thrown/],
+    [null, /non-Error value \(null\) was thrown/],
+  ];
+  for (const [thrown, expected] of cases) {
+    const n = tempTab(graph(3));
+    const svc = makeFrontend({ liveCanvas: graph(9), active: [n] });
+    n.changeTracker.prepareForSave = () => {
+      throw thrown;
+    };
+    let message = "";
+    await saveActiveWorkflow(svc, undefined, saveOpts(svc, { canvasBinding: () => "bound" })).catch(
+      (err) => {
+        message = err.message;
+      },
+    );
+    assert.match(message, expected);
+    assert.ok(!message.includes("[object Object]"), `opaque cause in: ${message}`);
+  }
+});
+
+test("#708 a PERSISTED tab's IN-PLACE save is refused too — a foreign canvas must never overwrite a real file", async () => {
+  // codex gate r3. Every route persists `wf.activeState`, and ComfyUI fills that by
+  // serializing the SHARED canvas into whichever tab is active — including after every
+  // completed panel command. So a persisted tab whose state was captured from a
+  // reconnect-restored foreign canvas would have its REAL FILE overwritten with the
+  // other workflow's graph. That is strictly worse than the reported bug, so the guard
+  // is not scoped to first saves.
+  const w = savedTab("workflows/Foo.json", PREVIOUS_WORKFLOW_GRAPH()); // state already poisoned
+  const svc = makeFrontend({
+    liveCanvas: PREVIOUS_WORKFLOW_GRAPH(),
+    active: [w],
+    disk: ["workflows/Foo.json"],
+  });
+  const before = svc.files.get("workflows/Foo.json");
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, undefined, saveOpts(svc, { canvasBinding: () => "foreign" })),
+    /#708/,
+  );
+  assert.equal(svc.files.get("workflows/Foo.json"), before, "the user's file is untouched");
+  assert.deepEqual(svc.calls, [], "and nothing was attempted");
+});
+
+test("#708 a PERSISTED tab's Save-As COPY is refused on a foreign canvas as well", async () => {
+  // The copy routes read the same `activeState`, so a foreign canvas here produces a
+  // NEW file holding another workflow's graph — a fabricated success, even though the
+  // original survives.
+  const w = savedTab("workflows/Foo.json", PREVIOUS_WORKFLOW_GRAPH());
+  const svc = makeFrontend({
+    liveCanvas: PREVIOUS_WORKFLOW_GRAPH(),
+    active: [w],
+    disk: ["workflows/Foo.json"],
+  });
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, "Bar", saveOpts(svc, { canvasBinding: () => "foreign" })),
+    /#708/,
+  );
+  assert.ok(!svc.files.has("workflows/Bar.json"), "no copy is created");
+  assert.ok(svc.files.has("workflows/Foo.json"), "and the original is untouched");
+});
+
+/** An oracle that reports "bound" once and "foreign" from then on — the reconnect
+ *  landing AFTER the entry check but before anything is written. */
+const foreignAfterFirstLook = () => {
+  let looks = 0;
+  return () => (looks++ === 0 ? "bound" : "foreign");
+};
+
+test("#708 a canvas that turns foreign AFTER the entry check still refuses (copy route)", async () => {
+  // codex gate r4. The entry-time verdict is stale by the time anything is written:
+  // `assertExpect` protects the workflow OBJECT, not the canvas, and a reconnect can
+  // repaint the shared canvas during the save's awaited disk probes while this tab stays
+  // active. Sampling once would wave through the exact write the guard exists to stop.
+  const n = tempTab(BLANK_GRAPH());
+  const svc = makeFrontend({ liveCanvas: PREVIOUS_WORKFLOW_GRAPH(), active: [n] });
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, undefined, saveOpts(svc, { canvasBinding: foreignAfterFirstLook() })),
+    /#708/,
+  );
+  assert.equal(svc.files.size, 0, "nothing written");
+  assert.deepEqual(svc.calls, [], "and no copy created — the re-assert precedes saveAs");
+});
+
+test("#708 a canvas that turns foreign AFTER the entry check still refuses (in-place route)", async () => {
+  // The same window on the route that overwrites a REAL file.
+  const w = savedTab("workflows/Foo.json", graph(5));
+  const svc = makeFrontend({ liveCanvas: graph(5), active: [w], disk: ["workflows/Foo.json"] });
+  const before = svc.files.get("workflows/Foo.json");
+
+  await assert.rejects(
+    () => saveActiveWorkflow(svc, undefined, saveOpts(svc, { canvasBinding: foreignAfterFirstLook() })),
+    /#708/,
+  );
+  assert.equal(svc.files.get("workflows/Foo.json"), before, "the user's file is untouched");
+  assert.deepEqual(svc.calls, [], "and no write was attempted");
+});
+
+test("#708 availability: an UNKNOWN binding never refuses any route — a persisted Save-As copy still works", async () => {
+  // The refusal bar is a POSITIVE identity conflict. An untagged root, an older
+  // frontend, or no oracle at all must leave every save exactly as it was before this
+  // fix — the whole point of the tri-state.
+  const w = savedTab("workflows/Foo.json", graph(5));
+  const svc = makeFrontend({
+    liveCanvas: PREVIOUS_WORKFLOW_GRAPH(),
+    active: [w],
+    disk: ["workflows/Foo.json"],
+  });
+
+  const saved = await saveActiveWorkflow(svc, "Bar", saveOpts(svc)); // no canvasBinding at all
+
+  assert.equal(saved, "Bar");
+  assert.ok(svc.files.has("workflows/Foo.json"), "the original file survives (a copy, never a move)");
+  assert.equal(written(svc, "workflows/Bar.json").nodes.length, 5, "the copy holds the SOURCE tab's graph");
+});
+
+// ---------------------------------------------------------------------------
+// 3. The oracle contract — absence of evidence is never evidence
+// ---------------------------------------------------------------------------
+
+test("#708 normalizeCanvasBinding: only the two positive verdicts survive; everything else is unknown", () => {
+  assert.equal(normalizeCanvasBinding(() => "bound"), "bound");
+  assert.equal(normalizeCanvasBinding(() => "foreign"), "foreign");
+  assert.equal(normalizeCanvasBinding(undefined), "unknown", "no oracle proves nothing");
+  assert.equal(normalizeCanvasBinding(() => "yes"), "unknown", "an unrecognized verdict proves nothing");
+  assert.equal(normalizeCanvasBinding(() => true), "unknown", "a truthy non-verdict must not read as bound");
+  assert.equal(normalizeCanvasBinding(() => undefined), "unknown");
+  assert.equal(
+    normalizeCanvasBinding(() => {
+      throw new Error("root unreadable");
+    }),
+    "unknown",
+    "a throwing oracle proves nothing and must never break a save",
+  );
+});
+
+test("#708 describeLiveCanvasBinding: the panel's real oracle answers from IDENTITY, and only positively", () => {
+  // The one piece that wires the save's tri-state to the live canvas. It must resolve the
+  // workflow's identity the way the graph fences do (the live object's own uuid first,
+  // `workflowStableUuid` only as the fallback — never `app.graph.extra`, which is the
+  // stale value being detected), it must exempt a drifted tag the workflow's own lineage
+  // claims (#545/#557), and it must answer "unknown" for every absence.
+  const src = balancedFrom(SRC, "function describeLiveCanvasBinding(wf)");
+  const build = ({ rootGraph, objectUuid = null, stableUuid = "uuid-tab", owns = () => false }) =>
+    new Function(
+      "app",
+      "workflowObjectUuid",
+      "workflowStableUuid",
+      "graphRootWorkflowUuidMatches",
+      "graphRootWorkflowUuidMismatches",
+      "workflowOwnsRootUuidTag",
+      "WORKFLOW_META_NAMESPACE",
+      "WORKFLOW_UUID_FIELD",
+      `${src}
+return describeLiveCanvasBinding;`,
+    )(
+      { graph: rootGraph },
+      () => objectUuid,
+      () => stableUuid,
+      graphRootWorkflowUuidMatches,
+      graphRootWorkflowUuidMismatches,
+      owns,
+      "comfyui_mcp",
+      "workflow_uuid",
+    );
+  const tagged = (uuid) => ({ _nodes: [], extra: { comfyui_mcp: { workflow_uuid: uuid } } });
+  const wf = {};
+
+  assert.equal(build({ rootGraph: tagged("uuid-tab") })(wf), "bound");
+  assert.equal(build({ rootGraph: tagged("uuid-previous") })(wf), "foreign");
+  assert.equal(build({ rootGraph: { _nodes: [], extra: {} } })(wf), "unknown", "an untagged root proves nothing");
+  assert.equal(build({ rootGraph: null })(wf), "unknown", "no canvas ⇒ nothing to say");
+  assert.equal(build({ rootGraph: tagged("uuid-tab") })(null), "unknown", "no workflow ⇒ nothing to say");
+  assert.equal(
+    build({ rootGraph: tagged("uuid-tab"), stableUuid: null })(wf),
+    "unknown",
+    "an unresolvable identity is never a match",
+  );
+  // The live object's own uuid WINS over the stable fallback: a root carrying the
+  // fallback value while the object is established as something else is FOREIGN.
+  assert.equal(
+    build({ rootGraph: tagged("uuid-tab"), objectUuid: "uuid-established" })(wf),
+    "foreign",
+    "the established object identity decides, not the fallback",
+  );
+  // #545/#557 — a conflicting tag the workflow's OWN lineage claims is its own drifted
+  // stamp on its own canvas. That must stay inconclusive: hard-refusing it would block
+  // saves after a save-swap or reconnect stamp drift, which the graph fence itself
+  // treats as a rebind rather than a conflict.
+  const claimed = [];
+  assert.equal(
+    build({
+      rootGraph: tagged("uuid-drifted"),
+      owns: (w, rootUuid) => {
+        claimed.push([w, rootUuid]);
+        return true;
+      },
+    })(wf),
+    "unknown",
+    "a self-claimed drifted stamp is not a foreign canvas",
+  );
+  assert.deepEqual(claimed, [[wf, "uuid-drifted"]], "the claim is asked about THIS workflow and THAT tag");
+});
+
+test("#708 an oracle that throws neither refuses the save nor licenses the canvas flush", async () => {
+  const n = tempTab(graph(3));
+  const svc = makeFrontend({ liveCanvas: PREVIOUS_WORKFLOW_GRAPH(), active: [n] });
+
+  await saveActiveWorkflow(
+    svc,
+    undefined,
+    saveOpts(svc, {
+      canvasBinding: () => {
+        throw new Error("root unreadable");
+      },
+    }),
+  );
+
+  assert.equal(written(svc, UNTITLED).nodes.length, 3, "falls back to the tab's own state");
+});
+
+// ---------------------------------------------------------------------------
+// 4. THE ACKNOWLEDGEMENT — workflow_new, driven from the real panel source
+// ---------------------------------------------------------------------------
+
+/** Balanced extraction starting at a marker's first "{". Mirrors binding-recovery's
+ *  helper (the extracted regions contain no template braces outside code). */
+function balancedFrom(src, marker, openAt = null) {
+  const start = src.indexOf(marker);
+  assert.notEqual(start, -1, `missing marker: ${marker}`);
+  const open = openAt ?? src.indexOf("{", start + marker.length);
+  let depth = 0;
+  for (let i = open; i < src.length; i += 1) {
+    const ch = src[i];
+    if (ch === "/" && src[i + 1] === "/") {
+      i = src.indexOf("\n", i + 2);
+      if (i < 0) break;
+      continue;
+    }
+    if (ch === "/" && src[i + 1] === "*") {
+      i = src.indexOf("*/", i + 2);
+      if (i < 0) break;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      const quote = ch;
+      for (i += 1; i < src.length; i += 1) {
+        if (src[i] === "\\") {
+          i += 1;
+          continue;
+        }
+        if (src[i] === quote) break;
+      }
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    if (ch === "}" && --depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error(`unterminated block: ${marker}`);
+}
+
+/** The REAL `workflow_new` body, with its globals injected. */
+function buildWorkflowNew({ rootGraph, activeWorkflow }) {
+  const sigStart = SRC.indexOf("async workflow_new({");
+  assert.notEqual(sigStart, -1, "workflow_new not found");
+  const bodyBrace = SRC.indexOf(") {", sigStart) + 1;
+  const methodSource = balancedFrom(SRC, "async workflow_new({", bodyBrace).replace(
+    /^async workflow_new\(/,
+    "async function workflow_new(",
+  );
+  return new Function(
+    "app",
+    "activeWorkflowRef",
+    "workflowTabId",
+    "workflowStableUuid",
+    "noteOpenAttempt",
+    "coerceMessageText",
+    "getWorkflowTitle",
+    "graphRootProvenEmpty",
+    "activeWorkflowProvenEmpty",
+    "stampGraphRootWorkflowUuid",
+    "backendReconnectEpoch",
+    "activeWorkflowResyncEpoch",
+    `${methodSource}\nreturn workflow_new;`,
+  )(
+    { graph: rootGraph, extensionManager: { command: { execute: async () => {} } } },
+    () => activeWorkflow,
+    () => "tmp:new-tab",
+    () => "uuid-new-tab",
+    () => ({ seq: 7 }),
+    (e) => String(e),
+    () => "Unsaved Workflow",
+    graphRootProvenEmpty,
+    activeWorkflowProvenEmpty,
+    () => {},
+    1,
+    0,
+  );
+}
+
+/** A live root LiteGraph would produce for a given serialized state. */
+const liveRoot = (state) => ({
+  _nodes: state.nodes,
+  extra: state.extra,
+  serialize: () => clone(state),
+});
+
+test("#708 ack: a PROVEN-empty new tab reports created:true — the honest success is unchanged", async () => {
+  const workflow_new = buildWorkflowNew({
+    rootGraph: liveRoot(BLANK_GRAPH()),
+    activeWorkflow: { isPersisted: false, isModified: false, changeTracker: { activeState: BLANK_GRAPH() } },
+  });
+
+  const out = await workflow_new({ rid: "r1" });
+
+  assert.equal(out.created, true);
+  assert.equal(out.empty, true);
+  assert.equal(out.routing_key, "tmp:new-tab");
+  assert.equal(out.note, undefined, "a proven blank tab needs no caveat");
+});
+
+test("#708 ack: the reported reconnect shape reports outcome-UNKNOWN, never created:true", async () => {
+  // The canvas still holds the previous dirty 12-node / 4-group workflow while the new
+  // tab is active. `created:true` here is the sentence that sent the agent building
+  // onto someone else's work.
+  const workflow_new = buildWorkflowNew({
+    rootGraph: liveRoot(PREVIOUS_WORKFLOW_GRAPH()),
+    activeWorkflow: { isPersisted: false, isModified: false, changeTracker: { activeState: BLANK_GRAPH() } },
+  });
+
+  const out = await workflow_new({ rid: "r1" });
+
+  assert.notEqual(out.created, true, "an unproven tab must NEVER be acknowledged as created:true");
+  assert.equal(out.created, "unknown");
+  assert.equal(out.empty, "unknown");
+  assert.equal(out.routing_key, "tmp:new-tab", "the tab is real and addressable — only 'blank' is unproven");
+  assert.equal(out.open_seq, 7, "the open receipt is still recorded");
+  assert.match(out.note, /panel_graph_outline/, "the note must tell the agent to VERIFY before building");
+  assert.match(out.note, /not idempotent/, "…and that a retry leaves a SECOND blank tab");
+});
+
+test("#708 ack: every unprovable side reports unknown — an empty ROOT is not proof about the TAB", async () => {
+  const unprovable = [
+    // The tab's own state cannot be read at all.
+    { root: BLANK_GRAPH(), wf: { isPersisted: false, isModified: false } },
+    { root: BLANK_GRAPH(), wf: { isPersisted: false, isModified: false, changeTracker: {} } },
+    // A DIRTY tracker can lag the real canvas, so it can never prove emptiness (#545).
+    {
+      root: BLANK_GRAPH(),
+      wf: { isPersisted: false, isModified: true, changeTracker: { activeState: BLANK_GRAPH() } },
+    },
+    // The tab's own state carries content.
+    {
+      root: BLANK_GRAPH(),
+      wf: { isPersisted: false, isModified: false, changeTracker: { activeState: graph(2) } },
+    },
+    // Zero nodes but real GROUPS on the canvas — "no nodes" is not "no content".
+    {
+      root: graph(0, 4),
+      wf: { isPersisted: false, isModified: false, changeTracker: { activeState: BLANK_GRAPH() } },
+    },
+  ];
+  for (const { root, wf } of unprovable) {
+    const workflow_new = buildWorkflowNew({ rootGraph: liveRoot(root), activeWorkflow: wf });
+    const out = await workflow_new({ rid: "r1" });
+    assert.equal(out.created, "unknown", `expected unknown for ${JSON.stringify(wf)}`);
+    assert.ok(out.note, "an unknown outcome must carry its explanation");
+  }
+});
+
+test("#708 ack: an unreadable root (no serializer) is unproven, not assumed empty", async () => {
+  const workflow_new = buildWorkflowNew({
+    rootGraph: { _nodes: [], extra: {} }, // no serialize() ⇒ non-node content unprovable
+    activeWorkflow: { isPersisted: false, isModified: false, changeTracker: { activeState: BLANK_GRAPH() } },
+  });
+
+  assert.equal((await workflow_new({ rid: "r1" })).created, "unknown");
+});
+
+// ---------------------------------------------------------------------------
+// 5. The two halves together — the reported sequence end to end
+// ---------------------------------------------------------------------------
+
+test("#708 end to end: create during the reconnect window, then ground — unknown ack AND no foreign graph on disk", async () => {
+  // Step 1: `panel_new_workflow` while the shared canvas still holds the previous
+  // workflow. The agent is told the outcome is unknown, not that it has a blank canvas.
+  const workflow_new = buildWorkflowNew({
+    rootGraph: liveRoot(PREVIOUS_WORKFLOW_GRAPH()),
+    activeWorkflow: { isPersisted: false, isModified: false, changeTracker: { activeState: BLANK_GRAPH() } },
+  });
+  const ack = await workflow_new({ rid: "r1" });
+  assert.equal(ack.created, "unknown");
+
+  // Step 2: the next turn grounds the new tab. Whatever it writes must be the tab's
+  // graph. With the canvas provably foreign it writes nothing at all.
+  const n = tempTab(BLANK_GRAPH());
+  const svc = makeFrontend({ liveCanvas: PREVIOUS_WORKFLOW_GRAPH(), active: [n] });
+  assert.equal(await groundActiveWorkflow(svc, saveOpts(svc, { canvasBinding: () => "foreign" })), null);
+  assert.equal(svc.files.size, 0, "no 'Untitled …' file holding the previous 12 nodes");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -3624,6 +3624,9 @@ async function programmaticSave(name) {
     // — including a BOM a decoded-string compare would miss, codex P0).
     readDiskBytes: workflowDiskBytes,
     reconcileSavedCopy: reconcileSavedWorkflowCopy,
+    // #708 — the LIVE-CANVAS identity oracle. It licenses the pre-copy canvas flush
+    // and refuses a first save whose canvas provably belongs to another workflow.
+    canvasBinding: describeLiveCanvasBinding,
     details,
     expect: expectWf, // #330: refuse if the user switched tabs during our pre-save HEAD
   });
@@ -3838,6 +3841,55 @@ async function workflowDiskBytes(rawPath) {
   }
 }
 
+/** #708 — does the LIVE root canvas positively belong to `wf`?
+ *
+ *  ComfyUI keeps ONE root graph and ONE activeWorkflow pointer, and a reconnect's
+ *  own tab-restore can leave them disagreeing: the canvas holds workflow W while the
+ *  active tab is a different, brand-new N. ChangeTracker then serializes that canvas
+ *  into N's state, and a save that reads "the current canvas" writes W's graph into
+ *  N's brand-new file and reports success (the reported symptom: a `panel_new_workflow`
+ *  tab persisted as "Untitled …" holding the previous workflow's 12 nodes / 4 groups).
+ *
+ *  Answers with the SAME durable-identity pair the graph fences use — never a content
+ *  comparison, which cannot separate two tabs holding one workflow from a bound canvas
+ *  whose widgets drifted (#696/#701/#702/#663). The identity is resolved exactly as
+ *  assertGraphBoundToActiveWorkflow resolves it: the live object's own uuid first, and
+ *  `workflowStableUuid` (root-blind for an unseen object) only as the fallback — so the
+ *  stale `app.graph.extra` this is trying to DETECT can never supply the answer.
+ *
+ *  A bare tag MISMATCH is deliberately NOT enough to say "foreign". #545/#557 record
+ *  that a save-swap or a reconnect can drift the root stamp away from the active
+ *  workflow's currently-resolved identity while the root is still that workflow's OWN
+ *  canvas, which is why assertGraphBoundToActiveWorkflow does not hard-refuse on the
+ *  mismatch either — it asks whether the ACTIVE workflow ITSELF claims the tag (its own
+ *  serialized state carries it, or the owner registry ties it to that object) and
+ *  rebinds when it does. This borrows the guard's EVIDENCE RULE, not its remedy: it
+ *  performs no rebind, so a self-claimed drifted stamp stays on the root until a later
+ *  graph command heals it. That is the right split — a save has no business re-stamping
+ *  a canvas, and a tag the tab's own lineage claims is not a wrong-canvas condition in
+ *  the first place. Only a tag the workflow does NOT claim — a FOREIGN tab's, or a
+ *  closed tab's stranded canvas — is "foreign", which is the #349/#708 case.
+ *
+ *  "unknown" on every inconclusive read (no root/workflow, no resolvable identity, an
+ *  untagged root, or a throw): absence of a tag is not evidence, and every consumer
+ *  treats unknown as "change nothing". */
+function describeLiveCanvasBinding(wf) {
+  try {
+    const rootGraph = app?.graph;
+    if (!rootGraph || !wf || typeof wf !== "object") return "unknown";
+    const activeWorkflowUuid = workflowObjectUuid(wf) || workflowStableUuid(wf);
+    if (!activeWorkflowUuid) return "unknown";
+    if (graphRootWorkflowUuidMatches({ rootGraph, activeWorkflowUuid })) return "bound";
+    if (!graphRootWorkflowUuidMismatches({ rootGraph, activeWorkflowUuid })) return "unknown";
+    // A conflicting tag the workflow's own lineage CLAIMS is its own drifted stamp
+    // (#545/#557), not another tab's canvas — inconclusive, never a refusal.
+    const rootUuid = rootGraph?.extra?.[WORKFLOW_META_NAMESPACE]?.[WORKFLOW_UUID_FIELD];
+    return workflowOwnsRootUuidTag(wf, rootUuid) ? "unknown" : "foreign";
+  } catch {
+    return "unknown";
+  }
+}
+
 /** If the open workflow was never saved to disk, save it (no dialog) so the
  *  agent works from a grounded file. Best-effort. Returns the saved name or null. */
 async function groundUnsavedWorkflow() {
@@ -3851,6 +3903,9 @@ async function groundUnsavedWorkflow() {
       existsOnDisk: workflowExistsOnDisk,
       autoWorkflowName,
       reconcileSavedCopy: reconcileSavedWorkflowCopy,
+      // #708 — grounding is the save that CREATES the "Untitled …" file, so it is the
+      // one that must not write a canvas belonging to a different workflow into it.
+      canvasBinding: describeLiveCanvasBinding,
     });
   } catch {
     return null; // best-effort — never block the chat on a save hiccup
@@ -10741,13 +10796,26 @@ const GRAPH_TOOL_EXECUTORS = {
     //
     // Best-effort: a stamp failure leaves the pre-existing guard behavior, never
     // a broken creation.
+    //
+    // #708 — ONE proof, TWO consequences. The same both-sides-proven-empty test that
+    // licenses the stamp is also the only evidence this command has that the tab it is
+    // about to call "a brand-new BLANK workflow" is actually blank, so it decides the
+    // ACKNOWLEDGEMENT too (below) rather than being computed twice and drifting apart.
+    // Evaluated BEFORE the stamp and in its own try/catch: a stamp that throws is
+    // identity bookkeeping failing, not evidence that the tab has content.
+    let provenEmpty = false;
     try {
       const rootGraph = app?.graph;
-      if (rootGraph && graphRootProvenEmpty(rootGraph) && activeWorkflowProvenEmpty(wf)) {
-        stampGraphRootWorkflowUuid(rootGraph, newWorkflowUuid, wf);
-      }
+      provenEmpty = !!rootGraph && graphRootProvenEmpty(rootGraph) && activeWorkflowProvenEmpty(wf);
     } catch {
-      // Identity bookkeeping must never break workflow creation.
+      provenEmpty = false; // an unreadable proof is not a proof
+    }
+    if (provenEmpty) {
+      try {
+        stampGraphRootWorkflowUuid(app?.graph, newWorkflowUuid, wf);
+      } catch {
+        // Identity bookkeeping must never break workflow creation.
+      }
     }
     // #433: an explicit new-tab authoritatively re-points `active` — record it
     // against the epoch we STARTED on, but only if no reconnect intervened during
@@ -10768,7 +10836,37 @@ const GRAPH_TOOL_EXECUTORS = {
     });
     // `key`/`routing_key` are the unique handle the agent should pass to
     // panel_set_workflow_target so its session pins to this exact graph.
-    return { created: true, active: getWorkflowTitle(), key, routing_key: key, open_seq: receipt.seq };
+    const identity = { active: getWorkflowTitle(), key, routing_key: key, open_seq: receipt.seq };
+    // #708 — DO NOT CLAIM "blank" WITHOUT PROVING IT. The tab and its routing identity
+    // are real either way (the receipt above records that), but `created:true` on a tool
+    // whose whole contract is "a brand-new BLANK workflow" is read as "you have an empty
+    // canvas" — and the agent's next move is to BUILD on it. The reported failure is
+    // exactly that: the acknowledgement said blank, a reconnect's tab-restore left the
+    // previous dirty workflow's graph in the new tab, and the agent went on adding nodes
+    // to a copy of someone else's 12-node work with nothing to warn it.
+    //
+    // So when the frontend cannot PROVE zero content on both sides, report the outcome as
+    // UNKNOWN rather than success. "I could not confirm this tab is empty" costs one
+    // panel_graph_outline; "created:true" costs the user's workflow. This is the same
+    // never-fabricate-a-success rule the open receipts (#402) already follow, and the
+    // note carries the two facts an agent needs to act correctly: VERIFY before building,
+    // and do NOT retry (workflow_new is not idempotent — a retry adds a second blank tab).
+    if (!provenEmpty) {
+      return {
+        created: "unknown",
+        empty: "unknown",
+        ...identity,
+        note:
+          "workflow_new: the new tab was created and is ACTIVE, but the frontend could not prove " +
+          "it holds zero nodes — so this is NOT a confirmed blank canvas. Call panel_graph_outline " +
+          "on this tab BEFORE adding anything; if it already has nodes they belong to another " +
+          "workflow (a reconnect/tab-restore can leave the previously active graph on the shared " +
+          "canvas — issue #708), so open the workflow you actually want instead of building here. " +
+          "Do NOT call panel_new_workflow again — it is not idempotent, and a second call leaves a " +
+          "SECOND blank tab behind.",
+      };
+    }
+    return { created: true, empty: true, ...identity };
   },
 
   async workflow_open({ path, rid }) {

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -44,6 +44,42 @@ function targetPath(wf, base) {
   return normalizePath(`${directoryOf(wf)}${base}${workflowExt(wf)}`);
 }
 
+/** A readable, TOTAL description of a thrown value for an error message. Deliberately
+ *  local and defensive: `String(err)` on a plain object yields "[object Object]", and
+ *  `JSON.stringify` returns UNDEFINED for an object whose `toJSON()` does — so neither is
+ *  trusted on its own (codex gate r2). Every fall-through names WHAT was thrown instead
+ *  of printing an opaque token, and a throwing `message`/`toJSON`/`constructor` getter is
+ *  contained by the outer catch so the error path itself can never fail. */
+function describeThrown(err) {
+  try {
+    if (err instanceof Error && err.message) return err.message;
+    if (typeof err === "string") return err || "a non-Error empty string was thrown";
+    if (err == null) return `a non-Error value (${String(err)}) was thrown`;
+    if (typeof err === "object") {
+      const message = err.message;
+      if (typeof message === "string" && message) return message;
+      let json = null;
+      try {
+        json = JSON.stringify(err);
+      } catch {
+        json = null; // circular / throwing toJSON
+      }
+      if (typeof json === "string" && json && json !== "{}") return json;
+      let name = null;
+      try {
+        name = err.constructor?.name;
+      } catch {
+        name = null;
+      }
+      return `a non-Error ${typeof name === "string" && name ? name : "object"} was thrown`;
+    }
+    const text = String(err);
+    return text || `a non-Error ${typeof err} was thrown`;
+  } catch {
+    return "unknown error";
+  }
+}
+
 /** True when `name` is a placeholder rather than a name the user/agent chose.
  *  ComfyUI's brand-new temporary tabs are pathed "Unsaved Workflow.json" (and
  *  "Unsaved Workflow (2).json", …); the panel's own grounding auto-name is
@@ -184,6 +220,44 @@ export async function groundingIsSafe(wf, existsOnDisk) {
   return exists === false; // ONLY a proven absence (404) authorizes the save
 }
 
+/** #708 — normalize the caller's LIVE-CANVAS identity oracle to a tri-state.
+ *
+ *  WHY a save needs one at all. ComfyUI keeps ONE root graph object (`app.rootGraph`)
+ *  and ONE `activeWorkflow` pointer, and they can disagree: after a reconnect the
+ *  frontend restores a tab's graph onto that shared canvas by itself, so a canvas
+ *  holding workflow W can sit under an `activeWorkflow` that is a different, brand-new
+ *  tab N. Everything ChangeTracker captures in that window (`captureCanvasState()`
+ *  serializes `app.rootGraph`, unconditionally) is W's content recorded as N's state.
+ *  A save that then reads "the current canvas" writes W's graph into N's file and
+ *  reports success — panel#708, where a `panel_new_workflow` tab came back after a
+ *  reconnect holding the previous workflow's 12 nodes and 4 groups.
+ *
+ *  The oracle answers ONE question: does the live root canvas positively belong to
+ *  the workflow we are about to persist?
+ *    - `"bound"`   — it positively carries THIS workflow's identity.
+ *    - `"foreign"` — it positively carries a DIFFERENT workflow's identity.
+ *    - `"unknown"` — no durable identity on one side or the other; PROVES NOTHING.
+ *
+ *  Identity, not content. A content comparison cannot answer this: two tabs holding
+ *  the same workflow are content-identical, and a correctly-bound canvas legitimately
+ *  drifts from its tracker between captures (#696/#701/#702/#663). Only the durable
+ *  per-workflow tag can, which is why the panel wires this to the SAME
+ *  graphRootWorkflowUuidMatches / graphRootWorkflowUuidMismatches pair the graph
+ *  fences use, and why "unknown" is the answer whenever a tag is absent.
+ *
+ *  Total and non-throwing: no oracle, a throw, or any unrecognized return ⇒
+ *  `"unknown"`, which never refuses a save and never licenses a canvas capture. */
+export function normalizeCanvasBinding(canvasBinding, wf) {
+  if (typeof canvasBinding !== "function") return "unknown";
+  let verdict;
+  try {
+    verdict = canvasBinding(wf);
+  } catch {
+    return "unknown";
+  }
+  return verdict === "bound" || verdict === "foreign" ? verdict : "unknown";
+}
+
 // #330 single-flight: SERIALIZE grounding per workflow SERVICE, not per workflow
 // instance. The atomic copy-trio activates a FRESH temporary copy (openWorkflow)
 // BEFORE its write commits, so the active-workflow identity changes mid-save — a
@@ -196,7 +270,7 @@ const _groundingChain = new Map(); // svc -> tail Promise<void>
  *  EXACT SAME workflow it probed (`expect: wf` → saveActiveWorkflow refuses if the
  *  active workflow changed during the async probe, so we never authorize on tab A
  *  and write to tab B). Best-effort: any refusal/hiccup ⇒ null (leave ungrounded). */
-async function groundOnce(svc, { existsOnDisk, autoWorkflowName, reconcileSavedCopy } = {}) {
+async function groundOnce(svc, { existsOnDisk, autoWorkflowName, reconcileSavedCopy, canvasBinding } = {}) {
   try {
     const wf = svc?.activeWorkflow;
     if (!needsGrounding(wf)) return null;
@@ -205,6 +279,7 @@ async function groundOnce(svc, { existsOnDisk, autoWorkflowName, reconcileSavedC
       autoWorkflowName,
       existsOnDisk,
       reconcileSavedCopy,
+      canvasBinding,
       expect: wf,
     });
   } catch {
@@ -265,11 +340,19 @@ export async function groundActiveWorkflow(svc, opts = {}) {
  *  a real file (must never be moved). This STRENGTHENS the #226 invariant — it
  *  is only ever consulted after the in-memory oracles are inconclusive, and its
  *  absence / failure leaves the classification "unknown" → refuse (fail safe).
+ *
+ *  `canvasBinding(wf)` is an OPTIONAL identity oracle over the LIVE root canvas —
+ *  `"bound"` (the canvas positively carries THIS workflow's identity), `"foreign"`
+ *  (it positively carries a DIFFERENT workflow's), or `"unknown"`. See
+ *  `normalizeCanvasBinding` and the two places it is consulted (#708): the WRONG-CANVAS
+ *  guard at the top of this function (which refuses EVERY route on a proven-foreign
+ *  canvas) and the source capture inside the copy trio.
+ *  Absent / throwing / any other value ⇒ `"unknown"`, which never refuses.
  */
 export async function saveActiveWorkflow(
   svc,
   name,
-  { autoWorkflowName, existsOnDisk, readDiskBytes, reconcileSavedCopy, expect, details } = {},
+  { autoWorkflowName, existsOnDisk, readDiskBytes, reconcileSavedCopy, canvasBinding, expect, details } = {},
 ) {
   const wf = svc?.activeWorkflow;
   if (!wf) throw new Error("no active workflow to save");
@@ -289,6 +372,61 @@ export async function saveActiveWorkflow(
     }
   };
   assertExpect();
+
+  // #708 WRONG-CANVAS GUARD — asserted on entry (before ANY classification, probe or
+  // write, so a refusal mutates nothing) and RE-ASSERTED immediately before every write.
+  //
+  // EVERY save route here ultimately persists `wf.activeState`: the in-place branch
+  // writes it through `saveWorkflow`, and both copy routes read it in `saveAs`. That
+  // state is not written by this module — ComfyUI's ChangeTracker fills it by
+  // serializing the ONE shared `app.rootGraph` into whichever workflow is ACTIVE, on
+  // user input, on `graphChanged`, and (in this panel) after every completed bridge
+  // command. So whenever the live canvas is a DIFFERENT workflow's — a reconnect
+  // restored another tab's graph onto the shared canvas while this tab stayed active —
+  // `wf.activeState` may already BE that other workflow's graph, and every route writes
+  // it out reporting success. Concretely (codex gate r3):
+  //   - never-persisted source ⇒ a brand-new "Untitled …" file holding another
+  //     workflow's graph, which is the reported #708;
+  //   - EXTERNAL source ⇒ a copy in the workflows dir holding another workflow's graph;
+  //   - PERSISTED source, in-place ⇒ the user's REAL file overwritten with another
+  //     workflow's graph. That last one is strictly worse than the reported bug, and
+  //     scoping the guard to first-saves would have left it standing.
+  //
+  // RE-ASSERTION IS REQUIRED, exactly like #330's `assertExpect` (codex gate r4).
+  // `assertExpect` protects the WORKFLOW OBJECT, not the canvas: a reconnect landing
+  // during this function's awaited disk probes can repaint the shared canvas with
+  // another tab's graph while `wf` stays active, and an entry-only sample would then
+  // wave through the very write it exists to stop. So every write site re-asserts
+  // synchronously, with no await between the assert and the write:
+  //   - both COPY routes assert inside the trio adapter, immediately before `saveAs`.
+  //     That is a tight bound rather than a best effort: `saveAs` CLONES the state
+  //     there and the copy is persisted from that clone, so a canvas drift afterwards
+  //     cannot change the bytes that land.
+  //   - the IN-PLACE route asserts immediately before `saveInPlace`. Its residual is
+  //     the same one the module already accepts elsewhere: ComfyUI's `save()` awaits a
+  //     dynamic import before reading `activeState`, so a reconnect restore landing in
+  //     that sub-millisecond microtask gap is not caught. Closing it needs a frontend
+  //     primitive that does not exist (a canvas-generation token on the write).
+  //
+  // Refusing here is consistent, not novel: `assertGraphBoundToActiveWorkflow` already
+  // fences every graph READ and MUTATION on this exact signal, so there is no state in
+  // which an agent could usefully save a tab it is not allowed to edit. And the bar is
+  // the same POSITIVE one — a durable identity conflict the workflow's own lineage does
+  // not claim. "unknown" (no tag, no oracle, an unreadable root) never refuses, so
+  // older frontends and first observation are untouched.
+  const assertCanvasNotForeign = () => {
+    if (normalizeCanvasBinding(canvasBinding, wf) === "foreign") {
+      throw new Error(
+        `refusing to save "${baseName(wf.filename) || wf.path || "this workflow"}": the live canvas ` +
+          `positively belongs to a DIFFERENT workflow, so this tab's in-memory graph cannot be ` +
+          `trusted to be its own — ComfyUI records whatever is on the shared canvas as the ACTIVE ` +
+          `tab's state, and saving now could write the other workflow's graph over this one ` +
+          `(issue #708). Nothing was written. Open the workflow you mean (panel_open_workflow) and ` +
+          `retry.`,
+      );
+    }
+  };
+  assertCanvasNotForeign();
 
   // An EXPLICIT name (any string, even "  ") must resolve to a real name. If it
   // normalizes to empty, refuse — never silently reinterpret an explicit-but-
@@ -383,7 +521,7 @@ export async function saveActiveWorkflow(
     // never references the source's on-disk file. If that copy API is unavailable,
     // REFUSE rather than risk moving the external original.
     if (isExternalWorkflowPath(sourcePath)) {
-      const copyToUserDir = resolveSaveAsCopy(svc, { reconcileSavedCopy });
+      const copyToUserDir = resolveSaveAsCopy(svc, { reconcileSavedCopy, canvasBinding, assertCanvasNotForeign });
       if (!copyToUserDir) {
         throw new Error(
           "save-as (copy) is unavailable on this frontend for an externally-loaded workflow; " +
@@ -447,7 +585,7 @@ export async function saveActiveWorkflow(
     // (#566 codex P0 — "whatever is active after the await" is NOT succession
     // evidence; a mid-trio switch to a foreign tab must thread/consume NOTHING).
     const producedRecord = {};
-    const atomicCopy = resolveSaveAsCopy(svc, { reconcileSavedCopy, producedRecord });
+    const atomicCopy = resolveSaveAsCopy(svc, { reconcileSavedCopy, producedRecord, canvasBinding, assertCanvasNotForeign });
     if (atomicCopy) {
       assertExpect(); // #330: still the workflow we probed?
       // Authoritative outcome: a "never-persisted" source (a temp / new_workflow tab
@@ -600,6 +738,11 @@ export async function saveActiveWorkflow(
         `(issue #442).`,
     );
   }
+  // #708 r4 — the canvas verdict is re-asserted here too: the awaited disk read above
+  // is exactly the window a reconnect can repaint the shared canvas in. Synchronous,
+  // with nothing awaited between it and saveInPlace (see the guard's own note on the
+  // residual microtask gap inside ComfyUI's save()).
+  assertCanvasNotForeign();
   if (inPlace === "authorize") markPersistedForOverwrite(wf); // sync (post-assert) ⇒ no leak window
   recordOutcome(details, "in-place", { sourcePath: currentPath, targetPath: finalTargetPath });
   const savedRecord = await saveInPlace(svc, wf);
@@ -725,8 +868,13 @@ async function probeSourceOnDisk(existsOnDisk, normPath) {
  *  is NOT succession evidence (a user/reconnect switch during saveWorkflow lands
  *  on a foreign tab); this is the same proof class the #557 r10 carry demands —
  *  the save's own produced record, never post-await active-tab occupancy. A proof
- *  failure threads NOTHING (fail safe). */
-function resolveSaveAsCopy(svc, { reconcileSavedCopy, producedRecord } = {}) {
+ *  failure threads NOTHING (fail safe).
+ *
+ *  `canvasBinding` is the #708 live-canvas identity oracle (see
+ *  normalizeCanvasBinding). It decides ONE thing here: whether the SOURCE tab's
+ *  serialized state may be refreshed from the live canvas before the copy is taken.
+ *  See the comment at that call. */
+function resolveSaveAsCopy(svc, { reconcileSavedCopy, producedRecord, canvasBinding, assertCanvasNotForeign } = {}) {
   // `openWorkflow` is MANDATORY for this path, not optional. The object saveAs
   // returns is UNLOADED (no changeTracker → activeState === null), and
   // ComfyWorkflow.save() serializes `activeState ?? null` — so persisting a copy
@@ -742,6 +890,59 @@ function resolveSaveAsCopy(svc, { reconcileSavedCopy, producedRecord } = {}) {
     typeof svc?.openWorkflow === "function"
   ) {
     return async (wf, effectiveName, finalTargetPath) => {
+      // #708 r4 — RE-ASSERT the canvas here, synchronously, before the clone `saveAs`
+      // takes below. The caller's entry-time assert is stale by now (awaited disk
+      // probes sit between), and this is the moment the copy's bytes are fixed.
+      assertCanvasNotForeign?.();
+      // #708 — REFRESH THE SOURCE, NEVER THE COPY. The copy's content is whatever
+      // `saveAs` reads out of `wf.activeState`, and that state can legitimately lag the
+      // canvas by a capture (ComfyUI snapshots on user-input events; bridge edits are
+      // snapshotted after the fact). Flushing the canvas into the tracker before the copy
+      // is taken is what keeps a save current.
+      //
+      // But `prepareForSave()` is `captureCanvasState()`, and that serializes the ONE
+      // shared `app.rootGraph` into whichever tracker is ACTIVE — it is a read of the
+      // global canvas, not of a tab. It used to be called on the COPY, AFTER
+      // `openWorkflow(copy)` made the copy active. That is the #708 defect in one line:
+      // `workflowStore.openWorkflow` moves the `activeWorkflow` pointer and does NOT
+      // repaint the canvas (only `workflowService.openWorkflow` calls loadGraphData), so
+      // the capture ran against a canvas that had never been asked to hold the copy's
+      // graph — and on a reconnect-restored canvas it OVERWROTE the tab-local state that
+      // `saveAs` had just faithfully copied with the previously-active workflow's graph.
+      // The blank tab was then persisted holding 12 foreign nodes, reported as saved.
+      //
+      // So the flush happens HERE, on the SOURCE, while the source is still the active
+      // tab — and only when the canvas is PROVEN to be this tab's canvas. Without that
+      // proof the tab-local state stands as written: possibly one capture stale, always
+      // this tab's own graph. Stale-but-right beats fresh-but-someone-else's, and the
+      // never-persisted case where the state itself may already be poisoned is refused
+      // outright upstream (the first-save binding guard).
+      //
+      // No #330 re-assert is needed around it: the caller re-asserted `expect`
+      // immediately before this adapter with no await in between, and the capture is
+      // self-guarding anyway — ComfyUI's `prepareForSave` is a documented no-op unless
+      // its own workflow is the active one (isActiveTracker), so a tab that is no longer
+      // active cannot be written to and no OTHER tab can be written to by this call.
+      // A capture that THROWS is not the same as one we chose not to take (codex gate).
+      // "bound" proves the canvas is this tab's; it does not prove `serialize()` works,
+      // and a serializer that throws mid-capture leaves the tracker holding a state we
+      // now know may be BEHIND the canvas. main aborted the whole save in that case (its
+      // capture sat inside the trio's try, so the throw propagated and nothing was
+      // written); swallowing it here would silently downgrade that into a reported
+      // success that quietly dropped the user's latest edit. So REFUSE, matching main.
+      // An ABSENT tracker/method is not a throw — optional chaining simply takes no
+      // capture, which is the same position as an unproven binding and stays allowed.
+      if (normalizeCanvasBinding(canvasBinding, wf) === "bound") {
+        try {
+          wf?.changeTracker?.prepareForSave?.();
+        } catch (err) {
+          throw new Error(
+            `refusing to save "${effectiveName}": the live canvas is this workflow's, but capturing ` +
+              `it failed (${describeThrown(err)}), so the saved copy could silently omit the newest ` +
+              `edits. Nothing was written — retry, or reload the ComfyUI tab if it persists (#708).`,
+          );
+        }
+      }
       // FINAL, SYNCHRONOUS collision re-check IMMEDIATELY before saveAs — this closes
       // the TOCTOU window between probeTargetCollision's async disk HEAD and this
       // write: another unsaved tab may have occupied the target WHILE the HEAD was
@@ -819,7 +1020,10 @@ function resolveSaveAsCopy(svc, { reconcileSavedCopy, producedRecord } = {}) {
       };
       try {
         await svc.openWorkflow(copy);
-        copy.changeTracker?.prepareForSave?.();
+        // NO capture on the copy — see the #708 note at the top of this adapter. The
+        // copy persists the state `saveAs` took from the source tab; asking the copy's
+        // tracker to "prepare" re-reads the shared global canvas, which is precisely the
+        // read that put a foreign workflow's graph into a brand-new tab's file.
         await svc.saveWorkflow(copy);
       } catch (err) {
         // P2 — distinguish a CONFIRMED pre-commit failure (409 conflict, or the


### PR DESCRIPTION
Fixes #708 — **both halves**: the persistence race that caused it, and the dishonest acknowledgement that hid it.

## What was reported

`panel_new_workflow` returned `{created:true, active:"Unsaved Workflow", key:"tmp:…"}` while a **dirty 12-node workflow** was active. The connection dropped before any load or graph edit. After reconnect, the new tab had persisted as `Untitled <timestamp>` and `panel_graph_outline` on it showed the **previous workflow's 12 nodes and 4 groups**. Nothing threw. The success result was simply false — and an agent told it has a blank canvas starts building on someone else's work.

## The cause — verified, not guessed

ComfyUI keeps **one** root graph and **one** `activeWorkflow` pointer, and a reconnect's own tab-restore can leave them disagreeing. Three facts, each read out of the installed frontend's own sources via its `.js.map` `sourcesContent`, and independently re-verified by the review gate:

1. `app.extensionManager.workflow` is `useWorkflowStore()` — the **store**, not the service (`workspaceStore.ts`).
2. `workflowStore.openWorkflow(copy)` loads the copy's content and moves the active pointer, and **does not repaint the canvas**. Only `workflowService.openWorkflow` calls `app.loadGraphData` (`workflowStore.ts` / `workflowService.ts`).
3. `ChangeTracker.prepareForSave()` is `captureCanvasState()`, which serializes the shared `app.rootGraph` into whichever tracker is **active** (`changeTracker.ts`).

Put together, the panel's Save-As copy trio was:

```js
const copy = svc.saveAs(wf, target);    // copy built from wf.activeState — TAB-LOCAL
await svc.openWorkflow(copy);           // activates the copy, canvas UNCHANGED
copy.changeTracker?.prepareForSave?.(); // <- re-reads the SHARED canvas into the copy
await svc.saveWorkflow(copy);           // writes it
```

That third line is the defect in one line: on a reconnect-restored canvas it overwrote the tab-local state `saveAs` had just faithfully copied with the previously-active workflow's graph. The per-turn grounding save (#330) then wrote it out as the new tab's first file, named by the panel's own `autoWorkflowName()` — which is exactly where `Untitled <timestamp>` comes from.

## The fix

**The capture is relocated, not removed.** It now runs on the **source tab**, before the copy is taken, and only when the live canvas is **proven** to be that tab's canvas. So a save stays as current as it was wherever that is provable, and is the tab's own state wherever it is not. A capture that **throws** refuses the save — matching what main did, never a reported success that quietly dropped the newest edit.

**A proven-foreign canvas refuses the save on every route.** Every route here ultimately persists `wf.activeState`, and ComfyUI fills that by serializing the shared canvas into whichever tab is active — including after every completed panel command (`deferChangeTrackerSnapshot`). So the guard covers:

| route | what a foreign canvas would have produced |
|---|---|
| never-persisted first save | a new `Untitled …` file holding another workflow's graph — **the reported #708** |
| external-source copy | a copy in the workflows dir holding another workflow's graph |
| **persisted, in-place** | **the user's real file overwritten** with another workflow's graph |

That last one is strictly worse than the reported bug; scoping the guard to first saves would have left it standing (found by the review gate, round 3). The verdict is **re-asserted immediately before every write** — the entry-time sample is stale after the awaited disk probes, and #330's `assertExpect` protects the workflow *object*, not the canvas (round 4).

**Proof is identity, never content.** It uses the same `graphRootWorkflowUuidMatches` / `graphRootWorkflowUuidMismatches` pair the graph fences use. Per f322c71 this must not become content-equality-as-identity reasoning, and it does not: two tabs holding one workflow are content-identical, and a correctly-bound canvas legitimately drifts from its tracker (#696/#701/#702/#663). A mismatching tag the workflow's **own lineage claims** is its own drifted stamp (#545/#557), not a foreign canvas, and stays inconclusive — otherwise the widened refusal would block legitimate saves after a save-swap. `"unknown"` never refuses and never licenses the flush, so older frontends and first observation are untouched.

**The acknowledgement.** `workflow_new` already computes a both-sides-proven-empty test for #606's identity stamp — the only evidence it has that the tab it calls "a brand-new BLANK workflow" is blank. That one proof now decides the acknowledgement too:

- proven ⇒ `{created:true, empty:true, …}` — unchanged for a normal new workflow (verified that a blank `LGraph.serialize()` passes `serializedStateProvenEmpty`'s allowlist, so this is not permanently caveated);
- unproven ⇒ `{created:"unknown", empty:"unknown", …, note:…}` telling the agent to check `panel_graph_outline` **before** building, and **not** to retry (`workflow_new` is not idempotent — a retry leaves a second blank tab).

The tab, its routing key and its open receipt are returned either way. Only "blank" is withheld.

## Verification

- **Fail-before**: 22 of 24 of the new tests fail on `main` (`a1ac583`). The repro fails with `12 !== 0` — main writes the previous workflow's 12 nodes into the new tab's file. The 2 that pass on main are the *other-direction* guards, which is the point.
- **Both directions covered**: a temp tab holding real work still saves it; a proven-bound canvas is still flushed (freshness preserved); an absent capture *method* is not a refusal; an unloaded tracker is not a refusal; an `"unknown"` binding never refuses any route. Nothing here blanks a tab.
- **Mutation-verified**, each restored afterwards:

| mutation | caught by |
|---|---|
| acknowledgement unconditionally `created:true` | `ack: the reported reconnect shape…` (+3 more) |
| restore `prepareForSave()` on the copy (main's behaviour) | `the reported repro…` (+4) |
| disarm the wrong-canvas refusal | `a PROVEN-foreign canvas refuses…` (+4) |
| drop the proven-bound source flush | `a BOUND canvas is still flushed…` (+1) |
| any truthy oracle verdict reads as `bound` | `normalizeCanvasBinding…` (+3) |
| flip the oracle's identity resolution order | `describeLiveCanvasBinding…` |
| swallow a throwing source flush | `a source flush that THROWS…` |
| `describeThrown` falls back to `String(err)` | `the refusal message names WHAT was thrown…` |
| drop the #545/#557 lineage exemption | `describeLiveCanvasBinding…` |
| remove the copy-route re-assert | `…turns foreign AFTER the entry check (copy route)` |
| remove the in-place re-assert | `…turns foreign AFTER the entry check (in-place route)` |

- **Full suite**: `npm run test:unit` gives **2695 passing, 0 failing**.
- Both changed `web/js` files parse **and link as ES modules** (`vm.SourceTextModule`, which catches the duplicate-top-level-declaration hazard `node --check` misses); control-byte scan clean on every changed file; no git-binary files; no `pyproject.toml` / `PANEL_VERSION` touched.

## Review gate

Four adversarial rounds (`codex exec`). **Disclosed:** the Windows sandbox denies process creation on this machine, so the gate ran with the sandbox off under an explicit review-only instruction; the working tree was verified unchanged after each round. Findings and dispositions:

- **r1 P1** — a throwing source capture was swallowed and the save proceeded. **Fixed**: it now refuses, matching main's fail-closed behaviour.
- **r2 P2/P3** — an over-claiming test name, and `describeThrown` could print `[object Object]` / `undefined`. **Fixed**, both pinned by tests.
- **r3 P1** — the guard was scoped to first saves, leaving a persisted tab's in-place save able to overwrite a real file. **Fixed**: hoisted to cover every route. r3 also *verified* the frontend diagnosis above and confirmed no acknowledgement regression for a normal new workflow.
- **r4 P1** — the verdict was sampled only on entry (TOCTOU across the awaited probes). **Fixed**: re-asserted before every write. **r4 P3** — a comment overstated the equivalence with the graph fence. **Fixed**: it borrows the fence's *evidence rule*, not its rebind.

## Known residual, stated plainly

For the **in-place** route only, ComfyUI's `ComfyWorkflow.save()` awaits a dynamic import before reading `activeState`, so a reconnect restore landing inside that sub-millisecond microtask gap is not caught. Closing it needs a frontend primitive that does not exist (a canvas-generation token carried on the write). The copy routes have no such gap: `saveAs` clones the state synchronously right after the assert, so a later drift cannot change the bytes that land.

## Not in scope

The panel cannot stop ComfyUI from capturing a foreign canvas into the active tab's tracker in the first place — that is upstream, in `ChangeTracker.captureCanvasState`. This change stops the panel from *persisting* the result and from *claiming* an unproven blank tab. A follow-up worth considering separately: the orchestrator's `panel_new_workflow` description could mention the `created:"unknown"` outcome (cross-repo, deliberately not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
