### PR TITLE
fix(panel #636): report slot / promoted-widget RENAMES in the manual-changes diff

### DIFF
--- a/browser_tests/unit/slot-rename-diff.test.mjs
+++ b/browser_tests/unit/slot-rename-diff.test.mjs
@@ -1,0 +1,124 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { slotRenameLines } from "../../web/js/lib/slot-rename-diff.js";
+
+/**
+ * #636 — the MANUAL CANVAS CHANGES block reported a widget VALUE change in the
+ * same edit session but said nothing about the user's slot renames, which
+ * "reinforced the wrong conclusion" that the renames hadn't stuck. They had; a
+ * screenshot was the only thing that settled it.
+ *
+ * The silence was worse than no diff at all: the value line proved the diff was
+ * running, so its omission read as evidence of absence.
+ */
+
+const NODE = '173 SubgraphNode "Save Video"';
+
+test("a promoted-widget rename is reported", () => {
+  const prev = { inputs: [{ name: "value", type: "STRING" }] };
+  const curr = { inputs: [{ name: "value", type: "STRING", label: "Filename" }] };
+  const [line, ...rest] = slotRenameLines(prev, curr, NODE);
+  assert.equal(rest.length, 0);
+  assert.match(line, /input "value" renamed \(default\) → "Filename"/);
+});
+
+test("the line keeps naming the ADDRESSABLE name, not the new label", () => {
+  // Load-bearing: a rename changes what the user sees, not what panel_set_widget
+  // and panel_connect must address. An agent that switched to "Filename" would
+  // start failing, so the line says so explicitly.
+  const prev = { inputs: [{ name: "value" }] };
+  const curr = { inputs: [{ name: "value", label: "Filename" }] };
+  assert.match(slotRenameLines(prev, curr, NODE)[0], /still addressed as "value"/);
+});
+
+test("renaming BACK to the default is reported too", () => {
+  const prev = { inputs: [{ name: "value", label: "Filename" }] };
+  const curr = { inputs: [{ name: "value" }] };
+  assert.match(slotRenameLines(prev, curr, NODE)[0], /renamed "Filename" → \(default\)/);
+});
+
+test("outputs are covered, not just inputs", () => {
+  const prev = { outputs: [{ name: "IMAGE" }] };
+  const curr = { outputs: [{ name: "IMAGE", label: "Preview" }] };
+  assert.match(slotRenameLines(prev, curr, NODE)[0], /output "IMAGE" renamed/);
+});
+
+test("the reporter's three renames all appear", () => {
+  const prev = { inputs: [{ name: "value" }, { name: "boolean" }, { name: "value_1" }] };
+  const curr = {
+    inputs: [
+      { name: "value", label: "Filename" },
+      { name: "boolean", label: "project?" },
+      { name: "value_1", label: "project" },
+    ],
+  };
+  const lines = slotRenameLines(prev, curr, NODE);
+  assert.equal(lines.length, 3);
+  for (const l of ["Filename", "project?", "project"]) {
+    assert.ok(lines.some((line) => line.includes(`→ "${l}"`)), `${l} must be reported`);
+  }
+});
+
+test("an UNCHANGED graph produces no lines — the diff must not become noise", () => {
+  const same = { inputs: [{ name: "value", label: "Filename" }], outputs: [{ name: "IMAGE" }] };
+  assert.deepEqual(slotRenameLines(same, structuredClone(same), NODE), []);
+});
+
+test("a label equal to the name is NOT a rename", () => {
+  // ComfyUI writes the label redundantly on some paths. Treating that as a change
+  // would emit a line for an edit the user never made.
+  const prev = { inputs: [{ name: "value" }] };
+  const curr = { inputs: [{ name: "value", label: "value" }] };
+  assert.deepEqual(slotRenameLines(prev, curr, NODE), []);
+});
+
+test("slots are matched by NAME, so an inserted slot does not fake renames", () => {
+  // Index-matching would shift every slot after the insertion and report each as
+  // renamed. Only the genuinely renamed one may be reported.
+  const prev = { inputs: [{ name: "a" }, { name: "b" }, { name: "c" }] };
+  const curr = { inputs: [{ name: "new" }, { name: "a" }, { name: "b", label: "Bee" }, { name: "c" }] };
+  const lines = slotRenameLines(prev, curr, NODE);
+  assert.equal(lines.length, 1);
+  assert.match(lines[0], /input "b" renamed/);
+});
+
+test("a slot that appeared or vanished is NOT reported as a rename", () => {
+  // Those are add/remove, already covered by the node and wiring lines.
+  const prev = { inputs: [{ name: "gone", label: "Old" }] };
+  const curr = { inputs: [{ name: "fresh", label: "New" }] };
+  assert.deepEqual(slotRenameLines(prev, curr, NODE), []);
+});
+
+test("missing/garbage snapshots yield no lines rather than throwing", () => {
+  for (const bad of [undefined, null, {}, { inputs: null }, { inputs: "nope" }, 42]) {
+    assert.deepEqual(slotRenameLines(bad, bad, NODE), []);
+    assert.deepEqual(slotRenameLines(bad, { inputs: [{ name: "x", label: "y" }] }, NODE), []);
+  }
+});
+
+test("unnamed slots are skipped — a rename cannot be attributed without an identity", () => {
+  const prev = { inputs: [{ type: "STRING" }] };
+  const curr = { inputs: [{ type: "STRING", label: "Something" }] };
+  assert.deepEqual(slotRenameLines(prev, curr, NODE), []);
+});
+
+// ── WIRING ────────────────────────────────────────────────────────────────
+// Everything above proves the helper is right. None of it proves it is CALLED:
+// deleting the one line in diffGraphsForAgent restores #636's silence with the
+// whole suite still green. diffGraphsForAgent is a module-private function in
+// the monolith (not exported, and the manual-changes path needs a live graph),
+// so the callable seam does not exist — pin the wiring at source.
+
+test("WIRING: diffGraphsForAgent emits the rename lines", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+
+  assert.match(src, /import \{ slotRenameLines \} from "\.\/lib\/slot-rename-diff\.js";/,
+    "the helper must be imported");
+
+  // Anchor INSIDE diffGraphsForAgent, so an occurrence elsewhere cannot satisfy this.
+  const fn = src.slice(src.indexOf("function diffGraphsForAgent"));
+  const body = fn.slice(0, fn.indexOf("\nfunction "));
+  assert.ok(body.includes("lines.push(...slotRenameLines(p, c, label(c)));"),
+    "diffGraphsForAgent must push the rename lines — without this #636's silence returns");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -183,6 +183,7 @@ import {
   outlineValueClipNote,
   clipOutlineTitle,
 } from "./lib/graph-read.js";
+import { slotRenameLines } from "./lib/slot-rename-diff.js";
 import { classifyManualChangeBaseline } from "./lib/manual-change-gate.js";
 import {
   CANVAS_TOOL_DISCLOSURE,
@@ -5940,6 +5941,11 @@ function diffGraphsForAgent(prev, curr, liveGraph) {
       lines.push(`• ${label(c)}: mode ${modeName(p.mode)} → ${modeName(c.mode)}`);
     if ((p.title || "") !== (c.title || ""))
       lines.push(`• ${id}: title "${p.title ?? ""}" → "${c.title ?? ""}"`);
+    // #636 — a slot/promoted-widget RENAME is a real user edit that the readers
+    // already surface as `label`, but this diff used to ignore, so a session that
+    // renamed a subgraph's promoted widgets saw only an unrelated widget VALUE
+    // change and read the silence as "the renames did not stick". They had.
+    lines.push(...slotRenameLines(p, c, label(c)));
     const pv = p.widgets_values, cv = c.widgets_values;
     if (JSON.stringify(pv) !== JSON.stringify(cv)) {
       if (Array.isArray(pv) && Array.isArray(cv)) {

--- a/web/js/lib/slot-rename-diff.js
+++ b/web/js/lib/slot-rename-diff.js
@@ -1,0 +1,89 @@
+/**
+ * #636 — report user RENAMES of slots and promoted subgraph widgets in the
+ * MANUAL CANVAS CHANGES block.
+ *
+ * The readers already surface a renamed slot's display `label` alongside its
+ * addressable `name`. The turn-start diff did not: it compared node add/remove,
+ * `mode`, `title`, `widgets_values` and links, and nothing else. So a session
+ * where the user renamed a subgraph's promoted widgets to `Filename` / `project?`
+ * / `project` reported only an unrelated widget VALUE change
+ * (`MiniMax_H3 -> MM3`) and said nothing about the renames — which, in the
+ * reporter's words, "reinforced the wrong conclusion" that the renames had not
+ * stuck. They had; a screenshot was the only thing that settled it.
+ *
+ * A rename is a real, intentional edit that changes what the user sees on the
+ * canvas while leaving the addressable name untouched. Reporting the value
+ * change but not the rename is the worst of both: it proves the diff was
+ * running, so its silence reads as evidence of absence.
+ *
+ * MATCHED BY NAME, NOT INDEX. `name` is the addressable identity and is exactly
+ * what a rename leaves alone; slot order is not stable across an edit that adds
+ * or removes a slot, so index-matching would report a spurious rename for every
+ * slot after an insertion.
+ */
+
+/** The display label a serialized slot carries, or null when it has none.
+ *  A label equal to the name is not a rename — ComfyUI writes the label
+ *  redundantly in some paths, and reporting that as a change would emit a line
+ *  for an edit the user never made. */
+function slotLabel(slot) {
+  if (!slot || typeof slot !== "object") return null;
+  const label = slot.label;
+  if (typeof label !== "string" || label === "") return null;
+  return label === slot.name ? null : label;
+}
+
+/** Index a serialized slot array by name. Unnamed slots are skipped: without a
+ *  stable identity a rename cannot be attributed to one. */
+function byName(slots) {
+  const out = new Map();
+  if (!Array.isArray(slots)) return out;
+  for (const slot of slots) {
+    const name = slot?.name;
+    if (typeof name !== "string" || !name) continue;
+    if (!out.has(name)) out.set(name, slot); // first wins; duplicates are ambiguous
+  }
+  return out;
+}
+
+function describe(label) {
+  return label == null ? "(default)" : `"${label}"`;
+}
+
+/**
+ * Rename lines for one node between two serialized snapshots.
+ *
+ * @param {object} prev serialized node BEFORE
+ * @param {object} curr serialized node AFTER
+ * @param {string} nodeLabel the caller's already-formatted `id type "title"` prefix
+ * @returns {string[]} zero or more `• <node>: input "name" renamed …` lines
+ *
+ * Only slots present in BOTH snapshots are compared: a slot that just appeared
+ * or vanished is an add/remove, already reported as a wiring or node change, and
+ * announcing it as a rename would be wrong.
+ */
+export function slotRenameLines(prev, curr, nodeLabel) {
+  const lines = [];
+  for (const [kind, key] of [
+    ["input", "inputs"],
+    ["output", "outputs"],
+  ]) {
+    const before = byName(prev?.[key]);
+    const after = byName(curr?.[key]);
+    for (const [name, currSlot] of after) {
+      const prevSlot = before.get(name);
+      if (!prevSlot) continue;
+      const a = slotLabel(prevSlot);
+      const b = slotLabel(currSlot);
+      if (a === b) continue;
+      // The addressable name is repeated deliberately: a rename changes what the
+      // user sees, NOT what panel_set_widget / panel_connect must address, and an
+      // agent that switches to the new label would start failing.
+      lines.push(
+        `• ${nodeLabel}: ${kind} "${name}" renamed ${describe(a)} → ${describe(b)} ` +
+          `(display only — still addressed as "${name}")`,
+      );
+    }
+  }
+  return lines;
+}


### PR DESCRIPTION
Refs #636 (its second defect; the other halves stay open)

The readers already surface a renamed slot's display `label` alongside its addressable `name` — `summarizeNode` emits it for inputs, outputs and promoted widgets, and `describeRails` for boundary slots. The turn-start **MANUAL CANVAS CHANGES** diff did not: it compared node add/remove, `mode`, `title`, `widgets_values` and links, and nothing else.

So the reporter's session — renaming a subgraph's promoted widgets to `Filename` / `project?` / `project` — reported only an unrelated widget **value** change (`MiniMax_H3 → MM3`) and said nothing about the renames. In their words that *"reinforced the wrong conclusion"*: the agent told them the renames hadn't stuck when the canvas showed they had, and only a screenshot settled it.

**The silence was worse than no diff at all.** The value line proved the diff was running, so its omission read as evidence of absence.

## Design choices worth stating

- **Matched by name, not index.** `name` is the addressable identity and is exactly what a rename leaves alone; slot order isn't stable across an edit that inserts or removes a slot, so index-matching would report a spurious rename for every slot after an insertion. There's a test for that, and mutating to index-matching fails five.
- **The line keeps naming the addressable name** (`still addressed as "value"`). A rename changes what the *user* sees, not what `panel_set_widget` / `panel_connect` must target — an agent that switched to `"Filename"` would start failing.
- **Quiet in every direction that isn't a real edit:** a label equal to the name is not a rename (ComfyUI writes it redundantly on some paths), a slot that appeared or vanished is an add/remove already reported elsewhere, unnamed slots are skipped, and malformed snapshots yield no lines rather than throwing.

Example output:

```
• 173 SubgraphNode "Save Video": input "value" renamed (default) → "Filename" (display only — still addressed as "value")
```

## Verification

- 12 tests, including the reporter's exact three-rename case and both no-op directions.
- **Three mutations**, each with a checked non-zero replacement count:
  - deleting the **call site** fails the wiring pin — `diffGraphsForAgent` is module-private in the monolith, so the wiring is pinned at source; a helper-only suite would have stayed green through the exact regression this fixes;
  - treating `label === name` as a rename fails one test;
  - matching by index instead of name fails five.
- `npm run test:unit`: **2728 pass, 0 fail**. ESM link on the new module and an ESM parse of the monolith (a duplicate top-level declaration there breaks the whole panel and `node --check` misses it). Control-byte scan 0 on all three files. No `pyproject.toml` / `PANEL_VERSION` change.

## Still open on #636

- No programmatic path to update a published blueprint (`overwrite:true` or a `graph_delete_subgraph`).
- The minor reader disagreement (instance override vs definition default) — plausibly correct data, but nothing distinguishes them in either payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)