### PR TITLE
fix(panel #699): explain a run-to-node "Prompt has no outputs" instead of passing it through

### DIFF
--- a/browser_tests/unit/queue-rejection.test.mjs
+++ b/browser_tests/unit/queue-rejection.test.mjs
@@ -175,3 +175,80 @@ test("mixed-representation ids (0 and '0') dedupe to one after normalization (#3
   const b = buildQueueAcceptResult({ batchCount: 3, promptIds: [7, "7", 8] });
   assert.deepEqual(b.prompt_ids, ["7", "8"]);
 });
+
+// ── #699: "Prompt has no outputs" on a run-to-node ────────────────────────
+//
+// panel_run({to_node_id:30}) was refused with a bare "Prompt has no outputs"
+// for a node panel_query_graph reported as is_output:true. Passing that string
+// through reads as "your output node is not an output node" and gives an agent
+// nothing to act on — the reporter's only way forward was to guess.
+//
+// The disagreement is real and lives in ComfyUI: /object_info sets output_node
+// with `OUTPUT_NODE == True` (equality) while execution.py selects outputs with
+// `OUTPUT_NODE is True` (identity). `1 == True` but `1 is not True`, so a pack
+// setting OUTPUT_NODE = 1 is advertised as an output and refused at execution.
+// The panel cannot see that in advance — the JSON is already a boolean — so the
+// only honest place to say it is after the backend has disagreed.
+
+const NO_OUTPUTS = { error: { type: "prompt_no_outputs", message: "Prompt has no outputs" } };
+
+test("#699 a run-to-node no-outputs refusal explains the disagreement", () => {
+  const r = summarizePromptRejection({
+    rejection: NO_OUTPUTS,
+    runToNode: { nodeId: 30, nodeType: "PixaromaSaveImage" },
+  });
+  assert.equal(r.queued, false);
+  assert.equal(r.error_type, "prompt_no_outputs");
+  // The backend's own words are preserved, not replaced.
+  assert.match(r.error, /Prompt has no outputs/);
+  // …and the target is named, so it is clearly not a bad node id.
+  assert.match(r.error, /node 30 \(PixaromaSaveImage\)/);
+  assert.match(r.error, /DISAGREEMENT/);
+  // Both known causes, neither asserted as the verdict.
+  assert.match(r.error, /muted or bypassed/);
+  assert.match(r.error, /EQUALS True without BEING True/);
+  // The remedy the reporter actually found working.
+  assert.match(r.error, /omit to_node_id/);
+});
+
+test("#699 a FULL run's no-outputs message is left alone", () => {
+  // Without a target, "no outputs" is simply true — the workflow has none — and
+  // appending a run-to-node explanation would be noise on a correct message.
+  const r = summarizePromptRejection({ rejection: NO_OUTPUTS });
+  assert.equal(r.error, "Prompt has no outputs");
+});
+
+test("#699 other rejection types are never annotated, even under run-to-node", () => {
+  // The hint is specific to an outputs disagreement. Attaching it to an unrelated
+  // failure would mislead in a new direction.
+  const r = summarizePromptRejection({
+    rejection: { error: { type: "missing_node_type", message: "Node 'X' not found." } },
+    runToNode: { nodeId: 30, nodeType: "PixaromaSaveImage" },
+  });
+  assert.equal(r.error, "Node 'X' not found.");
+  assert.ok(!/DISAGREEMENT/.test(r.error));
+});
+
+test("#699 an accepted prompt stays accepted with a run-to-node target", () => {
+  assert.equal(summarizePromptRejection({ rejection: null, runToNode: { nodeId: 30 } }), null);
+});
+
+test("#699 a missing node TYPE still produces a usable hint", () => {
+  const r = summarizePromptRejection({ rejection: NO_OUTPUTS, runToNode: { nodeId: "7:2" } });
+  assert.match(r.error, /node 7:2, which ComfyUI/);
+});
+
+test("WIRING: graph_run passes the run-to-node target into the summary", async () => {
+  // The tests above prove the hint is right; none prove it is REACHED. graph_run
+  // is a method on a module-private handler map in the monolith and the queue path
+  // needs a live app, so the callable seam does not exist — pin the wiring.
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  // Captured out of the resolve block…
+  assert.ok(src.includes("runToNodeInfo = { nodeId: to_node_id, nodeType: res.node?.type };"),
+    "the resolved target must be captured for the rejection summary");
+  // …and actually handed to the summary. Without this line #699 reports the bare
+  // backend string again with every test above still green.
+  assert.ok(src.includes("runToNode: runToNodeInfo,"),
+    "summarizePromptRejection must receive the run-to-node target");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -9896,6 +9896,10 @@ const GRAPH_TOOL_EXECUTORS = {
     // Stays undefined for a normal full run (byte-identical to the prior behaviour;
     // a root-level target yields String(id), the same value as before).
     let partialTargets;
+    // #699 — carried out of the resolve block so the queue-rejection summary can
+    // explain a `prompt_no_outputs` refusal of a target the panel already verified
+    // advertises output_node:true. Null for a full run.
+    let runToNodeInfo = null;
     if (to_node_id != null) {
       // Resolve the run-to-node target in the CURRENT viewing scope first (the reporter
       // added / is targeting the output node INSIDE the subgraph they are viewing —
@@ -9933,6 +9937,7 @@ const GRAPH_TOOL_EXECUTORS = {
       // Colon path for a nested node ("10:15:359") / first-level ("76:34"), or
       // String(id) at root.
       partialTargets = [res.execId];
+      runToNodeInfo = { nodeId: to_node_id, nodeType: res.node?.type };
     }
 
     // app.queuePrompt(number, batchCount, queueNodeIds | QueuePromptOptions) —
@@ -10137,6 +10142,7 @@ const GRAPH_TOOL_EXECUTORS = {
     const rejection = summarizePromptRejection({
       rejection: promptRejection,
       lastNodeErrors: app.lastNodeErrors,
+      runToNode: runToNodeInfo,
     });
     if (rejection) return rejection;
     // Surface the queued prompt_id(s) so the agent can correlate/track the run —

--- a/web/js/lib/queue-rejection.js
+++ b/web/js/lib/queue-rejection.js
@@ -27,10 +27,18 @@
  *   shape `{ error?, node_errors? }`. `null` when the POST returned 200.
  * @param {object|null} [args.lastNodeErrors]  `app.lastNodeErrors` read AFTER the
  *   queue attempt (per-node validation errors; `{}`/null when none).
+ * @param {{nodeId:(string|number), nodeType?:string}|null} [args.runToNode]  Set only
+ *   for a run-to-node partial run, naming the target the panel ALREADY verified
+ *   advertises `output_node:true`. Used to explain a `prompt_no_outputs` refusal
+ *   (#699) instead of passing the bare backend string through.
  * @returns {null | {queued:false, error?:string, error_type?:string, node_errors?:object}}
  *   `null` ⇒ accepted (report queued). Otherwise the failure to return verbatim.
  */
-export function summarizePromptRejection({ rejection = null, lastNodeErrors = null } = {}) {
+export function summarizePromptRejection({
+  rejection = null,
+  lastNodeErrors = null,
+  runToNode = null,
+} = {}) {
   const topError = rejection && typeof rejection === "object" ? rejection.error ?? null : null;
   // Prefer the node_errors carried on the rejection body itself; fall back to
   // what the frontend stored. Either is authoritative for per-node validation.
@@ -46,9 +54,68 @@ export function summarizePromptRejection({ rejection = null, lastNodeErrors = nu
     result.error = formatTopError(topError);
     const type = typeof topError === "object" && topError ? topError.type : null;
     if (type) result.error_type = String(type);
+    const hint = noOutputsHint(result.error_type, runToNode);
+    if (hint) result.error = `${result.error} ${hint}`;
   }
   if (nodeErrors) result.node_errors = nodeErrors;
   return result;
+}
+
+/**
+ * #699 — explain a `prompt_no_outputs` refusal of a run-to-node whose target the
+ * panel ALREADY verified is an output node.
+ *
+ * The reporter's contradiction was real and unexplained: `panel_query_graph` said
+ * `is_output:true` for the target, run-to-node accepted it on the same evidence,
+ * and ComfyUI then refused with "Prompt has no outputs". Passing that string
+ * through gives an agent nothing to act on — it reads as "your output node is not
+ * an output node".
+ *
+ * The two systems genuinely disagree, and ComfyUI's own source shows how. The
+ * flag the panel reads comes from `/object_info`, built in server.py with an
+ * EQUALITY test:
+ *
+ *     if hasattr(obj_class, 'OUTPUT_NODE') and obj_class.OUTPUT_NODE == True:
+ *         info['output_node'] = True
+ *
+ * while execution.py decides what counts as an output with an IDENTITY test:
+ *
+ *     if hasattr(class_, 'OUTPUT_NODE') and class_.OUTPUT_NODE is True:
+ *         if partial_execution_list is None or x in partial_execution_list:
+ *             outputs.add(x)
+ *     if len(outputs) == 0:  ->  "Prompt has no outputs"
+ *
+ * In Python `1 == True` but `1 is not True`. So a pack whose class sets
+ * `OUTPUT_NODE = 1` (or any value equal-but-not-identical to `True`, e.g. a numpy
+ * bool) is ADVERTISED as an output node and REFUSED at execution. The panel
+ * cannot detect this in advance — `/object_info` has already normalized the value
+ * to a JSON boolean by the time it arrives — so the only honest place to say it is
+ * here, after the backend has disagreed.
+ *
+ * The hint therefore states possibilities, not a verdict: the other way to get an
+ * empty output set is for the target to be absent from the submitted prompt at
+ * all (muted or bypassed nodes are dropped during serialization). Naming one cause
+ * as though it were established would be the same over-claiming this text exists to
+ * replace.
+ *
+ * Only fires for a run-to-node. A FULL run that reports no outputs means the
+ * workflow genuinely has none, which the plain message already says correctly.
+ */
+function noOutputsHint(errorType, runToNode) {
+  if (errorType !== "prompt_no_outputs" || !runToNode) return "";
+  const id = runToNode.nodeId;
+  const type = runToNode.nodeType ? ` (${runToNode.nodeType})` : "";
+  return (
+    `The panel targeted node ${id}${type}, which ComfyUI's /object_info advertises as an ` +
+    `output node — so this refusal is a DISAGREEMENT between what was advertised and what ` +
+    `the executor accepted, not a mistake in your node id. Two known causes: (1) the node is ` +
+    `muted or bypassed, so it is dropped during prompt serialization and never reaches the ` +
+    `executor; (2) the node pack sets OUTPUT_NODE to a value that EQUALS True without BEING ` +
+    `True (e.g. 1) — ComfyUI advertises output_node with an equality test but selects outputs ` +
+    `with an identity test, so such a node is listed as an output and then refused. Cause (2) ` +
+    `is a defect in the node pack and cannot be worked around from here. Either way, running ` +
+    `the FULL workflow (omit to_node_id) executes this node normally.`
+  );
 }
 
 function hasTopError(err) {


### PR DESCRIPTION
Refs #699

`panel_run({to_node_id:30})` was refused with a bare `Prompt has no outputs` — for a node `panel_query_graph` reported as `is_output:true`, and which the run-to-node path accepted on that same evidence. Passing the backend string straight through reads as *"your output node is not an output node"*, which is why the reporter's only way forward was to guess.

## The contradiction is real, and it's inside ComfyUI

The flag the panel reads comes from `/object_info`, built in `server.py` with an **equality** test:

```python
if hasattr(obj_class, 'OUTPUT_NODE') and obj_class.OUTPUT_NODE == True:
    info['output_node'] = True
```

while `execution.py` selects outputs with an **identity** test:

```python
if hasattr(class_, 'OUTPUT_NODE') and class_.OUTPUT_NODE is True:
    if partial_execution_list is None or x in partial_execution_list:
        outputs.add(x)
if len(outputs) == 0:   # -> "Prompt has no outputs"
```

In Python `1 == True` but `1 is not True`. So a pack whose class sets `OUTPUT_NODE = 1` — or any value equal-but-not-identical to `True`, such as a numpy bool — is **advertised** as an output node and **refused** at execution. That is exactly the reported shape: the panel's `is_output:true` was accurate about what ComfyUI advertised, and the executor still found no outputs.

The panel **cannot** detect this in advance: `/object_info` has already normalized the value to a JSON boolean by the time it arrives. So the only honest place to say it is after the backend has disagreed.

## What the refusal says now

ComfyUI's own words are kept, and the panel adds what it actually knows:

- it targeted a node **the backend itself advertised** as an output, so this is a disagreement rather than a bad node id;
- the two known causes — a **muted or bypassed** node is dropped during prompt serialization and never reaches the executor; or the pack's non-identical `OUTPUT_NODE` above, which is a defect in the pack and not workaroundable from here;
- the remedy the reporter found working: run the **full** workflow (omit `to_node_id`).

**Possibilities, not a verdict.** Which cause applies isn't knowable from here, and naming one as established would be the same over-claiming this text exists to replace.

A **full** run's no-outputs message is left untouched — there it is simply true, and annotating it would be noise on a correct message. Other rejection types are never annotated either.

## Verification

- 6 new tests including both negative directions (full run untouched; unrelated `missing_node_type` untouched).
- **Both mutation classes**, replacement counts checked: dropping `runToNode` from the **call site** fails the wiring pin — `graph_run` is a module-private handler and the queue path needs a live app, so a helper-only suite would have stayed green while the bare string came back; firing the hint for every error type fails the `missing_node_type` test.
- `npm run test:unit`: **2734 pass, 0 fail**. ESM link on the changed module plus an ESM parse of the monolith. Control-byte scan 0 on all three files. No `pyproject.toml` / `PANEL_VERSION` change.

## Left open

I did not change the eligibility check to pre-validate against a fresh `/object_info`, which the report suggests. It would not help: `/object_info` is the very source that advertises the node as an output, so re-reading it returns the same answer. Keeping #699 open pending confirmation of *which* cause applies on the reporter's install — the new message is designed to make that answerable from one run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)