### PR TITLE
fix(panel #686 #636): the reserved-namespace waiver must not require socket-shapedness

### DIFF
--- a/browser_tests/unit/node-widget-materialization.test.mjs
+++ b/browser_tests/unit/node-widget-materialization.test.mjs
@@ -875,14 +875,42 @@ test("#686 does NOT weaken #580: an unregistered custom widget still fails close
   );
 });
 
-test("#686 the input-level bar still applies — a COMFY_*_V3 input declaring WIDGET keys keeps waiting", () => {
-  // The waiver is namespace AND socket-shaped declaration, not namespace alone.
-  // An input that declares default/min/max is asking to carry a value, so it still
-  // needs a constructor — admitting it would be a #580 false accept.
-  const def = { input: { required: { v: [AUTOGROW, { default: 5, min: 0, max: 9 }] } } };
+test("#686 the REAL per-type config shapes are all addable (from ComfyUI's own as_dict)", () => {
+  // These are the exact config keys each family member emits in comfy_api/latest/_io.py,
+  // not an invented shape. The first version of this fix additionally required the input
+  // to be "socket-shaped", which silently excluded DynamicCombo — its `options` key is in
+  // WIDGET_VALUE_CONFIG_KEYS — and so left SaveVideo (#636) exactly as unaddable as before.
+  const REAL_SHAPES = {
+    COMFY_AUTOGROW_V3: { template: { input: ["STRING", {}], prefix: "v", min: 1, max: 10 } },
+    COMFY_DYNAMICCOMBO_V3: { options: [{ key: "auto", inputs: {} }, { key: "h264", inputs: {} }] },
+    COMFY_DYNAMICSLOT_V3: { inputs: {} },
+    COMFY_MATCHTYPE_V3: { template: {}, template_id: "t", allowed_types: ["IMAGE"] },
+    COMFY_MULTITYPED_V3: { template: {}, template_id: "t", allowed_types: ["IMAGE", "MASK"] },
+  };
+  for (const [type, config] of Object.entries(REAL_SHAPES)) {
+    const def = { input: { required: { v: [type, config] } } };
+    assert.deepEqual(
+      unavailableRequiredCustomWidgetTypes(def, REGISTERED, undefined, def),
+      [],
+      `${type} must be addable with its REAL emitted config`,
+    );
+  }
+});
+
+test("#636 SaveVideo is addable — the node the DynamicCombo gap actually blocked", () => {
+  // comfy_extras/nodes_video.py: video is a link input, codec is a DynamicCombo.
+  // VIDEO clears via knownSocketTypes (CreateVideo/LoadVideo output it); codec needs
+  // the reserved-namespace waiver. Both halves have to hold or the node stays unaddable.
+  const saveVideo = { input: { required: {
+    video: ["VIDEO", { tooltip: "The video to save." }],
+    filename_prefix: ["STRING", { default: "video/ComfyUI" }],
+    format: [["auto", "mp4", "webm"], { default: "auto" }],
+    codec: ["COMFY_DYNAMICCOMBO_V3", { options: [{ key: "auto", inputs: {} }] }],
+  } } };
+  const known = new Set(["VIDEO", "IMAGE", "LATENT"]);
   assert.deepEqual(
-    unavailableRequiredCustomWidgetTypes(def, REGISTERED, undefined, def),
-    [AUTOGROW],
+    unavailableRequiredCustomWidgetTypes(saveVideo, { STRING: () => {}, COMBO: () => {} }, known, saveVideo),
+    [],
   );
 });
 

--- a/web/js/lib/node-widget-materialization.js
+++ b/web/js/lib/node-widget-materialization.js
@@ -197,11 +197,25 @@ export function unavailableRequiredWidgetReport(
     // isCoreDynamicV3Type: it is not a link datatype (nothing outputs it, so
     // knownSocketTypes can never contain it and `linkProven` is unreachable), and it is
     // not a value widget (no constructor is ever registered for it — the frontend
-    // implements it natively). The input-level bar still applies: the declaration must
-    // itself be socket-shaped, so a COMFY_*_V3 input that declares widget-value keys is
-    // still held for its constructor. Single-member only — a union naming a dynamic
-    // declaration is not a shape ComfyUI emits, and admitting one would be guessing.
-    if (members.length === 1 && isCoreDynamicV3Type(type) && socketDeclared.has(type)) continue;
+    // implements it natively).
+    //
+    // The input-level socket-shaped bar is deliberately NOT applied here, and that is a
+    // correction to this fix's first version. `inputDeclaredAsSocket` asks whether an
+    // input declares config keys that only a widget can honour — a sound question for an
+    // ordinary datatype, and a meaningless one for this namespace, because the keys these
+    // types carry are the dynamic-io SCHEMA's own structure rather than a widget value:
+    // `template` (Autogrow, MatchType, MultiTyped), `inputs` (DynamicSlot) and — the one
+    // that broke it — `options` (DynamicCombo). `options` is in WIDGET_VALUE_CONFIG_KEYS
+    // because for a normal input it means a combo's choice list; for COMFY_DYNAMICCOMBO_V3
+    // it is the list of dynamic OPTION BRANCHES, each with its own nested inputs. Requiring
+    // socket-shapedness therefore left `SaveVideo` (whose `codec` is a DynamicCombo) exactly
+    // as unaddable as before, which is #636's first defect.
+    //
+    // #580 is still respected: this waives ONLY ComfyUI's reserved namespace, for which no
+    // widget constructor can ever appear, so there is nothing here that a retry could be
+    // waiting for. Single-member only — a union naming a dynamic declaration is not a shape
+    // ComfyUI emits, and admitting one would be guessing.
+    if (members.length === 1 && isCoreDynamicV3Type(type)) continue;
     report.push({ type, inputs, linkProven });
   }
   return report;


### PR DESCRIPTION
**Correction to #729.** That PR claimed to cover the whole `COMFY_*_V3` family and covered four of the five. `SaveVideo` is still unaddable on `main`, so #636's first defect is still live.

## What I got wrong

#729 required a core dynamic-input type to *also* declare itself socket-shaped. `inputDeclaredAsSocket` asks whether an input declares config keys only a widget can honour — a sound question for an ordinary datatype, and a meaningless one for this namespace, because the keys these types carry are the dynamic-io schema's **own structure**, not a widget value.

Read out of ComfyUI's `comfy_api/latest/_io.py`, the five `as_dict` shapes are:

| type | emitted config keys |
|---|---|
| `COMFY_AUTOGROW_V3` | `template` (with `min`/`max` nested *inside* it) |
| `COMFY_DYNAMICCOMBO_V3` | **`options`** ← collides |
| `COMFY_DYNAMICSLOT_V3` | `inputs` |
| `COMFY_MATCHTYPE_V3` | `template`, `template_id`, `allowed_types` |
| `COMFY_MULTITYPED_V3` | `template`, `template_id`, `allowed_types` |

`options` is in `WIDGET_VALUE_CONFIG_KEYS` because for a normal input it means a combo's **choice list**. For `COMFY_DYNAMICCOMBO_V3` it is the list of dynamic **option branches**, each carrying its own nested inputs. So DynamicCombo alone read as widget-declared and stayed blocked.

That is exactly the type `SaveVideo` uses for `codec` — which makes it #636's *"SaveVideo unaddable (VIDEO widget not registered)"*. Worth noting the report's title misattributes it: `VIDEO` was already fine, since `knownSocketTypes` proves it from `CreateVideo`/`LoadVideo` outputs. The `codec` input is what still refused.

## Why the tests didn't catch it

#729's family test used the autogrow `{template:{}}` shape for **all five** types. That shape is socket-shaped, so all five passed while the one type that emits a different shape stayed broken. The tests were self-consistent and not grounded in what ComfyUI actually emits.

Replaced with tests built from the real per-type config of each of the five, plus `SaveVideo` end-to-end. Both fail against the exact conjunct that shipped in #729 (mutation-verified).

## Safety unchanged

The waiver is now the reserved namespace alone. #580 is still respected: it covers only ComfyUI's own `COMFY_*_V3` prefix, for which no widget constructor can ever appear, so there is nothing a retry could be waiting for. An unregistered third-party widget, a lookalike outside the prefix (`COMFY_FAKE_V2`, `MYPACK_AUTOGROW_V3`, lowercase), and a registered constructor all behave exactly as before — those tests are untouched and still pass.

## Verification

- `npm run test:unit`: **2716 pass, 0 fail**.
- Mutation: restoring the `&& socketDeclared.has(type)` conjunct fails both new tests, and only those.
- Verified against `origin/main` (not the local working tree, which sits on an unrelated branch) that `SaveVideo` currently reports `["COMFY_DYNAMICCOMBO_V3"]` and reports `[]` with this change.
- Control-byte scan 0. No `pyproject.toml` / `PANEL_VERSION` change.

#636's other two defects (subgraph widget labels not reported; no programmatic blueprint overwrite) are untouched and that issue stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)