### PR TITLE
fix(attachments): keep the upload status and the exception

### DIFF
--- a/browser_tests/unit/attachment-upload.test.mjs
+++ b/browser_tests/unit/attachment-upload.test.mjs
@@ -1,0 +1,139 @@
+// panel#756 — a chat attachment upload that fails must report WHAT WAS OBSERVED.
+//
+// Both upload paths threw the outcome away twice: a non-200 had no `else` at all,
+// and the `catch` was bare. The agent got the string `upload failed` and nothing
+// more — no status, no size, no MIME type, no exception — so two failing .mp4
+// uploads could not be diagnosed by anyone, including the reporter.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  describeUploadFailure,
+  attachmentSummaryLine,
+  clipUploadBody,
+  describeSize,
+} from "../../web/js/lib/attachment-upload.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+test("#756 a refused upload reports the STATUS and the server's own words", () => {
+  const msg = describeUploadFailure({
+    status: 413,
+    statusText: "Payload Too Large",
+    body: "file exceeds max upload size",
+    name: "clip.mp4",
+    size: 88 * 1024 * 1024,
+    mediaType: "video/mp4",
+  });
+  assert.match(msg, /HTTP 413/);
+  assert.match(msg, /Payload Too Large/);
+  assert.match(msg, /clip\.mp4/);
+  assert.match(msg, /88\.0 MB/, "the size is what tells a caller whether to shrink it");
+  assert.match(msg, /video\/mp4/);
+  assert.match(msg, /Server said: file exceeds max upload size/);
+  assert.match(msg, /Nothing was written to input/);
+});
+
+test("#756 it does NOT infer a cause from the status", () => {
+  // A 413 is evidence ABOUT size; "the file is too big" is a conclusion. Asserting
+  // it is the same defect as the fence claiming "the workflow was switched" for
+  // every mismatch (#750) — and it would be wrong for a proxy-imposed limit.
+  const msg = describeUploadFailure({ status: 413, name: "a.mp4", size: 10, mediaType: "video/mp4" });
+  assert.doesNotMatch(msg, /too big|too large a file|shrink|re-encode|reduce the/i);
+  // …and it says plainly that the server explained nothing, rather than filling in.
+  assert.match(msg, /sent no body explaining it/);
+});
+
+test("#756 a transport failure is reported as a THROW, distinctly from a refusal", () => {
+  // The two need different responses: a refusal means the server judged the file,
+  // a throw means the request never completed. The old bare catch made them
+  // indistinguishable.
+  const msg = describeUploadFailure({ error: new TypeError("Failed to fetch"), name: "b.mp4", size: 2048 });
+  assert.match(msg, /did not COMPLETE/);
+  assert.match(msg, /Failed to fetch/);
+  assert.match(msg, /2\.0 KB/);
+  assert.doesNotMatch(msg, /HTTP/, "there was no status — do not invent one");
+  // Honest about the part that genuinely is unknown.
+  assert.match(msg, /Whether any bytes reached the server is unknown/);
+});
+
+test("#756 neither observed ⇒ says so, rather than picking the likelier half", () => {
+  const msg = describeUploadFailure({ name: "c.mp4" });
+  assert.match(msg, /unobserved reason/);
+  assert.match(msg, /no HTTP status and no exception were captured/);
+  assert.doesNotMatch(msg, /HTTP \d/);
+});
+
+test("#756 a huge error body is clipped, with the true length disclosed", () => {
+  // This lands in an agent's context; an HTML error page would otherwise paste the
+  // whole document into the chat. Truncation that hides its own extent is the
+  // silent-omission bug in miniature, so the real length is stated.
+  const body = "x".repeat(5000);
+  const clipped = clipUploadBody(body);
+  assert.ok(clipped.length < 600);
+  assert.match(clipped, /\[5000 chars total\]/);
+  assert.equal(clipUploadBody("   "), null, "an empty body is absent, not an empty quote");
+  assert.equal(clipUploadBody(undefined), null);
+});
+
+test("#756 describeSize refuses nonsense instead of rendering it", () => {
+  assert.equal(describeSize(512), "512 B");
+  assert.equal(describeSize(2048), "2.0 KB");
+  assert.equal(describeSize(1572864), "1.5 MB");
+  for (const bad of [undefined, null, -1, NaN, "big"]) assert.equal(describeSize(bad), null);
+});
+
+test("#756 the SUCCESS line is unchanged — only failure gained detail", () => {
+  const line = attachmentSummaryLine({ token: "[Video #3]", inputRef: "sub/clip.mp4" });
+  assert.equal(line, "[Video #3] → input/sub/clip.mp4");
+});
+
+test("#756 the failure line carries the captured cause, not a bare 'upload failed'", () => {
+  const withCause = attachmentSummaryLine({
+    token: "[Video #3]",
+    name: "clip.mp4",
+    uploadError: "upload REFUSED by ComfyUI — HTTP 413. Nothing was written to input/.",
+  });
+  assert.match(withCause, /HTTP 413/);
+  // And with nothing captured it still degrades to the old string rather than
+  // rendering "undefined" — a fallback, not a fabrication.
+  const bare = attachmentSummaryLine({ token: "[Video #3]", name: "clip.mp4" });
+  assert.equal(bare, "[Video #3] (clip.mp4 — upload failed)");
+});
+
+test("#756 WIRING: both upload paths record the status and the exception", () => {
+  // The helper being right proves nothing if the call sites still discard. Pin the
+  // two sites that had the defect, and that neither bare form survives.
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.equal(
+    (src.match(/att\.uploadError = describeUploadFailure\(\{\s*\r?\n?\s*status: res\.status/g) || []).length,
+    2,
+    "both upload paths must record a non-200 status",
+  );
+  assert.equal(
+    (src.match(/catch \(err\) \{[\s\S]{0,200}?att\.uploadError = describeUploadFailure\(\{ error: err/g) || []).length,
+    2,
+    "both upload paths must record the caught exception",
+  );
+  assert.ok(
+    !src.includes("/* upload failed — the chip still references it by name as a fallback */"),
+    "the bare image catch must be gone",
+  );
+  assert.ok(
+    !src.includes("/* upload failed — the chip still names the file as a fallback */"),
+    "the bare media catch must be gone",
+  );
+});
+
+test("#756 WIRING: the agent-facing lines report failure on BOTH branches", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  // media branch routes through the shared builder…
+  assert.match(src, /\.map\(\(a\) => attachmentSummaryLine\(a\)\)/);
+  // …and the image branch, which used to say NOTHING when the ref was absent.
+  assert.match(src, /NOT in input\/ — \$\{a\.uploadError \?\? "upload failed, cause unobserved"\}/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -66,6 +66,7 @@ import { marked } from "./vendor/marked.esm.js";
 import DOMPurify from "./vendor/purify.es.js";
 import qrcodegen from "./vendor/qrcode.esm.js";
 import { computeLayout } from "./lib/layout-engine.js";
+import { describeUploadFailure, attachmentSummaryLine } from "./lib/attachment-upload.js";
 import {
   buildInstallRequest,
   classifyInstallOutcome,
@@ -25389,9 +25390,21 @@ function buildPanel() {
           const info = await res.json();
           att.inputRef = (info.subfolder ? `${info.subfolder}/` : "") + info.name;
           att.ref = { filename: info.name, subfolder: info.subfolder || undefined, type: info.type || "input" };
+        } else {
+          // #756 — a non-200 had NO else at all. The status was in hand and thrown
+          // away, leaving "upload failed" as the whole of what anyone could learn.
+          att.uploadError = describeUploadFailure({
+            status: res.status,
+            statusText: res.statusText,
+            body: await res.text().catch(() => null),
+            name,
+            size: file.size,
+            mediaType: file.type,
+          });
         }
-      } catch {
-        /* upload failed — the chip still references it by name as a fallback */
+      } catch (err) {
+        // #756 — the bare catch swallowed transport failures identically.
+        att.uploadError = describeUploadFailure({ error: err, name, size: file.size, mediaType: file.type });
       }
     })();
     att.ready.then(renderAttachmentChips, () => {}); // refresh once the thumb loads
@@ -25425,9 +25438,21 @@ function buildPanel() {
           const info = await res.json();
           att.inputRef = (info.subfolder ? `${info.subfolder}/` : "") + info.name;
           att.ref = { filename: info.name, subfolder: info.subfolder || undefined, type: info.type || "input" };
+        } else {
+          // #756 — a non-200 had NO else at all. The status was in hand and thrown
+          // away, leaving "upload failed" as the whole of what anyone could learn.
+          att.uploadError = describeUploadFailure({
+            status: res.status,
+            statusText: res.statusText,
+            body: await res.text().catch(() => null),
+            name,
+            size: file.size,
+            mediaType: file.type,
+          });
         }
-      } catch {
-        /* upload failed — the chip still names the file as a fallback */
+      } catch (err) {
+        // #756 — the bare catch swallowed transport failures identically.
+        att.uploadError = describeUploadFailure({ error: err, name, size: file.size, mediaType: file.type });
       }
     })();
   }
@@ -26162,13 +26187,26 @@ function buildPanel() {
     }
     const imageRefs = await collectImageRefs(text, refImgs);
     if (refImgs.length) {
-      const lines = refImgs.map((a) => `#${a.id}${a.inputRef ? ` (input/${a.inputRef})` : ""}`).join(", ");
+      // #756 — the image branch reported an absent input/ ref by saying NOTHING,
+      // which reads as "no path needed" rather than "the upload failed". The image
+      // is still shown inline, so this is less severe than the media case, but an
+      // agent asked to wire it into a LoadImage node needs the path and would
+      // otherwise discover the gap only when the node errors. Same swallow, one
+      // branch over — and having just captured the cause it would be worse to
+      // capture it and then drop it here.
+      const lines = refImgs
+        .map((a) =>
+          a.inputRef
+            ? `#${a.id} (input/${a.inputRef})`
+            : `#${a.id} (NOT in input/ — ${a.uploadError ?? "upload failed, cause unobserved"})`,
+        )
+        .join(", ");
       sendText += `\n\n[Attached image(s) ${lines} — shown inline below.]`;
     }
     const mediaUploads = [...refVideos, ...refUploads];
     if (mediaUploads.length) {
       const lines = mediaUploads
-        .map((a) => `${a.token} ${a.inputRef ? `→ input/${a.inputRef}` : `(${a.name} — upload failed)`}`)
+        .map((a) => attachmentSummaryLine(a))
         .join("\n");
       sendText +=
         `\n\n[Attached media in ComfyUI's input/ folder (not viewable inline — load via a ` +

--- a/web/js/lib/attachment-upload.js
+++ b/web/js/lib/attachment-upload.js
@@ -1,0 +1,99 @@
+/**
+ * #756 — a chat attachment upload that fails must say WHAT was observed.
+ *
+ * Both upload paths (`handleImageFile`, `handleMediaUpload`) POST to
+ * `/upload/image` and then threw the outcome away twice over: a non-200 had no
+ * `else` at all, and the `catch` was bare. The agent received the string
+ * `upload failed` and nothing else — no status, no size, no MIME type, no
+ * exception. Two .mp4 attachments failed while a 1.5 MB .png had succeeded
+ * minutes earlier in the same session, and neither the reporter nor anyone
+ * reading the report could tell whether to retry, shrink, re-encode, or use a
+ * different path. The cause was discarded at both points where it was known.
+ *
+ * WHAT THIS DELIBERATELY DOES NOT DO: name a cause. A 413 is evidence about
+ * size, a 400 usually carries ComfyUI's own explanation in the body, and a
+ * TypeError is a transport failure — but "the file is too big" is an inference,
+ * and inferring one from a status is the same defect as the workflow fence
+ * asserting "the workflow was switched" for every mismatch (#750). Report the
+ * status, the server's own words when it sent any, and the file's measurements.
+ * The reader can then reason from facts rather than from our guess.
+ */
+
+/** ComfyUI answers a rejected upload with a JSON or text body that usually names
+ *  the real reason; it is the single most useful thing here and was never read.
+ *  Bounded because it lands in an agent's context, and a server that answers with
+ *  an HTML error page would otherwise paste the whole document into the chat. */
+const MAX_BODY_CHARS = 400;
+
+export function clipUploadBody(text, max = MAX_BODY_CHARS) {
+  if (typeof text !== "string") return null;
+  const t = text.trim();
+  if (!t) return null;
+  return t.length <= max ? t : `${t.slice(0, max)}… [${t.length} chars total]`;
+}
+
+/** Bytes → a short human size. Kept local and dependency-free: this string is
+ *  read by a human and by an agent deciding whether to shrink the file. */
+export function describeSize(bytes) {
+  // null/undefined/"" must be ABSENT, not zero. Number(null) is 0 and Number("")
+  // is 0, so a coerce-first check renders an unknown size as a confident "0 B" —
+  // a fabricated measurement in a message whose whole purpose is to report only
+  // what was observed.
+  if (bytes === null || bytes === undefined || bytes === "") return null;
+  const n = Number(bytes);
+  if (!Number.isFinite(n) || n < 0) return null;
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * The one description both upload paths use.
+ *
+ * `status` present  → the server answered and refused; `body` is its own words.
+ * `error` present   → the request never completed (network/CORS/abort).
+ * Neither           → we genuinely do not know, and say exactly that rather than
+ *                     picking whichever half sounds more likely.
+ */
+export function describeUploadFailure({ status, statusText, body, error, name, size, mediaType } = {}) {
+  const facts = [];
+  if (name) facts.push(`file "${name}"`);
+  const sz = describeSize(size);
+  if (sz) facts.push(sz);
+  if (mediaType) facts.push(mediaType);
+  const measured = facts.length ? ` (${facts.join(", ")})` : "";
+
+  const clipped = clipUploadBody(body);
+
+  if (Number.isFinite(Number(status))) {
+    const st = `HTTP ${status}${statusText ? ` ${statusText}` : ""}`;
+    // The server's own words go LAST and are labelled, so a body that itself
+    // contains advice cannot be mistaken for ours.
+    return (
+      `upload REFUSED by ComfyUI — ${st}${measured}. Nothing was written to input/.` +
+      (clipped ? ` Server said: ${clipped}` : ` The server sent no body explaining it.`)
+    );
+  }
+
+  if (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return (
+      `upload did not COMPLETE — the request to /upload/image threw${measured}: ${msg}. ` +
+      `Whether any bytes reached the server is unknown, but no usable input/ reference came back.`
+    );
+  }
+
+  return (
+    `upload failed for an unobserved reason${measured} — no HTTP status and no exception were ` +
+    `captured, so nothing about the cause is known. Nothing usable came back.`
+  );
+}
+
+/** The chip/agent line for one attachment. Success keeps its existing shape so a
+ *  reader (and the transcript) sees no change on the happy path. */
+export function attachmentSummaryLine(att) {
+  const token = att?.token ?? "";
+  if (att?.inputRef) return `${token} → input/${att.inputRef}`;
+  const why = att?.uploadError ? att.uploadError : `${att?.name ?? "attachment"} — upload failed`;
+  return `${token} (${why})`;
+}


### PR DESCRIPTION
Closes #756 (1).

The video-specific cause asked about in (2) is **not** diagnosed here. As the issue says,
this is the prerequisite: until the status and the error survive, nobody can diagnose it —
including the reporter.

## The cause was discarded at both points where it was known

```js
if (res.status === 200) { … }        // no else — a refusal recorded NOTHING
} catch { /* upload failed */ }      // bare — a throw recorded NOTHING
```

So the agent received the string `upload failed`, entire: no status, no size, no MIME
type, no exception. Two `.mp4` uploads failed while a 1.5 MB `.png` had succeeded minutes
earlier in the same session, and there was no way to tell whether to retry, shrink,
re-encode, or take a different path.

Now captured at both sites: `res.status`, `res.statusText`, the response **body** (ComfyUI
populates it on a 400 and it is usually the real reason), the file's size and MIME type,
and the caught exception.

## A refusal and a throw are different things

They call for different responses — the server judged the file, versus the request never
completed — and the bare catch made them indistinguishable. When neither was observed, it
says so, rather than picking the likelier half.

## No cause is inferred

A 413 is evidence *about* size; "the file is too big" is a conclusion, and it would be
wrong for a proxy-imposed limit. This reports the status, the server's own words when it
sent any, and the measurements — the same rule #750 applies to the workflow fence. There
is a test asserting the message contains no such advice.

## The image branch too

The agent-facing line for images reported an absent `input/` ref by saying **nothing**,
which reads as "no path needed" rather than "the upload failed" — the identical swallow one
branch over. Less severe, since the image is still shown inline, but an agent asked to wire
it into a `LoadImage` node needs that path. Having just captured the cause, dropping it
there would have been worse than never capturing it.

The success line is byte-identical, so the happy path and existing transcripts are
unchanged.

## Tests

2834 in the suite; typecheck and vocabulary gate green. Ten new, including wiring tests
pinning that **both** paths record **both** facts and that neither bare form survives.

Mutation-verified per call site — reverting either path's exception capture, either path's
status capture, the media consumer, or the image branch each fails a test.

Worth recording: two earlier mutation attempts **survived**, and were wrong rather than
passing. The patterns matched **17** and **22** places in the file, so they mutated
unrelated code and proved nothing. The harness now asserts an exact pre-count before
mutating — a mutation that does not land where you think is indistinguishable from a
coverage gap, and reads as reassurance.

Also fixed while testing: `describeSize(null)` rendered `"0 B"`, because `Number(null)` is
`0` — a fabricated measurement inside a message whose entire purpose is to report only what
was observed.
