### PR TITLE
fix(fence): let the recovery probe through both target guards

### DIFF
--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -7,7 +7,9 @@ import { dirname, join } from 'node:path'
 import {
   activeWorkflowFenceApplies,
   commandIsCanvasIndependent,
+  commandIsCanvasTargetless,
   commandWorkflowMismatch,
+  commandTargetsActiveWorkflow,
   hasEmbeddedUuidSuccessionEvidence,
   selectorSearchIncludesListed,
   selectorTargetsNonActiveWorkflow,
@@ -87,6 +89,92 @@ test('#570 fence does NOT apply to navigation / resolved-non-active workflow ops
   assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_rename', targetsNonActive: true }), false)
 })
 
+// #932/#607/#688 — the wedge was PERMANENT because the repair probe was fenced.
+// The orchestrator refreshes a stale stamp exactly one way: rebindWorkflowFence()
+// asks the panel for `workflow_list` and re-derives the fence from the record it
+// reports active. Fencing that probe made the repair require the fence to be
+// already-correct, so a stale stamp refused the only command that could clear it.
+test('#932 workflow_list — the recovery probe — is NOT fenced', () => {
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_list' }), false)
+})
+
+test('#932 a STALE stamp must not refuse the probe that would refresh it', () => {
+  // The exact wedge: the session is fenced to a workflow the user has navigated
+  // away from, so every stamp it sends names the wrong canvas.
+  const stale = { commandUuid: 'uuid-the-session-still-believes', activeUuid: 'uuid-actually-on-screen' }
+  // Graph work is correctly refused — that is the fence doing its job, and this
+  // assertion is what keeps the exemption from being read as "the fence relaxed".
+  assert.equal(commandTargetsActiveWorkflow({ cmd: 'graph_add_node', ...stale }), false)
+  assert.equal(commandTargetsActiveWorkflow({ cmd: 'graph_get_state', ...stale }), false)
+  // …but the probe that learns the right answer must get through, or nothing can.
+  assert.equal(commandTargetsActiveWorkflow({ cmd: 'workflow_list', ...stale }), true)
+})
+
+test('#932 the probe survives an ABSENT stamp too, which is how #718 wedges', () => {
+  // #718's half: an unstamped frame is refused HARDER than a mismatched one
+  // (an advertised fence must not fail open). That made the unstamped case the
+  // unrecoverable one, so the probe has to clear it as well — an exemption that
+  // only covered a mismatched uuid would leave exactly that wedge in place.
+  for (const commandUuid of [undefined, null, '', '   ']) {
+    assert.equal(commandWorkflowMismatch({ commandUuid, activeUuid: 'live' }), true, 'still a mismatch')
+    assert.equal(
+      commandTargetsActiveWorkflow({ cmd: 'workflow_list', commandUuid, activeUuid: 'live' }),
+      true,
+      'but the probe still runs',
+    )
+  }
+})
+
+test('#932 an UNRESOLVABLE active uuid still lets the probe through', () => {
+  // The panel fails closed when it cannot resolve its own active uuid (#186), which
+  // is precisely the moment the caller most needs the listing to find out what IS
+  // active. Fencing here would wedge the recovery at its most useful instant.
+  for (const activeUuid of [undefined, null, '']) {
+    assert.equal(commandTargetsActiveWorkflow({ cmd: 'workflow_list', commandUuid: 'x', activeUuid }), true)
+    assert.equal(commandTargetsActiveWorkflow({ cmd: 'graph_add_node', commandUuid: 'x', activeUuid }), false)
+  }
+})
+
+test('#932 the shared predicate covers BOTH guards, and is strictly wider', () => {
+  // Everything canvas-independent stays targetless…
+  for (const cmd of ['nodes_search', 'nodes_list', 'nodes_install', 'nodes_queue_status',
+                     'graph_update_node', 'comfy_reboot', 'free_vram']) {
+    assert.equal(commandIsCanvasTargetless(cmd), true, `${cmd} targets no canvas`)
+  }
+  // …plus exactly one more.
+  assert.equal(commandIsCanvasTargetless('workflow_list'), true)
+  assert.equal(commandIsCanvasIndependent('workflow_list'), false, 'wider, not the same set')
+  // And nothing else leaks in — a canvas write or a content read must still be
+  // refusable by the pin guard, which is the guard this predicate now also feeds.
+  for (const cmd of ['graph_add_node', 'graph_outline', 'graph_get_state', 'workflow_save',
+                     'workflow_close', 'workflow_open', 'refresh_nodes', 'some_future_command']) {
+    assert.equal(commandIsCanvasTargetless(cmd), false, `${cmd} still answers to target guards`)
+  }
+  assert.equal(commandIsCanvasTargetless(undefined), false)
+})
+
+test('#932 workflow_list is exempt WITHOUT being called canvas-independent', () => {
+  // It does observe the canvas — it reports which tab is active — so folding it into
+  // CANVAS_INDEPENDENT_COMMANDS ("never reads or mutates a canvas") would make that
+  // set's own contract false. The two ideas stay distinct: not canvas-independent,
+  // but not canvas-TARGETING either, which is what the fence actually guards.
+  assert.equal(commandIsCanvasIndependent('workflow_list'), false)
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_list' }), false)
+})
+
+test('#932 the exemption is workflow_list ALONE — sibling reads stay fenced', () => {
+  // Guards against the fix being widened into "reads are safe". These all return
+  // graph CONTENT, so a stale-stamped caller would read the wrong canvas and
+  // believe it read the right one.
+  for (const cmd of ['graph_get_state', 'graph_outline', 'graph_query', 'graph_view_selected']) {
+    assert.equal(activeWorkflowFenceApplies({ cmd }), true, `${cmd} returns canvas content — stays fenced`)
+  }
+  // Nor does it leak to look-alike command names.
+  for (const cmd of ['workflow_list_nodes', 'workflow_lis', 'workflow_listx', 'WORKFLOW_LIST']) {
+    assert.equal(activeWorkflowFenceApplies({ cmd }), true, `${cmd} is not the probe`)
+  }
+})
+
 // #602 — a command whose execution AND reply never reference the active canvas
 // (Manager registry/server ops, ComfyUI server controls) must not be fenced to the
 // active workflow's uuid: a tab switch after issue manufactured a false refusal for
