### PR TITLE
fix(panel #691): echo `filters` in the search receipt, and say when a sort is upstream-inert

### DIFF
--- a/browser_tests/unit/civitai-search-echo.test.mjs
+++ b/browser_tests/unit/civitai-search-echo.test.mjs
@@ -1,0 +1,128 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { summarizeSearchFilters } from "../../web/js/lib/civitai-search-echo.js";
+
+/**
+ * #691 — panel_civitai_search accepted a documented `filters` object, echoed
+ * tab/query/creator back but never `filters`, and reported dispatched:true. The
+ * caller could not tell applied from silently dropped.
+ *
+ * The second half matters as much: the reporter concluded modelSort was inert
+ * because the results were not sorted. The panel does send it — CivitAI ignores
+ * `sort` whenever a `query` is present (three different sorts return an identical
+ * ordering; without a query they diverge). So the receipt has to distinguish
+ * "your filter was dropped" from "upstream cannot honour it here", because those
+ * call for completely different actions.
+ */
+
+test("filters are echoed, so 'applied' is distinguishable from 'dropped'", () => {
+  const r = summarizeSearchFilters({
+    filters: { period: "Month", modelSort: "Most Liked", baseModels: ["Flux.1 D"], browsingLevels: [1, 2] },
+    query: "",
+    modelTab: true,
+  });
+  assert.deepEqual(r.filters, {
+    period: "Month",
+    modelSort: "Most Liked",
+    baseModels: ["Flux.1 D"],
+    browsingLevels: [1, 2],
+  });
+});
+
+test("array fields are COPIED, not aliased to live panel state", () => {
+  // The receipt is serialized after this returns; sharing the array would let a
+  // later filter change rewrite a receipt already handed to the caller.
+  const live = { baseModels: ["Flux.1 D"], browsingLevels: [1] };
+  const r = summarizeSearchFilters({ filters: live, query: "", modelTab: true });
+  live.baseModels.push("SDXL");
+  live.browsingLevels.push(8);
+  assert.deepEqual(r.filters.baseModels, ["Flux.1 D"], "echo must not follow later mutations");
+  assert.deepEqual(r.filters.browsingLevels, [1]);
+});
+
+test("unset filters are omitted rather than reported as null", () => {
+  const r = summarizeSearchFilters({ filters: { period: "Week", modelSort: null, imageSort: undefined }, query: "", modelTab: true });
+  assert.deepEqual(Object.keys(r.filters), ["period"]);
+});
+
+test("a keyword search reports sortApplied:false and says why", () => {
+  // The load-bearing case. Without this the agent sees an unsorted grid and
+  // reports a sort failure that no one can fix, because CivitAI relevance-ranks.
+  const r = summarizeSearchFilters({
+    filters: { modelSort: "Most Downloaded" },
+    query: "z-image turbo detail enhancer",
+    modelTab: true,
+  });
+  assert.equal(r.sortApplied, false);
+  assert.match(r.filterNote, /relevance-ranks/i);
+  assert.match(r.filterNote, /Most Downloaded/);
+  assert.match(r.filterNote, /NOT applied/);
+  // It must tell the agent NOT to call this a sort failure — that instruction is
+  // the whole point of surfacing it.
+  assert.match(r.filterNote, /Do NOT report it as a sort failure/i);
+});
+
+test("an EMPTY query sorts normally — sortApplied:true and no note", () => {
+  // The other direction: claiming the sort is inert when it does work would be a
+  // false warning, and would push the agent away from the one form that sorts.
+  for (const query of ["", "   ", undefined, null]) {
+    const r = summarizeSearchFilters({ filters: { modelSort: "Most Downloaded" }, query, modelTab: true });
+    assert.equal(r.sortApplied, true, `query ${JSON.stringify(query)} sorts normally`);
+    assert.equal(r.filterNote, undefined, "no warning when the sort really applies");
+  }
+});
+
+test("no note when no modelSort was requested, even with a query", () => {
+  // Nothing was asked for, so nothing was denied. A note here would be noise on
+  // every ordinary search.
+  const r = summarizeSearchFilters({ filters: { period: "Week" }, query: "portrait", modelTab: true });
+  assert.equal(r.sortApplied, false, "still reported — the sort would be inert if set");
+  assert.equal(r.filterNote, undefined);
+});
+
+test("NON-model tabs report no sortApplied verdict at all", () => {
+  // The image/video tabs hit a different endpoint whose behaviour was not
+  // measured. Asserting there would be a guess dressed up as a receipt.
+  const r = summarizeSearchFilters({
+    filters: { imageSort: "Most Reactions" },
+    query: "portrait",
+    modelTab: false,
+  });
+  assert.deepEqual(r.filters, { imageSort: "Most Reactions" }, "filters still echoed");
+  assert.equal("sortApplied" in r, false, "no claim about a path that wasn't measured");
+  assert.equal(r.filterNote, undefined);
+});
+
+test("a missing/garbage filters object yields an empty echo, never a throw", () => {
+  for (const bad of [undefined, null, "nope", 42]) {
+    const r = summarizeSearchFilters({ filters: bad, query: "", modelTab: true });
+    assert.deepEqual(r.filters, {});
+  }
+});
+
+// ── WIRING ────────────────────────────────────────────────────────────────
+// The tests above prove the helper is right. They cannot prove it is CALLED:
+// deleting the spread from driveSearch's return would leave every one of them
+// green while restoring the exact bug (#691's receipt, with no `filters`).
+// driveSearch is a closure inside openCivitai and is not exported, so the
+// callable seam does not exist to drive — pin the wiring at source instead.
+
+test("WIRING: driveSearch's receipt actually spreads the summary", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("../../web/js/cmcp-civitai-ui.js", import.meta.url), "utf8");
+
+  assert.match(src, /import \{ summarizeSearchFilters \} from "\.\/lib\/civitai-search-echo\.js";/,
+    "the helper must be imported");
+
+  // Anchor inside driveSearch's return, not merely somewhere in a 2000-line file.
+  const ret = src.slice(src.indexOf("async function driveSearch"));
+  const body = ret.slice(0, ret.indexOf("function driveGetResults"));
+  assert.ok(body.includes("...summarizeSearchFilters({"),
+    "driveSearch's receipt must SPREAD the summary — without this the receipt omits `filters` again");
+  // The arguments are load-bearing: passing the raw request instead of the
+  // EFFECTIVE state would echo what was asked for rather than what was applied,
+  // which is the same lie in a different shape.
+  assert.ok(body.includes("filters: state.filters"), "must echo the EFFECTIVE folded state");
+  assert.ok(body.includes("query: state.query"), "must judge the sort against the APPLIED query");
+  assert.ok(body.includes("modelTab: !!tabDef().model"), "must scope the sort verdict to model tabs");
+});

