### PR TITLE
fix(panel #686): core V3 dynamic-input declarations are addable, not "pending registration"

### DIFF
--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -799,3 +799,110 @@ test("#695 gate r1: the type list is deduped and first-seen ordered, as it alway
     { type: "ZED", inputs: ["other"], linkProven: false },
   ]);
 });
+
+// ── #686: core V3 DYNAMIC-INPUT declarations ──────────────────────────────
+//
+// panel_add_node could not create ANY node whose schema uses ComfyUI 0.30's
+// autogrow input type — StringFormat, ComfyMathExpression — failing with
+// "Required custom widget COMFY_AUTOGROW_V3 have not registered … retry
+// shortly". It never resolved: refresh_nodes returned refreshed:true and the
+// next attempt failed identically, while dragging the same node in from
+// ComfyUI's own menu worked and the node then executed normally.
+//
+// It is a THIRD kind of required input that both existing waivers misclassify:
+// nothing OUTPUTS the type (so `linkProven` is structurally unreachable) and no
+// widget constructor is ever registered for it (the frontend implements it
+// natively), so the wait was for something that could never happen.
+
+const AUTOGROW = "COMFY_AUTOGROW_V3";
+/** app.widgets with the ordinary value types registered — AUTOGROW never is. */
+const REGISTERED = { STRING: () => {}, FLOAT: () => {}, INT: () => {} };
+
+/** StringFormat as ComfyUI 0.30 emits it. Autogrow's Input.as_dict() yields the
+ *  base neutral keys plus `template`, and NO widget-value keys. */
+const stringFormatDef = {
+  input: {
+    required: {
+      format: ["STRING", { default: "{a}_{b:02d}" }],
+      values: [AUTOGROW, { template: { input: ["STRING", {}], prefix: "value", min: 1, max: 10 } }],
+    },
+  },
+};
+
+test("#686 an autogrow node is addable — StringFormat no longer waits for a widget that never registers", () => {
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(stringFormatDef, REGISTERED, undefined, stringFormatDef),
+    [],
+  );
+});
+
+test("#686 the waiver cannot come from output evidence — knownSocketTypes can never contain it", () => {
+  // The load-bearing point. Nothing outputs COMFY_AUTOGROW_V3, so passing a fully
+  // populated knownSocketTypes changes nothing: if the fix depended on link-proof
+  // it would still fail closed forever. Same verdict with and without.
+  const known = new Set(["IMAGE", "MASK", "LATENT", "STRING"]);
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(stringFormatDef, REGISTERED, known, stringFormatDef),
+    [],
+  );
+});
+
+test("#686 covers the whole reserved COMFY_*_V3 family, not just the reported type", () => {
+  // ComfyMathExpression is the second node in the report, and the other three are
+  // declared alongside autogrow in ComfyUI's comfy_api/latest/_io.py. Fixing only
+  // the reported one would leave the identical bug for its siblings.
+  for (const type of [
+    "COMFY_AUTOGROW_V3",
+    "COMFY_DYNAMICCOMBO_V3",
+    "COMFY_DYNAMICSLOT_V3",
+    "COMFY_MATCHTYPE_V3",
+    "COMFY_MULTITYPED_V3",
+  ]) {
+    const def = { input: { required: { values: [type, { template: {} }] } } };
+    assert.deepEqual(
+      unavailableRequiredCustomWidgetTypes(def, REGISTERED, undefined, def),
+      [],
+      `${type} must be addable`,
+    );
+  }
+});
+
+test("#686 does NOT weaken #580: an unregistered custom widget still fails closed", () => {
+  const def = { input: { required: { thing: ["SOME_CUSTOM_WIDGET", { default: 1, min: 0 }] } } };
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(def, REGISTERED, undefined, def),
+    ["SOME_CUSTOM_WIDGET"],
+  );
+});
+
+test("#686 the input-level bar still applies — a COMFY_*_V3 input declaring WIDGET keys keeps waiting", () => {
+  // The waiver is namespace AND socket-shaped declaration, not namespace alone.
+  // An input that declares default/min/max is asking to carry a value, so it still
+  // needs a constructor — admitting it would be a #580 false accept.
+  const def = { input: { required: { v: [AUTOGROW, { default: 5, min: 0, max: 9 }] } } };
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(def, REGISTERED, undefined, def),
+    [AUTOGROW],
+  );
+});
+
+test("#686 matches the RESERVED namespace only — a lookalike is not waived", () => {
+  // The rule is ComfyUI's own COMFY_*_V3 prefix. A third-party type that merely
+  // resembles it gets no waiver.
+  for (const type of ["COMFY_FAKE_V2", "COMFY_THING", "MYPACK_AUTOGROW_V3", "comfy_autogrow_v3"]) {
+    const def = { input: { required: { v: [type, {}] } } };
+    assert.deepEqual(
+      unavailableRequiredCustomWidgetTypes(def, REGISTERED, undefined, def),
+      [type],
+      `${type} must NOT be waived`,
+    );
+  }
+});
+
+test("#686 a registered constructor still wins — the waiver never shadows a real widget", () => {
+  const def = { input: { required: { v: [AUTOGROW, { template: {} }] } } };
+  assert.deepEqual(
+    unavailableRequiredCustomWidgetTypes(def, { ...REGISTERED, [AUTOGROW]: () => {} }, undefined, def),
+    [],
+  );
+});

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -192,6 +192,16 @@ export function unavailableRequiredWidgetReport(
     // exactly the same bar — LTXV's `("FLOAT,INT", {default, min, max, step})` is a
     // widget that ACCEPTS an int link, not a socket, and still waits for its constructor.
     if (linkProven && socketDeclared.has(type)) continue;
+    // #686 — a CORE DYNAMIC-INPUT declaration is neither of the two things the waivers
+    // above test for, so both misclassify it and it fails closed forever. See
+    // isCoreDynamicV3Type: it is not a link datatype (nothing outputs it, so
+    // knownSocketTypes can never contain it and `linkProven` is unreachable), and it is
+    // not a value widget (no constructor is ever registered for it — the frontend
+    // implements it natively). The input-level bar still applies: the declaration must
+    // itself be socket-shaped, so a COMFY_*_V3 input that declares widget-value keys is
+    // still held for its constructor. Single-member only — a union naming a dynamic
+    // declaration is not a shape ComfyUI emits, and admitting one would be guessing.
+    if (members.length === 1 && isCoreDynamicV3Type(type) && socketDeclared.has(type)) continue;
     report.push({ type, inputs, linkProven });
   }
   return report;