@@ -119,9 +207,12 @@ test('#602 the exemption stays EXPLICIT — canvas ops, workflow mutators, and u
   // Active-workflow mutators.
   assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_save' }), true)
   assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_close' }), true)
-  // workflow_list's reply DESCRIBES the active workflow — a stale-stamped call
-  // must not answer for the wrong tab, so it is NOT canvas-independent.
-  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_list' }), true)
+  // workflow_list observes the canvas (it reports which tab is active), so it is
+  // genuinely NOT canvas-independent and that half of this test still holds. What
+  // changed in #932 is the other half: being canvas-OBSERVING does not make it
+  // canvas-TARGETING, and it is the sole probe the fence repair runs through, so it
+  // is exempt from the fence while staying out of CANVAS_INDEPENDENT_COMMANDS.
+  assert.equal(activeWorkflowFenceApplies({ cmd: 'workflow_list' }), false)
   assert.equal(commandIsCanvasIndependent('workflow_list'), false)
   // An unknown/new command fails closed: coverage is lost only by an explicit opt-out.
   assert.equal(activeWorkflowFenceApplies({ cmd: 'graph_future_command' }), true)
@@ -140,11 +231,19 @@ test('#602 wiring: dispatch skips the graph-binding assert for canvas-independen
   )
   // Same for the PIN guard (codex gate round 2): a pin exists to stop a CANVAS
   // write landing on the wrong workflow — canvas-independent commands must not
-  // be refused by it either.
+  // be refused by it either. #932 widened this to commandIsCanvasTargetless so the
+  // recovery probe clears BOTH guards: exempting it from the uuid fence alone would
+  // have left a pinned session wedged in exactly the same way, one guard over, with
+  // the pin refusal advertising the very re-target that runs through workflow_list.
   assert.match(
     src,
-    /pinnedPath\.trim\(\)\s*&&\s*!commandIsCanvasIndependent\(msg\.cmd\)/,
-    'the pinned-target guard must skip commands that never touch a canvas',
+    /pinnedPath\.trim\(\)\s*&&\s*!commandIsCanvasTargetless\(msg\.cmd\)/,
+    'the pinned-target guard must skip commands that target no canvas',
+  )
+  // …and it must be the WIDER predicate, not the narrow one, at that call site.
+  assert.ok(
+    !/pinnedPath\.trim\(\)\s*&&\s*!commandIsCanvasIndependent\(msg\.cmd\)/.test(src),
+    'the pin guard must not fall back to the narrow canvas-independent test',
   )
   // The workflow-instance-mismatch refusal renders for real users; it once shipped
   // with a mojibake em dash ("â€”"). Pin the clean form.
@@ -575,9 +674,24 @@ test('#607 canvas and workflow commands stay fenced; unknown commands fail close
     // lists on the active graph (refreshComfyNodeDefs → reapplyDefsToLiveNodes) —
     // a canvas mutation, so the stamp must be proven before it runs (codex gate).
     'refresh_nodes',
-    // workflow_list's reply DESCRIBES the active workflow, so a stale-stamped
-    // call would answer for the wrong tab — fenced by #624's criterion.
-    'workflow_list',
+    // workflow_list USED to be fenced here, on the reading that its reply
+    // "describes the active workflow, so a stale-stamped call would answer for the
+    // wrong tab". #932/#607/#688 showed that premise does not hold and the cost of
+    // acting on it was a permanent wedge:
+    //   • the reply is computed from liveWorkflowListActive() at EXECUTION time, so
+    //     it always describes the genuinely-active tab — the stamp never enters the
+    //     answer, and there is no "wrong tab" for it to answer for;
+    //   • unlike a graph read, the reply CARRIES ITS OWN IDENTITY (routing_key per
+    //     record plus an `active` flag), so a caller holding a stale expectation can
+    //     see the difference rather than misattribute the result. graph_outline
+    //     returns node content with nothing to check it against — which is exactly
+    //     why it stays in this list;
+    //   • the orchestrator corroborates the active record against the open list
+    //     (corroborateActiveForFence) before adopting a uuid from it, so the panel
+    //     fence was not the thing preventing a bad adoption.
+    // And fencing it made the ONE repair probe depend on the fence being already
+    // correct, which is what left the documented recovery a no-op. Exemption and
+    // reasoning: see the '#932 …' tests above.
     'workflow_save',
     'workflow_save_as',
     'workflow_rename',

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -99,6 +99,7 @@ import {
 import {
   classifyPinnedTarget,
   commandIsCanvasIndependent,
+  commandIsCanvasTargetless,
   commandTargetsActiveWorkflow,
   hasEmbeddedUuidSuccessionEvidence,
   selectorSearchIncludesListed,
@@ -14999,7 +15000,7 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
             // a CANVAS write landing on the wrong workflow, and these commands write
             // to no canvas. Fencing them anyway re-creates the false refusal one
             // guard further down whenever a pinned session's active tab changed.
-            if (typeof pinnedPath === "string" && pinnedPath.trim() && !commandIsCanvasIndependent(msg.cmd)) {
+            if (typeof pinnedPath === "string" && pinnedPath.trim() && !commandIsCanvasTargetless(msg.cmd)) {
               const wf = activeWorkflowRef();
               // A pin identifier from panel_list_workflows / panel_new_workflow /
               // panel_set_workflow_target may be a path, a native key, a filename, OR

--- a/web/js/lib/workflow-chat-identity.js
+++ b/web/js/lib/workflow-chat-identity.js
@@ -275,6 +275,27 @@ export function commandIsCanvasIndependent(cmd) {
   return CANVAS_INDEPENDENT_COMMANDS.has(cmd);
 }
 
+/** #932 — commands that NO canvas-targeting guard may refuse, because they name no
+ *  canvas to get wrong. Strictly wider than commandIsCanvasIndependent: it adds
+ *  `workflow_list`, which DOES observe the canvas (it reports which tab is active)
+ *  and so cannot honestly join that set, but which targets none.
+ *
+ *  Both guards this feeds exist to stop an operation landing on the WRONG workflow —
+ *  the uuid fence (#570) and the pinned-target guard (#349/#186). `workflow_list`
+ *  lands on nothing: it mutates no graph, selects no target (it enumerates every open
+ *  tab), and returns tab metadata rather than graph content.
+ *
+ *  It is also the ONLY probe the recovery path has. `rebindWorkflowFence()` re-derives
+ *  a session's target from `workflow_list`'s active record, so gating it behind either
+ *  guard makes the repair require the thing it repairs to be already-correct. That
+ *  circularity is what made #932/#607/#688 permanent: every command refused, and the
+ *  refusal text advertising a recovery that was itself refused for the same reason.
+ *  Both guards must consult THIS predicate, or the wedge simply moves to whichever one
+ *  was left behind. */
+export function commandIsCanvasTargetless(cmd) {
+  return commandIsCanvasIndependent(cmd) || cmd === 'workflow_list';
+}
+
 /** #570 — does the per-command workflow-instance uuid fence APPLY to this command? The fence
  *  refuses a command whose stamped workflow_uuid ≠ the ACTIVE workflow's uuid, so it must cover
  *  everything that runs against the active canvas — every graph_* op AND the active-workflow
@@ -292,14 +313,37 @@ export function commandIsCanvasIndependent(cmd) {
  *   • canvas-independent Manager/server commands (CANVAS_INDEPENDENT_COMMANDS, #602): their
  *     execution and reply never reference the active canvas, so a stale stamp is irrelevant;
  *   • workflow_open / workflow_new: navigation/creation with their own explicit/new target;
+ *   • workflow_list: the RECOVERY PROBE — see below;
  *   • workflow_rename / workflow_close whose selector resolves to a genuinely NON-active open
  *     workflow (`targetsNonActive` — via selectorTargetsNonActiveWorkflow): a deterministic
  *     close/rename of a DIFFERENT workflow must run. A path that resolves to the ACTIVE workflow
  *     (incl. after an in-place replacement) is NOT exempt — it is fenced.
- *  Reads (graph_get_state, …) still return true here — harmlessly fenced (fail-closed); their
- *  reply is server-fenced anyway, and a read can only run against the active canvas regardless. */
+ *  Other reads (graph_get_state, …) still return true here — harmlessly fenced (fail-closed);
+ *  their reply is server-fenced anyway, and a read can only run against the active canvas
+ *  regardless.
+ *
+ *  #932/#607/#688 — `workflow_list` is the ONE read for which "harmlessly fenced" was FALSE,
+ *  and fencing it is what made the wedge PERMANENT rather than merely annoying. The
+ *  orchestrator repairs a stale fence exactly one way: `rebindWorkflowFence()` probes with
+ *  `workflow_list` and re-derives the stamp from the active record it returns. Fencing that
+ *  probe makes the repair depend on the fence being already-correct — so a stale stamp refuses
+ *  the only command that could refresh it, `panel_set_workflow_target({mode:"current"})` comes
+ *  back "could not read the live canvas identity", and NOTHING inside the protocol can clear
+ *  it. That circularity, not the refusal itself, is what those reports describe as "the
+ *  documented recovery paths do not clear the guard"; the advertised remedy was a no-op and a
+ *  browser reload was the only exit.
+ *
+ *  Exempting it does not weaken the guard the fence exists to be. The fence stops a command
+ *  from being APPLIED to a canvas it was not issued for. `workflow_list` applies nothing: it
+ *  mutates no graph, names no target (it enumerates every open tab rather than selecting one),
+ *  and its reply carries tab METADATA only — path, title, routing key, active/modified flags —
+ *  never graph content. Decisively, its handler reads the LIVE binding at execution time
+ *  (`liveWorkflowListActive()`), so a stale stamp cannot make it report a stale answer: the
+ *  reply describes the canvas that is actually active, which is precisely the fact the caller
+ *  needs in order to stop being wrong. A read that cannot be misapplied has nothing to fence,
+ *  and this one is the way back. */
 export function activeWorkflowFenceApplies({ cmd, targetsNonActive = false } = {}) {
-  if (commandIsCanvasIndependent(cmd)) return false;
+  if (commandIsCanvasTargetless(cmd)) return false;
   if (cmd === 'workflow_open' || cmd === 'workflow_new') return false;
   if ((cmd === 'workflow_rename' || cmd === 'workflow_close') && targetsNonActive) return false;
   return true;


### PR DESCRIPTION
## The circularity

`workflow_list` was refused by both canvas-target guards — the workflow-instance uuid
fence (#570) and the pinned-target guard (#349/#186). It is also the **only** probe the
recovery path has: `rebindWorkflowFence()` re-derives a session's target from the active
record `workflow_list` returns.

So repairing a stale target required the target to already be correct:

```
stale stamp
  → panel_set_workflow_target({mode:"current"})
    → rebindWorkflowFence()
      → ctx.call({cmd:"workflow_list"})
        → REFUSED: "workflow instance mismatch"     ← by the very fence being repaired
  → "Could NOT read the live canvas identity … still fenced to the previous
     workflow instance, which the panel will keep refusing."
```

That is what artokun/comfyui-mcp#932, #607 and #688 describe as *"the documented recovery
paths do not clear the guard"*. The advertised remedy was a no-op and a browser reload was
the only exit.

## Reproduced live before fixing

On released builds — orchestrator `mcp=0.50.14`, panel `panel=0.11.44` — a plain
`panel_new_workflow` → `panel_query_graph` → `panel_add_node` → `panel_query_graph`
sequence produced one success and three hard `workflow instance mismatch` refusals, with
the failed rebind quoting the refusal as its own underlying cause. `node_count: 0`
afterwards confirms the refusals were real: the node never landed.

## Why the exemption is safe

Both guards exist to stop an operation landing on the **wrong** workflow. `workflow_list`
lands on nothing:

- it mutates no graph;
- it selects no target — it enumerates *every* open tab rather than naming one;
- its reply is tab metadata (path, title, routing key, active/modified flags), never
  graph content;
- its handler reads the live binding at execution time (`liveWorkflowListActive()`), so a
  stale stamp cannot make it answer for a stale tab — the reply describes whatever is
  genuinely active, which is precisely the fact the caller needs;
- unlike a graph read, the reply **carries its own identity**, so a caller holding a stale
  expectation can see the difference instead of misattributing the result;
- the orchestrator still corroborates the active record against the open list
  (`corroborateActiveForFence`) before adopting a uuid from it.

## Both guards, not one

The new predicate `commandIsCanvasTargetless` feeds the fence **and** the pin guard.
Exempting the fence alone would have left a pinned session wedged the same way one guard
over — with the pin refusal advertising the very `mode:"current"` re-target that runs
through `workflow_list`.

It stays **out** of `CANVAS_INDEPENDENT_COMMANDS`: `workflow_list` does observe the canvas,
so claiming otherwise would falsify that set's contract. Canvas-observing, not
canvas-targeting.

## Tests

50 in the fence file, 2831 in the panel suite, plus typecheck and the vocabulary gate.
Mutation-verified on both classes:

| mutation | result |
|---|---|
| delete the exemption from the classifier | 6 tests fail |
| revert the pin-guard call site to the narrow predicate | wiring test fails |

Marker counts were asserted before and after each mutation — these files are CRLF, where a
naive substitution silently no-ops and reports a false clean sweep.

Two existing tests asserted the old behaviour on the premise that the reply "describes the
active workflow, so a stale-stamped call would answer for the wrong tab". Both are updated
**in place** with why that premise does not hold, rather than deleted.

## Not claimed

This does not touch the second failure mode seen in the same session — an orchestrator-side
`no connected tab can be chosen … issued from multiple workflows at once`, which fires when
`panel_new_workflow` moves the canvas mid-turn and is self-clearing on the next
single-origin message. That is a separate defect and is filed separately.

Does not close the reports on its own: they close when someone confirms on a released build.
