### PR TITLE
fix(save): a userdata 400 says what it can mean, and where the real cause is

### DIFF
--- a/browser_tests/unit/userdata-store-400.test.mjs
+++ b/browser_tests/unit/userdata-store-400.test.mjs
@@ -1,0 +1,77 @@
+// panel#771 — ComfyUI answers a userdata write with HTTP 400 for ANY OSError and
+// then blames the filename, so a save that failed because the disk was full (or
+// the directory was missing, or read-only) reads as "invalid filename".
+//
+// The reporter's name was `wan22_flf_seg1_alone_to_reaching` — no special
+// characters anywhere — on a remote box, where a full volume is common.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import { explainUserDataStoreFailure } from "../../web/js/lib/workflow-save.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SAVE_JS = join(HERE, "../../web/js/lib/workflow-save.js");
+
+const REPORTED =
+  "Error storing user data file 'workflows/wan22_flf_seg1_alone_to_reaching.json': 400";
+
+test("#771 a userdata 400 gains the explanation and keeps the original text", () => {
+  const out = explainUserDataStoreFailure(REPORTED);
+  assert.ok(out.startsWith(REPORTED), "the original message is preserved verbatim, then extended");
+  assert.match(out, /ANY filesystem error/);
+  assert.match(out, /Error saving file/, "names the exact log line that reveals the true cause");
+  assert.match(out, /server log/);
+});
+
+test("#771 it names NO single cause — that would be the same defect one level up", () => {
+  // Picking "your disk is full" would be an inference presented as a finding,
+  // which is exactly what ComfyUI's own "Invalid filename" reason does wrong.
+  const out = explainUserDataStoreFailure(REPORTED);
+  assert.doesNotMatch(out, /your disk is full|the disk is full\b/i);
+  // …but the possibilities ARE enumerated, so the reader has somewhere to look.
+  for (const cause of [/full disk/i, /read-only/i, /missing\s+parent/i, /fd limit/i]) {
+    assert.match(out, cause);
+  }
+});
+
+test("#771 it reassures about the workflow, because nothing was written", () => {
+  // The graph stays live and unsaved. Saying so stops a user reaching for a
+  // recovery action they do not need.
+  assert.match(explainUserDataStoreFailure(REPORTED), /nothing was written or overwritten/i);
+});
+
+test("#771 a 409 is left ALONE — it has its own accurate handling", () => {
+  // 409 is a genuine name collision (#309/#442). Burying that under a filesystem
+  // lecture would replace an accurate message with an irrelevant one.
+  const conflict = "Error storing user data file 'workflows/a.json': 409 Conflict";
+  assert.equal(explainUserDataStoreFailure(conflict), conflict);
+});
+
+test("#771 unrelated errors pass through byte-identical", () => {
+  for (const other of [
+    "refusing to save: the active workflow's path changed during the save",
+    "workflow save API unavailable on this frontend",
+    "Error storing user data file 'workflows/a.json': 500",
+    "",
+  ]) {
+    assert.equal(explainUserDataStoreFailure(other), other);
+  }
+  // Non-strings must not throw or stringify into a fake message.
+  for (const junk of [undefined, null, 42, {}]) {
+    assert.equal(explainUserDataStoreFailure(junk), "");
+  }
+});
+
+test("#771 WIRING: saveInPlace augments the thrown error, and only that shape", () => {
+  const src = readFileSync(SAVE_JS, "utf8");
+  // the wrap exists around the real save calls…
+  assert.match(src, /const augmented = explainUserDataStoreFailure\(/);
+  // …and rethrows the SAME error object, so nothing downstream that matches on
+  // error identity or other fields is disturbed.
+  assert.match(src, /if \(err instanceof Error && augmented !== err\.message\) err\.message = augmented;/);
+  assert.match(src, /\n\s*throw err;/);
+});

--- a/web/js/lib/workflow-save.js
+++ b/web/js/lib/workflow-save.js
@@ -1258,13 +1258,70 @@ export function normalizePath(path) {
     .replace(/\/+$/, "");
 }
 
+/**
+ * #771 — ComfyUI answers a userdata write with HTTP 400 for ANY OSError, and then
+ * blames the FILENAME regardless of what actually failed.
+ *
+ * app/user_manager.py, post_userdata — this is the only 400 on the write path:
+ *
+ *     except OSError as e:
+ *         logging.warning(f"Error saving file '{path}': {e}")
+ *         return web.Response(status=400,
+ *             reason="Invalid filename. Please avoid special characters like :\/*?\"<>|")
+ *
+ * So a full disk (ENOSPC), a read-only or unwritable directory, a missing parent
+ * (mkstemp on a directory that does not exist), or hitting an fd limit all arrive
+ * as "invalid filename". The reporter's name was `wan22_flf_seg1_alone_to_reaching`
+ * — no special characters anywhere — and they were on a remote box, where a full
+ * volume is a common failure.
+ *
+ * The real errno IS known, one line earlier, in the ComfyUI SERVER LOG. It never
+ * reaches the HTTP response, so the client cannot recover it — which makes naming
+ * where to look the entire value this can add.
+ *
+ * DELIBERATELY NAMES NO SINGLE CAUSE. Picking "your disk is full" would be the
+ * same defect one level up: an inference presented as a finding. It lists what 400
+ * can mean here and points at the one place that says which.
+ */
+export function explainUserDataStoreFailure(message) {
+  const text = typeof message === "string" ? message : "";
+  // Match the shape ComfyUI's client produces, and ONLY the 400: 409 is a genuine
+  // name collision with its own handling (#309/#442), and augmenting it would bury
+  // an accurate message under an irrelevant one.
+  // Deliberately NO word-boundary escapes here. An earlier revision used a word-boundary-
+  // anchored pattern and both escapes were mangled into literal BACKSPACE bytes
+  // (0x08) on the way into this file: the regex still PARSED, the file stayed
+  // git-text, the diff looked normal, and it silently matched nothing. A digit
+  // boundary expressed as a character class says the same thing with no escape
+  // that can be eaten in transit.
+  if (!/storing user data file/i.test(text)) return text;
+  if (!/(^|[^0-9])400([^0-9]|$)/.test(text)) return text;
+  return (
+    text +
+    " — NOTE: ComfyUI returns 400 here for ANY filesystem error while blaming the filename." +
+    " It is the same response for a full disk, an unwritable or read-only directory, a missing" +
+    " parent directory, or an fd limit, so the stated reason is only occasionally the real one." +
+    " ComfyUI logs the actual error one line earlier: look for \"Error saving file\" in the" +
+    " ComfyUI server log — that names the true cause. On a remote or container host, check free" +
+    " space first. The workflow is still open and unsaved; nothing was written or overwritten."
+  );
+}
+
 async function saveInPlace(svc, wf) {
   // Return the save API's own result: when it yields the workflow record it
   // PRODUCED (a re-registered successor object), that is the one unambiguous
   // replacement-event thread the identity carry can use (r10) — path occupancy
   // proves nothing (a close→reopen occupies the same path with a new identity).
-  if (typeof svc.saveWorkflow === "function") return await svc.saveWorkflow(wf);
-  if (typeof wf.save === "function") return await wf.save();
+  try {
+    if (typeof svc.saveWorkflow === "function") return await svc.saveWorkflow(wf);
+    if (typeof wf.save === "function") return await wf.save();
+  } catch (err) {
+    // #771 — augment ONLY the userdata-400 shape; every other failure is
+    // rethrown byte-identical so no existing message or matcher changes.
+    const augmented = explainUserDataStoreFailure(err instanceof Error ? err.message : String(err));
+    if (err instanceof Error && augmented !== err.message) err.message = augmented;
+    throw err;
+  }
   throw new Error("workflow save API unavailable on this frontend");
 }
 


### PR DESCRIPTION
For #771 — saving a valid 22-node workflow on a remote box failed with:

```
Error storing user data file 'workflows/wan22_flf_seg1_alone_to_reaching.json': 400
```

That filename has no special characters, and ComfyUI's 400 blames the filename.

## Why the stated reason is misleading by construction

`app/user_manager.py`'s `post_userdata` has exactly one 400 on the write path, and it
catches **any `OSError`**:

```python
except OSError as e:
    logging.warning(f"Error saving file '{path}': {e}")
    return web.Response(status=400,
        reason="Invalid filename. Please avoid special characters ...")
```

A full disk (`ENOSPC`), an unwritable or read-only directory, a **missing parent** (the
`tempfile.mkstemp` above raises `FileNotFoundError`), or an fd limit all arrive as
"invalid filename". The reporter is on a remote H100 host, where a full volume is a common
failure and a fresh pod may not have `user/default/workflows/` yet.

The true errno **is** known — one line earlier, in the ComfyUI **server log**. It never
reaches the HTTP response, so the client cannot recover it. Naming where to look is
therefore the entire value this can add.

## What it does not do

**Names no single cause.** Asserting "your disk is full" would be the same defect one level
up — an inference presented as a finding, which is precisely what ComfyUI's own reason does
wrong. It lists what 400 can mean and points at the one place that says which.

**Leaves 409 alone.** That is a genuine name collision with accurate handling already
(#309/#442); burying it under a filesystem lecture would replace a correct message with an
irrelevant one. There is a test.

The same `Error` object is rethrown with only `message` extended, so anything matching on
identity or other fields is undisturbed, and every non-matching error passes through
byte-identical.

## A note on the fix itself

The first revision of the guard used `/\b400\b/`, and **both escapes were mangled into
literal BACKSPACE bytes (0x08)** on the way into the file. It parsed, the file stayed
git-text, the diff looked normal — and the regex matched nothing. The tests caught the
behaviour; the control-byte scan then located the cause. The second attempt reintroduced
one **in the comment explaining the first**.

It is now a digit-boundary character class with no escape that can be eaten, and both
changed files scan clean (0 control bytes, git-text in `--numstat`).

## Tests

2864 pass; typecheck and vocabulary gate green.

Mutation-verified — each fails a test:

| mutation | result |
|---|---|
| stop augmenting entirely | fails |
| extend the augmentation to 409 | fails |
| remove the "Error saving file" log pointer | fails |
| name a single cause ("your disk is full") | fails |
