### PR TITLE
fix(panel #713): recover the slot-mirror WRITE variant of the disconnect crash

### DIFF
--- a/browser_tests/unit/safe-remove-node.test.mjs
+++ b/browser_tests/unit/safe-remove-node.test.mjs
@@ -439,3 +439,105 @@ test("works against the back-compat `links` record store (no _links Map)", () =>
   assert.equal(A.outputs[0].links, null);
   assert.equal(B.inputs[0].link, null);
 });
+
+// ── #713: the far-end SLOT MIRROR WRITE variant ────────────────────────────
+//
+// Same disconnect phase as #420, different signature. `graph.remove` clears the far
+// end's mirror of each link with a plain property write
+// (`farNode.inputs[slot].link = null`). In a rapid BATCHED removal of linked nodes a
+// sibling removal can tear that slot array out from under it, so the indexed slot
+// reads undefined and the write throws a TypeError instead of a "is not a function".
+// That fell through the old signature check to `throw err`, aborting the removal and
+// leaving the graph half-edited — with 9 sibling removals in the same batch reporting
+// success (the reported #713).
+
+/** A graph whose remove() reproduces the tear NATURALLY: the far end's slot array is
+ *  emptied (as a concurrent sibling removal would) and then the same mirror write the
+ *  real code performs is attempted, so the TypeError is thrown BY V8 with whatever
+ *  message this engine actually produces — never a hand-written string. If V8 ever
+ *  rephrases it, this test fails rather than passing against a stale literal. */
+function makeTearingGraph({ prop = "link" } = {}) {
+  const nodesById = new Map();
+  let torn = false;
+  return {
+    _links: new Map(),
+    inputNode: null,
+    outputNode: null,
+    getNodeById: (id) => nodesById.get(id) ?? null,
+    _register: (n) => nodesById.set(n.id, n),
+    remove(node) {
+      for (const out of node.outputs ?? []) {
+        for (const id of Array.isArray(out.links) ? [...out.links] : []) {
+          const link = this._links.get(id);
+          if (!link) continue;
+          const far = this.getNodeById(link.target_id);
+          if (far && !torn) {
+            torn = true;
+            far.inputs.length = 0; // a sibling removal tore the slot array out
+            // The real mirror write, on a slot that is now gone → genuine TypeError.
+            far.inputs[link.target_slot][prop] = null;
+          }
+          if (far && far.inputs[link.target_slot]) far.inputs[link.target_slot].link = null;
+          this._links.delete(id);
+        }
+        out.links = null;
+      }
+      for (const inp of node.inputs ?? []) {
+        if (inp.link != null) { this._links.delete(inp.link); inp.link = null; }
+      }
+      nodesById.delete(node.id);
+      node._removed = true;
+    },
+  };
+}
+
+test("#713 the slot-mirror WRITE crash is recovered, not aborted (error thrown by V8, not a literal)", () => {
+  const graph = makeTearingGraph();
+  const A = { id: 1, inputs: [], outputs: [{ name: "out", links: [10] }] };
+  const B = { id: 2, inputs: [{ name: "in", link: 10 }], outputs: [] };
+  graph._register(A); graph._register(B);
+  graph._links.set(10, { id: 10, origin_id: 1, origin_slot: 0, target_id: 2, target_slot: 0 });
+
+  const res = safeRemoveNode(graph, A);
+  assert.deepEqual(res, { removed: true, recovered: true }, "recovered instead of aborting");
+  assert.equal(graph.getNodeById(1), null, "the node really was removed on the retry");
+  assert.equal(graph._links.has(10), false, "the dangling link record was severed");
+});
+
+test("#713 the `links` (output mirror) spelling is recovered too", () => {
+  const graph = makeTearingGraph({ prop: "links" });
+  const A = { id: 1, inputs: [], outputs: [{ name: "out", links: [10] }] };
+  const B = { id: 2, inputs: [{ name: "in", link: 10 }], outputs: [] };
+  graph._register(A); graph._register(B);
+  graph._links.set(10, { id: 10, origin_id: 1, origin_slot: 0, target_id: 2, target_slot: 0 });
+  assert.deepEqual(safeRemoveNode(graph, A), { removed: true, recovered: true });
+});
+
+test("#713 predicate: both V8 phrasings match, and only for the link/links slot mirror", () => {
+  // Current V8 (Chrome >= 91) — the exact text in the #713 report.
+  assert.equal(isLinkDisconnectCrash(new TypeError("Cannot set properties of undefined (setting 'link')")), true);
+  assert.equal(isLinkDisconnectCrash(new TypeError("Cannot set properties of undefined (setting 'links')")), true);
+  assert.equal(isLinkDisconnectCrash(new TypeError("Cannot set properties of null (setting 'link')")), true);
+  // Legacy Chromium/Electron phrasing — panels do run on old embedded Chromium, and
+  // matching only the modern text would reopen this hole there.
+  assert.equal(isLinkDisconnectCrash(new TypeError("Cannot set property 'link' of undefined")), true);
+  assert.equal(isLinkDisconnectCrash(new TypeError('Cannot set property "links" of null')), true);
+
+  // Still NARROW: the property name is required, so an unrelated undefined-write is
+  // not recoverable. This is the assertion that keeps the widening honest.
+  assert.equal(isLinkDisconnectCrash(new TypeError("Cannot set properties of undefined (setting 'foo')")), false);
+  assert.equal(isLinkDisconnectCrash(new TypeError("Cannot set property 'widget' of undefined")), false);
+  assert.equal(isLinkDisconnectCrash(new TypeError("Cannot read properties of undefined (reading 'link')")), false, "a READ is a different failure");
+  assert.equal(isLinkDisconnectCrash(new Error("Cannot set properties of undefined (setting 'link')")), false, "not a TypeError");
+});
+
+test("#713 NARROW CATCH: the mirror-write message from a POST-disconnect hook still propagates", () => {
+  // The second guard (residual links) is what actually separates a disconnect-phase
+  // crash from an onRemoved() hook error. Widening the message shape must not weaken
+  // it: with every link already gone, this must abort, not retry the hook.
+  const graph = makeGraph();
+  const A = { id: 1, inputs: [], outputs: [] }; // no residual links at all
+  graph._register(A);
+  graph.remove = () => { throw new TypeError("Cannot set properties of undefined (setting 'link')"); };
+  assert.throws(() => safeRemoveNode(graph, A), /Cannot set properties of undefined/);
+});

