### PR TITLE
fix(panel #690(5)): bound panel_list_subgraphs, VISIBLY

### DIFF
--- a/browser_tests/unit/subgraph-list-bound.test.mjs
+++ b/browser_tests/unit/subgraph-list-bound.test.mjs
@@ -1,0 +1,140 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  boundSubgraphList,
+  normalizeSubgraphLimit,
+  SUBGRAPH_LIST_DEFAULT_LIMIT,
+} from "../../web/js/lib/subgraph-list-bound.js";
+
+/**
+ * #690(5) — panel_list_subgraphs returned all 90 bundled blueprints with full
+ * descriptions in one response, while every other panel read tool is explicitly
+ * token-bounded.
+ *
+ * The risk in fixing it is creating a worse bug: a tool that quietly returns 25 of
+ * 90 is a silent omission, and an agent that concludes a blueprint doesn't exist
+ * rebuilds it by hand. So most of these tests are about the bound being VISIBLE.
+ */
+
+const lib = (n, prefix = "bp") =>
+  Array.from({ length: n }, (_, i) => ({
+    name: `${prefix}${i}`,
+    type: `SubgraphBlueprint.${prefix}${i}`,
+    display_name: `Blueprint ${i}`,
+    description: `desc ${i}`,
+    is_global: i % 2 === 0,
+  }));
+
+test("a small library returns whole, with no truncation fields at all", () => {
+  const out = boundSubgraphList(lib(5));
+  assert.equal(out.count, 5);
+  assert.equal(out.blueprints.length, 5);
+  assert.equal(out.truncated, undefined, "must not claim truncation that did not happen");
+  assert.equal(out.note, undefined);
+  assert.equal(out.matched, undefined, "no filter ⇒ no matched field");
+});
+
+test("count stays the LIBRARY TOTAL when truncated — never the returned length", () => {
+  // The load-bearing property. If count shrank to the page size, a caller could not
+  // tell a bounded list from a complete one.
+  const out = boundSubgraphList(lib(90));
+  assert.equal(out.count, 90);
+  assert.equal(out.blueprints.length, SUBGRAPH_LIST_DEFAULT_LIMIT);
+  assert.equal(out.returned, SUBGRAPH_LIST_DEFAULT_LIMIT);
+  assert.equal(out.truncated, true);
+});
+
+test("the truncation note says entries were withheld and how to reach them", () => {
+  const out = boundSubgraphList(lib(90));
+  assert.match(out.note, /Showing 40 of 90/);
+  assert.match(out.note, /do not conclude a blueprint is absent/i);
+  assert.match(out.note, /filter/);
+  assert.match(out.note, /limit/);
+});
+
+test("a filter narrows and reports `matched` distinctly from `count`", () => {
+  // "3 of 90 matched" must be distinguishable from "the library has 3".
+  const out = boundSubgraphList([...lib(50), ...lib(3, "video")], { filter: "video" });
+  assert.equal(out.count, 53, "count is the whole library");
+  assert.equal(out.matched, 3, "matched is what the filter selected");
+  assert.equal(out.blueprints.length, 3);
+  assert.equal(out.truncated, undefined, "everything matching fit — nothing withheld");
+});
+
+test("the filter searches display name and description, not just name", () => {
+  const bps = [
+    { name: "a", display_name: "Upscale Chain", description: "x" },
+    { name: "b", display_name: "y", description: "does an upscale pass" },
+    { name: "c", display_name: "y", description: "unrelated" },
+  ];
+  assert.equal(boundSubgraphList(bps, { filter: "upscale" }).matched, 2);
+});
+
+test("filtering is case-insensitive and trims", () => {
+  const bps = [{ name: "Video_Gen", display_name: null, description: null }];
+  assert.equal(boundSubgraphList(bps, { filter: "  VIDEO  " }).matched, 1);
+});
+
+test("a filter that matches nothing says so honestly — 0 matched of a non-empty library", () => {
+  const out = boundSubgraphList(lib(10), { filter: "zzz-nothing" });
+  assert.equal(out.count, 10);
+  assert.equal(out.matched, 0);
+  assert.deepEqual(out.blueprints, []);
+  assert.equal(out.truncated, undefined, "nothing was withheld — the filter simply missed");
+});
+
+test("long descriptions clip, but name and type never do", () => {
+  // name/type are what panel_add_subgraph needs to act; the prose is not.
+  const long = "x".repeat(500);
+  const [bp] = boundSubgraphList([
+    { name: "keep-me-exactly", type: "SubgraphBlueprint.keep-me-exactly", description: long },
+  ]).blueprints;
+  assert.equal(bp.name, "keep-me-exactly");
+  assert.equal(bp.type, "SubgraphBlueprint.keep-me-exactly");
+  assert.ok(bp.description.length < 250);
+  assert.match(bp.description, /…$/);
+});
+
+test("an explicit limit is honoured and still reports truncation", () => {
+  const out = boundSubgraphList(lib(90), { limit: 5 });
+  assert.equal(out.blueprints.length, 5);
+  assert.equal(out.truncated, true);
+  assert.match(out.note, /Showing 5 of 90/);
+});
+
+test("a garbage limit falls back to the default rather than returning nothing", () => {
+  // A caller fumbling the parameter must not get an empty library that reads as
+  // "you have no blueprints".
+  for (const bad of [0, -3, NaN, "abc", null, undefined, {}]) {
+    assert.equal(normalizeSubgraphLimit(bad), SUBGRAPH_LIST_DEFAULT_LIMIT, `limit ${String(bad)}`);
+  }
+  assert.equal(boundSubgraphList(lib(50), { limit: 0 }).blueprints.length, SUBGRAPH_LIST_DEFAULT_LIMIT);
+});
+
+test("a huge limit is capped, and a fractional one floors", () => {
+  assert.equal(normalizeSubgraphLimit(1e9), 500);
+  assert.equal(normalizeSubgraphLimit(7.9), 7);
+});
+
+test("an empty or malformed library yields an honest empty result", () => {
+  for (const bad of [[], null, undefined, "nope", 42]) {
+    const out = boundSubgraphList(bad);
+    assert.equal(out.count, 0);
+    assert.deepEqual(out.blueprints, []);
+    assert.equal(out.truncated, undefined);
+  }
+});
+
+// ── WIRING ────────────────────────────────────────────────────────────────
+test("WIRING: graph_list_subgraphs returns the bounded shape and accepts the params", async () => {
+  // graph_list_subgraphs is a module-private handler needing a live subgraph store,
+  // so the wiring is pinned at source. Without this, deleting the call restores the
+  // unbounded dump with every test above still green.
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.match(src, /import \{ boundSubgraphList \} from "\.\/lib\/subgraph-list-bound\.js";/);
+  assert.ok(src.includes("graph_list_subgraphs({ filter, limit } = {}) {"),
+    "the handler must accept filter/limit — a defaulted destructure keeps a no-arg call working");
+  assert.ok(src.includes("return boundSubgraphList(blueprints, { filter, limit });"),
+    "the list must go through the bound — otherwise the unbounded dump returns");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -185,6 +185,7 @@ import {
 } from "./lib/graph-read.js";
 import { slotRenameLines } from "./lib/slot-rename-diff.js";
 import { describeRenameFailure } from "./lib/workflow-rename-error.js";
+import { boundSubgraphList } from "./lib/subgraph-list-bound.js";
 import { classifyManualChangeBaseline } from "./lib/manual-change-gate.js";
 import {
   CANVAS_TOOL_DISCLOSURE,
@@ -12089,7 +12090,7 @@ const GRAPH_TOOL_EXECUTORS = {
 
   // List saved subgraph blueprints. Each is addable via graph_add_subgraph(name)
   // or graph_add_node(type). Read-only.
-  graph_list_subgraphs() {
+  graph_list_subgraphs({ filter, limit } = {}) {
     const store = getSubgraphStore();
     const prefix = store.typePrefix ?? "SubgraphBlueprint.";
     const defs = store.subgraphBlueprints ?? [];
@@ -12103,7 +12104,10 @@ const GRAPH_TOOL_EXECUTORS = {
         is_global: d?.isGlobal === true,
       };
     });
-    return { count: blueprints.length, blueprints };
+    // #690(5) — bounded like every other panel read. `count` stays the LIBRARY
+    // TOTAL and truncation is explicit, so a bounded list can never be misread as
+    // "that blueprint does not exist" (see boundSubgraphList).
+    return boundSubgraphList(blueprints, { filter, limit });
   },
 
   // Add a saved subgraph blueprint to the current graph by name (or full type).

--- a/web/js/lib/subgraph-list-bound.js
+++ b/web/js/lib/subgraph-list-bound.js
@@ -1,0 +1,84 @@
+/**
+ * #690(5) — bound `panel_list_subgraphs`.
+ *
+ * Every other panel read tool is explicitly token-bounded (query_graph,
+ * graph_outline, find_nodes). This one was not: an install with the bundled
+ * global blueprints returned all 90 entries with full display names and
+ * descriptions in a single response.
+ *
+ * BOUNDING A READ CAN CREATE A WORSE BUG THAN IT FIXES, and that shapes the whole
+ * design here. A tool that quietly returns 25 of 90 is a silent-omission defect —
+ * an agent concludes a blueprint does not exist and rebuilds it by hand, which is
+ * exactly the class of "reads as success" failure the rest of this codebase keeps
+ * removing. So:
+ *
+ *   • `count` keeps its existing meaning — the TOTAL in the library — and never
+ *     shrinks to the number returned. A caller comparing count to the array length
+ *     can always see the difference.
+ *   • `truncated` is only ever `true` when entries were actually withheld, and it
+ *     comes with the exact number and how to reach them.
+ *   • filtering reports `matched` separately from `count`, so "3 of 90 matched" is
+ *     distinguishable from "the library only has 3".
+ *
+ * The default limit is generous on purpose: this is a library of user-authored
+ * blueprints, not an unbounded graph, and most installs have few enough that
+ * nothing is ever withheld.
+ */
+
+/** Big enough that a typical library returns whole, small enough that the bundled
+ *  global set cannot dominate a context window. */
+export const SUBGRAPH_LIST_DEFAULT_LIMIT = 40;
+const MAX_LIMIT = 500;
+/** Descriptions are free-form and can be paragraphs; the name/type are what a
+ *  caller needs to act (panel_add_subgraph takes them), so only the prose clips. */
+const DESCRIPTION_CLIP = 200;
+
+function clip(text, max = DESCRIPTION_CLIP) {
+  if (typeof text !== "string") return text ?? null;
+  return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}
+
+/** Coerce a caller-supplied limit into range. A non-number, NaN or <= 0 falls back
+ *  to the default rather than returning nothing — a caller fumbling the parameter
+ *  should not get an empty library that reads as "you have no blueprints". */
+export function normalizeSubgraphLimit(limit) {
+  const n = Number(limit);
+  if (!Number.isFinite(n) || n <= 0) return SUBGRAPH_LIST_DEFAULT_LIMIT;
+  return Math.min(Math.floor(n), MAX_LIMIT);
+}
+
+/** Case-insensitive substring over the fields a caller would search by. */
+function matchesFilter(bp, needle) {
+  if (!needle) return true;
+  const hay = `${bp?.name ?? ""}\n${bp?.display_name ?? ""}\n${bp?.description ?? ""}`;
+  return hay.toLowerCase().includes(needle);
+}
+
+/**
+ * @param {Array<object>} blueprints  every blueprint in the library
+ * @param {{filter?: string, limit?: number}} [opts]
+ * @returns {{count:number, blueprints:Array<object>, matched?:number,
+ *            returned?:number, truncated?:true, note?:string}}
+ *   `count` is ALWAYS the library total. `matched` appears only when a filter was
+ *   applied. `truncated`/`note` appear only when entries were actually withheld.
+ */
+export function boundSubgraphList(blueprints, { filter, limit } = {}) {
+  const all = Array.isArray(blueprints) ? blueprints : [];
+  const needle = typeof filter === "string" && filter.trim() ? filter.trim().toLowerCase() : "";
+  const matched = needle ? all.filter((bp) => matchesFilter(bp, needle)) : all;
+  const cap = normalizeSubgraphLimit(limit);
+  const shown = matched.slice(0, cap).map((bp) => ({ ...bp, description: clip(bp?.description) }));
+
+  const out = { count: all.length, blueprints: shown };
+  if (needle) out.matched = matched.length;
+  if (matched.length > shown.length) {
+    out.returned = shown.length;
+    out.truncated = true;
+    out.note =
+      `Showing ${shown.length} of ${matched.length}${needle ? " matching" : ""} blueprint(s)` +
+      `${needle ? "" : ` (library total ${all.length})`}. ` +
+      `The rest were NOT returned — do not conclude a blueprint is absent from this list. ` +
+      `Narrow with \`filter\` (matches name, display name and description) or raise \`limit\`.`;
+  }
+  return out;
+}


### PR DESCRIPTION
Refs #690 — defect **(5)**, the `panel_list_subgraphs` half.

Every other panel read tool is explicitly token-bounded (`query_graph`, `graph_outline`, `find_nodes`). This one wasn't: an install with the bundled global blueprints returned all 90 entries with full display names and descriptions in a single response.

## The bound is designed to be impossible to miss

Fixing this naively creates a worse bug. A tool that quietly returns 40 of 90 is a **silent omission** — an agent concludes a blueprint doesn't exist and rebuilds it by hand, which is the reads-as-success class this codebase keeps removing. So:

- **`count` keeps its existing meaning** — the library total — and never shrinks to the returned length, so comparing it to the array always reveals the difference.
- **`truncated` is true only when entries were actually withheld**, with the exact numbers and how to reach the rest ("do not conclude a blueprint is absent from this list").
- **A filter reports `matched` separately from `count`**, so *"3 of 90 matched"* is distinguishable from *"the library only has 3"*.
- **A filter that matches nothing** reports `matched:0` against a non-empty `count`, rather than an empty list that reads as an empty library.

Only **descriptions** clip — `name`/`type` are what `panel_add_subgraph` needs to act, so they're never truncated. A garbage `limit` falls back to the default rather than returning nothing, since a caller fumbling the parameter must not get an empty library.

The handler destructures with a default (`{ filter, limit } = {}`), so the current orchestrator — which sends no arguments — keeps working and simply gets the default bound. The matching `filter`/`limit` parameters go in a follow-up on the mcp side; either order is safe.

## Verification

- 13 tests, weighted toward the bound being visible rather than merely present.
- **Four mutations**, replacement counts checked: restoring the unbounded return fails the wiring pin; making `count` the returned length fails 3; claiming truncation unconditionally fails 4; returning nothing for a bad limit fails 6.
- `npm run test:unit`: **2754 pass, 0 fail**. ESM link + monolith ESM parse. Control-byte scan 0. No `pyproject.toml` / `PANEL_VERSION` change.

The `flatten_workflow` half of (5) — a summary-only mode — is not in this PR; #690 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)