### PR TITLE
fix(panel #697): a node the READS listed must say WHERE it is when a write can't find it

### DIFF
--- a/browser_tests/unit/node-scope-locator.test.mjs
+++ b/browser_tests/unit/node-scope-locator.test.mjs
@@ -1,0 +1,145 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  locateNodeAcrossScopes,
+  countSubgraphs,
+  describeMissingNode,
+} from "../../web/js/lib/node-scope-locator.js";
+
+/**
+ * #697 — "No node with id 105 in the current graph", right after graph_outline AND
+ * query_graph had both reported node 105 on the active workflow.
+ *
+ * Nothing was stale. Reads walk every scope; a write applies to the graph being
+ * VIEWED. The old message named neither scope, so a scope mismatch looked like a
+ * routing/session bug — the reporter's workaround (re-target, re-read, retry) worked
+ * only because it reset the viewing scope.
+ */
+
+const node = (id, extra = {}) => ({ id, ...extra });
+const sub = (nodes) => ({ _nodes: nodes });
+
+test("finds a node nested inside a subgraph and reports the route", () => {
+  const root = sub([node(1), node(9, { title: "Video", subgraph: sub([node(104), node(105)]) })]);
+  const hit = locateNodeAcrossScopes(root, 105);
+  assert.equal(hit.scope, "subgraph");
+  assert.deepEqual(hit.hostPath, [{ id: 9, title: "Video" }]);
+});
+
+test("finds a root node with an empty host path", () => {
+  const root = sub([node(1), node(2)]);
+  assert.deepEqual(locateNodeAcrossScopes(root, 2), { scope: "root", hostPath: [] });
+});
+
+test("prefers the CURRENT level over a same-id node deeper in", () => {
+  // Load-bearing: ids are only unique within a graph, so a nested node can share an
+  // id with a root node. Reporting the deep one would send the caller into a
+  // subgraph they never needed to enter.
+  const root = sub([node(5), node(9, { title: "S", subgraph: sub([node(5)]) })]);
+  assert.deepEqual(locateNodeAcrossScopes(root, 5).hostPath, []);
+});
+
+test("walks more than one level deep", () => {
+  const inner = sub([node(77)]);
+  const mid = sub([node(50), node(60, { title: "Inner", subgraph: inner })]);
+  const root = sub([node(9, { title: "Outer", subgraph: mid })]);
+  const hit = locateNodeAcrossScopes(root, 77);
+  assert.deepEqual(hit.hostPath.map((h) => h.title), ["Outer", "Inner"]);
+});
+
+test("returns null for an id that is nowhere", () => {
+  assert.equal(locateNodeAcrossScopes(sub([node(1)]), 999), null);
+});
+
+test("a shared subgraph instance cannot loop the walk", () => {
+  // The same subgraph object instanced twice must be visited once, not forever.
+  const shared = sub([node(42)]);
+  const root = sub([node(1, { subgraph: shared }), node(2, { subgraph: shared })]);
+  assert.equal(locateNodeAcrossScopes(root, 42).scope, "subgraph");
+  assert.equal(countSubgraphs(root), 2);
+});
+
+test("a self-referencing graph terminates instead of hanging", () => {
+  const loop = { _nodes: [] };
+  loop._nodes.push({ id: 1, subgraph: loop });
+  assert.equal(locateNodeAcrossScopes(loop, 999), null);
+  assert.ok(Number.isFinite(countSubgraphs(loop)));
+});
+
+test("a DEEP acyclic chain is bounded — `seen` never fires when every level is distinct", () => {
+  // The hazard MAX_DEPTH exists for, and the one `seen` cannot catch: 400 distinct
+  // graph objects, no repetition. Without the depth bound this recurses the whole
+  // chain (and, on a pathological graph, past the stack).
+  let deepest = { _nodes: [{ id: 999 }] };
+  for (let i = 0; i < 400; i++) deepest = { _nodes: [{ id: i, subgraph: deepest }] };
+  // The target sits below MAX_DEPTH, so a bounded search must NOT find it.
+  assert.equal(locateNodeAcrossScopes(deepest, 999), null, "the search must stop before the bottom");
+  // …while a node inside the bound is still found, so the guard is a ceiling and
+  // not a blanket refusal.
+  assert.ok(locateNodeAcrossScopes(deepest, 398), "shallow nodes stay reachable");
+});
+
+test("malformed graphs never throw — a diagnostic must not fail", () => {
+  for (const bad of [null, undefined, 42, "x", {}, { _nodes: "nope" }]) {
+    assert.doesNotThrow(() => locateNodeAcrossScopes(bad, 1));
+    assert.equal(locateNodeAcrossScopes(bad, 1), null);
+  }
+  assert.equal(locateNodeAcrossScopes(sub([node(1)]), "not-a-number"), null);
+});
+
+// ── the message ───────────────────────────────────────────────────────────
+
+test("keeps the historic prefix so existing matchers still work", () => {
+  for (const root of [null, sub([node(1)])]) {
+    assert.match(describeMissingNode(105, root, true), /^No node with id 105/);
+  }
+});
+
+test("the reporter's case: names the subgraph, the host node, and the remedy", () => {
+  const root = sub([node(9, { title: "MiniMax", subgraph: sub([node(104), node(105)]) })]);
+  const msg = describeMissingNode(105, root, true);
+  assert.match(msg, /lives INSIDE a subgraph/);
+  assert.match(msg, /"MiniMax" \(node 9\)/);
+  assert.match(msg, /panel_enter_subgraph\(9\)/);
+  // Explains WHY the reads disagreed — the thing that made it look like staleness.
+  assert.match(msg, /Reads such as panel_graph_outline span every scope/);
+  // And refuses to overclaim which instance.
+  assert.match(msg, /not necessarily the only one/);
+});
+
+test("a root node while viewing a subgraph tells you to EXIT", () => {
+  const root = sub([node(7)]);
+  const msg = describeMissingNode(7, root, false);
+  assert.match(msg, /on the ROOT graph/);
+  assert.match(msg, /panel_exit_subgraph/);
+});
+
+test("a genuine miss says how hard it looked, and does not invent a location", () => {
+  const root = sub([node(1), node(9, { subgraph: sub([node(2)]) })]);
+  const msg = describeMissingNode(999, root, true);
+  assert.match(msg, /not in any other scope either/);
+  assert.match(msg, /1 subgraph\(s\)/);
+  assert.ok(!/panel_enter_subgraph/.test(msg), "must not suggest entering anything");
+});
+
+test("no root graph ⇒ the original message, unchanged", () => {
+  assert.equal(describeMissingNode(5, null, true), "No node with id 5 in the current graph");
+});
+
+// ── WIRING ────────────────────────────────────────────────────────────────
+test("WIRING: resolveNode builds its error through describeMissingNode", async () => {
+  // resolveNode is module-private and shared by 20+ handlers, so the wiring is pinned
+  // at source. Without it every one of them reverts to the bare message.
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  assert.match(src, /import \{ describeMissingNode \} from "\.\/lib\/node-scope-locator\.js";/);
+  const fn = src.slice(src.indexOf("function resolveNode(graph, nodeId) {"));
+  const body = fn.slice(0, fn.indexOf("function normalizeLegacyNodeId"));
+  assert.ok(body.includes("describeMissingNode(nodeId, rootGraph, viewingRoot)"),
+    "the failure path must go through the locator");
+  // The lookup itself must be unchanged — this is diagnostics only, never a wider search.
+  assert.ok(body.includes("graph.getNodeById(Number(nodeId))"),
+    "resolution must still be scoped to the current graph");
+  // And the diagnostic must not be able to break the call.
+  assert.ok(body.includes("} catch {"), "reading the root must be guarded");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -188,6 +188,7 @@ import { describeRenameFailure } from "./lib/workflow-rename-error.js";
 import { boundSubgraphList } from "./lib/subgraph-list-bound.js";
 import { threadMatchesCurrentWorkflow } from "./lib/thread-workflow-match.js";
 import { subgraphValueProvenance } from "./lib/subgraph-value-provenance.js";
+import { describeMissingNode } from "./lib/node-scope-locator.js";
 import { classifyManualChangeBaseline } from "./lib/manual-change-gate.js";
 import {
   CANVAS_TOOL_DISCLOSURE,
@@ -6743,7 +6744,22 @@ function nodeDescription(node) {
 
 function resolveNode(graph, nodeId) {
   const node = graph.getNodeById(Number(nodeId));
-  if (!node) throw new Error(`No node with id ${nodeId} in the current graph`);
+  // #697 — a node the READS just listed can be unresolvable here: reads span every
+  // scope, while a write applies to the graph being VIEWED. Say WHERE it actually is
+  // instead of only that it is not here. Diagnostic-only: runs on the failure path,
+  // never throws, and degrades to the original message when the root is unreadable.
+  if (!node) {
+    let rootGraph = null;
+    let viewingRoot = true;
+    try {
+      const ctx = getGraphCtx();
+      rootGraph = ctx.rootGraph ?? null;
+      viewingRoot = ctx.graph === rootGraph;
+    } catch {
+      rootGraph = null;
+    }
+    throw new Error(describeMissingNode(nodeId, rootGraph, viewingRoot));
+  }
   return node;
 }
 

--- a/web/js/lib/node-scope-locator.js
+++ b/web/js/lib/node-scope-locator.js
@@ -1,0 +1,154 @@
+/**
+ * #697 — "No node with id 105 in the current graph", immediately after
+ * panel_graph_outline AND panel_query_graph had both reported node 105 on the
+ * active workflow.
+ *
+ * Nothing was stale. The reads and the write ask different questions:
+ *
+ *   • the READS walk the root graph AND its nested subgraphs, so they report a
+ *     node wherever it lives;
+ *   • `resolveNode` calls `graph.getNodeById()` on the CURRENT graph only — and
+ *     `getGraphCtx().graph` is the graph being VIEWED, which is a subgraph while
+ *     you are inside one.
+ *
+ * So a node a read just listed is genuinely unresolvable for a write whenever the
+ * two scopes differ, and the old message said only that it was not "in the current
+ * graph" — true, and useless, because it named neither the scope the caller was in
+ * nor the scope the node was in. The reporter's own workaround (re-target, re-read,
+ * retry) worked because it reset the viewing scope, which is also why it looked like
+ * a routing/session bug rather than a scope mismatch.
+ *
+ * This module answers the question the failure raises: WHERE is it, then?
+ *
+ * SEARCH IS BOUNDED AND NON-THROWING. It runs only on the failure path, and any
+ * unexpected shape simply ends that branch — a diagnostic that throws would replace a
+ * bad error with a worse one.
+ *
+ * `MAX_DEPTH` IS THE SAFETY PROPERTY; `seen` IS AN OPTIMIZATION. Worth stating because
+ * the reverse is the natural assumption. `MAX_DEPTH` bounds the one case nothing else
+ * does — an unbounded ACYCLIC chain, where every level is a distinct object and `seen`
+ * never fires — and it is pinned by its own test. `seen` only stops a subgraph
+ * definition instanced N times from being searched N times; with the depth bound in
+ * place a self-referencing graph already terminates without it, so deleting `seen`
+ * correctly breaks no test. Do not "fix" that by adding one: it would assert an
+ * invariant this code does not depend on.
+ *
+ * NO CLAIM IS MADE ABOUT WHICH INSTANCE. A subgraph definition can be instanced
+ * several times; the first host found is reported as *a* route to the node, not as
+ * the only one, because picking one and calling it "the" location would be a guess
+ * with a plausible-looking shape.
+ */
+
+/** Depth guard for a pathological/looping graph. Real workflows nest a handful deep. */
+const MAX_DEPTH = 12;
+
+function nodesOf(graph) {
+  const raw = graph?._nodes ?? graph?.nodes;
+  return Array.isArray(raw) ? raw : [];
+}
+
+/**
+ * Find a node by its LOCAL id anywhere in the workflow, reporting the route to it.
+ *
+ * @param {object} rootGraph the workflow's root graph
+ * @param {number|string} nodeId the local id being looked up
+ * @returns {null | {scope: "root"|"subgraph", hostPath: Array<{id: any, title: string}>}}
+ *   `hostPath` is the chain of subgraph HOST nodes to enter, outermost first; empty
+ *   for a node on the root graph.
+ */
+export function locateNodeAcrossScopes(rootGraph, nodeId) {
+  const target = Number(nodeId);
+  if (!Number.isFinite(target)) return null;
+  const seen = new Set();
+
+  const walk = (graph, hostPath, depth) => {
+    if (!graph || depth > MAX_DEPTH || seen.has(graph)) return null;
+    seen.add(graph);
+    for (const n of nodesOf(graph)) {
+      if (Number(n?.id) === target) {
+        return { scope: hostPath.length ? "subgraph" : "root", hostPath };
+      }
+    }
+    // Depth-first into each subgraph host. Done AFTER the flat scan so a node in the
+    // current level is always preferred over a same-id node deeper in.
+    for (const n of nodesOf(graph)) {
+      if (!n?.subgraph) continue;
+      const hit = walk(n.subgraph, [...hostPath, { id: n.id, title: n.title || n.type || "subgraph" }], depth + 1);
+      if (hit) return hit;
+    }
+    return null;
+  };
+
+  try {
+    return walk(rootGraph, [], 0);
+  } catch {
+    return null; // a diagnostic must never throw
+  }
+}
+
+/** Count the subgraphs searched, so a genuine miss can say how hard it looked. */
+export function countSubgraphs(rootGraph) {
+  const seen = new Set();
+  let n = 0;
+  const walk = (graph, depth) => {
+    if (!graph || depth > MAX_DEPTH || seen.has(graph)) return;
+    seen.add(graph);
+    for (const node of nodesOf(graph)) {
+      if (!node?.subgraph) continue;
+      n++;
+      walk(node.subgraph, depth + 1);
+    }
+  };
+  try {
+    walk(rootGraph, 0);
+  } catch {
+    /* best effort */
+  }
+  return n;
+}
+
+/**
+ * The message for a node id that did not resolve in the current graph.
+ *
+ * Always begins `No node with id <id>` so existing callers/tests that match that
+ * prefix are unaffected.
+ *
+ * @param {number|string} nodeId
+ * @param {object|null} rootGraph  null/absent ⇒ the plain message, unchanged
+ * @param {boolean} viewingRoot    true when the current graph IS the root
+ */
+export function describeMissingNode(nodeId, rootGraph, viewingRoot) {
+  const base = `No node with id ${nodeId} in the current graph`;
+  if (!rootGraph) return base;
+
+  const found = locateNodeAcrossScopes(rootGraph, nodeId);
+  if (!found) {
+    const subs = countSubgraphs(rootGraph);
+    return (
+      `${base} — and it is not in any other scope either ` +
+      `(searched the root graph${subs ? ` and ${subs} subgraph(s)` : ""}). ` +
+      `The id may be from a different workflow, or the node was removed. ` +
+      `Re-read with panel_graph_outline before retrying.`
+    );
+  }
+
+  if (found.scope === "root") {
+    // Only reachable while viewing a subgraph, so the remedy is to leave it.
+    return (
+      `${base}. Node ${nodeId} is on the ROOT graph, but you are currently inside a ` +
+      `subgraph — the write applies to the graph you are VIEWING, not the whole ` +
+      `workflow. Call panel_exit_subgraph, then retry. (Reads such as ` +
+      `panel_graph_outline span every scope, which is why they listed it.)`
+    );
+  }
+
+  const route = found.hostPath.map((h) => `"${h.title}" (node ${h.id})`).join(" → ");
+  const enter = found.hostPath.map((h) => `panel_enter_subgraph(${h.id})`).join(", then ");
+  return (
+    `${base}. Node ${nodeId} lives INSIDE a subgraph — ${route}${viewingRoot ? "" : ", from the root"} — ` +
+    `and the write applies to the graph you are VIEWING, not the whole workflow. ` +
+    `Enter it (${enter}), then retry. (Reads such as panel_graph_outline span every ` +
+    `scope, which is why they listed it.) A subgraph can be instanced more than once; ` +
+    `this is one route to that node, not necessarily the only one.`
+  );
+}


### PR DESCRIPTION
Closes #697

`panel_set_widget` returned `No node with id 105 in the current graph` **immediately after** `panel_graph_outline` and `panel_query_graph` had both reported node 105 on the active workflow.

## Not stale routing — a scope mismatch

The reads and the write ask different questions:

- the **reads** walk the root graph *and* its nested subgraphs, so they report a node wherever it lives;
- `resolveNode` calls `graph.getNodeById()` on the **current** graph only — and `getGraphCtx().graph` is the graph being **viewed**, which is a subgraph while you're inside one.

Node 105 was a subgraph node (its edit "promotes to inner node 104"). So a node a read just listed is genuinely unresolvable for a write whenever the scopes differ, and the message named neither the caller's scope nor the node's. The reporter's workaround — re-target, re-read, retry — worked because it **reset the viewing scope**, which is precisely why it looked like stale routing/session state.

## What the failure says now

It searches the whole workflow and answers "where is it, then?":

- **inside a subgraph** → names the host chain and the `panel_enter_subgraph(N)` calls to get there;
- **on the root while you're in a subgraph** → says to `panel_exit_subgraph`;
- **genuinely absent** → says how many scopes were searched and invents no location.

It also explains *why* the reads disagreed, since that contradiction is the confusing part.

**Diagnostics only.** Resolution stays scoped to the current graph — this widens no write. The search runs on the failure path, is bounded, and cannot throw; a diagnostic that throws replaces a bad error with a worse one. All 20+ `resolveNode` callers inherit the better message, and the historic `No node with id N` prefix is preserved so existing matchers keep working.

It also declines to overclaim: a subgraph definition can be instanced more than once, so the route is reported as *a* way to reach the node, not the only one.

## Two mutation findings, both of which corrected me

- **Removing the `seen` set killed zero tests — and that's correct.** `MAX_DEPTH` is the safety property; it bounds an unbounded *acyclic* chain where every level is a distinct object and `seen` never fires. `seen` only stops a subgraph instanced N times being searched N times. My first comment claimed `seen` prevented cycling; it doesn't, and the comment now says so rather than my inventing a test to prop up a false invariant.
- **Removing `MAX_DEPTH` also killed zero tests** — that one *was* a real gap, since nothing exercised a deep acyclic chain. Added a 400-level test; removing `MAX_DEPTH` now fails it.

I went back and forth on which guard did what before checking properly. The comment now states the version the mutations actually support.

## Verification

- 15 tests, including same-id-at-two-depths (must prefer the current level, or the caller is sent into a subgraph they never needed), self-loop, shared instance, malformed graphs, and the genuine-miss path.
- Call-site mutation (revert to the bare message) fails the wiring pin.
- `npm run test:unit`: **2787 pass, 0 fail**. ESM link + monolith ESM parse. Control-byte scan 0. No `pyproject.toml` / `PANEL_VERSION` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)