### PR TITLE
feat(pairing): show whether the QR's URL survives an orchestrator restart

### DIFF
--- a/browser_tests/unit/pair-durability-view.test.mjs
+++ b/browser_tests/unit/pair-durability-view.test.mjs
@@ -1,0 +1,94 @@
+// panel#749 — the pairing modal must show whether the URL survives a restart.
+//
+// The orchestrator already ships `durability` on the `pair_url` frame
+// (comfyui-mcp#1020 for #875); the panel ignored it, so the user saw a bare QR
+// with no expiry information. A user reported this as "updating the npm version
+// bricks my communication with the agent" — the version was never the cause.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { pairDurabilityView } from "../../web/js/lib/pair-durability-view.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PANEL_JS = join(HERE, "../../web/js/comfyui-mcp-panel.js");
+
+const DURABLE = {
+  survivesRestart: true,
+  rotates: [],
+  note: "This URL survives an orchestrator restart: COMFYUI_MCP_PAIR_TOKEN is pinned…",
+};
+const ROTATING = {
+  survivesRestart: false,
+  rotates: ["hostname", "token"],
+  note: "This URL stops working when the orchestrator restarts — both its hostname and its token are regenerated…",
+};
+
+test("#749 a durable URL is a QUIET confirmation", () => {
+  const v = pairDurabilityView(DURABLE);
+  assert.equal(v.tone, "ok");
+  assert.equal(v.icon, "✓");
+  assert.equal(v.note, DURABLE.note, "the orchestrator's sentence, verbatim");
+});
+
+test("#749 a rotating URL is a VISIBLE caution", () => {
+  const v = pairDurabilityView(ROTATING);
+  assert.equal(v.tone, "warn");
+  assert.equal(v.icon, "⚠");
+  assert.deepEqual(v.rotates, ["hostname", "token"]);
+  assert.equal(v.note, ROTATING.note);
+});
+
+test("#749 the note is passed through, never paraphrased", () => {
+  // Two spellings of one explanation drift, and this side is the one WITHOUT the
+  // facts — it cannot see whether the token is pinned or the restarter is armed.
+  const custom = { survivesRestart: false, rotates: ["token"], note: "ANY SENTENCE AT ALL" };
+  assert.equal(pairDurabilityView(custom).note, "ANY SENTENCE AT ALL");
+});
+
+test("#749 an ABSENT durability renders NOTHING — never a reassuring tick", () => {
+  // An older orchestrator does not send the field. Silence is the honest answer;
+  // inventing either verdict would be a claim about config the panel cannot see.
+  for (const absent of [undefined, null, "", 0, false, "yes", 42]) {
+    assert.equal(pairDurabilityView(absent), null, `${JSON.stringify(absent)} must render nothing`);
+  }
+  // Present but with no usable sentence is the same case.
+  assert.equal(pairDurabilityView({ survivesRestart: true }), null);
+  assert.equal(pairDurabilityView({ survivesRestart: true, note: "   " }), null);
+});
+
+test("#749 only a STRICT true reads as durable — anything else falls to caution", () => {
+  // This is the reassuring branch, and reassurance is the only direction where
+  // being wrong costs the user a phone that silently stops working. A truthy
+  // non-true value must not buy the tick.
+  for (const flag of [1, "true", "yes", {}, [], undefined, null]) {
+    const v = pairDurabilityView({ survivesRestart: flag, rotates: [], note: "n" });
+    assert.equal(v.tone, "warn", `survivesRestart=${JSON.stringify(flag)} must not read as durable`);
+  }
+  assert.equal(pairDurabilityView({ survivesRestart: true, rotates: [], note: "n" }).tone, "ok");
+});
+
+test("#749 a malformed rotates list cannot crash the modal", () => {
+  assert.deepEqual(pairDurabilityView({ survivesRestart: false, rotates: "token", note: "n" }).rotates, []);
+  assert.deepEqual(
+    pairDurabilityView({ survivesRestart: false, rotates: ["token", 7, null], note: "n" }).rotates,
+    ["token"],
+  );
+});
+
+test("#749 WIRING: the modal renders it and clears it between requests", () => {
+  const src = readFileSync(PANEL_JS, "utf8");
+  assert.match(src, /import \{ pairDurabilityView \} from "\.\/lib\/pair-durability-view\.js"/);
+  // painted from the frame the orchestrator sent…
+  assert.match(src, /const dur = pairDurabilityView\(res\.durability\)/);
+  assert.match(src, /durabilityLine\.textContent = `\$\{dur\.icon\} \$\{dur\.note\}`/);
+  // …and RESET on every new request, or a mode switch would leave the previous
+  // mode's verdict sitting under the new QR (LAN is durable, tunnel is not —
+  // exactly the pair a user toggles between).
+  assert.match(src, /durabilityLine\.hidden = true;\s*\r?\n\s*durabilityLine\.textContent = "";/);
+  // and it is actually in the modal
+  assert.match(src, /qrWrap\.append\(canvas, statusMsg, urlLine, durabilityLine\)/);
+});