@@ -224,6 +234,44 @@ export function unavailableRequiredWidgetMessage(report, classType, waitedMs) {
     "a socket (MASK, IMAGE, LATENT, a comma-joined union of them) is added immediately, without " +
     "any wait."
   );
+}
+
+/**
+ * ComfyUI's CORE V3 dynamic-input declarations, which occupy the reserved `COMFY_*_V3`
+ * type namespace: `COMFY_AUTOGROW_V3`, `COMFY_DYNAMICCOMBO_V3`, `COMFY_DYNAMICSLOT_V3`,
+ * `COMFY_MATCHTYPE_V3`, `COMFY_MULTITYPED_V3` (declared with `@comfytype(io_type=…)` in
+ * ComfyUI's `comfy_api/latest/_io.py`).
+ *
+ * These are a THIRD kind of required input, and the reason #686 failed closed forever:
+ *
+ *   • Not a value widget. No widget constructor is ever registered for them — the
+ *     frontend implements the dynamic behaviour natively — so waiting for `app.widgets`
+ *     to gain one waits for something that never happens. The reporter proved this
+ *     directly: dragging `StringFormat` in from ComfyUI's own node menu works, and the
+ *     node then wires and executes normally, so the def is valid and complete.
+ *   • Not a link datatype. Nothing OUTPUTS `COMFY_AUTOGROW_V3`, so no fresh
+ *     /object_info can ever put it in `knownSocketTypes`, and `linkProven` is
+ *     structurally unreachable for it.
+ *
+ * The input is a TEMPLATE that makes the node grow real inputs; it carries no prompt
+ * value of its own, which is why `StringFormat` and `ComfyMathExpression` are perfectly
+ * valid the instant they are created.
+ *
+ * MATCHED BY RESERVED NAMESPACE, NOT BY A LIST — deliberately. This module already
+ * carries the lesson: "Growing [SAFE_SOCKET_TYPES] is not how a new core datatype gets
+ * fixed — #695 was filed after MASK, and would have been filed again after the next
+ * one." Enumerating today's five would need editing the moment ComfyUI adds a sixth, and
+ * that report would look exactly like this one. `COMFY_*_V3` is ComfyUI's own reserved
+ * prefix for these, so the rule covers the family rather than its current membership.
+ *
+ * #580's protection is intact: this waives ONLY the reserved core namespace, and the
+ * caller still requires the input to declare itself socket-shaped, so an input using one
+ * of these types while declaring widget-value keys keeps waiting for a constructor.
+ */
+const CORE_DYNAMIC_V3_TYPE_RE = /^COMFY_[A-Z0-9]+_V3$/;
+
+export function isCoreDynamicV3Type(type) {
+  return typeof type === "string" && CORE_DYNAMIC_V3_TYPE_RE.test(type);
 }
 
 /**


### PR DESCRIPTION
Closes #686

`panel_add_node` could not create **any** node whose schema uses ComfyUI 0.30's autogrow input type — `StringFormat`, `ComfyMathExpression` — and the refusal never cleared. `panel_refresh_nodes` returned `refreshed:true` and the next attempt failed identically, while dragging the same node in from ComfyUI's own menu worked and the node then wired and executed normally. That last fact is what localizes it: the def is valid and complete, so nothing was actually pending.

## Why it failed closed forever

`COMFY_AUTOGROW_V3` is a **third** kind of required input, and both existing waivers misclassify it:

- **Not a value widget.** No constructor is ever registered for it — the frontend implements the dynamic behaviour natively — so waiting for `app.widgets` to gain one waits for something that cannot happen. That is why "retry shortly" was never going to be true.
- **Not a link datatype.** Nothing *outputs* it, so no fresh `/object_info` can put it in `knownSocketTypes`, and `linkProven` is structurally unreachable. I verified this rather than assuming it: passing a fully populated `knownSocketTypes` changes the verdict not at all — there is a test asserting exactly that, because a fix resting on link-proof would still fail closed forever.

The input is a **template** that makes the node grow real inputs; it carries no prompt value of its own, which is why those nodes are valid the instant they are created.

## Matched by reserved namespace, not by a list

This module already carries the lesson, and I followed it rather than doing the easy thing:

> *"Growing [SAFE_SOCKET_TYPES] is not how a new core datatype gets fixed — #695 was filed after MASK, and would have been filed again after the next one."*

Today's family is five types, all declared with `@comfytype(io_type=…)` in ComfyUI's `comfy_api/latest/_io.py`: `COMFY_AUTOGROW_V3`, `COMFY_DYNAMICCOMBO_V3`, `COMFY_DYNAMICSLOT_V3`, `COMFY_MATCHTYPE_V3`, `COMFY_MULTITYPED_V3`. I enumerated those from ComfyUI's source, not from memory — but enumerating them in the panel would need editing the moment ComfyUI adds a sixth, and *that* report would look exactly like this one. `COMFY_*_V3` is ComfyUI's own reserved prefix, so the rule covers the family instead of its current membership.

The reporter's own suggestion was to treat `COMFY_AUTOGROW_V3` as known-safe; this does that for the whole family, since fixing only the reported type would leave the identical bug for `ComfyMathExpression`'s siblings.

## #580 is intact

The waiver is namespace **and** socket-shaped declaration, so:

- a `COMFY_*_V3` input that declares widget-value keys (`default`/`min`/`max`) still waits for its constructor;
- an unregistered third-party widget still fails closed;
- a lookalike outside the reserved prefix (`COMFY_FAKE_V2`, `MYPACK_AUTOGROW_V3`, lowercase) gets no waiver;
- a registered constructor still wins.

Each of those is a test.

## Verification

- 7 new tests; **2715 pass, 0 fail** across the suite.
- **Both mutation classes**: removing the waiver fails 3 tests; dropping the socket-shaped half — the false-accept direction — fails the input-level-bar test. Marker counts checked so neither mutation silently applied 0 replacements.
- No new call site: the change is inside `unavailableRequiredWidgetReport`, already wired at `comfyui-mcp-panel.js:7139` with `knownSocketTypes` and `currentDef`.
- Control-byte scan 0 on both files. No `pyproject.toml` / `PANEL_VERSION` change.

## Not addressed

The reporter also noted `#659` — autogrow nodes mutate their slot list during serialization, which makes `panel_run to_node_id` refuse. Same widget family, different code path (running vs creating); that one stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)