### PR TITLE
feat(workflow_new): return the workflow_uuid it just minted

### DIFF
--- a/browser_tests/unit/binding-recovery.test.mjs
+++ b/browser_tests/unit/binding-recovery.test.mjs
@@ -113,6 +113,7 @@ function buildWorkflowNew({
     "stampGraphRootWorkflowUuid",
     "backendReconnectEpoch",
     "activeWorkflowResyncEpoch",
+    "isCanonicalWorkflowInstanceUuid",
     `${methodSource}\nreturn workflow_new;`,
   );
   return factory(
@@ -128,8 +129,16 @@ function buildWorkflowNew({
     onStamp,
     1,
     0,
+    realIsCanonicalWorkflowInstanceUuid,
   );
 }
+
+/** The REAL canonical-uuid gate from the shipped source — never a second spelling
+ *  of the regex here (#640). */
+const realIsCanonicalWorkflowInstanceUuid = new Function(
+  `${balancedFrom(SRC, "function isCanonicalWorkflowInstanceUuid(value)")}
+return isCanonicalWorkflowInstanceUuid;`,
+)();
 
 const EMPTY_SERIALIZE = () => ({ nodes: [], links: [], extra: { ds: { offset: [0, 0], scale: 1 } } });
 

--- a/browser_tests/unit/new-workflow-persistence.test.mjs
+++ b/browser_tests/unit/new-workflow-persistence.test.mjs
@@ -657,8 +657,16 @@ function balancedFrom(src, marker, openAt = null) {
   throw new Error(`unterminated block: ${marker}`);
 }
 
-/** The REAL `workflow_new` body, with its globals injected. */
-function buildWorkflowNew({ rootGraph, activeWorkflow }) {
+/** The REAL canonical-uuid gate from the shipped source — never a second spelling
+ *  of the regex here (#640: two spellings of one rule diverge silently). */
+const realIsCanonicalWorkflowInstanceUuid = new Function(
+  `${balancedFrom(SRC, "function isCanonicalWorkflowInstanceUuid(value)")}\nreturn isCanonicalWorkflowInstanceUuid;`,
+)();
+
+/** The REAL `workflow_new` body, with its globals injected.
+ *  `uuid` is what workflowStableUuid() returns for the created tab — default is the
+ *  deliberately NON-canonical placeholder the existing tests were written against. */
+function buildWorkflowNew({ rootGraph, activeWorkflow, uuid = "uuid-new-tab" }) {
   const sigStart = SRC.indexOf("async workflow_new({");
   assert.notEqual(sigStart, -1, "workflow_new not found");
   const bodyBrace = SRC.indexOf(") {", sigStart) + 1;
@@ -679,12 +687,13 @@ function buildWorkflowNew({ rootGraph, activeWorkflow }) {
     "stampGraphRootWorkflowUuid",
     "backendReconnectEpoch",
     "activeWorkflowResyncEpoch",
+    "isCanonicalWorkflowInstanceUuid",
     `${methodSource}\nreturn workflow_new;`,
   )(
     { graph: rootGraph, extensionManager: { command: { execute: async () => {} } } },
     () => activeWorkflow,
     () => "tmp:new-tab",
-    () => "uuid-new-tab",
+    () => uuid,
     () => ({ seq: 7 }),
     (e) => String(e),
     () => "Unsaved Workflow",
@@ -693,6 +702,7 @@ function buildWorkflowNew({ rootGraph, activeWorkflow }) {
     () => {},
     1,
     0,
+    realIsCanonicalWorkflowInstanceUuid,
   );
 }
 
@@ -715,6 +725,61 @@ test("#708 ack: a PROVEN-empty new tab reports created:true — the honest succe
   assert.equal(out.empty, true);
   assert.equal(out.routing_key, "tmp:new-tab");
   assert.equal(out.note, undefined, "a proven blank tab needs no caveat");
+});
+
+// #755 — workflow_new already MINTS the new canvas's fence identity, then dropped it
+// from the reply, so the orchestrator had to make a second workflow_list round trip to
+// re-learn a fact this command was holding. That round trip is where the wedge in
+// artokun/comfyui-mcp#932 lived: it could be refused, it could fail corroboration, and
+// the canvas could change underneath it in between.
+const CANONICAL = "c2512bcc-6a89-4b9f-a58c-ff48a2eb7e95";
+
+test("#755: workflow_new returns the workflow_uuid it just minted", async () => {
+  const workflow_new = buildWorkflowNew({
+    rootGraph: liveRoot(BLANK_GRAPH()),
+    activeWorkflow: { isPersisted: false, isModified: false, changeTracker: { activeState: BLANK_GRAPH() } },
+    uuid: CANONICAL,
+  });
+
+  const out = await workflow_new({ rid: "r1" });
+
+  assert.equal(out.workflow_uuid, CANONICAL);
+  // …alongside, and describing the SAME graph as, the routing handle.
+  assert.equal(out.routing_key, "tmp:new-tab");
+  assert.equal(out.created, true);
+});
+
+test("#755: the UNKNOWN-outcome reply carries it too — the tab is real either way", async () => {
+  // #708 withholds `created:true` when emptiness is unproven, but the tab and its
+  // identity ARE real (the receipt records that). Withholding the uuid here would send
+  // exactly the caller who most needs to re-target back through the round trip this
+  // change exists to remove.
+  const workflow_new = buildWorkflowNew({
+    rootGraph: liveRoot(PREVIOUS_WORKFLOW_GRAPH()),
+    activeWorkflow: { isPersisted: false, isModified: false, changeTracker: { activeState: BLANK_GRAPH() } },
+    uuid: CANONICAL,
+  });
+
+  const out = await workflow_new({ rid: "r1" });
+
+  assert.equal(out.created, "unknown", "the #708 honesty rule is untouched");
+  assert.equal(out.workflow_uuid, CANONICAL, "but the identity is still reported");
+});
+
+test("#755: a NON-canonical value is omitted, never published as an identity", async () => {
+  // The shape gate is the #716 rule carried over: publish a real per-instance uuid or
+  // nothing. A routing handle offered in its place must not be echoed as one.
+  for (const bogus of ["tmp:new-tab", "uuid-new-tab", "", null, undefined]) {
+    const workflow_new = buildWorkflowNew({
+      rootGraph: liveRoot(BLANK_GRAPH()),
+      activeWorkflow: { isPersisted: false, isModified: false, changeTracker: { activeState: BLANK_GRAPH() } },
+      uuid: bogus,
+    });
+    const out = await workflow_new({ rid: "r1" });
+    assert.equal("workflow_uuid" in out, false, `${JSON.stringify(bogus)} must be omitted, not echoed`);
+    // The reply is still fully usable — omission costs a round trip, nothing more.
+    assert.equal(out.routing_key, "tmp:new-tab");
+  }
 });
 
 test("#708 ack: the reported reconnect shape reports outcome-UNKNOWN, never created:true", async () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -10980,7 +10980,30 @@ const GRAPH_TOOL_EXECUTORS = {
     });
     // `key`/`routing_key` are the unique handle the agent should pass to
     // panel_set_workflow_target so its session pins to this exact graph.
-    const identity = { active: getWorkflowTitle(), key, routing_key: key, open_seq: receipt.seq };
+    //
+    // #755 — and `workflow_uuid` is the FENCE identity for that same graph, already
+    // minted above as `newWorkflowUuid`. Omitting it forced the orchestrator into a
+    // second `workflow_list` round trip to learn the identity of a canvas this
+    // command had just created and already knew. That round trip is where the wedge
+    // in artokun/comfyui-mcp#932 lived: it can be refused, it can fail
+    // corroboration, and the canvas can change underneath it in between — three ways
+    // to fail at re-reading a fact we are holding right here.
+    //
+    // Reported for the workflow this command CREATED, which is exactly what
+    // `key`/`routing_key` above already describe, so the three stay coherent even if
+    // a reconnect re-points `active` before the reply lands.
+    //
+    // Shape-gated (#716's rule, unchanged): publish only a canonical uuid, never a
+    // routing handle or a half-established value. The orchestrator keeps its
+    // workflow_list fallback for older panels, so a missing field costs a round trip
+    // rather than breaking anything.
+    const identity = {
+      active: getWorkflowTitle(),
+      key,
+      routing_key: key,
+      open_seq: receipt.seq,
+      ...(isCanonicalWorkflowInstanceUuid(newWorkflowUuid) ? { workflow_uuid: newWorkflowUuid } : {}),
+    };
     // #708 — DO NOT CLAIM "blank" WITHOUT PROVING IT. The tab and its routing identity
     // are real either way (the receipt above records that), but `created:true` on a tool
     // whose whole contract is "a brand-new BLANK workflow" is read as "you have an empty


### PR DESCRIPTION
Closes #755.

`workflow_new` already mints the new canvas's fence identity eagerly:

```js
const key = workflowTabId(wf);
const newWorkflowUuid = workflowStableUuid(wf);   // ← minted, then dropped
```

…and then omitted it from the reply, so the orchestrator had to make a second
`workflow_list` round trip to re-learn a fact this command was holding in a local
variable.

## Why it matters beyond one round trip

That round trip is where the wedge in artokun/comfyui-mcp#932 lived, and it can fail
three different ways:

- it can be **refused** — the probe was itself behind the fence it repairs (#759);
- it can **fail corroboration** — an unsaved canvas published no identity to corroborate
  (#761);
- the canvas can **change in between** creating it and reading it back.

Removing the round trip removes all three for the create path. The orchestrator keeps its
`workflow_list` fallback for older panels, so this is robustness and latency, not a
replacement for those fixes.

## What is reported

The uuid of the workflow this command **created** — exactly what `key`/`routing_key`
already describe — so the three stay coherent even if a reconnect re-points `active`
before the reply lands.

**Shape-gated**, carrying #716's rule over rather than weakening it: publish a real
canonical per-instance uuid, or publish nothing. A routing handle offered in its place is
never echoed as an identity.

**Both reply paths carry it**, including #708's outcome-UNKNOWN one. That reply withholds
`created:true` because emptiness is unproven — but the tab and its identity are real
either way (the open receipt records that), and withholding the uuid there would send
exactly the caller who most needs to re-target back through the round trip this removes.

## Tests

2827 in the suite, typecheck and the vocabulary gate green.

The canonical-uuid gate is **extracted from the shipped source** in both `workflow_new`
harnesses rather than re-spelled in the tests — #640's lesson that two spellings of one
rule diverge silently.

The second harness (`binding-recovery.test.mjs`) was only found by the **full** suite; the
targeted file passed on its own. Worth noting as a recurring shape: `workflow_new` is
rebuilt by `new Function` in two places, and adding a global dependency breaks the one you
did not edit.

Mutation-verified both ways:

| mutation | result |
|---|---|
| drop the field from the reply | 2 tests fail |
| publish it **without** the shape gate | the third test fails |
