### PR TITLE
fix(panel): a subgraph conversion that produced nothing must not report a null node id

### DIFF
--- a/browser_tests/unit/create-subgraph-verify.test.mjs
+++ b/browser_tests/unit/create-subgraph-verify.test.mjs
@@ -1,0 +1,79 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+/**
+ * PROACTIVE — fourth find from the audit behind #232 / #635 / #708 / #710, after
+ * set_node_mode (#739), remove_group (#740) and clear (#741).
+ *
+ * `graph_create_subgraph` and `graph_subgraph_group` both reported the converted
+ * node's id with a null fallback, so a conversion that produced nothing returned
+ * `{subgraph: {node_id: null, name: null, …}}` with NO error. That reads as "a
+ * subgraph was created, with a missing field" rather than "nothing happened" — and
+ * the caller then addresses a node id that does not exist.
+ *
+ * The sibling `graph_add_subgraph` already guards exactly this ("don't report a fake
+ * success if deserialize produced nothing"). This is that rule applied to the two
+ * paths that were missing it — the same one-surface-not-its-sibling shape as #712.
+ */
+
+const src = () =>
+  readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+
+/** Source with comment lines stripped. The guard's own doc comment quotes the bad
+ *  expression to explain what it prevents, and matching that would fail on a correct
+ *  tree — the assertion has to look at code. */
+const code = () =>
+  src()
+    .split(/\r?\n/)
+    .filter((line) => !/^\s*(\*|\/\/)/.test(line))
+    .join("\n");
+
+function guardBody() {
+  const s = src();
+  const fn = s.slice(s.indexOf("function assertSubgraphNodeLanded("));
+  return fn.slice(0, fn.indexOf("function clearStaleRedFlagsAfterSubgraphConversion"));
+}
+
+test("neither conversion path reports a null-coalesced node id any more", () => {
+  assert.ok(
+    !/node_id: res\?\.node\?\.id \?\? null/.test(code()),
+    "a conversion result must not be reported with a null-coalesced node id",
+  );
+});
+
+test("both paths assert the node LANDED before reporting", () => {
+  const s = src();
+  assert.match(s, /assertSubgraphNodeLanded\(res, graph, "panel_create_subgraph"\)/);
+  assert.match(s, /assertSubgraphNodeLanded\(res, graph, "panel_subgraph_group"\)/);
+  // …and the reported id comes from the verified node, not the raw result.
+  assert.match(s, /node_id: created\.id,/);
+  assert.match(s, /node_id: grouped\.id,/);
+});
+
+test("the guard checks the LIVE graph, not just the returned object", () => {
+  // A result carrying a node that never landed is exactly the case a truthful report
+  // has to catch, so an id alone is not enough.
+  const body = guardBody();
+  assert.ok(body.includes("list.includes(node)"), "must confirm the node is on the graph");
+  assert.match(
+    body,
+    /if \(id == null \|\| \(list && !list\.includes\(node\)\)\) \{/,
+    "the refusal must be gated on the missing id OR the absent node",
+  );
+});
+
+test("an unreadable node list does not manufacture a failure", () => {
+  // `list` is null when `_nodes` is not an array; the guard must then fall back to the
+  // id check alone rather than refusing every conversion on an unfamiliar frontend.
+  assert.ok(
+    guardBody().includes("Array.isArray(graph?._nodes) ? graph._nodes : null"),
+    "an unreadable list must degrade to the id check, not to a refusal",
+  );
+});
+
+test("the refusal says nothing was created and leaves the selection alone", () => {
+  const body = guardBody();
+  assert.match(body, /Nothing is being reported as created/);
+  assert.match(body, /left as they are/);
+});

--- a/browser_tests/unit/subgraph-stale-outline.test.mjs
+++ b/browser_tests/unit/subgraph-stale-outline.test.mjs
@@ -29,12 +29,26 @@ const cleanupMatch = panelSrc.match(/function clearStaleRedFlag\(node, \{ app, g
 assert.ok(cleanupMatch, "could not locate clearStaleRedFlag in panel source");
 const cleanupSource = cleanupMatch[0];
 
+// Both conversion executors now assert the converted node actually landed before
+// reporting it (the null-coalesced `node_id` used to let a no-op conversion read as a
+// success). Inject the REAL helper, extracted the same way as the cleanup above, so
+// these tests keep exercising the shipped guard rather than a stub that would hide a
+// regression in it.
+const landedMatch = panelSrc.match(
+  /function assertSubgraphNodeLanded\(res, graph, what\) \{[\s\S]*?\r?\n\}/,
+);
+assert.ok(landedMatch, "could not locate assertSubgraphNodeLanded in panel source");
+const assertSubgraphNodeLanded = new Function(
+  `return ${landedMatch[0]};`,
+)();
+
 function realCreate(getGraphCtx, clearStaleRedFlagsAfterSubgraphConversion) {
   return new Function(
     "getGraphCtx",
     "clearStaleRedFlagsAfterSubgraphConversion",
+    "assertSubgraphNodeLanded",
     `const executors = { ${createSource} }; return executors.graph_create_subgraph;`,
-  )(getGraphCtx, clearStaleRedFlagsAfterSubgraphConversion);
+  )(getGraphCtx, clearStaleRedFlagsAfterSubgraphConversion, assertSubgraphNodeLanded);
 }
 
 function realGroup(
@@ -50,6 +64,7 @@ function realGroup(
     "syncGraphNodeAreas",
     "groupMemberNodes",
     "clearStaleRedFlagsAfterSubgraphConversion",
+    "assertSubgraphNodeLanded",
     `const executors = { ${groupSource} }; return executors.graph_subgraph_group;`,
   )(
     getGraphCtx,
@@ -57,6 +72,7 @@ function realGroup(
     syncGraphNodeAreas,
     groupMemberNodes,
     clearStaleRedFlagsAfterSubgraphConversion,
+    assertSubgraphNodeLanded,
   );
 }
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -6270,6 +6270,31 @@ function clearStaleRedFlag(node, { app, graph, rootGraph }) {
  * wrapper but does not revalidate their sticky red flags. Re-adjudicate only
  * those direct neighbours; never the wrapper or the nodes moved inside it.
  */
+/** Confirm `convertToSubgraph` actually produced a subgraph NODE on this graph.
+ *
+ *  Both conversion tools reported `node_id: res?.node?.id ?? null` — so a conversion
+ *  that produced nothing returned `{subgraph: {node_id: null, name: null, …}}` with no
+ *  error, which reads as "a subgraph was created". The sibling graph_add_subgraph
+ *  already guards this ("don't report a fake success if deserialize produced
+ *  nothing"); this is the same rule applied to the two paths that were missing it.
+ *
+ *  Presence is checked on the LIVE graph, not just on the returned object: a result
+ *  carrying a node that never landed is exactly the case a truthful report must catch. */
+function assertSubgraphNodeLanded(res, graph, what) {
+  const node = res?.node;
+  const id = node?.id;
+  const list = Array.isArray(graph?._nodes) ? graph._nodes : null;
+  if (id == null || (list && !list.includes(node))) {
+    throw new Error(
+      `${what} did not produce a subgraph node on the canvas — the frontend's ` +
+        `convertToSubgraph returned no usable node. Nothing is being reported as created; ` +
+        `the selected nodes are left as they are. Re-read the graph (panel_graph_outline) ` +
+        `before retrying.`,
+    );
+  }
+  return node;
+}
+
 function clearStaleRedFlagsAfterSubgraphConversion(res, { app, graph, rootGraph }) {
   try {
     for (const id of collectLinkedNeighborNodeIds(res?.node, graph?.links)) {
@@ -11615,9 +11640,12 @@ const GRAPH_TOOL_EXECUTORS = {
     }
     clearStaleRedFlagsAfterSubgraphConversion(res, { app, graph, rootGraph });
     graph.setDirtyCanvas?.(true, true);
+    // `node_id: null` inside a `subgraph:` payload reads as a success with a missing
+    // field, not as a failure. Refuse instead — see assertSubgraphNodeLanded.
+    const created = assertSubgraphNodeLanded(res, graph, "panel_create_subgraph");
     return {
       subgraph: {
-        node_id: res?.node?.id ?? null,
+        node_id: created.id,
         name: res?.subgraph?.name ?? null,
         from_nodes: ns.map((n) => n.id),
       },
@@ -11657,9 +11685,12 @@ const GRAPH_TOOL_EXECUTORS = {
     }
     clearStaleRedFlagsAfterSubgraphConversion(res, { app, graph, rootGraph });
     graph.setDirtyCanvas?.(true, true);
+    // Same guard as panel_create_subgraph: a conversion that produced no node must
+    // not report a subgraph with a null id.
+    const grouped = assertSubgraphNodeLanded(res, graph, "panel_subgraph_group");
     return {
       subgraph: {
-        node_id: res?.node?.id ?? null,
+        node_id: grouped.id,
         name: res?.subgraph?.name ?? null,
         from_group: g.title ?? null,
         from_nodes: ns.map((n) => n.id),


### PR DESCRIPTION
**Fourth find** from the audit behind #232 / #635 / #708 / #710 — after `set_node_mode` (#739), `remove_group` (#740) and `clear` (#741). No issue filed.

`graph_create_subgraph` and `graph_subgraph_group` both reported:

```js
subgraph: { node_id: res?.node?.id ?? null, name: … }
```

So a conversion that produced nothing returned `{subgraph: {node_id: null, name: null, …}}` with **no error**. That reads as *"a subgraph was created, with a missing field"* rather than *"nothing happened"* — and the caller then addresses a node id that doesn't exist.

The sibling `graph_add_subgraph` **already guards exactly this** — *"don't report a fake success if deserialize produced nothing"*. This is that rule applied to the two paths that were missing it: the same one-surface-not-its-sibling shape as #712.

## Details

- Presence is checked on the **live graph**, not just the returned object. A result carrying a node that never landed is precisely the case a truthful report has to catch, so an id alone isn't enough.
- An unreadable `_nodes` **degrades to the id check** rather than refusing every conversion on an unfamiliar frontend. A false alarm is its own defect, and that direction is mutation-verified.

## Two things worth flagging

**The #516 stale-outline suite broke, and the fix was to extend the harness, not the code.** That suite `eval`s these executors from source, so the new helper had to be injected the way `clearStaleRedFlag` already is. It gets the **real extracted helper**, not a stub — a stub would let those tests pass over a regression in the guard itself. (Same harness pattern as the #605 manager-dialect suite.)

**My first assertion failed on a correct tree.** It matched the bad expression anywhere in the file, and the guard's own doc comment quotes that expression to explain what it prevents. It now strips comment lines and asserts against code — a test that fails because of its own phrasing teaches nothing.

## Verification

- 5 new tests; **three mutations** (restoring the null-coalesced id, dropping the live-graph presence check, refusing on an unreadable list) all fail, plus a whole-guard neutering that also fails.
- `npm run test:unit`: **2814 pass, 0 fail** — including the two #516 tests my change initially broke.
- Monolith ESM parse. Control-byte scan 0 on all three files. No `pyproject.toml` / `PANEL_VERSION` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)