### PR TITLE
fix(panel #698): make the DOM-widget refusal a ROUTE, not just a diagnosis

### DIFF
--- a/browser_tests/unit/dom-widget-diagnosis.test.mjs
+++ b/browser_tests/unit/dom-widget-diagnosis.test.mjs
@@ -60,3 +60,83 @@ test("the diagnosis is a suffix — it never replaces the observed wrote/became 
   assert.ok(d.startsWith(" "), "must append cleanly after the observed-facts sentence");
   assert.ok(!/did not retain/.test(d), "must not restate the observation");
 });
+
+// ── #698: the refusal must be a ROUTE, not just a diagnosis ───────────────
+//
+// The message already said the real value lives on the node ("commonly
+// node.properties") and that retrying will not help. What the reporter still had
+// nothing to act on was WHICH properties this node has, or which tool writes them —
+// they worked around it with a different node type instead.
+//
+// PixaromaPrompt keeps its prompt in `properties.promptState.text`, reachable with
+// panel_set_property. So the refusal now names the properties that exist.
+
+const domWidget = { name: "pix_prompt_ui", element: {}, options: {} };
+
+test("#698 names the node's actual properties and the tool that writes them", () => {
+  const node = { id: 44, properties: { promptState: { text: "" }, mode: "a" } };
+  const msg = describeNonValueBearingWidget(domWidget, node);
+  assert.match(msg, /"promptState"/);
+  assert.match(msg, /"mode"/);
+  assert.match(msg, /panel_set_property/);
+  assert.match(msg, /panel_query_graph/);
+});
+
+test("#698 refuses to say WHICH property backs the widget", () => {
+  // Load-bearing. A heuristic pairing would eventually point an agent at an
+  // unrelated property and have it overwrite real node state — a destructive wrong
+  // answer in place of an honest dead end.
+  const node = { id: 44, properties: { promptState: { text: "" } } };
+  const msg = describeNonValueBearingWidget(domWidget, node);
+  // The exact clause, not a substring of it: changing "WHICH property" to "The first
+  // property" leaves "cannot be determined from here" intact while inverting the claim.
+  assert.match(msg, /WHICH property backs this widget cannot be determined from here/);
+  assert.ok(!/first property/i.test(msg), "must not point at a specific property");
+  assert.match(msg, /verify against the canvas/i);
+});
+
+test("#698 the structural diagnosis survives — this is additive", () => {
+  const msg = describeNonValueBearingWidget(domWidget, { id: 1, properties: { a: 1 } });
+  assert.match(msg, /DOM-backed display widget/);
+  assert.match(msg, /Retrying will not help/);
+});
+
+test("#698 a node with NO properties adds nothing — no empty route", () => {
+  for (const node of [undefined, null, { id: 1 }, { id: 1, properties: {} }, { id: 1, properties: [] }]) {
+    const msg = describeNonValueBearingWidget(domWidget, node);
+    assert.match(msg, /DOM-backed display widget/, "the structural half still fires");
+    assert.ok(!/panel_set_property/.test(msg), `must not offer a route for ${JSON.stringify(node)}`);
+  }
+});
+
+test("#698 a healthy value widget still gets NOTHING, node or no node", () => {
+  // The #715 line: serialize:false is normal on working widgets, so this must never
+  // become a pre-emptive verdict.
+  const node = { id: 2, properties: { anything: 1 } };
+  assert.equal(describeNonValueBearingWidget({ name: "seed", value: 5 }, node), "");
+  assert.equal(describeNonValueBearingWidget({ name: "t", value: "", options: {} }, node), "");
+});
+
+test("#698 a property-heavy node is capped but reports the true count", () => {
+  const properties = Object.fromEntries(Array.from({ length: 30 }, (_, i) => [`p${i}`, i]));
+  const msg = describeNonValueBearingWidget(domWidget, { id: 3, properties });
+  assert.match(msg, /30 properties/);
+  assert.match(msg, /… and 18 more/);
+  assert.ok(!/"p29"/.test(msg));
+});
+
+// ── WIRING ────────────────────────────────────────────────────────────────
+test("WIRING: the failure branch passes the NODE, or the route can never appear", async () => {
+  // Every test above calls the helper directly, so dropping `targetNode` at the call
+  // site leaves them all green while the property names silently vanish from the real
+  // message. widget-write's failure path needs a live graph to drive, so pin it here.
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile(new URL("../../web/js/lib/widget-write.js", import.meta.url), "utf8");
+  assert.ok(src.includes("describeNonValueBearingWidget(w, targetNode);"),
+    "the observed-revert branch must pass the node");
+  // And it must stay in the OBSERVED-failure branch — never a pre-emptive gate (#715).
+  const idx = src.indexOf("describeNonValueBearingWidget(w, targetNode);");
+  const before = src.slice(Math.max(0, idx - 1200), idx);
+  assert.ok(before.includes("did not retain the"),
+    "must remain attached to the observed-revert failure, not a preflight");
+});