--- a/web/js/lib/safe-remove-node.js
+++ b/web/js/lib/safe-remove-node.js
@@ -196,19 +196,54 @@ export function severNodeLinks(graph, node) {
   }
 }
 
-/** True for the recognized #420 link-disconnect crash: a TypeError from litegraph
- *  resolving a link's far end and calling a SLOT-LOOKUP method on something that
- *  isn't a proper LGraphNode (minified: "t.findInputSlot is not a function"). The
- *  match is deliberately narrow — only findInputSlot / findOutputSlot, the far-end
- *  slot lookups litegraph performs during link disconnection — so an unrelated
- *  TypeError won't be treated as recoverable. (Recovery never re-runs litegraph's
- *  disconnect, so even in the extraordinarily rare case a custom hook throws this
- *  exact internal signature, the retry does not re-invoke it — see safeRemoveNode.) */
+/** #713 — the far-end SLOT MIRROR WRITE variant. Same disconnect phase and same
+ *  cause as the method-call variant above: while clearing the far end's mirror of a
+ *  link litegraph writes `farNode.inputs[slot].link = null` /
+ *  `farNode.outputs[slot].links = …`, and during a rapid batched removal of LINKED
+ *  nodes a sibling removal can tear that slot array out from under it, so the
+ *  indexed slot reads `undefined`/`null` and the property write throws.
+ *
+ *  Kept as narrow as the method-call form by requiring the `link`/`links` property
+ *  NAME: an unrelated undefined-write ("… (setting 'foo')") is not recoverable.
+ *
+ *  Both V8 phrasings are matched. Current V8 (Chrome ≥ 91) says
+ *  `Cannot set properties of undefined (setting 'link')` — the exact text in the
+ *  #713 report — while older Chromium/Electron builds say
+ *  `Cannot set property 'link' of undefined`. Panels do run on old embedded
+ *  Chromium, and recognizing only the modern phrasing there would reopen the same
+ *  hole this fixes.
+ *
+ *  KNOWN LIMIT, deliberately not papered over: SpiderMonkey ("o.inputs[3] is
+ *  undefined") and JavaScriptCore ("undefined is not an object") do not name the
+ *  property at all, so this variant cannot be recognized narrowly on those engines
+ *  and is left unrecovered rather than matched by a broad pattern that would swallow
+ *  unrelated TypeErrors. */
+const SLOT_MIRROR_WRITE_RE =
+  /Cannot set propert(?:y|ies) of (?:undefined|null) \(setting ['"](?:link|links)['"]\)|Cannot set property ['"](?:link|links)['"] of (?:undefined|null)/;
+
+/** True for a recognized link-disconnect crash — a TypeError thrown by litegraph
+ *  while it is tearing down the FAR END of a link during `graph.remove`. Two
+ *  variants, same phase and same recovery:
+ *
+ *  (a) #420, the slot-LOOKUP method call: the far end resolves to something that is
+ *      not a proper LGraphNode, so calling a slot lookup on it throws (minified:
+ *      "t.findInputSlot is not a function"). Narrowed to findInputSlot /
+ *      findOutputSlot, the only far-end lookups litegraph performs there.
+ *  (b) #713, the slot-MIRROR WRITE — see SLOT_MIRROR_WRITE_RE above.
+ *
+ *  Both stay narrow so an unrelated TypeError is never treated as recoverable, and
+ *  message shape is only the FIRST of safeRemoveNode's two guards: the crash must
+ *  also have left residual links, which is what actually distinguishes a
+ *  disconnect-phase crash from a post-disconnect hook error. (Recovery never re-runs
+ *  litegraph's disconnect, so even if a custom hook threw one of these exact internal
+ *  signatures, the retry does not re-invoke it — see safeRemoveNode.) */
 export function isLinkDisconnectCrash(err) {
   if (!(err instanceof TypeError)) return false;
   const msg = String(err?.message ?? "");
-  if (!/is not a function/.test(msg)) return false;
-  return /find(Input|Output)Slot/.test(msg);
+  // (a) far-end slot-LOOKUP method invoked on something that isn't an LGraphNode.
+  if (/is not a function/.test(msg) && /find(Input|Output)Slot/.test(msg)) return true;
+  // (b) far-end slot MIRROR WRITE onto a slot that is already gone.
+  return SLOT_MIRROR_WRITE_RE.test(msg);
 }
 
 /** True when `node` still has at least one link attached — via its own slot refs OR a


### PR DESCRIPTION
Closes #713

`panel_remove_node` aborted with `Cannot set properties of undefined (setting 'link')` while 9 sibling removals in the same parallel batch succeeded — leaving the graph half-edited with no rollback, and an agent that doesn't notice the individual tool error continuing on a partially-mutated graph.

Same disconnect-phase race as #420, different signature. `graph.remove()` clears the far end's mirror of each link with a plain property write (`farNode.inputs[slot].link = null` / `outputs[slot].links`). In a rapid batched removal of *linked* nodes, a sibling removal can tear that slot array out from under it, so the indexed slot reads `undefined` and the write throws a `TypeError` rather than an "is not a function". `safeRemoveNode` already has exactly the right recovery — sever at the record level, then retry — but `isLinkDisconnectCrash` only recognized the method-call variant, so this fell through to `throw err`.

## Kept narrow

- The `link`/`links` property **name** is required, so an unrelated undefined-write (`… (setting 'foo')`) is still not recoverable.
- A **read** (`Cannot read properties of undefined (reading 'link')`) is a different failure and still propagates.
- Message shape is only the **first** of `safeRemoveNode`'s two guards. `nodeHasResidualLinks` is untouched, and it is what actually separates a disconnect-phase crash from a post-disconnect `onRemoved()` hook error — there is a test asserting the widened message still propagates when no links remain.

## Beyond the proposed patch

**Both V8 phrasings**, not just the reported one. Current V8 (Chrome ≥ 91) produces `Cannot set properties of undefined (setting 'link')`; older Chromium/Electron produces `Cannot set property 'link' of undefined`. Panels do run on old embedded Chromium, and matching only the modern text would leave the same hole open there.

**Documented limit rather than a broad match**: SpiderMonkey (`o.inputs[3] is undefined`) and JavaScriptCore (`undefined is not an object`) don't name the property at all, so this variant can't be recognized *narrowly* on those engines. Left unrecovered and commented, rather than matched by a pattern that would swallow unrelated TypeErrors.

## Verification

- The two end-to-end tests **provoke the tear for real** — the far end's slot array is emptied and the actual mirror write attempted — so the `TypeError` is thrown *by V8* with whatever message the engine really produces. If V8 rephrases it, these fail rather than passing against a stale literal. (I also captured the live messages on this engine to confirm the reported text and that an unrelated property is cleanly distinguishable.)
- **Mutation-verified**: restoring main's predicate fails 3 of the 4 new tests; the 4th is the negative guard and correctly still passes. Restored, green again.
- `npm run test:unit`: **2699 pass, 0 fail**. ESM parse+link check on the changed module. Control-byte scan 0 on both files. No `pyproject.toml` / `PANEL_VERSION` change.

## Follow-up, not done here

The reporter's own point stands and I agree with it: recovering per-signature means the next litegraph phrasing reopens the same hole. Serializing `panel_remove_node` mutations, or applying a multi-node removal as one atomic frame, would remove the whole class. That's a design change to the command path rather than a fix for this report, so it isn't bundled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)