### PR TITLE
fix(panel #636): say which subgraph value is the DEFINITION's and which is the instance's

### DIFF
--- a/browser_tests/unit/subgraph-value-provenance.test.mjs
+++ b/browser_tests/unit/subgraph-value-provenance.test.mjs
@@ -1,0 +1,92 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { subgraphValueProvenance } from "../../web/js/lib/subgraph-value-provenance.js";
+
+/**
+ * #636 (minor) — panel_get_subgraph(173) reported inner node 166 value "MiniMax_H3"
+ * while panel_query_graph(ids:[173]) reported the parent instance value "MM3". Both
+ * correct, describing different things, with nothing in either payload saying so —
+ * so the difference read as stale data.
+ *
+ * That is the costly failure: an agent "fixes" a value that was never wrong, or
+ * re-reads in a loop waiting for two numbers to agree that never will and should not.
+ */
+
+test("the reporter's case: instance values ride alongside, labelled", () => {
+  const node = { id: 173, widgets: [{ name: "value", value: "MM3" }] };
+  const out = subgraphValueProvenance(node);
+  assert.deepEqual(out.instance_widgets, { value: "MM3" });
+  assert.match(out.values_note, /belong to the subgraph DEFINITION/);
+  assert.match(out.values_note, /node 173/);
+});
+
+test("the note names the override as INTENTIONAL, not stale", () => {
+  // The load-bearing sentence. Without it the payload still shows two values and
+  // leaves the reader to guess which is wrong — the original failure.
+  const out = subgraphValueProvenance({ id: 5, widgets: [{ name: "a", value: 1 }] });
+  assert.match(out.values_note, /intentional per-instance override/i);
+  assert.match(out.values_note, /NOT stale/);
+  assert.match(out.values_note, /do not "correct" it/i);
+});
+
+test("a subgraph with NO promoted widgets gets no block at all", () => {
+  // Nothing can diverge, so a note would be noise on every parameterless subgraph.
+  for (const node of [{ id: 1 }, { id: 1, widgets: [] }, { id: 1, widgets: null }]) {
+    assert.deepEqual(subgraphValueProvenance(node), {});
+  }
+});
+
+test("unnamed widgets are skipped rather than keyed on undefined", () => {
+  const out = subgraphValueProvenance({
+    id: 2,
+    widgets: [{ value: "no-name" }, { name: "", value: "empty" }, { name: "real", value: 7 }],
+  });
+  assert.deepEqual(out.instance_widgets, { real: 7 });
+});
+
+test("falsy and empty instance values are reported, not dropped", () => {
+  // 0 / "" / false are real widget values. Dropping them would recreate the ambiguity
+  // in the other direction — a caller could not tell "set to 0" from "not promoted".
+  const out = subgraphValueProvenance({
+    id: 3,
+    widgets: [
+      { name: "zero", value: 0 },
+      { name: "empty", value: "" },
+      { name: "off", value: false },
+      { name: "nul", value: null },
+    ],
+  });
+  assert.deepEqual(out.instance_widgets, { zero: 0, empty: "", off: false, nul: null });
+});
+
+test("a malformed node yields no block rather than throwing", () => {
+  for (const bad of [null, undefined, {}, 42, "x", { widgets: "nope" }]) {
+    assert.deepEqual(subgraphValueProvenance(bad), {});
+  }
+});
+
+test("no promotion-to-inner-widget PAIRING is asserted", () => {
+  // The mapping is not reliably recoverable across frontend versions, and a wrong
+  // pairing would state a false override relationship — worse than the ambiguity
+  // being fixed. The payload reports names as they are and lets the caller compare.
+  const out = subgraphValueProvenance({ id: 9, widgets: [{ name: "value", value: "MM3" }] });
+  assert.equal(out.instance_widgets.value, "MM3");
+  assert.ok(!("overrides" in out), "must not claim which inner widget this feeds");
+  assert.ok(!("mapping" in out));
+});
+
+// ── WIRING ────────────────────────────────────────────────────────────────
+test("WIRING: graph_get_subgraph spreads the provenance block", async () => {
+  // graph_get_subgraph is a module-private handler needing a live graph, so the
+  // wiring is pinned at source. Without the spread, both values are still returned
+  // by the two tools with nothing explaining the difference — #636's minor item.
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.match(src, /import \{ subgraphValueProvenance \} from "\.\/lib\/subgraph-value-provenance\.js";/);
+  const fn = src.slice(src.indexOf("graph_get_subgraph({ node_id }) {"));
+  const body = fn.slice(0, fn.indexOf("async graph_add_node("));
+  assert.ok(body.includes("...subgraphValueProvenance(node),"),
+    "the reply must carry the provenance block");
+  // It must describe the PARENT instance, not one of the inner nodes.
+  assert.ok(body.includes("subgraphValueProvenance(node)"), "must be passed the parent node");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -187,6 +187,7 @@ import { slotRenameLines } from "./lib/slot-rename-diff.js";
 import { describeRenameFailure } from "./lib/workflow-rename-error.js";
 import { boundSubgraphList } from "./lib/subgraph-list-bound.js";
 import { threadMatchesCurrentWorkflow } from "./lib/thread-workflow-match.js";
+import { subgraphValueProvenance } from "./lib/subgraph-value-provenance.js";
 import { classifyManualChangeBaseline } from "./lib/manual-change-gate.js";
 import {
   CANVAS_TOOL_DISCLOSURE,
@@ -8380,6 +8381,10 @@ const GRAPH_TOOL_EXECUTORS = {
     const inner = [...(sub._nodes ?? sub.nodes ?? [])];
     return {
       subgraph_of: { node_id: node.id, title: node.title },
+      // #636 — the inner nodes below are the DEFINITION's; the parent instance's
+      // promoted widgets can override them. Carry both, labelled, so a legitimate
+      // per-instance override cannot be misread as stale data.
+      ...subgraphValueProvenance(node),
       node_count: inner.length,
       truncated: inner.length > MAX_STATE_NODES,
       ...(inner.length > MAX_STATE_NODES

--- a/web/js/lib/subgraph-value-provenance.js
+++ b/web/js/lib/subgraph-value-provenance.js
@@ -1,0 +1,61 @@
+/**
+ * #636 (the "minor" item) — two readers disagreed about a widget value with nothing
+ * in either payload to explain it.
+ *
+ * `panel_get_subgraph(173)` reported inner node 166 `value: "MiniMax_H3"` while
+ * `panel_query_graph(ids:[173])` reported the parent instance `value: "MM3"`. Both
+ * were correct and they describe different things:
+ *
+ *   • the inner nodes belong to the subgraph DEFINITION, and their widget values are
+ *     the values stored in that definition;
+ *   • the parent subgraph NODE carries the promoted widgets, whose values are this
+ *     instance's — and an instance override is exactly how a reusable subgraph is
+ *     meant to be parameterized.
+ *
+ * With no provenance on either side the difference reads as stale data, which is the
+ * costly failure: an agent "fixes" a value that was never wrong, or re-reads in a
+ * loop looking for the two to agree. They never will, and they should not.
+ *
+ * So `graph_get_subgraph` now carries the parent instance's promoted widget values
+ * ALONGSIDE the definition's, and says which is which. One call, both facts, no
+ * inference.
+ *
+ * NO GUESS ABOUT WHICH INNER WIDGET A PROMOTION FEEDS. The promotion mapping is not
+ * reliably recoverable from the live objects across frontend versions, and a wrong
+ * pairing would state a false override relationship — worse than the ambiguity being
+ * fixed. Names are reported as they are; the caller compares them.
+ */
+
+/** Widget name → value for a node, skipping anything unnamed. Values are copied out
+ *  by reference only (they are already plain widget values); no clipping happens here
+ *  because the caller's existing summary caps already govern payload size. */
+function widgetValues(node) {
+  const out = {};
+  for (const w of node?.widgets ?? []) {
+    if (w && typeof w.name === "string" && w.name) out[w.name] = w.value;
+  }
+  return out;
+}
+
+/**
+ * The instance-vs-definition provenance block for a `graph_get_subgraph` reply.
+ *
+ * @param {object} node the PARENT subgraph node (the instance)
+ * @returns {{instance_widgets?: object, values_note?: string}}
+ *   Empty when the instance promotes no widgets — there is then nothing that could
+ *   diverge, and a note would be noise on every subgraph that has no parameters.
+ */
+export function subgraphValueProvenance(node) {
+  const instance = widgetValues(node);
+  if (!Object.keys(instance).length) return {};
+  return {
+    instance_widgets: instance,
+    values_note:
+      `The widget values on the inner nodes below belong to the subgraph DEFINITION. ` +
+      `\`instance_widgets\` above are this instance's PROMOTED widget values (node ` +
+      `${node?.id}), which is what the graph actually runs with where a promotion exists. ` +
+      `A difference between the two is an intentional per-instance override, NOT stale ` +
+      `data — do not "correct" it. panel_query_graph on this node reports the same ` +
+      `instance values.`,
+  };
+}


### PR DESCRIPTION
Refs #636 — the "minor" item, which turned out to be the last panel-side one in that report.

`panel_get_subgraph(173)` reported inner node 166 `value: "MiniMax_H3"` while `panel_query_graph(ids:[173])` reported the parent instance `value: "MM3"`. Both correct, describing different things — the inner nodes belong to the subgraph **definition**, the parent node carries the **promoted** widgets whose values are this instance's — but nothing in either payload said so, so the difference read as stale data.

That ambiguity is the expensive part: an agent "corrects" a value that was never wrong, or re-reads in a loop waiting for two numbers to agree that never will and never should. A per-instance override is how a reusable subgraph is *meant* to be parameterized.

`graph_get_subgraph` now carries the instance's promoted widget values alongside the definition's, labels both, and says the difference is an intentional override rather than staleness. One call, both facts.

## Judgement calls

- **No pairing is asserted** between a promoted widget and the inner widget it feeds. That mapping isn't reliably recoverable from the live objects across frontend versions, and a wrong pairing would state a false override relationship — worse than the ambiguity being fixed. Names are reported as they are; the caller compares them. There's a test asserting no `overrides`/`mapping` field appears.
- **Falsy values are reported, not dropped.** `0` / `""` / `false` / `null` are real widget values; dropping them recreates the ambiguity in the other direction, where a caller can't tell "set to 0" from "not promoted".
- **A subgraph that promotes nothing gets no block at all** — nothing can diverge, so a note would be noise on every parameterless subgraph.

## Verification

- 8 tests including the reporter's exact case and the three negatives above.
- **Three mutations**, replacement counts checked: dropping the call-site spread fails the wiring pin; filtering falsy values fails the falsy test; emitting the note with no promoted widgets fails two.
- `npm run test:unit`: **2772 pass, 0 fail**. ESM link + monolith ESM parse. Control-byte scan 0. No `pyproject.toml` / `PANEL_VERSION` change.

With this, #636's panel-side items are all addressed: **(1)** SaveVideo addable, **(2)** labels + rename diff, **(minor)** this. **(3)** — programmatic blueprint overwrite — is upstream-gated; I posted the evidence separately (ComfyUI's own `deleteBlueprint` also awaits a confirmation dialog and returns silently when declined, so a `graph_delete_subgraph` built on it would be a false-success tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)