--- a/web/js/lib/widget-write.js
+++ b/web/js/lib/widget-write.js
@@ -1228,7 +1228,7 @@ export function applyWidgetWrite(
       // Appended ONLY here, in the branch where the revert has already been
       // OBSERVED — so this can never turn into a pre-emptive refusal of a widget
       // that would have worked. Diagnosis, never a gate.
-      describeNonValueBearingWidget(w);
+      describeNonValueBearingWidget(w, targetNode);
   } else if (parentWidget && !matchesExpected(parentWidget.value)) {
     failure =
       `Promoted rail widget "${parentWidget.name}" on subgraph node ${node.id} did not retain ` +
@@ -1585,7 +1585,7 @@ export function applyWidgetWrite(
  * for perfectly healthy widgets (LoadImage's `upload` button is one), so gating on
  * it would manufacture exactly the kind of false refusal this file exists to avoid.
  */
-export function describeNonValueBearingWidget(w) {
+export function describeNonValueBearingWidget(w, node) {
   if (!w || typeof w !== "object") return "";
   const hasElement = !!w.element;
   const opts = w.options && typeof w.options === "object" ? w.options : null;
@@ -1599,8 +1599,42 @@ export function describeNonValueBearingWidget(w) {
     `${hasElement ? " (it owns a DOM element" : " (it defines getValue/setValue"}` +
     `${hasElement && hasAccessors ? " and defines getValue/setValue" : ""}), so its` +
     ` real value is held in ${where} — assigning the widget does not reach it.` +
-    ` Retrying will not help. Drive the node another way (an equivalent serialized` +
-    ` input, or a node whose value is a plain widget), or ask the pack's author to` +
-    ` expose a settable value.`
+    ` Retrying will not help.` +
+    describeNodeStateProperties(node) +
+    ` Otherwise drive the node another way (an equivalent serialized input, or a node` +
+    ` whose value is a plain widget), or ask the pack's author to expose a settable value.`
+  );
+}
+
+
+/** Cap the enumeration so a property-heavy node cannot turn one refusal into a wall
+ *  of text. The count is exact, so a truncated list still says how much it hid. */
+const MAX_STATE_KEYS = 12;
+
+/**
+ * #698 — name the properties this node actually carries, so the refusal above is a
+ * ROUTE rather than a dead end. The reporter was told the value did not stick and had
+ * nothing to try; PixaromaPrompt keeps its prompt in `properties.promptState.text`,
+ * which is reachable with panel_set_property.
+ *
+ * NAMES ONLY, NO PAIRING. Which property backs a given DOM widget is not something
+ * this can determine, and a heuristic guess (name similarity, "looks texty") would
+ * eventually point an agent at an unrelated property and have it overwrite real node
+ * state — a destructive wrong answer in place of an honest dead end. So it lists what
+ * exists and says to verify after writing.
+ */
+function describeNodeStateProperties(node) {
+  const props = node?.properties;
+  if (!props || typeof props !== "object" || Array.isArray(props)) return "";
+  const keys = Object.keys(props);
+  if (!keys.length) return "";
+  const shown = keys.slice(0, MAX_STATE_KEYS).map((k) => `"${k}"`).join(", ");
+  const more = keys.length > MAX_STATE_KEYS ? ` … and ${keys.length - MAX_STATE_KEYS} more` : "";
+  return (
+    ` This node carries ${keys.length} propert${keys.length === 1 ? "y" : "ies"}` +
+    ` (${shown}${more}) — for this kind of widget the live value is commonly one of them.` +
+    ` Read them with panel_query_graph and write with panel_set_property. WHICH property` +
+    ` backs this widget cannot be determined from here, so verify against the canvas` +
+    ` (panel_screenshot) after writing instead of assuming.`
   );
 }


### PR DESCRIPTION
Refs #698

`panel_set_widget` wrote to PixaromaPrompt's `pix_prompt_ui`, the widget reverted to `""`, and the post-write verification correctly refused to report success.

The refusal already explained the structural cause — a DOM-backed display widget whose real value lives on the node, and that retrying won't help — but it stopped there. The reporter had nothing to try and worked around it with a different node type entirely.

That node keeps its prompt in `properties.promptState.text`, which `panel_set_property` can reach. So the refusal now names the properties the node actually carries, and the two tools that read and write them.

## Names only, no pairing

Which property backs a given DOM widget **isn't determinable from here**. A heuristic guess — name similarity, "looks texty" — would eventually point an agent at an unrelated property and have it overwrite real node state. That's a destructive wrong answer in place of an honest dead end, so the message says explicitly that the pairing can't be determined and tells the caller to verify against the canvas rather than assume.

Still **diagnosis-only**, in the branch where the revert has already been *observed*. It never becomes a pre-emptive gate: #715 established that `serialize:false` is normal on healthy widgets (LoadImage's `upload` button is one), so gating on it would manufacture exactly the false refusals this file exists to avoid. A test pins that the call stays attached to the observed-failure branch and doesn't drift into a preflight.

## Two mutations initially killed zero tests — both my tests' fault, not the code's

Worth recording since they're the two classic shapes:

1. **Dropping `targetNode` at the call site.** Every test called the helper directly, so the property names could vanish from the real message with the whole suite green. Added a wiring pin.
2. **Inverting the disclaimer** (`WHICH property … cannot be determined` → `The first property …`). My assertion matched `/cannot be determined from here/`, a substring that *survives the claim being reversed*. It now asserts the exact clause and that no specific property is named.

Both fail now. The second is the more interesting one: the test looked like it guarded against overclaiming and didn't.

## Verification

- 13 tests, including a healthy value widget getting nothing (the #715 line), a node with no properties adding no empty route, and a property-heavy node capped with an exact count.
- `npm run test:unit`: **2794 pass, 0 fail**. ESM parse of the changed module and the monolith. Control-byte scan 0. No `pyproject.toml` / `PANEL_VERSION` change.

Leaving #698 open: this makes the dead end navigable, but `panel_set_widget` still cannot drive that widget, which is the title's ask. Actually doing so needs either a pack-specific adapter or a generic DOM-widget contract that packs opt into — and `setValue` being a deliberate no-op is the pack saying it doesn't accept writes on that path, so reaching around it into the element would be driving a UI the pack owns and would break on any re-render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)