--- a/web/js/comfyui-mcp-panel.js
+++ b/web/js/comfyui-mcp-panel.js
@@ -66,6 +66,7 @@ import { marked } from "./vendor/marked.esm.js";
 import DOMPurify from "./vendor/purify.es.js";
 import qrcodegen from "./vendor/qrcode.esm.js";
 import { computeLayout } from "./lib/layout-engine.js";
+import { pairDurabilityView } from "./lib/pair-durability-view.js";
 import { describeUploadFailure, attachmentSummaryLine } from "./lib/attachment-upload.js";
 import {
   buildInstallRequest,
@@ -26032,12 +26033,19 @@ function buildPanel() {
     const urlLine = document.createElement("div");
     urlLine.style.cssText =
       "font-size:0.7rem;opacity:0.55;word-break:break-all;text-align:center;max-width:280px;";
-    qrWrap.append(canvas, statusMsg, urlLine);
+    // #749 — the durability of THIS url, rendered where the user is looking at it.
+    const durabilityLine = document.createElement("div");
+    durabilityLine.style.cssText =
+      "font-size:0.72rem;line-height:1.35;text-align:left;max-width:280px;margin-top:0.15rem;";
+    durabilityLine.hidden = true;
+    qrWrap.append(canvas, statusMsg, urlLine, durabilityLine);
 
     let reqId = 0;
     function requestPairing() {
       canvas.hidden = true;
       urlLine.textContent = "";
+      durabilityLine.hidden = true;
+      durabilityLine.textContent = "";
       statusMsg.textContent =
         mode === "tunnel" ? "Opening a secure tunnel…" : "Preparing a local link…";
       const myReq = ++reqId;
@@ -26052,6 +26060,17 @@ function buildPanel() {
           canvas.hidden = false;
           statusMsg.textContent = "Scan with your phone camera or the app";
           urlLine.textContent = res.url;
+          // Weighted by survivesRestart: a quiet confirmation when it holds, a
+          // visible caution when it does not. The SENTENCE is the orchestrator's
+          // own — it knows whether the token is pinned and whether the
+          // self-restarter is armed, and this side does not.
+          const dur = pairDurabilityView(res.durability);
+          if (dur) {
+            durabilityLine.textContent = `${dur.icon} ${dur.note}`;
+            durabilityLine.style.color = dur.tone === "warn" ? "#f0b429" : "inherit";
+            durabilityLine.style.opacity = dur.tone === "warn" ? "1" : "0.7";
+            durabilityLine.hidden = false;
+          }
         } catch {
           statusMsg.textContent = "⚠ Could not render the QR code.";
         }

--- a/web/js/lib/pair-durability-view.js
+++ b/web/js/lib/pair-durability-view.js
@@ -1,0 +1,48 @@
+/**
+ * panel#749 — decide how the pairing modal PRESENTS the durability the
+ * orchestrator already ships on the `pair_url` frame (comfyui-mcp#1020, #875).
+ *
+ * The orchestrator computes this from configuration alone and writes one
+ * complete human sentence into `note`. This module therefore decides
+ * PRESENTATION ONLY — tone, and whether to render at all. It deliberately does
+ * not paraphrase, summarise or re-derive the sentence: two spellings of the same
+ * explanation drift, and the one on this side would be the one without the facts
+ * (it cannot see `pinnedToken` or whether the self-restarter is armed).
+ *
+ * WHY THIS MATTERS AT ALL. A user reported "updating the npm version bricks my
+ * communication with the agent" and asked for a version pin. The version was
+ * never the cause: the self-restarter rotates the pair token (unless pinned) and,
+ * in tunnel mode, the quick-tunnel hostname (always). They could only infer a
+ * cause from a phone that had stopped working. The QR modal is the one moment the
+ * user is looking at this URL, so it is where the tradeoff belongs.
+ */
+
+/**
+ * @param {unknown} durability the frame's `durability` field, or anything else.
+ * @returns {{tone:"ok"|"warn", icon:string, note:string, rotates:string[]} | null}
+ *   `null` means RENDER NOTHING.
+ */
+export function pairDurabilityView(durability) {
+  // ABSENT ⇒ render nothing. An older orchestrator does not send this field, and
+  // the honest response to "we were not told" is silence — not a reassuring tick
+  // and not a warning. Both would be claims about a configuration this panel
+  // cannot observe. (#402's rule: never fabricate an outcome nobody reported.)
+  if (!durability || typeof durability !== "object") return null;
+  const raw = /** @type {{note?:unknown, survivesRestart?:unknown, rotates?:unknown}} */ (durability);
+  const note = typeof raw.note === "string" ? raw.note.trim() : "";
+  if (!note) return null;
+
+  // STRICT `=== true`. A missing, null or truthy-but-not-true flag must NOT read
+  // as "survives": this is the reassuring branch, and reassurance is the only
+  // direction where being wrong costs the user a phone that silently stops
+  // working. Anything unproven falls to the caution branch, which still carries
+  // the orchestrator's own sentence and so cannot mislead.
+  const survives = raw.survivesRestart === true;
+
+  return {
+    tone: survives ? "ok" : "warn",
+    icon: survives ? "✓" : "⚠",
+    note,
+    rotates: Array.isArray(raw.rotates) ? raw.rotates.filter((r) => typeof r === "string") : [],
+  };
+}


### PR DESCRIPTION
Closes #749.

The orchestrator has shipped `durability` on the `pair_url` frame since
artokun/comfyui-mcp#1020 (for #875). The panel ignored it, so the user saw a bare QR code
with no expiry information.

## Why this is worth a UI change

A user reported it as *"updating the npm version bricks my communication with the agent"*
and asked for a version pin. **The version was never the cause.** The self-restarter is on
by default and rotates the pair token (unless `COMFYUI_MCP_PAIR_TOKEN` is pinned) and, in
tunnel mode, the quick-tunnel hostname (always). They could only infer a cause from a phone
that had stopped working.

The QR modal is the one moment the user is looking at this URL. That is where the tradeoff
belongs.

## What it does

Renders the durability weighted by `survivesRestart` — a quiet confirmation when it holds,
a visible caution when it does not.

**The sentence is the orchestrator's, verbatim.** This side does not paraphrase or
re-derive it: it cannot see whether the token is pinned or whether the self-restarter is
armed, so a second spelling here would be the one *without* the facts, and the two would
drift.

## Two deliberate refusals

**Absent ⇒ render nothing.** An older orchestrator does not send the field. The honest
response to "we were not told" is silence — not a reassuring tick and not a warning, both
of which assert something about a configuration this panel cannot observe.

**Strict `=== true`.** A missing, null or truthy-but-not-true flag falls to the *caution*
branch. This is the reassuring direction, and it is the only one where being wrong costs
the user a phone that silently stops working. The caution branch still carries the
orchestrator's own sentence, so failing that way cannot mislead.

## One detail that is easy to miss

The line is **cleared** on every new request, not merely repainted. LAN is durable and
tunnel is not — the exact pair a user toggles between in this modal — so a stale verdict
left sitting under a fresh QR would be wrong in the most likely case. There is a test for
it.

## Tests

2858 pass; typecheck and vocabulary gate green.

Mutation-verified on four sites — each fails a test:

| mutation | result |
|---|---|
| loosen the strict `true` | fails |
| return a durable view for an absent field | fails |
| drop the between-requests reset | fails |
| stop painting it at all | fails |

The reset mutation first reported **pre-count 0** — an LF pattern against this repo's CRLF
file. Redone CRLF-aware rather than recorded as a pass: a mutation that does not land is
indistinguishable from a coverage gap, and reads as reassurance.
