### PR TITLE
fix(fence): report the comparison, not a cause the panel never observed

### DIFF
--- a/browser_tests/unit/binding-recovery.test.mjs
+++ b/browser_tests/unit/binding-recovery.test.mjs
@@ -388,8 +388,12 @@ test("#607 the dispatch-time fence also re-advertises before refusing", () => {
   const marker = "const executor = GRAPH_TOOL_EXECUTORS[msg.cmd];";
   const start = SRC.indexOf(marker);
   assert.notEqual(start, -1);
-  const end = SRC.indexOf("workflow instance mismatch:", start);
-  assert.notEqual(end, -1);
+  // #750 moved the refusal TEXT into one shared builder (both dispatch sites used
+  // to carry their own copy), so the literal no longer appears after this point.
+  // Anchor on the call to that builder instead — same place in the flow, and it
+  // now also fails if a site goes back to hand-rolling its own message.
+  const end = SRC.indexOf("workflowInstanceMismatchMessage(", start);
+  assert.notEqual(end, -1, "the dispatch fence must refuse via the shared builder");
   const fenceRegion = SRC.slice(start, end);
   const noteAt = fenceRegion.indexOf("noteWorkflowInstanceMismatch();");
   assert.notEqual(noteAt, -1, "the dispatch fence must re-advertise on refusal");

--- a/browser_tests/unit/workflow-chat-identity.test.mjs
+++ b/browser_tests/unit/workflow-chat-identity.test.mjs
@@ -246,9 +246,89 @@ test('#602 wiring: dispatch skips the graph-binding assert for canvas-independen
     'the pin guard must not fall back to the narrow canvas-independent test',
   )
   // The workflow-instance-mismatch refusal renders for real users; it once shipped
-  // with a mojibake em dash ("â€”"). Pin the clean form.
-  assert.ok(src.includes('active canvas — the workflow was switched or replaced'), 'fence message keeps its em dash')
+  // with a mojibake em dash ("â€”"). Pin the clean form. #750 rewrote the sentence
+  // that used to carry the dash (it asserted a cause the panel never observed), so
+  // the guard now pins the em dash in its replacement.
+  assert.ok(
+    src.includes('That is the comparison, not the cause — the panel observed only that the two'),
+    'fence message keeps its em dash',
+  )
   assert.ok(!src.includes('â€'), 'no mojibake anywhere in the panel source')
+  // …and the refusal is built in exactly ONE place now, so the two dispatch sites
+  // cannot drift apart the way they did while each carried its own copy.
+  assert.equal(
+    (src.match(/workflow instance mismatch: /g) || []).length,
+    1,
+    'the refusal text must have a single spelling',
+  )
+})
+
+// #750 — the refusal must report the COMPARISON it made, not a cause it did not
+// observe. The old text committed to "the workflow was switched or replaced after it
+// was issued"; in the report behind #750 no tab was connected at all, and in the wedge
+// behind artokun/comfyui-mcp#932 nothing had been switched — the fence simply could
+// never be rebound. Both diagnoses were sent down the wrong path by this sentence.
+function loadMismatchMessage() {
+  const HERE = dirname(fileURLToPath(import.meta.url))
+  const src = readFileSync(join(HERE, '../../web/js/comfyui-mcp-panel.js'), 'utf8')
+  const start = src.indexOf('function workflowInstanceMismatchMessage(')
+  assert.notEqual(start, -1, 'the shared refusal builder must exist in the shipped source')
+  const end = src.indexOf('\n}', start)
+  assert.notEqual(end, -1)
+  const body = src.slice(start, end + 2)
+  return new Function(`${body}\nreturn workflowInstanceMismatchMessage;`)()
+}
+
+test('#750 the refusal states the two identities it compared', () => {
+  const msg = loadMismatchMessage()({ commandUuid: 'uuid-issued-for', activeUuid: 'uuid-on-screen' })
+  assert.match(msg, /uuid-issued-for/, 'names the instance the command was issued for')
+  assert.match(msg, /uuid-on-screen/, 'and what the canvas actually reports')
+  assert.match(msg, /Nothing was applied/, 'and that it did not partially run')
+})
+
+test('#750 it does NOT assert a cause it never observed', () => {
+  const msg = loadMismatchMessage()({ commandUuid: 'a', activeUuid: 'b' })
+  // The old sentence, as a bare claim, must be gone.
+  assert.doesNotMatch(
+    msg,
+    /the workflow was switched or replaced after it was issued\./,
+    'the single-cause assertion must not return',
+  )
+  // The switch is still OFFERED as one possibility among several — removing it
+  // entirely would be the opposite error, hiding the most common cause.
+  assert.match(msg, /can mean the workflow was switched or replaced/)
+  assert.match(msg, /never established or could not\s+be refreshed/, 'the #932 cause is listed')
+  assert.match(msg, /identity could not be read/, 'and the unreadable case')
+  assert.match(msg, /comparison, not the cause/, 'and it says which of the two this is')
+})
+
+test('#750 an UNSTAMPED command says so, rather than claiming a different workflow', () => {
+  // #718 refuses unstamped commands too. "your command carried no stamp" and "your
+  // stamp names another workflow" need different fixes; the old text described only
+  // the second, for both.
+  for (const commandUuid of [undefined, null, '', '   ']) {
+    const msg = loadMismatchMessage()({ commandUuid, activeUuid: 'uuid-on-screen' })
+    assert.match(msg, /carries no workflow-instance stamp/)
+    assert.doesNotMatch(msg, /issued for workflow instance/)
+  }
+})
+
+test('#750 an UNRESOLVABLE active identity is reported as unresolvable, not as a value', () => {
+  for (const activeUuid of [undefined, null, '']) {
+    const msg = loadMismatchMessage()({ commandUuid: 'uuid-issued-for', activeUuid })
+    assert.match(msg, /reports no resolvable identity/)
+    assert.doesNotMatch(msg, /reports undefined|reports null|reports \./)
+  }
+})
+
+test('#750 the remedy covers the disconnected case the old text stranded', () => {
+  // The #750 reporter had NO tab connected; the advertised remedies cannot help
+  // there, and it took six tool calls to find that out.
+  const msg = loadMismatchMessage()({ commandUuid: 'a', activeUuid: 'b' })
+  assert.match(msg, /panel_set_workflow_target/)
+  assert.match(msg, /panel_open_workflow/)
+  assert.match(msg, /If NO panel tab is\s+connected, neither will help/)
+  assert.match(msg, /panel_graph_outline reports connectivity/)
 })
 
 test('#570 pinned command after in-place replacement at the same path: uuid mismatch ⇒ REFUSED', () => {

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -2010,23 +2010,63 @@ function noteWorkflowInstanceMismatch() {
     // best-effort — the refusal stands regardless
   }
 }
+/** #750 — the ONE spelling of the fence refusal, reporting WHAT WAS COMPARED
+ *  rather than inferring why the two differed.
+ *
+ *  The old text asserted a single cause: "the workflow was switched or replaced
+ *  after it was issued". That is an inference, and it is frequently wrong. In the
+ *  report behind #750 no panel tab was connected at all, and it took six tool
+ *  calls to reach that far more actionable diagnosis. In the wedge behind
+ *  artokun/comfyui-mcp#932 the cause was that the session's fence could never be
+ *  REBOUND — nothing had been switched or replaced by anyone.
+ *
+ *  A mismatch is two identities failing to be equal. It can equally mean the
+ *  workflow was switched, that the fence was never established, that the identity
+ *  could not be read, or that the canvas is gone. Naming one of those sends the
+ *  diagnosis down a path the panel never observed — the same
+ *  reports-the-request-not-the-effect class cleared elsewhere in this file.
+ *
+ *  The leading `workflow instance mismatch:` token is preserved deliberately: it
+ *  is what readers and existing reports recognise this refusal by. Only the claim
+ *  about causation changes. */
+function workflowInstanceMismatchMessage({ commandUuid, activeUuid } = {}) {
+  const str = (v) => (typeof v === "string" && v.trim() ? v.trim() : null);
+  const expected = str(commandUuid);
+  const live = str(activeUuid);
+  const canvasSays = live ? `the active canvas reports ${live}` : `the active canvas reports no resolvable identity`;
+  // An UNSTAMPED command is refused too (#718 — an advertised fence must not fail
+  // open), and saying so plainly is worth a line: "your command carried no stamp"
+  // and "your stamp names another workflow" need different fixes, and the old text
+  // described only the second.
+  const compared = expected
+    ? `this command was issued for workflow instance ${expected}, and ${canvasSays}`
+    : `this command carries no workflow-instance stamp, and ${canvasSays}`;
+  return (
+    `workflow instance mismatch: ${compared}. Nothing was applied.\n\n` +
+    `That is the comparison, not the cause — the panel observed only that the two ` +
+    `identities differ. It can mean the workflow was switched or replaced after the ` +
+    `command was issued, that this session's fence was never established or could not ` +
+    `be refreshed, or that the identity could not be read at all.\n\n` +
+    `Re-target with panel_set_workflow_target({mode:"current"}), or re-select the ` +
+    `intended workflow with panel_open_workflow, then retry. If NO panel tab is ` +
+    `connected, neither will help and the connection is the thing to fix — ` +
+    `panel_graph_outline reports connectivity directly.`
+  );
+}
+
 function assertActiveWorkflowCommandTarget(msg, targetsNonActive = false) {
   const commandUuid = msg?.[WORKFLOW_UUID_FIELD];
+  const activeUuid = workflowStableUuid();
   if (
     !commandTargetsActiveWorkflow({
       cmd: msg?.cmd,
       commandUuid,
-      activeUuid: workflowStableUuid(),
+      activeUuid,
       targetsNonActive,
     })
   ) {
     noteWorkflowInstanceMismatch();
-    throw new Error(
-      `workflow instance mismatch: this command targets a different workflow than the ` +
-        `active canvas — the workflow was switched or replaced after it was issued. ` +
-        `Re-select the intended workflow (panel_open_workflow) or re-target with ` +
-        `panel_set_workflow_target({mode:"current"}), then retry.`,
-    );
+    throw new Error(workflowInstanceMismatchMessage({ commandUuid, activeUuid }));
   }
 }
 
@@ -14967,11 +15007,18 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
                 targetsNonActive = selectorTargetsNonActiveWorkflow({ resolved, active });
               }
             }
