### PR TITLE
fix(panel): panel_set_node_mode must report the mode the node HOLDS, not the one requested

### DIFF
--- a/browser_tests/unit/set-node-mode-verify.test.mjs
+++ b/browser_tests/unit/set-node-mode-verify.test.mjs
@@ -1,0 +1,76 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+/**
+ * PROACTIVE (found while auditing for the class behind #232 / #635 / #708 / #710):
+ * `graph_set_node_mode` reported the mode it was ASKED for, not the one the node
+ * ended up holding.
+ *
+ * `node.mode = target` is a plain assignment on a stock LGraphNode, so it normally
+ * sticks — but a pack may define a `mode` accessor that clamps, ignores or rewrites
+ * it, and nothing read the value back. This is not a cosmetic field: bypass and mute
+ * decide whether a node EXECUTES, so echoing the request would tell an agent it had
+ * disabled a node that is still running, and the graph would then render with an
+ * input the agent believes is switched off.
+ *
+ * The #690 shakedown is corroborating evidence: its author recorded verifying mode
+ * changes "by re-read, not by return value" — i.e. they had already learned not to
+ * trust this reply.
+ *
+ * The handler needs a live LiteGraph canvas to drive, so the guarantee is pinned at
+ * source, the same way the other module-private handlers are.
+ */
+
+const src = () =>
+  readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+
+function setNodeModeBody() {
+  const s = src();
+  const start = s.indexOf("graph_set_node_mode({ node_id, mode, force }) {");
+  assert.ok(start > -1, "graph_set_node_mode must exist");
+  return s.slice(start, s.indexOf("graph_screenshot(", start));
+}
+
+test("the mode is READ BACK after the write", () => {
+  const body = setNodeModeBody();
+  const write = body.indexOf("node.mode = target;");
+  const readBack = body.indexOf("const actualNum =");
+  assert.ok(write > -1, "the write must still be there");
+  assert.ok(readBack > write, "the read-back must come AFTER the write, or it proves nothing");
+});
+
+test("a node that did not accept the mode is REFUSED, not reported as changed", () => {
+  const body = setNodeModeBody();
+  assert.ok(body.includes("if (actualNum !== target) {"), "a mismatch must be detected");
+  assert.match(body, /did not accept mode/);
+  // Fail closed and say so — the rule the widget write and the restart/media reports
+  // already follow.
+  assert.match(body, /Nothing is being reported as changed/);
+});
+
+test("the reported mode comes from the NODE, never from the request", () => {
+  // The actual defect. `NUM_TO_MODE[target]` in the reply is the request echoed back;
+  // it must be the observed value.
+  const body = setNodeModeBody();
+  const ret = body.slice(body.indexOf("return {"));
+  assert.ok(ret.includes("mode: NUM_TO_MODE[actualNum],"), "must report the observed mode");
+  assert.ok(!ret.includes("mode: NUM_TO_MODE[target],"), "must NOT echo the requested mode");
+});
+
+test("previous_mode is still sampled BEFORE the write", () => {
+  // Sampling it after would report the new value as the old one — the same class of
+  // error in the other direction.
+  const body = setNodeModeBody();
+  const prev = body.indexOf("const previous_mode =");
+  const write = body.indexOf("node.mode = target;");
+  assert.ok(prev > -1 && write > -1 && prev < write, "previous_mode must be read before the write");
+});
+
+test("the existing bypass safety refusal is untouched", () => {
+  // #409: bypassing a subgraph whose boundary slots are ordered unsafely must still
+  // refuse unless force:true. This audit must not have widened or narrowed it.
+  const body = setNodeModeBody();
+  assert.match(body, /Refusing to bypass subgraph node/);
+  assert.match(body, /Pass force:true/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -12755,9 +12755,26 @@ const GRAPH_TOOL_EXECUTORS = {
       graph.afterChange?.();
     }
     graph.setDirtyCanvas?.(true, true);
+    // Report what the node HOLDS, not what was asked for. `node.mode = target` is a
+    // plain assignment on a stock LGraphNode, but a pack is free to define a `mode`
+    // accessor that clamps, ignores, or rewrites the value — and this is not a
+    // cosmetic field: bypass and mute decide whether the node EXECUTES, so echoing
+    // the request would tell an agent it had disabled a node that is still running.
+    // Same rule as the widget write (#240) and the restart/media reports: read back
+    // and refuse rather than assert an effect that was never observed.
+    const actualNum = typeof node.mode === "number" ? node.mode : 0;
+    if (actualNum !== target) {
+      throw new Error(
+        `Node ${node.id} (${node.title ?? node.type}) did not accept mode ` +
+          `"${NUM_TO_MODE[target]}": after the write it reads ` +
+          `"${NUM_TO_MODE[actualNum] ?? actualNum}". Nothing is being reported as changed. ` +
+          `Some node packs override \`mode\` to refuse or rewrite it — check the node on the ` +
+          `canvas (panel_screenshot) and set the mode from ComfyUI's own menu if it must hold.`,
+      );
+    }
     return {
       node_id: node.id,
-      mode: NUM_TO_MODE[target],
+      mode: NUM_TO_MODE[actualNum],
       previous_mode,
       ...(bypassWarning ? { warning: bypassWarning } : {}),
     };


### PR DESCRIPTION
**Found proactively**, auditing for the class behind #232, #635, #708 and #710 — a tool reporting an effect it never observed. No issue filed for this one; it's the same shape that produced those four.

`graph_set_node_mode` wrote `node.mode = target` and returned `mode: NUM_TO_MODE[target]` — **the request echoed back**. Nothing read the value again.

On a stock `LGraphNode` that assignment sticks, so this isn't a guaranteed failure. It matters because the field isn't cosmetic: **bypass and mute decide whether the node executes**. A pack that defines a `mode` accessor which clamps, ignores or rewrites the value would leave the tool telling an agent it had disabled a node that is still running — and the next render would silently include an input the agent believes is switched off.

Corroborating evidence that this already bit someone: the #690 shakedown author recorded verifying mode changes *"by re-read, not by return value"*. They'd learned not to trust this reply.

## The fix

Read back after the write, report from the **node**. A node that didn't accept the mode is **refused** with the observed value and an explicit *"Nothing is being reported as changed"* — the rule the widget write (#240) and the restart/media reports already follow.

Two things deliberately preserved, each with a test so this audit can't have quietly changed them:

- **`previous_mode` is still sampled BEFORE the write.** Sampling it afterwards would report the new value as the old one — the same error in the other direction.
- **The #409 unsafe-subgraph-bypass refusal is untouched.** ComfyUI's bypass forwards each output from the input at the same index, so a mismatched boundary silently mis-wires; that still refuses without `force:true`.

## Verification

- 5 tests pinning the read-back ordering, the refusal, that the reply comes from the node rather than the request, the `previous_mode` ordering, and the #409 refusal.
- **Three mutations**, replacement counts checked: echoing the requested mode again (the original defect), dropping the mismatch refusal, and moving the `previous_mode` sample after the write — each fails a named test.
- The handler needs a live LiteGraph canvas to drive, so the guarantee is pinned at source like the other module-private handlers.
- `npm run test:unit`: **2799 pass, 0 fail**. Monolith ESM parse. Control-byte scan 0. No `pyproject.toml` / `PANEL_VERSION` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)