### PR TITLE
fix(fence): let an UNSAVED canvas publish its established identity

### DIFF
--- a/browser_tests/unit/open-outcome.test.mjs
+++ b/browser_tests/unit/open-outcome.test.mjs
@@ -1031,7 +1031,30 @@ test("#716 P1: a malformed truthy active binding cannot mint reply identity", ()
   assert.equal(workflowUuids.has(malformedActive), false, "must not mint an ephemeral workflow UUID");
 });
 
-test("#716 P1: a temporary workflow UUID is never published as a durable refresh source", () => {
+// #760 — this test used to assert the OPPOSITE ("a temporary workflow UUID is
+// never published as a durable refresh source"), on the reading that "its tmp
+// routing identity is ephemeral, so it cannot refresh the MCP's durable command
+// fence". Two things in that premise do not hold, and the cost of acting on it
+// was that an unsaved canvas could never rebind its fence at all:
+//
+//   • it conflates two different values. What gets published as the fence source
+//     is `workflowObjectUuid` — the canonical per-instance uuid from the LIVE-
+//     OBJECT map — NOT the tmp handle. The tmp handle is only the routing key.
+//   • the tmp handle is not ephemeral either: `_tempWorkflowInstanceIds` is keyed
+//     on the live object exactly so "the same unsaved workflow must keep ONE tmp:
+//     id for its lifetime" (a churning id would cause a re-hello storm).
+//
+// And a fence REFRESH is not a durable-resume record: it re-stamps commands for
+// the canvas that is live right now and is discarded when the tab changes.
+// Decisively, the panel's own fence comparison uses workflowStableUuid(), which
+// for an unsaved workflow returns this same objectUuid — so publishing it makes
+// the orchestrator's stamp match the panel's active uuid exactly, which is the
+// whole point of the refresh.
+//
+// The #716 rule that DOES still hold — a reply must never INITIALIZE an identity
+// — is unchanged and separately pinned by the test below: workflowObjectUuid is a
+// pure read, so an object with no established uuid still publishes nothing.
+test("#760: an unsaved canvas with an ESTABLISHED uuid can refresh the fence", () => {
   const src = readFileSync(PANEL_JS, "utf8");
   const pathSource = namedFunctionSource(src, "savedWorkflowPath");
   const canonicalUuidSource = namedFunctionSource(src, "isCanonicalWorkflowInstanceUuid");
@@ -1039,10 +1062,12 @@ test("#716 P1: a temporary workflow UUID is never published as a durable refresh
   const helperSource = namedFunctionSource(src, "activeWorkflowUuidForOpenReply");
   const temporaryActive = { isPersisted: false, isTemporary: true };
   const workflowUuids = new WeakMap([[temporaryActive, "33333333-3333-4333-8333-333333333333"]]);
+  const tempIds = new WeakMap([[temporaryActive, "tmp:33333333-3333-4333-8333-333333333333"]]);
   const replyUuid = new Function(
     "activeWorkflowRef",
     "workflowObjectUuid",
     "savedWorkflowHandle",
+    "workflowTabId",
     `${pathSource}; ${canonicalUuidSource}; ${identitySource}; ${helperSource}; return activeWorkflowUuidForOpenReply;`,
   )(
     () => temporaryActive,
@@ -1051,11 +1076,66 @@ test("#716 P1: a temporary workflow UUID is never published as a durable refresh
     // sandboxes exist to run the shipped reply-identity code, and a hand-rolled
     // `wf:` + path here would be the second spelling the shared helper removed.
     savedWorkflowHandle,
+    (wf) => tempIds.get(wf),
   );
 
-  // Even an existing object-map UUID is insufficient for a temporary tab:
-  // its tmp routing identity is ephemeral, so it cannot refresh the MCP's
-  // durable command fence.
+  // The FENCE uuid is published — the canonical live-object value, not the handle.
+  assert.equal(replyUuid(temporaryActive), "33333333-3333-4333-8333-333333333333");
+});
+
+test("#760: an unsaved canvas with NO established uuid still publishes nothing (#716 holds)", () => {
+  // The establishment test moved, it did not go away. workflowObjectUuid is a
+  // pure WeakMap read, so an object the panel has never established has no uuid
+  // and the reply refuses to invent one — which is the actual #716 invariant.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const pathSource = namedFunctionSource(src, "savedWorkflowPath");
+  const canonicalUuidSource = namedFunctionSource(src, "isCanonicalWorkflowInstanceUuid");
+  const identitySource = namedFunctionSource(src, "establishedWorkflowReplyIdentity");
+  const helperSource = namedFunctionSource(src, "activeWorkflowUuidForOpenReply");
+  const unestablished = { isPersisted: false, isTemporary: true };
+  let tabIdCalls = 0;
+  const replyUuid = new Function(
+    "activeWorkflowRef",
+    "workflowObjectUuid",
+    "savedWorkflowHandle",
+    "workflowTabId",
+    `${pathSource}; ${canonicalUuidSource}; ${identitySource}; ${helperSource}; return activeWorkflowUuidForOpenReply;`,
+  )(
+    () => unestablished,
+    () => undefined, // never established
+    savedWorkflowHandle,
+    () => {
+      tabIdCalls += 1;
+      return "tmp:should-never-be-reached";
+    },
+  );
+
+  assert.equal(replyUuid(unestablished), null);
+  // …and it bailed BEFORE reaching the handle, so nothing was minted on the way.
+  assert.equal(tabIdCalls, 0, "an unestablished object must not even ask for a routing handle");
+});
+
+test("#760: a non-canonical uuid on an unsaved canvas is still refused", () => {
+  // The canonical-shape gate must not be bypassed by the new unsaved branch.
+  const src = readFileSync(PANEL_JS, "utf8");
+  const pathSource = namedFunctionSource(src, "savedWorkflowPath");
+  const canonicalUuidSource = namedFunctionSource(src, "isCanonicalWorkflowInstanceUuid");
+  const identitySource = namedFunctionSource(src, "establishedWorkflowReplyIdentity");
+  const helperSource = namedFunctionSource(src, "activeWorkflowUuidForOpenReply");
+  const temporaryActive = { isPersisted: false, isTemporary: true };
+  const replyUuid = new Function(
+    "activeWorkflowRef",
+    "workflowObjectUuid",
+    "savedWorkflowHandle",
+    "workflowTabId",
+    `${pathSource}; ${canonicalUuidSource}; ${identitySource}; ${helperSource}; return activeWorkflowUuidForOpenReply;`,
+  )(
+    () => temporaryActive,
+    () => "tmp:not-a-uuid", // the ROUTING handle, wrongly offered as the uuid
+    savedWorkflowHandle,
+    (wf) => `tmp:${String(!!wf)}`,
+  );
+
   assert.equal(replyUuid(temporaryActive), null);
 });
 

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2109,17 +2109,47 @@ function isCanonicalWorkflowInstanceUuid(value) {
 // to publish as a command-fence refresh source.
 function establishedWorkflowReplyIdentity(wf) {
   if (!wf || typeof wf !== "object") return null;
+  // THE ESTABLISHMENT TEST, and the only one that matters here (#716): the uuid
+  // must ALREADY be in the live-object map. workflowObjectUuid() is a pure read —
+  // it never mints — so a reply still cannot initialize an identity. Everything
+  // below runs only for an object the panel has already established.
   const uuid = workflowObjectUuid(wf);
   if (!isCanonicalWorkflowInstanceUuid(uuid)) return null;
   const savedPath = savedWorkflowPath(wf);
-  if (!savedPath) return null;
   // #640 — the SHARED spelling of the handle format, not a second local one.
   // This value is compared against workflowTabId()'s elsewhere in the same reply
   // (each workflow_list record's `active` flag is `routingKey === activeRoutingKey`),
   // so two independent spellings are a silent divergence waiting to happen:
   // whichever changed first, every record would report active:false and the agent
   // would be told no tab is active.
-  const routingKey = savedWorkflowHandle(savedPath);
+  if (savedPath) {
+    const routingKey = savedWorkflowHandle(savedPath);
+    return routingKey ? { routingKey, uuid } : null;
+  }
+  // UNSAVED — previously `return null` here, on the reading that "a tmp: routing
+  // handle is not durable enough to publish as a command-fence refresh source".
+  //
+  // Durability is the wrong axis, and the cost of that reading was the wedge in
+  // #760. A fence REFRESH is not a durable-resume record: it re-stamps commands
+  // for the canvas that is live right now, and it is thrown away when the tab
+  // changes. What it needs is a per-INSTANCE identity, which is exactly what the
+  // uuid proven above is — it comes from the live-object WeakMap, and a copy,
+  // import or in-place replace never shares that (#570, resolveUnsavedInstanceUuid).
+  //
+  // Returning null here meant an unsaved canvas could never publish an identity,
+  // so `workflow_list`'s top-level `active` record carried null key/routing_key,
+  // corroborateActiveForFence() found no comparable field, and the fence was never
+  // adopted. Since panel_new_workflow CREATES an unsaved workflow, recovery was not
+  // failing for those sessions — it was unavailable, which is the "permanently
+  // wedged / documented recovery does not clear the guard" of artokun/comfyui-mcp#932,
+  // #607 and #688.
+  //
+  // The tmp: handle comes from workflowTabId(), the same function brief() uses for
+  // every list record, so the two spellings agree by construction — the #640 hazard
+  // above is reduced here, not introduced. (It reads a DIFFERENT map from the uuid
+  // and may mint the handle; that is the ordinary routing-handle mint dispatch does
+  // constantly, not an identity initialization — the identity was already proven.)
+  const routingKey = workflowTabId(wf);
   return routingKey ? { routingKey, uuid } : null;
 }
 


### PR DESCRIPTION
Closes #760.

> **This reverses a deliberate, tested design decision.** The test asserting the old
> behaviour is updated in place with the reasoning rather than deleted. It deserves a
> considered review, not a rubber stamp.

## What was happening

`establishedWorkflowReplyIdentity()` returned `null` for any workflow without a saved path,
so an **unsaved canvas could never publish an identity in a reply**. Measured live on
`mcp=0.50.14` / `panel=0.11.44`, both records describing the *same* just-created workflow:

```
top-level `active`   : key None,             routing_key None
flagged list entry   : key 'tmp:68b3d2dd…',  routing_key 'tmp:68b3d2dd…'
```

The list entry derives identity independently via `workflowTabId()` and resolves fine. The
top-level record goes through `activeIdentity` and comes back empty. The orchestrator's
`corroborateActiveForFence()` then reports:

> the active record and the open-workflow list share no comparable identity field, so
> nothing corroborates it

…refuses to adopt, and the session stays fenced to the previous instance. Every following
graph command returns `workflow instance mismatch`.

Since `panel_new_workflow` **creates** an unsaved workflow, recovery for those sessions was
not failing — it was *unavailable*. That is the permanent half of artokun/comfyui-mcp#932,
#607 and #688, and why the advertised `panel_set_workflow_target({mode:"current"})` returns
a hollow non-recovery.

## Why the old premise does not hold

The rule read: *"a tmp: routing handle is not durable enough to publish as a command-fence
refresh source."*

1. **It conflates two values.** What is published is `workflowObjectUuid` — the canonical
   per-instance uuid from the **live-object** map. The tmp handle is only the routing key.
2. **The handle is not ephemeral.** `_tempWorkflowInstanceIds` is keyed on the live object
   precisely so that one unsaved workflow keeps **one** tmp: id for its lifetime — a
   churning id would cause the re-hello storm that comment warns about.
3. **A fence refresh is not a durable-resume record.** It re-stamps commands for the canvas
   that is live *now* and is discarded when the tab changes. Durability is the wrong axis;
   per-instance correctness is the right one, and the live-object uuid is exactly that
   (#570 — a copy, import or in-place replace never shares it).
4. **Decisively:** the panel's own fence comparison uses `workflowStableUuid()`, which for
   an unsaved workflow returns *this same objectUuid*. Publishing it makes the
   orchestrator's stamp match the panel's active uuid exactly — which is the entire purpose
   of the refresh.

## What #716 still forbids, unchanged

> A reply is an observation, never an identity-initialization point.

`workflowObjectUuid()` is a pure WeakMap read — it never mints. An object the panel has not
established still publishes nothing, and the function bails **before** it would even ask for
a routing handle. Both facts are pinned:

- an unsaved canvas with **no** established uuid → `null`, and `workflowTabId` is called
  **zero** times;
- a **non-canonical** uuid on an unsaved canvas → still refused (the shape gate is not
  bypassed by the new branch).

The handle comes from `workflowTabId()` — the same function `brief()` uses for every list
record — so the two spellings agree by construction. The #640 divergence hazard flagged in
that function is *reduced* here, not introduced.

## Tests

2826 in the panel suite, typecheck and the vocabulary gate green.
Mutation-verified: restoring the early `return null` fails the #760 test.

## Sequencing

Third of three in this cluster, and the last one standing:

| | | |
|---|---|---|
| #759 | the recovery probe was fenced by the fence it repairs | panel |
| artokun/comfyui-mcp#1047 | a save's `tmp:`→`wf:` rename counted as two workflows | orchestrator |
| **this** | an unsaved canvas can never publish a fence identity | panel |

Each was hiding the next: with #759 in place the failure moved from "the panel did not
answer" to "the panel answered, but its reply could not be corroborated", which is what
exposed this one.

Does not close the reports on its own: they close when someone confirms on a released build.
