### PR TITLE
fix(panel #845): bound the viewport read by CHARACTERS, not only by node count

### DIFF
--- a/browser_tests/unit/outline-coverage.test.mjs
+++ b/browser_tests/unit/outline-coverage.test.mjs
@@ -170,16 +170,26 @@ test("#809 the refusal itself fits the smallest budget the tool accepts", async 
 test("#809 the MAX_STATE_NODES views state their cap instead of a bare boolean", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   // Each capped view must carry prose the model actually reads, not just `truncated:true`.
-  for (const sig of [
-    "graph_view_selected()",
-    "graph_view_nodes_in_viewport()",
-    "graph_get_subgraph({",
-  ]) {
+  // Views whose cap is FIXED and has no lever: they must say so, using the shared
+  // wording that is honest about there being nothing to raise.
+  for (const sig of ["graph_view_selected()", "graph_get_subgraph({"]) {
     const body = handlerBody(src, sig);
     assert.ok(body, `${sig} must exist`);
     assert.match(body, /truncation_hint:/, `${sig} must emit a remedy, not only a boolean`);
     assert.match(body, /fixedCapNote\(/, `${sig} must use the shared fixed-cap wording`);
   }
+
+  // #845 — the viewport view now HAS a lever (`max_chars`), because a 100-node cap
+  // bounded the wrong unit and still emitted 135k characters. It must therefore NOT
+  // use the fixed-cap wording, which would tell a caller no parameter raises it when
+  // one does — the same defect (naming a lever that does not match reality) pointed
+  // the other way. It still owes a remedy, and that remedy must carry a ceiling.
+  const viewport = handlerBody(src, "graph_view_nodes_in_viewport({ max_chars } = {})");
+  assert.ok(viewport, "graph_view_nodes_in_viewport must exist");
+  assert.ok(!/fixedCapNote\(/.test(viewport),
+    "a view WITH a lever must not claim the fixed-cap 'no parameter raises it' wording");
+  assert.ok(/viewportTruncation\(/.test(viewport),
+    "it must emit the lever-aware truncation instead");
   // And the shared wording must be honest about there being no lever — inventing one
   // would be the same defect as naming the wrong one.
   assert.match(src, /FIXED cap of \$\{MAX_STATE_NODES\} and no parameter raises it/);

--- a/browser_tests/unit/viewport-char-bound.test.mjs
+++ b/browser_tests/unit/viewport-char-bound.test.mjs
@@ -1,0 +1,103 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  boundByChars,
+  normalizeViewportMaxChars,
+  viewportTruncation,
+  VIEWPORT_DEFAULT_MAX_CHARS,
+} from "../../web/js/lib/viewport-char-bound.js";
+
+/**
+ * #845 — panel_view_nodes_in_viewport returned 135,531 characters across 5,662 lines
+ * for a caller inspecting ONE node in a 175-node workflow.
+ *
+ * It was not unbounded: it capped at MAX_STATE_NODES (100). It was bounded by the
+ * WRONG UNIT — 100 nodes at ~1.3k chars each honours the cap exactly and still emits
+ * 135k characters. panel_query_graph is bounded by max_chars for this very reason.
+ */
+
+const node = (id, pad = 1200) => ({ id, type: "T", title: "x".repeat(pad) });
+
+test("the reported blowup is bounded: 100 fat nodes no longer emit ~135k chars", () => {
+  const cap = Array.from({ length: 100 }, (_, i) => node(i));
+  const raw = JSON.stringify(cap).length;
+  assert.ok(raw > 120000, `precondition: unbounded payload is large (${raw})`);
+  const { kept, keptChars } = boundByChars(cap, VIEWPORT_DEFAULT_MAX_CHARS);
+  assert.ok(keptChars <= VIEWPORT_DEFAULT_MAX_CHARS, `kept ${keptChars} within budget`);
+  assert.ok(kept.length < cap.length, "and fewer nodes came back");
+});
+
+test("a small viewport is NOT clipped — the common case is untouched", () => {
+  const few = [node(1), node(2), node(3)];
+  const { kept, droppedForChars } = boundByChars(few, VIEWPORT_DEFAULT_MAX_CHARS);
+  assert.equal(kept.length, 3);
+  assert.equal(droppedForChars, 0);
+});
+
+test("the FIRST node is always admitted, even if it alone blows the budget", () => {
+  // Returning an empty viewport for one large node would report "nothing here" about
+  // the very node the user is looking at.
+  const huge = [node(1, 50000), node(2)];
+  const { kept } = boundByChars(huge, 2000);
+  assert.equal(kept.length, 1);
+  assert.equal(kept[0].id, 1);
+});
+
+test("nodes are never partially serialized", () => {
+  // Half a node summary is not a smaller answer, it is a malformed one.
+  const { kept } = boundByChars([node(1), node(2), node(3)], 3000);
+  for (const k of kept) assert.deepEqual(Object.keys(k).sort(), ["id", "title", "type"]);
+});
+
+test("truncation is VISIBLE and says what was withheld", () => {
+  const t = viewportTruncation({ inViewCount: 87, keptCount: 12, nodeCap: 100, maxChars: 24000 });
+  assert.equal(t.truncated, true);
+  assert.equal(t.returned, 12);
+  assert.match(t.truncation_hint, /Showing 12 of 87/);
+  assert.match(t.truncation_hint, /do not read this as the viewport being empty/i);
+  assert.match(t.truncation_hint, /character budget 24000/);
+  // Names a lever WITH a ceiling — a caller already at the max must not be sent on a
+  // retry that cannot change anything.
+  assert.match(t.truncation_hint, /up to 200000/);
+});
+
+test("it distinguishes the NODE CAP from the character budget", () => {
+  // Different remedies: zoom out fewer nodes vs raise max_chars. Reporting the wrong
+  // cause sends the caller at a lever that will not move.
+  const byCap = viewportTruncation({ inViewCount: 175, keptCount: 100, nodeCap: 100, maxChars: 24000 });
+  assert.match(byCap.truncation_hint, /node cap 100/);
+  const byChars = viewportTruncation({ inViewCount: 40, keptCount: 12, nodeCap: 100, maxChars: 24000 });
+  assert.match(byChars.truncation_hint, /character budget/);
+});
+
+test("nothing withheld ⇒ NO truncation fields at all", () => {
+  assert.deepEqual(viewportTruncation({ inViewCount: 5, keptCount: 5, nodeCap: 100, maxChars: 24000 }), {});
+});
+
+test("a garbage max_chars falls back to the default, never to zero", () => {
+  for (const bad of [0, -5, NaN, "abc", null, undefined, {}]) {
+    assert.equal(normalizeViewportMaxChars(bad), VIEWPORT_DEFAULT_MAX_CHARS, String(bad));
+  }
+  assert.equal(normalizeViewportMaxChars(1e9), 200000, "clamped to the ceiling");
+  assert.equal(normalizeViewportMaxChars(10), 2000, "clamped to the floor");
+});
+
+test("an unserializable summary does not abort the whole page", () => {
+  const cyclic = { id: 9 }; cyclic.self = cyclic;
+  const { kept } = boundByChars([cyclic, node(2)], VIEWPORT_DEFAULT_MAX_CHARS);
+  assert.equal(kept.length, 2);
+});
+
+// ── WIRING ────────────────────────────────────────────────────────────────
+test("WIRING: the handler applies the budget and keeps in_view_count honest", () => {
+  const src = readFileSync(new URL("../../web/js/comfyui-mcp-panel.js", import.meta.url), "utf8");
+  const fn = src.slice(src.indexOf("graph_view_nodes_in_viewport({ max_chars } = {}) {"));
+  const body = fn.slice(0, fn.indexOf("\n  graph_", 10));
+  assert.ok(body.includes("normalizeViewportMaxChars(max_chars)"), "must normalize the caller's budget");
+  assert.ok(body.includes("boundByChars(cap, budget)"), "must apply the character budget");
+  assert.ok(body.includes("in_view_count: visible.length"),
+    "in_view_count must stay the SCREEN count, not the payload count");
+  // The node cap still runs first, so the char budget is a second gate, not a replacement.
+  assert.ok(body.includes("visible.slice(0, MAX_STATE_NODES)"), "the node cap must still apply");
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -189,6 +189,7 @@ import { boundSubgraphList } from "./lib/subgraph-list-bound.js";
 import { threadMatchesCurrentWorkflow } from "./lib/thread-workflow-match.js";
 import { subgraphValueProvenance } from "./lib/subgraph-value-provenance.js";
 import { describeMissingNode } from "./lib/node-scope-locator.js";
+import { boundByChars, normalizeViewportMaxChars, viewportTruncation, VIEWPORT_DEFAULT_MAX_CHARS } from "./lib/viewport-char-bound.js";
 import { classifyManualChangeBaseline } from "./lib/manual-change-gate.js";
 import {
   CANVAS_TOOL_DISCLOSURE,
@@ -7364,7 +7365,7 @@ const GRAPH_TOOL_EXECUTORS = {
   // visible when its full rendered box (getBounding — title bar included)
   // INTERSECTS that rect, so half-on-screen nodes are included rather than
   // dropped. Read-only.
-  graph_view_nodes_in_viewport() {
+  graph_view_nodes_in_viewport({ max_chars } = {}) {
     const { graph, canvas } = getGraphCtx();
     // DERIVE the rect rather than trusting `canvas.visible_area`: LiteGraph only
     // refreshes visible_area when it DRAWS, and it sizes it from the canvas
@@ -7420,18 +7421,24 @@ const GRAPH_TOOL_EXECUTORS = {
       },
       node_count: all.length,
       in_view_count: visible.length,
-      truncated: visible.length > MAX_STATE_NODES,
-      ...(visible.length > MAX_STATE_NODES
-        ? {
-            truncation_hint: fixedCapNote(
-              "visible node(s)",
-              MAX_STATE_NODES,
-              visible.length,
-              "Ask the user to zoom in so fewer nodes are on screen, or read the region with panel_query_graph (which DOES take limit and max_chars) / panel_graph_outline for the whole graph.",
-            ),
-          }
-        : {}),
-      nodes: visible.slice(0, MAX_STATE_NODES).map(summarizeNode),
+      // #845 — the node cap alone bounded the WRONG UNIT: 100 nodes honoured exactly
+      // still emitted 135k characters for a caller inspecting one node. Apply the node
+      // cap first, then a CHARACTER budget, and keep in_view_count describing the
+      // SCREEN so a caller comparing it to nodes.length always sees what was withheld.
+      ...(() => {
+        const cap = visible.slice(0, MAX_STATE_NODES).map(summarizeNode);
+        const budget = normalizeViewportMaxChars(max_chars);
+        const { kept } = boundByChars(cap, budget);
+        return {
+          ...viewportTruncation({
+            inViewCount: visible.length,
+            keptCount: kept.length,
+            nodeCap: MAX_STATE_NODES,
+            maxChars: budget,
+          }),
+          nodes: kept,
+        };
+      })(),
     };
   },
 

--- a/web/js/lib/viewport-char-bound.js
+++ b/web/js/lib/viewport-char-bound.js
@@ -1,0 +1,88 @@
+/**
+ * #845 — `panel_view_nodes_in_viewport` returned **135,531 characters across 5,662
+ * lines** for a caller inspecting ONE node in a 175-node workflow, tripping the
+ * harness token guard.
+ *
+ * The tool was not unbounded — it caps at `MAX_STATE_NODES` (100) nodes. It was
+ * bounded by the WRONG UNIT. A 100-node cap says nothing about size when each node
+ * summarizes to ~1.3k characters, so the cap can be honoured exactly and still emit
+ * 135k characters. `panel_query_graph` is bounded by `max_chars` for precisely this
+ * reason; this tool had no character budget and took no parameters at all, so a
+ * caller could not ask for less. (The reporter's `node_ids:["42"]` was silently
+ * dropped for the same reason — the handler accepts no arguments.)
+ *
+ * TRUNCATION MUST STAY VISIBLE. Every count in the reply keeps describing the
+ * WORKFLOW, not the payload: `in_view_count` remains how many nodes are actually on
+ * screen, so comparing it to `nodes.length` always reveals the difference. A read
+ * that quietly returns 12 of 87 is a silent-omission bug wearing a smaller token
+ * count — worse than the flood it replaces, because the caller stops looking.
+ *
+ * The budget is applied per node, in view order, and stops at the first node that
+ * would exceed it. Nodes are not partially serialized: half a node summary is not a
+ * smaller answer, it is a malformed one.
+ */
+
+/** Generous enough that an ordinary viewport (a handful of nodes) is never clipped,
+ *  small enough that a full 100-node screen cannot flood a context window. Chosen
+ *  against the reported case: 135k became the problem, ~24k is a readable page. */
+export const VIEWPORT_DEFAULT_MAX_CHARS = 24000;
+const MIN_MAX_CHARS = 2000;
+const MAX_MAX_CHARS = 200000;
+
+/** Coerce a caller-supplied budget into range. A non-number or nonsense value falls
+ *  back to the default rather than to zero: a caller fumbling the parameter must not
+ *  receive an empty viewport that reads as "nothing is on screen". */
+export function normalizeViewportMaxChars(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return VIEWPORT_DEFAULT_MAX_CHARS;
+  return Math.min(Math.max(Math.floor(n), MIN_MAX_CHARS), MAX_MAX_CHARS);
+}
+
+/**
+ * Take nodes in view order until the character budget is spent.
+ *
+ * @param {Array<object>} summaries already-summarized nodes, in view order
+ * @param {number} maxChars budget (already normalized)
+ * @returns {{kept: Array<object>, keptChars: number, droppedForChars: number}}
+ */
+export function boundByChars(summaries, maxChars) {
+  const list = Array.isArray(summaries) ? summaries : [];
+  const kept = [];
+  let used = 0;
+  for (const s of list) {
+    let size;
+    try {
+      size = JSON.stringify(s)?.length ?? 0;
+    } catch {
+      size = 0; // an unserializable summary is the caller's problem, not a reason to stop
+    }
+    // Always admit the FIRST node even if it alone exceeds the budget: returning an
+    // empty viewport for one large node would report "nothing here" about a node the
+    // user is looking at.
+    if (kept.length > 0 && used + size > maxChars) break;
+    kept.push(s);
+    used += size;
+  }
+  return { kept, keptChars: used, droppedForChars: list.length - kept.length };
+}
+
+/**
+ * The truncation fields for the reply, or `{}` when nothing was withheld.
+ *
+ * `inViewCount` stays the true on-screen count in the caller's payload; this only
+ * describes what was omitted and how to get it.
+ */
+export function viewportTruncation({ inViewCount, keptCount, nodeCap, maxChars }) {
+  if (keptCount >= inViewCount) return {};
+  const byCap = inViewCount > nodeCap;
+  return {
+    truncated: true,
+    returned: keptCount,
+    truncation_hint:
+      `Showing ${keptCount} of ${inViewCount} node(s) currently in view` +
+      (byCap ? ` (node cap ${nodeCap})` : ` (character budget ${maxChars})`) +
+      `. The rest were NOT returned — do not read this as the viewport being empty of them. ` +
+      `Zoom in so fewer nodes are on screen, raise \`max_chars\` (up to ${MAX_MAX_CHARS}), ` +
+      `or read specific nodes by id with panel_query_graph {ids:[…], fields:'detail'}.`,
+  };
+}


### PR DESCRIPTION
Refs artokun/comfyui-mcp#845 (its first defect).

`panel_view_nodes_in_viewport` returned **135,531 characters across 5,662 lines** for a caller inspecting **one** node in a 175-node workflow, tripping the harness token guard.

## It was bounded by the wrong unit

It wasn't unbounded — it caps at `MAX_STATE_NODES` (100). But a 100-node cap says nothing about **size**: at ~1.3k characters per node summary, the cap is honoured exactly and still emits ~135k. `panel_query_graph` is bounded by `max_chars` for precisely this reason.

The tool also accepted **no parameters at all**, which is why the reporter's `node_ids:["42"]` was silently dropped — worth noting on the issue separately, since it makes the tool look like it ignored a filter it never had.

## The fix

The node cap still runs first; the character budget is a **second gate**, not a replacement. The two are reported **distinctly** — "node cap 100" and "character budget 24000" have different remedies (zoom out vs raise `max_chars`), and naming the wrong one sends a caller at a lever that cannot move.

Truncation stays **visible**: `in_view_count` keeps describing the **screen**, not the payload, so comparing it to `nodes.length` always reveals what was withheld. A read that quietly returns 12 of 87 is a silent-omission bug wearing a smaller token count — worse than the flood it replaces, because the caller stops looking.

Two edges held deliberately:
- the **first** node is always admitted even if it alone exceeds the budget — an empty viewport would report "nothing here" about the node the user is looking at;
- nodes are **never partially serialized** — half a summary isn't a smaller answer, it's a malformed one.

## The #809 gate caught me, correctly

The existing gate asserts these views carry a fixed cap *"and no parameter raises it"* — which my change **falsified**. I updated it rather than relaxing it, keeping the intent (never name a lever that doesn't match reality):

- `graph_view_selected` / `graph_get_subgraph` still have no lever → must keep the fixed-cap wording;
- `graph_view_nodes_in_viewport` must now **not** use it, since claiming no parameter raises it when `max_chars` does is the same defect pointed the other way.

Mutation-verified after updating: removing `viewportTruncation` from the handler fails the gate, so it still bites.

## Verification

- 10 new tests, including the reported case (100 fat nodes no longer emit ~135k) and both no-op directions.
- **Four mutations**, replacement counts checked: dropping the budget, making `in_view_count` the payload count, dropping always-admit-first, and returning 0 for a bad `max_chars`.
- `npm run test:unit`: **2824 pass, 0 fail**. Monolith ESM parse. Control-byte scan 0. No `pyproject.toml` / `PANEL_VERSION` change.

The matching `max_chars` parameter on the orchestrator side is a follow-up; the default budget fixes the reported blowup without it, since the handler defaults when given nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)