### PR TITLE
fix(panel #690): a CREATED node property says so, and a rename conflict gives a reason

### DIFF
--- a/browser_tests/unit/workflow-rename-error.test.mjs
+++ b/browser_tests/unit/workflow-rename-error.test.mjs
@@ -1,0 +1,85 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { describeRenameFailure } from "../../web/js/lib/workflow-rename-error.js";
+
+/**
+ * #690(6) — panel_rename_workflow onto an existing name surfaced the frontend's
+ * raw transport error: `Failed to rename file 'workflows/X.json': 409 Conflict`.
+ *
+ * The refusal is correct; the message is a status, not a reason. An agent reading
+ * "409 Conflict" cannot tell a name collision (retry with a different name) from a
+ * permissions or path failure (retrying with any name fails identically).
+ */
+
+test("a 409 becomes a reason, and names the collision", () => {
+  const out = describeRenameFailure(
+    new Error("Failed to rename file 'workflows/PANEL-TEST-B.json': 409 Conflict"),
+    "PANEL-TEST",
+  );
+  assert.match(out, /a workflow named "PANEL-TEST" already exists/);
+  assert.match(out, /Nothing was changed/, "must say no partial rename happened");
+  // The original is preserved, not discarded — the status is still diagnostic.
+  assert.match(out, /409 Conflict/);
+});
+
+test("the word Conflict alone is enough (status text without the number)", () => {
+  assert.match(describeRenameFailure(new Error("Conflict"), "X"), /already exists/);
+});
+
+test("any OTHER failure keeps its original text verbatim", () => {
+  // The load-bearing negative. Inventing a friendly explanation for a status this
+  // cannot interpret replaces a true-but-terse message with a confident wrong one.
+  for (const msg of [
+    "Failed to rename file 'workflows/X.json': 403 Forbidden",
+    "Failed to rename file 'workflows/X.json': 500 Internal Server Error",
+    "NetworkError when attempting to fetch resource.",
+  ]) {
+    assert.equal(describeRenameFailure(new Error(msg), "X"), msg);
+  }
+});
+
+test("a non-Error throw still yields usable text", () => {
+  assert.equal(describeRenameFailure("boom", "X"), "boom");
+  assert.match(describeRenameFailure("409 Conflict", "X"), /already exists/);
+  assert.equal(describeRenameFailure(null, "X"), "the rename failed");
+  assert.equal(describeRenameFailure(undefined, "X"), "the rename failed");
+});
+
+test("a missing destination name degrades gracefully", () => {
+  const out = describeRenameFailure(new Error("409 Conflict"), "");
+  assert.match(out, /a workflow named that name already exists/);
+});
+
+// ── WIRING ────────────────────────────────────────────────────────────────
+// Both fixes live inside module-private handlers on the monolith's command map
+// (workflow_rename / graph_set_node_property), which need a live app + frontend
+// service to drive — so the wiring is pinned at source. Without these, both
+// regressions return with every test above still green.
+
+test("WIRING: workflow_rename routes its failure through describeRenameFailure", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.match(src, /import \{ describeRenameFailure \} from "\.\/lib\/workflow-rename-error\.js";/);
+  const fn = src.slice(src.indexOf("async workflow_rename("));
+  const body = fn.slice(0, fn.indexOf("async workflow_close("));
+  assert.ok(body.includes("throw new Error(describeRenameFailure(err, clean));"),
+    "the rename failure must be described, not rethrown raw");
+});
+
+test("WIRING: graph_set_node_property reports a CREATED property (#690(2))", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const fn = src.slice(src.indexOf("graph_set_node_property({ node_id, name, value })"));
+  const body = fn.slice(0, fn.indexOf("graph_edit_node("));
+  // Absence, not falsiness: `from === undefined` cannot distinguish "absent" from
+  // "present and undefined", and JSON drops the undefined field either way.
+  assert.ok(body.includes("Object.prototype.hasOwnProperty.call(node.properties, name)"),
+    "existence must be tested with hasOwnProperty, before the write");
+  assert.ok(body.includes("set.created = true;"),
+    "a created property must be reported — otherwise a typo reads as a successful edit");
+  // Sampled BEFORE the assignment, or it always reports existing.
+  const existsIdx = body.indexOf("hasOwnProperty.call(node.properties, name)");
+  const writeIdx = body.indexOf("node.properties[name] = value;");
+  assert.ok(existsIdx > -1 && writeIdx > -1 && existsIdx < writeIdx,
+    "existence must be sampled BEFORE the write");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -184,6 +184,7 @@ import {
   clipOutlineTitle,
 } from "./lib/graph-read.js";
 import { slotRenameLines } from "./lib/slot-rename-diff.js";
+import { describeRenameFailure } from "./lib/workflow-rename-error.js";
 import { classifyManualChangeBaseline } from "./lib/manual-change-gate.js";
 import {
   CANVAS_TOOL_DISCLOSURE,
@@ -9218,12 +9219,19 @@ const GRAPH_TOOL_EXECUTORS = {
     // key — refuse it loudly rather than silently corrupt the object (codex P1).
     if (name === "__proto__") throw new Error('property name "__proto__" is not allowed');
     let from;
+    let existed = false;
     let liveEffectError = null;
     graph.beforeChange();
     try {
       // Create the properties bag INSIDE the undo envelope so a Ctrl+Z restores the node's
       // prior "no properties bag" state, not an already-created empty one (codex P1).
       if (!node.properties || typeof node.properties !== "object") node.properties = {};
+      // #690(2) — ABSENCE, not falsiness. `from` is `undefined` for a property that
+      // never existed, and JSON drops an undefined field, so a misspelled name
+      // returned a payload with no `from` at all and read as a successful edit while
+      // creating a dead property nobody reads. hasOwnProperty distinguishes "absent"
+      // from "present and undefined", which a falsy check cannot.
+      existed = Object.prototype.hasOwnProperty.call(node.properties, name);
       from = node.properties[name];
       node.properties[name] = value;
       if (typeof node.onPropertyChanged === "function") {
@@ -9246,6 +9254,17 @@ const GRAPH_TOOL_EXECUTORS = {
     }
     graph.setDirtyCanvas(true, true);
     const set = { node_id: node.id, name, from, to: node.properties[name] };
+    // Creating a property is legitimate (LiteGraph nodes and packs both add them), so
+    // this REPORTS rather than refuses — a refusal would break every valid new-property
+    // write. But the caller must be able to tell it from an edit: a typo and a real
+    // change are otherwise the same payload.
+    if (!existed) {
+      set.created = true;
+      set.note =
+        `"${name}" did not exist on this node and was CREATED (no previous value). If you ` +
+        `meant to change an existing property, check the spelling against panel_query_graph — ` +
+        `a mistyped name creates a new property that nothing reads.`;
+    }
     return liveEffectError ? { set, live_effect_error: liveEffectError } : { set };
   },
 
@@ -11483,7 +11502,14 @@ const GRAPH_TOOL_EXECUTORS = {
     const clean = name.replace(/\.json$/i, "");
     const slash = target.path ? target.path.lastIndexOf("/") : -1;
     const dir = slash >= 0 ? target.path.slice(0, slash + 1) : "workflows/";
-    await s.renameWorkflow(target, `${dir}${clean}.json`);
+    try {
+      await s.renameWorkflow(target, `${dir}${clean}.json`);
+    } catch (err) {
+      // #690(6) — a raw "409 Conflict" is a status, not a reason. See
+      // describeRenameFailure: only an unambiguous conflict is rewritten, every other
+      // failure keeps its original text.
+      throw new Error(describeRenameFailure(err, clean));
+    }
     return { renamed: { to: `${clean}.json` } };
   },
 

--- a/web/js/lib/workflow-rename-error.js
+++ b/web/js/lib/workflow-rename-error.js
@@ -1,0 +1,39 @@
+/**
+ * #690(6) — say what a failed rename actually means.
+ *
+ * `panel_rename_workflow` onto an existing name surfaced the frontend's raw
+ * transport error:
+ *
+ *     Failed to rename file 'workflows/PANEL-TEST-B.json': 409 Conflict
+ *
+ * The refusal is CORRECT — a rename must not clobber another workflow — but an
+ * HTTP status is not a reason. An agent reading "409 Conflict" cannot tell a name
+ * collision (retry with a different name) from a permissions or path problem
+ * (retrying with any name will fail the same way), so it either guesses or gives
+ * up on a condition the user can fix in one step.
+ *
+ * Only the CONFLICT case is rewritten, and only when the status is unambiguous.
+ * Every other failure keeps its original text: inventing a friendly explanation
+ * for a status this cannot interpret would replace a true-but-terse message with
+ * a confident wrong one, which is worse.
+ */
+
+/** A 409 from the userdata move endpoint means the destination already exists. */
+const CONFLICT_RE = /\b409\b|\bconflict\b/i;
+
+/**
+ * @param {unknown} err       the error thrown by the frontend's renameWorkflow
+ * @param {string}  toName    the destination basename (no directory, no .json)
+ * @returns {string} the message to surface
+ */
+export function describeRenameFailure(err, toName) {
+  const raw = err instanceof Error ? err.message : typeof err === "string" ? err : "";
+  const text = raw || "the rename failed";
+  if (!CONFLICT_RE.test(text)) return text;
+  const named = typeof toName === "string" && toName ? `"${toName}"` : "that name";
+  return (
+    `a workflow named ${named} already exists — rename is refused rather than overwriting it. ` +
+    `Pick a different name, or close/delete the existing one first. ` +
+    `Nothing was changed. (${text})`
+  );
+}


### PR DESCRIPTION
Refs #690 — defects **(2)** and **(6)** of six. Both are the same class: a real side effect or a correct refusal, reported in a form the caller can't act on.

## (2) `panel_set_property` silently created a property

`from = node.properties[name]` is `undefined` for an absent property, and JSON drops an undefined field — so a misspelled name returned a payload with **no `from` at all**, indistinguishable from a successful edit, while writing a dead property nothing reads. The reporter found it by passing an HTML-escaped `S&amp;R` and getting the same shape as the real `Node name for S&R` edit.

Existence is now tested with `hasOwnProperty` **before** the write. That's the only test that separates *absent* from *present and undefined*; a falsy check cannot, and that conflation is the whole bug.

Creation is **reported, not refused** (`created:true` plus a note pointing at the spelling). LiteGraph nodes and packs both add properties legitimately, so refusing would break every valid new-property write in order to catch a typo — trading a silent success for a false refusal.

## (6) `panel_rename_workflow` leaked a raw 409

The refusal is correct — a rename must not clobber another workflow — but `409 Conflict` is a status, not a reason. An agent can't tell a name collision (retry with a different name) from a permissions or path failure (retrying with *any* name fails identically), so it guesses.

Now: a workflow of that name already exists, **nothing was changed**, and what to do — with the original text appended rather than discarded, since the status is still diagnostic.

**Only an unambiguous conflict is rewritten.** Every other failure keeps its text verbatim; there's a test asserting 403 / 500 / network errors pass through untouched. Inventing a friendly explanation for a status this can't interpret would replace a true-but-terse message with a confident wrong one.

## Verification

- 7 tests. Both negative directions covered: non-conflict failures unchanged, and non-Error throws still yielding usable text.
- **Four mutations**, each with a checked replacement count:
  - dropping `set.created` → fails;
  - sampling existence **after** the write (which would always report "existing") → fails;
  - rethrowing the rename error raw → fails;
  - rewriting **every** failure as a conflict → fails 2.
- Both handlers are module-private on the monolith's command map and need a live app to drive, so the wiring is pinned at source — **including the before-the-write ordering**, which a value-only assertion wouldn't catch.
- `npm run test:unit`: **2741 pass, 0 fail**. ESM link + monolith ESM parse. Control-byte scan 0. No `pyproject.toml` / `PANEL_VERSION` change.

## Not in this PR

- **(1)** the connection drop on `new_workflow`/`open_workflow` — the critical one. It's transport/lifecycle and overlaps the reconnect cluster (#607/#688/#689/#702), whose root cause I fixed separately in comfyui-mcp#976 (an untrusted hello was *erasing* the tab's command stamp). Worth re-testing after that ships before diagnosing further.
- **(3)** `expose_subgraph_output` dropping `name` on reuse — a docs-vs-behaviour decision (honour it, or document it) rather than a defect; `reused:true` is already honest.
- **(4)** the slice error not listing available groups, and whether `SaveVideo` is in the recognized output set — worth doing, and bigger than these two.
- **(5)** `list_subgraphs` / `flatten_workflow` token bounding.

Also noted from the report: the `panel_civitai_search` filters observation is now fixed separately (#728) — the sort was being sent correctly and CivitAI ignores it for keyword searches, which the receipt now says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)