### PR TITLE
fix(panel #694): a uuid re-mint must not split one canvas's conversations

### DIFF
--- a/browser_tests/unit/thread-workflow-match.test.mjs
+++ b/browser_tests/unit/thread-workflow-match.test.mjs
@@ -1,0 +1,114 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { threadMatchesCurrentWorkflow } from "../../web/js/lib/thread-workflow-match.js";
+
+/**
+ * #694 — "Current workflow only" showed 1 of 2 conversations created on the same
+ * unsaved canvas.
+ *
+ * The uuid a thread is stamped with can be RE-MINTED between two records on an
+ * unsaved draft (resolveUnsavedInstanceUuid fails closed rather than adopt a
+ * copyable embedded uuid, #570). The live-object route id does not change across
+ * that re-mint, so it is the stable half.
+ *
+ * The risk in this fix is the opposite of the bug: matching too loosely attaches
+ * ANOTHER workflow's conversation to this one. Several tests below exist only to
+ * hold that line.
+ */
+
+const keys = (...k) => new Set(k);
+
+test("the reporter's case: two threads, different uuids, same live canvas — both match", () => {
+  const current = keys("workflow:uuid-B", "tmp:live-object-1");
+  const older = { workflowKey: "workflow:uuid-A", workflowRouteKey: "tmp:live-object-1" };
+  const newer = { workflowKey: "workflow:uuid-B", workflowRouteKey: "tmp:live-object-1" };
+  assert.equal(threadMatchesCurrentWorkflow(older, current), true, "the re-minted one must not vanish");
+  assert.equal(threadMatchesCurrentWorkflow(newer, current), true);
+});
+
+test("the durable uuid alone still matches — the primary key is unchanged", () => {
+  // Every thread written before this change has no route key. It must keep working
+  // exactly as it does today, including after a reload when the WeakMap is gone.
+  const current = keys("workflow:uuid-A", "tmp:live-object-9");
+  assert.equal(threadMatchesCurrentWorkflow({ workflowKey: "workflow:uuid-A" }, current), true);
+});
+
+test("a DIFFERENT workflow does not match on either key", () => {
+  const current = keys("workflow:uuid-B", "tmp:live-object-1");
+  const foreign = { workflowKey: "workflow:uuid-Z", workflowRouteKey: "tmp:live-object-2" };
+  assert.equal(threadMatchesCurrentWorkflow(foreign, current), false);
+});
+
+test("a foreign thread whose UUID was re-minted still does not match", () => {
+  // The dangerous shape: a stale uuid plus a route id from another live object.
+  // Neither half may admit it — this is the #570 cross-attribution this must not
+  // reintroduce.
+  const current = keys("workflow:uuid-B", "tmp:live-object-1");
+  assert.equal(
+    threadMatchesCurrentWorkflow({ workflowKey: "workflow:uuid-OLD", workflowRouteKey: "tmp:other" }, current),
+    false,
+  );
+});
+
+test("an EMPTY or missing route key never matches by accident", () => {
+  // A set that happens to contain "" (a degenerate workflowTabId) must not turn
+  // every unstamped thread into a match.
+  const degenerate = keys("workflow:uuid-B", "");
+  for (const route of ["", null, undefined]) {
+    assert.equal(
+      threadMatchesCurrentWorkflow({ workflowKey: "workflow:OTHER", workflowRouteKey: route }, degenerate),
+      false,
+      `route ${JSON.stringify(route)} must not match`,
+    );
+  }
+});
+
+test("an empty storage key never matches by accident either", () => {
+  const degenerate = keys("", "tmp:live-1");
+  assert.equal(threadMatchesCurrentWorkflow({ workflowKey: "" }, degenerate), false);
+  assert.equal(threadMatchesCurrentWorkflow({ workflowKey: null }, degenerate), false);
+});
+
+test("a non-string key is not coerced into a match", () => {
+  const current = keys("workflow:uuid-B", "tmp:live-1");
+  assert.equal(threadMatchesCurrentWorkflow({ workflowKey: 0 }, current), false);
+  assert.equal(threadMatchesCurrentWorkflow({ workflowRouteKey: {} }, current), false);
+});
+
+test("saved workflows match on the shared path handle, as they already did", () => {
+  // workflowTabId() for a SAVED workflow is the path handle, which two tabs on the
+  // same file legitimately share — and which the filter set already accepted before
+  // this change. Not a regression, and not a new authority.
+  const current = keys("workflow:uuid-S", "wf:workflows/A.json");
+  assert.equal(
+    threadMatchesCurrentWorkflow({ workflowKey: "workflow:older", workflowRouteKey: "wf:workflows/A.json" }, current),
+    true,
+  );
+});
+
+test("malformed inputs return false rather than throwing", () => {
+  for (const bad of [null, undefined, 42, "x", {}]) {
+    assert.equal(threadMatchesCurrentWorkflow(bad, keys("a")), false);
+  }
+  for (const badSet of [null, undefined, [], {}, "nope"]) {
+    assert.equal(threadMatchesCurrentWorkflow({ workflowKey: "a" }, badSet), false);
+  }
+});
+
+// ── WIRING ────────────────────────────────────────────────────────────────
+test("WIRING: threads are STAMPED with the route key and the picker matches on it", async () => {
+  // The helper being right proves nothing about it being reached. Both halves have
+  // to hold: without the stamp there is nothing to match, and without the matcher
+  // the stamp is never read. Both live in module-private code needing a live panel,
+  // so they are pinned at source.
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+
+  assert.match(src, /import \{ threadMatchesCurrentWorkflow \} from "\.\/lib\/thread-workflow-match\.js";/);
+  // Stamped at thread creation AND on the revise that follows it.
+  const stamps = src.match(/workflowRouteKey: workflowTabId\(\),/g) ?? [];
+  assert.ok(stamps.length >= 2, `expected the route stamp at creation and revise, saw ${stamps.length}`);
+  // And actually consulted by the "Current workflow only" filter.
+  assert.ok(src.includes("threadMatchesCurrentWorkflow(candidate, currentWorkflowKeys)"),
+    "the picker must use the matcher — otherwise #694's under-report returns");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -186,6 +186,7 @@ import {
 import { slotRenameLines } from "./lib/slot-rename-diff.js";
 import { describeRenameFailure } from "./lib/workflow-rename-error.js";
 import { boundSubgraphList } from "./lib/subgraph-list-bound.js";
+import { threadMatchesCurrentWorkflow } from "./lib/thread-workflow-match.js";
 import { classifyManualChangeBaseline } from "./lib/manual-change-gate.js";
 import {
   CANVAS_TOOL_DISCLOSURE,
@@ -19687,6 +19688,10 @@ function buildPanel() {
         ts: now,
         msgs: [],
         workflowKey,
+        // #694 — the ROUTE stamp. Secondary to workflowKey (which is durable across a
+        // reload); this one is stable across an unsaved workflow's uuid RE-MINT, which is
+        // what made two conversations on one canvas look like two workflows.
+        workflowRouteKey: workflowTabId(),
         workflowTitle: getWorkflowTitle(),
         provider: connectedBackend || selectedBackend,
         model: prefs.model || orchestratorCurrentModel || pickDefaultModel(modelCatalog),
@@ -19695,6 +19700,7 @@ function buildPanel() {
       };
       historyStore.reviseThread(thread, {
         workflowKey,
+        workflowRouteKey: workflowTabId(),
         workflowTitle: getWorkflowTitle(),
         provider: connectedBackend || selectedBackend,
         model: prefs.model || orchestratorCurrentModel || pickDefaultModel(modelCatalog),
@@ -21431,7 +21437,7 @@ function buildPanel() {
       const currentWorkflowKeys = new Set([workflowStorageKey(), workflowTabId()]);
       const visible = threads
         .filter((candidate) =>
-          !currentOnly.checked || currentWorkflowKeys.has(candidate.workflowKey))
+          !currentOnly.checked || threadMatchesCurrentWorkflow(candidate, currentWorkflowKeys))
         .filter((candidate) => {
           if (!q) return true;
           const haystack = [

--- a/web/js/lib/thread-workflow-match.js
+++ b/web/js/lib/thread-workflow-match.js
@@ -1,0 +1,50 @@
+/**
+ * #694 — "Current workflow only" under-reported: two conversations created on the
+ * same unsaved canvas, one row shown.
+ *
+ * Threads are stamped with the STORAGE key, `workflow:<stable uuid>`. On an unsaved
+ * draft that uuid can be RE-MINTED between two records: `resolveUnsavedInstanceUuid`
+ * fails CLOSED and mints a fresh uuid whenever the creation-boundary sanitizer is not
+ * provably installed, because the embedded `graph.extra` uuid is copyable and adopting
+ * it could cross-resume a different workflow's conversation (#570). Lost resume, never
+ * wrong resume — correct, and it means two threads on one canvas can legitimately
+ * carry different storage keys.
+ *
+ * THE STABLE IDENTIFIER ALREADY EXISTS. `workflowTabId()` for an unsaved workflow is
+ * `_tempWorkflowInstanceIds.get(wf)` — keyed on the live workflow OBJECT and stable for
+ * that object's lifetime (deliberately: a churning tmp: id would drive a re-hello
+ * storm). A uuid re-mint does not change it. So a second, route-level stamp makes the
+ * two threads recognizably the same workflow WITHOUT inferring lineage — which matters,
+ * because guessing lineage wrong attaches another workflow's conversation to this one,
+ * the exact failure the re-mint exists to prevent.
+ *
+ * SECONDARY, NEVER PRIMARY. `_tempWorkflowInstanceIds` is an in-memory WeakMap that does
+ * not survive a reload, so a thread stamped ONLY with a route key would lose its match
+ * entirely after a refresh — trading an under-report for a worse one. The durable uuid
+ * stays the primary key; this only ADDS a way to match.
+ *
+ * Safe by construction, on the same authority the identity resolver already trusts:
+ * a tmp: route id is per-live-object and a copy never shares the object, and a saved
+ * route handle is the file path, which two tabs on the same file legitimately share —
+ * and which the filter set already accepted before this change.
+ */
+
+/**
+ * Does `thread` belong to the workflow whose current identity forms are `currentKeys`?
+ *
+ * @param {{workflowKey?: string, workflowRouteKey?: string}} thread
+ * @param {Set<string>} currentKeys  the live workflow's storage key AND route id
+ * @returns {boolean}
+ */
+export function threadMatchesCurrentWorkflow(thread, currentKeys) {
+  if (!thread || !currentKeys || typeof currentKeys.has !== "function") return false;
+  // The durable key first — it is what survives a reload and what every existing
+  // thread already carries.
+  const storage = thread.workflowKey;
+  if (typeof storage === "string" && storage && currentKeys.has(storage)) return true;
+  // Then the route stamp, which survives a uuid re-mint within a session. Absent on
+  // every thread written before this change, so an old thread simply falls back to
+  // the behaviour it has today rather than mismatching.
+  const route = thread.workflowRouteKey;
+  return typeof route === "string" && route !== "" && currentKeys.has(route);
+}


### PR DESCRIPTION
Closes #694

"Current workflow only" showed **1 of 2** conversations created on the same unsaved canvas.

## Cause

Threads are stamped with the storage key, `workflow:<stable uuid>`. On an unsaved draft that uuid can be **re-minted** between two records: `resolveUnsavedInstanceUuid` fails *closed* and mints fresh whenever the creation-boundary sanitizer isn't provably installed, because the embedded `graph.extra` uuid is copyable and adopting it could cross-resume a different workflow's conversation (#570). Lost resume, never wrong resume — that's correct, and it means two threads on one canvas can legitimately carry different storage keys.

## The stable identifier already existed

`workflowTabId()` for an unsaved workflow is `_tempWorkflowInstanceIds.get(wf)` — keyed on the live workflow **object** and stable for that object's lifetime (deliberately: a churning tmp: id would drive a re-hello storm). **A uuid re-mint doesn't change it.**

So threads now carry it as a second stamp and the picker matches either key. **No lineage is inferred**, which is the whole point — guessing lineage wrong attaches another workflow's conversation to this one, the exact failure the re-mint exists to prevent. The route id is per-live-object and a copy never shares the object: the same authority that already makes `objectUuid` outrank the embedded uuid.

## Constraints held

- **Secondary, never primary.** `_tempWorkflowInstanceIds` is an in-memory WeakMap that doesn't survive a reload, so a thread stamped *only* with a route key would lose its match after a refresh — trading this under-report for a worse one. The durable uuid stays primary, and a thread written before this change (no route key) behaves exactly as today.
- **Only the live-object id qualifies.** Nothing copyable is matched on.
- For a **saved** workflow the route id is the path handle, which two tabs on one file legitimately share — and which the filter set already accepted before this change, so it's not a new authority.

## Verification

- 10 tests. Several exist purely to hold the line against the *opposite* bug — a foreign thread with a stale uuid **and** a different route id must not match; an empty/missing key must never match by accident; non-strings aren't coerced.
- **Four mutations**, replacement counts checked: the picker ignoring the matcher (restores #694), dropping the stamp so there's nothing to match, matching an empty route key (the cross-attribution direction), and ignoring the durable uuid. Each fails a named test.
- The wiring pin covers **both halves** — without the stamp there's nothing to match, without the matcher the stamp is never read — since both live in module-private code needing a live panel.
- `npm run test:unit`: **2764 pass, 0 fail**. ESM link + monolith ESM parse. Control-byte scan 0. No `pyproject.toml` / `PANEL_VERSION` change.

Reporter classified this cosmetic-to-confusing with no data loss, and that matches: the change only ever makes a thread *visible* under the filter, never reassigns one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)