### PR TITLE
0.11.44 — seventeen fixes: the honest-result sweep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-agent-panel"
 description = "Autonomous AI agent in the ComfyUI sidebar - local-first, bring any LLM. Run it on your Claude or ChatGPT subscription (no API keys, no extra LLM costs), on a Kimi K3 / GLM / OpenRouter key, or fully offline on free local models via Ollama, LM Studio, or llama.cpp. The agent drives your live canvas at full parity: add, wire, move and tweak nodes with Ctrl+Z undo, load whole workflows and installer packs in one shot, generate images, video and audio, browse CivitAI, and run your workflow - asking before it spends paid API credits. The sidebar UI for comfyui-mcp, the local-first, agent-native control plane for ComfyUI."
-version = "0.11.43"
+version = "0.11.44"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
 # UI-only pack: no Python deps. The frontend floor guarantees

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -850,7 +850,7 @@ const DOCS_URL = "https://comfyui-mcp.artokun.io/docs";
 // Panel version — surfaced in the "Need help?" diagnostics blob. Bump via
 // `node scripts/set-version.mjs <v>` (updates this AND pyproject together); CI
 // and the publish gate FAIL if the two ever drift, so this can't go stale.
-const PANEL_VERSION = "0.11.43";
+const PANEL_VERSION = "0.11.44";
 
 // The connected orchestrator's console URL/token (captured off the `backends`
 // bridge message — see onBackends). Drives the "API Keys" credentials frame;


### PR DESCRIPTION
**Prepared, not merged.** Merging this publishes to the Comfy Registry, which is your call — the same way you merged #722 yourself. Everything below is verified and ready; nothing ships until you press the button.

Seventeen fixes since 0.11.43, and **seven live-repro reporters are waiting on a released build to confirm against** (#607, #688, #689, #682, plus mcp #932/933/934). Three of tonight's eight issue closures were reports already fixed on `main` that nobody had closed — which is what happens when fixes don't reach users.

## Reported and fixed

| issue | fix |
|---|---|
| **#708** | a save must write the **tab's** graph, and "blank" must be proven before it's claimed — also closed an **in-place save that could overwrite a real file with a foreign graph**, strictly worse than what was reported |
| **#713** | recover the slot-mirror **write** variant of the #420 disconnect crash (batched removals) |
| **#686 / #636** | core V3 dynamic-input declarations (`COMFY_*_V3`) are addable rather than "pending registration" — `SaveVideo`, `StringFormat`, `ComfyMathExpression` |
| **#691** | echo `filters` in the CivitAI receipt, and say when a sort is **upstream-inert** (CivitAI ignores `sort` whenever `query` is present — measured) |
| **#636** | subgraph slot/widget **renames** appear in the manual-changes diff; definition-vs-instance values are labelled so an override isn't read as stale data |
| **#699** | explain a run-to-node "Prompt has no outputs" — ComfyUI advertises `output_node` with `== True` but selects outputs with `is True` |
| **#690** | a **created** node property says so; a rename conflict gives a reason; `panel_list_subgraphs` is bounded **visibly** |
| **#694** | a uuid re-mint must not split one canvas's conversations |
| **#697** | a node the reads listed says **where** it is when a write can't find it (scope mismatch, not stale routing) |
| **#698** | the DOM-widget refusal is a **route**, not just a diagnosis |

## Found by audit — no report behind them

All four are one class: **a tool reporting the request it made instead of the effect it observed** — the shape behind #232, #635, #708 and #710.

- `panel_set_node_mode` reported the **requested** mode, not the held one. Not cosmetic: bypass/mute decide whether a node **executes**.
- `panel_remove_group` reported a removal it never verified (its fallback chain was `else if`, and LiteGraph's `remove` is for *nodes*).
- `panel_clear` reported the count it **attempted**, not what left.
- Both subgraph-conversion paths reported a **null node id** inside a success payload.

The discriminator turned out to be mechanical: handlers routing through `graph_edit_node` are honest (it reports `after: summarize(node)` from the live node); every handler that hand-built its own reply echoed the request.

## Verification

- **2814 unit tests pass**; monolith parses as an ES module.
- Tool-vocabulary check clean: 34 tool-call literals across 92 shipped JS files, all valid against 37 core / 91 panel tools (hash `0d805152a369…`). I also cross-checked that artefact **directly against mcp source** rather than trusting the vendored copy — they agree exactly, so it isn't stale post-0.50.0.
- `pyproject.toml` version and `PANEL_VERSION` match — the Registry publish gate.
- Every constituent PR was mutation-verified, including the call-site mutation.

## After merging

Per the standing rule, the seven live-repro reports **close when someone confirms on the released build**, not when this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)