### PR TITLE
fix(panel): panel_clear must report what LEFT the graph, not what it attempted

### DIFF
--- a/browser_tests/unit/graph-clear-verify.test.mjs
+++ b/browser_tests/unit/graph-clear-verify.test.mjs
@@ -1,0 +1,72 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+/**
+ * PROACTIVE — third find from the audit behind #232 / #635 / #708 / #710 and the two
+ * fixes that came out of it (set_node_mode #739, remove_group #740).
+ *
+ * `graph_clear` returned `{cleared: nodes.length}` — the number of nodes present when
+ * the sweep STARTED, not the number that actually left. `safeRemoveNode` reports
+ * success when `graph.remove` did not throw, which is not the same as the node being
+ * gone; that is precisely the gap that let `panel_remove_group` report a group still
+ * sitting on the canvas.
+ *
+ * A survivor here is worse than in the group case: the caller believes the canvas is
+ * empty and starts building, wiring new nodes alongside leftovers it cannot see.
+ */
+
+const src = () =>
+  readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+
+function clearBody() {
+  const s = src();
+  const start = s.indexOf("graph_clear() {");
+  assert.ok(start > -1, "graph_clear must exist");
+  return s.slice(start, s.indexOf("async graph_load(", start));
+}
+
+test("the graph is re-read AFTER the sweep", () => {
+  const body = clearBody();
+  const sweep = body.indexOf("safeRemoveNode(graph, node)");
+  const readBack = body.indexOf("const remaining =");
+  assert.ok(sweep > -1, "the sweep must still be there");
+  assert.ok(readBack > sweep, "the re-read must follow the sweep, or it proves nothing");
+});
+
+test("`cleared` is DERIVED from what remains, not from the starting count", () => {
+  // The defect: `cleared: nodes.length` reports the attempt.
+  const body = clearBody();
+  assert.ok(body.includes("const cleared = nodes.length - remaining;"),
+    "cleared must be computed from the observed remainder");
+  assert.ok(!/return \{ cleared: nodes\.length \}/.test(body),
+    "must not report the starting count as the cleared count");
+});
+
+test("survivors are reported, and the caller is told the canvas is NOT empty", () => {
+  // Tie the guard to the payload: a text-only assertion passes while the condition is
+  // neutered (the lesson from #738 and #740).
+  const body = clearBody();
+  assert.match(body, /if \(remaining > 0\) \{\s*return \{/,
+    "the warning must be gated on an observed remainder");
+  assert.match(body, /STILL on the canvas/);
+  assert.match(body, /NOT empty/);
+  assert.match(body, /panel_graph_outline/, "must name how to re-read");
+});
+
+test("a fully cleared graph returns the plain shape — no phantom warning", () => {
+  // The other direction: warning on every clear would train callers to ignore it.
+  const body = clearBody();
+  const plain = body.lastIndexOf("return { cleared };");
+  const warned = body.indexOf("remaining,");
+  assert.ok(plain > -1 && warned > -1 && plain > warned,
+    "the clean path must return cleared alone, after the warned path");
+});
+
+test("an unreadable node list counts as ZERO remaining, not as failure", () => {
+  // A frontend whose `_nodes` is not an array would otherwise turn every successful
+  // clear into a warning — a false alarm is its own defect.
+  const body = clearBody();
+  assert.ok(body.includes("Array.isArray(graph._nodes) ? graph._nodes.length : 0"),
+    "an unreadable list must not manufacture survivors");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -8628,7 +8628,25 @@ const GRAPH_TOOL_EXECUTORS = {
       graph.afterChange();
     }
     graph.setDirtyCanvas(true, true);
-    return { cleared: nodes.length };
+    // Report what LEFT the graph, not what was attempted. `nodes.length` is the count
+    // present when the sweep started; safeRemoveNode reports success when
+    // `graph.remove` did not throw, which is not the same as the node being gone —
+    // exactly the gap that let panel_remove_group report a group still on the canvas.
+    // A survivor here is worse: the caller believes the canvas is empty and starts
+    // building on top of nodes that are still wired.
+    const remaining = Array.isArray(graph._nodes) ? graph._nodes.length : 0;
+    const cleared = nodes.length - remaining;
+    if (remaining > 0) {
+      return {
+        cleared,
+        remaining,
+        warning:
+          `${remaining} of ${nodes.length} node(s) are STILL on the canvas — the graph is ` +
+          `NOT empty. Re-read it (panel_graph_outline) before adding anything: building on ` +
+          `an assumed-empty canvas is how nodes end up wired to leftovers.`,
+      };
+    }
+    return { cleared };
   },
 
   // Load a COMPLETE workflow onto the live canvas in one shot (replaces the


### PR DESCRIPTION
**Third find** from the audit behind #232 / #635 / #708 / #710 — after the `set_node_mode` echo (#739) and the unverified group removal (#740). No issue filed.

`graph_clear` returned `{cleared: nodes.length}` — the number of nodes present when the sweep **started**. `safeRemoveNode` reports success when `graph.remove` didn't throw, which is not the same as the node being gone; that's precisely the gap that let `panel_remove_group` report a group still sitting on the canvas.

**A survivor here is worse than in the group case.** The caller is told the canvas is empty, starts building, and wires new nodes alongside leftovers it can't see.

## The fix

`cleared` is derived from a re-read, and any remainder is reported with an explicit *"the graph is NOT empty"* and how to re-read it.

Two directions held deliberately:

- **A fully cleared graph returns the plain shape.** Warning on every clear would train callers to ignore the warning.
- **An unreadable `_nodes` counts as zero remaining**, not as survivors. A false alarm on every successful clear is its own defect — and that mutation is verified too.

## Verification

- 5 tests: the re-read follows the sweep, `cleared` is derived rather than assumed, survivors are reported, the clean path stays plain, and an unreadable list doesn't manufacture survivors.
- **Three mutations**, replacement counts checked, all failing first time: reporting the attempted count, neutering the survivor warning, and treating an unreadable list as survivors.
- The warning assertion ties the guard to the payload (`if (remaining > 0) { return {`) instead of matching the message text — carried over from #738 and #740, where a text-only assertion passed while the condition was neutered.
- `npm run test:unit`: **2809 pass, 0 fail**. Monolith ESM parse. Control-byte scan 0. No `pyproject.toml` / `PANEL_VERSION` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)