+            // #750 — read both sides ONCE, so the refusal reports the same two
+            // identities the comparison actually used. Re-reading them inside the
+            // message would let a switch land in between and print a pair that was
+            // never compared: the reports-what-it-observed rule applied to the
+            // diagnostic itself.
+            const dispatchCommandUuid = msg?.[WORKFLOW_UUID_FIELD];
+            const dispatchActiveUuid = workflowStableUuid();
             if (
               !commandTargetsActiveWorkflow({
                 cmd: msg.cmd,
-                commandUuid: msg?.[WORKFLOW_UUID_FIELD],
-                activeUuid: workflowStableUuid(),
+                commandUuid: dispatchCommandUuid,
+                activeUuid: dispatchActiveUuid,
                 targetsNonActive,
               })
             ) {
@@ -14980,10 +15027,10 @@ function createBridgeClient({ onStatus, onSay, onStream, onLog, onCommand, onCom
               // cached stamp; see noteWorkflowInstanceMismatch.
               noteWorkflowInstanceMismatch();
               throw new Error(
-                `workflow instance mismatch: this command targets a different workflow than the ` +
-                  `active canvas — the workflow was switched or replaced after it was issued. ` +
-                  `Re-select the intended workflow (panel_open_workflow) or re-target with ` +
-                  `panel_set_workflow_target({mode:"current"}), then retry.`,
+                workflowInstanceMismatchMessage({
+                  commandUuid: dispatchCommandUuid,
+                  activeUuid: dispatchActiveUuid,
+                }),
               );
             }
             // #349: UUID fencing proves the command was issued for the active


### PR DESCRIPTION
Closes #750 (a). **Part (b) of that issue is real** — see the answer below.

## The claim that was wrong

```
workflow instance mismatch: this command targets a different workflow than the
active canvas — the workflow was switched or replaced after it was issued.
```

"The stamps differ" is an observation. "The workflow was switched or replaced" is an
inference about *why*, and it is frequently wrong:

- in **#750's report** no panel tab was connected at all — six tool calls were spent
  before `panel_graph_outline` produced that far more actionable diagnosis;
- in **artokun/comfyui-mcp#932** nothing had been switched by anyone — the session's fence
  could never be *rebound*, because the probe that refreshes it was itself refused by the
  fence.

Both diagnoses were sent down the wrong path by that one sentence.

## What it says now

The two identities it compared, that this is the comparison rather than the cause, and the
possibilities instead of one asserted answer. The switch/replace case is still named — it
is the most common — just no longer stated as fact.

Two further gains fall out of stating the comparison:

- an **unstamped** command now says so, rather than claiming it "targets a different
  workflow". #718 refuses unstamped commands too, and *"your command carried no stamp"*
  and *"your stamp names another workflow"* need different fixes;
- an **unresolvable** active identity is reported as unresolvable, not rendered as a value.

And the remedy covers the disconnected case the old text stranded: if no tab is connected,
neither re-target helps, and `panel_graph_outline` is what answers.

## One spelling

Both dispatch sites carried their own copy of the message. They now call one builder, and
a test pins that the text has a single spelling. Both sides of the comparison are read
**once** and passed in, so the refusal cannot print a pair that was never compared — the
reports-what-it-observed rule applied to the diagnostic itself.

## Answering part (b): yes, and it is fixed

> **Ask:** confirm read-only, tab-agnostic commands are never refused by the
> workflow-instance fence — and if they already aren't, say so here and I will chase the
> remaining explanation on our side.

They **were** being refused. You were right not to trust the report alone, and right that
the orchestrator was not the cause. The panel's `activeWorkflowFenceApplies()` exempted
only canvas-independent commands and `workflow_open`/`workflow_new`; `workflow_list` was
fenced, with a comment reasoning that its reply "describes the active workflow, so a
stale-stamped call would answer for the wrong tab".

I reproduced it live on `mcp=0.50.14` / `panel=0.11.44`. It is worse than losing a
diagnostic tool: `workflow_list` is the **only** probe `rebindWorkflowFence()` has, so
gating it made the repair require the fence to be already-correct. That is the permanent
wedge in #932/#607/#688.

#759 exempts it from that fence **and** from the pinned-target guard. No third cause to
chase — thank you for flagging it as unconfirmed rather than asserting it, which is what
made it worth checking properly.

## Tests

2829, typecheck and vocabulary gate green. Mutation-verified: restoring the single-cause
assertion fails 2 tests; collapsing the unstamped branch fails 1.

Two existing tests are **re-anchored, not weakened** — the mojibake guard pins the em dash
in the replacement sentence, and #607's structural check now anchors on the shared builder.
I verified that check still fails when the re-advertise call is deleted, so it kept its
teeth.