--- a/web/js/cmcp-civitai-ui.js
+++ b/web/js/cmcp-civitai-ui.js
@@ -15,6 +15,7 @@ import {
   BASE_MODELS, ACTIVE_BASE_MODELS, prepareQuery, matchesBaseModel,
   filtersDirty, bitmask, parseCreatorQuery, levelLabel,
 } from "./cmcp-civitai.js";
+import { summarizeSearchFilters } from "./lib/civitai-search-echo.js";
 import { openSidePanel } from "./cmcp-sidepanel-ui.js";
 import { openSubModal as openSubModalBase, toast } from "./cmcp-modal.js";
 import { chipRow as filterChipRow, makeFilterButton } from "./cmcp-filter.js";
@@ -1995,7 +1996,23 @@ export function createCivitaiContent(ctx, shell, opts = {}) {
     // generation. The agent reads the data via panel_civitai_results
     // (loading/done flags) — the metadata-poll design.
     void reload({ searching: true });
-    return { tab: state.tab, query: state.query, creator: state.filters.username || null, renderRev: state.renderRev, dispatched: true };
+    // #691 — echo `filters` the way `tab`/`query`/`creator` are already echoed, so
+    // the caller can tell "applied" from "silently dropped" instead of reading
+    // `dispatched:true` as proof. summarizeSearchFilters also reports when a
+    // requested modelSort is inert because CivitAI relevance-ranks keyword
+    // searches — measured, not assumed; see that module for the evidence.
+    return {
+      tab: state.tab,
+      query: state.query,
+      creator: state.filters.username || null,
+      ...summarizeSearchFilters({
+        filters: state.filters,
+        query: state.query,
+        modelTab: !!tabDef().model,
+      }),
+      renderRev: state.renderRev,
+      dispatched: true,
+    };
   }
   function driveGetResults({ limit = 20 } = {}) {
     _assertOpen();

--- a/web/js/lib/civitai-search-echo.js
+++ b/web/js/lib/civitai-search-echo.js
@@ -1,0 +1,90 @@
+/**
+ * #691 — make a CivitAI search receipt say what actually happened to `filters`.
+ *
+ * `panel_civitai_search` accepts a documented `filters` object, echoes `tab`,
+ * `query` and `creator` back, and says `dispatched: true` — but said nothing at
+ * all about `filters`. From the caller's side there was no way to tell whether
+ * they were parsed, applied, or silently dropped, which is the false-success
+ * shape: a documented parameter accepted without complaint and no observable
+ * effect. (#374 was the same defect for `creator`, fixed the same way: echo it,
+ * and warn when it did not land.)
+ *
+ * THE SORT IS NOT DROPPED BY THE PANEL — it is ignored UPSTREAM.
+ * The reporter saw `modelSort: "Most Downloaded"` produce ascending download
+ * counts and reasonably concluded the filter was inert. It is not: `driveSearch`
+ * folds it into `state.filters`, the model-tab branch passes `sort: f.modelSort`
+ * to `fetchModels`, and "Most Downloaded" is inside MODEL_SORTS so the #459 clamp
+ * passes it through untouched. The panel sends it correctly.
+ *
+ * What actually happens is that CivitAI's /v1/models RELEVANCE-RANKS whenever a
+ * `query` is present and ignores `sort` completely. Measured directly against the
+ * live endpoint:
+ *
+ *   query="portrait", sort=Most Downloaded → ids 5658,2067704,685224,131324,156948
+ *   query="portrait", sort=Newest          → ids 5658,2067704,685224,131324,156948
+ *   query="portrait", sort=Oldest          → ids 5658,2067704,685224,131324,156948
+ *   (no query),       sort=Most Downloaded → ids 264290,58390,122359,82098,25995
+ *   (no query),       sort=Newest          → ids 2840129,2756662,2773267,2840095,…
+ *
+ * Three different sorts returning a byte-identical ordering is what proves it;
+ * without a query the same sorts diverge, which proves the parameter is otherwise
+ * honoured. So a keyword search cannot be sorted, by anyone, and an agent that
+ * asks for one deserves to be told that rather than left to infer it from a
+ * result set that looks mis-sorted.
+ *
+ * Deliberately NOT done here: silently dropping the sort, or refusing the search.
+ * The sort still matters — it applies the moment the query is cleared — and
+ * refusing a search because one of its filters is upstream-inert would turn a
+ * cosmetic surprise into a false refusal.
+ */
+
+/** The filter keys a caller can set through `panel_civitai_search`, echoed back
+ *  in this order. `username` is echoed separately as `creator` by driveSearch, so
+ *  it is not repeated here. */
+const ECHOED_KEYS = ["period", "modelSort", "imageSort", "baseModels", "browsingLevels"];
+
+/** Copy the effective filter state for the receipt. Arrays are COPIED, never
+ *  aliased: the receipt is serialized asynchronously and must not mutate (or be
+ *  mutated by) live panel state afterwards. Absent keys are omitted rather than
+ *  reported as null, so the echo describes what IS set. */
+function echoFilters(filters) {
+  const out = {};
+  if (!filters || typeof filters !== "object") return out;
+  for (const key of ECHOED_KEYS) {
+    const value = filters[key];
+    if (value === undefined || value === null) continue;
+    out[key] = Array.isArray(value) ? [...value] : value;
+  }
+  return out;
+}
+
+/**
+ * Build the `filters` half of a search receipt.
+ *
+ * @param {object}  opts
+ * @param {object}  opts.filters   the panel's EFFECTIVE filter state after folding
+ * @param {string}  opts.query     the search text actually applied (creator token stripped)
+ * @param {boolean} opts.modelTab  true when the active tab queries /v1/models
+ * @returns {{filters: object, sortApplied?: boolean, filterNote?: string}}
+ *   `sortApplied` is reported ONLY for a model tab, where the answer is knowable:
+ *   the image/video tabs use a different endpoint whose behaviour this has not
+ *   measured, and asserting there would be a guess dressed as a receipt.
+ */
+export function summarizeSearchFilters({ filters, query, modelTab } = {}) {
+  const echoed = echoFilters(filters);
+  const result = { filters: echoed };
+  if (!modelTab) return result;
+
+  const hasQuery = typeof query === "string" && query.trim() !== "";
+  result.sortApplied = !hasQuery;
+  if (hasQuery && echoed.modelSort) {
+    result.filterNote =
+      `CivitAI relevance-ranks keyword searches: with a \`query\` set, /v1/models ignores ` +
+      `\`sort\` entirely, so modelSort "${echoed.modelSort}" is NOT applied to these results ` +
+      `(verified — "Most Downloaded", "Newest" and "Oldest" return an identical ordering for ` +
+      `the same query). The ordering you see is relevance, not ${echoed.modelSort.toLowerCase()}. ` +
+      `Do NOT report it as a sort failure. To sort, run the search with an empty query and rely ` +
+      `on the other filters (baseModels / period) to narrow instead.`;
+  }
+  return result;
+}


### PR DESCRIPTION
Closes #691

Two halves, and only one of them was a panel bug.

## The receipt was silent about `filters` — that is a real defect

`panel_civitai_search` echoed `tab`, `query` and `creator` but never `filters`, while reporting `dispatched: true`. There was no way to tell parsed from applied from silently dropped. #374 was this exact defect for `creator`, fixed the same way. `driveSearch` now echoes the **effective** filter state (after folding), with arrays copied rather than aliased to live panel state.

## The sort is NOT dropped by the panel — CivitAI ignores it

The report reasonably concluded `modelSort` was inert, from ascending download counts. It isn't: `driveSearch` folds it into `state.filters`, the model-tab branch passes `sort: f.modelSort` to `fetchModels`, and `"Most Downloaded"` is in `MODEL_SORTS`, so the #459 clamp passes it through untouched.

I measured the live endpoint rather than guessing:

| request | first 5 model ids |
|---|---|
| `query=portrait`, `sort=Most Downloaded` | `5658,2067704,685224,131324,156948` |
| `query=portrait`, `sort=Newest` | `5658,2067704,685224,131324,156948` |
| `query=portrait`, `sort=Oldest` | `5658,2067704,685224,131324,156948` |
| *(no query)*, `sort=Most Downloaded` | `264290,58390,122359,82098,25995` |
| *(no query)*, `sort=Newest` | `2840129,2756662,2773267,2840095,…` |

Three different sorts returning an **identical** ordering is the proof: `/v1/models` relevance-ranks whenever `query` is present and ignores `sort`. Without a query the same sorts diverge, which proves the parameter is otherwise honoured.

So the receipt now reports `sortApplied` and, when a `modelSort` was actually requested alongside a query, a note explaining that the ordering is relevance — and explicitly telling the agent **not** to report it as a sort failure, since that is precisely the wrong conclusion to hand a user.

## Judgement calls

- **Not** dropping the sort or refusing the search. The sort applies the moment the query is cleared; refusing because a filter is upstream-inert would turn a cosmetic surprise into a false refusal.
- The verdict is reported **only for model tabs**. The image/video tabs use a different endpoint whose behaviour I did not measure, and asserting there would be a guess dressed up as a receipt.
- No note when no `modelSort` was requested — nothing was asked for, so nothing was denied, and a note on every ordinary search is noise.

## Verification

- 9 new tests, including both directions (a keyword search warns; an empty query must **not** warn, or the agent gets pushed away from the one form that does sort).
- **Both mutation classes**, which mattered here: inverting the `sortApplied` verdict fails 3 tests, and **deleting the call site** fails the wiring pin. `driveSearch` is a closure inside `openCivitai` and isn't exported, so the wiring is pinned at source — a helper-only suite would have stayed green through the exact regression this fixes. (My first call-site mutation silently applied 0 replacements under CRLF; that pass was discarded and redone with the marker count checked.)
- `npm run test:unit`: **2708 pass, 0 fail**. ESM parse+link on the new module. Control-byte scan 0 on all three files. No `pyproject.toml` / `PANEL_VERSION` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)